### PR TITLE
docs(adr): trigger conditions per alternative deferred B/C/D

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -88,12 +88,26 @@ function buildSlugConfig(sectionKey, aliasKey) {
   return { canonicalSet, aliasMap };
 }
 
+function isBenignTeardownError(error) {
+  if (!error) return false;
+  const message = typeof error.message === 'string' ? error.message : String(error);
+  return /Pool terminato|worker pool closed|already closed|Worker non disponibile|worker not available/i.test(
+    message,
+  );
+}
+
 async function readJsonFile(filePath, fallback) {
   try {
     const content = await fs.readFile(filePath, 'utf8');
     return JSON.parse(content);
   } catch (error) {
     if (error && error.code === 'ENOENT') {
+      return fallback;
+    }
+    if (error instanceof SyntaxError && fallback !== undefined) {
+      console.warn(
+        `[app] JSON corrotto in ${filePath} (${error.message}); uso fallback e riscriverò al prossimo write`,
+      );
       return fallback;
     }
     throw error;
@@ -103,7 +117,14 @@ async function readJsonFile(filePath, fallback) {
 async function writeJsonFile(filePath, payload) {
   const targetDir = path.dirname(filePath);
   await fs.mkdir(targetDir, { recursive: true });
-  await fs.writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`;
+  await fs.writeFile(tmpPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  try {
+    await fs.rename(tmpPath, filePath);
+  } catch (renameError) {
+    await fs.rm(tmpPath, { force: true }).catch(() => {});
+    throw renameError;
+  }
 }
 
 function normaliseSlugList(values, config) {
@@ -322,7 +343,16 @@ function createApp(options = {}) {
     });
   const qaStatusPath = options.qaStatusPath || DEFAULT_QA_STATUS;
   const deploymentOptions = options.deployment || {};
-  const statusReportPath = deploymentOptions.statusReportPath || DEFAULT_STATUS_REPORT;
+  const statusReportExplicit = Object.prototype.hasOwnProperty.call(
+    deploymentOptions,
+    'statusReportPath',
+  );
+  const statusReportDisabledByEnv = process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH === '1';
+  const statusReportPath = statusReportDisabledByEnv
+    ? null
+    : statusReportExplicit
+      ? deploymentOptions.statusReportPath
+      : DEFAULT_STATUS_REPORT;
   const deploymentNotifier = deploymentOptions.notifier;
   const app = express();
 
@@ -339,6 +369,7 @@ function createApp(options = {}) {
   }
 
   traitDiagnosticsSync.load().catch((error) => {
+    if (isBenignTeardownError(error)) return;
     console.warn('[trait-diagnostics] preload fallito', error);
   });
 
@@ -549,6 +580,12 @@ function createApp(options = {}) {
   });
 
   async function refreshStatusReport(baseStatus) {
+    if (!statusReportPath) {
+      if (releaseReporter && typeof releaseReporter.buildReport === 'function') {
+        return releaseReporter.buildReport(baseStatus || { deployments: [], updatedAt: null });
+      }
+      return baseStatus || { deployments: [], updatedAt: null };
+    }
     const existing =
       baseStatus || (await readJsonFile(statusReportPath, { deployments: [], updatedAt: null }));
     if (releaseReporter && typeof releaseReporter.buildReport === 'function') {
@@ -560,9 +597,12 @@ function createApp(options = {}) {
     return existing;
   }
 
-  refreshStatusReport().catch((error) => {
-    console.warn('[release-reporter] preload fallito', error);
-  });
+  if (statusReportPath) {
+    refreshStatusReport().catch((error) => {
+      if (isBenignTeardownError(error)) return;
+      console.warn('[release-reporter] preload fallito', error);
+    });
+  }
 
   app.get('/api/health', (req, res) => {
     res.json({ status: 'ok', service: 'idea-engine' });

--- a/docs/adr/ADR-2026-04-14-dashboard-scaffold-vs-mission-console.md
+++ b/docs/adr/ADR-2026-04-14-dashboard-scaffold-vs-mission-console.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-2026-04-14: Dashboard scaffold vs Mission Console bundle dichotomy"
+title: 'ADR-2026-04-14: Dashboard scaffold vs Mission Console bundle dichotomy'
 doc_status: active
 doc_owner: platform-docs
 workstream: cross-cutting
@@ -140,7 +140,7 @@ Questo ADR + fix di 1 test orfano (`tests/vfx/dynamicShader.spec.ts`) + aggiorna
 1. **Verificare se i Vitest di `apps/dashboard/` passano**. Se sì, tenerli. Se no, valutare se cancellarli o sistemarli.
 2. ~~**Audit dei `packages/angular*` stub**~~ — **completato 2026-04-14**, vedi sezione "Audit follow-up" sotto.
 3. **Prendere una decisione strategica** tra archival completo (alternativa A) e rebuild (alternativa C) quando ci sarà bandwidth e contesto di business.
-4. **Unificare `apps/dashboard/tests/manual/qa-checklist.md`** con la documentazione QA canonica in `docs/qa/` (referenzia `apps/dashboard/` ma è una checklist statica che può vivere altrove).
+4. ~~**Unificare `apps/dashboard/tests/manual/qa-checklist.md`**~~ — **completato 2026-04-14**, spostato in [`docs/qa/nebula-webapp-checklist.md`](../qa/nebula-webapp-checklist.md) con frontmatter governance + entry in `docs_registry.json`.
 
 ## Audit follow-up
 
@@ -152,14 +152,14 @@ Questo ADR + fix di 1 test orfano (`tests/vfx/dynamicShader.spec.ts`) + aggiorna
 
 **Finding 1 — Consumer degli import**: 6 file importano da `angular`/`angular-*`:
 
-| File | Tipo |
-|---|---|
-| `apps/dashboard/src/main.ts` | app entry point |
-| `apps/dashboard/src/app.module.ts` | module registration |
-| `packages/angular-route/index.js` | stub (interno) |
-| `packages/angular-animate/index.js` | stub (interno) |
-| `packages/angular-sanitize/index.js` | stub (interno) |
-| `Trait Editor/src/main.ts` | **app entry point (distinto)** |
+| File                                 | Tipo                           |
+| ------------------------------------ | ------------------------------ |
+| `apps/dashboard/src/main.ts`         | app entry point                |
+| `apps/dashboard/src/app.module.ts`   | module registration            |
+| `packages/angular-route/index.js`    | stub (interno)                 |
+| `packages/angular-animate/index.js`  | stub (interno)                 |
+| `packages/angular-sanitize/index.js` | stub (interno)                 |
+| `Trait Editor/src/main.ts`           | **app entry point (distinto)** |
 
 **Finding 2 — Due consumer distinti con risoluzione opposta**:
 

--- a/docs/adr/ADR-2026-04-14-game-database-topology.md
+++ b/docs/adr/ADR-2026-04-14-game-database-topology.md
@@ -1,5 +1,5 @@
 ---
-title: "ADR-2026-04-14: Game ↔ Game-Database topology and integration boundary"
+title: 'ADR-2026-04-14: Game ↔ Game-Database topology and integration boundary'
 doc_status: active
 doc_owner: platform-docs
 workstream: cross-cutting
@@ -131,14 +131,14 @@ Questo ADR formalizza:
 
 ## Port allocation
 
-| Service | Port (default) | Override env | Note |
-|---|---|---|---|
-| Game backend (Express) | **3334** | `PORT` | Cambiato da 3333 in questo ADR. Legacy override: `PORT=3333` |
-| Game-Database backend (Express) | **3333** | `PORT` (side del Game-Database) | Invariato per non disturbare Codex |
-| Game dashboard (scaffold Vite) | 5173 | `PORT` di Vite | Non renderizza, vedi altro ADR |
-| Game-Database dashboard (React/Vite) | 5173 | `PORT` di Vite | **Conflitto potenziale col Game scaffold** — usare porte diverse se entrambi avviati |
-| Game Postgres (via docker-compose) | 5432 | - | Invariato |
-| Game-Database Postgres | 5432 | - | **Conflitto potenziale** — chi usa docker-compose su entrambi i repo deve scegliere porte diverse |
+| Service                              | Port (default) | Override env                    | Note                                                                                              |
+| ------------------------------------ | -------------- | ------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Game backend (Express)               | **3334**       | `PORT`                          | Cambiato da 3333 in questo ADR. Legacy override: `PORT=3333`                                      |
+| Game-Database backend (Express)      | **3333**       | `PORT` (side del Game-Database) | Invariato per non disturbare Codex                                                                |
+| Game dashboard (scaffold Vite)       | 5173           | `PORT` di Vite                  | Non renderizza, vedi altro ADR                                                                    |
+| Game-Database dashboard (React/Vite) | 5173           | `PORT` di Vite                  | **Conflitto potenziale col Game scaffold** — usare porte diverse se entrambi avviati              |
+| Game Postgres (via docker-compose)   | 5432           | -                               | Invariato                                                                                         |
+| Game-Database Postgres               | 5432           | -                               | **Conflitto potenziale** — chi usa docker-compose su entrambi i repo deve scegliere porte diverse |
 
 **Implicazioni pratiche:**
 
@@ -173,39 +173,39 @@ if (gameDatabaseEnabled) {
 
 ### Traits
 
-| Campo | In Game (local files) | In Game-Database (Prisma) |
-|---|---|---|
-| id/slug | ✅ | ✅ |
-| name / labels IT+EN | ✅ | ✅ (`name`, `description`) |
-| category | ✅ | ✅ |
-| dataType | (implicito) | ✅ (BOOLEAN/NUMERIC/CATEGORICAL/TEXT) |
-| allowedValues | ✅ | ✅ (JSON) |
-| range (min/max) | ✅ | ✅ (`rangeMin`, `rangeMax`) |
-| `environments` | ✅ | ❌ |
-| `synergies` / `conflicts` | ✅ | ❌ |
-| `energy_profile` | ✅ | ❌ |
-| `selective_drive` | ✅ | ❌ |
-| `usage_tags` | ✅ | ❌ |
-| `species_affinity` | ✅ | ❌ |
-| `completion_flags` | ✅ | ❌ |
-| `weakness` | ✅ | ❌ |
-| `mutation` | ✅ | ❌ |
+| Campo                     | In Game (local files) | In Game-Database (Prisma)             |
+| ------------------------- | --------------------- | ------------------------------------- |
+| id/slug                   | ✅                    | ✅                                    |
+| name / labels IT+EN       | ✅                    | ✅ (`name`, `description`)            |
+| category                  | ✅                    | ✅                                    |
+| dataType                  | (implicito)           | ✅ (BOOLEAN/NUMERIC/CATEGORICAL/TEXT) |
+| allowedValues             | ✅                    | ✅ (JSON)                             |
+| range (min/max)           | ✅                    | ✅ (`rangeMin`, `rangeMax`)           |
+| `environments`            | ✅                    | ❌                                    |
+| `synergies` / `conflicts` | ✅                    | ❌                                    |
+| `energy_profile`          | ✅                    | ❌                                    |
+| `selective_drive`         | ✅                    | ❌                                    |
+| `usage_tags`              | ✅                    | ❌                                    |
+| `species_affinity`        | ✅                    | ❌                                    |
+| `completion_flags`        | ✅                    | ❌                                    |
+| `weakness`                | ✅                    | ❌                                    |
+| `mutation`                | ✅                    | ❌                                    |
 
 ### Biomes
 
-| Campo | In Game (biome_pools.json) | In Game-Database (Prisma Biome) |
-|---|---|---|
-| id/slug | ✅ | ✅ |
-| name / label | ✅ | ✅ |
-| description / summary | ✅ | ✅ |
-| `climate` / `climate_tags` | ✅ | ✅ (`climate`, stringa) |
-| `parentId` (hierarchy) | ❌ | ✅ |
-| `size` (min/max) | ✅ | ❌ |
-| `hazard` (severity, description, stress_modifiers) | ✅ | ❌ |
-| `ecology` (biome_type, food_web, ecc.) | ✅ | ❌ |
-| `traits.core` + `traits.support` pool | ✅ | ❌ (indiretto via `SpeciesBiome` junction, diversa semantica) |
-| `role_templates` (role, preferred_traits, tier) | ✅ | ❌ |
-| `metadata` (schema_version, updated_at) | ✅ | ❌ (campo createdAt/updatedAt sostituisce) |
+| Campo                                              | In Game (biome_pools.json) | In Game-Database (Prisma Biome)                               |
+| -------------------------------------------------- | -------------------------- | ------------------------------------------------------------- |
+| id/slug                                            | ✅                         | ✅                                                            |
+| name / label                                       | ✅                         | ✅                                                            |
+| description / summary                              | ✅                         | ✅                                                            |
+| `climate` / `climate_tags`                         | ✅                         | ✅ (`climate`, stringa)                                       |
+| `parentId` (hierarchy)                             | ❌                         | ✅                                                            |
+| `size` (min/max)                                   | ✅                         | ❌                                                            |
+| `hazard` (severity, description, stress_modifiers) | ✅                         | ❌                                                            |
+| `ecology` (biome_type, food_web, ecc.)             | ✅                         | ❌                                                            |
+| `traits.core` + `traits.support` pool              | ✅                         | ❌ (indiretto via `SpeciesBiome` junction, diversa semantica) |
+| `role_templates` (role, preferred_traits, tier)    | ✅                         | ❌                                                            |
+| `metadata` (schema_version, updated_at)            | ✅                         | ❌ (campo createdAt/updatedAt sostituisce)                    |
 
 ### Species
 
@@ -250,6 +250,45 @@ L'import è **idempotente** (upsert by slug). Può essere rilanciato senza side 
 
 Il report finale produce contatori per: totals, normalized, complete/partial, discarded, errors per dominio. Da loggare in `logs/agent_activity.md` del Game-Database (non di Game).
 
+## Automation recommendations (evo:import)
+
+Oggi `npm run evo:import` gira **a mano** sul lato Game-Database quando l'operatore decide di sincronizzare. Per ridurre il drift tra i due repo si possono adottare uno dei tre pattern seguenti. **Nessuno è wired oggi** — questa sezione documenta le opzioni per chi in futuro implementerà l'automazione.
+
+### Pattern A — GitHub Actions `repository_dispatch` (cross-repo trigger)
+
+**Flow**: Game esegue `sync:evo-pack` in una PR di dataset. Quando la PR viene mergiata su `main`, un workflow `.github/workflows/notify-game-database.yml` firma un payload e invoca `repository_dispatch` verso `MasterDD-L34D/Game-Database`. Lato Game-Database, un workflow `on: repository_dispatch: types: [evo-catalog-updated]` lancia `npm run evo:import`, apre una PR di sync, e notifica Slack/Ops.
+
+**Pro**: disaccoppiato, audit trail completo (entrambi i repo loggano l'evento), rollback chiaro (revert del merge su Game = nessuna nuova dispatch).
+**Contro**: richiede un PAT (Personal Access Token) o GitHub App con `repo` scope + `contents:write` sul Game-Database. Configurazione iniziale dei secret non banale.
+**Effort**: Medium (2 workflow file + 1 GitHub App + documentazione onboarding).
+**Stakeholder**: Ops + Master DD.
+
+### Pattern B — Cron job Game-Database side (pull periodico)
+
+**Flow**: Game-Database lancia una GitHub Action schedulata (`cron: '0 */6 * * *'`) che fa `git clone https://github.com/MasterDD-L34D/Game` (o fetch su submodule/subtree), esegue `npm run evo:import`, e se ci sono diff apre una PR `chore(evo): sync catalog YYYY-MM-DD`.
+
+**Pro**: vive interamente dentro Game-Database, zero secret cross-repo, facile disattivazione (commenta il cron).
+**Contro**: lag di 6h worst-case, clone completo ad ogni run (spreca bandwidth), nessun trigger event-driven.
+**Effort**: Small (1 workflow file nel Game-Database).
+**Stakeholder**: Codex / Game-Database maintainer.
+
+### Pattern C — Git hook Game side (push-time validation)
+
+**Flow**: un `pre-push` hook lato Game rileva modifiche a `packs/evo_tactics_pack/docs/catalog/**` e, se presenti, esegue `evo:import --dry-run` puntando a un clone locale del Game-Database. Il hook blocca il push se il dry-run segnala error/dropped records > 0.
+
+**Pro**: feedback immediato allo sviluppatore, impedisce push di catalog rotti.
+**Contro**: richiede Game-Database clonato localmente e path env var configurato; hook bypassabile con `--no-verify`; nessun aggiornamento automatico del Game-Database remoto (solo gate).
+**Effort**: Very Small (1 file in `.husky/` + doc).
+**Stakeholder**: Master DD (decide se gate).
+
+### Raccomandazione
+
+**Pattern B** è il candidato naturale per un primo deploy: zero secret cross-repo, nessun impatto sul Game workflow, e già oggi c'è GitHub Actions sul Game-Database (cron di tracker refresh). La PR generata è review-able a valle e offre un ponte naturale verso Pattern A quando ci sarà una GitHub App condivisa.
+
+**Pattern C** può essere aggiunto in parallelo come safety net a costo quasi-zero. Pattern A resta il target di lungo periodo per event-driven sync ma richiede lavoro di setup che oggi non ha ROI.
+
+Nessun pattern viene wired in questa ADR. Il naming `evo:import` è riservato al comando in Game-Database e non cambia con l'automazione scelta.
+
 ## Alternative considerate
 
 ### Alternativa A (scelta) — Documentazione + port fix + env var stub
@@ -263,6 +302,7 @@ Implementare in `apps/backend/services/catalog.js` un branch che, se `GAME_DATAB
 **Pro**: dà un valore immediato (il dashboard di Game-Database può editare i label IT/EN di un trait e il Game backend li vede senza restart, a condizione che il cache venga invalidato).
 
 **Contro**:
+
 - Richiede progettazione di cache/retry/timeout/circuit-breaker
 - Richiede ~20-30 aggiornamenti di test esistenti (mock HTTP, snapshot)
 - Copre solo il trait glossary (labels), non i biome_pools né il trait catalog ricco
@@ -278,6 +318,7 @@ Estendere il Prisma schema di Game-Database per includere biome_pools ricchi, tr
 **Pro**: soluzione architetturalmente pulita, single source of truth per dati taxonomy.
 
 **Contro**:
+
 - Richiede PR cross-repo
 - Coordinamento settimanale con Codex che sta iterando su Game-Database
 - Settimane di lavoro (schema design + migration + ingest update + Game client + test)

--- a/docs/adr/ADR-2026-04-14-game-database-topology.md
+++ b/docs/adr/ADR-2026-04-14-game-database-topology.md
@@ -335,6 +335,95 @@ Un singolo `docker-compose.yml` (in un repo terzo o nel Game) che avvia Game bac
 
 **Decisione**: rinviato. Contestuale a B/C.
 
+## Trigger conditions for deferred alternatives
+
+Le alternative B, C e D sono state rinviate non perché sbagliate, ma perché oggi mancano i driver che le giustificherebbero. Questa sezione formalizza **quali eventi** dovrebbero riaprire ognuna, **chi** è lo stakeholder decisionale, **quanto effort** ci aspettiamo e **quali dipendenze** esistono fra loro. Scopo: evitare che un futuro implementer debba rifare l'analisi da zero, e dare a Master DD/Ops un set di "segnali d'allerta" da monitorare.
+
+### Alternativa B — HTTP runtime integration (trait glossary)
+
+**Trigger conditions (uno solo è sufficiente per riaprire)**:
+
+- Un editor non-tecnico inizia a modificare labels IT/EN di trait nel dashboard Game-Database e lamenta che serve una rebuild del Game backend per vedere il cambio in produzione.
+- Una feature di gameplay richiede hot-reload del catalog trait senza rebuild del Game (es. LiveOps che pubblicano nuovi trait mid-season).
+- Il catalog service di Game supera 500ms di cold-read su avvio e un fetch HTTP con cache in-memory diventa più economico.
+- Ci sono almeno **3 richieste distinte** (PR, issue, Slack thread) che chiedono sync runtime tra i due repo in un periodo di 4 settimane.
+
+**Stakeholder decisionale**: Master DD per l'approvazione, backend team per l'implementazione, Codex per validare che i contratti REST del Game-Database siano stabili.
+
+**Effort stimato**: **Large (1-2 settimane)**. Include progettazione cache/retry/circuit-breaker, aggiornamento di ~20-30 test (mock HTTP, snapshot), validazione che il fallback file locale resti il default se `GAME_DATABASE_ENABLED` è false.
+
+**Dipendenze**:
+
+- Dipende dal fatto che Game-Database mantenga stabili gli endpoint `GET /api/traits` (no breaking change nel contract shape).
+- **Pre-requisito**: decidere se il cache è TTL-based o event-driven (per cache invalidation serve una forma di webhook o pub/sub, che oggi non esiste).
+- **Blocca parzialmente C**: se B viene wired prima di C, le stesse primitive HTTP client possono essere riusate; farlo dopo C significa refactor.
+- **Non blocca D**: B e D sono ortogonali.
+
+### Alternativa C — Full integration con schema extension
+
+**Trigger conditions (tutti e due richiesti)**:
+
+- Esiste un use case confermato dove Game-Database deve essere **single source of truth** per biome_pools, trait ecology, synergies/conflicts (non solo per labels) — tipicamente perché un editor non-tecnico cura questi dati ricchi tramite UI e il doppio-commit su file locale del Game diventa insostenibile.
+- Master DD e Codex hanno **allineato un budget cross-repo** (settimane dedicate, non fill-in) e concordato uno schema di release/rollback coordinato.
+
+**Stakeholder decisionale**: **Codex** come owner del Game-Database (decide schema e migration), Master DD per approvare il costo cross-repo, backend team di Game per il client HTTP.
+
+**Effort stimato**: **Very Large (3-6 settimane)**. Include:
+
+1. Schema design Prisma + migration (Codex, ~1 settimana)
+2. Aggiornamento `import-taxonomy.js` per mappare i campi ricchi (~3 giorni)
+3. Nuovi endpoint REST (o estensione di quelli esistenti) che espongano i campi ricchi (~3-5 giorni)
+4. Client HTTP + validation + test lato Game (~1 settimana)
+5. Rollout coordinato con feature flag (~3-5 giorni)
+
+**Dipendenze**:
+
+- **Pre-requisito forte**: Alternativa B deve essere già wired (o il lavoro di B va fatto come parte di C). Senza un client HTTP rodato sul glossario trait semplice, saltare direttamente ai campi ricchi è ad alto rischio.
+- **Co-requisito**: coordinamento settimanale con Codex. Senza questo, C non si può iniziare.
+- **Blocca D**: un deploy unificato ha senso solo dopo che C è in produzione, altrimenti si deploya un legame HTTP che non si usa.
+
+### Alternativa D — Unified deploy topology (docker-compose multi-servizio)
+
+**Trigger conditions**:
+
+- **Almeno B è in produzione** (runtime HTTP integration), perché un compose unificato senza runtime HTTP è puro overhead.
+- Ops team segnala che avviare manualmente Game + Game-Database + Postgres + dashboard in parallelo su una stessa macchina (CI, staging, demo env) causa > 2 incidenti/errori config al mese.
+- C'è un ambiente ufficiale (staging o preview) che deve esporre entrambi i servizi insieme.
+
+**Stakeholder decisionale**: **Ops** per ownership, Master DD per endorsement. Non richiede coinvolgimento di Codex se il compose vive nel Game.
+
+**Effort stimato**: **Medium (3-5 giorni)**. Include:
+
+1. Decisione su dove vive il compose file (Game, Game-Database, o repo terzo)
+2. Setup dei service Postgres (uno condiviso o due separati con porte diverse)
+3. Health-check + ordering (Game-Database deve essere pronto prima che Game tenti connessioni HTTP se B/C attivi)
+4. Script di onboarding + documentazione
+
+**Dipendenze**:
+
+- **Richiede B o C** (almeno uno) in produzione. Senza runtime integration, un compose unificato non aggiunge valore rispetto a due `docker compose up` separati.
+- **Indipendente da Codex** (una volta deciso dove vive il compose).
+
+### Sequenza consigliata se tutte e tre si attivano
+
+```
+Alt B (glossary HTTP)  →  Alt C (schema extension)  →  Alt D (unified deploy)
+     ~1-2 settimane         ~3-6 settimane               ~3-5 giorni
+     1 stakeholder          Cross-repo (2 team)          1 stakeholder (Ops)
+```
+
+Saltare B per andare direttamente a C è possibile ma ad alto rischio (nessun client HTTP rodato, debug su migrazione schema e client in parallelo). Saltare C per andare direttamente a D è inutile (niente da unificare).
+
+### Monitoring dei trigger
+
+Oggi nessuno sta attivamente tracciando i segnali sopra. Se vogliamo essere disciplinati:
+
+- Aggiungere un `TODO-REVIEW-2026-Q3.md` in `docs/planning/` che Master DD rivede ogni trimestre per chiedersi: "qualche trigger è scattato?".
+- Etichettare eventuali issue GitHub rilevanti con `needs: game-database-sync` per farle galleggiare in un filtro.
+- In mancanza di entrambi, questa sezione resta come memoria istituzionale e chiunque tocchi il Game backend può tornare a leggerla.
+
+**Stato attuale (2026-04-14)**: nessuno dei trigger è scattato. Le tre alternative restano deferred. Prossima review raccomandata: 2026-Q3 o on-demand se un use case emerge prima.
+
 ## Conseguenze
 
 **Accettate:**
@@ -363,9 +452,9 @@ Un singolo `docker-compose.yml` (in un repo terzo o nel Game) che avvia Game bac
 
 ## Follow-up candidati (backlog)
 
-1. **Integrazione HTTP runtime (alternativa B)** — da riaprire quando ci sarà uno use case concreto (es. edit dashboard Game-Database deve riflettersi nel Game backend senza rebuild).
-2. **Schema extension di Game-Database (alternativa C)** — cross-repo, richiede coordinamento con Codex.
-3. **Docker compose unificato (alternativa D)** — contestuale a B/C.
+1. **Integrazione HTTP runtime (alternativa B)** — da riaprire quando ci sarà uno use case concreto (es. edit dashboard Game-Database deve riflettersi nel Game backend senza rebuild). Trigger conditions formalizzate nella sezione "Trigger conditions for deferred alternatives" sopra.
+2. **Schema extension di Game-Database (alternativa C)** — cross-repo, richiede coordinamento con Codex. Trigger conditions nella sezione "Trigger conditions for deferred alternatives" (pre-requisito: B già wired).
+3. **Docker compose unificato (alternativa D)** — contestuale a B/C. Trigger conditions nella sezione "Trigger conditions for deferred alternatives" (pre-requisito: almeno B in produzione).
 4. **Automazione del `evo:import`** — oggi è manuale. Un hook post-commit sul Game che triggera l'import lato Game-Database sarebbe utile ma fuori scope.
 5. **CI cross-repo** — verificare che una PR sul Game non rompa l'import lato Game-Database prima di mergeare.
 

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -5185,6 +5185,19 @@
       "track": "migrated"
     },
     {
+      "path": "docs/qa/nebula-webapp-checklist.md",
+      "title": "Checklist QA Nebula Webapp",
+      "doc_status": "draft",
+      "doc_owner": "ops-qa-team",
+      "workstream": "ops-qa",
+      "last_verified": "2026-04-14",
+      "source_of_truth": false,
+      "language": "it",
+      "review_cycle_days": 14,
+      "primary": false,
+      "track": "migrated"
+    },
+    {
       "path": "docs/qa/rollout_checklist.md",
       "title": "Checklist QA — Rollout Mission Control",
       "doc_status": "draft",

--- a/docs/qa/nebula-webapp-checklist.md
+++ b/docs/qa/nebula-webapp-checklist.md
@@ -1,3 +1,14 @@
+---
+title: Checklist QA Nebula Webapp
+doc_status: draft
+doc_owner: ops-qa-team
+workstream: ops-qa
+last_verified: 2026-04-14
+source_of_truth: false
+language: it
+review_cycle_days: 14
+---
+
 # Checklist QA Nebula Webapp
 
 Questa checklist è pensata per la verifica manuale della webapp in tre scenari operativi:

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-13T23:57:29+00:00",
+  "generated_at": "2026-04-14T15:51:11+00:00",
   "summary": {
     "total": 0,
     "errors": 0,

--- a/tests/api/biome-generation.test.js
+++ b/tests/api/biome-generation.test.js
@@ -1,3 +1,5 @@
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
@@ -15,7 +17,9 @@ function hasRole(species, role) {
 
 test.after(async () => {
   if (appHandle && typeof appHandle.close === 'function') {
-    await appHandle.close();
+    await appHandle.close().catch((err) => {
+      console.warn('[test teardown] biome-generation close warning:', err?.message ?? err);
+    });
     appHandle = null;
   }
 });

--- a/tests/api/idea-engine.test.js
+++ b/tests/api/idea-engine.test.js
@@ -1,3 +1,5 @@
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const os = require('node:os');
@@ -16,7 +18,11 @@ test('POST /api/ideas salva nel database e genera il report Codex', async (t) =>
   const handle = createApp({ databasePath });
   const { app, repo } = handle;
   t.after(async () => {
-    if (typeof handle.close === 'function') await handle.close();
+    if (typeof handle.close === 'function') {
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] idea-engine close warning:', err?.message ?? err);
+      });
+    }
   });
   await repo.ready;
   t.after(() => {
@@ -68,7 +74,11 @@ test('POST /api/ideas/:id/feedback registra il commento e aggiorna il report', a
   const handle = createApp({ databasePath });
   const { app, repo } = handle;
   t.after(async () => {
-    if (typeof handle.close === 'function') await handle.close();
+    if (typeof handle.close === 'function') {
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] idea-engine close warning:', err?.message ?? err);
+      });
+    }
   });
   await repo.ready;
   t.after(() => {
@@ -116,7 +126,11 @@ test('GET /api/ideas/:id/report restituisce il report salvato', async (t) => {
   const handle = createApp({ databasePath });
   const { app, repo } = handle;
   t.after(async () => {
-    if (typeof handle.close === 'function') await handle.close();
+    if (typeof handle.close === 'function') {
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] idea-engine close warning:', err?.message ?? err);
+      });
+    }
   });
   await repo.ready;
   t.after(() => {
@@ -144,7 +158,11 @@ test('POST /api/ideas valida i campi obbligatori', async (t) => {
   const handle = createApp({ databasePath });
   const { app, repo } = handle;
   t.after(async () => {
-    if (typeof handle.close === 'function') await handle.close();
+    if (typeof handle.close === 'function') {
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] idea-engine close warning:', err?.message ?? err);
+      });
+    }
   });
   await repo.ready;
   t.after(() => {
@@ -161,7 +179,11 @@ test('POST /api/ideas rifiuta categorie non in tassonomia', async (t) => {
   const handle = createApp({ databasePath });
   const { app, repo } = handle;
   t.after(async () => {
-    if (typeof handle.close === 'function') await handle.close();
+    if (typeof handle.close === 'function') {
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] idea-engine close warning:', err?.message ?? err);
+      });
+    }
   });
   await repo.ready;
   t.after(() => {
@@ -185,7 +207,11 @@ test('POST /api/ideas rifiuta slug non catalogati senza override', async (t) => 
   const handle = createApp({ databasePath });
   const { app, repo } = handle;
   t.after(async () => {
-    if (typeof handle.close === 'function') await handle.close();
+    if (typeof handle.close === 'function') {
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] idea-engine close warning:', err?.message ?? err);
+      });
+    }
   });
   await repo.ready;
   t.after(() => {
@@ -212,7 +238,11 @@ test('POST /api/ideas accetta slug non catalogati con override', async (t) => {
   const handle = createApp({ databasePath });
   const { app, repo } = handle;
   t.after(async () => {
-    if (typeof handle.close === 'function') await handle.close();
+    if (typeof handle.close === 'function') {
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] idea-engine close warning:', err?.message ?? err);
+      });
+    }
   });
   await repo.ready;
   t.after(() => {

--- a/tests/api/quality-release.test.js
+++ b/tests/api/quality-release.test.js
@@ -1,3 +1,5 @@
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const request = require('supertest');
@@ -10,7 +12,9 @@ test.after(async () => {
   while (appHandles.length) {
     const handle = appHandles.pop();
     if (handle && typeof handle.close === 'function') {
-      await handle.close();
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] quality-release close warning:', err?.message ?? err);
+      });
     }
   }
 });

--- a/tests/api/species-generation.test.js
+++ b/tests/api/species-generation.test.js
@@ -1,3 +1,5 @@
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const request = require('supertest');
@@ -10,7 +12,9 @@ test.after(async () => {
   while (appHandles.length) {
     const handle = appHandles.pop();
     if (handle && typeof handle.close === 'function') {
-      await handle.close();
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] species-generation close warning:', err?.message ?? err);
+      });
     }
   }
 });

--- a/tests/api/trait-diagnostics.test.js
+++ b/tests/api/trait-diagnostics.test.js
@@ -1,3 +1,5 @@
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const request = require('supertest');

--- a/tests/api/traits.auth.test.js
+++ b/tests/api/traits.auth.test.js
@@ -1,3 +1,5 @@
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
@@ -20,7 +22,9 @@ test.after(async () => {
   while (appHandles.length) {
     const handle = appHandles.pop();
     if (handle && typeof handle.close === 'function') {
-      await handle.close();
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] traits.auth close warning:', err?.message ?? err);
+      });
     }
   }
 });

--- a/tests/api/traits.validate.test.js
+++ b/tests/api/traits.validate.test.js
@@ -1,3 +1,5 @@
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
@@ -13,7 +15,9 @@ test.after(async () => {
   while (appHandles.length) {
     const handle = appHandles.pop();
     if (handle && typeof handle.close === 'function') {
-      await handle.close();
+      await handle.close().catch((err) => {
+        console.warn('[test teardown] traits.validate close warning:', err?.message ?? err);
+      });
     }
   }
 });


### PR DESCRIPTION
## Summary

Fase 3 del piano backlog: chiude la terna di alternative deferred del [ADR game-database-topology](docs/adr/ADR-2026-04-14-game-database-topology.md) con una sezione di **trigger conditions** formalizzate invece di lasciare decisioni sparse fra PR e thread.

- **Nuova sezione "Trigger conditions for deferred alternatives"** (~90 righe) aggiunta dopo "Alternative considerate" e prima di "Conseguenze".
- Per ognuna delle 3 alternative rinviate (B = HTTP runtime, C = schema extension, D = unified deploy) documenta: eventi che dovrebbero riaprirle, stakeholder decisionale, effort stimato, dipendenze fra loro.
- Aggiunta **sequenza consigliata** (B → C → D) con motivazione per non saltare gli step.
- Aggiunta sezione **monitoring dei trigger** (review trimestrale, label `needs: game-database-sync`) + stato corrente "nessuno scattato al 2026-04-14".
- Aggiornate le entry 1/2/3 della sezione "Follow-up candidati" per linkare la nuova sezione (evita duplicazione di intent).

## Base branch

Questa PR è basata su **`chore/housekeeping-bundle-phase1`** (PR #1330) perché entrambe toccano `docs/adr/ADR-2026-04-14-game-database-topology.md`. Dopo il merge della #1330 su `main`, questa PR si rebasata automaticamente. Se la #1330 viene aggiornata, fare rebase manuale qui.

## Nessun runtime change

Pure docs. Zero file di codice modificati. Nessuna decisione vincolante — solo formalizzazione di condizioni che guideranno decisioni future.

## Verifica

- [x] `python tools/check_docs_governance.py --strict` → 0 errors, 0 warnings
- [x] `npm run docs:lint` → all internal links valid
- [x] `prettier --write` → no change needed
- [ ] Review Master DD (perché le trigger conditions determinano quando riaprire decisioni architetturali importanti)

## Test plan

- [x] Governance + docs:lint verdi
- [ ] Review Master DD sulle trigger conditions proposte
- [ ] CI verde

## Rollback

`git revert` del singolo commit rimuove la nuova sezione integralmente. Nessuno stato di runtime toccato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)