### PR TITLE
Fix status report script imports

### DIFF
--- a/tools/deploy/generateStatusReport.js
+++ b/tools/deploy/generateStatusReport.js
@@ -5,9 +5,11 @@ const path = require('node:path');
 
 const {
   createNebulaTelemetryAggregator,
-} = require('../../server/services/nebulaTelemetryAggregator');
-const { createGenerationSnapshotStore } = require('../../server/services/generationSnapshotStore');
-const { createReleaseReporter } = require('../../server/services/releaseReporter');
+} = require('../../apps/backend/services/nebulaTelemetryAggregator');
+const {
+  createGenerationSnapshotStore,
+} = require('../../apps/backend/services/generationSnapshotStore');
+const { createReleaseReporter } = require('../../apps/backend/services/releaseReporter');
 
 const ROOT_DIR = path.resolve(__dirname, '..', '..');
 const DEFAULT_STATUS_PATH = path.join(ROOT_DIR, 'reports', 'status.json');


### PR DESCRIPTION
## Descrizione
- Corretto il percorso degli import in `tools/deploy/generateStatusReport.js` per utilizzare i servizi sotto `apps/backend`.

## Checklist guida stile & QA
- [x] Nessuna modifica a `data/core/**`, `data/derived/**`, `incoming/**`, `docs/incoming/**` nella finestra freeze 2025-11-25T12:05Z–2025-11-27T12:05Z (salvo rollback autorizzati Master DD)
- [ ] N/A (validator di release non pertinente a questo change)
- [ ] N/A (approvazione Master DD non richiesta per questo change)
- [ ] N/A (nessun changelog o piano di rollback necessario)
- [ ] N/A (nessuna chiave i18n toccata)
- [ ] N/A (nessun tier/slot/slot_profile modificato)
- [ ] N/A (requisiti ambientali e completion_flags non toccati)
- [ ] N/A (non richiesto `scripts/trait_style_check.js`)
- [ ] N/A (badge guida stile non pertinente)
- [ ] N/A (`tools/py/styleguide_compliance_report.py` non generato)
- [ ] N/A (bridge QA non aggiornato)
- [x] Documentazione/processi aggiornati ove necessario

## Testing
- [x] `node tools/deploy/generateStatusReport.js --status reports/status.json`

## Note
- Nessuna nota aggiuntiva.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69386486d57883288cb4aa761fc90313)