### PR TITLE
play: AP budget canonical spec (FRICTION #2/#3 resolution)

### DIFF
--- a/docs/combat/action-types-guide.md
+++ b/docs/combat/action-types-guide.md
@@ -68,6 +68,56 @@ Questi 4 tipi sono in `NOOP_ACTION_TYPES = frozenset({"defend", "parry", "abilit
 - **`ability`**: **centrale per Fase 3**. Attiverà `active_effects` dei trait (attualmente NOOP nel catalog).
 - **`parry`**: distinto dal `parry_response` opt-in. Il `parry` come action type indipendente sarà implementato quando le reactions avranno un proprio timing (fuori dal turn dell'attore).
 
+## AP budget per turno (canonico)
+
+> **FRICTION #2+#3 resolution** dal playtest 2026-04-17 (vedi `docs/playtests/2026-04-17/notes.md`).
+
+Regola canonica: **AP è un budget azioni per turno, spendibile liberamente** secondo il costo di ciascuna action. Non esiste un template fisso "1 move + 1 attack" — qualunque combinazione di azioni che somma ≤ `ap_remaining` è valida.
+
+### Refresh AP
+
+- A inizio turno: `actor.ap_remaining = actor.ap_max` (default 2 per tutte le unità base)
+- Eccezione status `fracture`: `ap_remaining = min(1, ap_max)` (vedi `combat-canon.md` §status effects)
+
+### Costo per action type
+
+| Type      |       AP cost       | Note                                                  |
+| --------- | :-----------------: | ----------------------------------------------------- |
+| `attack`  |        **1**        | per attack roll, indipendente dal damage              |
+| `move`    |        **N**        | N = celle Manhattan spostate (`dist ≤ ap_remaining`)  |
+| `ability` | **ability.ap_cost** | per-ability dichiarato in `action_effects` trait YAML |
+| `defend`  |          1          | NOOP (Fase 2) — consumo AP senza logica               |
+| `parry`   |          1          | NOOP come action type (reactive via `parry_response`) |
+
+### Combinazioni valide (ap_max=2)
+
+- ✅ **2 attack**: `1 AP + 1 AP = 2 AP` → **doppio attacco = valid**
+- ✅ 1 attack + 1 move 1-cell: `1 + 1 = 2 AP`
+- ✅ 1 move 2-cell + 0 action: `2 + 0 = 2 AP`
+- ✅ 1 ability(ap_cost=2): consuma tutto il budget
+- ❌ 1 move 3-cell: `3 > 2` → rigettato con errore
+- ❌ 3 attack: 3° attack rigettato a `ap_remaining < 1`
+
+### Enforcement
+
+- `POST /api/session/action` verifica `ap_remaining >= action_cost` prima di eseguire (session.js:717+)
+- Errori espliciti: `"AP insufficienti per attaccare (termina il turno)"`, `"AP insufficienti per muoversi (termina il turno)"`, `"AP insufficienti per muoversi di N celle (ap residui: M)"`
+
+### Ability override AP
+
+Abilità con `ap_cost` esplicito in `data/core/jobs.yaml` o `data/core/traits/active_effects.yaml` possono costare più di 1 AP. Il resolver lo legge dal dataset, non hardcoded.
+
+Esempio Skirmisher `hit-and-run` (spec in arrivo, vedi FRICTION #4 roadmap):
+
+```yaml
+abilities:
+  hit_and_run:
+    ap_cost: 2 # attack + reposition atomico
+    effect_type: compound
+```
+
+---
+
 ## PT spend: perforazione e spinta
 
 Il campo `action.pt_spend` permette all'attore di consumare PT dal proprio pool per ottenere effetti aggiuntivi su un attack. Supportato solo per `type: "attack"`.

--- a/docs/playtests/2026-04-17/notes.md
+++ b/docs/playtests/2026-04-17/notes.md
@@ -91,11 +91,16 @@ FRICTION #2 (T2 S1): AP budget → azioni ambiguo.
   Trigger: S1 miss, AP residuo, cosa può fare?
   Impact: agent interpreta strict (1 attack/turno).
   Design need: spec esplicita "AP 2 = N attack max".
+  ✅ RESOLVED 2026-04-17: doc canonico in docs/combat/action-types-guide.md
+     §"AP budget per turno". Test tests/api/apBudget.test.js.
 
 FRICTION #3 (T2 P2): Master richiede doppio attack, regola mancante.
   Trigger: "mossa P2 è doppio attacco".
   Impact: agent applica permissivo + flagga friction.
   Design need: 2 attack/turno = sì/no/condizionato?
+  ✅ RESOLVED 2026-04-17: doppio attack VALID per design (1 AP + 1 AP = 2 AP).
+     Codice già corretto (session.js:717+), mancava solo doc. Spec +
+     test committati.
 
 FRICTION #4 (T3 P1): job Skirmisher "hit-and-run" non integrato.
   Trigger: review job description post-partita.

--- a/tests/api/apBudget.test.js
+++ b/tests/api/apBudget.test.js
@@ -1,0 +1,182 @@
+// Play: AP budget canonical — FRICTION #2/#3 resolution from playtest 2026-04-17.
+// Valida regola canonica: AP è budget spendibile liberamente, 2 attack/turno = valid.
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+
+async function startSession(app) {
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  assert.equal(scenario.status, 200);
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units });
+  assert.equal(startRes.status, 200);
+  return { sid: startRes.body.session_id, state: startRes.body.state };
+}
+
+function findInRange(units, attackerId) {
+  const attacker = units.find((u) => u.id === attackerId);
+  const enemies = units.filter((u) => u.controlled_by !== attacker.controlled_by && u.hp > 0);
+  if (!enemies.length) return null;
+  const range = attacker.attack_range ?? 2;
+  const closest = enemies
+    .map((e) => ({
+      e,
+      d:
+        Math.abs(attacker.position.x - e.position.x) + Math.abs(attacker.position.y - e.position.y),
+    }))
+    .sort((a, b) => a.d - b.d)[0];
+  return closest.d <= range ? closest.e : null;
+}
+
+test('AP budget: player con ap_max=2 può fare 2 attack nello stesso turno', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const { sid, state } = await startSession(app);
+  const player = state.units.find((u) => u.controlled_by === 'player');
+  const initialAp = player.ap_remaining ?? player.ap;
+  assert.ok(initialAp >= 2, `ap_max >= 2 atteso, actual=${initialAp}`);
+
+  // Move player adjacent to closest enemy if not in range
+  let target = findInRange(state.units, player.id);
+  if (!target) {
+    const enemy = state.units.find((u) => u.controlled_by === 'sistema');
+    // Move player near enemy (consume some AP — skip this test if move eats budget)
+    // Instead pick tutorial scenario which has player+enemy in range at start.
+    // Se non in range → skip (scenario tutorial should have range)
+    assert.ok(target, 'enc_tutorial_01 atteso con target in range');
+  }
+
+  // Attack #1
+  const r1 = await request(app).post('/api/session/action').send({
+    session_id: sid,
+    action_type: 'attack',
+    actor_id: player.id,
+    target_id: target.id,
+  });
+  assert.equal(r1.status, 200, `attack #1 should succeed: ${JSON.stringify(r1.body)}`);
+
+  // Verify AP decremented
+  const midState = await request(app).get('/api/session/state').query({ session_id: sid });
+  const playerMid = midState.body.units.find((u) => u.id === player.id);
+  assert.equal(
+    playerMid.ap_remaining,
+    initialAp - 1,
+    `AP dopo attack #1 atteso ${initialAp - 1}, actual=${playerMid.ap_remaining}`,
+  );
+
+  // Target potrebbe essere morto? Re-pick
+  let target2 = findInRange(midState.body.units, player.id);
+  if (!target2) {
+    // Tutte le SIS unit morte — il test OK: prima attack ha finito tutto
+    return;
+  }
+
+  // Attack #2 (stesso turno)
+  const r2 = await request(app).post('/api/session/action').send({
+    session_id: sid,
+    action_type: 'attack',
+    actor_id: player.id,
+    target_id: target2.id,
+  });
+  assert.equal(
+    r2.status,
+    200,
+    `attack #2 should succeed (FRICTION #3): ${JSON.stringify(r2.body)}`,
+  );
+
+  const finalState = await request(app).get('/api/session/state').query({ session_id: sid });
+  const playerFinal = finalState.body.units.find((u) => u.id === player.id);
+  assert.equal(
+    playerFinal.ap_remaining,
+    initialAp - 2,
+    `AP dopo 2 attack atteso ${initialAp - 2}, actual=${playerFinal.ap_remaining}`,
+  );
+});
+
+test('AP budget: 3° attack rigettato quando ap_remaining=0', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const { sid, state } = await startSession(app);
+  const player = state.units.find((u) => u.controlled_by === 'player');
+
+  let currentState = state;
+  for (let i = 0; i < 3; i++) {
+    const target = findInRange(currentState.units, player.id);
+    if (!target) return; // target moriti, test OK
+
+    const res = await request(app).post('/api/session/action').send({
+      session_id: sid,
+      action_type: 'attack',
+      actor_id: player.id,
+      target_id: target.id,
+    });
+
+    if (i < 2) {
+      assert.equal(res.status, 200, `attack #${i + 1} should succeed`);
+    } else {
+      // 3rd attack should fail with AP insufficient
+      assert.equal(res.status, 400, 'attack #3 should be rejected');
+      assert.match(
+        res.body.error || '',
+        /AP insufficienti|ap_remaining/i,
+        'errore esplicito su AP insufficienti',
+      );
+    }
+
+    const s = await request(app).get('/api/session/state').query({ session_id: sid });
+    currentState = s.body;
+  }
+});
+
+test('AP budget: move di N celle costa N AP (Manhattan)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const { sid, state } = await startSession(app);
+  const player = state.units.find((u) => u.controlled_by === 'player');
+  const initialAp = player.ap_remaining ?? player.ap;
+
+  // Trova cella libera adiacente al player
+  const from = player.position;
+  const occupied = new Set(
+    state.units.filter((u) => u.hp > 0).map((u) => `${u.position.x},${u.position.y}`),
+  );
+  const candidates = [
+    { x: from.x + 1, y: from.y },
+    { x: from.x - 1, y: from.y },
+    { x: from.x, y: from.y + 1 },
+    { x: from.x, y: from.y - 1 },
+  ].filter((p) => p.x >= 0 && p.x < 8 && p.y >= 0 && p.y < 8 && !occupied.has(`${p.x},${p.y}`));
+  assert.ok(candidates.length > 0, 'almeno una cella libera adiacente');
+  const targetPos = candidates[0];
+
+  const res = await request(app).post('/api/session/action').send({
+    session_id: sid,
+    action_type: 'move',
+    actor_id: player.id,
+    position: targetPos,
+  });
+  assert.equal(res.status, 200, `move dist 1 should succeed: ${JSON.stringify(res.body)}`);
+
+  const midState = await request(app).get('/api/session/state').query({ session_id: sid });
+  const pm = midState.body.units.find((u) => u.id === player.id);
+  assert.equal(
+    pm.ap_remaining,
+    initialAp - 1,
+    `move 1 cell consumes 1 AP, actual ap_remaining=${pm.ap_remaining}`,
+  );
+});


### PR DESCRIPTION
## Summary

Primo play: commit post-playtest M1. Chiude **FRICTION #2** (AP ambiguo) e **#3** (doppio attack) dal playtest 2026-04-17.

## Canonical rule

AP = budget azioni per turno, spendibile liberamente:
- \`attack\`: 1 AP (2 attack = 2 AP valid)
- \`move\`: N AP (N = celle Manhattan)
- \`ability\`: \`ability.ap_cost\` (dataset-driven)
- \`defend\`/\`parry\`: 1 AP (NOOP Fase 2)

## Code status

session.js:717+ **già corretto**. Solo doc + test mancavano.

## Changes

- \`docs/combat/action-types-guide.md\` — §"AP budget per turno (canonico)" nuova sezione
- \`tests/api/apBudget.test.js\` — 3 test (2 attack ok, 3rd rejected, move N cells)
- \`docs/playtests/2026-04-17/notes.md\` — marca #2+#3 ✅ RESOLVED

## Test plan

- [x] 3/3 AP budget test pass
- [x] 150+ AI regression green
- [x] Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)