### PR TITLE
Add pipeline 01A pre-meeting checklist

### DIFF
--- a/logs/RIAPERTURA-2025-02.md
+++ b/logs/RIAPERTURA-2025-02.md
@@ -16,6 +16,13 @@
 - Ricreare i branch dedicati da HEAD autorizzato prima del prossimo batch report-only.
 - Aggiornare `logs/agent_activity.md` se viene emessa una decisione di unfreeze o se vengono riattivati i branch.
 
+## Checklist PIPELINE 01A (pre-meeting)
+- [ ] `logs/agent_activity.md` aggiornato con l'ultimo handoff rilevante.
+- [ ] Cartella `_holding/` vuota (nessun drop in sospeso).
+- [ ] Trait-curator: conferma prerequisiti dati/trait per l'avvio di 01A.
+- [ ] Species-curator: conferma prerequisiti specie collegati a 01A.
+- [ ] Checklist condivisa ai partecipanti prima del meeting.
+
 ## 2026-09-20 – Kickoff PATCHSET-00 e gate verso pipeline 01A (coordinator)
 - Step: `[RIAPERTURA-2025-02-KICKOFF-2026-09-20T0000Z] owner=coordinator (con archivist, trait-curator, species-curator; approvatore Master DD); scope=PATCHSET-00; timeline=07/12/2025; durata=15'`; riferimento agenda: `docs/planning/agenda_PATCHSET-00_2025-12-07.md`.
 - Decisioni: confermato trigger sequenziale Fase 1→Fase 2→Fase 3, perimetro invariato in STRICT MODE, readiness log/README gestita da archivist; trait-curator e species-curator on-call per prerequisiti 01A.


### PR DESCRIPTION
## Summary
- add a pre-meeting checklist for pipeline 01A in the reopening log
- include updates for agent activity log, _holding cleanup, and curator confirmations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693757c828f883289e989bbf2ca65c23)