### PR TITLE
play: co-op scaling 4→8 + party.yaml (ADR-2026-04-17)

### DIFF
--- a/data/core/party.yaml
+++ b/data/core/party.yaml
@@ -1,0 +1,89 @@
+# =============================================================================
+# Party configuration canonica — Evo-Tactics
+# ADR: docs/adr/ADR-2026-04-17-coop-scaling-4to8.md
+# Pilastro 5 (Co-op vs Sistema) esteso 4 → 8 player
+# Schema: schemas/evo/party.schema.json
+# =============================================================================
+
+version: 1
+updated: '2026-04-17'
+
+party:
+  # SoT §pilastro 5 originale: 4 giocatori coop.
+  # ADR-2026-04-17 estende a 8 per campagne party casual TV+companion.
+  max_players_coop: 8
+
+  # Creature schierate PG per encounter. Cap per mantenere grid leggibile.
+  max_deployed_per_encounter: 8
+
+  # Roster totale disponibile per campagna (schierabili + Nido reserve).
+  # 8 schierabili + 8 Nido reserve = 16 creature totali in rotazione.
+  max_roster_total: 16
+
+  # Grid scaling automatico basato su N schierati.
+  # Mantiene fill ratio < 25% per leggibilità tattica.
+  grid_scaling:
+    deployed_1_4: '6x6' # 36 celle, fill <= 22%
+    deployed_5_6: '8x8' # 64 celle, fill <= 19%
+    deployed_7_8: '10x10' # 100 celle, fill <= 16%
+
+  # Preset encounter standard.
+  defaults:
+    tutorial: 2 # onboarding gentle (tutorial_01)
+    standard: 4 # encounter base SoT-coerente
+    boss: 6 # boss encounter (PG +1 per challenge)
+    hardcore: 8 # full coop max
+
+  # Distribuzione PG per player count. Total PG schierati costante per modalità.
+  # Formula: sum(player.pg_controlled) == deployed_total
+  modulation:
+    solo:
+      description: '1 player controlla tutto il party'
+      pg_per_player: [4]
+      deployed: 4
+    duo:
+      description: '2 player, 2 PG ciascuno'
+      pg_per_player: [2, 2]
+      deployed: 4
+    duo_hardcore:
+      description: '2 player, 4 PG ciascuno'
+      pg_per_player: [4, 4]
+      deployed: 8
+    trio:
+      description: '3 player, distribuzione 2+1+1'
+      pg_per_player: [2, 1, 1]
+      deployed: 4
+    trio_mid:
+      description: '3 player, 2 PG ciascuno'
+      pg_per_player: [2, 2, 2]
+      deployed: 6
+    quartet:
+      description: '4 player × 1 PG (SoT canonico)'
+      pg_per_player: [1, 1, 1, 1]
+      deployed: 4
+    quartet_hardcore:
+      description: '4 player × 2 PG'
+      pg_per_player: [2, 2, 2, 2]
+      deployed: 8
+    quintet:
+      description: '5 player, 2+2+2+1+1 = 8'
+      pg_per_player: [2, 2, 2, 1, 1]
+      deployed: 8
+    sextet:
+      description: '6 player, 2+2+1+1+1+1 = 8'
+      pg_per_player: [2, 2, 1, 1, 1, 1]
+      deployed: 8
+    septet:
+      description: '7 player, 2+1+1+1+1+1+1 = 8'
+      pg_per_player: [2, 1, 1, 1, 1, 1, 1]
+      deployed: 8
+    full:
+      description: '8 player × 1 PG (max coop hardcore)'
+      pg_per_player: [1, 1, 1, 1, 1, 1, 1, 1]
+      deployed: 8
+
+# Invarianti design:
+# - sum(pg_per_player) == deployed (per ogni modulation)
+# - deployed <= max_deployed_per_encounter
+# - len(pg_per_player) <= max_players_coop
+# - grid_size ricavata automaticamente da deployed via grid_scaling

