### PR TITLE
docs(combat): integration — worker bridge, determinism, testing (PR B3 of 3)

### DIFF
--- a/docs/combat/determinism.md
+++ b/docs/combat/determinism.md
@@ -1,0 +1,171 @@
+---
+title: Determinism & RNG Namespacing
+description: Come il rules engine garantisce riproducibilità dei combat tramite RNG namespacing.
+doc_status: active
+doc_owner: combat-team
+workstream: combat
+last_verified: 2026-04-14
+source_of_truth: false
+language: it-en
+review_cycle_days: 14
+---
+
+# Determinism & RNG Namespacing
+
+Il rules engine è **deterministico**: dato un `(state, action, catalog, seed, namespace)`, `resolve_action` produce sempre lo stesso `(next_state, turn_log_entry)`. Questa proprietà è essenziale per:
+
+- **Replay**: riprodurre un combat dalla log entry senza dipendere dalla wall clock o da stato esterno.
+- **Test**: scrivere test unitari con RNG controllato senza mock fragili.
+- **Snapshot**: paragonare un run contro uno snapshot di riferimento (`tests/snapshots/hydration_caverna.json`).
+- **Debugging**: riprodurre un bug dato un seed + turn log senza "non riesco a riprodurre".
+
+Questo documento spiega come il determinismo è implementato via `namespaced_rng` e quali sono le sue proprietà.
+
+## Il contract di `namespaced_rng`
+
+L'helper vive in `tools/py/game_utils/random_utils.py` ed è condiviso tra il rules engine e il flow pipeline (`services/generation/`).
+
+```python
+from game_utils.random_utils import namespaced_rng
+
+rng = namespaced_rng(seed="s-2026-04-14", namespace="attack")
+# rng è un RandomFloatGenerator: chiamate a rng() restituiscono float in [0.0, 1.0)
+```
+
+**Proprietà**:
+
+1. **Deterministico su (seed, namespace)**: dato lo stesso `(seed, namespace)`, `rng` produce **sempre la stessa sequenza** di float, a prescindere dal thread, dal processo, dal sistema operativo.
+2. **Indipendente tra namespace**: namespace diversi sullo stesso seed producono stream **indipendenti**. `namespaced_rng("s1", "attack")` e `namespaced_rng("s1", "parry")` non condividono stato.
+3. **Algoritmo**: mulberry32 (LCG veloce a 32 bit), seedato da `hash(seed + namespace)`. La scelta è documentata nell'ADR-2026-04-13: stesso algoritmo del generation pipeline per riuso e test parity.
+
+## Perché separato dal generation RNG
+
+Il flow pipeline (`services/generation/orchestrator.py`) usa lo stesso helper `namespaced_rng` ma con **namespace diversi** (tipicamente `"species"`, `"biome"`, `"trait"`). Questa separazione garantisce che:
+
+- Rigiocare un combat con lo stesso seed non consuma RNG del generation e viceversa.
+- Un bug in un sotto-sistema non contamina l'altro tramite side effect sul global RNG state.
+- I test possono usare lo stesso seed per casi diversi senza preoccuparsi di ordering.
+
+Il namespace `"attack"` è il **default** del worker rules engine e viene usato per tutti i tiri di `resolve_action` (d20 attack + damage dice + parry). Il `resolve_parry` eredita il namespace del chiamante, non crea un sub-namespace.
+
+## Come riprodurre un combat
+
+Dato un turn log di un combat reale:
+
+```json
+{
+  "session_id": "skydock-2026-04-14-01",
+  "seed": "s-2026-04-14",
+  "log": [
+    {
+      "turn": 1,
+      "action": {...},
+      "roll": {"natural": 17, "total": 19, "dc": 15, "success": true, ...},
+      "damage_applied": 6,
+      ...
+    },
+    ...
+  ]
+}
+```
+
+Per riprodurre il tiro `natural: 17` del turn 1, serve:
+
+1. **Stesso seed**: `"s-2026-04-14"`.
+2. **Stesso namespace**: `"attack"` (default) o l'esatto namespace passato al worker.
+3. **Stesso stato di partenza**: l'initial `CombatState` prima dell'azione.
+4. **Stesso catalog**: `trait_mechanics.yaml` identico (versioning tramite `schema_version`).
+5. **Stesso ordine di azioni**: ogni action precedente consuma N tiri dall'RNG stream. Riprodurre solo il turn N richiede di ripetere tutti i 1..N-1 turni nell'ordine originale.
+
+Pseudocodice per il replay:
+
+```python
+from services.rules.hydration import hydrate_encounter, load_trait_mechanics
+from services.rules.resolver import resolve_action
+from game_utils.random_utils import namespaced_rng
+
+catalog = load_trait_mechanics("packs/evo_tactics_pack/data/balance/trait_mechanics.yaml")
+state = hydrate_encounter(encounter, party, catalog, seed=original_seed, session_id=...)
+
+for turn_entry in original_log:
+    rng = namespaced_rng(original_seed, namespace="attack")
+    # WARNING: ogni call a resolve_action crea un nuovo RNG dallo stesso seed.
+    # Il tiro restituito sarà lo stesso solo se l'RNG è "fresh" — vedi caveat sotto.
+    result = resolve_action(state, turn_entry["action"], catalog, rng)
+    assert result["turn_log_entry"]["roll"]["natural"] == turn_entry["roll"]["natural"]
+    state = result["next_state"]
+```
+
+## Caveat importante: fresh RNG per request
+
+Guarda `services/rules/worker.py::_handle_resolve`:
+
+```python
+seed = _validate_str(payload, "seed")
+namespace = payload.get("namespace") or _DEFAULT_RNG_NAMESPACE
+rng = namespaced_rng(seed, namespace)
+return resolve_action(state=state, action=action, catalog=catalog, rng=rng)
+```
+
+**Ogni request** a `resolve-action` crea un `rng` fresco con lo stesso `(seed, namespace)`. Questo significa che:
+
+- Se il parent invia N azioni con lo stesso seed e namespace, **ogni azione riparte dal primo valore dell'RNG stream**.
+- L'N-esimo tiro di un attack singolo è sempre uguale (es. `rng()` → 0.42 → d20 rolls 9).
+- Ma se vuoi stream diversi per azioni diverse nello stesso combat, devi variare il seed o il namespace a ogni request.
+
+**Pattern consigliato**:
+
+- **Opzione A (seed per turno)**: il parent passa un seed diverso per ogni request, es. `"s-base-turn-1"`, `"s-base-turn-2"`, ecc. Semplice ma richiede un seeding strategy.
+- **Opzione B (namespace crescente)**: il parent passa lo stesso seed ma un namespace diverso, es. `"attack-001"`, `"attack-002"`, ecc. Più ordinato.
+- **Opzione C (seed derivato dallo state)**: il parent deriva il seed dal turn + attack index, es. `hash(seed_base + "-" + turn + "-" + action_id)`. Più robusto ma richiede che il client sia consistente.
+
+Attualmente il backend Node **non enforce** nessuno di questi pattern: è responsabilità del caller. In un replay affidabile, il pattern usato deve essere documentato nel log entry (es. salvare `rng_seed_effective` nel `turn_log_entry`).
+
+## Caveat: stress breakpoints e ordine degli status
+
+Gli status auto-applicati da `check_stress_breakpoints` sono deterministici **se l'ordine degli status esistenti è stabile**. La lista `unit.statuses` è un `list` Python (non `set`), quindi l'ordine è preservato nello state JSON.
+
+Tuttavia:
+
+- Un `apply_status` che fa refresh **non sposta la posizione** nella lista (modifica in-place).
+- Un nuovo `apply_status` appende in fondo.
+
+Se un replay serializza/deserializza lo state passando per un parser JSON che non preserva l'ordine degli array (raro ma possibile), il replay potrebbe divergere. Questa è una gap teorica che nella pratica non si verifica (JSON parser standard preservano l'ordine degli array).
+
+## Riproducibilità vs performance
+
+Il `namespaced_rng` non fa caching dello stream: ogni invocazione consuma `hash(seed+namespace)` e inizializza un nuovo LCG. Questo è O(1) ma non zero (~1µs per init).
+
+Se il worker dovesse gestire migliaia di azioni al secondo, questo overhead potrebbe essere visibile. Nella pratica, il bottleneck del worker è `deepcopy(state)` e il parsing JSON, non l'RNG init. Non ottimizzare finché non misurato.
+
+## Proprietà formali
+
+Dato lo stesso input:
+
+- `resolve_action(s, a, c, rng)` == `resolve_action(s, a, c, rng)` ✅
+- `hydrate_encounter(e, p, c, seed, sid)` == `hydrate_encounter(e, p, c, seed, sid)` ✅
+- `begin_turn(s, uid)` == `begin_turn(s, uid)` ✅ (non usa RNG — pure transform)
+- `resolve_parry(t, rng, bonus, total)` == `resolve_parry(t, rng, bonus, total)` ✅
+- `apply_status(u, id, dur, int, src_u, src_a)` == `apply_status(u, id, dur, int, src_u, src_a)` ✅
+
+**Non deterministico**:
+
+- Nessuna chiamata a `time.time()`, `uuid.uuid4()`, `os.urandom()` nel resolver/hydration/worker. Se un futuro contributor ne aggiunge una, rompe il contract.
+
+## Checklist per cambi al resolver
+
+Prima di mergiare un cambio a `services/rules/resolver.py`, verifica:
+
+- [ ] Il nuovo codice non usa `random.random()` direttamente. Se serve un random value, passa per `rng`.
+- [ ] Il nuovo codice non usa `time.time()`, `datetime.now()`, `uuid.uuid4()`, `os.urandom()`.
+- [ ] Il nuovo codice non muta globale. Variabili module-level aggiunte devono essere immutabili (costanti, frozenset).
+- [ ] Il nuovo test può passare anche con `rng = lambda: 0.5` (RNG fisso) se il test non deve stressare una distribuzione specifica.
+- [ ] La snapshot di `hydration_caverna.json` viene rigenerata se l'hydration cambia il risultato. Vedi [testing.md](testing.md).
+
+## Riferimenti
+
+- Implementazione `namespaced_rng`: `tools/py/game_utils/random_utils.py`
+- Worker che istanzia rng: `services/rules/worker.py::_handle_resolve`
+- Test di determinismo end-to-end: `tests/api/contracts-hydration-snapshot.test.js`
+- ADR-2026-04-13 decisione 3 (RNG namespacing): [ADR-2026-04-13: Rules Engine d20](../adr/ADR-2026-04-13-rules-engine-d20.md)
+- Contract del resolver (purity): [resolver-api.md](resolver-api.md#contract-di-purezza)

--- a/docs/combat/testing.md
+++ b/docs/combat/testing.md
@@ -1,0 +1,299 @@
+---
+title: Combat Testing Guide
+description: Come scrivere unit test e snapshot test per il rules engine d20.
+doc_status: active
+doc_owner: combat-team
+workstream: combat
+last_verified: 2026-04-14
+source_of_truth: false
+language: it-en
+review_cycle_days: 14
+---
+
+# Combat Testing Guide
+
+Il rules engine è coperto da **82 test Python** (64 resolver + 18 hydration) e **45 test Node** (contract validation su schema, snapshot, trait mechanics). Questo documento spiega l'infrastruttura, le convenzioni e come aggiungere/aggiornare test.
+
+## Panoramica test esistenti
+
+| File | Tipo | Test | Scope |
+|---|---|---|---|
+| `tests/test_resolver.py` | Python unit | 64 | Funzioni pure del resolver: pipeline attack, status, PT spend, parry, stress, formule |
+| `tests/test_hydration.py` | Python unit | 18 | `hydrate_encounter`, `load_trait_mechanics`, aggregazione resistenze, initiative ordering |
+| `tests/api/contracts-combat.test.js` | Node contract | 23 | Schema JSON validation: CombatState, action, turn_log, status_effect, roll_result, parry_result |
+| `tests/api/contracts-hydration-snapshot.test.js` | Node snapshot | 7 | Hydration di un encounter reale contro snapshot `tests/snapshots/hydration_caverna.json` |
+| `tests/api/contracts-trait-mechanics.test.js` | Node contract | 15 | `trait_mechanics.yaml` valida contro schema + allineamento con `traits_inventory.json` (33 core) |
+
+## Eseguire i test
+
+```bash
+# Python: tutti i test del rules engine
+PYTHONPATH=services/rules pytest tests/test_resolver.py tests/test_hydration.py -v
+
+# Singolo file
+PYTHONPATH=services/rules pytest tests/test_resolver.py -v
+
+# Test specifico per pattern
+PYTHONPATH=services/rules pytest tests/test_resolver.py -k "rage" -v
+
+# Node: tutti i contract test combat (fast, ~1s totali)
+node --test tests/api/contracts-combat.test.js \
+            tests/api/contracts-hydration-snapshot.test.js \
+            tests/api/contracts-trait-mechanics.test.js
+```
+
+Il set Python non richiede `ORCHESTRATOR_AUTOCLOSE_MS` o altri env (il resolver è puro). Il set Node richiede solo le node_modules (`npm ci`).
+
+## Scrivere un unit test del resolver
+
+Il pattern canonico:
+
+```python
+import pytest
+from services.rules.resolver import resolve_action
+
+
+def _make_state(actor_trait_ids=None, target_tier=2, target_defense_mod=0):
+    """Factory helper per uno state minimale 2-unit."""
+    return {
+        "session_id": "test",
+        "seed": "s-test",
+        "turn": 1,
+        "initiative_order": ["a", "t"],
+        "active_unit_id": "a",
+        "log": [],
+        "units": [
+            {
+                "id": "a", "species_id": "test-sp", "side": "party",
+                "tier": 2,
+                "hp": {"current": 30, "max": 30}, "ap": {"current": 2, "max": 2},
+                "armor": 0, "initiative": 10, "stress": 0.0,
+                "pt": 2, "reactions": {"current": 1, "max": 1},
+                "trait_ids": actor_trait_ids or [],
+                "statuses": [], "resistances": [],
+            },
+            {
+                "id": "t", "species_id": "test-sp", "side": "hostile",
+                "tier": target_tier,
+                "hp": {"current": 40, "max": 40}, "ap": {"current": 2, "max": 2},
+                "armor": 0, "initiative": 8, "stress": 0.0,
+                "pt": 0, "reactions": {"current": 1, "max": 1},
+                "trait_ids": [], "statuses": [], "resistances": [],
+            },
+        ],
+    }
+
+
+def _make_catalog(**kwargs):
+    """Factory helper per un catalog minimale."""
+    return {"artigli_sette_vie": {"attack_mod": 1, "damage_step": 1}, **kwargs}
+
+
+def _fixed_rng(value: float):
+    """RNG che restituisce sempre lo stesso valore. Utile per tiri deterministici."""
+    return lambda: value
+
+
+def test_resolve_attack_with_artigli_hits_at_mos_4():
+    state = _make_state(actor_trait_ids=["artigli_sette_vie"])
+    catalog = _make_catalog()
+    action = {
+        "id": "a-1",
+        "type": "attack",
+        "actor_id": "a",
+        "target_id": "t",
+        "ap_cost": 1,
+        "damage_dice": {"count": 1, "sides": 8, "modifier": 2},
+    }
+
+    # Con rng fisso a 0.7, d20 = 1 + floor(0.7 * 20) = 1 + 14 = 15
+    # attack_mod da artigli = +1, total = 16
+    # CD = 10 + tier(2) + defense_mod(0) = 12
+    # mos = 16 - 12 = 4, step_count = (4 // 5) + 1 = 1
+    # damage rolled (fisso a 0.7): ..., + step_bonus: ..., - armor: 0
+    result = resolve_action(state, action, catalog, rng=_fixed_rng(0.7))
+
+    roll = result["turn_log_entry"]["roll"]
+    assert roll["success"] is True
+    assert roll["mos"] == 4
+    assert roll["damage_step"] == 1
+    assert result["turn_log_entry"]["damage_applied"] > 0
+```
+
+**Pattern ricorrenti**:
+
+- **RNG fisso**: per test deterministici, usa `_fixed_rng(v)` dove `v` è un float tra 0 e 1. Il dado viene calcolato come `1 + floor(v * sides)`, quindi `v=0` → roll 1, `v=0.999` → roll `sides`.
+- **State minimale**: usa `_make_state()` e sovrascrivi solo i campi rilevanti per il test. Evita di copia-incollare state interi.
+- **Un asserto per concetto**: test `test_resolve_attack_with_X_hits_at_mos_Y` verifica solo il success e il mos. Test separato per damage. Test separato per status applicati. Non overloadare un test con 10 asserti.
+- **Commento inline del calcolo**: scrivi nel commento come hai derivato i valori attesi (es. `d20 = 1 + floor(0.7 * 20) = 15`). Facilita il debugging quando il test si rompe.
+
+## Scrivere un test per un nuovo status effect
+
+Vedi la procedura completa in [status-effects-guide.md](status-effects-guide.md#aggiungere-un-nuovo-status-effect). In sintesi, per uno status `poisoned`:
+
+```python
+def test_resolve_attack_with_poisoned_reduces_damage_step():
+    state = _make_state(actor_trait_ids=["artigli_sette_vie"])
+    state["units"][0]["statuses"].append({
+        "id": "poisoned",
+        "intensity": 2,
+        "remaining_turns": 3,
+        "source_unit_id": None,
+        "source_action_id": None,
+    })
+    # artigli_sette_vie dà damage_step +1
+    # poisoned intensity=2 → -2 damage_step
+    # effective damage_step = max(0, 1 - 2) = 0
+    result = resolve_action(state, attack_action(), _make_catalog(), _fixed_rng(0.7))
+    # ... asserzioni
+```
+
+## Scrivere un contract test (Node)
+
+I contract test validano gli schemi JSON. Pattern in `tests/api/contracts-combat.test.js`:
+
+```js
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { combatSchema } = require('../../packages/contracts');
+const { createSchemaValidator } = require('../../apps/backend/middleware/schemaValidator');
+
+const SCHEMA_ID = 'contracts://combat/state';
+
+function buildValidator() {
+  const validator = createSchemaValidator();
+  validator.registerSchema(SCHEMA_ID, combatSchema);
+  return validator;
+}
+
+test('CombatState valido accetta stato minimale', () => {
+  const validator = buildValidator();
+  const state = {
+    session_id: 'test-session',
+    seed: 's1',
+    turn: 1,
+    initiative_order: ['u-1'],
+    active_unit_id: 'u-1',
+    units: [{
+      id: 'u-1', species_id: 'sp-1', side: 'party', tier: 1,
+      hp: { current: 10, max: 10 }, ap: { current: 2, max: 2 },
+      armor: 0, initiative: 5, stress: 0, statuses: [],
+      resistances: [], trait_ids: [], pt: 0,
+      reactions: { current: 1, max: 1 },
+    }],
+    log: [],
+  };
+  assert.doesNotThrow(() => validator.validate(SCHEMA_ID, state));
+});
+```
+
+**Pattern**:
+
+- **Valido + invalido per ogni constraint**: per ogni campo required/enum/range, scrivi un test che lo accetta valido e un test che lo rifiuta invalido.
+- **Costruisci state minimale**: non riusare lo snapshot, costruisci a mano per isolare il constraint.
+- **`assert.doesNotThrow` per success, `assert.throws` per reject**: il validator lancia `SchemaValidationError` su fallimento.
+
+## Aggiornare uno snapshot di hydration
+
+Lo snapshot `tests/snapshots/hydration_caverna.json` è generato hydratando `docs/examples/encounter_caverna.md` + una party fissa. Se il tuo cambio all'hydration (o al catalog) ne modifica l'output, devi rigenerare.
+
+**Procedura**:
+
+1. Esegui lo script che rigenera lo snapshot (se esiste) o il test in "update mode":
+
+```bash
+# Se lo script dedicato esiste:
+PYTHONPATH=services/rules python3 scripts/regenerate_hydration_snapshot.py
+
+# Altrimenti, aggiorna manualmente:
+#   - Apri tests/api/contracts-hydration-snapshot.test.js
+#   - Trova il test che produce l'actual state
+#   - Aggiungi temporaneamente: fs.writeFileSync(snapshotPath, JSON.stringify(state, null, 2))
+#   - Esegui il test una volta, verifica il diff
+#   - Rimuovi la riga di writeFile
+```
+
+2. **Verifica il diff manualmente** prima di committare. Uno snapshot update che cambia troppi campi è un warning: magari il cambio non è intenzionale.
+
+3. Committa lo snapshot **insieme** al cambio che l'ha generato, con un commit message esplicito:
+
+```
+refactor(hydration): adjust hostile power scaling formula
+
+Old: HP = 40 + 10*power, armor = 2 + power//2
+New: HP = 50 + 8*power, armor = 2 + power//3
+
+Snapshot regenerated: tests/snapshots/hydration_caverna.json
+All 4 hostile units updated (h-01..h-04).
+```
+
+## Scrivere un contract test end-to-end per un nuovo trait
+
+Se aggiungi un trait a `trait_mechanics.yaml`, assicurati che il contract test lo cattura:
+
+```bash
+# 1. Aggiungi trait all'inventory (docs/catalog/traits_inventory.json)
+#    Aggiungi trait a trait_mechanics.yaml
+#    Aggiorna count nel test (33 → 34)
+
+# 2. Esegui contract test
+node --test tests/api/contracts-trait-mechanics.test.js
+
+# Ci dovrebbero essere 15 test passing.
+# Se il conteggio non matcha, il gate fallisce con:
+#   "traits_inventory.json deve esporre 33 core"
+
+# 3. Per un trait defensive con resistenze, aggiungi un test Python che verifica
+#    che il damage subito dal target sia ridotto correttamente:
+
+def test_resolve_attack_vs_target_with_new_resistance():
+    state = _make_state()
+    state["units"][1]["trait_ids"] = ["nuovo_trait_defensive"]
+    state["units"][1]["resistances"] = [{"channel": "ionico", "modifier_pct": 20}]
+    catalog = {"nuovo_trait_defensive": {"defense_mod": 1}}
+    action = {
+        "id": "a-1", "type": "attack", "actor_id": "a", "target_id": "t",
+        "ap_cost": 1, "channel": "ionico",
+        "damage_dice": {"count": 1, "sides": 6, "modifier": 0},
+    }
+    result = resolve_action(state, action, catalog, _fixed_rng(0.9))
+    # Verifica che il danno sia stato ridotto del 20%
+```
+
+## Best practices
+
+**Do**:
+
+- Usa RNG fisso (`_fixed_rng`) quando possibile. Solo per test di distribuzione (es. "su 1000 attack, il crit rate è ~5%") usa RNG reale.
+- Nomina i test con il pattern `test_<funzione>_<scenario>_<esito_atteso>`. Es: `test_resolve_parry_contested_fails_when_natural_is_1`.
+- Isola ogni meccanica in un test separato anche se sembra ridondante. Un test che verifica 10 cose è un test che ne verifica 0 quando fallisce.
+- Aggiorna il test count in `tests/api/contracts-trait-mechanics.test.js` quando aggiungi/rimuovi core traits.
+
+**Don't**:
+
+- Non usare `random.seed()` manualmente nei test Python. Il resolver riceve `rng` come argomento, mock via quello.
+- Non modificare `state` in-place nei test (il resolver già fa deep copy, ma i tuoi test dovrebbero riflettere la semantica di purezza).
+- Non usare fixture complesse che nascondono la shape dello state. Se il test richiede uno state elaborato, costruiscilo esplicitamente: il test deve essere leggibile senza decodificare 3 helper.
+- Non commentare un test flaky con `@pytest.mark.skip` senza aprire un ticket. Un test skip è debt.
+
+## Coverage goals
+
+- **64+ test resolver**: copertura completa delle funzioni pubbliche di `resolver.py`. Ogni costante di status (`RAGE_*`, `PANIC_*`, ecc.) dovrebbe avere almeno un test che ne verifica l'effetto.
+- **18+ test hydration**: copertura di `hydrate_encounter` per scenari party-only, hostile-only, mixed, trait sconosciuti, initiative order.
+- **45+ test contract Node**: schema validation positiva e negativa per ogni campo required dello schema combat.
+
+Il coverage tool (`pytest-cov`) non è attualmente configurato, ma può essere aggiunto con:
+
+```bash
+pip install pytest-cov
+PYTHONPATH=services/rules pytest tests/test_resolver.py --cov=services.rules --cov-report=html
+```
+
+## Riferimenti
+
+- File di test: `tests/test_resolver.py`, `tests/test_hydration.py`, `tests/api/contracts-*.test.js`
+- Snapshot di riferimento: `tests/snapshots/hydration_caverna.json`
+- Contratto di purezza del resolver: [resolver-api.md](resolver-api.md#contract-di-purezza)
+- RNG determinismo: [determinism.md](determinism.md)
+- Come aggiungere trait: [trait-mechanics-guide.md](trait-mechanics-guide.md#procedura-aggiungere-un-nuovo-trait)
+- Come aggiungere status: [status-effects-guide.md](status-effects-guide.md#aggiungere-un-nuovo-status-effect)

--- a/docs/combat/worker-bridge.md
+++ b/docs/combat/worker-bridge.md
@@ -1,0 +1,343 @@
+---
+title: Worker Bridge — Node ↔ Python protocol
+description: Protocollo JSON-line stdin/stdout tra il backend Node e il worker Python del rules engine.
+doc_status: active
+doc_owner: combat-team
+workstream: combat
+last_verified: 2026-04-14
+source_of_truth: false
+language: it-en
+review_cycle_days: 14
+---
+
+# Worker Bridge — Node ↔ Python protocol
+
+Il rules engine è scritto in Python (`services/rules/resolver.py`, `hydration.py`) ma il backend dell'applicazione è Node (`apps/backend/`). La comunicazione avviene tramite `services/rules/worker.py`, un **worker persistente** che legge messaggi JSON-line da stdin e scrive risposte JSON-line su stdout.
+
+Il pattern è identico a `services/generation/worker.py` (Flow workstream) per coerenza operativa: ready → heartbeat → response loop → shutdown.
+
+## Lifecycle del worker
+
+```
+Parent process (Node)          Worker process (Python)
+       |                                 |
+       |---- spawn (exec worker.py) ---->|
+       |                                 |
+       |                                 | 1. carica trait_mechanics.yaml
+       |                                 |    (via RULES_TRAIT_MECHANICS_PATH
+       |                                 |    o default pack path)
+       |                                 |
+       |                                 | 2. avvia heartbeat thread
+       |                                 |
+       |<-- {"type":"ready","pid":PID}---|
+       |                                 |
+       |                                 | 3. read loop su stdin
+       |                                 |
+       |-- {"id":..,"action":..} ------->|
+       |                                 | 4. parse + dispatch
+       |<-- {"type":"response",..}-------|
+       |                                 |
+       |-- {"id":..,"action":..} ------->|
+       |<-- {"type":"response",..}-------|
+       |                                 |
+       |<-- {"type":"heartbeat",..}------|   (ogni N ms)
+       |                                 |
+       |-- {"id":..,"action":"shutdown"}>|
+       |<-- {"type":"response",..}-------|
+       |                                 | 5. chiude heartbeat thread
+       |                                 |    e termina
+```
+
+Il worker è **single-threaded sul read loop**: una richiesta alla volta, in ordine. Il heartbeat gira su un thread separato daemon e non interferisce con le risposte.
+
+## Handshake iniziale
+
+All'avvio il worker emette:
+
+```json
+{"type": "ready", "pid": 12345}
+```
+
+Il parent Node deve **attendere questo messaggio** prima di inviare richieste. Se arriva invece un `response` con `status: "error"` e `code: "RULES_ERROR"`, il worker ha fallito il caricamento del catalog (tipicamente `trait_mechanics.yaml` mancante).
+
+## Heartbeat
+
+Ogni `RULES_WORKER_HEARTBEAT_INTERVAL_MS` millisecondi (default 5000, minimo 1000, configurabile via env), il worker emette:
+
+```json
+{"type": "heartbeat", "pid": 12345, "timestamp": 1713012345.678}
+```
+
+**Scopo**:
+
+- Il parent può rilevare un worker hung (assenza di heartbeat per N intervalli).
+- Il parent può usare il `timestamp` per sincronizzare orologi o log.
+- Non è una request-response; il parent **non deve rispondere** agli heartbeat.
+
+Il parent può ignorare silenziosamente i heartbeat se non ne ha bisogno.
+
+## Request format
+
+Il parent invia un messaggio per riga (newline-delimited) con shape:
+
+```json
+{
+  "id": "req-042",
+  "action": "resolve-action",
+  "payload": {
+    "state": {...},
+    "action": {...},
+    "seed": "s-2026-04-14",
+    "namespace": "attack"
+  }
+}
+```
+
+**Campi**:
+
+- `id` *(string | int, obbligatorio)*: identifier opaco del request. Il worker lo copia 1:1 in `response.id` per permettere al parent di correlare request/response.
+- `action` *(string, obbligatorio)*: uno di `"hydrate-encounter"`, `"resolve-action"`, `"shutdown"`.
+- `payload` *(object, obbligatorio)*: il contenuto specifico dell'action. Vedi sotto.
+
+## Action: `hydrate-encounter`
+
+Converte un encounter + party in un `CombatState` iniziale chiamando `hydration.hydrate_encounter`.
+
+**Payload**:
+
+```json
+{
+  "encounter": { ... },
+  "party": [ {...}, {...} ],
+  "seed": "s-2026-04-14",
+  "session_id": "skydock-2026-04-14-01",
+  "encounter_id": "caverna-eco",
+  "hostile_species_ids": ["h-drone", "h-sentinel"],
+  "hostile_trait_ids": ["artigli_sette_vie"]
+}
+```
+
+**Campi obbligatori**: `encounter` (object), `party` (array), `seed` (string), `session_id` (string).
+
+**Campi opzionali** (possono essere `null`):
+
+- `encounter_id` *(string | null)*: id opaco dell'encounter per tracciamento.
+- `hostile_species_ids` *(array<string> | null)*: override degli species id degli hostile quando l'encounter ne dichiara solo i gruppi.
+- `hostile_trait_ids` *(array<string> | null)*: override dei trait per gli hostile.
+
+**Response success**:
+
+```json
+{
+  "type": "response",
+  "id": "req-042",
+  "status": "ok",
+  "result": {
+    "session_id": "skydock-2026-04-14-01",
+    "seed": "s-2026-04-14",
+    "turn": 1,
+    "initiative_order": ["h-01", "p-02", ...],
+    "active_unit_id": "h-01",
+    "units": [...],
+    "log": []
+  }
+}
+```
+
+Il `result` è un `CombatState` conforme a `combat.schema.json`. Il parent può serializzarlo come-è nella risposta HTTP del backend.
+
+## Action: `resolve-action`
+
+Risolve una singola action chiamando `resolver.resolve_action`.
+
+**Payload**:
+
+```json
+{
+  "state": { ... },
+  "action": { ... },
+  "seed": "s-2026-04-14",
+  "namespace": "attack"
+}
+```
+
+**Campi obbligatori**: `state` (object, CombatState), `action` (object, Action), `seed` (string).
+
+**Campo opzionale**: `namespace` *(string, default `"attack"`)*. Il worker costruisce `rng = namespaced_rng(seed, namespace)` prima di chiamare il resolver. Usare namespace diversi (`"attack"`, `"parry"`, `"ability"`, ecc.) su seed uguali per ottenere stream RNG indipendenti. Vedi [determinism.md](determinism.md).
+
+**Response success**:
+
+```json
+{
+  "type": "response",
+  "id": "req-043",
+  "status": "ok",
+  "result": {
+    "next_state": { ... },
+    "turn_log_entry": { ... }
+  }
+}
+```
+
+Il parent tipicamente:
+
+1. Sostituisce il `CombatState` corrente con `result.next_state`.
+2. Appende `result.turn_log_entry` a `state.log`.
+3. Serializza lo state aggiornato nella risposta HTTP.
+
+## Action: `shutdown`
+
+Chiude il worker in modo pulito.
+
+**Payload**: `{}` (vuoto).
+
+**Response success**:
+
+```json
+{
+  "type": "response",
+  "id": "req-044",
+  "status": "ok",
+  "result": {"message": "shutdown"}
+}
+```
+
+Dopo aver inviato la response, il worker esce dal read loop, chiude il heartbeat thread e termina con exit code 0.
+
+**Nota**: il parent può anche chiudere stdin per forzare il termine. Il shutdown esplicito è preferibile perché permette la conferma round-trip.
+
+## Response format unificato
+
+Ogni response ha questa shape (`$defs` interno al worker, non formalizzato in JSON schema):
+
+```json
+{
+  "type": "response",
+  "id": <same as request.id, or null for parse errors>,
+  "status": "ok" | "error",
+  "result": <any> | null,
+  "error": <string>,
+  "code": <error code>
+}
+```
+
+- Se `status == "ok"`: il campo `result` contiene il payload della risposta, `error` e `code` sono assenti.
+- Se `status == "error"`: il campo `error` contiene un messaggio umano, `code` uno dei codici standard, `result` è assente.
+
+## Error codes
+
+| Code | Significato | Quando |
+|---|---|---|
+| `RULES_ERROR` | Errore gestito (validazione payload, action mancante, trait_mechanics non trovato, ecc.) | `RulesWorkerError` sollevato esplicitamente nel worker |
+| `UNEXPECTED_ERROR` | Eccezione non gestita (bug nel resolver, ValueError inatteso, ecc.) | `Exception` catturata dal wrapper `_handle_request` |
+| `INVALID_MESSAGE` | Riga stdin non è JSON valido | `json.JSONDecodeError` durante il parse |
+
+Per `UNEXPECTED_ERROR` il worker stampa anche un traceback su **stderr** (non stdout) per debugging, ma non in response.
+
+## Pattern di utilizzo dal backend Node
+
+Esempio schematico di un client Node per questo protocollo:
+
+```js
+const { spawn } = require('node:child_process');
+
+class RulesWorkerClient {
+  constructor() {
+    this.pending = new Map(); // id -> { resolve, reject }
+    this.nextId = 1;
+    this.proc = spawn('python3', ['services/rules/worker.py'], {
+      stdio: ['pipe', 'pipe', 'inherit'],
+    });
+
+    let buffer = '';
+    this.proc.stdout.on('data', (chunk) => {
+      buffer += chunk.toString('utf8');
+      let nl;
+      while ((nl = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, nl);
+        buffer = buffer.slice(nl + 1);
+        if (!line.trim()) continue;
+        this.handleMessage(JSON.parse(line));
+      }
+    });
+  }
+
+  handleMessage(msg) {
+    if (msg.type === 'ready') {
+      this.readyResolve();
+      return;
+    }
+    if (msg.type === 'heartbeat') {
+      this.lastHeartbeat = Date.now();
+      return;
+    }
+    if (msg.type === 'response') {
+      const pending = this.pending.get(msg.id);
+      if (!pending) return;
+      this.pending.delete(msg.id);
+      if (msg.status === 'ok') pending.resolve(msg.result);
+      else pending.reject(new Error(`${msg.code}: ${msg.error}`));
+    }
+  }
+
+  request(action, payload) {
+    const id = `req-${this.nextId++}`;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.proc.stdin.write(JSON.stringify({ id, action, payload }) + '\n');
+    });
+  }
+
+  async hydrate(encounter, party, seed, sessionId) {
+    return this.request('hydrate-encounter', {
+      encounter, party, seed, session_id: sessionId,
+    });
+  }
+
+  async resolve(state, action, seed, namespace = 'attack') {
+    return this.request('resolve-action', { state, action, seed, namespace });
+  }
+
+  async shutdown() {
+    return this.request('shutdown', {});
+  }
+}
+```
+
+**Considerazioni pratiche**:
+
+- **Una singola istanza persistente** per processo backend è preferibile. Lo spawn ogni request è costoso (~200ms per il catalog load).
+- **Pool di worker**: se il backend deve gestire richieste concorrenti, considera un pool di N worker. Il pattern è identico a `config/orchestrator.json` per il flow worker.
+- **Timeout**: applica un timeout lato Node per ogni request (es. 5s per `resolve-action`, 10s per `hydrate-encounter`). Un worker hung va killato e sostituito.
+- **Heartbeat watchdog**: se `Date.now() - this.lastHeartbeat > 3 * HEARTBEAT_INTERVAL_MS`, considera il worker dead e killalo.
+- **stderr**: il worker scrive traceback su stderr per errori inattesi. In produzione, cattura e log (es. via Winston) per postmortem.
+
+## Configurazione via environment
+
+Il worker legge due variabili d'ambiente:
+
+- `RULES_TRAIT_MECHANICS_PATH` *(opzionale)*: override del path di `trait_mechanics.yaml`. Utile per test isolati con una versione custom del catalog.
+- `RULES_WORKER_HEARTBEAT_INTERVAL_MS` *(opzionale, default 5000, minimo 1000)*: intervallo heartbeat.
+
+## Debugging
+
+**Smoke test manuale** (copia-incolla in shell):
+
+```bash
+echo '{"id": "test-1", "action": "hydrate-encounter", "payload": {"encounter": {"hostile": []}, "party": [], "seed": "s1", "session_id": "sess-1"}}' | \
+  PYTHONPATH=. python3 services/rules/worker.py
+```
+
+Dovresti vedere:
+
+1. `{"type": "ready", "pid": <PID>}` immediatamente
+2. `{"type": "response", "id": "test-1", "status": "ok", "result": {...}}` dopo il parse
+3. Il processo resta in attesa di ulteriori input. Usa Ctrl+D per chiudere stdin o manda un messaggio shutdown.
+
+## Riferimenti
+
+- Codice: `services/rules/worker.py`
+- Protocollo analogo (flow): `services/generation/worker.py`
+- Deterministic RNG: [determinism.md](determinism.md)
+- Resolver API che il worker invoca: [resolver-api.md](resolver-api.md)
+- Schema dei payload: `packages/contracts/schemas/combat.schema.json`

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -1519,6 +1519,19 @@
       "track": "authored"
     },
     {
+      "path": "docs/combat/determinism.md",
+      "title": "Determinism and RNG Namespacing",
+      "doc_status": "active",
+      "doc_owner": "combat-team",
+      "workstream": "combat",
+      "last_verified": "2026-04-14",
+      "source_of_truth": false,
+      "language": "it-en",
+      "review_cycle_days": 14,
+      "primary": false,
+      "track": "authored"
+    },
+    {
       "path": "docs/combat/resolver-api.md",
       "title": "Resolver API Reference",
       "doc_status": "active",
@@ -1545,8 +1558,34 @@
       "track": "authored"
     },
     {
+      "path": "docs/combat/testing.md",
+      "title": "Combat Testing Guide",
+      "doc_status": "active",
+      "doc_owner": "combat-team",
+      "workstream": "combat",
+      "last_verified": "2026-04-14",
+      "source_of_truth": false,
+      "language": "it-en",
+      "review_cycle_days": 14,
+      "primary": false,
+      "track": "authored"
+    },
+    {
       "path": "docs/combat/trait-mechanics-guide.md",
       "title": "Trait Mechanics Guide",
+      "doc_status": "active",
+      "doc_owner": "combat-team",
+      "workstream": "combat",
+      "last_verified": "2026-04-14",
+      "source_of_truth": false,
+      "language": "it-en",
+      "review_cycle_days": 14,
+      "primary": false,
+      "track": "authored"
+    },
+    {
+      "path": "docs/combat/worker-bridge.md",
+      "title": "Worker Bridge — Node to Python protocol",
       "doc_status": "active",
       "doc_owner": "combat-team",
       "workstream": "combat",


### PR DESCRIPTION
## Summary

Final PR of the 3-part combat workstream documentation expansion. Covers integration topics for Node ↔ Python communication, RNG determinism, and testing infrastructure.

## Files

| File | Lines | Purpose |
|---|---|---|
| `docs/combat/worker-bridge.md` | ~270 | JSON-line stdin/stdout protocol, lifecycle (ready/heartbeat/response/shutdown), error codes, request/response formats for `hydrate-encounter`/`resolve-action`/`shutdown`, pattern Node client with ~40 LOC example, configuration via env, smoke test |
| `docs/combat/determinism.md` | ~170 | `namespaced_rng(seed, namespace)` contract, properties, why separate from generation RNG, how to replay a combat, fresh-per-request caveat, formal determinism guarantees, checklist for resolver changes |
| `docs/combat/testing.md` | ~330 | Test inventory (64 resolver + 18 hydration + 45 contract Node), pytest/node --test commands, factory patterns (`_make_state`, `_make_catalog`, `_fixed_rng`), how to write tests for new status/trait/contract, snapshot update procedure, best practices |

Total: ~770 insertions.

## Coverage completion

With PR B1 (foundation) + B2 (extension guides) + this PR (integration), the combat workstream now has:

| Doc | Audience |
|---|---|
| `docs/hubs/combat.md` | Entry point (rewritten in B1) |
| `docs/combat/README.md` | Overview + navigation map |
| `docs/combat/resolver-api.md` | Developers who need to call/extend the resolver |
| `docs/combat/data-flow.md` | Developers who need to understand the pipeline |
| `docs/combat/trait-mechanics-guide.md` | Designers / Balancers |
| `docs/combat/status-effects-guide.md` | Developers adding status effects |
| `docs/combat/action-types-guide.md` | Developers adding action types / PT spend |
| `docs/combat/worker-bridge.md` | Backend Node engineers |
| `docs/combat/determinism.md` | Anyone debugging replays |
| `docs/combat/testing.md` | Contributors writing tests |

**10 docs total**, combat workstream grew from 1 → 10 entries in the registry.

## Verification

- [x] `check_docs_governance.py --strict` → 0 errors
- [x] `docs:lint` → all internal links valid (including cross-references between the 10 combat docs)
- [x] `pytest tests/test_docs_governance_migrator.py` → 41 passed
- [x] Combat workstream registry count: was 1 → now 10 ✅

## 03A Rollback

`git revert <sha>`. Pure docs, no code or config changes.

## Task B complete — what's next

With task B done, the outstanding candidates from the original list are:

- **C** — Tests for `check_docs_governance.py` (tooling test gap)
- **D** — Doc status promotion (369 draft → active)
- **E** — Simplify `docs/incoming/README.md` (stale TKT refs)
- **G** — Game ↔ Game-Database integration (new candidate from exploration, architectural discussion needed first)
- **Z** — Investigate `tests/api/biome-generation.test.js` runner teardown hang (carry-over from MongoDB PR #1317)

🤖 Generated with [Claude Code](https://claude.com/claude-code)