### PR TITLE
feat(combat): round orchestrator follow-ups (#2 YAML balance, #5 preview, #1+#3 reactions first-class)

### DIFF
--- a/docs/combat/round-loop.md
+++ b/docs/combat/round-loop.md
@@ -166,15 +166,51 @@ resolve   → AP consumati dentro resolve_action (via _consume_ap)
 
 Questo è intenzionale: un player può dichiarare 5 azioni diverse in planning e **nessuna** consuma AP finché non decide di fare commit e resolve. Solo l'ultima azione dichiarata per quell'unità verrà risolta nel round.
 
-### Reazioni / interrupt
+### Reazioni come intent first-class (follow-up #1 + #3)
 
-Le reazioni restano nel modello esistente del resolver (`parry_response` nell'action), non sono cittadini di prima classe del round orchestrator in questa iterazione:
+Dal patch di follow-up del 2026-04-15 le reazioni sono **cittadini di prima classe** del round orchestrator, con una shape dedicata e un meccanismo di trigger condizioni:
 
-- L'attaccante dichiara nella sua action un `parry_response: {attempt: true, parry_bonus: N}` se il difensore ha scelto di parare.
-- `resolve_action` consuma una `reaction` del target e tira il parry contestato dentro la pipeline dell'attacco.
-- Il difensore ha già consumato la sua reaction prima del proprio intent di round.
+```python
+declare_reaction(
+    state,
+    unit_id="bravo",
+    reaction_payload={"type": "parry", "parry_bonus": 1},
+    trigger={"event": "attacked", "source_any_of": None}
+)
+```
 
-Un'evoluzione futura (vedi [Follow-ups](#6-follow-ups)) potrà modellare le reazioni come intent separati con priorità propria nella queue, ma per ora il pattern è conservativo.
+Le reaction intents:
+
+- **Non compaiono nella main queue**: `build_resolution_queue` le esclude automaticamente.
+- **Non consumano AP al commit**: restano preview-only finché non triggerate.
+- **One-shot per round**: la prima volta che matchano, vengono segnate `_consumed=True` e non re-triggrano sullo stesso round anche se altri eventi matcherebbero.
+- **Trigger conditions**:
+  - `event`: per ora supportato solo `"attacked"` (vedi `SUPPORTED_REACTION_EVENTS`). Futuri: `damaged`, `moved_adjacent`, `healed`.
+  - `source_any_of`: opzionale, lista di `unit_id` che triggerano la reazione. `None` o vuoto = qualsiasi sorgente.
+- **Payload type**: per ora supportato solo `"parry"` (vedi `SUPPORTED_REACTION_TYPES`). Futuri: `counter` (contrattacco libero), `overwatch` (attacco opportunistico).
+
+**Pipeline di trigger** (dentro `resolve_round`):
+
+1. Il main intent di alpha risolve `attack` contro bravo.
+2. Prima di chiamare `resolve_action`, l'orchestrator consulta `reactions_by_unit["bravo"]`.
+3. Se trova una reaction con `event=attacked` e `source_any_of` che matcha (o è None), inietta `parry_response` nell'action clonata: `{attempt: true, parry_bonus: N}`.
+4. Chiama `resolve_action` con l'action arricchita. Il resolver atomico gestisce la pipeline parry come in ogni altra action con `parry_response`.
+5. Marca la reaction come consumata e registra l'evento in `result["reactions_triggered"]`.
+
+Il budget `unit.reactions.current` resta la responsabilità del resolver atomico: se bravo ha 0 reactions disponibili, il parry viene registrato come `executed: false` (come nel modello pre-refactor). Una reaction intent dichiarata ma mai triggerata costa 0.
+
+**Test di riferimento** in `tests/test_round_orchestrator.py`:
+
+- `test_declare_reaction_registers_reaction_intent`
+- `test_declare_reaction_rejects_unsupported_event`
+- `test_declare_reaction_rejects_unsupported_payload_type`
+- `test_build_resolution_queue_excludes_reaction_intents`
+- `test_reaction_triggers_parry_on_matching_attack`
+- `test_reaction_source_filter_matches_allowed_attacker`
+- `test_reaction_source_filter_rejects_other_attacker`
+- `test_reaction_consumed_after_first_trigger`
+- `test_reaction_unused_if_target_not_attacked`
+- `test_reaction_does_not_consume_ap_if_not_triggered`
 
 ---
 
@@ -204,21 +240,28 @@ Schema: `packages/contracts/schemas/combat.schema.json` ha `additionalProperties
         "actor_id": "alpha",
         "target_id": "bravo",
         "ap_cost": 1,
-        "damage_dice": {"count": 1, "sides": 8, "modifier": 3}
+        "damage_dice": { "count": 1, "sides": 8, "modifier": 3 }
       }
     },
     {
       "unit_id": "bravo",
-      "action": {
-        "id": "act-bravo-01",
-        "type": "defend",
-        "actor_id": "bravo",
-        "ap_cost": 1
+      "reaction_trigger": {
+        "event": "attacked",
+        "source_any_of": null
+      },
+      "reaction_payload": {
+        "type": "parry",
+        "parry_bonus": 1
       }
     }
   ]
 }
 ```
+
+**Due shapes di intent** coesistono in `pending_intents`:
+
+- **Main intent** (con `action`): va nella main queue, consuma AP, risolve in ordine di priority.
+- **Reaction intent** (con `reaction_trigger` + `reaction_payload`): non va in queue, resta come "listener" e triggera se qualcuno la matcha.
 
 ### Campi legacy: strategia di compatibilità
 
@@ -258,34 +301,57 @@ Rimuove l'intent precedentemente dichiarato per `unit_id`. No-op se assente.
 
 Transita a `'committed'`. Raises `ValueError` se `round_phase != 'planning'`.
 
-### `build_resolution_queue(state) → list[{unit_id, action, priority}]`
+### `declare_reaction(state, unit_id, reaction_payload, trigger) → {next_state}`
 
-Costruisce la queue ordinata per `resolve_priority` desc + id asc. Chiamabile indipendentemente (utile per UI preview).
+Registra una reaction intent. Preview-only (nessun AP). Valida `trigger.event ∈ SUPPORTED_REACTION_EVENTS` e `reaction_payload.type ∈ SUPPORTED_REACTION_TYPES`. Raises `ValueError` su payload/event non supportati o fase sbagliata.
 
-### `resolve_round(state, catalog, rng) → {next_state, turn_log_entries, resolution_queue, skipped}`
+### `build_resolution_queue(state, speed_table=None) → list[{unit_id, action, priority}]`
 
-Risolve tutti gli intent committed. Per ciascun entry della queue: skip se actor/target morti, altrimenti `resolve_action`. Thread lo state. Alla fine: `round_phase = 'resolved'`, `pending_intents = []`, `log` esteso. Il rng è consumato solo dagli intent effettivamente eseguiti.
+Costruisce la main queue ordinata per `resolve_priority` desc + id asc. **Esclude reaction intents** automaticamente. Accetta `speed_table` opzionale per override della tabella ACTION_SPEED (utile per test).
 
-### `compute_resolve_priority(unit, action) → int`
+### `resolve_round(state, catalog, rng) → {next_state, turn_log_entries, resolution_queue, reactions_triggered, skipped}`
 
-Helper puro: `initiative + action_speed - status_penalty`. Esportato per testing e UI preview.
+Risolve tutti i main intents committed. Per ciascun entry della queue: skip se actor/target morti, altrimenti `resolve_action`. Durante il loop, check reaction matching: se il target di un attack ha una reaction intent con trigger che matcha, inietta `parry_response` nell'action clonata e marca la reaction come consumata. Thread lo state. Alla fine: `round_phase = 'resolved'`, `pending_intents = []`, `log` esteso, `reactions_triggered` riporta le reazioni effettivamente eseguite.
 
-### `action_speed(action) → int`
+### `preview_round(state, catalog, rng) → {next_state, turn_log_entries, resolution_queue, reactions_triggered, skipped}`
 
-Helper puro: lookup nella tabella `ACTION_SPEED`, default 0 per tipi sconosciuti.
+What-if: simula `resolve_round` su una deep copy dello state, **non muta l'input**. Accetta fase `planning` o `committed` (auto-commita sulla copy se planning). Il `rng` deve essere dedicato alla preview (es. namespaced con namespace diverso dal canonical) per non consumare il rng canonico.
+
+### `compute_resolve_priority(unit, action, speed_table=None) → int`
+
+Helper puro: `initiative + action_speed - status_penalty`. Esportato per testing e UI preview. `speed_table` opzionale.
+
+### `action_speed(action, table=None) → int`
+
+Helper puro: lookup nella tabella passata (o in `ACTION_SPEED` modulo-level), default 0 per tipi sconosciuti.
+
+### `load_action_speed_table(path=None) → dict`
+
+Carica la tabella di speed da un YAML del balance pack. Default path: `packs/evo_tactics_pack/data/balance/action_speed.yaml`. Fallback tollerante a `DEFAULT_ACTION_SPEED` se il file manca, è malformato, o mancano le chiavi attese. Non solleva eccezioni: sempre ritorna un dict valido.
+
+### `reload_action_speed_table(path=None) → dict`
+
+Ricarica `ACTION_SPEED` dal filesystem (hot reload) e muta il dict modulo-level in-place. Utile nei test per override temporaneo.
 
 ---
 
 ## 6. Follow-ups
 
-Questa iterazione è intenzionalmente conservativa. Le evoluzioni pianificate:
+**Completati nel patch del 2026-04-15**:
 
-1. **Reazioni come intent first-class**: modellare parry/counter/overwatch come intent separati con priorità propria, anziché come flag `parry_response` sull'action dell'attaccante.
-2. **Action speed calibrato dal balance pack**: oggi `ACTION_SPEED` è hardcoded nel modulo. In futuro caricarlo da `packs/evo_tactics_pack/data/balance/action_speed.yaml` per tuning senza commit Python.
-3. **Interrupt window**: supportare intent che si attivano **solo** se triggerati da un altro intent nello stesso round (es. "contromossa se sono bersagliato"). Richiede un concetto di `trigger_condition` nella declaration.
-4. **Migrazione Node session engine**: portare `apps/backend/routes/session.js` allo stesso modello. Oggi il session engine è separato dal rules engine Python; il loro allineamento è un sprint dedicato (rischio alto, molti test da aggiornare).
-5. **Preview-safe resolve**: esporre una funzione `preview_round(state, catalog, rng) → expected_outcome` che applichi `resolve_round` su una deep copy senza mai restituire il next_state — utile per UI di "cosa succederebbe se...". Deve usare un rng dedicato a preview per non consumare il rng canonico.
-6. **Timer opzionale di planning phase**: oggi la planning phase non ha timer. Aggiungere un `planning_deadline_ms` opzionale nel state per i tavoli che vogliono pressione temporale. Il scheduler resta fuori dal rules engine (responsabilità del session engine Node).
+- ✅ **#2** `ACTION_SPEED` da YAML di balance pack: `load_action_speed_table()` + `packs/evo_tactics_pack/data/balance/action_speed.yaml`.
+- ✅ **#5** `preview_round(state, catalog, rng)`: what-if su deep copy, non muta l'input.
+- ✅ **#1** Reazioni come intent first-class: `declare_reaction()` + partizionamento in `resolve_round`.
+- ✅ **#3** Interrupt window con trigger conditions: `reaction_trigger.event` + `reaction_trigger.source_any_of`.
+
+**Ancora aperti** (evoluzioni future):
+
+1. **Counter e overwatch**: oltre a `parry`, supportare altri payload type nel sistema di reaction (`counter` = contrattacco libero, `overwatch` = attacco opportunistico su movimento).
+2. **Eventi di trigger aggiuntivi**: oltre a `attacked`, supportare `damaged` (dopo il damage step), `moved_adjacent` (quando un'unita' entra in mischia), `healed`, `ability_used`.
+3. **Migrazione Node session engine**: portare `apps/backend/routes/session.js` allo stesso modello. Oggi il session engine è separato dal rules engine Python; il loro allineamento è un sprint dedicato (rischio alto, molti test da aggiornare).
+4. **Timer opzionale di planning phase**: oggi la planning phase non ha timer. Aggiungere un `planning_deadline_ms` opzionale nel state per i tavoli che vogliono pressione temporale. Il scheduler resta fuori dal rules engine (responsabilità del session engine Node).
+5. **Reaction con cooldown multi-round**: oggi le reactions sono one-shot per round. Future: cooldown persistenti fra round (`cooldown_rounds: 2`) per reactions potenti.
+6. **Trigger predicate avanzati**: oltre a `source_any_of`, supportare condizioni come `damage_threshold` (triggera solo se il damage in arrivo supera X), `hp_threshold` (triggera solo se HP sotto Y).
 
 ---
 

--- a/packs/evo_tactics_pack/data/balance/action_speed.yaml
+++ b/packs/evo_tactics_pack/data/balance/action_speed.yaml
@@ -1,0 +1,36 @@
+# Tabella dei modificatori di velocita' di risoluzione per action type.
+#
+# Fonte: ADR-2026-04-15-round-based-combat-model.md
+# Consumer: services/rules/round_orchestrator.py::load_action_speed_table
+#
+# Semantica: il valore e' sommato a unit.initiative (reaction speed) per
+# calcolare resolve_priority. Alto = risolve prima nel round.
+#
+# Formula completa:
+#   resolve_priority = unit.initiative + action_speed[action.type] - status_penalty
+#
+# Modifica questo file per tarare il combat bilanciamento senza commit
+# al codice Python. Il round orchestrator fa hot reload al prossimo
+# import del modulo (o via load_action_speed_table() esplicito in test).
+#
+# Fallback: se il file manca o e' malformato, il round orchestrator usa
+# DEFAULT_ACTION_SPEED (stessi valori di questo file, hardcoded nel modulo).
+
+version: 1
+
+action_speed:
+  # Stance difensive: gia' mantenute, reazione immediata
+  defend: 2
+  parry: 2
+
+  # Azioni offensive: baseline del d20
+  attack: 0
+
+  # Abilita' elaborate: richiedono telegraph / windup
+  ability: -1
+
+  # Movimento: commitment fisico, piu' lento a reagire
+  move: -2
+
+  # Future extension: aggiungere qui nuovi action type senza toccare Python.
+  # Unknown action type → default 0 (il loader e' tollerante).

--- a/services/rules/round_orchestrator.py
+++ b/services/rules/round_orchestrator.py
@@ -65,6 +65,7 @@ completo e il piano di migrazione.
 from __future__ import annotations
 
 import copy
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional
 
 # Relative import: funziona sia quando il package e' importato come
@@ -98,17 +99,28 @@ VALID_PHASES = frozenset({PHASE_PLANNING, PHASE_COMMITTED, PHASE_RESOLVING, PHAS
 
 
 # ------------------------------------------------------------------
+# Reaction intents (follow-up #1 + #3)
+# ------------------------------------------------------------------
+
+#: Eventi che possono triggerare una reaction. Per v1 e' supportato solo
+#: ``'attacked'`` (trigger sull'attack risolto dall'attaccante). Future
+#: estensioni: ``'damaged'`` (dopo il damage step), ``'moved_adjacent'``,
+#: ``'healed'``.
+SUPPORTED_REACTION_EVENTS = frozenset({"attacked"})
+
+#: Tipi di payload per reaction. Per v1 solo ``'parry'``. Future: ``'counter'``
+#: (contrattacco libero), ``'overwatch'`` (attacco opportunistico).
+SUPPORTED_REACTION_TYPES = frozenset({"parry"})
+
+
+# ------------------------------------------------------------------
 # Action speed table
 # ------------------------------------------------------------------
 
-#: Modificatori di velocita' di risoluzione per action type. Piu' alto =
-#: risolve prima. La convenzione: azioni difensive/stance gia' mantenute
-#: sono rapide, azioni offensive sono baseline, movimento e abilita'
-#: elaborate sono leggermente piu' lente.
-#:
-#: Valori di prima iterazione — possono essere calibrati in seguito
-#: con il balance pack. Ogni action type non in tabella vale 0.
-ACTION_SPEED: Dict[str, int] = {
+#: Default action speed hardcoded — usato come fallback se lo YAML di
+#: balance non e' caricabile. Mantieni sincronizzato con
+#: ``packs/evo_tactics_pack/data/balance/action_speed.yaml``.
+DEFAULT_ACTION_SPEED: Dict[str, int] = {
     "defend": 2,
     "parry": 2,
     "attack": 0,
@@ -116,16 +128,99 @@ ACTION_SPEED: Dict[str, int] = {
     "move": -2,
 }
 
+#: Path canonico dello YAML di balance caricato al primo import.
+DEFAULT_ACTION_SPEED_PATH: Path = (
+    Path(__file__).resolve().parents[2]
+    / "packs"
+    / "evo_tactics_pack"
+    / "data"
+    / "balance"
+    / "action_speed.yaml"
+)
 
-def action_speed(action: Mapping[str, Any]) -> int:
-    """Ritorna il modificatore di velocita' per un'action, default 0."""
 
-    return int(ACTION_SPEED.get(str(action.get("type", "")), 0))
+def load_action_speed_table(path: Optional[Path] = None) -> Dict[str, int]:
+    """Carica la tabella ``action_speed`` da un file YAML di balance.
+
+    Fallback a ``DEFAULT_ACTION_SPEED`` se:
+    - ``path`` e' None e il default non esiste sul filesystem
+    - il file esiste ma non e' parsabile come YAML
+    - il file e' parsabile ma non contiene la chiave ``action_speed``
+      come dict
+    - ``pyyaml`` non e' disponibile nell'environment
+
+    Il loader e' volutamente tollerante: non solleva mai eccezioni,
+    sempre ritorna un dict ``{str: int}``. Questo permette di importare
+    il modulo anche in environment minimal (CI deployment-checks senza
+    ``yaml`` installato a livello root).
+
+    Il caller test puo' passare un ``path`` esplicito per override.
+    """
+
+    target = path if path is not None else DEFAULT_ACTION_SPEED_PATH
+    if not target.exists():
+        return dict(DEFAULT_ACTION_SPEED)
+    try:
+        import yaml  # type: ignore[import-untyped]
+    except ImportError:
+        return dict(DEFAULT_ACTION_SPEED)
+    try:
+        with target.open("r", encoding="utf-8") as handle:
+            doc = yaml.safe_load(handle) or {}
+    except Exception:
+        return dict(DEFAULT_ACTION_SPEED)
+    if not isinstance(doc, Mapping):
+        return dict(DEFAULT_ACTION_SPEED)
+    table = doc.get("action_speed")
+    if not isinstance(table, Mapping):
+        return dict(DEFAULT_ACTION_SPEED)
+    out: Dict[str, int] = {}
+    for key, value in table.items():
+        try:
+            out[str(key)] = int(value)
+        except (TypeError, ValueError):
+            continue
+    return out if out else dict(DEFAULT_ACTION_SPEED)
+
+
+#: Tabella runtime caricata al primo import. Mutabile via
+#: ``reload_action_speed_table(path)`` per hot reload nei test.
+ACTION_SPEED: Dict[str, int] = load_action_speed_table()
+
+
+def reload_action_speed_table(path: Optional[Path] = None) -> Dict[str, int]:
+    """Ricarica ``ACTION_SPEED`` dal filesystem, mutando il dict in-place.
+
+    Utile per i test che vogliono esercitare override della tabella
+    senza dover passare il parametro ``speed_table`` a ogni chiamata.
+    Ritorna il dict aggiornato per convenienza.
+    """
+
+    global ACTION_SPEED
+    ACTION_SPEED.clear()
+    ACTION_SPEED.update(load_action_speed_table(path))
+    return ACTION_SPEED
+
+
+def action_speed(
+    action: Mapping[str, Any],
+    table: Optional[Mapping[str, int]] = None,
+) -> int:
+    """Ritorna il modificatore di velocita' per un'action, default 0.
+
+    ``table`` opzionale per override puntuale (es. test unitari che
+    vogliono una tabella custom senza toccare il modulo-level
+    ``ACTION_SPEED``).
+    """
+
+    lookup = table if table is not None else ACTION_SPEED
+    return int(lookup.get(str(action.get("type", "")), 0))
 
 
 def compute_resolve_priority(
     unit: Mapping[str, Any],
     action: Mapping[str, Any],
+    speed_table: Optional[Mapping[str, int]] = None,
 ) -> int:
     """Calcola la priorita' di risoluzione di un intent nel round.
 
@@ -142,10 +237,12 @@ def compute_resolve_priority(
 
     Priorita' piu' alta = risolve prima nel round. Tiebreak in
     ``build_resolution_queue`` alfabetico su ``unit_id``.
+
+    ``speed_table`` opzionale per override (es. test).
     """
 
     base = int(unit.get("initiative", 0))
-    speed = action_speed(action)
+    speed = action_speed(action, table=speed_table)
     penalty = 0
     for status in unit.get("statuses") or []:
         sid = status.get("id")
@@ -254,6 +351,7 @@ def clear_intent(state: Mapping[str, Any], unit_id: str) -> Dict[str, Any]:
     """Rimuove l'intent precedentemente dichiarato per ``unit_id``.
 
     No-op se l'unita' non ha intents. Rispetta la fase di planning.
+    Rimuove anche eventuali reaction intents per la stessa unit.
     """
 
     next_state = copy.deepcopy(state)
@@ -264,6 +362,160 @@ def clear_intent(state: Mapping[str, Any], unit_id: str) -> Dict[str, Any]:
     ]
     next_state["pending_intents"] = intents
     return {"next_state": next_state}
+
+
+def declare_reaction(
+    state: Mapping[str, Any],
+    unit_id: str,
+    reaction_payload: Mapping[str, Any],
+    trigger: Mapping[str, Any],
+) -> Dict[str, Any]:
+    """Registra una **reaction intent** nella planning phase.
+
+    Le reaction intents sono un concetto separato dalle azioni principali:
+    non occupano la main queue del round, non consumano AP al commit e
+    non vengono risolte in sequenza. Attendono invece un **evento trigger**
+    (es. "essere attaccato") prodotto da un main intent. Quando il trigger
+    matcha, l'orchestratore inietta il ``reaction_payload`` nell'action
+    dell'attaccante (tipicamente come ``parry_response``) e lascia che
+    il resolver atomico gestisca la pipeline esistente.
+
+    Shape dell'intent risultante:
+
+        {
+          "unit_id": "<target>",
+          "reaction_trigger": {
+            "event": "attacked",
+            "source_any_of": ["alpha", "charlie"]  # null = qualsiasi
+          },
+          "reaction_payload": {
+            "type": "parry",
+            "parry_bonus": 1
+          }
+        }
+
+    **Preview-only**: non consuma AP ne' la reaction budget
+    (``unit.reactions.current``). Il budget viene decrementato dal resolver
+    atomico quando la reaction e' effettivamente triggerata durante
+    ``resolve_round``. Una reaction dichiarata ma mai triggerata costa 0.
+
+    **One per unit**: ogni unita' puo' avere **o** un main intent **o**
+    un reaction intent (non entrambi contemporaneamente) per evitare
+    ambiguita' di budget. La ri-dichiarazione latest-wins (come
+    ``declare_intent``) azzera il precedente.
+
+    Raises:
+        ValueError: se la fase non e' ``'planning'``, se l'evento non e'
+            tra ``SUPPORTED_REACTION_EVENTS``, o se il payload type non
+            e' tra ``SUPPORTED_REACTION_TYPES``.
+        KeyError: se ``unit_id`` non esiste nello state.
+    """
+
+    phase = state.get("round_phase")
+    if phase not in (PHASE_PLANNING, None):
+        raise ValueError(
+            f"declare_reaction richiede round_phase {PHASE_PLANNING!r}, "
+            f"trovato {phase!r}"
+        )
+    if _find_unit(state, unit_id) is None:
+        raise KeyError(f"unit_id non trovato nello state: {unit_id}")
+    event = str(trigger.get("event", ""))
+    if event not in SUPPORTED_REACTION_EVENTS:
+        raise ValueError(
+            f"reaction trigger event non supportato: {event!r} "
+            f"(supportati: {sorted(SUPPORTED_REACTION_EVENTS)})"
+        )
+    payload_type = str(reaction_payload.get("type", ""))
+    if payload_type not in SUPPORTED_REACTION_TYPES:
+        raise ValueError(
+            f"reaction payload type non supportato: {payload_type!r} "
+            f"(supportati: {sorted(SUPPORTED_REACTION_TYPES)})"
+        )
+
+    next_state = copy.deepcopy(state)
+    intents = [
+        dict(i)
+        for i in next_state.get("pending_intents", [])
+        if str(i.get("unit_id", "")) != unit_id
+    ]
+    source_filter = trigger.get("source_any_of")
+    normalised_trigger = {
+        "event": event,
+        "source_any_of": (
+            list(source_filter) if isinstance(source_filter, (list, tuple)) else None
+        ),
+    }
+    intents.append(
+        {
+            "unit_id": unit_id,
+            "reaction_trigger": normalised_trigger,
+            "reaction_payload": dict(reaction_payload),
+        }
+    )
+    next_state["pending_intents"] = intents
+    if phase is None:
+        next_state["round_phase"] = PHASE_PLANNING
+    return {"next_state": next_state}
+
+
+def _is_reaction_intent(intent: Mapping[str, Any]) -> bool:
+    """Vero se l'intent ha un ``reaction_trigger``, altrimenti falso."""
+
+    return bool(intent.get("reaction_trigger"))
+
+
+def _partition_intents(
+    state: Mapping[str, Any],
+) -> tuple:
+    """Separa ``pending_intents`` in (main_intents, reactions_by_unit_id).
+
+    ``reactions_by_unit_id`` mappa l'unit_id della reaction al dict
+    completo dell'intent (copia). ``main_intents`` e' la lista di
+    intent "normali" da mettere nella resolution queue. Il partizionamento
+    e' puro e non muta lo state.
+    """
+
+    main_intents: List[Mapping[str, Any]] = []
+    reactions_by_unit: Dict[str, Dict[str, Any]] = {}
+    for intent in state.get("pending_intents", []):
+        if _is_reaction_intent(intent):
+            uid = str(intent.get("unit_id", ""))
+            if uid:
+                reactions_by_unit[uid] = dict(intent)
+        else:
+            main_intents.append(intent)
+    return main_intents, reactions_by_unit
+
+
+def _match_reaction_for_attack(
+    reactions_by_unit: Mapping[str, Dict[str, Any]],
+    target_id: str,
+    attacker_id: str,
+) -> Optional[Dict[str, Any]]:
+    """Trova una reaction intent del target che matchi l'evento 'attacked'.
+
+    Filtri:
+    - target deve avere una reaction non ancora consumata
+    - ``reaction_trigger.event`` deve essere ``'attacked'``
+    - ``reaction_trigger.source_any_of`` deve essere None/vuoto oppure
+      contenere ``attacker_id``
+
+    Ritorna l'entry (mutabile) se matcha, altrimenti None. Il caller
+    e' responsabile di marcarlo come consumato (``_consumed=True``).
+    """
+
+    entry = reactions_by_unit.get(target_id)
+    if entry is None:
+        return None
+    if entry.get("_consumed"):
+        return None
+    trigger = entry.get("reaction_trigger", {})
+    if trigger.get("event") != "attacked":
+        return None
+    source_filter = trigger.get("source_any_of")
+    if source_filter and attacker_id not in source_filter:
+        return None
+    return entry
 
 
 def commit_round(state: Mapping[str, Any]) -> Dict[str, Any]:
@@ -288,7 +540,10 @@ def commit_round(state: Mapping[str, Any]) -> Dict[str, Any]:
     return {"next_state": next_state}
 
 
-def build_resolution_queue(state: Mapping[str, Any]) -> List[Dict[str, Any]]:
+def build_resolution_queue(
+    state: Mapping[str, Any],
+    speed_table: Optional[Mapping[str, int]] = None,
+) -> List[Dict[str, Any]]:
     """Produce la queue di risoluzione ordinata dagli intents committed.
 
     Ordinamento:
@@ -296,7 +551,11 @@ def build_resolution_queue(state: Mapping[str, Any]) -> List[Dict[str, Any]]:
     2. ``unit_id`` alfabetico (tiebreak deterministico)
 
     Intents per unita' non trovate nello state sono silenziosamente
-    ignorati (difesa contro state drift).
+    ignorati (difesa contro state drift). Le **reaction intents** sono
+    escluse dalla main queue — vengono trattate come interrupt da
+    ``resolve_round`` solo se il trigger matcha.
+
+    ``speed_table`` opzionale per override della tabella ACTION_SPEED.
 
     Returns:
         Lista di dict ``{unit_id, action, priority}``.
@@ -305,12 +564,14 @@ def build_resolution_queue(state: Mapping[str, Any]) -> List[Dict[str, Any]]:
     units = {str(u.get("id", "")): u for u in state.get("units", [])}
     queue: List[Dict[str, Any]] = []
     for intent in state.get("pending_intents", []):
+        if _is_reaction_intent(intent):
+            continue
         uid = str(intent.get("unit_id", ""))
         unit = units.get(uid)
         if unit is None:
             continue
         action = intent.get("action", {})
-        priority = compute_resolve_priority(unit, action)
+        priority = compute_resolve_priority(unit, action, speed_table=speed_table)
         queue.append({"unit_id": uid, "action": action, "priority": priority})
     queue.sort(key=lambda q: (-int(q["priority"]), str(q["unit_id"])))
     return queue
@@ -354,8 +615,10 @@ def resolve_round(
     next_state = copy.deepcopy(state)
     next_state["round_phase"] = PHASE_RESOLVING
     queue = build_resolution_queue(next_state)
+    _, reactions_by_unit = _partition_intents(next_state)
     turn_log_entries: List[Dict[str, Any]] = []
     skipped: List[Dict[str, Any]] = []
+    reactions_triggered: List[Dict[str, Any]] = []
 
     for entry in queue:
         uid = entry["unit_id"]
@@ -376,6 +639,34 @@ def resolve_round(
                     {"unit_id": uid, "reason": "target_dead", "action": dict(action)}
                 )
                 continue
+
+        # Reaction injection (follow-up #1 + #3): se il target ha una
+        # reaction intent con trigger="attacked" che matcha l'attaccante
+        # e non e' ancora stata consumata, iniettiamo parry_response
+        # nell'action dell'attaccante. Il resolver atomico gestira'
+        # la pipeline parry come in ogni altra action con parry_response.
+        if action_type == "attack" and target_id:
+            matched = _match_reaction_for_attack(
+                reactions_by_unit, str(target_id), str(uid)
+            )
+            if matched is not None:
+                payload = matched.get("reaction_payload", {})
+                if payload.get("type") == "parry":
+                    # Clona l'action per non mutare l'entry nella queue
+                    action = dict(action)
+                    action["parry_response"] = {
+                        "attempt": True,
+                        "parry_bonus": int(payload.get("parry_bonus", 0)),
+                    }
+                    matched["_consumed"] = True
+                    reactions_triggered.append(
+                        {
+                            "target_unit_id": str(target_id),
+                            "attacker_unit_id": str(uid),
+                            "reaction_payload": dict(payload),
+                        }
+                    )
+
         result = resolve_action(next_state, action, catalog, rng)
         next_state = result["next_state"]
         turn_log_entries.append(result["turn_log_entry"])
@@ -386,16 +677,75 @@ def resolve_round(
         "next_state": next_state,
         "turn_log_entries": turn_log_entries,
         "resolution_queue": queue,
+        "reactions_triggered": reactions_triggered,
         "skipped": skipped,
     }
 
 
+def preview_round(
+    state: Mapping[str, Any],
+    catalog: Mapping[str, Any],
+    rng: Callable[[], float],
+) -> Dict[str, Any]:
+    """Simula ``resolve_round`` su una deep copy, ritorna l'esito atteso.
+
+    Questa e' la funzione di "what-if" per la UI e per il client che
+    vuole mostrare al player l'outcome probabile del round corrente
+    senza mai toccare lo stato canonico ne' consumare il rng canonico.
+
+    Requisiti sul ``state``:
+
+    - ``round_phase`` deve essere ``'planning'`` o ``'committed'``. Se
+      ``'planning'``, la preview auto-committa sulla deep copy prima di
+      chiamare ``resolve_round``. Se ``'committed'``, procede direttamente.
+    - Stati ``'resolving'`` / ``'resolved'`` / altro → ``ValueError``.
+
+    Il ``state`` di input **non viene mutato**: il caller puo' continuare
+    a dichiarare intents come se la preview non fosse avvenuta.
+
+    Il ``rng`` passato deve essere un generatore **dedicato alla preview**
+    (es. namespaced_rng con namespace diverso dal canonical). Il caller
+    e' responsabile di non riusare il rng canonico per la preview — questa
+    funzione non prova a isolarlo internamente, per mantenere il contratto
+    di purezza.
+
+    Returns:
+        Stessa shape di ``resolve_round``:
+        ``{next_state, turn_log_entries, resolution_queue, skipped}``.
+        Il ``next_state`` ritornato rappresenta "come sarebbe lo stato
+        se il round fosse stato risolto", utile per UI previews.
+
+    Raises:
+        ValueError: se ``round_phase`` non e' planning o committed.
+    """
+
+    phase = state.get("round_phase")
+    if phase not in (PHASE_PLANNING, PHASE_COMMITTED, None):
+        raise ValueError(
+            f"preview_round richiede round_phase in "
+            f"{{{PHASE_PLANNING!r}, {PHASE_COMMITTED!r}}}, trovato {phase!r}"
+        )
+    preview_state = copy.deepcopy(state)
+    if phase in (PHASE_PLANNING, None):
+        # Se non c'e' mai stato un begin_round, trattiamo lo stato come
+        # planning implicito (pending_intents assenti → queue vuota).
+        if phase is None:
+            preview_state["round_phase"] = PHASE_PLANNING
+            preview_state.setdefault("pending_intents", [])
+        preview_state = commit_round(preview_state)["next_state"]
+    return resolve_round(preview_state, catalog, rng)
+
+
 __all__ = [
     "ACTION_SPEED",
+    "DEFAULT_ACTION_SPEED",
+    "DEFAULT_ACTION_SPEED_PATH",
     "PHASE_COMMITTED",
     "PHASE_PLANNING",
     "PHASE_RESOLVED",
     "PHASE_RESOLVING",
+    "SUPPORTED_REACTION_EVENTS",
+    "SUPPORTED_REACTION_TYPES",
     "VALID_PHASES",
     "action_speed",
     "begin_round",
@@ -404,5 +754,9 @@ __all__ = [
     "commit_round",
     "compute_resolve_priority",
     "declare_intent",
+    "declare_reaction",
+    "load_action_speed_table",
+    "preview_round",
+    "reload_action_speed_table",
     "resolve_round",
 ]

--- a/tests/test_round_orchestrator.py
+++ b/tests/test_round_orchestrator.py
@@ -33,9 +33,12 @@ from rules.hydration import (  # noqa: E402
 )
 from rules.round_orchestrator import (  # noqa: E402
     ACTION_SPEED,
+    DEFAULT_ACTION_SPEED,
     PHASE_COMMITTED,
     PHASE_PLANNING,
     PHASE_RESOLVED,
+    SUPPORTED_REACTION_EVENTS,
+    SUPPORTED_REACTION_TYPES,
     action_speed,
     begin_round,
     build_resolution_queue,
@@ -43,6 +46,10 @@ from rules.round_orchestrator import (  # noqa: E402
     commit_round,
     compute_resolve_priority,
     declare_intent,
+    declare_reaction,
+    load_action_speed_table,
+    preview_round,
+    reload_action_speed_table,
     resolve_round,
 )
 
@@ -165,6 +172,93 @@ def test_action_speed_table_defaults_to_zero_on_unknown_type():
     assert action_speed({"type": "move"}) == -2
     assert action_speed({"type": "unknown_future_type"}) == 0
     assert action_speed({}) == 0
+
+
+def test_action_speed_accepts_table_override():
+    custom = {"attack": 5, "move": 10}
+    assert action_speed({"type": "attack"}, table=custom) == 5
+    assert action_speed({"type": "move"}, table=custom) == 10
+    # Unknown in override → still 0
+    assert action_speed({"type": "defend"}, table=custom) == 0
+
+
+def test_load_action_speed_table_reads_balance_yaml():
+    """Verifica che il loader legga il file YAML canonico del balance pack."""
+    table = load_action_speed_table()
+    # Stessi valori del DEFAULT_ACTION_SPEED (il YAML balance mantiene
+    # la stessa calibrazione come fonte unica di verita').
+    assert table["defend"] == 2
+    assert table["parry"] == 2
+    assert table["attack"] == 0
+    assert table["ability"] == -1
+    assert table["move"] == -2
+
+
+def test_load_action_speed_table_missing_file_falls_back_to_default(tmp_path):
+    """Path inesistente → fallback a DEFAULT_ACTION_SPEED senza eccezioni."""
+    missing = tmp_path / "does_not_exist.yaml"
+    table = load_action_speed_table(missing)
+    assert table == DEFAULT_ACTION_SPEED
+
+
+def test_load_action_speed_table_malformed_file_falls_back(tmp_path):
+    """YAML malformato → fallback a DEFAULT_ACTION_SPEED."""
+    bad = tmp_path / "broken.yaml"
+    bad.write_text("this is not: valid: yaml: [[[", encoding="utf-8")
+    table = load_action_speed_table(bad)
+    assert table == DEFAULT_ACTION_SPEED
+
+
+def test_load_action_speed_table_missing_key_falls_back(tmp_path):
+    """YAML valido ma senza chiave action_speed → fallback."""
+    no_key = tmp_path / "no_key.yaml"
+    no_key.write_text("version: 1\nother_field: 42\n", encoding="utf-8")
+    table = load_action_speed_table(no_key)
+    assert table == DEFAULT_ACTION_SPEED
+
+
+def test_load_action_speed_table_custom_values(tmp_path):
+    """YAML custom → valori nuovi caricati."""
+    custom = tmp_path / "custom.yaml"
+    custom.write_text(
+        "version: 1\n"
+        "action_speed:\n"
+        "  attack: 5\n"
+        "  defend: -1\n"
+        "  move: 0\n",
+        encoding="utf-8",
+    )
+    table = load_action_speed_table(custom)
+    assert table == {"attack": 5, "defend": -1, "move": 0}
+
+
+def test_reload_action_speed_table_mutates_module_level_dict(tmp_path):
+    """``reload_action_speed_table`` aggiorna il ``ACTION_SPEED`` runtime."""
+    custom = tmp_path / "reload.yaml"
+    custom.write_text(
+        "action_speed:\n  attack: 99\n  defend: 88\n",
+        encoding="utf-8",
+    )
+    try:
+        reload_action_speed_table(custom)
+        assert ACTION_SPEED["attack"] == 99
+        assert ACTION_SPEED["defend"] == 88
+    finally:
+        # Ripristina i valori dal file canonico per non lasciare side
+        # effect su altri test dello stesso session pytest.
+        reload_action_speed_table()
+    assert ACTION_SPEED["attack"] == 0
+    assert ACTION_SPEED["defend"] == 2
+
+
+def test_compute_resolve_priority_respects_speed_table_override():
+    """``compute_resolve_priority`` accetta ``speed_table`` custom."""
+    unit = {"initiative": 10, "statuses": []}
+    custom = {"attack": 5}
+    # attack custom → priority 10 + 5 = 15
+    assert compute_resolve_priority(unit, {"type": "attack"}, speed_table=custom) == 15
+    # Senza override usa il modulo-level
+    assert compute_resolve_priority(unit, {"type": "attack"}) == 10
 
 
 def test_compute_resolve_priority_base_sums_initiative_and_action_speed():
@@ -535,6 +629,127 @@ def test_round_loop_deterministic_with_same_seed(catalog):
     assert first["round_phase"] == second["round_phase"]
 
 
+# ------------------------------------------------------------------
+# preview_round (follow-up #5)
+# ------------------------------------------------------------------
+
+
+def test_preview_round_from_planning_does_not_mutate_input(catalog):
+    """``preview_round`` non deve toccare lo stato di input."""
+
+    state = _make_state(catalog, initiative_a=14, initiative_b=10)
+    state = begin_round(state)["next_state"]
+    state = declare_intent(state, "alpha", _attack("alpha", "bravo"))[
+        "next_state"
+    ]
+    state = declare_intent(state, "bravo", _attack("bravo", "alpha"))[
+        "next_state"
+    ]
+    # Snapshot pre-preview
+    hp_alpha_before = state["units"][0]["hp"]["current"]
+    hp_bravo_before = state["units"][1]["hp"]["current"]
+    ap_alpha_before = state["units"][0]["ap"]["current"]
+    log_len_before = len(state["log"])
+    phase_before = state["round_phase"]
+    intents_before = len(state["pending_intents"])
+
+    rng = namespaced_rng("preview-seed", "what-if")
+    result = preview_round(state, catalog, rng)
+
+    # Input invariato
+    assert state["units"][0]["hp"]["current"] == hp_alpha_before
+    assert state["units"][1]["hp"]["current"] == hp_bravo_before
+    assert state["units"][0]["ap"]["current"] == ap_alpha_before
+    assert len(state["log"]) == log_len_before
+    assert state["round_phase"] == phase_before
+    assert len(state["pending_intents"]) == intents_before
+
+    # Il next_state della preview invece rappresenta "come sarebbe"
+    assert result["next_state"]["round_phase"] == PHASE_RESOLVED
+    assert result["next_state"]["pending_intents"] == []
+
+
+def test_preview_round_from_committed_matches_resolve_round(catalog):
+    """``preview_round`` su stato committed deve dare lo stesso
+    next_state di una resolve_round diretta (eccetto per il side-effect
+    sul state originale)."""
+
+    def build():
+        s = _make_state(catalog, initiative_a=14, initiative_b=10)
+        s = begin_round(s)["next_state"]
+        s = declare_intent(s, "alpha", _attack("alpha", "bravo"))["next_state"]
+        s = declare_intent(s, "bravo", _attack("bravo", "alpha"))["next_state"]
+        s = commit_round(s)["next_state"]
+        return s
+
+    state_preview = build()
+    state_real = build()
+
+    rng_preview = namespaced_rng("seed", "compare")
+    rng_real = namespaced_rng("seed", "compare")
+
+    preview = preview_round(state_preview, catalog, rng_preview)
+    real = resolve_round(state_real, catalog, rng_real)
+
+    # Stessi HP, stessa log length, stessi entries risolti
+    assert preview["next_state"]["units"][0]["hp"] == real["next_state"]["units"][0]["hp"]
+    assert preview["next_state"]["units"][1]["hp"] == real["next_state"]["units"][1]["hp"]
+    assert len(preview["turn_log_entries"]) == len(real["turn_log_entries"])
+    assert preview["resolution_queue"] == real["resolution_queue"]
+
+
+def test_preview_round_accepts_state_without_round_phase(catalog):
+    """Stato hydratato "vecchio stile" senza round_phase → preview
+    tratta come planning implicito, commit su copy, poi resolve."""
+
+    state = _make_state(catalog)
+    # NO begin_round: state["round_phase"] non esiste
+    assert "round_phase" not in state
+    rng = namespaced_rng("seed", "implicit")
+    result = preview_round(state, catalog, rng)
+    assert result["next_state"]["round_phase"] == PHASE_RESOLVED
+    # Nessun intent → nessun entry risolto
+    assert result["turn_log_entries"] == []
+    # Input invariato
+    assert "round_phase" not in state
+
+
+def test_preview_round_rejects_resolved_phase(catalog):
+    """Stato gia' resolved → ValueError."""
+
+    state = _make_state(catalog)
+    state = begin_round(state)["next_state"]
+    state = declare_intent(state, "alpha", _attack("alpha", "bravo"))[
+        "next_state"
+    ]
+    state = commit_round(state)["next_state"]
+    rng = namespaced_rng("seed", "resolve1")
+    state = resolve_round(state, catalog, rng)["next_state"]
+    assert state["round_phase"] == PHASE_RESOLVED
+    with pytest.raises(ValueError, match="planning"):
+        preview_round(state, catalog, namespaced_rng("seed", "resolve2"))
+
+
+def test_preview_round_deterministic_across_multiple_calls(catalog):
+    """Stesso stato + stesso rng → stesso outcome ripetutamente."""
+
+    def build():
+        s = _make_state(catalog, initiative_a=14, initiative_b=10)
+        s = begin_round(s)["next_state"]
+        s = declare_intent(s, "alpha", _attack("alpha", "bravo"))["next_state"]
+        s = declare_intent(s, "bravo", _defend("bravo"))["next_state"]
+        return s
+
+    state = build()
+    rng1 = namespaced_rng("preview", "det")
+    rng2 = namespaced_rng("preview", "det")
+    p1 = preview_round(state, catalog, rng1)
+    p2 = preview_round(state, catalog, rng2)
+    assert p1["next_state"]["units"][0]["hp"] == p2["next_state"]["units"][0]["hp"]
+    assert p1["next_state"]["units"][1]["hp"] == p2["next_state"]["units"][1]["hp"]
+    assert p1["resolution_queue"] == p2["resolution_queue"]
+
+
 def test_full_round_end_to_end_preview_then_commit_then_resolve(catalog):
     """Smoke test del flusso completo: preview-only → commit → resolve."""
 
@@ -571,3 +786,262 @@ def test_full_round_end_to_end_preview_then_commit_then_resolve(catalog):
     assert entries[0]["action"]["actor_id"] == "alpha"
     assert entries[0]["action"]["type"] == "defend"
     assert entries[1]["action"]["actor_id"] == "bravo"
+
+
+# ------------------------------------------------------------------
+# Reactions as first-class intents (follow-up #1 + #3)
+# ------------------------------------------------------------------
+
+
+def test_declare_reaction_registers_reaction_intent(catalog):
+    state = begin_round(_make_state(catalog))["next_state"]
+    ap_before = state["units"][1]["ap"]["current"]
+    state = declare_reaction(
+        state,
+        "bravo",
+        reaction_payload={"type": "parry", "parry_bonus": 1},
+        trigger={"event": "attacked", "source_any_of": None},
+    )["next_state"]
+    # AP di bravo invariato (reaction preview-only)
+    assert state["units"][1]["ap"]["current"] == ap_before
+    assert len(state["pending_intents"]) == 1
+    intent = state["pending_intents"][0]
+    assert intent["unit_id"] == "bravo"
+    assert intent["reaction_trigger"]["event"] == "attacked"
+    assert intent["reaction_trigger"]["source_any_of"] is None
+    assert intent["reaction_payload"]["type"] == "parry"
+    assert intent["reaction_payload"]["parry_bonus"] == 1
+
+
+def test_declare_reaction_rejects_unsupported_event(catalog):
+    state = begin_round(_make_state(catalog))["next_state"]
+    with pytest.raises(ValueError, match="event non supportato"):
+        declare_reaction(
+            state,
+            "bravo",
+            reaction_payload={"type": "parry", "parry_bonus": 1},
+            trigger={"event": "teleported", "source_any_of": None},
+        )
+
+
+def test_declare_reaction_rejects_unsupported_payload_type(catalog):
+    state = begin_round(_make_state(catalog))["next_state"]
+    with pytest.raises(ValueError, match="payload type non supportato"):
+        declare_reaction(
+            state,
+            "bravo",
+            reaction_payload={"type": "mind_blast", "power": 5},
+            trigger={"event": "attacked", "source_any_of": None},
+        )
+
+
+def test_declare_reaction_rejects_wrong_phase(catalog):
+    state = begin_round(_make_state(catalog))["next_state"]
+    state = commit_round(state)["next_state"]
+    with pytest.raises(ValueError, match="planning"):
+        declare_reaction(
+            state,
+            "bravo",
+            reaction_payload={"type": "parry", "parry_bonus": 1},
+            trigger={"event": "attacked", "source_any_of": None},
+        )
+
+
+def test_declare_reaction_latest_wins_per_unit(catalog):
+    state = begin_round(_make_state(catalog))["next_state"]
+    state = declare_reaction(
+        state,
+        "bravo",
+        reaction_payload={"type": "parry", "parry_bonus": 1},
+        trigger={"event": "attacked", "source_any_of": None},
+    )["next_state"]
+    # Ri-dichiara con parry_bonus diverso → sovrascrive
+    state = declare_reaction(
+        state,
+        "bravo",
+        reaction_payload={"type": "parry", "parry_bonus": 3},
+        trigger={"event": "attacked", "source_any_of": ["alpha"]},
+    )["next_state"]
+    assert len(state["pending_intents"]) == 1
+    assert state["pending_intents"][0]["reaction_payload"]["parry_bonus"] == 3
+    assert state["pending_intents"][0]["reaction_trigger"]["source_any_of"] == ["alpha"]
+
+
+def test_build_resolution_queue_excludes_reaction_intents(catalog):
+    """Le reaction intents NON devono comparire nella main queue."""
+
+    state = begin_round(_make_state(catalog))["next_state"]
+    state = declare_intent(state, "alpha", _attack("alpha", "bravo"))["next_state"]
+    state = declare_reaction(
+        state,
+        "bravo",
+        reaction_payload={"type": "parry", "parry_bonus": 1},
+        trigger={"event": "attacked", "source_any_of": None},
+    )["next_state"]
+    state = commit_round(state)["next_state"]
+    queue = build_resolution_queue(state)
+    # Solo alpha (attack) in queue. bravo (reaction) escluso.
+    assert len(queue) == 1
+    assert queue[0]["unit_id"] == "alpha"
+
+
+def test_reaction_triggers_parry_on_matching_attack(catalog):
+    """L'attacco di alpha su bravo con bravo che ha reaction parry →
+    parry_response iniettato nell'action, resolver atomico gestisce la
+    pipeline parry come in ogni altra action con parry_response."""
+
+    state = _make_state(catalog, initiative_a=14, initiative_b=10)
+    state = begin_round(state)["next_state"]
+    state = declare_intent(state, "alpha", _attack("alpha", "bravo"))["next_state"]
+    state = declare_reaction(
+        state,
+        "bravo",
+        reaction_payload={"type": "parry", "parry_bonus": 1},
+        trigger={"event": "attacked", "source_any_of": None},
+    )["next_state"]
+    state = commit_round(state)["next_state"]
+    rng = namespaced_rng("seed", "reaction-trigger")
+    result = resolve_round(state, catalog, rng)
+
+    # 1 entry in turn_log (l'attack di alpha con parry_response iniettato)
+    assert len(result["turn_log_entries"]) == 1
+    attack_entry = result["turn_log_entries"][0]
+    assert attack_entry["action"]["actor_id"] == "alpha"
+    assert attack_entry["action"].get("parry_response") is not None
+    assert attack_entry["action"]["parry_response"]["attempt"] is True
+    assert attack_entry["action"]["parry_response"]["parry_bonus"] == 1
+    # La parry entry e' loggata in reactions_triggered
+    assert len(result["reactions_triggered"]) == 1
+    assert result["reactions_triggered"][0]["target_unit_id"] == "bravo"
+    assert result["reactions_triggered"][0]["attacker_unit_id"] == "alpha"
+
+
+def test_reaction_source_filter_matches_allowed_attacker(catalog):
+    """Reaction con source_any_of=['alpha'] triggera su alpha."""
+
+    state = _make_state(catalog, initiative_a=14, initiative_b=10)
+    state = begin_round(state)["next_state"]
+    state = declare_intent(state, "alpha", _attack("alpha", "bravo"))["next_state"]
+    state = declare_reaction(
+        state,
+        "bravo",
+        reaction_payload={"type": "parry", "parry_bonus": 2},
+        trigger={"event": "attacked", "source_any_of": ["alpha"]},
+    )["next_state"]
+    state = commit_round(state)["next_state"]
+    rng = namespaced_rng("seed", "reaction-source-match")
+    result = resolve_round(state, catalog, rng)
+    assert len(result["reactions_triggered"]) == 1
+
+
+def test_reaction_source_filter_rejects_other_attacker(catalog):
+    """Reaction con source_any_of=['charlie'] NON triggera su alpha."""
+
+    state = _make_state(catalog, initiative_a=14, initiative_b=10)
+    state = begin_round(state)["next_state"]
+    state = declare_intent(state, "alpha", _attack("alpha", "bravo"))["next_state"]
+    state = declare_reaction(
+        state,
+        "bravo",
+        reaction_payload={"type": "parry", "parry_bonus": 2},
+        trigger={"event": "attacked", "source_any_of": ["charlie"]},
+    )["next_state"]
+    state = commit_round(state)["next_state"]
+    rng = namespaced_rng("seed", "reaction-source-miss")
+    result = resolve_round(state, catalog, rng)
+    assert result["reactions_triggered"] == []
+    # L'attack di alpha e' comunque risolto normalmente
+    assert len(result["turn_log_entries"]) == 1
+    attack_entry = result["turn_log_entries"][0]
+    # Nessun parry_response iniettato
+    assert attack_entry["action"].get("parry_response") is None
+
+
+def test_reaction_consumed_after_first_trigger(catalog):
+    """Reaction one-shot: dopo il primo trigger non riparte anche se c'e'
+    un secondo attacco nello stesso round."""
+
+    # 3 unita': alpha e charlie attaccano bravo. La reaction di bravo
+    # deve triggerare solo sul primo (quello con priority piu' alta).
+    state = _make_state(catalog, initiative_a=18, initiative_b=5)
+    charlie = build_hostile_unit_from_group(
+        unit_id="charlie",
+        species_id="demo_charlie",
+        group={"power": 4, "role": "front", "affixes": []},
+        trait_ids=[],
+        catalog=catalog,
+    )
+    charlie["initiative"] = 12
+    state["units"].append(charlie)
+    # bravo deve sopravvivere al primo hit: pump HP
+    state["units"][1]["hp"]["current"] = 100
+    state["units"][1]["hp"]["max"] = 100
+    state = begin_round(state)["next_state"]
+    state = declare_intent(state, "alpha", _attack("alpha", "bravo"))["next_state"]
+    state = declare_intent(state, "charlie", _attack("charlie", "bravo"))["next_state"]
+    state = declare_reaction(
+        state,
+        "bravo",
+        reaction_payload={"type": "parry", "parry_bonus": 1},
+        trigger={"event": "attacked", "source_any_of": None},
+    )["next_state"]
+    state = commit_round(state)["next_state"]
+    rng = namespaced_rng("seed", "reaction-consume")
+    result = resolve_round(state, catalog, rng)
+    # Esattamente 1 reaction triggerata (sul primo attacker = alpha,
+    # che ha priority 18 > 12 di charlie)
+    assert len(result["reactions_triggered"]) == 1
+    assert result["reactions_triggered"][0]["attacker_unit_id"] == "alpha"
+    # Entrambi gli attack sono stati risolti
+    actors_resolved = [e["action"]["actor_id"] for e in result["turn_log_entries"]]
+    assert "alpha" in actors_resolved
+    assert "charlie" in actors_resolved
+
+
+def test_reaction_unused_if_target_not_attacked(catalog):
+    """Reaction dichiarata ma mai triggerata non ha effetti collaterali."""
+
+    state = _make_state(catalog, initiative_a=14, initiative_b=10)
+    state = begin_round(state)["next_state"]
+    # alpha muove invece di attaccare
+    state = declare_intent(state, "alpha", _move("alpha"))["next_state"]
+    state = declare_reaction(
+        state,
+        "bravo",
+        reaction_payload={"type": "parry", "parry_bonus": 1},
+        trigger={"event": "attacked", "source_any_of": None},
+    )["next_state"]
+    state = commit_round(state)["next_state"]
+    rng = namespaced_rng("seed", "reaction-unused")
+    result = resolve_round(state, catalog, rng)
+    # Nessuna reaction triggerata
+    assert result["reactions_triggered"] == []
+    # L'action di alpha (move) e' risolta normalmente
+    assert len(result["turn_log_entries"]) == 1
+    assert result["turn_log_entries"][0]["action"]["actor_id"] == "alpha"
+
+
+def test_reaction_does_not_consume_ap_if_not_triggered(catalog):
+    """AP dell'unita' con reaction invariati se la reaction non triggera."""
+
+    state = _make_state(catalog, initiative_a=14, initiative_b=10)
+    state = begin_round(state)["next_state"]
+    ap_bravo_before = state["units"][1]["ap"]["current"]
+    state = declare_intent(state, "alpha", _move("alpha"))["next_state"]
+    state = declare_reaction(
+        state,
+        "bravo",
+        reaction_payload={"type": "parry", "parry_bonus": 1},
+        trigger={"event": "attacked", "source_any_of": None},
+    )["next_state"]
+    state = commit_round(state)["next_state"]
+    rng = namespaced_rng("seed", "reaction-ap")
+    result = resolve_round(state, catalog, rng)
+    # bravo non ha consumato AP (reaction mai triggerata)
+    assert result["next_state"]["units"][1]["ap"]["current"] == ap_bravo_before
+
+
+def test_supported_reaction_enums_are_exposed():
+    """Sanity check su costanti esportate."""
+    assert "attacked" in SUPPORTED_REACTION_EVENTS
+    assert "parry" in SUPPORTED_REACTION_TYPES


### PR DESCRIPTION
## Summary

Implementa 4 dei 6 follow-up tracciati in [ADR-2026-04-15](../adr/ADR-2026-04-15-round-based-combat-model.md) e [`docs/combat/round-loop.md §6`](../combat/round-loop.md). Il resolver atomico resta **invariato**: tutte le estensioni vivono in `round_orchestrator.py` e sono additive.

| Follow-up | Descrizione | Stato |
|---|---|---|
| **#2** | `ACTION_SPEED` da YAML balance pack | ✅ |
| **#5** | `preview_round` per UI what-if | ✅ |
| **#1** | Reazioni come intent first-class | ✅ |
| **#3** | Interrupt window con trigger conditions | ✅ |
| #4 | Migrazione Node session engine | ⏸️ sprint dedicato |
| #6 | Timer opzionale planning phase | ⏸️ follow-up |

## #2 — ACTION_SPEED da YAML balance pack

- **`packs/evo_tactics_pack/data/balance/action_speed.yaml`** (nuovo): fonte unica di verità per i modificatori di velocità. Tuning senza commit Python.
- **`load_action_speed_table(path)`**: loader tollerante. Fallback a `DEFAULT_ACTION_SPEED` se file manca / YAML malformato / pyyaml non installato. Non solleva mai.
- **`reload_action_speed_table(path)`**: hot reload per test override.
- **`action_speed(action, table=None)`** e **`compute_resolve_priority(unit, action, speed_table=None)`** accettano override opzionali.

## #5 — preview_round per UI what-if

- **`preview_round(state, catalog, rng)`**: simula `resolve_round` su deep copy, **non muta l'input**.
- Accetta fase `planning` o `committed` (auto-commit su copy se planning).
- Tratta state senza `round_phase` come planning implicito (retrocompat).
- Stessa shape di ritorno di `resolve_round`.
- Il caller passa un rng dedicato per non consumare il rng canonico.

## #1 — Reazioni come intent first-class

Le reazioni non sono più un flag `parry_response` nell'action dell'attaccante, ma un **intent separato** con shape dedicata:

```python
declare_reaction(
    state,
    unit_id="bravo",
    reaction_payload={"type": "parry", "parry_bonus": 1},
    trigger={"event": "attacked", "source_any_of": None}
)
```

Shape in `pending_intents`:

```json
{
  "unit_id": "bravo",
  "reaction_trigger": {"event": "attacked", "source_any_of": null},
  "reaction_payload": {"type": "parry", "parry_bonus": 1}
}
```

- **Non in main queue**: `build_resolution_queue` le esclude.
- **Preview-only al commit**: nessun AP consumato finché non triggerate.
- **One-shot per round**: la prima volta che matchano → `_consumed=True`.
- **Enum validati**: `SUPPORTED_REACTION_EVENTS = {"attacked"}`, `SUPPORTED_REACTION_TYPES = {"parry"}`. Rejects espliciti su payload/event non supportati.

Pipeline di trigger (dentro `resolve_round`):

1. Per ogni main intent di tipo `attack`, check `_match_reaction_for_attack(reactions_by_unit, target_id, attacker_id)`.
2. Se matcha, clone l'action + inject `parry_response={attempt:true, parry_bonus}`.
3. Chiama `resolve_action` con l'action arricchita → il resolver atomico gestisce la parry pipeline esistente senza modifiche.
4. Marca la reaction come consumata + log in `result["reactions_triggered"]`.

## #3 — Interrupt window con trigger conditions

- **`reaction_trigger.event`**: `"attacked"` per v1 (extensible).
- **`reaction_trigger.source_any_of`**: lista opzionale di `unit_id`. `None`/vuoto = qualsiasi sorgente. Filter attivo nel match.
- Validation in `declare_reaction`: `ValueError` su event/type non supportati con messaggio esplicito.

## Compatibilità

- ✅ Resolver atomico `resolve_action` **invariato**. 69 test di `test_resolver.py` passano senza regressione.
- ✅ Schema `combat.schema.json` invariato: nuovi campi vivono in `pending_intents[i]` (additive, non validati dallo schema dell'action).
- ✅ `ACTION_SPEED` resta un dict modulo-level (backward compat dell'API pubblica).
- ✅ Node session engine non toccato.

## Test

- **`tests/test_round_orchestrator.py`**: 29 → **55 test** (+26 nuovi)
  - 8 test per loader YAML + override tabella (`action_speed`, `compute_resolve_priority`, `load_action_speed_table` con fallback, malformed, custom, reload)
  - 5 test per `preview_round` (determinism, no-mutation, phase checks, implicit planning)
  - 13 test per reactions first-class (declare + trigger match + source filter + one-shot + unused + ap-not-consumed + enum validation)

Totali verdi:

- `pytest tests/test_round_orchestrator.py tests/test_resolver.py tests/test_hydration.py tests/test_demo_cli.py` → **166/166 verdi** in 0.65s
- `node --test tests/api/contracts-combat.test.js` → **23/23 verdi** (schema invariato)
- `prettier --check` → pulito

## File (4)

| File | Δ | Descrizione |
|---|---|---|
| `services/rules/round_orchestrator.py` | +322/-20 | loader YAML + preview_round + declare_reaction + partizionamento |
| `packs/evo_tactics_pack/data/balance/action_speed.yaml` | +36 (nuovo) | fonte di verità per speed modifiers |
| `tests/test_round_orchestrator.py` | +474 | 26 nuovi test |
| `docs/combat/round-loop.md` | +96/-24 | nuova sezione Reazioni, API aggiornata, Follow-ups aggiornati |

## Rollback

`git revert <sha>` rimuove:
- 1 file YAML nuovo (isolato)
- estensioni additive al modulo Python (non tocca `resolve_action`)
- test nuovi
- modifiche additive al doc

Il resolver atomico resta intoccato → rollback è chirurgico senza blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
