### PR TITLE
feat(ai): pressure-tier gates SIS intents per round (AI War wiring)

### DIFF
--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -39,6 +39,27 @@
 const { selectAiPolicy, stepAway, DEFAULT_ATTACK_RANGE, loadAiConfig } = require('./policy');
 const { selectAiPolicyUtility } = require('./utilityBrain');
 
+// Sistema pressure tier → max intents per round (AI War pattern).
+// Mirror dei tier definiti in packs/.../sistema_pressure.yaml e in
+// sessionHelpers.SISTEMA_PRESSURE_TIERS. Definito qui per evitare
+// dipendenza circolare con sessionHelpers.
+const PRESSURE_TIER_INTENT_CAP = [
+  { threshold: 0, intents_per_round: 1 }, // Calm
+  { threshold: 25, intents_per_round: 2 }, // Alert
+  { threshold: 50, intents_per_round: 2 }, // Escalated
+  { threshold: 75, intents_per_round: 3 }, // Critical
+  { threshold: 95, intents_per_round: 3 }, // Apex
+];
+
+function intentsCapForPressure(pressure) {
+  const p = Number.isFinite(Number(pressure)) ? Math.max(0, Math.min(100, Number(pressure))) : 0;
+  let cap = PRESSURE_TIER_INTENT_CAP[0].intents_per_round;
+  for (const t of PRESSURE_TIER_INTENT_CAP) {
+    if (p >= t.threshold) cap = t.intents_per_round;
+  }
+  return cap;
+}
+
 function createDeclareSistemaIntents(deps) {
   const {
     pickLowestHpEnemy,
@@ -82,13 +103,28 @@ function createDeclareSistemaIntents(deps) {
     const threatCtx =
       typeof computeThreatIndex === 'function' ? computeThreatIndex(session, threatConfig) : null;
 
+    // AI War pattern: pressure-driven intent cap.
+    // Tier piu' alto (player vincente) → SIS dichiara piu' intents.
+    // Calm: 1 intent/round, Critical/Apex: 3.
+    const intentsCap = intentsCapForPressure(session.sistema_pressure);
+
     const intents = [];
     const decisions = [];
+    let intentsEmitted = 0;
 
     for (const actor of session.units) {
       if (!actor) continue;
       if (actor.controlled_by !== 'sistema') continue;
       if (Number(actor.hp || 0) <= 0) continue;
+      if (intentsEmitted >= intentsCap) {
+        decisions.push({
+          unit_id: actor.id,
+          rule: 'PRESSURE_CAP',
+          intent: 'skip',
+          reason: `pressure cap raggiunto (${intentsEmitted}/${intentsCap})`,
+        });
+        continue;
+      }
 
       const target = pickLowestHpEnemy(session, actor);
       if (!target) {
@@ -154,6 +190,7 @@ function createDeclareSistemaIntents(deps) {
           source_ia_rule: policy.rule,
         };
         intents.push({ unit_id: actor.id, action });
+        intentsEmitted++;
         decisions.push({
           unit_id: actor.id,
           rule: policy.rule,
@@ -218,6 +255,7 @@ function createDeclareSistemaIntents(deps) {
         source_ia_rule: policy.rule,
       };
       intents.push({ unit_id: actor.id, action: moveAction });
+      intentsEmitted++;
       decisions.push({
         unit_id: actor.id,
         rule: policy.rule,

--- a/tests/ai/declareSistemaIntents.test.js
+++ b/tests/ai/declareSistemaIntents.test.js
@@ -79,6 +79,9 @@ function makeSession(overrides = {}) {
     turn: 1,
     units,
     grid: { width: 6, height: 6 },
+    // Default high pressure: tier=Apex (cap=3) → tutti gli intents emessi.
+    // Test che vogliono testare il pressure cap impostano sistema_pressure: 0.
+    sistema_pressure: overrides.sistema_pressure ?? 100,
   };
 }
 
@@ -499,6 +502,162 @@ test('multi-unit SIS produces intents in session.units order', () => {
 // ─────────────────────────────────────────────────────────────────
 // Purity
 // ─────────────────────────────────────────────────────────────────
+
+// ─────────────────────────────────────────────────────────────────
+// Sistema pressure tier — intent cap
+// ─────────────────────────────────────────────────────────────────
+
+test('pressure=0 (Calm): cap=1 — only first SIS unit emits intent', () => {
+  const declare = buildDeclare();
+  const session = makeSession({
+    sistema_pressure: 0,
+    units: [
+      {
+        id: 'p1',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        position: { x: 0, y: 0 },
+        controlled_by: 'player',
+        status: {},
+      },
+      {
+        id: 'sis_a',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        attack_range: 2,
+        position: { x: 2, y: 0 },
+        controlled_by: 'sistema',
+        status: {},
+      },
+      {
+        id: 'sis_b',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        attack_range: 2,
+        position: { x: 2, y: 1 },
+        controlled_by: 'sistema',
+        status: {},
+      },
+      {
+        id: 'sis_c',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        attack_range: 2,
+        position: { x: 2, y: 2 },
+        controlled_by: 'sistema',
+        status: {},
+      },
+    ],
+  });
+  const { intents, decisions } = declare(session);
+  assert.equal(intents.length, 1, 'cap=1 at Calm tier');
+  const skipped = decisions.filter((d) => d.rule === 'PRESSURE_CAP');
+  assert.equal(skipped.length, 2, '2 SIS skipped by pressure cap');
+});
+
+test('pressure=50 (Escalated): cap=2', () => {
+  const declare = buildDeclare();
+  const session = makeSession({
+    sistema_pressure: 50,
+    units: [
+      {
+        id: 'p1',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        position: { x: 0, y: 0 },
+        controlled_by: 'player',
+        status: {},
+      },
+      {
+        id: 'sis_a',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        attack_range: 2,
+        position: { x: 2, y: 0 },
+        controlled_by: 'sistema',
+        status: {},
+      },
+      {
+        id: 'sis_b',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        attack_range: 2,
+        position: { x: 2, y: 1 },
+        controlled_by: 'sistema',
+        status: {},
+      },
+      {
+        id: 'sis_c',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        attack_range: 2,
+        position: { x: 2, y: 2 },
+        controlled_by: 'sistema',
+        status: {},
+      },
+    ],
+  });
+  const { intents } = declare(session);
+  assert.equal(intents.length, 2, 'cap=2 at Escalated tier');
+});
+
+test('pressure=80 (Critical): cap=3 — all SIS emit', () => {
+  const declare = buildDeclare();
+  const session = makeSession({
+    sistema_pressure: 80,
+    units: [
+      {
+        id: 'p1',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        position: { x: 0, y: 0 },
+        controlled_by: 'player',
+        status: {},
+      },
+      {
+        id: 'sis_a',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        attack_range: 2,
+        position: { x: 2, y: 0 },
+        controlled_by: 'sistema',
+        status: {},
+      },
+      {
+        id: 'sis_b',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        attack_range: 2,
+        position: { x: 2, y: 1 },
+        controlled_by: 'sistema',
+        status: {},
+      },
+      {
+        id: 'sis_c',
+        hp: 10,
+        max_hp: 10,
+        ap: 2,
+        attack_range: 2,
+        position: { x: 2, y: 2 },
+        controlled_by: 'sistema',
+        status: {},
+      },
+    ],
+  });
+  const { intents } = declare(session);
+  assert.equal(intents.length, 3, 'cap=3 at Critical tier');
+});
 
 test('does not mutate session or units', () => {
   const declare = buildDeclare();


### PR DESCRIPTION
## Summary

Sistema pressure ora MODULA il comportamento AI invece di essere solo visualizzato.

### Tier-based intent cap

| Tier | Range | Cap intents/round |
|------|-------|-------------------|
| Calm | 0-24 | 1 (solo 1 SIS agisce) |
| Alert | 25-49 | 2 |
| Escalated | 50-74 | 2 |
| Critical | 75-94 | 3 |
| Apex | 95-100 | 3 (tutte) |

### Effetto gameplay

- **Early game** (low pressure): SIS passivo, player ha tempo
- **Mid game** (KOs accumulati → pressure sale): SIS si attiva
- **Late game** (high pressure): SIS pressante

PRESSURE_CAP rule emessa in `decisions` per debug/UI.

### Test
- 3 nuovi cases (cap 1/2/3 a pressure 0/50/80)
- makeSession default sistema_pressure: 100 per backward compat
- 143/143 verdi

### Batch playtest impact
| Metrica | Pre | Post |
|---------|-----|------|
| Win rate | 8/10 | 8/10 |
| Avg rounds | 6.2 | 7.0 |
| Defeats | 0 | 0 |
| Timeouts | 1 | 2 |

Curva pressione piu' graduale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)