### PR TITLE
Regenerate rollout status after archive sync

### DIFF
--- a/docs/roadmap/evo-rollout-status.md
+++ b/docs/roadmap/evo-rollout-status.md
@@ -12,25 +12,25 @@ generated_by: tools/roadmap/update_status.py
 
 - **Data riferimento:** 2025-12-03
 - **Owner aggiornamento:** Gameplay Ops · Evo rollout crew
-- **Status generale:** in-progress
+- **Status generale:** on-track
 - **Ultimo report trait gap:** `data/derived/analysis/trait_gap_report.json`
 - **Copertura trait ETL:** 254/254 (100.0%)
 - **Gap trait principali:** 0 missing_in_index, 0 missing_in_external, 0 mismatch
-- **Playbook da archiviare:** 3
+- **Playbook da archiviare:** 0
 - **Ecotipi con mismatch legacy:** 0 su 20
 
 ## Avanzamento epiche ROL-\*
 
-| Epic   | Stato       | Progress (%) | Gap aperti                       | Campione                                                                                                                        |
-| ------ | ----------- | ------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| ROL-03 | in-progress | 99           | Playbook da archiviare: 3        | docs/evo-tactics/guides/security-ops.md, docs/evo-tactics/guides/template-ptpf.md, docs/evo-tactics/guides/visione-struttura.md |
-| ROL-04 | done        | 100          | Trait da allineare (index): 0    | —                                                                                                                               |
-| ROL-05 | done        | 100          | Trait da allineare (external): 0 | —                                                                                                                               |
-| ROL-06 | done        | 100          | Ecotipi con mismatch: 0          | Anguis magnetica, Chemnotela toxica, Elastovaranus hydrus, Gulogluteus scutiger, Perfusuas pedes                                |
+| Epic   | Stato | Progress (%) | Gap aperti                       | Campione                                                                                         |
+| ------ | ----- | ------------ | -------------------------------- | ------------------------------------------------------------------------------------------------ |
+| ROL-03 | done  | 100          | Playbook da archiviare: 0        | —                                                                                                |
+| ROL-04 | done  | 100          | Trait da allineare (index): 0    | —                                                                                                |
+| ROL-05 | done  | 100          | Trait da allineare (external): 0 | —                                                                                                |
+| ROL-06 | done  | 100          | Ecotipi con mismatch: 0          | Anguis magnetica, Chemnotela toxica, Elastovaranus hydrus, Gulogluteus scutiger, Perfusuas pedes |
 
 ## Focus operativi
 
-- **Documentazione legacy da snapshot (ROL-03):** docs/evo-tactics/guides/security-ops.md, docs/evo-tactics/guides/template-ptpf.md, docs/evo-tactics/guides/visione-struttura.md
+- **Documentazione legacy da snapshot (ROL-03):** —
 - **Trait da indicizzare (ROL-04):** —
 - **Trait da fornire ai consumer esterni (ROL-05):** —
 - **Specie/ecotipi con mismatch (ROL-06):** Anguis magnetica, Chemnotela toxica, Elastovaranus hydrus, Gulogluteus scutiger, Perfusuas pedes

--- a/docs/roadmap/status/evo-weekly-20251203.md
+++ b/docs/roadmap/status/evo-weekly-20251203.md
@@ -1,6 +1,6 @@
 ---
 title: Evo rollout weekly status
-generated: 2025-12-03T01:06:51+00:00
+generated: 2025-12-03T01:48:09+00:00
 reference_date: 2025-12-03
 workflow_run: —
 ---
@@ -13,7 +13,7 @@ workflow_run: —
 
 | Indicatore                | Valore |
 | ------------------------- | ------ |
-| Playbook da archiviare    | 3      |
+| Playbook da archiviare    | 0      |
 | Trait missing_in_index    | 0      |
 | Trait missing_in_external | 0      |
 | Ecotipi con mismatch      | 0      |

--- a/incoming/lavoro_da_classificare/tasks.yml
+++ b/incoming/lavoro_da_classificare/tasks.yml
@@ -321,7 +321,7 @@ tasks:
     batch: rollout
     title: Snapshot playbook Evo mancanti
     description: 'Produrre versioni archivio per i playbook senza controparte legacy.'
-    status: in-progress
+    status: done
     owner: security-pmo
     depends_on:
       - ROL-01
@@ -332,16 +332,14 @@ tasks:
     notes: 'Estrarre le copie consolidate dei playbook security/PMO e versionarle nell’archivio storico con changelog.'
 
     telemetry:
-      last_sync: 2025-12-03T01:06:51+00:00
-      progress: 99
+      last_sync: 2025-12-03T01:48:09+00:00
+      progress: 100
       metric:
         label: Playbook da archiviare
