### PR TITLE
Document incoming freeze window and parking instructions

### DIFF
--- a/docs/incoming/README.md
+++ b/docs/incoming/README.md
@@ -19,6 +19,8 @@ Linee guida minime:
 
 Note:
 
+- 2026-07-08: freeze documentale approvato da Master DD attivo 2026-07-08T09:00Z → 2026-07-15T18:00Z su `incoming/**` e `docs/incoming/**`; i nuovi drop vanno parcheggiati in `incoming/_holding` con log e ticket in `logs/agent_activity.md`. Attivazione registrata alle 09:15Z, disattivazione programmata alle 18:00Z salvo estensioni approvate.
+
 - 2026-05-09: esito verifica owner 01B/01C (archivist, approvatore Master DD): species-curator conferma drop sanificato `ancestors_neurons_dump_v3` per TKT-01B-001 (licenza in pending) e riceve handoff con trait-curator per matrice 01B; trait-curator on-call per alias sentience/enneagramma su TKT-01B-002; dev-tooling marca i pack parametri v1.5/v8_3 LEGACY (TKT-01C-001) e chiede refactor dei binding su event-map engine v2.3 (TKT-01C-002), segnalando a Master DD il blocco su `scan_engine_idents.py` finché non arriva l’ID map aggiornata.
 - 2026-05-02: cleanup 03B chiuso con firma Master DD; freeze documentale su `incoming/**` e `docs/incoming/**` dismesso dopo il checkpoint con smoke schema-only (14 controlli, 3 avvisi pack) e redirect confermati (`reports/temp/patch-03B-incoming-cleanup/2026-02-20/cleanup_redirect.md`). Baseline validator 02A schema-only 2026-05-01/02 registrata in `reports/audit/2026-02-20_audit_bundle.md`. Nuovi drop richiedono apertura di una nuova finestra freeze e log dedicato in `logs/agent_activity.md`.
 

--- a/docs/planning/REF_INCOMING_CATALOG.md
+++ b/docs/planning/REF_INCOMING_CATALOG.md
@@ -129,11 +129,12 @@ Le etichette di stato seguono la convenzione **INTEGRATO / DA_INTEGRARE / STORIC
 
 #### Finestra freeze (approvata Master DD)
 
-| Inizio     | Fine       | Responsabili                                    | Note operative                                                                                                                                                      |
-| ---------- | ---------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 2025-11-24 | 2025-11-27 | archivist + coordinator, approvazione Master DD | Freeze soft su `incoming/**` e `docs/incoming/**`; nuovi drop vanno parcheggiati in `incoming/_holding` con log in `logs/agent_activity.md` e nota di approvazione. |
+| Inizio     | Fine       | Responsabili                                    | Note operative                                                                                                                                                                                                                    |
+| ---------- | ---------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2025-11-24 | 2025-11-27 | archivist + coordinator, approvazione Master DD | Freeze soft su `incoming/**` e `docs/incoming/**`; nuovi drop vanno parcheggiati in `incoming/_holding` con log in `logs/agent_activity.md` e nota di approvazione.                                                               |
+| 2026-07-08 | 2026-07-15 | archivist (approvazione Master DD)              | Freeze documentale attivo 2026-07-08T09:00Z → 2026-07-15T18:00Z su `incoming/**` e `docs/incoming/**`; nuovi drop parcheggiati in `incoming/_holding` con log/ticket e riferimento al timestamp di attivazione 2026-07-08T09:15Z. |
 
-**2026-02-07 (RIAPERTURA-2026-01):** la finestra sopra risulta chiusa; nessun freeze attivo al momento. Necessaria nuova approvazione di Master DD per riattivare blocchi o aprire una finestra aggiornata.
+**Stato freeze (2026-07-08):** finestra documentale attiva con approvazione Master DD e disattivazione programmata 2026-07-15T18:00Z salvo estensioni. Ogni nuovo drop va parcheggiato in `incoming/_holding` e loggato in `logs/agent_activity.md` con ticket di riferimento.
 
 #### Gap list 01A (bozza, in attesa di approvazione Master DD)
 

