### PR TITLE
fix: repair 43 broken HTML links after docs restructure

### DIFF
--- a/docs/frontend/test-interface/auto-fetch.html
+++ b/docs/frontend/test-interface/auto-fetch.html
@@ -19,7 +19,7 @@
       </p>
       <nav class="utility-nav" aria-label="Navigazione secondaria">
         <a href="index.html">⟵ Torna alla dashboard</a>
-        <a href="../ideas/index.html">Idea Engine</a>
+        <a href="../../planning/ideas/index.html">Idea Engine</a>
       </nav>
       <p id="auto-data-source" class="hint secondary">Sorgente dati: in rilevamento…</p>
     </header>

--- a/docs/frontend/test-interface/index.html
+++ b/docs/frontend/test-interface/index.html
@@ -29,8 +29,8 @@
           <button id="reload-data" type="button">Ricarica dati YAML</button>
           <a class="pill-link" href="auto-fetch.html">Fetch automatico</a>
           <a class="pill-link" href="manual-fetch.html">Fetch manuale</a>
-          <a class="pill-link" href="../ideas/index.html">Idea Engine</a>
-          <a class="pill-link" href="../01-VISIONE.md" target="_blank" rel="noopener"
+          <a class="pill-link" href="../../planning/ideas/index.html">Idea Engine</a>
+          <a class="pill-link" href="../../core/01-VISIONE.md" target="_blank" rel="noopener"
             >Visione del progetto</a
           >
         </div>
@@ -74,7 +74,7 @@
               Torna al Centro di Controllo Evo-Tactics per monitorare changelog, attività del
               repository e configurare il simulatore principale.
             </p>
-            <a class="pill-link" href="../index.html">Apri hub principale</a>
+            <a class="pill-link" href="../../index.html">Apri hub principale</a>
           </article>
           <article class="card link-card">
             <h3>Idea Engine</h3>
@@ -82,7 +82,7 @@
               Raccogli nuove proposte con il widget dedicato, esporta il reminder Markdown e inviale
               al backend di raccolta idee per generare automaticamente PR e documentazione.
             </p>
-            <a class="pill-link" href="../ideas/index.html">Apri Idea Engine</a>
+            <a class="pill-link" href="../../planning/ideas/index.html">Apri Idea Engine</a>
           </article>
           <article class="card link-card">
             <h3>Ecosystem Pack Hub</h3>
@@ -90,7 +90,7 @@
               Raggiungi la raccolta degli strumenti del pack sperimentale con collegamenti rapidi a
               generatori, cataloghi e dataset condivisi.
             </p>
-            <a class="pill-link" href="../evo-tactics-pack/index.html">Apri il pack</a>
+            <a class="pill-link" href="../../evo-tactics-pack/index.html">Apri il pack</a>
           </article>
           <article class="card link-card">
             <h3>Generatore di ecosistemi</h3>
@@ -98,7 +98,7 @@
               Avvia subito il tool per creare biomi e missioni procedurali usando i dataset
               aggiornati dal repository.
             </p>
-            <a class="pill-link" href="../evo-tactics-pack/generator.html">Avvia generatore</a>
+            <a class="pill-link" href="../../evo-tactics-pack/generator.html">Avvia generatore</a>
           </article>
           <article class="card link-card">
             <h3>Catalogo biomi &amp; specie</h3>
@@ -106,7 +106,7 @@
               Consulta l'elenco completo dei biomi mutanti e delle specie collegate per preparare
               rapidamente le sessioni di playtest.
             </p>
-            <a class="pill-link" href="../evo-tactics-pack/catalog.html">Apri catalogo</a>
+            <a class="pill-link" href="../../evo-tactics-pack/catalog.html">Apri catalogo</a>
           </article>
           <article class="card link-card">
             <h3>Fetch automatico dataset</h3>

--- a/docs/frontend/test-interface/manual-fetch.html
+++ b/docs/frontend/test-interface/manual-fetch.html
@@ -22,8 +22,8 @@
         <div class="hero-actions">
           <a class="pill-link" href="index.html">Torna alla dashboard</a>
           <a class="pill-link" href="auto-fetch.html">Fetch automatico</a>
