### PR TITLE
chore(docs): resolve 6/8 canonical refactor TODOs

### DIFF
--- a/docs/appendici/A-CANVAS_ORIGINALE.md
+++ b/docs/appendici/A-CANVAS_ORIGINALE.md
@@ -1,14 +1,21 @@
 ---
-versione: "Canvas A — Originale"
-ultima_revisione: "2025-10-23"
-fonte: "Export ChatGPT snapshot-20251023T101500Z (archivio interno)"
-note: |
-  Versione approvata durante la review VC-10/2025. Integra le telemetrie StressWave,
-  l'introduzione dei Resonance Shards e i requisiti HUD aggiornati per i vertical slice.
+title: 'Canvas A — Originale (A.L.I.E.N.A.)'
+doc_status: active
+doc_owner: platform-docs
+workstream: dataset-pack
+last_verified: '2026-04-16'
+source_of_truth: false
+language: it
+review_cycle_days: 30
+legacy_versione: 'Canvas A — Originale'
+legacy_ultima_revisione: '2025-10-23'
+legacy_fonte: 'Export ChatGPT snapshot-20251023T101500Z (archivio interno)'
 ---
+
 # Evo Tactics — Canvas Principale
 
 ## Visione
+
 Co-op tattico televisivo/app in cui cellule di resistenza guidano forme bio-meccanoidi
 in campagne generate, alternando pianificazione tabletop, incursioni in tempo semi-reale e
 fasi narrative a bivi. L'obiettivo è difendere habitat in mutazione costante, stabilizzare
@@ -16,17 +23,20 @@ nidi itineranti e guidare la comunità verso l'equilibrio tra coesione emotiva e
 bellica.
 
 ### Statement
+
 "Trasformare l'ansia da tiro di dado in un'intesa condivisa": ogni decisione deve
 visualizzare impatti immediati (risk/cohesion), proiettare conseguenze nel lungo periodo
 (stress, fiducia, reputazione) e restituire feedback audiovisivi sincronizzati tra TV e
 app compagne.
 
 ### Esperienza target
+
 - Gruppi da 3-4 giocatori in salotto, supportati da companion app su smartphone/tablet.
 - Sessioni da 90 minuti suddivise in atti: Briefing → Missione → Debrief/Nido.
 - Inclusività: onboarding in <10 minuti tramite preset Forme + direttive AI.
 
 ## Pilastri
+
 1. **Cooperazione situazionale** — Ruoli modulabili, poteri combinati, scoreboard
    cooperativo StressWave.
 2. **Mutazione significativa** — Ogni Forma evolve con tratti e parti che riscrivono
@@ -37,6 +47,7 @@ app compagne.
    affinità, fiducia e scelte morali del gruppo.
 
 ## Loop principale
+
 1. **Briefing** (TV): scelta missione, definizione obiettivo primario/secondario,
    assegnazione risorse, ricognizione telemetrica (Heatmap minacce + trend StressWave).
 2. **Setup squad** (App): drafting Forme/Job, moduli, mod richiesti. Check sinergie.
@@ -48,6 +59,7 @@ app compagne.
 6. **Fase Nido**: investimenti infrastruttura, ricerca mutazioni, gestione comunità.
 
 ## Progressione
+
 - **Livello Squadra** (1-10): sblocca slot PI, moduli sinergici, missioni avanzate.
 - **Prestigio Forma**: tracciato 5 tier; ogni tier concede tratti e mutazioni.
 - **Reputazione Fazioni**: influenza ricompense e missioni speciali.
@@ -55,6 +67,7 @@ app compagne.
   curva minacce.
 
 ### Evoluzione Tratti Base — Dune Stalker
+
 - **Core Tier 1**: Artigli Sette Vie + Struttura Elastica Amorfa + Scheletro Idro-Regolante.
   Mantengono mobilità verticale nelle cavità iper-saline e garantiscono difesa strutturale
   quando la squadra opera su terreni granulari instabili.
@@ -69,12 +82,14 @@ app compagne.
   missioni e ricaricare le sacche ascensoriali.
 
 ## Struttura Missioni
+
 - **Template**: Assault, Extraction, Resonance Survey, Escort, Siege.
 - **Obiettivi secondari**: ridurre StressWave, salvare NPG chiave, attivare Reattori Aeon.
 - **Twist dinamici**: Resistive Gates (richiedono Resonance Shards), Nidi itineranti,
   event-driven reinforcements.
 
 ## Sistema Dadi & Risoluzione
+
 - Core `d20` con bande di successo: Critico 18+, Successo 11-17, Parziale 6-10,
   Fallimento ≤5. Modificatori da PI, stance, condizioni.
 - `Stress Mod`: se StressWave > soglia scenario, sposta bande verso il fallimento.
