### PR TITLE
Fix trait gap summary to reflect coverage data

### DIFF
--- a/data/derived/analysis/trait_gap_report.json
+++ b/data/derived/analysis/trait_gap_report.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2025-12-03T01:18:36+00:00",
+  "generated_at": "2025-12-03T01:34:45+00:00",
   "sources": {
     "etl_report": "data/derived/analysis/trait_coverage_report.json",
     "trait_reference": "data/traits/index.json",
@@ -12,8 +12,8 @@
     "traits_missing_in_etl": 0,
     "traits_missing_in_reference": 0,
     "traits_with_coverage": 254,
-    "axes_total": 9,
-    "axes_with_coverage": 9
+    "axes_total": 10,
+    "axes_with_coverage": 10
   },
   "axes": {
     "sensoriale": {

--- a/tools/analysis/trait_gap_report.py
+++ b/tools/analysis/trait_gap_report.py
@@ -186,20 +186,21 @@ def main(argv: list[str] | None = None) -> int:
         trait_id for trait_id in etl_traits.keys() if trait_id not in reference_traits
     )
 
-    axes_with_coverage = {
-        key
-        for key, info in axis_summary.items()
-        if info["covered_traits"] > 0 and key != AXIS_UNKNOWN[0]
+    axes_with_data = {
+        key: info for key, info in axis_summary.items() if info["total_traits"] > 0
     }
-
     summary = {
         "reference_traits_total": len(reference_traits),
         "etl_traits_total": len(etl_traits),
         "traits_missing_in_etl": len(missing_in_etl),
         "traits_missing_in_reference": len(missing_in_reference),
-        "traits_with_coverage": len(reference_traits) - len(missing_in_etl),
-        "axes_total": len(AXES),
-        "axes_with_coverage": len(axes_with_coverage),
+        "traits_with_coverage": sum(
+            1 for detail in coverage_details.values() if detail["covered"]
+        ),
+        "axes_total": len(axes_with_data),
+        "axes_with_coverage": sum(
+            1 for info in axes_with_data.values() if info["covered_traits"] > 0
+        ),
     }
 
     for info in axis_summary.values():


### PR DESCRIPTION
## Summary
- derive trait gap summary metrics from actual coverage details and axes with data
- regenerate the derived trait gap report to reflect the updated summary logic

## Testing
- python tools/analysis/trait_gap_report.py --etl-report data/derived/analysis/trait_coverage_report.json --trait-reference data/traits/index.json --trait-glossary data/core/traits/glossary.json --out data/derived/analysis/trait_gap_report.json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f916acf3883289e4cc5ae1a24153c)