### PR TITLE
Handle lint-stack diff fallback

### DIFF
--- a/scripts/lint-stack.mjs
+++ b/scripts/lint-stack.mjs
@@ -43,21 +43,24 @@ const resolveBase = () => {
   return null;
 };
 
+const getStatusPaths = () =>
+  run('git status --porcelain')
+    .split('\n')
+    .map((line) => line.slice(3).trim())
+    .filter(Boolean)
+    .join('\n');
+
 const diffRange = resolveBase();
 let diffOutput = '';
 try {
   if (diffRange) {
     diffOutput = run(`git diff --name-only ${diffRange}`).trim();
   } else {
-    diffOutput = run('git status --porcelain')
-      .split('\n')
-      .map((line) => line.slice(3).trim())
-      .filter(Boolean)
-      .join('\n');
+    diffOutput = getStatusPaths();
   }
 } catch (error) {
-  console.error('Unable to compute diff for linting:', error.message);
-  process.exit(1);
+  console.warn('Unable to compute diff for linting, falling back to working tree:', error.message);
+  diffOutput = getStatusPaths();
 }
 
 if (!diffOutput) {


### PR DESCRIPTION
## Descrizione
- Gestito il fallback del calcolo diff in `scripts/lint-stack.mjs` usando lo stato della working tree quando manca il merge base.
- Evitata l'uscita con errore del lint quando non è disponibile `origin/main` o un merge base.

## Checklist guida stile & QA
- [x] Nessuna modifica a `data/core/**`, `data/derived/**`, `incoming/**`, `docs/incoming/**` nella finestra freeze 2025-11-25T12:05Z–2025-11-27T12:05Z (salvo rollback autorizzati Master DD)
- [ ] Validator di release **PASS senza regressioni** (n/a)
- [ ] Approvazione **Master DD** registrata (n/a)
- [ ] Changelog allegato alla PR e **piano di rollback 03A** incluso (n/a)
- [ ] Chiavi i18n `i18n:traits.<id>.campo` verificate/aggiornate (n/a)
- [ ] Tier, slot e `slot_profile` coerenti con la nomenclatura condivisa (n/a)
- [ ] Requisiti ambientali (`meta.tier`, `meta.notes`) e `completion_flags` sincronizzati (n/a)
- [ ] Eseguito `scripts/trait_style_check.js` (n/a)
- [ ] Badge "Guida stile" dell'editor in stato "In linea" (n/a)
- [ ] Generato `tools/py/styleguide_compliance_report.py` (n/a)
- [ ] Aggiornato bridge `logs/qa/latest-dashboard-metrics.json` se il report è stato rigenerato (n/a)
- [ ] Documentazione/processi aggiornati ove necessario (n/a)

## Testing
- [x] `npm run lint:stack`

## Note
- n/a

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693876151f2c83289fc90ecc1de3c056)