### PR TITLE
feat(reaction): iter4 trigger system per intercept + overwatch_shot

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -52,6 +52,7 @@ const { createSistemaTurnRunner } = require('../services/ai/sistemaTurnRunner');
 const { createDeclareSistemaIntents } = require('../services/ai/declareSistemaIntents');
 const { loadAiProfiles } = require('../services/ai/aiProfilesLoader');
 const { createAbilityExecutor } = require('../services/abilityExecutor');
+const reactionEngine = require('../services/reactionEngine');
 
 // Extracted modules — constants + pure helpers (token optimization).
 // See sessionConstants.js and sessionHelpers.js for the extracted code.
@@ -199,6 +200,7 @@ function createSessionRouter(options = {}) {
     let wasBackstab = false;
     let panicTriggered = false;
     let parryResult = null;
+    let interceptResult = null;
     if (result.hit) {
       const baseDamage = 1 + result.pt;
       // SPRINT_007 fase 1 (issue #4): bonus damage +1 quando l'attaccante
@@ -253,6 +255,15 @@ function createSessionRouter(options = {}) {
       if (target.hp === 0) {
         killOccurred = true;
       }
+      // iter4 reaction engine: intercept reroute damage da target a alleato
+      // adiacente con `intercept` armed. Restore target.hp + transfer to interceptor.
+      if (damageDealt > 0) {
+        interceptResult = reactionEngine.triggerOnDamage(session, actor, target, damageDealt);
+        if (interceptResult) {
+          killOccurred = false; // target survived
+          panicTriggered = false; // panic non si applica se danno deviato
+        }
+      }
       // SPRINT_013 (issue #10): trigger panic nel target se subisce un
       // colpo critico (MoS >= 8). Il target non e' ancora morto (target.hp
       // potrebbe essere a 0 ma panic su un'unita' KO e' innocuo). Applica
@@ -303,6 +314,7 @@ function createSessionRouter(options = {}) {
       panicTriggered,
       status_applies: statusApplies,
       parry: parryResult,
+      intercept: interceptResult,
     };
   }
 
@@ -830,6 +842,38 @@ function createSessionRouter(options = {}) {
           consumeCapPt(session, requestedCapPt);
         }
         await appendEvent(session, event);
+        // iter4 reaction engine: overwatch_shot fires se enemy con reaction
+        // armed ha il mover in attack_range post-move.
+        const overwatchResult = reactionEngine.triggerOnMove(
+          session,
+          actor,
+          positionFrom,
+          (overwatchUnit, mover) => performAttack(session, overwatchUnit, mover),
+        );
+        if (overwatchResult) {
+          await appendEvent(session, {
+            ts: new Date().toISOString(),
+            session_id: session.session_id,
+            actor_id: overwatchResult.overwatch_id,
+            action_type: 'reaction_trigger',
+            ability_id: overwatchResult.ability_id,
+            trigger: 'enemy_moves_in_range',
+            target_id: overwatchResult.mover_id,
+            turn: session.turn,
+            from_position: overwatchResult.from_position,
+            to_position: overwatchResult.to_position,
+            die: overwatchResult.die,
+            roll: overwatchResult.roll,
+            mos: overwatchResult.mos,
+            result: overwatchResult.hit ? 'hit' : 'miss',
+            damage_dealt: overwatchResult.damage_dealt,
+            mover_hp_before: overwatchResult.mover_hp_before,
+            mover_hp_after: overwatchResult.mover_hp_after,
+            mover_killed: overwatchResult.mover_killed,
+            damage_step_mod: overwatchResult.damage_step_mod,
+            trait_effects: [],
+          });
+        }
         return res.json({
           ok: true,
           actor_id: actor.id,
@@ -838,6 +882,7 @@ function createSessionRouter(options = {}) {
           facing: actor.facing,
           cap_pt_used: session.cap_pt_used,
           cap_pt_max: session.cap_pt_max,
+          overwatch: overwatchResult,
           state: publicSessionView(session),
         });
       }

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -166,6 +166,7 @@ function createRoundBridge(deps) {
         capturedResults.damageDealt = res.damageDealt;
         capturedResults.killOccurred = res.killOccurred;
         capturedResults.parry = res.parry;
+        capturedResults.intercept = res.intercept || null;
         // Pilastro 5: focus_fire combo. Se altri player hanno gia' colpito lo
         // stesso target in questo round, +1 dmg al secondo/terzo attacco.
         const comboInfo = detectFocusFireCombo(session, actor, target);
@@ -245,11 +246,32 @@ function createRoundBridge(deps) {
         targetPositionAtAttack,
       });
       if (capturedResults.parry) event.parry = capturedResults.parry;
+      if (capturedResults.intercept) event.intercept = capturedResults.intercept;
       if (requestedCapPt > 0) {
         event.cost = { cap_pt: requestedCapPt };
         consumeCapPt(session, requestedCapPt);
       }
       await appendEvent(session, event);
+      // iter4: emit reaction_trigger event quando intercept fires.
+      if (capturedResults.intercept) {
+        await appendEvent(session, {
+          ts: new Date().toISOString(),
+          session_id: session.session_id,
+          actor_id: capturedResults.intercept.interceptor_id,
+          action_type: 'reaction_trigger',
+          ability_id: capturedResults.intercept.ability_id,
+          trigger: 'ally_attacked_adjacent',
+          target_id: capturedResults.intercept.interceptor_id,
+          original_target_id: capturedResults.intercept.target_id,
+          attacker_id: capturedResults.intercept.attacker_id,
+          turn: session.turn,
+          damage_rerouted: capturedResults.intercept.damage_rerouted,
+          interceptor_hp_before: capturedResults.intercept.interceptor_hp_before,
+          interceptor_hp_after: capturedResults.intercept.interceptor_hp_after,
+          interceptor_killed: capturedResults.intercept.interceptor_killed,
+          trait_effects: [],
+        });
+      }
       if (capturedResults.killOccurred) {
         await emitKillAndAssists(session, actor, target, event);
         // Sistema pressure (AI War pattern — sistema_pressure.yaml §deltas):
@@ -286,6 +308,7 @@ function createRoundBridge(deps) {
       actor_position: { ...actor.position },
       target_position: targetPositionAtAttack,
       parry: capturedResults.parry,
+      intercept: capturedResults.intercept || null,
       combo: capturedResults.combo || null,
       state: publicSessionView(session),
       round_wrapper: true,

--- a/apps/backend/services/reactionEngine.js
+++ b/apps/backend/services/reactionEngine.js
@@ -1,0 +1,189 @@
+// Reaction Engine — iter4 (FRICTION #4 follow-up).
+//
+// Trigger system per ability con effect_type='reaction'. Reactions
+// armed via abilityExecutor.executeReaction() vivono in actor.reactions[].
+// Questo modulo le consuma quando il trigger fires:
+//   - intercept (warden): trigger='ally_attacked_adjacent'.
+//     Quando alleato adiacente subisce damage, l'interceptor reroute il
+//     danno su se stesso. Consuma reaction.
+//   - overwatch_shot (ranger): trigger='enemy_moves_in_range'.
+//     Quando enemy si muove in attack_range dell'overwatch, fires
+//     attacco automatico (-1 damage_step). Consuma reaction.
+//
+// Hook points:
+//   - performAttack post-damage: triggerOnDamage()
+//   - move handler post-position: triggerOnMove()
+//
+// Eventi reaction emessi separatamente con action_type='reaction_trigger'
+// per traceability nel log + vcScoring.
+
+'use strict';
+
+function manhattan(a, b) {
+  return Math.abs(Number(a.x) - Number(b.x)) + Math.abs(Number(a.y) - Number(b.y));
+}
+
+function isAlive(unit) {
+  return unit && Number(unit.hp) > 0;
+}
+
+function isStunned(unit) {
+  return unit && unit.status && Number(unit.status.stunned) > 0;
+}
+
+function findReaction(unit, trigger) {
+  if (!unit || !Array.isArray(unit.reactions)) return null;
+  for (let i = 0; i < unit.reactions.length; i += 1) {
+    if (String(unit.reactions[i].trigger || '') === trigger) {
+      return { reaction: unit.reactions[i], index: i };
+    }
+  }
+  return null;
+}
+
+function consumeReaction(unit, index) {
+  if (!unit || !Array.isArray(unit.reactions)) return null;
+  const removed = unit.reactions.splice(index, 1);
+  return removed[0] || null;
+}
+
+/**
+ * Intercept trigger: dopo damage applied, scan target's allies adiacenti
+ * (Manhattan=1) per intercept armed. Primo eligible reroute damageDealt.
+ *
+ * Side effect:
+ *   - target.hp += damageDealt (restore)
+ *   - interceptor.hp -= damageDealt (transfer)
+ *   - session.damage_taken[target] -= damageDealt
+ *   - session.damage_taken[interceptor] += damageDealt
+ *   - interceptor.reactions consumed
+ *
+ * @returns null se nessun intercept fired, altrimenti { interceptor_id, damage_rerouted, ability_id }.
+ */
+function triggerOnDamage(session, attacker, target, damageDealt) {
+  if (!session || !target || !damageDealt || damageDealt <= 0) return null;
+  if (!isAlive(target)) return null;
+
+  // Find allied unit adjacent to target with intercept armed.
+  for (const unit of session.units || []) {
+    if (!unit) continue;
+    if (unit.id === target.id) continue;
+    if (unit.controlled_by !== target.controlled_by) continue;
+    if (!isAlive(unit) || isStunned(unit)) continue;
+    if (manhattan(unit.position, target.position) !== 1) continue;
+    const found = findReaction(unit, 'ally_attacked_adjacent');
+    if (!found) continue;
+
+    const reaction = found.reaction;
+    consumeReaction(unit, found.index);
+
+    // Reroute: restore target, transfer to interceptor.
+    target.hp = Math.min(Number(target.max_hp || target.hp + damageDealt), target.hp + damageDealt);
+    if (session.damage_taken) {
+      session.damage_taken[target.id] = Math.max(
+        0,
+        (session.damage_taken[target.id] || 0) - damageDealt,
+      );
+    }
+    const interceptorHpBefore = unit.hp;
+    unit.hp = Math.max(0, Number(unit.hp || 0) - damageDealt);
+    if (session.damage_taken) {
+      session.damage_taken[unit.id] = (session.damage_taken[unit.id] || 0) + damageDealt;
+    }
+
+    return {
+      interceptor_id: unit.id,
+      target_id: target.id,
+      attacker_id: attacker ? attacker.id : null,
+      ability_id: reaction.ability_id || 'intercept',
+      damage_rerouted: damageDealt,
+      interceptor_hp_before: interceptorHpBefore,
+      interceptor_hp_after: unit.hp,
+      interceptor_killed: unit.hp === 0,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Overwatch trigger: dopo move, scan enemies con overwatch_shot armed
+ * la cui posizione è in attack_range del mover. Primo eligible fires:
+ * usa performAttack callback con damage_step_mod -1 applicato post-hoc.
+ *
+ * @param {object} session
+ * @param {object} mover unità che si è mossa
+ * @param {object} fromPos posizione precedente (per logging)
+ * @param {function} performAttack callback (overwatchUnit, mover) → { result, damageDealt, evaluation, parry }
+ * @returns null se nessun overwatch fired, altrimenti { overwatch_id, damage_dealt, ... }.
+ */
+function triggerOnMove(session, mover, fromPos, performAttack) {
+  if (!session || !mover || !isAlive(mover)) return null;
+
+  for (const unit of session.units || []) {
+    if (!unit) continue;
+    if (unit.id === mover.id) continue;
+    if (unit.controlled_by === mover.controlled_by) continue;
+    if (!isAlive(unit) || isStunned(unit)) continue;
+    const range = Number(unit.attack_range) || 2;
+    if (manhattan(unit.position, mover.position) > range) continue;
+    const found = findReaction(unit, 'enemy_moves_in_range');
+    if (!found) continue;
+
+    const reaction = found.reaction;
+    consumeReaction(unit, found.index);
+
+    // Fire attack
+    const moverHpBefore = mover.hp;
+    const res = performAttack(unit, mover);
+    let adjustedDamage = res ? Number(res.damageDealt || 0) : 0;
+    const damageStepMod = Number(reaction.damage_step_mod || 0);
+    // Apply damage_step_mod (es. overwatch_shot -1)
+    if (res && res.result && res.result.hit && adjustedDamage > 0 && damageStepMod !== 0) {
+      if (damageStepMod < 0) {
+        const refund = Math.min(-damageStepMod, adjustedDamage);
+        mover.hp = Math.min(Number(mover.max_hp || moverHpBefore), mover.hp + refund);
+        if (session.damage_taken) {
+          session.damage_taken[mover.id] = Math.max(
+            0,
+            (session.damage_taken[mover.id] || 0) - refund,
+          );
+        }
+        adjustedDamage = Math.max(0, adjustedDamage - refund);
+      } else {
+        const extra = Math.min(damageStepMod, mover.hp);
+        mover.hp = Math.max(0, mover.hp - extra);
+        if (session.damage_taken) {
+          session.damage_taken[mover.id] = (session.damage_taken[mover.id] || 0) + extra;
+        }
+        adjustedDamage += extra;
+      }
+    }
+
+    return {
+      overwatch_id: unit.id,
+      mover_id: mover.id,
+      ability_id: reaction.ability_id || 'overwatch_shot',
+      from_position: fromPos ? { ...fromPos } : null,
+      to_position: { ...mover.position },
+      hit: res && res.result ? !!res.result.hit : false,
+      die: res && res.result ? res.result.die : null,
+      roll: res && res.result ? res.result.roll : null,
+      mos: res && res.result ? res.result.mos : null,
+      damage_dealt: adjustedDamage,
+      mover_hp_before: moverHpBefore,
+      mover_hp_after: mover.hp,
+      mover_killed: mover.hp === 0,
+      damage_step_mod: damageStepMod,
+    };
+  }
+
+  return null;
+}
+
+module.exports = {
+  triggerOnDamage,
+  triggerOnMove,
+  findReaction,
+  consumeReaction,
+};

--- a/tests/api/abilityExecutor.test.js
+++ b/tests/api/abilityExecutor.test.js
@@ -745,6 +745,128 @@ test('FRICTION #7: ability con effect_trigger=always applica push + status anche
   assert.equal(res.body.applied_status.id, 'sbilanciato');
 });
 
+test('iter4 intercept: ally adjacent reroute damage to interceptor', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const { sid, state } = await startSession(app);
+  // p_scout (1,2), p_tank (1,3) adiacenti. e_nomad_1 (3,2) range 2 → può colpire scout.
+  // 1. p_tank arma intercept (warden ability via abilityIndex, no job check)
+  const armRes = await request(app).post('/api/session/action').send({
+    session_id: sid,
+    action_type: 'ability',
+    actor_id: 'p_tank',
+    ability_id: 'intercept',
+  });
+  assert.equal(armRes.status, 200, `intercept armed: ${JSON.stringify(armRes.body)}`);
+  assert.equal(armRes.body.effect_type, 'reaction');
+
+  // Verify reaction registered
+  const stateAfterArm = await request(app).get('/api/session/state').query({ session_id: sid });
+  const tank = stateAfterArm.body.units.find((u) => u.id === 'p_tank');
+  assert.ok(Array.isArray(tank.reactions) && tank.reactions.length === 1);
+  const tankHpBefore = tank.hp;
+  const scout = stateAfterArm.body.units.find((u) => u.id === 'p_scout');
+  const scoutHpBefore = scout.hp;
+
+  // 2. e_nomad_1 attacks p_scout (no side check on /action)
+  const atkRes = await request(app).post('/api/session/action').send({
+    session_id: sid,
+    action_type: 'attack',
+    actor_id: 'e_nomad_1',
+    target_id: 'p_scout',
+  });
+  assert.equal(atkRes.status, 200);
+
+  // 3. If hit, intercept should have rerouted damage to tank.
+  if (atkRes.body.result === 'hit' && atkRes.body.damage_dealt > 0) {
+    const stateAfter = await request(app).get('/api/session/state').query({ session_id: sid });
+    const scoutAfter = stateAfter.body.units.find((u) => u.id === 'p_scout');
+    const tankAfter = stateAfter.body.units.find((u) => u.id === 'p_tank');
+    assert.equal(
+      scoutAfter.hp,
+      scoutHpBefore,
+      `scout HP unchanged (intercept rerouted): before=${scoutHpBefore}, after=${scoutAfter.hp}`,
+    );
+    assert.ok(
+      tankAfter.hp < tankHpBefore,
+      `tank HP < before (received rerouted damage): before=${tankHpBefore}, after=${tankAfter.hp}`,
+    );
+    // Reaction consumed
+    assert.equal(
+      Array.isArray(tankAfter.reactions) ? tankAfter.reactions.length : 0,
+      0,
+      'reaction consumed after fire',
+    );
+  }
+});
+
+test('iter4 overwatch_shot: mover in range post-move fires reaction', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const { sid, state } = await startSession(app);
+  // 1. e_nomad_1 (3,2) arma overwatch_shot. nomad ap=2 → cast (1 AP) ok.
+  const armRes = await request(app).post('/api/session/action').send({
+    session_id: sid,
+    action_type: 'ability',
+    actor_id: 'e_nomad_1',
+    ability_id: 'overwatch_shot',
+  });
+  assert.equal(armRes.status, 200, `overwatch armed: ${JSON.stringify(armRes.body)}`);
+
+  // 2. p_scout (1,2) move a (2,2) → ancora in range 2 di e_nomad (3,2). Trigger fires.
+  const scoutHpBefore = state.units.find((u) => u.id === 'p_scout').hp;
+  const moveRes = await request(app)
+    .post('/api/session/action')
+    .send({
+      session_id: sid,
+      action_type: 'move',
+      actor_id: 'p_scout',
+      position: { x: 2, y: 2 },
+    });
+  assert.equal(moveRes.status, 200);
+  assert.ok(moveRes.body.overwatch, 'overwatch fired su move');
+  assert.equal(moveRes.body.overwatch.overwatch_id, 'e_nomad_1');
+  assert.equal(moveRes.body.overwatch.mover_id, 'p_scout');
+
+  // Verify reaction consumed
+  const stateAfter = await request(app).get('/api/session/state').query({ session_id: sid });
+  const nomadAfter = stateAfter.body.units.find((u) => u.id === 'e_nomad_1');
+  assert.equal(
+    Array.isArray(nomadAfter.reactions) ? nomadAfter.reactions.length : 0,
+    0,
+    'reaction consumed',
+  );
+});
+
+test('iter4 no reaction armed: damage applies normalmente', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const { sid, state } = await startSession(app);
+  const scoutHpBefore = state.units.find((u) => u.id === 'p_scout').hp;
+
+  const atkRes = await request(app).post('/api/session/action').send({
+    session_id: sid,
+    action_type: 'attack',
+    actor_id: 'e_nomad_1',
+    target_id: 'p_scout',
+  });
+  assert.equal(atkRes.status, 200);
+  if (atkRes.body.result === 'hit' && atkRes.body.damage_dealt > 0) {
+    const stateAfter = await request(app).get('/api/session/state').query({ session_id: sid });
+    const scoutAfter = stateAfter.body.units.find((u) => u.id === 'p_scout');
+    assert.ok(scoutAfter.hp < scoutHpBefore, 'scout HP scende normalmente (no intercept armed)');
+  }
+});
+
 test('raw event persistito con action_type=ability + ability_id', async (t) => {
   const { app, close } = createApp({ databasePath: null });
   t.after(async () => {


### PR DESCRIPTION
## Summary

Implementa **trigger system** per ability con `effect_type='reaction'` (stub iter3 [PR #1501](https://github.com/MasterDD-L34D/Game/pull/1501)). Reactions armed via `executeReaction` ora auto-consumate quando trigger fires.

**Nuovo modulo** [`apps/backend/services/reactionEngine.js`](apps/backend/services/reactionEngine.js):

- `triggerOnDamage(session, attacker, target, damageDealt)` — scan target's allies adiacenti (Manhattan=1) per `intercept` armed con `trigger='ally_attacked_adjacent'`. Primo eligible reroute damage:
  - target HP restored + damage_taken decremented
  - interceptor HP damaged + damage_taken incremented
  - reaction consumed
  - `killOccurred` + `panicTriggered` annullati
- `triggerOnMove(session, mover, fromPos, performAttack)` — scan enemies con `overwatch_shot` armed la cui posizione è in `attack_range` del mover post-move. Primo eligible fires `performAttack(overwatch, mover)` con `damage_step_mod` (es. -1) post-hoc + reaction consumed.

**Hook points**:

- [session.js performAttack](apps/backend/routes/session.js): `triggerOnDamage` chiamato dopo damage applied. `interceptResult` propagato via return value.
- [session.js move handler](apps/backend/routes/session.js): `triggerOnMove` chiamato dopo position update. `overwatch_event` emesso + result incluso in response body.
- [sessionRoundBridge.handleLegacyAttackViaRound](apps/backend/routes/sessionRoundBridge.js): captura `intercept` da `performAttack` + emette `reaction_trigger` event con `damage_rerouted`, `hp_before/after`, `killed`.

**Schema event** `reaction_trigger`:
```js
{ action_type: 'reaction_trigger', ability_id, trigger,
  actor_id (interceptor|overwatch), target_id, original_target_id?,
  damage_rerouted? | damage_dealt?, hp_before, hp_after, killed }
```

**Edge cases**:

- Stunned interceptor → skip (continua scan)
- Self-target interceptor → skip (own ID excluded)
- Multiple eligible → primo vince
- Damage 0 / miss → no trigger

## Test plan

- [x] `node --test tests/api/abilityExecutor.test.js` — **27/27 verdi** (3 nuovi)
  - intercept reroute: e_nomad attacks p_scout, p_tank intercept armed → tank prende danno, scout salvo, reaction consumed
  - overwatch fires: e_nomad arma overwatch_shot, p_scout move in range → fires + reaction consumed
  - no reaction → damage normale (regression check)
- [x] Regression: `tests/ai/*.test.js` 161/161, `jobs`, `sessionLegacyActionWrapper`, `atlasLive`, `hazardWiring`, `predict-combat` tutti verdi
- [ ] CI `stack-quality` + `python-tests`

## Rollback

Revert singolo commit. Modifiche isolate:
- `apps/backend/services/reactionEngine.js`: nuovo modulo (~150 LOC)
- `apps/backend/routes/session.js`: 2 hook (8 + 35 righe) per intercept + overwatch
- `apps/backend/routes/sessionRoundBridge.js`: 1 capture (intercept) + 1 event emit
- `tests/api/abilityExecutor.test.js`: +3 test

Nessuna modifica breaking. `reactions[]` è additivo a unit state.

## Follow-up (iter5)

- `aggro_pull` (taunt): estende `declareSistemaIntents` per rispettare `target.status.aggro_locked`
- Interceptor death NON triggera kill chain (no `emitKillAndAssists` sull'interceptor) — solo target kill chain attivo
- Overwatch semantica: fires se mover ends in range. NON distingue "moves INTO range" — iter follow-up può aggiungere `fromPos` distance check

🤖 Generated with [Claude Code](https://claude.com/claude-code)