--- a/docs/adr/ADR-2026-04-17-coop-scaling-4to8.md
+++ b/docs/adr/ADR-2026-04-17-coop-scaling-4to8.md
@@ -1,0 +1,123 @@
+---
+title: 'ADR 2026-04-17 — Co-op scaling: 4 → 8 giocatori'
+doc_status: active
+doc_owner: master-dd
+workstream: cross-cutting
+last_verified: 2026-04-17
+source_of_truth: true
+language: it
+review_cycle_days: 30
+supersedes: ['SoT §pilastro 5 linea 930 (max 4 coop)']
+---
+
+# ADR-2026-04-17 · Co-op scaling 4 → 8 giocatori
+
+**Stato**: 🟢 ACCEPTED — Master DD 2026-04-17
+**Branch**: `play/party-scaling-4to8`
+
+## Contesto
+
+SoT v5 §pilastro 5 (linea 930) dichiarava: _"Co-op 4 giocatori vs Sistema è pilastro #5. Oggi il sistema gira single-machine only."_ Playtest umano #2 con Master ha sollevato richiesta di party più grandi per:
+
+- Sessioni casual "TV + amici numerosi" (4+ amici in salotto)
+- Maggiore varietà tattica (8 PG = 8 ruoli diversi coeggibili)
+- Mapping Ennea 9 tipi quasi 1:1 con 8 player
+
+Proposta raccolta 2026-04-17 (chat): estendere coop cap da 4 a 8.
+
+## Decisione
+
+**Estendere Pilastro 5 → "Co-op 1-8 giocatori vs Sistema"**.
+
+Implementazione:
+
+- `max_players_coop: 8` (era 4 implicito)
+- `max_deployed_per_encounter: 8` PG schierati max
+- `max_roster_total: 16` (8 schierabili + 8 Nido reserve)
+- Grid auto-scale: 6×6 fino 4 PG · 8×8 per 5-6 · 10×10 per 7-8
+- 8 modulation preset: solo / duo / duo_hardcore / trio / trio_mid / quartet (SoT canonico) / quartet_hardcore / quintet / sextet / septet / full
+
+## Alternative valutate
+
+### A. Mantenere 4 canonici
+
+- **Pro**: zero conflitto SoT, nessun ADR
+- **Contro**: limita casual coop party TV (4+ amici non giocano insieme)
+- **Verdetto**: rigetto — feedback playtest richiede espansione
+
+### B. Scaling dinamico 4-8 (scelto)
+
+- **Pro**: preserva 4 canonico (default), estende fino 8, modulation YAML data-driven
+- **Contro**: grid variabile (serve auto-scale logic), balance ricalibrare per 6-8 player
+- **Verdetto**: ACCEPTED
+
+### C. Full scaling 16+ giocatori
+
+- **Pro**: party mega-casual
+- **Contro**: grid 16×16+ tattica illeggibile, AP economy esplode, balance impossibile
+- **Verdetto**: rigetto — out of scope
+
+## Conseguenze
+
+### Positive
+
+- Pilastro 5 più flessibile: casual 4 + hardcore 8
+- Roster 16 totali sblocca meta-loop Nido reale (rotation + mating significant)
+- Mapping Ennea-roster naturale
+
+### Negative
+
+- Conflict risolto con SoT §pilastro 5 → doc update richiesto
+- Grid scaling = complessità engine (switch grid size per scenario)
+- Balance encounter 6-8 player: richiede playtest dedicato
+- Tutorial 01-05 restano 6×6 (no impatto immediato)
+
+### Neutral
+
+- Modulation preset coprono 1-8 player con distribuzione PG flessibile
+
+## Piano esecuzione
+
+### PR 1 (questa) — data + schema + ADR ✅
+
+- `data/core/party.yaml` con tutto config
+- `schemas/evo/party.schema.json` validation AJV
+- Questo ADR
+- Update SoT §pilastro 5 con ref ADR (follow-up commit)
+
+### PR 2 (follow-up) — engine integration
+
+- Grid scaling auto-derive da scenario `deployed_count`
+- Session start accetta `modulation` preset
+- `apps/backend/services/partyLoader.js` memoized config loader
+- Tests: coverage 8 modulation preset
+
+### PR 3 (follow-up) — UI lobby
+
+- Frontend browser: pre-game lobby con slots 1-8 player
+- Assign PG per player drag-drop
+- Preset modulation dropdown (solo/duo/quartet/full)
+
+### PR 4 (follow-up) — balance
+
+- Encounter 06+ con `max_deployed: 8` hardcore
+- Playtest dedicato 6-8 player (multi-device test difficile single-machine)
+
+## Validation
+
+- [x] AJV: `data/core/party.yaml` valid contro `party.schema.json`
+- [x] Invarianti modulation: `sum(pg_per_player) == deployed` per tutti 11 preset
+- [x] Invarianti cap: `deployed <= max_deployed`, `len(pg_per_player) <= max_players_coop`
+- [ ] Engine integration (PR 2)
+- [ ] Playtest 8-player (PR 4, multi-device)
+
+## Cross-reference
+
+- SoT §pilastro 5: linea 930, va aggiornata con ref questo ADR
+- `docs/core/02-PILASTRI.md`: update text "4 giocatori" → "1-8 giocatori"
+- `data/core/party.yaml`: config canonica
+- Pilastro Playtest log `docs/playtests/`: prossimo playtest #4 può testare 2-player duo
+
+## Aperto per review
+
+Nessuna open question. Master DD ha confermato scaling 4→8 in chat 2026-04-17.

