### PR TITLE
feat(atlas,foodweb): in-match telemetry surfacing + foodweb bilingual migration + bonus

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -573,6 +573,10 @@ function createSessionRouter(options = {}) {
         // SPRINT_003 fase 1: fairness cap PT per-sessione.
         cap_pt_used: 0,
         cap_pt_max: fairnessConfig.cap_pt_max,
+        // AI War pattern (2026-04-17): single escalation dial 0..100.
+        // Gate SIS intent pool + reinforcement budget via computeSistemaTier().
+        // Updated da roundOrchestrator/session handlers su victory/KO events.
+        sistema_pressure: 0,
       };
       sessions.set(sessionId, session);
       activeSessionId = sessionId;

--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -19,6 +19,7 @@ const {
 } = require('./sessionConstants');
 
 const { DEFAULT_ATTACK_RANGE } = require('../services/ai/policy');
+const { buildAtlasLive } = require('../services/atlasLive');
 
 function rollD20(rng) {
   return Math.floor(rng() * 20) + 1;
@@ -202,6 +203,12 @@ function publicSessionView(session) {
     surge_ready: Math.floor((u.stress || 0) * 100) >= 75,
     pp_tier: (u.pp || 0) >= 10 ? 3 : (u.pp || 0) >= 6 ? 2 : (u.pp || 0) >= 3 ? 1 : 0,
   }));
+  const pressure = Number.isFinite(Number(session.sistema_pressure))
+    ? Number(session.sistema_pressure)
+    : 0;
+  const tier = computeSistemaTier(pressure);
+  // Atlas live in-match telemetry (pressure player-side, momentum, warnings)
+  const atlas = buildAtlasLive(session);
   return {
     session_id: session.session_id,
     turn: session.turn,
@@ -212,6 +219,9 @@ function publicSessionView(session) {
     grid: session.grid,
     grid_size: session.grid.width,
     log_events_count: session.events.length,
+    sistema_pressure: pressure,
+    sistema_tier: tier,
+    atlas,
   };
 }
 
@@ -303,6 +313,33 @@ function facingFromMove(from, to) {
   return dy > 0 ? 'S' : 'N';
 }
 
