### PR TITLE
Add Evo Tactics pipeline and derived generators

### DIFF
--- a/data/derived/analysis/README.md
+++ b/data/derived/analysis/README.md
@@ -1,0 +1,27 @@
+# Derived analysis
+
+Report derivati rigenerabili dal core e dal pack Evo Tactics.
+
+## Comando di generazione
+
+```bash
+python scripts/generate_derived_analysis.py --core-root data/core --pack-root packs/evo_tactics_pack
+```
+
+- Commit di origine (ultima rigenerazione): `8e958f913312fd75960ff08580f731f4b9c50a49`
+- Output attesi:
+  - `trait_coverage_report.json`
+  - `trait_coverage_matrix.csv`
+  - `progression/skydock_siege_xp.json`
+  - `progression/skydock_siege_xp_summary.csv`
+  - `progression/skydock_siege_xp_profiles.csv`
+
+## Checksum (sha256)
+
+| File | sha256 |
+| --- | --- |
+| `trait_coverage_report.json` | `63b05f49e9f78e5b1ac52b1d00eedf00593f36826d4029e815cb4dcc8fede856` |
+| `trait_coverage_matrix.csv` | `5e4f9ba4ee985d069ea58e0b453f33ccc1f5ed1836b80e713d91727f44c5c354` |
+| `progression/skydock_siege_xp.json` | `8f3014f01c7124dec2599e1bb3fa07375def5f95336ba269cceaba3cb035243d` |
+| `progression/skydock_siege_xp_summary.csv` | `a07044f6391a1958cd1b7042bd9a37b78c73f8934d537d1f05d0a0434f53f3d6` |
+| `progression/skydock_siege_xp_profiles.csv` | `fbf28f3e1f07430b475f47138aea4400c7f5f3184bc8569420a26c2460457d9f` |

--- a/data/derived/test-fixtures/minimal/README.md
+++ b/data/derived/test-fixtures/minimal/README.md
@@ -3,6 +3,14 @@
 Questo dataset riproduce un set ridotto di sorgenti (`packs`, `telemetry`, `biomes`, `mating`, `species`) per verificare
 l'interfaccia `docs/test-interface` senza dipendere dai dati completi di produzione.
 
+## Comando di generazione
+
+```bash
+python scripts/generate_minimal_fixture.py --root data/derived/test-fixtures/minimal
+```
+
+- Commit di origine (ultima rigenerazione): `8e958f913312fd75960ff08580f731f4b9c50a49`
+
 ## Contenuto
 
 | File | Descrizione |
@@ -27,4 +35,14 @@ l'interfaccia `docs/test-interface` senza dipendere dai dati completi di produzi
 
 - Tutti i file YAML si caricano correttamente tramite `loadAllData` senza generare eccezioni.
 - I test end-to-end (`webapp/tests/playwright/console/interface.spec.ts`) utilizzano questo dataset e devono passare in CI.
-- Eventuali modifiche al dataset devono aggiornare questa documentazione indicando l'impatto sui casi d'uso. 
+- Eventuali modifiche al dataset devono aggiornare questa documentazione indicando l'impatto sui casi d'uso.
+
+## Checksum (sha256)
+
+| File | sha256 |
+| --- | --- |
+| `data/packs.yaml` | `8d6988ee2747c54c6fc70d0c3bba2f72e1765f797d7e337baab82d3160d2e31e` |
+| `data/core/telemetry.yaml` | `ea76ac25807c13d5682027acd6f5fec857ababa7456c7e9d7addde07393f32a3` |
+| `data/core/biomes.yaml` | `432f99794e7babb942fa8b408c6335a0c894082161ee329a246415006fa18540` |
+| `data/core/mating.yaml` | `2a6fbe41ac33e07b2eb7a57d7f76ce1cc403d056225aa483b010ad4b1719cc72` |
+| `data/core/species.yaml` | `02dfa4bb190cb082b314f11d581765a9814b7fc27ffad996f77b7ae2d985e3d3` |

