### PR TITLE
feat(ability): FRICTION #6 effective_reach + #7 effect_trigger semantics

### DIFF
--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -608,6 +608,9 @@ function createAbilityExecutor(deps) {
   }
 
   // attack_push (shield_bash): attack + push target 1 cella + apply_status.
+  // FRICTION #7 (playtest 2026-04-17-02): ability paga AP, status default
+  // gated on hit. Override esplicito via ability.effect_trigger='always'
+  // applica push + apply_status anche su miss (caso "sbilanciato sempre").
   async function executeAttackPush({ session, actor, ability, body }) {
     const targetId = String(body.target_id || '');
     const target = session.units.find((u) => u.id === targetId);
@@ -623,10 +626,13 @@ function createAbilityExecutor(deps) {
     const targetPositionAtAttack = { ...target.position };
     const res = performAttack(session, actor, target);
 
+    const trigger = String(ability.effect_trigger || 'on_hit');
+    const allowEffect = (trigger === 'always' || res.result.hit) && target.hp > 0;
+
     // Push: calcola destinazione, verifica griglia + non occupata. Fallisce
     // silenziosamente se bloccato (attack va comunque a segno).
     let pushed = null;
-    if (res.result.hit && target.hp > 0) {
+    if (allowEffect) {
       const pushDist = Math.max(1, Number(ability.push_distance || 1));
       const pushFrom = { ...target.position };
       let destX = pushFrom.x;
@@ -648,9 +654,9 @@ function createAbilityExecutor(deps) {
       }
     }
 
-    // apply_status su target
+    // apply_status su target (rispetta effect_trigger come push)
     let appliedStatus = null;
-    if (res.result.hit && target.hp > 0 && ability.apply_status && ability.apply_status.status_id) {
+    if (allowEffect && ability.apply_status && ability.apply_status.status_id) {
       const sid = String(ability.apply_status.status_id);
       const dur = Number(ability.apply_status.duration || 1);
       if (!target.status) target.status = {};
@@ -672,6 +678,7 @@ function createAbilityExecutor(deps) {
     event.ability_id = ability.ability_id;
     event.effect_type = 'attack_push';
     event.ap_spent = Number(ability.cost_ap || 0);
+    event.effect_trigger = trigger;
     if (pushed) event.pushed = pushed;
     if (appliedStatus) event.applied_status = appliedStatus;
     if (res.parry) event.parry = res.parry;
@@ -689,6 +696,7 @@ function createAbilityExecutor(deps) {
         actor_id: actor.id,
         ability_id: ability.ability_id,
         effect_type: 'attack_push',
+        effect_trigger: trigger,
         attack: {
           target_id: target.id,
           die: res.result.die,
@@ -1622,9 +1630,21 @@ function createAbilityExecutor(deps) {
   return { executeAbility, findAbility, SUPPORTED_EFFECT_TYPES };
 }
 
+// Test helper: override l'index per test deterministici. Reset con
+// resetAbilityIndex() per ricaricare da jobs.yaml.
+function _setAbilityForTest(abilityId, spec) {
+  const idx = ensureAbilityIndex();
+  idx.set(String(abilityId), spec);
+}
+function _resetAbilityIndex() {
+  abilityIndex = null;
+}
+
 module.exports = {
   createAbilityExecutor,
   findAbility,
   ensureAbilityIndex,
   SUPPORTED_EFFECT_TYPES,
+  _setAbilityForTest,
+  _resetAbilityIndex,
 };

--- a/apps/backend/services/jobsLoader.js
+++ b/apps/backend/services/jobsLoader.js
@@ -46,14 +46,63 @@ function loadJobs(yamlPath = DEFAULT_JOBS_PATH, logger = console) {
 }
 
 /**
+ * FRICTION #6 (playtest 2026-04-17-02): effective_reach derivata.
+ * Distance Manhattan massima a cui l'ability puo' colpire un target,
+ * combinando move_distance (se presente) + range/attack_range.
+ *
+ * Map per effect_type:
+ *   - move_attack: move_distance + (attack_range del job, default 2)
+ *   - attack_move: attack_range (move dopo, no contributo)
+ *   - ranged_attack: ability.range || attack_range
+ *   - aoe_*, surge_aoe: ability.range (se centro va su cell remota)
+ *   - heal/team_heal: ability.range
+ *   - drain_attack/multi_attack/attack_push/execution_attack: attack_range
+ *   - buff/team_buff/shield/reaction: 0 (self/cast-on-allies in range custom)
+ */
+function computeEffectiveReach(ability, jobAttackRange) {
+  const ar = Number(jobAttackRange || 2);
+  const range = Number(ability.range || 0);
+  const moveDist = Number(ability.move_distance || 0);
+  switch (ability.effect_type) {
+    case 'move_attack':
+      return moveDist + ar;
+    case 'attack_move':
+    case 'multi_attack':
+    case 'attack_push':
+    case 'drain_attack':
+    case 'execution_attack':
+      return ar;
+    case 'ranged_attack':
+      return range || ar;
+    case 'aoe_buff':
+    case 'aoe_debuff':
+    case 'surge_aoe':
+    case 'heal':
+    case 'team_heal':
+    case 'team_buff':
+    case 'debuff':
+      return range || ar;
+    case 'buff':
+    case 'shield':
+    case 'reaction':
+    case 'aggro_pull':
+      return 0;
+    default:
+      return range || ar;
+  }
+}
+
+/**
  * Estrae lista abilities di un job come array (vs oggetto unlock_r1_1 / r1_2 / r2).
- * Ordina per rank asc.
+ * Ordina per rank asc. Aggiunge effective_reach per ogni ability.
  */
 function extractAbilities(jobEntry) {
   if (!jobEntry || !jobEntry.abilities) return [];
+  const ar = Number(jobEntry.attack_range || 2);
   return Object.values(jobEntry.abilities)
     .filter((a) => a && a.ability_id)
-    .sort((a, b) => (a.rank || 99) - (b.rank || 99));
+    .sort((a, b) => (a.rank || 99) - (b.rank || 99))
+    .map((a) => ({ ...a, effective_reach: computeEffectiveReach(a, ar) }));
 }
 
-module.exports = { loadJobs, extractAbilities, DEFAULT_JOBS_PATH };
+module.exports = { loadJobs, extractAbilities, computeEffectiveReach, DEFAULT_JOBS_PATH };

--- a/tests/api/abilityExecutor.test.js
+++ b/tests/api/abilityExecutor.test.js
@@ -577,6 +577,174 @@ test('overwatch_shot: reaction registra trigger su actor.reactions[]', async (t)
   assert.match(res.body.note || '', /trigger system pending/i);
 });
 
+test('FRICTION #6: effective_reach esposto in GET /api/jobs/:id per ogni ability', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const res = await request(app).get('/api/jobs/skirmisher');
+  assert.equal(res.status, 200);
+  const dash = res.body.abilities.find((a) => a.ability_id === 'dash_strike');
+  // dash_strike: move_distance=2 + skirmisher attack_range=2 = 4
+  assert.equal(dash.effective_reach, 4, `dash_strike effective_reach = move(2) + range(2) = 4`);
+
+  const evasive = res.body.abilities.find((a) => a.ability_id === 'evasive_maneuver');
+  // attack_move: solo attack_range=2 (move dopo non contribuisce)
+  assert.equal(evasive.effective_reach, 2);
+
+  const flurry = res.body.abilities.find((a) => a.ability_id === 'blade_flurry');
+  // multi_attack: attack_range=2
+  assert.equal(flurry.effective_reach, 2);
+
+  // Invoker focused_blast: ranged_attack range override implicito (no range field → attack_range=3)
+  const inv = await request(app).get('/api/jobs/invoker');
+  const blast = inv.body.abilities.find((a) => a.ability_id === 'focused_blast');
+  assert.equal(blast.effective_reach, 3, `focused_blast: invoker attack_range=3`);
+
+  // Vanguard fortify (buff self): effective_reach=0
+  const van = await request(app).get('/api/jobs/vanguard');
+  const fortify = van.body.abilities.find((a) => a.ability_id === 'fortify');
+  assert.equal(fortify.effective_reach, 0, 'self-buff = reach 0');
+});
+
+test('FRICTION #7: shield_bash default on_hit (miss → no push, no status)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  // Inietta rng deterministico nel session router per forzare miss
+  // (die=1, garantito miss vs DC>=12).
+  const fixedRng = (() => {
+    let calls = 0;
+    return () => {
+      calls += 1;
+      if (calls === 1) return 0; // rollD20 → die=1
+      return 0.5;
+    };
+  })();
+  const { app: app2, close: close2 } = createApp({
+    databasePath: null,
+    session: { rng: fixedRng },
+  });
+  t.after(async () => {
+    if (typeof close2 === 'function') await close2().catch(() => {});
+  });
+
+  const scenario = await request(app2).get('/api/tutorial/enc_tutorial_01');
+  const startRes = await request(app2)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units });
+  const sid = startRes.body.session_id;
+
+  // Move tank a (2,4) per essere in range di e_nomad_2 (3,4)
+  await request(app2)
+    .post('/api/session/action')
+    .send({
+      session_id: sid,
+      action_type: 'move',
+      actor_id: 'p_tank',
+      position: { x: 2, y: 3 },
+    });
+  await request(app2)
+    .post('/api/session/action')
+    .send({
+      session_id: sid,
+      action_type: 'move',
+      actor_id: 'p_tank',
+      position: { x: 2, y: 4 },
+    });
+
+  const res = await request(app2).post('/api/session/action').send({
+    session_id: sid,
+    action_type: 'ability',
+    actor_id: 'p_tank',
+    ability_id: 'shield_bash',
+    target_id: 'e_nomad_2',
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.attack.hit, false, 'attack miss confermato (die=1)');
+  assert.equal(res.body.effect_trigger, 'on_hit', 'default on_hit');
+  assert.equal(res.body.pushed, null, 'no push su miss');
+  assert.equal(res.body.applied_status, null, 'no status su miss');
+
+  // Verifica via /state che e_nomad_2 NON abbia sbilanciato
+  const stateRes = await request(app2).get('/api/session/state').query({ session_id: sid });
+  const enemy = stateRes.body.units.find((u) => u.id === 'e_nomad_2');
+  assert.equal(Number(enemy.status?.sbilanciato) || 0, 0, 'sbilanciato non applicato su miss');
+});
+
+test('FRICTION #7: ability con effect_trigger=always applica push + status anche su miss', async (t) => {
+  const {
+    _setAbilityForTest,
+    _resetAbilityIndex,
+  } = require('../../apps/backend/services/abilityExecutor');
+  // Inietta variant di shield_bash con effect_trigger=always
+  _setAbilityForTest('shield_bash_always', {
+    ability_id: 'shield_bash_always',
+    effect_type: 'attack_push',
+    cost_ap: 1,
+    push_distance: 1,
+    apply_status: { status_id: 'sbilanciato', duration: 1 },
+    effect_trigger: 'always',
+    target: 'enemy',
+    rank: 1,
+  });
+  t.after(() => _resetAbilityIndex());
+
+  // RNG forzato a die=1 (miss garantito)
+  const fixedRng = (() => {
+    let calls = 0;
+    return () => {
+      calls += 1;
+      if (calls === 1) return 0;
+      return 0.5;
+    };
+  })();
+  const { app, close } = createApp({ databasePath: null, session: { rng: fixedRng } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units });
+  const sid = startRes.body.session_id;
+
+  await request(app)
+    .post('/api/session/action')
+    .send({
+      session_id: sid,
+      action_type: 'move',
+      actor_id: 'p_tank',
+      position: { x: 2, y: 3 },
+    });
+  await request(app)
+    .post('/api/session/action')
+    .send({
+      session_id: sid,
+      action_type: 'move',
+      actor_id: 'p_tank',
+      position: { x: 2, y: 4 },
+    });
+
+  const res = await request(app).post('/api/session/action').send({
+    session_id: sid,
+    action_type: 'ability',
+    actor_id: 'p_tank',
+    ability_id: 'shield_bash_always',
+    target_id: 'e_nomad_2',
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.attack.hit, false, 'attack miss confermato');
+  assert.equal(res.body.effect_trigger, 'always');
+  // Su miss + always → status applicato comunque
+  assert.ok(res.body.applied_status, 'sbilanciato applicato anche su miss');
+  assert.equal(res.body.applied_status.id, 'sbilanciato');
+});
+
 test('raw event persistito con action_type=ability + ability_id', async (t) => {
   const { app, close } = createApp({ databasePath: null });
   t.after(async () => {


### PR DESCRIPTION
## Summary

Risolve 2 friction documentate in playtest 2026-04-17-02 ([PR #1502](https://github.com/MasterDD-L34D/Game/pull/1502)).

### FRICTION #6 — ability range explicit

- `jobsLoader.computeEffectiveReach(ability, jobAttackRange)`: calcola Manhattan max a cui ability può colpire, derivando da `move_distance + attack_range` per `effect_type`.
- Esposto in `GET /api/jobs/:id` per ogni ability come `effective_reach` field.
- Mapping per effect_type:
  - `move_attack` → `move_distance + attack_range` (es. dash_strike skirmisher = 2+2 = **4**)
  - `attack_move`, `multi_attack`, `attack_push`, `drain_attack`, `execution_attack` → `attack_range`
  - `ranged_attack` → `range || attack_range`
  - `aoe_*`, `surge_aoe`, `heal`, `team_*`, `debuff` → `range || attack_range`
  - `buff`, `shield`, `reaction`, `aggro_pull` → **0** (self/cast-on-allies)
- Master/UI mostrano reach reale durante planning → evita "ability inerti".

### FRICTION #7 — ability-effect semantics

- `executeAttackPush` rispetta `ability.effect_trigger ('on_hit' | 'always')`.
- **Default 'on_hit'** (no breaking change). `'always'` applica push + `apply_status` anche su miss (paga AP per tentativo).
- Field opzionale in ogni ability YAML: data scientist decide semantica per-ability senza modificare codice.
- Event log + response includono `effect_trigger` per traceability.

## Test plan

- [x] `node --test tests/api/abilityExecutor.test.js` — **24/24 verdi**
  - 5 verifica `effective_reach`: dash_strike (4), evasive_maneuver (2), blade_flurry (2), focused_blast (3), fortify (0)
  - `effect_trigger` default on_hit: rng forzato die=1 → no push, no status
  - `effect_trigger='always'`: variant `shield_bash_always` iniettata via test helper, miss → sbilanciato applicato comunque
- [x] Test helpers esposti: `_setAbilityForTest(id, spec)` + `_resetAbilityIndex()`
- [x] Regression: `tests/ai/*.test.js` 161/161, `jobs.test.js` 4/4 (effective_reach field non rompe assertions esistenti)
- [ ] CI `stack-quality` + `python-tests`

## Decisione data design

`effect_trigger` è OPT-IN: lasciato fuori dalle ability YAML attuali, default `on_hit` rimane. Master DD può aggiungere `effect_trigger: always` a `shield_bash` (o nuove ability) quando deciderà semantica canonica per playtest #3.

## Rollback

Revert singolo commit. Modifiche isolate:
- `apps/backend/services/jobsLoader.js`: +1 funzione `computeEffectiveReach` + map `effective_reach` su ability list
- `apps/backend/services/abilityExecutor.js`: 2 condizioni in `executeAttackPush` rispettano `effect_trigger` + 2 test helper export
- `tests/api/abilityExecutor.test.js`: +3 test

Nessuna modifica breaking. `effective_reach` field nuovo (additivo). `effect_trigger` opzionale (default invariato).

## Decisioni operative chiuse (da playtest #2)

- [x] Spec ability on-hit vs always-on per shield_bash → `effect_trigger` opt-in field, default on_hit canonico
- [ ] `GET /api/jobs/:id` integrato in tool playtest — già disponibile da PR #1496, ora arricchito con `effective_reach`
- [ ] Nuovo playtest con executor live (#1499-#1501) — abilitato

🤖 Generated with [Claude Code](https://claude.com/claude-code)