### PR TITLE
balance(tutorial): allinea AP tutorial 02-05 a SoT canonical (ap=2) — Fase 2

### DIFF
--- a/apps/backend/services/tutorialScenario.js
+++ b/apps/backend/services/tutorialScenario.js
@@ -102,6 +102,9 @@ const TUTORIAL_SCENARIO_04 = {
 function buildTutorialUnits() {
   return [
     // --- Player units ---
+    // NOTE: tutorial_01 eccezione canonical: ap=3 (vs SoT ap_max=2) per
+    // onboarding easy. Tutorial 02-05 allineati a ap=2. Vedi
+    // docs/core/11-REGOLE_D20_TV.md §"AP budget canonico".
     {
       id: 'p_scout',
       species: 'dune_stalker',
@@ -178,14 +181,15 @@ function buildTutorialUnits() {
 // dare scelta tattica.
 function buildTutorialUnits02() {
   return [
-    // Player units (stessi del tutorial 01)
+    // Player units (stessi del tutorial 01 ma ap=2 SoT canonical; 01 resta
+    // ap=3 come "tutorial_easy" eccezione per onboarding).
     {
       id: 'p_scout',
       species: 'dune_stalker',
       job: 'skirmisher',
       traits: ['zampe_a_molla'],
       hp: 10,
-      ap: 3,
+      ap: 2,
       mod: 3,
       dc: 12,
       guardia: 1,
@@ -199,7 +203,7 @@ function buildTutorialUnits02() {
       job: 'vanguard',
       traits: ['pelle_elastomera'],
       hp: 12,
-      ap: 3,
+      ap: 2,
       mod: 2,
       dc: 13,
       guardia: 1,
@@ -270,13 +274,14 @@ function buildTutorialUnits02() {
 // metadata: applicare danno e' wiring futuro nel turn/end handler.
 function buildTutorialUnits03() {
   return [
+    // Player units — ap=2 SoT canonical (da tutorial 02 in poi).
     {
       id: 'p_scout',
       species: 'dune_stalker',
       job: 'skirmisher',
       traits: ['zampe_a_molla'],
       hp: 10,
-      ap: 3,
+      ap: 2,
       mod: 3,
       dc: 12,
       guardia: 1,
@@ -290,7 +295,7 @@ function buildTutorialUnits03() {
       job: 'vanguard',
       traits: ['pelle_elastomera'],
       hp: 12,
-      ap: 3,
+      ap: 2,
       mod: 2,
       dc: 13,
       guardia: 1,
@@ -341,13 +346,14 @@ function buildTutorialUnits03() {
 // (trait denti_seghettati) + 3 hazard tiles distribuiti.
 function buildTutorialUnits04() {
   return [
+    // Player units — ap=2 SoT canonical.
     {
       id: 'p_scout',
       species: 'dune_stalker',
       job: 'skirmisher',
       traits: ['zampe_a_molla'],
       hp: 10,
-      ap: 3,
+      ap: 2,
       mod: 3,
       dc: 12,
       guardia: 1,
@@ -361,7 +367,7 @@ function buildTutorialUnits04() {
       job: 'vanguard',
       traits: ['pelle_elastomera'],
       hp: 12,
-      ap: 3,
+      ap: 2,
       mod: 2,
       dc: 13,
       guardia: 1,
@@ -430,13 +436,15 @@ function buildTutorialUnits04() {
 // con HP altissimo, ferocia (crit kill resets), martello_osseo (bonus crit).
 function buildTutorialUnits05() {
   return [
+    // Player units — ap=2 SoT canonical anche per BOSS (asimmetria solo
+    // su enemy stats, non via budget turn).
     {
       id: 'p_scout',
       species: 'dune_stalker',
       job: 'skirmisher',
       traits: ['zampe_a_molla'],
       hp: 12,
-      ap: 3,
+      ap: 2,
       mod: 4,
       dc: 13,
       guardia: 1,
@@ -450,7 +458,7 @@ function buildTutorialUnits05() {
       job: 'vanguard',
       traits: ['pelle_elastomera'],
       hp: 14,
-      ap: 3,
+      ap: 2,
       mod: 3,
       dc: 14,
       guardia: 2,


### PR DESCRIPTION
## Summary

**Fase 2 di 3** SoT alignment — tutorial 02-05 player `ap_max` allineato a canonical `2` (da `3`).

**Autorità**: [`docs/core/11-REGOLE_D20_TV.md`](docs/core/11-REGOLE_D20_TV.md) §AP budget canonico (source_of_truth: true).

## Cambio

| Scenario | Prima | Dopo | Note |
|---|---|---|---|
| Tutorial 01 (Savana, diff 1) | ap=3 | **ap=3 invariato** | Eccezione esplicita "tutorial_easy" onboarding |
| Tutorial 02 (Pattuglia, diff 2) | ap=3 | **ap=2** | SoT canonical |
| Tutorial 03 (Caverna, diff 3) | ap=3 | **ap=2** | SoT canonical |
| Tutorial 04 (Pozza Acida, diff 4) | ap=3 | **ap=2** | SoT canonical |
| Tutorial 05 (BOSS Apex, diff 5) | ap=3 | **ap=2** | SoT canonical |

Tutorial 01 eccezione documentata con commento inline per chiarire scelta intenzionale (onboarding easy). Enemy ap invariati — asimmetria rimane via HP/DC/profili AI.

## Impact atteso (balance)

- Win rate tutorial 02-05 **calerà** (meno azioni/turno = meno dmg player-side)
- Ri-tuning richiesto prossimo playtest — Master DD calibra enemy stats (HP/mod/DC) se fuori target band
- Tutorial 01 band attuale (90-95%) invariato

## Test plan

- [x] `apBudget` 3/3 (dinamico su ap_max, no regression)
- [x] `firstPlaytest` 1/1 (smoke test)
- [x] `batchPlaytest` 1/1 (N=10 harness)
- [ ] CI stack-quality
- [ ] Playtest #3 per validare balance post-change

## Rollback

Revert singolo commit. Se playtest M3 mostra win rate <30% per diff 2-3 (breaks "tutorial curve"), opzioni:
- Rollback intero (return ap=3)
- Oppure ri-tuning enemy (HP↓ o mod↓) mantenendo ap=2 canonical

## Segue

**Fase 3** (PR separato): CLI `tools/py/master_dm.py` REPL per playtest tabletop con canonical syntax → batch `/round/execute`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)