### PR TITLE
Add sandbox asset naming plan and draft sheets

### DIFF
--- a/assets/catalog/sandbox/metadata/draft-asset-sheets.md
+++ b/assets/catalog/sandbox/metadata/draft-asset-sheets.md
@@ -1,0 +1,67 @@
+# Schede Asset (Draft) – Sandbox Catalog
+
+Stato: draft. Annotare sostituzioni necessarie prima del rilascio.
+
+## UI – Pulsante Primario
+
+- **Percorso atteso**: `assets/catalog/sandbox/production/ui/ui-button-primary-final-v01.png`
+- **Stato**: placeholder grafico da sostituire
+- **Descrizione**: Pulsante principale per menu HUD (stato normale/hover/pressed).
+- **Dimensioni target**: 320x96 px @1x; esportare anche @2x.
+- **Palette**: blu elettrico (#4DB7FF) con bordo acciaio; testo bianco.
+- **Dipendenze grafiche**: font "Orbitron" (verificare licenza); shader bordo glow (engine VFX standard).
+- **Dipendenze audio**: richiede SFX click UI (`audio-sfx-button-metal-final-v01.ogg`).
+- **Placeholder da sostituire**: attuale asset `ui-button-primary-placeholder-v00.png` (nessuna licenza per ship); manca stato pressed.
+- **Export note**: PNG 32bit, 9-slice 12px; compressione lossless.
+- **Checklist**:
+  - [ ] Sostituire placeholder con layout definitivo e aggiornare stato pressed.
+  - [ ] Confermare licenza font o sostituire con font interno.
+  - [ ] Aggiornare nome file a `-final` e versione `v01` dopo approvazione.
+
+## VFX – Esplosione Plasma
+
+- **Percorso atteso**: `assets/catalog/sandbox/production/fx/fx-plasma-explosion-final-v01.webp`
+- **Stato**: wip con placeholder audio
+- **Descrizione**: Effetto esplosione al plasma (12 frame, 30fps) per abilità alto impatto.
+- **Dimensioni target**: atlas 512x512 px, canale alpha premoltiplicato.
+- **Palette**: turchese → magenta con bagliore bianco.
+- **Dipendenze grafiche**: shader additive + bloom (engine); richiede controllare compatibilità mobile.
+- **Dipendenze audio**: SFX placeholder `audio-sfx-plasma-explosion-placeholder-v00.wav` (da rimpiazzare con versione finale compressa in .ogg).
+- **Placeholder da sostituire**: SFX esplosione, prima parte della scia manca luce secondaria (frame 7-9).
+- **Export note**: WebP qualità 90, loop disattivato, frame sequence name `fx-plasma-explosion-final-v01_f{00..11}.png`.
+- **Checklist**:
+  - [ ] Produrre SFX finale e aggiornare dipendenza audio a `-final-v01.ogg`.
+  - [ ] Rifinire frame 7-9 con glow secondario; validare in engine a 30fps.
+  - [ ] Verificare dimensione atlas <512KB dopo compressione.
+
+## Audio – Loop Esplorazione Bioma Arido
+
+- **Percorso atteso**: `assets/catalog/sandbox/audio/audio-loop-arid-exploration-final-v01.ogg`
+- **Stato**: concept / placeholder musicale
+- **Descrizione**: Loop ambiente leggero per esplorazione bioma arido (pad granulare + percussioni leggere).
+- **Durata target**: 0:45–1:00, loop seamless.
+- **Palette sonora**: -16 LUFS target, taglio 120Hz per evitare rimbombo.
+- **Dipendenze grafiche**: nessuna.
+- **Dipendenze audio**: layer vento `audio-sfx-wind-sand-placeholder-v00.wav` (da sostituire con registrazione proprietaria), plugin riverbero "PlateSpace" (licenza in verifica).
+- **Placeholder da sostituire**: layer vento e sample percussivo stock (licenza CC BY, richiede attribuzione: valutare sostituzione interna).
+- **Export note**: OGG q6, mono, normalizzare a -1 dBTP; fornire anche stems WAV in `concept/`.
+- **Checklist**:
+  - [ ] Registrare vento proprietario e aggiornare layer a `audio-sfx-wind-sand-final-v01.ogg`.
+  - [ ] Rimpiazzare percussioni stock con libreria interna o confermare attribuzione.
+  - [ ] Verificare loop seamless e loudness integrato (-16 LUFS) prima del merge.
+
+## HUD Icon – Energia Overcharge
+
+- **Percorso atteso**: `assets/catalog/sandbox/production/icon/ui-icon-overcharge-final-v01.png`
+- **Stato**: wip grafico, placeholder assente
+- **Descrizione**: Icona HUD per stato "Overcharge" (energia elettrica, bordo dorato).
+- **Dimensioni target**: 128x128 px (fit in 96x96 safe area), versione @2x.
+- **Palette**: turchese/verde neon con bagliore arancio.
+- **Dipendenze grafiche**: font simbolico interno per glifi overlay; shader outline.
+- **Dipendenze audio**: nessuna.
+- **Placeholder da sostituire**: aggiungere alone di bloom; verificare coerenza con set iconico HUD.
+- **Export note**: PNG 32bit, background trasparente, linea 2px.
+- **Checklist**:
+  - [ ] Finalizzare glow e outline coerenti con altre icone HUD.
+  - [ ] Validare leggibilità a 64px e 48px.
+  - [ ] Aggiornare stato a `-final` e versione `v01` dopo approvazione art lead.

--- a/assets/catalog/sandbox/naming-plan.md
+++ b/assets/catalog/sandbox/naming-plan.md
@@ -1,0 +1,52 @@
+# Sandbox Naming Plan
+
+## Scopo
+
+Linee guida provvisorie per denominare e organizzare asset visivi/audio in `assets/catalog/sandbox/` prima del rilascio. Le regole coprono naming, versioning e gestione dei placeholder.
+
+## Struttura cartelle suggerita
+
+- `concept/` – schizzi, moodboard, palette.
+- `production/` – sprite, icone, VFX esportati.
+- `audio/` – SFX e loop musicali.
+- `placeholders/` – elementi temporanei da sostituire.
+- `metadata/` – schede e checklist (Markdown/JSON).
+
+## Convenzioni di naming
+
+- Usa snake-case, prefisso per categoria e suffisso di stato.
+- Formato generale: `{ambito}-{sottoambito}-{oggetto}-{stato}-v{nn}.{ext}`
+  - `ambito`: ui, unit, env, fx, audio.
+  - `sottoambito`: screen, icon, ability, biome, loop, sfx.
+  - `oggetto`: nome descrittivo breve.
+  - `stato`: concept, wip, final, placeholder.
+  - `v{nn}`: due cifre per versioning (es. v01, v02).
+- Esempi:
+  - `ui-screen-loadout-background-final-v01.png`
+  - `fx-ability-plasma-lance-final-v02.webp`
+  - `audio-sfx-button-metal-placeholder-v00.wav`
+
+## Formati file
+
+- Immagini: preferisci `.png` per UI/2D, `.webp` per VFX leggeri, `.psd/.kra` per sorgenti in `concept/` (non committare file >25MB senza accordo).
+- Audio: `.wav` per editing, `.ogg` o `.mp3` per runtime. Mantieni 44.1kHz, 16 bit mono per SFX UI.
+
+## Versioning e varianti
+
+- Incrementa `v{nn}` per modifiche rilevanti; usa suffisso `-alt{n}` per varianti cromatiche o layout.
+- Se il file è un placeholder, mantieni `-placeholder` fino alla sostituzione e registra la dipendenza nella scheda asset.
+
+## Metadati minimi da annotare
+
+- Autore o fonte (se stock/CC con link licenza).
+- Stato: concept / wip / final / placeholder.
+- Palette o temperatura colore (se rilevante per coerenza HUD/biomi).
+- Dipendenze grafiche/audio (es. shader, font, librerie SFX) e note di export (dimensioni, fps, compressione).
+
+## Checklist placeholder → asset finale
+
+- [ ] Confermare copyright e licenza (niente asset non verificati nel branch principale).
+- [ ] Allineare risoluzione ai target (UI: 1080p/1440p scaling; VFX: atlas 512/1024 px multipli di 2).
+- [ ] Verificare loop seamless per audio (no clip, normalizzare a -14 LUFS per musica, -10 dB peak per SFX UI).
+- [ ] Aggiornare naming da `-placeholder` a `-final` e incrementare versione.
+- [ ] Aggiornare scheda asset in `metadata/` con nuovo percorso e parametri export.


### PR DESCRIPTION
## Summary
- add sandbox naming plan for catalog assets with structure, naming, and placeholder handling guidance
- draft asset sheets outlining expected paths, dependencies, and placeholder replacements for key UI, VFX, audio, and icon assets

## Testing
- Not run (documentation changes only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e305afe008328b2cd542b6ad94508)