### PR TITLE
play: sprint α — ability UI + end-game overlay + scenarios completi

### DIFF
--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -24,12 +24,17 @@
             <select id="scenario-select">
               <option value="enc_tutorial_01">Tutorial 01 · Primi passi</option>
               <option value="enc_tutorial_02">Tutorial 02 · Pattuglia</option>
+              <option value="enc_tutorial_03">Tutorial 03 · Hazard savana</option>
+              <option value="enc_tutorial_04">Tutorial 04 · Bleeding foresta</option>
+              <option value="enc_tutorial_05">Tutorial 05 · BOSS Apex</option>
             </select>
           </div>
         </section>
         <aside class="sidebar">
           <h2>Unità</h2>
           <ul id="units"></ul>
+          <h2 id="abilities-title" class="hidden-empty">Abilities</h2>
+          <div id="abilities"></div>
           <h2>Log</h2>
           <div id="log"></div>
         </aside>
@@ -37,6 +42,17 @@
       <footer>
         <span id="selected-hint">Seleziona una tua unità per vedere azioni.</span>
       </footer>
+      <div id="endgame-overlay" class="hidden">
+        <div class="endgame-card">
+          <h2 id="endgame-title">—</h2>
+          <p id="endgame-stats">—</p>
+          <div class="endgame-actions">
+            <button id="endgame-next">Prossimo encounter</button>
+            <button id="endgame-retry">Rigioca</button>
+            <button id="endgame-close">Chiudi</button>
+          </div>
+        </div>
+      </div>
     </div>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/apps/play/src/abilityPanel.js
+++ b/apps/play/src/abilityPanel.js
@@ -1,0 +1,80 @@
+// Ability panel — fetch /api/jobs, render clickable abilities per unit selezionata.
+
+import { api } from './api.js';
+
+let jobCache = null;
+
+async function loadJobs() {
+  if (jobCache) return jobCache;
+  const r = await fetch('/api/jobs')
+    .then((res) => res.json())
+    .catch(() => null);
+  if (r && Array.isArray(r.jobs)) {
+    jobCache = {};
+    for (const j of r.jobs) jobCache[j.id] = j;
+  }
+  return jobCache || {};
+}
+
+async function loadJobDetail(jobId) {
+  const r = await fetch(`/api/jobs/${encodeURIComponent(jobId)}`)
+    .then((res) => res.json())
+    .catch(() => null);
+  return r;
+}
+
+export async function renderAbilities(unit, state, onAbility) {
+  const titleEl = document.getElementById('abilities-title');
+  const container = document.getElementById('abilities');
+  container.innerHTML = '';
+  if (!unit || !unit.job) {
+    titleEl.classList.add('hidden-empty');
+    return;
+  }
+  titleEl.classList.remove('hidden-empty');
+
+  const detail = await loadJobDetail(unit.job);
+  if (!detail || !Array.isArray(detail.abilities) || detail.abilities.length === 0) {
+    container.innerHTML = `<div class="ab-empty">Nessuna ability per ${unit.job}</div>`;
+    return;
+  }
+
+  titleEl.textContent = `Abilities · ${unit.job}`;
+  for (const ab of detail.abilities) {
+    const row = document.createElement('div');
+    row.className = 'ability-row';
+    const apCost = ab.cost_ap ?? ab.ap_cost ?? 1;
+    const apCurrent = unit.ap_remaining ?? unit.ap;
+    const canAfford = apCurrent >= apCost;
+    row.classList.toggle('disabled', !canAfford);
+
+    const needsTarget =
+      !!ab.needs_target ||
+      ['attack', 'debuff', 'heal', 'aoe_debuff'].some(
+        (t) => ab.effect_type && ab.effect_type.includes(t),
+      );
+
+    row.innerHTML = `
+      <div class="ab-head">
+        <strong>${ab.label_it || ab.label || ab.id}</strong>
+        <span class="ab-cost">AP ${apCost}</span>
+      </div>
+      <div class="ab-effect">${ab.effect_type || ''} ${ab.description_it || ab.description || ''}</div>
+    `;
+    row.addEventListener('click', () => {
+      if (!canAfford) return;
+      onAbility({ ability_id: ab.id, needs_target: needsTarget, effect_type: ab.effect_type });
+    });
+    container.appendChild(row);
+  }
+}
+
+export function clearAbilities() {
+  const titleEl = document.getElementById('abilities-title');
+  const container = document.getElementById('abilities');
+  if (titleEl) titleEl.classList.add('hidden-empty');
+  if (container) container.innerHTML = '';
+}
+
+// preload on module load (non bloccante)
+loadJobs();

