### PR TITLE
feat(session): priority queue opt-in in /round/execute (canonical ADR-2026-04-15)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -1020,6 +1020,34 @@ function createSessionRouter(options = {}) {
     return 0;
   }
 
+  // Canonical priority (ADR-2026-04-15):
+  // priority = unit.initiative + action_speed - status_penalty
+  // action_speed: defend/parry +2, attack 0, ability -1, move -2
+  // status_penalty: panic 2×intensity, disorient 1×intensity
+  const ACTION_SPEED_TABLE = {
+    defend: 2,
+    parry: 2,
+    attack: 0,
+    ability: -1,
+    heal: -1,
+    move: -2,
+    turn: 0,
+    skip: 0,
+  };
+
+  function computeIntentPriority(actor, action) {
+    const base = Number(actor?.initiative || 0);
+    const speed =
+      typeof ACTION_SPEED_TABLE[action?.type] === 'number' ? ACTION_SPEED_TABLE[action.type] : 0;
+    let penalty = 0;
+    if (actor?.status) {
+      const panic = Number(actor.status.panic) || 0;
+      const disorient = Number(actor.status.disorient) || 0;
+      penalty = panic * 2 + disorient;
+    }
+    return base + speed - penalty;
+  }
+
   router.post('/round/execute', async (req, res, next) => {
     try {
       const body = req.body || {};
@@ -1028,6 +1056,7 @@ function createSessionRouter(options = {}) {
 
       const playerIntents = Array.isArray(body.player_intents) ? body.player_intents : [];
       const aiAuto = body.ai_auto !== false;
+      const usePriorityQueue = body.priority_queue === true;
 
       // Validazione intent + AP cumulativo per actor.
       const apByUnit = {};
@@ -1073,10 +1102,61 @@ function createSessionRouter(options = {}) {
         });
       }
 
-      // Dispatch sequenziale intent player.
+      // Canonical priority queue (opt-in via priority_queue: true):
+      // - Mescola player intents + AI intents (se ai_auto) in una sola coda
+      // - Calcola priority per ogni intent (initiative + action_speed - penalty)
+      // - Sort stable: priority desc, originalIdx asc (preserva ordine per-actor)
+      // - Dispatch in priority order
+      // - End-of-round ticks via handleTurnEndViaRound(ai_auto=false path impossibile,
+      //   fallback: skip AI declare by emptying sistema_pending_intents)
+      let dispatchQueue = normalized.map((n) => ({
+        actor: n.actor,
+        raw: n.raw,
+        source: 'player',
+        priority: computeIntentPriority(n.actor, n.raw.action),
+        originalIdx: n.index,
+      }));
+
+      if (usePriorityQueue && aiAuto) {
+        try {
+          const { intents: aiIntents } = declareSistemaIntents(session);
+          for (let i = 0; i < aiIntents.length; i += 1) {
+            const aiIntent = aiIntents[i];
+            const actor = session.units.find((u) => u.id === aiIntent.unit_id);
+            if (!actor) continue;
+            const actionType = aiIntent.action?.type || 'skip';
+            const action =
+              actionType === 'move' && aiIntent.action.move_to
+                ? { type: 'move', position: aiIntent.action.move_to }
+                : actionType === 'attack'
+                  ? { type: 'attack', target_id: aiIntent.action.target_id }
+                  : { type: actionType };
+            dispatchQueue.push({
+              actor,
+              raw: { actor_id: actor.id, action },
+              source: 'ai',
+              priority: computeIntentPriority(actor, action),
+              originalIdx: 10000 + i,
+            });
+          }
+        } catch (_aiErr) {
+          // AI intent generation failed — continue with player only
+        }
+      }
+
+      if (usePriorityQueue) {
+        dispatchQueue.sort((a, b) => {
+          if (b.priority !== a.priority) return b.priority - a.priority;
+          if (a.actor.id !== b.actor.id)
+            return String(a.actor.id).localeCompare(String(b.actor.id));
+          return a.originalIdx - b.originalIdx;
+        });
+      }
+
+      // Dispatch in declared/priority order.
       const results = [];
       const eventsCountBefore = session.events.length;
-      for (const { actor, raw } of normalized) {
+      for (const { actor, raw } of dispatchQueue) {
         if (Number(actor.hp) <= 0) {
           results.push({ actor_id: actor.id, skipped: 'actor_dead_mid_round' });
           continue;
@@ -1213,9 +1293,50 @@ function createSessionRouter(options = {}) {
 
       // AI auto-declare: usa handleTurnEndViaRound (bleeding + hazard +
       // status decay + AI intents + commit + resolve).
+      // Con priority_queue=true, AI intents sono già dispatched nel queue,
+      // quindi saltiamo handleTurnEndViaRound (no double-dispatch).
       let aiResult = null;
-      if (aiAuto) {
+      if (aiAuto && !usePriorityQueue) {
         aiResult = await handleTurnEndViaRound(session);
+      } else if (usePriorityQueue) {
+        // End-of-round ticks minimali: bleeding + status decay + AP reset + turn++.
+        // NO AI declare (già fatto via priority queue).
+        for (const unit of session.units) {
+          if (!unit || Number(unit.hp) <= 0) continue;
+          // Bleeding tick
+          const bleedTurns = Number(unit.status?.bleeding) || 0;
+          if (bleedTurns > 0) {
+            unit.hp = Math.max(0, Number(unit.hp) - 1);
+            if (session.damage_taken) {
+              session.damage_taken[unit.id] = (session.damage_taken[unit.id] || 0) + 1;
+            }
+          }
+          // AP reset
+          const fractureActive = Number(unit.status?.fracture) > 0;
+          unit.ap_remaining = fractureActive ? Math.min(1, unit.ap) : unit.ap;
+          // Status decay + bonus clear
+          if (unit.status) {
+            for (const key of Object.keys(unit.status)) {
+              const v = Number(unit.status[key]);
+              if (v > 0) unit.status[key] = v - 1;
+            }
+            for (const key of Object.keys(unit.status)) {
+              if (!key.endsWith('_buff') && !key.endsWith('_debuff')) continue;
+              if (Number(unit.status[key]) > 0) continue;
+              const stat = key.replace(/_buff$|_debuff$/, '');
+              const bonusKey = `${stat}_bonus`;
+              if (unit[bonusKey] !== undefined) unit[bonusKey] = 0;
+            }
+            if (
+              unit.status.shield_buff !== undefined &&
+              Number(unit.status.shield_buff) <= 0 &&
+              unit.shield_hp
+            ) {
+              unit.shield_hp = 0;
+            }
+          }
+        }
+        session.turn += 1;
       }
 
       const eventsEmitted = session.events.slice(eventsCountBefore);
@@ -1224,6 +1345,7 @@ function createSessionRouter(options = {}) {
         round: session.turn,
         results,
         ai_result: aiResult,
+        priority_queue_used: usePriorityQueue,
         events_emitted_count: eventsEmitted.length,
         events: eventsEmitted,
         ap_consumed: apByUnit,

--- a/docs/core/11-REGOLE_D20_TV.md
+++ b/docs/core/11-REGOLE_D20_TV.md
@@ -58,7 +58,7 @@ Regole canoniche per turno, AP budget, syntax input. Chiude FRICTION #1-#3 dal p
 
 ### Batch execution: `POST /api/session/round/execute`
 
-Endpoint canonical per eseguire un round completo in una singola request. Accetta tutti gli intents player + opzionale AI auto-declare + risolve sequenzialmente.
+Endpoint canonical per eseguire un round completo in una singola request.
 
 **Body**:
 
@@ -69,13 +69,27 @@ Endpoint canonical per eseguire un round completo in una singola request. Accett
     { "actor_id": "p_scout", "action": { "type": "attack", "target_id": "e_nomad_1" } },
     { "actor_id": "p_tank", "action": { "type": "move", "position": { "x": 2, "y": 3 } } }
   ],
-  "ai_auto": true
+  "ai_auto": true,
+  "priority_queue": false
 }
 ```
 
 **Validazione cumulativa**: `Σ ap_cost ≤ ap_remaining` per ogni actor. Violations → 400 con lista dettagliata.
 
-**Response**: aggregato di `results[]` (per intent), `ai_result` (se ai_auto), `events[]`, `ap_consumed`, `state`.
+**Response**: aggregato di `results[]` (per intent), `ai_result` (se `ai_auto` + `priority_queue=false`), `events[]`, `ap_consumed`, `state`, `priority_queue_used`.
+
+**Priority queue** (opt-in, canonical ADR-2026-04-15): quando `priority_queue: true`, tutti gli intents (player + AI se `ai_auto`) vengono ordinati per:
+
+```
+priority = unit.initiative + action_speed - status_penalty
+```
+
+- `action_speed`: defend/parry **+2**, attack **0**, ability/heal **-1**, move **-2**, turn/skip **0**
+- `status_penalty`: panic **2×intensity**, disorient **1×intensity**
+
+Tiebreak: priority desc, actor_id alfabetico asc, declaration order asc. Con `priority_queue=true`, `ai_result=null` (AI intents dispatched inline) + end-of-round ticks (bleeding, status decay, AP reset) applicati inline.
+
+**Modalità default** (`priority_queue=false`): dispatch in declaration order + `ai_auto` esegue `handleTurnEndViaRound` dopo (legacy behavior, compat).
 
 **CLI assistant**: [`tools/py/master_dm.py`](../../tools/py/master_dm.py) — REPL canonical syntax → batch endpoint.
 

--- a/tests/api/roundExecutePriorityQueue.test.js
+++ b/tests/api/roundExecutePriorityQueue.test.js
@@ -1,0 +1,229 @@
+// tests/api/roundExecutePriorityQueue.test.js
+//
+// Verifica priority_queue flag in /api/session/round/execute (ADR-2026-04-15).
+// priority = initiative + action_speed - status_penalty
+// action_speed: defend/parry +2, attack 0, ability -1, move -2
+// status_penalty: panic 2×intensity, disorient 1×intensity
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+function threeUnits() {
+  return [
+    // p_fast: initiative alta + attack (priority = 15 + 0 = 15)
+    {
+      id: 'p_fast',
+      species: 'velox',
+      job: 'skirmisher',
+      hp: 10,
+      max_hp: 10,
+      ap: 2,
+      attack_range: 3,
+      initiative: 15,
+      position: { x: 1, y: 2 },
+      controlled_by: 'player',
+      status: {},
+    },
+    // p_slow: initiative bassa + move (priority = 5 - 2 = 3)
+    {
+      id: 'p_slow',
+      species: 'carapax',
+      job: 'vanguard',
+      hp: 10,
+      max_hp: 10,
+      ap: 2,
+      attack_range: 1,
+      initiative: 5,
+      position: { x: 2, y: 1 },
+      controlled_by: 'player',
+      status: {},
+    },
+    // enemy: target passivo
+    {
+      id: 'sis',
+      species: 'carapax',
+      job: 'vanguard',
+      hp: 50,
+      max_hp: 50,
+      ap: 2,
+      attack_range: 1,
+      initiative: 3,
+      position: { x: 3, y: 3 },
+      controlled_by: 'sistema',
+      status: {},
+    },
+  ];
+}
+
+async function startSession(app, units) {
+  const res = await request(app).post('/api/session/start').send({ units });
+  assert.equal(res.status, 200);
+  return res.body.session_id;
+}
+
+test('priority_queue=false (default): player_intents dispatched in declaration order', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const sid = await startSession(app, threeUnits());
+  // Declare p_slow move PRIMA di p_fast attack (ordine inverso a priority).
+  const res = await request(app)
+    .post('/api/session/round/execute')
+    .send({
+      session_id: sid,
+      player_intents: [
+        { actor_id: 'p_slow', action: { type: 'move', position: { x: 2, y: 2 } } },
+        { actor_id: 'p_fast', action: { type: 'attack', target_id: 'sis' } },
+      ],
+      ai_auto: false,
+    });
+  assert.equal(res.status, 200);
+  // Default (no priority queue): esegui p_slow prima (come in body)
+  assert.equal(res.body.results[0].actor_id, 'p_slow');
+  assert.equal(res.body.results[0].action_type, 'move');
+  assert.equal(res.body.results[1].actor_id, 'p_fast');
+  assert.equal(res.body.results[1].action_type, 'attack');
+  assert.equal(res.body.priority_queue_used, false);
+});
+
+test('priority_queue=true: sort desc per priority (p_fast attack > p_slow move)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const sid = await startSession(app, threeUnits());
+  // p_fast attack: priority = 15 + 0 = 15
+  // p_slow move:   priority = 5 + (-2) = 3
+  // Dichiarati in ordine inverso a priority → queue sorta
+  const res = await request(app)
+    .post('/api/session/round/execute')
+    .send({
+      session_id: sid,
+      player_intents: [
+        { actor_id: 'p_slow', action: { type: 'move', position: { x: 2, y: 2 } } },
+        { actor_id: 'p_fast', action: { type: 'attack', target_id: 'sis' } },
+      ],
+      ai_auto: false,
+      priority_queue: true,
+    });
+  assert.equal(res.status, 200);
+  // priority_queue sorts: p_fast (priority 15) PRIMA di p_slow (priority 3)
+  assert.equal(res.body.results[0].actor_id, 'p_fast', 'p_fast dispatch per prima');
+  assert.equal(res.body.results[0].action_type, 'attack');
+  assert.equal(res.body.results[1].actor_id, 'p_slow');
+  assert.equal(res.body.results[1].action_type, 'move');
+  assert.equal(res.body.priority_queue_used, true);
+});
+
+test('priority_queue=true: status_penalty (panic) riduce priority', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const units = threeUnits();
+  // Dai p_fast panic intensity 3 → penalty = 6
+  // Priority nuovo: 15 + 0 - 6 = 9 (ancora > p_slow 3, ma ridotto)
+  units[0].status = { panic: 3 };
+  const sid = await startSession(app, units);
+
+  const res = await request(app)
+    .post('/api/session/round/execute')
+    .send({
+      session_id: sid,
+      player_intents: [
+        { actor_id: 'p_fast', action: { type: 'attack', target_id: 'sis' } },
+        { actor_id: 'p_slow', action: { type: 'attack', target_id: 'sis' } },
+      ],
+      ai_auto: false,
+      priority_queue: true,
+    });
+  assert.equal(res.status, 200);
+  // p_fast ancora prima (9 > 5), ma panic penalty lo rallenta relativamente.
+  // Con p_slow attack (priority 5) vs p_fast panicked (9): p_fast vince comunque.
+  assert.equal(res.body.results[0].actor_id, 'p_fast');
+});
+
+test('priority_queue=true: tiebreak stabile per-actor (2 attack stesso actor)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const sid = await startSession(app, threeUnits());
+  // 2 attack di p_fast stesso actor, stessa priority → mantieni ordine dichiarazione
+  const res = await request(app)
+    .post('/api/session/round/execute')
+    .send({
+      session_id: sid,
+      player_intents: [
+        { actor_id: 'p_fast', action: { type: 'attack', target_id: 'sis' } },
+        { actor_id: 'p_fast', action: { type: 'attack', target_id: 'sis' } },
+      ],
+      ai_auto: false,
+      priority_queue: true,
+    });
+  assert.equal(res.status, 200);
+  // 2 attack dello stesso actor preservati in ordine originale.
+  assert.equal(res.body.results.length, 2);
+  assert.equal(res.body.results[0].actor_id, 'p_fast');
+  assert.equal(res.body.results[1].actor_id, 'p_fast');
+});
+
+test('priority_queue=true + ai_auto=true: AI intents mescolati via priority', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const sid = await startSession(app, threeUnits());
+  const res = await request(app)
+    .post('/api/session/round/execute')
+    .send({
+      session_id: sid,
+      player_intents: [{ actor_id: 'p_slow', action: { type: 'move', position: { x: 2, y: 2 } } }],
+      ai_auto: true,
+      priority_queue: true,
+    });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.priority_queue_used, true);
+  // ai_result è null (AI gestito nel queue, non via handleTurnEndViaRound)
+  assert.equal(res.body.ai_result, null);
+  // results dovrebbe contenere player + AI intents mescolati
+  assert.ok(res.body.results.length >= 1);
+});
+
+test('priority_queue: end-of-round ticks (bleeding decay) applicati', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const units = threeUnits();
+  units[0].status = { bleeding: 2 };
+  const initialHp = units[0].hp;
+  const sid = await startSession(app, units);
+
+  const res = await request(app).post('/api/session/round/execute').send({
+    session_id: sid,
+    player_intents: [],
+    ai_auto: true,
+    priority_queue: true,
+  });
+  assert.equal(res.status, 200);
+
+  // Verifica bleeding tick: hp -1 e status.bleeding decremented
+  const stateRes = await request(app).get('/api/session/state').query({ session_id: sid });
+  const pFast = stateRes.body.units.find((u) => u.id === 'p_fast');
+  assert.equal(pFast.hp, initialHp - 1, 'bleeding 1 dmg applicato');
+  assert.equal(Number(pFast.status.bleeding), 1, 'bleeding decay 2→1');
+});


### PR DESCRIPTION
## Summary

`POST /api/session/round/execute` accetta nuovo flag `priority_queue` opt-in che attiva canonical priority ordering ([ADR-2026-04-15](docs/adr/ADR-2026-04-15-round-based-combat-model.md)).

**Modalità**:
- `priority_queue: false` (default) — dispatch in declaration order + `ai_auto` via `handleTurnEndViaRound` (retrocompat)
- `priority_queue: true` — player + AI intents mescolati in unica coda sorta per priority

## Formula canonical

```
priority = unit.initiative + action_speed - status_penalty
```

**ACTION_SPEED** table (ADR-2026-04-15):
- `defend/parry` **+2**
- `attack` **0**
- `ability/heal` **-1**
- `move` **-2**
- `turn/skip` **0**

**Status penalty**:
- `panic` **2×intensity**
- `disorient` **1×intensity**

**Tiebreak**: priority desc → actor_id alfabetico asc → declaration order asc.

## Flow priority_queue=true

1. Valida player intents + AP budget cumulativo (come default)
2. Se `ai_auto`: genera AI intents via `declareSistemaIntents` (pure, no dispatch)
3. Mescola player + AI intents in singola coda
4. Calcola `priority` per ogni intent
5. **Stable sort** priority desc (tiebreak: actor_id asc, originalIdx asc)
6. Dispatch in priority order tramite stessi handler (attack/move/ability)
7. End-of-round ticks **inline**: bleeding tick + AP reset + status decay + bonus/shield clear
8. `turn++` inline
9. `ai_result: null` + `priority_queue_used: true`

## Test plan

- [x] `tests/api/roundExecutePriorityQueue.test.js` — **6/6 verdi**
  - default (false) preserva declaration order
  - priority sort desc (p_fast attack 15 > p_slow move 3)
  - status_penalty panic riduce priority (-2×intensity)
  - tiebreak stabile per-actor (2 attack stesso actor mantengono ordine)
  - ai_auto + priority_queue mescola AI nel queue (ai_result=null)
  - end-of-round ticks: bleeding decay applicato
- [x] Regression: roundExecute 6/6, ai 161/161, abilityExecutor 34/34, apBudget, squadCombo tutti verdi

## Doc

`docs/core/11-REGOLE_D20_TV.md` §"Batch execution" aggiornata con:
- Formula priority + tabelle action_speed/status_penalty
- Differenza comportamentale priority_queue=true vs false
- Tiebreak deterministico documentato

## Rollback

Revert singolo commit. Modifiche isolate:
- `apps/backend/routes/session.js`: +60 righe (priority helpers + queue flag branch)
- `tests/api/roundExecutePriorityQueue.test.js`: nuovo, 6 test
- `docs/core/11-REGOLE_D20_TV.md`: +15 righe doc

**Breaking**: nessun. Default `priority_queue=false` preserva comportamento pre-existing.

## Segue

- Migrazione `roundExecuteScenarioHarness.test.js` a `priority_queue: true` per proof canonical end-to-end su scenario (follow-up)
- Integrazione `priority_queue: true` come default in `master_dm.py` CLI (follow-up quando human-validato)

🤖 Generated with [Claude Code](https://claude.com/claude-code)