### PR TITLE
feat(tri-sorgente): MVP Node bridge + Python worker + AJV schema (Q-001 T3.2)

### DIFF
--- a/config/tri_sorgente_orchestrator.json
+++ b/config/tri_sorgente_orchestrator.json
@@ -1,0 +1,10 @@
+{
+  "pythonPath": "python3",
+  "poolSize": 2,
+  "requestTimeoutMs": 500,
+  "maxQueueSize": 50,
+  "heartbeatIntervalMs": 2000,
+  "heartbeatTimeoutMs": 8000,
+  "workerStartTimeoutMs": 10000,
+  "autoShutdownMs": null
+}

--- a/engine/tri_sorgente_worker.py
+++ b/engine/tri_sorgente_worker.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Tri-Sorgente Node Bridge Worker — Python subprocess.
+
+Q-001 T3.2 · ADR: docs/architecture/tri-sorgente-node-bridge.md
+
+Protocol: reads JSON requests from stdin (one per line), writes JSON responses
+to stdout (one per line). Mirror of services/generation/worker.py pattern.
+
+Current implementation: MVP con scoring deterministico semplificato.
+Port completo dell'algoritmo da tests/tri_sorgente_sim.py è follow-up.
+
+Config + engine YAML caricati una tantum al boot da:
+- engine/tri_sorgente/tri_sorgente_config.yaml
+- engine/tri_sorgente/card_offer_engine.yaml
+
+Request shape (stdin):
+    {"id": int, "payload": {actor_id, biome_id, recent_actions_counts, ...}}
+
+Response shape (stdout):
+    {"id": int, "result": {offers, skip_economy, meta}}
+    {"id": int, "error": {message, type}}
+"""
+
+import json
+import math
+import pathlib
+import random
+import sys
+from typing import Any, Dict
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+
+def _load_config() -> Dict[str, Any]:
+    """Load tri_sorgente_config.yaml. Gracefully degrade if yaml missing."""
+    if yaml is None:
+        return {"softmax_temperature": 0.7}
+    cfg_path = ROOT / "engine" / "tri_sorgente" / "tri_sorgente_config.yaml"
+    try:
+        with cfg_path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        return data.get("config", data)
+    except FileNotFoundError:
+        return {"softmax_temperature": 0.7}
+
+
+CONFIG = _load_config()
+
+
+def _softmax(values, temperature: float = 0.7):
+    if not values:
+        return []
+    t = max(temperature, 1e-6)
+    m = max(values)
+    exps = [math.exp((v - m) / t) for v in values]
+    total = sum(exps)
+    return [e / total for e in exps] if total > 0 else [0.0] * len(values)
+
+
+def _compute_offers(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    MVP scoring: deterministic mock based on seed + recent_actions_counts.
+    Real implementation (port of tests/tri_sorgente_sim.py) = follow-up PR.
+    """
+    seed = int(payload.get("seed", 0) or 0)
+    biome_id = payload.get("biome_id", "unknown")
+    actions = payload.get("recent_actions_counts", {}) or {}
+
+    rng = random.Random(seed)
+
+    # Mock 5 candidate cards with deterministic scoring
+    candidates = [f"card_{biome_id}_{i:02d}" for i in range(5)]
+    scores = []
+    for idx, card_id in enumerate(candidates):
+        action_bonus = sum(actions.values()) * 0.05 if actions else 0.0
+        noise = rng.random() * 0.1
+        raw_score = 0.5 + (idx * 0.1) + action_bonus + noise
+        scores.append(raw_score)
+
+    # Top-3 + softmax
+    indexed = sorted(enumerate(scores), key=lambda p: p[1], reverse=True)[:3]
+    top_scores = [s for _, s in indexed]
+    probs = _softmax(top_scores, CONFIG.get("softmax_temperature", 0.7))
+
+    offers = []
+    for (idx, score), prob in zip(indexed, probs):
+        offers.append(
+            {
+                "card_id": candidates[idx],
+                "score": round(score, 4),
+                "softmax_prob": round(prob, 4),
+                "breakdown": {
+                    "w_actions": round(action_bonus, 4) if actions else 0.0,
+                    "w_base": round(0.5 + idx * 0.1, 4),
+                },
+            }
+        )
+
+    skip_cfg = CONFIG.get("skip_economy", {})
+    decay = skip_cfg.get("consecutive_decay", [2, 1, 0])
+    cap = skip_cfg.get("cap_per_act", 6)
+
+    return {
+        "offers": offers,
+        "skip_economy": {
+            "fg_values": [int(decay[i]) if i < len(decay) else 0 for i in range(3)],
+            "cap_per_act": int(cap),
+        },
+        "meta": {
+            "seed": seed,
+            "export_version": 1,
+            "pool_ids": {"R": candidates[:2], "A": candidates[2:4], "P": candidates[4:]},
+            "timestamp": None,  # bridge fills
+        },
+    }
+
+
+def _handle_request(req: Dict[str, Any]) -> Dict[str, Any]:
+    req_id = req.get("id")
+    payload = req.get("payload") or {}
+    try:
+        result = _compute_offers(payload)
+        return {"id": req_id, "result": result}
+    except Exception as exc:  # pragma: no cover — defensive
+        return {"id": req_id, "error": {"message": str(exc), "type": type(exc).__name__}}
+
+
+def main():
+    # Heartbeat handshake: first line on stdout = ready
+    print(json.dumps({"type": "ready", "pid": None}), flush=True)
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except json.JSONDecodeError as exc:
+            print(
+                json.dumps({"id": None, "error": {"message": f"bad json: {exc}", "type": "JSONDecodeError"}}),
+                flush=True,
+            )
+            continue
+        resp = _handle_request(req)
+        print(json.dumps(resp), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/contracts/schemas/tri-sorgente.schema.json
+++ b/packages/contracts/schemas/tri-sorgente.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://game.example.com/schemas/contracts/tri-sorgente.schema.json",
+  "title": "Tri-Sorgente Card Offer Contract",
+  "description": "Request/response schema for /api/v1/tri-sorgente/offer (Q-001 T3.2). Mirror services/generation/ worker pattern.",
+  "type": "object",
+  "oneOf": [{ "$ref": "#/$defs/request" }, { "$ref": "#/$defs/response" }],
+  "$defs": {
+    "request": {
+      "type": "object",
+      "required": ["actor_id", "biome_id", "recent_actions_counts"],
+      "additionalProperties": false,
+      "properties": {
+        "actor_id": { "type": "string", "minLength": 1 },
+        "biome_id": { "type": "string", "minLength": 1 },
+        "recent_actions_counts": {
+          "type": "object",
+          "additionalProperties": { "type": "integer", "minimum": 0 }
+        },
+        "pools_override": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "R": { "type": "integer", "minimum": 1, "maximum": 20 },
+            "A": { "type": "integer", "minimum": 1, "maximum": 20 },
+            "P": { "type": "integer", "minimum": 1, "maximum": 20 }
+          }
+        },
+        "seed": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["offers", "skip_economy", "meta"],
+      "additionalProperties": false,
+      "properties": {
+        "offers": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 5,
+          "items": {
+            "type": "object",
+            "required": ["card_id", "score", "softmax_prob"],
+            "additionalProperties": false,
+            "properties": {
+              "card_id": { "type": "string", "minLength": 1 },
+              "score": { "type": "number" },
+              "softmax_prob": { "type": "number", "minimum": 0, "maximum": 1 },
+              "breakdown": {
+                "type": "object",
+                "additionalProperties": { "type": "number" }
+              }
+            }
+          }
+        },
+        "skip_economy": {
+          "type": "object",
+          "required": ["fg_values", "cap_per_act"],
+          "additionalProperties": false,
+          "properties": {
+            "fg_values": {
+              "type": "array",
+              "items": { "type": "integer", "minimum": 0 },
+              "minItems": 3,
+              "maxItems": 3
+            },
+            "cap_per_act": { "type": "integer", "minimum": 1 }
+          }
+        },
+        "meta": {
+          "type": "object",
+          "required": ["seed", "export_version"],
+          "additionalProperties": true,
+          "properties": {
+            "seed": { "type": "integer" },
+            "export_version": { "type": "integer", "minimum": 1 },
+            "pool_ids": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
+            },
+            "timestamp": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/services/triSorgente/bridge.js
+++ b/services/triSorgente/bridge.js
@@ -1,0 +1,152 @@
+/**
+ * Tri-Sorgente Node Bridge — Q-001 T3.2
+ *
+ * Spawn Python worker (engine/tri_sorgente_worker.py), invia request JSON via stdin,
+ * legge response JSON da stdout. Mirror del pattern services/generation/.
+ *
+ * MVP: single-worker (no pool). Pool manager = follow-up PR se throughput lo richiede.
+ *
+ * API:
+ *   const bridge = createTriSorgenteBridge({ pythonPath, workerPath, timeoutMs });
+ *   const offer = await bridge.offerCards({ actor_id, biome_id, recent_actions_counts, seed });
+ *   await bridge.shutdown();
+ *
+ * ADR: docs/architecture/tri-sorgente-node-bridge.md
+ */
+
+const { spawn } = require('node:child_process');
+const path = require('node:path');
+
+const DEFAULT_WORKER_PATH = path.resolve(__dirname, '..', '..', 'engine', 'tri_sorgente_worker.py');
+const DEFAULT_TIMEOUT_MS = 500;
+const DEFAULT_PYTHON = process.env.PYTHON_PATH || 'python3';
+
+function createTriSorgenteBridge(opts = {}) {
+  const pythonPath = opts.pythonPath || DEFAULT_PYTHON;
+  const workerPath = opts.workerPath || DEFAULT_WORKER_PATH;
+  const timeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
+
+  let proc = null;
+  let nextReqId = 1;
+  const pending = new Map(); // id → { resolve, reject, timer }
+  let stdoutBuf = '';
+  let readyPromise = null;
+
+  function _ensureProcess() {
+    if (proc && !proc.killed && proc.exitCode === null) return readyPromise;
+    proc = spawn(pythonPath, [workerPath], { stdio: ['pipe', 'pipe', 'pipe'] });
+
+    readyPromise = new Promise((resolve, reject) => {
+      const onReady = (line) => {
+        try {
+          const msg = JSON.parse(line);
+          if (msg && msg.type === 'ready') {
+            proc.stdout.removeListener('data', onReady);
+            resolve();
+          }
+        } catch {
+          // ignore partial lines
+        }
+      };
+      proc.stdout.once('data', (chunk) => {
+        const firstLine = chunk.toString().split('\n')[0];
+        onReady(firstLine);
+      });
+      proc.once('error', (err) => reject(err));
+      proc.once('exit', (code) => {
+        if (code !== 0 && pending.size > 0) {
+          for (const { reject: rej, timer } of pending.values()) {
+            clearTimeout(timer);
+            rej(new Error(`worker exited code=${code}`));
+          }
+          pending.clear();
+        }
+      });
+    });
+
+    proc.stdout.on('data', (chunk) => {
+      stdoutBuf += chunk.toString();
+      let nl;
+      while ((nl = stdoutBuf.indexOf('\n')) >= 0) {
+        const line = stdoutBuf.slice(0, nl);
+        stdoutBuf = stdoutBuf.slice(nl + 1);
+        if (!line.trim()) continue;
+        let msg;
+        try {
+          msg = JSON.parse(line);
+        } catch {
+          continue; // ignore malformed lines (including ready handshake)
+        }
+        if (msg.type === 'ready') continue;
+        const entry = pending.get(msg.id);
+        if (!entry) continue;
+        clearTimeout(entry.timer);
+        pending.delete(msg.id);
+        if (msg.error) {
+          entry.reject(new Error(`worker error: ${msg.error.message}`));
+        } else {
+          // Bridge fills timestamp (worker sends null)
+          if (msg.result && msg.result.meta && msg.result.meta.timestamp == null) {
+            msg.result.meta.timestamp = new Date().toISOString();
+          }
+          entry.resolve(msg.result);
+        }
+      }
+    });
+
+    return readyPromise;
+  }
+
+  async function offerCards(payload) {
+    if (!payload || typeof payload !== 'object') {
+      throw new TypeError('offerCards: payload object required');
+    }
+    if (!payload.actor_id || !payload.biome_id) {
+      throw new TypeError('offerCards: actor_id and biome_id required');
+    }
+    await _ensureProcess();
+
+    const id = nextReqId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`tri-sorgente worker timeout after ${timeoutMs}ms`));
+      }, timeoutMs);
+      pending.set(id, { resolve, reject, timer });
+
+      const req = JSON.stringify({ id, payload }) + '\n';
+      try {
+        proc.stdin.write(req);
+      } catch (err) {
+        clearTimeout(timer);
+        pending.delete(id);
+        reject(err);
+      }
+    });
+  }
+
+  async function shutdown() {
+    if (!proc || proc.killed) return;
+    for (const { reject, timer } of pending.values()) {
+      clearTimeout(timer);
+      reject(new Error('bridge shutdown'));
+    }
+    pending.clear();
+    try {
+      proc.stdin.end();
+    } catch {
+      /* ignore */
+    }
+    proc.kill('SIGTERM');
+    await new Promise((resolve) => {
+      if (proc.exitCode !== null) return resolve();
+      proc.once('exit', () => resolve());
+      setTimeout(() => resolve(), 200);
+    });
+    proc = null;
+  }
+
+  return { offerCards, shutdown };
+}
+
+module.exports = { createTriSorgenteBridge, DEFAULT_WORKER_PATH, DEFAULT_TIMEOUT_MS };

