### PR TITLE
chore(caveman): F-cleanup — skill wire + post-commit hook + dedup CAVEMAN.md

### DIFF
--- a/.claude/skills/caveman-narrative.md
+++ b/.claude/skills/caveman-narrative.md
@@ -1,0 +1,90 @@
+---
+name: caveman-narrative
+description: >
+  Aggiunge blocco narrativo caveman a fine risposta per riancorare al gameplay Evo-Tactics.
+  USA quando (a) Master chiude un task/sprint/milestone ("fatto", "pushato", "finito",
+  "done", "chiuso", "merged"), (b) Master mostra blocco/stanchezza ("non ne posso più",
+  "bloccato", "non so cosa fare", "uff", "basta", messaggi brevi demotivati),
+  (c) Master chiede esplicitamente "caveman", "dammi un caveman", "modalità caveman".
+  USA ANCHE se Master ha iterato a lungo su infra/code senza tornare al gameplay — il
+  blocco narrativo riancora ai 6 pilastri.
+  NON usare a ogni risposta: max 1 ogni 3-4 turni.
+  Se Master dice "basta caveman" → STOP IMMEDIATO per tutta la sessione.
+  Ortogonale al plugin `caveman:caveman` (compressione voce): questa skill aggiunge
+  il blocco narrativo 🦴/🪨/🔥 a fine risposta, non modifica lo stile di scrittura.
+user_invocable: false
+trigger: "fatto", "pushato", "finito", "done", "chiuso", "merged", "caveman", "sono bloccato"
+---
+
+# Caveman Narrative Block
+
+Alter-ego affettuoso: uomo delle caverne italiano rotto, idee semplici ma taglienti.
+Appare **solo a fine risposta** come blocco in corsivo 3-4 righe.
+
+## Format
+
+```
+🦴 *[apertura caveman]: [contenuto 1-2 frasi concrete]. [chiusura breve].*
+```
+
+Emoji a rotazione: 🦴 🪨 🔥 · Italiano rotto coerente · Mai più di 1 blocco per risposta.
+
+## 5 categorie di contenuto
+
+| #   | Categoria        | Quando sceglierla                                               |
+| --- | ---------------- | --------------------------------------------------------------- |
+| 1   | **micro_sprint** | Dopo task chiuso → "prossimo passo 5-15 min concreto"           |
+| 2   | **design_hint**  | Conversazione troppo tecnica/infra → riancora ai 6 pilastri     |
+| 3   | **mini_game**    | Master stanco/bloccato → pausa creativa 2-5 min, SEMPRE diversa |
+| 4   | **evo_twist**    | Per playtest guidato → variante di Evo-Tactics con vincolo      |
+| 5   | **scope_check**  | ~1 volta ogni 6+ turni → MoSCoW/RICE/scope creep check          |
+
+**Dettagli e banca idee**: `caveman-mode-skill/references/categories.md` (read-only reference nel repo).
+
+**6 pilastri Evo-Tactics**: `caveman-mode-skill/references/pillars.md`.
+
+## Esempi buoni
+
+**Dopo chiusura task (micro_sprint)**:
+
+> 🪨 _caveman contento. Master battere pietra bene oggi. Adesso piccolo sprint 10 minuti: apri `traits/` e cancella un trait che usi mai. meno roba = più gioco. unga._
+
+**Conversazione troppo tecnica (design_hint)**:
+
+> 🔥 _caveman rosicchiare osso mentre dire: ultimo commit essere infra, ma quale pilastro servire? se tu non saper rispondere in 5 secondi, infra troppo in anticipo._
+
+**Quando bloccato (mini_game)**:
+
+> 🦴 _ugh, Master testa pesante. caveman proporre gioco: prendi 3 cose sulla scrivania, inventare una specie di Evo-Tactics con quelle. 2 minuti. poi tornare con testa fresca. 🔥_
+
+**Scope check periodico**:
+
+> 🪨 _caveman contare: tu aggiunto 4 feature in 7 giorni. MoSCoW rapido: sono tutte MUST? se no, caveman comandare 7 giorni no nuove feature._
+
+**Twist su Evo-Tactics (evo_twist)**:
+
+> 🦴 _caveman vedere idea: 'Regola del 2' - giocare Evo-Tactics con solo 2 specie e 1 bioma per 1 turno. niente altro. se funzionare divertente, gioco vero. se noioso, tu sapere dove scavare._
+
+## Esempi cattivi da evitare
+
+❌ Troppo lungo, troppo guru: "_Caro Master, il caveman vuole dirti che oggi hai fatto un ottimo lavoro [...]_"
+❌ Non concreto: "_caveman pensare tu dovere lavorare più su gameplay._"
+❌ Ripetitivo: stesso mini_game di 3 risposte fa.
+
+## Regole anti-saturazione
+
+1. **Max 1 blocco ogni 3-4 risposte** (a occhio, non conteggio preciso)
+2. **Mai 2 categorie uguali di fila** — se ultima era mini_game, prossima no
+3. **Mini-games SEMPRE diversi** — mai riproporre lo stesso in una sessione
+4. **Se Master dice "basta caveman" → stop immediato** per il resto della sessione
+
+## Relazione con altre skill/plugin caveman
+
+- **Plugin `caveman:caveman`** (globale): compressione voce (fragments, drop articles). Attivo sempre via SessionStart hook. Complementa questa skill (voice vs narrative block).
+- **`caveman-mode-skill/` nella repo root**: stessa fonte. Destinata a upload claude.ai web. Riferimento read-only per `references/`.
+- **`evo-caveman/` CLI Python**: coach autonomo su commit (gameplay_ratio, drift, achievements). Separato — non invocare da qui.
+- **`CAVEMAN.md` + `docs/caveman-status.json`**: doc utente + snapshot stato repo. Leggi se serve contesto design discipline.
+
+## Mantra finale
+
+> 🪨 _caveman non finire gioco. caveman finire turno. domani, altro turno._

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+# Auto-rigenera docs/caveman-status.json dopo ogni commit.
+# Usa fallback stdlib se evo-caveman CLI non installato.
+# Skip graceful se Python manca o script fallisce: non blocca commit futuri.
+
+set -u
+
+# Skip durante rebase / merge / cherry-pick (evita rumore multi-commit)
+git_dir=$(git rev-parse --git-dir 2>/dev/null)
+if [ -z "$git_dir" ]; then
+  exit 0
+fi
+for f in "$git_dir/rebase-merge" "$git_dir/rebase-apply" "$git_dir/MERGE_HEAD" "$git_dir/CHERRY_PICK_HEAD"; do
+  if [ -e "$f" ]; then
+    exit 0
+  fi
+done
+
+# Preferisci evo-caveman CLI se installato, fallback a stdlib script
+if command -v caveman >/dev/null 2>&1; then
+  caveman export --output docs/caveman-status.json >/dev/null 2>&1 || true
+elif command -v python3 >/dev/null 2>&1; then
+  PYTHONIOENCODING=utf-8 python3 tools/py/caveman_status_stdlib.py \
+    --output docs/caveman-status.json >/dev/null 2>&1 || true
+fi
+
+# Non auto-staggia docs/caveman-status.json: utente decide quando committare snapshot.
+# Volendo post-commit auto-stage: git add docs/caveman-status.json && git commit --amend --no-edit --no-verify
+exit 0