--- a/apps/play/src/endgame.js
+++ b/apps/play/src/endgame.js
@@ -1,0 +1,59 @@
+// End-game detection + overlay.
+
+export function detectEndgame(state) {
+  if (!state || !Array.isArray(state.units)) return null;
+  const player = state.units.filter((u) => u.controlled_by === 'player');
+  const sistema = state.units.filter((u) => u.controlled_by === 'sistema');
+  const allPlayerDead = player.length > 0 && player.every((u) => u.hp <= 0);
+  const allSisDead = sistema.length > 0 && sistema.every((u) => u.hp <= 0);
+  if (allSisDead) return 'victory';
+  if (allPlayerDead) return 'defeat';
+  return null;
+}
+
+export function showEndgame(result, state, handlers) {
+  const overlay = document.getElementById('endgame-overlay');
+  const title = document.getElementById('endgame-title');
+  const stats = document.getElementById('endgame-stats');
+  if (!overlay || !title || !stats) return;
+
+  overlay.classList.remove('hidden');
+  title.textContent = result === 'victory' ? '🏆 Vittoria!' : '☠ Sconfitta';
+  title.className = result === 'victory' ? 'win' : 'lose';
+
+  const playerHpLost = (state.units || [])
+    .filter((u) => u.controlled_by === 'player')
+    .reduce((sum, u) => sum + Math.max(0, (u.max_hp || u.hp || 0) - u.hp), 0);
+  const sistemaHpLost = (state.units || [])
+    .filter((u) => u.controlled_by === 'sistema')
+    .reduce((sum, u) => sum + Math.max(0, (u.max_hp || u.hp || 0) - u.hp), 0);
+
+  stats.innerHTML = `
+    Turni: <strong>${state.turn || 0}</strong><br>
+    HP persi PG: <strong>${playerHpLost}</strong><br>
+    HP inflitti a Sistema: <strong>${sistemaHpLost}</strong><br>
+    Session: <code>${(state.session_id || '').slice(0, 8) || '—'}</code>
+  `;
+
+  document.getElementById('endgame-next').onclick = handlers.next;
+  document.getElementById('endgame-retry').onclick = handlers.retry;
+  document.getElementById('endgame-close').onclick = () => overlay.classList.add('hidden');
+}
+
+export function hideEndgame() {
+  const overlay = document.getElementById('endgame-overlay');
+  if (overlay) overlay.classList.add('hidden');
+}
+
+export function nextScenarioId(current) {
+  const order = [
+    'enc_tutorial_01',
+    'enc_tutorial_02',
+    'enc_tutorial_03',
+    'enc_tutorial_04',
+    'enc_tutorial_05',
+  ];
+  const idx = order.indexOf(current);
+  if (idx < 0 || idx >= order.length - 1) return order[0]; // loop to start
+  return order[idx + 1];
+}

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -1,14 +1,18 @@
 // Evo-Tactics Play — entry point. Orchestration layer.
 
 import { api } from './api.js';
-import { render, canvasToCell, CELL_SIZE } from './render.js';
+import { render, canvasToCell } from './render.js';
 import { renderUnits, appendLog, updateStatus } from './ui.js';
+import { renderAbilities, clearAbilities } from './abilityPanel.js';
+import { detectEndgame, showEndgame, hideEndgame, nextScenarioId } from './endgame.js';
 
 const state = {
   sid: null,
   world: null, // session state
   selected: null, // unit selected (player)
   target: null, // target preview (enemy hovered)
+  pendingAbility: null, // { ability_id, needs_target, effect_type }
+  endgameShown: false,
 };
 
 const canvas = document.getElementById('grid');
@@ -25,14 +29,86 @@ function redraw() {
   });
   renderUnits(unitsUl, state.world, state.selected, handleUnitClick);
   updateStatus(state.world);
