### PR TITLE
Add objectives for canyon fotosferico sandbox

### DIFF
--- a/reports/temp/sandbox_canyon_fotosferico/biome_canyon_fotosferico.yaml
+++ b/reports/temp/sandbox_canyon_fotosferico/biome_canyon_fotosferico.yaml
@@ -1,0 +1,38 @@
+biomes:
+  canyon_fotosferico:
+    label: Canyon Fotosferico
+    summary: Gole basaltiche illuminate da colonne aurorali che erodono e riscaldano la roccia porosa.
+    diff_base: 3
+    mod_biome: 2
+    affixes:
+      - vortice_fotonico
+      - micelio_riflettente
+      - correnti_basalto_termico
+    aliases:
+      - gole_aurorali
+      - canyon_plasmoide
+    hazard:
+      description: Vortici di plasma luminoso che generano microdetriti ionizzati e cecità temporanea.
+      severity: high
+      stress_modifiers:
+        orientamento: 0.05
+        respirazione: 0.04
+    npc_archetypes:
+      primary:
+        - migratore_fotonico
+        - predatore_barocromico
+      support:
+        - custode_micelio
+        - guida_echo
+    stresswave:
+      baseline: 0.6
+      escalation_rate: 0.18
+      event_thresholds:
+        soglia_crepuscolo: 0.35
+        soglia_tempesta: 0.75
+    narrative:
+      tone: bioluminescenza austera, risonanze profonde nelle pareti di basalto.
+      hooks:
+        - Scie di luce sincronizzata rivelano percorsi nascosti tra le gole.
+        - Colonne fotosferiche attirano droni di raccolta che diventano bersagli facili.
+        - Miceli riflettenti creano illusioni ottiche che separano i branchi.

--- a/reports/temp/sandbox_canyon_fotosferico/biome_pool_canyon_fotosferico.json
+++ b/reports/temp/sandbox_canyon_fotosferico/biome_pool_canyon_fotosferico.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "updated_at": "2026-07-20T00:00:00Z",
+  "pools": [
+    {
+      "id": "canyon_fotosferico",
+      "label": "Canyon Fotosferico",
+      "summary": "Gole basaltiche attraversate da colonne di luce aurorale e flussi di plasma superficiale.",
+      "climate_tags": ["arid", "nocturnal", "auroral"],
+      "size": { "min": 3, "max": 5 },
+      "hazard": {
+        "severity": "high",
+        "description": "Vortici fotonici e microdetriti ionizzati che alterano orientamento e respirazione.",
+        "stress_modifiers": {
+          "vortice_fotonico": 0.06,
+          "detriti_ionici": 0.05
+        }
+      },
+      "ecology": {
+        "biome_type": "canyon_fotosferico",
+        "primary_resources": ["plasma_fotosferico", "basalto_poroso"],
+        "notes": "Reticoli di micelio riflettente amplificano l'aurora al livello del suolo."
+      },
+      "traits": {
+        "core": [
+          "raggi_fotosferici",
+          "membrane_barocera"
+        ],
+        "support": [
+          "alveoli_luminescenti",
+          "filamenti_superconduttivi"
+        ]
+      },
+      "role_templates": [
+        {
+          "role": "keystone",
+          "label": "Pilastro Fotonico",
+          "summary": "Stabilizza le colonne di luce e dirige le migrazioni notturne.",
+          "functional_tags": ["supporto", "navigazione"],
+          "preferred_traits": ["raggi_fotosferici", "alveoli_luminescenti"],
+          "tier": 3
+        },
+        {
+          "role": "apex",
+          "label": "Cacciatore Barocromico",
+          "summary": "Sfrutta le membrane pressorie per incanalare detriti incandescenti.",
+          "functional_tags": ["assalto", "controllo_campo"],
+          "preferred_traits": ["membrane_barocera", "raggi_fotosferici"],
+          "tier": 4
+        },
+        {
+          "role": "bridge",
+          "label": "Vettore Aurorale",
+          "summary": "Trasporta nutrienti fotonici tra sacche di micelio attive.",
+          "functional_tags": ["logistica", "energia"],
+          "preferred_traits": ["alveoli_luminescenti"],
+          "tier": 2
+        }
+      ]
+    }
+  ]
+}

