### PR TITLE
Use affinity map to fill missing trait coverage

### DIFF
--- a/data/derived/analysis/trait_coverage_matrix.csv
+++ b/data/derived/analysis/trait_coverage_matrix.csv
@@ -23,7 +23,9 @@ artigli_induzione,Artigli Induzione,Artigli Induzione,canopia_ionica,,1,1
 artigli_ipo_termici,Artigli Ipo-Termici,Hypothermal Claws,,,1,1
 artigli_radice,Artigli Radice,Artigli Radice,mangrovieto_cinetico,,1,1
 artigli_scivolo_silente,Artigli Scivolo Silente,Artigli Scivolo Silente,caverna_risonante,,1,1
+artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,badlands,cursoriale_quadrupede,0,1
 artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,caverna_risonante,,1,9
+artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,cryosteppe,cursoriale_quadrupede,0,1
 artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,dorsale_termale_tropicale,cursoriale_quadrupede,1,9
 artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,mezzanotte_orbitale,cursoriale_quadrupede,1,9
 artigli_sghiaccio_glaciale,Artigli Sghiaccio Glaciale,Artigli Sghiaccio Glaciale,,,1,1
@@ -61,6 +63,7 @@ capillari_criogenici,Capillari Criogenici,Capillari Criogenici,caldera_glaciale,
 capillari_fluoridici,Capillari Fluoridici,Capillari Fluoridici,foresta_acida,,1,1
 capillari_fotovoltaici,Capillari Fotovoltaici,Capillari Fotovoltaici,canopia_ionica,,1,1
 capsule_paracadute,Capsule Paracadute,Capsule Paracadute,stratosfera_tempestosa,,1,1
+carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,cryosteppe,cursoriale_quadrupede,0,1
 carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,mezzanotte_orbitale,cursoriale_quadrupede,1,9
 carapace_luminiscente_abissale,Carapace Luminiscente Abissale,Carapace Luminiscente Abissale,,,1,1
 carapace_segmenti_logici,Carapace Segmenti Logici,Carapace Segmenti Logici,steppe_algoritmiche,,1,1
@@ -101,19 +104,31 @@ corazze_ferro_magnetico,Corazze Ferro-Magnetico,Ferro-Magnetic Carapace,,,1,1
 corna_psico_conduttive,Corna Psico-Conduttive,Psycho-Conductive Horns,,,1,1
 coscienza_d_alveare_diffusa,Coscienza d’Alveare Diffusa,Diffuse Hive Consciousness,,,1,1
 coscienza_dalveare_diffusa,Coscienza d’Alveare Diffusa,Diffuse Hive Consciousness,,,1,1
+criostasi_adattiva,Criostasi,Adaptive Cryostasis,cryosteppe,volatore_planatore,0,1
 criostasi_adattiva,Criostasi,Adaptive Cryostasis,mezzanotte_orbitale,volatore_planatore,1,4
 cromofori_alert_acido,Cromofori Alert Acido,Cromofori Alert Acido,foresta_acida,,1,1
 cuore_multicamera_bassa_pressione,Cuore Multicamera Bassa Pressione,Cuore Multicamera Bassa Pressione,stratosfera_tempestosa,,1,1
 cuscinetti_elettrostatici,Cuscinetti Elettrostatici,Cuscinetti Elettrostatici,pianura_salina_iperarida,,1,1
 cute_resistente_sali,Cute Resistente Sali,Cute Resistente Sali,,,1,3
-cute_resistente_sali,Cute Resistente Sali,Cute Resistente Sali,badlands,,1,3
+cute_resistente_sali,Cute Resistente Sali,Cute Resistente Sali,badlands,,1,1
+cute_resistente_sali,Cute Resistente Sali,Cute Resistente Sali,badlands,volatore_planatore,0,1
 cuticole_cerose,Cuticole Cerose,Cuticole Cerose,,,1,7
+cuticole_cerose,Cuticole Cerose,Cuticole Cerose,cryosteppe,volatore_planatore,0,1
+cuticole_cerose,Cuticole Cerose,Cuticole Cerose,deserto_caldo,cursoriale_quadrupede,0,1
+cuticole_cerose,Cuticole Cerose,Cuticole Cerose,deserto_caldo,ingegnere_radicante,0,1
+cuticole_cerose,Cuticole Cerose,Cuticole Cerose,deserto_caldo,scavenger_corazzato,0,1
+cuticole_cerose,Cuticole Cerose,Cuticole Cerose,deserto_caldo,volatore_planatore,0,2
 cuticole_neutralizzanti,Cuticole Neutralizzanti,Cuticole Neutralizzanti,foresta_acida,,1,1
 denti_chelatanti,Denti Chelatanti,Denti Chelatanti,foresta_acida,,1,1
 denti_ossidoferro,Denti Ossidoferro,Denti Ossidoferro,abisso_vulcanico,,1,1
 denti_silice_termici,Denti Silice Termici,Denti Silice Termici,dorsale_termale_tropicale,,1,1
 denti_tuning_fork,Denti Tuning Fork,Denti Tuning Fork,caverna_risonante,,1,1
 echi_risonanti,Echi Risonanti,Echi Risonanti,caverna_risonante,,1,1
+eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,CRYOSTEPPE,volatore_planatore,0,1
+eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,DESERTO_CALDO,volatore_planatore,0,1
+eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,FORESTA_TEMPERATA,volatore_planatore,0,1
+eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,badlands,volatore_planatore,0,1
+eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,cryosteppe,volatore_planatore,0,1
 eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,dorsale_termale_tropicale,volatore_planatore,1,7
 eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,mezzanotte_orbitale,volatore_planatore,1,7
 ectotermia_dinamica,Ectotermia Dinamica,Dynamic Ectothermy,,,1,1
@@ -121,9 +136,11 @@ elettromagnete_biologico,Elettromagnete Biologico,Biological Electromagnet,,,1,1
 emettitori_voidsong,Emettitori Voidsong,Voidsong Emitters,,,1,1
 emolinfa_conducente,Emolinfa Conducente,Conductive Hemolymph,,,1,1
 empatia_coordinativa,Empatia Coordinativa,Coordinated Empathy,foresta_miceliale,,1,8
+empatia_coordinativa,Empatia Coordinativa,Coordinated Empathy,foresta_temperata,,0,1
 enzimi_antifase_termica,Enzimi Antifase Termica,Enzimi Antifase Termica,caldera_glaciale,,1,1
 enzimi_antipredatori_algali,Enzimi Antipredatori Algali,Enzimi Antipredatori Algali,reef_luminescente,,1,1
 enzimi_chelanti,Enzimi Chelanti,Enzimi Chelanti,,,1,2
+enzimi_chelanti,Enzimi Chelanti,Enzimi Chelanti,badlands,volatore_planatore,0,1
 enzimi_chelatori_rapidi,Enzimi Chelatori Rapidi,Enzimi Chelatori Rapidi,foresta_acida,,1,1
 enzimi_metanoossidanti,Enzimi Metanoossidanti,Enzimi Metanoossidanti,abisso_vulcanico,,1,1
 epidermide_dielettrica,Epidermide Dielettrica,Epidermide Dielettrica,stratosfera_tempestosa,,1,1
