### PR TITLE
feat(combat): reinforcementSpawner engine (ADR-2026-04-19)

### DIFF
--- a/apps/backend/services/combat/reinforcementSpawner.js
+++ b/apps/backend/services/combat/reinforcementSpawner.js
@@ -1,0 +1,208 @@
+// Reinforcement spawn engine — ADR-2026-04-19 (Option B).
+//
+// Pure module. Consumes reinforcement_budget from the current Sistema tier
+// (AI Progress pattern, Park) and spawns SIS units from the scenario-authored
+// reinforcement_pool onto reinforcement_entry_tiles, respecting cooldown
+// and max_total_spawns.
+//
+// Contract:
+//   tick(session, encounter, opts?) → {
+//     spawned: [{ unit_id, spawn_tile, wave_index, tier_at_spawn }],
+//     budget_used: integer,
+//     skipped: boolean,
+//     reason: string,
+//   }
+//
+// Feature flag:
+//   encounter.reinforcement_policy.enabled !== true → skip (default OFF).
+//
+// Side effects (on session):
+//   - session.reinforcement_state { total_spawned, last_spawn_round, spawn_history }
+//   - session.units += N new units (if spawned)
+//
+// Emits raw event for /replay + vcScoring:
+//   { action_type: 'reinforcement_spawn', turn, actor_id, spawn_tile,
+//     wave_index, tier_at_spawn, automatic: true }
+
+'use strict';
+
+const { computeSistemaTier } = require('../../routes/sessionHelpers');
+
+const DEFAULT_MIN_DISTANCE_FROM_PG = 3; // Manhattan
+const TIER_LABEL_ORDER = ['Calm', 'Alert', 'Escalated', 'Critical', 'Apex'];
+
+function manhattanDistance(a, b) {
+  return Math.abs(a[0] - b[0]) + Math.abs(a[1] - b[1]);
+}
+
+function tierMeetsMin(currentLabel, minLabel) {
+  const cur = TIER_LABEL_ORDER.indexOf(currentLabel);
+  const min = TIER_LABEL_ORDER.indexOf(minLabel);
+  if (cur < 0 || min < 0) return true; // unknown → permissive
+  return cur >= min;
+}
+
+function isWalkable(tile, session) {
+  const [x, y] = tile;
+  const grid = session.grid || { width: 10, height: 10 };
+  if (x < 0 || y < 0 || x >= grid.width || y >= grid.height) return false;
+  const occupied = (session.units || []).some(
+    (u) => (u.hp ?? 0) > 0 && u.position && u.position[0] === x && u.position[1] === y,
+  );
+  return !occupied;
+}
+
+function farFromAllPG(tile, session, minDist) {
+  const pgs = (session.units || []).filter((u) => u.controlled_by === 'player' && (u.hp ?? 0) > 0);
+  if (pgs.length === 0) return true;
+  return pgs.every((pg) => !pg.position || manhattanDistance(tile, pg.position) >= minDist);
+}
+
+function pickEntryTile(entryTiles, session, minDist) {
+  const candidates = entryTiles.filter(
+    (t) => isWalkable(t, session) && farFromAllPG(t, session, minDist),
+  );
+  return candidates.length > 0 ? candidates[0] : null;
+}
+
+function pickPoolEntry(pool, session, rng) {
+  const history = session.reinforcement_state?.spawn_history || [];
+  const counts = history.reduce((m, h) => {
+    m[h.unit_id] = (m[h.unit_id] || 0) + 1;
+    return m;
+  }, {});
+  const eligible = pool.filter((entry) => {
+    const cap = Number(entry.max_spawns) || Infinity;
+    return (counts[entry.unit_id] || 0) < cap;
+  });
+  if (eligible.length === 0) return null;
+  const totalWeight = eligible.reduce((s, e) => s + (Number(e.weight) || 0), 0);
+  if (totalWeight <= 0) return eligible[0];
+  let r = rng() * totalWeight;
+  for (const entry of eligible) {
+    r -= Number(entry.weight) || 0;
+    if (r <= 0) return entry;
+  }
+  return eligible[eligible.length - 1];
+}
+
+function ensureReinforcementState(session) {
+  if (!session.reinforcement_state) {
+    session.reinforcement_state = {
+      total_spawned: 0,
+      last_spawn_round: -Infinity,
+      spawn_history: [],
+    };
+  }
+  return session.reinforcement_state;
+}
+
+function tick(session, encounter, opts = {}) {
+  const rng = typeof opts.rng === 'function' ? opts.rng : Math.random;
+  const policy = encounter?.reinforcement_policy;
+  if (!policy || policy.enabled !== true) {
+    return { spawned: [], budget_used: 0, skipped: true, reason: 'policy_disabled' };
+  }
+  const pool = encounter?.reinforcement_pool;
+  const entryTiles = encounter?.reinforcement_entry_tiles;
+  if (!Array.isArray(pool) || pool.length === 0) {
+    return { spawned: [], budget_used: 0, skipped: true, reason: 'no_pool' };
+  }
+  if (!Array.isArray(entryTiles) || entryTiles.length === 0) {
+    return { spawned: [], budget_used: 0, skipped: true, reason: 'no_entry_tiles' };
+  }
+
+  const tier = computeSistemaTier(session.pressure ?? 0);
+  const minTier = policy.min_tier || 'Alert';
+  if (!tierMeetsMin(tier.label, minTier)) {
+    return {
+      spawned: [],
+      budget_used: 0,
+      skipped: true,
+      reason: `tier_below_min (${tier.label} < ${minTier})`,
+    };
+  }
+
+  const state = ensureReinforcementState(session);
+  const round = session.round ?? session.turn ?? 0;
+  const cooldownRounds = Number(policy.cooldown_rounds) || 0;
+  if (round - state.last_spawn_round < cooldownRounds) {
+    return { spawned: [], budget_used: 0, skipped: true, reason: 'cooldown_active' };
+  }
+
+  const maxTotal = Number(policy.max_total_spawns) || Infinity;
+  const remaining = maxTotal - state.total_spawned;
+  if (remaining <= 0) {
+    return { spawned: [], budget_used: 0, skipped: true, reason: 'max_total_reached' };
+  }
+
+  const budget = Math.min(Number(tier.reinforcement_budget) || 0, remaining);
+  if (budget <= 0) {
+    return { spawned: [], budget_used: 0, skipped: true, reason: 'tier_budget_zero' };
+  }
+
+  const spawned = [];
+  const minDist = Number(policy.min_distance_from_pg) || DEFAULT_MIN_DISTANCE_FROM_PG;
+
+  for (let i = 0; i < budget; i += 1) {
+    const tile = pickEntryTile(entryTiles, session, minDist);
+    if (!tile) {
+      spawned.push({ skipped: true, reason: 'no_walkable_entry' });
+      break;
+    }
+    const entry = pickPoolEntry(pool, session, rng);
+    if (!entry) {
+      spawned.push({ skipped: true, reason: 'pool_exhausted' });
+      break;
+    }
+    const unitId = `reinf_${state.total_spawned + spawned.filter((s) => !s.skipped).length + 1}_${entry.unit_id}`;
+    const newUnit = {
+      id: unitId,
+      species: entry.unit_id,
+      controlled_by: 'sistema',
+      position: tile,
+      hp: Number(entry.hp) || 8,
+      hp_max: Number(entry.hp) || 8,
+      ap: 2,
+      mod: Number(entry.mod) || 0,
+      dc: Number(entry.dc) || 12,
+      ai_profile: entry.ai_profile || 'defensive',
+      reinforcement: true,
+    };
+    (session.units || (session.units = [])).push(newUnit);
+    const record = {
+      unit_id: entry.unit_id,
+      spawned_unit_id: unitId,
+      spawn_tile: tile,
+      wave_index: state.spawn_history.length + 1,
+      tier_at_spawn: tier.label,
+      round,
+    };
+    state.spawn_history.push(record);
+    state.total_spawned += 1;
+    state.last_spawn_round = round;
+    spawned.push(record);
+  }
+
+  const effective = spawned.filter((s) => !s.skipped);
+  return {
+    spawned: effective,
+    budget_used: effective.length,
+    skipped: effective.length === 0,
+    reason: effective.length === 0 ? 'no_tile_or_pool' : 'spawned',
+    tier_at_tick: tier.label,
+  };
+}
+
+module.exports = {
+  tick,
+  // exported for unit tests
+  _internals: {
+    manhattanDistance,
+    tierMeetsMin,
+    isWalkable,
+    farFromAllPG,
+    pickEntryTile,
+    pickPoolEntry,
+  },
+};

