### PR TITLE
Add boot cheat sheet prompts

### DIFF
--- a/.ai/BOOT_PROFILE.md
+++ b/.ai/BOOT_PROFILE.md
@@ -1,10 +1,10 @@
 # BOOT_PROFILE – Avvio globale sistema agenti (GOLDEN PATH)
 
-Versione: 1.0  
+Versione: 1.0
 Progetto: Game / Evo Tactics
 
 Questo profilo definisce il comportamento di boot dell’assistente quando lavora
-sul repository **Game**.  
+sul repository **Game**.
 L’obiettivo è attivare automaticamente:
 
 - la costituzione degli agenti
@@ -12,6 +12,17 @@ L’obiettivo è attivare automaticamente:
 - la Command Library
 - il Golden Path delle pipeline
 - la modalità STRICT MODE (nessun side-effect implicito)
+
+---
+
+## Cheat sheet rapido (avvio)
+
+Usa questi prompt pronti per avviare la sessione senza chiedere conferme ripetute:
+
+- **Avvio completo consigliato**: `Per favore, leggi e applica .ai/BOOT_PROFILE.md. Conferma strict-mode, router automatico, Command Library e Golden Path caricati; elenca gli agenti disponibili.`
+- **Avvio inline** (equivalente a BOOT_PROFILE): `MASTER_ENV` + blocco “Task” della sezione 0.2.
+- **Profilo light** (solo identità + strict-mode, senza Golden Path): `SETUP SESSIONE AGENTI`.
+- **Router rapido** (se lavori senza BOOT_PROFILE): `ATTIVA ROUTER AUTOMATICO`.
 
 ---
 

--- a/docs/COMMAND_LIBRARY.md
+++ b/docs/COMMAND_LIBRARY.md
@@ -15,6 +15,34 @@ Questa libreria raccoglie TUTTI i comandi operativi per:
 
 ---
 
+## Cheat sheet rapido
+
+Prompt pronti all’uso per evitare conferme ripetute. Copia-incolla la voce che ti serve e verifica i prerequisiti indicati.
+
+- **BOOT_PROFILE (avvio consigliato)** — [vai alla sezione](#01--boot_profile-avvio-consigliato)
+  - Prompt: `Per favore, leggi e applica .ai/BOOT_PROFILE.md. Conferma strict-mode, router automatico, Command Library e Golden Path caricati; elenca gli agenti disponibili.`
+  - Prerequisiti: nessuno; usalo all’avvio per avere tutte le protezioni e i riferimenti caricati.
+- **MASTER_ENV (avvio inline)** — [vai alla sezione](#02--master_env-avvio-inline-senza-boot_profile)
+  - Prompt: `MASTER_ENV` seguito dal blocco “Task” indicato nella sezione 0.2 (così attivi bootstrap completo in un unico messaggio).
+  - Prerequisiti: nessuno; alternativa rapida se non vuoi citare il file BOOT_PROFILE.
+- **ATTIVA ROUTER AUTOMATICO** — [vai alla sezione](#11--attivare-il-router-automatico)
+  - Prompt: `ATTIVA ROUTER AUTOMATICO`.
+  - Prerequisiti: serve quando lavori senza BOOT_PROFILE; necessario prima di usare i comandi di pipeline per avere assegnazione agenti.
+- **SETUP SESSIONE AGENTI (profilo light)** — [vai alla sezione](#12--setup-sessione-agente-light)
+  - Prompt: `SETUP SESSIONE AGENTI`.
+  - Prerequisiti: nessuno; carica solo identità, strict-mode e router per consultazioni rapide senza Golden Path.
+- **PIPELINE_DESIGNER** — [vai alla sezione](#21--disegnare-una-pipeline-standard-dal-template)
+  - Prompt: `COMANDO: PIPELINE_DESIGNER` + descrizione chiara della feature da coprire.
+  - Prerequisiti: router automatico attivo; prepara il testo della feature per evitare follow-up.
+- **PIPELINE_EXECUTOR** — [vai alla sezione](#23--eseguire-un-singolo-step)
+  - Prompt: `COMANDO: PIPELINE_EXECUTOR` + pipeline incollata + numero step da eseguire.
+  - Prerequisiti: pipeline già definita; router attivo; specifica file da leggere/scrivere per ridurre chiarimenti.
+- **PIPELINE_SIMULATOR** — [vai alla sezione](#24--simulare-una-pipeline-intera-dry-run)
+  - Prompt: `COMANDO: PIPELINE_SIMULATOR` + pipeline completa.
+  - Prerequisiti: pipeline definita; router attivo; utile per verificare output attesi senza toccare file.
+
+---
+
 # SEZIONE 0 — BOOT & MASTER ENV
 
 Questa sezione definisce come avviare rapidamente l’ambiente agenti completo


### PR DESCRIPTION
## Summary
- expand the Command Library cheat sheet with ready-to-use prompts and explicit prerequisites for common commands
- add a boot-profile cheat sheet section to centralize quick-start prompts for session setup

## Testing
- not run (documentation changes only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69376c66e0d48328b068fb555aee4b0a)