### PR TITLE
Add agent workflow telemetry logging and analysis

### DIFF
--- a/docs/agent_telemetry.md
+++ b/docs/agent_telemetry.md
@@ -1,0 +1,38 @@
+# Telemetria del flusso agenti
+
+## Passaggi chiave del flusso
+- **Scelta agente**: routing esplicito o automatico; registriamo agente richiesto, selezionato e latenza della scelta.
+- **Applicazione comando**: esecuzione dei COMANDO:* o azioni dirette; logghiamo comando, target e durata.
+- **Conferma patch**: decisione sull'applicazione di una patch/diff; logghiamo patch coinvolta, esito e tempo di validazione.
+
+## Tracciamento minimale
+- Logger JSONL in `scripts/agent_flow_telemetry.js`.
+- Eventi persistiti (se abilitato) in `logs/agent_workflow.log` oppure nel path definito da `AGENT_TELEMETRY_PATH`.
+- Metadata ridotti e sanitizzati (stringhe troncate, max 20 elementi in lista) per evitare dati sensibili.
+
+## Come usare
+1. Abilita la telemetria solo quando serve:
+   - `AGENT_TELEMETRY_ENABLED=1` per attivare la scrittura.
+   - `AGENT_TELEMETRY_PATH=/percorso/custom.log` (opzionale) per scegliere il file.
+2. Inserisci i log point nelle funzioni che orchestrano il flusso agenti:
+   - `const telemetry = require('./agent_flow_telemetry');`
+   - `await telemetry.logAgentSelection({ sessionId, requestedAgent, selectedAgent, router, latencyMs, reason });`
+   - `await telemetry.logCommandApplication({ sessionId, command, target, success, durationMs });`
+   - `await telemetry.logPatchConfirmation({ sessionId, patchId, accepted, durationMs });`
+3. Esegui la demo per validare il wiring: `AGENT_TELEMETRY_ENABLED=1 node scripts/agent_flow_telemetry.js --demo`.
+
+## Analisi rapida e colli di bottiglia
+- Genera un report leggibile: `node scripts/analyze_agent_flow.js --log logs/agent_workflow.log --threshold 2500`.
+- Il report mostra:
+  - medie e massimi per step (scelta agente, applicazione comando, conferma patch),
+  - sessioni con durata aggregata più alta,
+  - eventi che superano la soglia di bottleneck.
+- Aumenta/diminuisci la soglia per mettere a fuoco le aree critiche.
+
+## Privacy e prestazioni
+- Nessun log se `AGENT_TELEMETRY_ENABLED` è assente/false.
+- Metadata sanitizzati per evitare payload completi o PII.
+- File JSONL append-only per minimizzare lock e overhead; ruotare il file log via strumenti esterni se cresce troppo.
+
+## Disattivare
+- Rimuovi `AGENT_TELEMETRY_ENABLED` o impostalo a `0/false` per spegnere il tracciamento senza modificare il codice.