--- a/schemas/evo/encounter.schema.json
+++ b/schemas/evo/encounter.schema.json
@@ -214,6 +214,50 @@
       "type": "array",
       "items": { "type": "string" },
       "description": "Mechanics highlighted in tutorial encounters"
+    },
+    "reinforcement_pool": {
+      "type": "array",
+      "description": "ADR-2026-04-19: SIS reinforcement candidates (weighted selection).",
+      "items": {
+        "type": "object",
+        "required": ["unit_id"],
+        "additionalProperties": true,
+        "properties": {
+          "unit_id": { "type": "string", "minLength": 1 },
+          "weight": { "type": "number", "minimum": 0 },
+          "max_spawns": { "type": "integer", "minimum": 1 },
+          "hp": { "type": "integer", "minimum": 1 },
+          "mod": { "type": "integer" },
+          "dc": { "type": "integer", "minimum": 1 },
+          "ai_profile": { "type": "string" }
+        }
+      }
+    },
+    "reinforcement_entry_tiles": {
+      "type": "array",
+      "description": "ADR-2026-04-19: tiles where reinforcement units may spawn (Manhattan ≥ min_distance_from_pg from any PG).",
+      "items": {
+        "type": "array",
+        "items": { "type": "integer", "minimum": 0 },
+        "minItems": 2,
+        "maxItems": 2
+      }
+    },
+    "reinforcement_policy": {
+      "type": "object",
+      "description": "ADR-2026-04-19: gating rules for reinforcementSpawner.tick().",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "min_tier": {
+          "type": "string",
+          "enum": ["Calm", "Alert", "Escalated", "Critical", "Apex"],
+          "default": "Alert"
+        },
+        "cooldown_rounds": { "type": "integer", "minimum": 0, "default": 0 },
+        "max_total_spawns": { "type": "integer", "minimum": 0 },
+        "min_distance_from_pg": { "type": "integer", "minimum": 0, "default": 3 }
+      }
     }
   }
 }

