### PR TITLE
feat(ai): stati emotivi IA — panic, rage, stunned (sprint-013 / issue #10)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -114,6 +114,13 @@ function normaliseUnit(raw, fallbackIndex) {
   // possibile dall'input (utile per scenari di test che partono con SIS
   // gia' ferito). Default: parte a hp iniziale (unita' fresca = full HP).
   const maxHp = Number.isFinite(Number(input.max_hp)) ? Number(input.max_hp) : hp;
+  // SPRINT_013 (issue #10): oggetto status per stati emotivi temporanei.
+  // Ogni chiave e' il nome dello stato, valore = turns_remaining.
+  // 0 o mancante = inattivo. Accetta override iniziale dall'input.
+  const status =
+    input.status && typeof input.status === 'object'
+      ? { ...input.status }
+      : { panic: 0, rage: 0, stunned: 0, focused: 0, confused: 0 };
   return {
     id,
     species: input.species ? String(input.species) : 'unknown',
@@ -121,6 +128,7 @@ function normaliseUnit(raw, fallbackIndex) {
     traits,
     hp,
     max_hp: maxHp,
+    status,
     ap,
     ap_remaining: Number.isFinite(Number(input.ap_remaining)) ? Number(input.ap_remaining) : ap,
     mod: Number.isFinite(Number(input.mod)) ? Number(input.mod) : DEFAULT_MOD,
@@ -298,6 +306,8 @@ function createSessionRouter(options = {}) {
     let damageDealt = 0;
     let killOccurred = false;
     let adjacencyBonus = 0;
+    let rageBonus = 0;
+    let panicTriggered = false;
     if (result.hit) {
       const baseDamage = 1 + result.pt;
       // SPRINT_007 fase 1 (issue #4): bonus damage +1 quando l'attaccante
@@ -308,7 +318,12 @@ function createSessionRouter(options = {}) {
       if (attackDist === 1) {
         adjacencyBonus = 1;
       }
-      const adjusted = baseDamage + evaluation.damage_modifier + adjacencyBonus;
+      // SPRINT_013 (issue #10): bonus rage — se l'attaccante e' in stato
+      // rage, +1 damage in aggiunta al bonus adiacenza.
+      if (actor.status && Number(actor.status.rage) > 0) {
+        rageBonus = 1;
+      }
+      const adjusted = baseDamage + evaluation.damage_modifier + adjacencyBonus + rageBonus;
       damageDealt = Math.max(0, adjusted);
       // SPRINT_003 fase 0: traccia damage_taken cumulativo per unita'.
       // Lo stato e' in memoria (non nel log) — VC scoring lo ricalcola
@@ -318,8 +333,24 @@ function createSessionRouter(options = {}) {
       if (target.hp === 0) {
         killOccurred = true;
       }
+      // SPRINT_013 (issue #10): trigger panic nel target se subisce un
+      // colpo critico (MoS >= 8). Il target non e' ancora morto (target.hp
+      // potrebbe essere a 0 ma panic su un'unita' KO e' innocuo). Applica
+      // 2 turni di panic.
+      if (result.mos >= 8 && target.status && target.hp > 0) {
+        target.status.panic = Math.max(Number(target.status.panic) || 0, 2);
+        panicTriggered = true;
+      }
     }
-    return { result, evaluation, damageDealt, killOccurred, adjacencyBonus };
+    return {
+      result,
+      evaluation,
+      damageDealt,
+      killOccurred,
+      adjacencyBonus,
+      rageBonus,
+      panicTriggered,
+    };
   }
 
   async function emitKillAndAssists(session, killer, target, attackEvent) {
@@ -678,6 +709,20 @@ function createSessionRouter(options = {}) {
       const current = session.units.find((u) => u.id === session.active_unit);
       if (current) {
         current.ap_remaining = current.ap;
+      }
+
+      // SPRINT_013 (issue #10): decrementa le durate degli stati emotivi
+      // di TUTTE le unita' alla fine del turno. Uno stato che scade diventa
+      // 0 (inattivo). Cosi' panic/rage/stunned durano N turni e poi
+      // spariscono automaticamente.
+      for (const unit of session.units) {
+        if (!unit.status) continue;
+        for (const key of Object.keys(unit.status)) {
+          const v = Number(unit.status[key]);
+          if (v > 0) {
+            unit.status[key] = v - 1;
+          }
+        }
       }
 
       // 2. Passa il turno all'unita' successiva

--- a/apps/backend/services/ai/policy.js
+++ b/apps/backend/services/ai/policy.js
@@ -63,7 +63,52 @@ function stepAway(from, to, gridSize = 6) {
   return tryAxis('y') || tryAxis('x');
 }
 
+// SPRINT_013 (issue #10): stati emotivi temporanei che sovrascrivono
+// la selezione policy normale. Ogni stato ha un turns_remaining > 0
+// per essere attivo. Letti da actor.status (oggetto opzionale).
+//
+// Priorita' stati (alto → basso):
+//   1. stunned : policy intent 'skip', rule STATO_STUNNED
+//   2. rage    : forza 'attack' (o 'approach' se fuori range), rule
+//                STATO_RAGE, bonus damage applicato altrove
+//   3. panic   : forza 'retreat', rule STATO_PANIC
+//
+// Gli stati "confused" e "focused" sono dichiarati come flag ma non
+// hanno ancora override nella policy — rimandati a sprint futuri
+// (richiedono modifica target selection per confused, modifica
+// resolveAttack per focused).
+function checkEmotionalOverrides(actor, target) {
+  const status = actor.status;
+  if (!status) return null;
+  const hasDuration = (name) => {
+    const t = status[name];
+    return Number.isFinite(t) && t > 0;
+  };
+  if (hasDuration('stunned')) {
+    return { rule: 'STATO_STUNNED', intent: 'skip' };
+  }
+  if (hasDuration('rage')) {
+    // rage = "carica" — attacca se possibile, altrimenti avvicina
+    // ignorando qualunque consideration di HP o safe zone.
+    const dist = manhattanDistance(actor.position, target.position);
+    const range = actor.attack_range ?? DEFAULT_ATTACK_RANGE;
+    return {
+      rule: 'STATO_RAGE',
+      intent: dist <= range ? 'attack' : 'approach',
+    };
+  }
+  if (hasDuration('panic')) {
+    return { rule: 'STATO_PANIC', intent: 'retreat' };
+  }
+  return null;
+}
+
 function selectAiPolicy(actor, target) {
+  // SPRINT_013: stati emotivi hanno priorita' assoluta, bypassano HP
+  // check e range check.
+  const emotional = checkEmotionalOverrides(actor, target);
+  if (emotional) return emotional;
+
   const maxHp =
     Number.isFinite(actor.max_hp) && actor.max_hp > 0 ? actor.max_hp : DEFAULT_MAX_HP_FALLBACK;
   const hpRatio = actor.hp / maxHp;
@@ -116,4 +161,5 @@ module.exports = {
   manhattanDistance,
   stepAway,
   selectAiPolicy,
+  checkEmotionalOverrides,
 };

--- a/apps/backend/services/ai/sistemaTurnRunner.js
+++ b/apps/backend/services/ai/sistemaTurnRunner.js
@@ -101,6 +101,25 @@ function createSistemaTurnRunner(deps) {
         }
       }
 
+      // SPRINT_013 (issue #10): intent 'skip' per stati come stunned.
+      // L'actor non fa nulla, consuma tutti gli AP restanti, registra
+      // un'unica azione descrittiva.
+      if (policy.intent === 'skip') {
+        const apSpent = actor.ap_remaining;
+        actor.ap_remaining = 0;
+        actions.push({
+          actor: 'sistema',
+          unit_id: actor.id,
+          type: 'skip',
+          reason: `stato emotivo — ${policy.rule}`,
+          position_from: { ...actor.position },
+          position_to: { ...actor.position },
+          ia_rule: policy.rule,
+          ap_spent: apSpent,
+        });
+        break;
+      }
+
       if (policy.intent === 'attack') {
         const hpBefore = target.hp;
         const targetPositionAtAttack = { ...target.position };


### PR DESCRIPTION
## Summary

Chiude **issue #10** del playtest design backlog. Aggiunge stati emotivi temporanei (panic/rage/stunned) che sovrascrivono la policy IA standard, usando la foundation \`services/ai/\` estratta nello sprint-010.

Apre la strada a meccaniche più ricche (trait che inducono panic, colpi critici che provocano rage, ability stordente, ecc.) senza toccare il runner o il router.

## Architettura

### 1. Campo \`status\` su unit

\`normaliseUnit\` inizializza \`unit.status = { panic, rage, stunned, focused, confused }\` con \`turns_remaining\` numerici. 0 o mancante = inattivo. Accetta override esplicito dall'input del \`/api/session/start\` per scenari di test.

### 2. \`checkEmotionalOverrides\` in policy.js

Funzione helper pura chiamata da \`selectAiPolicy\` **prima** di tutte le altre regole. Priorità stati (alto → basso):

| Stato | Rule | Intent | Note |
|---|:-:|:-:|---|
| stunned | STATO_STUNNED | skip | bypassa tutto, consuma AP in un no-op |
| rage | STATO_RAGE | attack o approach | forza attack ignorando HP check |
| panic | STATO_PANIC | retreat | forza retreat ignorando range check |

Stati \`confused\` e \`focused\` dichiarati come flag ma non ancora implementati (rimandati: confused richiede target selection diversa, focused richiede mod a resolveAttack).

### 3. Intent \`skip\` nel runner

\`sistemaTurnRunner.js\` gestisce il nuovo intent \`skip\`: consuma tutti gli AP rimanenti in una singola azione descrittiva con \`type='skip'\`, \`reason='stato emotivo — STATO_STUNNED'\`. \`break\` immediato dal loop dual-action.

### 4. Bonus damage rage in \`performAttack\`

\`performAttack\` ora ritorna \`rageBonus\`. Quando \`actor.status.rage > 0\`:

\`\`\`
damage = 1 + pt + trait_damage_modifier + adjacencyBonus + rageBonus
                                          (sprint-007)   (+1 if rage)
\`\`\`

### 5. Trigger auto panic su critico

\`performAttack\` setta \`target.status.panic = max(current, 2)\` quando \`result.mos >= 8\`. Il bersaglio entra in panic per 2 turni. Trigger solo se ancora vivo.

### 6. Decrement durate in \`/turn/end\`

A ogni turn end, tutte le unità di \`session.units\` hanno le loro status key decrementate di 1 (se > 0). Panic/rage/stunned scadono automaticamente.

## Test end-to-end (4 scenari)

| Scenario | Setup | Expected | Got |
|---|---|---|:-:|
| Stunned | SIS \`stunned=2\`, fresh | 1× skip \`ap_spent=2\` | ✅ |
| Rage + HP basso | SIS \`rage=3, hp=3/10\` | STATO_RAGE attack ×2 (NO retreat) | ✅ |
| Panic + HP pieno | SIS \`panic=2\`, hp=10 | STATO_PANIC retreat + fallback | ✅ |
| Rage bonus damage | P1 rage, dist 2, pt=4 | dmg=6 (1 base + 4 pt + 1 rage) | ✅ |

Priorità override verificata: rage con HP 30% forza comunque attack (non entra in REGOLA_002 retreat). Stunned domina tutto (inclusi rage e panic).

## Gameplay impact

- **Panic**: il nemico che becca un critico (MoS 8+) entra in fuga per 2 turni. Crea momenti narrativi ("l'hai spaventato") e opportunità tattiche (puoi colpirlo mentre scappa, ma da dist 2 non sarà adiacente → no bonus adjacency).
- **Rage**: un nemico infuriato fa più danno E ignora l'autoconservazione, diventando più pericoloso. Trigger futuri: trait \`ferocia\`, ally morto nearby, ambush.
- **Stunned**: salta il turno. Trigger futuri: trait \`stordimento\`, colpo alla testa critico, ability \`electric_shock\`.

## Foundation per trait system futuri

Il sistema rende possibile:
- Trait che applicano stati al trigger (evento attack/kill)
- Stati che si combinano (es. panic + stunned = skip forzato, ma rage > panic nella priorità)
- Telemetry di stati (quanti turni P1 è stato in rage, ecc.) per metriche psicometriche (tilt, adaptation) — sblocca parte della metrica \`tilt\` rimasta null nel sprint-011.

## Rollback plan (03A)

- \`git revert 9e2ae034\` ripristina main post-#1360 (\`3bea6e06\`)
- **Schema DB**: nessuna modifica
- **Contracts**: nessuna modifica
- **Backward compat**: \`status\` è additive, unità legacy senza status si comportano identico a prima (\`checkEmotionalOverrides\` ritorna null se \`actor.status\` mancante)

## Backlog status finale

| # | Pri | Titolo | Stato |
|---|:-:|---|:-:|
| 2 | 🟡 | IA SIS: estrazione + REGOLA_003 | ✅ chiuso |
| 4 | 🟡 | close_engage vs DPS | ✅ chiuso |
| 5 | 🟢 | Metriche telemetria | parziale (1vX+new_tiles, resto out of scope) |
| 6 | 🟢 | attack_range per job | ✅ chiuso |
| 7 | 🟢 | AP cost granular | ✅ chiuso |
| 10 | 🟡 | **Stati emotivi IA** | ✅ **chiuso** |

Il backlog playtest originale è **praticamente esaurito**. Le issue #1, #3, #8 erano state chiuse in sprint-005. Ora con sprint-013 tutti i major sono fatti. Solo la metrica telemetria rimanente (#5 parziale) aspetta feature di gameplay future (heal, guard, fog of war, objective system) per completarsi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)