### PR TITLE
feat(backend): primo scenario giocabile end-to-end — enc_tutorial_01

### DIFF
--- a/apps/backend/routes/tutorial.js
+++ b/apps/backend/routes/tutorial.js
@@ -1,0 +1,38 @@
+// Tutorial encounter route — serves pre-built scenario definitions.
+//
+// GET /enc_tutorial_01 → scenario metadata + units ready for POST /api/session/start
+//
+// Registered via pluginLoader as tutorialPlugin at /api/tutorial.
+
+'use strict';
+
+const { Router } = require('express');
+const { TUTORIAL_SCENARIO, buildTutorialUnits } = require('../services/tutorialScenario');
+
+function createTutorialRouter() {
+  const router = Router();
+
+  router.get('/enc_tutorial_01', (_req, res) => {
+    res.json({
+      ...TUTORIAL_SCENARIO,
+      units: buildTutorialUnits(),
+      usage: 'POST the units array to /api/session/start to begin a playable session.',
+    });
+  });
+
+  router.get('/', (_req, res) => {
+    res.json({
+      scenarios: [
+        {
+          id: TUTORIAL_SCENARIO.id,
+          name: TUTORIAL_SCENARIO.name,
+          href: `/api/tutorial/${TUTORIAL_SCENARIO.id}`,
+        },
+      ],
+    });
+  });
+
+  return router;
+}
+
+module.exports = { createTutorialRouter };

--- a/apps/backend/services/pluginLoader.js
+++ b/apps/backend/services/pluginLoader.js
@@ -61,15 +61,24 @@ const metaPlugin = {
   },
 };
 
+const tutorialPlugin = {
+  name: 'tutorial',
+  register(app) {
+    const { createTutorialRouter } = require('../routes/tutorial');
+    app.use('/api/tutorial', createTutorialRouter());
+  },
+};
+
 /**
  * Lista plugin built-in. Aggiungere nuovi plugin qui.
  * Ordine = ordine di registrazione.
  */
-const BUILTIN_PLUGINS = [narrativePlugin, metaPlugin];
+const BUILTIN_PLUGINS = [narrativePlugin, metaPlugin, tutorialPlugin];
 
 module.exports = {
   loadPlugins,
   BUILTIN_PLUGINS,
   narrativePlugin,
   metaPlugin,
+  tutorialPlugin,
 };

--- a/apps/backend/services/tutorialScenario.js
+++ b/apps/backend/services/tutorialScenario.js
@@ -1,0 +1,89 @@
+// Primo scenario giocabile: enc_tutorial_01 "Primi Passi nella Savana"
+//
+// Hardcoded unit factory — il session engine non ha un encounter loader
+// runtime. Questo modulo colma il gap per il primo playtest end-to-end.
+//
+// Grid remappata da 8×8 (YAML) a 6×6 (GRID_SIZE costante).
+// Terrain (heights, covers) ignorato — session engine non ha terrain system.
+// AI profile "defensive" non mappato — AI usa policy default.
+
+'use strict';
+
+const TUTORIAL_SCENARIO = {
+  id: 'enc_tutorial_01',
+  name: 'Primi Passi nella Savana',
+  biome_id: 'savana',
+  difficulty_rating: 1,
+  estimated_turns: 6,
+  grid_size: 6,
+  objective: 'elimination',
+  objective_text: 'Sconfiggi tutte le unità nemiche.',
+  briefing_pre:
+    'Due predoni nomadi hanno preso posizione nella savana. Avvicinati con cautela e eliminali.',
+  briefing_post: 'Le sentinelle sono cadute. La via è libera — per ora.',
+};
+
+function buildTutorialUnits() {
+  return [
+    // --- Player units ---
+    {
+      id: 'p_scout',
+      species: 'dune_stalker',
+      job: 'skirmisher',
+      traits: ['zampe_a_molla'],
+      hp: 10,
+      ap: 2,
+      mod: 3,
+      dc: 12,
+      guardia: 1,
+      position: { x: 0, y: 2 },
+      controlled_by: 'player',
+      facing: 'E',
+    },
+    {
+      id: 'p_tank',
+      species: 'dune_stalker',
+      job: 'vanguard',
+      traits: ['pelle_elastomera'],
+      hp: 12,
+      ap: 2,
+      mod: 2,
+      dc: 13,
+      guardia: 1,
+      position: { x: 0, y: 3 },
+      controlled_by: 'player',
+      facing: 'E',
+    },
+    // --- Enemy units (predoni_nomadi, difficulty 1/5) ---
+    {
+      id: 'e_nomad_1',
+      species: 'predoni_nomadi',
+      job: 'skirmisher',
+      traits: [],
+      hp: 8,
+      ap: 2,
+      mod: 2,
+      dc: 11,
+      guardia: 1,
+      position: { x: 5, y: 2 },
+      controlled_by: 'sistema',
+      facing: 'W',
+    },
+    {
+      id: 'e_nomad_2',
+      species: 'predoni_nomadi',
+      job: 'skirmisher',
+      traits: [],
+      hp: 8,
+      ap: 2,
+      mod: 2,
+      dc: 11,
+      guardia: 1,
+      position: { x: 5, y: 4 },
+      controlled_by: 'sistema',
+      facing: 'W',
+    },
+  ];
+}
+
+module.exports = { TUTORIAL_SCENARIO, buildTutorialUnits };

