### PR TITLE
feat(combat): flip USE_ROUND_MODEL default to true (M15-M17, PR 7/N)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -69,10 +69,18 @@ const {
 } = require('../services/roundOrchestrator');
 
 // Feature flag: l'intera superficie round-based e' disabilitata se
-// USE_ROUND_MODEL !== 'true'. In quel caso ogni nuovo endpoint
-// ritorna 503. Di default e' false (comportamento legacy invariato).
+// M16 (ADR-2026-04-16): USE_ROUND_MODEL default flippato a true.
+// Il round-based combat model e' ora attivo per default. Per tornare
+// al sequential-turn model legacy, impostare USE_ROUND_MODEL=false
+// nell'environment. I test di equivalenza comportamentale (PR #1397,
+// M6-M14) verificano parita' strutturale tra i due flow.
+//
+// Per disattivare: USE_ROUND_MODEL=false npm run start:api
+// Per rollback completo: git revert i PR #1387-#1397 della serie
+//   feat/round-orchestrator-* + feat/turn-end-wrapper-*
 function isRoundModelEnabled() {
-  return String(process.env.USE_ROUND_MODEL || '').toLowerCase() === 'true';
+  const val = String(process.env.USE_ROUND_MODEL || 'true').toLowerCase();
+  return val !== 'false';
 }
 
 const GRID_SIZE = 6;

--- a/tests/api/sessionRoundEndpoints.test.js
+++ b/tests/api/sessionRoundEndpoints.test.js
@@ -64,7 +64,9 @@ async function startSession(app) {
 // Feature flag guard — 503 when off
 // ─────────────────────────────────────────────────────────────────
 
-test('round endpoints return 503 when USE_ROUND_MODEL is unset', async (t) => {
+test('round endpoints are ENABLED by default when USE_ROUND_MODEL is unset (M16 flip)', async (t) => {
+  // M16: default flippato a true. Endpoint round-based attivi quando
+  // USE_ROUND_MODEL e' unset (o vuoto). 503 solo con explicit 'false'.
   const restore = withRoundFlag('');
   t.after(restore);
   const { app, close } = createApp({ databasePath: null });
@@ -72,19 +74,20 @@ test('round endpoints return 503 when USE_ROUND_MODEL is unset', async (t) => {
     if (typeof close === 'function') await close().catch(() => {});
   });
 
+  // Endpoint attivi (non 503) — riceveranno 400 o 404 per session
+  // mancante, non 503 (flag non e' off).
   for (const path of [
     '/api/session/declare-intent',
     '/api/session/commit-round',
     '/api/session/resolve-round',
   ]) {
     const res = await request(app).post(path).send({ session_id: 'x' });
-    assert.equal(res.status, 503, `${path} should 503`);
-    assert.equal(res.body.error, 'round_model_disabled');
+    assert.notEqual(res.status, 503, `${path} should NOT be 503 with default flag`);
   }
   const clearRes = await request(app)
     .post('/api/session/clear-intent/p1')
     .send({ session_id: 'x' });
-  assert.equal(clearRes.status, 503);
+  assert.notEqual(clearRes.status, 503);
 });
 
 test('round endpoints return 503 when USE_ROUND_MODEL=false explicitly', async (t) => {


### PR DESCRIPTION
## Summary

Steps M15-M17 dell'ADR-2026-04-16. Flippa il default \`USE_ROUND_MODEL\` da \`false\` a \`true\`. Round-based combat model attivo per default.

**M15**: Client HTML (\`apps/backend/public/Evo-Tactics — Playtest.html\`) verificato — wrappers preservano legacy response shape (roll/mos/result/pt/damage_dealt/target_hp/ia_actions/state). Zero modifiche HTML necessarie.

**M16**: \`isRoundModelEnabled()\` default flippato. \`'false'\` esplicito per opt-out.

**M17**: Cleanup wrappers legacy deferred 1 mese (da ADR §rollback). Wrappers funzionano sia flag-on che flag-off.

## Change

\`\`\`diff
- return String(process.env.USE_ROUND_MODEL || '').toLowerCase() === 'true';
+ const val = String(process.env.USE_ROUND_MODEL || 'true').toLowerCase();
+ return val !== 'false';
\`\`\`

## Test update

\`sessionRoundEndpoints.test.js\`: test "503 when unset" → "ENABLED by default when unset (M16 flip)" — verifica endpoint attivi (not 503) quando env unset.

## Validation

- **162/162** regression verdi con default flipped (unset USE_ROUND_MODEL)
- Explicit \`USE_ROUND_MODEL=false\` tests still pass (503 behavior preserved)
- Governance 0 errors

## Rollback

- **Instant**: \`USE_ROUND_MODEL=false\` in env → 0 deploy
- **Git**: \`git revert <sha>\` → default false, test restored

## Migration complete

| M | Scope | PR | ✓ |
|---|---|---|:-:|
| M1-M3 | Foundation | #1387 | ✅ |
| M2 | Endpoints + flag | #1388 | ✅ |
| M4 | declareSistemaIntents | #1389 | ✅ |
| M5a | /action wrapper | #1390 | ✅ |
| M5b | /turn/end wrapper | #1395 | ✅ |
| M6-M14 | Equivalence tests | #1397 | CI |
| M15 | HTML verification | no-op | ✅ |
| **M16** | **Flip default** | **#1398** | **this** |
| M17 | Cleanup | deferred 1mo | 📋 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)