### PR TITLE
Add PATCHSET-00 kickoff agenda and gate log

### DIFF
--- a/docs/planning/agenda_PATCHSET-00_2025-12-07.md
+++ b/docs/planning/agenda_PATCHSET-00_2025-12-07.md
@@ -1,0 +1,21 @@
+# Agenda breve – Kickoff PATCHSET-00 (15')
+
+## Scope
+
+- Allineare il perimetro PATCHSET-00 con trigger sequenziale Fase 1 → Fase 2 → Fase 3.
+- Ribadire timeline di completamento al **07/12/2025** e dipendenze verso pipeline 01A.
+- Verificare owner e agenti coinvolti: **owner=coordinator**; agenti attivi: coordinator, archivist, trait-curator, species-curator.
+
+## Sequenza meeting (15')
+
+1. **00:00–02:00** – Apertura e obiettivi (coordinator).
+2. **02:00–05:00** – Stato pre-kickoff & readiness log/README (archivist).
+3. **05:00–09:00** – Trigger Fase 1 → 2 → 3 e prerequisiti pipeline 01A (trait-curator + species-curator).
+4. **09:00–12:00** – Rischi/contromisure e conferma timeline 07/12/2025 (tutti).
+5. **12:00–15:00** – Decisioni, prossimo gate (passaggio a pipeline 01A) e log finale (coordinator).
+
+## Output attesi
+
+- Conferma scope PATCHSET-00 e percorso Fase 1→2→3.
+- Decisione su handoff verso pipeline 01A e checkpoint per gate successivo.
+- Note archiviate in `logs/agent_activity.md` e aggiornamento `logs/RIAPERTURA-2025-02.md` post-kickoff.

--- a/logs/RIAPERTURA-2025-02.md
+++ b/logs/RIAPERTURA-2025-02.md
@@ -14,3 +14,8 @@
 ## Azioni suggerite (senza esecuzione)
 - Ricreare i branch dedicati da HEAD autorizzato prima del prossimo batch report-only.
 - Aggiornare `logs/agent_activity.md` se viene emessa una decisione di unfreeze o se vengono riattivati i branch.
+
+## 2026-09-20 – Kickoff PATCHSET-00 e gate verso pipeline 01A (coordinator)
+- Step: `[RIAPERTURA-2025-02-KICKOFF-2026-09-20T0000Z] owner=coordinator (con archivist, trait-curator, species-curator; approvatore Master DD); scope=PATCHSET-00; timeline=07/12/2025; durata=15'`; riferimento agenda: `docs/planning/agenda_PATCHSET-00_2025-12-07.md`.
+- Decisioni: confermato trigger sequenziale Fase 1→Fase 2→Fase 3, perimetro invariato in STRICT MODE, readiness log/README gestita da archivist; trait-curator e species-curator on-call per prerequisiti 01A.
+- Prossimo gate: `PIPELINE 01A → Fase 1` (handoff post-kickoff); prerequisiti: log aggiornati (`logs/agent_activity.md`), nessun drop nuovo in `_holding`, freeze 06/10/2025→13/10/2025 rispettato.


### PR DESCRIPTION
## Summary
- add a 15-minute PATCHSET-00 kickoff agenda with scope, timeline, and agents involved
- log kickoff decisions and gate toward pipeline 01A in RIAPERTURA-2025-02

## Testing
- npx prettier --write docs/planning/agenda_PATCHSET-00_2025-12-07.md

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693753b096808328b0630e2d22673892)