### PR TITLE
Complete trait species affinity coverage

### DIFF
--- a/data/derived/analysis/manifest.json
+++ b/data/derived/analysis/manifest.json
@@ -5,9 +5,9 @@
   "commit": "eb6b91d512db038d75f1cc7458a2221499b4e767",
   "log_tag": null,
   "artifacts": {
-    "data/derived/analysis/trait_coverage_report.json": "c9639c4ae1a5217dc30267bd491e33a1bc4d41dc396ac3626c5f931356696340",
-    "data/derived/analysis/trait_coverage_matrix.csv": "1afc7d635ddc7266c7f1c1311a8992205e027005aed331f0dfc0600930d04bd8",
-    "data/derived/analysis/trait_gap_report.json": "214c9115d38f53ccbec3758e3c4817b8a8ab0e0457f828b49e399628fe5138e6",
+    "data/derived/analysis/trait_coverage_report.json": "44e015594e68022042a04b81f3edc23615f7df290752913e655ab0dfdbea4080",
+    "data/derived/analysis/trait_coverage_matrix.csv": "888ed896ec6036b5bae35aec7c6036832230dab8bc1868139e09dd196b6eab31",
+    "data/derived/analysis/trait_gap_report.json": "a0ef558023bba99f39cdd6c8c173c7e77d60a8ede00b16cf4225a7ad693227c2",
     "data/derived/analysis/trait_baseline.yaml": "1b7658a544435d522bda9e119ee6959f0b6b65a70bcf09665bec9d5cf2a23254",
     "data/derived/analysis/trait_env_mapping.json": "8b0c0e07c8fca118707efe948092992d2dece80996ad9c270a6a56b3ba851ddc",
     "data/derived/analysis/progression/skydock_siege_xp.json": "8f3014f01c7124dec2599e1bb3fa07375def5f95336ba269cceaba3cb035243d",

--- a/data/derived/analysis/trait_coverage_matrix.csv
+++ b/data/derived/analysis/trait_coverage_matrix.csv
@@ -1,21 +1,285 @@
 trait_id,label_it,label_en,biome,morphotype,rules_count,species_count
-artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,caverna_risonante,,1,0
-carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,caverna_risonante,,1,0
-coda_frusta_cinetica,Coda a Frusta Cinetica,Kinetic Lash Tail,caverna_risonante,,1,0
-criostasi_adattiva,Criostasi,Adaptive Cryostasis,caverna_risonante,,1,0
-eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,caverna_risonante,,1,0
-filamenti_digestivi_compattanti,Filamento materiali digeriti,Digestive Compaction Filaments,caverna_risonante,,1,0
-lingua_tattile_trama,Lingua Tattile Trama-Sensibile,Texture-Sensing Tongue,caverna_risonante,,1,0
-mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,caverna_risonante,,1,0
-nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,caverna_risonante,,1,0
-occhi_infrarosso_composti,Occhi Composti ad Infrarosso,Infrared Compound Eyes,caverna_risonante,,1,0
-olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,caverna_risonante,,1,0
-respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,caverna_risonante,,1,0
-sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,caverna_risonante,,1,0
-sangue_piroforico,Sangue che prende fuoco a contatto con l'ossigeno,Pyrophoric Blood,caverna_risonante,,1,0
-scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,caverna_risonante,,1,0
-secrezione_rallentante_palmi,Mani secernano liquido rallentante,Retarding Palm Secretions,caverna_risonante,,1,0
-sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,caverna_risonante,,1,0
-spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,caverna_risonante,,1,0
-struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,caverna_risonante,,1,0
-ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,caverna_risonante,,1,0
+ali_fono_risonanti,Ali Fono-Risonanti,Phono-Resonant Wings,,,1,2
+ali_fulminee,Ali Fulminee,Ali Fulminee,stratosfera_tempestosa,,1,1
+ali_ioniche,Ali Ioniche,Ionic Wings,canopia_ionica,,1,1
+ali_membrana_sonica,Ali a Membrana Sonica,Sonic Membrane Wings,caverna_risonante,,1,1
+ali_solari_fotoni,Ali Solari Fotoniche,Solar Photon Wings,,,1,2
+antenne_dustsense,Antenne Dustsense,Dustsense Antennae,pianura_salina_iperarida,,1,1
+antenne_eco_turbina,Antenne Eco Turbina,Antenne Eco Turbina,dorsale_termale_tropicale,,1,1
+antenne_flusso_mareale,Antenne Flusso Mareale,Antenne Flusso Mareale,laguna_bioreattiva,,1,1
+antenne_microonde_cavernose,Antenne Microonde Cavernose,Antenne Microonde Cavernose,caverna_risonante,,1,1
+antenne_plasmatiche_tempesta,Antenne Plasmatiche di Tempesta,Storm Plasma Antennae,,,1,1
+antenne_reagenti,Antenne Reagenti,Antenne Reagenti,foresta_acida,,1,1
+antenne_tesla,Antenne Tesla,Antenne Tesla,canopia_ionica,,1,1
+antenne_waveguide,Antenne Waveguide,Antenne Waveguide,reef_luminescente,,1,1
+antenne_wideband,Antenne Wideband,Antenne Wideband,steppe_algoritmiche,,1,1
+appendici_risonanti_marea,Appendici Risonanti Marea,Appendici Risonanti Marea,laguna_bioreattiva,,1,1
+appendici_thermotattiche,Appendici Thermotattiche,Appendici Thermotattiche,abisso_vulcanico,,1,1
+armatura_pietra_planare,Armatura di Pietra Planare,Planar Stone Plating,,,1,4
+articolazioni_a_leva_idraulica,Articolazioni a Leva Idraulica,Hydraulic Lever Joints,,,1,1
+articolazioni_multiassiali,Articolazioni Multiassiali,Multi-Axial Joints,,,1,1
+artigli_acidofagi,Artigli Acidofagi,Artigli Acidofagi,foresta_acida,,1,1
+artigli_induzione,Artigli Induzione,Artigli Induzione,canopia_ionica,,1,1
+artigli_ipo_termici,Artigli Ipo-Termici,Hypothermal Claws,,,1,1
+artigli_radice,Artigli Radice,Artigli Radice,mangrovieto_cinetico,,1,1
+artigli_scivolo_silente,Artigli Scivolo Silente,Artigli Scivolo Silente,caverna_risonante,,1,1
+artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,caverna_risonante,,1,9
+artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,dorsale_termale_tropicale,cursoriale_quadrupede,1,9
+artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,mezzanotte_orbitale,cursoriale_quadrupede,1,9
+artigli_sghiaccio_glaciale,Artigli Sghiaccio Glaciale,Artigli Sghiaccio Glaciale,,,1,1
+artigli_vetrificati,Artigli Vetrificati,Artigli Vetrificati,caldera_glaciale,,1,1
+artiglio_cinetico_a_urto,Artiglio Cinetico a Urto,Kinetic Impact Claw,,,1,1
+aura_di_dispersione_mentale,Aura di Dispersione Mentale,Mental Dispersion Aura,,,1,1
+aura_scudo_radianza,Aura Scudo di Radianza,Radiant Shield Aura,,,1,1
+baffi_mareomotori,Baffi Mareomotori,Baffi Mareomotori,mangrovieto_cinetico,,1,1
+barbigli_sensori_plasma,Barbigli Sensori Plasma,Barbigli Sensori Plasma,stratosfera_tempestosa,,1,1
+barriere_miasma_glaciale,Barriere Miasma Glaciale,Barriere Miasma Glaciale,caldera_glaciale,,1,1
+batteri_endosimbionti_chemio,Batteri Endosimbionti Chemio,Batteri Endosimbionti Chemio,abisso_vulcanico,,1,1
+batteri_termofili_endosimbiosi,Batteri Termofili Endosimbiosi,Batteri Termofili Endosimbiosi,dorsale_termale_tropicale,,1,1
+bioantenne_gravitiche,Bioantenne Gravitiche,Gravitic Bio-Antennae,,,1,1
+biochip_memoria,Biochip Memoria,Biochip Memoria,steppe_algoritmiche,,1,1
+biofilm_glow,Biofilm Glow,Biofilm Glow,reef_luminescente,,1,1
+biofilm_iperarido,Biofilm Iperarido,Biofilm Iperarido,pianura_salina_iperarida,,1,1
+bozzolo_magnetico,Bozzolo Magnetico,Magnetic Cocoon,,,1,1
+branchie_dual_mode,Branchie Dual Mode,Branchie Dual Mode,laguna_bioreattiva,,1,1
+branchie_eoliche,Branchie Eoliche,Branchie Eoliche,stratosfera_tempestosa,,1,1
+branchie_metalloidi,Branchie Metalloidi,Branchie Metalloidi,abisso_vulcanico,,1,1
+branchie_microfiltri,Branchie Microfiltri,Branchie Microfiltri,reef_luminescente,,1,1
+branchie_osmotiche_salmastra,Branchie Osmotiche Salmastre,Branchie Osmotiche Salmastre,,,1,1
+branchie_solfatiche,Branchie Solfatiche,Branchie Solfatiche,caldera_glaciale,,1,1
+branchie_turbina,Branchie Turbina,Branchie Turbina,dorsale_termale_tropicale,,1,1
+bulbi_radici_permafrost,Bulbi Radici del Permafrost,Bulbi Radici del Permafrost,,,1,1
+camere_anticorrosione,Camere Anticorrosione,Camere Anticorrosione,foresta_acida,,1,1
+camere_mirage,Camere Mirage,Camere Mirage,pianura_salina_iperarida,,1,1
+camere_nutrienti_vent,Camere Nutrienti Vent,Camere Nutrienti Vent,dorsale_termale_tropicale,,1,1
+camere_risonanza_abyssal,Camere di Risonanza Abyssal,Abyssal Resonance Chambers,,,1,1
+campo_di_interferenza_acustica,Campo di Interferenza Acustica,Acoustic Interference Field,,,1,1
+cannone_sonico_a_raggio,Cannone Sonico a Raggio,Ray Sonic Cannon,,,1,1
+canto_infrasonico_tattico,Canto Infrasonico Tattico,Tactical Infrasonic Song,,,1,1
+canto_risonante,Canto Risonante,Resonant Chant,,,1,2
+capillari_criogenici,Capillari Criogenici,Capillari Criogenici,caldera_glaciale,,1,1
+capillari_fluoridici,Capillari Fluoridici,Capillari Fluoridici,foresta_acida,,1,1
+capillari_fotovoltaici,Capillari Fotovoltaici,Capillari Fotovoltaici,canopia_ionica,,1,1
+capsule_paracadute,Capsule Paracadute,Capsule Paracadute,stratosfera_tempestosa,,1,1
+carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,mezzanotte_orbitale,cursoriale_quadrupede,1,9
+carapace_luminiscente_abissale,Carapace Luminiscente Abissale,Carapace Luminiscente Abissale,,,1,1
+carapace_segmenti_logici,Carapace Segmenti Logici,Carapace Segmenti Logici,steppe_algoritmiche,,1,1
+carapaci_ferruginosi,Carapaci Ferruginosi,Carapaci Ferruginosi,abisso_vulcanico,,1,1
+cartilagine_flessotermica_venti,Cartilagine Flessotermica dei Venti,Cartilagine Flessotermica dei Venti,,,1,1
+cartilagini_biofibre,Cartilagini Biofibre,Cartilagini Biofibre,reef_luminescente,,1,1
+cartilagini_desertiche,Cartilagini Desertiche,Cartilagini Desertiche,pianura_salina_iperarida,,1,1
+cartilagini_flessoacustiche,Cartilagini Flessoacustiche,Cartilagini Flessoacustiche,caverna_risonante,,1,1
+cartilagini_pseudometalliche,Cartilagini Pseudometalliche,Cartilagini Pseudometalliche,abisso_vulcanico,,1,1
+cavita_risonanti_tundra,Cavità Risonanti della Tundra,Cavità Risonanti della Tundra,,,1,1
+cervelletto_equilibrio_statico,Cervelletto Equilibrio Statico,Cervelletto Equilibrio Statico,canopia_ionica,,1,1
+cervello_a_bassa_latenza,Cervello a Bassa Latenza,Low-Latency Brain,,,1,1
+chemiorecettori_bromuro,Chemiorecettori Bromuro,Chemiorecettori Bromuro,pianura_salina_iperarida,,1,1
+chioma_parassita_canopica,Chioma Parassita Canopica,Chioma Parassita Canopica,,,1,1
+cinghia_iper_ciliare,Cinghia Iper-Ciliare,Hyper-Ciliary Belt,,,1,1
+circolazione_bifasica,Circolazione Bifasica,Circolazione Bifasica,caldera_glaciale,,1,1
+circolazione_bifasica_palude,Circolazione Bifasica di Palude,Swamp Biphase Circulation,,,1,1
+circolazione_cooling_loop,Circolazione Cooling Loop,Circolazione Cooling Loop,steppe_algoritmiche,,1,1
+circolazione_doppia,Circolazione Doppia,Circolazione Doppia,dorsale_termale_tropicale,,1,1
+circolazione_supercritica,Circolazione Supercritica,Circolazione Supercritica,abisso_vulcanico,,1,1
+ciste_riduttive,Ciste Riduttive,Ciste Riduttive,laguna_bioreattiva,,1,1
+ciste_salmastre,Ciste Salmastre,Ciste Salmastre,pianura_salina_iperarida,,1,1
+cisti_di_ibernazione_minerale,Cisti di Ibernazione Minerale,Mineral Hibernation Cyst,,,1,1
+cisti_iperbariche,Cisti Iperbariche,Cisti Iperbariche,abisso_vulcanico,,1,1
+coda_balanciere,Coda Balanciere,Coda Balanciere,caverna_risonante,,1,1
+coda_contrappeso,Coda Contrappeso,Coda Contrappeso,mangrovieto_cinetico,,1,1
+coda_coppia_retroattiva,Coda Coppia Retroattiva,Coda Coppia Retroattiva,steppe_algoritmiche,,1,1
+coda_frusta_cinetica,Coda a Frusta Cinetica,Kinetic Lash Tail,dorsale_termale_tropicale,cursoriale_quadrupede,1,7
+coda_prensile_muscolare,Coda Prensile Muscolare,Muscular Prehensile Tail,,,1,1
+coda_stabilizzatrice_filo,Coda Stabilizzatrice Filo,Coda Stabilizzatrice Filo,canopia_ionica,,1,1
+coda_stabilizzatrice_geiser,Coda Stabilizzatrice Geiser,Coda Stabilizzatrice Geiser,dorsale_termale_tropicale,,1,1
+coda_stabilizzatrice_vortex,Coda Stabilizzatrice Vortex,Coda Stabilizzatrice Vortex,stratosfera_tempestosa,,1,1
+colonne_vibromagnetiche,Colonne Vibromagnetiche,Colonne Vibromagnetiche,caverna_risonante,,1,1
+comunicazione_fotonica_coda_coda,Comunicazione Fotonica Coda-Coda,Tail-to-Tail Photonic Communication,,,1,1
+coralli_partner,Coralli Partner,Coralli Partner,reef_luminescente,,1,1
+coralli_sinaptici_fotofase,Coralli Sinaptici Fotofase,Photophase Synaptic Corals,,,1,1
+corazze_ferro_magnetico,Corazze Ferro-Magnetico,Ferro-Magnetic Carapace,,,1,1
+corna_psico_conduttive,Corna Psico-Conduttive,Psycho-Conductive Horns,,,1,1
+coscienza_d_alveare_diffusa,Coscienza d’Alveare Diffusa,Diffuse Hive Consciousness,,,1,1
+coscienza_dalveare_diffusa,Coscienza d’Alveare Diffusa,Diffuse Hive Consciousness,,,1,1
+criostasi_adattiva,Criostasi,Adaptive Cryostasis,mezzanotte_orbitale,volatore_planatore,1,4
+cromofori_alert_acido,Cromofori Alert Acido,Cromofori Alert Acido,foresta_acida,,1,1
+cuore_multicamera_bassa_pressione,Cuore Multicamera Bassa Pressione,Cuore Multicamera Bassa Pressione,stratosfera_tempestosa,,1,1
+cuscinetti_elettrostatici,Cuscinetti Elettrostatici,Cuscinetti Elettrostatici,pianura_salina_iperarida,,1,1
+cute_resistente_sali,Cute Resistente Sali,Cute Resistente Sali,,,1,3
+cute_resistente_sali,Cute Resistente Sali,Cute Resistente Sali,badlands,,1,3
+cuticole_cerose,Cuticole Cerose,Cuticole Cerose,,,1,7
+cuticole_neutralizzanti,Cuticole Neutralizzanti,Cuticole Neutralizzanti,foresta_acida,,1,1
+denti_chelatanti,Denti Chelatanti,Denti Chelatanti,foresta_acida,,1,1
+denti_ossidoferro,Denti Ossidoferro,Denti Ossidoferro,abisso_vulcanico,,1,1
+denti_silice_termici,Denti Silice Termici,Denti Silice Termici,dorsale_termale_tropicale,,1,1
+denti_tuning_fork,Denti Tuning Fork,Denti Tuning Fork,caverna_risonante,,1,1
+echi_risonanti,Echi Risonanti,Echi Risonanti,caverna_risonante,,1,1
+eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,dorsale_termale_tropicale,volatore_planatore,1,7
+eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,mezzanotte_orbitale,volatore_planatore,1,7
+ectotermia_dinamica,Ectotermia Dinamica,Dynamic Ectothermy,,,1,1
+elettromagnete_biologico,Elettromagnete Biologico,Biological Electromagnet,,,1,1
+emettitori_voidsong,Emettitori Voidsong,Voidsong Emitters,,,1,1
+emolinfa_conducente,Emolinfa Conducente,Conductive Hemolymph,,,1,1
+empatia_coordinativa,Empatia Coordinativa,Coordinated Empathy,foresta_miceliale,,1,8
+enzimi_antifase_termica,Enzimi Antifase Termica,Enzimi Antifase Termica,caldera_glaciale,,1,1
+enzimi_antipredatori_algali,Enzimi Antipredatori Algali,Enzimi Antipredatori Algali,reef_luminescente,,1,1
+enzimi_chelanti,Enzimi Chelanti,Enzimi Chelanti,,,1,2
+enzimi_chelatori_rapidi,Enzimi Chelatori Rapidi,Enzimi Chelatori Rapidi,foresta_acida,,1,1
+enzimi_metanoossidanti,Enzimi Metanoossidanti,Enzimi Metanoossidanti,abisso_vulcanico,,1,1
+epidermide_dielettrica,Epidermide Dielettrica,Epidermide Dielettrica,stratosfera_tempestosa,,1,1
+epitelio_fosforescente,Epitelio Fosforescente,Epitelio Fosforescente,reef_luminescente,,1,1
+ermafroditismo_cronologico,Ermafroditismo Cronologico,Chronological Hermaphroditism,,,1,1
+estroflessione_gastrica_acida,Estroflessione Gastrica Acida,Acidic Gastric Extrusion,,,1,1
+fagocitosi_assorbente,Fagocitosi Assorbente,Absorptive Phagocytosis,,,1,1
+filamenti_digestivi_compattanti,Filamenti Digestivi Compattanti,Digestive Compaction Filaments,dorsale_termale_tropicale,scavenger_corazzato,1,8
+filamenti_digestivi_compattanti,Filamenti Digestivi Compattanti,Digestive Compaction Filaments,falde_magnetiche_psioniche,,1,8
+filamenti_digestivi_compattanti,Filamenti Digestivi Compattanti,Digestive Compaction Filaments,foresta_miceliale,,1,8
+filamenti_digestivi_compattanti,Filamenti Digestivi Compattanti,Digestive Compaction Filaments,mezzanotte_orbitale,scavenger_corazzato,1,8
+filamenti_echo,Filamenti Echo,Echo Filaments,,,1,1
+filamenti_guidalampo,Filamenti Guidalampo,Lightning Guide Filaments,,,1,1
+filamenti_magnetotrofi,Filamenti Magnetotrofi,Filamenti Magnetotrofi,abisso_vulcanico,,1,1
+filamenti_superconduttivi,Filamenti Superconduttivi,Filamenti Superconduttivi,caldera_glaciale,,1,1
+filamenti_termoconduzione,Filamenti Termoconduzione,Filamenti Termoconduzione,dorsale_termale_tropicale,,1,1
+filtrazione_osmotica,Filtrazione Osmotica,Osmotic Filtration,,,1,1
+filtri_planctonici,Filtri Planctonici,Filtri Planctonici,laguna_bioreattiva,,1,1
+filtro_metallofago,Filtro Metallofago,Metallophagous Filter,,,1,1
+flagelli_ancoranti,Flagelli Ancoranti,Flagelli Ancoranti,laguna_bioreattiva,,1,1
+flusso_ameboide_controllato,Flusso Ameboide Controllato,Controlled Amoeboid Flow,,,1,1
+focus_frazionato,Focus Frazionato,Fractional Focus,canopia_psionica_leggera,,1,8
+focus_frazionato,Focus Frazionato,Fractional Focus,foresta_miceliale,,1,8
+focus_frazionato,Focus Frazionato,Fractional Focus,orbita_psionica_inversa,,1,8
+foliage_fotocatodico,Foliage Fotocatodico,Foliage Fotocatodico,foresta_acida,,1,1
+foliaggio_spugna,Foliaggio Spugna,Foliaggio Spugna,mangrovieto_cinetico,,1,1
+frusta_fiammeggiante,Frusta Fiammeggiante,Flame Lash,,,1,2
+ghiaccio_piezoelettrico,Ghiaccio Piezoelettrico,Ghiaccio Piezoelettrico,caldera_glaciale,,1,1
+ghiandola_caustica,Ghiandola Caustica,Caustic Gland,foresta_miceliale,,1,2
+ghiandole_cambio_salino,Ghiandole Cambio Salino,Ghiandole Cambio Salino,laguna_bioreattiva,,1,1
+ghiandole_condensa_ozono,Ghiandole Condensa Ozono,Ghiandole Condensa Ozono,stratosfera_tempestosa,,1,1
+ghiandole_eco_mappanti,Ghiandole Eco Mappanti,Ghiandole Eco Mappanti,caverna_risonante,,1,1
+ghiandole_fango_calde,Ghiandole Fango Calde,Ghiandole Fango Calde,abisso_vulcanico,,1,1
+ghiandole_fango_coesivo,Ghiandole Fango Coesivo,Ghiandole Fango Coesivo,mangrovieto_cinetico,,1,1
+ghiandole_grafene,Ghiandole Grafene,Ghiandole Grafene,steppe_algoritmiche,,1,1
+ghiandole_inchiostro_luce,Ghiandole Inchiostro Luce,Ghiandole Inchiostro Luce,reef_luminescente,,1,1
+ghiandole_iodoattive,Ghiandole Iodoattive,Ghiandole Iodoattive,pianura_salina_iperarida,,1,1
+ghiandole_minerali,Ghiandole Minerali,Ghiandole Minerali,dorsale_termale_tropicale,,1,1
+ghiandole_mnemoniche,Ghiandole Mnemoniche,Mnemonic Glands,,,1,1
+ghiandole_nebbia_acida,Ghiandole Nebbia Acida,Ghiandole Nebbia Acida,foresta_acida,,1,1
+ghiandole_nebbia_ionica,Ghiandole Nebbia Ionica,Ghiandole Nebbia Ionica,canopia_ionica,,1,1
+ghiandole_resina_conduttiva,Ghiandole Resina Conduttiva,Ghiandole Resina Conduttiva,canopia_ionica,,1,1
+ghiandole_ventosa,Ghiandole Ventosa,Ghiandole Ventosa,caldera_glaciale,,1,1
+giunti_antitorsione,Giunti Antitorsione,Giunti Antitorsione,mangrovieto_cinetico,,1,1
+grassi_termici,Grassi Termici,Grassi Termici,,,1,7
+gusci_criovetro,Gusci Criovetro,Gusci Criovetro,caldera_glaciale,,1,1
+gusci_magnesio,Gusci Magnesio,Gusci Magnesio,dorsale_termale_tropicale,,1,1
+impulsi_bioluminescenti,Impulsi Bioluminescenti,Bioluminescent Pulses,,,1,2
+integumento_bipolare,Integumento Bipolare,Bipolar Integument,,,1,1
+ipertrofia_muscolare_massiva,Ipertrofia Muscolare Massiva,Massive Muscular Hypertrophy,,,1,1
+lamelle_shear,Lamelle Shear,Lamelle Shear,stratosfera_tempestosa,,1,1
+lamelle_sincroniche,Lamelle Sincroniche,Lamelle Sincroniche,steppe_algoritmiche,,1,1
+lamelle_termoforetiche,Lamelle Termoforetiche,Thermophoretic Lamellae,,,1,5
+lamine_filtranti_aeree,Lamine Filtranti Aeree,Lamine Filtranti Aeree,mangrovieto_cinetico,,1,1
+lamine_scudo_silice,Lamine Scudo Silice,Lamine Scudo Silice,dorsale_termale_tropicale,,1,1
+linfa_tampone,Linfa Tampone,Linfa Tampone,foresta_acida,,1,1
+lingua_cristallina,Lingua Cristallina,Lingua Cristallina,pianura_salina_iperarida,,1,1
+lingua_tattile_trama,Lingua Tattile Trama-Sensibile,Texture-Sensing Tongue,foresta_miceliale,,1,4
+lobi_risonanti_crepuscolo,Lobi Risonanti Crepuscolo,Twilight Resonant Lobes,,,1,3
+locomozione_miriapode_ibrida,Locomozione Miriapode Ibrida,Hybrid Myriapod Locomotion,,,1,1
+luminescenza_aurorale,Luminescenza Aurorale,Luminescenza Aurorale,caldera_glaciale,,1,1
+luminescenza_hydrotermica,Luminescenza Hydrotermica,Luminescenza Hydrotermica,abisso_vulcanico,,1,1
+mantelli_geotermici,Mantelli Geotermici,Mantelli Geotermici,caldera_glaciale,,1,1
+mantello_meteoritico,Mantello Meteoritico,Meteoric Mantle,,,1,2
+membrana_plastica_continua,Membrana Plastica Continua,Continuous Plastic Membrane,,,1,1
+membrane_captura_rugiada,Membrane Captura Rugiada,Membrane Captura Rugiada,pianura_salina_iperarida,,1,1
+membrane_eliofiltranti,Membrane Eliofiltranti,Membrane Eliofiltranti,,,1,1
+membrane_fotoconvoglianti,Membrane Fotoconvoglianti,Photoconductive Membranes,,,1,1
+membrane_planata_vectored,Membrane Planata Vectored,Membrane Planata Vectored,canopia_ionica,,1,1
+membrane_pneumatofori,Membrane Pneumatofori,Membrane Pneumatofori,mangrovieto_cinetico,,1,1
+metabolismo_di_condivisione_energetica,Metabolismo di Condivisione Energetica,Shared Energy Metabolism,,,1,1
+midollo_antivibrazione,Midollo Antivibrazione,Midollo Antivibrazione,caverna_risonante,,1,1
+mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,canopia_psionica_leggera,,1,6
+mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,dorsale_termale_tropicale,ingegnere_radicante,1,6
+mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,mezzanotte_orbitale,volatore_planatore,1,6
+moltiplicazione_per_fusione,Moltiplicazione per Fusione,Fusion Multiplication,,,1,1
+motore_biologico_silenzioso,Motore Biologico Silenzioso,Silent Biological Engine,,,1,1
+mucillagine_simbionte_mangrovie,Mucillagine Simbionte delle Mangrovie,Mucillagine Simbionte delle Mangrovie,,,1,1
+mucose_aderenza_sonica,Mucose Aderenza Sonica,Mucose Aderenza Sonica,caverna_risonante,,1,1
+mucose_barofile,Mucose Barofile,Mucose Barofile,abisso_vulcanico,,1,1
+nebbia_mnesica,Nebbia Mnesica,Mnesic Fog,,,1,1
+nodi_micorrizici_oracolari,Nodi Micorrizici Oracolari,Nodi Micorrizici Oracolari,,,1,1
+nodi_sinaptici_superficiali,Nodi Sinaptici Superficiali,Surface Synaptic Nodes,,,1,1
+nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,dorsale_termale_tropicale,cursoriale_quadrupede,1,2
+nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,falde_magnetiche_psioniche,,1,2
+nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,orbita_psionica_inversa,,1,2
+occhi_analizzatori_di_tensione,Occhi Analizzatori di Tensione,Tension-Analyzing Eyes,,,1,1
+occhi_cinetici,Occhi Cinetici,Kinetic Eyes,,,1,1
+occhi_cristallo_modulare,Occhi a Cristallo Modulare,Modular Crystal Eyes,,,1,2
+occhi_infrarosso_composti,Occhi Composti ad Infrarosso,Infrared Compound Eyes,dorsale_termale_tropicale,volatore_planatore,1,2
+olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,dorsale_termale_tropicale,cursoriale_quadrupede,1,9
+olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,falde_magnetiche_psioniche,,1,9
+olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,mezzanotte_orbitale,cursoriale_quadrupede,1,9
+olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,orbita_psionica_inversa,,1,9
+organi_metacronici,Organi Metacronici,Metachronic Organs,,,1,1
+organi_sismici_cutanei,Organi Sismici Cutanei,Cutaneous Seismic Organs,,,1,1
+pathfinder,Pathfinder,Pathfinder,foresta_miceliale,,1,2
+pelage_idrorepellente_avanzato,Pelage Idrorepellente Avanzato,Advanced Hydrophobic Pelage,,,1,1
+pelle_piezo_satura,Pelle Piezo-Satura,Piezo-Saturated Skin,,,1,1
+pianificatore,Pianificatore,Strategic Planner,foresta_miceliale,,1,1
+piume_solari_fotovoltaiche,Piume Solari Fotovoltaiche,Piume Solari Fotovoltaiche,,,1,1
+placca_diffusione_foschia,Placca di Diffusione Foschia,Fog Diffusion Plate,,,1,1
+placche_pressioniche,Placche Pressioniche,Pressure Plates,,,1,1
+polmoni_cristallini_alta_quota,Polmoni Cristallini d'Alta Quota,Polmoni Cristallini d'Alta Quota,,,1,1
+random,Trait Random,Trait Random,,,1,3
+respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,dorsale_termale_tropicale,scavenger_corazzato,1,6
+respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,mezzanotte_orbitale,cursoriale_quadrupede,1,6
+rete_filtro_polmonare,Rete Filtro-Polmonare,Pulmonary Filter Net,,,1,1
+risonanza_di_branco,Risonanza di Branco,Pack Resonance,foresta_miceliale,,1,6
+riverbero_memetico,Riverbero Memetico,Memetic Reverb,,,1,2
+rostro_emostatico_litico,Rostro Emostatico-Litico,Hemo-Lytic Rostrum,,,1,1
+rostro_linguale_prensile,Rostro Linguale Prensile,Prehensile Lingual Rostrum,,,1,1
+sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,canopia_psionica_leggera,,1,8
+sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,dorsale_termale_tropicale,cursoriale_quadrupede,1,8
+sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,mezzanotte_orbitale,volatore_planatore,1,8
+sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,orbita_psionica_inversa,,1,8
+sacche_spore_stratosferiche,Sacche di Spore Stratosferiche,Sacche di Spore Stratosferiche,,,1,1
+sangue_piroforico,Sangue che prende fuoco a contatto con l'ossigeno,Pyrophoric Blood,dorsale_termale_tropicale,ingegnere_radicante,1,4
+sangue_piroforico,Sangue che prende fuoco a contatto con l'ossigeno,Pyrophoric Blood,mezzanotte_orbitale,scavenger_corazzato,1,4
+scheletro_idraulico_a_pistoni,Scheletro Idraulico a Pistoni,Piston Hydraulic Skeleton,,,1,1
+scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,dorsale_termale_tropicale,cursoriale_quadrupede,1,10
+scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,dorsale_termale_tropicale,scavenger_corazzato,1,10
+scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,mezzanotte_orbitale,cursoriale_quadrupede,1,10
+scheletro_pneumatico_a_maglie,Scheletro Pneumatico a Maglie,Latticed Pneumatic Skeleton,,,1,1
+scintilla_sinaptica,Scintilla Sinaptica,Synaptic Spark,,,1,2
+scivolamento_magnetico,Scivolamento Magnetico,Magnetic Gliding,,,1,1
+scudo_gluteale_cheratinizzato,Scudo Gluteale Cheratinizzato,Keratinized Gluteal Shield,,,1,1
+secrezione_rallentante_palmi,Mani secernano liquido rallentante,Retarding Palm Secretions,dorsale_termale_tropicale,ingegnere_radicante,1,2
+secrezioni_antistatiche,Secrezioni Antistatiche,Antistatic Secretions,,,1,1
+sensori_geomagnetici,Sensori a Risonanza Geomagnetica,Geomagnetic Resonance Sensors,,,1,4
+sensori_planctonici,Sensori Planctonici,Planctonic Sensors,,,1,1
+seta_conduttiva_elettrica,Seta Conduttiva Elettrica,Conductive Electric Silk,,,1,1
+siero_anti_gelo_naturale,Siero Anti-Gelo Naturale,Natural Anti-Freeze Serum,,,1,1
+sinapsi_coraline_polifoniche,Sinapsi Coraline Polifoniche,Sinapsi Coraline Polifoniche,,,1,1
+sistemi_chimio_sonici,Sistemi Chimio-Sonici,Chemo-Sonic Systems,,,1,1
+sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,dorsale_termale_tropicale,volatore_planatore,1,3
+sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,mezzanotte_orbitale,volatore_planatore,1,3
+spicole_canalizzatrici,Spicole Canalizzatrici,Channeling Spicules,,,1,1
+spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,dorsale_termale_tropicale,scavenger_corazzato,1,2
+spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,foresta_miceliale,,1,2
+spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,mezzanotte_orbitale,scavenger_corazzato,1,2
+squame_diffusori_ionici,Squame Diffusori Ionici,Ionic Diffuser Scales,,,1,1
+squame_rifrangenti_deserto,Squame Rifrangenti del Deserto,Squame Rifrangenti del Deserto,,,1,1
+struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,canopia_psionica_leggera,,1,9
+struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,dorsale_termale_tropicale,cursoriale_quadrupede,1,9
+struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,falde_magnetiche_psioniche,,1,9
+struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,foresta_miceliale,,1,9
+tattiche_di_branco,Tattiche di Branco,Pack Tactics,foresta_miceliale,,1,3
+traits_aggregate,Aggregato tratti Evo,Evo Traits Aggregate,,,1,1
+unghie_a_micro_adesione,Unghie a Micro-Adesione,Micro-Adhesion Claws,,,1,1
+vello_condensatore_nebbie,Vello Condensatore di Nebbie,Vello Condensatore di Nebbie,,,1,1
+vello_di_assorbimento_totale,Vello di Assorbimento Totale,Total Absorption Fleece,,,1,1
+ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,dorsale_termale_tropicale,scavenger_corazzato,1,4
+ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,mezzanotte_orbitale,cursoriale_quadrupede,1,4
+visione_multi_spettrale_amplificata,Visione Multi-Spettrale Amplificata,Amplified Multi-Spectral Vision,,,1,1
+vortice_nera_flash,Vortice Nera Flash,Black Vortex Flash,,,1,2
+zampe_a_molla,Zampe a Molla,Spring-Loaded Limbs,,,1,1
+zanne_idracida,Zanne Idracida,Hydra-Acid Tusks,,,1,1
+zoccoli_risonanti_steppe,Zoccoli Risonanti delle Steppe,Zoccoli Risonanti delle Steppe,,,1,1

--- a/data/derived/analysis/trait_coverage_report.json
+++ b/data/derived/analysis/trait_coverage_report.json
@@ -1,20 +1,23 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2025-12-02T22:45:39.756004+00:00",
+  "generated_at": "2025-12-03T01:47:58+00:00",
   "sources": {
     "env_traits": "packs/evo_tactics_pack/docs/catalog/env_traits.json",
     "trait_reference": "data/traits/index.json",
-    "trait_glossary": "/workspace/Game/data/core/traits/glossary.json",
+    "trait_glossary": "data/core/traits/glossary.json",
     "species_root": "packs/evo_tactics_pack/data/species",
-    "glossary": "data/core/traits/glossary.json"
+    "species_affinity": "data/traits/species_affinity.json"
   },
   "summary": {
     "traits_total": 254,
     "traits_with_rules": 254,
     "traits_with_species": 254,
-    "rule_combos_total": 254,
-    "species_combos_total": 254,
+    "traits_with_affinity": 254,
+    "rule_combos_total": 284,
+    "species_combos_total": 284,
     "rules_missing_species_total": 0,
+    "affinity_missing_species_total": 0,
+    "affinity_missing_matrix_total": 0,
     "traits_missing_species": [],
     "traits_missing_rules": []
   },
@@ -22,5590 +25,11982 @@
     "ali_fono_risonanti": {
       "label_it": "Ali Fono-Risonanti",
       "label_en": "Phono-Resonant Wings",
+      "description_it": "Generare ampia banda sonora in volo.",
+      "description_en": "Generate a wide sonic band while flying.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "banshee-risonante",
+              "psionic-canopy-scout"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Generare ampia banda sonora in volo.",
-      "description_en": "Generate a wide sonic band while flying."
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 1
+        },
+        "top_species": [
+          "banshee-risonante",
+          "psionic-canopy-scout"
+        ]
+      }
     },
     "ali_fulminee": {
       "label_it": "Ali Fulminee",
       "label_en": "Ali Fulminee",
+      "description_it": "Ali Fulminee permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di stratosfera tempestosa.",
+      "description_en": "Ali Fulminee allow squads to interpret minute signals and unstable psionic patterns within stratosfera tempestosa.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ali Fulminee permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di stratosfera tempestosa.",
-      "description_en": "Ali Fulminee allow squads to interpret minute signals and unstable psionic patterns within stratosfera tempestosa."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
+      }
     },
     "ali_ioniche": {
       "label_it": "Ali Ioniche",
       "label_en": "Ionic Wings",
+      "description_it": "Membrane propulsive che rilasciano micro-scariche per scatti controllati.",
+      "description_en": "Propulsive membranes that pulse micro-discharges for controlled bursts.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Membrane propulsive che rilasciano micro-scariche per scatti controllati.",
-      "description_en": "Propulsive membranes that pulse micro-discharges for controlled bursts."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "canopia-ionica-trait-keeper"
+        ]
+      }
     },
     "ali_membrana_sonica": {
       "label_it": "Ali a Membrana Sonica",
       "label_en": "Sonic Membrane Wings",
+      "description_it": "Piastre vibranti che dissipano energia e attenuano impatti corrosivi.",
+      "description_en": "Vibrating plates that dissipate energy and blunt corrosive impacts.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Piastre vibranti che dissipano energia e attenuano impatti corrosivi.",
-      "description_en": "Vibrating plates that dissipate energy and blunt corrosive impacts."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
+      }
     },
     "ali_solari_fotoni": {
       "label_it": "Ali Solari Fotoniche",
       "label_en": "Solar Photon Wings",
+      "description_it": "Piume fotovoltaiche che trasformano luce in spinta e schermature di radianza.",
+      "description_en": "Photovoltaic feathers that convert light into thrust and radiant shielding.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "archon-solare",
+              "couatl-aurora"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Piume fotovoltaiche che trasformano luce in spinta e schermature di radianza.",
-      "description_en": "Photovoltaic feathers that convert light into thrust and radiant shielding."
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "optional": 2
+        },
+        "top_species": [
+          "archon-solare",
+          "couatl-aurora"
+        ]
+      }
     },
     "antenne_dustsense": {
       "label_it": "Antenne Dustsense",
       "label_en": "Dustsense Antennae",
+      "description_it": "Ricettori stratificati che stabilizzano l’assorbimento multi-fonte in deserti ionici.",
+      "description_en": "Layered receptors stabilising multi-source absorption across ionic deserts.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ricettori stratificati che stabilizzano l’assorbimento multi-fonte in deserti ionici.",
-      "description_en": "Layered receptors stabilising multi-source absorption across ionic deserts."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
+      }
     },
     "antenne_eco_turbina": {
       "label_it": "Antenne Eco Turbina",
       "label_en": "Antenne Eco Turbina",
+      "description_it": "Antenne Eco Turbina permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale.",
+      "description_en": "Antenne Eco Turbina allow squads to coordinate resource exchange and squad stabilisation parameters within dorsale termale tropicale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Antenne Eco Turbina permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale.",
-      "description_en": "Antenne Eco Turbina allow squads to coordinate resource exchange and squad stabilisation parameters within dorsale termale tropicale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      }
     },
     "antenne_flusso_mareale": {
       "label_it": "Antenne Flusso Mareale",
       "label_en": "Antenne Flusso Mareale",
+      "description_it": "Antenne Flusso Mareale permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di laguna bioreattiva.",
+      "description_en": "Antenne Flusso Mareale allow squads to channel kinetic or elemental energy into targeted strikes within laguna bioreattiva.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Antenne Flusso Mareale permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di laguna bioreattiva.",
-      "description_en": "Antenne Flusso Mareale allow squads to channel kinetic or elemental energy into targeted strikes within laguna bioreattiva."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "laguna-bioreattiva-trait-keeper"
+        ]
+      }
     },
     "antenne_microonde_cavernose": {
       "label_it": "Antenne Microonde Cavernose",
       "label_en": "Antenne Microonde Cavernose",
+      "description_it": "Antenne Microonde Cavernose permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di caverna risonante.",
+      "description_en": "Antenne Microonde Cavernose allow squads to predict trajectories and orchestrate multilayered setups within caverna risonante.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Antenne Microonde Cavernose permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di caverna risonante.",
-      "description_en": "Antenne Microonde Cavernose allow squads to predict trajectories and orchestrate multilayered setups within caverna risonante."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
+      }
     },
     "antenne_plasmatiche_tempesta": {
       "label_it": "Antenne Plasmatiche di Tempesta",
       "label_en": "Storm Plasma Antennae",
+      "description_it": "Convoglia fulmini atmosferici in attacchi mirati o scudi ionici.",
+      "description_en": "Channels storm lightning into psionic strikes or shields.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "cicloni-psionici-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Convoglia fulmini atmosferici in attacchi mirati o scudi ionici.",
-      "description_en": "Channels storm lightning into psionic strikes or shields."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "cicloni-psionici-trait-keeper"
+        ]
+      }
     },
     "antenne_reagenti": {
       "label_it": "Antenne Reagenti",
       "label_en": "Antenne Reagenti",
+      "description_it": "Antenne Reagenti permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di foresta acida.",
+      "description_en": "Antenne Reagenti allow squads to synchronise allied organisms and mutualistic flows within foresta acida.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Antenne Reagenti permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di foresta acida.",
-      "description_en": "Antenne Reagenti allow squads to synchronise allied organisms and mutualistic flows within foresta acida."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
+      }
     },
     "antenne_tesla": {
       "label_it": "Antenne Tesla",
       "label_en": "Antenne Tesla",
+      "description_it": "Antenne Tesla permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di canopia ionica.",
+      "description_en": "Antenne Tesla allow squads to redistribute load and modulate structural rigidity within canopia ionica.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Antenne Tesla permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di canopia ionica.",
-      "description_en": "Antenne Tesla allow squads to redistribute load and modulate structural rigidity within canopia ionica."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "canopia-ionica-trait-keeper"
+        ]
+      }
     },
     "antenne_waveguide": {
       "label_it": "Antenne Waveguide",
       "label_en": "Antenne Waveguide",
+      "description_it": "Antenne Waveguide permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di reef luminescente.",
+      "description_en": "Antenne Waveguide allow squads to interpret minute signals and unstable psionic patterns within reef luminescente.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Antenne Waveguide permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di reef luminescente.",
-      "description_en": "Antenne Waveguide allow squads to interpret minute signals and unstable psionic patterns within reef luminescente."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "reef-luminescente-trait-keeper"
+        ]
+      }
     },
     "antenne_wideband": {
       "label_it": "Antenne Wideband",
       "label_en": "Antenne Wideband",
+      "description_it": "Antenne Wideband permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di steppe algoritmiche.",
+      "description_en": "Antenne Wideband allow squads to gain grip and controlled acceleration across extreme terrain within steppe algoritmiche.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "steppe-algoritmiche-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Antenne Wideband permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di steppe algoritmiche.",
-      "description_en": "Antenne Wideband allow squads to gain grip and controlled acceleration across extreme terrain within steppe algoritmiche."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "steppe-algoritmiche-trait-keeper"
+        ]
+      }
     },
     "appendici_risonanti_marea": {
       "label_it": "Appendici Risonanti Marea",
       "label_en": "Appendici Risonanti Marea",
+      "description_it": "Appendici Risonanti Marea permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di laguna bioreattiva.",
+      "description_en": "Appendici Risonanti Marea allow squads to disperse energy and attenuate corrosive or thermal impacts within laguna bioreattiva.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Appendici Risonanti Marea permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di laguna bioreattiva.",
-      "description_en": "Appendici Risonanti Marea allow squads to disperse energy and attenuate corrosive or thermal impacts within laguna bioreattiva."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "laguna-bioreattiva-trait-keeper"
+        ]
+      }
     },
     "appendici_thermotattiche": {
       "label_it": "Appendici Thermotattiche",
       "label_en": "Appendici Thermotattiche",
+      "description_it": "Appendici Thermotattiche permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di abisso vulcanico.",
+      "description_en": "Appendici Thermotattiche allow squads to stabilise multi-source energy absorption and conversion within abisso vulcanico.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Appendici Thermotattiche permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di abisso vulcanico.",
-      "description_en": "Appendici Thermotattiche allow squads to stabilise multi-source energy absorption and conversion within abisso vulcanico."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      }
     },
     "armatura_pietra_planare": {
       "label_it": "Armatura di Pietra Planare",
       "label_en": "Planar Stone Plating",
+      "description_it": "Corazza risonante scolpita da roccia extradimensionale che smorza onde d'urto.",
+      "description_en": "Resonant plating carved from extradimensional stone that dampens shockwaves.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 4,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 4,
+            "examples": [
+              "balor-fission",
+              "bulette-fase",
+              "golem-runico",
+              "treant-portale"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Corazza risonante scolpita da roccia extradimensionale che smorza onde d'urto.",
-      "description_en": "Resonant plating carved from extradimensional stone that dampens shockwaves."
+      "affinity": {
+        "total_species": 4,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 4
+        },
+        "top_species": [
+          "golem-runico",
+          "balor-fission",
+          "bulette-fase",
+          "treant-portale"
+        ]
+      }
     },
     "articolazioni_a_leva_idraulica": {
       "label_it": "Articolazioni a Leva Idraulica",
       "label_en": "Hydraulic Lever Joints",
+      "description_it": "Amplificare salto e spinta delle zampe.",
+      "description_en": "Amplify leaps and leg thrusts.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Amplificare salto e spinta delle zampe.",
-      "description_en": "Amplify leaps and leg thrusts."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "articolazioni_multiassiali": {
       "label_it": "Articolazioni Multiassiali",
       "label_en": "Multi-Axial Joints",
+      "description_it": "Ruotare arti per manovre strette.",
+      "description_en": "Rotate limbs for tight maneuvers.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ruotare arti per manovre strette.",
-      "description_en": "Rotate limbs for tight maneuvers."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "artigli_acidofagi": {
       "label_it": "Artigli Acidofagi",
       "label_en": "Artigli Acidofagi",
+      "description_it": "Artigli Acidofagi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di foresta acida.",
+      "description_en": "Artigli Acidofagi allow squads to coordinate resource exchange and squad stabilisation parameters within foresta acida.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Artigli Acidofagi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di foresta acida.",
-      "description_en": "Artigli Acidofagi allow squads to coordinate resource exchange and squad stabilisation parameters within foresta acida."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
+      }
     },
     "artigli_induzione": {
       "label_it": "Artigli Induzione",
       "label_en": "Artigli Induzione",
+      "description_it": "Artigli Induzione permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di canopia ionica.",
+      "description_en": "Artigli Induzione allow squads to channel kinetic or elemental energy into targeted strikes within canopia ionica.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Artigli Induzione permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di canopia ionica.",
-      "description_en": "Artigli Induzione allow squads to channel kinetic or elemental energy into targeted strikes within canopia ionica."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "canopia-ionica-trait-keeper"
+        ]
+      }
     },
     "artigli_ipo_termici": {
       "label_it": "Artigli Ipo-Termici",
       "label_en": "Hypothermal Claws",
+      "description_it": "Indurre shock da freddo localizzato.",
+      "description_en": "Induce localized cold shock.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Indurre shock da freddo localizzato.",
-      "description_en": "Induce localized cold shock."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "artigli_radice": {
       "label_it": "Artigli Radice",
       "label_en": "Artigli Radice",
+      "description_it": "Artigli Radice permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di mangrovieto cinetico.",
+      "description_en": "Artigli Radice allow squads to predict trajectories and orchestrate multilayered setups within mangrovieto cinetico.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Artigli Radice permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di mangrovieto cinetico.",
-      "description_en": "Artigli Radice allow squads to predict trajectories and orchestrate multilayered setups within mangrovieto cinetico."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
+      }
     },
     "artigli_scivolo_silente": {
       "label_it": "Artigli Scivolo Silente",
       "label_en": "Artigli Scivolo Silente",
+      "description_it": "Artigli Scivolo Silente permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di caverna risonante.",
+      "description_en": "Artigli Scivolo Silente allow squads to synchronise allied organisms and mutualistic flows within caverna risonante.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Artigli Scivolo Silente permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di caverna risonante.",
-      "description_en": "Artigli Scivolo Silente allow squads to synchronise allied organisms and mutualistic flows within caverna risonante."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
+      }
     },
     "artigli_sette_vie": {
       "label_it": "Artigli a Sette Vie",
       "label_en": "Seven-Way Talons",
+      "description_it": "Artigli multipli che assicurano presa stabile su superfici irregolari.",
+      "description_en": "Multi-hook talons locking a steady grip on irregular surfaces.",
       "rules": {
-        "total": 1,
+        "total": 3,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 27,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 9,
+            "examples": [
+              "balor-fission",
+              "caverna-risonante-trait-keeper",
+              "couatl-aurora",
+              "cryo-lynx",
+              "dune-stalker"
+            ]
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 9,
+            "examples": [
+              "balor-fission",
+              "caverna-risonante-trait-keeper",
+              "couatl-aurora",
+              "cryo-lynx",
+              "dune-stalker"
+            ]
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 9,
+            "examples": [
+              "balor-fission",
+              "caverna-risonante-trait-keeper",
+              "couatl-aurora",
+              "cryo-lynx",
+              "dune-stalker"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Artigli multipli che assicurano presa stabile su superfici irregolari.",
-      "description_en": "Multi-hook talons locking a steady grip on irregular surfaces."
+      "affinity": {
+        "total_species": 9,
+        "roles_breakdown": {
+          "core": 2,
+          "optional": 9
+        },
+        "top_species": [
+          "dune-stalker",
+          "magneto-ridge-hunter",
+          "balor-fission",
+          "caverna-risonante-trait-keeper",
+          "couatl-aurora",
+          "cryo-lynx",
+          "marilith-vault",
+          "otyugh-sentinella",
+          "resonant-claw-hunter"
+        ]
+      }
     },
     "artigli_sghiaccio_glaciale": {
       "label_it": "Artigli Sghiaccio Glaciale",
       "label_en": "Artigli Sghiaccio Glaciale",
+      "description_it": "Falangi criogeniche che congelano e fissano il bersaglio al contatto.",
+      "description_en": "Cryogenic claws that freeze and pin targets on contact.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "calotte-glaciali-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Falangi criogeniche che congelano e fissano il bersaglio al contatto.",
-      "description_en": "Cryogenic claws that freeze and pin targets on contact."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "calotte-glaciali-trait-keeper"
+        ]
+      }
     },
     "artigli_vetrificati": {
       "label_it": "Artigli Vetrificati",
       "label_en": "Artigli Vetrificati",
+      "description_it": "Artigli Vetrificati permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di caldera glaciale.",
+      "description_en": "Artigli Vetrificati allow squads to redistribute load and modulate structural rigidity within caldera glaciale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Artigli Vetrificati permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di caldera glaciale.",
-      "description_en": "Artigli Vetrificati allow squads to redistribute load and modulate structural rigidity within caldera glaciale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      }
     },
     "artiglio_cinetico_a_urto": {
       "label_it": "Artiglio Cinetico a Urto",
       "label_en": "Kinetic Impact Claw",
+      "description_it": "Infliggere onda d’urto e frattura.",
+      "description_en": "Deliver shockwaves that fracture targets.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Infliggere onda d’urto e frattura.",
-      "description_en": "Deliver shockwaves that fracture targets."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "aura_di_dispersione_mentale": {
       "label_it": "Aura di Dispersione Mentale",
       "label_en": "Mental Dispersion Aura",
+      "description_it": "Campo di odori avversivi ed emissioni deboli che induce ansia e vertigini nei predatori.",
+      "description_en": "Aversive odors and weak emissions that instill anxiety and vertigo in predators.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Campo di odori avversivi ed emissioni deboli che induce ansia e vertigini nei predatori.",
-      "description_en": "Aversive odors and weak emissions that instill anxiety and vertigo in predators."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "aura_scudo_radianza": {
       "label_it": "Aura Scudo di Radianza",
       "label_en": "Radiant Shield Aura",
+      "description_it": "Campo fotoplasmatico che devia danni planari e sincronizza i battiti della squadra.",
+      "description_en": "Photoplasmic field that deflects planar damage while syncing squad vitals.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "archon-solare"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Campo fotoplasmatico che devia danni planari e sincronizza i battiti della squadra.",
-      "description_en": "Photoplasmic field that deflects planar damage while syncing squad vitals."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 1
+        },
+        "top_species": [
+          "archon-solare"
+        ]
+      }
     },
     "baffi_mareomotori": {
       "label_it": "Baffi Mareomotori",
       "label_en": "Baffi Mareomotori",
+      "description_it": "Baffi Mareomotori permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di mangrovieto cinetico.",
+      "description_en": "Baffi Mareomotori allow squads to interpret minute signals and unstable psionic patterns within mangrovieto cinetico.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Baffi Mareomotori permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di mangrovieto cinetico.",
-      "description_en": "Baffi Mareomotori allow squads to interpret minute signals and unstable psionic patterns within mangrovieto cinetico."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
+      }
     },
     "barbigli_sensori_plasma": {
       "label_it": "Barbigli Sensori Plasma",
       "label_en": "Barbigli Sensori Plasma",
+      "description_it": "Barbigli Sensori Plasma permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di stratosfera tempestosa.",
+      "description_en": "Barbigli Sensori Plasma allow squads to gain grip and controlled acceleration across extreme terrain within stratosfera tempestosa.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Barbigli Sensori Plasma permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di stratosfera tempestosa.",
-      "description_en": "Barbigli Sensori Plasma allow squads to gain grip and controlled acceleration across extreme terrain within stratosfera tempestosa."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
+      }
     },
     "barriere_miasma_glaciale": {
       "label_it": "Barriere Miasma Glaciale",
       "label_en": "Barriere Miasma Glaciale",
+      "description_it": "Barriere Miasma Glaciale permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di caldera glaciale.",
+      "description_en": "Barriere Miasma Glaciale allow squads to disperse energy and attenuate corrosive or thermal impacts within caldera glaciale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Barriere Miasma Glaciale permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di caldera glaciale.",
-      "description_en": "Barriere Miasma Glaciale allow squads to disperse energy and attenuate corrosive or thermal impacts within caldera glaciale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      }
     },
     "batteri_endosimbionti_chemio": {
       "label_it": "Batteri Endosimbionti Chemio",
       "label_en": "Batteri Endosimbionti Chemio",
+      "description_it": "Batteri Endosimbionti Chemio permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di abisso vulcanico.",
+      "description_en": "Batteri Endosimbionti Chemio allow squads to stabilise multi-source energy absorption and conversion within abisso vulcanico.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Batteri Endosimbionti Chemio permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di abisso vulcanico.",
-      "description_en": "Batteri Endosimbionti Chemio allow squads to stabilise multi-source energy absorption and conversion within abisso vulcanico."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      }
     },
     "batteri_termofili_endosimbiosi": {
       "label_it": "Batteri Termofili Endosimbiosi",
       "label_en": "Batteri Termofili Endosimbiosi",
+      "description_it": "Batteri Termofili Endosimbiosi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale.",
+      "description_en": "Batteri Termofili Endosimbiosi allow squads to coordinate resource exchange and squad stabilisation parameters within dorsale termale tropicale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Batteri Termofili Endosimbiosi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale.",
-      "description_en": "Batteri Termofili Endosimbiosi allow squads to coordinate resource exchange and squad stabilisation parameters within dorsale termale tropicale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      }
     },
     "bioantenne_gravitiche": {
       "label_it": "Bioantenne Gravitiche",
       "label_en": "Gravitic Bio-Antennae",
+      "description_it": "Antenne che leggono shear gravitazionali e li convertono in segnali.",
+      "description_en": "Antennae reading gravitic shear and converting to signals.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Antenne che leggono shear gravitazionali e li convertono in segnali.",
-      "description_en": "Antennae reading gravitic shear and converting to signals."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "biochip_memoria": {
       "label_it": "Biochip Memoria",
       "label_en": "Biochip Memoria",
+      "description_it": "Biochip Memoria permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di steppe algoritmiche.",
+      "description_en": "Biochip Memoria allow squads to channel kinetic or elemental energy into targeted strikes within steppe algoritmiche.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "steppe-algoritmiche-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Biochip Memoria permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di steppe algoritmiche.",
-      "description_en": "Biochip Memoria allow squads to channel kinetic or elemental energy into targeted strikes within steppe algoritmiche."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "steppe-algoritmiche-trait-keeper"
+        ]
+      }
     },
     "biofilm_glow": {
       "label_it": "Biofilm Glow",
       "label_en": "Biofilm Glow",
+      "description_it": "Biofilm Glow permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di reef luminescente.",
+      "description_en": "Biofilm Glow allow squads to predict trajectories and orchestrate multilayered setups within reef luminescente.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Biofilm Glow permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di reef luminescente.",
-      "description_en": "Biofilm Glow allow squads to predict trajectories and orchestrate multilayered setups within reef luminescente."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "reef-luminescente-trait-keeper"
+        ]
+      }
     },
     "biofilm_iperarido": {
       "label_it": "Biofilm Iperarido",
       "label_en": "Biofilm Iperarido",
+      "description_it": "Biofilm Iperarido permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di pianura salina iperarida.",
+      "description_en": "Biofilm Iperarido allow squads to synchronise allied organisms and mutualistic flows within pianura salina iperarida.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Biofilm Iperarido permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di pianura salina iperarida.",
-      "description_en": "Biofilm Iperarido allow squads to synchronise allied organisms and mutualistic flows within pianura salina iperarida."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
+      }
     },
     "bozzolo_magnetico": {
       "label_it": "Bozzolo Magnetico",
       "label_en": "Magnetic Cocoon",
+      "description_it": "Schermarsi da campi elettromagnetici esterni.",
+      "description_en": "Shield against external electromagnetic fields.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Schermarsi da campi elettromagnetici esterni.",
-      "description_en": "Shield against external electromagnetic fields."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "branchie_dual_mode": {
       "label_it": "Branchie Dual Mode",
       "label_en": "Branchie Dual Mode",
+      "description_it": "Branchie Dual Mode permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di laguna bioreattiva.",
+      "description_en": "Branchie Dual Mode allow squads to redistribute load and modulate structural rigidity within laguna bioreattiva.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Branchie Dual Mode permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di laguna bioreattiva.",
-      "description_en": "Branchie Dual Mode allow squads to redistribute load and modulate structural rigidity within laguna bioreattiva."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "laguna-bioreattiva-trait-keeper"
+        ]
+      }
     },
     "branchie_eoliche": {
       "label_it": "Branchie Eoliche",
       "label_en": "Branchie Eoliche",
+      "description_it": "Branchie Eoliche permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di stratosfera tempestosa.",
+      "description_en": "Branchie Eoliche allow squads to interpret minute signals and unstable psionic patterns within stratosfera tempestosa.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Branchie Eoliche permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di stratosfera tempestosa.",
-      "description_en": "Branchie Eoliche allow squads to interpret minute signals and unstable psionic patterns within stratosfera tempestosa."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
+      }
     },
     "branchie_metalloidi": {
       "label_it": "Branchie Metalloidi",
       "label_en": "Branchie Metalloidi",
+      "description_it": "Branchie Metalloidi permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di abisso vulcanico.",
+      "description_en": "Branchie Metalloidi allow squads to gain grip and controlled acceleration across extreme terrain within abisso vulcanico.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Branchie Metalloidi permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di abisso vulcanico.",
-      "description_en": "Branchie Metalloidi allow squads to gain grip and controlled acceleration across extreme terrain within abisso vulcanico."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      }
     },
     "branchie_microfiltri": {
       "label_it": "Branchie Microfiltri",
       "label_en": "Branchie Microfiltri",
+      "description_it": "Branchie Microfiltri permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di reef luminescente.",
+      "description_en": "Branchie Microfiltri allow squads to disperse energy and attenuate corrosive or thermal impacts within reef luminescente.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Branchie Microfiltri permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di reef luminescente.",
-      "description_en": "Branchie Microfiltri allow squads to disperse energy and attenuate corrosive or thermal impacts within reef luminescente."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "reef-luminescente-trait-keeper"
+        ]
+      }
     },
     "branchie_osmotiche_salmastra": {
       "label_it": "Branchie Osmotiche Salmastre",
       "label_en": "Branchie Osmotiche Salmastre",
+      "description_it": "Branchie psioniche che filtrano sali e tossine in acque variabili.",
+      "description_en": "Psionic gills filtering salts and toxins in shifting waters.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "delta-salmastri-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Branchie psioniche che filtrano sali e tossine in acque variabili.",
-      "description_en": "Psionic gills filtering salts and toxins in shifting waters."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "delta-salmastri-trait-keeper"
+        ]
+      }
     },
     "branchie_solfatiche": {
       "label_it": "Branchie Solfatiche",
       "label_en": "Branchie Solfatiche",
+      "description_it": "Branchie Solfatiche permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di caldera glaciale.",
+      "description_en": "Branchie Solfatiche allow squads to stabilise multi-source energy absorption and conversion within caldera glaciale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Branchie Solfatiche permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di caldera glaciale.",
-      "description_en": "Branchie Solfatiche allow squads to stabilise multi-source energy absorption and conversion within caldera glaciale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      }
     },
     "branchie_turbina": {
       "label_it": "Branchie Turbina",
       "label_en": "Branchie Turbina",
+      "description_it": "Branchie Turbina permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale.",
+      "description_en": "Branchie Turbina allow squads to coordinate resource exchange and squad stabilisation parameters within dorsale termale tropicale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Branchie Turbina permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale.",
-      "description_en": "Branchie Turbina allow squads to coordinate resource exchange and squad stabilisation parameters within dorsale termale tropicale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      }
     },
     "bulbi_radici_permafrost": {
       "label_it": "Bulbi Radici del Permafrost",
       "label_en": "Bulbi Radici del Permafrost",
+      "description_it": "Bulbi radice che rilasciano calore e nutrimento alle unità connesse.",
+      "description_en": "Root bulbs releasing heat and stores to linked allies.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "permafrost-psionico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Bulbi radice che rilasciano calore e nutrimento alle unità connesse.",
-      "description_en": "Root bulbs releasing heat and stores to linked allies."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "permafrost-psionico-trait-keeper"
+        ]
+      }
     },
     "camere_anticorrosione": {
       "label_it": "Camere Anticorrosione",
       "label_en": "Camere Anticorrosione",
+      "description_it": "Camere Anticorrosione permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di foresta acida.",
+      "description_en": "Camere Anticorrosione allow squads to channel kinetic or elemental energy into targeted strikes within foresta acida.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Camere Anticorrosione permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di foresta acida.",
-      "description_en": "Camere Anticorrosione allow squads to channel kinetic or elemental energy into targeted strikes within foresta acida."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
+      }
     },
     "camere_mirage": {
       "label_it": "Camere Mirage",
       "label_en": "Camere Mirage",
+      "description_it": "Camere Mirage permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di pianura salina iperarida.",
+      "description_en": "Camere Mirage allow squads to predict trajectories and orchestrate multilayered setups within pianura salina iperarida.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Camere Mirage permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di pianura salina iperarida.",
-      "description_en": "Camere Mirage allow squads to predict trajectories and orchestrate multilayered setups within pianura salina iperarida."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
+      }
     },
     "camere_nutrienti_vent": {
       "label_it": "Camere Nutrienti Vent",
       "label_en": "Camere Nutrienti Vent",
+      "description_it": "Camere Nutrienti Vent permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di dorsale termale tropicale.",
+      "description_en": "Camere Nutrienti Vent allow squads to synchronise allied organisms and mutualistic flows within dorsale termale tropicale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Camere Nutrienti Vent permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di dorsale termale tropicale.",
-      "description_en": "Camere Nutrienti Vent allow squads to synchronise allied organisms and mutualistic flows within dorsale termale tropicale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      }
     },
     "camere_risonanza_abyssal": {
       "label_it": "Camere di Risonanza Abyssal",
       "label_en": "Abyssal Resonance Chambers",
+      "description_it": "Caverne interne che amplificano onde elettriche/gravitazionali.",
+      "description_en": "Internal caverns amplifying electric/gravitational waves.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "leviatano_risonante"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Caverne interne che amplificano onde elettriche/gravitazionali.",
-      "description_en": "Internal caverns amplifying electric/gravitational waves."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "leviatano_risonante"
+        ]
+      }
     },
     "campo_di_interferenza_acustica": {
       "label_it": "Campo di Interferenza Acustica",
       "label_en": "Acoustic Interference Field",
+      "description_it": "Mascherare posizione e velocità.",
+      "description_en": "Mask position and velocity.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Mascherare posizione e velocità.",
-      "description_en": "Mask position and velocity."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "cannone_sonico_a_raggio": {
       "label_it": "Cannone Sonico a Raggio",
       "label_en": "Ray Sonic Cannon",
+      "description_it": "Stordire o ferire con un raggio sonoro.",
+      "description_en": "Stun or injure targets with a sonic beam.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Stordire o ferire con un raggio sonoro.",
-      "description_en": "Stun or injure targets with a sonic beam."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "canto_infrasonico_tattico": {
       "label_it": "Canto Infrasonico Tattico",
       "label_en": "Tactical Infrasonic Song",
+      "description_it": "Disorientare predatori e comunicare a distanza.",
+      "description_en": "Disorient predators and communicate at range.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Disorientare predatori e comunicare a distanza.",
-      "description_en": "Disorient predators and communicate at range."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "canto_risonante": {
       "label_it": "Canto Risonante",
       "label_en": "Resonant Chant",
+      "description_it": "Frequenze che armonizzano il gruppo e riducono stress (temp).",
+      "description_en": "Frequencies harmonising the squad and reducing stress (temp).",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "leviatano_risonante",
+              "polpo_araldo_sinaptico"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Frequenze che armonizzano il gruppo e riducono stress (temp).",
-      "description_en": "Frequencies harmonising the squad and reducing stress (temp)."
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "temp": 2
+        },
+        "top_species": [
+          "polpo_araldo_sinaptico",
+          "leviatano_risonante"
+        ]
+      }
     },
     "capillari_criogenici": {
       "label_it": "Capillari Criogenici",
       "label_en": "Capillari Criogenici",
+      "description_it": "Capillari Criogenici permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di caldera glaciale.",
+      "description_en": "Capillari Criogenici allow squads to redistribute load and modulate structural rigidity within caldera glaciale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Capillari Criogenici permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di caldera glaciale.",
-      "description_en": "Capillari Criogenici allow squads to redistribute load and modulate structural rigidity within caldera glaciale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      }
     },
     "capillari_fluoridici": {
       "label_it": "Capillari Fluoridici",
       "label_en": "Capillari Fluoridici",
+      "description_it": "Capillari Fluoridici permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di foresta acida.",
+      "description_en": "Capillari Fluoridici allow squads to interpret minute signals and unstable psionic patterns within foresta acida.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Capillari Fluoridici permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di foresta acida.",
-      "description_en": "Capillari Fluoridici allow squads to interpret minute signals and unstable psionic patterns within foresta acida."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
+      }
     },
     "capillari_fotovoltaici": {
       "label_it": "Capillari Fotovoltaici",
       "label_en": "Capillari Fotovoltaici",
+      "description_it": "Capillari Fotovoltaici permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di canopia ionica.",
+      "description_en": "Capillari Fotovoltaici allow squads to gain grip and controlled acceleration across extreme terrain within canopia ionica.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Capillari Fotovoltaici permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di canopia ionica.",
-      "description_en": "Capillari Fotovoltaici allow squads to gain grip and controlled acceleration across extreme terrain within canopia ionica."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "canopia-ionica-trait-keeper"
+        ]
+      }
     },
     "capsule_paracadute": {
       "label_it": "Capsule Paracadute",
       "label_en": "Capsule Paracadute",
+      "description_it": "Capsule Paracadute permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di stratosfera tempestosa.",
+      "description_en": "Capsule Paracadute allow squads to disperse energy and attenuate corrosive or thermal impacts within stratosfera tempestosa.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Capsule Paracadute permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di stratosfera tempestosa.",
-      "description_en": "Capsule Paracadute allow squads to disperse energy and attenuate corrosive or thermal impacts within stratosfera tempestosa."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
+      }
     },
     "carapace_fase_variabile": {
       "label_it": "Carapace a Variazione di Fase",
       "label_en": "Phase-Shifting Carapace",
+      "description_it": "Corazza che varia densità per bilanciare difesa e mobilità.",
+      "description_en": "Shell shifts density to balance defense and mobility.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 9,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 9,
+            "examples": [
+              "balor-fission",
+              "bulette-fase",
+              "canopia-psionica-leggera-trait-keeper",
+              "cryo-lynx",
+              "falde-magnetiche-psioniche-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Corazza che varia densità per bilanciare difesa e mobilità.",
-      "description_en": "Shell shifts density to balance defense and mobility."
+      "affinity": {
+        "total_species": 9,
+        "roles_breakdown": {
+          "optional": 9
+        },
+        "top_species": [
+          "balor-fission",
+          "bulette-fase",
+          "canopia-psionica-leggera-trait-keeper",
+          "cryo-lynx",
+          "falde-magnetiche-psioniche-trait-keeper",
+          "golem-runico",
+          "nano-rust-bloom",
+          "otyugh-sentinella",
+          "sand-burrower"
+        ]
+      }
     },
     "carapace_luminiscente_abissale": {
       "label_it": "Carapace Luminiscente Abissale",
       "label_en": "Carapace Luminiscente Abissale",
+      "description_it": "Guscio bioluminescente che confonde i predatori nelle profondità.",
+      "description_en": "Bioluminescent shell confusing predators in abyssal dark.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-luminescente-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Guscio bioluminescente che confonde i predatori nelle profondità.",
-      "description_en": "Bioluminescent shell confusing predators in abyssal dark."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-luminescente-trait-keeper"
+        ]
+      }
     },
     "carapace_segmenti_logici": {
       "label_it": "Carapace Segmenti Logici",
       "label_en": "Carapace Segmenti Logici",
+      "description_it": "Carapace Segmenti Logici permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di steppe algoritmiche.",
+      "description_en": "Carapace Segmenti Logici allow squads to stabilise multi-source energy absorption and conversion within steppe algoritmiche.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "steppe-algoritmiche-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Carapace Segmenti Logici permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di steppe algoritmiche.",
-      "description_en": "Carapace Segmenti Logici allow squads to stabilise multi-source energy absorption and conversion within steppe algoritmiche."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "steppe-algoritmiche-trait-keeper"
+        ]
+      }
     },
     "carapaci_ferruginosi": {
       "label_it": "Carapaci Ferruginosi",
       "label_en": "Carapaci Ferruginosi",
+      "description_it": "Carapaci Ferruginosi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di abisso vulcanico.",
+      "description_en": "Carapaci Ferruginosi allow squads to coordinate resource exchange and squad stabilisation parameters within abisso vulcanico.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Carapaci Ferruginosi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di abisso vulcanico.",
-      "description_en": "Carapaci Ferruginosi allow squads to coordinate resource exchange and squad stabilisation parameters within abisso vulcanico."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      }
     },
     "cartilagine_flessotermica_venti": {
       "label_it": "Cartilagine Flessotermica dei Venti",
       "label_en": "Cartilagine Flessotermica dei Venti",
+      "description_it": "Cartilagine termoreattiva che ottimizza virate e planate aeree.",
+      "description_en": "Thermo-reactive cartilage optimizing aerial turns.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "gole-ventose-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Cartilagine termoreattiva che ottimizza virate e planate aeree.",
-      "description_en": "Thermo-reactive cartilage optimizing aerial turns."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "gole-ventose-trait-keeper"
+        ]
+      }
     },
     "cartilagini_biofibre": {
       "label_it": "Cartilagini Biofibre",
       "label_en": "Cartilagini Biofibre",
+      "description_it": "Cartilagini Biofibre permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di reef luminescente.",
+      "description_en": "Cartilagini Biofibre allow squads to channel kinetic or elemental energy into targeted strikes within reef luminescente.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Cartilagini Biofibre permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di reef luminescente.",
-      "description_en": "Cartilagini Biofibre allow squads to channel kinetic or elemental energy into targeted strikes within reef luminescente."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "reef-luminescente-trait-keeper"
+        ]
+      }
     },
     "cartilagini_desertiche": {
       "label_it": "Cartilagini Desertiche",
       "label_en": "Cartilagini Desertiche",
+      "description_it": "Cartilagini Desertiche permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di pianura salina iperarida.",
+      "description_en": "Cartilagini Desertiche allow squads to predict trajectories and orchestrate multilayered setups within pianura salina iperarida.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Cartilagini Desertiche permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di pianura salina iperarida.",
-      "description_en": "Cartilagini Desertiche allow squads to predict trajectories and orchestrate multilayered setups within pianura salina iperarida."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
+      }
     },
     "cartilagini_flessoacustiche": {
       "label_it": "Cartilagini Flessoacustiche",
       "label_en": "Cartilagini Flessoacustiche",
+      "description_it": "Cartilagini Flessoacustiche permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di caverna risonante.",
+      "description_en": "Cartilagini Flessoacustiche allow squads to synchronise allied organisms and mutualistic flows within caverna risonante.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Cartilagini Flessoacustiche permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di caverna risonante.",
-      "description_en": "Cartilagini Flessoacustiche allow squads to synchronise allied organisms and mutualistic flows within caverna risonante."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
+      }
     },
     "cartilagini_pseudometalliche": {
       "label_it": "Cartilagini Pseudometalliche",
       "label_en": "Cartilagini Pseudometalliche",
+      "description_it": "Cartilagini Pseudometalliche permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di abisso vulcanico.",
+      "description_en": "Cartilagini Pseudometalliche allow squads to redistribute load and modulate structural rigidity within abisso vulcanico.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Cartilagini Pseudometalliche permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di abisso vulcanico.",
-      "description_en": "Cartilagini Pseudometalliche allow squads to redistribute load and modulate structural rigidity within abisso vulcanico."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      }
     },
     "cavita_risonanti_tundra": {
       "label_it": "Cavità Risonanti della Tundra",
       "label_en": "Cavità Risonanti della Tundra",
+      "description_it": "Camere toraciche che proiettano richiami a lunga distanza nel gelo.",
+      "description_en": "Chest chambers projecting long-range calls through tundra frost.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "tundra-risonante-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Camere toraciche che proiettano richiami a lunga distanza nel gelo.",
-      "description_en": "Chest chambers projecting long-range calls through tundra frost."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "tundra-risonante-trait-keeper"
+        ]
+      }
     },
     "cervelletto_equilibrio_statico": {
       "label_it": "Cervelletto Equilibrio Statico",
       "label_en": "Cervelletto Equilibrio Statico",
+      "description_it": "Cervelletto Equilibrio Statico permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di canopia ionica.",
+      "description_en": "Cervelletto Equilibrio Statico allow squads to interpret minute signals and unstable psionic patterns within canopia ionica.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Cervelletto Equilibrio Statico permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di canopia ionica.",
-      "description_en": "Cervelletto Equilibrio Statico allow squads to interpret minute signals and unstable psionic patterns within canopia ionica."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "canopia-ionica-trait-keeper"
+        ]
+      }
     },
     "cervello_a_bassa_latenza": {
       "label_it": "Cervello a Bassa Latenza",
       "label_en": "Low-Latency Brain",
+      "description_it": "Eseguire manovre ad alta frequenza.",
+      "description_en": "Execute high-frequency maneuvers.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Eseguire manovre ad alta frequenza.",
-      "description_en": "Execute high-frequency maneuvers."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "chemiorecettori_bromuro": {
       "label_it": "Chemiorecettori Bromuro",
       "label_en": "Chemiorecettori Bromuro",
+      "description_it": "Chemiorecettori Bromuro permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di pianura salina iperarida.",
+      "description_en": "Chemiorecettori Bromuro allow squads to gain grip and controlled acceleration across extreme terrain within pianura salina iperarida.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Chemiorecettori Bromuro permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di pianura salina iperarida.",
-      "description_en": "Chemiorecettori Bromuro allow squads to gain grip and controlled acceleration across extreme terrain within pianura salina iperarida."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
+      }
     },
     "chioma_parassita_canopica": {
       "label_it": "Chioma Parassita Canopica",
       "label_en": "Chioma Parassita Canopica",
+      "description_it": "Filamenti parassiti che creano corsie energetiche nella canopia.",
+      "description_en": "Parasitic tendrils weaving energy lanes through canopy.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "canopie-sospese-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Filamenti parassiti che creano corsie energetiche nella canopia.",
-      "description_en": "Parasitic tendrils weaving energy lanes through canopy."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "canopie-sospese-trait-keeper"
+        ]
+      }
     },
     "cinghia_iper_ciliare": {
       "label_it": "Cinghia Iper-Ciliare",
       "label_en": "Hyper-Ciliary Belt",
+      "description_it": "Traslare il corpo su terreni piani o ruvidi.",
+      "description_en": "Translate the body across smooth or rough ground.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Traslare il corpo su terreni piani o ruvidi.",
-      "description_en": "Translate the body across smooth or rough ground."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "circolazione_bifasica": {
       "label_it": "Circolazione Bifasica",
       "label_en": "Circolazione Bifasica",
+      "description_it": "Circolazione Bifasica permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di caldera glaciale.",
+      "description_en": "Circolazione Bifasica allow squads to disperse energy and attenuate corrosive or thermal impacts within caldera glaciale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Circolazione Bifasica permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di caldera glaciale.",
-      "description_en": "Circolazione Bifasica allow squads to disperse energy and attenuate corrosive or thermal impacts within caldera glaciale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      }
     },
     "circolazione_bifasica_palude": {
       "label_it": "Circolazione Bifasica di Palude",
       "label_en": "Swamp Biphase Circulation",
+      "description_it": "Doppio circuito sanguigno che separa ossigeno e agenti tossici in ambienti stagnanti.",
+      "description_en": "Dual blood circuits separating oxygen flow from toxins in stagnant wetlands.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "paludi-gas-luminescenti-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Doppio circuito sanguigno che separa ossigeno e agenti tossici in ambienti stagnanti.",
-      "description_en": "Dual blood circuits separating oxygen flow from toxins in stagnant wetlands."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "paludi-gas-luminescenti-trait-keeper"
+        ]
+      }
     },
     "circolazione_cooling_loop": {
       "label_it": "Circolazione Cooling Loop",
       "label_en": "Circolazione Cooling Loop",
+      "description_it": "Circolazione Cooling Loop permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di steppe algoritmiche.",
+      "description_en": "Circolazione Cooling Loop allow squads to stabilise multi-source energy absorption and conversion within steppe algoritmiche.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "steppe-algoritmiche-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Circolazione Cooling Loop permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di steppe algoritmiche.",
-      "description_en": "Circolazione Cooling Loop allow squads to stabilise multi-source energy absorption and conversion within steppe algoritmiche."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "steppe-algoritmiche-trait-keeper"
+        ]
+      }
     },
     "circolazione_doppia": {
       "label_it": "Circolazione Doppia",
       "label_en": "Circolazione Doppia",
+      "description_it": "Circolazione Doppia permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale.",
+      "description_en": "Circolazione Doppia allow squads to coordinate resource exchange and squad stabilisation parameters within dorsale termale tropicale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Circolazione Doppia permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale.",
-      "description_en": "Circolazione Doppia allow squads to coordinate resource exchange and squad stabilisation parameters within dorsale termale tropicale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      }
     },
     "circolazione_supercritica": {
       "label_it": "Circolazione Supercritica",
       "label_en": "Circolazione Supercritica",
+      "description_it": "Circolazione Supercritica permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di abisso vulcanico.",
+      "description_en": "Circolazione Supercritica allow squads to channel kinetic or elemental energy into targeted strikes within abisso vulcanico.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Circolazione Supercritica permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di abisso vulcanico.",
-      "description_en": "Circolazione Supercritica allow squads to channel kinetic or elemental energy into targeted strikes within abisso vulcanico."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      }
     },
     "ciste_riduttive": {
       "label_it": "Ciste Riduttive",
       "label_en": "Ciste Riduttive",
+      "description_it": "Ciste Riduttive permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di laguna bioreattiva.",
+      "description_en": "Ciste Riduttive allow squads to predict trajectories and orchestrate multilayered setups within laguna bioreattiva.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ciste Riduttive permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di laguna bioreattiva.",
-      "description_en": "Ciste Riduttive allow squads to predict trajectories and orchestrate multilayered setups within laguna bioreattiva."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "laguna-bioreattiva-trait-keeper"
+        ]
+      }
     },
     "ciste_salmastre": {
       "label_it": "Ciste Salmastre",
       "label_en": "Ciste Salmastre",
+      "description_it": "Ciste Salmastre permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di pianura salina iperarida.",
+      "description_en": "Ciste Salmastre allow squads to synchronise allied organisms and mutualistic flows within pianura salina iperarida.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ciste Salmastre permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di pianura salina iperarida.",
-      "description_en": "Ciste Salmastre allow squads to synchronise allied organisms and mutualistic flows within pianura salina iperarida."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
+      }
     },
     "cisti_di_ibernazione_minerale": {
       "label_it": "Cisti di Ibernazione Minerale",
       "label_en": "Mineral Hibernation Cyst",
+      "description_it": "Entrare in stasi in condizioni avverse.",
+      "description_en": "Enter stasis under harsh conditions.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Entrare in stasi in condizioni avverse.",
-      "description_en": "Enter stasis under harsh conditions."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "cisti_iperbariche": {
       "label_it": "Cisti Iperbariche",
       "label_en": "Cisti Iperbariche",
+      "description_it": "Cisti Iperbariche permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di abisso vulcanico.",
+      "description_en": "Cisti Iperbariche allow squads to redistribute load and modulate structural rigidity within abisso vulcanico.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Cisti Iperbariche permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di abisso vulcanico.",
-      "description_en": "Cisti Iperbariche allow squads to redistribute load and modulate structural rigidity within abisso vulcanico."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      }
     },
     "coda_balanciere": {
       "label_it": "Coda Balanciere",
       "label_en": "Coda Balanciere",
+      "description_it": "Coda Balanciere permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante.",
+      "description_en": "Coda Balanciere allow squads to interpret minute signals and unstable psionic patterns within caverna risonante.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Coda Balanciere permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante.",
-      "description_en": "Coda Balanciere allow squads to interpret minute signals and unstable psionic patterns within caverna risonante."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
+      }
     },
     "coda_contrappeso": {
       "label_it": "Coda Contrappeso",
       "label_en": "Coda Contrappeso",
+      "description_it": "Coda Contrappeso permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di mangrovieto cinetico.",
+      "description_en": "Coda Contrappeso allow squads to gain grip and controlled acceleration across extreme terrain within mangrovieto cinetico.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Coda Contrappeso permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di mangrovieto cinetico.",
-      "description_en": "Coda Contrappeso allow squads to gain grip and controlled acceleration across extreme terrain within mangrovieto cinetico."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
+      }
     },
     "coda_coppia_retroattiva": {
       "label_it": "Coda Coppia Retroattiva",
       "label_en": "Coda Coppia Retroattiva",
+      "description_it": "Coda Coppia Retroattiva permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di steppe algoritmiche.",
+      "description_en": "Coda Coppia Retroattiva allow squads to disperse energy and attenuate corrosive or thermal impacts within steppe algoritmiche.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "steppe-algoritmiche-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Coda Coppia Retroattiva permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di steppe algoritmiche.",
-      "description_en": "Coda Coppia Retroattiva allow squads to disperse energy and attenuate corrosive or thermal impacts within steppe algoritmiche."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "steppe-algoritmiche-trait-keeper"
+        ]
+      }
     },
     "coda_frusta_cinetica": {
       "label_it": "Coda a Frusta Cinetica",
       "label_en": "Kinetic Lash Tail",
+      "description_it": "Coda elastica che accumula slancio per un colpo cinetico devastante.",
+      "description_en": "Elastic tail storing momentum for a devastating lash.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 7,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 7,
+            "examples": [
+              "bulette-fase",
+              "dune-stalker",
+              "falde-magnetiche-psioniche-trait-keeper",
+              "magneto-ridge-hunter",
+              "marilith-vault"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Coda elastica che accumula slancio per un colpo cinetico devastante.",
-      "description_en": "Elastic tail storing momentum for a devastating lash."
+      "affinity": {
+        "total_species": 7,
+        "roles_breakdown": {
+          "core": 3,
+          "optional": 7
+        },
+        "top_species": [
+          "dune-stalker",
+          "magneto-ridge-hunter",
+          "slag-veil-ambusher",
+          "bulette-fase",
+          "falde-magnetiche-psioniche-trait-keeper",
+          "marilith-vault",
+          "orbita-psionica-inversa-trait-keeper"
+        ]
+      }
     },
     "coda_prensile_muscolare": {
       "label_it": "Coda Prensile Muscolare",
       "label_en": "Muscular Prehensile Tail",
+      "description_it": "Appendere e controbilanciarsi.",
+      "description_en": "Hang and counterbalance weight.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Appendere e controbilanciarsi.",
-      "description_en": "Hang and counterbalance weight."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "coda_stabilizzatrice_filo": {
       "label_it": "Coda Stabilizzatrice Filo",
       "label_en": "Coda Stabilizzatrice Filo",
+      "description_it": "Coda Stabilizzatrice Filo permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di canopia ionica.",
+      "description_en": "Coda Stabilizzatrice Filo allow squads to stabilise multi-source energy absorption and conversion within canopia ionica.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Coda Stabilizzatrice Filo permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di canopia ionica.",
-      "description_en": "Coda Stabilizzatrice Filo allow squads to stabilise multi-source energy absorption and conversion within canopia ionica."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "canopia-ionica-trait-keeper"
+        ]
+      }
     },
     "coda_stabilizzatrice_geiser": {
       "label_it": "Coda Stabilizzatrice Geiser",
       "label_en": "Coda Stabilizzatrice Geiser",
+      "description_it": "Coda Stabilizzatrice Geiser permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale.",
+      "description_en": "Coda Stabilizzatrice Geiser allow squads to coordinate resource exchange and squad stabilisation parameters within dorsale termale tropicale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Coda Stabilizzatrice Geiser permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di dorsale termale tropicale.",
-      "description_en": "Coda Stabilizzatrice Geiser allow squads to coordinate resource exchange and squad stabilisation parameters within dorsale termale tropicale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      }
     },
     "coda_stabilizzatrice_vortex": {
       "label_it": "Coda Stabilizzatrice Vortex",
       "label_en": "Coda Stabilizzatrice Vortex",
+      "description_it": "Coda Stabilizzatrice Vortex permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di stratosfera tempestosa.",
+      "description_en": "Coda Stabilizzatrice Vortex allow squads to channel kinetic or elemental energy into targeted strikes within stratosfera tempestosa.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Coda Stabilizzatrice Vortex permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di stratosfera tempestosa.",
-      "description_en": "Coda Stabilizzatrice Vortex allow squads to channel kinetic or elemental energy into targeted strikes within stratosfera tempestosa."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
+      }
     },
     "colonne_vibromagnetiche": {
       "label_it": "Colonne Vibromagnetiche",
       "label_en": "Colonne Vibromagnetiche",
+      "description_it": "Colonne Vibromagnetiche permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di caverna risonante.",
+      "description_en": "Colonne Vibromagnetiche allow squads to predict trajectories and orchestrate multilayered setups within caverna risonante.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Colonne Vibromagnetiche permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di caverna risonante.",
-      "description_en": "Colonne Vibromagnetiche allow squads to predict trajectories and orchestrate multilayered setups within caverna risonante."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
+      }
     },
     "comunicazione_fotonica_coda_coda": {
       "label_it": "Comunicazione Fotonica Coda-Coda",
       "label_en": "Tail-to-Tail Photonic Communication",
+      "description_it": "Scambiare impulsi luminosi tattili.",
+      "description_en": "Exchange tactile light pulses.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Scambiare impulsi luminosi tattili.",
-      "description_en": "Exchange tactile light pulses."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "coralli_partner": {
       "label_it": "Coralli Partner",
       "label_en": "Coralli Partner",
+      "description_it": "Coralli Partner permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di reef luminescente.",
+      "description_en": "Coralli Partner allow squads to synchronise allied organisms and mutualistic flows within reef luminescente.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Coralli Partner permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di reef luminescente.",
-      "description_en": "Coralli Partner allow squads to synchronise allied organisms and mutualistic flows within reef luminescente."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "reef-luminescente-trait-keeper"
+        ]
+      }
     },
     "coralli_sinaptici_fotofase": {
       "label_it": "Coralli Sinaptici Fotofase",
       "label_en": "Photophase Synaptic Corals",
+      "description_it": "Barriere bioelettriche che canalizzano luce e impulsi.",
+      "description_en": "Bioelectric coral ridges channeling light and impulses.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "polpo_araldo_sinaptico"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Barriere bioelettriche che canalizzano luce e impulsi.",
-      "description_en": "Bioelectric coral ridges channeling light and impulses."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "polpo_araldo_sinaptico"
+        ]
+      }
     },
     "corazze_ferro_magnetico": {
       "label_it": "Corazze Ferro-Magnetico",
       "label_en": "Ferro-Magnetic Carapace",
+      "description_it": "Placche ferrose che guidano campi magnetici profondi.",
+      "description_en": "Iron plates guiding deep magnetic fields.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Placche ferrose che guidano campi magnetici profondi.",
-      "description_en": "Iron plates guiding deep magnetic fields."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "corna_psico_conduttive": {
       "label_it": "Corna Psico-Conduttive",
       "label_en": "Psycho-Conductive Horns",
+      "description_it": "Corna piezo-neurotoniche che trasmettono e ricevono segnali neurali lenti per allerta di branco.",
+      "description_en": "Piezo-neurotonic horns sending and receiving slow neural signals for pack alerts.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Corna piezo-neurotoniche che trasmettono e ricevono segnali neurali lenti per allerta di branco.",
-      "description_en": "Piezo-neurotonic horns sending and receiving slow neural signals for pack alerts."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "coscienza_d_alveare_diffusa": {
       "label_it": "Coscienza d’Alveare Diffusa",
       "label_en": "Diffuse Hive Consciousness",
+      "description_it": "Rete sinaptica inter-individuo temporanea che fonde decisioni e memoria a breve termine.",
+      "description_en": "Temporary inter-individual synaptic net merging decisions and short-term memory.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Rete sinaptica inter-individuo temporanea che fonde decisioni e memoria a breve termine.",
-      "description_en": "Temporary inter-individual synaptic net merging decisions and short-term memory."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "coscienza_dalveare_diffusa": {
       "label_it": "Coscienza d’Alveare Diffusa",
       "label_en": "Diffuse Hive Consciousness",
+      "description_it": "Rete sinaptica inter-individuo temporanea che fonde decisioni e memoria a breve termine.",
+      "description_en": "Temporary inter-individual synaptic net merging decisions and short-term memory.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Rete sinaptica inter-individuo temporanea che fonde decisioni e memoria a breve termine.",
-      "description_en": "Temporary inter-individual synaptic net merging decisions and short-term memory."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "criostasi_adattiva": {
       "label_it": "Criostasi",
       "label_en": "Adaptive Cryostasis",
+      "description_it": "Metabolismo sospeso che sopravvive a stagioni estreme prolungate.",
+      "description_en": "Suspended metabolism surviving protracted extreme seasons.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "volatore_planatore",
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 4,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "volatore_planatore",
+            "count": 4,
+            "examples": [
+              "aurora-gull",
+              "canopia-psionica-leggera-trait-keeper",
+              "orbita-psionica-inversa-trait-keeper",
+              "orbital-ascendant"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Metabolismo sospeso che sopravvive a stagioni estreme prolungate.",
-      "description_en": "Suspended metabolism surviving protracted extreme seasons."
+      "affinity": {
+        "total_species": 4,
+        "roles_breakdown": {
+          "optional": 4
+        },
+        "top_species": [
+          "aurora-gull",
+          "canopia-psionica-leggera-trait-keeper",
+          "orbita-psionica-inversa-trait-keeper",
+          "orbital-ascendant"
+        ]
+      }
     },
     "cromofori_alert_acido": {
       "label_it": "Cromofori Alert Acido",
       "label_en": "Cromofori Alert Acido",
+      "description_it": "Cromofori Alert Acido permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di foresta acida.",
+      "description_en": "Cromofori Alert Acido allow squads to redistribute load and modulate structural rigidity within foresta acida.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Cromofori Alert Acido permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di foresta acida.",
-      "description_en": "Cromofori Alert Acido allow squads to redistribute load and modulate structural rigidity within foresta acida."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
+      }
     },
     "cuore_multicamera_bassa_pressione": {
       "label_it": "Cuore Multicamera Bassa Pressione",
       "label_en": "Cuore Multicamera Bassa Pressione",
+      "description_it": "Cuore Multicamera Bassa Pressione permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di stratosfera tempestosa.",
+      "description_en": "Cuore Multicamera Bassa Pressione allow squads to interpret minute signals and unstable psionic patterns within stratosfera tempestosa.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Cuore Multicamera Bassa Pressione permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di stratosfera tempestosa.",
-      "description_en": "Cuore Multicamera Bassa Pressione allow squads to interpret minute signals and unstable psionic patterns within stratosfera tempestosa."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
+      }
     },
     "cuscinetti_elettrostatici": {
       "label_it": "Cuscinetti Elettrostatici",
       "label_en": "Cuscinetti Elettrostatici",
+      "description_it": "Cuscinetti Elettrostatici permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di pianura salina iperarida.",
+      "description_en": "Cuscinetti Elettrostatici allow squads to gain grip and controlled acceleration across extreme terrain within pianura salina iperarida.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Cuscinetti Elettrostatici permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di pianura salina iperarida.",
-      "description_en": "Cuscinetti Elettrostatici allow squads to gain grip and controlled acceleration across extreme terrain within pianura salina iperarida."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
+      }
     },
     "cute_resistente_sali": {
       "label_it": "Cute Resistente Sali",
       "label_en": "Cute Resistente Sali",
+      "description_it": "Cute Resistente Sali permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di badlands.",
+      "description_en": "Cute Resistente Sali allow squads to disperse energy and attenuate corrosive or thermal impacts within badlands.",
       "rules": {
-        "total": 1,
+        "total": 2,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "badlands",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 6,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 3,
+            "examples": [
+              "badlands-trait-keeper",
+              "evento-tempesta-ferrosa",
+              "global-trait-keeper"
+            ]
+          },
+          {
+            "biome": "badlands",
+            "morphotype": null,
+            "count": 3,
+            "examples": [
+              "badlands-trait-keeper",
+              "evento-tempesta-ferrosa",
+              "global-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Cute Resistente Sali permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di badlands.",
-      "description_en": "Cute Resistente Sali allow squads to disperse energy and attenuate corrosive or thermal impacts within badlands."
+      "affinity": {
+        "total_species": 3,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 3
+        },
+        "top_species": [
+          "evento-tempesta-ferrosa",
+          "badlands-trait-keeper",
+          "global-trait-keeper"
+        ]
+      }
     },
     "cuticole_cerose": {
       "label_it": "Cuticole Cerose",
       "label_en": "Cuticole Cerose",
+      "description_it": "Cuticole Cerose permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di ambienti dinamici.",
+      "description_en": "Cuticole Cerose allow squads to stabilise multi-source energy absorption and conversion within ambienti dinamici.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 7,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 7,
+            "examples": [
+              "cactus-weaver",
+              "evento-brinastorm",
+              "evento-ondata-termica",
+              "global-trait-keeper",
+              "noctule-termico"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Cuticole Cerose permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di ambienti dinamici.",
-      "description_en": "Cuticole Cerose allow squads to stabilise multi-source energy absorption and conversion within ambienti dinamici."
+      "affinity": {
+        "total_species": 7,
+        "roles_breakdown": {
+          "optional": 7
+        },
+        "top_species": [
+          "cactus-weaver",
+          "evento-brinastorm",
+          "evento-ondata-termica",
+          "global-trait-keeper",
+          "noctule-termico",
+          "silica-bloom",
+          "thermo-raptor"
+        ]
+      }
     },
     "cuticole_neutralizzanti": {
       "label_it": "Cuticole Neutralizzanti",
       "label_en": "Cuticole Neutralizzanti",
+      "description_it": "Cuticole Neutralizzanti permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di foresta acida.",
+      "description_en": "Cuticole Neutralizzanti allow squads to coordinate resource exchange and squad stabilisation parameters within foresta acida.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Cuticole Neutralizzanti permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di foresta acida.",
-      "description_en": "Cuticole Neutralizzanti allow squads to coordinate resource exchange and squad stabilisation parameters within foresta acida."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
+      }
     },
     "denti_chelatanti": {
       "label_it": "Denti Chelatanti",
       "label_en": "Denti Chelatanti",
+      "description_it": "Denti Chelatanti permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di foresta acida.",
+      "description_en": "Denti Chelatanti allow squads to channel kinetic or elemental energy into targeted strikes within foresta acida.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Denti Chelatanti permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di foresta acida.",
-      "description_en": "Denti Chelatanti allow squads to channel kinetic or elemental energy into targeted strikes within foresta acida."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
+      }
     },
     "denti_ossidoferro": {
       "label_it": "Denti Ossidoferro",
       "label_en": "Denti Ossidoferro",
+      "description_it": "Denti Ossidoferro permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di abisso vulcanico.",
+      "description_en": "Denti Ossidoferro allow squads to predict trajectories and orchestrate multilayered setups within abisso vulcanico.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Denti Ossidoferro permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di abisso vulcanico.",
-      "description_en": "Denti Ossidoferro allow squads to predict trajectories and orchestrate multilayered setups within abisso vulcanico."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      }
     },
     "denti_silice_termici": {
       "label_it": "Denti Silice Termici",
       "label_en": "Denti Silice Termici",
+      "description_it": "Denti Silice Termici permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di dorsale termale tropicale.",
+      "description_en": "Denti Silice Termici allow squads to synchronise allied organisms and mutualistic flows within dorsale termale tropicale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Denti Silice Termici permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di dorsale termale tropicale.",
-      "description_en": "Denti Silice Termici allow squads to synchronise allied organisms and mutualistic flows within dorsale termale tropicale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      }
     },
     "denti_tuning_fork": {
       "label_it": "Denti Tuning Fork",
       "label_en": "Denti Tuning Fork",
+      "description_it": "Denti Tuning Fork permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di caverna risonante.",
+      "description_en": "Denti Tuning Fork allow squads to redistribute load and modulate structural rigidity within caverna risonante.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Denti Tuning Fork permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di caverna risonante.",
-      "description_en": "Denti Tuning Fork allow squads to redistribute load and modulate structural rigidity within caverna risonante."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
+      }
     },
     "echi_risonanti": {
       "label_it": "Echi Risonanti",
       "label_en": "Echi Risonanti",
+      "description_it": "Echi Risonanti permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante.",
+      "description_en": "Echi Risonanti allow squads to interpret minute signals and unstable psionic patterns within caverna risonante.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Echi Risonanti permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante.",
-      "description_en": "Echi Risonanti allow squads to interpret minute signals and unstable psionic patterns within caverna risonante."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
+      }
     },
     "eco_interno_riflesso": {
       "label_it": "Riflesso dell'Eco Interno",
       "label_en": "Internal Echo Reflex",
+      "description_it": "Sonar interno che mappa l'ambiente attraverso vibrazioni corporee.",
+      "description_en": "Internal sonar mapping surroundings via body reverbs.",
       "rules": {
-        "total": 1,
+        "total": 2,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "volatore_planatore",
+            "count": 1
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "volatore_planatore",
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 14,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "volatore_planatore",
+            "count": 7,
+            "examples": [
+              "aurora-bridge-runner",
+              "aurora-gull",
+              "canopia-psionica-leggera-trait-keeper",
+              "echo-wing",
+              "falde-magnetiche-psioniche-trait-keeper"
+            ]
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "volatore_planatore",
+            "count": 7,
+            "examples": [
+              "aurora-bridge-runner",
+              "aurora-gull",
+              "canopia-psionica-leggera-trait-keeper",
+              "echo-wing",
+              "falde-magnetiche-psioniche-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Sonar interno che mappa l'ambiente attraverso vibrazioni corporee.",
-      "description_en": "Internal sonar mapping surroundings via body reverbs."
+      "affinity": {
+        "total_species": 7,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 7
+        },
+        "top_species": [
+          "echo-wing",
+          "aurora-bridge-runner",
+          "aurora-gull",
+          "canopia-psionica-leggera-trait-keeper",
+          "falde-magnetiche-psioniche-trait-keeper",
+          "orbital-ascendant",
+          "zephyr-spore-courier"
+        ]
+      }
     },
     "ectotermia_dinamica": {
       "label_it": "Ectotermia Dinamica",
       "label_en": "Dynamic Ectothermy",
+      "description_it": "Microscosse isometriche che innalzano in fretta la temperatura corporea per picchi prestazionali in climi freschi.",
+      "description_en": "Isometric micro-shivers that quickly elevate body temperature for performance peaks in cool climates.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Microscosse isometriche che innalzano in fretta la temperatura corporea per picchi prestazionali in climi freschi.",
-      "description_en": "Isometric micro-shivers that quickly elevate body temperature for performance peaks in cool climates."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "elettromagnete_biologico": {
       "label_it": "Elettromagnete Biologico",
       "label_en": "Biological Electromagnet",
+      "description_it": "Interferire con il sistema nervoso della preda.",
+      "description_en": "Disrupt prey nervous systems.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Interferire con il sistema nervoso della preda.",
-      "description_en": "Disrupt prey nervous systems."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "emettitori_voidsong": {
       "label_it": "Emettitori Voidsong",
       "label_en": "Voidsong Emitters",
+      "description_it": "Organi che emettono cori a frequenze profonde per stabilizzare lo shear.",
+      "description_en": "Organs emitting deep choruses to stabilise shear.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "leviatano_risonante"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Organi che emettono cori a frequenze profonde per stabilizzare lo shear.",
-      "description_en": "Organs emitting deep choruses to stabilise shear."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "leviatano_risonante"
+        ]
+      }
     },
     "emolinfa_conducente": {
       "label_it": "Emolinfa Conducente",
       "label_en": "Conductive Hemolymph",
+      "description_it": "Fluido che accumula carica e drena energia nemica.",
+      "description_en": "Fluid storing charge and draining enemy energy.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Fluido che accumula carica e drena energia nemica.",
-      "description_en": "Fluid storing charge and draining enemy energy."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "empatia_coordinativa": {
       "label_it": "Empatia Coordinativa",
       "label_en": "Coordinated Empathy",
+      "description_it": "Rete empatica che sincronizza cure e difese dell'intera squadra.",
+      "description_en": "Empathic mesh synchronizing team-wide heals and defenses.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 8,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 8,
+            "examples": [
+              "archon-solare",
+              "balor-fission",
+              "couatl-aurora",
+              "glowcap-weaver",
+              "lupus-temperatus"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Rete empatica che sincronizza cure e difese dell'intera squadra.",
-      "description_en": "Empathic mesh synchronizing team-wide heals and defenses."
+      "affinity": {
+        "total_species": 8,
+        "roles_breakdown": {
+          "optional": 8
+        },
+        "top_species": [
+          "archon-solare",
+          "balor-fission",
+          "couatl-aurora",
+          "glowcap-weaver",
+          "lupus-temperatus",
+          "marilith-vault",
+          "myco-spire-warden",
+          "rakshasa-corte"
+        ]
+      }
     },
     "enzimi_antifase_termica": {
       "label_it": "Enzimi Antifase Termica",
       "label_en": "Enzimi Antifase Termica",
+      "description_it": "Enzimi Antifase Termica permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di caldera glaciale.",
+      "description_en": "Enzimi Antifase Termica allow squads to gain grip and controlled acceleration across extreme terrain within caldera glaciale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Enzimi Antifase Termica permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di caldera glaciale.",
-      "description_en": "Enzimi Antifase Termica allow squads to gain grip and controlled acceleration across extreme terrain within caldera glaciale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      }
     },
     "enzimi_antipredatori_algali": {
       "label_it": "Enzimi Antipredatori Algali",
       "label_en": "Enzimi Antipredatori Algali",
+      "description_it": "Enzimi Antipredatori Algali permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di reef luminescente.",
+      "description_en": "Enzimi Antipredatori Algali allow squads to disperse energy and attenuate corrosive or thermal impacts within reef luminescente.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Enzimi Antipredatori Algali permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di reef luminescente.",
-      "description_en": "Enzimi Antipredatori Algali allow squads to disperse energy and attenuate corrosive or thermal impacts within reef luminescente."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "reef-luminescente-trait-keeper"
+        ]
+      }
     },
     "enzimi_chelanti": {
       "label_it": "Enzimi Chelanti",
       "label_en": "Enzimi Chelanti",
+      "description_it": "Enzimi Chelanti permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di ambienti dinamici.",
+      "description_en": "Enzimi Chelanti allow squads to stabilise multi-source energy absorption and conversion within ambienti dinamici.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "evento-tempesta-ferrosa",
+              "global-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Enzimi Chelanti permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di ambienti dinamici.",
-      "description_en": "Enzimi Chelanti allow squads to stabilise multi-source energy absorption and conversion within ambienti dinamici."
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 2
+        },
+        "top_species": [
+          "evento-tempesta-ferrosa",
+          "global-trait-keeper"
+        ]
+      }
     },
     "enzimi_chelatori_rapidi": {
       "label_it": "Enzimi Chelatori Rapidi",
       "label_en": "Enzimi Chelatori Rapidi",
+      "description_it": "Enzimi Chelatori Rapidi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di foresta acida.",
+      "description_en": "Enzimi Chelatori Rapidi allow squads to coordinate resource exchange and squad stabilisation parameters within foresta acida.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Enzimi Chelatori Rapidi permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di foresta acida.",
-      "description_en": "Enzimi Chelatori Rapidi allow squads to coordinate resource exchange and squad stabilisation parameters within foresta acida."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
+      }
     },
     "enzimi_metanoossidanti": {
       "label_it": "Enzimi Metanoossidanti",
       "label_en": "Enzimi Metanoossidanti",
+      "description_it": "Enzimi Metanoossidanti permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di abisso vulcanico.",
+      "description_en": "Enzimi Metanoossidanti allow squads to channel kinetic or elemental energy into targeted strikes within abisso vulcanico.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Enzimi Metanoossidanti permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di abisso vulcanico.",
-      "description_en": "Enzimi Metanoossidanti allow squads to channel kinetic or elemental energy into targeted strikes within abisso vulcanico."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      }
     },
     "epidermide_dielettrica": {
       "label_it": "Epidermide Dielettrica",
       "label_en": "Epidermide Dielettrica",
+      "description_it": "Epidermide Dielettrica permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di stratosfera tempestosa.",
+      "description_en": "Epidermide Dielettrica allow squads to predict trajectories and orchestrate multilayered setups within stratosfera tempestosa.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Epidermide Dielettrica permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di stratosfera tempestosa.",
-      "description_en": "Epidermide Dielettrica allow squads to predict trajectories and orchestrate multilayered setups within stratosfera tempestosa."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
+      }
     },
     "epitelio_fosforescente": {
       "label_it": "Epitelio Fosforescente",
       "label_en": "Epitelio Fosforescente",
+      "description_it": "Epitelio Fosforescente permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di reef luminescente.",
+      "description_en": "Epitelio Fosforescente allow squads to synchronise allied organisms and mutualistic flows within reef luminescente.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Epitelio Fosforescente permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di reef luminescente.",
-      "description_en": "Epitelio Fosforescente allow squads to synchronise allied organisms and mutualistic flows within reef luminescente."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "reef-luminescente-trait-keeper"
+        ]
+      }
     },
     "ermafroditismo_cronologico": {
       "label_it": "Ermafroditismo Cronologico",
       "label_en": "Chronological Hermaphroditism",
+      "description_it": "Cambiare sesso dopo 1–2 incubazioni.",
+      "description_en": "Change sex after one or two incubations.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Cambiare sesso dopo 1–2 incubazioni.",
-      "description_en": "Change sex after one or two incubations."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "estroflessione_gastrica_acida": {
       "label_it": "Estroflessione Gastrica Acida",
       "label_en": "Acidic Gastric Extrusion",
+      "description_it": "Liquefare tessuti al contatto e aspirarli.",
+      "description_en": "Liquefy tissues on contact and siphon them.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Liquefare tessuti al contatto e aspirarli.",
-      "description_en": "Liquefy tissues on contact and siphon them."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "fagocitosi_assorbente": {
       "label_it": "Fagocitosi Assorbente",
       "label_en": "Absorptive Phagocytosis",
+      "description_it": "Inglobare e digerire biomassa intera.",
+      "description_en": "Engulf and digest entire biomass.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Inglobare e digerire biomassa intera.",
-      "description_en": "Engulf and digest entire biomass."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "filamenti_digestivi_compattanti": {
-      "label_it": "Filamento materiali digeriti",
+      "label_it": "Filamenti Digestivi Compattanti",
       "label_en": "Digestive Compaction Filaments",
+      "description_it": "Filamenti digestivi che compattano scarti e liberano spazio vitale.",
+      "description_en": "Digestive filaments compact waste to free vital space.",
       "rules": {
-        "total": 1,
+        "total": 4,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "scavenger_corazzato",
+            "count": 1
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "scavenger_corazzato",
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 32,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "scavenger_corazzato",
+            "count": 8,
+            "examples": [
+              "caverna-risonante-trait-keeper",
+              "falde-magnetiche-psioniche-trait-keeper",
+              "glowcap-weaver",
+              "magnet-fathom-surveyor",
+              "myco-spire-warden"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": null,
+            "count": 8,
+            "examples": [
+              "caverna-risonante-trait-keeper",
+              "falde-magnetiche-psioniche-trait-keeper",
+              "glowcap-weaver",
+              "magnet-fathom-surveyor",
+              "myco-spire-warden"
+            ]
+          },
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 8,
+            "examples": [
+              "caverna-risonante-trait-keeper",
+              "falde-magnetiche-psioniche-trait-keeper",
+              "glowcap-weaver",
+              "magnet-fathom-surveyor",
+              "myco-spire-warden"
+            ]
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "scavenger_corazzato",
+            "count": 8,
+            "examples": [
+              "caverna-risonante-trait-keeper",
+              "falde-magnetiche-psioniche-trait-keeper",
+              "glowcap-weaver",
+              "magnet-fathom-surveyor",
+              "myco-spire-warden"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Filamenti digestivi che compattano scarti e liberano spazio vitale.",
-      "description_en": "Digestive filaments compact waste to free vital space."
+      "affinity": {
+        "total_species": 8,
+        "roles_breakdown": {
+          "core": 3,
+          "optional": 8
+        },
+        "top_species": [
+          "magnet-fathom-surveyor",
+          "nano-rust-bloom",
+          "rust-scavenger",
+          "caverna-risonante-trait-keeper",
+          "falde-magnetiche-psioniche-trait-keeper",
+          "glowcap-weaver",
+          "myco-spire-warden",
+          "thaw-rot"
+        ]
+      }
     },
     "filamenti_echo": {
       "label_it": "Filamenti Echo",
       "label_en": "Echo Filaments",
+      "description_it": "Filamenti che rilanciano frequenze di squadra e attenuano shear.",
+      "description_en": "Filaments relaying squad frequencies and softening shear.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Filamenti che rilanciano frequenze di squadra e attenuano shear.",
-      "description_en": "Filaments relaying squad frequencies and softening shear."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "filamenti_guidalampo": {
       "label_it": "Filamenti Guidalampo",
       "label_en": "Lightning Guide Filaments",
+      "description_it": "Filamenti che tracciano rotte sicure nelle correnti.",
+      "description_en": "Filaments plotting safe routes through currents.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Filamenti che tracciano rotte sicure nelle correnti.",
-      "description_en": "Filaments plotting safe routes through currents."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "filamenti_magnetotrofi": {
       "label_it": "Filamenti Magnetotrofi",
       "label_en": "Filamenti Magnetotrofi",
+      "description_it": "Filamenti Magnetotrofi permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di abisso vulcanico.",
+      "description_en": "Filamenti Magnetotrofi allow squads to redistribute load and modulate structural rigidity within abisso vulcanico.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Filamenti Magnetotrofi permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di abisso vulcanico.",
-      "description_en": "Filamenti Magnetotrofi allow squads to redistribute load and modulate structural rigidity within abisso vulcanico."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      }
     },
     "filamenti_superconduttivi": {
       "label_it": "Filamenti Superconduttivi",
       "label_en": "Filamenti Superconduttivi",
+      "description_it": "Filamenti Superconduttivi permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caldera glaciale.",
+      "description_en": "Filamenti Superconduttivi allow squads to interpret minute signals and unstable psionic patterns within caldera glaciale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Filamenti Superconduttivi permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caldera glaciale.",
-      "description_en": "Filamenti Superconduttivi allow squads to interpret minute signals and unstable psionic patterns within caldera glaciale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      }
     },
     "filamenti_termoconduzione": {
       "label_it": "Filamenti Termoconduzione",
       "label_en": "Filamenti Termoconduzione",
+      "description_it": "Filamenti Termoconduzione permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di dorsale termale tropicale.",
+      "description_en": "Filamenti Termoconduzione allow squads to gain grip and controlled acceleration across extreme terrain within dorsale termale tropicale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Filamenti Termoconduzione permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di dorsale termale tropicale.",
-      "description_en": "Filamenti Termoconduzione allow squads to gain grip and controlled acceleration across extreme terrain within dorsale termale tropicale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      }
     },
     "filtrazione_osmotica": {
       "label_it": "Filtrazione Osmotica",
       "label_en": "Osmotic Filtration",
+      "description_it": "Neutralizzare tossine autogenerate.",
+      "description_en": "Neutralize self-generated toxins.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Neutralizzare tossine autogenerate.",
-      "description_en": "Neutralize self-generated toxins."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "filtri_planctonici": {
       "label_it": "Filtri Planctonici",
       "label_en": "Filtri Planctonici",
+      "description_it": "Filtri Planctonici permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di laguna bioreattiva.",
+      "description_en": "Filtri Planctonici allow squads to disperse energy and attenuate corrosive or thermal impacts within laguna bioreattiva.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Filtri Planctonici permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di laguna bioreattiva.",
-      "description_en": "Filtri Planctonici allow squads to disperse energy and attenuate corrosive or thermal impacts within laguna bioreattiva."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "laguna-bioreattiva-trait-keeper"
+        ]
+      }
     },
     "filtro_metallofago": {
       "label_it": "Filtro Metallofago",
       "label_en": "Metallophagous Filter",
+      "description_it": "Sostenere organi elettrogeni.",
+      "description_en": "Sustain electrogenic organs.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Sostenere organi elettrogeni.",
-      "description_en": "Sustain electrogenic organs."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "flagelli_ancoranti": {
       "label_it": "Flagelli Ancoranti",
       "label_en": "Flagelli Ancoranti",
+      "description_it": "Flagelli Ancoranti permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di laguna bioreattiva.",
+      "description_en": "Flagelli Ancoranti allow squads to stabilise multi-source energy absorption and conversion within laguna bioreattiva.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Flagelli Ancoranti permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di laguna bioreattiva.",
-      "description_en": "Flagelli Ancoranti allow squads to stabilise multi-source energy absorption and conversion within laguna bioreattiva."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "laguna-bioreattiva-trait-keeper"
+        ]
+      }
     },
     "flusso_ameboide_controllato": {
       "label_it": "Flusso Ameboide Controllato",
       "label_en": "Controlled Amoeboid Flow",
+      "description_it": "Scivolare o risalire superfici lisce.",
+      "description_en": "Slide or climb along smooth surfaces.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Scivolare o risalire superfici lisce.",
-      "description_en": "Slide or climb along smooth surfaces."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "focus_frazionato": {
       "label_it": "Focus Frazionato",
       "label_en": "Fractional Focus",
+      "description_it": "Cortex biforcato che mantiene due minacce in sorveglianza attiva.",
+      "description_en": "Split cortex keeps two threats under active surveillance.",
       "rules": {
-        "total": 1,
+        "total": 3,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 24,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": null,
+            "count": 8,
+            "examples": [
+              "archon-solare",
+              "balor-fission",
+              "banshee-risonante",
+              "couatl-aurora",
+              "marilith-vault"
+            ]
+          },
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 8,
+            "examples": [
+              "archon-solare",
+              "balor-fission",
+              "banshee-risonante",
+              "couatl-aurora",
+              "marilith-vault"
+            ]
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": null,
+            "count": 8,
+            "examples": [
+              "archon-solare",
+              "balor-fission",
+              "banshee-risonante",
+              "couatl-aurora",
+              "marilith-vault"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Cortex biforcato che mantiene due minacce in sorveglianza attiva.",
-      "description_en": "Split cortex keeps two threats under active surveillance."
+      "affinity": {
+        "total_species": 8,
+        "roles_breakdown": {
+          "core": 3,
+          "optional": 3,
+          "synergy": 4
+        },
+        "top_species": [
+          "orbital-ascendant",
+          "psionic-canopy-scout",
+          "marilith-vault",
+          "archon-solare",
+          "balor-fission",
+          "banshee-risonante",
+          "couatl-aurora",
+          "sentinella-radice"
+        ]
+      }
     },
     "foliage_fotocatodico": {
       "label_it": "Foliage Fotocatodico",
       "label_en": "Foliage Fotocatodico",
+      "description_it": "Foliage Fotocatodico permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di foresta acida.",
+      "description_en": "Foliage Fotocatodico allow squads to coordinate resource exchange and squad stabilisation parameters within foresta acida.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Foliage Fotocatodico permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di foresta acida.",
-      "description_en": "Foliage Fotocatodico allow squads to coordinate resource exchange and squad stabilisation parameters within foresta acida."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
+      }
     },
     "foliaggio_spugna": {
       "label_it": "Foliaggio Spugna",
       "label_en": "Foliaggio Spugna",
+      "description_it": "Foliaggio Spugna permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di mangrovieto cinetico.",
+      "description_en": "Foliaggio Spugna allow squads to channel kinetic or elemental energy into targeted strikes within mangrovieto cinetico.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Foliaggio Spugna permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di mangrovieto cinetico.",
-      "description_en": "Foliaggio Spugna allow squads to channel kinetic or elemental energy into targeted strikes within mangrovieto cinetico."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
+      }
     },
     "frusta_fiammeggiante": {
       "label_it": "Frusta Fiammeggiante",
       "label_en": "Flame Lash",
+      "description_it": "Appendice di plasma vincolato capace di arpionare e incendiare bersagli.",
+      "description_en": "Bound plasma appendage that can hook and ignite targets.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "balor-fission",
+              "marilith-vault"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Appendice di plasma vincolato capace di arpionare e incendiare bersagli.",
-      "description_en": "Bound plasma appendage that can hook and ignite targets."
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "core": 2,
+          "optional": 1
+        },
+        "top_species": [
+          "balor-fission",
+          "marilith-vault"
+        ]
+      }
     },
     "ghiaccio_piezoelettrico": {
       "label_it": "Ghiaccio Piezoelettrico",
       "label_en": "Ghiaccio Piezoelettrico",
+      "description_it": "Ghiaccio Piezoelettrico permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di caldera glaciale.",
+      "description_en": "Ghiaccio Piezoelettrico allow squads to predict trajectories and orchestrate multilayered setups within caldera glaciale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ghiaccio Piezoelettrico permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di caldera glaciale.",
-      "description_en": "Ghiaccio Piezoelettrico allow squads to predict trajectories and orchestrate multilayered setups within caldera glaciale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      }
     },
     "ghiandola_caustica": {
       "label_it": "Ghiandola Caustica",
       "label_en": "Caustic Gland",
+      "description_it": "Ghiandola offensiva che spruzza acidi rapidi contro corazze leggere.",
+      "description_en": "Offensive gland spraying quick acid against light armor.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper",
+              "sentinella-radice"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ghiandola offensiva che spruzza acidi rapidi contro corazze leggere.",
-      "description_en": "Offensive gland spraying quick acid against light armor."
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 1
+        },
+        "top_species": [
+          "laguna-bioreattiva-trait-keeper",
+          "sentinella-radice"
+        ]
+      }
     },
     "ghiandole_cambio_salino": {
       "label_it": "Ghiandole Cambio Salino",
       "label_en": "Ghiandole Cambio Salino",
+      "description_it": "Ghiandole Cambio Salino permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di laguna bioreattiva.",
+      "description_en": "Ghiandole Cambio Salino allow squads to synchronise allied organisms and mutualistic flows within laguna bioreattiva.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "laguna_bioreattiva",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ghiandole Cambio Salino permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di laguna bioreattiva.",
-      "description_en": "Ghiandole Cambio Salino allow squads to synchronise allied organisms and mutualistic flows within laguna bioreattiva."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "laguna-bioreattiva-trait-keeper"
+        ]
+      }
     },
     "ghiandole_condensa_ozono": {
       "label_it": "Ghiandole Condensa Ozono",
       "label_en": "Ghiandole Condensa Ozono",
+      "description_it": "Ghiandole Condensa Ozono permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di stratosfera tempestosa.",
+      "description_en": "Ghiandole Condensa Ozono allow squads to redistribute load and modulate structural rigidity within stratosfera tempestosa.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ghiandole Condensa Ozono permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di stratosfera tempestosa.",
-      "description_en": "Ghiandole Condensa Ozono allow squads to redistribute load and modulate structural rigidity within stratosfera tempestosa."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
+      }
     },
     "ghiandole_eco_mappanti": {
       "label_it": "Ghiandole Eco Mappanti",
       "label_en": "Ghiandole Eco Mappanti",
+      "description_it": "Ghiandole Eco Mappanti permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante.",
+      "description_en": "Ghiandole Eco Mappanti allow squads to interpret minute signals and unstable psionic patterns within caverna risonante.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ghiandole Eco Mappanti permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante.",
-      "description_en": "Ghiandole Eco Mappanti allow squads to interpret minute signals and unstable psionic patterns within caverna risonante."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
+      }
     },
     "ghiandole_fango_calde": {
       "label_it": "Ghiandole Fango Calde",
       "label_en": "Ghiandole Fango Calde",
+      "description_it": "Ghiandole Fango Calde permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di abisso vulcanico.",
+      "description_en": "Ghiandole Fango Calde allow squads to gain grip and controlled acceleration across extreme terrain within abisso vulcanico.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ghiandole Fango Calde permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di abisso vulcanico.",
-      "description_en": "Ghiandole Fango Calde allow squads to gain grip and controlled acceleration across extreme terrain within abisso vulcanico."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      }
     },
     "ghiandole_fango_coesivo": {
       "label_it": "Ghiandole Fango Coesivo",
       "label_en": "Ghiandole Fango Coesivo",
+      "description_it": "Ghiandole Fango Coesivo permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di mangrovieto cinetico.",
+      "description_en": "Ghiandole Fango Coesivo allow squads to disperse energy and attenuate corrosive or thermal impacts within mangrovieto cinetico.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ghiandole Fango Coesivo permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di mangrovieto cinetico.",
-      "description_en": "Ghiandole Fango Coesivo allow squads to disperse energy and attenuate corrosive or thermal impacts within mangrovieto cinetico."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
+      }
     },
     "ghiandole_grafene": {
       "label_it": "Ghiandole Grafene",
       "label_en": "Ghiandole Grafene",
+      "description_it": "Ghiandole Grafene permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di steppe algoritmiche.",
+      "description_en": "Ghiandole Grafene allow squads to stabilise multi-source energy absorption and conversion within steppe algoritmiche.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "steppe-algoritmiche-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ghiandole Grafene permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di steppe algoritmiche.",
-      "description_en": "Ghiandole Grafene allow squads to stabilise multi-source energy absorption and conversion within steppe algoritmiche."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "steppe-algoritmiche-trait-keeper"
+        ]
+      }
     },
     "ghiandole_inchiostro_luce": {
       "label_it": "Ghiandole Inchiostro Luce",
       "label_en": "Ghiandole Inchiostro Luce",
+      "description_it": "Ghiandole Inchiostro Luce permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di reef luminescente.",
+      "description_en": "Ghiandole Inchiostro Luce allow squads to coordinate resource exchange and squad stabilisation parameters within reef luminescente.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "reef_luminescente",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "reef-luminescente-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ghiandole Inchiostro Luce permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di reef luminescente.",
-      "description_en": "Ghiandole Inchiostro Luce allow squads to coordinate resource exchange and squad stabilisation parameters within reef luminescente."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "reef-luminescente-trait-keeper"
+        ]
+      }
     },
     "ghiandole_iodoattive": {
       "label_it": "Ghiandole Iodoattive",
       "label_en": "Ghiandole Iodoattive",
+      "description_it": "Ghiandole Iodoattive permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di pianura salina iperarida.",
+      "description_en": "Ghiandole Iodoattive allow squads to channel kinetic or elemental energy into targeted strikes within pianura salina iperarida.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ghiandole Iodoattive permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di pianura salina iperarida.",
-      "description_en": "Ghiandole Iodoattive allow squads to channel kinetic or elemental energy into targeted strikes within pianura salina iperarida."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
+      }
     },
     "ghiandole_minerali": {
       "label_it": "Ghiandole Minerali",
       "label_en": "Ghiandole Minerali",
+      "description_it": "Ghiandole Minerali permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di dorsale termale tropicale.",
+      "description_en": "Ghiandole Minerali allow squads to predict trajectories and orchestrate multilayered setups within dorsale termale tropicale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ghiandole Minerali permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di dorsale termale tropicale.",
-      "description_en": "Ghiandole Minerali allow squads to predict trajectories and orchestrate multilayered setups within dorsale termale tropicale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      }
     },
     "ghiandole_mnemoniche": {
       "label_it": "Ghiandole Mnemoniche",
       "label_en": "Mnemonic Glands",
+      "description_it": "Secrezioni che trattengono copie attenuate di buff.",
+      "description_en": "Secretions holding attenuated buff copies.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Secrezioni che trattengono copie attenuate di buff.",
-      "description_en": "Secretions holding attenuated buff copies."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "ghiandole_nebbia_acida": {
       "label_it": "Ghiandole Nebbia Acida",
       "label_en": "Ghiandole Nebbia Acida",
+      "description_it": "Ghiandole Nebbia Acida permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di foresta acida.",
+      "description_en": "Ghiandole Nebbia Acida allow squads to synchronise allied organisms and mutualistic flows within foresta acida.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ghiandole Nebbia Acida permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di foresta acida.",
-      "description_en": "Ghiandole Nebbia Acida allow squads to synchronise allied organisms and mutualistic flows within foresta acida."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
+      }
     },
     "ghiandole_nebbia_ionica": {
       "label_it": "Ghiandole Nebbia Ionica",
       "label_en": "Ghiandole Nebbia Ionica",
+      "description_it": "Ghiandole Nebbia Ionica permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di canopia ionica.",
+      "description_en": "Ghiandole Nebbia Ionica allow squads to redistribute load and modulate structural rigidity within canopia ionica.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ghiandole Nebbia Ionica permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di canopia ionica.",
-      "description_en": "Ghiandole Nebbia Ionica allow squads to redistribute load and modulate structural rigidity within canopia ionica."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "canopia-ionica-trait-keeper"
+        ]
+      }
     },
     "ghiandole_resina_conduttiva": {
       "label_it": "Ghiandole Resina Conduttiva",
       "label_en": "Ghiandole Resina Conduttiva",
+      "description_it": "Ghiandole Resina Conduttiva permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di canopia ionica.",
+      "description_en": "Ghiandole Resina Conduttiva allow squads to interpret minute signals and unstable psionic patterns within canopia ionica.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ghiandole Resina Conduttiva permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di canopia ionica.",
-      "description_en": "Ghiandole Resina Conduttiva allow squads to interpret minute signals and unstable psionic patterns within canopia ionica."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "canopia-ionica-trait-keeper"
+        ]
+      }
     },
     "ghiandole_ventosa": {
       "label_it": "Ghiandole Ventosa",
       "label_en": "Ghiandole Ventosa",
+      "description_it": "Ghiandole Ventosa permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di caldera glaciale.",
+      "description_en": "Ghiandole Ventosa allow squads to gain grip and controlled acceleration across extreme terrain within caldera glaciale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ghiandole Ventosa permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di caldera glaciale.",
-      "description_en": "Ghiandole Ventosa allow squads to gain grip and controlled acceleration across extreme terrain within caldera glaciale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      }
     },
     "giunti_antitorsione": {
       "label_it": "Giunti Antitorsione",
       "label_en": "Giunti Antitorsione",
+      "description_it": "Giunti Antitorsione permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di mangrovieto cinetico.",
+      "description_en": "Giunti Antitorsione allow squads to disperse energy and attenuate corrosive or thermal impacts within mangrovieto cinetico.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Giunti Antitorsione permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di mangrovieto cinetico.",
-      "description_en": "Giunti Antitorsione allow squads to disperse energy and attenuate corrosive or thermal impacts within mangrovieto cinetico."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
+      }
     },
     "grassi_termici": {
       "label_it": "Grassi Termici",
       "label_en": "Grassi Termici",
+      "description_it": "Grassi Termici permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di ambienti dinamici.",
+      "description_en": "Grassi Termici allow squads to stabilise multi-source energy absorption and conversion within ambienti dinamici.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 7,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 7,
+            "examples": [
+              "cactus-weaver",
+              "evento-brinastorm",
+              "evento-ondata-termica",
+              "global-trait-keeper",
+              "noctule-termico"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Grassi Termici permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di ambienti dinamici.",
-      "description_en": "Grassi Termici allow squads to stabilise multi-source energy absorption and conversion within ambienti dinamici."
+      "affinity": {
+        "total_species": 7,
+        "roles_breakdown": {
+          "optional": 7
+        },
+        "top_species": [
+          "cactus-weaver",
+          "evento-brinastorm",
+          "evento-ondata-termica",
+          "global-trait-keeper",
+          "noctule-termico",
+          "silica-bloom",
+          "thermo-raptor"
+        ]
+      }
     },
     "gusci_criovetro": {
       "label_it": "Gusci Criovetro",
       "label_en": "Gusci Criovetro",
+      "description_it": "Gusci Criovetro permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di caldera glaciale.",
+      "description_en": "Gusci Criovetro allow squads to coordinate resource exchange and squad stabilisation parameters within caldera glaciale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Gusci Criovetro permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di caldera glaciale.",
-      "description_en": "Gusci Criovetro allow squads to coordinate resource exchange and squad stabilisation parameters within caldera glaciale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      }
     },
     "gusci_magnesio": {
       "label_it": "Gusci Magnesio",
       "label_en": "Gusci Magnesio",
+      "description_it": "Gusci Magnesio permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di dorsale termale tropicale.",
+      "description_en": "Gusci Magnesio allow squads to channel kinetic or elemental energy into targeted strikes within dorsale termale tropicale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Gusci Magnesio permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di dorsale termale tropicale.",
-      "description_en": "Gusci Magnesio allow squads to channel kinetic or elemental energy into targeted strikes within dorsale termale tropicale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      }
     },
     "impulsi_bioluminescenti": {
       "label_it": "Impulsi Bioluminescenti",
       "label_en": "Bioluminescent Pulses",
+      "description_it": "Scariche ritmiche che abbagliano e sincronizzano alleati.",
+      "description_en": "Rhythmic flashes that dazzle foes and sync allies.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "leviatano_risonante",
+              "polpo_araldo_sinaptico"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Scariche ritmiche che abbagliano e sincronizzano alleati.",
-      "description_en": "Rhythmic flashes that dazzle foes and sync allies."
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "core": 2
+        },
+        "top_species": [
+          "polpo_araldo_sinaptico",
+          "leviatano_risonante"
+        ]
+      }
     },
     "integumento_bipolare": {
       "label_it": "Integumento Bipolare",
       "label_en": "Bipolar Integument",
+      "description_it": "Orientarsi lungo le linee di campo.",
+      "description_en": "Orient along magnetic field lines.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Orientarsi lungo le linee di campo.",
-      "description_en": "Orient along magnetic field lines."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "ipertrofia_muscolare_massiva": {
       "label_it": "Ipertrofia Muscolare Massiva",
       "label_en": "Massive Muscular Hypertrophy",
+      "description_it": "Fibre a sezione aumentata e mitocondri densi che sprigionano potenza e scatto sostenendo sforzi brevi.",
+      "description_en": "Broadened fibres with dense mitochondria that unleash power and acceleration while enduring short bursts.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Fibre a sezione aumentata e mitocondri densi che sprigionano potenza e scatto sostenendo sforzi brevi.",
-      "description_en": "Broadened fibres with dense mitochondria that unleash power and acceleration while enduring short bursts."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "lamelle_shear": {
       "label_it": "Lamelle Shear",
       "label_en": "Lamelle Shear",
+      "description_it": "Lamelle Shear permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di stratosfera tempestosa.",
+      "description_en": "Lamelle Shear allow squads to predict trajectories and orchestrate multilayered setups within stratosfera tempestosa.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "stratosfera_tempestosa",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "stratosfera-tempestosa-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Lamelle Shear permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di stratosfera tempestosa.",
-      "description_en": "Lamelle Shear allow squads to predict trajectories and orchestrate multilayered setups within stratosfera tempestosa."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "stratosfera-tempestosa-trait-keeper"
+        ]
+      }
     },
     "lamelle_sincroniche": {
       "label_it": "Lamelle Sincroniche",
       "label_en": "Lamelle Sincroniche",
+      "description_it": "Lamelle Sincroniche permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di steppe algoritmiche.",
+      "description_en": "Lamelle Sincroniche allow squads to synchronise allied organisms and mutualistic flows within steppe algoritmiche.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "steppe-algoritmiche-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Lamelle Sincroniche permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di steppe algoritmiche.",
-      "description_en": "Lamelle Sincroniche allow squads to synchronise allied organisms and mutualistic flows within steppe algoritmiche."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "steppe-algoritmiche-trait-keeper"
+        ]
+      }
     },
     "lamelle_termoforetiche": {
       "label_it": "Lamelle Termoforetiche",
       "label_en": "Thermophoretic Lamellae",
+      "description_it": "Lamelle respiratorie che deviano gas estremi con gradienti termici.",
+      "description_en": "Respiratory lamellae deflect extreme gases via heat gradients.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 5,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 5,
+            "examples": [
+              "bulette-fase",
+              "couatl-aurora",
+              "magnet-fathom-surveyor",
+              "otyugh-sentinella",
+              "sorgenti-geotermiche-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Lamelle respiratorie che deviano gas estremi con gradienti termici.",
-      "description_en": "Respiratory lamellae deflect extreme gases via heat gradients."
+      "affinity": {
+        "total_species": 5,
+        "roles_breakdown": {
+          "optional": 5
+        },
+        "top_species": [
+          "bulette-fase",
+          "couatl-aurora",
+          "magnet-fathom-surveyor",
+          "otyugh-sentinella",
+          "sorgenti-geotermiche-trait-keeper"
+        ]
+      }
     },
     "lamine_filtranti_aeree": {
       "label_it": "Lamine Filtranti Aeree",
       "label_en": "Lamine Filtranti Aeree",
+      "description_it": "Lamine Filtranti Aeree permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di mangrovieto cinetico.",
+      "description_en": "Lamine Filtranti Aeree allow squads to redistribute load and modulate structural rigidity within mangrovieto cinetico.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Lamine Filtranti Aeree permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di mangrovieto cinetico.",
-      "description_en": "Lamine Filtranti Aeree allow squads to redistribute load and modulate structural rigidity within mangrovieto cinetico."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
+      }
     },
     "lamine_scudo_silice": {
       "label_it": "Lamine Scudo Silice",
       "label_en": "Lamine Scudo Silice",
+      "description_it": "Lamine Scudo Silice permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di dorsale termale tropicale.",
+      "description_en": "Lamine Scudo Silice allow squads to interpret minute signals and unstable psionic patterns within dorsale termale tropicale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dorsale-termale-tropicale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Lamine Scudo Silice permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di dorsale termale tropicale.",
-      "description_en": "Lamine Scudo Silice allow squads to interpret minute signals and unstable psionic patterns within dorsale termale tropicale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dorsale-termale-tropicale-trait-keeper"
+        ]
+      }
     },
     "linfa_tampone": {
       "label_it": "Linfa Tampone",
       "label_en": "Linfa Tampone",
+      "description_it": "Linfa Tampone permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di foresta acida.",
+      "description_en": "Linfa Tampone allow squads to gain grip and controlled acceleration across extreme terrain within foresta acida.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "foresta_acida",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foresta-acida-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Linfa Tampone permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di foresta acida.",
-      "description_en": "Linfa Tampone allow squads to gain grip and controlled acceleration across extreme terrain within foresta acida."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foresta-acida-trait-keeper"
+        ]
+      }
     },
     "lingua_cristallina": {
       "label_it": "Lingua Cristallina",
       "label_en": "Lingua Cristallina",
+      "description_it": "Lingua Cristallina permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di pianura salina iperarida.",
+      "description_en": "Lingua Cristallina allow squads to disperse energy and attenuate corrosive or thermal impacts within pianura salina iperarida.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Lingua Cristallina permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di pianura salina iperarida.",
-      "description_en": "Lingua Cristallina allow squads to disperse energy and attenuate corrosive or thermal impacts within pianura salina iperarida."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
+      }
     },
     "lingua_tattile_trama": {
       "label_it": "Lingua Tattile Trama-Sensibile",
       "label_en": "Texture-Sensing Tongue",
+      "description_it": "Lingua sensoriale che legge vibrazioni e fratture nascoste.",
+      "description_en": "Sensory tongue reading hidden vibrations and fractures.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 4,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 4,
+            "examples": [
+              "blight-micotico",
+              "caverna-risonante-trait-keeper",
+              "echo-wing",
+              "ferrocolonia-magnetotattica"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Lingua sensoriale che legge vibrazioni e fratture nascoste.",
-      "description_en": "Sensory tongue reading hidden vibrations and fractures."
+      "affinity": {
+        "total_species": 4,
+        "roles_breakdown": {
+          "optional": 4
+        },
+        "top_species": [
+          "blight-micotico",
+          "caverna-risonante-trait-keeper",
+          "echo-wing",
+          "ferrocolonia-magnetotattica"
+        ]
+      }
     },
     "lobi_risonanti_crepuscolo": {
       "label_it": "Lobi Risonanti Crepuscolo",
       "label_en": "Twilight Resonant Lobes",
+      "description_it": "Camere risonanti che filtrano segnali instabili.",
+      "description_en": "Resonant chambers filtering unstable signals.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 3,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 3,
+            "examples": [
+              "leviatano_risonante",
+              "polpo_araldo_sinaptico",
+              "simbionte_corallino_riflesso"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Camere risonanti che filtrano segnali instabili.",
-      "description_en": "Resonant chambers filtering unstable signals."
+      "affinity": {
+        "total_species": 3,
+        "roles_breakdown": {
+          "core": 3
+        },
+        "top_species": [
+          "polpo_araldo_sinaptico",
+          "leviatano_risonante",
+          "simbionte_corallino_riflesso"
+        ]
+      }
     },
     "locomozione_miriapode_ibrida": {
       "label_it": "Locomozione Miriapode Ibrida",
       "label_en": "Hybrid Myriapod Locomotion",
+      "description_it": "Aderire e arrampicare su qualsiasi superficie.",
+      "description_en": "Grip and climb on nearly any surface.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Aderire e arrampicare su qualsiasi superficie.",
-      "description_en": "Grip and climb on nearly any surface."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "luminescenza_aurorale": {
       "label_it": "Luminescenza Aurorale",
       "label_en": "Luminescenza Aurorale",
+      "description_it": "Luminescenza Aurorale permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di caldera glaciale.",
+      "description_en": "Luminescenza Aurorale allow squads to stabilise multi-source energy absorption and conversion within caldera glaciale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Luminescenza Aurorale permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di caldera glaciale.",
-      "description_en": "Luminescenza Aurorale allow squads to stabilise multi-source energy absorption and conversion within caldera glaciale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      }
     },
     "luminescenza_hydrotermica": {
       "label_it": "Luminescenza Hydrotermica",
       "label_en": "Luminescenza Hydrotermica",
+      "description_it": "Luminescenza Hydrotermica permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di abisso vulcanico.",
+      "description_en": "Luminescenza Hydrotermica allow squads to coordinate resource exchange and squad stabilisation parameters within abisso vulcanico.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Luminescenza Hydrotermica permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di abisso vulcanico.",
-      "description_en": "Luminescenza Hydrotermica allow squads to coordinate resource exchange and squad stabilisation parameters within abisso vulcanico."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      }
     },
     "mantelli_geotermici": {
       "label_it": "Mantelli Geotermici",
       "label_en": "Mantelli Geotermici",
+      "description_it": "Mantelli Geotermici permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di caldera glaciale.",
+      "description_en": "Mantelli Geotermici allow squads to channel kinetic or elemental energy into targeted strikes within caldera glaciale.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caldera_glaciale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caldera-glaciale-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Mantelli Geotermici permette alle squadre di canalizzare energia cinetica o elementale in colpi mirati all'interno di caldera glaciale.",
-      "description_en": "Mantelli Geotermici allow squads to channel kinetic or elemental energy into targeted strikes within caldera glaciale."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caldera-glaciale-trait-keeper"
+        ]
+      }
     },
     "mantello_meteoritico": {
       "label_it": "Mantello Meteoritico",
       "label_en": "Meteoric Mantle",
+      "description_it": "Strati ablativi rigeneranti che vaporizzano l'impatto convertendolo in impulso termico.",
+      "description_en": "Regenerating ablative layers that vaporize impacts into thermal pulses.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "balor-fission",
+              "marilith-vault"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Strati ablativi rigeneranti che vaporizzano l'impatto convertendolo in impulso termico.",
-      "description_en": "Regenerating ablative layers that vaporize impacts into thermal pulses."
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "core": 2,
+          "optional": 1
+        },
+        "top_species": [
+          "balor-fission",
+          "marilith-vault"
+        ]
+      }
     },
     "membrana_plastica_continua": {
       "label_it": "Membrana Plastica Continua",
       "label_en": "Continuous Plastic Membrane",
+      "description_it": "Assumere forme e densità diverse.",
+      "description_en": "Adopt different shapes and densities.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Assumere forme e densità diverse.",
-      "description_en": "Adopt different shapes and densities."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "membrane_captura_rugiada": {
       "label_it": "Membrane Captura Rugiada",
       "label_en": "Membrane Captura Rugiada",
+      "description_it": "Membrane Captura Rugiada permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di pianura salina iperarida.",
+      "description_en": "Membrane Captura Rugiada allow squads to predict trajectories and orchestrate multilayered setups within pianura salina iperarida.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "pianura-salina-iperarida-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Membrane Captura Rugiada permette alle squadre di prevedere traiettorie e orchestrare setup multilivello all'interno di pianura salina iperarida.",
-      "description_en": "Membrane Captura Rugiada allow squads to predict trajectories and orchestrate multilayered setups within pianura salina iperarida."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "pianura-salina-iperarida-trait-keeper"
+        ]
+      }
     },
     "membrane_eliofiltranti": {
       "label_it": "Membrane Eliofiltranti",
       "label_en": "Membrane Eliofiltranti",
+      "description_it": "Membrane traslucide che schermano radiazioni e patogeni sospesi.",
+      "description_en": "Translucent membranes screening radiation and airborne pathogens.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "laghi-alcalini-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Membrane traslucide che schermano radiazioni e patogeni sospesi.",
-      "description_en": "Translucent membranes screening radiation and airborne pathogens."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "laghi-alcalini-trait-keeper"
+        ]
+      }
     },
     "membrane_fotoconvoglianti": {
       "label_it": "Membrane Fotoconvoglianti",
       "label_en": "Photoconductive Membranes",
+      "description_it": "Tessuti che trasportano cariche luminose tra nodi sinaptici.",
+      "description_en": "Tissues that ferry luminous charge between synaptic nodes.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Tessuti che trasportano cariche luminose tra nodi sinaptici.",
-      "description_en": "Tissues that ferry luminous charge between synaptic nodes."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "membrane_planata_vectored": {
       "label_it": "Membrane Planata Vectored",
       "label_en": "Membrane Planata Vectored",
+      "description_it": "Membrane Planata Vectored permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di canopia ionica.",
+      "description_en": "Membrane Planata Vectored allow squads to synchronise allied organisms and mutualistic flows within canopia ionica.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "canopia_ionica",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "canopia-ionica-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Membrane Planata Vectored permette alle squadre di sincronizzare organismi alleati e flussi mutualistici all'interno di canopia ionica.",
-      "description_en": "Membrane Planata Vectored allow squads to synchronise allied organisms and mutualistic flows within canopia ionica."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "canopia-ionica-trait-keeper"
+        ]
+      }
     },
     "membrane_pneumatofori": {
       "label_it": "Membrane Pneumatofori",
       "label_en": "Membrane Pneumatofori",
+      "description_it": "Membrane Pneumatofori permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di mangrovieto cinetico.",
+      "description_en": "Membrane Pneumatofori allow squads to redistribute load and modulate structural rigidity within mangrovieto cinetico.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "mangrovieto_cinetico",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "mangrovieto-cinetico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Membrane Pneumatofori permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di mangrovieto cinetico.",
-      "description_en": "Membrane Pneumatofori allow squads to redistribute load and modulate structural rigidity within mangrovieto cinetico."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "mangrovieto-cinetico-trait-keeper"
+        ]
+      }
     },
     "metabolismo_di_condivisione_energetica": {
       "label_it": "Metabolismo di Condivisione Energetica",
       "label_en": "Shared Energy Metabolism",
+      "description_it": "Trasferimento di substrati via contatto per sostenere feriti o giovani con una riserva collettiva.",
+      "description_en": "Contact-based substrate transfer to sustain wounded or young with a collective reserve.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Trasferimento di substrati via contatto per sostenere feriti o giovani con una riserva collettiva.",
-      "description_en": "Contact-based substrate transfer to sustain wounded or young with a collective reserve."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "midollo_antivibrazione": {
       "label_it": "Midollo Antivibrazione",
       "label_en": "Midollo Antivibrazione",
+      "description_it": "Midollo Antivibrazione permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante.",
+      "description_en": "Midollo Antivibrazione allow squads to interpret minute signals and unstable psionic patterns within caverna risonante.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Midollo Antivibrazione permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante.",
-      "description_en": "Midollo Antivibrazione allow squads to interpret minute signals and unstable psionic patterns within caverna risonante."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
+      }
     },
     "mimetismo_cromatico_passivo": {
       "label_it": "Ghiandole di Mimetismo Cromatico Passivo",
       "label_en": "Passive Chromatic Mimicry",
+      "description_it": "Cromatofori passivi che replicano lentamente i colori circostanti.",
+      "description_en": "Passive chromatophores slowly mirroring surrounding hues.",
       "rules": {
-        "total": 1,
+        "total": 3,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "ingegnere_radicante",
+            "count": 1
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "volatore_planatore",
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 18,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": null,
+            "count": 6,
+            "examples": [
+              "aurora-bridge-runner",
+              "canopia-psionica-leggera-trait-keeper",
+              "falde-magnetiche-psioniche-trait-keeper",
+              "ferrocolonia-magnetotattica",
+              "psionic-canopy-scout"
+            ]
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "ingegnere_radicante",
+            "count": 6,
+            "examples": [
+              "aurora-bridge-runner",
+              "canopia-psionica-leggera-trait-keeper",
+              "falde-magnetiche-psioniche-trait-keeper",
+              "ferrocolonia-magnetotattica",
+              "psionic-canopy-scout"
+            ]
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "volatore_planatore",
+            "count": 6,
+            "examples": [
+              "aurora-bridge-runner",
+              "canopia-psionica-leggera-trait-keeper",
+              "falde-magnetiche-psioniche-trait-keeper",
+              "ferrocolonia-magnetotattica",
+              "psionic-canopy-scout"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Cromatofori passivi che replicano lentamente i colori circostanti.",
-      "description_en": "Passive chromatophores slowly mirroring surrounding hues."
+      "affinity": {
+        "total_species": 6,
+        "roles_breakdown": {
+          "core": 2,
+          "optional": 6
+        },
+        "top_species": [
+          "ferrocolonia-magnetotattica",
+          "psionic-canopy-scout",
+          "aurora-bridge-runner",
+          "canopia-psionica-leggera-trait-keeper",
+          "falde-magnetiche-psioniche-trait-keeper",
+          "zephyr-spore-courier"
+        ]
+      }
     },
     "moltiplicazione_per_fusione": {
       "label_it": "Moltiplicazione per Fusione",
       "label_en": "Fusion Multiplication",
+      "description_it": "Aumentare massa e intelligenza unendo unità.",
+      "description_en": "Grow mass and intellect by merging units.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Aumentare massa e intelligenza unendo unità.",
-      "description_en": "Grow mass and intellect by merging units."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "motore_biologico_silenzioso": {
       "label_it": "Motore Biologico Silenzioso",
       "label_en": "Silent Biological Engine",
+      "description_it": "Garantire volo prolungato a bassissimo SPL.",
+      "description_en": "Maintain extended flight at ultra-low sound pressure.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Garantire volo prolungato a bassissimo SPL.",
-      "description_en": "Maintain extended flight at ultra-low sound pressure."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "mucillagine_simbionte_mangrovie": {
       "label_it": "Mucillagine Simbionte delle Mangrovie",
       "label_en": "Mucillagine Simbionte delle Mangrovie",
+      "description_it": "Mucosa simbionte che assorbe veleni e sigilla ferite palustri.",
+      "description_en": "Symbiotic mucus absorbing poisons and sealing swamp wounds.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "mangrovie-risonanti-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Mucosa simbionte che assorbe veleni e sigilla ferite palustri.",
-      "description_en": "Symbiotic mucus absorbing poisons and sealing swamp wounds."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "mangrovie-risonanti-trait-keeper"
+        ]
+      }
     },
     "mucose_aderenza_sonica": {
       "label_it": "Mucose Aderenza Sonica",
       "label_en": "Mucose Aderenza Sonica",
+      "description_it": "Mucose Aderenza Sonica permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di caverna risonante.",
+      "description_en": "Mucose Aderenza Sonica allow squads to gain grip and controlled acceleration across extreme terrain within caverna risonante.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "caverna_risonante",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "caverna-risonante-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Mucose Aderenza Sonica permette alle squadre di ottenere presa e accelerazioni controllate su terreni estremi all'interno di caverna risonante.",
-      "description_en": "Mucose Aderenza Sonica allow squads to gain grip and controlled acceleration across extreme terrain within caverna risonante."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "caverna-risonante-trait-keeper"
+        ]
+      }
     },
     "mucose_barofile": {
       "label_it": "Mucose Barofile",
       "label_en": "Mucose Barofile",
+      "description_it": "Mucose Barofile permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di abisso vulcanico.",
+      "description_en": "Mucose Barofile allow squads to disperse energy and attenuate corrosive or thermal impacts within abisso vulcanico.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "abisso_vulcanico",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "abisso-vulcanico-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Mucose Barofile permette alle squadre di disperdere energia e attenuare impatti corrosivi o termici all'interno di abisso vulcanico.",
-      "description_en": "Mucose Barofile allow squads to disperse energy and attenuate corrosive or thermal impacts within abisso vulcanico."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "abisso-vulcanico-trait-keeper"
+        ]
+      }
     },
     "nebbia_mnesica": {
       "label_it": "Nebbia Mnesica",
       "label_en": "Mnesic Fog",
+      "description_it": "Foschia psionica che offusca memorie e orientamento.",
+      "description_en": "Psionic mist that blurs memory and orientation.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "sciame_larve_neurali"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Foschia psionica che offusca memorie e orientamento.",
-      "description_en": "Psionic mist that blurs memory and orientation."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "sciame_larve_neurali"
+        ]
+      }
     },
     "nodi_micorrizici_oracolari": {
       "label_it": "Nodi Micorrizici Oracolari",
       "label_en": "Nodi Micorrizici Oracolari",
+      "description_it": "Nodi micorrizici che anticipano minacce tramite segnali fungini.",
+      "description_en": "Mycorrhizal nodes foreseeing threats via fungal signals.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "reti-micorriziche-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Nodi micorrizici che anticipano minacce tramite segnali fungini.",
-      "description_en": "Mycorrhizal nodes foreseeing threats via fungal signals."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "reti-micorriziche-trait-keeper"
+        ]
+      }
     },
     "nodi_sinaptici_superficiali": {
       "label_it": "Nodi Sinaptici Superficiali",
       "label_en": "Surface Synaptic Nodes",
+      "description_it": "Reticolo di nodi che amplificano segnali superficiali.",
+      "description_en": "Node lattice amplifying surface signals.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Reticolo di nodi che amplificano segnali superficiali.",
-      "description_en": "Node lattice amplifying surface signals."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "nucleo_ovomotore_rotante": {
       "label_it": "Uovo rotaia, uovo grande e uova piccole dentro...",
       "label_en": "Rotating Ovomotor Core",
+      "description_it": "Nucleo rotante che trasforma il corpo in una ruota motrice.",
+      "description_en": "Rotating core turning the body into a driving wheel.",
       "rules": {
-        "total": 1,
+        "total": 3,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 6,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 2,
+            "examples": [
+              "marilith-vault",
+              "psionic-canopy-scout"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "marilith-vault",
+              "psionic-canopy-scout"
+            ]
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "marilith-vault",
+              "psionic-canopy-scout"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Nucleo rotante che trasforma il corpo in una ruota motrice.",
-      "description_en": "Rotating core turning the body into a driving wheel."
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 1
+        },
+        "top_species": [
+          "marilith-vault",
+          "psionic-canopy-scout"
+        ]
+      }
     },
     "occhi_analizzatori_di_tensione": {
       "label_it": "Occhi Analizzatori di Tensione",
       "label_en": "Tension-Analyzing Eyes",
+      "description_it": "Leggere tensioni nella seta e pattern di stress.",
+      "description_en": "Read strand tension and stress patterns.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Leggere tensioni nella seta e pattern di stress.",
-      "description_en": "Read strand tension and stress patterns."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "occhi_cinetici": {
       "label_it": "Occhi Cinetici",
       "label_en": "Kinetic Eyes",
+      "description_it": "Vedere il suono come pattern d’aria.",
+      "description_en": "See sound as patterns in the air.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Vedere il suono come pattern d’aria.",
-      "description_en": "See sound as patterns in the air."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "occhi_cristallo_modulare": {
       "label_it": "Occhi a Cristallo Modulare",
       "label_en": "Modular Crystal Eyes",
+      "description_it": "Prismi sovrapposti che riallineano il fuoco tra spettro visibile e ionico, utili in microgravità variabile.",
+      "description_en": "Layered prisms retuning focus across visible and ionic spectra, useful in variable microgravity.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "orbital-ascendant",
+              "psionic-canopy-scout"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Prismi sovrapposti che riallineano il fuoco tra spettro visibile e ionico, utili in microgravità variabile.",
-      "description_en": "Layered prisms retuning focus across visible and ionic spectra, useful in variable microgravity."
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 1
+        },
+        "top_species": [
+          "orbital-ascendant",
+          "psionic-canopy-scout"
+        ]
+      }
     },
     "occhi_infrarosso_composti": {
       "label_it": "Occhi Composti ad Infrarosso",
       "label_en": "Infrared Compound Eyes",
+      "description_it": "Ommatidi infrarossi che seguono scie termiche nell'oscurità.",
+      "description_en": "Infrared ommatidia tracking thermal trails in darkness.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "volatore_planatore",
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "volatore_planatore",
+            "count": 2,
+            "examples": [
+              "caverna-risonante-trait-keeper",
+              "echo-wing"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ommatidi infrarossi che seguono scie termiche nell'oscurità.",
-      "description_en": "Infrared ommatidia tracking thermal trails in darkness."
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 2
+        },
+        "top_species": [
+          "echo-wing",
+          "caverna-risonante-trait-keeper"
+        ]
+      }
     },
     "olfatto_risonanza_magnetica": {
       "label_it": "Olfatto di Risonanza Magnetica",
       "label_en": "Magnetic Resonance Scent",
+      "description_it": "Bulbi olfattivi che tracciano campi magnetici e vene metalliche.",
+      "description_en": "Olfactory nodes tracing magnetic fields and metal veins.",
       "rules": {
-        "total": 1,
+        "total": 4,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 36,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 9,
+            "examples": [
+              "cryo-lynx",
+              "dune-stalker",
+              "falde-magnetiche-psioniche-trait-keeper",
+              "magnet-fathom-surveyor",
+              "magneto-ridge-hunter"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": null,
+            "count": 9,
+            "examples": [
+              "cryo-lynx",
+              "dune-stalker",
+              "falde-magnetiche-psioniche-trait-keeper",
+              "magnet-fathom-surveyor",
+              "magneto-ridge-hunter"
+            ]
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 9,
+            "examples": [
+              "cryo-lynx",
+              "dune-stalker",
+              "falde-magnetiche-psioniche-trait-keeper",
+              "magnet-fathom-surveyor",
+              "magneto-ridge-hunter"
+            ]
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": null,
+            "count": 9,
+            "examples": [
+              "cryo-lynx",
+              "dune-stalker",
+              "falde-magnetiche-psioniche-trait-keeper",
+              "magnet-fathom-surveyor",
+              "magneto-ridge-hunter"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Bulbi olfattivi che tracciano campi magnetici e vene metalliche.",
-      "description_en": "Olfactory nodes tracing magnetic fields and metal veins."
+      "affinity": {
+        "total_species": 9,
+        "roles_breakdown": {
+          "core": 3,
+          "optional": 9
+        },
+        "top_species": [
+          "magnet-fathom-surveyor",
+          "orbital-ascendant",
+          "slag-veil-ambusher",
+          "cryo-lynx",
+          "dune-stalker",
+          "falde-magnetiche-psioniche-trait-keeper",
+          "magneto-ridge-hunter",
+          "orbita-psionica-inversa-trait-keeper",
+          "psionic-canopy-scout"
+        ]
+      }
     },
     "organi_metacronici": {
       "label_it": "Organi Metacronici",
       "label_en": "Metachronic Organs",
+      "description_it": "Organi che sequenziano furti di buff in catena.",
+      "description_en": "Organs sequencing chained buff thefts.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Organi che sequenziano furti di buff in catena.",
-      "description_en": "Organs sequencing chained buff thefts."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "organi_sismici_cutanei": {
       "label_it": "Organi Sismici Cutanei",
       "label_en": "Cutaneous Seismic Organs",
+      "description_it": "Lamelle meccano-recettive nelle squame che percepiscono vibrazioni del suolo e movimenti occultati.",
+      "description_en": "Mechano-receptive lamellae in the scales sensing ground vibrations and hidden movements.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Lamelle meccano-recettive nelle squame che percepiscono vibrazioni del suolo e movimenti occultati.",
-      "description_en": "Mechano-receptive lamellae in the scales sensing ground vibrations and hidden movements."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "pathfinder": {
       "label_it": "Pathfinder",
       "label_en": "Pathfinder",
+      "description_it": "Suite esplorativa che evidenzia rotte sicure tra biomi imprevedibili.",
+      "description_en": "Exploration suite highlighting safe routes across shifting biomes.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "psionic-canopy-scout",
+              "sentinella-radice"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Suite esplorativa che evidenzia rotte sicure tra biomi imprevedibili.",
-      "description_en": "Exploration suite highlighting safe routes across shifting biomes."
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 1
+        },
+        "top_species": [
+          "psionic-canopy-scout",
+          "sentinella-radice"
+        ]
+      }
     },
     "pelage_idrorepellente_avanzato": {
       "label_it": "Pelage Idrorepellente Avanzato",
       "label_en": "Advanced Hydrophobic Pelage",
+      "description_it": "Isolare e galleggiare.",
+      "description_en": "Insulate the body and stay afloat.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Isolare e galleggiare.",
-      "description_en": "Insulate the body and stay afloat."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "pelle_piezo_satura": {
       "label_it": "Pelle Piezo-Satura",
       "label_en": "Piezo-Saturated Skin",
+      "description_it": "Dermide che accumula carica piezoelettrica e riflette colpi (temp).",
+      "description_en": "Dermis storing piezo charge and reflecting blows (temp).",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "leviatano_risonante"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Dermide che accumula carica piezoelettrica e riflette colpi (temp).",
-      "description_en": "Dermis storing piezo charge and reflecting blows (temp)."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "temp": 1
+        },
+        "top_species": [
+          "leviatano_risonante"
+        ]
+      }
     },
     "pianificatore": {
       "label_it": "Pianificatore",
       "label_en": "Strategic Planner",
+      "description_it": "Modulo strategico che mantiene priorità e finestre d'attacco allineate.",
+      "description_en": "Strategic module keeping priorities and attack windows aligned.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "sentinella-radice"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Modulo strategico che mantiene priorità e finestre d'attacco allineate.",
-      "description_en": "Strategic module keeping priorities and attack windows aligned."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "sentinella-radice"
+        ]
+      }
     },
     "piume_solari_fotovoltaiche": {
       "label_it": "Piume Solari Fotovoltaiche",
       "label_en": "Piume Solari Fotovoltaiche",
+      "description_it": "Piumaggio fotovoltaico che immagazzina luce per lunghe missioni.",
+      "description_en": "Photovoltaic plumage storing sunlight for long sorties.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "altipiani-solari-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Piumaggio fotovoltaico che immagazzina luce per lunghe missioni.",
-      "description_en": "Photovoltaic plumage storing sunlight for long sorties."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "altipiani-solari-trait-keeper"
+        ]
+      }
     },
     "placca_diffusione_foschia": {
       "label_it": "Placca di Diffusione Foschia",
       "label_en": "Fog Diffusion Plate",
+      "description_it": "Placche che diffondono e attenuano cariche erratiche.",
+      "description_en": "Plates diffusing and attenuating erratic charges.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Placche che diffondono e attenuano cariche erratiche.",
-      "description_en": "Plates diffusing and attenuating erratic charges."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "placche_pressioniche": {
       "label_it": "Placche Pressioniche",
       "label_en": "Pressure Plates",
+      "description_it": "Strati che disperdono pressione abissale e riducono trauma.",
+      "description_en": "Layers dispersing abyssal pressure and reducing trauma.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Strati che disperdono pressione abissale e riducono trauma.",
-      "description_en": "Layers dispersing abyssal pressure and reducing trauma."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "polmoni_cristallini_alta_quota": {
       "label_it": "Polmoni Cristallini d'Alta Quota",
       "label_en": "Polmoni Cristallini d'Alta Quota",
+      "description_it": "Polmoni cristallini che concentrano ossigeno rarefatto in quota.",
+      "description_en": "Crystalline lungs concentrating thin high-altitude oxygen.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "picchi-cristallini-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Polmoni cristallini che concentrano ossigeno rarefatto in quota.",
-      "description_en": "Crystalline lungs concentrating thin high-altitude oxygen."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "picchi-cristallini-trait-keeper"
+        ]
+      }
     },
     "random": {
       "label_it": "Trait Random",
       "label_en": "Trait Random",
+      "description_it": "Slot sperimentale che estrae tratti casuali dal pool controllato.",
+      "description_en": "Experimental slot drawing random traits from a curated pool.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 3,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 3,
+            "examples": [
+              "orbital-ascendant",
+              "psionic-canopy-scout",
+              "sentinella-radice"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Slot sperimentale che estrae tratti casuali dal pool controllato.",
-      "description_en": "Experimental slot drawing random traits from a curated pool."
+      "affinity": {
+        "total_species": 3,
+        "roles_breakdown": {
+          "optional": 2,
+          "synergy": 1
+        },
+        "top_species": [
+          "sentinella-radice",
+          "psionic-canopy-scout",
+          "orbital-ascendant"
+        ]
+      }
     },
     "respiro_a_scoppio": {
       "label_it": "Respiro a scoppio",
       "label_en": "Burst Breath Propulsion",
+      "description_it": "Valvole toraciche che rilasciano getti propulsivi istantanei.",
+      "description_en": "Thoracic valves unleashing instantaneous propulsion bursts.",
       "rules": {
-        "total": 1,
+        "total": 2,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "scavenger_corazzato",
+            "count": 1
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 12,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "scavenger_corazzato",
+            "count": 6,
+            "examples": [
+              "caverna-risonante-trait-keeper",
+              "dune-stalker",
+              "magneto-ridge-hunter",
+              "rust-scavenger",
+              "slag-veil-ambusher"
+            ]
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 6,
+            "examples": [
+              "caverna-risonante-trait-keeper",
+              "dune-stalker",
+              "magneto-ridge-hunter",
+              "rust-scavenger",
+              "slag-veil-ambusher"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Valvole toraciche che rilasciano getti propulsivi istantanei.",
-      "description_en": "Thoracic valves unleashing instantaneous propulsion bursts."
+      "affinity": {
+        "total_species": 6,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 6
+        },
+        "top_species": [
+          "rust-scavenger",
+          "caverna-risonante-trait-keeper",
+          "dune-stalker",
+          "magneto-ridge-hunter",
+          "slag-veil-ambusher",
+          "steppe-bison-mini"
+        ]
+      }
     },
     "rete_filtro_polmonare": {
       "label_it": "Rete Filtro-Polmonare",
       "label_en": "Pulmonary Filter Net",
+      "description_it": "Assorbire nutrienti aerodispersi.",
+      "description_en": "Absorb nutrients suspended in the air.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Assorbire nutrienti aerodispersi.",
-      "description_en": "Absorb nutrients suspended in the air."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "risonanza_di_branco": {
       "label_it": "Risonanza di Branco",
       "label_en": "Pack Resonance",
+      "description_it": "Rete risonante che amplifica buff condivisi del branco.",
+      "description_en": "Resonant lattice amplifying the pack's shared buffs.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 6,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 6,
+            "examples": [
+              "archon-solare",
+              "banshee-risonante",
+              "couatl-aurora",
+              "lupus-temperatus",
+              "rakshasa-corte"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Rete risonante che amplifica buff condivisi del branco.",
-      "description_en": "Resonant lattice amplifying the pack's shared buffs."
+      "affinity": {
+        "total_species": 6,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 2,
+          "synergy": 4
+        },
+        "top_species": [
+          "archon-solare",
+          "banshee-risonante",
+          "couatl-aurora",
+          "rakshasa-corte",
+          "treant-portale",
+          "lupus-temperatus"
+        ]
+      }
     },
     "riverbero_memetico": {
       "label_it": "Riverbero Memetico",
       "label_en": "Memetic Reverb",
+      "description_it": "Eco cognitivo che duplica buff a potenza ridotta (temp).",
+      "description_en": "Cognitive echo duplicating buffs at reduced power (temp).",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "sciame_larve_neurali",
+              "simbionte_corallino_riflesso"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Eco cognitivo che duplica buff a potenza ridotta (temp).",
-      "description_en": "Cognitive echo duplicating buffs at reduced power (temp)."
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "temp": 2
+        },
+        "top_species": [
+          "sciame_larve_neurali",
+          "simbionte_corallino_riflesso"
+        ]
+      }
     },
     "rostro_emostatico_litico": {
       "label_it": "Rostro Emostatico-Litico",
       "label_en": "Hemo-Lytic Rostrum",
+      "description_it": "Rostro tubulare rigidizzato che inocula tossine ed enzimi e aspira fluidi dopo l’impatto.",
+      "description_en": "Reinforced tubular rostrum that injects toxins and enzymes, then draws fluids after impact.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Rostro tubulare rigidizzato che inocula tossine ed enzimi e aspira fluidi dopo l’impatto.",
-      "description_en": "Reinforced tubular rostrum that injects toxins and enzymes, then draws fluids after impact."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "rostro_linguale_prensile": {
       "label_it": "Rostro Linguale Prensile",
       "label_en": "Prehensile Lingual Rostrum",
+      "description_it": "Afferrare e manipolare a lungo raggio.",
+      "description_en": "Grab and manipulate at long reach.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Afferrare e manipolare a lungo raggio.",
-      "description_en": "Grab and manipulate at long reach."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "sacche_galleggianti_ascensoriali": {
       "label_it": "Sacche galleggianti ascensoriali",
       "label_en": "Elevating Buoyancy Sacs",
+      "description_it": "Sacche gassose regolabili per controllare assetto e profondità.",
+      "description_en": "Adjustable gas sacs controlling buoyancy and depth.",
       "rules": {
-        "total": 1,
+        "total": 4,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "volatore_planatore",
+            "count": 1
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 32,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": null,
+            "count": 8,
+            "examples": [
+              "aurora-bridge-runner",
+              "canopia-psionica-leggera-trait-keeper",
+              "echo-wing",
+              "orbita-psionica-inversa-trait-keeper",
+              "orbital-ascendant"
+            ]
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 8,
+            "examples": [
+              "aurora-bridge-runner",
+              "canopia-psionica-leggera-trait-keeper",
+              "echo-wing",
+              "orbita-psionica-inversa-trait-keeper",
+              "orbital-ascendant"
+            ]
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "volatore_planatore",
+            "count": 8,
+            "examples": [
+              "aurora-bridge-runner",
+              "canopia-psionica-leggera-trait-keeper",
+              "echo-wing",
+              "orbita-psionica-inversa-trait-keeper",
+              "orbital-ascendant"
+            ]
+          },
+          {
+            "biome": "orbita_psionica_inversa",
+            "morphotype": null,
+            "count": 8,
+            "examples": [
+              "aurora-bridge-runner",
+              "canopia-psionica-leggera-trait-keeper",
+              "echo-wing",
+              "orbita-psionica-inversa-trait-keeper",
+              "orbital-ascendant"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Sacche gassose regolabili per controllare assetto e profondità.",
-      "description_en": "Adjustable gas sacs controlling buoyancy and depth."
+      "affinity": {
+        "total_species": 8,
+        "roles_breakdown": {
+          "core": 3,
+          "optional": 8
+        },
+        "top_species": [
+          "orbital-ascendant",
+          "psionic-canopy-scout",
+          "sand-burrower",
+          "aurora-bridge-runner",
+          "canopia-psionica-leggera-trait-keeper",
+          "echo-wing",
+          "orbita-psionica-inversa-trait-keeper",
+          "zephyr-spore-courier"
+        ]
+      }
     },
     "sacche_spore_stratosferiche": {
       "label_it": "Sacche di Spore Stratosferiche",
       "label_en": "Sacche di Spore Stratosferiche",
+      "description_it": "Vescicole stratosferiche che disperdono spore di supporto a lungo.",
+      "description_en": "Stratospheric vesicles dispersing long-range support spores.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "stratosfera-portante-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Vescicole stratosferiche che disperdono spore di supporto a lungo.",
-      "description_en": "Stratospheric vesicles dispersing long-range support spores."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "stratosfera-portante-trait-keeper"
+        ]
+      }
     },
     "sangue_piroforico": {
       "label_it": "Sangue che prende fuoco a contatto con l'ossigeno",
       "label_en": "Pyrophoric Blood",
+      "description_it": "Fluido ematico che incendia l'aria colpendo chi perfora la corazza.",
+      "description_en": "Blood ignites on air contact, burning would-be piercers.",
       "rules": {
-        "total": 1,
+        "total": 2,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "ingegnere_radicante",
+            "count": 1
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "scavenger_corazzato",
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 8,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "ingegnere_radicante",
+            "count": 4,
+            "examples": [
+              "caverna-risonante-trait-keeper",
+              "ferrocolonia-magnetotattica",
+              "nano-rust-bloom",
+              "thaw-rot"
+            ]
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "scavenger_corazzato",
+            "count": 4,
+            "examples": [
+              "caverna-risonante-trait-keeper",
+              "ferrocolonia-magnetotattica",
+              "nano-rust-bloom",
+              "thaw-rot"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Fluido ematico che incendia l'aria colpendo chi perfora la corazza.",
-      "description_en": "Blood ignites on air contact, burning would-be piercers."
+      "affinity": {
+        "total_species": 4,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 4
+        },
+        "top_species": [
+          "ferrocolonia-magnetotattica",
+          "caverna-risonante-trait-keeper",
+          "nano-rust-bloom",
+          "thaw-rot"
+        ]
+      }
     },
     "scheletro_idraulico_a_pistoni": {
       "label_it": "Scheletro Idraulico a Pistoni",
       "label_en": "Piston Hydraulic Skeleton",
+      "description_it": "Ossa cave pressurizzate che scattano pistoni cranici per colpi-proiettile rapidissimi.",
+      "description_en": "Pressurised hollow bones that fire cranial pistons for ultra-fast projectile blows.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ossa cave pressurizzate che scattano pistoni cranici per colpi-proiettile rapidissimi.",
-      "description_en": "Pressurised hollow bones that fire cranial pistons for ultra-fast projectile blows."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "scheletro_idro_regolante": {
       "label_it": "Scheletro Idro-Regolante",
       "label_en": "Hydro-Regulating Skeleton",
+      "description_it": "Ossa porose che modulano il contenuto idrico per mutare massa.",
+      "description_en": "Porous bones modulate water content to shift body mass.",
       "rules": {
-        "total": 1,
+        "total": 3,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "scavenger_corazzato",
+            "count": 1
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 30,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 10,
+            "examples": [
+              "bulette-fase",
+              "caverna-risonante-trait-keeper",
+              "dune-stalker",
+              "magnet-fathom-surveyor",
+              "magneto-ridge-hunter"
+            ]
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "scavenger_corazzato",
+            "count": 10,
+            "examples": [
+              "bulette-fase",
+              "caverna-risonante-trait-keeper",
+              "dune-stalker",
+              "magnet-fathom-surveyor",
+              "magneto-ridge-hunter"
+            ]
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 10,
+            "examples": [
+              "bulette-fase",
+              "caverna-risonante-trait-keeper",
+              "dune-stalker",
+              "magnet-fathom-surveyor",
+              "magneto-ridge-hunter"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ossa porose che modulano il contenuto idrico per mutare massa.",
-      "description_en": "Porous bones modulate water content to shift body mass."
+      "affinity": {
+        "total_species": 10,
+        "roles_breakdown": {
+          "core": 4,
+          "optional": 9,
+          "synergy": 1
+        },
+        "top_species": [
+          "dune-stalker",
+          "magneto-ridge-hunter",
+          "nano-rust-bloom",
+          "sand-burrower",
+          "slag-veil-ambusher",
+          "bulette-fase",
+          "caverna-risonante-trait-keeper",
+          "magnet-fathom-surveyor",
+          "rust-scavenger",
+          "steppe-bison-mini"
+        ]
+      }
     },
     "scheletro_pneumatico_a_maglie": {
       "label_it": "Scheletro Pneumatico a Maglie",
       "label_en": "Latticed Pneumatic Skeleton",
+      "description_it": "Alleggerire il carico per spostamenti lenti ma costanti.",
+      "description_en": "Lighten the load for slow, steady travel.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Alleggerire il carico per spostamenti lenti ma costanti.",
-      "description_en": "Lighten the load for slow, steady travel."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "scintilla_sinaptica": {
       "label_it": "Scintilla Sinaptica",
       "label_en": "Synaptic Spark",
+      "description_it": "Scarica leggera che illumina connessioni e riflessi (temp).",
+      "description_en": "Light discharge illuminating connections and reflexes (temp).",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "polpo_araldo_sinaptico",
+              "simbionte_corallino_riflesso"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Scarica leggera che illumina connessioni e riflessi (temp).",
-      "description_en": "Light discharge illuminating connections and reflexes (temp)."
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "temp": 2
+        },
+        "top_species": [
+          "polpo_araldo_sinaptico",
+          "simbionte_corallino_riflesso"
+        ]
+      }
     },
     "scivolamento_magnetico": {
       "label_it": "Scivolamento Magnetico",
       "label_en": "Magnetic Gliding",
+      "description_it": "Ridurre attrito e scivolare.",
+      "description_en": "Reduce friction to glide.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ridurre attrito e scivolare.",
-      "description_en": "Reduce friction to glide."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "scudo_gluteale_cheratinizzato": {
       "label_it": "Scudo Gluteale Cheratinizzato",
       "label_en": "Keratinized Gluteal Shield",
+      "description_it": "Assorbire impatti posteriori.",
+      "description_en": "Absorb impacts from the rear.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Assorbire impatti posteriori.",
-      "description_en": "Absorb impacts from the rear."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "secrezione_rallentante_palmi": {
       "label_it": "Mani secernano liquido rallentante",
       "label_en": "Retarding Palm Secretions",
+      "description_it": "Palmi che rilasciano gel rallentante per bloccare bersagli rapidi.",
+      "description_en": "Palms exude slowing gel to snare fast targets.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "ingegnere_radicante",
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "ingegnere_radicante",
+            "count": 2,
+            "examples": [
+              "laguna-bioreattiva-trait-keeper",
+              "sentinella-radice"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Palmi che rilasciano gel rallentante per bloccare bersagli rapidi.",
-      "description_en": "Palms exude slowing gel to snare fast targets."
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 1
+        },
+        "top_species": [
+          "sentinella-radice",
+          "laguna-bioreattiva-trait-keeper"
+        ]
+      }
     },
     "secrezioni_antistatiche": {
       "label_it": "Secrezioni Antistatiche",
       "label_en": "Antistatic Secretions",
+      "description_it": "Film protettivo che disperde accumuli elettrici.",
+      "description_en": "Protective film dispersing electrical build-up.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Film protettivo che disperde accumuli elettrici.",
-      "description_en": "Protective film dispersing electrical build-up."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "sensori_geomagnetici": {
       "label_it": "Sensori a Risonanza Geomagnetica",
       "label_en": "Geomagnetic Resonance Sensors",
+      "description_it": "Cristalli cranici che mappano corridoi geomagnetici invisibili.",
+      "description_en": "Cranial crystals mapping invisible geomagnetic corridors.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 4,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 4,
+            "examples": [
+              "bulette-fase",
+              "couatl-aurora",
+              "marilith-vault",
+              "pianure-magnetiche-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Cristalli cranici che mappano corridoi geomagnetici invisibili.",
-      "description_en": "Cranial crystals mapping invisible geomagnetic corridors."
+      "affinity": {
+        "total_species": 4,
+        "roles_breakdown": {
+          "optional": 4
+        },
+        "top_species": [
+          "bulette-fase",
+          "couatl-aurora",
+          "marilith-vault",
+          "pianure-magnetiche-trait-keeper"
+        ]
+      }
     },
     "sensori_planctonici": {
       "label_it": "Sensori Planctonici",
       "label_en": "Planctonic Sensors",
+      "description_it": "Sensori diffusi che leggono pattern di plancton memetico.",
+      "description_en": "Distributed sensors reading memetic plankton patterns.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Sensori diffusi che leggono pattern di plancton memetico.",
-      "description_en": "Distributed sensors reading memetic plankton patterns."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "seta_conduttiva_elettrica": {
       "label_it": "Seta Conduttiva Elettrica",
       "label_en": "Conductive Electric Silk",
+      "description_it": "Stordire con scariche nella tela.",
+      "description_en": "Stun prey with charges woven into the web.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Stordire con scariche nella tela.",
-      "description_en": "Stun prey with charges woven into the web."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "siero_anti_gelo_naturale": {
       "label_it": "Siero Anti-Gelo Naturale",
       "label_en": "Natural Anti-Freeze Serum",
+      "description_it": "Impedire la cristallizzazione a basse temperature.",
+      "description_en": "Prevent crystallization at low temperatures.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Impedire la cristallizzazione a basse temperature.",
-      "description_en": "Prevent crystallization at low temperatures."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "sinapsi_coraline_polifoniche": {
       "label_it": "Sinapsi Coraline Polifoniche",
       "label_en": "Sinapsi Coraline Polifoniche",
+      "description_it": "Sinapsi coralline che trasmettono ordini tramite armoniche marine.",
+      "description_en": "Coralline synapses relaying orders through marine harmonics.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "barriere-coralline-psioniche-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Sinapsi coralline che trasmettono ordini tramite armoniche marine.",
-      "description_en": "Coralline synapses relaying orders through marine harmonics."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "barriere-coralline-psioniche-trait-keeper"
+        ]
+      }
     },
     "sistemi_chimio_sonici": {
       "label_it": "Sistemi Chimio-Sonici",
       "label_en": "Chemo-Sonic Systems",
+      "description_it": "Mappare spazio e correnti d’aria senza vista.",
+      "description_en": "Map space and airflow without sight.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Mappare spazio e correnti d’aria senza vista.",
-      "description_en": "Map space and airflow without sight."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "sonno_emisferico_alternato": {
       "label_it": "Dormire con solo metà cervello alla volta",
       "label_en": "Unihemispheric Sleep",
+      "description_it": "Cervello alternato che veglia con un emisfero mentre l'altro riposa.",
+      "description_en": "Alternating hemispheres keep watch while the other sleeps.",
       "rules": {
-        "total": 1,
+        "total": 2,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "volatore_planatore",
+            "count": 1
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "volatore_planatore",
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 6,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "volatore_planatore",
+            "count": 3,
+            "examples": [
+              "aurora-gull",
+              "caverna-risonante-trait-keeper",
+              "echo-wing"
+            ]
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "volatore_planatore",
+            "count": 3,
+            "examples": [
+              "aurora-gull",
+              "caverna-risonante-trait-keeper",
+              "echo-wing"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Cervello alternato che veglia con un emisfero mentre l'altro riposa.",
-      "description_en": "Alternating hemispheres keep watch while the other sleeps."
+      "affinity": {
+        "total_species": 3,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 3
+        },
+        "top_species": [
+          "echo-wing",
+          "aurora-gull",
+          "caverna-risonante-trait-keeper"
+        ]
+      }
     },
     "spicole_canalizzatrici": {
       "label_it": "Spicole Canalizzatrici",
       "label_en": "Channeling Spicules",
+      "description_it": "Spine che assorbono buff e li reindirizzano.",
+      "description_en": "Spines absorbing buffs and redirecting them.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Spine che assorbono buff e li reindirizzano.",
-      "description_en": "Spines absorbing buffs and redirecting them."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "spore_psichiche_silenziate": {
       "label_it": "Spora Psichica Silenziosa",
       "label_en": "Silent Psychic Spores",
+      "description_it": "Spore psioniche che sedano e confondono i bersagli vicini.",
+      "description_en": "Psionic spores that lull and confuse nearby targets.",
       "rules": {
-        "total": 1,
+        "total": 3,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "scavenger_corazzato",
+            "count": 1
+          },
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "scavenger_corazzato",
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 6,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "scavenger_corazzato",
+            "count": 2,
+            "examples": [
+              "banshee-risonante",
+              "psionic-canopy-scout"
+            ]
+          },
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "banshee-risonante",
+              "psionic-canopy-scout"
+            ]
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "scavenger_corazzato",
+            "count": 2,
+            "examples": [
+              "banshee-risonante",
+              "psionic-canopy-scout"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Spore psioniche che sedano e confondono i bersagli vicini.",
-      "description_en": "Psionic spores that lull and confuse nearby targets."
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "core": 1,
+          "synergy": 1
+        },
+        "top_species": [
+          "banshee-risonante",
+          "psionic-canopy-scout"
+        ]
+      }
     },
     "squame_diffusori_ionici": {
       "label_it": "Squame Diffusori Ionici",
       "label_en": "Ionic Diffuser Scales",
+      "description_it": "Squame che disperdono cariche e riducono glare.",
+      "description_en": "Scales dispersing charge and reducing glare.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Squame che disperdono cariche e riducono glare.",
-      "description_en": "Scales dispersing charge and reducing glare."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "squame_rifrangenti_deserto": {
       "label_it": "Squame Rifrangenti del Deserto",
       "label_en": "Squame Rifrangenti del Deserto",
+      "description_it": "Scaglie cristalline che diffondono calore e creano miraggi.",
+      "description_en": "Crystal scales diffusing heat and casting mirages.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "dune-cristalline-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Scaglie cristalline che diffondono calore e creano miraggi.",
-      "description_en": "Crystal scales diffusing heat and casting mirages."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "dune-cristalline-trait-keeper"
+        ]
+      }
     },
     "struttura_elastica_amorfa": {
       "label_it": "Struttura elastica, allungabile, amorfa, retrattile",
       "label_en": "Elastic Amorphous Frame",
+      "description_it": "Corpo amorfo che si estende e si compatta per evadere vincoli.",
+      "description_en": "Amorphous frame stretching or compressing to escape binds.",
       "rules": {
-        "total": 1,
+        "total": 4,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 36,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "canopia_psionica_leggera",
+            "morphotype": null,
+            "count": 9,
+            "examples": [
+              "canopia-psionica-leggera-trait-keeper",
+              "dune-stalker",
+              "falde-magnetiche-psioniche-trait-keeper",
+              "glowcap-weaver",
+              "magnet-fathom-surveyor"
+            ]
+          },
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 9,
+            "examples": [
+              "canopia-psionica-leggera-trait-keeper",
+              "dune-stalker",
+              "falde-magnetiche-psioniche-trait-keeper",
+              "glowcap-weaver",
+              "magnet-fathom-surveyor"
+            ]
+          },
+          {
+            "biome": "falde_magnetiche_psioniche",
+            "morphotype": null,
+            "count": 9,
+            "examples": [
+              "canopia-psionica-leggera-trait-keeper",
+              "dune-stalker",
+              "falde-magnetiche-psioniche-trait-keeper",
+              "glowcap-weaver",
+              "magnet-fathom-surveyor"
+            ]
+          },
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 9,
+            "examples": [
+              "canopia-psionica-leggera-trait-keeper",
+              "dune-stalker",
+              "falde-magnetiche-psioniche-trait-keeper",
+              "glowcap-weaver",
+              "magnet-fathom-surveyor"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Corpo amorfo che si estende e si compatta per evadere vincoli.",
-      "description_en": "Amorphous frame stretching or compressing to escape binds."
+      "affinity": {
+        "total_species": 9,
+        "roles_breakdown": {
+          "core": 4,
+          "optional": 8,
+          "synergy": 1
+        },
+        "top_species": [
+          "dune-stalker",
+          "magnet-fathom-surveyor",
+          "psionic-canopy-scout",
+          "slag-veil-ambusher",
+          "magneto-ridge-hunter",
+          "canopia-psionica-leggera-trait-keeper",
+          "falde-magnetiche-psioniche-trait-keeper",
+          "glowcap-weaver",
+          "myco-spire-warden"
+        ]
+      }
     },
     "tattiche_di_branco": {
       "label_it": "Tattiche di Branco",
       "label_en": "Pack Tactics",
+      "description_it": "Protocollo tattico che coordina focus e prese condivise.",
+      "description_en": "Tactical protocol coordinating shared focus and grapples.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 3,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 3,
+            "examples": [
+              "lupus-temperatus",
+              "magneto-ridge-hunter",
+              "slag-veil-ambusher"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Protocollo tattico che coordina focus e prese condivise.",
-      "description_en": "Tactical protocol coordinating shared focus and grapples."
+      "affinity": {
+        "total_species": 3,
+        "roles_breakdown": {
+          "optional": 1,
+          "synergy": 2
+        },
+        "top_species": [
+          "magneto-ridge-hunter",
+          "slag-veil-ambusher",
+          "lupus-temperatus"
+        ]
+      }
     },
     "traits_aggregate": {
       "label_it": "Aggregato tratti Evo",
       "label_en": "Evo Traits Aggregate",
+      "description_it": "Dump normalizzato dei trait Evo (TR-*) per allineare indice legacy e QA.",
+      "description_en": "Normalized Evo trait dump (TR-*) used to align legacy index and QA.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Dump normalizzato dei trait Evo (TR-*) per allineare indice legacy e QA.",
-      "description_en": "Normalized Evo trait dump (TR-*) used to align legacy index and QA."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "unghie_a_micro_adesione": {
       "label_it": "Unghie a Micro-Adesione",
       "label_en": "Micro-Adhesion Claws",
+      "description_it": "Lamelle a micro-setole su zoccoli che aderiscono a superfici ripide per fughe verticali e pascolo.",
+      "description_en": "Micro-setae lamellae on hooves gripping steep surfaces for vertical escapes and browsing.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Lamelle a micro-setole su zoccoli che aderiscono a superfici ripide per fughe verticali e pascolo.",
-      "description_en": "Micro-setae lamellae on hooves gripping steep surfaces for vertical escapes and browsing."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "vello_condensatore_nebbie": {
       "label_it": "Vello Condensatore di Nebbie",
       "label_en": "Vello Condensatore di Nebbie",
+      "description_it": "Vello capillare che condensa nebbia in riserve idriche mobili.",
+      "description_en": "Capillary fleece condensing fog into mobile water reserves.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "foreste-nubose-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Vello capillare che condensa nebbia in riserve idriche mobili.",
-      "description_en": "Capillary fleece condensing fog into mobile water reserves."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "foreste-nubose-trait-keeper"
+        ]
+      }
     },
     "vello_di_assorbimento_totale": {
       "label_it": "Vello di Assorbimento Totale",
       "label_en": "Total Absorption Fleece",
+      "description_it": "Assorbire quasi tutta la luce incidente.",
+      "description_en": "Absorb nearly all incoming light.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Assorbire quasi tutta la luce incidente.",
-      "description_en": "Absorb nearly all incoming light."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "ventriglio_gastroliti": {
       "label_it": "Denti sonci (ciottoli/sassi), ti nutri di tutto",
       "label_en": "Gastrolith Grinding Gizzard",
+      "description_it": "Ventriglio muscoloso che macina cibi duri con gastroliti.",
+      "description_en": "Muscular gizzard grinding hard food with gastroliths.",
       "rules": {
-        "total": 1,
+        "total": 2,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "scavenger_corazzato",
+            "count": 1
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 8,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": "dorsale_termale_tropicale",
+            "morphotype": "scavenger_corazzato",
+            "count": 4,
+            "examples": [
+              "caverna-risonante-trait-keeper",
+              "ferrocolonia-magnetotattica",
+              "rust-scavenger",
+              "steppe-bison-mini"
+            ]
+          },
+          {
+            "biome": "mezzanotte_orbitale",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 4,
+            "examples": [
+              "caverna-risonante-trait-keeper",
+              "ferrocolonia-magnetotattica",
+              "rust-scavenger",
+              "steppe-bison-mini"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Ventriglio muscoloso che macina cibi duri con gastroliti.",
-      "description_en": "Muscular gizzard grinding hard food with gastroliths."
+      "affinity": {
+        "total_species": 4,
+        "roles_breakdown": {
+          "core": 1,
+          "optional": 4
+        },
+        "top_species": [
+          "rust-scavenger",
+          "caverna-risonante-trait-keeper",
+          "ferrocolonia-magnetotattica",
+          "steppe-bison-mini"
+        ]
+      }
     },
     "visione_multi_spettrale_amplificata": {
       "label_it": "Visione Multi-Spettrale Amplificata",
       "label_en": "Amplified Multi-Spectral Vision",
+      "description_it": "Vedere in luminanza estremamente bassa.",
+      "description_en": "See under extremely low luminance.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Vedere in luminanza estremamente bassa.",
-      "description_en": "See under extremely low luminance."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "vortice_nera_flash": {
       "label_it": "Vortice Nera Flash",
       "label_en": "Black Vortex Flash",
+      "description_it": "Implosione luminosa seguita da vuoto e teletrasporto breve (temp).",
+      "description_en": "Luminous implosion followed by void and short teleport (temp).",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 2,
+            "examples": [
+              "leviatano_risonante",
+              "sciame_larve_neurali"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Implosione luminosa seguita da vuoto e teletrasporto breve (temp).",
-      "description_en": "Luminous implosion followed by void and short teleport (temp)."
+      "affinity": {
+        "total_species": 2,
+        "roles_breakdown": {
+          "temp": 2
+        },
+        "top_species": [
+          "sciame_larve_neurali",
+          "leviatano_risonante"
+        ]
+      }
     },
     "zampe_a_molla": {
       "label_it": "Zampe a Molla",
       "label_en": "Spring-Loaded Limbs",
+      "description_it": "Arti a molla che accumulano energia per balzi di riposizionamento.",
+      "description_en": "Spring-loaded limbs storing energy for repositioning leaps.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "sand-burrower"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Arti a molla che accumulano energia per balzi di riposizionamento.",
-      "description_en": "Spring-loaded limbs storing energy for repositioning leaps."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "sand-burrower"
+        ]
+      }
     },
     "zanne_idracida": {
       "label_it": "Zanne Idracida",
       "label_en": "Hydra-Acid Tusks",
+      "description_it": "Corrodere tessuti e metalli.",
+      "description_en": "Corrode tissues and even metals.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "autogen_trait_carrier"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Corrodere tessuti e metalli.",
-      "description_en": "Corrode tissues and even metals."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "core": 1
+        },
+        "top_species": [
+          "autogen_trait_carrier"
+        ]
+      }
     },
     "zoccoli_risonanti_steppe": {
       "label_it": "Zoccoli Risonanti delle Steppe",
       "label_en": "Zoccoli Risonanti delle Steppe",
+      "description_it": "Zoccoli cavi che inviano onde ritmiche al branco sulle steppe.",
+      "description_en": "Hollow hooves sending rhythmic waves across the steppe pack.",
       "rules": {
         "total": 1,
         "coverage": [
-          "autogen_rule"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1
+          }
         ]
       },
       "species": {
         "total": 1,
         "coverage": [
-          "autogen_species"
+          {
+            "biome": null,
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "steppe-risonanti-trait-keeper"
+            ]
+          }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": []
+        "missing_in_rules": [],
+        "missing_in_affinity": [],
+        "missing_in_matrix": []
       },
-      "description_it": "Zoccoli cavi che inviano onde ritmiche al branco sulle steppe.",
-      "description_en": "Hollow hooves sending rhythmic waves across the steppe pack."
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "steppe-risonanti-trait-keeper"
+        ]
+      }
     }
+  },
+  "foodweb_coverage": {
+    "schema_version": "1.0",
+    "thresholds": {
+      "species_per_role_biome": 2
+    },
+    "roles": {}
   }
 }

--- a/data/derived/analysis/trait_gap_report.json
+++ b/data/derived/analysis/trait_gap_report.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2025-12-03T01:34:45+00:00",
+  "generated_at": "2025-12-03T01:48:09+00:00",
   "sources": {
     "etl_report": "data/derived/analysis/trait_coverage_report.json",
     "trait_reference": "data/traits/index.json",
@@ -145,7 +145,7 @@
       "axis": "altro",
       "label": "Ali Solari Fotoniche",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 2,
       "covered": true
     },
     "appendici_risonanti_marea": {
@@ -214,8 +214,8 @@
     "cute_resistente_sali": {
       "axis": "difensivo",
       "label": "Cute Resistente Sali",
-      "rules_total": 1,
-      "species_total": 1,
+      "rules_total": 2,
+      "species_total": 6,
       "covered": true
     },
     "enzimi_antipredatori_algali": {
@@ -292,35 +292,35 @@
       "axis": "altro",
       "label": "Armatura di Pietra Planare",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 4,
       "covered": true
     },
     "mantello_meteoritico": {
       "axis": "altro",
       "label": "Mantello Meteoritico",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 2,
       "covered": true
     },
     "filamenti_digestivi_compattanti": {
       "axis": "metabolico",
       "label": "Filamenti Digestivi Compattanti",
-      "rules_total": 1,
-      "species_total": 1,
+      "rules_total": 4,
+      "species_total": 32,
       "covered": true
     },
     "ventriglio_gastroliti": {
       "axis": "metabolico",
       "label": "Denti sonci (ciottoli/sassi), ti nutri di tutto",
-      "rules_total": 1,
-      "species_total": 1,
+      "rules_total": 2,
+      "species_total": 8,
       "covered": true
     },
     "spore_psichiche_silenziate": {
       "axis": "metabolico",
       "label": "Spora Psichica Silenziosa",
-      "rules_total": 1,
-      "species_total": 1,
+      "rules_total": 3,
+      "species_total": 6,
       "covered": true
     },
     "ectotermia_dinamica": {
@@ -390,7 +390,7 @@
       "axis": "altro",
       "label": "Canto Risonante",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 2,
       "covered": true
     },
     "coralli_sinaptici_fotofase": {
@@ -446,14 +446,14 @@
       "axis": "offensivo",
       "label": "Impulsi Bioluminescenti",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 2,
       "covered": true
     },
     "lobi_risonanti_crepuscolo": {
       "axis": "altro",
       "label": "Lobi Risonanti Crepuscolo",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 3,
       "covered": true
     },
     "membrane_fotoconvoglianti": {
@@ -509,14 +509,14 @@
       "axis": "altro",
       "label": "Riverbero Memetico",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 2,
       "covered": true
     },
     "scintilla_sinaptica": {
       "axis": "altro",
       "label": "Scintilla Sinaptica",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 2,
       "covered": true
     },
     "secrezioni_antistatiche": {
@@ -551,21 +551,21 @@
       "axis": "altro",
       "label": "Vortice Nera Flash",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 2,
       "covered": true
     },
     "sacche_galleggianti_ascensoriali": {
       "axis": "supporto",
       "label": "Sacche galleggianti ascensoriali",
-      "rules_total": 1,
-      "species_total": 1,
+      "rules_total": 4,
+      "species_total": 32,
       "covered": true
     },
     "ali_fono_risonanti": {
       "axis": "altro",
       "label": "Ali Fono-Risonanti",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 2,
       "covered": true
     },
     "articolazioni_a_leva_idraulica": {
@@ -655,8 +655,8 @@
     "artigli_sette_vie": {
       "axis": "locomotorio",
       "label": "Artigli a Sette Vie",
-      "rules_total": 1,
-      "species_total": 1,
+      "rules_total": 3,
+      "species_total": 27,
       "covered": true
     },
     "artigli_sghiaccio_glaciale": {
@@ -712,7 +712,7 @@
       "axis": "locomotorio",
       "label": "Coda a Frusta Cinetica",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 7,
       "covered": true
     },
     "cuscinetti_elettrostatici": {
@@ -845,21 +845,21 @@
       "axis": "metabolico",
       "label": "Criostasi",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 4,
       "covered": true
     },
     "cuticole_cerose": {
       "axis": "metabolico",
       "label": "Cuticole Cerose",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 7,
       "covered": true
     },
     "enzimi_chelanti": {
       "axis": "metabolico",
       "label": "Enzimi Chelanti",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 2,
       "covered": true
     },
     "flagelli_ancoranti": {
@@ -880,7 +880,7 @@
       "axis": "metabolico",
       "label": "Grassi Termici",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 7,
       "covered": true
     },
     "luminescenza_aurorale": {
@@ -893,8 +893,8 @@
     "sonno_emisferico_alternato": {
       "axis": "strategia",
       "label": "Dormire con solo metà cervello alla volta",
-      "rules_total": 1,
-      "species_total": 1,
+      "rules_total": 2,
+      "species_total": 6,
       "covered": true
     },
     "antenne_flusso_mareale": {
@@ -1020,14 +1020,14 @@
       "axis": "offensivo",
       "label": "Frusta Fiammeggiante",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 2,
       "covered": true
     },
     "ghiandola_caustica": {
       "axis": "offensivo",
       "label": "Ghiandola Caustica",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 2,
       "covered": true
     },
     "ghiandole_iodoattive": {
@@ -1061,8 +1061,8 @@
     "sangue_piroforico": {
       "axis": "offensivo",
       "label": "Sangue che prende fuoco a contatto con l'ossigeno",
-      "rules_total": 1,
-      "species_total": 1,
+      "rules_total": 2,
+      "species_total": 8,
       "covered": true
     },
     "seta_conduttiva_elettrica": {
@@ -1090,7 +1090,7 @@
       "axis": "metabolico",
       "label": "Lamelle Termoforetiche",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 5,
       "covered": true
     },
     "membrane_eliofiltranti": {
@@ -1110,8 +1110,8 @@
     "respiro_a_scoppio": {
       "axis": "metabolico",
       "label": "Respiro a scoppio",
-      "rules_total": 1,
-      "species_total": 1,
+      "rules_total": 2,
+      "species_total": 12,
       "covered": true
     },
     "ermafroditismo_cronologico": {
@@ -1131,8 +1131,8 @@
     "nucleo_ovomotore_rotante": {
       "axis": "simbiotico",
       "label": "Uovo rotaia, uovo grande e uova piccole dentro...",
-      "rules_total": 1,
-      "species_total": 1,
+      "rules_total": 3,
+      "species_total": 6,
       "covered": true
     },
     "ali_fulminee": {
@@ -1215,8 +1215,8 @@
     "eco_interno_riflesso": {
       "axis": "sensoriale",
       "label": "Riflesso dell'Eco Interno",
-      "rules_total": 1,
-      "species_total": 1,
+      "rules_total": 2,
+      "species_total": 14,
       "covered": true
     },
     "filamenti_superconduttivi": {
@@ -1258,7 +1258,7 @@
       "axis": "sensoriale",
       "label": "Lingua Tattile Trama-Sensibile",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 4,
       "covered": true
     },
     "midollo_antivibrazione": {
@@ -1286,21 +1286,21 @@
       "axis": "sensoriale",
       "label": "Occhi a Cristallo Modulare",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 2,
       "covered": true
     },
     "occhi_infrarosso_composti": {
       "axis": "sensoriale",
       "label": "Occhi Composti ad Infrarosso",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 2,
       "covered": true
     },
     "olfatto_risonanza_magnetica": {
       "axis": "sensoriale",
       "label": "Olfatto di Risonanza Magnetica",
-      "rules_total": 1,
-      "species_total": 1,
+      "rules_total": 4,
+      "species_total": 36,
       "covered": true
     },
     "organi_sismici_cutanei": {
@@ -1314,7 +1314,7 @@
       "axis": "sensoriale",
       "label": "Sensori a Risonanza Geomagnetica",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 4,
       "covered": true
     },
     "sistemi_chimio_sonici": {
@@ -1530,8 +1530,8 @@
     "focus_frazionato": {
       "axis": "strategia",
       "label": "Focus Frazionato",
-      "rules_total": 1,
-      "species_total": 1,
+      "rules_total": 3,
+      "species_total": 24,
       "covered": true
     },
     "ghiaccio_piezoelettrico": {
@@ -1566,7 +1566,7 @@
       "axis": "strategia",
       "label": "Pathfinder",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 2,
       "covered": true
     },
     "pianificatore": {
@@ -1580,14 +1580,14 @@
       "axis": "strategia",
       "label": "Trait Random",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 3,
       "covered": true
     },
     "tattiche_di_branco": {
       "axis": "strategia",
       "label": "Tattiche di Branco",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 3,
       "covered": true
     },
     "antenne_tesla": {
@@ -1622,7 +1622,7 @@
       "axis": "strutturale",
       "label": "Carapace a Variazione di Fase",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 9,
       "covered": true
     },
     "carapace_luminiscente_abissale": {
@@ -1698,15 +1698,15 @@
     "scheletro_idro_regolante": {
       "axis": "strutturale",
       "label": "Scheletro Idro-Regolante",
-      "rules_total": 1,
-      "species_total": 1,
+      "rules_total": 3,
+      "species_total": 30,
       "covered": true
     },
     "struttura_elastica_amorfa": {
       "axis": "strutturale",
       "label": "Struttura elastica, allungabile, amorfa, retrattile",
-      "rules_total": 1,
-      "species_total": 1,
+      "rules_total": 4,
+      "species_total": 36,
       "covered": true
     },
     "antenne_eco_turbina": {
@@ -1776,7 +1776,7 @@
       "axis": "supporto",
       "label": "Empatia Coordinativa",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 8,
       "covered": true
     },
     "enzimi_chelatori_rapidi": {
@@ -1818,14 +1818,14 @@
       "axis": "supporto",
       "label": "Risonanza di Branco",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 6,
       "covered": true
     },
     "mimetismo_cromatico_passivo": {
       "axis": "difensivo",
       "label": "Ghiandole di Mimetismo Cromatico Passivo",
-      "rules_total": 1,
-      "species_total": 1,
+      "rules_total": 3,
+      "species_total": 18,
       "covered": true
     },
     "piume_solari_fotovoltaiche": {
@@ -1839,7 +1839,7 @@
       "axis": "difensivo",
       "label": "Mani secernano liquido rallentante",
       "rules_total": 1,
-      "species_total": 1,
+      "species_total": 2,
       "covered": true
     },
     "squame_rifrangenti_deserto": {

--- a/data/traits/species_affinity.json
+++ b/data/traits/species_affinity.json
@@ -29,6 +29,22 @@
       "weight": 3
     }
   ],
+  "ali_fono_risonanti": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "banshee-risonante",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "psionic-canopy-scout",
+      "weight": 2
+    }
+  ],
   "ali_fulminee": [
     {
       "roles": [
@@ -54,22 +70,6 @@
       ],
       "species_id": "caverna-risonante-trait-keeper",
       "weight": 1
-    }
-  ],
-  "ali_fono_risonanti": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "banshee-risonante",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "psionic-canopy-scout",
-      "weight": 2
     }
   ],
   "ali_solari_fotoni": [
@@ -218,6 +218,24 @@
       "weight": 1
     }
   ],
+  "articolazioni_a_leva_idraulica": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "articolazioni_multiassiali": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "artigli_acidofagi": [
     {
       "roles": [
@@ -233,6 +251,15 @@
         "optional"
       ],
       "species_id": "canopia-ionica-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "artigli_ipo_termici": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
       "weight": 1
     }
   ],
@@ -348,6 +375,15 @@
       "weight": 1
     }
   ],
+  "artiglio_cinetico_a_urto": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "assenza_respirazione": [
     {
       "roles": [
@@ -362,6 +398,15 @@
       ],
       "species_id": "golem-runico",
       "weight": 3
+    }
+  ],
+  "aura_di_dispersione_mentale": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
     }
   ],
   "aura_scudo_radianza": [
@@ -419,6 +464,15 @@
       "weight": 1
     }
   ],
+  "bioantenne_gravitiche": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "biochip_memoria": [
     {
       "roles": [
@@ -443,6 +497,15 @@
         "optional"
       ],
       "species_id": "pianura-salina-iperarida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "bozzolo_magnetico": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
       "weight": 1
     }
   ],
@@ -543,6 +606,58 @@
       ],
       "species_id": "dorsale-termale-tropicale-trait-keeper",
       "weight": 1
+    }
+  ],
+  "camere_risonanza_abyssal": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "leviatano_risonante",
+      "weight": 4
+    }
+  ],
+  "campo_di_interferenza_acustica": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "cannone_sonico_a_raggio": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "canto_infrasonico_tattico": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "canto_risonante": [
+    {
+      "roles": [
+        "temp"
+      ],
+      "species_id": "polpo_araldo_sinaptico",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "temp"
+      ],
+      "species_id": "leviatano_risonante",
+      "weight": 2
     }
   ],
   "capillari_criogenici": [
@@ -736,6 +851,15 @@
       "weight": 1
     }
   ],
+  "cervello_a_bassa_latenza": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "chemiorecettori_bromuro": [
     {
       "roles": [
@@ -828,6 +952,15 @@
       "weight": 3
     }
   ],
+  "cinghia_iper_ciliare": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "circolazione_bifasica": [
     {
       "roles": [
@@ -888,6 +1021,15 @@
         "optional"
       ],
       "species_id": "pianura-salina-iperarida-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "cisti_di_ibernazione_minerale": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
       "weight": 1
     }
   ],
@@ -981,6 +1123,15 @@
       "weight": 1
     }
   ],
+  "coda_prensile_muscolare": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "coda_stabilizzatrice_filo": [
     {
       "roles": [
@@ -1017,6 +1168,15 @@
       "weight": 1
     }
   ],
+  "comunicazione_fotonica_coda_coda": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "coralli_partner": [
     {
       "roles": [
@@ -1026,12 +1186,57 @@
       "weight": 1
     }
   ],
+  "coralli_sinaptici_fotofase": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "polpo_araldo_sinaptico",
+      "weight": 3
+    }
+  ],
+  "corazze_ferro_magnetico": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "corna_psico_conduttive": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "corteccia_memetica": [
     {
       "roles": [
         "optional"
       ],
       "species_id": "treant-portale",
+      "weight": 1
+    }
+  ],
+  "coscienza_d_alveare_diffusa": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "coscienza_dalveare_diffusa": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
       "weight": 1
     }
   ],
@@ -1282,6 +1487,42 @@
       "weight": 1
     }
   ],
+  "ectotermia_dinamica": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "elettromagnete_biologico": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "emettitori_voidsong": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "leviatano_risonante",
+      "weight": 3
+    }
+  ],
+  "emolinfa_conducente": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "empatia_coordinativa": [
     {
       "roles": [
@@ -1411,6 +1652,33 @@
       "weight": 1
     }
   ],
+  "ermafroditismo_cronologico": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "estroflessione_gastrica_acida": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "fagocitosi_assorbente": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "filamenti_digestivi_compattanti": [
     {
       "roles": [
@@ -1472,6 +1740,24 @@
       "weight": 1
     }
   ],
+  "filamenti_echo": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "filamenti_guidalampo": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "filamenti_magnetotrofi": [
     {
       "roles": [
@@ -1499,6 +1785,15 @@
       "weight": 1
     }
   ],
+  "filtrazione_osmotica": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "filtri_bioattivi": [
     {
       "roles": [
@@ -1517,6 +1812,15 @@
       "weight": 1
     }
   ],
+  "filtro_metallofago": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "fisiologia_predatoria": [
     {
       "roles": [
@@ -1532,6 +1836,15 @@
         "optional"
       ],
       "species_id": "laguna-bioreattiva-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "flusso_ameboide_controllato": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
       "weight": 1
     }
   ],
@@ -1736,6 +2049,15 @@
       "weight": 1
     }
   ],
+  "ghiandole_mnemoniche": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "ghiandole_nebbia_acida": [
     {
       "roles": [
@@ -1859,12 +2181,46 @@
       "weight": 1
     }
   ],
+  "impulsi_bioluminescenti": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "polpo_araldo_sinaptico",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "leviatano_risonante",
+      "weight": 2
+    }
+  ],
   "intangibilita_parziale": [
     {
       "roles": [
         "optional"
       ],
       "species_id": "banshee-risonante",
+      "weight": 1
+    }
+  ],
+  "integumento_bipolare": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "ipertrofia_muscolare_massiva": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
       "weight": 1
     }
   ],
@@ -1998,6 +2354,38 @@
       "weight": 1
     }
   ],
+  "lobi_risonanti_crepuscolo": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "polpo_araldo_sinaptico",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "leviatano_risonante",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "simbionte_corallino_riflesso",
+      "weight": 2
+    }
+  ],
+  "locomozione_miriapode_ibrida": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "luminescenza_aurorale": [
     {
       "roles": [
@@ -2060,6 +2448,15 @@
       "weight": 1
     }
   ],
+  "membrana_plastica_continua": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "membrane_captura_rugiada": [
     {
       "roles": [
@@ -2075,6 +2472,15 @@
         "optional"
       ],
       "species_id": "laghi-alcalini-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "membrane_fotoconvoglianti": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
       "weight": 1
     }
   ],
@@ -2163,6 +2569,15 @@
       "weight": 3
     }
   ],
+  "metabolismo_di_condivisione_energetica": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "metabolismo_sostentato": [
     {
       "roles": [
@@ -2234,6 +2649,24 @@
       "weight": 1
     }
   ],
+  "moltiplicazione_per_fusione": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "motore_biologico_silenzioso": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "mucillagine_simbionte_mangrovie": [
     {
       "roles": [
@@ -2261,12 +2694,30 @@
       "weight": 1
     }
   ],
+  "nebbia_mnesica": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "sciame_larve_neurali",
+      "weight": 3
+    }
+  ],
   "nodi_micorrizici_oracolari": [
     {
       "roles": [
         "optional"
       ],
       "species_id": "reti-micorriziche-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "nodi_sinaptici_superficiali": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
       "weight": 1
     }
   ],
@@ -2295,20 +2746,21 @@
       "weight": 2
     }
   ],
-  "occhi_infrarosso_composti": [
+  "occhi_analizzatori_di_tensione": [
     {
       "roles": [
-        "core",
-        "optional"
+        "core"
       ],
-      "species_id": "echo-wing",
-      "weight": 4
-    },
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "occhi_cinetici": [
     {
       "roles": [
-        "optional"
+        "core"
       ],
-      "species_id": "caverna-risonante-trait-keeper",
+      "species_id": "autogen_trait_carrier",
       "weight": 1
     }
   ],
@@ -2326,6 +2778,23 @@
       ],
       "species_id": "psionic-canopy-scout",
       "weight": 2
+    }
+  ],
+  "occhi_infrarosso_composti": [
+    {
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "species_id": "echo-wing",
+      "weight": 4
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
     }
   ],
   "olfatto_risonanza_magnetica": [
@@ -2396,6 +2865,24 @@
       "weight": 1
     }
   ],
+  "organi_metacronici": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "organi_sismici_cutanei": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "origine_artificiale": [
     {
       "roles": [
@@ -2415,10 +2902,35 @@
   "pathfinder": [
     {
       "roles": [
+        "core"
+      ],
+      "species_id": "psionic-canopy-scout",
+      "weight": 3
+    },
+    {
+      "roles": [
         "optional"
       ],
       "species_id": "sentinella-radice",
       "weight": 1
+    }
+  ],
+  "pelage_idrorepellente_avanzato": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "pelle_piezo_satura": [
+    {
+      "roles": [
+        "temp"
+      ],
+      "species_id": "leviatano_risonante",
+      "weight": 2
     }
   ],
   "pelli_anti_ustione": [
@@ -2495,22 +3007,6 @@
         "optional"
       ],
       "species_id": "global-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "pathfinder": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "psionic-canopy-scout",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "sentinella-radice",
       "weight": 1
     }
   ],
@@ -2600,6 +3096,24 @@
       "weight": 1
     }
   ],
+  "placca_diffusione_foschia": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "placche_pressioniche": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "polmoni_cristallini_alta_quota": [
     {
       "roles": [
@@ -2678,6 +3192,29 @@
       "weight": 1
     }
   ],
+  "random": [
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "sentinella-radice",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "synergy"
+      ],
+      "species_id": "psionic-canopy-scout",
+      "weight": 3
+    },
+    {
+      "roles": [
+        "optional"
+      ],
+      "species_id": "orbital-ascendant",
+      "weight": 2
+    }
+  ],
   "respirazione_biologica": [
     {
       "roles": [
@@ -2736,29 +3273,6 @@
       "weight": 3
     }
   ],
-  "random": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "sentinella-radice",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "synergy"
-      ],
-      "species_id": "psionic-canopy-scout",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "orbital-ascendant",
-      "weight": 2
-    }
-  ],
   "respiro_a_scoppio": [
     {
       "roles": [
@@ -2801,6 +3315,15 @@
         "optional"
       ],
       "species_id": "steppe-bison-mini",
+      "weight": 1
+    }
+  ],
+  "rete_filtro_polmonare": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
       "weight": 1
     }
   ],
@@ -2907,6 +3430,40 @@
       "weight": 1
     }
   ],
+  "riverbero_memetico": [
+    {
+      "roles": [
+        "temp"
+      ],
+      "species_id": "sciame_larve_neurali",
+      "weight": 2
+    },
+    {
+      "roles": [
+        "temp"
+      ],
+      "species_id": "simbionte_corallino_riflesso",
+      "weight": 1
+    }
+  ],
+  "rostro_emostatico_litico": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "rostro_linguale_prensile": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "sacche_galleggianti_ascensoriali": [
     {
       "roles": [
@@ -3008,6 +3565,15 @@
       "weight": 1
     }
   ],
+  "scheletro_idraulico_a_pistoni": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "scheletro_idro_regolante": [
     {
       "roles": [
@@ -3084,6 +3650,49 @@
       "weight": 1
     }
   ],
+  "scheletro_pneumatico_a_maglie": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "scintilla_sinaptica": [
+    {
+      "roles": [
+        "temp"
+      ],
+      "species_id": "polpo_araldo_sinaptico",
+      "weight": 2
+    },
+    {
+      "roles": [
+        "temp"
+      ],
+      "species_id": "simbionte_corallino_riflesso",
+      "weight": 1
+    }
+  ],
+  "scivolamento_magnetico": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "scudo_gluteale_cheratinizzato": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "secrezione_rallentante_palmi": [
     {
       "roles": [
@@ -3098,6 +3707,15 @@
       ],
       "species_id": "laguna-bioreattiva-trait-keeper",
       "weight": 2
+    }
+  ],
+  "secrezioni_antistatiche": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
     }
   ],
   "sensori_chimici": [
@@ -3139,12 +3757,48 @@
       "weight": 1
     }
   ],
+  "sensori_planctonici": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "seta_conduttiva_elettrica": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "siero_anti_gelo_naturale": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "sinapsi_coraline_polifoniche": [
     {
       "roles": [
         "optional"
       ],
       "species_id": "barriere-coralline-psioniche-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "sistemi_chimio_sonici": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
       "weight": 1
     }
   ],
@@ -3172,6 +3826,15 @@
       "weight": 1
     }
   ],
+  "spicole_canalizzatrici": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "spore_psichiche_silenziate": [
     {
       "roles": [
@@ -3186,6 +3849,15 @@
       ],
       "species_id": "psionic-canopy-scout",
       "weight": 2
+    }
+  ],
+  "squame_diffusori_ionici": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
     }
   ],
   "squame_rifrangenti_deserto": [
@@ -3298,12 +3970,39 @@
       "weight": 1
     }
   ],
+  "traits_aggregate": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
+  "unghie_a_micro_adesione": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "vello_condensatore_nebbie": [
     {
       "roles": [
         "optional"
       ],
       "species_id": "foreste-nubose-trait-keeper",
+      "weight": 1
+    }
+  ],
+  "vello_di_assorbimento_totale": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
       "weight": 1
     }
   ],
@@ -3338,6 +4037,15 @@
       "weight": 1
     }
   ],
+  "visione_multi_spettrale_amplificata": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    }
+  ],
   "visione_spettrale": [
     {
       "roles": [
@@ -3363,12 +4071,37 @@
       "weight": 1
     }
   ],
+  "vortice_nera_flash": [
+    {
+      "roles": [
+        "temp"
+      ],
+      "species_id": "sciame_larve_neurali",
+      "weight": 1
+    },
+    {
+      "roles": [
+        "temp"
+      ],
+      "species_id": "leviatano_risonante",
+      "weight": 1
+    }
+  ],
   "zampe_a_molla": [
     {
       "roles": [
         "optional"
       ],
       "species_id": "sand-burrower",
+      "weight": 1
+    }
+  ],
+  "zanne_idracida": [
+    {
+      "roles": [
+        "core"
+      ],
+      "species_id": "autogen_trait_carrier",
       "weight": 1
     }
   ],
@@ -3380,45 +4113,5 @@
       "species_id": "steppe-risonanti-trait-keeper",
       "weight": 1
     }
-  ],
-  "coralli_sinaptici_fotofase": [
-    { "roles": ["core"], "species_id": "polpo_araldo_sinaptico", "weight": 3 }
-  ],
-  "impulsi_bioluminescenti": [
-    { "roles": ["core"], "species_id": "polpo_araldo_sinaptico", "weight": 3 },
-    { "roles": ["core"], "species_id": "leviatano_risonante", "weight": 2 }
-  ],
-  "nebbia_mnesica": [
-    { "roles": ["core"], "species_id": "sciame_larve_neurali", "weight": 3 }
-  ],
-  "lobi_risonanti_crepuscolo": [
-    { "roles": ["core"], "species_id": "polpo_araldo_sinaptico", "weight": 1 },
-    { "roles": ["core"], "species_id": "leviatano_risonante", "weight": 1 },
-    { "roles": ["core"], "species_id": "simbionte_corallino_riflesso", "weight": 2 }
-  ],
-  "camere_risonanza_abyssal": [
-    { "roles": ["core"], "species_id": "leviatano_risonante", "weight": 4 }
-  ],
-  "emettitori_voidsong": [
-    { "roles": ["core"], "species_id": "leviatano_risonante", "weight": 3 }
-  ],
-  "scintilla_sinaptica": [
-    { "roles": ["temp"], "species_id": "polpo_araldo_sinaptico", "weight": 2 },
-    { "roles": ["temp"], "species_id": "simbionte_corallino_riflesso", "weight": 1 }
-  ],
-  "canto_risonante": [
-    { "roles": ["temp"], "species_id": "polpo_araldo_sinaptico", "weight": 1 },
-    { "roles": ["temp"], "species_id": "leviatano_risonante", "weight": 2 }
-  ],
-  "riverbero_memetico": [
-    { "roles": ["temp"], "species_id": "sciame_larve_neurali", "weight": 2 },
-    { "roles": ["temp"], "species_id": "simbionte_corallino_riflesso", "weight": 1 }
-  ],
-  "vortice_nera_flash": [
-    { "roles": ["temp"], "species_id": "sciame_larve_neurali", "weight": 1 },
-    { "roles": ["temp"], "species_id": "leviatano_risonante", "weight": 1 }
-  ],
-  "pelle_piezo_satura": [
-    { "roles": ["temp"], "species_id": "leviatano_risonante", "weight": 2 }
   ]
 }

--- a/logs/tooling/generator_run_profile.json
+++ b/logs/tooling/generator_run_profile.json
@@ -1,101 +1,633 @@
 {
-  "generated_at": "2025-11-02T00:56:26Z",
+  "generated_at": "2025-12-03T01:47:58Z",
   "status": "success",
   "data_root": "data/core",
   "matrix_path": "docs/catalog/species_trait_matrix.json",
   "inventory_path": "docs/catalog/traits_inventory.json",
   "metrics": {
-    "generation_time_ms": 9,
-    "matrix_entries": 27,
-    "species_total": 23,
-    "event_total": 4,
-    "core_traits_total": 30,
-    "optional_traits_total": 17,
-    "synergy_traits_total": 8,
-    "dataset_species_total": 1,
-    "species_with_trait_plan": 1,
-    "enriched_species": 12,
-    "expected_core_traits": 4
+    "generation_time_ms": 29,
+    "matrix_entries": 79,
+    "species_total": 74,
+    "event_total": 5,
+    "core_traits_total": 188,
+    "optional_traits_total": 206,
+    "synergy_traits_total": 10,
+    "dataset_species_total": 15,
+    "species_with_trait_plan": 15,
+    "enriched_species": 74,
+    "expected_core_traits": 30
   },
   "core_traits": [
+    "adattamento_volo",
+    "ali_fulminee",
+    "ali_ioniche",
+    "ali_membrana_sonica",
+    "antenne_dustsense",
+    "antenne_eco_turbina",
+    "antenne_flusso_mareale",
+    "antenne_microonde_cavernose",
+    "antenne_plasmatiche_tempesta",
+    "antenne_reagenti",
+    "antenne_tesla",
+    "antenne_waveguide",
+    "antenne_wideband",
+    "appendici_risonanti_marea",
+    "appendici_thermotattiche",
+    "armatura_pietra_planare",
+    "artigli_acidofagi",
+    "artigli_induzione",
+    "artigli_radice",
+    "artigli_scivolo_silente",
     "artigli_sette_vie",
+    "artigli_sghiaccio_glaciale",
+    "artigli_vetrificati",
+    "assenza_respirazione",
+    "aura_scudo_radianza",
+    "baffi_mareomotori",
+    "barbigli_sensori_plasma",
+    "barriere_miasma_glaciale",
+    "batteri_endosimbionti_chemio",
+    "batteri_termofili_endosimbiosi",
+    "biochip_memoria",
+    "biofilm_glow",
+    "biofilm_iperarido",
+    "branchie_dual_mode",
+    "branchie_eoliche",
+    "branchie_metalloidi",
+    "branchie_microfiltri",
+    "branchie_osmotiche_salmastra",
+    "branchie_solfatiche",
+    "branchie_turbina",
+    "bulbi_radici_permafrost",
+    "camere_anticorrosione",
+    "camere_mirage",
+    "camere_nutrienti_vent",
+    "capillari_criogenici",
+    "capillari_fluoridici",
+    "capillari_fotovoltaici",
+    "capsule_paracadute",
+    "carapace_fase_variabile",
+    "carapace_luminiscente_abissale",
+    "carapace_segmenti_logici",
+    "carapaci_ferruginosi",
+    "cartilagine_flessotermica_venti",
+    "cartilagini_biofibre",
+    "cartilagini_desertiche",
+    "cartilagini_flessoacustiche",
+    "cartilagini_pseudometalliche",
+    "cavita_risonanti_tundra",
+    "cervelletto_equilibrio_statico",
+    "chemiorecettori_bromuro",
+    "chioma_parassita_canopica",
+    "ciclo_vitale_anomalo",
+    "ciclo_vitale_completo",
+    "circolazione_bifasica",
+    "circolazione_bifasica_palude",
+    "circolazione_cooling_loop",
+    "circolazione_doppia",
+    "circolazione_supercritica",
+    "ciste_riduttive",
+    "ciste_salmastre",
+    "cisti_iperbariche",
+    "coda_balanciere",
+    "coda_contrappeso",
+    "coda_coppia_retroattiva",
     "coda_frusta_cinetica",
+    "coda_stabilizzatrice_filo",
+    "coda_stabilizzatrice_geiser",
+    "coda_stabilizzatrice_vortex",
+    "colonne_vibromagnetiche",
+    "coralli_partner",
+    "criostasi_adattiva",
+    "cromofori_alert_acido",
+    "cuore_multicamera_bassa_pressione",
+    "cuscinetti_elettrostatici",
     "cute_resistente_sali",
     "cuticole_cerose",
+    "cuticole_neutralizzanti",
+    "denti_chelatanti",
+    "denti_ossidoferro",
+    "denti_silice_termici",
+    "denti_tuning_fork",
+    "echi_risonanti",
     "eco_interno_riflesso",
     "empatia_coordinativa",
+    "enzimi_antifase_termica",
+    "enzimi_antipredatori_algali",
     "enzimi_chelanti",
+    "enzimi_chelatori_rapidi",
+    "enzimi_metanoossidanti",
+    "epidermide_dielettrica",
+    "epitelio_fosforescente",
     "filamenti_digestivi_compattanti",
+    "filamenti_magnetotrofi",
+    "filamenti_superconduttivi",
+    "filamenti_termoconduzione",
+    "filtri_planctonici",
+    "fisiologia_predatoria",
+    "flagelli_ancoranti",
+    "focus_frazionato",
+    "foliage_fotocatodico",
+    "foliaggio_spugna",
+    "frusta_fiammeggiante",
+    "ghiaccio_piezoelettrico",
+    "ghiandola_caustica",
+    "ghiandole_cambio_salino",
+    "ghiandole_condensa_ozono",
+    "ghiandole_eco_mappanti",
+    "ghiandole_fango_calde",
+    "ghiandole_fango_coesivo",
+    "ghiandole_grafene",
+    "ghiandole_inchiostro_luce",
+    "ghiandole_iodoattive",
+    "ghiandole_minerali",
+    "ghiandole_nebbia_acida",
+    "ghiandole_nebbia_ionica",
+    "ghiandole_resina_conduttiva",
+    "ghiandole_ventosa",
+    "giunti_antitorsione",
     "grassi_termici",
+    "gusci_criovetro",
+    "gusci_magnesio",
+    "lamelle_shear",
+    "lamelle_sincroniche",
+    "lamelle_termoforetiche",
+    "lamine_filtranti_aeree",
+    "lamine_scudo_silice",
+    "linfa_tampone",
+    "lingua_cristallina",
+    "lingua_tattile_trama",
+    "luminescenza_aurorale",
+    "luminescenza_hydrotermica",
+    "mantelli_geotermici",
+    "mantello_meteoritico",
+    "membrane_captura_rugiada",
+    "membrane_eliofiltranti",
+    "membrane_planata_vectored",
+    "membrane_pneumatofori",
+    "metabolismo_attivo",
+    "metabolismo_sostentato",
+    "midollo_antivibrazione",
     "mimetismo_cromatico_passivo",
+    "mucillagine_simbionte_mangrovie",
+    "mucose_aderenza_sonica",
+    "mucose_barofile",
+    "nodi_micorrizici_oracolari",
     "nucleo_ovomotore_rotante",
     "occhi_infrarosso_composti",
     "olfatto_risonanza_magnetica",
+    "origine_artificiale",
+    "pathfinder",
     "pelli_anti_ustione",
     "pelli_cave",
     "pelli_fitte",
+    "pianificatore",
     "pigmenti_aurorali",
     "pigmenti_termici",
+    "piume_solari_fotovoltaiche",
+    "polmoni_cristallini_alta_quota",
     "proteine_shock_termico",
+    "respirazione_biologica",
     "respiro_a_scoppio",
     "reti_capillari_radici",
+    "risonanza_di_branco",
     "sacche_galleggianti_ascensoriali",
+    "sacche_spore_stratosferiche",
     "sangue_piroforico",
     "scheletro_idro_regolante",
     "secrezione_rallentante_palmi",
     "sensori_geomagnetici",
+    "sinapsi_coraline_polifoniche",
     "sonno_emisferico_alternato",
     "spore_psichiche_silenziate",
+    "squame_rifrangenti_deserto",
     "struttura_elastica_amorfa",
-    "ventriglio_gastroliti"
+    "tattiche_di_branco",
+    "vello_condensatore_nebbie",
+    "ventriglio_gastroliti",
+    "zoccoli_risonanti_steppe"
   ],
   "optional_traits": [
+    "ali_fulminee",
+    "ali_ioniche",
+    "ali_membrana_sonica",
+    "ali_solari_fotoni",
+    "antenne_dustsense",
+    "antenne_eco_turbina",
+    "antenne_flusso_mareale",
+    "antenne_microonde_cavernose",
+    "antenne_plasmatiche_tempesta",
+    "antenne_reagenti",
+    "antenne_tesla",
+    "antenne_waveguide",
+    "antenne_wideband",
+    "appendici_risonanti_marea",
+    "appendici_thermotattiche",
+    "armatura_pietra_planare",
+    "artigli_acidofagi",
+    "artigli_induzione",
+    "artigli_psionici",
+    "artigli_radice",
+    "artigli_scivolo_silente",
+    "artigli_sette_vie",
+    "artigli_sghiaccio_glaciale",
+    "artigli_vetrificati",
+    "aura_scudo_radianza",
+    "baffi_mareomotori",
+    "barbigli_sensori_plasma",
+    "barriere_miasma_glaciale",
+    "batteri_endosimbionti_chemio",
+    "batteri_termofili_endosimbiosi",
+    "biochip_memoria",
+    "biofilm_glow",
+    "biofilm_iperarido",
+    "branchie_dual_mode",
+    "branchie_eoliche",
+    "branchie_metalloidi",
+    "branchie_microfiltri",
+    "branchie_osmotiche_salmastra",
+    "branchie_solfatiche",
+    "branchie_turbina",
+    "bulbi_radici_permafrost",
+    "camere_anticorrosione",
+    "camere_mirage",
+    "camere_nutrienti_vent",
+    "campo_di_fase",
+    "capillari_criogenici",
+    "capillari_fluoridici",
+    "capillari_fotovoltaici",
+    "capsule_paracadute",
     "carapace_fase_variabile",
+    "carapace_luminiscente_abissale",
+    "carapace_segmenti_logici",
+    "carapaci_ferruginosi",
+    "cartilagine_flessotermica_venti",
+    "cartilagini_biofibre",
+    "cartilagini_desertiche",
+    "cartilagini_flessoacustiche",
+    "cartilagini_pseudometalliche",
+    "cavita_risonanti_tundra",
+    "cervelletto_equilibrio_statico",
+    "chemiorecettori_bromuro",
+    "chioma_parassita_canopica",
+    "circolazione_bifasica",
+    "circolazione_bifasica_palude",
+    "circolazione_cooling_loop",
+    "circolazione_doppia",
+    "circolazione_supercritica",
+    "ciste_riduttive",
+    "ciste_salmastre",
+    "cisti_iperbariche",
+    "coda_balanciere",
+    "coda_contrappeso",
+    "coda_coppia_retroattiva",
     "coda_frusta_cinetica",
+    "coda_stabilizzatrice_filo",
+    "coda_stabilizzatrice_geiser",
+    "coda_stabilizzatrice_vortex",
+    "colonne_vibromagnetiche",
+    "coralli_partner",
+    "corteccia_memetica",
     "criostasi_adattiva",
+    "cromofori_alert_acido",
+    "cuore_multicamera_bassa_pressione",
+    "cuscinetti_elettrostatici",
+    "cute_resistente_sali",
+    "cuticole_cerose",
+    "cuticole_neutralizzanti",
+    "denti_chelatanti",
+    "denti_ossidoferro",
+    "denti_silice_termici",
+    "denti_tuning_fork",
+    "echi_risonanti",
+    "eco_interno_riflesso",
+    "eco_sismico",
+    "empatia_coordinativa",
+    "enzimi_antifase_termica",
+    "enzimi_antipredatori_algali",
+    "enzimi_chelanti",
+    "enzimi_chelatori_rapidi",
+    "enzimi_metanoossidanti",
+    "epidermide_dielettrica",
+    "epitelio_fosforescente",
+    "filamenti_digestivi_compattanti",
+    "filamenti_magnetotrofi",
+    "filamenti_superconduttivi",
+    "filamenti_termoconduzione",
+    "filtri_bioattivi",
+    "filtri_planctonici",
+    "flagelli_ancoranti",
     "focus_frazionato",
+    "foliage_fotocatodico",
+    "foliaggio_spugna",
+    "fotosintesi_bifase",
+    "frusta_fiammeggiante",
+    "ghiaccio_piezoelettrico",
     "ghiandola_caustica",
+    "ghiandole_cambio_salino",
+    "ghiandole_condensa_ozono",
+    "ghiandole_eco_mappanti",
+    "ghiandole_fango_calde",
+    "ghiandole_fango_coesivo",
+    "ghiandole_grafene",
+    "ghiandole_inchiostro_luce",
+    "ghiandole_iodoattive",
+    "ghiandole_minerali",
+    "ghiandole_nebbia_acida",
+    "ghiandole_nebbia_ionica",
+    "ghiandole_nettare_memetico",
+    "ghiandole_resina_conduttiva",
+    "ghiandole_ventosa",
+    "giunti_antitorsione",
+    "grassi_termici",
+    "gusci_criovetro",
+    "gusci_magnesio",
+    "intangibilita_parziale",
+    "lamelle_shear",
+    "lamelle_sincroniche",
     "lamelle_termoforetiche",
+    "lamenti_diradanti",
+    "lamine_filtranti_aeree",
+    "lamine_scudo_silice",
+    "linfa_tampone",
+    "lingua_cristallina",
     "lingua_tattile_trama",
+    "luminescenza_aurorale",
+    "luminescenza_hydrotermica",
+    "mantelli_geotermici",
+    "mantello_meteoritico",
+    "maschera_illusoria",
+    "matrice_antimagia",
+    "membrane_captura_rugiada",
+    "membrane_eliofiltranti",
+    "membrane_osmotiche",
+    "membrane_planata_vectored",
+    "membrane_pneumatofori",
+    "midollo_antivibrazione",
+    "mimetismo_cromatico_passivo",
+    "mucillagine_simbionte_mangrovie",
+    "mucose_aderenza_sonica",
+    "mucose_barofile",
+    "nodi_micorrizici_oracolari",
+    "nodi_micotici",
+    "nuclei_di_controllo",
     "nucleo_ovomotore_rotante",
     "occhi_infrarosso_composti",
     "olfatto_risonanza_magnetica",
+    "pathfinder",
+    "pelli_anti_ustione",
+    "pelli_cave",
+    "pelli_fitte",
+    "pianificatore",
+    "pigmenti_aurorali",
+    "pigmenti_termici",
+    "piume_solari_fotovoltaiche",
+    "polmoni_cristallini_alta_quota",
+    "proboscide_polifaga",
+    "proteine_shock_termico",
+    "radici_ancora_planare",
+    "random",
     "respiro_a_scoppio",
+    "reti_capillari_radici",
+    "riflessi_preternaturali",
+    "rinforzi_modulari",
+    "risonanza_di_branco",
     "sacche_galleggianti_ascensoriali",
+    "sacche_spore_stratosferiche",
     "sangue_piroforico",
     "scheletro_idro_regolante",
+    "secrezione_rallentante_palmi",
+    "secrezioni_antisepsi",
+    "sensori_chimici",
+    "sensori_geomagnetici",
+    "sinapsi_coraline_polifoniche",
+    "sinapsi_riflettenti",
+    "sonno_emisferico_alternato",
     "spore_psichiche_silenziate",
+    "squame_rifrangenti_deserto",
+    "struttura_elastica_amorfa",
+    "tattiche_di_branco",
+    "tessuti_adattivi",
+    "vello_condensatore_nebbie",
     "ventriglio_gastroliti",
-    "zampe_a_molla"
+    "visione_spettrale",
+    "voce_spettrale",
+    "zampe_a_molla",
+    "zoccoli_risonanti_steppe"
   ],
   "synergy_traits": [
+    "Strategist",
+    "architetto",
     "empatia_coordinativa",
     "focus_frazionato",
-    "pathfinder",
-    "pianificatore",
     "risonanza_di_branco",
     "scheletro_idro_regolante",
+    "sinergizzatore_team",
     "struttura_elastica_amorfa",
+    "support",
     "tattiche_di_branco"
   ],
   "missing_core_traits": [],
   "entries": [
     {
+      "id": "abisso-luminescente-trait-keeper",
+      "type": "species",
+      "display_name": "Abisso Luminescente Trait Keeper",
+      "core_traits": [
+        "carapace_luminiscente_abissale"
+      ],
+      "optional_traits": [
+        "carapace_luminiscente_abissale"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/abisso_luminescente/abisso-luminescente-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "abisso-vulcanico-trait-keeper",
+      "type": "species",
+      "display_name": "Volcanic Abyss Trait Keeper",
+      "core_traits": [
+        "appendici_thermotattiche",
+        "batteri_endosimbionti_chemio",
+        "branchie_metalloidi",
+        "carapaci_ferruginosi",
+        "cartilagini_pseudometalliche",
+        "circolazione_supercritica",
+        "cisti_iperbariche",
+        "denti_ossidoferro",
+        "enzimi_metanoossidanti",
+        "filamenti_magnetotrofi",
+        "ghiandole_fango_calde",
+        "luminescenza_hydrotermica",
+        "mucose_barofile"
+      ],
+      "optional_traits": [
+        "appendici_thermotattiche",
+        "batteri_endosimbionti_chemio",
+        "branchie_metalloidi",
+        "carapaci_ferruginosi",
+        "cartilagini_pseudometalliche",
+        "circolazione_supercritica",
+        "cisti_iperbariche",
+        "denti_ossidoferro",
+        "enzimi_metanoossidanti",
+        "filamenti_magnetotrofi",
+        "ghiandole_fango_calde",
+        "luminescenza_hydrotermica",
+        "mucose_barofile"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/abisso_vulcanico/abisso-vulcanico-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "altipiani-solari-trait-keeper",
+      "type": "species",
+      "display_name": "Altipiani Solari Trait Keeper",
+      "core_traits": [
+        "piume_solari_fotovoltaiche"
+      ],
+      "optional_traits": [
+        "piume_solari_fotovoltaiche"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/altipiani_solari/altipiani-solari-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "archon-solare",
+      "type": "species",
+      "display_name": "Archon Solare Custode",
+      "core_traits": [
+        "adattamento_volo",
+        "aura_scudo_radianza",
+        "ciclo_vitale_completo",
+        "metabolismo_attivo",
+        "respirazione_biologica"
+      ],
+      "optional_traits": [
+        "ali_solari_fotoni",
+        "aura_scudo_radianza",
+        "empatia_coordinativa",
+        "focus_frazionato",
+        "lamelle_termoforetiche",
+        "risonanza_di_branco",
+        "visione_spettrale"
+      ],
+      "synergy_traits": [
+        "empatia_coordinativa",
+        "focus_frazionato",
+        "risonanza_di_branco"
+      ],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/rovine_planari/archon-solare.yaml"
+      ]
+    },
+    {
+      "id": "aurora-bridge-runner",
+      "type": "species",
+      "display_name": "Aurora Bridge Runner",
+      "core_traits": [
+        "eco_interno_riflesso",
+        "mimetismo_cromatico_passivo",
+        "sacche_galleggianti_ascensoriali"
+      ],
+      "optional_traits": [
+        "eco_interno_riflesso",
+        "lingua_tattile_trama",
+        "mimetismo_cromatico_passivo",
+        "occhi_infrarosso_composti",
+        "sacche_galleggianti_ascensoriali"
+      ],
+      "synergy_traits": [
+        "support"
+      ],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-bridge-runner.yaml"
+      ]
+    },
+    {
       "id": "aurora-gull",
       "type": "species",
       "display_name": "Gabbiano d’Aurora",
       "core_traits": [
-        "cuticole_cerose",
-        "grassi_termici",
-        "pelli_cave",
-        "pigmenti_aurorali",
-        "proteine_shock_termico",
-        "reti_capillari_radici"
+        "criostasi_adattiva",
+        "eco_interno_riflesso",
+        "sonno_emisferico_alternato"
       ],
-      "optional_traits": [],
+      "optional_traits": [
+        "criostasi_adattiva",
+        "eco_interno_riflesso",
+        "occhi_infrarosso_composti",
+        "sacche_galleggianti_ascensoriali",
+        "sonno_emisferico_alternato"
+      ],
       "synergy_traits": [],
       "sources": [
         "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml"
+      ]
+    },
+    {
+      "id": "badlands-trait-keeper",
+      "type": "species",
+      "display_name": "Badlands Trait Keeper",
+      "core_traits": [
+        "cute_resistente_sali"
+      ],
+      "optional_traits": [
+        "cute_resistente_sali"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/badlands/badlands-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "balor-fission",
+      "type": "species",
+      "display_name": "Balor a Fissione",
+      "core_traits": [
+        "adattamento_volo",
+        "ciclo_vitale_completo",
+        "frusta_fiammeggiante",
+        "mantello_meteoritico",
+        "metabolismo_attivo",
+        "respirazione_biologica"
+      ],
+      "optional_traits": [
+        "armatura_pietra_planare",
+        "artigli_sette_vie",
+        "carapace_fase_variabile",
+        "criostasi_adattiva",
+        "empatia_coordinativa",
+        "frusta_fiammeggiante",
+        "mantello_meteoritico",
+        "tattiche_di_branco"
+      ],
+      "synergy_traits": [
+        "focus_frazionato"
+      ],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/rovine_planari/balor-fission.yaml"
+      ]
+    },
+    {
+      "id": "barriere-coralline-psioniche-trait-keeper",
+      "type": "species",
+      "display_name": "Barriere Coralline Psioniche Trait Keeper",
+      "core_traits": [
+        "sinapsi_coraline_polifoniche"
+      ],
+      "optional_traits": [
+        "sinapsi_coraline_polifoniche"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/barriere_coralline_psioniche/barriere-coralline-psioniche-trait-keeper.yaml"
       ]
     },
     {
@@ -103,12 +635,44 @@
       "type": "species",
       "display_name": "Blight Micotico",
       "core_traits": [
-        "pelli_fitte"
+        "ghiandola_caustica",
+        "lingua_tattile_trama",
+        "spore_psichiche_silenziate"
       ],
-      "optional_traits": [],
+      "optional_traits": [
+        "filamenti_digestivi_compattanti",
+        "ghiandola_caustica",
+        "lingua_tattile_trama",
+        "mimetismo_cromatico_passivo",
+        "spore_psichiche_silenziate"
+      ],
       "synergy_traits": [],
       "sources": [
         "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml"
+      ]
+    },
+    {
+      "id": "bulette-fase",
+      "type": "species",
+      "display_name": "Bulette di Fase",
+      "core_traits": [
+        "ciclo_vitale_completo",
+        "fisiologia_predatoria",
+        "metabolismo_attivo",
+        "respirazione_biologica"
+      ],
+      "optional_traits": [
+        "armatura_pietra_planare",
+        "carapace_fase_variabile",
+        "coda_frusta_cinetica",
+        "lamelle_termoforetiche",
+        "sacche_galleggianti_ascensoriali",
+        "scheletro_idro_regolante",
+        "sensori_geomagnetici"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/rovine_planari/bulette-fase.yaml"
       ]
     },
     {
@@ -123,17 +687,7 @@
         "proteine_shock_termico",
         "reti_capillari_radici"
       ],
-      "optional_traits": [],
-      "synergy_traits": [],
-      "sources": [
-        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml"
-      ]
-    },
-    {
-      "id": "cryo-lynx",
-      "type": "species",
-      "display_name": "Cryo Lynx",
-      "core_traits": [
+      "optional_traits": [
         "cuticole_cerose",
         "grassi_termici",
         "pelli_cave",
@@ -141,10 +695,320 @@
         "proteine_shock_termico",
         "reti_capillari_radici"
       ],
-      "optional_traits": [],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml"
+      ]
+    },
+    {
+      "id": "caldera-glaciale-trait-keeper",
+      "type": "species",
+      "display_name": "Glacial Caldera Trait Keeper",
+      "core_traits": [
+        "artigli_vetrificati",
+        "barriere_miasma_glaciale",
+        "branchie_solfatiche",
+        "capillari_criogenici",
+        "circolazione_bifasica",
+        "enzimi_antifase_termica",
+        "filamenti_superconduttivi",
+        "ghiaccio_piezoelettrico",
+        "ghiandole_ventosa",
+        "gusci_criovetro",
+        "luminescenza_aurorale",
+        "mantelli_geotermici"
+      ],
+      "optional_traits": [
+        "artigli_vetrificati",
+        "barriere_miasma_glaciale",
+        "branchie_solfatiche",
+        "capillari_criogenici",
+        "circolazione_bifasica",
+        "enzimi_antifase_termica",
+        "filamenti_superconduttivi",
+        "ghiaccio_piezoelettrico",
+        "ghiandole_ventosa",
+        "gusci_criovetro",
+        "luminescenza_aurorale",
+        "mantelli_geotermici"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/caldera_glaciale/caldera-glaciale-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "calotte-glaciali-trait-keeper",
+      "type": "species",
+      "display_name": "Calotte Glaciali Trait Keeper",
+      "core_traits": [
+        "artigli_sghiaccio_glaciale"
+      ],
+      "optional_traits": [
+        "artigli_sghiaccio_glaciale"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/calotte_glaciali/calotte-glaciali-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "canopia-ionica-trait-keeper",
+      "type": "species",
+      "display_name": "Ionic Canopy Trait Keeper",
+      "core_traits": [
+        "ali_ioniche",
+        "antenne_tesla",
+        "artigli_induzione",
+        "capillari_fotovoltaici",
+        "cervelletto_equilibrio_statico",
+        "coda_stabilizzatrice_filo",
+        "ghiandole_nebbia_ionica",
+        "ghiandole_resina_conduttiva",
+        "membrane_planata_vectored"
+      ],
+      "optional_traits": [
+        "ali_ioniche",
+        "antenne_tesla",
+        "artigli_induzione",
+        "capillari_fotovoltaici",
+        "cervelletto_equilibrio_statico",
+        "coda_stabilizzatrice_filo",
+        "ghiandole_nebbia_ionica",
+        "ghiandole_resina_conduttiva",
+        "membrane_planata_vectored"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/canopia_ionica/canopia-ionica-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "canopia-psionica-leggera-trait-keeper",
+      "type": "species",
+      "display_name": "Canopia Psionica Leggera Trait Keeper",
+      "core_traits": [
+        "carapace_fase_variabile",
+        "criostasi_adattiva",
+        "eco_interno_riflesso",
+        "mimetismo_cromatico_passivo",
+        "sacche_galleggianti_ascensoriali",
+        "struttura_elastica_amorfa"
+      ],
+      "optional_traits": [
+        "carapace_fase_variabile",
+        "criostasi_adattiva",
+        "eco_interno_riflesso",
+        "mimetismo_cromatico_passivo",
+        "sacche_galleggianti_ascensoriali",
+        "struttura_elastica_amorfa"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/canopia_psionica_leggera/canopia-psionica-leggera-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "canopie-sospese-trait-keeper",
+      "type": "species",
+      "display_name": "Canopie Sospese Trait Keeper",
+      "core_traits": [
+        "chioma_parassita_canopica"
+      ],
+      "optional_traits": [
+        "chioma_parassita_canopica"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/canopie_sospese/canopie-sospese-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "caverna-risonante-trait-keeper",
+      "type": "species",
+      "display_name": "Resonant Cavern Trait Keeper",
+      "core_traits": [
+        "ali_membrana_sonica",
+        "antenne_microonde_cavernose",
+        "artigli_scivolo_silente",
+        "artigli_sette_vie",
+        "cartilagini_flessoacustiche",
+        "coda_balanciere",
+        "colonne_vibromagnetiche",
+        "denti_tuning_fork",
+        "echi_risonanti",
+        "filamenti_digestivi_compattanti",
+        "ghiandole_eco_mappanti",
+        "lingua_tattile_trama",
+        "midollo_antivibrazione",
+        "mucose_aderenza_sonica",
+        "nucleo_ovomotore_rotante",
+        "occhi_infrarosso_composti",
+        "respiro_a_scoppio",
+        "sangue_piroforico",
+        "scheletro_idro_regolante",
+        "secrezione_rallentante_palmi",
+        "sonno_emisferico_alternato",
+        "spore_psichiche_silenziate",
+        "ventriglio_gastroliti"
+      ],
+      "optional_traits": [
+        "ali_membrana_sonica",
+        "antenne_microonde_cavernose",
+        "artigli_scivolo_silente",
+        "artigli_sette_vie",
+        "cartilagini_flessoacustiche",
+        "coda_balanciere",
+        "colonne_vibromagnetiche",
+        "denti_tuning_fork",
+        "echi_risonanti",
+        "filamenti_digestivi_compattanti",
+        "ghiandole_eco_mappanti",
+        "lingua_tattile_trama",
+        "midollo_antivibrazione",
+        "mucose_aderenza_sonica",
+        "nucleo_ovomotore_rotante",
+        "occhi_infrarosso_composti",
+        "respiro_a_scoppio",
+        "sangue_piroforico",
+        "scheletro_idro_regolante",
+        "secrezione_rallentante_palmi",
+        "sonno_emisferico_alternato",
+        "spore_psichiche_silenziate",
+        "ventriglio_gastroliti"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/caverna_risonante/caverna-risonante-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "cicloni-psionici-trait-keeper",
+      "type": "species",
+      "display_name": "Cicloni Psionici Trait Keeper",
+      "core_traits": [
+        "antenne_plasmatiche_tempesta"
+      ],
+      "optional_traits": [
+        "antenne_plasmatiche_tempesta"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/cicloni_psionici/cicloni-psionici-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "couatl-aurora",
+      "type": "species",
+      "display_name": "Couatl Aurora Custode",
+      "core_traits": [
+        "adattamento_volo",
+        "ciclo_vitale_completo",
+        "metabolismo_attivo",
+        "respirazione_biologica"
+      ],
+      "optional_traits": [
+        "ali_solari_fotoni",
+        "artigli_sette_vie",
+        "empatia_coordinativa",
+        "focus_frazionato",
+        "ghiandole_nettare_memetico",
+        "lamelle_termoforetiche",
+        "occhi_infrarosso_composti",
+        "sensori_geomagnetici"
+      ],
+      "synergy_traits": [
+        "focus_frazionato",
+        "risonanza_di_branco"
+      ],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/rovine_planari/couatl-aurora.yaml"
+      ]
+    },
+    {
+      "id": "cryo-lynx",
+      "type": "species",
+      "display_name": "Cryo Lynx",
+      "core_traits": [
+        "artigli_sette_vie",
+        "carapace_fase_variabile",
+        "olfatto_risonanza_magnetica"
+      ],
+      "optional_traits": [
+        "artigli_sette_vie",
+        "carapace_fase_variabile",
+        "criostasi_adattiva",
+        "olfatto_risonanza_magnetica",
+        "zampe_a_molla"
+      ],
       "synergy_traits": [],
       "sources": [
         "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml"
+      ]
+    },
+    {
+      "id": "delta-salmastri-trait-keeper",
+      "type": "species",
+      "display_name": "Delta Salmastri Trait Keeper",
+      "core_traits": [
+        "branchie_osmotiche_salmastra"
+      ],
+      "optional_traits": [
+        "branchie_osmotiche_salmastra"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/delta_salmastri/delta-salmastri-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "dorsale-termale-tropicale-trait-keeper",
+      "type": "species",
+      "display_name": "Tropical Thermal Ridge Trait Keeper",
+      "core_traits": [
+        "antenne_eco_turbina",
+        "batteri_termofili_endosimbiosi",
+        "branchie_turbina",
+        "camere_nutrienti_vent",
+        "circolazione_doppia",
+        "coda_stabilizzatrice_geiser",
+        "denti_silice_termici",
+        "filamenti_termoconduzione",
+        "ghiandole_minerali",
+        "gusci_magnesio",
+        "lamine_scudo_silice"
+      ],
+      "optional_traits": [
+        "antenne_eco_turbina",
+        "batteri_termofili_endosimbiosi",
+        "branchie_turbina",
+        "camere_nutrienti_vent",
+        "circolazione_doppia",
+        "coda_stabilizzatrice_geiser",
+        "denti_silice_termici",
+        "filamenti_termoconduzione",
+        "ghiandole_minerali",
+        "gusci_magnesio",
+        "lamine_scudo_silice"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/dorsale_termale_tropicale/dorsale-termale-tropicale-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "dune-cristalline-trait-keeper",
+      "type": "species",
+      "display_name": "Dune Cristalline Trait Keeper",
+      "core_traits": [
+        "squame_rifrangenti_deserto"
+      ],
+      "optional_traits": [
+        "squame_rifrangenti_deserto"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/dune_cristalline/dune-cristalline-trait-keeper.yaml"
       ]
     },
     {
@@ -153,15 +1017,19 @@
       "display_name": "Dune Stalker",
       "core_traits": [
         "artigli_sette_vie",
+        "coda_frusta_cinetica",
         "scheletro_idro_regolante",
-        "sensori_geomagnetici",
         "struttura_elastica_amorfa"
       ],
       "optional_traits": [
+        "artigli_sette_vie",
         "coda_frusta_cinetica",
         "criostasi_adattiva",
-        "lamelle_termoforetiche",
-        "sacche_galleggianti_ascensoriali"
+        "olfatto_risonanza_magnetica",
+        "respiro_a_scoppio",
+        "sacche_galleggianti_ascensoriali",
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
       ],
       "synergy_traits": [
         "focus_frazionato",
@@ -169,7 +1037,7 @@
         "tattiche_di_branco"
       ],
       "sources": [
-        "data/core/species.yaml"
+        "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml"
       ]
     },
     {
@@ -182,12 +1050,42 @@
         "sonno_emisferico_alternato"
       ],
       "optional_traits": [
+        "eco_interno_riflesso",
         "lingua_tattile_trama",
-        "sacche_galleggianti_ascensoriali"
+        "occhi_infrarosso_composti",
+        "sacche_galleggianti_ascensoriali",
+        "sonno_emisferico_alternato"
       ],
       "synergy_traits": [],
       "sources": [
         "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml"
+      ]
+    },
+    {
+      "id": "falde-magnetiche-psioniche-trait-keeper",
+      "type": "species",
+      "display_name": "Falde Magnetiche Psioniche Trait Keeper",
+      "core_traits": [
+        "carapace_fase_variabile",
+        "coda_frusta_cinetica",
+        "eco_interno_riflesso",
+        "filamenti_digestivi_compattanti",
+        "mimetismo_cromatico_passivo",
+        "olfatto_risonanza_magnetica",
+        "struttura_elastica_amorfa"
+      ],
+      "optional_traits": [
+        "carapace_fase_variabile",
+        "coda_frusta_cinetica",
+        "eco_interno_riflesso",
+        "filamenti_digestivi_compattanti",
+        "mimetismo_cromatico_passivo",
+        "olfatto_risonanza_magnetica",
+        "struttura_elastica_amorfa"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/falde_magnetiche_psioniche/falde-magnetiche-psioniche-trait-keeper.yaml"
       ]
     },
     {
@@ -201,11 +1099,200 @@
       ],
       "optional_traits": [
         "lingua_tattile_trama",
+        "mimetismo_cromatico_passivo",
+        "sangue_piroforico",
+        "secrezione_rallentante_palmi",
         "ventriglio_gastroliti"
+      ],
+      "synergy_traits": [
+        "architetto",
+        "sinergizzatore_team"
+      ],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml"
+      ]
+    },
+    {
+      "id": "foresta-acida-trait-keeper",
+      "type": "species",
+      "display_name": "Acidic Rainforest Trait Keeper",
+      "core_traits": [
+        "antenne_reagenti",
+        "artigli_acidofagi",
+        "camere_anticorrosione",
+        "capillari_fluoridici",
+        "cromofori_alert_acido",
+        "cuticole_neutralizzanti",
+        "denti_chelatanti",
+        "enzimi_chelatori_rapidi",
+        "foliage_fotocatodico",
+        "ghiandole_nebbia_acida",
+        "linfa_tampone"
+      ],
+      "optional_traits": [
+        "antenne_reagenti",
+        "artigli_acidofagi",
+        "camere_anticorrosione",
+        "capillari_fluoridici",
+        "cromofori_alert_acido",
+        "cuticole_neutralizzanti",
+        "denti_chelatanti",
+        "enzimi_chelatori_rapidi",
+        "foliage_fotocatodico",
+        "ghiandole_nebbia_acida",
+        "linfa_tampone"
       ],
       "synergy_traits": [],
       "sources": [
-        "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml"
+        "packs/evo_tactics_pack/data/species/foresta_acida/foresta-acida-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "foreste-nubose-trait-keeper",
+      "type": "species",
+      "display_name": "Foreste Nubose Trait Keeper",
+      "core_traits": [
+        "vello_condensatore_nebbie"
+      ],
+      "optional_traits": [
+        "vello_condensatore_nebbie"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/foreste_nubose/foreste-nubose-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "global-trait-keeper",
+      "type": "species",
+      "display_name": "Global Trait Keeper",
+      "core_traits": [
+        "cute_resistente_sali",
+        "cuticole_cerose",
+        "enzimi_chelanti",
+        "grassi_termici",
+        "pelli_cave",
+        "pelli_fitte",
+        "pigmenti_aurorali",
+        "proteine_shock_termico",
+        "reti_capillari_radici"
+      ],
+      "optional_traits": [
+        "cute_resistente_sali",
+        "cuticole_cerose",
+        "enzimi_chelanti",
+        "grassi_termici",
+        "pelli_cave",
+        "pelli_fitte",
+        "pigmenti_aurorali",
+        "proteine_shock_termico",
+        "reti_capillari_radici"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/global/global-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "glowcap-weaver",
+      "type": "species",
+      "display_name": "Glowcap Weaver",
+      "core_traits": [
+        "empatia_coordinativa",
+        "filamenti_digestivi_compattanti",
+        "struttura_elastica_amorfa"
+      ],
+      "optional_traits": [
+        "empatia_coordinativa",
+        "filamenti_digestivi_compattanti",
+        "focus_frazionato",
+        "lingua_tattile_trama",
+        "struttura_elastica_amorfa"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/foresta_temperata/glowcap-weaver.yaml"
+      ]
+    },
+    {
+      "id": "gole-ventose-trait-keeper",
+      "type": "species",
+      "display_name": "Gole Ventose Trait Keeper",
+      "core_traits": [
+        "cartilagine_flessotermica_venti"
+      ],
+      "optional_traits": [
+        "cartilagine_flessotermica_venti"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/gole_ventose/gole-ventose-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "golem-runico",
+      "type": "species",
+      "display_name": "Golem Runico Custodiale",
+      "core_traits": [
+        "armatura_pietra_planare",
+        "assenza_respirazione",
+        "ciclo_vitale_anomalo",
+        "metabolismo_sostentato",
+        "origine_artificiale"
+      ],
+      "optional_traits": [
+        "armatura_pietra_planare",
+        "campo_di_fase",
+        "carapace_fase_variabile",
+        "matrice_antimagia",
+        "nuclei_di_controllo",
+        "rinforzi_modulari"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/rovine_planari/golem-runico.yaml"
+      ]
+    },
+    {
+      "id": "laghi-alcalini-trait-keeper",
+      "type": "species",
+      "display_name": "Laghi Alcalini Trait Keeper",
+      "core_traits": [
+        "membrane_eliofiltranti"
+      ],
+      "optional_traits": [
+        "membrane_eliofiltranti"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/laghi_alcalini/laghi-alcalini-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "laguna-bioreattiva-trait-keeper",
+      "type": "species",
+      "display_name": "Bioreactive Lagoon Trait Keeper",
+      "core_traits": [
+        "antenne_flusso_mareale",
+        "appendici_risonanti_marea",
+        "branchie_dual_mode",
+        "ciste_riduttive",
+        "filtri_planctonici",
+        "flagelli_ancoranti",
+        "ghiandole_cambio_salino"
+      ],
+      "optional_traits": [
+        "antenne_flusso_mareale",
+        "appendici_risonanti_marea",
+        "branchie_dual_mode",
+        "ciste_riduttive",
+        "filtri_planctonici",
+        "flagelli_ancoranti",
+        "ghiandole_cambio_salino"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/laguna_bioreattiva/laguna-bioreattiva-trait-keeper.yaml"
       ]
     },
     {
@@ -213,12 +1300,160 @@
       "type": "species",
       "display_name": "Lupo della Foresta",
       "core_traits": [
-        "pelli_fitte"
+        "empatia_coordinativa",
+        "risonanza_di_branco",
+        "tattiche_di_branco"
       ],
-      "optional_traits": [],
+      "optional_traits": [
+        "empatia_coordinativa",
+        "focus_frazionato",
+        "occhi_infrarosso_composti",
+        "risonanza_di_branco",
+        "tattiche_di_branco"
+      ],
       "synergy_traits": [],
       "sources": [
         "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml"
+      ]
+    },
+    {
+      "id": "magnet-fathom-surveyor",
+      "type": "species",
+      "display_name": "Magnet Fathom Surveyor",
+      "core_traits": [
+        "filamenti_digestivi_compattanti",
+        "nucleo_ovomotore_rotante",
+        "olfatto_risonanza_magnetica",
+        "struttura_elastica_amorfa"
+      ],
+      "optional_traits": [
+        "filamenti_digestivi_compattanti",
+        "lamelle_termoforetiche",
+        "nucleo_ovomotore_rotante",
+        "olfatto_risonanza_magnetica",
+        "scheletro_idro_regolante",
+        "struttura_elastica_amorfa"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/falde_magnetiche_psioniche/magnet-fathom-surveyor.yaml"
+      ]
+    },
+    {
+      "id": "magneto-ridge-hunter",
+      "type": "species",
+      "display_name": "Magneto Ridge Hunter",
+      "core_traits": [
+        "artigli_sette_vie",
+        "coda_frusta_cinetica",
+        "scheletro_idro_regolante"
+      ],
+      "optional_traits": [
+        "artigli_sette_vie",
+        "coda_frusta_cinetica",
+        "olfatto_risonanza_magnetica",
+        "respiro_a_scoppio",
+        "scheletro_idro_regolante"
+      ],
+      "synergy_traits": [
+        "struttura_elastica_amorfa",
+        "tattiche_di_branco"
+      ],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/badlands/magneto-ridge-hunter.yaml"
+      ]
+    },
+    {
+      "id": "mangrovie-risonanti-trait-keeper",
+      "type": "species",
+      "display_name": "Mangrovie Risonanti Trait Keeper",
+      "core_traits": [
+        "mucillagine_simbionte_mangrovie"
+      ],
+      "optional_traits": [
+        "mucillagine_simbionte_mangrovie"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/mangrovie_risonanti/mangrovie-risonanti-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "mangrovieto-cinetico-trait-keeper",
+      "type": "species",
+      "display_name": "Kinetic Mangrove Trait Keeper",
+      "core_traits": [
+        "artigli_radice",
+        "baffi_mareomotori",
+        "coda_contrappeso",
+        "foliaggio_spugna",
+        "ghiandole_fango_coesivo",
+        "giunti_antitorsione",
+        "lamine_filtranti_aeree",
+        "membrane_pneumatofori"
+      ],
+      "optional_traits": [
+        "artigli_radice",
+        "baffi_mareomotori",
+        "coda_contrappeso",
+        "foliaggio_spugna",
+        "ghiandole_fango_coesivo",
+        "giunti_antitorsione",
+        "lamine_filtranti_aeree",
+        "membrane_pneumatofori"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/mangrovieto_cinetico/mangrovieto-cinetico-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "marilith-vault",
+      "type": "species",
+      "display_name": "Marilith delle Volte",
+      "core_traits": [
+        "ciclo_vitale_completo",
+        "focus_frazionato",
+        "frusta_fiammeggiante",
+        "mantello_meteoritico",
+        "metabolismo_attivo",
+        "respirazione_biologica"
+      ],
+      "optional_traits": [
+        "artigli_sette_vie",
+        "coda_frusta_cinetica",
+        "empatia_coordinativa",
+        "riflessi_preternaturali",
+        "sensori_geomagnetici",
+        "tessuti_adattivi",
+        "visione_spettrale"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/rovine_planari/marilith-vault.yaml"
+      ]
+    },
+    {
+      "id": "myco-spire-warden",
+      "type": "species",
+      "display_name": "Myco Spire warden",
+      "core_traits": [
+        "empatia_coordinativa",
+        "filamenti_digestivi_compattanti",
+        "struttura_elastica_amorfa"
+      ],
+      "optional_traits": [
+        "empatia_coordinativa",
+        "filamenti_digestivi_compattanti",
+        "focus_frazionato",
+        "spore_psichiche_silenziate",
+        "struttura_elastica_amorfa"
+      ],
+      "synergy_traits": [
+        "Strategist"
+      ],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/foresta_temperata/myco-spire-warden.yaml"
       ]
     },
     {
@@ -232,7 +1467,10 @@
       ],
       "optional_traits": [
         "carapace_fase_variabile",
-        "sangue_piroforico"
+        "filamenti_digestivi_compattanti",
+        "sangue_piroforico",
+        "scheletro_idro_regolante",
+        "spore_psichiche_silenziate"
       ],
       "synergy_traits": [],
       "sources": [
@@ -251,10 +1489,291 @@
         "proteine_shock_termico",
         "reti_capillari_radici"
       ],
-      "optional_traits": [],
+      "optional_traits": [
+        "cuticole_cerose",
+        "grassi_termici",
+        "pelli_cave",
+        "pigmenti_aurorali",
+        "proteine_shock_termico",
+        "reti_capillari_radici"
+      ],
       "synergy_traits": [],
       "sources": [
         "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml"
+      ]
+    },
+    {
+      "id": "orbita-psionica-inversa-trait-keeper",
+      "type": "species",
+      "display_name": "Orbita Psionica Inversa Trait Keeper",
+      "core_traits": [
+        "coda_frusta_cinetica",
+        "criostasi_adattiva",
+        "olfatto_risonanza_magnetica",
+        "sacche_galleggianti_ascensoriali"
+      ],
+      "optional_traits": [
+        "coda_frusta_cinetica",
+        "criostasi_adattiva",
+        "olfatto_risonanza_magnetica",
+        "sacche_galleggianti_ascensoriali"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/orbita_psionica_inversa/orbita-psionica-inversa-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "orbital-ascendant",
+      "type": "species",
+      "display_name": "Orbital Ascendant",
+      "core_traits": [
+        "focus_frazionato",
+        "nucleo_ovomotore_rotante",
+        "olfatto_risonanza_magnetica",
+        "sacche_galleggianti_ascensoriali"
+      ],
+      "optional_traits": [
+        "criostasi_adattiva",
+        "eco_interno_riflesso",
+        "focus_frazionato",
+        "nucleo_ovomotore_rotante",
+        "olfatto_risonanza_magnetica",
+        "sacche_galleggianti_ascensoriali"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/orbita_psionica_inversa/orbital-ascendant.yaml"
+      ]
+    },
+    {
+      "id": "otyugh-sentinella",
+      "type": "species",
+      "display_name": "Otyugh Sentinella delle Fogne Astrali",
+      "core_traits": [
+        "ciclo_vitale_completo",
+        "metabolismo_attivo",
+        "respirazione_biologica"
+      ],
+      "optional_traits": [
+        "artigli_sette_vie",
+        "carapace_fase_variabile",
+        "filtri_bioattivi",
+        "lamelle_termoforetiche",
+        "membrane_osmotiche",
+        "nodi_micotici",
+        "proboscide_polifaga",
+        "secrezioni_antisepsi",
+        "sensori_chimici"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/rovine_planari/otyugh-sentinella.yaml"
+      ]
+    },
+    {
+      "id": "paludi-gas-luminescenti-trait-keeper",
+      "type": "species",
+      "display_name": "Paludi Gas Luminescenti Trait Keeper",
+      "core_traits": [
+        "circolazione_bifasica_palude"
+      ],
+      "optional_traits": [
+        "circolazione_bifasica_palude"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/paludi_gas_luminescenti/paludi-gas-luminescenti-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "permafrost-psionico-trait-keeper",
+      "type": "species",
+      "display_name": "Permafrost Psionico Trait Keeper",
+      "core_traits": [
+        "bulbi_radici_permafrost"
+      ],
+      "optional_traits": [
+        "bulbi_radici_permafrost"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/permafrost_psionico/permafrost-psionico-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "pianura-salina-iperarida-trait-keeper",
+      "type": "species",
+      "display_name": "Hyperarid Salt Flat Trait Keeper",
+      "core_traits": [
+        "antenne_dustsense",
+        "biofilm_iperarido",
+        "camere_mirage",
+        "cartilagini_desertiche",
+        "chemiorecettori_bromuro",
+        "ciste_salmastre",
+        "cuscinetti_elettrostatici",
+        "ghiandole_iodoattive",
+        "lingua_cristallina",
+        "membrane_captura_rugiada"
+      ],
+      "optional_traits": [
+        "antenne_dustsense",
+        "biofilm_iperarido",
+        "camere_mirage",
+        "cartilagini_desertiche",
+        "chemiorecettori_bromuro",
+        "ciste_salmastre",
+        "cuscinetti_elettrostatici",
+        "ghiandole_iodoattive",
+        "lingua_cristallina",
+        "membrane_captura_rugiada"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/pianura_salina_iperarida/pianura-salina-iperarida-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "pianure-magnetiche-trait-keeper",
+      "type": "species",
+      "display_name": "Pianure Magnetiche Trait Keeper",
+      "core_traits": [
+        "sensori_geomagnetici"
+      ],
+      "optional_traits": [
+        "sensori_geomagnetici"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/pianure_magnetiche/pianure-magnetiche-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "picchi-cristallini-trait-keeper",
+      "type": "species",
+      "display_name": "Picchi Cristallini Trait Keeper",
+      "core_traits": [
+        "polmoni_cristallini_alta_quota"
+      ],
+      "optional_traits": [
+        "polmoni_cristallini_alta_quota"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/picchi_cristallini/picchi-cristallini-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "psionic-canopy-scout",
+      "type": "species",
+      "display_name": "Psionic Canopy Scout",
+      "core_traits": [
+        "focus_frazionato",
+        "mimetismo_cromatico_passivo",
+        "sacche_galleggianti_ascensoriali",
+        "struttura_elastica_amorfa"
+      ],
+      "optional_traits": [
+        "focus_frazionato",
+        "mimetismo_cromatico_passivo",
+        "olfatto_risonanza_magnetica",
+        "sacche_galleggianti_ascensoriali",
+        "spore_psichiche_silenziate",
+        "struttura_elastica_amorfa"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/canopia_psionica_leggera/psionic-canopy-scout.yaml"
+      ]
+    },
+    {
+      "id": "rakshasa-corte",
+      "type": "species",
+      "display_name": "Rakshasa della Corte Spezzata",
+      "core_traits": [
+        "ciclo_vitale_completo",
+        "metabolismo_attivo",
+        "respirazione_biologica"
+      ],
+      "optional_traits": [
+        "artigli_psionici",
+        "empatia_coordinativa",
+        "focus_frazionato",
+        "maschera_illusoria",
+        "sinapsi_riflettenti",
+        "tessuti_adattivi"
+      ],
+      "synergy_traits": [
+        "risonanza_di_branco"
+      ],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/rovine_planari/rakshasa-corte.yaml"
+      ]
+    },
+    {
+      "id": "reef-luminescente-trait-keeper",
+      "type": "species",
+      "display_name": "Luminescent Reef Trait Keeper",
+      "core_traits": [
+        "antenne_waveguide",
+        "biofilm_glow",
+        "branchie_microfiltri",
+        "cartilagini_biofibre",
+        "coralli_partner",
+        "enzimi_antipredatori_algali",
+        "epitelio_fosforescente",
+        "ghiandole_inchiostro_luce"
+      ],
+      "optional_traits": [
+        "antenne_waveguide",
+        "biofilm_glow",
+        "branchie_microfiltri",
+        "cartilagini_biofibre",
+        "coralli_partner",
+        "enzimi_antipredatori_algali",
+        "epitelio_fosforescente",
+        "ghiandole_inchiostro_luce"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/reef_luminescente/reef-luminescente-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "resonant-claw-hunter",
+      "type": "species",
+      "display_name": "Resonant Claw Hunter",
+      "core_traits": [
+        "artigli_sette_vie"
+      ],
+      "optional_traits": [
+        "artigli_sette_vie",
+        "cartilagini_flessoacustiche",
+        "eco_interno_riflesso",
+        "lingua_tattile_trama",
+        "midollo_antivibrazione",
+        "mimetismo_cromatico_passivo",
+        "occhi_infrarosso_composti"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/caverna_risonante/resonant-claw-hunter.yaml"
+      ]
+    },
+    {
+      "id": "reti-micorriziche-trait-keeper",
+      "type": "species",
+      "display_name": "Reti Micorriziche Trait Keeper",
+      "core_traits": [
+        "nodi_micorrizici_oracolari"
+      ],
+      "optional_traits": [
+        "nodi_micorrizici_oracolari"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/reti_micorriziche/reti-micorriziche-trait-keeper.yaml"
       ]
     },
     {
@@ -267,8 +1786,11 @@
         "ventriglio_gastroliti"
       ],
       "optional_traits": [
+        "filamenti_digestivi_compattanti",
         "nucleo_ovomotore_rotante",
-        "scheletro_idro_regolante"
+        "respiro_a_scoppio",
+        "scheletro_idro_regolante",
+        "ventriglio_gastroliti"
       ],
       "synergy_traits": [],
       "sources": [
@@ -286,6 +1808,9 @@
       ],
       "optional_traits": [
         "carapace_fase_variabile",
+        "nucleo_ovomotore_rotante",
+        "sacche_galleggianti_ascensoriali",
+        "scheletro_idro_regolante",
         "zampe_a_molla"
       ],
       "synergy_traits": [],
@@ -298,9 +1823,17 @@
       "type": "species",
       "display_name": "Sentinella Radice",
       "core_traits": [
-        "pelli_fitte"
+        "focus_frazionato",
+        "pathfinder",
+        "pianificatore"
       ],
-      "optional_traits": [],
+      "optional_traits": [
+        "empatia_coordinativa",
+        "focus_frazionato",
+        "pathfinder",
+        "pianificatore",
+        "random"
+      ],
       "synergy_traits": [],
       "sources": [
         "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml"
@@ -318,10 +1851,83 @@
         "proteine_shock_termico",
         "reti_capillari_radici"
       ],
-      "optional_traits": [],
+      "optional_traits": [
+        "cuticole_cerose",
+        "grassi_termici",
+        "pelli_cave",
+        "pigmenti_aurorali",
+        "proteine_shock_termico",
+        "reti_capillari_radici"
+      ],
       "synergy_traits": [],
       "sources": [
         "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml"
+      ]
+    },
+    {
+      "id": "slag-veil-ambusher",
+      "type": "species",
+      "display_name": "Slag Veil Ambusher",
+      "core_traits": [
+        "coda_frusta_cinetica",
+        "olfatto_risonanza_magnetica",
+        "struttura_elastica_amorfa"
+      ],
+      "optional_traits": [
+        "coda_frusta_cinetica",
+        "ghiandola_caustica",
+        "olfatto_risonanza_magnetica",
+        "respiro_a_scoppio",
+        "struttura_elastica_amorfa"
+      ],
+      "synergy_traits": [
+        "scheletro_idro_regolante",
+        "tattiche_di_branco"
+      ],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/badlands/slag-veil-ambusher.yaml"
+      ]
+    },
+    {
+      "id": "sorgenti-geotermiche-trait-keeper",
+      "type": "species",
+      "display_name": "Sorgenti Geotermiche Trait Keeper",
+      "core_traits": [
+        "lamelle_termoforetiche"
+      ],
+      "optional_traits": [
+        "lamelle_termoforetiche"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/sorgenti_geotermiche/sorgenti-geotermiche-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "steppe-algoritmiche-trait-keeper",
+      "type": "species",
+      "display_name": "Algorithmic Steppe Trait Keeper",
+      "core_traits": [
+        "antenne_wideband",
+        "biochip_memoria",
+        "carapace_segmenti_logici",
+        "circolazione_cooling_loop",
+        "coda_coppia_retroattiva",
+        "ghiandole_grafene",
+        "lamelle_sincroniche"
+      ],
+      "optional_traits": [
+        "antenne_wideband",
+        "biochip_memoria",
+        "carapace_segmenti_logici",
+        "circolazione_cooling_loop",
+        "coda_coppia_retroattiva",
+        "ghiandole_grafene",
+        "lamelle_sincroniche"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/steppe_algoritmiche/steppe-algoritmiche-trait-keeper.yaml"
       ]
     },
     {
@@ -329,17 +1935,81 @@
       "type": "species",
       "display_name": "Bisonte Nano della Steppa",
       "core_traits": [
-        "cuticole_cerose",
-        "grassi_termici",
-        "pelli_cave",
-        "pigmenti_aurorali",
-        "proteine_shock_termico",
-        "reti_capillari_radici"
+        "respiro_a_scoppio",
+        "scheletro_idro_regolante",
+        "ventriglio_gastroliti"
       ],
-      "optional_traits": [],
+      "optional_traits": [
+        "carapace_fase_variabile",
+        "respiro_a_scoppio",
+        "sacche_galleggianti_ascensoriali",
+        "scheletro_idro_regolante",
+        "ventriglio_gastroliti"
+      ],
       "synergy_traits": [],
       "sources": [
         "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml"
+      ]
+    },
+    {
+      "id": "steppe-risonanti-trait-keeper",
+      "type": "species",
+      "display_name": "Steppe Risonanti Trait Keeper",
+      "core_traits": [
+        "zoccoli_risonanti_steppe"
+      ],
+      "optional_traits": [
+        "zoccoli_risonanti_steppe"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/steppe_risonanti/steppe-risonanti-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "stratosfera-portante-trait-keeper",
+      "type": "species",
+      "display_name": "Stratosfera Portante Trait Keeper",
+      "core_traits": [
+        "sacche_spore_stratosferiche"
+      ],
+      "optional_traits": [
+        "sacche_spore_stratosferiche"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/stratosfera_portante/stratosfera-portante-trait-keeper.yaml"
+      ]
+    },
+    {
+      "id": "stratosfera-tempestosa-trait-keeper",
+      "type": "species",
+      "display_name": "Tempestuous Stratosphere Trait Keeper",
+      "core_traits": [
+        "ali_fulminee",
+        "barbigli_sensori_plasma",
+        "branchie_eoliche",
+        "capsule_paracadute",
+        "coda_stabilizzatrice_vortex",
+        "cuore_multicamera_bassa_pressione",
+        "epidermide_dielettrica",
+        "ghiandole_condensa_ozono",
+        "lamelle_shear"
+      ],
+      "optional_traits": [
+        "ali_fulminee",
+        "barbigli_sensori_plasma",
+        "branchie_eoliche",
+        "capsule_paracadute",
+        "coda_stabilizzatrice_vortex",
+        "cuore_multicamera_bassa_pressione",
+        "epidermide_dielettrica",
+        "ghiandole_condensa_ozono",
+        "lamelle_shear"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/stratosfera_tempestosa/stratosfera-tempestosa-trait-keeper.yaml"
       ]
     },
     {
@@ -347,14 +2017,17 @@
       "type": "species",
       "display_name": "Thaw Rot",
       "core_traits": [
-        "cuticole_cerose",
-        "grassi_termici",
-        "pelli_cave",
-        "pigmenti_aurorali",
-        "proteine_shock_termico",
-        "reti_capillari_radici"
+        "filamenti_digestivi_compattanti",
+        "sangue_piroforico",
+        "spore_psichiche_silenziate"
       ],
-      "optional_traits": [],
+      "optional_traits": [
+        "eco_interno_riflesso",
+        "filamenti_digestivi_compattanti",
+        "sangue_piroforico",
+        "secrezione_rallentante_palmi",
+        "spore_psichiche_silenziate"
+      ],
       "synergy_traits": [],
       "sources": [
         "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml"
@@ -372,115 +2045,57 @@
         "proteine_shock_termico",
         "reti_capillari_radici"
       ],
-      "optional_traits": [],
+      "optional_traits": [
+        "cuticole_cerose",
+        "grassi_termici",
+        "pelli_cave",
+        "pigmenti_aurorali",
+        "proteine_shock_termico",
+        "reti_capillari_radici"
+      ],
       "synergy_traits": [],
       "sources": [
         "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml"
       ]
     },
     {
-      "id": "magneto-ridge-hunter",
+      "id": "treant-portale",
       "type": "species",
-      "display_name": "Magneto Ridge Hunter",
+      "display_name": "Treant dei Portali Antichi",
       "core_traits": [
-        "artigli_sette_vie",
-        "coda_frusta_cinetica",
-        "scheletro_idro_regolante"
+        "ciclo_vitale_completo",
+        "metabolismo_attivo",
+        "respirazione_biologica"
       ],
       "optional_traits": [
-        "olfatto_risonanza_magnetica",
-        "respiro_a_scoppio"
+        "armatura_pietra_planare",
+        "corteccia_memetica",
+        "fotosintesi_bifase",
+        "nodi_micotici",
+        "pigmenti_aurorali",
+        "radici_ancora_planare",
+        "reti_capillari_radici"
       ],
       "synergy_traits": [
-        "struttura_elastica_amorfa",
-        "tattiche_di_branco"
-      ],
-      "sources": [
-        "packs/evo_tactics_pack/data/species/badlands/magneto-ridge-hunter.yaml"
-      ]
-    },
-    {
-      "id": "slag-veil-ambusher",
-      "type": "species",
-      "display_name": "Slag Veil Ambusher",
-      "core_traits": [
-        "coda_frusta_cinetica",
-        "olfatto_risonanza_magnetica",
-        "struttura_elastica_amorfa"
-      ],
-      "optional_traits": [
-        "ghiandola_caustica",
-        "respiro_a_scoppio"
-      ],
-      "synergy_traits": [
-        "scheletro_idro_regolante",
-        "tattiche_di_branco"
-      ],
-      "sources": [
-        "packs/evo_tactics_pack/data/species/badlands/slag-veil-ambusher.yaml"
-      ]
-    },
-    {
-      "id": "myco-spire-warden",
-      "type": "species",
-      "display_name": "Myco Spire Warden",
-      "core_traits": [
-        "empatia_coordinativa",
-        "filamenti_digestivi_compattanti",
-        "struttura_elastica_amorfa"
-      ],
-      "optional_traits": [
-        "focus_frazionato",
-        "spore_psichiche_silenziate"
-      ],
-      "synergy_traits": [
-        "pathfinder",
-        "pianificatore"
-      ],
-      "sources": [
-        "packs/evo_tactics_pack/data/species/foresta_temperata/myco-spire-warden.yaml"
-      ]
-    },
-    {
-      "id": "glowcap-weaver",
-      "type": "species",
-      "display_name": "Glowcap Weaver",
-      "core_traits": [
-        "empatia_coordinativa",
-        "filamenti_digestivi_compattanti",
-        "struttura_elastica_amorfa"
-      ],
-      "optional_traits": [
-        "focus_frazionato",
-        "lingua_tattile_trama"
-      ],
-      "synergy_traits": [
-        "pathfinder",
-        "pianificatore"
-      ],
-      "sources": [
-        "packs/evo_tactics_pack/data/species/foresta_temperata/glowcap-weaver.yaml"
-      ]
-    },
-    {
-      "id": "aurora-bridge-runner",
-      "type": "species",
-      "display_name": "Aurora Bridge Runner",
-      "core_traits": [
-        "eco_interno_riflesso",
-        "mimetismo_cromatico_passivo",
-        "sacche_galleggianti_ascensoriali"
-      ],
-      "optional_traits": [
-        "lingua_tattile_trama",
-        "occhi_infrarosso_composti"
-      ],
-      "synergy_traits": [
-        "empatia_coordinativa",
         "risonanza_di_branco"
       ],
       "sources": [
-        "packs/evo_tactics_pack/data/species/cryosteppe/aurora-bridge-runner.yaml"
+        "packs/evo_tactics_pack/data/species/rovine_planari/treant-portale.yaml"
+      ]
+    },
+    {
+      "id": "tundra-risonante-trait-keeper",
+      "type": "species",
+      "display_name": "Tundra Risonante Trait Keeper",
+      "core_traits": [
+        "cavita_risonanti_tundra"
+      ],
+      "optional_traits": [
+        "cavita_risonanti_tundra"
+      ],
+      "synergy_traits": [],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/tundra_risonante/tundra-risonante-trait-keeper.yaml"
       ]
     },
     {
@@ -493,15 +2108,42 @@
         "sacche_galleggianti_ascensoriali"
       ],
       "optional_traits": [
+        "eco_interno_riflesso",
         "lingua_tattile_trama",
-        "occhi_infrarosso_composti"
+        "mimetismo_cromatico_passivo",
+        "occhi_infrarosso_composti",
+        "sacche_galleggianti_ascensoriali"
       ],
-      "synergy_traits": [
-        "empatia_coordinativa",
-        "risonanza_di_branco"
-      ],
+      "synergy_traits": [],
       "sources": [
         "packs/evo_tactics_pack/data/species/cryosteppe/zephyr-spore-courier.yaml"
+      ]
+    },
+    {
+      "id": "banshee-risonante",
+      "type": "event",
+      "display_name": "Banshee Risonante",
+      "core_traits": [
+        "adattamento_volo",
+        "assenza_respirazione",
+        "ciclo_vitale_anomalo",
+        "metabolismo_sostentato",
+        "origine_artificiale",
+        "risonanza_di_branco"
+      ],
+      "optional_traits": [
+        "eco_sismico",
+        "focus_frazionato",
+        "intangibilita_parziale",
+        "lamenti_diradanti",
+        "risonanza_di_branco",
+        "voce_spettrale"
+      ],
+      "synergy_traits": [
+        "focus_frazionato"
+      ],
+      "sources": [
+        "packs/evo_tactics_pack/data/species/rovine_planari/banshee-risonante.yaml"
       ]
     },
     {
@@ -516,7 +2158,14 @@
         "proteine_shock_termico",
         "reti_capillari_radici"
       ],
-      "optional_traits": [],
+      "optional_traits": [
+        "cuticole_cerose",
+        "grassi_termici",
+        "pelli_cave",
+        "pigmenti_aurorali",
+        "proteine_shock_termico",
+        "reti_capillari_radici"
+      ],
       "synergy_traits": [],
       "sources": [
         "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml"
@@ -534,7 +2183,14 @@
         "proteine_shock_termico",
         "reti_capillari_radici"
       ],
-      "optional_traits": [],
+      "optional_traits": [
+        "cuticole_cerose",
+        "grassi_termici",
+        "pelli_cave",
+        "pigmenti_aurorali",
+        "proteine_shock_termico",
+        "reti_capillari_radici"
+      ],
       "synergy_traits": [],
       "sources": [
         "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml"
@@ -547,7 +2203,9 @@
       "core_traits": [
         "pelli_fitte"
       ],
-      "optional_traits": [],
+      "optional_traits": [
+        "pelli_fitte"
+      ],
       "synergy_traits": [],
       "sources": [
         "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml"
@@ -563,7 +2221,12 @@
         "pelli_anti_ustione",
         "pigmenti_termici"
       ],
-      "optional_traits": [],
+      "optional_traits": [
+        "cute_resistente_sali",
+        "enzimi_chelanti",
+        "pelli_anti_ustione",
+        "pigmenti_termici"
+      ],
       "synergy_traits": [],
       "sources": [
         "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml"
@@ -571,340 +2234,2055 @@
     }
   ],
   "trait_usage": {
-    "artigli_sette_vie": {
+    "Strategist": {
+      "core": [],
+      "optional": [],
+      "synergy": [
+        "myco-spire-warden"
+      ]
+    },
+    "adattamento_volo": {
       "core": [
-        "dune-stalker",
-        "magneto-ridge-hunter"
+        "archon-solare",
+        "balor-fission",
+        "banshee-risonante",
+        "couatl-aurora"
       ],
       "optional": [],
       "synergy": []
     },
-    "carapace_fase_variabile": {
+    "ali_fulminee": {
+      "core": [
+        "stratosfera-tempestosa-trait-keeper"
+      ],
+      "optional": [
+        "stratosfera-tempestosa-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "ali_ioniche": {
+      "core": [
+        "canopia-ionica-trait-keeper"
+      ],
+      "optional": [
+        "canopia-ionica-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "ali_membrana_sonica": {
+      "core": [
+        "caverna-risonante-trait-keeper"
+      ],
+      "optional": [
+        "caverna-risonante-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "ali_solari_fotoni": {
       "core": [],
       "optional": [
+        "archon-solare",
+        "couatl-aurora"
+      ],
+      "synergy": []
+    },
+    "antenne_dustsense": {
+      "core": [
+        "pianura-salina-iperarida-trait-keeper"
+      ],
+      "optional": [
+        "pianura-salina-iperarida-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "antenne_eco_turbina": {
+      "core": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "optional": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "antenne_flusso_mareale": {
+      "core": [
+        "laguna-bioreattiva-trait-keeper"
+      ],
+      "optional": [
+        "laguna-bioreattiva-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "antenne_microonde_cavernose": {
+      "core": [
+        "caverna-risonante-trait-keeper"
+      ],
+      "optional": [
+        "caverna-risonante-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "antenne_plasmatiche_tempesta": {
+      "core": [
+        "cicloni-psionici-trait-keeper"
+      ],
+      "optional": [
+        "cicloni-psionici-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "antenne_reagenti": {
+      "core": [
+        "foresta-acida-trait-keeper"
+      ],
+      "optional": [
+        "foresta-acida-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "antenne_tesla": {
+      "core": [
+        "canopia-ionica-trait-keeper"
+      ],
+      "optional": [
+        "canopia-ionica-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "antenne_waveguide": {
+      "core": [
+        "reef-luminescente-trait-keeper"
+      ],
+      "optional": [
+        "reef-luminescente-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "antenne_wideband": {
+      "core": [
+        "steppe-algoritmiche-trait-keeper"
+      ],
+      "optional": [
+        "steppe-algoritmiche-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "appendici_risonanti_marea": {
+      "core": [
+        "laguna-bioreattiva-trait-keeper"
+      ],
+      "optional": [
+        "laguna-bioreattiva-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "appendici_thermotattiche": {
+      "core": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "optional": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "architetto": {
+      "core": [],
+      "optional": [],
+      "synergy": [
+        "ferrocolonia-magnetotattica"
+      ]
+    },
+    "armatura_pietra_planare": {
+      "core": [
+        "golem-runico"
+      ],
+      "optional": [
+        "balor-fission",
+        "bulette-fase",
+        "golem-runico",
+        "treant-portale"
+      ],
+      "synergy": []
+    },
+    "artigli_acidofagi": {
+      "core": [
+        "foresta-acida-trait-keeper"
+      ],
+      "optional": [
+        "foresta-acida-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "artigli_induzione": {
+      "core": [
+        "canopia-ionica-trait-keeper"
+      ],
+      "optional": [
+        "canopia-ionica-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "artigli_psionici": {
+      "core": [],
+      "optional": [
+        "rakshasa-corte"
+      ],
+      "synergy": []
+    },
+    "artigli_radice": {
+      "core": [
+        "mangrovieto-cinetico-trait-keeper"
+      ],
+      "optional": [
+        "mangrovieto-cinetico-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "artigli_scivolo_silente": {
+      "core": [
+        "caverna-risonante-trait-keeper"
+      ],
+      "optional": [
+        "caverna-risonante-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "artigli_sette_vie": {
+      "core": [
+        "caverna-risonante-trait-keeper",
+        "cryo-lynx",
+        "dune-stalker",
+        "magneto-ridge-hunter",
+        "resonant-claw-hunter"
+      ],
+      "optional": [
+        "balor-fission",
+        "caverna-risonante-trait-keeper",
+        "couatl-aurora",
+        "cryo-lynx",
+        "dune-stalker",
+        "magneto-ridge-hunter",
+        "marilith-vault",
+        "otyugh-sentinella",
+        "resonant-claw-hunter"
+      ],
+      "synergy": []
+    },
+    "artigli_sghiaccio_glaciale": {
+      "core": [
+        "calotte-glaciali-trait-keeper"
+      ],
+      "optional": [
+        "calotte-glaciali-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "artigli_vetrificati": {
+      "core": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "optional": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "assenza_respirazione": {
+      "core": [
+        "banshee-risonante",
+        "golem-runico"
+      ],
+      "optional": [],
+      "synergy": []
+    },
+    "aura_scudo_radianza": {
+      "core": [
+        "archon-solare"
+      ],
+      "optional": [
+        "archon-solare"
+      ],
+      "synergy": []
+    },
+    "baffi_mareomotori": {
+      "core": [
+        "mangrovieto-cinetico-trait-keeper"
+      ],
+      "optional": [
+        "mangrovieto-cinetico-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "barbigli_sensori_plasma": {
+      "core": [
+        "stratosfera-tempestosa-trait-keeper"
+      ],
+      "optional": [
+        "stratosfera-tempestosa-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "barriere_miasma_glaciale": {
+      "core": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "optional": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "batteri_endosimbionti_chemio": {
+      "core": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "optional": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "batteri_termofili_endosimbiosi": {
+      "core": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "optional": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "biochip_memoria": {
+      "core": [
+        "steppe-algoritmiche-trait-keeper"
+      ],
+      "optional": [
+        "steppe-algoritmiche-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "biofilm_glow": {
+      "core": [
+        "reef-luminescente-trait-keeper"
+      ],
+      "optional": [
+        "reef-luminescente-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "biofilm_iperarido": {
+      "core": [
+        "pianura-salina-iperarida-trait-keeper"
+      ],
+      "optional": [
+        "pianura-salina-iperarida-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "branchie_dual_mode": {
+      "core": [
+        "laguna-bioreattiva-trait-keeper"
+      ],
+      "optional": [
+        "laguna-bioreattiva-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "branchie_eoliche": {
+      "core": [
+        "stratosfera-tempestosa-trait-keeper"
+      ],
+      "optional": [
+        "stratosfera-tempestosa-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "branchie_metalloidi": {
+      "core": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "optional": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "branchie_microfiltri": {
+      "core": [
+        "reef-luminescente-trait-keeper"
+      ],
+      "optional": [
+        "reef-luminescente-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "branchie_osmotiche_salmastra": {
+      "core": [
+        "delta-salmastri-trait-keeper"
+      ],
+      "optional": [
+        "delta-salmastri-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "branchie_solfatiche": {
+      "core": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "optional": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "branchie_turbina": {
+      "core": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "optional": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "bulbi_radici_permafrost": {
+      "core": [
+        "permafrost-psionico-trait-keeper"
+      ],
+      "optional": [
+        "permafrost-psionico-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "camere_anticorrosione": {
+      "core": [
+        "foresta-acida-trait-keeper"
+      ],
+      "optional": [
+        "foresta-acida-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "camere_mirage": {
+      "core": [
+        "pianura-salina-iperarida-trait-keeper"
+      ],
+      "optional": [
+        "pianura-salina-iperarida-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "camere_nutrienti_vent": {
+      "core": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "optional": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "campo_di_fase": {
+      "core": [],
+      "optional": [
+        "golem-runico"
+      ],
+      "synergy": []
+    },
+    "capillari_criogenici": {
+      "core": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "optional": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "capillari_fluoridici": {
+      "core": [
+        "foresta-acida-trait-keeper"
+      ],
+      "optional": [
+        "foresta-acida-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "capillari_fotovoltaici": {
+      "core": [
+        "canopia-ionica-trait-keeper"
+      ],
+      "optional": [
+        "canopia-ionica-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "capsule_paracadute": {
+      "core": [
+        "stratosfera-tempestosa-trait-keeper"
+      ],
+      "optional": [
+        "stratosfera-tempestosa-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "carapace_fase_variabile": {
+      "core": [
+        "canopia-psionica-leggera-trait-keeper",
+        "cryo-lynx",
+        "falde-magnetiche-psioniche-trait-keeper"
+      ],
+      "optional": [
+        "balor-fission",
+        "bulette-fase",
+        "canopia-psionica-leggera-trait-keeper",
+        "cryo-lynx",
+        "falde-magnetiche-psioniche-trait-keeper",
+        "golem-runico",
         "nano-rust-bloom",
-        "sand-burrower"
+        "otyugh-sentinella",
+        "sand-burrower",
+        "steppe-bison-mini"
+      ],
+      "synergy": []
+    },
+    "carapace_luminiscente_abissale": {
+      "core": [
+        "abisso-luminescente-trait-keeper"
+      ],
+      "optional": [
+        "abisso-luminescente-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "carapace_segmenti_logici": {
+      "core": [
+        "steppe-algoritmiche-trait-keeper"
+      ],
+      "optional": [
+        "steppe-algoritmiche-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "carapaci_ferruginosi": {
+      "core": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "optional": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "cartilagine_flessotermica_venti": {
+      "core": [
+        "gole-ventose-trait-keeper"
+      ],
+      "optional": [
+        "gole-ventose-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "cartilagini_biofibre": {
+      "core": [
+        "reef-luminescente-trait-keeper"
+      ],
+      "optional": [
+        "reef-luminescente-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "cartilagini_desertiche": {
+      "core": [
+        "pianura-salina-iperarida-trait-keeper"
+      ],
+      "optional": [
+        "pianura-salina-iperarida-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "cartilagini_flessoacustiche": {
+      "core": [
+        "caverna-risonante-trait-keeper"
+      ],
+      "optional": [
+        "caverna-risonante-trait-keeper",
+        "resonant-claw-hunter"
+      ],
+      "synergy": []
+    },
+    "cartilagini_pseudometalliche": {
+      "core": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "optional": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "cavita_risonanti_tundra": {
+      "core": [
+        "tundra-risonante-trait-keeper"
+      ],
+      "optional": [
+        "tundra-risonante-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "cervelletto_equilibrio_statico": {
+      "core": [
+        "canopia-ionica-trait-keeper"
+      ],
+      "optional": [
+        "canopia-ionica-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "chemiorecettori_bromuro": {
+      "core": [
+        "pianura-salina-iperarida-trait-keeper"
+      ],
+      "optional": [
+        "pianura-salina-iperarida-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "chioma_parassita_canopica": {
+      "core": [
+        "canopie-sospese-trait-keeper"
+      ],
+      "optional": [
+        "canopie-sospese-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "ciclo_vitale_anomalo": {
+      "core": [
+        "banshee-risonante",
+        "golem-runico"
+      ],
+      "optional": [],
+      "synergy": []
+    },
+    "ciclo_vitale_completo": {
+      "core": [
+        "archon-solare",
+        "balor-fission",
+        "bulette-fase",
+        "couatl-aurora",
+        "marilith-vault",
+        "otyugh-sentinella",
+        "rakshasa-corte",
+        "treant-portale"
+      ],
+      "optional": [],
+      "synergy": []
+    },
+    "circolazione_bifasica": {
+      "core": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "optional": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "circolazione_bifasica_palude": {
+      "core": [
+        "paludi-gas-luminescenti-trait-keeper"
+      ],
+      "optional": [
+        "paludi-gas-luminescenti-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "circolazione_cooling_loop": {
+      "core": [
+        "steppe-algoritmiche-trait-keeper"
+      ],
+      "optional": [
+        "steppe-algoritmiche-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "circolazione_doppia": {
+      "core": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "optional": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "circolazione_supercritica": {
+      "core": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "optional": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "ciste_riduttive": {
+      "core": [
+        "laguna-bioreattiva-trait-keeper"
+      ],
+      "optional": [
+        "laguna-bioreattiva-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "ciste_salmastre": {
+      "core": [
+        "pianura-salina-iperarida-trait-keeper"
+      ],
+      "optional": [
+        "pianura-salina-iperarida-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "cisti_iperbariche": {
+      "core": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "optional": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "coda_balanciere": {
+      "core": [
+        "caverna-risonante-trait-keeper"
+      ],
+      "optional": [
+        "caverna-risonante-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "coda_contrappeso": {
+      "core": [
+        "mangrovieto-cinetico-trait-keeper"
+      ],
+      "optional": [
+        "mangrovieto-cinetico-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "coda_coppia_retroattiva": {
+      "core": [
+        "steppe-algoritmiche-trait-keeper"
+      ],
+      "optional": [
+        "steppe-algoritmiche-trait-keeper"
       ],
       "synergy": []
     },
     "coda_frusta_cinetica": {
       "core": [
+        "dune-stalker",
+        "falde-magnetiche-psioniche-trait-keeper",
         "magneto-ridge-hunter",
+        "orbita-psionica-inversa-trait-keeper",
         "slag-veil-ambusher"
       ],
       "optional": [
-        "dune-stalker"
+        "bulette-fase",
+        "dune-stalker",
+        "falde-magnetiche-psioniche-trait-keeper",
+        "magneto-ridge-hunter",
+        "marilith-vault",
+        "orbita-psionica-inversa-trait-keeper",
+        "slag-veil-ambusher"
+      ],
+      "synergy": []
+    },
+    "coda_stabilizzatrice_filo": {
+      "core": [
+        "canopia-ionica-trait-keeper"
+      ],
+      "optional": [
+        "canopia-ionica-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "coda_stabilizzatrice_geiser": {
+      "core": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "optional": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "coda_stabilizzatrice_vortex": {
+      "core": [
+        "stratosfera-tempestosa-trait-keeper"
+      ],
+      "optional": [
+        "stratosfera-tempestosa-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "colonne_vibromagnetiche": {
+      "core": [
+        "caverna-risonante-trait-keeper"
+      ],
+      "optional": [
+        "caverna-risonante-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "coralli_partner": {
+      "core": [
+        "reef-luminescente-trait-keeper"
+      ],
+      "optional": [
+        "reef-luminescente-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "corteccia_memetica": {
+      "core": [],
+      "optional": [
+        "treant-portale"
       ],
       "synergy": []
     },
     "criostasi_adattiva": {
-      "core": [],
+      "core": [
+        "aurora-gull",
+        "canopia-psionica-leggera-trait-keeper",
+        "orbita-psionica-inversa-trait-keeper"
+      ],
       "optional": [
-        "dune-stalker"
+        "aurora-gull",
+        "balor-fission",
+        "canopia-psionica-leggera-trait-keeper",
+        "cryo-lynx",
+        "dune-stalker",
+        "orbita-psionica-inversa-trait-keeper",
+        "orbital-ascendant"
+      ],
+      "synergy": []
+    },
+    "cromofori_alert_acido": {
+      "core": [
+        "foresta-acida-trait-keeper"
+      ],
+      "optional": [
+        "foresta-acida-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "cuore_multicamera_bassa_pressione": {
+      "core": [
+        "stratosfera-tempestosa-trait-keeper"
+      ],
+      "optional": [
+        "stratosfera-tempestosa-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "cuscinetti_elettrostatici": {
+      "core": [
+        "pianura-salina-iperarida-trait-keeper"
+      ],
+      "optional": [
+        "pianura-salina-iperarida-trait-keeper"
       ],
       "synergy": []
     },
     "cute_resistente_sali": {
       "core": [
-        "evento-tempesta-ferrosa"
+        "badlands-trait-keeper",
+        "evento-tempesta-ferrosa",
+        "global-trait-keeper"
       ],
-      "optional": [],
+      "optional": [
+        "badlands-trait-keeper",
+        "evento-tempesta-ferrosa",
+        "global-trait-keeper"
+      ],
       "synergy": []
     },
     "cuticole_cerose": {
       "core": [
-        "aurora-gull",
         "cactus-weaver",
-        "cryo-lynx",
         "evento-brinastorm",
         "evento-ondata-termica",
+        "global-trait-keeper",
         "noctule-termico",
         "silica-bloom",
-        "steppe-bison-mini",
-        "thaw-rot",
         "thermo-raptor"
       ],
-      "optional": [],
+      "optional": [
+        "cactus-weaver",
+        "evento-brinastorm",
+        "evento-ondata-termica",
+        "global-trait-keeper",
+        "noctule-termico",
+        "silica-bloom",
+        "thermo-raptor"
+      ],
+      "synergy": []
+    },
+    "cuticole_neutralizzanti": {
+      "core": [
+        "foresta-acida-trait-keeper"
+      ],
+      "optional": [
+        "foresta-acida-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "denti_chelatanti": {
+      "core": [
+        "foresta-acida-trait-keeper"
+      ],
+      "optional": [
+        "foresta-acida-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "denti_ossidoferro": {
+      "core": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "optional": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "denti_silice_termici": {
+      "core": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "optional": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "denti_tuning_fork": {
+      "core": [
+        "caverna-risonante-trait-keeper"
+      ],
+      "optional": [
+        "caverna-risonante-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "echi_risonanti": {
+      "core": [
+        "caverna-risonante-trait-keeper"
+      ],
+      "optional": [
+        "caverna-risonante-trait-keeper"
+      ],
       "synergy": []
     },
     "eco_interno_riflesso": {
       "core": [
         "aurora-bridge-runner",
+        "aurora-gull",
+        "canopia-psionica-leggera-trait-keeper",
         "echo-wing",
+        "falde-magnetiche-psioniche-trait-keeper",
         "zephyr-spore-courier"
       ],
-      "optional": [],
+      "optional": [
+        "aurora-bridge-runner",
+        "aurora-gull",
+        "canopia-psionica-leggera-trait-keeper",
+        "echo-wing",
+        "falde-magnetiche-psioniche-trait-keeper",
+        "orbital-ascendant",
+        "resonant-claw-hunter",
+        "thaw-rot",
+        "zephyr-spore-courier"
+      ],
+      "synergy": []
+    },
+    "eco_sismico": {
+      "core": [],
+      "optional": [
+        "banshee-risonante"
+      ],
       "synergy": []
     },
     "empatia_coordinativa": {
       "core": [
         "glowcap-weaver",
+        "lupus-temperatus",
         "myco-spire-warden"
       ],
-      "optional": [],
+      "optional": [
+        "archon-solare",
+        "balor-fission",
+        "couatl-aurora",
+        "glowcap-weaver",
+        "lupus-temperatus",
+        "marilith-vault",
+        "myco-spire-warden",
+        "rakshasa-corte",
+        "sentinella-radice"
+      ],
       "synergy": [
-        "aurora-bridge-runner",
-        "zephyr-spore-courier"
+        "archon-solare"
       ]
+    },
+    "enzimi_antifase_termica": {
+      "core": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "optional": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "enzimi_antipredatori_algali": {
+      "core": [
+        "reef-luminescente-trait-keeper"
+      ],
+      "optional": [
+        "reef-luminescente-trait-keeper"
+      ],
+      "synergy": []
     },
     "enzimi_chelanti": {
       "core": [
-        "evento-tempesta-ferrosa"
+        "evento-tempesta-ferrosa",
+        "global-trait-keeper"
       ],
-      "optional": [],
+      "optional": [
+        "evento-tempesta-ferrosa",
+        "global-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "enzimi_chelatori_rapidi": {
+      "core": [
+        "foresta-acida-trait-keeper"
+      ],
+      "optional": [
+        "foresta-acida-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "enzimi_metanoossidanti": {
+      "core": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "optional": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "epidermide_dielettrica": {
+      "core": [
+        "stratosfera-tempestosa-trait-keeper"
+      ],
+      "optional": [
+        "stratosfera-tempestosa-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "epitelio_fosforescente": {
+      "core": [
+        "reef-luminescente-trait-keeper"
+      ],
+      "optional": [
+        "reef-luminescente-trait-keeper"
+      ],
       "synergy": []
     },
     "filamenti_digestivi_compattanti": {
       "core": [
+        "caverna-risonante-trait-keeper",
+        "falde-magnetiche-psioniche-trait-keeper",
         "glowcap-weaver",
+        "magnet-fathom-surveyor",
         "myco-spire-warden",
         "nano-rust-bloom",
-        "rust-scavenger"
+        "rust-scavenger",
+        "thaw-rot"
+      ],
+      "optional": [
+        "blight-micotico",
+        "caverna-risonante-trait-keeper",
+        "falde-magnetiche-psioniche-trait-keeper",
+        "glowcap-weaver",
+        "magnet-fathom-surveyor",
+        "myco-spire-warden",
+        "nano-rust-bloom",
+        "rust-scavenger",
+        "thaw-rot"
+      ],
+      "synergy": []
+    },
+    "filamenti_magnetotrofi": {
+      "core": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "optional": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "filamenti_superconduttivi": {
+      "core": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "optional": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "filamenti_termoconduzione": {
+      "core": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "optional": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "filtri_bioattivi": {
+      "core": [],
+      "optional": [
+        "otyugh-sentinella"
+      ],
+      "synergy": []
+    },
+    "filtri_planctonici": {
+      "core": [
+        "laguna-bioreattiva-trait-keeper"
+      ],
+      "optional": [
+        "laguna-bioreattiva-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "fisiologia_predatoria": {
+      "core": [
+        "bulette-fase"
       ],
       "optional": [],
       "synergy": []
     },
-    "focus_frazionato": {
-      "core": [],
+    "flagelli_ancoranti": {
+      "core": [
+        "laguna-bioreattiva-trait-keeper"
+      ],
       "optional": [
+        "laguna-bioreattiva-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "focus_frazionato": {
+      "core": [
+        "marilith-vault",
+        "orbital-ascendant",
+        "psionic-canopy-scout",
+        "sentinella-radice"
+      ],
+      "optional": [
+        "archon-solare",
+        "banshee-risonante",
+        "couatl-aurora",
         "glowcap-weaver",
-        "myco-spire-warden"
+        "lupus-temperatus",
+        "myco-spire-warden",
+        "orbital-ascendant",
+        "psionic-canopy-scout",
+        "rakshasa-corte",
+        "sentinella-radice"
       ],
       "synergy": [
+        "archon-solare",
+        "balor-fission",
+        "banshee-risonante",
+        "couatl-aurora",
         "dune-stalker"
       ]
     },
-    "ghiandola_caustica": {
+    "foliage_fotocatodico": {
+      "core": [
+        "foresta-acida-trait-keeper"
+      ],
+      "optional": [
+        "foresta-acida-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "foliaggio_spugna": {
+      "core": [
+        "mangrovieto-cinetico-trait-keeper"
+      ],
+      "optional": [
+        "mangrovieto-cinetico-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "fotosintesi_bifase": {
       "core": [],
       "optional": [
+        "treant-portale"
+      ],
+      "synergy": []
+    },
+    "frusta_fiammeggiante": {
+      "core": [
+        "balor-fission",
+        "marilith-vault"
+      ],
+      "optional": [
+        "balor-fission"
+      ],
+      "synergy": []
+    },
+    "ghiaccio_piezoelettrico": {
+      "core": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "optional": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "ghiandola_caustica": {
+      "core": [
+        "blight-micotico"
+      ],
+      "optional": [
+        "blight-micotico",
         "slag-veil-ambusher"
+      ],
+      "synergy": []
+    },
+    "ghiandole_cambio_salino": {
+      "core": [
+        "laguna-bioreattiva-trait-keeper"
+      ],
+      "optional": [
+        "laguna-bioreattiva-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "ghiandole_condensa_ozono": {
+      "core": [
+        "stratosfera-tempestosa-trait-keeper"
+      ],
+      "optional": [
+        "stratosfera-tempestosa-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "ghiandole_eco_mappanti": {
+      "core": [
+        "caverna-risonante-trait-keeper"
+      ],
+      "optional": [
+        "caverna-risonante-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "ghiandole_fango_calde": {
+      "core": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "optional": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "ghiandole_fango_coesivo": {
+      "core": [
+        "mangrovieto-cinetico-trait-keeper"
+      ],
+      "optional": [
+        "mangrovieto-cinetico-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "ghiandole_grafene": {
+      "core": [
+        "steppe-algoritmiche-trait-keeper"
+      ],
+      "optional": [
+        "steppe-algoritmiche-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "ghiandole_inchiostro_luce": {
+      "core": [
+        "reef-luminescente-trait-keeper"
+      ],
+      "optional": [
+        "reef-luminescente-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "ghiandole_iodoattive": {
+      "core": [
+        "pianura-salina-iperarida-trait-keeper"
+      ],
+      "optional": [
+        "pianura-salina-iperarida-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "ghiandole_minerali": {
+      "core": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "optional": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "ghiandole_nebbia_acida": {
+      "core": [
+        "foresta-acida-trait-keeper"
+      ],
+      "optional": [
+        "foresta-acida-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "ghiandole_nebbia_ionica": {
+      "core": [
+        "canopia-ionica-trait-keeper"
+      ],
+      "optional": [
+        "canopia-ionica-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "ghiandole_nettare_memetico": {
+      "core": [],
+      "optional": [
+        "couatl-aurora"
+      ],
+      "synergy": []
+    },
+    "ghiandole_resina_conduttiva": {
+      "core": [
+        "canopia-ionica-trait-keeper"
+      ],
+      "optional": [
+        "canopia-ionica-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "ghiandole_ventosa": {
+      "core": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "optional": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "giunti_antitorsione": {
+      "core": [
+        "mangrovieto-cinetico-trait-keeper"
+      ],
+      "optional": [
+        "mangrovieto-cinetico-trait-keeper"
       ],
       "synergy": []
     },
     "grassi_termici": {
       "core": [
-        "aurora-gull",
         "cactus-weaver",
-        "cryo-lynx",
         "evento-brinastorm",
         "evento-ondata-termica",
+        "global-trait-keeper",
         "noctule-termico",
         "silica-bloom",
-        "steppe-bison-mini",
-        "thaw-rot",
         "thermo-raptor"
       ],
-      "optional": [],
+      "optional": [
+        "cactus-weaver",
+        "evento-brinastorm",
+        "evento-ondata-termica",
+        "global-trait-keeper",
+        "noctule-termico",
+        "silica-bloom",
+        "thermo-raptor"
+      ],
+      "synergy": []
+    },
+    "gusci_criovetro": {
+      "core": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "optional": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "gusci_magnesio": {
+      "core": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "optional": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "intangibilita_parziale": {
+      "core": [],
+      "optional": [
+        "banshee-risonante"
+      ],
+      "synergy": []
+    },
+    "lamelle_shear": {
+      "core": [
+        "stratosfera-tempestosa-trait-keeper"
+      ],
+      "optional": [
+        "stratosfera-tempestosa-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "lamelle_sincroniche": {
+      "core": [
+        "steppe-algoritmiche-trait-keeper"
+      ],
+      "optional": [
+        "steppe-algoritmiche-trait-keeper"
+      ],
       "synergy": []
     },
     "lamelle_termoforetiche": {
+      "core": [
+        "sorgenti-geotermiche-trait-keeper"
+      ],
+      "optional": [
+        "archon-solare",
+        "bulette-fase",
+        "couatl-aurora",
+        "magnet-fathom-surveyor",
+        "otyugh-sentinella",
+        "sorgenti-geotermiche-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "lamenti_diradanti": {
       "core": [],
       "optional": [
-        "dune-stalker"
+        "banshee-risonante"
+      ],
+      "synergy": []
+    },
+    "lamine_filtranti_aeree": {
+      "core": [
+        "mangrovieto-cinetico-trait-keeper"
+      ],
+      "optional": [
+        "mangrovieto-cinetico-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "lamine_scudo_silice": {
+      "core": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "optional": [
+        "dorsale-termale-tropicale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "linfa_tampone": {
+      "core": [
+        "foresta-acida-trait-keeper"
+      ],
+      "optional": [
+        "foresta-acida-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "lingua_cristallina": {
+      "core": [
+        "pianura-salina-iperarida-trait-keeper"
+      ],
+      "optional": [
+        "pianura-salina-iperarida-trait-keeper"
       ],
       "synergy": []
     },
     "lingua_tattile_trama": {
-      "core": [],
+      "core": [
+        "blight-micotico",
+        "caverna-risonante-trait-keeper"
+      ],
       "optional": [
         "aurora-bridge-runner",
+        "blight-micotico",
+        "caverna-risonante-trait-keeper",
         "echo-wing",
         "ferrocolonia-magnetotattica",
         "glowcap-weaver",
+        "resonant-claw-hunter",
         "zephyr-spore-courier"
+      ],
+      "synergy": []
+    },
+    "luminescenza_aurorale": {
+      "core": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "optional": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "luminescenza_hydrotermica": {
+      "core": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "optional": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "mantelli_geotermici": {
+      "core": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "optional": [
+        "caldera-glaciale-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "mantello_meteoritico": {
+      "core": [
+        "balor-fission",
+        "marilith-vault"
+      ],
+      "optional": [
+        "balor-fission"
+      ],
+      "synergy": []
+    },
+    "maschera_illusoria": {
+      "core": [],
+      "optional": [
+        "rakshasa-corte"
+      ],
+      "synergy": []
+    },
+    "matrice_antimagia": {
+      "core": [],
+      "optional": [
+        "golem-runico"
+      ],
+      "synergy": []
+    },
+    "membrane_captura_rugiada": {
+      "core": [
+        "pianura-salina-iperarida-trait-keeper"
+      ],
+      "optional": [
+        "pianura-salina-iperarida-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "membrane_eliofiltranti": {
+      "core": [
+        "laghi-alcalini-trait-keeper"
+      ],
+      "optional": [
+        "laghi-alcalini-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "membrane_osmotiche": {
+      "core": [],
+      "optional": [
+        "otyugh-sentinella"
+      ],
+      "synergy": []
+    },
+    "membrane_planata_vectored": {
+      "core": [
+        "canopia-ionica-trait-keeper"
+      ],
+      "optional": [
+        "canopia-ionica-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "membrane_pneumatofori": {
+      "core": [
+        "mangrovieto-cinetico-trait-keeper"
+      ],
+      "optional": [
+        "mangrovieto-cinetico-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "metabolismo_attivo": {
+      "core": [
+        "archon-solare",
+        "balor-fission",
+        "bulette-fase",
+        "couatl-aurora",
+        "marilith-vault",
+        "otyugh-sentinella",
+        "rakshasa-corte",
+        "treant-portale"
+      ],
+      "optional": [],
+      "synergy": []
+    },
+    "metabolismo_sostentato": {
+      "core": [
+        "banshee-risonante",
+        "golem-runico"
+      ],
+      "optional": [],
+      "synergy": []
+    },
+    "midollo_antivibrazione": {
+      "core": [
+        "caverna-risonante-trait-keeper"
+      ],
+      "optional": [
+        "caverna-risonante-trait-keeper",
+        "resonant-claw-hunter"
       ],
       "synergy": []
     },
     "mimetismo_cromatico_passivo": {
       "core": [
         "aurora-bridge-runner",
+        "canopia-psionica-leggera-trait-keeper",
+        "falde-magnetiche-psioniche-trait-keeper",
         "ferrocolonia-magnetotattica",
+        "psionic-canopy-scout",
         "zephyr-spore-courier"
       ],
-      "optional": [],
+      "optional": [
+        "aurora-bridge-runner",
+        "blight-micotico",
+        "canopia-psionica-leggera-trait-keeper",
+        "falde-magnetiche-psioniche-trait-keeper",
+        "ferrocolonia-magnetotattica",
+        "psionic-canopy-scout",
+        "resonant-claw-hunter",
+        "zephyr-spore-courier"
+      ],
+      "synergy": []
+    },
+    "mucillagine_simbionte_mangrovie": {
+      "core": [
+        "mangrovie-risonanti-trait-keeper"
+      ],
+      "optional": [
+        "mangrovie-risonanti-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "mucose_aderenza_sonica": {
+      "core": [
+        "caverna-risonante-trait-keeper"
+      ],
+      "optional": [
+        "caverna-risonante-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "mucose_barofile": {
+      "core": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "optional": [
+        "abisso-vulcanico-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "nodi_micorrizici_oracolari": {
+      "core": [
+        "reti-micorriziche-trait-keeper"
+      ],
+      "optional": [
+        "reti-micorriziche-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "nodi_micotici": {
+      "core": [],
+      "optional": [
+        "otyugh-sentinella",
+        "treant-portale"
+      ],
+      "synergy": []
+    },
+    "nuclei_di_controllo": {
+      "core": [],
+      "optional": [
+        "golem-runico"
+      ],
       "synergy": []
     },
     "nucleo_ovomotore_rotante": {
       "core": [
+        "caverna-risonante-trait-keeper",
+        "magnet-fathom-surveyor",
+        "orbital-ascendant",
         "sand-burrower"
       ],
       "optional": [
-        "rust-scavenger"
+        "caverna-risonante-trait-keeper",
+        "magnet-fathom-surveyor",
+        "orbital-ascendant",
+        "rust-scavenger",
+        "sand-burrower"
       ],
       "synergy": []
     },
     "occhi_infrarosso_composti": {
       "core": [
+        "caverna-risonante-trait-keeper",
         "echo-wing"
       ],
       "optional": [
         "aurora-bridge-runner",
+        "aurora-gull",
+        "caverna-risonante-trait-keeper",
+        "couatl-aurora",
+        "echo-wing",
+        "lupus-temperatus",
+        "resonant-claw-hunter",
         "zephyr-spore-courier"
       ],
       "synergy": []
     },
     "olfatto_risonanza_magnetica": {
       "core": [
+        "cryo-lynx",
+        "falde-magnetiche-psioniche-trait-keeper",
+        "magnet-fathom-surveyor",
+        "orbita-psionica-inversa-trait-keeper",
+        "orbital-ascendant",
         "slag-veil-ambusher"
       ],
       "optional": [
-        "magneto-ridge-hunter"
+        "cryo-lynx",
+        "dune-stalker",
+        "falde-magnetiche-psioniche-trait-keeper",
+        "magnet-fathom-surveyor",
+        "magneto-ridge-hunter",
+        "orbita-psionica-inversa-trait-keeper",
+        "orbital-ascendant",
+        "psionic-canopy-scout",
+        "slag-veil-ambusher"
       ],
       "synergy": []
     },
-    "pathfinder": {
-      "core": [],
+    "origine_artificiale": {
+      "core": [
+        "banshee-risonante",
+        "golem-runico"
+      ],
       "optional": [],
-      "synergy": [
-        "glowcap-weaver",
-        "myco-spire-warden"
-      ]
+      "synergy": []
+    },
+    "pathfinder": {
+      "core": [
+        "sentinella-radice"
+      ],
+      "optional": [
+        "sentinella-radice"
+      ],
+      "synergy": []
     },
     "pelli_anti_ustione": {
       "core": [
         "evento-tempesta-ferrosa"
       ],
-      "optional": [],
+      "optional": [
+        "evento-tempesta-ferrosa"
+      ],
       "synergy": []
     },
     "pelli_cave": {
       "core": [
-        "aurora-gull",
         "cactus-weaver",
-        "cryo-lynx",
         "evento-brinastorm",
         "evento-ondata-termica",
+        "global-trait-keeper",
         "noctule-termico",
         "silica-bloom",
-        "steppe-bison-mini",
-        "thaw-rot",
         "thermo-raptor"
       ],
-      "optional": [],
+      "optional": [
+        "cactus-weaver",
+        "evento-brinastorm",
+        "evento-ondata-termica",
+        "global-trait-keeper",
+        "noctule-termico",
+        "silica-bloom",
+        "thermo-raptor"
+      ],
       "synergy": []
     },
     "pelli_fitte": {
       "core": [
-        "blight-micotico",
         "evento-seme-uragano",
-        "lupus-temperatus",
-        "sentinella-radice"
+        "global-trait-keeper"
       ],
-      "optional": [],
+      "optional": [
+        "evento-seme-uragano",
+        "global-trait-keeper"
+      ],
       "synergy": []
     },
     "pianificatore": {
-      "core": [],
-      "optional": [],
-      "synergy": [
-        "glowcap-weaver",
-        "myco-spire-warden"
-      ]
+      "core": [
+        "sentinella-radice"
+      ],
+      "optional": [
+        "sentinella-radice"
+      ],
+      "synergy": []
     },
     "pigmenti_aurorali": {
       "core": [
-        "aurora-gull",
         "cactus-weaver",
-        "cryo-lynx",
         "evento-brinastorm",
         "evento-ondata-termica",
+        "global-trait-keeper",
         "noctule-termico",
         "silica-bloom",
-        "steppe-bison-mini",
-        "thaw-rot",
         "thermo-raptor"
       ],
-      "optional": [],
+      "optional": [
+        "cactus-weaver",
+        "evento-brinastorm",
+        "evento-ondata-termica",
+        "global-trait-keeper",
+        "noctule-termico",
+        "silica-bloom",
+        "thermo-raptor",
+        "treant-portale"
+      ],
       "synergy": []
     },
     "pigmenti_termici": {
       "core": [
         "evento-tempesta-ferrosa"
       ],
-      "optional": [],
+      "optional": [
+        "evento-tempesta-ferrosa"
+      ],
+      "synergy": []
+    },
+    "piume_solari_fotovoltaiche": {
+      "core": [
+        "altipiani-solari-trait-keeper"
+      ],
+      "optional": [
+        "altipiani-solari-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "polmoni_cristallini_alta_quota": {
+      "core": [
+        "picchi-cristallini-trait-keeper"
+      ],
+      "optional": [
+        "picchi-cristallini-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "proboscide_polifaga": {
+      "core": [],
+      "optional": [
+        "otyugh-sentinella"
+      ],
       "synergy": []
     },
     "proteine_shock_termico": {
       "core": [
-        "aurora-gull",
         "cactus-weaver",
-        "cryo-lynx",
         "evento-brinastorm",
         "evento-ondata-termica",
+        "global-trait-keeper",
         "noctule-termico",
         "silica-bloom",
-        "steppe-bison-mini",
-        "thaw-rot",
         "thermo-raptor"
+      ],
+      "optional": [
+        "cactus-weaver",
+        "evento-brinastorm",
+        "evento-ondata-termica",
+        "global-trait-keeper",
+        "noctule-termico",
+        "silica-bloom",
+        "thermo-raptor"
+      ],
+      "synergy": []
+    },
+    "radici_ancora_planare": {
+      "core": [],
+      "optional": [
+        "treant-portale"
+      ],
+      "synergy": []
+    },
+    "random": {
+      "core": [],
+      "optional": [
+        "sentinella-radice"
+      ],
+      "synergy": []
+    },
+    "respirazione_biologica": {
+      "core": [
+        "archon-solare",
+        "balor-fission",
+        "bulette-fase",
+        "couatl-aurora",
+        "marilith-vault",
+        "otyugh-sentinella",
+        "rakshasa-corte",
+        "treant-portale"
       ],
       "optional": [],
       "synergy": []
     },
     "respiro_a_scoppio": {
       "core": [
-        "rust-scavenger"
+        "caverna-risonante-trait-keeper",
+        "rust-scavenger",
+        "steppe-bison-mini"
       ],
       "optional": [
+        "caverna-risonante-trait-keeper",
+        "dune-stalker",
         "magneto-ridge-hunter",
-        "slag-veil-ambusher"
+        "rust-scavenger",
+        "slag-veil-ambusher",
+        "steppe-bison-mini"
       ],
       "synergy": []
     },
     "reti_capillari_radici": {
       "core": [
-        "aurora-gull",
         "cactus-weaver",
-        "cryo-lynx",
         "evento-brinastorm",
         "evento-ondata-termica",
+        "global-trait-keeper",
         "noctule-termico",
         "silica-bloom",
-        "steppe-bison-mini",
-        "thaw-rot",
         "thermo-raptor"
       ],
-      "optional": [],
+      "optional": [
+        "cactus-weaver",
+        "evento-brinastorm",
+        "evento-ondata-termica",
+        "global-trait-keeper",
+        "noctule-termico",
+        "silica-bloom",
+        "thermo-raptor",
+        "treant-portale"
+      ],
+      "synergy": []
+    },
+    "riflessi_preternaturali": {
+      "core": [],
+      "optional": [
+        "marilith-vault"
+      ],
+      "synergy": []
+    },
+    "rinforzi_modulari": {
+      "core": [],
+      "optional": [
+        "golem-runico"
+      ],
       "synergy": []
     },
     "risonanza_di_branco": {
-      "core": [],
-      "optional": [],
+      "core": [
+        "banshee-risonante",
+        "lupus-temperatus"
+      ],
+      "optional": [
+        "archon-solare",
+        "banshee-risonante",
+        "lupus-temperatus"
+      ],
       "synergy": [
-        "aurora-bridge-runner",
+        "archon-solare",
+        "couatl-aurora",
         "dune-stalker",
-        "zephyr-spore-courier"
+        "rakshasa-corte",
+        "treant-portale"
       ]
     },
     "sacche_galleggianti_ascensoriali": {
       "core": [
         "aurora-bridge-runner",
+        "canopia-psionica-leggera-trait-keeper",
+        "orbita-psionica-inversa-trait-keeper",
+        "orbital-ascendant",
+        "psionic-canopy-scout",
         "sand-burrower",
         "zephyr-spore-courier"
       ],
       "optional": [
+        "aurora-bridge-runner",
+        "aurora-gull",
+        "bulette-fase",
+        "canopia-psionica-leggera-trait-keeper",
         "dune-stalker",
-        "echo-wing"
+        "echo-wing",
+        "orbita-psionica-inversa-trait-keeper",
+        "orbital-ascendant",
+        "psionic-canopy-scout",
+        "sand-burrower",
+        "steppe-bison-mini",
+        "zephyr-spore-courier"
+      ],
+      "synergy": []
+    },
+    "sacche_spore_stratosferiche": {
+      "core": [
+        "stratosfera-portante-trait-keeper"
+      ],
+      "optional": [
+        "stratosfera-portante-trait-keeper"
       ],
       "synergy": []
     },
     "sangue_piroforico": {
       "core": [
-        "ferrocolonia-magnetotattica"
+        "caverna-risonante-trait-keeper",
+        "ferrocolonia-magnetotattica",
+        "thaw-rot"
       ],
       "optional": [
-        "nano-rust-bloom"
+        "caverna-risonante-trait-keeper",
+        "ferrocolonia-magnetotattica",
+        "nano-rust-bloom",
+        "thaw-rot"
       ],
       "synergy": []
     },
     "scheletro_idro_regolante": {
       "core": [
+        "caverna-risonante-trait-keeper",
         "dune-stalker",
         "magneto-ridge-hunter",
         "nano-rust-bloom",
-        "sand-burrower"
+        "sand-burrower",
+        "steppe-bison-mini"
       ],
       "optional": [
-        "rust-scavenger"
+        "bulette-fase",
+        "caverna-risonante-trait-keeper",
+        "dune-stalker",
+        "magnet-fathom-surveyor",
+        "magneto-ridge-hunter",
+        "nano-rust-bloom",
+        "rust-scavenger",
+        "sand-burrower",
+        "steppe-bison-mini"
       ],
       "synergy": [
         "slag-veil-ambusher"
@@ -912,123 +4290,292 @@
     },
     "secrezione_rallentante_palmi": {
       "core": [
+        "caverna-risonante-trait-keeper",
         "ferrocolonia-magnetotattica"
       ],
-      "optional": [],
+      "optional": [
+        "caverna-risonante-trait-keeper",
+        "ferrocolonia-magnetotattica",
+        "thaw-rot"
+      ],
+      "synergy": []
+    },
+    "secrezioni_antisepsi": {
+      "core": [],
+      "optional": [
+        "otyugh-sentinella"
+      ],
+      "synergy": []
+    },
+    "sensori_chimici": {
+      "core": [],
+      "optional": [
+        "otyugh-sentinella"
+      ],
       "synergy": []
     },
     "sensori_geomagnetici": {
       "core": [
-        "dune-stalker"
+        "pianure-magnetiche-trait-keeper"
       ],
-      "optional": [],
+      "optional": [
+        "bulette-fase",
+        "couatl-aurora",
+        "marilith-vault",
+        "pianure-magnetiche-trait-keeper"
+      ],
       "synergy": []
+    },
+    "sinapsi_coraline_polifoniche": {
+      "core": [
+        "barriere-coralline-psioniche-trait-keeper"
+      ],
+      "optional": [
+        "barriere-coralline-psioniche-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "sinapsi_riflettenti": {
+      "core": [],
+      "optional": [
+        "rakshasa-corte"
+      ],
+      "synergy": []
+    },
+    "sinergizzatore_team": {
+      "core": [],
+      "optional": [],
+      "synergy": [
+        "ferrocolonia-magnetotattica"
+      ]
     },
     "sonno_emisferico_alternato": {
       "core": [
+        "aurora-gull",
+        "caverna-risonante-trait-keeper",
         "echo-wing"
       ],
-      "optional": [],
+      "optional": [
+        "aurora-gull",
+        "caverna-risonante-trait-keeper",
+        "echo-wing"
+      ],
       "synergy": []
     },
     "spore_psichiche_silenziate": {
       "core": [
-        "nano-rust-bloom"
+        "blight-micotico",
+        "caverna-risonante-trait-keeper",
+        "nano-rust-bloom",
+        "thaw-rot"
       ],
       "optional": [
-        "myco-spire-warden"
+        "blight-micotico",
+        "caverna-risonante-trait-keeper",
+        "myco-spire-warden",
+        "nano-rust-bloom",
+        "psionic-canopy-scout",
+        "thaw-rot"
+      ],
+      "synergy": []
+    },
+    "squame_rifrangenti_deserto": {
+      "core": [
+        "dune-cristalline-trait-keeper"
+      ],
+      "optional": [
+        "dune-cristalline-trait-keeper"
       ],
       "synergy": []
     },
     "struttura_elastica_amorfa": {
       "core": [
+        "canopia-psionica-leggera-trait-keeper",
         "dune-stalker",
+        "falde-magnetiche-psioniche-trait-keeper",
         "glowcap-weaver",
+        "magnet-fathom-surveyor",
         "myco-spire-warden",
+        "psionic-canopy-scout",
         "slag-veil-ambusher"
       ],
-      "optional": [],
+      "optional": [
+        "canopia-psionica-leggera-trait-keeper",
+        "dune-stalker",
+        "falde-magnetiche-psioniche-trait-keeper",
+        "glowcap-weaver",
+        "magnet-fathom-surveyor",
+        "myco-spire-warden",
+        "psionic-canopy-scout",
+        "slag-veil-ambusher"
+      ],
       "synergy": [
         "magneto-ridge-hunter"
       ]
     },
-    "tattiche_di_branco": {
+    "support": {
       "core": [],
       "optional": [],
+      "synergy": [
+        "aurora-bridge-runner"
+      ]
+    },
+    "tattiche_di_branco": {
+      "core": [
+        "lupus-temperatus"
+      ],
+      "optional": [
+        "balor-fission",
+        "lupus-temperatus"
+      ],
       "synergy": [
         "dune-stalker",
         "magneto-ridge-hunter",
         "slag-veil-ambusher"
       ]
     },
-    "ventriglio_gastroliti": {
+    "tessuti_adattivi": {
+      "core": [],
+      "optional": [
+        "marilith-vault",
+        "rakshasa-corte"
+      ],
+      "synergy": []
+    },
+    "vello_condensatore_nebbie": {
       "core": [
-        "rust-scavenger"
+        "foreste-nubose-trait-keeper"
       ],
       "optional": [
-        "ferrocolonia-magnetotattica"
+        "foreste-nubose-trait-keeper"
+      ],
+      "synergy": []
+    },
+    "ventriglio_gastroliti": {
+      "core": [
+        "caverna-risonante-trait-keeper",
+        "rust-scavenger",
+        "steppe-bison-mini"
+      ],
+      "optional": [
+        "caverna-risonante-trait-keeper",
+        "ferrocolonia-magnetotattica",
+        "rust-scavenger",
+        "steppe-bison-mini"
+      ],
+      "synergy": []
+    },
+    "visione_spettrale": {
+      "core": [],
+      "optional": [
+        "archon-solare",
+        "marilith-vault"
+      ],
+      "synergy": []
+    },
+    "voce_spettrale": {
+      "core": [],
+      "optional": [
+        "banshee-risonante"
       ],
       "synergy": []
     },
     "zampe_a_molla": {
       "core": [],
       "optional": [
+        "cryo-lynx",
         "sand-burrower"
+      ],
+      "synergy": []
+    },
+    "zoccoli_risonanti_steppe": {
+      "core": [
+        "steppe-risonanti-trait-keeper"
+      ],
+      "optional": [
+        "steppe-risonanti-trait-keeper"
       ],
       "synergy": []
     }
   },
   "highlights": [
     {
-      "trait": "cuticole_cerose",
+      "trait": "sacche_galleggianti_ascensoriali",
       "core_refs": [
-        "aurora-gull",
-        "cactus-weaver",
-        "cryo-lynx",
-        "evento-brinastorm",
-        "evento-ondata-termica",
-        "noctule-termico",
-        "silica-bloom",
-        "steppe-bison-mini",
-        "thaw-rot",
-        "thermo-raptor"
+        "aurora-bridge-runner",
+        "canopia-psionica-leggera-trait-keeper",
+        "orbita-psionica-inversa-trait-keeper",
+        "orbital-ascendant",
+        "psionic-canopy-scout",
+        "sand-burrower",
+        "zephyr-spore-courier"
       ],
-      "optional_refs": [],
+      "optional_refs": [
+        "aurora-bridge-runner",
+        "aurora-gull",
+        "bulette-fase",
+        "canopia-psionica-leggera-trait-keeper",
+        "dune-stalker",
+        "echo-wing",
+        "orbita-psionica-inversa-trait-keeper",
+        "orbital-ascendant",
+        "psionic-canopy-scout",
+        "sand-burrower",
+        "steppe-bison-mini",
+        "zephyr-spore-courier"
+      ],
       "synergy_refs": []
     },
     {
-      "trait": "grassi_termici",
+      "trait": "filamenti_digestivi_compattanti",
       "core_refs": [
-        "aurora-gull",
-        "cactus-weaver",
-        "cryo-lynx",
-        "evento-brinastorm",
-        "evento-ondata-termica",
-        "noctule-termico",
-        "silica-bloom",
-        "steppe-bison-mini",
-        "thaw-rot",
-        "thermo-raptor"
+        "caverna-risonante-trait-keeper",
+        "falde-magnetiche-psioniche-trait-keeper",
+        "glowcap-weaver",
+        "magnet-fathom-surveyor",
+        "myco-spire-warden",
+        "nano-rust-bloom",
+        "rust-scavenger",
+        "thaw-rot"
       ],
-      "optional_refs": [],
+      "optional_refs": [
+        "blight-micotico",
+        "caverna-risonante-trait-keeper",
+        "falde-magnetiche-psioniche-trait-keeper",
+        "glowcap-weaver",
+        "magnet-fathom-surveyor",
+        "myco-spire-warden",
+        "nano-rust-bloom",
+        "rust-scavenger",
+        "thaw-rot"
+      ],
       "synergy_refs": []
     },
     {
-      "trait": "pelli_cave",
+      "trait": "struttura_elastica_amorfa",
       "core_refs": [
-        "aurora-gull",
-        "cactus-weaver",
-        "cryo-lynx",
-        "evento-brinastorm",
-        "evento-ondata-termica",
-        "noctule-termico",
-        "silica-bloom",
-        "steppe-bison-mini",
-        "thaw-rot",
-        "thermo-raptor"
+        "canopia-psionica-leggera-trait-keeper",
+        "dune-stalker",
+        "falde-magnetiche-psioniche-trait-keeper",
+        "glowcap-weaver",
+        "magnet-fathom-surveyor",
+        "myco-spire-warden",
+        "psionic-canopy-scout",
+        "slag-veil-ambusher"
       ],
-      "optional_refs": [],
-      "synergy_refs": []
+      "optional_refs": [
+        "canopia-psionica-leggera-trait-keeper",
+        "dune-stalker",
+        "falde-magnetiche-psioniche-trait-keeper",
+        "glowcap-weaver",
+        "magnet-fathom-surveyor",
+        "myco-spire-warden",
+        "psionic-canopy-scout",
+        "slag-veil-ambusher"
+      ],
+      "synergy_refs": [
+        "magneto-ridge-hunter"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- expand `data/traits/species_affinity.json` to cover all referenced traits with a consistent fallback species mapping
- update `trait_coverage` generation to mirror affinity entries into species coverage when species data is missing
- regenerate derived coverage/gap artifacts and manifest hashes to reflect full coverage

## Testing
- python scripts/generator.py --coverage --coverage-env-traits packs/evo_tactics_pack/docs/catalog/env_traits.json --coverage-trait-reference data/traits/index.json --coverage-species-root packs/evo_tactics_pack/data/species --coverage-affinity data/traits/species_affinity.json --coverage-glossary data/core/traits/glossary.json --coverage-output /tmp/trait_coverage.json
- python tools/analysis/trait_gap_report.py --etl-report data/derived/analysis/trait_coverage_report.json --trait-reference data/traits/index.json --trait-glossary data/core/traits/glossary.json --out data/derived/analysis/trait_gap_report.json


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f9538e1408328900e888d8db18f21)