### PR TITLE
Improve test fallbacks for idea and trait APIs

### DIFF
--- a/apps/backend/db/prisma.js
+++ b/apps/backend/db/prisma.js
@@ -10,6 +10,69 @@ function createPrismaStub(error) {
     throw new Error(missingClientError);
   };
 
+  const ideas = [];
+  let ideaIdSeq = 1;
+
+  function cloneWithFeedback(record, include) {
+    if (!record) return null;
+    const base = { ...record };
+    if (include && include.feedback) {
+      const feedback = Array.isArray(record.feedback) ? [...record.feedback] : [];
+      if (include.feedback.orderBy && include.feedback.orderBy.createdAt === 'asc') {
+        feedback.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
+      }
+      base.feedback = feedback;
+    }
+    return base;
+  }
+
+  const idea = {
+    async findMany(params = {}) {
+      return ideas.map((item) => cloneWithFeedback(item, params.include));
+    },
+    async findUnique(params = {}) {
+      const id = params?.where?.id;
+      const found = ideas.find((item) => item.id === id);
+      return cloneWithFeedback(found, params.include);
+    },
+    async count() {
+      return ideas.length;
+    },
+    async create(params = {}) {
+      const now = new Date();
+      const record = {
+        id: ideaIdSeq++,
+        createdAt: now,
+        updatedAt: now,
+        feedback: [],
+        ...(params.data || {}),
+      };
+      ideas.push(record);
+      return cloneWithFeedback(record, params.include);
+    },
+    async update(params = {}) {
+      const id = params?.where?.id;
+      const record = ideas.find((item) => item.id === id);
+      if (!record) {
+        throw new Error('Record non trovato');
+      }
+      const now = new Date();
+      const feedbackPayload = params?.data?.feedback?.create;
+      if (feedbackPayload) {
+        const entry = {
+          id: record.feedback.length + 1,
+          message: feedbackPayload.message,
+          contact: feedbackPayload.contact || '',
+          createdAt: now,
+          updatedAt: now,
+        };
+        record.feedback.push(entry);
+      }
+      record.updatedAt = now;
+      return cloneWithFeedback(record, params.include);
+    },
+  };
+
   const stubCollection = {
     findMany: async () => [],
     findUnique: async () => null,
@@ -19,7 +82,7 @@ function createPrismaStub(error) {
   };
 
   return {
-    idea: stubCollection,
+    idea,
     feedback: stubCollection,
     species: stubCollection,
     biome: stubCollection,
@@ -32,6 +95,11 @@ function createPrismaStub(error) {
 let prisma;
 
 try {
+  const missingDatabaseUrl = !process.env.DATABASE_URL;
+  if (missingDatabaseUrl) {
+    throw new Error('DATABASE_URL non configurato');
+  }
+
   prisma =
     globalForPrisma.prisma ||
     new PrismaClient({

--- a/apps/backend/routes/traits.js
+++ b/apps/backend/routes/traits.js
@@ -435,10 +435,10 @@ function createTraitRouter(options = {}) {
     try {
       const author = resolveAuthor(req, null);
       const deleted = await repository.deleteTrait(req.params.traitId, { author });
-      res.json(deleted);
       await auditTrail(req, 'trait.delete', {
         traitId: req.params.traitId,
       });
+      res.json(deleted);
     } catch (error) {
       handleError(res, error, 'Errore eliminazione trait');
     }

--- a/apps/backend/services/traitRepository.js
+++ b/apps/backend/services/traitRepository.js
@@ -2,7 +2,7 @@ const fs = require('node:fs/promises');
 const path = require('node:path');
 const Ajv = require('ajv/dist/2020');
 
-const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
 
 const DEFAULT_SCHEMA_PATH = path.resolve(REPO_ROOT, 'config', 'schemas', 'trait.schema.json');
 


### PR DESCRIPTION
## Summary
- add an in-memory Prisma stub that activates when DATABASE_URL is missing and supports idea feedback operations used in tests
- ensure trait audit logging runs before responses so audit files exist immediately
- fix trait repository schema resolution to use the repository root path

## Testing
- node --test tests/api/idea-engine.test.js
- node --test --test-reporter tap tests/api/traits.validate.test.js
- node --test --test-reporter tap tests/api/traits.auth.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693884153a4c83289d3a5adb777b48fc)