### PR TITLE
feat(tools): master_dm.py CLI playtest assistant — SoT Fase 3

### DIFF
--- a/docs/core/11-REGOLE_D20_TV.md
+++ b/docs/core/11-REGOLE_D20_TV.md
@@ -53,7 +53,31 @@ Regole canoniche per turno, AP budget, syntax input. Chiude FRICTION #1-#3 dal p
 ### Enforcement
 
 - **Codice**: `apps/backend/services/roundOrchestrator.js` + `sessionRoundBridge.js` validano `ap.current >= ap_cost` prima di eseguire azione.
-- **Test canonical**: [`tests/api/apBudget.test.js`](../../tests/api/apBudget.test.js) — asserisce 2 attack/turn valido con `ap_max=2` su tutorial_01.
+- **Test canonical**: [`tests/api/apBudget.test.js`](../../tests/api/apBudget.test.js) — asserisce budget valido con `ap_max` dinamico.
+- **Scenari**: tutorial 02-05 allineati a `ap_max=2` canonical. Tutorial 01 mantiene `ap_max=3` come eccezione esplicita (onboarding easy) — vedi `apps/backend/services/tutorialScenario.js`.
+
+### Batch execution: `POST /api/session/round/execute`
+
+Endpoint canonical per eseguire un round completo in una singola request. Accetta tutti gli intents player + opzionale AI auto-declare + risolve sequenzialmente.
+
+**Body**:
+
+```json
+{
+  "session_id": "uuid",
+  "player_intents": [
+    { "actor_id": "p_scout", "action": { "type": "attack", "target_id": "e_nomad_1" } },
+    { "actor_id": "p_tank", "action": { "type": "move", "position": { "x": 2, "y": 3 } } }
+  ],
+  "ai_auto": true
+}
+```
+
+**Validazione cumulativa**: `Σ ap_cost ≤ ap_remaining` per ogni actor. Violations → 400 con lista dettagliata.
+
+**Response**: aggregato di `results[]` (per intent), `ai_result` (se ai_auto), `events[]`, `ap_consumed`, `state`.
+
+**CLI assistant**: [`tools/py/master_dm.py`](../../tools/py/master_dm.py) — REPL canonical syntax → batch endpoint.
 
 ### Varianti future (opt-in, non default)
 

