### PR TITLE
ci(docs-governance): rimuovi path-filter per evitare il workaround sui fix non-docs

### DIFF
--- a/.github/workflows/docs-governance.yml
+++ b/.github/workflows/docs-governance.yml
@@ -1,18 +1,14 @@
 name: Docs Governance
 
 on:
+  # Run on every push and every PR, regardless of which files changed.
+  # The governance check is a required status on the protected `main` branch,
+  # so limiting the trigger to a path filter (as before) caused non-doc PRs
+  # to be stuck in "skipped" state and blocked from merging without a manual
+  # `gh workflow run docs-governance.yml --ref <branch>` workaround.
+  # The check itself is cheap (~8s), so running it always is fine.
   push:
-    paths:
-      - 'docs/**'
-      - 'tools/check_docs_governance.py'
-      - '.github/workflows/docs-governance.yml'
-      - 'package.json'
   pull_request:
-    paths:
-      - 'docs/**'
-      - 'tools/check_docs_governance.py'
-      - '.github/workflows/docs-governance.yml'
-      - 'package.json'
   schedule:
     - cron: '0 6 * * 1'
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Rimuovo il path-filter dalla trigger `push`/`pull_request` di [`docs-governance.yml`](.github/workflows/docs-governance.yml) così il workflow gira su **ogni** PR, non solo su quelle che toccano `docs/**`.

## Perché

Il workflow esistente aveva:

\`\`\`yaml
on:
  push:
    paths:
      - 'docs/**'
      - 'tools/check_docs_governance.py'
      - '.github/workflows/docs-governance.yml'
      - 'package.json'
  pull_request:
    paths: [ ...stessi path... ]
\`\`\`

Ma il job `governance` è un **required status check** sul branch protetto `main` ([`gh api repos/MasterDD-L34D/Game/branches/main/protection`](https://github.com/MasterDD-L34D/Game/settings/branches)). Le PR che non toccano `docs/**` finiscono in stato \"skipped\" e la branch protection le considera **pending**, bloccando il merge anche quando tutti gli altri check sono verdi.

Situazione reale capitata durante la sessione 2026-04-14 con #1335 (fix QA determinism cross-OS). La PR toccava solo `scripts/export-qa-report.js`, `services/generation/species_builder.py` e `services/generation/worker.py` — nessun file docs. Il workflow `Docs Governance` non è mai partito, `governance` è rimasto pending, il merge era bloccato nonostante tutti i check reali passassero. Il workaround manuale:

\`\`\`bash
gh workflow run docs-governance.yml --ref fix/qa-export-determinism-cross-os
gh pr update-branch 1335
# aspettare ~40 secondi
gh pr merge 1335 --merge --delete-branch
\`\`\`

## Fix

Tolto il path filter dalle due trigger. Il workflow ora parte su tutte le PR e tutti i push. Il check è **cheap**: la run su #1335 ha preso 8 secondi (`Docs governance check` step + `Docs link integrity`). Rispetto al fastidio del workaround manuale a ogni fix non-docs, il costo CI è trascurabile.

Le altre trigger restano invariate:
- `schedule: '0 6 * * 1'` — settimanale, lunedì 6 UTC
- `workflow_dispatch` — manuale

## Alternativa considerata (scartata)

Aggiungere un job `governance-noop` con un `paths-filter` interno che fa no-op `exit 0` quando non ci sono file rilevanti. Più complesso (serve `dorny/paths-filter` o uno script shell), duplica logica, e il risparmio di CI è di ~8 secondi per PR non-docs. Non vale la pena.

## Test plan

- [x] Il workflow file è prettier-clean (pre-commit passa)
- [ ] Questa PR stessa è il primo test reale: il workflow deve girare (ora tocca `.github/workflows/docs-governance.yml`, quindi sarebbe partito anche prima, ma da questa PR in poi partirà indipendentemente dai file toccati)
- [ ] Dopo il merge: qualunque fix futuro che non tocca `docs/**` vedrà `governance: success` invece di `governance: skipped`, senza bisogno di `gh workflow run`

## Rollback plan

Un solo file modificato. Revert via `git revert <sha>` ripristina il path-filter originale. Nessun effetto runtime, nessuna migrazione.

🤖 Generated with [Claude Code](https://claude.com/claude-code)