### PR TITLE
feat(session): ability executor MVP (FRICTION #4)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -51,6 +51,7 @@ const { DEFAULT_ATTACK_RANGE } = require('../services/ai/policy');
 const { createSistemaTurnRunner } = require('../services/ai/sistemaTurnRunner');
 const { createDeclareSistemaIntents } = require('../services/ai/declareSistemaIntents');
 const { loadAiProfiles } = require('../services/ai/aiProfilesLoader');
+const { createAbilityExecutor } = require('../services/abilityExecutor');
 
 // Extracted modules — constants + pure helpers (token optimization).
 // See sessionConstants.js and sessionHelpers.js for the extracted code.
@@ -480,6 +481,19 @@ function createSessionRouter(options = {}) {
   });
   const { handleLegacyAttackViaRound, handleTurnEndViaRound } = roundBridge;
 
+  // FRICTION #4 MVP (playtest 2026-04-17): ability executor.
+  // POST /api/session/action con action_type='ability' → executor dispatcher
+  // (move_attack, attack_move, buff, heal; altri effect_type = 501).
+  const abilityExecutor = createAbilityExecutor({
+    performAttack,
+    buildAttackEvent,
+    buildMoveEvent,
+    appendEvent,
+    manhattanDistance,
+    gridSize: GRID_SIZE,
+    rng,
+  });
+
   // SPRINT_020: helper riutilizzabile che avanza attraverso tutti i turni
   // IA non-player fino a fermarsi su un player vivo (o nessuno). Ritorna
   // { iaActions, bleedingEvents } accumulati dall'intera catena. Usato
@@ -854,8 +868,19 @@ function createSessionRouter(options = {}) {
         });
       }
 
