### PR TITLE
feat(balance): O1 trait inheritance — _defaults + inherits: merge

### DIFF
--- a/packs/evo_tactics_pack/data/balance/trait_mechanics.yaml
+++ b/packs/evo_tactics_pack/data/balance/trait_mechanics.yaml
@@ -18,6 +18,47 @@ notes: >
   gelo (solo criostasi_adattiva; documentato nel README come estensione da
   stabilizzare nel prossimo combat pack). Distribuzione: offensive 4,
   defensive 9, hybrid 1, mobility 3, utility 13. Trait con mod non-zero: 14/30.
+
+# O1 pattern (OpenRA template inheritance): baseline defaults per classe.
+# Trait possono usare `inherits: <class>` per ereditare campi dalla classe.
+# hydration.py risolve inherits depth-first: campi espliciti sovrascrivono.
+_defaults:
+  offensive:
+    attack_mod: 1
+    defense_mod: 0
+    damage_step: 0
+    cost_ap: 2
+    resistances: []
+    active_effects: []
+  defensive:
+    attack_mod: 0
+    defense_mod: 1
+    damage_step: 0
+    cost_ap: 1
+    resistances: []
+    active_effects: []
+  hybrid:
+    attack_mod: 1
+    defense_mod: 1
+    damage_step: 0
+    cost_ap: 2
+    resistances: []
+    active_effects: []
+  utility:
+    attack_mod: 0
+    defense_mod: 0
+    damage_step: 0
+    cost_ap: 1
+    resistances: []
+    active_effects: []
+  mobility:
+    attack_mod: 0
+    defense_mod: 0
+    damage_step: 0
+    cost_ap: 1
+    resistances: []
+    active_effects: []
+
 traits:
   struttura_elastica_amorfa:
     attack_mod: 0

--- a/services/rules/hydration.py
+++ b/services/rules/hydration.py
@@ -77,11 +77,40 @@ def derive_tier_from_power(power: int) -> int:
     return _clamp((int(power) // 3) + 1, TIER_MIN, 5)
 
 
+def _resolve_inheritance(
+    traits: Dict[str, Any], defaults: Dict[str, Any]
+) -> Dict[str, Any]:
+    """O1 pattern: risolve `inherits:` depth-first merge.
+
+    Se un trait ha ``inherits: <class>``, i campi mancanti vengono
+    copiati dalla classe in ``_defaults``. Campi espliciti sovrascrivono.
+    """
+    resolved: Dict[str, Any] = {}
+    for trait_id, entry in traits.items():
+        if not isinstance(entry, Mapping):
+            resolved[trait_id] = entry
+            continue
+        parent_key = entry.get("inherits")
+        if parent_key and parent_key in defaults:
+            merged = dict(defaults[parent_key])
+            for k, v in entry.items():
+                if k == "inherits":
+                    continue
+                merged[k] = v
+            resolved[trait_id] = merged
+        else:
+            resolved[trait_id] = dict(entry)
+    return resolved
+
+
 def load_trait_mechanics(path: Path) -> Dict[str, Any]:
     """Carica ``trait_mechanics.yaml`` e restituisce il dict ``{trait_id: entry}``.
 
     Il file atteso e' ``packs/evo_tactics_pack/data/balance/trait_mechanics.yaml``
     con shape validata da ``traitMechanics.schema.json``.
+
+    Supporta O1 pattern: ``_defaults`` per classi trait + ``inherits:`` per
+    ereditare baseline da una classe.
     """
 
     with open(path, encoding="utf-8") as fh:
@@ -91,6 +120,9 @@ def load_trait_mechanics(path: Path) -> Dict[str, Any]:
         raise ValueError(
             f"trait_mechanics atteso dict con chiave 'traits', trovato: {type(data).__name__}"
         )
+    defaults = data.get("_defaults") or {}
+    if defaults and isinstance(defaults, Mapping):
+        return _resolve_inheritance(dict(traits), dict(defaults))
     return dict(traits)
 
 
@@ -303,4 +335,5 @@ __all__ = [
     "derive_tier_from_power",
     "hydrate_encounter",
     "load_trait_mechanics",
+    "_resolve_inheritance",
 ]


### PR DESCRIPTION
## Summary
Pattern O1 (OpenRA template inheritance): trait in `trait_mechanics.yaml` possono ereditare baseline da classi.

- `_defaults:` sezione con 5 classi (offensive/defensive/hybrid/utility/mobility)
- `hydration.py`: `_resolve_inheritance()` merge depth-first
- Backward compatible: trait senza `inherits:` invariati
- Nuovo trait: `inherits: defensive` eredita `defense_mod: 1`, `cost_ap: 1`, etc.

## Test plan
- [x] `pytest tests/test_hydration.py tests/test_resolver.py tests/test_round_orchestrator.py` → 196/196
- [x] `node --test tests/ai/*.test.js` → 61/61

## 03A Rollback
Revert commit. `_defaults` ignorato se assente — nessun breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)