### PR TITLE
docs(core): canonicalizza AP budget + move syntax (FRICTION #1-#3)

### DIFF
--- a/docs/core/11-REGOLE_D20_TV.md
+++ b/docs/core/11-REGOLE_D20_TV.md
@@ -1,17 +1,115 @@
 ---
-title: Adattamento TV/d20
+title: Adattamento TV/d20 — Regole canoniche turno
 doc_status: active
-doc_owner: platform-docs
+doc_owner: master-dd
 workstream: cross-cutting
-last_verified: 2026-04-14
-source_of_truth: false
+last_verified: 2026-04-17
+source_of_truth: true
 language: it-en
 review_cycle_days: 14
 ---
 
 # Adattamento TV/d20
 
+Regole canoniche per turno, AP budget, syntax input. Chiude FRICTION #1-#3 dal playtest 2026-04-17. Autorità A1 (hub canonico).
+
+## Setup TV/companion
+
 - **Schermo condiviso** (app/sito TV): stato gruppo, mappa, log VC, consigli sblocchi.
-- **Dadi**: d20 centrale; dadi “Descent-like” mappati su spese PT/PP (icona e pattern).
+- **Dadi**: d20 centrale; dadi "Descent-like" mappati su spese PT/PP (icona e pattern).
 - **Condivisione tavolo**: ogni turno produce **eventi grezzi** per VC (no quiz).
-- **Privacy**: toggle “profilazione stile” (on/off); reset profilo (amnesia evolutiva).
+- **Privacy**: toggle "profilazione stile" (on/off); reset profilo (amnesia evolutiva).
+
+## AP budget canonico (FRICTION #2 + #3)
+
+**Regola canonica**: `AP 2 = 1 attack MAX + N move` dove `N ≤ AP rimanenti`.
+
+| AP spesi          | Azioni valide                |
+| ----------------- | ---------------------------- |
+| 0                 | nessuna azione (skip turno)  |
+| 1 attack          | 1 attacco, 0 move residui    |
+| 1 attack + 1 move | 1 attacco + 1 step movimento |
+| 2 move            | 2 step movimento, 0 attacchi |
+| 1 move + skip     | 1 step + skip                |
+
+**No doppio attack.** Un'unità attacca al massimo **1 volta per turno**, indipendentemente da AP residui. Motivazione:
+
+- Tensione tattica: "devo colpire adesso" ha peso. 2 attacchi/turno trivializzano target priority.
+- Coerenza con reference (FFT, XCOM, Wesnoth): tutti 1 attack/turn.
+- Matematica bilanciamento: player scout mod 3 \* 2 attack/turn = Sistema wipe garantito round 2.
+
+**Eccezioni future** (post-M4, opt-in):
+
+- Trait `ferocia_lampo` (placeholder): consente 2nd attack se MoS ≥10 al primo.
+- Job `berserker` (placeholder): 2nd attack a -2 mod.
+- Entrambi richiedono spec esplicita, non default.
+
+**Codice**: `apps/backend/services/roundOrchestrator.js` deve rifiutare 2° attack stesso turno (enforcement TODO — oggi consente via AP budget, ma batch test e playtest human usano già 1/turn convenzionalmente).
+
+## Syntax mosse canonica (FRICTION #1)
+
+**Formato input per playtest testuale**:
+
+```
+<actor_id>: move [<x>,<y>] atk <target_id>
+<actor_id>: move [<x>,<y>]
+<actor_id>: atk <target_id>
+<actor_id>: skip
+```
+
+### Esempi validi
+
+```
+p_scout: move [3,2] atk e_nomad_1     # move + attack (2 AP)
+p_tank: atk e_hunter                   # attack only (1 AP)
+p_scout: move [4,2]                    # move only (1 AP), skip resto
+e_nomad_1: atk p_scout                 # SIS attack (dichiarato da AI o Master)
+p_tank: skip                           # passa turno
+```
+
+### Coordinate
+
+- **Sistema**: `[x,y]` con origine `(0,0)` angolo **in alto a sinistra**.
+- `x` cresce verso destra (est), `y` cresce verso il basso (sud).
+- Alternativa cardinale NON canonica (ambigua su griglia non allineata): evitare "N 2" / "E 1" in input testuale.
+
+### Attack range
+
+- `atk <target>` valido solo se `distance(actor, target) ≤ actor.attack_range`.
+- Distance = **Manhattan** (`|dx| + |dy|`) su griglia quadrata.
+- Futuro (hex grid): distance axial-hex via `services/rules/hexGrid.py::distance()`.
+
+### Parser
+
+- Master/agent DM deve rifiutare input non-canonico con messaggio: `SYNTAX: <actor_id>: [move [x,y]] [atk <target_id>] | skip`.
+- Parser di riferimento: `apps/backend/routes/session.js` (accetta già `{actor_id, action_type, target_id, position}`).
+- Testi liberi ("vai a nord", "colpisci il nemico vicino") NON accettati — Master traduce in canonico prima.
+
+## Ordine turno (initiative)
+
+**Fisso per round**: `P1 → S1 → P2 → S2 → …` alternato player/sistema per initiative decrescente.
+
+- Initiative risolta a inizio encounter (stat `initiative` per unità).
+- Ties: player prima di Sistema (asymmetric bias per leggibilità).
+- Initiative NON rirollata tra i round (elimina meta-gioco).
+
+## Eventi grezzi per VC
+
+Ogni azione emette raw event:
+
+```
+{ action_type, turn, actor_id, target_id, damage_dealt, result, position_from, position_to }
+```
+
+Schema canonico in `packages/contracts/schemas/combat.schema.json`. Consumato da `apps/backend/services/vcScoring.js` per calcolo MBTI/Ennea aggregato a fine sessione.
+
+## Cross-ref
+
+- FRICTION log completo: [`docs/playtests/2026-04-17/notes.md`](../playtests/2026-04-17/notes.md)
+- Sistema tattico: [`10-SISTEMA_TATTICO.md`](10-SISTEMA_TATTICO.md)
+- Combat hub: [`../hubs/combat.md`](../hubs/combat.md)
+- Rules engine: `services/rules/resolver.py` + `services/rules/demo_cli.py`
+
+---
+
+_Aggiornato 2026-04-17 post-playtest M1. Revisione ogni 14 giorni o dopo playtest successivo._

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -2244,15 +2244,15 @@
     },
     {
       "path": "docs/core/11-REGOLE_D20_TV.md",
-      "title": "Adattamento TV/d20",
+      "title": "Adattamento TV/d20 — Regole canoniche turno",
       "doc_status": "active",
-      "doc_owner": "platform-docs",
+      "doc_owner": "master-dd",
       "workstream": "cross-cutting",
-      "last_verified": "2026-04-14",
-      "source_of_truth": false,
+      "last_verified": "2026-04-17",
+      "source_of_truth": true,
       "language": "it-en",
       "review_cycle_days": 14,
-      "primary": false,
+      "primary": true,
       "track": "migrated"
     },
     {

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-17T11:11:22+00:00",
+  "generated_at": "2026-04-17T11:46:11+00:00",
   "summary": {
     "total": 5,
     "errors": 0,


### PR DESCRIPTION
## Summary

Chiude **FRICTION #1-#3** del primo playtest umano 2026-04-17 ([`docs/playtests/2026-04-17/notes.md`](../blob/main/docs/playtests/2026-04-17/notes.md)).

Promosso [`docs/core/11-REGOLE_D20_TV.md`](../blob/main/docs/core/11-REGOLE_D20_TV.md) a hub canonico A1 (source_of_truth: true) con regole esplicite AP budget + syntax mosse.

## FRICTION chiusi

### FRICTION #1 — sintassi mosse non canonica

Formato canonico adottato:

```
<actor_id>: move [<x>,<y>] atk <target_id>
<actor_id>: move [<x>,<y>]
<actor_id>: atk <target_id>
<actor_id>: skip
```

Coordinate `[x,y]` origin in alto-sx, x→est, y→sud. Manhattan distance su griglia quadrata.

### FRICTION #2 — AP budget → azioni ambiguo

Regola canonica: `AP 2 = 1 attack MAX + N move`. Tabella esplicita con 5 combinazioni valide.

### FRICTION #3 — doppio attack

**Vietato**: unità attacca al massimo 1 volta per turno, indipendentemente da AP residui.

Motivazione:

- Coerenza reference (FFT, XCOM, Wesnoth)
- Tensione tattica preservata
- Player scout mod 3 × 2 attack/turn trivializza Sistema (wipe round 2 garantito)

Eccezioni future (opt-in, post-M4): trait `ferocia_lampo`, job `berserker`.

## Changes

- 📝 `docs/core/11-REGOLE_D20_TV.md`: da 18 a 115 righe. Nuove sezioni AP budget, move syntax, attack range, initiative, raw events. Promosso a A1 canonical.
- 📝 `docs/governance/docs_registry.json`: entry updated (`source_of_truth: true`, `primary: true`, `doc_owner: master-dd`, `last_verified: 2026-04-17`).

## Follow-up (non in scope)

- **Enforcement codice**: `apps/backend/services/roundOrchestrator.js` oggi consente 2 attack via AP budget. Batch test + playtest human usano già convenzionalmente 1 atk/turn. TODO separato per aggiungere check `unit.has_attacked_this_turn`.
- **FRICTION #4** Skirmisher job ability: spec `jobs.yaml` abilities schema (separata, richiede design + code).

## Test plan

- [x] `python tools/check_docs_governance.py --registry docs/governance/docs_registry.json --strict` → `errors=0 warnings=5` (pre-existing)
- [x] Link interni (10-SISTEMA_TATTICO, hubs/combat, playtest notes) funzionanti

## Rollback plan

Revert single commit — zero code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)