+      if (actionType === 'ability') {
+        const result = await abilityExecutor.executeAbility({ session, actor, body });
+        const payload = { ...result.body };
+        if (result.status === 200) {
+          payload.state = publicSessionView(session);
+          payload.cap_pt_used = session.cap_pt_used;
+          payload.cap_pt_max = session.cap_pt_max;
+        }
+        return res.status(result.status).json(payload);
+      }
+
       return res.status(400).json({
-        error: `action_type sconosciuto: "${actionType}" (atteso "attack", "move" o "turn")`,
+        error: `action_type sconosciuto: "${actionType}" (atteso "attack", "move", "turn" o "ability")`,
       });
     } catch (err) {
       next(err);

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -1,0 +1,485 @@
+// Ability Executor — FRICTION #4 MVP (playtest 2026-04-17).
+//
+// Dispatcher per action_type='ability' in POST /api/session/action.
+// Carica spec da jobsLoader (data/core/jobs.yaml), applica cost_ap,
+// dispatch per effect_type, emette raw event schema-compat:
+//   { action_type: 'ability', ability_id, effect_type, phase?, ... }
+//
+// MVP implementa 4 effect_type: move_attack, attack_move, buff, heal.
+// Altri tipi (aoe_*, multi_attack, shield, surge_aoe, reaction, ...)
+// ritornano 501 con la lista dei supported.
+
+'use strict';
+
+const { loadJobs, extractAbilities } = require('./jobsLoader');
+
+let abilityIndex = null;
+
+function buildAbilityIndex() {
+  const catalog = loadJobs();
+  const idx = new Map();
+  if (!catalog || !catalog.jobs) return idx;
+  for (const job of Object.values(catalog.jobs)) {
+    for (const ab of extractAbilities(job)) {
+      if (ab && ab.ability_id) idx.set(String(ab.ability_id), ab);
+    }
+  }
+  return idx;
+}
+
+function ensureAbilityIndex() {
+  if (!abilityIndex) abilityIndex = buildAbilityIndex();
+  return abilityIndex;
+}
+
+function findAbility(abilityId) {
+  return ensureAbilityIndex().get(String(abilityId || '')) || null;
+}
+
+const SUPPORTED_EFFECT_TYPES = new Set(['move_attack', 'attack_move', 'buff', 'heal']);
+
+function isWithinGrid(pos, gridSize) {
+  return pos.x >= 0 && pos.x < gridSize && pos.y >= 0 && pos.y < gridSize;
+}
+
+function createAbilityExecutor(deps) {
+  const {
+    performAttack,
+    buildAttackEvent,
+    buildMoveEvent,
+    appendEvent,
+    manhattanDistance,
+    gridSize = 6,
+    rng = Math.random,
+  } = deps;
+
+  // Applica buff self come status[buffStat_buff] + actor[buffStat_bonus].
+  // L'applicazione puntuale del bonus (es. a attack_mod effettivo) e'
+  // demandata al consumer: qui tracciamo solo il buff per il log e per
+  // lettura da parte di UI/debrief. Espansione al resolver = follow-up.
+  function applySelfBuff(actor, stat, amount, duration) {
+    if (!actor.status) actor.status = {};
+    const key = `${stat}_buff`;
+    actor.status[key] = Math.max(Number(actor.status[key]) || 0, duration);
+    actor[`${stat}_bonus`] = (actor[`${stat}_bonus`] || 0) + amount;
+  }
+
+  async function executeMoveAttack({ session, actor, ability, body }) {
+    const targetId = String(body.target_id || '');
+    const target = session.units.find((u) => u.id === targetId);
+    if (!target || target.hp <= 0) {
+      return { status: 400, body: { error: `target "${targetId}" non valido (morto o assente)` } };
+    }
+    const dest = body.position;
+    if (!dest || typeof dest.x !== 'number' || typeof dest.y !== 'number') {
+      return { status: 400, body: { error: 'position { x, y } richiesta per move_attack' } };
+    }
+    if (!isWithinGrid(dest, gridSize)) {
+      return {
+        status: 400,
+        body: { error: `posizione fuori griglia (${gridSize}x${gridSize})` },
+      };
+    }
+    const moveDist = manhattanDistance(actor.position, dest);
+    const maxMove = Number(ability.move_distance) || 0;
+    if (moveDist > maxMove) {
+      return {
+        status: 400,
+        body: { error: `move_distance superata: ${moveDist} > ${maxMove}` },
+      };
+    }
+    const blocker = session.units.find(
+      (u) => u.id !== actor.id && u.hp > 0 && u.position.x === dest.x && u.position.y === dest.y,
+    );
+    if (blocker) {
+      return {
+        status: 400,
+        body: { error: `casella (${dest.x},${dest.y}) occupata da ${blocker.id}` },
+      };
+    }
+
+    // Conditional buff valutato PRIMA del move (dash_strike: target_not_adjacent
+    // = Manhattan > 1 al momento della dichiarazione).
+    let buffApplied = null;
+    const distBefore = manhattanDistance(actor.position, target.position);
+    if (ability.buff_condition === 'target_not_adjacent' && distBefore > 1) {
+      buffApplied = {
+        stat: ability.buff_stat || 'attack_mod',
+        amount: Number(ability.buff_amount || 0),
+        reason: 'target_not_adjacent',
+      };
+    }
+
+    const positionFrom = { ...actor.position };
+    actor.position = { x: dest.x, y: dest.y };
+    const moveEvent = buildMoveEvent({ session, actor, positionFrom });
+    moveEvent.action_type = 'ability';
+    moveEvent.ability_id = ability.ability_id;
+    moveEvent.effect_type = 'move_attack';
+    moveEvent.phase = 'move';
+    moveEvent.ap_spent = 0;
+    await appendEvent(session, moveEvent);
+
+    // Verifica range dopo il move (skirmisher range=2 di default).
+    const attackRange = Number(actor.attack_range) || 2;
+    const distAfter = manhattanDistance(actor.position, target.position);
+    if (distAfter > attackRange) {
+      return {
+        status: 400,
+        body: {
+          error: `target fuori range dopo move: dist=${distAfter}, range=${attackRange}`,
+          position_from: positionFrom,
+          position_to: { ...actor.position },
+        },
+      };
+    }
+
+    // Applica bonus attack_mod temporaneo sull'attacco singolo.
+    const originalMod = actor.mod;
+    if (buffApplied && (ability.buff_stat || 'attack_mod') === 'attack_mod') {
+      actor.mod = Number(actor.mod || 0) + buffApplied.amount;
+    }
+    const hpBefore = target.hp;
+    const targetPosAtAttack = { ...target.position };
+    const res = performAttack(session, actor, target);
+    actor.mod = originalMod;
+
+    const attackEvent = buildAttackEvent({
+      session,
+      actor,
+      target,
+      result: res.result,
+      evaluation: res.evaluation,
+      damageDealt: res.damageDealt,
+      hpBefore,
+      targetPositionAtAttack: targetPosAtAttack,
+    });
+    attackEvent.action_type = 'ability';
+    attackEvent.ability_id = ability.ability_id;
+    attackEvent.effect_type = 'move_attack';
+    attackEvent.phase = 'attack';
+    attackEvent.ap_spent = Number(ability.cost_ap || 0);
+    if (buffApplied) attackEvent.ability_buff = buffApplied;
+    if (res.parry) attackEvent.parry = res.parry;
+    await appendEvent(session, attackEvent);
+
+    actor.ap_remaining = Math.max(
+      0,
+      (actor.ap_remaining ?? actor.ap) - Number(ability.cost_ap || 0),
+    );
+
+    return {
+      status: 200,
+      body: {
+        ok: true,
+        actor_id: actor.id,
+        ability_id: ability.ability_id,
+        effect_type: 'move_attack',
+        position_from: positionFrom,
+        position_to: { ...actor.position },
+        attack: {
+          target_id: target.id,
+          die: res.result.die,
+          roll: res.result.roll,
+          mos: res.result.mos,
+          hit: res.result.hit,
+          damage_dealt: res.damageDealt,
+          target_hp: target.hp,
+        },
+        buff_applied: buffApplied,
+        ap_remaining: actor.ap_remaining,
+      },
+    };
+  }
+
+  async function executeAttackMove({ session, actor, ability, body }) {
+    const targetId = String(body.target_id || '');
+    const target = session.units.find((u) => u.id === targetId);
+    if (!target || target.hp <= 0) {
+      return { status: 400, body: { error: `target "${targetId}" non valido (morto o assente)` } };
+    }
+    const attackRange = Number(actor.attack_range) || 2;
+    if (manhattanDistance(actor.position, target.position) > attackRange) {
+      return {
+        status: 400,
+        body: { error: `target fuori range (${attackRange})` },
+      };
+    }
+    const dest = body.position;
+    if (!dest || typeof dest.x !== 'number' || typeof dest.y !== 'number') {
+      return { status: 400, body: { error: 'position { x, y } richiesta per attack_move' } };
+    }
+    if (!isWithinGrid(dest, gridSize)) {
+      return {
+        status: 400,
+        body: { error: `posizione fuori griglia (${gridSize}x${gridSize})` },
+      };
+    }
+
+    const hpBefore = target.hp;
+    const targetPosAtAttack = { ...target.position };
+    const res = performAttack(session, actor, target);
+    const attackEvent = buildAttackEvent({
+      session,
+      actor,
+      target,
+      result: res.result,
+      evaluation: res.evaluation,
+      damageDealt: res.damageDealt,
+      hpBefore,
+      targetPositionAtAttack: targetPosAtAttack,
+    });
+    attackEvent.action_type = 'ability';
+    attackEvent.ability_id = ability.ability_id;
+    attackEvent.effect_type = 'attack_move';
+    attackEvent.phase = 'attack';
+    attackEvent.ap_spent = Number(ability.cost_ap || 0);
+    if (res.parry) attackEvent.parry = res.parry;
+    await appendEvent(session, attackEvent);
+
+    const moveDist = manhattanDistance(actor.position, dest);
+    const maxMove = Number(ability.move_distance) || 0;
+    if (moveDist > maxMove) {
+      return {
+        status: 400,
+        body: {
+          error: `move_distance superata: ${moveDist} > ${maxMove} (attack completato)`,
+        },
+      };
+    }
+    const blocker = session.units.find(
+      (u) => u.id !== actor.id && u.hp > 0 && u.position.x === dest.x && u.position.y === dest.y,
+    );
+    if (blocker) {
+      return {
+        status: 400,
+        body: {
+          error: `casella (${dest.x},${dest.y}) occupata da ${blocker.id} (attack completato)`,
+        },
+      };
+    }
+    const positionFrom = { ...actor.position };
+    actor.position = { x: dest.x, y: dest.y };
+    const moveEvent = buildMoveEvent({ session, actor, positionFrom });
+    moveEvent.action_type = 'ability';
+    moveEvent.ability_id = ability.ability_id;
+    moveEvent.effect_type = 'attack_move';
+    moveEvent.phase = 'move';
+    moveEvent.ap_spent = 0;
+    await appendEvent(session, moveEvent);
+
+    let buffApplied = null;
+    if (ability.buff_stat) {
+      const amt = Number(ability.buff_amount || 0);
+      const dur = Number(ability.buff_duration || 1);
+      applySelfBuff(actor, ability.buff_stat, amt, dur);
+      buffApplied = { stat: ability.buff_stat, amount: amt, duration: dur };
+    }
+
+    actor.ap_remaining = Math.max(
+      0,
+      (actor.ap_remaining ?? actor.ap) - Number(ability.cost_ap || 0),
+    );
+
+    return {
+      status: 200,
+      body: {
+        ok: true,
+        actor_id: actor.id,
+        ability_id: ability.ability_id,
+        effect_type: 'attack_move',
+        attack: {
+          target_id: target.id,
+          die: res.result.die,
+          roll: res.result.roll,
+          mos: res.result.mos,
+          hit: res.result.hit,
+          damage_dealt: res.damageDealt,
+          target_hp: target.hp,
+        },
+        position_from: positionFrom,
+        position_to: { ...actor.position },
+        buff_applied: buffApplied,
+        ap_remaining: actor.ap_remaining,
+      },
+    };
+  }
+
+  async function executeBuff({ session, actor, ability }) {
+    const buffStat = ability.buff_stat;
+    if (!buffStat) {
+      return { status: 400, body: { error: 'buff_stat richiesto in ability spec' } };
+    }
+    const amt = Number(ability.buff_amount || 0);
+    const dur = Number(ability.buff_duration || 1);
+    applySelfBuff(actor, buffStat, amt, dur);
+
+    actor.ap_remaining = Math.max(
+      0,
+      (actor.ap_remaining ?? actor.ap) - Number(ability.cost_ap || 0),
+    );
+
+    const event = {
+      ts: new Date().toISOString(),
+      session_id: session.session_id,
+      actor_id: actor.id,
+      actor_species: actor.species,
+      actor_job: actor.job,
+      action_type: 'ability',
+      ability_id: ability.ability_id,
+      effect_type: 'buff',
+      target_id: actor.id,
+      turn: session.turn,
+      ap_spent: Number(ability.cost_ap || 0),
+      buff_stat: buffStat,
+      buff_amount: amt,
+      buff_duration: dur,
+      trait_effects: [],
+    };
+    await appendEvent(session, event);
+
+    return {
+      status: 200,
+      body: {
+        ok: true,
+        actor_id: actor.id,
+        ability_id: ability.ability_id,
+        effect_type: 'buff',
+        buff_applied: { stat: buffStat, amount: amt, duration: dur },
+        ap_remaining: actor.ap_remaining,
+      },
+    };
+  }
+
+  async function executeHeal({ session, actor, ability, body }) {
+    const targetId = String(body.target_id || actor.id);
+    const target = session.units.find((u) => u.id === targetId);
+    if (!target || target.hp <= 0) {
+      return { status: 400, body: { error: `target "${targetId}" non valido (morto o assente)` } };
+    }
+    if (target.controlled_by !== actor.controlled_by) {
+      return { status: 400, body: { error: 'heal richiede target alleato' } };
+    }
+    const range = Number(ability.range) || 0;
+    if (range > 0 && manhattanDistance(actor.position, target.position) > range) {
+      return { status: 400, body: { error: `target fuori range (${range})` } };
+    }
+
+    const dice = ability.heal_dice || { count: 1, sides: 4, modifier: 0 };
+    let rolled = 0;
+    const dCount = Number(dice.count || 1);
+    const dSides = Number(dice.sides || 4);
+    for (let i = 0; i < dCount; i += 1) {
+      rolled += Math.floor(rng() * dSides) + 1;
+    }
+    rolled += Number(dice.modifier || 0);
+    const hpBefore = target.hp;
+    const maxHp = Number(target.max_hp || hpBefore || 0);
+    const healed = Math.max(0, Math.min(rolled, Math.max(0, maxHp - hpBefore)));
+    target.hp = hpBefore + healed;
+
+    let removedStatus = null;
+    if (ability.remove_status && target.status) {
+      const prev = Number(target.status[ability.remove_status]) || 0;
+      if (prev > 0) {
+        target.status[ability.remove_status] = 0;
+        removedStatus = { id: ability.remove_status, turns_removed: prev };
+      }
+    }
+
+    actor.ap_remaining = Math.max(
+      0,
+      (actor.ap_remaining ?? actor.ap) - Number(ability.cost_ap || 0),
+    );
+
+    const event = {
+      ts: new Date().toISOString(),
+      session_id: session.session_id,
+      actor_id: actor.id,
+      actor_species: actor.species,
+      actor_job: actor.job,
+      action_type: 'ability',
+      ability_id: ability.ability_id,
+      effect_type: 'heal',
+      target_id: target.id,
+      turn: session.turn,
+      ap_spent: Number(ability.cost_ap || 0),
+      healing_applied: healed,
+      heal_rolled: rolled,
+      target_hp_before: hpBefore,
+      target_hp_after: target.hp,
+      removed_status: removedStatus,
+      trait_effects: [],
+    };
+    await appendEvent(session, event);
+
+    return {
+      status: 200,
+      body: {
+        ok: true,
+        actor_id: actor.id,
+        ability_id: ability.ability_id,
+        effect_type: 'heal',
+        target_id: target.id,
+        healing_applied: healed,
+        heal_rolled: rolled,
+        target_hp_before: hpBefore,
+        target_hp_after: target.hp,
+        removed_status: removedStatus,
+        ap_remaining: actor.ap_remaining,
+      },
+    };
+  }
+
+  async function executeAbility({ session, actor, body }) {
+    const abilityId = String(body.ability_id || '');
+    if (!abilityId) {
+      return { status: 400, body: { error: 'ability_id richiesto per action_type=ability' } };
+    }
+    const ability = findAbility(abilityId);
+    if (!ability) {
+      return { status: 400, body: { error: `ability_id "${abilityId}" non trovata nel catalog` } };
+    }
+    const costAp = Number(ability.cost_ap || 0);
+    const apAvailable = Number(actor.ap_remaining ?? actor.ap ?? 0);
+    if (apAvailable < costAp) {
+      return {
+        status: 400,
+        body: {
+          error: `AP insufficienti per ability (richiesti ${costAp}, disponibili ${apAvailable})`,
+          ap_remaining: apAvailable,
+          cost_ap: costAp,
+        },
+      };
+    }
+    switch (ability.effect_type) {
+      case 'move_attack':
+        return executeMoveAttack({ session, actor, ability, body });
+      case 'attack_move':
+        return executeAttackMove({ session, actor, ability, body });
+      case 'buff':
+        return executeBuff({ session, actor, ability });
+      case 'heal':
+        return executeHeal({ session, actor, ability, body });
+      default:
+        return {
+          status: 501,
+          body: {
+            error: `effect_type "${ability.effect_type}" non implementato in MVP`,
+            ability_id: abilityId,
+            effect_type: ability.effect_type,
+            supported: Array.from(SUPPORTED_EFFECT_TYPES),
+          },
+        };
+    }
+  }
+
+  return { executeAbility, findAbility, SUPPORTED_EFFECT_TYPES };
+}
+
+module.exports = {
+  createAbilityExecutor,
+  findAbility,
+  ensureAbilityIndex,
+  SUPPORTED_EFFECT_TYPES,
+};

--- a/tests/api/abilityExecutor.test.js
+++ b/tests/api/abilityExecutor.test.js
@@ -1,0 +1,225 @@
+// tests/api/abilityExecutor.test.js — FRICTION #4 MVP executor.
+//
+// Verifica POST /api/session/action con action_type='ability':
+//   - dash_strike (move_attack): move + attack + buff conditional
+//   - evasive_maneuver (attack_move): attack + move + self-buff defense
+//   - cost_ap enforcement: AP insufficienti → 400
+//   - ability sconosciuta → 400
+//   - effect_type non supportato (blade_flurry = multi_attack) → 501
+//   - raw event persistito con action_type='ability' + ability_id
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+
+async function startSession(app) {
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  assert.equal(scenario.status, 200);
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units });
+  assert.equal(startRes.status, 200);
+  return { sid: startRes.body.session_id, state: startRes.body.state };
+}
+
+test('dash_strike: move_attack end-to-end, AP decremented, event emitted', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const { sid, state } = await startSession(app);
+  const scout = state.units.find((u) => u.id === 'p_scout');
+  const enemy = state.units.find((u) => u.id === 'e_nomad_1');
+  assert.ok(scout && enemy, 'scout + enemy presenti nel tutorial_01');
+  const apBefore = Number(scout.ap_remaining ?? scout.ap);
+
+  // scout (1,2) → enemy (3,2). Dash a (2,2) = 1 cella Manhattan, poi attack.
+  // Condition target_not_adjacent valutata PRIMA del move: dist=2 > 1 → buff attivo.
+  const dest = { x: 2, y: 2 };
+  const res = await request(app).post('/api/session/action').send({
+    session_id: sid,
+    action_type: 'ability',
+    actor_id: 'p_scout',
+    ability_id: 'dash_strike',
+    target_id: 'e_nomad_1',
+    position: dest,
+  });
+  assert.equal(res.status, 200, `dash_strike ok: ${JSON.stringify(res.body)}`);
+  assert.equal(res.body.effect_type, 'move_attack');
+  assert.equal(res.body.ability_id, 'dash_strike');
+  assert.deepEqual(res.body.position_to, dest);
+  assert.ok(res.body.attack, 'attack payload presente');
+  assert.equal(res.body.attack.target_id, 'e_nomad_1');
+  assert.ok(res.body.buff_applied, 'buff_applied atteso (target_not_adjacent)');
+  assert.equal(res.body.buff_applied.reason, 'target_not_adjacent');
+  assert.equal(res.body.ap_remaining, apBefore - 2, 'cost_ap=2 decrementa AP');
+
+  // Stato live conferma posizione scout + AP
+  const stateRes = await request(app).get('/api/session/state').query({ session_id: sid });
+  const scoutAfter = stateRes.body.units.find((u) => u.id === 'p_scout');
+  assert.deepEqual(scoutAfter.position, dest);
+  assert.equal(scoutAfter.ap_remaining, apBefore - 2);
+});
+
+test('evasive_maneuver: attack_move applica buff defense_mod 1 turno', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const { sid, state } = await startSession(app);
+  const scout = state.units.find((u) => u.id === 'p_scout');
+  const enemy = state.units.find((u) => u.id === 'e_nomad_1');
+  assert.ok(scout && enemy);
+
+  // scout (1,2) → range 2 → enemy (3,2) a distanza 2. Attack poi move verso (1,1).
+  const dest = { x: 1, y: 1 };
+  const res = await request(app).post('/api/session/action').send({
+    session_id: sid,
+    action_type: 'ability',
+    actor_id: 'p_scout',
+    ability_id: 'evasive_maneuver',
+    target_id: 'e_nomad_1',
+    position: dest,
+  });
+  assert.equal(res.status, 200, `evasive_maneuver ok: ${JSON.stringify(res.body)}`);
+  assert.equal(res.body.effect_type, 'attack_move');
+  assert.deepEqual(res.body.position_to, dest);
+  assert.ok(res.body.buff_applied, 'buff_applied atteso');
+  assert.equal(res.body.buff_applied.stat, 'defense_mod');
+  assert.equal(res.body.buff_applied.amount, 1);
+  assert.equal(res.body.buff_applied.duration, 1);
+
+  // Verifica status persistito
+  const stateRes = await request(app).get('/api/session/state').query({ session_id: sid });
+  const scoutAfter = stateRes.body.units.find((u) => u.id === 'p_scout');
+  assert.equal(
+    Number(scoutAfter.status?.defense_mod_buff) || 0,
+    1,
+    'defense_mod_buff status attivo 1 turno',
+  );
+  assert.equal(Number(scoutAfter.defense_mod_bonus) || 0, 1);
+});
+
+test('cost_ap enforcement: ability rigettata se AP insufficienti', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const { sid, state } = await startSession(app);
+  const scout = state.units.find((u) => u.id === 'p_scout');
+  const initialAp = Number(scout.ap_remaining ?? scout.ap);
+
+  // Drena AP via move finché ne resta 1 (insufficiente per dash_strike cost_ap=2).
+  // scout ap=3 → draina 2 con 2 move da 1 cella ciascuno.
+  for (let i = 0; i < initialAp - 1; i += 1) {
+    const stateRes = await request(app).get('/api/session/state').query({ session_id: sid });
+    const self = stateRes.body.units.find((u) => u.id === 'p_scout');
+    const from = self.position;
+    const occupied = new Set(
+      stateRes.body.units
+        .filter((u) => u.hp > 0 && u.id !== 'p_scout')
+        .map((u) => `${u.position.x},${u.position.y}`),
+    );
+    const candidates = [
+      { x: from.x + 1, y: from.y },
+      { x: from.x - 1, y: from.y },
+      { x: from.x, y: from.y + 1 },
+      { x: from.x, y: from.y - 1 },
+    ].filter((p) => p.x >= 0 && p.x < 6 && p.y >= 0 && p.y < 6 && !occupied.has(`${p.x},${p.y}`));
+    assert.ok(candidates.length > 0);
+    const mres = await request(app).post('/api/session/action').send({
+      session_id: sid,
+      action_type: 'move',
+      actor_id: 'p_scout',
+      position: candidates[0],
+    });
+    assert.equal(mres.status, 200);
+  }
+
+  const res = await request(app)
+    .post('/api/session/action')
+    .send({
+      session_id: sid,
+      action_type: 'ability',
+      actor_id: 'p_scout',
+      ability_id: 'dash_strike',
+      target_id: 'e_nomad_1',
+      position: { x: 2, y: 2 },
+    });
+  assert.equal(res.status, 400, `ability rigettata per AP: ${JSON.stringify(res.body)}`);
+  assert.match(res.body.error || '', /AP insufficienti/i);
+  assert.equal(res.body.cost_ap, 2);
+});
+
+test('ability_id sconosciuta → 400', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const { sid } = await startSession(app);
+  const res = await request(app).post('/api/session/action').send({
+    session_id: sid,
+    action_type: 'ability',
+    actor_id: 'p_scout',
+    ability_id: 'inexistent_ability',
+    target_id: 'e_nomad_1',
+  });
+  assert.equal(res.status, 400);
+  assert.match(res.body.error || '', /non trovata/i);
+});
+
+test('effect_type non supportato (blade_flurry = multi_attack) → 501', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const { sid } = await startSession(app);
+  const res = await request(app).post('/api/session/action').send({
+    session_id: sid,
+    action_type: 'ability',
+    actor_id: 'p_scout',
+    ability_id: 'blade_flurry',
+    target_id: 'e_nomad_1',
+  });
+  assert.equal(res.status, 501, `multi_attack non supportato in MVP: ${JSON.stringify(res.body)}`);
+  assert.equal(res.body.effect_type, 'multi_attack');
+  assert.ok(Array.isArray(res.body.supported), 'supported list presente');
+  assert.ok(res.body.supported.includes('move_attack'));
+});
+
+test('raw event persistito con action_type=ability + ability_id', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const { sid } = await startSession(app);
+  await request(app)
+    .post('/api/session/action')
+    .send({
+      session_id: sid,
+      action_type: 'ability',
+      actor_id: 'p_scout',
+      ability_id: 'dash_strike',
+      target_id: 'e_nomad_1',
+      position: { x: 2, y: 2 },
+    });
+
+  // Estrai eventi via debug endpoint se presente, altrimenti verifica via /state log_events_count
+  const stateRes = await request(app).get('/api/session/state').query({ session_id: sid });
+  assert.ok(
+    stateRes.body.log_events_count >= 2,
+    `attesi >=2 event (move + attack phase): ${stateRes.body.log_events_count}`,
+  );
+});


