### PR TITLE
fix(evo-caveman): allinea test drift a reason string italiana

### DIFF
--- a/evo-caveman/tests/test_engine.py
+++ b/evo-caveman/tests/test_engine.py
@@ -81,7 +81,7 @@ class TestShouldSpeak:
         snap = _snap(["INFRA"] * 5 + ["DOCS"] * 5)
         speak, reason = should_speak(snap)
         assert speak
-        assert "drift" in reason.lower()
+        assert "deriva" in reason.lower()
 
     def test_speaks_on_gameplay_commit(self) -> None:
         snap = _snap(["GAMEPLAY", "INFRA"])


### PR DESCRIPTION
## Summary

- `evo-caveman/tests/test_engine.py::TestShouldSpeak::test_speaks_on_drift` falliva perché assertiva `"drift" in reason.lower()` mentre l'engine ritorna `"Deriva rilevata: ..."` (italiano, coerente con la convenzione Italian-first del repo).
- Fix 1 riga: assertion da `"drift"` → `"deriva"`.
- Opzione A scelta (aggiorna test al contratto italiano), non Opzione B (cambio engine a inglese) perché il repo è Italian-first per CLAUDE.md.

## Why now

Il python-tests CI check falliva su PR docs non correlate dopo merge #1490 (install evo-caveman drop v0.2). Failure unrelated leakava in PR docs/test only. Sblocca pipeline.

## Test plan

- [x] `PYTHONPATH=evo-caveman/src pytest evo-caveman/tests/test_engine.py -v -o addopts=""` → 11/11 pass (locale)
- [ ] CI python-tests verde
- [ ] Admin merge se CI green (solo test change, no code impact)

## Rollback

Revert commit. 1 riga, zero impatto runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)