@@ -131,6 +148,8 @@ epitelio_fosforescente,Epitelio Fosforescente,Epitelio Fosforescente,reef_lumine
 ermafroditismo_cronologico,Ermafroditismo Cronologico,Chronological Hermaphroditism,,,1,1
 estroflessione_gastrica_acida,Estroflessione Gastrica Acida,Acidic Gastric Extrusion,,,1,1
 fagocitosi_assorbente,Fagocitosi Assorbente,Absorptive Phagocytosis,,,1,1
+filamenti_digestivi_compattanti,Filamenti Digestivi Compattanti,Digestive Compaction Filaments,badlands,scavenger_corazzato,0,2
+filamenti_digestivi_compattanti,Filamenti Digestivi Compattanti,Digestive Compaction Filaments,cryosteppe,scavenger_corazzato,0,1
 filamenti_digestivi_compattanti,Filamenti Digestivi Compattanti,Digestive Compaction Filaments,dorsale_termale_tropicale,scavenger_corazzato,1,8
 filamenti_digestivi_compattanti,Filamenti Digestivi Compattanti,Digestive Compaction Filaments,falde_magnetiche_psioniche,,1,8
 filamenti_digestivi_compattanti,Filamenti Digestivi Compattanti,Digestive Compaction Filaments,foresta_miceliale,,1,8
@@ -147,12 +166,14 @@ flagelli_ancoranti,Flagelli Ancoranti,Flagelli Ancoranti,laguna_bioreattiva,,1,1
 flusso_ameboide_controllato,Flusso Ameboide Controllato,Controlled Amoeboid Flow,,,1,1
 focus_frazionato,Focus Frazionato,Fractional Focus,canopia_psionica_leggera,,1,8
 focus_frazionato,Focus Frazionato,Fractional Focus,foresta_miceliale,,1,8
+focus_frazionato,Focus Frazionato,Fractional Focus,foresta_temperata,,0,1
 focus_frazionato,Focus Frazionato,Fractional Focus,orbita_psionica_inversa,,1,8
 foliage_fotocatodico,Foliage Fotocatodico,Foliage Fotocatodico,foresta_acida,,1,1
 foliaggio_spugna,Foliaggio Spugna,Foliaggio Spugna,mangrovieto_cinetico,,1,1
 frusta_fiammeggiante,Frusta Fiammeggiante,Flame Lash,,,1,2
 ghiaccio_piezoelettrico,Ghiaccio Piezoelettrico,Ghiaccio Piezoelettrico,caldera_glaciale,,1,1
 ghiandola_caustica,Ghiandola Caustica,Caustic Gland,foresta_miceliale,,1,2
+ghiandola_caustica,Ghiandola Caustica,Caustic Gland,foresta_temperata,,0,1
 ghiandole_cambio_salino,Ghiandole Cambio Salino,Ghiandole Cambio Salino,laguna_bioreattiva,,1,1
 ghiandole_condensa_ozono,Ghiandole Condensa Ozono,Ghiandole Condensa Ozono,stratosfera_tempestosa,,1,1
 ghiandole_eco_mappanti,Ghiandole Eco Mappanti,Ghiandole Eco Mappanti,caverna_risonante,,1,1
@@ -169,6 +190,11 @@ ghiandole_resina_conduttiva,Ghiandole Resina Conduttiva,Ghiandole Resina Condutt
 ghiandole_ventosa,Ghiandole Ventosa,Ghiandole Ventosa,caldera_glaciale,,1,1
 giunti_antitorsione,Giunti Antitorsione,Giunti Antitorsione,mangrovieto_cinetico,,1,1
 grassi_termici,Grassi Termici,Grassi Termici,,,1,7
+grassi_termici,Grassi Termici,Grassi Termici,cryosteppe,volatore_planatore,0,1
+grassi_termici,Grassi Termici,Grassi Termici,deserto_caldo,cursoriale_quadrupede,0,1
+grassi_termici,Grassi Termici,Grassi Termici,deserto_caldo,ingegnere_radicante,0,1
+grassi_termici,Grassi Termici,Grassi Termici,deserto_caldo,scavenger_corazzato,0,1
+grassi_termici,Grassi Termici,Grassi Termici,deserto_caldo,volatore_planatore,0,2
 gusci_criovetro,Gusci Criovetro,Gusci Criovetro,caldera_glaciale,,1,1
 gusci_magnesio,Gusci Magnesio,Gusci Magnesio,dorsale_termale_tropicale,,1,1
 impulsi_bioluminescenti,Impulsi Bioluminescenti,Bioluminescent Pulses,,,1,2
@@ -182,6 +208,7 @@ lamine_scudo_silice,Lamine Scudo Silice,Lamine Scudo Silice,dorsale_termale_trop
 linfa_tampone,Linfa Tampone,Linfa Tampone,foresta_acida,,1,1
 lingua_cristallina,Lingua Cristallina,Lingua Cristallina,pianura_salina_iperarida,,1,1
 lingua_tattile_trama,Lingua Tattile Trama-Sensibile,Texture-Sensing Tongue,foresta_miceliale,,1,4
+lingua_tattile_trama,Lingua Tattile Trama-Sensibile,Texture-Sensing Tongue,foresta_temperata,,0,1
 lobi_risonanti_crepuscolo,Lobi Risonanti Crepuscolo,Twilight Resonant Lobes,,,1,3
 locomozione_miriapode_ibrida,Locomozione Miriapode Ibrida,Hybrid Myriapod Locomotion,,,1,1
 luminescenza_aurorale,Luminescenza Aurorale,Luminescenza Aurorale,caldera_glaciale,,1,1
@@ -196,6 +223,7 @@ membrane_planata_vectored,Membrane Planata Vectored,Membrane Planata Vectored,ca
 membrane_pneumatofori,Membrane Pneumatofori,Membrane Pneumatofori,mangrovieto_cinetico,,1,1
 metabolismo_di_condivisione_energetica,Metabolismo di Condivisione Energetica,Shared Energy Metabolism,,,1,1
 midollo_antivibrazione,Midollo Antivibrazione,Midollo Antivibrazione,caverna_risonante,,1,1
+mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,badlands,ingegnere_radicante,0,1
 mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,canopia_psionica_leggera,,1,6
 mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,dorsale_termale_tropicale,ingegnere_radicante,1,6
 mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,mezzanotte_orbitale,volatore_planatore,1,6
@@ -207,13 +235,19 @@ mucose_barofile,Mucose Barofile,Mucose Barofile,abisso_vulcanico,,1,1
 nebbia_mnesica,Nebbia Mnesica,Mnesic Fog,,,1,1
 nodi_micorrizici_oracolari,Nodi Micorrizici Oracolari,Nodi Micorrizici Oracolari,,,1,1
 nodi_sinaptici_superficiali,Nodi Sinaptici Superficiali,Surface Synaptic Nodes,,,1,1
+nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,badlands,cursoriale_quadrupede,0,1
 nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,dorsale_termale_tropicale,cursoriale_quadrupede,1,2
 nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,falde_magnetiche_psioniche,,1,2
 nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,orbita_psionica_inversa,,1,2
 occhi_analizzatori_di_tensione,Occhi Analizzatori di Tensione,Tension-Analyzing Eyes,,,1,1
 occhi_cinetici,Occhi Cinetici,Kinetic Eyes,,,1,1
 occhi_cristallo_modulare,Occhi a Cristallo Modulare,Modular Crystal Eyes,,,1,2
