### PR TITLE
feat(naming): bilingual styleguide + recode existing + 30+20 expansion roster

### DIFF
--- a/data/core/biomes.yaml
+++ b/data/core/biomes.yaml
@@ -51,6 +51,10 @@ frequencies:
 
 biomes:
   abisso_vulcanico:
+    legacy_slug: abisso_vulcanico
+    biome_class: geothermal
+    display_name_it: Abisso Vulcanico
+    display_name_en: Volcanic Abyss
     label: Abisso Vulcanico
     summary: Camini abissali con lava pressurizzata e fauna bio-termica.
     diff_base: 5
@@ -87,6 +91,10 @@ biomes:
       - Stabilire condotti di raffreddamento attorno alle fucine naturali.
       - Recuperare artefatti termici prima dell'eruzione cataclismica.
   atollo_obsidiana:
+    legacy_slug: atollo_obsidiana
+    biome_class: littoral
+    display_name_it: Atollo di Ossidiana
+    display_name_en: Obsidian Atoll
     label: Atollo Obsidiana
     summary: Arcipelago magnetico con maree EMP e piattaforme mobili.
     diff_base: 4
@@ -118,6 +126,10 @@ biomes:
       - Proteggere i reattori a risonanza dagli attacchi delle maree.
       - Recuperare shard ossidiani prima dell'arrivo della tempesta.
   badlands:
+    legacy_slug: badlands
+    biome_class: arid
+    display_name_it: Calanchi Ferromagnetici
+    display_name_en: Ferromagnetic Badlands
     label: Badlands Ferro-Magnetiche
     summary: Altipiani arrugginiti con tempeste ferrose e rovine sepolte.
     diff_base: 4
@@ -150,6 +162,10 @@ biomes:
       - Recuperare relè Aeon arrugginiti prima che vengano fusi.
       - Convincere i clan magnetotattici a cooperare contro le tempeste.
   caldera_glaciale:
+    legacy_slug: caldera_glaciale
+    biome_class: upland
+    display_name_it: Caldera Glaciale
+    display_name_en: Glacial Caldera
     label: Caldera Glaciale
     summary: Crateri glaciali con geyser criogenici e pareti ricoperte di ghiaccio
       vivo.
@@ -183,6 +199,10 @@ biomes:
       - Stabilire ponti termici per attraversare crepacci dinamici.
       - Proteggere gli estrattori di ghiaccio vivo durante le eruzioni.
   canopia_ionica:
+    legacy_slug: canopia_ionica
+    biome_class: canopy
+    display_name_it: Canopia Ionica
+    display_name_en: Ionic Canopy
     label: Canopia Ionica
     summary: Foresta verticale sospesa da campi elettrostatici e rampicanti conduttivi.
     diff_base: 3
@@ -214,6 +234,10 @@ biomes:
       - Sincronizzare la rete ionica per aprire corridoi sicuri.
       - Recuperare semi conduttivi custoditi dai guardiani della canopia.
   canyons_risonanti:
+    legacy_slug: canyons_risonanti
+    biome_class: clastic
+    display_name_it: Canyon Risonanti
+    display_name_en: Resonant Canyons
     label: Canyons Risonanti
     summary: Labirinto ventoso di gole armoniche alimentate da risonanza.
     diff_base: 4
@@ -246,6 +270,10 @@ biomes:
       - Stabilizzare ponti risonanti prima delle tempeste di vento.
       - Seguire tracce sonore per rintracciare nidi dispersivi.
   caverna:
+    legacy_slug: caverna
+    biome_class: subterranean
+    display_name_it: Caverna Risonante
+    display_name_en: Resonant Cavern
     label: Caverna Risonante
     summary: Gallerie cristalline dove eco e pressioni invertite modellano la fauna.
     diff_base: 3
@@ -281,6 +309,10 @@ biomes:
       - Disinnescare camere di eco instabile prima del collasso.
       - Estrarre cristalli risonanti senza allertare i custodi del nido.
   palude:
+    legacy_slug: palude
+    biome_class: wetland
+    display_name_it: Palude Tossica
+    display_name_en: Toxic Marsh
     label: Palude Tossica
     summary: Acque stagnanti bio-luminescenti con fauna mutagena.
     diff_base: 3
@@ -314,6 +346,10 @@ biomes:
       - Recuperare reagenti bio-luminescenti per le squadre mediche.
       - Placare le colonie simbiotiche prima che scatenino la nube tossica.
   dorsale_termale_tropicale:
+    legacy_slug: dorsale_termale_tropicale
+    biome_class: geothermal
+    display_name_it: Dorsale Termale Tropicale
+    display_name_en: Tropical Thermal Ridge
     label: Dorsale Termale Tropicale
     summary: Catena montuosa sommersa con fumarole calde e fauna simbiotica.
     diff_base: 4
@@ -347,6 +383,10 @@ biomes:
       - Sigillare sfiati per proteggere gli avamposti sommersi.
       - Scortare i droni estrattori attraverso vortici bioluminescenti.
   foresta_acida:
+    legacy_slug: foresta_acida
+    biome_class: canopy
+    display_name_it: Foresta Acida
+    display_name_en: Acid Forest
     label: Foresta Acida
     summary: Bacini tropicali saturi di piogge corrosive e flora predatoria.
     diff_base: 4
@@ -379,6 +419,10 @@ biomes:
       - Neutralizzare bacini corrotti prima della tempesta acida.
       - Raccogliere reagenti rari dai guardiani fototropici.
   foresta_miceliale:
+    legacy_slug: foresta_miceliale
+    biome_class: canopy
+    display_name_it: Foresta Miceliale
+    display_name_en: Mycelial Forest
     label: Foresta Miceliale
     summary: Canopia micotica bioluminescente dove la rete fungina coordina la fauna.
     diff_base: 3
@@ -412,6 +456,10 @@ biomes:
       - Mappare nodi miceliali per isolare la rete neurale.
       - Convincere i guardiani a condividere antidoti spora.
   foresta_temperata:
+    legacy_slug: foresta_temperata
+    biome_class: canopy
+    display_name_it: Foresta Temperata Umida
+    display_name_en: Temperate Wet Forest
     label: Foresta Temperata Umida
     summary: Boschi piovosi con canopy densa, nebbie calde e radure bioenergetiche.
     diff_base: 3
@@ -444,6 +492,10 @@ biomes:
       - Proteggere i reattori a risonanza dagli attacchi delle maree.
       - Recuperare shard ossidiani prima dell'arrivo della tempesta.
   stratosfera_tempestosa:
