### PR TITLE
Add redirect server for staging data paths

### DIFF
--- a/scripts/redirect_server.py
+++ b/scripts/redirect_server.py
@@ -1,0 +1,112 @@
+"""Lightweight redirect + static server for staging validation.
+
+- Serves files from the repository root (so ``/data/core`` and ``/data/derived``
+  are reachable directly).
+- Applies redirect rules parsed from ``docs/planning/REF_REDIRECT_PLAN_STAGING.md``
+  (same source used by ``scripts/redirect_smoke_test.py``) returning the
+  expected status codes.
+
+Usage:
+    python scripts/redirect_server.py --host 0.0.0.0 --port 8000
+"""
+from __future__ import annotations
+
+import argparse
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Dict, Tuple
+
+from redirect_smoke_test import DEFAULT_MAPPING_PATH, RedirectEntry, normalize_path, parse_mapping
+
+RedirectMap = Dict[str, Tuple[int, str]]
+
+
+def build_redirect_map(entries: list[RedirectEntry]) -> RedirectMap:
+    """Create a lookup map {source_path: (status, target_path)}.
+
+    Both trailing and non-trailing slash variants are included to make the
+    redirect resilient to how the client formats the URL.
+    """
+
+    mapping: RedirectMap = {}
+    for entry in entries:
+        if not entry.source or not entry.target:
+            continue
+        status = entry.expected_status or 301
+        target = normalize_path(entry.target)
+        source = normalize_path(entry.source)
+        candidates = {source}
+        if source != "/":
+            if source.endswith("/"):
+                candidates.add(source.rstrip("/"))
+            else:
+                candidates.add(source + "/")
+        for candidate in candidates:
+            mapping[candidate] = (status, target)
+    return mapping
+
+
+class RedirectHandler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, redirects: RedirectMap, **kwargs):
+        self.redirects = redirects
+        super().__init__(*args, **kwargs)
+
+    def _handle(self, head_only: bool = False) -> None:
+        path = self.path.split("?")[0]
+        redirect = self.redirects.get(path)
+        if redirect:
+            status, target = redirect
+            self.send_response(status)
+            self.send_header("Location", target)
+            self.end_headers()
+            return
+        if head_only:
+            return super().do_HEAD()
+        return super().do_GET()
+
+    def do_GET(self) -> None:  # noqa: N802 - external API
+        self._handle(head_only=False)
+
+    def do_HEAD(self) -> None:  # noqa: N802 - external API
+        self._handle(head_only=True)
+
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Redirect + static server for staging")
+    parser.add_argument("--host", default="127.0.0.1", help="Address to bind (default: 127.0.0.1)")
+    parser.add_argument("--port", type=int, default=8000, help="Port to bind (default: 8000)")
+    parser.add_argument(
+        "--mapping",
+        default=DEFAULT_MAPPING_PATH,
+        help="Path to the markdown mapping file (default: docs/planning/REF_REDIRECT_PLAN_STAGING.md)",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Root directory to serve (default: repository root)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    entries = parse_mapping(args.mapping)
+    redirect_map = build_redirect_map(entries)
+
+    handler = partial(RedirectHandler, redirects=redirect_map, directory=str(args.root))
+    server = ThreadingHTTPServer((args.host, args.port), handler)
+    print(f"[redirect-server] Serving {args.root} on http://{args.host}:{args.port}")
+    print(f"[redirect-server] Loaded {len(redirect_map)} redirect rules from {args.mapping}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("[redirect-server] Shutting down")
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Descrizione
- aggiunto `scripts/redirect_server.py` per servire i percorsi `/data/core` e `/data/derived` e applicare i redirect approvati dal mapping di staging.
- lettura automatica del mapping da `docs/planning/REF_REDIRECT_PLAN_STAGING.md` per restituire i codici 301/302 attesi sui path legacy.

## Checklist guida stile & QA
- [ ] Nessuna modifica a `data/core/**`, `data/derived/**`, `incoming/**`, `docs/incoming/**` nella finestra freeze 2025-11-25T12:05Z–2025-11-27T12:05Z (salvo rollback autorizzati Master DD)
- [ ] Validator di release **PASS senza regressioni** (allega percorso report). Il merge rimane bloccato finché esistono regressioni aperte nel validator
- [ ] Approvazione **Master DD** registrata (link a commento/issue che conferma l'ok al merge)
- [ ] Changelog allegato alla PR e **piano di rollback 03A** incluso (link o allegato nella sezione Note)
- [ ] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate
- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa
- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati
- [ ] Eseguito `scripts/trait_style_check.js` (allega percorso report/artifact)
- [ ] Badge "Guida stile" dell'editor in stato "In linea" (suggerimenti applicabili gestiti)
- [ ] Generato `tools/py/styleguide_compliance_report.py` (link a JSON/Markdown)
- [ ] Aggiornato bridge `logs/qa/latest-dashboard-metrics.json` se il report è stato rigenerato
- [ ] Documentazione/processi aggiornati ove necessario

## Testing
- [ ] `npm run style:check`
- [x] Altro: `curl -I http://localhost:8000/data/species.yaml` / `curl -I http://localhost:8000/data/analysis` / `curl -I http://localhost:8000/data/core/biomes.yaml`

## Note
- il server si avvia con `python scripts/redirect_server.py --host 0.0.0.0 --port 8000 --root .` e usa il mapping in `docs/planning/REF_REDIRECT_PLAN_STAGING.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69316c148e74832892a6c110ee8a2cf5)