### PR TITLE
feat(combat): decision surfacing + PT economy depth

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -83,6 +83,7 @@ const {
   stepTowards,
   isBackstab,
   facingFromMove,
+  predictCombat,
 } = require('./sessionHelpers');
 const { createRoundBridge } = require('./sessionRoundBridge');
 
@@ -600,6 +601,32 @@ function createSessionRouter(options = {}) {
     const { error, session } = resolveSession(req.query?.session_id);
     if (error) return res.status(error.status).json(error.body);
     res.json(publicSessionView(session));
+  });
+
+  // Halfway lesson (decision surfacing): pre-combat prediction.
+  // Ritorna hit%, crit%, fumble%, avg MoS, avg PT per un attacco
+  // actor → target senza eseguirlo. Il client mostra questi numeri
+  // per rendere la tattica leggibile (P1).
+  router.post('/predict', (req, res) => {
+    const body = req.body || {};
+    const { error, session } = resolveSession(body.session_id);
+    if (error) return res.status(error.status).json(error.body);
+
+    const actor = session.units.find((u) => u.id === body.actor_id);
+    if (!actor) {
+      return res.status(400).json({ error: `actor_id "${body.actor_id}" non trovato` });
+    }
+    const target = session.units.find((u) => u.id === body.target_id);
+    if (!target) {
+      return res.status(400).json({ error: `target_id "${body.target_id}" non trovato` });
+    }
+
+    const prediction = predictCombat(actor, target);
+    res.json({
+      actor_id: actor.id,
+      target_id: target.id,
+      ...prediction,
+    });
   });
 
   router.post('/action', async (req, res, next) => {

--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -132,6 +132,59 @@ function resolveAttack({ actor, target, rng }) {
   return { die, roll, mos, hit, dc, pt };
 }
 
+/**
+ * Predizione combattimento (Halfway lesson: decision surfacing).
+ * Simula N attacchi con la stessa formula di resolveAttack e ritorna
+ * distribuzione statistica per il client.
+ *
+ * @param {{ mod?: number }} actor
+ * @param {{ dc?: number, dc_difesa?: number, mod?: number }} target
+ * @param {number} [n=1000] — simulazioni
+ * @returns {{ simulations, hit_pct, crit_pct, fumble_pct, avg_mos, dc, attack_mod, avg_pt }}
+ */
+function predictCombat(actor, target, n = 1000) {
+  const attackMod = actor.mod || 0;
+  const dc = target.dc ?? target.dc_difesa ?? 10 + (target.mod || 0);
+
+  let hits = 0;
+  let crits = 0;
+  let fumbles = 0;
+  let totalMos = 0;
+  let totalPt = 0;
+
+  // Analytic simulation over all 20 d20 faces, weighted equally
+  // (faster and more accurate than random sampling for d20)
+  for (let die = 1; die <= 20; die++) {
+    const roll = die + attackMod;
+    const mos = roll - dc;
+    const hit = mos >= 0;
+
+    if (hit) {
+      hits++;
+      let pt = 0;
+      if (die >= 15 && die <= 19) pt += 1;
+      if (die === 20) pt += 2;
+      pt += Math.floor(mos / 5);
+      totalPt += pt;
+      totalMos += mos;
+    }
+    if (die === 20) crits++;
+    if (die === 1) fumbles++;
+  }
+
+  const total = 20; // exact enumeration over d20
+  return {
+    simulations: total,
+    hit_pct: Math.round((hits / total) * 1000) / 10,
+    crit_pct: Math.round((crits / total) * 1000) / 10,
+    fumble_pct: Math.round((fumbles / total) * 1000) / 10,
+    avg_mos: hits > 0 ? Math.round((totalMos / hits) * 10) / 10 : 0,
+    avg_pt: hits > 0 ? Math.round((totalPt / hits) * 10) / 10 : 0,
+    dc,
+    attack_mod: attackMod,
+  };
+}
+
 function timestampStamp(date) {
   const iso = date.toISOString();
   return iso
@@ -253,4 +306,5 @@ module.exports = {
   stepTowards,
   isBackstab,
   facingFromMove,
+  predictCombat,
 };

--- a/packages/contracts/schemas/combat.schema.json
+++ b/packages/contracts/schemas/combat.schema.json
@@ -77,8 +77,8 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["perforazione"],
-          "description": "Categoria di spesa PT dal docs/10-SISTEMA_TATTICO.md ('spese su perforazione, spinte, condizioni e combo'). Attualmente implementata solo 'perforazione' (riduce armor del target di 2 per questo attacco); le altre 3 sono rimandate."
+          "enum": ["perforazione", "spinta"],
+          "description": "Categoria di spesa PT dal docs/10-SISTEMA_TATTICO.md. 'perforazione' riduce armor target di 2 per questo attacco; 'spinta' applica status 'sbilanciato' (-1 defense_mod, 1 turno) su hit. Le categorie 'condizioni' e 'combo' sono rimandate."
         },
         "amount": { "type": "integer", "minimum": 1 }
       },

--- a/tests/api/predict-combat.test.js
+++ b/tests/api/predict-combat.test.js
@@ -1,0 +1,143 @@
+// Integration tests: decision surfacing (Halfway lesson).
+//
+// Copre:
+//   - predictCombat pure function (hit%, crit%, fumble%, MoS, PT)
+//   - POST /api/session/predict endpoint
+//   - PT spend schema con spinta
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+const { predictCombat } = require('../../apps/backend/routes/sessionHelpers');
+
+// ─────────────────────────────────────────────────────────────────
+// predictCombat pure function
+// ─────────────────────────────────────────────────────────────────
+
+test('predictCombat: returns expected shape', () => {
+  const actor = { mod: 3 };
+  const target = { dc: 12 };
+  const result = predictCombat(actor, target);
+
+  assert.equal(typeof result.hit_pct, 'number');
+  assert.equal(typeof result.crit_pct, 'number');
+  assert.equal(typeof result.fumble_pct, 'number');
+  assert.equal(typeof result.avg_mos, 'number');
+  assert.equal(typeof result.avg_pt, 'number');
+  assert.equal(result.dc, 12);
+  assert.equal(result.attack_mod, 3);
+  assert.equal(result.simulations, 20);
+});
+
+test('predictCombat: hit% is correct for mod 3 vs DC 12', () => {
+  // d20+3 vs DC 12: need roll >= 9. Rolls 9-20 hit = 12/20 = 60%
+  const result = predictCombat({ mod: 3 }, { dc: 12 });
+  assert.equal(result.hit_pct, 60);
+});
+
+test('predictCombat: crit always 5% (nat 20)', () => {
+  const result = predictCombat({ mod: 0 }, { dc: 15 });
+  assert.equal(result.crit_pct, 5);
+});
+
+test('predictCombat: fumble always 5% (nat 1)', () => {
+  const result = predictCombat({ mod: 5 }, { dc: 10 });
+  assert.equal(result.fumble_pct, 5);
+});
+
+test('predictCombat: mod 0 vs DC 10 → 55% hit (rolls 10-20)', () => {
+  const result = predictCombat({ mod: 0 }, { dc: 10 });
+  assert.equal(result.hit_pct, 55);
+});
+
+test('predictCombat: avg_pt > 0 when hits occur', () => {
+  const result = predictCombat({ mod: 5 }, { dc: 10 });
+  assert.ok(result.avg_pt > 0, 'should gain PT on hits');
+});
+
+test('predictCombat: DC fallback when target has no dc', () => {
+  // dc = 10 + target.mod (0) = 10
+  const result = predictCombat({ mod: 0 }, { mod: 0 });
+  assert.equal(result.dc, 10);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// POST /api/session/predict endpoint
+// ─────────────────────────────────────────────────────────────────
+
+test('POST /api/session/predict returns prediction for valid session', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  // Start session
+  const startRes = await request(app).post('/api/session/start').send({});
+  assert.equal(startRes.status, 200);
+  const sid = startRes.body.session_id;
+  const units = startRes.body.state.units;
+  const actor = units.find((u) => u.controlled_by === 'player');
+  const target = units.find((u) => u.controlled_by !== actor.controlled_by);
+
+  // Predict
+  const res = await request(app).post('/api/session/predict').send({
+    session_id: sid,
+    actor_id: actor.id,
+    target_id: target.id,
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.actor_id, actor.id);
+  assert.equal(res.body.target_id, target.id);
+  assert.ok(typeof res.body.hit_pct === 'number');
+  assert.ok(typeof res.body.dc === 'number');
+  assert.ok(typeof res.body.attack_mod === 'number');
+});
+
+test('POST /api/session/predict returns 400 for missing actor', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const startRes = await request(app).post('/api/session/start').send({});
+  const sid = startRes.body.session_id;
+
+  const res = await request(app).post('/api/session/predict').send({
+    session_id: sid,
+    actor_id: 'nonexistent',
+    target_id: 'also-nonexistent',
+  });
+  assert.equal(res.status, 400);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// PT spend schema: spinta now valid
+// ─────────────────────────────────────────────────────────────────
+
+test('combat schema accepts pt_spend with type spinta', () => {
+  const { combatSchema } = require('../../packages/contracts');
+  const { createSchemaValidator } = require('../../apps/backend/middleware/schemaValidator');
+
+  const validator = createSchemaValidator();
+  const ACTION_ID = 'test://action';
+  const actionSubschema = {
+    $schema: combatSchema.$schema,
+    $id: 'https://contracts.game.local/combat.action.schema.json',
+    ...combatSchema.$defs.action,
+    $defs: combatSchema.$defs,
+  };
+  validator.registerSchema(ACTION_ID, actionSubschema);
+
+  const action = {
+    id: 'act-spinta-01',
+    type: 'attack',
+    actor_id: 'party-alpha',
+    target_id: 'hostile-01',
+    ap_cost: 1,
+    pt_spend: { type: 'spinta', amount: 1 },
+  };
+  assert.doesNotThrow(() => validator.validate(ACTION_ID, action));
+});


### PR DESCRIPTION
## Summary
- **Decision surfacing** (P1 gap, Halfway lesson): new `POST /api/session/predict` endpoint returns hit%, crit%, fumble%, avg MoS, avg PT, DC, attack_mod for any actor→target pair. Pure d20 enumeration — exact probabilities, no Monte Carlo noise
- **PT economy depth** (P6 gap): add `spinta` to `pt_spend` schema enum — was implemented in Python resolver but blocked by JSON Schema validation. Players now have 2 meaningful PT spend types: perforazione (-2 armor) and spinta (applies sbilanciato status)

Closes all remaining design monitor gaps: P1 🟡→🟢, P6 🟡→🟢.

## Test plan
- [x] `node --test tests/api/predict-combat.test.js` — 10/10 pass
- [x] `node --test tests/ai/*.test.js` — 61/61 pass (no regression)
- [x] `npm run format:check` — green (my files)
- [ ] CI pipeline green

## Rollback plan (03A)
Single commit revert: `c71a1716`. Schema change is additive (new enum value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)