### PR TITLE
feat(backend): V1 plugin registration — pluginLoader + narrative wired

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -21,6 +21,7 @@ const { createSessionRouter } = require('./routes/session');
 const { createNebulaTelemetryAggregator } = require('./services/nebulaTelemetryAggregator');
 const { createReleaseReporter } = require('./services/releaseReporter');
 const { createCatalogService } = require('./services/catalog');
+const { loadPlugins, BUILTIN_PLUGINS } = require('./services/pluginLoader');
 const { createSchemaValidator, SchemaValidationError } = require('./middleware/schemaValidator');
 const { generationSnapshotSchema, speciesSchema, telemetrySchema } = require('@game/contracts');
 const qualitySuggestionSchema = require('../../schemas/quality/suggestion.schema.json');
@@ -368,6 +369,9 @@ function createApp(options = {}) {
 
   const publicDir = options.publicDir || path.resolve(__dirname, 'public');
   app.use(express.static(publicDir));
+
+  // V1 pattern: plugin-based service registration
+  loadPlugins(app, BUILTIN_PLUGINS, options);
 
   const monitoringRouter = createMonitoringRouter();
   app.use('/monitoring', monitoringRouter);

--- a/apps/backend/services/pluginLoader.js
+++ b/apps/backend/services/pluginLoader.js
@@ -1,0 +1,65 @@
+// V1 pattern (bevy plugin modularity): plugin loader per servizi backend.
+//
+// Ogni plugin esporta { name, register(app, options) }.
+// Il loader li carica in sequenza, log registrazione.
+//
+// Uso in app.js:
+//   const { loadPlugins, BUILTIN_PLUGINS } = require('./services/pluginLoader');
+//   loadPlugins(app, BUILTIN_PLUGINS, options);
+//
+// Plugin custom (es. narrative) si aggiungono a BUILTIN_PLUGINS o
+// vengono caricati dinamicamente da una directory.
+//
+// Vedi docs/planning/tactical-architecture-patterns.md §V1
+
+'use strict';
+
+/**
+ * Carica e registra una lista di plugin sull'app Express.
+ *
+ * @param {import('express').Express} app
+ * @param {Array<{name: string, register: function}>} plugins
+ * @param {object} [options] — opzioni globali passate a ogni plugin
+ */
+function loadPlugins(app, plugins, options = {}) {
+  const loaded = [];
+  for (const plugin of plugins) {
+    if (!plugin || typeof plugin.register !== 'function') {
+      console.warn(`[plugin-loader] skip invalid plugin:`, plugin);
+      continue;
+    }
+    try {
+      plugin.register(app, options);
+      loaded.push(plugin.name || 'unnamed');
+    } catch (err) {
+      console.error(`[plugin-loader] failed to register '${plugin.name}':`, err.message);
+    }
+  }
+  if (loaded.length > 0) {
+    console.log(`[plugin-loader] ${loaded.length} plugins loaded: ${loaded.join(', ')}`);
+  }
+  return loaded;
+}
+
+// --- Built-in plugins ---
+
+const narrativePlugin = {
+  name: 'narrative',
+  register(app) {
+    const { createNarrativeRouter } = require('../../services/narrative/narrativeRoutes');
+    app.use('/api/v1/narrative', createNarrativeRouter());
+    app.use('/api/narrative', createNarrativeRouter());
+  },
+};
+
+/**
+ * Lista plugin built-in. Aggiungere nuovi plugin qui.
+ * Ordine = ordine di registrazione.
+ */
+const BUILTIN_PLUGINS = [narrativePlugin];
+
+module.exports = {
+  loadPlugins,
+  BUILTIN_PLUGINS,
+  narrativePlugin,
+};


### PR DESCRIPTION
## Summary
Pattern V1 (bevy plugin modularity): servizi auto-registrano via `register(app)`.

- **pluginLoader.js** — `loadPlugins(app, plugins, options)` con logging
- **BUILTIN_PLUGINS** — narrative come primo plugin
- **app.js** — `loadPlugins()` chiamato dopo static middleware
- Narrative endpoints ora su `/api/v1/narrative/*` e `/api/narrative/*`

Pattern incrementale — servizi esistenti migrano gradualmente.

## Test plan
- [x] `node --test tests/ai/*.test.js` → 61/61
- [x] Prettier → verde

## 03A Rollback
Revert commit. Rimuovere require + loadPlugins da app.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)