### PR TITLE
fix: add combat workstream to governance schema and validator

### DIFF
--- a/docs/governance/docs_metadata.schema.json
+++ b/docs/governance/docs_metadata.schema.json
@@ -32,7 +32,16 @@
     },
     "workstream": {
       "type": "string",
-      "enum": ["flow", "atlas", "backend", "dataset-pack", "ops-qa", "incoming", "cross-cutting"]
+      "enum": [
+        "flow",
+        "atlas",
+        "backend",
+        "dataset-pack",
+        "ops-qa",
+        "incoming",
+        "cross-cutting",
+        "combat"
+      ]
     },
     "last_verified": {
       "type": "string",

--- a/tools/check_docs_governance.py
+++ b/tools/check_docs_governance.py
@@ -38,6 +38,7 @@ DEFAULT_WORKSTREAMS = {
     "ops-qa",
     "incoming",
     "cross-cutting",
+    "combat",
 }
 DATE_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$")
 


### PR DESCRIPTION
## Summary

- Add `combat` to the `workstream` enum in `docs/governance/docs_metadata.schema.json`
- Add `combat` to `DEFAULT_WORKSTREAMS` in `tools/check_docs_governance.py`

The combat workstream was already defined in `docs_registry.json` and `workstream_matrix.json` (added in PR #1298) but was missing from the metadata schema and validator defaults. This meant `docs/hubs/combat.md` (workstream: combat) would fail strict schema validation.

## 03A Rollback plan

`git revert <sha>` — two-line change, no side effects.

## Test plan

- [x] `python tools/check_docs_governance.py --registry docs/governance/docs_registry.json --strict` → 0 errors, 0 warnings
- [x] `npx prettier --check` → clean
- [ ] CI docs-governance check passes

Part of the docs restructuring initiative (PR 1 of 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)