### PR TITLE
Add RIAPERTURA-2025-02 readiness check log

### DIFF
--- a/logs/RIAPERTURA-2025-02.md
+++ b/logs/RIAPERTURA-2025-02.md
@@ -1,0 +1,16 @@
+# RIAPERTURA-2025-02 – Verifica branch 01B/01C e readiness (report-only)
+
+## Sintesi esito
+- **Branch dedicati assenti**: `patch/01B-core-derived-matrix` e `patch/01C-tooling-ci-catalog` non risultano presenti né localmente né sui remoti monitorati al momento della verifica.
+- **Disponibilità owner confermata**: species-curator e trait-curator restano on-call per 01B (matrice core/derived), dev-tooling on-call per 01C (tooling/CI), con operatività **report-only** sui branch dedicati.
+- **Ticket attivi invariati**: 01B → `TKT-01B-001`, `TKT-01B-002`; 01C → `TKT-01C-001`, `TKT-01C-002`. Nessuna variazione di scope/owner segnalata.
+- **Freeze/unfreeze**: si mantiene il perimetro della finestra documentale 06/10/2025 → 13/10/2025; le attività restano **report-only fino a unfreeze** esplicito.
+
+## Dettaglio verifica
+- **Controllo branch**: eseguito `git branch -a --list 'patch/01B-core-derived-matrix' 'patch/01C-tooling-ci-catalog'` e `git branch -r --list 'patch/01B-core-derived-matrix' 'patch/01C-tooling-ci-catalog'` → nessuna corrispondenza trovata.
+- **Conferma owner/ticket**: fonti di stato (`reports/readiness_01B01C_status.md`, `docs/planning/REF_PLANNING_RIPRESA_2026.md`) confermano che 01B/01C sono in modalità report-only con owner species-curator/trait-curator/dev-tooling e ticket TKT-01B-001/002, TKT-01C-001/002.
+- **Stato operativo**: mantenere logging in STRICT MODE; non aprire nuovi drop o modifiche finché l’unfreeze della finestra 06/10/2025 → 13/10/2025 non viene registrato.
+
+## Azioni suggerite (senza esecuzione)
+- Ricreare i branch dedicati da HEAD autorizzato prima del prossimo batch report-only.
+- Aggiornare `logs/agent_activity.md` se viene emessa una decisione di unfreeze o se vengono riattivati i branch.


### PR DESCRIPTION
## Summary
- add RIAPERTURA-2025-02 log capturing branch checks for patch/01B and patch/01C
- document owner availability, active tickets, and freeze window with report-only status until unfreeze

## Testing
- not run (doc-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937501609a48328978b7628ab8b8140)