--- a/tests/services/reinforcementSpawner.test.js
+++ b/tests/services/reinforcementSpawner.test.js
@@ -1,0 +1,209 @@
+// Unit test for reinforcementSpawner — ADR-2026-04-19.
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { tick, _internals } = require('../../apps/backend/services/combat/reinforcementSpawner');
+
+function mockSession(overrides = {}) {
+  return {
+    pressure: 30,
+    round: 3,
+    turn: 3,
+    grid: { width: 10, height: 10 },
+    units: [
+      { id: 'p1', controlled_by: 'player', position: [0, 0], hp: 10 },
+      { id: 'p2', controlled_by: 'player', position: [1, 0], hp: 10 },
+    ],
+    ...overrides,
+  };
+}
+
+function mockEncounter(overrides = {}) {
+  return {
+    reinforcement_pool: [{ unit_id: 'minion_01', weight: 1.0, max_spawns: 5, hp: 6, mod: 2 }],
+    reinforcement_entry_tiles: [
+      [9, 9],
+      [8, 9],
+      [9, 8],
+    ],
+    reinforcement_policy: {
+      enabled: true,
+      min_tier: 'Alert',
+      cooldown_rounds: 0,
+      max_total_spawns: 10,
+    },
+    ...overrides,
+  };
+}
+
+test('tick skips when policy disabled (default OFF)', () => {
+  const session = mockSession();
+  const enc = mockEncounter({ reinforcement_policy: { enabled: false } });
+  const res = tick(session, enc, { rng: () => 0.5 });
+  assert.equal(res.skipped, true);
+  assert.equal(res.reason, 'policy_disabled');
+  assert.equal(res.spawned.length, 0);
+});
+
+test('tick skips at Calm tier (below min_tier Alert)', () => {
+  const session = mockSession({ pressure: 10 }); // Calm
+  const enc = mockEncounter();
+  const res = tick(session, enc, { rng: () => 0.5 });
+  assert.equal(res.skipped, true);
+  assert.match(res.reason, /tier_below_min/);
+});
+
+test('tick spawns 1 unit at Alert tier (budget 1)', () => {
+  const session = mockSession({ pressure: 30 }); // Alert → budget 1
+  const enc = mockEncounter();
+  const initialUnitCount = session.units.length;
+  const res = tick(session, enc, { rng: () => 0.5 });
+  assert.equal(res.budget_used, 1);
+  assert.equal(res.spawned.length, 1);
+  assert.equal(session.units.length, initialUnitCount + 1);
+  const spawn = res.spawned[0];
+  assert.equal(spawn.tier_at_spawn, 'Alert');
+  assert.equal(spawn.wave_index, 1);
+  assert.deepEqual(spawn.spawn_tile, [9, 9]);
+});
+
+test('tick spawns 4 units at Apex tier (budget 4)', () => {
+  const session = mockSession({ pressure: 95 }); // Apex → budget 4
+  const enc = mockEncounter({
+    reinforcement_entry_tiles: [
+      [9, 9],
+      [8, 9],
+      [9, 8],
+      [8, 8],
+    ],
+  });
+  const res = tick(session, enc, { rng: () => 0.5 });
+  assert.equal(res.budget_used, 4);
+});
+
+test('tick respects max_total_spawns cap', () => {
+  const session = mockSession({
+    pressure: 75,
+    reinforcement_state: {
+      total_spawned: 9,
+      last_spawn_round: 0,
+      spawn_history: Array(9).fill({ unit_id: 'minion_01' }),
+    },
+  });
+  // Pool with high per-unit cap so only total cap binds.
+  const enc = mockEncounter({
+    reinforcement_pool: [{ unit_id: 'minion_01', weight: 1.0, max_spawns: 100 }],
+  });
+  const res = tick(session, enc, { rng: () => 0.5 });
+  assert.equal(res.budget_used, 1, 'only 1 spawn left before cap');
+});
+
+test('tick blocks when max_total reached', () => {
+  const session = mockSession({
+    pressure: 75,
+    reinforcement_state: {
+      total_spawned: 10,
+      last_spawn_round: 0,
+      spawn_history: Array(10).fill({ unit_id: 'minion_01' }),
+    },
+  });
+  const res = tick(session, mockEncounter(), { rng: () => 0.5 });
+  assert.equal(res.skipped, true);
+  assert.equal(res.reason, 'max_total_reached');
+});
+
+test('tick respects cooldown_rounds', () => {
+  const session = mockSession({
+    pressure: 30,
+    round: 2,
+    reinforcement_state: {
+      total_spawned: 1,
+      last_spawn_round: 1,
+      spawn_history: [{ unit_id: 'minion_01' }],
+    },
+  });
+  const enc = mockEncounter({
+    reinforcement_policy: {
+      enabled: true,
+      min_tier: 'Alert',
+      cooldown_rounds: 3,
+      max_total_spawns: 10,
+    },
+  });
+  const res = tick(session, enc, { rng: () => 0.5 });
+  assert.equal(res.skipped, true);
+  assert.equal(res.reason, 'cooldown_active');
+});
+
+test('tick rejects entry_tile too close to PG (Manhattan < 3)', () => {
+  const session = mockSession({
+    pressure: 30,
+    units: [{ id: 'p1', controlled_by: 'player', position: [8, 8], hp: 10 }],
+  });
+  const enc = mockEncounter({
+    reinforcement_entry_tiles: [[9, 9]], // Manhattan=2 from [8,8]
+  });
+  const res = tick(session, enc, { rng: () => 0.5 });
+  assert.equal(res.skipped, true);
+  assert.match(res.reason, /no_tile_or_pool|no_walkable_entry/);
+});
+
+test('tick respects per-unit max_spawns cap', () => {
+  const session = mockSession({
+    pressure: 95, // Apex budget 4
+    reinforcement_state: {
+      total_spawned: 2,
+      last_spawn_round: 0,
+      spawn_history: [{ unit_id: 'rare_boss' }, { unit_id: 'rare_boss' }],
+    },
+  });
+  const enc = mockEncounter({
+    reinforcement_pool: [
+      { unit_id: 'rare_boss', weight: 1.0, max_spawns: 2 }, // already at cap
+      { unit_id: 'minion_01', weight: 1.0, max_spawns: 10 },
+    ],
+    reinforcement_entry_tiles: [
+      [9, 9],
+      [8, 9],
+      [9, 8],
+      [8, 8],
+    ],
+  });
+  const res = tick(session, enc, { rng: () => 0.5 });
+  // All spawns should fall back to minion_01
+  const bossSpawns = res.spawned.filter((s) => s.unit_id === 'rare_boss').length;
+  assert.equal(bossSpawns, 0, 'rare_boss cap respected');
+  assert.ok(res.budget_used > 0);
+});
+
+test('tick returns no_pool when pool empty', () => {
+  const res = tick(mockSession(), { reinforcement_policy: { enabled: true } }, { rng: () => 0.5 });
+  assert.equal(res.skipped, true);
+  assert.equal(res.reason, 'no_pool');
+});
+
+test('tick returns no_entry_tiles when entry list empty', () => {
+  const enc = {
+    reinforcement_pool: [{ unit_id: 'minion_01', weight: 1, max_spawns: 5 }],
+    reinforcement_entry_tiles: [],
+    reinforcement_policy: { enabled: true, min_tier: 'Alert' },
+  };
+  const res = tick(mockSession(), enc, { rng: () => 0.5 });
+  assert.equal(res.skipped, true);
+  assert.equal(res.reason, 'no_entry_tiles');
+});
+
+test('_internals: manhattanDistance', () => {
+  assert.equal(_internals.manhattanDistance([0, 0], [3, 4]), 7);
+  assert.equal(_internals.manhattanDistance([5, 5], [5, 5]), 0);
+});
+
+test('_internals: tierMeetsMin', () => {
+  assert.equal(_internals.tierMeetsMin('Alert', 'Calm'), true);
+  assert.equal(_internals.tierMeetsMin('Calm', 'Alert'), false);
+  assert.equal(_internals.tierMeetsMin('Apex', 'Escalated'), true);
+  assert.equal(_internals.tierMeetsMin('Unknown', 'Alert'), true); // permissive fallback
+});


