### PR TITLE
feat(dx): Mission Console serve script with API proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "ci:stack": "npm run lint:stack && npm run test:backend",
     "test:api": "ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/*.test.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/generation/flow-shell.spec.ts && node --test tests/server/generationSnapshot.spec.js && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/server/orchestrator-bridge.spec.ts && ORCHESTRATOR_AUTOCLOSE_MS=2000 ./node_modules/.bin/tsx tests/server/orchestrator-latency.spec.ts && ./node_modules/.bin/tsx tests/scripts/tune_items.test.ts && ./node_modules/.bin/tsx tests/events/dynamicEvents.e2e.ts && node --test tests/tools/deploy-checks.spec.js && ./node_modules/.bin/tsx tests/api/serviceActorSessions.spec.ts",
     "start:api": "node apps/backend/index.js",
+    "start:console": "node scripts/serve-mission-console.mjs",
     "docs:lint": "python tools/check_site_links.py docs",
     "docs:smoke": "node scripts/docs-smoke.js",
     "docs:governance:check": "python tools/check_docs_governance.py --registry docs/governance/docs_registry.json --report reports/docs/governance_drift_report.json",

--- a/scripts/serve-mission-console.mjs
+++ b/scripts/serve-mission-console.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Serve Mission Console with API proxy to backend.
+ *
+ * Usage: node scripts/serve-mission-console.mjs [port]
+ *
+ * Serves docs/mission-console/ as static SPA and proxies /api/* to backend
+ * (default http://localhost:3334). Start backend first with `npm run start:api`.
+ */
+import { createServer, request as httpRequest } from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import { join, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const ROOT = resolve(__dirname, '..', 'docs', 'mission-console');
+const PORT = Number(process.argv[2]) || 5555;
+const API_TARGET = process.env.API_TARGET || 'http://localhost:3334';
+
+const MIME = {
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.ico': 'image/x-icon',
+};
+
+async function serveStatic(res, filePath) {
+  try {
+    const s = await stat(filePath);
+    if (!s.isFile()) throw new Error('not a file');
+    const data = await readFile(filePath);
+    const ext = extname(filePath);
+    res.writeHead(200, { 'Content-Type': MIME[ext] || 'application/octet-stream' });
+    res.end(data);
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+function proxyToBackend(req, res) {
+  const url = new URL(API_TARGET);
+  const opts = {
+    hostname: url.hostname,
+    port: url.port,
+    path: req.url,
+    method: req.method,
+    headers: { ...req.headers, host: `${url.hostname}:${url.port}` },
+  };
+
+  const proxy = httpRequest(opts, (upstream) => {
+    res.writeHead(upstream.statusCode, upstream.headers);
+    upstream.pipe(res);
+  });
+
+  proxy.on('error', () => {
+    res.writeHead(502, { 'Content-Type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        error: 'Backend non raggiungibile',
+        hint: 'Avvia npm run start:api',
+      }),
+    );
+  });
+
+  req.pipe(proxy);
+}
+
+const server = createServer(async (req, res) => {
+  const pathname = new URL(req.url, `http://localhost:${PORT}`).pathname;
+
+  // Proxy API calls to backend
+  if (pathname.startsWith('/api/')) {
+    return proxyToBackend(req, res);
+  }
+
+  // Try static file
+  const filePath = join(ROOT, pathname === '/' ? 'index.html' : pathname);
+  if (await serveStatic(res, filePath)) return;
+
+  // SPA fallback — serve index.html for client routes
+  await serveStatic(res, join(ROOT, 'index.html'));
+});
+
+server.listen(PORT, () => {
+  console.log(`[mission-console] http://localhost:${PORT}`);
+  console.log(`[mission-console] API proxy → ${API_TARGET}`);
+  console.log(`[mission-console] Static root: ${ROOT}`);
+});


### PR DESCRIPTION
## Summary
- New `scripts/serve-mission-console.mjs` — zero-dependency Node server that serves `docs/mission-console/` as SPA + proxies `/api/*` to backend
- New npm script: `npm run start:console`
- **Fixes**: all Mission Console rendering bugs (raw HTML in SPECIE card, JSON error in TRAIT DIAGNOSTICS)

## Root cause
Mission Console's CSP restricts `connect-src` to `'self'`, requiring API and static files on same origin. Serving with `npx serve` returned HTML 404 pages for API calls, which Vue rendered as text content in cards.

## Usage
```bash
npm run start:api      # backend on :3334
npm run start:console  # console on :5555, proxies /api/* to :3334
```

## Rollback plan (03A)
Revert commit. No runtime dependencies added.

## Test plan
- [x] `node --test tests/ai/*.test.js` — all pass
- [x] Manual verification: SNAPSHOT, SPECIE, TRAIT DIAGNOSTICS cards render correctly
- [x] Quality & Release shows 260/260 checks, 100%
- [x] Graceful 502 JSON when backend not running

🤖 Generated with [Claude Code](https://claude.com/claude-code)