### PR TITLE
Align ali_solari_fotoni trait with i18n refs

### DIFF
--- a/data/external/evo/traits/traits_aggregate.json
+++ b/data/external/evo/traits/traits_aggregate.json
@@ -150,7 +150,7 @@
     {
       "trait_code": "TR-2009",
       "id": "ali_solari_fotoni",
-      "label": "Ali Solari Fotoniche",
+      "label": "i18n:traits.ali_solari_fotoni.label",
       "tier": "T2",
       "sinergie": [
         "cervello_a_bassa_latenza",
@@ -170,9 +170,9 @@
           }
         }
       ],
-      "mutazione_indotta": "Piume fotovoltaiche con rete di accumulo radiante.",
-      "uso_funzione": "Convertire luce in spinta e in schermature riflettenti.",
-      "spinta_selettiva": "Volo prolungato e protezione in ambienti ad alta radianza.",
+      "mutazione_indotta": "i18n:traits.ali_solari_fotoni.mutazione_indotta",
+      "uso_funzione": "i18n:traits.ali_solari_fotoni.uso_funzione",
+      "spinta_selettiva": "i18n:traits.ali_solari_fotoni.spinta_selettiva",
       "famiglia_tipologia": "Locomotivo/Aereo",
       "fattore_mantenimento_energetico": "Medio (manutenzione periodica o situazionale)",
       "slot": [


### PR DESCRIPTION
## Summary
- switch ali_solari_fotoni label and description fields to i18n trait pointers
- keep existing tier, slots, and synergies unchanged while aligning formatting

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69384a55cecc83289e049a650caa67f2)