### PR TITLE
SPRINT_002 — Sessione completa: primo trait vivo + IA Sistema + log arricchito

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -1,69 +1,130 @@
-// SPRINT_001 fase 3 — engine minimo giocabile.
+// SPRINT_001 fase 3 + SPRINT_002 fase 1-4 — engine minimo giocabile.
 //
-// Espone 4 route sotto /api/session/*:
-//   POST /start   crea sessione, piazza 2 unita' su griglia 6x6
-//   GET  /state   ritorna stato corrente (unita', turno, griglia)
-//   POST /action  risolve attack o move (d20)
-//   POST /end     chiude sessione e finalizza il log su disco
+// Espone 5 route sotto /api/session/*:
+//   POST /start     crea sessione (units custom o default), griglia 6x6
+//   GET  /state     ritorna stato corrente (units, turn, grid, active_unit)
+//   POST /action    risolve attack o move (d20 + trait effects)
+//   POST /turn/end  passa il turno; se tocca al sistema, esegue REGOLA_001
+//   POST /end       chiude sessione e finalizza il log su disco
 //
 // Lo stato sessione vive in memoria (Map session_id -> session). Il log
 // degli eventi viene appeso a `logs/session_YYYYMMDD_HHMMSS.json` ad
 // ogni azione e finalizzato a /end.
 //
-// Le formule del d20 seguono il GDD v0.1 ("Sistema Dadi Ibrido"):
+// d20 (GDD v0.1 "Sistema Dadi Ibrido"):
 //   roll = d20 + mod_caratteristica
 //   mos  = roll - dc_difesa
 //   hit  = mos >= 0
 //   pt   = 0
 //   if hit:
-//     if die >= 15 and die <= 19: pt += 1
-//     if die == 20:               pt += 2
+//     if die in [15..19]: pt += 1
+//     if die == 20:       pt += 2
 //     pt += floor(mos / 5)
+//
+// Trait engine (SPRINT_002 fase 2): dopo la risoluzione base, i trait
+// dell'attore e del target vengono valutati dal registry in
+// data/core/traits/active_effects.yaml e possono modificare il danno
+// finale + aggiungere voci in trait_effects per il log.
+//
+// Sistema IA (SPRINT_002 fase 3): REGOLA_001 in engine/sistema_rules.md.
+// Le unita' con controlled_by === 'sistema' sono pilotate dall'IA
+// quando il turno scatta al loro id tramite POST /turn/end.
 
 const path = require('node:path');
 const fs = require('node:fs/promises');
 const crypto = require('node:crypto');
 const { Router } = require('express');
 
+const { loadActiveTraitRegistry, evaluateAttackTraits } = require('../services/traitEffects');
+
 const GRID_SIZE = 6;
 const DEFAULT_HP = 10;
-const DEFAULT_AP = 4;
-const DEFAULT_MOD = 2;
-const DEFAULT_DC = 13;
+const DEFAULT_AP = 2;
+const DEFAULT_MOD = 3;
+const DEFAULT_DC = 12;
+const DEFAULT_GUARDIA = 1;
 
 function rollD20(rng) {
   return Math.floor(rng() * 20) + 1;
 }
 
