### PR TITLE
Tune orchestrator pool and load testing

### DIFF
--- a/config/orchestrator.json
+++ b/config/orchestrator.json
@@ -1,7 +1,7 @@
 {
   "pythonPath": "python3",
-  "poolSize": 2,
-  "requestTimeoutMs": 120000,
+  "poolSize": 6,
+  "requestTimeoutMs": 90000,
   "heartbeatIntervalMs": 5000,
   "heartbeatTimeoutMs": 15000,
   "workerStartTimeoutMs": 30000,

--- a/reports/orchestrator_load_review.md
+++ b/reports/orchestrator_load_review.md
@@ -2,31 +2,31 @@
 
 ## Contesto e stato attuale
 - File: `config/orchestrator.json`
-- Valori attuali: `poolSize: 2`, `requestTimeoutMs: 120000` (120s), `maxTaskRetries: 1`, heartbeat 5s.
-- Assunzioni sul carico: sistema gestisce richieste sugli endpoint `/api/v1/generation/*` e `/api/v1/validators/runtime` con picchi stimati di 8–12 richieste concorrenti (valore da confermare con metriche recenti).
+- Nuovi valori applicati: `poolSize: 6`, `requestTimeoutMs: 90000` (90s), `maxTaskRetries: 1`, heartbeat 5s.
+- Assunzioni sul carico: sistema gestisce richieste sugli endpoint `/api/v1/generation/*` e `/api/v1/validators/runtime` con picchi stimati di 8–12 richieste concorrenti (valore da confermare con metriche recenti). Il pool a 6 worker è allineato a un host con risorse CPU adeguate; in ambienti più stretti si può ridurre a 4–6.
 
 ## Valutazione
-- `poolSize: 2` è adeguato solo per 2–3 richieste simultanee; con 8–12 concorrenti crea coda e latenza elevata. Suggerito allineare il pool al numero di core/worker disponibili e al target di concorrenza.
-- `requestTimeoutMs: 120000` offre ampia tolleranza, ma può mascherare hang. Per workload generativi tipici (sotto i 45–60s) un timeout più stretto riduce la durata di richieste bloccate e libera slot più rapidamente.
+- `poolSize: 2` era adeguato solo per 2–3 richieste simultanee; con 8–12 concorrenti creava coda e latenza elevata. Il nuovo valore aumenta il parallelismo mantenendo margine di sicurezza.
+- `requestTimeoutMs: 120000` offriva ampia tolleranza, ma poteva mascherare hang. Il nuovo limite a 90s resta sopra i tempi medi di inferenza (45–60s) ma libera più rapidamente gli slot bloccati.
 - `maxTaskRetries: 1` limita l’impatto di ripetizioni eccessive; mantenerlo se gli errori sono transienti rari.
 
 ## Raccomandazioni
-- Impostare `poolSize` tra **6 e 8** se il target è 8–12 richieste concorrenti e l’host dispone di risorse CPU adeguate. Ridurre a 4–6 se la CPU è limitata o se i job sono particolarmente pesanti.
-- Ridurre `requestTimeoutMs` a **60000–90000 ms** per individuare più rapidamente i job bloccati, mantenendo margine per inference pesanti. Tenere 120s solo per modelli che superano stabilmente i 90s.
+- Impostare `poolSize` tra **6 e 8** se il target è 8–12 richieste concorrenti e l’host dispone di risorse CPU adeguate. Ridurre a 4–6 se la CPU è limitata o se i job sono particolarmente pesanti (configurazione attuale: 6 worker).
+- Ridurre `requestTimeoutMs` a **60000–90000 ms** per individuare più rapidamente i job bloccati, mantenendo margine per inferenze pesanti. Tenere 120s solo per modelli che superano stabilmente i 90s (configurazione attuale: 90s).
 - Monitorare la saturazione: se la coda rimane lunga a pool aumentato, valutare scale-out (più istanze orchestrator) oltre al tuning locale.
 
 ## Piano di test di carico
 Obiettivo: validare la nuova combinazione di `poolSize` e `requestTimeoutMs` sugli endpoint critici.
 
-1. **Strumenti**: k6 o Artillery, con scenari separati per `generation` e `validators`.
+1. **Script k6**: `tests/load/orchestrator-load.k6.js` con due scenari paralleli:
+   - `generation`: ramping a 10–12 VU (`POST /api/v1/generation/species`) con payload realistico e soglia p95 < 90s, errori < 1%.
+   - `validators`: ramping a 6–8 VU (`POST /api/v1/validators/runtime`) con soglia p95 < 10s, errori < 1%.
+   - Esecuzione: `BASE_URL=http://<host>:3333 k6 run tests/load/orchestrator-load.k6.js` (timeout per request impostati a 95s/30s).
 2. **Warm-up**: 2–3 minuti a bassa intensità (1–2 VU) per stabilizzare cache e connessioni.
-3. **Scenario `/api/v1/generation/*`**:
-   - Ramp-up fino a 10–12 VU in 5 minuti.
-   - Payload misti (richieste brevi e lunghe) per simulare variazione prompt.
-   - Metriche: p95 latency < target SLO, error rate < 1%, assenza di timeout.
-4. **Scenario `/api/v1/validators/runtime`**:
-   - Ramp-up a 6–8 VU; richieste più brevi ma frequenti.
-   - Metriche: p95 latency, throughput, errori/timeout.
-5. **Stress test breve**: spike di 15–18 VU per 2 minuti per validare recupero e coda.
-6. **Raccolta dati**: esportare log di latenza/timeout, saturazione CPU/RAM, code intere per `poolSize`.
-7. **Criteri di successo**: latenza p95 entro SLO, zero timeout per validator, retry non superiore a 1%.
+3. **Stress breve**: opzionale spike di 15–18 VU per 2 minuti per validare recupero e coda.
+4. **Raccolta dati**: esportare log di latenza/timeout, saturazione CPU/RAM, code intere per `poolSize`.
+5. **Criteri di successo**: latenza p95 entro SLO, zero timeout per validator, retry non superiore a 1%.
+
+## Risultati e note
+- Esecuzione non effettuata in questo ambiente (mancano dipendenze k6 e backend attivo). Lo script è pronto per essere lanciato dove sono disponibili backend e risorse.
+- Limiti previsti: se l'host dispone di meno core, ridurre `poolSize` a 4–5 per evitare saturazione CPU; mantenere `requestTimeoutMs` a 90s salvo workload eccezionalmente lunghi.

--- a/tests/load/orchestrator-load.k6.js
+++ b/tests/load/orchestrator-load.k6.js
@@ -1,0 +1,92 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3333';
+
+const generationPayload = {
+  trait_ids: ['artigli_sette_vie', 'coda_frusta_cinetica', 'scheletro_idro_regolante'],
+  seed: 421,
+  biome_id: 'caverna_risonante',
+  base_name: 'Predatore Load',
+};
+
+const validatorPayload = {
+  kind: 'species',
+  payload: {
+    biomeId: 'caverna_risonante',
+    entries: [
+      { id: 'specimen-1', trait_ids: ['artigli_sette_vie'], seed: 7 },
+      { id: 'specimen-2', trait_ids: ['coda_frusta_cinetica'], seed: 8 },
+    ],
+  },
+};
+
+export const options = {
+  scenarios: {
+    generation: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '1m', target: 4 },
+        { duration: '2m', target: 10 },
+        { duration: '2m', target: 12 },
+        { duration: '1m', target: 0 },
+      ],
+      gracefulRampDown: '30s',
+      exec: 'runGeneration',
+    },
+    validators: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      startTime: '30s',
+      stages: [
+        { duration: '1m', target: 3 },
+        { duration: '2m', target: 6 },
+        { duration: '2m', target: 8 },
+        { duration: '1m', target: 0 },
+      ],
+      gracefulRampDown: '30s',
+      exec: 'runValidator',
+    },
+  },
+  thresholds: {
+    'http_req_duration{scenario:generation}': ['p(95)<90000'],
+    'http_req_duration{scenario:validators}': ['p(95)<10000'],
+    'http_req_failed{scenario:generation}': ['rate<0.01'],
+    'http_req_failed{scenario:validators}': ['rate<0.01'],
+  },
+};
+
+export function runGeneration() {
+  const res = http.post(
+    `${BASE_URL}/api/v1/generation/species`,
+    JSON.stringify(generationPayload),
+    {
+      headers: { 'Content-Type': 'application/json' },
+      timeout: '95s',
+      tags: { endpoint: 'generation' },
+    },
+  );
+
+  check(res, {
+    'generation status is 200': (r) => r.status === 200,
+    'generation within 90s': (r) => r.timings.duration < 90000,
+  });
+
+  sleep(1);
+}
+
+export function runValidator() {
+  const res = http.post(`${BASE_URL}/api/v1/validators/runtime`, JSON.stringify(validatorPayload), {
+    headers: { 'Content-Type': 'application/json' },
+    timeout: '30s',
+    tags: { endpoint: 'validators' },
+  });
+
+  check(res, {
+    'validator status is 200': (r) => r.status === 200,
+    'validator within 10s': (r) => r.timings.duration < 10000,
+  });
+
+  sleep(0.5);
+}


### PR DESCRIPTION
## Summary
- increase orchestrator pool size to 6 and lower request timeout to 90s to better match expected load
- add k6 load script covering generation and validator endpoints with p95/timeout thresholds
- update orchestrator load review with new settings, execution notes, and resource guidance

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cc3255a38832896068930dbb491d7)