### PR TITLE
chore(workflows): bump Node to 22 + opt-in FORCE_JAVASCRIPT_ACTIONS_TO_NODE24

### DIFF
--- a/.github/workflows/chatgpt_sync.yml
+++ b/.github/workflows/chatgpt_sync.yml
@@ -5,6 +5,12 @@ on:
     - cron: '30 5 * * *'
   workflow_dispatch:
 
+env:
+  # Opt-in Node.js 24 runtime per actions JavaScript (checkout, setup-node,
+  # setup-python, upload-artifact, ecc.). Evita deprecation warning Node 20
+  # (rimosso 2026-09-16). Vedi https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
   push:
   pull_request:
 
+env:
+  # Opt-in Node.js 24 runtime per actions JavaScript (checkout, setup-node,
+  # setup-python, upload-artifact, ecc.). Evita deprecation warning Node 20
+  # (rimosso 2026-09-16). Vedi https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   paths-filter:
     runs-on: ubuntu-latest
@@ -84,7 +90,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: tools/ts/package-lock.json
 
@@ -164,7 +170,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: package-lock.json
 
@@ -196,7 +202,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: package-lock.json
 
@@ -234,7 +240,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: tools/ts/package-lock.json
 
@@ -284,7 +290,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -322,7 +328,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: package-lock.json
 
@@ -494,7 +500,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install Lighthouse CI
         run: npm i -g @lhci/cli@0.13.x
@@ -578,7 +584,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: tools/ts/package-lock.json
 

--- a/.github/workflows/daily-pr-summary.yml
+++ b/.github/workflows/daily-pr-summary.yml
@@ -5,6 +5,12 @@ on:
     - cron: '10 17 * * *'
   workflow_dispatch:
 
+env:
+  # Opt-in Node.js 24 runtime per actions JavaScript (checkout, setup-node,
+  # setup-python, upload-artifact, ecc.). Evita deprecation warning Node 20
+  # (rimosso 2026-09-16). Vedi https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily-tracker-refresh.yml
+++ b/.github/workflows/daily-tracker-refresh.yml
@@ -5,6 +5,12 @@ on:
     - cron: '0 12 * * *'
   workflow_dispatch:
 
+env:
+  # Opt-in Node.js 24 runtime per actions JavaScript (checkout, setup-node,
+  # setup-python, upload-artifact, ecc.). Evita deprecation warning Node 20
+  # (rimosso 2026-09-16). Vedi https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   refresh:
     runs-on: ubuntu-latest

--- a/.github/workflows/data-quality.yml
+++ b/.github/workflows/data-quality.yml
@@ -13,6 +13,12 @@ on:
       - 'reports/schema_validation.json'
   workflow_dispatch:
 
+env:
+  # Opt-in Node.js 24 runtime per actions JavaScript (checkout, setup-node,
+  # setup-python, upload-artifact, ecc.). Evita deprecation warning Node 20
+  # (rimosso 2026-09-16). Vedi https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   data-quality:
     name: Run trait audit and dataset validation
@@ -24,7 +30,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install Node.js dependencies

--- a/.github/workflows/deploy-test-interface.yml
+++ b/.github/workflows/deploy-test-interface.yml
@@ -12,6 +12,14 @@ permissions:
   pages: write
   id-token: write
 
+# Opt-in Node.js 24 runtime per gli actions JavaScript (checkout,
+# setup-node, setup-python, upload-artifact, ecc.). Documentato da
+# GitHub come path di opt-in early per evitare deprecation warning
+# Node 20 (rimosso 2026-09-16). Vedi https://github.blog/changelog/
+# 2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 concurrency:
   group: 'pages'
   cancel-in-progress: false
@@ -26,7 +34,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: tools/ts/package-lock.json
 

--- a/.github/workflows/derived_checksum.yml
+++ b/.github/workflows/derived_checksum.yml
@@ -14,6 +14,12 @@ on:
       - 'docs/planning/REF_TOOLING_AND_CI.md'
       - 'logs/agent_activity.md'
 
+env:
+  # Opt-in Node.js 24 runtime per actions JavaScript (checkout, setup-node,
+  # setup-python, upload-artifact, ecc.). Evita deprecation warning Node 20
+  # (rimosso 2026-09-16). Vedi https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   derived-checksum:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-governance.yml
+++ b/.github/workflows/docs-governance.yml
@@ -13,6 +13,12 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
+env:
+  # Opt-in Node.js 24 runtime per actions JavaScript (checkout, setup-node,
+  # setup-python, upload-artifact, ecc.). Evita deprecation warning Node 20
+  # (rimosso 2026-09-16). Vedi https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   governance:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,12 @@ on:
   schedule:
     - cron: '7 5 * * *'
 
+env:
+  # Opt-in Node.js 24 runtime per actions JavaScript (checkout, setup-node,
+  # setup-python, upload-artifact, ecc.). Evita deprecation warning Node 20
+  # (rimosso 2026-09-16). Vedi https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   e2e:
     runs-on: ubuntu-latest
