### PR TITLE
play: animations (move tween + damage popup) + status icons (β)

### DIFF
--- a/apps/play/src/anim.js
+++ b/apps/play/src/anim.js
@@ -1,0 +1,66 @@
+// Minimal animation layer — interpolated unit positions + damage popups.
+
+const ANIM_MS = 200; // move tween duration
+const POPUP_MS = 900;
+
+const movers = new Map(); // unit_id → { fromX, fromY, toX, toY, start }
+const popups = []; // [{ x, y, text, color, start }]
+
+export function recordMove(unitId, from, to) {
+  if (!from || !to) return;
+  if (from.x === to.x && from.y === to.y) return;
+  movers.set(unitId, {
+    fromX: from.x,
+    fromY: from.y,
+    toX: to.x,
+    toY: to.y,
+    start: performance.now(),
+  });
+}
+
+export function pushPopup(x, y, text, color = '#ff5252') {
+  popups.push({ x, y, text: String(text), color, start: performance.now() });
+}
+
+export function getInterpolatedPos(unitId, currentPos) {
+  const m = movers.get(unitId);
+  if (!m) return currentPos;
+  const t = (performance.now() - m.start) / ANIM_MS;
+  if (t >= 1) {
+    movers.delete(unitId);
+    return currentPos;
+  }
+  const eased = 1 - Math.pow(1 - t, 2); // ease-out
+  return {
+    x: m.fromX + (m.toX - m.fromX) * eased,
+    y: m.fromY + (m.toY - m.fromY) * eased,
+  };
+}
+
+export function drawPopups(ctx, cellSize, gridH) {
+  const now = performance.now();
+  for (let i = popups.length - 1; i >= 0; i--) {
+    const p = popups[i];
+    const t = (now - p.start) / POPUP_MS;
+    if (t >= 1) {
+      popups.splice(i, 1);
+      continue;
+    }
+    const yPx = gridH - 1 - p.y;
+    const alpha = 1 - t;
+    ctx.globalAlpha = alpha;
+    ctx.fillStyle = p.color;
+    ctx.font = 'bold 18px "SF Mono", monospace';
+    ctx.textAlign = 'center';
+    ctx.fillText(
+      p.text,
+      p.x * cellSize + cellSize / 2,
+      yPx * cellSize + cellSize / 2 - 14 - t * 30,
+    );
+    ctx.globalAlpha = 1;
+  }
+}
+
+export function hasActiveAnims() {
+  return movers.size > 0 || popups.length > 0;
+}

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -1,10 +1,11 @@
 // Evo-Tactics Play — entry point. Orchestration layer.
 
 import { api } from './api.js';
-import { render, canvasToCell } from './render.js';
+import { render, canvasToCell, needsAnimFrame } from './render.js';
 import { renderUnits, appendLog, updateStatus } from './ui.js';
 import { renderAbilities, clearAbilities } from './abilityPanel.js';
 import { detectEndgame, showEndgame, hideEndgame, nextScenarioId } from './endgame.js';