-          <a class="pill-link" href="../ideas/index.html">Idea Engine</a>
-          <a class="pill-link" href="../Canvas" target="_blank" rel="noopener">Canvas &amp; wiki</a>
+          <a class="pill-link" href="../../planning/ideas/index.html">Idea Engine</a>
+          <a class="pill-link" href="../feature-updates.md" target="_blank" rel="noopener">Canvas &amp; wiki</a>
         </div>
         <p class="hint">
           Suggerimento: usa questo workspace per esaminare file caricati manualmente (zip, md, pdf,

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,8 +46,8 @@
         <a href="#mission-control">Mission Control</a>
         <a href="mission-console/index.html">Mission Console</a>
         <a href="#release">Quality &amp; Release</a>
-        <a href="ideas/index.html">Idea Engine</a>
-        <a href="test-interface/index.html">Interfaccia Test</a>
+        <a href="planning/ideas/index.html">Idea Engine</a>
+        <a href="frontend/test-interface/index.html">Interfaccia Test</a>
         <a href="evo-tactics-pack/generator.html">Generatore</a>
         <a href="evo-tactics-pack/index.html">Strumenti Pack</a>
         <a href="evo-tactics-pack/reports/index.html">Report Pack</a>
@@ -134,7 +134,7 @@
               Plancia di verifica rapida con overview MBTI, telemetria VC e strumenti di fetch
               manuale o automatico.
             </p>
-            <a class="button button--ghost" href="test-interface/index.html">Apri l'interfaccia</a>
+            <a class="button button--ghost" href="frontend/test-interface/index.html">Apri l'interfaccia</a>
           </article>
           <article class="card landing-card">
             <h3>Idea Engine</h3>
@@ -142,7 +142,7 @@
               Form centralizzato per raccogliere nuove proposte, generare il reminder Markdown e
               inviarle al backend Idea Intake.
             </p>
-            <a class="button button--ghost" href="ideas/index.html">Apri Idea Engine</a>
+            <a class="button button--ghost" href="planning/ideas/index.html">Apri Idea Engine</a>
           </article>
           <article class="card landing-card">
             <h3>Ecosystem Pack Hub</h3>
@@ -176,7 +176,7 @@
               Esegue il download e la validazione dei file YAML, mostrando errori HTTP o di parsing
               in tempo reale.
             </p>
-            <a class="button button--ghost" href="test-interface/auto-fetch.html"
+            <a class="button button--ghost" href="frontend/test-interface/auto-fetch.html"
               >Avvia fetch automatico</a
             >
           </article>
@@ -186,7 +186,7 @@
               Strumento per scaricare selettivamente singoli file di dati e testarli in autonomia
               prima della pubblicazione.
             </p>
-            <a class="button button--ghost" href="test-interface/manual-fetch.html"
+            <a class="button button--ghost" href="frontend/test-interface/manual-fetch.html"
               >Apri fetch manuale</a
             >
           </article>
@@ -197,10 +197,10 @@
             <li><a href="#intent">Intento narrativo</a></li>
             <li><a href="#flow">Struttura di missione</a></li>
             <li><a href="#mission-control">Mission Control</a></li>
-            <li><a href="ideas/index.html">Idea Engine</a></li>
-            <li><a href="test-interface/index.html">Interfaccia Test &amp; Recap</a></li>
-            <li><a href="test-interface/auto-fetch.html">Fetch automatico YAML</a></li>
-            <li><a href="test-interface/manual-fetch.html">Fetch manuale YAML</a></li>
+            <li><a href="planning/ideas/index.html">Idea Engine</a></li>
+            <li><a href="frontend/test-interface/index.html">Interfaccia Test &amp; Recap</a></li>
+            <li><a href="frontend/test-interface/auto-fetch.html">Fetch automatico YAML</a></li>
+            <li><a href="frontend/test-interface/manual-fetch.html">Fetch manuale YAML</a></li>
             <li><a href="evo-tactics-pack/generator.html">Generatore di ecosistemi</a></li>
             <li><a href="evo-tactics-pack/catalog.html">Catalogo biomi</a></li>
             <li><a href="evo-tactics-pack/index.html">Hub strumenti pack</a></li>
@@ -222,7 +222,7 @@
               <button type="button" class="button" id="hero-open-simulator">
                 Apri il simulatore
               </button>
-              <a class="button button--secondary" href="40-ROADMAP.md">Roadmap</a>
+              <a class="button button--secondary" href="core/40-ROADMAP.md">Roadmap</a>
               <a class="button button--ghost" href="00-INDEX.md">Indice documentazione</a>
               <a class="button button--ghost" href="evo-tactics-pack/generator.html">Generatore</a>
             </div>
@@ -417,13 +417,13 @@
               <div class="stack">
                 <div class="stack__row">
                   <span class="stack__label">Data root attiva:</span>
-                  <a id="data-root-preview" href="test-interface/" target="_blank" rel="noreferrer"
+                  <a id="data-root-preview" href="frontend/test-interface/" target="_blank" rel="noreferrer"
                     >Rilevamento automatico</a
                   >
                 </div>
                 <div class="stack__row">
                   <span class="stack__label">URL simulatore:</span>
-                  <a id="simulator-link" href="test-interface/" target="_blank" rel="noreferrer"
+                  <a id="simulator-link" href="frontend/test-interface/" target="_blank" rel="noreferrer"
                     >test-interface/</a
                   >
                 </div>
@@ -442,7 +442,7 @@
               <iframe
                 id="simulator-frame"
                 title="Interfaccia di test Evo-Tactics"
-                src="test-interface/"
+                src="frontend/test-interface/"
                 loading="lazy"
                 referrerpolicy="no-referrer"
                 sandbox="allow-scripts allow-same-origin allow-forms"
@@ -534,13 +534,13 @@
                   <a href="process/incoming_triage_pipeline.md">Playbook pipeline agentica</a>
                 </li>
                 <li>
-                  <a href="checklist/incoming_triage.md">Checklist triage</a>
+                  <a href="process/incoming_triage.md">Checklist triage</a>
                 </li>
                 <li>
-                  <a href="templates/incoming_triage_meeting.md">Template sync agentica</a>
+                  <a href="guide/templates/incoming_triage_meeting.md">Template sync agentica</a>
                 </li>
                 <li>
-                  <a href="incoming/archive/INDEX.md">Indice archivio incoming</a>
+                  <a href="archive/historical-snapshots/INDEX.md">Indice archivio incoming</a>
                 </li>
               </ul>
             </article>
@@ -567,7 +567,7 @@
                 </div>
                 <div class="stack__row">
                   <span class="stack__label">Checklist</span>
-                  <a href="checklist/incoming_triage.md">Rivedi step</a>
+                  <a href="process/incoming_triage.md">Rivedi step</a>
                 </div>
               </div>
               <p class="form__hint">
@@ -592,7 +592,7 @@
                 Dashboard principale con riepiloghi MBTI, telemetria VC, negozio PI e strumenti di
                 fetch manuale dei dataset.
               </p>
-              <a href="test-interface/index.html" class="button button--ghost">Apri dashboard</a>
+              <a href="frontend/test-interface/index.html" class="button button--ghost">Apri dashboard</a>
             </article>
             <article class="card card--link">
               <h3>Generatore di ecosistemi</h3>
@@ -610,7 +610,7 @@
                 Pannello dedicato che scarica e valida tutti i file YAML dalla cartella
                 <code>data/</code> in modo automatico, segnalando errori di parsing o HTTP.
               </p>
-              <a href="test-interface/auto-fetch.html" class="button button--ghost">Avvia fetch</a>
+              <a href="frontend/test-interface/auto-fetch.html" class="button button--ghost">Avvia fetch</a>
             </article>
             <article class="card card--link">
               <h3>Ecosystem Pack Hub</h3>
@@ -636,27 +636,27 @@
             <article class="card card--link">
               <h3>Checklist produzione</h3>
               <p>Verifica gli step da completare prima di ogni release.</p>
-              <a href="checklist/action-items.md" class="button button--ghost">Apri checklist</a>
+              <a href="process/action-items.md" class="button button--ghost">Apri checklist</a>
             </article>
             <article class="card card--link">
               <h3>Guida contributori</h3>
               <p>Processo completo per aggiornare il sito e l'Idea Engine in sicurezza.</p>
-              <a href="CONTRIBUTING_SITE.md" class="button button--ghost">Leggi la guida</a>
+              <a href="guide/CONTRIBUTING_SITE.md" class="button button--ghost">Leggi la guida</a>
             </article>
             <article class="card card--link">
               <h3>Registro manutenzione tool</h3>
               <p>Storico delle operazioni effettuate sugli strumenti interni.</p>
-              <a href="tool_run_report.md" class="button button--ghost">Visualizza log</a>
+              <a href="ops/tool_run_report.md" class="button button--ghost">Visualizza log</a>
             </article>
             <article class="card card--link">
               <h3>Telemetria &amp; metriche</h3>
               <p>Analisi dettagliata in <code>24-TELEMETRIA_VC.md</code> e dataset correlati.</p>
-              <a href="24-TELEMETRIA_VC.md" class="button button--ghost">Apri documento</a>
+              <a href="core/24-TELEMETRIA_VC.md" class="button button--ghost">Apri documento</a>
             </article>
             <article class="card card--link">
               <h3>Documentazione UI</h3>
               <p>Specifiche dell'interfaccia televisiva e componenti di identità visiva.</p>
-              <a href="30-UI_TV_IDENTITA.md" class="button button--ghost">Consulta specifiche</a>
+              <a href="core/30-UI_TV_IDENTITA.md" class="button button--ghost">Consulta specifiche</a>
             </article>
           </div>
         </section>

--- a/docs/planning/ideas/index.html
+++ b/docs/planning/ideas/index.html
@@ -8,8 +8,8 @@
       name="description"
       content="Pannello Idea Intake per raccogliere nuove proposte e sincronizzarle con il repository Evo-Tactics."
     />
-    <link rel="stylesheet" href="../site.css" />
-    <link rel="stylesheet" href="../assets/styles/widget.css" data-idea-widget-styles />
+    <link rel="stylesheet" href="../../site.css" />
+    <link rel="stylesheet" href="../../assets/styles/widget.css" data-idea-widget-styles />
     <link rel="stylesheet" href="idea-intake.css" />
   </head>
   <body class="idea-intake">
@@ -88,11 +88,11 @@
         </div>
         <nav class="idea-intake__nav" aria-labelledby="idea-nav-title">
           <h2 class="idea-intake__visually-hidden" id="idea-nav-title">Navigazione Support Hub</h2>
-          <a href="../index.html">Support Hub</a>
-          <a href="../index.html#mission-control">Mission Control</a>
-          <a href="../test-interface/index.html">Interfaccia Test</a>
-          <a href="../evo-tactics-pack/generator.html">Generatore</a>
-          <a href="../evo-tactics-pack/index.html">Ecosystem Pack</a>
+          <a href="../../index.html">Support Hub</a>
+          <a href="../../index.html#mission-control">Mission Control</a>
+          <a href="../../frontend/test-interface/index.html">Interfaccia Test</a>
+          <a href="../../evo-tactics-pack/generator.html">Generatore</a>
+          <a href="../../evo-tactics-pack/index.html">Ecosystem Pack</a>
         </nav>
       </div>
     </header>
@@ -312,7 +312,7 @@
         }
       })();
     </script>
