### PR TITLE
feat(combat): declareSistemaIntents pure module (PR 3/N Node migration)

### DIFF
--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -1,0 +1,214 @@
+// ADR-2026-04-16 PR 3 di N — declareSistemaIntents.
+//
+// Rifattorizzazione del sistemaTurnRunner per il round model:
+// invece di eseguire sequenzialmente attack/move mutando lo state e
+// consumando AP in un loop, produce una lista di **intents** da passare
+// al round orchestrator via `declareIntent`.
+//
+// Uso tipico nel round flow (wiring futuro in session.js):
+//   const { createDeclareSistemaIntents } = require('./declareSistemaIntents');
+//   const declare = createDeclareSistemaIntents({
+//     pickLowestHpEnemy,
+//     stepTowards,
+//     manhattanDistance,
+//     gridSize: GRID_SIZE,
+//   });
+//   const { intents, decisions } = declare(session);
+//   for (const { unit_id, action } of intents) {
+//     session.roundState = orchestrator.declareIntent(
+//       session.roundState, unit_id, action,
+//     ).nextState;
+//   }
+//
+// Il modulo e' **puro**: non tocca session.units, non muta AP, non
+// emette eventi, non scrive su disco. Lavora sulla shape legacy
+// session.units (hp scalare, position {x,y}, ecc.) perche' e' quello
+// che selectAiPolicy da policy.js si aspetta. L'adattamento allo
+// shape del round orchestrator avviene nel chiamante (session.js
+// PR 4 scope).
+//
+// Semantica "un intent per round per unit":
+// Nel round model ogni unit dichiara al massimo un'azione principale
+// per round. Il loop AP del vecchio sistemaTurnRunner (2 azioni per
+// turno se AP pieno) non ha equivalente diretto: il round successivo
+// permettera' la seconda azione. Questo riduce la "pressione"
+// dell'AI a round pieni ma mantiene fairness (2 round SIS = 2 azioni,
+// stesso throughput di 1 turno SIS vecchio). Eventuali upgrade
+// (multi-action intents) sono PR futura.
+
+const { selectAiPolicy, stepAway, DEFAULT_ATTACK_RANGE } = require('./policy');
+
+function createDeclareSistemaIntents(deps) {
+  const { pickLowestHpEnemy, stepTowards, manhattanDistance, gridSize = 6 } = deps || {};
+
+  if (typeof pickLowestHpEnemy !== 'function') {
+    throw new Error('createDeclareSistemaIntents: pickLowestHpEnemy is required');
+  }
+  if (typeof stepTowards !== 'function') {
+    throw new Error('createDeclareSistemaIntents: stepTowards is required');
+  }
+  if (typeof manhattanDistance !== 'function') {
+    throw new Error('createDeclareSistemaIntents: manhattanDistance is required');
+  }
+
+  /**
+   * Dichiara intents per tutte le unita' SIS-controlled vive nella session.
+   *
+   * Non muta la session. Ritorna:
+   *   {
+   *     intents: [{ unit_id, action }],          // ready per declareIntent
+   *     decisions: [{ unit_id, rule, intent, reason? }], // log + debug
+   *   }
+   *
+   * L'ordine di emissione e' deterministico: segue session.units
+   * (stesso ordine di iterazione del runner legacy).
+   */
+  return function declareSistemaIntents(session) {
+    if (!session || !Array.isArray(session.units)) {
+      return { intents: [], decisions: [] };
+    }
+
+    const intents = [];
+    const decisions = [];
+
+    for (const actor of session.units) {
+      if (!actor) continue;
+      if (actor.controlled_by !== 'sistema') continue;
+      if (Number(actor.hp || 0) <= 0) continue;
+
+      const target = pickLowestHpEnemy(session, actor);
+      if (!target) {
+        decisions.push({
+          unit_id: actor.id,
+          rule: 'NO_TARGET',
+          intent: 'skip',
+          reason: 'no enemy alive',
+        });
+        continue;
+      }
+
+      let policy = selectAiPolicy(actor, target);
+      const distance = manhattanDistance(actor.position, target.position);
+
+      // Fallback cornered: stessa logica di sistemaTurnRunner. Se
+      // REGOLA_002 e' attiva ma il retreat e' bloccato (step fallisce
+      // o unit cornered), cade back a REGOLA_001 (attack se in range,
+      // approach altrimenti).
+      if (policy.intent === 'retreat') {
+        const range = actor.attack_range ?? DEFAULT_ATTACK_RANGE;
+        const canRetreat = stepAway(actor.position, target.position, gridSize) !== null;
+        if (!canRetreat) {
+          policy =
+            distance <= range
+              ? { rule: 'REGOLA_001', intent: 'attack' }
+              : { rule: 'REGOLA_001', intent: 'approach' };
+        }
+      }
+
+      // intent='skip' non genera nessun intent: l'unit resta ferma.
+      // Viene comunque tracciato in decisions per debug.
+      if (policy.intent === 'skip') {
+        decisions.push({
+          unit_id: actor.id,
+          rule: policy.rule,
+          intent: 'skip',
+          reason: `stato emotivo — ${policy.rule}`,
+        });
+        continue;
+      }
+
+      if (policy.intent === 'attack') {
+        // Attack intent minimale. Il campo damage_dice e' un default
+        // portabile: il resolver (placeholder in PR 2, reale in PR 4)
+        // puo' override via i trait/stats dell'actor. Il field
+        // `source_ia_rule` e' metadata per la UI/log.
+        const action = {
+          id: `sis-attack-${actor.id}`,
+          type: 'attack',
+          actor_id: actor.id,
+          target_id: target.id,
+          ability_id: null,
+          ap_cost: 1,
+          channel: null,
+          damage_dice: { count: 1, sides: 6, modifier: 2 },
+          source_ia_rule: policy.rule,
+        };
+        intents.push({ unit_id: actor.id, action });
+        decisions.push({
+          unit_id: actor.id,
+          rule: policy.rule,
+          intent: 'attack',
+          target_id: target.id,
+        });
+        continue;
+      }
+
+      // intent='approach' o 'retreat' → move
+      const positionFrom = { ...actor.position };
+      const nextPos =
+        policy.intent === 'retreat'
+          ? stepAway(actor.position, target.position, gridSize)
+          : stepTowards(actor.position, target.position);
+
+      if (!nextPos || (nextPos.x === positionFrom.x && nextPos.y === positionFrom.y)) {
+        decisions.push({
+          unit_id: actor.id,
+          rule: policy.rule,
+          intent: 'skip',
+          reason:
+            policy.intent === 'retreat'
+              ? `cannot retreat — cornered near ${target.id}`
+              : `cannot approach ${target.id}`,
+        });
+        continue;
+      }
+
+      // Overlap guard: se la cella e' occupata da un'altra unit viva,
+      // niente intent (no-op). Il controllo stretto avviene anche nel
+      // resolver reale PR 4, ma lo facciamo early per evitare intent
+      // invalidi nella pending_intents list.
+      const blocker = session.units.find(
+        (u) =>
+          u.id !== actor.id &&
+          Number(u.hp || 0) > 0 &&
+          u.position &&
+          u.position.x === nextPos.x &&
+          u.position.y === nextPos.y,
+      );
+      if (blocker) {
+        decisions.push({
+          unit_id: actor.id,
+          rule: policy.rule,
+          intent: 'skip',
+          reason: `blocked by ${blocker.id} at (${nextPos.x},${nextPos.y})`,
+        });
+        continue;
+      }
+
+      const moveAction = {
+        id: `sis-move-${actor.id}`,
+        type: 'move',
+        actor_id: actor.id,
+        target_id: null,
+        ability_id: null,
+        ap_cost: 1,
+        channel: null,
+        move_to: { x: nextPos.x, y: nextPos.y },
+        position_from: positionFrom,
+        source_ia_rule: policy.rule,
+      };
+      intents.push({ unit_id: actor.id, action: moveAction });
+      decisions.push({
+        unit_id: actor.id,
+        rule: policy.rule,
+        intent: policy.intent, // 'approach' o 'retreat'
+        target_id: target.id,
+        move_to: nextPos,
+      });
+    }
+
+    return { intents, decisions };
+  };
+}
+
+module.exports = { createDeclareSistemaIntents };

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-15T21:54:09+00:00",
+  "generated_at": "2026-04-15T22:06:01+00:00",
   "summary": {
     "total": 0,
     "errors": 0,

--- a/tests/ai/declareSistemaIntents.test.js
+++ b/tests/ai/declareSistemaIntents.test.js
@@ -1,0 +1,517 @@
+// ADR-2026-04-16 PR 3 di N — test suite per
+// apps/backend/services/ai/declareSistemaIntents.js.
+//
+// Strategy: DI con stub per pickLowestHpEnemy, stepTowards,
+// manhattanDistance. Isolato da session.js / trait registry /
+// orchestrator reale. Valida che il factory ritorni intents nella
+// shape attesa dal round orchestrator per tutte le unit SIS vive.
+//
+// Copre:
+//   - Factory validation (deps required)
+//   - Skip di unita' player-controlled
+//   - Skip di unita' morte
+//   - Skip se no target disponibile
+//   - Attack intent per policy.intent='attack'
+//   - Move intent per 'approach'
+//   - Move intent per 'retreat' (REGOLA_002, HP <= 30%)
+//   - Fallback cornered: retreat → attack/approach se bloccato
+//   - Intent 'skip' (stunned) → nessun intent, solo decision
+//   - Overlap guard: cella occupata → nessun intent
+//   - Multi-unit SIS: intents plurali in ordine deterministico
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createDeclareSistemaIntents,
+} = require('../../apps/backend/services/ai/declareSistemaIntents');
+
+// ─────────────────────────────────────────────────────────────────
+// helpers
+// ─────────────────────────────────────────────────────────────────
+
+function manhattanDistance(a, b) {
+  return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+}
+
+function pickLowestHpEnemy(session, actor) {
+  const enemies = session.units.filter(
+    (u) => u.id !== actor.id && Number(u.hp) > 0 && u.controlled_by !== actor.controlled_by,
+  );
+  if (!enemies.length) return null;
+  return enemies.reduce((lo, u) => (!lo || u.hp < lo.hp ? u : lo), null);
+}
+
+function stepTowards(from, to) {
+  const next = { ...from };
+  if (from.x !== to.x) next.x += from.x < to.x ? 1 : -1;
+  else if (from.y !== to.y) next.y += from.y < to.y ? 1 : -1;
+  return next;
+}
+
+function makeSession(overrides = {}) {
+  const units = overrides.units || [
+    {
+      id: 'p1',
+      hp: 10,
+      max_hp: 10,
+      ap: 2,
+      ap_remaining: 2,
+      attack_range: 2,
+      position: { x: 0, y: 0 },
+      controlled_by: 'player',
+      status: {},
+    },
+    {
+      id: 'sis',
+      hp: 10,
+      max_hp: 10,
+      ap: 2,
+      ap_remaining: 2,
+      attack_range: 1,
+      position: { x: 3, y: 0 },
+      controlled_by: 'sistema',
+      status: {},
+    },
+  ];
+  return {
+    session_id: 'test',
+    turn: 1,
+    units,
+    grid: { width: 6, height: 6 },
+  };
+}
+
+function buildDeclare() {
+  return createDeclareSistemaIntents({
+    pickLowestHpEnemy,
+    stepTowards,
+    manhattanDistance,
+    gridSize: 6,
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Factory validation
+// ─────────────────────────────────────────────────────────────────
+
+test('createDeclareSistemaIntents throws without pickLowestHpEnemy', () => {
+  assert.throws(
+    () => createDeclareSistemaIntents({ stepTowards, manhattanDistance }),
+    /pickLowestHpEnemy/,
+  );
+});
+
+test('createDeclareSistemaIntents throws without stepTowards', () => {
+  assert.throws(
+    () => createDeclareSistemaIntents({ pickLowestHpEnemy, manhattanDistance }),
+    /stepTowards/,
+  );
+});
+
+test('createDeclareSistemaIntents throws without manhattanDistance', () => {
+  assert.throws(
+    () => createDeclareSistemaIntents({ pickLowestHpEnemy, stepTowards }),
+    /manhattanDistance/,
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Skip logic
+// ─────────────────────────────────────────────────────────────────
+
+test('skips player-controlled units (no intent)', () => {
+  const declare = buildDeclare();
+  const session = makeSession();
+  const { intents, decisions } = declare(session);
+  // Only sis-controlled should appear
+  assert.ok(intents.every((i) => i.unit_id === 'sis'));
+  assert.ok(decisions.every((d) => d.unit_id === 'sis'));
+});
+
+test('skips dead SIS units', () => {
+  const declare = buildDeclare();
+  const session = makeSession({
+    units: [
+      {
+        id: 'p1',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        position: { x: 0, y: 0 },
+        controlled_by: 'player',
+        status: {},
+      },
+      {
+        id: 'sis',
+        hp: 0,
+        max_hp: 10,
+        ap: 2,
+        position: { x: 3, y: 0 },
+        controlled_by: 'sistema',
+        status: {},
+      },
+    ],
+  });
+  const { intents, decisions } = declare(session);
+  assert.equal(intents.length, 0);
+  assert.equal(decisions.length, 0);
+});
+
+test('skip with NO_TARGET reason when no enemy alive', () => {
+  const declare = buildDeclare();
+  const session = makeSession({
+    units: [
+      {
+        id: 'p1',
+        hp: 0,
+        max_hp: 10,
+        ap: 2,
+        position: { x: 0, y: 0 },
+        controlled_by: 'player',
+        status: {},
+      },
+      {
+        id: 'sis',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        attack_range: 1,
+        position: { x: 3, y: 0 },
+        controlled_by: 'sistema',
+        status: {},
+      },
+    ],
+  });
+  const { intents, decisions } = declare(session);
+  assert.equal(intents.length, 0);
+  assert.equal(decisions.length, 1);
+  assert.equal(decisions[0].rule, 'NO_TARGET');
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Attack intent
+// ─────────────────────────────────────────────────────────────────
+
+test('attack intent when target in range (REGOLA_001)', () => {
+  const declare = buildDeclare();
+  const session = makeSession({
+    units: [
+      {
+        id: 'p1',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        position: { x: 2, y: 0 },
+        controlled_by: 'player',
+        status: {},
+      },
+      {
+        id: 'sis',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        attack_range: 2,
+        position: { x: 3, y: 0 },
+        controlled_by: 'sistema',
+        status: {},
+      },
+    ],
+  });
+  const { intents, decisions } = declare(session);
+  assert.equal(intents.length, 1);
+  assert.equal(intents[0].action.type, 'attack');
+  assert.equal(intents[0].action.actor_id, 'sis');
+  assert.equal(intents[0].action.target_id, 'p1');
+  assert.equal(intents[0].action.ap_cost, 1);
+  assert.equal(intents[0].action.source_ia_rule, 'REGOLA_001');
+  assert.equal(decisions[0].intent, 'attack');
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Move intent (approach + retreat)
+// ─────────────────────────────────────────────────────────────────
+
+test('move approach intent when target out of range (REGOLA_001)', () => {
+  const declare = buildDeclare();
+  const session = makeSession({
+    units: [
+      {
+        id: 'p1',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        position: { x: 0, y: 0 },
+        controlled_by: 'player',
+        status: {},
+      },
+      {
+        id: 'sis',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        attack_range: 1,
+        position: { x: 5, y: 0 },
+        controlled_by: 'sistema',
+        status: {},
+      },
+    ],
+  });
+  const { intents, decisions } = declare(session);
+  assert.equal(intents.length, 1);
+  assert.equal(intents[0].action.type, 'move');
+  assert.ok(intents[0].action.move_to);
+  assert.equal(intents[0].action.move_to.x, 4); // stepTowards(5,0 -> 0,0)
+  assert.equal(decisions[0].intent, 'approach');
+});
+
+test('move retreat intent when HP <= 30% (REGOLA_002)', () => {
+  const declare = buildDeclare();
+  const session = makeSession({
+    units: [
+      {
+        id: 'p1',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        position: { x: 0, y: 0 },
+        controlled_by: 'player',
+        status: {},
+      },
+      {
+        id: 'sis',
+        hp: 3,
+        max_hp: 10,
+        ap: 2,
+        attack_range: 1,
+        position: { x: 2, y: 0 },
+        controlled_by: 'sistema',
+        status: {},
+      },
+    ],
+  });
+  const { intents, decisions } = declare(session);
+  assert.equal(intents.length, 1);
+  assert.equal(intents[0].action.type, 'move');
+  assert.equal(decisions[0].rule, 'REGOLA_002');
+  assert.equal(decisions[0].intent, 'retreat');
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Cornered fallback
+// ─────────────────────────────────────────────────────────────────
+
+test('cornered retreat falls back to attack if in range', () => {
+  const declare = buildDeclare();
+  // SIS angolo (0,0), player a (1,0): cornered, stepAway = null
+  const session = makeSession({
+    units: [
+      {
+        id: 'p1',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        position: { x: 1, y: 0 },
+        controlled_by: 'player',
+        status: {},
+      },
+      {
+        id: 'sis',
+        hp: 3,
+        max_hp: 10,
+        ap: 2,
+        attack_range: 1,
+        position: { x: 0, y: 0 },
+        controlled_by: 'sistema',
+        status: {},
+      },
+    ],
+  });
+  const { intents, decisions } = declare(session);
+  assert.equal(intents.length, 1);
+  // Dovrebbe cadere in attack (in range 1) con REGOLA_001
+  assert.equal(intents[0].action.type, 'attack');
+  assert.equal(decisions[0].rule, 'REGOLA_001');
+});
+
+test('cornered retreat falls back to approach if out of range', () => {
+  const declare = buildDeclare();
+  // SIS angolo (0,0), player lontano (5,0), HP basso, cornered → approach
+  const session = makeSession({
+    units: [
+      {
+        id: 'p1',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        position: { x: 5, y: 0 },
+        controlled_by: 'player',
+        status: {},
+      },
+      {
+        id: 'sis',
+        hp: 3,
+        max_hp: 10,
+        ap: 2,
+        attack_range: 1,
+        position: { x: 0, y: 0 },
+        controlled_by: 'sistema',
+        status: {},
+      },
+    ],
+  });
+  const { intents, decisions } = declare(session);
+  assert.equal(intents.length, 1);
+  assert.equal(intents[0].action.type, 'move');
+  assert.equal(decisions[0].rule, 'REGOLA_001');
+  assert.equal(decisions[0].intent, 'approach');
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Skip (stunned)
+// ─────────────────────────────────────────────────────────────────
+
+test('stunned SIS produces skip decision with no intent', () => {
+  const declare = buildDeclare();
+  const session = makeSession({
+    units: [
+      {
+        id: 'p1',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        position: { x: 0, y: 0 },
+        controlled_by: 'player',
+        status: {},
+      },
+      {
+        id: 'sis',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        attack_range: 1,
+        position: { x: 3, y: 0 },
+        controlled_by: 'sistema',
+        status: { stunned: 2 },
+      },
+    ],
+  });
+  const { intents, decisions } = declare(session);
+  assert.equal(intents.length, 0);
+  assert.equal(decisions.length, 1);
+  assert.equal(decisions[0].intent, 'skip');
+  assert.equal(decisions[0].rule, 'STATO_STUNNED');
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Overlap guard
+// ─────────────────────────────────────────────────────────────────
+
+test('move skipped if destination cell occupied', () => {
+  const declare = buildDeclare();
+  // sis a (5,0), player a (0,0), altro alleato a (4,0) → blocker su approach
+  const session = makeSession({
+    units: [
+      {
+        id: 'p1',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        position: { x: 0, y: 0 },
+        controlled_by: 'player',
+        status: {},
+      },
+      {
+        id: 'sis',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        attack_range: 1,
+        position: { x: 5, y: 0 },
+        controlled_by: 'sistema',
+        status: {},
+      },
+      // Blocker su (4,0): altro player alive
+      {
+        id: 'p2',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        position: { x: 4, y: 0 },
+        controlled_by: 'player',
+        status: {},
+      },
+    ],
+  });
+  const { intents, decisions } = declare(session);
+  assert.equal(intents.length, 0);
+  // sis targets lowest-hp enemy (p1, p2 both hp 10 - picks first).
+  // Approach step towards p1 = (4, 0), blocked by p2.
+  assert.equal(decisions.find((d) => d.unit_id === 'sis').intent, 'skip');
+  assert.match(decisions[0].reason, /blocked/);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Multi-unit deterministic order
+// ─────────────────────────────────────────────────────────────────
+
+test('multi-unit SIS produces intents in session.units order', () => {
+  const declare = buildDeclare();
+  const session = makeSession({
+    units: [
+      {
+        id: 'p1',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        position: { x: 0, y: 0 },
+        controlled_by: 'player',
+        status: {},
+      },
+      {
+        id: 'sis_a',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        attack_range: 2,
+        position: { x: 2, y: 0 },
+        controlled_by: 'sistema',
+        status: {},
+      },
+      {
+        id: 'sis_b',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        attack_range: 2,
+        position: { x: 2, y: 1 },
+        controlled_by: 'sistema',
+        status: {},
+      },
+    ],
+  });
+  const { intents } = declare(session);
+  assert.equal(intents.length, 2);
+  assert.equal(intents[0].unit_id, 'sis_a');
+  assert.equal(intents[1].unit_id, 'sis_b');
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Purity
+// ─────────────────────────────────────────────────────────────────
+
+test('does not mutate session or units', () => {
+  const declare = buildDeclare();
+  const session = makeSession();
+  const sisPosBefore = { ...session.units[1].position };
+  const apBefore = session.units[1].ap_remaining;
+  declare(session);
+  assert.deepEqual(session.units[1].position, sisPosBefore);
+  assert.equal(session.units[1].ap_remaining, apBefore);
+});
+
+test('returns empty when session is null or missing units', () => {
+  const declare = buildDeclare();
+  assert.deepEqual(declare(null), { intents: [], decisions: [] });
+  assert.deepEqual(declare({}), { intents: [], decisions: [] });
+});


### PR DESCRIPTION
## Summary

Terza PR del piano di migrazione Node session engine (ADR-2026-04-16). Rifattorizza la logica AI del SIS da **esegue azioni mutando lo state** (\`sistemaTurnRunner.js\`) a **emette intents puri** compatibili col round orchestrator.

Nuovo modulo: \`apps/backend/services/ai/declareSistemaIntents.js\`.

Il vecchio \`sistemaTurnRunner.js\` resta intatto per il flusso legacy (\`/action\`, \`/turn/end\`). Il nuovo modulo sara' wirato al round flow in PR 4 (legacy wrappers) o da un endpoint dedicato.

## Scope

### In

- Nuovo file \`apps/backend/services/ai/declareSistemaIntents.js\` (~170 LOC)
- Factory \`createDeclareSistemaIntents({ pickLowestHpEnemy, stepTowards, manhattanDistance, gridSize })\` con DI
- 16 unit test in \`tests/ai/declareSistemaIntents.test.js\` (16/16 verdi in ~67ms)

### Out (PR successive)

- Wiring endpoint round flow → PR 4
- Wrappers legacy \`/action\`/\`/turn/end\` → PR 4
- Migrazione 45 test AI al round model → PR 5-7
- Client HTML playtest → PR 8
- Flip default + cleanup → PR 9

### Zero modifica a

- \`sistemaTurnRunner.js\` intatto
- \`policy.js\` intatto (solo importato)
- \`session.js\` intatto
- \`roundOrchestrator.js\` intatto (solo consumatore conceptual via shape compatibility)
- 45 test AI esistenti + 12 endpoint test + 77 services → **tutti verdi**

## Design

**Output shape**:

\`\`\`js
{
  intents: [
    { unit_id: 'sis', action: { id, type: 'attack', actor_id, target_id, ap_cost, damage_dice, source_ia_rule } }
  ],
  decisions: [
    { unit_id: 'sis', rule: 'REGOLA_001', intent: 'attack', target_id: 'p1' }
  ]
}
\`\`\`

**Action types**:

- \`attack\` → intent \`{ type: 'attack', target_id, ap_cost: 1, damage_dice: {1d6+2}, source_ia_rule }\`
- \`approach\` / \`retreat\` → intent \`{ type: 'move', move_to: {x,y}, position_from, source_ia_rule }\`
- \`skip\` (stunned/rage/panic con no target) → **nessun intent**, solo decision per debug

**Purity**:

- No \`session.units\` mutation
- No \`ap_remaining\` decrement (round model consumed AP solo a resolve)
- No event emission / log write
- No HTTP / filesystem
- Idempotente: stessa session → stessi intents/decisions

**Logica AI preservata dal \`sistemaTurnRunner\`**:

- \`pickLowestHpEnemy\` → target selection
- \`selectAiPolicy(actor, target)\` → rule + intent (REGOLA_001/002/003 + emotional overrides)
- Fallback cornered: \`retreat\` + \`stepAway=null\` → \`attack\` (in range) o \`approach\` (out of range)
- Overlap guard: destination cell occupata → skip intent emission

**Semantica "un intent per unit per round"**:

Il vecchio runner faceva fino a 2 azioni per turno con AP 2 via loop. Il round model permette un solo main intent per unit per round → la seconda azione arriva nel round successivo. Throughput fairness preservato (2 round SIS = 2 azioni). Upgrade multi-action → PR futura.

## Test (16 totali, 16/16 verdi in ~67ms)

| Categoria         | Test                                             |
| ----------------- | ------------------------------------------------ |
| Factory (3)       | throws without pickLowestHpEnemy / stepTowards / manhattanDistance |
| Skip logic (3)    | skips player-controlled, skips dead SIS, NO_TARGET decision |
| Action (3)        | attack in range, approach out of range, retreat HP ≤ 30% |
| Cornered (2)      | retreat → attack / approach post-cornered         |
| Skip state (1)    | stunned → skip decision, no intent               |
| Overlap (1)       | move skipped se destination cell occupata         |
| Multi-unit (1)    | ordine deterministico intents                     |
| Purity (2)        | no mutation, null-safe                           |

## Validazione

- \`node --test tests/ai/declareSistemaIntents.test.js\` → **16/16 verdi**
- \`node --test tests/ai/*.test.js tests/services/*.test.js\` → **138/138 verdi** (45 AI esistenti + 16 nuovi + 77 services inclusi 32 roundOrchestrator)
- \`node --test tests/api/sessionRoundEndpoints.test.js\` → **12/12 verdi** (regression endpoint #1388 intatta)
- \`prettier --check\` → verde post-write
- \`python tools/check_docs_governance.py --strict\` → **errors=0 warnings=0**

## Rollback

\`git revert <sha>\` rimuove:
- \`apps/backend/services/ai/declareSistemaIntents.js\` (nuovo)
- \`tests/ai/declareSistemaIntents.test.js\` (nuovo)

Nessuna modifica a file esistenti. Rollback zero-impact.

## Stato piano migrazione

- PR #1387 (M1-M3): foundation module JS → ✅ MERGED
- PR #1388 (M2): endpoints + feature flag \`USE_ROUND_MODEL\` → ✅ MERGED
- **PR #1389 (M4): declareSistemaIntents pure module → QUESTA PR**
- PR futura (M5): wrappers legacy \`/action\` + \`/turn/end\` + wiring round flow AI
- PR futura (M6-M14): migrazione 45 test AI in batch
- PR futura (M15): client HTML playtest
- PR futura (M16-M17): flip \`USE_ROUND_MODEL\` default + cleanup legacy

## Test plan

- [x] Unit test nuovi verdi (16/16)
- [x] Regression AI + services (138/138)
- [x] Regression endpoint #1388 (12/12)
- [x] Purity verificata (no mutation)
- [x] Cornered fallback verificato (retreat → attack/approach)
- [x] Prettier clean
- [x] Governance strict verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)