### PR TITLE
Update redirect QA window to December 2025

### DIFF
--- a/docs/planning/REF_REDIRECT_PLAN_STAGING.md
+++ b/docs/planning/REF_REDIRECT_PLAN_STAGING.md
@@ -124,7 +124,7 @@ Note operative:
 ### Sequenza attivazione redirect (staging → go-live)
 
 1. **Pre-flight** – Verificare che l'host di staging sia raggiungibile; ripetere lo smoke test con `reports/redirects/redirect-smoke-staging.json` come output e allegare il log aggiornato a [#1204](https://github.com/MasterDD-L34D/Game/issues/1204) e [#1205](https://github.com/MasterDD-L34D/Game/issues/1205).
-2. **Check freeze QA** – Confermare che la finestra QA documentale 2025-07-08T09:00Z → 2025-07-15T18:00Z (owner archivist, approvata da Master DD e referenziata in `REF_INCOMING_CATALOG.md`) non sovrapponga la data di attivazione; in caso di blocco usare la finestra alternativa 2025-07-16T09:00Z → 2025-07-16T18:00Z e loggare l'esito nel ticket [#1204](https://github.com/MasterDD-L34D/Game/issues/1204).
+2. **Check freeze QA** – Confermare che la finestra QA documentale 2025-12-01T09:00Z → 2025-12-08T18:00Z (owner archivist, approvata da Master DD e referenziata in `REF_INCOMING_CATALOG.md`) non sovrapponga la data di attivazione; in caso di blocco usare la finestra alternativa 2025-12-09T09:00Z → 2025-12-09T18:00Z e loggare l'esito nei ticket [#1204](https://github.com/MasterDD-L34D/Game/issues/1204) e [#1205](https://github.com/MasterDD-L34D/Game/issues/1205).
 3. **Applicazione config** – Aggiornare il file di routing/redirect su staging secondo il mapping approvato (R-01, R-03 attivi; R-02 solo dopo payload completo), mantenendo backup corrente in `reports/backups/<label>/redirect-config/` come da sezione Rollback.
 4. **Verifica post-apply** – Rieseguire lo smoke test; se `PASS` per tutte le righe, pubblicare il risultato su [#1205](https://github.com/MasterDD-L34D/Game/issues/1205) e notificare Master DD per il via libera go-live.
 5. **Handoff prod** – Allineare la configurazione di produzione replicando il mapping validato; registrare timestamp e owner nel log di attivazione e aggiornare le note di ticket #1204/#1205 con gli estremi della finestra utilizzata.
@@ -133,7 +133,7 @@ Note operative:
 
 1. **Trigger** – Attivare se lo smoke test post-apply fallisce, se il monitoraggio analytics rileva loop/errore 5xx, o su richiesta QA durante il freeze.
 2. **Ripristino config** – Recuperare il manifest in `reports/backups/<label>/redirect-config/manifest.txt`, ripristinare i file di routing precedenti e confermare checksum, loggando l'owner (dev-tooling) e l'orario nel ticket #1206.
-3. **Verifica post-rollback** – Rieseguire lo smoke test puntando allo stesso host; se `PASS`, aggiornare #1204/#1205 con nota di rollback e pianificare nuova finestra (preferibilmente fuori da eventuali freeze QA o nella slot alternativa 2025-07-16T09:00Z → 2025-07-16T18:00Z).
+3. **Verifica post-rollback** – Rieseguire lo smoke test puntando allo stesso host; se `PASS`, aggiornare #1204/#1205 con nota di rollback e pianificare nuova finestra (preferibilmente fuori da eventuali freeze QA o nella slot alternativa 2025-12-09T09:00Z → 2025-12-09T18:00Z approvata da Master DD).
 4. **Chiusura** – Archiviare il report di rollback in `reports/redirects/redirect-smoke-staging.json` (nuova versione) e allegare il log a #1206; notificare Master DD per la riapertura del piano.
 
 ### Rilancio smoke test e criteri di rientro dei gate

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -11,6 +11,9 @@
   - Riferimento alla firma finale Master DD che chiude il freeze 3→4.
 - Per le finestre 03A/03B 2025-11-29→2025-12-07 usare i manifest di riferimento `reports/backups/2025-11-25_freeze/manifest.txt`, `reports/backups/2025-11-29T0525Z_freeze_03A-03B/manifest.txt` e i checkpoint Master DD (`reports/backups/2025-11-25T1500Z_freeze/manifest.txt`, `...1724Z...`, `...2028Z...`). Ogni nuova verifica o restore va registrata con il formato sintetico sopra, includendo ticket e approvazione Master DD nel campo note.
 
+## 2026-07-17 – Aggiornamento finestra QA redirect (archivist)
+- Step: `[REDIR-QA-WINDOW-2026-07-17] owner=archivist (approvatore Master DD); files=docs/planning/REF_REDIRECT_PLAN_STAGING.md,logs/agent_activity.md; rischio=basso (documentazione/QA window); note=Aggiornata la sequenza di attivazione redirect per usare la finestra QA documentale principale 2025-12-01T09:00Z→2025-12-08T18:00Z con slot alternativa 2025-12-09T09:00Z→2025-12-09T18:00Z. Allineate note di overlap e rollback alla timeline 2025 per i ticket #1204/#1205, confermando approvazione Master DD e rimozione delle date luglio 2025 per evitare riusi errati.`
+
 ## 2026-07-16 – Redirect R-02 staging completato (archivist)
 - Step: `[REDIR-R02-STAGING-2026-07-16] owner=archivist (approvatore Master DD); files=docs/planning/REF_REDIRECT_PLAN_STAGING.md, config/data_path_redirects.json, logs/agent_activity.md; rischio=basso (documentazione/redirect); note=Completata riga R-02 con source `/data/traits` → target `/data/core/traits` (301) su ticket **[TKT-03B-REDIR-002]**. Target verificato presente su staging (`data/core/traits/`), nessun loop/cascade rilevato rispetto alla config di routing. Note analytics allineate a R-01/R-03: monitorare hit 301 nei log di accesso staging; allegato al ticket per sblocco fase di attivazione.`
 


### PR DESCRIPTION
## Descrizione
- aggiornati i riferimenti alla finestra QA documentale nella sequenza di attivazione redirect con slot principale e alternativa su dicembre 2025
- sincronizzate le note di overlap/rollback con i ticket #1204/#1205 approvati da Master DD
- loggata la variazione di finestra in logs/agent_activity.md per evitare riuso delle date obsolete

## Checklist guida stile & QA
- [ ] Nessuna modifica a `data/core/**`, `data/derived/**`, `incoming/**`, `docs/incoming/**` nella finestra freeze 2025-11-25T12:05Z–2025-11-27T12:05Z (salvo rollback autorizzati Master DD)
- [ ] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate
- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa
- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati
- [ ] Eseguito `scripts/trait_style_check.js` (allega percorso report/artifact)
- [ ] Badge "Guida stile" dell'editor in stato "In linea" (suggerimenti applicabili gestiti)
- [ ] Generato `tools/py/styleguide_compliance_report.py` (link a JSON/Markdown)
- [ ] Aggiornato bridge `logs/qa/latest-dashboard-metrics.json` se il report è stato rigenerato
- [x] Documentazione/processi aggiornati ove necessario

## Testing
- [ ] `npm run style:check`
- [ ] Altro: <!-- specificare -->

## Note
- documentazione e log aggiornati; nessun test eseguito (solo modifiche testuali)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d757346e48328809ab90d43160609)