### PR TITLE
Clarify patch confirmation guidance

### DIFF
--- a/.ai/BOOT_PROFILE.md
+++ b/.ai/BOOT_PROFILE.md
@@ -144,6 +144,8 @@ e anche in quel caso:
 
 spiega PRIMA cosa farai
 
+se il comando di patch prevede una conferma esplicita (es. prompt yes/no), non è richiesta una doppia spiegazione preliminare: basta la preview/diff prima della conferma
+
 riepiloga DOPO quali file sono stati modificati.
 
 Mai introdurre slug, file o cartelle non coerenti con gli schemi e le convenzioni del repo.

--- a/docs/PIPELINE_TEMPLATES.md
+++ b/docs/PIPELINE_TEMPLATES.md
@@ -414,5 +414,6 @@ Non eseguire, solo definire la pipeline.
   - agents/agents_index.json
   - .ai/GLOBAL_PROFILE.md
   - (eventualmente router.md, se usi il router automatico).
+- Per i comandi di patch che chiedono conferma esplicita (es. prompt yes/no) non serve una doppia spiegazione preliminare: basta mostrare la preview/diff e attendere il via.
 
 [ FINE FILE ]


### PR DESCRIPTION
## Summary
- Clarified that patch commands with explicit confirmation do not require double preliminary explanations in the BOOT_PROFILE
- Updated pipeline template notes to reflect the explicit-confirmation exception

## Testing
- Not run (docs-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69376e629ad483288512fee8b13220e4)