### PR TITLE
fix: update contracts-trait-mechanics test to expect 33 core traits

### DIFF
--- a/tests/api/contracts-trait-mechanics.test.js
+++ b/tests/api/contracts-trait-mechanics.test.js
@@ -52,10 +52,10 @@ test('trait_mechanics.yaml valida contro traitMechanics schema', () => {
   assert.doesNotThrow(() => validator.validate(SCHEMA_ID, catalog));
 });
 
-test('trait_mechanics.yaml contiene tutti e 30 i core trait di traits_inventory.json', () => {
+test('trait_mechanics.yaml contiene tutti e 33 i core trait di traits_inventory.json', () => {
   const catalog = loadCatalog();
   const coreIds = loadCoreTraitIds();
-  assert.equal(coreIds.length, 30, 'traits_inventory.json deve esporre 30 core');
+  assert.equal(coreIds.length, 33, 'traits_inventory.json deve esporre 33 core');
   const present = Object.keys(catalog.traits);
   const missing = coreIds.filter((id) => !present.includes(id));
   assert.deepEqual(missing, [], `core trait mancanti nel layer: ${missing.join(', ')}`);


### PR DESCRIPTION
## Summary

Test assertion in `tests/api/contracts-trait-mechanics.test.js` still expected 30 core traits while PR #1298 bumped the inventory to 33 (`docs/catalog/traits_inventory.json` + `packs/evo_tactics_pack/data/balance/trait_mechanics.yaml` both at 33 aligned entries).

## Verification

```bash
# Diff inventory vs mechanics → 0 mismatches, both at 33
$ diff inventory.txt mechanics.txt   # empty
$ node --test tests/api/contracts-trait-mechanics.test.js
# pass 15, fail 0
```

## 03A Rollback
`git revert <sha>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)