+    legacy_slug: stratosfera_tempestosa
+    biome_class: upland
+    display_name_it: Stratosfera Tempestosa
+    display_name_en: Storm Stratosphere
     label: Stratosfera Tempestosa
     summary: Piattaforme aerostatiche tra nubi di tempesta, fulmini e venti supersonici.
     diff_base: 5
@@ -476,6 +528,10 @@ biomes:
       - Stabilizzare gli ancoraggi stratosferici prima del collasso.
       - Recuperare celle di energia trasportate da fulmini guidati.
   mezzanotte_orbitale:
+    legacy_slug: mezzanotte_orbitale
+    biome_class: upland
+    display_name_it: Mezzanotte Orbitale
+    display_name_en: Orbital Midnight
     label: Mezzanotte Orbitale
     summary: Stazione orbitale in decadimento con gravità variabile.
     diff_base: 4
@@ -509,6 +565,10 @@ biomes:
       - Ripristinare i reattori Aeon prima del blackout totale.
       - Neutralizzare l'allarme a cascata per evitare l'arrivo dei rinforzi.
   pianura_salina_iperarida:
+    legacy_slug: pianura_salina_iperarida
+    biome_class: salt
+    display_name_it: Pianura Salina Iperarida
+    display_name_en: Hyperarid Salt Flats
     label: Pianura Salina Iperarida
     summary: Distese saline ciclotroniche che riflettono radiazione e drenano umidità.
     diff_base: 4
@@ -540,6 +600,10 @@ biomes:
       - Stabilire torri condensatrici per sostenere gli avamposti.
       - Recuperare cristalli prismatici senza attirare predatori desertici.
   reef_luminescente:
+    legacy_slug: reef_luminescente
+    biome_class: littoral
+    display_name_it: Scogliera Luminescente
+    display_name_en: Luminescent Reef
     label: Reef Luminescente
     summary: Barriere coralline sintetiche con correnti luminescenti e fauna sensibile
       alla risonanza.
@@ -572,6 +636,10 @@ biomes:
       - Proteggere le colonie coralline da razzie di risonanza.
       - Convincere i custodi del reef a condividere i filtri luminescenti.
   savana:
+    legacy_slug: savana
+    biome_class: arid
+    display_name_it: Savana Ionizzata
+    display_name_en: Ionized Savannah
     label: Savana Ionizzata
     summary: Dune fotoniche con branchi adattivi e rovine sepolte.
     diff_base: 2
@@ -607,6 +675,10 @@ biomes:
     aliases:
     - savanna
   steppe_algoritmiche:
+    legacy_slug: steppe_algoritmiche
+    biome_class: arid
+    display_name_it: Steppe Algoritmiche
+    display_name_en: Algorithmic Steppes
     label: Steppe Algoritmiche
     summary: Pianure modulari controllate da IA agricole con pattern mutevoli.
     diff_base: 3
@@ -638,6 +710,10 @@ biomes:
       - Ripristinare i nodi sincroni per evitare la tempesta algoritmica.
       - Tracciare branchi dronici deviati prima della fusione.
   rovine_planari:
+    legacy_slug: rovine_planari
+    biome_class: clastic
+    display_name_it: Rovine Planari Fratturate
+    display_name_en: Fractured Planar Ruins
     label: Rovine Planari Fratturate
     summary: Metropoli extraplanare in rovina con portali instabili e correnti di
       energia astrale.
@@ -672,6 +748,10 @@ biomes:
       - Sigillare i portali corrotti prima del collasso dimensionale.
       - Recuperare reliquie pathfinder riadattate ai protocolli Evo Tactics.
   frattura_abissale_sinaptica:
+    legacy_slug: frattura_abissale_sinaptica
+    biome_class: deltaic
+    display_name_it: Frattura Abissale Sinaptica
+    display_name_en: Synaptic Abyssal Rift
     label: Frattura Abissale Sinaptica
     summary: Bioma abissale stratificato con tre livelli luminosi/pressori e correnti elettroluminescenti che modulano trait temporanei.
     diff_base: 5

--- a/data/core/biomes_expansion.yaml
+++ b/data/core/biomes_expansion.yaml
@@ -1,0 +1,143 @@
+# Expansion roster — 20 new biomes from naming_doc (docx_2026-04-16)
+# Bilingual display names (IT canonical + EN from docx).
+
+biomes:
+  - id: ferrous-badlands
+    slug: ferrous-badlands
+    biome_class: arid
+    display_name_it: "Calanchi Ferrosi"
+    display_name_en: "Ferrous Badlands"
+    source: docx_2026-04-16
+
+  - id: cinder-dunes
+    slug: cinder-dunes
+    biome_class: arid
+    display_name_it: "Dune di Cenere"
+    display_name_en: "Cinder Dunes"
+    source: docx_2026-04-16
+
+  - id: saltglass-flats
+    slug: saltglass-flats
+    biome_class: coastal
+    display_name_it: "Distese di Salvetro"
+    display_name_en: "Saltglass Flats"
+    source: docx_2026-04-16
+
+  - id: basalt-grottos
+    slug: basalt-grottos
+    biome_class: rocky
+    display_name_it: "Grotte di Basalto"
+    display_name_en: "Basalt Grottos"
+    source: docx_2026-04-16
+
+  - id: zephyr-steppe
+    slug: zephyr-steppe
+    biome_class: aerial
+    display_name_it: "Steppa dello Zefiro"
+    display_name_en: "Zephyr Steppe"
+    source: docx_2026-04-16
+
+  - id: brine-rift
+    slug: brine-rift
+    biome_class: coastal
+    display_name_it: "Spaccatura Salmastra"
+    display_name_en: "Brine Rift"
+    source: docx_2026-04-16
+
+  - id: ember-marsh
+    slug: ember-marsh
+    biome_class: wetland
+    display_name_it: "Palude di Brace"
+    display_name_en: "Ember Marsh"
+    source: docx_2026-04-16
+
+  - id: shardfall-ridge
+    slug: shardfall-ridge
+    biome_class: rocky
+    display_name_it: "Cresta delle Schegge"
+    display_name_en: "Shardfall Ridge"
+    source: docx_2026-04-16
+
+  - id: lumen-canopy
+    slug: lumen-canopy
+    biome_class: forest
+    display_name_it: "Volta Luminescente"
+    display_name_en: "Lumen Canopy"
+    source: docx_2026-04-16
+
+  - id: umbral-karst
+    slug: umbral-karst
+    biome_class: rocky
+    display_name_it: "Carso d'Ombra"
+    display_name_en: "Umbral Karst"
+    source: docx_2026-04-16
+
+  - id: silt-delta
+    slug: silt-delta
+    biome_class: wetland
+    display_name_it: "Delta di Limo"
+    display_name_en: "Silt Delta"
+    source: docx_2026-04-16
+
+  - id: crystal-scree
+    slug: crystal-scree
+    biome_class: rocky
+    display_name_it: "Detriti Cristallini"
+    display_name_en: "Crystal Scree"
+    source: docx_2026-04-16
+
+  - id: ironbloom-wastes
+    slug: ironbloom-wastes
+    biome_class: arid
+    display_name_it: "Piane di Fiore Ferreo"
+    display_name_en: "Ironbloom Wastes"
+    source: docx_2026-04-16
+
+  - id: hollow-fumaroles
+    slug: hollow-fumaroles
+    biome_class: volcanic
+    display_name_it: "Fumarole Cave"
+    display_name_en: "Hollow Fumaroles"
+    source: docx_2026-04-16
+
+  - id: paleroot-tangle
+    slug: paleroot-tangle
+    biome_class: forest
+    display_name_it: "Groviglio di Radici Pallide"
+    display_name_en: "Paleroot Tangle"
+    source: docx_2026-04-16
+
+  - id: thunder-reeds
+    slug: thunder-reeds
+    biome_class: wetland
+    display_name_it: "Canneti del Tuono"
+    display_name_en: "Thunder Reeds"
+    source: docx_2026-04-16
+
+  - id: ashen-sink
+    slug: ashen-sink
+    biome_class: volcanic
+    display_name_it: "Conca di Cenere"
+    display_name_en: "Ashen Sink"
+    source: docx_2026-04-16
+
+  - id: cold-mirror-fen
+    slug: cold-mirror-fen
+    biome_class: wetland
+    display_name_it: "Palude dello Specchio Freddo"
+    display_name_en: "Cold Mirror Fen"
+    source: docx_2026-04-16
+
+  - id: redspur-mesa
+    slug: redspur-mesa
+    biome_class: rocky
+    display_name_it: "Mesa dello Sperone Rosso"
+    display_name_en: "Redspur Mesa"
+    source: docx_2026-04-16
+
+  - id: mistral-hollows
+    slug: mistral-hollows
+    biome_class: aerial
+    display_name_it: "Cavità del Maestrale"
+    display_name_en: "Mistral Hollows"
+    source: docx_2026-04-16

