### PR TITLE
test(services): vcScoring + traitEffects unit tests (SPRINT_023)

### DIFF
--- a/tests/services/traitEffects.test.js
+++ b/tests/services/traitEffects.test.js
@@ -1,0 +1,368 @@
+// SPRINT_023: test suite per apps/backend/services/traitEffects.js
+//
+// Copre:
+//   - evaluateAttackTraits pass 1 (damage modifiers)
+//     * zampe_a_molla: trigger su mos>=5 + sopraelevato
+//     * pelle_elastomera: trigger su hit, damage_delta -1
+//     * trait non-definito: non triggerato
+//     * trait apply_status: deferred (non triggerato in pass 1)
+//   - evaluateStatusTraits pass 2 (status applications)
+//     * ferocia: on_kill=true, target_side=actor, rage=3
+//     * intimidatore: melee_only, target_side=target, panic=2
+//     * stordimento: min_mos=8, target_side=target, stunned=1
+//     * denti_seghettati: on hit, bleeding=2
+//     * martello_osseo: min_mos=8, fracture=2
+//     * Trigger falliti (miss, mos basso, non melee, non kill)
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const {
+  loadActiveTraitRegistry,
+  evaluateAttackTraits,
+  evaluateStatusTraits,
+  isElevated,
+} = require('../../apps/backend/services/traitEffects');
+
+// Carica il registry reale dalla yaml
+const TRAIT_REGISTRY_PATH = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'data',
+  'core',
+  'traits',
+  'active_effects.yaml',
+);
+const registry = loadActiveTraitRegistry(TRAIT_REGISTRY_PATH, {
+  log: () => {},
+  warn: () => {},
+});
+
+// ─────────────────────────────────────────────────────────────────
+// isElevated (helper)
+// ─────────────────────────────────────────────────────────────────
+
+test('isElevated: true quando actor.y > target.y', () => {
+  assert.equal(isElevated({ position: { x: 0, y: 3 } }, { position: { x: 0, y: 1 } }), true);
+});
+
+test('isElevated: false quando y uguale', () => {
+  assert.equal(isElevated({ position: { x: 0, y: 2 } }, { position: { x: 0, y: 2 } }), false);
+});
+
+test('isElevated: false su input null', () => {
+  assert.equal(isElevated(null, { position: { x: 0, y: 0 } }), false);
+  assert.equal(isElevated({ position: { x: 0, y: 0 } }, null), false);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// evaluateAttackTraits — pelle_elastomera (damage reduction)
+// ─────────────────────────────────────────────────────────────────
+
+function buildUnit(overrides = {}) {
+  return {
+    id: 'unit_test',
+    hp: 10,
+    max_hp: 10,
+    position: { x: 0, y: 0 },
+    traits: [],
+    ...overrides,
+  };
+}
+
+test('pelle_elastomera: hit → damage_modifier -1', () => {
+  const actor = buildUnit({ id: 'a' });
+  const target = buildUnit({ id: 't', traits: ['pelle_elastomera'] });
+  const result = evaluateAttackTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 3, pt: 0 },
+  });
+  assert.equal(result.damage_modifier, -1);
+  const triggered = result.trait_effects.find((t) => t.trait === 'pelle_elastomera');
+  assert.equal(triggered.triggered, true);
+  assert.equal(triggered.effect, 'damage_reduction');
+});
+
+test('pelle_elastomera: miss → non triggerato', () => {
+  const target = buildUnit({ traits: ['pelle_elastomera'] });
+  const result = evaluateAttackTraits({
+    registry,
+    actor: buildUnit(),
+    target,
+    attackResult: { hit: false, mos: -5, pt: 0 },
+  });
+  assert.equal(result.damage_modifier, 0);
+  const entry = result.trait_effects.find((t) => t.trait === 'pelle_elastomera');
+  assert.equal(entry.triggered, false);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// evaluateAttackTraits — zampe_a_molla (altezza)
+// ─────────────────────────────────────────────────────────────────
+
+test('zampe_a_molla: mos>=5 + sopraelevato → +1 damage', () => {
+  const actor = buildUnit({ traits: ['zampe_a_molla'], position: { x: 0, y: 3 } });
+  const target = buildUnit({ id: 't', position: { x: 0, y: 1 } });
+  const result = evaluateAttackTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 5, pt: 0 },
+  });
+  assert.equal(result.damage_modifier, 1);
+});
+
+test('zampe_a_molla: mos<5 → non triggerato anche sopraelevato', () => {
+  const actor = buildUnit({ traits: ['zampe_a_molla'], position: { x: 0, y: 3 } });
+  const target = buildUnit({ id: 't', position: { x: 0, y: 1 } });
+  const result = evaluateAttackTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 4, pt: 0 },
+  });
+  assert.equal(result.damage_modifier, 0);
+});
+
+test('zampe_a_molla: mos>=5 ma non sopraelevato → non triggerato', () => {
+  const actor = buildUnit({ traits: ['zampe_a_molla'], position: { x: 0, y: 1 } });
+  const target = buildUnit({ id: 't', position: { x: 0, y: 1 } });
+  const result = evaluateAttackTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 7, pt: 0 },
+  });
+  assert.equal(result.damage_modifier, 0);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// evaluateAttackTraits — apply_status trait (deferred)
+// ─────────────────────────────────────────────────────────────────
+
+test('ferocia (apply_status): deferred nel pass 1, no damage modifier', () => {
+  const actor = buildUnit({ traits: ['ferocia'] });
+  const target = buildUnit({ id: 't' });
+  const result = evaluateAttackTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 10, pt: 0 },
+  });
+  assert.equal(result.damage_modifier, 0);
+  const entry = result.trait_effects.find((t) => t.trait === 'ferocia');
+  assert.equal(entry.triggered, false);
+  assert.equal(entry.effect, 'deferred_status');
+});
+
+// ─────────────────────────────────────────────────────────────────
+// evaluateAttackTraits — trait sconosciuto
+// ─────────────────────────────────────────────────────────────────
+
+test('trait sconosciuto: no triggered, no damage modifier', () => {
+  const actor = buildUnit({ traits: ['trait_fantasma'] });
+  const target = buildUnit({ id: 't' });
+  const result = evaluateAttackTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 5, pt: 0 },
+  });
+  assert.equal(result.damage_modifier, 0);
+  const entry = result.trait_effects.find((t) => t.trait === 'trait_fantasma');
+  assert.equal(entry.triggered, false);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// evaluateStatusTraits — ferocia
+// ─────────────────────────────────────────────────────────────────
+
+test("ferocia: on_kill=true + hit → applica rage 3 all'actor", () => {
+  const actor = buildUnit({ traits: ['ferocia'] });
+  const target = buildUnit({ id: 't' });
+  const result = evaluateStatusTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 5, pt: 0 },
+    killOccurred: true,
+  });
+  assert.equal(result.status_applies.length, 1);
+  assert.equal(result.status_applies[0].trait, 'ferocia');
+  assert.equal(result.status_applies[0].target_side, 'actor');
+  assert.equal(result.status_applies[0].stato, 'rage');
+  assert.equal(result.status_applies[0].turns, 3);
+});
+
+test('ferocia: killOccurred=false → non triggerato', () => {
+  const actor = buildUnit({ traits: ['ferocia'] });
+  const target = buildUnit({ id: 't' });
+  const result = evaluateStatusTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 5, pt: 0 },
+    killOccurred: false,
+  });
+  assert.equal(result.status_applies.length, 0);
+});
+
+test('ferocia: hit=false → non triggerato', () => {
+  const actor = buildUnit({ traits: ['ferocia'] });
+  const target = buildUnit({ id: 't' });
+  const result = evaluateStatusTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: false, mos: -2, pt: 0 },
+    killOccurred: false,
+  });
+  assert.equal(result.status_applies.length, 0);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// evaluateStatusTraits — intimidatore (melee_only)
+// ─────────────────────────────────────────────────────────────────
+
+test('intimidatore: melee (dist 1) + hit → panic 2 al target', () => {
+  const actor = buildUnit({ traits: ['intimidatore'], position: { x: 2, y: 2 } });
+  const target = buildUnit({ id: 't', position: { x: 2, y: 3 } });
+  const result = evaluateStatusTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 3, pt: 0 },
+    killOccurred: false,
+  });
+  const apply = result.status_applies.find((s) => s.trait === 'intimidatore');
+  assert.ok(apply, 'intimidatore deve essere triggerato');
+  assert.equal(apply.target_side, 'target');
+  assert.equal(apply.stato, 'panic');
+  assert.equal(apply.turns, 2);
+});
+
+test('intimidatore: ranged (dist 2) → non triggerato', () => {
+  const actor = buildUnit({ traits: ['intimidatore'], position: { x: 2, y: 2 } });
+  const target = buildUnit({ id: 't', position: { x: 4, y: 2 } });
+  const result = evaluateStatusTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 3, pt: 0 },
+    killOccurred: false,
+  });
+  const apply = result.status_applies.find((s) => s.trait === 'intimidatore');
+  assert.equal(apply, undefined);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// evaluateStatusTraits — stordimento (min_mos=8)
+// ─────────────────────────────────────────────────────────────────
+
+test('stordimento: mos>=8 → stunned 1 al target', () => {
+  const actor = buildUnit({ traits: ['stordimento'] });
+  const target = buildUnit({ id: 't' });
+  const result = evaluateStatusTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 8, pt: 0 },
+    killOccurred: false,
+  });
+  const apply = result.status_applies.find((s) => s.trait === 'stordimento');
+  assert.ok(apply);
+  assert.equal(apply.stato, 'stunned');
+  assert.equal(apply.turns, 1);
+});
+
+test('stordimento: mos=7 → non triggerato', () => {
+  const actor = buildUnit({ traits: ['stordimento'] });
+  const target = buildUnit({ id: 't' });
+  const result = evaluateStatusTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 7, pt: 0 },
+    killOccurred: false,
+  });
+  const apply = result.status_applies.find((s) => s.trait === 'stordimento');
+  assert.equal(apply, undefined);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// evaluateStatusTraits — denti_seghettati (bleeding)
+// ─────────────────────────────────────────────────────────────────
+
+test('denti_seghettati: hit → bleeding 2 al target', () => {
+  const actor = buildUnit({ traits: ['denti_seghettati'] });
+  const target = buildUnit({ id: 't' });
+  const result = evaluateStatusTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 1, pt: 0 },
+    killOccurred: false,
+  });
+  const apply = result.status_applies.find((s) => s.trait === 'denti_seghettati');
+  assert.ok(apply);
+  assert.equal(apply.stato, 'bleeding');
+  assert.equal(apply.turns, 2);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// evaluateStatusTraits — martello_osseo (fracture + min_mos=8)
+// ─────────────────────────────────────────────────────────────────
+
+test('martello_osseo: critico → fracture 2 al target', () => {
+  const actor = buildUnit({ traits: ['martello_osseo'] });
+  const target = buildUnit({ id: 't' });
+  const result = evaluateStatusTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 10, pt: 0 },
+    killOccurred: false,
+  });
+  const apply = result.status_applies.find((s) => s.trait === 'martello_osseo');
+  assert.ok(apply);
+  assert.equal(apply.stato, 'fracture');
+});
+
+test('martello_osseo: mos basso → non triggerato', () => {
+  const actor = buildUnit({ traits: ['martello_osseo'] });
+  const target = buildUnit({ id: 't' });
+  const result = evaluateStatusTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 5, pt: 0 },
+    killOccurred: false,
+  });
+  const apply = result.status_applies.find((s) => s.trait === 'martello_osseo');
+  assert.equal(apply, undefined);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Multiple traits combinati
+// ─────────────────────────────────────────────────────────────────
+
+test('actor con ferocia + denti_seghettati: kill → sia rage che bleeding', () => {
+  const actor = buildUnit({ traits: ['ferocia', 'denti_seghettati'] });
+  const target = buildUnit({ id: 't' });
+  const result = evaluateStatusTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 5, pt: 0 },
+    killOccurred: true,
+  });
+  assert.equal(result.status_applies.length, 2);
+  const rage = result.status_applies.find((s) => s.stato === 'rage');
+  const bleed = result.status_applies.find((s) => s.stato === 'bleeding');
+  assert.ok(rage);
+  assert.ok(bleed);
+});

