### PR TITLE
feat(session): round/execute batch endpoint — SoT Fase 1

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -976,6 +976,264 @@ function createSessionRouter(options = {}) {
     }
   });
 
+  // ───────────────────────────────────────────────────────────────
+  // POST /round/execute — batch round resolver (Fase 1 SoT-alignment).
+  //
+  // Accetta TUTTI gli intents player di un round + opzionale AI auto-declare
+  // + risolve in una singola richiesta. Allineato al round model canonico
+  // (ADR-2026-04-15): internamente usa gli stessi dispatcher di /action
+  // (performAttack, abilityExecutor, move handler) in ordine di dichiarazione,
+  // seguito da AI turn end se ai_auto=true.
+  //
+  // Body:
+  //   {
+  //     session_id: string,
+  //     player_intents: [
+  //       { actor_id, action: { type: 'attack'|'move'|'ability', ...} },
+  //       ...
+  //     ],
+  //     ai_auto?: boolean (default true),
+  //     preview_only?: boolean (default false)  // MVP: not implemented, reserved
+  //   }
+  //
+  // AP budget validato cumulativamente per actor PRIMA del dispatch:
+  // Σ ap_cost ≤ ap_remaining → 400 violations se superato.
+  // ───────────────────────────────────────────────────────────────
+  function estimateApCost(action, actor) {
+    if (!action) return 0;
+    if (action.type === 'attack') return 1;
+    if (action.type === 'move') {
+      const dest = action.position;
+      if (!dest || !actor || !actor.position) return 1;
+      return manhattanDistance(actor.position, dest);
+    }
+    if (action.type === 'ability') {
+      try {
+        const { findAbility } = require('../services/abilityExecutor');
+        const ab = findAbility(action.ability_id);
+        return ab ? Number(ab.cost_ap || 0) : 0;
+      } catch {
+        return 0;
+      }
+    }
+    if (action.type === 'turn' || action.type === 'skip') return 0;
+    return 0;
+  }
+
+  router.post('/round/execute', async (req, res, next) => {
+    try {
+      const body = req.body || {};
+      const { error, session } = resolveSession(body.session_id);
+      if (error) return res.status(error.status).json(error.body);
+
+      const playerIntents = Array.isArray(body.player_intents) ? body.player_intents : [];
+      const aiAuto = body.ai_auto !== false;
+
+      // Validazione intent + AP cumulativo per actor.
+      const apByUnit = {};
+      const violations = [];
+      const normalized = [];
+      for (let i = 0; i < playerIntents.length; i += 1) {
+        const raw = playerIntents[i];
+        if (!raw || !raw.actor_id || !raw.action) {
+          violations.push({ index: i, error: 'intent richiede actor_id + action' });
+          continue;
+        }
+        const actor = session.units.find((u) => u.id === raw.actor_id);
+        if (!actor) {
+          violations.push({ index: i, actor_id: raw.actor_id, error: 'actor non trovato' });
+          continue;
+        }
+        if (Number(actor.hp) <= 0) {
+          violations.push({
+            index: i,
+            actor_id: raw.actor_id,
+            error: 'actor morto',
+          });
+          continue;
+        }
+        const cost = estimateApCost(raw.action, actor);
+        apByUnit[raw.actor_id] = (apByUnit[raw.actor_id] || 0) + cost;
+        if (apByUnit[raw.actor_id] > Number(actor.ap_remaining ?? actor.ap ?? 0)) {
+          violations.push({
+            index: i,
+            actor_id: raw.actor_id,
+            error: `AP budget superato: Σ ${apByUnit[raw.actor_id]} > ${actor.ap_remaining ?? actor.ap ?? 0}`,
+            requested: apByUnit[raw.actor_id],
+            available: Number(actor.ap_remaining ?? actor.ap ?? 0),
+          });
+          continue;
+        }
+        normalized.push({ index: i, actor, raw });
+      }
+      if (violations.length > 0) {
+        return res.status(400).json({
+          error: 'AP budget or intent validation failed',
+          violations,
+        });
+      }
+
+      // Dispatch sequenziale intent player.
+      const results = [];
+      const eventsCountBefore = session.events.length;
+      for (const { actor, raw } of normalized) {
+        if (Number(actor.hp) <= 0) {
+          results.push({ actor_id: actor.id, skipped: 'actor_dead_mid_round' });
+          continue;
+        }
+        const action = raw.action;
+        if (action.type === 'attack') {
+          const target = session.units.find((u) => u.id === action.target_id);
+          if (!target || Number(target.hp) <= 0) {
+            results.push({
+              actor_id: actor.id,
+              skipped: 'target_dead_or_missing',
+              target_id: action.target_id,
+            });
+            continue;
+          }
+          const range = Number(actor.attack_range) || DEFAULT_ATTACK_RANGE;
+          if (manhattanDistance(actor.position, target.position) > range) {
+            results.push({
+              actor_id: actor.id,
+              skipped: 'target_out_of_range',
+              target_id: action.target_id,
+            });
+            continue;
+          }
+          const wrapped = await handleLegacyAttackViaRound({
+            session,
+            actor,
+            target,
+            requestedCapPt: 0,
+          });
+          results.push({ actor_id: actor.id, action_type: 'attack', result: wrapped });
+        } else if (action.type === 'move') {
+          const dest = action.position;
+          if (
+            !dest ||
+            typeof dest.x !== 'number' ||
+            typeof dest.y !== 'number' ||
+            dest.x < 0 ||
+            dest.x >= GRID_SIZE ||
+            dest.y < 0 ||
+            dest.y >= GRID_SIZE
+          ) {
+            results.push({ actor_id: actor.id, skipped: 'invalid_position' });
+            continue;
+          }
+          const blocker = session.units.find(
+            (u) =>
+              u.id !== actor.id && u.hp > 0 && u.position.x === dest.x && u.position.y === dest.y,
+          );
+          if (blocker) {
+            results.push({
+              actor_id: actor.id,
+              skipped: 'cell_occupied',
+              blocker_id: blocker.id,
+            });
+            continue;
+          }
+          const dist = manhattanDistance(actor.position, dest);
+          actor.ap_remaining = Math.max(0, (actor.ap_remaining ?? actor.ap) - dist);
+          const positionFrom = { ...actor.position };
+          actor.position = { x: dest.x, y: dest.y };
+          const newFacing = facingFromMove(positionFrom, actor.position);
+          if (newFacing) actor.facing = newFacing;
+          const moveEvent = buildMoveEvent({ session, actor, positionFrom });
+          await appendEvent(session, moveEvent);
+          const overwatchResult = reactionEngine.triggerOnMove(
+            session,
+            actor,
+            positionFrom,
+            (overwatchUnit, mover) => performAttack(session, overwatchUnit, mover),
+          );
+          if (overwatchResult) {
+            await appendEvent(session, {
+              ts: new Date().toISOString(),
+              session_id: session.session_id,
+              actor_id: overwatchResult.overwatch_id,
+              action_type: 'reaction_trigger',
+              ability_id: overwatchResult.ability_id,
+              trigger: 'enemy_moves_in_range',
+              target_id: overwatchResult.mover_id,
+              turn: session.turn,
+              from_position: overwatchResult.from_position,
+              to_position: overwatchResult.to_position,
+              die: overwatchResult.die,
+              roll: overwatchResult.roll,
+              mos: overwatchResult.mos,
+              result: overwatchResult.hit ? 'hit' : 'miss',
+              damage_dealt: overwatchResult.damage_dealt,
+              mover_hp_before: overwatchResult.mover_hp_before,
+              mover_hp_after: overwatchResult.mover_hp_after,
+              mover_killed: overwatchResult.mover_killed,
+              damage_step_mod: overwatchResult.damage_step_mod,
+              trait_effects: [],
+            });
+          }
+          results.push({
+            actor_id: actor.id,
+            action_type: 'move',
+            result: {
+              position_from: positionFrom,
+              position_to: { ...actor.position },
+              overwatch: overwatchResult,
+            },
+          });
+        } else if (action.type === 'ability') {
+          const dispatch = await abilityExecutor.executeAbility({
+            session,
+            actor,
+            body: action,
+          });
+          results.push({
+            actor_id: actor.id,
+            action_type: 'ability',
+            status: dispatch.status,
+            result: dispatch.body,
+          });
+        } else if (action.type === 'turn') {
+          const rawFacing = action.facing ? String(action.facing).toUpperCase() : null;
+          if (VALID_FACINGS.has(rawFacing)) {
+            actor.facing = rawFacing;
+            results.push({ actor_id: actor.id, action_type: 'turn', facing: rawFacing });
+          } else {
+            results.push({ actor_id: actor.id, skipped: 'invalid_facing' });
+          }
+        } else if (action.type === 'skip') {
+          results.push({ actor_id: actor.id, action_type: 'skip' });
+        } else {
+          results.push({
+            actor_id: actor.id,
+            skipped: `unknown action type: ${action.type}`,
+          });
+        }
+      }
+
+      // AI auto-declare: usa handleTurnEndViaRound (bleeding + hazard +
+      // status decay + AI intents + commit + resolve).
+      let aiResult = null;
+      if (aiAuto) {
+        aiResult = await handleTurnEndViaRound(session);
+      }
+
+      const eventsEmitted = session.events.slice(eventsCountBefore);
+
+      return res.json({
+        round: session.turn,
+        results,
+        ai_result: aiResult,
+        events_emitted_count: eventsEmitted.length,
+        events: eventsEmitted,
+        ap_consumed: apByUnit,
+        state: publicSessionView(session),
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
   router.post('/end', async (req, res, next) => {
     try {
       const body = req.body || {};

--- a/tests/api/roundExecute.test.js
+++ b/tests/api/roundExecute.test.js
@@ -1,0 +1,171 @@
+// tests/api/roundExecute.test.js — Fase 1 SoT-alignment.
+//
+// Verifica POST /api/session/round/execute:
+//   - batch player intents (attack + move + ability) in 1 request
+//   - AP budget cumulativo enforced (violations 400)
+//   - ai_auto=true triggera handleTurnEndViaRound
+//   - ai_auto=false salta AI turn
+//   - reaction engine wired (overwatch fires mid-batch se INTO range)
+//   - events aggregati ritornati
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+
+async function startSession(app) {
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units });
+  return { sid: startRes.body.session_id, state: startRes.body.state };
+}
+
+test('round/execute: batch 2 attack player intents + ai_auto', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const { sid } = await startSession(app);
+  // p_scout (1,2) → e_nomad_1 (3,2) dist=2, range=2 → attack ok
+  // p_tank (1,3) → range=1, nemico troppo lontano → move only
+  const res = await request(app)
+    .post('/api/session/round/execute')
+    .send({
+      session_id: sid,
+      player_intents: [
+        { actor_id: 'p_scout', action: { type: 'attack', target_id: 'e_nomad_1' } },
+        { actor_id: 'p_tank', action: { type: 'move', position: { x: 2, y: 3 } } },
+      ],
+      ai_auto: true,
+    });
+  assert.equal(res.status, 200, `round/execute ok: ${JSON.stringify(res.body).slice(0, 200)}`);
+  assert.equal(res.body.results.length, 2);
+  assert.equal(res.body.results[0].action_type, 'attack');
+  assert.equal(res.body.results[1].action_type, 'move');
+  assert.ok(res.body.ai_result, 'ai_result populated con ai_auto=true');
+  assert.ok(res.body.events_emitted_count >= 2, 'almeno 2 event emessi (scout attack + tank move)');
+  assert.ok(res.body.ap_consumed.p_scout === 1);
+  assert.ok(res.body.ap_consumed.p_tank === 1);
+});
+
+test('round/execute: AP budget violation → 400 con violations list', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const { sid } = await startSession(app);
+  // p_scout ap=3. 4 attack tentati = 4 AP > 3.
+  const res = await request(app)
+    .post('/api/session/round/execute')
+    .send({
+      session_id: sid,
+      player_intents: [
+        { actor_id: 'p_scout', action: { type: 'attack', target_id: 'e_nomad_1' } },
+        { actor_id: 'p_scout', action: { type: 'attack', target_id: 'e_nomad_1' } },
+        { actor_id: 'p_scout', action: { type: 'attack', target_id: 'e_nomad_1' } },
+        { actor_id: 'p_scout', action: { type: 'attack', target_id: 'e_nomad_1' } },
+      ],
+      ai_auto: false,
+    });
+  assert.equal(res.status, 400);
+  assert.ok(Array.isArray(res.body.violations));
+  assert.ok(res.body.violations.length >= 1, 'almeno 1 violation');
+  const v = res.body.violations.find((x) => x.actor_id === 'p_scout');
+  assert.ok(v, 'violation per p_scout presente');
+  assert.match(v.error, /AP budget superato/i);
+});
+
+test('round/execute: ai_auto=false NON avanza AI turn', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const { sid } = await startSession(app);
+  const res = await request(app)
+    .post('/api/session/round/execute')
+    .send({
+      session_id: sid,
+      player_intents: [{ actor_id: 'p_scout', action: { type: 'attack', target_id: 'e_nomad_1' } }],
+      ai_auto: false,
+    });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.ai_result, null, 'ai_result null se ai_auto=false');
+  assert.equal(res.body.results.length, 1);
+});
+
+test('round/execute: ability intent dispatched via abilityExecutor', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const { sid } = await startSession(app);
+  const res = await request(app)
+    .post('/api/session/round/execute')
+    .send({
+      session_id: sid,
+      player_intents: [
+        {
+          actor_id: 'p_scout',
+          action: {
+            type: 'ability',
+            ability_id: 'dash_strike',
+            target_id: 'e_nomad_1',
+            position: { x: 2, y: 2 },
+          },
+        },
+      ],
+      ai_auto: false,
+    });
+  assert.equal(res.status, 200, `ability ok: ${JSON.stringify(res.body).slice(0, 300)}`);
+  assert.equal(res.body.results[0].action_type, 'ability');
+  assert.equal(res.body.results[0].status, 200);
+  assert.equal(res.body.results[0].result.effect_type, 'move_attack');
+});
+
+test('round/execute: invalid intent (actor missing) → 400', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const { sid } = await startSession(app);
+  const res = await request(app)
+    .post('/api/session/round/execute')
+    .send({
+      session_id: sid,
+      player_intents: [
+        { actor_id: 'ghost_xyz', action: { type: 'attack', target_id: 'e_nomad_1' } },
+      ],
+    });
+  assert.equal(res.status, 400);
+  assert.ok(res.body.violations);
+  assert.match(res.body.violations[0].error, /actor non trovato/i);
+});
+
+test('round/execute: empty intents + ai_auto=true runs AI only', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const { sid } = await startSession(app);
+  const res = await request(app).post('/api/session/round/execute').send({
+    session_id: sid,
+    player_intents: [],
+    ai_auto: true,
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.results.length, 0);
+  assert.ok(res.body.ai_result);
+  assert.ok(res.body.ai_result.turn > 1, 'AI ha avanzato turn');
+});