--- a/scripts/agent_flow_telemetry.js
+++ b/scripts/agent_flow_telemetry.js
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const DEFAULT_LOG_PATH = path.join(process.cwd(), 'logs', 'agent_workflow.log');
+const TELEMETRY_ENABLED_VALUES = new Set(['1', 'true', 'yes', 'on']);
+
+const isTelemetryEnabled = () => TELEMETRY_ENABLED_VALUES.has(String(process.env.AGENT_TELEMETRY_ENABLED || '').toLowerCase());
+
+const resolveLogPath = () => process.env.AGENT_TELEMETRY_PATH || DEFAULT_LOG_PATH;
+
+const sanitizeMetadata = (metadata) => {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return undefined;
+  }
+
+  const sanitized = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (value === null || value === undefined) continue;
+    const valueType = typeof value;
+    if (valueType === 'string') {
+      sanitized[key] = value.slice(0, 500);
+    } else if (valueType === 'number' || valueType === 'boolean') {
+      sanitized[key] = value;
+    } else if (Array.isArray(value)) {
+      sanitized[key] = value
+        .map((entry) => {
+          if (entry === null || entry === undefined) return null;
+          if (typeof entry === 'string') return entry.slice(0, 120);
+          if (typeof entry === 'number' || typeof entry === 'boolean') return entry;
+          return null;
+        })
+        .filter((entry) => entry !== null)
+        .slice(0, 20);
+    }
+  }
+
+  return Object.keys(sanitized).length ? sanitized : undefined;
+};
+
+const appendEvent = async (payload) => {
+  if (!isTelemetryEnabled()) return null;
+
+  const logPath = resolveLogPath();
+  const event = {
+    timestamp: new Date().toISOString(),
+    ...payload,
+  };
+
+  event.metadata = sanitizeMetadata(event.metadata);
+  await fs.mkdir(path.dirname(logPath), { recursive: true });
+  await fs.appendFile(logPath, `${JSON.stringify(event)}\n`, 'utf8');
+  return logPath;
+};
+
+const logAgentSelection = async ({
+  sessionId,
+  requestedAgent,
+  selectedAgent,
+  router,
+  latencyMs,
+  reason,
+  metadata,
+}) =>
+  appendEvent({
+    step: 'agent_selection',
+    sessionId,
+    requestedAgent,
+    selectedAgent,
+    router,
+    latencyMs,
+    reason,
+    metadata,
+  });
+
+const logCommandApplication = async ({
+  sessionId,
+  command,
+  target,
+  success,
+  durationMs,
+  metadata,
+}) =>
+  appendEvent({
+    step: 'command_application',
+    sessionId,
+    command,
+    target,
+    success,
+    durationMs,
+    metadata,
+  });
+
+const logPatchConfirmation = async ({
+  sessionId,
+  patchId,
+  accepted,
+  durationMs,
+  metadata,
+}) =>
+  appendEvent({
+    step: 'patch_confirmation',
+    sessionId,
+    patchId,
+    accepted,
+    durationMs,
+    metadata,
+  });
+
+const logEvent = async (payload) => appendEvent(payload);
+
+const help = () => {
+  const lines = [
+    '# Uso rapido: agent_flow_telemetry.js',
+    '',
+    'AGENT_TELEMETRY_ENABLED=1 node scripts/agent_flow_telemetry.js --demo',
+    '',
+    'Variabili supportate:',
+    '- AGENT_TELEMETRY_ENABLED=1|true per attivare la scrittura degli eventi',
+    '- AGENT_TELEMETRY_PATH per sovrascrivere logs/agent_workflow.log',
+    '',
+    'API (require):',
+    '- logAgentSelection({ sessionId, requestedAgent, selectedAgent, router, latencyMs, reason, metadata })',
+    '- logCommandApplication({ sessionId, command, target, success, durationMs, metadata })',
+    '- logPatchConfirmation({ sessionId, patchId, accepted, durationMs, metadata })',
+    '- logEvent(payload) per eventi custom',
+  ];
+  console.log(lines.join('\n'));
+};
+
+const runDemo = async () => {
+  const sessionId = `demo-${Date.now()}`;
+  await logAgentSelection({
+    sessionId,
+    requestedAgent: 'auto',
+    selectedAgent: 'dev-tooling',
+    router: 'router.md',
+    latencyMs: 120,
+    reason: 'Task di automazione',
+    metadata: { requestId: 'demo-run' },
+  });
+
+  await logCommandApplication({
+    sessionId,
+    command: 'APPLICA_PATCHSET',
+    target: 'tools/',
+    success: true,
+    durationMs: 2400,
+    metadata: { files: 3 },
+  });
+
+  await logPatchConfirmation({
+    sessionId,
+    patchId: 'demo-patch-01',
+    accepted: true,
+    durationMs: 350,
+    metadata: { reviewer: 'human-ops' },
+  });
+
+  const logPath = resolveLogPath();
+  console.log(`Demo completata. Eventi scritti in ${logPath}`);
+};
+
+const main = async () => {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    help();
+    return;
+  }
+  if (args.includes('--demo')) {
+    if (!isTelemetryEnabled()) {
+      console.error('Demo richiede AGENT_TELEMETRY_ENABLED=1');
+      process.exit(1);
+    }
+    await runDemo();
+    return;
+  }
+  help();
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('Errore telemetria agenti:', error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  logAgentSelection,
+  logCommandApplication,
+  logPatchConfirmation,
+  logEvent,
+  isTelemetryEnabled,
+  resolveLogPath,
+};

