### PR TITLE
chore: consolidate Canvas/ and meeting-notes/ into target dirs

### DIFF
--- a/docs/frontend/feature-updates.md
+++ b/docs/frontend/feature-updates.md
@@ -1,13 +1,14 @@
 ---
 title: Canvas — Aggiornamenti Rapidi
 doc_status: draft
-doc_owner: platform-docs
-workstream: cross-cutting
+doc_owner: atlas-team
+workstream: atlas
 last_verified: 2026-04-14
 source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # Canvas — Aggiornamenti Rapidi
 
 ## Nuove feature
@@ -49,6 +50,7 @@ review_cycle_days: 14
 ## Riepilogo quotidiano PR
 
 <!-- daily-pr-summary:start -->
+
 - **2026-04-12** — Nessun merge registrato.
 - **2026-04-11** — Nessun merge registrato.
 - **2026-04-10** — Nessun merge registrato.

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -258,11 +258,11 @@
       "track": "migrated"
     },
     {
-      "path": "docs/Canvas/feature-updates.md",
+      "path": "docs/frontend/feature-updates.md",
       "title": "Canvas — Aggiornamenti Rapidi",
       "doc_status": "draft",
-      "doc_owner": "platform-docs",
-      "workstream": "cross-cutting",
+      "doc_owner": "atlas-team",
+      "workstream": "atlas",
       "last_verified": "2026-04-14",
       "source_of_truth": false,
       "language": "it-en",
@@ -3287,7 +3287,7 @@
       "track": "migrated"
     },
     {
-      "path": "docs/meeting-notes/evo-enum-review.md",
+      "path": "docs/planning/evo-enum-review.md",
       "title": "Evo enum review",
       "doc_status": "draft",
       "doc_owner": "platform-docs",

--- a/docs/planning/evo-enum-review.md
+++ b/docs/planning/evo-enum-review.md
@@ -8,6 +8,7 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # Evo enum review
 
 ## Diff summary


### PR DESCRIPTION
## Summary

- Move `docs/Canvas/feature-updates.md` → `docs/frontend/` (reassigned to atlas workstream)
- Move `docs/meeting-notes/evo-enum-review.md` → `docs/planning/`
- Update `docs_registry.json` paths and workstream assignments

Both source directories contained a single file each — now consolidated into their natural workstream homes.

## Correction from plan

Directories initially flagged as "empty" (`design/`, `config/`, `assets/`, `mission-console/`, `prompts/`, `editorial/`, `examples/`, `test-interface/`) actually contain files (JSON configs, CSS, HTML apps, example data). These will be evaluated individually in subsequent PRs.

## 03A Rollback plan

`git revert <sha>` — simple file moves, no content changes.

## Test plan

- [x] `python tools/check_docs_governance.py --strict` → 0 errors, 0 warnings
- [x] Prettier check → clean
- [ ] CI docs-governance check passes

Part of docs restructuring initiative (PR 2 of 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)