### PR TITLE
Add report-only derived checksum audit workflow

### DIFF
--- a/.github/workflows/derived_checksum.yml
+++ b/.github/workflows/derived_checksum.yml
@@ -1,0 +1,41 @@
+name: Derived checksum audit (report-only)
+
+on:
+  pull_request:
+    paths:
+      - 'data/derived/**'
+      - 'tools/py/check_derived_checksums.py'
+      - 'docs/planning/REF_TOOLING_AND_CI.md'
+      - 'logs/agent_activity.md'
+  push:
+    paths:
+      - 'data/derived/**'
+      - 'tools/py/check_derived_checksums.py'
+      - 'docs/planning/REF_TOOLING_AND_CI.md'
+      - 'logs/agent_activity.md'
+
+jobs:
+  derived-checksum:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements-dev.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Run derived checksum audit (report-only)
+        run: python tools/py/check_derived_checksums.py --output-dir reports/derived_checksums
+      - name: Upload checksum audit artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: derived-checksum-audit-${{ github.run_id }}
+          path: reports/derived_checksums/
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ logs/tooling/*.png
 
 # Generated analytics outputs
 reports/trait_balance/*.png
+# Derived checksum reports (CI artifacts)
+reports/derived_checksums/
 # Generated trait style reports
 reports/trait_style/
 logs/monthly_trait_maintenance/trait_style_*.json

--- a/docs/planning/REF_TOOLING_AND_CI.md
+++ b/docs/planning/REF_TOOLING_AND_CI.md
@@ -69,7 +69,18 @@ Stato: PATCHSET-00 – completata una serie di 3 run verdi per `data-quality.yml
   2. **schema-validate.yml** enforcing su variazioni schema/lint (core + config/schemas) prima dei merge.
   3. **validate-naming.yml** promosso a gate PR (pull_request attivo, continue-on-error rimosso) dopo 3 run verdi; monitorare falsi positivi sul glossary e ripristinare consultivo se necessario.
   4. **incoming-smoke.yml** resta **disattivato/solo dispatch manuale** (nessun trigger PR) fino a quando non vengono definiti i check automatici su nuovi drop e arriva un via libera esplicito.
-- Reminder check mancanti: drift `data/derived/**` vs sorgenti non ancora monitorato (proposta step opzionale in `validate_traits.yml`), gating incoming ancora limitato a uso manuale di `scripts/report_incoming.sh`.
+- Reminder check mancanti: drift `data/derived/**` vs sorgenti non ancora monitorato (ora coperto da audit checksum consultivo), gating incoming ancora limitato a uso manuale di `scripts/report_incoming.sh`.
+
+### Audit checksum derived (consultivo → enforcing)
+
+- **Workflow**: `.github/workflows/derived_checksum.yml` (job `derived-checksum`).
+- **Scope**: ricalcola i checksum sha256 dei derived principali (`data/derived/analysis/**`, `data/derived/exports/**`) e li confronta con `manifest.json`/README; output in `reports/derived_checksums/report.{md,json}` pubblicato come artifact.
+- **Modalità attuale**: consultiva (`continue-on-error: true`), trigger `pull_request`/`push` sui percorsi `data/derived/**` e documentazione collegata; non blocca i gate PR.
+- **Condizioni per renderlo bloccante**:
+  - almeno **3 run consecutivi verdi** sul branch di sperimentazione (`tooling-ci/derived-checksum` o equivalente), con mismatch gestiti/risolti;
+  - approvazione owner umano (Master DD) e log operativo aggiornato in `logs/agent_activity.md` con piano di rollback;
+  - rimozione di `continue-on-error` e (se necessario) promozione a matrix PR con check obbligatorio.
+- **Uso manuale/analisi**: l’artifact contiene per ogni file derived lo stato `match/mismatch/missing` confrontando sia il manifest sia la tabella README; può essere allegato alle discussioni PR per decidere se rigenerare gli artifact o aggiornare i reference.
 
 ### Criteri di monitoraggio e promozione
 

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -593,3 +593,8 @@
 - Step ID: DERIVED-DOC-INVENTORY-2025-11-30; branch: `main`; owner: archivist (STRICT MODE).
 - Azioni: allineati README di `data/derived/analysis`, `data/derived/exports` e `data/derived/mock` ai prerequisiti `REF_PACKS_AND_DERIVED` con comandi di rigenerazione, input canonici e checksum; creato `data/derived/mock/VERSION` e manifest `manifest-prod_snapshot.sha256` post-rsync.
 - Note: nessuna rigenerazione dei dataset core; checksum verificati con `sha256sum` sugli artifact esistenti.
+## 2026-07-01 – Derived checksum audit (report-only)
+- Branch: `main`; owner: dev-tooling (STRICT MODE).
+- Azioni: aggiunto script `tools/py/check_derived_checksums.py` che ricalcola i checksum sha256 dei derived principali (analysis/exports) confrontandoli con manifest/README e produce report markdown/json in `reports/derived_checksums/`. Creato workflow consultivo `.github/workflows/derived_checksum.yml` con artifact pubblicato e `continue-on-error: true`.
+- Condizioni di promozione a gate PR: 3 run verdi consecutivi su branch di sperimentazione, approvazione Master DD con piano di rollback in `logs/agent_activity.md`, rimozione `continue-on-error` e (se richiesto) check obbligatorio PR.
+

--- a/tools/py/check_derived_checksums.py
+++ b/tools/py/check_derived_checksums.py
@@ -1,0 +1,162 @@
+"""Report-only audit for derived dataset checksums.
+
+This script recalculates sha256 checksums for the main derived datasets and
+compares them with the latest declared values in the manifest/README files.
+
+Outputs:
+- reports/derived_checksums/report.json (machine-readable)
+- reports/derived_checksums/report.md (human-readable)
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def sha256_file(path: Path) -> Optional[str]:
+    if not path.exists() or not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(8192), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def parse_manifest(path: Path) -> Dict[str, str]:
+    if not path.exists():
+        return {}
+    data = json.loads(path.read_text())
+    return data.get("artifacts", {})
+
+
+TABLE_REGEX = re.compile(r"\|\s*`([^`]+)`\s*\|\s*`([0-9a-f]{64})`\s*\|")
+
+
+def parse_readme_table(path: Path) -> Dict[str, str]:
+    if not path.exists():
+        return {}
+    matches = TABLE_REGEX.findall(path.read_text())
+    return {file_path: checksum for file_path, checksum in matches}
+
+
+@dataclass
+class DatasetSpec:
+    name: str
+    manifest_path: Optional[Path]
+    readme_path: Optional[Path]
+    files: List[str] = field(default_factory=list)
+
+
+@dataclass
+class FileReport:
+    file: str
+    actual: Optional[str]
+    expected_manifest: Optional[str]
+    expected_readme: Optional[str]
+    status: str
+
+
+def build_dataset_report(spec: DatasetSpec) -> Dict[str, List[FileReport]]:
+    manifest_entries = parse_manifest(spec.manifest_path) if spec.manifest_path else {}
+    readme_entries = parse_readme_table(spec.readme_path) if spec.readme_path else {}
+    files = set(spec.files)
+    files.update(manifest_entries.keys())
+    files.update(readme_entries.keys())
+
+    reports: List[FileReport] = []
+    for file_path in sorted(files):
+        absolute = ROOT / file_path
+        actual = sha256_file(absolute)
+        expected_manifest = manifest_entries.get(file_path)
+        expected_readme = readme_entries.get(file_path)
+
+        if actual is None:
+            status = "missing"
+        elif (expected_manifest and actual != expected_manifest) or (
+            expected_readme and actual != expected_readme
+        ):
+            status = "mismatch"
+        else:
+            status = "match"
+
+        reports.append(
+            FileReport(
+                file=file_path,
+                actual=actual,
+                expected_manifest=expected_manifest,
+                expected_readme=expected_readme,
+                status=status,
+            )
+        )
+
+    return {spec.name: reports}
+
+
+def render_markdown(report: Dict[str, List[FileReport]]) -> str:
+    lines = ["# Derived checksum audit (report-only)"]
+    for dataset, entries in report.items():
+        lines.append(f"\n## {dataset}")
+        lines.append("| File | Actual | Manifest | README | Status |")
+        lines.append("| --- | --- | --- | --- | --- |")
+        for item in entries:
+            actual = item.actual or "(missing)"
+            exp_manifest = item.expected_manifest or "-"
+            exp_readme = item.expected_readme or "-"
+            lines.append(
+                f"| `{item.file}` | `{actual}` | `{exp_manifest}` | `{exp_readme}` | {item.status} |"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def render_json(report: Dict[str, List[FileReport]]) -> str:
+    serializable = {
+        dataset: [entry.__dict__ for entry in entries] for dataset, entries in report.items()
+    }
+    return json.dumps(serializable, indent=2)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Audit derived checksums (report-only)")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=ROOT / "reports" / "derived_checksums",
+        help="Directory for report artifacts",
+    )
+    args = parser.parse_args()
+    output_dir: Path = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    specs = [
+        DatasetSpec(
+            name="analysis",
+            manifest_path=ROOT / "data/derived/analysis/manifest.json",
+            readme_path=ROOT / "data/derived/analysis/README.md",
+        ),
+        DatasetSpec(
+            name="exports",
+            manifest_path=None,
+            readme_path=ROOT / "data/derived/exports/README.md",
+        ),
+    ]
+
+    full_report: Dict[str, List[FileReport]] = {}
+    for spec in specs:
+        full_report.update(build_dataset_report(spec))
+
+    (output_dir / "report.md").write_text(render_markdown(full_report))
+    (output_dir / "report.json").write_text(render_json(full_report))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Python audit that recalculates derived dataset checksums against manifest/README and emits markdown/json reports
- introduce a report-only GitHub Actions workflow to run the audit and publish artifacts
- document the new control and log the consultive rollout conditions

## Testing
- python tools/py/check_derived_checksums.py --output-dir reports/derived_checksums


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c797b1ba48328b5ee47af4efcddae)