--- a/tests/services/vcScoring.test.js
+++ b/tests/services/vcScoring.test.js
@@ -1,0 +1,351 @@
+// SPRINT_023: test suite per apps/backend/services/vcScoring.js
+//
+// Scope: metriche derivate dagli eventi del session engine.
+// Target:
+//   - computeRawMetrics: attacks_started, hits, close_engage, kills,
+//     first_blood, kill_pressure, damage_taken, 1vX, new_tiles,
+//     evasion_ratio, low_hp_time
+//   - buildVcSnapshot: payload completo con aggregate indices + MBTI +
+//     Ennea archetypes
+//   - Edge cases: sessione vuota, nessun evento, unica unita', eventi
+//     mid-combat con kill e assist
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const { loadTelemetryConfig, buildVcSnapshot } = require('../../apps/backend/services/vcScoring');
+
+const CONFIG_PATH = path.resolve(__dirname, '..', '..', 'data', 'core', 'telemetry.yaml');
+const telemetryConfig = loadTelemetryConfig(CONFIG_PATH, {
+  log: () => {},
+  warn: () => {},
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Fixture builders
+// ─────────────────────────────────────────────────────────────────
+
+function makeUnit(overrides = {}) {
+  return {
+    id: 'unit_1',
+    species: 'velox',
+    job: 'skirmisher',
+    hp: 10,
+    max_hp: 10,
+    ap: 2,
+    attack_range: 2,
+    position: { x: 0, y: 0 },
+    controlled_by: 'player',
+    ...overrides,
+  };
+}
+
+function makeSession({ units, events = [] } = {}) {
+  return {
+    session_id: 'test-session',
+    turn: 1,
+    units: units || [
+      makeUnit(),
+      makeUnit({
+        id: 'unit_2',
+        species: 'carapax',
+        job: 'vanguard',
+        attack_range: 1,
+        controlled_by: 'sistema',
+        position: { x: 5, y: 5 },
+      }),
+    ],
+    events,
+    grid: { width: 6, height: 6 },
+    cap_pt_used: 0,
+    cap_pt_max: 1,
+  };
+}
+
+function makeAttackEvent({
+  turn = 1,
+  actor_id = 'unit_1',
+  target_id = 'unit_2',
+  position_from = { x: 2, y: 2 },
+  target_position_at_attack = { x: 3, y: 2 },
+  result = 'hit',
+  damage_dealt = 2,
+  mos = 3,
+  target_hp_before = 10,
+  target_hp_after = 8,
+}) {
+  return {
+    turn,
+    action_type: 'attack',
+    actor_id,
+    target_id,
+    position_from,
+    target_position_at_attack,
+    result,
+    damage_dealt,
+    mos,
+    target_hp_before,
+    target_hp_after,
+  };
+}
+
+function makeMoveEvent({
+  turn = 1,
+  actor_id = 'unit_1',
+  position_from = { x: 0, y: 0 },
+  position_to = { x: 1, y: 0 },
+}) {
+  return {
+    turn,
+    action_type: 'move',
+    actor_id,
+    position_from,
+    position_to,
+  };
+}
+
+function makeKillEvent({ turn = 1, actor_id = 'unit_1', target_id = 'unit_2' }) {
+  return {
+    turn,
+    action_type: 'kill',
+    actor_id,
+    target_id,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Sessione vuota
+// ─────────────────────────────────────────────────────────────────
+
+test('buildVcSnapshot: sessione vuota → per_actor con unit ma 0 metriche', () => {
+  const snapshot = buildVcSnapshot(makeSession({ events: [] }), telemetryConfig);
+  assert.ok(snapshot.per_actor.unit_1);
+  assert.equal(snapshot.per_actor.unit_1.raw_metrics.attacks_started, 0);
+  assert.equal(snapshot.per_actor.unit_1.raw_metrics.kills, 0);
+  assert.equal(snapshot.per_actor.unit_1.raw_metrics.first_blood, 0);
+});
+
+test('buildVcSnapshot: nessun unit → per_actor vuoto', () => {
+  const snapshot = buildVcSnapshot(makeSession({ units: [], events: [] }), telemetryConfig);
+  assert.deepEqual(snapshot.per_actor, {});
+});
+
+// ─────────────────────────────────────────────────────────────────
+// attacks_started + hit_rate
+// ─────────────────────────────────────────────────────────────────
+
+test('attacks_started: conta attacchi per attore', () => {
+  const events = [
+    makeAttackEvent({ result: 'hit' }),
+    makeAttackEvent({ result: 'miss', damage_dealt: 0 }),
+    makeAttackEvent({ result: 'hit' }),
+  ];
+  const snapshot = buildVcSnapshot(makeSession({ events }), telemetryConfig);
+  assert.equal(snapshot.per_actor.unit_1.raw_metrics.attacks_started, 3);
+  assert.equal(snapshot.per_actor.unit_1.raw_metrics.attack_hit_rate, 2 / 3);
+});
+
+test('attack_hit_rate: 0 se nessun attacco', () => {
+  const snapshot = buildVcSnapshot(makeSession({ events: [] }), telemetryConfig);
+  assert.equal(snapshot.per_actor.unit_1.raw_metrics.attack_hit_rate, 0);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// close_engage (mutual range — sprint-007)
+// ─────────────────────────────────────────────────────────────────
+
+test('close_engage: attacco in mutual range (dist <= target.attack_range)', () => {
+  // Target is vanguard r1, attack from dist 1 → mutual range → close_engage
+  const events = [
+    makeAttackEvent({
+      position_from: { x: 2, y: 2 },
+      target_position_at_attack: { x: 3, y: 2 },
+    }),
+  ];
+  const snapshot = buildVcSnapshot(makeSession({ events }), telemetryConfig);
+  // 1 attack, 1 close_engage → ratio 1.0
+  assert.equal(snapshot.per_actor.unit_1.raw_metrics.close_engage, 1);
+});
+
+test('close_engage: 0 se attacco fuori mutual range', () => {
+  // Target vanguard r1, attack dist 2 → NON in mutual range
+  const events = [
+    makeAttackEvent({
+      position_from: { x: 1, y: 2 },
+      target_position_at_attack: { x: 3, y: 2 },
+    }),
+  ];
+  const snapshot = buildVcSnapshot(makeSession({ events }), telemetryConfig);
+  assert.equal(snapshot.per_actor.unit_1.raw_metrics.close_engage, 0);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// first_blood + kill_pressure
+// ─────────────────────────────────────────────────────────────────
+
+test('first_blood: primo kill della sessione assegna first_blood=1', () => {
+  const events = [makeAttackEvent({ damage_dealt: 10, target_hp_after: 0 }), makeKillEvent({})];
+  const snapshot = buildVcSnapshot(makeSession({ events }), telemetryConfig);
+  assert.equal(snapshot.per_actor.unit_1.raw_metrics.first_blood, 1);
+  assert.equal(snapshot.per_actor.unit_1.raw_metrics.kills, 1);
+});
+
+test('first_blood: seconda unita' + ' a uccidere non ottiene first_blood', () => {
+  const units = [
+    makeUnit({ id: 'unit_1' }),
+    makeUnit({ id: 'unit_2' }),
+    makeUnit({ id: 'unit_3', controlled_by: 'sistema' }),
+  ];
+  const events = [
+    makeKillEvent({ turn: 1, actor_id: 'unit_1', target_id: 'unit_3' }),
+    makeKillEvent({ turn: 2, actor_id: 'unit_2', target_id: 'unit_3' }),
+  ];
+  const snapshot = buildVcSnapshot(makeSession({ units, events }), telemetryConfig);
+  assert.equal(snapshot.per_actor.unit_1.raw_metrics.first_blood, 1);
+  assert.equal(snapshot.per_actor.unit_2.raw_metrics.first_blood, 0);
+});
+
+test('kill_pressure: kills / maxTurn', () => {
+  const events = [
+    makeAttackEvent({ turn: 5, damage_dealt: 10, target_hp_after: 0 }),
+    makeKillEvent({ turn: 5 }),
+  ];
+  const snapshot = buildVcSnapshot(makeSession({ events }), telemetryConfig);
+  assert.equal(snapshot.per_actor.unit_1.raw_metrics.kill_pressure, 1 / 5);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// damage_taken + damage_taken_ratio
+// ─────────────────────────────────────────────────────────────────
+
+test('damage_taken: somma del damage subito', () => {
+  const events = [
+    makeAttackEvent({ actor_id: 'unit_2', target_id: 'unit_1', damage_dealt: 3 }),
+    makeAttackEvent({ actor_id: 'unit_2', target_id: 'unit_1', damage_dealt: 2 }),
+  ];
+  const snapshot = buildVcSnapshot(makeSession({ events }), telemetryConfig);
+  assert.equal(snapshot.per_actor.unit_1.raw_metrics.damage_taken, 5);
+});
+
+test('damage_taken_ratio: frazione del danno totale della sessione', () => {
+  const events = [
+    makeAttackEvent({ actor_id: 'unit_2', target_id: 'unit_1', damage_dealt: 3 }),
+    makeAttackEvent({ actor_id: 'unit_1', target_id: 'unit_2', damage_dealt: 7 }),
+  ];
+  const snapshot = buildVcSnapshot(makeSession({ events }), telemetryConfig);
+  // unit_1 damage_taken = 3, total damage = 10 → ratio 0.3
+  assert.equal(snapshot.per_actor.unit_1.raw_metrics.damage_taken_ratio, 3 / 10);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// 1vX (sprint-011)
+// ─────────────────────────────────────────────────────────────────
+
+test('1vX: attacchi 1v1 isolati contano 1.0', () => {
+  // Solo 2 unita' totali, ogni attacco e' in 1vX situation
+  const events = [makeAttackEvent({ turn: 1 }), makeAttackEvent({ turn: 2 })];
+  const snapshot = buildVcSnapshot(makeSession({ events }), telemetryConfig);
+  assert.equal(snapshot.per_actor.unit_1.raw_metrics['1vX'], 1);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// new_tiles (sprint-011)
+// ─────────────────────────────────────────────────────────────────
+
+test('new_tiles: conta celle uniche visitate', () => {
+  const events = [
+    makeMoveEvent({ position_from: { x: 0, y: 0 }, position_to: { x: 1, y: 0 } }),
+    makeMoveEvent({ position_from: { x: 1, y: 0 }, position_to: { x: 2, y: 0 } }),
+  ];
+  const snapshot = buildVcSnapshot(makeSession({ events }), telemetryConfig);
+  // Visitate: (0,0), (1,0), (2,0) = 3 celle uniche. Normalizzato su 36.
+  assert.equal(snapshot.per_actor.unit_1.raw_metrics.new_tiles_count, 3);
+});
+
+test('new_tiles: celle duplicate contate una volta sola', () => {
+  const events = [
+    makeMoveEvent({ position_from: { x: 0, y: 0 }, position_to: { x: 1, y: 0 } }),
+    makeMoveEvent({ position_from: { x: 1, y: 0 }, position_to: { x: 0, y: 0 } }),
+  ];
+  const snapshot = buildVcSnapshot(makeSession({ events }), telemetryConfig);
+  // Visited: (0,0), (1,0) = 2 uniche
+  assert.equal(snapshot.per_actor.unit_1.raw_metrics.new_tiles_count, 2);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// evasion_ratio (sprint-005 fase 2)
+// ─────────────────────────────────────────────────────────────────
+
+test('evasion_ratio: attack seguito da move che aumenta distanza', () => {
+  const events = [
+    makeAttackEvent({
+      turn: 1,
+      position_from: { x: 2, y: 2 },
+      target_position_at_attack: { x: 3, y: 2 },
+    }),
+    makeMoveEvent({
+      turn: 1,
+      position_from: { x: 2, y: 2 },
+      position_to: { x: 1, y: 2 },
+    }),
+  ];
+  const snapshot = buildVcSnapshot(makeSession({ events }), telemetryConfig);
+  // attack da (2,2) a (3,2), poi move (2,2)→(1,2). Distanza pre=1, post=2 → evasion
+  assert.equal(snapshot.per_actor.unit_1.raw_metrics.evasion_ratio, 1);
+});
+
+test("evasion_ratio: move verso target NON e' evasion", () => {
+  const events = [
+    makeAttackEvent({
+      turn: 1,
+      position_from: { x: 1, y: 2 },
+      target_position_at_attack: { x: 3, y: 2 },
+    }),
+    makeMoveEvent({
+      turn: 1,
+      position_from: { x: 1, y: 2 },
+      position_to: { x: 2, y: 2 },
+    }),
+  ];
+  const snapshot = buildVcSnapshot(makeSession({ events }), telemetryConfig);
+  assert.equal(snapshot.per_actor.unit_1.raw_metrics.evasion_ratio, 0);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Aggregate indices + Ennea triggers
+// ─────────────────────────────────────────────────────────────────
+
+test('buildVcSnapshot: include aggregate_indices (aggro, risk, ecc.)', () => {
+  const snapshot = buildVcSnapshot(makeSession({ events: [] }), telemetryConfig);
+  assert.ok(snapshot.per_actor.unit_1.aggregate_indices);
+  assert.ok('aggro' in snapshot.per_actor.unit_1.aggregate_indices);
+  assert.ok('risk' in snapshot.per_actor.unit_1.aggregate_indices);
+});
+
+test('buildVcSnapshot: include ennea_archetypes array', () => {
+  const snapshot = buildVcSnapshot(makeSession({ events: [] }), telemetryConfig);
+  assert.ok(Array.isArray(snapshot.per_actor.unit_1.ennea_archetypes));
+  // Il config ha 6 Ennea themes (Conquistatore, Coordinatore, Esploratore,
+  // Architetto, Stoico, Cacciatore)
+  assert.ok(snapshot.per_actor.unit_1.ennea_archetypes.length >= 5);
+});
+
+test('buildVcSnapshot: meta include coverage (full/partial/null)', () => {
+  const snapshot = buildVcSnapshot(makeSession({ events: [] }), telemetryConfig);
+  assert.ok(snapshot.meta.coverage);
+  assert.ok(Array.isArray(snapshot.meta.coverage.full));
+  assert.ok(Array.isArray(snapshot.meta.coverage.partial));
+  assert.ok(Array.isArray(snapshot.meta.coverage.null));
+});
+
+test('buildVcSnapshot: session_id propagato', () => {
+  const snapshot = buildVcSnapshot(makeSession({ events: [] }), telemetryConfig);
+  assert.equal(snapshot.session_id, 'test-session');
+});
+
+test('buildVcSnapshot: turns_played = max(event.turn)', () => {
+  const events = [makeAttackEvent({ turn: 3 }), makeAttackEvent({ turn: 7 })];
+  const snapshot = buildVcSnapshot(makeSession({ events }), telemetryConfig);
+  assert.equal(snapshot.meta.turns_played, 7);
+});


### PR DESCRIPTION
## Summary
- **SPRINT_023**: chiude il backlog sui test service-layer.
- Aggiunti 42 test unitari (21 + 21) per `apps/backend/services/vcScoring.js` e `apps/backend/services/traitEffects.js`.
- Nessuna modifica al runtime: solo test + fixture builders locali.

## Coverage

### `tests/services/traitEffects.test.js` (21 test)
- `isElevated` helper (3 test).
- `evaluateAttackTraits` pass 1:
  - `pelle_elastomera`: hit → damage_modifier -1, miss → non triggerato.
  - `zampe_a_molla`: mos≥5 + sopraelevato → +1 damage; mos<5 o non sopraelevato → non triggerato.
  - `ferocia` (apply_status): deferred nel pass 1, no damage modifier.
  - Trait sconosciuto: no trigger, no damage modifier.
- `evaluateStatusTraits` pass 2:
  - `ferocia` (on_kill → rage 3 all'actor): triggera solo su `killOccurred=true` e `hit=true`.
  - `intimidatore` (melee_only → panic 2): triggera a dist 1, non a dist 2.
  - `stordimento` (min_mos=8 → stunned 1): triggera su mos 8, non su mos 7.
  - `denti_seghettati` (hit → bleeding 2).
  - `martello_osseo` (min_mos=8 → fracture 2).
  - Combo: `ferocia + denti_seghettati` con kill → sia rage che bleeding.

### `tests/services/vcScoring.test.js` (21 test)
- Edge cases: sessione vuota, nessuna unit.
- Raw metrics: `attacks_started`, `attack_hit_rate`, `close_engage` (mutual range), `first_blood`, `kill_pressure`, `damage_taken`, `damage_taken_ratio`, `1vX`, `new_tiles_count`, `evasion_ratio`.
- `buildVcSnapshot`: `aggregate_indices` (aggro, risk...), `ennea_archetypes` array, `meta.coverage` (full/partial/null), `session_id` propagato, `turns_played = max(event.turn)`.

## Setup
- Entrambe le suite caricano registry/config reali:
  - `data/core/traits/active_effects.yaml` via `loadActiveTraitRegistry`.
  - `data/core/telemetry.yaml` via `loadTelemetryConfig`.
- Fixture builders locali (`makeUnit`, `makeSession`, `makeAttackEvent`, `makeMoveEvent`, `makeKillEvent`, `buildUnit`) per isolare i test dall'API Express.

## Test plan
- [x] `node --test tests/services/traitEffects.test.js` → 21/21 verdi in ~78ms.
- [x] `node --test tests/services/vcScoring.test.js` → 21/21 verdi in ~83ms.
- [x] `node --test tests/services/*.test.js` combinato → 42/42 verdi in ~90ms.
- [x] `prettier --check` pulito sui due nuovi file.

## Note rollback
Se la suite emerge flaky: `git revert <sha>` oppure rimuovi i due file sotto `tests/services/`. Nessun runtime toccato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)