### PR TITLE
Add external inventory entries for wing and antenna traits

### DIFF
--- a/data/external/evo/traits/TR-2006.json
+++ b/data/external/evo/traits/TR-2006.json
@@ -1,0 +1,46 @@
+{
+  "trait_code": "TR-2006",
+  "id": "ali_fulminee",
+  "label": "Ali Fulminee",
+  "famiglia_tipologia": "Sensoriale/Analitico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
+  "tier": "T1",
+  "slot": [],
+  "sinergie": [
+    "focus_frazionato",
+    "sinapsi_coraline_polifoniche"
+  ],
+  "conflitti": [],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": {
+        "biome_class": "stratosfera_tempestosa"
+      },
+      "fonte": "env_to_traits",
+      "meta": {
+        "expansion": "coverage_q4_2025",
+        "notes": "Ali Fulminee ottimizza le operazioni sensoriale nelle condizioni di stratosfera tempestosa.",
+        "tier": "T1"
+      }
+    }
+  ],
+  "mutazione_indotta": "Ali laminari elettrificate che leggono pattern ionici.",
+  "uso_funzione": "Decodificare micro-scariche e correnti psioniche turbolente.",
+  "spinta_selettiva": "Sopravvivenza e coordinamento in stratosfere cariche.",
+  "cost_profile": {
+    "rest": "Basso",
+    "burst": "Basso",
+    "sustained": "Basso"
+  },
+  "applicability": {
+    "clades": [],
+    "envo_terms": []
+  },
+  "version": "2.0.1",
+  "versioning": {
+    "created": "2026-08-22",
+    "updated": "2026-08-22",
+    "author": "Master DD / GPT-5 Pro"
+  }
+}

--- a/data/external/evo/traits/TR-2007.json
+++ b/data/external/evo/traits/TR-2007.json
@@ -1,0 +1,46 @@
+{
+  "trait_code": "TR-2007",
+  "id": "ali_ioniche",
+  "label": "Ali Ioniche",
+  "famiglia_tipologia": "Locomotorio/Mobilità",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
+  "tier": "T1",
+  "slot": [],
+  "sinergie": [
+    "coda_frusta_cinetica",
+    "zampe_a_molla"
+  ],
+  "conflitti": [],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": {
+        "biome_class": "canopia_ionica"
+      },
+      "fonte": "env_to_traits",
+      "meta": {
+        "expansion": "coverage_q4_2025",
+        "notes": "Ali Ioniche ottimizza le operazioni locomotorio nelle condizioni di canopia ionica.",
+        "tier": "T1"
+      }
+    }
+  ],
+  "mutazione_indotta": "Membrane propulsive che rilasciano micro-scariche direzionali.",
+  "uso_funzione": "Imprimere scatti controllati e stabilità in canopie ioniche.",
+  "spinta_selettiva": "Mobilità rapida in correnti elettrostatiche instabili.",
+  "cost_profile": {
+    "rest": "Basso",
+    "burst": "Medio",
+    "sustained": "Basso"
+  },
+  "applicability": {
+    "clades": [],
+    "envo_terms": []
+  },
+  "version": "2.0.1",
+  "versioning": {
+    "created": "2026-08-22",
+    "updated": "2026-08-22",
+    "author": "Master DD / GPT-5 Pro"
+  }
+}

