### PR TITLE
Add GitHub CLI setup guidance and ci-log-harvest reminder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,4 +165,5 @@ update-tracker:
         $(EVO_TRACKER_UPDATE) ${EVO_VERBOSE_FLAG} $(TRACKER_CHECK_FLAG) $(if $(BATCH),--batch "${BATCH}",)
 
 ci-log-harvest:
-        bash scripts/ci_log_harvest.sh $(if $(CI_LOG_HARVEST_CONFIG),--config "${CI_LOG_HARVEST_CONFIG}",)
+	command -v gh >/dev/null 2>&1 || { echo "GitHub CLI (gh) non trovata: installa 'brew install gh' o 'sudo apt update && sudo apt install gh' e autentica un PAT con scope workflow/read:org (SSO se richiesto)."; exit 1; }
+	bash scripts/ci_log_harvest.sh $(if $(CI_LOG_HARVEST_CONFIG),--config "${CI_LOG_HARVEST_CONFIG}",)

--- a/README.md
+++ b/README.md
@@ -63,19 +63,28 @@ evo-tactics/
 ## Setup rapido
 
 1. **Clona il repository** e posizionati nella root.
-2. **Dipendenze Node (root + tools/ts + dashboard)**:
+2. **Installa GitHub CLI (`gh`)** per poter usare i workflow CI e gli script di automazione:
+   ```bash
+   # macOS (Homebrew)
+   brew install gh
+
+   # Debian/Ubuntu
+   sudo apt update && sudo apt install gh
+   ```
+   Autenticati con un PAT che includa gli scope `workflow` e `read:org`, autorizzato via SSO dove richiesto (puoi seguire la guida in `docs/workflows/gh-cli-manual-dispatch.md`).
+3. **Dipendenze Node (root + tools/ts + dashboard)**:
    ```bash
    npm install
    npm --prefix tools/ts install
    npm --prefix apps/dashboard install
    ```
-3. **Dipendenze Python**:
+4. **Dipendenze Python**:
    ```bash
    python3 -m venv .venv
    source .venv/bin/activate
    pip install -r tools/py/requirements.txt
    ```
-4. (Facoltativo) Esporta variabili condivise per ambienti ottimizzati:
+5. (Facoltativo) Esporta variabili condivise per ambienti ottimizzati:
    ```bash
    export GAME_MODE=optimized
    export PYTHONPATH=tools/py

--- a/docs/planning/ci-log-automation.md
+++ b/docs/planning/ci-log-automation.md
@@ -8,6 +8,18 @@ Questo documento centralizza i comandi per scaricare i log/artefatti dei workflo
 - Accesso di rete a GitHub Actions.
 - Permessi di scrittura locali nelle cartelle di destinazione (`logs/ci_runs`, `logs/visual_runs`, `logs/incoming_smoke`).
 
+### Installazione rapida
+
+```bash
+# macOS (Homebrew)
+brew install gh
+
+# Debian/Ubuntu
+sudo apt update && sudo apt install gh
+```
+
+Autenticati con un PAT che includa gli scope `workflow` e `read:org`, autorizzato via SSO dove richiesto; consulta `docs/workflows/gh-cli-manual-dispatch.md` per i passaggi.
+
 ## Workflow coperti e destinazioni standard
 
 | Workflow | Trigger principale | Modalità | Destinazione download | Note/Inputs |


### PR DESCRIPTION
## Summary
- add GitHub CLI requirement with install commands and PAT scope notes to the main setup guide
- provide a quick-install block for GitHub CLI in the CI log automation prerequisites
- remind the ci-log-harvest target to install/authenticate gh when missing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69339605030c8328ade31aa9c5b360fc)