@@ -82,39 +97,46 @@ app compagne.
 - `Clock` (d6 segmenti) per eventi a tempo (evacuazione, anomalie).
 
 ## Companion App
+
 - Draft Forme e Job con filtri per PI e sinergie.
 - Macro azioni rapide (Assist, Combo, Interrupt) con cooldown condivisi.
 - Chat contestuale con emote tattiche.
 - Upload telemetria (json/yaml) verso repository condiviso.
 
 ## UI / HUD
+
 - Overlay risk/cohesion su timeline missione.
 - Log turni esportabile con tag (Forma, Job, Affisso, outcome).
 - Indicatori vertical slice: highlight mismatch ruoli, callout StressWave.
 - Supporto `second screen`: mappa tattica interattiva + indicatori nido.
 
 ## Audio / Feedback
+
 - Layer musicale adattivo: modulazioni in base a StressWave.
 - Cue audio per combinazioni PI riuscite o fallite.
 - VO sintetica per Regista (tonalità modulata dalla fiducia squad).
 
 ## Telemetria & Analitiche
+
 - KPI principali: risk delta, coesione media, durata turno, tasso completamento.
 - Export automatico `session-metrics.yaml` (vedi `logs/playtests/2025-02-15-vc`).
 - Trigger alert su mismatch ruoli >20% tra aspettativa e utilizzo reale.
 
 ## Monetizzazione / Live Ops
+
 - Pacchetti espansione Forme & Biomi (DLC stagionali).
 - Pass narrativo: archi storyline, missioni leggendarie, skin.
 - Eventi community con leaderboard StressWave minima.
 
 ## Tech Stack
+
 - TV app: Unity HDRP + input multi-device (Gamepad/Touch).
 - Companion: Flutter + WebSocket low-latency.
 - Backend: Supabase/Postgres per telemetria, Cloud Functions per analisi.
 - Tools: YAML dataset (packs), generatori Python, validatori CI.
 
 ## Stato Attuale (10/2025)
+
 - Vertical slice VC completato con 3 missioni giocabili.
 - Telemetria StressWave integrata nei test con 12 squadre.
 - Companion app v0.9 (drafting + log turni) live su canale interno.

--- a/docs/appendici/C-CANVAS_NPG_BIOMI.md
+++ b/docs/appendici/C-CANVAS_NPG_BIOMI.md
@@ -1,25 +1,34 @@
 ---
-versione: "Canvas C — NPG & Biomi"
-ultima_revisione: "2025-10-23"
-fonte: "Export ChatGPT snapshot-20251023T101500Z (archivio interno)"
-note: |
-  Consolidato dopo i playtest VC-15/02/2025 con metriche su spawn adattivo.
-  Include aggiornamenti su protocolli di soccorso e affissi dinamici introdotti nel pack VC.
+title: 'Canvas C — NPG Reattivi, Biomi & Director'
+doc_status: active
+doc_owner: platform-docs
+workstream: dataset-pack
+last_verified: '2026-04-16'
+source_of_truth: false
+language: it
+review_cycle_days: 30
+legacy_versione: 'Canvas C — NPG & Biomi'
+legacy_ultima_revisione: '2025-10-23'
+legacy_fonte: 'Export ChatGPT snapshot-20251023T101500Z (archivio interno)'
 ---
+
 # Canvas C — NPG Reattivi, Biomi & Director
 
 ## Obiettivi del sistema NPG
+
 - Generare incontri modulati su StressWave, reputazione fazioni e progressione squad.
 - Rendere reclutamento/ostilità dinamici tramite Affinità/Fiducia.
 - Offrire loop di missioni emergenti (soccorso, trade, escalation) legati al contesto bioma.
 
 ## Struttura dati
+
 - `npg_id`, `biome`, `role`, `power_range`, `motivation`, `affinity_tags`, `reward_hooks`.
 - `spawn_profile`: min/max group_size, trigger (timer, obiettivo, soglia StressWave).
 - `director_flags`: `reinforce`, `retreat`, `convertible`, `legendary`.
 - `telemetry_hooks`: metriche su assist, danni ricevuti, eventi social.
 
 ## Biomi principali
+
 1. **Canyons Risonanti**
    - Affissi: `Echo Surge` (replica abilità sonore), `Shifting Winds` (modifica traiettorie).
    - Hazard: cadute, tunnel sonori. StressWave +0.05 ogni turno scoperto.
@@ -38,54 +47,63 @@ note: |
    - NPG: `Skydock Sentinels`, `Aeon Engineers` (supporto Reattori).
 
 ## Ruoli NPG
+
 - **Director**: regola spawn, escalate, drop. Gestito da AI.
 - **Fazioni**: Resistenti, Mercanti, Predatori, Colonie Nomadi.
 - **Archetipi**: Tank, Bruiser, Skirmish, Support, Control, Specialist, Mythic.
 - Ogni archetipo ha `behavior_tree`, `combo_hooks`, `loot_table`.
 
 ## Comportamenti dinamici
