### PR TITLE
play(balance): hardcore_06 iter 1 — boss hp +57%, +1 elite (PR4.b)

### DIFF
--- a/apps/backend/services/hardcoreScenario.js
+++ b/apps/backend/services/hardcoreScenario.js
@@ -2,15 +2,16 @@
 //
 // tutorial_06_hardcore: "Cattedrale dell'Apex"
 // Party: 8 schierati (modulation full o quartet_hardcore), grid 10x10.
-// Enemy: 1 BOSS apex + 2 elite hunter + 3 minion nomad = 6.
+// Enemy: 1 BOSS apex + 3 elite hunter + 3 minion nomad = 7 (iter 1).
 // Difficulty 6/5 (boss + swarm). pressure_start 75 → Critical/Apex tier.
 //
-// Baseline calibration target (atteso post batch N=30):
-//   win_rate ~15-25% (BOSS hardcore, player deve coordinarsi 8-way)
-//   turns avg ~14-18
-//   K/D ratio player ~0.6-0.9
+// Calibration history:
+//   iter 0 (PR #1534): boss hp 14, 2 elite hp 7. N=13 → 84.6% win, fuori band.
+//     Vedi docs/playtest/2026-04-18-hardcore-06-calibration.md.
+//   iter 1 (PR4.b): boss hp 14→22 (+57%) guardia 2→3, +1 elite (3 totali)
+//     hp 7→9 (+29%). Target post-tune win 25-40%.
 //
-// Se batch rivela fuori band → tune hp apex/elite in iter successive (PR4.b).
+// Se iter1 ancora >50% win → iter 2: +1 minion, boss mod 4→5, hazard dmg 1→2.
 
 'use strict';
 