+  // ability panel
+  const selUnit = (state.world.units || []).find((u) => u.id === state.selected);
+  if (selUnit && selUnit.controlled_by === 'player' && selUnit.hp > 0) {
+    renderAbilities(selUnit, state.world, handleAbilitySelect);
+  } else {
+    clearAbilities();
+  }
+  // endgame
+  if (!state.endgameShown) {
+    const outcome = detectEndgame(state.world);
+    if (outcome) {
+      state.endgameShown = true;
+      showEndgame(
+        outcome,
+        { ...state.world, session_id: state.sid },
+        {
+          next: async () => {
+            const cur = document.getElementById('scenario-select').value;
+            const nxt = nextScenarioId(cur);
+            document.getElementById('scenario-select').value = nxt;
+            hideEndgame();
+            await startNewSession();
+          },
+          retry: async () => {
+            hideEndgame();
+            await startNewSession();
+          },
+        },
+      );
+    }
+  }
 }
 
 function updateHint(msg) {
   hintEl.textContent = msg;
 }
 
+function setAbilityTargetMode(on) {
+  document.body.classList.toggle('ability-target-mode', on);
+}
+
+function handleAbilitySelect(ab) {
+  if (!state.selected) return;
+  if (!ab.needs_target) {
+    // Self-cast or no target
+    doAction({
+      action_type: 'ability',
+      actor_id: state.selected,
+      ability_id: ab.ability_id,
+    });
+    return;
+  }
+  state.pendingAbility = ab;
+  setAbilityTargetMode(true);
+  updateHint(`Seleziona target per ability ${ab.ability_id}. Click unità o ESC per annullare.`);
+}
+
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape' && state.pendingAbility) {
+    state.pendingAbility = null;
+    setAbilityTargetMode(false);
+    updateHint(`Ability annullata.`);
+  }
+});
+
 function handleUnitClick(unit) {
   if (!state.world) return;
+  // Ability targeting mode
+  if (state.pendingAbility) {
+    const ab = state.pendingAbility;
+    state.pendingAbility = null;
+    setAbilityTargetMode(false);
+    doAction({
+      action_type: 'ability',
+      actor_id: state.selected,
+      ability_id: ab.ability_id,
+      target_id: unit.id,
+    });
+    return;
+  }
   if (unit.controlled_by === 'player') {
     if (unit.hp <= 0) {
       updateHint(`${unit.id} è KO.`);
@@ -40,10 +116,9 @@ function handleUnitClick(unit) {
     }
     state.selected = unit.id;
     state.target = null;
-    updateHint(`Selezionato ${unit.id}. Click cella=move · click nemico=attack.`);
+    updateHint(`Selezionato ${unit.id}. Click cella=move · click nemico=attack · sidebar=ability.`);
     redraw();
   } else {
-    // Click su nemico → attack se unità selezionata valida
     if (!state.selected) {
       updateHint('Seleziona prima una tua unità.');
       return;
@@ -68,8 +143,10 @@ canvas.addEventListener('click', (ev) => {
     handleUnitClick(unit);
     return;
   }
-
-  // Cella vuota → move se unit selezionata
+  if (state.pendingAbility) {
+    updateHint(`Ability richiede unit target. Premi ESC per annullare.`);
+    return;
+  }
   if (!state.selected) {
     updateHint('Click su una tua unità per selezionarla.');
     return;
@@ -86,10 +163,12 @@ async function doAction(body) {
     updateHint(r.data?.error || 'Azione rifiutata.');
     return;
   }
-  appendLog(
-    logEl,
-    `${body.actor_id}: ${body.action_type} ${body.target_id || body.position?.x != null ? JSON.stringify(body.position || body.target_id) : ''}`,
-  );
+  const tag = body.ability_id
+    ? `ability ${body.ability_id}${body.target_id ? ` → ${body.target_id}` : ''}`
+    : body.action_type === 'move'
+      ? `move [${body.position.x},${body.position.y}]`
+      : `atk ${body.target_id}`;
+  appendLog(logEl, `${body.actor_id}: ${tag}`);
   await refresh();
 }
 
@@ -97,7 +176,6 @@ async function refresh() {
   const r = await api.state(state.sid);
   if (r.ok) {
     state.world = r.data;
-    // Deselect if unit no longer alive
     if (state.selected) {
       const sel = state.world.units.find((u) => u.id === state.selected);
       if (!sel || sel.hp <= 0) state.selected = null;
@@ -107,6 +185,9 @@ async function refresh() {
 }
 
 async function startNewSession() {
+  state.endgameShown = false;
+  state.pendingAbility = null;
+  setAbilityTargetMode(false);
   const scenarioId = document.getElementById('scenario-select').value;
   appendLog(logEl, `→ carico scenario ${scenarioId}`);
   const sc = await api.scenario(scenarioId);
@@ -143,8 +224,5 @@ document.getElementById('end-turn').addEventListener('click', async () => {
   appendLog(logEl, '✓ SIS ha agito');
 });
 
-// Auto-start su load
 startNewSession();
-
-// Expose for debug
 window.__evo = { state, api, refresh };

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -190,3 +190,106 @@ footer {
   font-size: 0.85rem;
   color: var(--dim);
 }
+
+/* Ability panel */
+.hidden-empty {
+  display: none;
+}
+#abilities {
+  margin-bottom: 16px;
+}
+.ab-empty {
+  font-size: 0.8rem;
+  color: var(--dim);
+  font-style: italic;
+  padding: 4px;
+}
+.ability-row {
+  padding: 6px 8px;
+  margin-bottom: 4px;
+  background: var(--cell);
+  border-left: 3px solid var(--accent);
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+.ability-row:hover {
+  background: rgba(255, 204, 0, 0.08);
+}
+.ability-row.disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+  border-left-color: var(--dim);
+}
+.ab-head {
+  display: flex;
+  justify-content: space-between;
+  font-weight: bold;
+}
+.ab-cost {
+  color: var(--accent);
+}
+.ab-effect {
+  color: var(--dim);
+  font-size: 0.75rem;
+  margin-top: 2px;
+}
+
+/* Awaiting target mode */
+body.ability-target-mode canvas#grid {
+  cursor: crosshair;
+}
+body.ability-target-mode canvas#grid {
+  box-shadow: 0 0 0 3px var(--accent) inset;
+}
+
+/* Endgame overlay */
+#endgame-overlay.hidden {
+  display: none;
+}
+#endgame-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+.endgame-card {
+  background: var(--panel);
+  border: 2px solid var(--accent);
+  padding: 32px 48px;
+  text-align: center;
+  min-width: 320px;
+}
+.endgame-card h2 {
+  margin: 0 0 16px;
+  font-size: 2.2rem;
+}
+.endgame-card h2.win {
+  color: #4caf50;
+}
+.endgame-card h2.lose {
+  color: #f44336;
+}
+.endgame-card p {
+  line-height: 1.6;
+}
+.endgame-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 20px;
+}
+.endgame-actions button {
+  background: var(--cell);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  padding: 10px 20px;
+  cursor: pointer;
+  font-family: inherit;
+}
+.endgame-actions button:hover {
+  background: var(--accent);
+  color: var(--bg);
+}


### PR DESCRIPTION
## Sprint α — tripla feature frontend

1. **Ability UI**: fetch \`/api/jobs/:id\`, ability list sidebar, click → target mode con cursor crosshair + border giallo canvas, ESC cancel, disabled se AP insufficiente
2. **End-game overlay**: auto-detect wipe, card con stats + 3 buttons (Next/Retry/Close)
3. **Scenarios completi**: dropdown 01-05 (Tutorial Primi passi → BOSS Apex)

## Build

- 9 modules, 11.1KB JS (gzip 4.27KB), 63ms
- Zero runtime deps

## Files

- \`apps/play/index.html\` — dropdown 5 scenari + endgame overlay HTML
- \`apps/play/src/abilityPanel.js\` (nuovo) — fetch jobs + render
- \`apps/play/src/endgame.js\` (nuovo) — detect + show + nextScenario
- \`apps/play/src/main.js\` — orchestration con ability pending mode + endgame hook
- \`apps/play/src/style.css\` — ability-row + overlay styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)