### PR TITLE
Document fast path policy for command confirmations

### DIFF
--- a/docs/AGENT_COMMANDS_CHEATSHEET.md
+++ b/docs/AGENT_COMMANDS_CHEATSHEET.md
@@ -22,6 +22,25 @@ TASK: <descrizione del task>
 
 ---
 
+## FAST PATH – bypass conferme ridondanti (solo task a basso rischio)
+
+```
+Quando puoi usarlo:
+- Patch piccole (≤100 linee, max 3 file) su documentazione/config non eseguibile.
+- Nessun schema/DB/migrazione o cambi di build/CI.
+- Diff già condivisa/chiara; nessuna ambiguità nel task.
+
+Come attivarlo:
+- Aggiungi `FAST_PATH: true` nel blocco comando (es. PIPELINE_EXECUTOR, APPLICA_PATCHSET_*).
+- L’agente applica la modifica dopo la preview, senza chiedere una seconda conferma, solo se i criteri sopra sono rispettati.
+
+Tracciabilità e limiti:
+- Anche in fast path vengono riportati file toccati, numero linee e motivazione.
+- Se emerge un rischio (file sensibile, patch ampia) il fast path viene annullato e si torna al flusso standard con conferma.
+```
+
+---
+
 ## 1. ROUTER_AUTO – scegliere automaticamente l’agente
 
 (COMANDO)


### PR DESCRIPTION
## Summary
- Document fast path criteria and strict-mode confirmations for commands that mutate files
- Add FAST_PATH options to pipeline executor and patchset application commands
- Extend the agent commands cheatsheet with fast path usage and safety notes

## Testing
- npx prettier --write docs/COMMAND_LIBRARY.md docs/AGENT_COMMANDS_CHEATSHEET.md

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69377294607c83289a84e07e4eeedf6e)