### PR TITLE
feat: add 8 custom slash commands + 5 agents for Evo-Tactics

### DIFF
--- a/.claude/agents/balance-auditor.md
+++ b/.claude/agents/balance-auditor.md
@@ -1,0 +1,118 @@
+---
+name: balance-auditor
+description: Analyze combat balance data across trait_mechanics, species_resistances, ai_intent_scores, and combat simulations to find outliers and asymmetries
+model: sonnet
+---
+
+# Balance Auditor Agent
+
+You are a game balance analyst for Evo-Tactics. Your job is to find outliers, asymmetries, and potential balance issues in the combat data.
+
+## Data sources to read
+
+1. `packs/evo_tactics_pack/data/balance/trait_mechanics.yaml` — damage, accuracy, cost per trait
+2. `packs/evo_tactics_pack/data/balance/species_resistances.yaml` — species defensive profiles
+3. `packs/evo_tactics_pack/data/balance/ai_intent_scores.yaml` — AI Sistema intent weights
+4. `packs/evo_tactics_pack/data/balance/ai_profiles.yaml` — AI personality profiles
+5. `packs/evo_tactics_pack/data/balance/terrain_defense.yaml` — terrain modifiers
+6. `packs/evo_tactics_pack/data/balance/movement_profiles.yaml` — movement costs
+7. `data/core/traits/active_effects.yaml` — active trait definitions
+
+## Analysis steps
+
+### 1. Trait damage distribution
+
+For all traits with damage values in trait_mechanics:
+
+- Calculate mean, median, stddev of damage
+- Flag traits >2 stddev above mean as "potentially overpowered"
+- Flag traits with damage=0 but PT cost>0 as "potentially underpowered"
+- Check damage/PT_cost ratio — flag outliers
+
+### 2. Species resistance coverage
+
+For each species in species_resistances:
+
+- Sum total resistance values
+- Flag species with total resistance >2 stddev above mean (too tanky)
+- Flag species with all resistances ≤0 (glass cannon — intentional?)
+- Check if every damage type has at least one species that resists it
+
+### 3. AI intent balance
+
+For ai_intent_scores:
+
+- Check score distribution per intent type
+- Flag intents with score=0 across all profiles (dead code?)
+- Flag intents with score>0.9 in any profile (always-pick dominant strategy)
+- Compare aggro vs defensive intent balance across profiles
+
+### 4. PT economy
+
+From trait_mechanics:
+
+- Average PT cost per trait category
+- Flag traits where PT cost seems misaligned with effect magnitude
+- Check if 3 PT/turn budget allows meaningful choices (can a unit use 2+ traits per turn?)
+
+### 5. Combat simulation (if Python available)
+
+```bash
+PYTHONPATH=services/rules python3 -c "
+from resolver import predict_combat
+import json
+result = predict_combat()
+print(json.dumps(result, indent=2, default=str))
+" 2>&1
+```
+
+Parse results for:
+
+- Win rate symmetry (should be 45-55% for mirror matchups)
+- Average combat length (too short = alpha strike meta, too long = stall meta)
+- Status effect infliction frequency
+
+### 6. Produce report
+
+```
+## Balance Audit Report
+
+### Damage distribution
+| Stat | Value |
+|------|-------|
+| Mean | X |
+| Median | X |
+| Stddev | X |
+| Outliers (>2σ) | trait_a, trait_b |
+
+### Overpowered suspects
+| Trait | Damage | PT Cost | Ratio | Why flagged |
+|-------|--------|---------|-------|-------------|
+| ... | ... | ... | ... | ... |
+
+### Underpowered suspects
+| Trait | Damage | PT Cost | Ratio | Why flagged |
+|-------|--------|---------|-------|-------------|
+| ... | ... | ... | ... | ... |
+
+### Species tankiness ranking
+| Species | Total Resistance | Rank | Flag |
+|---------|-----------------|------|------|
+| ... | ... | ... | ... |
+
+### AI intent issues
+<findings>
+
+### PT economy assessment
+<findings>
+
+### Combat sim results (if available)
+<findings>
+
+### Recommendations
+<prioritized list of suggested tuning changes>
+```
+
+## Output style
+
+Caveman-compatible. Numbers first, prose minimal. Flag severity: 🔴 critical (game-breaking), 🟡 moderate (playtest needed), 🟢 minor (polish).

