### PR TITLE
Fix Husky install script for ESM modules

### DIFF
--- a/docs/archive/evo-tactics/guida-ai-tratti-1.md
+++ b/docs/archive/evo-tactics/guida-ai-tratti-1.md
@@ -184,7 +184,7 @@ Seguendo questa pipeline, le schede esistenti possono essere migrate
 senza perdere informazioni e diventando compatibili con gli strumenti
 del pacchetto v2.
 
-### Validazione nel repository Game
+### Validazione nel repository Game {#evo-guida-ai-tratti-1-validazione-nel-repository-game}
 
 Nel repository Game i controlli vanno eseguiti con la toolchain Python, che copre sia struttura dati sia glossari/localizzazioni:
 

--- a/docs/archive/evo-tactics/guida-ai-tratti-2.md
+++ b/docs/archive/evo-tactics/guida-ai-tratti-2.md
@@ -184,7 +184,7 @@ Seguendo questa pipeline, le schede esistenti possono essere migrate
 senza perdere informazioni e diventando compatibili con gli strumenti
 del pacchetto v2.
 
-### Validazione nel repository Game
+### Validazione nel repository Game {#evo-guida-ai-tratti-2-validazione-nel-repository-game}
 
 Nel repository Game i controlli vanno eseguiti con la toolchain Python, che copre sia struttura dati sia glossari/localizzazioni:
 

--- a/docs/archive/evo-tactics/guida-ai-tratti-3-evo-tactics.md
+++ b/docs/archive/evo-tactics/guida-ai-tratti-3-evo-tactics.md
@@ -185,7 +185,7 @@ Seguendo questa pipeline, le schede esistenti possono essere migrate
 senza perdere informazioni e diventando compatibili con gli strumenti
 del pacchetto v2.
 
-### Validazione nel repository Game
+### Validazione nel repository Game {#evo-guida-ai-tratti-3-evo-tactics-validazione-nel-repository-game}
 
 Nel repository Game i controlli vanno eseguiti con la toolchain Python, che copre sia struttura dati sia glossari/localizzazioni:
 

--- a/docs/archive/evo-tactics/integrazioni-v2.md
+++ b/docs/archive/evo-tactics/integrazioni-v2.md
@@ -185,7 +185,7 @@ Seguendo questa pipeline, le schede esistenti possono essere migrate
 senza perdere informazioni e diventando compatibili con gli strumenti
 del pacchetto v2.
 
-### Validazione nel repository Game
+### Validazione nel repository Game {#evo-integrazioni-v2-validazione-nel-repository-game}
 
 Nel repository Game i controlli vanno eseguiti con la toolchain Python, che copre sia struttura dati sia glossari/localizzazioni:
 

--- a/docs/evo-tactics/anchors-map.csv
+++ b/docs/evo-tactics/anchors-map.csv
@@ -20,6 +20,7 @@ docs/evo-tactics/guida-ai-tratti-1.md,evo-guida-ai-tratti-1-guida-completa-ai-tr
 docs/evo-tactics/guida-ai-tratti-1.md,evo-guida-ai-tratti-1-howto-autore-trait-estratto,/docs/evo-tactics/guida-ai-tratti-1#evo-guida-ai-tratti-1-howto-autore-trait-estratto
 docs/evo-tactics/guida-ai-tratti-1.md,evo-guida-ai-tratti-1-introduzione,/docs/evo-tactics/guida-ai-tratti-1#evo-guida-ai-tratti-1-introduzione
 docs/evo-tactics/guida-ai-tratti-1.md,evo-guida-ai-tratti-1-pipeline-di-migrazione-v1-v2,/docs/evo-tactics/guida-ai-tratti-1#evo-guida-ai-tratti-1-pipeline-di-migrazione-v1-v2
