### PR TITLE
Add migration phase 5-7 planning logs

### DIFF
--- a/docs/planning/REF_MIGRATION_PHASE5_ASSET_CATALOG.md
+++ b/docs/planning/REF_MIGRATION_PHASE5_ASSET_CATALOG.md
@@ -1,0 +1,55 @@
+# Log sandbox – Fase 5 Asset & Catalogo
+
+Log sandbox per la Fase 5: preparazione asset e cataloghi coerenti con gli output validati in Fase 4 e pronti per l'ingresso in patchset.
+
+## Riferimenti
+- Piano di migrazione: `docs/planning/REF_REPO_MIGRATION_PLAN.md`
+- Perimetro del refactor: `docs/planning/REF_REPO_SCOPE.md`
+- Gate Fase 4 (esiti validator/simulator): `docs/planning/REF_MIGRATION_PHASE4_VALIDATION.md`
+- Log fasi 0–4: `docs/planning/REF_MIGRATION_PHASE0-4_LOG.md`
+- Kickoff Fase 0: `docs/planning/REF_MIGRATION_PHASE0_KICKOFF.md`
+- Log Fase 1 Design: `docs/planning/REF_MIGRATION_PHASE1_DESIGN.md`
+- Log Fase 2 Modellazione: `docs/planning/REF_MIGRATION_PHASE2_MODELING.md`
+- Log Fase 3 Bilanciamento: `docs/planning/REF_MIGRATION_PHASE3_BALANCING.md`
+
+## Responsabilità
+- **Lead:** asset-prep (naming asset, schede catalogo, template grafici)
+- **Supporto:**
+  - archivist (tracciabilità, versioning log, mapping asset ↔ specie/biomi)
+  - coordinator (sincronizzazione con gate di Fase 4 e governance handoff)
+  - lore-designer (coerenza narrativa per descrizioni catalogo)
+  - species-curator / biome-ecosystem-curator (allineamento alias e bioma/specie)
+
+## Perimetro e obiettivi
+- Produrre naming e metadati asset in coerenza con i dataset validati in Fase 4, mantenendo STRICT MODE (solo log e draft in `docs/planning/` e `docs/catalog/` sandbox).
+- Redigere schede catalogo (biomi/specie/asset) collegate ai mapping di Fase 2 e alle curve di Fase 3, rispettando vincoli/gate di Fase 4.
+- Definire template grafici e requisiti tecnici per conversione asset (formati, dimensioni, cartelle target) senza toccare `assets/` produttivo.
+- Preparare prerequisiti asset (naming, versioni, placeholder) per l'inclusione nel patchset di Fase 7.
+
+## Rischi principali
+- Drift rispetto al gate di Fase 4 (asset non allineati ai mapping o alle curve convalidate).
+- Naming asset non aderente alle convenzioni o agli alias di specie/bioma, con rischio di collisioni o rollback.
+- Schede catalogo incomplete o non tracciate, che ostacolano l'integrazione in documentazione e patchset.
+- Vincoli tecnici (formati, pesi, dir) non dichiarati che bloccano conversioni o CI asset.
+
+## Deliverable e gate (Fase 5)
+- **Deliverable**
+  - Lista naming asset con metadati (slug, formato, directory target) collegata ai mapping/alias di specie/bioma.
+  - Schede catalogo sandbox (`docs/catalog/*_assets_draft.md`) con riferimenti a concept e curve validate.
+  - Template/linee guida per conversione asset (formati supportati, checklist qualità, path sandbox).
+  - Prerequisiti asset per Fase 7 con owner e scadenze: es. "placeholder webp biomi" (Owner: asset-prep, Scadenza: T+5d), "alias finali specie per naming" (Owner: species-curator, Scadenza: T+3d).
+- **Gate**
+  - Verifica congiunta coordinator + archivist che gli asset rispettino i blocchi/gate di Fase 4 e che i prerequisiti sopra siano chiusi o pianificati.
+  - Approvazione asset-prep sul naming finale prima del passaggio a Fase 6/7 (nessuna scrittura in `assets/` prod finché il gate Fase 4 non è segnato PASS).
+
+## Azioni immediate
+1. Importare nel log i vincoli e le deviazioni indicati dal gate di Fase 4 (alias, mapping, curve) per usarli come checklist di asset.
+2. Elaborare naming asset e schede catalogo in sandbox, mantenendo link espliciti ai mapping/alias e alle curve validate.
+3. Registrare prerequisiti asset con owner e scadenze e condividere con coordinator per il tracking verso Fase 6/7.
+4. Preparare un mini-handbook conversione (formati, dimensioni, directory staging) per evitare blocchi in CI/patchset.
+
+## Note operative
+- Operare solo in sandbox (`docs/planning/`, `docs/catalog/` bozze), senza modificare `assets/` o dataset core.
+- Ogni asset deve avere mapping esplicito a specie/bioma e stato (placeholder/finale) per supportare audit e rollback.
+- Se emergono gap dal gate di Fase 4, loggare rischio e proposta di fix prima di proporre integrazione nel patchset.
+- Allineare nomenclature e alias con `REF_REPO_SCOPE` e i log delle fasi precedenti per prevenire collisioni.

