### PR TITLE
feat(combat): facing + backstab + azione turn (sprint-022)

### DIFF
--- a/apps/backend/public/Evo-Tactics — Playtest.html
+++ b/apps/backend/public/Evo-Tactics — Playtest.html
@@ -199,6 +199,42 @@
     pointer-events: none;
     animation: pulse-status 1.2s ease-in-out infinite;
   }
+
+  /* SPRINT_022: indicatore di facing — piccolo triangolo al bordo della
+     cella sul lato verso cui guarda l'unita'. */
+  .facing-arrow {
+    position: absolute;
+    width: 0;
+    height: 0;
+    pointer-events: none;
+    opacity: .85;
+  }
+  .facing-arrow.N {
+    top: 2px; left: 50%; transform: translateX(-50%);
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-bottom: 6px solid currentColor;
+  }
+  .facing-arrow.S {
+    bottom: 2px; left: 50%; transform: translateX(-50%);
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 6px solid currentColor;
+  }
+  .facing-arrow.E {
+    right: 2px; top: 50%; transform: translateY(-50%);
+    border-top: 5px solid transparent;
+    border-bottom: 5px solid transparent;
+    border-left: 6px solid currentColor;
+  }
+  .facing-arrow.W {
+    left: 2px; top: 50%; transform: translateY(-50%);
+    border-top: 5px solid transparent;
+    border-bottom: 5px solid transparent;
+    border-right: 6px solid currentColor;
+  }
+  .cell .facing-arrow.p1-color { color: var(--p1-light); }
+  .cell .facing-arrow.sistema-color { color: var(--p2-light); }
   @keyframes pulse-status {
     0%, 100% { transform: scale(1); }
     50% { transform: scale(1.18); }
@@ -663,11 +699,16 @@ function renderGrid() {
         const badgeHtml = (!dead && statuses.length)
           ? `<span class="status-badge" title="${statuses.map(s=>s.key+' '+s.turns).join(', ')}">${STATUS_EMOJI[statuses[0].key]}</span>`
           : '';
+        // SPRINT_022: facing arrow sul token quando vivo
+        const facing = u.facing || 'S';
+        const facingHtml = !dead
+          ? `<span class="facing-arrow ${facing} ${isP1 ? 'p1-color' : 'sistema-color'}" title="facing ${facing}"></span>`
+          : '';
         cell.innerHTML = `
           <div class="token ${cls} ${selected === u.id ? 'selected' : ''} ${dead ? 'dead' : ''}">
             <span>${isP1 ? 'P1' : 'SIS'}</span>
             <span class="token-job">${u.job?.slice(0,4) ?? ''}</span>
-          </div>${badgeHtml}`;
+          </div>${facingHtml}${badgeHtml}`;
       }
 
       // highlight celle raggiungibili / attaccabili (solo se AP disponibili).

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -59,6 +59,10 @@ const DEFAULT_GUARDIA = 1;
 // DEFAULT_ATTACK_RANGE importato da services/ai/policy.js — autoritativo.
 // SPRINT_020: default initiative per unita' senza override esplicito.
 const DEFAULT_INITIATIVE = 10;
+// SPRINT_022: facing direction (backstab). Default 'S' = looking down
+// sulla griglia (verso y crescenti). Le 4 direzioni cardinali.
+const DEFAULT_FACING = 'S';
+const VALID_FACINGS = new Set(['N', 'S', 'E', 'W']);
 // SPRINT_020: initiative per job canonico. Skirmisher e ranger sono
 // mobili/veloci → init alta. Vanguard e harvester sono lenti → init bassa.
 // Fa da fallback se input.initiative e job_stats non lo sovrascrivono.
@@ -157,6 +161,11 @@ function normaliseUnit(raw, fallbackIndex) {
     : Number.isFinite(Number(JOB_INITIATIVE[job]))
       ? Number(JOB_INITIATIVE[job])
       : DEFAULT_INITIATIVE;
+  // SPRINT_022: facing direction. Accetta override, fallback 'S'.
+  // P1 di default spawna in alto-sinistra e guarda in basso,
+  // SIS in basso-destra e guarda in alto.
+  const rawFacing = input.facing ? String(input.facing).toUpperCase() : null;
+  const facing = VALID_FACINGS.has(rawFacing) ? rawFacing : fallbackIndex === 0 ? 'S' : 'N';
   return {
     id,
     species: input.species ? String(input.species) : 'unknown',
@@ -172,6 +181,7 @@ function normaliseUnit(raw, fallbackIndex) {
     guardia: Number.isFinite(Number(input.guardia)) ? Number(input.guardia) : DEFAULT_GUARDIA,
     attack_range: attackRange,
     initiative,
+    facing,
     position,
     controlled_by: input.controlled_by ? String(input.controlled_by) : 'player',
   };
@@ -324,6 +334,43 @@ function stepTowards(from, to) {
   return clampPosition(next.x, next.y);
 }
 
+// SPRINT_022: facing helpers — determina se l'actor sta attaccando
+// il target "dalle spalle" (backstab). Il facing di un'unita' e'
+// una direzione cardinale (N/S/E/W). La cella "dietro" e' l'opposta
+// del facing:
+//   - facing N → dietro = cella con y > target.y
+//   - facing S → dietro = cella con y < target.y
+//   - facing E → dietro = cella con x < target.x
+//   - facing W → dietro = cella con x > target.x
+//
+// Backstab = actor.position e' nella semipiano dietro rispetto al
+// facing del target. Non richiede adiacenza stretta (funziona anche
+// per attacchi ranged).
+function isBackstab(actor, target) {
+  if (!actor?.position || !target?.position) return false;
+  const f = target.facing || DEFAULT_FACING;
+  const dx = actor.position.x - target.position.x;
+  const dy = actor.position.y - target.position.y;
+  if (f === 'N') return dy > 0;
+  if (f === 'S') return dy < 0;
+  if (f === 'E') return dx < 0;
+  if (f === 'W') return dx > 0;
+  return false;
+}
+
+// SPRINT_022: auto-compute new facing quando l'unita' si muove.
+// La direzione di facing diventa quella del movimento (asse col
+// delta maggiore, tie-breaker su x).
+function facingFromMove(from, to) {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  if (dx === 0 && dy === 0) return null;
+  if (Math.abs(dx) >= Math.abs(dy)) {
+    return dx > 0 ? 'E' : 'W';
+  }
+  return dy > 0 ? 'S' : 'N';
+}
+
 // stepAway e selectAiPolicy sono stati estratti in services/ai/policy.js
 // (SPRINT_010 issue #2). Qui viene mantenuto solo l'import a inizio file.
 
@@ -413,6 +460,8 @@ function createSessionRouter(options = {}) {
     let killOccurred = false;
     let adjacencyBonus = 0;
     let rageBonus = 0;
+    let backstabBonus = 0;
+    let wasBackstab = false;
     let panicTriggered = false;
     let parryResult = null;
     if (result.hit) {
@@ -430,12 +479,23 @@ function createSessionRouter(options = {}) {
       if (actor.status && Number(actor.status.rage) > 0) {
         rageBonus = 1;
       }
-      // SPRINT_021: parata reattiva, pre-calcolata cosi' il damage_delta
-      // partecipa al calcolo del damage finale. Solo se result.hit.
-      parryResult = rollParry(target);
+      // SPRINT_022: bonus backstab — se l'actor attacca dalle spalle del
+      // target (posizione dietro il suo facing), +1 damage. Cumulativo con
+      // adjacency e rage. Inoltre: un backstab BYPASSA la parata (sorpresa).
+      wasBackstab = isBackstab(actor, target);
+      if (wasBackstab) {
+        backstabBonus = 1;
+      }
+      // SPRINT_021: parata reattiva. SPRINT_022: saltata se backstab.
+      parryResult = wasBackstab ? null : rollParry(target);
       const parryDelta = parryResult && parryResult.success ? parryResult.damage_delta : 0;
       const adjusted =
-        baseDamage + evaluation.damage_modifier + adjacencyBonus + rageBonus + parryDelta;
+        baseDamage +
+        evaluation.damage_modifier +
+        adjacencyBonus +
+        rageBonus +
+        backstabBonus +
+        parryDelta;
       damageDealt = Math.max(0, adjusted);
       // Consuma guardia solo se parata riuscita (mitigazione cumulativa)
       if (parryResult && parryResult.success) {
@@ -494,6 +554,8 @@ function createSessionRouter(options = {}) {
       killOccurred,
       adjacencyBonus,
       rageBonus,
+      backstabBonus,
+      wasBackstab,
       panicTriggered,
       status_applies: statusApplies,
       parry: parryResult,
@@ -909,6 +971,11 @@ function createSessionRouter(options = {}) {
         actor.ap_remaining = Math.max(0, (actor.ap_remaining ?? actor.ap) - dist);
         const positionFrom = { ...actor.position };
         actor.position = { x: dest.x, y: dest.y };
+        // SPRINT_022: auto-facing sul movimento. L'unita' "guarda" nella
+        // direzione in cui si e' mossa. Se dx==0 e dy==0 (impossibile
+        // dato il check dist > 0) non cambia niente.
+        const newFacing = facingFromMove(positionFrom, actor.position);
+        if (newFacing) actor.facing = newFacing;
         const event = buildMoveEvent({ session, actor, positionFrom });
         // SPRINT_003 fase 1: il costo cap_pt si applica anche al move
         // se passato nel body (utile per abilita' movimento potenziato).
@@ -922,15 +989,51 @@ function createSessionRouter(options = {}) {
           actor_id: actor.id,
           position: actor.position,
           position_from: positionFrom,
+          facing: actor.facing,
           cap_pt_used: session.cap_pt_used,
           cap_pt_max: session.cap_pt_max,
           state: publicSessionView(session),
         });
       }
 
-      return res
-        .status(400)
-        .json({ error: `action_type sconosciuto: "${actionType}" (atteso "attack" o "move")` });
+      // SPRINT_022: nuova azione 'turn' per ruotare senza muoversi.
+      // Costa 0 AP (libera, come reazione) — cosi' il giocatore puo'
+      // riposizionarsi visivamente a fine turno per prevenire backstab
+      // senza pagare un costo meccanico.
+      if (actionType === 'turn') {
+        const rawFacing = body.facing ? String(body.facing).toUpperCase() : null;
+        if (!VALID_FACINGS.has(rawFacing)) {
+          return res.status(400).json({
+            error: `facing invalido: "${body.facing}". Atteso N/S/E/W`,
+          });
+        }
+        const oldFacing = actor.facing;
+        actor.facing = rawFacing;
+        await appendEvent(session, {
+          ts: new Date().toISOString(),
+          session_id: session.session_id,
+          actor_id: actor.id,
+          actor_species: actor.species,
+          actor_job: actor.job,
+          action_type: 'turn',
+          turn: session.turn,
+          ap_spent: 0,
+          facing_from: oldFacing,
+          facing_to: rawFacing,
+          trait_effects: [],
+        });
+        return res.json({
+          ok: true,
+          actor_id: actor.id,
+          facing: actor.facing,
+          facing_from: oldFacing,
+          state: publicSessionView(session),
+        });
+      }
+
+      return res.status(400).json({
+        error: `action_type sconosciuto: "${actionType}" (atteso "attack", "move" o "turn")`,
+      });
     } catch (err) {
       next(err);
     }

--- a/apps/backend/services/ai/sistemaTurnRunner.js
+++ b/apps/backend/services/ai/sistemaTurnRunner.js
@@ -218,6 +218,17 @@ function createSistemaTurnRunner(deps) {
       }
 
       actor.position = nextPos;
+      // SPRINT_022: auto-facing sul SIS move come per il player.
+      // Il SIS "guarda" nella direzione in cui si e' mosso.
+      const dx = nextPos.x - positionFrom.x;
+      const dy = nextPos.y - positionFrom.y;
+      if (dx !== 0 || dy !== 0) {
+        if (Math.abs(dx) >= Math.abs(dy)) {
+          actor.facing = dx > 0 ? 'E' : 'W';
+        } else {
+          actor.facing = dy > 0 ? 'S' : 'N';
+        }
+      }
       const event = buildMoveEvent({ session, actor, positionFrom });
       event.actor_id = 'sistema';
       event.ia_rule = policy.rule;


### PR DESCRIPTION
## Summary

Chiude il punto 3 del design doc \`docs/core/10-SISTEMA_TATTICO.md\` riga 17 — *"Terreno/Altezze/Facing: backstab da spalle; coperture; linee di tiro chiare"*. Facing reale, non più solo proxy altitudine.

## \`unit.facing\`: N/S/E/W

- Default player → \`S\`, SIS → \`N\`
- Override esplicito da \`input.facing\` (case-insensitive, validato contro \`VALID_FACINGS\`)
- Esposto in \`publicSessionView\`

## \`isBackstab(actor, target)\` helper pure

Determina se l'actor è nella **semipiano dietro** il facing del target:

| target.facing | "dietro" |
|:-:|---|
| N | \`y > target.y\` |
| S | \`y < target.y\` |
| E | \`x < target.x\` |
| W | \`x > target.x\` |

**Non richiede adiacenza stretta** — funziona anche per ranger r3 che colpisce da distanza.

## Integrazione \`performAttack\`

\`\`\`js
const wasBackstab = isBackstab(actor, target);
const backstabBonus = wasBackstab ? 1 : 0;
// Backstab BYPASSA parata (sorpresa, niente tempo di reagire)
const parryResult = wasBackstab ? null : rollParry(target);
const adjusted = base + mods + adj + rage + backstabBonus + parryDelta;
\`\`\`

## Auto-facing sul move

- \`/action move\`: l'unità "guarda nella direzione in cui si muove" via \`facingFromMove\`
- \`sistemaTurnRunner\`: stesso behavior per il SIS

Semantica: il player non deve pensare manualmente al facing dopo ogni move — è automatico.

## Nuova azione \`turn\` (ruota senza muoversi)

\`POST /api/session/action\` con:
\`\`\`json
{ "action_type": "turn", "facing": "N"|"S"|"E"|"W" }
\`\`\`

**Costa 0 AP** (libera). Utile a fine turno per prevenire backstab o orientarsi verso un bersaglio. Emette evento \`action_type: 'turn'\` con \`facing_from\` e \`facing_to\` per il log.

## UI facing arrow

CSS \`.facing-arrow\` con 4 varianti (N/S/E/W): piccolo triangolo ai bordi della cella, colore coordinato al team (p1-color blu, sistema-color rosso). Reso da \`renderGrid\` per ogni unità viva.

**Screenshot verificato**: P1 facing E → freccia blu a destra del token; SIS facing W → freccia rossa a sinistra del token.

## Test end-to-end (5 scenari)

| Caso | Setup | Expected | Got |
|---|---|---|:-:|
| **Backstab** | P1 (3,2), SIS (3,3) facing S, guardia 10 | dmg alto, parry null (bypass) | ✅ dmg=7, parry=null |
| **Frontal** | P1 (3,4), SIS (3,3) facing S, guardia 10 | dmg normale, parry success | ✅ dmg=4, parry.success=true |
| **Turn valido** | \`action_type=turn, facing=E\` | AP invariato, facing S→E | ✅ AP 2→2 |
| **Turn invalido** | \`facing=X\` | 400 validation | ✅ "facing invalido" |
| **UI arrows** | P1 facing E, SIS facing W | frecce visibili | ✅ screenshot ok |

La **differenza netta backstab vs frontal**: **+3 damage** (+1 backstab bonus + 2 da parry bypassed). Molto più impattante del semplice +1 adjacency.

## Interazione con altri sistemi

- Backstab + rage: \`1 + pt + 1 adj + 1 rage + 1 backstab\`
- Backstab + stordimento: colpo crit che bypassa parata **e** applica stunned **e** +1 backstab
- Backstab + bleeding: il DoT sanguinamento ignora facing (gira in \`/turn/end\`), persiste indipendente
- Facing non influisce su stati emotivi o metriche VC

## Rollback

- \`git revert 224899ef\` ripristina pre-sprint-022
- **Backward compat**: unità legacy senza \`facing\` → \`DEFAULT_FACING='S'\`, \`isBackstab\` returns false su facing invalido
- Consumer non-backstab-aware continuano identici (campo \`parry\` può essere \`null\` con backstab, gestito da \`fmtParry\` esistente)

🤖 Generated with [Claude Code](https://claude.com/claude-code)