--- a/data/core/species.yaml
+++ b/data/core/species.yaml
@@ -52,6 +52,12 @@ global_rules:
 
 species:
   - id: dune_stalker
+    legacy_slug: dune_stalker
+    genus: Arenavenator
+    epithet: vagans
+    clade_tag: Threat
+    display_name_it: Predatore delle Dune
+    display_name_en: Dune Stalker
     display_name: Dune Stalker
     estimated_weight: 11
     weight_budget: 12
@@ -84,6 +90,12 @@ species:
           Mantenere mobilità verticale e resistenza termica nelle cavità iper-saline
           in cui si rifugia il branco durante le tempeste desertiche.
   - id: polpo_araldo_sinaptico
+    legacy_slug: polpo_araldo_sinaptico
+    genus: Synaptopus
+    epithet: praeco
+    clade_tag: Keystone
+    display_name_it: Polpo Araldo Sinaptico
+    display_name_en: Synaptic Herald Octopus
     display_name: Polpo Araldo Sinaptico
     estimated_weight: 14
     weight_budget: 14
@@ -101,6 +113,12 @@ species:
     synergy_hints: []
 
   - id: sciame_larve_neurali
+    legacy_slug: sciame_larve_neurali
+    genus: Neurolarva
+    epithet: gregaria
+    clade_tag: Threat
+    display_name_it: Sciame di Larve Neurali
+    display_name_en: Neural Larva Swarm
     display_name: Sciame di Larve Neurali
     estimated_weight: 9
     weight_budget: 10
@@ -118,6 +136,12 @@ species:
     synergy_hints: []
 
   - id: leviatano_risonante
+    legacy_slug: leviatano_risonante
+    genus: Resonoleviathan
+    epithet: abyssalis
+    clade_tag: Apex
+    display_name_it: Leviatano Risonante
+    display_name_en: Resonant Leviathan
     display_name: Leviatano Risonante
     estimated_weight: 28
     weight_budget: 30
@@ -135,6 +159,12 @@ species:
     synergy_hints: []
 
   - id: simbionte_corallino_riflesso
+    legacy_slug: simbionte_corallino_riflesso
+    genus: Corallosymbion
+    epithet: speculans
+    clade_tag: Support
+    display_name_it: Simbionte Corallino Riflesso
+    display_name_en: Mirror Coral Symbiont
     display_name: Simbionte Corallino Riflesso
     estimated_weight: 15
     weight_budget: 15
@@ -152,6 +182,12 @@ species:
     synergy_hints: []
 
   - id: anguis_magnetica
+    legacy_slug: anguis_magnetica
+    genus: Anguimagnus
+    epithet: litoralis
+    clade_tag: Bridge
+    display_name_it: Anguilla Magnetica
+    display_name_en: Magnetic Eel
     display_name: Anguis Magnetica
     estimated_weight: 9
     weight_budget: 10
@@ -174,6 +210,12 @@ species:
     synergy_hints: []
 
   - id: chemnotela_toxica
+    legacy_slug: chemnotela_toxica
+    genus: Chemnotela
+    epithet: toxifera
+    clade_tag: Threat
+    display_name_it: Tessitrice Tossica
+    display_name_en: Toxic Weaver
     display_name: Chemnotela Toxica
     estimated_weight: 11
     weight_budget: 12
@@ -196,6 +238,12 @@ species:
     synergy_hints: []
 
   - id: elastovaranus_hydrus
+    legacy_slug: elastovaranus_hydrus
+    genus: Elastovaranus
+    epithet: hydraulicus
+    clade_tag: Playable
+    display_name_it: Varano Idraulico Elastico
+    display_name_en: Hydraulic Elastic Varan
     display_name: Elastovaranus Hydrus
     estimated_weight: 12
     weight_budget: 12
@@ -218,6 +266,12 @@ species:
     synergy_hints: []
 
   - id: gulogluteus_scutiger
+    legacy_slug: gulogluteus_scutiger
+    genus: Gulogluteus
+    epithet: scutiger
+    clade_tag: Playable
+    display_name_it: Scudo Roccioso Prensile
+    display_name_en: Prehensile Rock Shield
     display_name: Gulogluteus Scutiger
     estimated_weight: 10
     weight_budget: 10
@@ -240,6 +294,12 @@ species:
     synergy_hints: []
 
   - id: perfusuas_pedes
