### PR TITLE
Add readiness log entry for 01B/01C

### DIFF
--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -3,6 +3,9 @@
 # 2025-12-07 – Verifica `_holding` e finestra 2025-10-06→2025-10-13 (archivist)
 - Step: `[INCOMING-HOLDING-CHECK-2025-12-07T2228Z] owner=archivist (supporto coordinator); modalità=report-only; files=logs/agent_activity.md,incoming/README.md; esito=PASS; note=Controllato `incoming/_holding`: directory assente, nessun drop in parcheggio da integrare o archiviare. Verificata finestra freeze 2025-10-06T09:00Z→2025-10-13T18:00Z: stato attuale SBLOCCATO (ticket 2025-10-FREEZE già approvato), nessun freeze attivo; decisione operativa: mantenere catalogo invariato in sola lettura senza movimenti.`
 
+## 2026-09-17 – Readiness 01B/01C report-only (archivist)
+- Step: `[01B01C-READINESS-2026-09-17T1200Z] owner=archivist (on-call species-curator, trait-curator, dev-tooling; approvatore Master DD); branch=patch/01B-core-derived-matrix,patch/01C-tooling-ci-catalog; modalità=report-only; ticket=[TKT-01B],[TKT-01C]; esito=PASS; note=Readiness registrata per le attività 01B/01C con soli controlli consultivi; nessuna patch applicata ai pack core/derived/incoming, mantenendo i cataloghi in sola lettura finché non arriva il via libera.`
+
 # 2025-12-07 – Kickoff PATCHSET-00 e routing 01A→01C (coordinator)
 - Step: `[RIAPERTURA-2025-02-KICKOFF-2025-12-07T2226Z] owner=Master DD + coordinator; scope=PATCHSET-00 (routing agenti 01A→01C); timeline=2025 (chiusura 2025-12-07); freeze_window=2025-10-06→2025-10-13; note=Kickoff registrato con ID log RIAPERTURA-2025-02, ribadito il freeze attivo 2025-10-06→2025-10-13 e l’obbligo di rispettare la finestra prima di ogni drop.`
 


### PR DESCRIPTION
## Summary
- add a report-only readiness entry for 01B/01C in logs/agent_activity.md
- document on-call agents, branches, active tickets, and absence of pack changes

## Testing
- not run (not required)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69360234a0d08328afead7e19069dc3f)