### PR TITLE
Update staging redirect plan mappings

### DIFF
--- a/docs/planning/REF_REDIRECT_PLAN_STAGING.md
+++ b/docs/planning/REF_REDIRECT_PLAN_STAGING.md
@@ -21,11 +21,11 @@ Preparare un piano di redirect con mapping e rollback, predisponendo snapshot/ba
 
 ### Mapping (da compilare)
 
-| ID   | Source (staging) | Target         | Tipo redirect         | Note                         |
-| ---- | ---------------- | -------------- | --------------------- | ---------------------------- |
-| R-01 | `<path/vecchio>` | `<path/nuovo>` | 301 / 302 (scegliere) | Dipendenze note / analytics  |
-| R-02 | `<path/vecchio>` | `<path/nuovo>` | 301 / 302 (scegliere) | Testing richiesto in staging |
-| R-03 | `<path/vecchio>` | `<path/nuovo>` | 301 / 302 (scegliere) | Path legacy o alias          |
+| ID   | Source (staging)     | Target                    | Tipo redirect | Owner       | Ticket            | Note                                                                                                                                                                                                                                                              |
+| ---- | -------------------- | ------------------------- | ------------- | ----------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R-01 | `/data/species.yaml` | `/data/core/species.yaml` | 301           | dev-tooling | TKT-03B-REDIR-001 | Target presente in staging (`data/core/species.yaml`), nessun loop. Dipendenze: `config/data_path_redirects.json` + `scripts/data_layout_migration.py`. Analytics: conteggio 301 nei log di accesso staging. Config unica.                                        |
+| R-02 | `<path/vecchio>`     | `<path/nuovo>`            | 301 / 302     | archivist   | TKT-03B-REDIR-002 | Slot da completare dopo validazione; mantenere verifica staging e note analytics come per le altre righe.                                                                                                                                                         |
+| R-03 | `/data/analysis`     | `/data/derived/analysis`  | 302           | dev-tooling | TKT-03B-REDIR-003 | Target presente in staging (`data/derived/analysis/`), nessun cascade. Dipendenze: `config/data_path_redirects.json` + pipeline di ingest che referenzia `data/derived`. Analytics: monitorare hit 302 nei log staging. Config condivisa, nessuna patch multipla. |
 
 Note operative:
 


### PR DESCRIPTION
## Summary
- fill the staging redirect table with concrete R-01 and R-03 mappings, owners, and ticket references
- note dependencies, analytics monitoring, and configuration scope for each redirect

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cc89e92708328970918daf803fbae)