### PR TITLE
Normalize frattura abyss traits metadata

### DIFF
--- a/data/traits/frattura_abissale_sinaptica/bioantenne_gravitiche.json
+++ b/data/traits/frattura_abissale_sinaptica/bioantenne_gravitiche.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.bioantenne_gravitiche.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Sensore/Gravitazionale",
-  "fattore_mantenimento_energetico": "i18n:traits.bioantenne_gravitiche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto: le antenne restano polarizzate sullo shear gravitazionale continuo.",
   "tier": "T3",
   "slot": [],
   "sinergie": [],
@@ -18,7 +18,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T3"
+        "tier": "T3",
+        "notes": "Attive nella frattura nera, dove i gradienti gravitazionali forniscono il segnale portante per mantenere il coro di fondo."
       }
     }
   ],
@@ -27,5 +28,9 @@
     "has_data_origin": true,
     "has_species_link": true,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "controller"
+  ],
+  "debolezza": "i18n:traits.bioantenne_gravitiche.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/camere_risonanza_abyssal.json
+++ b/data/traits/frattura_abissale_sinaptica/camere_risonanza_abyssal.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.camere_risonanza_abyssal.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Supporto/Risonanza",
-  "fattore_mantenimento_energetico": "i18n:traits.camere_risonanza_abyssal.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto: le camere devono mantenere risonanza profonda sotto carico costante.",
   "tier": "T3",
   "slot": [],
   "sinergie": [],
@@ -18,7 +18,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T3"
+        "tier": "T3",
+        "notes": "Attive nella frattura nera per stabilizzare le risonanze voidsong sotto shear gravitazionale."
       }
     }
   ],
@@ -27,5 +28,9 @@
     "has_data_origin": true,
     "has_species_link": true,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "tank"
+  ],
+  "debolezza": "i18n:traits.camere_risonanza_abyssal.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/canto_risonante.json
+++ b/data/traits/frattura_abissale_sinaptica/canto_risonante.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.canto_risonante.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Temporaneo/Risonanza",
-  "fattore_mantenimento_energetico": "i18n:traits.canto_risonante.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio: richiede cori coordinati e frequenze sostenute nel tempo.",
   "tier": "T3",
   "slot": [],
   "sinergie": [],
@@ -18,7 +18,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T3"
+        "tier": "T3",
+        "notes": "Attivo quando le correnti elettroluminescenti richiedono un coro che sincronizzi l'intero branco."
       }
     }
   ],
@@ -27,5 +28,9 @@
     "has_data_origin": true,
     "has_species_link": true,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "support"
+  ],
+  "debolezza": "i18n:traits.canto_risonante.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/coralli_sinaptici_fotofase.json
+++ b/data/traits/frattura_abissale_sinaptica/coralli_sinaptici_fotofase.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.coralli_sinaptici_fotofase.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Ambiente/Supporto",
-  "fattore_mantenimento_energetico": "i18n:traits.coralli_sinaptici_fotofase.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso: il nutrimento fotico mantiene attive le sinapsi coralline.",
   "tier": "T1",
   "slot": [],
   "sinergie": [],
@@ -19,7 +19,7 @@
       "fonte": "env_to_traits",
       "meta": {
         "tier": "T1",
-        "notes": "Cresta Fotofase"
+        "notes": "Attivi sulla cresta fotofase, nutriti dalla luce residua e dalle correnti superficiali."
       }
     }
   ],
@@ -28,5 +28,9 @@
     "has_data_origin": true,
     "has_species_link": false,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "support"
+  ],
+  "debolezza": "i18n:traits.coralli_sinaptici_fotofase.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/corazze_ferro_magnetico.json
+++ b/data/traits/frattura_abissale_sinaptica/corazze_ferro_magnetico.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.corazze_ferro_magnetico.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Difesa/Magnetico",
-  "fattore_mantenimento_energetico": "i18n:traits.corazze_ferro_magnetico.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio-alto: i campi magnetici devono restare alimentati per respingere lo shear.",
   "tier": "T3",
   "slot": [],
   "sinergie": [],
@@ -20,7 +20,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T3"
+        "tier": "T3",
+        "notes": "Attive nella frattura nera per schermare pressione e campi magnetici irregolari."
       }
     }
   ],
@@ -29,5 +30,9 @@
     "has_data_origin": true,
     "has_species_link": false,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "tank"
