### PR TITLE
Update Evo rollout status from latest gap reports

### DIFF
--- a/docs/roadmap/evo-rollout-status.md
+++ b/docs/roadmap/evo-rollout-status.md
@@ -12,27 +12,27 @@ generated_by: tools/roadmap/update_status.py
 
 - **Data riferimento:** 2025-12-02
 - **Owner aggiornamento:** Gameplay Ops · Evo rollout crew
-- **Status generale:** at-risk
+- **Status generale:** in-progress
 - **Ultimo report trait gap:** `data/derived/analysis/trait_gap_report.json`
-- **Copertura trait ETL:** 20/254 (7.9%)
-- **Gap trait principali:** 0 missing_in_index, 0 missing_in_external, 253 mismatch
+- **Copertura trait ETL:** 254/254 (100.0%)
+- **Gap trait principali:** 0 missing_in_index, 0 missing_in_external, 0 mismatch
 - **Playbook da archiviare:** 3
 - **Ecotipi con mismatch legacy:** 0 su 20
 
 ## Avanzamento epiche ROL-\*
 
-| Epic   | Stato       | Progress (%) | Gap aperti                         | Campione                                                                                                                        |
-| ------ | ----------- | ------------ | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| ROL-03 | in-progress | 99           | Playbook da archiviare: 3          | docs/evo-tactics/guides/security-ops.md, docs/evo-tactics/guides/template-ptpf.md, docs/evo-tactics/guides/visione-struttura.md |
-| ROL-04 | at-risk     | 0            | Trait da allineare (index): 253    | ali_fono_risonanti, ali_fulminee, ali_ioniche, ali_membrana_sonica, ali_solari_fotoni                                           |
-| ROL-05 | at-risk     | 0            | Trait da allineare (external): 253 | ali_fono_risonanti, ali_fulminee, ali_ioniche, ali_membrana_sonica, ali_solari_fotoni                                           |
-| ROL-06 | done        | 100          | Ecotipi con mismatch: 0            | Anguis magnetica, Chemnotela toxica, Elastovaranus hydrus, Gulogluteus scutiger, Perfusuas pedes                                |
+| Epic   | Stato       | Progress (%) | Gap aperti                       | Campione                                                                                                                        |
+| ------ | ----------- | ------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| ROL-03 | in-progress | 99           | Playbook da archiviare: 3        | docs/evo-tactics/guides/security-ops.md, docs/evo-tactics/guides/template-ptpf.md, docs/evo-tactics/guides/visione-struttura.md |
+| ROL-04 | done        | 100          | Trait da allineare (index): 0    | —                                                                                                                               |
+| ROL-05 | done        | 100          | Trait da allineare (external): 0 | —                                                                                                                               |
+| ROL-06 | done        | 100          | Ecotipi con mismatch: 0          | Anguis magnetica, Chemnotela toxica, Elastovaranus hydrus, Gulogluteus scutiger, Perfusuas pedes                                |
 
 ## Focus operativi
 
 - **Documentazione legacy da snapshot (ROL-03):** docs/evo-tactics/guides/security-ops.md, docs/evo-tactics/guides/template-ptpf.md, docs/evo-tactics/guides/visione-struttura.md
-- **Trait da indicizzare (ROL-04):** ali_fono_risonanti, ali_fulminee, ali_ioniche, ali_membrana_sonica, ali_solari_fotoni
-- **Trait da fornire ai consumer esterni (ROL-05):** ali_fono_risonanti, ali_fulminee, ali_ioniche, ali_membrana_sonica, ali_solari_fotoni
+- **Trait da indicizzare (ROL-04):** —
+- **Trait da fornire ai consumer esterni (ROL-05):** —
 - **Specie/ecotipi con mismatch (ROL-06):** Anguis magnetica, Chemnotela toxica, Elastovaranus hydrus, Gulogluteus scutiger, Perfusuas pedes
 
 ## Fonti principali

--- a/docs/roadmap/status/evo-weekly-20251202.md
+++ b/docs/roadmap/status/evo-weekly-20251202.md
@@ -1,6 +1,6 @@
 ---
 title: Evo rollout weekly status
-generated: 2025-12-02T19:14:01+00:00
+generated: 2025-12-02T22:45:39.756004+00:00
 reference_date: 2025-12-02
 workflow_run: —
 ---
@@ -14,8 +14,8 @@ workflow_run: —
 | Indicatore                | Valore |
 | ------------------------- | ------ |
 | Playbook da archiviare    | 3      |
-| Trait missing_in_index    | 253    |
-| Trait missing_in_external | 253    |
+| Trait missing_in_index    | 0      |
+| Trait missing_in_external | 0      |
 | Ecotipi con mismatch      | 0      |
 
 ## Workflow & integrazioni

