### PR TITLE
Document incoming freeze window

### DIFF
--- a/docs/incoming/README.md
+++ b/docs/incoming/README.md
@@ -19,6 +19,8 @@ Linee guida minime:
 
 Note:
 
+- 2025-11-30: freeze documentale attivo 2025-11-30T21:21Z → 2025-12-07T18:00Z su `incoming/**` e `docs/incoming/**`, registrato nel log `[FREEZE-INCOMING-2025-11-30]` in `logs/agent_activity.md`; parcheggio obbligatorio dei nuovi drop in `incoming/_holding` senza toccare i file esistenti. Riapertura da loggare come `[UNFREEZE-INCOMING-2025-12-07]` previa approvazione Master DD; `_holding` attualmente assente (nessun drop da integrare/archiviare).
+
 - 2026-07-08: freeze documentale approvato da Master DD attivo 2026-07-08T09:00Z → 2026-07-15T18:00Z su `incoming/**` e `docs/incoming/**`; i nuovi drop vanno parcheggiati in `incoming/_holding` con log e ticket in `logs/agent_activity.md`. Attivazione registrata alle 09:15Z, disattivazione programmata alle 18:00Z salvo estensioni approvate.
 
 - 2026-05-09: esito verifica owner 01B/01C (archivist, approvatore Master DD): species-curator conferma drop sanificato `ancestors_neurons_dump_v3` per TKT-01B-001 (licenza in pending) e riceve handoff con trait-curator per matrice 01B; trait-curator on-call per alias sentience/enneagramma su TKT-01B-002; dev-tooling marca i pack parametri v1.5/v8_3 LEGACY (TKT-01C-001) e chiede refactor dei binding su event-map engine v2.3 (TKT-01C-002), segnalando a Master DD il blocco su `scan_engine_idents.py` finché non arriva l’ID map aggiornata.

--- a/incoming/README.md
+++ b/incoming/README.md
@@ -35,6 +35,8 @@ Linee guida minime:
 
 Note:
 
+- 2025-11-30: freeze documentale attivo 2025-11-30T21:21Z → 2025-12-07T18:00Z su `incoming/**` e `docs/incoming/**`, registrato nel log `[FREEZE-INCOMING-2025-11-30]` in `logs/agent_activity.md`; parcheggio obbligatorio dei nuovi drop in `incoming/_holding` senza modificare i file esistenti. Riapertura da loggare come `[UNFREEZE-INCOMING-2025-12-07]` previa approvazione Master DD; `_holding` attualmente assente (nessun drop da integrare/archiviare).
+
 - 2026-07-08: freeze documentale approvato da Master DD attivo 2026-07-08T09:00Z → 2026-07-15T18:00Z su `incoming/**` e `docs/incoming/**`; nuovi drop vanno parcheggiati in `incoming/_holding` con log e ticket in `logs/agent_activity.md`. Attivazione registrata alle 09:15Z, disattivazione programmata alle 18:00Z salvo estensioni approvate.
 
 - 2026-05-09: esito verifica owner 01B/01C (archivist, approvatore Master DD): species-curator conferma drop sanificato `ancestors_neurons_dump_v3` (TKT-01B-001) con licenza in pending e handoff a species/trait-curator per matrice 01B; trait-curator on-call su TKT-01B-002 per alias sentience/enneagramma; dev-tooling marca `evo_tactics_validator-pack_v1.5` / `_param_synergy_v8_3` LEGACY (TKT-01C-001) e richiede refactor hook su event-map engine v2.3 (TKT-01C-002), segnalando a Master DD il blocco su `scan_engine_idents.py`.

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -10,6 +10,9 @@
   - Esito dry-run rollback (core/derived) e dry-run ripristino backup/redirect prima della chiusura.
   - Riferimento alla firma finale Master DD che chiude il freeze 3→4.
 
+## 2025-11-30 – Freeze incoming 12-07 (archivist)
+- Step: `[FREEZE-INCOMING-2025-11-30] owner=archivist (approvatore Master DD); files=logs/agent_activity.md,incoming/README.md,docs/incoming/README.md; scope=incoming/**,docs/incoming/**; freeze_window=2025-11-30T21:21Z→2025-12-07T18:00Z; parking=incoming/_holding; rischio=basso (documentazione/freeze); note=Freeze documentale attivato in STRICT MODE con parcheggio obbligatorio in `_holding` e senza spostare file; riapertura da loggare con ID `[UNFREEZE-INCOMING-2025-12-07]` previo ok Master DD; verifica `_holding`: directory assente, nessun drop da integrare/archiviare (file lasciati intatti).`
+
 ## 2026-07-08 – Freeze incoming 07-15 (archivist)
 - Step: `[FREEZE-INCOMING-2026-07-08] owner=archivist (approvatore Master DD); files=logs/agent_activity.md,incoming/README.md,docs/incoming/README.md,docs/planning/REF_INCOMING_CATALOG.md; scope=incoming/**,docs/incoming/**; freeze_window=2026-07-08T09:00Z→2026-07-15T18:00Z; parking=incoming/_holding; rischio=basso (documentazione/freeze); note=Freeze attivato 2026-07-08T09:15Z su richiesta Master DD; nuovi drop devono essere parcheggiati in `incoming/_holding` con log e ticket; disattivazione programmata 2026-07-15T18:00Z salvo estensioni approvate.`
 


### PR DESCRIPTION
## Summary
- log the new incoming/docs freeze window with parking guidance and planned unfreeze ID
- update incoming README notes with freeze status and _holding check
- mirror the freeze and parking instructions in docs/incoming README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cb4cc0934832896fb39010358e5d4)