### PR TITLE
Align coverage trait references and refresh audit logs

### DIFF
--- a/data/packs.yaml
+++ b/data/packs.yaml
@@ -115,11 +115,11 @@ forms:
     bias_d12: {A: "1-4", B: "5-8", C: "9-12"}
   COPERTURA_ALFA:
     A: [trait_T3:ali_fono_risonanti, modulo_tattico, PE]
-    B: [trait_T2:occhi_di_cristallo_modulare, guardia_situazionale, cap_pt]
+    B: [trait_T2:occhi_cristallo_modulare, guardia_situazionale, cap_pt]
     C: [trait_T1:spore_psichiche_silenziate, starter_bioma, PE]
     bias_d12: {A: "1-4", B: "5-8", C: "9-12"}
   COPERTURA_BETA:
-    A: [trait_T2:occhi_di_cristallo_modulare, sigillo_forma, PE]
+    A: [trait_T2:occhi_cristallo_modulare, sigillo_forma, PE]
     B: [trait_T1:secrezione_rallentante_palmi, guardia_situazionale, PE]
     C: [trait_T3:ali_fono_risonanti, cap_pt, PE]
     bias_d12: {A: "1-4", B: "5-8", C: "9-12"}

--- a/docs/appendici/A-CANVAS_ORIGINALE.txt
+++ b/docs/appendici/A-CANVAS_ORIGINALE.txt
@@ -55,10 +55,10 @@ app compagne.
   curva minacce.
 
 ### Evoluzione Tratti Base — Dune Stalker
-- **Core Tier 1**: Artigli a Sette Vie + Struttura Elastica Amorfa + Scheletro Idro-Regolante.
+- **Core Tier 1**: Artigli Sette Vie + Struttura Elastica Amorfa + Scheletro Idro-Regolante.
   Mantengono mobilità verticale nelle cavità iper-saline e garantiscono difesa strutturale
   quando la squadra opera su terreni granulari instabili.
-- **Opzionali Tier 1**: Coda a Frusta Cinetica, Sacche Galleggianti Ascensoriali e Criostasi.
+- **Opzionali Tier 1**: Coda Frusta Cinetica, Sacche Galleggianti Ascensoriali e Criostasi Adattiva.
   Consentono burst di controllo (frusta), mobilità verticale in ambienti caverna e cicli di
   ibernazione rapida durante tempeste prolungate.
 - **Sinergie Tier 1**: Focus Frazionato, Risonanza di Branco e Tattiche di Branco. Queste

--- a/logs/trait_audit.md
+++ b/logs/trait_audit.md
@@ -1,4 +1,77 @@
 # Trait Data Audit
 
 - Errori bloccanti: 0