+docs/evo-tactics/guida-ai-tratti-1.md,evo-guida-ai-tratti-1-validazione-nel-repository-game,/docs/evo-tactics/guida-ai-tratti-1#evo-guida-ai-tratti-1-validazione-nel-repository-game
 docs/evo-tactics/guida-ai-tratti-1.md,evo-guida-ai-tratti-1-prontuario-metriche-ucum-estratto,/docs/evo-tactics/guida-ai-tratti-1#evo-guida-ai-tratti-1-prontuario-metriche-ucum-estratto
 docs/evo-tactics/guida-ai-tratti-1.md,evo-guida-ai-tratti-1-prossimi-passi-e-raccomandazioni,/docs/evo-tactics/guida-ai-tratti-1#evo-guida-ai-tratti-1-prossimi-passi-e-raccomandazioni
 docs/evo-tactics/guida-ai-tratti-1.md,evo-guida-ai-tratti-1-schede-delle-specie-e-dei-loro-tratti,/docs/evo-tactics/guida-ai-tratti-1#evo-guida-ai-tratti-1-schede-delle-specie-e-dei-loro-tratti
@@ -52,6 +53,7 @@ docs/evo-tactics/guida-ai-tratti-2.md,evo-guida-ai-tratti-2-introduzione,/docs/e
 docs/evo-tactics/guida-ai-tratti-2.md,evo-guida-ai-tratti-2-mappatura-e-regole-di-convergenza,/docs/evo-tactics/guida-ai-tratti-2#evo-guida-ai-tratti-2-mappatura-e-regole-di-convergenza
 docs/evo-tactics/guida-ai-tratti-2.md,evo-guida-ai-tratti-2-passi-operativi-per-la-migrazione,/docs/evo-tactics/guida-ai-tratti-2#evo-guida-ai-tratti-2-passi-operativi-per-la-migrazione
 docs/evo-tactics/guida-ai-tratti-2.md,evo-guida-ai-tratti-2-pipeline-di-migrazione-v1-v2,/docs/evo-tactics/guida-ai-tratti-2#evo-guida-ai-tratti-2-pipeline-di-migrazione-v1-v2
+docs/evo-tactics/guida-ai-tratti-2.md,evo-guida-ai-tratti-2-validazione-nel-repository-game,/docs/evo-tactics/guida-ai-tratti-2#evo-guida-ai-tratti-2-validazione-nel-repository-game
 docs/evo-tactics/guida-ai-tratti-2.md,evo-guida-ai-tratti-2-prontuario-metriche-ucum-estratto,/docs/evo-tactics/guida-ai-tratti-2#evo-guida-ai-tratti-2-prontuario-metriche-ucum-estratto
 docs/evo-tactics/guida-ai-tratti-2.md,evo-guida-ai-tratti-2-prossimi-passi-e-raccomandazioni,/docs/evo-tactics/guida-ai-tratti-2#evo-guida-ai-tratti-2-prossimi-passi-e-raccomandazioni
 docs/evo-tactics/guida-ai-tratti-2.md,evo-guida-ai-tratti-2-roadmap-e-gate-di-qualita,/docs/evo-tactics/guida-ai-tratti-2#evo-guida-ai-tratti-2-roadmap-e-gate-di-qualita
@@ -100,6 +102,7 @@ docs/evo-tactics/guida-ai-tratti-3-evo-tactics.md,evo-guida-ai-tratti-3-evo-tact
 docs/evo-tactics/guida-ai-tratti-3-evo-tactics.md,evo-guida-ai-tratti-3-evo-tactics-mappatura-e-regole-di-convergenza,/docs/evo-tactics/guida-ai-tratti-3-evo-tactics#evo-guida-ai-tratti-3-evo-tactics-mappatura-e-regole-di-convergenza
 docs/evo-tactics/guida-ai-tratti-3-evo-tactics.md,evo-guida-ai-tratti-3-evo-tactics-passi-operativi-per-la-migrazione,/docs/evo-tactics/guida-ai-tratti-3-evo-tactics#evo-guida-ai-tratti-3-evo-tactics-passi-operativi-per-la-migrazione
 docs/evo-tactics/guida-ai-tratti-3-evo-tactics.md,evo-guida-ai-tratti-3-evo-tactics-pipeline-di-migrazione-v1-v2,/docs/evo-tactics/guida-ai-tratti-3-evo-tactics#evo-guida-ai-tratti-3-evo-tactics-pipeline-di-migrazione-v1-v2