### PR DESCRIPTION
## Summary

Nuovo endpoint `POST /api/session/round/execute` allinea il flusso a **round model canonico** ([ADR-2026-04-15](docs/adr/ADR-2026-04-15-round-based-combat-model.md)). Accetta batch player intents + AI auto-declare + risolve sequenzialmente in 1 request.

**Fase 1 di 3** — SoT alignment plan:
- **Fase 1** (questo PR): endpoint batch
- **Fase 2** (PR successivo): tutorial 02-05 allineamento `ap_max=2`
- **Fase 3** (PR successivo): CLI `master_dm.py` playtest REPL

## Body

```json
{
  "session_id": "uuid",
  "player_intents": [
    { "actor_id": "p_scout", "action": { "type": "attack", "target_id": "e_nomad_1" } },
    { "actor_id": "p_tank",  "action": { "type": "move", "position": {"x":2,"y":3} } }
  ],
  "ai_auto": true
}
```

## Validazione

- `Σ ap_cost ≤ ap_remaining` per actor (cumulativo) → **400** con `violations[]` dettagliato
- Actor alive + trovato in session
- Intent ben formato (`actor_id` + `action.type` required)

## Dispatch sequenziale

| Action type | Handler |
|---|---|
| `attack` | `handleLegacyAttackViaRound` (trigger reaction intercept) |
| `move` | inline + overwatch INTO range trigger |
| `ability` | `abilityExecutor.executeAbility` (18/18 effect_type) |
| `turn`, `skip` | no-op/facing |

