### PR TITLE
fix(qa-export): determinismo cross-OS Linux/Windows

### DIFF
--- a/scripts/export-qa-report.js
+++ b/scripts/export-qa-report.js
@@ -31,6 +31,24 @@ function toStringArray(value) {
   return normaliseArray(value).map((item) => String(item));
 }
 
+function normaliseSourcePath(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return String(value).replace(/\\/g, '/');
+}
+
+function normaliseSourcesMap(sources) {
+  if (!sources || typeof sources !== 'object') {
+    return {};
+  }
+  const out = {};
+  for (const [key, value] of Object.entries(sources)) {
+    out[key] = normaliseSourcePath(value);
+  }
+  return out;
+}
+
 function normaliseTraitEntry(entry) {
   const coverage = {
     core: toNumber(entry?.coverage?.core),
@@ -86,9 +104,9 @@ function buildTraitBaselineReport(diagnostics) {
     matrix_only_traits: matrixOnlyTraits,
     missing_glossary: missingGlossary,
     sources: {
-      trait_reference: diagnostics?.sources?.trait_reference || null,
-      trait_matrix: diagnostics?.sources?.trait_matrix || null,
-      trait_glossary: diagnostics?.sources?.trait_glossary || null,
+      trait_reference: normaliseSourcePath(diagnostics?.sources?.trait_reference),
+      trait_matrix: normaliseSourcePath(diagnostics?.sources?.trait_matrix),
+      trait_glossary: normaliseSourcePath(diagnostics?.sources?.trait_glossary),
     },
   };
 }
@@ -140,7 +158,7 @@ function buildQaBadgesReport(baseline) {
       zero_coverage_traits: zeroCoverage,
       top_conflicts: topConflicts,
     },
-    sources: baseline?.sources || {},
+    sources: normaliseSourcesMap(baseline?.sources),
   };
 }
 
@@ -203,7 +221,7 @@ function buildGeneratorValidationReport(diagnostics) {
     checks_failed: failedChecks || null,
   };
   const context = payload?.context && typeof payload.context === 'object' ? payload.context : {};