-    <script type="module" src="../public/embed.js"></script>
+    <script type="module" src="../../public/embed.js"></script>
     <script>
       (function mountIdeaWidget() {
         const container = document.querySelector('#idea-widget');


### PR DESCRIPTION
## Summary

Post-verification fix. Running \`npm run docs:lint\` after the restructuring revealed 43 broken HTML links in 5 files. All fixed.

## Files fixed

| File | Broken | Fix |
|---|---|---|
| \`docs/index.html\` | 25 | Reference \`core/\` for numbered docs, \`planning/ideas/\`, \`frontend/test-interface/\`, \`process/\`, \`guide/\`, \`ops/\`, \`archive/historical-snapshots/\` |
| \`docs/planning/ideas/index.html\` | 8 | Extra \`../\` because moved deeper (\`docs/ideas/\` → \`docs/planning/ideas/\`) |
| \`docs/frontend/test-interface/index.html\` | 6 | Extra \`../\` and \`core/\` prefix |
| \`docs/frontend/test-interface/auto-fetch.html\` | 2 | Same pattern |
| \`docs/frontend/test-interface/manual-fetch.html\` | 2 | Same pattern |

## Verification

\`\`\`bash
npm run docs:lint
# Tutti i collegamenti interni risultano validi.
\`\`\`

## 03A Rollback plan
\`git revert <sha>\`

## Test plan
- [x] \`npm run docs:lint\` → all links valid (43 → 0)
- [x] \`python tools/check_docs_governance.py --strict\` → still 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)