### PR TITLE
feat(combat): status fisici bleeding + fracture (sprint-019)

### DIFF
--- a/apps/backend/public/Evo-Tactics — Playtest.html
+++ b/apps/backend/public/Evo-Tactics — Playtest.html
@@ -204,9 +204,12 @@
     50% { transform: scale(1.18); }
   }
   /* Glow intorno al token quando c'e' uno stato attivo */
-  .cell.has-status-panic   { box-shadow: inset 0 0 12px rgba(255, 204,  79, .35); }
-  .cell.has-status-rage    { box-shadow: inset 0 0 12px rgba(226,  75,  74, .50); }
-  .cell.has-status-stunned { box-shadow: inset 0 0 12px rgba(192, 132, 252, .40); }
+  .cell.has-status-panic    { box-shadow: inset 0 0 12px rgba(255, 204,  79, .35); }
+  .cell.has-status-rage     { box-shadow: inset 0 0 12px rgba(226,  75,  74, .50); }
+  .cell.has-status-stunned  { box-shadow: inset 0 0 12px rgba(192, 132, 252, .40); }
+  /* SPRINT_019: status fisici */
+  .cell.has-status-bleeding { box-shadow: inset 0 0 12px rgba(220,  38,  38, .55); }
+  .cell.has-status-fracture { box-shadow: inset 0 0 12px rgba(250, 204,  21, .40); }
 
   /* Riga stati attivi nel pannello unit-card */
   .status-row {
@@ -225,9 +228,12 @@
     border: 1px solid var(--border);
     background: rgba(0,0,0,.2);
   }
