### PR TITLE
feat(combat): action type heal + evento healed reaction

### DIFF
--- a/docs/combat/resolver-api.md
+++ b/docs/combat/resolver-api.md
@@ -46,6 +46,8 @@ Pipeline per `action.type == "attack"`:
 15. Calcolo `pt_gained` attaccante (`compute_pt_gained`).
 16. Produzione `turn_log_entry` con `action`, `roll`, `damage_applied`, `statuses_applied`, `statuses_expired`.
 
+Per `action.type == "heal"`: pipeline dedicata. Richiede `target_id`, rolla `heal_dice` (shape `{count, sides, modifier}`), applica `healing = min(roll, hp_max - hp_current)` clampato a 0, aggiorna `target.hp.current`, registra `turn_log_entry.healing_applied`. Nessun d20, nessun MoS, nessun canale di resistenza. Panic NON blocca heal base. Self-heal consentito (`target_id == actor_id`). Consuma AP come le altre azioni.
+
 Per `action.type` in `{defend, parry, ability, move}` (`NOOP_ACTION_TYPES`): consumo AP + turn_log_entry senza `roll`. La logica reale di queste azioni è deferita a iterazioni future (tranne `parry` che è implementata come **parry response** opt-in in attack).
 
 **Raises**: `ValueError` se `action.target_id` manca su un attack, se `pt_spend.type` non è in `SUPPORTED_PT_SPEND_TYPES`, se `amount` non è positivo, se PT insufficienti.
