### PR TITLE
Align planning logs after 03B freeze closure

### DIFF
--- a/docs/incoming/README.md
+++ b/docs/incoming/README.md
@@ -19,6 +19,8 @@ Linee guida minime:
 
 Note:
 
+- 2026-05-02: cleanup 03B chiuso con firma Master DD; freeze documentale su `incoming/**` e `docs/incoming/**` dismesso dopo il checkpoint con smoke schema-only (14 controlli, 3 avvisi pack) e redirect confermati (`reports/temp/patch-03B-incoming-cleanup/2026-02-20/cleanup_redirect.md`). Baseline validator 02A schema-only 2026-05-01/02 registrata in `reports/audit/2026-02-20_audit_bundle.md`. Nuovi drop richiedono apertura di una nuova finestra freeze e log dedicato in `logs/agent_activity.md`.
+
 - 2026-04-13: soft freeze documentale su `incoming/**` e `docs/incoming/**` confermato fino alla chiusura 03B (branch `patch/03B-incoming-cleanup`, controlli core su `patch/03A-core-derived`). Nessun merge/spostamento; solo report-only. Previsto rerun 02A report-only con validator schema/trait/style nei log `reports/temp/patch-03A-core-derived/` e specchio `reports/temp/patch-03B-incoming-cleanup/2026-02-20/` prima di qualsiasi sblocco.
 
 - 2026-04-11: gate 01B chiuso con approvazione Master DD sulla matrice core/derived v0.2 (`patch/01B-core-derived-matrix`); handoff avviato verso fase 02A con README sincronizzati.

--- a/docs/planning/REF_PLANNING_RIPRESA_2026.md
+++ b/docs/planning/REF_PLANNING_RIPRESA_2026.md
@@ -24,6 +24,7 @@ Scope della ripresa: riattivare i flussi preparatori su incoming/01A–03B senza
 - **Allineamento reference:** ristudiare `REF_REPO_SCOPE` e `REF_REPO_MIGRATION_PLAN` per validare che i gate 01A/01B/01C non richiedano aggiornamenti preliminari.
 - **Stato ticketing:** verificare ticket aperti per 01A–03B e chiudere/aggiornare quelli già superati prima di pianificare nuovi step.
 - **Aggiornamento 2026-02-12:** aperto checkpoint **RIAPERTURA-2026-02** (patchset 03A/03B) dopo esito baseline 02A in modalità report-only; freeze soft su `incoming/**` e `docs/incoming/**` ancora da confermare con Master DD, README incoming/docs allineati e tracciati nel log.
+- **Aggiornamento 2026-05-08:** rerun 02A schema-only 2026-05-01/02 loggati in `reports/audit/2026-02-20_audit_bundle.md` e usati come base per i gate 03A/03B; cleanup 03B chiuso con firma Master DD (log 2026-05-02) e freeze documentale dismesso. Per nuovi drop incoming serve aprire una nuova finestra freeze approvata e registrare il kickoff nel log `agent_activity.md` con riferimento a README aggiornati.
 
 ## Checklist di riapertura (48h)
 
@@ -33,6 +34,13 @@ Scope della ripresa: riattivare i flussi preparatori su incoming/01A–03B senza
 4. **Validare freeze + holding:** controllare se esistono nuovi drop in `incoming/_holding`; loggare decisione (integrare o archiviare) senza muovere file.
 5. **Aggiornare README mirati:** se emergono variazioni, sincronizzare solo `incoming/README.md` e `docs/incoming/README.md` con note di stato e ticket.
 6. **Gate di uscita riapertura:** una volta chiusi i punti 1–5, loggare in `logs/agent_activity.md` “RIAPERTURA-2026-01 chiusa” e passare alla pipeline 01A.
+
+### Note operative 2026-05-08 (post 03A/03B)
+
+- Baseline validator: usare i log schema-only 2026-05-01/02 (report-only) e i mirror 03B in `reports/temp/patch-03B-incoming-cleanup/2026-02-20/` come riferimento unico per il prossimo ciclo.
+- Freeze: la finestra 03B documentale è stata chiusa con firma Master DD al 2026-05-02; prima di nuovi drop aprire un nuovo freeze (template in `logs/agent_activity.md`).
+- Documentazione: README `incoming/` e `docs/incoming/` sincronizzati sullo stato post-freeze; mantenere la coerenza con `reports/audit/2026-02-20_audit_bundle.md` per redirect/backup.
+- Azione successiva: richiesta conferma Master DD per riaprire il ciclo con nuovi batch o per mantenere lo stato di sola consultazione.
 
 ### Ruoli e responsabilità durante la riapertura
 

--- a/incoming/README.md
+++ b/incoming/README.md
@@ -35,6 +35,8 @@ Linee guida minime:
 
 Note:
 
