### PR TITLE
doc: scaffold M1 first playtest (RESEARCH_TODO M1 prep)

### DIFF
--- a/docs/playtests/2026-04-17/notes.md
+++ b/docs/playtests/2026-04-17/notes.md
@@ -1,0 +1,71 @@
+# Note — First Documented Session
+
+**Data**: 2026-04-17
+**Durata effettiva partita**: _da compilare_
+**Outcome**: _wipe A / wipe B / time-out / abbandono_
+
+---
+
+## 1. Cosa funzionava
+
+_(Compilare DOPO la partita. Minimo 3 punti, regola zero fluff. Ciò che hai capito subito o che ha creato un momento interessante.)_
+
+- _…_
+- _…_
+- _…_
+
+## 2. Cosa era confuso in <30 secondi
+
+_(Regole che hai dovuto rileggere, momenti in cui ti sei fermato per pensare "come funziona questo?". Anche se sembra ovvio, scrivilo.)_
+
+- _…_
+- _…_
+- _…_
+
+## 3. Cosa hai tagliato mentalmente durante la partita
+
+_(Regole saltate perché troppo pesanti, sistemi che hai ignorato per semplicità, meccaniche che "risolverai dopo". Questo è l'elenco più importante: sono le regole candidate al taglio.)_
+
+- _…_
+- _…_
+- _…_
+
+---
+
+## Insight prioritari (opzionale ma raccomandato)
+
+_(1-3 frasi: cosa ho imparato che non sapevo prima? Cambia qualche decisione in `docs/PITCH.md` o nei pilastri?)_
+
+_…_
+
+## Decisioni operative
+
+_(Cosa voglio fare DOMANI come conseguenza di questo playtest?)_
+
+- _…_
+
+## Dati quantitativi (se tracciati)
+
+- Turni giocati: _N_
+- Attacchi totali: _N_
+- Tiri d20 che sembravano "ingiusti": _N_
+- PT spesi (stima): _N_
+- Quante volte ho dovuto aprire un doc / riguardare regole: _N_
+
+---
+
+## Ancoraggio ai pilastri
+
+Dopo la partita, per ogni pilastro metti 🟢 (regge) / 🟡 (dubbi) / 🔴 (problema):
+
+- Pilastro 1 — Tattica leggibile: _?_
+- Pilastro 2 — Evoluzione emergente: _?_ (non testato al primo playtest, previsto)
+- Pilastro 3 — Identità Specie × Job: _?_
+- Pilastro 4 — Temperamenti MBTI/Ennea: _?_ (non testato al primo playtest, previsto)
+- Pilastro 5 — Co-op vs Sistema: _?_ (single-player, verifica solo "Sistema si fa sentire?")
+- Pilastro 6 — Fairness: _?_
+
+---
+
+_Nota caveman: compila questo file entro 10 minuti dalla fine della partita.
+Se aspetti "domani", domani non ti ricorderai. ugh bunga._

--- a/docs/playtests/2026-04-17/setup.md
+++ b/docs/playtests/2026-04-17/setup.md
@@ -1,0 +1,76 @@
+# Setup — First Documented Session
+
+**Data**: 2026-04-17
+**Formato**: single-player (Master vs Master, 2 squadre controllate)
+**Durata stimata**: 30-45 min partita + 10 min note
+**Griglia**: 8×8 (compatibile `enc_tutorial_01.yaml`)
+
+## Scelta setup (compatibile RESEARCH_TODO M1: 2 specie + 1 bioma + 1 job)
+
+### Bioma: Savana
+
+- Fonte: `data/core/biomes.yaml` § savana
+- Motivo: bioma di partenza tutorial, meccaniche basilari, nessun hazard complesso, nessun FoW
+
+### Job: Skirmisher (Schermidore)
+
+- Fonte: `data/core/jobs.yaml` § skirmisher
+- Ruolo: damage mobile, hit-and-run
+- Motivo: primo job insegnato, meno regole reattive (rimandate a playtest futuri)
+- Ability R1: movimento + attacco nello stesso turno
+
+### Specie (2)
+
+**Squadra A (controllata PG)**
+
+- **Predone Nomade** × 2 — baseline da `enc_tutorial_01.yaml`
+  - HP 10, AP 2, attack_range 2
+  - Trait: nessuno (base)
+
+**Squadra B (controllata da Master come "Sistema")**
+
+- **Echo Wing** × 1 + **Dune Stalker** × 1 — da `packs/evo_tactics_pack/data/species/badlands/`
+  - Echo Wing: volante, skirmish, trait leggero
+  - Dune Stalker: melee, corazza leggera
+  - Asimmetria intenzionale: 2 vs 2 ma tratti diversi
+
+## Regole in uso
+
+1. **d20** per attacchi: `d20 + bonus vs CD`
+2. **MoS** (Margin of Success): ≥10 = critico, danno ×2
+3. **Movement**: massimo 3 celle/turno (AP 2 = 1 move + 1 attack, oppure 2 move)
+4. **Parata reattiva**: 1 PT, ignora se troppo complesso al primo turno
+5. **Fine partita**: wipe di una squadra o 12 turni elapsed
+
+## Setup fisico suggerito
+
+- Foglio A4 con griglia 8×8 disegnata a matita
+- 4 monete / post-it / miniature come segnalini unità
+- Dado d20 fisico (o tiratore random da telefono)
+- Block-notes per tracciare HP/PT durante la partita
+
+## Cosa osservare durante la partita
+
+(Queste sono le 3 domande a cui rispondere in `notes.md`.)
+
+1. **Cosa funzionava?** → regole chiare, momenti di decisione interessanti
+2. **Cosa era confuso in <30 secondi?** → regole che ho dovuto rileggere
+3. **Cosa ho tagliato mentalmente?** → regole che ho saltato perché troppo pesanti
+
+## Post-game checklist
+
+- [ ] Foto del setup/campo finale in `setup.jpg`
+- [ ] `notes.md` compilato (entro 10 min dalla fine)
+- [ ] Aggiornato `docs/playtests/README.md` tabella index
+- [ ] Commit `playtest: [2026-04-17] first documented session`
+- [ ] Spunta checkbox M1 in `RESEARCH_TODO.md` → `[x]`
+- [ ] `caveman achievements` per celebrare
+
+## Fonti referenziate
+
+- `docs/core/01-VISIONE.md`
+- `docs/core/02-PILASTRI.md` (§1 Tattica leggibile)
+- `data/core/jobs.yaml` (skirmisher)
+- `data/core/biomes.yaml` (savana)
+- `docs/planning/encounters/enc_tutorial_01.yaml` (baseline unità)
+- `packs/evo_tactics_pack/data/species/badlands/` (echo wing, dune stalker)

--- a/docs/playtests/README.md
+++ b/docs/playtests/README.md
@@ -1,0 +1,40 @@
+# Playtest Log
+
+Directory canonica per **playtest fisici documentati** di Evo-Tactics.
+
+Ogni playtest vive in una sottocartella `YYYY-MM-DD/` e deve contenere:
+
+1. **`setup.md`** — specie + bioma + job scelti, compilato PRIMA della partita
+2. **`notes.md`** — 3 sezioni compilate DOPO la partita:
+   - Cosa funzionava
+   - Cosa era confuso in <30 secondi
+   - Cosa hai tagliato mentalmente durante la partita
+3. **`setup.jpg`** (opzionale ma raccomandato) — foto del setup fisico: griglia, segnalini, riferimenti a portata
+
+Dopo aver compilato tutto, commit con messaggio:
+
+```
+playtest: [YYYY-MM-DD] first documented session
+```
+
+(oppure descrittore specifico per playtest successivi: `playtest: [data] boss encounter feedback`, ecc.)
+
+## Perché
+
+Dal deep research (RESEARCH_TODO M1): _"nessun playtest documentato" è il red flag principale. Wayline e UniversityXP sono unanimi: senza playtest reali, il design è un'ipotesi._
+
+Un **playtest con post-it batte dieci dashboard** (Caveman Rule #3).
+
+## Anti-regola
+
+- Non validare playtest via test automatici come proxy (sono un'altra cosa)
+- Non tagliare sezioni di `notes.md` — anche "cosa era confuso" deve essere scritto, soprattutto se sembra banale
+- Non rimandare la compilazione note a "dopo": si scrive subito, entro 10 min dalla fine partita, altrimenti si perde il ricordo
+
+## Index playtest storici
+
+_(vuoto: questo è il primo setup. Aggiorna qui dopo ogni playtest chiuso.)_
+
+| Data       | Titolo                              | Outcome | Commit |
+| ---------- | ----------------------------------- | ------- | ------ |
+| 2026-04-17 | First documented session (scaffold) | pending | —      |


### PR DESCRIPTION
## Summary

Prepara scaffolding per **M1 Primo Playtest Documentato**. Non chiude M1 — Master deve giocare.

## Why

M1 = azione fisica Master. Agent può solo ridurre attrito: preparare setup file + template note.

## Changes

- \`docs/playtests/README.md\` — index + regole (compilare entro 10 min, zero fluff, anti-regole)
- \`docs/playtests/2026-04-17/setup.md\` — setup pre-partita: 2 specie (Predone Nomade × 2 vs Echo Wing + Dune Stalker) + bioma savana + job skirmisher + regole in uso + checklist post-game
- \`docs/playtests/2026-04-17/notes.md\` — template 3 sezioni + ancoraggio 6 pilastri 🟢🟡🔴

## Master post-game checklist

1. Gioca partita (single-player, 2 squadre, ~30-45 min)
2. Foto setup → \`setup.jpg\`
3. Compila \`notes.md\` entro 10 min (caveman rule)
4. Aggiorna README tabella index
5. Commit con prefix \`playtest:\` (non \`doc:\`)
6. Spunta checkbox M1 in \`RESEARCH_TODO.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)