### PR DESCRIPTION
## Summary

- Wire `action_type='ability'` in `POST /api/session/action` — chiude FRICTION #4 lato runtime (discoverability: PR #1496)
- Nuovo modulo `apps/backend/services/abilityExecutor.js` (factory DI) carica spec da `data/core/jobs.yaml` e dispatch per `effect_type`
- MVP supporta 4 `effect_type`:
  - `move_attack` (dash_strike) — move Manhattan ≤ `move_distance`, poi attack; `buff_condition='target_not_adjacent'` aggiunge `+buff_amount` ad `attack_mod` per l'attacco
  - `attack_move` (evasive_maneuver) — attack in range, poi move ≤ `move_distance`, applica self-buff `status[stat_buff]` + `actor[stat_bonus]`
  - `buff` (fortify) — self-buff come status + bonus stat
  - `heal` (growth_spore) — restore HP ad alleato in range, opzionale `remove_status`
- Altri `effect_type` (aoe_*, multi_attack, shield, surge_aoe, reaction, debuff, team_buff, team_heal, execution_attack, drain_attack, attack_push, aggro_pull, ranged_attack) → **501** con `supported` list

## Validation

- `cost_ap > actor.ap_remaining` → **400** con `cost_ap`, `ap_remaining` nel body
- `ability_id` non in catalog → **400**
- target morto/assente o fuori range → **400**
- position fuori griglia o occupata → **400**

