### PR TITLE
play: enc_tutorial_06_hardcore — BOSS 8p vs 6 (ADR-2026-04-17 PR 4/4)

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -18,6 +18,7 @@ const { createTraitRouter } = require('./routes/traits');
 const { createQualityRouter } = require('./routes/quality');
 const { createValidatorsRouter } = require('./routes/validators');
 const { createSessionRouter } = require('./routes/session');
+const { createPartyRouter } = require('./routes/party');
 const { createNebulaTelemetryAggregator } = require('./services/nebulaTelemetryAggregator');
 const { createReleaseReporter } = require('./services/releaseReporter');
 const { createCatalogService } = require('./services/catalog');
@@ -678,6 +679,7 @@ function createApp(options = {}) {
   // Espone POST /api/session/{start,action,end} + GET /api/session/state.
   // Stato in memoria, log eventi su disco in logs/session_*.json.
   app.use('/api/session', createSessionRouter(options.session || {}));
+  app.use('/api/party', createPartyRouter());
 
   app.get('/api/deployments/status', async (req, res) => {
     try {

--- a/apps/backend/routes/party.js
+++ b/apps/backend/routes/party.js
@@ -1,0 +1,44 @@
+// Party routes — expose modulation presets + config for frontend lobby.
+// ADR-2026-04-17.
+
+const { Router } = require('express');
+const {
+  getPartyConfig,
+  listModulations,
+  getModulation,
+  gridSizeFor,
+} = require('../../../services/party/loader');
+
+function createPartyRouter() {
+  const router = Router();
+
+  // GET /api/party/config — full party config canonica
+  router.get('/config', (req, res) => {
+    const cfg = getPartyConfig();
+    res.json({ version: 1, party: cfg });
+  });
+
+  // GET /api/party/modulations — lista preset per UI lobby
+  router.get('/modulations', (req, res) => {
+    res.json({ modulations: listModulations() });
+  });
+
+  // GET /api/party/modulations/:id — preset specifico
+  router.get('/modulations/:id', (req, res) => {
+    const m = getModulation(req.params.id);
+    if (!m) return res.status(404).json({ error: `modulation '${req.params.id}' non trovata` });
+    const [gw, gh] = gridSizeFor(m.deployed);
+    res.json({ id: req.params.id, ...m, grid_size: [gw, gh] });
+  });
+
+  // GET /api/party/grid-size?deployed=N — ricava grid auto-scale
+  router.get('/grid-size', (req, res) => {
+    const deployed = Number(req.query.deployed) || 4;
+    const [w, h] = gridSizeFor(deployed);
+    res.json({ deployed, grid_size: [w, h], width: w, height: h });
+  });
+
+  return router;
+}
+
+module.exports = { createPartyRouter };

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -629,6 +629,24 @@ function createSessionRouter(options = {}) {
         // best-effort: se config non carica, skip profile scaling
       }
 
+      // ADR-2026-04-17: grid auto-scale basato su deployed PG count (party.yaml)
+      let gridW = GRID_SIZE;
+      let gridH = GRID_SIZE;
+      try {
+        const { gridSizeFor, getModulation } = require('../../../services/party/loader');
+        const requestedModulation = req.body?.modulation;
+        let deployedCount = units.filter((u) => u && u.controlled_by === 'player').length;
+        if (requestedModulation) {
+          const preset = getModulation(requestedModulation);
+          if (preset) deployedCount = preset.deployed;
+        }
+        const [gw, gh] = gridSizeFor(deployedCount);
+        gridW = gw;
+        gridH = gh;
+      } catch {
+        // fallback GRID_SIZE default
+      }
+
       // SPRINT_020: calcola turn_order via iniziativa descending.
       const turnOrder = buildTurnOrder(units);
       const firstActiveId = turnOrder[0] || null;
@@ -641,7 +659,7 @@ function createSessionRouter(options = {}) {
         units,
         // Q-001 T2.4: snapshot iniziale per replay (deep copy, immutable)
         units_snapshot_initial: JSON.parse(JSON.stringify(units)),
-        grid: { width: GRID_SIZE, height: GRID_SIZE },
+        grid: { width: gridW, height: gridH },
         logFilePath,
         events: [],
         created_at: now.toISOString(),
@@ -812,10 +830,10 @@ function createSessionRouter(options = {}) {
         ) {
           return res.status(400).json({ error: 'position { x, y } numerica richiesta per move' });
         }
-        if (dest.x < 0 || dest.x >= GRID_SIZE || dest.y < 0 || dest.y >= GRID_SIZE) {
-          return res
-            .status(400)
-            .json({ error: `posizione fuori griglia (${GRID_SIZE}x${GRID_SIZE})` });
+        const _gw = session.grid?.width || GRID_SIZE;
+        const _gh = session.grid?.height || GRID_SIZE;
+        if (dest.x < 0 || dest.x >= _gw || dest.y < 0 || dest.y >= _gh) {
+          return res.status(400).json({ error: `posizione fuori griglia (${_gw}x${_gh})` });
         }
         if ((actor.ap_remaining ?? 0) < 1) {
           return res
@@ -1191,14 +1209,16 @@ function createSessionRouter(options = {}) {
           results.push({ actor_id: actor.id, action_type: 'attack', result: wrapped });
         } else if (action.type === 'move') {
           const dest = action.position;
+          const _gw2 = session.grid?.width || GRID_SIZE;
+          const _gh2 = session.grid?.height || GRID_SIZE;
           if (
             !dest ||
             typeof dest.x !== 'number' ||
             typeof dest.y !== 'number' ||
             dest.x < 0 ||
-            dest.x >= GRID_SIZE ||
+            dest.x >= _gw2 ||
             dest.y < 0 ||
-            dest.y >= GRID_SIZE
+            dest.y >= _gh2
           ) {
             results.push({ actor_id: actor.id, skipped: 'invalid_position' });
             continue;

--- a/apps/backend/routes/tutorial.js
+++ b/apps/backend/routes/tutorial.js
@@ -22,6 +22,7 @@ const {
   buildTutorialUnits04,
   buildTutorialUnits05,
 } = require('../services/tutorialScenario');
+const { HARDCORE_SCENARIO_06, buildHardcoreUnits06 } = require('../services/hardcoreScenario');
 
 function createTutorialRouter() {
   const router = Router();
@@ -66,6 +67,14 @@ function createTutorialRouter() {
     });
   });
 
+  router.get('/enc_tutorial_06_hardcore', (_req, res) => {
+    res.json({
+      ...HARDCORE_SCENARIO_06,
+      units: buildHardcoreUnits06(),
+      usage: 'POST the units array to /api/session/start with modulation="full" to begin.',
+    });
+  });
+
   router.get('/', (_req, res) => {
     res.json({
       scenarios: [
@@ -98,6 +107,12 @@ function createTutorialRouter() {
           name: TUTORIAL_SCENARIO_05.name,
           difficulty: TUTORIAL_SCENARIO_05.difficulty_rating,
           href: `/api/tutorial/${TUTORIAL_SCENARIO_05.id}`,
+        },
+        {
+          id: HARDCORE_SCENARIO_06.id,
+          name: HARDCORE_SCENARIO_06.name,
+          difficulty: HARDCORE_SCENARIO_06.difficulty_rating,
+          href: `/api/tutorial/${HARDCORE_SCENARIO_06.id}`,
         },
       ],
     });

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -149,10 +149,12 @@ function createAbilityExecutor(deps) {
     if (!dest || typeof dest.x !== 'number' || typeof dest.y !== 'number') {
       return { status: 400, body: { error: 'position { x, y } richiesta per move_attack' } };
     }
-    if (!isWithinGrid(dest, gridSize)) {
+    if (!isWithinGrid(dest, session.grid?.width || gridSize)) {
       return {
         status: 400,
-        body: { error: `posizione fuori griglia (${gridSize}x${gridSize})` },
+        body: {
+          error: `posizione fuori griglia (${session.grid?.width || gridSize}x${session.grid?.height || gridSize})`,
+        },
       };
     }
     const moveDist = manhattanDistance(actor.position, dest);
@@ -287,10 +289,12 @@ function createAbilityExecutor(deps) {
     if (!dest || typeof dest.x !== 'number' || typeof dest.y !== 'number') {
       return { status: 400, body: { error: 'position { x, y } richiesta per attack_move' } };
     }
-    if (!isWithinGrid(dest, gridSize)) {
+    if (!isWithinGrid(dest, session.grid?.width || gridSize)) {
       return {
         status: 400,
-        body: { error: `posizione fuori griglia (${gridSize}x${gridSize})` },
+        body: {
+          error: `posizione fuori griglia (${session.grid?.width || gridSize}x${session.grid?.height || gridSize})`,
+        },
       };
     }
 
@@ -640,7 +644,7 @@ function createAbilityExecutor(deps) {
       let destY = pushFrom.y;
       for (let step = 0; step < pushDist; step += 1) {
         const next = computePushDestination(actor, { position: { x: destX, y: destY } });
-        if (!isWithinGrid(next, gridSize)) break;
+        if (!isWithinGrid(next, session.grid?.width || gridSize)) break;
         const blocker = session.units.find(
           (u) =>
             u.id !== target.id && u.hp > 0 && u.position.x === next.x && u.position.y === next.y,
@@ -1280,7 +1284,7 @@ function createAbilityExecutor(deps) {
     if (!center || typeof center.x !== 'number' || typeof center.y !== 'number') {
       return { status: 400, body: { error: 'position { x, y } richiesta per aoe_buff' } };
     }
-    if (!isWithinGrid(center, gridSize)) {
+    if (!isWithinGrid(center, session.grid?.width || gridSize)) {
       return { status: 400, body: { error: 'centro AoE fuori griglia' } };
     }
     const range = Number(ability.range || 0);
@@ -1354,7 +1358,7 @@ function createAbilityExecutor(deps) {
     if (!center || typeof center.x !== 'number' || typeof center.y !== 'number') {
       return { status: 400, body: { error: 'position { x, y } richiesta per aoe_debuff' } };
     }
-    if (!isWithinGrid(center, gridSize)) {
+    if (!isWithinGrid(center, session.grid?.width || gridSize)) {
       return { status: 400, body: { error: 'centro AoE fuori griglia' } };
     }
     const range = Number(ability.range || 0);
@@ -1427,7 +1431,7 @@ function createAbilityExecutor(deps) {
     if (!center || typeof center.x !== 'number' || typeof center.y !== 'number') {
       return { status: 400, body: { error: 'position { x, y } richiesta per surge_aoe' } };
     }
-    if (!isWithinGrid(center, gridSize)) {
+    if (!isWithinGrid(center, session.grid?.width || gridSize)) {
       return { status: 400, body: { error: 'centro AoE fuori griglia' } };
     }
     const range = Number(ability.range || 0);

--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -117,6 +117,7 @@ function createDeclareSistemaIntents(deps) {
     if (!session || !Array.isArray(session.units)) {
       return { intents: [], decisions: [] };
     }
+    const effectiveGrid = session.grid?.width || gridSize;
 
     // AI War pattern: compute threat context once per round
     const threatCtx =
@@ -217,7 +218,7 @@ function createDeclareSistemaIntents(deps) {
       // approach altrimenti).
       if (policy.intent === 'retreat') {
         const range = actor.attack_range ?? DEFAULT_ATTACK_RANGE;
-        const canRetreat = stepAway(actor.position, target.position, gridSize) !== null;
+        const canRetreat = stepAway(actor.position, target.position, effectiveGrid) !== null;
         if (!canRetreat) {
           policy =
             distance <= range
@@ -273,7 +274,7 @@ function createDeclareSistemaIntents(deps) {
       const positionFrom = { ...actor.position };
       const nextPos =
         policy.intent === 'retreat'
-          ? stepAway(actor.position, target.position, gridSize)
+          ? stepAway(actor.position, target.position, effectiveGrid)
           : stepTowards(actor.position, target.position);
 
       if (!nextPos || (nextPos.x === positionFrom.x && nextPos.y === positionFrom.y)) {

--- a/apps/backend/services/ai/sistemaTurnRunner.js
+++ b/apps/backend/services/ai/sistemaTurnRunner.js
@@ -62,6 +62,7 @@ function createSistemaTurnRunner(deps) {
   }
 
   return async function runSistemaTurn(session) {
+    const effectiveGrid = session.grid?.width || gridSize;
     const actor = session.units.find((u) => u.id === session.active_unit);
     if (!actor) return [];
     if ((actor.ap_remaining ?? 0) <= 0) {
@@ -93,7 +94,7 @@ function createSistemaTurnRunner(deps) {
               ? { rule: 'REGOLA_001', intent: 'attack' }
               : { rule: 'REGOLA_001', intent: 'approach' };
         } else {
-          const canRetreat = stepAway(actor.position, target.position, gridSize) !== null;
+          const canRetreat = stepAway(actor.position, target.position, effectiveGrid) !== null;
           if (!canRetreat) {
             corneredThisTurn = true;
             policy =
@@ -178,7 +179,7 @@ function createSistemaTurnRunner(deps) {
       const positionFrom = { ...actor.position };
       const nextPos =
         policy.intent === 'retreat'
-          ? stepAway(actor.position, target.position, gridSize)
+          ? stepAway(actor.position, target.position, effectiveGrid)
           : stepTowards(actor.position, target.position);
 
       if (!nextPos || (nextPos.x === positionFrom.x && nextPos.y === positionFrom.y)) {

--- a/apps/backend/services/hardcoreScenario.js
+++ b/apps/backend/services/hardcoreScenario.js
@@ -1,0 +1,177 @@
+// Hardcore encounter — ADR-2026-04-17 co-op 4→8 scaling.
+//
+// tutorial_06_hardcore: "Cattedrale dell'Apex"
+// Party: 8 schierati (modulation full o quartet_hardcore), grid 10x10.
+// Enemy: 1 BOSS apex + 2 elite hunter + 3 minion nomad = 6.
+// Difficulty 6/5 (boss + swarm). pressure_start 75 → Critical/Apex tier.
+//
+// Baseline calibration target (atteso post batch N=30):
+//   win_rate ~15-25% (BOSS hardcore, player deve coordinarsi 8-way)
+//   turns avg ~14-18
+//   K/D ratio player ~0.6-0.9
+//
+// Se batch rivela fuori band → tune hp apex/elite in iter successive (PR4.b).
+
+'use strict';
+
+const HARDCORE_SCENARIO_06 = {
+  id: 'enc_tutorial_06_hardcore',
+  name: "Cattedrale dell'Apex",
+  biome_id: 'rovine_planari',
+  difficulty_rating: 6,
+  estimated_turns: 16,
+  grid_size: 10,
+  objective: 'elimination',
+  objective_text:
+    'Sconfiggi il BOSS Apex e i suoi 5 guardiani. Party 8 unità vs 6 nemici asimmetrici: coordina focus-fire e combo squadSync per superare la pressione massima.',
+  briefing_pre:
+    "Le rovine risuonano del passo pesante dell'Apex. Due elite cacciatori pattugliano i fianchi, tre predoni bloccano i corridoi. Party al completo (8 schierati): ogni PG conta, il focus-fire moltiplica il danno, il BOSS non perdona errori di posizionamento.",
+  briefing_post:
+    "L'Apex è caduto. La cattedrale si quieta. Avete dimostrato che 8 mani battono una mandibola.",
+  hazard_tiles: [
+    { x: 4, y: 4, damage: 1, type: 'rovine_instabili' },
+    { x: 5, y: 5, damage: 1, type: 'rovine_instabili' },
+    { x: 3, y: 6, damage: 1, type: 'rovine_instabili' },
+  ],
+  sistema_pressure_start: 75, // Critical: 3 intents/round + swarm AI unlocked
+  recommended_modulation: 'full', // 8p × 1 PG → grid 10x10 auto
+};
+
+function buildHardcoreUnits06() {
+  const players = [];
+  // 8 player PG — mix specie/job per composition leggibile.
+  // 4 skirmisher (ranged dmg) + 2 vanguard (tank frontline) + 2 support.
+  const playerLayouts = [
+    { id: 'p_scout_1', job: 'skirmisher', pos: [0, 2], hp: 10, mod: 3, dc: 12 },
+    { id: 'p_scout_2', job: 'skirmisher', pos: [0, 4], hp: 10, mod: 3, dc: 12 },
+    { id: 'p_scout_3', job: 'skirmisher', pos: [0, 6], hp: 10, mod: 3, dc: 12 },
+    { id: 'p_scout_4', job: 'skirmisher', pos: [0, 8], hp: 10, mod: 3, dc: 12 },
+    { id: 'p_tank_1', job: 'vanguard', pos: [1, 3], hp: 14, mod: 2, dc: 14 },
+    { id: 'p_tank_2', job: 'vanguard', pos: [1, 7], hp: 14, mod: 2, dc: 14 },
+    { id: 'p_support_1', job: 'skirmisher', pos: [1, 1], hp: 11, mod: 3, dc: 13 },
+    { id: 'p_support_2', job: 'skirmisher', pos: [1, 5], hp: 11, mod: 3, dc: 13 },
+  ];
+  for (const pl of playerLayouts) {
+    players.push({
+      id: pl.id,
+      species: 'dune_stalker',
+      job: pl.job,
+      traits: pl.job === 'vanguard' ? ['pelle_elastomera'] : ['zampe_a_molla'],
+      hp: pl.hp,
+      ap: 2, // SoT canonical
+      mod: pl.mod,
+      dc: pl.dc,
+      guardia: pl.job === 'vanguard' ? 2 : 1,
+      position: { x: pl.pos[0], y: pl.pos[1] },
+      controlled_by: 'player',
+      facing: 'E',
+    });
+  }
+
+  const enemies = [
+    // BOSS Apex (center-right) — HP alto, crit bonus, attack_range 2.
+    // Baseline: hp 14 mod 4 dc 14 (più duro del tutorial_05 hp 11).
+    {
+      id: 'e_apex_boss',
+      species: 'apex_predatore',
+      job: 'vanguard',
+      traits: ['martello_osseo', 'ferocia'],
+      hp: 14,
+      ap: 3,
+      mod: 4,
+      dc: 14,
+      guardia: 2,
+      attack_range: 2,
+      position: { x: 8, y: 5 },
+      controlled_by: 'sistema',
+      ai_profile: 'aggressive',
+      facing: 'W',
+    },
+    // 2 elite hunter — flanking, mod 3, hp 7.
+    {
+      id: 'e_elite_hunter_1',
+      species: 'cacciatore_corazzato',
+      job: 'vanguard',
+      traits: [],
+      hp: 7,
+      ap: 2,
+      mod: 3,
+      dc: 13,
+      guardia: 1,
+      attack_range: 2,
+      position: { x: 7, y: 2 },
+      controlled_by: 'sistema',
+      ai_profile: 'aggressive',
+      facing: 'W',
+    },
+    {
+      id: 'e_elite_hunter_2',
+      species: 'cacciatore_corazzato',
+      job: 'vanguard',
+      traits: [],
+      hp: 7,
+      ap: 2,
+      mod: 3,
+      dc: 13,
+      guardia: 1,
+      attack_range: 2,
+      position: { x: 7, y: 8 },
+      controlled_by: 'sistema',
+      ai_profile: 'aggressive',
+      facing: 'W',
+    },
+    // 3 minion nomad — fragili ma numerosi, mod 2 hp 4.
+    {
+      id: 'e_minion_1',
+      species: 'predoni_nomadi',
+      job: 'skirmisher',
+      traits: [],
+      hp: 4,
+      ap: 2,
+      mod: 2,
+      dc: 11,
+      guardia: 0,
+      attack_range: 1,
+      position: { x: 6, y: 4 },
+      controlled_by: 'sistema',
+      facing: 'W',
+    },
+    {
+      id: 'e_minion_2',
+      species: 'predoni_nomadi',
+      job: 'skirmisher',
+      traits: [],
+      hp: 4,
+      ap: 2,
+      mod: 2,
+      dc: 11,
+      guardia: 0,
+      attack_range: 1,
+      position: { x: 6, y: 6 },
+      controlled_by: 'sistema',
+      facing: 'W',
+    },
+    {
+      id: 'e_minion_3',
+      species: 'predoni_nomadi',
+      job: 'skirmisher',
+      traits: [],
+      hp: 4,
+      ap: 2,
+      mod: 2,
+      dc: 11,
+      guardia: 0,
+      attack_range: 1,
+      position: { x: 9, y: 5 },
+      controlled_by: 'sistema',
+      facing: 'W',
+    },
+  ];
+
+  return [...players, ...enemies];
+}
+
+module.exports = {
+  HARDCORE_SCENARIO_06,
+  buildHardcoreUnits06,
+};

--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -30,6 +30,9 @@
               <option value="enc_tutorial_04">Tutorial 04 · Bleeding foresta</option>
               <option value="enc_tutorial_05">Tutorial 05 · BOSS Apex</option>
             </select>
+            <select id="modulation-select" title="Party composition (co-op 1-8 player)">
+              <option value="">Party: auto</option>
+            </select>
           </div>
         </section>
         <aside class="sidebar">

--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -29,6 +29,7 @@
               <option value="enc_tutorial_03">Tutorial 03 · Hazard savana</option>
               <option value="enc_tutorial_04">Tutorial 04 · Bleeding foresta</option>
               <option value="enc_tutorial_05">Tutorial 05 · BOSS Apex</option>
+              <option value="enc_tutorial_06_hardcore">Tutorial 06 · HARDCORE 8p</option>
             </select>
             <select id="modulation-select" title="Party composition (co-op 1-8 player)">
               <option value="">Party: auto</option>

--- a/apps/play/src/api.js
+++ b/apps/play/src/api.js
@@ -32,4 +32,6 @@ export const api = {
     }),
   vc: (sid) => jsonFetch(`/api/session/${encodeURIComponent(sid)}/vc`),
   replay: (sid) => jsonFetch(`/api/session/${encodeURIComponent(sid)}/replay`),
+  modulations: () => jsonFetch('/api/party/modulations'),
+  partyConfig: () => jsonFetch('/api/party/config'),
 };

--- a/apps/play/src/endgame.js
+++ b/apps/play/src/endgame.js
@@ -103,6 +103,7 @@ export function nextScenarioId(current) {
     'enc_tutorial_03',
     'enc_tutorial_04',
     'enc_tutorial_05',
+    'enc_tutorial_06_hardcore',
   ];
   const idx = order.indexOf(current);
   if (idx < 0 || idx >= order.length - 1) return order[0]; // loop to start

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -311,10 +311,14 @@ async function startNewSession() {
     updateHint('Backend non raggiungibile? Verifica npm run start:api.');
     return;
   }
-  const st = await api.start(sc.data.units, {
+  const modSel = document.getElementById('modulation-select');
+  const modulation = modSel && modSel.value ? modSel.value : undefined;
+  const startOpts = {
     sistema_pressure_start: sc.data.sistema_pressure_start || 0,
     hazard_tiles: sc.data.hazard_tiles || [],
-  });
+  };
+  if (modulation) startOpts.modulation = modulation;
+  const st = await api.start(sc.data.units, startOpts);
   if (!st.ok) {
     appendLog(logEl, `✖ session start: ${st.status}`, 'error');
     return;
@@ -415,5 +419,29 @@ muteBtn.addEventListener('click', () => {
   muteBtn.title = isMuted() ? 'Unmute SFX' : 'Mute SFX';
 });
 
-startNewSession();
+// Popola modulation picker da /api/party/modulations (PR 3 co-op scaling).
+// Fallback silenzioso se backend < ADR-2026-04-17 o endpoint non risponde.
+async function loadModulations() {
+  const modSel = document.getElementById('modulation-select');
+  if (!modSel) return;
+  const res = await api.modulations();
+  if (!res.ok || !Array.isArray(res.data?.modulations)) return;
+  const current = modSel.value;
+  // Mantieni option "auto" come primo, aggiungi preset
+  for (const m of res.data.modulations) {
+    const opt = document.createElement('option');
+    opt.value = m.id;
+    const pgTotal = Array.isArray(m.pg_per_player)
+      ? m.pg_per_player.reduce((a, b) => a + b, 0)
+      : m.deployed;
+    opt.textContent = `${m.id} · ${m.players}p × ${pgTotal / m.players}PG = ${m.deployed} schierati`;
+    opt.title = m.description || '';
+    modSel.appendChild(opt);
+  }
+  modSel.value = current;
+  // Riavvia sessione se user cambia modulation (default: auto → 6x6)
+  modSel.addEventListener('change', () => startNewSession());
+}
+
+loadModulations().then(() => startNewSession());
 window.__evo = { state, api, refresh };

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -312,6 +312,11 @@ async function startNewSession() {
     return;
   }
   const modSel = document.getElementById('modulation-select');
+  // Se scenario raccomanda modulation (es. hardcore → 'full') e user non ha
+  // scelto manualmente, applica recommended (aggiorna dropdown per UI clarity).
+  if (sc.data.recommended_modulation && modSel && !modSel.value) {
+    modSel.value = sc.data.recommended_modulation;
+  }
   const modulation = modSel && modSel.value ? modSel.value : undefined;
   const startOpts = {
     sistema_pressure_start: sc.data.sistema_pressure_start || 0,

--- a/services/party/loader.js
+++ b/services/party/loader.js
@@ -1,0 +1,107 @@
+/**
+ * Party config loader — memoized.
+ * Legge data/core/party.yaml al boot. Fallback a config minimale se YAML
+ * mancante (backward compat).
+ * ADR-2026-04-17.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DEFAULT_CONFIG_PATH = path.resolve(__dirname, '..', '..', 'data', 'core', 'party.yaml');
+
+const FALLBACK = {
+  max_players_coop: 4,
+  max_deployed_per_encounter: 4,
+  max_roster_total: 8,
+  grid_scaling: { deployed_1_4: '6x6' },
+  defaults: { tutorial: 2, standard: 4, boss: 4, hardcore: 4 },
+  modulation: {
+    quartet: { description: '4 player × 1 PG', pg_per_player: [1, 1, 1, 1], deployed: 4 },
+  },
+};
+
+let _memoized = null;
+
+function loadFromDisk(configPath = DEFAULT_CONFIG_PATH) {
+  let yaml;
+  try {
+    yaml = require('js-yaml');
+  } catch {
+    return FALLBACK;
+  }
+  try {
+    const raw = fs.readFileSync(configPath, 'utf8');
+    const parsed = yaml.load(raw);
+    return (parsed && parsed.party) || FALLBACK;
+  } catch {
+    return FALLBACK;
+  }
+}
+
+function getPartyConfig() {
+  if (_memoized === null) _memoized = loadFromDisk();
+  return _memoized;
+}
+
+function resetCache() {
+  _memoized = null;
+}
+
+/**
+ * Calcola grid size [w, h] da deployed count usando party.grid_scaling.
+ * Ricava soglie da chiavi "deployed_N_M" e ritorna tuple "WxH" → [w, h].
+ */
+function gridSizeFor(deployedCount) {
+  const cfg = getPartyConfig();
+  const scaling = cfg.grid_scaling || {};
+  // Default fallback
+  let best = '6x6';
+  for (const [key, size] of Object.entries(scaling)) {
+    const m = /^deployed_(\d+)_(\d+)$/.exec(key);
+    if (!m) continue;
+    const lo = Number(m[1]);
+    const hi = Number(m[2]);
+    if (deployedCount >= lo && deployedCount <= hi) {
+      best = size;
+      break;
+    }
+  }
+  const mm = /^(\d+)x(\d+)$/.exec(best);
+  if (!mm) return [6, 6];
+  return [Number(mm[1]), Number(mm[2])];
+}
+
+/**
+ * Ritorna modulation preset by name oppure null.
+ */
+function getModulation(name) {
+  const cfg = getPartyConfig();
+  const preset = (cfg.modulation || {})[name];
+  return preset || null;
+}
+
+/**
+ * Lista nomi modulation preset disponibili.
+ */
+function listModulations() {
+  const cfg = getPartyConfig();
+  return Object.entries(cfg.modulation || {}).map(([id, data]) => ({
+    id,
+    description: data.description,
+    pg_per_player: data.pg_per_player,
+    deployed: data.deployed,
+    players: (data.pg_per_player || []).length,
+  }));
+}
+
+module.exports = {
+  getPartyConfig,
+  gridSizeFor,
+  getModulation,
+  listModulations,
+  loadFromDisk,
+  resetCache,
+  DEFAULT_CONFIG_PATH,
+  FALLBACK,
+};

--- a/tests/api/hardcoreScenario.test.js
+++ b/tests/api/hardcoreScenario.test.js
@@ -1,0 +1,70 @@
+// Test enc_tutorial_06_hardcore encounter + session /start con modulation=full
+// ADR-2026-04-17 PR 4 co-op scaling hardcore.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+test('GET /api/tutorial/enc_tutorial_06_hardcore returns 14 units + recommended modulation', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app).get('/api/tutorial/enc_tutorial_06_hardcore').expect(200);
+    assert.equal(res.body.id, 'enc_tutorial_06_hardcore');
+    assert.equal(res.body.difficulty_rating, 6);
+    assert.equal(res.body.recommended_modulation, 'full');
+    assert.equal(res.body.sistema_pressure_start, 75);
+    assert.ok(Array.isArray(res.body.units));
+    assert.equal(res.body.units.length, 14);
+    const players = res.body.units.filter((u) => u.controlled_by === 'player');
+    const enemies = res.body.units.filter((u) => u.controlled_by === 'sistema');
+    assert.equal(players.length, 8);
+    assert.equal(enemies.length, 6);
+    const boss = enemies.find((u) => u.id === 'e_apex_boss');
+    assert.ok(boss);
+    assert.equal(boss.hp, 14);
+  } finally {
+    await close();
+  }
+});
+
+test('GET /api/tutorial lists hardcore scenario', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app).get('/api/tutorial').expect(200);
+    assert.ok(Array.isArray(res.body.scenarios));
+    const hc = res.body.scenarios.find((s) => s.id === 'enc_tutorial_06_hardcore');
+    assert.ok(hc, 'hardcore scenario listed');
+    assert.equal(hc.difficulty, 6);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/session/start with hardcore units + modulation=full → grid 10x10', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const sc = await request(app).get('/api/tutorial/enc_tutorial_06_hardcore').expect(200);
+    const res = await request(app)
+      .post('/api/session/start')
+      .send({
+        units: sc.body.units,
+        sistema_pressure_start: sc.body.sistema_pressure_start,
+        modulation: sc.body.recommended_modulation,
+        hazard_tiles: sc.body.hazard_tiles,
+      })
+      .expect(200);
+    const state = await request(app)
+      .get(`/api/session/state?session_id=${res.body.session_id}`)
+      .expect(200);
+    assert.equal(state.body.grid?.width, 10);
+    assert.equal(state.body.grid?.height, 10);
+    assert.equal(state.body.grid_size, 10);
+    assert.equal(state.body.units.length, 14);
+    assert.equal(state.body.sistema_pressure, 75);
+  } finally {
+    await close();
+  }
+});

--- a/tests/api/partyRoutes.test.js
+++ b/tests/api/partyRoutes.test.js
@@ -1,0 +1,168 @@
+// Test /api/party/* endpoints + session /start modulation param.
+// ADR-2026-04-17 co-op scaling 4→8.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+test('GET /api/party/config returns party config', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app).get('/api/party/config').expect(200);
+    assert.ok(res.body.party);
+    assert.equal(res.body.party.max_players_coop, 8);
+    assert.equal(res.body.party.max_deployed_per_encounter, 8);
+  } finally {
+    await close();
+  }
+});
+
+test('GET /api/party/modulations returns 11 presets', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app).get('/api/party/modulations').expect(200);
+    assert.ok(Array.isArray(res.body.modulations));
+    assert.equal(res.body.modulations.length, 11);
+    const full = res.body.modulations.find((m) => m.id === 'full');
+    assert.ok(full);
+    assert.equal(full.deployed, 8);
+  } finally {
+    await close();
+  }
+});
+
+test('GET /api/party/modulations/:id returns preset + grid_size', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app).get('/api/party/modulations/full').expect(200);
+    assert.equal(res.body.id, 'full');
+    assert.equal(res.body.deployed, 8);
+    assert.deepEqual(res.body.grid_size, [10, 10]);
+
+    const quartet = await request(app).get('/api/party/modulations/quartet').expect(200);
+    assert.deepEqual(quartet.body.grid_size, [6, 6]);
+  } finally {
+    await close();
+  }
+});
+
+test('GET /api/party/modulations/:id 404 on unknown', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app).get('/api/party/modulations/nonexistent').expect(404);
+  } finally {
+    await close();
+  }
+});
+
+test('GET /api/party/grid-size?deployed=N maps to scaling tiers', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const r1 = await request(app).get('/api/party/grid-size?deployed=3').expect(200);
+    assert.deepEqual(r1.body.grid_size, [6, 6]);
+    const r2 = await request(app).get('/api/party/grid-size?deployed=5').expect(200);
+    assert.deepEqual(r2.body.grid_size, [8, 8]);
+    const r3 = await request(app).get('/api/party/grid-size?deployed=8').expect(200);
+    assert.deepEqual(r3.body.grid_size, [10, 10]);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/session/start with modulation scales grid', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const units = [
+      {
+        id: 'p1',
+        species: 'velox',
+        job: 'skirmisher',
+        hp: 10,
+        ap: 2,
+        attack_range: 2,
+        initiative: 14,
+        position: { x: 2, y: 2 },
+        controlled_by: 'player',
+      },
+      {
+        id: 'sis1',
+        species: 'mole',
+        job: 'tank',
+        hp: 10,
+        ap: 2,
+        attack_range: 1,
+        initiative: 10,
+        position: { x: 4, y: 4 },
+        controlled_by: 'sistema',
+      },
+    ];
+    const res = await request(app)
+      .post('/api/session/start')
+      .send({ units, modulation: 'full' })
+      .expect(200);
+    // Session state has 10x10 grid via preset 'full' (deployed=8 → 10x10)
+    const state = await request(app)
+      .get(`/api/session/state?session_id=${res.body.session_id}`)
+      .expect(200);
+    assert.ok(state.body.grid, 'session.grid exposed');
+    assert.equal(state.body.grid.width, 10);
+    assert.equal(state.body.grid.height, 10);
+    assert.equal(state.body.grid_size, 10);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/session/start without modulation defaults grid to player count', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    // 2 players → 6x6
+    const units = [
+      {
+        id: 'p1',
+        species: 'velox',
+        job: 'skirmisher',
+        hp: 10,
+        ap: 2,
+        attack_range: 2,
+        initiative: 14,
+        position: { x: 1, y: 1 },
+        controlled_by: 'player',
+      },
+      {
+        id: 'p2',
+        species: 'velox',
+        job: 'skirmisher',
+        hp: 10,
+        ap: 2,
+        attack_range: 2,
+        initiative: 13,
+        position: { x: 2, y: 2 },
+        controlled_by: 'player',
+      },
+      {
+        id: 'sis1',
+        species: 'mole',
+        job: 'tank',
+        hp: 10,
+        ap: 2,
+        attack_range: 1,
+        initiative: 10,
+        position: { x: 4, y: 4 },
+        controlled_by: 'sistema',
+      },
+    ];
+    const res = await request(app).post('/api/session/start').send({ units }).expect(200);
+    const state = await request(app)
+      .get(`/api/session/state?session_id=${res.body.session_id}`)
+      .expect(200);
+    assert.equal(state.body.grid?.width, 6);
+    assert.equal(state.body.grid?.height, 6);
+    assert.equal(state.body.grid_size, 6);
+  } finally {
+    await close();
+  }
+});


### PR DESCRIPTION
## Summary

Chiude arc co-op 4→8 (ADR-2026-04-17). Primo encounter hardcore che usa modulation \`full\` (8 player) + grid 10×10 auto-scale. Tutti i pezzi del rollout (data/engine/UI) sono ora exercised.

- **Scenario**: \`enc_tutorial_06_hardcore\` "Cattedrale dell'Apex" (difficulty 6/5)
- **Composition**: 8 player (4 skirmisher + 2 tank + 2 support) vs 6 enemy (1 BOSS Apex hp 14 + 2 elite hunter hp 7 + 3 minion nomad hp 4)
- **Grid**: 10×10 con 3 hazard tile "rovine_instabili" centrali
- **Pressure start**: 75 (Critical → 3 intents/round + swarm AI unlocked)
- **recommended_modulation**: \`full\` (UI auto-applica se user non ha scelto)

## Calibration target

| Metric | Target band | Note |
|--------|:-----------:|------|
| win_rate | 15-25% | BOSS + coord 8-way |
| turns avg | 14-18 | boss HP 14 |
| K/D player | 0.6-0.9 | tank death ok, not wipe |

Validazione da N=30 batch via master_dm.py harness — follow-up in PR4.b se band fail.

## Test plan

- [x] \`node --test tests/api/hardcoreScenario.test.js\` → 3/3 verde
- [x] \`node --test tests/api/partyRoutes.test.js\` → 7/7
- [x] \`node --test tests/ai/*.test.js tests/api/sessionRound*.test.js\` → 184/184
- [x] Smoke unit factory: 14 unit, no position conflict, no oob
- [x] Prettier format
- [ ] Smoke manuale UI: select "Tutorial 06 · HARDCORE 8p" → dropdown auto-applica full, canvas 10×10

## Rollback

Revert. Route additivo, frontend option-only. Zero breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)