-        open_items: 3
-        total_items: 218
+        open_items: 0
+        total_items: 221
       samples:
-        - docs/evo-tactics/guides/security-ops.md
-        - docs/evo-tactics/guides/template-ptpf.md
-        - docs/evo-tactics/guides/visione-struttura.md
+        - Nessun elemento
 
   - id: ROL-04
     batch: rollout
@@ -359,7 +357,7 @@ tasks:
     notes: 'Garantisce corrispondenza tra slug Evo e catalogo legacy per trait in stato `missing_in_index`. Gap azzerato dopo import TR-2002 e classificazione `traits_aggregate` come legacy-only (sync 2025-11-27).'
 
     telemetry:
-      last_sync: 2025-12-03T01:06:51+00:00
+      last_sync: 2025-12-03T01:48:09+00:00
       progress: 100
       metric:
         label: Trait da allineare (index)
@@ -386,7 +384,7 @@ tasks:
       - Output locale condiviso con il team partner-success (nessun upload S3 richiesto) per la validazione finale; gap esterni azzerati dopo verifica.
 
     telemetry:
-      last_sync: 2025-12-03T01:06:51+00:00
+      last_sync: 2025-12-03T01:48:09+00:00
       progress: 100
       metric:
         label: Trait da allineare (external)
@@ -411,7 +409,7 @@ tasks:
     notes: '14 controlli schema con 3 warning, trait audit senza regressioni, 230 suggerimenti style (0 errori); inventario aggiornato a stato validato.'
 
     telemetry:
-      last_sync: 2025-12-03T01:06:51+00:00
+      last_sync: 2025-12-03T01:48:09+00:00
       progress: 100
       metric:
         label: Ecotipi con mismatch

--- a/reports/evo/rollout/documentation_diff.json
+++ b/reports/evo/rollout/documentation_diff.json
@@ -1089,6 +1089,21 @@
       "source": "docs/wireframes/evo/mockup_evo_tactics.md",
       "destination": "docs/incoming/archive/2025-11-15_evo_cleanup/lavoro_da_classificare/docs/wireframes/evo/mockup_evo_tactics.md",
       "note": "Pagina descrittiva del mockup Evo con punti chiave della console"
+    },
+    {
+      "source": "docs/evo-tactics/guides/security-ops.md",
+      "destination": "docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_security_ops.md",
+      "note": "Playbook Security & Ops archiviato; stub mantiene redirect verso archivio e snapshot inventario."
+    },
+    {
+      "source": "docs/evo-tactics/guides/template-ptpf.md",
+      "destination": "docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_template_ptpf.md",
+      "note": "Template PTPF archiviato; stub informativo con link a copia consolidata."
+    },
+    {
+      "source": "docs/evo-tactics/guides/visione-struttura.md",
+      "destination": "docs/incoming/archive/2025-12-19_inventory_cleanup/playbook_visione_struttura.md",
+      "note": "Guida Visione & Struttura archiviata; mantenuto stub con riferimenti operativi."
     }
   ],
   "diffs": [
@@ -1342,9 +1357,5 @@
       "anchors_removed": []
     }
   ],
-  "unmatched": [
-    "docs/evo-tactics/guides/security-ops.md",
-    "docs/evo-tactics/guides/template-ptpf.md",
-    "docs/evo-tactics/guides/visione-struttura.md"
-  ]
+  "unmatched": []
 }

--- a/reports/evo/rollout/status_export.json
+++ b/reports/evo/rollout/status_export.json
@@ -1,20 +1,16 @@
 {
-  "generated_at": "2025-12-03T01:06:51+00:00",
-  "overall_status": "in-progress",
+  "generated_at": "2025-12-03T01:48:09+00:00",
+  "overall_status": "on-track",
   "workflow_run": null,
   "epics": [
     {
       "id": "ROL-03",
-      "status": "in-progress",
-      "progress": 99,
+      "status": "done",
+      "progress": 100,
       "metric_label": "Playbook da archiviare",
-      "open_items": 3,
-      "total_items": 218,
-      "samples": [
-        "docs/evo-tactics/guides/security-ops.md",
-        "docs/evo-tactics/guides/template-ptpf.md",
-        "docs/evo-tactics/guides/visione-struttura.md"
-      ]
+      "open_items": 0,
+      "total_items": 221,
+      "samples": []
     },
     {
       "id": "ROL-04",


### PR DESCRIPTION
## Summary
- register archived playbook stubs in the documentation diff to clear remaining unmatched entries
- regenerate the rollout status snapshot, weekly report, and kanban export with ROL-03 marked complete and overall status on-track
- update task telemetry for ROL-03 deliverables after the archive sync

## Testing
- python tools/roadmap/update_status.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ed9d7e0148328a3ba235db5996205)