### PR TITLE
Allow disabling orchestrator metrics when prom-client is absent

### DIFF
--- a/apps/backend/services/orchestratorMetrics.js
+++ b/apps/backend/services/orchestratorMetrics.js
@@ -8,11 +8,22 @@ let promClientLoadAttempted = false;
 let missingDependencyLogged = false;
 let defaultMetricsRegistered = false;
 
+function isMetricsDisabled() {
+  const flag = String(process.env.ORCHESTRATOR_METRICS_DISABLED || '')
+    .trim()
+    .toLowerCase();
+  return ['1', 'true', 'yes', 'on'].includes(flag);
+}
+
 function loadPromClient() {
   if (promClientLoadAttempted) {
     return promClientRef;
   }
   promClientLoadAttempted = true;
+  if (isMetricsDisabled()) {
+    promClientRef = null;
+    return promClientRef;
+  }
   try {
     // Lazy require to keep the dependency optional for environments that do not install it.
     // eslint-disable-next-line global-require, import/no-extraneous-dependencies

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "drive:push-approved": "node tools/drive/push-approved-assets.mjs",
     "drive-sync": "node tools/drive/sync-approved-assets.mjs",
     "stage:publishing": "node services/publishing/staging.js",
-    "export:qa": "node scripts/export-qa-report.js",
+    "export:qa": "ORCHESTRATOR_METRICS_DISABLED=true node scripts/export-qa-report.js",
     "mock:generate": "node scripts/mock/generate-demo-data.js",
     "webapp:deploy": "npm run build --workspace apps/dashboard && npm run preview --workspace apps/dashboard",
     "webapp:qa": "npm run qa --workspace apps/dashboard",


### PR DESCRIPTION
## Descrizione
- Aggiunto un flag d'ambiente per disattivare il caricamento delle metriche dell'orchestrator quando prom-client non è disponibile.
- Lo script `export:qa` disattiva le metriche per evitare avvisi durante la generazione dei report QA.

## Checklist guida stile & QA
- [ ] Nessuna modifica a `data/core/**`, `data/derived/**`, `incoming/**`, `docs/incoming/**` nella finestra freeze 2025-11-25T12:05Z–2025-11-27T12:05Z (salvo rollback autorizzati Master DD)
- [ ] Validator di release **PASS senza regressioni** (allega percorso report). Il merge rimane bloccato finché esistono regressioni aperte nel validator
- [ ] Approvazione **Master DD** registrata (link a commento/issue che conferma l'ok al merge)
- [ ] Changelog allegato alla PR e **piano di rollback 03A** incluso (link o allegato nella sezione Note)
- [ ] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate
- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa
- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati
- [ ] Eseguito `scripts/trait_style_check.js` (allega percorso report/artifact)
- [ ] Badge "Guida stile" dell'editor in stato "In linea" (suggerimenti applicabili gestiti)
- [ ] Generato `tools/py/styleguide_compliance_report.py` (link a JSON/Markdown)
- [ ] Aggiornato bridge `logs/qa/latest-dashboard-metrics.json` se il report è stato rigenerato
- [ ] Documentazione/processi aggiornati ove necessario

## Testing
- [ ] `npm run style:check`
- [ ] Altro: non eseguiti (fix mirato di configurazione)

## Note
- Nessun report QA rigenerato in questa modifica.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938739704b883288a1aea84613e44a1)