-- Warning: 0
+- Warning: 39
+
+## Warning
+
+- Sinergia non reciproca: 'i18n:traits.cisti_di_ibernazione_minerale.label' →
+'i18n:traits.fagocitosi_assorbente.label'.
+- Sinergia non reciproca: 'i18n:traits.ermafroditismo_cronologico.label' →
+'i18n:traits.estroflessione_gastrica_acida.label'.
+- Sinergia non reciproca: 'i18n:traits.filtro_metallofago.label' →
+'i18n:traits.bozzolo_magnetico.label'.
+- Sinergia non reciproca: 'i18n:traits.ghiandola_caustica.label' →
+'i18n:traits.campo_di_interferenza_acustica.label'.
+- Sinergia non reciproca: 'i18n:traits.ghiandola_caustica.label' →
+'i18n:traits.enzimi_chelanti.label'.
+- Sinergia non reciproca: 'i18n:traits.ghiandola_caustica.label' →
+'i18n:traits.respiro_a_scoppio.label'.
+- Sinergia non reciproca: 'i18n:traits.ghiandola_caustica.label' →
+'i18n:traits.sistemi_chimio_sonici.label'.
+- Sinergia non reciproca: 'i18n:traits.motore_biologico_silenzioso.label' →
+'i18n:traits.artigli_ipo_termici.label'.
+- Sinergia non reciproca: 'i18n:traits.nucleo_ovomotore_rotante.label' →
+'i18n:traits.coda_balanciere.label'.
+- Sinergia non reciproca: 'i18n:traits.nucleo_ovomotore_rotante.label' →
+'i18n:traits.flusso_ameboide_controllato.label'.
+- Sinergia non reciproca: 'i18n:traits.nucleo_ovomotore_rotante.label' →
+'i18n:traits.locomozione_miriapode_ibrida.label'.
+- Sinergia non reciproca: 'i18n:traits.occhi_analizzatori_di_tensione.label' →
+'i18n:traits.articolazioni_a_leva_idraulica.label'.
+- Sinergia non reciproca: 'i18n:traits.occhi_cristallo_modulare.label' →
+'i18n:traits.coda_balanciere.label'.
+- Sinergia non reciproca: 'i18n:traits.occhi_cristallo_modulare.label' →
+'i18n:traits.echi_risonanti.label'.
+- Sinergia non reciproca: 'i18n:traits.occhi_cristallo_modulare.label' →
+'i18n:traits.midollo_antivibrazione.label'.
+- Sinergia non reciproca: 'i18n:traits.occhi_cristallo_modulare.label' →
+'i18n:traits.occhi_cinetici.label'.
+- Sinergia non reciproca: 'i18n:traits.occhi_cristallo_modulare.label' →
+'i18n:traits.visione_multi_spettrale_amplificata.label'.
+- Sinergia non reciproca: 'i18n:traits.pathfinder.label' →
+'i18n:traits.antenne_microonde_cavernose.label'.
+- Sinergia non reciproca: 'i18n:traits.pathfinder.label' → 'i18n:traits.biofilm_glow.label'.
+- Sinergia non reciproca: 'i18n:traits.pathfinder.label' → 'i18n:traits.camere_mirage.label'.
+- Sinergia non reciproca: 'i18n:traits.pathfinder.label' →
+'i18n:traits.colonne_vibromagnetiche.label'.
+- Sinergia non reciproca: 'i18n:traits.pathfinder.label' →
+'i18n:traits.ghiaccio_piezoelettrico.label'.
+- Sinergia non reciproca: 'i18n:traits.pathfinder.label' →
+'i18n:traits.membrane_captura_rugiada.label'.
+- Sinergia non reciproca: 'i18n:traits.random.label' → 'i18n:traits.biofilm_glow.label'.
+- Sinergia non reciproca: 'i18n:traits.random.label' → 'i18n:traits.camere_mirage.label'.
+- Sinergia non reciproca: 'i18n:traits.random.label' → 'i18n:traits.colonne_vibromagnetiche.label'.
+- Sinergia non reciproca: 'i18n:traits.random.label' → 'i18n:traits.focus_frazionato.label'.
+- Sinergia non reciproca: 'i18n:traits.random.label' → 'i18n:traits.pianificatore.label'.
+- Sinergia non reciproca: 'i18n:traits.random.label' → 'i18n:traits.tattiche_di_branco.label'.
+- Sinergia non reciproca: 'i18n:traits.secrezione_rallentante_palmi.label' →
+'i18n:traits.biofilm_glow.label'.
+- Sinergia non reciproca: 'i18n:traits.secrezione_rallentante_palmi.label' →
+'i18n:traits.ciste_riduttive.label'.
+- Sinergia non reciproca: 'i18n:traits.secrezione_rallentante_palmi.label' →
+'i18n:traits.lamelle_shear.label'.
+- Sinergia non reciproca: 'i18n:traits.secrezione_rallentante_palmi.label' →
+'i18n:traits.membrana_plastica_continua.label'.
+- Sinergia non reciproca: 'i18n:traits.sistemi_chimio_sonici.label' →
+'i18n:traits.estroflessione_gastrica_acida.label'.
+- Sinergia non reciproca: 'i18n:traits.spore_psichiche_silenziate.label' →
+'i18n:traits.campo_di_interferenza_acustica.label'.
+- Sinergia non reciproca: 'i18n:traits.spore_psichiche_silenziate.label' →
+'i18n:traits.cervello_a_bassa_latenza.label'.
+- Sinergia non reciproca: 'i18n:traits.spore_psichiche_silenziate.label' →
+'i18n:traits.empatia_coordinativa.label'.
+- Sinergia non reciproca: 'i18n:traits.spore_psichiche_silenziate.label' →
+'i18n:traits.focus_frazionato.label'.
+- Sinergia non reciproca: 'i18n:traits.spore_psichiche_silenziate.label' →
+'i18n:traits.tattiche_di_branco.label'.

--- a/reports/temp/patch-03B-incoming-cleanup/schema_only.log
+++ b/reports/temp/patch-03B-incoming-cleanup/schema_only.log
@@ -1,2 +1,2 @@
-packs/evo_tactics_pack: 14 controlli eseguiti — 3 avvisi.
+packs/evo_tactics_pack: 14 controlli eseguiti — 0 avvisi.
 Tutti i dataset YAML sono validi.

