### PR TITLE
Allinea riferimenti CI ai run più recenti

### DIFF
--- a/docs/planning/REF_TOOLING_AND_CI.md
+++ b/docs/planning/REF_TOOLING_AND_CI.md
@@ -15,9 +15,9 @@ Stato: PATCHSET-00 – completata una serie di 3 run verdi per `data-quality.yml
 
 ## Stato attuale
 
-- Inventario CI/tooling aggiornato ai run del **05/12/2025** (vedi `docs/planning/ci-inventory.md`) con mapping esplicito dei workflow (`.github/workflows/**`) e degli script (`tools/**`, `scripts/**`, `ops/**`) ai rispettivi owner e sorgenti core/pack.
-- Gate PR enforcing confermati sui workflow dati/schema/naming (`data-quality.yml`, `validate_traits.yml`, `schema-validate.yml`, `validate-naming.yml`) e smoke `incoming-smoke.yml`; `derived_checksum.yml` rimane consultivo su derived. Sono monitorati anche i workflow QA export/reports, deploy test-interface, HUD Canary e `evo-batch.yml` con stato riportato nell’inventario.
-- Percorsi core/pack e fixture derived tracciati: i validatori leggono `data/core/**` come fonte canonica, mentre i derived (`data/derived/**`, `packs/evo_tactics_pack/**`) sono consumati solo come output o per verifica consultiva. KO e dispatch aperti (incoming-smoke, QA export/reports, HUD) sono elencati nell’inventario con owner e trigger.
+- Inventario CI/tooling allineato ai run più recenti archiviati (ultimo log verde su `validate-naming.yml` **run4 – 06/12/2025**, `schema-validate.yml`/`validate_traits.yml` **run3 – 30/11/2025**, `data-quality.yml` **run3 FAIL – 30/11/2025**) come riportato in `docs/planning/ci-inventory.md`. Per `incoming-smoke.yml`, `deploy-test-interface.yml`, `hud.yml`, suite QA/export e batch non risultano log dopo il 05/12/2025: restano in attesa di dispatch/manuale con raccolta artefatti in `logs/ci_runs`/`logs/visual_runs`.
+- Gate PR enforcing confermati sui workflow dati/schema/naming (`data-quality.yml`, `validate_traits.yml`, `schema-validate.yml`, `validate-naming.yml`) e smoke `incoming-smoke.yml`; `derived_checksum.yml` rimane consultivo su derived. Le note di rollback/consultivo post 05/12/2025 (ad es. fallback consultivo per `validate-naming.yml`, rollback a solo dispatch per `incoming-smoke.yml`) sono riprese dall’inventario.
+- Percorsi core/pack e fixture derived tracciati: i validatori leggono `data/core/**` come fonte canonica, mentre i derived (`data/derived/**`, `packs/evo_tactics_pack/**`) sono consumati solo come output o per verifica consultiva. KO e dispatch aperti (incoming-smoke, QA export/reports, HUD, data-quality) sono elencati nell’inventario con owner, trigger e rollback suggeriti.
 
 ## Rischi
 
@@ -52,13 +52,13 @@ Stato: PATCHSET-00 – completata una serie di 3 run verdi per `data-quality.yml
 
 ## Ordine di abilitazione CI (Master DD – 2025-12-07)
 
-- Branch operativo: `patch/01C-tooling-ci-catalog` (strict-mode, nessun artefatto commit) con milestone anticipata alla data del **07/12/2025**. Approvazione Master DD rilasciata sui run del 30/11/2025 e confermata con i run del **05/12/2025**.
-- Sequenza 2025 (stato attivo):
-  1. **data-quality.yml** e **validate_traits.yml** enforcing come gate PR (`pull_request` attivo) validati dai run del 05/12/2025 (matrix core+pack verde); rollback: reimpostare `continue-on-error` e limitare i trigger a `push`/`workflow_dispatch` se riemergono drift su core.
-  2. **schema-validate.yml** enforcing su variazioni schema/lint (core + config/schemas) con trigger `pull_request` e run 05/12/2025 verde; rollback: sospendere l’obbligatorietà del check e tornare a dispatch manuale.
-  3. **validate-naming.yml** confermato gate PR (`pull_request` attivo, `continue-on-error` rimosso) con run del 05/12/2025 in PASS e warning glossario tracciati; rollback consultivo documentato (riattivare solo `push`/`workflow_dispatch`, ripristinare `continue-on-error`).
-  4. **incoming-smoke.yml** attivo su `pull_request` con filtro `incoming/**` + `workflow_dispatch` manuale; esito 05/12/2025 in KO su dataset incompleto, retry dispatch aperto. Rollback: rimuovere il trigger PR e mantenere solo il dispatch se i guardrail smoke bloccano in modo improprio.
-  5. Workflow monitorati aggiuntivi: **deploy-test-interface.yml**, **hud.yml**, **qa-export.yml**, **qa-reports.yml**, **evo-batch.yml** (stato dettagliato in `ci-inventory.md`); nessun gate PR, ma mantenere dispatch manuali con rollback a skip se blocchi infrastrutturali.
+- Branch operativo: `patch/01C-tooling-ci-catalog` (strict-mode, nessun artefatto commit) con milestone anticipata alla data del **07/12/2025**. Approvazione Master DD rilasciata sui run del 30/11/2025 e confermata con i run documentati fino al **06/12/2025**.
+- Sequenza 2025 (stato attivo, allineata ai log più recenti):
+  1. **data-quality.yml** e **validate_traits.yml** enforcing come gate PR (`pull_request` attivo) validati dall’ultima serie completa del 30/11/2025; rollback: reimpostare `continue-on-error` e limitare i trigger a `push`/`workflow_dispatch` se i KO di schema/glossario (log run3) persistono.
+  2. **schema-validate.yml** enforcing su variazioni schema/lint (core + config/schemas) con trigger `pull_request` e ultimo run verde 30/11/2025; rollback: sospendere l’obbligatorietà del check e tornare a dispatch manuale.
+  3. **validate-naming.yml** confermato gate PR (`pull_request` attivo, `continue-on-error` rimosso) con ultimo log **run4 – 06/12/2025** in PASS; rollback consultivo post-05/12/2025: tornare a `push`/`workflow_dispatch` e ripristinare `continue-on-error` se riemergono falsi positivi.
+  4. **incoming-smoke.yml** previsto su `pull_request` con filtro `incoming/**` + `workflow_dispatch` manuale; log assenti dopo il 05/12/2025 e retry dispatch ancora aperto. Rollback consultivo: rimuovere il trigger PR e mantenere solo il dispatch manuale se i guardrail smoke risultano bloccanti.
+  5. Workflow monitorati aggiuntivi: **deploy-test-interface.yml**, **hud.yml**, **qa-export.yml**, **qa-reports.yml**, **evo-batch.yml** (stato dettagliato in `ci-inventory.md`); nessun gate PR, ma mantenere dispatch manuali e considerare rollback a skip/consultivo per blocchi infrastrutturali documentati dopo il 05/12/2025.
 - Decisioni storiche mantenute solo per audit (non operative):
   - **Decisione 2026-04-20**: `validate-naming.yml` in modalità consultiva con PR disattivato su `patch/01C-tooling-ci-catalog` (superata dalla promozione del 30/11/2025).
   - **Verifica 2026-04-26**: conferma dello stato consultivo e assenza di 3 run verdi consecutivi (archiviata, sostituita dalla milestone 07/12/2025).
@@ -77,7 +77,7 @@ Stato: PATCHSET-00 – completata una serie di 3 run verdi per `data-quality.yml
   | incoming-smoke.yml   | 2026-04-12 smoke consultivo su dispatch manuale                            | 2025-11-30 PR + dispatch con guardrail; rollback: solo dispatch                            |
   | derived_checksum.yml | 2026-04-12 consultivo (continue-on-error, push/PR su derived)              | 2025-12-07 consultivo invariato ma allineato ai trigger 2025 e pronto per promozione       |
 
-- Reminder check mancanti: drift `data/derived/**` vs sorgenti non ancora monitorato (coperto da audit checksum consultivo); gating incoming ancora limitato al profilo smoke (paths `incoming/**`) + eventuale uso manuale di `scripts/report_incoming.sh` per triage. KO/dispatch aperti del 05/12/2025: incoming-smoke (retry manuale), raccolta artefatti QA export/reports, HUD dispatch in corso.
+- Reminder check mancanti: drift `data/derived/**` vs sorgenti non ancora monitorato (coperto da audit checksum consultivo); gating incoming ancora limitato al profilo smoke (paths `incoming/**`) + eventuale uso manuale di `scripts/report_incoming.sh` per triage. KO/dispatch aperti post 05/12/2025: incoming-smoke (retry manuale), raccolta artefatti QA export/reports, HUD dispatch non archiviato, data-quality run3 da correggere e rerun.
 
 ### Audit checksum derived (consultivo → enforcing)
 

--- a/docs/planning/ci-inventory.md
+++ b/docs/planning/ci-inventory.md
@@ -67,12 +67,13 @@ Questa pagina riepiloga i workflow GitHub Actions e gli script locali citati dal
 
 ### Azioni aperte (aggiornato)
 
-- **data-quality.yml** – Owner: data. Correggere gli errori di schema (`schema_version`/`trait_glossary` mancanti, `data/core/species.yaml` non conforme) e rerun archiviando il log.
+- **data-quality.yml** – Owner: data. Correggere gli errori di schema (`schema_version`/`trait_glossary` mancanti, `data/core/species.yaml` non conforme) dal run3 30/11/2025 e rerun archiviando il log; rollback consultivo se i blocchi persistono (ripristino `continue-on-error` + trigger push/dispatch).
 - **ci.yml** – Owner: dev-tooling. Trigger push/PR su branch di riferimento e salvare log/artefatti in `logs/ci_runs/`.
 - **e2e.yml** – Owner: QA. Dispatch manuale su `main` con download del report Playwright in `logs/ci_runs/e2e_*`.
 - **QA suite** – Owner: QA. Rerun `qa-export.yml` e `qa-reports.yml` con upload artefatti, e aggiornare `qa-kpi-monitor.yml` includendo `logs/visual_runs`; `qa-export.yml` non eseguito in locale (gh non raggiungibile), vedi `logs/agent_activity.md`.
-- **hud.yml** – Owner: HUD. Dispatch con build overlay e, se prodotti, log visual in `logs/visual_runs/`; run del 05/12 non reperibile/artefatti mancanti in locale (vedi `logs/agent_activity.md`).
-- **incoming-smoke.yml** – Owner: dev-tooling. Dispatch manuale da ripetere su dataset completo (smoke non eseguito in locale, gh non disponibile); valutare rollback a solo `workflow_dispatch` PR se i guardrail restano bloccanti.
+- **hud.yml** – Owner: HUD. Dispatch con build overlay e, se prodotti, log visual in `logs/visual_runs/`; run del 05/12 non reperibile/artefatti mancanti in locale (vedi `logs/agent_activity.md`); possibile rollback consultivo a skip se i blocchi infrastrutturali restano.
+- **incoming-smoke.yml** – Owner: dev-tooling. Dispatch manuale da ripetere su dataset completo (smoke non eseguito in locale, gh non disponibile); rollback consultivo previsto: togliere il trigger PR mantenendo solo `workflow_dispatch` se i guardrail smoke restano bloccanti.
+- **validate-naming.yml** – Owner: data. Ultimo log PASS run4 06/12/2025; mantenere gate PR attivo, ma in caso di falsi positivi post-05/12/2025 usare rollback consultivo (push/dispatch + `continue-on-error`).
 - **evo-batch.yml** – Owner: ops/dev-tooling. Nessun log dry-run `batch=traits`: schedulato nuovo dry-run manuale con log da salvare in `logs/ci_runs` prima di decidere l'esecuzione con `execute=true`.
 
 


### PR DESCRIPTION
## Summary
- aggiorna lo stato corrente di REF_TOOLING_AND_CI con i run più recenti e le note di rollback post 05/12/2025
- riallinea l'ordine di abilitazione CI ai log fino al 06/12/2025 mantenendo le azioni aperte e i guardrail
- estende in ci-inventory le azioni aperte includendo opzioni di rollback consultivo e il gate validate-naming

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693387daf56c83289189b0c0575077cc)