### PR TITLE
feat(combat): 3 pattern medium — combat prediction, validation, resistance matrix

### DIFF
--- a/apps/backend/services/sessionValidation.js
+++ b/apps/backend/services/sessionValidation.js
@@ -1,0 +1,94 @@
+// B2 pattern: centralized session action validation + stateID.
+//
+// Estrae la validazione scattered da session.js in un singolo guard.
+// Ogni azione passa per validateAction() prima della mutazione.
+// stateID fornisce optimistic concurrency — rifiuta azioni stale.
+//
+// Vedi docs/planning/tactical-architecture-patterns.md §B2
+
+'use strict';
+
+const { PHASE_PLANNING, PHASE_COMMITTED, PHASE_RESOLVING } = require('./roundOrchestrator');
+
+/**
+ * Tipi azione permessi per fase round.
+ * null = permesso in qualunque fase (o senza round model).
+ */
+const PHASE_ALLOWED_ACTIONS = {
+  [PHASE_PLANNING]: new Set(['declare_intent', 'clear_intent', 'declare_reaction']),
+  [PHASE_COMMITTED]: new Set([]),
+  [PHASE_RESOLVING]: new Set(['resolve_next']),
+};
+
+/**
+ * Valida un'azione prima di mutare lo stato sessione.
+ *
+ * @param {object} session — stato sessione corrente
+ * @param {object} action — azione proposta { type, actor_id, stateId?, ... }
+ * @returns {{ valid: boolean, error?: string }}
+ */
+function validateAction(session, action) {
+  if (!session) {
+    return { valid: false, error: 'session_not_found' };
+  }
+  if (session.ended) {
+    return { valid: false, error: 'session_ended' };
+  }
+  if (!action || !action.type) {
+    return { valid: false, error: 'missing_action_type' };
+  }
+
+  // stateID optimistic lock: se il client invia un stateId, deve matchare
+  if (
+    action.stateId !== undefined &&
+    session._stateId !== undefined &&
+    action.stateId !== session._stateId
+  ) {
+    return {
+      valid: false,
+      error: 'stale_state',
+      detail: `client stateId=${action.stateId}, server stateId=${session._stateId}`,
+    };
+  }
+
+  // Phase-based action filtering (round model)
+  const phase = session.roundState && session.roundState.round_phase;
+  if (phase && PHASE_ALLOWED_ACTIONS[phase]) {
+    const allowed = PHASE_ALLOWED_ACTIONS[phase];
+    if (allowed.size > 0 && !allowed.has(action.type)) {
+      return {
+        valid: false,
+        error: 'action_not_allowed_in_phase',
+        detail: `action '${action.type}' not allowed in phase '${phase}'`,
+      };
+    }
+  }
+
+  // Actor alive check
+  if (action.actor_id) {
+    const actor = (session.units || []).find((u) => u.id === action.actor_id);
+    if (!actor) {
+      return { valid: false, error: 'actor_not_found' };
+    }
+    if (actor.hp <= 0) {
+      return { valid: false, error: 'actor_dead' };
+    }
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Incrementa stateId della sessione dopo una mutazione riuscita.
+ * Chiamare dopo ogni appendEvent o state change.
+ */
+function bumpStateId(session) {
+  session._stateId = (session._stateId || 0) + 1;
+  return session._stateId;
+}
+
+module.exports = {
+  validateAction,
+  bumpStateId,
+  PHASE_ALLOWED_ACTIONS,
+};

--- a/packs/evo_tactics_pack/data/balance/species_resistances.yaml
+++ b/packs/evo_tactics_pack/data/balance/species_resistances.yaml
@@ -1,0 +1,83 @@
+# Species Resistance Matrix — Evo-Tactics
+# Pattern W2 (wesnoth damage type / resistance matrix).
+# Resistenze base per-specie, indipendenti dai trait.
+# Il resolver somma queste + trait resistances nel calcolo danno.
+#
+# modifier_pct: 100 = neutro, >100 = vulnerabile, <100 = resistente
+# Es. 80 = 20% resistenza, 120 = 20% vulnerabilita
+#
+# Canali canonici: elettrico, psionico, fisico, fuoco, gravita, mentale, taglio, ionico
+# Vedi docs/planning/tactical-architecture-patterns.md §W2
+
+version: "0.1.0"
+
+# Matrice resistenze base per archetipo specie.
+# Le specie nel dataset riferiscono un archetipo qui definito.
+species_archetypes:
+  corazzato:
+    label: "Corazzato"
+    description: "Alta resistenza fisico/taglio, vulnerabile a psionico/mentale."
+    resistances:
+      fisico: 80
+      taglio: 80
+      fuoco: 100
+      elettrico: 100
+      psionico: 120
+      mentale: 120
+      gravita: 100
+      ionico: 100
+
+  bioelettrico:
+    label: "Bioelettrico"
+    description: "Resistente a elettrico/ionico, vulnerabile a fisico."
+    resistances:
+      fisico: 120
+      taglio: 100
+      fuoco: 100
+      elettrico: 70
+      psionico: 100
+      mentale: 100
+      gravita: 100
+      ionico: 80
+
+  psionico:
+    label: "Psionico"
+    description: "Resistente a mentale/psionico, fragile fisicamente."
+    resistances:
+      fisico: 120
+      taglio: 120
+      fuoco: 100
+      elettrico: 100
+      psionico: 70
+      mentale: 70
+      gravita: 100
+      ionico: 100
+
+  termico:
+    label: "Termico"
+    description: "Resistente a fuoco, vulnerabile a gelo (ionico proxy)."
+    resistances:
+      fisico: 100
+      taglio: 100
+      fuoco: 70
+      elettrico: 100
+      psionico: 100
+      mentale: 100
+      gravita: 100
+      ionico: 120
+
+  adattivo:
+    label: "Adattivo"
+    description: "Nessuna resistenza/vulnerabilita marcata. Equilibrato."
+    resistances:
+      fisico: 100
+      taglio: 100
+      fuoco: 100
+      elettrico: 100
+      psionico: 100
+      mentale: 100
+      gravita: 100
+      ionico: 100
+
+# Default per specie senza archetipo: neutro su tutto
+default_archetype: adattivo

--- a/services/rules/resolver.py
+++ b/services/rules/resolver.py
@@ -199,6 +199,33 @@ def compute_step_flat_bonus(
     return math.floor(bonus)
 
 
+def merge_resistances(
+    trait_resistances: Iterable[Mapping[str, Any]],
+    species_resistances: Optional[Mapping[str, int]] = None,
+) -> List[Dict[str, Any]]:
+    """W2 pattern: unisce resistenze trait + species archetype.
+
+    Le trait resistances (lista di {channel, modifier_pct}) vengono combinate
+    con la species resistance matrix (dict channel → pct dove 100=neutro).
+    Species fornisce il baseline, trait sovrascrive/somma.
+
+    Returns lista nel formato atteso da ``apply_resistance``.
+    """
+    merged: Dict[str, int] = {}
+    # Species baseline (100=neutro, convert a modifier_pct format: 80→+20 resist)
+    if species_resistances:
+        for ch, pct in species_resistances.items():
+            merged[ch] = 100 - pct  # 80→20, 120→-20
+
+    # Trait resistances sommano al baseline
+    for res in trait_resistances or []:
+        ch = res.get("channel")
+        if ch:
+            merged[ch] = merged.get(ch, 0) + int(res.get("modifier_pct", 0))
+
+    return [{"channel": ch, "modifier_pct": pct} for ch, pct in merged.items()]
+
+
 def apply_resistance(damage: int, resistances: Iterable[Mapping[str, Any]], channel: Optional[str]) -> int:
     """Applica la resistenza del target per il canale dell'attacco.
 
@@ -1043,6 +1070,112 @@ def resolve_action(
     }
 
 
+# ─────────────────────────────────────────────────────────────────
+# W1 pattern: combat prediction distribution
+# ─────────────────────────────────────────────────────────────────
+
+
+def predict_combat(
+    attacker: Mapping[str, Any],
+    target: Mapping[str, Any],
+    catalog: Mapping[str, Any],
+    n: int = 1000,
+) -> Dict[str, Any]:
+    """Simula *n* attacchi e restituisce distribuzione outcome.
+
+    Non muta attacker/target. Usa un RNG lineare deterministico
+    (seed = 42) per riproducibilita'.
+
+    Returns dict con:
+        hit_pct, crit_pct, fumble_pct, kill_pct,
+        avg_damage, min_damage, max_damage,
+        avg_mos, cd, attack_mod
+    """
+    import copy
+
+    attack_mod = aggregate_mod(attacker.get("trait_ids", []), catalog, "attack_mod")
+    defense_mod_target = aggregate_mod(
+        target.get("trait_ids", []), catalog, "defense_mod"
+    )
+    terrain_defense = int(target.get("terrain_defense_mod", 0))
+    cd = ATTACK_CD_BASE + int(target.get("tier", 1)) + defense_mod_target + terrain_defense
+    trait_step = aggregate_mod(attacker.get("trait_ids", []), catalog, "damage_step")
+
+    target_hp = int(target.get("hp", 10))
+    target_armor = int(target.get("armor", 0))
+    resistances = target.get("resistances") or []
+    channel = (attacker.get("damage_dice") or {}).get("channel")
+    dice = attacker.get("damage_dice") or {"count": 1, "sides": 6, "modifier": 0}
+
+    hits = 0
+    crits = 0
+    fumbles = 0
+    kills = 0
+    total_damage = 0
+    min_dmg = float("inf")
+    max_dmg = 0
+    total_mos = 0
+
+    # Deterministic simple RNG (mulberry32-style counter)
+    _seed = 42
+
+    def _simple_rng() -> float:
+        nonlocal _seed
+        _seed = (_seed + 0x6D2B79F5) & 0xFFFFFFFF
+        t = _seed
+        t = ((t ^ (t >> 15)) * (t | 1)) & 0xFFFFFFFF
+        t = (t ^ ((t ^ (t >> 7)) * (t | 61))) & 0xFFFFFFFF
+        return ((t ^ (t >> 14)) & 0xFFFFFFFF) / 0x100000000
+
+    for _ in range(n):
+        natural = int(_simple_rng() * 20) + 1
+        total = natural + attack_mod
+        is_fumble = natural == NATURAL_FUMBLE
+        is_crit = natural == NATURAL_MAX
+
+        if is_fumble:
+            success = False
+            fumbles += 1
+        elif is_crit:
+            success = True
+            crits += 1
+        else:
+            success = total >= cd
+
+        if success:
+            hits += 1
+            mos = max(0, total - cd)
+            total_mos += mos
+            step_count = compute_step_count(mos, trait_step)
+            raw = roll_damage_dice(_simple_rng, dice, step_count)
+            after_resist = apply_resistance(raw, resistances, channel)
+            final = apply_armor(after_resist, target_armor)
+            total_damage += final
+            if final < min_dmg:
+                min_dmg = final
+            if final > max_dmg:
+                max_dmg = final
+            if final >= target_hp:
+                kills += 1
+        else:
+            if 0 < min_dmg:
+                min_dmg = 0
+
+    return {
+        "simulations": n,
+        "hit_pct": round(hits / n * 100, 1),
+        "crit_pct": round(crits / n * 100, 1),
+        "fumble_pct": round(fumbles / n * 100, 1),
+        "kill_pct": round(kills / n * 100, 1),
+        "avg_damage": round(total_damage / max(hits, 1), 1),
+        "min_damage": int(min_dmg) if min_dmg != float("inf") else 0,
+        "max_damage": int(max_dmg),
+        "avg_mos": round(total_mos / max(hits, 1), 1),
+        "cd": cd,
+        "attack_mod": attack_mod,
+    }
+
+
 def _consume_ap(unit: Dict[str, Any], ap_cost: int) -> None:
     ap = unit.get("ap") or {}
     current = int(ap.get("current", 0))
@@ -1075,6 +1208,7 @@ __all__ = [
     "STRESS_BREAKPOINT_RAGE",
     "SUPPORTED_PT_SPEND_TYPES",
     "aggregate_mod",
+    "merge_resistances",
     "apply_armor",
     "apply_pt_spend",
     "apply_resistance",
@@ -1085,6 +1219,7 @@ __all__ = [
     "compute_step_count",
     "compute_step_flat_bonus",
     "get_status",
+    "predict_combat",
     "resolve_action",
     "resolve_parry",
     "roll_damage_dice",


### PR DESCRIPTION
## Summary
Implementa i 3 pattern medium-effort dalla roadmap:

- **W1**: `predict_combat()` — simulazione N=1000 attacchi con distribuzione outcome (hit%, crit%, kill%, avg_damage, MoS). Pure function, no side effects.
- **B2**: `sessionValidation.js` — centralized validation + stateID optimistic lock. `validateAction()` + `bumpStateId()`.
- **W2**: `species_resistances.yaml` — matrice resistenze per 5 archetipi specie + `merge_resistances()` per combinare species baseline + trait overrides.

## File (3 nuovi)
- `services/rules/resolver.py` — `predict_combat()` + `merge_resistances()`
- `apps/backend/services/sessionValidation.js` — validation guard
- `packs/evo_tactics_pack/data/balance/species_resistances.yaml` — 5 archetipi

## Test plan
- [x] `pytest tests/test_resolver.py tests/test_round_orchestrator.py tests/test_hydration.py` → 196/196
- [x] `node --test tests/ai/*.test.js` → 61/61
- [x] Prettier → verde

## 03A Rollback
Revert commit. Nuovi file senza dipendenze — nessun breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)