### PR TITLE
docs: reverse cross-references verso Final Design bundle

### DIFF
--- a/docs/adr/ADR-2026-04-13-rules-engine-d20.md
+++ b/docs/adr/ADR-2026-04-13-rules-engine-d20.md
@@ -8,6 +8,7 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # ADR-2026-04-13: Rules Engine d20 per il loop tattico giocabile
 
 - **Data**: 2026-04-13
@@ -506,3 +507,7 @@ trigger_dc}`) e `on_hit_stress_delta` (number `[-1, 1]`). Entrambi
       aggiuntive, tick effects per rage/panic, saving throw con modifier)
       richiedono modifiche retrocompatibili allo schema `combat.schema.json`
       o alla shape del layer `trait_mechanics.yaml`.
+
+## Consumer di prodotto
+
+Questo ADR e' recepito come vincolo tecnico dal [`Final Design Freeze v0.9 §7.3 Resolver freeze`](../core/90-FINAL-DESIGN-FREEZE.md), che dichiara lo scope shipping delle API del resolver atomico come baseline di prodotto. Il freeze non sostituisce questo ADR: in caso di conflitto, **vince l'ADR** per tutto cio' che riguarda confini architetturali e contratti tecnici (vedi [`SOURCE_AUTHORITY_MAP §4.1`](../planning/EVO_FINAL_DESIGN_SOURCE_AUTHORITY_MAP.md)).

--- a/docs/adr/ADR-2026-04-14-game-database-topology.md
+++ b/docs/adr/ADR-2026-04-14-game-database-topology.md
@@ -488,3 +488,9 @@ Oggi nessuno sta attivamente tracciando i segnali sopra. Se vogliamo essere disc
 - File locali catalog Game: `data/core/traits/glossary.json`, `data/core/traits/biome_pools.json`, `docs/catalog/catalog_data.json`
 - PR #1317 (rimozione MongoDB da Game)
 - ADR complementare sul dashboard: [`ADR-2026-04-14-dashboard-scaffold-vs-mission-console.md`](ADR-2026-04-14-dashboard-scaffold-vs-mission-console.md)
+
+## Runbook operativo
+
+Il piano operativo che traduce questo ADR in runbook (cadenza sync, dry-run, `sync:evo-pack`/`evo:import`, trigger per riaprire alternative avanzate) vive in [`docs/planning/EVO_FINAL_DESIGN_GAME_DATABASE_SYNC.md`](../planning/EVO_FINAL_DESIGN_GAME_DATABASE_SYNC.md). Il piano consumer **non sovrascrive** questo ADR: in caso di conflitto, vince l'ADR per tutto cio' che riguarda il confine architetturale (vedi [`SOURCE_AUTHORITY_MAP §4.1`](../planning/EVO_FINAL_DESIGN_SOURCE_AUTHORITY_MAP.md)).
+
+Il [`Final Design Freeze v0.9 §5 Vincolo architetturale non negoziabile`](../core/90-FINAL-DESIGN-FREEZE.md) recepisce questo ADR come baseline di prodotto: qualunque proposta di introdurre dipendenze runtime `Game ← HTTP ← Game-Database` va trattata come ADR separato, non come patch di design.

--- a/docs/adr/ADR-2026-04-15-round-based-combat-model.md
+++ b/docs/adr/ADR-2026-04-15-round-based-combat-model.md
@@ -166,3 +166,7 @@ Transizioni invalide sollevano `ValueError` con messaggio esplicito. Testato in 
 - ADR precedente: [`ADR-2026-04-13-rules-engine-d20.md`](ADR-2026-04-13-rules-engine-d20.md)
 - Hub combat: [`docs/hubs/combat.md`](../hubs/combat.md)
 - Schema contracts: `packages/contracts/schemas/combat.schema.json`
+
+## Consumer di prodotto
+
+Questo ADR e' recepito dal [`Final Design Freeze v0.9 §7.1 Nucleo canonico`](../core/90-FINAL-DESIGN-FREEZE.md) come parte del combat system finale: dichiara `initiative` come reaction speed passiva e il round loop shared-planning → commit → ordered-resolution sopra il resolver atomico. Il freeze non sostituisce questo ADR: in caso di conflitto, **vince l'ADR** per tutto cio' che riguarda confini architetturali e contratti tecnici (vedi [`SOURCE_AUTHORITY_MAP §4.1`](../planning/EVO_FINAL_DESIGN_SOURCE_AUTHORITY_MAP.md)).

--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -74,6 +74,12 @@ Report drift:
 
 - `reports/docs/governance_drift_report.json`
 
+## Gerarchia delle fonti per decisioni di design
+
+La governance (A0) regola **dove** vive un documento e quale stato ha, ma non decide il contenuto di design. Per le decisioni di prodotto e la risoluzione di conflitti tra fonti (ADR vs freeze vs core data vs file operativi), la fonte canonica e' [`docs/planning/EVO_FINAL_DESIGN_SOURCE_AUTHORITY_MAP.md`](../planning/EVO_FINAL_DESIGN_SOURCE_AUTHORITY_MAP.md), che definisce la gerarchia A0..A5 e le regole pratiche §4.1..§4.5.
+
+Il contratto governance di questo README e' il livello **A0**; le altre decisioni (cosa e' canonico, cosa vince in caso di conflitto semantico) vivono all'authority map.
+
 ## Rollout
 
 1. Schema + registry + hub canonici.

--- a/docs/process/action-items.md
+++ b/docs/process/action-items.md
@@ -11,6 +11,14 @@ review_cycle_days: 14
 
 # Action Items — Sintesi operativa
 
+> **Nota — documento storico**. Questa sintesi mantiene lo storico operativo del ciclo VC 2025. Il **backlog esecutivo corrente** del design finale di Evo Tactics vive nel bundle Final Design v0.9:
+>
+> - [`docs/planning/EVO_FINAL_DESIGN_BACKLOG_REGISTER.md`](../planning/EVO_FINAL_DESIGN_BACKLOG_REGISTER.md) — 88 task operativi organizzati per epic (A..K), con FD-IDs univoci e ranges contigui per epic.
+> - [`docs/planning/EVO_FINAL_DESIGN_MASTER_ROADMAP.md`](../planning/EVO_FINAL_DESIGN_MASTER_ROADMAP.md) — milestone e fasi che guidano l'esecuzione dei task.
+> - [`docs/planning/EVO_FINAL_DESIGN_CODEX_EXECUTION_PLAYBOOK.md`](../planning/EVO_FINAL_DESIGN_CODEX_EXECUTION_PLAYBOOK.md) — guida operativa per agenti Codex su come ingaggiare i task del backlog.
+>
+> Usare questo file per **tracciamento storico**, non come fonte di action items corrente.
+
 ## Stato attuale
 
 - **2025-11-07** — Workflow `daily-pr-summary` senza merge; follow-up HUD overlay telemetrico → UI Systems (F. Conti), XP Cipher (PROG-04) → Progression Design (L. Serra), contrasto EVT-03 → VFX/Lighting (G. Leone). Documentazione allineata in changelog, roadmap, checklist e Canvas con riferimento al report playtest.

--- a/docs/process/milestones.md
+++ b/docs/process/milestones.md
@@ -11,6 +11,14 @@ review_cycle_days: 14
 
 # Checklist Milestone
 
+> **Nota — documento storico**. Questa checklist mantiene lo storico operativo del ciclo VC 2025. La **roadmap finale** ufficiale e i **gate formali di avanzamento** del design finale di Evo Tactics vivono ora nel bundle Final Design v0.9:
+>
+> - [`docs/planning/EVO_FINAL_DESIGN_MASTER_ROADMAP.md`](../planning/EVO_FINAL_DESIGN_MASTER_ROADMAP.md) — fasi, milestone M0..M6, owner matrix.
+> - [`docs/planning/EVO_FINAL_DESIGN_MILESTONES_AND_GATES.md`](../planning/EVO_FINAL_DESIGN_MILESTONES_AND_GATES.md) — gate formali G0..G7 con entry/exit criteria.
+> - [`docs/planning/EVO_FINAL_DESIGN_BACKLOG_REGISTER.md`](../planning/EVO_FINAL_DESIGN_BACKLOG_REGISTER.md) — task esecutivi organizzati per epic (FD-IDs).
+>
+> Usare questo file per **tracciamento storico**, non come roadmap operativa corrente.
+
 ## Setup iniziale
 
 - [x] Caricati dataset YAML di base (biomi, pacchetti PI, mating, telemetria).【F:data/core/biomes.yaml†L1-L17】【F:data/packs.yaml†L1-L88】【F:data/core/mating.yaml†L1-L32】【F:data/core/telemetry.yaml†L1-L29】


### PR DESCRIPTION
## Summary

Completa la catena di navigazione del bundle **Final Design Freeze v0.9** aggiungendo le **cross-reference inverse** dai documenti esistenti del repo che il bundle gia' citava (ADR, process docs, governance README).

Dopo PR #1380 (entrypoint → bundle), questa PR chiude il cerchio: i documenti citati dal bundle ora linkano indietro al bundle. Navigazione bidirezionale completa senza duplicazione di contenuto.

## File toccati (6)

### ADR cross-reference inverse

| File | Modifica |
|---|---|
| [`ADR-2026-04-13-rules-engine-d20`](docs/adr/ADR-2026-04-13-rules-engine-d20.md) | Sezione "Consumer di prodotto" in coda, linka `Final Design Freeze §7.3` come consumer delle API del resolver. |
| [`ADR-2026-04-14-game-database-topology`](docs/adr/ADR-2026-04-14-game-database-topology.md) | Sezione "Runbook operativo" in coda, linka `EVO_FINAL_DESIGN_GAME_DATABASE_SYNC` come piano operativo che traduce l'ADR, + freeze §5 come consumer. |
| [`ADR-2026-04-15-round-based-combat-model`](docs/adr/ADR-2026-04-15-round-based-combat-model.md) | Sezione "Consumer di prodotto" in coda, linka `Final Design Freeze §7.1` che dichiara `initiative` come reaction speed passiva. |

**Ogni ADR riporta esplicitamente la regola di authority §4.1**: in caso di conflitto tra ADR e freeze, vince l'ADR (rispetto della gerarchia A1 > A3).

### Process docs — redirect a bundle esecutivo

| File | Modifica |
|---|---|
| [`docs/process/milestones.md`](docs/process/milestones.md) | Blockquote in cima: nota storica + redirect a MASTER_ROADMAP, MILESTONES_AND_GATES, BACKLOG_REGISTER del bundle. Mantiene lo storico operativo del ciclo VC 2025 ma reindirizza chi cerca la roadmap corrente. |
| [`docs/process/action-items.md`](docs/process/action-items.md) | Blockquote analoga: redirect a BACKLOG_REGISTER (88 task per epic), MASTER_ROADMAP, CODEX_PLAYBOOK. |

### Governance README — cross-ref a authority map

| File | Modifica |
|---|---|
| [`docs/governance/README.md`](docs/governance/README.md) | Sezione "Gerarchia delle fonti per decisioni di design" in coda: chiarisce che governance (A0) regola **dove** vive un documento ma non decide il contenuto di design; per quello la fonte canonica e' `SOURCE_AUTHORITY_MAP`. |

## Principio guida

Il bundle Final Design e' arrivato "dall'alto": il freeze e l'authority map linkano i documenti canonici del repo (ADR, hub, core data). Questa patch **chiude il cerchio**: i documenti del repo ora sanno del bundle che li cita.

Nessuna duplicazione: ogni sezione aggiunta e' ≤6 righe e punta al partner canonico.

## Validazione

- [x] `python tools/check_docs_governance.py --strict` → **`errors=0 warnings=0`**
- [x] `prettier --check` → pulito su 6 file
- [x] Nessuna modifica a frontmatter, registry, runtime, schemi, codice
- [x] Diff totale: **+37 righe** (solo aggiunte)

## Fuori scope (follow-up non bloccanti)

Restano aperti dopo questa patch ma non richiedono integrazione docs urgente:

- **Validazione tecnica combat-team** dei path/API del freeze §2.2/§2.3 (richiede review umana, flag al prossimo combat sprint).
- **Migrazione Node session engine** al round orchestrator (big one, sprint dedicato, blast radius alto: 45 test AI + endpoint + client).
- **Round orchestrator follow-ups residui**: counter/overwatch payload types, eventi trigger `damaged`/`moved_adjacent`, reaction cooldown multi-round, trigger predicates avanzati, timer planning phase. Parziale: PR B (separata) aggiungera' il solo evento `damaged`.

## Rollback

`git revert <sha>` rimuove le 6 sezioni aggiunte. Zero impatto su runtime, codice, altri documenti. Completamente additivo.

## Test plan

- [x] Governance strict locale
- [x] Prettier check locale
- [ ] CI build + governance (paths-filter skippa deployment-checks/stack-quality/site-audit)
- [ ] Master DD review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
