### PR TITLE
chore(combat+docs): backlog triage FD-IDs + timer planning phase

### DIFF
--- a/docs/combat/round-loop.md
+++ b/docs/combat/round-loop.md
@@ -423,10 +423,14 @@ Ricarica `ACTION_SPEED` dal filesystem (hot reload) e muta il dict modulo-level 
 - ✅ **Payload `overwatch`**: attacco opportunistico su `moved_adjacent`. Synthetic `attack` (flag `_is_overwatch=True`) del listener verso il mover. Anti-recursion attiva, non triggera su mover morto.
 - ✅ **Evento `healed` + action type `heal`**: nuovo branch `heal` nel resolver atomico (roll `heal_dice`, clamp a `hp_max`, log `healing_applied`). Orchestrator estende `SUPPORTED_REACTION_EVENTS` con `healed` e aggiunge injection post-heal. Predicates DSL esteso con field `healing`. Action speed `heal: -1`.
 
+- ✅ **Migrazione Node session engine**: ADR-2026-04-16 M1-M17 tutti completati. Round model default ON, legacy rimosso. session.js split in 4 moduli (851 LOC).
+- ✅ **Active effects trait (Fase 3)**: attack-triggered effects (#1408) + ability action type + buff system (#1409). 8 trait abilities live. `ability` rimosso da NOOP_ACTION_TYPES.
+- ✅ **Timer planning phase**: `planning_deadline_ms` + `planning_started_at` nello state. `is_planning_expired(state)` helper esportato. Enforcement lato caller (session engine Node).
+
 **Ancora aperti** (evoluzioni future):
 
-1. **Migrazione effettiva Node session engine**: portare `apps/backend/routes/session.js` al round model. ADR c'e', codice Node intoccato. Sprint dedicato di ~5 giornate.
-2. **Timer opzionale di planning phase**: `planning_deadline_ms` nello state. Enforcement del session engine Node, non del rules engine Python.
+1. **Ability per i restanti 22 trait**: solo 8 su 30 hanno active_effects. Balance pass + content expansion.
+2. **Node enforcement timer**: `setTimeout` in session engine che auto-committa quando `is_planning_expired()` ritorna True.
 
 ---
 

--- a/docs/planning/EVO_FINAL_DESIGN_BACKLOG_REGISTER.md
+++ b/docs/planning/EVO_FINAL_DESIGN_BACKLOG_REGISTER.md
@@ -69,19 +69,19 @@ Può essere usato per:
 
 ### EPIC C — Combat canon e resolver
 
-| Stato | Task                                         | Dettagli operativi                                                               |
-| ----- | -------------------------------------------- | -------------------------------------------------------------------------------- |
-| ☐     | FD-020 - Scrivere Combat Canon Spec          | Documento unico con formule, timing, side effect e non-scope.                    |
-| ☐     | FD-021 - Bloccare action types shipping      | `attack`, `move`, `defend`, `parry`, ability stub.                               |
-| ☐     | FD-022 - Bloccare status shipping            | `bleeding`, `fracture`, `disorient`, `rage`, `panic`.                            |
-| ☐     | FD-023 - Bloccare PT spend shipping          | `perforazione`, `spinta`, costi, limitazioni e timing.                           |
-| ☐     | FD-024 - Formalizzare timing begin_turn      | Tick status, decay e priorità effetti.                                           |
-| ☐     | FD-025 - Formalizzare ordine mitigazioni     | Armor, resistenze, parry, MoS, damage step.                                      |
-| ☐     | FD-026 - Esplicitare active_effects deferred | Mantenere NOOP come stato ufficiale fino a Fase 3+.                              |
-| ☐     | FD-027 - Verificare determinismo             | RNG namespacing, seed strategy e ripetibilità risultati.                         |
-| ☐     | FD-028 - Rieseguire suite Python combat      | `tests/test_resolver.py`, `tests/test_hydration.py`.                             |
-| ☐     | FD-029 - Rieseguire suite Node contract      | `contracts-combat`, `contracts-hydration-snapshot`, `contracts-trait-mechanics`. |
-| ☐     | FD-030 - Rieseguire demo CLI auto            | Smoke stabile con log archiviabile.                                              |
+| Stato | Task                                         | Dettagli operativi                                                                                                              |
+| ----- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| 🟡    | FD-020 - Scrivere Combat Canon Spec          | PARTIAL: round-loop.md + resolver-api.md coprono formule/timing. Manca doc unificato.                                           |
+| ☑    | FD-021 - Bloccare action types shipping      | DONE: attack, move, defend, parry, ability (Fase 3b #1409), heal (#1386). Tutti funzionali.                                     |
+| 🟡    | FD-022 - Bloccare status shipping            | PARTIAL: bleeding, fracture, disorient, rage, panic implementati + buff system (#1409). Lista shipping da formalizzare.         |
+| ☐     | FD-023 - Bloccare PT spend shipping          | `perforazione`, `spinta`, costi, limitazioni e timing.                                                                          |
+| ☑    | FD-024 - Formalizzare timing begin_turn      | DONE: begin_turn/begin_round implementati con tick status, decay, bleeding, buff decay, cooldown. Documentato in round-loop.md. |
+| ☐     | FD-025 - Formalizzare ordine mitigazioni     | Armor, resistenze, parry, MoS, damage step.                                                                                     |
+| ☑    | FD-026 - Esplicitare active_effects deferred | DONE: active_effects ora LIVE (Fase 3a #1408 + 3b #1409). 8 ability + attack-triggered trait effects. Non più NOOP.             |
+| ☐     | FD-027 - Verificare determinismo             | RNG namespacing, seed strategy e ripetibilità risultati.                                                                        |
+| ☑    | FD-028 - Rieseguire suite Python combat      | DONE: 237/237 verdi (resolver + orchestrator + hydration + trait_effects + demo_cli).                                           |
+| ☐     | FD-029 - Rieseguire suite Node contract      | `contracts-combat`, `contracts-hydration-snapshot`, `contracts-trait-mechanics`.                                                |
+| ☐     | FD-030 - Rieseguire demo CLI auto            | Smoke stabile con log archiviabile.                                                                                             |
 
 ### EPIC D — Balance layer
 

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-16T02:37:07+00:00",
+  "generated_at": "2026-04-16T02:50:08+00:00",
   "summary": {
     "total": 0,
     "errors": 0,

--- a/services/rules/round_orchestrator.py
+++ b/services/rules/round_orchestrator.py
@@ -467,11 +467,46 @@ def begin_round(state: Mapping[str, Any]) -> Dict[str, Any]:
             unit["reaction_cooldown_remaining"] = cd - 1
     next_state["round_phase"] = PHASE_PLANNING
     next_state["pending_intents"] = []
+    # Timer planning phase: se planning_deadline_ms e' configurato nello
+    # state, begin_round registra il timestamp di inizio planning. Il
+    # caller (session engine) puo' usare planning_started_at per enforce
+    # il timeout e auto-committare quando scade. Il rules engine Python
+    # non fa enforcement diretto (e' il session engine Node che gestisce
+    # il timer via setTimeout / setInterval).
+    deadline = state.get("planning_deadline_ms")
+    if deadline is not None and int(deadline) > 0:
+        next_state["planning_deadline_ms"] = int(deadline)
+        import time
+
+        next_state["planning_started_at"] = int(time.time() * 1000)
     return {
         "next_state": next_state,
         "expired": expired_all,
         "bleeding_total": bleeding_total,
     }
+
+
+def is_planning_expired(state: Mapping[str, Any]) -> bool:
+    """Controlla se il timer della planning phase e' scaduto.
+
+    Ritorna True se:
+    - ``planning_deadline_ms`` e' presente e > 0
+    - ``planning_started_at`` e' presente
+    - il tempo trascorso supera ``planning_deadline_ms``
+
+    Il caller (session engine Node) usa questa funzione per decidere se
+    auto-committare il round quando il timer scade. Il rules engine
+    Python non auto-committa: e' responsabilita' del caller.
+    """
+
+    deadline = state.get("planning_deadline_ms")
+    started = state.get("planning_started_at")
+    if deadline is None or started is None:
+        return False
+    import time
+
+    now = int(time.time() * 1000)
+    return (now - int(started)) >= int(deadline)
 
 
 def declare_intent(
@@ -1418,6 +1453,7 @@ __all__ = [
     "compute_resolve_priority",
     "declare_intent",
     "declare_reaction",
+    "is_planning_expired",
     "load_action_speed_table",
     "preview_round",
     "reload_action_speed_table",


### PR DESCRIPTION
## Summary

Two tasks:

**1. Backlog triage FD-IDs (EPIC C)**:
- 4 DONE: FD-021 (action types), FD-024 (timing), FD-026 (active_effects), FD-028 (Python suite)
- 2 PARTIAL: FD-020 (combat canon spec), FD-022 (status shipping)
- 82 PENDING (EPIC D-K untouched)

**2. Timer planning phase** (last round-loop.md follow-up):
- `planning_deadline_ms` + `planning_started_at` set in `begin_round`
- `is_planning_expired(state)` helper exported
- Enforcement = caller responsibility (Node session engine)

round-loop.md §6: all follow-ups now completed. Residui: 22 trait abilities + Node timer enforcement.

**237/237** Python test. Governance 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)