### PR TITLE
fix(combat,ai): 3 bugs from batch playtest + intentional friendly-fire design note

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -663,6 +663,11 @@ function createSessionRouter(options = {}) {
         if (!target) {
           return res.status(400).json({ error: `target "${targetId}" non trovato` });
         }
+        if ((target.hp ?? 0) <= 0) {
+          return res
+            .status(400)
+            .json({ error: `target "${targetId}" gia' abbattuto (hp ${target.hp ?? 0})` });
+        }
         if ((actor.ap_remaining ?? 0) < 1) {
           return res
             .status(400)

--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -250,7 +250,20 @@ function manhattanDistance(a, b) {
 }
 
 function pickLowestHpEnemy(session, actor) {
-  const enemies = session.units.filter((u) => u.id !== actor.id && u.hp > 0);
+  // Faction filter: un'unita' e' "enemy" solo se appartiene a una fazione
+  // diversa (controlled_by). Senza questo filtro, il SIS attaccava le
+  // proprie unita' (fratricidio osservato nel playtest 2026-04-17).
+  //
+  // NOTA design: il "friendly fire intenzionale" (fame, confusione,
+  // istinto evolutivo — es. predatori che si mangiano tra loro sotto
+  // soglia HP, unit in stato confused che bersagliano alleati) e' un
+  // vettore di design futuro. Quando introdotto, passera' da qui via
+  // override esplicito (status flag o rule-specific target picker),
+  // non rimuovendo questo guardrail di base.
+  const actorFaction = actor.controlled_by;
+  const enemies = session.units.filter(
+    (u) => u.id !== actor.id && u.hp > 0 && u.controlled_by !== actorFaction,
+  );
   if (!enemies.length) return null;
   return enemies.reduce((lowest, candidate) => {
     if (!lowest) return candidate;

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -6544,6 +6544,19 @@
       "review_cycle_days": 30,
       "primary": false,
       "track": "new"
+    },
+    {
+      "path": "docs/planning/research/intentional-friendly-fire.md",
+      "title": "Friendly Fire Intenzionale — Meccaniche Evolutive ed Emergenti",
+      "doc_status": "draft",
+      "doc_owner": "master-dd",
+      "workstream": "incoming",
+      "last_verified": "2026-04-16",
+      "source_of_truth": false,
+      "language": "it",
+      "review_cycle_days": 90,
+      "primary": false,
+      "track": "new"
     }
   ]
 }

--- a/docs/planning/research/intentional-friendly-fire.md
+++ b/docs/planning/research/intentional-friendly-fire.md
@@ -1,0 +1,83 @@
+---
+title: Friendly Fire Intenzionale — Meccaniche Evolutive ed Emergenti
+doc_status: draft
+doc_owner: master-dd
+workstream: incoming
+last_verified: '2026-04-16'
+source_of_truth: false
+language: it
+review_cycle_days: 90
+---
+
+# Friendly Fire Intenzionale — Meccaniche Evolutive ed Emergenti
+
+## Origine
+
+Durante il primo playtest digitale (2026-04-16, batch N=10) e' emerso che le unita' AI nemiche attaccavano i propri compagni di fazione (`e_nomad_1` → `e_nomad_2`). Bug fixato in [#XXXX] — di default l'AI ora targetta solo unita' di fazione opposta.
+
+**Pero'** il bug ha aperto una direzione di design interessante: il friendly fire NON dovrebbe essere sempre disabilitato. In un mondo ecologico vivo come Evo Tactics, ci sono ragioni narrative e meccaniche per cui creature della stessa fazione si attaccano.
+
+## Casi d'uso da progettare (futuro)
+
+### 1. Fame / bisogno di nutrirsi
+
+Creature con `metabolism` predatorio o opportunista possono attaccare compagni feriti per nutrirsi se `hunger >= soglia`. Soglia influenzata da:
+
+- `species.metabolism` (es. `fast_burn` consuma piu' energia)
+- Turni passati senza kill / loot
+- Stress level (StressWave > 0.6)
+- Trait specifici (es. `cannibal_drift`, `scavenger_instinct`)
+
+### 2. Status confusione
+
+Status effect `confused` (gia' nel sistema status) puo' fare scattare attacco random invece che target tattico. Probabilita' di self/friendly fire:
+
+- `confused`: 30% target random (incluso friendly)
+- `panic`: 50% friendly fire o flee
+- `rage`: 20% friendly fire ma con bonus damage
+
+### 3. Abitudini evolutive ereditate
+
+Trait `evolutionary_imprint` o `ancestral_instinct`: creature che durante mating/recruit hanno ereditato comportamenti aggressivi possono attaccare compagni con specie/Forma incompatibile. Esempio:
+
+- Specie `Apex` con `predator_imprint` attacca `Playable` con HP basso
+- Forma `INTJ` con `cold_calculation` puo' sacrificare compagno per vantaggio tattico
+
+### 4. Eventi stagionali / territoriali
+
+Periodi di accoppiamento (mating season da EventScheduler — vedi 00D) possono triggare aggressivita' tra maschi della stessa specie. Territorial breaks tra clade Threat/Apex.
+
+### 5. Frammenti di personalita' (MBTI/Ennea)
+
+Trigger Ennea `Conquistatore` con stress alto puo' attivare azioni autodistruttive (incluso danno a compagni che lo trattengono). Buff `Ennea_breaker` rare ma drammatico.
+
+## Implementazione futura
+
+Quando promosso a piano:
+
+1. **Schema `data/core/ai/friendly_fire_triggers.yaml`** — enum trigger + condizioni numeriche
+2. **Servizio `apps/backend/services/ai/friendlyFire.js`** — logica trigger + override target selection
+3. **Test cases**: simulare scenari hunger/confused/cannibal e verificare che friendly fire avvenga con probabilita' attesa
+4. **UI feedback**: HUD deve segnalare chiaramente quando una creatura attacca un compagno (icona warning + ragione narrativa)
+5. **Player agency**: per unita' player friendly fire deve essere SEMPRE prompted, mai automatico
+
+## Bilanciamento
+
+- Friendly fire NON deve dominare il gameplay
+- Frequenza target: <5% delle azioni AI in condizioni normali, >20% in condizioni stress estremo
+- Sempre riconducibile a una causa narrativa visibile (status, hunger meter, trait imprint)
+
+## Riferimenti
+
+- [`00D-ENGINES_AS_GAME_FEATURES.md`](../../core/00D-ENGINES_AS_GAME_FEATURES.md) — EventScheduler ecological events
+- [`27-MATING_NIDO.md`](../../core/27-MATING_NIDO.md) — Recruitment imprint inheritance
+- [`Telemetria-VC.md`](../../core/Telemetria-VC.md) — Tilt index e StressWave triggers
+- [`active_effects.yaml`](../../../data/core/traits/active_effects.yaml) — status confusion/panic/rage gia' implementati
+
+## Stato
+
+- 🟢 **Identificato** come opportunita' di design (2026-04-16)
+- ⚪ Non ancora pianificato
+- ⚪ Non ancora prototipato
+
+Reseguire come task quando si pianifichera' il combat advanced (post-vertical-slice).

--- a/tests/api/batchPlaytest.test.js
+++ b/tests/api/batchPlaytest.test.js
@@ -57,7 +57,12 @@ async function runOnePlaytest(app) {
     }
 
     for (const player of alivePlayers) {
-      const target = aliveEnemies[0];
+      // Re-read state between player attacks to avoid targeting dead enemies.
+      const liveStateRes = await request(app).get('/api/session/state').query({ session_id: sid });
+      const liveEnemies = liveStateRes.body.units.filter(
+        (u) => u.controlled_by === 'sistema' && u.hp > 0,
+      );
+      const target = liveEnemies[0];
       if (!target) break;
       const actionRes = await request(app).post('/api/session/action').send({
         session_id: sid,
@@ -80,7 +85,8 @@ async function runOnePlaytest(app) {
     const turnRes = await request(app).post('/api/session/turn/end').send({ session_id: sid });
     if (turnRes.status === 200 && turnRes.body.ia_actions) {
       for (const ia of turnRes.body.ia_actions) {
-        if (ia.action_type === 'attack' && ia.result === 'hit') {
+        // Backend emits `type: 'attack'` (not action_type). See sessionRoundBridge.js:367.
+        if ((ia.type === 'attack' || ia.action_type === 'attack') && ia.result === 'hit') {
           stats.enemy_damage += ia.damage_dealt || 0;
         }
       }

--- a/tests/api/firstPlaytest.test.js
+++ b/tests/api/firstPlaytest.test.js
@@ -76,7 +76,12 @@ test('FIRST PLAYTEST: full tutorial session with VC debrief', async (t) => {
 
     // Player actions: each alive player attacks nearest alive enemy
     for (const player of alivePlayers) {
-      const target = aliveEnemies[0]; // attack first alive enemy
+      // Re-read state between attacks to avoid targeting already-dead enemies
+      const liveStateRes = await request(app).get('/api/session/state').query({ session_id: sid });
+      const liveEnemies = liveStateRes.body.units.filter(
+        (u) => u.controlled_by === 'sistema' && u.hp > 0,
+      );
+      const target = liveEnemies[0];
       if (!target) break;
 
       // Use /action (legacy unified endpoint, wraps round automatically)
@@ -107,11 +112,12 @@ test('FIRST PLAYTEST: full tutorial session with VC debrief', async (t) => {
 
     if (turnRes.status === 200 && turnRes.body.ia_actions) {
       for (const ia of turnRes.body.ia_actions) {
-        if (ia.action_type === 'attack') {
+        // Backend emits `type: 'attack'` (not action_type). See sessionRoundBridge.js:367.
+        if (ia.type === 'attack' || ia.action_type === 'attack') {
           const emoji = ia.result === 'hit' ? '🔴' : '🔵';
-          console.log(
-            `  │  R${roundNum} AI ${ia.actor_id} → ${ia.target_id}: ${emoji} dmg=${ia.damage_dealt || 0}`,
-          );
+          const aid = ia.unit_id || ia.actor_id;
+          const tid = ia.target || ia.target_id;
+          console.log(`  │  R${roundNum} AI ${aid} → ${tid}: ${emoji} dmg=${ia.damage_dealt || 0}`);
         }
       }
     }


### PR DESCRIPTION
## Summary

3 bug fix critici emersi dal batch playtest (#1454) + nota design per future meccaniche evolutive.

### Bug fixes

**Bug 1 — server (session.js)**
`/action` accettava attacchi su target morti, restituendo `roll: 0` silenziosamente dal guard branch di `sessionRoundBridge`. Ora valida `target.hp > 0` prima di procedere.

**Bug 2 — test (batch + first playtest)**
Conteggio `enemy_damage = 0` causato da field name mismatch: test usava `ia.action_type`, backend emette `ia.type`. Fixato accettando entrambi.

**Bug 3 — AI (sessionHelpers.js)**
`pickLowestHpEnemy` non filtrava per fazione → SIS units attaccavano compagni (`e_nomad → e_nomad` fratricide). Aggiunto predicate `u.controlled_by !== actorFaction`.

### Design note salvata

`docs/planning/research/intentional-friendly-fire.md`
- Documenta 5 casi d'uso per friendly fire INTENZIONALE futuro:
  - Fame / nutrizione
  - Status confusione/panic/rage
  - Imprint evolutivo ereditato (mating)
  - Stagioni territoriali
  - Trigger Ennea estremi
- Implementazione + bilanciamento target: <5% normale, >20% stress

## Risultati post-fix (N=10 batch)

| Metrica | Pre-fix | Post-fix |
|---------|---------|----------|
| Vittorie | 9/10 | 4/10 |
| Timeout | 1/10 | 6/10 |
| AI infligge danno | NO | SI |
| AI fratricide | SI | NO |
| d20 min | 0 (bug) | 4 (corretto) |

Game ora realisticamente sfidante. Tutorial potrebbe richiedere re-balance.

## Test plan
- [x] `node --test tests/api/firstPlaytest.test.js tests/api/batchPlaytest.test.js` → pass
- [x] `node --test tests/ai/*.test.js` → 115/115 pass
- [x] Governance 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)