### PR DESCRIPTION
## Summary

Implementa Option B scelto in [ADR-2026-04-19](docs/adr/ADR-2026-04-19-reinforcement-spawn-engine.md). Modulo puro `apps/backend/services/combat/reinforcementSpawner.js` che consuma `reinforcement_budget` per tier (oggi dead field) e spawna unità SIS da `encounter.reinforcement_pool` su entry tiles (Manhattan ≥3 da PG).

## Contract

```js
tick(session, encounter, { rng? }) → {
  spawned: [...],
  budget_used, skipped, reason, tier_at_tick,
}
```

## Gate

- `policy.enabled !== true` → skip (default OFF)
- `min_tier` (default Alert)
- `cooldown_rounds`
- `max_total_spawns` globale + `max_spawns` per unit
- `min_distance_from_pg` (default 3 Manhattan)

## Schema

`schemas/evo/encounter.schema.json` estesa con `reinforcement_pool`, `reinforcement_entry_tiles`, `reinforcement_policy`. Tutti optional, backward compatible.

## Non wirato

Modulo **non wirato** in round orchestrator — scenario opt-in. Nessun encounter esistente modificato.

## Test plan

- [x] `node --test tests/services/reinforcementSpawner.test.js` → 13/13 pass
- [x] `node --test tests/api/*.test.js` → 246/246 pass (no regression)
- [x] Full stack 259/259 verdi
- [ ] Master DD approval + promote ADR 🟡 DRAFT → 🟢 ACCEPTED

## Rollback (03A)

Revert commit `8d910ab0`. Modulo non chiamato da nessun endpoint, zero impatto runtime. Schema extensions optional, no break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)