+
 - **StressWave Hooks**: se >0.60 attiva `Protocollo di soccorso` (rinforzi alleati) o `Overrun` (ondate nemiche).
 - **Affinità/Fiducia**: valori -3..+3. Influenza reazioni a chiamate radio, disponibilità trade, rischio tradimento.
 - **Motivazioni**: `Proteggi`, `Recupera`, `Stabilizza`, `Sfrutta`.
 - **Focus Director**: modula priorità (escalation vs tregua) in base a KPI missione.
 
 ## Tabelle spawn
-| Bioma | StressWave 0-0.3 | 0.31-0.6 | >0.6 |
-|-------|------------------|----------|------|
-| Canyons | Scout 2 + Support 1 | Bruiser 2 + Support 1 | Elite 1 + Reinforce timer |
-| Foresta | Shepherd 2 | Titan 1 + Shepherd 1 | Myco Hive + adds |
-| Atollo | Corsair 1 + Splicer 1 | Corsair 2 + Drone 1 | Legendary Tidecaller |
-| Orbitale | Sentinel 2 | Sentinel 1 + Engineer 1 | Director Command Squad |
+
+| Bioma    | StressWave 0-0.3      | 0.31-0.6                | >0.6                      |
+| -------- | --------------------- | ----------------------- | ------------------------- |
+| Canyons  | Scout 2 + Support 1   | Bruiser 2 + Support 1   | Elite 1 + Reinforce timer |
+| Foresta  | Shepherd 2            | Titan 1 + Shepherd 1    | Myco Hive + adds          |
+| Atollo   | Corsair 1 + Splicer 1 | Corsair 2 + Drone 1     | Legendary Tidecaller      |
+| Orbitale | Sentinel 2            | Sentinel 1 + Engineer 1 | Director Command Squad    |
 
 ## Missioni emergenti NPG
+
 - **Soccorso**: attivato da telemetria `ally_down`. Richiede completare 2 clock per estrarre.
 - **Contratto di Trade**: se reputazione Mercanti ≥2, genera hub mobile (loot esotico).
 - **Vendetta**: se NPG alleato ucciso → spawn nemico con buff Hate.
 - **Fuga**: NPG neutrale cerca evacuazione, offre bonus se assistito.
 
 ## Reclutamento rapido
+
 1. Identifica NPG `convertible`.
 2. Trigger narrazione (dialogo, supporto). Richiede check Affinità (d20, target 12).
 3. Se successo: si aggiunge alla Squad come `Ally Token` (slot limitati), sblocco missione legata.
 4. Fallimento critico: NPG segnala la squadra → StressWave +0.1.
 
 ## Gestione Mutazioni NPG
+
 - Tabelle mutazioni T0/T1/T2 legate a bioma.
 - Affissi ereditati dal nido (per NPG reclutati) influenzano stats e abilità.
 - `Fusion Node`: consente combinare due NPG convertiti (richiede Reattori Aeon + Resonance Shards).
 
 ## Interfacce & strumenti
+
 - Editor YAML `npg_pack.yaml` con validatore (`tools/py/.../validate_package.py`).
 - Dashboard Canvas: grafici spawn vs risk, timeline conversioni.
 - Log telemetria: `logs/playtests/<data>/session-metrics.yaml` registrano spawn, outcome, reward.
 
 ## KPI e Telemetria
+
 - Tasso conversione NPG → alleati.
 - Durata media scontro per bioma.
 - Uso abilità mito (>Tier 3) per sessione.
 - Eventi `Protocollo di soccorso` attivati e outcome.
 
 ## Stato 10/2025
+
 - Dataset `npg_pack.json` aggiornato con 48 profili.
 - Nuove carte Director per Resonance Siege e Skydock Siege.
 - Necessario bilanciamento `Myco Hive` (troppo punitivo in StressWave alto).

--- a/docs/appendici/D-CANVAS_ACCOPPIAMENTO.md
+++ b/docs/appendici/D-CANVAS_ACCOPPIAMENTO.md
@@ -1,19 +1,27 @@
 ---
-versione: "Canvas D — Mating, Reclutamento & Nido"
-ultima_revisione: "2025-10-23"
-fonte: "Export ChatGPT snapshot-20251023T101500Z (archivio interno)"
-note: |
-  Contiene le regole approvate per accoppiamento cross-fazione, gestione Nido itinerante
-  e sistemi di eredità parti/affissi. Validato con telemetria VC-02/2025.
+title: 'Canvas D — Mating, Reclutamento & Nido'
+doc_status: active
+doc_owner: platform-docs
+workstream: dataset-pack
+last_verified: '2026-04-16'
+source_of_truth: false
+language: it
+review_cycle_days: 30
+legacy_versione: 'Canvas D — Mating, Reclutamento & Nido'
+legacy_ultima_revisione: '2025-10-23'
+legacy_fonte: 'Export ChatGPT snapshot-20251023T101500Z (archivio interno)'
 ---