--- a/scripts/analyze_agent_flow.js
+++ b/scripts/analyze_agent_flow.js
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const DEFAULT_LOG_PATH = path.join(process.cwd(), 'logs', 'agent_workflow.log');
+
+const parseArgs = () => {
+  const args = process.argv.slice(2);
+  const options = { logPath: DEFAULT_LOG_PATH, thresholdMs: 2000 };
+  for (let i = 0; i < args.length; i += 1) {
+    const token = args[i];
+    if (token === '--help' || token === '-h') {
+      options.help = true;
+      break;
+    } else if (token === '--log' && args[i + 1]) {
+      options.logPath = path.resolve(args[i + 1]);
+      i += 1;
+    } else if (token === '--threshold' && args[i + 1]) {
+      options.thresholdMs = Number(args[i + 1]);
+      i += 1;
+    }
+  }
+  return options;
+};
+
+const readLogLines = async (logPath) => {
+  try {
+    const raw = await fs.readFile(logPath, 'utf8');
+    return raw
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
+};
+
+const parseEvents = (lines) => {
+  const events = [];
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed && typeof parsed === 'object') {
+        events.push(parsed);
+      }
+    } catch (error) {
+      // Ignora righe malformate senza interrompere l'analisi.
+    }
+  }
+  return events;
+};
+
+const summarizeDurations = (events) => {
+  const perStep = new Map();
+  const sessions = new Map();
+
+  for (const event of events) {
+    const { step, durationMs, latencyMs, sessionId } = event;
+    const timing = typeof durationMs === 'number' ? durationMs : typeof latencyMs === 'number' ? latencyMs : null;
+    if (step && timing !== null) {
+      if (!perStep.has(step)) {
+        perStep.set(step, { count: 0, total: 0, max: 0 });
+      }
+      const stats = perStep.get(step);
+      stats.count += 1;
+      stats.total += timing;
+      stats.max = Math.max(stats.max, timing);
+    }
+
+    if (sessionId && timing !== null) {
+      if (!sessions.has(sessionId)) {
+        sessions.set(sessionId, { total: 0, events: 0 });
+      }
+      const bucket = sessions.get(sessionId);
+      bucket.total += timing;
+      bucket.events += 1;
+    }
+  }
+
+  return { perStep, sessions };
+};
+
+const findBottlenecks = (events, thresholdMs) => {
+  const flagged = [];
+  for (const event of events) {
+    const timing = typeof event.durationMs === 'number' ? event.durationMs : typeof event.latencyMs === 'number' ? event.latencyMs : null;
+    if (timing !== null && timing >= thresholdMs) {
+      flagged.push({
+        step: event.step || 'unknown',
+        sessionId: event.sessionId || 'n/a',
+        timing,
+        command: event.command,
+        patchId: event.patchId,
+        timestamp: event.timestamp,
+      });
+    }
+  }
+
+  flagged.sort((a, b) => b.timing - a.timing);
+  return flagged.slice(0, 10);
+};
+
+const formatStepStats = (perStep) =>
+  Array.from(perStep.entries())
+    .map(([step, stats]) => ({
+      step,
+      count: stats.count,
+      avg: stats.count ? Math.round(stats.total / stats.count) : 0,
+      max: Math.round(stats.max),
+    }))
+    .sort((a, b) => b.avg - a.avg);
+
+const printReport = ({ events, perStep, sessions, bottlenecks, options }) => {
+  console.log('=== Agent workflow telemetry ===');
+  console.log(`Log analizzato: ${options.logPath}`);
+  console.log(`Eventi letti: ${events.length}`);
+  console.log('');
+
+  if (!events.length) {
+    console.log('Nessun evento trovato. Abilita la telemetria e riesegui un flusso.');
+    return;
+  }
+
+  console.log('--- Durate per step (ms) ---');
+  for (const entry of formatStepStats(perStep)) {
+    console.log(`- ${entry.step}: avg=${entry.avg} max=${entry.max} (n=${entry.count})`);
+  }
+  console.log('');
+
+  const sessionEntries = Array.from(sessions.entries())
+    .map(([sessionId, stats]) => ({ sessionId, total: stats.total, events: stats.events }))
+    .sort((a, b) => b.total - a.total)
+    .slice(0, 10);
+
+  console.log('--- Sessioni più pesanti ---');
+  for (const entry of sessionEntries) {
+    console.log(`- ${entry.sessionId}: totale=${Math.round(entry.total)}ms su ${entry.events} eventi`);
+  }
+  console.log('');
+
+  console.log(`--- Colli di bottiglia (> ${options.thresholdMs} ms) ---`);
+  if (!bottlenecks.length) {
+    console.log('Nessun evento sopra soglia.');
+  } else {
+    for (const entry of bottlenecks) {
+      console.log(
+        `- ${entry.step} (${entry.sessionId}): ${entry.timing}ms` +
+          (entry.command ? ` command=${entry.command}` : '') +
+          (entry.patchId ? ` patch=${entry.patchId}` : ''),
+      );
+    }
+  }
+};
+
+const main = async () => {
+  const options = parseArgs();
+  if (options.help) {
+    console.log('Usage: node scripts/analyze_agent_flow.js [--log path] [--threshold ms]');
+    console.log('Default log: logs/agent_workflow.log; default threshold: 2000ms');
+    return;
+  }
+
+  const lines = await readLogLines(options.logPath);
+  const events = parseEvents(lines);
+  const { perStep, sessions } = summarizeDurations(events);
+  const bottlenecks = findBottlenecks(events, options.thresholdMs);
+  printReport({ events, perStep, sessions, bottlenecks, options });
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('Analisi telemetria fallita:', error.message);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- add a JSONL telemetry logger for agent selection, command application, and patch confirmation, with env toggles and demo
- add a lightweight analyzer that surfaces per-step timings and bottlenecks from workflow logs
- document how to enable/disable telemetry and interpret reports

## Testing
- AGENT_TELEMETRY_ENABLED=1 node scripts/agent_flow_telemetry.js --demo
- node scripts/analyze_agent_flow.js --log logs/agent_workflow.log --threshold 100

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937754367e88328b143a21243089d1e)