### PR TITLE
Allinea i18n per traits_aggregate

### DIFF
--- a/data/traits/meta/traits_aggregate.json
+++ b/data/traits/meta/traits_aggregate.json
@@ -1,6 +1,6 @@
 {
   "id": "traits_aggregate",
-  "label": "Aggregato tratti Evo",
+  "label": "i18n:traits.traits_aggregate.label",
   "data_origin": "external_evo_pack",
   "famiglia_tipologia": "Meta/Dataset",
   "fattore_mantenimento_energetico": "N/A",
@@ -8,9 +8,9 @@
   "slot": [],
   "sinergie": [],
   "conflitti": [],
-  "mutazione_indotta": "Dump normalizzato dei trait Evo (TR-*) per pipeline legacy.",
-  "uso_funzione": "Punto di ingresso legacy per cataloghi e audit Evo.",
-  "spinta_selettiva": "Allineare export Evo e indice legacy.",
+  "mutazione_indotta": "i18n:traits.traits_aggregate.mutazione_indotta",
+  "uso_funzione": "i18n:traits.traits_aggregate.uso_funzione",
+  "spinta_selettiva": "i18n:traits.traits_aggregate.spinta_selettiva",
   "metrics": [],
   "cost_profile": {
     "rest": "N/A",
@@ -31,8 +31,7 @@
     "complementare": "supporto"
   },
   "usage_tags": [
-    "catalogo",
-    "meta"
+    "support"
   ],
-  "debolezza": "Non rappresenta un tratto giocabile; solo metadato di pacchetto."
+  "debolezza": "i18n:traits.traits_aggregate.debolezza"
 }


### PR DESCRIPTION
## Summary
- allineati i campi testuali di `traits_aggregate` al namespace i18n del tratto
- aggiornati i `usage_tags` con un valore conforme al vocabolario per il dataset meta
- rigenerato il report di trait style nella cartella `reports/trait_style`

## Testing
- node scripts/trait_style_check.js --output-json reports/trait_style/trait_style_report.json --output-markdown reports/trait_style/trait_style_report.md --fail-on-error


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938566d0ff08328a1fc1b2982050840)