### PR TITLE
Enable manual dispatch for validate_traits workflow

### DIFF
--- a/.github/workflows/validate_traits.yml
+++ b/.github/workflows/validate_traits.yml
@@ -1,6 +1,7 @@
 name: Validate Trait Catalog
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - 'data/traits/**'


### PR DESCRIPTION
## Summary
- add manual workflow_dispatch trigger to the validate_traits GitHub Actions workflow

## Testing
- not run (configuration-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693841733e788328a096420e87155fff)