### PR TITLE
Align ali_solari_fotoni label with i18n

### DIFF
--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -412,7 +412,7 @@
     },
     "ali_solari_fotoni": {
       "id": "ali_solari_fotoni",
-      "label": "Ali Solari Fotoni",
+      "label": "i18n:traits.ali_solari_fotoni.label",
       "debolezza": "i18n:traits.ali_solari_fotoni.debolezza",
       "data_origin": "coverage_q4_2025",
       "famiglia_tipologia": "Locomotivo/Aereo",

--- a/data/traits/locomotivo/ali_solari_fotoni.json
+++ b/data/traits/locomotivo/ali_solari_fotoni.json
@@ -1,6 +1,6 @@
 {
   "id": "ali_solari_fotoni",
-  "label": "Ali Solari Fotoni",
+  "label": "i18n:traits.ali_solari_fotoni.label",
   "debolezza": "i18n:traits.ali_solari_fotoni.debolezza",
   "data_origin": "coverage_q4_2025",
   "famiglia_tipologia": "Locomotivo/Aereo",


### PR DESCRIPTION
## Summary
- switch the ali_solari_fotoni trait label to the expected i18n reference to align with other localized fields
- keep trait metadata consistent between the main definition and index entry

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693848fdae4083289b27c654603b8c4c)