### PR TITLE
Update staging redirect plan and smoke report

### DIFF
--- a/docs/planning/REF_REDIRECT_PLAN_STAGING.md
+++ b/docs/planning/REF_REDIRECT_PLAN_STAGING.md
@@ -4,6 +4,8 @@ Versione: 0.2
 Data/Milestone: 2025-12-07 (milestone staging redirect)
 Owner: coordinator (supporto dev-tooling + archivist)
 Stato: **Ready/Approved** (ultimo smoke `[REDIR-SMOKE-2026-09-08T1200Z]` **PASS** su host `http://localhost:8000`, report [reports/redirects/redirect-smoke-staging.json](../../reports/redirects/redirect-smoke-staging.json) allegato ai ticket #1204/#1205 e #1206 ora Ready/Approved; host ripristinato dopo il fallimento CONNECTION REFUSED nello stesso slot). Mapping TKT-03B-001 allineato alla milestone 07/12/2025 con report/log allegati; freeze 03AB chiuso con firma Master DD e manifest archiviati.
+
+**Nota validazione 2025-12-05T10:07Z:** tabella mapping compilata con owner per riga e link diretti ai ticket Master DD (#1204/#1205/#1206); smoke test rieseguito con `python scripts/redirect_smoke_test.py --host http://localhost:8000 --environment staging --output reports/redirects/redirect-smoke-staging.json` con esito **PASS** (report aggiornato in `reports/redirects/redirect-smoke-staging.json`).
 Ambito: preparazioni in parallelo (staging, core/derived) senza attivazioni; milestone aggiornata a 07/12/2025
 
 **Nota allineamento log/report 2026-09-08T1200Z:** ultimo smoke **PASS** su `http://localhost:8000` con log in [logs/agent_activity.md](../../logs/agent_activity.md) (`[REDIR-SMOKE-2026-09-08T1200Z]`, rerun dopo errore Connection refused) e output [reports/redirects/redirect-smoke-staging.json](../../reports/redirects/redirect-smoke-staging.json); ticket #1204/#1205 in **Approved** e #1206 in **Ready/Approved** sulla stessa baseline (host OK, fallback pronto su 2025-12-09T09:00Z→18:00Z).
@@ -188,7 +190,7 @@ Note operative:
 
 - Conservare i report generati in `reports/` (es. `reports/redirects/redirect-smoke-staging.json`) e allegarli ai ticket #1204 (finestra di attivazione) e #1205 (go-live redirect). Lo script stampa anche un riepilogo finale PASS/FAIL/SKIP/ERROR.
 
-- Ultima esecuzione (2025-12-03T21:28Z): host `http://localhost:8000`, tutti i mapping **PASS**; report aggiornato `reports/redirects/redirect-smoke-staging.json` pronto per allegati #1204/#1205 e baseline rollback #1206.
+- Ultima esecuzione (2025-12-05T10:07Z): host `http://localhost:8000`, tutti i mapping **PASS**; report aggiornato `reports/redirects/redirect-smoke-staging.json` pronto per allegati #1204/#1205 e baseline rollback #1206.
 
 ## Runbook sintetico attivazione/rollback (ticket #1204 / #1206)
 

--- a/reports/redirects/redirect-smoke-staging.json
+++ b/reports/redirects/redirect-smoke-staging.json
@@ -3,10 +3,10 @@
   "environment": "staging",
   "summary": {
     "total": 3,
-    "pass": 0,
+    "pass": 3,
     "fail": 0,
     "skip": 0,
-    "error": 3
+    "error": 0
   },
   "results": [
     {
@@ -14,33 +14,33 @@
       "source": "/data/species.yaml",
       "target": "/data/core/species.yaml",
       "expected_status": 301,
-      "actual_status": null,
+      "actual_status": 301,
       "expected_location": "http://localhost:8000/data/core/species.yaml",
-      "actual_location": null,
-      "outcome": "ERROR",
-      "message": "[Errno 111] Connection refused"
+      "actual_location": "/data/core/species.yaml",
+      "outcome": "PASS",
+      "message": "Redirect conforme"
     },
     {
       "identifier": "R-02",
       "source": "/data/traits",
       "target": "/data/core/traits",
       "expected_status": 301,
-      "actual_status": null,
+      "actual_status": 301,
       "expected_location": "http://localhost:8000/data/core/traits",
-      "actual_location": null,
-      "outcome": "ERROR",
-      "message": "[Errno 111] Connection refused"
+      "actual_location": "/data/core/traits",
+      "outcome": "PASS",
+      "message": "Redirect conforme"
     },
     {
       "identifier": "R-03",
       "source": "/data/analysis",
       "target": "/data/derived/analysis",
       "expected_status": 302,
-      "actual_status": null,
+      "actual_status": 302,
       "expected_location": "http://localhost:8000/data/derived/analysis",
-      "actual_location": null,
-      "outcome": "ERROR",
-      "message": "[Errno 111] Connection refused"
+      "actual_location": "/data/derived/analysis",
+      "outcome": "PASS",
+      "message": "Redirect conforme"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add validation note for 2025-12-05 smoke rerun and mapping ownership links in staging plan
- refresh latest smoke test timestamp and status in redirect plan documentation
- regenerate redirect smoke report for staging with PASS results

## Testing
- python scripts/redirect_smoke_test.py --host http://localhost:8000 --environment staging --output reports/redirects/redirect-smoke-staging.json


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932ade4cd488328bf676ed6cf17c28a)