### PR TITLE
play: CLI interactive — "far partire il gioco" sprint A

### DIFF
--- a/tests/tools/play.test.js
+++ b/tests/tools/play.test.js
@@ -1,0 +1,204 @@
+// Play CLI unit tests — parser + renderer pure functions.
+// (No HTTP calls — integration via real backend = manual/e2e separate.)
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { parseInput, renderGrid, renderUnits, renderState } = require('../../tools/js/play.js');
+
+// ─────────────────────────────────────────────────────────────────
+// Parser
+// ─────────────────────────────────────────────────────────────────
+
+test('parseInput: comandi vuoti', () => {
+  assert.equal(parseInput('').kind, 'noop');
+  assert.equal(parseInput('   ').kind, 'noop');
+});
+
+test('parseInput: end/quit/state/help', () => {
+  assert.equal(parseInput('end').kind, 'end');
+  assert.equal(parseInput('fine').kind, 'end');
+  assert.equal(parseInput('quit').kind, 'quit');
+  assert.equal(parseInput('q').kind, 'quit');
+  assert.equal(parseInput('state').kind, 'state');
+  assert.equal(parseInput('stato').kind, 'state');
+  assert.equal(parseInput('help').kind, 'help');
+  assert.equal(parseInput('?').kind, 'help');
+});
+
+test('parseInput: move con coord', () => {
+  const r = parseInput('p_scout: move [3,4]');
+  assert.equal(r.kind, 'move');
+  assert.equal(r.actor_id, 'p_scout');
+  assert.deepEqual(r.position, { x: 3, y: 4 });
+});
+
+test('parseInput: move shorthand mv', () => {
+  const r = parseInput('p1: mv [0,0]');
+  assert.equal(r.kind, 'move');
+  assert.deepEqual(r.position, { x: 0, y: 0 });
+});
+
+test('parseInput: move con spazi extra', () => {
+  const r = parseInput('p_tank:   move   [ 2 , 3 ]');
+  assert.equal(r.kind, 'move');
+  assert.deepEqual(r.position, { x: 2, y: 3 });
+});
+
+test('parseInput: move errore senza coord', () => {
+  const r = parseInput('p_scout: move');
+  assert.equal(r.kind, 'error');
+  assert.match(r.msg, /move richiede/);
+});
+
+test('parseInput: attack con target', () => {
+  const r = parseInput('p_scout: atk e_nomad_1');
+  assert.equal(r.kind, 'attack');
+  assert.equal(r.actor_id, 'p_scout');
+  assert.equal(r.target_id, 'e_nomad_1');
+});
+
+test('parseInput: attack shorthand attack/attacca', () => {
+  assert.equal(parseInput('p_scout: attack e_hunter').kind, 'attack');
+  assert.equal(parseInput('p_scout: attacca e_hunter').kind, 'attack');
+});
+
+test('parseInput: attack errore senza target', () => {
+  const r = parseInput('p_scout: atk');
+  assert.equal(r.kind, 'error');
+});
+
+test('parseInput: ability con target', () => {
+  const r = parseInput('p_scout: ability dash_strike target=e_hunter');
+  assert.equal(r.kind, 'ability');
+  assert.equal(r.actor_id, 'p_scout');
+  assert.equal(r.ability_id, 'dash_strike');
+  assert.equal(r.target_id, 'e_hunter');
+});
+
+test('parseInput: ability senza target', () => {
+  const r = parseInput('p_tank: ability fortify');
+  assert.equal(r.kind, 'ability');
+  assert.equal(r.ability_id, 'fortify');
+  assert.equal(r.target_id, null);
+});
+
+test('parseInput: ability shorthand ab', () => {
+  const r = parseInput('p_scout: ab dash_strike target=e1');
+  assert.equal(r.kind, 'ability');
+  assert.equal(r.ability_id, 'dash_strike');
+});
+
+test('parseInput: verbo sconosciuto', () => {
+  const r = parseInput('p_scout: teleport e_nomad_1');
+  assert.equal(r.kind, 'error');
+  assert.match(r.msg, /non supportato/);
+});
+
+test('parseInput: sintassi rotta', () => {
+  const r = parseInput('random garbage here');
+  assert.equal(r.kind, 'error');
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Renderer
+// ─────────────────────────────────────────────────────────────────
+
+function mockState() {
+  return {
+    turn: 2,
+    active_unit: 'p_scout',
+    grid: { width: 8, height: 8 },
+    units: [
+      {
+        id: 'p_scout',
+        hp: 8,
+        max_hp: 10,
+        ap: 3,
+        ap_remaining: 2,
+        position: { x: 1, y: 2 },
+        controlled_by: 'player',
+        job: 'skirmisher',
+      },
+      {
+        id: 'p_tank',
+        hp: 12,
+        max_hp: 12,
+        ap: 3,
+        ap_remaining: 3,
+        position: { x: 1, y: 3 },
+        controlled_by: 'player',
+        job: 'vanguard',
+      },
+      {
+        id: 'e_nomad_1',
+        hp: 0,
+        max_hp: 3,
+        ap: 2,
+        ap_remaining: 0,
+        position: { x: 4, y: 1 },
+        controlled_by: 'sistema',
+      },
+      {
+        id: 'e_hunter',
+        hp: 6,
+        max_hp: 6,
+        ap: 2,
+        ap_remaining: 2,
+        position: { x: 3, y: 3 },
+        controlled_by: 'sistema',
+      },
+    ],
+  };
+}
+
+test('renderGrid: contiene header colonne + righe', () => {
+  const out = renderGrid(mockState());
+  assert.match(out, /0\s+1\s+2\s+3\s+4/);
+  // Row 0 exists at bottom
+  assert.match(out, /\n\s*0\s+/);
+  // Row 7 at top
+  assert.match(out, /^\s+0\s+1/);
+});
+
+test('renderGrid: place units at correct cells', () => {
+  const out = renderGrid(mockState());
+  // p_scout abbreviated to "p_" (2 chars of id)
+  assert.ok(out.includes('p_'));
+  // e_hunter → "e_"
+  assert.ok(out.includes('e_'));
+  // dead unit uses skull
+  assert.ok(out.includes('☠'));
+});
+
+test('renderUnits: include HP bar e AP', () => {
+  const out = renderUnits(mockState());
+  assert.match(out, /p_scout/);
+  assert.match(out, /8\/10/);
+  assert.match(out, /AP 2\/3/);
+  assert.match(out, /\[1,2\]/);
+  assert.match(out, /skirmisher/);
+});
+
+test('renderUnits: dead unit flagged', () => {
+  const out = renderUnits(mockState());
+  assert.match(out, /e_nomad_1.*DEAD/);
+});
+
+test('renderUnits: active unit marker', () => {
+  const out = renderUnits(mockState());
+  // p_scout active → ▶ prefix
+  assert.match(out, /▶.*p_scout/s);
+});
+
+test('renderState: include turn + grid + units', () => {
+  const out = renderState(mockState());
+  assert.match(out, /Turn 2/);
+  assert.match(out, /p_scout/);
+  assert.ok(out.includes('AP'));
+});
+
+test('renderState: empty units', () => {
+  const out = renderState({ turn: 1, grid: { width: 4, height: 4 }, units: [] });
+  assert.match(out, /Turn 1/);
+});

--- a/tools/js/README.md
+++ b/tools/js/README.md
@@ -1,0 +1,88 @@
+# tools/js — Node CLI Tools
+
+## play.js — Interactive CLI player
+
+Consuma `/api/session/*` e rende grid ASCII + unità con color. Input con sintassi canonica (FRICTION #1 resolution).
+
+### Usage
+
+```bash
+# 1. Start backend in another shell
+npm run start:api
+
+# 2. Run CLI
+node tools/js/play.js
+
+# Custom scenario / URL
+node tools/js/play.js --scenario enc_tutorial_02 --url http://localhost:3334
+
+# Via env
+PLAY_SCENARIO=enc_tutorial_02 PLAY_URL=http://localhost:3334 node tools/js/play.js
+```
+
+### Sintassi input (canonical)
+
+```
+<actor_id>: move [x,y]                   # muovi actor a coord
+<actor_id>: atk <target_id>              # attacca target
+<actor_id>: ability <id> target=<tid>    # usa ability (es. dash_strike)
+end                                       # termina turno (SIS agisce)
+state                                     # refresh stato
+help                                      # mostra comandi
+quit                                      # exit
+```
+
+Sinonimi:
+
+- `mv` = `move`
+- `attack`/`attacca` = `atk`
+- `ab` = `ability`
+- `fine`/`end-turn` = `end`
+- `stato` = `state`
+- `q`/`exit` = `quit`
+
+### Esempio sessione
+
+```
+> help
+...
+> p_scout: atk e_nomad_1
+━━━ Turn 1 · active: p_scout ━━━
+    0  1  2  3  4  5
+ 5  .  .  .  .  .  .
+ 4  .  .  .  e_ .  .
+ 3  .  p_ .  .  .  .
+ 2  .  p_ .  ☠  .  .
+ 1  .  .  .  .  .  .
+ 0  .  .  .  .  .  .
+
+▶ p_scout      PG  10/10   AP 2/3  [1,2] skirmisher
+  p_tank       PG  12/12   AP 3/3  [1,3] vanguard
+  e_nomad_1    SIS 0/3     AP 2/2  [3,2] skirmisher DEAD
+  e_nomad_2    SIS 5/5     AP 2/2  [3,4] skirmisher
+> end
+⏭  Turno terminato. SIS agisce...
+...
+> quit
+🦴 caveman dire: Master finire turno. ugh bunga.
+```
+
+### Color legenda
+
+- `PG` cyan · `SIS` red
+- HP: verde ≥60%, giallo 30-60%, rosso <30%
+- AP: magenta
+- `▶` marker unità attiva
+- `☠` unità morta
+
+### Test
+
+```bash
+node --test tests/tools/play.test.js
+```
+
+21 test (parser + renderer pure functions, no HTTP mock needed).
+
+## validate_encounter_difficulty.js
+
+Vedi commit message del file stesso.

--- a/tools/js/play.js
+++ b/tools/js/play.js
@@ -1,0 +1,347 @@
+#!/usr/bin/env node
+/**
+ * Evo-Tactics — Play CLI (RESEARCH_TODO sprint "far partire il gioco")
+ *
+ * Interactive session runner. Consuma /api/session/* via HTTP.
+ * Input sintassi canonica (FRICTION #1 resolution):
+ *
+ *   <actor_id>: move [x,y]
+ *   <actor_id>: atk <target_id>
+ *   <actor_id>: ability <ability_id> [target=<target_id>]
+ *   end                           # termina turno corrente
+ *   state                         # refresh state
+ *   help                          # lista comandi
+ *   quit                          # exit
+ *
+ * Usage:
+ *   node tools/js/play.js [--url http://localhost:3334] [--scenario enc_tutorial_01]
+ *
+ * Prerequisito: backend attivo (npm run start:api).
+ */
+
+const readline = require('node:readline');
+const { argv, exit, stdout, stdin } = require('node:process');
+
+// ─────────────────────────────────────────────────────────────────
+// Config + args
+// ─────────────────────────────────────────────────────────────────
+
+function parseArgs(args) {
+  const out = { url: 'http://localhost:3334', scenario: 'enc_tutorial_01' };
+  for (let i = 2; i < args.length; i++) {
+    if (args[i] === '--url' && args[i + 1]) out.url = args[++i];
+    else if (args[i] === '--scenario' && args[i + 1]) out.scenario = args[++i];
+    else if (args[i] === '--help' || args[i] === '-h') {
+      console.log(
+        'Usage: node tools/js/play.js [--url URL] [--scenario ID]\n\n' +
+          'Env:\n  PLAY_URL        override --url\n  PLAY_SCENARIO   override --scenario',
+      );
+      exit(0);
+    }
+  }
+  if (process.env.PLAY_URL) out.url = process.env.PLAY_URL;
+  if (process.env.PLAY_SCENARIO) out.scenario = process.env.PLAY_SCENARIO;
+  return out;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// ANSI color (minimal, no deps)
+// ─────────────────────────────────────────────────────────────────
+
+const COLOR = {
+  reset: '\x1b[0m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  cyan: '\x1b[36m',
+  magenta: '\x1b[35m',
+  gray: '\x1b[90m',
+};
+
+const c = (txt, col) => `${COLOR[col] || ''}${txt}${COLOR.reset}`;
+
+// ─────────────────────────────────────────────────────────────────
+// API client (fetch-based, Node 18+)
+// ─────────────────────────────────────────────────────────────────
+
+function createClient(baseUrl) {
+  async function request(method, path, body) {
+    const url = `${baseUrl}${path}`;
+    const opts = { method, headers: { 'Content-Type': 'application/json' } };
+    if (body) opts.body = JSON.stringify(body);
+    const res = await fetch(url, opts);
+    let data;
+    try {
+      data = await res.json();
+    } catch {
+      data = null;
+    }
+    return { ok: res.ok, status: res.status, data };
+  }
+  return {
+    getScenario: (id) => request('GET', `/api/tutorial/${id}`),
+    start: (units) => request('POST', '/api/session/start', { units }),
+    state: (sessionId) =>
+      request('GET', `/api/session/state?session_id=${encodeURIComponent(sessionId)}`),
+    action: (body) => request('POST', '/api/session/action', body),
+    endTurn: (sessionId) => request('POST', '/api/session/turn/end', { session_id: sessionId }),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Rendering
+// ─────────────────────────────────────────────────────────────────
+
+function unitGlyph(u) {
+  if (u.hp <= 0) return c('☠', 'gray');
+  if (u.controlled_by === 'player') return c(u.id.slice(0, 2), 'cyan');
+  return c(u.id.slice(0, 2), 'red');
+}
+
+function renderGrid(state) {
+  const w = state.grid?.width || 8;
+  const h = state.grid?.height || 8;
+  const cells = Array.from({ length: h }, () => Array.from({ length: w }, () => '.'));
+
+  for (const u of state.units || []) {
+    if (!u.position) continue;
+    const { x, y } = u.position;
+    if (x < 0 || x >= w || y < 0 || y >= h) continue;
+    cells[y][x] = unitGlyph(u);
+  }
+
+  const header = '    ' + Array.from({ length: w }, (_, i) => String(i).padEnd(3)).join('');
+  const rows = [];
+  for (let y = h - 1; y >= 0; y--) {
+    const row = cells[y].map((cell) => cell.padEnd(cell.length > 1 ? 3 : 3)).join('');
+    rows.push(`${String(y).padStart(2)}  ${row}`);
+  }
+  return [header, ...rows].join('\n');
+}
+
+function renderUnits(state) {
+  const lines = [];
+  for (const u of state.units || []) {
+    const hpRatio = u.hp / (u.max_hp || u.hp || 1);
+    const hpColor = hpRatio < 0.3 ? 'red' : hpRatio < 0.6 ? 'yellow' : 'green';
+    const hpText = c(`${u.hp}/${u.max_hp || u.hp}`, hpColor);
+    const apText = c(`AP ${u.ap_remaining ?? u.ap}/${u.ap}`, 'magenta');
+    const pos = u.position ? `[${u.position.x},${u.position.y}]` : '—';
+    const faction = u.controlled_by === 'player' ? c('PG', 'cyan') : c('SIS', 'red');
+    const job = u.job ? c(u.job, 'dim') : '';
+    const active = u.id === state.active_unit ? c('▶ ', 'yellow') : '  ';
+    const dead = u.hp <= 0 ? c(' DEAD', 'gray') : '';
+    lines.push(
+      `${active}${u.id.padEnd(12)} ${faction} ${hpText.padEnd(16)} ${apText} ${pos} ${job}${dead}`,
+    );
+  }
+  return lines.join('\n');
+}
+
+function renderState(state) {
+  const header = c(`━━━ Turn ${state.turn} · active: ${state.active_unit || '—'} ━━━`, 'bold');
+  return [header, '', renderGrid(state), '', renderUnits(state), ''].join('\n');
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Parser input
+// ─────────────────────────────────────────────────────────────────
+
+// Match: <actor>: <verb> <rest>
+const CMD_RE = /^([a-z0-9_]+):\s*(\w+)(.*)$/i;
+const COORD_RE = /\[\s*(-?\d+)\s*,\s*(-?\d+)\s*\]/;
+const KV_RE = /([a-z_]+)=([a-z0-9_]+)/gi;
+
+function parseInput(raw) {
+  const line = raw.trim();
+  if (!line) return { kind: 'noop' };
+  const lower = line.toLowerCase();
+  if (lower === 'end' || lower === 'end-turn' || lower === 'fine') return { kind: 'end' };
+  if (lower === 'state' || lower === 'stato') return { kind: 'state' };
+  if (lower === 'help' || lower === '?') return { kind: 'help' };
+  if (lower === 'quit' || lower === 'exit' || lower === 'q') return { kind: 'quit' };
+
+  const m = CMD_RE.exec(line);
+  if (!m) return { kind: 'error', msg: `Comando non parsato: "${line}"` };
+
+  const [, actor, verbRaw, restRaw] = m;
+  const verb = verbRaw.toLowerCase();
+  const rest = restRaw.trim();
+
+  if (verb === 'move' || verb === 'mv') {
+    const cm = COORD_RE.exec(rest);
+    if (!cm) return { kind: 'error', msg: 'move richiede [x,y]' };
+    return { kind: 'move', actor_id: actor, position: { x: +cm[1], y: +cm[2] } };
+  }
+  if (verb === 'atk' || verb === 'attack' || verb === 'attacca') {
+    const targetId = rest.split(/\s+/)[0];
+    if (!targetId) return { kind: 'error', msg: 'atk richiede target_id' };
+    return { kind: 'attack', actor_id: actor, target_id: targetId };
+  }
+  if (verb === 'ability' || verb === 'ab') {
+    const parts = rest.split(/\s+/);
+    const abilityId = parts[0];
+    if (!abilityId) return { kind: 'error', msg: 'ability richiede <ability_id>' };
+    const kv = {};
+    let m2;
+    while ((m2 = KV_RE.exec(rest)) !== null) kv[m2[1]] = m2[2];
+    return {
+      kind: 'ability',
+      actor_id: actor,
+      ability_id: abilityId,
+      target_id: kv.target || null,
+    };
+  }
+  return { kind: 'error', msg: `verbo non supportato: "${verb}"` };
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Help
+// ─────────────────────────────────────────────────────────────────
+
+function printHelp() {
+  console.log(
+    [
+      c('\nComandi disponibili:', 'bold'),
+      '  <actor_id>: move [x,y]                  — muovi actor a coordinate',
+      '  <actor_id>: atk <target_id>             — attacca target',
+      '  <actor_id>: ability <id> target=<tid>   — usa ability (es. dash_strike)',
+      '  end                                     — termina turno',
+      '  state                                   — refresh stato',
+      '  help                                    — questo messaggio',
+      '  quit                                    — esci',
+      '',
+    ].join('\n'),
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Main loop
+// ─────────────────────────────────────────────────────────────────
+
+async function main() {
+  const { url, scenario } = parseArgs(argv);
+  const client = createClient(url);
+
+  console.log(c(`\n🦴 Evo-Tactics — Play CLI`, 'bold'));
+  console.log(c(`Backend: ${url}`, 'dim'));
+  console.log(c(`Scenario: ${scenario}`, 'dim'));
+
+  const sc = await client.getScenario(scenario);
+  if (!sc.ok) {
+    console.error(c(`\n❌ Scenario load failed (${sc.status}): ${JSON.stringify(sc.data)}`, 'red'));
+    console.error(c(`   Verifica backend attivo: npm run start:api`, 'yellow'));
+    exit(1);
+  }
+
+  const startRes = await client.start(sc.data.units);
+  if (!startRes.ok) {
+    console.error(c(`\n❌ Session start failed: ${JSON.stringify(startRes.data)}`, 'red'));
+    exit(1);
+  }
+
+  const sid = startRes.data.session_id;
+  console.log(c(`\n✓ Session started: ${sid.slice(0, 8)}...`, 'green'));
+
+  let state = startRes.data.state;
+  let stopped = false;
+  const rl = readline.createInterface({ input: stdin, output: stdout });
+  rl.on('close', () => {
+    stopped = true;
+  });
+
+  function prompt() {
+    if (stopped) return;
+    rl.question(c('> ', 'magenta'), async (line) => {
+      const parsed = parseInput(line);
+      try {
+        switch (parsed.kind) {
+          case 'noop':
+            break;
+          case 'help':
+            printHelp();
+            break;
+          case 'quit':
+            console.log(c('\n🦴 caveman dire: Master finire turno. ugh bunga.\n', 'yellow'));
+            stopped = true;
+            rl.close();
+            return;
+          case 'error':
+            console.error(c(`❌ ${parsed.msg}`, 'red'));
+            break;
+          case 'state': {
+            const r = await client.state(sid);
+            if (r.ok) {
+              state = r.data;
+              console.log(renderState(state));
+            } else console.error(c(`state failed: ${JSON.stringify(r.data)}`, 'red'));
+            break;
+          }
+          case 'end': {
+            const r = await client.endTurn(sid);
+            if (r.ok) {
+              state = r.data.state || state;
+              console.log(c(`\n⏭  Turno terminato. SIS agisce...`, 'yellow'));
+              const s2 = await client.state(sid);
+              if (s2.ok) state = s2.data;
+              console.log(renderState(state));
+            } else console.error(c(`end failed: ${JSON.stringify(r.data)}`, 'red'));
+            break;
+          }
+          case 'move':
+          case 'attack':
+          case 'ability': {
+            const body = {
+              session_id: sid,
+              action_type: parsed.kind === 'attack' ? 'attack' : parsed.kind,
+              actor_id: parsed.actor_id,
+            };
+            if (parsed.kind === 'move') body.position = parsed.position;
+            if (parsed.kind === 'attack') body.target_id = parsed.target_id;
+            if (parsed.kind === 'ability') {
+              body.ability_id = parsed.ability_id;
+              if (parsed.target_id) body.target_id = parsed.target_id;
+            }
+            const r = await client.action(body);
+            if (r.ok) {
+              state = r.data.state || state;
+              const s2 = await client.state(sid);
+              if (s2.ok) state = s2.data;
+              console.log(renderState(state));
+              if (r.data.resolution)
+                console.log(c(`  → ${JSON.stringify(r.data.resolution)}`, 'dim'));
+            } else {
+              console.error(c(`❌ action failed: ${r.data?.error || r.status}`, 'red'));
+            }
+            break;
+          }
+          default:
+            console.error(c(`❌ unknown command kind`, 'red'));
+        }
+      } catch (err) {
+        console.error(c(`❌ error: ${err.message}`, 'red'));
+      }
+      if (!stopped) prompt();
+    });
+  }
+
+  console.log(renderState(state));
+  printHelp();
+  prompt();
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Export for tests (when required) + run as CLI
+// ─────────────────────────────────────────────────────────────────
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(c(`\n💥 fatal: ${err.message}`, 'red'));
+    exit(1);
+  });
+}
+
+module.exports = { parseInput, createClient, renderGrid, renderUnits, renderState };


### PR DESCRIPTION
## Summary

Sprint A "far partire il gioco": **CLI interattivo giocabile** end-to-end via backend HTTP.

Risolve: M1/M2 playtest pain point "agent DM tabletop → serve tool" — ora Master può giocare solo in terminale senza agent.

## Changes

- \`tools/js/play.js\` (347 LOC) — Node CLI, zero deps (fetch + readline built-in)
- \`tools/js/README.md\` — usage + color legenda + esempio sessione
- \`tests/tools/play.test.js\` — 21 test parser + renderer

## Features

- Auto-start session da scenario (default \`enc_tutorial_01\`)
- Grid ASCII render con unit glyphs (color per faction)
- HP bar color-coded · AP counter · active unit marker ▶
- Sintassi canonica (FRICTION #1 resolved):
  - \`p_scout: move [1,3]\`
  - \`p_scout: atk e_nomad_1\`
  - \`p_scout: ability dash_strike target=e_hunter\`
  - \`end\` / \`state\` / \`help\` / \`quit\`
- Sinonimi: mv/attack/ab/fine/stato/q

## Smoke test end-to-end

Verificato con backend live (\`npm run start:api\`):
- ✅ Scenario load
- ✅ Session start
- ✅ Move + attack actions (API returns state, grid updates)
- ✅ End turn (SIS acts, state refreshes)
- ✅ Clean quit

## Test plan

- [x] 21/21 unit test (parser + renderer pure functions)
- [x] AI regression green
- [x] Prettier clean
- [x] Smoke test manuale end-to-end

## Next

Sprint B: frontend Vite 2D browser (separate PR, scope L).

🤖 Generated with [Claude Code](https://claude.com/claude-code)