+    legacy_slug: perfusuas_pedes
+    genus: Perfusuas
+    epithet: subterraneus
+    clade_tag: Bridge
+    display_name_it: Miriapode delle Cripte
+    display_name_en: Crypt Myriapod
     display_name: Perfusuas Pedes
     estimated_weight: 13
     weight_budget: 13
@@ -262,6 +322,12 @@ species:
     synergy_hints: []
 
   - id: proteus_plasma
+    legacy_slug: proteus_plasma
+    genus: Proteoplasma
+    epithet: amoebiforme
+    clade_tag: Playable
+    display_name_it: Plasma Proteico
+    display_name_en: Protean Plasma
     display_name: Proteus Plasma
     estimated_weight: 8
     weight_budget: 8
@@ -284,6 +350,12 @@ species:
     synergy_hints: []
 
   - id: rupicapra_sensoria
+    legacy_slug: rupicapra_sensoria
+    genus: Rupicapra
+    epithet: sensoria
+    clade_tag: Keystone
+    display_name_it: Stambecco Sensoriale
+    display_name_en: Sensory Ibex
     display_name: Rupicapra Sensoria
     estimated_weight: 16
     weight_budget: 16
@@ -306,6 +378,12 @@ species:
     synergy_hints: []
 
   - id: soniptera_resonans
+    legacy_slug: soniptera_resonans
+    genus: Soniptera
+    epithet: resonans
+    clade_tag: Threat
+    display_name_it: Ala Risonante
+    display_name_en: Resonant Wing
     display_name: Soniptera Resonans
     estimated_weight: 7
     weight_budget: 8
@@ -328,6 +406,12 @@ species:
     synergy_hints: []
 
   - id: terracetus_ambulator
+    legacy_slug: terracetus_ambulator
+    genus: Terracetus
+    epithet: ambulator
+    clade_tag: Keystone
+    display_name_it: Cetaceo Terrestre
+    display_name_en: Walking Cetacean
     display_name: Terracetus Ambulator
     estimated_weight: 14
     weight_budget: 14
@@ -350,6 +434,12 @@ species:
     synergy_hints: []
 
   - id: umbra_alaris
+    legacy_slug: umbra_alaris
+    genus: Umbralaris
+    epithet: silens
+    clade_tag: Playable
+    display_name_it: Ala d'Ombra
+    display_name_en: Shadow Wing
     display_name: Umbra Alaris
     estimated_weight: 6
     weight_budget: 7