+  ],
+  "debolezza": "i18n:traits.corazze_ferro_magnetico.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/emettitori_voidsong.json
+++ b/data/traits/frattura_abissale_sinaptica/emettitori_voidsong.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.emettitori_voidsong.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Supporto/Anomalia",
-  "fattore_mantenimento_energetico": "i18n:traits.emettitori_voidsong.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio: gli emettitori modulano canti voidsong continuativi.",
   "tier": "T3",
   "slot": [],
   "sinergie": [],
@@ -18,7 +18,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T3"
+        "tier": "T3",
+        "notes": "Attivi nella frattura nera per modulare i canti che tengono insieme le morfologie."
       }
     }
   ],
@@ -27,5 +28,9 @@
     "has_data_origin": true,
     "has_species_link": true,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "controller"
+  ],
+  "debolezza": "i18n:traits.emettitori_voidsong.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/emolinfa_conducente.json
+++ b/data/traits/frattura_abissale_sinaptica/emolinfa_conducente.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.emolinfa_conducente.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Supporto/Energetico",
-  "fattore_mantenimento_energetico": "i18n:traits.emolinfa_conducente.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio: la circolazione elettrolitica deve restare fluida per scaricare energia.",
   "tier": "T3",
   "slot": [],
   "sinergie": [],
@@ -18,7 +18,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T3"
+        "tier": "T3",
+        "notes": "Attiva nella frattura nera per drenare le scariche magnetiche accumulate."
       }
     }
   ],
@@ -27,5 +28,9 @@
     "has_data_origin": true,
     "has_species_link": true,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "sustain"
+  ],
+  "debolezza": "i18n:traits.emolinfa_conducente.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/filamenti_echo.json
+++ b/data/traits/frattura_abissale_sinaptica/filamenti_echo.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.filamenti_echo.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Supporto/Risonanza",
-  "fattore_mantenimento_energetico": "i18n:traits.filamenti_echo.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso: vibrazioni passive mantengono l'eco di riferimento.",
   "tier": "T3",
   "slot": [],
   "sinergie": [],
@@ -18,7 +18,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T3"
+        "tier": "T3",
+        "notes": "Attivi nella frattura nera per mantenere la frequenza di riferimento tra i cori."
       }
     }
   ],
@@ -27,5 +28,9 @@
     "has_data_origin": true,
     "has_species_link": true,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "support"
+  ],
+  "debolezza": "i18n:traits.filamenti_echo.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/filamenti_guidalampo.json
+++ b/data/traits/frattura_abissale_sinaptica/filamenti_guidalampo.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.filamenti_guidalampo.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Mobilità/Logistica",
-  "fattore_mantenimento_energetico": "i18n:traits.filamenti_guidalampo.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio-basso: impulsi fotici guidati richiedono modulazione costante.",
   "tier": "T1",
   "slot": [],
   "sinergie": [],
@@ -18,7 +18,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T1"
+        "tier": "T1",
+        "notes": "Attivi sulla cresta fotofase per tracciare rotte sicure lungo i corridoi luminosi."
       }
     }
   ],
@@ -27,5 +28,9 @@
     "has_data_origin": true,
     "has_species_link": false,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "scout"
+  ],
+  "debolezza": "i18n:traits.filamenti_guidalampo.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/ghiandole_mnemoniche.json
+++ b/data/traits/frattura_abissale_sinaptica/ghiandole_mnemoniche.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.ghiandole_mnemoniche.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Supporto/Copia",
-  "fattore_mantenimento_energetico": "i18n:traits.ghiandole_mnemoniche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio: le secrezioni mnesiche vanno rigenerate e distribuite.",
   "tier": "T2",
   "slot": [],
   "sinergie": [],
@@ -18,7 +18,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T2"
+        "tier": "T2",
+        "notes": "Attive nella soglia crepuscolare per conservare ricordi stabili dentro la foschia psionica."
       }
     }
   ],
@@ -27,5 +28,9 @@
     "has_data_origin": true,
     "has_species_link": true,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "controller"
+  ],
+  "debolezza": "i18n:traits.ghiandole_mnemoniche.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/impulsi_bioluminescenti.json
+++ b/data/traits/frattura_abissale_sinaptica/impulsi_bioluminescenti.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.impulsi_bioluminescenti.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Offensivo/Illuminazione",
-  "fattore_mantenimento_energetico": "i18n:traits.impulsi_bioluminescenti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio-basso: emissioni fotiche intermittenti consumano energia contenuta.",
   "tier": "T1",
   "slot": [],
   "sinergie": [],