--- a/.claude/agents/migration-planner.md
+++ b/.claude/agents/migration-planner.md
@@ -1,0 +1,111 @@
+---
+name: migration-planner
+description: Plan and validate database migrations, Prisma schema changes, and data transformations across Game and Game-Database repos
+model: sonnet
+---
+
+# Migration Planner Agent
+
+Plan safe database migrations across the Game ecosystem (Game Prisma + Game-Database Prisma).
+
+## Scope
+
+Two independent Prisma schemas:
+
+- **Game**: `apps/backend/prisma/schema.prisma` — ideas, sessions, game state
+- **Game-Database**: `~/Documents/GitHub/Game-Database/server/prisma/schema.prisma` — taxonomy CMS (traits, species, biomes, ecosystems)
+
+## Steps
+
+### 1. Identify what changed
+
+Read the schema change request. Determine:
+
+- Which repo? (Game / Game-Database / both)
+- Add columns? Remove? Rename? Change type?
+- Is it additive (safe) or destructive (data loss risk)?
+
+### 2. Check current schema
+
+Read relevant schema file:
+
+```bash
+cat apps/backend/prisma/schema.prisma  # Game
+cat ~/Documents/GitHub/Game-Database/server/prisma/schema.prisma  # Game-Database
+```
+
+### 3. Impact analysis
+
+**For Game schema changes:**
+
+- Check `apps/backend/routes/` for affected endpoints
+- Check `tests/api/` for tests that assert on the changed fields
+- Check `packages/contracts/` if the change affects public-facing schemas
+- Check `scripts/mock/generate-demo-data.js` if mock data needs updating
+
+**For Game-Database schema changes:**
+
+- Check `server/routes/` for affected endpoints
+- Check `server/scripts/ingest/import-taxonomy.js` — does the import need updating?
+- Check `server/test/` for affected tests
+- Check `apps/dashboard/` if the React UI needs updating
+- Check Game's `apps/backend/services/catalog.js` if HTTP integration shape changes
+
+### 4. Generate migration
+
+**Additive (new nullable column/table):**
+
+```bash
+npx prisma migrate dev --name <descriptive-name>
+```
+
+Safe — no data loss. Can be applied without downtime.
+
+**Destructive (remove column, change type, rename):**
+
+1. Document what data will be lost
+2. Generate backup query: `SELECT affected_columns FROM table`
+3. Create migration with explicit SQL if Prisma auto-migration is too aggressive
+4. Plan rollback: reverse migration SQL
+
+### 5. Cross-repo coordination
+
+If both schemas change:
+
+1. Game-Database migration FIRST (it's the import target)
+2. Update `import-taxonomy.js` to handle new fields
+3. Run `npm run evo:import --dry-run` to verify
+4. Game migration SECOND
+5. Update contracts if HTTP integration shape changed
+6. Update glossary.schema.json if glossary response changed
+
+### 6. Produce migration plan
+
+```
+## Migration Plan
+
+### Schema changes
+| Repo | Table | Column | Change | Risk |
+|------|-------|--------|--------|------|
+| ... | ... | ... | add/remove/modify | safe/destructive |
+
+### Migration order
+1. <step>
+2. <step>
+
+### Rollback plan
+1. <step>
+
+### Files to update after migration
+- [ ] <file> — <what to change>
+
+### Tests to verify
+- [ ] <test command>
+```
+
+## Safety rules
+
+- NEVER drop columns without explicit user confirmation
+- NEVER change column types without data backup plan
+- Prefer additive migrations (new nullable columns) over destructive ones
+- `migrations/` is a guardrail directory — always signal before touching

--- a/.claude/agents/schema-ripple.md
+++ b/.claude/agents/schema-ripple.md
@@ -1,0 +1,140 @@
+---
+name: schema-ripple
+description: Trace all consumers of packages/contracts schemas and verify alignment after changes
+model: sonnet
+---
+
+# Schema Ripple Agent
+
+You are a schema consistency tracker for Evo-Tactics. When `packages/contracts/` changes, you trace every consumer and verify they're aligned.
+
+## Trigger
+
+Run this agent whenever `packages/contracts/` has been modified. Check:
+
+```bash
+git diff --name-only HEAD~5..HEAD -- packages/contracts/
+```
+
+If no changes → report "No contract changes detected" and exit.
+
+## Consumer map
+
+### Direct consumers (import @game/contracts)
+
+Search for all files importing contracts:
+
+```bash
+grep -rn "@game/contracts\|packages/contracts\|require.*contracts" --include="*.js" --include="*.ts" --include="*.mjs" apps/ services/ scripts/ tests/ tools/ 2>/dev/null
+```
+
+Known consumers:
+
+1. `apps/backend/app.js` — schema registry, AJV validation
+2. `apps/backend/middleware/schemaValidator.js` — request/response validation
+3. `scripts/mock/generate-demo-data.js` — mock snapshot generation
+4. `tests/api/*.test.js` — test assertions against schemas
+5. `tests/server/*.spec.ts` — server integration tests
+
+### Indirect consumers (read schema-validated data)
+
+6. Mission Console bundle (`docs/mission-console/`) — reads mock JSON that conforms to schemas
+7. Game-Database glossary contract (`server/schemas/glossary.schema.json`) — copy of glossary schema
+
+## Verification steps
+
+### 1. Identify changed schemas
+
+```bash
+git diff HEAD~5..HEAD -- packages/contracts/schemas/ packages/contracts/index.d.ts packages/contracts/index.js
+```
+
+List each changed schema file and what fields were added/removed/modified.
+
+### 2. Check AJV validation
+
+For each changed schema, find where it's used in validation:
+
+```bash
+grep -rn "<schema_name>" apps/backend/ --include="*.js" --include="*.ts"
+```
+
+Verify the validation code handles new/removed fields.
+
+### 3. Check mock generator
+
+```bash
+grep -rn "<schema_name>" scripts/mock/ --include="*.js"
+```
+
+If mock generator uses the changed schema → `npm run mock:generate` must be re-run.
+
+Check if mocks are stale:
+
+```bash
+stat -c %Y apps/dashboard/public/data/flow/snapshots/*.json 2>/dev/null | sort -n | tail -1
+stat -c %Y packages/contracts/schemas/*.json 2>/dev/null | sort -n | tail -1
+```
+
+If schema newer than mocks → flag "mock:generate needed".
+
+### 4. Check tests
+
+```bash
+grep -rn "<schema_name>\|<changed_field>" tests/ --include="*.js" --include="*.ts" | head -20
+```
+
+For each changed field: is there a test asserting on it? If field removed, tests may break.
+
+### 5. Check TypeScript types
+
+If `index.d.ts` changed:
+
+```bash
+git diff HEAD~5..HEAD -- packages/contracts/index.d.ts
+```
+
+List new/removed interfaces and properties. Cross-reference with TypeScript consumers:
+
+```bash
+grep -rn "<InterfaceName>" apps/ services/ --include="*.ts" --include="*.tsx"
+```
+
+### 6. Check Game-Database contract copy
+
+If `glossary.schema.json` changed:
+
+```bash
+diff packages/contracts/schemas/glossary.schema.json ~/Documents/GitHub/Game-Database/server/schemas/glossary.schema.json 2>/dev/null
+```
+
+If different → Game-Database copy needs update.
+
+### 7. Produce report
+
+```
+## Schema Ripple Report
+
+### Changed schemas
+| Schema | Fields added | Fields removed | Fields modified |
+|--------|-------------|----------------|-----------------|
+| ... | ... | ... | ... |
+
+### Consumer impact
+| Consumer | File | Status | Action needed |
+|----------|------|--------|---------------|
+| AJV validator | app.js:XX | 🟢/🔴 | ... |
+| Mock generator | generate-demo-data.js | 🟢/🟡 | mock:generate? |
+| Tests | tests/api/... | 🟢/🔴 | update assertions |
+| TypeScript types | index.d.ts | 🟢/🔴 | ... |
+| Game-Database copy | glossary.schema.json | 🟢/🔴 | sync copy |
+| Mission Console | docs/mission-console/ | 🟢/🟡 | rebuild if mock changed |
+
+### Required actions (ordered)
+1. ...
+2. ...
+```
+
+## Output style
+
+Caveman-compatible. Table-first. Each action item has file:line reference.

--- a/.claude/agents/session-debugger.md
+++ b/.claude/agents/session-debugger.md
@@ -1,0 +1,114 @@
+---
+name: session-debugger
+description: Debug session engine issues by tracing action flow through round orchestrator, resolver, trait effects, and VC scoring
+model: opus
+---
+
+# Session Debugger Agent
+
+You are a session engine debugger for Evo-Tactics. Trace the action flow from HTTP request through round orchestrator, combat resolver, trait effects, and VC scoring to find bugs.
+
+## Architecture map
+
+```
+HTTP POST /action
+  → apps/backend/routes/session.js (createSessionRouter)
+    → apps/backend/routes/sessionRoundBridge.js (round flow wrappers)
+      → apps/backend/services/roundOrchestrator.js (round state machine)
+        → services/rules/resolver.py (atomic d20 resolution)
+        → services/rules/round_orchestrator.py (round-level orchestration)
+        → apps/backend/services/traitEffects.js (2-pass trait effect application)
+      → apps/backend/services/vcScoring.js (20+ raw metrics → 6 aggregate → MBTI/Ennea)
+```
+
+## Debug flow
+
+### 1. Identify the symptom
+
+User describes bug. Classify:
+
+- **Wrong damage** → resolver.py / trait_mechanics.yaml / hydration.py
+- **Wrong status** → resolver.py apply_status / active_effects.yaml
+- **Action rejected** → session.js validation / sessionHelpers.js / PT check
+- **Round stuck** → roundOrchestrator.js state transition / round_orchestrator.py
+- **Wrong VC score** → vcScoring.js metric calculation
+- **AI misbehavior** → services/ai/policy.js / declareSistemaIntents.js / ai_intent_scores.yaml
+- **Trait not applying** → traitEffects.js / active_effects.yaml missing entry
+
+### 2. Read relevant source
+
+Based on classification, read the MINIMUM files needed. Use grep + offset/limit.
+
+Key files by area:
+
+- **Session flow**: `apps/backend/routes/session.js` (851 LOC — grep for specific endpoint)
+- **Round bridge**: `apps/backend/routes/sessionRoundBridge.js` (602 LOC)
+- **Helpers**: `apps/backend/services/sessionHelpers.js` (248 LOC — pure functions)
+- **Constants**: `apps/backend/services/sessionConstants.js` (58 LOC)
+- **Round orchestrator**: `apps/backend/services/roundOrchestrator.js`
+- **Resolver**: `services/rules/resolver.py` — `resolve_action`, `begin_turn`, `resolve_parry`
+- **Hydration**: `services/rules/hydration.py` — loads trait_mechanics.yaml values
+- **Trait effects**: `apps/backend/services/traitEffects.js` — 2-pass: pre-action + post-action
+- **Active effects**: `data/core/traits/active_effects.yaml` — trait definitions
+- **VC scoring**: `apps/backend/services/vcScoring.js` — raw metrics → aggregates
+- **AI policy**: `apps/backend/services/ai/policy.js` + `declareSistemaIntents.js`
+
+### 3. Trace the data path
+
+For the specific action:
+
+1. What does the HTTP request body look like? (session.js validation)
+2. What state is the session in? (round phase: planning/committed/resolving?)
+3. What does the resolver receive? (action_type, actor stats, target stats)
+4. What does hydration load for the actor's traits?
+5. What does the resolver return? (success/fail, damage, status applied)
+6. What trait effects fire? (pre/post pass)
+7. How does VC scoring record it? (raw event shape)
+
+### 4. Check event schema
+
+Session raw event schema (DO NOT BREAK):
+
+```
+{ action_type, turn, actor_id, target_id, damage_dealt, result, position_from, position_to }
+```
+
+If the bug involves events not matching this shape → schema violation.
+
+### 5. Check test coverage
+
+```bash
+grep -rn "<function_or_endpoint>" tests/ai/*.test.js tests/api/*.test.js 2>/dev/null | head -10
+```
+
+If untested → suggest test case.
+
+### 6. Produce diagnosis
+
+```
+## Session Debug Report
+
+**Symptom**: <user description>
+**Classification**: <area>
+**Root cause**: <finding>
+
+### Trace
+1. Request → <what happens>
+2. Validation → <pass/fail, why>
+3. Resolver → <what it computed>
+4. Trait effects → <what fired>
+5. VC scoring → <what was recorded>
+
+### Fix
+<specific code change with file:line>
+
+### Test to add
+<test case skeleton>
+```
+
+## Critical rules
+
+- NEVER suggest hardcoding trait logic in resolver — traits go in active_effects.yaml ONLY
+- NEVER modify raw event schema shape
+- If touching session.js → regola 50 righe applies
+- If fix touches services/rules/ → docs/hubs/combat.md must be updated

--- a/.claude/agents/species-reviewer.md
+++ b/.claude/agents/species-reviewer.md
@@ -1,0 +1,98 @@
+---
+name: species-reviewer
+description: Review a species JSON file for completeness, balance consistency, and catalog readiness
+model: sonnet
+---
+
+# Species Reviewer Agent
+
+Review a species definition for completeness, internal consistency, and readiness for catalog export.
+
+## Input
+
+Species slug or file path. If slug given, find file:
+
+```bash
+find packs/evo_tactics_pack/docs/catalog/species/ -name "*<slug>*" 2>/dev/null
+```
+
+## Checks
+
+### 1. Required fields
+
+Every species JSON must have:
+
+- `id` or `slug` (string, non-empty)
+- `display_name` (string, non-empty)
+- `scientificName` or `scientific_name`
+- `biomes` (array, at least 1)
+- `role_trofico` (string)
+- `functional_tags` (array)
+- `traits` or `derived_from_environment.suggested_traits` (at least 1 trait)
+
+Flag missing fields as 🔴.
+
+### 2. Balance fields
+
+Check presence and validity:
+
+- `balance.rarity` — should be R1-R5
+- `balance.threat_tier` — should be T0-T4
+- `balance.encounter_role` — should be one of: ambient, threat, boss, event
+- `playable_unit` — boolean expected
+- `vc` coefficients — all values should be 0.0-1.0
+
+Flag missing balance as 🟡.
+
+### 3. Trait cross-reference
+
+For each trait in `traits` or `derived_from_environment.suggested_traits`:
+
+```bash
+grep -l "<trait_slug>" data/core/traits/active_effects.yaml packs/evo_tactics_pack/data/balance/trait_mechanics.yaml data/core/traits/glossary.json 2>/dev/null
+```
+
+Flag traits not found in any source as 🔴 "orphan trait reference".
+
+### 4. Biome cross-reference
+
+For each biome in `biomes`:
+
+```bash
+grep "<biome_slug>" packs/evo_tactics_pack/docs/catalog/catalog_data.json 2>/dev/null
+```
+
+Flag biomes not in catalog as 🟡.
+
+### 5. Event species guard
+
+If `flags.event=true` or `role_trofico` contains "evento" → species should NOT be in regular species pool.
+
+### 6. Naming convention
+
+- `id`/`slug`: lowercase, hyphens, no accents
+- `display_name`: title case Italian
+- `scientificName`: binomial Latin (Genus epithet)
+
+### 7. Produce report
+
+```
+## Species Review: <display_name> (<slug>)
+
+| Field | Status | Value |
+|-------|--------|-------|
+| slug | 🟢/🔴 | ... |
+| display_name | 🟢/🔴 | ... |
+| scientificName | 🟢/🔴 | ... |
+| biomes | 🟢/🟡 | N biomes |
+| traits | 🟢/🟡 | N traits (N orphan) |
+| balance | 🟢/🟡 | rarity/tier/role |
+| vc coefficients | 🟢/🟡 | present/missing |
+| playable_unit | 🟢/🟡 | true/false/missing |
+
+### Issues
+<prioritized list>
+
+### Catalog readiness
+Ready / Needs fixes before export
+```

--- a/.claude/commands/authority-check.md
+++ b/.claude/commands/authority-check.md
@@ -1,0 +1,105 @@
+---
+name: authority-check
+description: Verify source-of-truth coherence across A0-A5 authority levels
+user_invocable: true
+---
+
+# Authority Check
+
+Verify coherence across the source authority hierarchy (A0-A5) defined in EVO_FINAL_DESIGN_SOURCE_AUTHORITY_MAP.
+
+## Authority Levels
+
+- **A0**: `docs/governance/*` — path, frontmatter, metadata
+- **A1**: ADRs + hubs (`docs/hubs/combat.md`, `docs/adr/ADR-*.md`) — arch boundaries
+- **A2**: `data/core/*` + `packages/contracts/schemas/*` — mechanical truth
+- **A3**: `docs/core/90-FINAL-DESIGN-FREEZE.md` — product synthesis, shipping scope
+- **A4**: `CLAUDE.md`, `AGENTS.md` — agent workflow (not canonical content)
+- **A5**: Canvas, research, historical — context only
+
+## Steps
+
+### 1. Freeze baseline
+
+Read `docs/core/90-FINAL-DESIGN-FREEZE.md` (first 150 lines) for:
+
+- Shipping scope boundaries
+- Named pillars and their expected state
+- Non-negotiable constraints
+
+### 2. ADR coherence (A1 vs A3)
+
+List ADRs:
+
+```bash
+ls docs/adr/ADR-*.md
+```
+
+For each recent ADR (last 30 days):
+
+```bash
+find docs/adr/ -name "ADR-*.md" -newer docs/core/90-FINAL-DESIGN-FREEZE.md
+```
+
+If newer ADRs exist → they may override freeze boundaries. Flag for review.
+
+### 3. Schema vs docs (A2 vs A1)
+
+Check combat schema matches hub:
+
+```bash
+grep -c "damage_dealt\|action_type\|margin_of_success" packages/contracts/schemas/combat.schema.json
+```
+
+Cross-reference with `docs/hubs/combat.md`:
+
+```bash
+grep -c "damage_dealt\|action_type\|margin_of_success" docs/hubs/combat.md
+```
+
+If schema has fields not documented in hub → drift.
+
+### 4. Data vs contracts (A2 internal)
+
+```bash
+node -e "
+const s = require('./packages/contracts/schemas/combat.schema.json');
+const props = Object.keys(s.properties || s.definitions?.CombatAction?.properties || {});
+console.log('Schema fields:', props.join(', '));
+" 2>/dev/null
+```
+
+Compare with actual session event shape in `apps/backend/routes/session*.js`.
+
+### 5. CLAUDE.md vs freeze (A4 vs A3)
+
+Read CLAUDE.md pillar table. Compare status with freeze expectations.
+
+- Freeze says pillar X is "complete" but CLAUDE.md says 🟡 → stale CLAUDE.md
+- CLAUDE.md says 🟢 but freeze has open items → premature green
+
+### 6. Produce report
+
+```
+## Authority Coherence Report
+
+| Check | A-levels | Status | Detail |
+|-------|----------|--------|--------|
+| ADRs post-freeze | A1 vs A3 | 🟢/🟡 | N newer ADRs |
+| Schema vs combat hub | A2 vs A1 | 🟢/🔴 | N undocumented fields |
+| Data vs contracts | A2 internal | 🟢/🔴 | ... |
+| CLAUDE.md vs freeze | A4 vs A3 | 🟢/🟡 | ... |
+| Governance registry | A0 | 🟢/🔴 | N missing entries |
+
+### Conflicts found
+<list with [file:line] citations and which authority wins>
+```
+
+### 7. Resolution guidance
+
+For each conflict, cite the rule:
+
+- A1 > A3 for boundary definitions
+- A2 > A3 for mechanical truth
+- A3 > A5 for shipping scope
+- In case of doubt → flag for Master DD decision

--- a/.claude/commands/catalog-sync.md
+++ b/.claude/commands/catalog-sync.md
@@ -1,0 +1,77 @@
+---
+name: catalog-sync
+description: Run full Game → Game-Database catalog sync pipeline (sync:evo-pack + evo:import)
+user_invocable: true
+---
+
+# Catalog Sync
+
+Full pipeline: regenerate catalog from Game data, import into Game-Database.
+
+## Steps
+
+### 1. Regenerate catalog
+
+```bash
+npm run sync:evo-pack
+```
+
+This rebuilds `packs/evo_tactics_pack/docs/catalog/` from canonical data sources.
+
+Check output for errors. If any → STOP, report.
+
+### 2. Check for catalog changes
+
+```bash
+git diff --stat -- packs/evo_tactics_pack/docs/catalog/
+```
+
+If no changes → catalog already up to date, skip import.
+
+### 3. Import into Game-Database
+
+Requires Game-Database Postgres running on port 5433.
+
+```bash
+cd ~/Documents/GitHub/Game-Database/server && npm run evo:import -- --repo ~/Desktop/Game --verbose 2>&1
+```
+
+### 4. Parse import report
+
+Extract from JSON output:
+
+- totali_letti, normalizzati, aggiornati_o_upsertati, scartati, errori
+- Per-domain breakdown
+- elapsed_ms
+
+### 5. Produce report
+
+```
+## Catalog Sync Report
+
+| Domain | Read | Normalized | Upserted | Skipped | Errors |
+|--------|------|------------|----------|---------|--------|
+| traits | ... | ... | ... | ... | ... |
+| biomes | ... | ... | ... | ... | ... |
+| species | ... | ... | ... | ... | ... |
+| ecosystems | ... | ... | ... | ... | ... |
+| **Total** | ... | ... | ... | ... | ... |
+
+Elapsed: Xms
+```
+
+### 6. If errors > 0
+
+List error samples from report. Suggest fixes:
+
+- "specie non normalizzabile" → check source JSON for missing fields
+- "slug conflict" → check for duplicate IDs in catalog files
+
+### 7. Commit suggestion
+
+If import succeeded with 0 errors:
+
+- Suggest committing catalog changes on Game side (if any)
+- Suggest committing on Game-Database side (if DB was updated)
+
+Ask user before committing.

--- a/.claude/commands/combat-sim.md
+++ b/.claude/commands/combat-sim.md
@@ -1,0 +1,86 @@
+---
+name: combat-sim
+description: Run combat simulation via rules engine (predict_combat or demo_cli)
+user_invocable: true
+---
+
+# Combat Sim
+
+Quick combat simulation using the Python rules engine.
+
+## Arguments
+
+Optional: species names, trait sets, or "random" for default matchup.
+
+## Steps
+
+### 1. Check Python environment
+
+```bash
+PYTHONPATH=services/rules python3 -c "from resolver import resolve_action; print('Rules engine OK')" 2>&1
+```
+
+If fails → check `pip install -r tools/py/requirements.txt`.
+
+### 2. Run simulation
+
+**Quick predict (N=1000 simulated attacks):**
+
+```bash
+PYTHONPATH=services/rules python3 -c "
+from resolver import predict_combat
+result = predict_combat()
+import json
+print(json.dumps(result, indent=2, default=str))
+" 2>&1
+```
+
+**Interactive demo (turn-by-turn):**
+
+```bash
+PYTHONPATH=services/rules python3 services/rules/demo_cli.py 2>&1 | head -80
+```
+
+### 3. Parse results
+
+From predict_combat output, extract:
+
+- Win rate (attacker vs defender)
+- Average damage per attack
+- Average margin of success
+- Status effect distribution (bleeding, fracture, stun)
+- Average PT spent per turn
+
+### 4. Produce report
+
+```
+## Combat Simulation Report
+
+| Metric | Value |
+|--------|-------|
+| Simulations | 1000 |
+| Attacker win rate | X% |
+| Avg damage/attack | X |
+| Avg MoS | X |
+| Status infliction rate | X% |
+
+### Status distribution
+| Status | Frequency |
+|--------|-----------|
+| bleeding | X% |
+| fracture | X% |
+| stunned | X% |
+| focused | X% |
+```
+
+### 5. Balance assessment
+
+Compare results against balance targets from `packs/evo_tactics_pack/data/balance/`:
+
+- Win rate should be 45-55% for balanced matchups
+- If >60% or <40% → flag asymmetry
+- If status infliction >50% → may need tuning
+
+### 6. If user provides specific matchup
+
+Parse species/trait names from user input. Build custom combat config and pass to predict_combat with specific parameters.

--- a/.claude/commands/docs-govern.md
+++ b/.claude/commands/docs-govern.md
@@ -1,0 +1,68 @@
+---
+name: docs-govern
+description: Run docs governance check locally (frontmatter, registry, stale docs)
+user_invocable: true
+---
+
+# Docs Governance
+
+Local pre-CI governance check. Faster than waiting for GitHub Actions.
+
+## Steps
+
+### 1. Run governance validator
+
+```bash
+python tools/check_docs_governance.py --registry docs/governance/docs_registry.json --strict 2>&1
+```
+
+### 2. Parse output
+
+If errors:
+
+- **Missing frontmatter** → list files, suggest adding with schema from `docs/governance/docs_metadata.schema.json`
+- **Registry drift** → list paths not in registry, suggest running `tools/docs_governance_migrator.py`
+- **Stale entries** → registry points to files that don't exist
+
+### 3. Quick stale check
+
+Find docs not updated in 90+ days (review_cycle_days default):
+
+```bash
+find docs/ -name "*.md" -not -path "docs/archive/*" -not -path "docs/generated/*" -mtime +90 2>/dev/null | head -20
+```
+
+### 4. Workstream coverage
+
+Check each hub has recent activity:
+
+```bash
+for hub in combat flow atlas backend dataset-pack ops-qa incoming cross-cutting; do
+  echo -n "$hub: "
+  find "docs/" -path "*$hub*" -name "*.md" -mtime -30 2>/dev/null | wc -l
+done
+```
+
+### 5. Produce report
+
+```
+## Docs Governance Report
+
+| Check | Status | Detail |
+|-------|--------|--------|
+| Frontmatter | 🟢/🔴 | N files missing |
+| Registry sync | 🟢/🔴 | N orphan entries |
+| Stale docs (>90d) | 🟢/🟡 | N files |
+| Workstream coverage | 🟢/🟡 | ... |
+
+### Files needing attention
+<list>
+```
+
+### 6. Auto-fix option
+
+If user asks to fix:
+
+- Run `python tools/docs_governance_migrator.py` for bulk frontmatter generation
+- Update registry entries for new files
+- Ask user to confirm before committing

--- a/.claude/commands/monitor.md
+++ b/.claude/commands/monitor.md
@@ -1,0 +1,184 @@
+---
+name: monitor
+description: Design-direction monitor — assess project health against frozen pillars, reference repos, and architectural patterns
+user_invocable: true
+trigger: "come sto mettendo?", "cosa lavoro adesso?", "sono sulla strada giusta?", "monitor", "design check", "health check progetto", "stato progetto", "dove siamo?"
+---
+
+# Evo-Tactics Design Monitor
+
+Comprehensive project health assessment against the 6 design pillars, 7 reference repos, and frozen architectural patterns.
+
+## Reference baseline
+
+Read these (targeted, not full):
+
+- `CLAUDE.md` → grep "Pilastri di design" and "Sprint context" sections
+- `docs/core/90-FINAL-DESIGN-FREEZE.md` → first 100 lines for freeze scope
+- `docs/guide/external-references.md` → section A "DEEP DIVE" table (lines 20-33) for repo-pillar mapping
+- `docs/planning/tactical-architecture-patterns.md` → "Riepilogo priorita" table (lines 22-40) for pattern adoption status
+
+## Steps
+
+### 1. Pillar health with reference-repo lens
+
+For each pillar, assess current state AND alignment with reference patterns:
+
+**P1 — Tattica leggibile (FFT)**
+Reference: **wesnoth** (combat prediction, terrain defense), **boardgame.io** (round flow), **Frozen Synapse** (simultaneous turns), **Halfway** (grid readability)
+
+- Check: `services/rules/resolver.py` — does `predict_combat()` exist and work?
+- Check: terrain defense modifier implemented? (`grep "terrain_defense\|defense_mod" services/rules/ data/core/`)
+- Check: all decision numbers surfaced? (hit%, damage range, MoS thresholds, cooldown — per Halfway lesson)
+- Wesnoth pattern W1 (combat prediction): implemented? W4 (terrain defense): implemented?
+
+**P2 — Evoluzione emergente (Spore)**
+Reference: **bevy** (ECS composition), **Hades** (progression loop), **Cogmind** (modular components), **Binding of Isaac** (emergent combos)
+
+- Check: trait combo system active? (`grep "combo\|synerg\|PP.*combo\|SG.*surge" apps/backend/`)
+- Check: progression transforms gameplay, not just stat bumps? (per Halfway lesson)
+- Bevy pattern: species = archetype bundle, job = system set? Check species JSON structure.
+
+**P3 — Identita Specie x Job**
+Reference: **OpenRA** (YAML actor-trait composition), **bevy** (bundles + required components)
+
+- Check: `data/core/traits/active_effects.yaml` — traits are data-driven, not hardcoded?
+- Check: species have meaningful differentiation beyond stats?
+- OpenRA pattern: auto-generated trait docs? (`grep "gen_trait_docs\|gen_trait_types" tools/py/`)
+
+**P4 — Temperamenti MBTI/Ennea**
+Reference: **xstate** (personality FSM), **Theory of Fun** (learning patterns)
+
+- Check: `statusEffectsMachine.js` uses xstate? MBTI axes implemented? Ennea themes in YAML?
+- Check: `grep "deriveMbtiType\|ennea\|mbti" apps/backend/`
+
+**P5 — Co-op vs Sistema**
+Reference: **wesnoth** (AI composite), **boardgame.io** (MCTS bot), **AI War** (threat meter, asymmetry)
+
+- Check: AI policy data-driven? (`data/core/balance/ai_intent_scores.yaml` exists?)
+- Check: AI personality variants? (`data/core/balance/ai_profiles.yaml` exists?)
+- AI War pattern: threat reattivo? Sistema punisce turtling?
+- boardgame.io pattern: MCTS or weighted objectives for Sistema?
+
+**P6 — Fairness**
+Reference: **wesnoth** (20yr balance), **Machinations** (economy modeling), **Balatro** (emergent balance), **SpaceChem** (simple rules, emergent complexity)
+
+- Check: resistance matrix implemented? (`grep "resistance\|species_resistance" packs/ data/core/`)
+- Check: PT economy allows meaningful choices per turn? (3 PT budget analysis)
+
+### 2. Pattern adoption tracker
+
+From `docs/planning/tactical-architecture-patterns.md`, check which of the 16 patterns are implemented:
+
+```bash
+grep -rl "predict_combat" services/rules/ 2>/dev/null && echo "W1 combat prediction: YES" || echo "W1: NO"
+grep -rl "terrain_defense" services/rules/ data/core/ 2>/dev/null && echo "W4 terrain defense: YES" || echo "W4: NO"
+grep -rl "ai_intent_scores" data/core/ apps/backend/ 2>/dev/null && echo "W3 AI intent registry: YES" || echo "W3: NO"
+grep -rl "statusEffectsMachine\|roundStatechart" apps/backend/ 2>/dev/null && echo "X1/X2 xstate FSM: YES" || echo "X1/X2: NO"
+grep -rl "sistemaActor" apps/backend/ 2>/dev/null && echo "X3 Sistema actor model: YES" || echo "X3: NO"
+grep -rl "movement_profiles" data/core/ packs/ 2>/dev/null && echo "W5 movement profiles: YES" || echo "W5: NO"
+grep -rl "pluginLoader" apps/backend/ 2>/dev/null && echo "BEVY plugin modularity: YES" || echo "BEVY: NO"
+grep -rl "narrativeEngine\|inkjs\|ink" apps/backend/ 2>/dev/null && echo "INK narrative: YES" || echo "INK: NO"
+```
+
+### 3. Technical health
+
+```bash
+node --test tests/ai/*.test.js 2>&1 | tail -5
+npm run format:check 2>&1 | tail -3
+git status --short
+git log --oneline -10
+```
+
+### 4. Guardrail check
+
+```bash
+git log --oneline --name-only -10 | grep -E "(\.github/workflows/|packages/contracts/|services/generation/|migrations/)" || echo "No guardrail touches"
+```
+
+Hardcoded trait check:
+
+```bash
+grep -rn "artigli_sette_vie\|coda_frusta_cinetica\|scheletro_idro_regolante" services/rules/ apps/backend/routes/session*.js --include="*.js" --include="*.py" | grep -v "fallback\|test\|#\|//" | head -5
+```
+
+### 5. Game-Database sync check
+
+```bash
+git log --oneline -1 -- packs/evo_tactics_pack/docs/catalog/
+```
+
+Compare timestamp with last known evo:import run.
+
+### 6. Produce scorecard
+
+```
+## Evo-Tactics Health Scorecard
+
+### Design pillars
+| # | Pilastro | Status | Reference alignment | Gap |
+|---|----------|--------|-------------------|-----|
+| 1 | Tattica leggibile | 🟢/🟡/🔴 | wesnoth W1/W4: YES/NO | ... |
+| 2 | Evoluzione emergente | 🟢/🟡/🔴 | bevy ECS: YES/NO | ... |
+| 3 | Identita Specie×Job | 🟢/🟡/🔴 | OpenRA YAML comp: YES/NO | ... |
+| 4 | Temperamenti MBTI/Ennea | 🟢/🟡/🔴 | xstate FSM: YES/NO | ... |
+| 5 | Co-op vs Sistema | 🟢/🟡/🔴 | AI War threat: YES/NO | ... |
+| 6 | Fairness | 🟢/🟡/🔴 | wesnoth resistance: YES/NO | ... |
+
+### Pattern adoption (from tactical-architecture-patterns.md)
+| Pattern | Source | Implemented | File |
+|---------|--------|:-----------:|------|
+| W1 combat prediction | wesnoth | ✅/❌ | ... |
+| W2 damage type matrix | wesnoth | ✅/❌ | ... |
+| W3 AI intent registry | wesnoth | ✅/❌ | ... |
+| W4 terrain defense | wesnoth | ✅/❌ | ... |
+| B1 auto phase transitions | boardgame.io | ✅/❌ | ... |
+| B2 centralized validation | boardgame.io | ✅/❌ | ... |
+| X1 status effects FSM | xstate | ✅/❌ | ... |
+| X2 round statechart | xstate | ✅/❌ | ... |
+| X3 Sistema actor model | xstate | ✅/❌ | ... |
+| INK narrative engine | ink | ✅/❌ | ... |
+| BEVY plugin modularity | bevy | ✅/❌ | ... |
+
+### Technical health
+| Check | Status | Detail |
+|-------|--------|--------|
+| AI tests | 🟢/🔴 | X/45 pass |
+| Format | 🟢/🔴 | ... |
+| Working tree | 🟢/🟡 | clean / N files |
+| Guardrails | 🟢/🔴 | ... |
+| Hardcoded traits | 🟢/🔴 | ... |
+| Game-Database sync | 🟢/🟡 | last catalog: <date> |
+
+### Postmortem lessons check
+| Lesson | Source | Status |
+|--------|--------|--------|
+| All decision numbers surfaced | Halfway | 🟢/🟡 |
+| Enemy variety via AI personality | Halfway + AI War | 🟢/🟡 |
+| Progression transforms gameplay | Halfway + Hades | 🟢/🟡 |
+| Threat reattivo (no turtling) | AI War | 🟢/🟡 |
+| Sistema response leggibile | AI War | 🟢/🟡 |
+```
+
+### 7. Suggest next steps
+
+Priority order:
+
+1. 🔴 items (broken/missing)
+2. Unimplemented high-impact patterns from tactical-architecture-patterns.md
+3. Postmortem lessons not yet addressed
+4. Next milestone from Final Design Freeze roadmap
+
+For each suggestion, cite the reference repo/postmortem that motivates it.
+
+### 8. Authority reminder
+
+If any finding contradicts freeze:
+
+- A1 (ADR/hubs) > A3 (freeze) for boundary definitions
+- A2 (data/contracts) > A3 for mechanical truth
+- A3 > A5 for shipping scope
+
+## Output
+
+Caveman-compatible. Tables first, prose only for actionable gaps. Each gap cites reference repo or postmortem.

--- a/.claude/commands/pr-prepare.md
+++ b/.claude/commands/pr-prepare.md
@@ -1,0 +1,116 @@
+---
+name: pr-prepare
+description: Pre-flight checks and PR body generation before opening a pull request
+user_invocable: true
+---
+
+# PR Prepare
+
+Run all pre-merge gates from CONTRIBUTING.md, generate PR body with changelog + rollback plan.
+
+## Arguments
+
+Optional: PR title or branch name. If omitted, infer from current branch.
+
+## Steps
+
+### 1. Identify changes
+
+```bash
+BRANCH=$(git branch --show-current)
+BASE="origin/main"
+git log --oneline $BASE..$BRANCH
+git diff --stat $BASE..$BRANCH
+```
+
+### 2. Format check + fix
+
+```bash
+npm run format:check 2>&1
+```
+
+If fails: `npm run format`, stage fixed files, report.
+
+### 3. Run tests
+
+```bash
+npm run test 2>&1 | tail -20
+```
+
+If AI tests exist and session code touched:
+
+```bash
+node --test tests/ai/*.test.js 2>&1 | tail -5
+```
+
+### 4. Docs governance
+
+Check if any new `.md` files in `docs/` lack frontmatter:
+
+```bash
+git diff --name-only $BASE..$BRANCH -- "docs/**/*.md" | while read f; do head -1 "$f" | grep -q "^---" || echo "MISSING FRONTMATTER: $f"; done
+```
+
+If new docs found → check `docs/governance/docs_registry.json` has entries for them.
+
+### 5. Contract ripple check
+
+```bash
+git diff --name-only $BASE..$BRANCH | grep "packages/contracts/" && echo "CONTRACTS CHANGED — verify mock:generate was run" || true
+```
+
+### 6. Generate changelog entry
+
+From commit messages, produce a concise changelog entry:
+
+- feat: → "Aggiunto: ..."
+- fix: → "Corretto: ..."
+- refactor: → "Ristrutturato: ..."
+- test: → "Test: ..."
+
+### 7. Generate rollback plan (03A)
+
+Template:
+
+```
+### 03A Rollback Plan
+1. `git revert <merge-commit>` on main
+2. Affected services: [list from diff]
+3. Data migration: [none / describe]
+4. Monitoring: check [endpoints/tests] post-revert
+```
+
+### 8. Produce PR body
+
+```markdown
+## Summary
+
+<bullet points from changelog>
+
+## Checklist
+
+- [x] `npm run format:check` passa
+- [x] `npm run test` passa
+- [x] Docs governance verificata
+- [ ] Master DD approval
+
+## Changelog
+
+<generated entry>
+
+## 03A Rollback Plan
+
+<generated plan>
+
+## Test plan
+
+<inferred from changes>
+```
+
+### 9. Open PR
+
+Ask user: "Creo la PR con questo body?" If yes:
+
+```bash
+gh pr create --title "<title>" --body "<body>" --base main
+```

--- a/.claude/commands/sprint-close.md
+++ b/.claude/commands/sprint-close.md
@@ -1,0 +1,95 @@
+---
+name: sprint-close
+description: Run full Definition of Done checklist, generate sprint summary, update CLAUDE.md
+user_invocable: true
+---
+
+# Sprint Close
+
+Automated DoD verification + sprint summary generation.
+
+## Steps
+
+### 1. Run test suites
+
+```bash
+node --test tests/ai/*.test.js 2>&1
+```
+
+Report: X/45 pass. If any fail → STOP, flag, do not proceed.
+
+### 2. Format check
+
+```bash
+npm run format:check 2>&1
+```
+
+If fail → run `npm run format` to fix, then re-check.
+
+### 3. Working tree check
+
+```bash
+git status --short
+```
+
+If uncommitted changes → list them, warn user.
+
+### 4. Forbidden directory scan
+
+Check if recent commits added files to forbidden areas:
+
+```bash
+git diff --name-only HEAD~10..HEAD | grep -E "^(\.github/workflows/|packages/contracts/|services/generation/|migrations/)" || echo "No guardrail touches"
+```
+
+If hits found → list them with commit hash and author. Verify signaling happened.
+
+### 5. Doc update verification
+
+```bash
+git diff --name-only HEAD~10..HEAD | grep -E "(vcScoring|policy\.js)" && echo "CHECK: docs/architecture/ai-policy-engine.md updated?" || true
+git diff --name-only HEAD~10..HEAD | grep -E "services/rules/" && echo "CHECK: docs/hubs/combat.md updated?" || true
+```
+
+### 6. Generate sprint summary
+
+Collect:
+
+```bash
+git log --oneline --since="7 days ago" | head -30
+git diff --stat HEAD~20..HEAD | tail -5
+gh pr list --state merged --limit 20 --json number,title,mergedAt
+```
+
+### 7. Produce DoD scorecard
+
+```
+## Sprint Close Report
+
+| Check | Status | Detail |
+|-------|--------|--------|
+| AI tests | 🟢/🔴 | X/45 pass |
+| Format | 🟢/🔴 | ... |
+| Working tree | 🟢/🟡 | clean / N files |
+| Guardrail touches | 🟢/🔴 | ... |
+| Doc updates | 🟢/🟡 | ... |
+| PR merged | — | N PRs |
+| LOC delta | — | +X / -Y |
+```
+
+### 8. Update CLAUDE.md sprint context
+
+Read current CLAUDE.md "Sprint context" section. Update:
+
+- Sprint number
+- PR count + range
+- Test counts
+- Ultimo commit hash
+- Milestone completate (from PR titles)
+- Pillar status (only change if evidence from this sprint)
+
+Ask user to confirm before writing.
+
+## Output
+
+Caveman-compatible. Table-first. Only flag actionable items.

--- a/.claude/commands/trait-lint.md
+++ b/.claude/commands/trait-lint.md
@@ -1,0 +1,88 @@
+---
+name: trait-lint
+description: Cross-validate trait definitions across glossary, active_effects, trait_mechanics, and Game-Database
+user_invocable: true
+---
+
+# Trait Lint
+
+Cross-check trait consistency across all sources of truth.
+
+## Steps
+
+### 1. Load trait sources
+
+Read these files (use targeted reads):
+
+- `data/core/traits/active_effects.yaml` — canonical trait registry (A2)
+- `packs/evo_tactics_pack/data/balance/trait_mechanics.yaml` — combat balance values
+- `data/core/traits/glossary.json` — labels IT/EN + descriptions
+- `packs/evo_tactics_pack/docs/catalog/trait_glossary.json` — export for Game-Database
+- `packs/evo_tactics_pack/docs/catalog/trait_reference.json` — rich trait data
+
+Extract slug lists from each.
+
+### 2. Cross-reference
+
+Build sets:
+
+- `A` = slugs in active_effects.yaml
+- `M` = slugs in trait_mechanics.yaml
+- `G` = slugs in glossary.json
+- `C` = slugs in trait_glossary.json (catalog export)
+- `R` = slugs in trait_reference.json
+
+Check:
+
+- `A \ G` = active traits missing from glossary (labels needed)
+- `M \ A` = mechanics defined but trait not in active_effects (orphan mechanics)
+- `A \ M` = active traits without combat mechanics (may be intentional for non-combat traits)
+- `G \ C` = glossary entries not in catalog export (sync:evo-pack needed?)
+- `R \ G` = reference entries not in glossary
+
+### 3. Hardcoded trait check
+
+```bash
+grep -rn "artigli_sette_vie\|coda_frusta_cinetica\|scheletro_idro_regolante\|criostasi_adattiva" services/rules/ apps/backend/routes/session*.js apps/backend/services/ --include="*.js" --include="*.py" | grep -v "fallback\|test\|comment\|#"
+```
+
+Only the hardcoded fallback set in generation orchestrator is acceptable. Any other occurrence = violation.
+
+### 4. Type consistency
+
+For traits in both active_effects and mechanics:
+
+- Does the dataType match? (NUMERIC in glossary but TEXT in mechanics?)
+- Range min/max consistent?
+
+### 5. Produce report
+
+```
+## Trait Lint Report
+
+| Check | Count | Status |
+|-------|-------|--------|
+| Active traits | N | — |
+| With mechanics | N | 🟢/🟡 |
+| With glossary labels | N | 🟢/🟡 |
+| In catalog export | N | 🟢/🟡 |
+| Orphan mechanics | N | 🟢/🔴 |
+| Missing glossary | N | 🟢/🔴 |
+| Hardcoded in code | N | 🟢/🔴 |
+| Type mismatches | N | 🟢/🔴 |
+
+### Orphan mechanics (in mechanics but not active_effects)
+<list slugs>
+
+### Missing glossary labels
+<list slugs>
+
+### Hardcoded violations
+<list with file:line>
+```
+
+### 6. Suggest fixes
+
+- Missing glossary → "Add to glossary.json then run sync:evo-pack"
+- Orphan mechanics → "Remove from trait_mechanics.yaml or add to active_effects.yaml"
+- Catalog drift → "Run npm run sync:evo-pack"

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -17,7 +17,7 @@
       "name": "dev-stack",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev:stack"],
-      "port": 3333
+      "port": 3334
     }
   ]
 }

