### PR TITLE
Add verification memo and log entry

### DIFF
--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -1,5 +1,8 @@
 # Agent activity log
 
+## 2026-09-14 – Memo verifiche/report-only e follow-up approvazioni (archivist)
+- Step: `[MEMO-VERIFICHE-2026-09-14T1500Z] owner=archivist (approvatore Master DD); files=reports/memo_verifiche_2026-09-14.md,logs/agent_activity.md,reports/pipeline_simulation.md,reports/readiness_01B01C_status.md,reports/orchestrator_load_review.md; modalità=report-only; ticket=#1204,#1205,#1206,[TKT-03B-001],[TKT-02A-VALIDATOR],[TKT-01B-001],[TKT-01B-002],[TKT-01C-001],[TKT-01C-002]; esito=PASS; note=Redatto memo sintetico con esiti verifiche recenti, rischi aperti (host staging non raggiungibile, approvazioni Master DD pendenti, test carico orchestrator non eseguiti) e comandi/validatori da lanciare in report-only. Memo condiviso con owner archivist/dev-tooling/coordinator e Master DD per raccolta approvazioni prima di rollout; richiesto logging dei prossimi rerun (smoke redirect, validator 02A) e di eventuali freeze 3→4.]
+
 ## 2026-09-14 – Riesame smoke redirect + gate 03A/03B (archivist)
 - Step: `[REDIR-SMOKE-2026-09-14T1200Z] owner=archivist (approvatore Master DD); branch=patch/03B-incoming-cleanup; files=reports/redirects/redirect-smoke-staging.json,logs/agent_activity.md,docs/planning/REF_REDIRECT_PLAN_STAGING.md; esito=ERROR; note=Riesaminato lo smoke staging: tutti i redirect R-01/R-02/R-03 in ERROR (Connection refused) su http://localhost:8000, nessun PASS registrato. Allegato ai ticket #1204/#1205/#1206 e **[TKT-03B-001]**; richiesto rerun smoke su host ripristinato prima di sbloccare merge verso milestone 2025-12-07 e gate 03B. Gate 03A resta pronto con validator 02A PASS; 03B bloccato finché il listener non torna attivo.`
 

--- a/reports/memo_verifiche_2026-09-14.md
+++ b/reports/memo_verifiche_2026-09-14.md
@@ -1,0 +1,22 @@
+# Memo sintetico – Verifiche e rischi aperti (2026-09-14)
+
+## Esiti verifiche
+- **Redirect smoke staging (2026-09-14)**: ultimo run `reports/redirects/redirect-smoke-staging.json` in **ERROR** per host `http://localhost:8000` non raggiungibile (Connection refused). Gate 03B bloccato; 03A resta pronto. Ticket correlati: #1204/#1205/#1206, **[TKT-03B-001]**. (rif. log 2026-09-14)
+- **Readiness 01B/01C**: checkpoint 2025-11-30 conferma freeze documentale chiuso e attività in modalità report-only sui branch dedicati con ticket **[TKT-01B-001/002]**, **[TKT-01C-001/002]**; nessun nuovo drop rilevato. (rif. `reports/readiness_01B01C_status.md`)
+- **Pipeline 02A→03A→03B (simulazione)**: runbook aggiornato conferma sequenza seriale con validator 02A in report-only e log obbligatori per freeze/sblocco; preparazioni parallele consentite solo in draft. (rif. `reports/pipeline_simulation.md`)
+- **Orchestrator tuning**: configurazione rivista (poolSize 6, timeout 90s, retry 1) con piano di test k6 pronto ma non eseguito in questo ambiente. (rif. `reports/orchestrator_load_review.md`)
+
+## Rischi aperti / blocchi
+- **Connettività staging**: smoke redirect in errore finché l’host `http://localhost:8000` non è ripristinato; impedisce lo sblocco dei gate 03B e la chiusura del freeze 03A/03B.
+- **Dipendenza approvazione Master DD**: ogni passo di freeze/merge richiede firma Master DD; le attività restano in report-only fino al via libera.
+- **Test di carico orchestrator non eseguiti**: necessario eseguirli in ambiente con backend attivo per validare il tuning.
+
+## Comandi/validatori da lanciare (report-only)
+- **Rerun smoke redirect staging** (dev-tooling, report-only) appena il listener è attivo: `python scripts/redirect_smoke_test.py --host http://localhost:8000 --environment staging --output reports/redirects/redirect-smoke-staging.json` (allegare al ticket #1204/#1206 e loggare su `logs/agent_activity.md`).
+- **Validator 02A** su `patch/03A-core-derived` (report-only) prima di qualsiasi merge o riapertura freeze: eseguire schema-only, trait audit, trait style; loggare con ID `TKT-02A-VALIDATOR` come da pipeline.
+- **Freeze/rollback readiness**: se si apre o riconferma il freeze 3→4, registrare snapshot/backup e approvazione Master DD con il template di log riportato in `reports/pipeline_simulation.md`.
+- **Test di carico orchestrator** (solo in ambiente idoneo): `BASE_URL=http://<host>:3333 k6 run tests/load/orchestrator-load.k6.js` con soglie p95 <90s per generation e <10s per validators; risultato da riportare in modalità report-only.
+
+## Condivisione e approvazioni
+- **Owners**: archivist (log/memo), dev-tooling (smoke redirect & validator 02A), coordinator (freeze/sblocco), Master DD (approvazioni). Coinvolgere anche backups-oncall per snapshot/rollback quando si riattiva il freeze.
+- **Azione richiesta**: condividere il presente memo con gli owner sopra per raccogliere approvazioni e confermare l’esecuzione dei comandi in report-only prima di qualsiasi rollout.


### PR DESCRIPTION
## Summary
- add a memo summarizing recent verification outcomes, open risks, and report-only commands
- log the memo and related tickets in the activity log for owner approvals

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69322c09b8ac8328954fe4958e7c2dbc)