@@ -18,7 +18,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T1"
+        "tier": "T1",
+        "notes": "Attivi sulla cresta fotofase per marcare bersagli e sovrasaturare i sensori avversari."
       }
     }
   ],
@@ -27,5 +28,9 @@
     "has_data_origin": true,
     "has_species_link": true,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "controller"
+  ],
+  "debolezza": "i18n:traits.impulsi_bioluminescenti.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/lobi_risonanti_crepuscolo.json
+++ b/data/traits/frattura_abissale_sinaptica/lobi_risonanti_crepuscolo.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.lobi_risonanti_crepuscolo.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Risonanza/Crepuscolo",
-  "fattore_mantenimento_energetico": "i18n:traits.lobi_risonanti_crepuscolo.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio: i lobi mantengono fase con le onde psioniche circostanti.",
   "tier": "T2",
   "slot": [],
   "sinergie": [],
@@ -18,7 +18,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T2"
+        "tier": "T2",
+        "notes": "Attivi nella soglia crepuscolare per aprire canali risonanti dentro la foschia mnesica."
       }
     }
   ],
@@ -27,5 +28,9 @@
     "has_data_origin": true,
     "has_species_link": true,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "controller"
+  ],
+  "debolezza": "i18n:traits.lobi_risonanti_crepuscolo.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/membrane_fotoconvoglianti.json
+++ b/data/traits/frattura_abissale_sinaptica/membrane_fotoconvoglianti.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.membrane_fotoconvoglianti.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Difesa/Elettrico",
-  "fattore_mantenimento_energetico": "i18n:traits.membrane_fotoconvoglianti.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso: le membrane convogliano la luce residua con minima dispersione.",
   "tier": "T1",
   "slot": [],
   "sinergie": [],
@@ -20,7 +20,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T1"
+        "tier": "T1",
+        "notes": "Attive sulla cresta fotofase per convogliare e smorzare i picchi di luce superficiale."
       }
     }
   ],
@@ -29,5 +30,9 @@
     "has_data_origin": true,
     "has_species_link": false,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "tank"
+  ],
+  "debolezza": "i18n:traits.membrane_fotoconvoglianti.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/nebbia_mnesica.json
+++ b/data/traits/frattura_abissale_sinaptica/nebbia_mnesica.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.nebbia_mnesica.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Controllo/Memoria",
-  "fattore_mantenimento_energetico": "i18n:traits.nebbia_mnesica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio: l'aerosol memetico richiede rinnovo continuo.",
   "tier": "T2",
   "slot": [],
   "sinergie": [],
@@ -20,7 +20,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T2"
+        "tier": "T2",
+        "notes": "Attiva nella soglia crepuscolare dove la foschia memetica disorienta e va rinnovata."
       }
     }
   ],
@@ -29,5 +30,9 @@
     "has_data_origin": true,
     "has_species_link": true,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "controller"
+  ],
+  "debolezza": "i18n:traits.nebbia_mnesica.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/nodi_sinaptici_superficiali.json
+++ b/data/traits/frattura_abissale_sinaptica/nodi_sinaptici_superficiali.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.nodi_sinaptici_superficiali.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Supporto/Sensore",
-  "fattore_mantenimento_energetico": "i18n:traits.nodi_sinaptici_superficiali.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso: i nodi sfruttano correnti locali per tenersi attivi.",
   "tier": "T1",
   "slot": [],
   "sinergie": [],
@@ -18,7 +18,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T1"
+        "tier": "T1",
+        "notes": "Attivi sulla cresta fotofase come nodi di instradamento per messaggeri e barriere coralline."
       }
     }
   ],
@@ -27,5 +28,9 @@
     "has_data_origin": true,
     "has_species_link": false,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "support"
+  ],
+  "debolezza": "i18n:traits.nodi_sinaptici_superficiali.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/organi_metacronici.json
+++ b/data/traits/frattura_abissale_sinaptica/organi_metacronici.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.organi_metacronici.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Supporto/Sequenziamento",
-  "fattore_mantenimento_energetico": "i18n:traits.organi_metacronici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio-alto: gli organi forzano riallineamenti temporali frequenti.",
   "tier": "T2",
   "slot": [],
   "sinergie": [],
@@ -18,7 +18,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T2"
+        "tier": "T2",
+        "notes": "Attivi nella soglia crepuscolare per riallineare cicli quando la foschia resetta i timer sinaptici."
       }
     }
   ],
@@ -27,5 +28,9 @@
     "has_data_origin": true,
     "has_species_link": true,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "controller"
