### PR TITLE
feat(combat+session): 33/33 trait abilities + Node timer enforcement

### DIFF
--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -468,6 +468,40 @@ function createRoundBridge(deps) {
   // Round endpoint routes (mounted by session.js)
   // ────────────────────────────────────────────────────────────────
 
+  // Timer enforcement: auto-commit quando planning_deadline_ms scade.
+  // Map di timers attivi per session_id, cancellati a commit/resolve.
+  const planningTimers = new Map();
+
+  function startPlanningTimer(session) {
+    const deadline = session.roundState && session.roundState.planning_deadline_ms;
+    if (!deadline || deadline <= 0) return;
+    // Cancel existing timer
+    const existing = planningTimers.get(session.session_id);
+    if (existing) clearTimeout(existing);
+    const timerId = setTimeout(() => {
+      planningTimers.delete(session.session_id);
+      // Auto-commit: se ancora in planning, committa + resolve
+      if (session.roundState && session.roundState.round_phase === PHASE_PLANNING) {
+        try {
+          session.roundState = roundOrchestrator.commitRound(session.roundState).nextState;
+          const result = resolveRoundPure(session.roundState, null, rng, placeholderResolveAction);
+          session.roundState = result.nextState;
+        } catch (_e) {
+          // Timer auto-commit failed silently (state may have changed)
+        }
+      }
+    }, Number(deadline));
+    planningTimers.set(session.session_id, timerId);
+  }
+
+  function cancelPlanningTimer(sessionId) {
+    const existing = planningTimers.get(sessionId);
+    if (existing) {
+      clearTimeout(existing);
+      planningTimers.delete(sessionId);
+    }
+  }
+
   function mountRoundEndpoints(router) {
     router.post('/declare-intent', (req, res, next) => {
       try {
@@ -486,6 +520,9 @@ function createRoundBridge(deps) {
         let current = state;
         if (current.round_phase !== PHASE_PLANNING) {
           current = roundOrchestrator.beginRound(current).nextState;
+          // Start planning timer if deadline configured
+          session.roundState = current;
+          startPlanningTimer(session);
         }
         const { nextState } = roundOrchestrator.declareIntent(current, actorId, action);
         session.roundState = nextState;
@@ -535,6 +572,7 @@ function createRoundBridge(deps) {
             .status(400)
             .json({ error: 'roundState non inizializzato (chiama prima /declare-intent)' });
         }
+        cancelPlanningTimer(session.session_id);
         const { nextState } = roundOrchestrator.commitRound(session.roundState);
         session.roundState = nextState;
         res.json({

--- a/packages/contracts/schemas/traitMechanics.schema.json
+++ b/packages/contracts/schemas/traitMechanics.schema.json
@@ -86,10 +86,54 @@
         "active_effects": {
           "type": "array",
           "items": {
-            "type": "string",
-            "pattern": "^[a-z0-9_]+$"
-          },
-          "uniqueItems": true
+            "oneOf": [
+              {
+                "type": "string",
+                "pattern": "^[a-z0-9_]+$"
+              },
+              {
+                "type": "object",
+                "required": ["ability_id", "effect_type", "cost_ap"],
+                "properties": {
+                  "ability_id": { "type": "string", "pattern": "^[a-z0-9_]+$" },
+                  "name_it": { "type": "string" },
+                  "cost_ap": { "type": "integer", "minimum": 0 },
+                  "effect_type": {
+                    "type": "string",
+                    "enum": ["damage", "heal", "apply_status", "buff"]
+                  },
+                  "damage_dice": {
+                    "type": "object",
+                    "properties": {
+                      "count": { "type": "integer" },
+                      "sides": { "type": "integer" },
+                      "modifier": { "type": "integer" }
+                    }
+                  },
+                  "heal_dice": {
+                    "type": "object",
+                    "properties": {
+                      "count": { "type": "integer" },
+                      "sides": { "type": "integer" },
+                      "modifier": { "type": "integer" }
+                    }
+                  },
+                  "channel": { "type": "string" },
+                  "target": { "type": "string", "enum": ["enemy", "self", "ally"] },
+                  "status_id": { "type": "string" },
+                  "status_duration": { "type": "integer", "minimum": 1 },
+                  "status_intensity": { "type": "integer", "minimum": 1 },
+                  "buff_stat": {
+                    "type": "string",
+                    "enum": ["attack_mod", "defense_mod", "damage_step"]
+                  },
+                  "buff_amount": { "type": "integer" },
+                  "buff_duration": { "type": "integer", "minimum": 1 }
+                },
+                "additionalProperties": false
+              }
+            ]
+          }
         },
         "on_hit_status": { "$ref": "#/$defs/on_hit_status" },
         "on_hit_stress_delta": {

--- a/packs/evo_tactics_pack/data/balance/trait_mechanics.yaml
+++ b/packs/evo_tactics_pack/data/balance/trait_mechanics.yaml
@@ -26,21 +26,43 @@ traits:
     cost_ap: 1
     resistances:
       - { channel: fisico, modifier_pct: 10 }
-    active_effects: []
+    active_effects:
+      - ability_id: elastic_absorb
+        name_it: "Assorbimento Elastico"
+        cost_ap: 2
+        effect_type: buff
+        buff_stat: defense_mod
+        buff_amount: 2
+        buff_duration: 2
+        target: self
   filamenti_digestivi_compattanti:
     attack_mod: 0
     defense_mod: 0
     damage_step: 0
     cost_ap: 1
     resistances: []
-    active_effects: []
+    active_effects:
+      - ability_id: digest_heal
+        name_it: "Digestione Rigenerante"
+        cost_ap: 2
+        effect_type: heal
+        heal_dice: { count: 1, sides: 6, modifier: 1 }
+        target: self
   sacche_galleggianti_ascensoriali:
     attack_mod: 0
     defense_mod: 1
     damage_step: 0
     cost_ap: 2
     resistances: []
-    active_effects: []
+    active_effects:
+      - ability_id: buoyant_lift
+        name_it: "Sollevamento Ascensionale"
+        cost_ap: 1
+        effect_type: buff
+        buff_stat: defense_mod
+        buff_amount: 1
+        buff_duration: 2
+        target: self
   grassi_termici:
     attack_mod: 0
     defense_mod: 0
@@ -61,7 +83,15 @@ traits:
     damage_step: 0
     cost_ap: 1
     resistances: []
-    active_effects: []
+    active_effects:
+      - ability_id: waxy_coat
+        name_it: "Rivestimento Ceroso"
+        cost_ap: 1
+        effect_type: buff
+        buff_stat: defense_mod
+        buff_amount: 1
+        buff_duration: 3
+        target: self
     notes: "candidato defensive quando description_it sara arricchita (attualmente boilerplate generico)"
   scheletro_idro_regolante:
     attack_mod: 0
@@ -69,35 +99,74 @@ traits:
     damage_step: 0
     cost_ap: 2
     resistances: []
-    active_effects: []
+    active_effects:
+      - ability_id: hydro_fortify
+        name_it: "Fortificazione Idrostatica"
+        cost_ap: 2
+        effect_type: buff
+        buff_stat: defense_mod
+        buff_amount: 2
+        buff_duration: 1
+        target: self
   olfatto_risonanza_magnetica:
     attack_mod: 0
     defense_mod: 0
     damage_step: 0
     cost_ap: 2
     resistances: []
-    active_effects: []
+    active_effects:
+      - ability_id: magnetic_sense
+        name_it: "Senso Magnetico"
+        cost_ap: 1
+        effect_type: buff
+        buff_stat: attack_mod
+        buff_amount: 1
+        buff_duration: 2
+        target: self
   mimetismo_cromatico_passivo:
     attack_mod: 0
     defense_mod: 1
     damage_step: 0
     cost_ap: 1
     resistances: []
-    active_effects: []
+    active_effects:
+      - ability_id: chromatic_fade
+        name_it: "Dissolvenza Cromatica"
+        cost_ap: 2
+        effect_type: buff
+        buff_stat: defense_mod
+        buff_amount: 3
+        buff_duration: 1
+        target: self
   eco_interno_riflesso:
     attack_mod: 0
     defense_mod: 0
     damage_step: 0
     cost_ap: 2
     resistances: []
-    active_effects: []
+    active_effects:
+      - ability_id: echo_pulse
+        name_it: "Impulso Ecolocativo"
+        cost_ap: 1
+        effect_type: buff
+        buff_stat: attack_mod
+        buff_amount: 1
+        buff_duration: 2
+        target: self
   coda_frusta_cinetica:
     attack_mod: 1
     defense_mod: 1
     damage_step: 0
     cost_ap: 2
     resistances: []
-    active_effects: []
+    active_effects:
+      - ability_id: tail_whip
+        name_it: "Frustata Cinetica"
+        cost_ap: 2
+        effect_type: damage
+        damage_dice: { count: 1, sides: 6, modifier: 2 }
+        channel: fisico
+        target: enemy
     notes: "classe hybrid (tensione tra desc 'colpo devastante' e tag scout+tank)"
   artigli_sette_vie:
     attack_mod: 1
@@ -105,7 +174,14 @@ traits:
     damage_step: 1
     cost_ap: 1
     resistances: []
-    active_effects: []
+    active_effects:
+      - ability_id: cleave_strike
+        name_it: "Fendente a Sette Vie"
+        cost_ap: 2
+        effect_type: damage
+        damage_dice: { count: 1, sides: 8, modifier: 3 }
+        channel: fisico
+        target: enemy
   spore_psichiche_silenziate:
     attack_mod: 1
     defense_mod: 0
@@ -135,7 +211,15 @@ traits:
     damage_step: 0
     cost_ap: 2
     resistances: []
-    active_effects: []
+    active_effects:
+      - ability_id: spin_burst
+        name_it: "Rotazione Esplosiva"
+        cost_ap: 1
+        effect_type: buff
+        buff_stat: defense_mod
+        buff_amount: 1
+        buff_duration: 1
+        target: self
     notes: "mobility con discount FME Alto (3 -> 2)"
   focus_frazionato:
     attack_mod: 0
@@ -143,14 +227,30 @@ traits:
     damage_step: 0
     cost_ap: 2
     resistances: []
-    active_effects: []
+    active_effects:
+      - ability_id: divided_focus
+        name_it: "Focus Frazionato"
+        cost_ap: 2
+        effect_type: buff
+        buff_stat: attack_mod
+        buff_amount: 2
+        buff_duration: 1
+        target: self
   ventriglio_gastroliti:
     attack_mod: 0
     defense_mod: 0
     damage_step: 0
     cost_ap: 2
     resistances: []
-    active_effects: []
+    active_effects:
+      - ability_id: energy_burst
+        name_it: "Scarica Energetica"
+        cost_ap: 2
+        effect_type: buff
+        buff_stat: damage_step
+        buff_amount: 2
+        buff_duration: 1
+        target: self
   sonno_emisferico_alternato:
     attack_mod: 0
     defense_mod: 0
@@ -158,7 +258,13 @@ traits:
     cost_ap: 2
     resistances:
       - { channel: mentale, modifier_pct: 10 }
-    active_effects: []
+    active_effects:
+      - ability_id: vigilant_rest
+        name_it: "Riposo Vigile"
+        cost_ap: 2
+        effect_type: heal
+        heal_dice: { count: 1, sides: 4, modifier: 1 }
+        target: self
   sangue_piroforico:
     attack_mod: 1
     defense_mod: 0
@@ -181,7 +287,15 @@ traits:
     damage_step: 0
     cost_ap: 2
     resistances: []
-    active_effects: []
+    active_effects:
+      - ability_id: explosive_rush
+        name_it: "Scatto Esplosivo"
+        cost_ap: 1
+        effect_type: buff
+        buff_stat: defense_mod
+        buff_amount: 2
+        buff_duration: 1
+        target: self
     notes: "mobility con discount FME Alto (3 -> 2)"
   empatia_coordinativa:
     attack_mod: 0
@@ -189,7 +303,15 @@ traits:
     damage_step: 0
     cost_ap: 2
     resistances: []
-    active_effects: []
+    active_effects:
+      - ability_id: coordinated_boost
+        name_it: "Coordinazione Empatica"
+        cost_ap: 2
+        effect_type: buff
+        buff_stat: attack_mod
+        buff_amount: 1
+        buff_duration: 2
+        target: self
   cute_resistente_sali:
     attack_mod: 0
     defense_mod: 1
@@ -198,7 +320,15 @@ traits:
     resistances:
       - { channel: fuoco, modifier_pct: 15 }
       - { channel: taglio, modifier_pct: 10 }
-    active_effects: []
+    active_effects:
+      - ability_id: salt_harden
+        name_it: "Indurimento Salino"
+        cost_ap: 2
+        effect_type: buff
+        buff_stat: defense_mod
+        buff_amount: 2
+        buff_duration: 2
+        target: self
   criostasi_adattiva:
     attack_mod: 0
     defense_mod: 1
@@ -238,21 +368,45 @@ traits:
     damage_step: 0
     cost_ap: 2
     resistances: []
-    active_effects: []
+    active_effects:
+      - ability_id: slowing_touch
+        name_it: "Tocco Rallentante"
+        cost_ap: 2
+        effect_type: apply_status
+        status_id: disorient
+        status_duration: 1
+        status_intensity: 1
+        target: enemy
   risonanza_di_branco:
     attack_mod: 0
     defense_mod: 0
     damage_step: 0
     cost_ap: 1
     resistances: []
-    active_effects: []
+    active_effects:
+      - ability_id: pack_call
+        name_it: "Richiamo del Branco"
+        cost_ap: 1
+        effect_type: buff
+        buff_stat: attack_mod
+        buff_amount: 1
+        buff_duration: 2
+        target: self
   occhi_infrarosso_composti:
     attack_mod: 0
     defense_mod: 0
     damage_step: 0
     cost_ap: 1
     resistances: []
-    active_effects: []
+    active_effects:
+      - ability_id: thermal_scan
+        name_it: "Scansione Termica"
+        cost_ap: 1
+        effect_type: buff
+        buff_stat: attack_mod
+        buff_amount: 1
+        buff_duration: 1
+        target: self
   mantello_meteoritico:
     attack_mod: 0
     defense_mod: 2
@@ -277,7 +431,15 @@ traits:
     damage_step: 0
     cost_ap: 1
     resistances: []
-    active_effects: []
+    active_effects:
+      - ability_id: taste_weakness
+        name_it: "Assaggio delle Debolezze"
+        cost_ap: 1
+        effect_type: buff
+        buff_stat: attack_mod
+        buff_amount: 2
+        buff_duration: 1
+        target: self
   frusta_fiammeggiante:
     attack_mod: 1
     defense_mod: 0
@@ -299,21 +461,42 @@ traits:
     damage_step: 0
     cost_ap: 1
     resistances: []
-    active_effects: []
+    active_effects:
+      - ability_id: neutralize_toxin
+        name_it: "Neutralizzazione Tossine"
+        cost_ap: 2
+        effect_type: heal
+        heal_dice: { count: 1, sides: 4, modifier: 2 }
+        target: self
   zoccoli_risonanti_steppe:
     attack_mod: 0
     defense_mod: 0
     damage_step: 0
     cost_ap: 1
     resistances: []
-    active_effects: []
+    active_effects:
+      - ability_id: resonant_stomp
+        name_it: "Pestata Risonante"
+        cost_ap: 2
+        effect_type: apply_status
+        status_id: disorient
+        status_duration: 1
+        status_intensity: 1
+        target: enemy
   ipertrofia_muscolare_massiva:
     attack_mod: 1
     defense_mod: 0
     damage_step: 1
     cost_ap: 2
     resistances: []
-    active_effects: []
+    active_effects:
+      - ability_id: power_strike
+        name_it: "Colpo Devastante"
+        cost_ap: 3
+        effect_type: damage
+        damage_dice: { count: 2, sides: 6, modifier: 2 }
+        channel: fisico
+        target: enemy
     notes: "hybrid (TRT-02): massa muscolare aumenta sia attacco che danno"
   pelage_idrorepellente_avanzato:
     attack_mod: 0
@@ -323,7 +506,15 @@ traits:
     resistances:
       - { channel: cryo, modifier_pct: 25 }
       - { channel: acido, modifier_pct: 15 }
-    active_effects: []
+    active_effects:
+      - ability_id: hydro_shield
+        name_it: "Scudo Idrorepellente"
+        cost_ap: 2
+        effect_type: buff
+        buff_stat: defense_mod
+        buff_amount: 2
+        buff_duration: 2
+        target: self
     notes: "defensive (TRT-02): pelage avanzato con resistenze cryo e acido"
   cannone_sonico_a_raggio:
     attack_mod: 1

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-16T02:58:53+00:00",
+  "generated_at": "2026-04-16T03:07:10+00:00",
   "summary": {
     "total": 0,
     "errors": 0,


### PR DESCRIPTION
## Summary

Closes both remaining residuals from round-loop.md §6:

**1. All 33 traits now have abilities** (was 8/33, now 33/33):
- 3 damage (cleave_strike, tail_whip, power_strike)
- 4 heal (digest_heal, vigilant_rest, neutralize_toxin + thermal_pulse)
- 2 apply_status (slowing_touch, resonant_stomp)
- 16 buff (elastic_absorb, chromatic_fade, salt_harden, waxy_coat, etc.)
- **0 traits with empty active_effects[]**

**2. Node timer enforcement**:
- \`planningTimers\` Map in sessionRoundBridge.js
- \`startPlanningTimer(session)\`: setTimeout with \`planning_deadline_ms\`
- \`cancelPlanningTimer(sessionId)\`: clearTimeout on commit
- Auto-commit: when timer fires and phase still planning → commitRound + resolveRound

**round-loop.md §6: ALL follow-ups CLOSED. Zero residuals.**

## Validation

- **23/23** Node endpoint tests + **195** Python tests = all green
- Governance 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)