--- a/data/external/evo/traits/TR-2008.json
+++ b/data/external/evo/traits/TR-2008.json
@@ -1,0 +1,46 @@
+{
+  "trait_code": "TR-2008",
+  "id": "ali_membrana_sonica",
+  "label": "Ali Membrana Sonica",
+  "famiglia_tipologia": "Tegumentario/Difensivo",
+  "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+  "tier": "T1",
+  "slot": [],
+  "sinergie": [
+    "carapace_fase_variabile",
+    "mimetismo_cromatico_passivo"
+  ],
+  "conflitti": [],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": {
+        "biome_class": "caverna_risonante"
+      },
+      "fonte": "env_to_traits",
+      "meta": {
+        "expansion": "coverage_q4_2025",
+        "notes": "Ali Membrana Sonica ottimizza le operazioni difensivo nelle condizioni di caverna risonante.",
+        "tier": "T1"
+      }
+    }
+  ],
+  "mutazione_indotta": "Piastre vibranti che disperdono onde e impatti corrosivi.",
+  "uso_funzione": "Smorzare vibrazioni e deviare attacchi acustici sotterranei.",
+  "spinta_selettiva": "Difesa attiva in cavità risonanti e ambienti corrosivi.",
+  "cost_profile": {
+    "rest": "Basso",
+    "burst": "Basso",
+    "sustained": "Basso"
+  },
+  "applicability": {
+    "clades": [],
+    "envo_terms": []
+  },
+  "version": "2.0.1",
+  "versioning": {
+    "created": "2026-08-22",
+    "updated": "2026-08-22",
+    "author": "Master DD / GPT-5 Pro"
+  }
+}

--- a/data/external/evo/traits/TR-2009.json
+++ b/data/external/evo/traits/TR-2009.json
@@ -1,0 +1,49 @@
+{
+  "trait_code": "TR-2009",
+  "id": "ali_solari_fotoni",
+  "label": "Ali Solari Fotoni",
+  "famiglia_tipologia": "Locomotivo/Aereo",
+  "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+  "tier": "T2",
+  "slot": [
+    "A",
+    "C"
+  ],
+  "sinergie": [
+    "cervello_a_bassa_latenza",
+    "occhi_cristallo_modulare",
+    "antenne_tesla"
+  ],
+  "conflitti": [],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": {
+        "biome_class": "terrestre"
+      },
+      "fonte": "envo_mapping",
+      "meta": {
+        "notes": "Richiede esposizione solare costante per massimizzare spinta e schermature.",
+        "tier": "T2"
+      }
+    }
+  ],
+  "mutazione_indotta": "Piume fotovoltaiche con rete di accumulo radiante.",
+  "uso_funzione": "Convertire luce in spinta e in schermature riflettenti.",
+  "spinta_selettiva": "Volo prolungato e protezione in ambienti ad alta radianza.",
+  "cost_profile": {
+    "rest": "Medio",
+    "burst": "Medio",
+    "sustained": "Medio"
+  },
+  "applicability": {
+    "clades": [],
+    "envo_terms": []
+  },
+  "version": "2.0.1",
+  "versioning": {
+    "created": "2026-08-22",
+    "updated": "2026-08-22",
+    "author": "Master DD / GPT-5 Pro"
+  }
+}

--- a/data/external/evo/traits/TR-2010.json
+++ b/data/external/evo/traits/TR-2010.json
@@ -1,0 +1,46 @@
+{
+  "trait_code": "TR-2010",
+  "id": "antenne_dustsense",
+  "label": "Antenne Dustsense",
+  "famiglia_tipologia": "Digestivo/Metabolico",
+  "fattore_mantenimento_energetico": "Basso (Passivo)",
+  "tier": "T1",
+  "slot": [],
+  "sinergie": [
+    "filamenti_digestivi_compattanti",
+    "ventriglio_gastroliti"
+  ],
+  "conflitti": [],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": {
+        "biome_class": "pianura_salina_iperarida"
+      },
+      "fonte": "env_to_traits",
+      "meta": {
+        "expansion": "coverage_q4_2025",
+        "notes": "Antenne Dustsense ottimizza le operazioni metabolico nelle condizioni di pianura salina iperarida.",
+        "tier": "T1"
+      }
+    }
+  ],
+  "mutazione_indotta": "Ricettori stratificati che filtrano polveri ioniche.",
+  "uso_funzione": "Stabilizzare assorbimento multi-fonte in deserti ionici.",
+  "spinta_selettiva": "Nutrizione efficiente in pianure saline iperaride.",
+  "cost_profile": {
+    "rest": "Basso",
+    "burst": "Basso",
+    "sustained": "Basso"
+  },
+  "applicability": {
+    "clades": [],
+    "envo_terms": []
+  },
+  "version": "2.0.1",
+  "versioning": {
+    "created": "2026-08-22",
+    "updated": "2026-08-22",
+    "author": "Master DD / GPT-5 Pro"
+  }
+}