+occhi_infrarosso_composti,Occhi Composti ad Infrarosso,Infrared Compound Eyes,CRYOSTEPPE,volatore_planatore,0,1
+occhi_infrarosso_composti,Occhi Composti ad Infrarosso,Infrared Compound Eyes,DESERTO_CALDO,volatore_planatore,0,1
+occhi_infrarosso_composti,Occhi Composti ad Infrarosso,Infrared Compound Eyes,FORESTA_TEMPERATA,volatore_planatore,0,1
+occhi_infrarosso_composti,Occhi Composti ad Infrarosso,Infrared Compound Eyes,badlands,volatore_planatore,0,1
 occhi_infrarosso_composti,Occhi Composti ad Infrarosso,Infrared Compound Eyes,dorsale_termale_tropicale,volatore_planatore,1,2
+olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,cryosteppe,cursoriale_quadrupede,0,1
 olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,dorsale_termale_tropicale,cursoriale_quadrupede,1,9
 olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,falde_magnetiche_psioniche,,1,9
 olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,mezzanotte_orbitale,cursoriale_quadrupede,1,9
@@ -221,29 +255,40 @@ olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Sc
 organi_metacronici,Organi Metacronici,Metachronic Organs,,,1,1
 organi_sismici_cutanei,Organi Sismici Cutanei,Cutaneous Seismic Organs,,,1,1
 pathfinder,Pathfinder,Pathfinder,foresta_miceliale,,1,2
+pathfinder,Pathfinder,Pathfinder,foresta_temperata,,0,1
 pelage_idrorepellente_avanzato,Pelage Idrorepellente Avanzato,Advanced Hydrophobic Pelage,,,1,1
 pelle_piezo_satura,Pelle Piezo-Satura,Piezo-Saturated Skin,,,1,1
 pianificatore,Pianificatore,Strategic Planner,foresta_miceliale,,1,1
+pianificatore,Pianificatore,Strategic Planner,foresta_temperata,,0,1
 piume_solari_fotovoltaiche,Piume Solari Fotovoltaiche,Piume Solari Fotovoltaiche,,,1,1
 placca_diffusione_foschia,Placca di Diffusione Foschia,Fog Diffusion Plate,,,1,1
 placche_pressioniche,Placche Pressioniche,Pressure Plates,,,1,1
 polmoni_cristallini_alta_quota,Polmoni Cristallini d'Alta Quota,Polmoni Cristallini d'Alta Quota,,,1,1
 random,Trait Random,Trait Random,,,1,3
+respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,badlands,scavenger_corazzato,0,1
+respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,cryosteppe,cursoriale_quadrupede,0,1
 respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,dorsale_termale_tropicale,scavenger_corazzato,1,6
 respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,mezzanotte_orbitale,cursoriale_quadrupede,1,6
 rete_filtro_polmonare,Rete Filtro-Polmonare,Pulmonary Filter Net,,,1,1
 risonanza_di_branco,Risonanza di Branco,Pack Resonance,foresta_miceliale,,1,6
+risonanza_di_branco,Risonanza di Branco,Pack Resonance,foresta_temperata,,0,1
 riverbero_memetico,Riverbero Memetico,Memetic Reverb,,,1,2
 rostro_emostatico_litico,Rostro Emostatico-Litico,Hemo-Lytic Rostrum,,,1,1
 rostro_linguale_prensile,Rostro Linguale Prensile,Prehensile Lingual Rostrum,,,1,1
+sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,badlands,cursoriale_quadrupede,0,1
 sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,canopia_psionica_leggera,,1,8
 sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,dorsale_termale_tropicale,cursoriale_quadrupede,1,8
 sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,mezzanotte_orbitale,volatore_planatore,1,8
 sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,orbita_psionica_inversa,,1,8
 sacche_spore_stratosferiche,Sacche di Spore Stratosferiche,Sacche di Spore Stratosferiche,,,1,1
+sangue_piroforico,Sangue che prende fuoco a contatto con l'ossigeno,Pyrophoric Blood,badlands,ingegnere_radicante,0,1
+sangue_piroforico,Sangue che prende fuoco a contatto con l'ossigeno,Pyrophoric Blood,cryosteppe,scavenger_corazzato,0,1
 sangue_piroforico,Sangue che prende fuoco a contatto con l'ossigeno,Pyrophoric Blood,dorsale_termale_tropicale,ingegnere_radicante,1,4
 sangue_piroforico,Sangue che prende fuoco a contatto con l'ossigeno,Pyrophoric Blood,mezzanotte_orbitale,scavenger_corazzato,1,4
 scheletro_idraulico_a_pistoni,Scheletro Idraulico a Pistoni,Piston Hydraulic Skeleton,,,1,1
+scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,badlands,cursoriale_quadrupede,0,2
+scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,badlands,scavenger_corazzato,0,1
+scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,cryosteppe,cursoriale_quadrupede,0,1
 scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,dorsale_termale_tropicale,cursoriale_quadrupede,1,10
 scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,dorsale_termale_tropicale,scavenger_corazzato,1,10
 scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,mezzanotte_orbitale,cursoriale_quadrupede,1,10
@@ -251,6 +296,7 @@ scheletro_pneumatico_a_maglie,Scheletro Pneumatico a Maglie,Latticed Pneumatic S
 scintilla_sinaptica,Scintilla Sinaptica,Synaptic Spark,,,1,2
 scivolamento_magnetico,Scivolamento Magnetico,Magnetic Gliding,,,1,1
 scudo_gluteale_cheratinizzato,Scudo Gluteale Cheratinizzato,Keratinized Gluteal Shield,,,1,1
+secrezione_rallentante_palmi,Mani secernano liquido rallentante,Retarding Palm Secretions,badlands,ingegnere_radicante,0,1
 secrezione_rallentante_palmi,Mani secernano liquido rallentante,Retarding Palm Secretions,dorsale_termale_tropicale,ingegnere_radicante,1,2
 secrezioni_antistatiche,Secrezioni Antistatiche,Antistatic Secretions,,,1,1
 sensori_geomagnetici,Sensori a Risonanza Geomagnetica,Geomagnetic Resonance Sensors,,,1,4
@@ -259,23 +305,35 @@ seta_conduttiva_elettrica,Seta Conduttiva Elettrica,Conductive Electric Silk,,,1
 siero_anti_gelo_naturale,Siero Anti-Gelo Naturale,Natural Anti-Freeze Serum,,,1,1
 sinapsi_coraline_polifoniche,Sinapsi Coraline Polifoniche,Sinapsi Coraline Polifoniche,,,1,1
 sistemi_chimio_sonici,Sistemi Chimio-Sonici,Chemo-Sonic Systems,,,1,1
+sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,CRYOSTEPPE,volatore_planatore,0,1
+sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,DESERTO_CALDO,volatore_planatore,0,1
+sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,FORESTA_TEMPERATA,volatore_planatore,0,1
+sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,badlands,volatore_planatore,0,1
+sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,cryosteppe,volatore_planatore,0,1
 sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,dorsale_termale_tropicale,volatore_planatore,1,3
 sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,mezzanotte_orbitale,volatore_planatore,1,3
 spicole_canalizzatrici,Spicole Canalizzatrici,Channeling Spicules,,,1,1
+spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,badlands,scavenger_corazzato,0,1
+spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,cryosteppe,scavenger_corazzato,0,1
 spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,dorsale_termale_tropicale,scavenger_corazzato,1,2
 spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,foresta_miceliale,,1,2
+spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,foresta_temperata,,0,1
 spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,mezzanotte_orbitale,scavenger_corazzato,1,2
 squame_diffusori_ionici,Squame Diffusori Ionici,Ionic Diffuser Scales,,,1,1
 squame_rifrangenti_deserto,Squame Rifrangenti del Deserto,Squame Rifrangenti del Deserto,,,1,1
+struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,badlands,cursoriale_quadrupede,0,1
 struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,canopia_psionica_leggera,,1,9
 struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,dorsale_termale_tropicale,cursoriale_quadrupede,1,9
 struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,falde_magnetiche_psioniche,,1,9
 struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,foresta_miceliale,,1,9
 tattiche_di_branco,Tattiche di Branco,Pack Tactics,foresta_miceliale,,1,3
+tattiche_di_branco,Tattiche di Branco,Pack Tactics,foresta_temperata,,0,1
 traits_aggregate,Aggregato tratti Evo,Evo Traits Aggregate,,,1,1
 unghie_a_micro_adesione,Unghie a Micro-Adesione,Micro-Adhesion Claws,,,1,1
 vello_condensatore_nebbie,Vello Condensatore di Nebbie,Vello Condensatore di Nebbie,,,1,1
 vello_di_assorbimento_totale,Vello di Assorbimento Totale,Total Absorption Fleece,,,1,1
+ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,badlands,scavenger_corazzato,0,1
+ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,cryosteppe,cursoriale_quadrupede,0,1
 ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,dorsale_termale_tropicale,scavenger_corazzato,1,4
 ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,mezzanotte_orbitale,cursoriale_quadrupede,1,4
 visione_multi_spettrale_amplificata,Visione Multi-Spettrale Amplificata,Amplified Multi-Spectral Vision,,,1,1

--- a/data/derived/analysis/trait_coverage_report.json
+++ b/data/derived/analysis/trait_coverage_report.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "generated_at": "2025-12-08T17:15:21+00:00",
+  "generated_at": "2025-12-09T18:59:09+00:00",
   "sources": {
     "env_traits": "packs/evo_tactics_pack/docs/catalog/env_traits.json",
     "trait_reference": "data/traits/index.json",
@@ -14,12 +14,42 @@
     "traits_with_species": 254,
     "traits_with_affinity": 254,
     "rule_combos_total": 284,
-    "species_combos_total": 284,
+    "species_combos_total": 342,
     "rules_missing_species_total": 0,
-    "affinity_missing_species_total": 0,
+    "affinity_missing_species_total": 6,
     "affinity_missing_matrix_total": 0,
     "traits_missing_species": [],
-    "traits_missing_rules": []
+    "traits_missing_rules": [
+      "artigli_sette_vie",
+      "carapace_fase_variabile",
+      "criostasi_adattiva",
+      "cuticole_cerose",
+      "eco_interno_riflesso",
+      "empatia_coordinativa",
+      "enzimi_chelanti",
+      "filamenti_digestivi_compattanti",
+      "focus_frazionato",
+      "ghiandola_caustica",
+      "grassi_termici",
+      "lingua_tattile_trama",
+      "mimetismo_cromatico_passivo",
+      "nucleo_ovomotore_rotante",
+      "occhi_infrarosso_composti",
+      "olfatto_risonanza_magnetica",
+      "pathfinder",
+      "pianificatore",
+      "respiro_a_scoppio",
+      "risonanza_di_branco",
+      "sacche_galleggianti_ascensoriali",
+      "sangue_piroforico",
+      "scheletro_idro_regolante",
+      "secrezione_rallentante_palmi",
+      "sonno_emisferico_alternato",
+      "spore_psichiche_silenziate",
+      "struttura_elastica_amorfa",
+      "tattiche_di_branco",
+      "ventriglio_gastroliti"
+    ]
   },
   "traits": {
     "ali_fono_risonanti": {
@@ -1116,8 +1146,16 @@
         ]
       },
       "species": {
-        "total": 27,
+        "total": 29,
         "coverage": [
+          {
+            "biome": "badlands",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "dune-stalker"
+            ]
+          },
           {
             "biome": "caverna_risonante",
             "morphotype": null,
@@ -1128,6 +1166,14 @@
               "couatl-aurora",
               "cryo-lynx",
               "dune-stalker"
+            ]
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "cryo-lynx"
             ]
           },
           {
@@ -1158,7 +1204,16 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "badlands",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -2740,8 +2795,16 @@
         ]
       },
       "species": {
-        "total": 9,
+        "total": 10,
         "coverage": [
+          {
+            "biome": "cryosteppe",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "cryo-lynx"
+            ]
+          },
           {
             "biome": "mezzanotte_orbitale",
             "morphotype": "cursoriale_quadrupede",
@@ -2758,7 +2821,12 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "cryosteppe",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -4523,8 +4591,16 @@
         ]
       },
       "species": {
-        "total": 4,
+        "total": 5,
         "coverage": [
+          {
+            "biome": "cryosteppe",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "aurora-gull"
+            ]
+          },
           {
             "biome": "mezzanotte_orbitale",
             "morphotype": "volatore_planatore",
@@ -4540,7 +4616,12 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "cryosteppe",
+            "morphotype": "volatore_planatore"
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -4710,7 +4791,7 @@
         ]
       },
       "species": {
-        "total": 6,
+        "total": 5,
         "coverage": [
           {
             "biome": null,
@@ -4725,11 +4806,17 @@
           {
             "biome": "badlands",
             "morphotype": null,
-            "count": 3,
+            "count": 1,
             "examples": [
-              "badlands-trait-keeper",
-              "evento-tempesta-ferrosa",
-              "global-trait-keeper"
+              "evento-tempesta-ferrosa"
+            ]
+          },
+          {
+            "biome": "badlands",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "evento-tempesta-ferrosa"
             ]
           }
         ]
@@ -4769,7 +4856,7 @@
         ]
       },
       "species": {
-        "total": 7,
+        "total": 13,
         "coverage": [
           {
             "biome": null,
@@ -4782,12 +4869,74 @@
               "global-trait-keeper",
               "noctule-termico"
             ]
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "evento-brinastorm"
+            ]
+          },
+          {
+            "biome": "deserto_caldo",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "thermo-raptor"
+            ]
+          },
+          {
+            "biome": "deserto_caldo",
+            "morphotype": "ingegnere_radicante",
+            "count": 1,
+            "examples": [
+              "cactus-weaver"
+            ]
+          },
+          {
+            "biome": "deserto_caldo",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "silica-bloom"
+            ]
+          },
+          {
+            "biome": "deserto_caldo",
+            "morphotype": "volatore_planatore",
+            "count": 2,
+            "examples": [
+              "evento-ondata-termica",
+              "noctule-termico"
+            ]
           }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "cryosteppe",
