### PR TITLE
feat(jobs): discovery endpoint + ability syntax (FRICTION #4)

### DIFF
--- a/apps/backend/routes/jobs.js
+++ b/apps/backend/routes/jobs.js
@@ -1,0 +1,58 @@
+// Jobs discovery route — expone catalog da data/core/jobs.yaml.
+//
+// FRICTION #4 (playtest 2026-04-17): Master non aveva visibilità runtime
+// su job abilities. Questo endpoint risolve discoverability.
+//
+// GET /api/jobs          → lista compatta: id, label, role, signature, ability_ids
+// GET /api/jobs/:job_id  → job completo con abilities dettagliate
+//
+// Executor ability = PR separato (action_type='ability' in session route).
+
+'use strict';
+
+const { Router } = require('express');
+const { loadJobs, extractAbilities } = require('../services/jobsLoader');
+
+function createJobsRouter() {
+  const router = Router();
+  const catalog = loadJobs();
+
+  router.get('/', (_req, res) => {
+    if (!catalog || !catalog.jobs) {
+      return res.status(503).json({ error: 'jobs catalog not loaded' });
+    }
+    const summary = Object.entries(catalog.jobs).map(([id, job]) => ({
+      id,
+      label: job.label || job.label_it || id,
+      label_en: job.label_en,
+      role: job.role,
+      signature_mechanic: job.signature_mechanic,
+      initiative: job.initiative,
+      attack_range: job.attack_range,
+      resource_usage: job.resource_usage,
+      status: job.status,
+      ability_ids: extractAbilities(job).map((a) => a.ability_id),
+      href: `/api/jobs/${id}`,
+    }));
+    res.json({ version: catalog.version || null, count: summary.length, jobs: summary });
+  });
+
+  router.get('/:job_id', (req, res) => {
+    if (!catalog || !catalog.jobs) {
+      return res.status(503).json({ error: 'jobs catalog not loaded' });
+    }
+    const job = catalog.jobs[req.params.job_id];
+    if (!job) {
+      return res.status(404).json({ error: `job not found: ${req.params.job_id}` });
+    }
+    res.json({
+      id: req.params.job_id,
+      ...job,
+      abilities: extractAbilities(job),
+    });
+  });
+
+  return router;
+}
+
+module.exports = { createJobsRouter };

--- a/apps/backend/services/jobsLoader.js
+++ b/apps/backend/services/jobsLoader.js
@@ -1,0 +1,59 @@
+// Jobs Loader — carica data/core/jobs.yaml e espone catalog + abilities.
+//
+// FRICTION #4 (playtest 2026-04-17): Skirmisher job abilities (dash_strike,
+// evasive_maneuver, blade_flurry) specificate in YAML ma Master non aveva
+// visibilità cost/trigger durante playtest → ability ignorate.
+//
+// Questo loader espone il catalog via GET /api/jobs → discoverability.
+// Executor ability (POST /api/session/action action_type='ability') = PR separato.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const DEFAULT_JOBS_PATH = path.resolve(__dirname, '..', '..', '..', 'data', 'core', 'jobs.yaml');
+
+/**
+ * Carica data/core/jobs.yaml. Fallback silenzioso a struttura vuota se file mancante.
+ *
+ * @param {string} [yamlPath] override path.
+ * @param {{ log?: Function, warn?: Function }} [logger] logger (default console).
+ * @returns {{ version?: string, jobs: Record<string, object> } | null}
+ */
+function loadJobs(yamlPath = DEFAULT_JOBS_PATH, logger = console) {
+  try {
+    const text = fs.readFileSync(yamlPath, 'utf8');
+    const parsed = yaml.load(text);
+    if (!parsed || typeof parsed !== 'object' || !parsed.jobs) {
+      logger.warn(`[jobs] struttura invalida in ${yamlPath}, uso null`);
+      return null;
+    }
+    const count = Object.keys(parsed.jobs).length;
+    logger.log(`[jobs] caricato ${yamlPath}: ${count} job`);
+    return parsed;
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      logger.warn(`[jobs] ${yamlPath} non trovato, uso null`);
+    } else {
+      logger.warn(
+        `[jobs] errore caricamento ${yamlPath}: ${err && err.message ? err.message : err}`,
+      );
+    }
+    return null;
+  }
+}
+
+/**
+ * Estrae lista abilities di un job come array (vs oggetto unlock_r1_1 / r1_2 / r2).
+ * Ordina per rank asc.
+ */
+function extractAbilities(jobEntry) {
+  if (!jobEntry || !jobEntry.abilities) return [];
+  return Object.values(jobEntry.abilities)
+    .filter((a) => a && a.ability_id)
+    .sort((a, b) => (a.rank || 99) - (b.rank || 99));
+}
+
+module.exports = { loadJobs, extractAbilities, DEFAULT_JOBS_PATH };

--- a/apps/backend/services/pluginLoader.js
+++ b/apps/backend/services/pluginLoader.js
@@ -69,11 +69,19 @@ const tutorialPlugin = {
   },
 };
 