--- a/docs/planning/REF_TOOLING_AND_CI.md
+++ b/docs/planning/REF_TOOLING_AND_CI.md
@@ -45,7 +45,7 @@ Stato: PATCHSET-00 – completata una serie di 3 run verdi per `data-quality.yml
 
 1. Elencare i workflow CI e gli script rilevanti con input, output, dipendenze e owner.
 2. Mappare quali validatori/schema-checker usano core vs derived e verificare la presenza degli schemi aggiornati.
-3. Definire una checklist minima per la rigenerazione dei pack (comandi, prerequisiti, validazioni) da integrare in CI o documentazione.
+3. Definire una checklist minima per la rigenerazione dei pack (comandi, prerequisiti, validazioni) da integrare in CI o documentazione (ora coperta da `scripts/evo_pack_pipeline.py`).
 4. Identificare fixture `data/derived/**` critiche per i test e pianificare la loro sostituzione con versioni rigenerate dai core.
 5. Proporre aggiornamenti incrementali ai workflow CI, allineandoli con i patchset definiti nel piano di migrazione.
 

--- a/scripts/evo_pack_pipeline.py
+++ b/scripts/evo_pack_pipeline.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Pipeline di rigenerazione per Evo Tactics Pack.
+
+Esegue in sequenza:
+1) sync dati core -> pack (specie, biomi, mating, telemetry);
+2) derivazione suggerimenti trait ambientali;
+3) aggiornamento catalogo pack;
+4) build distributivo statico;
+5) validatori del pack con report HTML/JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+from pathlib import Path
+
+
+DEFAULT_CORE_ROOT = Path("data/core")
+DEFAULT_PACK_ROOT = Path("packs/evo_tactics_pack")
+
+
+class PipelineError(RuntimeError):
+    """Errore in uno step della pipeline."""
+
+
+def run_command(command: list[str], cwd: Path | None = None) -> None:
+    result = subprocess.run(command, cwd=cwd, check=False)
+    if result.returncode != 0:
+        raise PipelineError(f"Comando fallito ({result.returncode}): {' '.join(command)}")
+
+
+def copy_tree(source: Path, target: Path) -> None:
+    if target.exists():
+        shutil.rmtree(target)
+    shutil.copytree(source, target)
+
+
+def sync_core(core_root: Path, pack_root: Path) -> None:
+    mapping: dict[Path, Path] = {
+        core_root / "species.yaml": pack_root / "data" / "species.yaml",
+        core_root / "species": pack_root / "data" / "species",
+        core_root / "biomes.yaml": pack_root / "data" / "biomes.yaml",
+        core_root / "biome_aliases.yaml": pack_root / "data" / "biome_aliases.yaml",
+        core_root / "telemetry.yaml": pack_root / "data" / "telemetry.yaml",
+        core_root / "mating.yaml": pack_root / "data" / "mating.yaml",
+    }
+    for source, target in mapping.items():
+        if not source.exists():
+            raise PipelineError(f"Sorgente non trovata: {source}")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if source.is_dir():
+            copy_tree(source, target)
+        else:
+            shutil.copy2(source, target)
+        print(f"✔ Sync {source} -> {target}")
+
+
+def derive_env_traits(pack_root: Path) -> None:
+    registries_dir = pack_root / "tools" / "config" / "registries"
+    species_dir = pack_root / "data" / "species"
+    out_dir = pack_root / "out" / "env_traits"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    ecosystem_dir = pack_root / "data" / "ecosystems"
+    ecosystem_files = sorted(ecosystem_dir.glob("*.ecosystem.yaml"))
+    if not ecosystem_files:
+        raise PipelineError(f"Nessun ecosistema trovato in {ecosystem_dir}")
+
+    for ecosystem in ecosystem_files:
+        stem = ecosystem.stem.split(".")[0]
+        species_candidate = species_dir / stem
+        species_root = species_candidate if species_candidate.exists() else species_dir
+        target_dir = out_dir / stem
+        target_dir.mkdir(parents=True, exist_ok=True)
+        command = [
+            "python",
+            str(pack_root / "tools" / "py" / "derive_env_traits_v1_0.py"),
+            str(ecosystem),
+            str(species_root),
+            str(registries_dir),
+            str(target_dir),
+        ]
+        run_command(command)
+        print(f"✔ Derivati env_traits per {ecosystem.name} -> {target_dir}")
+
+
+def update_catalog(pack_root: Path) -> None:
+    run_command(["node", "scripts/update_evo_pack_catalog.js"])
+    run_command(["node", "scripts/sync_evo_pack_assets.js"])
+
+
+def build_dist(pack_root: Path) -> None:
+    run_command(["node", "scripts/build_evo_tactics_pack_dist.mjs"])
+
+
+def run_validators(pack_root: Path) -> None:
+    out_dir = pack_root / "out" / "validation"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_out = out_dir / "last_report.json"
+    html_out = out_dir / "last_report.html"
+    command = [
+        "python",
+        str(pack_root / "tools" / "py" / "run_all_validators.py"),
+        "--json-out",
+        str(json_out),
+        "--html-out",
+        str(html_out),
+    ]
+    run_command(command)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--core-root", type=Path, default=DEFAULT_CORE_ROOT)
+    parser.add_argument("--pack-root", type=Path, default=DEFAULT_PACK_ROOT)
+    parser.add_argument(
+        "--skip-build", action="store_true", help="Salta la build del distributivo"
+    )
+    parser.add_argument(
+        "--skip-validators",
+        action="store_true",
+        help="Salta l'esecuzione dei validator del pack",
+    )
+    args = parser.parse_args()
+
+    core_root = args.core_root.resolve()
+    pack_root = args.pack_root.resolve()
+
+    print(f"▶ Sync core -> pack ({core_root} → {pack_root})")
+    sync_core(core_root, pack_root)
+
+    print("▶ Derivazione env_traits")
+    derive_env_traits(pack_root)
+
+    print("▶ Aggiornamento catalogo pack")
+    update_catalog(pack_root)
+
+    if not args.skip_build:
+        print("▶ Build distributivo pack")
+        build_dist(pack_root)
+
+    if not args.skip_validators:
+        print("▶ Validator pack")
+        run_validators(pack_root)
+
+    print("✔ Pipeline completata")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_derived_analysis.py
+++ b/scripts/generate_derived_analysis.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Rigenera i report di analysis (coverage + progression).
+
+Il comando usa gli script esistenti del repository per produrre:
+- data/derived/analysis/trait_coverage_report.json
+- data/derived/analysis/trait_coverage_matrix.csv
+- data/derived/analysis/progression/* (skydock siege)
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+DEFAULT_CORE_ROOT = Path("data/core")
+DEFAULT_PACK_ROOT = Path("packs/evo_tactics_pack")
+ANALYSIS_ROOT = Path("data/derived/analysis")
+
+
+class GenerationError(RuntimeError):
+    """Errore nella generazione dei report derived."""
+
+
+def run_command(command: list[str], cwd: Path | None = None) -> None:
+    result = subprocess.run(command, cwd=cwd, check=False)
+    if result.returncode != 0:
+        raise GenerationError(f"Comando fallito ({result.returncode}): {' '.join(command)}")
+
+
+def generate_trait_coverage(pack_root: Path) -> None:
+    env_traits = pack_root / "docs" / "catalog" / "env_traits.json"
+    trait_reference = Path("data/traits/index.json")
+    species_root = pack_root / "data" / "species"
+    out_json = ANALYSIS_ROOT / "trait_coverage_report.json"
+    out_csv = ANALYSIS_ROOT / "trait_coverage_matrix.csv"
+
+    command = [
+        "python",
+        "tools/py/report_trait_coverage.py",
+        "--env-traits",
+        str(env_traits),
+        "--trait-reference",
+        str(trait_reference),
+        "--species-root",
+        str(species_root),
+        "--out-json",
+        str(out_json),
+        "--out-csv",
+        str(out_csv),
+    ]
+    run_command(command)
+
+
+def generate_progression(core_root: Path) -> None:
+    mission = core_root / "missions" / "skydock_siege.yaml"
+    out_dir = ANALYSIS_ROOT / "progression"
+    command = [
+        "python",
+        "tools/py/balance_progression.py",
+        "--mission",
+        str(mission),
+        "--out-dir",
+        str(out_dir),
+    ]
+    run_command(command)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--core-root", type=Path, default=DEFAULT_CORE_ROOT)
+    parser.add_argument("--pack-root", type=Path, default=DEFAULT_PACK_ROOT)
+    args = parser.parse_args()
+
+    core_root = args.core_root.resolve()
+    pack_root = args.pack_root.resolve()
+
+    ANALYSIS_ROOT.mkdir(parents=True, exist_ok=True)
+
+    print("▶ Generazione coverage trait")
+    generate_trait_coverage(pack_root)
+
+    print("▶ Generazione progression")
+    generate_progression(core_root)
+
+    print("✔ Report analysis aggiornati in data/derived/analysis")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_minimal_fixture.py
+++ b/scripts/generate_minimal_fixture.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Rigenera `data/derived/test-fixtures/minimal` con payload deterministici."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+FIXTURE_ROOT = Path("data/derived/test-fixtures/minimal")
+
+PACKS_PAYLOAD: dict[str, Any] = {
+    "forms": {
+        "sentinel_proto": {
+            "name": "Sentinel Proto",
+            "role": "Vanguardia di test",
+            "tags": ["demo", "starter"],
+            "summary": "Forma dimostrativa per validare la dashboard.",
+            "compatibility": {
+                "likes": ["Condivisione dati con squadre esplorative"],
+                "neutrals": ["Missioni di supporto"],
+                "dislikes": ["Operazioni clandestine prolungate"],
+                "strengths": ["Analisi rapida del territorio"],
+                "stress_triggers": ["Oscurità prolungata"],
+                "collaboration_hooks": ["Offri materiale di studio prima delle missioni"],
+                "base_scores": {"like": 3, "neutral": 2, "dislike": 1},
+            },
+            "bias_d12": {1: "Tattiche difensive", 6: "Asset di rilevamento", 12: "Riserve energetiche"},
+        }
+    },
+    "pi_shop": {
+        "costs": {"moduli_di_base": 3, "sinergie_rare": 7},
+        "caps": {"max_moduli": 2, "max_richieste": 1},
+        "budget_curve": {
+            "early": ["1 slot di supporto"],
+            "mid": ["+1 slot tattico"],
+            "late": ["Sblocco sinergia Aurora"],
+        },
+    },
+    "random_general_d20": [
+        "Rinvenuto un manufatto aurorale custodito da un sentinel.",
+        "Richiesta urgente di supporto logistico dalla base mobile.",
+    ],
+}
+
+TELEMETRY_PAYLOAD: dict[str, Any] = {
+    "indices": {
+        "focus_index": {
+            "label": "Indice di focus",
+            "value": 0.72,
+            "change": "stabile",
+            "notes": "Valore sintetico per la suite di test.",
+        },
+        "stress_index": {
+            "label": "Indice di stress",
+            "value": 0.35,
+            "change": "in calo",
+        },
+    }
+}
+
+BIOMES_PAYLOAD: dict[str, Any] = {
+    "biomes": {
+        "aurora_grove": {
+            "label": "Bosco Aurora",
+            "tier": "1",
+            "summary": "Bioma compatto per verificare le anteprime.",
+            "features": ["Foliage luminescente", "Campi magnetici stabili"],
+            "diff_base": 1,
+            "mod_biome": 0,
+            "affixes": [],
+            "hazard": {
+                "description": "TODO: definire hazard specifico per la fixture.",
+                "severity": "low",
+                "stress_modifiers": {"exposure": 0.0},
+            },
+            "npc_archetypes": {"primary": [], "support": []},
+            "stresswave": {
+                "baseline": 0.2,
+                "escalation_rate": 0.03,
+                "event_thresholds": {"support": 0.4, "overrun": 0.6},
+            },
+            "narrative": {"tone": "TBD", "hooks": ["TODO: gancio narrativo di esempio per la fixture."]},
+        }
+    },
+    "vc_adapt": {"demo": {}},
+    "mutations": {},
+    "frequencies": {},
+}
+
+MATING_PAYLOAD: dict[str, Any] = {
+    "compat_forme": {"sentinel_proto": {"compatible": ["sentinel_proto"], "incompatible": ["sentinel_shadow"]}},
+    "base_scores": {"sentinel_proto": {"empathy": 2, "strategy": 3, "creativity": 1}},
+}
+
+SPECIES_PAYLOAD: dict[str, Any] = {
+    "catalog": {
+        "slots": {
+            "sentinel_proto": {
+                "core": {
+                    "aurora_core": {
+                        "name": "Aurora Core",
+                        "effects": {"resistances": {"light": {"aurora": True}}},
+                        "summary": "Modulo base per validare il rendering del catalogo.",
+                    }
+                }
+            }
+        },
+        "synergies": [
+            {
+                "name": "Aurora Focus",
+                "modules": ["core.aurora_core"],
+                "summary": "Aumenta la precisione in ambienti luminosi.",
+            }
+        ],
+    },
+    "species": [
+        {"id": "sentinel_proto", "name": "Sentinel Proto", "summary": "Specie prototipo per gli scenari di test."},
+        {"id": "sentinel_shadow", "name": "Sentinel Shadow", "summary": "Variante antagonista per la checklist."},
+    ],
+}
+
+
+def dump_yaml(path: Path, payload: dict[str, Any]) -> None:
+    import yaml
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=True), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=FIXTURE_ROOT)
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+
+    dump_yaml(root / "data" / "packs.yaml", PACKS_PAYLOAD)
+    dump_yaml(root / "data" / "core" / "telemetry.yaml", TELEMETRY_PAYLOAD)
+    dump_yaml(root / "data" / "core" / "biomes.yaml", BIOMES_PAYLOAD)
+    dump_yaml(root / "data" / "core" / "mating.yaml", MATING_PAYLOAD)
+    dump_yaml(root / "data" / "core" / "species.yaml", SPECIES_PAYLOAD)
+
+    manifest = {
+        "generated_by": "scripts/generate_minimal_fixture.py",
+        "root": str(root),
+    }
+    (root / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    print(f"✔ Fixture minimal aggiornata in {root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add orchestrated Evo Tactics pack pipeline with core sync, catalog refresh, build, and validators
- introduce generators for derived analysis outputs and minimal test fixture with documented checksums
- update documentation to link new tooling into pack/derived and CI references

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c58545c8083288ecc45cbb0a6304c)