### PR TITLE
Clarify manual dispatch guidance in CI inventory

### DIFF
--- a/docs/planning/ci-inventory.md
+++ b/docs/planning/ci-inventory.md
@@ -74,10 +74,11 @@ Questa pagina riepiloga i workflow GitHub Actions e gli script locali citati dal
 ### Come mantenere aggiornato l'inventario (fino al 07/12/2025)
 
 - Ogni lunedì verifica nuovi log in `logs/ci_runs` (o artefatti CI) e aggiorna la colonna “Ultimo run” con data/esito e link ai log corrispondenti.
-- Se mancano log, lancia i workflow manuali con `gh workflow run <file.yml> --ref <branch>` o attiva i `workflow_dispatch` dal repository.
+- Se mancano log, lancia i workflow manuali con `gh workflow run <file.yml> --ref <branch>` solo per i file con trigger `workflow_dispatch` e passando gli input obbligatori (es. `evo-batch.yml -f batch=<valore>`). Usa un PAT con scope `workflow` e `read:org` autorizzato SSO quando richiesto.
 - Mantieni il semaforo go-live coerente con l’ultimo esito (verde se run completo <7 giorni e verde, giallo se log assente/vecchio, rosso se KO o step critici mancanti).
 - Aggiorna le note con blocchi e retry pianificati, archiviando eventuali artefatti aggiuntivi in `logs/ci_runs` o `logs/visual_runs`.
 - Esegui un controllo incrociato settimanale con i responsabili (owner colonna) per confermare retry e scadenze prima delle milestone di rilascio.
+- Se usi la CLI, dopo il dispatch controlla i log con `gh run list --workflow <file.yml> --limit <n>` e scaricali con `gh run download <id> --dir logs/ci_runs`, sostituendo i placeholder con valori reali.
 
 ## Script locali citati
 

--- a/docs/workflows/gh-cli-manual-dispatch.md
+++ b/docs/workflows/gh-cli-manual-dispatch.md
@@ -34,7 +34,7 @@ Questi workflow espongono `workflow_dispatch` e possono essere avviati via CLI:
 
 ### Dispatch multiplo (PowerShell)
 
-Usa questo ciclo solo per i workflow senza input obbligatori:
+Usa questo ciclo solo per i workflow con `workflow_dispatch` e senza input obbligatori:
 
 ```powershell
 $workflows = @(
@@ -84,4 +84,4 @@ gh workflow run evo-batch.yml -f batch=<valore> [-f execute=true] [-f ignore_err
 
 - Rimuovi il PAT dal keychain/credential manager dopo l'uso per ridurre l'esposizione.
 - I workflow privi di `workflow_dispatch` vanno eseguiti esclusivamente tramite i loro trigger nativi (push, schedule o dipendenze da altri workflow).
-- Verifica e scarica i log con `gh run list --workflow <nome-workflow>` e `gh run download <run-id>`.
+- Verifica e scarica i log con `gh run list --workflow <nome-workflow>` e `gh run download <run-id>` sostituendo `<nome-workflow>` e `<run-id>` con valori reali.


### PR DESCRIPTION
## Summary
- clarify that manual dispatch via GitHub CLI should target workflow_dispatch workflows and include required inputs
- note PAT scope read:org with potential SSO authorization when triggering runs manually
- add reminder to list and download run logs via gh CLI replacing placeholders

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69334d735ac4832896f597ed6e9fe29a)