### PR TITLE
feat(tutorial): enc_tutorial_04 'Pozza Acida' diff 4/5 + bleeding + hazard

### DIFF
--- a/apps/backend/routes/tutorial.js
+++ b/apps/backend/routes/tutorial.js
@@ -14,9 +14,11 @@ const {
   TUTORIAL_SCENARIO,
   TUTORIAL_SCENARIO_02,
   TUTORIAL_SCENARIO_03,
+  TUTORIAL_SCENARIO_04,
   buildTutorialUnits,
   buildTutorialUnits02,
   buildTutorialUnits03,
+  buildTutorialUnits04,
 } = require('../services/tutorialScenario');
 
 function createTutorialRouter() {
@@ -46,6 +48,14 @@ function createTutorialRouter() {
     });
   });
 
+  router.get('/enc_tutorial_04', (_req, res) => {
+    res.json({
+      ...TUTORIAL_SCENARIO_04,
+      units: buildTutorialUnits04(),
+      usage: 'POST the units array to /api/session/start to begin a playable session.',
+    });
+  });
+
   router.get('/', (_req, res) => {
     res.json({
       scenarios: [
@@ -66,6 +76,12 @@ function createTutorialRouter() {
           name: TUTORIAL_SCENARIO_03.name,
           difficulty: TUTORIAL_SCENARIO_03.difficulty_rating,
           href: `/api/tutorial/${TUTORIAL_SCENARIO_03.id}`,
+        },
+        {
+          id: TUTORIAL_SCENARIO_04.id,
+          name: TUTORIAL_SCENARIO_04.name,
+          difficulty: TUTORIAL_SCENARIO_04.difficulty_rating,
+          href: `/api/tutorial/${TUTORIAL_SCENARIO_04.id}`,
         },
       ],
     });

--- a/apps/backend/services/tutorialScenario.js
+++ b/apps/backend/services/tutorialScenario.js
@@ -63,6 +63,26 @@ const TUTORIAL_SCENARIO_03 = {
   ],
 };
 
+const TUTORIAL_SCENARIO_04 = {
+  id: 'enc_tutorial_04',
+  name: 'Pozza Acida del Bosco',
+  biome_id: 'foresta_acida',
+  difficulty_rating: 4,
+  estimated_turns: 12,
+  grid_size: 6,
+  objective: 'elimination',
+  objective_text:
+    'Sconfiggi i 3 guardiani della pozza. Attento al lanciere: il suo morso causa emorragia.',
+  briefing_pre:
+    'La pozza acida nasconde 3 guardiani: 2 corrieri rapidi e un lanciere con denti seghettati. Il bleeding accumula danno turno per turno: prioritizza il lanciere o tieni HP alto.',
+  briefing_post: 'La pozza si calma. I corpi dei guardiani si dissolvono nel liquido.',
+  hazard_tiles: [
+    { x: 2, y: 1, damage: 1, type: 'pozza_acida' },
+    { x: 3, y: 4, damage: 1, type: 'pozza_acida' },
+    { x: 2, y: 3, damage: 1, type: 'pozza_acida' },
+  ],
+};
+
 function buildTutorialUnits() {
   return [
     // --- Player units ---
@@ -280,11 +300,97 @@ function buildTutorialUnits03() {
   ];
 }
 
+// enc_tutorial_04: foresta acida diff 4/5. 2v3 con un lanciere bleeding
+// (trait denti_seghettati) + 3 hazard tiles distribuiti.
+function buildTutorialUnits04() {
+  return [
+    {
+      id: 'p_scout',
+      species: 'dune_stalker',
+      job: 'skirmisher',
+      traits: ['zampe_a_molla'],
+      hp: 10,
+      ap: 3,
+      mod: 3,
+      dc: 12,
+      guardia: 1,
+      position: { x: 1, y: 1 },
+      controlled_by: 'player',
+      facing: 'E',
+    },
+    {
+      id: 'p_tank',
+      species: 'dune_stalker',
+      job: 'vanguard',
+      traits: ['pelle_elastomera'],
+      hp: 12,
+      ap: 3,
+      mod: 2,
+      dc: 13,
+      guardia: 1,
+      position: { x: 1, y: 4 },
+      controlled_by: 'player',
+      facing: 'E',
+    },
+    // Lanciere bleeding: priority target (denti_seghettati causa emorragia
+    // su hit). Player deve sceglire se ucciderlo subito o tankare il bleed.
+    {
+      id: 'e_lanciere',
+      species: 'guardiano_pozza',
+      job: 'skirmisher',
+      traits: ['denti_seghettati'],
+      hp: 5,
+      ap: 2,
+      mod: 3,
+      dc: 12,
+      guardia: 0,
+      attack_range: 2,
+      position: { x: 3, y: 2 },
+      controlled_by: 'sistema',
+      facing: 'W',
+    },
+    // Corriere 1: rapido ma fragile
+    {
+      id: 'e_corriere_1',
+      species: 'guardiano_pozza',
+      job: 'skirmisher',
+      traits: [],
+      hp: 4,
+      ap: 3,
+      mod: 2,
+      dc: 11,
+      guardia: 0,
+      attack_range: 2,
+      position: { x: 4, y: 0 },
+      controlled_by: 'sistema',
+      facing: 'W',
+    },
+    // Corriere 2: stesso pattern
+    {
+      id: 'e_corriere_2',
+      species: 'guardiano_pozza',
+      job: 'skirmisher',
+      traits: [],
+      hp: 4,
+      ap: 3,
+      mod: 2,
+      dc: 11,
+      guardia: 0,
+      attack_range: 2,
+      position: { x: 4, y: 5 },
+      controlled_by: 'sistema',
+      facing: 'W',
+    },
+  ];
+}
+
 module.exports = {
   TUTORIAL_SCENARIO,
   TUTORIAL_SCENARIO_02,
   TUTORIAL_SCENARIO_03,
+  TUTORIAL_SCENARIO_04,
   buildTutorialUnits,
   buildTutorialUnits02,
   buildTutorialUnits03,
+  buildTutorialUnits04,
 };

--- a/tests/api/tutorial04.test.js
+++ b/tests/api/tutorial04.test.js
@@ -1,0 +1,147 @@
+// =============================================================================
+// TUTORIAL 04 BATCH — "Pozza Acida del Bosco" (diff 4/5)
+//
+// 2 player vs 3 (1 lanciere bleeding + 2 corrieri) + 3 hazard tiles.
+// Trait denti_seghettati su lanciere causa bleeding cumulativo.
+// Target win rate ~30-50% per diff 4/5.
+// =============================================================================
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+const N_RUNS = 10;
+const MAX_ROUNDS = 18;
+
+async function runOne(app) {
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_04');
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units, hazard_tiles: scenario.body.hazard_tiles });
+  const sid = startRes.body.session_id;
+
+  const stats = {
+    sid: sid.slice(0, 8),
+    rounds: 0,
+    outcome: 'timeout',
+    player_hits: 0,
+    player_misses: 0,
+    player_damage: 0,
+    enemy_damage: 0,
+    hazard_damage: 0,
+    bleeding_events: 0,
+  };
+
+  for (let r = 1; r <= MAX_ROUNDS; r++) {
+    stats.rounds = r;
+    const stateRes = await request(app).get('/api/session/state').query({ session_id: sid });
+    if (stateRes.status !== 200) break;
+    const state = stateRes.body;
+
+    const aliveEnemies = state.units.filter((u) => u.controlled_by === 'sistema' && u.hp > 0);
+    const alivePlayers = state.units.filter((u) => u.controlled_by === 'player' && u.hp > 0);
+
+    if (aliveEnemies.length === 0) {
+      stats.outcome = 'victory';
+      break;
+    }
+    if (alivePlayers.length === 0) {
+      stats.outcome = 'defeat';
+      break;
+    }
+
+    for (const player of alivePlayers) {
+      const liveStateRes = await request(app).get('/api/session/state').query({ session_id: sid });
+      const liveEnemies = liveStateRes.body.units.filter(
+        (u) => u.controlled_by === 'sistema' && u.hp > 0,
+      );
+      const target = liveEnemies[0];
+      if (!target) break;
+      const actionRes = await request(app).post('/api/session/action').send({
+        session_id: sid,
+        actor_id: player.id,
+        action_type: 'attack',
+        target_id: target.id,
+      });
+      if (actionRes.status === 200 && actionRes.body.roll !== undefined) {
+        const x = actionRes.body;
+        if (x.result === 'hit') {
+          stats.player_hits++;
+          stats.player_damage += x.damage_dealt || 0;
+        } else {
+          stats.player_misses++;
+        }
+      }
+    }
+
+    const turnRes = await request(app).post('/api/session/turn/end').send({ session_id: sid });
+    if (turnRes.status === 200) {
+      if (turnRes.body.ia_actions) {
+        for (const ia of turnRes.body.ia_actions) {
+          if ((ia.type === 'attack' || ia.action_type === 'attack') && ia.result === 'hit') {
+            stats.enemy_damage += ia.damage_dealt || 0;
+          }
+        }
+      }
+      if (Array.isArray(turnRes.body.hazard_events)) {
+        for (const h of turnRes.body.hazard_events) stats.hazard_damage += h.damage || 0;
+      }
+      if (Array.isArray(turnRes.body.side_effects)) {
+        for (const s of turnRes.body.side_effects) {
+          if (s.unit_id) stats.bleeding_events++;
+        }
+      }
+    }
+  }
+
+  await request(app).post('/api/session/end').send({ session_id: sid });
+  return stats;
+}
+
+test(`TUTORIAL 04 BATCH: ${N_RUNS} runs (diff 4/5, bleeding + hazard)`, async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const allStats = [];
+  for (let i = 0; i < N_RUNS; i++) {
+    allStats.push(await runOne(app));
+  }
+
+  const victories = allStats.filter((s) => s.outcome === 'victory').length;
+  const defeats = allStats.filter((s) => s.outcome === 'defeat').length;
+  const timeouts = allStats.filter((s) => s.outcome === 'timeout').length;
+  const avgRounds = allStats.reduce((a, s) => a + s.rounds, 0) / N_RUNS;
+  const totalAttacks = allStats.reduce((a, s) => a + s.player_hits + s.player_misses, 0);
+  const totalHits = allStats.reduce((a, s) => a + s.player_hits, 0);
+  const hitRate = totalAttacks > 0 ? (totalHits / totalAttacks) * 100 : 0;
+  const avgPlayerDmg = allStats.reduce((a, s) => a + s.player_damage, 0) / N_RUNS;
+  const avgEnemyDmg = allStats.reduce((a, s) => a + s.enemy_damage, 0) / N_RUNS;
+  const avgHazardDmg = allStats.reduce((a, s) => a + s.hazard_damage, 0) / N_RUNS;
+  const totalBleed = allStats.reduce((a, s) => a + s.bleeding_events, 0);
+
+  console.log(`\n  ╔═══ TUTORIAL 04 BATCH (N=${N_RUNS}) ═══╗`);
+  console.log(`  ║  Difficulty: 4/5 — Pozza Acida + bleeding`);
+  console.log(`  ║`);
+  console.log(`  ║  Outcomes:`);
+  console.log(
+    `  ║    Victories: ${victories}/${N_RUNS} (${((victories / N_RUNS) * 100).toFixed(0)}%)`,
+  );
+  console.log(`  ║    Defeats:   ${defeats}/${N_RUNS}`);
+  console.log(`  ║    Timeouts:  ${timeouts}/${N_RUNS}`);
+  console.log(`  ║`);
+  console.log(`  ║  Combat:`);
+  console.log(`  ║    Avg rounds: ${avgRounds.toFixed(1)}`);
+  console.log(`  ║    Hit rate: ${hitRate.toFixed(1)}% (${totalHits}/${totalAttacks})`);
+  console.log(`  ║    Avg player damage/run: ${avgPlayerDmg.toFixed(1)}`);
+  console.log(`  ║    Avg enemy damage/run: ${avgEnemyDmg.toFixed(1)}`);
+  console.log(`  ║    Avg hazard damage/run: ${avgHazardDmg.toFixed(1)}`);
+  console.log(`  ║    Total bleeding events: ${totalBleed}`);
+  console.log(`  ╚════════════════════════════════════════╝\n`);
+
+  assert.equal(allStats.length, N_RUNS);
+});


