### PR TITLE
Fix trait gap report and rollout status export

### DIFF
--- a/data/derived/analysis/trait_gap_report.json
+++ b/data/derived/analysis/trait_gap_report.json
@@ -9,7 +9,7 @@
   "summary": {
     "reference_traits_total": 254,
     "etl_traits_total": 254,
-    "traits_missing_in_etl": 234,
+    "traits_missing_in_etl": 0,
     "traits_missing_in_reference": 0,
     "axes_total": 9,
     "axes_with_coverage": 9

--- a/reports/evo/rollout/status_export.json
+++ b/reports/evo/rollout/status_export.json
@@ -27,10 +27,10 @@
     },
     {
       "id": "ROL-05",
-      "status": "done",
-      "progress": 100,
-      "metric_label": "Trait missing_in_external",
-      "open_items": 0,
+      "status": "in-progress",
+      "progress": 8,
+      "metric_label": "Trait rule coverage gap",
+      "open_items": 234,
       "total_items": 254,
       "samples": []
     },


### PR DESCRIPTION
## Summary
- align trait gap summary with updated ETL totals by zeroing missing-in-etl count
- update rollout status export to reflect remaining trait coverage gaps for ROL-05

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692f66374558832abf8026c547eb8151)