### PR TITLE
Aggiorna guida per dispatch manuale con gh CLI

### DIFF
--- a/docs/workflows/gh-cli-manual-dispatch.md
+++ b/docs/workflows/gh-cli-manual-dispatch.md
@@ -7,51 +7,49 @@ Guida rapida per lanciare workflow GitHub Actions con `gh workflow run` in modo 
 - [GitHub CLI](https://cli.github.com/) installata e autenticata (`gh auth login`).
 - Personal Access Token (PAT) con gli scope `repo`, `workflow` **e** `read:org`; se l'organizzazione usa SSO, autorizza il PAT prima dell'uso.
 
-## Esempio di dispatch per i workflow con trigger manuale
+## Workflow con trigger manuale
 
-Usa PowerShell per lanciare in sequenza i workflow che espongono `workflow_dispatch`:
+Questi workflow espongono `workflow_dispatch` e possono essere avviati via CLI:
 
-```powershell
-$workflows = @(
-  "e2e.yml",
-  "deploy-test-interface.yml",
-  "qa-export.yml",
-  "qa-reports.yml",
-  "hud.yml",
-  "search-index.yml",
-  "traits-sync.yml",
-  "validate-naming.yml",
-  "gh-pages.yml",
-  "incoming-smoke.yml",
-  "evo-rollout-status.yml",
-  "chatgpt_sync.yml",
-  "traits-monthly-maintenance.yml",
-  "qa-kpi-monitor.yml",
-  "daily-pr-summary.yml",
-  "daily-tracker-refresh.yml",
-  "evo-doc-backfill.yml",
-  "lighthouse.yml"
-)
+- `chatgpt_sync.yml`
+- `daily-pr-summary.yml`
+- `daily-tracker-refresh.yml`
+- `deploy-test-interface.yml`
+- `e2e.yml`
+- `evo-batch.yml`
+- `evo-doc-backfill.yml`
+- `evo-rollout-status.yml`
+- `gh-pages.yml`
+- `hud.yml`
+- `incoming-smoke.yml`
+- `lighthouse.yml`
+- `qa-export.yml`
+- `qa-kpi-monitor.yml`
+- `qa-reports.yml`
+- `schema-validate.yml`
+- `search-index.yml`
+- `traits-monthly-maintenance.yml`
+- `traits-sync.yml`
+- `validate-naming.yml`
 
-foreach ($workflow in $workflows) {
-  gh workflow run $workflow
-}
+## Esempi di dispatch
+
+### Workflow senza input obbligatori
+
+```bash
+# Esegui un workflow semplice (puoi specificare -r <branch> se serve)
+gh workflow run e2e.yml
 ```
 
-## Esempio dedicato: `evo-batch.yml`
+### Workflow con input obbligatori
 
-Questo workflow richiede la specifica del batch target come input obbligatorio:
-
-```powershell
+```bash
 # Esegui un batch specifico (sostituisci <valore> con il batch richiesto)
-gh workflow run evo-batch.yml -f batch=<valore>
-
-# Aggiungi ulteriori flag solo se richiesti dal workflow (es. -f dry_run=true)
+gh workflow run evo-batch.yml -f batch=<valore> [-f execute=true] [-f ignore_errors=true]
 ```
-
-`schema-validate.yml` non espone `workflow_dispatch` sul branch principale: si attiva solo tramite i trigger previsti dal file.
 
 ## Note operative
 
 - Rimuovi il PAT dal keychain/credential manager dopo l'uso per ridurre l'esposizione.
 - I workflow privi di `workflow_dispatch` vanno eseguiti esclusivamente tramite i loro trigger nativi (push, schedule o dipendenze da altri workflow).
+- Verifica e scarica i log con `gh run list --workflow <nome-workflow>` e `gh run download <run-id>`.


### PR DESCRIPTION
## Summary
- aggiorna i prerequisiti del PAT includendo lo scope read:org con nota SSO
- sostituisce il ciclo PowerShell con l'elenco dei workflow con trigger workflow_dispatch
- aggiunge esempi separati per workflow con input obbligatori e il richiamo al download dei log

## Testing
- non eseguiti (documentazione)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693344faf7988328bb076b6680eac0c4)