### PR TITLE
play: enc_tutorial_06_hardcore — BOSS 8p vs 6 (ADR-2026-04-17 PR 4/4)

### DIFF
--- a/apps/backend/routes/tutorial.js
+++ b/apps/backend/routes/tutorial.js
@@ -22,6 +22,7 @@ const {
   buildTutorialUnits04,
   buildTutorialUnits05,
 } = require('../services/tutorialScenario');
+const { HARDCORE_SCENARIO_06, buildHardcoreUnits06 } = require('../services/hardcoreScenario');
 
 function createTutorialRouter() {
   const router = Router();
@@ -66,6 +67,14 @@ function createTutorialRouter() {
     });
   });
 
+  router.get('/enc_tutorial_06_hardcore', (_req, res) => {
+    res.json({
+      ...HARDCORE_SCENARIO_06,
+      units: buildHardcoreUnits06(),
+      usage: 'POST the units array to /api/session/start with modulation="full" to begin.',
+    });
+  });
+
   router.get('/', (_req, res) => {
     res.json({
       scenarios: [
@@ -98,6 +107,12 @@ function createTutorialRouter() {
           name: TUTORIAL_SCENARIO_05.name,
           difficulty: TUTORIAL_SCENARIO_05.difficulty_rating,
           href: `/api/tutorial/${TUTORIAL_SCENARIO_05.id}`,
+        },
+        {
+          id: HARDCORE_SCENARIO_06.id,
+          name: HARDCORE_SCENARIO_06.name,
+          difficulty: HARDCORE_SCENARIO_06.difficulty_rating,
+          href: `/api/tutorial/${HARDCORE_SCENARIO_06.id}`,
         },
       ],
     });

--- a/apps/backend/services/hardcoreScenario.js
+++ b/apps/backend/services/hardcoreScenario.js
@@ -1,0 +1,177 @@
+// Hardcore encounter — ADR-2026-04-17 co-op 4→8 scaling.
+//
+// tutorial_06_hardcore: "Cattedrale dell'Apex"
+// Party: 8 schierati (modulation full o quartet_hardcore), grid 10x10.
+// Enemy: 1 BOSS apex + 2 elite hunter + 3 minion nomad = 6.
+// Difficulty 6/5 (boss + swarm). pressure_start 75 → Critical/Apex tier.
+//
+// Baseline calibration target (atteso post batch N=30):
+//   win_rate ~15-25% (BOSS hardcore, player deve coordinarsi 8-way)
+//   turns avg ~14-18
+//   K/D ratio player ~0.6-0.9
+//
+// Se batch rivela fuori band → tune hp apex/elite in iter successive (PR4.b).
+
+'use strict';
+
+const HARDCORE_SCENARIO_06 = {
+  id: 'enc_tutorial_06_hardcore',
+  name: "Cattedrale dell'Apex",
+  biome_id: 'rovine_planari',
+  difficulty_rating: 6,
+  estimated_turns: 16,
+  grid_size: 10,
+  objective: 'elimination',
+  objective_text:
+    'Sconfiggi il BOSS Apex e i suoi 5 guardiani. Party 8 unità vs 6 nemici asimmetrici: coordina focus-fire e combo squadSync per superare la pressione massima.',
+  briefing_pre:
+    "Le rovine risuonano del passo pesante dell'Apex. Due elite cacciatori pattugliano i fianchi, tre predoni bloccano i corridoi. Party al completo (8 schierati): ogni PG conta, il focus-fire moltiplica il danno, il BOSS non perdona errori di posizionamento.",
+  briefing_post:
+    "L'Apex è caduto. La cattedrale si quieta. Avete dimostrato che 8 mani battono una mandibola.",
+  hazard_tiles: [
+    { x: 4, y: 4, damage: 1, type: 'rovine_instabili' },
+    { x: 5, y: 5, damage: 1, type: 'rovine_instabili' },
+    { x: 3, y: 6, damage: 1, type: 'rovine_instabili' },
+  ],
+  sistema_pressure_start: 75, // Critical: 3 intents/round + swarm AI unlocked
+  recommended_modulation: 'full', // 8p × 1 PG → grid 10x10 auto
+};
+
+function buildHardcoreUnits06() {
+  const players = [];
+  // 8 player PG — mix specie/job per composition leggibile.
+  // 4 skirmisher (ranged dmg) + 2 vanguard (tank frontline) + 2 support.
+  const playerLayouts = [
+    { id: 'p_scout_1', job: 'skirmisher', pos: [0, 2], hp: 10, mod: 3, dc: 12 },
+    { id: 'p_scout_2', job: 'skirmisher', pos: [0, 4], hp: 10, mod: 3, dc: 12 },
+    { id: 'p_scout_3', job: 'skirmisher', pos: [0, 6], hp: 10, mod: 3, dc: 12 },
+    { id: 'p_scout_4', job: 'skirmisher', pos: [0, 8], hp: 10, mod: 3, dc: 12 },
+    { id: 'p_tank_1', job: 'vanguard', pos: [1, 3], hp: 14, mod: 2, dc: 14 },
+    { id: 'p_tank_2', job: 'vanguard', pos: [1, 7], hp: 14, mod: 2, dc: 14 },
+    { id: 'p_support_1', job: 'skirmisher', pos: [1, 1], hp: 11, mod: 3, dc: 13 },
+    { id: 'p_support_2', job: 'skirmisher', pos: [1, 5], hp: 11, mod: 3, dc: 13 },
+  ];
+  for (const pl of playerLayouts) {
+    players.push({
+      id: pl.id,
+      species: 'dune_stalker',
+      job: pl.job,
+      traits: pl.job === 'vanguard' ? ['pelle_elastomera'] : ['zampe_a_molla'],
+      hp: pl.hp,
+      ap: 2, // SoT canonical
+      mod: pl.mod,
+      dc: pl.dc,
+      guardia: pl.job === 'vanguard' ? 2 : 1,
+      position: { x: pl.pos[0], y: pl.pos[1] },
+      controlled_by: 'player',
+      facing: 'E',
+    });
+  }
+
+  const enemies = [
+    // BOSS Apex (center-right) — HP alto, crit bonus, attack_range 2.
+    // Baseline: hp 14 mod 4 dc 14 (più duro del tutorial_05 hp 11).
+    {
+      id: 'e_apex_boss',
+      species: 'apex_predatore',
+      job: 'vanguard',
+      traits: ['martello_osseo', 'ferocia'],
+      hp: 14,
+      ap: 3,
+      mod: 4,
+      dc: 14,
+      guardia: 2,
+      attack_range: 2,
+      position: { x: 8, y: 5 },
+      controlled_by: 'sistema',
+      ai_profile: 'aggressive',
+      facing: 'W',
+    },
+    // 2 elite hunter — flanking, mod 3, hp 7.
+    {
+      id: 'e_elite_hunter_1',
+      species: 'cacciatore_corazzato',
+      job: 'vanguard',
+      traits: [],
+      hp: 7,
+      ap: 2,
+      mod: 3,
+      dc: 13,
+      guardia: 1,
+      attack_range: 2,
+      position: { x: 7, y: 2 },
+      controlled_by: 'sistema',
+      ai_profile: 'aggressive',
+      facing: 'W',
+    },
+    {
+      id: 'e_elite_hunter_2',
+      species: 'cacciatore_corazzato',
+      job: 'vanguard',
+      traits: [],
+      hp: 7,
+      ap: 2,
+      mod: 3,
+      dc: 13,
+      guardia: 1,
+      attack_range: 2,
+      position: { x: 7, y: 8 },
+      controlled_by: 'sistema',
+      ai_profile: 'aggressive',
+      facing: 'W',
+    },
+    // 3 minion nomad — fragili ma numerosi, mod 2 hp 4.
+    {
+      id: 'e_minion_1',
+      species: 'predoni_nomadi',
+      job: 'skirmisher',
+      traits: [],
+      hp: 4,
+      ap: 2,
+      mod: 2,
+      dc: 11,
+      guardia: 0,
+      attack_range: 1,
+      position: { x: 6, y: 4 },
+      controlled_by: 'sistema',
+      facing: 'W',
+    },
+    {
+      id: 'e_minion_2',
+      species: 'predoni_nomadi',
+      job: 'skirmisher',
+      traits: [],
+      hp: 4,
+      ap: 2,
+      mod: 2,
+      dc: 11,
+      guardia: 0,
+      attack_range: 1,
+      position: { x: 6, y: 6 },
+      controlled_by: 'sistema',
+      facing: 'W',
+    },
+    {
+      id: 'e_minion_3',
+      species: 'predoni_nomadi',
+      job: 'skirmisher',
+      traits: [],
+      hp: 4,
+      ap: 2,
+      mod: 2,
+      dc: 11,
+      guardia: 0,
+      attack_range: 1,
+      position: { x: 9, y: 5 },
+      controlled_by: 'sistema',
+      facing: 'W',
+    },
+  ];
+
+  return [...players, ...enemies];
+}
+
+module.exports = {
+  HARDCORE_SCENARIO_06,
+  buildHardcoreUnits06,
+};

--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -29,6 +29,7 @@
               <option value="enc_tutorial_03">Tutorial 03 · Hazard savana</option>
               <option value="enc_tutorial_04">Tutorial 04 · Bleeding foresta</option>
               <option value="enc_tutorial_05">Tutorial 05 · BOSS Apex</option>
+              <option value="enc_tutorial_06_hardcore">Tutorial 06 · HARDCORE 8p</option>
             </select>
             <select id="modulation-select" title="Party composition (co-op 1-8 player)">
               <option value="">Party: auto</option>

--- a/apps/play/src/endgame.js
+++ b/apps/play/src/endgame.js
@@ -103,6 +103,7 @@ export function nextScenarioId(current) {
     'enc_tutorial_03',
     'enc_tutorial_04',
     'enc_tutorial_05',
+    'enc_tutorial_06_hardcore',
   ];
   const idx = order.indexOf(current);
   if (idx < 0 || idx >= order.length - 1) return order[0]; // loop to start

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -312,6 +312,11 @@ async function startNewSession() {
     return;
   }
   const modSel = document.getElementById('modulation-select');
+  // Se scenario raccomanda modulation (es. hardcore → 'full') e user non ha
+  // scelto manualmente, applica recommended (aggiorna dropdown per UI clarity).
+  if (sc.data.recommended_modulation && modSel && !modSel.value) {
+    modSel.value = sc.data.recommended_modulation;
+  }
   const modulation = modSel && modSel.value ? modSel.value : undefined;
   const startOpts = {
     sistema_pressure_start: sc.data.sistema_pressure_start || 0,

--- a/tests/api/hardcoreScenario.test.js
+++ b/tests/api/hardcoreScenario.test.js
@@ -1,0 +1,70 @@
+// Test enc_tutorial_06_hardcore encounter + session /start con modulation=full
+// ADR-2026-04-17 PR 4 co-op scaling hardcore.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+test('GET /api/tutorial/enc_tutorial_06_hardcore returns 14 units + recommended modulation', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app).get('/api/tutorial/enc_tutorial_06_hardcore').expect(200);
+    assert.equal(res.body.id, 'enc_tutorial_06_hardcore');
+    assert.equal(res.body.difficulty_rating, 6);
+    assert.equal(res.body.recommended_modulation, 'full');
+    assert.equal(res.body.sistema_pressure_start, 75);
+    assert.ok(Array.isArray(res.body.units));
+    assert.equal(res.body.units.length, 14);
+    const players = res.body.units.filter((u) => u.controlled_by === 'player');
+    const enemies = res.body.units.filter((u) => u.controlled_by === 'sistema');
+    assert.equal(players.length, 8);
+    assert.equal(enemies.length, 6);
+    const boss = enemies.find((u) => u.id === 'e_apex_boss');
+    assert.ok(boss);
+    assert.equal(boss.hp, 14);
+  } finally {
+    await close();
+  }
+});
+
+test('GET /api/tutorial lists hardcore scenario', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app).get('/api/tutorial').expect(200);
+    assert.ok(Array.isArray(res.body.scenarios));
+    const hc = res.body.scenarios.find((s) => s.id === 'enc_tutorial_06_hardcore');
+    assert.ok(hc, 'hardcore scenario listed');
+    assert.equal(hc.difficulty, 6);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/session/start with hardcore units + modulation=full → grid 10x10', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const sc = await request(app).get('/api/tutorial/enc_tutorial_06_hardcore').expect(200);
+    const res = await request(app)
+      .post('/api/session/start')
+      .send({
+        units: sc.body.units,
+        sistema_pressure_start: sc.body.sistema_pressure_start,
+        modulation: sc.body.recommended_modulation,
+        hazard_tiles: sc.body.hazard_tiles,
+      })
+      .expect(200);
+    const state = await request(app)
+      .get(`/api/session/state?session_id=${res.body.session_id}`)
+      .expect(200);
+    assert.equal(state.body.grid?.width, 10);
+    assert.equal(state.body.grid?.height, 10);
+    assert.equal(state.body.grid_size, 10);
+    assert.equal(state.body.units.length, 14);
+    assert.equal(state.body.sistema_pressure, 75);
+  } finally {
+    await close();
+  }
+});


### PR DESCRIPTION
Replaces closed #1533 (branch was deleted; rebased on fresh main).

## Summary

Chiude arc co-op 4→8 (ADR-2026-04-17). Primo encounter hardcore che usa modulation \`full\` (8 player) + grid 10×10 auto-scale.

- Scenario \`enc_tutorial_06_hardcore\` "Cattedrale dell'Apex" (difficulty 6/5)
- 8 player (4 skirmisher + 2 tank + 2 support) vs 6 enemy (1 BOSS Apex hp 14 + 2 elite hp 7 + 3 minion hp 4)
- Grid 10×10, 3 hazard tile, pressure_start 75 (Critical tier)
- \`recommended_modulation: 'full'\` → UI auto-applica

## Calibration target

win_rate 15-25% · turns avg 14-18 · K/D 0.6-0.9. Validazione via N=30 batch follow-up.

## Test plan

- [x] 10/10 test verdi (hardcore + party routes)
- [x] Full sweep 194/194

🤖 Generated with [Claude Code](https://claude.com/claude-code)