### PR TITLE
Add Frattura Abissale Sinaptica trait files and rebuild index

### DIFF
--- a/data/derived/analysis/trait_coverage_report.json
+++ b/data/derived/analysis/trait_coverage_report.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2025-11-21T18:33:15+00:00",
+  "generated_at": "2025-11-29T14:17:55+00:00",
   "sources": {
     "env_traits": "packs/evo_tactics_pack/docs/catalog/env_traits.json",
     "trait_reference": "data/traits/index.json",
@@ -9,7 +9,7 @@
     "species_affinity": null
   },
   "summary": {
-    "traits_total": 175,
+    "traits_total": 251,
     "traits_with_rules": 147,
     "traits_with_species": 172,
     "traits_with_affinity": 0,
@@ -71,6 +71,26 @@
     ]
   },
   "traits": {
+    "ali_fono_risonanti": {
+      "label_it": "Ali Fono-Risonanti",
+      "label_en": "Phono-Resonant Wings",
+      "description_it": "Generare ampia banda sonora in volo.",
+      "description_en": "Generate a wide sonic band while flying.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "ali_fulminee": {
       "label_it": "Ali Fulminee",
       "label_en": "Ali Fulminee",
@@ -710,6 +730,46 @@
         "missing_in_matrix": []
       }
     },
+    "articolazioni_a_leva_idraulica": {
+      "label_it": "Articolazioni a Leva Idraulica",
+      "label_en": "Hydraulic Lever Joints",
+      "description_it": "Amplificare salto e spinta delle zampe.",
+      "description_en": "Amplify leaps and leg thrusts.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "articolazioni_multiassiali": {
+      "label_it": "Articolazioni Multiassiali",
+      "label_en": "Multi-Axial Joints",
+      "description_it": "Ruotare arti per manovre strette.",
+      "description_en": "Rotate limbs for tight maneuvers.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "artigli_acidofagi": {
       "label_it": "Artigli Acidofagi",
       "label_en": "Artigli Acidofagi",
@@ -788,6 +848,26 @@
             ]
           }
         ]
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "artigli_ipo_termici": {
+      "label_it": "Artigli Ipo-Termici",
+      "label_en": "Hypothermal Claws",
+      "description_it": "Indurre shock da freddo localizzato.",
+      "description_en": "Induce localized cold shock.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
@@ -1045,6 +1125,46 @@
         "missing_in_matrix": []
       }
     },
+    "artiglio_cinetico_a_urto": {
+      "label_it": "Artiglio Cinetico a Urto",
+      "label_en": "Kinetic Impact Claw",
+      "description_it": "Infliggere onda d’urto e frattura.",
+      "description_en": "Deliver shockwaves that fracture targets.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "aura_di_dispersione_mentale": {
+      "label_it": "Aura di Dispersione Mentale",
+      "label_en": "Mental Dispersion Aura",
+      "description_it": "Campo di odori avversivi ed emissioni deboli che induce ansia e vertigini nei predatori.",
+      "description_en": "Aversive odors and weak emissions that instill anxiety and vertigo in predators.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "aura_scudo_radianza": {
       "label_it": "Aura Scudo di Radianza",
       "label_en": "Radiant Shield Aura",
@@ -1294,6 +1414,26 @@
         "missing_in_matrix": []
       }
     },
+    "bioantenne_gravitiche": {
+      "label_it": "Bioantenne Gravitiche",
+      "label_en": "Gravitic Bio-Antennae",
+      "description_it": "Antenne che leggono shear gravitazionali e li convertono in segnali.",
+      "description_en": "Antennae reading gravitic shear and converting to signals.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "biochip_memoria": {
       "label_it": "Biochip Memoria",
       "label_en": "Biochip Memoria",
@@ -1415,6 +1555,26 @@
             ]
           }
         ]
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "bozzolo_magnetico": {
+      "label_it": "Bozzolo Magnetico",
+      "label_en": "Magnetic Cocoon",
+      "description_it": "Schermarsi da campi elettromagnetici esterni.",
+      "description_en": "Shield against external electromagnetic fields.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
@@ -1870,6 +2030,106 @@
             ]
           }
         ]
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "camere_risonanza_abyssal": {
+      "label_it": "Camere di Risonanza Abyssal",
+      "label_en": "Abyssal Resonance Chambers",
+      "description_it": "Caverne interne che amplificano onde elettriche/gravitazionali.",
+      "description_en": "Internal caverns amplifying electric/gravitational waves.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "campo_di_interferenza_acustica": {
+      "label_it": "Campo di Interferenza Acustica",
+      "label_en": "Acoustic Interference Field",
+      "description_it": "Mascherare posizione e velocità.",
+      "description_en": "Mask position and velocity.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "cannone_sonico_a_raggio": {
+      "label_it": "Cannone Sonico a Raggio",
+      "label_en": "Ray Sonic Cannon",
+      "description_it": "Stordire o ferire con un raggio sonoro.",
+      "description_en": "Stun or injure targets with a sonic beam.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "canto_infrasonico_tattico": {
+      "label_it": "Canto Infrasonico Tattico",
+      "label_en": "Tactical Infrasonic Song",
+      "description_it": "Disorientare predatori e comunicare a distanza.",
+      "description_en": "Disorient predators and communicate at range.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "canto_risonante": {
+      "label_it": "Canto Risonante",
+      "label_en": "Resonant Chant",
+      "description_it": "Frequenze che armonizzano il gruppo e riducono stress (temp).",
+      "description_en": "Frequencies harmonising the squad and reducing stress (temp).",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
@@ -2537,6 +2797,26 @@
         "missing_in_matrix": []
       }
     },
+    "cervello_a_bassa_latenza": {
+      "label_it": "Cervello a Bassa Latenza",
+      "label_en": "Low-Latency Brain",
+      "description_it": "Eseguire manovre ad alta frequenza.",
+      "description_en": "Execute high-frequency maneuvers.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "chemiorecettori_bromuro": {
       "label_it": "Chemiorecettori Bromuro",
       "label_en": "Chemiorecettori Bromuro",
@@ -2610,6 +2890,26 @@
             "morphotype": "cursoriale_quadrupede"
           }
         ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "cinghia_iper_ciliare": {
+      "label_it": "Cinghia Iper-Ciliare",
+      "label_en": "Hyper-Ciliary Belt",
+      "description_it": "Traslare il corpo su terreni piani o ruvidi.",
+      "description_en": "Translate the body across smooth or rough ground.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       }
@@ -2906,6 +3206,26 @@
         "missing_in_matrix": []
       }
     },
+    "cisti_di_ibernazione_minerale": {
+      "label_it": "Cisti di Ibernazione Minerale",
+      "label_en": "Mineral Hibernation Cyst",
+      "description_it": "Entrare in stasi in condizioni avverse.",
+      "description_en": "Enter stasis under harsh conditions.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "cisti_iperbariche": {
       "label_it": "Cisti Iperbariche",
       "label_en": "Cisti Iperbariche",
@@ -3152,6 +3472,26 @@
         "missing_in_matrix": []
       }
     },
+    "coda_prensile_muscolare": {
+      "label_it": "Coda Prensile Muscolare",
+      "label_en": "Muscular Prehensile Tail",
+      "description_it": "Appendere e controbilanciarsi.",
+      "description_en": "Hang and counterbalance weight.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "coda_stabilizzatrice_filo": {
       "label_it": "Coda Stabilizzatrice Filo",
       "label_en": "Coda Stabilizzatrice Filo",
@@ -3324,6 +3664,26 @@
         "missing_in_matrix": []
       }
     },
+    "comunicazione_fotonica_coda_coda": {
+      "label_it": "Comunicazione Fotonica Coda-Coda",
+      "label_en": "Tail-to-Tail Photonic Communication",
+      "description_it": "Scambiare impulsi luminosi tattili.",
+      "description_en": "Exchange tactile light pulses.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "coralli_partner": {
       "label_it": "Coralli Partner",
       "label_en": "Coralli Partner",
@@ -3359,6 +3719,86 @@
             ]
           }
         ]
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "coralli_sinaptici_fotofase": {
+      "label_it": "Coralli Sinaptici Fotofase",
+      "label_en": "Photophase Synaptic Corals",
+      "description_it": "Barriere bioelettriche che canalizzano luce e impulsi.",
+      "description_en": "Bioelectric coral ridges channeling light and impulses.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "corazze_ferro_magnetico": {
+      "label_it": "Corazze Ferro-Magnetico",
+      "label_en": "Ferro-Magnetic Carapace",
+      "description_it": "Placche ferrose che guidano campi magnetici profondi.",
+      "description_en": "Iron plates guiding deep magnetic fields.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "corna_psico_conduttive": {
+      "label_it": "Corna Psico-Conduttive",
+      "label_en": "Psycho-Conductive Horns",
+      "description_it": "Corna piezo-neurotoniche che trasmettono e ricevono segnali neurali lenti per allerta di branco.",
+      "description_en": "Piezo-neurotonic horns sending and receiving slow neural signals for pack alerts.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "coscienza_d_alveare_diffusa": {
+      "label_it": "Coscienza d’Alveare Diffusa",
+      "label_en": "Diffuse Hive Consciousness",
+      "description_it": "Rete sinaptica inter-individuo temporanea che fonde decisioni e memoria a breve termine.",
+      "description_en": "Temporary inter-individual synaptic net merging decisions and short-term memory.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
@@ -4071,6 +4511,86 @@
         "missing_in_matrix": []
       }
     },
+    "ectotermia_dinamica": {
+      "label_it": "Ectotermia Dinamica",
+      "label_en": "Dynamic Ectothermy",
+      "description_it": "Microscosse isometriche che innalzano in fretta la temperatura corporea per picchi prestazionali in climi freschi.",
+      "description_en": "Isometric micro-shivers that quickly elevate body temperature for performance peaks in cool climates.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "elettromagnete_biologico": {
+      "label_it": "Elettromagnete Biologico",
+      "label_en": "Biological Electromagnet",
+      "description_it": "Interferire con il sistema nervoso della preda.",
+      "description_en": "Disrupt prey nervous systems.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "emettitori_voidsong": {
+      "label_it": "Emettitori Voidsong",
+      "label_en": "Voidsong Emitters",
+      "description_it": "Organi che emettono cori a frequenze profonde per stabilizzare lo shear.",
+      "description_en": "Organs emitting deep choruses to stabilise shear.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "emolinfa_conducente": {
+      "label_it": "Emolinfa Conducente",
+      "label_en": "Conductive Hemolymph",
+      "description_it": "Fluido che accumula carica e drena energia nemica.",
+      "description_en": "Fluid storing charge and draining enemy energy.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "empatia_coordinativa": {
       "label_it": "Empatia Coordinativa",
       "label_en": "Coordinated Empathy",
@@ -4457,6 +4977,66 @@
         "missing_in_matrix": []
       }
     },
+    "ermafroditismo_cronologico": {
+      "label_it": "Ermafroditismo Cronologico",
+      "label_en": "Chronological Hermaphroditism",
+      "description_it": "Cambiare sesso dopo 1–2 incubazioni.",
+      "description_en": "Change sex after one or two incubations.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "estroflessione_gastrica_acida": {
+      "label_it": "Estroflessione Gastrica Acida",
+      "label_en": "Acidic Gastric Extrusion",
+      "description_it": "Liquefare tessuti al contatto e aspirarli.",
+      "description_en": "Liquefy tissues on contact and siphon them.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "fagocitosi_assorbente": {
+      "label_it": "Fagocitosi Assorbente",
+      "label_en": "Absorptive Phagocytosis",
+      "description_it": "Inglobare e digerire biomassa intera.",
+      "description_en": "Engulf and digest entire biomass.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "filamenti_digestivi_compattanti": {
       "label_it": "Filamenti Digestivi Compattanti",
       "label_en": "Digestive Compaction Filaments",
@@ -4568,6 +5148,46 @@
             "morphotype": "cursoriale_quadrupede"
           }
         ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "filamenti_echo": {
+      "label_it": "Filamenti Echo",
+      "label_en": "Echo Filaments",
+      "description_it": "Filamenti che rilanciano frequenze di squadra e attenuano shear.",
+      "description_en": "Filaments relaying squad frequencies and softening shear.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "filamenti_guidalampo": {
+      "label_it": "Filamenti Guidalampo",
+      "label_en": "Lightning Guide Filaments",
+      "description_it": "Filamenti che tracciano rotte sicure nelle correnti.",
+      "description_en": "Filaments plotting safe routes through currents.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       }
@@ -4701,6 +5321,26 @@
         "missing_in_matrix": []
       }
     },
+    "filtrazione_osmotica": {
+      "label_it": "Filtrazione Osmotica",
+      "label_en": "Osmotic Filtration",
+      "description_it": "Neutralizzare tossine autogenerate.",
+      "description_en": "Neutralize self-generated toxins.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "filtri_planctonici": {
       "label_it": "Filtri Planctonici",
       "label_en": "Filtri Planctonici",
@@ -4744,6 +5384,26 @@
         "missing_in_matrix": []
       }
     },
+    "filtro_metallofago": {
+      "label_it": "Filtro Metallofago",
+      "label_en": "Metallophagous Filter",
+      "description_it": "Sostenere organi elettrogeni.",
+      "description_en": "Sustain electrogenic organs.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "flagelli_ancoranti": {
       "label_it": "Flagelli Ancoranti",
       "label_en": "Flagelli Ancoranti",
@@ -4779,6 +5439,26 @@
             ]
           }
         ]
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "flusso_ameboide_controllato": {
+      "label_it": "Flusso Ameboide Controllato",
+      "label_en": "Controlled Amoeboid Flow",
+      "description_it": "Scivolare o risalire superfici lisce.",
+      "description_en": "Slide or climb along smooth surfaces.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
@@ -5449,6 +6129,26 @@
         "missing_in_matrix": []
       }
     },
+    "ghiandole_mnemoniche": {
+      "label_it": "Ghiandole Mnemoniche",
+      "label_en": "Mnemonic Glands",
+      "description_it": "Secrezioni che trattengono copie attenuate di buff.",
+      "description_en": "Secretions holding attenuated buff copies.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "ghiandole_nebbia_acida": {
       "label_it": "Ghiandole Nebbia Acida",
       "label_en": "Ghiandole Nebbia Acida",
@@ -5855,6 +6555,66 @@
         "missing_in_matrix": []
       }
     },
+    "impulsi_bioluminescenti": {
+      "label_it": "Impulsi Bioluminescenti",
+      "label_en": "Bioluminescent Pulses",
+      "description_it": "Scariche ritmiche che abbagliano e sincronizzano alleati.",
+      "description_en": "Rhythmic flashes that dazzle foes and sync allies.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "integumento_bipolare": {
+      "label_it": "Integumento Bipolare",
+      "label_en": "Bipolar Integument",
+      "description_it": "Orientarsi lungo le linee di campo.",
+      "description_en": "Orient along magnetic field lines.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "ipertrofia_muscolare_massiva": {
+      "label_it": "Ipertrofia Muscolare Massiva",
+      "label_en": "Massive Muscular Hypertrophy",
+      "description_it": "Fibre a sezione aumentata e mitocondri densi che sprigionano potenza e scatto sostenendo sforzi brevi.",
+      "description_en": "Broadened fibres with dense mitochondria that unleash power and acceleration while enduring short bursts.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "lamelle_shear": {
       "label_it": "Lamelle Shear",
       "label_en": "Lamelle Shear",
@@ -6207,6 +6967,46 @@
         "missing_in_matrix": []
       }
     },
+    "lobi_risonanti_crepuscolo": {
+      "label_it": "Lobi Risonanti Crepuscolo",
+      "label_en": "Twilight Resonant Lobes",
+      "description_it": "Camere risonanti che filtrano segnali instabili.",
+      "description_en": "Resonant chambers filtering unstable signals.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "locomozione_miriapode_ibrida": {
+      "label_it": "Locomozione Miriapode Ibrida",
+      "label_en": "Hybrid Myriapod Locomotion",
+      "description_it": "Aderire e arrampicare su qualsiasi superficie.",
+      "description_en": "Grip and climb on nearly any surface.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "luminescenza_aurorale": {
       "label_it": "Luminescenza Aurorale",
       "label_en": "Luminescenza Aurorale",
@@ -6370,6 +7170,26 @@
         "missing_in_matrix": []
       }
     },
+    "membrana_plastica_continua": {
+      "label_it": "Membrana Plastica Continua",
+      "label_en": "Continuous Plastic Membrane",
+      "description_it": "Assumere forme e densità diverse.",
+      "description_en": "Adopt different shapes and densities.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "membrane_captura_rugiada": {
       "label_it": "Membrane Captura Rugiada",
       "label_en": "Membrane Captura Rugiada",
@@ -6443,6 +7263,26 @@
             "morphotype": "cursoriale_quadrupede"
           }
         ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "membrane_fotoconvoglianti": {
+      "label_it": "Membrane Fotoconvoglianti",
+      "label_en": "Photoconductive Membranes",
+      "description_it": "Tessuti che trasportano cariche luminose tra nodi sinaptici.",
+      "description_en": "Tissues that ferry luminous charge between synaptic nodes.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       }
@@ -6525,6 +7365,26 @@
             ]
           }
         ]
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "metabolismo_di_condivisione_energetica": {
+      "label_it": "Metabolismo di Condivisione Energetica",
+      "label_en": "Shared Energy Metabolism",
+      "description_it": "Trasferimento di substrati via contatto per sostenere feriti o giovani con una riserva collettiva.",
+      "description_en": "Contact-based substrate transfer to sustain wounded or young with a collective reserve.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
@@ -6668,6 +7528,46 @@
         "missing_in_matrix": []
       }
     },
+    "moltiplicazione_per_fusione": {
+      "label_it": "Moltiplicazione per Fusione",
+      "label_en": "Fusion Multiplication",
+      "description_it": "Aumentare massa e intelligenza unendo unità.",
+      "description_en": "Grow mass and intellect by merging units.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "motore_biologico_silenzioso": {
+      "label_it": "Motore Biologico Silenzioso",
+      "label_en": "Silent Biological Engine",
+      "description_it": "Garantire volo prolungato a bassissimo SPL.",
+      "description_en": "Maintain extended flight at ultra-low sound pressure.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "mucillagine_simbionte_mangrovie": {
       "label_it": "Mucillagine Simbionte delle Mangrovie",
       "label_en": "Mucillagine Simbionte delle Mangrovie",
@@ -6788,6 +7688,26 @@
         "missing_in_matrix": []
       }
     },
+    "nebbia_mnesica": {
+      "label_it": "Nebbia Mnesica",
+      "label_en": "Mnesic Fog",
+      "description_it": "Foschia psionica che offusca memorie e orientamento.",
+      "description_en": "Psionic mist that blurs memory and orientation.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "nodi_micorrizici_oracolari": {
       "label_it": "Nodi Micorrizici Oracolari",
       "label_en": "Nodi Micorrizici Oracolari",
@@ -6818,6 +7738,26 @@
             "morphotype": "cursoriale_quadrupede"
           }
         ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "nodi_sinaptici_superficiali": {
+      "label_it": "Nodi Sinaptici Superficiali",
+      "label_en": "Surface Synaptic Nodes",
+      "description_it": "Reticolo di nodi che amplificano segnali superficiali.",
+      "description_en": "Node lattice amplifying surface signals.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       }
@@ -6908,6 +7848,46 @@
             "morphotype": "cursoriale_quadrupede"
           }
         ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "occhi_analizzatori_di_tensione": {
+      "label_it": "Occhi Analizzatori di Tensione",
+      "label_en": "Tension-Analyzing Eyes",
+      "description_it": "Leggere tensioni nella seta e pattern di stress.",
+      "description_en": "Read strand tension and stress patterns.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "occhi_cinetici": {
+      "label_it": "Occhi Cinetici",
+      "label_en": "Kinetic Eyes",
+      "description_it": "Vedere il suono come pattern d’aria.",
+      "description_en": "See sound as patterns in the air.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       }
@@ -7088,6 +8068,46 @@
         "missing_in_matrix": []
       }
     },
+    "organi_metacronici": {
+      "label_it": "Organi Metacronici",
+      "label_en": "Metachronic Organs",
+      "description_it": "Organi che sequenziano furti di buff in catena.",
+      "description_en": "Organs sequencing chained buff thefts.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "organi_sismici_cutanei": {
+      "label_it": "Organi Sismici Cutanei",
+      "label_en": "Cutaneous Seismic Organs",
+      "description_it": "Lamelle meccano-recettive nelle squame che percepiscono vibrazioni del suolo e movimenti occultati.",
+      "description_en": "Mechano-receptive lamellae in the scales sensing ground vibrations and hidden movements.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "pathfinder": {
       "label_it": "Pathfinder",
       "label_en": "Pathfinder",
@@ -7115,6 +8135,46 @@
             ]
           }
         ]
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "pelage_idrorepellente_avanzato": {
+      "label_it": "Pelage Idrorepellente Avanzato",
+      "label_en": "Advanced Hydrophobic Pelage",
+      "description_it": "Isolare e galleggiare.",
+      "description_en": "Insulate the body and stay afloat.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "pelle_piezo_satura": {
+      "label_it": "Pelle Piezo-Satura",
+      "label_en": "Piezo-Saturated Skin",
+      "description_it": "Dermide che accumula carica piezoelettrica e riflette colpi (temp).",
+      "description_en": "Dermis storing piezo charge and reflecting blows (temp).",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
       },
       "diff": {
         "missing_in_species": [],
@@ -7188,6 +8248,46 @@
             "morphotype": "cursoriale_quadrupede"
           }
         ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "placca_diffusione_foschia": {
+      "label_it": "Placca di Diffusione Foschia",
+      "label_en": "Fog Diffusion Plate",
+      "description_it": "Placche che diffondono e attenuano cariche erratiche.",
+      "description_en": "Plates diffusing and attenuating erratic charges.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "placche_pressioniche": {
+      "label_it": "Placche Pressioniche",
+      "label_en": "Pressure Plates",
+      "description_it": "Strati che disperdono pressione abissale e riducono trauma.",
+      "description_en": "Layers dispersing abyssal pressure and reducing trauma.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       }
@@ -7307,6 +8407,26 @@
         "missing_in_matrix": []
       }
     },
+    "rete_filtro_polmonare": {
+      "label_it": "Rete Filtro-Polmonare",
+      "label_en": "Pulmonary Filter Net",
+      "description_it": "Assorbire nutrienti aerodispersi.",
+      "description_en": "Absorb nutrients suspended in the air.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "risonanza_di_branco": {
       "label_it": "Risonanza di Branco",
       "label_en": "Pack Resonance",
@@ -7351,6 +8471,66 @@
             "morphotype": "volatore_planatore"
           }
         ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "riverbero_memetico": {
+      "label_it": "Riverbero Memetico",
+      "label_en": "Memetic Reverb",
+      "description_it": "Eco cognitivo che duplica buff a potenza ridotta (temp).",
+      "description_en": "Cognitive echo duplicating buffs at reduced power (temp).",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "rostro_emostatico_litico": {
+      "label_it": "Rostro Emostatico-Litico",
+      "label_en": "Hemo-Lytic Rostrum",
+      "description_it": "Rostro tubulare rigidizzato che inocula tossine ed enzimi e aspira fluidi dopo l’impatto.",
+      "description_en": "Reinforced tubular rostrum that injects toxins and enzymes, then draws fluids after impact.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "rostro_linguale_prensile": {
+      "label_it": "Rostro Linguale Prensile",
+      "label_en": "Prehensile Lingual Rostrum",
+      "description_it": "Afferrare e manipolare a lungo raggio.",
+      "description_en": "Grab and manipulate at long reach.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       }
@@ -7559,6 +8739,26 @@
         "missing_in_matrix": []
       }
     },
+    "scheletro_idraulico_a_pistoni": {
+      "label_it": "Scheletro Idraulico a Pistoni",
+      "label_en": "Piston Hydraulic Skeleton",
+      "description_it": "Ossa cave pressurizzate che scattano pistoni cranici per colpi-proiettile rapidissimi.",
+      "description_en": "Pressurised hollow bones that fire cranial pistons for ultra-fast projectile blows.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "scheletro_idro_regolante": {
       "label_it": "Scheletro Idro-Regolante",
       "label_en": "Hydro-Regulating Skeleton",
@@ -7647,6 +8847,86 @@
         "missing_in_matrix": []
       }
     },
+    "scheletro_pneumatico_a_maglie": {
+      "label_it": "Scheletro Pneumatico a Maglie",
+      "label_en": "Latticed Pneumatic Skeleton",
+      "description_it": "Alleggerire il carico per spostamenti lenti ma costanti.",
+      "description_en": "Lighten the load for slow, steady travel.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "scintilla_sinaptica": {
+      "label_it": "Scintilla Sinaptica",
+      "label_en": "Synaptic Spark",
+      "description_it": "Scarica leggera che illumina connessioni e riflessi (temp).",
+      "description_en": "Light discharge illuminating connections and reflexes (temp).",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "scivolamento_magnetico": {
+      "label_it": "Scivolamento Magnetico",
+      "label_en": "Magnetic Gliding",
+      "description_it": "Ridurre attrito e scivolare.",
+      "description_en": "Reduce friction to glide.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "scudo_gluteale_cheratinizzato": {
+      "label_it": "Scudo Gluteale Cheratinizzato",
+      "label_en": "Keratinized Gluteal Shield",
+      "description_it": "Assorbire impatti posteriori.",
+      "description_en": "Absorb impacts from the rear.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "secrezione_rallentante_palmi": {
       "label_it": "Mani secernano liquido rallentante",
       "label_en": "Retarding Palm Secretions",
@@ -7691,6 +8971,26 @@
             "morphotype": "cursoriale_quadrupede"
           }
         ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "secrezioni_antistatiche": {
+      "label_it": "Secrezioni Antistatiche",
+      "label_en": "Antistatic Secretions",
+      "description_it": "Film protettivo che disperde accumuli elettrici.",
+      "description_en": "Protective film dispersing electrical build-up.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       }
@@ -7754,6 +9054,66 @@
         "missing_in_matrix": []
       }
     },
+    "sensori_planctonici": {
+      "label_it": "Sensori Planctonici",
+      "label_en": "Planctonic Sensors",
+      "description_it": "Sensori diffusi che leggono pattern di plancton memetico.",
+      "description_en": "Distributed sensors reading memetic plankton patterns.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "seta_conduttiva_elettrica": {
+      "label_it": "Seta Conduttiva Elettrica",
+      "label_en": "Conductive Electric Silk",
+      "description_it": "Stordire con scariche nella tela.",
+      "description_en": "Stun prey with charges woven into the web.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "siero_anti_gelo_naturale": {
+      "label_it": "Siero Anti-Gelo Naturale",
+      "label_en": "Natural Anti-Freeze Serum",
+      "description_it": "Impedire la cristallizzazione a basse temperature.",
+      "description_en": "Prevent crystallization at low temperatures.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "sinapsi_coraline_polifoniche": {
       "label_it": "Sinapsi Coraline Polifoniche",
       "label_en": "Sinapsi Coraline Polifoniche",
@@ -7784,6 +9144,26 @@
             "morphotype": "cursoriale_quadrupede"
           }
         ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "sistemi_chimio_sonici": {
+      "label_it": "Sistemi Chimio-Sonici",
+      "label_en": "Chemo-Sonic Systems",
+      "description_it": "Mappare spazio e correnti d’aria senza vista.",
+      "description_en": "Map space and airflow without sight.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       }
@@ -7845,6 +9225,26 @@
             "morphotype": "cursoriale_quadrupede"
           }
         ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "spicole_canalizzatrici": {
+      "label_it": "Spicole Canalizzatrici",
+      "label_en": "Channeling Spicules",
+      "description_it": "Spine che assorbono buff e li reindirizzano.",
+      "description_en": "Spines absorbing buffs and redirecting them.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       }
@@ -7919,6 +9319,26 @@
             "morphotype": "cursoriale_quadrupede"
           }
         ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "squame_diffusori_ionici": {
+      "label_it": "Squame Diffusori Ionici",
+      "label_en": "Ionic Diffuser Scales",
+      "description_it": "Squame che disperdono cariche e riducono glare.",
+      "description_en": "Scales dispersing charge and reducing glare.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       }
@@ -8111,6 +9531,26 @@
         "missing_in_matrix": []
       }
     },
+    "unghie_a_micro_adesione": {
+      "label_it": "Unghie a Micro-Adesione",
+      "label_en": "Micro-Adhesion Claws",
+      "description_it": "Lamelle a micro-setole su zoccoli che aderiscono a superfici ripide per fughe verticali e pascolo.",
+      "description_en": "Micro-setae lamellae on hooves gripping steep surfaces for vertical escapes and browsing.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "vello_condensatore_nebbie": {
       "label_it": "Vello Condensatore di Nebbie",
       "label_en": "Vello Condensatore di Nebbie",
@@ -8141,6 +9581,26 @@
             "morphotype": "cursoriale_quadrupede"
           }
         ],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "vello_di_assorbimento_totale": {
+      "label_it": "Vello di Assorbimento Totale",
+      "label_en": "Total Absorption Fleece",
+      "description_it": "Assorbire quasi tutta la luce incidente.",
+      "description_en": "Absorb nearly all incoming light.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       }
@@ -8206,11 +9666,71 @@
         "missing_in_matrix": []
       }
     },
+    "visione_multi_spettrale_amplificata": {
+      "label_it": "Visione Multi-Spettrale Amplificata",
+      "label_en": "Amplified Multi-Spectral Vision",
+      "description_it": "Vedere in luminanza estremamente bassa.",
+      "description_en": "See under extremely low luminance.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "vortice_nera_flash": {
+      "label_it": "Vortice Nera Flash",
+      "label_en": "Black Vortex Flash",
+      "description_it": "Implosione luminosa seguita da vuoto e teletrasporto breve (temp).",
+      "description_en": "Luminous implosion followed by void and short teleport (temp).",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
     "zampe_a_molla": {
       "label_it": "Zampe a Molla",
       "label_en": "Spring-Loaded Limbs",
       "description_it": "Arti a molla che accumulano energia per balzi di riposizionamento.",
       "description_en": "Spring-loaded limbs storing energy for repositioning leaps.",
+      "rules": {
+        "total": 0,
+        "coverage": []
+      },
+      "species": {
+        "total": 0,
+        "coverage": []
+      },
+      "diff": {
+        "missing_in_species": [],
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
+      }
+    },
+    "zanne_idracida": {
+      "label_it": "Zanne Idracida",
+      "label_en": "Hydra-Acid Tusks",
+      "description_it": "Corrodere tessuti e metalli.",
+      "description_en": "Corrode tissues and even metals.",
       "rules": {
         "total": 0,
         "coverage": []

--- a/data/traits/frattura_abissale_sinaptica/bioantenne_gravitiche.json
+++ b/data/traits/frattura_abissale_sinaptica/bioantenne_gravitiche.json
@@ -1,0 +1,31 @@
+{
+  "id": "bioantenne_gravitiche",
+  "label": "i18n:traits.bioantenne_gravitiche.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Sensore/Gravitazionale",
+  "fattore_mantenimento_energetico": "i18n:traits.bioantenne_gravitiche.fattore_mantenimento_energetico",
+  "tier": "T3",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "mutazione_indotta": "i18n:traits.bioantenne_gravitiche.mutazione_indotta",
+  "uso_funzione": "i18n:traits.bioantenne_gravitiche.uso_funzione",
+  "spinta_selettiva": "i18n:traits.bioantenne_gravitiche.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T3"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": true,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/camere_risonanza_abyssal.json
+++ b/data/traits/frattura_abissale_sinaptica/camere_risonanza_abyssal.json
@@ -1,0 +1,31 @@
+{
+  "id": "camere_risonanza_abyssal",
+  "label": "i18n:traits.camere_risonanza_abyssal.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Supporto/Risonanza",
+  "fattore_mantenimento_energetico": "i18n:traits.camere_risonanza_abyssal.fattore_mantenimento_energetico",
+  "tier": "T3",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "mutazione_indotta": "i18n:traits.camere_risonanza_abyssal.mutazione_indotta",
+  "uso_funzione": "i18n:traits.camere_risonanza_abyssal.uso_funzione",
+  "spinta_selettiva": "i18n:traits.camere_risonanza_abyssal.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T3"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": true,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/canto_risonante.json
+++ b/data/traits/frattura_abissale_sinaptica/canto_risonante.json
@@ -1,0 +1,31 @@
+{
+  "id": "canto_risonante",
+  "label": "i18n:traits.canto_risonante.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Temporaneo/Risonanza",
+  "fattore_mantenimento_energetico": "i18n:traits.canto_risonante.fattore_mantenimento_energetico",
+  "tier": "T3",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "mutazione_indotta": "i18n:traits.canto_risonante.mutazione_indotta",
+  "uso_funzione": "i18n:traits.canto_risonante.uso_funzione",
+  "spinta_selettiva": "i18n:traits.canto_risonante.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T3"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": true,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/coralli_sinaptici_fotofase.json
+++ b/data/traits/frattura_abissale_sinaptica/coralli_sinaptici_fotofase.json
@@ -1,0 +1,32 @@
+{
+  "id": "coralli_sinaptici_fotofase",
+  "label": "i18n:traits.coralli_sinaptici_fotofase.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Ambiente/Supporto",
+  "fattore_mantenimento_energetico": "i18n:traits.coralli_sinaptici_fotofase.fattore_mantenimento_energetico",
+  "tier": "T1",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "mutazione_indotta": "i18n:traits.coralli_sinaptici_fotofase.mutazione_indotta",
+  "uso_funzione": "i18n:traits.coralli_sinaptici_fotofase.uso_funzione",
+  "spinta_selettiva": "i18n:traits.coralli_sinaptici_fotofase.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "env_to_traits",
+      "meta": {
+        "tier": "T1",
+        "notes": "Cresta Fotofase"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": false,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/corazze_ferro_magnetico.json
+++ b/data/traits/frattura_abissale_sinaptica/corazze_ferro_magnetico.json
@@ -1,0 +1,33 @@
+{
+  "id": "corazze_ferro_magnetico",
+  "label": "i18n:traits.corazze_ferro_magnetico.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Difesa/Magnetico",
+  "fattore_mantenimento_energetico": "i18n:traits.corazze_ferro_magnetico.fattore_mantenimento_energetico",
+  "tier": "T3",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [
+    "ossidazione_rapida"
+  ],
+  "mutazione_indotta": "i18n:traits.corazze_ferro_magnetico.mutazione_indotta",
+  "uso_funzione": "i18n:traits.corazze_ferro_magnetico.uso_funzione",
+  "spinta_selettiva": "i18n:traits.corazze_ferro_magnetico.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T3"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": false,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/emettitori_voidsong.json
+++ b/data/traits/frattura_abissale_sinaptica/emettitori_voidsong.json
@@ -1,0 +1,31 @@
+{
+  "id": "emettitori_voidsong",
+  "label": "i18n:traits.emettitori_voidsong.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Supporto/Anomalia",
+  "fattore_mantenimento_energetico": "i18n:traits.emettitori_voidsong.fattore_mantenimento_energetico",
+  "tier": "T3",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "mutazione_indotta": "i18n:traits.emettitori_voidsong.mutazione_indotta",
+  "uso_funzione": "i18n:traits.emettitori_voidsong.uso_funzione",
+  "spinta_selettiva": "i18n:traits.emettitori_voidsong.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T3"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": true,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/emolinfa_conducente.json
+++ b/data/traits/frattura_abissale_sinaptica/emolinfa_conducente.json
@@ -1,0 +1,31 @@
+{
+  "id": "emolinfa_conducente",
+  "label": "i18n:traits.emolinfa_conducente.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Supporto/Energetico",
+  "fattore_mantenimento_energetico": "i18n:traits.emolinfa_conducente.fattore_mantenimento_energetico",
+  "tier": "T3",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "mutazione_indotta": "i18n:traits.emolinfa_conducente.mutazione_indotta",
+  "uso_funzione": "i18n:traits.emolinfa_conducente.uso_funzione",
+  "spinta_selettiva": "i18n:traits.emolinfa_conducente.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T3"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": true,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/filamenti_echo.json
+++ b/data/traits/frattura_abissale_sinaptica/filamenti_echo.json
@@ -1,0 +1,31 @@
+{
+  "id": "filamenti_echo",
+  "label": "i18n:traits.filamenti_echo.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Supporto/Risonanza",
+  "fattore_mantenimento_energetico": "i18n:traits.filamenti_echo.fattore_mantenimento_energetico",
+  "tier": "T3",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "mutazione_indotta": "i18n:traits.filamenti_echo.mutazione_indotta",
+  "uso_funzione": "i18n:traits.filamenti_echo.uso_funzione",
+  "spinta_selettiva": "i18n:traits.filamenti_echo.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T3"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": true,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/filamenti_guidalampo.json
+++ b/data/traits/frattura_abissale_sinaptica/filamenti_guidalampo.json
@@ -1,0 +1,31 @@
+{
+  "id": "filamenti_guidalampo",
+  "label": "i18n:traits.filamenti_guidalampo.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Mobilità/Logistica",
+  "fattore_mantenimento_energetico": "i18n:traits.filamenti_guidalampo.fattore_mantenimento_energetico",
+  "tier": "T1",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "mutazione_indotta": "i18n:traits.filamenti_guidalampo.mutazione_indotta",
+  "uso_funzione": "i18n:traits.filamenti_guidalampo.uso_funzione",
+  "spinta_selettiva": "i18n:traits.filamenti_guidalampo.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T1"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": false,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/ghiandole_mnemoniche.json
+++ b/data/traits/frattura_abissale_sinaptica/ghiandole_mnemoniche.json
@@ -1,0 +1,31 @@
+{
+  "id": "ghiandole_mnemoniche",
+  "label": "i18n:traits.ghiandole_mnemoniche.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Supporto/Copia",
+  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_mnemoniche.fattore_mantenimento_energetico",
+  "tier": "T2",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "mutazione_indotta": "i18n:traits.ghiandole_mnemoniche.mutazione_indotta",
+  "uso_funzione": "i18n:traits.ghiandole_mnemoniche.uso_funzione",
+  "spinta_selettiva": "i18n:traits.ghiandole_mnemoniche.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T2"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": true,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/impulsi_bioluminescenti.json
+++ b/data/traits/frattura_abissale_sinaptica/impulsi_bioluminescenti.json
@@ -1,0 +1,31 @@
+{
+  "id": "impulsi_bioluminescenti",
+  "label": "i18n:traits.impulsi_bioluminescenti.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Offensivo/Illuminazione",
+  "fattore_mantenimento_energetico": "i18n:traits.impulsi_bioluminescenti.fattore_mantenimento_energetico",
+  "tier": "T1",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "mutazione_indotta": "i18n:traits.impulsi_bioluminescenti.mutazione_indotta",
+  "uso_funzione": "i18n:traits.impulsi_bioluminescenti.uso_funzione",
+  "spinta_selettiva": "i18n:traits.impulsi_bioluminescenti.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T1"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": true,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/lobi_risonanti_crepuscolo.json
+++ b/data/traits/frattura_abissale_sinaptica/lobi_risonanti_crepuscolo.json
@@ -1,0 +1,31 @@
+{
+  "id": "lobi_risonanti_crepuscolo",
+  "label": "i18n:traits.lobi_risonanti_crepuscolo.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Risonanza/Crepuscolo",
+  "fattore_mantenimento_energetico": "i18n:traits.lobi_risonanti_crepuscolo.fattore_mantenimento_energetico",
+  "tier": "T2",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "mutazione_indotta": "i18n:traits.lobi_risonanti_crepuscolo.mutazione_indotta",
+  "uso_funzione": "i18n:traits.lobi_risonanti_crepuscolo.uso_funzione",
+  "spinta_selettiva": "i18n:traits.lobi_risonanti_crepuscolo.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T2"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": true,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/membrane_fotoconvoglianti.json
+++ b/data/traits/frattura_abissale_sinaptica/membrane_fotoconvoglianti.json
@@ -1,0 +1,33 @@
+{
+  "id": "membrane_fotoconvoglianti",
+  "label": "i18n:traits.membrane_fotoconvoglianti.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Difesa/Elettrico",
+  "fattore_mantenimento_energetico": "i18n:traits.membrane_fotoconvoglianti.fattore_mantenimento_energetico",
+  "tier": "T1",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [
+    "affaticamento_oculare"
+  ],
+  "mutazione_indotta": "i18n:traits.membrane_fotoconvoglianti.mutazione_indotta",
+  "uso_funzione": "i18n:traits.membrane_fotoconvoglianti.uso_funzione",
+  "spinta_selettiva": "i18n:traits.membrane_fotoconvoglianti.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T1"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": false,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/nebbia_mnesica.json
+++ b/data/traits/frattura_abissale_sinaptica/nebbia_mnesica.json
@@ -1,0 +1,33 @@
+{
+  "id": "nebbia_mnesica",
+  "label": "i18n:traits.nebbia_mnesica.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Controllo/Memoria",
+  "fattore_mantenimento_energetico": "i18n:traits.nebbia_mnesica.fattore_mantenimento_energetico",
+  "tier": "T2",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [
+    "immunoscossa"
+  ],
+  "mutazione_indotta": "i18n:traits.nebbia_mnesica.mutazione_indotta",
+  "uso_funzione": "i18n:traits.nebbia_mnesica.uso_funzione",
+  "spinta_selettiva": "i18n:traits.nebbia_mnesica.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T2"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": true,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/nodi_sinaptici_superficiali.json
+++ b/data/traits/frattura_abissale_sinaptica/nodi_sinaptici_superficiali.json
@@ -1,0 +1,31 @@
+{
+  "id": "nodi_sinaptici_superficiali",
+  "label": "i18n:traits.nodi_sinaptici_superficiali.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Supporto/Sensore",
+  "fattore_mantenimento_energetico": "i18n:traits.nodi_sinaptici_superficiali.fattore_mantenimento_energetico",
+  "tier": "T1",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "mutazione_indotta": "i18n:traits.nodi_sinaptici_superficiali.mutazione_indotta",
+  "uso_funzione": "i18n:traits.nodi_sinaptici_superficiali.uso_funzione",
+  "spinta_selettiva": "i18n:traits.nodi_sinaptici_superficiali.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T1"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": false,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/organi_metacronici.json
+++ b/data/traits/frattura_abissale_sinaptica/organi_metacronici.json
@@ -1,0 +1,31 @@
+{
+  "id": "organi_metacronici",
+  "label": "i18n:traits.organi_metacronici.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Supporto/Sequenziamento",
+  "fattore_mantenimento_energetico": "i18n:traits.organi_metacronici.fattore_mantenimento_energetico",
+  "tier": "T2",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "mutazione_indotta": "i18n:traits.organi_metacronici.mutazione_indotta",
+  "uso_funzione": "i18n:traits.organi_metacronici.uso_funzione",
+  "spinta_selettiva": "i18n:traits.organi_metacronici.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T2"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": true,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/pelle_piezo_satura.json
+++ b/data/traits/frattura_abissale_sinaptica/pelle_piezo_satura.json
@@ -1,0 +1,31 @@
+{
+  "id": "pelle_piezo_satura",
+  "label": "i18n:traits.pelle_piezo_satura.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Temporaneo/Difesa",
+  "fattore_mantenimento_energetico": "i18n:traits.pelle_piezo_satura.fattore_mantenimento_energetico",
+  "tier": "T3",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "mutazione_indotta": "i18n:traits.pelle_piezo_satura.mutazione_indotta",
+  "uso_funzione": "i18n:traits.pelle_piezo_satura.uso_funzione",
+  "spinta_selettiva": "i18n:traits.pelle_piezo_satura.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T3"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": true,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/placca_diffusione_foschia.json
+++ b/data/traits/frattura_abissale_sinaptica/placca_diffusione_foschia.json
@@ -1,0 +1,31 @@
+{
+  "id": "placca_diffusione_foschia",
+  "label": "i18n:traits.placca_diffusione_foschia.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Difesa/Foschia",
+  "fattore_mantenimento_energetico": "i18n:traits.placca_diffusione_foschia.fattore_mantenimento_energetico",
+  "tier": "T2",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "mutazione_indotta": "i18n:traits.placca_diffusione_foschia.mutazione_indotta",
+  "uso_funzione": "i18n:traits.placca_diffusione_foschia.uso_funzione",
+  "spinta_selettiva": "i18n:traits.placca_diffusione_foschia.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T2"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": false,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/placche_pressioniche.json
+++ b/data/traits/frattura_abissale_sinaptica/placche_pressioniche.json
@@ -1,0 +1,31 @@
+{
+  "id": "placche_pressioniche",
+  "label": "i18n:traits.placche_pressioniche.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Difesa/Pressione",
+  "fattore_mantenimento_energetico": "i18n:traits.placche_pressioniche.fattore_mantenimento_energetico",
+  "tier": "T3",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "mutazione_indotta": "i18n:traits.placche_pressioniche.mutazione_indotta",
+  "uso_funzione": "i18n:traits.placche_pressioniche.uso_funzione",
+  "spinta_selettiva": "i18n:traits.placche_pressioniche.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T3"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": false,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/riverbero_memetico.json
+++ b/data/traits/frattura_abissale_sinaptica/riverbero_memetico.json
@@ -1,0 +1,31 @@
+{
+  "id": "riverbero_memetico",
+  "label": "i18n:traits.riverbero_memetico.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Temporaneo/Memoria",
+  "fattore_mantenimento_energetico": "i18n:traits.riverbero_memetico.fattore_mantenimento_energetico",
+  "tier": "T3",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "mutazione_indotta": "i18n:traits.riverbero_memetico.mutazione_indotta",
+  "uso_funzione": "i18n:traits.riverbero_memetico.uso_funzione",
+  "spinta_selettiva": "i18n:traits.riverbero_memetico.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T3"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": true,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/scintilla_sinaptica.json
+++ b/data/traits/frattura_abissale_sinaptica/scintilla_sinaptica.json
@@ -1,0 +1,31 @@
+{
+  "id": "scintilla_sinaptica",
+  "label": "i18n:traits.scintilla_sinaptica.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Temporaneo/Scarica",
+  "fattore_mantenimento_energetico": "i18n:traits.scintilla_sinaptica.fattore_mantenimento_energetico",
+  "tier": "T2",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "mutazione_indotta": "i18n:traits.scintilla_sinaptica.mutazione_indotta",
+  "uso_funzione": "i18n:traits.scintilla_sinaptica.uso_funzione",
+  "spinta_selettiva": "i18n:traits.scintilla_sinaptica.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T2"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": true,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/secrezioni_antistatiche.json
+++ b/data/traits/frattura_abissale_sinaptica/secrezioni_antistatiche.json
@@ -1,0 +1,33 @@
+{
+  "id": "secrezioni_antistatiche",
+  "label": "i18n:traits.secrezioni_antistatiche.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Difesa/Antistatico",
+  "fattore_mantenimento_energetico": "i18n:traits.secrezioni_antistatiche.fattore_mantenimento_energetico",
+  "tier": "T2",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [
+    "corrosione_instabile"
+  ],
+  "mutazione_indotta": "i18n:traits.secrezioni_antistatiche.mutazione_indotta",
+  "uso_funzione": "i18n:traits.secrezioni_antistatiche.uso_funzione",
+  "spinta_selettiva": "i18n:traits.secrezioni_antistatiche.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T2"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": false,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/sensori_planctonici.json
+++ b/data/traits/frattura_abissale_sinaptica/sensori_planctonici.json
@@ -1,0 +1,31 @@
+{
+  "id": "sensori_planctonici",
+  "label": "i18n:traits.sensori_planctonici.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Analisi/Sensori Planctonici",
+  "fattore_mantenimento_energetico": "i18n:traits.sensori_planctonici.fattore_mantenimento_energetico",
+  "tier": "T1",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "mutazione_indotta": "i18n:traits.sensori_planctonici.mutazione_indotta",
+  "uso_funzione": "i18n:traits.sensori_planctonici.uso_funzione",
+  "spinta_selettiva": "i18n:traits.sensori_planctonici.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T1"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": false,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/spicole_canalizzatrici.json
+++ b/data/traits/frattura_abissale_sinaptica/spicole_canalizzatrici.json
@@ -1,0 +1,31 @@
+{
+  "id": "spicole_canalizzatrici",
+  "label": "i18n:traits.spicole_canalizzatrici.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Offensivo/Assorbimento",
+  "fattore_mantenimento_energetico": "i18n:traits.spicole_canalizzatrici.fattore_mantenimento_energetico",
+  "tier": "T2",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [],
+  "mutazione_indotta": "i18n:traits.spicole_canalizzatrici.mutazione_indotta",
+  "uso_funzione": "i18n:traits.spicole_canalizzatrici.uso_funzione",
+  "spinta_selettiva": "i18n:traits.spicole_canalizzatrici.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T2"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": false,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/squame_diffusori_ionici.json
+++ b/data/traits/frattura_abissale_sinaptica/squame_diffusori_ionici.json
@@ -1,0 +1,33 @@
+{
+  "id": "squame_diffusori_ionici",
+  "label": "i18n:traits.squame_diffusori_ionici.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Difesa/Elettrico",
+  "fattore_mantenimento_energetico": "i18n:traits.squame_diffusori_ionici.fattore_mantenimento_energetico",
+  "tier": "T1",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [
+    "overcharge_cronico"
+  ],
+  "mutazione_indotta": "i18n:traits.squame_diffusori_ionici.mutazione_indotta",
+  "uso_funzione": "i18n:traits.squame_diffusori_ionici.uso_funzione",
+  "spinta_selettiva": "i18n:traits.squame_diffusori_ionici.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T1"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": false,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/frattura_abissale_sinaptica/vortice_nera_flash.json
+++ b/data/traits/frattura_abissale_sinaptica/vortice_nera_flash.json
@@ -1,0 +1,33 @@
+{
+  "id": "vortice_nera_flash",
+  "label": "i18n:traits.vortice_nera_flash.label",
+  "data_origin": "frattura_abissale_sinaptica",
+  "famiglia_tipologia": "Temporaneo/Traslazione",
+  "fattore_mantenimento_energetico": "i18n:traits.vortice_nera_flash.fattore_mantenimento_energetico",
+  "tier": "T3",
+  "slot": [],
+  "sinergie": [],
+  "conflitti": [
+    "stress_spike"
+  ],
+  "mutazione_indotta": "i18n:traits.vortice_nera_flash.mutazione_indotta",
+  "uso_funzione": "i18n:traits.vortice_nera_flash.uso_funzione",
+  "spinta_selettiva": "i18n:traits.vortice_nera_flash.spinta_selettiva",
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "frattura_abissale_sinaptica"
+      },
+      "fonte": "frattura_abissale_sinaptica",
+      "meta": {
+        "tier": "T3"
+      }
+    }
+  ],
+  "completion_flags": {
+    "has_biome": true,
+    "has_data_origin": true,
+    "has_species_link": true,
+    "has_usage_tags": true
+  }
+}

--- a/data/traits/index.csv
+++ b/data/traits/index.csv
@@ -20,12 +20,21 @@ struttura_elastica_amorfa_2,i18n:traits.struttura_elastica_amorfa_2.label,TODO/i
 tattiche_di_branco_2,i18n:traits.tattiche_di_branco_2.label,TODO/import_esterno,import_esterno,data/traits/_drafts/tattiche_di_branco_2.json,,appendix_a_canvas_originale,,,false,false
 teach_action,i18n:traits.teach_action.label,TODO/import_esterno,import_esterno,data/traits/_drafts/teach_action.json,,incoming_sentience_traits_v1_0_t4_civico,,,false,false
 toolseed,i18n:traits.toolseed.label,TODO/import_esterno,import_esterno,data/traits/_drafts/toolseed.json,,incoming_sentience_traits_v1_0_t3_emergente,,,false,false
+fagocitosi_assorbente,i18n:traits.fagocitosi_assorbente.label,Alimentazione/Digestione,Digestione,data/traits/alimentazione/fagocitosi_assorbente.json,,coverage_q4_2025,,support,true,false
+filtro_metallofago,i18n:traits.filtro_metallofago.label,Alimentazione/Digestione,Digestione,data/traits/alimentazione/filtro_metallofago.json,,coverage_q4_2025,,support,true,false
+cervello_a_bassa_latenza,i18n:traits.cervello_a_bassa_latenza.label,Cognitivo/Apprendimento,Apprendimento,data/traits/cognitivo/cervello_a_bassa_latenza.json,,coverage_q4_2025,,controller,true,false
+comunicazione_fotonica_coda_coda,i18n:traits.comunicazione_fotonica_coda_coda.label,Cognitivo/Sociale,Sociale,data/traits/cognitivo/comunicazione_fotonica_coda_coda.json,,coverage_q4_2025,,controller,true,false
+corna_psico_conduttive,i18n:traits.corna_psico_conduttive.label,Cognitivo/Sociale,Sociale,data/traits/cognitivo/corna_psico_conduttive.json,,coverage_q4_2025,,controller,true,false
+coscienza_d_alveare_diffusa,i18n:traits.coscienza_d_alveare_diffusa.label,Cognitivo/Sociale,Sociale,data/traits/cognitivo/coscienza_d_alveare_diffusa.json,,coverage_q4_2025,,controller,true,false
 ali_membrana_sonica,i18n:traits.ali_membrana_sonica.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/ali_membrana_sonica.json,,coverage_q4_2025,caverna_risonante,tank,true,false
 appendici_risonanti_marea,i18n:traits.appendici_risonanti_marea.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/appendici_risonanti_marea.json,,coverage_q4_2025,laguna_bioreattiva,tank,true,false
 barriere_miasma_glaciale,i18n:traits.barriere_miasma_glaciale.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/barriere_miasma_glaciale.json,,coverage_q4_2025,caldera_glaciale,tank,true,false
+bozzolo_magnetico,i18n:traits.bozzolo_magnetico.label,Difensivo/Resistenze,Resistenze,data/traits/difensivo/bozzolo_magnetico.json,,coverage_q4_2025,,tank,true,false
 branchie_microfiltri,i18n:traits.branchie_microfiltri.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/branchie_microfiltri.json,,coverage_q4_2025,reef_luminescente,tank,true,false
+campo_di_interferenza_acustica,i18n:traits.campo_di_interferenza_acustica.label,Difensivo/Camuffamento,Camuffamento,data/traits/difensivo/campo_di_interferenza_acustica.json,,coverage_q4_2025,,controller;support,true,false
 capsule_paracadute,i18n:traits.capsule_paracadute.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/capsule_paracadute.json,,coverage_q4_2025,stratosfera_tempestosa,tank,true,false
 circolazione_bifasica,i18n:traits.circolazione_bifasica.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/circolazione_bifasica.json,,coverage_q4_2025,caldera_glaciale,tank,true,false
+cisti_di_ibernazione_minerale,i18n:traits.cisti_di_ibernazione_minerale.label,Difensivo/Resistenze,Resistenze,data/traits/difensivo/cisti_di_ibernazione_minerale.json,,coverage_q4_2025,,tank,true,false
 coda_coppia_retroattiva,i18n:traits.coda_coppia_retroattiva.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/coda_coppia_retroattiva.json,,coverage_q4_2025,steppe_algoritmiche,tank,true,false
 cute_resistente_sali,i18n:traits.cute_resistente_sali.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/cute_resistente_sali.json,,coverage_q4_2025,badlands,tank,true,false
 enzimi_antipredatori_algali,i18n:traits.enzimi_antipredatori_algali.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/enzimi_antipredatori_algali.json,,coverage_q4_2025,reef_luminescente,tank,true,false
@@ -33,13 +42,61 @@ filtri_planctonici,i18n:traits.filtri_planctonici.label,Tegumentario/Difensivo,D
 ghiandole_fango_coesivo,i18n:traits.ghiandole_fango_coesivo.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/ghiandole_fango_coesivo.json,,coverage_q4_2025,mangrovieto_cinetico,tank,true,false
 giunti_antitorsione,i18n:traits.giunti_antitorsione.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/giunti_antitorsione.json,,coverage_q4_2025,mangrovieto_cinetico,tank,true,false
 lingua_cristallina,i18n:traits.lingua_cristallina.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/lingua_cristallina.json,,coverage_q4_2025,pianura_salina_iperarida,tank,true,false
+membrana_plastica_continua,i18n:traits.membrana_plastica_continua.label,Difensivo/Camuffamento,Camuffamento,data/traits/difensivo/membrana_plastica_continua.json,,coverage_q4_2025,,tank,true,false
 mucose_barofile,i18n:traits.mucose_barofile.label,Tegumentario/Difensivo,Difensivo,data/traits/difensivo/mucose_barofile.json,,coverage_q4_2025,abisso_vulcanico,tank,true,false
-armatura_pietra_planare,i18n:traits.armatura_pietra_planare.label,Difesa/Strutturale,Strutturale,data/traits/difesa/armatura_pietra_planare.json,,pathfinder_dataset,,tank,true,false
-mantello_meteoritico,i18n:traits.mantello_meteoritico.label,Difesa/Termoregolazione,Termoregolazione,data/traits/difesa/mantello_meteoritico.json,,pathfinder_dataset,,sustain;tank,true,false
+pelage_idrorepellente_avanzato,i18n:traits.pelage_idrorepellente_avanzato.label,Difensivo/Termoregolazione,Termoregolazione,data/traits/difensivo/pelage_idrorepellente_avanzato.json,,coverage_q4_2025,,tank,true,false
+scudo_gluteale_cheratinizzato,i18n:traits.scudo_gluteale_cheratinizzato.label,Difensivo/Corazza,Corazza,data/traits/difensivo/scudo_gluteale_cheratinizzato.json,,coverage_q4_2025,,tank,true,false
+vello_di_assorbimento_totale,i18n:traits.vello_di_assorbimento_totale.label,Difensivo/Camuffamento,Camuffamento,data/traits/difensivo/vello_di_assorbimento_totale.json,,coverage_q4_2025,,tank,true,false
+armatura_pietra_planare,i18n:traits.armatura_pietra_planare.label,Difesa/Strutturale,Strutturale,data/traits/difesa/armatura_pietra_planare.json,,pathfinder_dataset,rovine_planari,tank,true,false
+mantello_meteoritico,i18n:traits.mantello_meteoritico.label,Difesa/Termoregolazione,Termoregolazione,data/traits/difesa/mantello_meteoritico.json,,pathfinder_dataset,rovine_planari,sustain;tank,true,false
 filamenti_digestivi_compattanti,i18n:traits.filamenti_digestivi_compattanti.label,Digestivo/Escretorio,Escretorio,data/traits/digestivo/filamenti_digestivi_compattanti.json,,controllo_psionico,caverna_risonante;falde_magnetiche_psioniche,sustain,true,false
 ventriglio_gastroliti,i18n:traits.ventriglio_gastroliti.label,Digestivo/Alimentare,Alimentare,data/traits/digestivo/ventriglio_gastroliti.json,,controllo_psionico,caverna_risonante,sustain,true,false
-spore_psichiche_silenziate,i18n:traits.spore_psichiche_silenziate.label,Escretorio/Psichico,Psichico,data/traits/escretorio/spore_psichiche_silenziate.json,,controllo_psionico,caverna_risonante,controller;sustain,true,false
+spore_psichiche_silenziate,i18n:traits.spore_psichiche_silenziate.label,Escretorio/Psichico,Psichico,data/traits/escretorio/spore_psichiche_silenziate.json,,controllo_psionico,caverna_risonante,controller;sustain,true,true
+ectotermia_dinamica,i18n:traits.ectotermia_dinamica.label,Fisiologico/Termico,Termico,data/traits/fisiologico/ectotermia_dinamica.json,,incoming_tr1100_pack,,sustain,true,false
+filtrazione_osmotica,i18n:traits.filtrazione_osmotica.label,Fisiologico/Idrico,Idrico,data/traits/fisiologico/filtrazione_osmotica.json,,coverage_q4_2025,,sustain,true,false
+ipertrofia_muscolare_massiva,i18n:traits.ipertrofia_muscolare_massiva.label,Fisiologico/Metabolico,Metabolico,data/traits/fisiologico/ipertrofia_muscolare_massiva.json,,incoming_tr1100_pack,,sustain,true,false
+metabolismo_di_condivisione_energetica,i18n:traits.metabolismo_di_condivisione_energetica.label,Fisiologico/Metabolico,Metabolico,data/traits/fisiologico/metabolismo_di_condivisione_energetica.json,,coverage_q4_2025,,sustain,true,false
+motore_biologico_silenzioso,i18n:traits.motore_biologico_silenzioso.label,Fisiologico/Metabolico,Metabolico,data/traits/fisiologico/motore_biologico_silenzioso.json,,coverage_q4_2025,,sustain,true,false
+rete_filtro_polmonare,i18n:traits.rete_filtro_polmonare.label,Fisiologico/Respiratorio,Respiratorio,data/traits/fisiologico/rete_filtro_polmonare.json,,coverage_q4_2025,,sustain,true,false
+siero_anti_gelo_naturale,i18n:traits.siero_anti_gelo_naturale.label,Fisiologico/Termico,Termico,data/traits/fisiologico/siero_anti_gelo_naturale.json,,coverage_q4_2025,,sustain,true,false
+bioantenne_gravitiche,i18n:traits.bioantenne_gravitiche.label,Sensore/Gravitazionale,Gravitazionale,data/traits/frattura_abissale_sinaptica/bioantenne_gravitiche.json,,frattura_abissale_sinaptica,,,true,true
+camere_risonanza_abyssal,i18n:traits.camere_risonanza_abyssal.label,Supporto/Risonanza,Risonanza,data/traits/frattura_abissale_sinaptica/camere_risonanza_abyssal.json,,frattura_abissale_sinaptica,,,true,true
+canto_risonante,i18n:traits.canto_risonante.label,Temporaneo/Risonanza,Risonanza,data/traits/frattura_abissale_sinaptica/canto_risonante.json,,frattura_abissale_sinaptica,,,true,true
+coralli_sinaptici_fotofase,i18n:traits.coralli_sinaptici_fotofase.label,Ambiente/Supporto,Supporto,data/traits/frattura_abissale_sinaptica/coralli_sinaptici_fotofase.json,,frattura_abissale_sinaptica,,,true,false
+corazze_ferro_magnetico,i18n:traits.corazze_ferro_magnetico.label,Difesa/Magnetico,Magnetico,data/traits/frattura_abissale_sinaptica/corazze_ferro_magnetico.json,,frattura_abissale_sinaptica,,,true,false
+emettitori_voidsong,i18n:traits.emettitori_voidsong.label,Supporto/Anomalia,Anomalia,data/traits/frattura_abissale_sinaptica/emettitori_voidsong.json,,frattura_abissale_sinaptica,,,true,true
+emolinfa_conducente,i18n:traits.emolinfa_conducente.label,Supporto/Energetico,Energetico,data/traits/frattura_abissale_sinaptica/emolinfa_conducente.json,,frattura_abissale_sinaptica,,,true,true
+filamenti_echo,i18n:traits.filamenti_echo.label,Supporto/Risonanza,Risonanza,data/traits/frattura_abissale_sinaptica/filamenti_echo.json,,frattura_abissale_sinaptica,,,true,true
+filamenti_guidalampo,i18n:traits.filamenti_guidalampo.label,Mobilità/Logistica,Logistica,data/traits/frattura_abissale_sinaptica/filamenti_guidalampo.json,,frattura_abissale_sinaptica,,,true,false
+ghiandole_mnemoniche,i18n:traits.ghiandole_mnemoniche.label,Supporto/Copia,Copia,data/traits/frattura_abissale_sinaptica/ghiandole_mnemoniche.json,,frattura_abissale_sinaptica,,,true,true
+impulsi_bioluminescenti,i18n:traits.impulsi_bioluminescenti.label,Offensivo/Illuminazione,Illuminazione,data/traits/frattura_abissale_sinaptica/impulsi_bioluminescenti.json,,frattura_abissale_sinaptica,,,true,true
+lobi_risonanti_crepuscolo,i18n:traits.lobi_risonanti_crepuscolo.label,Risonanza/Crepuscolo,Crepuscolo,data/traits/frattura_abissale_sinaptica/lobi_risonanti_crepuscolo.json,,frattura_abissale_sinaptica,,,true,true
+membrane_fotoconvoglianti,i18n:traits.membrane_fotoconvoglianti.label,Difesa/Elettrico,Elettrico,data/traits/frattura_abissale_sinaptica/membrane_fotoconvoglianti.json,,frattura_abissale_sinaptica,,,true,false
+nebbia_mnesica,i18n:traits.nebbia_mnesica.label,Controllo/Memoria,Memoria,data/traits/frattura_abissale_sinaptica/nebbia_mnesica.json,,frattura_abissale_sinaptica,,,true,true
+nodi_sinaptici_superficiali,i18n:traits.nodi_sinaptici_superficiali.label,Supporto/Sensore,Sensore,data/traits/frattura_abissale_sinaptica/nodi_sinaptici_superficiali.json,,frattura_abissale_sinaptica,,,true,false
+organi_metacronici,i18n:traits.organi_metacronici.label,Supporto/Sequenziamento,Sequenziamento,data/traits/frattura_abissale_sinaptica/organi_metacronici.json,,frattura_abissale_sinaptica,,,true,true
+pelle_piezo_satura,i18n:traits.pelle_piezo_satura.label,Temporaneo/Difesa,Difesa,data/traits/frattura_abissale_sinaptica/pelle_piezo_satura.json,,frattura_abissale_sinaptica,,,true,true
+placca_diffusione_foschia,i18n:traits.placca_diffusione_foschia.label,Difesa/Foschia,Foschia,data/traits/frattura_abissale_sinaptica/placca_diffusione_foschia.json,,frattura_abissale_sinaptica,,,true,false
+placche_pressioniche,i18n:traits.placche_pressioniche.label,Difesa/Pressione,Pressione,data/traits/frattura_abissale_sinaptica/placche_pressioniche.json,,frattura_abissale_sinaptica,,,true,false
+riverbero_memetico,i18n:traits.riverbero_memetico.label,Temporaneo/Memoria,Memoria,data/traits/frattura_abissale_sinaptica/riverbero_memetico.json,,frattura_abissale_sinaptica,,,true,true
+scintilla_sinaptica,i18n:traits.scintilla_sinaptica.label,Temporaneo/Scarica,Scarica,data/traits/frattura_abissale_sinaptica/scintilla_sinaptica.json,,frattura_abissale_sinaptica,,,true,true
+secrezioni_antistatiche,i18n:traits.secrezioni_antistatiche.label,Difesa/Antistatico,Antistatico,data/traits/frattura_abissale_sinaptica/secrezioni_antistatiche.json,,frattura_abissale_sinaptica,,,true,false
+sensori_planctonici,i18n:traits.sensori_planctonici.label,Analisi/Sensori Planctonici,Sensori Planctonici,data/traits/frattura_abissale_sinaptica/sensori_planctonici.json,,frattura_abissale_sinaptica,,,true,false
+spicole_canalizzatrici,i18n:traits.spicole_canalizzatrici.label,Offensivo/Assorbimento,Assorbimento,data/traits/frattura_abissale_sinaptica/spicole_canalizzatrici.json,,frattura_abissale_sinaptica,,,true,false
+squame_diffusori_ionici,i18n:traits.squame_diffusori_ionici.label,Difesa/Elettrico,Elettrico,data/traits/frattura_abissale_sinaptica/squame_diffusori_ionici.json,,frattura_abissale_sinaptica,,,true,false
+vortice_nera_flash,i18n:traits.vortice_nera_flash.label,Temporaneo/Traslazione,Traslazione,data/traits/frattura_abissale_sinaptica/vortice_nera_flash.json,,frattura_abissale_sinaptica,,,true,true
 sacche_galleggianti_ascensoriali,i18n:traits.sacche_galleggianti_ascensoriali.label,Idrostatico/Locomotorio,Locomotorio,data/traits/idrostatico/sacche_galleggianti_ascensoriali.json,,controllo_psionico,canopia_psionica_leggera;orbita_psionica_inversa,scout;tank,true,false
+ali_fono_risonanti,i18n:traits.ali_fono_risonanti.label,Locomotivo/Aereo,Aereo,data/traits/locomotivo/ali_fono_risonanti.json,,coverage_q4_2025,,scout;controller,true,true
+articolazioni_a_leva_idraulica,i18n:traits.articolazioni_a_leva_idraulica.label,Locomotivo/Terrestre,Terrestre,data/traits/locomotivo/articolazioni_a_leva_idraulica.json,,coverage_q4_2025,,scout,true,false
+articolazioni_multiassiali,i18n:traits.articolazioni_multiassiali.label,Locomotivo/Terrestre,Terrestre,data/traits/locomotivo/articolazioni_multiassiali.json,,coverage_q4_2025,,scout,true,false
+cinghia_iper_ciliare,i18n:traits.cinghia_iper_ciliare.label,Locomotivo/Terrestre,Terrestre,data/traits/locomotivo/cinghia_iper_ciliare.json,,coverage_q4_2025,,scout,true,false
+coda_prensile_muscolare,i18n:traits.coda_prensile_muscolare.label,Locomotivo/Arboricolo,Arboricolo,data/traits/locomotivo/coda_prensile_muscolare.json,,coverage_q4_2025,,scout,true,false
+flusso_ameboide_controllato,i18n:traits.flusso_ameboide_controllato.label,Locomotivo/Terrestre,Terrestre,data/traits/locomotivo/flusso_ameboide_controllato.json,,coverage_q4_2025,,scout,true,false
+locomozione_miriapode_ibrida,i18n:traits.locomozione_miriapode_ibrida.label,Locomotivo/Terrestre,Terrestre,data/traits/locomotivo/locomozione_miriapode_ibrida.json,,coverage_q4_2025,,scout,true,false
+scheletro_idraulico_a_pistoni,i18n:traits.scheletro_idraulico_a_pistoni.label,Locomotivo/Balistico,Balistico,data/traits/locomotivo/scheletro_idraulico_a_pistoni.json,,coverage_q4_2025,,scout,true,false
+scheletro_pneumatico_a_maglie,i18n:traits.scheletro_pneumatico_a_maglie.label,Locomotivo/Terrestre,Terrestre,data/traits/locomotivo/scheletro_pneumatico_a_maglie.json,,coverage_q4_2025,,scout,true,false
+scivolamento_magnetico,i18n:traits.scivolamento_magnetico.label,Locomotivo/Terrestre,Terrestre,data/traits/locomotivo/scivolamento_magnetico.json,,coverage_q4_2025,,scout,true,false
+unghie_a_micro_adesione,i18n:traits.unghie_a_micro_adesione.label,Locomotivo/Arboricolo,Arboricolo,data/traits/locomotivo/unghie_a_micro_adesione.json,,coverage_q4_2025,,scout,true,false
 ali_ioniche,i18n:traits.ali_ioniche.label,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/ali_ioniche.json,,coverage_q4_2025,canopia_ionica,scout,true,false
 antenne_wideband,i18n:traits.antenne_wideband.label,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/antenne_wideband.json,,coverage_q4_2025,steppe_algoritmiche,scout,true,false
 artigli_sette_vie,i18n:traits.artigli_sette_vie.label,Locomotorio/Prensile,Prensile,data/traits/locomotorio/artigli_sette_vie.json,,controllo_psionico,caverna_risonante,breaker;scout,true,false
@@ -60,6 +117,7 @@ linfa_tampone,i18n:traits.linfa_tampone.label,Locomotorio/Mobilità,Mobilità,da
 mucose_aderenza_sonica,i18n:traits.mucose_aderenza_sonica.label,Locomotorio/Mobilità,Mobilità,data/traits/locomotorio/mucose_aderenza_sonica.json,,coverage_q4_2025,caverna_risonante,scout,true,false
 zampe_a_molla,i18n:traits.zampe_a_molla.label,Mobilità/Cinetico,Cinetico,data/traits/locomotorio/zampe_a_molla.json,,controllo_psionico,foresta_miceliale,scout,true,false
 zoccoli_risonanti_steppe,i18n:traits.zoccoli_risonanti_steppe.label,Locomotorio/Supporto,Supporto,data/traits/locomotorio/zoccoli_risonanti_steppe.json,,controllo_psionico,steppe_risonanti,scout;support,true,false
+rostro_linguale_prensile,i18n:traits.rostro_linguale_prensile.label,Manipolativo/Alimentare,Alimentare,data/traits/manipolativo/rostro_linguale_prensile.json,,coverage_q4_2025,,controller,true,false
 antenne_dustsense,i18n:traits.antenne_dustsense.label,Digestivo/Metabolico,Metabolico,data/traits/metabolico/antenne_dustsense.json,,coverage_q4_2025,pianura_salina_iperarida,sustain,true,false
 appendici_thermotattiche,i18n:traits.appendici_thermotattiche.label,Digestivo/Metabolico,Metabolico,data/traits/metabolico/appendici_thermotattiche.json,,coverage_q4_2025,abisso_vulcanico,sustain,true,false
 batteri_endosimbionti_chemio,i18n:traits.batteri_endosimbionti_chemio.label,Digestivo/Metabolico,Metabolico,data/traits/metabolico/batteri_endosimbionti_chemio.json,,coverage_q4_2025,abisso_vulcanico,sustain,true,false
@@ -78,26 +136,38 @@ luminescenza_aurorale,i18n:traits.luminescenza_aurorale.label,Digestivo/Metaboli
 sonno_emisferico_alternato,i18n:traits.sonno_emisferico_alternato.label,Nervoso/Omeostatico,Omeostatico,data/traits/nervoso/sonno_emisferico_alternato.json,,controllo_psionico,caverna_risonante,controller;sustain,true,false
 antenne_flusso_mareale,i18n:traits.antenne_flusso_mareale.label,Offensivo/Assalto,Assalto,data/traits/offensivo/antenne_flusso_mareale.json,,coverage_q4_2025,laguna_bioreattiva,breaker,true,false
 artigli_induzione,i18n:traits.artigli_induzione.label,Offensivo/Assalto,Assalto,data/traits/offensivo/artigli_induzione.json,,coverage_q4_2025,canopia_ionica,breaker,true,false
+artigli_ipo_termici,i18n:traits.artigli_ipo_termici.label,Offensivo/Termico,Termico,data/traits/offensivo/artigli_ipo_termici.json,,coverage_q4_2025,,breaker,true,false
+artiglio_cinetico_a_urto,i18n:traits.artiglio_cinetico_a_urto.label,Offensivo/Contusivo,Contusivo,data/traits/offensivo/artiglio_cinetico_a_urto.json,,coverage_q4_2025,,breaker,true,false
+aura_di_dispersione_mentale,i18n:traits.aura_di_dispersione_mentale.label,Offensivo/Controllo,Controllo,data/traits/offensivo/aura_di_dispersione_mentale.json,,coverage_q4_2025,,breaker,true,false
 biochip_memoria,i18n:traits.biochip_memoria.label,Offensivo/Assalto,Assalto,data/traits/offensivo/biochip_memoria.json,,coverage_q4_2025,steppe_algoritmiche,breaker,true,false
 camere_anticorrosione,i18n:traits.camere_anticorrosione.label,Offensivo/Assalto,Assalto,data/traits/offensivo/camere_anticorrosione.json,,coverage_q4_2025,foresta_acida,breaker,true,false
+cannone_sonico_a_raggio,i18n:traits.cannone_sonico_a_raggio.label,Offensivo/Controllo,Controllo,data/traits/offensivo/cannone_sonico_a_raggio.json,,coverage_q4_2025,,breaker;controller,true,false
+canto_infrasonico_tattico,i18n:traits.canto_infrasonico_tattico.label,Offensivo/Controllo,Controllo,data/traits/offensivo/canto_infrasonico_tattico.json,,coverage_q4_2025,,breaker,true,false
 cartilagini_biofibre,i18n:traits.cartilagini_biofibre.label,Offensivo/Assalto,Assalto,data/traits/offensivo/cartilagini_biofibre.json,,coverage_q4_2025,reef_luminescente,breaker,true,false
 circolazione_supercritica,i18n:traits.circolazione_supercritica.label,Offensivo/Assalto,Assalto,data/traits/offensivo/circolazione_supercritica.json,,coverage_q4_2025,abisso_vulcanico,breaker,true,false
 coda_stabilizzatrice_vortex,i18n:traits.coda_stabilizzatrice_vortex.label,Offensivo/Assalto,Assalto,data/traits/offensivo/coda_stabilizzatrice_vortex.json,,coverage_q4_2025,stratosfera_tempestosa,breaker,true,false
 denti_chelatanti,i18n:traits.denti_chelatanti.label,Offensivo/Assalto,Assalto,data/traits/offensivo/denti_chelatanti.json,,coverage_q4_2025,foresta_acida,breaker,true,false
+elettromagnete_biologico,i18n:traits.elettromagnete_biologico.label,Offensivo/Elettrico,Elettrico,data/traits/offensivo/elettromagnete_biologico.json,,coverage_q4_2025,,breaker,true,false
 enzimi_metanoossidanti,i18n:traits.enzimi_metanoossidanti.label,Offensivo/Assalto,Assalto,data/traits/offensivo/enzimi_metanoossidanti.json,,coverage_q4_2025,abisso_vulcanico,breaker,true,false
+estroflessione_gastrica_acida,i18n:traits.estroflessione_gastrica_acida.label,Offensivo/Chimico,Chimico,data/traits/offensivo/estroflessione_gastrica_acida.json,,coverage_q4_2025,,breaker,true,false
 foliaggio_spugna,i18n:traits.foliaggio_spugna.label,Offensivo/Assalto,Assalto,data/traits/offensivo/foliaggio_spugna.json,,coverage_q4_2025,mangrovieto_cinetico,breaker,true,false
-frusta_fiammeggiante,i18n:traits.frusta_fiammeggiante.label,Offensivo/Controllo,Controllo,data/traits/offensivo/frusta_fiammeggiante.json,,pathfinder_dataset,,breaker;controller,true,false
-ghiandola_caustica,i18n:traits.ghiandola_caustica.label,Offensivo/Chimico,Chimico,data/traits/offensivo/ghiandola_caustica.json,,controllo_psionico,foresta_miceliale,breaker,true,false
+frusta_fiammeggiante,i18n:traits.frusta_fiammeggiante.label,Offensivo/Controllo,Controllo,data/traits/offensivo/frusta_fiammeggiante.json,,pathfinder_dataset,rovine_planari,breaker;controller,true,false
+ghiandola_caustica,i18n:traits.ghiandola_caustica.label,Offensivo/Chimico,Chimico,data/traits/offensivo/ghiandola_caustica.json,,controllo_psionico,foresta_miceliale,breaker,true,true
 ghiandole_iodoattive,i18n:traits.ghiandole_iodoattive.label,Offensivo/Assalto,Assalto,data/traits/offensivo/ghiandole_iodoattive.json,,coverage_q4_2025,pianura_salina_iperarida,breaker,true,false
 gusci_magnesio,i18n:traits.gusci_magnesio.label,Offensivo/Assalto,Assalto,data/traits/offensivo/gusci_magnesio.json,,coverage_q4_2025,dorsale_termale_tropicale,breaker,true,false
 mantelli_geotermici,i18n:traits.mantelli_geotermici.label,Offensivo/Assalto,Assalto,data/traits/offensivo/mantelli_geotermici.json,,coverage_q4_2025,caldera_glaciale,breaker,true,false
+rostro_emostatico_litico,i18n:traits.rostro_emostatico_litico.label,Offensivo/Perforante,Perforante,data/traits/offensivo/rostro_emostatico_litico.json,,incoming_tr1100_pack,,breaker,true,false
 sangue_piroforico,i18n:traits.sangue_piroforico.label,Offensivo/Cinetico,Cinetico,data/traits/offensivo/sangue_piroforico.json,,controllo_psionico,caverna_risonante,breaker,true,false
+seta_conduttiva_elettrica,i18n:traits.seta_conduttiva_elettrica.label,Offensivo/Elettrico,Elettrico,data/traits/offensivo/seta_conduttiva_elettrica.json,,coverage_q4_2025,,breaker,true,false
+zanne_idracida,i18n:traits.zanne_idracida.label,Offensivo/Chimico,Chimico,data/traits/offensivo/zanne_idracida.json,,coverage_q4_2025,,breaker,true,false
 branchie_osmotiche_salmastra,i18n:traits.branchie_osmotiche_salmastra.label,Respiratorio/Osmoregolazione,Osmoregolazione,data/traits/respiratorio/branchie_osmotiche_salmastra.json,,controllo_psionico,delta_salmastri,sustain,true,false
 lamelle_termoforetiche,i18n:traits.lamelle_termoforetiche.label,Respiratorio/Termoregolazione,Termoregolazione,data/traits/respiratorio/lamelle_termoforetiche.json,,controllo_psionico,sorgenti_geotermiche,sustain,true,false
 membrane_eliofiltranti,i18n:traits.membrane_eliofiltranti.label,Respiratorio/Protezione,Protezione,data/traits/respiratorio/membrane_eliofiltranti.json,,controllo_psionico,laghi_alcalini,sustain;tank,true,false
 polmoni_cristallini_alta_quota,i18n:traits.polmoni_cristallini_alta_quota.label,Respiratorio/Aerobico,Aerobico,data/traits/respiratorio/polmoni_cristallini_alta_quota.json,,controllo_psionico,picchi_cristallini,sustain,true,false
 respiro_a_scoppio,i18n:traits.respiro_a_scoppio.label,Respiratorio/Propulsivo,Propulsivo,data/traits/respiratorio/respiro_a_scoppio.json,,controllo_psionico,caverna_risonante,scout;sustain,true,false
-nucleo_ovomotore_rotante,i18n:traits.nucleo_ovomotore_rotante.label,Riproduttivo/Locomotorio,Locomotorio,data/traits/riproduttivo/nucleo_ovomotore_rotante.json,,controllo_psionico,caverna_risonante,scout;support,true,false
+ermafroditismo_cronologico,i18n:traits.ermafroditismo_cronologico.label,Riproduttivo/Cicli,Cicli,data/traits/riproduttivo/ermafroditismo_cronologico.json,,coverage_q4_2025,,support,true,false
+moltiplicazione_per_fusione,i18n:traits.moltiplicazione_per_fusione.label,Riproduttivo/Cicli,Cicli,data/traits/riproduttivo/moltiplicazione_per_fusione.json,,coverage_q4_2025,,support,true,false
+nucleo_ovomotore_rotante,i18n:traits.nucleo_ovomotore_rotante.label,Riproduttivo/Locomotorio,Locomotorio,data/traits/riproduttivo/nucleo_ovomotore_rotante.json,,controllo_psionico,caverna_risonante,scout;support,true,true
 ali_fulminee,i18n:traits.ali_fulminee.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/ali_fulminee.json,,coverage_q4_2025,stratosfera_tempestosa,scout;support,true,false
 antenne_plasmatiche_tempesta,i18n:traits.antenne_plasmatiche_tempesta.label,Sensoriale/Offensivo,Offensivo,data/traits/sensoriale/antenne_plasmatiche_tempesta.json,,controllo_psionico,cicloni_psionici,breaker;scout,true,false
 antenne_waveguide,i18n:traits.antenne_waveguide.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/antenne_waveguide.json,,coverage_q4_2025,reef_luminescente,scout;support,true,false
@@ -113,13 +183,19 @@ eco_interno_riflesso,i18n:traits.eco_interno_riflesso.label,Sensoriale/Nervoso,N
 filamenti_superconduttivi,i18n:traits.filamenti_superconduttivi.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/filamenti_superconduttivi.json,,coverage_q4_2025,caldera_glaciale,scout;support,true,false
 ghiandole_eco_mappanti,i18n:traits.ghiandole_eco_mappanti.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/ghiandole_eco_mappanti.json,,coverage_q4_2025,caverna_risonante,scout;support,true,false
 ghiandole_resina_conduttiva,i18n:traits.ghiandole_resina_conduttiva.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/ghiandole_resina_conduttiva.json,,coverage_q4_2025,canopia_ionica,scout;support,true,false
+integumento_bipolare,i18n:traits.integumento_bipolare.label,Sensoriale/Magneto-ricettivo,Magneto-ricettivo,data/traits/sensoriale/integumento_bipolare.json,,coverage_q4_2025,,scout,true,false
 lamine_scudo_silice,i18n:traits.lamine_scudo_silice.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/lamine_scudo_silice.json,,coverage_q4_2025,dorsale_termale_tropicale,scout;support,true,false
 lingua_tattile_trama,i18n:traits.lingua_tattile_trama.label,Sensoriale/Alimentare,Alimentare,data/traits/sensoriale/lingua_tattile_trama.json,,controllo_psionico,caverna_risonante,scout;sustain,true,false
 midollo_antivibrazione,i18n:traits.midollo_antivibrazione.label,Sensoriale/Analitico,Analitico,data/traits/sensoriale/midollo_antivibrazione.json,,coverage_q4_2025,caverna_risonante,scout;support,true,false
+occhi_analizzatori_di_tensione,i18n:traits.occhi_analizzatori_di_tensione.label,Sensoriale/Visivo,Visivo,data/traits/sensoriale/occhi_analizzatori_di_tensione.json,,coverage_q4_2025,,scout,true,false
+occhi_cinetici,i18n:traits.occhi_cinetici.label,Sensoriale/Visivo,Visivo,data/traits/sensoriale/occhi_cinetici.json,,coverage_q4_2025,,scout;support,true,false
+occhi_cristallo_modulare,i18n:traits.occhi_cristallo_modulare.label,Sensoriale/Visivo,Visivo,data/traits/sensoriale/occhi_cristallo_modulare.json,,pathfinder_dataset,,scout,false,true
 occhi_infrarosso_composti,i18n:traits.occhi_infrarosso_composti.label,Sensoriale/Visivo,Visivo,data/traits/sensoriale/occhi_infrarosso_composti.json,,controllo_psionico,caverna_risonante,scout,true,false
-occhi_cristallo_modulare,Occhi di Cristallo Modulare,Sensoriale/Visivo,Visivo,data/traits/sensoriale/occhi_cristallo_modulare.json,,pathfinder_dataset,,,false,false
 olfatto_risonanza_magnetica,i18n:traits.olfatto_risonanza_magnetica.label,Sensoriale/Nervoso,Nervoso,data/traits/sensoriale/olfatto_risonanza_magnetica.json,,controllo_psionico,falde_magnetiche_psioniche;orbita_psionica_inversa,controller;scout,true,false
+organi_sismici_cutanei,i18n:traits.organi_sismici_cutanei.label,Sensoriale/Tatto-Vibro,Tatto-Vibro,data/traits/sensoriale/organi_sismici_cutanei.json,,incoming_tr1100_pack,,scout,true,false
 sensori_geomagnetici,i18n:traits.sensori_geomagnetici.label,Sensoriale/Navigazione,Navigazione,data/traits/sensoriale/sensori_geomagnetici.json,,controllo_psionico,pianure_magnetiche,scout,true,false
+sistemi_chimio_sonici,i18n:traits.sistemi_chimio_sonici.label,Sensoriale/Uditivo-Olfattivo,Uditivo-Olfattivo,data/traits/sensoriale/sistemi_chimio_sonici.json,,coverage_q4_2025,,scout,true,false
+visione_multi_spettrale_amplificata,i18n:traits.visione_multi_spettrale_amplificata.label,Sensoriale/Visivo,Visivo,data/traits/sensoriale/visione_multi_spettrale_amplificata.json,,coverage_q4_2025,,scout,true,false
 antenne_reagenti,i18n:traits.antenne_reagenti.label,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/antenne_reagenti.json,,coverage_q4_2025,foresta_acida,support,true,false
 artigli_scivolo_silente,i18n:traits.artigli_scivolo_silente.label,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/artigli_scivolo_silente.json,,coverage_q4_2025,caverna_risonante,support,true,false
 biofilm_iperarido,i18n:traits.biofilm_iperarido.label,Simbiotico/Cooperativo,Cooperativo,data/traits/simbiotico/biofilm_iperarido.json,,coverage_q4_2025,pianura_salina_iperarida,support,true,false
@@ -153,7 +229,7 @@ ghiaccio_piezoelettrico,i18n:traits.ghiaccio_piezoelettrico.label,Strategico/Tat
 ghiandole_minerali,i18n:traits.ghiandole_minerali.label,Strategico/Tattico,Tattico,data/traits/strategia/ghiandole_minerali.json,,coverage_q4_2025,dorsale_termale_tropicale,support,true,false
 lamelle_shear,i18n:traits.lamelle_shear.label,Strategico/Tattico,Tattico,data/traits/strategia/lamelle_shear.json,,coverage_q4_2025,stratosfera_tempestosa,support,true,false
 membrane_captura_rugiada,i18n:traits.membrane_captura_rugiada.label,Strategico/Tattico,Tattico,data/traits/strategia/membrane_captura_rugiada.json,,coverage_q4_2025,pianura_salina_iperarida,support,true,false
-pathfinder,i18n:traits.pathfinder.label,Esplorazione/Tattico,Tattico,data/traits/strategia/pathfinder.json,,controllo_psionico,foresta_acida;foresta_miceliale,scout;support,true,false
+pathfinder,i18n:traits.pathfinder.label,Esplorazione/Tattico,Tattico,data/traits/strategia/pathfinder.json,,controllo_psionico,foresta_acida;foresta_miceliale,scout;support,true,true
 pianificatore,i18n:traits.pianificatore.label,Strategico/Tattico,Tattico,data/traits/strategia/pianificatore.json,,controllo_psionico,foresta_miceliale,support,true,false
 random,i18n:traits.random.label,Flessibile/Generico,Generico,data/traits/strategia/random.json,,controllo_psionico,foresta_miceliale,support;tank,true,true
 tattiche_di_branco,i18n:traits.tattiche_di_branco.label,Strategico/Tattico,Tattico,data/traits/strategia/tattiche_di_branco.json,,controllo_psionico,foresta_miceliale,support,true,false
@@ -176,7 +252,7 @@ scheletro_idro_regolante,i18n:traits.scheletro_idro_regolante.label,Strutturale/
 struttura_elastica_amorfa,i18n:traits.struttura_elastica_amorfa.label,Strutturale/Locomotorio,Locomotorio,data/traits/strutturale/struttura_elastica_amorfa.json,,controllo_psionico,canopia_psionica_leggera;falde_magnetiche_psioniche,scout;tank,true,false
 antenne_eco_turbina,i18n:traits.antenne_eco_turbina.label,Supporto/Logistico,Logistico,data/traits/supporto/antenne_eco_turbina.json,,coverage_q4_2025,dorsale_termale_tropicale,support,true,false
 artigli_acidofagi,i18n:traits.artigli_acidofagi.label,Supporto/Logistico,Logistico,data/traits/supporto/artigli_acidofagi.json,,coverage_q4_2025,foresta_acida,support,true,false
-aura_scudo_radianza,i18n:traits.aura_scudo_radianza.label,Supporto/Difesa,Difesa,data/traits/supporto/aura_scudo_radianza.json,,pathfinder_dataset,,support;tank,true,false
+aura_scudo_radianza,i18n:traits.aura_scudo_radianza.label,Supporto/Difesa,Difesa,data/traits/supporto/aura_scudo_radianza.json,,pathfinder_dataset,rovine_planari,support;tank,true,false
 batteri_termofili_endosimbiosi,i18n:traits.batteri_termofili_endosimbiosi.label,Supporto/Logistico,Logistico,data/traits/supporto/batteri_termofili_endosimbiosi.json,,coverage_q4_2025,dorsale_termale_tropicale,support,true,false
 branchie_turbina,i18n:traits.branchie_turbina.label,Supporto/Logistico,Logistico,data/traits/supporto/branchie_turbina.json,,coverage_q4_2025,dorsale_termale_tropicale,support,true,false
 carapaci_ferruginosi,i18n:traits.carapaci_ferruginosi.label,Supporto/Logistico,Logistico,data/traits/supporto/carapaci_ferruginosi.json,,coverage_q4_2025,abisso_vulcanico,support,true,false
@@ -192,21 +268,6 @@ luminescenza_hydrotermica,i18n:traits.luminescenza_hydrotermica.label,Supporto/L
 risonanza_di_branco,i18n:traits.risonanza_di_branco.label,Supporto/Coordinativo,Coordinativo,data/traits/supporto/risonanza_di_branco.json,,controllo_psionico,foresta_miceliale,support,true,false
 mimetismo_cromatico_passivo,i18n:traits.mimetismo_cromatico_passivo.label,Tegumentario/Difensivo,Difensivo,data/traits/tegumentario/mimetismo_cromatico_passivo.json,,controllo_psionico,canopia_psionica_leggera;falde_magnetiche_psioniche,tank,true,false
 piume_solari_fotovoltaiche,i18n:traits.piume_solari_fotovoltaiche.label,Tegumentario/Energetico,Energetico,data/traits/tegumentario/piume_solari_fotovoltaiche.json,,controllo_psionico,altipiani_solari,sustain;tank,true,false
-secrezione_rallentante_palmi,i18n:traits.secrezione_rallentante_palmi.label,Tegumentario/Difensivo,Difensivo,data/traits/tegumentario/secrezione_rallentante_palmi.json,,controllo_psionico,caverna_risonante,tank,true,false
+secrezione_rallentante_palmi,i18n:traits.secrezione_rallentante_palmi.label,Tegumentario/Difensivo,Difensivo,data/traits/tegumentario/secrezione_rallentante_palmi.json,,controllo_psionico,caverna_risonante,tank,true,true
 squame_rifrangenti_deserto,i18n:traits.squame_rifrangenti_deserto.label,Tegumentario/Difensivo,Difensivo,data/traits/tegumentario/squame_rifrangenti_deserto.json,,controllo_psionico,dune_cristalline,tank,true,false
 vello_condensatore_nebbie,i18n:traits.vello_condensatore_nebbie.label,Tegumentario/Idratazione,Idratazione,data/traits/tegumentario/vello_condensatore_nebbie.json,,controllo_psionico,foreste_nubose,sustain;tank,true,false
-rostro_emostatico_litico,i18n:traits.rostro_emostatico_litico.label,Offensivo/Perforante,Perforante,data/traits/offensivo/rostro_emostatico_litico.json,,incoming_tr1100_pack,terrestre,,true,false
-scheletro_idraulico_a_pistoni,Scheletro Idraulico a Pistoni,Locomotivo/Balistico,Balistico,data/traits/locomotivo/scheletro_idraulico_a_pistoni.json,,coverage_q4_2025,terrestre,,true,false
-ipertrofia_muscolare_massiva,i18n:traits.ipertrofia_muscolare_massiva.label,Fisiologico/Metabolico,Metabolico,data/traits/fisiologico/ipertrofia_muscolare_massiva.json,,incoming_tr1100_pack,terrestre,,true,false
-ectotermia_dinamica,i18n:traits.ectotermia_dinamica.label,Fisiologico/Termico,Termico,data/traits/fisiologico/ectotermia_dinamica.json,,incoming_tr1100_pack,terrestre,,true,false
-organi_sismici_cutanei,i18n:traits.organi_sismici_cutanei.label,Sensoriale/Tatto-Vibro,Tatto-Vibro,data/traits/sensoriale/organi_sismici_cutanei.json,,incoming_tr1100_pack,terrestre,,true,false
-ali_fono_risonanti,Ali Fono-Risonanti,Locomotivo/Aereo,Aereo,data/traits/locomotivo/ali_fono_risonanti.json,,coverage_q4_2025,terrestre,scout;controller,true,false
-articolazioni_a_leva_idraulica,Articolazioni a Leva Idraulica,Locomotivo/Terrestre,Terrestre,data/traits/locomotivo/articolazioni_a_leva_idraulica.json,,coverage_q4_2025,terrestre,,true,false
-articolazioni_multiassiali,Articolazioni Multiassiali,Locomotivo/Terrestre,Terrestre,data/traits/locomotivo/articolazioni_multiassiali.json,,coverage_q4_2025,terrestre,,true,false
-cinghia_iper_ciliare,Cinghia Iper-Ciliare,Locomotivo/Terrestre,Terrestre,data/traits/locomotivo/cinghia_iper_ciliare.json,,coverage_q4_2025,terrestre,,true,false
-coda_prensile_muscolare,Coda Prensile Muscolare,Locomotivo/Arboricolo,Arboricolo,data/traits/locomotivo/coda_prensile_muscolare.json,,coverage_q4_2025,terrestre,,true,false
-flusso_ameboide_controllato,Flusso Ameboide Controllato,Locomotivo/Terrestre,Terrestre,data/traits/locomotivo/flusso_ameboide_controllato.json,,coverage_q4_2025,terrestre,,true,false
-locomozione_miriapode_ibrida,Locomozione Miriapode Ibrida,Locomotivo/Terrestre,Terrestre,data/traits/locomotivo/locomozione_miriapode_ibrida.json,,coverage_q4_2025,terrestre,,true,false
-scheletro_pneumatico_a_maglie,Scheletro Pneumatico a Maglie,Locomotivo/Terrestre,Terrestre,data/traits/locomotivo/scheletro_pneumatico_a_maglie.json,,coverage_q4_2025,terrestre,,true,false
-scivolamento_magnetico,Scivolamento Magnetico,Locomotivo/Terrestre,Terrestre,data/traits/locomotivo/scivolamento_magnetico.json,,coverage_q4_2025,terrestre,,true,false
-unghie_a_micro_adesione,Unghie a Micro-Adesione,Locomotivo/Arboricolo,Arboricolo,data/traits/locomotivo/unghie_a_micro_adesione.json,,coverage_q4_2025,terrestre,,true,false

--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -1,143 +1,371 @@
 {
-  "schema_version": "2.0",
-  "trait_glossary": "data/core/traits/glossary.json",
   "traits": {
-    "ali_fulminee": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
+    "fagocitosi_assorbente": {
+      "id": "fagocitosi_assorbente",
+      "label": "i18n:traits.fagocitosi_assorbente.label",
       "data_origin": "coverage_q4_2025",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "ali_fulminee",
-      "label": "Ali Fulminee",
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "famiglia_tipologia": "Alimentazione/Digestione",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "membrana_plastica_continua"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.fagocitosi_assorbente.mutazione_indotta",
+      "uso_funzione": "i18n:traits.fagocitosi_assorbente.uso_funzione",
+      "spinta_selettiva": "i18n:traits.fagocitosi_assorbente.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "volume_ingestione",
+          "value": 5,
+          "unit": "L"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Assorbe 1 L di gel in < 30 s",
+        "scene_prompt": "Misura variazione massa dopo contatto prolungato"
+      },
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "stratosfera_tempestosa"
+            "biome_class": "terrestre"
           },
-          "fonte": "env_to_traits",
+          "fonte": "envo_mapping",
           "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Ali Fulminee ottimizza le operazioni sensoriale nelle condizioni di stratosfera tempestosa.",
-            "tier": "T1"
+            "tier": "T3",
+            "notes": "Attivo in biomi terrestri ricchi di detriti organici, dove il suolo fornisce superfici lente da inglobare."
           }
         }
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_00000873"
+        ]
       },
-      "slot": [],
       "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
+        "core": "alimentazione",
+        "complementare": "digestione"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "stratosfera-tempestosa-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "tier": "T1",
       "usage_tags": [
-        "scout",
         "support"
       ],
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+      "debolezza": "i18n:traits.fagocitosi_assorbente.debolezza"
     },
-    "ali_ioniche": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
+    "filtro_metallofago": {
+      "id": "filtro_metallofago",
+      "label": "i18n:traits.filtro_metallofago.label",
       "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "ali_ioniche",
-      "label": "Ali Ioniche",
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "famiglia_tipologia": "Alimentazione/Digestione",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [
+        "elettromagnete_biologico",
+        "bozzolo_magnetico"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.filtro_metallofago.mutazione_indotta",
+      "uso_funzione": "i18n:traits.filtro_metallofago.uso_funzione",
+      "spinta_selettiva": "i18n:traits.filtro_metallofago.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "metabolic_rate",
+          "value": 12,
+          "unit": "W/kg"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Livelli Fe plasmatico stabili",
+        "scene_prompt": "Profilo ematico su dieta priva di Fe"
+      },
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "canopia_ionica"
+            "biome_class": "terrestre"
           },
-          "fonte": "env_to_traits",
+          "fonte": "envo_mapping",
           "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Ali Ioniche ottimizza le operazioni locomotorio nelle condizioni di canopia ionica.",
-            "tier": "T1"
+            "tier": "T2",
+            "notes": "Funziona in ambienti terrestri con polveri e ossidi metallici nel terreno da filtrare e metabolizzare."
           }
         }
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_00000873"
+        ]
       },
-      "slot": [],
       "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
+        "core": "alimentazione",
+        "complementare": "digestione"
       },
-      "species_affinity": [
+      "usage_tags": [
+        "support"
+      ],
+      "debolezza": "i18n:traits.filtro_metallofago.debolezza"
+    },
+    "cervello_a_bassa_latenza": {
+      "id": "cervello_a_bassa_latenza",
+      "label": "i18n:traits.cervello_a_bassa_latenza.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Cognitivo/Apprendimento",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "ali_fono_risonanti"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.cervello_a_bassa_latenza.mutazione_indotta",
+      "uso_funzione": "i18n:traits.cervello_a_bassa_latenza.uso_funzione",
+      "spinta_selettiva": "i18n:traits.cervello_a_bassa_latenza.spinta_selettiva",
+      "metrics": [
         {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "canopia-ionica-trait-keeper",
-          "weight": 1
+          "name": "tempo_apprendimento",
+          "value": 30,
+          "unit": "s"
         }
       ],
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout"
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Apprende traiettorie in < 1 min",
+        "scene_prompt": "Task di tracking in volo"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "Le connessioni schermate restano stabili solo in atmosfera terrestre con campi elettromagnetici prevedibili."
+          }
+        }
       ],
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000178"
+        ]
+      },
+      "slot_profile": {
+        "core": "cognitivo",
+        "complementare": "apprendimento"
+      },
+      "usage_tags": [
+        "controller"
+      ],
+      "debolezza": "i18n:traits.cervello_a_bassa_latenza.debolezza"
+    },
+    "comunicazione_fotonica_coda_coda": {
+      "id": "comunicazione_fotonica_coda_coda",
+      "label": "i18n:traits.comunicazione_fotonica_coda_coda.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Cognitivo/Sociale",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [
+        "vello_di_assorbimento_totale"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.comunicazione_fotonica_coda_coda.mutazione_indotta",
+      "uso_funzione": "i18n:traits.comunicazione_fotonica_coda_coda.uso_funzione",
+      "spinta_selettiva": "i18n:traits.comunicazione_fotonica_coda_coda.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "cohesion_index",
+          "value": 0.85,
+          "unit": "1"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Esegue virate sincronizzate",
+        "scene_prompt": "Riprese IR e analisi di coesione"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T2",
+            "notes": "Richiede linee di vista sgombre tipiche di biomi terrestri per scambiare impulsi fotonici fra individui."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000228"
+        ]
+      },
+      "slot_profile": {
+        "core": "cognitivo",
+        "complementare": "sociale"
+      },
+      "usage_tags": [
+        "controller"
+      ],
+      "debolezza": "i18n:traits.comunicazione_fotonica_coda_coda.debolezza"
+    },
+    "corna_psico_conduttive": {
+      "id": "corna_psico_conduttive",
+      "label": "i18n:traits.corna_psico_conduttive.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Cognitivo/Sociale",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "coscienza_d_alveare_diffusa",
+        "aura_di_dispersione_mentale",
+        "metabolismo_di_condivisione_energetica",
+        "unghie_a_micro_adesione"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.corna_psico_conduttive.mutazione_indotta",
+      "uso_funzione": "i18n:traits.corna_psico_conduttive.uso_funzione",
+      "spinta_selettiva": "i18n:traits.corna_psico_conduttive.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "cohesion_index",
+          "value": 0.9,
+          "unit": "1"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Allerta sincrona in < 1 s",
+        "scene_prompt": "EEG di gruppo durante stimolo"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "Sfruttano i gradienti geomagnetici e la bassa ionizzazione dell'aria terrestre per amplificare segnali psionici."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000178"
+        ]
+      },
+      "slot_profile": {
+        "core": "cognitivo",
+        "complementare": "sociale"
+      },
+      "usage_tags": [
+        "controller"
+      ],
+      "debolezza": "i18n:traits.corna_psico_conduttive.debolezza"
+    },
+    "coscienza_d_alveare_diffusa": {
+      "id": "coscienza_d_alveare_diffusa",
+      "label": "i18n:traits.coscienza_d_alveare_diffusa.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Cognitivo/Sociale",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T4",
+      "slot": [],
+      "sinergie": [
+        "corna_psico_conduttive"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.coscienza_d_alveare_diffusa.mutazione_indotta",
+      "uso_funzione": "i18n:traits.coscienza_d_alveare_diffusa.uso_funzione",
+      "spinta_selettiva": "i18n:traits.coscienza_d_alveare_diffusa.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "tempo_apprendimento",
+          "value": 10,
+          "unit": "s"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Risoluzione labirinto condivisa",
+        "scene_prompt": "Task cooperativo con marker cranici"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T4",
+            "notes": "La rete alveare si ancora a tane e corridoi terrestri, mantenendo contatto fisico e ottico fra nodi."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000178"
+        ]
+      },
+      "slot_profile": {
+        "core": "cognitivo",
+        "complementare": "sociale"
+      },
+      "usage_tags": [
+        "controller"
+      ],
+      "debolezza": "i18n:traits.coscienza_d_alveare_diffusa.debolezza"
     },
     "ali_membrana_sonica": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
       "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "debolezza": "i18n:traits.ali_membrana_sonica.debolezza",
       "famiglia_tipologia": "Tegumentario/Difensivo",
       "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
       "id": "ali_membrana_sonica",
-      "label": "Ali Membrana Sonica",
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "label": "i18n:traits.ali_membrana_sonica.label",
+      "mutazione_indotta": "i18n:traits.ali_membrana_sonica.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -167,590 +395,31 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caverna-risonante-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "spinta_selettiva": "i18n:traits.ali_membrana_sonica.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.ali_membrana_sonica.uso_funzione",
       "usage_tags": [
         "tank"
       ],
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
-    },
-    "antenne_dustsense": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "antenne_dustsense",
-      "label": "Antenne Dustsense",
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "pianura_salina_iperarida"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Antenne Dustsense ottimizza le operazioni metabolico nelle condizioni di pianura salina iperarida.",
-            "tier": "T1"
-          }
-        }
+      "biome_tags": [
+        "caverna_risonante"
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "pianura-salina-iperarida-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "tier": "T1",
-      "usage_tags": [
-        "sustain"
-      ],
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
-    },
-    "antenne_eco_turbina": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "antenne_eco_turbina",
-      "label": "Antenne Eco Turbina",
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "dorsale_termale_tropicale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Antenne Eco Turbina ottimizza le operazioni supporto nelle condizioni di dorsale termale tropicale.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "dorsale-termale-tropicale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
-    },
-    "antenne_flusso_mareale": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "antenne_flusso_mareale",
-      "label": "Antenne Flusso Mareale",
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "laguna_bioreattiva"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Antenne Flusso Mareale ottimizza le operazioni offensivo nelle condizioni di laguna bioreattiva.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "laguna-bioreattiva-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "tier": "T1",
-      "usage_tags": [
-        "breaker"
-      ],
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
-    },
-    "antenne_microonde_cavernose": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "antenne_microonde_cavernose",
-      "label": "Antenne Microonde Cavernose",
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caverna_risonante"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Antenne Microonde Cavernose ottimizza le operazioni strategia nelle condizioni di caverna risonante.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco",
-        "pathfinder"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caverna-risonante-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
-    },
-    "antenne_plasmatiche_tempesta": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Scariche elettriche massicce possono bruciare i recettori e compromettere la coordinazione.",
-      "famiglia_tipologia": "Sensoriale/Offensivo",
-      "fattore_mantenimento_energetico": "Alto (Canalizzazione costante di plasma atmosferico)",
-      "id": "antenne_plasmatiche_tempesta",
-      "label": "Antenne Plasmatiche di Tempesta",
-      "mutazione_indotta": "Flagelli coronati da nodi plasma-sensibili che captano e deviano fulmini.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "cicloni_psionici"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Occhi di tempesta permanenti che concentrano elettricità e onde psioniche."
-          }
-        }
-      ],
-      "sinergie": [
-        "carapace_luminiscente_abissale",
-        "focus_frazionato",
-        "risonanza_di_branco",
-        "sinapsi_coraline_polifoniche"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [
-          "boardgame:Evolution/Camouflage-Ambush",
-          "hud:StormMeshPsi",
-          "bioma:cicloni_psionici"
-        ],
-        "combo_totale": 3,
-        "forme": [
-          "Forma:Tempestarii",
-          "HUD:Fulcro_Tempesta"
-        ],
-        "tabelle_random": [
-          "tabella:fulmini_empatici"
-        ]
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "offensivo",
-        "core": "sensoriale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "cicloni-psionici-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Comandare fulmini e navigare in cieli turbolenti durante campagne aeree.",
-      "tier": "T3",
-      "usage_tags": [
-        "breaker",
-        "scout"
-      ],
-      "uso_funzione": "Canalizza scariche atmosferiche in attacchi direzionati o scudi ionici."
-    },
-    "antenne_reagenti": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "antenne_reagenti",
-      "label": "Antenne Reagenti",
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "foresta_acida"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Antenne Reagenti ottimizza le operazioni simbiotico nelle condizioni di foresta acida.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "foresta-acida-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
-    },
-    "antenne_tesla": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Risonanze errate possono generare microfratture.",
-      "famiglia_tipologia": "Strutturale/Adattivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "antenne_tesla",
-      "label": "Antenne Tesla",
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "canopia_ionica"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Antenne Tesla ottimizza le operazioni strutturale nelle condizioni di canopia ionica.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "resilienza",
-        "core": "strutturale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "canopia-ionica-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
-      "tier": "T1",
-      "usage_tags": [
-        "tank"
-      ],
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
-    },
-    "antenne_waveguide": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "antenne_waveguide",
-      "label": "Antenne Waveguide",
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "reef_luminescente"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Antenne Waveguide ottimizza le operazioni sensoriale nelle condizioni di reef luminescente.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "reef-luminescente-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout",
-        "support"
-      ],
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
-    },
-    "antenne_wideband": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "antenne_wideband",
-      "label": "Antenne Wideband",
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "steppe_algoritmiche"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Antenne Wideband ottimizza le operazioni locomotorio nelle condizioni di steppe algoritmiche.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "steppe-algoritmiche-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout"
-      ],
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
+      "data_origin": "coverage_q4_2025"
     },
     "appendici_risonanti_marea": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
       "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
+      "debolezza": "i18n:traits.appendici_risonanti_marea.debolezza",
       "famiglia_tipologia": "Tegumentario/Difensivo",
       "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
       "id": "appendici_risonanti_marea",
-      "label": "Appendici Risonanti Marea",
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "label": "i18n:traits.appendici_risonanti_marea.label",
+      "mutazione_indotta": "i18n:traits.appendici_risonanti_marea.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -780,54 +449,48 @@
         "complementare": "protezione",
         "core": "difensivo"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "laguna-bioreattiva-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "spinta_selettiva": "i18n:traits.appendici_risonanti_marea.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.appendici_risonanti_marea.uso_funzione",
       "usage_tags": [
         "tank"
       ],
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
-    },
-    "appendici_thermotattiche": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
+      "biome_tags": [
+        "laguna_bioreattiva"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "barriere_miasma_glaciale": {
       "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
-      "famiglia_tipologia": "Digestivo/Metabolico",
+      "debolezza": "i18n:traits.barriere_miasma_glaciale.debolezza",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "appendici_thermotattiche",
-      "label": "Appendici Thermotattiche",
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
+      "id": "barriere_miasma_glaciale",
+      "label": "i18n:traits.barriere_miasma_glaciale.label",
+      "mutazione_indotta": "i18n:traits.barriere_miasma_glaciale.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "abisso_vulcanico"
+            "biome_class": "caldera_glaciale"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "coverage_q4_2025",
-            "notes": "Appendici Thermotattiche ottimizza le operazioni metabolico nelle condizioni di abisso vulcanico.",
+            "notes": "Barriere Miasma Glaciale ottimizza le operazioni difensivo nelle condizioni di caldera glaciale.",
             "tier": "T1"
           }
         }
       ],
       "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
       ],
       "sinergie_pi": {
         "co_occorrenze": [],
@@ -837,40 +500,1053 @@
       },
       "slot": [],
       "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
+        "complementare": "protezione",
+        "core": "difensivo"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "abisso-vulcanico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
+      "spinta_selettiva": "i18n:traits.barriere_miasma_glaciale.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.barriere_miasma_glaciale.uso_funzione",
       "usage_tags": [
-        "sustain"
+        "tank"
       ],
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
-    },
-    "armatura_pietra_planare": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
+      "biome_tags": [
+        "caldera_glaciale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "bozzolo_magnetico": {
+      "id": "bozzolo_magnetico",
+      "label": "i18n:traits.bozzolo_magnetico.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Difensivo/Resistenze",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [
+        "integumento_bipolare"
+      ],
       "conflitti": [],
-      "data_origin": "pathfinder_dataset",
-      "debolezza": "Pesante: riduce mobilità in ambienti non supportati o a bassa gravità.",
+      "mutazione_indotta": "i18n:traits.bozzolo_magnetico.mutazione_indotta",
+      "uso_funzione": "i18n:traits.bozzolo_magnetico.uso_funzione",
+      "spinta_selettiva": "i18n:traits.bozzolo_magnetico.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "campo_magnetico",
+          "value": 0.2,
+          "unit": "T"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Schermatura 10 dB EM a 0.5 m",
+        "scene_prompt": "Misura attenuazione con gaussmetro"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T2",
+            "notes": "Richiede minerali ferrosi presenti nei suoli terrestri per polarizzare il bozzolo difensivo."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_00000873"
+        ]
+      },
+      "slot_profile": {
+        "core": "difensivo",
+        "complementare": "resistenze"
+      },
+      "usage_tags": [
+        "tank"
+      ],
+      "debolezza": "i18n:traits.bozzolo_magnetico.debolezza"
+    },
+    "branchie_microfiltri": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.branchie_microfiltri.debolezza",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "branchie_microfiltri",
+      "label": "i18n:traits.branchie_microfiltri.label",
+      "mutazione_indotta": "i18n:traits.branchie_microfiltri.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "reef_luminescente"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Branchie Microfiltri ottimizza le operazioni difensivo nelle condizioni di reef luminescente.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "spinta_selettiva": "i18n:traits.branchie_microfiltri.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.branchie_microfiltri.uso_funzione",
+      "usage_tags": [
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "reef_luminescente"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "campo_di_interferenza_acustica": {
+      "id": "campo_di_interferenza_acustica",
+      "label": "i18n:traits.campo_di_interferenza_acustica.label",
+      "debolezza": "i18n:traits.campo_di_interferenza_acustica.debolezza",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Difensivo/Camuffamento",
+      "fattore_mantenimento_energetico": "Basso (rumore bianco a fase variabile)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "ali_fono_risonanti",
+        "occhi_cinetici",
+        "cannone_sonico_a_raggio"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.campo_di_interferenza_acustica.mutazione_indotta",
+      "uso_funzione": "i18n:traits.campo_di_interferenza_acustica.uso_funzione",
+      "spinta_selettiva": "i18n:traits.campo_di_interferenza_acustica.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "SPL_riduzione",
+          "value": 18,
+          "unit": "dB"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Interferisce con ecolocalizzazione",
+        "scene_prompt": "Test radar acustico in galleria del vento"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "Genera turbolenze nell'aria terrestre, disperdendo onde sonore e sonar in ambienti aperti."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000178"
+        ]
+      },
+      "usage_tags": [
+        "controller",
+        "support"
+      ],
+      "slot_profile": {
+        "core": "difensivo",
+        "complementare": "controllo"
+      }
+    },
+    "capsule_paracadute": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.capsule_paracadute.debolezza",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "capsule_paracadute",
+      "label": "i18n:traits.capsule_paracadute.label",
+      "mutazione_indotta": "i18n:traits.capsule_paracadute.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "stratosfera_tempestosa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Capsule Paracadute ottimizza le operazioni difensivo nelle condizioni di stratosfera tempestosa.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "spinta_selettiva": "i18n:traits.capsule_paracadute.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.capsule_paracadute.uso_funzione",
+      "usage_tags": [
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "stratosfera_tempestosa"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "circolazione_bifasica": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.circolazione_bifasica.debolezza",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "circolazione_bifasica",
+      "label": "i18n:traits.circolazione_bifasica.label",
+      "mutazione_indotta": "i18n:traits.circolazione_bifasica.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Circolazione Bifasica ottimizza le operazioni difensivo nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "spinta_selettiva": "i18n:traits.circolazione_bifasica.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.circolazione_bifasica.uso_funzione",
+      "usage_tags": [
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caldera_glaciale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "cisti_di_ibernazione_minerale": {
+      "id": "cisti_di_ibernazione_minerale",
+      "label": "i18n:traits.cisti_di_ibernazione_minerale.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Difensivo/Resistenze",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [
+        "moltiplicazione_per_fusione",
+        "fagocitosi_assorbente"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.cisti_di_ibernazione_minerale.mutazione_indotta",
+      "uso_funzione": "i18n:traits.cisti_di_ibernazione_minerale.uso_funzione",
+      "spinta_selettiva": "i18n:traits.cisti_di_ibernazione_minerale.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "tolleranza_termica",
+          "value": 120,
+          "unit": "K"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Sopravvive a 80 Cel per 10 min",
+        "scene_prompt": "Test termico/pressione con risveglio successivo"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T2",
+            "notes": "Le cisti si mineralizzano compattando sedimenti terrestri a protezione durante l'ibernazione."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_00000873"
+        ]
+      },
+      "slot_profile": {
+        "core": "difensivo",
+        "complementare": "resistenze"
+      },
+      "usage_tags": [
+        "tank"
+      ],
+      "debolezza": "i18n:traits.cisti_di_ibernazione_minerale.debolezza"
+    },
+    "coda_coppia_retroattiva": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.coda_coppia_retroattiva.debolezza",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "coda_coppia_retroattiva",
+      "label": "i18n:traits.coda_coppia_retroattiva.label",
+      "mutazione_indotta": "i18n:traits.coda_coppia_retroattiva.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "steppe_algoritmiche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Coda Coppia Retroattiva ottimizza le operazioni difensivo nelle condizioni di steppe algoritmiche.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "spinta_selettiva": "i18n:traits.coda_coppia_retroattiva.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.coda_coppia_retroattiva.uso_funzione",
+      "usage_tags": [
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "steppe_algoritmiche"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "cute_resistente_sali": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.cute_resistente_sali.debolezza",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Medio (Attivazione situazionale)",
+      "id": "cute_resistente_sali",
+      "label": "i18n:traits.cute_resistente_sali.label",
+      "mutazione_indotta": "i18n:traits.cute_resistente_sali.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "badlands"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Cute Resistente Sali ottimizza le operazioni difensivo nelle condizioni di badlands.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "spinta_selettiva": "i18n:traits.cute_resistente_sali.spinta_selettiva",
+      "tier": "T2",
+      "uso_funzione": "i18n:traits.cute_resistente_sali.uso_funzione",
+      "usage_tags": [
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "badlands"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "enzimi_antipredatori_algali": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.enzimi_antipredatori_algali.debolezza",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "enzimi_antipredatori_algali",
+      "label": "i18n:traits.enzimi_antipredatori_algali.label",
+      "mutazione_indotta": "i18n:traits.enzimi_antipredatori_algali.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "reef_luminescente"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Enzimi Antipredatori Algali ottimizza le operazioni difensivo nelle condizioni di reef luminescente.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "spinta_selettiva": "i18n:traits.enzimi_antipredatori_algali.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.enzimi_antipredatori_algali.uso_funzione",
+      "usage_tags": [
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "reef_luminescente"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "filtri_planctonici": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.filtri_planctonici.debolezza",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "filtri_planctonici",
+      "label": "i18n:traits.filtri_planctonici.label",
+      "mutazione_indotta": "i18n:traits.filtri_planctonici.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "laguna_bioreattiva"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Filtri Planctonici ottimizza le operazioni difensivo nelle condizioni di laguna bioreattiva.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "spinta_selettiva": "i18n:traits.filtri_planctonici.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.filtri_planctonici.uso_funzione",
+      "usage_tags": [
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "laguna_bioreattiva"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "ghiandole_fango_coesivo": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.ghiandole_fango_coesivo.debolezza",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_fango_coesivo",
+      "label": "i18n:traits.ghiandole_fango_coesivo.label",
+      "mutazione_indotta": "i18n:traits.ghiandole_fango_coesivo.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "mangrovieto_cinetico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Fango Coesivo ottimizza le operazioni difensivo nelle condizioni di mangrovieto cinetico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "spinta_selettiva": "i18n:traits.ghiandole_fango_coesivo.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.ghiandole_fango_coesivo.uso_funzione",
+      "usage_tags": [
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "mangrovieto_cinetico"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "giunti_antitorsione": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.giunti_antitorsione.debolezza",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "giunti_antitorsione",
+      "label": "i18n:traits.giunti_antitorsione.label",
+      "mutazione_indotta": "i18n:traits.giunti_antitorsione.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "mangrovieto_cinetico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Giunti Antitorsione ottimizza le operazioni difensivo nelle condizioni di mangrovieto cinetico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "spinta_selettiva": "i18n:traits.giunti_antitorsione.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.giunti_antitorsione.uso_funzione",
+      "usage_tags": [
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "mangrovieto_cinetico"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "lingua_cristallina": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.lingua_cristallina.debolezza",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "lingua_cristallina",
+      "label": "i18n:traits.lingua_cristallina.label",
+      "mutazione_indotta": "i18n:traits.lingua_cristallina.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianura_salina_iperarida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Lingua Cristallina ottimizza le operazioni difensivo nelle condizioni di pianura salina iperarida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "spinta_selettiva": "i18n:traits.lingua_cristallina.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.lingua_cristallina.uso_funzione",
+      "usage_tags": [
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "pianura_salina_iperarida"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "membrana_plastica_continua": {
+      "id": "membrana_plastica_continua",
+      "label": "i18n:traits.membrana_plastica_continua.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Difensivo/Camuffamento",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "flusso_ameboide_controllato",
+        "fagocitosi_assorbente",
+        "moltiplicazione_per_fusione"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.membrana_plastica_continua.mutazione_indotta",
+      "uso_funzione": "i18n:traits.membrana_plastica_continua.uso_funzione",
+      "spinta_selettiva": "i18n:traits.membrana_plastica_continua.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "rilevabilita_visiva",
+          "value": 0.2,
+          "unit": "1"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Forma blob semitrasparente in 3 s",
+        "scene_prompt": "Documenta transito in fessura 5 mm"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "La membrana si sigilla contro polveri e vento tipici degli habitat terrestri, riducendo microfessure."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_00000873"
+        ]
+      },
+      "slot_profile": {
+        "core": "difensivo",
+        "complementare": "camuffamento"
+      },
+      "usage_tags": [
+        "tank"
+      ],
+      "debolezza": "i18n:traits.membrana_plastica_continua.debolezza"
+    },
+    "mucose_barofile": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.mucose_barofile.debolezza",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "mucose_barofile",
+      "label": "i18n:traits.mucose_barofile.label",
+      "mutazione_indotta": "i18n:traits.mucose_barofile.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_vulcanico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Mucose Barofile ottimizza le operazioni difensivo nelle condizioni di abisso vulcanico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "difensivo"
+      },
+      "spinta_selettiva": "i18n:traits.mucose_barofile.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.mucose_barofile.uso_funzione",
+      "usage_tags": [
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "abisso_vulcanico"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "pelage_idrorepellente_avanzato": {
+      "id": "pelage_idrorepellente_avanzato",
+      "label": "i18n:traits.pelage_idrorepellente_avanzato.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Difensivo/Termoregolazione",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [
+        "scudo_gluteale_cheratinizzato",
+        "coda_prensile_muscolare"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.pelage_idrorepellente_avanzato.mutazione_indotta",
+      "uso_funzione": "i18n:traits.pelage_idrorepellente_avanzato.uso_funzione",
+      "spinta_selettiva": "i18n:traits.pelage_idrorepellente_avanzato.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "res_termica",
+          "value": 0.08,
+          "unit": "K/W"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Mantello asciutto dopo immersione 2 min",
+        "scene_prompt": "Pesare prima/dopo immersione in acqua dolce"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T2",
+            "notes": "Pensato per piogge intermittenti e fango dei biomi terrestri, mantiene isolamento termico costante."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_00000873",
+          "http://purl.obolibrary.org/obo/ENVO_01000228"
+        ]
+      },
+      "slot_profile": {
+        "core": "difensivo",
+        "complementare": "termoregolazione"
+      },
+      "usage_tags": [
+        "tank"
+      ],
+      "debolezza": "i18n:traits.pelage_idrorepellente_avanzato.debolezza"
+    },
+    "scudo_gluteale_cheratinizzato": {
+      "id": "scudo_gluteale_cheratinizzato",
+      "label": "i18n:traits.scudo_gluteale_cheratinizzato.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Difensivo/Corazza",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "pelage_idrorepellente_avanzato"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.scudo_gluteale_cheratinizzato.mutazione_indotta",
+      "uso_funzione": "i18n:traits.scudo_gluteale_cheratinizzato.uso_funzione",
+      "spinta_selettiva": "i18n:traits.scudo_gluteale_cheratinizzato.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "spessore_corazza",
+          "value": 35,
+          "unit": "mm"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Resiste a morso medio senza lesioni",
+        "scene_prompt": "Pressare su dinamometro dorsale"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "Le placche posteriori si rinforzano tramite abrasione su rocce e tronchi presenti nei terreni terrestri."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000228"
+        ]
+      },
+      "slot_profile": {
+        "core": "difensivo",
+        "complementare": "corazza"
+      },
+      "usage_tags": [
+        "tank"
+      ],
+      "debolezza": "i18n:traits.scudo_gluteale_cheratinizzato.debolezza"
+    },
+    "vello_di_assorbimento_totale": {
+      "id": "vello_di_assorbimento_totale",
+      "label": "i18n:traits.vello_di_assorbimento_totale.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Difensivo/Camuffamento",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "visione_multi_spettrale_amplificata",
+        "comunicazione_fotonica_coda_coda",
+        "motore_biologico_silenzioso"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.vello_di_assorbimento_totale.mutazione_indotta",
+      "uso_funzione": "i18n:traits.vello_di_assorbimento_totale.uso_funzione",
+      "spinta_selettiva": "i18n:traits.vello_di_assorbimento_totale.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "trasmittanza_ottica",
+          "value": 0.001,
+          "unit": "1"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Indistinguibile a 5 m al buio",
+        "scene_prompt": "Fotometro: luce riflessa vs piuma standard"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "Le fibre assorbono vibrazioni e particolato sospeso comuni in canyon e caverne terrestri."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000228"
+        ]
+      },
+      "slot_profile": {
+        "core": "difensivo",
+        "complementare": "camuffamento"
+      },
+      "usage_tags": [
+        "tank"
+      ],
+      "debolezza": "i18n:traits.vello_di_assorbimento_totale.debolezza"
+    },
+    "armatura_pietra_planare": {
+      "conflitti": [
+        "frusta_fiammeggiante"
+      ],
+      "debolezza": "i18n:traits.armatura_pietra_planare.debolezza",
       "famiglia_tipologia": "Difesa/Strutturale",
       "fattore_mantenimento_energetico": "Basso (Risonanza geodetica stabile)",
       "id": "armatura_pietra_planare",
-      "label": "Armatura di Pietra Planare",
-      "mutazione_indotta": "Cristallizza il dermascheletro con nodi rune che deviano energia.",
+      "label": "i18n:traits.armatura_pietra_planare.label",
+      "mutazione_indotta": "i18n:traits.armatura_pietra_planare.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [
@@ -901,299 +1577,90 @@
         "complementare": "strutturale",
         "core": "difesa"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "golem-runico",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "balor-fission",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "bulette-fase",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "treant-portale",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Stabilizzare varchi e proteggere infrastrutture dalle onde d'urto.",
+      "spinta_selettiva": "i18n:traits.armatura_pietra_planare.spinta_selettiva",
       "tier": "T2",
+      "uso_funzione": "i18n:traits.armatura_pietra_planare.uso_funzione",
       "usage_tags": [
         "tank"
       ],
-      "uso_funzione": "Offre schermatura massiva e ancoraggio durante le aperture dimensionali."
-    },
-    "artigli_acidofagi": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "artigli_acidofagi",
-      "label": "Artigli Acidofagi",
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
+      "biome_tags": [
+        "rovine_planari"
+      ],
+      "data_origin": "pathfinder_dataset"
+    },
+    "mantello_meteoritico": {
+      "conflitti": [
+        "aura_scudo_radianza"
+      ],
+      "debolezza": "i18n:traits.mantello_meteoritico.debolezza",
+      "famiglia_tipologia": "Difesa/Termoregolazione",
+      "fattore_mantenimento_energetico": "Alto (Rivestimento ablativo rigenerante)",
+      "id": "mantello_meteoritico",
+      "label": "i18n:traits.mantello_meteoritico.label",
+      "mutazione_indotta": "i18n:traits.mantello_meteoritico.mutazione_indotta",
       "requisiti_ambientali": [
         {
-          "capacita_richieste": [],
+          "capacita_richieste": [
+            "fire_resist"
+          ],
           "condizioni": {
-            "biome_class": "foresta_acida"
+            "biome_class": "rovine_planari"
           },
-          "fonte": "env_to_traits",
+          "fonte": "pathfinder_import",
           "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Artigli Acidofagi ottimizza le operazioni supporto nelle condizioni di foresta acida.",
-            "tier": "T1"
+            "expansion": "pathfinder_dataset",
+            "notes": "Richiede continue docce di plasma per mantenere la matrice ablativa.",
+            "tier": "T3"
           }
         }
       ],
       "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
+        "frusta_fiammeggiante",
+        "carapace_fase_variabile"
       ],
       "sinergie_pi": {
         "co_occorrenze": [],
-        "combo_totale": 2,
+        "combo_totale": 0,
         "forme": [],
         "tabelle_random": []
       },
       "slot": [],
       "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
+        "complementare": "termico",
+        "core": "difesa"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "foresta-acida-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "tier": "T1",
+      "spinta_selettiva": "i18n:traits.mantello_meteoritico.spinta_selettiva",
+      "tier": "T3",
+      "uso_funzione": "i18n:traits.mantello_meteoritico.uso_funzione",
       "usage_tags": [
-        "support"
+        "sustain",
+        "tank"
       ],
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
-    },
-    "artigli_induzione": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "artigli_induzione",
-      "label": "Artigli Induzione",
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "canopia_ionica"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Artigli Induzione ottimizza le operazioni offensivo nelle condizioni di canopia ionica.",
-            "tier": "T1"
-          }
-        }
+      "biome_tags": [
+        "rovine_planari"
       ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "canopia-ionica-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "tier": "T1",
-      "usage_tags": [
-        "breaker"
-      ],
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
+      "data_origin": "pathfinder_dataset"
     },
-    "artigli_radice": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
+    "filamenti_digestivi_compattanti": {
       "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
-      "famiglia_tipologia": "Strategico/Tattico",
+      "debolezza": "i18n:traits.filamenti_digestivi_compattanti.debolezza",
+      "famiglia_tipologia": "Digestivo/Escretorio",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "artigli_radice",
-      "label": "Artigli Radice",
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "mangrovieto_cinetico"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Artigli Radice ottimizza le operazioni strategia nelle condizioni di mangrovieto cinetico.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "mangrovieto-cinetico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
-    },
-    "artigli_scivolo_silente": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "artigli_scivolo_silente",
-      "label": "Artigli Scivolo Silente",
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caverna_risonante"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Artigli Scivolo Silente ottimizza le operazioni simbiotico nelle condizioni di caverna risonante.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caverna-risonante-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
-    },
-    "artigli_sette_vie": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Angoli di presa limitati se la superficie è perfettamente liscia.",
-      "famiglia_tipologia": "Locomotorio/Prensile",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "artigli_sette_vie",
-      "label": "Artigli a Sette Vie",
-      "mutazione_indotta": "Dita lunghe e segmentate con punte a uncino multiplo.",
+      "id": "filamenti_digestivi_compattanti",
+      "label": "i18n:traits.filamenti_digestivi_compattanti.label",
+      "mutazione_indotta": "i18n:traits.filamenti_digestivi_compattanti.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1203,7 +1670,2422 @@
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+            "tier": "T2"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Variante T2 che sfrutta falde magnetiche per compattare residui ad alta densità.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "sinergie": [
+        "antenne_dustsense",
+        "appendici_thermotattiche",
+        "batteri_endosimbionti_chemio",
+        "branchie_solfatiche",
+        "carapace_segmenti_logici",
+        "circolazione_cooling_loop",
+        "coda_stabilizzatrice_filo",
+        "cuticole_cerose",
+        "enzimi_chelanti",
+        "flagelli_ancoranti",
+        "ghiandole_grafene",
+        "grassi_termici",
+        "luminescenza_aurorale",
+        "ventriglio_gastroliti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "escretorio",
+        "core": "digestivo"
+      },
+      "spinta_selettiva": "i18n:traits.filamenti_digestivi_compattanti.spinta_selettiva",
+      "tier": "T2",
+      "uso_funzione": "i18n:traits.filamenti_digestivi_compattanti.uso_funzione",
+      "usage_tags": [
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caverna_risonante",
+        "falde_magnetiche_psioniche"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "ventriglio_gastroliti": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.ventriglio_gastroliti.debolezza",
+      "famiglia_tipologia": "Digestivo/Alimentare",
+      "fattore_mantenimento_energetico": "Medio (Contrazione muscolare costante)",
+      "id": "ventriglio_gastroliti",
+      "label": "i18n:traits.ventriglio_gastroliti.label",
+      "mutazione_indotta": "i18n:traits.ventriglio_gastroliti.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "antenne_dustsense",
+        "appendici_thermotattiche",
+        "batteri_endosimbionti_chemio",
+        "branchie_solfatiche",
+        "carapace_segmenti_logici",
+        "circolazione_cooling_loop",
+        "coda_stabilizzatrice_filo",
+        "cuticole_cerose",
+        "enzimi_chelanti",
+        "filamenti_digestivi_compattanti",
+        "flagelli_ancoranti",
+        "ghiandole_grafene",
+        "grassi_termici",
+        "luminescenza_aurorale"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "alimentare",
+        "core": "digestivo"
+      },
+      "spinta_selettiva": "i18n:traits.ventriglio_gastroliti.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.ventriglio_gastroliti.uso_funzione",
+      "usage_tags": [
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caverna_risonante"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "spore_psichiche_silenziate": {
+      "conflitti": [
+        "respiro_a_scoppio"
+      ],
+      "debolezza": "i18n:traits.spore_psichiche_silenziate.debolezza",
+      "famiglia_tipologia": "Escretorio/Psichico",
+      "fattore_mantenimento_energetico": "Alto (Produzione e rilascio)",
+      "id": "spore_psichiche_silenziate",
+      "label": "i18n:traits.spore_psichiche_silenziate.label",
+      "mutazione_indotta": "i18n:traits.spore_psichiche_silenziate.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "focus_frazionato",
+        "empatia_coordinativa",
+        "cervello_a_bassa_latenza",
+        "tattiche_di_branco",
+        "campo_di_interferenza_acustica"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "cap_pt",
+          "starter_bioma",
+          "job_ability:invoker/sincronia"
+        ],
+        "combo_totale": 2,
+        "forme": [
+          "INFJ",
+          "INTJ"
+        ],
+        "tabelle_random": []
+      },
+      "slot": [
+        "B",
+        "C"
+      ],
+      "slot_profile": {
+        "complementare": "psichico",
+        "core": "escretorio"
+      },
+      "spinta_selettiva": "i18n:traits.spore_psichiche_silenziate.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.spore_psichiche_silenziate.uso_funzione",
+      "usage_tags": [
+        "controller",
+        "sustain"
+      ],
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "psionic-canopy-scout",
+          "weight": 2
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": true,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caverna_risonante"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "ectotermia_dinamica": {
+      "id": "ectotermia_dinamica",
+      "label": "i18n:traits.ectotermia_dinamica.label",
+      "data_origin": "incoming_tr1100_pack",
+      "famiglia_tipologia": "Fisiologico/Termico",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "ipertrofia_muscolare_massiva",
+        "rostro_emostatico_litico"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.ectotermia_dinamica.mutazione_indotta",
+      "uso_funzione": "i18n:traits.ectotermia_dinamica.uso_funzione",
+      "spinta_selettiva": "i18n:traits.ectotermia_dinamica.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "tolleranza_termica",
+          "value": 20,
+          "unit": "K"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Mantiene output a 10 Cel ambientali",
+        "scene_prompt": "Prova in camera fredda"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "Regola il metabolismo seguendo le oscillazioni termiche giornaliere dei biomi terrestri."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000178"
+        ]
+      },
+      "version": "2.0.1",
+      "versioning": {
+        "created": "2025-11-04",
+        "updated": "2025-11-23",
+        "author": "Master DD / GPT-5 Pro"
+      },
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "termico"
+      },
+      "usage_tags": [
+        "sustain"
+      ],
+      "debolezza": "i18n:traits.ectotermia_dinamica.debolezza"
+    },
+    "filtrazione_osmotica": {
+      "id": "filtrazione_osmotica",
+      "label": "i18n:traits.filtrazione_osmotica.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Fisiologico/Idrico",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [
+        "zanne_idracida"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.filtrazione_osmotica.mutazione_indotta",
+      "uso_funzione": "i18n:traits.filtrazione_osmotica.uso_funzione",
+      "spinta_selettiva": "i18n:traits.filtrazione_osmotica.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "metabolic_rate",
+          "value": 15,
+          "unit": "W/kg"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Emivita tossine ridotta del 50%",
+        "scene_prompt": "Analisi ematica dopo somministrazione standard"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T2",
+            "notes": "Filtra vapori e aerosol presenti nell'aria terrestre per mantenere l'omeostasi idrica."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000228"
+        ]
+      },
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "idrico"
+      },
+      "usage_tags": [
+        "sustain"
+      ],
+      "debolezza": "i18n:traits.filtrazione_osmotica.debolezza"
+    },
+    "ipertrofia_muscolare_massiva": {
+      "id": "ipertrofia_muscolare_massiva",
+      "label": "i18n:traits.ipertrofia_muscolare_massiva.label",
+      "data_origin": "incoming_tr1100_pack",
+      "famiglia_tipologia": "Fisiologico/Metabolico",
+      "fattore_mantenimento_energetico": "Alto (apporto costante o consumo continuo)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "ectotermia_dinamica",
+        "scheletro_idraulico_a_pistoni"
+      ],
+      "conflitti": [
+        "organi_sismici_cutanei"
+      ],
+      "mutazione_indotta": "i18n:traits.ipertrofia_muscolare_massiva.mutazione_indotta",
+      "uso_funzione": "i18n:traits.ipertrofia_muscolare_massiva.uso_funzione",
+      "spinta_selettiva": "i18n:traits.ipertrofia_muscolare_massiva.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "metabolic_rate",
+          "value": 60,
+          "unit": "W/kg"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Sprint 0–10 m < 2 s",
+        "scene_prompt": "Cronometra tre sprint; rileva FC post-sforzo"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "La crescita muscolare richiede gravità standard e superfici di spinta dei biomi terrestri."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000178"
+        ]
+      },
+      "version": "2.0.1",
+      "versioning": {
+        "created": "2025-11-04",
+        "updated": "2025-11-23",
+        "author": "Master DD / GPT-5 Pro"
+      },
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "metabolico"
+      },
+      "usage_tags": [
+        "sustain"
+      ],
+      "debolezza": "i18n:traits.ipertrofia_muscolare_massiva.debolezza"
+    },
+    "metabolismo_di_condivisione_energetica": {
+      "id": "metabolismo_di_condivisione_energetica",
+      "label": "i18n:traits.metabolismo_di_condivisione_energetica.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Fisiologico/Metabolico",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "corna_psico_conduttive"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.metabolismo_di_condivisione_energetica.mutazione_indotta",
+      "uso_funzione": "i18n:traits.metabolismo_di_condivisione_energetica.uso_funzione",
+      "spinta_selettiva": "i18n:traits.metabolismo_di_condivisione_energetica.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "consumo_o2",
+          "value": 50,
+          "unit": "L/min"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Ripristino FC di infortunato accelerato",
+        "scene_prompt": "Misura lattato prima/dopo contatto"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "Le riserve energetiche si scambiano facilmente in colonie ravvicinate che convivono in tane terrestri."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000178"
+        ]
+      },
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "metabolico"
+      },
+      "usage_tags": [
+        "sustain"
+      ],
+      "debolezza": "i18n:traits.metabolismo_di_condivisione_energetica.debolezza"
+    },
+    "motore_biologico_silenzioso": {
+      "id": "motore_biologico_silenzioso",
+      "label": "i18n:traits.motore_biologico_silenzioso.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Fisiologico/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [
+        "vello_di_assorbimento_totale",
+        "artigli_ipo_termici"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.motore_biologico_silenzioso.mutazione_indotta",
+      "uso_funzione": "i18n:traits.motore_biologico_silenzioso.uso_funzione",
+      "spinta_selettiva": "i18n:traits.motore_biologico_silenzioso.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "metabolic_rate",
+          "value": 8,
+          "unit": "W/kg"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "SPL < 20 dB a 5 m in volo",
+        "scene_prompt": "Misura sonoro in tunnel"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T2",
+            "notes": "Ottimizzato per vibrare sotto la soglia percepibile nel rumore di fondo degli ambienti terrestri."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000228"
+        ]
+      },
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "metabolico"
+      },
+      "usage_tags": [
+        "sustain"
+      ],
+      "debolezza": "i18n:traits.motore_biologico_silenzioso.debolezza"
+    },
+    "rete_filtro_polmonare": {
+      "id": "rete_filtro_polmonare",
+      "label": "i18n:traits.rete_filtro_polmonare.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Fisiologico/Respiratorio",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "scheletro_pneumatico_a_maglie"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.rete_filtro_polmonare.mutazione_indotta",
+      "uso_funzione": "i18n:traits.rete_filtro_polmonare.uso_funzione",
+      "spinta_selettiva": "i18n:traits.rete_filtro_polmonare.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "consumo_O2",
+          "value": 800,
+          "unit": "L/min"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Incremento massa senza ingesta solida",
+        "scene_prompt": "Camera aerosol con micro-fitoplancton"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "La rete trattiene spore e polveri diffuse nei biomi terrestri ventilati, proteggendo i polmoni."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000178"
+        ]
+      },
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "respiratorio"
+      },
+      "usage_tags": [
+        "sustain"
+      ],
+      "debolezza": "i18n:traits.rete_filtro_polmonare.debolezza"
+    },
+    "siero_anti_gelo_naturale": {
+      "id": "siero_anti_gelo_naturale",
+      "label": "i18n:traits.siero_anti_gelo_naturale.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Fisiologico/Termico",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [
+        "scheletro_pneumatico_a_maglie"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.siero_anti_gelo_naturale.mutazione_indotta",
+      "uso_funzione": "i18n:traits.siero_anti_gelo_naturale.uso_funzione",
+      "spinta_selettiva": "i18n:traits.siero_anti_gelo_naturale.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "tolleranza_termica",
+          "value": 60,
+          "unit": "K"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Mantiene mobilità a −20 Cel",
+        "scene_prompt": "Camera climatica con prova motoria"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T2",
+            "notes": "Progettato per sbalzi termici terrestri, impedisce la cristallizzazione dei fluidi durante gelate improvvise."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000178"
+        ]
+      },
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "termico"
+      },
+      "usage_tags": [
+        "sustain"
+      ],
+      "debolezza": "i18n:traits.siero_anti_gelo_naturale.debolezza"
+    },
+    "bioantenne_gravitiche": {
+      "id": "bioantenne_gravitiche",
+      "label": "i18n:traits.bioantenne_gravitiche.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Sensore/Gravitazionale",
+      "fattore_mantenimento_energetico": "i18n:traits.bioantenne_gravitiche.fattore_mantenimento_energetico",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.bioantenne_gravitiche.mutazione_indotta",
+      "uso_funzione": "i18n:traits.bioantenne_gravitiche.uso_funzione",
+      "spinta_selettiva": "i18n:traits.bioantenne_gravitiche.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T3"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      }
+    },
+    "camere_risonanza_abyssal": {
+      "id": "camere_risonanza_abyssal",
+      "label": "i18n:traits.camere_risonanza_abyssal.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Supporto/Risonanza",
+      "fattore_mantenimento_energetico": "i18n:traits.camere_risonanza_abyssal.fattore_mantenimento_energetico",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.camere_risonanza_abyssal.mutazione_indotta",
+      "uso_funzione": "i18n:traits.camere_risonanza_abyssal.uso_funzione",
+      "spinta_selettiva": "i18n:traits.camere_risonanza_abyssal.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T3"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      }
+    },
+    "canto_risonante": {
+      "id": "canto_risonante",
+      "label": "i18n:traits.canto_risonante.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Temporaneo/Risonanza",
+      "fattore_mantenimento_energetico": "i18n:traits.canto_risonante.fattore_mantenimento_energetico",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.canto_risonante.mutazione_indotta",
+      "uso_funzione": "i18n:traits.canto_risonante.uso_funzione",
+      "spinta_selettiva": "i18n:traits.canto_risonante.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T3"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      }
+    },
+    "coralli_sinaptici_fotofase": {
+      "id": "coralli_sinaptici_fotofase",
+      "label": "i18n:traits.coralli_sinaptici_fotofase.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Ambiente/Supporto",
+      "fattore_mantenimento_energetico": "i18n:traits.coralli_sinaptici_fotofase.fattore_mantenimento_energetico",
+      "tier": "T1",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.coralli_sinaptici_fotofase.mutazione_indotta",
+      "uso_funzione": "i18n:traits.coralli_sinaptici_fotofase.uso_funzione",
+      "spinta_selettiva": "i18n:traits.coralli_sinaptici_fotofase.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "tier": "T1",
+            "notes": "Cresta Fotofase"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      }
+    },
+    "corazze_ferro_magnetico": {
+      "id": "corazze_ferro_magnetico",
+      "label": "i18n:traits.corazze_ferro_magnetico.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Difesa/Magnetico",
+      "fattore_mantenimento_energetico": "i18n:traits.corazze_ferro_magnetico.fattore_mantenimento_energetico",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [
+        "ossidazione_rapida"
+      ],
+      "mutazione_indotta": "i18n:traits.corazze_ferro_magnetico.mutazione_indotta",
+      "uso_funzione": "i18n:traits.corazze_ferro_magnetico.uso_funzione",
+      "spinta_selettiva": "i18n:traits.corazze_ferro_magnetico.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T3"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      }
+    },
+    "emettitori_voidsong": {
+      "id": "emettitori_voidsong",
+      "label": "i18n:traits.emettitori_voidsong.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Supporto/Anomalia",
+      "fattore_mantenimento_energetico": "i18n:traits.emettitori_voidsong.fattore_mantenimento_energetico",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.emettitori_voidsong.mutazione_indotta",
+      "uso_funzione": "i18n:traits.emettitori_voidsong.uso_funzione",
+      "spinta_selettiva": "i18n:traits.emettitori_voidsong.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T3"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      }
+    },
+    "emolinfa_conducente": {
+      "id": "emolinfa_conducente",
+      "label": "i18n:traits.emolinfa_conducente.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Supporto/Energetico",
+      "fattore_mantenimento_energetico": "i18n:traits.emolinfa_conducente.fattore_mantenimento_energetico",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.emolinfa_conducente.mutazione_indotta",
+      "uso_funzione": "i18n:traits.emolinfa_conducente.uso_funzione",
+      "spinta_selettiva": "i18n:traits.emolinfa_conducente.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T3"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      }
+    },
+    "filamenti_echo": {
+      "id": "filamenti_echo",
+      "label": "i18n:traits.filamenti_echo.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Supporto/Risonanza",
+      "fattore_mantenimento_energetico": "i18n:traits.filamenti_echo.fattore_mantenimento_energetico",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.filamenti_echo.mutazione_indotta",
+      "uso_funzione": "i18n:traits.filamenti_echo.uso_funzione",
+      "spinta_selettiva": "i18n:traits.filamenti_echo.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T3"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      }
+    },
+    "filamenti_guidalampo": {
+      "id": "filamenti_guidalampo",
+      "label": "i18n:traits.filamenti_guidalampo.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Mobilità/Logistica",
+      "fattore_mantenimento_energetico": "i18n:traits.filamenti_guidalampo.fattore_mantenimento_energetico",
+      "tier": "T1",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.filamenti_guidalampo.mutazione_indotta",
+      "uso_funzione": "i18n:traits.filamenti_guidalampo.uso_funzione",
+      "spinta_selettiva": "i18n:traits.filamenti_guidalampo.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T1"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      }
+    },
+    "ghiandole_mnemoniche": {
+      "id": "ghiandole_mnemoniche",
+      "label": "i18n:traits.ghiandole_mnemoniche.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Supporto/Copia",
+      "fattore_mantenimento_energetico": "i18n:traits.ghiandole_mnemoniche.fattore_mantenimento_energetico",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.ghiandole_mnemoniche.mutazione_indotta",
+      "uso_funzione": "i18n:traits.ghiandole_mnemoniche.uso_funzione",
+      "spinta_selettiva": "i18n:traits.ghiandole_mnemoniche.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T2"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      }
+    },
+    "impulsi_bioluminescenti": {
+      "id": "impulsi_bioluminescenti",
+      "label": "i18n:traits.impulsi_bioluminescenti.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Offensivo/Illuminazione",
+      "fattore_mantenimento_energetico": "i18n:traits.impulsi_bioluminescenti.fattore_mantenimento_energetico",
+      "tier": "T1",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.impulsi_bioluminescenti.mutazione_indotta",
+      "uso_funzione": "i18n:traits.impulsi_bioluminescenti.uso_funzione",
+      "spinta_selettiva": "i18n:traits.impulsi_bioluminescenti.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T1"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      }
+    },
+    "lobi_risonanti_crepuscolo": {
+      "id": "lobi_risonanti_crepuscolo",
+      "label": "i18n:traits.lobi_risonanti_crepuscolo.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Risonanza/Crepuscolo",
+      "fattore_mantenimento_energetico": "i18n:traits.lobi_risonanti_crepuscolo.fattore_mantenimento_energetico",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.lobi_risonanti_crepuscolo.mutazione_indotta",
+      "uso_funzione": "i18n:traits.lobi_risonanti_crepuscolo.uso_funzione",
+      "spinta_selettiva": "i18n:traits.lobi_risonanti_crepuscolo.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T2"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      }
+    },
+    "membrane_fotoconvoglianti": {
+      "id": "membrane_fotoconvoglianti",
+      "label": "i18n:traits.membrane_fotoconvoglianti.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Difesa/Elettrico",
+      "fattore_mantenimento_energetico": "i18n:traits.membrane_fotoconvoglianti.fattore_mantenimento_energetico",
+      "tier": "T1",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [
+        "affaticamento_oculare"
+      ],
+      "mutazione_indotta": "i18n:traits.membrane_fotoconvoglianti.mutazione_indotta",
+      "uso_funzione": "i18n:traits.membrane_fotoconvoglianti.uso_funzione",
+      "spinta_selettiva": "i18n:traits.membrane_fotoconvoglianti.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T1"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      }
+    },
+    "nebbia_mnesica": {
+      "id": "nebbia_mnesica",
+      "label": "i18n:traits.nebbia_mnesica.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Controllo/Memoria",
+      "fattore_mantenimento_energetico": "i18n:traits.nebbia_mnesica.fattore_mantenimento_energetico",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [
+        "immunoscossa"
+      ],
+      "mutazione_indotta": "i18n:traits.nebbia_mnesica.mutazione_indotta",
+      "uso_funzione": "i18n:traits.nebbia_mnesica.uso_funzione",
+      "spinta_selettiva": "i18n:traits.nebbia_mnesica.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T2"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      }
+    },
+    "nodi_sinaptici_superficiali": {
+      "id": "nodi_sinaptici_superficiali",
+      "label": "i18n:traits.nodi_sinaptici_superficiali.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Supporto/Sensore",
+      "fattore_mantenimento_energetico": "i18n:traits.nodi_sinaptici_superficiali.fattore_mantenimento_energetico",
+      "tier": "T1",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.nodi_sinaptici_superficiali.mutazione_indotta",
+      "uso_funzione": "i18n:traits.nodi_sinaptici_superficiali.uso_funzione",
+      "spinta_selettiva": "i18n:traits.nodi_sinaptici_superficiali.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T1"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      }
+    },
+    "organi_metacronici": {
+      "id": "organi_metacronici",
+      "label": "i18n:traits.organi_metacronici.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Supporto/Sequenziamento",
+      "fattore_mantenimento_energetico": "i18n:traits.organi_metacronici.fattore_mantenimento_energetico",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.organi_metacronici.mutazione_indotta",
+      "uso_funzione": "i18n:traits.organi_metacronici.uso_funzione",
+      "spinta_selettiva": "i18n:traits.organi_metacronici.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T2"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      }
+    },
+    "pelle_piezo_satura": {
+      "id": "pelle_piezo_satura",
+      "label": "i18n:traits.pelle_piezo_satura.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Temporaneo/Difesa",
+      "fattore_mantenimento_energetico": "i18n:traits.pelle_piezo_satura.fattore_mantenimento_energetico",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.pelle_piezo_satura.mutazione_indotta",
+      "uso_funzione": "i18n:traits.pelle_piezo_satura.uso_funzione",
+      "spinta_selettiva": "i18n:traits.pelle_piezo_satura.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T3"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      }
+    },
+    "placca_diffusione_foschia": {
+      "id": "placca_diffusione_foschia",
+      "label": "i18n:traits.placca_diffusione_foschia.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Difesa/Foschia",
+      "fattore_mantenimento_energetico": "i18n:traits.placca_diffusione_foschia.fattore_mantenimento_energetico",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.placca_diffusione_foschia.mutazione_indotta",
+      "uso_funzione": "i18n:traits.placca_diffusione_foschia.uso_funzione",
+      "spinta_selettiva": "i18n:traits.placca_diffusione_foschia.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T2"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      }
+    },
+    "placche_pressioniche": {
+      "id": "placche_pressioniche",
+      "label": "i18n:traits.placche_pressioniche.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Difesa/Pressione",
+      "fattore_mantenimento_energetico": "i18n:traits.placche_pressioniche.fattore_mantenimento_energetico",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.placche_pressioniche.mutazione_indotta",
+      "uso_funzione": "i18n:traits.placche_pressioniche.uso_funzione",
+      "spinta_selettiva": "i18n:traits.placche_pressioniche.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T3"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      }
+    },
+    "riverbero_memetico": {
+      "id": "riverbero_memetico",
+      "label": "i18n:traits.riverbero_memetico.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Temporaneo/Memoria",
+      "fattore_mantenimento_energetico": "i18n:traits.riverbero_memetico.fattore_mantenimento_energetico",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.riverbero_memetico.mutazione_indotta",
+      "uso_funzione": "i18n:traits.riverbero_memetico.uso_funzione",
+      "spinta_selettiva": "i18n:traits.riverbero_memetico.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T3"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      }
+    },
+    "scintilla_sinaptica": {
+      "id": "scintilla_sinaptica",
+      "label": "i18n:traits.scintilla_sinaptica.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Temporaneo/Scarica",
+      "fattore_mantenimento_energetico": "i18n:traits.scintilla_sinaptica.fattore_mantenimento_energetico",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.scintilla_sinaptica.mutazione_indotta",
+      "uso_funzione": "i18n:traits.scintilla_sinaptica.uso_funzione",
+      "spinta_selettiva": "i18n:traits.scintilla_sinaptica.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T2"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      }
+    },
+    "secrezioni_antistatiche": {
+      "id": "secrezioni_antistatiche",
+      "label": "i18n:traits.secrezioni_antistatiche.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Difesa/Antistatico",
+      "fattore_mantenimento_energetico": "i18n:traits.secrezioni_antistatiche.fattore_mantenimento_energetico",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [
+        "corrosione_instabile"
+      ],
+      "mutazione_indotta": "i18n:traits.secrezioni_antistatiche.mutazione_indotta",
+      "uso_funzione": "i18n:traits.secrezioni_antistatiche.uso_funzione",
+      "spinta_selettiva": "i18n:traits.secrezioni_antistatiche.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T2"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      }
+    },
+    "sensori_planctonici": {
+      "id": "sensori_planctonici",
+      "label": "i18n:traits.sensori_planctonici.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Analisi/Sensori Planctonici",
+      "fattore_mantenimento_energetico": "i18n:traits.sensori_planctonici.fattore_mantenimento_energetico",
+      "tier": "T1",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.sensori_planctonici.mutazione_indotta",
+      "uso_funzione": "i18n:traits.sensori_planctonici.uso_funzione",
+      "spinta_selettiva": "i18n:traits.sensori_planctonici.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T1"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      }
+    },
+    "spicole_canalizzatrici": {
+      "id": "spicole_canalizzatrici",
+      "label": "i18n:traits.spicole_canalizzatrici.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Offensivo/Assorbimento",
+      "fattore_mantenimento_energetico": "i18n:traits.spicole_canalizzatrici.fattore_mantenimento_energetico",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.spicole_canalizzatrici.mutazione_indotta",
+      "uso_funzione": "i18n:traits.spicole_canalizzatrici.uso_funzione",
+      "spinta_selettiva": "i18n:traits.spicole_canalizzatrici.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T2"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      }
+    },
+    "squame_diffusori_ionici": {
+      "id": "squame_diffusori_ionici",
+      "label": "i18n:traits.squame_diffusori_ionici.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Difesa/Elettrico",
+      "fattore_mantenimento_energetico": "i18n:traits.squame_diffusori_ionici.fattore_mantenimento_energetico",
+      "tier": "T1",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [
+        "overcharge_cronico"
+      ],
+      "mutazione_indotta": "i18n:traits.squame_diffusori_ionici.mutazione_indotta",
+      "uso_funzione": "i18n:traits.squame_diffusori_ionici.uso_funzione",
+      "spinta_selettiva": "i18n:traits.squame_diffusori_ionici.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T1"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": false,
+        "has_usage_tags": true
+      }
+    },
+    "vortice_nera_flash": {
+      "id": "vortice_nera_flash",
+      "label": "i18n:traits.vortice_nera_flash.label",
+      "data_origin": "frattura_abissale_sinaptica",
+      "famiglia_tipologia": "Temporaneo/Traslazione",
+      "fattore_mantenimento_energetico": "i18n:traits.vortice_nera_flash.fattore_mantenimento_energetico",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [],
+      "conflitti": [
+        "stress_spike"
+      ],
+      "mutazione_indotta": "i18n:traits.vortice_nera_flash.mutazione_indotta",
+      "uso_funzione": "i18n:traits.vortice_nera_flash.uso_funzione",
+      "spinta_selettiva": "i18n:traits.vortice_nera_flash.spinta_selettiva",
+      "requisiti_ambientali": [
+        {
+          "condizioni": {
+            "biome_class": "frattura_abissale_sinaptica"
+          },
+          "fonte": "frattura_abissale_sinaptica",
+          "meta": {
+            "tier": "T3"
+          }
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_data_origin": true,
+        "has_species_link": true,
+        "has_usage_tags": true
+      }
+    },
+    "sacche_galleggianti_ascensoriali": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.sacche_galleggianti_ascensoriali.debolezza",
+      "famiglia_tipologia": "Idrostatico/Locomotorio",
+      "fattore_mantenimento_energetico": "Medio (Per il controllo della pressione)",
+      "id": "sacche_galleggianti_ascensoriali",
+      "label": "i18n:traits.sacche_galleggianti_ascensoriali.label",
+      "mutazione_indotta": "i18n:traits.sacche_galleggianti_ascensoriali.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_psionica_leggera"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Fase T1 in canopie sospese per calibrare pompaggio e feedback pressorio.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "orbita_psionica_inversa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Apex T3 su piattaforme orbitali a gravità invertita per ascese rapide.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "cartilagine_flessotermica_venti",
+        "respiro_a_scoppio",
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "locomotorio",
+        "core": "idrostatico"
+      },
+      "spinta_selettiva": "i18n:traits.sacche_galleggianti_ascensoriali.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.sacche_galleggianti_ascensoriali.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "canopia_psionica_leggera",
+        "orbita_psionica_inversa"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "ali_fono_risonanti": {
+      "id": "ali_fono_risonanti",
+      "label": "i18n:traits.ali_fono_risonanti.label",
+      "debolezza": "i18n:traits.ali_fono_risonanti.debolezza",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Locomotivo/Aereo",
+      "fattore_mantenimento_energetico": "Medio (risonanza ad ampio spettro)",
+      "tier": "T3",
+      "slot": [
+        "A",
+        "C"
+      ],
+      "sinergie": [
+        "cannone_sonico_a_raggio",
+        "campo_di_interferenza_acustica",
+        "cervello_a_bassa_latenza",
+        "occhi_cinetici"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.ali_fono_risonanti.mutazione_indotta",
+      "uso_funzione": "i18n:traits.ali_fono_risonanti.uso_funzione",
+      "spinta_selettiva": "i18n:traits.ali_fono_risonanti.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "dose_acustica",
+          "value": 100,
+          "unit": "dB·s"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Varia frequenza 1–40 kHz",
+        "scene_prompt": "Spettrogramma durante manovre"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "Le ali richiedono correnti asciutte e aperture per modulare fasci sonori a lungo raggio."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000178"
+        ]
+      },
+      "usage_tags": [
+        "scout",
+        "controller"
+      ],
+      "slot_profile": {
+        "core": "locomotivo",
+        "complementare": "sensoriale"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "banshee-risonante",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "psionic-canopy-scout",
+          "weight": 2
+        }
+      ],
+      "version": "1.0.0",
+      "versioning": {
+        "created": "2025-11-04",
+        "updated": "2025-11-23",
+        "author": "Master DD / GPT-5 Pro"
+      }
+    },
+    "articolazioni_a_leva_idraulica": {
+      "id": "articolazioni_a_leva_idraulica",
+      "label": "i18n:traits.articolazioni_a_leva_idraulica.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Locomotivo/Terrestre",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "zanne_idracida"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.articolazioni_a_leva_idraulica.mutazione_indotta",
+      "uso_funzione": "i18n:traits.articolazioni_a_leva_idraulica.uso_funzione",
+      "spinta_selettiva": "i18n:traits.articolazioni_a_leva_idraulica.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "salto_verticale",
+          "value": 3.5,
+          "unit": "m"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Supera ostacolo 3 m",
+        "scene_prompt": "Video-analisi del salto"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "Le leve idrauliche sfruttano appoggi rocciosi e la gravità terrestre per moltiplicare la forza senza slittare."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000228"
+        ]
+      },
+      "usage_tags": [
+        "scout"
+      ],
+      "slot_profile": {
+        "core": "locomotivo",
+        "complementare": "terrestre"
+      },
+      "species_affinity": [],
+      "version": "1.0.0",
+      "versioning": {
+        "created": "2025-11-04",
+        "updated": "2025-11-23",
+        "author": "Master DD / GPT-5 Pro"
+      },
+      "debolezza": "i18n:traits.articolazioni_a_leva_idraulica.debolezza"
+    },
+    "articolazioni_multiassiali": {
+      "id": "articolazioni_multiassiali",
+      "label": "i18n:traits.articolazioni_multiassiali.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Locomotivo/Terrestre",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "coda_prensile_muscolare"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.articolazioni_multiassiali.mutazione_indotta",
+      "uso_funzione": "i18n:traits.articolazioni_multiassiali.uso_funzione",
+      "spinta_selettiva": "i18n:traits.articolazioni_multiassiali.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "accelerazione_0_10",
+          "value": 4.2,
+          "unit": "m/s2"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Pivot a 180° in corridoio 1 m",
+        "scene_prompt": "Traccia cono di sterzata su terreno bagnato"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "Necessitano di terreno solido terrestre per distribuire il peso su più assi senza cedere."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000228"
+        ]
+      },
+      "usage_tags": [
+        "scout"
+      ],
+      "slot_profile": {
+        "core": "locomotivo",
+        "complementare": "terrestre"
+      },
+      "species_affinity": [],
+      "version": "1.0.0",
+      "versioning": {
+        "created": "2025-11-04",
+        "updated": "2025-11-23",
+        "author": "Master DD / GPT-5 Pro"
+      },
+      "debolezza": "i18n:traits.articolazioni_multiassiali.debolezza"
+    },
+    "cinghia_iper_ciliare": {
+      "id": "cinghia_iper_ciliare",
+      "label": "i18n:traits.cinghia_iper_ciliare.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Locomotivo/Terrestre",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "scheletro_pneumatico_a_maglie"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.cinghia_iper_ciliare.mutazione_indotta",
+      "uso_funzione": "i18n:traits.cinghia_iper_ciliare.uso_funzione",
+      "spinta_selettiva": "i18n:traits.cinghia_iper_ciliare.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "velocita_max",
+          "value": 1.2,
+          "unit": "m/s"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Percorre 100 m su ghiaia in < 90 s",
+        "scene_prompt": "Rileva tracce ciliate su impronte"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "Le micro-ciglie aderiscono a superfici rugose terrestri, convertendo attrito in trazione stabile."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000178"
+        ]
+      },
+      "usage_tags": [
+        "scout"
+      ],
+      "slot_profile": {
+        "core": "locomotivo",
+        "complementare": "terrestre"
+      },
+      "species_affinity": [],
+      "version": "1.0.0",
+      "versioning": {
+        "created": "2025-11-04",
+        "updated": "2025-11-23",
+        "author": "Master DD / GPT-5 Pro"
+      },
+      "debolezza": "i18n:traits.cinghia_iper_ciliare.debolezza"
+    },
+    "coda_prensile_muscolare": {
+      "id": "coda_prensile_muscolare",
+      "label": "i18n:traits.coda_prensile_muscolare.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Locomotivo/Arboricolo",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "articolazioni_multiassiali",
+        "rostro_linguale_prensile",
+        "pelage_idrorepellente_avanzato"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.coda_prensile_muscolare.mutazione_indotta",
+      "uso_funzione": "i18n:traits.coda_prensile_muscolare.uso_funzione",
+      "spinta_selettiva": "i18n:traits.coda_prensile_muscolare.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "salto_verticale",
+          "value": 1.8,
+          "unit": "m"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Sospensione 30 s su ramo standard",
+        "scene_prompt": "Cronometrare appensione su trave 6 cm"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "Si avvolge a rami e rocce terrestri per controbilanciare movimenti rapidi o pendolari."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000228"
+        ]
+      },
+      "usage_tags": [
+        "scout"
+      ],
+      "slot_profile": {
+        "core": "locomotivo",
+        "complementare": "arboricolo"
+      },
+      "species_affinity": [],
+      "version": "1.0.0",
+      "versioning": {
+        "created": "2025-11-04",
+        "updated": "2025-11-23",
+        "author": "Master DD / GPT-5 Pro"
+      },
+      "debolezza": "i18n:traits.coda_prensile_muscolare.debolezza"
+    },
+    "flusso_ameboide_controllato": {
+      "id": "flusso_ameboide_controllato",
+      "label": "i18n:traits.flusso_ameboide_controllato.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Locomotivo/Terrestre",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [
+        "membrana_plastica_continua"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.flusso_ameboide_controllato.mutazione_indotta",
+      "uso_funzione": "i18n:traits.flusso_ameboide_controllato.uso_funzione",
+      "spinta_selettiva": "i18n:traits.flusso_ameboide_controllato.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "raggio_di_volta",
+          "value": 0.1,
+          "unit": "m"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Curva stretta in tubo 20 cm",
+        "scene_prompt": "Traccia percorso in labirinto cilindrico"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T2",
+            "notes": "Il corpo vischioso scorre tra fessure e sedimenti compatti che si trovano nei biomi terrestri."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_00000873"
+        ]
+      },
+      "usage_tags": [
+        "scout"
+      ],
+      "slot_profile": {
+        "core": "locomotivo",
+        "complementare": "terrestre"
+      },
+      "species_affinity": [],
+      "version": "1.0.0",
+      "versioning": {
+        "created": "2025-11-04",
+        "updated": "2025-11-23",
+        "author": "Master DD / GPT-5 Pro"
+      },
+      "debolezza": "i18n:traits.flusso_ameboide_controllato.debolezza"
+    },
+    "locomozione_miriapode_ibrida": {
+      "id": "locomozione_miriapode_ibrida",
+      "label": "i18n:traits.locomozione_miriapode_ibrida.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Locomotivo/Terrestre",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "artiglio_cinetico_a_urto",
+        "ermafroditismo_cronologico",
+        "sistemi_chimio_sonici"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.locomozione_miriapode_ibrida.mutazione_indotta",
+      "uso_funzione": "i18n:traits.locomozione_miriapode_ibrida.uso_funzione",
+      "spinta_selettiva": "i18n:traits.locomozione_miriapode_ibrida.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "velocita_max",
+          "value": 2.5,
+          "unit": "m/s"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Scala parete 3 m in < 10 s",
+        "scene_prompt": "Cronometra arrampicata su pannello 80°"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "Molte zampe sfruttano appigli multipli su terreni granulari o rocciosi tipici degli ambienti terrestri."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000228"
+        ]
+      },
+      "usage_tags": [
+        "scout"
+      ],
+      "slot_profile": {
+        "core": "locomotivo",
+        "complementare": "terrestre"
+      },
+      "species_affinity": [],
+      "version": "1.0.0",
+      "versioning": {
+        "created": "2025-11-04",
+        "updated": "2025-11-23",
+        "author": "Master DD / GPT-5 Pro"
+      },
+      "debolezza": "i18n:traits.locomozione_miriapode_ibrida.debolezza"
+    },
+    "scheletro_idraulico_a_pistoni": {
+      "id": "scheletro_idraulico_a_pistoni",
+      "label": "i18n:traits.scheletro_idraulico_a_pistoni.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Locomotivo/Balistico",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T4",
+      "slot": [],
+      "sinergie": [
+        "rostro_emostatico_litico",
+        "ipertrofia_muscolare_massiva"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.scheletro_idraulico_a_pistoni.mutazione_indotta",
+      "uso_funzione": "i18n:traits.scheletro_idraulico_a_pistoni.uso_funzione",
+      "spinta_selettiva": "i18n:traits.scheletro_idraulico_a_pistoni.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "energia_impattiva",
+          "value": 1500,
+          "unit": "J"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Colpo tipo frusta su bersaglio a 2 m",
+        "scene_prompt": "Misura penetrazione in blocchi gel balistico"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T4",
+            "notes": "I pistoni scaricano la pressione su superfici dure terrestri, garantendo scatti rapidi e stabilità."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000178"
+        ]
+      },
+      "version": "2.0.1",
+      "versioning": {
+        "created": "2025-11-04",
+        "updated": "2025-11-23",
+        "author": "Master DD / GPT-5 Pro"
+      },
+      "usage_tags": [
+        "scout"
+      ],
+      "slot_profile": {
+        "core": "locomotivo",
+        "complementare": "balistico"
+      },
+      "species_affinity": [],
+      "debolezza": "i18n:traits.scheletro_idraulico_a_pistoni.debolezza"
+    },
+    "scheletro_pneumatico_a_maglie": {
+      "id": "scheletro_pneumatico_a_maglie",
+      "label": "i18n:traits.scheletro_pneumatico_a_maglie.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Locomotivo/Terrestre",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "cinghia_iper_ciliare",
+        "canto_infrasonico_tattico",
+        "rete_filtro_polmonare",
+        "siero_anti_gelo_naturale"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.scheletro_pneumatico_a_maglie.mutazione_indotta",
+      "uso_funzione": "i18n:traits.scheletro_pneumatico_a_maglie.uso_funzione",
+      "spinta_selettiva": "i18n:traits.scheletro_pneumatico_a_maglie.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "metabolic_rate",
+          "value": 20,
+          "unit": "W/kg"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Spostamento 5 km senza affaticamento eccessivo",
+        "scene_prompt": "Test su piastra di forza per massa apparente"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "Le maglie pneumatiche dissipano urti da cadute e balzi su terreno terrestre irregolare."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000178"
+        ]
+      },
+      "usage_tags": [
+        "scout"
+      ],
+      "slot_profile": {
+        "core": "locomotivo",
+        "complementare": "terrestre"
+      },
+      "species_affinity": [],
+      "version": "1.0.0",
+      "versioning": {
+        "created": "2025-11-04",
+        "updated": "2025-11-23",
+        "author": "Master DD / GPT-5 Pro"
+      },
+      "debolezza": "i18n:traits.scheletro_pneumatico_a_maglie.debolezza"
+    },
+    "scivolamento_magnetico": {
+      "id": "scivolamento_magnetico",
+      "label": "i18n:traits.scivolamento_magnetico.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Locomotivo/Terrestre",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "integumento_bipolare"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.scivolamento_magnetico.mutazione_indotta",
+      "uso_funzione": "i18n:traits.scivolamento_magnetico.uso_funzione",
+      "spinta_selettiva": "i18n:traits.scivolamento_magnetico.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "velocita_max",
+          "value": 4,
+          "unit": "m/s"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Percorre 50 m su sabbia in 20 s",
+        "scene_prompt": "Cronometra su tre substrati diversi"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "Sfrutta vene ferromagnetiche e superfici metalliche presenti in rovine terrestri per creare portanza."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_00000304"
+        ]
+      },
+      "usage_tags": [
+        "scout"
+      ],
+      "slot_profile": {
+        "core": "locomotivo",
+        "complementare": "terrestre"
+      },
+      "species_affinity": [],
+      "version": "1.0.0",
+      "versioning": {
+        "created": "2025-11-04",
+        "updated": "2025-11-23",
+        "author": "Master DD / GPT-5 Pro"
+      },
+      "debolezza": "i18n:traits.scivolamento_magnetico.debolezza"
+    },
+    "unghie_a_micro_adesione": {
+      "id": "unghie_a_micro_adesione",
+      "label": "i18n:traits.unghie_a_micro_adesione.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Locomotivo/Arboricolo",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [
+        "corna_psico_conduttive"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.unghie_a_micro_adesione.mutazione_indotta",
+      "uso_funzione": "i18n:traits.unghie_a_micro_adesione.uso_funzione",
+      "spinta_selettiva": "i18n:traits.unghie_a_micro_adesione.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "tasso_di_salita",
+          "value": 1.2,
+          "unit": "m/s"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Scala parete 10 m inclinata 75°",
+        "scene_prompt": "Cronometra salita su lastra liscia"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T2",
+            "notes": "Le micro-setole si ancorano a pareti e corteccia terrestre, migliorando arrampicata e trazione."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000178"
+        ]
+      },
+      "usage_tags": [
+        "scout"
+      ],
+      "slot_profile": {
+        "core": "locomotivo",
+        "complementare": "arboricolo"
+      },
+      "species_affinity": [],
+      "version": "1.0.0",
+      "versioning": {
+        "created": "2025-11-04",
+        "updated": "2025-11-23",
+        "author": "Master DD / GPT-5 Pro"
+      },
+      "debolezza": "i18n:traits.unghie_a_micro_adesione.debolezza"
+    },
+    "ali_ioniche": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.ali_ioniche.debolezza",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ali_ioniche",
+      "label": "i18n:traits.ali_ioniche.label",
+      "mutazione_indotta": "i18n:traits.ali_ioniche.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_ionica"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ali Ioniche ottimizza le operazioni locomotorio nelle condizioni di canopia ionica.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "spinta_selettiva": "i18n:traits.ali_ioniche.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.ali_ioniche.uso_funzione",
+      "usage_tags": [
+        "scout"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "canopia_ionica"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "antenne_wideband": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.antenne_wideband.debolezza",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "antenne_wideband",
+      "label": "i18n:traits.antenne_wideband.label",
+      "mutazione_indotta": "i18n:traits.antenne_wideband.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "steppe_algoritmiche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Antenne Wideband ottimizza le operazioni locomotorio nelle condizioni di steppe algoritmiche.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "spinta_selettiva": "i18n:traits.antenne_wideband.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.antenne_wideband.uso_funzione",
+      "usage_tags": [
+        "scout"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "steppe_algoritmiche"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "artigli_sette_vie": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.artigli_sette_vie.debolezza",
+      "famiglia_tipologia": "Locomotorio/Prensile",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "artigli_sette_vie",
+      "label": "i18n:traits.artigli_sette_vie.label",
+      "mutazione_indotta": "i18n:traits.artigli_sette_vie.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+            "tier": "T1"
           }
         }
       ],
@@ -1233,96 +4115,32 @@
         "complementare": "prensile",
         "core": "locomotorio"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "dune-stalker",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "magneto-ridge-hunter",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "balor-fission",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caverna-risonante-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "couatl-aurora",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "cryo-lynx",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "marilith-vault",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "otyugh-sentinella",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "resonant-claw-hunter",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Arrampicarsi su pareti rocciose o vegetazione densa.",
+      "spinta_selettiva": "i18n:traits.artigli_sette_vie.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.artigli_sette_vie.uso_funzione",
       "usage_tags": [
         "breaker",
         "scout"
       ],
-      "uso_funzione": "Afferrare superfici irregolari o oggetti multipli."
-    },
-    "artigli_sghiaccio_glaciale": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
+      "biome_tags": [
+        "caverna_risonante"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "artigli_sghiaccio_glaciale": {
       "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "In ambienti temperati i tessuti subiscono microfratture e richiedono continue riparazioni.",
+      "debolezza": "i18n:traits.artigli_sghiaccio_glaciale.debolezza",
       "famiglia_tipologia": "Locomotorio/Predatorio",
       "fattore_mantenimento_energetico": "Medio (Raffreddamento endogeno controllato)",
       "id": "artigli_sghiaccio_glaciale",
-      "label": "Artigli Sghiaccio Glaciale",
-      "mutazione_indotta": "Falangi rivestite da ghiaccio strutturale che si espande creando lame traslucide.",
+      "label": "i18n:traits.artigli_sghiaccio_glaciale.label",
+      "mutazione_indotta": "i18n:traits.artigli_sghiaccio_glaciale.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1332,7 +4150,8 @@
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Calotte di ghiaccio psionico che reagiscono alle vibrazioni e amplificano le lame criogeniche."
+            "notes": "Calotte di ghiaccio psionico che reagiscono alle vibrazioni e amplificano le lame criogeniche.",
+            "tier": "T2"
           }
         }
       ],
@@ -1360,223 +4179,32 @@
         "complementare": "predatorio",
         "core": "locomotorio"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "calotte-glaciali-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Cacciare su superfici gelate e pareti verticali di ghiaccio vivo.",
+      "spinta_selettiva": "i18n:traits.artigli_sghiaccio_glaciale.spinta_selettiva",
       "tier": "T2",
+      "uso_funzione": "i18n:traits.artigli_sghiaccio_glaciale.uso_funzione",
       "usage_tags": [
         "breaker",
         "scout"
       ],
-      "uso_funzione": "Scalza e immobilizza i bersagli congelandoli al contatto."
-    },
-    "artigli_vetrificati": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Risonanze errate possono generare microfratture.",
-      "famiglia_tipologia": "Strutturale/Adattivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "artigli_vetrificati",
-      "label": "Artigli Vetrificati",
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caldera_glaciale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Artigli Vetrificati ottimizza le operazioni strutturale nelle condizioni di caldera glaciale.",
-            "tier": "T1"
-          }
-        }
+      "biome_tags": [
+        "calotte_glaciali"
       ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "resilienza",
-        "core": "strutturale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caldera-glaciale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
-      "tier": "T1",
-      "usage_tags": [
-        "tank"
-      ],
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
-    },
-    "aura_scudo_radianza": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "pathfinder_dataset",
-      "debolezza": "Soffre saturazione se esposta a ombre gravitazionali o zone di antimagia.",
-      "famiglia_tipologia": "Supporto/Difesa",
-      "fattore_mantenimento_energetico": "Alto (Canalizzazione fotonica continua)",
-      "id": "aura_scudo_radianza",
-      "label": "Aura Scudo di Radianza",
-      "mutazione_indotta": "Innesta organi fotoplasmatici che diffondono uno scudo radiante sugli alleati vicini.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [
-            "flight"
-          ],
-          "condizioni": {
-            "biome_class": "rovine_planari"
-          },
-          "fonte": "pathfinder_import",
-          "meta": {
-            "expansion": "pathfinder_dataset",
-            "notes": "Richiede catalizzatori di luce stabili nelle rovine planari.",
-            "tier": "T3"
-          }
-        }
-      ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "difesa",
-        "core": "supporto"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "archon-solare",
-          "weight": 4
-        }
-      ],
-      "spinta_selettiva": "Proteggere gli hub di evacuazione durante tempeste di energia planare.",
-      "tier": "T3",
-      "usage_tags": [
-        "support",
-        "tank"
-      ],
-      "uso_funzione": "Proietta schermature luminose sincronizzate con i segnali tattici della squadra."
-    },
-    "baffi_mareomotori": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "baffi_mareomotori",
-      "label": "Baffi Mareomotori",
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "mangrovieto_cinetico"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Baffi Mareomotori ottimizza le operazioni sensoriale nelle condizioni di mangrovieto cinetico.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "mangrovieto-cinetico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout",
-        "support"
-      ],
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+      "data_origin": "controllo_psionico"
     },
     "barbigli_sensori_plasma": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
       "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "debolezza": "i18n:traits.barbigli_sensori_plasma.debolezza",
       "famiglia_tipologia": "Locomotorio/Mobilità",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "id": "barbigli_sensori_plasma",
-      "label": "Barbigli Sensori Plasma",
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "label": "i18n:traits.barbigli_sensori_plasma.label",
+      "mutazione_indotta": "i18n:traits.barbigli_sensori_plasma.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -1606,521 +4234,31 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "stratosfera-tempestosa-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "spinta_selettiva": "i18n:traits.barbigli_sensori_plasma.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.barbigli_sensori_plasma.uso_funzione",
       "usage_tags": [
         "scout"
       ],
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
-    },
-    "barriere_miasma_glaciale": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "barriere_miasma_glaciale",
-      "label": "Barriere Miasma Glaciale",
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caldera_glaciale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Barriere Miasma Glaciale ottimizza le operazioni difensivo nelle condizioni di caldera glaciale.",
-            "tier": "T1"
-          }
-        }
+      "biome_tags": [
+        "stratosfera_tempestosa"
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caldera-glaciale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "tier": "T1",
-      "usage_tags": [
-        "tank"
-      ],
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
-    },
-    "batteri_endosimbionti_chemio": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "batteri_endosimbionti_chemio",
-      "label": "Batteri Endosimbionti Chemio",
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "abisso_vulcanico"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Batteri Endosimbionti Chemio ottimizza le operazioni metabolico nelle condizioni di abisso vulcanico.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "abisso-vulcanico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "tier": "T1",
-      "usage_tags": [
-        "sustain"
-      ],
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
-    },
-    "batteri_termofili_endosimbiosi": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "batteri_termofili_endosimbiosi",
-      "label": "Batteri Termofili Endosimbiosi",
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "dorsale_termale_tropicale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Batteri Termofili Endosimbiosi ottimizza le operazioni supporto nelle condizioni di dorsale termale tropicale.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "dorsale-termale-tropicale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
-    },
-    "biochip_memoria": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "biochip_memoria",
-      "label": "Biochip Memoria",
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "steppe_algoritmiche"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Biochip Memoria ottimizza le operazioni offensivo nelle condizioni di steppe algoritmiche.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "steppe-algoritmiche-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "tier": "T1",
-      "usage_tags": [
-        "breaker"
-      ],
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
-    },
-    "biofilm_glow": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "biofilm_glow",
-      "label": "Biofilm Glow",
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "reef_luminescente"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Biofilm Glow ottimizza le operazioni strategia nelle condizioni di reef luminescente.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco",
-        "secrezione_rallentante_palmi",
-        "pathfinder",
-        "random"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "reef-luminescente-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
-    },
-    "biofilm_iperarido": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "biofilm_iperarido",
-      "label": "Biofilm Iperarido",
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "pianura_salina_iperarida"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Biofilm Iperarido ottimizza le operazioni simbiotico nelle condizioni di pianura salina iperarida.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "pianura-salina-iperarida-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
-    },
-    "branchie_dual_mode": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Risonanze errate possono generare microfratture.",
-      "famiglia_tipologia": "Strutturale/Adattivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "branchie_dual_mode",
-      "label": "Branchie Dual Mode",
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "laguna_bioreattiva"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Branchie Dual Mode ottimizza le operazioni strutturale nelle condizioni di laguna bioreattiva.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "resilienza",
-        "core": "strutturale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "laguna-bioreattiva-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
-      "tier": "T1",
-      "usage_tags": [
-        "tank"
-      ],
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
-    },
-    "branchie_eoliche": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "branchie_eoliche",
-      "label": "Branchie Eoliche",
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "stratosfera_tempestosa"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Branchie Eoliche ottimizza le operazioni sensoriale nelle condizioni di stratosfera tempestosa.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "stratosfera-tempestosa-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout",
-        "support"
-      ],
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+      "data_origin": "coverage_q4_2025"
     },
     "branchie_metalloidi": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
       "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "debolezza": "i18n:traits.branchie_metalloidi.debolezza",
       "famiglia_tipologia": "Locomotorio/Mobilità",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "id": "branchie_metalloidi",
-      "label": "Branchie Metalloidi",
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "label": "i18n:traits.branchie_metalloidi.label",
+      "mutazione_indotta": "i18n:traits.branchie_metalloidi.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2150,657 +4288,31 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "abisso-vulcanico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "spinta_selettiva": "i18n:traits.branchie_metalloidi.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.branchie_metalloidi.uso_funzione",
       "usage_tags": [
         "scout"
       ],
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
-    },
-    "branchie_microfiltri": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "branchie_microfiltri",
-      "label": "Branchie Microfiltri",
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "reef_luminescente"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Branchie Microfiltri ottimizza le operazioni difensivo nelle condizioni di reef luminescente.",
-            "tier": "T1"
-          }
-        }
+      "biome_tags": [
+        "abisso_vulcanico"
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "reef-luminescente-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "tier": "T1",
-      "usage_tags": [
-        "tank"
-      ],
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
-    },
-    "branchie_osmotiche_salmastra": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Richiede accesso costante ad acqua salmastra; ambienti d'acqua dolce provocano stress ionico.",
-      "famiglia_tipologia": "Respiratorio/Osmoregolazione",
-      "fattore_mantenimento_energetico": "Medio (Pompe ioniche attive)",
-      "id": "branchie_osmotiche_salmastra",
-      "label": "Branchie Osmotiche Salmastre",
-      "mutazione_indotta": "Lamelle branchiali multilivello con valvole che separano sali e tossine.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "delta_salmastri"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Estuari psionici dove l'acqua dolce e marina si mescolano creando gradienti forti."
-          }
-        }
-      ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "scheletro_idro_regolante"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [
-          "boardgame:Evolution/Symbiosis",
-          "boardgame:DominantSpecies/Adaptation",
-          "hud:EstuarioPsi"
-        ],
-        "combo_totale": 3,
-        "forme": [
-          "Forma:Amfibio_Oracolare"
-        ],
-        "tabelle_random": [
-          "tabella:osmosi_psionica"
-        ]
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "osmoregolazione",
-        "core": "respiratorio"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "delta-salmastri-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Colonizzare mangrovie psioniche e barriere di estuario soggette a maree estreme.",
-      "tier": "T2",
-      "usage_tags": [
-        "sustain"
-      ],
-      "uso_funzione": "Bilancia sali e tossine sfruttando microvalvole controllate psionicamente."
-    },
-    "branchie_solfatiche": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "branchie_solfatiche",
-      "label": "Branchie Solfatiche",
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caldera_glaciale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Branchie Solfatiche ottimizza le operazioni metabolico nelle condizioni di caldera glaciale.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caldera-glaciale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "tier": "T1",
-      "usage_tags": [
-        "sustain"
-      ],
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
-    },
-    "branchie_turbina": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "branchie_turbina",
-      "label": "Branchie Turbina",
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "dorsale_termale_tropicale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Branchie Turbina ottimizza le operazioni supporto nelle condizioni di dorsale termale tropicale.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "dorsale-termale-tropicale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
-    },
-    "bulbi_radici_permafrost": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Disgeli improvvisi trasformano i bulbi in masse gelatinose che rallentano i movimenti.",
-      "famiglia_tipologia": "Simbiotico/Nutrizione",
-      "fattore_mantenimento_energetico": "Medio (Accumulo e rilascio lento di nutrienti)",
-      "id": "bulbi_radici_permafrost",
-      "label": "Bulbi Radici del Permafrost",
-      "mutazione_indotta": "Bulbi radicali multipli che immagazzinano energia nelle stagioni fredde per rilasciarla durante le missioni.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "permafrost_psionico"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Suoli congelati con vene energetiche che alimentano radici coscienti."
-          }
-        }
-      ],
-      "sinergie": [
-        "chioma_parassita_canopica",
-        "nodi_micorrizici_oracolari",
-        "vello_condensatore_nebbie"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [
-          "boardgame:DominantSpecies/Fertility",
-          "boardgame:Evolution/Cooperation",
-          "hud:RootMesh_Psi"
-        ],
-        "combo_totale": 3,
-        "forme": [
-          "Forma:Archivio_Subglaciale",
-          "HUD:Radice_Proxy"
-        ],
-        "tabelle_random": [
-          "tabella:riserva_empatica"
-        ]
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "nutrizione",
-        "core": "simbiotico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "permafrost-psionico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Sostenere campagne lunghe in climi artici con riserve nutrizionali concentrate.",
-      "tier": "T2",
-      "usage_tags": [
-        "support",
-        "sustain"
-      ],
-      "uso_funzione": "Rilascia energia e calore agli alleati radicati nella stessa rete subglaciale."
-    },
-    "camere_anticorrosione": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "camere_anticorrosione",
-      "label": "Camere Anticorrosione",
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "foresta_acida"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Camere Anticorrosione ottimizza le operazioni offensivo nelle condizioni di foresta acida.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "foresta-acida-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "tier": "T1",
-      "usage_tags": [
-        "breaker"
-      ],
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
-    },
-    "camere_mirage": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "camere_mirage",
-      "label": "Camere Mirage",
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "pianura_salina_iperarida"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Camere Mirage ottimizza le operazioni strategia nelle condizioni di pianura salina iperarida.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco",
-        "pathfinder",
-        "random"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "pianura-salina-iperarida-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
-    },
-    "camere_nutrienti_vent": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "camere_nutrienti_vent",
-      "label": "Camere Nutrienti Vent",
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "dorsale_termale_tropicale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Camere Nutrienti Vent ottimizza le operazioni simbiotico nelle condizioni di dorsale termale tropicale.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "dorsale-termale-tropicale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
-    },
-    "capillari_criogenici": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Risonanze errate possono generare microfratture.",
-      "famiglia_tipologia": "Strutturale/Adattivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "capillari_criogenici",
-      "label": "Capillari Criogenici",
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caldera_glaciale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Capillari Criogenici ottimizza le operazioni strutturale nelle condizioni di caldera glaciale.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "resilienza",
-        "core": "strutturale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caldera-glaciale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
-      "tier": "T1",
-      "usage_tags": [
-        "tank"
-      ],
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
-    },
-    "capillari_fluoridici": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "capillari_fluoridici",
-      "label": "Capillari Fluoridici",
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "foresta_acida"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Capillari Fluoridici ottimizza le operazioni sensoriale nelle condizioni di foresta acida.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "foresta-acida-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout",
-        "support"
-      ],
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
+      "data_origin": "coverage_q4_2025"
     },
     "capillari_fotovoltaici": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
       "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
+      "debolezza": "i18n:traits.capillari_fotovoltaici.debolezza",
       "famiglia_tipologia": "Locomotorio/Mobilità",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "id": "capillari_fotovoltaici",
-      "label": "Capillari Fotovoltaici",
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "label": "i18n:traits.capillari_fotovoltaici.label",
+      "mutazione_indotta": "i18n:traits.capillari_fotovoltaici.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2830,54 +4342,115 @@
         "complementare": "mobilita",
         "core": "locomotorio"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "canopia-ionica-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "spinta_selettiva": "i18n:traits.capillari_fotovoltaici.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.capillari_fotovoltaici.uso_funzione",
       "usage_tags": [
         "scout"
       ],
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
-    },
-    "capsule_paracadute": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "capsule_paracadute",
-      "label": "Capsule Paracadute",
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "biome_tags": [
+        "canopia_ionica"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "cartilagine_flessotermica_venti": {
+      "conflitti": [
+        "scheletro_idro_regolante"
+      ],
+      "debolezza": "i18n:traits.cartilagine_flessotermica_venti.debolezza",
+      "famiglia_tipologia": "Locomotorio/Adattivo",
+      "fattore_mantenimento_energetico": "Medio (Richiede frequenti riallineamenti fibrosi)",
+      "id": "cartilagine_flessotermica_venti",
+      "label": "i18n:traits.cartilagine_flessotermica_venti.label",
+      "mutazione_indotta": "i18n:traits.cartilagine_flessotermica_venti.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "stratosfera_tempestosa"
+            "biome_class": "gole_ventose"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Canyon sospesi dove venti caldi e freddi si alternano in pattern ciclici.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "sinergie": [
+        "artigli_sghiaccio_glaciale",
+        "carapace_fase_variabile",
+        "sacche_galleggianti_ascensoriali",
+        "zoccoli_risonanti_steppe"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "boardgame:DominantSpecies/Wind",
+          "boardgame:Evolution/Flight",
+          "hud:VentSplice_Halo"
+        ],
+        "combo_totale": 3,
+        "forme": [
+          "Forma:Planatore_Psionico"
+        ],
+        "tabelle_random": [
+          "tabella:assetto_eolico"
+        ]
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "adattivo",
+        "core": "locomotorio"
+      },
+      "spinta_selettiva": "i18n:traits.cartilagine_flessotermica_venti.spinta_selettiva",
+      "tier": "T2",
+      "uso_funzione": "i18n:traits.cartilagine_flessotermica_venti.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "gole_ventose"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "chemiorecettori_bromuro": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.chemiorecettori_bromuro.debolezza",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "chemiorecettori_bromuro",
+      "label": "i18n:traits.chemiorecettori_bromuro.label",
+      "mutazione_indotta": "i18n:traits.chemiorecettori_bromuro.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianura_salina_iperarida"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "coverage_q4_2025",
-            "notes": "Capsule Paracadute ottimizza le operazioni difensivo nelle condizioni di stratosfera tempestosa.",
+            "notes": "Chemiorecettori Bromuro ottimizza le operazioni locomotorio nelle condizioni di pianura salina iperarida.",
             "tier": "T1"
           }
         }
       ],
       "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
       ],
       "sinergie_pi": {
         "co_occorrenze": [],
@@ -2887,40 +4460,7707 @@
       },
       "slot": [],
       "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
+        "complementare": "mobilita",
+        "core": "locomotorio"
       },
+      "spinta_selettiva": "i18n:traits.chemiorecettori_bromuro.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.chemiorecettori_bromuro.uso_funzione",
+      "usage_tags": [
+        "scout"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "pianura_salina_iperarida"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "coda_contrappeso": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.coda_contrappeso.debolezza",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "coda_contrappeso",
+      "label": "i18n:traits.coda_contrappeso.label",
+      "mutazione_indotta": "i18n:traits.coda_contrappeso.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "mangrovieto_cinetico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Coda Contrappeso ottimizza le operazioni locomotorio nelle condizioni di mangrovieto cinetico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "spinta_selettiva": "i18n:traits.coda_contrappeso.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.coda_contrappeso.uso_funzione",
+      "usage_tags": [
+        "scout"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "mangrovieto_cinetico"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "coda_frusta_cinetica": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.coda_frusta_cinetica.debolezza",
+      "famiglia_tipologia": "Locomotorio/Difensivo",
+      "fattore_mantenimento_energetico": "Medio (Mantenimento dell'energia accumulata)",
+      "id": "coda_frusta_cinetica",
+      "label": "i18n:traits.coda_frusta_cinetica.label",
+      "mutazione_indotta": "i18n:traits.coda_frusta_cinetica.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Corridore T2 per intercettare campi magnetici psionici sulle dorsali.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "orbita_psionica_inversa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Variante T3 calibrata alle camere di gravità invertita e ai flussi orbitali.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "ali_ioniche",
+        "antenne_flusso_mareale",
+        "antenne_wideband",
+        "artigli_induzione",
+        "artigli_sette_vie",
+        "barbigli_sensori_plasma",
+        "biochip_memoria",
+        "branchie_metalloidi",
+        "camere_anticorrosione",
+        "capillari_fotovoltaici",
+        "cartilagini_biofibre",
+        "chemiorecettori_bromuro",
+        "circolazione_supercritica",
+        "coda_contrappeso",
+        "coda_stabilizzatrice_vortex",
+        "cuscinetti_elettrostatici",
+        "denti_chelatanti",
+        "enzimi_antifase_termica",
+        "enzimi_metanoossidanti",
+        "filamenti_termoconduzione",
+        "foliaggio_spugna",
+        "ghiandole_fango_calde",
+        "ghiandole_iodoattive",
+        "ghiandole_ventosa",
+        "gusci_magnesio",
+        "linfa_tampone",
+        "mantelli_geotermici",
+        "mucose_aderenza_sonica"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "difensivo",
+        "core": "locomotorio"
+      },
+      "spinta_selettiva": "i18n:traits.coda_frusta_cinetica.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.coda_frusta_cinetica.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "falde_magnetiche_psioniche",
+        "orbita_psionica_inversa"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "cuscinetti_elettrostatici": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.cuscinetti_elettrostatici.debolezza",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "cuscinetti_elettrostatici",
+      "label": "i18n:traits.cuscinetti_elettrostatici.label",
+      "mutazione_indotta": "i18n:traits.cuscinetti_elettrostatici.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianura_salina_iperarida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Cuscinetti Elettrostatici ottimizza le operazioni locomotorio nelle condizioni di pianura salina iperarida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "spinta_selettiva": "i18n:traits.cuscinetti_elettrostatici.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.cuscinetti_elettrostatici.uso_funzione",
+      "usage_tags": [
+        "scout"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "pianura_salina_iperarida"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "enzimi_antifase_termica": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.enzimi_antifase_termica.debolezza",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "enzimi_antifase_termica",
+      "label": "i18n:traits.enzimi_antifase_termica.label",
+      "mutazione_indotta": "i18n:traits.enzimi_antifase_termica.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Enzimi Antifase Termica ottimizza le operazioni locomotorio nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "spinta_selettiva": "i18n:traits.enzimi_antifase_termica.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.enzimi_antifase_termica.uso_funzione",
+      "usage_tags": [
+        "scout"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caldera_glaciale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "filamenti_termoconduzione": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.filamenti_termoconduzione.debolezza",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "filamenti_termoconduzione",
+      "label": "i18n:traits.filamenti_termoconduzione.label",
+      "mutazione_indotta": "i18n:traits.filamenti_termoconduzione.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dorsale_termale_tropicale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Filamenti Termoconduzione ottimizza le operazioni locomotorio nelle condizioni di dorsale termale tropicale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "spinta_selettiva": "i18n:traits.filamenti_termoconduzione.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.filamenti_termoconduzione.uso_funzione",
+      "usage_tags": [
+        "scout"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "dorsale_termale_tropicale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "ghiandole_fango_calde": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.ghiandole_fango_calde.debolezza",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_fango_calde",
+      "label": "i18n:traits.ghiandole_fango_calde.label",
+      "mutazione_indotta": "i18n:traits.ghiandole_fango_calde.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_vulcanico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Fango Calde ottimizza le operazioni locomotorio nelle condizioni di abisso vulcanico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "spinta_selettiva": "i18n:traits.ghiandole_fango_calde.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.ghiandole_fango_calde.uso_funzione",
+      "usage_tags": [
+        "scout"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "abisso_vulcanico"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "ghiandole_ventosa": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.ghiandole_ventosa.debolezza",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_ventosa",
+      "label": "i18n:traits.ghiandole_ventosa.label",
+      "mutazione_indotta": "i18n:traits.ghiandole_ventosa.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Ventosa ottimizza le operazioni locomotorio nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "spinta_selettiva": "i18n:traits.ghiandole_ventosa.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.ghiandole_ventosa.uso_funzione",
+      "usage_tags": [
+        "scout"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caldera_glaciale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "linfa_tampone": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.linfa_tampone.debolezza",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "linfa_tampone",
+      "label": "i18n:traits.linfa_tampone.label",
+      "mutazione_indotta": "i18n:traits.linfa_tampone.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_acida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Linfa Tampone ottimizza le operazioni locomotorio nelle condizioni di foresta acida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "spinta_selettiva": "i18n:traits.linfa_tampone.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.linfa_tampone.uso_funzione",
+      "usage_tags": [
+        "scout"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "foresta_acida"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "mucose_aderenza_sonica": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.mucose_aderenza_sonica.debolezza",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "id": "mucose_aderenza_sonica",
+      "label": "i18n:traits.mucose_aderenza_sonica.label",
+      "mutazione_indotta": "i18n:traits.mucose_aderenza_sonica.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Mucose Aderenza Sonica ottimizza le operazioni locomotorio nelle condizioni di caverna risonante.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "mobilita",
+        "core": "locomotorio"
+      },
+      "spinta_selettiva": "i18n:traits.mucose_aderenza_sonica.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.mucose_aderenza_sonica.uso_funzione",
+      "usage_tags": [
+        "scout"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caverna_risonante"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "zampe_a_molla": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.zampe_a_molla.debolezza",
+      "famiglia_tipologia": "Mobilità/Cinetico",
+      "fattore_mantenimento_energetico": "Basso (Carica elastica a turni alterni)",
+      "id": "zampe_a_molla",
+      "label": "i18n:traits.zampe_a_molla.label",
+      "mutazione_indotta": "i18n:traits.zampe_a_molla.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_miceliale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "tier": "T1",
+            "notes": "Le molle organiche comprimono il tappeto miceliale elastico delle foreste fungine per salti controllati."
+          }
+        }
+      ],
+      "sinergie": [
+        "ali_ioniche",
+        "antenne_wideband",
+        "artigli_sghiaccio_glaciale",
+        "barbigli_sensori_plasma",
+        "branchie_metalloidi",
+        "capillari_fotovoltaici",
+        "chemiorecettori_bromuro",
+        "coda_contrappeso",
+        "cuscinetti_elettrostatici",
+        "enzimi_antifase_termica",
+        "filamenti_termoconduzione",
+        "ghiandole_fango_calde",
+        "ghiandole_ventosa",
+        "linfa_tampone",
+        "mucose_aderenza_sonica"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "cap_pt",
+          "guardia_situazionale",
+          "job_ability:skirmisher/dash_cut"
+        ],
+        "combo_totale": 2,
+        "forme": [
+          "ESTP",
+          "ISFP"
+        ],
+        "tabelle_random": []
+      },
+      "slot": [
+        "A",
+        "B"
+      ],
+      "slot_profile": {
+        "complementare": "propulsione",
+        "core": "locomotorio"
+      },
+      "spinta_selettiva": "i18n:traits.zampe_a_molla.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.zampe_a_molla.uso_funzione",
+      "usage_tags": [
+        "scout"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "foresta_miceliale"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "zoccoli_risonanti_steppe": {
+      "conflitti": [
+        "zampe_a_molla"
+      ],
+      "debolezza": "i18n:traits.zoccoli_risonanti_steppe.debolezza",
+      "famiglia_tipologia": "Locomotorio/Supporto",
+      "fattore_mantenimento_energetico": "Basso (Vibrazione passiva del suolo)",
+      "id": "zoccoli_risonanti_steppe",
+      "label": "i18n:traits.zoccoli_risonanti_steppe.label",
+      "mutazione_indotta": "i18n:traits.zoccoli_risonanti_steppe.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "steppe_risonanti"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Praterie ventose dove il suolo amplifica vibrazioni utili alla comunicazione di branco.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "cartilagine_flessotermica_venti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "supporto",
+        "core": "locomotorio"
+      },
+      "spinta_selettiva": "i18n:traits.zoccoli_risonanti_steppe.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.zoccoli_risonanti_steppe.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "steppe_risonanti"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "rostro_linguale_prensile": {
+      "id": "rostro_linguale_prensile",
+      "label": "i18n:traits.rostro_linguale_prensile.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Manipolativo/Alimentare",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "coda_prensile_muscolare"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.rostro_linguale_prensile.mutazione_indotta",
+      "uso_funzione": "i18n:traits.rostro_linguale_prensile.uso_funzione",
+      "spinta_selettiva": "i18n:traits.rostro_linguale_prensile.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "lunghezza_estensione",
+          "value": 2,
+          "unit": "m"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Estrae oggetto a 2 m in 3 s",
+        "scene_prompt": "Recupero uovo da cavità senza frattura"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "La lingua prensile si aggancia a crepe e tronchi terrestri per estrarre prede e resina."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000228"
+        ]
+      },
+      "slot_profile": {
+        "core": "manipolativo",
+        "complementare": "alimentare"
+      },
+      "usage_tags": [
+        "controller"
+      ],
+      "debolezza": "i18n:traits.rostro_linguale_prensile.debolezza"
+    },
+    "antenne_dustsense": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.antenne_dustsense.debolezza",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "antenne_dustsense",
+      "label": "i18n:traits.antenne_dustsense.label",
+      "mutazione_indotta": "i18n:traits.antenne_dustsense.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianura_salina_iperarida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Antenne Dustsense ottimizza le operazioni metabolico nelle condizioni di pianura salina iperarida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "spinta_selettiva": "i18n:traits.antenne_dustsense.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.antenne_dustsense.uso_funzione",
+      "usage_tags": [
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "pianura_salina_iperarida"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "appendici_thermotattiche": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.appendici_thermotattiche.debolezza",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "appendici_thermotattiche",
+      "label": "i18n:traits.appendici_thermotattiche.label",
+      "mutazione_indotta": "i18n:traits.appendici_thermotattiche.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_vulcanico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Appendici Thermotattiche ottimizza le operazioni metabolico nelle condizioni di abisso vulcanico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "spinta_selettiva": "i18n:traits.appendici_thermotattiche.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.appendici_thermotattiche.uso_funzione",
+      "usage_tags": [
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "abisso_vulcanico"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "batteri_endosimbionti_chemio": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.batteri_endosimbionti_chemio.debolezza",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "batteri_endosimbionti_chemio",
+      "label": "i18n:traits.batteri_endosimbionti_chemio.label",
+      "mutazione_indotta": "i18n:traits.batteri_endosimbionti_chemio.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_vulcanico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Batteri Endosimbionti Chemio ottimizza le operazioni metabolico nelle condizioni di abisso vulcanico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "spinta_selettiva": "i18n:traits.batteri_endosimbionti_chemio.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.batteri_endosimbionti_chemio.uso_funzione",
+      "usage_tags": [
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "abisso_vulcanico"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "branchie_solfatiche": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.branchie_solfatiche.debolezza",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "branchie_solfatiche",
+      "label": "i18n:traits.branchie_solfatiche.label",
+      "mutazione_indotta": "i18n:traits.branchie_solfatiche.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Branchie Solfatiche ottimizza le operazioni metabolico nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "spinta_selettiva": "i18n:traits.branchie_solfatiche.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.branchie_solfatiche.uso_funzione",
+      "usage_tags": [
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caldera_glaciale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "carapace_segmenti_logici": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.carapace_segmenti_logici.debolezza",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "carapace_segmenti_logici",
+      "label": "i18n:traits.carapace_segmenti_logici.label",
+      "mutazione_indotta": "i18n:traits.carapace_segmenti_logici.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "steppe_algoritmiche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Carapace Segmenti Logici ottimizza le operazioni metabolico nelle condizioni di steppe algoritmiche.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "spinta_selettiva": "i18n:traits.carapace_segmenti_logici.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.carapace_segmenti_logici.uso_funzione",
+      "usage_tags": [
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "steppe_algoritmiche"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "circolazione_bifasica_palude": {
+      "conflitti": [
+        "sangue_piroforico"
+      ],
+      "debolezza": "i18n:traits.circolazione_bifasica_palude.debolezza",
+      "famiglia_tipologia": "Metabolico/Resilienza",
+      "fattore_mantenimento_energetico": "Medio (Doppio circuito emolinfa/linfa)",
+      "id": "circolazione_bifasica_palude",
+      "label": "i18n:traits.circolazione_bifasica_palude.label",
+      "mutazione_indotta": "i18n:traits.circolazione_bifasica_palude.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "paludi_gas_luminescenti"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Paludi bioluminescenti piene di gas nervini e batteri simbionti.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "metabolico"
+      },
+      "spinta_selettiva": "i18n:traits.circolazione_bifasica_palude.spinta_selettiva",
+      "tier": "T2",
+      "uso_funzione": "i18n:traits.circolazione_bifasica_palude.uso_funzione",
+      "usage_tags": [
+        "sustain",
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "paludi_gas_luminescenti"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "circolazione_cooling_loop": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.circolazione_cooling_loop.debolezza",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "circolazione_cooling_loop",
+      "label": "i18n:traits.circolazione_cooling_loop.label",
+      "mutazione_indotta": "i18n:traits.circolazione_cooling_loop.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "steppe_algoritmiche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Circolazione Cooling Loop ottimizza le operazioni metabolico nelle condizioni di steppe algoritmiche.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "spinta_selettiva": "i18n:traits.circolazione_cooling_loop.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.circolazione_cooling_loop.uso_funzione",
+      "usage_tags": [
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "steppe_algoritmiche"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "coda_stabilizzatrice_filo": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.coda_stabilizzatrice_filo.debolezza",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "coda_stabilizzatrice_filo",
+      "label": "i18n:traits.coda_stabilizzatrice_filo.label",
+      "mutazione_indotta": "i18n:traits.coda_stabilizzatrice_filo.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_ionica"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Coda Stabilizzatrice Filo ottimizza le operazioni metabolico nelle condizioni di canopia ionica.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "spinta_selettiva": "i18n:traits.coda_stabilizzatrice_filo.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.coda_stabilizzatrice_filo.uso_funzione",
+      "usage_tags": [
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "canopia_ionica"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "criostasi_adattiva": {
+      "conflitti": [
+        "sangue_piroforico",
+        "sacche_galleggianti_ascensoriali"
+      ],
+      "debolezza": "i18n:traits.criostasi_adattiva.debolezza",
+      "famiglia_tipologia": "Metabolico/Difensivo",
+      "fattore_mantenimento_energetico": "Alto (Fase di risveglio/inizio) / Basso (Fase Criostasi).",
+      "id": "criostasi_adattiva",
+      "label": "i18n:traits.criostasi_adattiva.label",
+      "mutazione_indotta": "i18n:traits.criostasi_adattiva.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_psionica_leggera"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Fase T1 controllata: micro-canopie sospese usate per cicli brevi di ibernazione.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "orbita_psionica_inversa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Variante apex T3 in camere orbitali a gravità invertita per stasi prolungate.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "cavita_risonanti_tundra"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "difensivo",
+        "core": "metabolico"
+      },
+      "spinta_selettiva": "i18n:traits.criostasi_adattiva.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.criostasi_adattiva.uso_funzione",
+      "usage_tags": [
+        "sustain",
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "canopia_psionica_leggera",
+        "orbita_psionica_inversa"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "cuticole_cerose": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.cuticole_cerose.debolezza",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "cuticole_cerose",
+      "label": "i18n:traits.cuticole_cerose.label",
+      "mutazione_indotta": "i18n:traits.cuticole_cerose.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_miceliale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "tier": "T1",
+            "notes": "Le cuticole sigillano la pelle contro umidità e spore dense tipiche delle foreste miceliali."
+          }
+        }
+      ],
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "spinta_selettiva": "i18n:traits.cuticole_cerose.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.cuticole_cerose.uso_funzione",
+      "usage_tags": [
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "foresta_miceliale"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "enzimi_chelanti": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.enzimi_chelanti.debolezza",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "enzimi_chelanti",
+      "label": "i18n:traits.enzimi_chelanti.label",
+      "mutazione_indotta": "i18n:traits.enzimi_chelanti.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_miceliale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "tier": "T1",
+            "notes": "Gli enzimi legano metalli disciolti nei substrati umidi dei biomi miceliali, evitando accumuli tossici."
+          }
+        }
+      ],
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "spinta_selettiva": "i18n:traits.enzimi_chelanti.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.enzimi_chelanti.uso_funzione",
+      "usage_tags": [
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "foresta_miceliale"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "flagelli_ancoranti": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.flagelli_ancoranti.debolezza",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "flagelli_ancoranti",
+      "label": "i18n:traits.flagelli_ancoranti.label",
+      "mutazione_indotta": "i18n:traits.flagelli_ancoranti.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "laguna_bioreattiva"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Flagelli Ancoranti ottimizza le operazioni metabolico nelle condizioni di laguna bioreattiva.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "spinta_selettiva": "i18n:traits.flagelli_ancoranti.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.flagelli_ancoranti.uso_funzione",
+      "usage_tags": [
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "laguna_bioreattiva"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "ghiandole_grafene": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.ghiandole_grafene.debolezza",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_grafene",
+      "label": "i18n:traits.ghiandole_grafene.label",
+      "mutazione_indotta": "i18n:traits.ghiandole_grafene.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "steppe_algoritmiche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Grafene ottimizza le operazioni metabolico nelle condizioni di steppe algoritmiche.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "spinta_selettiva": "i18n:traits.ghiandole_grafene.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.ghiandole_grafene.uso_funzione",
+      "usage_tags": [
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "steppe_algoritmiche"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "grassi_termici": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.grassi_termici.debolezza",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "grassi_termici",
+      "label": "i18n:traits.grassi_termici.label",
+      "mutazione_indotta": "i18n:traits.grassi_termici.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_miceliale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "tier": "T1",
+            "notes": "Le riserve termiche isolano dal freddo umido del sottobosco miceliale e rilasciano calore graduale."
+          }
+        }
+      ],
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "spinta_selettiva": "i18n:traits.grassi_termici.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.grassi_termici.uso_funzione",
+      "usage_tags": [
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "foresta_miceliale"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "luminescenza_aurorale": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.luminescenza_aurorale.debolezza",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "luminescenza_aurorale",
+      "label": "i18n:traits.luminescenza_aurorale.label",
+      "mutazione_indotta": "i18n:traits.luminescenza_aurorale.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Luminescenza Aurorale ottimizza le operazioni metabolico nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "energia",
+        "core": "metabolico"
+      },
+      "spinta_selettiva": "i18n:traits.luminescenza_aurorale.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.luminescenza_aurorale.uso_funzione",
+      "usage_tags": [
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caldera_glaciale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "sonno_emisferico_alternato": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.sonno_emisferico_alternato.debolezza",
+      "famiglia_tipologia": "Nervoso/Omeostatico",
+      "fattore_mantenimento_energetico": "Medio (Mantenimento attivo di metà cervello)",
+      "id": "sonno_emisferico_alternato",
+      "label": "i18n:traits.sonno_emisferico_alternato.label",
+      "mutazione_indotta": "i18n:traits.sonno_emisferico_alternato.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "artigli_sghiaccio_glaciale",
+        "occhi_infrarosso_composti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "omeostatico",
+        "core": "nervoso"
+      },
+      "spinta_selettiva": "i18n:traits.sonno_emisferico_alternato.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.sonno_emisferico_alternato.uso_funzione",
+      "usage_tags": [
+        "controller",
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caverna_risonante"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "antenne_flusso_mareale": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.antenne_flusso_mareale.debolezza",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "antenne_flusso_mareale",
+      "label": "i18n:traits.antenne_flusso_mareale.label",
+      "mutazione_indotta": "i18n:traits.antenne_flusso_mareale.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "laguna_bioreattiva"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Antenne Flusso Mareale ottimizza le operazioni offensivo nelle condizioni di laguna bioreattiva.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "spinta_selettiva": "i18n:traits.antenne_flusso_mareale.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.antenne_flusso_mareale.uso_funzione",
+      "usage_tags": [
+        "breaker"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "laguna_bioreattiva"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "artigli_induzione": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.artigli_induzione.debolezza",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "artigli_induzione",
+      "label": "i18n:traits.artigli_induzione.label",
+      "mutazione_indotta": "i18n:traits.artigli_induzione.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_ionica"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Artigli Induzione ottimizza le operazioni offensivo nelle condizioni di canopia ionica.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "spinta_selettiva": "i18n:traits.artigli_induzione.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.artigli_induzione.uso_funzione",
+      "usage_tags": [
+        "breaker"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "canopia_ionica"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "artigli_ipo_termici": {
+      "id": "artigli_ipo_termici",
+      "label": "i18n:traits.artigli_ipo_termici.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Offensivo/Termico",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "visione_multi_spettrale_amplificata"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.artigli_ipo_termici.mutazione_indotta",
+      "uso_funzione": "i18n:traits.artigli_ipo_termici.uso_funzione",
+      "spinta_selettiva": "i18n:traits.artigli_ipo_termici.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "temperatura_fiato",
+          "value": -20,
+          "unit": "Cel"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Riduce T cutanea di 10 Cel in 2 s",
+        "scene_prompt": "Termocamera su preda simulata"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "Gli artigli raffreddati mantengono presa su rocce calde o fumarole terrestri, evitando surriscaldamento."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000228"
+        ]
+      },
+      "slot_profile": {
+        "core": "offensivo",
+        "complementare": "termico"
+      },
+      "usage_tags": [
+        "breaker"
+      ],
+      "debolezza": "i18n:traits.artigli_ipo_termici.debolezza"
+    },
+    "artiglio_cinetico_a_urto": {
+      "id": "artiglio_cinetico_a_urto",
+      "label": "i18n:traits.artiglio_cinetico_a_urto.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Offensivo/Contusivo",
+      "fattore_mantenimento_energetico": "Alto (apporto costante o consumo continuo)",
+      "tier": "T4",
+      "slot": [],
+      "sinergie": [
+        "locomozione_miriapode_ibrida",
+        "estroflessione_gastrica_acida"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.artiglio_cinetico_a_urto.mutazione_indotta",
+      "uso_funzione": "i18n:traits.artiglio_cinetico_a_urto.uso_funzione",
+      "spinta_selettiva": "i18n:traits.artiglio_cinetico_a_urto.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "energia_impattiva",
+          "value": 800,
+          "unit": "J"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Frattura tibia su osso bovino in prova",
+        "scene_prompt": "Misura impulso con accelerometro"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T4",
+            "notes": "Serve terreno solido terrestre per scaricare l'energia d'urto senza perdere equilibrio."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000228"
+        ]
+      },
+      "slot_profile": {
+        "core": "offensivo",
+        "complementare": "contusivo"
+      },
+      "usage_tags": [
+        "breaker"
+      ],
+      "debolezza": "i18n:traits.artiglio_cinetico_a_urto.debolezza"
+    },
+    "aura_di_dispersione_mentale": {
+      "id": "aura_di_dispersione_mentale",
+      "label": "i18n:traits.aura_di_dispersione_mentale.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Offensivo/Controllo",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "corna_psico_conduttive"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.aura_di_dispersione_mentale.mutazione_indotta",
+      "uso_funzione": "i18n:traits.aura_di_dispersione_mentale.uso_funzione",
+      "spinta_selettiva": "i18n:traits.aura_di_dispersione_mentale.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "intimidazione_index",
+          "value": 0.8,
+          "unit": "1"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Predatore abbandona inseguimento",
+        "scene_prompt": "Osserva risposta etologica di canidi"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "Le onde psichiche si propagano meglio nell'aria densa terrestre, disturbando coordinazioni vicine."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000178"
+        ]
+      },
+      "slot_profile": {
+        "core": "offensivo",
+        "complementare": "controllo"
+      },
+      "usage_tags": [
+        "breaker"
+      ],
+      "debolezza": "i18n:traits.aura_di_dispersione_mentale.debolezza"
+    },
+    "biochip_memoria": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.biochip_memoria.debolezza",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "biochip_memoria",
+      "label": "i18n:traits.biochip_memoria.label",
+      "mutazione_indotta": "i18n:traits.biochip_memoria.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "steppe_algoritmiche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Biochip Memoria ottimizza le operazioni offensivo nelle condizioni di steppe algoritmiche.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "spinta_selettiva": "i18n:traits.biochip_memoria.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.biochip_memoria.uso_funzione",
+      "usage_tags": [
+        "breaker"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "steppe_algoritmiche"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "camere_anticorrosione": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.camere_anticorrosione.debolezza",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "camere_anticorrosione",
+      "label": "i18n:traits.camere_anticorrosione.label",
+      "mutazione_indotta": "i18n:traits.camere_anticorrosione.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_acida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Camere Anticorrosione ottimizza le operazioni offensivo nelle condizioni di foresta acida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "spinta_selettiva": "i18n:traits.camere_anticorrosione.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.camere_anticorrosione.uso_funzione",
+      "usage_tags": [
+        "breaker"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "foresta_acida"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "cannone_sonico_a_raggio": {
+      "id": "cannone_sonico_a_raggio",
+      "label": "i18n:traits.cannone_sonico_a_raggio.label",
+      "debolezza": "i18n:traits.cannone_sonico_a_raggio.debolezza",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Offensivo/Controllo",
+      "fattore_mantenimento_energetico": "Medio (scarica focalizzata con ricarica)",
+      "tier": "T4",
+      "slot": [],
+      "sinergie": [
+        "ali_fono_risonanti",
+        "occhi_cinetici",
+        "campo_di_interferenza_acustica"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.cannone_sonico_a_raggio.mutazione_indotta",
+      "uso_funzione": "i18n:traits.cannone_sonico_a_raggio.uso_funzione",
+      "spinta_selettiva": "i18n:traits.cannone_sonico_a_raggio.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "dose_acustica",
+          "value": 140,
+          "unit": "dB·s"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Stordisce pollo in 2 s a 3 m",
+        "scene_prompt": "Misura SPL puntuale + risposta preda"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T4",
+            "notes": "Richiede atmosfera terrestre come mezzo per convogliare i fronti d'urto sonici a lunga distanza."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000178"
+        ]
+      },
+      "usage_tags": [
+        "breaker",
+        "controller"
+      ],
+      "slot_profile": {
+        "core": "offensivo",
+        "complementare": "controllo"
+      }
+    },
+    "canto_infrasonico_tattico": {
+      "id": "canto_infrasonico_tattico",
+      "label": "i18n:traits.canto_infrasonico_tattico.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Offensivo/Controllo",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T4",
+      "slot": [],
+      "sinergie": [
+        "scheletro_pneumatico_a_maglie"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.canto_infrasonico_tattico.mutazione_indotta",
+      "uso_funzione": "i18n:traits.canto_infrasonico_tattico.uso_funzione",
+      "spinta_selettiva": "i18n:traits.canto_infrasonico_tattico.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "dose_acustica",
+          "value": 120,
+          "unit": "dB·s"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Predatore desiste entro 30 s",
+        "scene_prompt": "Fonometro e risposta comportamentale"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T4",
+            "notes": "Le onde infrasoniche sfruttano l'aria e il suolo terrestri per indurre risonanze tattiche."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000178"
+        ]
+      },
+      "slot_profile": {
+        "core": "offensivo",
+        "complementare": "controllo"
+      },
+      "usage_tags": [
+        "breaker"
+      ],
+      "debolezza": "i18n:traits.canto_infrasonico_tattico.debolezza"
+    },
+    "cartilagini_biofibre": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.cartilagini_biofibre.debolezza",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "cartilagini_biofibre",
+      "label": "i18n:traits.cartilagini_biofibre.label",
+      "mutazione_indotta": "i18n:traits.cartilagini_biofibre.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "reef_luminescente"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Cartilagini Biofibre ottimizza le operazioni offensivo nelle condizioni di reef luminescente.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "spinta_selettiva": "i18n:traits.cartilagini_biofibre.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.cartilagini_biofibre.uso_funzione",
+      "usage_tags": [
+        "breaker"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "reef_luminescente"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "circolazione_supercritica": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.circolazione_supercritica.debolezza",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "circolazione_supercritica",
+      "label": "i18n:traits.circolazione_supercritica.label",
+      "mutazione_indotta": "i18n:traits.circolazione_supercritica.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_vulcanico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Circolazione Supercritica ottimizza le operazioni offensivo nelle condizioni di abisso vulcanico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "spinta_selettiva": "i18n:traits.circolazione_supercritica.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.circolazione_supercritica.uso_funzione",
+      "usage_tags": [
+        "breaker"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "abisso_vulcanico"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "coda_stabilizzatrice_vortex": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.coda_stabilizzatrice_vortex.debolezza",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "coda_stabilizzatrice_vortex",
+      "label": "i18n:traits.coda_stabilizzatrice_vortex.label",
+      "mutazione_indotta": "i18n:traits.coda_stabilizzatrice_vortex.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "stratosfera_tempestosa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Coda Stabilizzatrice Vortex ottimizza le operazioni offensivo nelle condizioni di stratosfera tempestosa.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "spinta_selettiva": "i18n:traits.coda_stabilizzatrice_vortex.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.coda_stabilizzatrice_vortex.uso_funzione",
+      "usage_tags": [
+        "breaker"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "stratosfera_tempestosa"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "denti_chelatanti": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.denti_chelatanti.debolezza",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "denti_chelatanti",
+      "label": "i18n:traits.denti_chelatanti.label",
+      "mutazione_indotta": "i18n:traits.denti_chelatanti.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_acida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Denti Chelatanti ottimizza le operazioni offensivo nelle condizioni di foresta acida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "spinta_selettiva": "i18n:traits.denti_chelatanti.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.denti_chelatanti.uso_funzione",
+      "usage_tags": [
+        "breaker"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "foresta_acida"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "elettromagnete_biologico": {
+      "id": "elettromagnete_biologico",
+      "label": "i18n:traits.elettromagnete_biologico.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Offensivo/Elettrico",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T4",
+      "slot": [],
+      "sinergie": [
+        "integumento_bipolare",
+        "filtro_metallofago"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.elettromagnete_biologico.mutazione_indotta",
+      "uso_funzione": "i18n:traits.elettromagnete_biologico.uso_funzione",
+      "spinta_selettiva": "i18n:traits.elettromagnete_biologico.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "corrente_picco",
+          "value": 15,
+          "unit": "A"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Stordisce tilapia a 1 m",
+        "scene_prompt": "Misura corrente in impulso su sonda"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T4",
+            "notes": "Attinge a minerali ferrosi del suolo terrestre per amplificare i campi generati dal corpo."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_00000873"
+        ]
+      },
+      "slot_profile": {
+        "core": "offensivo",
+        "complementare": "elettrico"
+      },
+      "usage_tags": [
+        "breaker"
+      ],
+      "debolezza": "i18n:traits.elettromagnete_biologico.debolezza"
+    },
+    "enzimi_metanoossidanti": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.enzimi_metanoossidanti.debolezza",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "enzimi_metanoossidanti",
+      "label": "i18n:traits.enzimi_metanoossidanti.label",
+      "mutazione_indotta": "i18n:traits.enzimi_metanoossidanti.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_vulcanico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Enzimi Metanoossidanti ottimizza le operazioni offensivo nelle condizioni di abisso vulcanico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "spinta_selettiva": "i18n:traits.enzimi_metanoossidanti.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.enzimi_metanoossidanti.uso_funzione",
+      "usage_tags": [
+        "breaker"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "abisso_vulcanico"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "estroflessione_gastrica_acida": {
+      "id": "estroflessione_gastrica_acida",
+      "label": "i18n:traits.estroflessione_gastrica_acida.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Offensivo/Chimico",
+      "fattore_mantenimento_energetico": "Alto (apporto costante o consumo continuo)",
+      "tier": "T4",
+      "slot": [],
+      "sinergie": [
+        "artiglio_cinetico_a_urto"
+      ],
+      "conflitti": [
+        "sistemi_chimio_sonici"
+      ],
+      "mutazione_indotta": "i18n:traits.estroflessione_gastrica_acida.mutazione_indotta",
+      "uso_funzione": "i18n:traits.estroflessione_gastrica_acida.uso_funzione",
+      "spinta_selettiva": "i18n:traits.estroflessione_gastrica_acida.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "pressione_getto",
+          "value": 50000,
+          "unit": "Pa"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Disgrega 1 kg gel proteico in < 60 s",
+        "scene_prompt": "Versa su supporto standard e misura tempo liquefazione"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T4",
+            "notes": "La proiezione acida è efficace in cavità e superfici terrestri dove si possono dissolvere ostacoli solidi."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000228"
+        ]
+      },
+      "slot_profile": {
+        "core": "offensivo",
+        "complementare": "chimico"
+      },
+      "usage_tags": [
+        "breaker"
+      ],
+      "debolezza": "i18n:traits.estroflessione_gastrica_acida.debolezza"
+    },
+    "foliaggio_spugna": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.foliaggio_spugna.debolezza",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "foliaggio_spugna",
+      "label": "i18n:traits.foliaggio_spugna.label",
+      "mutazione_indotta": "i18n:traits.foliaggio_spugna.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "mangrovieto_cinetico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Foliaggio Spugna ottimizza le operazioni offensivo nelle condizioni di mangrovieto cinetico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "spinta_selettiva": "i18n:traits.foliaggio_spugna.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.foliaggio_spugna.uso_funzione",
+      "usage_tags": [
+        "breaker"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "mangrovieto_cinetico"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "frusta_fiammeggiante": {
+      "conflitti": [
+        "armatura_pietra_planare"
+      ],
+      "debolezza": "i18n:traits.frusta_fiammeggiante.debolezza",
+      "famiglia_tipologia": "Offensivo/Controllo",
+      "fattore_mantenimento_energetico": "Medio (Filamenti di plasma vincolato)",
+      "id": "frusta_fiammeggiante",
+      "label": "i18n:traits.frusta_fiammeggiante.label",
+      "mutazione_indotta": "i18n:traits.frusta_fiammeggiante.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [
+            "void_stride"
+          ],
+          "condizioni": {
+            "biome_class": "rovine_planari"
+          },
+          "fonte": "pathfinder_import",
+          "meta": {
+            "expansion": "pathfinder_dataset",
+            "notes": "Necessita condotti di stabilizzazione infernale nelle rovine planari.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "sinergie": [
+        "focus_frazionato",
+        "mantello_meteoritico"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "controllo",
+        "core": "offensivo"
+      },
+      "spinta_selettiva": "i18n:traits.frusta_fiammeggiante.spinta_selettiva",
+      "tier": "T2",
+      "uso_funzione": "i18n:traits.frusta_fiammeggiante.uso_funzione",
+      "usage_tags": [
+        "breaker",
+        "controller"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "rovine_planari"
+      ],
+      "data_origin": "pathfinder_dataset"
+    },
+    "ghiandola_caustica": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.ghiandola_caustica.debolezza",
+      "famiglia_tipologia": "Offensivo/Chimico",
+      "fattore_mantenimento_energetico": "Medio (Produzione reagenti)",
+      "id": "ghiandola_caustica",
+      "label": "i18n:traits.ghiandola_caustica.label",
+      "mutazione_indotta": "i18n:traits.ghiandola_caustica.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_miceliale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "tier": "T1",
+            "notes": "Secrezioni caustiche contrastano muffe e liane delle foreste miceliali, sterilizzando il passaggio."
+          }
+        }
+      ],
+      "sinergie": [
+        "enzimi_chelanti",
+        "respiro_a_scoppio",
+        "campo_di_interferenza_acustica",
+        "sistemi_chimio_sonici"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "PE",
+          "guardia_situazionale",
+          "sigillo_forma"
+        ],
+        "combo_totale": 2,
+        "forme": [
+          "ISTP",
+          "ESTP"
+        ],
+        "tabelle_random": []
+      },
+      "slot": [
+        "A"
+      ],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "sentinella-radice",
+          "weight": 1
+        }
+      ],
+      "spinta_selettiva": "i18n:traits.ghiandola_caustica.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.ghiandola_caustica.uso_funzione",
+      "usage_tags": [
+        "breaker"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": true,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "foresta_miceliale"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "ghiandole_iodoattive": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.ghiandole_iodoattive.debolezza",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_iodoattive",
+      "label": "i18n:traits.ghiandole_iodoattive.label",
+      "mutazione_indotta": "i18n:traits.ghiandole_iodoattive.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianura_salina_iperarida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Iodoattive ottimizza le operazioni offensivo nelle condizioni di pianura salina iperarida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "spinta_selettiva": "i18n:traits.ghiandole_iodoattive.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.ghiandole_iodoattive.uso_funzione",
+      "usage_tags": [
+        "breaker"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "pianura_salina_iperarida"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "gusci_magnesio": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.gusci_magnesio.debolezza",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "gusci_magnesio",
+      "label": "i18n:traits.gusci_magnesio.label",
+      "mutazione_indotta": "i18n:traits.gusci_magnesio.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dorsale_termale_tropicale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Gusci Magnesio ottimizza le operazioni offensivo nelle condizioni di dorsale termale tropicale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "spinta_selettiva": "i18n:traits.gusci_magnesio.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.gusci_magnesio.uso_funzione",
+      "usage_tags": [
+        "breaker"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "dorsale_termale_tropicale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "mantelli_geotermici": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.mantelli_geotermici.debolezza",
+      "famiglia_tipologia": "Offensivo/Assalto",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "mantelli_geotermici",
+      "label": "i18n:traits.mantelli_geotermici.label",
+      "mutazione_indotta": "i18n:traits.mantelli_geotermici.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Mantelli Geotermici ottimizza le operazioni offensivo nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "sangue_piroforico"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "assalto",
+        "core": "offensivo"
+      },
+      "spinta_selettiva": "i18n:traits.mantelli_geotermici.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.mantelli_geotermici.uso_funzione",
+      "usage_tags": [
+        "breaker"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caldera_glaciale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "rostro_emostatico_litico": {
+      "id": "rostro_emostatico_litico",
+      "label": "i18n:traits.rostro_emostatico_litico.label",
+      "data_origin": "incoming_tr1100_pack",
+      "famiglia_tipologia": "Offensivo/Perforante",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T4",
+      "slot": [],
+      "sinergie": [
+        "organi_sismici_cutanei",
+        "scheletro_idraulico_a_pistoni",
+        "ectotermia_dinamica"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.rostro_emostatico_litico.mutazione_indotta",
+      "uso_funzione": "i18n:traits.rostro_emostatico_litico.uso_funzione",
+      "spinta_selettiva": "i18n:traits.rostro_emostatico_litico.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "velocita_proiettile",
+          "value": 120,
+          "unit": "m/s"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Puntura e retrazione in < 0.1 s",
+        "scene_prompt": "Filma in slow-motion tre attacchi su gel fluorescente"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T4",
+            "notes": "Progettato per perforare carapaci e ossa di fauna terrestre, fermando il flusso con coagulanti litici."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000178",
+          "http://purl.obolibrary.org/obo/ENVO_01000228"
+        ]
+      },
+      "version": "2.0.1",
+      "versioning": {
+        "created": "2025-11-04",
+        "updated": "2025-11-23",
+        "author": "Master DD / GPT-5 Pro"
+      },
+      "slot_profile": {
+        "core": "offensivo",
+        "complementare": "perforante"
+      },
+      "usage_tags": [
+        "breaker"
+      ],
+      "debolezza": "i18n:traits.rostro_emostatico_litico.debolezza"
+    },
+    "sangue_piroforico": {
+      "conflitti": [
+        "criostasi_adattiva",
+        "scheletro_idro_regolante"
+      ],
+      "debolezza": "i18n:traits.sangue_piroforico.debolezza",
+      "famiglia_tipologia": "Offensivo/Cinetico",
+      "fattore_mantenimento_energetico": "Medio (Sintesi dei composti)",
+      "id": "sangue_piroforico",
+      "label": "i18n:traits.sangue_piroforico.label",
+      "mutazione_indotta": "i18n:traits.sangue_piroforico.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "antenne_flusso_mareale",
+        "artigli_induzione",
+        "biochip_memoria",
+        "camere_anticorrosione",
+        "cartilagini_biofibre",
+        "circolazione_supercritica",
+        "coda_stabilizzatrice_vortex",
+        "denti_chelatanti",
+        "enzimi_metanoossidanti",
+        "foliaggio_spugna",
+        "ghiandole_iodoattive",
+        "gusci_magnesio",
+        "lamelle_termoforetiche",
+        "mantelli_geotermici"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "impatto",
+        "core": "offensivo"
+      },
+      "spinta_selettiva": "i18n:traits.sangue_piroforico.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.sangue_piroforico.uso_funzione",
+      "usage_tags": [
+        "breaker"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caverna_risonante"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "seta_conduttiva_elettrica": {
+      "id": "seta_conduttiva_elettrica",
+      "label": "i18n:traits.seta_conduttiva_elettrica.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Offensivo/Elettrico",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T4",
+      "slot": [],
+      "sinergie": [
+        "zanne_idracida",
+        "occhi_analizzatori_di_tensione"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.seta_conduttiva_elettrica.mutazione_indotta",
+      "uso_funzione": "i18n:traits.seta_conduttiva_elettrica.uso_funzione",
+      "spinta_selettiva": "i18n:traits.seta_conduttiva_elettrica.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "tensione_picco",
+          "value": 1200,
+          "unit": "V"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Scarica a impulso su sonda",
+        "scene_prompt": "Misura tensione su rete 1×1 m"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T4",
+            "notes": "I fili conducono lungo strutture terrestri metalliche o rocciose, scaricando cariche controllate."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000228"
+        ]
+      },
+      "slot_profile": {
+        "core": "offensivo",
+        "complementare": "elettrico"
+      },
+      "usage_tags": [
+        "breaker"
+      ],
+      "debolezza": "i18n:traits.seta_conduttiva_elettrica.debolezza"
+    },
+    "zanne_idracida": {
+      "id": "zanne_idracida",
+      "label": "i18n:traits.zanne_idracida.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Offensivo/Chimico",
+      "fattore_mantenimento_energetico": "Alto (apporto costante o consumo continuo)",
+      "tier": "T4",
+      "slot": [],
+      "sinergie": [
+        "seta_conduttiva_elettrica",
+        "articolazioni_a_leva_idraulica",
+        "filtrazione_osmotica"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.zanne_idracida.mutazione_indotta",
+      "uso_funzione": "i18n:traits.zanne_idracida.uso_funzione",
+      "spinta_selettiva": "i18n:traits.zanne_idracida.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "pressione_getto",
+          "value": 1000000,
+          "unit": "Pa"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Perfora lamina d’alluminio 1 mm",
+        "scene_prompt": "Spruzzo controllato su pannello metallico"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T4",
+            "notes": "Le zanne rilasciano acido in ambienti terrestri asciutti dove evapora lentamente e resta aderente."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000228"
+        ]
+      },
+      "slot_profile": {
+        "core": "offensivo",
+        "complementare": "chimico"
+      },
+      "usage_tags": [
+        "breaker"
+      ],
+      "debolezza": "i18n:traits.zanne_idracida.debolezza"
+    },
+    "branchie_osmotiche_salmastra": {
+      "conflitti": [
+        "polmoni_cristallini_alta_quota"
+      ],
+      "debolezza": "i18n:traits.branchie_osmotiche_salmastra.debolezza",
+      "famiglia_tipologia": "Respiratorio/Osmoregolazione",
+      "fattore_mantenimento_energetico": "Medio (Pompe ioniche attive)",
+      "id": "branchie_osmotiche_salmastra",
+      "label": "i18n:traits.branchie_osmotiche_salmastra.label",
+      "mutazione_indotta": "i18n:traits.branchie_osmotiche_salmastra.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "delta_salmastri"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Estuari psionici dove l'acqua dolce e marina si mescolano creando gradienti forti.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "scheletro_idro_regolante"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "boardgame:Evolution/Symbiosis",
+          "boardgame:DominantSpecies/Adaptation",
+          "hud:EstuarioPsi"
+        ],
+        "combo_totale": 3,
+        "forme": [
+          "Forma:Amfibio_Oracolare"
+        ],
+        "tabelle_random": [
+          "tabella:osmosi_psionica"
+        ]
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "osmoregolazione",
+        "core": "respiratorio"
+      },
+      "spinta_selettiva": "i18n:traits.branchie_osmotiche_salmastra.spinta_selettiva",
+      "tier": "T2",
+      "uso_funzione": "i18n:traits.branchie_osmotiche_salmastra.uso_funzione",
+      "usage_tags": [
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "delta_salmastri"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "lamelle_termoforetiche": {
+      "conflitti": [
+        "criostasi_adattiva"
+      ],
+      "debolezza": "i18n:traits.lamelle_termoforetiche.debolezza",
+      "famiglia_tipologia": "Respiratorio/Termoregolazione",
+      "fattore_mantenimento_energetico": "Medio (Flusso continuo di fluidi caldi)",
+      "id": "lamelle_termoforetiche",
+      "label": "i18n:traits.lamelle_termoforetiche.label",
+      "mutazione_indotta": "i18n:traits.lamelle_termoforetiche.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "sorgenti_geotermiche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Habitat idrotermali psionici dove il calore e la pressione variano rapidamente.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "sinergie": [
+        "sangue_piroforico"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "termoregolazione",
+        "core": "respiratorio"
+      },
+      "spinta_selettiva": "i18n:traits.lamelle_termoforetiche.spinta_selettiva",
+      "tier": "T2",
+      "uso_funzione": "i18n:traits.lamelle_termoforetiche.uso_funzione",
+      "usage_tags": [
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "sorgenti_geotermiche"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "membrane_eliofiltranti": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.membrane_eliofiltranti.debolezza",
+      "famiglia_tipologia": "Respiratorio/Protezione",
+      "fattore_mantenimento_energetico": "Basso (Auto-riparazione lenta)",
+      "id": "membrane_eliofiltranti",
+      "label": "i18n:traits.membrane_eliofiltranti.label",
+      "mutazione_indotta": "i18n:traits.membrane_eliofiltranti.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "laghi_alcalini"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Bacini alcalini sospesi dove la luce viene rifratta da vapori metallici.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "sinergie": [
+        "piume_solari_fotovoltaiche",
+        "polmoni_cristallini_alta_quota"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "protezione",
+        "core": "respiratorio"
+      },
+      "spinta_selettiva": "i18n:traits.membrane_eliofiltranti.spinta_selettiva",
+      "tier": "T2",
+      "uso_funzione": "i18n:traits.membrane_eliofiltranti.uso_funzione",
+      "usage_tags": [
+        "sustain",
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "laghi_alcalini"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "polmoni_cristallini_alta_quota": {
+      "conflitti": [
+        "branchie_osmotiche_salmastra"
+      ],
+      "debolezza": "i18n:traits.polmoni_cristallini_alta_quota.debolezza",
+      "famiglia_tipologia": "Respiratorio/Aerobico",
+      "fattore_mantenimento_energetico": "Medio (Pulizia periodica dei cristalli)",
+      "id": "polmoni_cristallini_alta_quota",
+      "label": "i18n:traits.polmoni_cristallini_alta_quota.label",
+      "mutazione_indotta": "i18n:traits.polmoni_cristallini_alta_quota.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "picchi_cristallini"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Catene montuose sospese dove i cristalli amplificano l'aria rarefatta.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "sinergie": [
+        "membrane_eliofiltranti"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "aerobico",
+        "core": "respiratorio"
+      },
+      "spinta_selettiva": "i18n:traits.polmoni_cristallini_alta_quota.spinta_selettiva",
+      "tier": "T2",
+      "uso_funzione": "i18n:traits.polmoni_cristallini_alta_quota.uso_funzione",
+      "usage_tags": [
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "picchi_cristallini"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "respiro_a_scoppio": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.respiro_a_scoppio.debolezza",
+      "famiglia_tipologia": "Respiratorio/Propulsivo",
+      "fattore_mantenimento_energetico": "Alto (Richiede ricarica polmonare)",
+      "id": "respiro_a_scoppio",
+      "label": "i18n:traits.respiro_a_scoppio.label",
+      "mutazione_indotta": "i18n:traits.respiro_a_scoppio.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "sacche_galleggianti_ascensoriali",
+        "squame_rifrangenti_deserto"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "propulsivo",
+        "core": "respiratorio"
+      },
+      "spinta_selettiva": "i18n:traits.respiro_a_scoppio.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.respiro_a_scoppio.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caverna_risonante"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "ermafroditismo_cronologico": {
+      "id": "ermafroditismo_cronologico",
+      "label": "i18n:traits.ermafroditismo_cronologico.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Riproduttivo/Cicli",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "locomozione_miriapode_ibrida",
+        "estroflessione_gastrica_acida"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.ermafroditismo_cronologico.mutazione_indotta",
+      "uso_funzione": "i18n:traits.ermafroditismo_cronologico.uso_funzione",
+      "spinta_selettiva": "i18n:traits.ermafroditismo_cronologico.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "tasso_propaguli",
+          "value": 50,
+          "unit": "1/season"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Ciclo documentato su due stagioni",
+        "scene_prompt": "Registro di incubazione con campionamenti ormonali"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "La modulazione stagionale funziona in cicli fotoperiodici terrestri e richiede tane stabili."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000228"
+        ]
+      },
+      "slot_profile": {
+        "core": "riproduttivo",
+        "complementare": "cicli"
+      },
+      "usage_tags": [
+        "support"
+      ],
+      "debolezza": "i18n:traits.ermafroditismo_cronologico.debolezza"
+    },
+    "moltiplicazione_per_fusione": {
+      "id": "moltiplicazione_per_fusione",
+      "label": "i18n:traits.moltiplicazione_per_fusione.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Riproduttivo/Cicli",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [
+        "cisti_di_ibernazione_minerale",
+        "membrana_plastica_continua"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.moltiplicazione_per_fusione.mutazione_indotta",
+      "uso_funzione": "i18n:traits.moltiplicazione_per_fusione.uso_funzione",
+      "spinta_selettiva": "i18n:traits.moltiplicazione_per_fusione.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "tasso_propaguli",
+          "value": 3,
+          "unit": "1/season"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Raddoppio massa in 24 h",
+        "scene_prompt": "Time-lapse di scissione e fusione"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T2",
+            "notes": "Le colonie si ricombinano nel suolo terrestre dove le matrici cellulari restano protette dall'erosione."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_00000873"
+        ]
+      },
+      "slot_profile": {
+        "core": "riproduttivo",
+        "complementare": "cicli"
+      },
+      "usage_tags": [
+        "support"
+      ],
+      "debolezza": "i18n:traits.moltiplicazione_per_fusione.debolezza"
+    },
+    "nucleo_ovomotore_rotante": {
+      "conflitti": [
+        "secrezione_rallentante_palmi"
+      ],
+      "debolezza": "i18n:traits.nucleo_ovomotore_rotante.debolezza",
+      "famiglia_tipologia": "Riproduttivo/Locomotorio",
+      "fattore_mantenimento_energetico": "Alto (Rotolamento)",
+      "id": "nucleo_ovomotore_rotante",
+      "label": "i18n:traits.nucleo_ovomotore_rotante.label",
+      "mutazione_indotta": "i18n:traits.nucleo_ovomotore_rotante.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "coda_balanciere",
+        "locomozione_miriapode_ibrida",
+        "flusso_ameboide_controllato"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "starter_bioma",
+          "sigillo_forma"
+        ],
+        "combo_totale": 2,
+        "forme": [
+          "ESFP",
+          "ISTP"
+        ],
+        "tabelle_random": []
+      },
+      "slot": [
+        "C"
+      ],
+      "slot_profile": {
+        "complementare": "locomotorio",
+        "core": "riproduttivo"
+      },
+      "spinta_selettiva": "i18n:traits.nucleo_ovomotore_rotante.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.nucleo_ovomotore_rotante.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "marilith-vault",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "psionic-canopy-scout",
+          "weight": 2
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": true,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caverna_risonante"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "ali_fulminee": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.ali_fulminee.debolezza",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ali_fulminee",
+      "label": "i18n:traits.ali_fulminee.label",
+      "mutazione_indotta": "i18n:traits.ali_fulminee.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "stratosfera_tempestosa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ali Fulminee ottimizza le operazioni sensoriale nelle condizioni di stratosfera tempestosa.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "spinta_selettiva": "i18n:traits.ali_fulminee.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.ali_fulminee.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "stratosfera_tempestosa"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "antenne_plasmatiche_tempesta": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.antenne_plasmatiche_tempesta.debolezza",
+      "famiglia_tipologia": "Sensoriale/Offensivo",
+      "fattore_mantenimento_energetico": "Alto (Canalizzazione costante di plasma atmosferico)",
+      "id": "antenne_plasmatiche_tempesta",
+      "label": "i18n:traits.antenne_plasmatiche_tempesta.label",
+      "mutazione_indotta": "i18n:traits.antenne_plasmatiche_tempesta.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "cicloni_psionici"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Occhi di tempesta permanenti che concentrano elettricità e onde psioniche.",
+            "tier": "T3"
+          }
+        }
+      ],
+      "sinergie": [
+        "carapace_luminiscente_abissale",
+        "focus_frazionato",
+        "risonanza_di_branco",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "boardgame:Evolution/Camouflage-Ambush",
+          "hud:StormMeshPsi",
+          "bioma:cicloni_psionici"
+        ],
+        "combo_totale": 3,
+        "forme": [
+          "Forma:Tempestarii",
+          "HUD:Fulcro_Tempesta"
+        ],
+        "tabelle_random": [
+          "tabella:fulmini_empatici"
+        ]
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "offensivo",
+        "core": "sensoriale"
+      },
+      "spinta_selettiva": "i18n:traits.antenne_plasmatiche_tempesta.spinta_selettiva",
+      "tier": "T3",
+      "uso_funzione": "i18n:traits.antenne_plasmatiche_tempesta.uso_funzione",
+      "usage_tags": [
+        "breaker",
+        "scout"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "cicloni_psionici"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "antenne_waveguide": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.antenne_waveguide.debolezza",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "antenne_waveguide",
+      "label": "i18n:traits.antenne_waveguide.label",
+      "mutazione_indotta": "i18n:traits.antenne_waveguide.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "reef_luminescente"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Antenne Waveguide ottimizza le operazioni sensoriale nelle condizioni di reef luminescente.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "spinta_selettiva": "i18n:traits.antenne_waveguide.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.antenne_waveguide.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "reef_luminescente"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "baffi_mareomotori": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.baffi_mareomotori.debolezza",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "baffi_mareomotori",
+      "label": "i18n:traits.baffi_mareomotori.label",
+      "mutazione_indotta": "i18n:traits.baffi_mareomotori.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "mangrovieto_cinetico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Baffi Mareomotori ottimizza le operazioni sensoriale nelle condizioni di mangrovieto cinetico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "spinta_selettiva": "i18n:traits.baffi_mareomotori.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.baffi_mareomotori.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "mangrovieto_cinetico"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "branchie_eoliche": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.branchie_eoliche.debolezza",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "branchie_eoliche",
+      "label": "i18n:traits.branchie_eoliche.label",
+      "mutazione_indotta": "i18n:traits.branchie_eoliche.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "stratosfera_tempestosa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Branchie Eoliche ottimizza le operazioni sensoriale nelle condizioni di stratosfera tempestosa.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "spinta_selettiva": "i18n:traits.branchie_eoliche.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.branchie_eoliche.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "stratosfera_tempestosa"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "capillari_fluoridici": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.capillari_fluoridici.debolezza",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "capillari_fluoridici",
+      "label": "i18n:traits.capillari_fluoridici.label",
+      "mutazione_indotta": "i18n:traits.capillari_fluoridici.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_acida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Capillari Fluoridici ottimizza le operazioni sensoriale nelle condizioni di foresta acida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "spinta_selettiva": "i18n:traits.capillari_fluoridici.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.capillari_fluoridici.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "foresta_acida"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "cavita_risonanti_tundra": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.cavita_risonanti_tundra.debolezza",
+      "famiglia_tipologia": "Sensoriale/Supporto",
+      "fattore_mantenimento_energetico": "Basso (Camere di risonanza statiche)",
+      "id": "cavita_risonanti_tundra",
+      "label": "i18n:traits.cavita_risonanti_tundra.label",
+      "mutazione_indotta": "i18n:traits.cavita_risonanti_tundra.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "tundra_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Steppe gelate che trasmettono vibrazioni psioniche a chilometri di distanza.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "criostasi_adattiva",
+        "eco_interno_riflesso",
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "boardgame:Evolution/Communication",
+          "boardgame:DominantSpecies/Initiative",
+          "hud:TundraPulse"
+        ],
+        "combo_totale": 3,
+        "forme": [
+          "Forma:Cantore_Tundra",
+          "HUD:EchoGrid"
+        ],
+        "tabelle_random": [
+          "tabella:canti_ipersonici"
+        ]
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "supporto",
+        "core": "sensoriale"
+      },
+      "spinta_selettiva": "i18n:traits.cavita_risonanti_tundra.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.cavita_risonanti_tundra.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "tundra_risonante"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "cervelletto_equilibrio_statico": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.cervelletto_equilibrio_statico.debolezza",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "cervelletto_equilibrio_statico",
+      "label": "i18n:traits.cervelletto_equilibrio_statico.label",
+      "mutazione_indotta": "i18n:traits.cervelletto_equilibrio_statico.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_ionica"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Cervelletto Equilibrio Statico ottimizza le operazioni sensoriale nelle condizioni di canopia ionica.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "spinta_selettiva": "i18n:traits.cervelletto_equilibrio_statico.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.cervelletto_equilibrio_statico.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "canopia_ionica"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "coda_balanciere": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.coda_balanciere.debolezza",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "coda_balanciere",
+      "label": "i18n:traits.coda_balanciere.label",
+      "mutazione_indotta": "i18n:traits.coda_balanciere.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Coda Balanciere ottimizza le operazioni sensoriale nelle condizioni di caverna risonante.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "spinta_selettiva": "i18n:traits.coda_balanciere.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.coda_balanciere.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caverna_risonante"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "cuore_multicamera_bassa_pressione": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.cuore_multicamera_bassa_pressione.debolezza",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "cuore_multicamera_bassa_pressione",
+      "label": "i18n:traits.cuore_multicamera_bassa_pressione.label",
+      "mutazione_indotta": "i18n:traits.cuore_multicamera_bassa_pressione.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "stratosfera_tempestosa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Cuore Multicamera Bassa Pressione ottimizza le operazioni sensoriale nelle condizioni di stratosfera tempestosa.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "spinta_selettiva": "i18n:traits.cuore_multicamera_bassa_pressione.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.cuore_multicamera_bassa_pressione.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "stratosfera_tempestosa"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "echi_risonanti": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.echi_risonanti.debolezza",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "id": "echi_risonanti",
+      "label": "i18n:traits.echi_risonanti.label",
+      "mutazione_indotta": "i18n:traits.echi_risonanti.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Echi Risonanti ottimizza le operazioni sensoriale nelle condizioni di caverna risonante.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "spinta_selettiva": "i18n:traits.echi_risonanti.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.echi_risonanti.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caverna_risonante"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "eco_interno_riflesso": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.eco_interno_riflesso.debolezza",
+      "famiglia_tipologia": "Sensoriale/Nervoso",
+      "fattore_mantenimento_energetico": "Medio (Emissioni e ricezione continua)",
+      "id": "eco_interno_riflesso",
+      "label": "i18n:traits.eco_interno_riflesso.label",
+      "mutazione_indotta": "i18n:traits.eco_interno_riflesso.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_psionica_leggera"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Start T1 nelle canopie conduttrici per apprendere deformazioni controllate.",
+            "tier": "T2"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Upgrade T2 sulle dorsali magnetiche per mantenere elasticità sotto stress.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "sinergie": [
+        "cavita_risonanti_tundra",
+        "olfatto_risonanza_magnetica",
+        "sensori_geomagnetici"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "nervoso",
+        "core": "sensoriale"
+      },
+      "spinta_selettiva": "i18n:traits.eco_interno_riflesso.spinta_selettiva",
+      "tier": "T2",
+      "uso_funzione": "i18n:traits.eco_interno_riflesso.uso_funzione",
+      "usage_tags": [
+        "controller",
+        "scout"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "canopia_psionica_leggera",
+        "falde_magnetiche_psioniche"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "filamenti_superconduttivi": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.filamenti_superconduttivi.debolezza",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "filamenti_superconduttivi",
+      "label": "i18n:traits.filamenti_superconduttivi.label",
+      "mutazione_indotta": "i18n:traits.filamenti_superconduttivi.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Filamenti Superconduttivi ottimizza le operazioni sensoriale nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "spinta_selettiva": "i18n:traits.filamenti_superconduttivi.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.filamenti_superconduttivi.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caldera_glaciale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "ghiandole_eco_mappanti": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.ghiandole_eco_mappanti.debolezza",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_eco_mappanti",
+      "label": "i18n:traits.ghiandole_eco_mappanti.label",
+      "mutazione_indotta": "i18n:traits.ghiandole_eco_mappanti.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Eco Mappanti ottimizza le operazioni sensoriale nelle condizioni di caverna risonante.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "spinta_selettiva": "i18n:traits.ghiandole_eco_mappanti.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.ghiandole_eco_mappanti.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caverna_risonante"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "ghiandole_resina_conduttiva": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.ghiandole_resina_conduttiva.debolezza",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_resina_conduttiva",
+      "label": "i18n:traits.ghiandole_resina_conduttiva.label",
+      "mutazione_indotta": "i18n:traits.ghiandole_resina_conduttiva.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_ionica"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Resina Conduttiva ottimizza le operazioni sensoriale nelle condizioni di canopia ionica.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "spinta_selettiva": "i18n:traits.ghiandole_resina_conduttiva.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.ghiandole_resina_conduttiva.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "canopia_ionica"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "integumento_bipolare": {
+      "id": "integumento_bipolare",
+      "label": "i18n:traits.integumento_bipolare.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Sensoriale/Magneto-ricettivo",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "scivolamento_magnetico",
+        "bozzolo_magnetico",
+        "elettromagnete_biologico"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.integumento_bipolare.mutazione_indotta",
+      "uso_funzione": "i18n:traits.integumento_bipolare.uso_funzione",
+      "spinta_selettiva": "i18n:traits.integumento_bipolare.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "sens_magnetica",
+          "value": 1e-06,
+          "unit": "T"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Mantiene rotta con EM artificiale",
+        "scene_prompt": "Labirinto con bobine Helmholtz"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "Il mantello polarizzato disperde calore e cariche in climi terrestri secchi o tempeste di polvere."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_00000304",
+          "http://purl.obolibrary.org/obo/ENVO_00000873"
+        ]
+      },
+      "slot_profile": {
+        "core": "sensoriale",
+        "complementare": "magnetoricettivo"
+      },
+      "usage_tags": [
+        "scout"
+      ],
+      "debolezza": "i18n:traits.integumento_bipolare.debolezza"
+    },
+    "lamine_scudo_silice": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.lamine_scudo_silice.debolezza",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "lamine_scudo_silice",
+      "label": "i18n:traits.lamine_scudo_silice.label",
+      "mutazione_indotta": "i18n:traits.lamine_scudo_silice.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dorsale_termale_tropicale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Lamine Scudo Silice ottimizza le operazioni sensoriale nelle condizioni di dorsale termale tropicale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "spinta_selettiva": "i18n:traits.lamine_scudo_silice.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.lamine_scudo_silice.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "dorsale_termale_tropicale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "lingua_tattile_trama": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.lingua_tattile_trama.debolezza",
+      "famiglia_tipologia": "Sensoriale/Alimentare",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "lingua_tattile_trama",
+      "label": "i18n:traits.lingua_tattile_trama.label",
+      "mutazione_indotta": "i18n:traits.lingua_tattile_trama.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "olfatto_risonanza_magnetica"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "alimentare",
+        "core": "sensoriale"
+      },
+      "spinta_selettiva": "i18n:traits.lingua_tattile_trama.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.lingua_tattile_trama.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caverna_risonante"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "midollo_antivibrazione": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.midollo_antivibrazione.debolezza",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "midollo_antivibrazione",
+      "label": "i18n:traits.midollo_antivibrazione.label",
+      "mutazione_indotta": "i18n:traits.midollo_antivibrazione.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Midollo Antivibrazione ottimizza le operazioni sensoriale nelle condizioni di caverna risonante.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "analitico",
+        "core": "sensoriale"
+      },
+      "spinta_selettiva": "i18n:traits.midollo_antivibrazione.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.midollo_antivibrazione.uso_funzione",
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caverna_risonante"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "occhi_analizzatori_di_tensione": {
+      "id": "occhi_analizzatori_di_tensione",
+      "label": "i18n:traits.occhi_analizzatori_di_tensione.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Sensoriale/Visivo",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [
+        "seta_conduttiva_elettrica",
+        "articolazioni_a_leva_idraulica"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.occhi_analizzatori_di_tensione.mutazione_indotta",
+      "uso_funzione": "i18n:traits.occhi_analizzatori_di_tensione.uso_funzione",
+      "spinta_selettiva": "i18n:traits.occhi_analizzatori_di_tensione.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "acuita_visiva",
+          "value": 0.92,
+          "unit": "1"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Rileva filo scarico vs carico",
+        "scene_prompt": "Test scelta su trame con diversa polarizzazione"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T2",
+            "notes": "Lettori di stress funzionano su cavi e rocce tese tipiche di rovine terrestri, rilevando microfratture."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000228"
+        ]
+      },
+      "slot_profile": {
+        "core": "sensoriale",
+        "complementare": "visivo"
+      },
+      "usage_tags": [
+        "scout"
+      ],
+      "debolezza": "i18n:traits.occhi_analizzatori_di_tensione.debolezza"
+    },
+    "occhi_cinetici": {
+      "id": "occhi_cinetici",
+      "label": "i18n:traits.occhi_cinetici.label",
+      "debolezza": "i18n:traits.occhi_cinetici.debolezza",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Sensoriale/Visivo",
+      "fattore_mantenimento_energetico": "Basso (micro-attuatori oculari)",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [
+        "cannone_sonico_a_raggio",
+        "campo_di_interferenza_acustica",
+        "ali_fono_risonanti"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.occhi_cinetici.mutazione_indotta",
+      "uso_funzione": "i18n:traits.occhi_cinetici.uso_funzione",
+      "spinta_selettiva": "i18n:traits.occhi_cinetici.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "acuita_visiva",
+          "value": 0.8,
+          "unit": "1"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Riconosce vortici davanti al raggio",
+        "scene_prompt": "Strobo fumo + valutazione traiettoria"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T2",
+            "notes": "Le lenti calibrano traiettorie con orizzonti aperti terrestri, anticipando movimenti in gravità standard."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000178"
+        ]
+      },
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "slot_profile": {
+        "core": "sensoriale",
+        "complementare": "supporto"
+      }
+    },
+    "occhi_cristallo_modulare": {
+      "id": "occhi_cristallo_modulare",
+      "label": "i18n:traits.occhi_cristallo_modulare.label",
+      "famiglia_tipologia": "Sensoriale/Visivo",
+      "fattore_mantenimento_energetico": "Moderato (Attivo)",
+      "tier": "T2",
+      "slot": [
+        "A",
+        "B"
+      ],
+      "sinergie": [
+        "occhi_cinetici",
+        "visione_multi_spettrale_amplificata",
+        "echi_risonanti",
+        "coda_balanciere",
+        "midollo_antivibrazione"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "sigillo_forma",
+          "starter_bioma"
+        ],
+        "combo_totale": 3,
+        "forme": [
+          "INTP",
+          "ISTP",
+          "ISTJ"
+        ],
+        "tabelle_random": []
+      },
+      "conflitti": [],
+      "data_origin": "pathfinder_dataset",
+      "mutazione_indotta": "i18n:traits.occhi_cristallo_modulare.mutazione_indotta",
+      "uso_funzione": "i18n:traits.occhi_cristallo_modulare.uso_funzione",
+      "spinta_selettiva": "i18n:traits.occhi_cristallo_modulare.spinta_selettiva",
+      "completion_flags": {
+        "has_biome": false,
+        "has_species_link": true,
+        "has_data_origin": true
+      },
+      "slot_profile": {
+        "core": "sensoriale",
+        "complementare": "visivo"
+      },
+      "usage_tags": [
+        "scout"
+      ],
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "orbital-ascendant",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "psionic-canopy-scout",
+          "weight": 2
+        }
+      ],
+      "debolezza": "i18n:traits.occhi_cristallo_modulare.debolezza"
+    },
+    "occhi_infrarosso_composti": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.occhi_infrarosso_composti.debolezza",
+      "famiglia_tipologia": "Sensoriale/Visivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "occhi_infrarosso_composti",
+      "label": "i18n:traits.occhi_infrarosso_composti.label",
+      "mutazione_indotta": "i18n:traits.occhi_infrarosso_composti.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "sonno_emisferico_alternato"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "visivo",
+        "core": "sensoriale"
+      },
+      "spinta_selettiva": "i18n:traits.occhi_infrarosso_composti.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.occhi_infrarosso_composti.uso_funzione",
+      "usage_tags": [
+        "scout"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caverna_risonante"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "olfatto_risonanza_magnetica": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.olfatto_risonanza_magnetica.debolezza",
+      "famiglia_tipologia": "Sensoriale/Nervoso",
+      "fattore_mantenimento_energetico": "Medio (Elaborazione sensoriale costante)",
+      "id": "olfatto_risonanza_magnetica",
+      "label": "i18n:traits.olfatto_risonanza_magnetica.label",
+      "mutazione_indotta": "i18n:traits.olfatto_risonanza_magnetica.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Corridore T2 per intercettare campi magnetici psionici sulle dorsali.",
+            "tier": "T2"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "orbita_psionica_inversa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Variante T3 calibrata alle camere di gravità invertita e ai flussi orbitali.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "sinergie": [
+        "eco_interno_riflesso",
+        "lingua_tattile_trama"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "nervoso",
+        "core": "sensoriale"
+      },
+      "spinta_selettiva": "i18n:traits.olfatto_risonanza_magnetica.spinta_selettiva",
+      "tier": "T2",
+      "uso_funzione": "i18n:traits.olfatto_risonanza_magnetica.uso_funzione",
+      "usage_tags": [
+        "controller",
+        "scout"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "falde_magnetiche_psioniche",
+        "orbita_psionica_inversa"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "organi_sismici_cutanei": {
+      "id": "organi_sismici_cutanei",
+      "label": "i18n:traits.organi_sismici_cutanei.label",
+      "data_origin": "incoming_tr1100_pack",
+      "famiglia_tipologia": "Sensoriale/Tatto-Vibro",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "tier": "T2",
+      "slot": [],
+      "sinergie": [
+        "rostro_emostatico_litico"
+      ],
+      "conflitti": [
+        "ipertrofia_muscolare_massiva"
+      ],
+      "mutazione_indotta": "i18n:traits.organi_sismici_cutanei.mutazione_indotta",
+      "uso_funzione": "i18n:traits.organi_sismici_cutanei.uso_funzione",
+      "spinta_selettiva": "i18n:traits.organi_sismici_cutanei.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "soglia_udito",
+          "value": 20,
+          "unit": "dB"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Individua passi entro 15 m",
+        "scene_prompt": "Sabbiera vibrata: segnala direzione corretta"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T2",
+            "notes": "I recettori subdermici leggono vibrazioni trasmesse dal suolo terrestre, avvisando di movimenti sotterranei."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000178"
+        ]
+      },
+      "version": "2.0.1",
+      "versioning": {
+        "created": "2025-11-04",
+        "updated": "2025-11-23",
+        "author": "Master DD / GPT-5 Pro"
+      },
+      "slot_profile": {
+        "core": "sensoriale",
+        "complementare": "tattovibro"
+      },
+      "usage_tags": [
+        "scout"
+      ],
+      "debolezza": "i18n:traits.organi_sismici_cutanei.debolezza"
+    },
+    "sensori_geomagnetici": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.sensori_geomagnetici.debolezza",
+      "famiglia_tipologia": "Sensoriale/Navigazione",
+      "fattore_mantenimento_energetico": "Basso (Ricettori passivi)",
+      "id": "sensori_geomagnetici",
+      "label": "i18n:traits.sensori_geomagnetici.label",
+      "mutazione_indotta": "i18n:traits.sensori_geomagnetici.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianure_magnetiche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Distese pianeggianti con vortici geomagnetici da sfruttare per la navigazione.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "carapace_fase_variabile",
+        "eco_interno_riflesso"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "navigazione",
+        "core": "sensoriale"
+      },
+      "spinta_selettiva": "i18n:traits.sensori_geomagnetici.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.sensori_geomagnetici.uso_funzione",
+      "usage_tags": [
+        "scout"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "pianure_magnetiche"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "sistemi_chimio_sonici": {
+      "id": "sistemi_chimio_sonici",
+      "label": "i18n:traits.sistemi_chimio_sonici.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Sensoriale/Uditivo-Olfattivo",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "locomozione_miriapode_ibrida",
+        "estroflessione_gastrica_acida"
+      ],
+      "conflitti": [
+        "estroflessione_gastrica_acida"
+      ],
+      "mutazione_indotta": "i18n:traits.sistemi_chimio_sonici.mutazione_indotta",
+      "uso_funzione": "i18n:traits.sistemi_chimio_sonici.uso_funzione",
+      "spinta_selettiva": "i18n:traits.sistemi_chimio_sonici.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "banda_uditiva_max",
+          "value": 120000,
+          "unit": "Hz"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Evita ostacoli a 10 m in fumo denso",
+        "scene_prompt": "Tunnel con curve cieche + generatore di fumo"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "Combina feromoni e impulsi sonici che si diffondono bene nell'aria e nel sottobosco terrestri."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000228"
+        ]
+      },
+      "slot_profile": {
+        "core": "sensoriale",
+        "complementare": "uditivoolfattivo"
+      },
+      "usage_tags": [
+        "scout"
+      ],
+      "debolezza": "i18n:traits.sistemi_chimio_sonici.debolezza"
+    },
+    "visione_multi_spettrale_amplificata": {
+      "id": "visione_multi_spettrale_amplificata",
+      "label": "i18n:traits.visione_multi_spettrale_amplificata.label",
+      "data_origin": "coverage_q4_2025",
+      "famiglia_tipologia": "Sensoriale/Visivo",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T3",
+      "slot": [],
+      "sinergie": [
+        "vello_di_assorbimento_totale",
+        "artigli_ipo_termici"
+      ],
+      "conflitti": [],
+      "mutazione_indotta": "i18n:traits.visione_multi_spettrale_amplificata.mutazione_indotta",
+      "uso_funzione": "i18n:traits.visione_multi_spettrale_amplificata.uso_funzione",
+      "spinta_selettiva": "i18n:traits.visione_multi_spettrale_amplificata.spinta_selettiva",
+      "metrics": [
+        {
+          "name": "acuita_visiva",
+          "value": 0.95,
+          "unit": "1"
+        }
+      ],
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "testability": {
+        "observable": "Rileva topo a 30 m al chiaro di luna",
+        "scene_prompt": "Prova campo notturna con target termico"
+      },
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "tier": "T3",
+            "notes": "Gli oculari sfruttano riflessi e radiazione termica degli ambienti terrestri per ampliare lo spettro."
+          }
+        }
+      ],
+      "applicability": {
+        "clades": [],
+        "envo_terms": [
+          "http://purl.obolibrary.org/obo/ENVO_01000228"
+        ]
+      },
+      "slot_profile": {
+        "core": "sensoriale",
+        "complementare": "visivo"
+      },
+      "usage_tags": [
+        "scout"
+      ],
+      "debolezza": "i18n:traits.visione_multi_spettrale_amplificata.debolezza"
+    },
+    "antenne_reagenti": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.antenne_reagenti.debolezza",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "antenne_reagenti",
+      "label": "i18n:traits.antenne_reagenti.label",
+      "mutazione_indotta": "i18n:traits.antenne_reagenti.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_acida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Antenne Reagenti ottimizza le operazioni simbiotico nelle condizioni di foresta acida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "spinta_selettiva": "i18n:traits.antenne_reagenti.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.antenne_reagenti.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "foresta_acida"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "artigli_scivolo_silente": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.artigli_scivolo_silente.debolezza",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "artigli_scivolo_silente",
+      "label": "i18n:traits.artigli_scivolo_silente.label",
+      "mutazione_indotta": "i18n:traits.artigli_scivolo_silente.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Artigli Scivolo Silente ottimizza le operazioni simbiotico nelle condizioni di caverna risonante.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "spinta_selettiva": "i18n:traits.artigli_scivolo_silente.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.artigli_scivolo_silente.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caverna_risonante"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "biofilm_iperarido": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.biofilm_iperarido.debolezza",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "biofilm_iperarido",
+      "label": "i18n:traits.biofilm_iperarido.label",
+      "mutazione_indotta": "i18n:traits.biofilm_iperarido.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianura_salina_iperarida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Biofilm Iperarido ottimizza le operazioni simbiotico nelle condizioni di pianura salina iperarida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "spinta_selettiva": "i18n:traits.biofilm_iperarido.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.biofilm_iperarido.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "pianura_salina_iperarida"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "bulbi_radici_permafrost": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.bulbi_radici_permafrost.debolezza",
+      "famiglia_tipologia": "Simbiotico/Nutrizione",
+      "fattore_mantenimento_energetico": "Medio (Accumulo e rilascio lento di nutrienti)",
+      "id": "bulbi_radici_permafrost",
+      "label": "i18n:traits.bulbi_radici_permafrost.label",
+      "mutazione_indotta": "i18n:traits.bulbi_radici_permafrost.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "permafrost_psionico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Suoli congelati con vene energetiche che alimentano radici coscienti.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "sinergie": [
+        "chioma_parassita_canopica",
+        "nodi_micorrizici_oracolari",
+        "vello_condensatore_nebbie"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "boardgame:DominantSpecies/Fertility",
+          "boardgame:Evolution/Cooperation",
+          "hud:RootMesh_Psi"
+        ],
+        "combo_totale": 3,
+        "forme": [
+          "Forma:Archivio_Subglaciale",
+          "HUD:Radice_Proxy"
+        ],
+        "tabelle_random": [
+          "tabella:riserva_empatica"
+        ]
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "nutrizione",
+        "core": "simbiotico"
+      },
+      "spinta_selettiva": "i18n:traits.bulbi_radici_permafrost.spinta_selettiva",
+      "tier": "T2",
+      "uso_funzione": "i18n:traits.bulbi_radici_permafrost.uso_funzione",
+      "usage_tags": [
+        "support",
+        "sustain"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "permafrost_psionico"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "camere_nutrienti_vent": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.camere_nutrienti_vent.debolezza",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "camere_nutrienti_vent",
+      "label": "i18n:traits.camere_nutrienti_vent.label",
+      "mutazione_indotta": "i18n:traits.camere_nutrienti_vent.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dorsale_termale_tropicale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Camere Nutrienti Vent ottimizza le operazioni simbiotico nelle condizioni di dorsale termale tropicale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "spinta_selettiva": "i18n:traits.camere_nutrienti_vent.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.camere_nutrienti_vent.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "dorsale_termale_tropicale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "cartilagini_flessoacustiche": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.cartilagini_flessoacustiche.debolezza",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "cartilagini_flessoacustiche",
+      "label": "i18n:traits.cartilagini_flessoacustiche.label",
+      "mutazione_indotta": "i18n:traits.cartilagini_flessoacustiche.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Cartilagini Flessoacustiche ottimizza le operazioni simbiotico nelle condizioni di caverna risonante.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "spinta_selettiva": "i18n:traits.cartilagini_flessoacustiche.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.cartilagini_flessoacustiche.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caverna_risonante"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "chioma_parassita_canopica": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.chioma_parassita_canopica.debolezza",
+      "famiglia_tipologia": "Simbiotico/Utility",
+      "fattore_mantenimento_energetico": "Medio (Nutrimento condiviso con l'ospite arboreo)",
+      "id": "chioma_parassita_canopica",
+      "label": "i18n:traits.chioma_parassita_canopica.label",
+      "mutazione_indotta": "i18n:traits.chioma_parassita_canopica.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopie_sospese"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Foreste verticali multilivello con alberi levitanti e liane sensibili.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "bulbi_radici_permafrost",
+        "nodi_micorrizici_oracolari"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "utility",
+        "core": "simbiotico"
+      },
+      "spinta_selettiva": "i18n:traits.chioma_parassita_canopica.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.chioma_parassita_canopica.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "canopie_sospese"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "ciste_salmastre": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.ciste_salmastre.debolezza",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ciste_salmastre",
+      "label": "i18n:traits.ciste_salmastre.label",
+      "mutazione_indotta": "i18n:traits.ciste_salmastre.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianura_salina_iperarida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ciste Salmastre ottimizza le operazioni simbiotico nelle condizioni di pianura salina iperarida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "spinta_selettiva": "i18n:traits.ciste_salmastre.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.ciste_salmastre.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "pianura_salina_iperarida"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "coralli_partner": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.coralli_partner.debolezza",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "coralli_partner",
+      "label": "i18n:traits.coralli_partner.label",
+      "mutazione_indotta": "i18n:traits.coralli_partner.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "reef_luminescente"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Coralli Partner ottimizza le operazioni simbiotico nelle condizioni di reef luminescente.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "spinta_selettiva": "i18n:traits.coralli_partner.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.coralli_partner.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "reef_luminescente"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "denti_silice_termici": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.denti_silice_termici.debolezza",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "denti_silice_termici",
+      "label": "i18n:traits.denti_silice_termici.label",
+      "mutazione_indotta": "i18n:traits.denti_silice_termici.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dorsale_termale_tropicale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Denti Silice Termici ottimizza le operazioni simbiotico nelle condizioni di dorsale termale tropicale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "spinta_selettiva": "i18n:traits.denti_silice_termici.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.denti_silice_termici.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "dorsale_termale_tropicale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "epitelio_fosforescente": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.epitelio_fosforescente.debolezza",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "epitelio_fosforescente",
+      "label": "i18n:traits.epitelio_fosforescente.label",
+      "mutazione_indotta": "i18n:traits.epitelio_fosforescente.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "reef_luminescente"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Epitelio Fosforescente ottimizza le operazioni simbiotico nelle condizioni di reef luminescente.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "spinta_selettiva": "i18n:traits.epitelio_fosforescente.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.epitelio_fosforescente.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "reef_luminescente"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "ghiandole_cambio_salino": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.ghiandole_cambio_salino.debolezza",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_cambio_salino",
+      "label": "i18n:traits.ghiandole_cambio_salino.label",
+      "mutazione_indotta": "i18n:traits.ghiandole_cambio_salino.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "laguna_bioreattiva"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Cambio Salino ottimizza le operazioni simbiotico nelle condizioni di laguna bioreattiva.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "spinta_selettiva": "i18n:traits.ghiandole_cambio_salino.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.ghiandole_cambio_salino.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "laguna_bioreattiva"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "ghiandole_nebbia_acida": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.ghiandole_nebbia_acida.debolezza",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_nebbia_acida",
+      "label": "i18n:traits.ghiandole_nebbia_acida.label",
+      "mutazione_indotta": "i18n:traits.ghiandole_nebbia_acida.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_acida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Nebbia Acida ottimizza le operazioni simbiotico nelle condizioni di foresta acida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "spinta_selettiva": "i18n:traits.ghiandole_nebbia_acida.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.ghiandole_nebbia_acida.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "foresta_acida"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "lamelle_sincroniche": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.lamelle_sincroniche.debolezza",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "lamelle_sincroniche",
+      "label": "i18n:traits.lamelle_sincroniche.label",
+      "mutazione_indotta": "i18n:traits.lamelle_sincroniche.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "steppe_algoritmiche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Lamelle Sincroniche ottimizza le operazioni simbiotico nelle condizioni di steppe algoritmiche.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "spinta_selettiva": "i18n:traits.lamelle_sincroniche.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.lamelle_sincroniche.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "steppe_algoritmiche"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "membrane_planata_vectored": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.membrane_planata_vectored.debolezza",
+      "famiglia_tipologia": "Simbiotico/Cooperativo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "membrane_planata_vectored",
+      "label": "i18n:traits.membrane_planata_vectored.label",
+      "mutazione_indotta": "i18n:traits.membrane_planata_vectored.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_ionica"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Membrane Planata Vectored ottimizza le operazioni simbiotico nelle condizioni di canopia ionica.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "mucillagine_simbionte_mangrovie",
+        "nodi_micorrizici_oracolari"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "cooperazione",
+        "core": "simbiotico"
+      },
+      "spinta_selettiva": "i18n:traits.membrane_planata_vectored.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.membrane_planata_vectored.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "canopia_ionica"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "mucillagine_simbionte_mangrovie": {
+      "conflitti": [
+        "ghiandola_caustica"
+      ],
+      "debolezza": "i18n:traits.mucillagine_simbionte_mangrovie.debolezza",
+      "famiglia_tipologia": "Simbiotico/Difensivo",
+      "fattore_mantenimento_energetico": "Medio (Coltura simbiotica costante)",
+      "id": "mucillagine_simbionte_mangrovie",
+      "label": "i18n:traits.mucillagine_simbionte_mangrovie.label",
+      "mutazione_indotta": "i18n:traits.mucillagine_simbionte_mangrovie.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "mangrovie_risonanti"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Foreste di mangrovie ipersature dove le radici cantano frequenze psioniche.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "antenne_reagenti",
+        "artigli_scivolo_silente",
+        "biofilm_iperarido",
+        "branchie_osmotiche_salmastra",
+        "camere_nutrienti_vent",
+        "cartilagini_flessoacustiche",
+        "circolazione_bifasica_palude",
+        "ciste_salmastre",
+        "coralli_partner",
+        "denti_silice_termici",
+        "epitelio_fosforescente",
+        "ghiandole_cambio_salino",
+        "ghiandole_nebbia_acida",
+        "lamelle_sincroniche",
+        "membrane_planata_vectored",
+        "nodi_micorrizici_oracolari"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "difensivo",
+        "core": "simbiotico"
+      },
+      "spinta_selettiva": "i18n:traits.mucillagine_simbionte_mangrovie.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.mucillagine_simbionte_mangrovie.uso_funzione",
+      "usage_tags": [
+        "support",
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "mangrovie_risonanti"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "nodi_micorrizici_oracolari": {
+      "conflitti": [
+        "spore_psichiche_silenziate"
+      ],
+      "debolezza": "i18n:traits.nodi_micorrizici_oracolari.debolezza",
+      "famiglia_tipologia": "Simbiotico/Nervoso",
+      "fattore_mantenimento_energetico": "Medio (Scambio continuo di segnali con simbionti)",
+      "id": "nodi_micorrizici_oracolari",
+      "label": "i18n:traits.nodi_micorrizici_oracolari.label",
+      "mutazione_indotta": "i18n:traits.nodi_micorrizici_oracolari.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "reti_micorriziche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Sottoboschi viventi con reti fungine coscienti che emettono segnali premonitori.",
+            "tier": "T3"
+          }
+        }
+      ],
+      "sinergie": [
+        "antenne_reagenti",
+        "artigli_scivolo_silente",
+        "biofilm_iperarido",
+        "bulbi_radici_permafrost",
+        "camere_nutrienti_vent",
+        "cartilagini_flessoacustiche",
+        "chioma_parassita_canopica",
+        "ciste_salmastre",
+        "coralli_partner",
+        "denti_silice_termici",
+        "epitelio_fosforescente",
+        "ghiandole_cambio_salino",
+        "ghiandole_nebbia_acida",
+        "lamelle_sincroniche",
+        "membrane_planata_vectored",
+        "mucillagine_simbionte_mangrovie"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "nervoso",
+        "core": "simbiotico"
+      },
+      "spinta_selettiva": "i18n:traits.nodi_micorrizici_oracolari.spinta_selettiva",
+      "tier": "T3",
+      "uso_funzione": "i18n:traits.nodi_micorrizici_oracolari.uso_funzione",
+      "usage_tags": [
+        "controller",
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "reti_micorriziche"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "sacche_spore_stratosferiche": {
+      "conflitti": [
+        "respiro_a_scoppio"
+      ],
+      "debolezza": "i18n:traits.sacche_spore_stratosferiche.debolezza",
+      "famiglia_tipologia": "Simbiotico/Supporto",
+      "fattore_mantenimento_energetico": "Alto (Coltura continua di spore portanti)",
+      "id": "sacche_spore_stratosferiche",
+      "label": "i18n:traits.sacche_spore_stratosferiche.label",
+      "mutazione_indotta": "i18n:traits.sacche_spore_stratosferiche.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "stratosfera_portante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Correnti ascendenti permanenti che trasportano semi e spore su larga scala.",
+            "tier": "T3"
+          }
+        }
+      ],
+      "sinergie": [
+        "piume_solari_fotovoltaiche"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "supporto",
+        "core": "simbiotico"
+      },
+      "spinta_selettiva": "i18n:traits.sacche_spore_stratosferiche.spinta_selettiva",
+      "tier": "T3",
+      "uso_funzione": "i18n:traits.sacche_spore_stratosferiche.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "stratosfera_portante"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "sinapsi_coraline_polifoniche": {
+      "conflitti": [
+        "spore_psichiche_silenziate"
+      ],
+      "debolezza": "i18n:traits.sinapsi_coraline_polifoniche.debolezza",
+      "famiglia_tipologia": "Simbiotico/Comunicazione",
+      "fattore_mantenimento_energetico": "Medio (Scambio continuo di impulsi corallini)",
+      "id": "sinapsi_coraline_polifoniche",
+      "label": "i18n:traits.sinapsi_coraline_polifoniche.label",
+      "mutazione_indotta": "i18n:traits.sinapsi_coraline_polifoniche.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "barriere_coralline_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Scogliere viventi che rispondono a canti psionici e onde sonore.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "sinergie": [
+        "ali_fulminee",
+        "antenne_plasmatiche_tempesta",
+        "antenne_waveguide",
+        "baffi_mareomotori",
+        "branchie_eoliche",
+        "capillari_fluoridici",
+        "carapace_luminiscente_abissale",
+        "cervelletto_equilibrio_statico",
+        "coda_balanciere",
+        "cuore_multicamera_bassa_pressione",
+        "echi_risonanti",
+        "filamenti_superconduttivi",
+        "ghiandole_eco_mappanti",
+        "ghiandole_resina_conduttiva",
+        "lamine_scudo_silice",
+        "midollo_antivibrazione"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "comunicazione",
+        "core": "simbiotico"
+      },
+      "spinta_selettiva": "i18n:traits.sinapsi_coraline_polifoniche.spinta_selettiva",
+      "tier": "T2",
+      "uso_funzione": "i18n:traits.sinapsi_coraline_polifoniche.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "barriere_coralline_psioniche"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "antenne_microonde_cavernose": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.antenne_microonde_cavernose.debolezza",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "antenne_microonde_cavernose",
+      "label": "i18n:traits.antenne_microonde_cavernose.label",
+      "mutazione_indotta": "i18n:traits.antenne_microonde_cavernose.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Antenne Microonde Cavernose ottimizza le operazioni strategia nelle condizioni di caverna risonante.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "spinta_selettiva": "i18n:traits.antenne_microonde_cavernose.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.antenne_microonde_cavernose.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caverna_risonante"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "artigli_radice": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.artigli_radice.debolezza",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "artigli_radice",
+      "label": "i18n:traits.artigli_radice.label",
+      "mutazione_indotta": "i18n:traits.artigli_radice.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "mangrovieto_cinetico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Artigli Radice ottimizza le operazioni strategia nelle condizioni di mangrovieto cinetico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "spinta_selettiva": "i18n:traits.artigli_radice.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.artigli_radice.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "mangrovieto_cinetico"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "biofilm_glow": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.biofilm_glow.debolezza",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "biofilm_glow",
+      "label": "i18n:traits.biofilm_glow.label",
+      "mutazione_indotta": "i18n:traits.biofilm_glow.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "reef_luminescente"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Biofilm Glow ottimizza le operazioni strategia nelle condizioni di reef luminescente.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "spinta_selettiva": "i18n:traits.biofilm_glow.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.biofilm_glow.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "reef_luminescente"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "camere_mirage": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.camere_mirage.debolezza",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "camere_mirage",
+      "label": "i18n:traits.camere_mirage.label",
+      "mutazione_indotta": "i18n:traits.camere_mirage.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianura_salina_iperarida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Camere Mirage ottimizza le operazioni strategia nelle condizioni di pianura salina iperarida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "spinta_selettiva": "i18n:traits.camere_mirage.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.camere_mirage.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "pianura_salina_iperarida"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "cartilagini_desertiche": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.cartilagini_desertiche.debolezza",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "cartilagini_desertiche",
+      "label": "i18n:traits.cartilagini_desertiche.label",
+      "mutazione_indotta": "i18n:traits.cartilagini_desertiche.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianura_salina_iperarida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Cartilagini Desertiche ottimizza le operazioni strategia nelle condizioni di pianura salina iperarida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "spinta_selettiva": "i18n:traits.cartilagini_desertiche.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.cartilagini_desertiche.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "pianura_salina_iperarida"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "ciste_riduttive": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.ciste_riduttive.debolezza",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ciste_riduttive",
+      "label": "i18n:traits.ciste_riduttive.label",
+      "mutazione_indotta": "i18n:traits.ciste_riduttive.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "laguna_bioreattiva"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ciste Riduttive ottimizza le operazioni strategia nelle condizioni di laguna bioreattiva.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "spinta_selettiva": "i18n:traits.ciste_riduttive.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.ciste_riduttive.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "laguna_bioreattiva"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "colonne_vibromagnetiche": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.colonne_vibromagnetiche.debolezza",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "colonne_vibromagnetiche",
+      "label": "i18n:traits.colonne_vibromagnetiche.label",
+      "mutazione_indotta": "i18n:traits.colonne_vibromagnetiche.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Colonne Vibromagnetiche ottimizza le operazioni strategia nelle condizioni di caverna risonante.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "spinta_selettiva": "i18n:traits.colonne_vibromagnetiche.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.colonne_vibromagnetiche.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caverna_risonante"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "denti_ossidoferro": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.denti_ossidoferro.debolezza",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "denti_ossidoferro",
+      "label": "i18n:traits.denti_ossidoferro.label",
+      "mutazione_indotta": "i18n:traits.denti_ossidoferro.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_vulcanico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Denti Ossidoferro ottimizza le operazioni strategia nelle condizioni di abisso vulcanico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "spinta_selettiva": "i18n:traits.denti_ossidoferro.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.denti_ossidoferro.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "abisso_vulcanico"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "epidermide_dielettrica": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.epidermide_dielettrica.debolezza",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "epidermide_dielettrica",
+      "label": "i18n:traits.epidermide_dielettrica.label",
+      "mutazione_indotta": "i18n:traits.epidermide_dielettrica.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "stratosfera_tempestosa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Epidermide Dielettrica ottimizza le operazioni strategia nelle condizioni di stratosfera tempestosa.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "spinta_selettiva": "i18n:traits.epidermide_dielettrica.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.epidermide_dielettrica.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "stratosfera_tempestosa"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "focus_frazionato": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.focus_frazionato.debolezza",
+      "famiglia_tipologia": "Strategico/Psionico",
+      "fattore_mantenimento_energetico": "Medio (Dividere l'attenzione su più canali)",
+      "id": "focus_frazionato",
+      "label": "i18n:traits.focus_frazionato.label",
+      "mutazione_indotta": "i18n:traits.focus_frazionato.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_miceliale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "tier": "T1",
+            "notes": "Il multitasking mentale nasce dalla gestione di molteplici minacce ravvicinate nelle foreste miceliali fitte."
+          }
+        }
+      ],
+      "sinergie": [
+        "ali_fulminee",
+        "antenne_plasmatiche_tempesta",
+        "antenne_waveguide",
+        "baffi_mareomotori",
+        "branchie_eoliche",
+        "capillari_fluoridici",
+        "cervelletto_equilibrio_statico",
+        "coda_balanciere",
+        "cuore_multicamera_bassa_pressione",
+        "echi_risonanti",
+        "filamenti_superconduttivi",
+        "ghiandole_eco_mappanti",
+        "ghiandole_resina_conduttiva",
+        "lamine_scudo_silice",
+        "midollo_antivibrazione",
+        "frusta_fiammeggiante"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "PE",
+          "cap_pt",
+          "job_ability:invoker/sincronia",
+          "sigillo_forma",
+          "starter_bioma"
+        ],
+        "combo_totale": 3,
+        "forme": [
+          "ENTP",
+          "INFJ",
+          "INTP"
+        ],
+        "tabelle_random": []
+      },
+      "slot": [
+        "A",
+        "C"
+      ],
+      "slot_profile": {
+        "complementare": "psionico",
+        "core": "strategia"
+      },
+      "spinta_selettiva": "i18n:traits.focus_frazionato.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.focus_frazionato.uso_funzione",
+      "usage_tags": [
+        "controller",
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "foresta_miceliale"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "ghiaccio_piezoelettrico": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.ghiaccio_piezoelettrico.debolezza",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiaccio_piezoelettrico",
+      "label": "i18n:traits.ghiaccio_piezoelettrico.label",
+      "mutazione_indotta": "i18n:traits.ghiaccio_piezoelettrico.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiaccio Piezoelettrico ottimizza le operazioni strategia nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "spinta_selettiva": "i18n:traits.ghiaccio_piezoelettrico.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.ghiaccio_piezoelettrico.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caldera_glaciale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "ghiandole_minerali": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.ghiandole_minerali.debolezza",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_minerali",
+      "label": "i18n:traits.ghiandole_minerali.label",
+      "mutazione_indotta": "i18n:traits.ghiandole_minerali.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dorsale_termale_tropicale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Minerali ottimizza le operazioni strategia nelle condizioni di dorsale termale tropicale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "spinta_selettiva": "i18n:traits.ghiandole_minerali.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.ghiandole_minerali.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "dorsale_termale_tropicale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "lamelle_shear": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.lamelle_shear.debolezza",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "lamelle_shear",
+      "label": "i18n:traits.lamelle_shear.label",
+      "mutazione_indotta": "i18n:traits.lamelle_shear.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "stratosfera_tempestosa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Lamelle Shear ottimizza le operazioni strategia nelle condizioni di stratosfera tempestosa.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "spinta_selettiva": "i18n:traits.lamelle_shear.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.lamelle_shear.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "stratosfera_tempestosa"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "membrane_captura_rugiada": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.membrane_captura_rugiada.debolezza",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "membrane_captura_rugiada",
+      "label": "i18n:traits.membrane_captura_rugiada.label",
+      "mutazione_indotta": "i18n:traits.membrane_captura_rugiada.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianura_salina_iperarida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Membrane Captura Rugiada ottimizza le operazioni strategia nelle condizioni di pianura salina iperarida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "pianificatore",
+        "tattiche_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "spinta_selettiva": "i18n:traits.membrane_captura_rugiada.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.membrane_captura_rugiada.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "pianura_salina_iperarida"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "pathfinder": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.pathfinder.debolezza",
+      "famiglia_tipologia": "Esplorazione/Tattico",
+      "fattore_mantenimento_energetico": "Basso (Sincronizzazione con HUD di esplorazione)",
+      "id": "pathfinder",
+      "label": "i18n:traits.pathfinder.label",
+      "mutazione_indotta": "i18n:traits.pathfinder.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_miceliale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "tier": "T1",
+            "notes": "Ottimizzato per seguire gallerie e radici intrecciate tipiche dei biomi miceliali, evitando sacche di spore."
+          }
+        }
+      ],
+      "sinergie": [
+        "antenne_microonde_cavernose",
+        "biofilm_glow",
+        "camere_mirage",
+        "colonne_vibromagnetiche",
+        "membrane_captura_rugiada",
+        "ghiaccio_piezoelettrico"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "PE",
+          "cap_pt",
+          "starter_bioma",
+          "guardia_situazionale"
+        ],
+        "combo_totale": 3,
+        "forme": [
+          "ENFP",
+          "ESTP",
+          "ISTP"
+        ],
+        "tabelle_random": []
+      },
+      "slot": [
+        "A"
+      ],
+      "slot_profile": {
+        "complementare": "ricognizione",
+        "core": "strategia"
+      },
+      "biome_tags": [
+        "foresta_acida",
+        "foresta_miceliale"
+      ],
+      "usage_tags": [
+        "scout",
+        "support"
+      ],
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "roles": [
+            "core"
+          ],
+          "species_id": "psionic-canopy-scout",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "sentinella-radice",
+          "weight": 1
+        }
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": true,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "spinta_selettiva": "i18n:traits.pathfinder.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.pathfinder.uso_funzione"
+    },
+    "pianificatore": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.pianificatore.debolezza",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Medio (Analisi continua di stato squadre)",
+      "id": "pianificatore",
+      "label": "i18n:traits.pianificatore.label",
+      "mutazione_indotta": "i18n:traits.pianificatore.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_miceliale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "tier": "T1",
+            "notes": "La pianificazione si basa su percorsi nascosti del sottobosco miceliale e su riserve condivise."
+          }
+        }
+      ],
+      "sinergie": [
+        "antenne_microonde_cavernose",
+        "artigli_radice",
+        "biofilm_glow",
+        "camere_mirage",
+        "cartilagini_desertiche",
+        "ciste_riduttive",
+        "colonne_vibromagnetiche",
+        "denti_ossidoferro",
+        "epidermide_dielettrica",
+        "ghiaccio_piezoelettrico",
+        "ghiandole_minerali",
+        "lamelle_shear",
+        "membrane_captura_rugiada"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "PE",
+          "cap_pt",
+          "guardia_situazionale",
+          "sigillo_forma",
+          "starter_bioma"
+        ],
+        "combo_totale": 6,
+        "forme": [
+          "ENTJ",
+          "ENTP",
+          "ESTJ",
+          "INTJ",
+          "ISTJ"
+        ],
+        "tabelle_random": []
+      },
+      "slot": [
+        "A",
+        "C"
+      ],
+      "slot_profile": {
+        "complementare": "tattico",
+        "core": "strategia"
+      },
+      "spinta_selettiva": "i18n:traits.pianificatore.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.pianificatore.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "foresta_miceliale"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "random": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.random.debolezza",
+      "famiglia_tipologia": "Flessibile/Generico",
+      "fattore_mantenimento_energetico": "Variabile (Dipende dal tratto estratto)",
+      "id": "random",
+      "label": "i18n:traits.random.label",
+      "mutazione_indotta": "i18n:traits.random.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_miceliale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "tier": "T1",
+            "notes": "Gli schemi imprevedibili confondono predatori che si affidano a tracce nel tappeto miceliale."
+          }
+        }
+      ],
+      "sinergie": [
+        "pianificatore",
+        "focus_frazionato",
+        "tattiche_di_branco",
+        "camere_mirage",
+        "biofilm_glow",
+        "colonne_vibromagnetiche"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "cap_pt",
+          "guardia_situazionale",
+          "job_ability:random",
+          "starter_bioma"
+        ],
+        "combo_totale": 3,
+        "forme": [
+          "ENFP",
+          "ENTP",
+          "ISTP"
+        ],
+        "tabelle_random": []
+      },
+      "slot": [
+        "A",
+        "B"
+      ],
+      "slot_profile": {
+        "complementare": "adattivo",
+        "core": "strategia"
+      },
+      "usage_tags": [
+        "support",
+        "tank"
+      ],
       "species_affinity": [
         {
           "roles": [
             "optional"
           ],
-          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "species_id": "sentinella-radice",
           "weight": 1
+        },
+        {
+          "roles": [
+            "synergy"
+          ],
+          "species_id": "psionic-canopy-scout",
+          "weight": 3
+        },
+        {
+          "roles": [
+            "optional"
+          ],
+          "species_id": "orbital-ascendant",
+          "weight": 2
         }
       ],
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "spinta_selettiva": "i18n:traits.random.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.random.uso_funzione",
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": true,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "foresta_miceliale"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "tattiche_di_branco": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.tattiche_di_branco.debolezza",
+      "famiglia_tipologia": "Strategico/Tattico",
+      "fattore_mantenimento_energetico": "Medio (Broadcast continuo di segnali)",
+      "id": "tattiche_di_branco",
+      "label": "i18n:traits.tattiche_di_branco.label",
+      "mutazione_indotta": "i18n:traits.tattiche_di_branco.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_miceliale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "tier": "T1",
+            "notes": "Coordinazione pensata per spazi chiusi e visibilità ridotta delle foreste miceliali, con segnali tattili."
+          }
+        }
+      ],
+      "sinergie": [
+        "antenne_microonde_cavernose",
+        "artigli_radice",
+        "artigli_sette_vie",
+        "biofilm_glow",
+        "camere_mirage",
+        "cartilagini_desertiche",
+        "ciste_riduttive",
+        "colonne_vibromagnetiche",
+        "denti_ossidoferro",
+        "epidermide_dielettrica",
+        "ghiaccio_piezoelettrico",
+        "ghiandole_minerali",
+        "lamelle_shear",
+        "membrane_captura_rugiada"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [
+          "PE",
+          "cap_pt",
+          "guardia_situazionale",
+          "sigillo_forma",
+          "starter_bioma"
+        ],
+        "combo_totale": 2,
+        "forme": [
+          "ESFJ",
+          "ESFP"
+        ],
+        "tabelle_random": []
+      },
+      "slot": [
+        "B"
+      ],
+      "slot_profile": {
+        "complementare": "coordinazione",
+        "core": "strategia"
+      },
+      "spinta_selettiva": "i18n:traits.tattiche_di_branco.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.tattiche_di_branco.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "foresta_miceliale"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "antenne_tesla": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.antenne_tesla.debolezza",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "antenne_tesla",
+      "label": "i18n:traits.antenne_tesla.label",
+      "mutazione_indotta": "i18n:traits.antenne_tesla.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_ionica"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Antenne Tesla ottimizza le operazioni strutturale nelle condizioni di canopia ionica.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "strutturale"
+      },
+      "spinta_selettiva": "i18n:traits.antenne_tesla.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.antenne_tesla.uso_funzione",
       "usage_tags": [
         "tank"
       ],
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
-    },
-    "carapace_fase_variabile": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
+      "biome_tags": [
+        "canopia_ionica"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "artigli_vetrificati": {
       "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Debolezza strutturale durante la transizione tra le fasi di durezza.",
+      "debolezza": "i18n:traits.artigli_vetrificati.debolezza",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "artigli_vetrificati",
+      "label": "i18n:traits.artigli_vetrificati.label",
+      "mutazione_indotta": "i18n:traits.artigli_vetrificati.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Artigli Vetrificati ottimizza le operazioni strutturale nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "strutturale"
+      },
+      "spinta_selettiva": "i18n:traits.artigli_vetrificati.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.artigli_vetrificati.uso_funzione",
+      "usage_tags": [
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caldera_glaciale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "branchie_dual_mode": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.branchie_dual_mode.debolezza",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "branchie_dual_mode",
+      "label": "i18n:traits.branchie_dual_mode.label",
+      "mutazione_indotta": "i18n:traits.branchie_dual_mode.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "laguna_bioreattiva"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Branchie Dual Mode ottimizza le operazioni strutturale nelle condizioni di laguna bioreattiva.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "strutturale"
+      },
+      "spinta_selettiva": "i18n:traits.branchie_dual_mode.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.branchie_dual_mode.uso_funzione",
+      "usage_tags": [
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "laguna_bioreattiva"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "capillari_criogenici": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.capillari_criogenici.debolezza",
+      "famiglia_tipologia": "Strutturale/Adattivo",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "capillari_criogenici",
+      "label": "i18n:traits.capillari_criogenici.label",
+      "mutazione_indotta": "i18n:traits.capillari_criogenici.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Capillari Criogenici ottimizza le operazioni strutturale nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "resilienza",
+        "core": "strutturale"
+      },
+      "spinta_selettiva": "i18n:traits.capillari_criogenici.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.capillari_criogenici.uso_funzione",
+      "usage_tags": [
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caldera_glaciale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "carapace_fase_variabile": {
+      "conflitti": [
+        "struttura_elastica_amorfa"
+      ],
+      "debolezza": "i18n:traits.carapace_fase_variabile.debolezza",
       "famiglia_tipologia": "Strutturale/Difensivo",
       "fattore_mantenimento_energetico": "Alto (Richiede energia per il cambio di fase)",
       "id": "carapace_fase_variabile",
-      "label": "Carapace a Variazione di Fase",
-      "mutazione_indotta": "Strutture minerali a legame reversibile o micro-strutture a rigidità controllata.",
+      "label": "i18n:traits.carapace_fase_variabile.label",
+      "mutazione_indotta": "i18n:traits.carapace_fase_variabile.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -2943,7 +12183,7 @@
           "meta": {
             "expansion": "controllo_psionico",
             "notes": "Percorso T2 che aggiunge gradienti magnetici per pattern cromatici complessi.",
-            "tier": "T2"
+            "tier": "T1"
           }
         }
       ],
@@ -2987,93 +12227,34 @@
         "complementare": "difensivo",
         "core": "strutturale"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "balor-fission",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "bulette-fase",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "canopia-psionica-leggera-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "cryo-lynx",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "falde-magnetiche-psioniche-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "golem-runico",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "nano-rust-bloom",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "otyugh-sentinella",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "sand-burrower",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Alternanza tra ambienti con attacchi cinetici pesanti e ambienti che richiedono velocità.",
+      "spinta_selettiva": "i18n:traits.carapace_fase_variabile.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.carapace_fase_variabile.uso_funzione",
       "usage_tags": [
         "tank"
       ],
-      "uso_funzione": "Durezza/densità del guscio modificabile rapidamente."
-    },
-    "carapace_luminiscente_abissale": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Luce intensa di superficie sovraccarica i biofotoni rendendo la corazza fragile.",
+      "biome_tags": [
+        "canopia_psionica_leggera",
+        "falde_magnetiche_psioniche"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "carapace_luminiscente_abissale": {
+      "conflitti": [
+        "carapace_fase_variabile"
+      ],
+      "debolezza": "i18n:traits.carapace_luminiscente_abissale.debolezza",
       "famiglia_tipologia": "Strutturale/Sensoriale",
       "fattore_mantenimento_energetico": "Alto (Bioluminescenza controllata)",
       "id": "carapace_luminiscente_abissale",
-      "label": "Carapace Luminiscente Abissale",
-      "mutazione_indotta": "Placche chitino-minerali con microrganismi luminescenti che comunicano in pattern.",
+      "label": "i18n:traits.carapace_luminiscente_abissale.label",
+      "mutazione_indotta": "i18n:traits.carapace_luminiscente_abissale.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3083,7 +12264,8 @@
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Gole oceaniche illuminate da coralli psionici e scariche elettrostatiche."
+            "notes": "Gole oceaniche illuminate da coralli psionici e scariche elettrostatiche.",
+            "tier": "T3"
           }
         }
       ],
@@ -3112,408 +12294,32 @@
         "complementare": "sensoriale",
         "core": "strutturale"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "abisso-luminescente-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Comunicare e mimetizzarsi nelle profondità prive di luce naturale.",
+      "spinta_selettiva": "i18n:traits.carapace_luminiscente_abissale.spinta_selettiva",
       "tier": "T3",
+      "uso_funzione": "i18n:traits.carapace_luminiscente_abissale.uso_funzione",
       "usage_tags": [
         "scout",
         "tank"
       ],
-      "uso_funzione": "Emette segnali di branco e devia attacchi grazie a pattern luminosi cangianti."
-    },
-    "carapace_segmenti_logici": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "carapace_segmenti_logici",
-      "label": "Carapace Segmenti Logici",
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "steppe_algoritmiche"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Carapace Segmenti Logici ottimizza le operazioni metabolico nelle condizioni di steppe algoritmiche.",
-            "tier": "T1"
-          }
-        }
+      "biome_tags": [
+        "abisso_luminescente"
       ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "steppe-algoritmiche-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "tier": "T1",
-      "usage_tags": [
-        "sustain"
-      ],
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
-    },
-    "carapaci_ferruginosi": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "carapaci_ferruginosi",
-      "label": "Carapaci Ferruginosi",
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "abisso_vulcanico"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Carapaci Ferruginosi ottimizza le operazioni supporto nelle condizioni di abisso vulcanico.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "abisso-vulcanico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
-    },
-    "cartilagine_flessotermica_venti": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Temperature stabili riducono la reattività della cartilagine rendendo l'organismo lento.",
-      "famiglia_tipologia": "Locomotorio/Adattivo",
-      "fattore_mantenimento_energetico": "Medio (Richiede frequenti riallineamenti fibrosi)",
-      "id": "cartilagine_flessotermica_venti",
-      "label": "Cartilagine Flessotermica dei Venti",
-      "mutazione_indotta": "Giunzioni cartilaginee che cambiano rigidità in risposta a gradienti termici e eolici.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "gole_ventose"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Canyon sospesi dove venti caldi e freddi si alternano in pattern ciclici."
-          }
-        }
-      ],
-      "sinergie": [
-        "artigli_sghiaccio_glaciale",
-        "carapace_fase_variabile",
-        "sacche_galleggianti_ascensoriali",
-        "zoccoli_risonanti_steppe"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [
-          "boardgame:DominantSpecies/Wind",
-          "boardgame:Evolution/Flight",
-          "hud:VentSplice_Halo"
-        ],
-        "combo_totale": 3,
-        "forme": [
-          "Forma:Planatore_Psionico"
-        ],
-        "tabelle_random": [
-          "tabella:assetto_eolico"
-        ]
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "adattivo",
-        "core": "locomotorio"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "gole-ventose-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Scalare falesie e planare tra correnti ascensionali turbolente.",
-      "tier": "T2",
-      "usage_tags": [
-        "scout",
-        "tank"
-      ],
-      "uso_funzione": "Modula elasticità e rigidità muscolo-scheletrica per manovre evasive rapide."
-    },
-    "cartilagini_biofibre": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "cartilagini_biofibre",
-      "label": "Cartilagini Biofibre",
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "reef_luminescente"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Cartilagini Biofibre ottimizza le operazioni offensivo nelle condizioni di reef luminescente.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "reef-luminescente-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "tier": "T1",
-      "usage_tags": [
-        "breaker"
-      ],
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
-    },
-    "cartilagini_desertiche": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "cartilagini_desertiche",
-      "label": "Cartilagini Desertiche",
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "pianura_salina_iperarida"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Cartilagini Desertiche ottimizza le operazioni strategia nelle condizioni di pianura salina iperarida.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "pianura-salina-iperarida-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
-    },
-    "cartilagini_flessoacustiche": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "cartilagini_flessoacustiche",
-      "label": "Cartilagini Flessoacustiche",
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caverna_risonante"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Cartilagini Flessoacustiche ottimizza le operazioni simbiotico nelle condizioni di caverna risonante.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caverna-risonante-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+      "data_origin": "controllo_psionico"
     },
     "cartilagini_pseudometalliche": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
       "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "debolezza": "i18n:traits.cartilagini_pseudometalliche.debolezza",
       "famiglia_tipologia": "Strutturale/Adattivo",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "id": "cartilagini_pseudometalliche",
-      "label": "Cartilagini Pseudometalliche",
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "label": "i18n:traits.cartilagini_pseudometalliche.label",
+      "mutazione_indotta": "i18n:traits.cartilagini_pseudometalliche.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -3543,708 +12349,31 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "abisso-vulcanico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "spinta_selettiva": "i18n:traits.cartilagini_pseudometalliche.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.cartilagini_pseudometalliche.uso_funzione",
       "usage_tags": [
         "tank"
       ],
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
-    },
-    "cavita_risonanti_tundra": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "In ambienti temperati l'eco interna produce rumori udibili che rivelano la posizione.",
-      "famiglia_tipologia": "Sensoriale/Supporto",
-      "fattore_mantenimento_energetico": "Basso (Camere di risonanza statiche)",
-      "id": "cavita_risonanti_tundra",
-      "label": "Cavità Risonanti della Tundra",
-      "mutazione_indotta": "Camere toraciche espanse che amplificano vibrazioni subsoniche nel permafrost.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "tundra_risonante"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Steppe gelate che trasmettono vibrazioni psioniche a chilometri di distanza."
-          }
-        }
+      "biome_tags": [
+        "abisso_vulcanico"
       ],
-      "sinergie": [
-        "criostasi_adattiva",
-        "eco_interno_riflesso",
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [
-          "boardgame:Evolution/Communication",
-          "boardgame:DominantSpecies/Initiative",
-          "hud:TundraPulse"
-        ],
-        "combo_totale": 3,
-        "forme": [
-          "Forma:Cantore_Tundra",
-          "HUD:EchoGrid"
-        ],
-        "tabelle_random": [
-          "tabella:canti_ipersonici"
-        ]
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "supporto",
-        "core": "sensoriale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "tundra-risonante-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Coordinare branchi in lande aperte dove la visibilità è ridotta da bufere di ghiaccio.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout",
-        "support"
-      ],
-      "uso_funzione": "Amplifica segnali acustici per comunicazioni a lungo raggio nel gelo."
-    },
-    "cervelletto_equilibrio_statico": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "cervelletto_equilibrio_statico",
-      "label": "Cervelletto Equilibrio Statico",
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "canopia_ionica"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Cervelletto Equilibrio Statico ottimizza le operazioni sensoriale nelle condizioni di canopia ionica.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "canopia-ionica-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout",
-        "support"
-      ],
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
-    },
-    "chemiorecettori_bromuro": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "chemiorecettori_bromuro",
-      "label": "Chemiorecettori Bromuro",
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "pianura_salina_iperarida"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Chemiorecettori Bromuro ottimizza le operazioni locomotorio nelle condizioni di pianura salina iperarida.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "pianura-salina-iperarida-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout"
-      ],
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
-    },
-    "chioma_parassita_canopica": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Se la pianta ospite muore la chioma psionica collassa causando shock sistemico.",
-      "famiglia_tipologia": "Simbiotico/Utility",
-      "fattore_mantenimento_energetico": "Medio (Nutrimento condiviso con l'ospite arboreo)",
-      "id": "chioma_parassita_canopica",
-      "label": "Chioma Parassita Canopica",
-      "mutazione_indotta": "Filamenti vegetali che si intrecciano con la canopia ospite fornendo punti d'ancoraggio e energia.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "canopie_sospese"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Foreste verticali multilivello con alberi levitanti e liane sensibili."
-          }
-        }
-      ],
-      "sinergie": [
-        "bulbi_radici_permafrost",
-        "nodi_micorrizici_oracolari"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "utility",
-        "core": "simbiotico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "canopie-sospese-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Stabilizzare piattaforme mobili e reti di trasporto tra gli alberi viventi.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Crea passaggi e nodi energetici condivisi nella canopia per movimenti rapidi."
-    },
-    "circolazione_bifasica": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "circolazione_bifasica",
-      "label": "Circolazione Bifasica",
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caldera_glaciale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Circolazione Bifasica ottimizza le operazioni difensivo nelle condizioni di caldera glaciale.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caldera-glaciale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "tier": "T1",
-      "usage_tags": [
-        "tank"
-      ],
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
-    },
-    "circolazione_bifasica_palude": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Zone asciutte e calde causano stagnazione del circuito linfatico portando a tossicosi.",
-      "famiglia_tipologia": "Metabolico/Resilienza",
-      "fattore_mantenimento_energetico": "Medio (Doppio circuito emolinfa/linfa)",
-      "id": "circolazione_bifasica_palude",
-      "label": "Circolazione Bifasica di Palude",
-      "mutazione_indotta": "Cuori gemelli che pompano separatamente emolinfa ossigenata e linfa detossificante.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "paludi_gas_luminescenti"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Paludi bioluminescenti piene di gas nervini e batteri simbionti."
-          }
-        }
-      ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "resilienza",
-        "core": "metabolico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "paludi-gas-luminescenti-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Resistere a tossine e anossia tipiche delle paludi psioniche.",
-      "tier": "T2",
-      "usage_tags": [
-        "sustain",
-        "tank"
-      ],
-      "uso_funzione": "Gestisce due circuiti circolatori per filtrare veleni e mantenere prestazioni elevate."
-    },
-    "circolazione_cooling_loop": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "circolazione_cooling_loop",
-      "label": "Circolazione Cooling Loop",
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "steppe_algoritmiche"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Circolazione Cooling Loop ottimizza le operazioni metabolico nelle condizioni di steppe algoritmiche.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "steppe-algoritmiche-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "tier": "T1",
-      "usage_tags": [
-        "sustain"
-      ],
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
-    },
-    "circolazione_doppia": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "circolazione_doppia",
-      "label": "Circolazione Doppia",
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "dorsale_termale_tropicale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Circolazione Doppia ottimizza le operazioni supporto nelle condizioni di dorsale termale tropicale.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "dorsale-termale-tropicale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
-    },
-    "circolazione_supercritica": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "circolazione_supercritica",
-      "label": "Circolazione Supercritica",
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "abisso_vulcanico"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Circolazione Supercritica ottimizza le operazioni offensivo nelle condizioni di abisso vulcanico.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "abisso-vulcanico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "tier": "T1",
-      "usage_tags": [
-        "breaker"
-      ],
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
-    },
-    "ciste_riduttive": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "ciste_riduttive",
-      "label": "Ciste Riduttive",
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "laguna_bioreattiva"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Ciste Riduttive ottimizza le operazioni strategia nelle condizioni di laguna bioreattiva.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco",
-        "secrezione_rallentante_palmi"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "laguna-bioreattiva-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
-    },
-    "ciste_salmastre": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "ciste_salmastre",
-      "label": "Ciste Salmastre",
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "pianura_salina_iperarida"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Ciste Salmastre ottimizza le operazioni simbiotico nelle condizioni di pianura salina iperarida.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "pianura-salina-iperarida-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+      "data_origin": "coverage_q4_2025"
     },
     "cisti_iperbariche": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
       "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "debolezza": "i18n:traits.cisti_iperbariche.debolezza",
       "famiglia_tipologia": "Strutturale/Adattivo",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "id": "cisti_iperbariche",
-      "label": "Cisti Iperbariche",
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "label": "i18n:traits.cisti_iperbariche.label",
+      "mutazione_indotta": "i18n:traits.cisti_iperbariche.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -4274,759 +12403,31 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "abisso-vulcanico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "spinta_selettiva": "i18n:traits.cisti_iperbariche.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.cisti_iperbariche.uso_funzione",
       "usage_tags": [
         "tank"
       ],
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
-    },
-    "coda_balanciere": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "coda_balanciere",
-      "label": "Coda Balanciere",
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caverna_risonante"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Coda Balanciere ottimizza le operazioni sensoriale nelle condizioni di caverna risonante.",
-            "tier": "T1"
-          }
-        }
+      "biome_tags": [
+        "abisso_vulcanico"
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche",
-        "occhi_cristallo_modulare",
-        "nucleo_ovomotore_rotante"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caverna-risonante-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout",
-        "support"
-      ],
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
-    },
-    "coda_contrappeso": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "coda_contrappeso",
-      "label": "Coda Contrappeso",
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "mangrovieto_cinetico"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Coda Contrappeso ottimizza le operazioni locomotorio nelle condizioni di mangrovieto cinetico.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "mangrovieto-cinetico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout"
-      ],
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
-    },
-    "coda_coppia_retroattiva": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "coda_coppia_retroattiva",
-      "label": "Coda Coppia Retroattiva",
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "steppe_algoritmiche"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Coda Coppia Retroattiva ottimizza le operazioni difensivo nelle condizioni di steppe algoritmiche.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "steppe-algoritmiche-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "tier": "T1",
-      "usage_tags": [
-        "tank"
-      ],
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
-    },
-    "coda_frusta_cinetica": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Richiede un periodo di inattività o movimento preparatorio per massimizzare il danno.",
-      "famiglia_tipologia": "Locomotorio/Difensivo",
-      "fattore_mantenimento_energetico": "Medio (Mantenimento dell'energia accumulata)",
-      "id": "coda_frusta_cinetica",
-      "label": "Coda a Frusta Cinetica",
-      "mutazione_indotta": "Muscolatura della coda densa con tendini e fibre che agiscono come molle.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "falde_magnetiche_psioniche"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Corridore T2 per intercettare campi magnetici psionici sulle dorsali.",
-            "tier": "T2"
-          }
-        },
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "orbita_psionica_inversa"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Variante T3 calibrata alle camere di gravità invertita e ai flussi orbitali.",
-            "tier": "T3"
-          }
-        }
-      ],
-      "sinergie": [
-        "ali_ioniche",
-        "antenne_flusso_mareale",
-        "antenne_wideband",
-        "artigli_induzione",
-        "artigli_sette_vie",
-        "barbigli_sensori_plasma",
-        "biochip_memoria",
-        "branchie_metalloidi",
-        "camere_anticorrosione",
-        "capillari_fotovoltaici",
-        "cartilagini_biofibre",
-        "chemiorecettori_bromuro",
-        "circolazione_supercritica",
-        "coda_contrappeso",
-        "coda_stabilizzatrice_vortex",
-        "cuscinetti_elettrostatici",
-        "denti_chelatanti",
-        "enzimi_antifase_termica",
-        "enzimi_metanoossidanti",
-        "filamenti_termoconduzione",
-        "foliaggio_spugna",
-        "ghiandole_fango_calde",
-        "ghiandole_iodoattive",
-        "ghiandole_ventosa",
-        "gusci_magnesio",
-        "linfa_tampone",
-        "mantelli_geotermici",
-        "mucose_aderenza_sonica"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "difensivo",
-        "core": "locomotorio"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "dune-stalker",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "magneto-ridge-hunter",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "slag-veil-ambusher",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "bulette-fase",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "falde-magnetiche-psioniche-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "marilith-vault",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "orbita-psionica-inversa-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Necessità di un attacco di \"sfondamento\" dopo movimento preparatorio.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout",
-        "tank"
-      ],
-      "uso_funzione": "Immagazzinare energia da ogni movimento per un colpo finale potente."
-    },
-    "coda_stabilizzatrice_filo": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "coda_stabilizzatrice_filo",
-      "label": "Coda Stabilizzatrice Filo",
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "canopia_ionica"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Coda Stabilizzatrice Filo ottimizza le operazioni metabolico nelle condizioni di canopia ionica.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "canopia-ionica-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "tier": "T1",
-      "usage_tags": [
-        "sustain"
-      ],
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
-    },
-    "coda_stabilizzatrice_geiser": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "coda_stabilizzatrice_geiser",
-      "label": "Coda Stabilizzatrice Geiser",
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "dorsale_termale_tropicale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Coda Stabilizzatrice Geiser ottimizza le operazioni supporto nelle condizioni di dorsale termale tropicale.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "dorsale-termale-tropicale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
-    },
-    "coda_stabilizzatrice_vortex": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "coda_stabilizzatrice_vortex",
-      "label": "Coda Stabilizzatrice Vortex",
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "stratosfera_tempestosa"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Coda Stabilizzatrice Vortex ottimizza le operazioni offensivo nelle condizioni di stratosfera tempestosa.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "stratosfera-tempestosa-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "tier": "T1",
-      "usage_tags": [
-        "breaker"
-      ],
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
-    },
-    "colonne_vibromagnetiche": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "colonne_vibromagnetiche",
-      "label": "Colonne Vibromagnetiche",
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caverna_risonante"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Colonne Vibromagnetiche ottimizza le operazioni strategia nelle condizioni di caverna risonante.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco",
-        "pathfinder",
-        "random"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caverna-risonante-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
-    },
-    "coralli_partner": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "coralli_partner",
-      "label": "Coralli Partner",
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "reef_luminescente"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Coralli Partner ottimizza le operazioni simbiotico nelle condizioni di reef luminescente.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "reef-luminescente-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
-    },
-    "criostasi_adattiva": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Vulnerabilità estrema agli attacchi chimici (veleni) in fase Criostasi.",
-      "famiglia_tipologia": "Metabolico/Difensivo",
-      "fattore_mantenimento_energetico": "Alto (Fase di risveglio/inizio) / Basso (Fase Criostasi).",
-      "id": "criostasi_adattiva",
-      "label": "Criostasi",
-      "mutazione_indotta": "Sviluppo di enzimi crioprotettivi e tessuto adiposo isolante.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "canopia_psionica_leggera"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Fase T1 controllata: micro-canopie sospese usate per cicli brevi di ibernazione.",
-            "tier": "T1"
-          }
-        },
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "orbita_psionica_inversa"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Variante apex T3 in camere orbitali a gravità invertita per stasi prolungate.",
-            "tier": "T3"
-          }
-        }
-      ],
-      "sinergie": [
-        "cavita_risonanti_tundra"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "difensivo",
-        "core": "metabolico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "aurora-gull",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "canopia-psionica-leggera-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "orbita-psionica-inversa-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "orbital-ascendant",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Inverni prolungati o lunghi periodi di scarsità di cibo.",
-      "tier": "T1",
-      "usage_tags": [
-        "sustain",
-        "tank"
-      ],
-      "uso_funzione": "Sopravvivenza a condizioni ambientali estreme."
+      "data_origin": "coverage_q4_2025"
     },
     "cromofori_alert_acido": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
       "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "debolezza": "i18n:traits.cromofori_alert_acido.debolezza",
       "famiglia_tipologia": "Strutturale/Adattivo",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "id": "cromofori_alert_acido",
-      "label": "Cromofori Alert Acido",
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "label": "i18n:traits.cromofori_alert_acido.label",
+      "mutazione_indotta": "i18n:traits.cromofori_alert_acido.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5056,562 +12457,31 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "foresta-acida-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "spinta_selettiva": "i18n:traits.cromofori_alert_acido.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.cromofori_alert_acido.uso_funzione",
       "usage_tags": [
         "tank"
       ],
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
-    },
-    "cuore_multicamera_bassa_pressione": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "cuore_multicamera_bassa_pressione",
-      "label": "Cuore Multicamera Bassa Pressione",
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "stratosfera_tempestosa"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Cuore Multicamera Bassa Pressione ottimizza le operazioni sensoriale nelle condizioni di stratosfera tempestosa.",
-            "tier": "T1"
-          }
-        }
+      "biome_tags": [
+        "foresta_acida"
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "stratosfera-tempestosa-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout",
-        "support"
-      ],
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
-    },
-    "cuscinetti_elettrostatici": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "cuscinetti_elettrostatici",
-      "label": "Cuscinetti Elettrostatici",
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "pianura_salina_iperarida"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Cuscinetti Elettrostatici ottimizza le operazioni locomotorio nelle condizioni di pianura salina iperarida.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "pianura-salina-iperarida-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout"
-      ],
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
-    },
-    "cute_resistente_sali": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Medio (Attivazione situazionale)",
-      "id": "cute_resistente_sali",
-      "label": "Cute Resistente Sali",
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "badlands"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Cute Resistente Sali ottimizza le operazioni difensivo nelle condizioni di badlands.",
-            "tier": "T2"
-          }
-        }
-      ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "evento-tempesta-ferrosa",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "badlands-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "global-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "tier": "T2",
-      "usage_tags": [
-        "tank"
-      ],
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
-    },
-    "cuticole_cerose": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "cuticole_cerose",
-      "label": "Cuticole Cerose",
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "requisiti_ambientali": [],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "cactus-weaver",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "evento-brinastorm",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "evento-ondata-termica",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "global-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "noctule-termico",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "silica-bloom",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "thermo-raptor",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "tier": "T1",
-      "usage_tags": [
-        "sustain"
-      ],
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
-    },
-    "cuticole_neutralizzanti": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "cuticole_neutralizzanti",
-      "label": "Cuticole Neutralizzanti",
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "foresta_acida"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Cuticole Neutralizzanti ottimizza le operazioni supporto nelle condizioni di foresta acida.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "foresta-acida-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
-    },
-    "denti_chelatanti": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "denti_chelatanti",
-      "label": "Denti Chelatanti",
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "foresta_acida"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Denti Chelatanti ottimizza le operazioni offensivo nelle condizioni di foresta acida.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "foresta-acida-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "tier": "T1",
-      "usage_tags": [
-        "breaker"
-      ],
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
-    },
-    "denti_ossidoferro": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "denti_ossidoferro",
-      "label": "Denti Ossidoferro",
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "abisso_vulcanico"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Denti Ossidoferro ottimizza le operazioni strategia nelle condizioni di abisso vulcanico.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "abisso-vulcanico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
-    },
-    "denti_silice_termici": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "denti_silice_termici",
-      "label": "Denti Silice Termici",
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "dorsale_termale_tropicale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Denti Silice Termici ottimizza le operazioni simbiotico nelle condizioni di dorsale termale tropicale.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "dorsale-termale-tropicale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+      "data_origin": "coverage_q4_2025"
     },
     "denti_tuning_fork": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
       "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "debolezza": "i18n:traits.denti_tuning_fork.debolezza",
       "famiglia_tipologia": "Strutturale/Adattivo",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "id": "denti_tuning_fork",
-      "label": "Denti Tuning Fork",
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "label": "i18n:traits.denti_tuning_fork.label",
+      "mutazione_indotta": "i18n:traits.denti_tuning_fork.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -5641,884 +12511,31 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caverna-risonante-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "spinta_selettiva": "i18n:traits.denti_tuning_fork.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.denti_tuning_fork.uso_funzione",
       "usage_tags": [
         "tank"
       ],
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
-    },
-    "echi_risonanti": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "id": "echi_risonanti",
-      "label": "Echi Risonanti",
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caverna_risonante"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Echi Risonanti ottimizza le operazioni sensoriale nelle condizioni di caverna risonante.",
-            "tier": "T1"
-          }
-        }
+      "biome_tags": [
+        "caverna_risonante"
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche",
-        "occhi_cristallo_modulare"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caverna-risonante-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout",
-        "support"
-      ],
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
-    },
-    "eco_interno_riflesso": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Estremamente disorientato da suoni o vibrazioni esterne forti e continue.",
-      "famiglia_tipologia": "Sensoriale/Nervoso",
-      "fattore_mantenimento_energetico": "Medio (Emissioni e ricezione continua)",
-      "id": "eco_interno_riflesso",
-      "label": "Riflesso dell'Eco Interno",
-      "mutazione_indotta": "Organi interni che emettono ultrasuoni e li captano tramite lo scheletro.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "canopia_psionica_leggera"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Start T1 nelle canopie conduttrici per apprendere deformazioni controllate.",
-            "tier": "T1"
-          }
-        },
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "falde_magnetiche_psioniche"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Upgrade T2 sulle dorsali magnetiche per mantenere elasticità sotto stress.",
-            "tier": "T2"
-          }
-        }
-      ],
-      "sinergie": [
-        "cavita_risonanti_tundra",
-        "olfatto_risonanza_magnetica",
-        "sensori_geomagnetici"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "nervoso",
-        "core": "sensoriale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "echo-wing",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "aurora-bridge-runner",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "aurora-gull",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "canopia-psionica-leggera-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "falde-magnetiche-psioniche-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "orbital-ascendant",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "zephyr-spore-courier",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Orientamento in ambienti completamente privi di luce.",
-      "tier": "T2",
-      "usage_tags": [
-        "controller",
-        "scout"
-      ],
-      "uso_funzione": "Utilizzo di onde sonore emesse internamente per mappare l'ambiente."
-    },
-    "empatia_coordinativa": {
-      "completion_flags": {
-        "has_biome": false,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Richiede squadra disciplinata; cade in efficacia se pick rate warden scende.",
-      "famiglia_tipologia": "Supporto/Empatico",
-      "fattore_mantenimento_energetico": "Medio (Feedback costante dai compagni)",
-      "id": "empatia_coordinativa",
-      "label": "Empatia Coordinativa",
-      "mutazione_indotta": "Circuiti sensorio-emotivi collegati al feed HUD PI.",
-      "requisiti_ambientali": [],
-      "sinergie": [
-        "antenne_eco_turbina",
-        "artigli_acidofagi",
-        "batteri_termofili_endosimbiosi",
-        "branchie_turbina",
-        "carapaci_ferruginosi",
-        "cavita_risonanti_tundra",
-        "circolazione_doppia",
-        "coda_stabilizzatrice_geiser",
-        "cuticole_neutralizzanti",
-        "enzimi_chelatori_rapidi",
-        "foliage_fotocatodico",
-        "ghiandole_inchiostro_luce",
-        "gusci_criovetro",
-        "luminescenza_hydrotermica",
-        "aura_scudo_radianza",
-        "spore_psichiche_silenziate"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [
-          "job_ability:warden/scudo_di_risonanza"
-        ],
-        "combo_totale": 1,
-        "forme": [
-          "INFP"
-        ],
-        "tabelle_random": []
-      },
-      "slot": [
-        "A"
-      ],
-      "slot_profile": {
-        "complementare": "coordinazione",
-        "core": "supporto"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "archon-solare",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "balor-fission",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "couatl-aurora",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "glowcap-weaver",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "lupus-temperatus",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "marilith-vault",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "myco-spire-warden",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "rakshasa-corte",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Turni lunghi con rischio alto in cui serve mitigare tilt e HP critici.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Collega cooldown difensivi e cura quando la squadra entra in finestra rischio."
-    },
-    "enzimi_antifase_termica": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "enzimi_antifase_termica",
-      "label": "Enzimi Antifase Termica",
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caldera_glaciale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Enzimi Antifase Termica ottimizza le operazioni locomotorio nelle condizioni di caldera glaciale.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caldera-glaciale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout"
-      ],
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
-    },
-    "enzimi_antipredatori_algali": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "enzimi_antipredatori_algali",
-      "label": "Enzimi Antipredatori Algali",
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "reef_luminescente"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Enzimi Antipredatori Algali ottimizza le operazioni difensivo nelle condizioni di reef luminescente.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "reef-luminescente-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "tier": "T1",
-      "usage_tags": [
-        "tank"
-      ],
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
-    },
-    "enzimi_chelanti": {
-      "completion_flags": {
-        "has_biome": false,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "enzimi_chelanti",
-      "label": "Enzimi Chelanti",
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "requisiti_ambientali": [],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti",
-        "ghiandola_caustica"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "evento-tempesta-ferrosa",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "global-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "tier": "T1",
-      "usage_tags": [
-        "sustain"
-      ],
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
-    },
-    "enzimi_chelatori_rapidi": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "enzimi_chelatori_rapidi",
-      "label": "Enzimi Chelatori Rapidi",
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "foresta_acida"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Enzimi Chelatori Rapidi ottimizza le operazioni supporto nelle condizioni di foresta acida.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "foresta-acida-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
-    },
-    "enzimi_metanoossidanti": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "enzimi_metanoossidanti",
-      "label": "Enzimi Metanoossidanti",
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "abisso_vulcanico"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Enzimi Metanoossidanti ottimizza le operazioni offensivo nelle condizioni di abisso vulcanico.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "abisso-vulcanico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "tier": "T1",
-      "usage_tags": [
-        "breaker"
-      ],
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
-    },
-    "epidermide_dielettrica": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "epidermide_dielettrica",
-      "label": "Epidermide Dielettrica",
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "stratosfera_tempestosa"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Epidermide Dielettrica ottimizza le operazioni strategia nelle condizioni di stratosfera tempestosa.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "stratosfera-tempestosa-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
-    },
-    "epitelio_fosforescente": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "epitelio_fosforescente",
-      "label": "Epitelio Fosforescente",
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "reef_luminescente"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Epitelio Fosforescente ottimizza le operazioni simbiotico nelle condizioni di reef luminescente.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "reef-luminescente-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
-    },
-    "filamenti_digestivi_compattanti": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Blocco intestinale se la dieta è priva di materiale 'legante'.",
-      "famiglia_tipologia": "Digestivo/Escretorio",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "filamenti_digestivi_compattanti",
-      "label": "Filamento materiali digeriti",
-      "mutazione_indotta": "Muscolatura rettale ipertrofica e organo appendice dedicato.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caverna_risonante"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
-            "tier": "T1"
-          }
-        },
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "falde_magnetiche_psioniche"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Variante T2 che sfrutta falde magnetiche per compattare residui ad alta densità.",
-            "tier": "T2"
-          }
-        }
-      ],
-      "sinergie": [
-        "antenne_dustsense",
-        "appendici_thermotattiche",
-        "batteri_endosimbionti_chemio",
-        "branchie_solfatiche",
-        "carapace_segmenti_logici",
-        "circolazione_cooling_loop",
-        "coda_stabilizzatrice_filo",
-        "cuticole_cerose",
-        "enzimi_chelanti",
-        "flagelli_ancoranti",
-        "ghiandole_grafene",
-        "grassi_termici",
-        "luminescenza_aurorale",
-        "ventriglio_gastroliti"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "escretorio",
-        "core": "digestivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "magnet-fathom-surveyor",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "nano-rust-bloom",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "rust-scavenger",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caverna-risonante-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "falde-magnetiche-psioniche-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "glowcap-weaver",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "myco-spire-warden",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "thaw-rot",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Necessità di mantenere la pulizia del territorio/nido.",
-      "tier": "T2",
-      "usage_tags": [
-        "sustain"
-      ],
-      "uso_funzione": "Espulsione compatta e ordinata di scorie."
+      "data_origin": "coverage_q4_2025"
     },
     "filamenti_magnetotrofi": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
       "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "debolezza": "i18n:traits.filamenti_magnetotrofi.debolezza",
       "famiglia_tipologia": "Strutturale/Adattivo",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "id": "filamenti_magnetotrofi",
-      "label": "Filamenti Magnetotrofi",
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "label": "i18n:traits.filamenti_magnetotrofi.label",
+      "mutazione_indotta": "i18n:traits.filamenti_magnetotrofi.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -6548,783 +12565,31 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "abisso-vulcanico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "spinta_selettiva": "i18n:traits.filamenti_magnetotrofi.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.filamenti_magnetotrofi.uso_funzione",
       "usage_tags": [
         "tank"
       ],
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
-    },
-    "filamenti_superconduttivi": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "filamenti_superconduttivi",
-      "label": "Filamenti Superconduttivi",
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caldera_glaciale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Filamenti Superconduttivi ottimizza le operazioni sensoriale nelle condizioni di caldera glaciale.",
-            "tier": "T1"
-          }
-        }
+      "biome_tags": [
+        "abisso_vulcanico"
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caldera-glaciale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout",
-        "support"
-      ],
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
-    },
-    "filamenti_termoconduzione": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "filamenti_termoconduzione",
-      "label": "Filamenti Termoconduzione",
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "dorsale_termale_tropicale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Filamenti Termoconduzione ottimizza le operazioni locomotorio nelle condizioni di dorsale termale tropicale.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "dorsale-termale-tropicale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout"
-      ],
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
-    },
-    "filtri_planctonici": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "filtri_planctonici",
-      "label": "Filtri Planctonici",
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "laguna_bioreattiva"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Filtri Planctonici ottimizza le operazioni difensivo nelle condizioni di laguna bioreattiva.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "laguna-bioreattiva-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "tier": "T1",
-      "usage_tags": [
-        "tank"
-      ],
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
-    },
-    "flagelli_ancoranti": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "flagelli_ancoranti",
-      "label": "Flagelli Ancoranti",
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "laguna_bioreattiva"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Flagelli Ancoranti ottimizza le operazioni metabolico nelle condizioni di laguna bioreattiva.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "laguna-bioreattiva-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "tier": "T1",
-      "usage_tags": [
-        "sustain"
-      ],
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
-    },
-    "focus_frazionato": {
-      "completion_flags": {
-        "has_biome": false,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Rischio di overload mentale se tilt e aggro salgono oltre le soglie HUD.",
-      "famiglia_tipologia": "Strategico/Psionico",
-      "fattore_mantenimento_energetico": "Medio (Dividere l'attenzione su più canali)",
-      "id": "focus_frazionato",
-      "label": "Focus Frazionato",
-      "mutazione_indotta": "Processore di priorità multi-thread per bersagli e obiettivi.",
-      "requisiti_ambientali": [],
-      "sinergie": [
-        "ali_fulminee",
-        "antenne_plasmatiche_tempesta",
-        "antenne_waveguide",
-        "baffi_mareomotori",
-        "branchie_eoliche",
-        "capillari_fluoridici",
-        "cervelletto_equilibrio_statico",
-        "coda_balanciere",
-        "cuore_multicamera_bassa_pressione",
-        "echi_risonanti",
-        "filamenti_superconduttivi",
-        "ghiandole_eco_mappanti",
-        "ghiandole_resina_conduttiva",
-        "lamine_scudo_silice",
-        "midollo_antivibrazione",
-        "frusta_fiammeggiante",
-        "spore_psichiche_silenziate",
-        "random"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "cap_pt",
-          "job_ability:invoker/sincronia",
-          "sigillo_forma",
-          "starter_bioma"
-        ],
-        "combo_totale": 3,
-        "forme": [
-          "ENTP",
-          "INFJ",
-          "INTP"
-        ],
-        "tabelle_random": []
-      },
-      "slot": [
-        "A",
-        "C"
-      ],
-      "slot_profile": {
-        "complementare": "psionico",
-        "core": "strategia"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "orbital-ascendant",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "psionic-canopy-scout",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "core"
-          ],
-          "species_id": "marilith-vault",
-          "weight": 3
-        },
-        {
-          "roles": [
-            "synergy"
-          ],
-          "species_id": "archon-solare",
-          "weight": 2
-        },
-        {
-          "roles": [
-            "synergy"
-          ],
-          "species_id": "balor-fission",
-          "weight": 2
-        },
-        {
-          "roles": [
-            "synergy"
-          ],
-          "species_id": "banshee-risonante",
-          "weight": 2
-        },
-        {
-          "roles": [
-            "synergy"
-          ],
-          "species_id": "couatl-aurora",
-          "weight": 2
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "sentinella-radice",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Comunicazioni piatte dove occorre coprire minacce su più fronti.",
-      "tier": "T1",
-      "usage_tags": [
-        "controller",
-        "support"
-      ],
-      "uso_funzione": "Permette di gestire due ingaggi paralleli senza perdere efficienza."
-    },
-    "foliage_fotocatodico": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "foliage_fotocatodico",
-      "label": "Foliage Fotocatodico",
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "foresta_acida"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Foliage Fotocatodico ottimizza le operazioni supporto nelle condizioni di foresta acida.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "foresta-acida-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
-    },
-    "foliaggio_spugna": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "foliaggio_spugna",
-      "label": "Foliaggio Spugna",
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "mangrovieto_cinetico"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Foliaggio Spugna ottimizza le operazioni offensivo nelle condizioni di mangrovieto cinetico.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "mangrovieto-cinetico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "tier": "T1",
-      "usage_tags": [
-        "breaker"
-      ],
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
-    },
-    "frusta_fiammeggiante": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "pathfinder_dataset",
-      "debolezza": "Consumante: richiede costante dissipazione termica per non bruciare la matrice portante.",
-      "famiglia_tipologia": "Offensivo/Controllo",
-      "fattore_mantenimento_energetico": "Medio (Filamenti di plasma vincolato)",
-      "id": "frusta_fiammeggiante",
-      "label": "Frusta Fiammeggiante",
-      "mutazione_indotta": "Genera appendici tentacolari avvolte da plasma infernale controllato.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [
-            "void_stride"
-          ],
-          "condizioni": {
-            "biome_class": "rovine_planari"
-          },
-          "fonte": "pathfinder_import",
-          "meta": {
-            "expansion": "pathfinder_dataset",
-            "notes": "Necessita condotti di stabilizzazione infernale nelle rovine planari.",
-            "tier": "T2"
-          }
-        }
-      ],
-      "sinergie": [
-        "focus_frazionato",
-        "mantello_meteoritico"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "controllo",
-        "core": "offensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "balor-fission",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "core"
-          ],
-          "species_id": "marilith-vault",
-          "weight": 3
-        }
-      ],
-      "spinta_selettiva": "Creare distanza di sicurezza contro predatori d'élite nelle zone instabili.",
-      "tier": "T2",
-      "usage_tags": [
-        "breaker",
-        "controller"
-      ],
-      "uso_funzione": "Afferra e disarma avversari o sigilla varchi planari con tagli di energia."
-    },
-    "ghiaccio_piezoelettrico": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "ghiaccio_piezoelettrico",
-      "label": "Ghiaccio Piezoelettrico",
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caldera_glaciale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Ghiaccio Piezoelettrico ottimizza le operazioni strategia nelle condizioni di caldera glaciale.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco",
-        "pathfinder"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caldera-glaciale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
-    },
-    "ghiandola_caustica": {
-      "completion_flags": {
-        "has_biome": false,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Gestione accurata delle riserve per non calare sotto i budget PE previsto.",
-      "famiglia_tipologia": "Offensivo/Chimico",
-      "fattore_mantenimento_energetico": "Medio (Produzione reagenti)",
-      "id": "ghiandola_caustica",
-      "label": "Ghiandola Caustica",
-      "mutazione_indotta": "Sintesi rapida di composti caustici nei moduli d'attacco.",
-      "requisiti_ambientali": [],
-      "sinergie": [
-        "enzimi_chelanti",
-        "respiro_a_scoppio",
-        "campo_di_interferenza_acustica",
-        "sistemi_chimio_sonici"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "guardia_situazionale",
-          "sigillo_forma"
-        ],
-        "combo_totale": 2,
-        "forme": [
-          "ISTP",
-          "ESTP"
-        ],
-        "tabelle_random": []
-      },
-      "slot": [
-        "A"
-      ],
-      "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "core"
-          ],
-          "species_id": "laguna-bioreattiva-trait-keeper",
-          "weight": 3
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "sentinella-radice",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Squadre che devono rispondere a guardie situazionali al turno 1-2.",
-      "tier": "T1",
-      "usage_tags": [
-        "breaker"
-      ],
-      "uso_funzione": "Sblocco early di danni da acido per rompere armature leggere."
-    },
-    "ghiandole_cambio_salino": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "ghiandole_cambio_salino",
-      "label": "Ghiandole Cambio Salino",
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "laguna_bioreattiva"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Ghiandole Cambio Salino ottimizza le operazioni simbiotico nelle condizioni di laguna bioreattiva.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "laguna-bioreattiva-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+      "data_origin": "coverage_q4_2025"
     },
     "ghiandole_condensa_ozono": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
       "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "debolezza": "i18n:traits.ghiandole_condensa_ozono.debolezza",
       "famiglia_tipologia": "Strutturale/Adattivo",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "id": "ghiandole_condensa_ozono",
-      "label": "Ghiandole Condensa Ozono",
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "label": "i18n:traits.ghiandole_condensa_ozono.label",
+      "mutazione_indotta": "i18n:traits.ghiandole_condensa_ozono.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -7354,518 +12619,31 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "stratosfera-tempestosa-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "spinta_selettiva": "i18n:traits.ghiandole_condensa_ozono.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.ghiandole_condensa_ozono.uso_funzione",
       "usage_tags": [
         "tank"
       ],
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
-    },
-    "ghiandole_eco_mappanti": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "ghiandole_eco_mappanti",
-      "label": "Ghiandole Eco Mappanti",
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caverna_risonante"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Ghiandole Eco Mappanti ottimizza le operazioni sensoriale nelle condizioni di caverna risonante.",
-            "tier": "T1"
-          }
-        }
+      "biome_tags": [
+        "stratosfera_tempestosa"
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caverna-risonante-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout",
-        "support"
-      ],
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
-    },
-    "ghiandole_fango_calde": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "ghiandole_fango_calde",
-      "label": "Ghiandole Fango Calde",
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "abisso_vulcanico"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Ghiandole Fango Calde ottimizza le operazioni locomotorio nelle condizioni di abisso vulcanico.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "abisso-vulcanico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout"
-      ],
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
-    },
-    "ghiandole_fango_coesivo": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "ghiandole_fango_coesivo",
-      "label": "Ghiandole Fango Coesivo",
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "mangrovieto_cinetico"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Ghiandole Fango Coesivo ottimizza le operazioni difensivo nelle condizioni di mangrovieto cinetico.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "mangrovieto-cinetico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "tier": "T1",
-      "usage_tags": [
-        "tank"
-      ],
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
-    },
-    "ghiandole_grafene": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "ghiandole_grafene",
-      "label": "Ghiandole Grafene",
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "steppe_algoritmiche"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Ghiandole Grafene ottimizza le operazioni metabolico nelle condizioni di steppe algoritmiche.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "steppe-algoritmiche-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "tier": "T1",
-      "usage_tags": [
-        "sustain"
-      ],
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
-    },
-    "ghiandole_inchiostro_luce": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "ghiandole_inchiostro_luce",
-      "label": "Ghiandole Inchiostro Luce",
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "reef_luminescente"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Ghiandole Inchiostro Luce ottimizza le operazioni supporto nelle condizioni di reef luminescente.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "reef-luminescente-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
-    },
-    "ghiandole_iodoattive": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "ghiandole_iodoattive",
-      "label": "Ghiandole Iodoattive",
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "pianura_salina_iperarida"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Ghiandole Iodoattive ottimizza le operazioni offensivo nelle condizioni di pianura salina iperarida.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "pianura-salina-iperarida-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "tier": "T1",
-      "usage_tags": [
-        "breaker"
-      ],
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
-    },
-    "ghiandole_minerali": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "ghiandole_minerali",
-      "label": "Ghiandole Minerali",
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "dorsale_termale_tropicale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Ghiandole Minerali ottimizza le operazioni strategia nelle condizioni di dorsale termale tropicale.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "dorsale-termale-tropicale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
-    },
-    "ghiandole_nebbia_acida": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "ghiandole_nebbia_acida",
-      "label": "Ghiandole Nebbia Acida",
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "foresta_acida"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Ghiandole Nebbia Acida ottimizza le operazioni simbiotico nelle condizioni di foresta acida.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "foresta-acida-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+      "data_origin": "coverage_q4_2025"
     },
     "ghiandole_nebbia_ionica": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
       "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "debolezza": "i18n:traits.ghiandole_nebbia_ionica.debolezza",
       "famiglia_tipologia": "Strutturale/Adattivo",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "id": "ghiandole_nebbia_ionica",
-      "label": "Ghiandole Nebbia Ionica",
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "label": "i18n:traits.ghiandole_nebbia_ionica.label",
+      "mutazione_indotta": "i18n:traits.ghiandole_nebbia_ionica.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -7895,634 +12673,31 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "canopia-ionica-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "spinta_selettiva": "i18n:traits.ghiandole_nebbia_ionica.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.ghiandole_nebbia_ionica.uso_funzione",
       "usage_tags": [
         "tank"
       ],
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
-    },
-    "ghiandole_resina_conduttiva": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "ghiandole_resina_conduttiva",
-      "label": "Ghiandole Resina Conduttiva",
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "canopia_ionica"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Ghiandole Resina Conduttiva ottimizza le operazioni sensoriale nelle condizioni di canopia ionica.",
-            "tier": "T1"
-          }
-        }
+      "biome_tags": [
+        "canopia_ionica"
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "canopia-ionica-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout",
-        "support"
-      ],
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
-    },
-    "ghiandole_ventosa": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "ghiandole_ventosa",
-      "label": "Ghiandole Ventosa",
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caldera_glaciale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Ghiandole Ventosa ottimizza le operazioni locomotorio nelle condizioni di caldera glaciale.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caldera-glaciale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout"
-      ],
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
-    },
-    "giunti_antitorsione": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "giunti_antitorsione",
-      "label": "Giunti Antitorsione",
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "mangrovieto_cinetico"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Giunti Antitorsione ottimizza le operazioni difensivo nelle condizioni di mangrovieto cinetico.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "mangrovieto-cinetico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "tier": "T1",
-      "usage_tags": [
-        "tank"
-      ],
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
-    },
-    "grassi_termici": {
-      "completion_flags": {
-        "has_biome": false,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "grassi_termici",
-      "label": "Grassi Termici",
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "requisiti_ambientali": [],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "cactus-weaver",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "evento-brinastorm",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "evento-ondata-termica",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "global-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "noctule-termico",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "silica-bloom",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "thermo-raptor",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "tier": "T1",
-      "usage_tags": [
-        "sustain"
-      ],
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
-    },
-    "gusci_criovetro": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "gusci_criovetro",
-      "label": "Gusci Criovetro",
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caldera_glaciale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Gusci Criovetro ottimizza le operazioni supporto nelle condizioni di caldera glaciale.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caldera-glaciale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
-    },
-    "gusci_magnesio": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "gusci_magnesio",
-      "label": "Gusci Magnesio",
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "dorsale_termale_tropicale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Gusci Magnesio ottimizza le operazioni offensivo nelle condizioni di dorsale termale tropicale.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "dorsale-termale-tropicale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "tier": "T1",
-      "usage_tags": [
-        "breaker"
-      ],
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
-    },
-    "lamelle_shear": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "lamelle_shear",
-      "label": "Lamelle Shear",
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "stratosfera_tempestosa"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Lamelle Shear ottimizza le operazioni strategia nelle condizioni di stratosfera tempestosa.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco",
-        "secrezione_rallentante_palmi"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "stratosfera-tempestosa-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
-    },
-    "lamelle_sincroniche": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "lamelle_sincroniche",
-      "label": "Lamelle Sincroniche",
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "steppe_algoritmiche"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Lamelle Sincroniche ottimizza le operazioni simbiotico nelle condizioni di steppe algoritmiche.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "steppe-algoritmiche-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
-    },
-    "lamelle_termoforetiche": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Rende instabile la fisiologia in ambienti a gelo improvviso, con rischio di microfratture vascolari.",
-      "famiglia_tipologia": "Respiratorio/Termoregolazione",
-      "fattore_mantenimento_energetico": "Medio (Flusso continuo di fluidi caldi)",
-      "id": "lamelle_termoforetiche",
-      "label": "Lamelle Termoforetiche",
-      "mutazione_indotta": "Canali lamellari mineralizzati che convogliano fluidi caldi tra branchie interne.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "sorgenti_geotermiche"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Habitat idrotermali psionici dove il calore e la pressione variano rapidamente."
-          }
-        }
-      ],
-      "sinergie": [
-        "sangue_piroforico"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "termoregolazione",
-        "core": "respiratorio"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "bulette-fase",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "couatl-aurora",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "magnet-fathom-surveyor",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "otyugh-sentinella",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "sorgenti-geotermiche-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Sopravvivere a fluidi tossici e temperature estreme nelle fumarole geotermiche.",
-      "tier": "T2",
-      "usage_tags": [
-        "sustain"
-      ],
-      "uso_funzione": "Regola lo scambio gassoso sfruttando gradienti termici controllati."
+      "data_origin": "coverage_q4_2025"
     },
     "lamine_filtranti_aeree": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
       "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "debolezza": "i18n:traits.lamine_filtranti_aeree.debolezza",
       "famiglia_tipologia": "Strutturale/Adattivo",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "id": "lamine_filtranti_aeree",
-      "label": "Lamine Filtranti Aeree",
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "label": "i18n:traits.lamine_filtranti_aeree.label",
+      "mutazione_indotta": "i18n:traits.lamine_filtranti_aeree.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -8552,730 +12727,31 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "mangrovieto-cinetico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "spinta_selettiva": "i18n:traits.lamine_filtranti_aeree.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.lamine_filtranti_aeree.uso_funzione",
       "usage_tags": [
         "tank"
       ],
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
-    },
-    "lamine_scudo_silice": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "lamine_scudo_silice",
-      "label": "Lamine Scudo Silice",
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "dorsale_termale_tropicale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Lamine Scudo Silice ottimizza le operazioni sensoriale nelle condizioni di dorsale termale tropicale.",
-            "tier": "T1"
-          }
-        }
+      "biome_tags": [
+        "mangrovieto_cinetico"
       ],
-      "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "dorsale-termale-tropicale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout",
-        "support"
-      ],
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
-    },
-    "linfa_tampone": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "linfa_tampone",
-      "label": "Linfa Tampone",
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "foresta_acida"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Linfa Tampone ottimizza le operazioni locomotorio nelle condizioni di foresta acida.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "foresta-acida-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout"
-      ],
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
-    },
-    "lingua_cristallina": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "lingua_cristallina",
-      "label": "Lingua Cristallina",
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "pianura_salina_iperarida"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Lingua Cristallina ottimizza le operazioni difensivo nelle condizioni di pianura salina iperarida.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "pianura-salina-iperarida-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
-      "tier": "T1",
-      "usage_tags": [
-        "tank"
-      ],
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
-    },
-    "lingua_tattile_trama": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Estrema vulnerabilità della lingua a contaminanti chimici o acidi.",
-      "famiglia_tipologia": "Sensoriale/Alimentare",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "lingua_tattile_trama",
-      "label": "Lingua Tattile Trama-Sensibile",
-      "mutazione_indotta": "Lingua sottile con papille tattili e meccanocettori avanzati.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caverna_risonante"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
-          }
-        }
-      ],
-      "sinergie": [
-        "olfatto_risonanza_magnetica"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "alimentare",
-        "core": "sensoriale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "blight-micotico",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caverna-risonante-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "echo-wing",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "ferrocolonia-magnetotattica",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Individuare movimenti sismici o cibi sepolti.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout",
-        "sustain"
-      ],
-      "uso_funzione": "\"Leggere\" la tessitura delle superfici per vibrazioni o micro-fratture."
-    },
-    "luminescenza_aurorale": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Sensibile a tossine sconosciute finché non vengono adattate.",
-      "famiglia_tipologia": "Digestivo/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "luminescenza_aurorale",
-      "label": "Luminescenza Aurorale",
-      "mutazione_indotta": "introduce camere metaboliche con enzimi adattivi a cicli rapidi.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caldera_glaciale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Luminescenza Aurorale ottimizza le operazioni metabolico nelle condizioni di caldera glaciale.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "energia",
-        "core": "metabolico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caldera-glaciale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Ridurre downtime energetico in condizioni di risorse instabili.",
-      "tier": "T1",
-      "usage_tags": [
-        "sustain"
-      ],
-      "uso_funzione": "Coordina digestione, filtraggio e rilascio di energia nelle marce prolungate."
-    },
-    "luminescenza_hydrotermica": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Soffre se separato dalla rete cooperativa del gruppo.",
-      "famiglia_tipologia": "Supporto/Logistico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "luminescenza_hydrotermica",
-      "label": "Luminescenza Hydrotermica",
-      "mutazione_indotta": "intreccia canali biochimici condivisi che bilanciano stress collettivo.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "abisso_vulcanico"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Luminescenza Hydrotermica ottimizza le operazioni supporto nelle condizioni di abisso vulcanico.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "logistico",
-        "core": "supporto"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "abisso-vulcanico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Aumentare la resilienza coordinativa durante campagne prolungate.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Distribuisce riserve e modulazioni ritmiche per mantenere coesione."
-    },
-    "mantelli_geotermici": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Rischio di sovraccarico se scaricato senza controllo.",
-      "famiglia_tipologia": "Offensivo/Assalto",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "mantelli_geotermici",
-      "label": "Mantelli Geotermici",
-      "mutazione_indotta": "forgia condotti muscolari che accumulano energia di impatto.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caldera_glaciale"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Mantelli Geotermici ottimizza le operazioni offensivo nelle condizioni di caldera glaciale.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_frusta_cinetica",
-        "sangue_piroforico"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "assalto",
-        "core": "offensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caldera-glaciale-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire pressione costante sulle difese avversarie.",
-      "tier": "T1",
-      "usage_tags": [
-        "breaker"
-      ],
-      "uso_funzione": "Aumenta penetrazione e burst durante finestre di vulnerabilità."
-    },
-    "mantello_meteoritico": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "pathfinder_dataset",
-      "debolezza": "Vulnerabile a scariche di freddo gravitazionale che irrigidiscono il mantello.",
-      "famiglia_tipologia": "Difesa/Termoregolazione",
-      "fattore_mantenimento_energetico": "Alto (Rivestimento ablativo rigenerante)",
-      "id": "mantello_meteoritico",
-      "label": "Mantello Meteoritico",
-      "mutazione_indotta": "Deposita strati sovrapposti di materiale meteorico che vaporizzano l'impatto e rilasciano radianza.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [
-            "fire_resist"
-          ],
-          "condizioni": {
-            "biome_class": "rovine_planari"
-          },
-          "fonte": "pathfinder_import",
-          "meta": {
-            "expansion": "pathfinder_dataset",
-            "notes": "Richiede continue docce di plasma per mantenere la matrice ablativa.",
-            "tier": "T3"
-          }
-        }
-      ],
-      "sinergie": [
-        "frusta_fiammeggiante",
-        "carapace_fase_variabile"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "termico",
-        "core": "difesa"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "balor-fission",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "core"
-          ],
-          "species_id": "marilith-vault",
-          "weight": 3
-        }
-      ],
-      "spinta_selettiva": "Sopravvivere a bombardamenti planari e piogge di meteore dimensionali.",
-      "tier": "T3",
-      "usage_tags": [
-        "sustain",
-        "tank"
-      ],
-      "uso_funzione": "Assorbe colpi energetici estremi e converte il surplus in impulsi offensivi."
-    },
-    "membrane_captura_rugiada": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede tempo di pianificazione prima di rendere il massimo.",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "membrane_captura_rugiada",
-      "label": "Membrane Captura Rugiada",
-      "mutazione_indotta": "espande gangli pianificatori e nodi logici distribuiti.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "pianura_salina_iperarida"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Membrane Captura Rugiada ottimizza le operazioni strategia nelle condizioni di pianura salina iperarida.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "pianificatore",
-        "tattiche_di_branco",
-        "pathfinder"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "pianura-salina-iperarida-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Allineare tattiche di lungo termine con segnali ambientali.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Sblocca pattern predittivi per trappole e imboscate coordinate."
-    },
-    "membrane_eliofiltranti": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Atmosfere acide degradano rapidamente il film eliofiltrante.",
-      "famiglia_tipologia": "Respiratorio/Protezione",
-      "fattore_mantenimento_energetico": "Basso (Auto-riparazione lenta)",
-      "id": "membrane_eliofiltranti",
-      "label": "Membrane Eliofiltranti",
-      "mutazione_indotta": "Strati di mucopolisaccaridi trasparenti che filtrano radiazioni e microrganismi sospesi.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "laghi_alcalini"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Bacini alcalini sospesi dove la luce viene rifratta da vapori metallici."
-          }
-        }
-      ],
-      "sinergie": [
-        "piume_solari_fotovoltaiche",
-        "polmoni_cristallini_alta_quota"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "protezione",
-        "core": "respiratorio"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "laghi-alcalini-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Proteggersi da radiazioni e agenti patogeni in altopiani ipersalini.",
-      "tier": "T2",
-      "usage_tags": [
-        "sustain",
-        "tank"
-      ],
-      "uso_funzione": "Filtra l'aria e i flussi luminosi rendendoli sicuri per tessuti delicati."
-    },
-    "membrane_planata_vectored": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Dipendenza da partner stabili per evitare collasso funzionale.",
-      "famiglia_tipologia": "Simbiotico/Cooperativo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "membrane_planata_vectored",
-      "label": "Membrane Planata Vectored",
-      "mutazione_indotta": "integra organi ponte che mediano scambi nutrizionali e psionici.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "canopia_ionica"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Membrane Planata Vectored ottimizza le operazioni simbiotico nelle condizioni di canopia ionica.",
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "cooperazione",
-        "core": "simbiotico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "canopia-ionica-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Coltivare ecosistemi interdipendenti resilienti.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Stabilizza reti simbiotiche e trasferimenti enzimo-elettrotonici."
+      "data_origin": "coverage_q4_2025"
     },
     "membrane_pneumatofori": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
       "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Risonanze errate possono generare microfratture.",
+      "debolezza": "i18n:traits.membrane_pneumatofori.debolezza",
       "famiglia_tipologia": "Strutturale/Adattivo",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "id": "membrane_pneumatofori",
-      "label": "Membrane Pneumatofori",
-      "mutazione_indotta": "compatta matrici scheletriche con fibre autoreattive.",
+      "label": "i18n:traits.membrane_pneumatofori.label",
+      "mutazione_indotta": "i18n:traits.membrane_pneumatofori.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -9305,37 +12781,33 @@
         "complementare": "resilienza",
         "core": "strutturale"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "mangrovieto-cinetico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere integrità strutturale durante stress ciclici.",
+      "spinta_selettiva": "i18n:traits.membrane_pneumatofori.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.membrane_pneumatofori.uso_funzione",
       "usage_tags": [
         "tank"
       ],
-      "uso_funzione": "Regola densità e flessibilità per sopportare cambi repentini."
-    },
-    "midollo_antivibrazione": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Suscettibile a disturbi elettromagnetici e saturazione sensoriale.",
-      "famiglia_tipologia": "Sensoriale/Analitico",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "midollo_antivibrazione",
-      "label": "Midollo Antivibrazione",
-      "mutazione_indotta": "innesta recettori stratificati che filtrano impulsi elettromagnetici e feromoni.",
+      "biome_tags": [
+        "mangrovieto_cinetico"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "scheletro_idro_regolante": {
+      "conflitti": [
+        "sangue_piroforico"
+      ],
+      "debolezza": "i18n:traits.scheletro_idro_regolante.debolezza",
+      "famiglia_tipologia": "Strutturale/Omeostatico",
+      "fattore_mantenimento_energetico": "Medio (Scambio rapido di fluidi)",
+      "id": "scheletro_idro_regolante",
+      "label": "i18n:traits.scheletro_idro_regolante.label",
+      "mutazione_indotta": "i18n:traits.scheletro_idro_regolante.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -9344,102 +12816,28 @@
           },
           "fonte": "env_to_traits",
           "meta": {
-            "expansion": "coverage_q4_2025",
-            "notes": "Midollo Antivibrazione ottimizza le operazioni sensoriale nelle condizioni di caverna risonante.",
+            "expansion": "controllo_psionico",
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
             "tier": "T1"
           }
         }
       ],
       "sinergie": [
-        "focus_frazionato",
-        "sinapsi_coraline_polifoniche",
-        "occhi_cristallo_modulare"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 2,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "analitico",
-        "core": "sensoriale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caverna-risonante-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere consapevolezza costante in biomi ad alta entropia percettiva.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout",
-        "support"
-      ],
-      "uso_funzione": "Amplifica percezioni multi-spettro e fornisce orientamento tattile immediato."
-    },
-    "mimetismo_cromatico_passivo": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "La colorazione è fissa finché non c'è un nuovo contatto prolungato.",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
-      "fattore_mantenimento_energetico": "Basso (Fase passiva)",
-      "id": "mimetismo_cromatico_passivo",
-      "label": "Ghiandole di Mimetismo Cromatico Passivo",
-      "mutazione_indotta": "Cromatofori che richiedono un input tattile prolungato per la ricarica.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "canopia_psionica_leggera"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "T1 di acclimatazione nelle canopie conduttrici a bassa intensità.",
-            "tier": "T1"
-          }
-        },
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "falde_magnetiche_psioniche"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Percorso T2 che aggiunge gradienti magnetici per pattern cromatici complessi.",
-            "tier": "T2"
-          }
-        }
-      ],
-      "sinergie": [
-        "ali_membrana_sonica",
-        "appendici_risonanti_marea",
-        "artigli_sette_vie",
-        "barriere_miasma_glaciale",
-        "branchie_microfiltri",
-        "capsule_paracadute",
-        "circolazione_bifasica",
-        "coda_coppia_retroattiva",
-        "cute_resistente_sali",
-        "enzimi_antipredatori_algali",
-        "filtri_planctonici",
-        "ghiandole_fango_coesivo",
-        "giunti_antitorsione",
-        "lingua_cristallina",
-        "mucose_barofile",
+        "antenne_tesla",
+        "artigli_vetrificati",
+        "branchie_dual_mode",
+        "branchie_osmotiche_salmastra",
+        "capillari_criogenici",
+        "cartilagini_pseudometalliche",
+        "cisti_iperbariche",
+        "cromofori_alert_acido",
+        "denti_tuning_fork",
+        "filamenti_magnetotrofi",
+        "ghiandole_condensa_ozono",
+        "ghiandole_nebbia_ionica",
+        "lamine_filtranti_aeree",
+        "membrane_pneumatofori",
+        "sacche_galleggianti_ascensoriali",
         "struttura_elastica_amorfa"
       ],
       "sinergie_pi": {
@@ -9450,107 +12848,79 @@
       },
       "slot": [],
       "slot_profile": {
-        "complementare": "difensivo",
-        "core": "tegumentario"
+        "complementare": "omeostatico",
+        "core": "strutturale"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "ferrocolonia-magnetotattica",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "psionic-canopy-scout",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "aurora-bridge-runner",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "canopia-psionica-leggera-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "falde-magnetiche-psioniche-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "zephyr-spore-courier",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Ambiente con pattern cromatici molto variabili che cambiano lentamente.",
+      "spinta_selettiva": "i18n:traits.scheletro_idro_regolante.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.scheletro_idro_regolante.uso_funzione",
       "usage_tags": [
+        "sustain",
         "tank"
       ],
-      "uso_funzione": "Assorbire e replicare il colore dell'ambiente circostante dopo contatto."
-    },
-    "mucillagine_simbionte_mangrovie": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
+      "biome_tags": [
+        "caverna_risonante"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "struttura_elastica_amorfa": {
       "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Acque eccessivamente pure diluiscono la mucillagine riducendo la protezione.",
-      "famiglia_tipologia": "Simbiotico/Difensivo",
-      "fattore_mantenimento_energetico": "Medio (Coltura simbiotica costante)",
-      "id": "mucillagine_simbionte_mangrovie",
-      "label": "Mucillagine Simbionte delle Mangrovie",
-      "mutazione_indotta": "Strati mucosi che ospitano microfauna detossificante proveniente dalle radici di mangrovia.",
+      "debolezza": "i18n:traits.struttura_elastica_amorfa.debolezza",
+      "famiglia_tipologia": "Strutturale/Locomotorio",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "struttura_elastica_amorfa",
+      "label": "i18n:traits.struttura_elastica_amorfa.label",
+      "mutazione_indotta": "i18n:traits.struttura_elastica_amorfa.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "mangrovie_risonanti"
+            "biome_class": "canopia_psionica_leggera"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Foreste di mangrovie ipersature dove le radici cantano frequenze psioniche."
+            "notes": "Start T1 nelle canopie conduttrici per apprendere deformazioni controllate.",
+            "tier": "T1"
+          }
+        },
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "falde_magnetiche_psioniche"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "notes": "Upgrade T2 sulle dorsali magnetiche per mantenere elasticità sotto stress.",
+            "tier": "T1"
           }
         }
       ],
       "sinergie": [
-        "antenne_reagenti",
-        "artigli_scivolo_silente",
-        "biofilm_iperarido",
-        "branchie_osmotiche_salmastra",
-        "camere_nutrienti_vent",
-        "cartilagini_flessoacustiche",
-        "circolazione_bifasica_palude",
-        "ciste_salmastre",
-        "coralli_partner",
-        "denti_silice_termici",
-        "epitelio_fosforescente",
-        "ghiandole_cambio_salino",
-        "ghiandole_nebbia_acida",
-        "lamelle_sincroniche",
-        "membrane_planata_vectored",
-        "nodi_micorrizici_oracolari"
+        "antenne_tesla",
+        "artigli_sette_vie",
+        "artigli_vetrificati",
+        "branchie_dual_mode",
+        "capillari_criogenici",
+        "cartilagini_pseudometalliche",
+        "cisti_iperbariche",
+        "cromofori_alert_acido",
+        "denti_tuning_fork",
+        "filamenti_magnetotrofi",
+        "ghiandole_condensa_ozono",
+        "ghiandole_nebbia_ionica",
+        "lamine_filtranti_aeree",
+        "membrane_pneumatofori",
+        "mimetismo_cromatico_passivo",
+        "sacche_galleggianti_ascensoriali",
+        "scheletro_idro_regolante"
       ],
       "sinergie_pi": {
         "co_occorrenze": [],
@@ -9560,58 +12930,53 @@
       },
       "slot": [],
       "slot_profile": {
-        "complementare": "difensivo",
-        "core": "simbiotico"
+        "complementare": "locomotorio",
+        "core": "strutturale"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "mangrovie-risonanti-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Respinge tossine e predatori microbici tipici dei delta paludosi.",
+      "spinta_selettiva": "i18n:traits.struttura_elastica_amorfa.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.struttura_elastica_amorfa.uso_funzione",
       "usage_tags": [
-        "support",
+        "scout",
         "tank"
       ],
-      "uso_funzione": "Forma una barriera viva che neutralizza veleni e sigilla ferite."
-    },
-    "mucose_aderenza_sonica": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
+      "biome_tags": [
+        "canopia_psionica_leggera",
+        "falde_magnetiche_psioniche"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "antenne_eco_turbina": {
       "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Richiede manutenzione costante delle strutture propulsive.",
-      "famiglia_tipologia": "Locomotorio/Mobilità",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "id": "mucose_aderenza_sonica",
-      "label": "Mucose Aderenza Sonica",
-      "mutazione_indotta": "rimodella appendici elastiche e membrane propulsive con microattuatori.",
+      "debolezza": "i18n:traits.antenne_eco_turbina.debolezza",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "antenne_eco_turbina",
+      "label": "i18n:traits.antenne_eco_turbina.label",
+      "mutazione_indotta": "i18n:traits.antenne_eco_turbina.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "caverna_risonante"
+            "biome_class": "dorsale_termale_tropicale"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "coverage_q4_2025",
-            "notes": "Mucose Aderenza Sonica ottimizza le operazioni locomotorio nelle condizioni di caverna risonante.",
+            "notes": "Antenne Eco Turbina ottimizza le operazioni supporto nelle condizioni di dorsale termale tropicale.",
             "tier": "T1"
           }
         }
       ],
       "sinergie": [
-        "coda_frusta_cinetica",
-        "zampe_a_molla"
+        "empatia_coordinativa",
+        "risonanza_di_branco"
       ],
       "sinergie_pi": {
         "co_occorrenze": [],
@@ -9621,40 +12986,255 @@
       },
       "slot": [],
       "slot_profile": {
-        "complementare": "mobilita",
-        "core": "locomotorio"
+        "complementare": "logistico",
+        "core": "supporto"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caverna-risonante-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire continuità di movimento durante rotte multi-bioma.",
+      "spinta_selettiva": "i18n:traits.antenne_eco_turbina.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.antenne_eco_turbina.uso_funzione",
       "usage_tags": [
-        "scout"
+        "support"
       ],
-      "uso_funzione": "Ottimizza scatti direzionali e transizioni rapide fra livelli verticali."
-    },
-    "mucose_barofile": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
+      "biome_tags": [
+        "dorsale_termale_tropicale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "artigli_acidofagi": {
       "conflitti": [],
-      "data_origin": "coverage_q4_2025",
-      "debolezza": "Peso aggiuntivo che riduce agilità se non calibrato.",
-      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "debolezza": "i18n:traits.artigli_acidofagi.debolezza",
+      "famiglia_tipologia": "Supporto/Logistico",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "mucose_barofile",
-      "label": "Mucose Barofile",
-      "mutazione_indotta": "sintetizza placche stratificate con microcanali di dissipazione.",
+      "id": "artigli_acidofagi",
+      "label": "i18n:traits.artigli_acidofagi.label",
+      "mutazione_indotta": "i18n:traits.artigli_acidofagi.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_acida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Artigli Acidofagi ottimizza le operazioni supporto nelle condizioni di foresta acida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "spinta_selettiva": "i18n:traits.artigli_acidofagi.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.artigli_acidofagi.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "foresta_acida"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "aura_scudo_radianza": {
+      "conflitti": [
+        "mantello_meteoritico"
+      ],
+      "debolezza": "i18n:traits.aura_scudo_radianza.debolezza",
+      "famiglia_tipologia": "Supporto/Difesa",
+      "fattore_mantenimento_energetico": "Alto (Canalizzazione fotonica continua)",
+      "id": "aura_scudo_radianza",
+      "label": "i18n:traits.aura_scudo_radianza.label",
+      "mutazione_indotta": "i18n:traits.aura_scudo_radianza.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [
+            "flight"
+          ],
+          "condizioni": {
+            "biome_class": "rovine_planari"
+          },
+          "fonte": "pathfinder_import",
+          "meta": {
+            "expansion": "pathfinder_dataset",
+            "notes": "Richiede catalizzatori di luce stabili nelle rovine planari.",
+            "tier": "T3"
+          }
+        }
+      ],
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 0,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "difesa",
+        "core": "supporto"
+      },
+      "spinta_selettiva": "i18n:traits.aura_scudo_radianza.spinta_selettiva",
+      "tier": "T3",
+      "uso_funzione": "i18n:traits.aura_scudo_radianza.uso_funzione",
+      "usage_tags": [
+        "support",
+        "tank"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "rovine_planari"
+      ],
+      "data_origin": "pathfinder_dataset"
+    },
+    "batteri_termofili_endosimbiosi": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.batteri_termofili_endosimbiosi.debolezza",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "batteri_termofili_endosimbiosi",
+      "label": "i18n:traits.batteri_termofili_endosimbiosi.label",
+      "mutazione_indotta": "i18n:traits.batteri_termofili_endosimbiosi.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dorsale_termale_tropicale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Batteri Termofili Endosimbiosi ottimizza le operazioni supporto nelle condizioni di dorsale termale tropicale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "spinta_selettiva": "i18n:traits.batteri_termofili_endosimbiosi.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.batteri_termofili_endosimbiosi.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "dorsale_termale_tropicale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "branchie_turbina": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.branchie_turbina.debolezza",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "branchie_turbina",
+      "label": "i18n:traits.branchie_turbina.label",
+      "mutazione_indotta": "i18n:traits.branchie_turbina.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dorsale_termale_tropicale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Branchie Turbina ottimizza le operazioni supporto nelle condizioni di dorsale termale tropicale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "spinta_selettiva": "i18n:traits.branchie_turbina.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.branchie_turbina.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "dorsale_termale_tropicale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "carapaci_ferruginosi": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.carapaci_ferruginosi.debolezza",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "carapaci_ferruginosi",
+      "label": "i18n:traits.carapaci_ferruginosi.label",
+      "mutazione_indotta": "i18n:traits.carapaci_ferruginosi.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -9664,14 +13244,14 @@
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "coverage_q4_2025",
-            "notes": "Mucose Barofile ottimizza le operazioni difensivo nelle condizioni di abisso vulcanico.",
+            "notes": "Carapaci Ferruginosi ottimizza le operazioni supporto nelle condizioni di abisso vulcanico.",
             "tier": "T1"
           }
         }
       ],
       "sinergie": [
-        "carapace_fase_variabile",
-        "mimetismo_cromatico_passivo"
+        "empatia_coordinativa",
+        "risonanza_di_branco"
       ],
       "sinergie_pi": {
         "co_occorrenze": [],
@@ -9681,474 +13261,234 @@
       },
       "slot": [],
       "slot_profile": {
-        "complementare": "protezione",
-        "core": "difensivo"
+        "complementare": "logistico",
+        "core": "supporto"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "abisso-vulcanico-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Assorbire shock continui proteggendo unità di supporto.",
+      "spinta_selettiva": "i18n:traits.carapaci_ferruginosi.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.carapaci_ferruginosi.uso_funzione",
       "usage_tags": [
-        "tank"
-      ],
-      "uso_funzione": "Crea rivestimenti adattivi contro agenti ostili e bombardamenti ambientali."
-    },
-    "nodi_micorrizici_oracolari": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Se la rete micorrizica viene recisa, l'organismo soffre crisi percettive e perdita di orientamento.",
-      "famiglia_tipologia": "Simbiotico/Nervoso",
-      "fattore_mantenimento_energetico": "Medio (Scambio continuo di segnali con simbionti)",
-      "id": "nodi_micorrizici_oracolari",
-      "label": "Nodi Micorrizici Oracolari",
-      "mutazione_indotta": "Radici dermiche che intrecciano funghi psionici capaci di predire variazioni ambientali.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "reti_micorriziche"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Sottoboschi viventi con reti fungine coscienti che emettono segnali premonitori."
-          }
-        }
-      ],
-      "sinergie": [
-        "antenne_reagenti",
-        "artigli_scivolo_silente",
-        "biofilm_iperarido",
-        "bulbi_radici_permafrost",
-        "camere_nutrienti_vent",
-        "cartilagini_flessoacustiche",
-        "chioma_parassita_canopica",
-        "ciste_salmastre",
-        "coralli_partner",
-        "denti_silice_termici",
-        "epitelio_fosforescente",
-        "ghiandole_cambio_salino",
-        "ghiandole_nebbia_acida",
-        "lamelle_sincroniche",
-        "membrane_planata_vectored",
-        "mucillagine_simbionte_mangrovie"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "nervoso",
-        "core": "simbiotico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "reti-micorriziche-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Anticipare frane psioniche e predatori guidati da reti vegetali senzienti.",
-      "tier": "T3",
-      "usage_tags": [
-        "controller",
         "support"
       ],
-      "uso_funzione": "Riceve presagi e segnali tattici dalla rete fungina per coordinare manovre di squadra."
-    },
-    "nucleo_ovomotore_rotante": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Impossibilità di muoversi su superfici irregolari o in salita ripida.",
-      "famiglia_tipologia": "Riproduttivo/Locomotorio",
-      "fattore_mantenimento_energetico": "Alto (Rotolamento)",
-      "id": "nucleo_ovomotore_rotante",
-      "label": "Uovo rotaia, uovo grande e uova piccole dentro...",
-      "mutazione_indotta": "Massa globulare rigida con giunto sferico al centro del petto.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caverna_risonante"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_balanciere",
-        "locomozione_miriapode_ibrida",
-        "flusso_ameboide_controllato"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [
-          "starter_bioma",
-          "sigillo_forma"
-        ],
-        "combo_totale": 2,
-        "forme": [
-          "ESFP",
-          "ISTP"
-        ],
-        "tabelle_random": []
-      },
-      "slot": [
-        "C"
-      ],
-      "slot_profile": {
-        "complementare": "locomotorio",
-        "core": "riproduttivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "core"
-          ],
-          "species_id": "marilith-vault",
-          "weight": 3
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "psionic-canopy-scout",
-          "weight": 2
-        }
-      ],
-      "spinta_selettiva": "Necessità di spostarsi rapidamente su terreni uniformi in assenza di arti.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout",
-        "support"
-      ],
-      "uso_funzione": "Organo Motorio Rotante: usato come 'ruota' centrale per il rotolamento."
-    },
-    "occhi_infrarosso_composti": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Accecamento temporaneo da fonti di calore intenso e concentrato.",
-      "famiglia_tipologia": "Sensoriale/Visivo",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "occhi_infrarosso_composti",
-      "label": "Occhi Composti ad Infrarosso",
-      "mutazione_indotta": "Sviluppo di un secondo strato retinico sensibile all'infrarosso.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caverna_risonante"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
-          }
-        }
-      ],
-      "sinergie": [
-        "sonno_emisferico_alternato"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "visivo",
-        "core": "sensoriale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "echo-wing",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caverna-risonante-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Caccia notturna o nell'oscurità totale basata sul gradiente termico.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout"
-      ],
-      "uso_funzione": "Vista specializzata che percepisce il calore corporeo."
-    },
-    "occhi_cristallo_modulare": {
-      "completion_flags": {
-        "has_biome": false,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "pathfinder_dataset",
-      "famiglia_tipologia": "Sensoriale/Visivo",
-      "fattore_mantenimento_energetico": "Moderato (Attivo)",
-      "id": "occhi_cristallo_modulare",
-      "label": "Occhi di Cristallo Modulare",
-      "mutazione_indotta": "L'organo visivo si fraziona in lenti di cristallo sostituibili che modulano spettro e messa a fuoco in tempo reale.",
-      "sinergie": [
-        "occhi_cinetici",
-        "visione_multi_spettrale_amplificata",
-        "echi_risonanti",
-        "coda_balanciere",
-        "midollo_antivibrazione"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [
-          "sigillo_forma",
-          "starter_bioma"
-        ],
-        "combo_totale": 3,
-        "forme": [
-          "INTP",
-          "ISTP",
-          "ISTJ"
-        ],
-        "tabelle_random": []
-      },
-      "slot": [
-        "A",
-        "B"
-      ],
-      "spinta_selettiva": "Garantire riconoscimento rapido di minacce e risorse in scenari multibioma mantenendo resilienza a bagliori o accecamenti mirati.",
-      "tier": "T2",
-      "usage_tags": [
-        "scout"
-      ],
-      "species_affinity": [
-        {
-          "roles": [
-            "core"
-          ],
-          "species_id": "orbital-ascendant",
-          "weight": 3
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "psionic-canopy-scout",
-          "weight": 2
-        }
-      ],
-      "uso_funzione": "Amplifica la raccolta dati a lunga distanza e consente di passare rapidamente da zoom tattici a panoramiche ambientali senza perdita di dettaglio."
-    },
-    "olfatto_risonanza_magnetica": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Sensibilità a forti interferenze elettromagnetiche (es. fulmini o minerali magnetici).",
-      "famiglia_tipologia": "Sensoriale/Nervoso",
-      "fattore_mantenimento_energetico": "Medio (Elaborazione sensoriale costante)",
-      "id": "olfatto_risonanza_magnetica",
-      "label": "Olfatto di Risonanza Magnetica",
-      "mutazione_indotta": "Organi sensoriali elettrorecettori concentrati su muso o antenne.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "falde_magnetiche_psioniche"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Corridore T2 per intercettare campi magnetici psionici sulle dorsali.",
-            "tier": "T2"
-          }
-        },
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "orbita_psionica_inversa"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Variante T3 calibrata alle camere di gravità invertita e ai flussi orbitali.",
-            "tier": "T3"
-          }
-        }
-      ],
-      "sinergie": [
-        "eco_interno_riflesso",
-        "lingua_tattile_trama"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "nervoso",
-        "core": "sensoriale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "magnet-fathom-surveyor",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "orbital-ascendant",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "slag-veil-ambusher",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "cryo-lynx",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "dune-stalker",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "falde-magnetiche-psioniche-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "magneto-ridge-hunter",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "orbita-psionica-inversa-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "psionic-canopy-scout",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Orientamento in ambienti sotterranei senza luce o caccia a prede metallifere.",
-      "tier": "T2",
-      "usage_tags": [
-        "controller",
-        "scout"
-      ],
-      "uso_funzione": "Percepire la direzione e la composizione di metalli o campi energetici."
-    },
-    "pathfinder": {
       "biome_tags": [
-        "foresta_acida",
-        "foresta_miceliale"
+        "abisso_vulcanico"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "circolazione_doppia": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.circolazione_doppia.debolezza",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "circolazione_doppia",
+      "label": "i18n:traits.circolazione_doppia.label",
+      "mutazione_indotta": "i18n:traits.circolazione_doppia.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dorsale_termale_tropicale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Circolazione Doppia ottimizza le operazioni supporto nelle condizioni di dorsale termale tropicale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "spinta_selettiva": "i18n:traits.circolazione_doppia.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.circolazione_doppia.uso_funzione",
+      "usage_tags": [
+        "support"
       ],
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
+      "biome_tags": [
+        "dorsale_termale_tropicale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "coda_stabilizzatrice_geiser": {
       "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Valore ridotto in scenari a corridoio o con tilt già stabilizzato.",
-      "famiglia_tipologia": "Esplorazione/Tattico",
-      "fattore_mantenimento_energetico": "Basso (Sincronizzazione con HUD di esplorazione)",
-      "id": "pathfinder",
-      "label": "Pathfinder",
-      "mutazione_indotta": "Suite sensoriale orientata a scouting e lettura minacce.",
-      "requisiti_ambientali": [],
+      "debolezza": "i18n:traits.coda_stabilizzatrice_geiser.debolezza",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "coda_stabilizzatrice_geiser",
+      "label": "i18n:traits.coda_stabilizzatrice_geiser.label",
+      "mutazione_indotta": "i18n:traits.coda_stabilizzatrice_geiser.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "dorsale_termale_tropicale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Coda Stabilizzatrice Geiser ottimizza le operazioni supporto nelle condizioni di dorsale termale tropicale.",
+            "tier": "T1"
+          }
+        }
+      ],
       "sinergie": [
-        "antenne_microonde_cavernose",
-        "biofilm_glow",
-        "camere_mirage",
-        "colonne_vibromagnetiche",
-        "membrane_captura_rugiada",
-        "ghiaccio_piezoelettrico"
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "spinta_selettiva": "i18n:traits.coda_stabilizzatrice_geiser.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.coda_stabilizzatrice_geiser.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "dorsale_termale_tropicale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "cuticole_neutralizzanti": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.cuticole_neutralizzanti.debolezza",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "cuticole_neutralizzanti",
+      "label": "i18n:traits.cuticole_neutralizzanti.label",
+      "mutazione_indotta": "i18n:traits.cuticole_neutralizzanti.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_acida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Cuticole Neutralizzanti ottimizza le operazioni supporto nelle condizioni di foresta acida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "spinta_selettiva": "i18n:traits.cuticole_neutralizzanti.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.cuticole_neutralizzanti.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "foresta_acida"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "empatia_coordinativa": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.empatia_coordinativa.debolezza",
+      "famiglia_tipologia": "Supporto/Empatico",
+      "fattore_mantenimento_energetico": "Medio (Feedback costante dai compagni)",
+      "id": "empatia_coordinativa",
+      "label": "i18n:traits.empatia_coordinativa.label",
+      "mutazione_indotta": "i18n:traits.empatia_coordinativa.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_miceliale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "tier": "T1",
+            "notes": "L'empatia amplifica la coesione di gruppo dove linee di vista sono ostruite da funghi e radici."
+          }
+        }
+      ],
+      "sinergie": [
+        "antenne_eco_turbina",
+        "artigli_acidofagi",
+        "batteri_termofili_endosimbiosi",
+        "branchie_turbina",
+        "carapaci_ferruginosi",
+        "cavita_risonanti_tundra",
+        "circolazione_doppia",
+        "coda_stabilizzatrice_geiser",
+        "cuticole_neutralizzanti",
+        "enzimi_chelatori_rapidi",
+        "foliage_fotocatodico",
+        "ghiandole_inchiostro_luce",
+        "gusci_criovetro",
+        "luminescenza_hydrotermica",
+        "aura_scudo_radianza"
       ],
       "sinergie_pi": {
         "co_occorrenze": [
-          "PE",
-          "cap_pt",
-          "starter_bioma",
-          "guardia_situazionale"
+          "job_ability:warden/scudo_di_risonanza"
         ],
-        "combo_totale": 3,
+        "combo_totale": 1,
         "forme": [
-          "ENFP",
-          "ESTP",
-          "ISTP"
+          "INFP"
         ],
         "tabelle_random": []
       },
@@ -10156,416 +13496,318 @@
         "A"
       ],
       "slot_profile": {
-        "complementare": "ricognizione",
-        "core": "strategia"
+        "complementare": "coordinazione",
+        "core": "supporto"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "core"
-          ],
-          "species_id": "psionic-canopy-scout",
-          "weight": 3
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "sentinella-radice",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Missioni con indice explore alto e opzioni opzionali da capitalizzare.",
+      "spinta_selettiva": "i18n:traits.empatia_coordinativa.spinta_selettiva",
       "tier": "T1",
-      "usage_tags": [
-        "scout",
-        "support"
-      ],
-      "uso_funzione": "Ottimizza esplorazione e controllo mappe multi-bioma."
-    },
-    "pianificatore": {
-      "completion_flags": {
-        "has_biome": false,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Rigidità tattica se gli input di telemetria arrivano in ritardo.",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Medio (Analisi continua di stato squadre)",
-      "id": "pianificatore",
-      "label": "Pianificatore",
-      "mutazione_indotta": "Protocollo decisionale adattivo con buffer informativi dedicati.",
-      "requisiti_ambientali": [],
-      "sinergie": [
-        "antenne_microonde_cavernose",
-        "artigli_radice",
-        "biofilm_glow",
-        "camere_mirage",
-        "cartilagini_desertiche",
-        "ciste_riduttive",
-        "colonne_vibromagnetiche",
-        "denti_ossidoferro",
-        "epidermide_dielettrica",
-        "ghiaccio_piezoelettrico",
-        "ghiandole_minerali",
-        "lamelle_shear",
-        "membrane_captura_rugiada",
-        "random"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "cap_pt",
-          "guardia_situazionale",
-          "sigillo_forma",
-          "starter_bioma"
-        ],
-        "combo_totale": 6,
-        "forme": [
-          "ENTJ",
-          "ENTP",
-          "ESTJ",
-          "INTJ",
-          "ISTJ"
-        ],
-        "tabelle_random": []
-      },
-      "slot": [
-        "A",
-        "C"
-      ],
-      "slot_profile": {
-        "complementare": "tattico",
-        "core": "strategia"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "sentinella-radice",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Squadre che devono mantenere priorità multiple su turni lunghi.",
-      "tier": "T1",
+      "uso_funzione": "i18n:traits.empatia_coordinativa.uso_funzione",
       "usage_tags": [
         "support"
       ],
-      "uso_funzione": "Coordina finestre di danno e difesa, mantenendo la squadra allineata al piano PI."
-    },
-    "piume_solari_fotovoltaiche": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
+      "biome_tags": [
+        "foresta_miceliale"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "enzimi_chelatori_rapidi": {
       "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Ombre prolungate o polveri dense riducono drasticamente la produzione energetica.",
-      "famiglia_tipologia": "Tegumentario/Energetico",
-      "fattore_mantenimento_energetico": "Alto (Richiede manutenzione delle lamine fotoreattive)",
-      "id": "piume_solari_fotovoltaiche",
-      "label": "Piume Solari Fotovoltaiche",
-      "mutazione_indotta": "Piumaggio stratificato con pigmenti piezo-fotovoltaici che immagazzinano luce.",
+      "debolezza": "i18n:traits.enzimi_chelatori_rapidi.debolezza",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "enzimi_chelatori_rapidi",
+      "label": "i18n:traits.enzimi_chelatori_rapidi.label",
+      "mutazione_indotta": "i18n:traits.enzimi_chelatori_rapidi.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "altipiani_solari"
+            "biome_class": "foresta_acida"
           },
           "fonte": "env_to_traits",
           "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Altipiani ad alta insolazione dove le correnti psioniche amplificano la luce."
+            "expansion": "coverage_q4_2025",
+            "notes": "Enzimi Chelatori Rapidi ottimizza le operazioni supporto nelle condizioni di foresta acida.",
+            "tier": "T1"
           }
         }
       ],
       "sinergie": [
-        "membrane_eliofiltranti",
-        "sacche_spore_stratosferiche"
+        "empatia_coordinativa",
+        "risonanza_di_branco"
       ],
       "sinergie_pi": {
         "co_occorrenze": [],
-        "combo_totale": 0,
+        "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
       "slot": [],
       "slot_profile": {
-        "complementare": "energetico",
-        "core": "tegumentario"
+        "complementare": "logistico",
+        "core": "supporto"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "altipiani-solari-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Massimizzare l'autonomia energetica per migrazioni aeree sopra deserti e oceani.",
-      "tier": "T2",
-      "usage_tags": [
-        "sustain",
-        "tank"
-      ],
-      "uso_funzione": "Convertire la radiazione solare in riserve energetiche per abilità a lungo raggio."
-    },
-    "polmoni_cristallini_alta_quota": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Particolato pesante o sabbia vulcanica graffia i cristalli riducendo l'efficienza respiratoria.",
-      "famiglia_tipologia": "Respiratorio/Aerobico",
-      "fattore_mantenimento_energetico": "Medio (Pulizia periodica dei cristalli)",
-      "id": "polmoni_cristallini_alta_quota",
-      "label": "Polmoni Cristallini d'Alta Quota",
-      "mutazione_indotta": "Sistemi alveolari irrobustiti da strutture cristalline che catturano ossigeno rarefatto.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "picchi_cristallini"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Catene montuose sospese dove i cristalli amplificano l'aria rarefatta."
-          }
-        }
-      ],
-      "sinergie": [
-        "membrane_eliofiltranti"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "aerobico",
-        "core": "respiratorio"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "picchi-cristallini-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Operare in missioni d'alta quota senza supporto logistico esterno.",
-      "tier": "T2",
-      "usage_tags": [
-        "sustain"
-      ],
-      "uso_funzione": "Massimizza l'assorbimento di ossigeno rarefatto e filtra agenti nocivi."
-    },
-    "random": {
-      "completion_flags": {
-        "has_biome": false,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Bassa affidabilità: richiede slot aggiuntivi per mitigare risultati sfavorevoli.",
-      "famiglia_tipologia": "Flessibile/Generico",
-      "fattore_mantenimento_energetico": "Variabile (Dipende dal tratto estratto)",
-      "id": "random",
-      "label": "Trait Random",
-      "mutazione_indotta": "Selezione casuale da pool controllata per esperimenti di build.",
-      "requisiti_ambientali": [],
-      "sinergie": [
-        "pianificatore",
-        "focus_frazionato",
-        "tattiche_di_branco",
-        "camere_mirage",
-        "biofilm_glow",
-        "colonne_vibromagnetiche"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [
-          "cap_pt",
-          "guardia_situazionale",
-          "job_ability:random",
-          "starter_bioma"
-        ],
-        "combo_totale": 3,
-        "forme": [
-          "ENFP",
-          "ENTP",
-          "ISTP"
-        ],
-        "tabelle_random": []
-      },
-      "slot": [
-        "A",
-        "B"
-      ],
-      "slot_profile": {
-        "complementare": "adattivo",
-        "core": "strategia"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "sentinella-radice",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "synergy"
-          ],
-          "species_id": "psionic-canopy-scout",
-          "weight": 3
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "orbital-ascendant",
-          "weight": 2
-        }
-      ],
-      "spinta_selettiva": "Draft rapidi o recuperi quando il tavolo necessita sorprese adattive.",
+      "spinta_selettiva": "i18n:traits.enzimi_chelatori_rapidi.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.enzimi_chelatori_rapidi.uso_funzione",
       "usage_tags": [
-        "support",
-        "tank"
+        "support"
       ],
-      "uso_funzione": "Slot jolly per testing o pareggiare budget PI quando serve varietà."
-    },
-    "respiro_a_scoppio": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
+      "biome_tags": [
+        "foresta_acida"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "foliage_fotocatodico": {
       "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Vulnerabilità respiratoria subito dopo l'utilizzo (tempo di ricarica).",
-      "famiglia_tipologia": "Respiratorio/Propulsivo",
-      "fattore_mantenimento_energetico": "Alto (Richiede ricarica polmonare)",
-      "id": "respiro_a_scoppio",
-      "label": "Respiro a scoppio",
-      "mutazione_indotta": "Polmoni o sacche aeree ad alta pressione con valvole di rilascio rapide.",
+      "debolezza": "i18n:traits.foliage_fotocatodico.debolezza",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "foliage_fotocatodico",
+      "label": "i18n:traits.foliage_fotocatodico.label",
+      "mutazione_indotta": "i18n:traits.foliage_fotocatodico.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "caverna_risonante"
+            "biome_class": "foresta_acida"
           },
           "fonte": "env_to_traits",
           "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+            "expansion": "coverage_q4_2025",
+            "notes": "Foliage Fotocatodico ottimizza le operazioni supporto nelle condizioni di foresta acida.",
+            "tier": "T1"
           }
         }
       ],
       "sinergie": [
-        "sacche_galleggianti_ascensoriali",
-        "squame_rifrangenti_deserto",
-        "ghiandola_caustica"
+        "empatia_coordinativa",
+        "risonanza_di_branco"
       ],
       "sinergie_pi": {
         "co_occorrenze": [],
-        "combo_totale": 0,
+        "combo_totale": 2,
         "forme": [],
         "tabelle_random": []
       },
       "slot": [],
       "slot_profile": {
-        "complementare": "propulsivo",
-        "core": "respiratorio"
+        "complementare": "logistico",
+        "core": "supporto"
       },
-      "species_affinity": [
+      "spinta_selettiva": "i18n:traits.foliage_fotocatodico.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.foliage_fotocatodico.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "foresta_acida"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "ghiandole_inchiostro_luce": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.ghiandole_inchiostro_luce.debolezza",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "ghiandole_inchiostro_luce",
+      "label": "i18n:traits.ghiandole_inchiostro_luce.label",
+      "mutazione_indotta": "i18n:traits.ghiandole_inchiostro_luce.mutazione_indotta",
+      "requisiti_ambientali": [
         {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "rust-scavenger",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caverna-risonante-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "dune-stalker",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "magneto-ridge-hunter",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "slag-veil-ambusher",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "steppe-bison-mini",
-          "weight": 1
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "reef_luminescente"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ghiandole Inchiostro Luce ottimizza le operazioni supporto nelle condizioni di reef luminescente.",
+            "tier": "T1"
+          }
         }
       ],
-      "spinta_selettiva": "Spostamento rapido tramite getto d'aria in ambienti a bassa resistenza.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout",
-        "sustain"
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
       ],
-      "uso_funzione": "Rilasciare grandi quantità d'aria o energia in un getto potente."
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "spinta_selettiva": "i18n:traits.ghiandole_inchiostro_luce.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.ghiandole_inchiostro_luce.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "reef_luminescente"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "gusci_criovetro": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.gusci_criovetro.debolezza",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "gusci_criovetro",
+      "label": "i18n:traits.gusci_criovetro.label",
+      "mutazione_indotta": "i18n:traits.gusci_criovetro.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caldera_glaciale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Gusci Criovetro ottimizza le operazioni supporto nelle condizioni di caldera glaciale.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "spinta_selettiva": "i18n:traits.gusci_criovetro.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.gusci_criovetro.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "caldera_glaciale"
+      ],
+      "data_origin": "coverage_q4_2025"
+    },
+    "luminescenza_hydrotermica": {
+      "conflitti": [],
+      "debolezza": "i18n:traits.luminescenza_hydrotermica.debolezza",
+      "famiglia_tipologia": "Supporto/Logistico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "id": "luminescenza_hydrotermica",
+      "label": "i18n:traits.luminescenza_hydrotermica.label",
+      "mutazione_indotta": "i18n:traits.luminescenza_hydrotermica.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "abisso_vulcanico"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Luminescenza Hydrotermica ottimizza le operazioni supporto nelle condizioni di abisso vulcanico.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "sinergie": [
+        "empatia_coordinativa",
+        "risonanza_di_branco"
+      ],
+      "sinergie_pi": {
+        "co_occorrenze": [],
+        "combo_totale": 2,
+        "forme": [],
+        "tabelle_random": []
+      },
+      "slot": [],
+      "slot_profile": {
+        "complementare": "logistico",
+        "core": "supporto"
+      },
+      "spinta_selettiva": "i18n:traits.luminescenza_hydrotermica.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.luminescenza_hydrotermica.uso_funzione",
+      "usage_tags": [
+        "support"
+      ],
+      "completion_flags": {
+        "has_biome": true,
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
+      },
+      "biome_tags": [
+        "abisso_vulcanico"
+      ],
+      "data_origin": "coverage_q4_2025"
     },
     "risonanza_di_branco": {
-      "completion_flags": {
-        "has_biome": false,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
       "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Stress elevato se la coesione cala sotto i target di telemetria.",
+      "debolezza": "i18n:traits.risonanza_di_branco.debolezza",
       "famiglia_tipologia": "Supporto/Coordinativo",
       "fattore_mantenimento_energetico": "Basso (Richiede mantenimento empatico)",
       "id": "risonanza_di_branco",
-      "label": "Risonanza di Branco",
-      "mutazione_indotta": "Reticolo empatico che collega i canali PI cooperativi.",
-      "requisiti_ambientali": [],
+      "label": "i18n:traits.risonanza_di_branco.label",
+      "mutazione_indotta": "i18n:traits.risonanza_di_branco.mutazione_indotta",
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "foresta_miceliale"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "controllo_psionico",
+            "tier": "T1",
+            "notes": "Le vibrazioni di branco viaggiano attraverso il micelio umido, mantenendo il gruppo sincronizzato."
+          }
+        }
+      ],
       "sinergie": [
         "antenne_eco_turbina",
         "antenne_plasmatiche_tempesta",
@@ -10609,73 +13851,31 @@
         "complementare": "coordinazione",
         "core": "supporto"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional",
-            "synergy"
-          ],
-          "species_id": "archon-solare",
-          "weight": 3
-        },
-        {
-          "roles": [
-            "core"
-          ],
-          "species_id": "banshee-risonante",
-          "weight": 3
-        },
-        {
-          "roles": [
-            "synergy"
-          ],
-          "species_id": "couatl-aurora",
-          "weight": 2
-        },
-        {
-          "roles": [
-            "synergy"
-          ],
-          "species_id": "rakshasa-corte",
-          "weight": 2
-        },
-        {
-          "roles": [
-            "synergy"
-          ],
-          "species_id": "treant-portale",
-          "weight": 2
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "lupus-temperatus",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Forme che eccellono in difesa coordinata e scudi sovrapposti.",
+      "spinta_selettiva": "i18n:traits.risonanza_di_branco.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.risonanza_di_branco.uso_funzione",
       "usage_tags": [
         "support"
       ],
-      "uso_funzione": "Amplifica buff condivisi sincronizzando i timer di squadra."
-    },
-    "sacche_galleggianti_ascensoriali": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
+      "biome_tags": [
+        "foresta_miceliale"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "mimetismo_cromatico_passivo": {
       "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Rischio di barotrauma se la pressione esterna cambia troppo rapidamente.",
-      "famiglia_tipologia": "Idrostatico/Locomotorio",
-      "fattore_mantenimento_energetico": "Medio (Per il controllo della pressione)",
-      "id": "sacche_galleggianti_ascensoriali",
-      "label": "Sacche galleggianti ascensoriali",
-      "mutazione_indotta": "Sacche ripiene di gas leggeri con pompe muscolari.",
+      "debolezza": "i18n:traits.mimetismo_cromatico_passivo.debolezza",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (Fase passiva)",
+      "id": "mimetismo_cromatico_passivo",
+      "label": "i18n:traits.mimetismo_cromatico_passivo.label",
+      "mutazione_indotta": "i18n:traits.mimetismo_cromatico_passivo.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -10685,27 +13885,39 @@
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Fase T1 in canopie sospese per calibrare pompaggio e feedback pressorio.",
+            "notes": "T1 di acclimatazione nelle canopie conduttrici a bassa intensità.",
             "tier": "T1"
           }
         },
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "orbita_psionica_inversa"
+            "biome_class": "falde_magnetiche_psioniche"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Apex T3 su piattaforme orbitali a gravità invertita per ascese rapide.",
-            "tier": "T3"
+            "notes": "Percorso T2 che aggiunge gradienti magnetici per pattern cromatici complessi.",
+            "tier": "T1"
           }
         }
       ],
       "sinergie": [
-        "cartilagine_flessotermica_venti",
-        "respiro_a_scoppio",
-        "scheletro_idro_regolante",
+        "ali_membrana_sonica",
+        "appendici_risonanti_marea",
+        "artigli_sette_vie",
+        "barriere_miasma_glaciale",
+        "branchie_microfiltri",
+        "capsule_paracadute",
+        "circolazione_bifasica",
+        "coda_coppia_retroattiva",
+        "cute_resistente_sali",
+        "enzimi_antipredatori_algali",
+        "filtri_planctonici",
+        "ghiandole_fango_coesivo",
+        "giunti_antitorsione",
+        "lingua_cristallina",
+        "mucose_barofile",
         "struttura_elastica_amorfa"
       ],
       "sinergie_pi": {
@@ -10716,108 +13928,54 @@
       },
       "slot": [],
       "slot_profile": {
-        "complementare": "locomotorio",
-        "core": "idrostatico"
+        "complementare": "difensivo",
+        "core": "tegumentario"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "orbital-ascendant",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "psionic-canopy-scout",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "sand-burrower",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "aurora-bridge-runner",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "canopia-psionica-leggera-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "echo-wing",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "orbita-psionica-inversa-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "zephyr-spore-courier",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Vivere in un ambiente acquatico con forti correnti verticali.",
+      "spinta_selettiva": "i18n:traits.mimetismo_cromatico_passivo.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.mimetismo_cromatico_passivo.uso_funzione",
       "usage_tags": [
-        "scout",
         "tank"
       ],
-      "uso_funzione": "Controllo preciso della profondità e del movimento verticale."
-    },
-    "sacche_spore_stratosferiche": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Correnti ionizzate possono incendiare le sacche rendendo l'organismo instabile.",
-      "famiglia_tipologia": "Simbiotico/Supporto",
-      "fattore_mantenimento_energetico": "Alto (Coltura continua di spore portanti)",
-      "id": "sacche_spore_stratosferiche",
-      "label": "Sacche di Spore Stratosferiche",
-      "mutazione_indotta": "Vescicole dermiche che rilasciano spore portatrici capaci di galleggiare per chilometri.",
+      "biome_tags": [
+        "canopia_psionica_leggera",
+        "falde_magnetiche_psioniche"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "piume_solari_fotovoltaiche": {
+      "conflitti": [
+        "criostasi_adattiva"
+      ],
+      "debolezza": "i18n:traits.piume_solari_fotovoltaiche.debolezza",
+      "famiglia_tipologia": "Tegumentario/Energetico",
+      "fattore_mantenimento_energetico": "Alto (Richiede manutenzione delle lamine fotoreattive)",
+      "id": "piume_solari_fotovoltaiche",
+      "label": "i18n:traits.piume_solari_fotovoltaiche.label",
+      "mutazione_indotta": "i18n:traits.piume_solari_fotovoltaiche.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
           "condizioni": {
-            "biome_class": "stratosfera_portante"
+            "biome_class": "altipiani_solari"
           },
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Correnti ascendenti permanenti che trasportano semi e spore su larga scala."
+            "notes": "Altipiani ad alta insolazione dove le correnti psioniche amplificano la luce.",
+            "tier": "T2"
           }
         }
       ],
       "sinergie": [
-        "piume_solari_fotovoltaiche"
+        "membrane_eliofiltranti",
+        "sacche_spore_stratosferiche"
       ],
       "sinergie_pi": {
         "co_occorrenze": [],
@@ -10827,274 +13985,38 @@
       },
       "slot": [],
       "slot_profile": {
-        "complementare": "supporto",
-        "core": "simbiotico"
+        "complementare": "energetico",
+        "core": "tegumentario"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "stratosfera-portante-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Dispersone genetica rapida tra arcipelaghi aerei e piattaforme galleggianti.",
-      "tier": "T3",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Distribuisce simbionti di supporto e crea corridoi di movimento per la squadra."
-    },
-    "sangue_piroforico": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Rischio di auto-combustione in caso di ferita profonda in atmosfera ricca di ossigeno.",
-      "famiglia_tipologia": "Offensivo/Cinetico",
-      "fattore_mantenimento_energetico": "Medio (Sintesi dei composti)",
-      "id": "sangue_piroforico",
-      "label": "Sangue che prende fuoco a contatto con l'ossigeno",
-      "mutazione_indotta": "Presenza di composti piroforici nel sangue.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caverna_risonante"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
-          }
-        }
-      ],
-      "sinergie": [
-        "antenne_flusso_mareale",
-        "artigli_induzione",
-        "biochip_memoria",
-        "camere_anticorrosione",
-        "cartilagini_biofibre",
-        "circolazione_supercritica",
-        "coda_stabilizzatrice_vortex",
-        "denti_chelatanti",
-        "enzimi_metanoossidanti",
-        "foliaggio_spugna",
-        "ghiandole_iodoattive",
-        "gusci_magnesio",
-        "lamelle_termoforetiche",
-        "mantelli_geotermici"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "impatto",
-        "core": "offensivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "ferrocolonia-magnetotattica",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caverna-risonante-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "nano-rust-bloom",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "thaw-rot",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Difesa contro predatori che tentano di estrarre fluidi corporei.",
-      "tier": "T1",
-      "usage_tags": [
-        "breaker"
-      ],
-      "uso_funzione": "Meccanismo di difesa termico o chimico che si attiva con l'aria."
-    },
-    "scheletro_idro_regolante": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Vulnerabilità a veleni o malattie che attaccano direttamente il sistema circolatorio.",
-      "famiglia_tipologia": "Strutturale/Omeostatico",
-      "fattore_mantenimento_energetico": "Medio (Scambio rapido di fluidi)",
-      "id": "scheletro_idro_regolante",
-      "label": "Scheletro Idro-Regolante",
-      "mutazione_indotta": "Struttura ossea porosa capace di scambio rapido di fluidi.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caverna_risonante"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
-          }
-        }
-      ],
-      "sinergie": [
-        "antenne_tesla",
-        "artigli_vetrificati",
-        "branchie_dual_mode",
-        "branchie_osmotiche_salmastra",
-        "capillari_criogenici",
-        "cartilagini_pseudometalliche",
-        "cisti_iperbariche",
-        "cromofori_alert_acido",
-        "denti_tuning_fork",
-        "filamenti_magnetotrofi",
-        "ghiandole_condensa_ozono",
-        "ghiandole_nebbia_ionica",
-        "lamine_filtranti_aeree",
-        "membrane_pneumatofori",
-        "sacche_galleggianti_ascensoriali",
-        "struttura_elastica_amorfa"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "omeostatico",
-        "core": "strutturale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "dune-stalker",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "magneto-ridge-hunter",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "nano-rust-bloom",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "sand-burrower",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "synergy"
-          ],
-          "species_id": "slag-veil-ambusher",
-          "weight": 2
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "bulette-fase",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caverna-risonante-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "magnet-fathom-surveyor",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "rust-scavenger",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "steppe-bison-mini",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Alternare vita terrestre e vita acquatica/aerea.",
-      "tier": "T1",
+      "spinta_selettiva": "i18n:traits.piume_solari_fotovoltaiche.spinta_selettiva",
+      "tier": "T2",
+      "uso_funzione": "i18n:traits.piume_solari_fotovoltaiche.uso_funzione",
       "usage_tags": [
         "sustain",
         "tank"
       ],
-      "uso_funzione": "Assorbire o espellere rapidamente acqua dai tessuti ossei per modificare il peso."
-    },
-    "secrezione_rallentante_palmi": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Esaurimento rapido delle riserve di liquido con tempo di ricarica prolungato.",
+      "biome_tags": [
+        "altipiani_solari"
+      ],
+      "data_origin": "controllo_psionico"
+    },
+    "secrezione_rallentante_palmi": {
+      "conflitti": [
+        "carapace_fase_variabile",
+        "nucleo_ovomotore_rotante"
+      ],
+      "debolezza": "i18n:traits.secrezione_rallentante_palmi.debolezza",
       "famiglia_tipologia": "Tegumentario/Difensivo",
       "fattore_mantenimento_energetico": "Medio (Produzione del liquido)",
       "id": "secrezione_rallentante_palmi",
-      "label": "Mani secernano liquido rallentante",
-      "mutazione_indotta": "Ghiandole mucose modificate sulle superfici prensili.",
+      "label": "i18n:traits.secrezione_rallentante_palmi.label",
+      "mutazione_indotta": "i18n:traits.secrezione_rallentante_palmi.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -11104,7 +14026,8 @@
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
+            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive.",
+            "tier": "T1"
           }
         }
       ],
@@ -11133,6 +14056,12 @@
         "complementare": "difensivo",
         "core": "tegumentario"
       },
+      "spinta_selettiva": "i18n:traits.secrezione_rallentante_palmi.spinta_selettiva",
+      "tier": "T1",
+      "uso_funzione": "i18n:traits.secrezione_rallentante_palmi.uso_funzione",
+      "usage_tags": [
+        "tank"
+      ],
       "species_affinity": [
         {
           "roles": [
@@ -11149,336 +14078,27 @@
           "weight": 2
         }
       ],
-      "spinta_selettiva": "Cattura di prede veloci o difesa da aggressori corpo a corpo.",
-      "tier": "T1",
-      "usage_tags": [
-        "tank"
-      ],
-      "uso_funzione": "Neutralizzare o immobilizzare prede/nemici."
-    },
-    "sensori_geomagnetici": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
         "has_species_link": true,
-        "has_usage_tags": true
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Tempeste solari possono saturare il segnale magnetico, causando disorientamento prolungato.",
-      "famiglia_tipologia": "Sensoriale/Navigazione",
-      "fattore_mantenimento_energetico": "Basso (Ricettori passivi)",
-      "id": "sensori_geomagnetici",
-      "label": "Sensori Geomagnetici",
-      "mutazione_indotta": "Cristalli ferromagnetici allineati lungo il cranio che fungono da bussola psionica.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "pianure_magnetiche"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Distese pianeggianti con vortici geomagnetici da sfruttare per la navigazione."
-          }
-        }
+      "biome_tags": [
+        "caverna_risonante"
       ],
-      "sinergie": [
-        "carapace_fase_variabile",
-        "eco_interno_riflesso"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "navigazione",
-        "core": "sensoriale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "bulette-fase",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "couatl-aurora",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "marilith-vault",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "pianure-magnetiche-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Orientarsi in steppe polarizzate e tunnel sotterranei privi di riferimenti visivi.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout"
-      ],
-      "uso_funzione": "Traccia linee di campo e memorizza corridoi magnetici per la migrazione."
-    },
-    "sinapsi_coraline_polifoniche": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Vibrazioni sintonizzate male possono generare feedback dolorosi e perdita di coscienza.",
-      "famiglia_tipologia": "Simbiotico/Comunicazione",
-      "fattore_mantenimento_energetico": "Medio (Scambio continuo di impulsi corallini)",
-      "id": "sinapsi_coraline_polifoniche",
-      "label": "Sinapsi Coraline Polifoniche",
-      "mutazione_indotta": "Fibre nervose intrecciate con coralli sonori che trasmettono ordini tramite armoniche.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "barriere_coralline_psioniche"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Scogliere viventi che rispondono a canti psionici e onde sonore."
-          }
-        }
-      ],
-      "sinergie": [
-        "ali_fulminee",
-        "antenne_plasmatiche_tempesta",
-        "antenne_waveguide",
-        "baffi_mareomotori",
-        "branchie_eoliche",
-        "capillari_fluoridici",
-        "carapace_luminiscente_abissale",
-        "cervelletto_equilibrio_statico",
-        "coda_balanciere",
-        "cuore_multicamera_bassa_pressione",
-        "echi_risonanti",
-        "filamenti_superconduttivi",
-        "ghiandole_eco_mappanti",
-        "ghiandole_resina_conduttiva",
-        "lamine_scudo_silice",
-        "midollo_antivibrazione"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "comunicazione",
-        "core": "simbiotico"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "barriere-coralline-psioniche-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Coordinare banchi e alleati in ambienti tridimensionali complessi.",
-      "tier": "T2",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Trasmette comandi e pattern tattici sfruttando armoniche subacquee."
-    },
-    "sonno_emisferico_alternato": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Vulnerabilità a suoni/stimoli che colpiscono entrambi i lobi contemporaneamente.",
-      "famiglia_tipologia": "Nervoso/Omeostatico",
-      "fattore_mantenimento_energetico": "Medio (Mantenimento attivo di metà cervello)",
-      "id": "sonno_emisferico_alternato",
-      "label": "Dormire con solo metà cervello alla volta",
-      "mutazione_indotta": "Encefalizzazione asimmetrica o due lobi cerebrali separati.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caverna_risonante"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
-          }
-        }
-      ],
-      "sinergie": [
-        "artigli_sghiaccio_glaciale",
-        "occhi_infrarosso_composti"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "omeostatico",
-        "core": "nervoso"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "echo-wing",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "aurora-gull",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caverna-risonante-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Monitoraggio costante dei predatori in ambienti ad alto rischio.",
-      "tier": "T1",
-      "usage_tags": [
-        "controller",
-        "sustain"
-      ],
-      "uso_funzione": "Vigilanza continua pur garantendo riposo."
-    },
-    "spore_psichiche_silenziate": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Funzionalità ridotta in presenza di vento forte o umidità elevata.",
-      "famiglia_tipologia": "Escretorio/Psichico",
-      "fattore_mantenimento_energetico": "Alto (Produzione e rilascio)",
-      "id": "spore_psichiche_silenziate",
-      "label": "Spora Psichica Silenziosa",
-      "mutazione_indotta": "Pori che rilasciano nano-particelle attive chimicamente o psichicamente.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caverna_risonante"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
-          }
-        }
-      ],
-      "sinergie": [
-        "focus_frazionato",
-        "empatia_coordinativa",
-        "cervello_a_bassa_latenza",
-        "tattiche_di_branco",
-        "campo_di_interferenza_acustica"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [
-          "cap_pt",
-          "starter_bioma",
-          "job_ability:invoker/sincronia"
-        ],
-        "combo_totale": 2,
-        "forme": [
-          "INFJ",
-          "INTJ"
-        ],
-        "tabelle_random": []
-      },
-      "slot": [
-        "B",
-        "C"
-      ],
-      "slot_profile": {
-        "complementare": "psichico",
-        "core": "escretorio"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "core"
-          ],
-          "species_id": "banshee-risonante",
-          "weight": 3
-        },
-        {
-          "roles": [
-            "synergy"
-          ],
-          "species_id": "psionic-canopy-scout",
-          "weight": 2
-        }
-      ],
-      "spinta_selettiva": "Neutralizzare gruppi di prede o predatori senza impegnare in combattimento.",
-      "tier": "T1",
-      "usage_tags": [
-        "controller",
-        "sustain"
-      ],
-      "uso_funzione": "Indurre uno stato di confusione o letargia negli individui vicini."
+      "data_origin": "controllo_psionico"
     },
     "squame_rifrangenti_deserto": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Soffre danni da feedback termico se colpito da raggi concentrati o laser.",
+      "conflitti": [
+        "mimetismo_cromatico_passivo"
+      ],
+      "debolezza": "i18n:traits.squame_rifrangenti_deserto.debolezza",
       "famiglia_tipologia": "Tegumentario/Difensivo",
       "fattore_mantenimento_energetico": "Medio (Richiede riallineamento delle placche)",
       "id": "squame_rifrangenti_deserto",
-      "label": "Squame Rifrangenti del Deserto",
-      "mutazione_indotta": "Placche cristalline sovrapposte che deviano luce e calore lungo superfici multiple.",
+      "label": "i18n:traits.squame_rifrangenti_deserto.label",
+      "mutazione_indotta": "i18n:traits.squame_rifrangenti_deserto.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -11488,7 +14108,8 @@
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Deserti di quarzo e vetro dove le tempeste solari vengono amplificate."
+            "notes": "Deserti di quarzo e vetro dove le tempeste solari vengono amplificate.",
+            "tier": "T2"
           }
         }
       ],
@@ -11506,271 +14127,31 @@
         "complementare": "difensivo",
         "core": "tegumentario"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "dune-cristalline-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Sopravvivere a intensi flare termici e accecanti miraggi desertici.",
+      "spinta_selettiva": "i18n:traits.squame_rifrangenti_deserto.spinta_selettiva",
       "tier": "T2",
+      "uso_funzione": "i18n:traits.squame_rifrangenti_deserto.uso_funzione",
       "usage_tags": [
         "tank"
       ],
-      "uso_funzione": "Rifrange la luce generando miraggi e dissipando attacchi energetici."
-    },
-    "struttura_elastica_amorfa": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
+        "has_species_link": false,
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Vulnerabilità a danni da taglio o perforazione (difficile cauterizzazione).",
-      "famiglia_tipologia": "Strutturale/Locomotorio",
-      "fattore_mantenimento_energetico": "Basso (Passivo)",
-      "id": "struttura_elastica_amorfa",
-      "label": "Struttura elastica, allungabile, amorfa, retrattile",
-      "mutazione_indotta": "Tessuto con matrice di proteine elastiche iper-modificate.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "canopia_psionica_leggera"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Start T1 nelle canopie conduttrici per apprendere deformazioni controllate.",
-            "tier": "T1"
-          }
-        },
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "falde_magnetiche_psioniche"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Upgrade T2 sulle dorsali magnetiche per mantenere elasticità sotto stress.",
-            "tier": "T2"
-          }
-        }
+      "biome_tags": [
+        "dune_cristalline"
       ],
-      "sinergie": [
-        "antenne_tesla",
-        "artigli_sette_vie",
-        "artigli_vetrificati",
-        "branchie_dual_mode",
-        "capillari_criogenici",
-        "cartilagini_pseudometalliche",
-        "cisti_iperbariche",
-        "cromofori_alert_acido",
-        "denti_tuning_fork",
-        "filamenti_magnetotrofi",
-        "ghiandole_condensa_ozono",
-        "ghiandole_nebbia_ionica",
-        "lamine_filtranti_aeree",
-        "membrane_pneumatofori",
-        "mimetismo_cromatico_passivo",
-        "sacche_galleggianti_ascensoriali",
-        "scheletro_idro_regolante"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "locomotorio",
-        "core": "strutturale"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "dune-stalker",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "magnet-fathom-surveyor",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "psionic-canopy-scout",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "slag-veil-ambusher",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "synergy"
-          ],
-          "species_id": "magneto-ridge-hunter",
-          "weight": 2
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "canopia-psionica-leggera-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "falde-magnetiche-psioniche-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "glowcap-weaver",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "myco-spire-warden",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Fuga rapida da predatori in spazi confinati.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout",
-        "tank"
-      ],
-      "uso_funzione": "Flessibilità estrema e capacità di assumere forme diverse."
-    },
-    "tattiche_di_branco": {
-      "completion_flags": {
-        "has_biome": false,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Richiede formazione stabile; cala se la coesione precipita sotto il target.",
-      "famiglia_tipologia": "Strategico/Tattico",
-      "fattore_mantenimento_energetico": "Medio (Broadcast continuo di segnali)",
-      "id": "tattiche_di_branco",
-      "label": "Tattiche di Branco",
-      "mutazione_indotta": "Canale condiviso per marcature e ingaggi simultanei.",
-      "requisiti_ambientali": [],
-      "sinergie": [
-        "antenne_microonde_cavernose",
-        "artigli_radice",
-        "artigli_sette_vie",
-        "biofilm_glow",
-        "camere_mirage",
-        "cartilagini_desertiche",
-        "ciste_riduttive",
-        "colonne_vibromagnetiche",
-        "denti_ossidoferro",
-        "epidermide_dielettrica",
-        "ghiaccio_piezoelettrico",
-        "ghiandole_minerali",
-        "lamelle_shear",
-        "membrane_captura_rugiada",
-        "spore_psichiche_silenziate",
-        "random"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [
-          "PE",
-          "cap_pt",
-          "guardia_situazionale",
-          "sigillo_forma",
-          "starter_bioma"
-        ],
-        "combo_totale": 2,
-        "forme": [
-          "ESFJ",
-          "ESFP"
-        ],
-        "tabelle_random": []
-      },
-      "slot": [
-        "B"
-      ],
-      "slot_profile": {
-        "complementare": "coordinazione",
-        "core": "strategia"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "synergy"
-          ],
-          "species_id": "magneto-ridge-hunter",
-          "weight": 2
-        },
-        {
-          "roles": [
-            "synergy"
-          ],
-          "species_id": "slag-veil-ambusher",
-          "weight": 2
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "lupus-temperatus",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Squadre che puntano a style bonus tramite assist e controllo spazio.",
-      "tier": "T1",
-      "usage_tags": [
-        "support"
-      ],
-      "uso_funzione": "Coordina prese e focus bersaglio condividendo segnali di priorità."
+      "data_origin": "controllo_psionico"
     },
     "vello_condensatore_nebbie": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
       "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "In ambienti aridi accumula detriti che riducono la capacità di condensa.",
+      "debolezza": "i18n:traits.vello_condensatore_nebbie.debolezza",
       "famiglia_tipologia": "Tegumentario/Idratazione",
       "fattore_mantenimento_energetico": "Basso (Strutture passive a microfilo)",
       "id": "vello_condensatore_nebbie",
-      "label": "Vello Condensatore di Nebbie",
-      "mutazione_indotta": "Peli cavi microstriati che catturano e canalizzano la bruma atmosferica.",
+      "label": "i18n:traits.vello_condensatore_nebbie.label",
+      "mutazione_indotta": "i18n:traits.vello_condensatore_nebbie.mutazione_indotta",
       "requisiti_ambientali": [
         {
           "capacita_richieste": [],
@@ -11780,7 +14161,8 @@
           "fonte": "env_to_traits",
           "meta": {
             "expansion": "controllo_psionico",
-            "notes": "Canopie immerse in nebbia costante con risonanza umida e lampi bioluminescenti."
+            "notes": "Canopie immerse in nebbia costante con risonanza umida e lampi bioluminescenti.",
+            "tier": "T1"
           }
         }
       ],
@@ -11798,4353 +14180,23 @@
         "complementare": "idratazione",
         "core": "tegumentario"
       },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "foreste-nubose-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Garantire idratazione in climi montani dove l'acqua liquida è scarsa ma la nebbia abbondante.",
+      "spinta_selettiva": "i18n:traits.vello_condensatore_nebbie.spinta_selettiva",
       "tier": "T1",
+      "uso_funzione": "i18n:traits.vello_condensatore_nebbie.uso_funzione",
       "usage_tags": [
         "sustain",
         "tank"
       ],
-      "uso_funzione": "Condensa acqua atmosferica per supportare abilità metaboliche ad alto consumo."
-    },
-    "ventriglio_gastroliti": {
       "completion_flags": {
         "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Usura e rottura del ventriglio se i gastroliti sono esauriti o troppo lisci.",
-      "famiglia_tipologia": "Digestivo/Alimentare",
-      "fattore_mantenimento_energetico": "Medio (Contrazione muscolare costante)",
-      "id": "ventriglio_gastroliti",
-      "label": "Denti sonci (ciottoli/sassi), ti nutri di tutto",
-      "mutazione_indotta": "Sviluppo di un organo muscolare (ventriglio) con gastroliti.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "caverna_risonante"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Pacchetto di controllo sensoriale e psichico per specie iperadattive."
-          }
-        }
-      ],
-      "sinergie": [
-        "antenne_dustsense",
-        "appendici_thermotattiche",
-        "batteri_endosimbionti_chemio",
-        "branchie_solfatiche",
-        "carapace_segmenti_logici",
-        "circolazione_cooling_loop",
-        "coda_stabilizzatrice_filo",
-        "cuticole_cerose",
-        "enzimi_chelanti",
-        "filamenti_digestivi_compattanti",
-        "flagelli_ancoranti",
-        "ghiandole_grafene",
-        "grassi_termici",
-        "luminescenza_aurorale"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "alimentare",
-        "core": "digestivo"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "core",
-            "optional"
-          ],
-          "species_id": "rust-scavenger",
-          "weight": 4
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "caverna-risonante-trait-keeper",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "ferrocolonia-magnetotattica",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "steppe-bison-mini",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Dieta basata su semi, conchiglie o insetti corazzati.",
-      "tier": "T1",
-      "usage_tags": [
-        "sustain"
-      ],
-      "uso_funzione": "Macinazione di cibo duro all'interno di un ventriglio."
-    },
-    "zampe_a_molla": {
-      "completion_flags": {
-        "has_biome": false,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Perdita di valore su mappe con spazi stretti o controllo setup elevato.",
-      "famiglia_tipologia": "Mobilità/Cinetico",
-      "fattore_mantenimento_energetico": "Basso (Carica elastica a turni alterni)",
-      "id": "zampe_a_molla",
-      "label": "Zampe a Molla",
-      "mutazione_indotta": "Arti potenziati con ammortizzatori ad alta compressione.",
-      "requisiti_ambientali": [],
-      "sinergie": [
-        "ali_ioniche",
-        "antenne_wideband",
-        "artigli_sghiaccio_glaciale",
-        "barbigli_sensori_plasma",
-        "branchie_metalloidi",
-        "capillari_fotovoltaici",
-        "chemiorecettori_bromuro",
-        "coda_contrappeso",
-        "cuscinetti_elettrostatici",
-        "enzimi_antifase_termica",
-        "filamenti_termoconduzione",
-        "ghiandole_fango_calde",
-        "ghiandole_ventosa",
-        "linfa_tampone",
-        "mucose_aderenza_sonica"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [
-          "cap_pt",
-          "guardia_situazionale",
-          "job_ability:skirmisher/dash_cut"
-        ],
-        "combo_totale": 2,
-        "forme": [
-          "ESTP",
-          "ISFP"
-        ],
-        "tabelle_random": []
-      },
-      "slot": [
-        "A",
-        "B"
-      ],
-      "slot_profile": {
-        "complementare": "propulsione",
-        "core": "locomotorio"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "sand-burrower",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Metagame con forte pressione di aggro e necessità di riposizionamento.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout"
-      ],
-      "uso_funzione": "Dash esplosivi per mantenere il ritmo di ingaggio o disimpegno."
-    },
-    "zoccoli_risonanti_steppe": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "conflitti": [],
-      "data_origin": "controllo_psionico",
-      "debolezza": "Suoli cedevoli come sabbie mobili annullano la vibrazione e riducono la trazione.",
-      "famiglia_tipologia": "Locomotorio/Supporto",
-      "fattore_mantenimento_energetico": "Basso (Vibrazione passiva del suolo)",
-      "id": "zoccoli_risonanti_steppe",
-      "label": "Zoccoli Risonanti delle Steppe",
-      "mutazione_indotta": "Placche cornee cave che emettono onde sismiche ritmiche al contatto con il terreno.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "steppe_risonanti"
-          },
-          "fonte": "env_to_traits",
-          "meta": {
-            "expansion": "controllo_psionico",
-            "notes": "Praterie ventose dove il suolo amplifica vibrazioni utili alla comunicazione di branco."
-          }
-        }
-      ],
-      "sinergie": [
-        "cartilagine_flessotermica_venti"
-      ],
-      "sinergie_pi": {
-        "co_occorrenze": [],
-        "combo_totale": 0,
-        "forme": [],
-        "tabelle_random": []
-      },
-      "slot": [],
-      "slot_profile": {
-        "complementare": "supporto",
-        "core": "locomotorio"
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "steppe-risonanti-trait-keeper",
-          "weight": 1
-        }
-      ],
-      "spinta_selettiva": "Mantenere coesione di branchi su grandi distanze e rilevare predatori sotterranei.",
-      "tier": "T1",
-      "usage_tags": [
-        "scout",
-        "support"
-      ],
-      "uso_funzione": "Propaga segnali ritmici che sincronizzano movimenti e abilità di squadra."
-    },
-    "rostro_emostatico_litico": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
         "has_species_link": false,
-        "has_usage_tags": false
+        "has_usage_tags": true,
+        "has_data_origin": true
       },
-      "conflitti": [],
-      "data_origin": "incoming_tr1100_pack",
-      "famiglia_tipologia": "Offensivo/Perforante",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "id": "rostro_emostatico_litico",
-      "label": "Rostro Emostatico-Litico",
-      "mutazione_indotta": "Mascellare tubulare rigidizzato.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T4",
-            "notes": ""
-          }
-        }
+      "biome_tags": [
+        "foreste_nubose"
       ],
-      "sinergie": [
-        "organi_sismici_cutanei",
-        "scheletro_idraulico_a_pistoni",
-        "ectotermia_dinamica"
-      ],
-      "slot": [],
-      "spinta_selettiva": "Predazione d'impatto a distanza ravvicinata.",
-      "tier": "T4",
-      "usage_tags": [],
-      "uso_funzione": "Inoculare tossine ed enzimi e aspirare fluidi.",
-      "metrics": [
-        {
-          "name": "velocita_proiettile",
-          "value": 120,
-          "unit": "m/s"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Puntura e retrazione in < 0.1 s",
-        "scene_prompt": "Filma in slow-motion tre attacchi su gel fluorescente"
-      },
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000178",
-          "http://purl.obolibrary.org/obo/ENVO_01000228"
-        ]
-      }
-    },
-    "scheletro_idraulico_a_pistoni": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      },
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Locomotivo/Balistico",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "id": "scheletro_idraulico_a_pistoni",
-      "label": "Scheletro Idraulico a Pistoni",
-      "mutazione_indotta": "Ossa cave pressurizzate con fluido.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T4",
-            "notes": ""
-          }
-        }
-      ],
-      "sinergie": [
-        "rostro_emostatico_litico",
-        "ipertrofia_muscolare_massiva"
-      ],
-      "slot": [],
-      "spinta_selettiva": "Vincere fughe brevi con colpi-proiettile.",
-      "tier": "T4",
-      "usage_tags": [],
-      "uso_funzione": "Estendere rapidamente il cranio per colpire.",
-      "metrics": [
-        {
-          "name": "energia_impattiva",
-          "value": 1500,
-          "unit": "J"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Colpo tipo frusta su bersaglio a 2 m",
-        "scene_prompt": "Misura penetrazione in blocchi gel balistico"
-      },
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000178"
-        ]
-      }
-    },
-    "ipertrofia_muscolare_massiva": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      },
-      "conflitti": [
-        "organi_sismici_cutanei"
-      ],
-      "data_origin": "incoming_tr1100_pack",
-      "famiglia_tipologia": "Fisiologico/Metabolico",
-      "fattore_mantenimento_energetico": "Alto (apporto costante o consumo continuo)",
-      "id": "ipertrofia_muscolare_massiva",
-      "label": "Ipertrofia Muscolare Massiva",
-      "mutazione_indotta": "Fibre a sezione aumentata e mitocondri densi.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "sinergie": [
-        "ectotermia_dinamica",
-        "scheletro_idraulico_a_pistoni"
-      ],
-      "slot": [],
-      "spinta_selettiva": "Selezione per cattura prede muscolose.",
-      "tier": "T3",
-      "usage_tags": [],
-      "uso_funzione": "Aumentare potenza e scatto.",
-      "metrics": [
-        {
-          "name": "metabolic_rate",
-          "value": 60,
-          "unit": "W/kg"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Sprint 0–10 m < 2 s",
-        "scene_prompt": "Cronometra tre sprint; rileva FC post-sforzo"
-      },
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000178"
-        ]
-      }
-    },
-    "ectotermia_dinamica": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      },
-      "conflitti": [],
-      "data_origin": "incoming_tr1100_pack",
-      "famiglia_tipologia": "Fisiologico/Termico",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "id": "ectotermia_dinamica",
-      "label": "Ectotermia Dinamica",
-      "mutazione_indotta": "Microscosse isometriche per termogenesi rapida.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "sinergie": [
-        "ipertrofia_muscolare_massiva",
-        "rostro_emostatico_litico"
-      ],
-      "slot": [],
-      "spinta_selettiva": "Caccia all’alba/crepuscolo in climi freschi.",
-      "tier": "T3",
-      "usage_tags": [],
-      "uso_funzione": "Alzare temperatura per performance.",
-      "metrics": [
-        {
-          "name": "tolleranza_termica",
-          "value": 20,
-          "unit": "K"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Mantiene output a 10 Cel ambientali",
-        "scene_prompt": "Prova in camera fredda"
-      },
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000178"
-        ]
-      }
-    },
-    "organi_sismici_cutanei": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      },
-      "conflitti": [
-        "ipertrofia_muscolare_massiva"
-      ],
-      "data_origin": "incoming_tr1100_pack",
-      "famiglia_tipologia": "Sensoriale/Tatto-Vibro",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "id": "organi_sismici_cutanei",
-      "label": "Organi Sismici Cutanei",
-      "mutazione_indotta": "Squame con lamelle meccano-recettive.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T2",
-            "notes": ""
-          }
-        }
-      ],
-      "sinergie": [
-        "rostro_emostatico_litico"
-      ],
-      "slot": [],
-      "spinta_selettiva": "Predazione in copertura e notturna.",
-      "tier": "T2",
-      "usage_tags": [],
-      "uso_funzione": "Percepire vibrazioni del suolo.",
-      "metrics": [
-        {
-          "name": "soglia_udito",
-          "value": 20,
-          "unit": "dB"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Individua passi entro 15 m",
-        "scene_prompt": "Sabbiera vibrata: segnala direzione corretta"
-      },
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000178"
-        ]
-      }
-    },
-    "ali_fono_risonanti": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Locomotivo/Aereo",
-      "fattore_mantenimento_energetico": "Medio (risonanza ad ampio spettro)",
-      "id": "ali_fono_risonanti",
-      "label": "Ali Fono-Risonanti",
-      "mutazione_indotta": "Venature come corde vibranti controllate.",
-      "debolezza": "Le membrane si lacerano o si ghiacciano facilmente riducendo la risonanza.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": "Le ali richiedono correnti asciutte e aperture per modulare fasci sonori a lungo raggio."
-          }
-        }
-      ],
-      "sinergie": [
-        "cannone_sonico_a_raggio",
-        "campo_di_interferenza_acustica",
-        "cervello_a_bassa_latenza",
-        "occhi_cinetici"
-      ],
-      "slot": [
-        "A",
-        "C"
-      ],
-      "slot_profile": {
-        "core": "locomotivo",
-        "complementare": "sensoriale"
-      },
-      "spinta_selettiva": "Mappatura ambiente e segnalazione.",
-      "tier": "T3",
-      "usage_tags": [
-        "scout",
-        "controller"
-      ],
-      "uso_funzione": "Generare ampia banda sonora in volo.",
-      "metrics": [
-        {
-          "name": "dose_acustica",
-          "value": 100,
-          "unit": "dB·s"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Varia frequenza 1–40 kHz",
-        "scene_prompt": "Spettrogramma durante manovre"
-      },
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000178"
-        ]
-      },
-      "species_affinity": [
-        {
-          "roles": [
-            "core"
-          ],
-          "species_id": "banshee-risonante",
-          "weight": 3
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "psionic-canopy-scout",
-          "weight": 2
-        }
-      ]
-    },
-    "articolazioni_a_leva_idraulica": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      },
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Locomotivo/Terrestre",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "id": "articolazioni_a_leva_idraulica",
-      "label": "Articolazioni a Leva Idraulica",
-      "mutazione_indotta": "Camere pressurizzate nelle giunture.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "sinergie": [
-        "zanne_idracida",
-        "occhi_analizzatori_di_tensione"
-      ],
-      "slot": [],
-      "spinta_selettiva": "Aggancio rapido su prede/rami.",
-      "tier": "T3",
-      "usage_tags": [],
-      "uso_funzione": "Amplificare salto e spinta delle zampe.",
-      "metrics": [
-        {
-          "name": "salto_verticale",
-          "value": 3.5,
-          "unit": "m"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Supera ostacolo 3 m",
-        "scene_prompt": "Video-analisi del salto"
-      },
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000228"
-        ]
-      }
-    },
-    "articolazioni_multiassiali": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      },
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Locomotivo/Terrestre",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "id": "articolazioni_multiassiali",
-      "label": "Articolazioni Multiassiali",
-      "mutazione_indotta": "Glenoidi/acetaboli ampliati, cartilagini elastiche.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "sinergie": [
-        "coda_prensile_muscolare"
-      ],
-      "slot": [],
-      "spinta_selettiva": "Arrampicata su tronchi umidi/scogliere",
-      "tier": "T3",
-      "usage_tags": [],
-      "uso_funzione": "Ruotare arti per manovre strette",
-      "metrics": [
-        {
-          "name": "accelerazione_0_10",
-          "value": 4.2,
-          "unit": "m/s2"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Pivot a 180° in corridoio 1 m",
-        "scene_prompt": "Traccia cono di sterzata su terreno bagnato"
-      },
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000228"
-        ]
-      }
-    },
-    "artigli_ipo_termici": {
-      "id": "artigli_ipo_termici",
-      "label": "Artigli Ipo-Termici",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Offensivo/Termico",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "tier": "T3",
-      "slot": [],
-      "sinergie": [
-        "visione_multi_spettrale_amplificata",
-        "comunicazione_fotonica_coda_coda",
-        "motore_biologico_silenzioso"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Reazioni endo-termiche locali in guaine artigli.",
-      "uso_funzione": "Indurre shock da freddo localizzato.",
-      "spinta_selettiva": "Immobilizzazione rapida senza sangue.",
-      "metrics": [
-        {
-          "name": "temperatura_fiato",
-          "value": -20,
-          "unit": "Cel"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Riduce T cutanea di 10 Cel in 2 s",
-        "scene_prompt": "Termocamera su preda simulata"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000228"
-        ]
-      },
-      "description": "Indurre shock da freddo localizzato.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "artiglio_cinetico_a_urto": {
-      "id": "artiglio_cinetico_a_urto",
-      "label": "Artiglio Cinetico a Urto",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Offensivo/Contusivo",
-      "fattore_mantenimento_energetico": "Alto (apporto costante o consumo continuo)",
-      "tier": "T4",
-      "slot": [],
-      "sinergie": [
-        "locomozione_miriapode_ibrida",
-        "estroflessione_gastrica_acida"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Appendice scattante tipo mantide pavone.",
-      "uso_funzione": "Infliggere onda d’urto e frattura.",
-      "spinta_selettiva": "Neutralizzare rapidamente prede corazzate.",
-      "metrics": [
-        {
-          "name": "energia_impattiva",
-          "value": 800,
-          "unit": "J"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Frattura tibia su osso bovino in prova",
-        "scene_prompt": "Misura impulso con accelerometro"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T4",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000228"
-        ]
-      },
-      "description": "Infliggere onda d’urto e frattura.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "aura_di_dispersione_mentale": {
-      "id": "aura_di_dispersione_mentale",
-      "label": "Aura di Dispersione Mentale",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Offensivo/Controllo",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "tier": "T3",
-      "slot": [],
-      "sinergie": [
-        "corna_psico_conduttive"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Emissioni EM deboli e odori avversivi coordinati.",
-      "uso_funzione": "Indurre ansia/vertigini nei predatori.",
-      "spinta_selettiva": "Deterrenza senza scontro fisico.",
-      "metrics": [
-        {
-          "name": "intimidazione_index",
-          "value": 0.8,
-          "unit": "1"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Predatore abbandona inseguimento",
-        "scene_prompt": "Osserva risposta etologica di canidi"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000178"
-        ]
-      },
-      "description": "Campo di odori avversivi ed emissioni deboli che induce ansia e vertigini nei predatori.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "bozzolo_magnetico": {
-      "id": "bozzolo_magnetico",
-      "label": "Bozzolo Magnetico",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Difensivo/Resistenze",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "tier": "T2",
-      "slot": [],
-      "sinergie": [
-        "integumento_bipolare",
-        "filtro_metallofago"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Campo isolante stazionario a bassa frequenza.",
-      "uso_funzione": "Schermarsi da EM esterni.",
-      "spinta_selettiva": "Riposo profondo e protezione da predatori elettrorecettivi.",
-      "metrics": [
-        {
-          "name": "campo_magnetico",
-          "value": 0.2,
-          "unit": "T"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Schermatura 10 dB EM a 0.5 m",
-        "scene_prompt": "Misura attenuazione con gaussmetro"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T2",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_00000873"
-        ]
-      },
-      "description": "Schermarsi da campi elettromagnetici esterni.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "campo_di_interferenza_acustica": {
-      "id": "campo_di_interferenza_acustica",
-      "label": "Campo di Interferenza Acustica",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Difensivo/Camuffamento",
-      "fattore_mantenimento_energetico": "Basso (rumore bianco a fase variabile)",
-      "tier": "T3",
-      "slot": [],
-      "sinergie": [
-        "ali_fono_risonanti",
-        "occhi_cinetici",
-        "cannone_sonico_a_raggio",
-        "ghiandola_caustica",
-        "spore_psichiche_silenziate"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Rumore bianco caotico a fase variabile.",
-      "debolezza": "Saturazione prolungata rompe la coerenza del rumore bianco e rivela la fonte.",
-      "uso_funzione": "Mascherare posizione/velocità.",
-      "spinta_selettiva": "Evasione da pipistrelli/rapaci.",
-      "metrics": [
-        {
-          "name": "SPL_riduzione",
-          "value": 18,
-          "unit": "dB"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Interferisce con ecolocalizzazione",
-        "scene_prompt": "Test radar acustico in galleria del vento"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000178"
-        ]
-      },
-      "description": "Mascherare posizione e velocità.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": true
-      },
-      "usage_tags": [
-        "controller",
-        "support"
-      ],
-      "slot_profile": {
-        "core": "difensivo",
-        "complementare": "controllo"
-      }
-    },
-    "cannone_sonico_a_raggio": {
-      "id": "cannone_sonico_a_raggio",
-      "label": "Cannone Sonico a Raggio",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Offensivo/Controllo",
-      "fattore_mantenimento_energetico": "Medio (scarica focalizzata con ricarica)",
-      "tier": "T4",
-      "slot": [],
-      "sinergie": [
-        "ali_fono_risonanti",
-        "occhi_cinetici",
-        "campo_di_interferenza_acustica"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Risonanza focale su membrana alare.",
-      "debolezza": "I risonatori si surriscaldano e deviano il fascio senza cicli di raffreddamento.",
-      "uso_funzione": "Stordire/ferire con raggio sonoro.",
-      "spinta_selettiva": "Caccia rapida su sciami/uccelli piccoli.",
-      "metrics": [
-        {
-          "name": "dose_acustica",
-          "value": 140,
-          "unit": "dB·s"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Stordisce pollo in 2 s a 3 m",
-        "scene_prompt": "Misura SPL puntuale + risposta preda"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T4",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000178"
-        ]
-      },
-      "description": "Stordire o ferire con un raggio sonoro.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": true
-      },
-      "usage_tags": [
-        "breaker",
-        "controller"
-      ],
-      "slot_profile": {
-        "core": "offensivo",
-        "complementare": "controllo"
-      }
-    },
-    "canto_infrasonico_tattico": {
-      "id": "canto_infrasonico_tattico",
-      "label": "Canto Infrasonico Tattico",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Offensivo/Controllo",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "tier": "T4",
-      "slot": [],
-      "sinergie": [
-        "scheletro_pneumatico_a_maglie"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Corde vocali modificate a bassa frequenza.",
-      "uso_funzione": "Disorientare predatori e comunicare a distanza.",
-      "spinta_selettiva": "Coordinamento di branco e deterrenza.",
-      "metrics": [
-        {
-          "name": "dose_acustica",
-          "value": 120,
-          "unit": "dB·s"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Predatore desiste entro 30 s",
-        "scene_prompt": "Fonometro e risposta comportamentale"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T4",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000178"
-        ]
-      },
-      "description": "Disorientare predatori e comunicare a distanza.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "cervello_a_bassa_latenza": {
-      "id": "cervello_a_bassa_latenza",
-      "label": "Cervello a Bassa Latenza",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Cognitivo/Apprendimento",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "tier": "T3",
-      "slot": [],
-      "sinergie": [
-        "ali_fono_risonanti",
-        "spore_psichiche_silenziate"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Circuiti neurali a tempi di integrazione ridotti.",
-      "uso_funzione": "Eseguire manovre ad alta frequenza.",
-      "spinta_selettiva": "Predazione aerea in stormi.",
-      "metrics": [
-        {
-          "name": "tempo_apprendimento",
-          "value": 30,
-          "unit": "s"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Apprende traiettorie in < 1 min",
-        "scene_prompt": "Task di tracking in volo"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000178"
-        ]
-      },
-      "description": "Eseguire manovre ad alta frequenza.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "cinghia_iper_ciliare": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      },
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Locomotivo/Terrestre",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "id": "cinghia_iper_ciliare",
-      "label": "Cinghia Iper-Ciliare",
-      "mutazione_indotta": "Ciglia muscolari ventrali a tappeto mobile.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "sinergie": [
-        "scheletro_pneumatico_a_maglie"
-      ],
-      "slot": [],
-      "spinta_selettiva": "Ridurre necessità di arti portanti tradizionali.",
-      "tier": "T3",
-      "usage_tags": [],
-      "uso_funzione": "Traslare il corpo su terreni piani/ruvidi.",
-      "metrics": [
-        {
-          "name": "velocita_max",
-          "value": 1.2,
-          "unit": "m/s"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Percorre 100 m su ghiaia in < 90 s",
-        "scene_prompt": "Rileva tracce ciliate su impronte"
-      },
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000178"
-        ]
-      }
-    },
-    "cisti_di_ibernazione_minerale": {
-      "id": "cisti_di_ibernazione_minerale",
-      "label": "Cisti di Ibernazione Minerale",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Difensivo/Resistenze",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "tier": "T2",
-      "slot": [],
-      "sinergie": [
-        "moltiplicazione_per_fusione",
-        "fagocitosi_assorbente"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Parete silicea a prova di calore/pressione.",
-      "uso_funzione": "Entra in stasi in condizioni avverse.",
-      "spinta_selettiva": "Sopravvivenza a lungo termine.",
-      "metrics": [
-        {
-          "name": "tolleranza_termica",
-          "value": 120,
-          "unit": "K"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Sopravvive a 80 Cel per 10 min",
-        "scene_prompt": "Test termico/pressione con risveglio successivo"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T2",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_00000873"
-        ]
-      },
-      "description": "Entrare in stasi in condizioni avverse.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "coda_prensile_muscolare": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      },
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Locomotivo/Arboricolo",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "id": "coda_prensile_muscolare",
-      "label": "Coda Prensile Muscolare",
-      "mutazione_indotta": "Fasci caudali spiralizzati, vertebre con verticilli.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "sinergie": [
-        "articolazioni_multiassiali",
-        "rostro_linguale_prensile",
-        "pelage_idrorepellente_avanzato"
-      ],
-      "slot": [],
-      "spinta_selettiva": "Foraggiamento in chioma; attraversamento gole",
-      "tier": "T3",
-      "usage_tags": [],
-      "uso_funzione": "Appendere e contro-bilanciare",
-      "metrics": [
-        {
-          "name": "salto_verticale",
-          "value": 1.8,
-          "unit": "m"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Sospensione 30 s su ramo standard",
-        "scene_prompt": "Cronometrare appensione su trave 6 cm"
-      },
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000228"
-        ]
-      }
-    },
-    "comunicazione_fotonica_coda_coda": {
-      "id": "comunicazione_fotonica_coda_coda",
-      "label": "Comunicazione Fotonica Coda-Coda",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Cognitivo/Sociale",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "tier": "T2",
-      "slot": [],
-      "sinergie": [
-        "vello_di_assorbimento_totale",
-        "artigli_ipo_termici"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Piume codali con bioluminescenza debole.",
-      "uso_funzione": "Scambiare impulsi luminosi tattili.",
-      "spinta_selettiva": "Coordinamento silente in stormo.",
-      "metrics": [
-        {
-          "name": "cohesion_index",
-          "value": 0.85,
-          "unit": "1"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Esegue virate sincronizzate",
-        "scene_prompt": "Riprese IR e analisi di coesione"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T2",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000228"
-        ]
-      },
-      "description": "Scambiare impulsi luminosi tattili.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "corna_psico_conduttive": {
-      "id": "corna_psico_conduttive",
-      "label": "Corna Psico-Conduttive",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Cognitivo/Sociale",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "tier": "T3",
-      "slot": [],
-      "sinergie": [
-        "coscienza_d_alveare_diffusa",
-        "aura_di_dispersione_mentale",
-        "metabolismo_di_condivisione_energetica",
-        "unghie_a_micro_adesione"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Tessuti piezo-neurotonici nelle corna.",
-      "uso_funzione": "Trasmettere/ricevere segnali neurali lenti.",
-      "spinta_selettiva": "Allerta precoce e tattiche di branco.",
-      "metrics": [
-        {
-          "name": "cohesion_index",
-          "value": 0.9,
-          "unit": "1"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Allerta sincrona in < 1 s",
-        "scene_prompt": "EEG di gruppo durante stimolo"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000178"
-        ]
-      },
-      "description": "Corna piezo-neurotoniche che trasmettono e ricevono segnali neurali lenti per allerta di branco.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "coscienza_d_alveare_diffusa": {
-      "id": "coscienza_d_alveare_diffusa",
-      "label": "Coscienza d’Alveare Diffusa",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Cognitivo/Sociale",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "tier": "T4",
-      "slot": [],
-      "sinergie": [
-        "corna_psico_conduttive"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Rete sinaptica inter-individuo temporanea.",
-      "uso_funzione": "Fondere decisioni e memoria a breve termine.",
-      "spinta_selettiva": "Evasione collettiva e pianificazione rapida.",
-      "metrics": [
-        {
-          "name": "tempo_apprendimento",
-          "value": 10,
-          "unit": "s"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Risoluzione labirinto condivisa",
-        "scene_prompt": "Task cooperativo con marker cranici"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T4",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000178"
-        ]
-      },
-      "description": "Rete sinaptica inter-individuo temporanea che fonde decisioni e memoria a breve termine.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "elettromagnete_biologico": {
-      "id": "elettromagnete_biologico",
-      "label": "Elettromagnete Biologico",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Offensivo/Elettrico",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "tier": "T4",
-      "slot": [],
-      "sinergie": [
-        "integumento_bipolare",
-        "filtro_metallofago"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Organo elettrico a pacchetti sincro.",
-      "uso_funzione": "Interferire con sistema nervoso preda.",
-      "spinta_selettiva": "Immobilizzare pesci e piccoli rettili.",
-      "metrics": [
-        {
-          "name": "corrente_picco",
-          "value": 15,
-          "unit": "A"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Stordisce tilapia a 1 m",
-        "scene_prompt": "Misura corrente in impulso su sonda"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T4",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_00000873"
-        ]
-      },
-      "description": "Interferire con il sistema nervoso della preda.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "ermafroditismo_cronologico": {
-      "id": "ermafroditismo_cronologico",
-      "label": "Ermafroditismo Cronologico",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Riproduttivo/Cicli",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "tier": "T3",
-      "slot": [],
-      "sinergie": [
-        "locomozione_miriapode_ibrida",
-        "estroflessione_gastrica_acida"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Rimodellamento gonadico sequenziale.",
-      "uso_funzione": "Cambiare sesso dopo 1–2 incubazioni.",
-      "spinta_selettiva": "Ottimizzare successo riproduttivo in densità variabile.",
-      "metrics": [
-        {
-          "name": "tasso_propaguli",
-          "value": 50,
-          "unit": "1/season"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Ciclo documentato su due stagioni",
-        "scene_prompt": "Registro di incubazione con campionamenti ormonali"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000228"
-        ]
-      },
-      "description": "Cambiare sesso dopo 1–2 incubazioni.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "estroflessione_gastrica_acida": {
-      "id": "estroflessione_gastrica_acida",
-      "label": "Estroflessione Gastrica Acida",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Offensivo/Chimico",
-      "fattore_mantenimento_energetico": "Alto (apporto costante o consumo continuo)",
-      "tier": "T4",
-      "slot": [],
-      "sinergie": [
-        "artiglio_cinetico_a_urto",
-        "ermafroditismo_cronologico",
-        "sistemi_chimio_sonici"
-      ],
-      "conflitti": [
-        "sistemi_chimio_sonici"
-      ],
-      "mutazione_indotta": "Sacca digestiva everted con enzimi proteolitici.",
-      "uso_funzione": "Liquefare tessuti su contatto e aspirare.",
-      "spinta_selettiva": "Cattura prede più grandi con rischio minimo.",
-      "metrics": [
-        {
-          "name": "pressione_getto",
-          "value": 50000,
-          "unit": "Pa"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Disgrega 1 kg gel proteico in < 60 s",
-        "scene_prompt": "Versa su supporto standard e misura tempo liquefazione"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T4",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000228"
-        ]
-      },
-      "description": "Liquefare tessuti al contatto e aspirarli.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "fagocitosi_assorbente": {
-      "id": "fagocitosi_assorbente",
-      "label": "Fagocitosi Assorbente",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Alimentazione/Digestione",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "tier": "T3",
-      "slot": [],
-      "sinergie": [
-        "membrana_plastica_continua",
-        "cisti_di_ibernazione_minerale"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Invaginazione membranaria a vacuolo digestivo.",
-      "uso_funzione": "Inglobare e digerire biomassa intera.",
-      "spinta_selettiva": "Dieta onnivora opportunista.",
-      "metrics": [
-        {
-          "name": "volume_ingestione",
-          "value": 5,
-          "unit": "L"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Assorbe 1 L di gel in < 30 s",
-        "scene_prompt": "Misura variazione massa dopo contatto prolungato"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_00000873"
-        ]
-      },
-      "description": "Inglobare e digerire biomassa intera.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "filtrazione_osmotica": {
-      "id": "filtrazione_osmotica",
-      "label": "Filtrazione Osmotica",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Fisiologico/Idrico",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "tier": "T2",
-      "slot": [],
-      "sinergie": [
-        "zanne_idracida"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Reni a multi-stadio con escrezione selettiva.",
-      "uso_funzione": "Neutralizzare tossine autogenerate.",
-      "spinta_selettiva": "Sopravvivere all’autointossicazione.",
-      "metrics": [
-        {
-          "name": "metabolic_rate",
-          "value": 15,
-          "unit": "W/kg"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Emivita tossine ridotta del 50%",
-        "scene_prompt": "Analisi ematica dopo somministrazione standard"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T2",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000228"
-        ]
-      },
-      "description": "Neutralizzare tossine autogenerate.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "filtro_metallofago": {
-      "id": "filtro_metallofago",
-      "label": "Filtro Metallofago",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Alimentazione/Digestione",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "tier": "T2",
-      "slot": [],
-      "sinergie": [
-        "elettromagnete_biologico",
-        "bozzolo_magnetico"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Assorbimento selettivo di micro-metalli.",
-      "uso_funzione": "Sostenere organi elettrogeni.",
-      "spinta_selettiva": "Metabolismo efficiente in acque povere.",
-      "metrics": [
-        {
-          "name": "metabolic_rate",
-          "value": 12,
-          "unit": "W/kg"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Livelli Fe plasmatico stabili",
-        "scene_prompt": "Profilo ematico su dieta priva di Fe"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T2",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_00000873"
-        ]
-      },
-      "description": "Sostenere organi elettrogeni.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "flusso_ameboide_controllato": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      },
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Locomotivo/Terrestre",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "id": "flusso_ameboide_controllato",
-      "label": "Flusso Ameboide Controllato",
-      "mutazione_indotta": "Pseudopodi coordinati a pressione interna.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T2",
-            "notes": ""
-          }
-        }
-      ],
-      "sinergie": [
-        "membrana_plastica_continua",
-        "nucleo_ovomotore_rotante"
-      ],
-      "slot": [],
-      "spinta_selettiva": "Ricerca cibo in interstizi umidi.",
-      "tier": "T2",
-      "usage_tags": [],
-      "uso_funzione": "Scivolare/risalire superfici lisce.",
-      "metrics": [
-        {
-          "name": "raggio_di_volta",
-          "value": 0.1,
-          "unit": "m"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Curva stretta in tubo 20 cm",
-        "scene_prompt": "Traccia percorso in labirinto cilindrico"
-      },
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_00000873"
-        ]
-      }
-    },
-    "integumento_bipolare": {
-      "id": "integumento_bipolare",
-      "label": "Integumento Bipolare",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Sensoriale/Magneto-ricettivo",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "tier": "T3",
-      "slot": [],
-      "sinergie": [
-        "scivolamento_magnetico",
-        "bozzolo_magnetico",
-        "elettromagnete_biologico"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Cristalli di magnetite dermici con neuriti afferenti.",
-      "uso_funzione": "Orientarsi su linee di campo.",
-      "spinta_selettiva": "Migrazioni precise e caccia notturna.",
-      "metrics": [
-        {
-          "name": "sens_magnetica",
-          "value": 1e-06,
-          "unit": "T"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Mantiene rotta con EM artificiale",
-        "scene_prompt": "Labirinto con bobine Helmholtz"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_00000304",
-          "http://purl.obolibrary.org/obo/ENVO_00000873"
-        ]
-      },
-      "description": "Orientarsi lungo le linee di campo.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "locomozione_miriapode_ibrida": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      },
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Locomotivo/Terrestre",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "id": "locomozione_miriapode_ibrida",
-      "label": "Locomozione Miriapode Ibrida",
-      "mutazione_indotta": "50–100 paia di arti segmentati.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "sinergie": [
-        "artiglio_cinetico_a_urto",
-        "ermafroditismo_cronologico",
-        "sistemi_chimio_sonici",
-        "nucleo_ovomotore_rotante"
-      ],
-      "slot": [],
-      "spinta_selettiva": "Predazione in tunnel e pareti rocciose.",
-      "tier": "T3",
-      "usage_tags": [],
-      "uso_funzione": "Aderire e arrampicare su qualsiasi superficie.",
-      "metrics": [
-        {
-          "name": "velocita_max",
-          "value": 2.5,
-          "unit": "m/s"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Scala parete 3 m in < 10 s",
-        "scene_prompt": "Cronometra arrampicata su pannello 80°"
-      },
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000228"
-        ]
-      }
-    },
-    "membrana_plastica_continua": {
-      "id": "membrana_plastica_continua",
-      "label": "Membrana Plastica Continua",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Difensivo/Camuffamento",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "tier": "T3",
-      "slot": [],
-      "sinergie": [
-        "flusso_ameboide_controllato",
-        "fagocitosi_assorbente",
-        "moltiplicazione_per_fusione",
-        "secrezione_rallentante_palmi"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Struttura citoscheletrica rimodulabile.",
-      "uso_funzione": "Assumere forme e densità diverse.",
-      "spinta_selettiva": "Elusione predatori e passaggio micro-fessure.",
-      "metrics": [
-        {
-          "name": "rilevabilita_visiva",
-          "value": 0.2,
-          "unit": "1"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Forma blob semitrasparente in 3 s",
-        "scene_prompt": "Documenta transito in fessura 5 mm"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_00000873"
-        ]
-      },
-      "description": "Assumere forme e densità diverse.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "metabolismo_di_condivisione_energetica": {
-      "id": "metabolismo_di_condivisione_energetica",
-      "label": "Metabolismo di Condivisione Energetica",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Fisiologico/Metabolico",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "tier": "T3",
-      "slot": [],
-      "sinergie": [
-        "corna_psico_conduttive"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Trasferimento di substrati via contatto/derma.",
-      "uso_funzione": "Sostenere feriti/giovani con riserva collettiva.",
-      "spinta_selettiva": "Massimizzare sopravvivenza del branco.",
-      "metrics": [
-        {
-          "name": "consumo_o2",
-          "value": 50,
-          "unit": "L/min"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Ripristino FC di infortunato accelerato",
-        "scene_prompt": "Misura lattato prima/dopo contatto"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000178"
-        ]
-      },
-      "description": "Trasferimento di substrati via contatto per sostenere feriti o giovani con una riserva collettiva.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "moltiplicazione_per_fusione": {
-      "id": "moltiplicazione_per_fusione",
-      "label": "Moltiplicazione per Fusione",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Riproduttivo/Cicli",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "tier": "T2",
-      "slot": [],
-      "sinergie": [
-        "cisti_di_ibernazione_minerale",
-        "membrana_plastica_continua"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Scissione binaria e fusione selettiva.",
-      "uso_funzione": "Aumentare massa/intelligenza unendo unità.",
-      "spinta_selettiva": "Resilienza in condizioni variabili.",
-      "metrics": [
-        {
-          "name": "tasso_propaguli",
-          "value": 3,
-          "unit": "1/season"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Raddoppio massa in 24 h",
-        "scene_prompt": "Time-lapse di scissione e fusione"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T2",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_00000873"
-        ]
-      },
-      "description": "Aumentare massa e intelligenza unendo unità.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "motore_biologico_silenzioso": {
-      "id": "motore_biologico_silenzioso",
-      "label": "Motore Biologico Silenzioso",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Fisiologico/Metabolico",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "tier": "T2",
-      "slot": [],
-      "sinergie": [
-        "vello_di_assorbimento_totale",
-        "artigli_ipo_termici"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Tendini frangi-rumore + piume a bordo seghettato.",
-      "uso_funzione": "Volo prolungato a bassissimo SPL.",
-      "spinta_selettiva": "Caccia persistente con sorpresa tattica.",
-      "metrics": [
-        {
-          "name": "metabolic_rate",
-          "value": 8,
-          "unit": "W/kg"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "SPL < 20 dB a 5 m in volo",
-        "scene_prompt": "Misura sonoro in tunnel"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T2",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000228"
-        ]
-      },
-      "description": "Garantire volo prolungato a bassissimo SPL.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "occhi_analizzatori_di_tensione": {
-      "id": "occhi_analizzatori_di_tensione",
-      "label": "Occhi Analizzatori di Tensione",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Sensoriale/Visivo",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "tier": "T2",
-      "slot": [],
-      "sinergie": [
-        "seta_conduttiva_elettrica",
-        "articolazioni_a_leva_idraulica"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Retina sensibile alla polarizzazione.",
-      "uso_funzione": "Leggere tensioni nella seta e pattern di stress.",
-      "spinta_selettiva": "Ottimizzare riparazioni e trappole.",
-      "metrics": [
-        {
-          "name": "acuita_visiva",
-          "value": 0.92,
-          "unit": "1"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Rileva filo scarico vs carico",
-        "scene_prompt": "Test scelta su trame con diversa polarizzazione"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T2",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000228"
-        ]
-      },
-      "description": "Leggere tensioni nella seta e pattern di stress.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "occhi_cinetici": {
-      "id": "occhi_cinetici",
-      "label": "Occhi Cinetici",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Sensoriale/Visivo",
-      "fattore_mantenimento_energetico": "Basso (micro-attuatori oculari)",
-      "tier": "T2",
-      "slot": [],
-      "sinergie": [
-        "cannone_sonico_a_raggio",
-        "campo_di_interferenza_acustica",
-        "ali_fono_risonanti",
-        "occhi_cristallo_modulare"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Retina sensibile a distorsioni da vibrazione.",
-      "debolezza": "I micro-attuatori si saturano di polveri, rallentando la messa a fuoco.",
-      "uso_funzione": "Vedere il suono come pattern d’aria.",
-      "spinta_selettiva": "Allineamento col cannone sonico.",
-      "metrics": [
-        {
-          "name": "acuita_visiva",
-          "value": 0.8,
-          "unit": "1"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Riconosce vortici davanti al raggio",
-        "scene_prompt": "Strobo fumo + valutazione traiettoria"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T2",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000178"
-        ]
-      },
-      "description": "Vedere il suono come pattern d’aria.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": true
-      },
-      "usage_tags": [
-        "scout",
-        "support"
-      ],
-      "slot_profile": {
-        "core": "sensoriale",
-        "complementare": "supporto"
-      }
-    },
-    "pelage_idrorepellente_avanzato": {
-      "id": "pelage_idrorepellente_avanzato",
-      "label": "Pelage Idrorepellente Avanzato",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Difensivo/Termoregolazione",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "tier": "T2",
-      "slot": [],
-      "sinergie": [
-        "scudo_gluteale_cheratinizzato",
-        "coda_prensile_muscolare"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Ghiandole olocrine con olio ad alta densità.",
-      "uso_funzione": "Isolare e galleggiare",
-      "spinta_selettiva": "Foraggiamento anfibio e notturno in climi umidi.",
-      "metrics": [
-        {
-          "name": "res_termica",
-          "value": 0.08,
-          "unit": "K/W"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Mantello asciutto dopo immersione 2 min",
-        "scene_prompt": "Pesare prima/dopo immersione in acqua dolce"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T2",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_00000873",
-          "http://purl.obolibrary.org/obo/ENVO_01000228"
-        ]
-      },
-      "description": "Isolare e galleggiare.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "rete_filtro_polmonare": {
-      "id": "rete_filtro_polmonare",
-      "label": "Rete Filtro-Polmonare",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Fisiologico/Respiratorio",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "tier": "T3",
-      "slot": [],
-      "sinergie": [
-        "scheletro_pneumatico_a_maglie"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Ghiandole parenchimali filtranti in sacche polmonari.",
-      "uso_funzione": "Assorbire nutrienti aerodispersi.",
-      "spinta_selettiva": "Sussistenza in ambienti poveri di vegetazione.",
-      "metrics": [
-        {
-          "name": "consumo_O2",
-          "value": 800,
-          "unit": "L/min"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Incremento massa senza ingesta solida",
-        "scene_prompt": "Camera aerosol con micro-fitoplancton"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000178"
-        ]
-      },
-      "description": "Assorbire nutrienti aerodispersi.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "rostro_linguale_prensile": {
-      "id": "rostro_linguale_prensile",
-      "label": "Rostro Linguale Prensile",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Manipolativo/Alimentare",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "tier": "T3",
-      "slot": [],
-      "sinergie": [
-        "coda_prensile_muscolare"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Lingua muscolare adesiva con ioide esteso.",
-      "uso_funzione": "Afferrrare/manipolare a lungo raggio",
-      "spinta_selettiva": "Accesso a risorse in cavità/altezza senza muovere il corpo",
-      "metrics": [
-        {
-          "name": "lunghezza_estensione",
-          "value": 2.0,
-          "unit": "m"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Estrae oggetto a 2 m in 3 s",
-        "scene_prompt": "Recupero uovo da cavità senza frattura"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000228"
-        ]
-      },
-      "description": "Afferrare e manipolare a lungo raggio.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "scheletro_pneumatico_a_maglie": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      },
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Locomotivo/Terrestre",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "id": "scheletro_pneumatico_a_maglie",
-      "label": "Scheletro Pneumatico a Maglie",
-      "mutazione_indotta": "Ossa porose con alveoli d’aria.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "sinergie": [
-        "cinghia_iper_ciliare",
-        "canto_infrasonico_tattico",
-        "rete_filtro_polmonare",
-        "siero_anti_gelo_naturale"
-      ],
-      "slot": [],
-      "spinta_selettiva": "Transito terrestre di megafauna fuori dall’acqua.",
-      "tier": "T3",
-      "usage_tags": [],
-      "uso_funzione": "Alleggerire il carico per spostamenti lenti ma costanti.",
-      "metrics": [
-        {
-          "name": "metabolic_rate",
-          "value": 20,
-          "unit": "W/kg"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Spostamento 5 km senza affaticamento eccessivo",
-        "scene_prompt": "Test su piastra di forza per massa apparente"
-      },
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000178"
-        ]
-      }
-    },
-    "scivolamento_magnetico": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      },
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Locomotivo/Terrestre",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "id": "scivolamento_magnetico",
-      "label": "Scivolamento Magnetico",
-      "mutazione_indotta": "Rivestimento paramagnetico + micro-vibrazioni.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "sinergie": [
-        "integumento_bipolare"
-      ],
-      "slot": [],
-      "spinta_selettiva": "Traslazione silente su superfici variabili.",
-      "tier": "T3",
-      "usage_tags": [],
-      "uso_funzione": "Ridurre attrito e scivolare.",
-      "metrics": [
-        {
-          "name": "velocita_max",
-          "value": 4.0,
-          "unit": "m/s"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Percorre 50 m su sabbia in 20 s",
-        "scene_prompt": "Cronometra su tre substrati diversi"
-      },
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_00000304"
-        ]
-      }
-    },
-    "scudo_gluteale_cheratinizzato": {
-      "id": "scudo_gluteale_cheratinizzato",
-      "label": "Scudo Gluteale Cheratinizzato",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Difensivo/Corazza",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "tier": "T3",
-      "slot": [],
-      "sinergie": [
-        "pelage_idrorepellente_avanzato"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Placca subdermica cheratino-ossea su eminenze glutee.",
-      "uso_funzione": "Assorbire impatti posteriori",
-      "spinta_selettiva": "Predatori d’agguato; lotte in tana stretta",
-      "metrics": [
-        {
-          "name": "spessore_corazza",
-          "value": 35,
-          "unit": "mm"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Resiste a morso medio senza lesioni",
-        "scene_prompt": "Pressare su dinamometro dorsale"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000228"
-        ]
-      },
-      "description": "Assorbire impatti posteriori.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "seta_conduttiva_elettrica": {
-      "id": "seta_conduttiva_elettrica",
-      "label": "Seta Conduttiva Elettrica",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Offensivo/Elettrico",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "tier": "T4",
-      "slot": [],
-      "sinergie": [
-        "zanne_idracida",
-        "occhi_analizzatori_di_tensione"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Seta con nano-metalli piezoresponsivi.",
-      "uso_funzione": "Stordire con scariche nella tela.",
-      "spinta_selettiva": "Cattura prede veloci con trappola attiva.",
-      "metrics": [
-        {
-          "name": "tensione_picco",
-          "value": 1200,
-          "unit": "V"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Scarica a impulso su sonda",
-        "scene_prompt": "Misura tensione su rete 1×1 m"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T4",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000228"
-        ]
-      },
-      "description": "Stordire con scariche nella tela.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "siero_anti_gelo_naturale": {
-      "id": "siero_anti_gelo_naturale",
-      "label": "Siero Anti-Gelo Naturale",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Fisiologico/Termico",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "tier": "T2",
-      "slot": [],
-      "sinergie": [
-        "scheletro_pneumatico_a_maglie"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Proteine antigelo circolanti.",
-      "uso_funzione": "Impedire cristallizzazione a basse temperature.",
-      "spinta_selettiva": "Migrazione notturna in steppe fredde.",
-      "metrics": [
-        {
-          "name": "tolleranza_termica",
-          "value": 60,
-          "unit": "K"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Mantiene mobilità a −20 Cel",
-        "scene_prompt": "Camera climatica con prova motoria"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T2",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000178"
-        ]
-      },
-      "description": "Impedire la cristallizzazione a basse temperature.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "sistemi_chimio_sonici": {
-      "id": "sistemi_chimio_sonici",
-      "label": "Sistemi Chimio-Sonici",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Sensoriale/Uditivo-Olfattivo",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "tier": "T3",
-      "slot": [],
-      "sinergie": [
-        "locomozione_miriapode_ibrida",
-        "estroflessione_gastrica_acida",
-        "ghiandola_caustica"
-      ],
-      "conflitti": [
-        "estroflessione_gastrica_acida"
-      ],
-      "mutazione_indotta": "Echolocazione + spruzzi feromonali orientativi.",
-      "uso_funzione": "Mappare spazio e correnti d’aria senza vista.",
-      "spinta_selettiva": "Caccia in buio totale e gallerie fumose.",
-      "metrics": [
-        {
-          "name": "banda_uditiva_max",
-          "value": 120000,
-          "unit": "Hz"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Evita ostacoli a 10 m in fumo denso",
-        "scene_prompt": "Tunnel con curve cieche + generatore di fumo"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000228"
-        ]
-      },
-      "description": "Mappare spazio e correnti d’aria senza vista.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "unghie_a_micro_adesione": {
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      },
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Locomotivo/Arboricolo",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "id": "unghie_a_micro_adesione",
-      "label": "Unghie a Micro-Adesione",
-      "mutazione_indotta": "Lamelle a micro-setole tipo geco su zoccoli.",
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T2",
-            "notes": ""
-          }
-        }
-      ],
-      "sinergie": [
-        "corna_psico_conduttive"
-      ],
-      "slot": [],
-      "spinta_selettiva": "Fuga verticale e pascolo in cenge.",
-      "tier": "T2",
-      "usage_tags": [],
-      "uso_funzione": "Aderire a superfici ripide.",
-      "metrics": [
-        {
-          "name": "tasso_di_salita",
-          "value": 1.2,
-          "unit": "m/s"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Scala parete 10 m inclinata 75°",
-        "scene_prompt": "Cronometra salita su lastra liscia"
-      },
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000178"
-        ]
-      }
-    },
-    "vello_di_assorbimento_totale": {
-      "id": "vello_di_assorbimento_totale",
-      "label": "Vello di Assorbimento Totale",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Difensivo/Camuffamento",
-      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
-      "tier": "T3",
-      "slot": [],
-      "sinergie": [
-        "visione_multi_spettrale_amplificata",
-        "comunicazione_fotonica_coda_coda",
-        "motore_biologico_silenzioso"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Nano-strutture piumari tipo vantablack biologico.",
-      "uso_funzione": "Assorbire quasi tutta la luce incidente.",
-      "spinta_selettiva": "Caccia e fuga in oscurità totale.",
-      "metrics": [
-        {
-          "name": "trasmittanza_ottica",
-          "value": 0.001,
-          "unit": "1"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Indistinguibile a 5 m al buio",
-        "scene_prompt": "Fotometro: luce riflessa vs piuma standard"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000228"
-        ]
-      },
-      "description": "Assorbire quasi tutta la luce incidente.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "visione_multi_spettrale_amplificata": {
-      "id": "visione_multi_spettrale_amplificata",
-      "label": "Visione Multi-Spettrale Amplificata",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Sensoriale/Visivo",
-      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
-      "tier": "T3",
-      "slot": [],
-      "sinergie": [
-        "vello_di_assorbimento_totale",
-        "artigli_ipo_termici",
-        "occhi_cristallo_modulare"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Bastoncelli potenziati + recettori IR/UV.",
-      "uso_funzione": "Vedere in luminanza estremamente bassa.",
-      "spinta_selettiva": "Predazione su prede a sangue caldo.",
-      "metrics": [
-        {
-          "name": "acuita_visiva",
-          "value": 0.95,
-          "unit": "1"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Rileva topo a 30 m al chiaro di luna",
-        "scene_prompt": "Prova campo notturna con target termico"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T3",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000228"
-        ]
-      },
-      "description": "Vedere in luminanza estremamente bassa.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "zanne_idracida": {
-      "id": "zanne_idracida",
-      "label": "Zanne Idracida",
-      "data_origin": "coverage_q4_2025",
-      "famiglia_tipologia": "Offensivo/Chimico",
-      "fattore_mantenimento_energetico": "Alto (apporto costante o consumo continuo)",
-      "tier": "T4",
-      "slot": [],
-      "sinergie": [
-        "seta_conduttiva_elettrica",
-        "articolazioni_a_leva_idraulica",
-        "filtrazione_osmotica"
-      ],
-      "conflitti": [],
-      "mutazione_indotta": "Ghiandole acido-termiche nei cheliceri.",
-      "uso_funzione": "Corrodere tessuti e metalli.",
-      "spinta_selettiva": "Predazione su prede in corazza minerale.",
-      "metrics": [
-        {
-          "name": "pressione_getto",
-          "value": 1000000,
-          "unit": "Pa"
-        }
-      ],
-      "cost_profile": {
-        "rest": "Basso",
-        "burst": "Medio",
-        "sustained": "Basso"
-      },
-      "testability": {
-        "observable": "Perfora lamina d’alluminio 1 mm",
-        "scene_prompt": "Spruzzo controllato su pannello metallico"
-      },
-      "requisiti_ambientali": [
-        {
-          "capacita_richieste": [],
-          "condizioni": {
-            "biome_class": "terrestre"
-          },
-          "fonte": "envo_mapping",
-          "meta": {
-            "tier": "T4",
-            "notes": ""
-          }
-        }
-      ],
-      "applicability": {
-        "clades": [],
-        "envo_terms": [
-          "http://purl.obolibrary.org/obo/ENVO_01000228"
-        ]
-      },
-      "description": "Corrodere tessuti e metalli.",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": false
-      }
-    },
-    "coralli_sinaptici_fotofase": {
-      "id": "coralli_sinaptici_fotofase",
-      "label": "Coralli Sinaptici Fotofase",
-      "famiglia_tipologia": "Ambiente/Supporto",
-      "data_origin": "frattura_abissale_sinaptica",
-      "requisiti_ambientali": [
-        {
-          "fonte": "env_to_traits",
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T1",
-            "notes": "Cresta Fotofase"
-          }
-        }
-      ],
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": true
-      },
-      "sinergie": [],
-      "mutazione_indotta": "i18n:traits.coralli_sinaptici_fotofase.mutazione_indotta",
-      "uso_funzione": "i18n:traits.coralli_sinaptici_fotofase.uso_funzione",
-      "spinta_selettiva": "i18n:traits.coralli_sinaptici_fotofase.spinta_selettiva"
-    },
-    "membrane_fotoconvoglianti": {
-      "id": "membrane_fotoconvoglianti",
-      "label": "Membrane Fotoconvoglianti",
-      "famiglia_tipologia": "Difesa/Elettrico",
-      "data_origin": "frattura_abissale_sinaptica",
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T1"
-          }
-        }
-      ],
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": true
-      },
-      "conflitti": [
-        "affaticamento_oculare"
-      ],
-      "mutazione_indotta": "i18n:traits.membrane_fotoconvoglianti.mutazione_indotta",
-      "uso_funzione": "i18n:traits.membrane_fotoconvoglianti.uso_funzione",
-      "spinta_selettiva": "i18n:traits.membrane_fotoconvoglianti.spinta_selettiva"
-    },
-    "nodi_sinaptici_superficiali": {
-      "id": "nodi_sinaptici_superficiali",
-      "label": "Nodi Sinaptici Superficiali",
-      "famiglia_tipologia": "Supporto/Sensore",
-      "data_origin": "frattura_abissale_sinaptica",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": true
-      },
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [],
-      "mutazione_indotta": "i18n:traits.nodi_sinaptici_superficiali.mutazione_indotta",
-      "uso_funzione": "i18n:traits.nodi_sinaptici_superficiali.uso_funzione",
-      "spinta_selettiva": "i18n:traits.nodi_sinaptici_superficiali.spinta_selettiva"
-    },
-    "impulsi_bioluminescenti": {
-      "id": "impulsi_bioluminescenti",
-      "label": "Impulsi Bioluminescenti",
-      "famiglia_tipologia": "Offensivo/Illuminazione",
-      "data_origin": "frattura_abissale_sinaptica",
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T1"
-          }
-        }
-      ],
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "sinergie": [],
-      "mutazione_indotta": "i18n:traits.impulsi_bioluminescenti.mutazione_indotta",
-      "uso_funzione": "i18n:traits.impulsi_bioluminescenti.uso_funzione",
-      "spinta_selettiva": "i18n:traits.impulsi_bioluminescenti.spinta_selettiva"
-    },
-    "filamenti_guidalampo": {
-      "id": "filamenti_guidalampo",
-      "label": "Filamenti Guidalampo",
-      "famiglia_tipologia": "Mobilità/Logistica",
-      "data_origin": "frattura_abissale_sinaptica",
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T1"
-          }
-        }
-      ],
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": true
-      },
-      "mutazione_indotta": "i18n:traits.filamenti_guidalampo.mutazione_indotta",
-      "uso_funzione": "i18n:traits.filamenti_guidalampo.uso_funzione",
-      "spinta_selettiva": "i18n:traits.filamenti_guidalampo.spinta_selettiva"
-    },
-    "sensori_planctonici": {
-      "id": "sensori_planctonici",
-      "label": "Sensori Planctonici",
-      "famiglia_tipologia": "Analisi/Sensori Planctonici",
-      "data_origin": "frattura_abissale_sinaptica",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": true
-      },
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [],
-      "mutazione_indotta": "i18n:traits.sensori_planctonici.mutazione_indotta",
-      "uso_funzione": "i18n:traits.sensori_planctonici.uso_funzione",
-      "spinta_selettiva": "i18n:traits.sensori_planctonici.spinta_selettiva"
-    },
-    "squame_diffusori_ionici": {
-      "id": "squame_diffusori_ionici",
-      "label": "Squame Diffusori Ionici",
-      "famiglia_tipologia": "Difesa/Elettrico",
-      "data_origin": "frattura_abissale_sinaptica",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": true
-      },
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T1"
-          }
-        }
-      ],
-      "conflitti": [
-        "overcharge_cronico"
-      ],
-      "mutazione_indotta": "i18n:traits.squame_diffusori_ionici.mutazione_indotta",
-      "uso_funzione": "i18n:traits.squame_diffusori_ionici.uso_funzione",
-      "spinta_selettiva": "i18n:traits.squame_diffusori_ionici.spinta_selettiva"
-    },
-    "nebbia_mnesica": {
-      "id": "nebbia_mnesica",
-      "label": "Nebbia Mnesica",
-      "famiglia_tipologia": "Controllo/Mnesica",
-      "data_origin": "frattura_abissale_sinaptica",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T2"
-          }
-        }
-      ],
-      "conflitti": [
-        "immunoscossa"
-      ],
-      "sinergie": [],
-      "mutazione_indotta": "i18n:traits.nebbia_mnesica.mutazione_indotta",
-      "uso_funzione": "i18n:traits.nebbia_mnesica.uso_funzione",
-      "spinta_selettiva": "i18n:traits.nebbia_mnesica.spinta_selettiva"
-    },
-    "lobi_risonanti_crepuscolo": {
-      "id": "lobi_risonanti_crepuscolo",
-      "label": "Lobi Risonanti Crepuscolo",
-      "famiglia_tipologia": "Supporto/Risonanza",
-      "data_origin": "frattura_abissale_sinaptica",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T2"
-          }
-        }
-      ],
-      "sinergie": [],
-      "mutazione_indotta": "i18n:traits.lobi_risonanti_crepuscolo.mutazione_indotta",
-      "uso_funzione": "i18n:traits.lobi_risonanti_crepuscolo.uso_funzione",
-      "spinta_selettiva": "i18n:traits.lobi_risonanti_crepuscolo.spinta_selettiva"
-    },
-    "placca_diffusione_foschia": {
-      "id": "placca_diffusione_foschia",
-      "label": "Placca di Diffusione Foschia",
-      "famiglia_tipologia": "Difesa/Aura",
-      "data_origin": "frattura_abissale_sinaptica",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": true
-      },
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T2"
-          }
-        }
-      ],
-      "sinergie": [],
-      "mutazione_indotta": "i18n:traits.placca_diffusione_foschia.mutazione_indotta",
-      "uso_funzione": "i18n:traits.placca_diffusione_foschia.uso_funzione",
-      "spinta_selettiva": "i18n:traits.placca_diffusione_foschia.spinta_selettiva"
-    },
-    "spicole_canalizzatrici": {
-      "id": "spicole_canalizzatrici",
-      "label": "Spicole Canalizzatrici",
-      "famiglia_tipologia": "Offensivo/Assorbimento",
-      "data_origin": "frattura_abissale_sinaptica",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": true
-      },
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T2"
-          }
-        }
-      ],
-      "sinergie": [],
-      "mutazione_indotta": "i18n:traits.spicole_canalizzatrici.mutazione_indotta",
-      "uso_funzione": "i18n:traits.spicole_canalizzatrici.uso_funzione",
-      "spinta_selettiva": "i18n:traits.spicole_canalizzatrici.spinta_selettiva"
-    },
-    "secrezioni_antistatiche": {
-      "id": "secrezioni_antistatiche",
-      "label": "Secrezioni Antistatiche",
-      "famiglia_tipologia": "Difensivo/Elettrico",
-      "data_origin": "frattura_abissale_sinaptica",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": true
-      },
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T2"
-          }
-        }
-      ],
-      "conflitti": [
-        "corrosione_instabile"
-      ],
-      "mutazione_indotta": "i18n:traits.secrezioni_antistatiche.mutazione_indotta",
-      "uso_funzione": "i18n:traits.secrezioni_antistatiche.uso_funzione",
-      "spinta_selettiva": "i18n:traits.secrezioni_antistatiche.spinta_selettiva"
-    },
-    "organi_metacronici": {
-      "id": "organi_metacronici",
-      "label": "Organi Metacronici",
-      "famiglia_tipologia": "Supporto/Sequenziamento",
-      "data_origin": "frattura_abissale_sinaptica",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T2"
-          }
-        }
-      ],
-      "sinergie": [],
-      "mutazione_indotta": "i18n:traits.organi_metacronici.mutazione_indotta",
-      "uso_funzione": "i18n:traits.organi_metacronici.uso_funzione",
-      "spinta_selettiva": "i18n:traits.organi_metacronici.spinta_selettiva"
-    },
-    "ghiandole_mnemoniche": {
-      "id": "ghiandole_mnemoniche",
-      "label": "Ghiandole Mnemoniche",
-      "famiglia_tipologia": "Supporto/Copia",
-      "data_origin": "frattura_abissale_sinaptica",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T2"
-          }
-        }
-      ],
-      "sinergie": [],
-      "mutazione_indotta": "i18n:traits.ghiandole_mnemoniche.mutazione_indotta",
-      "uso_funzione": "i18n:traits.ghiandole_mnemoniche.uso_funzione",
-      "spinta_selettiva": "i18n:traits.ghiandole_mnemoniche.spinta_selettiva"
-    },
-    "camere_risonanza_abyssal": {
-      "id": "camere_risonanza_abyssal",
-      "label": "Camere di Risonanza Abyssal",
-      "famiglia_tipologia": "Supporto/Risonanza",
-      "data_origin": "frattura_abissale_sinaptica",
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T3"
-          }
-        }
-      ],
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "sinergie": [],
-      "mutazione_indotta": "i18n:traits.camere_risonanza_abyssal.mutazione_indotta",
-      "uso_funzione": "i18n:traits.camere_risonanza_abyssal.uso_funzione",
-      "spinta_selettiva": "i18n:traits.camere_risonanza_abyssal.spinta_selettiva"
-    },
-    "corazze_ferro_magnetico": {
-      "id": "corazze_ferro_magnetico",
-      "label": "Corazze Ferro-Magnetico",
-      "famiglia_tipologia": "Difesa/Magnetico",
-      "data_origin": "frattura_abissale_sinaptica",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": true
-      },
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T3"
-          }
-        }
-      ],
-      "sinergie": [],
-      "conflitti": [
-        "ossidazione_rapida"
-      ],
-      "mutazione_indotta": "i18n:traits.corazze_ferro_magnetico.mutazione_indotta",
-      "uso_funzione": "i18n:traits.corazze_ferro_magnetico.uso_funzione",
-      "spinta_selettiva": "i18n:traits.corazze_ferro_magnetico.spinta_selettiva"
-    },
-    "bioantenne_gravitiche": {
-      "id": "bioantenne_gravitiche",
-      "label": "Bioantenne Gravitiche",
-      "famiglia_tipologia": "Sensore/Gravitazionale",
-      "data_origin": "frattura_abissale_sinaptica",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T3"
-          }
-        }
-      ],
-      "sinergie": [],
-      "mutazione_indotta": "i18n:traits.bioantenne_gravitiche.mutazione_indotta",
-      "uso_funzione": "i18n:traits.bioantenne_gravitiche.uso_funzione",
-      "spinta_selettiva": "i18n:traits.bioantenne_gravitiche.spinta_selettiva"
-    },
-    "emettitori_voidsong": {
-      "id": "emettitori_voidsong",
-      "label": "Emettitori Voidsong",
-      "famiglia_tipologia": "Supporto/Anomalia",
-      "data_origin": "frattura_abissale_sinaptica",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T3"
-          }
-        }
-      ],
-      "sinergie": [],
-      "mutazione_indotta": "i18n:traits.emettitori_voidsong.mutazione_indotta",
-      "uso_funzione": "i18n:traits.emettitori_voidsong.uso_funzione",
-      "spinta_selettiva": "i18n:traits.emettitori_voidsong.spinta_selettiva"
-    },
-    "emolinfa_conducente": {
-      "id": "emolinfa_conducente",
-      "label": "Emolinfa Conducente",
-      "famiglia_tipologia": "Supporto/Energetico",
-      "data_origin": "frattura_abissale_sinaptica",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T3"
-          }
-        }
-      ],
-      "sinergie": [],
-      "mutazione_indotta": "i18n:traits.emolinfa_conducente.mutazione_indotta",
-      "uso_funzione": "i18n:traits.emolinfa_conducente.uso_funzione",
-      "spinta_selettiva": "i18n:traits.emolinfa_conducente.spinta_selettiva"
-    },
-    "placche_pressioniche": {
-      "id": "placche_pressioniche",
-      "label": "Placche Pressioniche",
-      "famiglia_tipologia": "Difesa/Pressione",
-      "data_origin": "frattura_abissale_sinaptica",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": false,
-        "has_usage_tags": true
-      },
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T3"
-          }
-        }
-      ],
-      "sinergie": [],
-      "mutazione_indotta": "i18n:traits.placche_pressioniche.mutazione_indotta",
-      "uso_funzione": "i18n:traits.placche_pressioniche.uso_funzione",
-      "spinta_selettiva": "i18n:traits.placche_pressioniche.spinta_selettiva"
-    },
-    "filamenti_echo": {
-      "id": "filamenti_echo",
-      "label": "Filamenti Echo",
-      "famiglia_tipologia": "Supporto/Risonanza",
-      "data_origin": "frattura_abissale_sinaptica",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T3"
-          }
-        }
-      ],
-      "sinergie": [],
-      "mutazione_indotta": "i18n:traits.filamenti_echo.mutazione_indotta",
-      "uso_funzione": "i18n:traits.filamenti_echo.uso_funzione",
-      "spinta_selettiva": "i18n:traits.filamenti_echo.spinta_selettiva"
-    },
-    "scintilla_sinaptica": {
-      "id": "scintilla_sinaptica",
-      "label": "Scintilla Sinaptica",
-      "famiglia_tipologia": "Temp/Elettrico",
-      "data_origin": "frattura_abissale_sinaptica",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [],
-      "tipo": "temp",
-      "mutazione_indotta": "i18n:traits.scintilla_sinaptica.mutazione_indotta",
-      "uso_funzione": "i18n:traits.scintilla_sinaptica.uso_funzione",
-      "spinta_selettiva": "i18n:traits.scintilla_sinaptica.spinta_selettiva"
-    },
-    "riverbero_memetico": {
-      "id": "riverbero_memetico",
-      "label": "Riverbero Memetico",
-      "famiglia_tipologia": "Temp/Psionico",
-      "data_origin": "frattura_abissale_sinaptica",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T2"
-          }
-        }
-      ],
-      "sinergie": [],
-      "tipo": "temp",
-      "mutazione_indotta": "i18n:traits.riverbero_memetico.mutazione_indotta",
-      "uso_funzione": "i18n:traits.riverbero_memetico.uso_funzione",
-      "spinta_selettiva": "i18n:traits.riverbero_memetico.spinta_selettiva"
-    },
-    "pelle_piezo_satura": {
-      "id": "pelle_piezo_satura",
-      "label": "Pelle Piezo-Satura",
-      "famiglia_tipologia": "Temp/Difesa",
-      "data_origin": "frattura_abissale_sinaptica",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T3"
-          }
-        }
-      ],
-      "sinergie": [],
-      "tipo": "temp",
-      "mutazione_indotta": "i18n:traits.pelle_piezo_satura.mutazione_indotta",
-      "uso_funzione": "i18n:traits.pelle_piezo_satura.uso_funzione",
-      "spinta_selettiva": "i18n:traits.pelle_piezo_satura.spinta_selettiva"
-    },
-    "canto_risonante": {
-      "id": "canto_risonante",
-      "label": "Canto Risonante",
-      "famiglia_tipologia": "Temp/Risonanza",
-      "data_origin": "frattura_abissale_sinaptica",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T1"
-          }
-        }
-      ],
-      "sinergie": [],
-      "tipo": "temp",
-      "mutazione_indotta": "i18n:traits.canto_risonante.mutazione_indotta",
-      "uso_funzione": "i18n:traits.canto_risonante.uso_funzione",
-      "spinta_selettiva": "i18n:traits.canto_risonante.spinta_selettiva"
-    },
-    "vortice_nera_flash": {
-      "id": "vortice_nera_flash",
-      "label": "Vortice Nera Flash",
-      "famiglia_tipologia": "Temp/Movimento",
-      "data_origin": "frattura_abissale_sinaptica",
-      "completion_flags": {
-        "has_biome": true,
-        "has_data_origin": true,
-        "has_species_link": true,
-        "has_usage_tags": true
-      },
-      "requisiti_ambientali": [
-        {
-          "condizioni": {
-            "biome_class": "frattura_abissale_sinaptica"
-          },
-          "meta": {
-            "tier": "T3"
-          }
-        }
-      ],
-      "sinergie": [],
-      "conflitti": [
-        "stress_spike"
-      ],
-      "tipo": "temp",
-      "mutazione_indotta": "i18n:traits.vortice_nera_flash.mutazione_indotta",
-      "uso_funzione": "i18n:traits.vortice_nera_flash.uso_funzione",
-      "spinta_selettiva": "i18n:traits.vortice_nera_flash.spinta_selettiva"
-    }
-  },
-  "types": {
-    "difensivo": {
-      "query": {
-        "filters": {
-          "type": [
-            "difensivo"
-          ]
-        },
-        "source": "data/traits/index.json"
-      },
-      "traits": [
-        "ali_membrana_sonica",
-        "appendici_risonanti_marea",
-        "barriere_miasma_glaciale",
-        "branchie_microfiltri",
-        "capsule_paracadute",
-        "circolazione_bifasica",
-        "coda_coppia_retroattiva",
-        "cute_resistente_sali",
-        "enzimi_antipredatori_algali",
-        "filtri_planctonici",
-        "ghiandole_fango_coesivo",
-        "giunti_antitorsione",
-        "lingua_cristallina",
-        "mucose_barofile"
-      ],
-      "type": "difensivo"
-    },
-    "difesa": {
-      "query": {
-        "filters": {
-          "type": [
-            "difesa"
-          ]
-        },
-        "source": "data/traits/index.json"
-      },
-      "traits": [
-        "armatura_pietra_planare",
-        "mantello_meteoritico"
-      ],
-      "type": "difesa"
-    },
-    "digestivo": {
-      "query": {
-        "filters": {
-          "type": [
-            "digestivo"
-          ]
-        },
-        "source": "data/traits/index.json"
-      },
-      "traits": [
-        "filamenti_digestivi_compattanti",
-        "ventriglio_gastroliti"
-      ],
-      "type": "digestivo"
-    },
-    "escretorio": {
-      "query": {
-        "filters": {
-          "type": [
-            "escretorio"
-          ]
-        },
-        "source": "data/traits/index.json"
-      },
-      "traits": [
-        "spore_psichiche_silenziate"
-      ],
-      "type": "escretorio"
-    },
-    "idrostatico": {
-      "query": {
-        "filters": {
-          "type": [
-            "idrostatico"
-          ]
-        },
-        "source": "data/traits/index.json"
-      },
-      "traits": [
-        "sacche_galleggianti_ascensoriali"
-      ],
-      "type": "idrostatico"
-    },
-    "locomotorio": {
-      "query": {
-        "filters": {
-          "type": [
-            "locomotorio"
-          ]
-        },
-        "source": "data/traits/index.json"
-      },
-      "traits": [
-        "ali_ioniche",
-        "antenne_wideband",
-        "artigli_sette_vie",
-        "artigli_sghiaccio_glaciale",
-        "barbigli_sensori_plasma",
-        "branchie_metalloidi",
-        "capillari_fotovoltaici",
-        "cartilagine_flessotermica_venti",
-        "chemiorecettori_bromuro",
-        "coda_contrappeso",
-        "coda_frusta_cinetica",
-        "cuscinetti_elettrostatici",
-        "enzimi_antifase_termica",
-        "filamenti_termoconduzione",
-        "ghiandole_fango_calde",
-        "ghiandole_ventosa",
-        "linfa_tampone",
-        "mucose_aderenza_sonica",
-        "zampe_a_molla",
-        "zoccoli_risonanti_steppe"
-      ],
-      "type": "locomotorio"
-    },
-    "metabolico": {
-      "query": {
-        "filters": {
-          "type": [
-            "metabolico"
-          ]
-        },
-        "source": "data/traits/index.json"
-      },
-      "traits": [
-        "antenne_dustsense",
-        "appendici_thermotattiche",
-        "batteri_endosimbionti_chemio",
-        "branchie_solfatiche",
-        "carapace_segmenti_logici",
-        "circolazione_bifasica_palude",
-        "circolazione_cooling_loop",
-        "coda_stabilizzatrice_filo",
-        "criostasi_adattiva",
-        "cuticole_cerose",
-        "enzimi_chelanti",
-        "flagelli_ancoranti",
-        "ghiandole_grafene",
-        "grassi_termici",
-        "luminescenza_aurorale"
-      ],
-      "type": "metabolico"
-    },
-    "nervoso": {
-      "query": {
-        "filters": {
-          "type": [
-            "nervoso"
-          ]
-        },
-        "source": "data/traits/index.json"
-      },
-      "traits": [
-        "sonno_emisferico_alternato"
-      ],
-      "type": "nervoso"
-    },
-    "offensivo": {
-      "query": {
-        "filters": {
-          "type": [
-            "offensivo"
-          ]
-        },
-        "source": "data/traits/index.json"
-      },
-      "traits": [
-        "antenne_flusso_mareale",
-        "artigli_induzione",
-        "biochip_memoria",
-        "camere_anticorrosione",
-        "cartilagini_biofibre",
-        "circolazione_supercritica",
-        "coda_stabilizzatrice_vortex",
-        "denti_chelatanti",
-        "enzimi_metanoossidanti",
-        "foliaggio_spugna",
-        "frusta_fiammeggiante",
-        "ghiandola_caustica",
-        "ghiandole_iodoattive",
-        "gusci_magnesio",
-        "mantelli_geotermici",
-        "sangue_piroforico"
-      ],
-      "type": "offensivo"
-    },
-    "respiratorio": {
-      "query": {
-        "filters": {
-          "type": [
-            "respiratorio"
-          ]
-        },
-        "source": "data/traits/index.json"
-      },
-      "traits": [
-        "branchie_osmotiche_salmastra",
-        "lamelle_termoforetiche",
-        "membrane_eliofiltranti",
-        "polmoni_cristallini_alta_quota",
-        "respiro_a_scoppio"
-      ],
-      "type": "respiratorio"
-    },
-    "riproduttivo": {
-      "query": {
-        "filters": {
-          "type": [
-            "riproduttivo"
-          ]
-        },
-        "source": "data/traits/index.json"
-      },
-      "traits": [
-        "nucleo_ovomotore_rotante"
-      ],
-      "type": "riproduttivo"
-    },
-    "sensoriale": {
-      "query": {
-        "filters": {
-          "type": [
-            "sensoriale"
-          ]
-        },
-        "source": "data/traits/index.json"
-      },
-      "traits": [
-        "ali_fulminee",
-        "antenne_plasmatiche_tempesta",
-        "antenne_waveguide",
-        "baffi_mareomotori",
-        "branchie_eoliche",
-        "capillari_fluoridici",
-        "cavita_risonanti_tundra",
-        "cervelletto_equilibrio_statico",
-        "coda_balanciere",
-        "cuore_multicamera_bassa_pressione",
-        "echi_risonanti",
-        "eco_interno_riflesso",
-        "filamenti_superconduttivi",
-        "ghiandole_eco_mappanti",
-        "ghiandole_resina_conduttiva",
-        "lamine_scudo_silice",
-        "lingua_tattile_trama",
-        "midollo_antivibrazione",
-        "occhi_infrarosso_composti",
-        "olfatto_risonanza_magnetica",
-        "sensori_geomagnetici"
-      ],
-      "type": "sensoriale"
-    },
-    "simbiotico": {
-      "query": {
-        "filters": {
-          "type": [
-            "simbiotico"
-          ]
-        },
-        "source": "data/traits/index.json"
-      },
-      "traits": [
-        "antenne_reagenti",
-        "artigli_scivolo_silente",
-        "biofilm_iperarido",
-        "bulbi_radici_permafrost",
-        "camere_nutrienti_vent",
-        "cartilagini_flessoacustiche",
-        "chioma_parassita_canopica",
-        "ciste_salmastre",
-        "coralli_partner",
-        "denti_silice_termici",
-        "epitelio_fosforescente",
-        "ghiandole_cambio_salino",
-        "ghiandole_nebbia_acida",
-        "lamelle_sincroniche",
-        "membrane_planata_vectored",
-        "mucillagine_simbionte_mangrovie",
-        "nodi_micorrizici_oracolari",
-        "sacche_spore_stratosferiche",
-        "sinapsi_coraline_polifoniche"
-      ],
-      "type": "simbiotico"
-    },
-    "strategia": {
-      "query": {
-        "filters": {
-          "type": [
-            "strategia"
-          ]
-        },
-        "source": "data/traits/index.json"
-      },
-      "traits": [
-        "antenne_microonde_cavernose",
-        "artigli_radice",
-        "biofilm_glow",
-        "camere_mirage",
-        "cartilagini_desertiche",
-        "ciste_riduttive",
-        "colonne_vibromagnetiche",
-        "denti_ossidoferro",
-        "epidermide_dielettrica",
-        "focus_frazionato",
-        "ghiaccio_piezoelettrico",
-        "ghiandole_minerali",
-        "lamelle_shear",
-        "membrane_captura_rugiada",
-        "pathfinder",
-        "pianificatore",
-        "random",
-        "tattiche_di_branco"
-      ],
-      "type": "strategia"
-    },
-    "strutturale": {
-      "query": {
-        "filters": {
-          "type": [
-            "strutturale"
-          ]
-        },
-        "source": "data/traits/index.json"
-      },
-      "traits": [
-        "antenne_tesla",
-        "artigli_vetrificati",
-        "branchie_dual_mode",
-        "capillari_criogenici",
-        "carapace_fase_variabile",
-        "carapace_luminiscente_abissale",
-        "cartilagini_pseudometalliche",
-        "cisti_iperbariche",
-        "cromofori_alert_acido",
-        "denti_tuning_fork",
-        "filamenti_magnetotrofi",
-        "ghiandole_condensa_ozono",
-        "ghiandole_nebbia_ionica",
-        "lamine_filtranti_aeree",
-        "membrane_pneumatofori",
-        "scheletro_idro_regolante",
-        "struttura_elastica_amorfa"
-      ],
-      "type": "strutturale"
-    },
-    "supporto": {
-      "query": {
-        "filters": {
-          "type": [
-            "supporto"
-          ]
-        },
-        "source": "data/traits/index.json"
-      },
-      "traits": [
-        "antenne_eco_turbina",
-        "artigli_acidofagi",
-        "aura_scudo_radianza",
-        "batteri_termofili_endosimbiosi",
-        "branchie_turbina",
-        "carapaci_ferruginosi",
-        "circolazione_doppia",
-        "coda_stabilizzatrice_geiser",
-        "cuticole_neutralizzanti",
-        "empatia_coordinativa",
-        "enzimi_chelatori_rapidi",
-        "foliage_fotocatodico",
-        "ghiandole_inchiostro_luce",
-        "gusci_criovetro",
-        "luminescenza_hydrotermica",
-        "risonanza_di_branco"
-      ],
-      "type": "supporto"
-    },
-    "tegumentario": {
-      "query": {
-        "filters": {
-          "type": [
-            "tegumentario"
-          ]
-        },
-        "source": "data/traits/index.json"
-      },
-      "traits": [
-        "mimetismo_cromatico_passivo",
-        "piume_solari_fotovoltaiche",
-        "secrezione_rallentante_palmi",
-        "squame_rifrangenti_deserto",
-        "vello_condensatore_nebbie"
-      ],
-      "type": "tegumentario"
+      "data_origin": "controllo_psionico"
     }
   }
 }

--- a/logs/ci/validate_traits_run2.log
+++ b/logs/ci/validate_traits_run2.log
@@ -1,0 +1,400 @@
+[VALIDATION] Tutti i trait rispettano lo schema.
+[TRAIT] ali_fono_risonanti: OK
+[TRAIT] ali_fulminee: OK
+[TRAIT] ali_ioniche: OK
+[TRAIT] ali_membrana_sonica: OK
+[TRAIT] antenne_dustsense: OK
+[TRAIT] antenne_eco_turbina: OK
+[TRAIT] antenne_flusso_mareale: OK
+[TRAIT] antenne_microonde_cavernose: OK
+[TRAIT] antenne_plasmatiche_tempesta: OK
+[TRAIT] antenne_reagenti: OK
+[TRAIT] antenne_tesla: OK
+[TRAIT] antenne_waveguide: OK
+[TRAIT] antenne_wideband: OK
+[TRAIT] appendici_risonanti_marea: OK
+[TRAIT] appendici_thermotattiche: OK
+[TRAIT] armatura_pietra_planare: OK
+[TRAIT] articolazioni_a_leva_idraulica: OK
+[TRAIT] articolazioni_multiassiali: OK
+[TRAIT] artigli_acidofagi: OK
+[TRAIT] artigli_induzione: OK
+[TRAIT] artigli_ipo_termici: OK
+[TRAIT] artigli_radice: OK
+[TRAIT] artigli_scivolo_silente: OK
+[TRAIT] artigli_sette_vie: OK
+[TRAIT] artigli_sghiaccio_glaciale: OK
+[TRAIT] artigli_vetrificati: OK
+[TRAIT] artiglio_cinetico_a_urto: OK
+[TRAIT] aura_di_dispersione_mentale: OK
+[TRAIT] aura_scudo_radianza: OK
+[TRAIT] baffi_mareomotori: OK
+[TRAIT] barbigli_sensori_plasma: OK
+[TRAIT] barriere_miasma_glaciale: OK
+[TRAIT] batteri_endosimbionti_chemio: OK
+[TRAIT] batteri_termofili_endosimbiosi: OK
+[TRAIT] bioantenne_gravitiche: OK
+[TRAIT] biochip_memoria: OK
+[TRAIT] biofilm_glow: OK
+[TRAIT] biofilm_iperarido: OK
+[TRAIT] bozzolo_magnetico: OK
+[TRAIT] branchie_dual_mode: OK
+[TRAIT] branchie_eoliche: OK
+[TRAIT] branchie_metalloidi: OK
+[TRAIT] branchie_microfiltri: OK
+[TRAIT] branchie_osmotiche_salmastra: OK
+[TRAIT] branchie_solfatiche: OK
+[TRAIT] branchie_turbina: OK
+[TRAIT] bulbi_radici_permafrost: OK
+[TRAIT] camere_anticorrosione: OK
+[TRAIT] camere_mirage: OK
+[TRAIT] camere_nutrienti_vent: OK
+[TRAIT] camere_risonanza_abyssal: OK
+[TRAIT] campo_di_interferenza_acustica: OK
+[TRAIT] cannone_sonico_a_raggio: OK
+[TRAIT] canto_infrasonico_tattico: OK
+[TRAIT] canto_risonante: OK
+[TRAIT] capillari_criogenici: OK
+[TRAIT] capillari_fluoridici: OK
+[TRAIT] capillari_fotovoltaici: OK
+[TRAIT] capsule_paracadute: OK
+[TRAIT] carapace_fase_variabile: OK
+[TRAIT] carapace_luminiscente_abissale: OK
+[TRAIT] carapace_segmenti_logici: OK
+[TRAIT] carapaci_ferruginosi: OK
+[TRAIT] cartilagine_flessotermica_venti: OK
+[TRAIT] cartilagini_biofibre: OK
+[TRAIT] cartilagini_desertiche: OK
+[TRAIT] cartilagini_flessoacustiche: OK
+[TRAIT] cartilagini_pseudometalliche: OK
+[TRAIT] cavita_risonanti_tundra: OK
+[TRAIT] cervelletto_equilibrio_statico: OK
+[TRAIT] cervello_a_bassa_latenza: OK
+[TRAIT] chemiorecettori_bromuro: OK
+[TRAIT] chioma_parassita_canopica: OK
+[TRAIT] cinghia_iper_ciliare: OK
+[TRAIT] circolazione_bifasica: OK
+[TRAIT] circolazione_bifasica_palude: OK
+[TRAIT] circolazione_cooling_loop: OK
+[TRAIT] circolazione_doppia: OK
+[TRAIT] circolazione_supercritica: OK
+[TRAIT] ciste_riduttive: OK
+[TRAIT] ciste_salmastre: OK
+[TRAIT] cisti_di_ibernazione_minerale: OK
+[TRAIT] cisti_iperbariche: OK
+[TRAIT] coda_balanciere: OK
+[TRAIT] coda_contrappeso: OK
+[TRAIT] coda_coppia_retroattiva: OK
+[TRAIT] coda_frusta_cinetica: OK
+[TRAIT] coda_prensile_muscolare: OK
+[TRAIT] coda_stabilizzatrice_filo: OK
+[TRAIT] coda_stabilizzatrice_geiser: OK
+[TRAIT] coda_stabilizzatrice_vortex: OK
+[TRAIT] colonne_vibromagnetiche: OK
+[TRAIT] comunicazione_fotonica_coda_coda: OK
+[TRAIT] coralli_partner: OK
+[TRAIT] coralli_sinaptici_fotofase: OK
+[TRAIT] corazze_ferro_magnetico: OK
+[TRAIT] corna_psico_conduttive: OK
+[TRAIT] coscienza_d_alveare_diffusa: OK
+[TRAIT] criostasi_adattiva: OK
+[TRAIT] cromofori_alert_acido: OK
+[TRAIT] cuore_multicamera_bassa_pressione: OK
+[TRAIT] cuscinetti_elettrostatici: OK
+[TRAIT] cute_resistente_sali: OK
+[TRAIT] cuticole_cerose: OK
+[TRAIT] cuticole_neutralizzanti: OK
+[TRAIT] denti_chelatanti: OK
+[TRAIT] denti_ossidoferro: OK
+[TRAIT] denti_silice_termici: OK
+[TRAIT] denti_tuning_fork: OK
+[TRAIT] echi_risonanti: OK
+[TRAIT] eco_interno_riflesso: OK
+[TRAIT] ectotermia_dinamica: OK
+[TRAIT] elettromagnete_biologico: OK
+[TRAIT] emettitori_voidsong: OK
+[TRAIT] emolinfa_conducente: OK
+[TRAIT] empatia_coordinativa: OK
+[TRAIT] enzimi_antifase_termica: OK
+[TRAIT] enzimi_antipredatori_algali: OK
+[TRAIT] enzimi_chelanti: OK
+[TRAIT] enzimi_chelatori_rapidi: OK
+[TRAIT] enzimi_metanoossidanti: OK
+[TRAIT] epidermide_dielettrica: OK
+[TRAIT] epitelio_fosforescente: OK
+[TRAIT] ermafroditismo_cronologico: OK
+[TRAIT] estroflessione_gastrica_acida: OK
+[TRAIT] fagocitosi_assorbente: OK
+[TRAIT] filamenti_digestivi_compattanti: OK
+[TRAIT] filamenti_echo: OK
+[TRAIT] filamenti_guidalampo: OK
+[TRAIT] filamenti_magnetotrofi: OK
+[TRAIT] filamenti_superconduttivi: OK
+[TRAIT] filamenti_termoconduzione: OK
+[TRAIT] filtrazione_osmotica: OK
+[TRAIT] filtri_planctonici: OK
+[TRAIT] filtro_metallofago: OK
+[TRAIT] flagelli_ancoranti: OK
+[TRAIT] flusso_ameboide_controllato: OK
+[TRAIT] focus_frazionato: OK
+[TRAIT] foliage_fotocatodico: OK
+[TRAIT] foliaggio_spugna: OK
+[TRAIT] frusta_fiammeggiante: OK
+[TRAIT] ghiaccio_piezoelettrico: OK
+[TRAIT] ghiandola_caustica: OK
+[TRAIT] ghiandole_cambio_salino: OK
+[TRAIT] ghiandole_condensa_ozono: OK
+[TRAIT] ghiandole_eco_mappanti: OK
+[TRAIT] ghiandole_fango_calde: OK
+[TRAIT] ghiandole_fango_coesivo: OK
+[TRAIT] ghiandole_grafene: OK
+[TRAIT] ghiandole_inchiostro_luce: OK
+[TRAIT] ghiandole_iodoattive: OK
+[TRAIT] ghiandole_minerali: OK
+[TRAIT] ghiandole_mnemoniche: OK
+[TRAIT] ghiandole_nebbia_acida: OK
+[TRAIT] ghiandole_nebbia_ionica: OK
+[TRAIT] ghiandole_resina_conduttiva: OK
+[TRAIT] ghiandole_ventosa: OK
+[TRAIT] giunti_antitorsione: OK
+[TRAIT] grassi_termici: OK
+[TRAIT] gusci_criovetro: OK
+[TRAIT] gusci_magnesio: OK
+[TRAIT] impulsi_bioluminescenti: OK
+[TRAIT] integumento_bipolare: OK
+[TRAIT] ipertrofia_muscolare_massiva: OK
+[TRAIT] lamelle_shear: OK
+[TRAIT] lamelle_sincroniche: OK
+[TRAIT] lamelle_termoforetiche: OK
+[TRAIT] lamine_filtranti_aeree: OK
+[TRAIT] lamine_scudo_silice: OK
+[TRAIT] linfa_tampone: OK
+[TRAIT] lingua_cristallina: OK
+[TRAIT] lingua_tattile_trama: OK
+[TRAIT] lobi_risonanti_crepuscolo: OK
+[TRAIT] locomozione_miriapode_ibrida: OK
+[TRAIT] luminescenza_aurorale: OK
+[TRAIT] luminescenza_hydrotermica: OK
+[TRAIT] mantelli_geotermici: OK
+[TRAIT] mantello_meteoritico: OK
+[TRAIT] membrana_plastica_continua: OK
+[TRAIT] membrane_captura_rugiada: OK
+[TRAIT] membrane_eliofiltranti: OK
+[TRAIT] membrane_fotoconvoglianti: OK
+[TRAIT] membrane_planata_vectored: OK
+[TRAIT] membrane_pneumatofori: OK
+[TRAIT] metabolismo_di_condivisione_energetica: OK
+[TRAIT] midollo_antivibrazione: OK
+[TRAIT] mimetismo_cromatico_passivo: OK
+[TRAIT] moltiplicazione_per_fusione: OK
+[TRAIT] motore_biologico_silenzioso: OK
+[TRAIT] mucillagine_simbionte_mangrovie: OK
+[TRAIT] mucose_aderenza_sonica: OK
+[TRAIT] mucose_barofile: OK
+[TRAIT] nebbia_mnesica: OK
+[TRAIT] nodi_micorrizici_oracolari: OK
+[TRAIT] nodi_sinaptici_superficiali: OK
+[TRAIT] nucleo_ovomotore_rotante: OK
+[TRAIT] occhi_analizzatori_di_tensione: OK
+[TRAIT] occhi_cinetici: OK
+[TRAIT] occhi_cristallo_modulare: OK
+[TRAIT] occhi_infrarosso_composti: OK
+[TRAIT] olfatto_risonanza_magnetica: OK
+[TRAIT] organi_metacronici: OK
+[TRAIT] organi_sismici_cutanei: OK
+[TRAIT] pathfinder: OK
+[TRAIT] pelage_idrorepellente_avanzato: OK
+[TRAIT] pelle_piezo_satura: OK
+[TRAIT] pianificatore: OK
+[TRAIT] piume_solari_fotovoltaiche: OK
+[TRAIT] placca_diffusione_foschia: OK
+[TRAIT] placche_pressioniche: OK
+[TRAIT] polmoni_cristallini_alta_quota: OK
+[TRAIT] random: OK
+[TRAIT] respiro_a_scoppio: OK
+[TRAIT] rete_filtro_polmonare: OK
+[TRAIT] risonanza_di_branco: OK
+[TRAIT] riverbero_memetico: OK
+[TRAIT] rostro_emostatico_litico: OK
+[TRAIT] rostro_linguale_prensile: OK
+[TRAIT] sacche_galleggianti_ascensoriali: OK
+[TRAIT] sacche_spore_stratosferiche: OK
+[TRAIT] sangue_piroforico: OK
+[TRAIT] scheletro_idraulico_a_pistoni: OK
+[TRAIT] scheletro_idro_regolante: OK
+[TRAIT] scheletro_pneumatico_a_maglie: OK
+[TRAIT] scintilla_sinaptica: OK
+[TRAIT] scivolamento_magnetico: OK
+[TRAIT] scudo_gluteale_cheratinizzato: OK
+[TRAIT] secrezione_rallentante_palmi: OK
+[TRAIT] secrezioni_antistatiche: OK
+[TRAIT] sensori_geomagnetici: OK
+[TRAIT] sensori_planctonici: OK
+[TRAIT] seta_conduttiva_elettrica: OK
+[TRAIT] siero_anti_gelo_naturale: OK
+[TRAIT] sinapsi_coraline_polifoniche: OK
+[TRAIT] sistemi_chimio_sonici: OK
+[TRAIT] sonno_emisferico_alternato: OK
+[TRAIT] spicole_canalizzatrici: OK
+[TRAIT] spore_psichiche_silenziate: OK
+[TRAIT] squame_diffusori_ionici: OK
+[TRAIT] squame_rifrangenti_deserto: OK
+[TRAIT] struttura_elastica_amorfa: OK
+[TRAIT] tattiche_di_branco: OK
+[TRAIT] unghie_a_micro_adesione: OK
+[TRAIT] vello_condensatore_nebbie: OK
+[TRAIT] vello_di_assorbimento_totale: OK
+[TRAIT] ventriglio_gastroliti: OK
+[TRAIT] visione_multi_spettrale_amplificata: OK
+[TRAIT] vortice_nera_flash: OK
+[TRAIT] zampe_a_molla: OK
+[TRAIT] zanne_idracida: OK
+[TRAIT] zoccoli_risonanti_steppe: OK
+== Summary of fields (Campi per tipologia) ==
+- Alimentazione/Digestione (2 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Ambiente/Supporto (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Analisi/Sensori Planctonici (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Cognitivo/Apprendimento (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Cognitivo/Sociale (3 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Controllo/Memoria (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Difensivo/Camuffamento (3 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Difensivo/Corazza (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Difensivo/Resistenze (2 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Difensivo/Termoregolazione (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Difesa/Antistatico (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Difesa/Elettrico (2 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Difesa/Foschia (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Difesa/Magnetico (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Difesa/Pressione (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Difesa/Strutturale (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Difesa/Termoregolazione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Digestivo/Alimentare (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Digestivo/Escretorio (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Digestivo/Metabolico (13 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Escretorio/Psichico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, species_affinity, spinta_selettiva, tier, usage_tags, uso_funzione
+- Esplorazione/Tattico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, species_affinity, spinta_selettiva, tier, usage_tags, uso_funzione
+- Fisiologico/Idrico (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Fisiologico/Metabolico (3 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Fisiologico/Respiratorio (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Fisiologico/Termico (2 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Flessibile/Generico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, species_affinity, spinta_selettiva, tier, usage_tags, uso_funzione
+- Idrostatico/Locomotorio (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Locomotivo/Aereo (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, species_affinity, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Locomotivo/Arboricolo (2 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, species_affinity, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Locomotivo/Balistico (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, species_affinity, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Locomotivo/Terrestre (7 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, species_affinity, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Locomotorio/Adattivo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Locomotorio/Difensivo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Locomotorio/Mobilità (14 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Locomotorio/Predatorio (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Locomotorio/Prensile (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Locomotorio/Supporto (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Manipolativo/Alimentare (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Metabolico/Difensivo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Metabolico/Resilienza (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Mobilità/Cinetico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Mobilità/Logistica (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Nervoso/Omeostatico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Offensivo/Assalto (13 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Offensivo/Assorbimento (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Offensivo/Chimico (3 trait): applicability, biome_tags, completion_flags, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, species_affinity, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Offensivo/Cinetico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Offensivo/Controllo (4 trait): applicability, biome_tags, completion_flags, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Offensivo/Contusivo (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Offensivo/Elettrico (2 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Offensivo/Illuminazione (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Offensivo/Perforante (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Offensivo/Termico (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Respiratorio/Aerobico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Respiratorio/Osmoregolazione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Respiratorio/Propulsivo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Respiratorio/Protezione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Respiratorio/Termoregolazione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Riproduttivo/Cicli (2 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Riproduttivo/Locomotorio (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, species_affinity, spinta_selettiva, tier, usage_tags, uso_funzione
+- Risonanza/Crepuscolo (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Sensore/Gravitazionale (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Sensoriale/Alimentare (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Sensoriale/Analitico (14 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Sensoriale/Magneto-ricettivo (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Sensoriale/Navigazione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Sensoriale/Nervoso (2 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Sensoriale/Offensivo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Sensoriale/Supporto (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Sensoriale/Tatto-Vibro (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Sensoriale/Uditivo-Olfattivo (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Sensoriale/Visivo (5 trait): applicability, biome_tags, completion_flags, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, species_affinity, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Simbiotico/Comunicazione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Simbiotico/Cooperativo (13 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Simbiotico/Difensivo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Simbiotico/Nervoso (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Simbiotico/Nutrizione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Simbiotico/Supporto (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Simbiotico/Utility (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Strategico/Psionico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Strategico/Tattico (15 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Strutturale/Adattivo (13 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Strutturale/Difensivo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Strutturale/Locomotorio (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Strutturale/Omeostatico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Strutturale/Sensoriale (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Supporto/Anomalia (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Supporto/Coordinativo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Supporto/Copia (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Supporto/Difesa (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Supporto/Empatico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Supporto/Energetico (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Supporto/Logistico (13 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Supporto/Risonanza (2 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Supporto/Sensore (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Supporto/Sequenziamento (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- TODO/import_esterno (21 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, sinergie, slot, slot_profile, spinta_selettiva, tier, uso_funzione
+- Tegumentario/Difensivo (17 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, species_affinity, spinta_selettiva, tier, usage_tags, uso_funzione
+- Tegumentario/Energetico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Tegumentario/Idratazione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Temporaneo/Difesa (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Temporaneo/Memoria (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Temporaneo/Risonanza (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Temporaneo/Scarica (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Temporaneo/Traslazione (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+
+== Field inventory ==
+ - applicability
+ - biome_tags
+ - completion_flags
+ - conflitti
+ - cost_profile
+ - data_origin
+ - debolezza
+ - famiglia_tipologia
+ - fattore_mantenimento_energetico
+ - id
+ - label
+ - metrics
+ - mutazione_indotta
+ - requisiti_ambientali
+ - sinergie
+ - sinergie_pi
+ - slot
+ - slot_profile
+ - species_affinity
+ - spinta_selettiva
+ - testability
+ - tier
+ - usage_tags
+ - uso_funzione
+ - version
+ - versioning
+
+Total traits: 272
+Indice generato (CSV): data/traits/index.csv
+Totale trait: 272
+Report coverage generato in data/derived/analysis/trait_coverage_report.json
+Controlli strict superati: min_traits_with_species=27, max_rules_missing_species=0
+Trait style: 129 suggerimenti (error=0, warning=78, info=51) su 251 file
+  - [WARNING] bioantenne_gravitiche /debolezza :: Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.bioantenne_gravitiche.debolezza).
+  - [WARNING] bioantenne_gravitiche /fattore_mantenimento_energetico :: `fattore_mantenimento_energetico` è nella whitelist NON_LOCALISED_FIELDS: usa il testo inline invece di una chiave i18n.
+  - [WARNING] bioantenne_gravitiche /usage_tags :: Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank).
+  - [WARNING] camere_risonanza_abyssal /debolezza :: Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.camere_risonanza_abyssal.debolezza).
+  - [WARNING] camere_risonanza_abyssal /fattore_mantenimento_energetico :: `fattore_mantenimento_energetico` è nella whitelist NON_LOCALISED_FIELDS: usa il testo inline invece di una chiave i18n.
+  … altri 124 suggerimenti

--- a/logs/ci/validate_traits_run3.log
+++ b/logs/ci/validate_traits_run3.log
@@ -1,0 +1,400 @@
+[VALIDATION] Tutti i trait rispettano lo schema.
+[TRAIT] ali_fono_risonanti: OK
+[TRAIT] ali_fulminee: OK
+[TRAIT] ali_ioniche: OK
+[TRAIT] ali_membrana_sonica: OK
+[TRAIT] antenne_dustsense: OK
+[TRAIT] antenne_eco_turbina: OK
+[TRAIT] antenne_flusso_mareale: OK
+[TRAIT] antenne_microonde_cavernose: OK
+[TRAIT] antenne_plasmatiche_tempesta: OK
+[TRAIT] antenne_reagenti: OK
+[TRAIT] antenne_tesla: OK
+[TRAIT] antenne_waveguide: OK
+[TRAIT] antenne_wideband: OK
+[TRAIT] appendici_risonanti_marea: OK
+[TRAIT] appendici_thermotattiche: OK
+[TRAIT] armatura_pietra_planare: OK
+[TRAIT] articolazioni_a_leva_idraulica: OK
+[TRAIT] articolazioni_multiassiali: OK
+[TRAIT] artigli_acidofagi: OK
+[TRAIT] artigli_induzione: OK
+[TRAIT] artigli_ipo_termici: OK
+[TRAIT] artigli_radice: OK
+[TRAIT] artigli_scivolo_silente: OK
+[TRAIT] artigli_sette_vie: OK
+[TRAIT] artigli_sghiaccio_glaciale: OK
+[TRAIT] artigli_vetrificati: OK
+[TRAIT] artiglio_cinetico_a_urto: OK
+[TRAIT] aura_di_dispersione_mentale: OK
+[TRAIT] aura_scudo_radianza: OK
+[TRAIT] baffi_mareomotori: OK
+[TRAIT] barbigli_sensori_plasma: OK
+[TRAIT] barriere_miasma_glaciale: OK
+[TRAIT] batteri_endosimbionti_chemio: OK
+[TRAIT] batteri_termofili_endosimbiosi: OK
+[TRAIT] bioantenne_gravitiche: OK
+[TRAIT] biochip_memoria: OK
+[TRAIT] biofilm_glow: OK
+[TRAIT] biofilm_iperarido: OK
+[TRAIT] bozzolo_magnetico: OK
+[TRAIT] branchie_dual_mode: OK
+[TRAIT] branchie_eoliche: OK
+[TRAIT] branchie_metalloidi: OK
+[TRAIT] branchie_microfiltri: OK
+[TRAIT] branchie_osmotiche_salmastra: OK
+[TRAIT] branchie_solfatiche: OK
+[TRAIT] branchie_turbina: OK
+[TRAIT] bulbi_radici_permafrost: OK
+[TRAIT] camere_anticorrosione: OK
+[TRAIT] camere_mirage: OK
+[TRAIT] camere_nutrienti_vent: OK
+[TRAIT] camere_risonanza_abyssal: OK
+[TRAIT] campo_di_interferenza_acustica: OK
+[TRAIT] cannone_sonico_a_raggio: OK
+[TRAIT] canto_infrasonico_tattico: OK
+[TRAIT] canto_risonante: OK
+[TRAIT] capillari_criogenici: OK
+[TRAIT] capillari_fluoridici: OK
+[TRAIT] capillari_fotovoltaici: OK
+[TRAIT] capsule_paracadute: OK
+[TRAIT] carapace_fase_variabile: OK
+[TRAIT] carapace_luminiscente_abissale: OK
+[TRAIT] carapace_segmenti_logici: OK
+[TRAIT] carapaci_ferruginosi: OK
+[TRAIT] cartilagine_flessotermica_venti: OK
+[TRAIT] cartilagini_biofibre: OK
+[TRAIT] cartilagini_desertiche: OK
+[TRAIT] cartilagini_flessoacustiche: OK
+[TRAIT] cartilagini_pseudometalliche: OK
+[TRAIT] cavita_risonanti_tundra: OK
+[TRAIT] cervelletto_equilibrio_statico: OK
+[TRAIT] cervello_a_bassa_latenza: OK
+[TRAIT] chemiorecettori_bromuro: OK
+[TRAIT] chioma_parassita_canopica: OK
+[TRAIT] cinghia_iper_ciliare: OK
+[TRAIT] circolazione_bifasica: OK
+[TRAIT] circolazione_bifasica_palude: OK
+[TRAIT] circolazione_cooling_loop: OK
+[TRAIT] circolazione_doppia: OK
+[TRAIT] circolazione_supercritica: OK
+[TRAIT] ciste_riduttive: OK
+[TRAIT] ciste_salmastre: OK
+[TRAIT] cisti_di_ibernazione_minerale: OK
+[TRAIT] cisti_iperbariche: OK
+[TRAIT] coda_balanciere: OK
+[TRAIT] coda_contrappeso: OK
+[TRAIT] coda_coppia_retroattiva: OK
+[TRAIT] coda_frusta_cinetica: OK
+[TRAIT] coda_prensile_muscolare: OK
+[TRAIT] coda_stabilizzatrice_filo: OK
+[TRAIT] coda_stabilizzatrice_geiser: OK
+[TRAIT] coda_stabilizzatrice_vortex: OK
+[TRAIT] colonne_vibromagnetiche: OK
+[TRAIT] comunicazione_fotonica_coda_coda: OK
+[TRAIT] coralli_partner: OK
+[TRAIT] coralli_sinaptici_fotofase: OK
+[TRAIT] corazze_ferro_magnetico: OK
+[TRAIT] corna_psico_conduttive: OK
+[TRAIT] coscienza_d_alveare_diffusa: OK
+[TRAIT] criostasi_adattiva: OK
+[TRAIT] cromofori_alert_acido: OK
+[TRAIT] cuore_multicamera_bassa_pressione: OK
+[TRAIT] cuscinetti_elettrostatici: OK
+[TRAIT] cute_resistente_sali: OK
+[TRAIT] cuticole_cerose: OK
+[TRAIT] cuticole_neutralizzanti: OK
+[TRAIT] denti_chelatanti: OK
+[TRAIT] denti_ossidoferro: OK
+[TRAIT] denti_silice_termici: OK
+[TRAIT] denti_tuning_fork: OK
+[TRAIT] echi_risonanti: OK
+[TRAIT] eco_interno_riflesso: OK
+[TRAIT] ectotermia_dinamica: OK
+[TRAIT] elettromagnete_biologico: OK
+[TRAIT] emettitori_voidsong: OK
+[TRAIT] emolinfa_conducente: OK
+[TRAIT] empatia_coordinativa: OK
+[TRAIT] enzimi_antifase_termica: OK
+[TRAIT] enzimi_antipredatori_algali: OK
+[TRAIT] enzimi_chelanti: OK
+[TRAIT] enzimi_chelatori_rapidi: OK
+[TRAIT] enzimi_metanoossidanti: OK
+[TRAIT] epidermide_dielettrica: OK
+[TRAIT] epitelio_fosforescente: OK
+[TRAIT] ermafroditismo_cronologico: OK
+[TRAIT] estroflessione_gastrica_acida: OK
+[TRAIT] fagocitosi_assorbente: OK
+[TRAIT] filamenti_digestivi_compattanti: OK
+[TRAIT] filamenti_echo: OK
+[TRAIT] filamenti_guidalampo: OK
+[TRAIT] filamenti_magnetotrofi: OK
+[TRAIT] filamenti_superconduttivi: OK
+[TRAIT] filamenti_termoconduzione: OK
+[TRAIT] filtrazione_osmotica: OK
+[TRAIT] filtri_planctonici: OK
+[TRAIT] filtro_metallofago: OK
+[TRAIT] flagelli_ancoranti: OK
+[TRAIT] flusso_ameboide_controllato: OK
+[TRAIT] focus_frazionato: OK
+[TRAIT] foliage_fotocatodico: OK
+[TRAIT] foliaggio_spugna: OK
+[TRAIT] frusta_fiammeggiante: OK
+[TRAIT] ghiaccio_piezoelettrico: OK
+[TRAIT] ghiandola_caustica: OK
+[TRAIT] ghiandole_cambio_salino: OK
+[TRAIT] ghiandole_condensa_ozono: OK
+[TRAIT] ghiandole_eco_mappanti: OK
+[TRAIT] ghiandole_fango_calde: OK
+[TRAIT] ghiandole_fango_coesivo: OK
+[TRAIT] ghiandole_grafene: OK
+[TRAIT] ghiandole_inchiostro_luce: OK
+[TRAIT] ghiandole_iodoattive: OK
+[TRAIT] ghiandole_minerali: OK
+[TRAIT] ghiandole_mnemoniche: OK
+[TRAIT] ghiandole_nebbia_acida: OK
+[TRAIT] ghiandole_nebbia_ionica: OK
+[TRAIT] ghiandole_resina_conduttiva: OK
+[TRAIT] ghiandole_ventosa: OK
+[TRAIT] giunti_antitorsione: OK
+[TRAIT] grassi_termici: OK
+[TRAIT] gusci_criovetro: OK
+[TRAIT] gusci_magnesio: OK
+[TRAIT] impulsi_bioluminescenti: OK
+[TRAIT] integumento_bipolare: OK
+[TRAIT] ipertrofia_muscolare_massiva: OK
+[TRAIT] lamelle_shear: OK
+[TRAIT] lamelle_sincroniche: OK
+[TRAIT] lamelle_termoforetiche: OK
+[TRAIT] lamine_filtranti_aeree: OK
+[TRAIT] lamine_scudo_silice: OK
+[TRAIT] linfa_tampone: OK
+[TRAIT] lingua_cristallina: OK
+[TRAIT] lingua_tattile_trama: OK
+[TRAIT] lobi_risonanti_crepuscolo: OK
+[TRAIT] locomozione_miriapode_ibrida: OK
+[TRAIT] luminescenza_aurorale: OK
+[TRAIT] luminescenza_hydrotermica: OK
+[TRAIT] mantelli_geotermici: OK
+[TRAIT] mantello_meteoritico: OK
+[TRAIT] membrana_plastica_continua: OK
+[TRAIT] membrane_captura_rugiada: OK
+[TRAIT] membrane_eliofiltranti: OK
+[TRAIT] membrane_fotoconvoglianti: OK
+[TRAIT] membrane_planata_vectored: OK
+[TRAIT] membrane_pneumatofori: OK
+[TRAIT] metabolismo_di_condivisione_energetica: OK
+[TRAIT] midollo_antivibrazione: OK
+[TRAIT] mimetismo_cromatico_passivo: OK
+[TRAIT] moltiplicazione_per_fusione: OK
+[TRAIT] motore_biologico_silenzioso: OK
+[TRAIT] mucillagine_simbionte_mangrovie: OK
+[TRAIT] mucose_aderenza_sonica: OK
+[TRAIT] mucose_barofile: OK
+[TRAIT] nebbia_mnesica: OK
+[TRAIT] nodi_micorrizici_oracolari: OK
+[TRAIT] nodi_sinaptici_superficiali: OK
+[TRAIT] nucleo_ovomotore_rotante: OK
+[TRAIT] occhi_analizzatori_di_tensione: OK
+[TRAIT] occhi_cinetici: OK
+[TRAIT] occhi_cristallo_modulare: OK
+[TRAIT] occhi_infrarosso_composti: OK
+[TRAIT] olfatto_risonanza_magnetica: OK
+[TRAIT] organi_metacronici: OK
+[TRAIT] organi_sismici_cutanei: OK
+[TRAIT] pathfinder: OK
+[TRAIT] pelage_idrorepellente_avanzato: OK
+[TRAIT] pelle_piezo_satura: OK
+[TRAIT] pianificatore: OK
+[TRAIT] piume_solari_fotovoltaiche: OK
+[TRAIT] placca_diffusione_foschia: OK
+[TRAIT] placche_pressioniche: OK
+[TRAIT] polmoni_cristallini_alta_quota: OK
+[TRAIT] random: OK
+[TRAIT] respiro_a_scoppio: OK
+[TRAIT] rete_filtro_polmonare: OK
+[TRAIT] risonanza_di_branco: OK
+[TRAIT] riverbero_memetico: OK
+[TRAIT] rostro_emostatico_litico: OK
+[TRAIT] rostro_linguale_prensile: OK
+[TRAIT] sacche_galleggianti_ascensoriali: OK
+[TRAIT] sacche_spore_stratosferiche: OK
+[TRAIT] sangue_piroforico: OK
+[TRAIT] scheletro_idraulico_a_pistoni: OK
+[TRAIT] scheletro_idro_regolante: OK
+[TRAIT] scheletro_pneumatico_a_maglie: OK
+[TRAIT] scintilla_sinaptica: OK
+[TRAIT] scivolamento_magnetico: OK
+[TRAIT] scudo_gluteale_cheratinizzato: OK
+[TRAIT] secrezione_rallentante_palmi: OK
+[TRAIT] secrezioni_antistatiche: OK
+[TRAIT] sensori_geomagnetici: OK
+[TRAIT] sensori_planctonici: OK
+[TRAIT] seta_conduttiva_elettrica: OK
+[TRAIT] siero_anti_gelo_naturale: OK
+[TRAIT] sinapsi_coraline_polifoniche: OK
+[TRAIT] sistemi_chimio_sonici: OK
+[TRAIT] sonno_emisferico_alternato: OK
+[TRAIT] spicole_canalizzatrici: OK
+[TRAIT] spore_psichiche_silenziate: OK
+[TRAIT] squame_diffusori_ionici: OK
+[TRAIT] squame_rifrangenti_deserto: OK
+[TRAIT] struttura_elastica_amorfa: OK
+[TRAIT] tattiche_di_branco: OK
+[TRAIT] unghie_a_micro_adesione: OK
+[TRAIT] vello_condensatore_nebbie: OK
+[TRAIT] vello_di_assorbimento_totale: OK
+[TRAIT] ventriglio_gastroliti: OK
+[TRAIT] visione_multi_spettrale_amplificata: OK
+[TRAIT] vortice_nera_flash: OK
+[TRAIT] zampe_a_molla: OK
+[TRAIT] zanne_idracida: OK
+[TRAIT] zoccoli_risonanti_steppe: OK
+== Summary of fields (Campi per tipologia) ==
+- Alimentazione/Digestione (2 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Ambiente/Supporto (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Analisi/Sensori Planctonici (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Cognitivo/Apprendimento (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Cognitivo/Sociale (3 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Controllo/Memoria (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Difensivo/Camuffamento (3 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Difensivo/Corazza (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Difensivo/Resistenze (2 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Difensivo/Termoregolazione (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Difesa/Antistatico (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Difesa/Elettrico (2 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Difesa/Foschia (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Difesa/Magnetico (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Difesa/Pressione (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Difesa/Strutturale (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Difesa/Termoregolazione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Digestivo/Alimentare (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Digestivo/Escretorio (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Digestivo/Metabolico (13 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Escretorio/Psichico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, species_affinity, spinta_selettiva, tier, usage_tags, uso_funzione
+- Esplorazione/Tattico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, species_affinity, spinta_selettiva, tier, usage_tags, uso_funzione
+- Fisiologico/Idrico (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Fisiologico/Metabolico (3 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Fisiologico/Respiratorio (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Fisiologico/Termico (2 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Flessibile/Generico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, species_affinity, spinta_selettiva, tier, usage_tags, uso_funzione
+- Idrostatico/Locomotorio (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Locomotivo/Aereo (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, species_affinity, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Locomotivo/Arboricolo (2 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, species_affinity, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Locomotivo/Balistico (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, species_affinity, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Locomotivo/Terrestre (7 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, species_affinity, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Locomotorio/Adattivo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Locomotorio/Difensivo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Locomotorio/Mobilità (14 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Locomotorio/Predatorio (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Locomotorio/Prensile (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Locomotorio/Supporto (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Manipolativo/Alimentare (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Metabolico/Difensivo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Metabolico/Resilienza (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Mobilità/Cinetico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Mobilità/Logistica (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Nervoso/Omeostatico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Offensivo/Assalto (13 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Offensivo/Assorbimento (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Offensivo/Chimico (3 trait): applicability, biome_tags, completion_flags, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, species_affinity, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Offensivo/Cinetico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Offensivo/Controllo (4 trait): applicability, biome_tags, completion_flags, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Offensivo/Contusivo (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Offensivo/Elettrico (2 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Offensivo/Illuminazione (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Offensivo/Perforante (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Offensivo/Termico (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Respiratorio/Aerobico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Respiratorio/Osmoregolazione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Respiratorio/Propulsivo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Respiratorio/Protezione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Respiratorio/Termoregolazione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Riproduttivo/Cicli (2 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Riproduttivo/Locomotorio (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, species_affinity, spinta_selettiva, tier, usage_tags, uso_funzione
+- Risonanza/Crepuscolo (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Sensore/Gravitazionale (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Sensoriale/Alimentare (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Sensoriale/Analitico (14 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Sensoriale/Magneto-ricettivo (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Sensoriale/Navigazione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Sensoriale/Nervoso (2 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Sensoriale/Offensivo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Sensoriale/Supporto (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Sensoriale/Tatto-Vibro (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Sensoriale/Uditivo-Olfattivo (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Sensoriale/Visivo (5 trait): applicability, biome_tags, completion_flags, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, species_affinity, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Simbiotico/Comunicazione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Simbiotico/Cooperativo (13 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Simbiotico/Difensivo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Simbiotico/Nervoso (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Simbiotico/Nutrizione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Simbiotico/Supporto (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Simbiotico/Utility (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Strategico/Psionico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Strategico/Tattico (15 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Strutturale/Adattivo (13 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Strutturale/Difensivo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Strutturale/Locomotorio (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Strutturale/Omeostatico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Strutturale/Sensoriale (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Supporto/Anomalia (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Supporto/Coordinativo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Supporto/Copia (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Supporto/Difesa (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Supporto/Empatico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Supporto/Energetico (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Supporto/Logistico (13 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Supporto/Risonanza (2 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Supporto/Sensore (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Supporto/Sequenziamento (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- TODO/import_esterno (21 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, sinergie, slot, slot_profile, spinta_selettiva, tier, uso_funzione
+- Tegumentario/Difensivo (17 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, species_affinity, spinta_selettiva, tier, usage_tags, uso_funzione
+- Tegumentario/Energetico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Tegumentario/Idratazione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Temporaneo/Difesa (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Temporaneo/Memoria (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Temporaneo/Risonanza (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Temporaneo/Scarica (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+- Temporaneo/Traslazione (1 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, uso_funzione
+
+== Field inventory ==
+ - applicability
+ - biome_tags
+ - completion_flags
+ - conflitti
+ - cost_profile
+ - data_origin
+ - debolezza
+ - famiglia_tipologia
+ - fattore_mantenimento_energetico
+ - id
+ - label
+ - metrics
+ - mutazione_indotta
+ - requisiti_ambientali
+ - sinergie
+ - sinergie_pi
+ - slot
+ - slot_profile
+ - species_affinity
+ - spinta_selettiva
+ - testability
+ - tier
+ - usage_tags
+ - uso_funzione
+ - version
+ - versioning
+
+Total traits: 272
+Indice generato (CSV): data/traits/index.csv
+Totale trait: 272
+Report coverage generato in data/derived/analysis/trait_coverage_report.json
+Controlli strict superati: min_traits_with_species=27, max_rules_missing_species=0
+Trait style: 129 suggerimenti (error=0, warning=78, info=51) su 251 file
+  - [WARNING] bioantenne_gravitiche /debolezza :: Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.bioantenne_gravitiche.debolezza).
+  - [WARNING] bioantenne_gravitiche /fattore_mantenimento_energetico :: `fattore_mantenimento_energetico` è nella whitelist NON_LOCALISED_FIELDS: usa il testo inline invece di una chiave i18n.
+  - [WARNING] bioantenne_gravitiche /usage_tags :: Imposta almeno un usage tag scegliendo dal vocabolario ufficiale (breaker, controller, scout, support, sustain, tank).
+  - [WARNING] camere_risonanza_abyssal /debolezza :: Il campo `debolezza` deve usare una chiave i18n dedicata (i18n:traits.camere_risonanza_abyssal.debolezza).
+  - [WARNING] camere_risonanza_abyssal /fattore_mantenimento_energetico :: `fattore_mantenimento_energetico` è nella whitelist NON_LOCALISED_FIELDS: usa il testo inline invece di una chiave i18n.
+  … altri 124 suggerimenti


### PR DESCRIPTION
## Summary
- add explicit trait definitions for the Frattura Abissale Sinaptica set with valid families, tiers, and biome requirements
- rebuild the trait index and regenerate coverage outputs after adding the new entries
- record the successful validate_traits reruns for run2 and run3

## Testing
- python tools/py/trait_template_validator.py --summary
- node scripts/build_trait_index.js
- python tools/py/report_trait_coverage.py --strict
- node scripts/trait_style_check.js --output-json reports/trait_style/trait_style_report.json --output-markdown reports/trait_style/trait_style_report.md --fail-on error


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692aff2dc0f08328b50f5daa0a54f078)