+import { recordMove, pushPopup } from './anim.js';
 
 const state = {
   sid: null,
@@ -172,16 +173,56 @@ async function doAction(body) {
   await refresh();
 }
 
+// Track last events count to detect new events for anim
+let lastEventsCount = 0;
+
+function processNewEvents(prevWorld, newWorld) {
+  const prevUnits = new Map((prevWorld?.units || []).map((u) => [u.id, u]));
+  const events = (newWorld?.events || []).slice(lastEventsCount);
+  for (const ev of events) {
+    if (ev.action_type === 'move' && ev.position_from && ev.position_to) {
+      recordMove(
+        ev.actor_id,
+        { x: ev.position_from[0], y: ev.position_from[1] },
+        { x: ev.position_to[0], y: ev.position_to[1] },
+      );
+    }
+    if (
+      (ev.action_type === 'attack' || ev.action_type === 'ability') &&
+      ev.damage_dealt &&
+      ev.target_id
+    ) {
+      const target = (newWorld.units || []).find((u) => u.id === ev.target_id);
+      if (target && target.position) {
+        const color = ev.damage_dealt < 0 ? '#4caf50' : '#ff5252';
+        const txt = ev.damage_dealt < 0 ? `+${-ev.damage_dealt}` : `-${ev.damage_dealt}`;
+        pushPopup(target.position.x, target.position.y, txt, color);
+      }
+    }
+  }
+  lastEventsCount = (newWorld?.events || []).length;
+}
+
 async function refresh() {
   const r = await api.state(state.sid);
   if (r.ok) {
+    const prev = state.world;
     state.world = r.data;
+    processNewEvents(prev, state.world);
     if (state.selected) {
       const sel = state.world.units.find((u) => u.id === state.selected);
       if (!sel || sel.hp <= 0) state.selected = null;
     }
     redraw();
+    // Animation loop
+    if (needsAnimFrame()) requestAnimationFrame(animTick);
   }
+}
+
+function animTick() {
+  if (!state.world) return;
+  redraw();
+  if (needsAnimFrame()) requestAnimationFrame(animTick);
 }
 
 async function startNewSession() {
@@ -205,6 +246,7 @@ async function startNewSession() {
   state.world = st.data.state;
   state.selected = null;
   state.target = null;
+  lastEventsCount = (state.world?.events || []).length;
   appendLog(logEl, `✓ sessione ${state.sid.slice(0, 8)}…`);
   updateHint('Sessione iniziata. Seleziona una tua unità.');
   redraw();

--- a/apps/play/src/render.js
+++ b/apps/play/src/render.js
@@ -1,4 +1,6 @@
-// Canvas 2D rendering — grid + units.
+// Canvas 2D rendering — grid + units + animations + status icons.
+
+import { getInterpolatedPos, drawPopups, hasActiveAnims } from './anim.js';
 
 const CELL = 64; // pixel per cell
 const COLORS = {
@@ -14,6 +16,19 @@ const COLORS = {
   hpFull: '#4caf50',
   hpWarn: '#ffc107',
   hpCrit: '#f44336',
+};
+
+const STATUS_ICONS = {
+  panic: { glyph: '!', bg: '#ff9800' },
+  rage: { glyph: '⚡', bg: '#f44336' },
+  stunned: { glyph: '★', bg: '#9c27b0' },
+  focused: { glyph: '◎', bg: '#03a9f4' },
+  confused: { glyph: '?', bg: '#ffc107' },
+  bleeding: { glyph: '☽', bg: '#e91e63' },
+  fracture: { glyph: '✕', bg: '#795548' },
+  sbilanciato: { glyph: '↯', bg: '#ffeb3b' },
+  taunted_by: { glyph: '⎯', bg: '#ffc107' },
+  aggro_locked: { glyph: '◉', bg: '#ff5722' },
 };
 
 export function fitCanvas(canvas, width, height) {
@@ -37,9 +52,41 @@ function drawCell(ctx, x, yPx, fill) {
   ctx.strokeRect(x * CELL + 0.5, yPx * CELL + 0.5, CELL - 1, CELL - 1);
 }
 
+function drawStatusIcons(ctx, unit, cx, yPxTop) {
+  const status = unit.status || {};
+  const icons = [];
+  for (const [key, meta] of Object.entries(STATUS_ICONS)) {
+    const val = status[key];
+    if (val !== undefined && val !== null && (typeof val !== 'number' || val > 0)) {
+      icons.push(meta);
+    }
+  }
+  if (icons.length === 0) return;
+  const size = 12;
+  const gap = 2;
+  const startX = cx + CELL * 0.18;
+  for (let i = 0; i < icons.length && i < 4; i++) {
+    const ic = icons[i];
+    const ix = startX + i * (size + gap);
+    const iy = yPxTop + 4;
+    ctx.fillStyle = ic.bg;
+    ctx.beginPath();
+    ctx.arc(ix + size / 2, iy + size / 2, size / 2, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = '#000';
+    ctx.font = 'bold 10px "SF Mono", monospace';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(ic.glyph, ix + size / 2, iy + size / 2 + 1);
+  }
+}
+
 function drawUnit(ctx, unit, gridH, highlight = {}) {
   if (!unit.position) return;
-  const { x, y } = unit.position;
+  // Interpolate position via anim module
+  const interpolated = getInterpolatedPos(unit.id, unit.position);
+  const x = interpolated.x;
+  const y = interpolated.y;
   const yPx = gridH - 1 - y;
   const cx = x * CELL + CELL / 2;
   const cy = yPx * CELL + CELL / 2;
@@ -107,6 +154,9 @@ function drawUnit(ctx, unit, gridH, highlight = {}) {
     ctx.fillStyle = ratio < 0.3 ? COLORS.hpCrit : ratio < 0.6 ? COLORS.hpWarn : COLORS.hpFull;
     ctx.fillRect(barX, barY, barW * ratio, 4);
   }
+
+  // Status icons (top-right)
+  if (!dead) drawStatusIcons(ctx, unit, cx, yPx * CELL);
 }
 
 export function render(canvas, state, highlight = {}) {
@@ -127,6 +177,13 @@ export function render(canvas, state, highlight = {}) {
 
   // Units
   for (const u of state.units || []) drawUnit(ctx, u, h, highlight);
+
+  // Damage popups on top
+  drawPopups(ctx, CELL, h);
+}
+
+export function needsAnimFrame() {
+  return hasActiveAnims();
 }
 
 export const CELL_SIZE = CELL;


### PR DESCRIPTION
Sprint β frontend polish. 10 modules, 13.6KB JS gzipped 5.28KB. Zero deps.

- Move tween 200ms ease-out
- Damage popup floating 900ms fade+rise (red dmg / green heal)
- 10 status icons (panic/rage/stunned/focused/confused/bleeding/fracture/sbilanciato/taunted_by/aggro_locked)
- requestAnimationFrame driver only when active anims exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)