--- a/reports/temp/sandbox_canyon_fotosferico/obiettivi.md
+++ b/reports/temp/sandbox_canyon_fotosferico/obiettivi.md
@@ -1,0 +1,20 @@
+# Obiettivi sandbox: canyon_fotosferico
+
+## Trait-curator
+- Slug/ID da mantenere: `raggi_fotosferici` (TR-9810), `alveoli_luminescenti` (TR-9811), `membrane_barocera` (TR-9812).
+- Sinergie chiave: TR-9810 <-> TR-9811 per cicli di ricarica e segnalazione; TR-9810 <-> TR-9812 per schermare i coni fotonici dai vortici; evitare conflitto con TR-0113 su membrane.
+- Vincoli ambientali: `biome_class: canyon_fotosferico` con requisiti di tolleranza radiazione, adattamento pressorio e metabolismo fotochimico; stress test in presenza di vortici fotonici e detriti ionici.
+- Metriche da verificare: densità luminosa e tempi di ripristino (TR-9810), capacità di accumulo e scarica (TR-9811), assorbimento impatti e rigetto calore (TR-9812).
+
+## Species-curator
+- Specie di riferimento: *Noctilumen barocromicus* (`trait_refs`: TR-9810, TR-9811, TR-9812).
+- Vincoli dichiarati: ricarica vincolata a colonne aurorali attive; degradazione membrane barocere in biomi non canyonici con vento stabile.
+- Ecotipi su cui stressare i test: `Canyon Notturno`, `Gole Ventose`; verificare allineamento con hazard `vortici_fotonici` e `detriti_ionici`.
+- Signature funzionale: trasporto fotonico con lampi accecanti e planate stabilizzate; da mantenere coerente con ruolo "keystone/bridge" nel pool.
+
+## Biome-ecosystem-curator
+- Slug bioma: `canyon_fotosferico` con alias `gole_aurorali`, `canyon_plasmoide`.
+- Hazard prioritari: vortice_fotonico, micelio_riflettente, correnti_basalto_termico; stress_modifiers su orientamento (0.05) e respirazione (0.04).
+- Risorse e note ecologiche: plasma_fotosferico, basalto_poroso, reticoli di micelio riflettente che amplificano l'aurora.
+- Role template da coprire nei test: Pilastro Fotonico (keystone, tier 3), Cacciatore Barocromico (apex, tier 4), Vettore Aurorale (bridge, tier 2).
+- Parametri di stresswave da monitorare: baseline 0.6, escalation_rate 0.18, soglie evento (crepuscolo 0.35, tempesta 0.75).

--- a/reports/temp/sandbox_canyon_fotosferico/species_canyon_fotosferico.json
+++ b/reports/temp/sandbox_canyon_fotosferico/species_canyon_fotosferico.json
@@ -1,0 +1,35 @@
+{
+  "species": {
+    "scientific_name": "Noctilumen barocromicus",
+    "common_names": ["Trasvolatore Aurorale", "Custode dei Vortici"],
+    "classification": {
+      "macro_class": "Mammalo-artropode",
+      "habitat": "foreste pluviali e canyon notturni"
+    },
+    "functional_signature": "Veicolo da trasporto fotonico che alterna lampi accecanti a planate stabilizzate da membrane pressorie.",
+    "visual_description": "Corpo allungato con placche scure, sacche luminose sul petto e membrane che si aprono tra le zampe.",
+    "risk_profile": {
+      "danger_level": 3,
+      "vectors": ["accecamento", "detriti_ionici"]
+    },
+    "interactions": {
+      "predates_on": ["coleotteri_micelio"],
+      "predated_by": ["predatore_barocromico"],
+      "symbiosis": "Si sincronizza con miceli riflettenti per amplificare i lampi di segnalazione."
+    },
+    "constraints": [
+      "Richiede colonne aurorali attive per ricarica dei sacchi luminosi.",
+      "Membrane barocere degradano in biomi non canyonici con vento stabile."
+    ],
+    "sentience_index": "T3",
+    "ecotypes": ["Canyon Notturno", "Gole Ventose"],
+    "trait_refs": ["TR-9810", "TR-9811", "TR-9812"]
+  },
+  "version": "0.1.0",
+  "versioning": {
+    "created": "2026-07-20",
+    "updated": "2026-07-20",
+    "author": "sandbox-species-curator",
+    "status": "draft"
+  }
+}

--- a/reports/temp/sandbox_canyon_fotosferico/trait_TR-9810_raggi_fotosferici.json
+++ b/reports/temp/sandbox_canyon_fotosferico/trait_TR-9810_raggi_fotosferici.json
@@ -1,0 +1,57 @@
+{
+  "trait_code": "TR-9810",
+  "id": "raggi_fotosferici",
+  "label": "Raggi Fotosferici",
+  "tier": "T3",
+  "slot": ["O"],
+  "sinergie": ["TR-9811", "TR-9812"],
+  "conflitti": ["TR-0007"],
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "canyon_fotosferico"
+      },
+      "capacita_richieste": ["tolleranza_radiazione", "navigazione_notturna"],
+      "fonte": "sandbox_canyon_fotosferico",
+      "meta": {
+        "tier": "T2",
+        "notes": "Richiede creste con emissione aurorale stabile e protezione dai vortici fotonici."
+      }
+    }
+  ],
+  "uso_funzione": "Emette coni di luce coerente per orientamento e accecamento tattico in canyon oscuri.",
+  "spinta_selettiva": "Sfruttare le sacche di plasma fotosferico per difesa e comunicazione a lungo raggio.",
+  "metrics": [
+    {
+      "name": "densita_luminosa",
+      "value": 18.5,
+      "unit": "W/kg",
+      "conditions": "picco aurorale"
+    },
+    {
+      "name": "tempo_ripristino",
+      "value": 12.0,
+      "unit": "s",
+      "conditions": "dopo impulso di piena potenza"
+    }
+  ],
+  "cost_profile": {
+    "rest": "basso",
+    "burst": "medio",
+    "sustained": "alto"
+  },
+  "testability": {
+    "observable": "Emissione di colonne fotoniche che lasciano tracce ioniche sulle pareti del canyon.",
+    "scene_prompt": "Un branco accende fari di luce ambrata a cascata durante una fuga notturna."
+  },
+  "applicability": {
+    "clades": ["chiropteroide", "anuroide"],
+    "notes": "Preferito da specie con retine filtranti e sonar passivo."
+  },
+  "version": "0.1.0",
+  "versioning": {
+    "created": "2026-07-20",
+    "updated": "2026-07-20",
+    "author": "sandbox-trait-curator"
+  }
+}

