### PR TITLE
Add Frattura Abissale step checkpoints

### DIFF
--- a/docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step10.md
+++ b/docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step10.md
@@ -1,0 +1,28 @@
+# Esecuzione Step 10 (Strict-Mode) – Frattura Abissale Sinaptica
+
+## Titolo step
+
+Piano esecutivo finale e gating – Agente previsto: coordinator
+
+## Input attesi
+
+- Output Step 1–9 consolidati.
+- `ops/ci/pipeline.md`, `Makefile` per checklist CI/tooling.
+
+## Output attesi
+
+- Roadmap di implementazione con assegnazione agenti e milestone.
+- Gating CI: schema/lint richiesti per merge, con comandi da eseguire.
+- Piano merge sul branch dedicato con prerequisiti e owner per ogni patchset.
+
+## Blocklist e vincoli
+
+- **Slug**: non introdurre slug nuovi; usare solo referenze approvate nei passi precedenti.
+- **Biome_tags**: non modificare i tag; riportare solo quelli confermati.
+- **Trait temporanei**: non aggiungere nuovi trait; segnalare solo quelli pronti per applicazione.
+- **Affinity**: non alterare valori; elencare solo modifiche già validate.
+
+## Note operative
+
+- Nessuna modifica ai dataset; produrre piano di azione e checklist di comandi CI (schema, lint) prima del merge.
+- Allineare la roadmap con le dipendenze bloccanti emerse nel report di step 7.

--- a/docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step3.md
+++ b/docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step3.md
@@ -1,0 +1,31 @@
+# Esecuzione Step 3 (Strict-Mode) – Frattura Abissale Sinaptica
+
+## Titolo step
+
+Modellazione bioma e livelli ambientali – Agente previsto: biome-ecosystem-curator
+
+## Input attesi
+
+- `data/core/biomes.yaml` e `data/core/biome_aliases.yaml` per struttura campi e alias esistenti.
+- `config/schemas/biome.schema.yaml` per vincoli formali.
+- `biomes/terraforming_bands.yaml` per compatibilità bande/terraforming.
+- `data/core/traits/biome_pools.json` per pool ambientali correnti.
+- Output Step 2 (hook narrativi e mood dei tre livelli).
+
+## Output attesi
+
+- Scheda bioma con i tre livelli (cresta fotofase, soglia crepuscolare, frattura nera) e relative `biome_tags`/`requisiti_ambientali`.
+- Alias e bande di terraformazione allineate alle correnti elettroluminescenti.
+- Piano preliminare dei pool ambientali per livello, con note su interazioni correnti.
+
+## Blocklist e vincoli
+
+- **Slug**: non introdurre slug che collidono con biomi esistenti; evitare riuso di slug di eventi generici.
+- **Biome_tags**: vietati tag fuori schema (`config/schemas/biome.schema.yaml`); evitare combinazioni duplicate tra livelli.
+- **Trait temporanei**: non generare trait in questo step; solo note descrittive per il trait-curator.
+- **Affinity**: non dichiarare affinità specie; spostare al passo species-curator.
+
+## Note operative
+
+- Tutte le uscite sono analitiche; nessuna modifica ai file YAML/JSON.
+- Annotare dipendenze con i pool esistenti per semplificare la validazione del balancer.

--- a/docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step4.md
+++ b/docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step4.md
@@ -1,0 +1,31 @@
+# Esecuzione Step 4 (Strict-Mode) – Frattura Abissale Sinaptica
+
+## Titolo step
+
+Trait ambientali e correnti elettroluminescenti – Agente previsto: trait-curator
+
+## Input attesi
+
+- `data/core/traits/biome_pools.json` per stato attuale dei pool ambientali.
+- `data/core/traits/glossary.json` e `docs/trait_reference_manual.md` per definizioni e convenzioni.
+- `data/traits/index.json` e `data/traits/species_affinity.json` per coerenza slug/affinity.
+- `Trait Editor/docs/howto-author-trait.md` per requisiti editoriali.
+- Output Step 3 (scheda bioma e piano pool per livello).
+
+## Output attesi
+
+- Elenco trait ambientali/temporanei per ogni livello, inclusi eventuali nuovi slug proposti con descrizione sintetica.
+- Aggiornamento proposto dei pool per cresta fotofase, soglia crepuscolare e frattura nera.
+- Note su mapping glossary per correnti elettroluminescenti e interazioni con slot/trait esistenti.
+
+## Blocklist e vincoli
+
+- **Slug**: evitare duplicati con slug presenti in `data/core/traits/glossary.json` e `data/traits/index.json`.
+- **Biome_tags**: non modificare tag definiti nello step 3; solo referenziarli.
+- **Trait temporanei**: vietato riutilizzare slug segnaposto generici (es. `temp_*`); nominare in modo coerente con glossario.
+- **Affinity**: non impostare affinity specie definitive; limitarsi a suggerire compatibilità generali.
+
+## Note operative
+
+- Non applicare patch ai JSON; produrre solo proposte strutturate e verificabili.
+- Evidenziare per livello quali trait sono gating o opzionali per il balancer (step 6).

