### PR TITLE
chore(housekeeping): bundle pulizia residua (status.json race, teardown, qa-checklist, evo:import)

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -88,12 +88,26 @@ function buildSlugConfig(sectionKey, aliasKey) {
   return { canonicalSet, aliasMap };
 }
 
+function isBenignTeardownError(error) {
+  if (!error) return false;
+  const message = typeof error.message === 'string' ? error.message : String(error);
+  return /Pool terminato|worker pool closed|already closed|Worker non disponibile|worker not available/i.test(
+    message,
+  );
+}
+
 async function readJsonFile(filePath, fallback) {
   try {
     const content = await fs.readFile(filePath, 'utf8');
     return JSON.parse(content);
   } catch (error) {
     if (error && error.code === 'ENOENT') {
+      return fallback;
+    }
+    if (error instanceof SyntaxError && fallback !== undefined) {
+      console.warn(
+        `[app] JSON corrotto in ${filePath} (${error.message}); uso fallback e riscriverò al prossimo write`,
+      );
       return fallback;
     }
     throw error;
@@ -103,7 +117,14 @@ async function readJsonFile(filePath, fallback) {
 async function writeJsonFile(filePath, payload) {
   const targetDir = path.dirname(filePath);
   await fs.mkdir(targetDir, { recursive: true });
-  await fs.writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`;
+  await fs.writeFile(tmpPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  try {
+    await fs.rename(tmpPath, filePath);
+  } catch (renameError) {
+    await fs.rm(tmpPath, { force: true }).catch(() => {});
+    throw renameError;
+  }
 }
 
 function normaliseSlugList(values, config) {
@@ -322,7 +343,16 @@ function createApp(options = {}) {
     });
   const qaStatusPath = options.qaStatusPath || DEFAULT_QA_STATUS;
   const deploymentOptions = options.deployment || {};
-  const statusReportPath = deploymentOptions.statusReportPath || DEFAULT_STATUS_REPORT;
+  const statusReportExplicit = Object.prototype.hasOwnProperty.call(
+    deploymentOptions,
+    'statusReportPath',
+  );
+  const statusReportDisabledByEnv = process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH === '1';
+  const statusReportPath = statusReportDisabledByEnv
+    ? null
+    : statusReportExplicit
+      ? deploymentOptions.statusReportPath
+      : DEFAULT_STATUS_REPORT;
   const deploymentNotifier = deploymentOptions.notifier;
   const app = express();
 
@@ -339,6 +369,7 @@ function createApp(options = {}) {
   }
 
   traitDiagnosticsSync.load().catch((error) => {
+    if (isBenignTeardownError(error)) return;
     console.warn('[trait-diagnostics] preload fallito', error);
   });
 
@@ -549,6 +580,12 @@ function createApp(options = {}) {
   });
 
   async function refreshStatusReport(baseStatus) {
+    if (!statusReportPath) {
+      if (releaseReporter && typeof releaseReporter.buildReport === 'function') {
+        return releaseReporter.buildReport(baseStatus || { deployments: [], updatedAt: null });
+      }
+      return baseStatus || { deployments: [], updatedAt: null };
+    }
     const existing =
       baseStatus || (await readJsonFile(statusReportPath, { deployments: [], updatedAt: null }));
     if (releaseReporter && typeof releaseReporter.buildReport === 'function') {
@@ -560,9 +597,12 @@ function createApp(options = {}) {
     return existing;
   }
 
-  refreshStatusReport().catch((error) => {
-    console.warn('[release-reporter] preload fallito', error);
-  });
+  if (statusReportPath) {
+    refreshStatusReport().catch((error) => {
+      if (isBenignTeardownError(error)) return;
+      console.warn('[release-reporter] preload fallito', error);
+    });
+  }
 
   app.get('/api/health', (req, res) => {
     res.json({ status: 'ok', service: 'idea-engine' });

--- a/docs/adr/ADR-2026-04-14-dashboard-scaffold-vs-mission-console.md
+++ b/docs/adr/ADR-2026-04-14-dashboard-scaffold-vs-mission-console.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-2026-04-14: Dashboard scaffold vs Mission Console bundle dichotomy"
+title: 'ADR-2026-04-14: Dashboard scaffold vs Mission Console bundle dichotomy'
 doc_status: active
 doc_owner: platform-docs
 workstream: cross-cutting
@@ -140,7 +140,7 @@ Questo ADR + fix di 1 test orfano (`tests/vfx/dynamicShader.spec.ts`) + aggiorna
 1. **Verificare se i Vitest di `apps/dashboard/` passano**. Se sì, tenerli. Se no, valutare se cancellarli o sistemarli.
 2. ~~**Audit dei `packages/angular*` stub**~~ — **completato 2026-04-14**, vedi sezione "Audit follow-up" sotto.
 3. **Prendere una decisione strategica** tra archival completo (alternativa A) e rebuild (alternativa C) quando ci sarà bandwidth e contesto di business.
-4. **Unificare `apps/dashboard/tests/manual/qa-checklist.md`** con la documentazione QA canonica in `docs/qa/` (referenzia `apps/dashboard/` ma è una checklist statica che può vivere altrove).
+4. ~~**Unificare `apps/dashboard/tests/manual/qa-checklist.md`**~~ — **completato 2026-04-14**, spostato in [`docs/qa/nebula-webapp-checklist.md`](../qa/nebula-webapp-checklist.md) con frontmatter governance + entry in `docs_registry.json`.
 
 ## Audit follow-up
 
@@ -152,14 +152,14 @@ Questo ADR + fix di 1 test orfano (`tests/vfx/dynamicShader.spec.ts`) + aggiorna
 
 **Finding 1 — Consumer degli import**: 6 file importano da `angular`/`angular-*`:
 
-| File | Tipo |
-|---|---|
-| `apps/dashboard/src/main.ts` | app entry point |
-| `apps/dashboard/src/app.module.ts` | module registration |
-| `packages/angular-route/index.js` | stub (interno) |
-| `packages/angular-animate/index.js` | stub (interno) |
-| `packages/angular-sanitize/index.js` | stub (interno) |
-| `Trait Editor/src/main.ts` | **app entry point (distinto)** |
+| File                                 | Tipo                           |
+| ------------------------------------ | ------------------------------ |
+| `apps/dashboard/src/main.ts`         | app entry point                |
+| `apps/dashboard/src/app.module.ts`   | module registration            |
+| `packages/angular-route/index.js`    | stub (interno)                 |
+| `packages/angular-animate/index.js`  | stub (interno)                 |
+| `packages/angular-sanitize/index.js` | stub (interno)                 |
+| `Trait Editor/src/main.ts`           | **app entry point (distinto)** |
 
 **Finding 2 — Due consumer distinti con risoluzione opposta**:
 

--- a/docs/adr/ADR-2026-04-14-game-database-topology.md
+++ b/docs/adr/ADR-2026-04-14-game-database-topology.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-2026-04-14: Game ↔ Game-Database topology and integration boundary"
+title: 'ADR-2026-04-14: Game ↔ Game-Database topology and integration boundary'
 doc_status: active
 doc_owner: platform-docs
 workstream: cross-cutting
@@ -131,14 +131,14 @@ Questo ADR formalizza:
 
 ## Port allocation
 
-| Service | Port (default) | Override env | Note |
-|---|---|---|---|
-| Game backend (Express) | **3334** | `PORT` | Cambiato da 3333 in questo ADR. Legacy override: `PORT=3333` |
-| Game-Database backend (Express) | **3333** | `PORT` (side del Game-Database) | Invariato per non disturbare Codex |
-| Game dashboard (scaffold Vite) | 5173 | `PORT` di Vite | Non renderizza, vedi altro ADR |
-| Game-Database dashboard (React/Vite) | 5173 | `PORT` di Vite | **Conflitto potenziale col Game scaffold** — usare porte diverse se entrambi avviati |
-| Game Postgres (via docker-compose) | 5432 | - | Invariato |
-| Game-Database Postgres | 5432 | - | **Conflitto potenziale** — chi usa docker-compose su entrambi i repo deve scegliere porte diverse |
+| Service                              | Port (default) | Override env                    | Note                                                                                              |
+| ------------------------------------ | -------------- | ------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Game backend (Express)               | **3334**       | `PORT`                          | Cambiato da 3333 in questo ADR. Legacy override: `PORT=3333`                                      |
+| Game-Database backend (Express)      | **3333**       | `PORT` (side del Game-Database) | Invariato per non disturbare Codex                                                                |
+| Game dashboard (scaffold Vite)       | 5173           | `PORT` di Vite                  | Non renderizza, vedi altro ADR                                                                    |
+| Game-Database dashboard (React/Vite) | 5173           | `PORT` di Vite                  | **Conflitto potenziale col Game scaffold** — usare porte diverse se entrambi avviati              |
+| Game Postgres (via docker-compose)   | 5432           | -                               | Invariato                                                                                         |
+| Game-Database Postgres               | 5432           | -                               | **Conflitto potenziale** — chi usa docker-compose su entrambi i repo deve scegliere porte diverse |
 
 **Implicazioni pratiche:**
 
@@ -173,39 +173,39 @@ if (gameDatabaseEnabled) {
 
 ### Traits
 
-| Campo | In Game (local files) | In Game-Database (Prisma) |
-|---|---|---|
-| id/slug | ✅ | ✅ |
-| name / labels IT+EN | ✅ | ✅ (`name`, `description`) |
-| category | ✅ | ✅ |
-| dataType | (implicito) | ✅ (BOOLEAN/NUMERIC/CATEGORICAL/TEXT) |
-| allowedValues | ✅ | ✅ (JSON) |
-| range (min/max) | ✅ | ✅ (`rangeMin`, `rangeMax`) |
-| `environments` | ✅ | ❌ |
-| `synergies` / `conflicts` | ✅ | ❌ |
-| `energy_profile` | ✅ | ❌ |
-| `selective_drive` | ✅ | ❌ |
-| `usage_tags` | ✅ | ❌ |
-| `species_affinity` | ✅ | ❌ |
-| `completion_flags` | ✅ | ❌ |
-| `weakness` | ✅ | ❌ |
-| `mutation` | ✅ | ❌ |
+| Campo                     | In Game (local files) | In Game-Database (Prisma)             |
+| ------------------------- | --------------------- | ------------------------------------- |
+| id/slug                   | ✅                    | ✅                                    |
+| name / labels IT+EN       | ✅                    | ✅ (`name`, `description`)            |
+| category                  | ✅                    | ✅                                    |
+| dataType                  | (implicito)           | ✅ (BOOLEAN/NUMERIC/CATEGORICAL/TEXT) |
+| allowedValues             | ✅                    | ✅ (JSON)                             |
+| range (min/max)           | ✅                    | ✅ (`rangeMin`, `rangeMax`)           |
+| `environments`            | ✅                    | ❌                                    |
+| `synergies` / `conflicts` | ✅                    | ❌                                    |
+| `energy_profile`          | ✅                    | ❌                                    |
+| `selective_drive`         | ✅                    | ❌                                    |
+| `usage_tags`              | ✅                    | ❌                                    |
+| `species_affinity`        | ✅                    | ❌                                    |
+| `completion_flags`        | ✅                    | ❌                                    |
+| `weakness`                | ✅                    | ❌                                    |
+| `mutation`                | ✅                    | ❌                                    |
 
 ### Biomes
 
-| Campo | In Game (biome_pools.json) | In Game-Database (Prisma Biome) |
-|---|---|---|
-| id/slug | ✅ | ✅ |
-| name / label | ✅ | ✅ |
-| description / summary | ✅ | ✅ |
-| `climate` / `climate_tags` | ✅ | ✅ (`climate`, stringa) |
-| `parentId` (hierarchy) | ❌ | ✅ |
-| `size` (min/max) | ✅ | ❌ |
-| `hazard` (severity, description, stress_modifiers) | ✅ | ❌ |
-| `ecology` (biome_type, food_web, ecc.) | ✅ | ❌ |
-| `traits.core` + `traits.support` pool | ✅ | ❌ (indiretto via `SpeciesBiome` junction, diversa semantica) |
-| `role_templates` (role, preferred_traits, tier) | ✅ | ❌ |
-| `metadata` (schema_version, updated_at) | ✅ | ❌ (campo createdAt/updatedAt sostituisce) |
+| Campo                                              | In Game (biome_pools.json) | In Game-Database (Prisma Biome)                               |
+| -------------------------------------------------- | -------------------------- | ------------------------------------------------------------- |
+| id/slug                                            | ✅                         | ✅                                                            |
+| name / label                                       | ✅                         | ✅                                                            |
+| description / summary                              | ✅                         | ✅                                                            |
+| `climate` / `climate_tags`                         | ✅                         | ✅ (`climate`, stringa)                                       |
+| `parentId` (hierarchy)                             | ❌                         | ✅                                                            |
+| `size` (min/max)                                   | ✅                         | ❌                                                            |
+| `hazard` (severity, description, stress_modifiers) | ✅                         | ❌                                                            |
+| `ecology` (biome_type, food_web, ecc.)             | ✅                         | ❌                                                            |
+| `traits.core` + `traits.support` pool              | ✅                         | ❌ (indiretto via `SpeciesBiome` junction, diversa semantica) |
+| `role_templates` (role, preferred_traits, tier)    | ✅                         | ❌                                                            |
+| `metadata` (schema_version, updated_at)            | ✅                         | ❌ (campo createdAt/updatedAt sostituisce)                    |
 
 ### Species
 
@@ -250,6 +250,45 @@ L'import è **idempotente** (upsert by slug). Può essere rilanciato senza side 
 
 Il report finale produce contatori per: totals, normalized, complete/partial, discarded, errors per dominio. Da loggare in `logs/agent_activity.md` del Game-Database (non di Game).
 
+## Automation recommendations (evo:import)
+
+Oggi `npm run evo:import` gira **a mano** sul lato Game-Database quando l'operatore decide di sincronizzare. Per ridurre il drift tra i due repo si possono adottare uno dei tre pattern seguenti. **Nessuno è wired oggi** — questa sezione documenta le opzioni per chi in futuro implementerà l'automazione.
+
+### Pattern A — GitHub Actions `repository_dispatch` (cross-repo trigger)
+
+**Flow**: Game esegue `sync:evo-pack` in una PR di dataset. Quando la PR viene mergiata su `main`, un workflow `.github/workflows/notify-game-database.yml` firma un payload e invoca `repository_dispatch` verso `MasterDD-L34D/Game-Database`. Lato Game-Database, un workflow `on: repository_dispatch: types: [evo-catalog-updated]` lancia `npm run evo:import`, apre una PR di sync, e notifica Slack/Ops.
+
+**Pro**: disaccoppiato, audit trail completo (entrambi i repo loggano l'evento), rollback chiaro (revert del merge su Game = nessuna nuova dispatch).
+**Contro**: richiede un PAT (Personal Access Token) o GitHub App con `repo` scope + `contents:write` sul Game-Database. Configurazione iniziale dei secret non banale.
+**Effort**: Medium (2 workflow file + 1 GitHub App + documentazione onboarding).
+**Stakeholder**: Ops + Master DD.
+
+### Pattern B — Cron job Game-Database side (pull periodico)
+
+**Flow**: Game-Database lancia una GitHub Action schedulata (`cron: '0 */6 * * *'`) che fa `git clone https://github.com/MasterDD-L34D/Game` (o fetch su submodule/subtree), esegue `npm run evo:import`, e se ci sono diff apre una PR `chore(evo): sync catalog YYYY-MM-DD`.
+
+**Pro**: vive interamente dentro Game-Database, zero secret cross-repo, facile disattivazione (commenta il cron).
+**Contro**: lag di 6h worst-case, clone completo ad ogni run (spreca bandwidth), nessun trigger event-driven.
+**Effort**: Small (1 workflow file nel Game-Database).
+**Stakeholder**: Codex / Game-Database maintainer.
+
+### Pattern C — Git hook Game side (push-time validation)
+
+**Flow**: un `pre-push` hook lato Game rileva modifiche a `packs/evo_tactics_pack/docs/catalog/**` e, se presenti, esegue `evo:import --dry-run` puntando a un clone locale del Game-Database. Il hook blocca il push se il dry-run segnala error/dropped records > 0.
+
+**Pro**: feedback immediato allo sviluppatore, impedisce push di catalog rotti.
+**Contro**: richiede Game-Database clonato localmente e path env var configurato; hook bypassabile con `--no-verify`; nessun aggiornamento automatico del Game-Database remoto (solo gate).
+**Effort**: Very Small (1 file in `.husky/` + doc).
+**Stakeholder**: Master DD (decide se gate).
+
+### Raccomandazione
+
+**Pattern B** è il candidato naturale per un primo deploy: zero secret cross-repo, nessun impatto sul Game workflow, e già oggi c'è GitHub Actions sul Game-Database (cron di tracker refresh). La PR generata è review-able a valle e offre un ponte naturale verso Pattern A quando ci sarà una GitHub App condivisa.
+
+**Pattern C** può essere aggiunto in parallelo come safety net a costo quasi-zero. Pattern A resta il target di lungo periodo per event-driven sync ma richiede lavoro di setup che oggi non ha ROI.
+
+Nessun pattern viene wired in questa ADR. Il naming `evo:import` è riservato al comando in Game-Database e non cambia con l'automazione scelta.
+
 ## Alternative considerate
 
 ### Alternativa A (scelta) — Documentazione + port fix + env var stub
@@ -263,6 +302,7 @@ Implementare in `apps/backend/services/catalog.js` un branch che, se `GAME_DATAB
 **Pro**: dà un valore immediato (il dashboard di Game-Database può editare i label IT/EN di un trait e il Game backend li vede senza restart, a condizione che il cache venga invalidato).
 
 **Contro**:
+
 - Richiede progettazione di cache/retry/timeout/circuit-breaker
 - Richiede ~20-30 aggiornamenti di test esistenti (mock HTTP, snapshot)
 - Copre solo il trait glossary (labels), non i biome_pools né il trait catalog ricco
@@ -278,6 +318,7 @@ Estendere il Prisma schema di Game-Database per includere biome_pools ricchi, tr
 **Pro**: soluzione architetturalmente pulita, single source of truth per dati taxonomy.
 
 **Contro**:
+
 - Richiede PR cross-repo
 - Coordinamento settimanale con Codex che sta iterando su Game-Database
 - Settimane di lavoro (schema design + migration + ingest update + Game client + test)

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -5185,6 +5185,19 @@
       "track": "migrated"
     },
     {
+      "path": "docs/qa/nebula-webapp-checklist.md",
+      "title": "Checklist QA Nebula Webapp",
+      "doc_status": "draft",
+      "doc_owner": "ops-qa-team",
+      "workstream": "ops-qa",
+      "last_verified": "2026-04-14",
+      "source_of_truth": false,
+      "language": "it",
+      "review_cycle_days": 14,
+      "primary": false,
+      "track": "migrated"
+    },
+    {
       "path": "docs/qa/rollout_checklist.md",
       "title": "Checklist QA — Rollout Mission Control",
       "doc_status": "draft",

--- a/docs/qa/nebula-webapp-checklist.md
+++ b/docs/qa/nebula-webapp-checklist.md
@@ -1,3 +1,14 @@
+---
+title: Checklist QA Nebula Webapp
+doc_status: draft
+doc_owner: ops-qa-team
+workstream: ops-qa
+last_verified: 2026-04-14
+source_of_truth: false
+language: it
+review_cycle_days: 14
+---
+
 # Checklist QA Nebula Webapp
 
 Questa checklist è pensata per la verifica manuale della webapp in tre scenari operativi:

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-13T23:57:29+00:00",
+  "generated_at": "2026-04-14T15:51:11+00:00",
   "summary": {
     "total": 0,
     "errors": 0,

--- a/reports/qa-changelog.md
+++ b/reports/qa-changelog.md
@@ -1,38 +1,22 @@
----
-title: QA export changelog
-doc_status: generated
-doc_owner: platform-docs
-workstream: cross-cutting
-last_verified: 2026-04-14
-source_of_truth: false
-language: it-en
-review_cycle_days: 14
----
 # QA export changelog
 
-Generato: 2025-12-09T20:02:28.734099Z
+Generato: 2026-04-14T19:23:03.693761Z
+Baseline precedente: 2025-12-09T20:02:28.734099Z
 
 ## Metriche baseline
-- Tratti totali: 254 (+254 vs precedente)
-- Glossario OK: 254 (+254 vs precedente)
+- Tratti totali: 254 (0 vs precedente)
+- Glossario OK: 254 (0 vs precedente)
 - Glossario mancanti: 0 (0 vs precedente)
-- Mismatch matrice: 79 (+79 vs precedente)
-- Tratti con conflitti: 34 (+34 vs precedente)
+- Mismatch matrice: 76 (-3 vs precedente)
+- Tratti con conflitti: 34 (0 vs precedente)
 
 ### tratti con mismatch matrice
-- Nuovi:
-  - ali_fono_risonanti, articolazioni_a_leva_idraulica, articolazioni_multiassiali, artigli_ipo_termici, artiglio_cinetico_a_urto, aura_di_dispersione_mentale, bioantenne_gravitiche, bozzolo_magnetico, camere_risonanza_abyssal, campo_di_interferenza_acustica, cannone_sonico_a_raggio, canto_infrasonico_tattico, canto_risonante, cervello_a_bassa_latenza, cinghia_iper_ciliare, cisti_di_ibernazione_minerale, coda_prensile_muscolare, comunicazione_fotonica_coda_coda, coralli_sinaptici_fotofase, corazze_ferro_magnetico
-  - … (59 ulteriori)
-
-### tratti presenti solo nel matrix
-- Nuovi:
-  - Strategist, adattamento_volo, architetto, artigli_psionici, assenza_respirazione, campo_di_fase, ciclo_vitale_anomalo, ciclo_vitale_completo, corteccia_memetica, eco_sismico, filtri_bioattivi, fisiologia_predatoria, fotosintesi_bifase, ghiandole_nettare_memetico, intangibilita_parziale, lamenti_diradanti, maschera_illusoria, matrice_antimagia, membrane_osmotiche, metabolismo_attivo
-  - … (24 ulteriori)
+- Risolti:
+  - cannone_sonico_a_raggio, ipertrofia_muscolare_massiva, pelage_idrorepellente_avanzato
 
 ### tratti senza copertura QA
-- Nuovi:
-  - ali_fono_risonanti, articolazioni_a_leva_idraulica, articolazioni_multiassiali, artigli_ipo_termici, artiglio_cinetico_a_urto, aura_di_dispersione_mentale, bioantenne_gravitiche, bozzolo_magnetico, camere_risonanza_abyssal, campo_di_interferenza_acustica, cannone_sonico_a_raggio, canto_infrasonico_tattico, canto_risonante, cervello_a_bassa_latenza, cinghia_iper_ciliare, cisti_di_ibernazione_minerale, coda_prensile_muscolare, comunicazione_fotonica_coda_coda, coralli_sinaptici_fotofase, corazze_ferro_magnetico
-  - … (59 ulteriori)
+- Risolti:
+  - cannone_sonico_a_raggio, ipertrofia_muscolare_massiva, pelage_idrorepellente_avanzato
 
 ## Highlights UI
 - Solo matrice: Strategist, adattamento_volo, architetto, artigli_psionici, assenza_respirazione, campo_di_fase, ciclo_vitale_anomalo, ciclo_vitale_completo, corteccia_memetica, eco_sismico
@@ -54,5 +38,9 @@ Generato: 2025-12-09T20:02:28.734099Z
 - Check passati: 0 (0 vs precedente)
 - Check falliti: 0 (0 vs precedente)
 - Tratti validati: 0 (0 vs precedente)
+
+## Badge QA
+- Tratti passed: 254 (0 vs precedente)
+- Conflitti badge: 34 (0 vs precedente)
 
 _Report generato da scripts/export-qa-report.js_

--- a/reports/qa_badges.json
+++ b/reports/qa_badges.json
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2025-12-09T20:02:28.734099Z",
+  "generated_at": "2026-04-14T19:23:03.693761Z",
   "summary": {
     "total_traits": 254,
     "glossary_ok": 254,
     "glossary_missing": 0,
-    "matrix_ok": 175,
-    "matrix_mismatch": 79,
+    "matrix_ok": 178,
+    "matrix_mismatch": 76,
     "with_conflicts": 34,
     "matrix_only_traits": 44
   },
@@ -15,7 +15,7 @@
       "total": 254,
       "conflicts": 34,
       "missing_glossary": 0,
-      "matrix_mismatch": 79
+      "matrix_mismatch": 76
     }
   },
   "highlights": {
@@ -53,7 +53,6 @@
       "bozzolo_magnetico",
       "camere_risonanza_abyssal",
       "campo_di_interferenza_acustica",
-      "cannone_sonico_a_raggio",
       "canto_infrasonico_tattico",
       "canto_risonante",
       "cervello_a_bassa_latenza",
@@ -62,7 +61,8 @@
       "coda_prensile_muscolare",
       "comunicazione_fotonica_coda_coda",
       "coralli_sinaptici_fotofase",
-      "corazze_ferro_magnetico"
+      "corazze_ferro_magnetico",
+      "corna_psico_conduttive"
     ],
     "zero_coverage_traits": [
       "ali_fono_risonanti",
@@ -75,7 +75,6 @@
       "bozzolo_magnetico",
       "camere_risonanza_abyssal",
       "campo_di_interferenza_acustica",
-      "cannone_sonico_a_raggio",
       "canto_infrasonico_tattico",
       "canto_risonante",
       "cervello_a_bassa_latenza",
@@ -84,7 +83,8 @@
       "coda_prensile_muscolare",
       "comunicazione_fotonica_coda_coda",
       "coralli_sinaptici_fotofase",
-      "corazze_ferro_magnetico"
+      "corazze_ferro_magnetico",
+      "corna_psico_conduttive"
     ],
     "top_conflicts": [
       {

--- a/reports/trait_baseline.json
+++ b/reports/trait_baseline.json
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2025-12-09T20:02:28.734099Z",
+  "generated_at": "2026-04-14T19:23:03.693761Z",
   "summary": {
     "total_traits": 254,
     "glossary_ok": 254,
     "glossary_missing": 0,
-    "matrix_ok": 175,
-    "matrix_mismatch": 79,
+    "matrix_ok": 178,
+    "matrix_mismatch": 76,
     "with_conflicts": 34,
     "matrix_only_traits": 44
   },
@@ -6178,14 +6178,14 @@
       "label": "Cannone Sonico a Raggio",
       "tier": "T4",
       "coverage": {
-        "core": 0,
-        "optional": 0,
+        "core": 1,
+        "optional": 1,
         "synergy": 0,
-        "total": 0
+        "total": 2
       },
       "statuses": {
         "glossary": "ok",
-        "matrix": "mismatch"
+        "matrix": "ok"
       },
       "conflicts": [],
       "synergies": [
@@ -19260,14 +19260,14 @@
       "label": "Ipertrofia Muscolare Massiva",
       "tier": "T3",
       "coverage": {
-        "core": 0,
-        "optional": 0,
+        "core": 1,
+        "optional": 1,
         "synergy": 0,
-        "total": 0
+        "total": 2
       },
       "statuses": {
         "glossary": "ok",
-        "matrix": "mismatch"
+        "matrix": "ok"
       },
       "conflicts": [
         "organi_sismici_cutanei"
@@ -24074,14 +24074,14 @@
       "label": "Pelage Idrorepellente Avanzato",
       "tier": "T2",
       "coverage": {
-        "core": 0,
-        "optional": 0,
+        "core": 1,
+        "optional": 1,
         "synergy": 0,
-        "total": 0
+        "total": 2
       },
       "statuses": {
         "glossary": "ok",
-        "matrix": "mismatch"
+        "matrix": "ok"
       },
       "conflicts": [],
       "synergies": [

--- a/tests/api/biome-generation.test.js
+++ b/tests/api/biome-generation.test.js
@@ -1,3 +1,5 @@
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
@@ -15,7 +17,9 @@ function hasRole(species, role) {
 
 test.after(async () => {
   if (appHandle && typeof appHandle.close === 'function') {
-    await appHandle.close();
+    await appHandle.close().catch((err) => {
+      console.warn('[test teardown] biome-generation close warning:', err?.message ?? err);
+    });
     appHandle = null;
   }
 });

--- a/tests/api/idea-engine.test.js
+++ b/tests/api/idea-engine.test.js
@@ -1,3 +1,5 @@
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const os = require('node:os');
@@ -16,7 +18,11 @@ test('POST /api/ideas salva nel database e genera il report Codex', async (t) =>
   const handle = createApp({ databasePath });
   const { app, repo } = handle;
   t.after(async () => {
-    if (typeof handle.close === 'function') await handle.close();
+    if (typeof handle.close === 'function') {
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] idea-engine close warning:', err?.message ?? err);
+      });
+    }
   });
   await repo.ready;
   t.after(() => {
@@ -68,7 +74,11 @@ test('POST /api/ideas/:id/feedback registra il commento e aggiorna il report', a
   const handle = createApp({ databasePath });
   const { app, repo } = handle;
   t.after(async () => {
-    if (typeof handle.close === 'function') await handle.close();
+    if (typeof handle.close === 'function') {
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] idea-engine close warning:', err?.message ?? err);
+      });
+    }
   });
   await repo.ready;
   t.after(() => {
@@ -116,7 +126,11 @@ test('GET /api/ideas/:id/report restituisce il report salvato', async (t) => {
   const handle = createApp({ databasePath });
   const { app, repo } = handle;
   t.after(async () => {
-    if (typeof handle.close === 'function') await handle.close();
+    if (typeof handle.close === 'function') {
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] idea-engine close warning:', err?.message ?? err);
+      });
+    }
   });
   await repo.ready;
   t.after(() => {
@@ -144,7 +158,11 @@ test('POST /api/ideas valida i campi obbligatori', async (t) => {
   const handle = createApp({ databasePath });
   const { app, repo } = handle;
   t.after(async () => {
-    if (typeof handle.close === 'function') await handle.close();
+    if (typeof handle.close === 'function') {
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] idea-engine close warning:', err?.message ?? err);
+      });
+    }
   });
   await repo.ready;
   t.after(() => {
@@ -161,7 +179,11 @@ test('POST /api/ideas rifiuta categorie non in tassonomia', async (t) => {
   const handle = createApp({ databasePath });
   const { app, repo } = handle;
   t.after(async () => {
-    if (typeof handle.close === 'function') await handle.close();
+    if (typeof handle.close === 'function') {
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] idea-engine close warning:', err?.message ?? err);
+      });
+    }
   });
   await repo.ready;
   t.after(() => {
@@ -185,7 +207,11 @@ test('POST /api/ideas rifiuta slug non catalogati senza override', async (t) => 
   const handle = createApp({ databasePath });
   const { app, repo } = handle;
   t.after(async () => {
-    if (typeof handle.close === 'function') await handle.close();
+    if (typeof handle.close === 'function') {
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] idea-engine close warning:', err?.message ?? err);
+      });
+    }
   });
   await repo.ready;
   t.after(() => {
@@ -212,7 +238,11 @@ test('POST /api/ideas accetta slug non catalogati con override', async (t) => {
   const handle = createApp({ databasePath });
   const { app, repo } = handle;
   t.after(async () => {
-    if (typeof handle.close === 'function') await handle.close();
+    if (typeof handle.close === 'function') {
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] idea-engine close warning:', err?.message ?? err);
+      });
+    }
   });
   await repo.ready;
   t.after(() => {

--- a/tests/api/quality-release.test.js
+++ b/tests/api/quality-release.test.js
@@ -1,3 +1,5 @@
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const request = require('supertest');
@@ -10,7 +12,9 @@ test.after(async () => {
   while (appHandles.length) {
     const handle = appHandles.pop();
     if (handle && typeof handle.close === 'function') {
-      await handle.close();
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] quality-release close warning:', err?.message ?? err);
+      });
     }
   }
 });

--- a/tests/api/species-generation.test.js
+++ b/tests/api/species-generation.test.js
@@ -1,3 +1,5 @@
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const request = require('supertest');
@@ -10,7 +12,9 @@ test.after(async () => {
   while (appHandles.length) {
     const handle = appHandles.pop();
     if (handle && typeof handle.close === 'function') {
-      await handle.close();
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] species-generation close warning:', err?.message ?? err);
+      });
     }
   }
 });

--- a/tests/api/trait-diagnostics.test.js
+++ b/tests/api/trait-diagnostics.test.js
@@ -1,3 +1,5 @@
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const request = require('supertest');

--- a/tests/api/traits.auth.test.js
+++ b/tests/api/traits.auth.test.js
@@ -1,3 +1,5 @@
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
@@ -20,7 +22,9 @@ test.after(async () => {
   while (appHandles.length) {
     const handle = appHandles.pop();
     if (handle && typeof handle.close === 'function') {
-      await handle.close();
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] traits.auth close warning:', err?.message ?? err);
+      });
     }
   }
 });

--- a/tests/api/traits.validate.test.js
+++ b/tests/api/traits.validate.test.js
@@ -1,3 +1,5 @@
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
@@ -13,7 +15,9 @@ test.after(async () => {
   while (appHandles.length) {
     const handle = appHandles.pop();
     if (handle && typeof handle.close === 'function') {
-      await handle.close();
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] traits.validate close warning:', err?.message ?? err);
+      });
     }
   }
 });


### PR DESCRIPTION
## Summary

Phase 1 del piano di chiusura backlog: bundle di 4 task di pulizia indipendenti.

- **Task 7 (release-reporter preload)**: `writeJsonFile` ora è atomico (`*.tmp` + rename); `createApp` supporta `deployment.statusReportPath=null` e `IDEA_ENGINE_DISABLE_STATUS_REFRESH=1`. Elimina la race che corrompeva `reports/status.json` durante `tests/api/*.test.js`.
- **Task 8 (teardown cosmetic)**: 6 test file avvolgono `handle.close()` in `.catch()` + helper `isBenignTeardownError` per silenziare \"Pool terminato\" / \"Worker non disponibile\" dai preload cancellati in teardown.
- **Task 2 (qa-checklist unify)**: `apps/dashboard/tests/manual/qa-checklist.md` → `docs/qa/nebula-webapp-checklist.md` con frontmatter + registry entry; ADR dashboard-scaffold follow-up #4 marcato completato.
- **Task 6 (evo:import automation)**: nuova sezione \"Automation recommendations\" nell'ADR topology (3 pattern, raccomandazione Pattern B, nessun wiring).

## Test plan

- [x] `python tools/check_docs_governance.py --strict` → 0 errors, 0 warnings
- [x] `npm run docs:lint` → tutti i link interni validi
- [x] `ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/*.test.js` → 73 pass, 0 fail, zero residui `preload fallito` / teardown warning
- [x] `node apps/backend/index.js` con env disable → boot pulito su :3334
- [x] `git mv` preserva history del qa-checklist.md (similarity 93%)

## Rollback

Revert della PR. Lo schema `docs_registry.json` è backward-compatible, `writeJsonFile` atomico è un miglioramento puro, il move del qa-checklist può essere invertito con un altro `git mv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)