### PR TITLE
feat(ability): iter5 aggro_pull (taunt) — 18/18 effect_type

### DIFF
--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -5,7 +5,7 @@
 // dispatch per effect_type, emette raw event schema-compat:
 //   { action_type: 'ability', ability_id, effect_type, phase?, ... }
 //
-// Implementa 17 effect_type (16 attivi + 1 stub reaction):
+// Implementa 18/18 effect_type (TUTTI supportati):
 //   - move_attack (dash_strike): move + attack + conditional buff
 //   - attack_move (evasive_maneuver): attack + move + self-buff
 //   - buff (fortify): self-buff stat + duration
@@ -23,8 +23,8 @@
 //   - aoe_debuff (binding_field): area NxN, debuff enemies
 //   - surge_aoe (cataclysm): area NxN, damage_dice + stress_reset, shield-aware
 //   - reaction (intercept, overwatch_shot): register actor.reactions[] (trigger sys = follow-up)
-//
-// Non implementato (→ 501): aggro_pull (richiede AI integration).
+//   - aggro_pull (taunt): self-buff defense + target.status.aggro_locked
+//     (declareSistemaIntents respect override per SIS units)
 //
 // Stat bonus wiring: actor.attack_mod_bonus + target.defense_mod_bonus
 // consumati in sessionHelpers.resolveAttack + predictCombat. Decay via
@@ -75,6 +75,7 @@ const SUPPORTED_EFFECT_TYPES = new Set([
   'aoe_debuff',
   'surge_aoe',
   'reaction',
+  'aggro_pull',
 ]);
 
 // Push direction from actor to target: target spostato di 1 cella
@@ -1558,6 +1559,84 @@ function createAbilityExecutor(deps) {
     };
   }
 
