### PR TITLE
test(ai): suite di unit test per services/ai/ (sprint-015)

### DIFF
--- a/tests/ai/policy.test.js
+++ b/tests/ai/policy.test.js
@@ -1,0 +1,319 @@
+// SPRINT_015: test suite per apps/backend/services/ai/policy.js
+//
+// Copre:
+//   - manhattanDistance (purezza)
+//   - stepAway (tutti i casi di bordo)
+//   - selectAiPolicy:
+//     * REGOLA_001 attack/approach (HP pieno, range match/mismatch)
+//     * REGOLA_002 retreat (HP <= 30%)
+//     * REGOLA_003 kite (actor range > target range)
+//   - checkEmotionalOverrides:
+//     * priorita' stunned > rage > panic
+//     * durata 0 = inattivo
+//     * nessun status = null
+//     * rage in/fuori range → intent attack/approach
+//     * priorita' assoluta su HP check (rage con HP basso)
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  DEFAULT_ATTACK_RANGE,
+  LOW_HP_RETREAT_THRESHOLD,
+  manhattanDistance,
+  stepAway,
+  selectAiPolicy,
+  checkEmotionalOverrides,
+} = require('../../apps/backend/services/ai/policy');
+
+// ─────────────────────────────────────────────────────────────────
+// manhattanDistance
+// ─────────────────────────────────────────────────────────────────
+
+test('manhattanDistance: 0 fra cella e se stessa', () => {
+  assert.equal(manhattanDistance({ x: 2, y: 3 }, { x: 2, y: 3 }), 0);
+});
+
+test('manhattanDistance: cardinal 1', () => {
+  assert.equal(manhattanDistance({ x: 0, y: 0 }, { x: 1, y: 0 }), 1);
+  assert.equal(manhattanDistance({ x: 0, y: 0 }, { x: 0, y: 1 }), 1);
+});
+
+test('manhattanDistance: diagonale = 2', () => {
+  assert.equal(manhattanDistance({ x: 0, y: 0 }, { x: 1, y: 1 }), 2);
+});
+
+test('manhattanDistance: simmetrica', () => {
+  const a = { x: 1, y: 2 };
+  const b = { x: 4, y: 5 };
+  assert.equal(manhattanDistance(a, b), manhattanDistance(b, a));
+});
+
+test('manhattanDistance: input null/undefined → 0', () => {
+  assert.equal(manhattanDistance(null, { x: 1, y: 1 }), 0);
+  assert.equal(manhattanDistance({ x: 1, y: 1 }, undefined), 0);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// stepAway
+// ─────────────────────────────────────────────────────────────────
+
+test('stepAway: preferisce asse x se |dx| >= |dy|', () => {
+  // from (3,3), target (1,3): dx=2, dy=0 → step verso +x
+  assert.deepEqual(stepAway({ x: 3, y: 3 }, { x: 1, y: 3 }), { x: 4, y: 3 });
+});
+
+test('stepAway: preferisce asse y se |dy| > |dx|', () => {
+  // from (3,3), target (3,1): dx=0, dy=2 → step verso +y
+  assert.deepEqual(stepAway({ x: 3, y: 3 }, { x: 3, y: 1 }), { x: 3, y: 4 });
+});
+
+test('stepAway: diagonale (pari) preferisce x', () => {
+  // from (3,3), target (2,2): dx=1, dy=1 (pari) → asse x vince per |dx|>=|dy|
+  assert.deepEqual(stepAway({ x: 3, y: 3 }, { x: 2, y: 2 }), { x: 4, y: 3 });
+});
+
+test('stepAway: fallback a asse y se x bloccato al bordo', () => {
+  // from (5,3), target (3,3): +x andrebbe a 6 (fuori) → fallback y
+  // ma dy=0 → null
+  assert.equal(stepAway({ x: 5, y: 3 }, { x: 3, y: 3 }), null);
+});
+
+test('stepAway: con dy > 0 e x bloccato, usa y', () => {
+  // from (5,2), target (3,4): dx=2, dy=-2. |dx|=|dy| → preferisce x.
+  // x: newX = 6 → fuori. Fallback y: newY = 1 (−2 sign) → (5,1)
+  assert.deepEqual(stepAway({ x: 5, y: 2 }, { x: 3, y: 4 }), { x: 5, y: 1 });
+});
+
+test('stepAway: gridSize custom 8 permette bordo diverso', () => {
+  // con grid 8, (5,3) da (3,3) → +x a 6 (in grid 8)
+  assert.deepEqual(stepAway({ x: 5, y: 3 }, { x: 3, y: 3 }, 8), { x: 6, y: 3 });
+});
+
+test('stepAway: angolato totalmente ritorna null', () => {
+  // from (0,0), target (5,5): vuole -x (a -1) e -y (a -1), entrambi out
+  assert.equal(stepAway({ x: 0, y: 0 }, { x: 5, y: 5 }), null);
+});
+
+test('stepAway: stesse coordinate ritorna null', () => {
+  assert.equal(stepAway({ x: 3, y: 3 }, { x: 3, y: 3 }), null);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// selectAiPolicy — REGOLA_001 default
+// ─────────────────────────────────────────────────────────────────
+
+function baseActor(overrides = {}) {
+  return {
+    id: 'sistema',
+    hp: 10,
+    max_hp: 10,
+    attack_range: 2,
+    position: { x: 0, y: 0 },
+    status: null,
+    ...overrides,
+  };
+}
+function baseTarget(overrides = {}) {
+  return {
+    id: 'player',
+    hp: 10,
+    max_hp: 10,
+    attack_range: 2,
+    position: { x: 1, y: 0 },
+    ...overrides,
+  };
+}
+
+test('selectAiPolicy R001: in range → attack', () => {
+  const actor = baseActor({ position: { x: 2, y: 2 } });
+  const target = baseTarget({ position: { x: 3, y: 2 } }); // dist 1
+  assert.deepEqual(selectAiPolicy(actor, target), {
+    rule: 'REGOLA_001',
+    intent: 'attack',
+  });
+});
+
+test('selectAiPolicy R001: fuori range → approach', () => {
+  const actor = baseActor({ position: { x: 0, y: 0 } });
+  const target = baseTarget({ position: { x: 5, y: 5 } }); // dist 10
+  assert.deepEqual(selectAiPolicy(actor, target), {
+    rule: 'REGOLA_001',
+    intent: 'approach',
+  });
+});
+
+test('selectAiPolicy R001: actor senza attack_range usa DEFAULT_ATTACK_RANGE', () => {
+  const actor = baseActor({ attack_range: undefined, position: { x: 0, y: 0 } });
+  const target = baseTarget({ position: { x: 2, y: 0 } }); // dist 2 == DEFAULT
+  assert.equal(selectAiPolicy(actor, target).intent, 'attack');
+});
+
+// ─────────────────────────────────────────────────────────────────
+// selectAiPolicy — REGOLA_002 retreat
+// ─────────────────────────────────────────────────────────────────
+
+test('selectAiPolicy R002: HP <= 30% → retreat', () => {
+  const actor = baseActor({ hp: 3, max_hp: 10 }); // 30% esatto
+  const target = baseTarget();
+  assert.deepEqual(selectAiPolicy(actor, target), {
+    rule: 'REGOLA_002',
+    intent: 'retreat',
+  });
+});
+
+test('selectAiPolicy R002: HP 31% NON triggera retreat', () => {
+  const actor = baseActor({ hp: 4, max_hp: 10 }); // 40%
+  const target = baseTarget({ position: { x: 1, y: 0 } }); // dist 1
+  assert.equal(selectAiPolicy(actor, target).rule, 'REGOLA_001');
+});
+
+test('selectAiPolicy R002: HP 0 → retreat (edge case)', () => {
+  // Un SIS morto potrebbe vedere HP=0. In teoria il caller filtra i morti,
+  // ma il policy deve essere robusto.
+  const actor = baseActor({ hp: 0, max_hp: 10 });
+  assert.equal(selectAiPolicy(actor, baseTarget()).rule, 'REGOLA_002');
+});
+
+test('selectAiPolicy R002: senza max_hp fa fallback al default', () => {
+  const actor = baseActor({ hp: 2, max_hp: undefined }); // 2/10 = 20% col fallback
+  assert.equal(selectAiPolicy(actor, baseTarget()).rule, 'REGOLA_002');
+});
+
+// ─────────────────────────────────────────────────────────────────
+// selectAiPolicy — REGOLA_003 kite
+// ─────────────────────────────────────────────────────────────────
+
+test('selectAiPolicy R003: actor range > target range, in safe zone → attack', () => {
+  // actor r3, target r1, dist 3 (>= target+1=2 && <= actor=3)
+  const actor = baseActor({ attack_range: 3, position: { x: 5, y: 3 } });
+  const target = baseTarget({ attack_range: 1, position: { x: 2, y: 3 } });
+  assert.deepEqual(selectAiPolicy(actor, target), {
+    rule: 'REGOLA_003',
+    intent: 'attack',
+  });
+});
+
+test('selectAiPolicy R003: in target range → retreat (kite)', () => {
+  // actor r3, target r1, dist 1 (dentro target range + buffer)
+  const actor = baseActor({ attack_range: 3, position: { x: 3, y: 3 } });
+  const target = baseTarget({ attack_range: 1, position: { x: 2, y: 3 } });
+  assert.deepEqual(selectAiPolicy(actor, target), {
+    rule: 'REGOLA_003',
+    intent: 'retreat',
+  });
+});
+
+test('selectAiPolicy R003: fuori actor range → approach', () => {
+  // actor r3, target r1, dist 5
+  const actor = baseActor({ attack_range: 3, position: { x: 5, y: 3 } });
+  const target = baseTarget({ attack_range: 1, position: { x: 0, y: 3 } });
+  assert.deepEqual(selectAiPolicy(actor, target), {
+    rule: 'REGOLA_003',
+    intent: 'approach',
+  });
+});
+
+test('selectAiPolicy R003: range uguali → fallback a R001 (no kite)', () => {
+  const actor = baseActor({ attack_range: 2, position: { x: 3, y: 3 } });
+  const target = baseTarget({ attack_range: 2, position: { x: 1, y: 3 } });
+  assert.equal(selectAiPolicy(actor, target).rule, 'REGOLA_001');
+});
+
+test('selectAiPolicy R003: range inferiore → fallback a R001', () => {
+  const actor = baseActor({ attack_range: 1, position: { x: 3, y: 3 } });
+  const target = baseTarget({ attack_range: 3, position: { x: 1, y: 3 } });
+  assert.equal(selectAiPolicy(actor, target).rule, 'REGOLA_001');
+});
+
+// ─────────────────────────────────────────────────────────────────
+// checkEmotionalOverrides
+// ─────────────────────────────────────────────────────────────────
+
+test('checkEmotionalOverrides: nessuno status → null', () => {
+  const actor = baseActor({ status: null });
+  assert.equal(checkEmotionalOverrides(actor, baseTarget()), null);
+});
+
+test('checkEmotionalOverrides: status presente ma tutti 0 → null', () => {
+  const actor = baseActor({
+    status: { panic: 0, rage: 0, stunned: 0 },
+  });
+  assert.equal(checkEmotionalOverrides(actor, baseTarget()), null);
+});
+
+test('checkEmotionalOverrides: stunned ha priorita' + ' assoluta', () => {
+  const actor = baseActor({
+    status: { panic: 5, rage: 5, stunned: 1 },
+  });
+  assert.deepEqual(checkEmotionalOverrides(actor, baseTarget()), {
+    rule: 'STATO_STUNNED',
+    intent: 'skip',
+  });
+});
+
+test('checkEmotionalOverrides: rage supera panic', () => {
+  const actor = baseActor({
+    status: { panic: 3, rage: 2, stunned: 0 },
+    position: { x: 2, y: 2 },
+  });
+  const target = baseTarget({ position: { x: 3, y: 2 } }); // dist 1
+  const result = checkEmotionalOverrides(actor, target);
+  assert.equal(result.rule, 'STATO_RAGE');
+  assert.equal(result.intent, 'attack');
+});
+
+test('checkEmotionalOverrides: rage fuori range → approach', () => {
+  const actor = baseActor({
+    status: { rage: 2 },
+    position: { x: 0, y: 0 },
+  });
+  const target = baseTarget({ position: { x: 5, y: 5 } });
+  assert.equal(checkEmotionalOverrides(actor, target).intent, 'approach');
+});
+
+test('checkEmotionalOverrides: panic forza retreat', () => {
+  const actor = baseActor({
+    status: { panic: 2, rage: 0, stunned: 0 },
+  });
+  assert.deepEqual(checkEmotionalOverrides(actor, baseTarget()), {
+    rule: 'STATO_PANIC',
+    intent: 'retreat',
+  });
+});
+
+test('selectAiPolicy: rage override HP retreat (REGOLA_002)', () => {
+  // HP basso normalmente triggera R002, ma rage batte tutto
+  const actor = baseActor({
+    hp: 2,
+    max_hp: 10,
+    status: { rage: 3 },
+    position: { x: 0, y: 0 },
+  });
+  const target = baseTarget({ position: { x: 1, y: 0 } }); // dist 1
+  const result = selectAiPolicy(actor, target);
+  assert.equal(result.rule, 'STATO_RAGE');
+  assert.equal(result.intent, 'attack');
+});
+
+test('selectAiPolicy: panic override HP safe (sopra soglia)', () => {
+  // HP 100% normalmente niente retreat, ma panic forza retreat
+  const actor = baseActor({
+    hp: 10,
+    max_hp: 10,
+    status: { panic: 2 },
+  });
+  assert.equal(selectAiPolicy(actor, baseTarget()).rule, 'STATO_PANIC');
+});
+
+test('selectAiPolicy: stunned override tutto', () => {
+  const actor = baseActor({
+    hp: 10,
+    max_hp: 10,
+    attack_range: 3, // R003 kite condition
+    status: { stunned: 1 },
+  });
+  const target = baseTarget({ attack_range: 1 });
+  assert.equal(selectAiPolicy(actor, target).rule, 'STATO_STUNNED');
+  assert.equal(selectAiPolicy(actor, target).intent, 'skip');
+});

--- a/tests/ai/sistemaTurnRunner.test.js
+++ b/tests/ai/sistemaTurnRunner.test.js
@@ -1,0 +1,496 @@
+// SPRINT_015: test suite per apps/backend/services/ai/sistemaTurnRunner.js
+//
+// Strategy: creare un runner con dependency injection usando stub/mock
+// delle funzioni performAttack, buildAttackEvent, buildMoveEvent,
+// emitKillAndAssists, appendEvent. Cosi' il test e' completamente
+// isolato dal router session.js e dal trait registry.
+//
+// Copre:
+//   - Dual-action loop (2 iterazioni per turno a ap 2)
+//   - Break on kill (no iter 2 se iter 1 uccide)
+//   - Skip on stunned (consuma tutti AP, 1 action)
+//   - Retreat cornered + fallback approach flag per evitare oscillazioni
+//   - Overlap guard (cell occupata)
+//   - Distinzione retreat vs move type nell'output
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createSistemaTurnRunner } = require('../../apps/backend/services/ai/sistemaTurnRunner');
+
+// ─────────────────────────────────────────────────────────────────
+// helpers e fixture
+// ─────────────────────────────────────────────────────────────────
+
+function makeSession(overrides = {}) {
+  const units = overrides.units || [
+    {
+      id: 'unit_1',
+      species: 'velox',
+      job: 'skirmisher',
+      hp: 10,
+      max_hp: 10,
+      ap: 2,
+      ap_remaining: 2,
+      attack_range: 2,
+      position: { x: 0, y: 0 },
+      controlled_by: 'player',
+    },
+    {
+      id: 'unit_2',
+      species: 'carapax',
+      job: 'vanguard',
+      hp: 10,
+      max_hp: 10,
+      ap: 2,
+      ap_remaining: 2,
+      attack_range: 1,
+      position: { x: 3, y: 0 },
+      controlled_by: 'sistema',
+    },
+  ];
+  return {
+    session_id: 'test',
+    turn: 1,
+    active_unit: overrides.active_unit || 'unit_2',
+    units,
+    grid: { width: 6, height: 6 },
+    events: [],
+    damage_taken: {},
+    action_counter: 0,
+  };
+}
+
+function manhattanDistance(a, b) {
+  return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+}
+
+function pickLowestHpEnemy(session, actor) {
+  const enemies = session.units.filter(
+    (u) => u.id !== actor.id && u.hp > 0 && u.controlled_by !== actor.controlled_by,
+  );
+  if (!enemies.length) return null;
+  return enemies.reduce((lo, u) => (!lo || u.hp < lo.hp ? u : lo), null);
+}
+
+function stepTowards(from, to) {
+  const next = { ...from };
+  if (from.x !== to.x) next.x += from.x < to.x ? 1 : -1;
+  else if (from.y !== to.y) next.y += from.y < to.y ? 1 : -1;
+  return next;
+}
+
+// Factory per un runner con stubs configurabili
+function buildRunner(overrides = {}) {
+  const appended = [];
+  const killsEmitted = [];
+  const attackResults = overrides.attackResults || [
+    // default: 2 attacchi hit con damage 2 ciascuno
+    { hit: true, damage: 2, pt: 1, roll: 15, mos: 3 },
+    { hit: true, damage: 2, pt: 1, roll: 16, mos: 4 },
+    { hit: true, damage: 2, pt: 1, roll: 16, mos: 4 },
+  ];
+  let attackIdx = 0;
+
+  const performAttack = (session, actor, target) => {
+    const r = attackResults[attackIdx++] || attackResults[attackResults.length - 1];
+    const damageDealt = r.hit ? r.damage : 0;
+    if (r.hit) target.hp = Math.max(0, target.hp - damageDealt);
+    return {
+      result: {
+        hit: r.hit,
+        roll: r.roll || 15,
+        mos: r.mos || 3,
+        pt: r.pt || 0,
+        die: 20,
+      },
+      evaluation: { trait_effects: [] },
+      damageDealt,
+      killOccurred: target.hp === 0,
+    };
+  };
+
+  const buildAttackEvent = ({ session, actor, target, result }) => ({
+    action_type: 'attack',
+    actor_id: actor.id,
+    target_id: target.id,
+    turn: session.turn,
+    position_from: { ...actor.position },
+    target_position_at_attack: { ...target.position },
+    result: result.hit ? 'hit' : 'miss',
+  });
+
+  const buildMoveEvent = ({ session, actor, positionFrom }) => ({
+    action_type: 'move',
+    actor_id: actor.id,
+    turn: session.turn,
+    position_from: { ...positionFrom },
+    position_to: { ...actor.position },
+  });
+
+  const emitKillAndAssists = async (session, killer, target, event) => {
+    killsEmitted.push({ killer: killer.id, target: target.id });
+  };
+
+  const appendEvent = async (session, event) => {
+    appended.push(event);
+    session.events.push(event);
+  };
+
+  const runner = createSistemaTurnRunner({
+    pickLowestHpEnemy,
+    manhattanDistance,
+    stepTowards,
+    performAttack,
+    buildAttackEvent,
+    buildMoveEvent,
+    emitKillAndAssists,
+    appendEvent,
+    gridSize: 6,
+    ...overrides.depsOverrides,
+  });
+
+  return { runner, appended, killsEmitted };
+}
+
+// ─────────────────────────────────────────────────────────────────
+// test
+// ─────────────────────────────────────────────────────────────────
+
+test('runner: dual-action attack + attack se in range', async () => {
+  const { runner, appended } = buildRunner();
+  const session = makeSession({
+    units: [
+      {
+        id: 'unit_1',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        ap_remaining: 2,
+        attack_range: 2,
+        position: { x: 3, y: 0 },
+        controlled_by: 'player',
+      },
+      {
+        id: 'unit_2',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        ap_remaining: 2,
+        attack_range: 2,
+        position: { x: 2, y: 0 },
+        controlled_by: 'sistema',
+      },
+    ],
+  });
+  const actions = await runner(session);
+  assert.equal(actions.length, 2);
+  assert.equal(actions[0].type, 'attack');
+  assert.equal(actions[1].type, 'attack');
+  assert.equal(session.units[1].ap_remaining, 0);
+});
+
+test('runner: break on kill non esegue iter 2', async () => {
+  // Target starts with 1 HP, first hit uccide, runner deve break
+  const { runner, killsEmitted } = buildRunner({
+    attackResults: [{ hit: true, damage: 5, pt: 0 }],
+  });
+  const session = makeSession({
+    units: [
+      {
+        id: 'unit_1',
+        hp: 1,
+        max_hp: 10,
+        ap: 2,
+        ap_remaining: 2,
+        attack_range: 2,
+        position: { x: 3, y: 0 },
+        controlled_by: 'player',
+      },
+      {
+        id: 'unit_2',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        ap_remaining: 2,
+        attack_range: 2,
+        position: { x: 2, y: 0 },
+        controlled_by: 'sistema',
+      },
+    ],
+  });
+  const actions = await runner(session);
+  assert.equal(actions.length, 1);
+  assert.equal(actions[0].type, 'attack');
+  assert.equal(killsEmitted.length, 1);
+  assert.equal(session.units[0].hp, 0);
+});
+
+test('runner: fuori range fa move approach per 2 iter', async () => {
+  const { runner } = buildRunner();
+  const session = makeSession({
+    units: [
+      {
+        id: 'unit_1',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        ap_remaining: 2,
+        attack_range: 2,
+        position: { x: 0, y: 0 },
+        controlled_by: 'player',
+      },
+      {
+        id: 'unit_2',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        ap_remaining: 2,
+        attack_range: 1,
+        position: { x: 5, y: 0 },
+        controlled_by: 'sistema',
+      },
+    ],
+  });
+  const actions = await runner(session);
+  assert.equal(actions.length, 2);
+  assert.equal(actions[0].type, 'move');
+  assert.equal(actions[1].type, 'move');
+  // SIS si e' mosso di 2 celle verso P1 (da 5 a 3)
+  assert.equal(session.units[1].position.x, 3);
+});
+
+test('runner: REGOLA_002 retreat quando HP basso con spazio', async () => {
+  const { runner } = buildRunner();
+  const session = makeSession({
+    units: [
+      {
+        id: 'unit_1',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        ap_remaining: 2,
+        attack_range: 2,
+        position: { x: 1, y: 0 },
+        controlled_by: 'player',
+      },
+      {
+        id: 'unit_2',
+        hp: 2,
+        max_hp: 10,
+        ap: 2,
+        ap_remaining: 2,
+        attack_range: 1,
+        position: { x: 3, y: 0 },
+        controlled_by: 'sistema',
+      },
+    ],
+  });
+  const actions = await runner(session);
+  assert.equal(
+    actions.every((a) => a.ia_rule === 'REGOLA_002'),
+    true,
+  );
+  assert.equal(actions[0].type, 'retreat');
+  assert.equal(session.units[1].position.x, 5); // retreatato fino al bordo
+});
+
+test('runner: cornered fallback — retreat impossibile + in range → attack REGOLA_001', async () => {
+  const { runner } = buildRunner();
+  const session = makeSession({
+    units: [
+      {
+        id: 'unit_1',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        ap_remaining: 2,
+        attack_range: 2,
+        position: { x: 4, y: 5 },
+        controlled_by: 'player',
+      },
+      {
+        id: 'unit_2',
+        hp: 2,
+        max_hp: 10,
+        ap: 2,
+        ap_remaining: 2,
+        attack_range: 1,
+        position: { x: 5, y: 5 }, // corner, non puo' ritirarsi
+        controlled_by: 'sistema',
+      },
+    ],
+  });
+  const actions = await runner(session);
+  // Entrambi gli iter dovrebbero essere attack REGOLA_001 (desperate attack)
+  assert.equal(actions.length, 2);
+  assert.equal(actions[0].type, 'attack');
+  assert.equal(actions[0].ia_rule, 'REGOLA_001');
+  assert.equal(actions[1].ia_rule, 'REGOLA_001');
+});
+
+test('runner: cornered fallback — retreat impossibile + fuori range → approach', async () => {
+  const { runner } = buildRunner();
+  const session = makeSession({
+    units: [
+      {
+        id: 'unit_1',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        ap_remaining: 2,
+        attack_range: 2,
+        position: { x: 2, y: 3 },
+        controlled_by: 'player',
+      },
+      {
+        id: 'unit_2',
+        hp: 2,
+        max_hp: 10,
+        ap: 2,
+        ap_remaining: 2,
+        attack_range: 1,
+        position: { x: 2, y: 5 }, // bordo bottom, non puo' retreatare verso y=6
+        controlled_by: 'sistema',
+      },
+    ],
+  });
+  const actions = await runner(session);
+  // Iter 1: cornered, fuori range 1 (dist 2) → approach
+  // Iter 2: ora a dist 1, in range → attack
+  assert.equal(actions.length, 2);
+  assert.equal(actions[0].type, 'move');
+  assert.equal(actions[0].ia_rule, 'REGOLA_001');
+  assert.equal(actions[1].type, 'attack');
+});
+
+test('runner: stunned → 1 skip action e break', async () => {
+  const { runner } = buildRunner();
+  const session = makeSession({
+    units: [
+      {
+        id: 'unit_1',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        ap_remaining: 2,
+        attack_range: 2,
+        position: { x: 2, y: 0 },
+        controlled_by: 'player',
+      },
+      {
+        id: 'unit_2',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        ap_remaining: 2,
+        attack_range: 1,
+        position: { x: 3, y: 0 },
+        status: { stunned: 2, rage: 0, panic: 0 },
+        controlled_by: 'sistema',
+      },
+    ],
+  });
+  const actions = await runner(session);
+  assert.equal(actions.length, 1);
+  assert.equal(actions[0].type, 'skip');
+  assert.equal(actions[0].ia_rule, 'STATO_STUNNED');
+  assert.equal(actions[0].ap_spent, 2);
+  assert.equal(session.units[1].ap_remaining, 0);
+});
+
+test('runner: overlap guard — blocker sulla cella destinazione', async () => {
+  // SIS vuole approach verso P1, ma c'e' un'altra unita' alleata in mezzo
+  const { runner } = buildRunner();
+  const session = makeSession({
+    units: [
+      {
+        id: 'unit_1',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        ap_remaining: 2,
+        attack_range: 2,
+        position: { x: 0, y: 0 },
+        controlled_by: 'player',
+      },
+      {
+        id: 'unit_2',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        ap_remaining: 2,
+        attack_range: 1,
+        position: { x: 5, y: 0 },
+        controlled_by: 'sistema',
+      },
+      {
+        id: 'unit_3',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        ap_remaining: 2,
+        attack_range: 1,
+        position: { x: 4, y: 0 }, // blocca lo step di unit_2
+        controlled_by: 'sistema',
+      },
+    ],
+  });
+  const actions = await runner(session);
+  // stepTowards da (5,0) verso (0,0): dx=-1 → (4,0) ma c'e' unit_3 → skip
+  assert.ok(actions.some((a) => a.type === 'skip' && a.reason.includes('blocked by')));
+});
+
+test('runner: actor morto o inesistente → ritorna array vuoto', async () => {
+  const { runner } = buildRunner();
+  const session = makeSession({ active_unit: 'nonesiste' });
+  const actions = await runner(session);
+  assert.deepEqual(actions, []);
+});
+
+test('runner: AP pieni se ap_remaining era 0 a inizio turno', async () => {
+  const { runner } = buildRunner();
+  const session = makeSession({
+    units: [
+      {
+        id: 'unit_1',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        ap_remaining: 2,
+        attack_range: 2,
+        position: { x: 3, y: 0 },
+        controlled_by: 'player',
+      },
+      {
+        id: 'unit_2',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        ap_remaining: 0, // dimenticato il reset
+        attack_range: 2,
+        position: { x: 2, y: 0 },
+        controlled_by: 'sistema',
+      },
+    ],
+  });
+  const actions = await runner(session);
+  // Il runner reintegra: deve comunque fare 2 azioni
+  assert.equal(actions.length, 2);
+});
+
+test('runner: factory valida deps required', () => {
+  assert.throws(() => createSistemaTurnRunner({}), /pickLowestHpEnemy is required/);
+  assert.throws(
+    () => createSistemaTurnRunner({ pickLowestHpEnemy: () => null }),
+    /stepTowards is required/,
+  );
+  assert.throws(
+    () =>
+      createSistemaTurnRunner({
+        pickLowestHpEnemy: () => null,
+        stepTowards: () => null,
+      }),
+    /performAttack is required/,
+  );
+});


### PR DESCRIPTION
## Summary

Aggiunge **45 unit test** (34 \`policy.test.js\` + 11 \`sistemaTurnRunner.test.js\`) per il modulo AI estratto in sprint-010. Protegge il codice dalle regression durante future modifiche.

**Prima** di questo sprint: ogni modifica alla policy engine richiedeva validazione manuale via Claude Preview (~10 min per full pass su 4 scenari).
**Dopo**: 118ms di test automatici, 45 scenari coperti.

## Coverage \`tests/ai/policy.test.js\` (34 test)

- \`manhattanDistance\`: purezza, simmetria, edge null
- \`stepAway\`: asse x vs y, tie-breaker, fallback, cornered totale, gridSize custom
- \`selectAiPolicy\` REGOLA_001: in range/fuori range/default attack_range
- \`selectAiPolicy\` REGOLA_002: soglia esatta 30%, edge HP 0, max_hp fallback
- \`selectAiPolicy\` REGOLA_003 kite: safe zone/in target range/fuori/range uguali/inferiore
- \`checkEmotionalOverrides\`: null/zero/priorità \`stunned > rage > panic\`
- **Integration override**: rage batte REGOLA_002 HP retreat, panic batte stato normale, stunned batte tutto (anche REGOLA_003)

## Coverage \`tests/ai/sistemaTurnRunner.test.js\` (11 test)

Strategy: **dependency injection con stubs configurabili**. Factory \`buildRunner({ attackResults, depsOverrides })\`:
- Forza sequenze di attack result deterministiche (no RNG)
- Intercetta appended events, kills emessi
- Mocka \`performAttack\`, \`buildAttackEvent\`, \`buildMoveEvent\`, \`emitKillAndAssists\`, \`appendEvent\`

- Dual-action loop standard (2 attacchi, ap 2→0)
- Break on kill (no iter 2 se iter 1 uccide)
- Approach → approach fuori range
- REGOLA_002 retreat con spazio (retreatato fino al bordo)
- **Fallback cornered + in range → desperate attack ×2**
- **Fallback cornered + fuori range → approach** (SIS si sposta, poi attack iter 2)
- Stunned → 1 skip action \`ap_spent=2\` + break
- Overlap guard con blocker
- Actor inesistente → array vuoto
- AP reset se \`ap_remaining=0\` a inizio turno
- Factory throws su deps mancanti

## Protegge edge case storici

| Sprint | Bug scoperto | Test che lo copre |
|---|---|---|
| 009 | SIS stuck in corner 8+ turni | \`cornered fallback fuori range → approach\` |
| 009 | Oscillazione retreat↔approach | \`cornered in range → 2 desperate attacks\` (flag corneredThisTurn) |
| 013 | Rage + HP basso potrebbe entrare in R002 | \`rage override HP retreat (REGOLA_002)\` |
| 013 | Stunned deve battere tutto | \`stunned override tutto\` |

## Esecuzione

\`\`\`bash
node --test tests/ai/policy.test.js
node --test tests/ai/sistemaTurnRunner.test.js
# Totale: 45 test, ~118ms
\`\`\`

## Rollback

\`git revert 7c7047af\` rimuove i test. **Zero modifiche al codice di produzione**: solo nuovi file di test, impatto 0 sul comportamento runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)