--- a/tests/triSorgente/bridge.test.js
+++ b/tests/triSorgente/bridge.test.js
@@ -1,0 +1,107 @@
+// Q-001 T3.2 · Tri-Sorgente Bridge smoke test.
+// Spawns real Python worker. Skip se python3 non disponibile.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+
+const { createTriSorgenteBridge } = require('../../services/triSorgente/bridge');
+
+const pythonCheck = spawnSync('python3', ['--version'], { stdio: 'ignore' });
+const pythonAvailable = pythonCheck.status === 0;
+
+if (!pythonAvailable) {
+  test('tri-sorgente bridge: skip (python3 not available)', () => {
+    assert.ok(true);
+  });
+} else {
+  test('bridge.offerCards returns valid offer payload', async () => {
+    const bridge = createTriSorgenteBridge({ timeoutMs: 5000 });
+    try {
+      const result = await bridge.offerCards({
+        actor_id: 'u1',
+        biome_id: 'savana',
+        recent_actions_counts: { cariche_effettuate: 3 },
+        seed: 42,
+      });
+      assert.ok(Array.isArray(result.offers), 'offers array');
+      assert.ok(result.offers.length > 0, 'offers not empty');
+      assert.ok(result.offers.length <= 5, 'offers <= 5');
+      for (const offer of result.offers) {
+        assert.equal(typeof offer.card_id, 'string');
+        assert.equal(typeof offer.score, 'number');
+        assert.equal(typeof offer.softmax_prob, 'number');
+        assert.ok(offer.softmax_prob >= 0 && offer.softmax_prob <= 1);
+      }
+      assert.ok(result.skip_economy);
+      assert.equal(result.skip_economy.fg_values.length, 3);
+      assert.equal(result.meta.seed, 42);
+      assert.equal(result.meta.export_version, 1);
+    } finally {
+      await bridge.shutdown();
+    }
+  });
+
+  test('bridge.offerCards deterministic with same seed', async () => {
+    const bridge = createTriSorgenteBridge({ timeoutMs: 5000 });
+    try {
+      const payload = {
+        actor_id: 'u1',
+        biome_id: 'savana',
+        recent_actions_counts: {},
+        seed: 100,
+      };
+      const r1 = await bridge.offerCards(payload);
+      const r2 = await bridge.offerCards(payload);
+      assert.deepEqual(
+        r1.offers.map((o) => o.card_id),
+        r2.offers.map((o) => o.card_id),
+        'same seed → same card_ids',
+      );
+    } finally {
+      await bridge.shutdown();
+    }
+  });
+
+  test('bridge throws on missing required payload fields', async () => {
+    const bridge = createTriSorgenteBridge({ timeoutMs: 1000 });
+    try {
+      await assert.rejects(() => bridge.offerCards({}), /actor_id/);
+      await assert.rejects(() => bridge.offerCards({ actor_id: 'u1' }), /biome_id/);
+    } finally {
+      await bridge.shutdown();
+    }
+  });
+
+  test('bridge validates response against AJV schema', async () => {
+    let Ajv, schema;
+    try {
+      Ajv = require('ajv/dist/2020');
+      schema = require('../../packages/contracts/schemas/tri-sorgente.schema.json');
+    } catch {
+      return; // skip se AJV non disponibile
+    }
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    const validateResponse = ajv.compile(schema.$defs.response);
+
+    const bridge = createTriSorgenteBridge({ timeoutMs: 5000 });
+    try {
+      const result = await bridge.offerCards({
+        actor_id: 'u1',
+        biome_id: 'savana',
+        recent_actions_counts: { colpi_critici: 2 },
+        seed: 7,
+      });
+      const valid = validateResponse(result);
+      if (!valid) {
+        const errs = validateResponse.errors
+          .map((e) => `${e.instancePath} ${e.message}`)
+          .join('; ');
+        assert.fail(`response invalid: ${errs}`);
+      }
+      assert.ok(valid);
+    } finally {
+      await bridge.shutdown();
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Implementazione MVP **ADR Tri-Sorgente Node Bridge** (Q-001 T3.2 approvato).

Pattern: Python subprocess worker, mirror di \`services/generation/\`.

## Changes

- \`packages/contracts/schemas/tri-sorgente.schema.json\` — AJV draft2020 request/response contract
- \`engine/tri_sorgente_worker.py\` — subprocess stdin/stdout JSON, scoring deterministico mock
- \`services/triSorgente/bridge.js\` — Node bridge async \`offerCards()\` + shutdown + timeout
- \`config/tri_sorgente_orchestrator.json\` — worker config
- \`tests/triSorgente/bridge.test.js\` — 4 test (payload, determinismo, validation, schema match)

## Deferred (follow-up PR)

- Port completo algoritmo da \`tests/tri_sorgente_sim.py\` (pool R/A/P merge, diversity, sinergia)
- Route \`apps/backend/routes/triSorgente.js\` (tocca guardrail session)
- Session loop integration (\`pendingOffers\` field)
- Worker pool (currently single-worker)

## Test plan

- [x] \`node --test tests/triSorgente/bridge.test.js\` → 4/4 pass
- [x] \`npm run format:check\` → clean
- [x] Python worker smoke test manuale

## Guardrail

- \`packages/contracts/\` = guardrail, approvato via [ADR](docs/architecture/tri-sorgente-node-bridge.md)
- Schema backward-compatible (nuovo file, no breaking change)

## Rollback plan

File nuovi, no code modificato altrove. Rollback = \`git revert\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)