--- a/tests/api/tutorial.test.js
+++ b/tests/api/tutorial.test.js
@@ -1,0 +1,123 @@
+// Integration tests: primo scenario giocabile enc_tutorial_01.
+//
+// Copre:
+//   - GET /api/tutorial/enc_tutorial_01 ritorna scenario + 4 unità
+//   - Round-trip: scenario → POST /start → 4 unità su griglia 6×6
+//   - Combat smoke: declare-intent → commit → resolve funziona
+//   - Enemy units are sistema-controlled
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+test('GET /api/tutorial/enc_tutorial_01 returns valid scenario', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const res = await request(app).get('/api/tutorial/enc_tutorial_01');
+  assert.equal(res.status, 200);
+  assert.equal(res.body.id, 'enc_tutorial_01');
+  assert.equal(res.body.name, 'Primi Passi nella Savana');
+  assert.equal(res.body.objective, 'elimination');
+  assert.equal(res.body.grid_size, 6);
+  assert.ok(Array.isArray(res.body.units));
+  assert.equal(res.body.units.length, 4);
+
+  const players = res.body.units.filter((u) => u.controlled_by === 'player');
+  const enemies = res.body.units.filter((u) => u.controlled_by === 'sistema');
+  assert.equal(players.length, 2, '2 player units');
+  assert.equal(enemies.length, 2, '2 enemy units');
+});
+
+test('GET /api/tutorial/ lists available scenarios', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const res = await request(app).get('/api/tutorial/');
+  assert.equal(res.status, 200);
+  assert.ok(Array.isArray(res.body.scenarios));
+  assert.ok(res.body.scenarios.length >= 1);
+  assert.equal(res.body.scenarios[0].id, 'enc_tutorial_01');
+});
+
+test('tutorial units → session start → valid session', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  // 1. Get tutorial scenario
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  assert.equal(scenario.status, 200);
+
+  // 2. Start session with tutorial units
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units });
+  assert.equal(startRes.status, 200, `start failed: ${JSON.stringify(startRes.body)}`);
+  assert.ok(startRes.body.session_id);
+
+  const sid = startRes.body.session_id;
+  const state = startRes.body.state;
+
+  // 3. Verify 4 units on grid
+  assert.equal(state.units.length, 4);
+
+  // 4. Verify positions are within 6×6 grid
+  for (const u of state.units) {
+    assert.ok(u.position.x >= 0 && u.position.x < 6, `x out of bounds: ${u.id}`);
+    assert.ok(u.position.y >= 0 && u.position.y < 6, `y out of bounds: ${u.id}`);
+  }
+
+  // 5. Verify enemy species
+  const enemies = state.units.filter((u) => u.controlled_by === 'sistema');
+  assert.equal(enemies.length, 2);
+  for (const e of enemies) {
+    assert.equal(e.species, 'predoni_nomadi');
+  }
+});
+
+test('tutorial session: declare → commit → resolve round', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  // Setup session
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units });
+  const sid = startRes.body.session_id;
+
+  // Declare intent: p_scout attacks e_nomad_1
+  const declareRes = await request(app)
+    .post('/api/session/declare-intent')
+    .send({
+      session_id: sid,
+      actor_id: 'p_scout',
+      action: { type: 'attack', target_id: 'e_nomad_1' },
+    });
+  assert.equal(declareRes.status, 200, `declare failed: ${JSON.stringify(declareRes.body)}`);
+
+  // Commit round
+  const commitRes = await request(app).post('/api/session/commit-round').send({ session_id: sid });
+  assert.equal(commitRes.status, 200, `commit failed: ${JSON.stringify(commitRes.body)}`);
+
+  // Resolve round
+  const resolveRes = await request(app)
+    .post('/api/session/resolve-round')
+    .send({ session_id: sid });
+  assert.equal(resolveRes.status, 200, `resolve failed: ${JSON.stringify(resolveRes.body)}`);
+  assert.ok(
+    resolveRes.body.turn_log_entries || resolveRes.body.turnLogEntries,
+    'resolution should produce log entries',
+  );
+});


### PR DESCRIPTION
## Summary
- Primo scenario **giocabile via API**: `enc_tutorial_01` "Primi Passi nella Savana"
- `GET /api/tutorial/enc_tutorial_01` → 4 unità (2 player dune_stalker, 2 enemy predoni_nomadi)
- Flusso completo testato: scenario → `/start` → `/declare-intent` → `/commit-round` → `/resolve-round`
- Plugin registration via pluginLoader (pattern Bevy V1)

## File
- `apps/backend/services/tutorialScenario.js` (NEW) — pure function factory, 4 hardcoded units
- `apps/backend/routes/tutorial.js` (NEW) — GET route per scenario
- `apps/backend/services/pluginLoader.js` — +tutorialPlugin
- `tests/api/tutorial.test.js` (NEW) — 4 integration test

## Limitazioni note
- Grid 6×6 (YAML dice 8×8) — refactor grid dinamica in PR separata
- Terrain (heights, covers) ignorato — session engine non ha terrain system
- AI profile "defensive" non mappato — AI usa policy default
- Stats hardcoded — bridge species→stats in futuro

## Test plan
- [x] `node --test tests/api/tutorial.test.js` → 4/4 pass
- [x] `node --test tests/ai/*.test.js` → 61/61 pass (0 regressions)
- [x] `npx prettier --check` → pass

## Rollback
Rimuovere i 3 file nuovi + revert pluginLoader.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)