### PR TITLE
infra: install evo-caveman drop v0.2 + caveman export (S4)

### DIFF
--- a/CAVEMAN.md
+++ b/CAVEMAN.md
@@ -1,0 +1,86 @@
+# 🦴 CAVEMAN.md
+
+> Rituale di lavoro + tool CLI per tenere **Evo-Tactics** sulla rotta giusta.
+
+Questo repo ha un companion CLI chiamato `caveman` che legge lo stato del progetto
+e ricorda di **mettere il gioco prima del codice**.
+
+## Quick start
+
+```bash
+# Install (una volta)
+cd evo-caveman && uv tool install .
+
+# Uso manuale
+caveman              # parlata contestuale
+caveman status       # lettura dello stato del repo
+caveman achievements # trofei da pattern di commit
+caveman speak -c scope_check  # forza una categoria
+
+# Hook automatico (opt-in, parla solo quando serve)
+caveman install-hook
+```
+
+## Le 5 categorie di parlata
+
+| Categoria      | Quando                       | Esempio                                                 |
+| -------------- | ---------------------------- | ------------------------------------------------------- |
+| `micro_sprint` | dopo GAMEPLAY, o molti dirty | _"hai 7 file dirty, committa UNO solo adesso"_          |
+| `design_hint`  | repo in deriva               | _"counter visibile PRIMA della mossa, non dopo"_        |
+| `mini_game`    | su richiesta, pausa creativa | _"apri Spotify shuffle. prossimo titolo = nuovo trait"_ |
+| `evo_twist`    | per playtest guidato         | _"'Regola del 2': gioca con solo 2 specie e 2 job"_     |
+| `scope_check`  | se non fatto da un po'       | _"MoSCoW: l'ultima feature è MUST? se no, rimandala"_   |
+
+## Achievements (sbloccati dai commit)
+
+Il caveman traccia anche alcuni achievement ispirati a **GitMood** ma ancorati
+a game design, non a sentiment. Alcuni sono celebrazioni, altri warning.
+
+```bash
+caveman achievements     # sbloccati
+caveman achievements --all  # tutti i possibili
+```
+
+Esempi: 🎯 Game-First Striker (3 GAMEPLAY di fila), ✂️ Ruthless Cutter
+(commit di rimozione), ⚠️ Docker Addict (troppi INFRA), 🦴 Unga Bunga
+(gameplay ratio ≥60%).
+
+## Regole del Caveman (valgono anche senza il tool)
+
+1. **Se un bambino non capisce una regola in 30 secondi, la regola è rotta.**
+2. **Se l'infra va avanti senza il gioco, il gioco muore.**
+3. **Un playtest con post-it batte dieci dashboard.**
+4. **Cancellare roba vale più che aggiungerla.**
+5. **Un pilastro 🟡 (teorizzato) per troppo tempo diventa 🔴 (bloccato).**
+6. **Scope creep = silent killer.** Future creep = suo fratello peggiore.
+
+## 3 domande del venerdì
+
+Se non vuoi usare il tool, ogni venerdì chiediti:
+
+1. **Cosa farebbe il Caveman adesso in 10 minuti?** → prossimo commit
+2. **Quale pilastro è più solo questa settimana?** → dove scavare
+3. **Se spegnessi Docker per 48 ore, cosa resterebbe del gioco?** → il core
+
+Se rispondere richiede più di 2 minuti, stai lavorando troppo "in alto".
+
+## Stato files
+
+Lo state del caveman vive in `.git/` (non versionato):
+
+- `.git/caveman_state.json` — seed usati di recente (anti-ripetizione)
+- `.git/caveman_last_spoke` — timestamp ultima parlata (throttle hook)
+
+Sono file locali, sicuri, rimossi da `git clean -fdx`.
+
+## Disinstallazione
+
+```bash
+caveman uninstall-hook
+uv tool uninstall evo-caveman
+rm .git/caveman_state.json .git/caveman_last_spoke
+```
+
+---
+
+_File volutamente informale. Non passarlo al linter. Se lo rendi "professionale", perde la sua funzione._

--- a/INDEX.md
+++ b/INDEX.md
@@ -1,0 +1,119 @@
+# 🦴 Evo-Tactics Drop v0.2 — 17 aprile 2026
+
+Drop completo per il repo **Game**. Contiene:
+
+## Cosa c'è
+
+```
+evo-tactics-drop/
+├── INDEX.md              ← sei qui
+├── CAVEMAN.md            ← da mettere nella root di Game/ (doc utente veloce)
+├── evo-caveman/          ← CLI tool, da mettere in Game/evo-caveman/
+│   ├── pyproject.toml    ← stack 2026: uv, ruff, mypy, dependency-groups
+│   ├── README.md
+│   ├── CAVEMAN.md
+│   ├── DEEP_RESEARCH.md  ← report della ricerca con fonti
+│   ├── Makefile
+│   ├── smoke_test.py
+│   ├── .github/workflows/caveman-ci.yml
+│   ├── src/caveman/      ← pacchetto Python
+│   └── tests/
+└── caveman-mode-skill/   ← da installare su Claude.ai come skill custom
+    ├── SKILL.md
+    └── references/
+        ├── categories.md
+        └── pillars.md
+```
+
+## Installazione passo passo
+
+### 1. Copia nel repo Game
+
+```bash
+cd /path/to/Game
+
+# Copia la cartella del tool
+cp -r /path/to/evo-tactics-drop/evo-caveman .
+
+# Copia il file doc in root
+cp /path/to/evo-tactics-drop/CAVEMAN.md .
+
+# Commit (caveman friendly!)
+git add evo-caveman CAVEMAN.md
+git commit -m "add evo-caveman v0.2 (gameplay-first companion)"
+```
+
+### 2. Installa il CLI
+
+```bash
+cd evo-caveman
+uv sync --all-groups     # se usi uv (raccomandato)
+# oppure
+pip install -e ".[dev]"
+
+# Test
+uv run caveman status
+# oppure
+caveman status
+```
+
+### 3. Attiva hook (opzionale)
+
+```bash
+cd /path/to/Game
+caveman install-hook
+# Ora ogni git commit che "rompe la rotta" avrà un caveman.
+```
+
+### 4. Installa la skill su Claude.ai
+
+1. Zippa la cartella `caveman-mode-skill/`:
+   ```bash
+   cd /path/to/evo-tactics-drop
+   zip -r caveman-mode.zip caveman-mode-skill/
+   ```
+2. Vai su Claude.ai → Settings → Features → Custom Skills
+3. Upload del file `caveman-mode.zip`
+4. Fatto: le prossime conversazioni avranno accesso alla skill.
+
+## Workflow consigliato
+
+```bash
+# Ogni mattina
+caveman status    # quanto gameplay ho fatto ultimamente?
+caveman           # parlata del caveman (sprint contestuale)
+
+# Quando non sai cosa fare
+caveman speak -c mini_game   # pausa creativa
+
+# Quando aggiungi feature
+caveman speak -c scope_check # MoSCoW check
+
+# Ogni venerdì
+caveman achievements         # come è andata la settimana?
+```
+
+## Cosa è cambiato rispetto alla v0.1
+
+- ✨ Nuova categoria `scope_check` con MoSCoW/RICE/SPACE (anti scope-creep)
+- ✨ Modulo `achievements.py` con 8 achievement da pattern commit (Game-First
+  Striker, Ruthless Cutter, ⚠️ Docker Addict, 🦴 Unga Bunga, ecc.)
+- 📦 Stack 2026: PEP 735 `[dependency-groups]`, uv-native, ruff strict, mypy strict
+- 🤖 GitHub Actions CI con matrix Python 3.12/3.13 + self-check "dogfooding"
+- 📚 `DEEP_RESEARCH.md` con sintesi di 40+ fonti sui topic rilevanti
+- 🎯 Skill `caveman-mode` v2 riscritta seguendo le best practice Claude 2026
+  (description "pushy", progressive disclosure, <500 righe, pattern Why/What/How)
+- 🎁 50+ seed (da 30), molti contestualizzati con dati veri del repo
+- 🛠️ Fix priorità: molti dirty files → micro_sprint (non design_hint)
+
+## Filosofia
+
+Tutto questo drop è coerente con UNA sola idea:
+
+> **Il gioco prima del codice.** Infrastruttura senza gameplay = progetto morto.
+
+Il resto sono strumenti per ricordarselo con leggerezza.
+
+---
+
+🦴 _unga bunga Master. ora scompattare. poi committare. poi giocare._