+
 # Canvas D — Attrazione, Affinità/Fiducia, Standard di Nido & Eredità
 
 ## Intento del sistema
+
 - Dare peso narrativo e meccanico alle relazioni con NPG e squadmates.
 - Trasformare il Nido in hub evolutivo che influenza mutazioni, reclutamento e economia.
 - Collegare progressione sociale (affinità/fiducia) a vantaggi tattici e sviluppo Forme.
 
 ## Struttura Affinità & Fiducia
+
 - Scala da -3 a +3 (ostilità → devozione). Valori separati per `Affinità` (empatia) e `Fiducia` (affidabilità).
 - Azioni Sociali chiave:
   - `Dialogo mirato` (check d20 + mod Charisma PI).
@@ -22,12 +30,14 @@ note: |
 - Eventi negativi: fallimento obiettivi, tradimenti, StressWave >0.70.
 
 ## Attrazione & Compatibilità
+
 - Tabelle `Piace/Non piace` per specie/job (vedi dataset `packs/.../affinity_trust.yaml`).
 - Compatibilità minima richiede Affinità ≥1 e Fiducia ≥0.
 - `Trigger Romance`: scena narrativa dedicata + scelta consensuale (tutti i giocatori devono approvare nella companion app).
 - Bonus temporanei: `Bond Link` (reroll cooperativo 1/sessione), `Shared Resilience` (-0.05 StressWave su fallimento condiviso).
 
 ## Reclutamento da ex-nemici
+
 1. Identifica NPG con tag `convertible` (Canvas C).
 2. Supera due prove narrative (dialogo/aiuto/salvataggio) → +1 Affinità.
 3. Missione `Trust Trial`: obiettivo opzionale dentro missione principale.
@@ -35,17 +45,20 @@ note: |
 5. Se fallisce → NPG ritorna ostile e aumenta StressWave globale +0.08.
 
 ## Standard di Nido
+
 - **Moduli Base**: `Dormitori`, `Bio-Lab`, `Resonance Anchor`, `Hangar`.
 - Ogni modulo ha `tier` (0-3), costo (risorse + Resonance Shards) e impatto su telemetria.
 - `Nido Itinerante`: richiede 2 Anchor, permette spostamento ogni 3 turni campagna (vedi Canvas A).
 - `Security Rating`: somma guardie + barriere. Deve superare minaccia bioma per evitare raid.
 
 ### Gestione Risorse Nido
+
 - Risorse: `Nutrienti`, `Energia`, `Legami`, `Reattori Aeon`, `Shards`.
 - Cruscotto HUD mostra trend. Se qualsiasi risorsa <2 → penalità su missione successiva.
 - `Rituali di coesione`: spendi Legami per abbassare StressWave globale.
 
 ## Ereditarietà & Mutazioni
+
 - Alla nascita/assemblaggio nuova Forma:
   - Seleziona 2 `gene slots` dai genitori + 1 mutazione ambientale.
   - Applica bias `form_seed_bias` (dataset PI) per preferenze tratti.
@@ -56,23 +69,27 @@ note: |
 - Mutazioni T1/T2 richiedono moduli Nido di livello ≥2.
 
 ## Rituali & Eventi Sociali
+
 - **Convergenza**: cerimonia per legare due membri. Dà buff `Bond Shield` (assorbe 1 fallimento critico).
 - **Veglia Resonance**: riduce StressWave di 0.05 se partecipano ≥3 membri con Affinità positiva.
 - **Consiglio del Nido**: decisione mensile (spendere risorse, definire obiettivi). Impatta reputazione fazioni.
 
 ## Companion App — Modulo Relazioni
+
 - Tracker Affinità/Fiducia per ogni pair.
 - Timeline eventi (dialoghi, scelte, fallimenti).
 - Alert mismatch: se differenza >2 tra membri, suggerisce attività di coesione.
 - Export `relations-log.yaml` per audit.
 
 ## KPI & Telemetria Sociale
+
 - Media Affinità/Fiducia squad.
 - Numero rituali completati per arco narrativo.
 - Tasso successo `Trust Trial`.
 - Impatto risorse Nido sul tasso completamento missioni.
 
 ## Stato 10/2025
+
 - Companion app integra mod Relazioni v0.7 (sync 2-way con backend).
 - Nido itinerante testato in VC (necessarie UI per indicare cooldown spostamento).
 - Bilanciamento richiesto: ridurre penalty cumulativa StressWave durante fallimenti romance.