+docs/evo-tactics/guida-ai-tratti-3-evo-tactics.md,evo-guida-ai-tratti-3-evo-tactics-validazione-nel-repository-game,/docs/evo-tactics/guida-ai-tratti-3-evo-tactics#evo-guida-ai-tratti-3-evo-tactics-validazione-nel-repository-game
 docs/evo-tactics/guida-ai-tratti-3-evo-tactics.md,evo-guida-ai-tratti-3-evo-tactics-prontuario-metriche-ucum-estratto,/docs/evo-tactics/guida-ai-tratti-3-evo-tactics#evo-guida-ai-tratti-3-evo-tactics-prontuario-metriche-ucum-estratto
 docs/evo-tactics/guida-ai-tratti-3-evo-tactics.md,evo-guida-ai-tratti-3-evo-tactics-prossimi-passi-e-raccomandazioni,/docs/evo-tactics/guida-ai-tratti-3-evo-tactics#evo-guida-ai-tratti-3-evo-tactics-prossimi-passi-e-raccomandazioni
 docs/evo-tactics/guida-ai-tratti-3-evo-tactics.md,evo-guida-ai-tratti-3-evo-tactics-roadmap-e-gate-di-qualita,/docs/evo-tactics/guida-ai-tratti-3-evo-tactics#evo-guida-ai-tratti-3-evo-tactics-roadmap-e-gate-di-qualita
@@ -131,6 +134,7 @@ docs/evo-tactics/integrazioni-v2.md,evo-integrazioni-v2-guida-completa-ai-trait-
 docs/evo-tactics/integrazioni-v2.md,evo-integrazioni-v2-howto-autore-trait-estratto,/docs/evo-tactics/integrazioni-v2#evo-integrazioni-v2-howto-autore-trait-estratto
 docs/evo-tactics/integrazioni-v2.md,evo-integrazioni-v2-introduzione,/docs/evo-tactics/integrazioni-v2#evo-integrazioni-v2-introduzione
 docs/evo-tactics/integrazioni-v2.md,evo-integrazioni-v2-pipeline-di-migrazione-v1-v2,/docs/evo-tactics/integrazioni-v2#evo-integrazioni-v2-pipeline-di-migrazione-v1-v2
+docs/evo-tactics/integrazioni-v2.md,evo-integrazioni-v2-validazione-nel-repository-game,/docs/evo-tactics/integrazioni-v2#evo-integrazioni-v2-validazione-nel-repository-game
 docs/evo-tactics/integrazioni-v2.md,evo-integrazioni-v2-prontuario-metriche-ucum-estratto,/docs/evo-tactics/integrazioni-v2#evo-integrazioni-v2-prontuario-metriche-ucum-estratto
 docs/evo-tactics/integrazioni-v2.md,evo-integrazioni-v2-prossimi-passi-e-raccomandazioni,/docs/evo-tactics/integrazioni-v2#evo-integrazioni-v2-prossimi-passi-e-raccomandazioni
 docs/evo-tactics/integrazioni-v2.md,evo-integrazioni-v2-schede-delle-specie-e-dei-loro-tratti,/docs/evo-tactics/integrazioni-v2#evo-integrazioni-v2-schede-delle-specie-e-dei-loro-tratti

--- a/docs/evo-tactics/guida-ai-tratti-1.md
+++ b/docs/evo-tactics/guida-ai-tratti-1.md
@@ -183,7 +183,7 @@ Seguendo questa pipeline, le schede esistenti possono essere migrate
 senza perdere informazioni e diventando compatibili con gli strumenti
 del pacchetto v2.
 
-### Validazione nel repository Game
+### Validazione nel repository Game {#evo-guida-ai-tratti-1-validazione-nel-repository-game}
 
 Nel repository Game i controlli vanno eseguiti con la toolchain Python, che copre sia struttura dati sia glossari/localizzazioni:
 

