### PR TITLE
feat(combat): hazard tile damage wiring (enc_tutorial_03 fumarole)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -577,6 +577,10 @@ function createSessionRouter(options = {}) {
         // Gate SIS intent pool + reinforcement budget via computeSistemaTier().
         // Updated da roundOrchestrator/session handlers su victory/KO events.
         sistema_pressure: 0,
+        // Hazard tiles dal scenario (es. enc_tutorial_03 fumarole).
+        // Lista {x, y, damage, type}. Applicato a fine turno via
+        // applyHazardDamage in handleTurnEndViaRound.
+        hazard_tiles: Array.isArray(req.body?.hazard_tiles) ? req.body.hazard_tiles : [],
       };
       sessions.set(sessionId, session);
       activeSessionId = sessionId;

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -303,6 +303,45 @@ function createRoundBridge(deps) {
     resetRoundAttackTracker(session);
     session.roundState = adaptSessionToRoundState(session);
 
+    // Hazard tiles: applica danno a unita' che terminano il turno su tile pericolosi.
+    // Es. enc_tutorial_03 fumarole. Skip se nessun hazard configurato.
+    const hazardEvents = [];
+    if (Array.isArray(session.hazard_tiles) && session.hazard_tiles.length > 0) {
+      for (const unit of session.units) {
+        if (!unit || Number(unit.hp || 0) <= 0) continue;
+        const hazard = session.hazard_tiles.find(
+          (h) =>
+            Number(h.x) === Number(unit.position?.x) && Number(h.y) === Number(unit.position?.y),
+        );
+        if (!hazard) continue;
+        const dmg = Number(hazard.damage) || 1;
+        const hpBefore = unit.hp;
+        unit.hp = Math.max(0, unit.hp - dmg);
+        session.damage_taken[unit.id] = (session.damage_taken[unit.id] || 0) + dmg;
+        await appendEvent(session, {
+          ts: new Date().toISOString(),
+          session_id: session.session_id,
+          action_type: 'hazard',
+          actor_id: hazard.type || 'hazard',
+          target_id: unit.id,
+          turn: session.turn,
+          damage_dealt: dmg,
+          result: 'hit',
+          hp_before: hpBefore,
+          hp_after: unit.hp,
+          hazard_type: hazard.type || 'unknown',
+          position: { x: hazard.x, y: hazard.y },
+        });
+        hazardEvents.push({
+          unit_id: unit.id,
+          hazard_type: hazard.type,
+          damage: dmg,
+          hp_after: unit.hp,
+          killed: unit.hp === 0,
+        });
+      }
+    }
+
     const bleedingEvents = [];
     for (const unit of session.units) {
       if (!unit || !unit.status || Number(unit.hp || 0) <= 0) continue;
@@ -517,6 +556,7 @@ function createRoundBridge(deps) {
       ia_actions: iaActions,
       ia_action: iaActions[0] || null,
       side_effects: bleedingEvents,
+      hazard_events: hazardEvents,
       state: publicSessionView(session),
       round_wrapper: true,
       round_phase: session.roundState.round_phase,

--- a/tests/api/hazardWiring.test.js
+++ b/tests/api/hazardWiring.test.js
@@ -1,0 +1,82 @@
+// =============================================================================
+// HAZARD WIRING — verifica che hazard_tiles applichi danno a fine turno
+//
+// enc_tutorial_03 ha fumarole tossiche a (2,2) e (3,3). Quando una unita'
+// termina il turno su un tile hazard, hp -= damage.
+// =============================================================================
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+test('Hazard: enc_tutorial_03 esposto in tutorial loader', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const res = await request(app).get('/api/tutorial/enc_tutorial_03');
+  assert.equal(res.status, 200);
+  assert.equal(res.body.id, 'enc_tutorial_03');
+  assert.equal(res.body.difficulty_rating, 3);
+  assert.ok(Array.isArray(res.body.hazard_tiles), 'hazard_tiles array');
+  assert.equal(res.body.hazard_tiles.length, 2);
+  assert.equal(res.body.hazard_tiles[0].type, 'fumarole_tossica');
+});
+
+test('Hazard: tile damage applied at turn end', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_03');
+  // Posiziona p_scout direttamente su tile hazard (2,2) prima di /start
+  const units = scenario.body.units.map((u) =>
+    u.id === 'p_scout' ? { ...u, position: { x: 2, y: 2 } } : u,
+  );
+
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({ units, hazard_tiles: scenario.body.hazard_tiles });
+  assert.equal(startRes.status, 200);
+  const sid = startRes.body.session_id;
+
+  const stateBefore = await request(app).get('/api/session/state').query({ session_id: sid });
+  const scoutBefore = stateBefore.body.units.find((u) => u.id === 'p_scout');
+  assert.equal(scoutBefore.hp, 10, 'scout starts at full HP');
+
+  // Trigger turn/end senza nessuna azione → hazard fires
+  const turnRes = await request(app).post('/api/session/turn/end').send({ session_id: sid });
+  assert.equal(turnRes.status, 200);
+  assert.ok(Array.isArray(turnRes.body.hazard_events), 'hazard_events array in response');
+  const scoutHazard = turnRes.body.hazard_events.find((h) => h.unit_id === 'p_scout');
+  assert.ok(scoutHazard, 'p_scout should have hazard event');
+  assert.equal(scoutHazard.hazard_type, 'fumarole_tossica');
+  assert.equal(scoutHazard.damage, 1);
+
+  const stateAfter = await request(app).get('/api/session/state').query({ session_id: sid });
+  const scoutAfter = stateAfter.body.units.find((u) => u.id === 'p_scout');
+  assert.equal(scoutAfter.hp, 9, 'scout HP should drop by 1 from hazard');
+});
+
+test('Hazard: no damage when no unit on hazard tiles', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_03');
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units, hazard_tiles: scenario.body.hazard_tiles });
+  const sid = startRes.body.session_id;
+
+  // Nessuna unita' parte su tile hazard (default positions: 0,1 / 0,4 / 4,1 / 4,4)
+  const turnRes = await request(app).post('/api/session/turn/end').send({ session_id: sid });
+  assert.equal(turnRes.status, 200);
+  assert.equal(turnRes.body.hazard_events.length, 0, 'no hazard events when no unit on tile');
+});


### PR DESCRIPTION
## Summary

enc_tutorial_03 dichiarava hazard_tiles ma il damage non veniva applicato. Wired in handleTurnEndViaRound.

### Changes
- session.js: /start accetta hazard_tiles in body
- sessionRoundBridge.js handleTurnEndViaRound:
  - Scan unita' vive vs hazard_tiles
  - Match (x,y) → applica damage, log event 'hazard'
  - hazard_events array in response

### Test (3 cases)
- enc_tutorial_03 espone hazard_tiles in tutorial loader
- p_scout su tile (2,2) → -1 HP a fine turno
- Nessuna unita' su tile → hazard_events vuoto

🤖 Generated with [Claude Code](https://claude.com/claude-code)