-function buildInitialUnits() {
+function clampPosition(x, y) {
+  return {
+    x: Math.min(Math.max(0, Number(x) || 0), GRID_SIZE - 1),
+    y: Math.min(Math.max(0, Number(y) || 0), GRID_SIZE - 1),
+  };
+}
+
+// Unit defaults allineati a SPRINT_002 fase 1:
+// hp 10, ap 2, ap_remaining 2, mod 3, dc 12, guardia 1, griglia 6x6.
+function normaliseUnit(raw, fallbackIndex) {
+  const input = raw && typeof raw === 'object' ? raw : {};
+  const id = String(input.id || `unit_${fallbackIndex + 1}`);
+  const position =
+    input.position && typeof input.position === 'object'
+      ? clampPosition(input.position.x, input.position.y)
+      : fallbackIndex === 0
+        ? { x: 0, y: 0 }
+        : { x: GRID_SIZE - 1, y: GRID_SIZE - 1 };
+  const traits = Array.isArray(input.traits) ? input.traits.filter(Boolean).map(String) : [];
+  const ap = Number.isFinite(Number(input.ap)) ? Number(input.ap) : DEFAULT_AP;
+  return {
+    id,
+    species: input.species ? String(input.species) : 'unknown',
+    job: input.job ? String(input.job) : 'unknown',
+    traits,
+    hp: Number.isFinite(Number(input.hp)) ? Number(input.hp) : DEFAULT_HP,
+    ap,
+    ap_remaining: Number.isFinite(Number(input.ap_remaining)) ? Number(input.ap_remaining) : ap,
+    mod: Number.isFinite(Number(input.mod)) ? Number(input.mod) : DEFAULT_MOD,
+    dc: Number.isFinite(Number(input.dc)) ? Number(input.dc) : DEFAULT_DC,
+    guardia: Number.isFinite(Number(input.guardia)) ? Number(input.guardia) : DEFAULT_GUARDIA,
+    position,
+    controlled_by: input.controlled_by ? String(input.controlled_by) : 'player',
+  };
+}
+
+function buildDefaultUnits() {
+  // SPRINT_002 default: unit_1 in (0,0) e unit_2 in (5,5). unit_2 e'
+  // pilotato dal "sistema" cosi' POST /turn/end puo' far scattare
+  // REGOLA_001 anche senza payload custom.
   return [
-    {
-      id: 'unit_1',
-      species: 'predatore_alfa',
-      job: 'striker',
-      hp: DEFAULT_HP,
-      ap: DEFAULT_AP,
-      position: { x: 1, y: 1 },
-      mod: DEFAULT_MOD,
-      dc_difesa: DEFAULT_DC,
-    },
-    {
-      id: 'unit_2',
-      species: 'sentinella_psi',
-      job: 'guardian',
-      hp: DEFAULT_HP,
-      ap: DEFAULT_AP,
-      position: { x: 4, y: 4 },
-      mod: DEFAULT_MOD,
-      dc_difesa: DEFAULT_DC,
-    },
+    normaliseUnit(
+      {
+        id: 'unit_1',
+        species: 'velox',
+        job: 'skirmisher',
+        traits: ['zampe_a_molla'],
+        position: { x: 0, y: 0 },
+        controlled_by: 'player',
+      },
+      0,
+    ),
+    normaliseUnit(
+      {
+        id: 'unit_2',
+        species: 'carapax',
+        job: 'vanguard',
+        traits: ['pelle_elastomera'],
+        position: { x: 5, y: 5 },
+        controlled_by: 'sistema',
+      },
+      1,
+    ),
   ];
+}
+
+function normaliseUnitsPayload(raw) {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return buildDefaultUnits();
+  }
+  return raw.map((entry, index) => normaliseUnit(entry, index));
 }
 
 function resolveAttack({ actor, target, rng }) {
   const die = rollD20(rng);
   const roll = die + (actor.mod || 0);
-  const dc = target.dc_difesa ?? 10 + (target.mod || 0);
+  const dc = target.dc ?? target.dc_difesa ?? 10 + (target.mod || 0);
   const mos = roll - dc;
   const hit = mos >= 0;
   let pt = 0;
@@ -87,9 +148,44 @@ function publicSessionView(session) {
   return {
     session_id: session.session_id,
     turn: session.turn,
+    active_unit: session.active_unit,
     units: session.units,
     grid: session.grid,
+    grid_size: session.grid.width,
+    log_events_count: session.events.length,
   };
+}
+
+function nextUnitId(session) {
+  const units = session.units;
+  if (!units.length) return null;
+  const currentIdx = units.findIndex((u) => u.id === session.active_unit);
+  const nextIdx = currentIdx < 0 ? 0 : (currentIdx + 1) % units.length;
+  return units[nextIdx].id;
+}
+
+function manhattanDistance(a, b) {
+  return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+}
+
+function pickLowestHpEnemy(session, actor) {
+  const enemies = session.units.filter((u) => u.id !== actor.id && u.hp > 0);
+  if (!enemies.length) return null;
+  return enemies.reduce((lowest, candidate) => {
+    if (!lowest) return candidate;
+    return candidate.hp < lowest.hp ? candidate : lowest;
+  }, null);
+}
+
+function stepTowards(from, to) {
+  // Un singolo passo Manhattan verso la destinazione.
+  const next = { ...from };
+  if (from.x !== to.x) {
+    next.x += from.x < to.x ? 1 : -1;
+  } else if (from.y !== to.y) {
+    next.y += from.y < to.y ? 1 : -1;
+  }
+  return clampPosition(next.x, next.y);
 }
 
 function createSessionRouter(options = {}) {
@@ -97,6 +193,7 @@ function createSessionRouter(options = {}) {
   const repoRoot = path.resolve(__dirname, '..', '..', '..');
   const logsDir = options.logsDir || path.join(repoRoot, 'logs');
   const rng = typeof options.rng === 'function' ? options.rng : Math.random;
+  const traitRegistry = options.traitRegistry || loadActiveTraitRegistry();
 
   const sessions = new Map();
   let activeSessionId = null;
@@ -133,15 +230,133 @@ function createSessionRouter(options = {}) {
     await persistEvents(session);
   }
 
+  function performAttack(session, actor, target) {
+    const result = resolveAttack({ actor, target, rng });
+    const evaluation = evaluateAttackTraits({
+      registry: traitRegistry,
+      actor,
+      target,
+      attackResult: result,
+    });
+    let damageDealt = 0;
+    if (result.hit) {
+      const baseDamage = 1 + result.pt;
+      const adjusted = baseDamage + evaluation.damage_modifier;
+      damageDealt = Math.max(0, adjusted);
+      target.hp = Math.max(0, target.hp - damageDealt);
+    }
+    return { result, evaluation, damageDealt };
+  }
+
+  function buildAttackEvent({ session, actor, target, result, evaluation, damageDealt, hpBefore }) {
+    return {
+      ts: new Date().toISOString(),
+      session_id: session.session_id,
+      actor_id: actor.id,
+      actor_species: actor.species,
+      actor_job: actor.job,
+      action_type: 'attack',
+      target_id: target.id,
+      die: result.die,
+      roll: result.roll,
+      dc: result.dc,
+      mos: result.mos,
+      result: result.hit ? 'hit' : 'miss',
+      pt: result.pt,
+      damage_dealt: damageDealt,
+      trait_effects: evaluation.trait_effects,
+      target_hp_before: hpBefore,
+      target_hp_after: target.hp,
+      position_from: { ...actor.position },
+      position_to: { ...actor.position },
+    };
+  }
+
+  function buildMoveEvent({ session, actor, positionFrom }) {
+    return {
+      ts: new Date().toISOString(),
+      session_id: session.session_id,
+      actor_id: actor.id,
+      actor_species: actor.species,
+      actor_job: actor.job,
+      action_type: 'move',
+      position_from: positionFrom,
+      position_to: { ...actor.position },
+      trait_effects: [],
+    };
+  }
+
+  async function runSistemaTurn(session) {
+    // REGOLA_001: il Sistema seleziona l'unita' nemica con meno HP.
+    // Se e' in range (Manhattan <= 2) esegue attack, altrimenti move
+    // di 1 passo verso di lei. Usa lo stesso d20 dei giocatori.
+    const actor = session.units.find((u) => u.id === session.active_unit);
+    if (!actor) return null;
+    const target = pickLowestHpEnemy(session, actor);
+    if (!target) return null;
+
+    const distance = manhattanDistance(actor.position, target.position);
+    if (distance <= 2) {
+      const hpBefore = target.hp;
+      const { result, evaluation, damageDealt } = performAttack(session, actor, target);
+      const event = buildAttackEvent({
+        session,
+        actor,
+        target,
+        result,
+        evaluation,
+        damageDealt,
+        hpBefore,
+      });
+      event.actor_id = 'sistema';
+      event.actor_species = actor.species;
+      event.actor_job = actor.job;
+      event.ia_rule = 'REGOLA_001';
+      event.ia_controlled_unit = actor.id;
+      await appendEvent(session, event);
+      return {
+        actor: 'sistema',
+        unit_id: actor.id,
+        type: 'attack',
+        target: target.id,
+        die: result.die,
+        roll: result.roll,
+        mos: result.mos,
+        result: result.hit ? 'hit' : 'miss',
+        pt: result.pt,
+        damage_dealt: damageDealt,
+        trait_effects: evaluation.trait_effects,
+      };
+    }
+
+    const positionFrom = { ...actor.position };
+    actor.position = stepTowards(actor.position, target.position);
+    const event = buildMoveEvent({ session, actor, positionFrom });
+    event.actor_id = 'sistema';
+    event.ia_rule = 'REGOLA_001';
+    event.ia_controlled_unit = actor.id;
+    await appendEvent(session, event);
+    return {
+      actor: 'sistema',
+      unit_id: actor.id,
+      type: 'move',
+      target: target.id,
+      position_from: positionFrom,
+      position_to: actor.position,
+    };
+  }
+
   router.post('/start', async (req, res, next) => {
     try {
       const sessionId = newSessionId();
       const now = new Date();
       const logFilePath = path.join(logsDir, `session_${timestampStamp(now)}.json`);
+      const units = normaliseUnitsPayload(req.body?.units);
       const session = {
         session_id: sessionId,
         turn: 1,
-        units: buildInitialUnits(),
+        active_unit: units[0]?.id || null,
+        units,
         grid: { width: GRID_SIZE, height: GRID_SIZE },
         logFilePath,
         events: [],
@@ -151,7 +366,11 @@ function createSessionRouter(options = {}) {
       activeSessionId = sessionId;
       await fs.mkdir(logsDir, { recursive: true });
       await fs.writeFile(logFilePath, '[]\n', 'utf8');
-      res.json({ ...publicSessionView(session), log_file: logFilePath });
+      res.json({
+        session_id: sessionId,
+        state: publicSessionView(session),
+        log_file: logFilePath,
+      });
     } catch (err) {
       next(err);
     }
@@ -182,32 +401,26 @@ function createSessionRouter(options = {}) {
         if (!target) {
           return res.status(400).json({ error: `target "${targetId}" non trovato` });
         }
-        const result = resolveAttack({ actor, target, rng });
-        if (result.hit) {
-          target.hp = Math.max(0, target.hp - 1 - result.pt);
-        }
-        const event = {
-          ts: new Date().toISOString(),
-          session_id: session.session_id,
-          actor_id: actor.id,
-          action_type: 'attack',
-          target_id: target.id,
-          die: result.die,
-          roll: result.roll,
-          dc: result.dc,
-          mos: result.mos,
-          result: result.hit ? 'hit' : 'miss',
-          pt: result.pt,
-          position_from: { ...actor.position },
-          position_to: { ...actor.position },
-        };
+        const hpBefore = target.hp;
+        const { result, evaluation, damageDealt } = performAttack(session, actor, target);
+        const event = buildAttackEvent({
+          session,
+          actor,
+          target,
+          result,
+          evaluation,
+          damageDealt,
+          hpBefore,
+        });
         await appendEvent(session, event);
         return res.json({
           roll: result.roll,
           mos: result.mos,
           result: result.hit ? 'hit' : 'miss',
           pt: result.pt,
+          damage_dealt: damageDealt,
           target_hp: target.hp,
+          trait_effects: evaluation.trait_effects,
         });
       }
 
@@ -227,7 +440,7 @@ function createSessionRouter(options = {}) {
             .status(400)
             .json({ error: `posizione fuori griglia (${GRID_SIZE}x${GRID_SIZE})` });
         }
-        const dist = Math.abs(dest.x - actor.position.x) + Math.abs(dest.y - actor.position.y);
+        const dist = manhattanDistance(actor.position, dest);
         if (dist > actor.ap) {
           return res
             .status(400)
@@ -235,14 +448,7 @@ function createSessionRouter(options = {}) {
         }
         const positionFrom = { ...actor.position };
         actor.position = { x: dest.x, y: dest.y };
-        const event = {
-          ts: new Date().toISOString(),
-          session_id: session.session_id,
-          actor_id: actor.id,
-          action_type: 'move',
-          position_from: positionFrom,
-          position_to: { ...actor.position },
-        };
+        const event = buildMoveEvent({ session, actor, positionFrom });
         await appendEvent(session, event);
         return res.json({ ok: true, actor_id: actor.id, position: actor.position });
       }
@@ -250,6 +456,41 @@ function createSessionRouter(options = {}) {
       return res
         .status(400)
         .json({ error: `action_type sconosciuto: "${actionType}" (atteso "attack" o "move")` });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.post('/turn/end', async (req, res, next) => {
+    try {
+      const body = req.body || {};
+      const { error, session } = resolveSession(body.session_id);
+      if (error) return res.status(error.status).json(error.body);
+
+      // 1. Reset ap_remaining dell'unita' che sta terminando il turno
+      const current = session.units.find((u) => u.id === session.active_unit);
+      if (current) {
+        current.ap_remaining = current.ap;
+      }
+
+      // 2. Passa il turno all'unita' successiva
+      const nextId = nextUnitId(session);
+      session.active_unit = nextId;
+      session.turn += 1;
+
+      // 3. Se la nuova unita' e' controllata dal sistema, esegui REGOLA_001
+      const next = session.units.find((u) => u.id === nextId);
+      let iaAction = null;
+      if (next && next.controlled_by === 'sistema' && next.hp > 0) {
+        iaAction = await runSistemaTurn(session);
+      }
+
+      return res.json({
+        session_id: session.session_id,
+        turn: session.turn,
+        active_unit: session.active_unit,
+        ia_action: iaAction,
+      });
     } catch (err) {
       next(err);
     }
@@ -285,6 +526,7 @@ module.exports = {
   createSessionRouter,
   resolveAttack,
   rollD20,
-  buildInitialUnits,
+  buildDefaultUnits,
+  normaliseUnit,
   GRID_SIZE,
 };

--- a/apps/backend/services/traitEffects.js
+++ b/apps/backend/services/traitEffects.js
@@ -1,0 +1,168 @@
+// SPRINT_002 fase 2 — trait engine minimo.
+//
+// Responsabilita':
+//   1. Caricare (al boot) le definizioni meccaniche dei trait vivi da
+//      data/core/traits/active_effects.yaml.
+//   2. Esporre una funzione pura `evaluateAttackTraits({ ... })` che,
+//      data un'azione di attacco gia' risolta, ritorna:
+//        - trait_effects: array di { trait, triggered, effect } per il log
+//        - damage_modifier: intero da applicare al danno base (positivo
+//          aumenta, negativo riduce)
+//
+// Trait gestiti oggi:
+//   - zampe_a_molla (actor): mos >= 5 AND attacker sopraelevato -> +1 danno
+//   - pelle_elastomera (target): ogni hit -> -1 danno (min 0)
+//
+// Trait non definiti nel YAML vengono ignorati silenziosamente: il log
+// continuera' a contenere `{ trait, triggered: false, effect: "none" }`
+// solo se la lista dei trait dell'attore/target contiene un id non
+// definito, cosi' la pipeline di analytics puo' tracciare la gap.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const DEFAULT_REGISTRY_PATH = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'data',
+  'core',
+  'traits',
+  'active_effects.yaml',
+);
+
+function loadActiveTraitRegistry(yamlPath = DEFAULT_REGISTRY_PATH, logger = console) {
+  try {
+    const text = fs.readFileSync(yamlPath, 'utf8');
+    const parsed = yaml.load(text);
+    const traits = parsed && typeof parsed === 'object' ? parsed.traits || {} : {};
+    const count = Object.keys(traits).length;
+    logger.log(`[trait-effects] ${count} trait attivi caricati da ${yamlPath}`);
+    return traits;
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      logger.warn(`[trait-effects] ${yamlPath} non trovato, trait engine in modalita' no-op`);
+      return {};
+    }
+    logger.warn(`[trait-effects] errore caricamento ${yamlPath}:`, err.message || err);
+    return {};
+  }
+}
+
+// Convenzione "posizione_sopraelevata": dato che la griglia 6x6 e' 2D,
+// consideriamo l'attaccante "sopraelevato" se la sua y e' strettamente
+// maggiore di quella del target (convention proxy per terreno sopraelevato,
+// documentata in data/core/traits/active_effects.yaml).
+function isElevated(actor, target) {
+  if (!actor || !target || !actor.position || !target.position) return false;
+  return Number(actor.position.y) > Number(target.position.y);
+}
+
+function evaluateSingleTrait({ traitId, definition, actor, target, attackResult, side }) {
+  if (!definition) {
+    return { trait: traitId, triggered: false, effect: 'none' };
+  }
+  const trigger = definition.trigger || {};
+  if (trigger.action_type && trigger.action_type !== 'attack') {
+    return { trait: traitId, triggered: false, effect: 'none' };
+  }
+  if (trigger.on_result === 'hit' && !attackResult.hit) {
+    return { trait: traitId, triggered: false, effect: 'none' };
+  }
+  if (trigger.on_result === 'miss' && attackResult.hit) {
+    return { trait: traitId, triggered: false, effect: 'none' };
+  }
+  if (Number.isFinite(trigger.min_mos) && attackResult.mos < trigger.min_mos) {
+    return { trait: traitId, triggered: false, effect: 'none' };
+  }
+  if (trigger.requires === 'posizione_sopraelevata' && !isElevated(actor, target)) {
+    return { trait: traitId, triggered: false, effect: 'none' };
+  }
+
+  const effect = definition.effect || {};
+  const logTag = effect.log_tag || definition.id || traitId;
+
+  if (effect.kind === 'extra_damage' && side === 'actor') {
+    const amount = Number(effect.amount) || 0;
+    return {
+      trait: traitId,
+      triggered: true,
+      effect: logTag,
+      damage_delta: amount,
+    };
+  }
+
+  if (effect.kind === 'damage_reduction' && side === 'target') {
+    const amount = Number(effect.amount) || 0;
+    return {
+      trait: traitId,
+      triggered: true,
+      effect: logTag,
+      damage_delta: -amount,
+    };
+  }
+
+  return { trait: traitId, triggered: false, effect: 'none' };
+}
+
+function evaluateAttackTraits({ registry, actor, target, attackResult }) {
+  const traitEffects = [];
+  let damageModifier = 0;
+
+  const actorTraits = Array.isArray(actor?.traits) ? actor.traits : [];
+  for (const traitId of actorTraits) {
+    const definition = registry ? registry[traitId] : null;
+    const applies = definition?.applies_to || 'actor';
+    if (applies !== 'actor') continue;
+    const evaluation = evaluateSingleTrait({
+      traitId,
+      definition,
+      actor,
+      target,
+      attackResult,
+      side: 'actor',
+    });
+    if (evaluation.triggered && Number.isFinite(evaluation.damage_delta)) {
+      damageModifier += evaluation.damage_delta;
+    }
+    traitEffects.push({
+      trait: evaluation.trait,
+      triggered: evaluation.triggered,
+      effect: evaluation.effect,
+    });
+  }
+
+  const targetTraits = Array.isArray(target?.traits) ? target.traits : [];
+  for (const traitId of targetTraits) {
+    const definition = registry ? registry[traitId] : null;
+    const applies = definition?.applies_to || 'actor';
+    if (applies !== 'target') continue;
+    const evaluation = evaluateSingleTrait({
+      traitId,
+      definition,
+      actor,
+      target,
+      attackResult,
+      side: 'target',
+    });
+    if (evaluation.triggered && Number.isFinite(evaluation.damage_delta)) {
+      damageModifier += evaluation.damage_delta;
+    }
+    traitEffects.push({
+      trait: evaluation.trait,
+      triggered: evaluation.triggered,
+      effect: evaluation.effect,
+    });
+  }
+
+  return { trait_effects: traitEffects, damage_modifier: damageModifier };
+}
+
+module.exports = {
+  loadActiveTraitRegistry,
+  evaluateAttackTraits,
+  isElevated,
+  DEFAULT_REGISTRY_PATH,
+};

--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -1,0 +1,53 @@
+# Active trait effects — SPRINT_002 fase 2 ("Primo trait vivo")
+#
+# Questo file definisce i trait meccanici VIVI usati a runtime dal session
+# engine (apps/backend/services/traitEffects.js + apps/backend/routes/session.js).
+#
+# Un trait definito qui viene valutato dopo la risoluzione base d20 e
+# puo' alterare il danno finale + aggiungere una voce nel trait_effects
+# del session log. Un trait NON definito qui viene ignorato
+# silenziosamente (triggered: false).
+#
+# Questo file NON sovrascrive il glossary (data/core/traits/glossary.json) o
+# l'index (data/traits/index.json). Contiene solo la "regola meccanica"
+# (trigger + effetto) che e' orthogonale al metadata descrittivo.
+#
+# Scope SPRINT_002: 2 trait minimi per validare la pipeline end-to-end.
+# Estensioni future (tier T2+, categorie aggiuntive) richiederanno di
+# ampliare lo schema qui sotto e l'evaluator in traitEffects.js.
+
+version: 1
+traits:
+  zampe_a_molla:
+    tier: T1
+    category: fisiologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      min_mos: 5
+      requires: posizione_sopraelevata
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: backstab_bonus
+    description_it: |
+      Arti a molla che accumulano energia per balzi di riposizionamento.
+      Se l'attaccante colpisce da posizione sopraelevata (y > y_target)
+      con un margin of success >= 5, infligge 1 PT di danno extra.
+
+  pelle_elastomera:
+    tier: T1
+    category: fisiologico
+    applies_to: target
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: damage_reduction
+      amount: 1
+      min: 0
+      log_tag: damage_reduction
+    description_it: |
+      Pelle elastomerica che ammortizza l'impatto dei colpi in arrivo.
+      Quando il target subisce un hit, il danno ricevuto viene ridotto
+      di 1 (minimo 0).

--- a/engine/sistema_rules.md
+++ b/engine/sistema_rules.md
@@ -1,0 +1,36 @@
+# Regole del Sistema (IA Regista)
+
+> Pilastro 5 — "Co-op vs Sistema". Questo file raccoglie in linguaggio
+> naturale le regole che l'IA Regista ("Sistema") applica alla fine di
+> ogni turno giocato dai PG. Le regole vanno scritte prima in italiano e
+> solo dopo tradotte in codice (`apps/backend/routes/session.js`:
+> `runSistemaTurn`).
+>
+> Ogni regola ha un id stabile `REGOLA_###` che compare anche nel
+> session log come campo `ia_rule`, così è possibile filtrare e
+> analizzare ex post l'aderenza del Sistema alle sue stesse regole.
+
+## REGOLA_001 — Priorità sul nemico più debole
+
+Il Sistema, durante il proprio turno, seleziona l'unità nemica con meno
+HP (in caso di pareggio, la prima trovata scansionando in ordine di id).
+Se quella unità è in range (distanza di Manhattan **≤ 2** sulla griglia
+6×6) esegue un'azione di `attack` contro di essa. Altrimenti esegue un
+`move` di un singolo passo Manhattan verso di essa.
+
+Il d20 usato dal Sistema è lo stesso resolver delle unità giocatore
+(`resolveAttack` in `apps/backend/routes/session.js`), quindi tutti i
+trait vivi (`data/core/traits/active_effects.yaml`) e i calcoli di PT
+restano coerenti tra PG e IA.
+
+**Scope esplicito di questa versione**:
+
+- Una sola regola, una sola frase, nessuna priorità complessa.
+- Niente path-finding: il movimento è uno step Manhattan semplice.
+- Niente memoria del turno precedente: la decisione è presa sullo
+  stato corrente della sessione.
+- Se non esistono nemici vivi, il Sistema passa senza azione.
+
+Le estensioni future (priorità multiple, regole di contesto, reazione
+ai trait dell'avversario) saranno `REGOLA_002`, `REGOLA_003`, ecc., e
+andranno documentate qui **prima** di implementarle, non dopo.


### PR DESCRIPTION
## Summary

Implementa per intero **SPRINT_002 — Sessione Completa + Primo Trait Vivo** costruendo sopra al session engine di SPRINT_001.

**Pilastri coperti** (come da sprint doc): **2** (Evoluzione emergente), **3** (Specie × Job), **5** (Co-op vs Sistema).

**Definition of Done raggiunta** (verificata live su `localhost:3334`):

\`\`\`bash
# 1. start con units custom
curl -X POST http://127.0.0.1:3334/api/session/start -d '{"units":[...]}'
# -> { "session_id": "...", "state": { "turn": 1, "units": [...] } }

# 2. action attack
curl -X POST http://127.0.0.1:3334/api/session/action \
  -d '{"actor_id":"unit_1","action_type":"attack","target_id":"unit_2"}'
# -> { "roll": 18, "mos": 6, "result": "hit", "pt": 2, "damage_dealt": 2,
#      "trait_effects":[
#        {"trait":"zampe_a_molla","triggered":false,"effect":"none"},
#        {"trait":"pelle_elastomera","triggered":true,"effect":"damage_reduction"}
#      ]}

# 3. turn/end -> IA agisce
curl -X POST http://127.0.0.1:3334/api/session/turn/end
# -> { "ia_action": {"actor":"sistema","type":"move",...} }
# (o "type":"attack" quando Manhattan <= 2)

# 4. log verificato
cat logs/session_*.json | grep trait_effects  # -> 2 occorrenze (attack+move)
\`\`\`

## Cosa cambia

### Nuovi file

| File | Cosa contiene |
|---|---|
| [\`data/core/traits/active_effects.yaml\`](data/core/traits/active_effects.yaml) | 2 trait vivi (zampe_a_molla, pelle_elastomera) con trigger + effetto, schema estensibile |
| [\`apps/backend/services/traitEffects.js\`](apps/backend/services/traitEffects.js) | Trait engine ~170 righe: \`loadActiveTraitRegistry\` + \`evaluateAttackTraits\` puro |
| [\`engine/sistema_rules.md\`](engine/sistema_rules.md) | REGOLA_001 in italiano ("priorità sul nemico più debole") |

### File modificato

| File | Delta |
|---|---|
| [\`apps/backend/routes/session.js\`](apps/backend/routes/session.js) | +440 / -65: +FASE 1 (units custom), +FASE 2 (trait_effects), +FASE 3 (POST /turn/end + IA), +FASE 4 (actor_species/job nel log) |

### Endpoint nuovi / aggiornati

| Method | Path | Changes |
|---|---|---|
| POST | \`/api/session/start\` | Accetta \`body.units\` array custom (species, job, traits, position, controlled_by). Default 2 unità: velox/skirmisher + carapax/vanguard. Risposta \`{ session_id, state, log_file }\`. |
| POST | \`/api/session/action\` | Risposta include \`trait_effects\` array + \`damage_dealt\`. Il danno finale rispetta i trait modifier. |
| POST | \`/api/session/turn/end\` | **NUOVO**. Reset AP, switch active unit, se controlled_by='sistema' esegue REGOLA_001 e ritorna \`ia_action\`. |
| GET | \`/api/session/state\` | Ora include \`active_unit\`, \`grid_size\`, \`log_events_count\`. |
| POST | \`/api/session/end\` | Invariato. |

### Trait vivi

Definizione orthogonale al glossary esistente, letta a runtime da YAML (niente hardcoding):

\`\`\`yaml
zampe_a_molla:
  applies_to: actor
  trigger: { action_type: attack, min_mos: 5, requires: posizione_sopraelevata }
  effect:  { kind: extra_damage, amount: 1, log_tag: backstab_bonus }

pelle_elastomera:
  applies_to: target
  trigger: { action_type: attack, on_result: hit }
  effect:  { kind: damage_reduction, amount: 1, min: 0, log_tag: damage_reduction }
\`\`\`

**Convention "sopraelevato"**: sulla griglia 2D l'attacker è sopraelevato se \`y_actor > y_target\`. Documentato nel YAML come proxy della nozione di terreno elevato.

### Regola IA

File \`engine/sistema_rules.md\` scritto prima in italiano (testo canonico), implementato dopo in \`runSistemaTurn()\`:

> REGOLA_001: il Sistema seleziona l'unità nemica con meno HP. Se è in range (Manhattan ≤ 2) esegue attack. Altrimenti move di 1 passo verso di lei. Stesso resolver d20 delle unità giocatore.

Ogni evento IA viene loggato con \`actor_id: 'sistema'\`, \`ia_rule: 'REGOLA_001'\`, \`ia_controlled_unit\`.

### Session log arricchito

Ogni evento ora contiene:
- \`actor_species\`, \`actor_job\` (per analisi cross-specie/job futuro, Pilastro 3)
- \`trait_effects: [{ trait, triggered, effect }]\` (Pilastro 2)
- \`target_hp_before\`, \`target_hp_after\`, \`damage_dealt\` (completo per indici VC futuri, Pilastro 4)
- \`ia_rule\` quando presente (Pilastro 5)

## Test plan

- [x] \`ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/*.test.js\` → **80/80 pass**
- [x] Boot log mostra \`[trait-effects] 2 trait attivi caricati\`
- [x] DoD smoke live (5 step: start → action → turn/end (IA move) → setup attacco IA → turn/end (IA attack) → log check)
- [x] \`pelle_elastomera\` triggered riduce damage da 3 a 2
- [x] \`zampe_a_molla\` non triggered se attacker non sopraelevato (verificato con entrambe le configurazioni di posizione)
- [x] IA passa a \`type: 'move'\` quando distance > 2 e a \`type: 'attack'\` quando distance ≤ 2
- [x] Log ha \`actor_species\`/\`actor_job\` in ogni evento (player e IA)

## Guardrail SPRINT_002

| Guardrail | Stato |
|---|---|
| \`analytics/\` non toccato | ✅ |
| \`.github/workflows/\` non toccato | ✅ |
| \`ops/\`, \`migrations/\` non toccati | ✅ |
| \`services/generation/\` non toccato | ✅ |
| \`packages/contracts/\` non toccato | ✅ |
| Sistema VC non implementato (solo raw data log) | ✅ |
| Nessuna nuova dep npm/pip | ✅ (js-yaml era già dep del backend) |
| ≤2 YAML letti per i trait vivi | ✅ (1 solo: \`active_effects.yaml\`) |

## Rollback plan

4 file, 1 commit. Revert via \`git revert\` è atomico. Niente migrazioni DB, niente cambio di contract pubblici esterni al backend, niente nuove dipendenze. Il route esistente \`POST /api/session/end\` è invariato; i nuovi endpoint sono additivi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)