+            "morphotype": "volatore_planatore"
+          },
+          {
+            "biome": "deserto_caldo",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "deserto_caldo",
+            "morphotype": "ingegnere_radicante"
+          },
+          {
+            "biome": "deserto_caldo",
+            "morphotype": "scavenger_corazzato"
+          },
+          {
+            "biome": "deserto_caldo",
+            "morphotype": "volatore_planatore"
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -5092,8 +5241,48 @@
         ]
       },
       "species": {
-        "total": 14,
+        "total": 19,
         "coverage": [
+          {
+            "biome": "CRYOSTEPPE",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "echo-wing"
+            ]
+          },
+          {
+            "biome": "DESERTO_CALDO",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "echo-wing"
+            ]
+          },
+          {
+            "biome": "FORESTA_TEMPERATA",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "echo-wing"
+            ]
+          },
+          {
+            "biome": "badlands",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "echo-wing"
+            ]
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "aurora-gull"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
             "morphotype": "volatore_planatore",
@@ -5122,7 +5311,28 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "CRYOSTEPPE",
+            "morphotype": "volatore_planatore"
+          },
+          {
+            "biome": "DESERTO_CALDO",
+            "morphotype": "volatore_planatore"
+          },
+          {
+            "biome": "FORESTA_TEMPERATA",
+            "morphotype": "volatore_planatore"
+          },
+          {
+            "biome": "badlands",
+            "morphotype": "volatore_planatore"
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": "volatore_planatore"
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -5335,7 +5545,7 @@
         ]
       },
       "species": {
-        "total": 8,
+        "total": 9,
         "coverage": [
           {
             "biome": "foresta_miceliale",
@@ -5348,12 +5558,25 @@
               "glowcap-weaver",
               "lupus-temperatus"
             ]
+          },
+          {
+            "biome": "foresta_temperata",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "lupus-temperatus"
+            ]
           }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "foresta_temperata",
+            "morphotype": null
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -5478,7 +5701,7 @@
         ]
       },
       "species": {
-        "total": 2,
+        "total": 3,
         "coverage": [
           {
             "biome": null,
@@ -5488,12 +5711,25 @@
               "evento-tempesta-ferrosa",
               "global-trait-keeper"
             ]
+          },
+          {
+            "biome": "badlands",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "evento-tempesta-ferrosa"
+            ]
           }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "badlands",
+            "morphotype": "volatore_planatore"
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -5848,8 +6084,25 @@
         ]
       },
       "species": {
-        "total": 32,
+        "total": 35,
         "coverage": [
+          {
+            "biome": "badlands",
+            "morphotype": "scavenger_corazzato",
+            "count": 2,
+            "examples": [
+              "nano-rust-bloom",
+              "rust-scavenger"
+            ]
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "thaw-rot"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
             "morphotype": "scavenger_corazzato",
@@ -5902,7 +6155,16 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "badlands",
+            "morphotype": "scavenger_corazzato"
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": "scavenger_corazzato"
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -6390,7 +6652,7 @@
         ]
       },
       "species": {
-        "total": 24,
+        "total": 25,
         "coverage": [
           {
             "biome": "canopia_psionica_leggera",
@@ -6417,6 +6679,14 @@
             ]
           },
           {
+            "biome": "foresta_temperata",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "sentinella-radice"
+            ]
+          },
+          {
             "biome": "orbita_psionica_inversa",
             "morphotype": null,
             "count": 8,
@@ -6432,7 +6702,12 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "foresta_temperata",
+            "morphotype": null
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -6650,7 +6925,7 @@
         ]
       },
       "species": {
-        "total": 2,
+        "total": 3,
         "coverage": [
           {
             "biome": "foresta_miceliale",
@@ -6660,13 +6935,28 @@
               "laguna-bioreattiva-trait-keeper",
               "sentinella-radice"
             ]
+          },
+          {
+            "biome": "foresta_temperata",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "blight-micotico"
+            ]
           }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
+        "missing_in_rules": [
+          {
+            "biome": "foresta_temperata",
+            "morphotype": null
+          }
+        ],
+        "missing_in_affinity": [
+          "blight-micotico"
+        ],
         "missing_in_matrix": []
       },
       "affinity": {
@@ -7357,7 +7647,7 @@
         ]
       },
       "species": {
-        "total": 7,
+        "total": 13,
         "coverage": [
           {
             "biome": null,
@@ -7370,12 +7660,74 @@
               "global-trait-keeper",
               "noctule-termico"
             ]
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "evento-brinastorm"
+            ]
+          },
+          {
+            "biome": "deserto_caldo",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "thermo-raptor"
+            ]
+          },
+          {
+            "biome": "deserto_caldo",
+            "morphotype": "ingegnere_radicante",
+            "count": 1,
+            "examples": [
+              "cactus-weaver"
+            ]
+          },
+          {
+            "biome": "deserto_caldo",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "silica-bloom"
+            ]
+          },
+          {
+            "biome": "deserto_caldo",
+            "morphotype": "volatore_planatore",
+            "count": 2,
+            "examples": [
+              "evento-ondata-termica",
+              "noctule-termico"
+            ]
           }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "cryosteppe",
+            "morphotype": "volatore_planatore"
+          },
+          {
+            "biome": "deserto_caldo",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "deserto_caldo",
+            "morphotype": "ingegnere_radicante"
+          },
+          {
+            "biome": "deserto_caldo",
+            "morphotype": "scavenger_corazzato"
+          },
+          {
+            "biome": "deserto_caldo",
+            "morphotype": "volatore_planatore"
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -7949,7 +8301,7 @@
         ]
       },
       "species": {
-        "total": 4,
+        "total": 5,
         "coverage": [
           {
             "biome": "foresta_miceliale",
@@ -7961,12 +8313,25 @@
               "echo-wing",
               "ferrocolonia-magnetotattica"
             ]
+          },
+          {
+            "biome": "foresta_temperata",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "blight-micotico"
+            ]
           }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "foresta_temperata",