-  .status-chip.panic   { border-color: #ffcc4f; color: #ffcc4f; }
-  .status-chip.rage    { border-color: var(--p2); color: var(--p2-light); }
-  .status-chip.stunned { border-color: #c084fc; color: #c084fc; }
+  .status-chip.panic    { border-color: #ffcc4f; color: #ffcc4f; }
+  .status-chip.rage     { border-color: var(--p2); color: var(--p2-light); }
+  .status-chip.stunned  { border-color: #c084fc; color: #c084fc; }
+  /* SPRINT_019: chip status fisici */
+  .status-chip.bleeding { border-color: #dc2626; color: #f87171; }
+  .status-chip.fracture { border-color: #facc15; color: #fde047; }
   .status-chip-dur { opacity: .75; font-weight: 700; }
 
   /* SPRINT_017: scenario picker grid di bottoni */
@@ -453,6 +459,7 @@
         <button class="btn scenario-btn"        data-scenario="mirror_ranger"  onclick="startSession('mirror_ranger')">Mirror Ranger</button>
         <button class="btn scenario-btn"        data-scenario="berserker"     onclick="startSession('berserker')">Berserker</button>
         <button class="btn scenario-btn"        data-scenario="shock_troops"  onclick="startSession('shock_troops')">Shock Troops</button>
+        <button class="btn scenario-btn"        data-scenario="bloody_mess"   onclick="startSession('bloody_mess')">Bloody Mess</button>
       </div>
     </div>
 
@@ -540,6 +547,15 @@ const SCENARIOS = {
       { id:'unit_2', species:'carapax', job:'vanguard',   traits:['pelle_elastomera','stordimento'], controlled_by:'sistema', position:{x:5,y:5} },
     ],
   },
+  // SPRINT_019: scenario per testare gli status fisici
+  bloody_mess: {
+    label: 'Bloody Mess',
+    desc: 'Tu velox + denti seghettati (bleeding), SIS carapax + martello osseo (frattura)',
+    units: [
+      { id:'unit_1', species:'velox',   job:'skirmisher', traits:['zampe_a_molla','denti_seghettati'], controlled_by:'player',  position:{x:0,y:0} },
+      { id:'unit_2', species:'carapax', job:'vanguard',   traits:['pelle_elastomera','martello_osseo'], controlled_by:'sistema', position:{x:5,y:5} },
+    ],
+  },
 };
 
 let currentScenarioId = 'classic';
@@ -597,9 +613,18 @@ function render() {
   }
 }
 
-// SPRINT_014: stato → emoji. Priorita' visiva: stunned > rage > panic.
-const STATUS_EMOJI = { stunned: '💫', rage: '😡', panic: '😱' };
-const STATUS_PRIORITY = ['stunned', 'rage', 'panic'];
+// SPRINT_014 + SPRINT_019: stato → emoji. Priorita' visiva:
+// stunned > rage > bleeding > fracture > panic.
+// stati fisici (bleeding/fracture) dominano su panic perche' sono piu'
+// pericolosi meccanicamente (DoT + movement penalty).
+const STATUS_EMOJI = {
+  stunned: '💫',
+  rage: '😡',
+  bleeding: '🩸',
+  fracture: '🦴',
+  panic: '😱',
+};
+const STATUS_PRIORITY = ['stunned', 'rage', 'bleeding', 'fracture', 'panic'];
 
 function activeStatuses(unit) {
   if (!unit || !unit.status) return [];
@@ -750,11 +775,13 @@ function snapshotStatuses(s) {
   return out;
 }
 const STATUS_LABEL = {
-  panic:   'panico',
-  rage:    'rabbia',
-  stunned: 'stordimento',
-  focused: 'concentrazione',
-  confused:'confusione',
+  panic:    'panico',
+  rage:     'rabbia',
+  stunned:  'stordimento',
+  focused:  'concentrazione',
+  confused: 'confusione',
+  bleeding: 'sanguinamento',
+  fracture: 'frattura',
 };
 function logStatusDiff(pre, post) {
   for (const [unitId, cur] of Object.entries(post)) {
@@ -796,6 +823,14 @@ async function endTurn() {
   try {
     const res = await api('/api/session/turn/end', {});
     state = res.state ?? state;
+    // SPRINT_019: side_effects (bleeding damage) loggati PRIMA delle
+    // azioni IA perche' avvengono a inizio /turn/end nel backend.
+    const sideEffects = res.side_effects || [];
+    for (const se of sideEffects) {
+      const who = se.unit_id === 'unit_1' ? 'P1' : 'SIS';
+      const kill = se.killed ? ' → KO' : '';
+      addLog('miss', `🩸 ${who} sanguina (−${se.damage} HP, hp ${se.hp_after})${kill}`);
+    }
     const iaList = res.ia_actions ?? (res.ia_action ? [res.ia_action] : []);
     for (const ia of iaList) logIaAction(ia);
     logStatusDiff(preStatus, snapshotStatuses(state));

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -118,13 +118,24 @@ function normaliseUnit(raw, fallbackIndex) {
   // possibile dall'input (utile per scenari di test che partono con SIS
   // gia' ferito). Default: parte a hp iniziale (unita' fresca = full HP).
   const maxHp = Number.isFinite(Number(input.max_hp)) ? Number(input.max_hp) : hp;
-  // SPRINT_013 (issue #10): oggetto status per stati emotivi temporanei.
+  // SPRINT_013 (issue #10): oggetto status per stati temporanei.
   // Ogni chiave e' il nome dello stato, valore = turns_remaining.
   // 0 o mancante = inattivo. Accetta override iniziale dall'input.
+  // SPRINT_019: aggiunti status fisici bleeding e fracture dal design
+  // doc docs/core/10-SISTEMA_TATTICO.md. bleeding = DoT non riducibile,
+  // fracture = ap_remaining reset a 1 invece di ap pieno.
   const status =
     input.status && typeof input.status === 'object'
       ? { ...input.status }
-      : { panic: 0, rage: 0, stunned: 0, focused: 0, confused: 0 };
+      : {
+          panic: 0,
+          rage: 0,
+          stunned: 0,
+          focused: 0,
+          confused: 0,
+          bleeding: 0,
+          fracture: 0,
+        };
   return {
     id,
     species: input.species ? String(input.species) : 'unknown',
@@ -739,39 +750,93 @@ function createSessionRouter(options = {}) {
       const { error, session } = resolveSession(body.session_id);
       if (error) return res.status(error.status).json(error.body);
 
-      // 1. Reset ap_remaining dell'unita' che sta terminando il turno
-      const current = session.units.find((u) => u.id === session.active_unit);
-      if (current) {
-        current.ap_remaining = current.ap;
-      }
+      // Helper: damage-over-time (bleeding) applicato a una singola unita'.
+      // Ritorna l'evento descrittore se applicato, null altrimenti.
+      const bleedingEvents = [];
+      const applyBleedingTo = async (unit) => {
+        if (!unit || !unit.status || unit.hp <= 0) return;
+        const bleedTurns = Number(unit.status.bleeding) || 0;
+        if (bleedTurns <= 0) return;
+        const dmg = 1;
+        const hpBefore = unit.hp;
+        unit.hp = Math.max(0, unit.hp - dmg);
+        session.damage_taken[unit.id] = (session.damage_taken[unit.id] || 0) + dmg;
+        await appendEvent(session, {
+          ts: new Date().toISOString(),
+          session_id: session.session_id,
+          action_type: 'bleeding',
+          actor_id: unit.id,
+          actor_species: unit.species,
+          actor_job: unit.job,
+          target_id: unit.id,
+          turn: session.turn,
+          damage_dealt: dmg,
+          result: 'hit',
+          hp_before: hpBefore,
+          hp_after: unit.hp,
+          bleeding_remaining: bleedTurns - 1,
+          trait_effects: [],
+        });
+        bleedingEvents.push({
+          unit_id: unit.id,
+          damage: dmg,
+          hp_after: unit.hp,
+          killed: unit.hp === 0,
+        });
+      };
 
-      // SPRINT_013 (issue #10): decrementa le durate degli stati emotivi
-      // di TUTTE le unita' alla fine del turno. Uno stato che scade diventa
-      // 0 (inattivo). Cosi' panic/rage/stunned durano N turni e poi
-      // spariscono automaticamente.
-      for (const unit of session.units) {
-        if (!unit.status) continue;
+      // Helper: reset ap_remaining rispettando fracture (se attivo, cap a 1).
+      const resetApWithStatus = (unit) => {
+        if (!unit) return;
+        const fractureActive = Number(unit.status?.fracture) > 0;
+        unit.ap_remaining = fractureActive ? Math.min(1, unit.ap) : unit.ap;
+      };
+
+      // Helper: decrementa tutte le status durations di UNA unita' (end-of-turn).
+      // Questo e' la variante per-unit della vecchia logica global.
+      // SPRINT_019: separato per timing corretto di fracture e bleeding.
+      const decrementStatuses = (unit) => {
+        if (!unit || !unit.status) return;
         for (const key of Object.keys(unit.status)) {
           const v = Number(unit.status[key]);
           if (v > 0) {
             unit.status[key] = v - 1;
           }
         }
-      }
+      };
+
+      // === END OF CURRENT UNIT'S TURN ===
+      // 1a. Bleeding damage applicato all'unita' che sta finendo (se bleeding)
+      const current = session.units.find((u) => u.id === session.active_unit);
+      await applyBleedingTo(current);
+      // 1b. Reset ap_remaining per il prossimo turno dell'unita' corrente
+      // (fracture check usando il valore CORRENTE di fracture, pre-decrement)
+      if (current) resetApWithStatus(current);
+      // 1c. Decrement delle status durations dell'unita' corrente
+      decrementStatuses(current);
 
       // 2. Passa il turno all'unita' successiva
       const nextId = nextUnitId(session);
       session.active_unit = nextId;
       session.turn += 1;
 
-      // 3. Se la nuova unita' e' controllata dal sistema, esegui REGOLA_001
-      //    e avanza di nuovo al prossimo turno giocatore, in modo che un
-      //    singolo "Fine Turno" chiuda il round e restituisca il controllo.
+      // 3. Se la nuova unita' e' controllata dal sistema, esegui il suo
+      //    turno e avanza oltre per tornare al player.
       const next = session.units.find((u) => u.id === nextId);
       let iaActions = [];
       if (next && next.controlled_by === 'sistema' && next.hp > 0) {
-        iaActions = await runSistemaTurn(session);
-        next.ap_remaining = next.ap;
+        // === START OF SIS TURN ===
+        // 3a. Bleeding damage al SIS (se bleeding, applicato prima di agire)
+        await applyBleedingTo(next);
+        // 3b. Pre-SIS-turn reset AP con fracture check (usando valore pre-decrement)
+        if (next.hp > 0) {
+          resetApWithStatus(next);
+          // 3c. Esegui turno IA con AP gia' limitati se fracture attivo
+          iaActions = await runSistemaTurn(session);
+        }
+        // === END OF SIS TURN ===
+        // 3d. Decrement delle status durations del SIS (post-turno)
+        decrementStatuses(next);
         const followupId = nextUnitId(session);
         session.active_unit = followupId;
         session.turn += 1;
@@ -783,6 +848,10 @@ function createSessionRouter(options = {}) {
         active_unit: session.active_unit,
         ia_actions: iaActions,
         ia_action: iaActions[0] || null,
+        // SPRINT_019: side_effects contiene i danni da status fisici
+        // applicati a inizio /turn/end (bleeding e simili). Il frontend
+        // li logga separatamente con emoji 🩸.
+        side_effects: bleedingEvents,
         state: publicSessionView(session),
       });
     } catch (err) {

--- a/apps/backend/services/ai/sistemaTurnRunner.js
+++ b/apps/backend/services/ai/sistemaTurnRunner.js
@@ -65,7 +65,10 @@ function createSistemaTurnRunner(deps) {
     const actor = session.units.find((u) => u.id === session.active_unit);
     if (!actor) return [];
     if ((actor.ap_remaining ?? 0) <= 0) {
-      actor.ap_remaining = actor.ap;
+      // SPRINT_019: safety-net reset con check fracture (movement penalty).
+      // Se l'actor ha fracture > 0, limita a 1 AP per il turno.
+      const fractureActive = Number(actor.status?.fracture) > 0;
+      actor.ap_remaining = fractureActive ? Math.min(1, actor.ap) : actor.ap;
     }
 
     const actions = [];

--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -118,3 +118,45 @@ traits:
     description_it: |
       Colpo traumatico: ogni critico (MoS >= 8) applica 1 turno di
       stunned al bersaglio, che saltera' il turno successivo.
+
+  # SPRINT_019: status fisici (Sanguinamento + Frattura), dal design doc
+  # docs/core/10-SISTEMA_TATTICO.md linea 18. Si innestano sul sistema
+  # status di sprint-013 + trait pipeline di sprint-018.
+
+  denti_seghettati:
+    tier: T1
+    category: fisiologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: apply_status
+      target_side: target
+      stato: bleeding
+      turns: 2
+      log_tag: denti_bleeding
+    description_it: |
+      Denti seghettati che lacerano la carne del bersaglio. Ogni hit
+      applica 2 turni di sanguinamento: il target subisce 1 danno non
+      riducibile al termine di ogni turno.
+
+  martello_osseo:
+    tier: T1
+    category: traumatico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      # Trigger solo sui colpi critici (mos >= 8).
+      min_mos: 8
+    effect:
+      kind: apply_status
+      target_side: target
+      stato: fracture
+      turns: 2
+      log_tag: martello_fracture
+    description_it: |
+      Protuberanza ossea pesante come una mazza. Ogni critico (MoS >= 8)
+      applica 2 turni di frattura: il target perde AP al reset di turno
+      (ap_remaining = 1 invece di ap pieno), limitando il movimento.


### PR DESCRIPTION
## Summary

Chiude il gap fra il design doc (\`docs/core/10-SISTEMA_TATTICO.md\` linea 18 — *"Status: fisici **Sanguinamento, Frattura**, Disorientamento; mentali Furia, Panico"*) e l'implementazione. Sprint-013 aveva già gli **stati mentali** (panic/rage/stunned); ora si aggiungono i **fisici** bleeding e fracture usando la stessa foundation.

## 2 nuovi stati fisici

### 🩸 bleeding — damage over time
- **1 danno non riducibile** per turno al \`unit.hp\`
- Emesso come evento \`action_type='bleeding'\` a inizio \`/turn/end\`
- Bypassa \`pelle_elastomera\` (non passa da performAttack)
- Contato in \`damage_taken\` per le metriche VC

### 🦴 fracture — movement penalty
- Cap \`ap_remaining\` a \`min(1, actor.ap)\` per la durata
- Applicato nei **2 punti di reset AP**: \`/turn/end\` pre-turn e safety-net di \`runSistemaTurn\`
- \`fracture=2\` causa **esattamente 2 turni di AP ridotto**

## 2 nuovi trait

| Trait | Trigger | Effect |
|---|---|---|
| **denti_seghettati** (actor) | \`on_result=hit\` | target \`bleeding=2\` |
| **martello_osseo** (actor) | \`on_result=hit + min_mos=8\` | target \`fracture=2\` |

## 🔧 Refactor del timing in \`/turn/end\`

**Bug scoperto durante il test**: il vecchio global decrement delle status durations dopo il reset \`current.ap_remaining\` + reset POST-turn per SIS (line 826 legacy) faceva perdere **un turno** di effetto fracture. \`fracture=2\` dava solo 1 turno di penalty invece di 2.

**Fix**: separazione del decrement in due fasi **per-unit**:

\`\`\`
End of current unit turn (P1 di solito):
  1. applyBleedingTo(current)       ← bleeding DoT
  2. resetApWithStatus(current)      ← pre-decrement fracture check  
  3. decrementStatuses(current)      ← decrement SOLO su current

Advance to SIS, turn++

End of SIS turn (auto-advance):
  4. applyBleedingTo(next)           ← SIS bleeding
  5. resetApWithStatus(next)         ← pre-SIS-turn reset fracture check
  6. runSistemaTurn(session)         ← SIS agisce con AP gia' limitati
  7. decrementStatuses(next)         ← decrement SOLO su SIS
\`\`\`

Così ogni unità sperimenta fracture per esattamente \`turns\` turni, consistente col comportamento degli stati mentali.

Nuovi helper locali (scope per-chiamata):
- \`applyBleedingTo(unit)\`: emette evento + damage + push bleedingEvents
- \`resetApWithStatus(unit)\`: reset AP rispettando fracture
- \`decrementStatuses(unit)\`: decrementa chiavi > 0

Stesso fix applicato a \`sistemaTurnRunner.js\` safety-net.

## UI sprint-014 estesa

- \`STATUS_EMOJI\`: + 🩸 bleeding, 🦴 fracture
- \`STATUS_PRIORITY\`: \`stunned > rage > bleeding > fracture > panic\`
- \`STATUS_LABEL\`: + sanguinamento, frattura
- CSS glow: \`.has-status-bleeding\` (rosso), \`.has-status-fracture\` (giallo)
- CSS chip: \`.status-chip.bleeding\`, \`.status-chip.fracture\`
- **Nuovo scenario "Bloody Mess"**: P1 velox con denti_seghettati vs SIS carapax con martello_osseo

### Frontend side_effects log

Response di \`/turn/end\` ora include \`side_effects: [...]\` con la lista dei bleeding damage. Il frontend li logga con emoji 🩸:
\`\`\`
🩸 SIS sanguina (−1 HP, hp 94)
\`\`\`

## Test end-to-end validati

**Bleeding**:
- P1 hit SIS con denti_seghettati → \`SIS.bleeding=2\` ✅
- Fine turno: \`side_effects=[{damage:1, hp_after:94}]\` ✅
- SIS.bleeding decrementato a 1

**Fracture** (verifica duration esatta):
- P1 critico MoS=25 con martello_osseo → \`SIS.fracture=2\`
- **T1 end**: SIS \`ia_count=1\`, fracture 2→1 ✅
- **T2 end**: SIS \`ia_count=1\`, fracture 1→0 ✅
- **T3 end**: SIS \`ia_count=2\`, fracture scaduto ✅

\`fracture=2\` → 2 turni di penalty, esatta corrispondenza col semantico del designer.

## Valore design

Questo sprint chiude il gap principale fra design doc e implementazione per gli status. Il sistema ora supporta:
- **5 stati mentali**: panic, rage, stunned, focused, confused (ultimi 2 dichiarati ma non triggered)
- **2 stati fisici**: bleeding, fracture
- **7 trait vivi** in \`active_effects.yaml\` (2 legacy + 3 sprint-018 + 2 sprint-019)

Pattern consolidato per aggiungere nuovi stati:
1. Aggiungerlo a \`unit.status\` defaults
2. Emoji + label nel frontend
3. (Opz) Integrazione in \`selectAiPolicy\` se altera comportamento
4. (Opz) Effetto speciale in \`/turn/end\` se DoT o penalty
5. Trait in \`active_effects.yaml\` che lo applica

## Rollback plan

- \`git revert dfe50282\` ripristina pre-sprint-019
- **Schema**: nessun cambio
- **Contracts**: nessun cambio
- **Backward compat**: trait legacy identici, stati mentali invariati

🤖 Generated with [Claude Code](https://claude.com/claude-code)