### PR TITLE
Document readiness 01B/01C and CI inventory links

### DIFF
--- a/logs/agent_activity.md
+++ b/logs/agent_activity.md
@@ -1,5 +1,9 @@
 # Agent activity log
 
+## 2026-10-12 – Readiness 01B/01C e collegamento inventario (archivist)
+- Step: `[01B01C-READINESS-2026-10-12T1200Z] owner=archivist (approvatore Master DD); scope=01B/01C report-only; files=reports/readiness_01B01C_status.md,reports/audit/readiness-01c-ci-inventory.md,logs/RIAPERTURA-2025-02.md; branch=patch/01A-report-only,patch/01B-core-derived-matrix,patch/01C-tooling-ci-catalog; riferimento=docs/planning/REF_PLANNING_RIPRESA_2026.md; esito=PASS; decision=READINESS-CONFERMATA (report-only).`
+- Azioni: confermata la disponibilità indicata (archivist lead 01A; species-curator + trait-curator on-call 01B; dev-tooling on-call 01C con coordinator/balancer backup) e i ticket attivi **TKT-01B-001/002**, **TKT-01C-001/002**; nessuna variazione di scope/owner. Inventario CI/script aggiornato con link ai branch dedicati `patch/01B-core-derived-matrix` e `patch/01C-tooling-ci-catalog` e referenziato dalla nota readiness `reports/readiness_01B01C_status.md`.
+
 ## 2026-09-30 – Pre-meeting 01A e ripristino branch (coordinator)
 - Step: `[RIAPERTURA-2025-02-CHECKLIST-48H-2026-10-11T1200Z] owner=archivist (approvatore Master DD); scope=PATCHSET-00→PIPELINE 01A; riferimento=docs/planning/REF_PLANNING_RIPRESA_2026.md §Checklist 48h; modalità=STRICT MODE; freeze_window=2025-10-06T09:00Z→2025-10-13T18:00Z; esito=PASS.`
 - Azioni: eseguita la checklist punti 1–7 (kickoff confermato senza variazioni, catalogo 01A/gap list riesaminati in sola lettura, readiness 01B/01C invariata su ticket 2025, `_holding` assente, finestra freeze ottobre 2025 confermata **SBLOCCATA** con ticket **TKT-FREEZE-OCT25**, nessun nuovo drop). Log `logs/RIAPERTURA-2025-02.md` aggiornato con esito e con nota che la gap list 01A resta quella già referenziata (pack minimo v5–v8, unified ≥2.0, badlands/biomi, sentience/enneagramma, hook engine, asset MBTI). README incoming/docs da sincronizzare con stato post-freeze (ticket 2025) mantenendo report-only.

--- a/reports/audit/readiness-01c-ci-inventory.md
+++ b/reports/audit/readiness-01c-ci-inventory.md
@@ -2,6 +2,11 @@
 
 Inventario aggiornato per il gate **01C** collegato alla nota di readiness `reports/readiness_01B01C_status.md` e al log di riapertura `logs/RIAPERTURA-2025-02.md`. Tutte le voci restano **report-only** (nessuna pipeline eseguita).
 
+## Collegamento branch readiness 01B/01C
+- Branch dedicati attivi in sola lettura: `patch/01B-core-derived-matrix` (01B) e `patch/01C-tooling-ci-catalog` (01C); `patch/01A-report-only` resta il punto di handoff da 01A.
+- Stato readiness 2026-10-12T1200Z (report-only): agenti on-call confermati (species-curator + trait-curator per 01B; dev-tooling per 01C; coordinator/balancer backup) con ticket **TKT-01B-001/002** e **TKT-01C-001/002**.
+- Log di riferimento: `logs/agent_activity.md` entry `01B01C-READINESS-2026-10-12T1200Z` con link a questo inventario e alla nota readiness `reports/readiness_01B01C_status.md`.
+
 ## Workflow CI attivi
 
 | Nome | Percorso | Trigger | Input principali | Output/artefatti | Rischio |