--- a/docs/planning/REF_MIGRATION_PHASE6_DOC_ARCHIVE.md
+++ b/docs/planning/REF_MIGRATION_PHASE6_DOC_ARCHIVE.md
@@ -1,0 +1,55 @@
+# Log sandbox – Fase 6 Documentazione & Archiviazione
+
+Log sandbox per la Fase 6: consolidare la documentazione di alto livello e gli indici, allineati ai gate di Fase 4 e alle decisioni asset/catalogo di Fase 5.
+
+## Riferimenti
+- Piano di migrazione: `docs/planning/REF_REPO_MIGRATION_PLAN.md`
+- Perimetro del refactor: `docs/planning/REF_REPO_SCOPE.md`
+- Gate Fase 4 (esiti validator/simulator): `docs/planning/REF_MIGRATION_PHASE4_VALIDATION.md`
+- Log fasi 0–5: `docs/planning/REF_MIGRATION_PHASE0-4_LOG.md`, `docs/planning/REF_MIGRATION_PHASE5_ASSET_CATALOG.md`
+- Kickoff Fase 0: `docs/planning/REF_MIGRATION_PHASE0_KICKOFF.md`
+- Log Fase 1 Design: `docs/planning/REF_MIGRATION_PHASE1_DESIGN.md`
+- Log Fase 2 Modellazione: `docs/planning/REF_MIGRATION_PHASE2_MODELING.md`
+- Log Fase 3 Bilanciamento: `docs/planning/REF_MIGRATION_PHASE3_BALANCING.md`
+
+## Responsabilità
+- **Lead:** archivist (appendici, indici, changelog, tracciabilità)
+- **Supporto:**
+  - coordinator (governance gate, allineamento con prerequisiti asset/doc/patchset)
+  - asset-prep (link schede catalogo e naming asset verso i README/indici)
+  - trait-curator / species-curator / biome-ecosystem-curator (coerenza con dataset e alias)
+  - lore-designer (verifica narrativa delle descrizioni pubbliche)
+
+## Perimetro e obiettivi
+- Aggiornare documentazione sandbox (appendici, README, manuali) riflettendo gli output validati in Fase 4 e le decisioni di Fase 5, senza modificare dataset core.
+- Consolidare indici/specie/biomi/trait in versione draft, collegandoli ai mapping e alle curve approvate.
+- Preparare changelog e note di rilascio per l’handoff verso il piano esecutivo/patchset di Fase 7.
+- Registrare prerequisiti documentali (appendici, indici, note pubbliche) con owner e scadenze, derivati dal gate Fase 4 e dagli asset di Fase 5.
+
+## Rischi principali
+- Desallineamento con il gate Fase 4 o con le schede asset/catalogo di Fase 5, generando documentazione incoerente.
+- Mancanza di tracciabilità tra indici, alias e dataset, ostacolando audit e validazioni successive.
+- Appendici/README incompleti che non coprono vincoli tecnici o naming, causando errori in patchset/CI.
+- Rischi di sovrascrittura di documenti produttivi se non mantenuto il perimetro sandbox.
+
+## Deliverable e gate (Fase 6)
+- **Deliverable**
+  - Appendici e integrazioni sandbox (es. `docs/biomes.md`, `docs/trait_reference_manual.md`, `docs/catalog/*`) con note di differenza rispetto a dataset attuale.
+  - Indici/specie/biomi/trait aggiornati in bozza con collegamenti a mapping/alias e schede asset.
+  - Changelog/archivio decisioni (log archivist) con riferimenti ai gate Fase 4 e alle approvazioni di Fase 5.
+  - Prerequisiti documentali con owner e scadenze: es. "appendice alias specie" (Owner: archivist, Scadenza: T+4d), "nota pubblica formati asset" (Owner: asset-prep, Scadenza: T+2d).
+- **Gate**
+  - Revisione coordinator + archivist per verificare che la documentazione rifletta fedelmente i vincoli di Fase 4 e le uscite di Fase 5, con tracciabilità completa.
+  - Accordo con asset-prep/curator su indici e alias prima di passare a Fase 7; i prerequisiti documentali devono risultare chiusi o schedulati.
+
+## Azioni immediate
+1. Importare nel log i prerequisiti e i blocchi registrati nel gate Fase 4 e nel log asset di Fase 5, marcandoli come requisiti documentali.
+2. Aggiornare bozze di appendici/indici in sandbox collegando mapping, alias e schede asset; evidenziare le parti da congelare in patchset.
+3. Registrare changelog e note di rilascio preliminari con owner e scadenze e condividerli con coordinator per il gating.
+4. Preparare matrice di tracciabilità (dataset ↔ alias ↔ asset ↔ doc) per supportare Fase 7.
+
+## Note operative
+- Lavorare esclusivamente in sandbox (`docs/planning/`, `docs/catalog/` bozze, `docs/reports/` draft) senza toccare dataset o manuali produttivi.
+- Ogni sezione aggiornata deve citare il gate Fase 4 e i riferimenti asset di Fase 5 per evitare drift.
+- In caso di discrepanze tra alias/indici e schede asset, documentare rischio e richiesta di fix prima del passaggio a Fase 7.
+- Mantenere naming e slug aderenti a `REF_REPO_SCOPE` e ai log precedenti per assicurare continuità nei validator.

