### PR TITLE
Rerun trait pipeline and refresh QA documentation

### DIFF
--- a/data/derived/analysis/trait_coverage_report.json
+++ b/data/derived/analysis/trait_coverage_report.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2025-11-30T13:50:32+00:00",
+  "generated_at": "2025-11-30T13:59:12+00:00",
   "sources": {
     "env_traits": "packs/evo_tactics_pack/docs/catalog/env_traits.json",
     "trait_reference": "data/traits/index.json",

--- a/docs/migration_targeted_workplan.md
+++ b/docs/migration_targeted_workplan.md
@@ -92,17 +92,17 @@ Questo piano elenca le attività operative a "lavori mirati" per avviare subito 
    - Uscita: report QA finale e indicizzazione aggiornata.
 
    **Checklist post-migrazione (esecuzione pipeline trait + QA + indici)**
-   - [x] Pipeline trait eseguita end-to-end con evidenza dei tre step: **conversione**, **coverage**, **locale sync** (log in `logs/trait_pipeline_20251130T051614Z/{conversion.log,coverage.log,locale_sync.log}`).
+   - [x] Pipeline trait eseguita end-to-end con evidenza dei tre step: **conversione**, **coverage**, **locale sync** (rerun 2025-11-30 13:59 UTC, log in `logs/trait_pipeline_20251130T135906Z/{conversion.log,coverage.log,locale_sync.log}`).
    - [x] QA finale completato:
-     - [x] Validator di riferimento eseguiti con log archiviati (`logs/trait_pipeline_20251130T051614Z/validator.log`).
-     - [x] Link checker su documentazione/indici completato con esito verde (`logs/trait_pipeline_20251130T051614Z/link_checker.log`).
+     - [x] Validator di riferimento eseguiti con log archiviati (`logs/trait_pipeline_20251130T135906Z/validator.log`).
+     - [x] Link checker su documentazione/indici completato con esito verde (`logs/trait_pipeline_20251130T135906Z/link_checker.log`, warning npm su env config non bloccante).
    - [x] Aggiornamento indici/documentazione completato con percorsi espliciti:
      - [x] Indice trait aggiornato (es. `traits/index.md` o `docs/traits/index.md`).
      - [x] Indice biomi aggiornato (es. `biomes/index.md` o `docs/biomes.md`).
      - [x] Altri indici correlati (es. `docs/migrations/README.md` o sommari locali) con riferimenti ai nuovi path.
    - [x] Field di controllo:
      - URL indici aggiornati: `docs/catalog/trait_reference.md`; `docs/biomes.md`
-     - Report QA finale allegato (percorso file o URL): `logs/trait_pipeline_20251130T051614Z/README.md`
+     - Report QA finale allegato (percorso file o URL): `logs/trait_pipeline_20251130T135906Z/README.md`
 
 ## Note operative
 

--- a/logs/trait_pipeline_20251130T135906Z/README.md
+++ b/logs/trait_pipeline_20251130T135906Z/README.md
@@ -1,0 +1,9 @@
+# Trait pipeline 2025-11-30 (UTC) – rerun
+
+- Conversione: `python tools/py/import_external_traits.py --appendix-dir docs/appendici --incoming incoming/sentience_traits_v1.0.yaml --output-dir data/traits/_drafts` → vedi `conversion.log`.
+- Coverage: `python tools/py/report_trait_coverage.py --env-traits packs/evo_tactics_pack/docs/catalog/env_traits.json --trait-reference data/traits/index.json --species-root packs/evo_tactics_pack/data/species --trait-glossary data/core/traits/glossary.json --out-json data/derived/analysis/trait_coverage_report.json --out-csv data/derived/analysis/trait_coverage_matrix.csv --strict` → vedi `coverage.log`.
+- Locale sync: `python scripts/sync_trait_locales.py --traits-dir data/traits --locales-dir locales --language it` → vedi `locale_sync.log`.
+- Validator di riferimento: `python tools/py/trait_template_validator.py --summary` → vedi `validator.log`.
+- Link checker: `npm run docs:lint` → vedi `link_checker.log` (warning npm su env config non blocca l'esecuzione).
+
+Esito: tutti i passi completati con successo; validator e link checker in pass. I draft importati e sincronizzati restano sotto `data/traits/_drafts/`.

--- a/logs/trait_pipeline_20251130T135906Z/conversion.log
+++ b/logs/trait_pipeline_20251130T135906Z/conversion.log
@@ -1,0 +1,10 @@
+Generati 9 draft in data/traits/_drafts
+ - data/traits/_drafts/artigli_sette_vie_2.json
+ - data/traits/_drafts/struttura_elastica_amorfa_2.json
+ - data/traits/_drafts/scheletro_idro_regolante_2.json
+ - data/traits/_drafts/coda_frusta_cinetica_2.json
+ - data/traits/_drafts/sacche_galleggianti_ascensoriali_2.json
+ - data/traits/_drafts/criostasi_adattiva_2.json
+ - data/traits/_drafts/focus_frazionato_2.json
+ - data/traits/_drafts/risonanza_di_branco_2.json
+ - data/traits/_drafts/tattiche_di_branco_2.json

--- a/logs/trait_pipeline_20251130T135906Z/coverage.log
+++ b/logs/trait_pipeline_20251130T135906Z/coverage.log
@@ -1,0 +1,3 @@
+Report coverage generato in data/derived/analysis/trait_coverage_report.json
+Matrice esportata in data/derived/analysis/trait_coverage_matrix.csv
+Controlli strict superati: min_traits_with_species=27, max_rules_missing_species=0

--- a/logs/trait_pipeline_20251130T135906Z/link_checker.log
+++ b/logs/trait_pipeline_20251130T135906Z/link_checker.log
@@ -1,0 +1,5 @@
+
+> docs:lint
+> python tools/check_site_links.py docs
+
+Tutti i collegamenti interni risultano validi.

--- a/logs/trait_pipeline_20251130T135906Z/locale_sync.log
+++ b/logs/trait_pipeline_20251130T135906Z/locale_sync.log
@@ -1,0 +1,11 @@
+Trait aggiornati:
+ - data/traits/_drafts/artigli_sette_vie_2.json
+ - data/traits/_drafts/coda_frusta_cinetica_2.json
+ - data/traits/_drafts/criostasi_adattiva_2.json
+ - data/traits/_drafts/focus_frazionato_2.json
+ - data/traits/_drafts/risonanza_di_branco_2.json
+ - data/traits/_drafts/sacche_galleggianti_ascensoriali_2.json
+ - data/traits/_drafts/scheletro_idro_regolante_2.json
+ - data/traits/_drafts/struttura_elastica_amorfa_2.json
+ - data/traits/_drafts/tattiche_di_branco_2.json
+File locale invariato.

--- a/logs/trait_pipeline_20251130T135906Z/validator.log
+++ b/logs/trait_pipeline_20251130T135906Z/validator.log
@@ -1,0 +1,389 @@
+[VALIDATION] Tutti i trait rispettano lo schema.
+[TRAIT] ali_fono_risonanti: OK
+[TRAIT] ali_fulminee: OK
+[TRAIT] ali_ioniche: OK
+[TRAIT] ali_membrana_sonica: OK
+[TRAIT] antenne_dustsense: OK
+[TRAIT] antenne_eco_turbina: OK
+[TRAIT] antenne_flusso_mareale: OK
+[TRAIT] antenne_microonde_cavernose: OK
+[TRAIT] antenne_plasmatiche_tempesta: OK
+[TRAIT] antenne_reagenti: OK
+[TRAIT] antenne_tesla: OK
+[TRAIT] antenne_waveguide: OK
+[TRAIT] antenne_wideband: OK
+[TRAIT] appendici_risonanti_marea: OK
+[TRAIT] appendici_thermotattiche: OK
+[TRAIT] armatura_pietra_planare: OK
+[TRAIT] articolazioni_a_leva_idraulica: OK
+[TRAIT] articolazioni_multiassiali: OK
+[TRAIT] artigli_acidofagi: OK
+[TRAIT] artigli_induzione: OK
+[TRAIT] artigli_ipo_termici: OK
+[TRAIT] artigli_radice: OK
+[TRAIT] artigli_scivolo_silente: OK
+[TRAIT] artigli_sette_vie: OK
+[TRAIT] artigli_sghiaccio_glaciale: OK
+[TRAIT] artigli_vetrificati: OK
+[TRAIT] artiglio_cinetico_a_urto: OK
+[TRAIT] aura_di_dispersione_mentale: OK
+[TRAIT] aura_scudo_radianza: OK
+[TRAIT] baffi_mareomotori: OK
+[TRAIT] barbigli_sensori_plasma: OK
+[TRAIT] barriere_miasma_glaciale: OK
+[TRAIT] batteri_endosimbionti_chemio: OK
+[TRAIT] batteri_termofili_endosimbiosi: OK
+[TRAIT] bioantenne_gravitiche: OK
+[TRAIT] biochip_memoria: OK
+[TRAIT] biofilm_glow: OK
+[TRAIT] biofilm_iperarido: OK
+[TRAIT] bozzolo_magnetico: OK
+[TRAIT] branchie_dual_mode: OK
+[TRAIT] branchie_eoliche: OK
+[TRAIT] branchie_metalloidi: OK
+[TRAIT] branchie_microfiltri: OK
+[TRAIT] branchie_osmotiche_salmastra: OK
+[TRAIT] branchie_solfatiche: OK
+[TRAIT] branchie_turbina: OK
+[TRAIT] bulbi_radici_permafrost: OK
+[TRAIT] camere_anticorrosione: OK
+[TRAIT] camere_mirage: OK
+[TRAIT] camere_nutrienti_vent: OK
+[TRAIT] camere_risonanza_abyssal: OK
+[TRAIT] campo_di_interferenza_acustica: OK
+[TRAIT] cannone_sonico_a_raggio: OK
+[TRAIT] canto_infrasonico_tattico: OK
+[TRAIT] canto_risonante: OK
+[TRAIT] capillari_criogenici: OK
+[TRAIT] capillari_fluoridici: OK
+[TRAIT] capillari_fotovoltaici: OK
+[TRAIT] capsule_paracadute: OK
+[TRAIT] carapace_fase_variabile: OK
+[TRAIT] carapace_luminiscente_abissale: OK
+[TRAIT] carapace_segmenti_logici: OK
+[TRAIT] carapaci_ferruginosi: OK
+[TRAIT] cartilagine_flessotermica_venti: OK
+[TRAIT] cartilagini_biofibre: OK
+[TRAIT] cartilagini_desertiche: OK
+[TRAIT] cartilagini_flessoacustiche: OK
+[TRAIT] cartilagini_pseudometalliche: OK
+[TRAIT] cavita_risonanti_tundra: OK
+[TRAIT] cervelletto_equilibrio_statico: OK
+[TRAIT] cervello_a_bassa_latenza: OK
+[TRAIT] chemiorecettori_bromuro: OK
+[TRAIT] chioma_parassita_canopica: OK
+[TRAIT] cinghia_iper_ciliare: OK
+[TRAIT] circolazione_bifasica: OK
+[TRAIT] circolazione_bifasica_palude: OK
+[TRAIT] circolazione_cooling_loop: OK
+[TRAIT] circolazione_doppia: OK
+[TRAIT] circolazione_supercritica: OK
+[TRAIT] ciste_riduttive: OK
+[TRAIT] ciste_salmastre: OK
+[TRAIT] cisti_di_ibernazione_minerale: OK
+[TRAIT] cisti_iperbariche: OK
+[TRAIT] coda_balanciere: OK
+[TRAIT] coda_contrappeso: OK
+[TRAIT] coda_coppia_retroattiva: OK
+[TRAIT] coda_frusta_cinetica: OK
+[TRAIT] coda_prensile_muscolare: OK
+[TRAIT] coda_stabilizzatrice_filo: OK
+[TRAIT] coda_stabilizzatrice_geiser: OK
+[TRAIT] coda_stabilizzatrice_vortex: OK
+[TRAIT] colonne_vibromagnetiche: OK
+[TRAIT] comunicazione_fotonica_coda_coda: OK
+[TRAIT] coralli_partner: OK
+[TRAIT] coralli_sinaptici_fotofase: OK
+[TRAIT] corazze_ferro_magnetico: OK
+[TRAIT] corna_psico_conduttive: OK
+[TRAIT] coscienza_d_alveare_diffusa: OK
+[TRAIT] criostasi_adattiva: OK
+[TRAIT] cromofori_alert_acido: OK
+[TRAIT] cuore_multicamera_bassa_pressione: OK
+[TRAIT] cuscinetti_elettrostatici: OK
+[TRAIT] cute_resistente_sali: OK
+[TRAIT] cuticole_cerose: OK
+[TRAIT] cuticole_neutralizzanti: OK
+[TRAIT] denti_chelatanti: OK
+[TRAIT] denti_ossidoferro: OK
+[TRAIT] denti_silice_termici: OK
+[TRAIT] denti_tuning_fork: OK
+[TRAIT] echi_risonanti: OK
+[TRAIT] eco_interno_riflesso: OK
+[TRAIT] ectotermia_dinamica: OK
+[TRAIT] elettromagnete_biologico: OK
+[TRAIT] emettitori_voidsong: OK
+[TRAIT] emolinfa_conducente: OK
+[TRAIT] empatia_coordinativa: OK
+[TRAIT] enzimi_antifase_termica: OK
+[TRAIT] enzimi_antipredatori_algali: OK
+[TRAIT] enzimi_chelanti: OK
+[TRAIT] enzimi_chelatori_rapidi: OK
+[TRAIT] enzimi_metanoossidanti: OK
+[TRAIT] epidermide_dielettrica: OK
+[TRAIT] epitelio_fosforescente: OK
+[TRAIT] ermafroditismo_cronologico: OK
+[TRAIT] estroflessione_gastrica_acida: OK
+[TRAIT] fagocitosi_assorbente: OK
+[TRAIT] filamenti_digestivi_compattanti: OK
+[TRAIT] filamenti_echo: OK
+[TRAIT] filamenti_guidalampo: OK
+[TRAIT] filamenti_magnetotrofi: OK
+[TRAIT] filamenti_superconduttivi: OK
+[TRAIT] filamenti_termoconduzione: OK
+[TRAIT] filtrazione_osmotica: OK
+[TRAIT] filtri_planctonici: OK
+[TRAIT] filtro_metallofago: OK
+[TRAIT] flagelli_ancoranti: OK
+[TRAIT] flusso_ameboide_controllato: OK
+[TRAIT] focus_frazionato: OK
+[TRAIT] foliage_fotocatodico: OK
+[TRAIT] foliaggio_spugna: OK
+[TRAIT] frusta_fiammeggiante: OK
+[TRAIT] ghiaccio_piezoelettrico: OK
+[TRAIT] ghiandola_caustica: OK
+[TRAIT] ghiandole_cambio_salino: OK
+[TRAIT] ghiandole_condensa_ozono: OK
+[TRAIT] ghiandole_eco_mappanti: OK
+[TRAIT] ghiandole_fango_calde: OK
+[TRAIT] ghiandole_fango_coesivo: OK
+[TRAIT] ghiandole_grafene: OK
+[TRAIT] ghiandole_inchiostro_luce: OK
+[TRAIT] ghiandole_iodoattive: OK
+[TRAIT] ghiandole_minerali: OK
+[TRAIT] ghiandole_mnemoniche: OK
+[TRAIT] ghiandole_nebbia_acida: OK
+[TRAIT] ghiandole_nebbia_ionica: OK
+[TRAIT] ghiandole_resina_conduttiva: OK
+[TRAIT] ghiandole_ventosa: OK
+[TRAIT] giunti_antitorsione: OK
+[TRAIT] grassi_termici: OK
+[TRAIT] gusci_criovetro: OK
+[TRAIT] gusci_magnesio: OK
+[TRAIT] impulsi_bioluminescenti: OK
+[TRAIT] integumento_bipolare: OK
+[TRAIT] ipertrofia_muscolare_massiva: OK
+[TRAIT] lamelle_shear: OK
+[TRAIT] lamelle_sincroniche: OK
+[TRAIT] lamelle_termoforetiche: OK
+[TRAIT] lamine_filtranti_aeree: OK
+[TRAIT] lamine_scudo_silice: OK
+[TRAIT] linfa_tampone: OK
+[TRAIT] lingua_cristallina: OK
+[TRAIT] lingua_tattile_trama: OK
+[TRAIT] lobi_risonanti_crepuscolo: OK
+[TRAIT] locomozione_miriapode_ibrida: OK
+[TRAIT] luminescenza_aurorale: OK
+[TRAIT] luminescenza_hydrotermica: OK
+[TRAIT] mantelli_geotermici: OK
+[TRAIT] mantello_meteoritico: OK
+[TRAIT] membrana_plastica_continua: OK
+[TRAIT] membrane_captura_rugiada: OK
+[TRAIT] membrane_eliofiltranti: OK
+[TRAIT] membrane_fotoconvoglianti: OK
+[TRAIT] membrane_planata_vectored: OK
+[TRAIT] membrane_pneumatofori: OK
+[TRAIT] metabolismo_di_condivisione_energetica: OK
+[TRAIT] midollo_antivibrazione: OK
+[TRAIT] mimetismo_cromatico_passivo: OK
+[TRAIT] moltiplicazione_per_fusione: OK
+[TRAIT] motore_biologico_silenzioso: OK
+[TRAIT] mucillagine_simbionte_mangrovie: OK
+[TRAIT] mucose_aderenza_sonica: OK
+[TRAIT] mucose_barofile: OK
+[TRAIT] nebbia_mnesica: OK
+[TRAIT] nodi_micorrizici_oracolari: OK
+[TRAIT] nodi_sinaptici_superficiali: OK
+[TRAIT] nucleo_ovomotore_rotante: OK
+[TRAIT] occhi_analizzatori_di_tensione: OK
+[TRAIT] occhi_cinetici: OK
+[TRAIT] occhi_cristallo_modulare: OK
+[TRAIT] occhi_infrarosso_composti: OK
+[TRAIT] olfatto_risonanza_magnetica: OK
+[TRAIT] organi_metacronici: OK
+[TRAIT] organi_sismici_cutanei: OK
+[TRAIT] pathfinder: OK
+[TRAIT] pelage_idrorepellente_avanzato: OK
+[TRAIT] pelle_piezo_satura: OK
+[TRAIT] pianificatore: OK
+[TRAIT] piume_solari_fotovoltaiche: OK
+[TRAIT] placca_diffusione_foschia: OK
+[TRAIT] placche_pressioniche: OK
+[TRAIT] polmoni_cristallini_alta_quota: OK
+[TRAIT] random: OK
+[TRAIT] respiro_a_scoppio: OK
+[TRAIT] rete_filtro_polmonare: OK
+[TRAIT] risonanza_di_branco: OK
+[TRAIT] riverbero_memetico: OK
+[TRAIT] rostro_emostatico_litico: OK
+[TRAIT] rostro_linguale_prensile: OK
+[TRAIT] sacche_galleggianti_ascensoriali: OK
+[TRAIT] sacche_spore_stratosferiche: OK
+[TRAIT] sangue_piroforico: OK
+[TRAIT] scheletro_idraulico_a_pistoni: OK
+[TRAIT] scheletro_idro_regolante: OK
+[TRAIT] scheletro_pneumatico_a_maglie: OK
+[TRAIT] scintilla_sinaptica: OK
+[TRAIT] scivolamento_magnetico: OK
+[TRAIT] scudo_gluteale_cheratinizzato: OK
+[TRAIT] secrezione_rallentante_palmi: OK
+[TRAIT] secrezioni_antistatiche: OK
+[TRAIT] sensori_geomagnetici: OK
+[TRAIT] sensori_planctonici: OK
+[TRAIT] seta_conduttiva_elettrica: OK
+[TRAIT] siero_anti_gelo_naturale: OK
+[TRAIT] sinapsi_coraline_polifoniche: OK
+[TRAIT] sistemi_chimio_sonici: OK
+[TRAIT] sonno_emisferico_alternato: OK
+[TRAIT] spicole_canalizzatrici: OK
+[TRAIT] spore_psichiche_silenziate: OK
+[TRAIT] squame_diffusori_ionici: OK
+[TRAIT] squame_rifrangenti_deserto: OK
+[TRAIT] struttura_elastica_amorfa: OK
+[TRAIT] tattiche_di_branco: OK
+[TRAIT] unghie_a_micro_adesione: OK
+[TRAIT] vello_condensatore_nebbie: OK
+[TRAIT] vello_di_assorbimento_totale: OK
+[TRAIT] ventriglio_gastroliti: OK
+[TRAIT] visione_multi_spettrale_amplificata: OK
+[TRAIT] vortice_nera_flash: OK
+[TRAIT] zampe_a_molla: OK
+[TRAIT] zanne_idracida: OK
+[TRAIT] zoccoli_risonanti_steppe: OK
+== Summary of fields (Campi per tipologia) ==
+- Alimentazione/Digestione (2 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Ambiente/Supporto (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Analisi/Sensori Planctonici (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Cognitivo/Apprendimento (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Cognitivo/Sociale (3 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Controllo/Memoria (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Difensivo/Camuffamento (3 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Difensivo/Corazza (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Difensivo/Resistenze (2 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Difensivo/Termoregolazione (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Difesa/Antistatico (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Difesa/Elettrico (2 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Difesa/Foschia (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Difesa/Magnetico (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Difesa/Pressione (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Difesa/Strutturale (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Difesa/Termoregolazione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Digestivo/Alimentare (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Digestivo/Escretorio (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Digestivo/Metabolico (13 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Escretorio/Psichico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, species_affinity, spinta_selettiva, tier, usage_tags, uso_funzione
+- Esplorazione/Tattico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, species_affinity, spinta_selettiva, tier, usage_tags, uso_funzione
+- Fisiologico/Idrico (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Fisiologico/Metabolico (3 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Fisiologico/Respiratorio (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Fisiologico/Termico (2 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Flessibile/Generico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, species_affinity, spinta_selettiva, tier, usage_tags, uso_funzione
+- Idrostatico/Locomotorio (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Locomotivo/Aereo (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, species_affinity, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Locomotivo/Arboricolo (2 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, species_affinity, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Locomotivo/Balistico (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, species_affinity, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Locomotivo/Terrestre (7 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, species_affinity, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Locomotorio/Adattivo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Locomotorio/Difensivo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Locomotorio/Mobilità (14 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Locomotorio/Predatorio (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Locomotorio/Prensile (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Locomotorio/Supporto (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Manipolativo/Alimentare (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Metabolico/Difensivo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Metabolico/Resilienza (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Mobilità/Cinetico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Mobilità/Logistica (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Nervoso/Omeostatico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Offensivo/Assalto (13 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Offensivo/Assorbimento (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Offensivo/Chimico (3 trait): applicability, biome_tags, completion_flags, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, species_affinity, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Offensivo/Cinetico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Offensivo/Controllo (4 trait): applicability, biome_tags, completion_flags, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Offensivo/Contusivo (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Offensivo/Elettrico (2 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Offensivo/Illuminazione (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Offensivo/Perforante (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Offensivo/Termico (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Respiratorio/Aerobico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Respiratorio/Osmoregolazione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Respiratorio/Propulsivo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Respiratorio/Protezione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Respiratorio/Termoregolazione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Riproduttivo/Cicli (2 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Riproduttivo/Locomotorio (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, species_affinity, spinta_selettiva, tier, usage_tags, uso_funzione
+- Risonanza/Crepuscolo (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Sensore/Gravitazionale (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Sensoriale/Alimentare (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Sensoriale/Analitico (14 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Sensoriale/Magneto-ricettivo (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Sensoriale/Navigazione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Sensoriale/Nervoso (2 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Sensoriale/Offensivo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Sensoriale/Supporto (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Sensoriale/Tatto-Vibro (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione, version, versioning
+- Sensoriale/Uditivo-Olfattivo (1 trait): applicability, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, slot, slot_profile, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Sensoriale/Visivo (5 trait): applicability, biome_tags, completion_flags, conflitti, cost_profile, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, metrics, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, species_affinity, spinta_selettiva, testability, tier, usage_tags, uso_funzione
+- Simbiotico/Comunicazione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Simbiotico/Cooperativo (13 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Simbiotico/Difensivo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Simbiotico/Nervoso (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Simbiotico/Nutrizione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Simbiotico/Supporto (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Simbiotico/Utility (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Strategico/Psionico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Strategico/Tattico (15 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Strutturale/Adattivo (13 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Strutturale/Difensivo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Strutturale/Locomotorio (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Strutturale/Omeostatico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Strutturale/Sensoriale (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Supporto/Anomalia (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Supporto/Coordinativo (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Supporto/Copia (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Supporto/Difesa (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Supporto/Empatico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Supporto/Energetico (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Supporto/Logistico (13 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Supporto/Risonanza (2 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Supporto/Sensore (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Supporto/Sequenziamento (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- TODO/import_esterno (9 trait): completion_flags, conflitti, data_origin, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, sinergie, slot, slot_profile, spinta_selettiva, tier, uso_funzione
+- Tegumentario/Difensivo (17 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, species_affinity, spinta_selettiva, tier, usage_tags, uso_funzione
+- Tegumentario/Energetico (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Tegumentario/Idratazione (1 trait): biome_tags, completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, sinergie_pi, slot, slot_profile, spinta_selettiva, tier, usage_tags, uso_funzione
+- Temporaneo/Difesa (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Temporaneo/Memoria (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Temporaneo/Risonanza (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Temporaneo/Scarica (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+- Temporaneo/Traslazione (1 trait): completion_flags, conflitti, data_origin, debolezza, famiglia_tipologia, fattore_mantenimento_energetico, id, label, mutazione_indotta, requisiti_ambientali, sinergie, slot, spinta_selettiva, tier, usage_tags, uso_funzione
+
+== Field inventory ==
+ - applicability
+ - biome_tags
+ - completion_flags
+ - conflitti
+ - cost_profile
+ - data_origin
+ - debolezza
+ - famiglia_tipologia
+ - fattore_mantenimento_energetico
+ - id
+ - label
+ - metrics
+ - mutazione_indotta
+ - requisiti_ambientali
+ - sinergie
+ - sinergie_pi
+ - slot
+ - slot_profile
+ - species_affinity
+ - spinta_selettiva
+ - testability
+ - tier
+ - usage_tags
+ - uso_funzione
+ - version
+ - versioning
+
+Total traits: 260


### PR DESCRIPTION
## Summary
- reran the trait pipeline (conversion, coverage, locale sync) and archived fresh logs under a new timestamped folder
- refreshed the migration checklist to point at the latest pipeline execution and QA outputs
- regenerated the trait coverage report metadata after the new run

## Testing
- python tools/py/import_external_traits.py --appendix-dir docs/appendici --incoming incoming/sentience_traits_v1.0.yaml --output-dir data/traits/_drafts
- python tools/py/report_trait_coverage.py --env-traits packs/evo_tactics_pack/docs/catalog/env_traits.json --trait-reference data/traits/index.json --species-root packs/evo_tactics_pack/data/species --trait-glossary data/core/traits/glossary.json --out-json data/derived/analysis/trait_coverage_report.json --out-csv data/derived/analysis/trait_coverage_matrix.csv --strict
- python scripts/sync_trait_locales.py --traits-dir data/traits --locales-dir locales --language it
- python tools/py/trait_template_validator.py --summary
- npm run docs:lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c4cc0eca083288182e97724eae8ec)