--- a/data/external/evo/traits/traits_aggregate.json
+++ b/data/external/evo/traits/traits_aggregate.json
@@ -2865,6 +2865,239 @@
         "updated": "2025-11-04",
         "author": "Master DD / GPT-5 Pro"
       }
+    },
+    {
+      "trait_code": "TR-2006",
+      "id": "ali_fulminee",
+      "label": "Ali Fulminee",
+      "famiglia_tipologia": "Sensoriale/Analitico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "sinergie": [
+        "focus_frazionato",
+        "sinapsi_coraline_polifoniche"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "stratosfera_tempestosa"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ali Fulminee ottimizza le operazioni sensoriale nelle condizioni di stratosfera tempestosa.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "Ali laminari elettrificate che leggono pattern ionici.",
+      "uso_funzione": "Decodificare micro-scariche e correnti psioniche turbolente.",
+      "spinta_selettiva": "Sopravvivenza e coordinamento in stratosfere cariche.",
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Basso",
+        "sustained": "Basso"
+      },
+      "applicability": {
+        "clades": [],
+        "envo_terms": []
+      },
+      "version": "2.0.1",
+      "versioning": {
+        "created": "2026-08-22",
+        "updated": "2026-08-22",
+        "author": "Master DD / GPT-5 Pro"
+      }
+    },
+    {
+      "trait_code": "TR-2007",
+      "id": "ali_ioniche",
+      "label": "Ali Ioniche",
+      "famiglia_tipologia": "Locomotorio/Mobilità",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "sinergie": [
+        "coda_frusta_cinetica",
+        "zampe_a_molla"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "canopia_ionica"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ali Ioniche ottimizza le operazioni locomotorio nelle condizioni di canopia ionica.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "Membrane propulsive che rilasciano micro-scariche direzionali.",
+      "uso_funzione": "Imprimere scatti controllati e stabilità in canopie ioniche.",
+      "spinta_selettiva": "Mobilità rapida in correnti elettrostatiche instabili.",
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Medio",
+        "sustained": "Basso"
+      },
+      "applicability": {
+        "clades": [],
+        "envo_terms": []
+      },
+      "version": "2.0.1",
+      "versioning": {
+        "created": "2026-08-22",
+        "updated": "2026-08-22",
+        "author": "Master DD / GPT-5 Pro"
+      }
+    },
+    {
+      "trait_code": "TR-2008",
+      "id": "ali_membrana_sonica",
+      "label": "Ali Membrana Sonica",
+      "famiglia_tipologia": "Tegumentario/Difensivo",
+      "fattore_mantenimento_energetico": "Basso (mantenimento passivo o trascurabile)",
+      "tier": "T1",
+      "slot": [],
+      "sinergie": [
+        "carapace_fase_variabile",
+        "mimetismo_cromatico_passivo"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "caverna_risonante"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Ali Membrana Sonica ottimizza le operazioni difensivo nelle condizioni di caverna risonante.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "Piastre vibranti che disperdono onde e impatti corrosivi.",
+      "uso_funzione": "Smorzare vibrazioni e deviare attacchi acustici sotterranei.",
+      "spinta_selettiva": "Difesa attiva in cavità risonanti e ambienti corrosivi.",
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Basso",
+        "sustained": "Basso"
+      },
+      "applicability": {
+        "clades": [],
+        "envo_terms": []
+      },
+      "version": "2.0.1",
+      "versioning": {
+        "created": "2026-08-22",
+        "updated": "2026-08-22",
+        "author": "Master DD / GPT-5 Pro"
+      }
+    },
+    {
+      "trait_code": "TR-2009",
+      "id": "ali_solari_fotoni",
+      "label": "Ali Solari Fotoni",
+      "famiglia_tipologia": "Locomotivo/Aereo",
+      "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
+      "tier": "T2",
+      "slot": [
+        "A",
+        "C"
+      ],
+      "sinergie": [
+        "cervello_a_bassa_latenza",
+        "occhi_cristallo_modulare",
+        "antenne_tesla"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "terrestre"
+          },
+          "fonte": "envo_mapping",
+          "meta": {
+            "notes": "Richiede esposizione solare costante per massimizzare spinta e schermature.",
+            "tier": "T2"
+          }
+        }
+      ],
+      "mutazione_indotta": "Piume fotovoltaiche con rete di accumulo radiante.",
+      "uso_funzione": "Convertire luce in spinta e in schermature riflettenti.",
+      "spinta_selettiva": "Volo prolungato e protezione in ambienti ad alta radianza.",
+      "cost_profile": {
+        "rest": "Medio",
+        "burst": "Medio",
+        "sustained": "Medio"
+      },
+      "applicability": {
+        "clades": [],
+        "envo_terms": []
+      },
+      "version": "2.0.1",
+      "versioning": {
+        "created": "2026-08-22",
+        "updated": "2026-08-22",
+        "author": "Master DD / GPT-5 Pro"
+      }
+    },
+    {
+      "trait_code": "TR-2010",
+      "id": "antenne_dustsense",
+      "label": "Antenne Dustsense",
+      "famiglia_tipologia": "Digestivo/Metabolico",
+      "fattore_mantenimento_energetico": "Basso (Passivo)",
+      "tier": "T1",
+      "slot": [],
+      "sinergie": [
+        "filamenti_digestivi_compattanti",
+        "ventriglio_gastroliti"
+      ],
+      "conflitti": [],
+      "requisiti_ambientali": [
+        {
+          "capacita_richieste": [],
+          "condizioni": {
+            "biome_class": "pianura_salina_iperarida"
+          },
+          "fonte": "env_to_traits",
+          "meta": {
+            "expansion": "coverage_q4_2025",
+            "notes": "Antenne Dustsense ottimizza le operazioni metabolico nelle condizioni di pianura salina iperarida.",
+            "tier": "T1"
+          }
+        }
+      ],
+      "mutazione_indotta": "Ricettori stratificati che filtrano polveri ioniche.",
+      "uso_funzione": "Stabilizzare assorbimento multi-fonte in deserti ionici.",
+      "spinta_selettiva": "Nutrizione efficiente in pianure saline iperaride.",
+      "cost_profile": {
+        "rest": "Basso",
+        "burst": "Basso",
+        "sustained": "Basso"
+      },
+      "applicability": {
+        "clades": [],
+        "envo_terms": []
+      },
+      "version": "2.0.1",
+      "versioning": {
+        "created": "2026-08-22",
+        "updated": "2026-08-22",
+        "author": "Master DD / GPT-5 Pro"
+      }
     }
   ]
 }