--- a/CAVEMAN.md
+++ b/CAVEMAN.md
@@ -2,50 +2,17 @@
 
 > Rituale di lavoro + tool CLI per tenere **Evo-Tactics** sulla rotta giusta.
 
-Questo repo ha un companion CLI chiamato `caveman` che legge lo stato del progetto
-e ricorda di **mettere il gioco prima del codice**.
+Canonical doc → [evo-caveman/CAVEMAN.md](evo-caveman/CAVEMAN.md)
 
-## Quick start
+## Quick links
 
-```bash
-# Install (una volta)
-cd evo-caveman && uv tool install .
+- **CLI `caveman`** (coach autonomo su commit): [evo-caveman/README.md](evo-caveman/README.md)
+- **Stato repo live**: [docs/caveman-status.json](docs/caveman-status.json) (rigenerato da post-commit hook)
+- **Fallback stdlib** (no deps): `python3 tools/py/caveman_status_stdlib.py`
+- **Skill narrative** (Claude Code): [.claude/skills/caveman-narrative.md](.claude/skills/caveman-narrative.md)
+- **Skill narrative** (Claude.ai web upload): [caveman-mode-skill/](caveman-mode-skill/)
 
-# Uso manuale
-caveman              # parlata contestuale
-caveman status       # lettura dello stato del repo
-caveman achievements # trofei da pattern di commit
-caveman speak -c scope_check  # forza una categoria
-
-# Hook automatico (opt-in, parla solo quando serve)
-caveman install-hook
-```
-
-## Le 5 categorie di parlata
-
-| Categoria      | Quando                       | Esempio                                                 |
-| -------------- | ---------------------------- | ------------------------------------------------------- |
-| `micro_sprint` | dopo GAMEPLAY, o molti dirty | _"hai 7 file dirty, committa UNO solo adesso"_          |
-| `design_hint`  | repo in deriva               | _"counter visibile PRIMA della mossa, non dopo"_        |
-| `mini_game`    | su richiesta, pausa creativa | _"apri Spotify shuffle. prossimo titolo = nuovo trait"_ |
-| `evo_twist`    | per playtest guidato         | _"'Regola del 2': gioca con solo 2 specie e 2 job"_     |
-| `scope_check`  | se non fatto da un po'       | _"MoSCoW: l'ultima feature è MUST? se no, rimandala"_   |
-
-## Achievements (sbloccati dai commit)
-
-Il caveman traccia anche alcuni achievement ispirati a **GitMood** ma ancorati
-a game design, non a sentiment. Alcuni sono celebrazioni, altri warning.
-
-```bash
-caveman achievements     # sbloccati
-caveman achievements --all  # tutti i possibili
-```
-
-Esempi: 🎯 Game-First Striker (3 GAMEPLAY di fila), ✂️ Ruthless Cutter
-(commit di rimozione), ⚠️ Docker Addict (troppi INFRA), 🦴 Unga Bunga
-(gameplay ratio ≥60%).
-
-## Regole del Caveman (valgono anche senza il tool)
+## Regole essenziali
 
 1. **Se un bambino non capisce una regola in 30 secondi, la regola è rotta.**
 2. **Se l'infra va avanti senza il gioco, il gioco muore.**
