### PR TITLE
Enhance CI log harvesting with PAT archive support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,5 +165,9 @@ update-tracker:
         $(EVO_TRACKER_UPDATE) ${EVO_VERBOSE_FLAG} $(TRACKER_CHECK_FLAG) $(if $(BATCH),--batch "${BATCH}",)
 
 ci-log-harvest:
-	command -v gh >/dev/null 2>&1 || { echo "GitHub CLI (gh) non trovata: installa 'brew install gh' o 'sudo apt update && sudo apt install gh' e autentica un PAT con scope workflow/read:org (SSO se richiesto)."; exit 1; }
-	bash scripts/ci_log_harvest.sh $(if $(CI_LOG_HARVEST_CONFIG),--config "${CI_LOG_HARVEST_CONFIG}",)
+        command -v gh >/dev/null 2>&1 || { echo "GitHub CLI (gh) non trovata: installa 'brew install gh' o 'sudo apt update && sudo apt install gh'."; exit 1; }
+        @if [ -z "${CI_LOG_PAT}${LOG_HARVEST_PAT}${GH_TOKEN}${GITHUB_TOKEN}" ]; then \
+                echo "Impostare CI_LOG_PAT (consigliato) o LOG_HARVEST_PAT/GH_TOKEN con un PAT GitHub (workflow, read:org, repo admin) autenticato SSO."; \
+                exit 1; \
+        fi
+        bash scripts/ci_log_harvest.sh $(if $(CI_LOG_HARVEST_CONFIG),--config "${CI_LOG_HARVEST_CONFIG}",)

--- a/docs/planning/ci-inventory.md
+++ b/docs/planning/ci-inventory.md
@@ -69,7 +69,7 @@ Questa pagina riepiloga i workflow GitHub Actions e gli script locali citati dal
 
 ### Azioni aperte (aggiornato)
 
-- **Raccolta automatica log** – Configurare/abilitare lo script `gh run list --workflow <file> --limit 1 --json databaseId,status` → `gh run download <id> --dir <dest>` usando un PAT con scope `workflow/read:org` **e** permessi repo/admin per sbloccare il download zip dei log (attualmente solo le pagine HTML pubbliche sono archiviabili). Applicare a tutti i workflow con trigger push/PR/cron.
+- **Raccolta automatica log** – Configurare/abilitare lo script `gh run list --workflow <file> --limit 1 --json databaseId,status` → `gh run download <id> --dir <dest>` usando un PAT con scope `workflow/read:org` **e** permessi repo/admin (esposto come `CI_LOG_PAT`/`LOG_HARVEST_PAT` → `GH_TOKEN`) per sbloccare il download zip dei log oltre alle pagine HTML. Applicare a tutti i workflow con trigger push/PR/cron.
 - **ci.yml** – Owner: dev-tooling. Ultimo run4960 (06/12) in PASS con log HTML salvato; mantenere monitoraggio e abilitare PAT con permessi adeguati per scaricare i pacchetti log zip in automatico.
 - **e2e.yml** – Owner: QA. Ultimo run38 (06/12) in PASS con log HTML salvato; mantenere la raccolta automatica e abilitare PAT con permessi repo per il download zip completo.
 - **data-quality.yml** – Owner: data. Ultimo run171 (03/12) in FAILURE; necessario fix + rerun e download log (zip bloccato senza permessi admin, salvata solo pagina HTML).

--- a/docs/planning/ci-log-automation.md
+++ b/docs/planning/ci-log-automation.md
@@ -4,7 +4,7 @@ Questo documento centralizza i comandi per scaricare i log/artefatti dei workflo
 
 ## Prerequisiti
 
-- GitHub CLI (`gh`) installato e autenticato con un PAT che abbia scope `workflow` e `read:org`, autorizzato via SSO.
+- GitHub CLI (`gh`) installato e autenticato con un PAT che abbia scope `workflow`, `read:org` **e** permessi repo/admin, autorizzato via SSO. Salvalo come secret `CI_LOG_PAT` (preferito) o `LOG_HARVEST_PAT` e rendilo disponibile come `GH_TOKEN`/`GITHUB_TOKEN` per l’automazione.
 - Accesso di rete a GitHub Actions.
 - Permessi di scrittura locali nelle cartelle di destinazione (`logs/ci_runs`, `logs/visual_runs`, `logs/incoming_smoke`).
 
@@ -18,7 +18,7 @@ brew install gh
 sudo apt update && sudo apt install gh
 ```
 
-Autenticati con un PAT che includa gli scope `workflow` e `read:org`, autorizzato via SSO dove richiesto; consulta `docs/workflows/gh-cli-manual-dispatch.md` per i passaggi.
+Autenticati con un PAT che includa gli scope `workflow` e `read:org` più permessi repo/admin, autorizzato via SSO dove richiesto; consulta `docs/workflows/gh-cli-manual-dispatch.md` per i passaggi.
 
 ## Workflow coperti e destinazioni standard
 
@@ -47,8 +47,8 @@ Per workflow non elencati qui (es. `data-quality.yml`, `schema-validate.yml`, `v
   - Formato: `workflow_file|destinazione|modalità|dispatch_inputs`
   - Modalità: `auto` (solo download) oppure `manual` (skip di default, dispatch se `DISPATCH_MANUAL=1`).
 - Per ogni workflow esegue:
-  1. `gh run list --workflow <file> --limit 1 --json databaseId,status,conclusion` per prendere l’ultimo run.
-  2. Se il run è `completed`, scarica gli artefatti con `gh run download <id> --dir <destinazione>`.
+  1. `gh run list --workflow <file> --limit 1 --json databaseId,status,conclusion` per prendere l’ultimo run (autenticato con `GH_TOKEN` impostato dal PAT dei secret sopra).
+  2. Se il run è `completed`, salva la pagina HTML del run, scarica i log zipped via API (`.../runs/<id>/logs`) e scarica gli artefatti sia estratti sia come archivio `.zip` (`gh run download --archive`).
   3. Per i manuali, se `DISPATCH_MANUAL=1`, lancia `gh workflow run <file> --ref <branch> <dispatch_inputs>`; opzionale attesa con `WAIT_FOR_COMPLETION=1`.
 
 ### Esempi d’uso


### PR DESCRIPTION
## Descrizione
- aggiunto supporto per PAT con permessi workflow/read:org e repo admin nello script di raccolta log, usando variabili CI_LOG_PAT/LOG_HARVEST_PAT come sorgente del token
- estesa la raccolta per salvare pagina HTML, archivio log zip e artefatti (estratti + zip) per ogni run, includendo destinazioni visual e incoming
- aggiornati riferimenti documentali e il target Makefile per riflettere il nuovo requisito di secret e i percorsi di download

## Testing
- bash -n scripts/ci_log_harvest.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934250992088328af2882b003302d5c)