--- a/docs/planning/REF_MIGRATION_PHASE7_EXEC_PLAN_PATCHSET.md
+++ b/docs/planning/REF_MIGRATION_PHASE7_EXEC_PLAN_PATCHSET.md
@@ -1,0 +1,56 @@
+# Log sandbox – Fase 7 Piano esecutivo & Patchset
+
+Log sandbox per la Fase 7: definire il piano esecutivo e il patchset derivato dai gate di Fase 4 e dagli output di asset/catalogo (Fase 5) e documentazione (Fase 6).
+
+## Riferimenti
+- Piano di migrazione: `docs/planning/REF_REPO_MIGRATION_PLAN.md`
+- Perimetro del refactor: `docs/planning/REF_REPO_SCOPE.md`
+- Gate Fase 4 (esiti validator/simulator): `docs/planning/REF_MIGRATION_PHASE4_VALIDATION.md`
+- Log fasi 0–6: `docs/planning/REF_MIGRATION_PHASE0-4_LOG.md`, `docs/planning/REF_MIGRATION_PHASE5_ASSET_CATALOG.md`, `docs/planning/REF_MIGRATION_PHASE6_DOC_ARCHIVE.md`
+- Kickoff Fase 0: `docs/planning/REF_MIGRATION_PHASE0_KICKOFF.md`
+- Log Fase 1 Design: `docs/planning/REF_MIGRATION_PHASE1_DESIGN.md`
+- Log Fase 2 Modellazione: `docs/planning/REF_MIGRATION_PHASE2_MODELING.md`
+- Log Fase 3 Bilanciamento: `docs/planning/REF_MIGRATION_PHASE3_BALANCING.md`
+
+## Responsabilità
+- **Lead:** coordinator (piano esecutivo, sequencing patchset, governance gating)
+- **Supporto:**
+  - dev-tooling (script, validazioni, checklist CI/lint per applicazione patch)
+  - archivist (tracciabilità patch, log decisioni, handoff finale)
+  - asset-prep (integrazione asset approvati e prerequisiti tecnici)
+  - trait-curator / species-curator / biome-ecosystem-curator (coerenza patch dati con mapping/alias)
+  - balancer (verifica impatti numerici e controlli post-merge)
+
+## Perimetro e obiettivi
+- Costruire un execution plan che ordini patch e merge secondo i vincoli del gate Fase 4 e le disponibilità asset/doc definite in Fasi 5–6.
+- Redigere patchset sandbox con blocchi diff strutturati e tracciabilità verso mapping, alias, asset e documentazione.
+- Definire prerequisiti tecnici (branch, script, sequenza commit, controlli CI) e owner/scadenze per ciascun blocco patch.
+- Garantire percorso di rollback e criteri di pass/fail gate prima dell'applicazione su branch produttivo.
+
+## Rischi principali
+- Sequenza patch non coerente con i vincoli del gate di Fase 4 o con la disponibilità di asset/doc, causando fallimenti CI o rollback.
+- Patchset incompleto o non tracciato (assenza di mapping a dataset/asset/doc), rendendo difficile audit e recovery.
+- Mancanza di prerequisiti tecnici (branch, script, dataset) o owner/scadenze, con rischio di slittamento o applicazione parziale.
+- Controlli CI/lint non eseguiti o non documentati, con potenziali regressioni.
+
+## Deliverable e gate (Fase 7)
+- **Deliverable**
+  - Execution plan sandbox (`docs/pipelines/<feature>_execution_plan.md`) con sequenza patch, branch consigliata, ordine commit, controlli CI/lint.
+  - Patchset sandbox (`docs/reports/<feature>_patchset_sandbox.md`) con blocchi `--- PATCH N: path ---` collegati a mapping/alias/asset/doc.
+  - Tabella prerequisiti patchset con owner e scadenze: es. "branch feature/<nome>" (Owner: coordinator, Scadenza: T+1d), "script validazione slug" (Owner: dev-tooling, Scadenza: T+2d), "pack asset finali" (Owner: asset-prep, Scadenza: T+4d).
+  - Piano di rollback e checklist post-merge (controlli CI, validator, aggiornamento log archivist).
+- **Gate**
+  - Revisione congiunta coordinator + dev-tooling + archivist sul piano esecutivo e sul patchset sandbox, verificando copertura prerequisiti e allineamento al gate Fase 4.
+  - Autorizzazione finale (PASS/HOLD) prima di qualsiasi applicazione su branch produttivo; i prerequisiti patchset devono risultare completati o avere scadenze/owner chiari.
+
+## Azioni immediate
+1. Importare nel log i prerequisiti aperti dai gate di Fase 4 e dai log di Fasi 5–6, trasformandoli in checklist patchset con owner/scadenze.
+2. Bozzare l'execution plan (sequenza patch, branch, CI) e il relativo patchset sandbox, collegandoli a mapping/alias/asset/doc.
+3. Validare con dev-tooling la lista di controlli (validator, lint, test) e inserire i punti di rollback nel piano.
+4. Condividere la checklist con coordinator/archivist per ottenere decisione di gate (PASS/HOLD) prima di procedere a qualsiasi applicazione reale.
+
+## Note operative
+- Produrre solo log e draft in sandbox (`docs/planning/`, `docs/reports/`, `docs/pipelines/`), senza applicare patch ai dataset core o agli asset.
+- Ogni patch deve riferire esplicitamente mapping, alias, asset e documentazione correlata per facilitare audit e rollback.
+- In caso di conflitti o prerequisiti mancanti, documentare rischio e bloccare l'avanzamento finché il gate non viene risolto.
+- Coordinare sequenza e proprietari con il calendario di scadenze definito nei prerequisiti per evitare sovrapposizioni e freeze violation.


### PR DESCRIPTION
## Summary
- add phase 5 asset/catalog planning log linked to phase 4 gate and prerequisites
- document phase 6 documentation/archiving log with owners and deadlines
- create phase 7 execution plan and patchset log outlining deliverables and gate

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69321a68ebd08328adcb6d5c7611a8b2)