## AI auto (default on)

Dopo player intents, `handleTurnEndViaRound` esegue AI declarations + status decay + hazard tick. `ai_auto: false` salta (per debug/preview).

## Response

```json
{
  "round": 3,
  "results": [ { "actor_id", "action_type", "result" } ],
  "ai_result": { "ia_actions": [...], "side_effects": [...] },
  "events": [ ...all round events... ],
  "events_emitted_count": 5,
  "ap_consumed": { "p_scout": 2 },
  "state": { ...public view... }
}
```

## Test plan

- [x] `node --test tests/api/roundExecute.test.js` — **6/6 verdi**
  - batch 2 player intents (attack + move) + ai_auto
  - AP budget violation → 400 con violations
  - ai_auto=false non avanza AI
  - ability intent via abilityExecutor
  - invalid actor → 400
  - empty intents + ai_auto → runs AI only
- [x] Regression: ai 161, abilityExecutor 34, apBudget 3, jobs 4, sessionLegacyActionWrapper tutti verdi
- [ ] CI `stack-quality` + `python-tests`

## Rollback

Revert singolo commit. Aggiunta isolata: nuovo endpoint + test file. Nessuna modifica a `/action` o `/turn/end` esistenti.

## Segue

- **Fase 2**: tutorial 02-05 `ap_max=2` canonical (tutorial 01 resta ap=3 eccezione easy)
- **Fase 3**: CLI `master_dm.py` REPL che traduce canonical syntax in batch requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)