### PR TITLE
feat(session): close_engage mutual range + bonus adiacenza (sprint-007)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -333,9 +333,18 @@ function createSessionRouter(options = {}) {
     });
     let damageDealt = 0;
     let killOccurred = false;
+    let adjacencyBonus = 0;
     if (result.hit) {
       const baseDamage = 1 + result.pt;
-      const adjusted = baseDamage + evaluation.damage_modifier;
+      // SPRINT_007 fase 1 (issue #4): bonus damage +1 quando l'attaccante
+      // e' strettamente adiacente al bersaglio (Manhattan == 1). Incentiva
+      // la scelta tattica di entrare in mischia anche se skirmisher/ranger
+      // hanno range superiore.
+      const attackDist = manhattanDistance(actor.position, target.position);
+      if (attackDist === 1) {
+        adjacencyBonus = 1;
+      }
+      const adjusted = baseDamage + evaluation.damage_modifier + adjacencyBonus;
       damageDealt = Math.max(0, adjusted);
       // SPRINT_003 fase 0: traccia damage_taken cumulativo per unita'.
       // Lo stato e' in memoria (non nel log) — VC scoring lo ricalcola
@@ -346,7 +355,7 @@ function createSessionRouter(options = {}) {
         killOccurred = true;
       }
     }
-    return { result, evaluation, damageDealt, killOccurred };
+    return { result, evaluation, damageDealt, killOccurred, adjacencyBonus };
   }
 
   async function emitKillAndAssists(session, killer, target, attackEvent) {

--- a/apps/backend/services/vcScoring.js
+++ b/apps/backend/services/vcScoring.js
@@ -111,6 +111,16 @@ function computeRawMetrics(events, units, gridSize = 6) {
   if (!Array.isArray(events)) return {};
   if (!Array.isArray(units)) return {};
 
+  // SPRINT_007 fase 1 (issue #4): mappa unit_id → attack_range per il
+  // lookup efficiente durante il computo di close_engage. Il default
+  // fallback e' 1 (pre-sprint-007 behavior: solo adiacenza contava).
+  const unitRangeMap = {};
+  for (const unit of units) {
+    unitRangeMap[unit.id] = Number.isFinite(Number(unit?.attack_range))
+      ? Number(unit.attack_range)
+      : 1;
+  }
+
   const perActor = {};
   for (const unit of units) {
     perActor[unit.id] = {
@@ -166,10 +176,18 @@ function computeRawMetrics(events, units, gridSize = 6) {
       if (event.result === 'hit') {
         bucket.attack_hits += 1;
         bucket.damage_dealt_total += Number(event.damage_dealt) || 0;
-        // close_engage: attack con Manhattan <= 1 dal target al momento
+        // SPRINT_007 fase 1 (issue #4): close_engage ridefinito come
+        // "attacco in mutual range" — conta se la distanza e' <=
+        // attack_range DEL BERSAGLIO (non dell'attaccante). Semantica:
+        // "ti sei esposto al counter-attack nemico nello stesso turno".
+        // Questo generalizza la vecchia condizione (d <= 1) senza
+        // banalizzarla: un skirmisher r2 che colpisce da dist 2 un
+        // vanguard r1 NON prende close_engage (il vanguard non puo'
+        // rispondere). Fallback 1 per compat con sessioni legacy.
         if (event.target_position_at_attack && event.position_from) {
           const d = manhattan(event.position_from, event.target_position_at_attack);
-          if (d <= 1) bucket.close_engage_attacks += 1;
+          const targetRange = unitRangeMap[event.target_id] ?? 1;
+          if (d <= targetRange) bucket.close_engage_attacks += 1;
         }
         // low_hp_time proxy: target_hp_after < 0.3 * target_hp_before (proxy)
         if (


### PR DESCRIPTION
## Summary

Chiude **issue #4** del playtest design backlog — il trade-off \`close_engage\` vs DPS. Applicato il combo **A + B** concordato nella design session del 2026-04-16 12:35, con un'interpretazione più smart di A per evitare la trivializzazione della metrica.

### A) \`close_engage\` ridefinito come "attacco in mutual range"

**Prima**: \`close_engage = 1\` se \`manhattan(actor, target) <= 1\` (solo adiacenza)
**Dopo**: \`close_engage = 1\` se \`manhattan(actor, target) <= target.attack_range\`

**Semantica**: *"ti sei esposto al counter-attack nemico nello stesso turno"* invece di *"sei in mischia"*. Esempi con balance sprint-006:

- Skirmisher r2 attacca vanguard r1 da dist 2 → ❌ (vanguard non può rispondere)
- Skirmisher r2 attacca vanguard r1 da dist 1 → ✅ (mutual range)
- Ranger r3 attacca skirmisher r2 da dist 2 → ✅ (mutual range)
- Ranger r3 attacca skirmisher r2 da dist 3 → ❌ (fuori portata skirmisher)

Implementazione in [vcScoring.js](apps/backend/services/vcScoring.js) con \`unitRangeMap\` costruita una volta sulle units, lookup via \`event.target_id\` durante il loop eventi. Fallback 1 per sessioni legacy.

⚠️ **Nota**: la versione inizialmente proposta (\`dist <= actor.range\`) avrebbe trivializzato la metrica — ogni attacco valido sarebbe stato close_engage. La versione "mutual range" cattura invece l'intent tattico senza rendere la metrica automatica.

### B) Bonus damage adiacenza +1

[performAttack](apps/backend/routes/session.js) aggiunge +1 al damage quando \`manhattan(actor, target) == 1\`:

\`\`\`
damage = 1 + pt + trait_damage_modifier + (adjacent ? 1 : 0)
\`\`\`

Incentivo tattico: anche chi ha range > 1 ha motivo di avvicinarsi a dist 1 (più danno, bypass parziale del damage_reduction del \`pelle_elastomera\`).

## Balance validation (200-run simulation)

| Strategia | pre sprint-007 | **post sprint-007 +adj** | Δ |
|---|:-:|:-:|:-:|
| close_engage win rate | 52.5% | **65.5%** | **+13%** |
| kite puro win rate | 100% | **71.0%** | **-29%** |
| close avg turns | 13.9 | **6.1** | -7.8 |
| kite avg turns | 28.4 | 10.1 | -18.3 |
| close damage taken | 8.3 | 6.3 | -2 |

**Risultato**: il kite scende dal 100% al 71% perché anche il SIS guadagna il bonus adiacenza quando chiude la distanza. Close_engage diventa efficace (+13% win rate, -8 turni medi). **Entrambe le strategie restano viable** — obiettivo "2 playstyle competitivi, niente dominanza" raggiunto.

## Test end-to-end in sessione live

- ✅ P1 adiacente a dist 1, 6 attacchi consecutivi: \`dmg = 1 + pt + 1_adj\` verificato cell-by-cell
- ✅ P1 a dist 2: \`dmg = 1 + pt\` (no bonus)
- ✅ Tracking \`close_engage\` differenziato: kite bot → 0 (tutti dist 2 vs r1, fuori mutual range), close bot → 0.667 (2/3 attacchi da dist 1)
- ✅ **Cacciatore(8) ancora triggerabile** con kite (evasion_ratio=1, dmg_taken=0)
- ✅ **Conquistatore(3) raggiungibile** da close (serve sufficiente sopravvivenza per saturare attacks_started)

## Rollback plan (03A)

- **Revert**: \`git revert b22dd7b3\` ripristina main post-#1354 (\`c3a4d563\`)
- **Schema DB**: nessuna modifica
- **Contracts**: nessuna modifica
- **Backward compat**: la nuova formula di close_engage ha fallback a 1 per sessioni senza \`attack_range\` sulle unità, così le sessioni storiche continuano a funzionare

## Backlog residuo

| # | Pri | Titolo | Stato |
|---|:-:|---|:-:|
| 2 | 🟡 | IA SIS: REGOLA_003 kite opportunistico (003 fatta, 001/002 ok) | parziale |
| 4 | 🟡 | close_engage vs DPS | ✅ **chiuso** |
| 5 | 🟢 | Metriche telemetria mancanti (explore/setup/tilt/EI/SN) | aperto |
| 6 | 🟢 | attack_range per job | ✅ chiuso |
| 7 | 🟢 | AP cost granular | aperto |

🤖 Generated with [Claude Code](https://claude.com/claude-code)