### PR TITLE
Update evo rollout status metrics

### DIFF
--- a/docs/roadmap/evo-rollout-status.md
+++ b/docs/roadmap/evo-rollout-status.md
@@ -12,27 +12,27 @@ generated_by: tools/roadmap/update_status.py
 
 - **Data riferimento:** 2025-12-02
 - **Owner aggiornamento:** Gameplay Ops · Evo rollout crew
-- **Status generale:** in-progress
+- **Status generale:** at-risk
 - **Ultimo report trait gap:** `data/derived/analysis/trait_gap_report.json`
-- **Copertura trait ETL:** 254/254 (100.0%)
-- **Gap trait principali:** 0 missing_in_index, 0 missing_in_external
+- **Copertura trait ETL:** 20/254 (7.9%)
+- **Gap trait principali:** 0 missing_in_index, 0 missing_in_external, 253 mismatch
 - **Playbook da archiviare:** 3
 - **Ecotipi con mismatch legacy:** 0 su 20
 
 ## Avanzamento epiche ROL-\*
 
-| Epic   | Stato       | Progress (%) | Gap aperti                   | Campione                                                                                                                        |
-| ------ | ----------- | ------------ | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| ROL-03 | in-progress | 99           | Playbook da archiviare: 3    | docs/evo-tactics/guides/security-ops.md, docs/evo-tactics/guides/template-ptpf.md, docs/evo-tactics/guides/visione-struttura.md |
-| ROL-04 | done        | 100          | Trait missing_in_index: 0    | —                                                                                                                               |
-| ROL-05 | done        | 100          | Trait missing_in_external: 0 | —                                                                                                                               |
-| ROL-06 | done        | 100          | Ecotipi con mismatch: 0      | Anguis magnetica, Chemnotela toxica, Elastovaranus hydrus, Gulogluteus scutiger, Perfusuas pedes                                |
+| Epic   | Stato       | Progress (%) | Gap aperti                         | Campione                                                                                                                        |
+| ------ | ----------- | ------------ | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| ROL-03 | in-progress | 99           | Playbook da archiviare: 3          | docs/evo-tactics/guides/security-ops.md, docs/evo-tactics/guides/template-ptpf.md, docs/evo-tactics/guides/visione-struttura.md |
+| ROL-04 | at-risk     | 0            | Trait da allineare (index): 253    | ali_fono_risonanti, ali_fulminee, ali_ioniche, ali_membrana_sonica, ali_solari_fotoni                                           |
+| ROL-05 | at-risk     | 0            | Trait da allineare (external): 253 | ali_fono_risonanti, ali_fulminee, ali_ioniche, ali_membrana_sonica, ali_solari_fotoni                                           |
+| ROL-06 | done        | 100          | Ecotipi con mismatch: 0            | Anguis magnetica, Chemnotela toxica, Elastovaranus hydrus, Gulogluteus scutiger, Perfusuas pedes                                |
 
 ## Focus operativi
 
 - **Documentazione legacy da snapshot (ROL-03):** docs/evo-tactics/guides/security-ops.md, docs/evo-tactics/guides/template-ptpf.md, docs/evo-tactics/guides/visione-struttura.md
-- **Trait da indicizzare (ROL-04):** —
-- **Trait da fornire ai consumer esterni (ROL-05):** —
+- **Trait da indicizzare (ROL-04):** ali_fono_risonanti, ali_fulminee, ali_ioniche, ali_membrana_sonica, ali_solari_fotoni
+- **Trait da fornire ai consumer esterni (ROL-05):** ali_fono_risonanti, ali_fulminee, ali_ioniche, ali_membrana_sonica, ali_solari_fotoni
 - **Specie/ecotipi con mismatch (ROL-06):** Anguis magnetica, Chemnotela toxica, Elastovaranus hydrus, Gulogluteus scutiger, Perfusuas pedes
 
 ## Fonti principali

--- a/docs/roadmap/status/evo-weekly-20251202.md
+++ b/docs/roadmap/status/evo-weekly-20251202.md
@@ -14,8 +14,8 @@ workflow_run: —
 | Indicatore                | Valore |
 | ------------------------- | ------ |
 | Playbook da archiviare    | 3      |
