### PR TITLE
feat(combat): round-based endpoints dietro USE_ROUND_MODEL flag (PR 2/N Node migration)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -49,6 +49,24 @@ const { loadTelemetryConfig, buildVcSnapshot } = require('../services/vcScoring'
 // DEFAULT_ATTACK_RANGE e' ora autoritativo in policy.js (usato sia qui che dall'IA).
 const { DEFAULT_ATTACK_RANGE } = require('../services/ai/policy');
 const { createSistemaTurnRunner } = require('../services/ai/sistemaTurnRunner');
+// ADR-2026-04-16: round-based combat model migration. PR 2 di N —
+// endpoint stubs dietro feature flag USE_ROUND_MODEL. Il modulo e'
+// completamente isolato (PR #1387), esposto qui solo come dipendenza
+// delle nuove route /declare-intent, /clear-intent/:id, /commit-round,
+// /resolve-round. Il flusso legacy (/action, /turn/end) e' intatto.
+const {
+  createRoundOrchestrator,
+  PHASE_PLANNING,
+  PHASE_COMMITTED,
+  PHASE_RESOLVED,
+} = require('../services/roundOrchestrator');
+
+// Feature flag: l'intera superficie round-based e' disabilitata se
+// USE_ROUND_MODEL !== 'true'. In quel caso ogni nuovo endpoint
+// ritorna 503. Di default e' false (comportamento legacy invariato).
+function isRoundModelEnabled() {
+  return String(process.env.USE_ROUND_MODEL || '').toLowerCase() === 'true';
+}
 
 const GRID_SIZE = 6;
 const DEFAULT_HP = 10;
@@ -1176,6 +1194,281 @@ function createSessionRouter(options = {}) {
       const snapshot = buildVcSnapshot(session, telemetryConfig);
       res.json(snapshot);
     } catch (err) {
+      next(err);
+    }
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Round-based combat endpoints (ADR-2026-04-16, PR 2 di N)
+  // ────────────────────────────────────────────────────────────────
+  //
+  // Le 4 route qui sotto abilitano il nuovo modello round-based
+  // (shared-planning → commit → resolve) descritto in
+  // ADR-2026-04-16-session-engine-round-migration.md e implementato
+  // in apps/backend/services/roundOrchestrator.js (port in JS del
+  // Python orchestrator).
+  //
+  // Feature flag: `USE_ROUND_MODEL`. Se falsa, ogni endpoint ritorna
+  // 503. Se vera, il session object accumula uno state parallelo
+  // `session.roundState` in shape nativa dell'orchestrator
+  // (pending_intents, round_phase, units con hp/ap/reactions dict).
+  //
+  // Il flusso legacy (/start, /action, /turn/end, /end, /state, /:id/vc)
+  // e' intatto: la mappa `sessions` e le funzioni esistenti non sono
+  // toccate. Le due superfici coesistono. La migrazione del flusso
+  // legacy ai round endpoints (wrapper + refactor AI) e' scope di PR
+  // successive.
+  //
+  // Il `resolveAction` iniettato e' un **placeholder minimale** per
+  // PR 2: gestisce `attack` applicando 3 HP di danno fisso al target,
+  // `heal` con healing deterministico, e gli altri type come no-op
+  // con consumo AP. Il wiring al resolver reale (performAttack +
+  // traitEffects) e' scope di PR 4 (legacy wrappers).
+
+  function roundModelGuard(_req, res) {
+    if (!isRoundModelEnabled()) {
+      res.status(503).json({
+        error: 'round_model_disabled',
+        message:
+          'Feature flag USE_ROUND_MODEL non attivo. Imposta USE_ROUND_MODEL=true per abilitare gli endpoint round-based (vedi ADR-2026-04-16).',
+      });
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Adapter session.js units -> orchestrator units.
+   *
+   * La session in-memory usa `hp`/`max_hp` scalari, `ap`/`ap_remaining`,
+   * `status` come oggetto, `guardia` come parry budget. L'orchestrator
+   * vuole `hp: {current, max}`, `ap: {current, max}`,
+   * `reactions: {current, max}`, `statuses: []`.
+   *
+   * Il mapping e' idempotente: chiamarlo piu' volte sullo stesso
+   * session object ritorna sempre la stessa shape. Preserva `tier`
+   * (default 1) e `stress` (default 0) per i predicates DSL.
+   */
+  function adaptSessionToRoundState(session) {
+    const units = (session.units || []).map((u) => {
+      const statusObj = u.status || {};
+      const statuses = [];
+      for (const [id, turns] of Object.entries(statusObj)) {
+        if (Number(turns) > 0) {
+          statuses.push({
+            id,
+            intensity: 1,
+            remaining_turns: Number(turns),
+          });
+        }
+      }
+      return {
+        id: String(u.id),
+        hp: {
+          current: Number(u.hp || 0),
+          max: Number(u.max_hp || u.hp || 0),
+        },
+        ap: {
+          current: Number(u.ap_remaining != null ? u.ap_remaining : u.ap || 0),
+          max: Number(u.ap || 0),
+        },
+        reactions: { current: 1, max: 1 },
+        initiative: Number(u.initiative || 0),
+        tier: Number(u.tier || 1),
+        stress: Number(u.stress || 0),
+        statuses,
+        reaction_cooldown_remaining: Number(u.reaction_cooldown_remaining || 0),
+      };
+    });
+    return {
+      session_id: session.session_id,
+      turn: Number(session.turn || 1),
+      round_phase: null,
+      pending_intents: [],
+      units,
+      log: [],
+    };
+  }
+
+  /**
+   * Ensure `session.roundState` e' inizializzato. Chiamato lazy
+   * all'ingresso dei 4 endpoint round-based. Se non esiste, lo
+   * costruisce dall'adattamento delle units legacy.
+   */
+  function ensureRoundState(session) {
+    if (!session.roundState) {
+      session.roundState = adaptSessionToRoundState(session);
+    }
+    return session.roundState;
+  }
+
+  /**
+   * Placeholder resolveAction per PR 2. Gestisce:
+   *   - attack: infligge 3 HP di danno fisso al target, consuma AP
+   *   - heal: applica 3 HP di healing clampato a max_hp, consuma AP
+   *   - defend/parry/ability/move: consuma AP, nessun effect
+   *
+   * Restituisce `{ nextState, turnLogEntry }` in shape orchestrator
+   * (turn_log_entry con damage_applied / healing_applied).
+   *
+   * PR 4 scope: replace con wiring al `performAttack` reale di
+   * session.js (con trait effects, fairness cap, status system, ...).
+   */
+  function placeholderResolveAction(state, action, _catalog, _rng) {
+    const next = JSON.parse(JSON.stringify(state));
+    const actorId = String(action.actor_id || '');
+    const targetId = action.target_id ? String(action.target_id) : null;
+    const actor = next.units.find((u) => u.id === actorId);
+    if (actor && actor.ap) {
+      actor.ap.current = Math.max(0, Number(actor.ap.current || 0) - Number(action.ap_cost || 0));
+    }
+    let damageApplied = 0;
+    let healingApplied = 0;
+    if (action.type === 'attack' && targetId) {
+      const target = next.units.find((u) => u.id === targetId);
+      if (target && target.hp) {
+        damageApplied = 3;
+        target.hp.current = Math.max(0, Number(target.hp.current || 0) - damageApplied);
+      }
+    } else if (action.type === 'heal' && targetId) {
+      const target = next.units.find((u) => u.id === targetId);
+      if (target && target.hp) {
+        const missing = Number(target.hp.max || 0) - Number(target.hp.current || 0);
+        healingApplied = Math.max(0, Math.min(3, missing));
+        target.hp.current = Number(target.hp.current || 0) + healingApplied;
+      }
+    }
+    const turnLogEntry = {
+      turn: Number(next.turn || 1),
+      action: { ...action },
+      damage_applied: damageApplied,
+      healing_applied: healingApplied,
+    };
+    (next.log = next.log || []).push(turnLogEntry);
+    return { nextState: next, turnLogEntry };
+  }
+
+  // Orchestrator con closure-scoped deps. Gli unit test del modulo
+  // (tests/services/roundOrchestrator.test.js) validano la purezza
+  // delle funzioni — qui ci limitiamo a fornire resolveAction +
+  // rng = Math.random. La sostituzione del placeholder e' scope PR 4.
+  const roundOrchestrator = createRoundOrchestrator({
+    resolveAction: placeholderResolveAction,
+    defaultRng: rng,
+  });
+
+  router.post('/declare-intent', (req, res, next) => {
+    try {
+      if (!roundModelGuard(req, res)) return;
+      const { session_id: sessionId, actor_id: actorId, action } = req.body || {};
+      const { error, session } = resolveSession(sessionId);
+      if (error) return res.status(error.status).json(error.body);
+      if (!actorId || typeof actorId !== 'string') {
+        return res.status(400).json({ error: 'actor_id richiesto (string)' });
+      }
+      if (!action || typeof action !== 'object') {
+        return res
+          .status(400)
+          .json({ error: "action richiesto (object con campi 'type', 'actor_id', ...)" });
+      }
+      const state = ensureRoundState(session);
+      // beginRound automatico se phase e' null o 'resolved'
+      let current = state;
+      if (current.round_phase !== PHASE_PLANNING) {
+        current = roundOrchestrator.beginRound(current).nextState;
+      }
+      const { nextState } = roundOrchestrator.declareIntent(current, actorId, action);
+      session.roundState = nextState;
+      res.json({
+        session_id: session.session_id,
+        round_phase: nextState.round_phase,
+        pending_intents: nextState.pending_intents,
+      });
+    } catch (err) {
+      // Phase-machine errors -> 400
+      if (err && /round_phase|unit_id/.test(String(err.message || ''))) {
+        return res.status(400).json({ error: err.message });
+      }
+      next(err);
+    }
+  });
+
+  router.post('/clear-intent/:actorId', (req, res, next) => {
+    try {
+      if (!roundModelGuard(req, res)) return;
+      const sessionId = (req.body && req.body.session_id) || req.query.session_id;
+      const actorId = req.params.actorId;
+      const { error, session } = resolveSession(sessionId);
+      if (error) return res.status(error.status).json(error.body);
+      if (!session.roundState) {
+        return res
+          .status(400)
+          .json({ error: 'roundState non inizializzato (chiama prima /declare-intent)' });
+      }
+      const { nextState } = roundOrchestrator.clearIntent(session.roundState, actorId);
+      session.roundState = nextState;
+      res.json({
+        session_id: session.session_id,
+        round_phase: nextState.round_phase,
+        pending_intents: nextState.pending_intents,
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.post('/commit-round', (req, res, next) => {
+    try {
+      if (!roundModelGuard(req, res)) return;
+      const sessionId = req.body && req.body.session_id;
+      const { error, session } = resolveSession(sessionId);
+      if (error) return res.status(error.status).json(error.body);
+      if (!session.roundState) {
+        return res
+          .status(400)
+          .json({ error: 'roundState non inizializzato (chiama prima /declare-intent)' });
+      }
+      const { nextState } = roundOrchestrator.commitRound(session.roundState);
+      session.roundState = nextState;
+      res.json({
+        session_id: session.session_id,
+        round_phase: nextState.round_phase,
+        pending_intents: nextState.pending_intents,
+      });
+    } catch (err) {
+      if (err && /round_phase/.test(String(err.message || ''))) {
+        return res.status(400).json({ error: err.message });
+      }
+      next(err);
+    }
+  });
+
+  router.post('/resolve-round', (req, res, next) => {
+    try {
+      if (!roundModelGuard(req, res)) return;
+      const sessionId = req.body && req.body.session_id;
+      const { error, session } = resolveSession(sessionId);
+      if (error) return res.status(error.status).json(error.body);
+      if (!session.roundState) {
+        return res
+          .status(400)
+          .json({ error: 'roundState non inizializzato (chiama prima /declare-intent)' });
+      }
+      const result = roundOrchestrator.resolveRound(session.roundState);
+      session.roundState = result.nextState;
+      res.json({
+        session_id: session.session_id,
+        round_phase: result.nextState.round_phase,
+        turn_log_entries: result.turnLogEntries,
+        resolution_queue: result.resolutionQueue,
+        reactions_triggered: result.reactionsTriggered,
+        skipped: result.skipped,
+        units: result.nextState.units,
+      });
+    } catch (err) {
+      if (err && /round_phase/.test(String(err.message || ''))) {
+        return res.status(400).json({ error: err.message });
+      }
       next(err);
     }
   });

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-15T21:39:03+00:00",
+  "generated_at": "2026-04-15T21:54:09+00:00",
   "summary": {
     "total": 0,
     "errors": 0,

--- a/tests/api/sessionRoundEndpoints.test.js
+++ b/tests/api/sessionRoundEndpoints.test.js
@@ -1,0 +1,370 @@
+// ADR-2026-04-16 PR 2 di N — integration tests per gli endpoint
+// round-based aggiunti in apps/backend/routes/session.js.
+//
+// Copre:
+//   - guardia feature flag USE_ROUND_MODEL (503 se off)
+//   - /declare-intent + /clear-intent/:id + /commit-round + /resolve-round
+//     end-to-end quando flag on
+//   - Phase machine error mapping (400 per violazioni di fase)
+//   - Placeholder resolveAction (attack applica 3 HP di danno)
+//
+// Nota: il flag e' letto da process.env.USE_ROUND_MODEL via helper
+// `isRoundModelEnabled()` inline in session.js. I test impostano
+// esplicitamente `process.env.USE_ROUND_MODEL = 'true' | 'false'`
+// prima di costruire l'app, poi lo ripristinano nel t.after().
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+function withRoundFlag(value) {
+  const prior = process.env.USE_ROUND_MODEL;
+  process.env.USE_ROUND_MODEL = value;
+  return () => {
+    if (prior === undefined) delete process.env.USE_ROUND_MODEL;
+    else process.env.USE_ROUND_MODEL = prior;
+  };
+}
+
+async function startSession(app) {
+  const res = await request(app)
+    .post('/api/session/start')
+    .send({
+      units: [
+        {
+          id: 'p1',
+          species: 'test',
+          job: 'skirmisher',
+          hp: 10,
+          ap: 2,
+          initiative: 14,
+          position: { x: 0, y: 0 },
+          controlled_by: 'player',
+        },
+        {
+          id: 'sis',
+          species: 'test',
+          job: 'vanguard',
+          hp: 10,
+          ap: 2,
+          initiative: 10,
+          position: { x: 5, y: 5 },
+          controlled_by: 'sistema',
+        },
+      ],
+    })
+    .expect(200);
+  return res.body.session_id;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Feature flag guard — 503 when off
+// ─────────────────────────────────────────────────────────────────
+
+test('round endpoints return 503 when USE_ROUND_MODEL is unset', async (t) => {
+  const restore = withRoundFlag('');
+  t.after(restore);
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  for (const path of [
+    '/api/session/declare-intent',
+    '/api/session/commit-round',
+    '/api/session/resolve-round',
+  ]) {
+    const res = await request(app).post(path).send({ session_id: 'x' });
+    assert.equal(res.status, 503, `${path} should 503`);
+    assert.equal(res.body.error, 'round_model_disabled');
+  }
+  const clearRes = await request(app)
+    .post('/api/session/clear-intent/p1')
+    .send({ session_id: 'x' });
+  assert.equal(clearRes.status, 503);
+});
+
+test('round endpoints return 503 when USE_ROUND_MODEL=false explicitly', async (t) => {
+  const restore = withRoundFlag('false');
+  t.after(restore);
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const res = await request(app).post('/api/session/declare-intent').send({ session_id: 'x' });
+  assert.equal(res.status, 503);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Flag on — happy path
+// ─────────────────────────────────────────────────────────────────
+
+test('declare-intent initializes roundState and accepts planning intent', async (t) => {
+  const restore = withRoundFlag('true');
+  t.after(restore);
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const sessionId = await startSession(app);
+
+  const declareRes = await request(app)
+    .post('/api/session/declare-intent')
+    .send({
+      session_id: sessionId,
+      actor_id: 'p1',
+      action: {
+        id: 'act-p1',
+        type: 'attack',
+        actor_id: 'p1',
+        target_id: 'sis',
+        ap_cost: 1,
+      },
+    })
+    .expect(200);
+
+  assert.equal(declareRes.body.round_phase, 'planning');
+  assert.equal(declareRes.body.pending_intents.length, 1);
+  assert.equal(declareRes.body.pending_intents[0].unit_id, 'p1');
+  assert.equal(declareRes.body.pending_intents[0].action.type, 'attack');
+});
+
+test('declare-intent rejects missing actor_id or action', async (t) => {
+  const restore = withRoundFlag('true');
+  t.after(restore);
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sessionId = await startSession(app);
+
+  const r1 = await request(app)
+    .post('/api/session/declare-intent')
+    .send({ session_id: sessionId, action: { type: 'attack' } });
+  assert.equal(r1.status, 400);
+  assert.match(r1.body.error, /actor_id/);
+
+  const r2 = await request(app)
+    .post('/api/session/declare-intent')
+    .send({ session_id: sessionId, actor_id: 'p1' });
+  assert.equal(r2.status, 400);
+  assert.match(r2.body.error, /action/);
+});
+
+test('clear-intent removes pending intent', async (t) => {
+  const restore = withRoundFlag('true');
+  t.after(restore);
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sessionId = await startSession(app);
+
+  await request(app)
+    .post('/api/session/declare-intent')
+    .send({
+      session_id: sessionId,
+      actor_id: 'p1',
+      action: { id: 'a', type: 'attack', actor_id: 'p1', target_id: 'sis', ap_cost: 1 },
+    })
+    .expect(200);
+
+  const clearRes = await request(app)
+    .post('/api/session/clear-intent/p1')
+    .send({ session_id: sessionId })
+    .expect(200);
+
+  assert.equal(clearRes.body.pending_intents.length, 0);
+});
+
+test('commit-round transitions phase to committed', async (t) => {
+  const restore = withRoundFlag('true');
+  t.after(restore);
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sessionId = await startSession(app);
+
+  await request(app)
+    .post('/api/session/declare-intent')
+    .send({
+      session_id: sessionId,
+      actor_id: 'p1',
+      action: { id: 'a', type: 'attack', actor_id: 'p1', target_id: 'sis', ap_cost: 1 },
+    })
+    .expect(200);
+
+  const commitRes = await request(app)
+    .post('/api/session/commit-round')
+    .send({ session_id: sessionId })
+    .expect(200);
+
+  assert.equal(commitRes.body.round_phase, 'committed');
+});
+
+test('commit-round without declared intent still allowed (empty round)', async (t) => {
+  const restore = withRoundFlag('true');
+  t.after(restore);
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sessionId = await startSession(app);
+  // Trigger beginRound via declare + clear
+  await request(app)
+    .post('/api/session/declare-intent')
+    .send({
+      session_id: sessionId,
+      actor_id: 'p1',
+      action: { id: 'a', type: 'move', actor_id: 'p1', ap_cost: 1 },
+    })
+    .expect(200);
+  await request(app)
+    .post('/api/session/clear-intent/p1')
+    .send({ session_id: sessionId })
+    .expect(200);
+  const commitRes = await request(app)
+    .post('/api/session/commit-round')
+    .send({ session_id: sessionId })
+    .expect(200);
+  assert.equal(commitRes.body.round_phase, 'committed');
+});
+
+test('resolve-round executes attack intent and applies placeholder damage', async (t) => {
+  const restore = withRoundFlag('true');
+  t.after(restore);
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sessionId = await startSession(app);
+
+  await request(app)
+    .post('/api/session/declare-intent')
+    .send({
+      session_id: sessionId,
+      actor_id: 'p1',
+      action: { id: 'a', type: 'attack', actor_id: 'p1', target_id: 'sis', ap_cost: 1 },
+    })
+    .expect(200);
+  await request(app).post('/api/session/commit-round').send({ session_id: sessionId }).expect(200);
+
+  const resolveRes = await request(app)
+    .post('/api/session/resolve-round')
+    .send({ session_id: sessionId })
+    .expect(200);
+
+  assert.equal(resolveRes.body.round_phase, 'resolved');
+  assert.equal(resolveRes.body.turn_log_entries.length, 1);
+  assert.equal(resolveRes.body.turn_log_entries[0].damage_applied, 3);
+  assert.equal(resolveRes.body.resolution_queue.length, 1);
+  assert.equal(resolveRes.body.resolution_queue[0].unit_id, 'p1');
+  // sis ha subito 3 HP di danno (placeholder)
+  const sisUnit = resolveRes.body.units.find((u) => u.id === 'sis');
+  assert.equal(sisUnit.hp.current, 7);
+});
+
+test('resolve-round priority order: higher initiative resolves first', async (t) => {
+  const restore = withRoundFlag('true');
+  t.after(restore);
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sessionId = await startSession(app);
+
+  await request(app)
+    .post('/api/session/declare-intent')
+    .send({
+      session_id: sessionId,
+      actor_id: 'p1',
+      action: { id: 'p', type: 'attack', actor_id: 'p1', target_id: 'sis', ap_cost: 1 },
+    });
+  await request(app)
+    .post('/api/session/declare-intent')
+    .send({
+      session_id: sessionId,
+      actor_id: 'sis',
+      action: { id: 's', type: 'attack', actor_id: 'sis', target_id: 'p1', ap_cost: 1 },
+    });
+  await request(app).post('/api/session/commit-round').send({ session_id: sessionId });
+  const resolveRes = await request(app)
+    .post('/api/session/resolve-round')
+    .send({ session_id: sessionId })
+    .expect(200);
+
+  // p1 initiative 14 > sis initiative 10 -> p1 first
+  assert.equal(resolveRes.body.resolution_queue[0].unit_id, 'p1');
+  assert.equal(resolveRes.body.resolution_queue[1].unit_id, 'sis');
+  assert.equal(resolveRes.body.turn_log_entries.length, 2);
+});
+
+test('resolve-round rejects if phase is not committed', async (t) => {
+  const restore = withRoundFlag('true');
+  t.after(restore);
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sessionId = await startSession(app);
+
+  await request(app)
+    .post('/api/session/declare-intent')
+    .send({
+      session_id: sessionId,
+      actor_id: 'p1',
+      action: { id: 'a', type: 'attack', actor_id: 'p1', target_id: 'sis', ap_cost: 1 },
+    });
+  // No commit
+  const resolveRes = await request(app)
+    .post('/api/session/resolve-round')
+    .send({ session_id: sessionId });
+  assert.equal(resolveRes.status, 400);
+  assert.match(resolveRes.body.error, /round_phase/);
+});
+
+test('round endpoints reject unknown session_id', async (t) => {
+  const restore = withRoundFlag('true');
+  t.after(restore);
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const res = await request(app)
+    .post('/api/session/declare-intent')
+    .send({
+      session_id: 'unknown-session',
+      actor_id: 'p1',
+      action: { type: 'attack' },
+    });
+  assert.equal(res.status, 404);
+});
+
+test('commit-round rejects if not in planning phase', async (t) => {
+  const restore = withRoundFlag('true');
+  t.after(restore);
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sessionId = await startSession(app);
+
+  await request(app)
+    .post('/api/session/declare-intent')
+    .send({
+      session_id: sessionId,
+      actor_id: 'p1',
+      action: { id: 'a', type: 'attack', actor_id: 'p1', target_id: 'sis', ap_cost: 1 },
+    });
+  await request(app).post('/api/session/commit-round').send({ session_id: sessionId });
+
+  // Second commit without resolve -> phase is 'committed', not 'planning'
+  const res = await request(app).post('/api/session/commit-round').send({ session_id: sessionId });
+  assert.equal(res.status, 400);
+  assert.match(res.body.error, /round_phase/);
+});


### PR DESCRIPTION
## Summary

Seconda PR del piano di migrazione Node session engine (ADR-2026-04-16). Aggiunge 4 nuovi endpoint HTTP al session router che espongono il round orchestrator JS del #1387 dietro feature flag \`USE_ROUND_MODEL\`. Flusso legacy intatto.

## Scope

### In

- **Feature flag** \`USE_ROUND_MODEL\` con helper \`isRoundModelEnabled()\` in \`apps/backend/routes/session.js\`
- **4 nuovi endpoint**:
  - \`POST /api/session/declare-intent\` \`{ session_id, actor_id, action }\`
  - \`POST /api/session/clear-intent/:actorId\` \`{ session_id }\`
  - \`POST /api/session/commit-round\` \`{ session_id }\`
  - \`POST /api/session/resolve-round\` \`{ session_id }\`
- **Adapter** \`adaptSessionToRoundState\` (session.js units → orchestrator units)
- **Placeholder resolveAction** (attack = 3 HP damage fisso, heal = 3 HP healing clampato, altri = consumo AP only)
- **12 integration test** in \`tests/api/sessionRoundEndpoints.test.js\` (supertest + createApp)

### Out (PR successive)

- Wiring al \`performAttack\` reale + trait effects + fairness cap → PR 4
- Refactor \`sistemaTurnRunner\` → \`declareSistemaIntents\` → PR 3
- Wrapper legacy \`/action\` e \`/turn/end\` → PR 4
- Migrazione 45 test AI al round flow → PR 5-7
- Client HTML playtest → PR 8
- Flip default \`USE_ROUND_MODEL=true\` → PR 9

### Zero modifica a

- \`apps/backend/routes/session.js\` flusso legacy (\`/start\`, \`/action\`, \`/turn/end\`, \`/end\`, \`/state\`, \`/:id/vc\`) intatto
- Shape \`session.units\` originale (il nuovo state vive in \`session.roundState\` parallelo)
- \`apps/backend/services/roundOrchestrator.js\` (solo importato)
- \`tests/ai/*\` e \`tests/services/*\` (zero regression)
- Nessuna nuova dipendenza npm

## Feature flag semantics

| Flag value              | Behavior                                                                      |
| ----------------------- | ----------------------------------------------------------------------------- |
| unset / \`false\` / altro | Tutti e 4 gli endpoint ritornano **503** \`{ error: 'round_model_disabled' }\` |
| \`'true'\` (case-insens.) | Endpoint funzionali, operano su \`session.roundState\` parallelo                |

Lettura via \`process.env.USE_ROUND_MODEL\` ad ogni request (no caching), permette toggle a runtime nei test.

## Error mapping

| Codice | Causa                                                                                        |
| :----: | -------------------------------------------------------------------------------------------- |
| 503    | \`USE_ROUND_MODEL !== 'true'\`                                                                 |
| 400    | \`round_phase\` errato (violazione phase machine), \`actor_id\`/\`action\` missing, roundState non init |
| 404    | \`session_id\` sconosciuto                                                                     |
| 200    | Success con \`round_phase\`, \`pending_intents\`, \`turn_log_entries\`, \`resolution_queue\`, ecc. |

## Test (12/12 verdi in ~1.3s)

1. \`round endpoints return 503 when USE_ROUND_MODEL is unset\`
2. \`round endpoints return 503 when USE_ROUND_MODEL=false explicitly\`
3. \`declare-intent initializes roundState and accepts planning intent\`
4. \`declare-intent rejects missing actor_id or action\`
5. \`clear-intent removes pending intent\`
6. \`commit-round transitions phase to committed\`
7. \`commit-round without declared intent still allowed (empty round)\`
8. \`resolve-round executes attack intent and applies placeholder damage\` (verifica sis.hp 10 → 7)
9. \`resolve-round priority order: higher initiative resolves first\`
10. \`resolve-round rejects if phase is not committed\`
11. \`round endpoints reject unknown session_id\`
12. \`commit-round rejects if not in planning phase\` (double commit)

## Validazione completa

- \`node --test tests/api/sessionRoundEndpoints.test.js\` → **12/12 verdi**
- \`node --test tests/services/*.test.js tests/ai/*.test.js\` → **122/122 verdi** (77 services inclusi 32 roundOrchestrator + 45 AI intatti)
- \`prettier --check\` → verde post-write
- \`python tools/check_docs_governance.py --strict\` → **errors=0 warnings=0**

## Rollback

\`git revert <sha>\` rimuove:
- Import \`roundOrchestrator\` + helper \`isRoundModelEnabled\`
- 4 route definitions + adapter + placeholder resolveAction
- Test file \`tests/api/sessionRoundEndpoints.test.js\`

Il codice legacy (session Map, \`/start\`, \`/action\`, \`/turn/end\`, \`/end\`) e' completamente intatto. Nessuna dipendenza di runtime se il flag resta false. Rollback zero-impact.

## Riferimenti

- PR #1387 — round orchestrator JS foundation module (merged \`d678e220\`)
- [\`ADR-2026-04-16-session-engine-round-migration.md\`](https://github.com/MasterDD-L34D/Game/blob/main/docs/adr/ADR-2026-04-16-session-engine-round-migration.md) — migration blueprint (17-step checklist)
- [\`apps/backend/services/roundOrchestrator.js\`](https://github.com/MasterDD-L34D/Game/blob/main/apps/backend/services/roundOrchestrator.js) — foundation module

## Test plan

- [x] Unit test nuovi verdi (12/12)
- [x] Regression services + AI (122/122)
- [x] 503 verificato su flag off
- [x] Phase machine error mapping (400 su commit doppio, resolve senza commit)
- [x] Priority order verificato (p1 init 14 → prima di sis init 10)
- [x] Placeholder damage applicato correttamente (10 - 3 = 7 hp)
- [x] Prettier clean
- [x] Governance strict verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)