--- a/reports/evo/rollout/status_export.json
+++ b/reports/evo/rollout/status_export.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2025-12-02T15:16:28+00:00",
+  "generated_at": "2025-12-02T18:22:54+00:00",
   "overall_status": "at-risk",
   "workflow_run": null,
   "epics": [
@@ -28,16 +28,16 @@
     {
       "id": "ROL-05",
       "status": "at-risk",
-      "progress": 20,
+      "progress": 22,
       "metric_label": "Trait missing_in_external",
-      "open_items": 203,
+      "open_items": 198,
       "total_items": 254,
       "samples": [
-        "ali_fulminee",
-        "ali_ioniche",
-        "ali_membrana_sonica",
-        "ali_solari_fotoni",
-        "antenne_dustsense"
+        "antenne_eco_turbina",
+        "antenne_flusso_mareale",
+        "antenne_microonde_cavernose",
+        "antenne_plasmatiche_tempesta",
+        "antenne_reagenti"
       ]
     },
     {

--- a/reports/evo/rollout/traits_gap.csv
+++ b/reports/evo/rollout/traits_gap.csv
@@ -1,10 +1,10 @@
 slug,status,name_mismatch,tier_mismatch,synergy_mismatch,env_mismatch,legacy_flag_mismatch,external_code,external_label,external_tier,external_synergies,external_envs,legacy_label,legacy_tier,legacy_synergies,legacy_envs,duplicate_flag,merge_conflict_flag
 ali_fono_risonanti,mismatch,1,0,1,0,0,TR-1701,Ali Fono-Risonanti,T3,campo_di_interferenza_acustica;cannone_sonico_a_raggio,terrestre,i18n:traits.ali_fono_risonanti.label,T3,campo_di_interferenza_acustica;cannone_sonico_a_raggio;cervello_a_bassa_latenza;occhi_cinetici,terrestre,0,0
-ali_fulminee,missing_in_external,0,0,0,0,0,,,,,,i18n:traits.ali_fulminee.label,T1,focus_frazionato;sinapsi_coraline_polifoniche,stratosfera_tempestosa,0,0
-ali_ioniche,missing_in_external,0,0,0,0,0,,,,,,i18n:traits.ali_ioniche.label,T1,coda_frusta_cinetica;zampe_a_molla,canopia_ionica,0,0
-ali_membrana_sonica,missing_in_external,0,0,0,0,0,,,,,,i18n:traits.ali_membrana_sonica.label,T1,carapace_fase_variabile;mimetismo_cromatico_passivo,caverna_risonante,0,0
-ali_solari_fotoni,missing_in_external,0,0,0,0,0,,,,,,i18n:traits.ali_solari_fotoni.label,T2,antenne_tesla;cervello_a_bassa_latenza;occhi_cristallo_modulare,terrestre,0,0
-antenne_dustsense,missing_in_external,0,0,0,0,0,,,,,,i18n:traits.antenne_dustsense.label,T1,filamenti_digestivi_compattanti;ventriglio_gastroliti,pianura_salina_iperarida,0,0
+ali_fulminee,mismatch,1,0,0,0,0,TR-2006,Ali Fulminee,T1,focus_frazionato;sinapsi_coraline_polifoniche,stratosfera_tempestosa,i18n:traits.ali_fulminee.label,T1,focus_frazionato;sinapsi_coraline_polifoniche,stratosfera_tempestosa,0,0
+ali_ioniche,mismatch,1,0,0,0,0,TR-2007,Ali Ioniche,T1,coda_frusta_cinetica;zampe_a_molla,canopia_ionica,i18n:traits.ali_ioniche.label,T1,coda_frusta_cinetica;zampe_a_molla,canopia_ionica,0,0
+ali_membrana_sonica,mismatch,1,0,0,0,0,TR-2008,Ali Membrana Sonica,T1,carapace_fase_variabile;mimetismo_cromatico_passivo,caverna_risonante,i18n:traits.ali_membrana_sonica.label,T1,carapace_fase_variabile;mimetismo_cromatico_passivo,caverna_risonante,0,0
+ali_solari_fotoni,mismatch,1,0,0,0,0,TR-2009,Ali Solari Fotoni,T2,antenne_tesla;cervello_a_bassa_latenza;occhi_cristallo_modulare,terrestre,i18n:traits.ali_solari_fotoni.label,T2,antenne_tesla;cervello_a_bassa_latenza;occhi_cristallo_modulare,terrestre,0,0
+antenne_dustsense,mismatch,1,0,0,0,0,TR-2010,Antenne Dustsense,T1,filamenti_digestivi_compattanti;ventriglio_gastroliti,pianura_salina_iperarida,i18n:traits.antenne_dustsense.label,T1,filamenti_digestivi_compattanti;ventriglio_gastroliti,pianura_salina_iperarida,0,0
 antenne_eco_turbina,missing_in_external,0,0,0,0,0,,,,,,i18n:traits.antenne_eco_turbina.label,T1,empatia_coordinativa;risonanza_di_branco,dorsale_termale_tropicale,0,0
 antenne_flusso_mareale,missing_in_external,0,0,0,0,0,,,,,,i18n:traits.antenne_flusso_mareale.label,T1,coda_frusta_cinetica;sangue_piroforico,laguna_bioreattiva,0,0
 antenne_microonde_cavernose,missing_in_external,0,0,0,0,0,,,,,,i18n:traits.antenne_microonde_cavernose.label,T1,pathfinder;pianificatore;tattiche_di_branco,caverna_risonante,0,0

--- a/reports/evo/rollout/traits_gap.svg
+++ b/reports/evo/rollout/traits_gap.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2025-12-02T15:16:49.020306</dc:date>
+    <dc:date>2025-12-02T18:22:42.386683</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -40,10 +40,10 @@ z
    <g id="patch_3">
     <path d="M 68.091818 288.095888 
 L 221.174646 288.095888 
-L 221.174646 235.759363 
-L 68.091818 235.759363 
+L 221.174646 229.17713 
+L 68.091818 229.17713 
 z
-" clip-path="url(#p32051607bc)" style="fill: #005f73"/>
+" clip-path="url(#p7a84a5852a)" style="fill: #005f73"/>
    </g>
    <g id="patch_4">
     <path d="M 259.445354 288.095888 
@@ -51,18 +51,18 @@ L 412.528182 288.095888
 L 412.528182 79.775995 
 L 259.445354 79.775995 
 z
-" clip-path="url(#p32051607bc)" style="fill: #005f73"/>
+" clip-path="url(#p7a84a5852a)" style="fill: #005f73"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mfa29b2ce3c" d="M 0 0 
+       <path id="m50d587bec3" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mfa29b2ce3c" x="144.633232" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m50d587bec3" x="144.633232" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -252,7 +252,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mfa29b2ce3c" x="335.986768" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m50d587bec3" x="335.986768" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -411,12 +411,12 @@ z
     <g id="ytick_1">
      <g id="line2d_3">
       <defs>
-       <path id="mbcb19d5927" d="M 0 0 
+       <path id="m3024305335" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mbcb19d5927" x="50.87" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3024305335" x="50.87" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -452,12 +452,12 @@ z
     <g id="ytick_2">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mbcb19d5927" x="50.87" y="262.440728" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3024305335" x="50.87" y="261.792871" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- 25 -->
-      <g transform="translate(31.145 266.239947) scale(0.1 -0.1)">
+      <g transform="translate(31.145 265.59209) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -517,12 +517,12 @@ z
     <g id="ytick_3">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mbcb19d5927" x="50.87" y="236.785569" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3024305335" x="50.87" y="235.489854" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- 50 -->
-      <g transform="translate(31.145 240.584788) scale(0.1 -0.1)">
+      <g transform="translate(31.145 239.289073) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-35"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
       </g>
@@ -531,12 +531,12 @@ z
     <g id="ytick_4">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mbcb19d5927" x="50.87" y="211.13041" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3024305335" x="50.87" y="209.186837" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- 75 -->
-      <g transform="translate(31.145 214.929629) scale(0.1 -0.1)">
+      <g transform="translate(31.145 212.986056) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -557,12 +557,12 @@ z
     <g id="ytick_5">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mbcb19d5927" x="50.87" y="185.475251" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3024305335" x="50.87" y="182.88382" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 100 -->
-      <g transform="translate(24.7825 189.274469) scale(0.1 -0.1)">
+      <g transform="translate(24.7825 186.683039) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -588,12 +588,12 @@ z
     <g id="ytick_6">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mbcb19d5927" x="50.87" y="159.820091" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3024305335" x="50.87" y="156.580804" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 125 -->
-      <g transform="translate(24.7825 163.61931) scale(0.1 -0.1)">
+      <g transform="translate(24.7825 160.380022) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -603,12 +603,12 @@ z
     <g id="ytick_7">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mbcb19d5927" x="50.87" y="134.164932" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3024305335" x="50.87" y="130.277787" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 150 -->
-      <g transform="translate(24.7825 137.964151) scale(0.1 -0.1)">
+      <g transform="translate(24.7825 134.077006) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -618,12 +618,12 @@ z
     <g id="ytick_8">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mbcb19d5927" x="50.87" y="108.509773" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3024305335" x="50.87" y="103.97477" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 175 -->
-      <g transform="translate(24.7825 112.308992) scale(0.1 -0.1)">
+      <g transform="translate(24.7825 107.773989) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -633,12 +633,12 @@ z
     <g id="ytick_9">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mbcb19d5927" x="50.87" y="82.854614" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3024305335" x="50.87" y="77.671753" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 200 -->
-      <g transform="translate(24.7825 86.653833) scale(0.1 -0.1)">
+      <g transform="translate(24.7825 81.470972) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -838,23 +838,23 @@ L 548.947879 288.095888
 L 548.947879 79.775995 
 L 491.541818 79.775995 
 z
-" clip-path="url(#p52d9095fa6)" style="fill: #ee9b00"/>
+" clip-path="url(#p41c2119011)" style="fill: #ee9b00"/>
    </g>
    <g id="patch_11">
     <path d="M 563.299394 288.095888 
 L 620.705455 288.095888 
-L 620.705455 283.92949 
-L 563.299394 283.92949 
+L 620.705455 284.308253 
+L 563.299394 284.308253 
 z
-" clip-path="url(#p52d9095fa6)" style="fill: #ee9b00"/>
+" clip-path="url(#p41c2119011)" style="fill: #ee9b00"/>
    </g>
    <g id="patch_12">
     <path d="M 635.05697 288.095888 
 L 692.46303 288.095888 
-L 692.46303 150.604758 
-L 635.05697 150.604758 
+L 692.46303 163.103952 
+L 635.05697 163.103952 
 z
-" clip-path="url(#p52d9095fa6)" style="fill: #ee9b00"/>
+" clip-path="url(#p41c2119011)" style="fill: #ee9b00"/>
    </g>
    <g id="patch_13">
     <path d="M 706.814545 288.095888 
@@ -862,7 +862,7 @@ L 764.220606 288.095888
 L 764.220606 288.095888 
 L 706.814545 288.095888 
 z
-" clip-path="url(#p52d9095fa6)" style="fill: #ee9b00"/>
+" clip-path="url(#p41c2119011)" style="fill: #ee9b00"/>
    </g>
    <g id="patch_14">
     <path d="M 778.572121 288.095888 
@@ -870,13 +870,13 @@ L 835.978182 288.095888
 L 835.978182 288.095888 
 L 778.572121 288.095888 
 z
-" clip-path="url(#p52d9095fa6)" style="fill: #ee9b00"/>
+" clip-path="url(#p41c2119011)" style="fill: #ee9b00"/>
    </g>
    <g id="matplotlib.axis_3">
     <g id="xtick_3">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mfa29b2ce3c" x="520.244848" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m50d587bec3" x="520.244848" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -903,7 +903,7 @@ z
     <g id="xtick_4">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mfa29b2ce3c" x="592.002424" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m50d587bec3" x="592.002424" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -930,7 +930,7 @@ z
     <g id="xtick_5">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mfa29b2ce3c" x="663.76" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m50d587bec3" x="663.76" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -979,7 +979,7 @@ z
     <g id="xtick_6">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mfa29b2ce3c" x="735.517576" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m50d587bec3" x="735.517576" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1017,7 +1017,7 @@ z
     <g id="xtick_7">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mfa29b2ce3c" x="807.275152" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m50d587bec3" x="807.275152" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1055,7 +1055,7 @@ z
     <g id="ytick_10">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mbcb19d5927" x="474.32" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3024305335" x="474.32" y="288.095888" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1068,12 +1068,12 @@ z
     <g id="ytick_11">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mbcb19d5927" x="474.32" y="246.431909" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3024305335" x="474.32" y="250.219543" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
       <!-- 10 -->
-      <g transform="translate(454.595 250.231128) scale(0.1 -0.1)">
+      <g transform="translate(454.595 254.018762) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
       </g>
@@ -1082,12 +1082,12 @@ z
     <g id="ytick_12">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mbcb19d5927" x="474.32" y="204.76793" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3024305335" x="474.32" y="212.343199" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_21">
       <!-- 20 -->
-      <g transform="translate(454.595 208.567149) scale(0.1 -0.1)">
+      <g transform="translate(454.595 216.142418) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
       </g>
@@ -1096,12 +1096,12 @@ z
     <g id="ytick_13">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mbcb19d5927" x="474.32" y="163.103952" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3024305335" x="474.32" y="174.466855" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_22">
       <!-- 30 -->
-      <g transform="translate(454.595 166.903171) scale(0.1 -0.1)">
+      <g transform="translate(454.595 178.266074) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1144,12 +1144,12 @@ z
     <g id="ytick_14">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mbcb19d5927" x="474.32" y="121.439973" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3024305335" x="474.32" y="136.590511" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_23">
       <!-- 40 -->
-      <g transform="translate(454.595 125.239192) scale(0.1 -0.1)">
+      <g transform="translate(454.595 140.38973) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1179,12 +1179,12 @@ z
     <g id="ytick_15">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mbcb19d5927" x="474.32" y="79.775995" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3024305335" x="474.32" y="98.714167" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_24">
       <!-- 50 -->
-      <g transform="translate(454.595 83.575213) scale(0.1 -0.1)">
+      <g transform="translate(454.595 102.513385) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-35"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
       </g>
@@ -1449,10 +1449,10 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p32051607bc">
+  <clipPath id="p7a84a5852a">
    <rect x="50.87" y="69.36" width="378.88" height="218.735888"/>
   </clipPath>
-  <clipPath id="p52d9095fa6">
+  <clipPath id="p41c2119011">
    <rect x="474.32" y="69.36" width="378.88" height="218.735888"/>
   </clipPath>
  </defs>

--- a/reports/evo/rollout/traits_normalized.csv
+++ b/reports/evo/rollout/traits_normalized.csv
@@ -49,6 +49,11 @@ external_evo,coscienza_dalveare_diffusa,TR-2002,Coscienza d’Alveare Diffusa,T4
 external_evo,aura_di_dispersione_mentale,TR-2003,Aura di Dispersione Mentale,T3,0,,corna_psico_conduttive,terrestre
 external_evo,metabolismo_di_condivisione_energetica,TR-2004,Metabolismo di Condivisione Energetica,T3,0,,corna_psico_conduttive,terrestre
 external_evo,unghie_a_micro_adesione,TR-2005,Unghie a Micro-Adesione,T2,0,,corna_psico_conduttive,terrestre
+external_evo,ali_fulminee,TR-2006,Ali Fulminee,T1,0,,focus_frazionato;sinapsi_coraline_polifoniche,stratosfera_tempestosa
+external_evo,ali_ioniche,TR-2007,Ali Ioniche,T1,0,,coda_frusta_cinetica;zampe_a_molla,canopia_ionica
+external_evo,ali_membrana_sonica,TR-2008,Ali Membrana Sonica,T1,0,,carapace_fase_variabile;mimetismo_cromatico_passivo,caverna_risonante
+external_evo,ali_solari_fotoni,TR-2009,Ali Solari Fotoni,T2,0,,antenne_tesla;cervello_a_bassa_latenza;occhi_cristallo_modulare,terrestre
+external_evo,antenne_dustsense,TR-2010,Antenne Dustsense,T1,0,,filamenti_digestivi_compattanti;ventriglio_gastroliti,pianura_salina_iperarida
 external_evo,traits_aggregate,traits_aggregate,,,0,,,
 legacy_index,fagocitosi_assorbente,,i18n:traits.fagocitosi_assorbente.label,T3,0,coverage_q4_2025,cisti_di_ibernazione_minerale;membrana_plastica_continua,terrestre
 legacy_index,filtro_metallofago,,i18n:traits.filtro_metallofago.label,T2,0,coverage_q4_2025,bozzolo_magnetico;elettromagnete_biologico,terrestre


### PR DESCRIPTION
## Summary
- add external Evo trait definitions and codes for ali_fulminee, ali_ioniche, ali_membrana_sonica, ali_solari_fotoni, and antenne_dustsense
- regenerate trait gap/normalized reports after importing the new external entries
- update the ROL-05 rollout tracker with refreshed counts and samples

## Testing
- python tools/audit/evo_trait_diff.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f2cb0e8008328b3b0a843dbecb133)