+- 2026-05-02: cleanup 03B chiuso con firma Master DD; freeze documentale su `incoming/**` e `docs/incoming/**` dismesso dopo il checkpoint con smoke schema-only (14 controlli, 3 avvisi pack) e redirect confermati (`reports/temp/patch-03B-incoming-cleanup/2026-02-20/cleanup_redirect.md`). Baseline validator 02A schema-only 2026-05-01/02 registrata in `reports/audit/2026-02-20_audit_bundle.md`. Nuovi drop richiedono apertura di una nuova finestra freeze e log dedicato in `logs/agent_activity.md`.
+
 - 2026-04-13: soft freeze documentale su `incoming/**` e `docs/incoming/**` confermato fino alla chiusura 03B (branch `patch/03B-incoming-cleanup`, controlli core su `patch/03A-core-derived`). Nessun merge/spostamento; solo report-only. Previsto rerun 02A report-only con validator schema/trait/style nei log `reports/temp/patch-03A-core-derived/` e specchio `reports/temp/patch-03B-incoming-cleanup/2026-02-20/` prima di qualsiasi sblocco.
 
 - 2026-04-11: gate 01B chiuso con approvazione Master DD sulla matrice core/derived v0.2 (`patch/01B-core-derived-matrix`); handoff avviato verso fase 02A con README sincronizzati.

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -10,6 +10,9 @@
   - Esito dry-run rollback (core/derived) e dry-run ripristino backup/redirect prima della chiusura.
   - Riferimento alla firma finale Master DD che chiude il freeze 3→4.
 
+## 2026-05-08 – Allineamento planning 03A/03B e note riaperture (archivist)
+- Step: `[PLANNING-ALIGN-2026-05-08] owner=archivist (approvatore Master DD); files=docs/planning/REF_PLANNING_RIPRESA_2026.md, incoming/README.md, docs/incoming/README.md, reports/audit/2026-02-20_audit_bundle.md, logs/agent_activity.md; rischio=basso (documentazione/freeze); note=Allineati i reference di ripresa con gli esiti dei rerun 02A schema-only (log 2026-05-01/02) e con la chiusura del cleanup 03B firmata Master DD. README incoming/docs aggiornati per riflettere che il freeze 03B documentale è chiuso al 2026-05-02 e che per nuovi drop servirà una finestra approvata. L’audit bundle annota il checkpoint finale 03B e mantiene come baseline i log specchiati 03A/03B; prossimi passi: conferma Master DD sull’apertura del ciclo successivo e nuova finestra freeze se entrano nuovi batch incoming.`
+
 ## 2026-05-06 – Allineamento fonti core/pack (archivist)
 - Step: `[REF-SOURCES-PACKS-2026-05-06] owner=archivist (approvatore Master DD); files=docs/planning/REF_REPO_SOURCES_OF_TRUTH.md, docs/planning/REF_PACKS_AND_DERIVED.md, logs/agent_activity.md; rischio=basso (documentazione/cataloghi); note=Aggiornata tabella canonica per trait/specie/biomi/telemetria con link a schemi ALIENA/UCUM e cross-link reciproco a REF_PACKS_AND_DERIVED; mappati generatori pack/derived con requisiti di checksum/log e verificata assenza di percorsi duplicati in data/core/**, packs/**, data/derived/**.`
 

--- a/reports/audit/2026-02-20_audit_bundle.md
+++ b/reports/audit/2026-02-20_audit_bundle.md
@@ -42,6 +42,12 @@ Raccogliere in un unico punto i riferimenti operativi per chiudere il ciclo 02A�
 - [x] Istruzioni backup/redirect 03B
 - [x] Trigger riavvio eseguito
 
+## Aggiornamento 2026-05-08 (allineamento pianificazione)
+
+- Freeze 03B: finestra documentale chiusa con firma Master DD al 2026-05-02 (`logs/agent_activity.md`), redirect invariati e backup confermati sui manifest 2025-11-25 e sul README 2026-02-20; nuovi drop richiedono l’apertura di un freeze dedicato prima di qualsiasi ingest.
+- Validator: baseline schema-only 2026-05-01/02 in `reports/temp/patch-03A-core-derived/` e mirror 03B in `reports/temp/patch-03B-incoming-cleanup/2026-02-20/` restano il riferimento per il prossimo ciclo 03A/03B.
+- Documentazione: README `incoming/` e `docs/incoming/` aggiornati con lo stato post-cleanup e collegati al presente bundle; runbook e log di riapertura puntano a questa sezione per aprire eventuali nuove finestre.
+
 ## Step 2026-04-28 (rerun 02A → gate 03A → checkpoint 03B)
 - **Rerun 02A (report-only)** — log consolidato in `logs/TKT-02A-VALIDATOR.rerun.log` (sha256 `31e07dde55ebd94ab1c31ba59f36a261e09a50b8f72083ef4d50cd8c925d44bb`) e copie specchiate in `reports/temp/patch-03A-core-derived/`:
   - `schema_only.log` — sha256 `805d6a88ae39f76fc1ad9dd9a7f26cbe26a91019c63c9bdf32aba74390cb59ec`.


### PR DESCRIPTION
## Summary
- log the 2026-05-08 planning alignment for post-03B cleanup and validator baselines
- sync planning reference and incoming README files with the closed 03B freeze and new freeze requirements for future drops
- update the audit bundle with the May 8 checkpoint and pointers to the current schema-only logs

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c4ebaf73c8328b5b5a3c301aa2976)