--- a/docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step5.md
+++ b/docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step5.md
@@ -1,0 +1,30 @@
+# Esecuzione Step 5 (Strict-Mode) – Frattura Abissale Sinaptica
+
+## Titolo step
+
+Specie collegate e trait_plan – Agente previsto: species-curator
+
+## Input attesi
+
+- `data/core/species.yaml` e `data/core/species/aliases.json` per struttura e alias esistenti.
+- `data/traits/species_affinity.json` per stato attuale delle affinità.
+- `docs/20-SPECIE_E_PARTI.md` per linee guida narrative e anatomiche.
+- Output Step 2 (hook narrativi per specie) e Step 3–4 (requisiti ambientali, pool e trait proposti).
+
+## Output attesi
+
+- Trait_plan proposto per Polpo Araldo Sinaptico, Sciame di Larve Neurali, Leviatano Risonante e Simbionte Corallino Riflesso.
+- Biome_affinity allineate ai tre livelli, con note su sinergie/conflitti e prerequisiti.
+- Indicazioni su trasformazioni di forma (Leviatano) e comportamenti condizionati dalle correnti.
+
+## Blocklist e vincoli
+
+- **Slug**: non creare nuovi slug specie; utilizzare denominazioni coerenti con `data/core/species.yaml` e alias esistenti.
+- **Biome_tags**: non introdurre tag non validati nello step 3; referenziare solo quelli confermati.
+- **Trait temporanei**: non assegnare trait non approvati nello step 4; marcali come `proposti` se necessari.
+- **Affinity**: evitare modifiche dirette a `species_affinity.json`; fornire solo mapping proposti per review.
+
+## Note operative
+
+- Nessuna modifica ai dataset; fornire schede per review del balancer e del coordinator.
+- Evidenziare eventuali requisiti di asset o storytelling che influenzano le future card (step 8).

--- a/docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step6.md
+++ b/docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step6.md
@@ -1,0 +1,29 @@
+# Esecuzione Step 6 (Strict-Mode) – Frattura Abissale Sinaptica
+
+## Titolo step
+
+Bilanciamento e forme dinamiche – Agente previsto: balancer
+
+## Input attesi
+
+- Output Step 3–5 (scheda bioma, pool/trait proposti, trait_plan e affinity proposte).
+- `data/core/game_functions.yaml` per curve di scaling.
+- `docs/10-SISTEMA_TATTICO.md` e `docs/11-REGOLE_D20_TV.md` per vincoli di sistema.
+
+## Output attesi
+
+- Raccomandazioni numeriche su buff/debuff delle correnti e intensità per ciascun livello.
+- Script/logiche proposte per variazione forma del Leviatano Risonante in base alla fase bioma.
+- Checklist di tuning per i trait ambientali e specie, con indicazione di valori da validare in dataset.
+
+## Blocklist e vincoli
+
+- **Slug**: non modificare slug di specie o trait; lavorare su referenze esistenti/proposte.
+- **Biome_tags**: non alterare set definiti nello step 3; evitare nuovi tag.
+- **Trait temporanei**: non aggiungere nuovi trait; usare solo quelli proposti al passo 4.
+- **Affinity**: non confermare affinity definitive; segnalare solo variazioni suggerite.
+
+## Note operative
+
+- Prodotti solo numerici/descrittivi; nessuna patch diretta ai file YAML/JSON.
+- Evidenziare rischi di stacking o overflow per la validazione successiva (step 7).

--- a/docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step7.md
+++ b/docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step7.md
@@ -1,0 +1,28 @@
+# Esecuzione Step 7 (Strict-Mode) – Frattura Abissale Sinaptica
+
+## Titolo step
+
+Validazione cross-dataset – Agente previsto: coordinator
+
+## Input attesi
+
+- Output Step 3–6 (bioma, pool/trait, specie, tuning numerico).
+- `data/core/traits/biome_pools.json`, `data/core/species.yaml`, `data/core/biomes.yaml` per confronto formale.
+
+## Output attesi
+
+- Report di coerenza tra pool ambientali e trait_plan specie con evidenza di duplicati/conflitti.
+- Lista patch proposta per dataset globali (species, pools, traits) con priorità e owner.
+- Verifica preliminare contro gli schemi (senza applicare modifiche) e note per CI.
+
+## Blocklist e vincoli
+
+- **Slug**: non introdurre nuovi slug; verificare collisioni e segnalarle nel report.
+- **Biome_tags**: non modificare i tag; segnalare solo mismatch o assenze.
+- **Trait temporanei**: non creare/alterare trait; limitarsi a segnalarne lo stato di approvazione.
+- **Affinity**: non aggiornare `species_affinity.json`; solo evidenziare cambi richiesti.
+
+## Note operative
+
+- Output in forma di checklist o tabella di conformità.
+- Allegare rischi residui e dipendenze per il piano esecutivo finale (step 10).