--- a/docs/core/00-SOURCE-OF-TRUTH.md
+++ b/docs/core/00-SOURCE-OF-TRUTH.md
@@ -927,13 +927,13 @@ difficulty = clamp(raw_score × biome_mult × objective_mult, 1, 5)
 
 ## 16. Networking & Co-op Architecture 🟡 ADR PROPOSTO
 
-Co-op 4 giocatori vs Sistema è pilastro #5. Oggi il sistema gira **single-machine only**.
+Co-op **1-8 giocatori** vs Sistema è pilastro #5 (esteso da 4 a 8 via [ADR-2026-04-17](../adr/ADR-2026-04-17-coop-scaling-4to8.md)). Oggi il sistema gira **single-machine only**.
 
 ### 16.1 Requisiti co-op
 
-Da §6 e dai design doc:
+Da §6, dai design doc e da `data/core/party.yaml`:
 
-- 4 giocatori contemporanei
+- **1-8 giocatori** contemporanei (default 4 canonico, 8 hardcore)
 - TV shared screen (host) + companion personale (client)
 - Planning simultaneo → commit → risoluzione
 - Stato autoritativo sul server

--- a/schemas/evo/party.schema.json
+++ b/schemas/evo/party.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://game.example.com/schemas/evo/party.schema.json",
+  "title": "Party Configuration",
+  "description": "Party canonical config: coop scaling, roster, grid, modulation presets. ADR-2026-04-17.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "party"],
+  "properties": {
+    "version": { "type": "integer", "minimum": 1 },
+    "updated": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
+    "party": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "max_players_coop",
+        "max_deployed_per_encounter",
+        "max_roster_total",
+        "grid_scaling",
+        "defaults",
+        "modulation"
+      ],
+      "properties": {
+        "max_players_coop": { "type": "integer", "minimum": 1, "maximum": 16 },
+        "max_deployed_per_encounter": { "type": "integer", "minimum": 1, "maximum": 16 },
+        "max_roster_total": { "type": "integer", "minimum": 1, "maximum": 32 },
+        "grid_scaling": {
+          "type": "object",
+          "patternProperties": {
+            "^deployed_[0-9_]+$": {
+              "type": "string",
+              "pattern": "^\\d+x\\d+$"
+            }
+          }
+        },
+        "defaults": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["tutorial", "standard", "boss", "hardcore"],
+          "properties": {
+            "tutorial": { "type": "integer", "minimum": 1, "maximum": 16 },
+            "standard": { "type": "integer", "minimum": 1, "maximum": 16 },
+            "boss": { "type": "integer", "minimum": 1, "maximum": 16 },
+            "hardcore": { "type": "integer", "minimum": 1, "maximum": 16 }
+          }
+        },
+        "modulation": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-z_]+$": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["description", "pg_per_player", "deployed"],
+              "properties": {
+                "description": { "type": "string", "minLength": 1 },
+                "pg_per_player": {
+                  "type": "array",
+                  "items": { "type": "integer", "minimum": 1, "maximum": 8 },
+                  "minItems": 1,
+                  "maxItems": 8
+                },
+                "deployed": { "type": "integer", "minimum": 1, "maximum": 16 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Extend coop cap 4→8 player. Data+schema+ADR+SoT update. Engine/UI in PR successivi.