### PR TITLE
Update trait style reports for November 30, 2025 run

### DIFF
--- a/logs/trait_style_20251130.json
+++ b/logs/trait_style_20251130.json
@@ -1,0 +1,11 @@
+{
+  "generatedAt": "2025-11-30T04:55:19.850Z",
+  "totalTraits": 251,
+  "totalIssues": 0,
+  "counts": {
+    "info": 0,
+    "warning": 0,
+    "error": 0
+  },
+  "traitsWithIssues": 0
+}

--- a/logs/trait_style_20251130.md
+++ b/logs/trait_style_20251130.md
@@ -1,0 +1,9 @@
+# Trait style guide report
+
+Generato: 2025-11-30T04:55:19.850Z
+Totale trait analizzati: 251
+Totale suggerimenti: 0
+Breakdown: error=0, warning=0, info=0
+Trait con suggerimenti: 0
+
+_Nessuna anomalia rilevata._

--- a/reports/temp/patch-03B-incoming-cleanup/2026-02-20/trait_style_20251130.json
+++ b/reports/temp/patch-03B-incoming-cleanup/2026-02-20/trait_style_20251130.json
@@ -1,0 +1,11 @@
+{
+  "generatedAt": "2025-11-30T04:55:22.522Z",
+  "totalTraits": 251,
+  "totalIssues": 0,
+  "counts": {
+    "info": 0,
+    "warning": 0,
+    "error": 0
+  },
+  "traitsWithIssues": 0
+}

--- a/reports/temp/patch-03B-incoming-cleanup/2026-02-20/trait_style_20251130.md
+++ b/reports/temp/patch-03B-incoming-cleanup/2026-02-20/trait_style_20251130.md
@@ -1,0 +1,9 @@
+# Trait style guide report
+
+Generato: 2025-11-30T04:55:22.522Z
+Totale trait analizzati: 251
+Totale suggerimenti: 0
+Breakdown: error=0, warning=0, info=0
+Trait con suggerimenti: 0
+
+_Nessuna anomalia rilevata._


### PR DESCRIPTION
## Summary
- add refreshed trait style JSON and Markdown outputs under logs for the 2025-11-30 run
- generate matching trait style reports for patch-03B incoming cleanup snapshot

## Testing
- `node scripts/trait_style_check.js --output-json logs/trait_style_20251130.json --output-markdown logs/trait_style_20251130.md`
- `node scripts/trait_style_check.js --output-json reports/temp/patch-03B-incoming-cleanup/2026-02-20/trait_style_20251130.json --output-markdown reports/temp/patch-03B-incoming-cleanup/2026-02-20/trait_style_20251130.md --quiet`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bcd7de0848328a3d13b929190451d)