--- a/.claude/skills/evo-tactics-monitor.md
+++ b/.claude/skills/evo-tactics-monitor.md
@@ -1,0 +1,94 @@
+---
+name: evo-tactics-monitor
+description: Monitor Evo-Tactics design direction, guardrails, and sprint health
+user_invocable: true
+trigger: "come sto mettendo?", "cosa lavoro adesso?", "sono sulla strada giusta?", "monitor", "design check", "health check progetto", "stato progetto", "dove siamo?"
+---
+
+# Evo-Tactics Design Monitor
+
+You are a design-direction monitor for the Evo-Tactics project. Your job is to assess project health against the frozen design pillars, guardrails, and Definition of Done.
+
+## Steps
+
+### 1. Gather current state
+
+Read these files (use offset/limit to avoid loading too much):
+
+- `CLAUDE.md` — search for "Pilastri di design" section and "Sprint context" section (around line 200+)
+- `docs/core/90-FINAL-DESIGN-FREEZE.md` — first 100 lines for freeze status and scope
+- Run: `git log --oneline -20` for recent activity
+- Run: `git diff --stat HEAD~5..HEAD` for recent change scope
+- Run: `git status --short` for uncommitted work
+- Run: `node --test tests/ai/*.test.js 2>&1 | tail -5` for AI test status
+- Run: `npm run format:check 2>&1 | tail -3` for format status
+
+### 2. Check guardrail violations
+
+Grep recent commits for changes to protected areas:
+
+```bash
+git log --oneline --name-only -10 | grep -E "(\.github/workflows/|packages/contracts/|services/generation/|migrations/)"
+```
+
+If any hits: flag as guardrail touch — verify it was signaled/approved.
+
+### 3. Check hardcoded traits
+
+```bash
+git diff HEAD~5..HEAD -- services/rules/ apps/backend/routes/session*.js | grep -E "(artigli|coda_frusta|scheletro|criostasi)" | head -10
+```
+
+Trait logic must live in `data/core/traits/active_effects.yaml`, never hardcoded in resolver/session code.
+
+### 4. Check schema parity
+
+```bash
+git log --oneline --name-only -10 | grep "packages/contracts/"
+```
+
+If contracts changed: verify `npm run mock:generate` was run (check if `apps/dashboard/public/data/` has matching timestamps).
+
+### 5. Produce scorecard
+
+Output this table with live status from the checks above:
+
+```
+## Evo-Tactics Health Scorecard
+
+| Area | Status | Note |
+|------|--------|------|
+| Pilastro 1: Tattica leggibile | 🟢/🟡/🔴 | ... |
+| Pilastro 2: Evoluzione emergente | 🟢/🟡/🔴 | ... |
+| Pilastro 3: Identita Specie×Job | 🟢/🟡/🔴 | ... |
+| Pilastro 4: Temperamenti MBTI/Ennea | 🟢/🟡/🔴 | ... |
+| Pilastro 5: Co-op vs Sistema | 🟢/🟡/🔴 | ... |
+| Pilastro 6: Fairness | 🟢/🟡/🔴 | ... |
+| Test AI | 🟢/🔴 | X/45 pass |
+| Format check | 🟢/🔴 | ... |
+| Working tree | 🟢/🟡 | clean / N uncommitted |
+| Guardrail violations | 🟢/🔴 | ... |
+| Hardcoded traits | 🟢/🔴 | ... |
+| Schema parity | 🟢/🟡 | ... |
+| Game-Database sync | 🟢/🟡 | last evo:import date |
+```
+
+### 6. Suggest next steps
+
+Based on the scorecard:
+
+- If all green: suggest next sprint focus from `docs/core/90-FINAL-DESIGN-FREEZE.md` roadmap section
+- If any yellow/red: prioritize fixes before new features
+- Always check: are there open PRs that need review? (`gh pr list --state open`)
+
+### 7. Authority reminder
+
+If any finding contradicts the design freeze, cite the source authority:
+
+- A1 (ADR/hubs) > A3 (freeze) for boundary definitions
+- A2 (data/contracts) > A3 for mechanical truth
+- A3 > A5 for shipping scope decisions
+
+## Output format
+
+Caveman-compatible: terse, fragments OK, no filler. Table-first, prose only for actionable items.


### PR DESCRIPTION
## Summary
- 8 slash commands in `.claude/commands/`: `/monitor`, `/sprint-close`, `/pr-prepare`, `/trait-lint`, `/catalog-sync`, `/authority-check`, `/combat-sim`, `/docs-govern`
- 5 agents in `.claude/agents/`: `balance-auditor`, `schema-ripple`, `species-reviewer`, `session-debugger`, `migration-planner`
- `/monitor` uses 7 reference repos (wesnoth, boardgame.io, xstate, OpenRA, bevy, ink, langium) + 5 postmortem lessons as evaluation lens
- Fix: launch.json dev-stack port 3333→3334

## Test plan
- [x] No code changes — only `.claude/` config files
- [ ] Invoke `/monitor` in a session with CWD=Desktop/Game to verify output

🤖 Generated with [Claude Code](https://claude.com/claude-code)