### PR TITLE
feat(vc): apply VC calibration iter1 — lower Ennea thresholds + MBTI dead-band

### DIFF
--- a/apps/backend/services/vcScoring.js
+++ b/apps/backend/services/vcScoring.js
@@ -516,9 +516,19 @@ function computeMbtiAxes(raw) {
 
 /**
  * P4: derive MBTI 4-letter type from axes values.
- * Threshold: 0.5 (center) — above = first letter, below = second letter.
+ * VC Calibration iter1 (2026-04-17): dead-band 0.45-0.55 ritorna 'X'
+ * per evitare false classification da rumore in sessioni corte.
  * Returns null if any axis is null.
  */
+const MBTI_DEAD_BAND_LOW = 0.45;
+const MBTI_DEAD_BAND_HIGH = 0.55;
+
+function letterOrUncertain(value, lo, hi) {
+  if (value < MBTI_DEAD_BAND_LOW) return lo;
+  if (value > MBTI_DEAD_BAND_HIGH) return hi;
+  return 'X'; // dead-band: indeterminato
+}
+
 function deriveMbtiType(axes) {
   if (!axes) return null;
   const get = (axis) => (axis && axis.value !== undefined ? axis.value : null);
@@ -528,10 +538,10 @@ function deriveMbtiType(axes) {
   const jp = get(axes.J_P);
   if (ei === null || sn === null || tf === null || jp === null) return null;
   return (
-    (ei >= 0.5 ? 'I' : 'E') +
-    (sn >= 0.5 ? 'S' : 'N') +
-    (tf >= 0.5 ? 'T' : 'F') +
-    (jp >= 0.5 ? 'J' : 'P')
+    letterOrUncertain(ei, 'E', 'I') +
+    letterOrUncertain(sn, 'N', 'S') +
+    letterOrUncertain(tf, 'F', 'T') +
+    letterOrUncertain(jp, 'P', 'J')
   );
 }
 

--- a/data/core/telemetry.yaml
+++ b/data/core/telemetry.yaml
@@ -53,11 +53,14 @@ mbti_axes:
   T_F: {formula: "1 - 0.5*utility_actions + 0.5*support_bias"}
   J_P: {formula: "1 - 0.6*setup - 0.2*time_to_commit + 0.2*last_second"}
 ennea_themes:
+  # VC Calibration iter1 (2026-04-17): soglie abbassate per indici
+  # con weight parziali (cohesion/explore/setup/tilt). Vedi
+  # docs/balance/vc-calibration-iter1.md per analisi.
   - {id: "Conquistatore(3)", when: "aggro>0.65 && risk>0.55"}
-  - {id: "Coordinatore(2)",  when: "cohesion>0.70"}
-  - {id: "Esploratore(7)",   when: "explore>0.70"}
-  - {id: "Architetto(5)",    when: "setup>0.70"}
-  - {id: "Stoico(9)",        when: "tilt>0.65"}
+  - {id: "Coordinatore(2)",  when: "cohesion>0.55"}     # da 0.70 (formation_time/support_actions null)
+  - {id: "Esploratore(7)",   when: "explore>0.45"}       # da 0.70 (time_in_fow/optionals null)
+  - {id: "Architetto(5)",    when: "setup>0.50"}         # da 0.70 (overwatch/trap/cover null)
+  - {id: "Stoico(9)",        when: "tilt>0.65"}          # tilt non implementato — soglia invariata
   # SPRINT_005 fase 2: archetipo mordi-e-fuggi.
   # Trigger multi-criterio che premia il giocatore mobile:
   #   evasion_ratio > 0.6        → la maggioranza degli attacchi e' seguita da ritirata

--- a/docs/balance/vc-calibration-iter1.md
+++ b/docs/balance/vc-calibration-iter1.md
@@ -1,6 +1,6 @@
 ---
-title: VC Scoring Calibration — Iteration 1 (analysis)
-doc_status: draft
+title: VC Scoring Calibration — Iteration 1 (analysis + applied)
+doc_status: active
 doc_owner: master-dd
 workstream: dataset-pack
 last_verified: '2026-04-17'
@@ -10,6 +10,8 @@ review_cycle_days: 30
 ---
 
 # VC Scoring Calibration — Iteration 1
+
+> **Stato**: proposte applicate 2026-04-17. Vedi sezione "Applied changes" in fondo.
 
 Prima analisi VC scoring vs dati osservati nei batch playtest tutorial. Iterazione conservativa, **non applicare modifiche al config senza N≥50 sessioni varie**.
 
@@ -87,3 +89,35 @@ Mirror del pattern `Cacciatore` (gia' usa `attacks_started>=5`).
 - `data/core/telemetry.yaml`
 - `tests/api/batchPlaytest.test.js`
 - `tests/api/firstPlaytest.test.js`
+
+## Applied changes (2026-04-17)
+
+### #1 Ennea threshold lower (data/core/telemetry.yaml)
+
+- `Coordinatore(2)`: cohesion>0.70 → **>0.55**
+- `Esploratore(7)`: explore>0.70 → **>0.45**
+- `Architetto(5)`: setup>0.70 → **>0.50**
+- `Stoico(9)`: tilt>0.65 (invariato — tilt non implementato)
+
+### #2 MBTI dead-band (apps/backend/services/vcScoring.js)
+
+`deriveMbtiType` ora usa dead-band 0.45-0.55 → ritorna `X` per asse indeterminato. Esempi:
+
+- `INTJ`: tutti gli assi nettamente fuori dead-band
+- `XNTJ`: E/I nel dead-band, asse N/T/J chiari
+- `XXXX`: classification incerta, sessione troppo corta
+
+### #3 Risk null weights — NOT applied
+
+Decisione: non azzerare `self_heal` e `overcap_guard` in YAML. Servono per quando heal/overcap saranno derivati. Aspetto piu' dati.
+
+### #4 insufficient_data guard — NOT applied
+
+Aggiungere `min_attacks` su Ennea triggers richiede update parser whitelist in vcScoring. Rinviato a iter2 con piu' contesto.
+
+## Iter2 todo
+
+- Implementare `tilt` window model (richiede storico per-round)
+- Derivare `formation_time`, `support_actions`, `cover_before_attack`
+- Run batch su tutti e 3 gli encounter (1, 2, 3) e aggregare N≥30
+- Applicare proposta #4 (insufficient_data guard) se Ennea triggers troppo rumorosi


### PR DESCRIPTION
## Summary

Applico 2 delle 4 proposte da docs/balance/vc-calibration-iter1.md.

### #1 Ennea threshold lower (telemetry.yaml)
| Archetipo | Prima | Dopo |
|-----------|-------|------|
| Coordinatore(2) | cohesion>0.70 | **>0.55** |
| Esploratore(7) | explore>0.70 | **>0.45** |
| Architetto(5) | setup>0.70 | **>0.50** |
| Stoico(9) | tilt>0.65 | invariato (tilt non wired) |

Compensa weight mancanti (formation_time, support_actions, time_in_fow, optionals, overwatch, trap, cover) finche' non derivati.

### #2 MBTI dead-band (vcScoring.js)
deriveMbtiType ora usa dead-band 0.45-0.55. Asse nel range → 'X'.
Esempi: `INTJ` (deciso) vs `XNTJ` (E/I incerto) vs `XXXX` (sessione troppo corta).

### NOT applied
- #3 Risk null weights (rinviato — servono per heal/overcap futuri)
- #4 insufficient_data guard (rinviato — richiede parser update)

## Test plan
- [x] 145+ test verdi, no breakage
- [x] firstPlaytest pass
- [x] batchPlaytest pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)