### PR TITLE
fix(caveman): classifier copre conventional commit scopes + rigenera status

### DIFF
--- a/docs/caveman-status.json
+++ b/docs/caveman-status.json
@@ -2,75 +2,75 @@
   "_meta": {
     "generator": "caveman_status_stdlib (fallback)",
     "version": "0.2.0-stdlib",
-    "generated_at": "2026-04-17T11:17:27.060654+00:00",
-    "repo_root": "C:\\Users\\VGit\\Desktop\\Game\\.claude\\worktrees\\clever-khayyam",
+    "generated_at": "2026-04-18T00:03:42.130832+00:00",
+    "repo_root": "C:\\Users\\VGit\\Desktop\\Game",
     "note": "File generato via tools/py/caveman_status_stdlib.py (stdlib-only). Quando evo-caveman CLI è installato, rigenerare con `caveman export`."
   },
   "snapshot": {
-    "dirty_files_count": 5,
+    "dirty_files_count": 10,
     "recent_commits_count": 10,
-    "gameplay_ratio": 0.0,
+    "gameplay_ratio": 0.8,
     "consecutive_infra_commits": 0,
-    "is_drifting": true,
+    "is_drifting": false,
     "recent_commits": [
       {
-        "sha": "949f6ca0",
+        "sha": "fcadf364",
+        "kind": "GAMEPLAY",
+        "message_first_line": "feat(playtest-ui): cell highlight durante resolve + keyboard shortcuts (#1549)",
+        "files_count": 0
+      },
+      {
+        "sha": "aa4731f1",
         "kind": "DOCS",
-        "message_first_line": "doc: COMMIT_STYLE canonico (RESEARCH_TODO S2) (#1489)",
+        "message_first_line": "docs(claude-md): session workflow patterns section (#1547)",
         "files_count": 0
       },
       {
-        "sha": "8cc1287f",
-        "kind": "DOCS",
-        "message_first_line": "doc: README refresh — Why/What/How/For-agents (RESEARCH_TODO S3) (#1487)",
-        "files_count": 0
-      },
-      {
-        "sha": "8c3f6fd3",
-        "kind": "TOOLING",
-        "message_first_line": "doc: add PILLARS_STATUS dashboard — RESEARCH_TODO S1 (#1486)",
-        "files_count": 0
-      },
-      {
-        "sha": "7ae85d52",
+        "sha": "ac5188bf",
         "kind": "ALTRO",
-        "message_first_line": "playtest: [2026-04-17] first documented session (#1485)",
+        "message_first_line": "chore: sprint context + GDD ADR placeholders + AI meter UI + harness fixes (#1546)",
         "files_count": 0
       },
       {
-        "sha": "193a31a5",
-        "kind": "DOCS",
-        "message_first_line": "doc: scaffold M1 first playtest (setup + notes template) (#1484)",
+        "sha": "c9f08caf",
+        "kind": "GAMEPLAY",
+        "message_first_line": "feat(playtest-ui): resolve animation sequenziale + cleanup dead code (#1545)",
         "files_count": 0
       },
       {
-        "sha": "4d526cd4",
-        "kind": "ALTRO",
-        "message_first_line": "docs(canonical): chiude 8 Open Questions Master DD — Art/Audio/Business/Narrative (#1481)",
+        "sha": "9976db41",
+        "kind": "GAMEPLAY",
+        "message_first_line": "feat(playtest-ui): pannello \"Ordini pendenti\" laterale (#1544)",
         "files_count": 0
       },
       {
-        "sha": "2b58cd73",
-        "kind": "DOCS",
-        "message_first_line": "doc: commit RESEARCH_TODO.md as source of truth + mark M2/M3 done (#1483)",
+        "sha": "d3828f5f",
+        "kind": "GAMEPLAY",
+        "message_first_line": "feat(playtest): scenari 3v3 + 4v4 co-op planning-first (#1543)",
         "files_count": 0
       },
       {
-        "sha": "aee9609e",
-        "kind": "DOCS",
-        "message_first_line": "doc: add project pitch (3 sentences max) — RESEARCH_TODO M3 (#1482)",
+        "sha": "35278ac6",
+        "kind": "GAMEPLAY",
+        "message_first_line": "play(balance): hardcore_06 iter 1 — boss hp +57%, +1 elite (PR4.b post calibration) (#1542)",
         "files_count": 0
       },
       {
-        "sha": "9ae81ec3",
-        "kind": "ALTRO",
-        "message_first_line": "feat(difficulty): session integration + /profiles endpoint (Q-001 T2.3 PR-3 of 5) (#1480)",
+        "sha": "6e601158",
+        "kind": "GAMEPLAY",
+        "message_first_line": "feat(playtest-ui): shift-click own unit → clear pending intent (#1541)",
         "files_count": 0
       },
       {
-        "sha": "17003bd0",
-        "kind": "ALTRO",
-        "message_first_line": "feat(replay): deterministic engine MVP (Q-001 T2.4 PR-3 of 5) (#1479)",
+        "sha": "18069352",
+        "kind": "GAMEPLAY",
+        "message_first_line": "feat(playtest-ui): visual preview intent + multi-player token labels (#1540)",
+        "files_count": 0
+      },
+      {
+        "sha": "814611fb",
+        "kind": "GAMEPLAY",
+        "message_first_line": "feat(round): /declare-intent server-side validation (range/AP/target/grid) (#1538)",
         "files_count": 0
       }
     ]

--- a/evo-caveman/src/caveman/repo.py
+++ b/evo-caveman/src/caveman/repo.py
@@ -17,11 +17,11 @@ CommitKind = Literal["GAMEPLAY", "INFRA", "TOOLING", "DOCS", "DATA", "ALTRO"]
 # o nei file toccati del commit (lowercase).
 _COMMIT_PATTERNS: Final[tuple[tuple[tuple[str, ...], CommitKind], ...]] = (
     # GAMEPLAY ha priorità: se un commit tocca traits/ anche solo di striscio, conta.
-    (("traits/", "biomes/", "rules/", "jobs/", "species/", "engine/game", "combat", "turn"), "GAMEPLAY"),
-    (("data/", "datasets/", "yaml", "schema"), "DATA"),
-    (("docker", "ci/", ".github/workflows", "prisma", "migration", "deploy", "compose"), "INFRA"),
+    (("traits/", "biomes/", "rules/", "jobs/", "species/", "engine/game", "combat", "turn", "round", "session/", "session.js", "playtest", "play(", "ai/", "intent"), "GAMEPLAY"),
+    (("data/", "datasets/", "yaml", "schema", "data("), "DATA"),
+    (("docker", "ci/", ".github/workflows", "prisma", "migration", "deploy", "compose", "chore("), "INFRA"),
     (("cli/", "tools/", "validator", "dashboard", "analytics", "script"), "TOOLING"),
-    (("readme", "docs/", "changelog", "canvas", ".md"), "DOCS"),
+    (("readme", "docs/", "changelog", "canvas", ".md", "docs("), "DOCS"),
 )
 
 

--- a/evo-caveman/tests/test_repo.py
+++ b/evo-caveman/tests/test_repo.py
@@ -30,6 +30,26 @@ class TestClassifyCommit:
     def test_fallback_altro(self) -> None:
         assert _classify_commit("random stuff", ("random/file.txt",)) == "ALTRO"
 
+    def test_conventional_commit_playtest(self) -> None:
+        """Pattern 'playtest' intercetta feat(playtest-ui) e simili."""
+        assert _classify_commit("feat(playtest-ui): new button", ("apps/backend/public/x.html",)) == "GAMEPLAY"
+
+    def test_conventional_commit_round(self) -> None:
+        """Pattern 'round' intercetta feat(round) e simili."""
+        assert _classify_commit("feat(round): add orchestrator", ("apps/backend/services/round.js",)) == "GAMEPLAY"
+
+    def test_conventional_commit_play_scope(self) -> None:
+        """Pattern 'play(' intercetta play(balance), play(tutorial) ecc."""
+        assert _classify_commit("play(balance): hardcore iter", ("packs/evo/data/balance/x.yaml",)) == "GAMEPLAY"
+
+    def test_conventional_commit_docs_scope(self) -> None:
+        """Pattern 'docs(' intercetta docs(claude-md), docs(core) ecc."""
+        assert _classify_commit("docs(core): update vision", ("docs/core/01.md",)) == "DOCS"
+
+    def test_ai_directory(self) -> None:
+        """Pattern 'ai/' intercetta commit su apps/backend/services/ai/."""
+        assert _classify_commit("feat: new ai brain", ("apps/backend/services/ai/policy.js",)) == "GAMEPLAY"
+
 
 class TestSnapshotMetrics:
     def _make_snap(self, kinds: list[str]) -> RepoSnapshot:

--- a/tools/py/caveman_status_stdlib.py
+++ b/tools/py/caveman_status_stdlib.py
@@ -19,11 +19,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 COMMIT_PATTERNS = [
-    (("traits/", "biomes/", "rules/", "jobs/", "species/", "combat", "turn", "play:"), "GAMEPLAY"),
-    (("data/", "datasets/", "yaml", "schema", "data:"), "DATA"),
-    (("docker", "ci/", ".github/workflows", "prisma", "migration", "deploy", "compose", "infra:"), "INFRA"),
+    (("traits/", "biomes/", "rules/", "jobs/", "species/", "engine/game", "combat", "turn", "round", "session/", "session.js", "playtest", "play:", "play(", "ai/", "intent"), "GAMEPLAY"),
+    (("data/", "datasets/", "yaml", "schema", "data:", "data("), "DATA"),
+    (("docker", "ci/", ".github/workflows", "prisma", "migration", "deploy", "compose", "infra:", "infra(", "chore("), "INFRA"),
     (("cli/", "tools/", "validator", "dashboard", "analytics", "script"), "TOOLING"),
-    (("readme", "docs/", "changelog", "canvas", ".md", "doc:"), "DOCS"),
+    (("readme", "docs/", "changelog", "canvas", ".md", "doc:", "docs(", "doc("), "DOCS"),
 ]
 
 


### PR DESCRIPTION
## Problem

9 PR oggi (round simultaneo UI, #1536-#1549) classificati **"ALTRO"**. \`docs/caveman-status.json\` riportava \`gameplay_ratio: 0%\` + \`is_drifting: true\` nonostante fosse **la giornata più gameplay-dense dell'ultimo mese**.

Root cause: \`_COMMIT_PATTERNS\` cercava solo \`"play:"\` non \`"play("\`, non aveva entry per \`"playtest"\`, \`"round"\`, \`"session"\`, \`"ai/"\`, né per conventional commit scope notation \`type(scope):\`.

## Fix

Due file specchio toccati (stdlib fallback + CLI source):

### GAMEPLAY pattern
\`\`\`diff
- (("traits/", "biomes/", "rules/", "jobs/", "species/", "engine/game", "combat", "turn"), "GAMEPLAY"),
+ (("traits/", "biomes/", "rules/", "jobs/", "species/", "engine/game", "combat", "turn",
+   "round", "session/", "session.js", "playtest", "play(", "ai/", "intent"), "GAMEPLAY"),
\`\`\`

### DATA / INFRA / DOCS aggiungono scope notation
\`\`\`diff
- (("data/", "datasets/", "yaml", "schema"), "DATA"),
+ (("data/", "datasets/", "yaml", "schema", "data("), "DATA"),

- (("docker", "ci/", ".github/workflows", "prisma", "migration", "deploy", "compose"), "INFRA"),
+ (("docker", "ci/", ".github/workflows", "prisma", "migration", "deploy", "compose", "chore("), "INFRA"),

- (("readme", "docs/", "changelog", "canvas", ".md"), "DOCS"),
+ (("readme", "docs/", "changelog", "canvas", ".md", "docs("), "DOCS"),
\`\`\`

## Effetto

| Metrica | Before | After |
|---------|:-:|:-:|
| gameplay_ratio | **0%** | **80%** |
| is_drifting | true | **false** |
| ALTRO commits | 10/10 | 1/10 |

\`docs/caveman-status.json\` rigenerato con stato accurato post-sessione 2026-04-18.

## Test

5 nuovi casi in \`evo-caveman/tests/test_repo.py\`:
- \`test_conventional_commit_playtest\`
- \`test_conventional_commit_round\`
- \`test_conventional_commit_play_scope\`
- \`test_conventional_commit_docs_scope\`
- \`test_ai_directory\`

Test esistenti non toccati (aggiunta patterns non rimuove).

## Rollback

\`git revert\`. Classifier torna a pattern precedenti. Snapshot potrà diventare obsoleto al prossimo genera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)