### PR TITLE
Add logs for workflow dispatch attempts

### DIFF
--- a/logs/ci_runs/deploy-test-interface_20251208T210443Z.log
+++ b/logs/ci_runs/deploy-test-interface_20251208T210443Z.log
@@ -1,0 +1,3 @@
+Dispatching deploy-test-interface at 20251208T210443Z
+To get started with GitHub CLI, please run:  gh auth login
+Alternatively, populate the GH_TOKEN environment variable with a GitHub API authentication token.

--- a/logs/ci_runs/hud_20251208T210443Z.log
+++ b/logs/ci_runs/hud_20251208T210443Z.log
@@ -1,0 +1,1 @@
+HUD flag not set; skipping hud.yml dispatch.

--- a/logs/incoming_smoke/incoming-smoke_20251208T210443Z.log
+++ b/logs/incoming_smoke/incoming-smoke_20251208T210443Z.log
@@ -1,0 +1,13 @@
+Dispatching incoming-smoke at 20251208T210443Z
+unknown shorthand flag: 'b' in -b
+
+Usage:  gh workflow run [<workflow-id> | <workflow-name>] [flags]
+
+Flags:
+  -F, --field key=value       Add a string parameter in key=value format, respecting @ syntax (see "gh help api").
+      --json                  Read workflow inputs as JSON via STDIN
+  -f, --raw-field key=value   Add a string parameter in key=value format
+  -r, --ref string            The branch or tag name which contains the version of the workflow file you'd like to run
+  
+To get started with GitHub CLI, please run:  gh auth login
+Alternatively, populate the GH_TOKEN environment variable with a GitHub API authentication token.


### PR DESCRIPTION
## Summary
- attempted to dispatch incoming-smoke and deploy-test-interface workflows and captured the CLI responses
- noted the HUD workflow was skipped because the HUD flag was not set

## Testing
- not run (logging-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69373d22739c832894c48fe6a8b804fe)