## Raw event schema

Ogni ability emette 1-2 event con:
- `action_type: 'ability'`
- `ability_id: '<id>'`
- `effect_type: '<type>'`
- `phase: 'move' | 'attack'` per multi-phase (move_attack, attack_move)
- `ap_spent` sull'event che paga il costo (attack o buff/heal)

Compat con `vcScoring.js` (che cerca `action_type`, `damage_dealt`, `result`).

## Test plan

- [x] `node --test tests/api/abilityExecutor.test.js` — **6/6 verdi**
  - dash_strike move_attack end-to-end
  - evasive_maneuver attack_move + buff persistito
  - cost_ap enforcement (drain via move, ability rigettata 400)
  - ability_id sconosciuta → 400
  - blade_flurry (multi_attack) → 501
  - raw event log_events_count >= 2
- [x] Regression: `tests/ai/*.test.js` (161/161), `jobs.test.js`, `sessionLegacyActionWrapper.test.js`, `atlasLive.test.js`, `hazardWiring.test.js` — verdi
- [ ] CI `python-tests` + `stack-quality`

## Rollback

Revert singolo commit. Nuovo modulo isolato (`abilityExecutor.js`), wiring in `session.js` è 2 linee di import + 12 linee di dispatcher. Nessuna modifica a endpoint esistenti (`attack`/`move`/`turn`).

## Follow-up (non in questo PR)

- `multi_attack` (blade_flurry): 3 attack con `-damage_step_mod` + PP generation
- `attack_push` (shield_bash): push target 1 cella + apply_status sbilanciato
- `aoe_*` (binding_field, sanctuary): area-of-effect con mask su cells
- `reaction` (intercept, opportunist_strike): trigger passive
- Bonus `actor[stat]_bonus` al resolver (attualmente applicato solo `attack_mod` temporaneo nel move_attack; `defense_mod_bonus` tracciato ma non consumato nel damage step → issue dedicata)

🤖 Generated with [Claude Code](https://claude.com/claude-code)