### PR TITLE
style: prettier blank line after frontmatter in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # CLAUDE.md
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.


### PR DESCRIPTION
Trivial prettier fix — blank line after YAML frontmatter.

## 03A Rollback
`git revert <sha>`

## Test plan
- [x] `npx prettier --check CLAUDE.md` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)