### PR TITLE
Improve backlog setup token validation and dry-run support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,14 @@ evo-backlog:
 		echo "Errore: impostare EVO_BACKLOG_REPO=<owner/repo>."; \
 		exit 1; \
 	fi
+	@if [ -z "${BACKLOG_PAT}${GITHUB_TOKEN}" ]; then \
+		echo "Errore: impostare BACKLOG_PAT con un PAT GitHub (scope repo, workflow, project)."; \
+		exit 1; \
+	fi
+	@case "${BACKLOG_PAT:-${GITHUB_TOKEN}}" in \
+		ghp_*|github_pat_*) ;; \
+		*) echo "Errore: BACKLOG_PAT deve essere un PAT (prefisso ghp_/github_pat_)."; exit 1;; \
+	esac
 	BACKLOG_FILE="${EVO_BACKLOG_FILE}" \
 	REPO="${EVO_BACKLOG_REPO}" \
 	$(PYTHON) ${EVO_BACKLOG_SCRIPT}

--- a/docs/tooling/evo.md
+++ b/docs/tooling/evo.md
@@ -95,14 +95,18 @@ Il comando è disponibile anche tramite `make evo-lint` (variabili opzionali
 - Obiettivo: creare un project board e popolare le colonne/issue leggendo un
   file YAML.
 - Variabili richieste:
-  - `GITHUB_TOKEN`: token con permessi `repo` e `project`.
+  - `BACKLOG_PAT`: PAT GitHub con scope **`repo`**, **`workflow`** e
+    **`project`** (fallback `GITHUB_TOKEN` solo se è un PAT con prefisso
+    `ghp_`/`github_pat_`).
   - `EVO_BACKLOG_REPO`/`REPO`: repository di destinazione (`org/repo`).
   - `EVO_BACKLOG_FILE`/`BACKLOG_FILE`: percorso del backlog YAML.
 - File YAML atteso: chiavi `project_name`, `columns` e `issues` (con titolo,
   body, label opzionali e colonna di destinazione).
+- Flag utili: `--dry-run` valida token e YAML senza chiamare l'API GitHub
+  (utile per verifiche locali).
 - Target Makefile: `make evo-backlog EVO_BACKLOG_REPO=org/repo \
 EVO_BACKLOG_FILE=backlog.yaml` che reindirizza le variabili richieste allo
-  script.
+  script e fallisce immediatamente se il token non è un PAT valido.
 
 ## Revisione dei trait
 

--- a/incoming/lavoro_da_classificare/README.md
+++ b/incoming/lavoro_da_classificare/README.md
@@ -10,18 +10,22 @@ L'ambiente di lavoro containerizzato non contiene credenziali personali: i segre
 
 ## Come ottenere e configurare il token
 
-1. Crea un **Personal Access Token (classic)** su GitHub con scope **`repo`** e **`project`**.
-2. Esporta le variabili richieste prima di eseguire lo script:
+1. Crea un **Personal Access Token (classic)** su GitHub con scope **`repo`**,
+   **`workflow`** e **`project`**.
+2. Esporta le variabili richieste prima di eseguire lo script (usa sempre
+   `BACKLOG_PAT`, non il `GITHUB_TOKEN` automatico delle Actions):
    ```bash
-   export GITHUB_TOKEN=<il_tuo_token>
+   export BACKLOG_PAT=<il_tuo_token_pat>
    export REPO=<owner>/<repo>   # es. MasterDD-L34D/Game
    export BACKLOG_FILE=incoming/lavoro_da_classificare/backlog_tasks_example.yaml
-   python incoming/scripts/setup_backlog.py
+   python incoming/scripts/setup_backlog.py --dry-run   # valida input e token
+   python incoming/scripts/setup_backlog.py             # esecuzione completa
    ```
-3. Se usi `gh` CLI, puoi generare il token con `gh auth token` (assicurati di avere gli scope necessari) e assegnarlo a `GITHUB_TOKEN`.
+3. Se usi `gh` CLI, puoi generare il token con `gh auth token` (assicurati di
+   avere gli scope necessari) e assegnarlo a `BACKLOG_PAT`.
 
 ## Note operative
 
-- Il token deve poter accedere **al repository di destinazione** e ai **Projects (classic)**.
-- Lo script esegue un preflight di accesso; con token errato o senza permessi riceverai un errore 404/401.
+- Il token deve poter accedere **al repository di destinazione** e ai **Projects (classic)** e avere scope `repo`, `workflow`, `project`.
+- Lo script esegue un preflight di accesso e controllo scope; con token errato o senza permessi riceverai un errore esplicito prima di creare risorse.
 - Non salvare il token nel repository: usa variabili d'ambiente o un `.env` non tracciato.

--- a/incoming/scripts/setup_backlog.py
+++ b/incoming/scripts/setup_backlog.py
@@ -13,17 +13,18 @@ Requisiti:
 
 Prima di eseguire, impostare le seguenti variabili d'ambiente:
 
-* `GITHUB_TOKEN` – token personale con permessi repo e project.
+* `BACKLOG_PAT` – Personal Access Token (PAT) con scope `repo`, `workflow`, `project`.
 * `REPO` – nome completo del repo (es. `MasterDD-L34D/Game`).
 * `BACKLOG_FILE` – percorso a un file YAML che descrive le issue da creare.
 
 Esempio di esecuzione:
 
 ```bash
-export GITHUB_TOKEN=ghp_xxx
+export BACKLOG_PAT=ghp_xxx
 export REPO=MasterDD-L34D/Game
 export BACKLOG_FILE=backlog.yaml
-python3 scripts/setup_backlog.py
+python3 scripts/setup_backlog.py --dry-run   # valida configurazione senza chiamare GitHub
+python3 scripts/setup_backlog.py             # esecuzione completa
 ```
 
 Il file YAML deve avere il seguente formato:
@@ -49,10 +50,11 @@ issues:
 Nota: Questo script non gestisce la deduplicazione di issue esistenti.  Utilizzare con cautela.
 """
 
+import argparse
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, List, Tuple
 
 import requests
 import yaml
@@ -62,10 +64,33 @@ class BacklogConfigError(Exception):
     """Raised when local configuration is invalid."""
 
 
-def github_request(method: str, url: str, **kwargs) -> Any:
-    token = os.environ.get("GITHUB_TOKEN")
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Setup backlog GitHub")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Esegue solo la validazione locale (token e file YAML) senza chiamare l'API GitHub.",
+    )
+    return parser.parse_args()
+
+
+def get_github_token() -> str:
+    """Return a PAT ready for GitHub API usage."""
+
+    token = os.environ.get("BACKLOG_PAT") or os.environ.get("GITHUB_TOKEN")
     if not token:
-        raise BacklogConfigError("GITHUB_TOKEN non impostato: servono permessi repo+project.")
+        raise BacklogConfigError(
+            "Token GitHub non impostato: definire BACKLOG_PAT (PAT con scope repo, workflow, project)."
+        )
+    if not token.startswith(("ghp_", "github_pat_")):
+        raise BacklogConfigError(
+            "Token GitHub non riconosciuto come PAT (atteso prefisso ghp_ o github_pat_). "
+            "Usa un PAT con scope repo, workflow, project invece del GITHUB_TOKEN di Actions."
+        )
+    return token
+
+
+def github_request(method: str, url: str, token: str, **kwargs) -> Any:
     headers = kwargs.pop("headers", {})
     headers.update(
         {
@@ -80,6 +105,11 @@ def github_request(method: str, url: str, **kwargs) -> Any:
         raise RuntimeError(f"Errore di rete verso GitHub: {exc}") from exc
 
     if not response.ok:
+        if response.status_code in (401, 403):
+            raise RuntimeError(
+                "Token GitHub non valido o privo degli scope richiesti (repo, workflow, project). "
+                "Rigenera un PAT e impostalo in BACKLOG_PAT."
+            )
         if response.status_code == 404:
             raise RuntimeError(
                 "GitHub API error 404: repository o Projects non accessibili. "
@@ -91,42 +121,77 @@ def github_request(method: str, url: str, **kwargs) -> Any:
     return None
 
 
-def create_project(repo_full_name: str, project_name: str) -> int:
+def validate_token_scopes(token: str) -> None:
+    """Fail fast when the PAT misses the required scopes."""
+
+    url = "https://api.github.com/user"
+    try:
+        response = requests.get(
+            url,
+            headers={
+                "Authorization": f"token {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            timeout=15,
+        )
+    except requests.exceptions.RequestException as exc:  # pragma: no cover - network guardrail
+        raise RuntimeError(f"Errore di rete verso GitHub: {exc}") from exc
+
+    if response.status_code in (401, 403):
+        raise BacklogConfigError(
+            "Token GitHub non valido o scaduto. Rigenera un PAT con scope repo, workflow, project e impostalo in BACKLOG_PAT."
+        )
+
+    scopes_header = response.headers.get("X-OAuth-Scopes", "")
+    scopes = {scope.strip().lower() for scope in scopes_header.split(",") if scope.strip()}
+    required_scopes = {"repo", "workflow", "project"}
+    missing = required_scopes - scopes
+    if missing:
+        raise BacklogConfigError(
+            "Token GitHub privo degli scope richiesti (repo, workflow, project). "
+            f"Scope attivi: {', '.join(sorted(scopes)) or 'nessuno'}."
+        )
+
+
+def create_project(repo_full_name: str, project_name: str, token: str) -> int:
     url = f"https://api.github.com/repos/{repo_full_name}/projects"
     data = {"name": project_name}
-    project = github_request("POST", url, json=data)
+    project = github_request("POST", url, token, json=data)
     return project["id"]
 
 
-def create_column(project_id: int, name: str) -> int:
+def create_column(project_id: int, name: str, token: str) -> int:
     url = f"https://api.github.com/projects/{project_id}/columns"
     data = {"name": name}
-    column = github_request("POST", url, json=data)
+    column = github_request("POST", url, token, json=data)
     return column["id"]
 
 
-def create_issue(repo_full_name: str, title: str, body: str, labels: List[str]) -> Tuple[int, int]:
+def create_issue(repo_full_name: str, title: str, body: str, labels: List[str], token: str) -> Tuple[int, int]:
     url = f"https://api.github.com/repos/{repo_full_name}/issues"
     data = {
         "title": title,
         "body": body,
         "labels": labels,
     }
-    issue = github_request("POST", url, json=data)
+    issue = github_request("POST", url, token, json=data)
     return issue["id"], issue["number"]
 
 
-def add_issue_to_column(column_id: int, issue_id: int) -> None:
+def add_issue_to_column(column_id: int, issue_id: int, token: str) -> None:
     url = f"https://api.github.com/projects/columns/{column_id}/cards"
     data = {
         "content_id": issue_id,
         "content_type": "Issue",
     }
-    github_request("POST", url, json=data)
+    github_request("POST", url, token, json=data)
 
 
 def main() -> None:
     try:
+        args = parse_args()
+        token = get_github_token()
         repo = os.environ.get("REPO")
         backlog_file = os.environ.get("BACKLOG_FILE")
         if not repo or not backlog_file:
@@ -137,8 +202,10 @@ def main() -> None:
         if not backlog_path.is_file():
             raise BacklogConfigError(f"BACKLOG_FILE non trovato: {backlog_path}")
 
-        # Preflight: verificare che il token abbia accesso al repository e ai progetti
-        github_request("GET", f"https://api.github.com/repos/{repo}")
+        if not args.dry_run:
+            validate_token_scopes(token)
+            # Preflight: verificare che il token abbia accesso al repository e ai progetti
+            github_request("GET", f"https://api.github.com/repos/{repo}", token)
 
         with backlog_path.open("r", encoding="utf-8") as f:
             config = yaml.safe_load(f)
@@ -146,20 +213,25 @@ def main() -> None:
         if "project_name" not in config or "columns" not in config or "issues" not in config:
             raise BacklogConfigError("BACKLOG_FILE mancante di una delle chiavi richieste: project_name, columns, issues.")
 
-        project_id = create_project(repo, config["project_name"])
+        if args.dry_run:
+            print("Dry-run completato: configurazione valida, nessuna chiamata GitHub eseguita.")
+            return
+
+        validate_token_scopes(token)
+        project_id = create_project(repo, config["project_name"], token)
         # Creazione colonne
         column_ids = {}
         for col_name in config.get("columns", []):
-            col_id = create_column(project_id, col_name)
+            col_id = create_column(project_id, col_name, token)
             column_ids[col_name] = col_id
         # Creazione issue e assegnazione a colonna
         for item in config.get("issues", []):
             issue_id, _issue_number = create_issue(
-                repo, item["title"], item.get("body", ""), item.get("labels", [])
+                repo, item["title"], item.get("body", ""), item.get("labels", []), token
             )
             column_name = item.get("column") or config["columns"][0]
             col_id = column_ids[column_name]
-            add_issue_to_column(col_id, issue_id)
+            add_issue_to_column(col_id, issue_id, token)
             print(f"Creata issue '{item['title']}' in colonna {column_name}")
         print("Setup backlog completato.")
     except BacklogConfigError as cfg_error:

--- a/reports/setup_backlog_20250624_000000.log
+++ b/reports/setup_backlog_20250624_000000.log
@@ -1,0 +1,1 @@
+Dry-run completato: configurazione valida, nessuna chiamata GitHub eseguita.


### PR DESCRIPTION
## Summary
- enforce PAT usage and scope validation in setup_backlog.py, adding a dry-run mode to validate inputs without hitting GitHub
- guard the evo-backlog Make target against missing/invalid PATs and update docs to require repo/workflow/project scopes
- archive a fresh backlog setup log produced via dry-run

## Testing
- python -m py_compile incoming/scripts/setup_backlog.py
- BACKLOG_FILE=incoming/lavoro_da_classificare/backlog_tasks_example.yaml REPO=MasterDD-L34D/Game BACKLOG_PAT=github_pat_dummy_token_for_tests_1234567890 python incoming/scripts/setup_backlog.py --dry-run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cc532d7fc8328b2eadf8d5d988ca5)