+  ],
+  "debolezza": "i18n:traits.organi_metacronici.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/pelle_piezo_satura.json
+++ b/data/traits/frattura_abissale_sinaptica/pelle_piezo_satura.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.pelle_piezo_satura.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Temporaneo/Difesa",
-  "fattore_mantenimento_energetico": "i18n:traits.pelle_piezo_satura.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio: i tessuti carichi necessitano scariche periodiche controllate.",
   "tier": "T3",
   "slot": [],
   "sinergie": [],
@@ -18,7 +18,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T3"
+        "tier": "T3",
+        "notes": "Attiva nella frattura nera convertendo pressione e shear in carica difensiva."
       }
     }
   ],
@@ -27,5 +28,9 @@
     "has_data_origin": true,
     "has_species_link": true,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "tank"
+  ],
+  "debolezza": "i18n:traits.pelle_piezo_satura.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/placca_diffusione_foschia.json
+++ b/data/traits/frattura_abissale_sinaptica/placca_diffusione_foschia.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.placca_diffusione_foschia.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Difesa/Foschia",
-  "fattore_mantenimento_energetico": "i18n:traits.placca_diffusione_foschia.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio: mantenere la diffusione uniforme della foschia assorbe energia costante.",
   "tier": "T2",
   "slot": [],
   "sinergie": [],
@@ -18,7 +18,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T2"
+        "tier": "T2",
+        "notes": "Attiva nella soglia crepuscolare per distribuire uniformemente la foschia protettiva."
       }
     }
   ],
@@ -27,5 +28,9 @@
     "has_data_origin": true,
     "has_species_link": false,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "support"
+  ],
+  "debolezza": "i18n:traits.placca_diffusione_foschia.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/placche_pressioniche.json
+++ b/data/traits/frattura_abissale_sinaptica/placche_pressioniche.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.placche_pressioniche.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Difesa/Pressione",
-  "fattore_mantenimento_energetico": "i18n:traits.placche_pressioniche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto: la struttura resiste a pressioni variabili e richiede pompaggio continuo.",
   "tier": "T3",
   "slot": [],
   "sinergie": [],
@@ -18,7 +18,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T3"
+        "tier": "T3",
+        "notes": "Attive nella frattura nera per assorbire gli sbalzi di pressione e le microfratture."
       }
     }
   ],
@@ -27,5 +28,9 @@
     "has_data_origin": true,
     "has_species_link": false,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "tank"
+  ],
+  "debolezza": "i18n:traits.placche_pressioniche.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/riverbero_memetico.json
+++ b/data/traits/frattura_abissale_sinaptica/riverbero_memetico.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.riverbero_memetico.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Temporaneo/Memoria",
-  "fattore_mantenimento_energetico": "i18n:traits.riverbero_memetico.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio: serve buffer cognitivo per replicare pattern mentali.",
   "tier": "T3",
   "slot": [],
   "sinergie": [],
@@ -18,7 +18,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T3"
+        "tier": "T3",
+        "notes": "Attivo nella soglia crepuscolare dove gli echi memetici si moltiplicano nelle correnti lente."
       }
     }
   ],
@@ -27,5 +28,9 @@
     "has_data_origin": true,
     "has_species_link": true,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "support"
+  ],
+  "debolezza": "i18n:traits.riverbero_memetico.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/scintilla_sinaptica.json
+++ b/data/traits/frattura_abissale_sinaptica/scintilla_sinaptica.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.scintilla_sinaptica.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Temporaneo/Scarica",
-  "fattore_mantenimento_energetico": "i18n:traits.scintilla_sinaptica.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso: scarica rapida con costo minimo ma picco immediato.",
   "tier": "T2",
   "slot": [],
   "sinergie": [],
@@ -18,7 +18,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T2"
+        "tier": "T2",
+        "notes": "Attiva sulla cresta fotofase quando le correnti luminose innescano riflessi immediati."
       }
     }
   ],
@@ -27,5 +28,9 @@
     "has_data_origin": true,
     "has_species_link": true,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "support"
+  ],
+  "debolezza": "i18n:traits.scintilla_sinaptica.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/secrezioni_antistatiche.json
+++ b/data/traits/frattura_abissale_sinaptica/secrezioni_antistatiche.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.secrezioni_antistatiche.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Difesa/Antistatico",
-  "fattore_mantenimento_energetico": "i18n:traits.secrezioni_antistatiche.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio-basso: il sebo conduttivo va rinnovato per scaricare statico.",
   "tier": "T2",
   "slot": [],
   "sinergie": [],
