### PR TITLE
chore: move 13 numbered core docs to docs/core/

### DIFF
--- a/docs/00-INDEX.md
+++ b/docs/00-INDEX.md
@@ -29,14 +29,14 @@ review_cycle_days: 14
 
 ## Linee guida principali
 
-- [01 Visione](01-VISIONE.md)
-- [02 Pilastri di Design](02-PILASTRI.md)
-- [03 Loop di Gioco](03-LOOP.md)
+- [01 Visione](core/01-VISIONE.md)
+- [02 Pilastri di Design](core/02-PILASTRI.md)
+- [03 Loop di Gioco](core/03-LOOP.md)
 
 ## Sistema
 
-- [10 Sistema Tattico (TV/d20)](10-SISTEMA_TATTICO.md)
-- [11 Regole TV/d20 specifiche](11-REGOLE_D20_TV.md)
+- [10 Sistema Tattico (TV/d20)](core/10-SISTEMA_TATTICO.md)
+- [11 Regole TV/d20 specifiche](core/11-REGOLE_D20_TV.md)
 
 ## Rules Engine / Combat
 
@@ -46,18 +46,18 @@ review_cycle_days: 14
 
 ## Contenuti & Progressione
 
-- [20 Specie & Parti (catalogo + budget)](20-SPECIE_E_PARTI.md)
-- [22 Forme Base (16) + pacchetti PI](22-FORME_BASE_16.md)
-- [24 Telemetria VC (Aggro/Risk/…)](24-TELEMETRIA_VC.md)
-- [25 Regole Sblocco + Economia PE](25-REGOLE_SBLOCCO_PE.md)
-- [27 Mating / Nido (reclutamento & riproduzione)](27-MATING_NIDO.md)
-- [28 NPG, Biomi, Affissi & Director](28-NPC_BIOMI_SPAWN.md)
+- [20 Specie & Parti (catalogo + budget)](core/20-SPECIE_E_PARTI.md)
+- [22 Forme Base (16) + pacchetti PI](core/22-FORME_BASE_16.md)
+- [24 Telemetria VC (Aggro/Risk/…)](core/24-TELEMETRIA_VC.md)
+- [25 Regole Sblocco + Economia PE](core/25-REGOLE_SBLOCCO_PE.md)
+- [27 Mating / Nido (reclutamento & riproduzione)](core/27-MATING_NIDO.md)
+- [28 NPG, Biomi, Affissi & Director](core/28-NPC_BIOMI_SPAWN.md)
 - [Trait Reference & Glossario](catalog/trait_reference.md)
 
 ## Interfaccia & Produzione
 
-- [30 UI TV — Carta Temperamentale & Albero Evolutivo](30-UI_TV_IDENTITA.md)
-- [40 Roadmap / MVP → Alpha](40-ROADMAP.md)
+- [30 UI TV — Carta Temperamentale & Albero Evolutivo](core/30-UI_TV_IDENTITA.md)
+- [40 Roadmap / MVP → Alpha](core/40-ROADMAP.md)
 - [Tutorial rapidi (CLI, Idea Engine, Dashboard)](tutorials/README.md)
 
 ## Dati & Appendici

--- a/docs/core/01-VISIONE.md
+++ b/docs/core/01-VISIONE.md
@@ -8,6 +8,7 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # Visione
 
 “Tattica profonda a turni in cui **come giochi** modella **ciò che diventi**.”

--- a/docs/core/02-PILASTRI.md
+++ b/docs/core/02-PILASTRI.md
@@ -8,6 +8,7 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # Pilastri di Design (sintesi)
 
 1. **Tattica leggibile** (FFT-like): iniziativa, posizionamento, altezze, facing, reazioni.

--- a/docs/core/03-LOOP.md
+++ b/docs/core/03-LOOP.md
@@ -8,6 +8,7 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # Loop di Gioco (alto livello)
 
 Metagioco (epoche/stagioni) → draft/creazione specie → **Match TBT** (mappe a obiettivo)

--- a/docs/core/10-SISTEMA_TATTICO.md
+++ b/docs/core/10-SISTEMA_TATTICO.md
@@ -8,6 +8,7 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # Sistema Tattico (TV/d20)
 
 - **Iniziativa**: CT a scatti; VEL può concedere riprese extra.

--- a/docs/core/11-REGOLE_D20_TV.md
+++ b/docs/core/11-REGOLE_D20_TV.md
@@ -8,6 +8,7 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # Adattamento TV/d20
 
 - **Schermo condiviso** (app/sito TV): stato gruppo, mappa, log VC, consigli sblocchi.

--- a/docs/core/20-SPECIE_E_PARTI.md
+++ b/docs/core/20-SPECIE_E_PARTI.md
@@ -8,6 +8,7 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # Specie & Parti
 
 - **Slot**: locomotion / offense / defense / senses / metabolism.