+const jobsPlugin = {
+  name: 'jobs',
+  register(app) {
+    const { createJobsRouter } = require('../routes/jobs');
+    app.use('/api/jobs', createJobsRouter());
+  },
+};
+
 /**
  * Lista plugin built-in. Aggiungere nuovi plugin qui.
  * Ordine = ordine di registrazione.
  */
-const BUILTIN_PLUGINS = [narrativePlugin, metaPlugin, tutorialPlugin];
+const BUILTIN_PLUGINS = [narrativePlugin, metaPlugin, tutorialPlugin, jobsPlugin];
 
 module.exports = {
   loadPlugins,
@@ -81,4 +89,5 @@ module.exports = {
   narrativePlugin,
   metaPlugin,
   tutorialPlugin,
+  jobsPlugin,
 };

--- a/docs/core/11-REGOLE_D20_TV.md
+++ b/docs/core/11-REGOLE_D20_TV.md
@@ -96,9 +96,48 @@ p_tank: skip                           # passa turno
 
 ### Parser
 
-- Master/agent DM deve rifiutare input non-canonico con messaggio: `SYNTAX: <actor_id>: [move [x,y]] [atk <target_id>] | skip`.
+- Master/agent DM deve rifiutare input non-canonico con messaggio: `SYNTAX: <actor_id>: [move [x,y]] [atk <target_id>] | skip | ability <ability_id> [target=<target_id>]`.
 - Parser di riferimento: `apps/backend/routes/session.js` (accetta già `{actor_id, action_type, target_id, position}`).
 - Testi liberi ("vai a nord", "colpisci il nemico vicino") NON accettati — Master traduce in canonico prima.
+
+## Ability syntax (FRICTION #4)
+
+**Formato canonico per job abilities** (dash_strike, taunt, binding_field, etc.):
+
+```
+<actor_id>: ability <ability_id> target=<target_id>
+<actor_id>: ability <ability_id>  # su self-target o no-target
+```
+
+### Esempi validi
+
+```
+p_scout: ability dash_strike target=e_nomad_1   # Skirmisher hit-and-run
+p_tank: ability taunt                           # Vanguard aggro pull (no explicit target)
+p_scout: ability evasive_maneuver               # self-target buff
+p_tank: ability fortify                         # self buff 2 turni
+```
+
+### Catalog abilities
+
+**Runtime discoverability**: `GET /api/jobs` per lista job, `GET /api/jobs/:job_id` per dettaglio con cost/trigger.
+
+**7 job base**: `skirmisher`, `vanguard`, `warden`, `artificer`, `invoker`, `ranger`, `harvester`. Ogni job ha 2 R1 abilities + 1 R2 (`unlock_r1_1`, `unlock_r1_2`, `unlock_r2`). Spec completa in [`data/core/jobs.yaml`](../../data/core/jobs.yaml).
+
+### Cost spec per ability
+
+Ogni ability specifica:
+
+- `cost_ap`: AP consumati (tipico 0-2)
+- `cost_pi`: Punti Investimento per unlock (3 R1, 8 R2) — meta-progression, non runtime
+- `cost_pt` / `cost_pp` / `cost_sg` / `cost_seed`: risorse rigenerabili in-match (opzionali)
+- `effect_type`: es. `move_attack`, `attack_move`, `multi_attack`, `buff`, `debuff`, `heal`, `shield`, `aoe_debuff`, `reaction`, `ranged_attack`, `execution_attack`
+
+### Enforcement
+
+- **Runtime executor**: TODO follow-up PR (action_type `ability` in session route + effect dispatcher per `effect_type`).
+- **Discoverability oggi**: Master/agent DM può curlare `GET /api/jobs/:job_id` durante playtest per lookup rapido.
+- **Fallback playtest senza executor**: Master applica manualmente effect (es. `dash_strike` = move 2 celle + attack con +1 mod se target non-adjacent a inizio turno), traccia evento raw come `ability` action_type placeholder.
 
 ## Ordine turno (initiative)
 

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-17T13:23:30+00:00",
+  "generated_at": "2026-04-17T13:35:52+00:00",
   "summary": {
     "total": 5,
     "errors": 0,

--- a/tests/api/jobs.test.js
+++ b/tests/api/jobs.test.js
@@ -1,0 +1,91 @@
+// tests/api/jobs.test.js — FRICTION #4 discoverability endpoint
+//
+// Verifica:
+//   - GET /api/jobs → lista 7 job (skirmisher, vanguard, warden, artificer, invoker, ranger, harvester)
+//   - GET /api/jobs/skirmisher → dettaglio con abilities [dash_strike, evasive_maneuver, blade_flurry]
+//   - GET /api/jobs/nonexistent → 404
+//   - GET /api/jobs/skirmisher expose cost_ap/cost_pi/cost_pp per ability
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+
+test('GET /api/jobs ritorna 7 job con signature_mechanic + ability_ids', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const res = await request(app).get('/api/jobs');
+  assert.equal(res.status, 200);
+  assert.ok(res.body.jobs, 'body.jobs presente');
+  assert.equal(res.body.count, 7, 'expected 7 job in catalog');
+  const ids = res.body.jobs.map((j) => j.id).sort();
+  assert.deepEqual(ids, [
+    'artificer',
+    'harvester',
+    'invoker',
+    'ranger',
+    'skirmisher',
+    'vanguard',
+    'warden',
+  ]);
+  const skirm = res.body.jobs.find((j) => j.id === 'skirmisher');
+  assert.ok(skirm.signature_mechanic);
+  assert.ok(skirm.signature_mechanic.toLowerCase().includes('hit-and-run'));
+  assert.deepEqual(skirm.ability_ids, ['dash_strike', 'evasive_maneuver', 'blade_flurry']);
+});
+
+test('GET /api/jobs/skirmisher ritorna abilities con cost + effect_type', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const res = await request(app).get('/api/jobs/skirmisher');
+  assert.equal(res.status, 200);
+  assert.equal(res.body.id, 'skirmisher');
+  assert.equal(res.body.role, 'damage');
+  assert.ok(Array.isArray(res.body.abilities));
+  assert.equal(res.body.abilities.length, 3);
+  const dash = res.body.abilities.find((a) => a.ability_id === 'dash_strike');
+  assert.ok(dash, 'dash_strike presente');
+  assert.equal(dash.cost_ap, 2);
+  assert.equal(dash.cost_pi, 3);
+  assert.equal(dash.effect_type, 'move_attack');
+  assert.equal(dash.move_distance, 2);
+  assert.equal(dash.rank, 1);
+});
+
+test('GET /api/jobs/vanguard abilities includono shield_bash + taunt + fortify', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const res = await request(app).get('/api/jobs/vanguard');
+  assert.equal(res.status, 200);
+  const ids = res.body.abilities.map((a) => a.ability_id);
+  assert.deepEqual(ids, ['shield_bash', 'taunt', 'fortify']);
+  const fortify = res.body.abilities.find((a) => a.ability_id === 'fortify');
+  assert.equal(fortify.rank, 2);
+  assert.equal(fortify.cost_pt, 3);
+});
+
+test('GET /api/jobs/nonexistent → 404 con error message', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const res = await request(app).get('/api/jobs/nonexistent');
+  assert.equal(res.status, 404);
+  assert.ok(res.body.error);
+  assert.ok(res.body.error.includes('nonexistent'));
+});


