### PR TITLE
feat(ai): REGOLA_003 kite opportunistico (sprint-012 / issue #2)

### DIFF
--- a/apps/backend/services/ai/policy.js
+++ b/apps/backend/services/ai/policy.js
@@ -30,6 +30,10 @@ const DEFAULT_ATTACK_RANGE = 2;
 const DEFAULT_MAX_HP_FALLBACK = 10;
 // Soglia di retreat REGOLA_002 (HP ratio).
 const LOW_HP_RETREAT_THRESHOLD = 0.3;
+// SPRINT_012 (issue #2): target range "da evitare" per REGOLA_003 kite.
+// La regola e' che il SIS con range > target's range dovrebbe mantenersi
+// a >= target.attack_range + KITE_BUFFER dal nemico.
+const KITE_BUFFER = 1;
 
 function manhattanDistance(a, b) {
   if (!a || !b) return 0;
@@ -63,12 +67,43 @@ function selectAiPolicy(actor, target) {
   const maxHp =
     Number.isFinite(actor.max_hp) && actor.max_hp > 0 ? actor.max_hp : DEFAULT_MAX_HP_FALLBACK;
   const hpRatio = actor.hp / maxHp;
+
+  // REGOLA_002: autoconservazione prima di tutto
   if (hpRatio <= LOW_HP_RETREAT_THRESHOLD) {
     return { rule: 'REGOLA_002', intent: 'retreat' };
   }
+
   const distance = manhattanDistance(actor.position, target.position);
-  const range = actor.attack_range ?? DEFAULT_ATTACK_RANGE;
-  if (distance <= range) {
+  const actorRange = actor.attack_range ?? DEFAULT_ATTACK_RANGE;
+  const targetRange = target.attack_range ?? DEFAULT_ATTACK_RANGE;
+
+  // SPRINT_012 (issue #2): REGOLA_003 kite opportunistico.
+  // Se l'actor ha range superiore al target, preferisce colpire da fuori
+  // dal range di risposta del nemico:
+  //   - target_range + KITE_BUFFER <= distance <= actor_range → attacco "safe"
+  //     intent 'attack' con rule REGOLA_003 (non consuma la 001)
+  //   - distance < target_range + KITE_BUFFER → l'actor e' dentro il range
+  //     del nemico, intent 'retreat' con rule REGOLA_003 (kite away to safe)
+  //   - distance > actor_range → intent 'approach' per arrivare in safe zone
+  //
+  // Condizioni: actor.attack_range deve essere strettamente maggiore di
+  // target.attack_range, altrimenti il kite non e' meccanicamente possibile
+  // (sarebbe un attacco reciproco) e la policy cade su REGOLA_001.
+  if (actorRange > targetRange) {
+    const safeMinDist = targetRange + KITE_BUFFER;
+    if (distance >= safeMinDist && distance <= actorRange) {
+      return { rule: 'REGOLA_003', intent: 'attack' };
+    }
+    if (distance < safeMinDist) {
+      // dentro range del nemico → scappa per tornare in zona safe
+      return { rule: 'REGOLA_003', intent: 'retreat' };
+    }
+    // distance > actorRange → troppo lontano, avvicinati
+    return { rule: 'REGOLA_003', intent: 'approach' };
+  }
+
+  // REGOLA_001: default — range <= target range (o uguale), fight simmetrico
+  if (distance <= actorRange) {
     return { rule: 'REGOLA_001', intent: 'attack' };
   }
   return { rule: 'REGOLA_001', intent: 'approach' };


### PR DESCRIPTION
## Summary

Chiude la parte rimanente dell'**issue #2** del playtest design backlog: REGOLA_003 per l'IA SIS con \`attack_range\` superiore al target. Il SIS ora fa **kite automaticamente** quando ha il vantaggio di range — colpisce da fuori dal counter-attack del nemico e si riposiziona per mantenere la safe zone.

## Logica in \`selectAiPolicy\` (policy.js)

\`\`\`
Se actor.attack_range > target.attack_range:
  safeMinDist = target.attack_range + KITE_BUFFER (1)

  distance in [safeMinDist, actor.attack_range] → REGOLA_003 attack
  distance < safeMinDist                        → REGOLA_003 retreat
  distance > actor.attack_range                 → REGOLA_003 approach

Se actor.attack_range <= target.attack_range:
  cade su REGOLA_001 default (niente vantaggio al kite).

Priorita': REGOLA_002 (retreat HP basso) > REGOLA_003 (opportunismo tattico).
\`\`\`

## Non serve modificare il runner

Grazie alla modularizzazione sprint-010, \`sistemaTurnRunner.js\` gestisce già gli intent \`attack\`, \`approach\`, \`retreat\` a prescindere dalla rule. Il **fallback cornered** esistente (\`policy.intent === 'retreat' && !canRetreat → REGOLA_001 fallback\`) funziona anche per REGOLA_003 retreat impossibile.

## Test end-to-end (SIS ranger r3 vs P1 skirmisher r2)

| Scenario | SIS pos | P1 pos | dist | Expected | Got |
|---|---|---|:-:|---|:-:|
| Out of range | (5,3) | (0,3) | 5 | R003 approach | R003 move ×2 ✅ |
| Safe zone | (5,3) | (2,3) | 3 | R003 attack | R003 attack ×2 ✅ |
| Inside target, SIS cornered | (5,3) | (3,3) | 2 | R003 retreat → fallback R001 attack | R001 attack ×2 ✅ |
| Inside target, SIS centered | (3,3) | (1,3) | 2 | R003 retreat + attack | retreat (3,3)→(4,3) + attack ✅ |

Lo scenario "centered" mostra il **loop tipico del kite**: iter 1 retreat alla safe zone, iter 2 attack senza counter. Due azioni in un turno, coerenti con il dual-action model.

## Design note: attivabilità nel setup attuale

Con il setup default (skirmisher r2 vs vanguard r1), **REGOLA_003 non si attiva mai** perché il SIS (vanguard) ha range _inferiore_ al player. La regola si attiva solo se il SIS ha un job long-range:
- **ranger** (r3) — il classico kiter
- **invoker** (r3) — caster long-range

Lascia spazio a futuri matchup più ricchi (es. scenari boss o mission con nemici specializzati).

## Interazione col fallback cornered

Un SIS r3 al bordo griglia che vuole retreatare ma non può → fallback a REGOLA_001. Questo è corretto perché il SIS "cornered" ha già fallito la strategia kite e deve ripiegare sul combattimento simmetrico. Il flag \`corneredThisTurn\` locale al turno evita oscillazioni.

## Rollback plan (03A)

- \`git revert 439afeec\` ripristina main post-#1359 (\`2dd5d59f\`)
- **Schema DB**: nessuna modifica
- **Contracts**: nessuna modifica
- **Nessun impatto sul setup default**: REGOLA_003 si attiva solo con \`actor.attack_range > target.attack_range\`, che non è il caso di skirmisher vs vanguard

## Backlog status

| # | Pri | Titolo | Stato |
|---|:-:|---|:-:|
| 2 | 🟡 | IA SIS: extraction + REGOLA_003 kite | ✅ **chiuso** |
| 5 | 🟢 | Metriche telemetria mancanti | parziale (1vX+new_tiles fatte) |
| 10 | 🟡 | Stati emotivi IA (panic/rage/...) | aperto (sprint-013 next) |

Con questo merge restano solo **1.5 issue** aperte. Sprint-013 chiuderà #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)