### PR TITLE
feat(cli,test): priority_queue=true default in master_dm.py + scenario harness

### DIFF
--- a/tests/api/roundExecuteScenarioHarness.test.js
+++ b/tests/api/roundExecuteScenarioHarness.test.js
@@ -81,11 +81,14 @@ async function runOneBatch(app) {
       }
     }
 
-    // Batch round/execute con ai_auto=true
+    // Batch round/execute con ai_auto=true + priority_queue=true (canonical).
+    // Canonical flow ordina player + AI intents per priority e dispatcha in
+    // ordine di initiative + action_speed - status_penalty.
     const batchRes = await request(app).post('/api/session/round/execute').send({
       session_id: sid,
       player_intents: intents,
       ai_auto: true,
+      priority_queue: true,
     });
     stats.batch_requests += 1;
 
@@ -100,20 +103,28 @@ async function runOneBatch(app) {
       `round ${r} batch: ${JSON.stringify(batchRes.body).slice(0, 200)}`,
     );
 
-    // Conta hit/miss/damage dai results
+    // Conta hit/miss/damage dai results. Con priority_queue=true, results[]
+    // include player + AI intents mescolati. Distingui via controlled_by
+    // dallo state corrente (alivePlayers lookup set).
+    const playerIds = new Set(alivePlayers.map((u) => u.id));
     for (const result of batchRes.body.results || []) {
       if (result.action_type === 'attack' && result.result) {
         const r = result.result;
+        const isPlayer = playerIds.has(result.actor_id);
         if (r.result === 'hit') {
-          stats.player_hits += 1;
-          stats.player_damage += Number(r.damage_dealt || 0);
-        } else if (r.result === 'miss') {
+          if (isPlayer) {
+            stats.player_hits += 1;
+            stats.player_damage += Number(r.damage_dealt || 0);
+          } else {
+            stats.enemy_damage += Number(r.damage_dealt || 0);
+          }
+        } else if (r.result === 'miss' && isPlayer) {
           stats.player_misses += 1;
         }
       }
     }
 
-    // AI damage da ai_result
+    // ai_result è null con priority_queue=true (AI nel queue, non handleTurnEndViaRound).
     const ai = batchRes.body.ai_result;
     if (ai && Array.isArray(ai.ia_actions)) {
       for (const ia of ai.ia_actions) {

--- a/tools/py/master_dm.py
+++ b/tools/py/master_dm.py
@@ -287,13 +287,15 @@ def main():
             print("intents cleared.")
             continue
         if line == "end":
-            # Commit round
+            # Commit round (canonical: priority_queue=true ordina player+AI
+            # intents per initiative + action_speed - status_penalty).
             status, resp = http_post(
                 f"{host}/api/session/round/execute",
                 {
                     "session_id": session_id,
                     "player_intents": pending_intents,
                     "ai_auto": True,
+                    "priority_queue": True,
                 },
             )
             if status != 200:


### PR DESCRIPTION
## Summary

Migra **CLI `master_dm.py`** + **scenario harness `roundExecuteScenarioHarness.test.js`** a `priority_queue: true` come default per canonical flow ([ADR-2026-04-15](docs/adr/ADR-2026-04-15-round-based-combat-model.md), PR #1525 endpoint).

## Changes

### `tools/py/master_dm.py`

- POST `/round/execute` body ora include `priority_queue: true`
- Commento inline rinforza motivazione canonical
- `print_batch_result` invariato: AI intents ora appaiono in `results[]` mescolati via priority (actor_id = enemy unit id), stampati come normali attack/move

### `tests/api/roundExecuteScenarioHarness.test.js`

- `priority_queue: true` nel body batch
- Contatore damage distingue player vs AI via `playerIds Set` (ai_result=null con canonical, enemy damage arriva da `results[].actor_id` enemy)

## Risultato N=10 su `enc_tutorial_02` post-migrazione

```
╔═══ ROUND/EXECUTE HARNESS (N=10) ═══╗
║  Outcomes: Victories 10/10 (100%), Defeats 0, Timeouts 0
║  Avg rounds: 10.9
║  Hit rate: 63.0% (58/92)
║  Avg player dmg/run: 14.6
║  Avg enemy dmg/run:  3.0  ← prima 0.8 (AI ora attacca via priority mix)
║  AP violations: 0
╚════════════════════════════════════╝
```

**Win rate 100%** spiegato: `p_scout.initiative=15` >> `sis.initiative=3-5` → player attacca sempre prima via priority queue. Comportamento canonical rispettato.

Enemy damage salito 0.8 → 3.0 dopo priority mix — AI ora ha turni interleavati con player invece di essere bloccata in `handleTurnEndViaRound` sequenziale.

## Test plan

- [x] `python3 tests/test_master_dm_parser.py` — 10/10 verdi
- [x] `roundExecute` 6/6, `roundExecutePriorityQueue` 6/6, `roundExecuteScenarioHarness` 1/1, `abilityExecutor` 34/34 tutti verdi
- [ ] CI stack-quality

## Rollback

Revert singolo commit. Se human-playtest con canonical priority queue mostra 100% win troppo easy, opzioni:
- Rollback (CLI torna legacy)
- Tuning enemy initiative (alzare a 10+ per competere con player)
- Tuning player initiative (abbassare)

## Segue

- Human-driven playtest M3 con CLI canonical per validare subjective
- VC scoring analysis su N=30 canonical data (MBTI/Ennea distribution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)