### PR TITLE
docs(combat): extension guides — trait mechanics, status, action types (PR B2 of 3)

### DIFF
--- a/docs/combat/action-types-guide.md
+++ b/docs/combat/action-types-guide.md
@@ -1,0 +1,248 @@
+---
+title: Action Types Guide
+description: Action types supportati dal rules engine d20, PT spend reference, parry response e ability stub.
+doc_status: active
+doc_owner: combat-team
+workstream: combat
+last_verified: 2026-04-14
+source_of_truth: false
+language: it-en
+review_cycle_days: 14
+---
+
+# Action Types Guide
+
+Ogni turno nel rules engine produce una o più `action` che vengono risolte da `resolve_action()`. Questo documento descrive i 5 tipi di action supportati, il meccanismo di **PT spend** (perforazione, spinta), il **parry response** opt-in, e lo stato attuale dell'**ability stub** (Fase 3 deferred).
+
+## Anatomia di un'action
+
+Uno `action` object ha questa shape (`$defs.action` in `combat.schema.json`):
+
+```json
+{
+  "id": "act-042",
+  "type": "attack",
+  "actor_id": "party-01",
+  "target_id": "h-03",
+  "ap_cost": 1,
+  "channel": "taglio",
+  "damage_dice": { "count": 1, "sides": 8, "modifier": 2 },
+  "pt_spend": { "type": "perforazione", "amount": 1 },
+  "parry_response": { "attempt": true, "parry_bonus": 1 },
+  "ability_id": null
+}
+```
+
+Campi richiesti: `id`, `type`, `actor_id`, `ap_cost`. Tutti gli altri sono opzionali e dipendono dal `type`.
+
+## I 5 action types
+
+### `attack`
+
+**Il tipo principale** — l'unico con logica completa nel resolver.
+
+**Campi rilevanti**:
+
+- `target_id` *(required)*: id dell'unità bersaglio.
+- `damage_dice` *(required)*: `{count, sides, modifier}`. Se omesso, fallback a `{count: 1, sides: 6, modifier: 0}`.
+- `channel` *(opzionale)*: canale di danno per l'applicazione di resistenze. Canoni: `elettrico, psionico, fisico, fuoco, gravita, mentale, taglio, ionico`. Se omesso, la resistenza non viene applicata (danno passa invariato).
+- `pt_spend` *(opzionale)*: spesa PT per effetti aggiuntivi (vedi sotto).
+- `parry_response` *(opzionale)*: tiro reattivo del target (vedi sotto).
+
+**Pipeline**: vedi [data-flow.md](data-flow.md#2-resolve-action-combatstate--next_state--turn_log_entry) per la sequenza completa di 14 step.
+
+**Test ref**: ~50 test in `tests/test_resolver.py` coprono scenari di hit/miss/crit/fumble, resistenze, armor, pt_spend, parry, stress breakpoint, status stacking.
+
+### `defend`, `move`, `ability`, `parry` *(NOOP_ACTION_TYPES)*
+
+Questi 4 tipi sono in `NOOP_ACTION_TYPES = frozenset({"defend", "parry", "ability", "move"})`. Il resolver li gestisce così:
+
+- **Consumo AP**: `actor.ap.current -= action.ap_cost` (clamp a 0)
+- **Turn log**: produce una `turn_log_entry` con `roll: null`, `damage_applied: 0`, `statuses_applied: []`.
+- **Nessuna logica di risoluzione**: non c'è difesa attiva, non c'è movimento sulla griglia, non ci sono ability.
+
+**Perché?** La Fase 2 si è concentrata sul combat loop core (attack + status + parry response opt-in). Le altre action type sono contratti stabili — i client possono dichiararle — ma la logica di risoluzione è deferita:
+
+- **`defend`**: probabile implementazione Fase 3 come "+1 defense_mod per il turno", con nuovo status `defending`.
+- **`move`**: deferred fino a quando la griglia tattica esiste. Il contratto esiste per non dover fare breaking change quando si aggiungerà.
+- **`ability`**: **centrale per Fase 3**. Attiverà `active_effects` dei trait (attualmente NOOP nel catalog).
+- **`parry`**: distinto dal `parry_response` opt-in. Il `parry` come action type indipendente sarà implementato quando le reactions avranno un proprio timing (fuori dal turn dell'attore).
+
+## PT spend: perforazione e spinta
+
+Il campo `action.pt_spend` permette all'attore di consumare PT dal proprio pool per ottenere effetti aggiuntivi su un attack. Supportato solo per `type: "attack"`.
+
+Shape:
+
+```json
+"pt_spend": {
+  "type": "perforazione",
+  "amount": 1
+}
+```
+
+Tipi supportati (`SUPPORTED_PT_SPEND_TYPES`):
+
+### `perforazione`
+
+**Effetto**: armor effettiva del target ridotta di `PERFORAZIONE_ARMOR_REDUCTION = 2` per questo attack.
+
+**Formula**: durante il pipeline step 10, `apply_armor(damage, max(0, target.armor - 2))` invece di `apply_armor(damage, target.armor)`.
+
+**Quando usarlo**: contro target con armor alta (≥ 4) dove il damage rolled supera la resistenza ma viene mangiato dall'armor. Es: damage 8, armor 4 → damage_applied=4. Con perforazione: damage 8, armor 2 → damage_applied=6.
+
+**Costo**: `amount` PT dal pool dell'attore (minimo 1). Il resolver non impone un costo fisso, ma per convenzione `amount=1` è sufficiente per il boost base.
+
+### `spinta`
+
+**Effetto**: applica un nuovo status `sbilanciato` sul target per la durata specificata.
+
+**Implementazione attuale**: durante il pipeline step 11, se `pt_spend.type == "spinta"` e l'attack ha hittato, viene chiamato `apply_status(target, "sbilanciato", duration=1, intensity=1, source_unit_id=actor.id, source_action_id=action.id)`.
+
+> **Nota**: `sbilanciato` NON è nell'enum ufficiale dei 5 status (bleeding/fracture/disorient/rage/panic). È un **6° status informale** consumato direttamente dal pipeline nel calcolo di `defense_mod_target`. Se lo schema viene esteso in Fase 3, `sbilanciato` andrà formalizzato. Per ora è tollerato dal validator perché lo schema enum è meno restrittivo delle costanti del resolver.
+
+**Quando usarlo**: contro target con `defense_mod` alto. Il `sbilanciato` riduce `defense_mod_target` di `intensity * 1` al prossimo attack, rendendo più facile hittare il target al turno successivo.
+
+### Panic blocca la spesa
+
+Se l'attore ha lo status `panic`, qualsiasi `pt_spend` viene **silent-droppato**:
+
+```python
+# Pipeline step 3 (da resolver.py)
+actor_panic = get_status(actor, "panic")
+if pt_spend:
+    if actor_panic is not None:
+        pass  # silent drop, no PT consumed
+    else:
+        pt_spent = apply_pt_spend(actor, pt_spend)
+        # ... apply effect based on pt_spend.type
+```
+
+Nessuna eccezione sollevata, nessun PT consumato, l'azione continua come attack normale. Questo è documentato in `turn_log_entry.roll.pt_spent` che sarà 0 in caso di silent drop.
+
+### Errori
+
+`apply_pt_spend` solleva `ValueError` in 3 casi:
+
+1. `pt_spend.type` non in `SUPPORTED_PT_SPEND_TYPES` (es. `"combo"` o `"condizioni"` — deferred)
+2. `pt_spend.amount <= 0`
+3. `actor.pt < amount`
+
+Un `ValueError` qui **blocca l'intera `resolve_action`** prima che il roll avvenga. Nessun side effect sullo state. Il caller deve gestire l'errore (tipicamente presentando un messaggio utente in modalità interactive, o loggando in modalità auto).
+
+### Tipi deferred
+
+Il doc `10-SISTEMA_TATTICO.md` cita 4 tipi di PT spend totali:
+
+- ✅ `perforazione` — implementato
+- ✅ `spinta` — implementato
+- ⏳ `condizioni` — deferred (applicazione di status condizionali)
+- ⏳ `combo` — deferred (chain di attack multipli nello stesso turno)
+
+L'ADR-2026-04-13 registra i tipi deferred come scope di Fase 3. Quando verranno implementati, dovranno essere aggiunti a `SUPPORTED_PT_SPEND_TYPES` e al match-case nel pipeline step 3 del resolver.
+
+## Parry response (opt-in)
+
+Il campo `action.parry_response` permette al target di tentare un tiro reattivo di parata **opt-in** quando viene colpito. Il parry è distinto dall'action type `parry` (che è NOOP).
+
+Shape:
+
+```json
+"parry_response": {
+  "attempt": true,
+  "parry_bonus": 2
+}
+```
+
+Campi:
+
+- `attempt` *(bool, default false)*: se `true`, il target tenta la parata quando subisce l'attack.
+- `parry_bonus` *(int, default 0)*: bonus additivo al tiro d20 di parata, tipicamente aggregato dai trait difensivi del target in una future iterazione (attualmente va passato dal client).
+
+### Come funziona
+
+Durante pipeline step 12 di `resolve_action`, se l'attack ha hittato E `action.parry_response.attempt == true`, il resolver chiama `resolve_parry(target, rng, parry_bonus, attack_total)`:
+
+```python
+parry_dc = attack_total if attack_total is not None else PARRY_CD
+natural = roll_die(rng, 20)
+total = natural + int(parry_bonus)
+success = natural == NATURAL_MAX or total >= parry_dc
+pt_gained = 0
+step_reduced = 0
+if success:
+    step_reduced = 1
+    pt_gained = PARRY_PT_CRIT if natural == NATURAL_MAX else PARRY_PT_BASE
+```
+
+**Success condition**: nat 20 auto-success, oppure `total >= attack_total` (parata batte l'attack). Se `attack_total` non è passato, fallback a `PARRY_CD = 12` (modalità legacy).
+
+### Effetti sul damage
+
+Se la parata ha successo, `step_reduced = 1` e `pt_defensive_gained = 1` (o 2 su nat 20).
+
+Il caller applica `step_reduced` al `step_count` prima di calcolare `step_bonus`:
+
+```
+step_count_finale = max(0, step_count - step_reduced)
+```
+
+Questo riduce il danno flat, ma **non azzera l'attack**: il dado base continua a rollare. Un parry riuscito mitiga, non annulla.
+
+I PT difensivi guadagnati vanno sommati al pool del target (che tipicamente li userà in un turn successivo per perforazione/spinta).
+
+### Costo in reactions
+
+Per convenzione, `parry_response.attempt = true` consuma 1 `reactions` del target. Attualmente il resolver **non enforce** il check (`target.reactions.current > 0`). È una gap della Fase 2: dovrebbe essere aggiunto in Fase 3 per evitare che un target con 0 reactions continui a parare.
+
+### Fallback PARRY_CD
+
+Quando il caller non passa `attack_total` (es. per test isolati di `resolve_parry` senza un attack reale), il resolver usa `PARRY_CD = 12` come CD fissa. Questa era l'implementazione Fase 1 (parata non contestata). La Fase 2 ha aggiunto la parry contestata passando `attack_total`, ma il fallback è mantenuto per retrocompat e per i test unitari.
+
+**Test ref**: `tests/test_resolver.py::test_resolve_parry_contested_*` e `tests/test_resolver.py::test_resolve_parry_fallback_cd_*`.
+
+## Ability stub (Fase 3)
+
+Il campo `action.ability_id` esiste nello schema ma **non ha logica di risoluzione** nel resolver Fase 2. Un'action con `type: "ability"` cade nel ramo NOOP: consuma AP, produce turn_log entry, fine.
+
+Il piano per Fase 3 (dall'ADR):
+
+1. Il catalog `trait_mechanics.yaml` ha un campo `active_effects: []` per-trait, attualmente sempre vuoto.
+2. Quando popolato, conterrà identifier come `"apply_disorient_on_hit"`, `"bleeding_on_crit"`, `"summon_meteor"`.
+3. Un nuovo registry `services/rules/effects/` (ancora da creare) mapperà `effect_id → handler_function`.
+4. Il resolver, per `action.type == "ability"`, cercherà l'handler e lo eseguirà con `(state, action, actor, catalog, rng)`.
+5. L'handler restituirà modifiche al `next_state` e entry da aggiungere al `turn_log`.
+
+Per ora, chi sviluppa trait content può **popolare** `active_effects` come preparazione, ma il resolver ignorerà i valori.
+
+## Esempio completo
+
+Un'action `attack` con tutti i campi opzionali:
+
+```json
+{
+  "id": "act-007",
+  "type": "attack",
+  "actor_id": "party-02",
+  "target_id": "h-03",
+  "ap_cost": 1,
+  "channel": "taglio",
+  "damage_dice": { "count": 1, "sides": 8, "modifier": 2 },
+  "pt_spend": { "type": "perforazione", "amount": 1 },
+  "parry_response": { "attempt": true, "parry_bonus": 1 },
+  "ability_id": null
+}
+```
+
+Interpretazione: party-02 attacca h-03, 1 AP, dado d8+2, canale taglio (per resistenze), spende 1 PT per penetrare armor (-2 effective), h-03 tenta una parata reattiva con +1 bonus (contestata sul total dell'attack).
+
+Vedi [data-flow.md](data-flow.md#3-esempio-worked-attacco-con-parry-response-e-stress-breakpoint) per un walk-through di questa action con tutti i valori intermedi.
+
+## Riferimenti
+
+- Schema completo `$defs.action`: `packages/contracts/schemas/combat.schema.json`
+- Implementazione pipeline attack: `services/rules/resolver.py::resolve_action`
+- `apply_pt_spend`, `resolve_parry`: [resolver-api.md](resolver-api.md#apply_pt_spend-actor-pt_spend--amount_consumed)
+- Constanti esportate (`SUPPORTED_PT_SPEND_TYPES`, `PARRY_CD`, `PERFORAZIONE_ARMOR_REDUCTION`, ecc.): [resolver-api.md](resolver-api.md#costanti-esportate)
+- Status consumati dalla pipeline: [status-effects-guide.md](status-effects-guide.md)
+- ADR con scope Fase 2 vs Fase 3: [ADR-2026-04-13: Rules Engine d20](../adr/ADR-2026-04-13-rules-engine-d20.md)

--- a/docs/combat/status-effects-guide.md
+++ b/docs/combat/status-effects-guide.md
@@ -1,0 +1,272 @@
+---
+title: Status Effects Guide
+description: Catalog dei 5 status effect implementati e procedura per aggiungerne di nuovi al rules engine d20.
+doc_status: active
+doc_owner: combat-team
+workstream: combat
+last_verified: 2026-04-14
+source_of_truth: false
+language: it-en
+review_cycle_days: 14
+---
+
+# Status Effects Guide
+
+Il rules engine supporta **5 status effect** nella Phase 2: `bleeding`, `fracture`, `disorient`, `rage`, `panic`. Questo documento li cataloga uno per uno, spiega come vengono triggerati e consumati, e fornisce la procedura per aggiungerne di nuovi.
+
+## Anatomia di uno status effect
+
+Uno `status_effect` nel `CombatState` ha questa shape (`$defs.status_effect` in `combat.schema.json`):
+
+```json
+{
+  "id": "rage",
+  "intensity": 2,
+  "remaining_turns": 3,
+  "source_unit_id": "h-01",
+  "source_action_id": "act-014"
+}
+```
+
+- **id**: uno di `{bleeding, fracture, disorient, rage, panic}` nell'enum attuale.
+- **intensity**: int ≥ 1, scala l'effetto (es. `rage intensity=2` → `+2 attack_mod`, `+2 damage_step`, `-2 defense_mod`).
+- **remaining_turns**: int ≥ 0, decrementato di 1 ad ogni `begin_turn()` dell'unità. Quando raggiunge 0, lo status viene rimosso.
+- **source_unit_id** / **source_action_id**: audit trail opzionale (who/what applied this), utile per log e replay.
+
+## Catalog dei 5 status
+
+### `bleeding`
+
+**Semantica**: danno ricorrente a inizio turno del target. Simula emorragie, tossine, bruciature persistenti.
+
+**Trigger**: applicato manualmente dal caller (future ability) o dai contract dei trait con `active_effects`. Non è auto-triggered dal resolver in Fase 2.
+
+**Effetto**: in `begin_turn(state, unit_id)`, prima del decay status, viene eseguito un tick: `unit.hp.current -= sum(status.intensity for status in unit.statuses if status.id == "bleeding")`, clamp a 0.
+
+**Implementazione**: `services/rules/resolver.py` — cerca `bleeding` in `begin_turn`. Il tick avviene **prima** del decay `remaining_turns`, quindi uno status con `remaining_turns=1` fa un ultimo tick prima di essere rimosso.
+
+**Test ref**: `tests/test_resolver.py::test_begin_turn_bleeding_*`.
+
+### `fracture`
+
+**Semantica**: riduzione dello `step_count` degli attack del portatore. Simula ossa rotte, armature compromesse, mobilità ridotta.
+
+**Trigger**: applicato manualmente (no auto-trigger in Fase 2).
+
+**Effetto**: in `resolve_action()` durante il calcolo dello step_count dell'attore:
+
+```
+step_count = max(0, step_count - intensity * FRACTURE_STEP_REDUCTION_PER_INTENSITY)
+```
+
+Costante: `FRACTURE_STEP_REDUCTION_PER_INTENSITY = 1`. Quindi `fracture intensity=2` → `-2 step_count`, con floor a 0.
+
+**Test ref**: `tests/test_resolver.py::test_resolve_attack_with_fracture_*`.
+
+### `disorient`
+
+**Semantica**: malus al tiro di attack del portatore. Simula stordimento, accecamento, confusione percettiva.
+
+**Trigger**: applicato manualmente (no auto-trigger).
+
+**Effetto**: in `resolve_action()`:
+
+```
+attack_mod -= intensity * DISORIENT_ATTACK_MALUS_PER_INTENSITY
+```
+
+Costante: `DISORIENT_ATTACK_MALUS_PER_INTENSITY = 2`. Quindi `disorient intensity=2` → `-4 attack_mod`.
+
+**Test ref**: `tests/test_resolver.py::test_resolve_attack_with_disorient_*`.
+
+### `rage`
+
+**Semantica**: "furia cieca". Bonus offensivi ma malus difensivo (l'unità in rage si espone a contrattacchi).
+
+**Trigger**: **auto-triggered** da `check_stress_breakpoints` quando lo stress del target attraversa la soglia `STRESS_BREAKPOINT_RAGE = 0.5` durante l'azione. Applicato con `RAGE_DEFAULT_INTENSITY=1` e `RAGE_DEFAULT_DURATION=3`.
+
+**Effetto**: in `resolve_action()`:
+
+- Sull'attore (pipeline step 5): `attack_mod += intensity * 1`, `damage_step += intensity * 1`
+- Sul target (quando è il difensore, pipeline step 5): `defense_mod -= intensity * 1`
+
+Costanti: `RAGE_ATTACK_BONUS_PER_INTENSITY = 1`, `RAGE_DAMAGE_STEP_BONUS_PER_INTENSITY = 1`, `RAGE_DEFENSE_MALUS_PER_INTENSITY = 1`.
+
+**Test ref**: `tests/test_resolver.py::test_resolve_attack_with_rage_*`, `tests/test_resolver.py::test_check_stress_breakpoints_rage_*`.
+
+### `panic`
+
+**Semantica**: terrore. Blocca la spesa di PT (azioni concentrate) e riduce l'accuratezza.
+
+**Trigger**: **auto-triggered** da `check_stress_breakpoints` quando lo stress attraversa `STRESS_BREAKPOINT_PANIC = 0.75`. Applicato con `PANIC_DEFAULT_INTENSITY=1` e `PANIC_DEFAULT_DURATION=2`.
+
+**Effetto**: in `resolve_action()`:
+
+- Pipeline step 3 (**prima** del roll): se `get_status(actor, "panic")` è truthy, `action.pt_spend` viene **silent-droppato** (nessun PT consumato, nessun effetto di perforazione/spinta applicato). Non solleva eccezione.
+- Pipeline step 5: `attack_mod -= intensity * PANIC_ATTACK_MALUS_PER_INTENSITY` (costante = 2).
+
+Costante: `PANIC_ATTACK_MALUS_PER_INTENSITY = 2`.
+
+**Test ref**: `tests/test_resolver.py::test_resolve_attack_with_panic_*`, `tests/test_resolver.py::test_panic_blocks_pt_spend`.
+
+## Refresh semantics
+
+Quando `apply_status` riceve un `status_id` che l'unità ha già, viene eseguito un **refresh con max**, non un'aggiunta:
+
+```python
+# Stato esistente:
+# {id: rage, intensity: 1, remaining_turns: 2}
+
+apply_status(unit, "rage", duration=3, intensity=2, ...)
+
+# Stato dopo refresh:
+# {id: rage, intensity: 2, remaining_turns: 3}
+#             ^^^                     ^^^
+#             max(1, 2) = 2           max(2, 3) = 3
+```
+
+Il `source_unit_id` e `source_action_id` **vengono sovrascritti** con i nuovi valori (non accumulati). Questo significa che la "colpa" di uno status è sempre attribuita all'ultimo trigger.
+
+Il refresh garantisce che:
+
+- Status di durata diversa non si sovrappongano (non hai 2 entry di rage).
+- Un secondo proc "peggiorativo" (intensity maggiore) upgrada l'effetto.
+- Un secondo proc con intensity minore **non degrada** lo status esistente.
+
+## Stress breakpoints
+
+Gli unici status auto-applicati dal resolver sono `rage` e `panic`, e solo via `check_stress_breakpoints()`. Vedi `services/rules/resolver.py` per la logica:
+
+```python
+def check_stress_breakpoints(target, stress_before, stress_after, ...):
+    applied = []
+    if stress_before < STRESS_BREAKPOINT_RAGE <= stress_after:
+        applied.append(apply_status(target, "rage", duration=3, intensity=1, ...))
+    if stress_before < STRESS_BREAKPOINT_PANIC <= stress_after:
+        applied.append(apply_status(target, "panic", duration=2, intensity=1, ...))
+    return applied
+```
+
+Il check "attraversa la soglia" (`<` stretto a sinistra, `<=` chiuso a destra) garantisce che ogni breakpoint scatti **una sola volta** durante la singola azione.
+
+**Caveat Fase 2**: il resolver non modifica direttamente lo `stress` per attack base. Gli unici triggers di stress nel Frattura draft sono hazard ambientali e forme attivate, non attack. Quindi nella Fase 2 gli status rage/panic si auto-applicano solo se un altro sistema (hazard engine, form activation, demo CLI) ha modificato lo stress prima di chiamare `resolve_action`.
+
+## Aggiungere un nuovo status effect
+
+Procedura step-by-step per aggiungere uno status, ad esempio `poisoned`.
+
+### 1. Aggiungere all'enum dello schema
+
+Edita `packages/contracts/schemas/combat.schema.json`, sezione `$defs.status_effect`:
+
+```json
+"$defs": {
+  "status_effect": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "enum": ["bleeding", "fracture", "disorient", "rage", "panic", "poisoned"]
+      },
+      ...
+    }
+  }
+}
+```
+
+### 2. Definire le costanti in `resolver.py`
+
+Aggiungi le costanti di effetto in testa al modulo:
+
+```python
+#: Effetto di poisoned: -intensity al damage_step del portatore per ogni intensity
+POISONED_DAMAGE_STEP_MALUS_PER_INTENSITY = 1
+
+#: Se poisoned ha una meccanica di tick (come bleeding), aggiungi anche:
+POISONED_HP_TICK_PER_INTENSITY = 1
+```
+
+### 3. Consumare lo status nella pipeline
+
+Apri `resolve_action()` e aggiungi il consumo nel punto appropriato. Per un malus offensivo:
+
+```python
+# Pipeline step 5: apply status modifiers
+actor_poisoned = get_status(actor, "poisoned")
+if actor_poisoned is not None:
+    trait_damage_step -= int(actor_poisoned.get("intensity", 1)) * POISONED_DAMAGE_STEP_MALUS_PER_INTENSITY
+    trait_damage_step = max(0, trait_damage_step)  # clamp
+```
+
+Per un tick HP come bleeding, aggiungi in `begin_turn()`:
+
+```python
+# Dentro begin_turn, prima del decay
+poisoned_damage = sum(
+    int(s.get("intensity", 1)) * POISONED_HP_TICK_PER_INTENSITY
+    for s in unit.get("statuses", [])
+    if s.get("id") == "poisoned"
+)
+if poisoned_damage:
+    current_hp = int(unit["hp"]["current"])
+    unit["hp"]["current"] = max(0, current_hp - poisoned_damage)
+```
+
+### 4. Aggiungere test unitari
+
+In `tests/test_resolver.py`, per ogni meccanica:
+
+```python
+def test_resolve_attack_with_poisoned_reduces_damage_step():
+    state = make_state(...)
+    actor = state["units"][0]
+    actor["statuses"].append({
+        "id": "poisoned",
+        "intensity": 2,
+        "remaining_turns": 3,
+        "source_unit_id": None,
+        "source_action_id": None,
+    })
+    result = resolve_action(state, attack_action, catalog, rng=fixed_rng(0.5))
+    # ... asserzioni sul damage_applied
+```
+
+Aggiungere almeno 1 test per:
+- Trigger meccanico corretto (intensity=1, intensity=2)
+- Stacking con altri status (es. disorient + poisoned)
+- Decay corretto via `begin_turn` → rimozione a `remaining_turns=0`
+
+### 5. Aggiornare i contract test se necessario
+
+Se aggiungi un nuovo `id` all'enum, `tests/api/contracts-combat.test.js` dovrebbe accettarlo senza modifiche perché valida contro lo schema aggiornato. Se hai aggiunto constraint specifici (es. un nuovo campo sullo status), aggiungi un test che verifica l'accettazione.
+
+### 6. Documentare qui
+
+Aggiungi una nuova sottosezione nel [catalog](#catalog-dei-5-status) di questo documento con: semantica, trigger, effetto, costanti, test ref.
+
+### 7. Verifica end-to-end
+
+```bash
+# Schema validation
+node --test tests/api/contracts-combat.test.js
+
+# Unit test resolver
+PYTHONPATH=services/rules pytest tests/test_resolver.py -k poisoned
+
+# Governance strict (i doc modificati non devono rompere nulla)
+python tools/check_docs_governance.py --registry docs/governance/docs_registry.json --strict
+```
+
+## Antipatterns da evitare
+
+- **Hardcodare intensity o duration nel resolver**: usa sempre le costanti (es. `RAGE_DEFAULT_INTENSITY`). Rende il balancing testabile senza toccare la logica.
+- **Duplicare status con lo stesso id**: sempre passare da `apply_status` che fa refresh. Non fare `unit["statuses"].append(...)` a mano.
+- **Leggere `remaining_turns <= 0` come "status attivo"**: lo schema richiede `remaining_turns >= 0`, ma un valore 0 è ambiguo tra "scaduto" e "perenne". La convenzione: status con `remaining_turns > 0` sono attivi, e `begin_turn` li rimuove quando raggiungono 0. Un "status perenne" dovrebbe avere `remaining_turns: 999` o una costante `STATUS_PERENNE`.
+- **Modificare `source_unit_id` dopo l'applicazione**: è parte dell'audit trail, non un campo di lavoro. Se serve cambiarlo, chiama `apply_status` con i nuovi valori (che sovrascrive anche gli altri campi via refresh).
+
+## Riferimenti
+
+- Schema: `$defs.status_effect` in `packages/contracts/schemas/combat.schema.json`
+- Implementazione status: `services/rules/resolver.py` (cerca `apply_status`, `get_status`, `check_stress_breakpoints`, e le costanti `*_PER_INTENSITY`)
+- Test di riferimento: `tests/test_resolver.py` (44+ test su status e scenari misti)
+- Flow di stress e breakpoint: [data-flow.md](data-flow.md#4-stacking-degli-status-effect)
+- API dettagliata di `apply_status` / `check_stress_breakpoints`: [resolver-api.md](resolver-api.md#apply_status)

--- a/docs/combat/trait-mechanics-guide.md
+++ b/docs/combat/trait-mechanics-guide.md
@@ -1,0 +1,249 @@
+---
+title: Trait Mechanics Guide
+description: Come popolare e modificare trait_mechanics.yaml, la fonte unica dei valori meccanici consumati dal resolver d20.
+doc_status: active
+doc_owner: combat-team
+workstream: combat
+last_verified: 2026-04-14
+source_of_truth: false
+language: it-en
+review_cycle_days: 14
+---
+
+# Trait Mechanics Guide
+
+Il file `packs/evo_tactics_pack/data/balance/trait_mechanics.yaml` è la **fonte unica di verità** per i valori meccanici dei trait consumati dal rules engine. Se un trait non è in questo file, per il resolver è come se non avesse effetti meccanici (viene silenziosamente ignorato in `aggregate_mod`).
+
+Questo documento spiega la struttura del file, la semantica dei campi, il processo di validazione e come aggiungere o modificare una entry.
+
+## Struttura del file
+
+```yaml
+schema_version: "0.2.0"
+generated_from: >
+  <descrizione delle fonti del pass Balancer>
+notes: >
+  <policy, canali canonici, distribuzione>
+traits:
+  <trait_id>:
+    attack_mod: 0
+    defense_mod: 0
+    damage_step: 0
+    cost_ap: 1
+    resistances: []
+    active_effects: []
+    notes: "opzionale"
+  <altro_trait_id>:
+    ...
+```
+
+Il top-level espone 3 campi:
+
+- `schema_version`: versione semantica del layer (attualmente `"0.2.0"`)
+- `generated_from` / `notes`: metadati descrittivi non consumati dal resolver
+- `traits`: mapping `trait_id → mechanics_entry`
+
+Lo schema formale è in `packages/contracts/schemas/traitMechanics.schema.json` e viene validato automaticamente dai contract test.
+
+## Campi di una entry
+
+Ogni entry sotto `traits.<trait_id>` ha i seguenti campi:
+
+### `attack_mod` *(int, default 0)*
+
+Modificatore additivo al tiro d20 di attack quando il trait è attivo sull'attore. Viene sommato da `resolve_action` via `aggregate_mod(actor.trait_ids, catalog, "attack_mod")`. Valori tipici: `-2` … `+2`. Positivo = aggressive, negativo = handicap.
+
+### `defense_mod` *(int, default 0)*
+
+Modificatore additivo alla CD di attack del target quando il trait è attivo sul difensore. Formula CD: `10 + target.tier + aggregate(target.trait_ids, "defense_mod")`. Valori tipici: `-1` … `+2`.
+
+### `damage_step` *(int, default 0)*
+
+Step di danno "già maturato" quando il trait è attivo sull'attore. Viene sommato al `step_count` derivato dal MoS nella formula `compute_step_count(mos, trait_damage_step_bonus)`. Effetto netto: un attaccante con `damage_step: 1` parte già con +1 step di danno anche a MoS 0.
+
+Il cap del Balancer è `+1` per trait singolo. I test contract (`tests/api/contracts-trait-mechanics.test.js`) verificano che nessun trait superi `damage_step: 2`.
+
+### `cost_ap` *(int, default 1)*
+
+AP richiesti per un'azione di tipo ability che attiva il trait. **Non è consumato dal resolver nella fase attuale** (le ability sono NOOP), ma è tracciato nel layer per future iterazioni. Usa 1 per trait leggeri, 2 per trait impegnativi, 3 per trait definitivi.
+
+### `resistances` *(list di `{channel, modifier_pct}`)*
+
+Lista di resistenze per-canale che vengono **aggregate sul target** durante l'hydration e applicate dal resolver in `apply_resistance` con formula moltiplicativa `floor(damage * (1 - pct/100))`.
+
+- `channel` *(string, slug)*: canale di danno. Canali canonici: `elettrico, psionico, fisico, fuoco, gravita, mentale, taglio, ionico`. Canale non-canonico attualmente usato: `gelo` (solo `criostasi_adattiva`).
+- `modifier_pct` *(int, clamp [-100, 100])*: percentuale di riduzione. Positivo = riduce danno (resistenza); negativo = amplifica (vulnerabilità).
+
+L'aggregazione via `hydration.aggregate_resistances` somma i `modifier_pct` sullo stesso `channel` attraverso tutti i trait attivi, poi clampa a `[-100, 100]`.
+
+### `active_effects` *(list di string, default [])*
+
+Lista di identifier di effetti attivi (es. `"apply_disorient_on_hit"`, `"bleeding_on_crit"`). Il campo **esiste nello schema ma è NOOP nella Fase 2**: non viene letto dal resolver. È popolato solo come preparazione per la Fase 3 (ability implementation). Vedi [action-types-guide.md](action-types-guide.md) per il piano.
+
+### `notes` *(string, opzionale)*
+
+Documentazione inline: motivazione di un valore non ovvio, riferimento a un draft di bilanciamento, flag "candidato per revisione", ecc. Non consumato dal resolver.
+
+## Tre esempi worked
+
+### Esempio 1 — offensive: `artigli_sette_vie`
+
+```yaml
+artigli_sette_vie:
+  attack_mod: 1
+  defense_mod: 0
+  damage_step: 1
+  cost_ap: 1
+  resistances: []
+  active_effects: []
+```
+
+Un trait pienamente offensive: `+1 attack_mod` garantisce tiri più accurati, `+1 damage_step` aggiunge un flat bonus al danno a prescindere dal MoS, `cost_ap: 1` lo rende spammabile. Tipico early-game trait di un predatore. Non ha resistenze perché è orientato all'offesa, non alla sopravvivenza.
+
+### Esempio 2 — defensive: `criostasi_adattiva`
+
+```yaml
+criostasi_adattiva:
+  attack_mod: 0
+  defense_mod: 1
+  damage_step: 0
+  cost_ap: 3
+  resistances:
+    - { channel: gelo, modifier_pct: 20 }
+  active_effects: []
+  notes: "canale non-canonico gelo (estensione da stabilizzare nel prossimo combat pack)"
+```
+
+Trait defensive: nessun bonus offensivo, ma `+1 defense_mod` alza la CD di attack del target, e una resistenza del 20% al canale `gelo`. Il `cost_ap: 3` è alto perché l'attivazione (quando le ability saranno implementate) sarà impegnativa. Il campo `notes` documenta che `gelo` è un canale non-canonico introdotto da questo trait; andrà stabilizzato nel prossimo pack di combat content.
+
+### Esempio 3 — hybrid: `coda_frusta_cinetica`
+
+```yaml
+coda_frusta_cinetica:
+  attack_mod: 1
+  defense_mod: 1
+  damage_step: 0
+  cost_ap: 2
+  resistances: []
+  active_effects: []
+```
+
+Trait hybrid: `+1 attack_mod` e `+1 defense_mod`, nessun damage_step extra. Non eccelle in nessun ruolo ma è versatile. Il `cost_ap: 2` bilancia il doppio bonus. Tipico trait di scout/tank.
+
+## Catalog coverage gate
+
+Il resolver **rifiuta di avviarsi** se il catalog non contiene tutti i core trait elencati in `docs/catalog/traits_inventory.json` (campo `core_traits`). Attualmente sono **33 core trait** (bumpati da 30 in PR #1298).
+
+Il gate è enforced da due test:
+
+- `tests/api/contracts-trait-mechanics.test.js::trait_mechanics.yaml contiene tutti e 33 i core trait di traits_inventory.json` — scorre i core e verifica che ogni id sia presente in `catalog.traits`.
+- `tests/api/contracts-trait-mechanics.test.js::trait_mechanics.yaml valida contro traitMechanics schema` — valida la struttura completa contro `traitMechanics.schema.json`.
+
+Se aggiungi un nuovo trait al catalog (es. dal Balancer pass), **devi aggiornare entrambi** `trait_mechanics.yaml` e `docs/catalog/traits_inventory.json` nello stesso commit.
+
+## Procedura: aggiungere un nuovo trait
+
+### 1. Aggiungere al catalog inventory
+
+Apri `docs/catalog/traits_inventory.json` e aggiungi l'id del nuovo trait a `core_traits`:
+
+```json
+{
+  "core_traits": [
+    "...",
+    "nuovo_trait_id"
+  ]
+}
+```
+
+### 2. Aggiungere a trait_mechanics.yaml
+
+Apri `packs/evo_tactics_pack/data/balance/trait_mechanics.yaml` e aggiungi una entry sotto `traits:`:
+
+```yaml
+traits:
+  ...
+  nuovo_trait_id:
+    attack_mod: 0      # riempi secondo la classe (offensive/defensive/hybrid/mobility/utility)
+    defense_mod: 0
+    damage_step: 0
+    cost_ap: 1
+    resistances: []    # opzionale, lista di {channel, modifier_pct}
+    active_effects: [] # NOOP in Fase 2, lascia vuota a meno che non stia implementando una ability
+    notes: "motivazione dei valori scelti"
+```
+
+### 3. Aggiornare il test count
+
+Il test `tests/api/contracts-trait-mechanics.test.js` ha un'asserzione hardcoded sul numero di core trait:
+
+```js
+test('trait_mechanics.yaml contiene tutti e 33 i core trait di traits_inventory.json', () => {
+  ...
+  assert.equal(coreIds.length, 33, 'traits_inventory.json deve esporre 33 core');
+  ...
+});
+```
+
+Aggiorna `33` al nuovo conteggio nel title e nell'assertion.
+
+### 4. Verificare
+
+```bash
+# Contract validation (inventory ↔ mechanics ↔ schema)
+node --test tests/api/contracts-trait-mechanics.test.js
+
+# Test end-to-end del resolver (assicura che l'aggregazione funzioni)
+PYTHONPATH=services/rules pytest tests/test_resolver.py tests/test_hydration.py
+```
+
+### 5. Committare entrambi i file insieme
+
+Il catalog inventory e il mechanics file sono accoppiati. Un commit parziale (solo uno dei due) rompe il gate di coverage. Esempio di commit message:
+
+```
+feat(combat): add trait <nuovo_trait_id> to mechanics catalog
+
+- attack_mod: 0, defense_mod: 2, damage_step: 0 (defensive)
+- cost_ap: 2 (attivazione media)
+- resistances: [{channel: ionico, modifier_pct: 15}]
+- Bump core_traits count 33 → 34 in traits_inventory.json
+- Update contract test assertion 33 → 34
+```
+
+## Procedura: modificare un trait esistente
+
+1. Edita l'entry in `trait_mechanics.yaml`. Il campo `notes` è il posto giusto per giustificare il cambio.
+2. Se il nuovo valore invalida scenari nei test del resolver (es. alzi l'`attack_mod` di `artigli_sette_vie` e ora il test `test_resolve_attack_with_artigli_hits_at_mos_0` fallisce perché il MoS cambia), **aggiorna il test**, non bypassa l'asserzione.
+3. Esegui `node --test tests/api/contracts-trait-mechanics.test.js` e `pytest tests/test_resolver.py` per verificare.
+4. Se il cambio invalida le snapshot di hydration (`tests/snapshots/hydration_caverna.json`), rigenera lo snapshot seguendo [testing.md](testing.md).
+
+## Framework Balancer (sintesi)
+
+Il pass Balancer assegna ogni trait a una **classe** basandosi su `description_it` + `family_type` + `usage_tags`:
+
+| Classe | Allocazione tipica | Quota attuale |
+|---|---|---|
+| offensive | `attack_mod: +1`, `damage_step: +1`, `cost_ap: 1` | 4/33 |
+| defensive | `defense_mod: +1..+2`, `resistances: [...]`, `cost_ap: 2..3` | 9/33 |
+| hybrid | `attack_mod: +1`, `defense_mod: +1`, `cost_ap: 2` | 1/33 |
+| mobility | `damage_step: 0`, modifiers neutri, effetti futuri via `active_effects` | 3/33 |
+| utility | neutrale, `cost_ap: 1..2`, spazio per `active_effects` in Fase 3 | 13/33 (15/33 con i 3 nuovi) |
+
+Le regole sono deterministiche: ogni valore è giustificato da un fatto del repo, non da intuizione. Per il framework completo vedi `packs/evo_tactics_pack/data/balance/README.md` e `docs/balance/Frattura_Abissale_Sinaptica_balance_draft.md`.
+
+## Errori comuni
+
+- **Campo YAML con la virgola invece che con `- { key: val }`**: lo schema richiede array di object. `resistances: gelo, 15` non è valido; usare `resistances: [{ channel: gelo, modifier_pct: 15 }]`.
+- **`cost_ap` a 0**: lo schema richiede `cost_ap >= 1`. Usare 1 per trait passivi che potrebbero avere un'activation cost in Fase 3.
+- **`modifier_pct > 100`**: il clamp effettivo è `[-100, 100]`, un valore oltre viene clampato silenziosamente. Meglio scrivere esplicitamente il valore effettivo.
+- **Canale non-canonico senza `notes`**: se introduci un canale fuori dalla lista canonica, documenta la scelta in `notes` per non perderla.
+- **Trait dimenticato nel inventory**: se aggiungi a `mechanics.yaml` ma non a `traits_inventory.json`, il test gate non vede il mismatch. Ricordati sempre di aggiornare entrambi.
+
+## Riferimenti
+
+- Schema formale: `packages/contracts/schemas/traitMechanics.schema.json`
+- Balancer framework: `packs/evo_tactics_pack/data/balance/README.md`
+- ADR per le decisioni di layer separato: [ADR-2026-04-13: Rules Engine d20](../adr/ADR-2026-04-13-rules-engine-d20.md)
+- Contract test gate: `tests/api/contracts-trait-mechanics.test.js`
+- Resolver API che consuma il catalog: [resolver-api.md](resolver-api.md)

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -1493,6 +1493,19 @@
       "track": "authored"
     },
     {
+      "path": "docs/combat/action-types-guide.md",
+      "title": "Action Types Guide",
+      "doc_status": "active",
+      "doc_owner": "combat-team",
+      "workstream": "combat",
+      "last_verified": "2026-04-14",
+      "source_of_truth": false,
+      "language": "it-en",
+      "review_cycle_days": 14,
+      "primary": false,
+      "track": "authored"
+    },
+    {
       "path": "docs/combat/data-flow.md",
       "title": "Combat Data Flow",
       "doc_status": "active",
@@ -1508,6 +1521,32 @@
     {
       "path": "docs/combat/resolver-api.md",
       "title": "Resolver API Reference",
+      "doc_status": "active",
+      "doc_owner": "combat-team",
+      "workstream": "combat",
+      "last_verified": "2026-04-14",
+      "source_of_truth": false,
+      "language": "it-en",
+      "review_cycle_days": 14,
+      "primary": false,
+      "track": "authored"
+    },
+    {
+      "path": "docs/combat/status-effects-guide.md",
+      "title": "Status Effects Guide",
+      "doc_status": "active",
+      "doc_owner": "combat-team",
+      "workstream": "combat",
+      "last_verified": "2026-04-14",
+      "source_of_truth": false,
+      "language": "it-en",
+      "review_cycle_days": 14,
+      "primary": false,
+      "track": "authored"
+    },
+    {
+      "path": "docs/combat/trait-mechanics-guide.md",
+      "title": "Trait Mechanics Guide",
       "doc_status": "active",
       "doc_owner": "combat-team",
       "workstream": "combat",


### PR DESCRIPTION
## Summary

Second of 3 PRs. Adds extension guides for developers who need to add/modify trait mechanics, status effects, or action types.

## Files

| File | Lines | Purpose |
|---|---|---|
| `docs/combat/trait-mechanics-guide.md` | ~280 | Structure of \`trait_mechanics.yaml\`, field semantics, 3 worked examples (artigli_sette_vie / criostasi_adattiva / coda_frusta_cinetica), catalog coverage gate, step-by-step "add a new trait" procedure, common errors |
| `docs/combat/status-effects-guide.md` | ~270 | Catalog of bleeding/fracture/disorient/rage/panic with triggers, effects, constants, test refs. Refresh semantics. Step-by-step "add a new status" procedure (with \`poisoned\` as example). Antipatterns |
| `docs/combat/action-types-guide.md` | ~260 | 5 action types (attack + 4 NOOP), PT spend (perforazione / spinta / deferred types), parry response opt-in vs fallback PARRY_CD, ability stub deferred to Phase 3 |

Total: ~810 insertions in docs.

## Coverage for Phase 2 decisions

These guides cover every Phase 2 decision that a developer or AI agent would need to extend the rules engine without reading source code:

- How to populate \`trait_mechanics.yaml\` (balancer framework sintesi + examples)
- How the 5 status effects are implemented and auto-triggered
- How to add a new status (walked through with \`poisoned\`)
- How to add a new trait (and keep inventory + mechanics + test gate aligned)
- When PT spend is silent-dropped vs raised
- Parry contestata vs fallback CD
- Status refresh with max semantics
- Scope deferred to Phase 3 (abilities, combo PT spend, move on grid)

## Verification

- [x] \`check_docs_governance.py --strict\` → 0 errors
- [x] \`docs:lint\` → all internal links valid
- [x] Combat workstream entries: was 4 → now 7

## 03A Rollback

\`git revert <sha>\`. Pure docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)