### PR TITLE
feat(difficulty): session integration + profiles endpoint (Q-001 T2.3 PR-3 of 5)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -552,7 +552,41 @@ function createSessionRouter(options = {}) {
       const sessionId = newSessionId();
       const now = new Date();
       const logFilePath = path.join(logsDir, `session_${timestampStamp(now)}.json`);
-      const units = normaliseUnitsPayload(req.body?.units);
+      let units = normaliseUnitsPayload(req.body?.units);
+
+      // Q-001 T2.3 PR-3: applica difficulty profile scaling (opt-in, default normal)
+      const requestedProfile =
+        typeof req.body?.difficulty_profile === 'string'
+          ? req.body.difficulty_profile.trim()
+          : 'normal';
+      let difficultyProfileMeta = null;
+      try {
+        const { getDifficultyConfig } = require('../../../services/difficulty/loader');
+        const { applyPlayerProfile } = require('../../../services/difficulty/difficultyCalculator');
+        const diffCfg = getDifficultyConfig();
+        if (diffCfg.player_difficulty_profiles[requestedProfile]) {
+          const mockEncounter = {
+            waves: [{ units: units.map((u) => ({ species: u.id, count: 1, tier: 'base' })) }],
+          };
+          const scaled = applyPlayerProfile(mockEncounter, requestedProfile, diffCfg);
+          difficultyProfileMeta = scaled._difficultyProfile;
+
+          // Applica enemy_hp_multiplier + player_hp_multiplier a units SIS vs player
+          const hpMultEnemy = difficultyProfileMeta.enemy_hp_multiplier || 1.0;
+          const hpMultPlayer = difficultyProfileMeta.player_hp_multiplier || 1.0;
+          units = units.map((u) => {
+            if (!u) return u;
+            const isSis = u.controlled_by === 'sistema';
+            const mult = isSis ? hpMultEnemy : hpMultPlayer;
+            if (mult === 1.0) return u;
+            const newMax = Math.round(Number(u.max_hp || u.hp || 10) * mult);
+            return { ...u, hp: newMax, max_hp: newMax };
+          });
+        }
+      } catch {
+        // best-effort: se config non carica, skip profile scaling
+      }
+
       // SPRINT_020: calcola turn_order via iniziativa descending.
       const turnOrder = buildTurnOrder(units);
       const firstActiveId = turnOrder[0] || null;
@@ -583,6 +617,8 @@ function createSessionRouter(options = {}) {
         // Lista {x, y, damage, type}. Applicato a fine turno via
         // applyHazardDamage in handleTurnEndViaRound.
         hazard_tiles: Array.isArray(req.body?.hazard_tiles) ? req.body.hazard_tiles : [],
+        // Q-001 T2.3: difficulty profile scaling metadata (null se profile invalid)
+        _difficultyProfile: difficultyProfileMeta,
       };
       sessions.set(sessionId, session);
       activeSessionId = sessionId;
@@ -905,6 +941,29 @@ function createSessionRouter(options = {}) {
         pfResult[unitId] = computePfSession(actorVc, formsData);
       }
       res.json({ session_id: session.session_id, pf_session: pfResult });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // Q-001 T2.3 PR-3: List available difficulty profiles.
+  router.get('/difficulty/profiles', (req, res, next) => {
+    try {
+      const { getDifficultyConfig } = require('../../../services/difficulty/loader');
+      const cfg = getDifficultyConfig();
+      const profiles = cfg.player_difficulty_profiles || {};
+      const list = Object.entries(profiles).map(([id, profile]) => ({
+        id,
+        label_it: profile.label_it,
+        label_en: profile.label_en,
+        description_it: profile.description_it,
+        description_en: profile.description_en,
+        enemy_count_multiplier: profile.enemy_count_multiplier,
+        enemy_hp_multiplier: profile.enemy_hp_multiplier,
+        enemy_damage_multiplier: profile.enemy_damage_multiplier,
+        player_hp_multiplier: profile.player_hp_multiplier,
+      }));
+      res.json({ profiles: list, default: 'normal' });
     } catch (err) {
       next(err);
     }

--- a/services/difficulty/loader.js
+++ b/services/difficulty/loader.js
@@ -1,0 +1,42 @@
+/**
+ * Difficulty Config Loader — Q-001 T2.3 PR-3
+ *
+ * Carica data/core/difficulty.yaml al boot e memoizza.
+ * Separato da difficultyCalculator.js per mantenere calcolatore puro.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { loadDifficultyConfig } = require('./difficultyCalculator');
+
+const DEFAULT_CONFIG_PATH = path.resolve(__dirname, '..', '..', 'data', 'core', 'difficulty.yaml');
+
+let _memoized = null;
+
+function loadFromDisk(configPath = DEFAULT_CONFIG_PATH) {
+  let yaml;
+  try {
+    yaml = require('js-yaml');
+  } catch {
+    return loadDifficultyConfig(null); // defaults
+  }
+  try {
+    const raw = fs.readFileSync(configPath, 'utf8');
+    return loadDifficultyConfig(yaml.load(raw));
+  } catch {
+    return loadDifficultyConfig(null);
+  }
+}
+
+function getDifficultyConfig() {
+  if (_memoized === null) {
+    _memoized = loadFromDisk();
+  }
+  return _memoized;
+}
+
+function resetCache() {
+  _memoized = null;
+}
+
+module.exports = { getDifficultyConfig, loadFromDisk, resetCache, DEFAULT_CONFIG_PATH };

--- a/tests/api/sessionDifficulty.test.js
+++ b/tests/api/sessionDifficulty.test.js
@@ -1,0 +1,117 @@
+// Q-001 T2.3 PR-3 · Difficulty integration smoke test.
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+
+test('GET /api/session/difficulty/profiles lists 4 profiles', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const res = await request(app).get('/api/session/difficulty/profiles');
+  assert.equal(res.status, 200);
+  assert.ok(Array.isArray(res.body.profiles));
+  const ids = res.body.profiles.map((p) => p.id);
+  assert.ok(ids.includes('easy'));
+  assert.ok(ids.includes('normal'));
+  assert.ok(ids.includes('hard'));
+  assert.ok(ids.includes('nightmare'));
+  assert.equal(res.body.default, 'normal');
+});
+
+test('POST /api/session/start with difficulty_profile=normal keeps HP unchanged', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  const res = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units, difficulty_profile: 'normal' });
+  assert.equal(res.status, 200);
+
+  const replay = await request(app).get(`/api/session/${res.body.session_id}/replay`);
+  // Normal = multiplier 1.0 → HP uguale a scenario
+  for (const u of replay.body.units_snapshot_initial) {
+    const orig = scenario.body.units.find((o) => o.id === u.id);
+    if (orig) assert.equal(u.hp, orig.hp, `unit ${u.id} hp unchanged`);
+  }
+});
+
+test('POST /api/session/start with difficulty_profile=hard increases enemy HP', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  const res = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units, difficulty_profile: 'hard' });
+  assert.equal(res.status, 200);
+
+  const units = res.body.state.units;
+  for (const u of units) {
+    const orig = scenario.body.units.find((o) => o.id === u.id);
+    if (!orig) continue;
+    if (u.controlled_by === 'sistema') {
+      // hard = 1.15× HP
+      const expected = Math.round(Number(orig.hp || orig.max_hp || 10) * 1.15);
+      assert.equal(u.hp, expected, `sis ${u.id} hp scaled by 1.15×`);
+    } else {
+      // player unchanged on hard
+      assert.equal(u.hp, orig.hp, `player ${u.id} hp unchanged on hard`);
+    }
+  }
+});
+
+test('POST /api/session/start with difficulty_profile=easy scales player HP up', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  const res = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units, difficulty_profile: 'easy' });
+  assert.equal(res.status, 200);
+
+  const units = res.body.state.units;
+  for (const u of units) {
+    const orig = scenario.body.units.find((o) => o.id === u.id);
+    if (!orig) continue;
+    if (u.controlled_by === 'player') {
+      // easy = player 1.15× HP
+      const expected = Math.round(Number(orig.hp || orig.max_hp || 10) * 1.15);
+      assert.equal(u.hp, expected, `player ${u.id} hp scaled by 1.15×`);
+    }
+  }
+});
+
+test('POST /api/session/start with invalid difficulty_profile falls back (no scaling)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  const res = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units, difficulty_profile: 'invalid_xyz' });
+  assert.equal(res.status, 200);
+
+  const units = res.body.state.units;
+  // No scaling applied — match original
+  for (const u of units) {
+    const orig = scenario.body.units.find((o) => o.id === u.id);
+    if (orig) assert.equal(u.hp, orig.hp, `${u.id} hp unchanged (invalid profile)`);
+  }
+});


### PR DESCRIPTION
## Summary

PR-3 della 5-PR split **Difficulty Integration** (Q-001 T2.3).

Hook \`/start\` + nuovo endpoint \`GET /difficulty/profiles\`. Guardrail Pilastro 5 rispettato (additive, fallback safe).

## Changes

- \`apps/backend/routes/session.js\`:
  - \`/start\` accetta \`difficulty_profile\` (default \`normal\`)
  - Apply \`enemy_hp_multiplier\` (SIS) + \`player_hp_multiplier\` (player)
  - \`session._difficultyProfile\` metadata
  - Invalid profile → fallback no-scaling
  - Nuovo \`GET /api/session/difficulty/profiles\` → lista 4 profili + default
- \`services/difficulty/loader.js\` — memoized YAML loader
- \`tests/api/sessionDifficulty.test.js\` — 5 test

## Test plan

- [x] 5/5 difficulty integration test pass
- [x] 153/153 AI regression
- [x] 4/4 replay test (no conflict)
- [x] Prettier clean

## Deferred

- PR-5: Dashboard Settings UI (frontend source non in repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)