### PR TITLE
Align pending/borderline notes and log review

### DIFF
--- a/docs/planning/REF_CORE_DERIVED_MATRIX.md
+++ b/docs/planning/REF_CORE_DERIVED_MATRIX.md
@@ -45,3 +45,4 @@ Delta vs calendario 2026: anticipato il go-live al 07/12/2025 (rispetto alla fin
 - Quando un asset passa da derived/pending a core, registrare la decisione (owner, ticket) e includere nota su fixture critiche e compatibilità con validator.
 - Borderline = richiede co-triage (trait-curator/balancer/archivist) e validazione Master DD prima di promozione.
 - Punto di ingresso post-rebaseline: usare `incoming/README.md` per aggiornare i cataloghi e registrare ogni attività correlata in `logs/agent_activity.md` con riferimento ai ticket 01B.
+- Allineamento pending/borderline 2026-09-09: confermato blocco licenza `ancestors_*` (TKT-01B-001, species-curator lead), mantenuto blocco hook/event-map v2.3 (`scan_engine_idents.py`, TKT-01C-002, dev-tooling owner) e handoff `lavoro_da_classificare` (TKT-01A-001 → 01B) in carico archivist con controllo species/trait-curator; note sincronizzate con `REF_INCOMING_CATALOG` e log centrale.

--- a/docs/planning/REF_INCOMING_CATALOG.md
+++ b/docs/planning/REF_INCOMING_CATALOG.md
@@ -43,6 +43,13 @@ Stato: Baseline 07/12/2025 – 01A chiuso, 01B/01C in report-only allineati ai g
 
 **Delta sintetico vs versione 0.5 (post-milestone 30/12/2025):** ownership ampliata 01A→01C con registrazione anticipata al 07/12; branch 01B/01C spostati in report-only pre-07/12 anziché post-30/12; logging obbligatorio di ogni riallineamento 01A→01B→01C prima di riaprire i branch.
 
+### Allineamento pending/borderline 2026-09-09
+
+- Licenza `ancestors_*` ancora pending su **[TKT-01B-001]** (species-curator owner); mantenere uso bloccato dei dataset fino al via libera legale e alla pubblicazione del dump sanificato definitivo.
+- Hook/event-map engine (**[TKT-01C-002]**) bloccati fino al rebase su event-map v2.3 e alla rigenerazione di `scan_engine_idents.py`; dev-tooling owner con alert a Master DD se persiste il blocco.
+- `incoming/lavoro_da_classificare/*` e `docs/incoming/lavoro_da_classificare/INTEGRATION_PLAN.md` restano in handoff 01B (archivist lead, controllo species/trait-curator) con note di triage/alias da non usare fuori contesto; mantenere logging STRICT MODE su ogni riuso.
+- Note operative sincronizzate con `REF_CORE_DERIVED_MATRIX` (sezione note) e `logs/agent_activity.md` (rilettura blocchi/sblocchi 2026-09-09).
+
 ### Stato prerequisiti PATCHSET-01A
 
 - Prerequisiti chiusi: catalogo incoming consolidato e allineato con `incoming/README.md` e `docs/incoming/README.md` (riesame 07/12/2025 confermato da Master DD).

--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -1,5 +1,8 @@
 # Agent activity log
 
+## 2026-09-09 – Allineamento pending/borderline 01B (archivist)
+- Step: `[PENDING-BORDERLINE-2026-09-09T1200Z] owner=archivist (coordinamento species-curator/trait-curator; approvatore Master DD); files=docs/planning/REF_CORE_DERIVED_MATRIX.md,docs/planning/REF_INCOMING_CATALOG.md,logs/agent_activity.md; esito=PASS; note=Verificati blocchi pending/borderline: licenza `ancestors_*` ancora pending su TKT-01B-001 (uso bloccato); hook/event-map v2.3 con `scan_engine_idents.py` bloccato (TKT-01C-002, dev-tooling owner) finché non arriva ID map aggiornata; handoff `lavoro_da_classificare` confermato in 01B con controllo species/trait-curator e no riuso fuori contesto. Note operative aggiornate nei due reference e log sincronizzato.`
+
 ## Template freeze fase 3→4
 - Step: `[FREEZE-03A03B-<YYYY-MM-DDThhmmZ>] owner=<coordinator|archivist> (approvatore Master DD); branch=patch/03A-core-derived, patch/03B-incoming-cleanup;
   snapshot=<path data/core/** + data/derived/**> (checksum+storage); backup_incoming=<path incoming/** + docs/incoming/**> (manifest+checksum);


### PR DESCRIPTION
## Summary
- add aligned pending/borderline note to REF_CORE_DERIVED_MATRIX for ancestors, hook/event-map, e lavoro_da_classificare
- record dedicated pending/borderline alignment section in REF_INCOMING_CATALOG with owners and prerequisites
- log the 2026-09-09 audit of pending/borderline states in logs/agent_activity.md

## Testing
- not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931e0bedba4832894554c1c2b8ae596)