@@ -12,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
       - name: Install deps
         working-directory: tests/playwright
         run: npm ci || npm i

--- a/.github/workflows/evo-rollout-status.yml
+++ b/.github/workflows/evo-rollout-status.yml
@@ -5,6 +5,12 @@ on:
     - cron: '0 6 * * MON'
   workflow_dispatch:
 
+env:
+  # Opt-in Node.js 24 runtime per actions JavaScript (checkout, setup-node,
+  # setup-python, upload-artifact, ecc.). Evita deprecation warning Node 20
+  # (rimosso 2026-09-16). Vedi https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   rollout-status:
     name: Generate rollout status snapshot

--- a/.github/workflows/idea-intake-index.yml
+++ b/.github/workflows/idea-intake-index.yml
@@ -4,6 +4,13 @@ on:
     paths: ['docs/ideas/submissions/**']
 permissions:
   contents: write
+
+env:
+  # Opt-in Node.js 24 runtime per actions JavaScript (checkout, setup-node,
+  # setup-python, upload-artifact, ecc.). Evita deprecation warning Node 20
+  # (rimosso 2026-09-16). Vedi https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   index:
     runs-on: ubuntu-latest

--- a/.github/workflows/qa-export.yml
+++ b/.github/workflows/qa-export.yml
@@ -7,6 +7,12 @@ on:
         description: 'Numero PR su cui pubblicare il commento (opzionale)'
         required: false
 
+env:
+  # Opt-in Node.js 24 runtime per actions JavaScript (checkout, setup-node,
+  # setup-python, upload-artifact, ecc.). Evita deprecation warning Node 20
+  # (rimosso 2026-09-16). Vedi https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   export:
     name: Run QA export
@@ -35,7 +41,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Generate QA reports
         run: node scripts/export-qa-report.js

--- a/.github/workflows/qa-kpi-monitor.yml
+++ b/.github/workflows/qa-kpi-monitor.yml
@@ -5,6 +5,12 @@ on:
     - cron: '0 6 1 * *'
   workflow_dispatch:
 
+env:
+  # Opt-in Node.js 24 runtime per actions JavaScript (checkout, setup-node,
+  # setup-python, upload-artifact, ecc.). Evita deprecation warning Node 20
+  # (rimosso 2026-09-16). Vedi https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   kpi-visual:
     runs-on: ubuntu-latest

--- a/.github/workflows/qa-reports.yml
+++ b/.github/workflows/qa-reports.yml
@@ -12,6 +12,12 @@ on:
       - 'data/**'
       - 'docs/recap/qa-playbook.md'
 
+env:
+  # Opt-in Node.js 24 runtime per actions JavaScript (checkout, setup-node,
+  # setup-python, upload-artifact, ecc.). Evita deprecation warning Node 20
+  # (rimosso 2026-09-16). Vedi https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   export-qa-reports:
     name: Generate QA baselines
@@ -35,7 +41,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Generate QA reports
         run: node scripts/export-qa-report.js

--- a/.github/workflows/schema-validate.yml
+++ b/.github/workflows/schema-validate.yml
@@ -11,6 +11,12 @@ on:
       - 'config/schemas/**'
   workflow_dispatch: {}
 
+env:
+  # Opt-in Node.js 24 runtime per actions JavaScript (checkout, setup-node,
+  # setup-python, upload-artifact, ecc.). Evita deprecation warning Node 20
+  # (rimosso 2026-09-16). Vedi https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/telemetry-export.yml
+++ b/.github/workflows/telemetry-export.yml
@@ -14,6 +14,12 @@ on:
       - 'tools/ts/package-lock.json'
       - 'tools/ts/tests/export-modal.test.tsx'
 
+env:
+  # Opt-in Node.js 24 runtime per actions JavaScript (checkout, setup-node,
+  # setup-python, upload-artifact, ecc.). Evita deprecation warning Node 20
+  # (rimosso 2026-09-16). Vedi https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   validate-schema:
     runs-on: ubuntu-latest
@@ -35,7 +41,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install UI test deps
         run: npm install --prefix tools/ts

--- a/.github/workflows/traits-monthly-maintenance.yml
+++ b/.github/workflows/traits-monthly-maintenance.yml
@@ -5,6 +5,12 @@ on:
     - cron: '0 6 1 * *'
   workflow_dispatch:
 
+env:
+  # Opt-in Node.js 24 runtime per actions JavaScript (checkout, setup-node,
+  # setup-python, upload-artifact, ecc.). Evita deprecation warning Node 20
+  # (rimosso 2026-09-16). Vedi https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   maintenance:
     name: Run monthly trait maintenance
@@ -16,7 +22,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/traits-sync.yml
+++ b/.github/workflows/traits-sync.yml
@@ -11,6 +11,12 @@ on:
         type: boolean
         default: true
 
+env:
+  # Opt-in Node.js 24 runtime per actions JavaScript (checkout, setup-node,
+  # setup-python, upload-artifact, ecc.). Evita deprecation warning Node 20
+  # (rimosso 2026-09-16). Vedi https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   sync-traits:
     name: Update glossary and export partner feed

