### PR TITLE
chore(cleanup): quick wins bundle — triage reports + gitignore housekeeping (#1338, #1345, #1347)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,13 @@ reports/status.json
 # Playtest session event streams raw (rigenerati da ogni run, non servono in VCS)
 # I report analitici (.md) restano tracciati.
 logs/session_*.json
+
+# Backup spurious dei tool ACL (vedi #1347)
+.git_acl_backup_*.txt
+
+# Backup file dei dataset (creati da test runs, vedi #1341)
+*.bak
+data/flow-shell/*.bak
+
+# Setup backlog logs (rigenerati da scripts/setup_*.sh, vedi #1345)
+reports/setup_backlog_*.log

--- a/docs/archive/historical-snapshots/2026-04-16_reports_cleanup/02A_validator_rerun.md
+++ b/docs/archive/historical-snapshots/2026-04-16_reports_cleanup/02A_validator_rerun.md
@@ -8,6 +8,7 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # 02A validator rerun (report-only)
 
 - **Modalità**: consultiva, nessuna modifica ai dataset.

--- a/docs/archive/historical-snapshots/2026-04-16_reports_cleanup/memo_verifiche_2026-09-14.md
+++ b/docs/archive/historical-snapshots/2026-04-16_reports_cleanup/memo_verifiche_2026-09-14.md
@@ -8,25 +8,30 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # Memo sintetico – Verifiche e rischi aperti (2026-09-14)
 
 ## Esiti verifiche
+
 - **Redirect smoke staging (2026-09-14)**: ultimo run `reports/redirects/redirect-smoke-staging.json` in **ERROR** per host `http://localhost:8000` non raggiungibile (Connection refused). Gate 03B bloccato; 03A resta pronto. Ticket correlati: #1204/#1205/#1206, **[TKT-03B-001]**. (rif. log 2026-09-14)
 - **Readiness 01B/01C**: checkpoint 2025-11-30 conferma freeze documentale chiuso e attività in modalità report-only sui branch dedicati con ticket **[TKT-01B-001/002]**, **[TKT-01C-001/002]**; nessun nuovo drop rilevato. (rif. `reports/readiness_01B01C_status.md`)
 - **Pipeline 02A→03A→03B (simulazione)**: runbook aggiornato conferma sequenza seriale con validator 02A in report-only e log obbligatori per freeze/sblocco; preparazioni parallele consentite solo in draft. (rif. `reports/pipeline_simulation.md`)
 - **Orchestrator tuning**: configurazione rivista (poolSize 6, timeout 90s, retry 1) con piano di test k6 pronto ma non eseguito in questo ambiente. (rif. `reports/orchestrator_load_review.md`)
 
 ## Rischi aperti / blocchi
+
 - **Connettività staging**: smoke redirect in errore finché l’host `http://localhost:8000` non è ripristinato; impedisce lo sblocco dei gate 03B e la chiusura del freeze 03A/03B.
 - **Dipendenza approvazione Master DD**: ogni passo di freeze/merge richiede firma Master DD; le attività restano in report-only fino al via libera.
 - **Test di carico orchestrator non eseguiti**: necessario eseguirli in ambiente con backend attivo per validare il tuning.
 
 ## Comandi/validatori da lanciare (report-only)
+
 - **Rerun smoke redirect staging** (dev-tooling, report-only) appena il listener è attivo: `python scripts/redirect_smoke_test.py --host http://localhost:8000 --environment staging --output reports/redirects/redirect-smoke-staging.json` (allegare al ticket #1204/#1206 e loggare su `logs/agent_activity.md`).
 - **Validator 02A** su `patch/03A-core-derived` (report-only) prima di qualsiasi merge o riapertura freeze: eseguire schema-only, trait audit, trait style; loggare con ID `TKT-02A-VALIDATOR` come da pipeline.
 - **Freeze/rollback readiness**: se si apre o riconferma il freeze 3→4, registrare snapshot/backup e approvazione Master DD con il template di log riportato in `reports/pipeline_simulation.md`.
 - **Test di carico orchestrator** (solo in ambiente idoneo): `BASE_URL=http://<host>:3333 k6 run tests/load/orchestrator-load.k6.js` con soglie p95 <90s per generation e <10s per validators; risultato da riportare in modalità report-only.
 
 ## Condivisione e approvazioni
+
 - **Owners**: archivist (log/memo), dev-tooling (smoke redirect & validator 02A), coordinator (freeze/sblocco), Master DD (approvazioni). Coinvolgere anche backups-oncall per snapshot/rollback quando si riattiva il freeze.
 - **Azione richiesta**: condividere il presente memo con gli owner sopra per raccogliere approvazioni e confermare l’esecuzione dei comandi in report-only prima di qualsiasi rollout.

--- a/docs/archive/historical-snapshots/2026-04-16_reports_cleanup/orchestrator_load_review.md
+++ b/docs/archive/historical-snapshots/2026-04-16_reports_cleanup/orchestrator_load_review.md
@@ -8,24 +8,29 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # Revisione configurazione orchestrator
 
 ## Contesto e stato attuale
+
 - File: `config/orchestrator.json`
 - Nuovi valori applicati: `poolSize: 6`, `requestTimeoutMs: 90000` (90s), `maxTaskRetries: 1`, heartbeat 5s.
 - Assunzioni sul carico: sistema gestisce richieste sugli endpoint `/api/v1/generation/*` e `/api/v1/validators/runtime` con picchi stimati di 8–12 richieste concorrenti (valore da confermare con metriche recenti). Il pool a 6 worker è allineato a un host con risorse CPU adeguate; in ambienti più stretti si può ridurre a 4–6.
 
 ## Valutazione
+
 - `poolSize: 2` era adeguato solo per 2–3 richieste simultanee; con 8–12 concorrenti creava coda e latenza elevata. Il nuovo valore aumenta il parallelismo mantenendo margine di sicurezza.
 - `requestTimeoutMs: 120000` offriva ampia tolleranza, ma poteva mascherare hang. Il nuovo limite a 90s resta sopra i tempi medi di inferenza (45–60s) ma libera più rapidamente gli slot bloccati.
 - `maxTaskRetries: 1` limita l’impatto di ripetizioni eccessive; mantenerlo se gli errori sono transienti rari.
 
 ## Raccomandazioni
+
 - Impostare `poolSize` tra **6 e 8** se il target è 8–12 richieste concorrenti e l’host dispone di risorse CPU adeguate. Ridurre a 4–6 se la CPU è limitata o se i job sono particolarmente pesanti (configurazione attuale: 6 worker).
 - Ridurre `requestTimeoutMs` a **60000–90000 ms** per individuare più rapidamente i job bloccati, mantenendo margine per inferenze pesanti. Tenere 120s solo per modelli che superano stabilmente i 90s (configurazione attuale: 90s).
 - Monitorare la saturazione: se la coda rimane lunga a pool aumentato, valutare scale-out (più istanze orchestrator) oltre al tuning locale.
 
 ## Piano di test di carico
+
 Obiettivo: validare la nuova combinazione di `poolSize` e `requestTimeoutMs` sugli endpoint critici.
 
 1. **Script k6**: `tests/load/orchestrator-load.k6.js` con due scenari paralleli:
@@ -38,5 +43,6 @@ Obiettivo: validare la nuova combinazione di `poolSize` e `requestTimeoutMs` sug
 5. **Criteri di successo**: latenza p95 entro SLO, zero timeout per validator, retry non superiore a 1%.
 
 ## Risultati e note
+
 - Esecuzione non effettuata in questo ambiente (mancano dipendenze k6 e backend attivo). Lo script è pronto per essere lanciato dove sono disponibili backend e risorse.
 - Limiti previsti: se l'host dispone di meno core, ridurre `poolSize` a 4–5 per evitare saturazione CPU; mantenere `requestTimeoutMs` a 90s salvo workload eccezionalmente lunghi.

--- a/docs/archive/historical-snapshots/2026-04-16_reports_cleanup/pipeline_simulation.md
+++ b/docs/archive/historical-snapshots/2026-04-16_reports_cleanup/pipeline_simulation.md
@@ -8,32 +8,34 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # Pipeline 02A→Freeze→03A→Transizione→03B→Sblocco
 
 Questa sintesi documenta la sequenza richiesta per PIPELINE_SIMULATOR, la variante ottimizzata con PIPELINE_OPTIMIZER e il piano batch/gate di PIPELINE_EXECUTOR. Le indicazioni rispettano la modalità report-only dove previsto e mantengono i gate serializzati per le approvazioni Master DD.
 
 ## PIPELINE_SIMULATOR (strict-mode, step 1→6)
-1. **02A — validator report-only su `patch/03A-core-derived`**  
-   - Esegui schema-only, trait audit e style audit.  
-   - Registra log locale con ID `TKT-02A-VALIDATOR`, includendo whitelist temporanee (se servono) e archiviando output temporanei.  
-   - Dipendenze: branch disponibile.  
+
+1. **02A — validator report-only su `patch/03A-core-derived`**
+   - Esegui schema-only, trait audit e style audit.
+   - Registra log locale con ID `TKT-02A-VALIDATOR`, includendo whitelist temporanee (se servono) e archiviando output temporanei.
+   - Dipendenze: branch disponibile.
    - Rischio: medio (difformità schema).
 
-2. **Freeze 3→4 — apertura/riconferma**  
-   - Crea log del freeze con ID/owner/branch/file toccati/rischi/ticket/comandi.  
-   - Registra approvazione Master DD, esegui snapshot/backup e tracciali.  
-   - Dipendenze: report 02A a supporto.  
+2. **Freeze 3→4 — apertura/riconferma**
+   - Crea log del freeze con ID/owner/branch/file toccati/rischi/ticket/comandi.
+   - Registra approvazione Master DD, esegui snapshot/backup e tracciali.
+   - Dipendenze: report 02A a supporto.
    - Rischio: medio-alto (blocco release).
 
-3. **03A — patch core/derived**  
-   - Applica patch minime, produci changelog e pacchetto di rollback legato allo snapshot.  
-   - Richiedi approvazione Master DD per il merge.  
-   - Dipendenze: freeze attivo, snapshot registrato, esito 02A.  
+3. **03A — patch core/derived**
+   - Applica patch minime, produci changelog e pacchetto di rollback legato allo snapshot.
+   - Richiedi approvazione Master DD per il merge.
+   - Dipendenze: freeze attivo, snapshot registrato, esito 02A.
    - Rischio: medio (alterazione dataset core/derived).
 
-4. **Transizione verso 03B**  
-   - Checkpoint con backup/redirect pronti, piano di switch documentato.  
-   - Conferma superamento gate di uscita 03A e approvazione Master DD.  
+4. **Transizione verso 03B**
+   - Checkpoint con backup/redirect pronti, piano di switch documentato.
+   - Conferma superamento gate di uscita 03A e approvazione Master DD.
    - Rischio: basso-medio.
 
 5. **03B — cleanup + redirect**
@@ -42,26 +44,28 @@ Questa sintesi documenta la sequenza richiesta per PIPELINE_SIMULATOR, la varian
    - Dipendenze: transizione ok, backup/redirect preparati.
    - Rischio: medio (disallineamento redirect).
 
-6. **Sblocco freeze**  
-   - Log di chiusura con riferimenti ad approvazione Master DD e smoke 02A positivo.  
-   - Aggiorna README solo dopo il log, quindi trigger di riavvio ciclo.  
-   - Dipendenze: smoke 02A ok e approvazione finale.  
+6. **Sblocco freeze**
+   - Log di chiusura con riferimenti ad approvazione Master DD e smoke 02A positivo.
+   - Aggiorna README solo dopo il log, quindi trigger di riavvio ciclo.
+   - Dipendenze: smoke 02A ok e approvazione finale.
    - Rischio: basso.
 
 **Output attesi**: report 02A (+ whitelist), log freeze + backup/snapshot, patch 03A con changelog/rollback, checkpoint transizione, report cleanup/redirect + smoke 02A, log sblocco freeze.
 
 ## PIPELINE_OPTIMIZER (preparazioni in parallelo)
+
 - **Step 1: 02A report-only** su `patch/03A-core-derived` come baseline qualità.
 - **Step 2 in parallelo con 02A**: raccogli approvazioni Master DD in bozza; predisponi snapshot/backup core/derived in staging (non attivati); prepara redirect plan.
 - **Step 3: Freeze 3→4** con attivazione backup e log ufficiale.
-- **Step 4: 03A patch** con changelog/rollback legati allo snapshot; richiedi approvazione Master DD per il merge.  
-- **Step 5: Transizione verso 03B** (verifica pre-redirect, backup confermati).  
-- **Step 6: 03B cleanup/redirect** su `patch/03B-incoming-cleanup` + smoke 02A post-merge in report-only.  
+- **Step 4: 03A patch** con changelog/rollback legati allo snapshot; richiedi approvazione Master DD per il merge.
+- **Step 5: Transizione verso 03B** (verifica pre-redirect, backup confermati).
+- **Step 6: 03B cleanup/redirect** su `patch/03B-incoming-cleanup` + smoke 02A post-merge in report-only.
 - **Step 7: Sblocco freeze** dopo smoke 02A ok e approvazione finale Master DD.
 
 **Parallelo consentito**: solo preparazioni (approvazioni draft, backup in staging, redirect plan). Tutti i gate restano serializzati. Non attivare backup prima del freeze ufficiale; il validator 02A resta report-only finché non arriva il via libera; collega patch 03A allo snapshot e cleanup 03B al backup incoming/redirect.
 
 ### Runbook operativo (variante ottimizzata)
+
 Esegui i punti nell'ordine indicato, usando in parallelo solo le preparazioni del punto 2. Ogni step richiede log con ID/owner/branch/file/rischi/ticket/comandi e, dove indicato, approvazione Master DD.
 
 1. **Kickoff 02A (baseline qualità)** – Avvia 02A in report-only su `patch/03A-core-derived`; salva output temporanei, whitelist e log `TKT-02A-VALIDATOR`.
@@ -73,6 +77,7 @@ Esegui i punti nell'ordine indicato, usando in parallelo solo le preparazioni de
 7. **Sblocco e riavvio** – Sblocca il freeze dopo smoke 02A positivo e approvazione finale Master DD; aggiorna README solo dopo il log; attiva il trigger di riavvio (vedi sezione dedicata) e riallinea snapshot/backup per il ciclo successivo.
 
 ## PIPELINE_EXECUTOR (batch & gate)
+
 - **Batch 1–2**: rerun 02A (schema-only/trait/style) in report-only su `patch/03A-core-derived`; salva output temporanei, log ID `TKT-02A-VALIDATOR`, documenta whitelist. Apri o riconferma il freeze 3→4 con approvazione Master DD e snapshot/backup registrati (log completo di ID/owner/branch/file/rischi/ticket/comandi).
 - **Batch 3**: applica patch minime 03A sullo stesso branch; genera changelog e pacchetto rollback legati allo snapshot; riesegui 02A in report-only; invia richiesta di approvazione Master DD per il merge.
 - **Batch 4–5**: checkpoint transizione verso 03B (backup/redirect pronti, gate 03A confermati); esegui cleanup su `patch/03B-incoming-cleanup`, verifica redirect e backup incoming, quindi smoke 02A post-merge in report-only con log esito.
@@ -81,17 +86,19 @@ Esegui i punti nell'ordine indicato, usando in parallelo solo le preparazioni de
 **Quality/Safety**: log obbligatorio prima/dopo ogni micro-step; validator sempre in report-only finché non arriva il via libera; documentare whitelist temporanee 02A; associare patch 03A a snapshot core/derived e 03B a backup incoming/redirect; evitare compressione dei controlli; includere nel log il report di redirect 03B e il log di chiusura freeze con approvazione Master DD.
 
 ## Sequenza operativa pronta all’uso (come procedere)
+
 Usa questa checklist per eseguire subito i passi consigliati. Tutti i punti prevedono log con ID/owner/branch/file/rischi/ticket/comandi.
 
-1) **Rerun 02A in report-only** su `patch/03A-core-derived` (schema-only, trait audit, style). Salva output temporanei, annota whitelist e collega il log a `TKT-02A-VALIDATOR`.
-2) **Apri o riconferma il freeze 3→4**: registra approvazione Master DD, attiva snapshot/backup e archivia il log di freeze.
-3) **Applica le patch 03A minime** con changelog + rollback legati allo snapshot; riesegui 02A in report-only; invia richiesta di approvazione Master DD per il merge.
-4) **Esegui il checkpoint di transizione**: verifica che backup/redirect siano pronti, conferma il superamento dei gate di uscita 03A e documenta il piano di switch.
-5) **Completa 03B** su `patch/03B-incoming-cleanup`: usa la checklist (backup incoming aggiornato, redirect/link verificati, istruzioni di ripristino) e chiudi con smoke 02A post-merge in report-only, allegando il report di redirect e log dell’esito.
-6) **Sblocca il freeze** solo dopo smoke 02A positivo e approvazione Master DD registrata; aggiorna README dopo il log e attiva il trigger di riavvio.
-7) **Riavvia la simulazione** sull’intera sequenza (02A→freeze→03A→transizione→03B→sblocco) aggiornando branch/artefatti se le baseline sono cambiate. Allinea la whitelist 02A, ricollega patch 03A allo snapshot aggiornato e 03B al backup/redirect rivisti.
+1. **Rerun 02A in report-only** su `patch/03A-core-derived` (schema-only, trait audit, style). Salva output temporanei, annota whitelist e collega il log a `TKT-02A-VALIDATOR`.
+2. **Apri o riconferma il freeze 3→4**: registra approvazione Master DD, attiva snapshot/backup e archivia il log di freeze.
+3. **Applica le patch 03A minime** con changelog + rollback legati allo snapshot; riesegui 02A in report-only; invia richiesta di approvazione Master DD per il merge.
+4. **Esegui il checkpoint di transizione**: verifica che backup/redirect siano pronti, conferma il superamento dei gate di uscita 03A e documenta il piano di switch.
+5. **Completa 03B** su `patch/03B-incoming-cleanup`: usa la checklist (backup incoming aggiornato, redirect/link verificati, istruzioni di ripristino) e chiudi con smoke 02A post-merge in report-only, allegando il report di redirect e log dell’esito.
+6. **Sblocca il freeze** solo dopo smoke 02A positivo e approvazione Master DD registrata; aggiorna README dopo il log e attiva il trigger di riavvio.
+7. **Riavvia la simulazione** sull’intera sequenza (02A→freeze→03A→transizione→03B→sblocco) aggiornando branch/artefatti se le baseline sono cambiate. Allinea la whitelist 02A, ricollega patch 03A allo snapshot aggiornato e 03B al backup/redirect rivisti.
 
 ## Action plan ottimizzato (parallelo vs seriale)
+
 Usa questa griglia per distinguere cosa può correre in parallelo e cosa resta serializzato. Ogni blocco richiede log obbligatori.
 
 - **Parallelo ammesso (solo preparazioni)**
@@ -107,19 +114,22 @@ Usa questa griglia per distinguere cosa può correre in parallelo e cosa resta s
   - Sblocco freeze: chiusura log, approvazione finale Master DD, trigger riavvio.
 
 ## Tabella gate rapida
-| Step | Owner | Modalità | Input chiave | Output richiesto |
-| --- | --- | --- | --- | --- |
-| 02A | Dev-tooling | Report-only | Branch `patch/03A-core-derived`, whitelist temporanee (se servono) | Log `TKT-02A-VALIDATOR`, report schema/trait/style, output temporanei salvati |
-| Freeze 3→4 | Coordinator | Gate | Report 02A, approvazione Master DD | Log freeze con ID/owner/branch/file/rischi/ticket/comandi, backup/snapshot attivati e tracciati |
-| 03A patch | Coordinator + Dev-tooling | Gate | Freeze attivo, snapshot registrato | Patch minime + changelog + pacchetto rollback, rerun 02A, richiesta approvazione Master DD merge |
-| Transizione | Coordinator | Gate | Approvazione Master DD su 03A | Checkpoint con backup/redirect pronti, piano di switch confermato |
-| 03B cleanup | Coordinator + Dev-tooling | Gate | Backup/redirect pronti, branch `patch/03B-incoming-cleanup` | Cleanup+redirect verificati, backup incoming aggiornato, smoke 02A post-merge (report-only) loggato |
-| Sblocco | Coordinator | Gate | Smoke 02A ok, approvazione Master DD finale | Log chiusura freeze, README aggiornato dopo il log, trigger riavvio ciclo |
+
+| Step        | Owner                     | Modalità    | Input chiave                                                       | Output richiesto                                                                                    |
+| ----------- | ------------------------- | ----------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| 02A         | Dev-tooling               | Report-only | Branch `patch/03A-core-derived`, whitelist temporanee (se servono) | Log `TKT-02A-VALIDATOR`, report schema/trait/style, output temporanei salvati                       |
+| Freeze 3→4  | Coordinator               | Gate        | Report 02A, approvazione Master DD                                 | Log freeze con ID/owner/branch/file/rischi/ticket/comandi, backup/snapshot attivati e tracciati     |
+| 03A patch   | Coordinator + Dev-tooling | Gate        | Freeze attivo, snapshot registrato                                 | Patch minime + changelog + pacchetto rollback, rerun 02A, richiesta approvazione Master DD merge    |
+| Transizione | Coordinator               | Gate        | Approvazione Master DD su 03A                                      | Checkpoint con backup/redirect pronti, piano di switch confermato                                   |
+| 03B cleanup | Coordinator + Dev-tooling | Gate        | Backup/redirect pronti, branch `patch/03B-incoming-cleanup`        | Cleanup+redirect verificati, backup incoming aggiornato, smoke 02A post-merge (report-only) loggato |
+| Sblocco     | Coordinator               | Gate        | Smoke 02A ok, approvazione Master DD finale                        | Log chiusura freeze, README aggiornato dopo il log, trigger riavvio ciclo                           |
 
 ## Riavvio simulazione post-sblocco
+
 Dopo lo sblocco e la registrazione dell’approvazione finale, riavvia PIPELINE_SIMULATOR sulla sequenza 02A→freeze→03A→transizione→03B→sblocco. Aggiorna branch e artefatti di backup se le baseline sono cambiate per mantenere la copertura del nuovo ciclo.
 
 ## Prossimo passo (ottimizzato) – esecuzione immediata
+
 Usa questa mini-checklist per avviare subito il ciclo ottimizzato senza perdere i parallelismi consentiti:
 
 1. **Kickoff 02A** – Lancia 02A in report-only su `patch/03A-core-derived`, salva output temporanei e whitelist, collega il log a `TKT-02A-VALIDATOR`.
@@ -130,6 +140,7 @@ Usa questa mini-checklist per avviare subito il ciclo ottimizzato senza perdere 
 6. **Sblocco + trigger** – Sblocca il freeze solo con smoke 02A positivo e approvazione finale; aggiorna README dopo il log e riavvia la sequenza con i nuovi snapshot/backup.
 
 ### Template di log consigliato (per ogni step)
+
 - **ID step / owner / branch**
 - **Comandi eseguiti** (con riferimenti a script o job)
 - **Rischi e mitigazioni**
@@ -140,10 +151,12 @@ Usa questa mini-checklist per avviare subito il ciclo ottimizzato senza perdere 
 - **Report allegati**: report redirect 03B (esito link/redirect e istruzioni di ripristino) e log di chiusura freeze con approvazione Master DD.
 
 ## Owners raccomandati e formato report archiviati in `logs/`
+
 - **Owners**: archivist (responsabile primaria) per checklist, log e report; asset-prep come co-owner per la verifica di redirect/link.
 - **Formato report**: archivia in `logs/` file Markdown nominati `LOG_ID-YYYYMMDD-03B-redirect.md` con sezioni `Contesto`, `Checklist 03B` (backup incoming, redirect/link, istruzioni ripristino), `Smoke 02A` (esito e log collegati), `Approvazioni` (inclusa chiusura freeze con Master DD) e `Follow-up`.
 
 ## Stato rispetto al piano iniziale
+
 Questa sezione riassume dove siamo e il prossimo passo da eseguire, in coerenza con le ottimizzazioni concordate:
 
 - **Documentazione**: pipeline simulatore/ottimizzatore/executor, checklist operativa e template di log già definiti in questo file.
@@ -151,6 +164,7 @@ Questa sezione riassume dove siamo e il prossimo passo da eseguire, in coerenza 
 - **Prossima azione operativa**: avviare il kickoff **02A in report-only** su `patch/03A-core-derived`, raccogliendo log `TKT-02A-VALIDATOR` e mantenendo in parallelo le preparazioni (approvazioni draft, snapshot/backup in staging, redirect plan) prima di procedere al freeze ufficiale.
 
 ## Pre-flight (prima del kickoff 02A)
+
 Esegui questa checklist prima di avviare il ciclo ottimizzato:
 
 1. **Branch e ticket** – Verifica che `patch/03A-core-derived` e `patch/03B-incoming-cleanup` siano aggiornati; conferma il riferimento a `TKT-02A-VALIDATOR` nel log di run.
@@ -161,6 +175,7 @@ Esegui questa checklist prima di avviare il ciclo ottimizzato:
 6. **Log book** – Prepara il template di log per ogni step con campo whitelist 02A e sezione follow-up (per il trigger di riavvio post-sblocco).
 
 ## Pacchetto di audit e riavvio post-sblocco
+
 Per chiudere il ciclo e riavviare la simulazione:
 
 1. **Audit bundle** – Archivia in un pacchetto unico: log freeze/sblocco, report 02A (run iniziale e post-merge), changelog+rollback 03A legati allo snapshot, backup/redirect instructions 03B, esito smoke 02A post-merge.
@@ -168,6 +183,7 @@ Per chiudere il ciclo e riavviare la simulazione:
 3. **Trigger riavvio** – Riavvia PIPELINE_SIMULATOR sulla sequenza 02A→freeze→03A→transizione→03B→sblocco usando le baseline rinnovate; azzera o rinnova la whitelist 02A se cambiata.
 
 ## Stato esecuzione corrente (post-report)
+
 Usa questo tracker per verificare cosa è stato completato e cosa resta da fare dopo l'ultimo ciclo dichiarato:
 
 - ✅ Kickoff 02A in report-only su `patch/03A-core-derived` con log `TKT-02A-VALIDATOR` e whitelist salvate.
@@ -179,11 +195,13 @@ Usa questo tracker per verificare cosa è stato completato e cosa resta da fare 
 - ✅ Pacchetto di audit compilato con log freeze/sblocco, report 02A, changelog+rollback 03A, istruzioni backup/redirect 03B e esito smoke 02A.
 
 ### Prossimi passi raccomandati
+
 1. **Riallinea le baseline** – Se gli artefatti (snapshot/backup/redirect) sono cambiati dopo l'ultimo giro, aggiorna gli ID nelle checklist e rinnova la whitelist 02A per il prossimo ciclo.
 2. **Rilancia il simulatore** – Esegui nuovamente la sequenza 02A→freeze→03A→transizione→03B→sblocco usando le baseline aggiornate per verificare che i log e le approvazioni siano coerenti con il nuovo stato.
 3. **Verifica QA post-riavvio** – Controlla che i log di riavvio includano ID/timestamp coerenti e che il pacchetto di audit sia archiviato con i nuovi riferimenti prima di chiudere il ciclo.
 
 ## Sequenza di riavvio pronta all'uso (kickoff immediato)
+
 Usa questa checklist per **avviare ora** il nuovo ciclo dopo il pacchetto di audit:
 
 1. **Allinea artefatti** – Aggiorna ID di snapshot/backup/redirect nel log book e nella whitelist 02A; conferma che i branch `patch/03A-core-derived` e `patch/03B-incoming-cleanup` puntino alle baseline corrette.
@@ -196,6 +214,7 @@ Usa questa checklist per **avviare ora** il nuovo ciclo dopo il pacchetto di aud
 8. **Audit rapido** – Aggiorna il pacchetto di audit con log/artefatti del nuovo giro e archivialo prima di passare al ciclo successivo.
 
 ## Script pronto all'uso (bash)
+
 Per avviare subito il ciclo, usa il wrapper di radice `./run_pipeline_cycle.sh` (richiama automaticamente `scripts/run_pipeline_cycle.sh`). Mantiene i validator in **report-only**, registra whitelist e approvazioni e crea il bundle di audit finale.
 
 Esempi d'uso:
@@ -219,6 +238,7 @@ BRANCH_03A=my/branch-03A BRANCH_03B=my/branch-03B LOG_DIR=custom_logs \
 ```
 
 Suggerimenti operativi:
+
 - `./scripts/run_pipeline_cycle.sh --help` mostra i parametri disponibili (branch, LOG_ID, LOG_DIR, patch 03A, `--cycles`) senza eseguire la pipeline.
 - Lo script richiede i binari `git`, `npm`, `node` e `tar`, si porta automaticamente nella radice del repo Git, registra il branch corrente per ripristinarlo a fine esecuzione e crea la directory `logs` (o quella indicata da `LOG_DIR`).
 - Se il branch richiesto per 03A/03B non esiste localmente, il runner torna sul branch corrente e logga il fallback nel file di stato, così puoi comunque eseguire la pipeline senza interromperla. Con `--prepare-only` puoi risolvere branch/log/configurazione e popolare il file di stato senza lanciare i gate della pipeline.

--- a/docs/archive/historical-snapshots/2026-04-16_reports_cleanup/readiness_01B01C_status.md
+++ b/docs/archive/historical-snapshots/2026-04-16_reports_cleanup/readiness_01B01C_status.md
@@ -8,27 +8,33 @@ source_of_truth: false
 language: it-en
 review_cycle_days: 14
 ---
+
 # Readiness 01B/01C – Checkpoint 2025-11-30T23:12Z
 
 ## Scopo
+
 Verificare stato di readiness per i gate 01B (core/derived) e 01C (tooling/CI), confermando freeze documentale, ticket e owner con approvazione Master DD prima di procedere con pipeline/patchset successivi.
 
 ## Esito verifica
+
 - Finestra freeze documentale di riferimento: **2026-07-08T09:00Z → 2026-07-15T18:00Z** su `incoming/**` e `docs/incoming/**`, confermata come baseline readiness con approvazione Master DD (report-only).
 - Owner confermati: **01B** species-curator + trait-curator (supporto coordinator), **01C** dev-tooling (supporto balancer/coordinator). Operatività in **modalità report-only** su `patch/01B-core-derived-matrix` e `patch/01C-tooling-ci-catalog`.
 - Ticket attivi: **[TKT-01B-001]**, **[TKT-01B-002]**, **[TKT-01C-001]**, **[TKT-01C-002]** (nessuna variazione di scope/owner). Logging richiesto in STRICT MODE su ogni batch.
 - Nessun nuovo drop in `_holding` rilevato; catalogo 01A e README risultano sincronizzati con gap list chiusa e handoff 01B/01C.
 
 ### Aggiornamento readiness 2026-10-12T1200Z
+
 - Disponibilità confermata: **archivist lead 01A**, **species-curator + trait-curator on-call 01B**, **dev-tooling on-call 01C** con **coordinator/balancer** in backup consultivo. Copertura mantenuta in report-only sui branch `patch/01A-report-only`, `patch/01B-core-derived-matrix`, `patch/01C-tooling-ci-catalog`.
 - Ticket tracciati per il ciclo 01B/01C: **TKT-01B-001**, **TKT-01B-002**, **TKT-01C-001**, **TKT-01C-002** (nessuna variazione di scope/owner). ID di riferimento readiness/log: `01B01C-READINESS-2026-10-12T1200Z` su `logs/agent_activity.md`.
 - Inventario CI/script collegato (report-only) aggiornato in `reports/audit/readiness-01c-ci-inventory.md` con link ai branch dedicati.
 
 ## Finestre e approvazioni
+
 - **Freeze documentale (incoming/docs/incoming):** attivazione 2026-07-08T09:00Z, chiusura 2026-07-15T18:00Z; approvatore Master DD. Nessuna estensione richiesta.
 - **Autorizzazione pipeline/patchset successivi:** Master DD conferma via libera alla prosecuzione di pipeline/patchset post-readiness 01B/01C, mantenendo l’obbligo di loggare ogni batch e owner su `logs/agent_activity.md`.
 
 ## Azioni successive
+
 - Continuare il lavoro 01B/01C in report-only sui branch dedicati, loggando ogni batch/ticket.
 - Mantenere l’allineamento tra `docs/planning/REF_INCOMING_CATALOG.md`, `incoming/README.md`, `docs/incoming/README.md` e il presente checkpoint.
 - Rieseguire un controllo di readiness prima dell’eventuale apertura di nuove finestre di freeze o di upgrade a modalità enforcing.

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -6121,7 +6121,7 @@
       "track": "migrated"
     },
     {
-      "path": "reports/02A_validator_rerun.md",
+      "path": "docs/archive/historical-snapshots/2026-04-16_reports_cleanup/02A_validator_rerun.md",
       "title": "02A validator rerun (report-only)",
       "doc_status": "generated",
       "doc_owner": "platform-docs",
@@ -6134,7 +6134,7 @@
       "track": "migrated"
     },
     {
-      "path": "reports/memo_verifiche_2026-09-14.md",
+      "path": "docs/archive/historical-snapshots/2026-04-16_reports_cleanup/memo_verifiche_2026-09-14.md",
       "title": "Memo sintetico – Verifiche e rischi aperti (2026-09-14)",
       "doc_status": "generated",
       "doc_owner": "platform-docs",
@@ -6147,7 +6147,7 @@
       "track": "migrated"
     },
     {
-      "path": "reports/orchestrator_load_review.md",
+      "path": "docs/archive/historical-snapshots/2026-04-16_reports_cleanup/orchestrator_load_review.md",
       "title": "Revisione configurazione orchestrator",
       "doc_status": "generated",
       "doc_owner": "platform-docs",
@@ -6160,7 +6160,7 @@
       "track": "migrated"
     },
     {
-      "path": "reports/pipeline_simulation.md",
+      "path": "docs/archive/historical-snapshots/2026-04-16_reports_cleanup/pipeline_simulation.md",
       "title": "Pipeline 02A→Freeze→03A→Transizione→03B→Sblocco",
       "doc_status": "generated",
       "doc_owner": "platform-docs",
@@ -6186,7 +6186,7 @@
       "track": "migrated"
     },
     {
-      "path": "reports/readiness_01B01C_status.md",
+      "path": "docs/archive/historical-snapshots/2026-04-16_reports_cleanup/readiness_01B01C_status.md",
       "title": "Readiness 01B/01C – Checkpoint 2025-11-30T23:12Z",
       "doc_status": "generated",
       "doc_owner": "platform-docs",

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-15T23:11:32+00:00",
+  "generated_at": "2026-04-15T23:28:19+00:00",
   "summary": {
     "total": 0,
     "errors": 0,

--- a/reports/setup_backlog_20250624_000000.log
+++ b/reports/setup_backlog_20250624_000000.log
@@ -1,1 +1,0 @@
-Dry-run completato: configurazione valida, nessuna chiamata GitHub eseguita.

--- a/reports/setup_backlog_20251127_201830.log
+++ b/reports/setup_backlog_20251127_201830.log
@@ -1,5 +1,0 @@
-GitHub API error 401: {
-  "message": "Bad credentials",
-  "documentation_url": "https://docs.github.com/rest",
-  "status": "401"
-}


### PR DESCRIPTION
## Summary

Chiude 3 issue umane in un'unica PR zero-rischio: #1338 (verified already fixed), #1345 (reports triage), #1347 (gitignore housekeeping).

## Issues

### #1338 — glossary.json + index.json Unicode replacement char

**Verificato 2026-04-16**: scan repo-wide per U+FFFD ritorna **0 occorrenze** in tutti i file JSON (esclusi .git e node_modules). Gia' risolto in sessione precedente (docs restructuring 2026-04-14 o fix encoding worker.py).

**Azione**: issue chiusa come "already fixed" via gh CLI con comment di verifica. Nessuna modifica ai file dataset richiesta in questa PR.

### #1345 — reports/ pseudo-archive triage

**5 file markdown** spostati da \`reports/\` (root) a \`docs/archive/historical-snapshots/2026-04-16_reports_cleanup/\`:
- \`02A_validator_rerun.md\`
- \`memo_verifiche_2026-09-14.md\` (nota: data futura, archivio per preservazione storica)
- \`orchestrator_load_review.md\`
- \`pipeline_simulation.md\`
- \`readiness_01B01C_status.md\`

**2 setup backlog log** eliminati (non sono output di script pubblici, gitignorati per prevenire ri-accumulo):
- \`setup_backlog_20250624_000000.log\`
- \`setup_backlog_20251127_201830.log\`

**Governance**: 5 entry in \`docs/governance/docs_registry.json\` aggiornate ai nuovi path archivio. Zero drift post-move.

### #1347 — gitignore housekeeping

Aggiunti **3 pattern** nuovi a \`.gitignore\`:

\`\`\`
# Backup spurious dei tool ACL (vedi #1347)
.git_acl_backup_*.txt

# Backup file dei dataset (creati da test runs, vedi #1341)
*.bak
data/flow-shell/*.bak

# Setup backlog logs (rigenerati da scripts/setup_*.sh, vedi #1345)
reports/setup_backlog_*.log
\`\`\`

**Nota**: \`apps/backend/logs/\` era gia' gitignorato (linea 54).

## Validazione

- \`python tools/check_docs_governance.py --strict\` → **errors=0 warnings=0**
- \`prettier --check docs/governance/docs_registry.json\` → verde
- \`prettier --write docs/archive/.../*.md\` → verde
- Scan \`U+FFFD\` repo-wide → 0 match

## Rollback

\`git revert <sha>\` ripristina:
- 5 file in \`reports/\` root (erano pseudo-archive)
- 2 log setup backlog
- 3 pattern gitignore
- 5 entry registry ai vecchi path

**Rollback NON consigliato**: la PR riorganizza senza perdere contenuto (archivio storico preservato) e rimuove noise tracker.

## Stato piano cleanup issue (9 da fixare, 1 deferred)

- **#1338** glossary/index unicode → ✅ QUESTA PR (already fixed)
- **#1345** reports/ triage → ✅ QUESTA PR
- **#1347** gitignore housekeeping → ✅ QUESTA PR
- #1339 atlas 500 → PR δ futura
- #1341 + #1342 test side-effects + autoclose → PR ε futura combinata
- #1343 dashboard removal → PR β futura
- #1346 + #1348 rename Trait Editor + husky DX → PR γ futura combinata
- #1344 incoming/ triage → deferred backlog

## Test plan

- [x] Governance strict verde (0 errors)
- [x] Prettier clean
- [x] Registry paths aggiornati
- [x] Unicode scan repo-wide verificato
- [x] File spostati preservando contenuto
- [x] Gitignore patterns testati

🤖 Generated with [Claude Code](https://claude.com/claude-code)