--- a/reports/temp/patch-03B-incoming-cleanup/trait_audit.log
+++ b/reports/temp/patch-03B-incoming-cleanup/trait_audit.log
@@ -1,2 +1,42 @@
-Validazione schemi saltata (modulo 'jsonschema' assente). Skipping verifica report schema.
-Audit dei tratti: nessuna regressione rilevata.
+Modulo 'jsonschema' non disponibile: report schema non aggiornato.
+[WARNING] Sinergia non reciproca: 'i18n:traits.filtro_metallofago.label' → 'i18n:traits.bozzolo_magnetico.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.cisti_di_ibernazione_minerale.label' → 'i18n:traits.fagocitosi_assorbente.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.spore_psichiche_silenziate.label' → 'i18n:traits.focus_frazionato.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.spore_psichiche_silenziate.label' → 'i18n:traits.empatia_coordinativa.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.spore_psichiche_silenziate.label' → 'i18n:traits.cervello_a_bassa_latenza.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.spore_psichiche_silenziate.label' → 'i18n:traits.tattiche_di_branco.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.spore_psichiche_silenziate.label' → 'i18n:traits.campo_di_interferenza_acustica.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.motore_biologico_silenzioso.label' → 'i18n:traits.artigli_ipo_termici.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.ghiandola_caustica.label' → 'i18n:traits.enzimi_chelanti.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.ghiandola_caustica.label' → 'i18n:traits.respiro_a_scoppio.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.ghiandola_caustica.label' → 'i18n:traits.campo_di_interferenza_acustica.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.ghiandola_caustica.label' → 'i18n:traits.sistemi_chimio_sonici.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.ermafroditismo_cronologico.label' → 'i18n:traits.estroflessione_gastrica_acida.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.nucleo_ovomotore_rotante.label' → 'i18n:traits.coda_balanciere.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.nucleo_ovomotore_rotante.label' → 'i18n:traits.locomozione_miriapode_ibrida.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.nucleo_ovomotore_rotante.label' → 'i18n:traits.flusso_ameboide_controllato.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.occhi_analizzatori_di_tensione.label' → 'i18n:traits.articolazioni_a_leva_idraulica.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.occhi_cristallo_modulare.label' → 'i18n:traits.occhi_cinetici.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.occhi_cristallo_modulare.label' → 'i18n:traits.visione_multi_spettrale_amplificata.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.occhi_cristallo_modulare.label' → 'i18n:traits.echi_risonanti.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.occhi_cristallo_modulare.label' → 'i18n:traits.coda_balanciere.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.occhi_cristallo_modulare.label' → 'i18n:traits.midollo_antivibrazione.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.sistemi_chimio_sonici.label' → 'i18n:traits.estroflessione_gastrica_acida.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.pathfinder.label' → 'i18n:traits.antenne_microonde_cavernose.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.pathfinder.label' → 'i18n:traits.biofilm_glow.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.pathfinder.label' → 'i18n:traits.camere_mirage.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.pathfinder.label' → 'i18n:traits.colonne_vibromagnetiche.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.pathfinder.label' → 'i18n:traits.membrane_captura_rugiada.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.pathfinder.label' → 'i18n:traits.ghiaccio_piezoelettrico.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.random.label' → 'i18n:traits.pianificatore.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.random.label' → 'i18n:traits.focus_frazionato.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.random.label' → 'i18n:traits.tattiche_di_branco.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.random.label' → 'i18n:traits.camere_mirage.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.random.label' → 'i18n:traits.biofilm_glow.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.random.label' → 'i18n:traits.colonne_vibromagnetiche.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.secrezione_rallentante_palmi.label' → 'i18n:traits.ciste_riduttive.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.secrezione_rallentante_palmi.label' → 'i18n:traits.biofilm_glow.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.secrezione_rallentante_palmi.label' → 'i18n:traits.membrana_plastica_continua.label'.
+[WARNING] Sinergia non reciproca: 'i18n:traits.secrezione_rallentante_palmi.label' → 'i18n:traits.lamelle_shear.label'.
+[WARNING] Modulo 'jsonschema' non disponibile: validazione schemi saltata. Installare 'jsonschema' per eseguire la verifica.
+Report scritto in /workspace/Game/logs/trait_audit.md


### PR DESCRIPTION
## Summary
- update COPERTURA form entries to use the existing `occhi_cristallo_modulare` trait id
- refresh appendix trait names to match current catalog slugs and avoid audit blockers
- rerun dataset validation and trait audit, updating temporary reports and audit log outputs

## Testing
- python tools/py/validate_datasets.py
- python scripts/trait_audit.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bbf720ef883288cdcfc1470b4c290)