--- a/incoming/lavoro_da_classificare/tasks.yml
+++ b/incoming/lavoro_da_classificare/tasks.yml
@@ -332,7 +332,7 @@ tasks:
     notes: 'Estrarre le copie consolidate dei playbook security/PMO e versionarle nell’archivio storico con changelog.'
 
     telemetry:
-      last_sync: 2025-12-02T19:14:01+00:00
+      last_sync: 2025-12-02T22:45:39.756004+00:00
       progress: 99
       metric:
         label: Playbook da archiviare
@@ -347,7 +347,7 @@ tasks:
     batch: rollout
     title: Allineamento indice trait Evo
     description: 'Mappare i trait `missing_in_index` con gli ID legacy e aggiornare il glossario.'
-    status: at-risk
+    status: done
     owner: gameplay-data
     depends_on:
       - TRT-02
@@ -359,24 +359,20 @@ tasks:
     notes: 'Garantisce corrispondenza tra slug Evo e catalogo legacy per trait in stato `missing_in_index`. Gap azzerato dopo import TR-2002 e classificazione `traits_aggregate` come legacy-only (sync 2025-11-27).'
 
     telemetry:
-      last_sync: 2025-12-02T19:14:01+00:00
-      progress: 0
+      last_sync: 2025-12-02T22:45:39.756004+00:00
+      progress: 100
       metric:
         label: Trait da allineare (index)
-        open_items: 253
+        open_items: 0
         total_items: 254
       samples:
-        - ali_fono_risonanti
-        - ali_fulminee
-        - ali_ioniche
-        - ali_membrana_sonica
-        - ali_solari_fotoni
+        - Nessun elemento
 
   - id: ROL-05
     batch: rollout
     title: Esportazione dataset trait consumer esterni
     description: 'Preparare il pacchetto CSV/JSON per i consumer esterni che non ricevono i nuovi trait.'
-    status: at-risk
+    status: done
     owner: partner-success
     depends_on:
       - ROL-04
@@ -390,18 +386,14 @@ tasks:
       - Output locale condiviso con il team partner-success (nessun upload S3 richiesto) per la validazione finale; gap esterni azzerati dopo verifica.
 
     telemetry:
-      last_sync: 2025-12-02T19:14:01+00:00
-      progress: 0
+      last_sync: 2025-12-02T22:45:39.756004+00:00
+      progress: 100
       metric:
         label: Trait da allineare (external)
-        open_items: 253
+        open_items: 0
         total_items: 254
       samples:
-        - ali_fono_risonanti
-        - ali_fulminee
-        - ali_ioniche
-        - ali_membrana_sonica
-        - ali_solari_fotoni
+        - Nessun elemento
 
   - id: ROL-06
     batch: rollout
@@ -419,7 +411,7 @@ tasks:
     notes: '14 controlli schema con 3 warning, trait audit senza regressioni, 230 suggerimenti style (0 errori); inventario aggiornato a stato validato.'
 
     telemetry:
-      last_sync: 2025-12-02T19:14:01+00:00
+      last_sync: 2025-12-02T22:45:39.756004+00:00
       progress: 100
       metric:
         label: Ecotipi con mismatch

--- a/reports/evo/rollout/status_export.json
+++ b/reports/evo/rollout/status_export.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2025-12-02T19:14:01+00:00",
-  "overall_status": "at-risk",
+  "generated_at": "2025-12-02T22:45:39.756004+00:00",
+  "overall_status": "in-progress",
   "workflow_run": null,
   "epics": [
     {
@@ -18,33 +18,21 @@
     },
     {
       "id": "ROL-04",
-      "status": "at-risk",
-      "progress": 0,
+      "status": "done",
+      "progress": 100,
       "metric_label": "Trait da allineare (index)",
-      "open_items": 253,
+      "open_items": 0,
       "total_items": 254,
-      "samples": [
-        "ali_fono_risonanti",
-        "ali_fulminee",
-        "ali_ioniche",
-        "ali_membrana_sonica",
-        "ali_solari_fotoni"
-      ]
+      "samples": []
     },
     {
       "id": "ROL-05",
-      "status": "at-risk",
-      "progress": 0,
+      "status": "done",
+      "progress": 100,
       "metric_label": "Trait da allineare (external)",
-      "open_items": 253,
+      "open_items": 0,
       "total_items": 254,
-      "samples": [
-        "ali_fono_risonanti",
-        "ali_fulminee",
-        "ali_ioniche",
-        "ali_membrana_sonica",
-        "ali_solari_fotoni"
-      ]
+      "samples": []
     },
     {
       "id": "ROL-06",


### PR DESCRIPTION
## Summary
- Refresh Evo rollout snapshot and weekly status export to reflect zero trait gaps and current ecotype checks
- Update rollout task telemetry and kanban JSON export based on regenerated gap metrics

## Testing
- python tools/roadmap/update_status.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f7b3c4000832882c36db2ae824a99)