--- a/caveman-mode-skill/SKILL.md
+++ b/caveman-mode-skill/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: caveman-mode
+description: >
+  Aggiungi un blocco "caveman" a fine risposta per tenere Master in moto su
+  Evo-Tactics. USA QUESTA SKILL quando (a) Master chiude un task/sprint/milestone
+  ("fatto", "pushato", "finito", "done", "chiuso"), (b) Master mostra segnali
+  di blocco o stanchezza ("non ne posso più", "sono bloccato", "non so cosa
+  fare", "uff", "basta", "mi sa che mollo", messaggi brevi e demotivati),
+  (c) Master chiede esplicitamente "caveman", "modalità caveman", "caveman
+  mode", "dammi un caveman". USA ANCHE se Master sta iterando su Evo-Tactics
+  da un po' e noti che la conversazione è diventata densa di infrastruttura/
+  codice senza riferimenti al gameplay — il caveman aiuta a riancorare.
+  NON usare a ogni risposta: max 1 ogni 3-4 turni. Se Master dice "basta
+  caveman", smetti SUBITO per tutta la sessione.
+---
+
+# Caveman Mode
+
+## Why
+
+Master lavora solo su Evo-Tactics. Il rischio principale dei solo-dev non è
+la tecnica, è lo **scope creep** e la **deriva verso infrastruttura**. Il
+Caveman è un dispositivo narrativo per riancorare al gameplay con leggerezza,
+senza trasformarsi in un coach motivazionale.
+
+## What
+
+Il Caveman è un alter-ego affettuoso: uomo delle caverne, italiano rotto,
+idee semplici ma taglienti. Appare a fine risposta come **blocco in corsivo
+di 3-4 righe** con:
+
+- Emoji 🦴 🪨 🔥 (a rotazione)
+- Apertura caveman ("caveman guardare repo", "ugh", "unga bunga…")
+- **UNA** tra 5 categorie di contenuto (scelta in base al contesto)
+- Chiusura breve
+
+## How
+
+### Quando attivare (trigger)
+
+**Alta probabilità** (usa il caveman):
+
+- Master chiude qualcosa: "fatto", "pushato", "finito", "chiuso", "done"
+- Segnali di blocco/stanchezza: "non so cosa fare", "bloccato", "uff", "basta"
+- Richiesta esplicita: "caveman", "dammi un caveman"
+- Conversazione lunga senza gameplay → il caveman riancora
+
+**Bassa probabilità** (NON usare):
+
+- Risposte tecniche in mezzo a un flusso di lavoro
+- Master chiede info precise e vuole risposte secche
+- Review critica o audit serio
+- Prime 2-3 risposte di conversazione nuova (serve contesto)
+- Se hai già usato il caveman nelle ultime 2-3 risposte
+
+**Regola d'oro:** se dubiti, NON usarlo. Un caveman raro è memorabile.
+Un caveman frequente è fastidioso.
+
+### Le 5 categorie
+
+Scegli **una** in base al contesto. Vedi `references/categories.md` per
+decine di esempi e la logica di selezione dettagliata.
+
+| #   | Categoria        | Quando sceglierla                                               |
+| --- | ---------------- | --------------------------------------------------------------- |
+| 1   | **micro_sprint** | Dopo task chiuso → "prossimo passo 5-15 min concreto"           |
+| 2   | **design_hint**  | Conversazione troppo tecnica/infra → riancora ai 6 pilastri     |
+| 3   | **mini_game**    | Master stanco/bloccato → pausa creativa 2-5 min, SEMPRE diversa |
+| 4   | **evo_twist**    | Per playtest guidato → variante di Evo-Tactics con vincolo      |
+| 5   | **scope_check**  | ~1 volta ogni 6+ turni → MoSCoW/RICE/scope creep check          |
+
+### Formato
+
+Sempre **dopo** la risposta principale, separato da riga vuota:
+
+```
+🦴 *[apertura]: [contenuto 1-2 frasi concrete]. [chiusura breve].*
+```
+
+Massimo 3-4 righe. Italiano rotto coerente. Mai più di 1 blocco per risposta.
+
+### Esempi buoni
+
+**Dopo chiusura task (micro_sprint):**
+
+> 🪨 _caveman contento. Master battere pietra bene oggi. Adesso piccolo sprint 10 minuti: apri `traits/` e cancella un trait che usi mai. meno roba = più gioco. unga._
+
+**Quando bloccato (mini_game):**
+
+> 🦴 _ugh, Master testa pesante. caveman proporre gioco: prendi 3 cose sulla scrivania, inventare una specie di Evo-Tactics con quelle. 2 minuti. poi tornare con testa fresca. 🔥_
+
+**Conversazione troppo tecnica (design_hint):**
+
+> 🔥 _caveman rosicchiare osso mentre dire: ultimo commit essere infra, ma quale pilastro servire? se tu non saper rispondere in 5 secondi, infra troppo in anticipo._
+
+**Scope check periodico:**
+
+> 🪨 _caveman contare: tu aggiunto 4 feature in 7 giorni. MoSCoW rapido: sono tutte MUST? se no, caveman comandare 7 giorni no nuove feature. ugh bunga._
+
+**Twist su Evo-Tactics:**
+
+> 🦴 _caveman vedere idea: 'Regola del 2' - giocare Evo-Tactics con solo 2 specie e 1 bioma per 1 turno. niente altro. se funzionare divertente così, gioco vero. se noioso, tu sapere dove scavare._
+
+### Esempi cattivi (da evitare)
+
+❌ Troppo lungo, troppo guru:
+
+> 🦴 _Caro Master, il caveman vuole dirti che oggi hai fatto un ottimo lavoro [...]_
+
+❌ Non concreto:
+
+> 🪨 _caveman pensare tu dovere lavorare più su gameplay._
+
+❌ Ripetitivo (stesso gioco di 3 risposte fa):
+
+> 🦴 _di nuovo gioco dei 3 oggetti..._
+
+### Regole anti-saturazione
+
+1. **Max 1 blocco ogni 3-4 risposte** (a occhio, non conteggio preciso)
+2. **Mai 2 categorie uguali di fila** — se ultima era `mini_game`, prossima no
+3. **Mini-games SEMPRE diversi** — mai riproporre lo stesso in una sessione
+4. **Se Master dice "basta caveman" → stop immediato** per il resto della sessione
+
+## Riferimenti
+
+- `references/categories.md` — banca idee dettagliata per ogni categoria, con
+  esempi ancorati ai 6 pilastri di Evo-Tactics (leggi se servono idee fresche)
+- `references/pillars.md` — i 6 pilastri del GDD v0.1 con descrizioni
+- Skill correlata: `evo-tactics-monitor` (per briefing direzionali del repo)
+- Tool correlato: `evo-caveman` CLI nel repo (fa la stessa cosa lato git,
+  con analisi commit + achievements + hook opzionale)
+
+## Mantra finale
+
+> 🪨 _caveman non finire gioco. caveman finire turno. domani, altro turno._

--- a/caveman-mode-skill/references/categories.md
+++ b/caveman-mode-skill/references/categories.md
@@ -1,0 +1,137 @@
+# Categorie Caveman — banca idee
+
+Riferimento da consultare quando serve ispirazione. Non seguire alla lettera:
+questi sono seed, il caveman inventa sempre qualcosa di contestuale.
+
+---
+
+## 1. Micro-sprint (5–15 min)
+
+Pattern: "piccolo passo giocabile > grande refactor". Sempre concreto, sempre
+legato a un file/cartella reale del repo se possibile.
+
+### Seed per Evo-Tactics
+
+- Cancella un trait/specie/job che non usi mai (meno = più giocabile)
+- Rinomina una variabile confusa in qualcosa di leggibile
+- Stampa un YAML di dataset e leggilo ad alta voce: se non è chiaro, è rotto
+- Scrivi UNA regola di gameplay su post-it fisico (non in codice)
+- Testa un singolo scontro 1v1 a mano con 2 specie su carta
+- Aggiungi UN counter/contromossa a una regola che ne manca (pilastro 6)
+- Chiudi 1 issue aperta da >30 giorni (anche solo con commento "non rilevante")
+- Fai 1 commit che tocca SOLO gameplay (vietato infra/CI)
+- Riduci di 1 riga la complessità di una regola del core
+- Disegna a mano lo schema di 1 turno di gioco su foglio, fotografalo in `docs/`
+- **Cut darlings**: scegli la feature di cui sei più orgoglioso. Immagina di tagliarla. Se il gioco cadrebbe, tienila.
+- Apri ultima issue che hai aperto: se titolo usa "magari", "un giorno" → chiudi wontfix
+- Dimezza il file di regole più lungo (taglia dentro, non riscrivere)
+
+### Regole
+
+- Mai "refactor grosso". Se serve >15 min è troppo.
+- Mai "scrivi test" come micro-sprint (importante ma non energetico).
+- Preferisci cancellazioni/semplificazioni a nuove aggiunte.
+
+---
+
+## 2. Design Hint (ancorato ai 6 pilastri)
+
+I 6 pilastri di Evo-Tactics (vedi `pillars.md`):
+
+1. **Tattica leggibile** (FFT)
+2. **Evoluzione emergente** (Spore)
+3. **Identità doppia: Specie × Job**
+4. **Temperamenti giocati** (MBTI/Ennea come seme ludico)
+5. **Co-op vs Sistema** (Descent: Leggende)
+6. **Fairness** (caps, counter disclosure, anti-snowball)
+
+### Seed per hint
+
+- **Pilastro 1**: _"se un nuovo giocatore non capire turno in 30 secondi, turno rotto"_
+- **Pilastro 2**: _"evoluzione non essere upgrade tree. essere sorpresa da uso ripetuto"_
+- **Pilastro 3**: _"specie dare COSA fare, job dare COME farlo. se si sovrappongono, uno morire"_
+- **Pilastro 4**: _"temperamento non essere statistica. essere tentazione durante il turno"_
+- **Pilastro 5**: _"il Sistema deve poter perdere. altrimenti non cooperazione, puzzle"_
+- **Pilastro 6**: _"counter deve essere visibile PRIMA della mossa avversaria, non dopo"_
+
+### Pattern generali
+
+- Un pilastro 🟡 (teorizzato)? → farlo 🟢 in 1 sessione fisica, non in codice
+- Se stai aggiungendo feature: quale pilastro serve? Se non c'è risposta, non aggiungere
+- **Saint-Exupéry**: _"perfezione non quando niente da aggiungere, ma quando niente da togliere"_
+- **Chess**: regole poche + infinita profondità. Evo-Tactics ha regole più di chess ed è più divertente di chess?
+- **Undertale**: Toby Fox vinceva perché ha tagliato tutto tranne il core
+
+---
+
+## 3. Mini-game (SEMPRE diversi)
+
+Banca di idee. **Non riproporre mai un mini-game già fatto** nella conversazione.
+
+### Seed
+
+- 3 oggetti sulla scrivania → inventare una specie di Evo-Tactics con quelli
+- Spotify shuffle → prossimo titolo di canzone è il nome di un nuovo trait
+- Timer 60 secondi → elencare tutti i job possibili
+- Guarda fuori dalla finestra → primo essere vivente come specie
+- Apri un libro a caso → prima parola = nome di un bioma
+- Tira 1d20 → 1-5 movimento, 6-10 attacco, 11-15 difesa, 16-20 sociale
+- Spiega il tuo gioco a qualcuno in casa in 60 secondi
+- Cammina 5 minuti senza telefono, torna, scrivi 1 riga di cosa hai pensato
+- Chiudi gli occhi, descrivi il tuo gioco come un film (90 secondi)
+- Disegna UNA unit su carta, solo linee: se amico capisce in 10 sec, icon pronta
+- Timer 5 minuti, scrivi senza fermarti "il mio gioco parla di...", non modificare
+
+### Regole
+
+- Max 5 minuti
+- Mai tool esterni complicati
+- Sempre "toccabile" (preferibile fisico a schermo)
+- Se Master in contesto dove non può (es. in treno), proporne uno mentale
+
+---
+
+## 4. Evo-Tactics Twist (playtest con vincolo)
+
+Proposte di giocare SUL gioco con un vincolo creativo per **far emergere
+problemi o intuizioni** con attrito minimo.
+
+### Seed
+
+- **"Regola del 2"**: gioca con solo 2 specie e 2 job per 1 turno. Se noioso così, core debole. Se divertente, tutto il resto è sovrastruttura.
+- **"Muto"**: gioca senza testo sullo schermo, solo icone. Se non si capisce, leggibilità rotta.
+- **"Peggior combo"**: scegli apposta specie+job più deboli. Sistema li rende interessanti? (pilastro 6)
+- **"Solo temperamenti"**: ignora specie/job, gioca solo con MBTI. Se non emerge gameplay, pilastro 4 decorativo.
+- **"Reverse"**: il Sistema vince se i giocatori arrivano alla fine. Cosa succede? Rivela priorità vere.
+- **"Playtester fantasma"**: gioca fingendo di essere un amico che non ha mai visto il gioco. Annota ogni "non capisco".
+- **"Carta e penna"**: stampa le regole, gioca a mano 10 minuti. L'infra serve davvero?
+- **"Speedrun evoluzione"**: sblocca un'evoluzione nel minor tempo. Troppo facile? Non è emergenza, è checklist.
+- **"Turno blindato"**: timer 30 sec per turno. Se stressa, UI lenta. Se facile, dimezza.
+- **"Rimuovi UI"**: post-it per nascondere metà schermo. Cosa non è essenziale?
+- **"3 partite stessa build"**: 3a partita ancora interessante? Se no, evoluzione non emerge.
+
+### Obiettivo
+
+Produrre in 15-30 minuti un'osservazione utile che altrimenti richiederebbe
+ore di discussione o un playtest completo.
+
+---
+
+## 5. Scope Check (NEW v0.2)
+
+Anti scope-creep e future-creep, ispirato a framework di prioritizzazione.
+
+### Seed
+
+- **MoSCoW**: l'ultima feature è MUST, SHOULD, COULD o WON'T? Se non MUST, rimandala.
+- **Scope creep check**: quante feature aggiunte al GDD ultimo mese? Se più di 2, stop per 7 giorni.
+- **Future creep check**: stai codando per "quando ci saranno utenti"? Non ci sono utenti ancora. Taglia, fai dopo.
+- **RICE scoring**: (Reach × Impact × Confidence) / Effort. Se <2, saltare.
+- **SPACE check**: Soddisfatto? Performi? Attivo? Collabori? Efficiente? Se 2+ "no", non è tecnica, è scope.
+
+### Quando usarla
+
+- Se è passato un po' senza uno scope check (~6 turni di conversazione)
+- Se Master sta aggiungendo feature a raffica
+- Se Master parla di "quando ci sarà X" per qualcosa che non esiste ancora
+- Mai 2 scope_check ravvicinati, altrimenti diventa un moralismo

--- a/caveman-mode-skill/references/pillars.md
+++ b/caveman-mode-skill/references/pillars.md
@@ -1,0 +1,93 @@
+# I 6 Pilastri di Evo-Tactics (GDD v0.1)
+
+Riferimento per ancorare hint e sprint a principi concreti del design.
+
+---
+
+## 1. Tattica leggibile, scacchistica (FFT)
+
+Ispirazione: **Final Fantasy Tactics**, chess.
+
+- Ogni turno deve essere comprensibile in 30 secondi
+- Le conseguenze di una mossa devono essere prevedibili al momento della scelta
+- Niente dadi nascosti, niente "ha calcolato dietro le quinte"
+- Se serve un manuale per capire un turno, il turno è rotto
+
+**Sintomo di pilastro in deriva:** regole che richiedono spiegazione > 1 paragrafo.
+
+---
+
+## 2. Evoluzione emergente da comportamenti (Spore)
+
+Ispirazione: **Spore**, evoluzione biologica.
+
+- L'evoluzione NON è uno skill tree. È una sorpresa da uso ripetuto.
+- Se il giocatore può prevedere l'upgrade, non è evoluzione, è shopping
+- Le evoluzioni dovrebbero emergere da pattern di comportamento ripetuti, non da scelte dirette
+- "Ho usato 5 volte il fuoco" → evolve qualcosa relativo al fuoco (non "scegli upgrade fuoco")
+
+**Sintomo di pilastro in deriva:** menu "scegli la tua evoluzione".
+
+---
+
+## 3. Identità doppia: Specie × Job
+
+Ispirazione: doppia classificazione (biologia × ruolo).
+
+- **Specie** = COSA fa un'unità (capacità innate, corpo, biomi preferiti)
+- **Job** = COME lo fa (tecniche, disciplina, ruolo tattico)
+- Se Specie e Job si sovrappongono, uno dei due è inutile → tagliare
+- Ogni combinazione Specie×Job deve avere una ragion d'essere unica
+
+**Sintomo di pilastro in deriva:** combo Specie×Job intercambiabili.
+
+---
+
+## 4. Temperamenti giocati (MBTI/Ennea come seme ludico)
+
+Ispirazione: psicologia giocabile.
+
+- Il temperamento NON è +2 STAT
+- È una **tentazione** durante il turno ("INTJ vuole pianificare, ma il turno dura 30 sec")
+- Il giocatore deve sentire il temperamento come pulsione, non come etichetta
+- I temperamenti dovrebbero creare dilemmi tattici, non descrivere personaggi
+
+**Sintomo di pilastro in deriva:** temperamenti usati solo per dialoghi o lore.
+
+---
+
+## 5. Co-op vs Sistema (Descent: Leggende)
+
+Ispirazione: **Descent: Legends of the Dark**.
+
+- Il gioco è cooperativo: i giocatori contro il Sistema (AI avversaria)
+- Il Sistema deve poter vincere **davvero**, altrimenti non è cooperazione, è puzzle
+- Niente "il Sistema fa ciò che i giocatori si aspettano per farli sentire forti"
+- La tensione viene dal fatto che il Sistema può e vuole sconfiggerti
+
+**Sintomo di pilastro in deriva:** "qual è la strategia giusta per vincere?" → è un puzzle.
+
+---
+
+## 6. Fairness: caps, counter disclosure, anti-snowball
+
+Ispirazione: game design competitivo, teoria del "fun".
+
+- **Caps**: nessuna scalata esponenziale (niente unità 10x più forti di altre)
+- **Counter disclosure**: se il nemico ha un counter alla tua mossa, il gioco te lo deve dire PRIMA della mossa, non dopo
+- **Anti-snowball**: perdere un turno non deve garantire perdere la partita
+- Una combo "peggior specie + peggior job" deve poter essere interessante da giocare
+
+**Sintomo di pilastro in deriva:** "eh, ti ho beccato con il counter nascosto".
+
+---
+
+## Stato operativo
+
+Ogni pilastro ha uno stato:
+
+- 🟢 **Coperto** — esiste artefatto giocabile/dataset validato
+- 🟡 **Teorizzato** — esiste nel GDD ma nessuna implementazione giocabile
+- 🔴 **Bloccato** — infrastruttura in conflitto o pilastro ignorato di recente
+
+**Regola:** un pilastro 🟡 per troppo tempo diventa 🔴. Il caveman lo sa e lo dice.

--- a/docs/caveman-status.json
+++ b/docs/caveman-status.json
@@ -1,0 +1,85 @@
+{
+  "_meta": {
+    "generator": "caveman_status_stdlib (fallback)",
+    "version": "0.2.0-stdlib",
+    "generated_at": "2026-04-17T11:17:27.060654+00:00",
+    "repo_root": "C:\\Users\\VGit\\Desktop\\Game\\.claude\\worktrees\\clever-khayyam",
+    "note": "File generato via tools/py/caveman_status_stdlib.py (stdlib-only). Quando evo-caveman CLI è installato, rigenerare con `caveman export`."
+  },
+  "snapshot": {
+    "dirty_files_count": 5,
+    "recent_commits_count": 10,
+    "gameplay_ratio": 0.0,
+    "consecutive_infra_commits": 0,
+    "is_drifting": true,
+    "recent_commits": [
+      {
+        "sha": "949f6ca0",
+        "kind": "DOCS",
+        "message_first_line": "doc: COMMIT_STYLE canonico (RESEARCH_TODO S2) (#1489)",
+        "files_count": 0
+      },
+      {
+        "sha": "8cc1287f",
+        "kind": "DOCS",
+        "message_first_line": "doc: README refresh — Why/What/How/For-agents (RESEARCH_TODO S3) (#1487)",
+        "files_count": 0
+      },
+      {
+        "sha": "8c3f6fd3",
+        "kind": "TOOLING",
+        "message_first_line": "doc: add PILLARS_STATUS dashboard — RESEARCH_TODO S1 (#1486)",
+        "files_count": 0
+      },
+      {
+        "sha": "7ae85d52",
+        "kind": "ALTRO",
+        "message_first_line": "playtest: [2026-04-17] first documented session (#1485)",
+        "files_count": 0
+      },
+      {
+        "sha": "193a31a5",
+        "kind": "DOCS",
+        "message_first_line": "doc: scaffold M1 first playtest (setup + notes template) (#1484)",
+        "files_count": 0
+      },
+      {
+        "sha": "4d526cd4",
+        "kind": "ALTRO",
+        "message_first_line": "docs(canonical): chiude 8 Open Questions Master DD — Art/Audio/Business/Narrative (#1481)",
+        "files_count": 0
+      },
+      {
+        "sha": "2b58cd73",
+        "kind": "DOCS",
+        "message_first_line": "doc: commit RESEARCH_TODO.md as source of truth + mark M2/M3 done (#1483)",
+        "files_count": 0
+      },
+      {
+        "sha": "aee9609e",
+        "kind": "DOCS",
+        "message_first_line": "doc: add project pitch (3 sentences max) — RESEARCH_TODO M3 (#1482)",
+        "files_count": 0
+      },
+      {
+        "sha": "9ae81ec3",
+        "kind": "ALTRO",
+        "message_first_line": "feat(difficulty): session integration + /profiles endpoint (Q-001 T2.3 PR-3 of 5) (#1480)",
+        "files_count": 0
+      },
+      {
+        "sha": "17003bd0",
+        "kind": "ALTRO",
+        "message_first_line": "feat(replay): deterministic engine MVP (Q-001 T2.4 PR-3 of 5) (#1479)",
+        "files_count": 0
+      }
+    ]
+  },
+  "achievements": {
+    "unlocked_count": null,
+    "total_count": 8,
+    "items": [],
+    "note": "Achievements computed by caveman CLI, not stdlib fallback"
+  },
+  "last_spoke_unix": null
+}

--- a/evo-caveman/.github/workflows/caveman-ci.yml
+++ b/evo-caveman/.github/workflows/caveman-ci.yml
@@ -1,0 +1,88 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'evo-caveman/**'
+      - '.github/workflows/caveman-ci.yml'
+  pull_request:
+    paths:
+      - 'evo-caveman/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: evo-caveman
+
+jobs:
+  lint-and-test:
+    name: Test on Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.12', '3.13']
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # caveman ha bisogno dello storico git
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: 'evo-caveman/uv.lock'
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras --all-groups
+
+      - name: Lint with ruff
+        run: uv run ruff check .
+
+      - name: Format check with ruff
+        run: uv run ruff format --check .
+
+      - name: Type check with mypy
+        run: uv run mypy src
+
+      - name: Run tests
+        run: uv run pytest
+
+      - name: Upload coverage
+        if: matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: evo-caveman/htmlcov
+          if-no-files-found: ignore
+
+  caveman-self-check:
+    name: Caveman self-check (dogfooding)
+    runs-on: ubuntu-latest
+    needs: lint-and-test
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50 # ultimi 50 commit per l'analisi
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install caveman
+        working-directory: evo-caveman
+        run: uv sync
+
+      - name: Run caveman status sul repo
+        run: |
+          cd evo-caveman
+          uv run caveman status --repo ..
+        continue-on-error: true # non blocca la CI, è solo informativo

--- a/evo-caveman/CAVEMAN.md
+++ b/evo-caveman/CAVEMAN.md
@@ -1,0 +1,86 @@
+# 🦴 CAVEMAN.md
+
+> Rituale di lavoro + tool CLI per tenere **Evo-Tactics** sulla rotta giusta.
+
+Questo repo ha un companion CLI chiamato `caveman` che legge lo stato del progetto
+e ricorda di **mettere il gioco prima del codice**.
+
+## Quick start
+
+```bash
+# Install (una volta)
+cd evo-caveman && uv tool install .
+
+# Uso manuale
+caveman              # parlata contestuale
+caveman status       # lettura dello stato del repo
+caveman achievements # trofei da pattern di commit
+caveman speak -c scope_check  # forza una categoria
+
+# Hook automatico (opt-in, parla solo quando serve)
+caveman install-hook
+```
+
+## Le 5 categorie di parlata
+
+| Categoria      | Quando                       | Esempio                                                 |
+| -------------- | ---------------------------- | ------------------------------------------------------- |
+| `micro_sprint` | dopo GAMEPLAY, o molti dirty | _"hai 7 file dirty, committa UNO solo adesso"_          |
+| `design_hint`  | repo in deriva               | _"counter visibile PRIMA della mossa, non dopo"_        |
+| `mini_game`    | su richiesta, pausa creativa | _"apri Spotify shuffle. prossimo titolo = nuovo trait"_ |
+| `evo_twist`    | per playtest guidato         | _"'Regola del 2': gioca con solo 2 specie e 2 job"_     |
+| `scope_check`  | se non fatto da un po'       | _"MoSCoW: l'ultima feature è MUST? se no, rimandala"_   |
+
+## Achievements (sbloccati dai commit)
+
+Il caveman traccia anche alcuni achievement ispirati a **GitMood** ma ancorati
+a game design, non a sentiment. Alcuni sono celebrazioni, altri warning.
+
+```bash
+caveman achievements     # sbloccati
+caveman achievements --all  # tutti i possibili
+```
+
+Esempi: 🎯 Game-First Striker (3 GAMEPLAY di fila), ✂️ Ruthless Cutter
+(commit di rimozione), ⚠️ Docker Addict (troppi INFRA), 🦴 Unga Bunga
+(gameplay ratio ≥60%).
+
+## Regole del Caveman (valgono anche senza il tool)
+
+1. **Se un bambino non capisce una regola in 30 secondi, la regola è rotta.**
+2. **Se l'infra va avanti senza il gioco, il gioco muore.**
+3. **Un playtest con post-it batte dieci dashboard.**
+4. **Cancellare roba vale più che aggiungerla.**
+5. **Un pilastro 🟡 (teorizzato) per troppo tempo diventa 🔴 (bloccato).**
+6. **Scope creep = silent killer.** Future creep = suo fratello peggiore.
+
+## 3 domande del venerdì
+
+Se non vuoi usare il tool, ogni venerdì chiediti:
+
+1. **Cosa farebbe il Caveman adesso in 10 minuti?** → prossimo commit
+2. **Quale pilastro è più solo questa settimana?** → dove scavare
+3. **Se spegnessi Docker per 48 ore, cosa resterebbe del gioco?** → il core
+
+Se rispondere richiede più di 2 minuti, stai lavorando troppo "in alto".
+
+## Stato files
+
+Lo state del caveman vive in `.git/` (non versionato):
+
+- `.git/caveman_state.json` — seed usati di recente (anti-ripetizione)
+- `.git/caveman_last_spoke` — timestamp ultima parlata (throttle hook)
+
+Sono file locali, sicuri, rimossi da `git clean -fdx`.
+
+## Disinstallazione
+
+```bash
+caveman uninstall-hook
+uv tool uninstall evo-caveman
+rm .git/caveman_state.json .git/caveman_last_spoke
+```
+
+---
+
+_File volutamente informale. Non passarlo al linter. Se lo rendi "professionale", perde la sua funzione._

--- a/evo-caveman/DEEP_RESEARCH.md
+++ b/evo-caveman/DEEP_RESEARCH.md
@@ -1,0 +1,267 @@
+# 🔍 DEEP_RESEARCH.md
+
+> Sintesi della ricerca di aprile 2026 per il progetto `evo-caveman`.
+> Aggiornato al 17 aprile 2026.
+
+Questo file raccoglie scoperte, fonti e take-aways per informare il design
+di `evo-caveman` e il workflow su Evo-Tactics. Non è letteratura pura:
+solo ciò che ha influenzato scelte concrete.
+
+---
+
+## 1. Tool simili esistenti (cosa c'è già fuori)
+
+### Dev-companion / sentiment / achievements
+
+**GitMood** — _CLI che analizza le emozioni dei tuoi commit_ (devchallenge 2026).
+
+- Sentiment analysis lexicon-based (AFINN), achievements, mood weekly patterns.
+- Link: https://dev.to/ohmygod/building-gitmood-a-cli-that-analyzes-your-commit-emotions-with-github-copilot-cli-3lgm
+- **Take-away:** ispirazione diretta per `achievements.py`. Abbiamo però ancorato
+  gli achievement a **game design** (Game-First Striker, Ruthless Cutter) invece
+  che a sentiment, perché per Evo-Tactics conta la rotta, non l'umore.
+
+**DocWeave** — genera doc markdown + mermaid dai commit (GitHub Copilot CLI).
+
+- Pattern interessante: classifica commit → output strutturato.
+- Link: https://dev.to/julsr_mx/cli-tool-that-analyzes-git-repos-and-generates-beautiful-documentation-4e47
+- **Take-away:** scope diverso, ma la logica di "leggere commit → produrre artefatto"
+  è la stessa che applichiamo in `repo.py`.
+
+**Burnout early warning system** (su GitHub topic `git-analytics`).
+
+- Sistema self-hosted che analizza pattern di commit per predire burnout dei dev.
+- Link: https://github.com/topics/git-analytics
+- **Take-away:** la filosofia "il codice dice come stai" è validata in campo.
+  Non l'abbiamo implementata perché fuori scope, ma è una direzione futura.
+
+### Hook managers
+
+**prek** (Rust, 2026) — drop-in replacement per `pre-commit`.
+
+- Single binary, no Python/Node runtime required, multi-language toolchains.
+- Link: https://prek.j178.dev/ · https://github.com/j178/prek
+- **Take-away:** il nostro caveman è un singolo post-commit hook leggero, non
+  in conflitto. Potremmo distribuirlo come hook prek-compatibile in futuro.
+
+**lefthook** / **husky** — alternative leggere più usate in progetti JS/TS.
+
+- Link: https://devtoolbox.dedyn.io/blog/git-hooks-complete-guide
+- **Take-away:** il nostro hook è plain bash, compatibile con qualsiasi gestore.
+
+---
+
+## 2. Stack Python 2026 — cosa usare, cosa lasciare
+
+### Astral domina
+
+**uv** (Astral) ha sostituito **pip + poetry + venv + pyenv + pip-tools** in un
+singolo Rust binary. 10-100× più veloce, cache condivisa, hard-link, workspaces.
+
+**ruff** (Astral) ha sostituito **flake8 + black + isort + pydocstyle**. 500+
+regole, autofix, zero-config, millisecondi invece di secondi.
+
+**ty** (Astral, beta) — nuovo type checker, alternativa a mypy.
+
+**pyx** — registry Python privato di Astral (waitlist).
+
+**News importante (marzo 2026):** Astral è stata acquisita da OpenAI (Codex team).
+I tool restano MIT, la community potrà forkare se peggiorano.
+
+- Link: https://www.ismatsamadov.com/blog/uv-ruff-replaced-pip-flake8-black-python-toolchain
+- Link: https://docs.astral.sh/uv/guides/tools/
+- **Take-away applicato:** `evo-caveman` usa uv + ruff strict. CI con
+  `astral-sh/setup-uv@v5` e cache su `uv.lock`.
+
+### PEP 735 — `[dependency-groups]`
+
+Nuovo standard 2026 per le dev deps. Sostituisce `optional-dependencies[dev]`.
+
+```toml
+[dependency-groups]
+dev = ["pytest>=8.3.0", "ruff>=0.8.0", "mypy>=1.13.0"]
+```
+
+Installi con: `uv sync --all-groups` o `uv sync --group dev`.
+
+- **Take-away applicato:** `pyproject.toml` usa questa sintassi.
+
+### GitHub Actions pattern 2026
+
+```yaml
+- uses: astral-sh/setup-uv@v5
+  with:
+    enable-cache: true
+    cache-dependency-glob: 'uv.lock'
+- run: uv sync --all-extras --all-groups
+- run: uv run ruff check .
+- run: uv run mypy src
+- run: uv run pytest
+```
+
+- **Take-away applicato:** `.github/workflows/caveman-ci.yml` segue questo pattern,
+  matrix su Python 3.12 + 3.13, più un job "dogfooding" che fa girare
+  `caveman status` sul repo stesso (meta!).
+
+---
+
+## 3. Claude Skills best practices (novembre 2025 – aprile 2026)
+
+### Dalla doc ufficiale Anthropic
+
+- **SKILL.md ≤ 500 righe** per performance ottimale (context window è bene pubblico)
+- **Progressive disclosure**: la description nel frontmatter è sempre in context,
+  il body si carica solo quando triggera, `references/` solo quando necessario
+- **Description "pushy"**: meglio over-triggerare che under-triggerare.
+  Esempio: non "How to build a dashboard", ma "How to build a dashboard.
+  **Make sure to use this whenever the user mentions dashboards, data viz, metrics,
+  or wants to display any kind of data, even if they don't explicitly ask**".
+
+Fonti:
+
+- https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview
+- https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices
+
+### Vercel evals — finding scomodo
+
+Vercel ha valutato skills e ha trovato che:
+
+- **Skills non triggerano nel 56% dei test cases**, producendo zero improvement su baseline
+- **AGENTS.md / CLAUDE.md compresso batte le skills**: docs index embedded direttamente
+  nel file di onboarding ha raggiunto 100% pass rate
+
+Link: https://alexop.dev/posts/stop-bloating-your-claude-md-progressive-disclosure-ai-coding-tools/
+
+**Take-away applicato:** la skill `caveman-mode` v2 è più "pushy" nella description,
+e abbiamo duplicato le info critiche in `CAVEMAN.md` del repo così vivono anche
+fuori dalla skill (per quando la skill non triggera).
+
+### Pattern Why/What/How per CLAUDE.md
+
+Dalla HumanLayer (autori di Claude Code wrappers):
+
+```markdown
+# Project Name
+
+## Why [1-3 frasi]
+
+## What [mappa progetto]
+
+## How [regole sempre attive]
+
+## Progressive Disclosure [puntatori a file specifici]
+```
+
+- CLAUDE.md ≤ 100 righe, auto-generati vengono ignorati dall'agent.
+- Link: https://www.humanlayer.dev/blog/writing-a-good-claude-md
+- **Take-away:** `CAVEMAN.md` del repo segue una versione leggera di questo pattern.
+
+### Self-improving skills (pattern emergente)
+
+Alcuni dev fanno skills che analizzano le sessioni passate ed estraggono pattern
+di errore per auto-aggiornare le loro stesse istruzioni. Interessante per futuro,
+non implementato nella v0.2.
+
+---
+
+## 4. Game Design — scope creep & future creep
+
+### Scope creep = silent killer (Wayline, UniversityXP, Codecks)
+
+**Scope creep**: aggiunte al progetto che sembrano piccole, ma si accumulano.
+**Future creep**: cugino peggiore — codare per utenti/feature che non esistono ancora.
+
+Citazione chiave (Wayline): _"Docker funzionante, CI verde, dashboard bella non
+sono progress di game design."_ → ha ispirato il messaggio del nostro design_hint
+quando rileviamo streak INFRA ≥3.
+
+**Undertale** come caso studio (Toby Fox): grafica semplice, mondo piccolo,
+turni base. **Vincente perché ha tagliato tutto tranne il core.** Citato direttamente
+in un seed `design_hint`.
+
+### Frameworks di prioritizzazione
+
+**MoSCoW** (Must/Should/Could/Won't) — semplice, veloce, perfetto per solo dev.
+**RICE** (Reach × Impact × Confidence / Effort) — più quantitativo.
+**SPACE** (Satisfaction, Performance, Activity, Collaboration, Efficiency) —
+framework moderno (Google/GitHub research) per misurare produttività senza
+ridurla a LoC/commits.
+
+- Link: https://www.wayline.io/blog/scope-creep-solo-indie-game-development
+- Link: https://www.manuelsanchezdev.com/blog/scope-vs-future-creep-game-development
+- Link: https://www.codecks.io/blog/2025/how-to-avoid-scope-creep-in-game-development/
+
+**Take-away applicato:** nuova categoria **`scope_check`** con 5 seed basati
+esattamente su MoSCoW, RICE, SPACE, scope creep, future creep. Il caveman
+propone uno scope check ogni ~6 commit se non ne ha fatto recentemente.
+
+### Saint-Exupéry, citato da mezza industria
+
+> _"La perfezione si raggiunge non quando non c'è più nulla da aggiungere,
+> ma quando non c'è più nulla da togliere."_
+
+Usato direttamente come seed `design_hint`. Funziona.
+
+---
+
+## 5. Cosa NON abbiamo implementato (ma lo nota)
+
+Idee valide viste durante la ricerca, rimandate per tenere lo scope stretto:
+
+- **Sentiment analysis sui messaggi di commit** (GitMood style)
+- **Report PDF / mermaid diagram** (DocWeave style)
+- **Integration con GitHub API per issue metrics** (siamo 100% local-first)
+- **Burnout detection** (troppo invasivo per un companion leggero)
+- **Self-improving via session analysis** (pattern emergente, ancora immaturo)
+- **Prek-compatibility** (utile se evo-caveman diventa distribuito)
+- **Dashboard web** (vs filosofia "playtest > dashboard")
+
+Scope creep prevention applicato al caveman stesso: cut your darlings.
+
+---
+
+## 6. Risorse consultate (lista completa)
+
+### Python 2026
+
+- https://www.ismatsamadov.com/blog/uv-ruff-replaced-pip-flake8-black-python-toolchain
+- https://www.pyinns.com/python/efficient-code/uv-ruff-fastest-python-workflow-2026
+- https://docs.astral.sh/uv/guides/tools/
+- https://medium.com/@diwasb54/the-2026-golden-path-building-and-publishing-python-packages-with-a-single-tool-uv-b19675e02670
+- https://simone-carolini.medium.com/modern-python-code-quality-setup-uv-ruff-and-mypy-8038c6549dcc
+
+### Git hooks / dev tools
+
+- https://prek.j178.dev/
+- https://devtoolbox.dedyn.io/blog/git-hooks-complete-guide
+- https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
+- https://github.com/topics/git-analytics
+
+### Claude skills & CLAUDE.md
+
+- https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview
+- https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices
+- https://www.humanlayer.dev/blog/writing-a-good-claude-md
+- https://www.groff.dev/blog/implementing-claude-md-agent-skills
+- https://alexop.dev/posts/stop-bloating-your-claude-md-progressive-disclosure-ai-coding-tools/
+
+### Game design (scope, MVP, cut darlings)
+
+- https://www.wayline.io/blog/scope-creep-solo-indie-game-development
+- https://www.wayline.io/blog/solo-game-dev-scope-creep-stay-on-track
+- https://www.codecks.io/blog/2025/how-to-avoid-scope-creep-in-game-development/
+- https://www.universityxp.com/blog/2025/2/13/game-design-constraints-and-scope-creep
+- https://www.manuelsanchezdev.com/blog/scope-vs-future-creep-game-development
+- https://www.gamedeveloper.com/design/scope-choose-a-target-focus-shoot-
+- https://medium.com/@doandaniel/gamedev-protips-how-to-kick-scope-creep-in-the-ass-and-ship-your-indie-game-8fa3051500d1
+
+### Git analytics / companions
+
+- https://dev.to/ohmygod/building-gitmood-a-cli-that-analyzes-your-commit-emotions-with-github-copilot-cli-3lgm
+- https://dev.to/julsr_mx/cli-tool-that-analyzes-git-repos-and-generates-beautiful-documentation-4e47
+- https://axify.io/blog/git-analytics
+
+---
+
+_Questo file è aggiornato periodicamente. Se vedi che sta invecchiando, apri
+una issue o aggiornalo tu — è un documento vivo._

--- a/evo-caveman/Makefile
+++ b/evo-caveman/Makefile
@@ -1,0 +1,31 @@
+.PHONY: install dev test lint fmt type check clean speak
+
+install:
+	uv tool install . || pip install .
+
+dev:
+	uv sync --dev || pip install -e ".[dev]"
+
+test:
+	pytest
+
+lint:
+	ruff check . --fix
+
+fmt:
+	ruff format .
+
+type:
+	mypy src
+
+check: lint type test
+
+clean:
+	rm -rf build dist *.egg-info .pytest_cache .mypy_cache .ruff_cache
+	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+
+speak:
+	caveman speak
+
+status:
+	caveman status

--- a/evo-caveman/README.md
+++ b/evo-caveman/README.md
@@ -1,0 +1,152 @@
+# 🦴 evo-caveman v0.2
+
+> Companion CLI per il repo **Evo-Tactics**. Un caveman che legge i tuoi commit e ti aiuta a non perdere la rotta.
+
+**Stack 2026:** Python 3.12+ · uv · Typer · Rich · Ruff strict · mypy strict · pytest+cov · GitHub Actions CI · PEP 735 dependency-groups.
+
+## Cosa fa
+
+1. **Analizza i tuoi commit** (ultimi 10) e li classifica: `GAMEPLAY`, `INFRA`, `TOOLING`, `DOCS`, `DATA`, `ALTRO`.
+2. **Rileva deriva**: se il gameplay ratio scende sotto il 20% o ci sono 4+ INFRA consecutivi, te lo dice.
+3. **Parla solo quando serve**, con 5 tipi di output contestuali:
+   - `micro_sprint` — task 5-15 min concreto
+   - `design_hint` — principio ancorato ai 6 pilastri di Evo-Tactics
+   - `mini_game` — pausa creativa 2-5 min, sempre diversa
+   - `evo_twist` — playtest guidato con vincolo
+   - `scope_check` — anti scope/future creep (MoSCoW, RICE, SPACE) ✨ NEW
+4. **Achievements**: sblocca celebrazioni e warning dai pattern di commit (Game-First Striker, Ruthless Cutter, ⚠️ Docker Addict…). ✨ NEW
+5. **Hook git opzionale** con throttling 90 min: niente spam, parla solo se hai rotto la rotta o chiuso un GAMEPLAY.
+
+## Install
+
+```bash
+# Stack 2026: uv raccomandato
+uv tool install evo-caveman
+
+# Legacy: pipx
+pipx install evo-caveman
+
+# Dev locale
+cd evo-caveman
+uv sync --all-extras --all-groups
+```
+
+## Uso
+
+```bash
+caveman                              # parlata contestuale (usa stato repo corrente)
+caveman speak -c scope_check         # forza categoria
+caveman status                       # tabella commit + metriche
+caveman achievements                 # achievement sbloccati
+caveman achievements --all           # tutti gli achievement possibili
+caveman check                        # hook-mode: exit 0 se parla, 1 se zitto
+caveman check --force                # ignora throttling
+caveman install-hook                 # post-commit hook opt-in
+caveman uninstall-hook
+caveman --version
+```
+
+## Categorie & logica di scelta
+
+```
+se file dirty >= 5           → micro_sprint (pulisci WIP)
+else se repo in deriva       → design_hint (schiaffo)
+else se 6+ commit senza      → scope_check (30% prob)
+     scope check recente
+else se ultimo è GAMEPLAY    → micro_sprint (prossimo passo)
+else                         → random pesato
+                               (sprint 35% / twist 20% / game 18% /
+                                hint 15% / scope 12%)
+```
+
+**Repo "in deriva"** = `gameplay_ratio < 20%` sugli ultimi 10 commit, OPPURE `4+ INFRA consecutivi`.
+
+## Hook automatico
+
+```bash
+caveman install-hook
+```
+
+Dopo ogni `git commit`:
+
+- Se in deriva → design_hint
+- Se GAMEPLAY → celebra + prossimo sprint
+- Altrimenti → zitto
+- Throttle 90 min per evitare spam
+
+Disattiva: `caveman uninstall-hook`.
+
+## Achievement
+
+| Emoji | Titolo             | Condizione                             |
+| ----- | ------------------ | -------------------------------------- |
+| 🎯    | Game-First Striker | 3 commit GAMEPLAY di fila              |
+| ✂️    | Ruthless Cutter    | 2+ commit di rimozione negli ultimi 10 |
+| 🏔️    | Pillar Diversifier | 3+ pilastri toccati in 5 commit        |
+| 🌱    | Fresh Breath       | 1° GAMEPLAY dopo 3+ INFRA di fila      |
+| 🧹    | Clean Workspace    | zero file dirty                        |
+| 🦴    | Unga Bunga         | gameplay ratio ≥ 60%                   |
+| ⚠️    | Docker Addict      | WARN: 5+/10 commit INFRA               |
+| 📜    | Wordy Committer    | WARN: 3+ messaggi >80 char             |
+
+## Architettura
+
+```
+evo-caveman/
+├── pyproject.toml          # PEP 735 dependency-groups, ruff strict, mypy strict
+├── Makefile
+├── README.md
+├── CAVEMAN.md              # doc utente veloce
+├── DEEP_RESEARCH.md        # scoperte ricerca 2026
+├── smoke_test.py
+├── .github/workflows/caveman-ci.yml  # uv + matrix py3.12/3.13
+├── src/caveman/
+│   ├── __init__.py
+│   ├── __main__.py
+│   ├── repo.py             # snapshot repo via git (<100ms)
+│   ├── seeds.py            # 50+ seed contestualizzati, 5 categorie
+│   ├── engine.py           # decisione + throttling + persistenza
+│   ├── achievements.py     # ✨ NEW: 8 achievement da pattern commit
+│   └── cli.py              # Typer + Rich, 6 subcomandi
+└── tests/
+    ├── test_repo.py
+    └── test_engine.py
+```
+
+## Performance
+
+- Snapshot completo: ~50-100ms su repo tipico
+- `frozen dataclass + slots=True` per dati immutabili
+- `@functools.cache` su metriche derivate
+- Hook post-commit early-exits in <10ms se non serve parlare
+
+## Dev
+
+```bash
+make check   # lint + type + test
+make test
+make lint
+make fmt
+make type
+```
+
+CI GitHub Actions gira su ogni push: ruff + ruff format + mypy + pytest su Python 3.12 e 3.13, più un job "dogfooding" che fa girare `caveman status` sul repo stesso.
+
+## Confronto con tool simili
+
+Dal deep research (aprile 2026):
+
+- **GitMood** — sentiment analysis sui commit, achievements. Stesso spirito, ma il caveman è ancorato a game design, non a emozioni.
+- **DocWeave** — genera doc da commit. Scope diverso.
+- **git-commits-analysis / commits-analyzer** — produttività pura, dashboard. Noi siamo più "compagno di lavoro" che dashboard.
+- **prek** (hook manager 2026 in Rust) — alternativa a pre-commit. Caveman può convivere: caveman è un post-commit hook singolo, prek è il gestore globale.
+
+## Filosofia
+
+> 🪨 _caveman non finire gioco. caveman finire turno. domani, altro turno. piano piano, gioco diventare vivo._
+
+Vedi `CAVEMAN.md` per il mantra completo e le 3 domande da farsi ogni venerdì.
+
+## Licenza
+
+MIT.

--- a/evo-caveman/pyproject.toml
+++ b/evo-caveman/pyproject.toml
@@ -1,0 +1,113 @@
+[project]
+name = "evo-caveman"
+version = "0.2.0"
+description = "🦴 Caveman companion per il repo Evo-Tactics — git-driven, context-aware, scope-creep repellent."
+readme = "README.md"
+requires-python = ">=3.12"
+license = { text = "MIT" }
+authors = [{ name = "Master", email = "master@evo-tactics.local" }]
+keywords = ["gamedev", "cli", "evo-tactics", "caveman", "scope-creep", "indie-game", "dev-companion"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Games/Entertainment",
+    "Topic :: Software Development :: Version Control :: Git",
+]
+dependencies = [
+    "typer>=0.15.0",
+    "rich>=13.9.0",
+]
+
+[project.optional-dependencies]
+remote = ["httpx>=0.28.0"]
+
+# 2026 standard: dependency-groups (PEP 735)
+[dependency-groups]
+dev = [
+    "pytest>=8.3.0",
+    "pytest-cov>=6.0.0",
+    "ruff>=0.8.0",
+    "mypy>=1.13.0",
+]
+
+[project.scripts]
+caveman = "caveman.cli:app"
+
+[project.urls]
+Homepage = "https://github.com/MasterDD-L34D/Game"
+Documentation = "https://github.com/MasterDD-L34D/Game/tree/main/evo-caveman"
+Issues = "https://github.com/MasterDD-L34D/Game/issues"
+
+[build-system]
+requires = ["hatchling>=1.27"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/caveman"]
+
+[tool.uv]
+required-version = ">=0.5.0"
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+src = ["src", "tests"]
+extend-exclude = ["__pycache__", ".venv", "build", "dist"]
+
+[tool.ruff.lint]
+select = [
+    "E", "W", "F", "I", "B", "UP", "SIM", "RUF", "PERF",
+    "PL", "C4", "PTH", "RET", "TRY", "N",
+]
+ignore = [
+    "PLR0913",
+    "TRY003",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["PLR2004"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+docstring-code-format = true
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+disallow_any_generics = true
+check_untyped_defs = true
+no_implicit_reexport = true
+show_error_codes = true
+
+[[tool.mypy.overrides]]
+module = ["tests.*"]
+disallow_untyped_defs = false
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+addopts = [
+    "-ra",
+    "--strict-markers",
+    "--cov=caveman",
+    "--cov-report=term-missing",
+]
+testpaths = ["tests"]
+
+[tool.coverage.run]
+source = ["src/caveman"]
+branch = true
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+]

--- a/evo-caveman/smoke_test.py
+++ b/evo-caveman/smoke_test.py
@@ -1,0 +1,128 @@
+"""Smoke test standalone: simula un repo vero e verifica tutta la pipeline v0.2."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Aggiungo src al path senza installare il pacchetto
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+
+from caveman.achievements import compute_achievements
+from caveman.engine import decide_category, generate, should_speak
+from caveman.repo import snapshot
+from caveman.seeds import Category
+
+
+def make_fake_repo(path: Path, commits: list[tuple[str, str, str]]) -> None:
+    """Crea un repo git con commit simulati. commits = [(message, filepath, content), ...]"""
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.t"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=path, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=path, check=True)
+
+    for msg, filepath, content in commits:
+        fp = path / filepath
+        fp.parent.mkdir(parents=True, exist_ok=True)
+        fp.write_text(content)
+        subprocess.run(["git", "add", "."], cwd=path, check=True)
+        subprocess.run(["git", "commit", "-qm", msg], cwd=path, check=True)
+
+
+def test_scenario(name: str, commits: list[tuple[str, str, str]], extra_dirty: list[str] | None = None) -> None:
+    print(f"\n{'=' * 70}")
+    print(f"SCENARIO: {name}")
+    print("=" * 70)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        make_fake_repo(repo, commits)
+
+        # Aggiungi file dirty senza committarli
+        if extra_dirty:
+            for f in extra_dirty:
+                (repo / f).parent.mkdir(parents=True, exist_ok=True)
+                (repo / f).write_text("dirty")
+
+        snap = snapshot(repo)
+        print(f"Commits trovati: {len(snap.recent_commits)}")
+        for c in snap.recent_commits:
+            print(f"  [{c.kind:>9}] {c.sha} {c.message}")
+        print(f"Gameplay ratio: {snap.gameplay_ratio():.0%}")
+        print(f"INFRA consecutivi: {snap.consecutive_infra_commits()}")
+        print(f"In deriva? {snap.is_drifting()}")
+        print(f"Pilastri: {sorted(snap.pillar_dirs)}")
+        print(f"Dirty files: {snap.dirty_files}")
+
+        # Test should_speak (senza throttle, siamo in test)
+        speak, reason = should_speak(snap, respect_throttle=False)
+        print(f"\nshould_speak: {speak} — {reason}")
+
+        # Test generate
+        cat = decide_category(snap)
+        print(f"Categoria scelta: {cat.value}")
+
+        out = generate(snap, seed=42)
+        print(f"\n>>> OUTPUT CAVEMAN:")
+        print(f"    {out.render_plain()}")
+        print(f"    (categoria: {out.category.value}, ~{out.minutes} min, seed_id: {out.seed_id})")
+
+        # Achievements
+        achs = compute_achievements(snap)
+        if achs:
+            print(f"\n>>> ACHIEVEMENTS:")
+            for a in achs:
+                status = "✓" if a.unlocked else "⚠"
+                print(f"    {status} {a.emoji} {a.title}")
+
+
+# SCENARIO 1: repo in deriva (troppi INFRA)
+test_scenario(
+    "Repo in deriva — 6 INFRA di fila",
+    [
+        ("add trait fire", "traits/fire.yaml", "name: fire\n"),
+        ("init docker", "Dockerfile", "FROM python\n"),
+        ("ci setup", ".github/workflows/ci.yml", "name: CI\n"),
+        ("prisma migration", "prisma/schema.prisma", "model X {}\n"),
+        ("docker compose", "docker-compose.yml", "version: 3\n"),
+        ("fix ci permissions", ".github/workflows/ci.yml", "name: CI fixed\n"),
+        ("add deploy script", "scripts/deploy.sh", "#!/bin/bash\n"),
+    ],
+)
+
+# SCENARIO 2: appena chiuso un commit gameplay
+test_scenario(
+    "Fresh gameplay commit",
+    [
+        ("refactor auth", "src/auth.py", "x = 1\n"),
+        ("update readme", "README.md", "# Game\n"),
+        ("add species wolf", "species/wolf.yaml", "name: wolf\n"),
+    ],
+)
+
+# SCENARIO 3: WIP selvaggio (molti dirty)
+test_scenario(
+    "WIP selvaggio — molti file dirty",
+    [
+        ("initial", "README.md", "# game\n"),
+    ],
+    extra_dirty=["a.py", "b.py", "c.py", "d.py", "e.py", "f.py"],
+)
+
+# SCENARIO 4: repo sano
+test_scenario(
+    "Repo sano — mix bilanciato",
+    [
+        ("add trait ice", "traits/ice.yaml", "name: ice\n"),
+        ("add job warrior", "jobs/warrior.yaml", "name: warrior\n"),
+        ("fix ci", ".github/workflows/ci.yml", "v: 1\n"),
+        ("add biome forest", "biomes/forest.yaml", "name: forest\n"),
+        ("species cat", "species/cat.yaml", "name: cat\n"),
+    ],
+)
+
+print(f"\n{'=' * 70}")
+print("✓ Tutti gli scenari girati senza errori.")
+print("=" * 70)

--- a/evo-caveman/src/caveman/__init__.py
+++ b/evo-caveman/src/caveman/__init__.py
@@ -1,0 +1,6 @@
+"""🦴 evo-caveman: companion CLI per il repo Evo-Tactics."""
+
+from __future__ import annotations
+
+__version__ = "0.2.0"
+__all__ = ["__version__"]

--- a/evo-caveman/src/caveman/__main__.py
+++ b/evo-caveman/src/caveman/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point per `python -m caveman`."""
+
+from __future__ import annotations
+
+from .cli import app
+
+if __name__ == "__main__":
+    app()

--- a/evo-caveman/src/caveman/achievements.py
+++ b/evo-caveman/src/caveman/achievements.py
@@ -1,0 +1,123 @@
+"""Achievements: unlocked dall'analisi dei pattern di commit.
+
+Ispirato al pattern GitMood (devchallenge 2026) ma ancorato a obiettivi di
+game design, non a sentiment analysis. Achievements celebrano i comportamenti
+virtuosi (gameplay-first, cut darlings, shipping) e segnalano anti-pattern.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from .repo import RepoSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class Achievement:
+    emoji: str
+    title: str
+    description: str
+    unlocked: bool = True
+
+
+def compute_achievements(snap: RepoSnapshot) -> list[Achievement]:
+    """Calcola achievement basandosi sullo stato del repo."""
+    if not snap.recent_commits:
+        return []
+
+    achievements: list[Achievement] = []
+
+    # 🎯 Game-First Striker — ultimi 3 commit sono tutti GAMEPLAY
+    if len(snap.recent_commits) >= 3 and all(c.is_gameplay for c in snap.recent_commits[:3]):
+        achievements.append(Achievement(
+            emoji="🎯",
+            title="Game-First Striker",
+            description="3 commit GAMEPLAY di fila. core è il focus.",
+        ))
+
+    # ✂️ Ruthless Cutter — commit con "remove" / "delete" / "cut" / "clean"
+    cut_keywords = ("remove", "delete", "cut", "clean", "rimuov", "cancell", "elimin")
+    cuts = sum(1 for c in snap.recent_commits if any(k in c.message.lower() for k in cut_keywords))
+    if cuts >= 2:
+        achievements.append(Achievement(
+            emoji="✂️",
+            title="Ruthless Cutter",
+            description=f"{cuts} commit di pulizia. caveman fiero.",
+        ))
+
+    # 🏔️ Pillar Diversifier — commit su 3+ pilastri diversi tra gli ultimi 5
+    pillar_dirs_hit: set[str] = set()
+    for c in snap.recent_commits[:5]:
+        for f in c.files:
+            for pillar in ("traits", "biomes", "rules", "jobs", "species"):
+                if f.startswith(pillar + "/"):
+                    pillar_dirs_hit.add(pillar)
+    if len(pillar_dirs_hit) >= 3:
+        achievements.append(Achievement(
+            emoji="🏔️",
+            title="Pillar Diversifier",
+            description=f"{len(pillar_dirs_hit)} pilastri diversi toccati. equilibrio buono.",
+        ))
+
+    # 🔁 Docker Addict (anti-achievement, warning) — 5+ INFRA nelle ultime 10
+    infra_count = sum(1 for c in snap.recent_commits if c.kind == "INFRA")
+    if infra_count >= 5:
+        achievements.append(Achievement(
+            emoji="⚠️",
+            title="Docker Addict",
+            description=f"{infra_count}/10 commit INFRA. il gioco ti aspetta.",
+            unlocked=False,  # è un warning, non una celebrazione
+        ))
+
+    # 📜 Wordy Committer — messaggi lunghi >80 char
+    long_msgs = sum(1 for c in snap.recent_commits if len(c.message) > 80)
+    if long_msgs >= 3:
+        achievements.append(Achievement(
+            emoji="📜",
+            title="Wordy Committer",
+            description=f"{long_msgs} messaggi >80 char. caveman dire: messaggio corto, pensiero chiaro.",
+            unlocked=False,
+        ))
+
+    # 🌱 Fresh Breath — 1° commit GAMEPLAY dopo 3+ INFRA di fila (rottura della deriva)
+    if len(snap.recent_commits) >= 4:
+        last = snap.recent_commits[0]
+        others = snap.recent_commits[1:4]
+        if last.is_gameplay and all(c.kind == "INFRA" for c in others):
+            achievements.append(Achievement(
+                emoji="🌱",
+                title="Fresh Breath",
+                description="hai rotto una streak INFRA con un commit GAMEPLAY. caveman applaude.",
+            ))
+
+    # 🧹 Clean Workspace — zero file dirty
+    if not snap.dirty_files and snap.recent_commits:
+        achievements.append(Achievement(
+            emoji="🧹",
+            title="Clean Workspace",
+            description="zero WIP. niente distrae dal prossimo turno.",
+        ))
+
+    # 🦴 Unga Bunga — gameplay_ratio >= 60%
+    if snap.gameplay_ratio() >= 0.6:
+        achievements.append(Achievement(
+            emoji="🦴",
+            title="Unga Bunga",
+            description=f"{snap.gameplay_ratio():.0%} gameplay ratio. caveman felice felice.",
+        ))
+
+    return achievements
+
+
+# Lista di achievement potenziali (per `caveman achievements --all`)
+ALL_ACHIEVEMENTS: Final[tuple[dict[str, str], ...]] = (
+    {"emoji": "🎯", "title": "Game-First Striker", "how": "3 commit GAMEPLAY di fila"},
+    {"emoji": "✂️", "title": "Ruthless Cutter", "how": "2+ commit di rimozione negli ultimi 10"},
+    {"emoji": "🏔️", "title": "Pillar Diversifier", "how": "3+ pilastri toccati negli ultimi 5 commit"},
+    {"emoji": "🌱", "title": "Fresh Breath", "how": "1° GAMEPLAY dopo 3+ INFRA di fila"},
+    {"emoji": "🧹", "title": "Clean Workspace", "how": "zero file dirty"},
+    {"emoji": "🦴", "title": "Unga Bunga", "how": "gameplay ratio >= 60%"},
+    {"emoji": "⚠️", "title": "Docker Addict", "how": "WARN: 5+/10 commit INFRA"},
+    {"emoji": "📜", "title": "Wordy Committer", "how": "WARN: 3+ messaggi >80 char"},
+)

--- a/evo-caveman/src/caveman/cli.py
+++ b/evo-caveman/src/caveman/cli.py
@@ -1,0 +1,337 @@
+"""CLI caveman — Typer + Rich."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from . import __version__
+from .achievements import ALL_ACHIEVEMENTS, compute_achievements
+from .engine import generate, mark_spoke, should_speak
+from .repo import snapshot
+from .seeds import Category
+
+app = typer.Typer(
+    name="caveman",
+    help="🦴 Caveman companion per il repo Evo-Tactics.",
+    no_args_is_help=False,
+    rich_markup_mode="rich",
+    add_completion=True,
+)
+
+console = Console(stderr=False)
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        console.print(f"🦴 evo-caveman v{__version__}")
+        raise typer.Exit
+
+
+@app.callback(invoke_without_command=True)
+def main(
+    ctx: typer.Context,
+    version: Annotated[
+        bool,
+        typer.Option("--version", "-V", callback=_version_callback, is_eager=True, help="Mostra versione."),
+    ] = False,
+) -> None:
+    """Se invocato senza subcomando, chiama `speak` di default."""
+    if ctx.invoked_subcommand is None:
+        speak()
+
+
+@app.command()
+def speak(
+    repo: Annotated[
+        Path,
+        typer.Option("--repo", "-r", help="Root del repo (default: cwd)."),
+    ] = Path("."),
+    category: Annotated[
+        Category | None,
+        typer.Option("--category", "-c", help="Forza categoria specifica."),
+    ] = None,
+    seed: Annotated[
+        int | None,
+        typer.Option("--seed", "-s", help="Seed random per output riproducibile."),
+    ] = None,
+    plain: Annotated[
+        bool,
+        typer.Option("--plain", help="Output testo semplice, niente colori/box."),
+    ] = False,
+) -> None:
+    """🦴 Fa parlare il caveman in base allo stato del repo."""
+    snap = snapshot(repo.resolve())
+    output = generate(snap, force_category=category, seed=seed)
+
+    if plain:
+        print(output.render_plain())
+        return
+
+    # Rich panel
+    body = Text()
+    body.append(output.opening + ": ", style="bold italic yellow")
+    body.append(output.body, style="italic")
+    body.append("  " + output.closer, style="italic dim")
+
+    panel = Panel(
+        body,
+        title=f"{output.emoji} caveman — {output.category.value} · ~{output.minutes} min",
+        border_style="bright_yellow",
+        padding=(0, 1),
+    )
+    console.print(panel)
+
+
+@app.command()
+def check(
+    repo: Annotated[Path, typer.Option("--repo", "-r")] = Path("."),
+    force: Annotated[bool, typer.Option("--force", help="Ignora il throttling.")] = False,
+) -> None:
+    """🔍 Decide se il caveman DEBBA parlare adesso (per hook). Exit 0 = parla, 1 = zitto."""
+    snap = snapshot(repo.resolve())
+    speak_now, reason = should_speak(snap, respect_throttle=not force)
+
+    console.print(f"[dim]{reason}[/dim]")
+    if speak_now:
+        console.print()
+        output = generate(snap)
+        body = Text()
+        body.append(output.opening + ": ", style="bold italic yellow")
+        body.append(output.body, style="italic")
+        body.append("  " + output.closer, style="italic dim")
+        console.print(
+            Panel(
+                body,
+                title=f"{output.emoji} caveman — {output.category.value} · ~{output.minutes} min",
+                border_style="bright_yellow",
+                padding=(0, 1),
+            )
+        )
+        mark_spoke(snap.root)
+        raise typer.Exit(0)
+    raise typer.Exit(1)
+
+
+@app.command()
+def status(
+    repo: Annotated[Path, typer.Option("--repo", "-r")] = Path("."),
+) -> None:
+    """📊 Mostra la lettura del repo dal punto di vista del caveman."""
+    snap = snapshot(repo.resolve())
+
+    if not snap.recent_commits:
+        console.print("[red]Nessun commit trovato (o non è un repo git).[/red]")
+        raise typer.Exit(1)
+
+    # Tabella commit
+    table = Table(title="🦴 Repo status (ultimi commit)", show_lines=False)
+    table.add_column("SHA", style="dim", no_wrap=True)
+    table.add_column("Tipo", style="bold")
+    table.add_column("Messaggio")
+
+    kind_colors = {
+        "GAMEPLAY": "green",
+        "INFRA": "red",
+        "TOOLING": "yellow",
+        "DOCS": "blue",
+        "DATA": "cyan",
+        "ALTRO": "white",
+    }
+    for c in snap.recent_commits:
+        color = kind_colors.get(c.kind, "white")
+        table.add_row(c.sha, f"[{color}]{c.kind}[/{color}]", c.message[:60])
+
+    console.print(table)
+    console.print()
+
+    # Metriche
+    gp = snap.gameplay_ratio()
+    infra_chain = snap.consecutive_infra_commits()
+    drifting = snap.is_drifting()
+
+    drift_style = "red bold" if drifting else "green"
+    drift_text = "IN DERIVA 🚨" if drifting else "sulla rotta ✅"
+
+    console.print(f"  Gameplay ratio: [bold]{gp:.0%}[/bold]")
+    console.print(f"  INFRA consecutivi: [bold]{infra_chain}[/bold]")
+    console.print(f"  Stato: [{drift_style}]{drift_text}[/{drift_style}]")
+    console.print(f"  Pilastri fisici: [cyan]{', '.join(sorted(snap.pillar_dirs)) or '(nessuno)'}[/cyan]")
+    console.print(f"  File dirty: [yellow]{len(snap.dirty_files)}[/yellow]")
+
+
+@app.command()
+def install_hook(
+    repo: Annotated[Path, typer.Option("--repo", "-r")] = Path("."),
+    force: Annotated[bool, typer.Option("--force", "-f", help="Sovrascrivi hook esistente.")] = False,
+) -> None:
+    """🔧 Installa il post-commit hook opzionale. Il caveman parlerà solo quando serve."""
+    repo_root = repo.resolve()
+    hook_dir = repo_root / ".git" / "hooks"
+
+    if not hook_dir.exists():
+        console.print(f"[red]Non trovo {hook_dir}. Sei sicuro che sia un repo git?[/red]")
+        raise typer.Exit(1)
+
+    hook_path = hook_dir / "post-commit"
+    if hook_path.exists() and not force:
+        console.print(f"[yellow]Hook già presente in {hook_path}. Usa --force per sovrascrivere.[/yellow]")
+        raise typer.Exit(1)
+
+    hook_content = """#!/usr/bin/env bash
+# 🦴 caveman post-commit hook — parla solo quando serve
+# Installato da: caveman install-hook
+# Per disinstallare: rm .git/hooks/post-commit
+
+if command -v caveman >/dev/null 2>&1; then
+    caveman check 2>/dev/null || true
+elif command -v python >/dev/null 2>&1 && python -c "import caveman" 2>/dev/null; then
+    python -m caveman check 2>/dev/null || true
+fi
+"""
+    hook_path.write_text(hook_content)
+    hook_path.chmod(0o755)
+    console.print(f"[green]✓[/green] Hook installato in {hook_path}")
+    console.print("  Il caveman parlerà solo quando il repo è in deriva o chiudi un commit GAMEPLAY.")
+    console.print("  Per disattivarlo: [dim]rm .git/hooks/post-commit[/dim]")
+
+
+@app.command()
+def uninstall_hook(
+    repo: Annotated[Path, typer.Option("--repo", "-r")] = Path("."),
+) -> None:
+    """🧹 Rimuovi il post-commit hook."""
+    hook_path = repo.resolve() / ".git" / "hooks" / "post-commit"
+    if not hook_path.exists():
+        console.print("[yellow]Nessun hook da rimuovere.[/yellow]")
+        raise typer.Exit
+    hook_path.unlink()
+    console.print(f"[green]✓[/green] Hook rimosso da {hook_path}")
+
+
+@app.command()
+def achievements(
+    repo: Annotated[Path, typer.Option("--repo", "-r")] = Path("."),
+    show_all: Annotated[bool, typer.Option("--all", help="Mostra tutti gli achievement possibili.")] = False,
+) -> None:
+    """🏆 Mostra achievement sbloccati dai pattern di commit del repo."""
+    if show_all:
+        console.print("[bold]Tutti gli achievement possibili:[/bold]\n")
+        table = Table(show_lines=False)
+        table.add_column("Emoji", width=4)
+        table.add_column("Titolo", style="bold")
+        table.add_column("Condizione")
+        for a in ALL_ACHIEVEMENTS:
+            table.add_row(a["emoji"], a["title"], a["how"])
+        console.print(table)
+        return
+
+    snap = snapshot(repo.resolve())
+    achs = compute_achievements(snap)
+
+    if not achs:
+        console.print("[dim]Nessun achievement sbloccato ancora. Fai commit di gameplay![/dim]")
+        return
+
+    console.print("[bold]🏆 Achievements sbloccati:[/bold]\n")
+    for a in achs:
+        color = "green" if a.unlocked else "yellow"
+        status = "✓" if a.unlocked else "⚠"
+        console.print(f"  [{color}]{status}[/{color}] {a.emoji}  [bold]{a.title}[/bold]")
+        console.print(f"      [dim]{a.description}[/dim]")
+
+
+@app.command()
+def export(
+    output: Annotated[
+        Path | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Destinazione JSON (default: docs/caveman-status.json).",
+        ),
+    ] = None,
+) -> None:
+    """Esporta stato corrente + metriche in JSON (per skill evo-tactics).
+
+    RESEARCH_TODO S4: produce file committabile con snapshot, achievements,
+    ultimo spoke, metriche aggregate (gameplay_ratio, drift flags).
+
+    Il file è letto dalla skill `evo-tactics-monitor` prima di fare web fetch,
+    per briefing offline più accurati.
+    """
+    import json
+    from datetime import datetime, timezone
+
+    repo_root = Path.cwd()
+    snap = snapshot(repo_root)
+    achs = compute_achievements(snap)
+
+    last_spoke_path = repo_root / ".git" / "caveman_last_spoke"
+    last_spoke = None
+    if last_spoke_path.exists():
+        try:
+            last_spoke = float(last_spoke_path.read_text().strip())
+        except (ValueError, OSError):
+            last_spoke = None
+
+    payload = {
+        "_meta": {
+            "generator": "evo-caveman export",
+            "version": __version__,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "repo_root": str(repo_root),
+        },
+        "snapshot": {
+            "dirty_files_count": len(snap.dirty_files),
+            "recent_commits_count": len(snap.recent_commits),
+            "gameplay_ratio": snap.gameplay_ratio(),
+            "consecutive_infra_commits": snap.consecutive_infra_commits(),
+            "is_drifting": snap.is_drifting(),
+            "recent_commits": [
+                {
+                    "sha": c.sha[:8],
+                    "kind": c.kind,
+                    "message_first_line": c.message.splitlines()[0] if c.message else "",
+                    "files_count": len(c.files),
+                }
+                for c in snap.recent_commits
+            ],
+        },
+        "achievements": {
+            "unlocked_count": sum(1 for a in achs if a.unlocked),
+            "total_count": len(achs),
+            "items": [
+                {
+                    "id": a.id,
+                    "title": a.title,
+                    "emoji": a.emoji,
+                    "unlocked": a.unlocked,
+                    "description": a.description,
+                }
+                for a in achs
+            ],
+        },
+        "last_spoke_unix": last_spoke,
+    }
+
+    dest = output or (repo_root / "docs" / "caveman-status.json")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    console.print(f"[green]✓[/green] Esportato stato caveman in [bold]{dest}[/bold]")
+    console.print(
+        f"  commits={len(snap.recent_commits)} gameplay_ratio={snap.gameplay_ratio():.0%} "
+        f"drift={'YES' if snap.is_drifting() else 'no'} "
+        f"achievements={sum(1 for a in achs if a.unlocked)}/{len(achs)}"
+    )
+
+
+if __name__ == "__main__":
+    app()

--- a/evo-caveman/src/caveman/engine.py
+++ b/evo-caveman/src/caveman/engine.py
@@ -1,0 +1,224 @@
+"""Motore caveman: decide QUALE categoria usare in base al contesto e rende output."""
+
+from __future__ import annotations
+
+import json
+import random
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+from .repo import RepoSnapshot
+from .seeds import ALL_SEEDS, Category, Seed, pick_seed
+
+# Emoji a rotazione
+_EMOJIS: Final[tuple[str, ...]] = ("🦴", "🪨", "🔥")
+
+# Aperture caveman (italiano rotto, brevissime)
+_OPENINGS: Final[tuple[str, ...]] = (
+    "caveman guardare repo",
+    "ugh, caveman pensare",
+    "caveman rosicchiare osso mentre dire",
+    "caveman contento, ma",
+    "caveman battere pietra e poi",
+    "unga bunga, caveman vedere che",
+    "caveman annusare aria",
+)
+
+_CLOSERS: Final[tuple[str, ...]] = (
+    "unga.",
+    "ugh bunga.",
+    "poi continuare battere pietra.",
+    "caveman crede in te.",
+    "piccolo passo, grande fuoco.",
+    "poi tornare a scavare.",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CavemanOutput:
+    emoji: str
+    opening: str
+    body: str
+    closer: str
+    category: Category
+    seed_id: int
+    minutes: int
+
+    def render_plain(self) -> str:
+        """Output testuale semplice (per hook git, no colori)."""
+        return f"{self.emoji} {self.opening}: {self.body} {self.closer}"
+
+    def render_markdown(self) -> str:
+        """Output markdown italicizzato (per chat / docs)."""
+        return f"{self.emoji} *{self.opening}: {self.body} {self.closer}*"
+
+
+# ---------- Decisione categoria ----------
+
+
+def decide_category(snap: RepoSnapshot, *, force: Category | None = None) -> Category:
+    """Scegli la categoria giusta in base al contesto del repo.
+
+    Regole:
+    - Se il repo è in deriva (troppi INFRA di fila, poco gameplay) → DESIGN_HINT per schiaffare
+    - Se l'utente ha appena finito qualcosa (ultimo commit GAMEPLAY) → MICRO_SPRINT prossimo passo
+    - Se molti file dirty non committati → MICRO_SPRINT (ridurre WIP)
+    - Altrimenti → scelta ponderata con varietà (MICRO_SPRINT > TWIST > MINI_GAME > HINT)
+    """
+    if force is not None:
+        return force
+
+    # PRIORITÀ 1: troppi file dirty → serve sprint di pulizia (non predica)
+    if len(snap.dirty_files) >= 5:
+        return Category.MICRO_SPRINT
+
+    # PRIORITÀ 2: repo in deriva → schiaffo di design
+    if snap.is_drifting():
+        return Category.DESIGN_HINT
+
+    # PRIORITÀ 3: troppi commit consecutivi (>= 6) senza SCOPE_CHECK → tempo di ripasso
+    if len(snap.recent_commits) >= 6 and random.random() < 0.3:
+        return Category.SCOPE_CHECK
+
+    # PRIORITÀ 4: appena chiuso gameplay → prossimo micro-sprint
+    if snap.recent_commits and snap.recent_commits[0].is_gameplay:
+        return Category.MICRO_SPRINT
+
+    # Default: pesata, ma randomica per varietà
+    weights = {
+        Category.MICRO_SPRINT: 0.35,
+        Category.EVO_TWIST: 0.20,
+        Category.MINI_GAME: 0.18,
+        Category.DESIGN_HINT: 0.15,
+        Category.SCOPE_CHECK: 0.12,  # NEW v0.2
+    }
+    r = random.random()
+    acc = 0.0
+    for cat, w in weights.items():
+        acc += w
+        if r <= acc:
+            return cat
+    return Category.MICRO_SPRINT  # fallback
+
+
+# ---------- Memoria seed usati (anti-ripetizione tra invocazioni) ----------
+
+
+def _state_file(repo_root: Path) -> Path:
+    return repo_root / ".git" / "caveman_state.json"
+
+
+def _load_used_seeds(repo_root: Path) -> dict[str, list[int]]:
+    f = _state_file(repo_root)
+    if not f.exists():
+        return {}
+    try:
+        return json.loads(f.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_used_seeds(repo_root: Path, state: dict[str, list[int]]) -> None:
+    f = _state_file(repo_root)
+    try:
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(json.dumps(state))
+    except OSError:
+        pass  # non-fatale
+
+
+_MAX_REMEMBERED: Final[int] = 8  # ricordiamo solo gli ultimi N per categoria
+_HOOK_THROTTLE_MINUTES: Final[int] = 90  # hook non parla più di 1 volta ogni N minuti
+
+
+# ---------- API principale ----------
+
+
+def generate(
+    snap: RepoSnapshot,
+    *,
+    force_category: Category | None = None,
+    seed: int | None = None,
+) -> CavemanOutput:
+    """Genera un blocco caveman completo dallo stato del repo."""
+    rng = random.Random(seed)
+    category = decide_category(snap, force=force_category)
+
+    # Recupera seed già usati per evitare ripetizioni
+    used = _load_used_seeds(snap.root)
+    exclude = frozenset(used.get(category.value, []))
+
+    chosen_seed, seed_id = pick_seed(category, snap, exclude_ids=exclude, rng=rng)
+
+    # Aggiorna memoria (mantieni solo ultimi N)
+    history = used.get(category.value, [])
+    history = [*history, seed_id][-_MAX_REMEMBERED:]
+    used[category.value] = history
+    _save_used_seeds(snap.root, used)
+
+    # Componi
+    emoji = rng.choice(_EMOJIS)
+    opening = rng.choice(_OPENINGS)
+    closer = rng.choice(_CLOSERS)
+    body = chosen_seed.render(snap)
+
+    return CavemanOutput(
+        emoji=emoji,
+        opening=opening,
+        body=body,
+        closer=closer,
+        category=category,
+        seed_id=seed_id,
+        minutes=chosen_seed.minutes,
+    )
+
+
+def should_speak(snap: RepoSnapshot, *, respect_throttle: bool = True) -> tuple[bool, str]:
+    """Decide se il caveman DEBBA parlare (usato dal post-commit hook).
+
+    Ritorna (parla?, motivo). Il caveman parla solo quando serve davvero.
+    Se `respect_throttle=True`, rispetta l'ultima volta che ha parlato (default per hook).
+    """
+    if not snap.recent_commits:
+        return False, "nessun commit ancora"
+
+    # Throttling: non parlare se ha parlato da poco (solo per hook automatico)
+    if respect_throttle:
+        last_spoke = _load_last_spoke(snap.root)
+        if last_spoke is not None:
+            elapsed_min = (time.time() - last_spoke) / 60
+            if elapsed_min < _HOOK_THROTTLE_MINUTES:
+                return False, f"caveman ha appena parlato ({elapsed_min:.0f} min fa, throttle={_HOOK_THROTTLE_MINUTES}min)"
+
+    if snap.is_drifting():
+        return True, f"deriva rilevata: {snap.gameplay_ratio():.0%} gameplay / {snap.consecutive_infra_commits()} INFRA consecutivi"
+    last = snap.recent_commits[0]
+    if last.kind == "GAMEPLAY":
+        return True, "commit GAMEPLAY → celebrare + prossimo sprint"
+    return False, "commit di routine, caveman sta zitto"
+
+
+def _last_spoke_file(repo_root: Path) -> Path:
+    return repo_root / ".git" / "caveman_last_spoke"
+
+
+def _load_last_spoke(repo_root: Path) -> float | None:
+    f = _last_spoke_file(repo_root)
+    if not f.exists():
+        return None
+    try:
+        return float(f.read_text().strip())
+    except (ValueError, OSError):
+        return None
+
+
+def mark_spoke(repo_root: Path) -> None:
+    """Registra che il caveman ha parlato ora (per throttling)."""
+    f = _last_spoke_file(repo_root)
+    try:
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(str(time.time()))
+    except OSError:
+        pass

--- a/evo-caveman/src/caveman/repo.py
+++ b/evo-caveman/src/caveman/repo.py
@@ -1,0 +1,160 @@
+"""Lettura stato repo Evo-Tactics — veloce, solo stdlib + subprocess."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from functools import cache
+from pathlib import Path
+from typing import Final, Literal
+
+# ---------- Tipi ----------
+
+CommitKind = Literal["GAMEPLAY", "INFRA", "TOOLING", "DOCS", "DATA", "ALTRO"]
+
+# Mapping path/parola-chiave → categoria, in ordine di priorità.
+# Tuple di (pattern, categoria). Match se QUALSIASI pattern appare nel messaggio
+# o nei file toccati del commit (lowercase).
+_COMMIT_PATTERNS: Final[tuple[tuple[tuple[str, ...], CommitKind], ...]] = (
+    # GAMEPLAY ha priorità: se un commit tocca traits/ anche solo di striscio, conta.
+    (("traits/", "biomes/", "rules/", "jobs/", "species/", "engine/game", "combat", "turn"), "GAMEPLAY"),
+    (("data/", "datasets/", "yaml", "schema"), "DATA"),
+    (("docker", "ci/", ".github/workflows", "prisma", "migration", "deploy", "compose"), "INFRA"),
+    (("cli/", "tools/", "validator", "dashboard", "analytics", "script"), "TOOLING"),
+    (("readme", "docs/", "changelog", "canvas", ".md"), "DOCS"),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Commit:
+    sha: str
+    message: str
+    files: tuple[str, ...]
+    kind: CommitKind
+
+    @property
+    def is_gameplay(self) -> bool:
+        return self.kind == "GAMEPLAY"
+
+
+@dataclass(frozen=True, slots=True)
+class RepoSnapshot:
+    """Snapshot istantaneo dello stato del repo per decisioni del caveman."""
+
+    root: Path
+    recent_commits: tuple[Commit, ...]
+    dirty_files: tuple[str, ...]  # file modificati non committati
+    pillar_dirs: frozenset[str] = field(default_factory=frozenset)
+
+    # --- Metriche derivate (cached) ---
+
+    @cache
+    def gameplay_ratio(self) -> float:
+        """Rapporto commit GAMEPLAY/totali negli ultimi N commit. 0.0 se nessuno."""
+        if not self.recent_commits:
+            return 0.0
+        gp = sum(1 for c in self.recent_commits if c.is_gameplay)
+        return gp / len(self.recent_commits)
+
+    @cache
+    def consecutive_infra_commits(self) -> int:
+        """Quanti commit INFRA di fila partendo dal più recente. Segnale di deriva."""
+        count = 0
+        for c in self.recent_commits:
+            if c.kind == "INFRA":
+                count += 1
+            else:
+                break
+        return count
+
+    @cache
+    def is_drifting(self) -> bool:
+        """Heuristica: repo in deriva se <20% gameplay negli ultimi 10 o 4+ INFRA di fila."""
+        return self.gameplay_ratio() < 0.2 or self.consecutive_infra_commits() >= 4
+
+
+# ---------- Lettura repo ----------
+
+
+def _run_git(args: list[str], cwd: Path) -> str:
+    """Esegue git in modo robusto. Ritorna stdout strippato, stringa vuota se fallisce."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return ""
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _classify_commit(message: str, files: tuple[str, ...]) -> CommitKind:
+    """Classifica un commit in base a messaggio + file toccati."""
+    haystack = (message + " " + " ".join(files)).lower()
+    for patterns, kind in _COMMIT_PATTERNS:
+        if any(p in haystack for p in patterns):
+            return kind
+    return "ALTRO"
+
+
+def _parse_log_output(raw: str) -> list[Commit]:
+    """Parser per git log con formato custom."""
+    if not raw:
+        return []
+    commits: list[Commit] = []
+    # Formato: %H%x00%s%x00<files>%x00%x00 (nullbyte-separated, double-null record separator)
+    for record in raw.split("\0\0"):
+        record = record.strip("\0\n")
+        if not record:
+            continue
+        parts = record.split("\0", 2)
+        if len(parts) < 2:
+            continue
+        sha, message = parts[0], parts[1]
+        files_raw = parts[2] if len(parts) > 2 else ""
+        files = tuple(f for f in files_raw.split("\n") if f)
+        commits.append(
+            Commit(sha=sha[:7], message=message, files=files, kind=_classify_commit(message, files))
+        )
+    return commits
+
+
+def snapshot(repo_root: Path, *, max_commits: int = 10) -> RepoSnapshot:
+    """Crea snapshot dello stato del repo. Operazione rapida (<100ms tipicamente)."""
+    repo_root = repo_root.resolve()
+
+    # Verifica che sia un repo git
+    if not (repo_root / ".git").exists():
+        return RepoSnapshot(root=repo_root, recent_commits=(), dirty_files=())
+
+    # Log degli ultimi N commit con file toccati
+    log_raw = _run_git(
+        [
+            "log",
+            f"-{max_commits}",
+            "--name-only",
+            "--pretty=format:%H%x00%s%x00",
+            "-z",  # null-termination
+        ],
+        cwd=repo_root,
+    )
+    commits = _parse_log_output(log_raw)
+
+    # File dirty (non committati)
+    dirty_raw = _run_git(["status", "--porcelain"], cwd=repo_root)
+    dirty = tuple(line[3:] for line in dirty_raw.splitlines() if line)
+
+    # Quali "pilastri fisici" (cartelle chiave) esistono nel repo
+    candidates = ("traits", "biomes", "rules", "jobs", "species", "engine", "data", "docs")
+    pillars = frozenset(d for d in candidates if (repo_root / d).is_dir())
+
+    return RepoSnapshot(
+        root=repo_root,
+        recent_commits=tuple(commits),
+        dirty_files=dirty,
+        pillar_dirs=pillars,
+    )

--- a/evo-caveman/src/caveman/seeds.py
+++ b/evo-caveman/src/caveman/seeds.py
@@ -1,0 +1,229 @@
+"""Banca idee caveman — seed tipizzati ancorati a game design literature 2026.
+
+Ogni seed è:
+- Ancorato ai 6 pilastri di Evo-Tactics (GDD v0.1)
+- Contestualizzabile con dati veri dal RepoSnapshot
+- Ispirato a: MoSCoW, RICE, MVP-first, "cut your darlings", SPACE framework,
+  scope/future creep prevention
+
+Riferimenti deep search (aprile 2026):
+- Wayline.io: scope creep = silent killer indie dev
+- University XP: minimalist framework → MVP
+- Codecks / Saint-Exupéry: "finished = nothing left to take away"
+- GameDeveloper.com: "scope = choose a target, focus, shoot"
+- GitHub topic `git-analytics` / GitMood: sentiment + achievements sui commit
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import IntEnum, StrEnum
+from typing import Final
+
+from .repo import RepoSnapshot
+
+# ---------- Tipi ----------
+
+
+class Category(StrEnum):
+    MICRO_SPRINT = "micro_sprint"
+    DESIGN_HINT = "design_hint"
+    MINI_GAME = "mini_game"
+    EVO_TWIST = "evo_twist"
+    SCOPE_CHECK = "scope_check"  # NEW v0.2
+
+
+class Pillar(IntEnum):
+    """6 pilastri Evo-Tactics (GDD v0.1)."""
+
+    TACTICS_READABLE = 1
+    EVOLUTION_EMERGENT = 2
+    IDENTITY_DOUBLE = 3
+    TEMPERAMENTS = 4
+    COOP_VS_SYSTEM = 5
+    FAIRNESS = 6
+
+    @property
+    def short(self) -> str:
+        names = {
+            1: "tattica-leggibile",
+            2: "evoluzione-emergente",
+            3: "specie×job",
+            4: "temperamenti",
+            5: "co-op-vs-sistema",
+            6: "fairness",
+        }
+        return names[int(self)]
+
+
+@dataclass(frozen=True, slots=True)
+class Seed:
+    category: Category
+    pillar: Pillar | None
+    minutes: int
+    render: Callable[[RepoSnapshot], str]
+
+
+# ---------- Helper per render contestuale ----------
+
+
+def _largest_pillar_dir(snap: RepoSnapshot) -> str | None:
+    if not snap.pillar_dirs:
+        return None
+    counts = {d: sum(1 for _ in (snap.root / d).rglob("*") if _.is_file()) for d in snap.pillar_dirs}
+    if not counts:
+        return None
+    return max(counts, key=counts.__getitem__)
+
+
+def _last_infra_commit(snap: RepoSnapshot) -> str | None:
+    for c in snap.recent_commits:
+        if c.kind == "INFRA":
+            return c.message
+    return None
+
+
+# ---------- MICRO-SPRINT ----------
+
+MICRO_SPRINT_SEEDS: Final[tuple[Seed, ...]] = (
+    Seed(Category.MICRO_SPRINT, Pillar.TACTICS_READABLE, 10,
+         lambda s: f"cancella UN trait in `{_largest_pillar_dir(s) or 'traits'}/` che non toccare da 30+ giorni. meno roba = più gioco."),
+    Seed(Category.MICRO_SPRINT, Pillar.TACTICS_READABLE, 5,
+         lambda s: "apri un file di regole a caso. leggi ad alta voce in 30 secondi. se tu non capire te stesso, nuovo giocatore morire."),
+    Seed(Category.MICRO_SPRINT, Pillar.IDENTITY_DOUBLE, 15,
+         lambda s: "prendi UNA specie + UN job a caso. scrivi cosa fanno di unico INSIEME. se risposta uguale ad altri combo, combo morire."),
+    Seed(Category.MICRO_SPRINT, Pillar.FAIRNESS, 10,
+         lambda s: "trova UNA regola senza counter disclosure. aggiungi 1 riga che dice come batterla PRIMA che accada. unga."),
+    Seed(Category.MICRO_SPRINT, None, 5,
+         lambda s: f"hai {len(s.dirty_files)} file non committati. committa UNO solo adesso, 5 parole max. gli altri aspettare."
+         if s.dirty_files else "fai UN commit che cancella qualcosa. solo cancellare, niente aggiungere. 5 minuti."),
+    Seed(Category.MICRO_SPRINT, Pillar.EVOLUTION_EMERGENT, 12,
+         lambda s: "scrivi su post-it fisico UN comportamento che SE ripetuto 3 volte, evoluzione parte. attacca su monitor. domani vedere."),
+    Seed(Category.MICRO_SPRINT, Pillar.COOP_VS_SYSTEM, 10,
+         lambda s: "pensa: come il Sistema PERDE? scrivi 3 modi in 10 minuti. se tutti 3 uguali, Sistema troppo debole."),
+    # NEW v0.2 — cut your darlings + future creep
+    Seed(Category.MICRO_SPRINT, None, 10,
+         lambda s: "scegli la feature di cui sei più orgoglioso. immagina di TAGLIARLA. il gioco cadrebbe? se no, apri issue 'maybe kill'. 10 min."),
+    Seed(Category.MICRO_SPRINT, None, 8,
+         lambda s: "apri l'ultima issue che hai aperto tu stesso. se titolo usa 'magari', 'potrebbe', 'un giorno' → chiudila wontfix. future creep muore."),
+    Seed(Category.MICRO_SPRINT, Pillar.TACTICS_READABLE, 15,
+         lambda s: "prendi file di regole più lungo. DIMEZZALO. non riscrivere, tagliaci dentro. se ti manca, tornerà da solo. 15 min hard timer."),
+)
+
+
+# ---------- DESIGN HINT ----------
+
+DESIGN_HINT_SEEDS: Final[tuple[Seed, ...]] = (
+    Seed(Category.DESIGN_HINT, Pillar.TACTICS_READABLE, 2,
+         lambda s: "se bambino non capire turno in 30 secondi, turno rotto. non regole complesse, regole sbagliate."),
+    Seed(Category.DESIGN_HINT, Pillar.EVOLUTION_EMERGENT, 2,
+         lambda s: "evoluzione non essere skill tree. essere SORPRESA da uso ripetuto. se giocatore prevedere upgrade, non evoluzione, è shopping."),
+    Seed(Category.DESIGN_HINT, Pillar.IDENTITY_DOUBLE, 2,
+         lambda s: "specie dare COSA fare. job dare COME farlo. se uno ripetere l'altro, uno morire. tagliare subito."),
+    Seed(Category.DESIGN_HINT, Pillar.TEMPERAMENTS, 2,
+         lambda s: "temperamento non essere +2 STAT. essere TENTAZIONE durante turno. se giocatore non sentire pulsione, solo etichetta."),
+    Seed(Category.DESIGN_HINT, Pillar.COOP_VS_SYSTEM, 2,
+         lambda s: "Sistema deve poter vincere davvero. se impossibile, non cooperazione, puzzle con passi obbligati."),
+    Seed(Category.DESIGN_HINT, Pillar.FAIRNESS, 2,
+         lambda s: "counter visibile PRIMA della mossa nemica, non dopo. se giocatore sapere solo dopo, non tattica, lotteria."),
+    Seed(Category.DESIGN_HINT, None, 2,
+         lambda s: f"caveman guardare: ultimo commit INFRA dire «{last_infra}». ma quale pilastro servire? se tu non saper rispondere in 5 sec, infra troppo in anticipo."
+         if (last_infra := _last_infra_commit(s))
+         else "se stai per aggiungere feature: chiedi QUALE pilastro serve. no risposta = no aggiungere."),
+    # NEW v0.2
+    Seed(Category.DESIGN_HINT, None, 2,
+         lambda s: "Saint-Exupéry dire: perfezione non quando niente da aggiungere, ma quando niente da togliere. tu cosa togliere oggi?"),
+    Seed(Category.DESIGN_HINT, None, 2,
+         lambda s: "chess essere perfetto con regole poche. tu quante regole avere? se più di chess e non più divertente di chess, caveman preoccupato."),
+    Seed(Category.DESIGN_HINT, None, 3,
+         lambda s: f"{s.consecutive_infra_commits()} commit INFRA di fila. Docker verde + CI verde + game rosso = progetto morto. prossimo commit GAMEPLAY o caveman mordere."
+         if s.consecutive_infra_commits() >= 3
+         else "un gioco finito male batte un prototipo perfetto. ship > polish, sempre."),
+    Seed(Category.DESIGN_HINT, Pillar.TACTICS_READABLE, 2,
+         lambda s: "Undertale: grafica semplice, mondo piccolo, turni base. Toby Fox vincere perché tagliare tutto tranne core. tu che tagliare oggi?"),
+)
+
+
+# ---------- MINI-GAME ----------
+
+MINI_GAME_SEEDS: Final[tuple[Seed, ...]] = (
+    Seed(Category.MINI_GAME, None, 3, lambda s: "prendi 3 oggetti dalla scrivania. inventare 1 specie Evo-Tactics con ciascuno. 3 minuti. poi buttare le cattive."),
+    Seed(Category.MINI_GAME, None, 2, lambda s: "apri Spotify shuffle. prossimo titolo canzone = nome di nuovo trait. scrivi cosa fa in 2 righe."),
+    Seed(Category.MINI_GAME, None, 1, lambda s: "timer 60 secondi. elenca tutti i job che ti vengono. vince quantità, poi scegli 1 solo e tenere."),
+    Seed(Category.MINI_GAME, None, 2, lambda s: "guarda fuori dalla finestra. primo essere vivente che vedi = nuova specie. 3 trait in 2 minuti."),
+    Seed(Category.MINI_GAME, None, 3, lambda s: "apri un libro di casa a pagina a caso. prima parola = nome di bioma. descrivilo in 3 righe."),
+    Seed(Category.MINI_GAME, None, 3, lambda s: "tira 1d20 (o random.org). 1-5 movimento, 6-10 attacco, 11-15 difesa, 16-20 sociale. inventare quello uscito."),
+    Seed(Category.MINI_GAME, None, 2, lambda s: "spiega il gioco a qualcuno in casa in 60 secondi. se non riesci, problema è LÌ, non nel codice."),
+    Seed(Category.MINI_GAME, None, 5, lambda s: "cammina 5 minuti senza telefono. torna. scrivi 1 riga di cosa hai pensato. quella riga = design doc segreto."),
+    Seed(Category.MINI_GAME, None, 3, lambda s: "scegli la specie più debole. in 3 minuti, scrivi 1 scenario dove vince. se non esiste, specie da buttare."),
+    Seed(Category.MINI_GAME, None, 2, lambda s: "chiudi gli occhi. descrivi il gioco a voce come se fosse un film. 90 sec. se è noioso, lo è anche il gioco."),
+    # NEW v0.2
+    Seed(Category.MINI_GAME, None, 4, lambda s: "disegna su carta UNA unit di Evo-Tactics. solo linee. se amico capisce cos'è in 10 sec, icon game pronto."),
+    Seed(Category.MINI_GAME, None, 3, lambda s: "tira dado 3 volte: i 3 numeri = stat di una nuova specie. 3 minuti per trovarla interessante o buttarla."),
+    Seed(Category.MINI_GAME, None, 5, lambda s: "timer 5 minuti. scrivi senza fermarti: 'il mio gioco parla di...'. quello che esce = tua vera visione. non modificare."),
+    Seed(Category.MINI_GAME, None, 2, lambda s: "guarda ultima riga che hai scritto oggi nel repo. se la leggessi tra 6 mesi, capiresti? se no, annota in TODO. 2 min."),
+)
+
+
+# ---------- EVO-TACTICS TWIST ----------
+
+EVO_TWIST_SEEDS: Final[tuple[Seed, ...]] = (
+    Seed(Category.EVO_TWIST, Pillar.TACTICS_READABLE, 15, lambda s: "'Regola del 2': gioca con solo 2 specie e 2 job per 1 turno. se noioso, core debole. se divertente, tutto il resto sovrastruttura."),
+    Seed(Category.EVO_TWIST, Pillar.TACTICS_READABLE, 15, lambda s: "'Muto': gioca senza testo, solo icone. se non si capisce, leggibilità rotta."),
+    Seed(Category.EVO_TWIST, Pillar.FAIRNESS, 20, lambda s: "'Peggior combo': scegli specie+job più deboli. vedi se sistema li rende interessanti. se no, anti-snowball rotto."),
+    Seed(Category.EVO_TWIST, Pillar.TEMPERAMENTS, 15, lambda s: "'Solo temperamenti': ignora specie/job, gioca SOLO con MBTI. se non emerge gameplay, pilastro 4 solo decorativo."),
+    Seed(Category.EVO_TWIST, Pillar.COOP_VS_SYSTEM, 25, lambda s: "'Reverse': il Sistema vince se i giocatori arrivano alla fine. che succede? rivela priorità vere."),
+    Seed(Category.EVO_TWIST, Pillar.TACTICS_READABLE, 30, lambda s: "'Playtester fantasma': gioca fingendoti amico che non ha mai visto il gioco. annota ogni 'non capisco'. lista = roadmap vera."),
+    Seed(Category.EVO_TWIST, None, 20, lambda s: "'Carta e penna': stampa le regole, gioca a mano 10 minuti. se funziona, infra giustificata. se no, infra è fuga dal design."),
+    Seed(Category.EVO_TWIST, Pillar.EVOLUTION_EMERGENT, 20, lambda s: "'Speedrun evoluzione': sblocca un'evoluzione nel minor tempo. se troppo facile, non emergenza, checklist."),
+    # NEW v0.2
+    Seed(Category.EVO_TWIST, Pillar.TACTICS_READABLE, 10, lambda s: "'Turno blindato': timer 30 sec per turno. se stressa, UI troppo lenta. se facile, dimezza."),
+    Seed(Category.EVO_TWIST, None, 15, lambda s: "'Rimuovi UI': nascondi con post-it metà schermo. cosa non è essenziale? quello è il prossimo commit di pulizia."),
+    Seed(Category.EVO_TWIST, Pillar.EVOLUTION_EMERGENT, 30, lambda s: "'3 partite stessa build': 3a partita ancora interessante? se no, evoluzione non emerge, solo prima volta illusione."),
+)
+
+
+# ---------- SCOPE-CHECK (NEW v0.2) ----------
+
+SCOPE_CHECK_SEEDS: Final[tuple[Seed, ...]] = (
+    Seed(Category.SCOPE_CHECK, None, 5,
+         lambda s: "MoSCoW rapido: prendi ultima feature pensata. è MUST, SHOULD, COULD, WON'T? se non MUST, rimandala. 5 min."),
+    Seed(Category.SCOPE_CHECK, None, 5,
+         lambda s: "scope creep check: quante feature aggiunte al GDD ultimo mese? se più di 2, stop nuove feature per 7 giorni. caveman comandare."),
+    Seed(Category.SCOPE_CHECK, None, 3,
+         lambda s: "future creep check: stai codando qualcosa per 'quando ci saranno utenti'? non ci sono utenti ancora. tagliare, fare dopo."),
+    Seed(Category.SCOPE_CHECK, None, 10,
+         lambda s: "RICE scoring prossima feature: Reach, Impact, Confidence(%), Effort(giorni). (R×I×C)/E. se <2, saltare. 10 min."),
+    Seed(Category.SCOPE_CHECK, None, 7,
+         lambda s: "SPACE check (solo dev): Soddisfatto? Performi? Attivo? Collabori? Efficiente? se 2+ 'no', non è tecnica, è scope. fermati."),
+)
+
+
+# ---------- Pool ----------
+
+ALL_SEEDS: Final[dict[Category, tuple[Seed, ...]]] = {
+    Category.MICRO_SPRINT: MICRO_SPRINT_SEEDS,
+    Category.DESIGN_HINT: DESIGN_HINT_SEEDS,
+    Category.MINI_GAME: MINI_GAME_SEEDS,
+    Category.EVO_TWIST: EVO_TWIST_SEEDS,
+    Category.SCOPE_CHECK: SCOPE_CHECK_SEEDS,
+}
+
+
+def pick_seed(
+    category: Category,
+    snap: RepoSnapshot,
+    *,
+    exclude_ids: frozenset[int] = frozenset(),
+    rng: random.Random | None = None,
+) -> tuple[Seed, int]:
+    """Sceglie un seed dalla categoria evitando ripetizioni recenti."""
+    rng = rng or random.Random()
+    pool = ALL_SEEDS[category]
+    available = [i for i in range(len(pool)) if i not in exclude_ids]
+    if not available:
+        available = list(range(len(pool)))
+    idx = rng.choice(available)
+    return pool[idx], idx

--- a/evo-caveman/tests/test_engine.py
+++ b/evo-caveman/tests/test_engine.py
@@ -1,0 +1,94 @@
+"""Test per engine.py — decisione categoria e generazione output."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from caveman.engine import decide_category, generate, should_speak
+from caveman.repo import Commit, RepoSnapshot
+from caveman.seeds import Category
+
+
+def _snap(kinds: list[str], dirty: int = 0, root: Path | None = None) -> RepoSnapshot:
+    commits = tuple(
+        Commit(sha=f"{i:07d}", message="msg", files=(), kind=k)  # type: ignore[arg-type]
+        for i, k in enumerate(kinds)
+    )
+    return RepoSnapshot(
+        root=root or Path("/tmp/nonexistent-caveman-test"),
+        recent_commits=commits,
+        dirty_files=tuple(f"f{i}.py" for i in range(dirty)),
+    )
+
+
+class TestDecideCategory:
+    def test_drifting_forces_hint(self) -> None:
+        snap = _snap(["INFRA"] * 8 + ["GAMEPLAY", "DOCS"])
+        assert decide_category(snap) == Category.DESIGN_HINT
+
+    def test_last_gameplay_triggers_micro_sprint(self) -> None:
+        snap = _snap(["GAMEPLAY", "GAMEPLAY", "DOCS"])
+        assert decide_category(snap) == Category.MICRO_SPRINT
+
+    def test_many_dirty_triggers_micro_sprint(self) -> None:
+        snap = _snap(["DOCS", "GAMEPLAY"], dirty=7)
+        assert decide_category(snap) == Category.MICRO_SPRINT
+
+    def test_force_overrides(self) -> None:
+        snap = _snap(["INFRA"] * 10)  # sarebbe DESIGN_HINT
+        assert decide_category(snap, force=Category.MINI_GAME) == Category.MINI_GAME
+
+
+class TestGenerate:
+    def test_deterministic_with_seed(self) -> None:
+        snap = _snap(["GAMEPLAY", "DOCS"])
+        a = generate(snap, seed=42, force_category=Category.DESIGN_HINT)
+        # Se lo stato persiste, il secondo potrebbe differire — usiamo due seed uguali
+        # ma ripuliamo chiamando di nuovo con stesso seed e comando.
+        b = generate(snap, seed=42, force_category=Category.DESIGN_HINT)
+        # Non identici necessariamente (lo stato "used" è cambiato), ma il RENDER è valido
+        assert a.category == Category.DESIGN_HINT
+        assert b.category == Category.DESIGN_HINT
+        assert a.body
+        assert b.body
+
+    def test_output_contains_all_parts(self) -> None:
+        snap = _snap(["GAMEPLAY"])
+        out = generate(snap, seed=1)
+        assert out.emoji in ("🦴", "🪨", "🔥")
+        assert out.opening
+        assert out.body
+        assert out.closer
+        md = out.render_markdown()
+        assert md.startswith(out.emoji)
+        assert "*" in md  # italic
+
+    def test_plain_render_no_markdown(self) -> None:
+        snap = _snap(["GAMEPLAY"])
+        out = generate(snap, seed=1)
+        plain = out.render_plain()
+        assert "*" not in plain
+        assert out.emoji in plain
+
+
+class TestShouldSpeak:
+    def test_silent_on_empty_repo(self) -> None:
+        snap = _snap([])
+        speak, _ = should_speak(snap)
+        assert not speak
+
+    def test_speaks_on_drift(self) -> None:
+        snap = _snap(["INFRA"] * 5 + ["DOCS"] * 5)
+        speak, reason = should_speak(snap)
+        assert speak
+        assert "drift" in reason.lower()
+
+    def test_speaks_on_gameplay_commit(self) -> None:
+        snap = _snap(["GAMEPLAY", "INFRA"])
+        speak, _ = should_speak(snap)
+        assert speak
+
+    def test_silent_on_routine_infra(self) -> None:
+        snap = _snap(["INFRA", "GAMEPLAY", "GAMEPLAY", "DOCS"])
+        speak, _ = should_speak(snap)
+        assert not speak  # solo 1 INFRA e gameplay_ratio 50%

--- a/evo-caveman/tests/test_repo.py
+++ b/evo-caveman/tests/test_repo.py
@@ -1,0 +1,100 @@
+"""Test per repo.py — classificazione commit e snapshot."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from caveman.repo import Commit, RepoSnapshot, _classify_commit, snapshot
+
+
+class TestClassifyCommit:
+    def test_gameplay_commit(self) -> None:
+        assert _classify_commit("add new trait", ("traits/fire.yaml",)) == "GAMEPLAY"
+
+    def test_infra_commit(self) -> None:
+        assert _classify_commit("fix ci", (".github/workflows/test.yml",)) == "INFRA"
+
+    def test_docs_commit(self) -> None:
+        assert _classify_commit("update readme", ("README.md",)) == "DOCS"
+
+    def test_data_commit(self) -> None:
+        assert _classify_commit("add dataset", ("data/species.yaml",)) == "DATA"
+
+    def test_gameplay_beats_docs(self) -> None:
+        """Se un commit tocca sia traits/ che README.md, vince GAMEPLAY."""
+        assert _classify_commit("big refactor", ("traits/x.yaml", "README.md")) == "GAMEPLAY"
+
+    def test_fallback_altro(self) -> None:
+        assert _classify_commit("random stuff", ("random/file.txt",)) == "ALTRO"
+
+
+class TestSnapshotMetrics:
+    def _make_snap(self, kinds: list[str]) -> RepoSnapshot:
+        commits = tuple(
+            Commit(sha=f"{i:07d}", message="x", files=(), kind=k)  # type: ignore[arg-type]
+            for i, k in enumerate(kinds)
+        )
+        return RepoSnapshot(root=Path("/tmp"), recent_commits=commits, dirty_files=())
+
+    def test_gameplay_ratio(self) -> None:
+        snap = self._make_snap(["GAMEPLAY", "INFRA", "GAMEPLAY", "DOCS", "INFRA"])
+        assert snap.gameplay_ratio() == 0.4
+
+    def test_gameplay_ratio_empty(self) -> None:
+        snap = self._make_snap([])
+        assert snap.gameplay_ratio() == 0.0
+
+    def test_consecutive_infra(self) -> None:
+        snap = self._make_snap(["INFRA", "INFRA", "INFRA", "GAMEPLAY", "INFRA"])
+        assert snap.consecutive_infra_commits() == 3
+
+    def test_drift_low_gameplay(self) -> None:
+        snap = self._make_snap(["INFRA"] * 8 + ["GAMEPLAY", "DOCS"])
+        assert snap.is_drifting()
+
+    def test_drift_consecutive_infra(self) -> None:
+        snap = self._make_snap(["INFRA", "INFRA", "INFRA", "INFRA", "GAMEPLAY"])
+        assert snap.is_drifting()
+
+    def test_not_drifting(self) -> None:
+        snap = self._make_snap(["GAMEPLAY", "GAMEPLAY", "INFRA", "GAMEPLAY"])
+        assert not snap.is_drifting()
+
+
+class TestRealGitRepo:
+    """Test d'integrazione con un vero repo git temporaneo."""
+
+    @pytest.fixture
+    def git_repo(self, tmp_path: Path) -> Path:
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t.t"], cwd=tmp_path, check=True)
+        subprocess.run(["git", "config", "user.name", "test"], cwd=tmp_path, check=True)
+
+        # Commit 1: GAMEPLAY
+        (tmp_path / "traits").mkdir()
+        (tmp_path / "traits" / "fire.yaml").write_text("name: fire\n")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+        subprocess.run(["git", "commit", "-qm", "add fire trait"], cwd=tmp_path, check=True)
+
+        # Commit 2: INFRA
+        (tmp_path / "Dockerfile").write_text("FROM python\n")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+        subprocess.run(["git", "commit", "-qm", "add docker"], cwd=tmp_path, check=True)
+
+        return tmp_path
+
+    def test_snapshot_reads_real_repo(self, git_repo: Path) -> None:
+        snap = snapshot(git_repo)
+        assert len(snap.recent_commits) == 2
+        # Ultimo commit è il più recente
+        assert snap.recent_commits[0].kind == "INFRA"
+        assert snap.recent_commits[1].kind == "GAMEPLAY"
+        assert "traits" in snap.pillar_dirs
+
+    def test_snapshot_non_git_dir(self, tmp_path: Path) -> None:
+        snap = snapshot(tmp_path)
+        assert snap.recent_commits == ()
+        assert snap.dirty_files == ()

--- a/tools/py/caveman_status_stdlib.py
+++ b/tools/py/caveman_status_stdlib.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Genera docs/caveman-status.json con stdlib-only (no typer/rich deps).
+
+Fallback usato quando evo-caveman CLI non è installato. Produce JSON
+shape-compatible con `caveman export`. Usato da CI e dal setup iniziale
+S4 (RESEARCH_TODO).
+
+Usage:
+    python3 tools/py/caveman_status_stdlib.py [--output path]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+COMMIT_PATTERNS = [
+    (("traits/", "biomes/", "rules/", "jobs/", "species/", "combat", "turn", "play:"), "GAMEPLAY"),
+    (("data/", "datasets/", "yaml", "schema", "data:"), "DATA"),
+    (("docker", "ci/", ".github/workflows", "prisma", "migration", "deploy", "compose", "infra:"), "INFRA"),
+    (("cli/", "tools/", "validator", "dashboard", "analytics", "script"), "TOOLING"),
+    (("readme", "docs/", "changelog", "canvas", ".md", "doc:"), "DOCS"),
+]
+
+
+def classify(message: str, files: list[str]) -> str:
+    haystack = (message + " " + " ".join(files)).lower()
+    for patterns, kind in COMMIT_PATTERNS:
+        for p in patterns:
+            if p in haystack:
+                return kind
+    return "ALTRO"
+
+
+def git_log(repo: Path, limit: int = 10) -> list[dict]:
+    result = subprocess.run(
+        ["git", "log", f"-{limit}", "--name-only", "--pretty=format:%H%n%s%n--END--"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if result.returncode != 0:
+        return []
+
+    commits = []
+    lines = result.stdout.split("\n")
+    i = 0
+    while i < len(lines):
+        if i + 1 >= len(lines):
+            break
+        sha = lines[i].strip()
+        if not re.match(r"^[0-9a-f]{7,40}$", sha):
+            i += 1
+            continue
+        msg = lines[i + 1] if i + 1 < len(lines) else ""
+        files = []
+        j = i + 2
+        while j < len(lines) and lines[j].strip() != "--END--":
+            if lines[j].strip():
+                files.append(lines[j].strip())
+            j += 1
+        commits.append({"sha": sha, "message": msg, "files": files, "kind": classify(msg, files)})
+        i = j + 1
+    return commits
+
+
+def dirty_files(repo: Path) -> list[str]:
+    result = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=repo, capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        return []
+    out = []
+    for line in result.stdout.splitlines():
+        if line.strip():
+            parts = line.strip().split(maxsplit=1)
+            if len(parts) == 2:
+                out.append(parts[1])
+    return out
+
+
+def compute_metrics(commits: list[dict]) -> dict:
+    if not commits:
+        return {
+            "gameplay_ratio": 0.0,
+            "consecutive_infra_commits": 0,
+            "is_drifting": False,
+        }
+    gp = sum(1 for c in commits if c["kind"] == "GAMEPLAY")
+    ratio = gp / len(commits)
+    consec = 0
+    for c in commits:
+        if c["kind"] == "INFRA":
+            consec += 1
+        else:
+            break
+    return {
+        "gameplay_ratio": ratio,
+        "consecutive_infra_commits": consec,
+        "is_drifting": ratio < 0.2 or consec >= 4,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", "-o", default="docs/caveman-status.json")
+    args = parser.parse_args()
+
+    repo = Path.cwd()
+    commits = git_log(repo, limit=10)
+    dirty = dirty_files(repo)
+    metrics = compute_metrics(commits)
+
+    payload = {
+        "_meta": {
+            "generator": "caveman_status_stdlib (fallback)",
+            "version": "0.2.0-stdlib",
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "repo_root": str(repo),
+            "note": (
+                "File generato via tools/py/caveman_status_stdlib.py (stdlib-only). "
+                "Quando evo-caveman CLI è installato, rigenerare con `caveman export`."
+            ),
+        },
+        "snapshot": {
+            "dirty_files_count": len(dirty),
+            "recent_commits_count": len(commits),
+            "gameplay_ratio": metrics["gameplay_ratio"],
+            "consecutive_infra_commits": metrics["consecutive_infra_commits"],
+            "is_drifting": metrics["is_drifting"],
+            "recent_commits": [
+                {
+                    "sha": c["sha"][:8],
+                    "kind": c["kind"],
+                    "message_first_line": c["message"],
+                    "files_count": len(c["files"]),
+                }
+                for c in commits
+            ],
+        },
+        "achievements": {
+            "unlocked_count": None,
+            "total_count": 8,
+            "items": [],
+            "note": "Achievements computed by caveman CLI, not stdlib fallback",
+        },
+        "last_spoke_unix": None,
+    }
+
+    dest = Path(args.output)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"OK: exported caveman status → {dest}")
+    print(
+        f"  commits={len(commits)} gameplay_ratio={metrics['gameplay_ratio']:.0%} "
+        f"drifting={metrics['is_drifting']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Chiude **S4** RESEARCH_TODO. Installa drop v0.2 + nuovo comando \`caveman export\` + stdlib fallback.

## Changes

- \`CAVEMAN.md\` (root) — mantra + rituale venerdì
- \`INDEX.md\` (root) — drop navigation
- \`evo-caveman/\` (Python CLI, 111K, 12 file): src/caveman/{cli,engine,repo,seeds,achievements}, pyproject PEP 735, CI workflow, tests
- \`caveman-mode-skill/\` (Anthropic skill, 20K): SKILL.md + references
- \`tools/py/caveman_status_stdlib.py\` — stdlib fallback generator (no typer/rich deps)
- \`docs/caveman-status.json\` — snapshot committato

## New command

\`caveman export [--output PATH]\` → JSON con snapshot + achievements + last_spoke.

Skill evo-tactics-monitor legge questo file prima di web fetch.

## Stato rilevato

\`\`\`
commits=10 gameplay_ratio=0% drift=true
\`\`\`

Drift flaggato correttamente — batch recente è tutto DOCS/TOOLING (Q-001 + RESEARCH_TODO). Caveman fa il suo lavoro.

## Deferred (separate PR)

- Prefix classifier in \`evo-caveman/src/caveman/repo.py\` (TODO post-merge)
- \`caveman install-hook\` attivazione post-commit automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)