--- a/data/core/species_expansion.yaml
+++ b/data/core/species_expansion.yaml
@@ -1,0 +1,514 @@
+# Expansion roster — 30 new species from naming_doc (docx_2026-04-16)
+# Bilingual display names (IT canonical + EN from docx).
+# Genus/epithet canonical per docs/core/00E-NAMING_STYLEGUIDE.md.
+
+species_examples:
+  - id: sp_arenavolux_sagittalis
+    slug: arenavolux-sagittalis
+    genus: Arenavolux
+    epithet: sagittalis
+    clade_tag: Apex
+    display_name_it: "Saettatore delle Dune"
+    display_name_en: "Dune Skiver"
+    morph_slots:
+      locomotion: skimmer_legs
+      offense: fore_sickles
+      defense: dust_frill
+      senses: vibration_pinnae
+      metabolism: heat_saver
+    preferred_biomes: [cinder-dunes, ferrous-badlands]
+    role_tags: [apex, predator, playable]
+    source: docx_2026-04-16
+
+  - id: sp_ferriscroba_detrita
+    slug: ferriscroba-detrita
+    genus: Ferriscroba
+    epithet: detrita
+    clade_tag: Keystone
+    display_name_it: "Spazzino Ferroso"
+    display_name_en: "Rust Scavenger"
+    morph_slots:
+      locomotion: burrow_pads
+      offense: crushing_beak
+      defense: ferric_scutes
+      senses: chemic_whiskers
+      metabolism: scrap_ferment
+    preferred_biomes: [ferrous-badlands, ironbloom-wastes]
+    role_tags: [keystone, scavenger, playable]
+    source: docx_2026-04-16
+
+  - id: sp_sonapteryx_resonans
+    slug: sonapteryx-resonans
+    genus: Sonapteryx
+    epithet: resonans
+    clade_tag: Bridge
+    display_name_it: "Ala Risonante"
+    display_name_en: "Echo Wing"
+    morph_slots:
+      locomotion: sail_wings
+      offense: dart_talons
+      defense: fold_fan
+      senses: echo_crests
+      metabolism: glide_lung
+    preferred_biomes: [redspur-mesa, zephyr-steppe]
+    role_tags: [bridge, disperser, playable]
+    source: docx_2026-04-16
+
+  - id: sp_lithoraptor_acutornis
+    slug: lithoraptor-acutornis
+    genus: Lithoraptor
+    epithet: acutornis
+    clade_tag: Threat
+    display_name_it: "Cacciatore di Schegge"
+    display_name_en: "Shard Prowler"
+    morph_slots:
+      locomotion: grip_claws
+      offense: jaw_spikes
+      defense: shard_plating
+      senses: slit_ocelli
+      metabolism: fast_burn
+    preferred_biomes: [shardfall-ridge, ferrous-badlands]
+    role_tags: [threat, predator]
+    source: docx_2026-04-16
+
+  - id: sp_salifossa_tenebris
+    slug: salifossa-tenebris
+    genus: Salifossa
+    epithet: tenebris
+    clade_tag: Keystone
+    display_name_it: "Scavatore Salino"
+    display_name_en: "Salt Burrower"
+    morph_slots:
+      locomotion: tunnel_limbs
+      offense: rasp_mandibles
+      defense: salt_carapace
+      senses: pressure_whiskers
+      metabolism: brine_kidney
+    preferred_biomes: [saltglass-flats, brine-rift]
+    role_tags: [keystone, detritivore]
+    source: docx_2026-04-16
+
+  - id: sp_ventornis_longiala
+    slug: ventornis-longiala
+    genus: Ventornis
+    epithet: longiala
+    clade_tag: Bridge
+    display_name_it: "Aliante della Mesa"
+    display_name_en: "Mesa Glider"
+    morph_slots:
+      locomotion: membrane_wings
+      offense: snap_beak
+      defense: thermal_hide
+      senses: horizon_eyes
+      metabolism: draft_sacs
+    preferred_biomes: [redspur-mesa, zephyr-steppe]
+    role_tags: [bridge, scout]
+    source: docx_2026-04-16
+
+  - id: sp_ferrimordax_rutilus
+    slug: ferrimordax-rutilus
+    genus: Ferrimordax
+    epithet: rutilus
+    clade_tag: Apex
+    display_name_it: "Martellatore Ferroso"
+    display_name_en: "Iron Mauler"
+    morph_slots:
+      locomotion: brace_legs
+      offense: hammer_jaws
+      defense: magnet_plate
+      senses: tremor_inner_ear
+      metabolism: ore_store
+    preferred_biomes: [ferrous-badlands, shardfall-ridge]
+    role_tags: [apex, predator]
+    source: docx_2026-04-16
+
+  - id: sp_pyrosaltus_celeris
+    slug: pyrosaltus-celeris
+    genus: Pyrosaltus
+    epithet: celeris
+    clade_tag: Threat
+    display_name_it: "Saltatore di Cenere"
+    display_name_en: "Cinder Leaper"
+    morph_slots:
+      locomotion: spring_legs
+      offense: ember_fangs
+      defense: soot_quills
+      senses: heat_pits
+      metabolism: spark_gland
+    preferred_biomes: [cinder-dunes, ashen-sink]
+    role_tags: [threat, ambusher]
+    source: docx_2026-04-16
+
+  - id: sp_basaltocara_scutata
+    slug: basaltocara-scutata
+    genus: Basaltocara
+    epithet: scutata
+    clade_tag: Support
+    display_name_it: "Custode di Basalto"
+    display_name_en: "Basalt Warden"
+    morph_slots:
+      locomotion: rooted_stance
+      offense: shield_ram
+      defense: basalt_carapace
+      senses: deep_resonator
+      metabolism: slow_furnace
+    preferred_biomes: [basalt-grottos, hollow-fumaroles]
+    role_tags: [support, sentinel]
+    source: docx_2026-04-16
+
+  - id: sp_arenaceros_placidus
+    slug: arenaceros-placidus
+    genus: Arenaceros
+    epithet: placidus
+    clade_tag: Keystone
+    display_name_it: "Brucatore di Polvere"
+    display_name_en: "Dust Grazer"
+    morph_slots:
+      locomotion: drift_hooves
+      offense: horn_sweep
+      defense: grit_hide
+      senses: wide_nares
+      metabolism: silica_gut
+    preferred_biomes: [cinder-dunes, redspur-mesa]
+    role_tags: [keystone, grazer]
+    source: docx_2026-04-16
+
+  - id: sp_lucinerva_filata
+    slug: lucinerva-filata
+    genus: Lucinerva
+    epithet: filata
+    clade_tag: Bridge
+    display_name_it: "Tessitore di Luce"
+    display_name_en: "Lumen Weaver"
+    morph_slots:
+      locomotion: branch_hooklets
+      offense: filament_spur
+      defense: glare_veil
+      senses: prism_ocelli
+      metabolism: glow_sac
+    preferred_biomes: [lumen-canopy, paleroot-tangle]
+    role_tags: [bridge, disperser]
+    source: docx_2026-04-16
+
+  - id: sp_radiluma_pendula
+    slug: radiluma-pendula
+    genus: Radiluma
+    epithet: pendula
+    clade_tag: Support
+    display_name_it: "Lanterna di Radici"
+    display_name_en: "Root Lantern"
+    morph_slots:
+      locomotion: tendril_steps
+      offense: seed_darts
+      defense: bark_folds
+      senses: sap_tasters
+      metabolism: biolamp_gland
+    preferred_biomes: [paleroot-tangle, lumen-canopy]
+    role_tags: [support, symbiont]
+    source: docx_2026-04-16
+
+  - id: sp_limnofalcis_serrata
+    slug: limnofalcis-serrata
+    genus: Limnofalcis
+    epithet: serrata
+    clade_tag: Threat
+    display_name_it: "Trebbiatore di Palude"
+    display_name_en: "Mire Thresher"
+    morph_slots:
+      locomotion: reed_stride
+      offense: scythe_beak
+      defense: mire_slime
+      senses: ripple_line
+      metabolism: marsh_lung
+    preferred_biomes: [ember-marsh, silt-delta]
+    role_tags: [threat, predator]
+    source: docx_2026-04-16
+
+  - id: sp_cavatympa_sonans
+    slug: cavatympa-sonans
+    genus: Cavatympa
+    epithet: sonans
+    clade_tag: Bridge
+    display_name_it: "Ascoltatore Cavo"
+    display_name_en: "Hollow Listener"
+    morph_slots:
+      locomotion: pad_feet
+      offense: hook_limbs
+      defense: cave_hide
+      senses: drum_ears
+      metabolism: low_oxygen_blood
+    preferred_biomes: [umbral-karst, basalt-grottos]
+    role_tags: [bridge, scout]
+    source: docx_2026-04-16
+
+  - id: sp_calamipes_gracilis
+    slug: calamipes-gracilis
+    genus: Calamipes
+    epithet: gracilis
+    clade_tag: Playable
+    display_name_it: "Camminatore di Canne"
+    display_name_en: "Reed Strider"
+    morph_slots:
+      locomotion: stilt_legs
+      offense: spur_knuckles
+      defense: reed_hide
+      senses: storm_whiskers
+      metabolism: saline_filter
+    preferred_biomes: [thunder-reeds, ember-marsh]
+    role_tags: [playable, grazer, bridge]
+    source: docx_2026-04-16
+
+  - id: sp_salisucta_alveata
+    slug: salisucta-alveata
+    genus: Salisucta
+    epithet: alveata
+    clade_tag: Keystone
+    display_name_it: "Filtratore Salmastro"
+    display_name_en: "Brine Filter"
+    morph_slots:
+      locomotion: fan_fins
+      offense: sieve_palps
+      defense: gel_mantle
+      senses: ion_pits
+      metabolism: brine_filter
+    preferred_biomes: [brine-rift, saltglass-flats]
+    role_tags: [keystone, filter_feeder]
+    source: docx_2026-04-16
+
+  - id: sp_nebulocornis_mollis
+    slug: nebulocornis-mollis
+    genus: Nebulocornis
+    epithet: mollis
+    clade_tag: Support
+    display_name_it: "Cervo di Nebbia"
+    display_name_en: "Fog Antler"
+    morph_slots:
+      locomotion: soft_hooves
+      offense: antler_rake
+      defense: mist_coat
+      senses: scent_fans
+      metabolism: dew_collector
+    preferred_biomes: [cold-mirror-fen, mistral-hollows]
+    role_tags: [support, grazer]
+    source: docx_2026-04-16
+
+  - id: sp_cryptolorca_medicata
+    slug: cryptolorca-medicata
+    genus: Cryptolorca
+    epithet: medicata
+    clade_tag: Keystone
+    display_name_it: "Riparatore Carsico"
+    display_name_en: "Karst Mender"
+    morph_slots:
+      locomotion: cling_pads
+      offense: anchor_claws
+      defense: shell_ribs
+      senses: mineral_tasters
+      metabolism: repair_gel
+    preferred_biomes: [umbral-karst, crystal-scree]
+    role_tags: [keystone, support]
+    source: docx_2026-04-16
+
+  - id: sp_glaciolabis_nitida
+    slug: glaciolabis-nitida
+    genus: Glaciolabis
+    epithet: nitida
+    clade_tag: Bridge
+    display_name_it: "Pattinatore Specchio"
+    display_name_en: "Mirror Skater"
+    morph_slots:
+      locomotion: glide_fins
+      offense: needle_beak
+      defense: reflective_scale
+      senses: glare_eyes
+      metabolism: cold_reserve
+    preferred_biomes: [cold-mirror-fen, silt-delta]
+    role_tags: [bridge, predator]
+    source: docx_2026-04-16
+
+  - id: sp_tonitrudens_ferox
+    slug: tonitrudens-ferox
+    genus: Tonitrudens
+    epithet: ferox
+    clade_tag: Threat
+    display_name_it: "Rosicchiatore di Tuono"
+    display_name_en: "Thunder Gnawer"
+    morph_slots:
+      locomotion: charge_legs
+      offense: bolt_incisors
+      defense: static_fur
+      senses: field_whiskers
+      metabolism: capacitor_nodes
+    preferred_biomes: [thunder-reeds, redspur-mesa]
+    role_tags: [threat, omnivore]
+    source: docx_2026-04-16
+
+  - id: sp_rubrospina_velox
+    slug: rubrospina-velox
+    genus: Rubrospina
+    epithet: velox
+    clade_tag: Playable
+    display_name_it: "Corriere Spinato"
+    display_name_en: "Spurback Courier"
+    morph_slots:
+      locomotion: courier_legs
+      offense: rear_spines
+      defense: spur_crest
+      senses: far_ears
+      metabolism: burst_liver
+    preferred_biomes: [redspur-mesa, zephyr-steppe]
+    role_tags: [playable, scout, bridge]
+    source: docx_2026-04-16
+
+  - id: sp_paludogromus_magnus
+    slug: paludogromus-magnus
+    genus: Paludogromus
+    epithet: magnus
+    clade_tag: Keystone
+    display_name_it: "Colosso Palustre"
+    display_name_en: "Fen Colossus"
+    morph_slots:
+      locomotion: pillar_legs
+      offense: trunk_hammer
+      defense: peat_skin
+      senses: fog_trunk
+      metabolism: cold_ferment
+    preferred_biomes: [cold-mirror-fen, ember-marsh]
+    role_tags: [keystone, support]
+    source: docx_2026-04-16
+
+  - id: sp_cinerastra_nodosa
+    slug: cinerastra-nodosa
+    genus: Cinerastra
+    epithet: nodosa
+    clade_tag: Threat
+    display_name_it: "Spirale di Cenere"
+    display_name_en: "Ash Coil"
+    morph_slots:
+      locomotion: coil_body
+      offense: constricting_ribs
+      defense: ash_scales
+      senses: ember_tongue
+      metabolism: soot_lung
+    preferred_biomes: [ashen-sink, hollow-fumaroles]
+    role_tags: [threat, ambusher]
+    source: docx_2026-04-16
+
+  - id: sp_zephyrovum_fidelis
+    slug: zephyrovum-fidelis
+    genus: Zephyrovum
+    epithet: fidelis
+    clade_tag: Bridge
+    display_name_it: "Nidificatore del Maestrale"
+    display_name_en: "Mistral Nester"
+    morph_slots:
+      locomotion: kite_wings
+      offense: nesting_spurs
+      defense: down_cloak
+      senses: sky_barbs
+      metabolism: wind_crop
+    preferred_biomes: [mistral-hollows, zephyr-steppe]
+    role_tags: [bridge, disperser]
+    source: docx_2026-04-16
+
+  - id: sp_vitricyba_punctata
+    slug: vitricyba-punctata
+    genus: Vitricyba
+    epithet: punctata
+    clade_tag: Threat
+    display_name_it: "Beccatore di Vetro"
+    display_name_en: "Glass Peck"
+    morph_slots:
+      locomotion: rapid_hops
+      offense: shard_beak
+      defense: glass_quills
+      senses: sparkle_eyes
+      metabolism: mineral_crop
+    preferred_biomes: [crystal-scree, saltglass-flats]
+    role_tags: [threat, forager]
+    source: docx_2026-04-16
+
+  - id: sp_fumarisorba_sulfurea
+    slug: fumarisorba-sulfurea
+    genus: Fumarisorba
+    epithet: sulfurea
+    clade_tag: Keystone
+    display_name_it: "Bevitore di Fumarole"
+    display_name_en: "Fumarole Drinker"
+    morph_slots:
+      locomotion: vent_pads
+      offense: tube_jaws
+      defense: sulfur_hide
+      senses: gas_pits
+      metabolism: sulfur_ferment
+    preferred_biomes: [hollow-fumaroles, basalt-grottos]
+    role_tags: [keystone, detritivore]
+    source: docx_2026-04-16
+
+  - id: sp_arboryxis_lenis
+    slug: arboryxis-lenis
+    genus: Arboryxis
+    epithet: lenis
+    clade_tag: Bridge
+    display_name_it: "Vagabondo della Volta"
+    display_name_en: "Canopy Drifter"
+    morph_slots:
+      locomotion: parachute_membrane
+      offense: hook_beak
+      defense: leaf_mimic
+      senses: canopy_ocelli
+      metabolism: nectar_ferment
+    preferred_biomes: [lumen-canopy, paleroot-tangle]
+    role_tags: [bridge, grazer]
+    source: docx_2026-04-16
+
+  - id: sp_noctipedis_umbrata
+    slug: noctipedis-umbrata
+    genus: Noctipedis
+    epithet: umbrata
+    clade_tag: Apex
+    display_name_it: "Corridore Notturno"
+    display_name_en: "Night Loper"
+    morph_slots:
+      locomotion: silent_legs
+      offense: crescent_claws
+      defense: shadow_pelt
+      senses: nocti_pinnae
+      metabolism: night_liver
+    preferred_biomes: [umbral-karst, mistral-hollows]
+    role_tags: [apex, predator]
+    source: docx_2026-04-16
+
+  - id: sp_magnetocola_pastoris
+    slug: magnetocola-pastoris
+    genus: Magnetocola
+    epithet: pastoris
+    clade_tag: Support
+    display_name_it: "Pastore Ferrico"
+    display_name_en: "Ferric Shepherd"
+    morph_slots:
+      locomotion: steady_hooves
+      offense: crook_horns
+      defense: magnetic_mane
+      senses: signal_sacs
+      metabolism: iron_rumen
+    preferred_biomes: [ironbloom-wastes, ferrous-badlands]
+    role_tags: [support, playable, grazer]
+    source: docx_2026-04-16
+
+  - id: sp_siltovena_bifida
+    slug: siltovena-bifida
+    genus: Siltovena
+    epithet: bifida
+    clade_tag: Threat
+    display_name_it: "Divisore del Delta"
+    display_name_en: "Delta Splitter"
+    morph_slots:
+      locomotion: fork_tail
+      offense: cleaving_rostrum
+      defense: silt_scutes
+      senses: current_line
+      metabolism: estuary_gills
+    preferred_biomes: [silt-delta, ember-marsh]
+    role_tags: [threat, predator]
+    source: docx_2026-04-16