--- a/.github/workflows/validate_traits.yml
+++ b/.github/workflows/validate_traits.yml
@@ -17,6 +17,12 @@ on:
       - 'reports/trait_fields_by_type.json'
       - 'tools/py/**.py'
 
+env:
+  # Opt-in Node.js 24 runtime per actions JavaScript (checkout, setup-node,
+  # setup-python, upload-artifact, ecc.). Evita deprecation warning Node 20
+  # (rimosso 2026-09-16). Vedi https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   validate-traits:
     runs-on: ubuntu-latest
@@ -25,7 +31,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - name: Install Node.js dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

Risolve i **deprecation warning Node.js 20** su tutti e 19 i workflow GitHub Actions. Due modifiche complementari:

1. **\`node-version: 20 -> 22\`** nei 9 workflow con setup-node esplicito (16 occorrenze totali)
2. **\`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true\`** come env block top-level in tutti i 19 workflow

Zero bump di versione delle actions (niente \`v4 -> v5\` rischioso). Approccio minimalmente invasivo usando il path di opt-in documentato.

## Context

GitHub ha deprecato Node 20 per il runtime delle actions JavaScript ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Timeline:

- **2026-06-02**: Node 24 diventa default forzato
- **2026-09-16**: Node 20 rimosso dai runner

Il repo attualmente triggera il warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4, actions/setup-python@v5, actions/upload-artifact@v4.

## Changes

### 1. \`node-version: 20 -> 22\`

9 workflow con \`setup-node\` esplicito, 16 occorrenze totali:

- \`ci.yml\` (8 occorrenze nei job build/dataset/playwright/generator/ecc)
- \`data-quality.yml\`
- \`deploy-test-interface.yml\`
- \`e2e.yml\`
- \`qa-export.yml\`
- \`qa-reports.yml\`
- \`telemetry-export.yml\`
- \`traits-monthly-maintenance.yml\`
- \`validate_traits.yml\`

Node 22 LTS e' anche la versione consigliata dal \`CLAUDE.md\` del repo (\`Node 22.19.0 recommended\`), quindi la CI ora matcha l'ambiente dev locale.

### 2. \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true\`

Env block top-level in **tutti e 19** i workflow (incluso quelli senza setup-node custom come \`chatgpt_sync\`, \`daily-pr-summary\`, \`docs-governance\`, ecc):

\`\`\`yaml
env:
  # Opt-in Node.js 24 runtime per actions JavaScript (checkout, setup-node,
  # setup-python, upload-artifact, ecc.). Evita deprecation warning Node 20
  # (rimosso 2026-09-16). Vedi https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
\`\`\`

Questa env var abilita il **Node 24 runtime sulle actions JavaScript built-in** (\`actions/checkout\`, \`actions/setup-node\`, \`actions/setup-python\`, \`actions/upload-artifact\`, ecc.) senza dover bumpare le versioni individuali (rischioso).

## Impatto

| Aspetto | Pre | Post |
|---|---|---|
| Deprecation warning Node 20 | Ogni job | **Zero** |
| Node runtime code custom | 20 | **22** |
| Action runtime built-in | 20 (deprecato) | **24** |
| Bump versione actions | n/a | **zero** (minimal blast) |
| Backward compat | ✓ | ✓ |

## Validazione

- \`python3 yaml lint\` su tutti i 19 file → **0 errori**
- \`prettier --check .github/workflows/*.yml\` → verde post \`--write\`
- \`grep FORCE_JAVASCRIPT_ACTIONS_TO_NODE24\` → **19 match** (tutti i file)
- \`grep node-version: 20\` → **0 match** (tutti bumped a 22)

## Rollback

\`git revert <sha>\` riporta tutti i file a Node 20 + senza env var. La CI continuerebbe a funzionare ma riapparirebbero i deprecation warning. Nessun impatto funzionale.

## Follow-up pianificato

- **Post 2026-06-02** (Node 24 forced default): rimuovere l'env var \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24\` perche' diventera' default implicito
- **Post 2026-09-16** (Node 20 rimosso): verificare che nessun altro script interno dipenda da Node 20

## Stato piano cleanup workflow

- Fase 1 (#1391): rimozione 6 stale/redundant → ✅ MERGED
- Fase 2 (#1392): fix daily-tracker + rimozione 3 broken → ✅ MERGED
- **Fase 3 (QUESTA PR): Node 22 + FORCE_JAVASCRIPT_ACTIONS_TO_NODE24**
- Fase 4 (futura): consolidazione data-quality + validate_traits
- Fase 5 (futura): fix 10 issue umane #1338..#1348

## Test plan

- [x] Tutti i 19 workflow parsano YAML correttamente
- [x] Prettier verde
- [x] Node version bumped nei 9 workflow con setup-node custom
- [x] Env var presente in tutti i 19 workflow
- [x] Zero bump di versione actions (niente rischio regressione)
- [x] CLAUDE.md Node 22.19.0 recommended → match CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)