### PR TITLE
fix(python): platform-aware default Python executable (fixes quality-release + species-generation tests)

### DIFF
--- a/apps/backend/services/orchestratorBridge.js
+++ b/apps/backend/services/orchestratorBridge.js
@@ -6,8 +6,12 @@ const readline = require('node:readline');
 
 const { createOrchestratorMetrics } = require('./orchestratorMetrics');
 
+// On Windows, 'python3' is typically the Windows Store stub without packages.
+// On Linux/macOS, 'python3' is the canonical entry point.
+const DEFAULT_PYTHON = process.platform === 'win32' ? 'python' : 'python3';
+
 const DEFAULT_CONFIG = {
-  pythonPath: process.env.PYTHON || 'python3',
+  pythonPath: process.env.PYTHON || DEFAULT_PYTHON,
   poolSize: 2,
   requestTimeoutMs: 120_000,
   heartbeatIntervalMs: 5_000,

--- a/apps/dashboard/tests/GenerationFlow.spec.ts
+++ b/apps/dashboard/tests/GenerationFlow.spec.ts
@@ -19,7 +19,8 @@ function orchestrateSpecies() {
     base_name: 'Predatore Snapshot',
     biome_id: 'caverna_risonante',
   };
-  const pythonExecutable = process.env.PYTHON || 'python3';
+  const pythonExecutable =
+    process.env.PYTHON || (process.platform === 'win32' ? 'python' : 'python3');
   const result = spawnSync(pythonExecutable, [scriptPath, '--action', 'generate-species'], {
     cwd: repoRoot,
     input: JSON.stringify(payload),
@@ -51,7 +52,8 @@ function orchestrateSpeciesBatch() {
       },
     ],
   };
-  const pythonExecutable = process.env.PYTHON || 'python3';
+  const pythonExecutable =
+    process.env.PYTHON || (process.platform === 'win32' ? 'python' : 'python3');
   const result = spawnSync(pythonExecutable, [scriptPath, '--action', 'generate-species-batch'], {
     cwd: repoRoot,
     input: JSON.stringify(payload),

--- a/services/generation/runtimeValidator.js
+++ b/services/generation/runtimeValidator.js
@@ -11,6 +11,11 @@ const DEFAULT_SCRIPT_PATH = path.resolve(
   'runtime_api.py',
 );
 
+// On Windows, 'python3' is typically the Windows Store stub without any
+// third-party packages. The real CPython installation is exposed as 'python'.
+// On Linux/macOS, 'python3' is the canonical entry point.
+const DEFAULT_PYTHON = process.platform === 'win32' ? 'python' : 'python3';
+
 function invokePython(scriptPath, pythonExecutable, args, payload) {
   return new Promise((resolve, reject) => {
     const proc = spawn(pythonExecutable, [scriptPath, ...args], {
@@ -45,7 +50,7 @@ function invokePython(scriptPath, pythonExecutable, args, payload) {
 }
 
 function createRuntimeValidator(options = {}) {
-  const pythonExecutable = options.pythonPath || process.env.PYTHON || 'python3';
+  const pythonExecutable = options.pythonPath || process.env.PYTHON || DEFAULT_PYTHON;
   const scriptPath = options.scriptPath || DEFAULT_SCRIPT_PATH;
 
   async function validateSpeciesBatch(entries, context = {}) {


### PR DESCRIPTION
## Summary

Fix cross-platform bug in Python subprocess defaults. On Windows, \`python3\` is a Windows Store stub (execution alias) that cannot import any packages. Routing subprocess Python calls to it caused \`ModuleNotFoundError: No module named 'yaml'\` → 500 Internal Server Error from every API route that spawned the runtime validator or orchestrator worker pool.

This is a **pre-existing bug**, not a regression — it had been masking as a test hang/failure for species-generation and quality-release since the tests were first written. PR #1324's teardown fix revealed the actual error by making the test fail cleanly instead of timing out.

## Changes

Introduce a platform-aware default:

\`\`\`js
const DEFAULT_PYTHON = process.platform === 'win32' ? 'python' : 'python3';
const pythonExecutable = options.pythonPath || process.env.PYTHON || DEFAULT_PYTHON;
\`\`\`

The \`PYTHON\` env var override is still honored first, so CI and developers can force a specific interpreter (e.g. \`python3.11\`) without platform guessing.

**Files touched:**

- \`services/generation/runtimeValidator.js\` — runtime validator spawner
- \`apps/backend/services/orchestratorBridge.js\` — generation worker pool DEFAULT_CONFIG
- \`apps/dashboard/tests/GenerationFlow.spec.ts\` — 2 call sites in the test (preserved for consistency even though this test file is tied to the frozen dashboard scaffold)

## Results

All 10 API test files that call \`createApp()\` with real orchestrator now pass:

| File | Before | After |
|---|---|---|
| \`quality-release.test.js\` | **500 error** on apply → test fail | **2/2 pass in 628ms** |
| \`species-generation.test.js\` | **45s hang** waiting for worker | **2/2 pass in 464ms** |
| \`biome-generation.test.js\` | (fixed in PR #1324) | 1/1 pass in 1.1s |
| \`idea-engine.test.js\` | (fixed in PR #1324) | 7/7 pass in 675ms |
| \`traits.auth.test.js\` | (fixed in PR #1324) | 3/3 pass in 506ms |
| \`traits.validate.test.js\` | (fixed in PR #1324) | 2/2 pass in 473ms |
| \`trait-diagnostics.test.js\` | already working | 1/1 pass in 300ms |
| \`contracts-combat.test.js\` | contract only | 23/23 pass in 457ms |
| \`contracts-hydration-snapshot.test.js\` | contract only | 7/7 pass in 139ms |
| \`contracts-trait-mechanics.test.js\` | contract only | 15/15 pass in 200ms |

**Total: 63 API tests passing, 0 failing, total runtime <5s.**

## Root cause diagnosis

\`\`\`bash
\$ python3 packs/evo_tactics_pack/validators/runtime_api.py --kind species ...
ModuleNotFoundError: No module named 'yaml'

\$ python3 --version  # Windows Store stub
Python 3.14.0

\$ python --version   # Real CPython with PyYAML installed
Python 3.13.2

\$ which python3 python
/c/Users/VGit/AppData/Local/Microsoft/WindowsApps/python3  # stub
/c/Users/VGit/AppData/Local/Programs/Python/Python313/python  # real
\`\`\`

On Windows, \`python3\` typically points at the execution alias set by Microsoft Store even when the user has installed CPython via the official installer, because the Store alias sits higher in \`%PATH%\`.

## 03A Rollback

\`git revert <sha>\`. Anyone relying on \`python3\` being truly available (e.g. from a WSL or conda environment) can set \`PYTHON=python3\` explicitly to restore the previous behavior.

## Test plan

- [x] \`quality-release.test.js\` passes
- [x] \`species-generation.test.js\` passes
- [x] All other API tests still pass (regression check)
- [x] \`runtimeValidator.js\` respects \`PYTHON\` env var override
- [ ] Linux/macOS CI passes (the change preserves \`python3\` default there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)