--- a/docs/core/00E-NAMING_STYLEGUIDE.md
+++ b/docs/core/00E-NAMING_STYLEGUIDE.md
@@ -1,0 +1,249 @@
+---
+title: Naming Styleguide — Specie e Biomi (Bilingue IT/EN)
+doc_status: active
+doc_owner: master-dd
+workstream: cross-cutting
+last_verified: '2026-04-16'
+source_of_truth: true
+language: it-en
+review_cycle_days: 30
+---
+
+# Naming Styleguide — Specie e Biomi
+
+Style guide canonica per il naming di specie e biomi in Evo Tactics. Stratifica nomi tecnici (codice) e nomi player-facing (display) con supporto bilingue.
+
+**Autorita'**: livello **A1** (hub). Vincoli formali al livello A2 (schema). Vedi [`00B-CANONICAL_PROMOTION_MATRIX.md`](00B-CANONICAL_PROMOTION_MATRIX.md).
+
+## Principio di base
+
+> **Codice in inglese, display primario in italiano, display alternativo in inglese.**
+
+- Slug, id, genus, epithet, schema fields → **inglese ASCII**
+- `display_name` → **italiano** (player-facing primary, TV/HUD)
+- `display_name_en` → **inglese** (i18n alternate)
+
+## Modello a doppio livello
+
+Ogni specie/bioma ha:
+
+1. **Layer canonico (codice)**: stabile, non localizzato, machine-readable
+2. **Layer player-facing (display)**: leggibile, localizzato, TV-first
+
+```yaml
+# Esempio specie
+- id: sp_arenavolux_sagittalis
+  slug: arenavolux-sagittalis # canonico (kebab-case ASCII)
+  genus: Arenavolux # canonico
+  epithet: sagittalis # canonico
+  clade_tag: Apex # enum
+  display_name: 'Predatore delle Dune' # IT player-facing
+  display_name_en: 'Dune Skiver' # EN alternate
+  legacy_slug: dune_stalker # opzionale, per migrazione
+```
+
+```yaml
+# Esempio bioma
+- id: ferrous-badlands
+  slug: ferrous-badlands # canonico
+  biome_class: arid # enum
+  display_name: 'Calanchi Ferrosi' # IT player-facing
+  display_name_en: 'Ferrous Badlands' # EN alternate
+  legacy_slug: badlands # opzionale
+```
+
+## Regole formali — Specie
+
+### genus
+
+- Una parola, iniziale maiuscola, ASCII
+- 4-18 caratteri
+- No spazi, apostrofi, diacritici
+- Terminazioni latinizzanti preferite (`-us`, `-a`, `-ax`, `-ops`, `-eros`)
+- Deve suggerire affinita' o analogie del taxon (Madrid Code 2025)
+- Regex: `^[A-Z][a-z]{3,17}$`
+
+### epithet
+
+- Una parola, minuscola, ASCII
+- 3-30 caratteri (limite editoriale, coerente con Madrid Code 2026)
+- Esprime habitat, funzione, forma, comportamento
+- Suffissi geografici: `-ensis`, `-(a)nus`, `-inus`, `-icus`
+- Suffissi funzionali: `-cola`, `-fer`, `-ptera`, `-denta`, `-scuta`
+- Regex: `^[a-z][a-z-]{2,29}$`
+
+### clade_tag
+
+Enum strettamente controllato. Non incluso nello slug (stabile vs balance changes):
+
+- `Apex` — predatore di vertice
+- `Keystone` — specie chiave dell'ecosistema
+- `Bridge` — connettore cross-bioma
+- `Threat` — minaccia tattica primaria
+- `Playable` — disponibile come unita' giocatore
+- `Support` — ruolo di supporto
+
+### display_name (italiano)
+
+- 2 parole preferite, 3 max
+- Title Case in italiano
+- Pattern: `[Habitat / Materiale / Comportamento] + [Corpo / Ruolo]`
+- Esempi: "Predatore delle Dune", "Spazzino Ferroso", "Ala Risonante"
+
+### display_name_en
+
+- 2 parole preferite, 3 max
+- Title Case in inglese
+- Stesso pattern semantico
+- Esempi: "Dune Skiver", "Rust Scavenger", "Echo Wing"
+
+### slug
+
+- Derivato dal nome canonico (genus-epithet), kebab-case ASCII
+- **Mai** dal display name (evita i18n problems)
+- Esempio: `arenavolux-sagittalis`
+
+### id
+
+- Prefisso `sp_` + slug normalizzato underscore
+- Esempio: `sp_arenavolux_sagittalis`
+
+### legacy_slug (opzionale)
+
+- Slug esistente pre-migrazione
+- Mantenuto per backward compat foodweb/ecosystem/test
+- Esempio: `legacy_slug: dune_stalker`
+
+## Regole formali — Biomi
+
+### slug
+
+- Lowercase ASCII, kebab-case
+- Descrittivo: `[Materiale/Processo/Clima] + [Landform/Habitat]`
+- Esempi: `ferrous-badlands`, `basalt-grottos`, `cold-mirror-fen`
+
+### biome_class
+
+Enum controllato:
+
+- `arid`, `subterranean`, `wetland`, `upland`, `canopy`
+- `littoral`, `geothermal`, `salt`, `deltaic`, `clastic`
+
+### display_name (italiano) e display_name_en
+
+- 2-3 parole, Title Case
+- Stesso pattern descrittivo nelle due lingue
+- IT esempio: "Calanchi Ferrosi" / EN: "Ferrous Badlands"
+
+### Regola toponimi
+
+I core biomes **non** usano proper noun o toponimi narrativi. Solo descrittivi e trasferibili. Eccezione: contenuti campagna specifici.
+
+## Morph slots (specie)
+
+Chiavi obbligatorie, snake_case:
+
+- `locomotion`, `offense`, `defense`, `senses`, `metabolism`
+
+Pattern valori:
+
+- `locomotion`: `*_legs`, `*_pads`, `*_wings`, `*_fins`, `*_tendrils`
+- `offense`: `*_claws`, `*_fangs`, `*_beak`, `*_jaws`, `*_spurs`
+- `defense`: `*_hide`, `*_frill`, `*_scutes`, `*_carapace`, `*_quills`
+- `senses`: `*_eyes`, `*_ocelli`, `*_pinnae`, `*_whiskers`, `*_pits`
+- `metabolism`: `*_gland`, `*_filter`, `*_lung`, `*_gut`, `*_rumen`
+
+## Diacritici e translitterazione
+
+**Campi canonici** (slug, id, genus, epithet) = ASCII-only.
+**Campi display** possono contenere diacritici se servono.
+
+Tabella translitterazione:
+
+| Originale | ASCII |
+| --------- | ----- |
+| ä         | ae    |
+| ö         | oe    |
+| ü         | ue    |
+| é è ê     | e     |
+| ñ         | n     |
+| ø         | oe    |
+| å         | ao    |
+| æ         | ae    |
+| œ         | oe    |
+| ß         | ss    |
+
+## Palette fonemiche
+
+**Bias, non gabbia.** Naming deve restare leggibile e semanticamente motivato.
+
+### Ferro-xeno (Apex/Threat, biomi metallici/aridi/subterranei)
+
+- Cluster: `k`, `t`, `kr`, `sk`, `tr`, `ct`, `x`, `r`
+- Vocali agili/taglienti: `i`, `e`
+- Vocali massive: `o`, `u`
+- Esempi: Lithoraptor, Ferrimordax, Pyrosaltus
+
+### Bio-liminale (Keystone/Bridge/Support, canopy/wetland/airy)
+
+- Sonoranti: `m`, `n`, `l`, `s`, `v`, `r`
+- Sillabe `CV`/`CVCV`, code sonore
+- Vocali grandi/placide: `o`, `u`, `a`
+- Vocali leggere: `e`, `i`
+- Esempi: Lucinerva, Cavatympa, Nebulocornis
+
+## Unicita' e collisioni
+
+- `slug` unico per tipo entita'
+- Coppia `(genus, epithet)` unica tra tutte le specie
+- `display_name` warning su duplicato (non hard fail)
+- `biome.slug` unico globalmente
+- `foodweb.node_id` unico almeno nel pack
+
+**Chiave di collisione normalizzata**: due varianti ortografiche stretto-simili (`ae`/`oe`/`e`, `i`/`j`/`y`, `u`/`v`, `c`/`k`, `ph`/`f`, doppie consonanti) collidono dopo normalizzazione → CI fallisce.
+
+## Pipeline di validazione
+
+Vedi [`docs/guide/naming-pipeline.md`](../guide/naming-pipeline.md) per regex completi, JSON Schema, e check linter.
+
+```mermaid
+flowchart LR
+  A[Nuovo nome] --> B[ASCII normalize]
+  B --> C[Regex genus/epithet]
+  C --> D[JSON Schema]
+  D --> E[Phonotactic lint]
+  E --> F[Unique slug + homonym key]
+  F --> G[Referential integrity<br/>species ↔ biomes ↔ foodweb]
+  G --> H[A.L.I.E.N.A. semantic check]
+  H --> I[CI pass]
+```
+
+## Migrazione da naming legacy
+
+Le specie/biomi esistenti pre-2026-04 mantengono il loro slug originale come `legacy_slug` durante la migrazione. Il nuovo `slug` (genus-epithet) e' aggiunto incrementalmente. Nessun rename forzato dei foodweb/ecosystem esistenti finche' la migrazione non e' completa.
+
+Esempio:
+
+```yaml
+# Prima
+- id: dune_stalker
+  display_name: 'Dune Stalker'
+
+# Dopo
+- id: sp_arenavolux_sagittalis # nuovo id canonico
+  slug: arenavolux-sagittalis # nuovo slug
+  legacy_slug: dune_stalker # mantenuto
+  genus: Arenavolux
+  epithet: sagittalis
+  display_name: 'Predatore delle Dune'
+  display_name_en: 'Dune Stalker' # preserva nome originale come EN
+```
+
+## Riferimenti
+
+- ICZN — codice zoologico
+- IAPT Madrid Code 2025 (botanico)
+- Treccani — nomenclatura binomia
+- Hayes & Wilson — fonotattica MaxEnt
+- Speculative evolution: Dixon (After Man, New Dinosaurs), All Yesterdays
+- Documento sorgente: `Naming di specie e biomi per Evo Tactics.docx` (utente, 2026-04-16)

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -6518,6 +6518,19 @@
       "review_cycle_days": 30,
       "primary": false,
       "track": "new"