--- a/docs/archive/gdd-baseline/GDD_v1_baseline.md
+++ b/docs/archive/gdd-baseline/GDD_v1_baseline.md
@@ -1,0 +1,99 @@
+---
+title: Evo‑Tactics – Game Design Document (GDD)
+doc_status: historical_ref
+doc_owner: incoming-archivist
+workstream: incoming
+last_verified: 2026-04-14
+source_of_truth: false
+language: it-en
+review_cycle_days: 14
+---
+
+# Evo‑Tactics – Game Design Document (GDD)
+
+## Visione e obiettivi
+
+Evo‑Tactics è un gioco di strategia e crescita personale in cui il giocatore guida una squadra di compagni attraverso biomi dinamici, sviluppando le proprie abilità e creando sinergie uniche fra talenti, tratti MBTI/enneagramma e morfologie delle specie. L’obiettivo è fornire un’esperienza coinvolgente che unisca esplorazione, tattica e narrazione, alimentata da un sistema di progressione profondo e da scelte significative.
+
+### Target e tono
+
+Il gioco è rivolto a giocatori interessati a giochi tattici, roguelike e di ruolo, con particolare attenzione a chi apprezza la profondità narrativa e la personalizzazione. Il tono è misterioso ma positivo: i biomi e le missioni invitano alla scoperta e alla crescita interiore.
+
+## Panoramica del sistema di gioco
+
+### Loop principale
+
+1. **Preparazione della squadra:** il giocatore seleziona e personalizza i compagni, assegnando tratti, specie e job in base al proprio stile di gioco.
+2. **Esplorazione dei biomi:** ogni run si svolge attraverso biomi generati proceduralmente, suddivisi in zone con caratteristiche e sfide differenti. Alla fine di ogni zona si accede al sistema _Tri‑Sorgente_ per potenziare la squadra.
+3. **Battaglie tattiche:** combat system a turni ispirato al sistema d20, con modificatori dati da tratti e job. La gestione delle risorse (salute, stamina, “energie”) e il posizionamento sono fondamentali.
+4. **Progressione e scelta:** dopo le battaglie, il giocatore acquisisce esperienza, materiali e frammenti genetici. Si aprono nuove scelte tramite il _Tri‑Sorgente_ e la possibilità di modificare i compagni.
+5. **Narrativa emergente:** eventi, incontri e missioni generano narrazione basata sulle scelte del giocatore e sulle combinazioni di tratti, fornendo rigiocabilità e immersione.
+
+### Sistema Tri‑Sorgente
+
+Il _Tri‑Sorgente_ offre al giocatore tre carte più un’opzione “skip” al termine delle battaglie minori. La scelta viene generata attraverso un pipeline che considera:
+
+- **Tabella del bioma** – definisce la rarità e il tipo di carte disponibili in base al livello di zona raggiunto.
+- **Composizione della squadra** – include risultati dei tiri basati sul sistema d20, personalità (MBTI/enneagramma) e azioni recenti (telemetria). Le carte vengono punteggiate con la formula:
+
+```
+score(c) = base(c)
+           + w_roll × roll_comp(c)
+           + w_pers × pers_comp(c)
+           + w_act × act_comp(c)
+           – penalty_duplicate(c)
+```
+
+dove la **base(c)** è la rarità intrinseca della carta, i pesi \_w\__ modulano l’influenza dei componenti e \_penalty_duplicate(c)_ riduce il punteggio per evitare ripetizioni. La pipeline filtra inoltre le carte in base a sinergie/diversità con la squadra e offre un’opzione di skip che rilascia un frammento genetico.
+
+I principi alla base del _Tri‑Sorgente_ sono: dare al giocatore agency senza sovraccarico cognitivo, controllare la varianza per evitare roll “dominanti”, garantire coerenza con le combinazioni di tratti e prevenire il power creep【109425184895403†L8-L16】.
+
+### Progressione e crescita
+
+- **Esperienza e livelli:** le attività di gioco (battaglie, missioni, esplorazione) concedono XP per job e tratti. I compagni sbloccano abilità e talenti avanzati aumentando di livello.
+- **Frammenti genetici:** ottenuti dalle opzioni skip e da eventi speciali; permettono di modificare specie, morfologia o potenziare tratti esistenti.
+- **Telemetria e adattamento:** un sistema di telemetria raccoglie le azioni del giocatore e adatta la generazione di missioni ed eventi, favorendo la rigiocabilità.
+
+### Componenti principali
+
+| Modulo      | Descrizione breve                                                                                                          |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **Dataset** | Insiemi di specie, job, tratti, talenti, sinergie e parametri di gioco.                                                    |
+| **CLI**     | Strumenti in Python e TypeScript per validare dataset, generare baseline e audit, e per lanciare processi (es. export QA). |
+| **Backend** | Gestione database, API e servizi (matchmaking, telemetria) con sicurezza integrata.                                        |
+| **Webapp**  | Dashboard per visualizzare telemetria, QA e tracker dei progressi.                                                         |
+| **HUD**     | Overlay smart che mostra alert e statistiche in tempo reale, configurato tramite YAML.                                     |
+
+## World‑building e ambientazione
+
+Ogni bioma rappresenta un ecosistema con regole e creature uniche: foreste antiche, deserti magnetici, grotte bioluminescenti, ecc. I compagni hanno storie e motivazioni che influenzano le loro relazioni e le interazioni con l’ambiente. La narrativa si sviluppa tramite missioni principali, secondarie e incontri emergenti, orchestrati da un _director_ dinamico che bilancia sfida e varietà.
+
+## Monetizzazione
+
+Il modello previsto è _free‑to‑play_ con monetizzazione etica basata su cosmetici e contenuti opzionali. Non è previsto il pay‑to‑win: tutti i contenuti che influiscono sul gameplay (specie, job, talenti) sono ottenibili giocando.
+
+## Requisiti tecnici e pipeline di sviluppo
+
+- Utilizzo di GitHub con workflow CI/CD per testing, linting e deployment.
+- Pipeline suddivisa in fasi (origine, build, test, deployment) con check di qualità e sicurezza【189322877471245†L985-L1011】.
+- Automatizzazione di validazione dataset e audit tratti tramite script Python/TS.
+- Generazione e aggiornamento di report QA e tracker giornalieri.
+
+## Roadmap e milestone
+
+La roadmap dettagliata è mantenuta in `docs/piani/roadmap.md` e nel board di progetto. Le prossime milestone includono:
+
+1. **Smart HUD & SquadSync:** completare l’overlay e la sincronizzazione telemetria.
+2. **Export telemetria incrementale:** finalizzare API e script per esportare eventi.
+3. **Release VC:** preparare la versione per venture capital con build stabile e presentazione.
+4. **Level design e biomi avanzati:** introdurre nuovi biomi con meccaniche uniche.
+5. **Bilanciamento XP e tratti:** rifinire la progressione e le sinergie.
+
+## Appendice
+
+Per ulteriori dettagli consultare i documenti nel repository:
+
+- `docs/tri-sorgente/overview.md` – pipeline e motivazioni del Tri‑Sorgente【109425184895403†L8-L16】.
+- `docs/piani/roadmap.md` – roadmap operativa con milestone e task.
+- `docs/tabelle/*` – liste di job, specie, talenti, parametri e sinergie.
+- `docs/api/*` – definizioni API e endpoints.

