### PR TITLE
fix(tests): close orchestrator after API tests to eliminate 45s teardown hang

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -804,7 +804,13 @@ function createApp(options = {}) {
   app.get('/api/v1/catalog/pools', sendCatalogPools);
   app.get('/api/catalog/pools', sendCatalogPools);
 
-  return { app, repo };
+  async function close() {
+    if (generationOrchestrator && typeof generationOrchestrator.close === 'function') {
+      await generationOrchestrator.close();
+    }
+  }
+
+  return { app, repo, generationOrchestrator, close };
 }
 
 module.exports = { createApp };

--- a/tests/api/biome-generation.test.js
+++ b/tests/api/biome-generation.test.js
@@ -6,14 +6,25 @@ const { createApp } = require('../../apps/backend/app');
 
 const REQUIRED_ROLES = ['apex', 'keystone', 'threat'];
 
+let appHandle = null;
+
 function hasRole(species, role) {
   if (!species?.flags) return false;
   return Boolean(species.flags[role]);
 }
 
+test.after(async () => {
+  if (appHandle && typeof appHandle.close === 'function') {
+    await appHandle.close();
+    appHandle = null;
+  }
+});
+
 test('POST /api/v1/generation/biomes produce biomi sintetici coerenti con i vincoli', async () => {
   const dataRoot = path.resolve(__dirname, '..', '..', 'data');
-  const { app } = createApp({ dataRoot });
+  const handle = createApp({ dataRoot });
+  appHandle = handle;
+  const { app } = handle;
 
   const response = await request(app)
     .post('/api/v1/generation/biomes')

--- a/tests/api/idea-engine.test.js
+++ b/tests/api/idea-engine.test.js
@@ -13,7 +13,11 @@ function createTempDbPath() {
 
 test('POST /api/ideas salva nel database e genera il report Codex', async (t) => {
   const databasePath = createTempDbPath();
-  const { app, repo } = createApp({ databasePath });
+  const handle = createApp({ databasePath });
+  const { app, repo } = handle;
+  t.after(async () => {
+    if (typeof handle.close === 'function') await handle.close();
+  });
   await repo.ready;
   t.after(() => {
     // nedb non richiede chiusura esplicita
@@ -61,7 +65,11 @@ test('POST /api/ideas salva nel database e genera il report Codex', async (t) =>
 
 test('POST /api/ideas/:id/feedback registra il commento e aggiorna il report', async (t) => {
   const databasePath = createTempDbPath();
-  const { app, repo } = createApp({ databasePath });
+  const handle = createApp({ databasePath });
+  const { app, repo } = handle;
+  t.after(async () => {
+    if (typeof handle.close === 'function') await handle.close();
+  });
   await repo.ready;
   t.after(() => {
     // no-op
@@ -105,7 +113,11 @@ test('POST /api/ideas/:id/feedback registra il commento e aggiorna il report', a
 
 test('GET /api/ideas/:id/report restituisce il report salvato', async (t) => {
   const databasePath = createTempDbPath();
-  const { app, repo } = createApp({ databasePath });
+  const handle = createApp({ databasePath });
+  const { app, repo } = handle;
+  t.after(async () => {
+    if (typeof handle.close === 'function') await handle.close();
+  });
   await repo.ready;
   t.after(() => {
     // no-op
@@ -129,7 +141,11 @@ test('GET /api/ideas/:id/report restituisce il report salvato', async (t) => {
 
 test('POST /api/ideas valida i campi obbligatori', async (t) => {
   const databasePath = createTempDbPath();
-  const { app, repo } = createApp({ databasePath });
+  const handle = createApp({ databasePath });
+  const { app, repo } = handle;
+  t.after(async () => {
+    if (typeof handle.close === 'function') await handle.close();
+  });
   await repo.ready;
   t.after(() => {
     // no-op
@@ -142,7 +158,11 @@ test('POST /api/ideas valida i campi obbligatori', async (t) => {
 
 test('POST /api/ideas rifiuta categorie non in tassonomia', async (t) => {
   const databasePath = createTempDbPath();
-  const { app, repo } = createApp({ databasePath });
+  const handle = createApp({ databasePath });
+  const { app, repo } = handle;
+  t.after(async () => {
+    if (typeof handle.close === 'function') await handle.close();
+  });
   await repo.ready;
   t.after(() => {
     // no-op
@@ -162,7 +182,11 @@ test('POST /api/ideas rifiuta categorie non in tassonomia', async (t) => {
 
 test('POST /api/ideas rifiuta slug non catalogati senza override', async (t) => {
   const databasePath = createTempDbPath();
-  const { app, repo } = createApp({ databasePath });
+  const handle = createApp({ databasePath });
+  const { app, repo } = handle;
+  t.after(async () => {
+    if (typeof handle.close === 'function') await handle.close();
+  });
   await repo.ready;
   t.after(() => {
     // no-op
@@ -185,7 +209,11 @@ test('POST /api/ideas rifiuta slug non catalogati senza override', async (t) => 
 
 test('POST /api/ideas accetta slug non catalogati con override', async (t) => {
   const databasePath = createTempDbPath();
-  const { app, repo } = createApp({ databasePath });
+  const handle = createApp({ databasePath });
+  const { app, repo } = handle;
+  t.after(async () => {
+    if (typeof handle.close === 'function') await handle.close();
+  });
   await repo.ready;
   t.after(() => {
     // no-op

--- a/tests/api/quality-release.test.js
+++ b/tests/api/quality-release.test.js
@@ -4,6 +4,23 @@ const request = require('supertest');
 
 const { createApp } = require('../../apps/backend/app');
 
+const appHandles = [];
+
+test.after(async () => {
+  while (appHandles.length) {
+    const handle = appHandles.pop();
+    if (handle && typeof handle.close === 'function') {
+      await handle.close();
+    }
+  }
+});
+
+function makeApp(options) {
+  const handle = createApp(options);
+  appHandles.push(handle);
+  return handle;
+}
+
 const speciesEntry = {
   id: 'spec-runtime-node',
   display_name: 'Predatore Nodo QA',
@@ -16,7 +33,7 @@ const speciesEntry = {
 };
 
 test('POST /api/v1/quality/suggestions/apply esegue fix specie via runtime validator', async () => {
-  const { app } = createApp();
+  const { app } = makeApp();
 
   const response = await request(app)
     .post('/api/v1/quality/suggestions/apply')
@@ -43,7 +60,7 @@ test('POST /api/v1/quality/suggestions/apply esegue fix specie via runtime valid
 });
 
 test('POST /api/v1/quality/suggestions/apply rigenera batch tramite orchestrator', async () => {
-  const { app } = createApp();
+  const { app } = makeApp();
 
   const response = await request(app)
     .post('/api/v1/quality/suggestions/apply')

--- a/tests/api/species-generation.test.js
+++ b/tests/api/species-generation.test.js
@@ -4,8 +4,25 @@ const request = require('supertest');
 
 const { createApp } = require('../../apps/backend/app');
 
+const appHandles = [];
+
+test.after(async () => {
+  while (appHandles.length) {
+    const handle = appHandles.pop();
+    if (handle && typeof handle.close === 'function') {
+      await handle.close();
+    }
+  }
+});
+
+function makeApp(options) {
+  const handle = createApp(options);
+  appHandles.push(handle);
+  return handle;
+}
+
 test('POST /api/v1/generation/species restituisce blueprint validato', async () => {
-  const { app } = createApp();
+  const { app } = makeApp();
 
   const response = await request(app)
     .post('/api/v1/generation/species')
@@ -29,7 +46,7 @@ test('POST /api/v1/generation/species restituisce blueprint validato', async () 
 });
 
 test('POST /api/v1/generation/species ritorna 400 senza trait', async () => {
-  const { app } = createApp();
+  const { app } = makeApp();
 
   const response = await request(app)
     .post('/api/v1/generation/species')

--- a/tests/api/traits.auth.test.js
+++ b/tests/api/traits.auth.test.js
@@ -14,8 +14,19 @@ function createToken(roles) {
   return signJwt({ sub: 'test-user', roles }, AUTH_SECRET, { expiresIn: '1h' });
 }
 
+const appHandles = [];
+
+test.after(async () => {
+  while (appHandles.length) {
+    const handle = appHandles.pop();
+    if (handle && typeof handle.close === 'function') {
+      await handle.close();
+    }
+  }
+});
+
 function createAppWithOptions(options = {}) {
-  const { app } = createApp({
+  const handle = createApp({
     traits: {
       auth: {
         secret: AUTH_SECRET,
@@ -24,7 +35,8 @@ function createAppWithOptions(options = {}) {
       ...(options.traits || {}),
     },
   });
-  return app;
+  appHandles.push(handle);
+  return handle.app;
 }
 
 test('POST /api/traits/validate richiede un token JWT', async () => {

--- a/tests/api/traits.validate.test.js
+++ b/tests/api/traits.validate.test.js
@@ -7,6 +7,17 @@ const request = require('supertest');
 const { createApp } = require('../../apps/backend/app');
 const { signJwt } = require('../../apps/backend/utils/jwt');
 
+const appHandles = [];
+
+test.after(async () => {
+  while (appHandles.length) {
+    const handle = appHandles.pop();
+    if (handle && typeof handle.close === 'function') {
+      await handle.close();
+    }
+  }
+});
+
 const SAMPLE_TRAIT = path.resolve(
   __dirname,
   '..',
@@ -24,14 +35,15 @@ function buildAuthToken(roles) {
 }
 
 function createAuthenticatedApp() {
-  const { app } = createApp({
+  const handle = createApp({
     traits: {
       auth: {
         secret: AUTH_SECRET,
       },
     },
   });
-  return app;
+  appHandles.push(handle);
+  return handle.app;
 }
 
 test('POST /api/traits/validate restituisce suggerimenti stile', async () => {


### PR DESCRIPTION
## Summary

Fixes the long-standing test runner teardown hang on \`tests/api/biome-generation.test.js\` and 4 other API test files. Root cause was that \`createApp()\` never exposed the generation orchestrator, so tests had no way to close the Python worker pool — keeping Node's event loop alive for ~44s after the test body completed.

## Root cause

\`createApp()\` in \`apps/backend/app.js\` instantiates a \`generationOrchestrator\` via \`createGenerationOrchestratorBridge\`, which spawns a Python worker pool (\`services/generation/worker.py\`). The pool stays alive until:
1. Explicit \`.close()\` call (never happened in tests)
2. \`ORCHESTRATOR_AUTOCLOSE_MS\` idle timeout (default 2000ms, still not enough to free Node's event loop because Python child process stdin/stdout keep it referenced)

Result: the test **assertion** passes in <1s but the **runner** hangs for ~44s waiting for active handles to close.

## Fix

### 1. Expose close() from createApp

\`apps/backend/app.js\` now returns:

\`\`\`js
return { app, repo, generationOrchestrator, close };
\`\`\`

Backwards-compatible: existing destructuring \`{ app, repo } = createApp(...)\` continues to work.

### 2. Add test.after() hooks to API tests

Each test file that calls \`createApp()\` with a real orchestrator now tracks created handles in an \`appHandles[]\` array and closes them in a \`test.after()\` hook.

## Results

| File | Before | After |
|---|---|---|
| \`biome-generation.test.js\` | **45s hang** | **1.2s pass** (1/1) |
| \`traits.auth.test.js\` | unclear | **0.7s pass** (3/3) |
| \`traits.validate.test.js\` | **20s hang** | **543ms pass** (2/2) |
| \`idea-engine.test.js\` | empty pass/fail | **876ms pass** (7/7) |
| \`trait-diagnostics.test.js\` | already working | **332ms pass** (1/1) |

Contract test files (no change needed — they don't use real orchestrator):
- \`contracts-combat.test.js\` (23/23), \`contracts-hydration-snapshot.test.js\` (7/7), \`contracts-trait-mechanics.test.js\` (15/15)

**Total green: 59 API tests passing in <5s vs prior 45s+ hang per file.**

## Known NOT fixed (separate investigation needed)

These files still hang for **deeper reasons unrelated to teardown**:

- **\`species-generation.test.js\`**: the test body itself hangs. The Python worker pool doesn't respond to generation requests. Likely pre-existing, possibly related to the recent MongoDB removal affecting the catalog → orchestrator data flow. Needs investigation.
- **\`quality-release.test.js\`**: supertest assertion failure on the response body (functional issue, not teardown). The test expects a specific response format that the backend doesn't produce. Likely a regression from MongoDB removal or the catalog path fix.

Both files **still received the close() hook** as preventive hygiene — the hook is harmless if the orchestrator is already stuck, and will clean up properly once the deeper issues are fixed.

## 03A Rollback

\`git revert <sha>\`. The only app.js change is the expanded return shape (backwards-compatible); tests can be reverted individually.

## Test plan

- [x] \`biome-generation\`, \`traits.auth\`, \`traits.validate\`, \`idea-engine\`, \`trait-diagnostics\` all pass fast
- [x] Contract tests unchanged (still pass)
- [x] \`apps/backend/app.js\` change is minimal (4 added lines for close(), 1 changed return line)
- [ ] \`species-generation\` / \`quality-release\` hang issues remain (flagged as follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)