### PR TITLE
Document rollback readiness for core/derived and redirect restores

### DIFF
--- a/docs/planning/REF_BACKUP_AND_ROLLBACK.md
+++ b/docs/planning/REF_BACKUP_AND_ROLLBACK.md
@@ -27,6 +27,11 @@ Stato: operativo
 3. Applica il restore solo in sandbox/staging, seguendo le note operative collegate (es. ripristino pack o dataset) e senza committare gli artefatti.
 4. Dopo il ripristino aggiorna `Last verified` nel manifest, registra l'azione in `logs/agent_activity.md` e allega l'esito (pass/fail) nel ticket di incidente.
 
+### Readiness (post-merge e smoke)
+
+- Mantieni sempre pronti script e changelog di rollback per core/derived (vedi `reports/temp/patch-03A-core-derived/rollback.md` e `reports/temp/patch-03A-core-derived/changelog.md`) e per il ripristino dei redirect incoming (vedi `reports/temp/patch-03B-incoming-cleanup/2026-02-20/cleanup_redirect.md`).
+- Se un post-merge fallisce, applica subito lo snapshot corrispondente (core/derived + incoming/redirect) in staging, riattiva i redirect originali e riesegui i validator smoke (`python tools/py/validate_datasets.py --schemas-only ...` + redirect smoke) per confermare la stabilità prima di riaprire la finestra.
+
 ## Controlli automatici
 
 - Il pre-commit blocca nuovi binari sotto `reports/backups/**` e suggerisce di spostarli off-repo e committare solo il manifest.

--- a/reports/temp/patch-03B-incoming-cleanup/2026-02-20/cleanup_redirect.md
+++ b/reports/temp/patch-03B-incoming-cleanup/2026-02-20/cleanup_redirect.md
@@ -17,6 +17,14 @@
 - Nessun nuovo artefatto binario aggiunto; redirect pronti per l’eventuale switch post-approvazione Master DD.
 - Output smoke 02A associato a questa verifica è salvato nella stessa cartella (`schema_only.log`, `trait_audit.log`, `trait_style.log`, `trait_style.json`).
 
+## Ripristino rapido redirect (post-merge fail)
+- Backup di riferimento: `reports/backups/2025-11-25_freeze/manifest.txt` + `incoming/archive_cold/backups/2025-11-25/manifest.sha256` (percorsi e checksum già verificati).
+- Script/changelog pronti: usare questa scheda con `incoming/REDIRECTS.md` come fonte canonica per ripristinare le entry originali; i delta core/derived hanno il rollback in `reports/temp/patch-03A-core-derived/rollback.md`.
+- Procedura sintetica:
+  1. Ripristina lo snapshot incoming/redirect dal manifest sopra in staging (no commit) e riallinea `incoming/REDIRECTS.md` alla versione archiviata.
+  2. Riesegui i validator smoke: `python tools/py/validate_datasets.py --schemas-only --core-root data/core --pack-root packs/evo_tactics_pack` (per dipendenze incoming ↔ core/derived) e lo smoke redirect documentato in `reports/redirects/redirect-smoke-staging.json`.
+  3. Registra l’esito in `logs/agent_activity.md` e nel ticket collegato prima di riaprire la finestra di merge.
+
 ## Aggiornamento 2026-04-27
 - Verificati i manifest backup storici prima del cleanup: `reports/backups/2025-11-25_freeze/manifest.txt` e `incoming/archive_cold/backups/2025-11-25/manifest.sha256` (nessun drift rilevato).
 - Confermata la tabella redirect in `incoming/REDIRECTS.md` senza nuove righe o modifiche: rimane l’archiviazione in `incoming/archive_cold/**` per bundle repo, devkit e inventari storici.


### PR DESCRIPTION
## Descrizione
- Documentata la readiness post-merge: tenere pronti script/changelog di rollback per core/derived e redirect incoming, con snapshot e smoke validator da rilanciare in caso di fallimenti.
- Aggiunta una procedura sintetica di ripristino redirect (post-merge fail) con riferimenti a manifest e smoke test.

## Checklist guida stile & QA
- [x] Documentazione/processi aggiornati ove necessario
- [ ] (non applicabile) Nessuna modifica a `data/core/**`, `data/derived/**`, `incoming/**`, `docs/incoming/**` nella finestra freeze 2025-11-25T12:05Z–2025-11-27T12:05Z (salvo rollback autorizzati Master DD)
- [ ] (non eseguito) Validator di release PASS senza regressioni
- [ ] (non applicabile) Approvazione Master DD registrata
- [ ] (non applicabile) Changelog allegato alla PR e piano di rollback 03A incluso
- [ ] (non applicabile) Chiavi i18n verificate/aggiornate
- [ ] (non applicabile) Tier/slot coerenti
- [ ] (non eseguito) Eseguito `scripts/trait_style_check.js`
- [ ] (non applicabile) Badge "Guida stile" in linea
- [ ] (non eseguito) Generato `tools/py/styleguide_compliance_report.py`
- [ ] (non applicabile) Aggiornato bridge `logs/qa/latest-dashboard-metrics.json`

## Testing
- [ ] `npm run style:check`
- [ ] Altro: non eseguito (modifiche di documentazione)

## Note
- Aggiornamenti solo documentali per readiness/rollback; nessun artefatto o dati modificati.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e13383534832885fab0965be2438a)