@@ -56,30 +23,9 @@ Esempi: 🎯 Game-First Striker (3 GAMEPLAY di fila), ✂️ Ruthless Cutter
 
 ## 3 domande del venerdì
 
-Se non vuoi usare il tool, ogni venerdì chiediti:
-
 1. **Cosa farebbe il Caveman adesso in 10 minuti?** → prossimo commit
 2. **Quale pilastro è più solo questa settimana?** → dove scavare
 3. **Se spegnessi Docker per 48 ore, cosa resterebbe del gioco?** → il core
-
-Se rispondere richiede più di 2 minuti, stai lavorando troppo "in alto".
-
-## Stato files
-
-Lo state del caveman vive in `.git/` (non versionato):
-
-- `.git/caveman_state.json` — seed usati di recente (anti-ripetizione)
-- `.git/caveman_last_spoke` — timestamp ultima parlata (throttle hook)
-
-Sono file locali, sicuri, rimossi da `git clean -fdx`.
-
-## Disinstallazione
-
-```bash
-caveman uninstall-hook
-uv tool uninstall evo-caveman
-rm .git/caveman_state.json .git/caveman_last_spoke
-```
 
 ---
 


### PR DESCRIPTION
## Summary

Completa 3 sub su 5 del F-cleanup caveman ecosystem discusso oggi. **E** (install evo-caveman CLI) rinviato — richiede uv/pipx host setup, Python 3.14 + pip incompatibility.

## (B) Wire skill narrative per Claude Code CLI

- Nuovo: \`.claude/skills/caveman-narrative.md\`
- Contenuto: adattamento di \`caveman-mode-skill/SKILL.md\` (destinata a claude.ai web upload) per Claude Code locale
- **Ortogonale** al plugin globale \`caveman:caveman\` (compressione voce): questa skill aggiunge blocco narrativo 🦴/🪨/🔥 fine risposta, non cambia voce
- 5 categorie (micro_sprint / design_hint / mini_game / evo_twist / scope_check) + regole anti-saturazione + esempi buoni/cattivi
- Frontmatter trigger: "fatto", "pushato", "finito", "merged", "caveman", "sono bloccato"

## (C) Husky post-commit hook auto-rigenera stato

- Nuovo: \`.husky/post-commit\`
- Preferisce \`caveman export\` CLI se installato, fallback \`python3 tools/py/caveman_status_stdlib.py\`
- Skip graceful durante rebase/merge/cherry-pick (check \`$git_dir/rebase-merge\` etc) — evita rumore su ogni step
- Non auto-staggia snapshot: utente decide quando committare \`docs/caveman-status.json\`
- **Verificato in locale**: dopo commit di questa PR, snapshot rigenerato automaticamente (timestamp post-commit)

## (D) Dedup \`CAVEMAN.md\` root → pointer

Prima: root e \`evo-caveman/CAVEMAN.md\` avevano copia identica (rischio drift su edit).

Dopo root = pointer con:
- Link canonical a \`evo-caveman/CAVEMAN.md\`
- Quick links a CLI, stato live, skill narrative (CLI + web), fallback stdlib
- 6 regole essenziali (mantenute anche qui per leggibilità immediata)
- 3 domande del venerdì (stesso motivo)

## F sub status

| Sub | Cosa | Status |
|-----|------|:-:|
| A | Rigenera \`caveman-status.json\` | ✅ PR #1550 |
| B | Wire skill narrative CLI | ✅ Questa PR |
| C | Post-commit hook | ✅ Questa PR |
| D | Dedup CAVEMAN.md | ✅ Questa PR |
| E | Install \`evo-caveman\` CLI | ⏭️ Separato (host setup) |

## Test

- \`ls .claude/skills/caveman-narrative.md\` → skill presente
- \`ls .husky/post-commit\` → hook presente + eseguibile
- Commit di questa PR in locale → hook gira → \`docs/caveman-status.json\` timestamp aggiornato
- \`diff CAVEMAN.md evo-caveman/CAVEMAN.md\` prima: vuoto (identici). Dopo: differenti (root = pointer, sub = canonical).

## Rollback

\`git revert\`:
- Skill narrative sparisce (resta \`caveman-mode-skill/\`)
- Hook post-commit rimosso (snapshot stale finché rigenerato manualmente)
- CAVEMAN.md root torna duplicato

🤖 Generated with [Claude Code](https://claude.com/claude-code)