--- a/reports/temp/sandbox_canyon_fotosferico/trait_TR-9811_alveoli_luminescenti.json
+++ b/reports/temp/sandbox_canyon_fotosferico/trait_TR-9811_alveoli_luminescenti.json
@@ -1,0 +1,49 @@
+{
+  "trait_code": "TR-9811",
+  "id": "alveoli_luminescenti",
+  "label": "Alveoli Luminescenti",
+  "tier": "T2",
+  "slot": ["S"],
+  "sinergie": ["TR-9810"],
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "canyon_fotosferico"
+      },
+      "capacita_richieste": ["metabolismo_fotochimico"],
+      "fonte": "sandbox_canyon_fotosferico",
+      "meta": {
+        "tier": "T1",
+        "notes": "Richiede strati di micelio riflettente presenti solo nelle gole aurorali."
+      }
+    }
+  ],
+  "mutazione_indotta": "conversione_radiazione_termica",
+  "uso_funzione": "Accumula fotoni nelle sacche dermiche per rilasciare lampi sincroni o nutrimento lento.",
+  "spinta_selettiva": "Ridurre il fabbisogno di caccia notturna sfruttando la fotosintesi aurorale.",
+  "metrics": [
+    {
+      "name": "capacita_accumulo",
+      "value": 2.4,
+      "unit": "K/W",
+      "conditions": "gole a emissione continua"
+    },
+    {
+      "name": "rilascio_pulsato",
+      "value": 3.1,
+      "unit": "A",
+      "conditions": "scarica difensiva"
+    }
+  ],
+  "applicability": {
+    "clades": ["mammalo-artropode"],
+    "envo_terms": ["http://purl.obolibrary.org/obo/ENVO_01001042"],
+    "notes": "Funziona meglio su carapaci con microcanali di ventilazione."
+  },
+  "version": "0.1.0",
+  "versioning": {
+    "created": "2026-07-20",
+    "updated": "2026-07-20",
+    "author": "sandbox-trait-curator"
+  }
+}

--- a/reports/temp/sandbox_canyon_fotosferico/trait_TR-9812_membrane_barocera.json
+++ b/reports/temp/sandbox_canyon_fotosferico/trait_TR-9812_membrane_barocera.json
@@ -1,0 +1,48 @@
+{
+  "trait_code": "TR-9812",
+  "id": "membrane_barocera",
+  "label": "Membrane Barocera",
+  "tier": "T2",
+  "slot": ["D"],
+  "sinergie": ["TR-9810"],
+  "conflitti": ["TR-0113"],
+  "requisiti_ambientali": [
+    {
+      "condizioni": {
+        "biome_class": "canyon_fotosferico"
+      },
+      "capacita_richieste": ["adattamento_pressorio"],
+      "fonte": "sandbox_canyon_fotosferico",
+      "meta": {
+        "tier": "T2",
+        "notes": "Necessita corridoi di vento per mantenere la tensione strutturale e dissipare calore."
+      }
+    }
+  ],
+  "uso_funzione": "Membrane flessibili che si irrigidiscono con le sovrapressioni, schermando da vortici fotonici e microdetriti.",
+  "spinta_selettiva": "Proteggere organi fotosensibili e canali respiratori durante le tempeste di plasma superficiale.",
+  "metrics": [
+    {
+      "name": "assorbimento_impatti",
+      "value": 0.42,
+      "unit": "J",
+      "conditions": "microdetriti a 30 m/s"
+    },
+    {
+      "name": "tempo_rigetto_calore",
+      "value": 4.8,
+      "unit": "s",
+      "conditions": "dopo contrazione massima"
+    }
+  ],
+  "applicability": {
+    "clades": ["reptilia"],
+    "notes": "Compatibili con scheletri flessibili e dorso a camera d'aria."
+  },
+  "version": "0.1.0",
+  "versioning": {
+    "created": "2026-07-20",
+    "updated": "2026-07-20",
+    "author": "sandbox-trait-curator"
+  }
+}


### PR DESCRIPTION
## Summary
- add an objectives note for the canyon_fotosferico sandbox covering trait, species, and biome curators

## Testing
- for f in reports/temp/sandbox_canyon_fotosferico/*.json; do python -m json.tool "$f" >/dev/null && echo "validated $f"; done


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e27fe8dd88328934b3edfbf5adac8)