--- a/docs/archive/gdd-baseline/README.md
+++ b/docs/archive/gdd-baseline/README.md
@@ -1,0 +1,30 @@
+---
+title: GDD Baseline Archive
+doc_status: historical_ref
+doc_owner: incoming-archivist
+workstream: incoming
+last_verified: '2026-04-16'
+source_of_truth: false
+language: it-en
+review_cycle_days: 90
+---
+
+# GDD Baseline Archive
+
+Snapshot consolidato del Game Design Document v1.0, originariamente presente in 3 copie identiche nel repo:
+
+1. `historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/.../docs/GDD.md`
+2. `historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/GDD.md`
+3. `historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/docs/GDD.md`
+
+Tutte e 3 erano identiche (99 righe). Consolidate qui come `GDD_v1_baseline.md`.
+
+## Stato
+
+**SUPERATO** da:
+
+- [`docs/core/00-GDD_MASTER.md`](../../core/00-GDD_MASTER.md) — entrypoint canonico attuale
+- [`docs/core/00-SOURCE-OF-TRUTH.md`](../../core/00-SOURCE-OF-TRUTH.md) — ricostruzione completa v4
+- [`docs/core/90-FINAL-DESIGN-FREEZE.md`](../../core/90-FINAL-DESIGN-FREEZE.md) — scope shipping
+
+Non usare come fonte di design attuale. Mantenuto solo come riferimento storico.

--- a/docs/core/00B-CANONICAL_PROMOTION_MATRIX.md
+++ b/docs/core/00B-CANONICAL_PROMOTION_MATRIX.md
@@ -45,14 +45,14 @@ Classificazione ufficiale dei 10 sistemi di design di Evo Tactics. Ogni sistema 
 
 ## TODO aperti post-matrice
 
