### PR TITLE
Add guidance for simple-task mini pipeline

### DIFF
--- a/.ai/BOOT_PROFILE.md
+++ b/.ai/BOOT_PROFILE.md
@@ -194,6 +194,10 @@ Per evitare carichi inutili in task a basso rischio, gli elementi di boot sono s
 
 Impatto: in profili leggeri, l’agente resta vincolato a identità e router ma non carica strumenti avanzati (Command Library, Golden Path), riducendo tempo di boot e complessità decisionale.
 
+### Mini-pipeline per task semplici (basso rischio)
+
+Per task **BASSO** che rispettano TUTTI i criteri di `docs/PIPELINE_TEMPLATES.md` → sezione “Definizione di task "semplice"” (patch complessiva < 20 righe, zero dipendenze, ambito limitato, rischio minimo), puoi attivare `MINI_PIPELINE_SEMPLICE` (max 2 step) al posto del Golden Path. Se emergono dipendenze, più file o impatti su gameplay/dati core, torna immediatamente al Golden Path completo.
+
 ---
 
 ## 5. Tabella severità e workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Quando Codex lavora in questo repository:
   - Opzionali: `docs/COMMAND_LIBRARY.md` (macro-comandi), `docs/pipelines/GOLDEN_PATH.md` e `docs/PIPELINE_TEMPLATES.md` (pipeline). Se non servono macro-comandi, puoi saltarli.
 - **Ridondanze ridotte**: ogni documento ora rimanda a questa sezione per il bootstrap. Consulta i file specifici solo quando devi approfondire (es. sintassi dei comandi → Command Library; logica di routing → router.md).
 - **Percorso consigliato**: 1) leggi questa sezione, 2) apri `.ai/BOOT_PROFILE.md` per l’avvio completo oppure usa il “profilo light” indicato lì, 3) passa ai documenti opzionali solo se richiesto dal task.
+- **Eccezione per task semplici**: se il task rispetta i criteri di rischio basso/patch < 20 righe/nessuna dipendenza (vedi `docs/PIPELINE_TEMPLATES.md` → MINI_PIPELINE_SEMPLICE), puoi seguire la mini-pipeline a 2 step senza caricare il Golden Path.
 
 2. Questo attiva in automatico:
 

--- a/docs/PIPELINE_TEMPLATES.md
+++ b/docs/PIPELINE_TEMPLATES.md
@@ -8,6 +8,51 @@ ottimizzare ed eseguire pipeline multi-agente nel progetto Game / Evo Tactics.
 Ogni blocco qui sotto può essere copiato e incollato in una richiesta a Codex
 per attivare il comportamento descritto.
 
+## Definizione di task "semplice"
+
+Usa la mini-pipeline solo quando TUTTI i criteri seguenti sono soddisfatti:
+
+- **Nessuna modifica a file** oppure patch complessiva **< 20 righe** (somma
+  delle aggiunte/rimozioni);
+- **Zero nuove dipendenze** (npm/pip/apt) e nessuna modifica a build/CI;
+- **Ambito limitato**: un singolo documento o risposta testuale, senza effetti
+  sul gameplay, sui dati core o sulle API pubbliche;
+- **Rischio basso**: rollback triviale, nessun dato sensibile o migrazione
+  richiesta.
+
+Se uno solo dei punti non è vero, usa il Golden Path completo o la pipeline
+dedicata più adatta.
+
+## MINI_PIPELINE_SEMPLICE (max 2 step)
+
+```text
+COMANDO: MINI_PIPELINE_SEMPLICE
+
+Uso: task a basso rischio che rispettano i criteri sopra.
+
+Step 1 – Comprensione rapida
+  - Agente: archivist (o coordinatore se serve routing)
+  - Output: riepilogo del task, vincoli, file eventualmente coinvolti; scelta
+    se restare in mini-pipeline o passare al Golden Path.
+
+Step 2 – Esecuzione sintetica
+  - Agente: in base al dominio (es. archivist per documentazione)
+  - Output: modifica/testo richiesto, check di coerenza, note su rischi e su
+    quando scalare al Golden Path.
+```
+
+### Esempi d'uso e fallback
+
+- Correzione refusi o chiarimento di istruzioni operative in un singolo file di
+  documentazione → **usa la mini-pipeline**.
+- Aggiornare un numero limitato di righe (< 20) in README/guide senza toccare
+  dati o codice → **usa la mini-pipeline**.
+- Richiesta informativa/QA senza modifiche ai file → **Step 1** basta.
+- Se durante Step 1 emergono impatti su più file, nuove dipendenze, o bisogno di
+  test/build → **passa al Golden Path** prima di eseguire cambi.
+- Se il lavoro tocca gameplay, dataset core, API o migrazioni → **Golden Path
+  obbligatorio**.
+
 ---
 
 ## COMANDO: PIPELINE_DESIGNER


### PR DESCRIPTION
## Descrizione
- Definiti i criteri per i task semplici e documentata una mini-pipeline a 2 step in `docs/PIPELINE_TEMPLATES.md` con esempi e fallback verso il Golden Path.
- Aggiornati `AGENTS.md` e `.ai/BOOT_PROFILE.md` per autorizzare l’uso della mini-pipeline nei casi a basso rischio senza attivare il Golden Path.
- Aggiunte linee guida su quando tornare al percorso completo per evitare rischi o dipendenze aggiuntive.

## Testing
- Non eseguiti (aggiornamento documentazione/procedure).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693776778c5c8328b84149c0619caf03)