@@ -23,9 +24,9 @@ const HARDCORE_SCENARIO_06 = {
   grid_size: 10,
   objective: 'elimination',
   objective_text:
-    'Sconfiggi il BOSS Apex e i suoi 5 guardiani. Party 8 unità vs 6 nemici asimmetrici: coordina focus-fire e combo squadSync per superare la pressione massima.',
+    'Sconfiggi il BOSS Apex e i suoi 6 guardiani. Party 8 unità vs 7 nemici asimmetrici: coordina focus-fire e combo squadSync per superare la pressione massima.',
   briefing_pre:
-    "Le rovine risuonano del passo pesante dell'Apex. Due elite cacciatori pattugliano i fianchi, tre predoni bloccano i corridoi. Party al completo (8 schierati): ogni PG conta, il focus-fire moltiplica il danno, il BOSS non perdona errori di posizionamento.",
+    "Le rovine risuonano del passo pesante dell'Apex. Tre elite cacciatori controllano i fianchi e il centro, tre predoni bloccano i corridoi. Party al completo (8 schierati): ogni PG conta, il focus-fire moltiplica il danno, il BOSS non perdona errori di posizionamento.",
   briefing_post:
     "L'Apex è caduto. La cattedrale si quieta. Avete dimostrato che 8 mani battono una mandibola.",
   hazard_tiles: [
@@ -70,30 +71,34 @@ function buildHardcoreUnits06() {
 
   const enemies = [
     // BOSS Apex (center-right) — HP alto, crit bonus, attack_range 2.
-    // Baseline: hp 14 mod 4 dc 14 (più duro del tutorial_05 hp 11).
+    // Iter 0 (PR #1534): hp 14 mod 4 dc 14 guardia 2.
+    // Iter 1 (PR4.b post calibration N=13 → 84.6% win rate, target 15-25%):
+    //   hp 14→22 (+57%), guardia 2→3 (+1 dmg reduction). Boss deve sopravvivere
+    //   8-12 round invece di 5-8 (player kill-time troppo veloce con 8p swarm).
     {
       id: 'e_apex_boss',
       species: 'apex_predatore',
       job: 'vanguard',
       traits: ['martello_osseo', 'ferocia'],
-      hp: 14,
+      hp: 22,
       ap: 3,
       mod: 4,
       dc: 14,
-      guardia: 2,
+      guardia: 3,
       attack_range: 2,
       position: { x: 8, y: 5 },
       controlled_by: 'sistema',
       ai_profile: 'aggressive',
       facing: 'W',
     },
-    // 2 elite hunter — flanking, mod 3, hp 7.
+    // 3 elite hunter — flanking + mid (iter 1: +1 elite + hp 7→9).
+    // Spread aggro, force player split focus-fire.
     {
       id: 'e_elite_hunter_1',
       species: 'cacciatore_corazzato',
       job: 'vanguard',
       traits: [],
-      hp: 7,
+      hp: 9,
       ap: 2,
       mod: 3,
       dc: 13,
@@ -109,13 +114,29 @@ function buildHardcoreUnits06() {
       species: 'cacciatore_corazzato',
       job: 'vanguard',
       traits: [],
-      hp: 7,
+      hp: 9,
       ap: 2,
       mod: 3,
       dc: 13,
       guardia: 1,
       attack_range: 2,
       position: { x: 7, y: 8 },
+      controlled_by: 'sistema',
+      ai_profile: 'aggressive',
+      facing: 'W',
+    },
+    {
+      id: 'e_elite_hunter_3',
+      species: 'cacciatore_corazzato',
+      job: 'vanguard',
+      traits: [],
+      hp: 9,
+      ap: 2,
+      mod: 3,
+      dc: 13,
+      guardia: 1,
+      attack_range: 2,
+      position: { x: 7, y: 5 },
       controlled_by: 'sistema',
       ai_profile: 'aggressive',
       facing: 'W',

--- a/docs/playtest/2026-04-18-hardcore-06-calibration.md
+++ b/docs/playtest/2026-04-18-hardcore-06-calibration.md
@@ -1,0 +1,105 @@
+---
+title: 'Hardcore_06 Calibration Batch — iter 0 baseline'
+workstream: ops-qa
+type: playtest
+status: active
+owners: ['MasterDD']
+created: '2026-04-18'
+related:
+  - docs/adr/ADR-2026-04-17-coop-scaling-4to8.md
+  - apps/backend/services/hardcoreScenario.js
+---
+
+# Hardcore_06 Calibration — iter 0 baseline (PR #1534 baseline)
+
+## TL;DR
+
+`enc_tutorial_06_hardcore` baseline (boss hp 14, 2 elite hp 7, 3 minion hp 4) **TROPPO FACILE**. Win rate 84.6% (target 15-25%), turns avg 32 (target 14-18). Tune iter1 proposto: boss hp +50%, +1 elite, eventuale -1 player support.
+
+## Setup
+
+- Scenario: `enc_tutorial_06_hardcore`
+- Modulation: `full` (8p × 1 PG, grid 10×10)
+- Pressure start: 75 (Critical tier)
+- Player policy: greedy nearest-enemy (skirmisher minion-first, boss last)
+- AI policy: data-driven `aggressive` profile (Utility brain ON)
+- Harness: `tools/py/batch_calibrate_hardcore06.py`
+- Backend port: 3340
+- Run target: N=30
+- **Run effettivi: N=13** (backend morì al run #14, EADDRINUSE/crash inspiegato)
+
+## Aggregate (N=13)
+
+| Metric                    | Value                 | Target |           Status           |
+| ------------------------- | --------------------- | ------ | :------------------------: |
+| **win_rate**              | 84.6% (11V / 0L / 2T) | 15-25% |  🔴 **+59pp out of band**  |
+| **boss_kill_rate**        | 84.6%                 | n/a    |             —              |
+| **turns_avg**             | 32.2                  | 14-18  |      🔴 **+14 above**      |
+| **turns_median**          | 33                    | —      |             —              |
+| **turns_min**             | 23                    | —      |             —              |
+| **turns_max**             | 41 (timeout)          | —      |             —              |
+| **players_alive_avg**     | 5.4 / 8               | 4-6    |         🟢 in band         |
+| **boss_hp_remaining_avg** | 0.6 / 14              | 5-9    | 🔴 boss muore quasi sempre |
+
+## Per-run
+
+| #   | Outcome | Rounds | Boss HP | Players Alive |
+| --- | :-----: | -----: | ------: | ------------: |
+| 1   |    V    |     30 |       0 |             5 |
+| 2   |    V    |     27 |       0 |             6 |
+| 3   |    V    |     23 |       0 |             5 |
+| 4   |    V    |     33 |       0 |             5 |
+| 5   |    V    |     32 |       0 |             5 |
+| 6   |    V    |     23 |       0 |             5 |
+| 7   |    V    |     27 |       0 |             5 |
+| 8   |  **T**  |     41 |       2 |             6 |
+| 9   |    V    |     35 |       0 |             7 |
+| 10  |  **T**  |     41 |       6 |             5 |
+| 11  |    V    |     35 |       0 |             5 |
+| 12  |    V    |     37 |       0 |             6 |
+| 13  |    V    |     34 |       0 |             5 |
+
+(V=victory, T=timeout MAX_ROUNDS=41, L=defeat)
+
+## Diagnosi
+
+1. **Player swarm overwhelms BOSS**: 8 player vs 1 boss + 5 enemies → focus-fire + aggro-spread = boss muore prima di 1-shottare nessuno
+2. **Boss hp 14 troppo basso**: 8 player @ ~3 dmg/turn × 2-3 round in range = 50-70 dmg/round potenziale → kill in ~5-8 round se tutti convergono
+3. **Player_alive_avg 5.4** indica boss/elite uccidono ~3 player ma non bastano (5 sopravvivono)
+4. **Turn count 32** non per difficoltà ma per **movement overhead 8p su grid 10x10**: 2-3 round per posizionarsi
+5. **2 timeout**: anche quando boss sopravvive, player non muoiono (T=41 con boss hp 2/6, players 5-6)
+
+## Bias N=13 (vs N=30 target)
+
+- Sample piccolo ma signal extreme (84.6% vs 15-25% target = 4 stdev fuori band con tipica binomial p=0.2)
+- Anche se i restanti 17 fossero tutti L/T, win_rate min = 11/30 = 36.7% → ancora fuori band
+- Conclusione: tune è giustificato senza completare N=30
+
+## Tune iter1 proposto
+
+| Stat                   | Iter 0 |   Iter 1   | Δ       | Razionale                             |
+| ---------------------- | :----: | :--------: | ------- | ------------------------------------- |
+| `e_apex_boss.hp`       |   14   |   **22**   | +57%    | Sopravvivere 8-12 round invece di 5-8 |
+| `e_apex_boss.mod`      |   4    |     4      | 0       | Mantenere offensive output            |
+| `e_apex_boss.guardia`  |   2    |   **3**    | +1      | Più dmg reduction                     |
+| `e_elite_hunter_*.hp`  |   7    |   **9**    | +29%    | Sopravvivere 1 round in più           |
+| Add `e_elite_hunter_3` |   —    | hp 9 mod 3 | +1 unit | Spread aggro player                   |
+| `e_minion_*.hp`        |   4    |     4      | 0       | Restano fragili, OK                   |
+| Player count           |   8    |     8      | 0       | Mantenere full modulation test        |
+
+**Target post-tune**: win_rate 25-40% (band leggermente più larga), turns avg 18-24, boss_hp_remaining_avg 3-6 on win, player_alive_avg 3-5.
+
+Iter2 conditional (se iter1 ancora >50% win): +1 minion, boss mod 4→5, hazard tiles damage 1→2.
+
+## Backlog tickets
+
+- **TKT-08**: backend stability under batch load — investigare crash al run #14, valutare keep-alive / health endpoint / restart loop
+- **TKT-09**: ai_intent_distribution e dmg_dealt/taken per-actor non emessi via /round/execute — script aggregava 0 per `ai_intent_distribution` (vuoto). Verifica `ai_result.ia_actions` shape canonical
+- **TKT-10**: harness resilience — script crasha su connection refused, dovrebbe retry+resume (write JSONL incrementale)
+- **TKT-11**: predict_combat boss vs full party 8p — sanity check teorico danno aggregato per-round
+
+## Action items
+
+- [ ] PR4.b: applica tune iter1 in `apps/backend/services/hardcoreScenario.js`
+- [ ] Re-run N=30 batch dopo TKT-08 (+ TKT-10) risolti
+- [ ] Update sprint context CLAUDE.md con calibration arc

--- a/tests/api/hardcoreScenario.test.js
+++ b/tests/api/hardcoreScenario.test.js
@@ -17,14 +17,19 @@ test('GET /api/tutorial/enc_tutorial_06_hardcore returns 14 units + recommended 
     assert.equal(res.body.recommended_modulation, 'full');
     assert.equal(res.body.sistema_pressure_start, 75);
     assert.ok(Array.isArray(res.body.units));
-    assert.equal(res.body.units.length, 14);
+    // iter 1 (PR4.b): +1 elite, totale 8 player + 7 enemy = 15.
+    assert.equal(res.body.units.length, 15);
     const players = res.body.units.filter((u) => u.controlled_by === 'player');
     const enemies = res.body.units.filter((u) => u.controlled_by === 'sistema');
     assert.equal(players.length, 8);
-    assert.equal(enemies.length, 6);
+    assert.equal(enemies.length, 7);
     const boss = enemies.find((u) => u.id === 'e_apex_boss');
     assert.ok(boss);
-    assert.equal(boss.hp, 14);
+    assert.equal(boss.hp, 22); // iter 1: 14→22
+    assert.equal(boss.guardia, 3); // iter 1: 2→3
+    const elite3 = enemies.find((u) => u.id === 'e_elite_hunter_3');
+    assert.ok(elite3, 'iter 1 third elite present');
+    assert.equal(elite3.hp, 9);
   } finally {
     await close();
   }
@@ -62,7 +67,7 @@ test('POST /api/session/start with hardcore units + modulation=full → grid 10x
     assert.equal(state.body.grid?.width, 10);
     assert.equal(state.body.grid?.height, 10);
     assert.equal(state.body.grid_size, 10);
-    assert.equal(state.body.units.length, 14);
+    assert.equal(state.body.units.length, 15);
     assert.equal(state.body.sistema_pressure, 75);
   } finally {
     await close();

--- a/tools/py/batch_calibrate_hardcore06.py
+++ b/tools/py/batch_calibrate_hardcore06.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Batch calibration runner — enc_tutorial_06_hardcore (PR #1534).
+
+Greedy player policy (atk-closest), AI auto. N=30 default.
+Target: win_rate 15-25%, turns 14-18, K/D 0.6-0.9.
+"""
+
+import argparse
+import json
+import statistics
+import sys
+import time
+import urllib.error
+import urllib.request
+
+SCENARIO_ID = "enc_tutorial_06_hardcore"
+MAX_ROUNDS = 40
+DEFAULT_HOST = "http://localhost:3340"
+
+
+def post(url, body):
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"}, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return r.status, json.loads(r.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        try:
+            return e.code, json.loads(e.read().decode("utf-8"))
+        except Exception:
+            return e.code, {"error": str(e)}
+
+
+def get(url):
+    try:
+        with urllib.request.urlopen(url, timeout=15) as r:
+            return r.status, json.loads(r.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        return e.code, {"error": str(e)}
+
+
+def pressure_tier(p):
+    if p < 25: return "Low"
+    if p < 50: return "Medium"
+    if p < 75: return "High"
+    if p < 90: return "Critical"
+    return "Apex"
+
+
+def manhattan(a, b):
+    return abs(a["x"] - b["x"]) + abs(a["y"] - b["y"])
+
+
+def step_toward(src, dst, grid_w, grid_h):
+    dx = dst["x"] - src["x"]
+    dy = dst["y"] - src["y"]
+    nx, ny = src["x"], src["y"]
+    # Prefer axis with larger diff (greedy orthogonal 1-step).
+    if abs(dx) >= abs(dy) and dx != 0:
+        nx += 1 if dx > 0 else -1
+    elif dy != 0:
+        ny += 1 if dy > 0 else -1
+    nx = max(0, min(grid_w - 1, nx))
+    ny = max(0, min(grid_h - 1, ny))
+    return {"x": nx, "y": ny}
+
+
+def plan_player_intents(state, occupied):
+    units = state.get("units", [])
+    grid = state.get("grid", {})
+    gw, gh = grid.get("width", 10), grid.get("height", 10)
+    players = [u for u in units if u.get("controlled_by") == "player" and u.get("hp", 0) > 0]
+    enemies = [u for u in units if u.get("controlled_by") == "sistema" and u.get("hp", 0) > 0]
+    if not enemies:
+        return []
+
+    # Prioritize BOSS last (focus minions first for swarm reduction).
+    def enemy_priority(e):
+        if e["id"] == "e_apex_boss":
+            return 2
+        if "elite" in e["id"]:
+            return 1
+        return 0
+
+    intents = []
+    reserved = {(u["position"]["x"], u["position"]["y"]) for u in units if u.get("hp", 0) > 0}
+
+    for pl in players:
+        ap = pl.get("ap_remaining", pl.get("ap", 2))
+        if ap <= 0:
+            continue
+        rng = pl.get("attack_range", 1)
+        # Nearest enemy (prefer lower priority = minions first).
+        enemies_sorted = sorted(enemies, key=lambda e: (enemy_priority(e), manhattan(pl["position"], e["position"])))
+        target = enemies_sorted[0]
+        dist = manhattan(pl["position"], target["position"])
+        if dist <= rng and ap >= 1:
+            intents.append({"actor_id": pl["id"], "action": {"type": "attack", "target_id": target["id"]}})
+        elif ap >= 2:
+            new_pos = step_toward(pl["position"], target["position"], gw, gh)
+            if (new_pos["x"], new_pos["y"]) in reserved:
+                # Try alt axis.
+                alt = step_toward(pl["position"], {"x": target["position"]["x"] + 1, "y": target["position"]["y"]}, gw, gh)
+                if (alt["x"], alt["y"]) not in reserved:
+                    new_pos = alt
+            # Move then attack if now in range, else skip atk.
+            intents.append({"actor_id": pl["id"], "action": {"type": "move", "position": new_pos}})
+            new_dist = manhattan(new_pos, target["position"])
+            if new_dist <= rng and ap >= 2:
+                intents.append({"actor_id": pl["id"], "action": {"type": "attack", "target_id": target["id"]}})
+            reserved.discard((pl["position"]["x"], pl["position"]["y"]))
+            reserved.add((new_pos["x"], new_pos["y"]))
+        else:
+            intents.append({"actor_id": pl["id"], "action": {"type": "skip"}})
+    return intents
+
+
+def detect_outcome(state):
+    units = state.get("units", [])
+    pa = [u for u in units if u.get("controlled_by") == "player" and u.get("hp", 0) > 0]
+    ea = [u for u in units if u.get("controlled_by") == "sistema" and u.get("hp", 0) > 0]
+    if not pa: return "defeat"
+    if not ea: return "victory"
+    return None
+
+
+def run_one(host, run_idx):
+    # Fetch scenario.
+    status, sc = get(f"{host}/api/tutorial/{SCENARIO_ID}")
+    if status != 200:
+        return {"error": f"fetch scenario failed: {sc}"}
+    units = sc["units"]
+    hazard = sc.get("hazard_tiles", [])
+    pstart = sc.get("sistema_pressure_start", 75)
+
+    # Start.
+    status, start = post(f"{host}/api/session/start", {
+        "units": units,
+        "modulation": "full",
+        "sistema_pressure_start": pstart,
+        "hazard_tiles": hazard,
+    })
+    if status != 200:
+        return {"error": f"session/start failed: {start}"}
+    sid = start["session_id"]
+    state = start["state"]
+
+    ai_intent_tally = {}  # type -> count per tier
+    pressure_samples = []
+    dmg_to_boss = 0
+    initial_units = {u["id"]: dict(u) for u in units}
+
+    outcome = None
+    for rnd in range(1, MAX_ROUNDS + 1):
+        outcome = detect_outcome(state)
+        if outcome:
+            break
+        intents = plan_player_intents(state, None)
+        status, resp = post(f"{host}/api/session/round/execute", {
+            "session_id": sid,
+            "player_intents": intents,
+            "ai_auto": True,
+            "priority_queue": True,
+        })
+        if status != 200:
+            # End round if e.g. session already terminated; try to read state.
+            st_status, st = get(f"{host}/api/session/state?session_id={sid}")
+            if st_status == 200:
+                state = st
+                outcome = detect_outcome(state)
+            break
+        state = resp.get("state", state)
+        pressure_samples.append(state.get("sistema_pressure", pstart))
+
+        # Tally AI actions (ia_actions).
+        ai_res = resp.get("ai_result") or {}
+        for a in ai_res.get("ia_actions", []):
+            tier = pressure_tier(state.get("sistema_pressure", pstart))
+            key = (tier, a.get("type", "unknown"))
+            ai_intent_tally[key] = ai_intent_tally.get(key, 0) + 1
+
+    if outcome is None:
+        outcome = detect_outcome(state) or "timeout"
+
+    # Final metrics.
+    final_units = {u["id"]: u for u in state.get("units", [])}
+    players_alive = sum(1 for u in final_units.values() if u.get("controlled_by") == "player" and u.get("hp", 0) > 0)
+    players_dead = sum(1 for u in final_units.values() if u.get("controlled_by") == "player" and u.get("hp", 0) <= 0)
+    enemies_alive = sum(1 for u in final_units.values() if u.get("controlled_by") == "sistema" and u.get("hp", 0) > 0)
+    enemies_dead = sum(1 for u in final_units.values() if u.get("controlled_by") == "sistema" and u.get("hp", 0) <= 0)
+    dmg_dealt_player = sum(max(0, initial_units[u_id]["hp"] - u.get("hp", 0))
+                           for u_id, u in final_units.items() if u.get("controlled_by") == "sistema")
+    dmg_taken_player = sum(max(0, initial_units[u_id]["hp"] - u.get("hp", 0))
+                           for u_id, u in final_units.items() if u.get("controlled_by") == "player")
+    boss_hp_remaining = final_units.get("e_apex_boss", {}).get("hp", 0)
+
+    # VC scores.
+    vc_status, vc = get(f"{host}/api/session/{sid}/vc")
+    vc_data = vc if vc_status == 200 else {}
+
+    # Cleanup.
+    post(f"{host}/api/session/end", {"session_id": sid})
+
+    return {
+        "run": run_idx,
+        "outcome": outcome,
+        "rounds": state.get("turn", 0),
+        "players_alive": players_alive,
+        "players_dead": players_dead,
+        "enemies_alive": enemies_alive,
+        "enemies_dead": enemies_dead,
+        "dmg_dealt_player": dmg_dealt_player,
+        "dmg_taken_player": dmg_taken_player,
+        "boss_hp_remaining": boss_hp_remaining,
+        "pressure_final": pressure_samples[-1] if pressure_samples else pstart,
+        "ai_intent_tally": {f"{t}|{a}": c for (t, a), c in ai_intent_tally.items()},
+        "vc": {
+            "mbti": vc_data.get("mbti"),
+            "ennea": vc_data.get("ennea"),
+            "aggregate": vc_data.get("aggregate"),
+        },
+    }
+
+
+def aggregate(runs):
+    ok = [r for r in runs if "error" not in r]
+    if not ok:
+        return {"error": "no successful runs"}
+    wins = [r for r in ok if r["outcome"] == "victory"]
+    losses = [r for r in ok if r["outcome"] == "defeat"]
+    timeouts = [r for r in ok if r["outcome"] == "timeout"]
+    turns = [r["rounds"] for r in ok]
+    kd = []
+    for r in ok:
+        d = r["players_dead"] or 0
+        k = r["enemies_dead"] or 0
+        kd.append(k / d if d > 0 else float(k))
+    # Aggregate AI intent distribution by tier.
+    ai_global = {}
+    for r in ok:
+        for k, v in r["ai_intent_tally"].items():
+            ai_global[k] = ai_global.get(k, 0) + v
+
+    return {
+        "N": len(ok),
+        "win_rate": len(wins) / len(ok),
+        "win_count": len(wins),
+        "loss_count": len(losses),
+        "timeout_count": len(timeouts),
+        "turns_avg": statistics.mean(turns),
+        "turns_median": statistics.median(turns),
+        "turns_stdev": statistics.pstdev(turns) if len(turns) > 1 else 0.0,
+        "turns_min": min(turns),
+        "turns_max": max(turns),
+        "turns_hist": _hist(turns, bins=[(1,5),(6,10),(11,15),(16,20),(21,30),(31,40)]),
+        "kd_avg": statistics.mean(kd),
+        "kd_median": statistics.median(kd),
+        "dmg_dealt_avg": statistics.mean(r["dmg_dealt_player"] for r in ok),
+        "dmg_taken_avg": statistics.mean(r["dmg_taken_player"] for r in ok),
+        "boss_hp_remaining_avg_on_loss": (
+            statistics.mean(r["boss_hp_remaining"] for r in losses) if losses else None
+        ),
+        "players_alive_avg_on_win": (
+            statistics.mean(r["players_alive"] for r in wins) if wins else None
+        ),
+        "ai_intent_distribution": ai_global,
+    }
+
+
+def _hist(values, bins):
+    out = {}
+    for lo, hi in bins:
+        label = f"{lo}-{hi}"
+        out[label] = sum(1 for v in values if lo <= v <= hi)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default=DEFAULT_HOST)
+    ap.add_argument("--n", type=int, default=30)
+    ap.add_argument("--out", default=None, help="JSON output path")
+    args = ap.parse_args()
+
+    runs = []
+    t0 = time.time()
+    for i in range(args.n):
+        r = run_one(args.host, i)
+        runs.append(r)
+        mark = "V" if r.get("outcome") == "victory" else "L" if r.get("outcome") == "defeat" else "T" if r.get("outcome") == "timeout" else "E"
+        print(f"[{i+1}/{args.n}] {mark} rounds={r.get('rounds','?')} boss_hp={r.get('boss_hp_remaining','?')} pa={r.get('players_alive','?')}", flush=True)
+    elapsed = time.time() - t0
+    agg = aggregate(runs)
+    agg["elapsed_sec"] = round(elapsed, 1)
+
+    out = {"aggregate": agg, "runs": runs}
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as f:
+            json.dump(out, f, indent=2)
+        print(f"\nWrote {args.out}")
+    print("\n=== AGGREGATE ===")
+    print(json.dumps(agg, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Calibration tune iter 1 post batch N=13 su PR #1534. Baseline = **84.6% win rate** (target 15-25%) → over-easy boss + swarm under-pressure.

### Changes
- \`e_apex_boss\`: hp 14→**22** (+57%), guardia 2→**3**
- \`e_elite_hunter_*\`: hp 7→**9** (+29%)
- **+\`e_elite_hunter_3\`** new (hp 9, pos 7,5)
- Totale: 14 unit → **15 unit** (8p vs 7e)

### Tools + report
- \`tools/py/batch_calibrate_hardcore06.py\` — N-run harness greedy player
- \`docs/playtest/2026-04-18-hardcore-06-calibration.md\` — full report

## Calibration data (N=13 baseline)

| Metric | Value | Target | Status |
|---|---|---|:-:|
| win_rate | 84.6% (11V/0L/2T) | 15-25% | 🔴 |
| turns_avg | 32.2 | 14-18 | 🔴 |
| boss_hp_remain | 0.6/14 | 5-9 | 🔴 |
| players_alive | 5.4/8 | 4-6 | 🟢 |

## Target post iter 1

win_rate 25-40%, turns 18-24, boss_hp_remain 3-6 on win. Re-batch dopo merge.

## Backlog tickets

- **TKT-08** backend stability under load (morì al run #14)
- **TKT-09** ai_intent_distribution non emessa via /round/execute
- **TKT-10** harness resilience (retry+resume)
- **TKT-11** predict_combat 8p aggregate sanity

## Test plan

- [x] 3/3 hardcoreScenario.test.js verde con nuove assertion
- [x] Smoke factory: 15 unit, no position conflict
- [x] Prettier format
- [ ] Re-batch N=30 post merge

## Rollback

Revert. Encounter additivo, no breaking. Iter 0 baseline ricostruibile da PR #1534.

🤖 Generated with [Claude Code](https://claude.com/claude-code)