+// Sistema Pressure — AI War "AI Progress" pattern.
+// Mappa pressure integer (0..100) → tier capabilities SIS.
+// Tiers hardcoded qui come fallback; il sorgente autoritativo e'
+// packs/evo_tactics_pack/data/balance/sistema_pressure.yaml (future wiring).
+const SISTEMA_PRESSURE_TIERS = [
+  { threshold: 0, label: 'Calm', intents_per_round: 1, reinforcement_budget: 0 },
+  { threshold: 25, label: 'Alert', intents_per_round: 2, reinforcement_budget: 1 },
+  { threshold: 50, label: 'Escalated', intents_per_round: 2, reinforcement_budget: 2 },
+  { threshold: 75, label: 'Critical', intents_per_round: 3, reinforcement_budget: 3 },
+  { threshold: 95, label: 'Apex', intents_per_round: 3, reinforcement_budget: 4 },
+];
+
+function computeSistemaTier(pressure) {
+  const p = Number.isFinite(Number(pressure)) ? Math.max(0, Math.min(100, Number(pressure))) : 0;
+  let tier = SISTEMA_PRESSURE_TIERS[0];
+  for (const t of SISTEMA_PRESSURE_TIERS) {
+    if (p >= t.threshold) tier = t;
+  }
+  return tier;
+}
+
+function applyPressureDelta(current, delta) {
+  const base = Number.isFinite(Number(current)) ? Number(current) : 0;
+  const d = Number.isFinite(Number(delta)) ? Number(delta) : 0;
+  return Math.max(0, Math.min(100, base + d));
+}
+
 module.exports = {
   rollD20,
   clampPosition,
@@ -320,4 +357,7 @@ module.exports = {
   isBackstab,
   facingFromMove,
   predictCombat,
+  computeSistemaTier,
+  applyPressureDelta,
+  SISTEMA_PRESSURE_TIERS,
 };

--- a/apps/backend/services/atlasLive.js
+++ b/apps/backend/services/atlasLive.js
@@ -1,0 +1,176 @@
+// =============================================================================
+// Atlas Live — In-match telemetry surfacing
+//
+// Calcola pressure, momentum e warning_signals dalla session state corrente.
+// Esposto da /api/session/state e /api/session/turn/end.
+//
+// Pillar 1 (Tactica leggibile): leggibilita' real-time durante il match.
+//
+// Vedi docs/core/00D-ENGINES_AS_GAME_FEATURES.md §Atlas per il design intent.
+// =============================================================================
+
+'use strict';
+
+const HP_LOW_THRESHOLD = 0.33; // unita' < 33% HP → low_hp warning
+const HP_CRITICAL_THRESHOLD = 0.15;
+const PRESSURE_VICTORY_THRESHOLD = 75; // pressure >= 75 → likely victory
+const PRESSURE_DEFEAT_THRESHOLD = 25;
+
+/**
+ * Calcola match_pressure (0-100): score lato player.
+ * 50 = parita', 100 = dominio player, 0 = dominio nemico.
+ *
+ * Componenti:
+ *   - HP ratio (40%): hp_player_total / hp_total
+ *   - Unit count ratio (30%): alive_player / alive_total
+ *   - AP economy (15%): ap_player_avg / ap_max
+ *   - Position (15%): center-of-mass advantage (semplificato)
+ */
+function computeMatchPressure(session) {
+  const units = session.units || [];
+  const players = units.filter((u) => u.controlled_by === 'player');
+  const enemies = units.filter((u) => u.controlled_by === 'sistema');
+  const alivePlayersList = players.filter((u) => (u.hp || 0) > 0);
+  const aliveEnemiesList = enemies.filter((u) => (u.hp || 0) > 0);
+
+  if (!alivePlayersList.length && !aliveEnemiesList.length) return 50;
+  if (!aliveEnemiesList.length) return 100;
+  if (!alivePlayersList.length) return 0;
+
+  const hpPlayer = players.reduce((a, u) => a + Math.max(0, u.hp || 0), 0);
+  const hpEnemy = enemies.reduce((a, u) => a + Math.max(0, u.hp || 0), 0);
+  const hpMaxPlayer = players.reduce((a, u) => a + (u.max_hp || u.hp || 0), 0);
+  const hpMaxEnemy = enemies.reduce((a, u) => a + (u.max_hp || u.hp || 0), 0);
+  const hpRatioPlayer = hpMaxPlayer > 0 ? hpPlayer / hpMaxPlayer : 0;
+  const hpRatioEnemy = hpMaxEnemy > 0 ? hpEnemy / hpMaxEnemy : 0;
+  const hpScore = (hpRatioPlayer / Math.max(0.01, hpRatioPlayer + hpRatioEnemy)) * 100;
+
+  const alivePlayers = players.filter((u) => (u.hp || 0) > 0).length;
+  const aliveEnemies = enemies.filter((u) => (u.hp || 0) > 0).length;
+  const totalAlive = alivePlayers + aliveEnemies;
+  const unitScore = totalAlive > 0 ? (alivePlayers / totalAlive) * 100 : 50;
+
+  const apPlayerAvg =
+    alivePlayers > 0
+      ? players
+          .filter((u) => (u.hp || 0) > 0)
+          .reduce((a, u) => a + (u.ap_remaining ?? u.ap ?? 0), 0) / alivePlayers
+      : 0;
+  const apMax = 4; // tipico ap_max in tutorial; per ora hardcoded
+  const apScore = Math.min(100, (apPlayerAvg / apMax) * 100);
+
+  // Position: distanza media center-of-mass player vs enemy.
+  // Player vicino al center → momentum forward (semplificazione).
+  const posScore = 50; // neutro per ora — calcolare con grid heatmap in iter futura
+
+  const pressure = Math.round(0.4 * hpScore + 0.3 * unitScore + 0.15 * apScore + 0.15 * posScore);
+  return Math.max(0, Math.min(100, pressure));
+}
+
+/**
+ * Calcola momentum: tag qualitativo basato su pressure + trend.
+ * Se non c'e' history di pressure, usa solo valore corrente.
+ */
+function computeMomentum(session, currentPressure) {
+  const lastPressure = Number.isFinite(session._last_atlas_pressure)
+    ? Number(session._last_atlas_pressure)
+    : currentPressure;
+  const delta = currentPressure - lastPressure;
+
+  let label;
+  if (currentPressure >= PRESSURE_VICTORY_THRESHOLD) label = 'player_dominant';
+  else if (currentPressure >= 60) label = 'player_advantage';
+  else if (currentPressure >= 40) label = 'even';
+  else if (currentPressure >= PRESSURE_DEFEAT_THRESHOLD) label = 'enemy_advantage';
+  else label = 'enemy_dominant';
+
+  let trend;
+  if (Math.abs(delta) < 5) trend = 'stable';
+  else if (delta > 0) trend = 'rising';
+  else trend = 'falling';
+
+  return { label, trend, delta };
+}
+
+/**
+ * Genera warning_signals: alert player-facing real-time.
+ * Esempi: low_hp, focused_fire, almost_kill, victory_imminent.
+ */
+function computeWarningSignals(session, pressure) {
+  const signals = [];
+  const units = session.units || [];
+
+  for (const u of units) {
+    const hpRatio = (u.max_hp || u.hp || 1) > 0 ? (u.hp || 0) / (u.max_hp || u.hp || 1) : 0;
+    if (u.hp <= 0) continue;
+    if (u.controlled_by === 'player' && hpRatio <= HP_CRITICAL_THRESHOLD) {
+      signals.push({
+        severity: 'critical',
+        type: 'low_hp',
+        unit_id: u.id,
+        message_it: `${u.id} in pericolo critico (HP ${u.hp})`,
+        message_en: `${u.id} critical HP (${u.hp})`,
+      });
+    } else if (u.controlled_by === 'player' && hpRatio <= HP_LOW_THRESHOLD) {
+      signals.push({
+        severity: 'warning',
+        type: 'low_hp',
+        unit_id: u.id,
+        message_it: `${u.id} ferito (HP ${u.hp})`,
+        message_en: `${u.id} wounded (HP ${u.hp})`,
+      });
+    }
+    if (u.controlled_by === 'sistema' && hpRatio <= HP_CRITICAL_THRESHOLD) {
+      signals.push({
+        severity: 'info',
+        type: 'almost_kill',
+        unit_id: u.id,
+        message_it: `${u.id} sta per cadere (HP ${u.hp})`,
+        message_en: `${u.id} almost dead (HP ${u.hp})`,
+      });
+    }
+  }
+
+  if (pressure >= PRESSURE_VICTORY_THRESHOLD) {
+    signals.push({
+      severity: 'info',
+      type: 'victory_imminent',
+      message_it: 'Vittoria probabile nei prossimi turni.',
+      message_en: 'Victory likely in next rounds.',
+    });
+  } else if (pressure <= PRESSURE_DEFEAT_THRESHOLD) {
+    signals.push({
+      severity: 'critical',
+      type: 'defeat_imminent',
+      message_it: 'Sconfitta imminente — riconsidera la strategia.',
+      message_en: 'Defeat imminent — reconsider strategy.',
+    });
+  }
+
+  return signals;
+}
+
+/**
+ * Wrapper principale: ritorna pacchetto Atlas live completo.
+ * Side effect: aggiorna session._last_atlas_pressure per trend computation.
+ */
+function buildAtlasLive(session) {
+  const pressure = computeMatchPressure(session);
+  const momentum = computeMomentum(session, pressure);
+  const warning_signals = computeWarningSignals(session, pressure);
+  if (session && typeof session === 'object') {
+    session._last_atlas_pressure = pressure;
+  }
+  return {
+    match_pressure: pressure,
+    momentum,
+    warning_signals,
+  };
+}
+
+module.exports = {
+  buildAtlasLive,
+  computeMatchPressure,
+  computeMomentum,
+  computeWarningSignals,
+};

--- a/docs/balance/MACHINATIONS_MODELS.md
+++ b/docs/balance/MACHINATIONS_MODELS.md
@@ -1,0 +1,120 @@
+---
+title: Machinations — modelli di bilanciamento per Evo-Tactics
+doc_status: active
+doc_owner: platform-docs
+workstream: dataset-pack
+last_verified: 2026-04-17
+source_of_truth: false
+language: it
+review_cycle_days: 60
+---
+
+# Machinations — modelli di bilanciamento
+
+[Machinations](https://machinations.io) è un tool visuale per modellare economie di gioco come grafi di flusso (pool, source, drain, gate, register). Questo documento specifica **4 modelli da ricostruire nel tool** per validare visualmente il bilanciamento di Evo-Tactics, alternativa agli spreadsheet per calibrare Pilastro 6 (Fairness).
+
+Machinations non ha un formato di export aperto canonico: i modelli vanno ricostruiti manualmente dal diagramma qui descritto. Il file `.machinations` finale va salvato in `docs/balance/machinations/` (nuova cartella da creare al primo export).
+
+---
+
+## Modello 1 — `d20_attack_economy`
+
+**Scopo**: visualizzare la distribuzione di esiti dell'attacco d20 vs Difficulty Class, inclusi Margin of Success tiers e damage step scaling.
+
+**Fonte dati**: `packs/evo_tactics_pack/data/balance/trait_mechanics.yaml` + `packs/evo_tactics_pack/data/balance/terrain_defense.yaml`.
+
+**Nodi**:
+
+- `d20_roll` (source, random 1–20, uniform)
+- `attacker_mod` (register, da `trait_mechanics.yaml::attack_mod`)
+- `DC` (register, da `species_resistances.yaml` + terrain cover bonus)
+- `hit_check` (gate, condizione: `d20_roll + attacker_mod >= DC`)
+- `MoS_tier` (converter, mappa MoS → {0: miss, 1–4: graze, 5–9: hit, 10+: crit})
+- `damage_step` (pool, output per tier, cap DAMAGE_STEP_CAP)
+- `miss_pool` / `hit_pool` / `crit_pool` (drain counters per fairness telemetry)
+
+**Verifica**: run 1000 iterazioni → confronta distribuzione con `services/rules/predict_combat.py` (N=1000 già esistente). Divergenza >5% = bug nel modello o nel resolver.
+
+---
+
+## Modello 2 — `pt_pool_combo_meter`
+
+**Scopo**: modellare accumulo Power Tokens (PT) durante un round e trigger soglie combo.
+
+**Fonte dati**: `apps/backend/services/roundOrchestrator.js` + `packs/evo_tactics_pack/data/balance/action_speed.yaml`.
+
+**Nodi**:
+
+- `round_start` (trigger, 1x per round)
+- `pt_per_action` (source, da action_speed.yaml per azione risolta)
+- `pt_pool` (pool, cap PT_POOL_CAP)
+- `combo_threshold_t1` (gate, fire a 3 PT)
+- `combo_threshold_t2` (gate, fire a 6 PT)
+- `combo_threshold_t3` (gate, fire a 10 PT)
+- `round_end_drain` (drain, azzera pt_pool con decay_rate configurabile)
+
+**Verifica**: confronta firing rate con log round in `tests/ai/roundOrchestrator.test.js`. Se un threshold scatta >80% dei round = cap troppo basso (power creep combo).
+
+---
+
+## Modello 3 — `damage_step_fairness_cap`
+
+**Scopo**: verificare che nessun trait o combo bypassi DAMAGE_STEP_CAP per più di N turni consecutivi.
+
+**Fonte dati**: `data/core/traits/active_effects.yaml` + `packs/evo_tactics_pack/data/balance/trait_mechanics.yaml`.
+
+**Nodi**:
+
+- `trait_damage_output` (source per trait, 7 paralleli)
+- `stack_multiplier` (register, moltiplicatore da synergie trait)
+- `raw_damage` (pool, somma trait outputs)
+- `cap_gate` (gate, condizione: `raw_damage <= DAMAGE_STEP_CAP`)
+- `overflow_register` (counter turni consecutivi con overflow)
+- `fairness_flag` (trigger, fire se overflow_register > 2)
+
+**Verifica**: se `fairness_flag` scatta → trait va flaggato in `docs/reports/trait_balance_summary.md`. Lega con telemetria esistente.
+
+---
+
+## Modello 4 — `status_propagation_decay`
+
+**Scopo**: validare durate e cleanup dei 7 status fisici/mentali (panic, rage, stunned, focused, confused, bleeding, fracture).
+
+**Fonte dati**: `apps/backend/services/statusEffectsMachine.js` (xstate FSM) + `data/core/traits/active_effects.yaml`.
+
+**Nodi per ogni status**:
+
+- `apply_trigger` (source, da azione o trait)
+- `duration_pool` (pool, iniziale 3 turni, decay 1/turno)
+- `tick_drain` (drain, -1 per round_end)
+- `cleanse_gate` (gate, input da healer trait o turn cap)
+- `propagation_source` (gate, fire se status produce contagio a adiacenti — es. panic bleeding→rage)
+
+**Verifica**: confronta decay con `tests/ai/statusEffects.test.js`. Se un status persiste >6 turni in media = decay rate troppo basso.
+
+---
+
+## Workflow di utilizzo
+
+1. **Setup**: account free su machinations.io. Salva workspace "Evo-Tactics".
+2. **Modellazione**: ricostruisci i 4 modelli dal descrittore sopra. Ogni nodo deve citare il file YAML sorgente come nota.
+3. **Run simulation**: Machinations supporta Monte Carlo run (N=1000). Esporta i risultati come CSV.
+4. **Confronto**: diff con output `predict_combat.py` e `tests/ai/*.test.js`. Documenta divergenze in PR.
+5. **Export**: salva il `.machinations` file in `docs/balance/machinations/<modello>.machinations`. Screenshot PNG in `docs/balance/machinations/img/`.
+
+## Quando aggiornare
+
+- Cambio di `trait_mechanics.yaml`, `ai_intent_scores.yaml`, `species_resistances.yaml` → rerun Modello 1+3.
+- Cambio di `action_speed.yaml` o `roundOrchestrator.js` → rerun Modello 2.
+- Nuovo status in `statusEffectsMachine.js` → aggiungi branch a Modello 4.
+
+## Limiti
+
+- Machinations è un tool closed-source, no CI integration. Il modello è **documentazione visuale**, non autorità. Il source of truth rimane YAML + rules engine Python.
+- Free tier ha limiti di complessità grafi; per modelli >50 nodi valutare tier Pro o splittare in sub-modelli.
+
+## Riferimenti
+
+- [Machinations.io documentation](https://machinations.io/community/wiki)
+- Citato in `docs/guide/external-references.md` sezione "Tool di bilanciamento"
+- Pattern origine: `reference_tier0_deep_dive.md` (awesome-game-design gap resources)

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -1922,6 +1922,19 @@
       "track": "migrated"
     },
     {
+      "path": "docs/balance/MACHINATIONS_MODELS.md",
+      "title": "Machinations — modelli di bilanciamento per Evo-Tactics",
+      "doc_status": "active",
+      "doc_owner": "platform-docs",
+      "workstream": "dataset-pack",
+      "last_verified": "2026-04-17",
+      "source_of_truth": false,
+      "language": "it",
+      "review_cycle_days": 60,
+      "primary": false,
+      "track": "new"
+    },
+    {
       "path": "docs/biomes/Frattura_Abissale_Sinaptica_biome.md",
       "title": "'Frattura Abissale Sinaptica – Step 3 (Modellazione tecnica, STRICT MODE / SANDBOX)'",
       "doc_status": "active",

--- a/docs/guide/external-references.md
+++ b/docs/guide/external-references.md
@@ -107,10 +107,10 @@ Repo da studiare per pattern architetturali, non da adottare come dipendenze.
 
 ## C. Tool di bilanciamento
 
-| Risorsa                                  | Link                                                 | Rilevanza Evo-Tactics                                                                                                                                                            |
-| ---------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Machinations**                         | <https://machinations.io/>                           | Modellazione visuale economia di gioco. Utile per: trait economy, damage step scaling, cap_pt budget, PP combo meter. Alternativa ai fogli di calcolo per Pilastro 6 (Fairness). |
-| **Game Design Patterns Wiki** (Chalmers) | <https://virt10.itu.chalmers.se/index.php/Main_Page> | Catalogo accademico di pattern. Pattern mappabili: Action Point Allowance, Rock-Paper-Scissors (counter system), Asymmetric Abilities (specie x job), Team Combos.               |
+| Risorsa                                  | Link                                                 | Rilevanza Evo-Tactics                                                                                                                                                                                                                                      |
+| ---------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Machinations**                         | <https://machinations.io/>                           | Modellazione visuale economia di gioco. 4 modelli specificati in [`docs/balance/MACHINATIONS_MODELS.md`](../balance/MACHINATIONS_MODELS.md): d20 attack economy, PT pool combo meter, damage step fairness cap, status propagation. Pilastro 6 (Fairness). |
+| **Game Design Patterns Wiki** (Chalmers) | <https://virt10.itu.chalmers.se/index.php/Main_Page> | Catalogo accademico di pattern. Pattern mappabili: Action Point Allowance, Rock-Paper-Scissors (counter system), Asymmetric Abilities (specie x job), Team Combos.                                                                                         |
 
 ## D. Pattern e architettura gameplay
 

--- a/docs/hubs/combat.md
+++ b/docs/hubs/combat.md
@@ -5,7 +5,7 @@ tags: [combat, rules-engine, d20, tactical]
 doc_status: active
 doc_owner: combat-team
 workstream: combat
-last_verified: 2026-04-16
+last_verified: 2026-04-17
 source_of_truth: true
 language: it-en
 review_cycle_days: 14
@@ -62,7 +62,15 @@ Per una panoramica e mappa completa dei doc del workstream vedi [docs/combat/REA
 - `packs/evo_tactics_pack/data/balance/terrain_defense.yaml` — modificatori CD per tipo terreno (roccia +2, lava -1, etc.). Pattern W4.
 - `packs/evo_tactics_pack/data/balance/movement_profiles.yaml` — profili movimento (heavy/medium/light) con terrain cost multiplier. Pattern W6.
 - `packs/evo_tactics_pack/data/balance/species_resistances.yaml` — matrice resistenze per 5 archetipi specie (corazzato/bioelettrico/psionico/termico/adattivo). Pattern W2.
+- `packs/evo_tactics_pack/data/balance/sistema_pressure.yaml` — AI War "AI Progress" meter: 5 tier da Calm (0) a Apex (95) con intents_per_round + reinforcement_budget + unlocked_intent_types. Gate capabilities SIS via `computeSistemaTier()` in `sessionHelpers.js`.
 - `packs/evo_tactics_pack/pack_manifest.yaml` — manifest esplicito di tutti i file dati del pack. Pattern O2.
+
+## Invarianti di design combat
+
+Stabiliti 2026-04-17 da lezioni AI War + Fallout Tactics postmortem (vedi `memory/reference_tactical_postmortems.md`).
+
+- **Single combat mode**. Round model (ADR-2026-04-15) è l'**unico** modello di combat. Qualsiasi "quick mode" o "real-time variant" è un breaking change, non una feature flag. Lesson: Fallout Tactics shipped 3 modi (CTB/ITB/STB) nessuno canonico — confusion player + reviewer split.
+- **Asymmetric AI rules**. SIS non usa l'economia PG. Niente PT pool, niente trait cost. Intent budget derivato da `sistema_pressure` (vedi `sistema_resource_model` in `ai_profiles.yaml`). SIS può ignorare fog-of-war, avere budget reinforcement invisibile, non build economia. Fairness garantita via outcome measurement (`vcScoring`), non simmetria di regole. Lesson AI War: AI che mimano player "fall apart in advanced play" (Park).
 
 ## Schemi e tipi generati
 

--- a/packs/evo_tactics_pack/data/balance/ai_profiles.yaml
+++ b/packs/evo_tactics_pack/data/balance/ai_profiles.yaml
@@ -5,7 +5,21 @@
 #
 # Vedi docs/planning/tactical-architecture-patterns.md §W5
 
-version: "0.1.0"
+version: "0.2.0"
+
+# Asymmetric AI resource model (AI War pattern: Park 2012)
+# SIS non usa la stessa economia dei PG. Niente PT pool, niente trait cost.
+# Il Sistema riceve un "intent budget" per round derivato da sistema_pressure
+# (vedi sistema_pressure.yaml). Questo e' un invariante di design:
+# risolve fairness via outcome measurement, non via simmetria di regole.
+# Source: reference_tactical_postmortems.md §A.2
+sistema_resource_model:
+  economy: "intent_budget"        # non "pt_pool"
+  budget_source: "sistema_pressure"  # tier lookup da sistema_pressure.yaml
+  ignores_fog_of_war: true        # SIS vede stato completo
+  ignores_trait_costs: true       # intent non consuma PT/AP del PG model
+  reinforcement_from_pressure: true
+  note: "Asymmetry invariant — do NOT refactor to mirror player rules"
 
 profiles:
   aggressive:

--- a/packs/evo_tactics_pack/data/balance/sistema_pressure.yaml
+++ b/packs/evo_tactics_pack/data/balance/sistema_pressure.yaml
@@ -1,0 +1,60 @@
+# Sistema Pressure — AI Progress meter
+# Pattern AI War (Chris Park): single escalation dial controls SIS reinforcement
+# pool + intent variety. Players see the integer + have levers to lower it.
+# Source: reference_tactical_postmortems.md §A.3
+#
+# Semantics:
+# - sistema_pressure è un integer 0..100 su session state
+# - Sale quando PG vincono obiettivi (victory_delta per evento)
+# - Cala quando PG usano azioni "pressure_relief" (future: Data Centers, objectives neutral)
+# - Gate per intents_per_round + unlock intent types + reinforcement budget
+#
+# Hook Evo-Tactics:
+# - Inizializzato a 0 in session.js createSession
+# - Aggiornato da roundOrchestrator quando PG completa obiettivo
+# - Letto da declareSistemaIntents per sizing pool
+
+version: "0.1.0"
+
+# Tier soglie → capabilities SIS
+# Ogni tier sblocca un pool più largo di intents + reinforcement slot
+tiers:
+  - threshold: 0
+    label: "Calm"
+    intents_per_round: 1
+    reinforcement_budget: 0
+    unlocked_intent_types: ["attack_basic", "move", "skip"]
+  - threshold: 25
+    label: "Alert"
+    intents_per_round: 2
+    reinforcement_budget: 1
+    unlocked_intent_types: ["attack_basic", "move", "skip", "flank"]
+  - threshold: 50
+    label: "Escalated"
+    intents_per_round: 2
+    reinforcement_budget: 2
+    unlocked_intent_types: ["attack_basic", "move", "skip", "flank", "focus_fire"]
+  - threshold: 75
+    label: "Critical"
+    intents_per_round: 3
+    reinforcement_budget: 3
+    unlocked_intent_types: ["attack_basic", "move", "skip", "flank", "focus_fire", "swarm"]
+  - threshold: 95
+    label: "Apex"
+    intents_per_round: 3
+    reinforcement_budget: 4
+    unlocked_intent_types: ["attack_basic", "move", "skip", "flank", "focus_fire", "swarm", "overwhelm"]
+
+# Delta events → pressure change
+# Applied by roundOrchestrator / session handlers
+deltas:
+  pg_victory_encounter: +15
+  pg_trait_unlock: +5
+  pg_biome_clear: +20
+  sg_pg_down: -10           # PG messo KO abbassa pressione (narrativa: Sistema si placa)
+  pg_objective_data_center: -15  # future: oggetti "pressure relief" (placeholder)
+  round_decay: -1           # decay naturale per round senza eventi
+
+# Caps
+min_pressure: 0
+max_pressure: 100

--- a/tests/ai/sistemaPressure.test.js
+++ b/tests/ai/sistemaPressure.test.js
@@ -1,0 +1,117 @@
+// tests/ai/sistemaPressure.test.js — AI War "AI Progress" pattern
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  computeSistemaTier,
+  applyPressureDelta,
+  SISTEMA_PRESSURE_TIERS,
+} = require('../../apps/backend/routes/sessionHelpers');
+
+// ── computeSistemaTier ──
+
+test('computeSistemaTier: pressure 0 → Calm', () => {
+  const tier = computeSistemaTier(0);
+  assert.equal(tier.label, 'Calm');
+  assert.equal(tier.intents_per_round, 1);
+  assert.equal(tier.reinforcement_budget, 0);
+});
+
+test('computeSistemaTier: pressure 24 → still Calm', () => {
+  assert.equal(computeSistemaTier(24).label, 'Calm');
+});
+
+test('computeSistemaTier: pressure 25 → Alert', () => {
+  const tier = computeSistemaTier(25);
+  assert.equal(tier.label, 'Alert');
+  assert.equal(tier.intents_per_round, 2);
+  assert.equal(tier.reinforcement_budget, 1);
+});
+
+test('computeSistemaTier: pressure 50 → Escalated', () => {
+  assert.equal(computeSistemaTier(50).label, 'Escalated');
+});
+
+test('computeSistemaTier: pressure 75 → Critical', () => {
+  const tier = computeSistemaTier(75);
+  assert.equal(tier.label, 'Critical');
+  assert.equal(tier.intents_per_round, 3);
+});
+
+test('computeSistemaTier: pressure 95 → Apex', () => {
+  const tier = computeSistemaTier(95);
+  assert.equal(tier.label, 'Apex');
+  assert.equal(tier.reinforcement_budget, 4);
+});
+
+test('computeSistemaTier: pressure 100 (cap) → Apex', () => {
+  assert.equal(computeSistemaTier(100).label, 'Apex');
+});
+
+test('computeSistemaTier: pressure 150 (overflow) → clamped to Apex', () => {
+  assert.equal(computeSistemaTier(150).label, 'Apex');
+});
+
+test('computeSistemaTier: pressure -5 (underflow) → Calm', () => {
+  assert.equal(computeSistemaTier(-5).label, 'Calm');
+});
+
+test('computeSistemaTier: NaN → Calm default', () => {
+  assert.equal(computeSistemaTier(NaN).label, 'Calm');
+  assert.equal(computeSistemaTier(undefined).label, 'Calm');
+  assert.equal(computeSistemaTier(null).label, 'Calm');
+});
+
+// ── applyPressureDelta ──
+
+test('applyPressureDelta: +15 from 0 → 15', () => {
+  assert.equal(applyPressureDelta(0, 15), 15);
+});
+
+test('applyPressureDelta: -10 from 5 → clamped to 0', () => {
+  assert.equal(applyPressureDelta(5, -10), 0);
+});
+
+test('applyPressureDelta: +20 from 90 → 100 (clamped)', () => {
+  assert.equal(applyPressureDelta(90, 20), 100);
+});
+
+test('applyPressureDelta: NaN delta → no change', () => {
+  assert.equal(applyPressureDelta(42, NaN), 42);
+  assert.equal(applyPressureDelta(42, undefined), 42);
+});
+
+test('applyPressureDelta: NaN current → treated as 0', () => {
+  assert.equal(applyPressureDelta(null, 15), 15);
+  assert.equal(applyPressureDelta(undefined, 15), 15);
+});
+
+// ── SISTEMA_PRESSURE_TIERS contract ──
+
+test('SISTEMA_PRESSURE_TIERS: 5 tiers monotonic thresholds', () => {
+  assert.equal(SISTEMA_PRESSURE_TIERS.length, 5);
+  for (let i = 1; i < SISTEMA_PRESSURE_TIERS.length; i++) {
+    assert.ok(
+      SISTEMA_PRESSURE_TIERS[i].threshold > SISTEMA_PRESSURE_TIERS[i - 1].threshold,
+      `tier ${i} threshold must exceed tier ${i - 1}`,
+    );
+  }
+});
+
+test('SISTEMA_PRESSURE_TIERS: intents_per_round never decreases', () => {
+  for (let i = 1; i < SISTEMA_PRESSURE_TIERS.length; i++) {
+    assert.ok(
+      SISTEMA_PRESSURE_TIERS[i].intents_per_round >=
+        SISTEMA_PRESSURE_TIERS[i - 1].intents_per_round,
+    );
+  }
+});
+
+test('SISTEMA_PRESSURE_TIERS: reinforcement_budget strictly non-decreasing', () => {
+  for (let i = 1; i < SISTEMA_PRESSURE_TIERS.length; i++) {
+    assert.ok(
+      SISTEMA_PRESSURE_TIERS[i].reinforcement_budget >=
+        SISTEMA_PRESSURE_TIERS[i - 1].reinforcement_budget,
+    );
+  }
+});

--- a/tests/api/atlasLive.test.js
+++ b/tests/api/atlasLive.test.js
@@ -1,0 +1,127 @@
+// =============================================================================
+// ATLAS LIVE — in-match telemetry
+//
+// Verifica che /api/session/state esponga atlas { match_pressure, momentum,
+// warning_signals } durante il match.
+// =============================================================================
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+const {
+  computeMatchPressure,
+  computeMomentum,
+  computeWarningSignals,
+  buildAtlasLive,
+} = require('../../apps/backend/services/atlasLive');
+
+test('Atlas: match_pressure 100 when no enemies alive', () => {
+  const session = {
+    units: [
+      { id: 'p1', controlled_by: 'player', hp: 10, max_hp: 10 },
+      { id: 'e1', controlled_by: 'sistema', hp: 0, max_hp: 5 },
+    ],
+  };
+  const p = computeMatchPressure(session);
+  // No alive enemies → pressure should be 100 (player wins)
+  assert.equal(p, 100);
+});
+
+test('Atlas: match_pressure 0 when no players alive', () => {
+  const session = {
+    units: [
+      { id: 'p1', controlled_by: 'player', hp: 0, max_hp: 10 },
+      { id: 'e1', controlled_by: 'sistema', hp: 5, max_hp: 5 },
+    ],
+  };
+  const p = computeMatchPressure(session);
+  assert.equal(p, 0);
+});
+
+test('Atlas: match_pressure ~50 when even', () => {
+  const session = {
+    units: [
+      { id: 'p1', controlled_by: 'player', hp: 10, max_hp: 10, ap_remaining: 2, ap: 2 },
+      { id: 'e1', controlled_by: 'sistema', hp: 5, max_hp: 5, ap_remaining: 2, ap: 2 },
+    ],
+  };
+  const p = computeMatchPressure(session);
+  // Both at 100% HP, both alive, both have AP → should be near 50
+  assert.ok(p > 40 && p < 70, `pressure ${p} should be near 50`);
+});
+
+test('Atlas: momentum labels reflect pressure ranges', () => {
+  const s = { _last_atlas_pressure: 50 };
+  assert.equal(computeMomentum(s, 80).label, 'player_dominant');
+  assert.equal(computeMomentum(s, 65).label, 'player_advantage');
+  assert.equal(computeMomentum(s, 50).label, 'even');
+  assert.equal(computeMomentum(s, 30).label, 'enemy_advantage');
+  assert.equal(computeMomentum(s, 10).label, 'enemy_dominant');
+});
+
+test('Atlas: warning_signals fire on low HP player', () => {
+  const session = {
+    units: [
+      { id: 'p1', controlled_by: 'player', hp: 1, max_hp: 10 }, // 10% — critical
+      { id: 'p2', controlled_by: 'player', hp: 3, max_hp: 10 }, // 30% — warning
+      { id: 'e1', controlled_by: 'sistema', hp: 5, max_hp: 5 },
+    ],
+  };
+  const signals = computeWarningSignals(session, 50);
+  const critical = signals.filter((s) => s.severity === 'critical');
+  const warning = signals.filter((s) => s.severity === 'warning');
+  assert.ok(critical.length >= 1, 'critical low_hp signal expected');
+  assert.ok(warning.length >= 1, 'warning low_hp signal expected');
+});
+
+test('Atlas: warning_signals fire victory_imminent at high pressure', () => {
+  const session = {
+    units: [
+      { id: 'p1', controlled_by: 'player', hp: 10, max_hp: 10 },
+      { id: 'e1', controlled_by: 'sistema', hp: 1, max_hp: 5 },
+    ],
+  };
+  const signals = computeWarningSignals(session, 80);
+  const victory = signals.find((s) => s.type === 'victory_imminent');
+  assert.ok(victory, 'victory_imminent signal expected at pressure >= 75');
+});
+
+test('Atlas: state endpoint exposes atlas object', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units });
+  const sid = startRes.body.session_id;
+
+  const stateRes = await request(app).get('/api/session/state').query({ session_id: sid });
+  assert.equal(stateRes.status, 200);
+  assert.ok(stateRes.body.atlas, 'state must include atlas');
+  assert.ok(typeof stateRes.body.atlas.match_pressure === 'number', 'match_pressure number');
+  assert.ok(stateRes.body.atlas.momentum, 'momentum object');
+  assert.ok(Array.isArray(stateRes.body.atlas.warning_signals), 'warning_signals array');
+
+  console.log(
+    `\n  Atlas snapshot: pressure=${stateRes.body.atlas.match_pressure} momentum=${stateRes.body.atlas.momentum.label}/${stateRes.body.atlas.momentum.trend} signals=${stateRes.body.atlas.warning_signals.length}\n`,
+  );
+});
+
+test('Atlas: buildAtlasLive returns full package', () => {
+  const session = {
+    units: [
+      { id: 'p1', controlled_by: 'player', hp: 10, max_hp: 10 },
+      { id: 'e1', controlled_by: 'sistema', hp: 5, max_hp: 5 },
+    ],
+  };
+  const atlas = buildAtlasLive(session);
+  assert.ok(typeof atlas.match_pressure === 'number');
+  assert.ok(atlas.momentum && atlas.momentum.label);
+  assert.ok(Array.isArray(atlas.warning_signals));
+});

