### PR TITLE
Align CI reference doc with latest inventory statuses

### DIFF
--- a/docs/planning/REF_TOOLING_AND_CI.md
+++ b/docs/planning/REF_TOOLING_AND_CI.md
@@ -15,9 +15,10 @@ Stato: PATCHSET-00 – completata una serie di 3 run verdi per `data-quality.yml
 
 ## Stato attuale
 
-- Inventario CI/tooling aggiornato ai run del **05/12/2025** (vedi `docs/planning/ci-inventory.md`) con mapping esplicito dei workflow (`.github/workflows/**`) e degli script (`tools/**`, `scripts/**`, `ops/**`) ai rispettivi owner e sorgenti core/pack.
-- Gate PR enforcing confermati sui workflow dati/schema/naming (`data-quality.yml`, `validate_traits.yml`, `schema-validate.yml`, `validate-naming.yml`) e smoke `incoming-smoke.yml`; `derived_checksum.yml` rimane consultivo su derived. Sono monitorati anche i workflow QA export/reports, deploy test-interface, HUD Canary e `evo-batch.yml` con stato riportato nell’inventario.
-- Percorsi core/pack e fixture derived tracciati: i validatori leggono `data/core/**` come fonte canonica, mentre i derived (`data/derived/**`, `packs/evo_tactics_pack/**`) sono consumati solo come output o per verifica consultiva. KO e dispatch aperti (incoming-smoke, QA export/reports, HUD) sono elencati nell’inventario con owner e trigger.
+- Inventario CI/tooling aggiornato ai run del **05/12/2025** (vedi `docs/planning/ci-inventory.md`) con mapping esplicito dei workflow (`.github/workflows/**`) e degli script (`tools/**`, `scripts/**`, `ops/**`) ai rispettivi owner e sorgenti core/pack, includendo KO/dispatch aperti.
+- Gate PR enforcing confermati sui workflow dati/schema/naming (`data-quality.yml`, `validate_traits.yml`, `schema-validate.yml`, `validate-naming.yml`) e smoke `incoming-smoke.yml`; `derived_checksum.yml` rimane consultivo su derived. `validate-naming.yml` è in **PASS** (run 05/12), `validate_traits.yml` e `schema-validate.yml` in **PASS** (run 30/11) mentre `data-quality.yml` è in **FAIL** (run 30/11) con fix schema/glossario aperti. `incoming-smoke.yml` non ha log archiviati e mantiene dispatch manuale programmato.
+- Percorsi core/pack e fixture derived tracciati: i validatori leggono `data/core/**` come fonte canonica, mentre i derived (`data/derived/**`, `packs/evo_tactics_pack/**`) sono consumati solo come output o per verifica consultiva. KO e dispatch aperti (incoming-smoke, QA export/reports, HUD, `data-quality.yml`) sono elencati nell’inventario con owner e trigger.
+- Workflow monitorati estesi (rimando a tabella inventario): oltre ai gate dati/schema/naming sono inclusi `qa-export.yml`, `qa-reports.yml`, `qa-kpi-monitor.yml`, `deploy-test-interface.yml`, `hud.yml`, `evo-batch.yml`, `search-index.yml`, `telemetry-export.yml`, `traits-sync.yml`, `lighthouse.yml`, `evo-doc-backfill.yml`, `evo-rollout-status.yml` e `update-evo-tracker.yml` con stato `enforcing` o consultivo esplicitato nella tabella.
 
 ## Rischi
 
@@ -53,12 +54,12 @@ Stato: PATCHSET-00 – completata una serie di 3 run verdi per `data-quality.yml
 ## Ordine di abilitazione CI (Master DD – 2025-12-07)
 
 - Branch operativo: `patch/01C-tooling-ci-catalog` (strict-mode, nessun artefatto commit) con milestone anticipata alla data del **07/12/2025**. Approvazione Master DD rilasciata sui run del 30/11/2025 e confermata con i run del **05/12/2025**.
-- Sequenza 2025 (stato attivo):
-  1. **data-quality.yml** e **validate_traits.yml** enforcing come gate PR (`pull_request` attivo) validati dai run del 05/12/2025 (matrix core+pack verde); rollback: reimpostare `continue-on-error` e limitare i trigger a `push`/`workflow_dispatch` se riemergono drift su core.
-  2. **schema-validate.yml** enforcing su variazioni schema/lint (core + config/schemas) con trigger `pull_request` e run 05/12/2025 verde; rollback: sospendere l’obbligatorietà del check e tornare a dispatch manuale.
-  3. **validate-naming.yml** confermato gate PR (`pull_request` attivo, `continue-on-error` rimosso) con run del 05/12/2025 in PASS e warning glossario tracciati; rollback consultivo documentato (riattivare solo `push`/`workflow_dispatch`, ripristinare `continue-on-error`).
-  4. **incoming-smoke.yml** attivo su `pull_request` con filtro `incoming/**` + `workflow_dispatch` manuale; esito 05/12/2025 in KO su dataset incompleto, retry dispatch aperto. Rollback: rimuovere il trigger PR e mantenere solo il dispatch se i guardrail smoke bloccano in modo improprio.
-  5. Workflow monitorati aggiuntivi: **deploy-test-interface.yml**, **hud.yml**, **qa-export.yml**, **qa-reports.yml**, **evo-batch.yml** (stato dettagliato in `ci-inventory.md`); nessun gate PR, ma mantenere dispatch manuali con rollback a skip se blocchi infrastrutturali.
+- Sequenza 2025 (stato attivo, allineata agli esiti inventario):
+  1. **data-quality.yml** e **validate_traits.yml** enforcing come gate PR (`pull_request` attivo); `validate_traits.yml` valido al 30/11 (PASS), mentre `data-quality.yml` è in **FAIL** (schema/glossario) con owner dati per la correzione. Rollback: reimpostare `continue-on-error` e limitare i trigger a `push`/`workflow_dispatch` se il KO persiste o blocca i PR.
+  2. **schema-validate.yml** enforcing su variazioni schema/lint (core + config/schemas) con ultimo run 30/11 in PASS; rollback: sospendere l’obbligatorietà del check e tornare a dispatch manuale.
+  3. **validate-naming.yml** confermato gate PR (`pull_request` attivo, `continue-on-error` rimosso) con run del 05/12 in PASS e warning glossario chiusi; rollback consultivo documentato (riattivare solo `push`/`workflow_dispatch`, ripristinare `continue-on-error`).
+  4. **incoming-smoke.yml** attivo su `pull_request` con filtro `incoming/**` + `workflow_dispatch` manuale; nessun log archiviato, retry dispatch aperto per dataset completo. Rollback: rimuovere il trigger PR e mantenere solo il dispatch se i guardrail smoke bloccano in modo improprio.
+  5. Workflow monitorati aggiuntivi: **deploy-test-interface.yml**, **hud.yml**, **qa-export.yml**, **qa-reports.yml**, **evo-batch.yml**, **search-index.yml**, **telemetry-export.yml** (stato dettagliato in `ci-inventory.md`); nessun gate PR, ma mantenere dispatch manuali con rollback a skip se blocchi infrastrutturali.
 - Decisioni storiche mantenute solo per audit (non operative):
   - **Decisione 2026-04-20**: `validate-naming.yml` in modalità consultiva con PR disattivato su `patch/01C-tooling-ci-catalog` (superata dalla promozione del 30/11/2025).
   - **Verifica 2026-04-26**: conferma dello stato consultivo e assenza di 3 run verdi consecutivi (archiviata, sostituita dalla milestone 07/12/2025).
@@ -77,7 +78,17 @@ Stato: PATCHSET-00 – completata una serie di 3 run verdi per `data-quality.yml
   | incoming-smoke.yml   | 2026-04-12 smoke consultivo su dispatch manuale                            | 2025-11-30 PR + dispatch con guardrail; rollback: solo dispatch                            |
   | derived_checksum.yml | 2026-04-12 consultivo (continue-on-error, push/PR su derived)              | 2025-12-07 consultivo invariato ma allineato ai trigger 2025 e pronto per promozione       |
 
-- Reminder check mancanti: drift `data/derived/**` vs sorgenti non ancora monitorato (coperto da audit checksum consultivo); gating incoming ancora limitato al profilo smoke (paths `incoming/**`) + eventuale uso manuale di `scripts/report_incoming.sh` per triage. KO/dispatch aperti del 05/12/2025: incoming-smoke (retry manuale), raccolta artefatti QA export/reports, HUD dispatch in corso.
+- Reminder check mancanti: drift `data/derived/**` vs sorgenti non ancora monitorato (coperto da audit checksum consultivo); gating incoming ancora limitato al profilo smoke (paths `incoming/**`) + eventuale uso manuale di `scripts/report_incoming.sh` per triage. KO/dispatch aperti del 05/12/2025: incoming-smoke (retry manuale), raccolta artefatti QA export/reports, HUD dispatch in corso, `data-quality.yml` in FAIL con fix schema/glossario pianificati.
+
+### Azioni aperte e owner (inventario 05/12/2025)
+
+- **data-quality.yml** – Owner dati. Correggere schema/glossario core (`data/core/**`) e rerun archiviando log `logs/ci_runs/data-quality*.log`; rollback consultivo se il gate blocca altri PR.
+- **ci.yml** – Owner dev-tooling. Necessario run completo (push/PR) e download artefatti in `logs/ci_runs/`, mantenendo lettura su core e derived generati.
+- **e2e.yml** – Owner QA. Dispatch manuale con upload report Playwright in `logs/ci_runs/e2e_*` prima del go-live.
+- **QA suite** (`qa-export.yml`, `qa-reports.yml`, `qa-kpi-monitor.yml`) – Owner QA. Ripetere export/report con artefatti in `logs/ci_runs` e `logs/visual_runs`, riallineando badge/baseline pack ai core.
+- **hud.yml** – Owner HUD. Dispatch con build overlay/visual e log in `logs/ci_runs`/`logs/visual_runs`; valutare rollback a dispatch-only se blocchi infrastrutturali.
+- **incoming-smoke.yml** – Owner dev-tooling. Dispatch manuale su dataset completo (core/incoming) e decisione su rollback a solo `workflow_dispatch` se i guardrail smoke restano bloccanti.
+- **evo-batch.yml** – Owner ops/dev-tooling. Programmato dry-run `batch=traits` con log in `logs/ci_runs`; solo dopo valutare `execute=true`.
 
 ### Audit checksum derived (consultivo → enforcing)
 


### PR DESCRIPTION
## Summary
- update CI tooling reference with current workflow outcomes, including KO/dispatch from ci-inventory
- refresh CI enablement order and rollback notes to reflect recent runs and monitored workflows
- add open action items with owners and logging expectations tied to core/pack sources

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693381053eb88328b8d00949ba0208d5)