### PR TITLE
feat(vc-scoring): metriche 1vX + new_tiles (sprint-011 / issue #5)

### DIFF
--- a/apps/backend/services/vcScoring.js
+++ b/apps/backend/services/vcScoring.js
@@ -59,6 +59,13 @@ const DERIVABLE_RAW_KEYS = new Set([
   // evasion_ratio = attacchi seguiti (nello stesso turno) da una
   // move che aumenta la distanza dal bersaglio / attacchi totali.
   'evasion_ratio',
+  // SPRINT_011 (issue #5): metriche derivabili dagli eventi correnti.
+  // 1vX = frazione di attacchi condotti in situazione "1 vs 1" (ciascuna
+  //       fazione ha 1 sola unita' alive). Componente di `risk`.
+  // new_tiles = numero di celle uniche visitate dall'attore nel suo
+  //             percorso. Componente di `explore`.
+  '1vX',
+  'new_tiles',
 ]);
 
 function loadTelemetryConfig(yamlPath = DEFAULT_TELEMETRY_PATH, logger = console) {
@@ -121,6 +128,15 @@ function computeRawMetrics(events, units, gridSize = 6) {
       : 1;
   }
 
+  // SPRINT_011: lookup unit side/team per 1vX check. Al momento il gioco
+  // ha 2 unita' (unit_1=player, unit_2=sistema) e la fazione e' determinata
+  // dal campo `controlled_by`. Per generalizzare: due unita' sono "alleate"
+  // se hanno lo stesso controlled_by.
+  const unitTeamMap = {};
+  for (const unit of units) {
+    unitTeamMap[unit.id] = unit.controlled_by || 'unknown';
+  }
+
   const perActor = {};
   for (const unit of units) {
     perActor[unit.id] = {
@@ -149,12 +165,39 @@ function computeRawMetrics(events, units, gridSize = 6) {
       // move successivo: { target_pos_at_attack, actor_pos_at_attack, turn }
       pendingEvasionAttack: null,
       evasion_attacks: 0,
+      // SPRINT_011 (issue #5): metriche derivabili dagli eventi.
+      // oneVxOneAttacks: count di attacchi dove l'actor era l'unica
+      //   unita' viva del suo team E il target era l'unico nemico vivo.
+      //   Usato per la metrica 1vX (frazione) in risk.
+      // visitedTiles: set di chiavi "x,y" visitate dall'actor nel corso
+      //   della sessione, per new_tiles (count) in explore.
+      oneVxOneAttacks: 0,
+      visitedTiles: new Set(),
     };
   }
 
   let totalDamageInSession = 0;
   let firstKillActor = null;
   const lastActionType = {};
+
+  // SPRINT_011: replay HP state per 1vX. hpAtEvent[unit_id] = HP vivo
+  // al momento corrente. Iniziale = max_hp (o hp iniziale dell'unita').
+  // Decrementato su ogni attack hit contro quella unita'.
+  const hpAtEvent = {};
+  for (const unit of units) {
+    hpAtEvent[unit.id] = Number.isFinite(unit.max_hp) ? unit.max_hp : (unit.hp ?? 10);
+  }
+  // Helper: conta alive per team alla situazione attuale.
+  const countAliveByTeam = () => {
+    const count = {};
+    for (const unit of units) {
+      if ((hpAtEvent[unit.id] ?? 0) > 0) {
+        const team = unitTeamMap[unit.id];
+        count[team] = (count[team] || 0) + 1;
+      }
+    }
+    return count;
+  };
 
   for (const event of events) {
     if (!event) continue;
@@ -169,6 +212,24 @@ function computeRawMetrics(events, units, gridSize = 6) {
     if (event.action_type === 'attack') {
       bucket.attacks_started += 1;
       bucket.total_actions += 1;
+
+      // SPRINT_011 (issue #5): 1vX check PRIMA di applicare il danno
+      // dell'attacco corrente. Se al momento dell'attacco esisteva una
+      // sola unita' viva per team (inclusi actor e target), conta come
+      // attacco in duello 1v1. Semanticamente "sei rimasto l'unico contro
+      // l'unico, ogni colpo vale doppio psicologicamente".
+      const aliveByTeam = countAliveByTeam();
+      const actorTeam = unitTeamMap[bucketId];
+      const targetTeam = unitTeamMap[event.target_id];
+      if (
+        actorTeam &&
+        targetTeam &&
+        actorTeam !== targetTeam &&
+        aliveByTeam[actorTeam] === 1 &&
+        aliveByTeam[targetTeam] === 1
+      ) {
+        bucket.oneVxOneAttacks += 1;
+      }
 
       if (bucket.first_attack_turn === null && Number.isFinite(event.turn)) {
         bucket.first_attack_turn = event.turn;
@@ -198,6 +259,15 @@ function computeRawMetrics(events, units, gridSize = 6) {
         ) {
           bucket.low_hp_events += 1;
         }
+        // SPRINT_011: aggiorna hpAtEvent[target] col danno inflitto
+        // DOPO aver usato lo stato pre-attack per il check 1vX.
+        if (event.target_id && Number.isFinite(event.target_hp_after)) {
+          hpAtEvent[event.target_id] = event.target_hp_after;
+        } else if (event.target_id) {
+          // Fallback se target_hp_after non disponibile
+          const dmg = Number(event.damage_dealt) || 0;
+          hpAtEvent[event.target_id] = Math.max(0, (hpAtEvent[event.target_id] ?? 0) - dmg);
+        }
       } else {
         bucket.attack_misses += 1;
       }
@@ -222,6 +292,16 @@ function computeRawMetrics(events, units, gridSize = 6) {
     } else if (event.action_type === 'move') {
       bucket.moves += 1;
       bucket.total_actions += 1;
+      // SPRINT_011 (issue #5): tracking delle celle uniche visitate
+      // per new_tiles (esplorazione). Si contano sia la cella di partenza
+      // che quella di arrivo: cosi' la prima azione di un'unita' registra
+      // anche la sua posizione iniziale.
+      if (event.position_from) {
+        bucket.visitedTiles.add(`${event.position_from.x},${event.position_from.y}`);
+      }
+      if (event.position_to) {
+        bucket.visitedTiles.add(`${event.position_to.x},${event.position_to.y}`);
+      }
       // distanza prima del primo attack (proxy time_to_commit)
       if (bucket.first_attack_turn === null) {
         const d = manhattan(event.position_from, event.position_to);
@@ -288,6 +368,14 @@ function computeRawMetrics(events, units, gridSize = 6) {
     // SPRINT_005 fase 2: evasion_ratio = attacchi seguiti da ritirata / attacchi totali.
     const evasionRatio = attacksStarted > 0 ? bucket.evasion_attacks / attacksStarted : 0;
 
+    // SPRINT_011 (issue #5): metriche nuove.
+    // 1vX: frazione degli attacchi condotti in situazione 1v1 isolata.
+    const oneVxOneRatio = attacksStarted > 0 ? bucket.oneVxOneAttacks / attacksStarted : 0;
+    // new_tiles: numero di celle uniche visitate, normalizzato su gridSize^2
+    // cosi' e' in [0, 1] (1 = ha visitato tutto il grid).
+    const newTilesRaw = bucket.visitedTiles.size;
+    const newTilesNorm = safeDivide(newTilesRaw, Math.max(1, gridSize * gridSize));
+
     finalRaw[unitId] = {
       attacks_started: attacksStarted,
       attack_hit_rate: attackHitRate,
@@ -309,6 +397,9 @@ function computeRawMetrics(events, units, gridSize = 6) {
       time_to_commit: timeToCommit,
       evasion_ratio: evasionRatio,
       evasion_attacks: bucket.evasion_attacks,
+      '1vX': oneVxOneRatio,
+      new_tiles: newTilesNorm,
+      new_tiles_count: newTilesRaw,
     };
   }
 


### PR DESCRIPTION
## Summary

Chiude parzialmente **issue #5** del playtest design backlog aggiungendo le metriche telemetria derivabili dagli eventi correnti. Le altre (\`self_heal\`, \`overcap_guard\`, \`pattern_entropy\`, \`formation_time\`, \`cover_discipline\`, \`time_in_fow\`, \`optionals\`, \`tilt\`) richiedono feature di gameplay non ancora implementate e restano null per design.

## Metriche aggiunte

### 1. \`1vX\` (risk index, peso 0.28)

Frazione degli attacchi dell'actor condotti in **duello isolato**: al momento dell'attacco c'era una sola unità viva per team (actor + target). Semantica: *"sei rimasto l'unico contro l'unico"*.

**Implementazione**:
- \`unitTeamMap\` costruita via \`unit.controlled_by\` (alleati = stesso controlled_by)
- \`hpAtEvent[unit_id]\` replaya lo stato HP turno per turno
- \`countAliveByTeam()\` helper locale al loop eventi
- Check **prima** di applicare il danno dell'attacco corrente (così l'attacco che uccide il singolo nemico conta ancora come 1vX)
- Fallback robusto se \`target_hp_after\` non presente

### 2. \`new_tiles\` (explore index, peso 0.45)

Numero di celle uniche visitate dall'actor, normalizzato su \`gridSize^2\`. Include sia \`position_from\` che \`position_to\` di ogni move event.

## Impatto sugli aggregate indices

| Index | pre sprint-011 | post sprint-011 | Coverage |
|---|:-:|:-:|:-:|
| \`risk\` | 2/5 weights (damage_taken + low_hp_time) | **3/5 weights** (+1vX) | parziale |
| \`explore\` | 0/3 weights (tutto null) | **1/3 weights** (+new_tiles) | parziale (prima null) |

## Test end-to-end (bot close engage, 12 turni)

| Metrica | Valore |
|---|:-:|
| \`1vX\` raw | **1.0** (6/6 attacchi in 1v1) |
| \`new_tiles_count\` | 4 |
| \`new_tiles\` normalizzato | 0.111 (4/36) |
| \`risk\` pre → post | 0.58 → **0.81** |
| \`explore\` pre → post | null → 0.111 (partial) |
| \`aggro\` | 0.75 |
| **Ennea triggered** | **Conquistatore(3)** ✅ |

Conquistatore(3) ora si attiva grazie alla combinazione di \`aggro > 0.65\` e \`risk\` che sale ben sopra 0.55 per via di \`1vX\` saturato.

## Nota design: 1vX in gioco 1v1

In un gioco a 2 unità (il setup attuale: velox player + carapax sistema), \`1vX\` è sempre **1.0** perché c'è sempre un solo alleato e un solo nemico. La metrica diventerà differenziante quando si aggiungeranno team multi-unit (2v2, 3v3, eventi con alleati temporanei). Per ora ha l'effetto di rendere Conquistatore(3) più facile da raggiungere, che è in linea con l'intento del trigger (aggro + risk).

## Metriche rimaste null (out of scope, richiedono feature di gioco)

| Metrica | Index | Perché non implementata |
|---|:-:|---|
| \`self_heal\` | risk | Nessuna heal action nel gioco |
| \`overcap_guard\` | risk | Nessun guard system |
| \`pattern_entropy\` | S_N | Calcolo complesso, pattern analysis |
| \`cover_discipline\` | S_N | Nessun cover system |
| \`formation_time\` | cohesion | Richiede >2 alleati |
| \`cover_before_attack\` | setup | Nessun cover system |
| \`overwatch_turns\` | setup | Feature da implementare |
| \`trap_value\` | setup | Trap system |
| \`time_in_fow\` | explore | Nessun fog of war |
| \`optionals\` | explore | Nessun objective system |
| \`tilt\` | tilt | Psychometric, troppo complesso |

## Rollback plan (03A)

- \`git revert a13946fa\` ripristina main post-#1358 (\`f1edc0ff\`)
- **Schema DB**: nessuna modifica
- **Contracts**: nessuna modifica
- **Backward compat**: metriche puramente additive, sessioni storiche continuano a ritornare gli stessi indici con in più \`1vX\` e \`new_tiles\` computati dagli eventi pre-esistenti

## Backlog status

| # | Pri | Titolo | Stato |
|---|:-:|---|:-:|
| 2 | 🟡 | IA SIS: REGOLA_003 kite | aperto (sprint-012 next) |
| 5 | 🟢 | Metriche telemetria mancanti | **parziale** (1vX + new_tiles fatte, resto fuori scope) |
| 10 | 🟡 | Stati emotivi IA (panic/rage/...) | aperto (sprint-013 next) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)