--- a/tests/test_author_encounter.py
+++ b/tests/test_author_encounter.py
@@ -1,0 +1,225 @@
+"""Unit tests for tools/py/author_encounter.py.
+
+Tests pure builder function + interactive loop via fake reader/writer.
+CI runs full AJV validation separately via tests/scripts/encounterSchema.test.js.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools" / "py"))
+
+from author_encounter import (  # noqa: E402
+    AuthoringError,
+    build_encounter,
+    dump_encounter_yaml,
+    run_interactive,
+)
+
+
+MIN_INPUTS = {
+    "encounter_id": "enc_test_01",
+    "name": "Test Encounter",
+    "biome_id": "savana",
+    "grid_size": [8, 8],
+    "objective_type": "elimination",
+    "player_spawn": [[0, 3], [0, 4]],
+    "difficulty_rating": 2,
+    "waves": [
+        {
+            "wave_id": 1,
+            "turn_trigger": 0,
+            "spawn_points": [[7, 3]],
+            "units": [{"species": "predoni_nomadi", "count": 2}],
+        }
+    ],
+}
+
+
+# ── build_encounter: happy path ──
+
+
+def test_build_minimal_valid_encounter():
+    out = build_encounter(MIN_INPUTS)
+    assert out["encounter_id"] == "enc_test_01"
+    assert out["name"] == "Test Encounter"
+    assert out["grid_size"] == [8, 8]
+    assert out["objective"] == {"type": "elimination"}
+    assert len(out["waves"]) == 1
+    assert out["waves"][0]["units"][0]["species"] == "predoni_nomadi"
+
+
+def test_build_with_optional_fields():
+    inputs = dict(MIN_INPUTS)
+    inputs["estimated_turns"] = 6
+    inputs["tags"] = ["tutorial", "standard"]
+    out = build_encounter(inputs)
+    assert out["estimated_turns"] == 6
+    assert out["tags"] == ["tutorial", "standard"]
+
+
+def test_build_with_unit_tier_and_ai_profile():
+    inputs = dict(MIN_INPUTS)
+    inputs["waves"] = [
+        {
+            "wave_id": 1,
+            "turn_trigger": 0,
+            "spawn_points": [[7, 3]],
+            "units": [
+                {
+                    "species": "sand_skitter",
+                    "count": 3,
+                    "tier": "elite",
+                    "ai_profile": "aggressive",
+                }
+            ],
+        }
+    ]
+    out = build_encounter(inputs)
+    unit = out["waves"][0]["units"][0]
+    assert unit["tier"] == "elite"
+    assert unit["ai_profile"] == "aggressive"
+
+
+def test_build_dedupes_tags():
+    inputs = dict(MIN_INPUTS)
+    inputs["tags"] = ["tutorial", "tutorial", "standard"]
+    out = build_encounter(inputs)
+    assert out["tags"] == ["tutorial", "standard"]
+
+
+# ── build_encounter: validation errors ──
+
+
+def test_reject_bad_encounter_id():
+    bad = dict(MIN_INPUTS, encounter_id="tutorial_01")
+    with pytest.raises(AuthoringError, match="encounter_id"):
+        build_encounter(bad)
+
+
+def test_reject_empty_name():
+    bad = dict(MIN_INPUTS, name="")
+    with pytest.raises(AuthoringError, match="name"):
+        build_encounter(bad)
+
+
+def test_reject_grid_size_too_small():
+    bad = dict(MIN_INPUTS, grid_size=[3, 3])
+    with pytest.raises(AuthoringError, match="grid_size"):
+        build_encounter(bad)
+
+
+def test_reject_grid_size_too_large():
+    bad = dict(MIN_INPUTS, grid_size=[21, 21])
+    with pytest.raises(AuthoringError, match="grid_size"):
+        build_encounter(bad)
+
+
+def test_reject_bad_objective_type():
+    bad = dict(MIN_INPUTS, objective_type="conquest")
+    with pytest.raises(AuthoringError, match="objective_type"):
+        build_encounter(bad)
+
+
+def test_reject_empty_player_spawn():
+    bad = dict(MIN_INPUTS, player_spawn=[])
+    with pytest.raises(AuthoringError, match="player_spawn"):
+        build_encounter(bad)
+
+
+def test_reject_difficulty_out_of_range():
+    bad = dict(MIN_INPUTS, difficulty_rating=6)
+    with pytest.raises(AuthoringError, match="difficulty_rating"):
+        build_encounter(bad)
+
+
+def test_reject_empty_waves():
+    bad = dict(MIN_INPUTS, waves=[])
+    with pytest.raises(AuthoringError, match="waves"):
+        build_encounter(bad)
+
+
+def test_reject_wave_with_no_units():
+    bad = dict(MIN_INPUTS)
+    bad["waves"] = [
+        {"wave_id": 1, "turn_trigger": 0, "spawn_points": [[7, 3]], "units": []}
+    ]
+    with pytest.raises(AuthoringError, match="units"):
+        build_encounter(bad)
+
+
+def test_reject_bad_unit_tier():
+    bad = dict(MIN_INPUTS)
+    bad["waves"] = [
+        {
+            "wave_id": 1,
+            "turn_trigger": 0,
+            "spawn_points": [[7, 3]],
+            "units": [{"species": "x", "count": 1, "tier": "legendary"}],
+        }
+    ]
+    with pytest.raises(AuthoringError, match="tier"):
+        build_encounter(bad)
+
+
+def test_reject_bad_tag():
+    bad = dict(MIN_INPUTS, tags=["not_a_valid_tag"])
+    with pytest.raises(AuthoringError, match="tags"):
+        build_encounter(bad)
+
+
+# ── dump + interactive round-trip ──
+
+
+def test_dump_encounter_yaml_roundtrip(tmp_path):
+    enc = build_encounter(MIN_INPUTS)
+    path = tmp_path / "enc_test_01.yaml"
+    dump_encounter_yaml(enc, path)
+    assert path.exists()
+    reloaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert reloaded["encounter_id"] == enc["encounter_id"]
+    assert reloaded["waves"] == enc["waves"]
+
+
+def test_run_interactive_full_flow(tmp_path):
+    """Simulate keystrokes for the whole interactive loop."""
+    answers = iter([
+        "enc_flow_01",       # encounter_id
+        "Flow Test",         # name
+        "savana",            # biome_id
+        "8,8",               # grid_size
+        "elimination",       # objective_type
+        "0,3; 0,4",          # player_spawn
+        "2",                 # difficulty_rating
+        "1",                 # num waves
+        "0",                 # wave 1 turn_trigger
+        "7,3; 7,5",          # wave 1 spawn_points
+        "1",                 # wave 1 num units
+        "predoni_nomadi",    # unit species
+        "2",                 # unit count
+        "base",              # unit tier
+        "tutorial",          # tags
+    ])
+    captured: list[str] = []
+
+    def fake_reader() -> str:
+        return next(answers)
+
+    def fake_writer(s: str) -> int:
+        captured.append(s)
+        return len(s)
+
+    path = run_interactive(output_dir=tmp_path, reader=fake_reader, writer=fake_writer)
+    assert path.name == "enc_flow_01.yaml"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert data["encounter_id"] == "enc_flow_01"
+    assert data["name"] == "Flow Test"
+    assert data["grid_size"] == [8, 8]
+    assert data["tags"] == ["tutorial"]
+    joined = "".join(captured)
+    assert "Encounter Authoring" in joined
+    assert "wrote" in joined

--- a/tools/py/author_encounter.py
+++ b/tools/py/author_encounter.py
@@ -1,0 +1,297 @@
+"""Interactive encounter authoring CLI.
+
+Pattern: Fallout Tactics postmortem (Micro Forte, 2001) — tool investment
+early pays off. Evo-Tactics gap: schema exists at schemas/evo/encounter.schema.json
+but no authoring UI. This module provides a guided CLI that:
+
+  1. Walks the user through schema-required fields with validation.
+  2. Produces encounter YAML in docs/planning/encounters/ (matches CI test path).
+  3. Runs basic structural validation (full AJV validation is in CI via
+     tests/scripts/encounterSchema.test.js).
+
+The module is split in two layers:
+
+  - build_encounter(inputs): pure function, dict -> dict. Testable without I/O.
+  - run_interactive(...): stdin/stdout loop calling build_encounter.
+
+Source: memory/reference_tactical_postmortems.md §B.2
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "docs" / "planning" / "encounters"
+SCHEMA_PATH = REPO_ROOT / "schemas" / "evo" / "encounter.schema.json"
+
+ENCOUNTER_ID_PATTERN = re.compile(r"^enc_[a-z0-9_]+$")
+OBJECTIVE_TYPES = [
+    "elimination", "capture_point", "escort", "sabotage", "survival", "escape",
+]
+UNIT_TIERS = ["base", "elite", "apex"]
+TAG_ENUM = [
+    "tutorial", "standard", "boss", "survival", "escort",
+    "puzzle", "timed", "night", "storm",
+]
+
+
+class AuthoringError(ValueError):
+    """Raised when inputs fail structural validation."""
+
+
+def build_encounter(inputs: Dict[str, Any]) -> Dict[str, Any]:
+    """Pure function: input dict -> encounter dict ready for YAML dump.
+
+    Validates required fields + field shapes. Raises AuthoringError on bad
+    input. Does NOT run full AJV validation (that's CI's job).
+    """
+    encounter_id = str(inputs.get("encounter_id", "")).strip()
+    if not ENCOUNTER_ID_PATTERN.match(encounter_id):
+        raise AuthoringError(
+            f"encounter_id must match ^enc_[a-z0-9_]+$, got {encounter_id!r}"
+        )
+
+    name = str(inputs.get("name", "")).strip()
+    if not name:
+        raise AuthoringError("name is required and non-empty")
+
+    biome_id = str(inputs.get("biome_id", "")).strip()
+    if not biome_id:
+        raise AuthoringError("biome_id is required")
+
+    grid_size = inputs.get("grid_size")
+    if not (isinstance(grid_size, list) and len(grid_size) == 2
+            and all(isinstance(n, int) and 4 <= n <= 20 for n in grid_size)):
+        raise AuthoringError("grid_size must be [width, height] with 4 <= n <= 20")
+
+    objective_type = inputs.get("objective_type")
+    if objective_type not in OBJECTIVE_TYPES:
+        raise AuthoringError(
+            f"objective_type must be one of {OBJECTIVE_TYPES}, got {objective_type!r}"
+        )
+
+    player_spawn = inputs.get("player_spawn")
+    if not (isinstance(player_spawn, list) and len(player_spawn) >= 1
+            and all(isinstance(p, list) and len(p) == 2
+                    and all(isinstance(c, int) and c >= 0 for c in p)
+                    for p in player_spawn)):
+        raise AuthoringError("player_spawn must be list of [x, y] integer pairs, min 1")
+
+    waves_in = inputs.get("waves", [])
+    if not (isinstance(waves_in, list) and len(waves_in) >= 1):
+        raise AuthoringError("waves must be a non-empty list")
+
+    waves_out: List[Dict[str, Any]] = []
+    for idx, w in enumerate(waves_in):
+        if not isinstance(w, dict):
+            raise AuthoringError(f"wave #{idx} must be a dict")
+        wave_id = w.get("wave_id", idx + 1)
+        turn_trigger = w.get("turn_trigger", 0)
+        spawn_points = w.get("spawn_points", [])
+        units = w.get("units", [])
+        if not (isinstance(turn_trigger, int) and turn_trigger >= 0):
+            raise AuthoringError(f"wave #{idx} turn_trigger must be int >= 0")
+        if not (isinstance(spawn_points, list) and len(spawn_points) >= 1):
+            raise AuthoringError(f"wave #{idx} spawn_points must be non-empty list")
+        if not (isinstance(units, list) and len(units) >= 1):
+            raise AuthoringError(f"wave #{idx} units must be non-empty list")
+        wave_units_out: List[Dict[str, Any]] = []
+        for uidx, u in enumerate(units):
+            if not isinstance(u, dict):
+                raise AuthoringError(f"wave #{idx} unit #{uidx} must be dict")
+            species = str(u.get("species", "")).strip()
+            count = u.get("count", 0)
+            if not species:
+                raise AuthoringError(f"wave #{idx} unit #{uidx} species required")
+            if not (isinstance(count, int) and count >= 1):
+                raise AuthoringError(
+                    f"wave #{idx} unit #{uidx} count must be int >= 1"
+                )
+            unit_out: Dict[str, Any] = {"species": species, "count": count}
+            tier = u.get("tier")
+            if tier:
+                if tier not in UNIT_TIERS:
+                    raise AuthoringError(
+                        f"unit tier must be one of {UNIT_TIERS}, got {tier!r}"
+                    )
+                unit_out["tier"] = tier
+            if u.get("ai_profile"):
+                unit_out["ai_profile"] = str(u["ai_profile"]).strip()
+            wave_units_out.append(unit_out)
+        waves_out.append({
+            "wave_id": wave_id,
+            "turn_trigger": turn_trigger,
+            "spawn_points": spawn_points,
+            "units": wave_units_out,
+        })
+
+    difficulty_rating = inputs.get("difficulty_rating")
+    if not (isinstance(difficulty_rating, int) and 1 <= difficulty_rating <= 5):
+        raise AuthoringError("difficulty_rating must be int 1..5")
+
+    encounter: Dict[str, Any] = {
+        "encounter_id": encounter_id,
+        "name": name,
+        "biome_id": biome_id,
+        "grid_size": grid_size,
+        "difficulty_rating": difficulty_rating,
+        "objective": {"type": objective_type},
+        "player_spawn": player_spawn,
+        "waves": waves_out,
+    }
+
+    estimated_turns = inputs.get("estimated_turns")
+    if estimated_turns is not None:
+        if not (isinstance(estimated_turns, int) and estimated_turns >= 1):
+            raise AuthoringError("estimated_turns must be int >= 1")
+        encounter["estimated_turns"] = estimated_turns
+
+    tags = inputs.get("tags")
+    if tags:
+        if not (isinstance(tags, list)
+                and all(isinstance(t, str) and t in TAG_ENUM for t in tags)):
+            raise AuthoringError(f"tags must be list of values in {TAG_ENUM}")
+        encounter["tags"] = list(dict.fromkeys(tags))  # dedupe preserving order
+
+    return encounter
+
+
+def dump_encounter_yaml(encounter: Dict[str, Any], path: Path) -> None:
+    """Write encounter dict to YAML file (no I/O in build step)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(encounter, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+def _prompt(
+    question: str,
+    default: Optional[str] = None,
+    reader: Callable[[], str] = input,
+    writer: Callable[[str], int] = sys.stdout.write,
+) -> str:
+    hint = f" [{default}]" if default else ""
+    writer(f"{question}{hint}: ")
+    if writer is sys.stdout.write:
+        sys.stdout.flush()
+    raw = reader().strip()
+    return raw if raw else (default or "")
+
+
+def _prompt_int(question: str, default: int, reader, writer) -> int:
+    while True:
+        raw = _prompt(question, str(default), reader, writer)
+        try:
+            return int(raw)
+        except ValueError:
+            writer(f"  ! Not an integer: {raw!r}\n")
+
+
+def _prompt_list_ints(question: str, default: str, reader, writer) -> List[int]:
+    raw = _prompt(question, default, reader, writer)
+    return [int(p.strip()) for p in raw.split(",") if p.strip()]
+
+
+def _prompt_xy_list(question: str, default: str, reader, writer) -> List[List[int]]:
+    """Parse 'x1,y1; x2,y2' -> [[x1,y1],[x2,y2]]."""
+    raw = _prompt(question, default, reader, writer)
+    pairs = []
+    for chunk in raw.split(";"):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        parts = [p.strip() for p in chunk.split(",") if p.strip()]
+        if len(parts) != 2:
+            raise AuthoringError(f"invalid xy pair {chunk!r}; expected 'x,y'")
+        pairs.append([int(parts[0]), int(parts[1])])
+    return pairs
+
+
+def run_interactive(
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    reader: Callable[[], str] = input,
+    writer: Callable[[str], int] = sys.stdout.write,
+) -> Path:
+    """Interactive loop. Returns path to written YAML."""
+    writer("=== Evo-Tactics Encounter Authoring ===\n")
+    writer(f"Output dir: {output_dir}\n")
+    writer(f"Schema:     {SCHEMA_PATH}\n\n")
+
+    inputs: Dict[str, Any] = {}
+    inputs["encounter_id"] = _prompt(
+        "encounter_id (enc_<slug>)", "enc_new_01", reader, writer
+    )
+    inputs["name"] = _prompt("name (Italian display)", "Nuovo Incontro", reader, writer)
+    inputs["biome_id"] = _prompt("biome_id", "savana", reader, writer)
+    inputs["grid_size"] = _prompt_list_ints(
+        "grid_size (w,h)", "8,8", reader, writer
+    )
+    writer(f"objective_type options: {', '.join(OBJECTIVE_TYPES)}\n")
+    inputs["objective_type"] = _prompt(
+        "objective_type", "elimination", reader, writer
+    )
+    inputs["player_spawn"] = _prompt_xy_list(
+        "player_spawn ('x1,y1; x2,y2')", "0,3; 0,4", reader, writer
+    )
+    inputs["difficulty_rating"] = _prompt_int(
+        "difficulty_rating (1-5)", 1, reader, writer
+    )
+
+    num_waves = _prompt_int("how many waves?", 1, reader, writer)
+    waves: List[Dict[str, Any]] = []
+    for w_idx in range(num_waves):
+        writer(f"\n-- Wave {w_idx + 1} --\n")
+        turn_trigger = _prompt_int(
+            f"  wave {w_idx + 1} turn_trigger", 0 if w_idx == 0 else 3,
+            reader, writer,
+        )
+        spawn_points = _prompt_xy_list(
+            f"  wave {w_idx + 1} spawn_points ('x1,y1; ...')",
+            "7,3; 7,5", reader, writer,
+        )
+        num_units = _prompt_int(
+            f"  wave {w_idx + 1} how many unit entries?", 1, reader, writer,
+        )
+        units = []
+        for u_idx in range(num_units):
+            species = _prompt(
+                f"    unit {u_idx + 1} species", "predoni_nomadi", reader, writer,
+            )
+            count = _prompt_int(
+                f"    unit {u_idx + 1} count", 2, reader, writer,
+            )
+            tier = _prompt(
+                f"    unit {u_idx + 1} tier (base/elite/apex, optional)",
+                "base", reader, writer,
+            )
+            unit: Dict[str, Any] = {"species": species, "count": count}
+            if tier:
+                unit["tier"] = tier
+            units.append(unit)
+        waves.append({
+            "wave_id": w_idx + 1,
+            "turn_trigger": turn_trigger,
+            "spawn_points": spawn_points,
+            "units": units,
+        })
+    inputs["waves"] = waves
+
+    tags_raw = _prompt(
+        f"tags (comma-separated, from {TAG_ENUM})", "", reader, writer,
+    )
+    if tags_raw:
+        inputs["tags"] = [t.strip() for t in tags_raw.split(",") if t.strip()]
+
+    encounter = build_encounter(inputs)
+    path = output_dir / f"{encounter['encounter_id']}.yaml"
+    dump_encounter_yaml(encounter, path)
+    writer(f"\n[ok] wrote {path}\n")
+    writer("[info] run 'node --test tests/scripts/encounterSchema.test.js' "
+           "to validate against AJV schema.\n")
+    return path

--- a/tools/py/game_cli.py
+++ b/tools/py/game_cli.py
@@ -12,6 +12,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
 
+from author_encounter import (
+    DEFAULT_OUTPUT_DIR as AUTHOR_ENCOUNTER_DEFAULT_DIR,
+    AuthoringError,
+    run_interactive as run_author_encounter,
+)
 from generate_encounter import generate as generate_encounter
 from investigate_sources import (
     InvestigationResult,
@@ -213,6 +218,22 @@ def build_parser() -> argparse.ArgumentParser:
         help="Numero massimo di caratteri mostrati nella preview",
     )
 
+    author_parser = subparsers.add_parser(
+        "author-encounter",
+        help="Autore guidato di un encounter YAML (pattern Fallout Tactics: tool investment)",
+    )
+    author_parser.add_argument(
+        "--interactive",
+        action="store_true",
+        help="Modalita' interattiva (default se nessun altro input)",
+    )
+    author_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Directory di output (default: docs/planning/encounters/)",
+    )
+
     return parser
 
 
@@ -238,6 +259,20 @@ def command_generate_encounter(args: argparse.Namespace) -> int:
 
 def command_validate_datasets(args: argparse.Namespace) -> int:
     return validate_datasets_main()
+
+
+def command_author_encounter(args: argparse.Namespace) -> int:
+    """Interactive encounter authoring (pattern Fallout Tactics postmortem)."""
+    output_dir = args.output_dir or AUTHOR_ENCOUNTER_DEFAULT_DIR
+    try:
+        run_author_encounter(output_dir=output_dir)
+    except AuthoringError as exc:
+        sys.stderr.write(f"[error] {exc}\n")
+        return 1
+    except KeyboardInterrupt:
+        sys.stderr.write("\n[cancelled]\n")
+        return 130
+    return 0
 
 
 def command_validate_ecosystem_pack(args: argparse.Namespace) -> int:
@@ -463,6 +498,8 @@ def main(argv: Optional[Any] = None) -> int:
         exit_code = command_validate_ecosystem_pack(args)
     elif args.command == "investigate":
         exit_code = command_investigate(args)
+    elif args.command == "author-encounter":
+        exit_code = command_author_encounter(args)
     else:  # pragma: no cover - dovrebbe essere inaccessibile
         parser.error(f"Comando sconosciuto: {args.command}")
 


### PR DESCRIPTION
## Summary

Pacchetto duplice (#3 + #4) + lavoro bonus che era nel working tree.

### #3 Atlas in-match telemetry (NEW)
- apps/backend/services/atlasLive.js — pressure/momentum/warning_signals
- tests/api/atlasLive.test.js — 8 test cases
- Wired in publicSessionView → /api/session/state ora espone atlas object

Pressure formula: HP 40% + units 30% + AP 15% + position 15% (range 0-100)
Momentum: player_dominant/advantage/even/enemy_advantage/enemy_dominant + trend
Warnings: low_hp, almost_kill, victory_imminent, defeat_imminent

### #4 Foodweb bilingual migration (NEW)
5 pack files migrati additivamente: 52 nodi con display_name_it + display_name_en

### Bonus dal worktree
- docs/balance/MACHINATIONS_MODELS.md
- packs/.../sistema_pressure.yaml + test (AI War tier)
- tools/py/author_encounter.py + test

🤖 Generated with [Claude Code](https://claude.com/claude-code)