--- a/docs/evo-tactics/guida-ai-tratti-2.md
+++ b/docs/evo-tactics/guida-ai-tratti-2.md
@@ -183,7 +183,7 @@ Seguendo questa pipeline, le schede esistenti possono essere migrate
 senza perdere informazioni e diventando compatibili con gli strumenti
 del pacchetto v2.
 
-### Validazione nel repository Game
+### Validazione nel repository Game {#evo-guida-ai-tratti-2-validazione-nel-repository-game}
 
 Nel repository Game i controlli vanno eseguiti con la toolchain Python, che copre sia struttura dati sia glossari/localizzazioni:
 

--- a/docs/evo-tactics/guida-ai-tratti-3-evo-tactics.md
+++ b/docs/evo-tactics/guida-ai-tratti-3-evo-tactics.md
@@ -184,7 +184,7 @@ Seguendo questa pipeline, le schede esistenti possono essere migrate
 senza perdere informazioni e diventando compatibili con gli strumenti
 del pacchetto v2.
 
-### Validazione nel repository Game
+### Validazione nel repository Game {#evo-guida-ai-tratti-3-evo-tactics-validazione-nel-repository-game}
 
 Nel repository Game i controlli vanno eseguiti con la toolchain Python, che copre sia struttura dati sia glossari/localizzazioni:
 

--- a/docs/evo-tactics/integrazioni-v2.md
+++ b/docs/evo-tactics/integrazioni-v2.md
@@ -184,7 +184,7 @@ Seguendo questa pipeline, le schede esistenti possono essere migrate
 senza perdere informazioni e diventando compatibili con gli strumenti
 del pacchetto v2.
 
-### Validazione nel repository Game
+### Validazione nel repository Game {#evo-integrazioni-v2-validazione-nel-repository-game}
 
 Nel repository Game i controlli vanno eseguiti con la toolchain Python, che copre sia struttura dati sia glossari/localizzazioni:
 

--- a/scripts/husky-install.cjs
+++ b/scripts/husky-install.cjs
@@ -1,25 +1,43 @@
 #!/usr/bin/env node
 
-try {
-  // Husky v9 exports install on the default export.
-  const husky = require('husky');
-  const install =
-    typeof husky === 'function'
-      ? husky
-      : typeof husky?.install === 'function'
-        ? husky.install
-        : typeof husky?.default === 'function'
-          ? husky.default
-          : typeof husky?.default?.install === 'function'
-            ? husky.default.install
-            : null;
-  if (typeof install === 'function') {
-    install('.husky');
-  } else {
-    console.warn('[husky] install skipped: install helper not available');
+async function main() {
+  try {
+    // Husky v9 exports install on the default export.
+    let husky;
+
+    try {
+      husky = require('husky');
+    } catch (error) {
+      const message =
+        error && typeof error === 'object' && 'message' in error ? error.message : String(error);
+      if (message.includes('ES Module')) {
+        husky = await import('husky');
+      } else {
+        throw error;
+      }
+    }
+
+    const install =
+      typeof husky === 'function'
+        ? husky
+        : typeof husky?.install === 'function'
+          ? husky.install
+          : typeof husky?.default === 'function'
+            ? husky.default
+            : typeof husky?.default?.install === 'function'
+              ? husky.default.install
+              : null;
+
+    if (typeof install === 'function') {
+      install('.husky');
+    } else {
+      console.warn('[husky] install skipped: install helper not available');
+    }
+  } catch (error) {
+    const message =
+      error && typeof error === 'object' && 'message' in error ? error.message : String(error);
+    console.warn(`[husky] install skipped: ${message}`);
   }
-} catch (error) {
-  const message =
-    error && typeof error === 'object' && 'message' in error ? error.message : String(error);
-  console.warn(`[husky] install skipped: ${message}`);
 }
+
+main();


### PR DESCRIPTION
## Summary
- add a dynamic `import()` fallback in `scripts/husky-install.cjs` so Husky installs when the package is ESM-only
- keep install helper detection and warnings intact to avoid skipped hook setup

## Testing
- npm ci
- npm run docs:lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932f1424a1c8328a3e675aec80da610)