-  const sources = payload?.sources && typeof payload.sources === 'object' ? payload.sources : {};
+  const sources = normaliseSourcesMap(payload?.sources);
 
   return {
     generated_at: generatedAt,

--- a/services/generation/species_builder.py
+++ b/services/generation/species_builder.py
@@ -283,14 +283,14 @@ def build_trait_catalog_map(
             "generated_at": None,
             "traits": {trait_id: profile.to_payload() for trait_id, profile in catalog_traits.items()},
             "sources": {
-                "trait_reference": str(trait_reference_path.relative_to(REPO_ROOT)),
-                "trait_matrix": str(trait_matrix_path.relative_to(REPO_ROOT))
+                "trait_reference": trait_reference_path.relative_to(REPO_ROOT).as_posix(),
+                "trait_matrix": trait_matrix_path.relative_to(REPO_ROOT).as_posix()
                 if trait_matrix_path.exists()
                 else None,
-                "trait_glossary": str(trait_glossary_path.relative_to(REPO_ROOT))
+                "trait_glossary": trait_glossary_path.relative_to(REPO_ROOT).as_posix()
                 if trait_glossary_path.exists()
                 else None,
-                "inventory": str(inventory_path.relative_to(REPO_ROOT))
+                "inventory": inventory_path.relative_to(REPO_ROOT).as_posix()
                 if inventory_path.exists()
                 else None,
             },
@@ -410,11 +410,11 @@ def build_trait_diagnostics(
         "summary": summary,
         "matrix_only_traits": orphan_matrix_traits,
         "sources": {
-            "trait_reference": str(trait_reference_path.relative_to(REPO_ROOT)),
-            "trait_matrix": str(trait_matrix_path.relative_to(REPO_ROOT))
+            "trait_reference": trait_reference_path.relative_to(REPO_ROOT).as_posix(),
+            "trait_matrix": trait_matrix_path.relative_to(REPO_ROOT).as_posix()
             if trait_matrix_path.exists()
             else None,
-            "trait_glossary": str(trait_glossary_path.relative_to(REPO_ROOT))
+            "trait_glossary": trait_glossary_path.relative_to(REPO_ROOT).as_posix()
             if trait_glossary_path.exists()
             else None,
         },

--- a/services/generation/worker.py
+++ b/services/generation/worker.py
@@ -23,7 +23,11 @@ from services.generation.orchestrator import (  # noqa: E402
 )
 
 try:  # pragma: no cover - non disponibile su Python < 3.7
-    sys.stdout.reconfigure(line_buffering=True)  # type: ignore[attr-defined]
+    # Forziamo utf-8 su stdin/stdout: su Windows il default sarebbe cp1252 e
+    # i caratteri Unicode (à, è, ’) finirebbero come replacement char nel
+    # bridge Node, rompendo la determinismo dei report QA cross-OS.
+    sys.stdout.reconfigure(encoding="utf-8", line_buffering=True)  # type: ignore[attr-defined]
+    sys.stdin.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
 except AttributeError:  # pragma: no cover - fallback legacy
     pass
 


### PR DESCRIPTION
## Summary

- `services/generation/worker.py` ora riconfigura stdin/stdout in **utf-8** esplicito (su Windows il default cp1252 corrompeva i label Unicode `Cavità` → `Cavit?`)
- `services/generation/species_builder.py` usa `.as_posix()` invece di `str(...)` quando emette i `sources` (su Windows finivano come `data\traits\index.json`)
- `scripts/export-qa-report.js` aggiunge un helper `normaliseSourcePath` come defense-in-depth nei tre builder che copiano `sources`

Effetto: `node scripts/export-qa-report.js` su Windows produce `qa_badges.json`, `trait_baseline.json`, `generator_validation.json` **byte-identici** alla baseline Linux degli artefatti `qa-export.yml`. Le PR future che toccano dataset/orchestrator non richiedono più il workaround "scarica artefatto e committalo a mano".

## Diagnosi

Riprodotto facendo run su Windows e diffando contro l'artifact del workflow `qa-export.yml` (run 24418459564). Trovate due cause distinte:

1. **Path separators**. `species_builder.py` lines 286, 290, 293, 413, 417 usavano `str(path.relative_to(REPO_ROOT))`. Su Windows `pathlib.Path.__str__` emette `\` come separator. Diff atteso, fix: `.as_posix()`.

2. **Encoding cp1252**. `worker.py:26` chiamava `sys.stdout.reconfigure(line_buffering=True)` senza `encoding`. Python su Windows defaulta a cp1252 sullo stdout console. Quando il bridge Node leggeva il payload con `chunk.toString()` (utf-8), i byte cp1252 venivano interpretati male e i caratteri Unicode (`à`, `’`, `è`) diventavano replacement char. Fix: `reconfigure(encoding="utf-8", line_buffering=True)` su stdout e `reconfigure(encoding="utf-8")` su stdin.

`preserveGeneratedAt` lato JS ha sempre funzionato correttamente: si limita a non riusare il timestamp se il `rest` del payload è cambiato. Era proprio il `rest` a divergere.

## Test plan

- [x] `node scripts/export-qa-report.js` su Windows post-fix → diff vs `/tmp/qa-reports/qa-reports-24418459564/*.json` vuoto (byte-identico)
- [x] Caratteri Unicode preservati: `Cavità Risonanti della Tundra`, `Coscienza d'Alveare Diffusa`, `metà cervello`
- [x] Tutti i path nei `sources` con forward slash: `data/traits/index.json`, `docs/catalog/species_trait_matrix.json`, `data/core/traits/glossary.json`
- [x] `npm run test:api` (eseguito stage-per-stage): 96/96 pass
  - `tests/api/*.test.js`: 73 pass
  - `tests/generation/flow-shell.spec.ts`: 2 pass
  - `tests/server/generationSnapshot.spec.js`: 5 pass
  - `tests/server/orchestrator-bridge.spec.ts`: 3 pass
  - `tests/server/orchestrator-latency.spec.ts`: 1 pass
  - `tests/scripts/tune_items.test.ts`: 3 pass
  - `tests/events/dynamicEvents.e2e.ts`: 1 pass
  - `tests/tools/deploy-checks.spec.js`: 3 pass
  - `tests/api/serviceActorSessions.spec.ts`: 5 pass
- [x] `pytest tests/test_species_builder.py tests/test_generation_orchestrator.py`: 10/10 pass
- [ ] Verificare run di `qa-export.yml` su questo branch dopo il merge: i 3 JSON dovrebbero coincidere byte-identici con quelli generati su Windows

## Rollback plan

Tre file modificati, nessun cambio di schema o di shape dei payload. Revert via `git revert <sha>` riporta esattamente allo stato precedente. Nessuna migrazione, nessun dato persistente toccato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)