--- a/reports/readiness_01B01C_status.md
+++ b/reports/readiness_01B01C_status.md
@@ -9,6 +9,11 @@ Verificare stato di readiness per i gate 01B (core/derived) e 01C (tooling/CI), 
 - Ticket attivi: **[TKT-01B-001]**, **[TKT-01B-002]**, **[TKT-01C-001]**, **[TKT-01C-002]** (nessuna variazione di scope/owner). Logging richiesto in STRICT MODE su ogni batch.
 - Nessun nuovo drop in `_holding` rilevato; catalogo 01A e README risultano sincronizzati con gap list chiusa e handoff 01B/01C.
 
+### Aggiornamento readiness 2026-10-12T1200Z
+- Disponibilità confermata: **archivist lead 01A**, **species-curator + trait-curator on-call 01B**, **dev-tooling on-call 01C** con **coordinator/balancer** in backup consultivo. Copertura mantenuta in report-only sui branch `patch/01A-report-only`, `patch/01B-core-derived-matrix`, `patch/01C-tooling-ci-catalog`.
+- Ticket tracciati per il ciclo 01B/01C: **TKT-01B-001**, **TKT-01B-002**, **TKT-01C-001**, **TKT-01C-002** (nessuna variazione di scope/owner). ID di riferimento readiness/log: `01B01C-READINESS-2026-10-12T1200Z` su `logs/agent_activity.md`.
+- Inventario CI/script collegato (report-only) aggiornato in `reports/audit/readiness-01c-ci-inventory.md` con link ai branch dedicati.
+
 ## Finestre e approvazioni
 - **Freeze documentale (incoming/docs/incoming):** attivazione 2026-07-08T09:00Z, chiusura 2026-07-15T18:00Z; approvatore Master DD. Nessuna estensione richiesta.
 - **Autorizzazione pipeline/patchset successivi:** Master DD conferma via libera alla prosecuzione di pipeline/patchset post-readiness 01B/01C, mantenendo l’obbligo di loggare ogni batch e owner su `logs/agent_activity.md`.


### PR DESCRIPTION
## Descrizione
- Aggiornata la nota di readiness 01B/01C con conferma disponibilità agenti, ticket attivi e riferimento log `01B01C-READINESS-2026-10-12T1200Z`.
- Integrato l’inventario CI/script 01C con sezione di collegamento ai branch `patch/01B-core-derived-matrix` e `patch/01C-tooling-ci-catalog` e allo stato readiness.
- Registrata in `logs/agent_activity.md` la nota di readiness 01B/01C con link a inventario e riferimento `REF_PLANNING_RIPRESA_2026.md`.

## Checklist guida stile & QA
- [ ] Nessuna modifica a `data/core/**`, `data/derived/**`, `incoming/**`, `docs/incoming/**` nella finestra freeze 2025-11-25T12:05Z–2025-11-27T12:05Z (salvo rollback autorizzati Master DD) – non applicabile (solo documentazione/log)
- [ ] Validator di release **PASS senza regressioni** (allega percorso report). Il merge rimane bloccato finché esistono regressioni aperte nel validator – non eseguito (aggiornamento documentazione)
- [ ] Approvazione **Master DD** registrata (link a commento/issue che conferma l'ok al merge) – non applicabile (report-only)
- [ ] Changelog allegato alla PR e **piano di rollback 03A** incluso (link o allegato nella sezione Note) – non applicabile
- [ ] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate – non applicabile
- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa – non applicabile
- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati – non applicabile
- [ ] Eseguito `scripts/trait_style_check.js` (allega percorso report/artifact) – non eseguito (aggiornamento documentazione)
- [ ] Badge "Guida stile" dell'editor in stato "In linea" (suggerimenti applicabili gestiti) – non applicabile
- [ ] Generato `tools/py/styleguide_compliance_report.py` (link a JSON/Markdown) – non applicabile
- [ ] Aggiornato bridge `logs/qa/latest-dashboard-metrics.json` se il report è stato rigenerato – non applicabile
- [x] Documentazione/processi aggiornati ove necessario

## Testing
- [ ] `npm run style:check`
- [ ] Altro: non eseguito (solo documentazione/log)

## Note
- Aggiornamenti in sola lettura su readiness e log, nessuna pipeline o script eseguito.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938054828e483288120bdb3e01e3660)