### PR TITLE
Update migration workplan status after completed gates

### DIFF
--- a/docs/migration_targeted_workplan.md
+++ b/docs/migration_targeted_workplan.md
@@ -43,17 +43,18 @@ Questo piano elenca le attività operative a "lavori mirati" per avviare subito 
    - Creare snapshot di core/derived e backup di incoming; predisporre script di rollback già elencati nel piano di fase 3.
    - Annotare in `logs/agent_activity.md` l'apertura del freeze fase 3→4, con riferimenti ai branch `patch/03A-core-derived` e `patch/03B-incoming-cleanup`.
    - Uscita: checklist freeze compilata e rollback testato a secco.
+   - **Stato:** completato e firmato Master DD → entry `[TKT-03AB-FREEZE-WINDOW-2026-05-03]` con snapshot/backup/redirect e dry-run rollback registrati in `logs/agent_activity.md` (finestra 2025-11-25T12:05Z→2025-11-27T12:05Z).
 
 3. **Applicazione patch 03A (core/derived)** (owner: coordinator + dev-tooling)
    - Prerequisiti: 02A verde (tutti i validator in pass e log archiviati in `logs/`).
    - Applicare le patch su core/derived solo dopo il pass verde di 02A.
    - Pubblicare changelog e includere i comandi di rollback rapidi.
    - Checklist applicazione patch core/derived:
-     - [ ] Confermare riferimenti commit/patchset e snapshot disponibili.
-     - [ ] Applicare patch su `data/core/` e `data/derived/` seguendo l'ordine dei diff dichiarato.
-     - [ ] Rieseguire smoke locale delle patch (lint/schema veloce) prima di validazioni complete.
-     - [ ] Aggiornare changelog utilizzando il template sotto.
-     - [ ] Registrare comandi di rollback rapidi testati a secco.
+     - [x] Confermare riferimenti commit/patchset e snapshot disponibili (`reports/backups/2025-11-25T2028Z_masterdd_freeze/`).
+     - [x] Applicare patch su `data/core/` e `data/derived/` seguendo l'ordine dei diff dichiarato (gate 03A approvato con Master DD: vedi log 2026-05-02 e 2026-05-01 in `logs/agent_activity.md`).
+     - [x] Rieseguire smoke locale delle patch (lint/schema veloce) prima di validazioni complete (validator schema-only in pass con 3 avvisi pack).
+     - [x] Aggiornare changelog utilizzando il template sotto (`reports/temp/patch-03A-core-derived/changelog.md`).
+     - [x] Registrare comandi di rollback rapidi testati a secco (`reports/temp/patch-03A-core-derived/rollback.md`).
    - Template changelog (linkabile):
      - Titolo: `Changelog 03A – core/derived`
      - Campi: **Scope**, **Patchset applicato (commit/PR)**, **Data/Owner**, **Validator eseguiti** (con link ai log), **Rollback rapido** (comandi e note), **Note aggiuntive**.
@@ -62,26 +63,28 @@ Questo piano elenca le attività operative a "lavori mirati" per avviare subito 
      - `git revert <commit_patch_03A>` (se applicato come commit singolo)
      - Ripristino log: `cp reports/temp/patch-03A-core-derived/*.log logs/`
    - Punto di controllo post-patch: rieseguire i validator 02A (`validate_datasets.py --schemas-only`, `trait_audit --check`, `trait_style_check`), allegare gli output aggiornati in `logs/` e ottenere firma Master DD per il pass verde.
+     - **Stato:** completato con log `logs/schema_only_2026-05-02.log`, `logs/trait_audit_2026-05-02.log`, `logs/trait_style_2026-05-02.log`, `logs/TKT-02A-VALIDATOR.rerun.log` (firma Master DD registrata in `logs/agent_activity.md`).
 4. **Pulizia incoming 03B con redirect** (owner: archivist + asset-prep)
    - Ripulire/archiviare incoming dopo backup; verificare redirect/link e rieseguire validator 02A in smoke.
    - Chiudere il freeze registrando approvazione Master DD nel log attività.
    - Uscita: log di chiusura freeze e report redirect.
+   - **Stato:** completato → checkpoint e cleanup con approvazione Master DD registrati come `[03B-CLEANUP-SMOKE-2026-05-02]` e `[03B-CLEANUP-SMOKE-2026-05-01]` in `logs/agent_activity.md` (backup/redirect invariati, smoke schema-only in pass con 3 avvisi pack, freeze 03B chiuso).
 
 5. **Promozione CI progressiva** (owner: dev-tooling)
    - Raccogliere 3 run verdi su `patch/01C-tooling-ci-catalog` per: `data-quality`, `validate_traits`, `schema-validate`.
    - Mantenere `validate-naming` consultivo finché non è stabile la matrice core/derived; poi proporre passaggio a enforcing con rollback plan.
    - Uscita: memo con stato gate CI e decisione su enforcement.
 
