### PR TITLE
docs: integrate Final Design Freeze bundle into repo entrypoints

### DIFF
--- a/docs/00-INDEX.md
+++ b/docs/00-INDEX.md
@@ -15,6 +15,8 @@ review_cycle_days: 30
 >
 > I doc numerati sono stati spostati in [`docs/core/`](core/) durante la ristrutturazione di aprile 2026. Tutti i link sotto sono già aggiornati ai nuovi path.
 
+> **Final Design Freeze v0.9.** La baseline canonica di design finale di Evo Tactics vive in [`docs/core/90-FINAL-DESIGN-FREEZE.md`](core/90-FINAL-DESIGN-FREEZE.md) (A3 source of truth). Il bundle esecutivo (roadmap, milestones & gates, backlog, playbook Codex, piano cross-repo) e' in [`docs/planning/EVO_FINAL_DESIGN_ROADMAPS_INDEX.md`](planning/EVO_FINAL_DESIGN_ROADMAPS_INDEX.md). Le regole di risoluzione conflitti tra fonti sono in [`docs/planning/EVO_FINAL_DESIGN_SOURCE_AUTHORITY_MAP.md`](planning/EVO_FINAL_DESIGN_SOURCE_AUTHORITY_MAP.md).
+
 ## Accesso rapido (SSoT)
 
 - [INTEGRAZIONE GUIDE — SSoT](INTEGRAZIONE_GUIDE.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,20 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # Docs (indice)
+
+## Final Design Freeze v0.9 (baseline canonica)
+
+La sintesi di design finale di Evo Tactics e il bundle esecutivo vivono in:
+
+- [`docs/core/90-FINAL-DESIGN-FREEZE.md`](core/90-FINAL-DESIGN-FREEZE.md) — sintesi di prodotto, scope shipping, vincoli architetturali (A3 source of truth).
+- [`docs/planning/EVO_FINAL_DESIGN_ROADMAPS_INDEX.md`](planning/EVO_FINAL_DESIGN_ROADMAPS_INDEX.md) — indice del bundle esecutivo con ordine di lettura consigliato.
+- [`docs/planning/EVO_FINAL_DESIGN_SOURCE_AUTHORITY_MAP.md`](planning/EVO_FINAL_DESIGN_SOURCE_AUTHORITY_MAP.md) — **leggere per primo** in caso di conflitto tra fonti.
+
+Il bundle include master roadmap, milestones & gates, backlog esecutivo (FD-IDs per epic), playbook Codex e piano cross-repo Game ↔ Game-Database. Per l'entrypoint canonico del workstream vedi [`docs/hubs/README.md`](hubs/README.md).
+
+---
 
 Questi file sono scheletri collegati ai **Canvas** già creati in ChatGPT. Copia/incolla dal canvas per avere i contenuti completi.
 

--- a/docs/hubs/README.md
+++ b/docs/hubs/README.md
@@ -18,6 +18,14 @@ review_cycle_days: 14
 
 Questo e' l'entrypoint primario dei documenti operativi.
 
+## Final Design Freeze (baseline canonica)
+
+La baseline di design finale di Evo Tactics e' pubblicata nel bundle [Final Design Freeze v0.9](../core/90-FINAL-DESIGN-FREEZE.md). Per un nuovo contributor o agente la sequenza di lettura consigliata e':
+
+1. [`90-FINAL-DESIGN-FREEZE`](../core/90-FINAL-DESIGN-FREEZE.md) — sintesi di prodotto, scope shipping, vincoli architetturali.
+2. [`EVO_FINAL_DESIGN_SOURCE_AUTHORITY_MAP`](../planning/EVO_FINAL_DESIGN_SOURCE_AUTHORITY_MAP.md) — **leggere per primo** in caso di conflitto tra fonti: definisce la gerarchia A0..A5 (governance → ADR/hub → core data → freeze → agent docs → storico).
+3. [`EVO_FINAL_DESIGN_ROADMAPS_INDEX`](../planning/EVO_FINAL_DESIGN_ROADMAPS_INDEX.md) — indice del bundle esecutivo (roadmap, milestones & gates, backlog, playbook Codex, piano cross-repo).
+
 ## Hub per workstream
 
 - [Flow](flow.md) - orchestrazione e validazione contenuti.

--- a/docs/hubs/backend.md
+++ b/docs/hubs/backend.md
@@ -28,3 +28,8 @@ review_cycle_days: 14
 
 - completare baseline minima dei moduli incompleti
 - aggiornare `docs/governance/workstream_matrix.json`
+
+## Cross-repo (Game ↔ Game-Database)
+
+- [ADR-2026-04-14: Game-Database topology](../adr/ADR-2026-04-14-game-database-topology.md) — confine architetturale non negoziabile: `Game` resta runtime source of truth, `Game-Database` resta CMS/taxonomy e import target build-time.
+- [Final Design — Game Database Sync Plan](../planning/EVO_FINAL_DESIGN_GAME_DATABASE_SYNC.md) — runbook operativo per `sync:evo-pack` / `evo:import`, cadence manuale/batch, trigger per riaprire integrazioni avanzate. Segue l'ADR senza introdurre dipendenze runtime.

--- a/docs/hubs/combat.md
+++ b/docs/hubs/combat.md
@@ -54,6 +54,10 @@ Per una panoramica e mappa completa dei doc del workstream vedi [docs/combat/REA
 - [ADR-2026-04-13: Rules Engine d20](../adr/ADR-2026-04-13-rules-engine-d20.md) — scelte di linguaggio (Python), gate sul balance layer separato, RNG namespacing, scope degli status in Fase 1.
 - [ADR-2026-04-15: Round-based combat model](../adr/ADR-2026-04-15-round-based-combat-model.md) — nuovo loop shared-planning → commit → ordered-resolution, semantica di `initiative` come reaction speed.
 
+## Vista di prodotto
+
+- [Final Design Freeze v0.9 §7 Combat system](../core/90-FINAL-DESIGN-FREEZE.md) — sintesi di prodotto del combat nucleo canonico, scope shipping degli action type e status, resolver freeze API, formula tattica da fissare nel rulebook. Complementare alla reference API di questo hub.
+
 ## Comandi demo
 
 ```bash


### PR DESCRIPTION
## Summary

Aggiunge link ad alto-livello al Final Design Freeze v0.9 (PR #1378) dagli **entrypoint documentali esistenti** del repo. Massimizza la scopribilita' del bundle per nuovi contributor e agenti Codex senza riscrivere contenuto.

Modifiche **chirurgiche**: ogni file riceve 2-10 righe mirate con link markdown al freeze, al bundle esecutivo e alla source authority map. Zero cambi di semantica, zero riscrittura di sezioni esistenti.

## File toccati (5)

### Entrypoint documentali (alta priorita')

| File | Modifica |
| --- | --- |
| [`docs/README.md`](docs/README.md) | Sezione "Final Design Freeze v0.9 (baseline canonica)" in alto, linka freeze + ROADMAPS_INDEX + SOURCE_AUTHORITY_MAP + hub canonico. |
| [`docs/hubs/README.md`](docs/hubs/README.md) | Sezione "Final Design Freeze (baseline canonica)" prima degli hub per workstream, con **sequenza di lettura consigliata** (freeze → authority map → roadmaps index). |
| [`docs/00-INDEX.md`](docs/00-INDEX.md) | Blockquote con riferimento a freeze + bundle + authority map, mantenendo il tono "indice legacy" esistente del doc. |

### Hub workstream (media priorita')

| File | Modifica |
| --- | --- |
| [`docs/hubs/combat.md`](docs/hubs/combat.md) | Sezione "Vista di prodotto" dopo gli ADR, linka `freeze §7 Combat system` come complemento della reference API gia' presente. |
| [`docs/hubs/backend.md`](docs/hubs/backend.md) | Sezione "Cross-repo (Game ↔ Game-Database)" in coda, linka `ADR-2026-04-14` e il piano `EVO_FINAL_DESIGN_GAME_DATABASE_SYNC` come runbook operativo. |

## Fuori scope (follow-up dedicati)

Segnalati nel navigation pass di PR #1378 ma intenzionalmente non toccati in questa patch per restare nel perimetro minimo:

- `docs/hubs/atlas.md`, `dataset-pack.md`, `flow.md`, `ops-qa.md`, `incoming.md` — hub di workstream non direttamente interessati dal bundle.
- `docs/process/milestones.md`, `action-items.md` — redirect verso `MASTER_ROADMAP` e `BACKLOG_REGISTER`.
- `docs/governance/README.md` — cross-reference verso `SOURCE_AUTHORITY_MAP` come estensione del contratto governance.
- `docs/adr/ADR-2026-04-13/04-14/04-15` — cross-reference inverse verso `freeze §7` (gli ADR non tipicamente linkano indietro al consumer di prodotto).

Questi restano disponibili come patch dedicata quando autorizzata.

## Validazione

- [x] `python tools/check_docs_governance.py --strict` → **`errors=0 warnings=0`**
- [x] `prettier --check` → pulito sui 5 file modificati
- [x] Nessuna modifica a frontmatter, registry, runtime o schemi
- [x] Diff totale: **+33/-1 righe** (solo aggiunte, una sola riga di rewrap prettier)

## Dipendenze

Questa PR e' **indipendente** da #1379 (cascade FD-IDs). Tocca file diversi (`docs/README.md`, `docs/hubs/*`, `docs/00-INDEX.md`) mentre #1379 tocca `docs/planning/*`. Possono essere mergiate in qualsiasi ordine.

## Rollback

`git revert <sha>` rimuove le 5 sezioni aggiunte. Nessun impatto su runtime, codice, o altri documenti. Completamente additivo.

## Test plan

- [x] Governance strict locale
- [x] Prettier check locale
- [ ] CI build + governance (paths-filter skippa deployment-checks/site-audit/stack-quality)
- [ ] Master DD review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