--- a/tests/test_master_dm_parser.py
+++ b/tests/test_master_dm_parser.py
@@ -1,0 +1,69 @@
+"""Test parser CLI master_dm.py (Fase 3). Standalone unittest (no pytest)."""
+
+import sys
+import pathlib
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent / "tools" / "py"))
+from master_dm import parse_line  # noqa: E402
+
+
+class TestMasterDmParser(unittest.TestCase):
+    def test_move_atk_combo(self):
+        intents = parse_line("p_scout: move [3,2] atk e_nomad_1")
+        self.assertEqual(len(intents), 2)
+        self.assertEqual(intents[0]["actor_id"], "p_scout")
+        self.assertEqual(intents[0]["action"]["type"], "move")
+        self.assertEqual(intents[0]["action"]["position"], {"x": 3, "y": 2})
+        self.assertEqual(intents[1]["action"]["type"], "attack")
+        self.assertEqual(intents[1]["action"]["target_id"], "e_nomad_1")
+
+    def test_atk_only(self):
+        intents = parse_line("p_tank: atk e_hunter")
+        self.assertEqual(len(intents), 1)
+        self.assertEqual(intents[0]["action"], {"type": "attack", "target_id": "e_hunter"})
+
+    def test_move_only(self):
+        intents = parse_line("p_scout: move [4,2]")
+        self.assertEqual(len(intents), 1)
+        self.assertEqual(intents[0]["action"]["type"], "move")
+        self.assertEqual(intents[0]["action"]["position"], {"x": 4, "y": 2})
+
+    def test_ability_with_target(self):
+        intents = parse_line("p_scout: ability dash_strike target=e_nomad_1")
+        self.assertEqual(len(intents), 1)
+        self.assertEqual(intents[0]["action"]["ability_id"], "dash_strike")
+        self.assertEqual(intents[0]["action"]["target_id"], "e_nomad_1")
+
+    def test_ability_self(self):
+        intents = parse_line("p_tank: ability fortify")
+        self.assertEqual(len(intents), 1)
+        self.assertEqual(intents[0]["action"]["type"], "ability")
+        self.assertEqual(intents[0]["action"]["ability_id"], "fortify")
+        self.assertNotIn("target_id", intents[0]["action"])
+
+    def test_ability_with_position(self):
+        intents = parse_line("p_scout: ability dash_strike target=e_nomad_1 pos=[2,2]")
+        self.assertEqual(len(intents), 1)
+        self.assertEqual(intents[0]["action"]["position"], {"x": 2, "y": 2})
+
+    def test_skip(self):
+        intents = parse_line("p_tank: skip")
+        self.assertEqual(len(intents), 1)
+        self.assertEqual(intents[0]["action"], {"type": "skip"})
+
+    def test_empty_line(self):
+        self.assertEqual(parse_line(""), [])
+        self.assertEqual(parse_line("   "), [])
+
+    def test_invalid_syntax(self):
+        with self.assertRaises(ValueError):
+            parse_line("p_scout: vai a nord")
+
+    def test_negative_coords(self):
+        intents = parse_line("p_scout: move [-1,2]")
+        self.assertEqual(intents[0]["action"]["position"], {"x": -1, "y": 2})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/py/master_dm.py
+++ b/tools/py/master_dm.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Master DM CLI — Fase 3 playtest assistant.
+
+REPL che traduce mosse canoniche (11-REGOLE_D20_TV.md §Syntax) in
+batch POST /api/session/round/execute. Per playtest tabletop: Master
+legge fogli player, inserisce intents, invia round, legge risultati.
+
+Canonical syntax:
+    <actor_id>: move [x,y] atk <target_id>    # move + attack (2 AP)
+    <actor_id>: atk <target_id>               # attack only (1 AP)
+    <actor_id>: move [x,y]                    # move only (N AP, Manhattan)
+    <actor_id>: ability <ability_id> target=<target_id>
+    <actor_id>: skip                          # 0 AP
+
+Commands REPL:
+    end      → commit round (send batch + AI turn)
+    state    → show current state
+    clear    → clear pending intents
+    help     → show syntax
+    quit     → exit
+
+Usage:
+    python3 tools/py/master_dm.py [--scenario enc_tutorial_01] [--host http://localhost:3334]
+"""
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+
+
+SYNTAX_HELP = """\
+CANONICAL MOSSE:
+  actor_id: move [x,y] atk target_id        # move + attack (2 AP)
+  actor_id: atk target_id                   # attack (1 AP)
+  actor_id: move [x,y]                      # move N cell = N AP
+  actor_id: ability id target=target_id     # ability with target
+  actor_id: ability id                      # ability self/no-target
+  actor_id: skip                            # 0 AP
+
+COMANDI:
+  end         commit round (batch + AI turn)
+  state       show units + AP + HP
+  intents     list pending intents
+  clear       reset pending intents
+  help        show syntax
+  quit        exit
+"""
+
+
+def http_post(url, body):
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        try:
+            body = json.loads(e.read().decode("utf-8"))
+        except Exception:
+            body = {"error": str(e)}
+        return e.code, body
+
+
+def http_get(url):
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            return resp.status, json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        return e.code, {"error": str(e)}
+
+
+MOVE_ATK_RE = re.compile(
+    r"^(?P<actor>\S+):\s*move\s*\[(?P<x>-?\d+),\s*(?P<y>-?\d+)\]\s*atk\s+(?P<target>\S+)\s*$"
+)
+ATK_RE = re.compile(r"^(?P<actor>\S+):\s*atk\s+(?P<target>\S+)\s*$")
+MOVE_RE = re.compile(r"^(?P<actor>\S+):\s*move\s*\[(?P<x>-?\d+),\s*(?P<y>-?\d+)\]\s*$")
+ABILITY_RE = re.compile(
+    r"^(?P<actor>\S+):\s*ability\s+(?P<ability>\S+)(?:\s+target=(?P<target>\S+))?"
+    r"(?:\s+pos=\[(?P<x>-?\d+),\s*(?P<y>-?\d+)\])?\s*$"
+)
+SKIP_RE = re.compile(r"^(?P<actor>\S+):\s*skip\s*$")
+
+
+def parse_line(line):
+    """Parse canonical syntax line → list of intents (can be 1-2 for move+atk)."""
+    line = line.strip()
+    if not line:
+        return []
+
+    m = MOVE_ATK_RE.match(line)
+    if m:
+        actor = m.group("actor")
+        return [
+            {
+                "actor_id": actor,
+                "action": {
+                    "type": "move",
+                    "position": {"x": int(m.group("x")), "y": int(m.group("y"))},
+                },
+            },
+            {
+                "actor_id": actor,
+                "action": {"type": "attack", "target_id": m.group("target")},
+            },
+        ]
+
+    m = ATK_RE.match(line)
+    if m:
+        return [
+            {
+                "actor_id": m.group("actor"),
+                "action": {"type": "attack", "target_id": m.group("target")},
+            }
+        ]
+
+    m = MOVE_RE.match(line)
+    if m:
+        return [
+            {
+                "actor_id": m.group("actor"),
+                "action": {
+                    "type": "move",
+                    "position": {"x": int(m.group("x")), "y": int(m.group("y"))},
+                },
+            }
+        ]
+
+    m = ABILITY_RE.match(line)
+    if m:
+        action = {"type": "ability", "ability_id": m.group("ability")}
+        if m.group("target"):
+            action["target_id"] = m.group("target")
+        if m.group("x") is not None and m.group("y") is not None:
+            action["position"] = {"x": int(m.group("x")), "y": int(m.group("y"))}
+        return [{"actor_id": m.group("actor"), "action": action}]
+
+    m = SKIP_RE.match(line)
+    if m:
+        return [{"actor_id": m.group("actor"), "action": {"type": "skip"}}]
+
+    raise ValueError(f"syntax non canonica: '{line}' — usa 'help' per syntax")
+
+
+def fmt_unit(u):
+    status_bits = []
+    if u.get("status"):
+        for k, v in u["status"].items():
+            if isinstance(v, (int, float)) and v > 0:
+                status_bits.append(f"{k}:{v}")
+    pos = u.get("position", {})
+    return (
+        f"  {u.get('id','?'):<12} {u.get('controlled_by','?'):<8} "
+        f"hp:{u.get('hp',0):>3} ap:{u.get('ap_remaining', u.get('ap', 0)):>2} "
+        f"[{pos.get('x','?')},{pos.get('y','?')}] "
+        f"{('/'.join(status_bits)) if status_bits else ''}"
+    )
+
+
+def print_state(state):
+    print(f"\n=== Round {state.get('turn', '?')} ===")
+    for u in state.get("units", []):
+        if u.get("hp", 0) > 0:
+            print(fmt_unit(u))
+    dead = [u for u in state.get("units", []) if u.get("hp", 0) <= 0]
+    if dead:
+        print("  KO:", ", ".join(u.get("id", "?") for u in dead))
+    print()
+
+
+def print_batch_result(resp):
+    print(f"\n--- Round {resp.get('round', '?')} resolved ---")
+    for r in resp.get("results", []):
+        if r.get("skipped"):
+            print(f"  SKIP {r.get('actor_id')}: {r['skipped']}")
+        elif r.get("action_type") == "attack":
+            res = r.get("result", {})
+            print(
+                f"  ATK  {r.get('actor_id')}: {res.get('result','?')} "
+                f"(roll={res.get('roll','?')} mos={res.get('mos','?')} dmg={res.get('damage_dealt',0)})"
+            )
+        elif r.get("action_type") == "move":
+            res = r.get("result", {})
+            print(f"  MOVE {r.get('actor_id')}: → {res.get('position_to',{})}")
+            if res.get("overwatch"):
+                ow = res["overwatch"]
+                print(
+                    f"       OVERWATCH {ow.get('overwatch_id')} fires "
+                    f"(dmg={ow.get('damage_dealt',0)})"
+                )
+        elif r.get("action_type") == "ability":
+            res = r.get("result", {})
+            print(
+                f"  ABIL {r.get('actor_id')}: {res.get('ability_id','?')} "
+                f"({res.get('effect_type','?')})"
+            )
+        elif r.get("action_type") == "skip":
+            print(f"  SKIP {r.get('actor_id')}")
+    if resp.get("ai_result"):
+        ai = resp["ai_result"]
+        for a in ai.get("ia_actions", []):
+            if a.get("type") == "attack":
+                print(
+                    f"  SIS  {a.get('unit_id')}: atk {a.get('target')} "
+                    f"({a.get('result','?')} dmg={a.get('damage_dealt',0)})"
+                )
+            elif a.get("type") == "move":
+                print(f"  SIS  {a.get('unit_id')}: → {a.get('position_to','?')}")
+            elif a.get("type") == "skip":
+                print(f"  SIS  {a.get('unit_id')}: skip ({a.get('reason','')})")
+
+
+def detect_outcome(state):
+    units = state.get("units", [])
+    players_alive = [u for u in units if u.get("controlled_by") == "player" and u.get("hp", 0) > 0]
+    enemies_alive = [u for u in units if u.get("controlled_by") == "sistema" and u.get("hp", 0) > 0]
+    if not players_alive:
+        return "defeat"
+    if not enemies_alive:
+        return "victory"
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Master DM CLI — playtest assistant")
+    parser.add_argument("--host", default="http://localhost:3334", help="API host (default 3334)")
+    parser.add_argument("--scenario", default="enc_tutorial_01", help="tutorial scenario id")
+    args = parser.parse_args()
+
+    host = args.host.rstrip("/")
+
+    # Fetch scenario
+    status, scenario = http_get(f"{host}/api/tutorial/{args.scenario}")
+    if status != 200:
+        print(f"ERROR fetching scenario: {scenario}", file=sys.stderr)
+        return 1
+    print(f"Scenario: {scenario.get('name', args.scenario)} (diff {scenario.get('difficulty_rating','?')}/5)")
+
+    # Start session
+    status, start = http_post(f"{host}/api/session/start", {"units": scenario["units"]})
+    if status != 200:
+        print(f"ERROR starting session: {start}", file=sys.stderr)
+        return 1
+    session_id = start["session_id"]
+    print(f"Session: {session_id[:8]}...")
+    print_state(start["state"])
+
+    pending_intents = []
+    current_state = start["state"]
+
+    print("Type 'help' for syntax, 'end' to commit round, 'quit' to exit.\n")
+
+    while True:
+        try:
+            line = input("> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            break
+        if not line:
+            continue
+        if line == "quit" or line == "exit":
+            break
+        if line == "help":
+            print(SYNTAX_HELP)
+            continue
+        if line == "state":
+            status, st = http_get(f"{host}/api/session/state?session_id={session_id}")
+            if status == 200:
+                current_state = st
+                print_state(st)
+            else:
+                print(f"ERROR: {st}")
+            continue
+        if line == "intents":
+            if not pending_intents:
+                print("  (no pending intents)")
+            else:
+                for idx, it in enumerate(pending_intents):
+                    print(f"  [{idx}] {it['actor_id']}: {json.dumps(it['action'])}")
+            continue
+        if line == "clear":
+            pending_intents = []
+            print("intents cleared.")
+            continue
+        if line == "end":
+            # Commit round
+            status, resp = http_post(
+                f"{host}/api/session/round/execute",
+                {
+                    "session_id": session_id,
+                    "player_intents": pending_intents,
+                    "ai_auto": True,
+                },
+            )
+            if status != 200:
+                print(f"ERROR round/execute: {resp}", file=sys.stderr)
+                continue
+            print_batch_result(resp)
+            current_state = resp.get("state", current_state)
+            print_state(current_state)
+            pending_intents = []
+            outcome = detect_outcome(current_state)
+            if outcome:
+                print(f"\n=== MATCH OUTCOME: {outcome.upper()} ===")
+                break
+            continue
+
+        # Try parse as intent
+        try:
+            new_intents = parse_line(line)
+            pending_intents.extend(new_intents)
+            for it in new_intents:
+                print(f"  + {it['actor_id']}: {json.dumps(it['action'])}")
+        except ValueError as e:
+            print(f"PARSE ERROR: {e}")
+
+    # End session
+    http_post(f"{host}/api/session/end", {"session_id": session_id})
+    print("Session closed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

**Fase 3 di 3** SoT alignment — CLI playtest assistant che traduce mosse canoniche ([11-REGOLE_D20_TV.md](docs/core/11-REGOLE_D20_TV.md) §Syntax) in batch `POST /round/execute`.

Completa il piano:
- Fase 1: [PR #1510](https://github.com/MasterDD-L34D/Game/pull/1510) `/round/execute` endpoint
- Fase 2: [PR #1511](https://github.com/MasterDD-L34D/Game/pull/1511) tutorial AP alignment  
- **Fase 3** (questo PR): CLI tool

## `tools/py/master_dm.py`

REPL che accetta:

```
p_scout: move [3,2] atk e_nomad_1        # combo 2 AP
p_tank: atk e_hunter                      # 1 AP
p_scout: move [4,2]                       # N AP Manhattan
p_scout: ability dash_strike target=e_nomad_1 pos=[2,2]
p_tank: ability fortify                   # self-target
p_tank: skip                              # 0 AP
```

Commands:
- `end` — commit round (batch + AI turn via `/round/execute`)
- `state` — show units + HP + AP + status
- `intents` — list pending intents
- `clear` — reset pending
- `help` — syntax reference
- `quit` — exit

## Flow

1. Fetch `/api/tutorial/<scenario_id>` → scenario data
2. `POST /api/session/start` → session_id
3. Print state
4. REPL loop: Master enters canonical syntax → accumula intents → `end` → batch `/round/execute` → print results + new state
5. Victory/defeat detection → exit

## Dependencies

Stdlib only (`urllib`, `re`, `argparse`, `json`). No pip install. Compatible Python 3.8+.

## Test plan

- [x] `python3 tests/test_master_dm_parser.py` — **10/10 verdi** (unittest, no pytest dep)
  - combo move+atk
  - atk only
  - move only
  - ability with/without target + pos
  - skip
  - empty line
  - invalid syntax → ValueError
  - negative coords
- [x] Manual smoke: CLI si avvia, parser rifiuta "vai a nord", syntax canonica passa
- [ ] CI (Python tests)

## Usage

```bash
# Default: tutorial 01 via localhost:3334
python3 tools/py/master_dm.py

# Custom scenario + host
python3 tools/py/master_dm.py --scenario enc_tutorial_03 --host http://localhost:3334
```

## Doc update

`docs/core/11-REGOLE_D20_TV.md` aggiornato:
- Sezione "Batch execution: POST /api/session/round/execute" con esempio body
- Enforcement note: `ap_max` dinamico (tutorial 01 eccezione, 02-05 canonical)
- Cross-ref a `master_dm.py` come CLI assistant

## Rollback

Revert singolo commit. File aggiunti isolati:
- `tools/py/master_dm.py` (nuovo)
- `tests/test_master_dm_parser.py` (nuovo)
- `docs/core/11-REGOLE_D20_TV.md` (sezione additiva + 1 nota)

Nessuna modifica a codice engine/API — pure tool layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)