+    },
+    {
+      "path": "docs/core/00E-NAMING_STYLEGUIDE.md",
+      "title": "Naming Styleguide — Specie e Biomi (Bilingue IT/EN)",
+      "doc_status": "active",
+      "doc_owner": "master-dd",
+      "workstream": "cross-cutting",
+      "last_verified": "2026-04-16",
+      "source_of_truth": true,
+      "language": "it-en",
+      "review_cycle_days": 30,
+      "primary": true,
+      "track": "new"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Naming styleguide bilingue (IT/EN) applicata in modo additivo. No breakage.

### Nuovi file
- **`docs/core/00E-NAMING_STYLEGUIDE.md`** — regole canoniche bilingual (~250 righe)
- **`data/core/species_expansion.yaml`** — 30 specie nuove dal docx
- **`data/core/biomes_expansion.yaml`** — 20 biomi nuovi dal docx

### File ricodificati (additivo)
- **`data/core/species.yaml`** — 15 specie + 90 nuovi field (genus/epithet/clade_tag/display bilingue/legacy_slug)
- **`data/core/biomes.yaml`** — 20 biomi + 80 nuovi field

### Principio
- **Codice in inglese** (slug, id, genus, epithet)
- **Display primario in italiano** (`display_name_it`)
- **Display alternativo in inglese** (`display_name_en`)
- Slug/ID esistenti preservati → foodweb/ecosystem/test intatti

### Roster totale
- Specie: 15 esistenti + 30 espansione = **45 specie**
- Biomi: 20 esistenti + 20 espansione = **40 biomi**

## Test plan
- [x] `node --test tests/api/firstPlaytest.test.js` → pass (VICTORY 5 round)
- [x] `node --test tests/api/tutorial.test.js` → 4/4 pass
- [x] `node --test tests/ai/*.test.js` → 115/115 pass
- [x] `python tools/check_docs_governance.py --strict` → 0 errors
- [x] Prettier pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)