### PR TITLE
Validate loadout recommendation inputs

### DIFF
--- a/tests/ab/loadoutRecommendation.test.ts
+++ b/tests/ab/loadoutRecommendation.test.ts
@@ -1,8 +1,15 @@
 import { describe, it } from 'node:test';
 import assert from 'assert';
-import { assignVariant, rankLoadouts, type LoadoutRecommendationRequest } from '../../src/services/loadoutRecommendation';
+import type { Request, Response } from 'express';
+import createLoadoutRecommendationRouter, {
+  assignVariant,
+  rankLoadouts,
+  type LoadoutRecommendationRequest,
+} from '../../src/services/loadoutRecommendation';
 
-const makeContext = (overrides: Partial<LoadoutRecommendationRequest> = {}): LoadoutRecommendationRequest => ({
+const makeContext = (
+  overrides: Partial<LoadoutRecommendationRequest> = {},
+): LoadoutRecommendationRequest => ({
   playerId: overrides.playerId,
   map: overrides.map ?? 'Fungal Labyrinth',
   skillRating: overrides.skillRating ?? 1700,
@@ -15,12 +22,16 @@ const makeContext = (overrides: Partial<LoadoutRecommendationRequest> = {}): Loa
 });
 
 describe('Loadout recommendation experiment', () => {
-  it('mantiene deterministico il bucket dell\'esperimento per playerId', () => {
+  it("mantiene deterministico il bucket dell'esperimento per playerId", () => {
     const playerAFirst = assignVariant('player-123', 1800);
     const playerASecond = assignVariant('player-123', 1900);
     const playerB = assignVariant('player-456', 1800);
 
-    assert.strictEqual(playerAFirst, playerASecond, 'lo stesso player deve rimanere nello stesso bucket');
+    assert.strictEqual(
+      playerAFirst,
+      playerASecond,
+      'lo stesso player deve rimanere nello stesso bucket',
+    );
     assert.ok(
       playerAFirst !== playerB,
       'due player differenti dovrebbero distribuirsi nei bucket (hash differente)',
@@ -31,15 +42,24 @@ describe('Loadout recommendation experiment', () => {
     const samples = Array.from({ length: 120 }, (_, index) =>
       makeContext({
         playerId: `player-${index}`,
-        map: index % 3 === 0 ? 'Fungal Labyrinth' : index % 3 === 1 ? 'Crimson Dunes' : 'Azure Ruins',
+        map:
+          index % 3 === 0 ? 'Fungal Labyrinth' : index % 3 === 1 ? 'Crimson Dunes' : 'Azure Ruins',
         skillRating: 1350 + (index % 10) * 70,
         sessionsPlayed: 18 + (index % 6) * 16,
         objectiveRate: 0.32 + (index % 7) * 0.08,
         avgTimeAlive: 140 + (index % 8) * 22,
         preferredPlaystyle:
-          index % 4 === 0 ? 'support' : index % 4 === 1 ? 'aggressive' : index % 4 === 2 ? 'balanced' : 'skirmisher',
-        preferredWeapon: index % 3 === 0 ? 'burst_rifle' : index % 3 === 1 ? 'ion_blade' : 'plasma_bow',
-        preferredCompanion: index % 3 === 0 ? 'medic_drone' : index % 3 === 1 ? 'scout_beetle' : 'shield_mender',
+          index % 4 === 0
+            ? 'support'
+            : index % 4 === 1
+              ? 'aggressive'
+              : index % 4 === 2
+                ? 'balanced'
+                : 'skirmisher',
+        preferredWeapon:
+          index % 3 === 0 ? 'burst_rifle' : index % 3 === 1 ? 'ion_blade' : 'plasma_bow',
+        preferredCompanion:
+          index % 3 === 0 ? 'medic_drone' : index % 3 === 1 ? 'scout_beetle' : 'shield_mender',
       }),
     );
 
@@ -76,11 +96,81 @@ describe('Loadout recommendation experiment', () => {
     const personalized = rankLoadouts(context, 'personalized', 1)[0];
     const baseline = rankLoadouts(context, 'baseline', 1)[0];
 
-    const objectiveContribution = personalized.contributions.find((item) => item.feature === 'objectiveRate');
-    assert.ok(objectiveContribution, 'la variante personalizzata deve descrivere la metrica obiettivi');
+    const objectiveContribution = personalized.contributions.find(
+      (item) => item.feature === 'objectiveRate',
+    );
+    assert.ok(
+      objectiveContribution,
+      'la variante personalizzata deve descrivere la metrica obiettivi',
+    );
     assert.strictEqual(objectiveContribution.direction, 'positive');
 
-    const baselineObjective = baseline.contributions.find((item) => item.feature === 'objectiveRate');
-    assert.ok(!baselineObjective, 'la baseline non dovrebbe personalizzare sulla metrica obiettivi');
+    const baselineObjective = baseline.contributions.find(
+      (item) => item.feature === 'objectiveRate',
+    );
+    assert.ok(
+      !baselineObjective,
+      'la baseline non dovrebbe personalizzare sulla metrica obiettivi',
+    );
+  });
+
+  describe('validazione input', () => {
+    const expectedError =
+      'Payload non valido per le raccomandazioni loadout: i campi numerici devono essere finiti e non negativi (objectiveRate compreso tra 0 e 1).';
+
+    const executeRoute = (body: unknown) => {
+      const router = createLoadoutRecommendationRouter();
+      const response: { statusCode?: number; body?: unknown } & Partial<Response> = {
+        status(code: number) {
+          this.statusCode = code;
+          return this as unknown as Response;
+        },
+        json(payload: unknown) {
+          this.body = payload;
+          return this as unknown as Response;
+        },
+      };
+
+      const [postRoute] = (router as unknown as { stack: unknown[] }).stack.filter((layer) =>
+        Boolean(
+          (layer as { route?: { path?: string } }).route?.path === '/loadout/recommendations',
+        ),
+      );
+
+      const postHandler = (
+        postRoute as { route?: { stack?: { method?: string; handle?: unknown }[] } }
+      ).route?.stack?.find((entry) => entry.method === 'post')?.handle as
+        | ((request: Request, response: Response) => void)
+        | undefined;
+
+      assert.ok(postHandler, 'il router deve esporre il POST /loadout/recommendations');
+
+      postHandler({ body } as unknown as Request, response as unknown as Response);
+
+      return response;
+    };
+
+    it('rifiuta NaN e Infinity nei campi numerici', async () => {
+      const basePayload = makeContext();
+
+      const nanResponse = executeRoute({ ...basePayload, skillRating: Number.NaN });
+      assert.strictEqual(nanResponse.statusCode, 400);
+      assert.deepStrictEqual(nanResponse.body, { error: expectedError });
+
+      const infinityResponse = executeRoute({
+        ...basePayload,
+        sessionsPlayed: Number.POSITIVE_INFINITY,
+      });
+      assert.strictEqual(infinityResponse.statusCode, 400);
+      assert.deepStrictEqual(infinityResponse.body, { error: expectedError });
+    });
+
+    it('rifiuta valori negativi per le metriche numeriche', async () => {
+      const basePayload = makeContext();
+      const invalidPayload = { ...basePayload, avgTimeAlive: -10, objectiveRate: -0.2 };
+      const response = executeRoute(invalidPayload);
+      assert.strictEqual(response.statusCode, 400);
+      assert.deepStrictEqual(response.body, { error: expectedError });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- enforce finite, non-negative numeric validation for loadout recommendation payloads with clear error messaging
- add coverage around invalid numeric inputs (NaN, Infinity, negative values) for the recommendation endpoint

## Testing
- npx tsx --test tests/ab/loadoutRecommendation.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cbf7b3b8083289d058a3b24024ddc)