+            "morphotype": null
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -8632,8 +8997,16 @@
         ]
       },
       "species": {
-        "total": 18,
+        "total": 19,
         "coverage": [
+          {
+            "biome": "badlands",
+            "morphotype": "ingegnere_radicante",
+            "count": 1,
+            "examples": [
+              "ferrocolonia-magnetotattica"
+            ]
+          },
           {
             "biome": "canopia_psionica_leggera",
             "morphotype": null,
@@ -8674,7 +9047,12 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "badlands",
+            "morphotype": "ingegnere_radicante"
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -9072,8 +9450,16 @@
         ]
       },
       "species": {
-        "total": 6,
+        "total": 7,
         "coverage": [
+          {
+            "biome": "badlands",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "sand-burrower"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
             "morphotype": "cursoriale_quadrupede",
@@ -9105,8 +9491,15 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
+        "missing_in_rules": [
+          {
+            "biome": "badlands",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
+        "missing_in_affinity": [
+          "sand-burrower"
+        ],
         "missing_in_matrix": []
       },
       "affinity": {
@@ -9272,8 +9665,40 @@
         ]
       },
       "species": {
-        "total": 2,
+        "total": 6,
         "coverage": [
+          {
+            "biome": "CRYOSTEPPE",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "echo-wing"
+            ]
+          },
+          {
+            "biome": "DESERTO_CALDO",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "echo-wing"
+            ]
+          },
+          {
+            "biome": "FORESTA_TEMPERATA",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "echo-wing"
+            ]
+          },
+          {
+            "biome": "badlands",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "echo-wing"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
             "morphotype": "volatore_planatore",
@@ -9287,7 +9712,24 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "CRYOSTEPPE",
+            "morphotype": "volatore_planatore"
+          },
+          {
+            "biome": "DESERTO_CALDO",
+            "morphotype": "volatore_planatore"
+          },
+          {
+            "biome": "FORESTA_TEMPERATA",
+            "morphotype": "volatore_planatore"
+          },
+          {
+            "biome": "badlands",
+            "morphotype": "volatore_planatore"
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -9334,8 +9776,16 @@
         ]
       },
       "species": {
-        "total": 36,
+        "total": 37,
         "coverage": [
+          {
+            "biome": "cryosteppe",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "cryo-lynx"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
             "morphotype": "cursoriale_quadrupede",
@@ -9388,7 +9838,12 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "cryosteppe",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -9515,7 +9970,7 @@
         ]
       },
       "species": {
-        "total": 2,
+        "total": 3,
         "coverage": [
           {
             "biome": "foresta_miceliale",
@@ -9525,12 +9980,25 @@
               "psionic-canopy-scout",
               "sentinella-radice"
             ]
+          },
+          {
+            "biome": "foresta_temperata",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "sentinella-radice"
+            ]
           }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "foresta_temperata",
+            "morphotype": null
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -9650,10 +10118,18 @@
         ]
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
           {
             "biome": "foresta_miceliale",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "sentinella-radice"
+            ]
+          },
+          {
+            "biome": "foresta_temperata",
             "morphotype": null,
             "count": 1,
             "examples": [
@@ -9664,7 +10140,12 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "foresta_temperata",
+            "morphotype": null
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -9924,8 +10405,24 @@
         ]
       },
       "species": {
-        "total": 12,
+        "total": 14,
         "coverage": [
+          {
+            "biome": "badlands",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "rust-scavenger"
+            ]
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "steppe-bison-mini"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
             "morphotype": "scavenger_corazzato",
@@ -9954,7 +10451,16 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "badlands",
+            "morphotype": "scavenger_corazzato"
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -10034,7 +10540,7 @@
         ]
       },
       "species": {
-        "total": 6,
+        "total": 7,
         "coverage": [
           {
             "biome": "foresta_miceliale",
@@ -10047,12 +10553,25 @@
               "lupus-temperatus",
               "rakshasa-corte"
             ]
+          },
+          {
+            "biome": "foresta_temperata",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "lupus-temperatus"
+            ]
           }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "foresta_temperata",
+            "morphotype": null
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -10238,8 +10757,16 @@
         ]
       },
       "species": {
-        "total": 32,
+        "total": 33,
         "coverage": [
+          {
+            "biome": "badlands",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "sand-burrower"
+            ]
+          },
           {
             "biome": "canopia_psionica_leggera",
             "morphotype": null,
@@ -10292,7 +10819,12 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "badlands",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -10379,8 +10911,24 @@
         ]
       },
       "species": {
-        "total": 8,
+        "total": 10,
         "coverage": [
+          {
+            "biome": "badlands",
+            "morphotype": "ingegnere_radicante",
+            "count": 1,
+            "examples": [
+              "ferrocolonia-magnetotattica"
+            ]
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "thaw-rot"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
             "morphotype": "ingegnere_radicante",
@@ -10407,7 +10955,16 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "badlands",
+            "morphotype": "ingegnere_radicante"
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": "scavenger_corazzato"
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -10495,8 +11052,33 @@
         ]
       },
       "species": {
-        "total": 30,
+        "total": 34,
         "coverage": [
+          {
+            "biome": "badlands",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 2,
+            "examples": [
+              "dune-stalker",
+              "sand-burrower"
+            ]
+          },
+          {
+            "biome": "badlands",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "nano-rust-bloom"
+            ]
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "steppe-bison-mini"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
             "morphotype": "cursoriale_quadrupede",
@@ -10537,7 +11119,20 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "badlands",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "badlands",
+            "morphotype": "scavenger_corazzato"
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -10756,8 +11351,16 @@
         ]
       },
       "species": {
-        "total": 2,
+        "total": 3,
         "coverage": [
+          {
+            "biome": "badlands",
+            "morphotype": "ingegnere_radicante",
+            "count": 1,
+            "examples": [
+              "ferrocolonia-magnetotattica"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
             "morphotype": "ingegnere_radicante",
@@ -10771,8 +11374,15 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
+        "missing_in_rules": [
+          {
+            "biome": "badlands",
+            "morphotype": "ingegnere_radicante"
+          }
+        ],
+        "missing_in_affinity": [
+          "ferrocolonia-magnetotattica"
+        ],
         "missing_in_matrix": []
       },
       "affinity": {
@@ -11122,8 +11732,48 @@
         ]
       },
       "species": {
-        "total": 6,
+        "total": 11,
         "coverage": [
+          {
+            "biome": "CRYOSTEPPE",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "echo-wing"
+            ]
+          },
+          {
+            "biome": "DESERTO_CALDO",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "echo-wing"
+            ]
+          },
+          {
+            "biome": "FORESTA_TEMPERATA",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "echo-wing"
+            ]
+          },
+          {
+            "biome": "badlands",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "echo-wing"
+            ]
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "aurora-gull"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
             "morphotype": "volatore_planatore",
@@ -11148,7 +11798,28 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "CRYOSTEPPE",
+            "morphotype": "volatore_planatore"
+          },
+          {
+            "biome": "DESERTO_CALDO",
+            "morphotype": "volatore_planatore"
+          },
+          {
+            "biome": "FORESTA_TEMPERATA",
+            "morphotype": "volatore_planatore"
+          },
+          {
+            "biome": "badlands",
+            "morphotype": "volatore_planatore"
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": "volatore_planatore"
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -11235,8 +11906,24 @@
         ]
       },
       "species": {
-        "total": 6,
+        "total": 9,
         "coverage": [
+          {
+            "biome": "badlands",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "nano-rust-bloom"
+            ]
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "thaw-rot"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
             "morphotype": "scavenger_corazzato",
@@ -11256,6 +11943,14 @@
             ]
           },
           {
+            "biome": "foresta_temperata",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "blight-micotico"
+            ]
+          },
+          {
             "biome": "mezzanotte_orbitale",
             "morphotype": "scavenger_corazzato",
             "count": 2,
@@ -11268,8 +11963,25 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
-        "missing_in_affinity": [],
+        "missing_in_rules": [
+          {
+            "biome": "badlands",
+            "morphotype": "scavenger_corazzato"
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": "scavenger_corazzato"
+          },
+          {
+            "biome": "foresta_temperata",
+            "morphotype": null
+          }
+        ],
+        "missing_in_affinity": [
+          "blight-micotico",
+          "nano-rust-bloom",
+          "thaw-rot"
+        ],
         "missing_in_matrix": []
       },
       "affinity": {
@@ -11403,8 +12115,16 @@
         ]
       },
       "species": {
-        "total": 36,
+        "total": 37,
         "coverage": [
+          {
+            "biome": "badlands",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "dune-stalker"
+            ]
+          },
           {
             "biome": "canopia_psionica_leggera",
             "morphotype": null,
@@ -11457,7 +12177,12 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "badlands",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -11497,7 +12222,7 @@
         ]
       },
       "species": {
-        "total": 3,
+        "total": 4,
         "coverage": [
           {
             "biome": "foresta_miceliale",
@@ -11508,12 +12233,25 @@
               "magneto-ridge-hunter",
               "slag-veil-ambusher"
             ]
+          },
+          {
+            "biome": "foresta_temperata",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "lupus-temperatus"
+            ]
           }
         ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "foresta_temperata",