### PR DESCRIPTION
## Summary

Chiude **FRICTION #4** del playtest umano 2026-04-17 ("Skirmisher job ability `hit-and-run` non integrato — cost/trigger non chiari durante gioco").

**Root cause**: `data/core/jobs.yaml` contiene spec completa **21 abilities** su **7 job** (skirmisher, vanguard, warden, artificer, invoker, ranger, harvester) — ma zero backend endpoint per discoverability runtime. Master non aveva modo di lookup cost/effect durante playtest.

## Scope MVP (discoverability, executor = PR separato)

### Code
- ➕ `apps/backend/services/jobsLoader.js` (66 LOC) — carica jobs.yaml con graceful fallback
- ➕ `apps/backend/routes/jobs.js` (55 LOC):
  - `GET /api/jobs` → lista 7 job (id, label, role, signature, ability_ids, href)
  - `GET /api/jobs/:job_id` → dettaglio con abilities sorted by rank
  - 404 job invalido, 503 catalog null
- 📝 `apps/backend/services/pluginLoader.js` — registrato `jobsPlugin` in BUILTIN_PLUGINS

### Test
- ➕ `tests/api/jobs.test.js` (4 test, tutti verdi):
  - `GET /api/jobs` → 7 job con signature_mechanic + ability_ids
  - `GET /api/jobs/skirmisher` → abilities con cost + effect_type
  - `GET /api/jobs/vanguard` → shield_bash/taunt/fortify
  - `GET /api/jobs/nonexistent` → 404
- **Totale 165/165 test** AI+jobs verdi (era 161)

### Docs
- 📝 `docs/core/11-REGOLE_D20_TV.md` — nuova sezione "Ability syntax (FRICTION #4)":
  - Formato canonico: `<actor>: ability <ability_id> [target=<target_id>]`
  - Esempi (dash_strike, taunt, evasive_maneuver, fortify)
  - Runtime discoverability via GET /api/jobs
  - Cost spec (cost_ap, cost_pi, cost_pt/pp/sg/seed, effect_type)
  - Fallback playtest senza executor (Master applica manualmente)

## Follow-up (scope >300 LOC, PR separato)

- Executor `action_type='ability'` in `apps/backend/routes/session.js`
- Dispatcher per `effect_type`: `move_attack`, `attack_move`, `multi_attack`, `buff`, `debuff`, `heal`, `shield`, `aoe_debuff`, `reaction`, `ranged_attack`, ecc.
- Integration test end-to-end: player usa dash_strike, verifica move+atk + conditional buff

## Test plan

- [x] `node --test tests/ai/*.test.js tests/api/jobs.test.js` → 165/165 verdi
- [x] Governance `errors=0 warnings=5` (pre-existing)
- [x] Boot log: `[jobs] caricato …/jobs.yaml: 7 job`

## Rollback plan

Revert single commit. Endpoint discoverability-only, no executor → nessun rischio gameplay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)