### PR TITLE
fix(session): squadCombo flake — combo metadata esposta su hit damage=0

### DIFF
--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -169,19 +169,24 @@ function createRoundBridge(deps) {
         capturedResults.intercept = res.intercept || null;
         // Pilastro 5: focus_fire combo. Se altri player hanno gia' colpito lo
         // stesso target in questo round, +1 dmg al secondo/terzo attacco.
+        // Fix flake (iter6): combo metadata esposta anche su hit con damage=0
+        // (parry completo, cap damage). Bonus_applied=0 ma is_combo=true.
         const comboInfo = detectFocusFireCombo(session, actor, target);
-        if (res.result && res.result.hit && comboInfo.is_combo && res.damageDealt > 0) {
-          const extra = comboInfo.bonus_damage;
-          const hpNow = Number(target.hp || 0);
-          const applied = Math.min(extra, hpNow);
-          if (applied > 0) {
-            target.hp = hpNow - applied;
-            capturedResults.damageDealt = res.damageDealt + applied;
-            if (session.damage_taken) {
-              session.damage_taken[target.id] = (session.damage_taken[target.id] || 0) + applied;
-            }
-            if (target.hp <= 0 && !capturedResults.killOccurred) {
-              capturedResults.killOccurred = true;
+        if (res.result && res.result.hit && comboInfo.is_combo) {
+          let applied = 0;
+          if (res.damageDealt > 0) {
+            const extra = comboInfo.bonus_damage;
+            const hpNow = Number(target.hp || 0);
+            applied = Math.min(extra, hpNow);
+            if (applied > 0) {
+              target.hp = hpNow - applied;
+              capturedResults.damageDealt = res.damageDealt + applied;
+              if (session.damage_taken) {
+                session.damage_taken[target.id] = (session.damage_taken[target.id] || 0) + applied;
+              }
+              if (target.hp <= 0 && !capturedResults.killOccurred) {
+                capturedResults.killOccurred = true;
+              }
             }
           }
           capturedResults.combo = { ...comboInfo, bonus_applied: applied };


### PR DESCRIPTION
## Summary

Fix flake ~5-10% in `tests/api/squadCombo.test.js::due player stesso target stesso round`. Ha richiesto **admin override 3 PR** ([#1498](https://github.com/MasterDD-L34D/Game/pull/1498), [#1506](https://github.com/MasterDD-L34D/Game/pull/1506), [#1518](https://github.com/MasterDD-L34D/Game/pull/1518)).

## Root cause (N=50 diagnostic)

Quando r2 hit con `damage_dealt=0` (parry completo, damage step 0, HP cap), `capturedResults.combo` **NON** veniva settato in `handleLegacyAttackViaRound`. La condizione era:

```js
if (res.result && res.result.hit && comboInfo.is_combo && res.damageDealt > 0) {
  capturedResults.combo = { ...comboInfo, bonus_applied: applied };
}
```

Il `damageDealt > 0` troppo stretto. Tracker `session.last_round_combos` popolato correttamente da `recordAttackForCombo`, ma response body ometteva `combo` field.

**Samples raccolti** (debug script 50 iter):
- iter11: r1 miss dmg=0, r2 hit dmg=0 → combo=null (FAIL)
- iter21: r1 hit dmg=5, r2 hit dmg=0 (parry) → combo=null (FAIL)
- iter41: r1 hit dmg=1, r2 hit dmg=0 → combo=null (FAIL)

## Fix

`is_combo` check separato da `damage` check. Combo metadata esposta sempre su `hit + is_combo`. `bonus_applied=0` quando damage=0 (fact che combo fire'd rimane true, solo effetto nil).

Semantica invariata per consumer:
- `is_combo=true` → detected, `chain_index` incrementato
- `bonus_damage=+1` declared
- `bonus_applied=N` actual (0 se damage=0 o HP cap)

## Test plan

- [x] **50/50 verdi** squadCombo (prima ~5-10% flake)
- [x] Regression: `tests/ai/*.test.js` 197/197, abilityExecutor 34/34, apBudget 3/3, roundExecute 6/6, sessionLegacyActionWrapper 6/6 — tutti verdi
- [ ] CI stack-quality dovrebbe passare senza admin override

## Rollback

Revert singolo commit. Modifica isolata: 17 righe in `handleLegacyAttackViaRound`. Nessuna modifica a `detectFocusFireCombo` / `recordAttackForCombo` / tracker logic.

## Next

CI stack-quality ora non dovrebbe più richiedere admin override. Se regression, rollback + investigate deeper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)