### PR TITLE
Add remediation plan and validator rerun log stub

### DIFF
--- a/docs/planning/02A_validator_report.md
+++ b/docs/planning/02A_validator_report.md
@@ -27,3 +27,24 @@
 - Gli esiti negativi costituiscono la baseline 02A: servono correzioni su `data/core/biomes.yaml`, sinergie mancanti nei trait e allineamento i18n/stile.
 - Nessun workflow CI modificato; i risultati sono pronti per essere rieseguiti in CI in modalità consultiva.
 - Richiesto via libera di **Master DD** per procedere al gate 03A (patch applicative) dopo la revisione di questa baseline.
+
+## Remediation plan (pre-03A)
+
+- **Errori schema (biomi core)** — owner: **dev-tooling**.
+  - Fix richiesti: completare chiavi obbligatorie e normalizzare i tipi mappa in `data/core/biomes.yaml`.
+  - Branch/ticket: aggiornare `patch/03A-core-derived` con MR legato a ticket di schema-fix; acceptance: validator schema in **pass** su core/pack.
+  - Scadenza: prima del ciclo di integrazione 03A (gate schema).
+- **Sinergie mancanti (trait)** — owner: **trait-curator**.
+  - Fix richiesti: definire o rimuovere le 23 sinergie mancanti rilevate da `trait_audit`, con report aggiornato.
+  - Branch/ticket: collegare ticket a `patch/03B-incoming-cleanup` con criteri di accettazione: rerun `trait_audit --check` senza missing synergies e log aggiornato.
+  - Scadenza: pre-03A per sblocco del gate trait.
+- **Debito di style i18n (trait)** — owner: **balancer** per il coordinamento dei naming e della consistenza.
+  - Fix richiesti: ridurre errori/warning dal lint i18n (`trait_style_check`) con priorità su campi `fattore_mantenimento_energetico` e namespace mancanti.
+  - Branch/ticket: aprire ticket collegato a `patch/03B-incoming-cleanup` con acceptance: errori ridotti (0 blocker) e warning residui documentati.
+  - Scadenza: entro la finestra pre-03A per riallineare stile e localizzazione.
+
+## Piano rerun validator (report-only)
+
+- Obiettivo: rieseguire i tre validator (schema/trait/style) in modalità report-only per confermare le correzioni e sbloccare il gate 03A.
+- Comandi previsti: stessi comandi baseline con output indirizzato a `reports/02A_validator_rerun.md`.
+- Log atteso: per ciascun validator, stato `PASS` oppure elenco errori residui con timestamp; il file di log sarà archiviato in `reports/02A_validator_rerun.md` e referenziato da questo documento.

--- a/reports/02A_validator_rerun.md
+++ b/reports/02A_validator_rerun.md
@@ -1,0 +1,11 @@
+# 02A validator rerun (report-only)
+
+- **Modalità**: consultiva, nessuna modifica ai dataset.
+- **Comandi previsti**:
+  1. `python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack`
+  2. `python scripts/trait_audit.py --check`
+  3. `node scripts/trait_style_check.js --output-json /tmp/trait_style.json --fail-on error`
+- **Output atteso**:
+  - Stato `PASS` per ogni comando dopo le fix pre-03A; se emergono errori residui, elencarli con timestamp e riferimento al ticket correlato.
+  - Log archiviato qui e referenziato da `docs/planning/02A_validator_report.md`.
+- **Note**: esecuzione pianificata prima del gate 03A per convalida schema/trait/style.


### PR DESCRIPTION
## Descrizione
- Aggiunta sezione di remediation plan al report 02A con owner, branch/ticket e scadenze per gate 03A.
- Collegati i branch patch/03A-core-derived e patch/03B-incoming-cleanup alle fix richieste con criteri di accettazione.
- Creato file di log per il rerun report-only dei validator e referenziato dal documento.

## Checklist guida stile & QA
- [ ] Nessuna modifica a `data/core/**`, `data/derived/**`, `incoming/**`, `docs/incoming/**` nella finestra freeze 2025-11-25T12:05Z–2025-11-27T12:05Z (N/A: modifica documentazione planning/reports)
- [ ] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate (N/A)
- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa (N/A)
- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati (N/A)
- [ ] Eseguito `scripts/trait_style_check.js` (N/A, modifica documentazione)
- [ ] Badge "Guida stile" dell'editor in stato "In linea" (suggerimenti applicabili gestiti) (N/A)
- [ ] Generato `tools/py/styleguide_compliance_report.py` (N/A)
- [ ] Aggiornato bridge `logs/qa/latest-dashboard-metrics.json` se il report è stato rigenerato (N/A)
- [x] Documentazione/processi aggiornati ove necessario

## Testing
- [ ] `npm run style:check`
- [ ] Altro: N/A (documentazione)

## Note
- Piano di rerun in `reports/02A_validator_rerun.md` collegato al report principale.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ce322759483289239765b83ba2275)