--- a/incoming/README.md
+++ b/incoming/README.md
@@ -35,6 +35,8 @@ Linee guida minime:
 
 Note:
 
+- 2026-07-08: freeze documentale approvato da Master DD attivo 2026-07-08T09:00Z → 2026-07-15T18:00Z su `incoming/**` e `docs/incoming/**`; nuovi drop vanno parcheggiati in `incoming/_holding` con log e ticket in `logs/agent_activity.md`. Attivazione registrata alle 09:15Z, disattivazione programmata alle 18:00Z salvo estensioni approvate.
+
 - 2026-05-09: esito verifica owner 01B/01C (archivist, approvatore Master DD): species-curator conferma drop sanificato `ancestors_neurons_dump_v3` (TKT-01B-001) con licenza in pending e handoff a species/trait-curator per matrice 01B; trait-curator on-call su TKT-01B-002 per alias sentience/enneagramma; dev-tooling marca `evo_tactics_validator-pack_v1.5` / `_param_synergy_v8_3` LEGACY (TKT-01C-001) e richiede refactor hook su event-map engine v2.3 (TKT-01C-002), segnalando a Master DD il blocco su `scan_engine_idents.py`.
 - 2026-05-02: cleanup 03B chiuso con firma Master DD; freeze documentale su `incoming/**` e `docs/incoming/**` dismesso dopo il checkpoint con smoke schema-only (14 controlli, 3 avvisi pack) e redirect confermati (`reports/temp/patch-03B-incoming-cleanup/2026-02-20/cleanup_redirect.md`). Baseline validator 02A schema-only 2026-05-01/02 registrata in `reports/audit/2026-02-20_audit_bundle.md`. Nuovi drop richiedono apertura di una nuova finestra freeze e log dedicato in `logs/agent_activity.md`.
 

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -10,6 +10,9 @@
   - Esito dry-run rollback (core/derived) e dry-run ripristino backup/redirect prima della chiusura.
   - Riferimento alla firma finale Master DD che chiude il freeze 3→4.
 
+## 2026-07-08 – Freeze incoming 07-15 (archivist)
+- Step: `[FREEZE-INCOMING-2026-07-08] owner=archivist (approvatore Master DD); files=logs/agent_activity.md,incoming/README.md,docs/incoming/README.md,docs/planning/REF_INCOMING_CATALOG.md; scope=incoming/**,docs/incoming/**; freeze_window=2026-07-08T09:00Z→2026-07-15T18:00Z; parking=incoming/_holding; rischio=basso (documentazione/freeze); note=Freeze attivato 2026-07-08T09:15Z su richiesta Master DD; nuovi drop devono essere parcheggiati in `incoming/_holding` con log e ticket; disattivazione programmata 2026-07-15T18:00Z salvo estensioni approvate.`
+
 ## 2026-07-05 – incoming-smoke PR gate (dev-tooling)
 - Step: `[01C-CI-INCOMING-2026-07-05] owner=dev-tooling (approvatore Master DD); files=.github/workflows/incoming-smoke.yml, docs/ci.md, docs/planning/REF_TOOLING_AND_CI.md, logs/agent_activity.md; rischio=basso (attivazione progressiva CI); note=Attivato trigger pull_request filtrato sui percorsi incoming con guardrail (timeout 30m, concurrency cancel-in-progress, permessi ridotti) mantenendo `workflow_dispatch` manuale; documentati prerequisiti asset decompressi e piano di rollback a sola modalità dispatch.`
 


### PR DESCRIPTION
## Summary
- Logged the newly approved 2026-07-08 → 2026-07-15 freeze for incoming/** and docs/incoming/** with Master DD approval, scope, parking, and activation timing.
- Updated incoming and docs/incoming README notes to communicate the active freeze and direct new drops to incoming/_holding with logging requirements.
- Refreshed REF_INCOMING_CATALOG with the active freeze window and parking guidance for new drops.

## Testing
- Not run (documentation-only changes).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692caefbe874832894f3a5e144039ab0)