### PR TITLE
Document default-coordinator mode in router

### DIFF
--- a/router.md
+++ b/router.md
@@ -9,6 +9,7 @@ verso i vari agenti presenti nel progetto, secondo:
 - profili in .ai/
 
 Il contenuto di questo file DEVE essere letto a inizio sessione Codex insieme a:
+
 - MASTER_PROMPT.md
 - .ai/GLOBAL_PROFILE.md
 
@@ -49,8 +50,8 @@ Se l’utente NON indica “AGENTE: …”, comportati così:
    - archivist → indici, refactor documentazione
    - dev-tooling → script, tool
    - trait-curator → trait, normalizzazione, cataloghi
-   - species-curator* → specie avanzate (se presente)
-   - biome-curator* → ecosistemi (se presente)
+   - species-curator\* → specie avanzate (se presente)
+   - biome-curator\* → ecosistemi (se presente)
 
 3. Se un agente è appropriato:
    - Dichiaralo apertamente:
@@ -62,6 +63,12 @@ Se l’utente NON indica “AGENTE: …”, comportati così:
 
 4. Se NESSUN agente è appropriato:
    - Rispondi come assistente generale sul repo.
+
+### Modalità default-coordinator (AUTO_ROUTER)
+
+- Per richieste generiche o miste che non richiedono un agente specifico, attiva automaticamente il **default-coordinator** senza necessità di dichiarazione esplicita.
+- Quando scatta il default-coordinator, il router DEVE loggare nella risposta la scelta effettuata (es.: “Modalità default-coordinator: instradato a coordinator per richiesta generica/mista”).
+- Il coordinator tratta la richiesta come fallback intelligente, mantenendo strict-mode e gli altri vincoli del router.
 
 ---
 
@@ -101,7 +108,12 @@ ooppure:
 
 ---
 
-# 6. Versionamento
+# 6. Esempi rapidi per richieste miste
+
+- "Mi serve un breve piano di missione e, se serve, aggiungi due idee visive base" → default-coordinator attivo, log nella risposta e suddivisione del task verso coordinator con eventuale consulto di asset-prep se necessario.
+- "Fammi un sommario delle regole e proponi un bilanciamento iniziale" → default-coordinator attivo; la risposta deve indicare il log di routing e, se opportuno, segnalare coinvolgimento balancer come passo successivo.
+
+# 7. Versionamento
 
 - v1.0 – Prima versione del router automatico agenti.
 


### PR DESCRIPTION
## Descrizione
- Documentata la modalità default-coordinator per le richieste generiche/miste, con log automatico della scelta.
- Aggiunti esempi rapidi su come gestire richieste miste e indicare il routing implicito.

## Checklist guida stile & QA
- [ ] Nessuna modifica a `data/core/**`, `data/derived/**`, `incoming/**`, `docs/incoming/**` nella finestra freeze 2025-11-25T12:05Z–2025-11-27T12:05Z (salvo rollback autorizzati Master DD)
- [ ] Validator di release **PASS senza regressioni** (allega percorso report). Il merge rimane bloccato finché esistono regressioni aperte nel validator
- [ ] Approvazione **Master DD** registrata (link a commento/issue che conferma l'ok al merge)
- [ ] Changelog allegato alla PR e **piano di rollback 03A** incluso (link o allegato nella sezione Note)
- [ ] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate
- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa
- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati
- [ ] Eseguito `scripts/trait_style_check.js` (allega percorso report/artifact)
- [ ] Badge "Guida stile" dell'editor in stato "In linea" (suggerimenti applicabili gestiti)
- [ ] Generato `tools/py/styleguide_compliance_report.py` (link a JSON/Markdown)
- [ ] Aggiornato bridge `logs/qa/latest-dashboard-metrics.json` se il report è stato rigenerato
- [x] Documentazione/processi aggiornati ove necessario

## Testing
- [ ] `npm run style:check`
- [x] Altro: `npx prettier --write router.md`

## Note
- Aggiornamento limitato alla documentazione del router; nessun altro artefatto toccato.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69376b8a7b248328908c2a344401fc82)