@@ -20,7 +20,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T2"
+        "tier": "T2",
+        "notes": "Attive nella soglia crepuscolare per proteggere dall'accumulo ionico delle nebbie intermittenti."
       }
     }
   ],
@@ -29,5 +30,9 @@
     "has_data_origin": true,
     "has_species_link": false,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "sustain"
+  ],
+  "debolezza": "i18n:traits.secrezioni_antistatiche.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/sensori_planctonici.json
+++ b/data/traits/frattura_abissale_sinaptica/sensori_planctonici.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.sensori_planctonici.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Analisi/Sensori Planctonici",
-  "fattore_mantenimento_energetico": "i18n:traits.sensori_planctonici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Basso: sensori passivi sfruttano bioilluminazione del plancton.",
   "tier": "T1",
   "slot": [],
   "sinergie": [],
@@ -18,7 +18,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T1"
+        "tier": "T1",
+        "notes": "Attivi sulla cresta fotofase seguendo le scie del plancton mnesico illuminato."
       }
     }
   ],
@@ -27,5 +28,9 @@
     "has_data_origin": true,
     "has_species_link": false,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "scout"
+  ],
+  "debolezza": "i18n:traits.sensori_planctonici.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/spicole_canalizzatrici.json
+++ b/data/traits/frattura_abissale_sinaptica/spicole_canalizzatrici.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.spicole_canalizzatrici.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Offensivo/Assorbimento",
-  "fattore_mantenimento_energetico": "i18n:traits.spicole_canalizzatrici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio: micro-oscillazioni continue mantengono i canali attivi.",
   "tier": "T2",
   "slot": [],
   "sinergie": [],
@@ -18,7 +18,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T2"
+        "tier": "T2",
+        "notes": "Attive nella soglia crepuscolare per incanalare correnti e nebbie in condotti furtivi."
       }
     }
   ],
@@ -27,5 +28,9 @@
     "has_data_origin": true,
     "has_species_link": false,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "controller"
+  ],
+  "debolezza": "i18n:traits.spicole_canalizzatrici.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/squame_diffusori_ionici.json
+++ b/data/traits/frattura_abissale_sinaptica/squame_diffusori_ionici.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.squame_diffusori_ionici.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Difesa/Elettrico",
-  "fattore_mantenimento_energetico": "i18n:traits.squame_diffusori_ionici.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Medio: le squame si polarizzano per disperdere cariche.",
   "tier": "T1",
   "slot": [],
   "sinergie": [],
@@ -20,7 +20,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T1"
+        "tier": "T1",
+        "notes": "Attive sulla cresta fotofase per dissipare i picchi elettrici superficiali."
       }
     }
   ],
@@ -29,5 +30,9 @@
     "has_data_origin": true,
     "has_species_link": false,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "tank"
+  ],
+  "debolezza": "i18n:traits.squame_diffusori_ionici.debolezza"
 }

--- a/data/traits/frattura_abissale_sinaptica/vortice_nera_flash.json
+++ b/data/traits/frattura_abissale_sinaptica/vortice_nera_flash.json
@@ -3,7 +3,7 @@
   "label": "i18n:traits.vortice_nera_flash.label",
   "data_origin": "frattura_abissale_sinaptica",
   "famiglia_tipologia": "Temporaneo/Traslazione",
-  "fattore_mantenimento_energetico": "i18n:traits.vortice_nera_flash.fattore_mantenimento_energetico",
+  "fattore_mantenimento_energetico": "Alto: compressione e rilascio di energia gravitofotica ad alto consumo.",
   "tier": "T3",
   "slot": [],
   "sinergie": [],
@@ -20,7 +20,8 @@
       },
       "fonte": "frattura_abissale_sinaptica",
       "meta": {
-        "tier": "T3"
+        "tier": "T3",
+        "notes": "Attivo nella frattura nera quando le correnti collassano in micro-implosioni gravitofotiche."
       }
     }
   ],
@@ -29,5 +30,9 @@
     "has_data_origin": true,
     "has_species_link": true,
     "has_usage_tags": true
-  }
+  },
+  "usage_tags": [
+    "breaker"
+  ],
+  "debolezza": "i18n:traits.vortice_nera_flash.debolezza"
 }


### PR DESCRIPTION
## Summary
- add debolezza i18n references and inline energy maintenance factors to all frattura_abissale_sinaptica traits
- set usage_tags and activation notes in environmental requirements across the 26 affected trait files

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bcbff351483289a8dea47ceeb0193)