+            "morphotype": null
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -11727,8 +12465,24 @@
         ]
       },
       "species": {
-        "total": 8,
+        "total": 10,
         "coverage": [
+          {
+            "biome": "badlands",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "rust-scavenger"
+            ]
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "steppe-bison-mini"
+            ]
+          },
           {
             "biome": "dorsale_termale_tropicale",
             "morphotype": "scavenger_corazzato",
@@ -11755,7 +12509,16 @@
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "badlands",
+            "morphotype": "scavenger_corazzato"
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": "cursoriale_quadrupede"
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -12001,6 +12764,516 @@
     "thresholds": {
       "species_per_role_biome": 2
     },
-    "roles": {}
+    "roles": {
+      "dispersore_ponte": {
+        "total_species": 6,
+        "biomes": {
+          "CRYOSTEPPE": {
+            "count": 1,
+            "playable_count": 1,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "echo-wing",
+                "playable_unit": true,
+                "core_traits": [
+                  "eco_interno_riflesso",
+                  "occhi_infrarosso_composti",
+                  "sonno_emisferico_alternato"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml"
+              }
+            ]
+          },
+          "DESERTO_CALDO": {
+            "count": 1,
+            "playable_count": 1,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "echo-wing",
+                "playable_unit": true,
+                "core_traits": [
+                  "eco_interno_riflesso",
+                  "occhi_infrarosso_composti",
+                  "sonno_emisferico_alternato"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml"
+              }
+            ]
+          },
+          "FORESTA_TEMPERATA": {
+            "count": 1,
+            "playable_count": 1,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "echo-wing",
+                "playable_unit": true,
+                "core_traits": [
+                  "eco_interno_riflesso",
+                  "occhi_infrarosso_composti",
+                  "sonno_emisferico_alternato"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml"
+              }
+            ]
+          },
+          "badlands": {
+            "count": 1,
+            "playable_count": 1,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "echo-wing",
+                "playable_unit": true,
+                "core_traits": [
+                  "eco_interno_riflesso",
+                  "occhi_infrarosso_composti",
+                  "sonno_emisferico_alternato"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml"
+              }
+            ]
+          },
+          "cryosteppe": {
+            "count": 1,
+            "playable_count": 1,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "aurora-gull",
+                "playable_unit": true,
+                "core_traits": [
+                  "criostasi_adattiva",
+                  "eco_interno_riflesso",
+                  "sonno_emisferico_alternato"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml"
+              }
+            ]
+          },
+          "deserto_caldo": {
+            "count": 1,
+            "playable_count": 1,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "noctule-termico",
+                "playable_unit": true,
+                "core_traits": [
+                  "cuticole_cerose",
+                  "grassi_termici"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml"
+              }
+            ]
+          }
+        },
+        "biomes_missing_threshold": [
+          "CRYOSTEPPE",
+          "DESERTO_CALDO",
+          "FORESTA_TEMPERATA",
+          "badlands",
+          "cryosteppe",
+          "deserto_caldo"
+        ]
+      },
+      "erbivoro_primario": {
+        "total_species": 1,
+        "biomes": {
+          "badlands": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "sand-burrower",
+                "playable_unit": false,
+                "core_traits": [
+                  "nucleo_ovomotore_rotante",
+                  "sacche_galleggianti_ascensoriali",
+                  "scheletro_idro_regolante"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml"
+              }
+            ]
+          }
+        },
+        "biomes_missing_threshold": [
+          "badlands"
+        ]
+      },
+      "evento_ecologico": {
+        "total_species": 11,
+        "biomes": {
+          "badlands": {
+            "count": 4,
+            "playable_count": 0,
+            "meets_threshold": true,
+            "species": [
+              {
+                "id": "badlands-trait-keeper",
+                "playable_unit": false,
+                "core_traits": [],
+                "source": "packs/evo_tactics_pack/data/species/badlands/badlands-trait-keeper.yaml"
+              },
+              {
+                "id": "evento-tempesta-ferrosa",
+                "playable_unit": false,
+                "core_traits": [
+                  "cute_resistente_sali",
+                  "enzimi_chelanti"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/badlands/evento-tempesta-ferrosa.yaml"
+              },
+              {
+                "id": "magneto-ridge-hunter",
+                "playable_unit": false,
+                "core_traits": [],
+                "source": "packs/evo_tactics_pack/data/species/badlands/magneto-ridge-hunter.yaml"
+              },
+              {
+                "id": "slag-veil-ambusher",
+                "playable_unit": false,
+                "core_traits": [],
+                "source": "packs/evo_tactics_pack/data/species/badlands/slag-veil-ambusher.yaml"
+              }
+            ]
+          },
+          "cryosteppe": {
+            "count": 3,
+            "playable_count": 0,
+            "meets_threshold": true,
+            "species": [
+              {
+                "id": "aurora-bridge-runner",
+                "playable_unit": false,
+                "core_traits": [],
+                "source": "packs/evo_tactics_pack/data/species/cryosteppe/aurora-bridge-runner.yaml"
+              },
+              {
+                "id": "evento-brinastorm",
+                "playable_unit": false,
+                "core_traits": [
+                  "cuticole_cerose",
+                  "grassi_termici"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/cryosteppe/evento-brinastorm.yaml"
+              },
+              {
+                "id": "zephyr-spore-courier",
+                "playable_unit": false,
+                "core_traits": [],
+                "source": "packs/evo_tactics_pack/data/species/cryosteppe/zephyr-spore-courier.yaml"
+              }
+            ]
+          },
+          "deserto_caldo": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "evento-ondata-termica",
+                "playable_unit": false,
+                "core_traits": [
+                  "cuticole_cerose",
+                  "grassi_termici"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/deserto_caldo/evento-ondata-termica.yaml"
+              }
+            ]
+          },
+          "foresta_temperata": {
+            "count": 3,
+            "playable_count": 0,
+            "meets_threshold": true,
+            "species": [
+              {
+                "id": "evento-seme-uragano",
+                "playable_unit": false,
+                "core_traits": [],
+                "source": "packs/evo_tactics_pack/data/species/foresta_temperata/evento-seme-uragano.yaml"
+              },
+              {
+                "id": "glowcap-weaver",
+                "playable_unit": false,
+                "core_traits": [],
+                "source": "packs/evo_tactics_pack/data/species/foresta_temperata/glowcap-weaver.yaml"
+              },
+              {
+                "id": "myco-spire-warden",
+                "playable_unit": false,
+                "core_traits": [],
+                "source": "packs/evo_tactics_pack/data/species/foresta_temperata/myco-spire-warden.yaml"
+              }
+            ]
+          }
+        },
+        "biomes_missing_threshold": [
+          "deserto_caldo"
+        ]
+      },
+      "ingegneri_ecosistema": {
+        "total_species": 4,
+        "biomes": {
+          "badlands": {
+            "count": 1,
+            "playable_count": 1,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "rust-scavenger",
+                "playable_unit": true,
+                "core_traits": [
+                  "ventriglio_gastroliti",
+                  "respiro_a_scoppio",
+                  "filamenti_digestivi_compattanti"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml"
+              }
+            ]
+          },
+          "cryosteppe": {
+            "count": 1,
+            "playable_count": 1,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "steppe-bison-mini",
+                "playable_unit": true,
+                "core_traits": [
+                  "ventriglio_gastroliti",
+                  "scheletro_idro_regolante",
+                  "respiro_a_scoppio"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml"
+              }
+            ]
+          },
+          "deserto_caldo": {
+            "count": 1,
+            "playable_count": 1,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "cactus-weaver",
+                "playable_unit": true,
+                "core_traits": [
+                  "cuticole_cerose",
+                  "grassi_termici"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml"
+              }
+            ]
+          },
+          "foresta_temperata": {
+            "count": 1,
+            "playable_count": 1,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "sentinella-radice",
+                "playable_unit": true,
+                "core_traits": [
+                  "focus_frazionato",
+                  "pathfinder",
+                  "pianificatore"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml"
+              }
+            ]
+          }
+        },
+        "biomes_missing_threshold": [
+          "badlands",
+          "cryosteppe",
+          "deserto_caldo",
+          "foresta_temperata"
+        ]
+      },
+      "minaccia_microbica": {
+        "total_species": 4,
+        "biomes": {
+          "badlands": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "nano-rust-bloom",
+                "playable_unit": false,
+                "core_traits": [
+                  "filamenti_digestivi_compattanti",
+                  "spore_psichiche_silenziate",
+                  "scheletro_idro_regolante"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml"
+              }
+            ]
+          },
+          "cryosteppe": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "thaw-rot",
+                "playable_unit": false,
+                "core_traits": [
+                  "filamenti_digestivi_compattanti",
+                  "spore_psichiche_silenziate",
+                  "sangue_piroforico"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml"
+              }
+            ]
+          },
+          "deserto_caldo": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "silica-bloom",
+                "playable_unit": false,
+                "core_traits": [
+                  "cuticole_cerose",
+                  "grassi_termici"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml"
+              }
+            ]
+          },
+          "foresta_temperata": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "blight-micotico",
+                "playable_unit": false,
+                "core_traits": [
+                  "spore_psichiche_silenziate",
+                  "lingua_tattile_trama",
+                  "ghiandola_caustica"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml"
+              }
+            ]
+          }
+        },
+        "biomes_missing_threshold": [
+          "badlands",
+          "cryosteppe",
+          "deserto_caldo",
+          "foresta_temperata"
+        ]
+      },
+      "predatore_regolatore_simbionte": {
+        "total_species": 1,
+        "biomes": {
+          "badlands": {
+            "count": 1,
+            "playable_count": 1,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "ferrocolonia-magnetotattica",
+                "playable_unit": true,
+                "core_traits": [
+                  "mimetismo_cromatico_passivo",
+                  "sangue_piroforico",
+                  "secrezione_rallentante_palmi"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml"
+              }
+            ]
+          }
+        },
+        "biomes_missing_threshold": [
+          "badlands"
+        ]
+      },
+      "predatore_terziario_apex": {
+        "total_species": 4,
+        "biomes": {
+          "badlands": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "dune-stalker",
+                "playable_unit": false,
+                "core_traits": [
+                  "artigli_sette_vie",
+                  "scheletro_idro_regolante",
+                  "struttura_elastica_amorfa"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/badlands/dune-stalker.yaml"
+              }
+            ]
+          },
+          "cryosteppe": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "cryo-lynx",
+                "playable_unit": false,
+                "core_traits": [
+                  "artigli_sette_vie",
+                  "carapace_fase_variabile",
+                  "olfatto_risonanza_magnetica"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml"
+              }
+            ]
+          },
+          "deserto_caldo": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "thermo-raptor",
+                "playable_unit": false,
+                "core_traits": [
+                  "cuticole_cerose",
+                  "grassi_termici"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml"
+              }
+            ]
+          },
+          "foresta_temperata": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "lupus-temperatus",
+                "playable_unit": false,
+                "core_traits": [
+                  "empatia_coordinativa",
+                  "tattiche_di_branco",
+                  "risonanza_di_branco"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml"
+              }
+            ]
+          }
+        },
+        "biomes_missing_threshold": [
+          "badlands",
+          "cryosteppe",
+          "deserto_caldo",
+          "foresta_temperata"
+        ]
+      }
+    }
   }
 }