### PR DESCRIPTION
## Summary

Quarto encounter — completa curva difficolta' 1→4.

### Composizione
- 2 player (scout + tank)
- 3 enemy: 1 lanciere bleeding + 2 corrieri rapidi
- 3 hazard tiles (pozze acide)
- Trait `denti_seghettati` su lanciere → bleeding cumulativo

### Design intent diff 4/5
- Target priority: lanciere prima (bleeding) vs corrieri (volume)
- Bleeding tick a fine turno → pressione cumulativa
- Hazard distribuiti per costringere posizionamento accorto

### Batch N=10 risultati
- **3/10 vittorie** (target 30-50% diff 4/5) ✓
- **2/10 SCONFITTE** (prima volta player muore in batch test!)
- 5/10 timeout
- **29 eventi bleeding** totali (denti_seghettati funziona)
- Avg rounds 15.4
- Hit rate 56.8%

### Curva tutorial completa
| # | Diff | Win rate | Mechanic introduced |
|---|------|----------|---------------------|
| 01 | 1/5 | ~80% | Movimento, attacco, MoS |
| 02 | 2/5 | ~80% | Asimmetria target (cacciatore corazzato) |
| 03 | 3/5 | 50% | Hazard tiles + AI pressure |
| 04 | 4/5 | 30% | Status effect bleeding + multi-hazard |

🤖 Generated with [Claude Code](https://claude.com/claude-code)