--- a/docs/core/22-FORME_BASE_16.md
+++ b/docs/core/22-FORME_BASE_16.md
@@ -8,6 +8,7 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # Forme Base (16) — seed temperamentale
 
 Ogni Forma assegna: 1 **innata** + **7 PI** (pacchetti preconfezionati) tematici. VC in-match sposta gradualmente i pesi (non è un test psicologico).

--- a/docs/core/24-TELEMETRIA_VC.md
+++ b/docs/core/24-TELEMETRIA_VC.md
@@ -8,6 +8,7 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # Telemetria → Vettore Comportamentale (VC)
 
 Eventi, finestre, indici (Aggro/Risk/Cohesion/Setup/Explore/Tilt) e mapping verso layer MBTI-like + Ennea-themes.
@@ -18,11 +19,11 @@ Eventi, finestre, indici (Aggro/Risk/Cohesion/Setup/Explore/Tilt) e mapping vers
 
 ## Calendario revisione PI/telemetria
 
-| Ricorrenza | Slot | Focus principale | Owner | Deliverable |
-| --- | --- | --- | --- | --- |
-| Settimanale | Martedì · 10:00-10:45 CET | Stato pacchetti PI, anomalie sugli indici Aggro/Risk e follow-up delle azioni correttive | Lead Design · PM | Note sintetiche + flag su ticket aperti |
-| Settimanale | Giovedì · 16:00-16:30 CET | Debrief dati raw dei playtest, verifica log depositati e triage ticket critici | Analytics · QA | Aggiornamento `logs/playtests/` + elenco bug prioritari |
-| Quindicinale (settimana dispari) | Venerdì · 15:00-16:00 CET | Retrospettiva VC completa (telemetria → decisioni design) e pianificazione backlog | Design Council · Tech Lead | Decision log + aggiornamento roadmap |
+| Ricorrenza                       | Slot                      | Focus principale                                                                         | Owner                      | Deliverable                                             |
+| -------------------------------- | ------------------------- | ---------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------- |
+| Settimanale                      | Martedì · 10:00-10:45 CET | Stato pacchetti PI, anomalie sugli indici Aggro/Risk e follow-up delle azioni correttive | Lead Design · PM           | Note sintetiche + flag su ticket aperti                 |
+| Settimanale                      | Giovedì · 16:00-16:30 CET | Debrief dati raw dei playtest, verifica log depositati e triage ticket critici           | Analytics · QA             | Aggiornamento `logs/playtests/` + elenco bug prioritari |
+| Quindicinale (settimana dispari) | Venerdì · 15:00-16:00 CET | Retrospettiva VC completa (telemetria → decisioni design) e pianificazione backlog       | Design Council · Tech Lead | Decision log + aggiornamento roadmap                    |
 
 - Tutte le sessioni sono registrate nel calendario condiviso `Evo-Tactics / VC Reviews` con promemoria 24h prima e agenda allegata in Notion.
 - Materiali e metriche vengono raccolti entro le 18:00 CET dello stesso giorno nella cartella condivisa `telemetria/reports`.

--- a/docs/core/25-REGOLE_SBLOCCO_PE.md
+++ b/docs/core/25-REGOLE_SBLOCCO_PE.md
@@ -8,6 +8,7 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # Regole di Sblocco + Economia PE
 
 - PE da delta VC.

--- a/docs/core/27-MATING_NIDO.md
+++ b/docs/core/27-MATING_NIDO.md
@@ -8,6 +8,7 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # Mating / Nido (reclutamento & riproduzione)
 
 - Attrazione/Convincimento: tabelle Piace/Non piace per specie/job; azioni sociali.

--- a/docs/core/28-NPC_BIOMI_SPAWN.md
+++ b/docs/core/28-NPC_BIOMI_SPAWN.md
@@ -8,6 +8,7 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # NPG, Biomi, Affissi & Director
 
 - Director: genera NPG con `spawn_profile` (power_range, group_size, role_weights).

--- a/docs/core/30-UI_TV_IDENTITA.md
+++ b/docs/core/30-UI_TV_IDENTITA.md
@@ -8,6 +8,7 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # UI TV — Carta Temperamentale & Albero Evolutivo
 
 - Carte con 4 assi MBTI-like + temi Ennea-like; effetti **solo gameplay**.

