### PR TITLE
Add severity-based workflow guidance

### DIFF
--- a/.ai/BOOT_PROFILE.md
+++ b/.ai/BOOT_PROFILE.md
@@ -179,7 +179,19 @@ Impatto: in profili leggeri, l’agente resta vincolato a identità e router ma 
 
 ---
 
-## 5. Profilo di boot “LIGHT” (task a basso rischio / consultazioni rapide)
+## 5. Tabella severità e workflow
+
+| Severità  | Piano                                                                                                | Self-critique                                                                                   | Note operative                                                                                              |
+| --------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| **BASSO** | Piano breve (1–3 punti) focalizzato sui file toccati; consentito saltare step intermedi non critici. | Può essere omessa per output sintetici, mantenendo comunque coerenza con agent_constitution.md. | Usa Strict Mode e routing; Command Library/Golden Path opzionali; ideale per refusi e aggiornamenti minimi. |
+| **MEDIO** | Piano completo (3–7 punti) con evidenza dei rischi.                                                  | Obbligatoria, con nota esplicita di eventuali punti deboli.                                     | Valuta se abilitare Command Library e Golden Path se servono macro-azioni.                                  |
+| **ALTO**  | Piano dettagliato (5–10 punti) + sandbox se impatta formati/core loop.                               | Obbligatoria e approfondita; richiedi review umana.                                             | Attiva tutti gli strumenti di boot e documenta le decisioni.                                                |
+
+Questa tabella riduce il workflow per i task BASSO consentendo un piano più breve e l’assenza di self-critique quando l’output è molto sintetico, mantenendo comunque i vincoli di sicurezza e routing.
+
+---
+
+## 6. Profilo di boot “LIGHT” (task a basso rischio / consultazioni rapide)
 
 Usare quando il compito è di sola consultazione, QA rapido o verifica documentale senza esecuzioni di pipeline/command macro.
 

--- a/agent.md
+++ b/agent.md
@@ -107,11 +107,12 @@ Usato prima di ogni output importante:
 
 2. **Classificazione rischio**
    - BASSO / MEDIO / ALTO.
+   - BASSO → workflow ridotto: piano breve (1–3 punti) e self-critique opzionale solo se l’output è sintetico e a basso impatto.
    - MEDIO → avvisa.
    - ALTO → sandbox-mode + richiesta conferma.
 
 3. **Piano sintetico**
-   - 3–10 punti su cosa farà.
+   - 3–10 punti su cosa farà (1–3 punti per il caso BASSO).
    - Elenco cartelle/file coinvolti.
 
 4. **Esecuzione**
@@ -119,8 +120,8 @@ Usato prima di ogni output importante:
    - Usa strict-mode.
 
 5. **Self-critique**
-   - Rilegge l’output.
-   - Segnala problemi e li corregge se possibile.
+   - Rilegge l’output (può essere saltata nei casi BASSO con output minimale).
+   - Segnala problemi e li corregge se possibile; obbligatoria per MEDIO/ALTO.
 
 6. **Output finale**
    - Pulito, strutturato, in stile repo.


### PR DESCRIPTION
## Summary
- add a severity/workflow table to BOOT_PROFILE to clarify reduced steps for low-risk tasks
- align the agent thought cycle with the severity-based workflow guidance

## Testing
- n/a (documentation updates only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69376ab03f4883288e6e48a9d044e6b1)