-   | Check CI        | Branch                       | Esito atteso | Run/Log CI                                               | Note                                 |
-   | --------------- | ---------------------------- | ------------ | -------------------------------------------------------- | ------------------------------------ |
-   | data-quality    | patch/01C-tooling-ci-catalog | Verde        | Vedi log in `logs/ci_patch-01C-tooling-ci-catalog.md`    | Tracking run 1–3 e link CI esterni.  |
-   | validate_traits | patch/01C-tooling-ci-catalog | Verde        | Vedi log in `logs/ci_patch-01C-tooling-ci-catalog.md`    | Run allineata ai dati core/derived.  |
-   | schema-validate | patch/01C-tooling-ci-catalog | Verde        | Vedi log in `logs/ci_patch-01C-tooling-ci-catalog.md`    | Run completa su catalogo CI tooling. |
-   | validate-naming | patch/01C-tooling-ci-catalog | Consultivo   | Documentato in `logs/ci_patch-01C-tooling-ci-catalog.md` | Enforcing solo dopo matrice stabile. |
+   | Check CI        | Branch                       | Esito atteso | Run/Log CI                                                                                                            | Note                                                                                                    |
+   | --------------- | ---------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+   | data-quality    | patch/01C-tooling-ci-catalog | Verde        | Run 1–3 verdi archiviate in `logs/ci_patch-01C-tooling-ci-catalog.md`                                                 | Tracking completato.                                                                                    |
+   | validate_traits | patch/01C-tooling-ci-catalog | Verde        | Run #1 rossa (log locale), run 2–3 da rilanciare dopo fix coverage/index (`logs/ci_patch-01C-tooling-ci-catalog.md`). | Rilancio pianificato.                                                                                   |
+   | schema-validate | patch/01C-tooling-ci-catalog | Verde        | Run 1–3 verdi archiviate in `logs/ci_patch-01C-tooling-ci-catalog.md`                                                 | Tracking completato.                                                                                    |
+   | validate-naming | patch/01C-tooling-ci-catalog | Consultivo   | Decisione condivisa e approvata in log `[01C-NAMING-CONSULTIVE-2026-04-26]` (`logs/agent_activity.md`).               | Enforcing rinviato finché la matrice core/derived non è stabile e `validate_traits` non ha 3 run verdi. |
    - Nota enforcement `validate-naming`:
-     - Stato attuale: **consultivo** (mantenere fino a stabilizzazione matrice core/derived).
-     - Decisione finale: **[da compilare]**.
-     - Rollback plan: **[da compilare]** (includere comando/commit per disabilitare enforcement e ripristinare configurazione attuale).
+     - Stato attuale: **consultivo** (trigger limitati a `push`/`workflow_dispatch`).
+     - Decisione finale: mantenere consultivo (approvazione Master DD in `[01C-NAMING-CONSULTIVE-2026-04-26]`).
+     - Rollback plan: revert dell'eventuale commit di enforcement o ripristino `continue-on-error: true` + trigger limitato al branch `patch/01C-tooling-ci-catalog` come documentato in `logs/ci_patch-01C-tooling-ci-catalog.md`.
 
 6. **Allineamento trait/biomi post-migrazione** (owner: trait-curator + balancer)
    - Applicare pipeline trait (conversione, coverage, locale sync) e migrazione v1→v2 secondo il piano operativo trait.
@@ -89,15 +92,15 @@ Questo piano elenca le attività operative a "lavori mirati" per avviare subito 
    - Uscita: report QA finale e indicizzazione aggiornata.
 
    **Checklist post-migrazione (esecuzione pipeline trait + QA + indici)**
-   - [ ] Pipeline trait eseguita end-to-end con evidenza dei tre step: **conversione**, **coverage**, **locale sync** (owner: trait-curator; supporto balancer per verifiche numeriche).
-   - [ ] QA finale completato:
-     - [ ] Validator di riferimento eseguiti (es. `validate_traits`, `validate_datasets.py --schemas-only` se applicabile) con log archiviati.
-     - [ ] Link checker su documentazione/indici completato con esito verde o lista fix allegata.
-   - [ ] Aggiornamento indici/documentazione completato con percorsi espliciti:
-     - [ ] Indice trait aggiornato (es. `traits/index.md` o `docs/traits/index.md`).
-     - [ ] Indice biomi aggiornato (es. `biomes/index.md` o `docs/biomes/index.md`).
-     - [ ] Altri indici correlati (es. `docs/migrations/README.md` o sommari locali) con riferimenti ai nuovi path.
-   - [ ] Field di controllo:
+   - [x] Pipeline trait eseguita end-to-end con evidenza dei tre step: **conversione**, **coverage**, **locale sync** (log in `logs/trait_pipeline_20251130T051614Z/{conversion.log,coverage.log,locale_sync.log}`).
+   - [x] QA finale completato:
+     - [x] Validator di riferimento eseguiti con log archiviati (`logs/trait_pipeline_20251130T051614Z/validator.log`).
+     - [x] Link checker su documentazione/indici completato con esito verde (`logs/trait_pipeline_20251130T051614Z/link_checker.log`).
+   - [x] Aggiornamento indici/documentazione completato con percorsi espliciti:
+     - [x] Indice trait aggiornato (es. `traits/index.md` o `docs/traits/index.md`).
+     - [x] Indice biomi aggiornato (es. `biomes/index.md` o `docs/biomes.md`).
+     - [x] Altri indici correlati (es. `docs/migrations/README.md` o sommari locali) con riferimenti ai nuovi path.
+   - [x] Field di controllo:
      - URL indici aggiornati: `docs/catalog/trait_reference.md`; `docs/biomes.md`
      - Report QA finale allegato (percorso file o URL): `logs/trait_pipeline_20251130T051614Z/README.md`
 


### PR DESCRIPTION
## Summary
- Marked freeze 03A/03B, patch 03A, and cleanup 03B as completed with references to logged approvals.
- Updated CI tracking table and validate-naming decision, and recorded completion of the trait/biome post-migration pipeline and QA.

## Testing
- `npx prettier docs/migration_targeted_workplan.md --write`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a4ae00afc8328b88c7fda03dd6159)