### PR TITLE
Add dashboard data source config and Vue plugin

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -14,17 +14,18 @@
   "dependencies": {
     "@game/contracts": "file:../../packages/contracts",
     "@game/ui": "file:../../packages/ui",
+    "ajv": "^8.17.1",
     "angular": "file:../../packages/angular",
     "angular-animate": "file:../../packages/angular-animate",
     "angular-route": "file:../../packages/angular-route",
     "angular-sanitize": "file:../../packages/angular-sanitize",
-    "ajv": "^8.17.1",
     "dompurify": "^3.1.7",
     "marked": "^15.0.11",
     "web-vitals": "^4.2.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@vitejs/plugin-vue": "^6.0.2",
     "jsdom": "^24.1.0",
     "rollup-plugin-visualizer": "^5.12.0",
     "typescript": "^5.9.3",

--- a/apps/dashboard/src/config/dataSources.ts
+++ b/apps/dashboard/src/config/dataSources.ts
@@ -1,0 +1,132 @@
+import { readEnvString } from '../services/apiEndpoints';
+
+type NullableString = string | null;
+
+export type DataSourceId =
+  | 'flowSnapshot'
+  | 'generationSpecies'
+  | 'generationSpeciesBatch'
+  | 'generationSpeciesPreview'
+  | 'traitDiagnostics'
+  | 'nebulaAtlas'
+  | (string & {});
+
+export interface DataSourceConfig {
+  id: DataSourceId;
+  endpoint: NullableString;
+  fallback: NullableString;
+  mock: NullableString;
+}
+
+const defaults: Record<DataSourceId, DataSourceConfig> = {
+  flowSnapshot: {
+    id: 'flowSnapshot',
+    endpoint: '/api/v1/generation/snapshot',
+    fallback: 'data/flow/snapshots/flow-shell-snapshot.json',
+    mock: null,
+  },
+  generationSpecies: {
+    id: 'generationSpecies',
+    endpoint: '/api/v1/generation/species',
+    fallback: null,
+    mock: null,
+  },
+  generationSpeciesBatch: {
+    id: 'generationSpeciesBatch',
+    endpoint: '/api/v1/generation/species/batch',
+    fallback: null,
+    mock: null,
+  },
+  generationSpeciesPreview: {
+    id: 'generationSpeciesPreview',
+    endpoint: '/api/v1/generation/species/batch',
+    fallback: null,
+    mock: null,
+  },
+  traitDiagnostics: {
+    id: 'traitDiagnostics',
+    endpoint: '/api/traits/diagnostics',
+    fallback: 'data/flow/traits/diagnostics.json',
+    mock: null,
+  },
+  nebulaAtlas: {
+    id: 'nebulaAtlas',
+    endpoint: '/api/v1/atlas',
+    fallback: 'data/nebula/atlas.json',
+    mock: 'data/nebula/telemetry.json',
+  },
+};
+
+function parseNullable(value: string | undefined): NullableString | undefined {
+  if (value === undefined) return undefined;
+  if (value.toLowerCase() === 'null') return null;
+  return value;
+}
+
+function mergeConfig(
+  base: DataSourceConfig,
+  overrides: Partial<DataSourceConfig>,
+): DataSourceConfig {
+  const result: DataSourceConfig = { ...base };
+  if (Object.prototype.hasOwnProperty.call(overrides, 'endpoint')) {
+    result.endpoint = overrides.endpoint ?? null;
+  }
+  if (Object.prototype.hasOwnProperty.call(overrides, 'fallback')) {
+    result.fallback = overrides.fallback ?? null;
+  }
+  if (Object.prototype.hasOwnProperty.call(overrides, 'mock')) {
+    result.mock = overrides.mock ?? null;
+  }
+  return result;
+}
+
+function getEnvOverrides(id: DataSourceId): Partial<DataSourceConfig> {
+  switch (id) {
+    case 'flowSnapshot': {
+      const endpoint = parseNullable(readEnvString('VITE_FLOW_SNAPSHOT_URL'));
+      const fallback = parseNullable(readEnvString('VITE_FLOW_SNAPSHOT_FALLBACK'));
+      const overrides: Partial<DataSourceConfig> = {};
+      if (endpoint !== undefined) overrides.endpoint = endpoint;
+      if (fallback !== undefined) overrides.fallback = fallback;
+      return overrides;
+    }
+    case 'nebulaAtlas': {
+      const fallback = parseNullable(readEnvString('VITE_NEBULA_ATLAS_FALLBACK'));
+      const mock = parseNullable(readEnvString('VITE_NEBULA_TELEMETRY_MOCK'));
+      const overrides: Partial<DataSourceConfig> = {};
+      if (fallback !== undefined) overrides.fallback = fallback;
+      if (mock !== undefined) overrides.mock = mock;
+      return overrides;
+    }
+    default:
+      return {};
+  }
+}
+
+function ensureDataSource(id: DataSourceId): DataSourceConfig {
+  const base = defaults[id];
+  if (!base) {
+    throw new Error(`Data source "${String(id)}" non configurato.`);
+  }
+  return base;
+}
+
+export function getDataSource(id: DataSourceId): DataSourceConfig {
+  const base = ensureDataSource(id);
+  const envOverrides = getEnvOverrides(id);
+  return mergeConfig(base, envOverrides);
+}
+
+export function resolveDataSource(
+  id: DataSourceId,
+  overrides: Partial<DataSourceConfig> = {},
+): DataSourceConfig {
+  const base = ensureDataSource(id);
+  const envOverrides = getEnvOverrides(id);
+  const withEnv = mergeConfig(base, envOverrides);
+  return mergeConfig(withEnv, overrides);
+}
+
+export function listDataSourceIds(): DataSourceId[] {
+  return Object.keys(defaults) as DataSourceId[];
+}

--- a/apps/dashboard/src/services/apiEndpoints.ts
+++ b/apps/dashboard/src/services/apiEndpoints.ts
@@ -1,0 +1,42 @@
+export function readEnvString(key: string): string | undefined {
+  if (typeof import.meta !== 'undefined' && typeof import.meta.env !== 'undefined') {
+    const value = import.meta.env[key];
+    if (typeof value === 'string') {
+      return value;
+    }
+  }
+  if (typeof process !== 'undefined' && process.env) {
+    const value = process.env[key];
+    if (typeof value === 'string') {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function joinUrl(base: string | undefined, path: string): string {
+  if (!base) return path;
+  const cleanedBase = base.endsWith('/') ? base.slice(0, -1) : base;
+  return path.startsWith('/') ? `${cleanedBase}${path}` : `${cleanedBase}/${path}`;
+}
+
+export function resolveApiUrl(path: string): string {
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+  const base = readEnvString('VITE_API_BASE_URL');
+  return joinUrl(base, path);
+}
+
+export function resolveAssetUrl(path: string): string {
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+  const base = readEnvString('VITE_ASSETS_BASE_URL');
+  return joinUrl(base, path);
+}
+
+export function isStaticDeployment(): boolean {
+  const flag = readEnvString('VITE_STATIC_DEPLOYMENT');
+  return flag === 'true' || flag === '1';
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "zod": "^3.24.1"
       },
       "devDependencies": {
+        "@vitejs/plugin-vue": "^6.0.2",
         "jsdom": "^24.1.0",
         "rollup-plugin-visualizer": "^5.12.0",
         "typescript": "^5.9.3",
@@ -98,6 +99,17 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
@@ -108,12 +120,44 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/parser": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.28.5"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -931,6 +975,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.50",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.50.tgz",
+      "integrity": "sha512-5e76wQiQVeL1ICOZVUg4LSOVYg9jyhGCin+icYozhsUzM+fHE7kddi1bdiE0jwVqTfkjba3jUFbEkoC9WkdvyA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.52.5",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.5.tgz",
@@ -1394,6 +1445,23 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.2.tgz",
+      "integrity": "sha512-iHmwV3QcVGGvSC1BG5bZ4z6iwa1SOpAPWmnjOErd4Ske+lZua5K9TtAVdx0gMBClJ28DViCbSmZitjWZsWO3LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-beta.50"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "vue": "^3.2.25"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
@@ -1506,6 +1574,154 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.25.tgz",
+      "integrity": "sha512-vay5/oQJdsNHmliWoZfHPoVZZRmnSWhug0BYT34njkYTPqClh3DNWLkZNJBVSjsNMrg0CCrBfoKkjZQPM/QVUw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@vue/shared": "3.5.25",
+        "entities": "^4.5.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.25.tgz",
+      "integrity": "sha512-4We0OAcMZsKgYoGlMjzYvaoErltdFI2/25wqanuTu+S4gismOTRTBPi4IASOjxWdzIwrYSjnqONfKvuqkXzE2Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-core": "3.5.25",
+        "@vue/shared": "3.5.25"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.25.tgz",
+      "integrity": "sha512-PUgKp2rn8fFsI++lF2sO7gwO2d9Yj57Utr5yEsDf3GNaQcowCLKL7sf+LvVFvtJDXUp/03+dC6f2+LCv5aK1ag==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@vue/compiler-core": "3.5.25",
+        "@vue/compiler-dom": "3.5.25",
+        "@vue/compiler-ssr": "3.5.25",
+        "@vue/shared": "3.5.25",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.6",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.25.tgz",
+      "integrity": "sha512-ritPSKLBcParnsKYi+GNtbdbrIE1mtuFEJ4U1sWeuOMlIziK5GtOL85t5RhsNy4uWIXPgk+OUdpnXiTdzn8o3A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.25",
+        "@vue/shared": "3.5.25"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.25.tgz",
+      "integrity": "sha512-5xfAypCQepv4Jog1U4zn8cZIcbKKFka3AgWHEFQeK65OW+Ys4XybP6z2kKgws4YB43KGpqp5D/K3go2UPPunLA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/shared": "3.5.25"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.25.tgz",
+      "integrity": "sha512-Z751v203YWwYzy460bzsYQISDfPjHTl+6Zzwo/a3CsAf+0ccEjQ8c+0CdX1WsumRTHeywvyUFtW6KvNukT/smA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/reactivity": "3.5.25",
+        "@vue/shared": "3.5.25"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.25.tgz",
+      "integrity": "sha512-a4WrkYFbb19i9pjkz38zJBg8wa/rboNERq3+hRRb0dHiJh13c+6kAbgqCPfMaJ2gg4weWD3APZswASOfmKwamA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/reactivity": "3.5.25",
+        "@vue/runtime-core": "3.5.25",
+        "@vue/shared": "3.5.25",
+        "csstype": "^3.1.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.25.tgz",
+      "integrity": "sha512-UJaXR54vMG61i8XNIzTSf2Q7MOqZHpp8+x3XLGtE3+fL+nQd+k7O5+X3D/uWrnQXOdMw5VPih+Uremcw+u1woQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.25",
+        "@vue/shared": "3.5.25"
+      },
+      "peerDependencies": {
+        "vue": "3.5.25"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.25.tgz",
+      "integrity": "sha512-AbOPdQQnAnzs58H2FrrDxYj/TJfmeS2jdfEEhgiKINy+bnOANmVizIEgq1r+C5zsbs6l1CCQxtcj71rwNQ4jWg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -6277,6 +6493,29 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vue": {
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.25.tgz",
+      "integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.25",
+        "@vue/compiler-sfc": "3.5.25",
+        "@vue/runtime-dom": "3.5.25",
+        "@vue/server-renderer": "3.5.25",
+        "@vue/shared": "3.5.25"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",


### PR DESCRIPTION
## Summary
- add environment-aware API endpoint utilities for the dashboard
- introduce a data source registry with defaults and override helpers for tests
- include @vitejs/plugin-vue as a dev dependency to satisfy Vitest configuration

## Testing
- npm run test --workspace apps/dashboard


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938890d45908328b9e71678a407843e)