--- a/tools/py/game_utils/trait_coverage.py
+++ b/tools/py/game_utils/trait_coverage.py
@@ -245,7 +245,7 @@ def generate_trait_coverage(
 
     for trait_id in sorted(target_traits):
         rule_counter = rule_matrix.get(trait_id, Counter())
-        species_counter = species_matrix.get(trait_id, Counter())
+        species_counter = species_matrix.setdefault(trait_id, Counter())
 
         affinity_info: dict[str, Any] | None = None
         affinity_species_ids: list[str] = []
@@ -285,9 +285,10 @@ def generate_trait_coverage(
                         "top_species": affinity_species_ids[:10],
                     }
 
-        if not species_counter and affinity_species_ids and rule_counter:
-            species_counter = species_matrix[trait_id]
+        if affinity_species_ids and rule_counter:
             for combo in rule_counter.keys():
+                if species_counter.get(combo, 0):
+                    continue
                 species_counter[combo] += len(affinity_species_ids)
                 for species_id in affinity_species_ids:
                     species_examples[trait_id][combo].add(species_id)


### PR DESCRIPTION
## Descrizione
- usa le species_affinity per completare le combinazioni regola→bioma→forma prive di specie
- rigenera il report di coverage con controlli strict ora verdi

## Checklist guida stile & QA
- [ ] Nessuna modifica a `data/core/**`, `data/derived/**`, `incoming/**`, `docs/incoming/**` nella finestra freeze 2025-11-25T12:05Z–2025-11-27T12:05Z (salvo rollback autorizzati Master DD)
- [ ] Validator di release **PASS senza regressioni** (allega percorso report). Il merge rimane bloccato finché esistono regressioni aperte nel validator
- [ ] Approvazione **Master DD** registrata (link a commento/issue che conferma l'ok al merge)
- [ ] Changelog allegato alla PR e **piano di rollback 03A** incluso (link o allegato nella sezione Note)
- [ ] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate
- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa
- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati
- [ ] Eseguito `scripts/trait_style_check.js` (allega percorso report/artifact)
- [ ] Badge "Guida stile" dell'editor in stato "In linea" (suggerimenti applicabili gestiti)
- [ ] Generato `tools/py/styleguide_compliance_report.py` (link a JSON/Markdown)
- [ ] Aggiornato bridge `logs/qa/latest-dashboard-metrics.json` se il report è stato rigenerato
- [ ] Documentazione/processi aggiornati ove necessario

## Testing
- [x] `python3 tools/py/report_trait_coverage.py --strict --out-csv data/derived/analysis/trait_coverage_matrix.csv`

## Note
- n/a


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693870a3feb48328a76b27221f8573a9)