### PR TITLE
play: party engine integration — dynamic grid + modulation API (ADR-2026-04-17 PR 2/4)

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -18,6 +18,7 @@ const { createTraitRouter } = require('./routes/traits');
 const { createQualityRouter } = require('./routes/quality');
 const { createValidatorsRouter } = require('./routes/validators');
 const { createSessionRouter } = require('./routes/session');
+const { createPartyRouter } = require('./routes/party');
 const { createNebulaTelemetryAggregator } = require('./services/nebulaTelemetryAggregator');
 const { createReleaseReporter } = require('./services/releaseReporter');
 const { createCatalogService } = require('./services/catalog');
@@ -678,6 +679,7 @@ function createApp(options = {}) {
   // Espone POST /api/session/{start,action,end} + GET /api/session/state.
   // Stato in memoria, log eventi su disco in logs/session_*.json.
   app.use('/api/session', createSessionRouter(options.session || {}));
+  app.use('/api/party', createPartyRouter());
 
   app.get('/api/deployments/status', async (req, res) => {
     try {

--- a/apps/backend/routes/party.js
+++ b/apps/backend/routes/party.js
@@ -1,0 +1,44 @@
+// Party routes — expose modulation presets + config for frontend lobby.
+// ADR-2026-04-17.
+
+const { Router } = require('express');
+const {
+  getPartyConfig,
+  listModulations,
+  getModulation,
+  gridSizeFor,
+} = require('../../../services/party/loader');
+
+function createPartyRouter() {
+  const router = Router();
+
+  // GET /api/party/config — full party config canonica
+  router.get('/config', (req, res) => {
+    const cfg = getPartyConfig();
+    res.json({ version: 1, party: cfg });
+  });
+
+  // GET /api/party/modulations — lista preset per UI lobby
+  router.get('/modulations', (req, res) => {
+    res.json({ modulations: listModulations() });
+  });
+
+  // GET /api/party/modulations/:id — preset specifico
+  router.get('/modulations/:id', (req, res) => {
+    const m = getModulation(req.params.id);
+    if (!m) return res.status(404).json({ error: `modulation '${req.params.id}' non trovata` });
+    const [gw, gh] = gridSizeFor(m.deployed);
+    res.json({ id: req.params.id, ...m, grid_size: [gw, gh] });
+  });
+
+  // GET /api/party/grid-size?deployed=N — ricava grid auto-scale
+  router.get('/grid-size', (req, res) => {
+    const deployed = Number(req.query.deployed) || 4;
+    const [w, h] = gridSizeFor(deployed);
+    res.json({ deployed, grid_size: [w, h], width: w, height: h });
+  });
+
+  return router;
+}
+
+module.exports = { createPartyRouter };

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -629,6 +629,24 @@ function createSessionRouter(options = {}) {
         // best-effort: se config non carica, skip profile scaling
       }
 
+      // ADR-2026-04-17: grid auto-scale basato su deployed PG count (party.yaml)
+      let gridW = GRID_SIZE;
+      let gridH = GRID_SIZE;
+      try {
+        const { gridSizeFor, getModulation } = require('../../../services/party/loader');
+        const requestedModulation = req.body?.modulation;
+        let deployedCount = units.filter((u) => u && u.controlled_by === 'player').length;
+        if (requestedModulation) {
+          const preset = getModulation(requestedModulation);
+          if (preset) deployedCount = preset.deployed;
+        }
+        const [gw, gh] = gridSizeFor(deployedCount);
+        gridW = gw;
+        gridH = gh;
+      } catch {
+        // fallback GRID_SIZE default
+      }
+
       // SPRINT_020: calcola turn_order via iniziativa descending.
       const turnOrder = buildTurnOrder(units);
       const firstActiveId = turnOrder[0] || null;
@@ -641,7 +659,7 @@ function createSessionRouter(options = {}) {
         units,
         // Q-001 T2.4: snapshot iniziale per replay (deep copy, immutable)
         units_snapshot_initial: JSON.parse(JSON.stringify(units)),
-        grid: { width: GRID_SIZE, height: GRID_SIZE },
+        grid: { width: gridW, height: gridH },
         logFilePath,
         events: [],
         created_at: now.toISOString(),
@@ -812,10 +830,10 @@ function createSessionRouter(options = {}) {
         ) {
           return res.status(400).json({ error: 'position { x, y } numerica richiesta per move' });
         }
-        if (dest.x < 0 || dest.x >= GRID_SIZE || dest.y < 0 || dest.y >= GRID_SIZE) {
-          return res
-            .status(400)
-            .json({ error: `posizione fuori griglia (${GRID_SIZE}x${GRID_SIZE})` });
+        const _gw = session.grid?.width || GRID_SIZE;
+        const _gh = session.grid?.height || GRID_SIZE;
+        if (dest.x < 0 || dest.x >= _gw || dest.y < 0 || dest.y >= _gh) {
+          return res.status(400).json({ error: `posizione fuori griglia (${_gw}x${_gh})` });
         }
         if ((actor.ap_remaining ?? 0) < 1) {
           return res
@@ -1191,14 +1209,16 @@ function createSessionRouter(options = {}) {
           results.push({ actor_id: actor.id, action_type: 'attack', result: wrapped });
         } else if (action.type === 'move') {
           const dest = action.position;
+          const _gw2 = session.grid?.width || GRID_SIZE;
+          const _gh2 = session.grid?.height || GRID_SIZE;
           if (
             !dest ||
             typeof dest.x !== 'number' ||
             typeof dest.y !== 'number' ||
             dest.x < 0 ||
-            dest.x >= GRID_SIZE ||
+            dest.x >= _gw2 ||
             dest.y < 0 ||
-            dest.y >= GRID_SIZE
+            dest.y >= _gh2
           ) {
             results.push({ actor_id: actor.id, skipped: 'invalid_position' });
             continue;

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -149,10 +149,12 @@ function createAbilityExecutor(deps) {
     if (!dest || typeof dest.x !== 'number' || typeof dest.y !== 'number') {
       return { status: 400, body: { error: 'position { x, y } richiesta per move_attack' } };
     }
-    if (!isWithinGrid(dest, gridSize)) {
+    if (!isWithinGrid(dest, session.grid?.width || gridSize)) {
       return {
         status: 400,
-        body: { error: `posizione fuori griglia (${gridSize}x${gridSize})` },
+        body: {
+          error: `posizione fuori griglia (${session.grid?.width || gridSize}x${session.grid?.height || gridSize})`,
+        },
       };
     }
     const moveDist = manhattanDistance(actor.position, dest);
@@ -287,10 +289,12 @@ function createAbilityExecutor(deps) {
     if (!dest || typeof dest.x !== 'number' || typeof dest.y !== 'number') {
       return { status: 400, body: { error: 'position { x, y } richiesta per attack_move' } };
     }
-    if (!isWithinGrid(dest, gridSize)) {
+    if (!isWithinGrid(dest, session.grid?.width || gridSize)) {
       return {
         status: 400,
-        body: { error: `posizione fuori griglia (${gridSize}x${gridSize})` },
+        body: {
+          error: `posizione fuori griglia (${session.grid?.width || gridSize}x${session.grid?.height || gridSize})`,
+        },
       };
     }
 
@@ -640,7 +644,7 @@ function createAbilityExecutor(deps) {
       let destY = pushFrom.y;
       for (let step = 0; step < pushDist; step += 1) {
         const next = computePushDestination(actor, { position: { x: destX, y: destY } });
-        if (!isWithinGrid(next, gridSize)) break;
+        if (!isWithinGrid(next, session.grid?.width || gridSize)) break;
         const blocker = session.units.find(
           (u) =>
             u.id !== target.id && u.hp > 0 && u.position.x === next.x && u.position.y === next.y,
@@ -1280,7 +1284,7 @@ function createAbilityExecutor(deps) {
     if (!center || typeof center.x !== 'number' || typeof center.y !== 'number') {
       return { status: 400, body: { error: 'position { x, y } richiesta per aoe_buff' } };
     }
-    if (!isWithinGrid(center, gridSize)) {
+    if (!isWithinGrid(center, session.grid?.width || gridSize)) {
       return { status: 400, body: { error: 'centro AoE fuori griglia' } };
     }
     const range = Number(ability.range || 0);
@@ -1354,7 +1358,7 @@ function createAbilityExecutor(deps) {
     if (!center || typeof center.x !== 'number' || typeof center.y !== 'number') {
       return { status: 400, body: { error: 'position { x, y } richiesta per aoe_debuff' } };
     }
-    if (!isWithinGrid(center, gridSize)) {
+    if (!isWithinGrid(center, session.grid?.width || gridSize)) {
       return { status: 400, body: { error: 'centro AoE fuori griglia' } };
     }
     const range = Number(ability.range || 0);
@@ -1427,7 +1431,7 @@ function createAbilityExecutor(deps) {
     if (!center || typeof center.x !== 'number' || typeof center.y !== 'number') {
       return { status: 400, body: { error: 'position { x, y } richiesta per surge_aoe' } };
     }
-    if (!isWithinGrid(center, gridSize)) {
+    if (!isWithinGrid(center, session.grid?.width || gridSize)) {
       return { status: 400, body: { error: 'centro AoE fuori griglia' } };
     }
     const range = Number(ability.range || 0);

--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -117,6 +117,7 @@ function createDeclareSistemaIntents(deps) {
     if (!session || !Array.isArray(session.units)) {
       return { intents: [], decisions: [] };
     }
+    const effectiveGrid = session.grid?.width || gridSize;
 
     // AI War pattern: compute threat context once per round
     const threatCtx =
@@ -217,7 +218,7 @@ function createDeclareSistemaIntents(deps) {
       // approach altrimenti).
       if (policy.intent === 'retreat') {
         const range = actor.attack_range ?? DEFAULT_ATTACK_RANGE;
-        const canRetreat = stepAway(actor.position, target.position, gridSize) !== null;
+        const canRetreat = stepAway(actor.position, target.position, effectiveGrid) !== null;
         if (!canRetreat) {
           policy =
             distance <= range
@@ -273,7 +274,7 @@ function createDeclareSistemaIntents(deps) {
       const positionFrom = { ...actor.position };
       const nextPos =
         policy.intent === 'retreat'
-          ? stepAway(actor.position, target.position, gridSize)
+          ? stepAway(actor.position, target.position, effectiveGrid)
           : stepTowards(actor.position, target.position);
 
       if (!nextPos || (nextPos.x === positionFrom.x && nextPos.y === positionFrom.y)) {

--- a/apps/backend/services/ai/sistemaTurnRunner.js
+++ b/apps/backend/services/ai/sistemaTurnRunner.js
@@ -62,6 +62,7 @@ function createSistemaTurnRunner(deps) {
   }
 
   return async function runSistemaTurn(session) {
+    const effectiveGrid = session.grid?.width || gridSize;
     const actor = session.units.find((u) => u.id === session.active_unit);
     if (!actor) return [];
     if ((actor.ap_remaining ?? 0) <= 0) {
@@ -93,7 +94,7 @@ function createSistemaTurnRunner(deps) {
               ? { rule: 'REGOLA_001', intent: 'attack' }
               : { rule: 'REGOLA_001', intent: 'approach' };
         } else {
-          const canRetreat = stepAway(actor.position, target.position, gridSize) !== null;
+          const canRetreat = stepAway(actor.position, target.position, effectiveGrid) !== null;
           if (!canRetreat) {
             corneredThisTurn = true;
             policy =
@@ -178,7 +179,7 @@ function createSistemaTurnRunner(deps) {
       const positionFrom = { ...actor.position };
       const nextPos =
         policy.intent === 'retreat'
-          ? stepAway(actor.position, target.position, gridSize)
+          ? stepAway(actor.position, target.position, effectiveGrid)
           : stepTowards(actor.position, target.position);
 
       if (!nextPos || (nextPos.x === positionFrom.x && nextPos.y === positionFrom.y)) {

--- a/services/party/loader.js
+++ b/services/party/loader.js
@@ -1,0 +1,107 @@
+/**
+ * Party config loader — memoized.
+ * Legge data/core/party.yaml al boot. Fallback a config minimale se YAML
+ * mancante (backward compat).
+ * ADR-2026-04-17.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DEFAULT_CONFIG_PATH = path.resolve(__dirname, '..', '..', 'data', 'core', 'party.yaml');
+
+const FALLBACK = {
+  max_players_coop: 4,
+  max_deployed_per_encounter: 4,
+  max_roster_total: 8,
+  grid_scaling: { deployed_1_4: '6x6' },
+  defaults: { tutorial: 2, standard: 4, boss: 4, hardcore: 4 },
+  modulation: {
+    quartet: { description: '4 player × 1 PG', pg_per_player: [1, 1, 1, 1], deployed: 4 },
+  },
+};
+
+let _memoized = null;
+
+function loadFromDisk(configPath = DEFAULT_CONFIG_PATH) {
+  let yaml;
+  try {
+    yaml = require('js-yaml');
+  } catch {
+    return FALLBACK;
+  }
+  try {
+    const raw = fs.readFileSync(configPath, 'utf8');
+    const parsed = yaml.load(raw);
+    return (parsed && parsed.party) || FALLBACK;
+  } catch {
+    return FALLBACK;
+  }
+}
+
+function getPartyConfig() {
+  if (_memoized === null) _memoized = loadFromDisk();
+  return _memoized;
+}
+
+function resetCache() {
+  _memoized = null;
+}
+
+/**
+ * Calcola grid size [w, h] da deployed count usando party.grid_scaling.
+ * Ricava soglie da chiavi "deployed_N_M" e ritorna tuple "WxH" → [w, h].
+ */
+function gridSizeFor(deployedCount) {
+  const cfg = getPartyConfig();
+  const scaling = cfg.grid_scaling || {};
+  // Default fallback
+  let best = '6x6';
+  for (const [key, size] of Object.entries(scaling)) {
+    const m = /^deployed_(\d+)_(\d+)$/.exec(key);
+    if (!m) continue;
+    const lo = Number(m[1]);
+    const hi = Number(m[2]);
+    if (deployedCount >= lo && deployedCount <= hi) {
+      best = size;
+      break;
+    }
+  }
+  const mm = /^(\d+)x(\d+)$/.exec(best);
+  if (!mm) return [6, 6];
+  return [Number(mm[1]), Number(mm[2])];
+}
+
+/**
+ * Ritorna modulation preset by name oppure null.
+ */
+function getModulation(name) {
+  const cfg = getPartyConfig();
+  const preset = (cfg.modulation || {})[name];
+  return preset || null;
+}
+
+/**
+ * Lista nomi modulation preset disponibili.
+ */
+function listModulations() {
+  const cfg = getPartyConfig();
+  return Object.entries(cfg.modulation || {}).map(([id, data]) => ({
+    id,
+    description: data.description,
+    pg_per_player: data.pg_per_player,
+    deployed: data.deployed,
+    players: (data.pg_per_player || []).length,
+  }));
+}
+
+module.exports = {
+  getPartyConfig,
+  gridSizeFor,
+  getModulation,
+  listModulations,
+  loadFromDisk,
+  resetCache,
+  DEFAULT_CONFIG_PATH,
+  FALLBACK,
+};

--- a/tests/api/partyRoutes.test.js
+++ b/tests/api/partyRoutes.test.js
@@ -1,0 +1,168 @@
+// Test /api/party/* endpoints + session /start modulation param.
+// ADR-2026-04-17 co-op scaling 4→8.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+test('GET /api/party/config returns party config', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app).get('/api/party/config').expect(200);
+    assert.ok(res.body.party);
+    assert.equal(res.body.party.max_players_coop, 8);
+    assert.equal(res.body.party.max_deployed_per_encounter, 8);
+  } finally {
+    await close();
+  }
+});
+
+test('GET /api/party/modulations returns 11 presets', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app).get('/api/party/modulations').expect(200);
+    assert.ok(Array.isArray(res.body.modulations));
+    assert.equal(res.body.modulations.length, 11);
+    const full = res.body.modulations.find((m) => m.id === 'full');
+    assert.ok(full);
+    assert.equal(full.deployed, 8);
+  } finally {
+    await close();
+  }
+});
+
+test('GET /api/party/modulations/:id returns preset + grid_size', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app).get('/api/party/modulations/full').expect(200);
+    assert.equal(res.body.id, 'full');
+    assert.equal(res.body.deployed, 8);
+    assert.deepEqual(res.body.grid_size, [10, 10]);
+
+    const quartet = await request(app).get('/api/party/modulations/quartet').expect(200);
+    assert.deepEqual(quartet.body.grid_size, [6, 6]);
+  } finally {
+    await close();
+  }
+});
+
+test('GET /api/party/modulations/:id 404 on unknown', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app).get('/api/party/modulations/nonexistent').expect(404);
+  } finally {
+    await close();
+  }
+});
+
+test('GET /api/party/grid-size?deployed=N maps to scaling tiers', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const r1 = await request(app).get('/api/party/grid-size?deployed=3').expect(200);
+    assert.deepEqual(r1.body.grid_size, [6, 6]);
+    const r2 = await request(app).get('/api/party/grid-size?deployed=5').expect(200);
+    assert.deepEqual(r2.body.grid_size, [8, 8]);
+    const r3 = await request(app).get('/api/party/grid-size?deployed=8').expect(200);
+    assert.deepEqual(r3.body.grid_size, [10, 10]);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/session/start with modulation scales grid', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const units = [
+      {
+        id: 'p1',
+        species: 'velox',
+        job: 'skirmisher',
+        hp: 10,
+        ap: 2,
+        attack_range: 2,
+        initiative: 14,
+        position: { x: 2, y: 2 },
+        controlled_by: 'player',
+      },
+      {
+        id: 'sis1',
+        species: 'mole',
+        job: 'tank',
+        hp: 10,
+        ap: 2,
+        attack_range: 1,
+        initiative: 10,
+        position: { x: 4, y: 4 },
+        controlled_by: 'sistema',
+      },
+    ];
+    const res = await request(app)
+      .post('/api/session/start')
+      .send({ units, modulation: 'full' })
+      .expect(200);
+    // Session state has 10x10 grid via preset 'full' (deployed=8 → 10x10)
+    const state = await request(app)
+      .get(`/api/session/state?session_id=${res.body.session_id}`)
+      .expect(200);
+    assert.ok(state.body.grid, 'session.grid exposed');
+    assert.equal(state.body.grid.width, 10);
+    assert.equal(state.body.grid.height, 10);
+    assert.equal(state.body.grid_size, 10);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/session/start without modulation defaults grid to player count', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    // 2 players → 6x6
+    const units = [
+      {
+        id: 'p1',
+        species: 'velox',
+        job: 'skirmisher',
+        hp: 10,
+        ap: 2,
+        attack_range: 2,
+        initiative: 14,
+        position: { x: 1, y: 1 },
+        controlled_by: 'player',
+      },
+      {
+        id: 'p2',
+        species: 'velox',
+        job: 'skirmisher',
+        hp: 10,
+        ap: 2,
+        attack_range: 2,
+        initiative: 13,
+        position: { x: 2, y: 2 },
+        controlled_by: 'player',
+      },
+      {
+        id: 'sis1',
+        species: 'mole',
+        job: 'tank',
+        hp: 10,
+        ap: 2,
+        attack_range: 1,
+        initiative: 10,
+        position: { x: 4, y: 4 },
+        controlled_by: 'sistema',
+      },
+    ];
+    const res = await request(app).post('/api/session/start').send({ units }).expect(200);
+    const state = await request(app)
+      .get(`/api/session/state?session_id=${res.body.session_id}`)
+      .expect(200);
+    assert.equal(state.body.grid?.width, 6);
+    assert.equal(state.body.grid?.height, 6);
+    assert.equal(state.body.grid_size, 6);
+  } finally {
+    await close();
+  }
+});


### PR DESCRIPTION
## Summary

PR 2/4 del rollout co-op scaling 4→8 (ADR-2026-04-17). PR 1 (#1529) ha introdotto \`data/core/party.yaml\` + schema + ADR. Questo PR wira l'engine.

- **services/party/loader.js** (nuovo): memoized YAML loader (\`getPartyConfig\`, \`getModulation\`, \`listModulations\`, \`gridSizeFor\`) con FALLBACK sicuro.
- **apps/backend/routes/party.js** (nuovo): 4 endpoint \`/api/party/{config,modulations,modulations/:id,grid-size}\`
- **session /start** accetta \`body.modulation\` (es. \`"full"\`, \`"quartet"\`): calcola deployedCount + grid dinamica via \`gridSizeFor\` (6×6 → 8×8 → 10×10). \`session.grid = { width, height }\` esposto in \`/state\`.
- **Grid dinamica per-session** in validazione move + AI (sistemaTurnRunner, declareSistemaIntents, abilityExecutor \`isWithinGrid\`). Pattern: \`session.grid?.width || gridSize\` (backward-compat).

## Test plan

- [x] \`node --test tests/api/partyRoutes.test.js\` → 7/7 verde (config, modulations, grid-size, session /start con/senza modulation)
- [x] \`node --test tests/ai/*.test.js\` → 161/161 verde
- [x] \`node --test tests/api/sessionRound*.test.js tests/api/sessionLegacy*.test.js tests/api/sessionTurnEnd*.test.js\` → 35/35 verde
- [x] Prettier format applied

**Totale 203/203 test verdi. Nessun breaking change.**

## Rollback

Revert del commit — \`party.yaml\` resta in place (PR #1529), solo engine torna a grid 6×6 hardcoded. Factory defaults \`gridSize = 6\` preservati.

🤖 Generated with [Claude Code](https://claude.com/claude-code)