### PR TITLE
Archive Evo-Tactics playbooks and close ROL-03

### DIFF
--- a/docs/evo-tactics/guides/security-ops.md
+++ b/docs/evo-tactics/guides/security-ops.md
@@ -14,4 +14,9 @@ updated: 2025-12-02
 Questo playbook è stato archiviato e non viene più mantenuto nella sezione attiva.
 Consulta la copia storica in [`docs/archive/evo-tactics/guides/security-ops.md`](../../archive/evo-tactics/guides/security-ops.md) e, per gli snapshot di inventario, i file in `docs/incoming/archive/2025-12-19_inventory_cleanup/`.
 
+> **Stato archivio (ROL-03 chiuso)**
+> - Percorso archivio: `docs/archive/evo-tactics/guides/security-ops.md`
+> - Snapshot inventario: `docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_security_ops.md`
+> - Nota operativa: questo file resta come stub informativo; non aggiornare i flussi attivi qui.
+
 **Stato rollout:** chiusura ROL-03 (archiviazione playbook completata).

--- a/docs/evo-tactics/guides/template-ptpf.md
+++ b/docs/evo-tactics/guides/template-ptpf.md
@@ -14,4 +14,9 @@ updated: 2025-12-02
 Il template PTPF consolidato è ora conservato in [`docs/archive/evo-tactics/guides/template-ptpf.md`](../../archive/evo-tactics/guides/template-ptpf.md).
 Per gli snapshot di inventario utilizza i file `docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_template_ptpf.md`.
 
+> **Stato archivio (ROL-03 chiuso)**
+> - Percorso archivio: `docs/archive/evo-tactics/guides/template-ptpf.md`
+> - Snapshot inventario: `docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_template_ptpf.md`
+> - Nota operativa: questo file è mantenuto come stub; usa la copia in archivio per modifiche o consultazioni.
+
 **Stato rollout:** chiusura ROL-03 (archiviazione playbook completata).

--- a/docs/evo-tactics/guides/visione-struttura.md
+++ b/docs/evo-tactics/guides/visione-struttura.md
@@ -14,4 +14,9 @@ updated: 2025-12-02
 La versione consolidata della guida è ora conservata in [`docs/archive/evo-tactics/guides/visione-struttura.md`](../../archive/evo-tactics/guides/visione-struttura.md).
 Consulta anche lo snapshot di inventario `docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_visione_struttura.md`.
 
+> **Stato archivio (ROL-03 chiuso)**
+> - Percorso archivio: `docs/archive/evo-tactics/guides/visione-struttura.md`
+> - Snapshot inventario: `docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_visione_struttura.md`
+> - Nota operativa: file mantenuto come stub; fai riferimento all'archivio per le versioni operative.
+
 **Stato rollout:** chiusura ROL-03 (archiviazione playbook completata).

--- a/docs/roadmap/evo-rollout-status.md
+++ b/docs/roadmap/evo-rollout-status.md
@@ -1,6 +1,6 @@
 ---
 title: Evo-Tactics rollout status
-updated: 2025-12-02
+updated: 2025-12-21
 generated_by: tools/roadmap/update_status.py
 ---
 
@@ -10,27 +10,27 @@ generated_by: tools/roadmap/update_status.py
 
 ## Snapshot settimanale
 
-- **Data riferimento:** 2025-12-02
+- **Data riferimento:** 2025-12-21
 - **Owner aggiornamento:** Gameplay Ops · Evo rollout crew
 - **Status generale:** at-risk
 - **Ultimo report trait gap:** `data/derived/analysis/trait_gap_report.json`
 - **Copertura trait ETL:** 29/254 (11.4%)
 - **Gap trait principali:** 0 missing_in_index, 203 missing_in_external
-- **Playbook da archiviare:** 3
+- **Playbook da archiviare:** 0 (ROL-03 chiuso)
 - **Righe con mismatch trait↔legacy:** 20 su 20
 
 ## Avanzamento epiche ROL-\*
 
 | Epic   | Stato       | Progress (%) | Gap aperti                       | Campione                                                                                                                        |
 | ------ | ----------- | ------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| ROL-03 | in-progress | 99           | Playbook da archiviare: 3        | docs/evo-tactics/guides/security-ops.md, docs/evo-tactics/guides/template-ptpf.md, docs/evo-tactics/guides/visione-struttura.md |
+| ROL-03 | done        | 100          | —                                | Archivio playbook completato in `docs/archive/evo-tactics/guides/` |
 | ROL-04 | done        | 100          | Trait missing_in_index: 0        | —                                                                                                                               |
 | ROL-05 | at-risk     | 20           | Trait missing_in_external: 203   | ali_fulminee, ali_ioniche, ali_membrana_sonica, ali_solari_fotoni, antenne_dustsense                                            |
 | ROL-06 | at-risk     | 20           | Righe mismatch trait↔legacy: 20 | Anguis magnetica, Chemnotela toxica, Elastovaranus hydrus, Gulogluteus scutiger, Perfusuas pedes                                |
 
 ## Focus operativi
 
-- **Documentazione legacy da snapshot (ROL-03):** docs/evo-tactics/guides/security-ops.md, docs/evo-tactics/guides/template-ptpf.md, docs/evo-tactics/guides/visione-struttura.md
+- **Documentazione legacy da snapshot (ROL-03):** chiusa; usare le copie in `docs/archive/evo-tactics/guides/` e gli snapshot in `docs/incoming/archive/2025-12-19_inventory_cleanup/`.
 - **Trait da indicizzare (ROL-04):** —
 - **Trait da fornire ai consumer esterni (ROL-05):** ali_fulminee, ali_ioniche, ali_membrana_sonica, ali_solari_fotoni, antenne_dustsense
 - **Specie/ecotipi con mismatch (ROL-06):** Anguis magnetica, Chemnotela toxica, Elastovaranus hydrus, Gulogluteus scutiger, Perfusuas pedes


### PR DESCRIPTION
## Summary
- add explicit archive status blocks to the three Evo-Tactics playbook stubs with archive and inventory references
- update the rollout tracker to reflect ROL-03 closure and zero remaining playbooks to archive

## Testing
- npx prettier --write docs/evo-tactics/guides/security-ops.md docs/evo-tactics/guides/template-ptpf.md docs/evo-tactics/guides/visione-struttura.md docs/roadmap/evo-rollout-status.md


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f083145848328965f664b42259995)