@@ -173,31 +175,31 @@ Rolla `count` dadi a `sides` facce + `modifier`. `dice` è il dict `{count, side
 
 ## Costanti esportate
 
-| Nome | Valore | Significato |
-|---|---|---|
-| `ATTACK_CD_BASE` | 10 | Base d20 prima di `tier` e `defense_mod` |
-| `CRIT_PT_THRESHOLD` | 15 | Nat ≥ 15 → +1 PT |
-| `NATURAL_MAX` | 20 | Nat 20 → +2 PT, auto-hit, crit parry |
-| `NATURAL_FUMBLE` | 1 | Nat 1 → auto-miss |
-| `MOS_PER_STEP` | 5 | Ogni +5 MoS = +1 step danno |
-| `NOOP_ACTION_TYPES` | `frozenset({"defend","parry","ability","move"})` | Action che consumano AP ma non hanno logica di risoluzione in questa iterazione |
-| `PARRY_CD` | 12 | Fallback CD per parry quando `attack_total` non fornito |
-| `PARRY_PT_BASE` | 1 | PT difensivi su parry riuscita normale |
-| `PARRY_PT_CRIT` | 2 | PT difensivi su parry riuscita con nat 20 |
-| `SUPPORTED_PT_SPEND_TYPES` | `frozenset({"perforazione","spinta"})` | Tipologie di spesa PT supportate (le altre 2 citate nel doc 10-SISTEMA_TATTICO sono deferred) |
-| `PERFORAZIONE_ARMOR_REDUCTION` | 2 | Armor -2 applicata da perforazione sul target |
-| `STRESS_BREAKPOINT_RAGE` | 0.5 | Soglia stress per auto-applicare rage |
-| `STRESS_BREAKPOINT_PANIC` | 0.75 | Soglia stress per auto-applicare panic |
-| `RAGE_DEFAULT_INTENSITY` | 1 | Intensity di default rage da breakpoint |
-| `RAGE_DEFAULT_DURATION` | 3 | Turni di default rage da breakpoint |
-| `PANIC_DEFAULT_INTENSITY` | 1 | Intensity di default panic da breakpoint |
-| `PANIC_DEFAULT_DURATION` | 2 | Turni di default panic da breakpoint |
-| `DISORIENT_ATTACK_MALUS_PER_INTENSITY` | 2 | Malus attack_mod per intensity di disorient |
-| `FRACTURE_STEP_REDUCTION_PER_INTENSITY` | 1 | Riduzione step_count per intensity di fracture |
-| `RAGE_ATTACK_BONUS_PER_INTENSITY` | 1 | Bonus attack_mod per intensity di rage |
-| `RAGE_DAMAGE_STEP_BONUS_PER_INTENSITY` | 1 | Bonus damage_step per intensity di rage |
-| `RAGE_DEFENSE_MALUS_PER_INTENSITY` | 1 | Malus defense_mod per intensity di rage (furia cieca) |
-| `PANIC_ATTACK_MALUS_PER_INTENSITY` | 2 | Malus attack_mod per intensity di panic |
+| Nome                                    | Valore                                           | Significato                                                                                   |
+| --------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| `ATTACK_CD_BASE`                        | 10                                               | Base d20 prima di `tier` e `defense_mod`                                                      |
+| `CRIT_PT_THRESHOLD`                     | 15                                               | Nat ≥ 15 → +1 PT                                                                              |
+| `NATURAL_MAX`                           | 20                                               | Nat 20 → +2 PT, auto-hit, crit parry                                                          |
+| `NATURAL_FUMBLE`                        | 1                                                | Nat 1 → auto-miss                                                                             |
+| `MOS_PER_STEP`                          | 5                                                | Ogni +5 MoS = +1 step danno                                                                   |
+| `NOOP_ACTION_TYPES`                     | `frozenset({"defend","parry","ability","move"})` | Action che consumano AP ma non hanno logica di risoluzione in questa iterazione               |
+| `PARRY_CD`                              | 12                                               | Fallback CD per parry quando `attack_total` non fornito                                       |
+| `PARRY_PT_BASE`                         | 1                                                | PT difensivi su parry riuscita normale                                                        |
+| `PARRY_PT_CRIT`                         | 2                                                | PT difensivi su parry riuscita con nat 20                                                     |
+| `SUPPORTED_PT_SPEND_TYPES`              | `frozenset({"perforazione","spinta"})`           | Tipologie di spesa PT supportate (le altre 2 citate nel doc 10-SISTEMA_TATTICO sono deferred) |
+| `PERFORAZIONE_ARMOR_REDUCTION`          | 2                                                | Armor -2 applicata da perforazione sul target                                                 |
+| `STRESS_BREAKPOINT_RAGE`                | 0.5                                              | Soglia stress per auto-applicare rage                                                         |
+| `STRESS_BREAKPOINT_PANIC`               | 0.75                                             | Soglia stress per auto-applicare panic                                                        |
+| `RAGE_DEFAULT_INTENSITY`                | 1                                                | Intensity di default rage da breakpoint                                                       |
+| `RAGE_DEFAULT_DURATION`                 | 3                                                | Turni di default rage da breakpoint                                                           |
+| `PANIC_DEFAULT_INTENSITY`               | 1                                                | Intensity di default panic da breakpoint                                                      |
+| `PANIC_DEFAULT_DURATION`                | 2                                                | Turni di default panic da breakpoint                                                          |
+| `DISORIENT_ATTACK_MALUS_PER_INTENSITY`  | 2                                                | Malus attack_mod per intensity di disorient                                                   |
+| `FRACTURE_STEP_REDUCTION_PER_INTENSITY` | 1                                                | Riduzione step_count per intensity di fracture                                                |
+| `RAGE_ATTACK_BONUS_PER_INTENSITY`       | 1                                                | Bonus attack_mod per intensity di rage                                                        |
+| `RAGE_DAMAGE_STEP_BONUS_PER_INTENSITY`  | 1                                                | Bonus damage_step per intensity di rage                                                       |
+| `RAGE_DEFENSE_MALUS_PER_INTENSITY`      | 1                                                | Malus defense_mod per intensity di rage (furia cieca)                                         |
+| `PANIC_ATTACK_MALUS_PER_INTENSITY`      | 2                                                | Malus attack_mod per intensity di panic                                                       |
 
 ## Contract di purezza
 

--- a/docs/combat/round-loop.md
+++ b/docs/combat/round-loop.md
@@ -197,6 +197,7 @@ Le reaction intents:
   - `"trigger_status"` — usata con `event="damaged"`, `event="moved_adjacent"` o `event="ability_used"`. Applica uno status effect (bleeding/fracture/disorient/rage/panic) a un'unita' quando la reaction triggera. Richiede `status_id`, `duration`, `intensity`, e `target` opzionale (`"attacker"` default o `"self"`).
   - `"counter"` — contrattacco libero post-hit. Usata solo con `event="damaged"`. Costruisce al volo una synthetic `attack` action con `actor = reaction owner`, `target = attaccante originale`, e la esegue via `resolve_action`. Richiede `counter_dice` (`{count, sides, modifier}`), campi opzionali `counter_channel` e `counter_ap_cost` (default 0). **Anti-recursion**: la synthetic action porta flag `_is_counter=True` e non ri-triggera damaged-reactions a cascata (max depth = 1). Non triggera se l'attaccante originale e' morto post main-hit.
   - `"overwatch"` — attacco opportunistico su movimento. Usata solo con `event="moved_adjacent"`. Costruisce synthetic `attack` con `actor = reaction owner (listener)`, `target = unita' che si e' mossa`. Richiede `overwatch_dice`, campi opzionali `overwatch_channel` e `overwatch_ap_cost`. **Anti-recursion**: flag `_is_overwatch=True`, non triggera damaged-reactions a cascata.
+- **Evento `healed`** (post-heal): triggerato dopo un `action.type == "heal"` con `healing_applied > 0`. Il resolver atomico ha un nuovo branch `heal` che rolla `heal_dice` e ripristina HP del target, clampato a `hp_max`. Source = caster (`uid`), heal target = receiver (`action.target_id`). Context include `healing` (field nei predicates). Payload supportato: `trigger_status`.
 
 ### Predicates DSL
 
@@ -226,6 +227,7 @@ declare_reaction(
 | Field         | Semantica                                | Evento richiesto  |
 | ------------- | ---------------------------------------- | ----------------- |
 | `damage`      | `damage_applied` dal turn_log_entry      | `damaged`         |
+| `healing`     | `healing_applied` dal turn_log_entry     | `healed`          |
 | `hp_pct`      | `hp_current / hp_max` del reaction owner | qualsiasi         |
 | `hp_current`  | HP assoluto del reaction owner           | qualsiasi         |
 | `hp_max`      | HP max del reaction owner                | qualsiasi         |
@@ -419,12 +421,12 @@ Ricarica `ACTION_SPEED` dal filesystem (hot reload) e muta il dict modulo-level 
 - ✅ **ADR Node session engine migration**: [`ADR-2026-04-16-session-engine-round-migration.md`](../adr/ADR-2026-04-16-session-engine-round-migration.md) — piano in 17 step, feature flag, rollback, stima effort. **Solo documento**: codice Node intoccato.
 - ✅ **Payload `counter`**: contrattacco libero post-hit. Costruisce synthetic `attack` action (flag `_is_counter=True`) del reaction owner verso l'attaccante originale, la esegue via `resolve_action`. Anti-recursion: max depth = 1. Non triggera su attaccante morto.
 - ✅ **Payload `overwatch`**: attacco opportunistico su `moved_adjacent`. Synthetic `attack` (flag `_is_overwatch=True`) del listener verso il mover. Anti-recursion attiva, non triggera su mover morto.
+- ✅ **Evento `healed` + action type `heal`**: nuovo branch `heal` nel resolver atomico (roll `heal_dice`, clamp a `hp_max`, log `healing_applied`). Orchestrator estende `SUPPORTED_REACTION_EVENTS` con `healed` e aggiunge injection post-heal. Predicates DSL esteso con field `healing`. Action speed `heal: -1`.
 
 **Ancora aperti** (evoluzioni future):
 
-1. **Evento `healed`**: richiederebbe un nuovo action type `heal` nel resolver atomico (oggi non esiste). Scope creep.
-2. **Migrazione effettiva Node session engine**: portare `apps/backend/routes/session.js` al round model. ADR c'e', codice Node intoccato. Sprint dedicato di ~5 giornate.
-3. **Timer opzionale di planning phase**: `planning_deadline_ms` nello state. Enforcement del session engine Node, non del rules engine Python.
+1. **Migrazione effettiva Node session engine**: portare `apps/backend/routes/session.js` al round model. ADR c'e', codice Node intoccato. Sprint dedicato di ~5 giornate.
+2. **Timer opzionale di planning phase**: `planning_deadline_ms` nello state. Enforcement del session engine Node, non del rules engine Python.
 
 ---
 
@@ -435,4 +437,4 @@ Ricarica `ACTION_SPEED` dal filesystem (hot reload) e muta il dict modulo-level 
 - [ADR-2026-04-15-round-based-combat-model.md](../adr/ADR-2026-04-15-round-based-combat-model.md) — decisione architetturale completa
 - [combat hub](../hubs/combat.md) — ingresso canonico al workstream combat
 - `services/rules/round_orchestrator.py` — implementazione
-- `tests/test_round_orchestrator.py` — 95 test unitari
+- `tests/test_round_orchestrator.py` — 104 test unitari

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-15T20:41:39+00:00",
+  "generated_at": "2026-04-15T20:54:11+00:00",
   "summary": {
     "total": 0,
     "errors": 0,

--- a/services/rules/resolver.py
+++ b/services/rules/resolver.py
@@ -744,6 +744,40 @@ def resolve_action(
         log_entry["roll"] = roll_result
         log_entry["damage_applied"] = int(damage_applied)
         log_entry["statuses_applied"] = statuses_applied
+    elif action_type == "heal":
+        # --- Heal action ---------------------------------------------------
+        # Ripristina HP a un target (self, alleato, o anche hostile se il
+        # caller decide cosi'). Pipeline minimale:
+        # 1. Richiede target_id; self-heal usa target_id == actor_id
+        # 2. Rolla heal_dice (shape identica a damage_dice): {count, sides, modifier}
+        # 3. Calcola healing effettivo = min(roll, hp_max - hp_current) clamp a 0
+        # 4. Aggiorna target.hp.current
+        # 5. Log turn_log_entry.healing_applied, no roll d20, no MoS, no PT
+        #
+        # Non consuma stress, non triggera status, non interagisce con
+        # armor/resistances (canale "healing" semanticamente diverso dal
+        # damage channel). Panic NON blocca heal base (differenza dal PT
+        # spend): il player puo' ripristinare HP anche in panic, come
+        # azione riflessiva di base.
+        target_id = action.get("target_id")
+        if not target_id:
+            raise ValueError("heal action richiede target_id")
+        target = _find_unit(next_state, str(target_id))
+        heal_dice = action.get("heal_dice") or {"count": 1, "sides": 4, "modifier": 0}
+        heal_roll = roll_damage_dice(heal_dice, rng)
+        hp_target = target.get("hp") or {}
+        hp_current = int(hp_target.get("current", 0))
+        hp_max = int(hp_target.get("max", hp_current))
+        missing = max(0, hp_max - hp_current)
+        healing_applied = max(0, min(heal_roll, missing))
+        hp_target["current"] = hp_current + healing_applied
+        target["hp"] = hp_target
+        log_entry["healing_applied"] = int(healing_applied)
+        log_entry["roll"] = {
+            "natural": None,
+            "heal_roll": int(heal_roll),
+            "heal_dice": dict(heal_dice),
+        }
     elif action_type in NOOP_ACTION_TYPES:
         # AP gia' consumato sopra. Nessun roll, nessun update stato oltre.
         pass

--- a/services/rules/round_orchestrator.py
+++ b/services/rules/round_orchestrator.py
@@ -116,11 +116,15 @@ VALID_PHASES = frozenset({PHASE_PLANNING, PHASE_COMMITTED, PHASE_RESOLVING, PHAS
 #:   moventi attivano la reaction. Semantica: "quando X si muove".
 #: - ``'ability_used'`` (post-ability): triggerato dopo che un'unita'
 #:   esegue un ``action.type == "ability"``. Context include ``ability_id``.
+#: - ``'healed'`` (post-heal): triggerato dopo che un'unita' esegue un
+#:   ``action.type == "heal"`` che risulta in ``healing_applied > 0``.
+#:   Il ``source_id`` e' chi ha curato (l'actor), il ``target_id`` del
+#:   match e' il ricevente (il healed target). Context include ``healing``
+#:   (quantita' applicata).
 #:
-#: Future estensioni: ``'healed'`` (richiede nuovo action type heal nel
-#: resolver), ``'status_applied'``.
+#: Future estensioni: ``'status_applied'``.
 SUPPORTED_REACTION_EVENTS = frozenset(
-    {"attacked", "damaged", "moved_adjacent", "ability_used"}
+    {"attacked", "damaged", "moved_adjacent", "ability_used", "healed"}
 )
 
 #: Tipi di payload per reaction.
@@ -164,6 +168,7 @@ SUPPORTED_PREDICATE_OPS = frozenset({"==", "!=", ">", ">=", "<", "<="})
 SUPPORTED_PREDICATE_FIELDS = frozenset(
     {
         "damage",  # damage_applied (solo evento 'damaged')
+        "healing",  # healing_applied (solo evento 'healed')
         "hp_pct",  # hp_current / hp_max del reaction owner
         "hp_current",
         "hp_max",
@@ -233,6 +238,7 @@ def _build_context_for_event(
     reaction_owner: Mapping[str, Any],
     source_unit: Optional[Mapping[str, Any]] = None,
     damage_applied: int = 0,
+    healing_applied: int = 0,
     action: Optional[Mapping[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Costruisce il context dict per la valutazione dei predicati.
@@ -244,6 +250,7 @@ def _build_context_for_event(
 
     Campi context-specific:
     - ``damage`` solo per evento ``'damaged'``
+    - ``healing`` solo per evento ``'healed'``
     """
 
     hp = reaction_owner.get("hp") or {}
@@ -260,6 +267,8 @@ def _build_context_for_event(
         context["source_tier"] = int(source_unit.get("tier", 1))
     if event == "damaged":
         context["damage"] = int(damage_applied)
+    if event == "healed":
+        context["healing"] = int(healing_applied)
     return context
 
 
@@ -275,6 +284,7 @@ DEFAULT_ACTION_SPEED: Dict[str, int] = {
     "parry": 2,
     "attack": 0,
     "ability": -1,
+    "heal": -1,
     "move": -2,
 }
 
@@ -1258,6 +1268,67 @@ def resolve_round(
                                     "reaction_payload": dict(ab_payload),
                                     "status_target_unit_id": status_target_id,
                                     "ability_id": action.get("ability_id"),
+                                }
+                            )
+
+        # Post-heal reaction injection (evento 'healed'):
+        # Triggerato dopo action.type == 'heal' che risulta in
+        # healing_applied > 0. source = caster (uid), heal_target =
+        # receiver (action.target_id). Scan di tutte le reactions pending
+        # per match via source_any_of filter + predicates.
+        healing_applied = int(result["turn_log_entry"].get("healing_applied", 0))
+        heal_target_id = action.get("target_id")
+        if action_type == "heal" and healing_applied > 0 and heal_target_id:
+            for listener_uid, listener_entry in reactions_by_unit.items():
+                if listener_entry.get("_consumed"):
+                    continue
+                listener_unit = _find_unit_by_id(listener_uid)
+                if listener_unit is None:
+                    continue
+                ctx_healed = _build_context_for_event(
+                    event="healed",
+                    reaction_owner=listener_unit,
+                    source_unit=_find_unit_by_id(str(uid)),
+                    healing_applied=healing_applied,
+                )
+                matched_heal = _match_reaction_for_event(
+                    reactions_by_unit,
+                    "healed",
+                    listener_uid,
+                    str(uid),
+                    context=ctx_healed,
+                )
+                if matched_heal is not None:
+                    heal_payload = matched_heal.get("reaction_payload", {})
+                    if heal_payload.get("type") == "trigger_status":
+                        status_target_side = str(heal_payload.get("target", "attacker"))
+                        status_target_id = (
+                            str(uid) if status_target_side == "attacker" else listener_uid
+                        )
+                        status_target_unit = _find_unit_by_id(status_target_id)
+                        if status_target_unit is not None:
+                            apply_status(
+                                status_target_unit,
+                                status_id=str(heal_payload.get("status_id", "bleeding")),
+                                duration=int(heal_payload.get("duration", 1)),
+                                intensity=int(heal_payload.get("intensity", 1)),
+                                source_unit_id=listener_uid,
+                                source_action_id="reaction_healed",
+                            )
+                            matched_heal["_consumed"] = True
+                            _set_cooldown_on_unit(
+                                listener_uid,
+                                matched_heal.get("reaction_trigger", {}),
+                            )
+                            reactions_triggered.append(
+                                {
+                                    "target_unit_id": listener_uid,
+                                    "attacker_unit_id": str(uid),
+                                    "event": "healed",
+                                    "reaction_payload": dict(heal_payload),
+                                    "status_target_unit_id": status_target_id,
+                                    "heal_target_unit_id": str(heal_target_id),
+                                    "healing_applied": healing_applied,
                                 }
                             )
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1065,6 +1065,97 @@ def test_contested_parry_with_rage_bonus_on_attacker(catalog):
     assert roll["parry"]["executed"] is True
 
 
+def test_heal_action_restores_hp_on_target(catalog):
+    """Heal action rolla heal_dice e ripristina HP del target."""
+    state = _mini_state(catalog)
+    # Danneggia il target a meta'
+    target = state["units"][1]
+    hp_max = target["hp"]["max"]
+    target["hp"]["current"] = max(1, hp_max // 2)
+    hp_before = target["hp"]["current"]
+
+    heal_action = {
+        "id": "heal-1",
+        "type": "heal",
+        "actor_id": "atk",
+        "target_id": "tgt",
+        "ability_id": None,
+        "ap_cost": 1,
+        "channel": None,
+        "heal_dice": {"count": 1, "sides": 4, "modifier": 2},
+    }
+    # rng roll d4 = 3 (3/4 = 0.75)
+    rng = rng_from_sequence([3 / 4])
+    result = resolve_action(state, heal_action, catalog, rng)
+    entry = result["turn_log_entry"]
+    assert entry["healing_applied"] > 0
+    new_tgt = next(u for u in result["next_state"]["units"] if u["id"] == "tgt")
+    assert new_tgt["hp"]["current"] > hp_before
+    assert new_tgt["hp"]["current"] <= new_tgt["hp"]["max"]
+
+
+def test_heal_action_clamps_to_hp_max(catalog):
+    """Heal roll eccedente l'hp mancante viene clampato a max."""
+    state = _mini_state(catalog)
+    target = state["units"][1]
+    hp_max = target["hp"]["max"]
+    target["hp"]["current"] = hp_max - 1  # solo 1 hp mancante
+    heal_action = {
+        "id": "heal-big",
+        "type": "heal",
+        "actor_id": "atk",
+        "target_id": "tgt",
+        "ability_id": None,
+        "ap_cost": 1,
+        "channel": None,
+        "heal_dice": {"count": 1, "sides": 8, "modifier": 10},  # 11-18
+    }
+    rng = rng_from_sequence([7 / 8])  # roll ~8, + 10 = 18 total
+    result = resolve_action(state, heal_action, catalog, rng)
+    entry = result["turn_log_entry"]
+    assert entry["healing_applied"] == 1  # clamped da 1 missing
+    new_tgt = next(u for u in result["next_state"]["units"] if u["id"] == "tgt")
+    assert new_tgt["hp"]["current"] == hp_max
+
+
+def test_heal_action_noop_when_full_hp(catalog):
+    """Heal su target a full hp non cambia nulla (healing_applied = 0)."""
+    state = _mini_state(catalog)
+    target = state["units"][1]
+    target["hp"]["current"] = target["hp"]["max"]
+    heal_action = {
+        "id": "heal-full",
+        "type": "heal",
+        "actor_id": "atk",
+        "target_id": "tgt",
+        "ability_id": None,
+        "ap_cost": 1,
+        "channel": None,
+        "heal_dice": {"count": 1, "sides": 4, "modifier": 0},
+    }
+    rng = rng_from_sequence([3 / 4])
+    result = resolve_action(state, heal_action, catalog, rng)
+    assert result["turn_log_entry"]["healing_applied"] == 0
+
+
+def test_heal_action_requires_target_id(catalog):
+    """Heal senza target_id solleva ValueError."""
+    state = _mini_state(catalog)
+    heal_action = {
+        "id": "heal-bad",
+        "type": "heal",
+        "actor_id": "atk",
+        "target_id": None,
+        "ability_id": None,
+        "ap_cost": 1,
+        "channel": None,
+        "heal_dice": {"count": 1, "sides": 4, "modifier": 0},
+    }
+    rng = rng_from_sequence([0.5])
+    with pytest.raises(ValueError, match="target_id"):
+        resolve_action(state, heal_action, catalog, rng)
+
+
 def test_spinta_sbilanciato_decay_via_begin_turn(catalog):
     """Il sbilanciato applicato da spinta decade via begin_turn."""
     state = _mini_state(catalog)

--- a/tests/test_round_orchestrator.py
+++ b/tests/test_round_orchestrator.py
@@ -2047,6 +2047,164 @@ def test_overwatch_respects_one_shot_and_cooldown(catalog):
     assert bravo_after["reaction_cooldown_remaining"] == 1
 
 
+def _heal(actor_id: str, target_id: str, dice=None, ap_cost=1):
+    return {
+        "id": f"heal-{actor_id}",
+        "type": "heal",
+        "actor_id": actor_id,
+        "target_id": target_id,
+        "ability_id": None,
+        "ap_cost": ap_cost,
+        "channel": None,
+        "heal_dice": dice or {"count": 1, "sides": 4, "modifier": 2},
+    }
+
+
+# ------------------------------------------------------------------
+# Healed event (follow-up batch 3)
+# ------------------------------------------------------------------
+
+
+def test_healed_in_supported_reaction_events():
+    assert "healed" in SUPPORTED_REACTION_EVENTS
+
+
+def test_healing_field_in_supported_predicate_fields():
+    assert "healing" in SUPPORTED_PREDICATE_FIELDS
+
+
+def test_declare_reaction_accepts_healed_event(catalog):
+    state = begin_round(_make_state(catalog))["next_state"]
+    state = declare_reaction(
+        state,
+        "bravo",
+        reaction_payload={
+            "type": "trigger_status",
+            "status_id": "focused",
+            "duration": 1,
+            "intensity": 1,
+        },
+        trigger={"event": "healed"},
+    )["next_state"]
+    assert state["pending_intents"][0]["reaction_trigger"]["event"] == "healed"
+
+
+def test_heal_action_integrates_via_round_orchestrator(catalog):
+    """Alpha esegue heal su bravo via round loop, HP bravo aumenta."""
+    state = _make_state(catalog, initiative_a=14, initiative_b=10)
+    # Ferisci bravo
+    state["units"][1]["hp"]["current"] = max(1, state["units"][1]["hp"]["max"] // 2)
+    hp_before = state["units"][1]["hp"]["current"]
+    state = begin_round(state)["next_state"]
+    state = declare_intent(
+        state,
+        "alpha",
+        _heal("alpha", "bravo", dice={"count": 1, "sides": 4, "modifier": 2}),
+    )["next_state"]
+    state = commit_round(state)["next_state"]
+    rng = rng_from_sequence([3 / 4])
+    result = resolve_round(state, catalog, rng)
+    bravo_after = next(u for u in result["next_state"]["units"] if u["id"] == "bravo")
+    assert bravo_after["hp"]["current"] > hp_before
+    assert result["turn_log_entries"][0]["healing_applied"] > 0
+
+
+def test_healed_reaction_triggers_on_healing(catalog):
+    """Listener reaction su 'healed' triggera post-heal."""
+    state = _make_state(catalog, initiative_a=14, initiative_b=10)
+    # Ferisci bravo
+    state["units"][1]["hp"]["current"] = max(1, state["units"][1]["hp"]["max"] // 2)
+    state = begin_round(state)["next_state"]
+    state = declare_intent(
+        state,
+        "alpha",
+        _heal("alpha", "bravo", dice={"count": 1, "sides": 4, "modifier": 3}),
+    )["next_state"]
+    # Listener: bravo stesso (target receiver) reagisce al proprio heal
+    # applicando focused all'alpha (il caster)
+    state = declare_reaction(
+        state,
+        "bravo",
+        reaction_payload={
+            "type": "trigger_status",
+            "status_id": "focused",
+            "duration": 2,
+            "intensity": 1,
+            "target": "attacker",  # attacker = caster nel contesto 'healed'
+        },
+        trigger={"event": "healed"},
+    )["next_state"]
+    state = commit_round(state)["next_state"]
+    rng = rng_from_sequence([3 / 4])
+    result = resolve_round(state, catalog, rng)
+    assert len(result["reactions_triggered"]) == 1
+    triggered = result["reactions_triggered"][0]
+    assert triggered["event"] == "healed"
+    assert triggered["healing_applied"] > 0
+    assert triggered["heal_target_unit_id"] == "bravo"
+    alpha_after = next(u for u in result["next_state"]["units"] if u["id"] == "alpha")
+    focused = [s for s in alpha_after.get("statuses", []) if s.get("id") == "focused"]
+    assert len(focused) == 1
+
+
+def test_healed_reaction_NOT_triggered_if_no_healing(catalog):
+    """Heal su target full HP -> healing_applied=0 -> reaction no trigger."""
+    state = _make_state(catalog, initiative_a=14, initiative_b=10)
+    # Bravo gia' a full hp
+    state["units"][1]["hp"]["current"] = state["units"][1]["hp"]["max"]
+    state = begin_round(state)["next_state"]
+    state = declare_intent(
+        state,
+        "alpha",
+        _heal("alpha", "bravo", dice={"count": 1, "sides": 4, "modifier": 0}),
+    )["next_state"]
+    state = declare_reaction(
+        state,
+        "bravo",
+        reaction_payload={
+            "type": "trigger_status",
+            "status_id": "focused",
+            "duration": 1,
+            "intensity": 1,
+        },
+        trigger={"event": "healed"},
+    )["next_state"]
+    state = commit_round(state)["next_state"]
+    rng = rng_from_sequence([3 / 4])
+    result = resolve_round(state, catalog, rng)
+    assert result["reactions_triggered"] == []
+
+
+def test_healed_reaction_with_predicate_healing_threshold(catalog):
+    """Predicate healing>=3 filtra micro-heals."""
+    state = _make_state(catalog, initiative_a=14, initiative_b=10)
+    state["units"][1]["hp"]["current"] = max(1, state["units"][1]["hp"]["max"] - 10)
+    state = begin_round(state)["next_state"]
+    state = declare_intent(
+        state,
+        "alpha",
+        _heal("alpha", "bravo", dice={"count": 1, "sides": 4, "modifier": 3}),
+    )["next_state"]
+    state = declare_reaction(
+        state,
+        "bravo",
+        reaction_payload={
+            "type": "trigger_status",
+            "status_id": "focused",
+            "duration": 1,
+            "intensity": 1,
+        },
+        trigger={
+            "event": "healed",
+            "predicates": [{"op": ">=", "field": "healing", "value": 3}],
+        },
+    )["next_state"]
+    state = commit_round(state)["next_state"]
+    rng = rng_from_sequence([3 / 4])  # roll = 3, + 3 mod = 6 healing
+    result = resolve_round(state, catalog, rng)
+    assert len(result["reactions_triggered"]) == 1
+
+
 def test_overwatch_with_predicate_source_tier(catalog):
     """Overwatch con predicate source_tier >= 1 triggera quando il
     mover e' tier 1+."""


### PR DESCRIPTION
## Summary

Chiude l'ultimo residuo del follow-up batch 2 aggiungendo un nuovo action type (\`heal\`) nel resolver atomico e l'evento reaction corrispondente (\`healed\`) nel round orchestrator. Con questa PR la reactive layer del round orchestrator supporta 5 eventi (\`attacked\`, \`damaged\`, \`moved_adjacent\`, \`ability_used\`, \`healed\`) e 4 payload types (\`parry\`, \`trigger_status\`, \`counter\`, \`overwatch\`).

## Cosa cambia

### \`services/rules/resolver.py\`

- Nuovo branch \`heal\` in \`resolve_action\`:
  - Richiede \`target_id\` (self-heal = \`target_id == actor_id\`)
  - Rolla \`heal_dice\` (shape \`{count, sides, modifier}\`)
  - \`healing_applied = min(roll, hp_max - hp_current)\` clampato a 0
  - Aggiorna \`target.hp.current\`, log \`turn_log_entry.healing_applied\`
  - Nessun d20, nessun MoS, nessun canale di resistenza
  - Panic NON blocca heal base
  - ValueError se \`target_id\` manca

### \`services/rules/round_orchestrator.py\`

- \`SUPPORTED_REACTION_EVENTS\` esteso con \`'healed'\`
- \`SUPPORTED_PREDICATE_FIELDS\` esteso con \`'healing'\`
- \`DEFAULT_ACTION_SPEED\` esteso con \`'heal': -1\`
- \`_build_context_for_event\` accetta \`healing_applied\` arg, popola \`context['healing']\` per event \`healed\`
- \`resolve_round\`: nuovo injection point post-heal. Scan listener reactions su event \`healed\`. Payload supportato: \`trigger_status\`.

### Test (+11 totali)

**\`tests/test_resolver.py\` (+4)**:
- heal action restores HP
- heal clamps a hp_max
- heal no-op su full HP
- heal senza target_id → ValueError

**\`tests/test_round_orchestrator.py\` (+7)**:
- healed in SUPPORTED_REACTION_EVENTS
- healing in SUPPORTED_PREDICATE_FIELDS
- declare_reaction accetta event healed
- heal via round orchestrator integration
- healed reaction triggera con status applicato al caster
- healed reaction NON triggera se healing=0
- healed reaction con predicate healing>=N

### Docs

- \`docs/combat/round-loop.md\` §5: nuovo bullet evento healed, tabella predicate fields estesa con \`healing\`. §6 follow-ups: healed marcato completato, residui ridotti a 2.
- \`docs/combat/resolver-api.md\`: nuovo paragrafo per action type heal.

## Validazione

- \`PYTHONPATH=services python -m pytest tests/test_round_orchestrator.py tests/test_resolver.py tests/test_hydration.py tests/test_demo_cli.py\` → **217/217 verdi**
- \`python tools/check_docs_governance.py --strict\` → **errors=0 warnings=0**
- \`prettier --check\` → pulito

## Rollback

\`git revert <sha>\` rimuove:
- Nuovo branch \`heal\` in resolve_action
- Estensioni orchestrator (events, fields, action speed, context, injection)
- 11 test nuovi
- Update doc

Nessuna modifica a schema contracts, dati o governance. Il rollback lascia intatti tutti i 3 PR precedenti del batch (#1383, #1384, #1385).

## Residui dopo questa PR

1. Migrazione effettiva Node session engine (\`apps/backend/routes/session.js\`) — ADR-2026-04-16 esiste, codice Node intoccato. Sprint dedicato ~5 giornate.
2. Timer opzionale planning phase (\`planning_deadline_ms\`) — enforcement lato session engine Node, non rules engine Python.

## Test plan

- [x] pytest rules engine 217/217 verde
- [x] governance strict verde
- [x] prettier verde
- [x] heal action end-to-end via round loop
- [x] healed reaction triggera con predicate DSL
- [x] healing=0 → no reaction trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)