+  // aggro_pull (taunt): forza target a attaccare actor per N turni.
+  // Self-buff defense_mod (per spec). Target.status.aggro_locked = duration
+  // + target.aggro_source = actor.id. declareSistemaIntents rispetta override
+  // se target è SIS. Su PG (target=player) il flag è informativo (no AI).
+  async function executeAggroPull({ session, actor, ability, body }) {
+    const targetId = String(body.target_id || '');
+    const target = session.units.find((u) => u.id === targetId);
+    if (!target || target.hp <= 0) {
+      return { status: 400, body: { error: `target "${targetId}" non valido (morto o assente)` } };
+    }
+    if (target.controlled_by === actor.controlled_by) {
+      return { status: 400, body: { error: 'aggro_pull richiede target nemico' } };
+    }
+    // Target deve essere adiacente (taunt mischia per design)
+    const range = Number(ability.range || 1);
+    if (manhattanDistance(actor.position, target.position) > range) {
+      return {
+        status: 400,
+        body: {
+          error: `target fuori range (${range}, dist=${manhattanDistance(actor.position, target.position)})`,
+        },
+      };
+    }
+
+    // Self-buff defense (es. taunt: defense_mod +2 1 turno)
+    let buffApplied = null;
+    if (ability.buff_stat) {
+      const amt = Number(ability.buff_amount || 0);
+      const dur = Number(ability.buff_duration || 1);
+      applySelfBuff(actor, ability.buff_stat, amt, dur);
+      buffApplied = { stat: ability.buff_stat, amount: amt, duration: dur };
+    }
+
+    // Aggro lock su target
+    const aggroDuration = Number(ability.aggro_duration || ability.buff_duration || 1);
+    if (!target.status) target.status = {};
+    target.status.aggro_locked = Math.max(Number(target.status.aggro_locked) || 0, aggroDuration);
+    target.aggro_source = actor.id;
+
+    actor.ap_remaining = Math.max(
+      0,
+      (actor.ap_remaining ?? actor.ap) - Number(ability.cost_ap || 0),
+    );
+
+    const event = {
+      ts: new Date().toISOString(),
+      session_id: session.session_id,
+      actor_id: actor.id,
+      actor_species: actor.species,
+      actor_job: actor.job,
+      action_type: 'ability',
+      ability_id: ability.ability_id,
+      effect_type: 'aggro_pull',
+      target_id: target.id,
+      turn: session.turn,
+      ap_spent: Number(ability.cost_ap || 0),
+      aggro_duration: aggroDuration,
+      buff_applied: buffApplied,
+      trait_effects: [],
+    };
+    await appendEvent(session, event);
+
+    return {
+      status: 200,
+      body: {
+        ok: true,
+        actor_id: actor.id,
+        ability_id: ability.ability_id,
+        effect_type: 'aggro_pull',
+        target_id: target.id,
+        aggro_duration: aggroDuration,
+        aggro_source: actor.id,
+        buff_applied: buffApplied,
+        ap_remaining: actor.ap_remaining,
+      },
+    };
+  }
+
   async function executeAbility({ session, actor, body }) {
     const abilityId = String(body.ability_id || '');
     if (!abilityId) {
@@ -1614,6 +1693,8 @@ function createAbilityExecutor(deps) {
         return executeSurgeAoe({ session, actor, ability, body });
       case 'reaction':
         return executeReaction({ session, actor, ability });
+      case 'aggro_pull':
+        return executeAggroPull({ session, actor, ability, body });
       default:
         return {
           status: 501,

--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -164,11 +164,26 @@ function createDeclareSistemaIntents(deps) {
         continue;
       }
 
-      // Prima scelta: lowest-HP globale (pick classico).
-      let target = pickLowestHpEnemy(session, actor);
+      // iter5 aggro_pull (taunt): se actor ha status.aggro_locked attivo,
+      // forza target = aggro_source (vivo). Override pickLowestHpEnemy.
+      let target = null;
+      let aggroOverride = false;
+      const aggroLocked = Number(actor.status?.aggro_locked) || 0;
+      const aggroSource = actor.aggro_source;
+      if (aggroLocked > 0 && aggroSource) {
+        const lock = (session.units || []).find(
+          (u) => u && u.id === aggroSource && Number(u.hp) > 0,
+        );
+        if (lock) {
+          target = lock;
+          aggroOverride = true;
+        }
+      }
+      if (!target) target = pickLowestHpEnemy(session, actor);
       // Se gia' preso da altro SIS, ri-pick escludendo i presi.
       // Fall back al pick originale solo se non ci sono alternative.
-      if (target && takenTargetIds.has(target.id)) {
+      // Aggro override IGNORA il taken-set (taunt forza il bersaglio).
+      if (!aggroOverride && target && takenTargetIds.has(target.id)) {
         const alt = pickTargetExcluding(actor, takenTargetIds);
         if (alt) target = alt;
       }
@@ -245,6 +260,7 @@ function createDeclareSistemaIntents(deps) {
           rule: policy.rule,
           intent: 'attack',
           target_id: target.id,
+          aggro_override: aggroOverride || undefined,
         });
         continue;
       }
@@ -311,6 +327,7 @@ function createDeclareSistemaIntents(deps) {
         intent: policy.intent, // 'approach' o 'retreat'
         target_id: target.id,
         move_to: nextPos,
+        aggro_override: aggroOverride || undefined,
       });
     }
 

--- a/tests/api/abilityExecutor.test.js
+++ b/tests/api/abilityExecutor.test.js
@@ -178,7 +178,20 @@ test('ability_id sconosciuta → 400', async (t) => {
   assert.match(res.body.error || '', /non trovata/i);
 });
 
-test('effect_type non supportato (taunt = aggro_pull) → 501', async (t) => {
+test('effect_type non supportato → 501 (sentinel test, ability sintetica unsupported_xyz)', async (t) => {
+  const {
+    _setAbilityForTest,
+    _resetAbilityIndex,
+  } = require('../../apps/backend/services/abilityExecutor');
+  _setAbilityForTest('synthetic_unknown', {
+    ability_id: 'synthetic_unknown',
+    effect_type: 'unknown_xyz',
+    cost_ap: 1,
+    target: 'self',
+    rank: 1,
+  });
+  t.after(() => _resetAbilityIndex());
+
   const { app, close } = createApp({ databasePath: null });
   t.after(async () => {
     if (typeof close === 'function') await close().catch(() => {});
@@ -189,13 +202,13 @@ test('effect_type non supportato (taunt = aggro_pull) → 501', async (t) => {
     session_id: sid,
     action_type: 'ability',
     actor_id: 'p_tank',
-    ability_id: 'taunt',
+    ability_id: 'synthetic_unknown',
   });
-  assert.equal(res.status, 501, `aggro_pull non supportato: ${JSON.stringify(res.body)}`);
-  assert.equal(res.body.effect_type, 'aggro_pull');
+  assert.equal(res.status, 501, `unknown effect_type: ${JSON.stringify(res.body)}`);
+  assert.equal(res.body.effect_type, 'unknown_xyz');
   assert.ok(Array.isArray(res.body.supported));
-  assert.ok(res.body.supported.includes('shield'));
-  assert.ok(res.body.supported.includes('aoe_debuff'));
+  assert.ok(res.body.supported.includes('aggro_pull'), 'aggro_pull ora supportato in iter5');
+  assert.equal(res.body.supported.length, 18, '18/18 effect_type supportati');
 });
 
 test('blade_flurry: multi_attack esegue fino a attack_count hit', async (t) => {
@@ -865,6 +878,171 @@ test('iter4 no reaction armed: damage applies normalmente', async (t) => {
     const scoutAfter = stateAfter.body.units.find((u) => u.id === 'p_scout');
     assert.ok(scoutAfter.hp < scoutHpBefore, 'scout HP scende normalmente (no intercept armed)');
   }
+});
+
+test('iter5 taunt: aggro_pull applica defense buff + aggro_locked su target', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const { sid } = await startSession(app);
+  // p_tank (1,3) → move (2,3) → move (3,3) adjacente a e_nomad_1 (3,2). 2 AP usati.
+  await request(app)
+    .post('/api/session/action')
+    .send({
+      session_id: sid,
+      action_type: 'move',
+      actor_id: 'p_tank',
+      position: { x: 2, y: 3 },
+    });
+  await request(app)
+    .post('/api/session/action')
+    .send({
+      session_id: sid,
+      action_type: 'move',
+      actor_id: 'p_tank',
+      position: { x: 3, y: 3 },
+    });
+
+  const res = await request(app).post('/api/session/action').send({
+    session_id: sid,
+    action_type: 'ability',
+    actor_id: 'p_tank',
+    ability_id: 'taunt',
+    target_id: 'e_nomad_1',
+  });
+  assert.equal(res.status, 200, `taunt ok: ${JSON.stringify(res.body)}`);
+  assert.equal(res.body.effect_type, 'aggro_pull');
+  assert.equal(res.body.target_id, 'e_nomad_1');
+  assert.equal(res.body.aggro_source, 'p_tank');
+  assert.equal(res.body.buff_applied.stat, 'defense_mod');
+  assert.equal(res.body.buff_applied.amount, 2);
+
+  // Verifica state
+  const stateRes = await request(app).get('/api/session/state').query({ session_id: sid });
+  const enemy = stateRes.body.units.find((u) => u.id === 'e_nomad_1');
+  assert.ok(Number(enemy.status?.aggro_locked) >= 1, 'enemy.status.aggro_locked attivo');
+  assert.equal(enemy.aggro_source, 'p_tank');
+  const tank = stateRes.body.units.find((u) => u.id === 'p_tank');
+  assert.equal(Number(tank.defense_mod_bonus) || 0, 2);
+});
+
+test('iter5 declareSistemaIntents respect aggro_locked → target = aggro_source', async (t) => {
+  const {
+    createDeclareSistemaIntents,
+  } = require('../../apps/backend/services/ai/declareSistemaIntents');
+  const declare = createDeclareSistemaIntents({
+    pickLowestHpEnemy: (sess, actor) => {
+      // Default pick: lowest hp enemy
+      return (sess.units || [])
+        .filter((u) => u.controlled_by !== actor.controlled_by && Number(u.hp) > 0)
+        .sort((a, b) => Number(a.hp) - Number(b.hp))[0];
+    },
+    stepTowards: (from, to) => ({
+      x: from.x + Math.sign(to.x - from.x),
+      y: from.y + Math.sign(to.y - from.y),
+    }),
+    manhattanDistance: (a, b) => Math.abs(a.x - b.x) + Math.abs(a.y - b.y),
+    gridSize: 6,
+  });
+
+  const session = {
+    units: [
+      {
+        id: 'p_scout',
+        controlled_by: 'player',
+        hp: 5,
+        max_hp: 10,
+        position: { x: 1, y: 2 },
+        attack_range: 2,
+      },
+      {
+        id: 'p_tank',
+        controlled_by: 'player',
+        hp: 12,
+        max_hp: 12,
+        position: { x: 3, y: 3 },
+        attack_range: 1,
+      },
+      {
+        id: 'e_nomad_1',
+        controlled_by: 'sistema',
+        hp: 3,
+        max_hp: 3,
+        position: { x: 3, y: 2 },
+        attack_range: 2,
+        // Aggro-locked su p_tank (NON il lowest-hp che sarebbe p_scout)
+        status: { aggro_locked: 1 },
+        aggro_source: 'p_tank',
+      },
+    ],
+  };
+
+  const { decisions } = declare(session);
+  const decision = decisions.find((d) => d.unit_id === 'e_nomad_1');
+  assert.ok(decision, 'decision per e_nomad presente');
+  assert.equal(
+    decision.target_id,
+    'p_tank',
+    'aggro override → target = p_tank (non p_scout lowest-hp)',
+  );
+  assert.equal(decision.aggro_override, true);
+});
+
+test('iter5 senza aggro_locked, AI sceglie lowest-hp normale (regression)', async (t) => {
+  const {
+    createDeclareSistemaIntents,
+  } = require('../../apps/backend/services/ai/declareSistemaIntents');
+  const declare = createDeclareSistemaIntents({
+    pickLowestHpEnemy: (sess, actor) => {
+      return (sess.units || [])
+        .filter((u) => u.controlled_by !== actor.controlled_by && Number(u.hp) > 0)
+        .sort((a, b) => Number(a.hp) - Number(b.hp))[0];
+    },
+    stepTowards: (from, to) => ({
+      x: from.x + Math.sign(to.x - from.x),
+      y: from.y + Math.sign(to.y - from.y),
+    }),
+    manhattanDistance: (a, b) => Math.abs(a.x - b.x) + Math.abs(a.y - b.y),
+    gridSize: 6,
+  });
+
+  const session = {
+    units: [
+      {
+        id: 'p_scout',
+        controlled_by: 'player',
+        hp: 5,
+        max_hp: 10,
+        position: { x: 1, y: 2 },
+        attack_range: 2,
+      },
+      {
+        id: 'p_tank',
+        controlled_by: 'player',
+        hp: 12,
+        max_hp: 12,
+        position: { x: 3, y: 3 },
+        attack_range: 1,
+      },
+      {
+        id: 'e_nomad_1',
+        controlled_by: 'sistema',
+        hp: 3,
+        max_hp: 3,
+        position: { x: 3, y: 2 },
+        attack_range: 2,
+        // No aggro: AI sceglie lowest-hp
+      },
+    ],
+  };
+
+  const { decisions } = declare(session);
+  const decision = decisions.find((d) => d.unit_id === 'e_nomad_1');
+  assert.ok(decision);
+  assert.equal(decision.target_id, 'p_scout', 'no aggro → lowest-hp pick (p_scout)');
+  assert.equal(decision.aggro_override, undefined);
 });
 
 test('raw event persistito con action_type=ability + ability_id', async (t) => {


### PR DESCRIPTION
## Summary

Ultimo `effect_type` non implementato (`aggro_pull`) ora attivo. **Roster ability completo** per FRICTION #4 — 18/18 effect_type supportati.

### abilityExecutor

`executeAggroPull` (target nemico, default range=1):
- Self-buff `defense_mod` via `applySelfBuff` (es. taunt: +2 defense 1 turno)
- `target.status.aggro_locked = aggro_duration` (default = `buff_duration`)
- `target.aggro_source = actor.id` (puntatore per AI override)
- Raw event con `effect_type='aggro_pull'`

`SUPPORTED_EFFECT_TYPES`: 17 → **18** (aggiunge `aggro_pull`).

### declareSistemaIntents

Override target selection in [`apps/backend/services/ai/declareSistemaIntents.js`](apps/backend/services/ai/declareSistemaIntents.js):
- Prima di `pickLowestHpEnemy`, controlla `actor.status.aggro_locked > 0` + `actor.aggro_source`
- Se source vivo → target forzato a source
- Annotato in `decisions[]` con `aggro_override: true`
- `takenTargetIds` NON applicato a aggro override (taunt forza bersaglio)

## Test plan

- [x] `node --test tests/api/abilityExecutor.test.js` — **27/27 verdi** (3 nuovi)
  - taunt end-to-end: p_tank casts taunt su e_nomad_1 → verify `aggro_locked` + `aggro_source` + `defense_mod_bonus` persistito
  - declareSistemaIntents aggro override: enemy con aggro_locked + source → targets aggro_source (NON lowest-hp p_scout)
  - regression senza aggro_locked: AI sceglie lowest-hp normale
- [x] Test sentinel 501 aggiornato: ability sintetica `unknown_xyz` invece di taunt (ora supportato). Verifica `supported.length === 18`
- [x] Regression: `tests/ai/*.test.js` 161/161, `jobs`, `sessionLegacyActionWrapper`, `atlasLive`, `hazardWiring`, `predict-combat`, `apBudget` tutti verdi
- [ ] CI `stack-quality` + `python-tests`

## Note design

- `aggro_locked` decade via roundBridge standard status decay (no logic extra)
- `aggro_source` NON azzerato a decay (puntatore stale ok: AI check `aggro_locked > 0` prima di leggere source)
- Player units NON gestite: flag informativo per UI/log, nessuna AI da forzare lato player. Tutorial solo player attacks SIS

## Rollback

Revert singolo commit. Modifiche isolate:
- `apps/backend/services/abilityExecutor.js`: +1 executor (~75 LOC) + dispatcher case + supported set + header doc
- `apps/backend/services/ai/declareSistemaIntents.js`: 12 righe (override target selection) + 2 annotation aggro_override
- `tests/api/abilityExecutor.test.js`: +3 test, sentinel 501 aggiornato

Nessuna modifica breaking. Le decisioni AI continuano a usare lowest-hp default quando aggro_locked non attivo.

## Roster completo finale

`move_attack`, `attack_move`, `buff`, `heal`, `multi_attack`, `attack_push`, `debuff`, `ranged_attack`, `drain_attack`, `execution_attack`, `shield`, `team_buff`, `team_heal`, `aoe_buff`, `aoe_debuff`, `surge_aoe`, `reaction`, `aggro_pull` — **18/18**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)