--- a/docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step8.md
+++ b/docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step8.md
@@ -1,0 +1,28 @@
+# Esecuzione Step 8 (Strict-Mode) – Frattura Abissale Sinaptica
+
+## Titolo step
+
+Asset e schede visual – Agente previsto: asset-prep
+
+## Input attesi
+
+- Output Step 2–6 (lore, scheda bioma, pool/trait e parametri numerici).
+- `assets/`, `docs/catalog/`, `docs/templates` per pattern di asset e schede.
+
+## Output attesi
+
+- Bozze di card/illustrazioni per i tre livelli bioma e le quattro specie con naming coerente.
+- Aggiornamenti proposti per schede in `docs/catalog/` (senza commit diretto su asset di produzione).
+- Lista asset mancanti o da convertire con priorità e formato richiesto.
+
+## Blocklist e vincoli
+
+- **Slug**: non creare nuovi slug di asset fuori naming esistente; rispettare convenzioni di `docs/catalog/`.
+- **Biome_tags**: non alterare i tag di bioma; usarli solo per etichettare le schede.
+- **Trait temporanei**: non introdurre nuovi trait visual; referenziare solo quelli approvati/proposti.
+- **Affinity**: non modificare mapping di affinità; eventuali note solo descrittive.
+
+## Note operative
+
+- Nessuna generazione asset automatica; produrre solo istruzioni e bozze descrittive.
+- Coordinare con archivist per tracciamento decisioni in step 9.

--- a/docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step9.md
+++ b/docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step9.md
@@ -1,0 +1,28 @@
+# Esecuzione Step 9 (Strict-Mode) – Frattura Abissale Sinaptica
+
+## Titolo step
+
+Documentazione e archiviazione – Agente previsto: archivist
+
+## Input attesi
+
+- Output Step 1–8 consolidati.
+- `docs/trait_reference_manual.md`, `docs/biomes.md`, `docs/README.md` per aggiornamenti documentali.
+
+## Output attesi
+
+- Appendici e aggiornamenti proposti per trait_reference_manual e biomes con riferimenti agli step precedenti.
+- Indici/specie aggiornati e note di archiviazione in `docs/reports/`.
+- Changelog sintetico delle decisioni con puntamento ai file da aggiornare.
+
+## Blocklist e vincoli
+
+- **Slug**: non introdurre slug nuovi; citare solo quelli validati o proposti negli step precedenti.
+- **Biome_tags**: non alterare i tag definiti; mantenere coerenza terminologica.
+- **Trait temporanei**: non creare nuove bozze di trait; documentare solo quelli approvati/proposti.
+- **Affinity**: non modificare valori; riportare solo mapping approvati dai curatori.
+
+## Note operative
+
+- Aggiornare i documenti in bozza o checklist senza applicare modifiche ai dataset.
+- Preparare materiale per il piano esecutivo (step 10) e per eventuale revisione CI/lint.

--- a/docs/pipelines/PIPELINE_SPECIES_BIOMES_Frattura_Abissale_Sinaptica.md
+++ b/docs/pipelines/PIPELINE_SPECIES_BIOMES_Frattura_Abissale_Sinaptica.md
@@ -51,3 +51,14 @@ Pipeline instanziata dal modello `docs/pipelines/PIPELINE_SPECIES_BIOMES_STANDAR
     - Input (file reali): output step 1-9; ops/ci/pipeline.md; Makefile
     - Output attesi: roadmap di implementazione con assegnazione agenti, checklist CI/tooling e merge finale per il pacchetto Frattura Abissale Sinaptica
     - Rischio: Basso
+
+## Avvio sequenziale step 3–10
+
+1. Step 3 → biome-ecosystem-curator (parte dagli output narrativi dello step 2 e genera scheda bioma/livelli).
+2. Step 4 → trait-curator (consuma la scheda bioma dello step 3 per modellare pool e trait temporanei/correnti).
+3. Step 5 → species-curator (usa pool e requisiti ambientali degli step 3–4 per definire trait_plan/affinity delle specie).
+4. Step 6 → balancer (riceve valori da step 3–5 per calibrare forme dinamiche e buff/debuff delle correnti).
+5. Step 7 → coordinator (valida cross-dataset incrociando output 3–6 e prepara lista patch sui dataset core).
+6. Step 8 → asset-prep (sfrutta narrativa e parametri 2–6 per card/illustrazioni e naming coerente).
+7. Step 9 → archivist (documenta e archivia decisioni usando gli output consolidati 1–8).
+8. Step 10 → coordinator (chiude con roadmap esecutiva, gating CI e piano merge basato sugli output 1–9).


### PR DESCRIPTION
## Summary
- plan sequential execution for steps 3–10 of the Frattura Abissale Sinaptica pipeline with assigned agents
- add execution checkpoint files for steps 3–10 detailing inputs, outputs, and blocklists
- include CI gating reminders for the final execution step

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ccd41c220832880ada23ef5e0fe5c)