-1. [ ] Consolidare duplicati Nido (27-MATING vs Mating-Reclutamento)
-2. [ ] Deduplicare 24-TELEMETRIA_VC vs Telemetria-VC
-3. [ ] Risolvere naming Sentience (T0-T5 vs T1-T6)
-4. [ ] Consolidare 3 copie GDD snapshot in archive
-5. [ ] Documentare pipeline rebuild Mission Console
-6. [ ] Chiarire XP Cipher (trovato? scartato? rinominato?)
-7. [ ] Completare gene slot in mating.yaml
-8. [ ] Convertire canvas .txt A.L.I.E.N.A. in .md con frontmatter
+1. [x] Consolidare duplicati Nido — `27-MATING_NIDO.md` ora redirect a `Mating-Reclutamento-Nido.md`
+2. [x] Deduplicare Telemetria — `24-TELEMETRIA_VC.md` ora redirect a `Telemetria-VC.md`
+3. [ ] Risolvere naming Sentience (T0-T5 vs T1-T6) — richiede decisione design
+4. [x] Consolidare GDD snapshot — 3 copie → 1 in `docs/archive/gdd-baseline/GDD_v1_baseline.md`
+5. [ ] Documentare pipeline rebuild Mission Console — nessun source nel repo, serve doc processo esterno
+6. [x] Chiarire XP Cipher — esiste nel backlog come FD-058 ("Chiudere XP Cipher gap"), non scartato. Owner: L. Serra (PROG-04)
+7. [ ] Completare gene slot in mating.yaml — richiede decisione design
+8. [x] Convertire canvas .txt A.L.I.E.N.A. in .md con frontmatter — fatto (A, C, D convertiti)
 
 ---
 

--- a/docs/core/24-TELEMETRIA_VC.md
+++ b/docs/core/24-TELEMETRIA_VC.md
@@ -3,7 +3,7 @@ title: Telemetria → Vettore Comportamentale (VC)
 doc_status: active
 doc_owner: platform-docs
 workstream: cross-cutting
-last_verified: 2026-04-14
+last_verified: 2026-04-16
 source_of_truth: false
 language: it-en
 review_cycle_days: 14
@@ -11,21 +11,8 @@ review_cycle_days: 14
 
 # Telemetria → Vettore Comportamentale (VC)
 
-Eventi, finestre, indici (Aggro/Risk/Cohesion/Setup/Explore/Tilt) e mapping verso layer MBTI-like + Ennea-themes.
+> **Documento canonico**: [`Telemetria-VC.md`](Telemetria-VC.md)
 
-- Log eventi: hit, miss, crit, heal, buff, debuff, objective_tick, tile_enter, LOS_gain, formation_time, chat_ping, surrender, tilt triggers, turn_time.
-- EMA per turni/fasi/mappe; clipping outlier.
-- Output: grafici TV, consigli sblocchi, seed Forme.
+Questo file è un indice di navigazione. Il design completo del sistema VC (eventi, indici EMA, mapping MBTI/Ennea, economie PE, procedure operative) è in [`Telemetria-VC.md`](Telemetria-VC.md).
 
-## Calendario revisione PI/telemetria
-
-| Ricorrenza                       | Slot                      | Focus principale                                                                         | Owner                      | Deliverable                                             |
-| -------------------------------- | ------------------------- | ---------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------- |
-| Settimanale                      | Martedì · 10:00-10:45 CET | Stato pacchetti PI, anomalie sugli indici Aggro/Risk e follow-up delle azioni correttive | Lead Design · PM           | Note sintetiche + flag su ticket aperti                 |
-| Settimanale                      | Giovedì · 16:00-16:30 CET | Debrief dati raw dei playtest, verifica log depositati e triage ticket critici           | Analytics · QA             | Aggiornamento `logs/playtests/` + elenco bug prioritari |
-| Quindicinale (settimana dispari) | Venerdì · 15:00-16:00 CET | Retrospettiva VC completa (telemetria → decisioni design) e pianificazione backlog       | Design Council · Tech Lead | Decision log + aggiornamento roadmap                    |
-
-- Tutte le sessioni sono registrate nel calendario condiviso `Evo-Tactics / VC Reviews` con promemoria 24h prima e agenda allegata in Notion.
-- Materiali e metriche vengono raccolti entro le 18:00 CET dello stesso giorno nella cartella condivisa `telemetria/reports`.
-- L'owner della sessione aggiorna i punti rilevanti in `docs/tool_run_report.md` o, per decisioni strategiche, apre/integra i relativi ADR.
-- Quando emergono impatti sui playtest, il PM verifica che la cartella `logs/playtests/YYYY-MM-DD` contenga i log dell'ultima sessione prima di chiudere la riunione.
+Dati runtime: [`data/core/telemetry.yaml`](../../data/core/telemetry.yaml)

--- a/docs/core/27-MATING_NIDO.md
+++ b/docs/core/27-MATING_NIDO.md
@@ -3,7 +3,7 @@ title: Mating / Nido (reclutamento & riproduzione)
 doc_status: active
 doc_owner: platform-docs
 workstream: cross-cutting