--- a/docs/core/40-ROADMAP.md
+++ b/docs/core/40-ROADMAP.md
@@ -8,6 +8,7 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # Roadmap (MVP → Alpha)
 
 - Core TBT, 6 Specie base, 6 Job base, Telemetria VC, 12 Regole Sblocco, UI identità.

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -37,7 +37,7 @@
       "track": "historical"
     },
     {
-      "path": "docs/01-VISIONE.md",
+      "path": "docs/core/01-VISIONE.md",
       "title": "Visione",
       "doc_status": "draft",
       "doc_owner": "platform-docs",
@@ -50,7 +50,7 @@
       "track": "migrated"
     },
     {
-      "path": "docs/02-PILASTRI.md",
+      "path": "docs/core/02-PILASTRI.md",
       "title": "Pilastri di Design (sintesi)",
       "doc_status": "draft",
       "doc_owner": "platform-docs",
@@ -63,7 +63,7 @@
       "track": "migrated"
     },
     {
-      "path": "docs/03-LOOP.md",
+      "path": "docs/core/03-LOOP.md",
       "title": "Loop di Gioco (alto livello)",
       "doc_status": "draft",
       "doc_owner": "platform-docs",
@@ -76,7 +76,7 @@
       "track": "migrated"
     },
     {
-      "path": "docs/10-SISTEMA_TATTICO.md",
+      "path": "docs/core/10-SISTEMA_TATTICO.md",
       "title": "Sistema Tattico (TV/d20)",
       "doc_status": "draft",
       "doc_owner": "platform-docs",
@@ -89,7 +89,7 @@
       "track": "migrated"
     },
     {
-      "path": "docs/11-REGOLE_D20_TV.md",
+      "path": "docs/core/11-REGOLE_D20_TV.md",
       "title": "Adattamento TV/d20",
       "doc_status": "draft",
       "doc_owner": "platform-docs",
@@ -102,7 +102,7 @@
       "track": "migrated"
     },
     {
-      "path": "docs/20-SPECIE_E_PARTI.md",
+      "path": "docs/core/20-SPECIE_E_PARTI.md",
       "title": "Specie & Parti",
       "doc_status": "draft",
       "doc_owner": "platform-docs",
@@ -115,7 +115,7 @@
       "track": "migrated"
     },
     {
-      "path": "docs/22-FORME_BASE_16.md",
+      "path": "docs/core/22-FORME_BASE_16.md",
       "title": "Forme Base (16) — seed temperamentale",
       "doc_status": "draft",
       "doc_owner": "platform-docs",
@@ -128,7 +128,7 @@
       "track": "migrated"
     },
     {
-      "path": "docs/24-TELEMETRIA_VC.md",
+      "path": "docs/core/24-TELEMETRIA_VC.md",
       "title": "Telemetria → Vettore Comportamentale (VC)",
       "doc_status": "draft",
       "doc_owner": "platform-docs",
@@ -141,7 +141,7 @@
       "track": "migrated"
     },
     {
-      "path": "docs/25-REGOLE_SBLOCCO_PE.md",
+      "path": "docs/core/25-REGOLE_SBLOCCO_PE.md",
       "title": "Regole di Sblocco + Economia PE",
       "doc_status": "draft",
       "doc_owner": "platform-docs",
@@ -154,7 +154,7 @@
       "track": "migrated"
     },
     {
-      "path": "docs/27-MATING_NIDO.md",
+      "path": "docs/core/27-MATING_NIDO.md",
       "title": "Mating / Nido (reclutamento & riproduzione)",
       "doc_status": "draft",
       "doc_owner": "platform-docs",
@@ -167,7 +167,7 @@
       "track": "migrated"
     },
     {
-      "path": "docs/28-NPC_BIOMI_SPAWN.md",
+      "path": "docs/core/28-NPC_BIOMI_SPAWN.md",
       "title": "NPG, Biomi, Affissi & Director",
       "doc_status": "draft",
       "doc_owner": "platform-docs",
@@ -180,7 +180,7 @@
       "track": "migrated"
     },
     {
-      "path": "docs/30-UI_TV_IDENTITA.md",
+      "path": "docs/core/30-UI_TV_IDENTITA.md",
       "title": "UI TV — Carta Temperamentale & Albero Evolutivo",
       "doc_status": "draft",
       "doc_owner": "platform-docs",
@@ -193,7 +193,7 @@
       "track": "migrated"
     },
     {
-      "path": "docs/40-ROADMAP.md",
+      "path": "docs/core/40-ROADMAP.md",
       "title": "Roadmap (MVP → Alpha)",
       "doc_status": "draft",
       "doc_owner": "platform-docs",


### PR DESCRIPTION
## Summary

- Create `docs/core/` directory as home for the 13 canonical design reference docs
- Move `01-VISIONE.md` through `40-ROADMAP.md` into `docs/core/`
- Keep `00-INDEX.md` at `docs/` root as legacy index entrypoint
- Update all internal links in `00-INDEX.md` to point to `core/` paths
- Update `docs_registry.json` for all 13 moved entries

## Rationale

The numbered docs (01-40) are the core game design reference. Moving them to a dedicated `core/` directory:
- Separates stable reference material from operational/transient docs
- Reduces clutter at the `docs/` root level (was 59 loose files)
- Makes the doc hierarchy self-documenting

## 03A Rollback plan

`git revert <sha>` — pure file moves + link updates, no content changes.

## Test plan

- [x] `python tools/check_docs_governance.py --strict` → 0 errors, 0 warnings
- [x] `npx prettier --check` → clean
- [x] All 13 links in `00-INDEX.md` updated to `core/` paths
- [ ] CI docs-governance check passes

Part of docs restructuring initiative (PR 3 of 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)