-| Trait missing_in_index    | 0      |
-| Trait missing_in_external | 0      |
+| Trait missing_in_index    | 253    |
+| Trait missing_in_external | 253    |
 | Ecotipi con mismatch      | 0      |
 
 ## Workflow & integrazioni

--- a/incoming/lavoro_da_classificare/tasks.yml
+++ b/incoming/lavoro_da_classificare/tasks.yml
@@ -347,7 +347,7 @@ tasks:
     batch: rollout
     title: Allineamento indice trait Evo
     description: 'Mappare i trait `missing_in_index` con gli ID legacy e aggiornare il glossario.'
-    status: done
+    status: at-risk
     owner: gameplay-data
     depends_on:
       - TRT-02
@@ -360,19 +360,23 @@ tasks:
 
     telemetry:
       last_sync: 2025-12-02T19:14:01+00:00
-      progress: 100
+      progress: 0
       metric:
-        label: Trait missing_in_index
-        open_items: 0
+        label: Trait da allineare (index)
+        open_items: 253
         total_items: 254
       samples:
-        - Nessun elemento
+        - ali_fono_risonanti
+        - ali_fulminee
+        - ali_ioniche
+        - ali_membrana_sonica
+        - ali_solari_fotoni
 
   - id: ROL-05
     batch: rollout
     title: Esportazione dataset trait consumer esterni
     description: 'Preparare il pacchetto CSV/JSON per i consumer esterni che non ricevono i nuovi trait.'
-    status: done
+    status: at-risk
     owner: partner-success
     depends_on:
       - ROL-04
@@ -387,13 +391,17 @@ tasks:
 
     telemetry:
       last_sync: 2025-12-02T19:14:01+00:00
-      progress: 100
+      progress: 0
       metric:
-        label: Trait missing_in_external
-        open_items: 0
+        label: Trait da allineare (external)
+        open_items: 253
         total_items: 254
       samples:
-        - Nessun elemento
+        - ali_fono_risonanti
+        - ali_fulminee
+        - ali_ioniche
+        - ali_membrana_sonica
+        - ali_solari_fotoni
 
   - id: ROL-06
     batch: rollout

--- a/reports/evo/rollout/status_export.json
+++ b/reports/evo/rollout/status_export.json
@@ -1,6 +1,6 @@
 {
   "generated_at": "2025-12-02T19:14:01+00:00",
-  "overall_status": "in-progress",
+  "overall_status": "at-risk",
   "workflow_run": null,
   "epics": [
     {
@@ -18,21 +18,33 @@
     },
     {
       "id": "ROL-04",
-      "status": "done",
-      "progress": 100,
-      "metric_label": "Trait missing_in_index",
-      "open_items": 0,
+      "status": "at-risk",
+      "progress": 0,
+      "metric_label": "Trait da allineare (index)",
+      "open_items": 253,
       "total_items": 254,
-      "samples": []
+      "samples": [
+        "ali_fono_risonanti",
+        "ali_fulminee",
+        "ali_ioniche",
+        "ali_membrana_sonica",
+        "ali_solari_fotoni"
+      ]
     },
     {
       "id": "ROL-05",
-      "status": "done",
-      "progress": 100,
-      "metric_label": "Trait missing_in_external",
-      "open_items": 0,
+      "status": "at-risk",
+      "progress": 0,
+      "metric_label": "Trait da allineare (external)",
+      "open_items": 253,
       "total_items": 254,
-      "samples": []
+      "samples": [
+        "ali_fono_risonanti",
+        "ali_fulminee",
+        "ali_ioniche",
+        "ali_membrana_sonica",
+        "ali_solari_fotoni"
+      ]
     },
     {
       "id": "ROL-06",


### PR DESCRIPTION
## Summary
- count trait mismatches alongside missing entries when computing rollout metrics
- refresh roadmap status outputs and weekly snapshot to reflect the updated ROL-03/04/05/06 gap counts
- sync kanban export and tasks telemetry with the latest mismatch-driven coverage and samples

## Testing
- python tools/roadmap/update_status.py
- npx prettier --write docs/roadmap/evo-rollout-status.md docs/roadmap/status/evo-weekly-20251202.md

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f68be17e883289c634dde9a4f4a3e)