-last_verified: 2026-04-14
+last_verified: 2026-04-16
 source_of_truth: false
 language: it-en
 review_cycle_days: 14
@@ -11,7 +11,8 @@ review_cycle_days: 14
 
 # Mating / Nido (reclutamento & riproduzione)
 
-- Attrazione/Convincimento: tabelle Piace/Non piace per specie/job; azioni sociali.
-- Reclutamento: ex-nemici → alleati dopo azioni chiave.
-- Nido: requisiti `env/structure/security/resources/privacy`.
-- Ereditarietà: slot e parti pesate; bias `form_seed_bias`; mutazioni da affissi mappa.
+> **Documento canonico**: [`Mating-Reclutamento-Nido.md`](Mating-Reclutamento-Nido.md)
+
+Questo file è un indice di navigazione. Il design completo del sistema Mating/Nido (affinità, fiducia, reclutamento, moduli Nido, ereditarietà, rituali) è in [`Mating-Reclutamento-Nido.md`](Mating-Reclutamento-Nido.md).
+
+Dati runtime: [`data/core/mating.yaml`](../../data/core/mating.yaml)

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -6388,6 +6388,71 @@
       "review_cycle_days": 30,
       "primary": true,
       "track": "new"
+    },
+    {
+      "path": "docs/archive/gdd-baseline/README.md",
+      "title": "GDD Baseline Archive",
+      "doc_status": "historical_ref",
+      "doc_owner": "incoming-archivist",
+      "workstream": "incoming",
+      "last_verified": "2026-04-16",
+      "source_of_truth": false,
+      "language": "it-en",
+      "review_cycle_days": 90,
+      "primary": false,
+      "track": "new"
+    },
+    {
+      "path": "docs/archive/gdd-baseline/GDD_v1_baseline.md",
+      "title": "Evo-Tactics GDD v1 Baseline (historical snapshot)",
+      "doc_status": "historical_ref",
+      "doc_owner": "incoming-archivist",
+      "workstream": "incoming",
+      "last_verified": "2026-04-16",
+      "source_of_truth": false,
+      "language": "it-en",
+      "review_cycle_days": 90,
+      "primary": false,
+      "track": "new"
+    },
+    {
+      "path": "docs/appendici/A-CANVAS_ORIGINALE.md",
+      "title": "Canvas A — Originale (A.L.I.E.N.A.)",
+      "doc_status": "active",
+      "doc_owner": "platform-docs",
+      "workstream": "dataset-pack",
+      "last_verified": "2026-04-16",
+      "source_of_truth": false,
+      "language": "it",
+      "review_cycle_days": 30,
+      "primary": false,
+      "track": "new"
+    },
+    {
+      "path": "docs/appendici/C-CANVAS_NPG_BIOMI.md",
+      "title": "Canvas C — NPG Reattivi, Biomi & Director",
+      "doc_status": "active",
+      "doc_owner": "platform-docs",
+      "workstream": "dataset-pack",
+      "last_verified": "2026-04-16",
+      "source_of_truth": false,
+      "language": "it",
+      "review_cycle_days": 30,
+      "primary": false,
+      "track": "new"
+    },
+    {
+      "path": "docs/appendici/D-CANVAS_ACCOPPIAMENTO.md",
+      "title": "Canvas D — Mating, Reclutamento & Nido",
+      "doc_status": "active",
+      "doc_owner": "platform-docs",
+      "workstream": "dataset-pack",
+      "last_verified": "2026-04-16",
+      "source_of_truth": false,
+      "language": "it",
+      "review_cycle_days": 30,
+      "primary": false,
+      "track": "new"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Follow-up a #1447. Risolve 6 degli 8 TODO dalla matrice di promozione canonica.

- **TODO 1**: `27-MATING_NIDO.md` → redirect a `Mating-Reclutamento-Nido.md` (canonico)
- **TODO 2**: `24-TELEMETRIA_VC.md` → redirect a `Telemetria-VC.md` (canonico)
- **TODO 4**: 3 copie identiche GDD snapshot consolidate in `docs/archive/gdd-baseline/`
- **TODO 6**: XP Cipher chiarito — esiste come FD-058 nel backlog, non scartato
- **TODO 8**: Canvas A/C/D: `.txt` → `.md` con frontmatter governance-compliant
- Registry: +5 entry (3 canvas + 2 gdd-baseline)

### TODO rimasti (richiedono decisione design)

- TODO 3: naming Sentience (T0-T5 vs T1-T6)
- TODO 5: pipeline rebuild Mission Console
- TODO 7: gene slot in mating.yaml

## Test plan

- [x] `python tools/check_docs_governance.py --strict` → 0 errors
- [x] Prettier → pass
- [ ] Verify redirect links in 27-MATING and 24-TELEMETRIA resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)