### PR TITLE
flint(claude-integration): add classify-4d command + 4D framework memory

### DIFF
--- a/flint/claude-integration/README.md
+++ b/flint/claude-integration/README.md
@@ -11,9 +11,11 @@ claude-integration/
 │   ├── MEMORY.md.template              ← index template (personalizza)
 │   ├── feedback_claude_workflow_consolidated.md    ← 9 pattern workflow
 │   ├── feedback_meta_checkpoint_directive.md       ← auto-trigger meta-pause
+│   ├── reference_classification_4d.md              ← framework 4D keep/kill
 │   └── reference_flint_optimization_guide.md       ← 40+ sources research
 ├── commands/                           ← slash commands
-│   └── meta-checkpoint.md              ← /meta-checkpoint
+│   ├── meta-checkpoint.md              ← /meta-checkpoint (self-audit)
+│   └── classify-4d.md                  ← /classify-4d (asset triage)
 └── CLAUDE.md-section-template.md       ← sezione da paste in CLAUDE.md
 ```
 
@@ -48,8 +50,9 @@ Apri `CLAUDE.md` del tuo repo. Paste contenuto di `CLAUDE.md-section-template.md
 ### 4. Verify
 
 - Riavvia Claude Code session
-- Check skill list — deve apparire `meta-checkpoint`
+- Check skill list — devono apparire `meta-checkpoint` + `classify-4d`
 - Test: scrivi "dammi un flint" → risposta composta A+C+D+E (+G se venerdì)
+- Test: `/classify-4d <file>` → tabella 4D + raccomandazione atomica
 
 ## Installazione (automatica)
 

--- a/flint/claude-integration/commands/classify-4d.md
+++ b/flint/claude-integration/commands/classify-4d.md
@@ -1,0 +1,114 @@
+---
+name: classify-4d
+description: Classifica un asset (code/memory/doc/skill) con framework Flint 4D prima di keep/kill/archive decision
+user_invocable: true
+---
+
+# Classify 4D
+
+Applica classification framework Flint 4D a un asset specifico. Output = tabella 4D + raccomandazione atomica (keep / kill / archive / refactor).
+
+Vedi `reference_classification_4d.md` in memory per framework completo + esempi.
+
+## Invocazione
+
+```
+/classify-4d <asset_path_or_name>
+```
+
+Esempi:
+
+- `/classify-4d flint/src/flint/achievements.py`
+- `/classify-4d feedback_old_pattern.md`
+- `/classify-4d docs/adr/ADR-2026-04-XX.md`
+
+## Steps
+
+### 1. Identify asset
+
+Leggi file o contesto. Se nome ambiguo (memory/doc/code), chiedi chiarimento.
+
+Estrai: scope funzionale, dipendenze, test coverage, last modified, usage evidence.
+
+### 2. Apply 4 axes
+
+Per ciascuno, scegli valore + 1-riga motivazione:
+
+**Valore scope** (🟢 alto · 🟡 medio · 🔴 basso)
+
+- 🟢 = asset core (blocker rimuoverlo) / riusato 3+ posti / testcov >70%
+- 🟡 = utile ma sostituibile / riusato 1-2 posti / testcov 30-70%
+- 🔴 = dead code / nessun usage / testcov <30% / deprecated
+
+**Applicabilità** (universal / gamedev / data-ops / solo-dev / single-user / `<project>`-only)
+
+- universal = riusabile in qualsiasi progetto software
+- `<project>`-only = hardcoded dependencies al dominio attuale
+- single-user = legato a setup specifico (host, preferenze user)
+
+**Stato sviluppo** (production / experimental / draft / deprecated / consolidated / killed)
+
+- production = wirato + test + doc
+- experimental = wirato ma feature-flag OFF default
+- draft = scritto non wirato
+- consolidated = merged da N file in 1 (post-refactor)
+
+**Re-open cost** (XS / S / M / L / XL)
+
+- XS = <30min (copy-paste from archive)
+- S = ≤2h (reinstall + config)
+- M = ≤1gg (re-wire + test)
+- L = >1gg (refactor downstream)
+- XL = >settimana (rewrite from scratch)
+
+### 3. Output tabella
+
+```
+| Dimensione     | Valore           | Motivazione (≤10 parole)         |
+|----------------|------------------|----------------------------------|
+| Valore scope   | 🔴 basso         | dead code, 0 usage grep          |
+| Applicabilità  | single-user      | hardcoded path user-specific     |
+| Stato sviluppo | deprecated       | superseded da X in PR #YYYY      |
+| Re-open cost   | XS               | copy da archive + 1 import       |
+```
+
+### 4. Raccomandazione atomica
+
+Applica regole (vedi `reference_classification_4d.md`):
+
+- 🔴 + single-user + draft + XS/S → **KILL** (archive + remove)
+- 🔴 + universal + deprecated + M/L → **KILL GRADUAL** (deprecation warning 30gg)
+- 🟢 + universal + production + L → **KEEP HARD** (no touch)
+- 🟡 + gamedev + draft + M → **REFACTOR or PARK** (proponi trigger re-open)
+- 🟢 + `<project>`-only + experimental + S → **PROMOTE** (codifica + docs)
+
+### 5. Next step (se KILL)
+
+Se raccomandazione = KILL:
+
+1. Proponi creazione archive folder `docs/archive/<project>-<slug>-<date>/`
+2. Usa `flint/archive-template/MANIFEST-template.md` come skeleton
+3. Lista file da spostare + git mv commands
+4. Aspetta "procedi" utente
+
+Se raccomandazione = KEEP:
+
+1. Identifica gap (test mancanti? doc stale? wired?)
+2. Proponi 1-3 follow-up ticket atomici
+
+### 6. Log decisione
+
+Se keep/kill applicato → append entry a `IDEAS_INDEX.md` sezione appropriata (parked / completed) con classificazione 4D esplicita.
+
+## Quando invocare
+
+- Dopo research-critique con voto ≤5/10 (gate kill-60)
+- Prima di eliminare code/doc non banale
+- Durante archive session (post decision)
+- Per parked ideas catalog (ogni idea = classificata)
+
+## Quando NON invocare
+
+- Asset trivial (singola costante, 1 riga)
+- Classification ovvia senza ambiguità (dead code grep 0 → kill diretto)
+- Già classificato in archive MANIFEST esistente

--- a/flint/claude-integration/memory/reference_classification_4d.md
+++ b/flint/claude-integration/memory/reference_classification_4d.md
@@ -1,0 +1,52 @@
+---
+name: Classification 4D framework (Flint standard)
+description: 4-axis framework per classificare asset (code/memory/doc/skill) prima di keep/kill/archive. Derivato da kill-60 Flint sessione 2026-04-18.
+type: reference
+---
+
+Framework 4D riusabile per decisioni kill/keep/archive su asset software. Applicare PRIMA di eliminare o codificare, non dopo.
+
+## I 4 assi
+
+| Asse               | Valori                                                                     | Domanda che risponde                     |
+| ------------------ | -------------------------------------------------------------------------- | ---------------------------------------- |
+| **Valore scope**   | 🟢 alto · 🟡 medio · 🔴 basso                                              | Serve davvero al progetto?               |
+| **Applicabilità**  | universal / gamedev / data-ops / solo-dev / single-user / `<project>`-only | Chi può riusarlo oltre me?               |
+| **Stato sviluppo** | production / experimental / draft / deprecated / consolidated / killed     | Maturità code/doc?                       |
+| **Re-open cost**   | XS (<30min) · S (≤2h) · M (≤1gg) · L (>1gg) · XL (>settimana)              | Se kill e devo riportarlo, quanto costa? |
+
+## Quando applicare
+
+- Prima di archive (MANIFEST 4D obbligatorio, vedi `flint/archive-template/MANIFEST-template.md`)
+- Prima di codificare memory file (gate: osservato ≥3 volte + 🟢 valore)
+- Durante parked ideas catalog (`IDEAS_INDEX.md` format canonico)
+- In ADR kill decision (per giustificare voto)
+
+## Regola kill-60
+
+Asset 🔴 basso + single-user + draft + XS/S re-open cost → **kill candidate**.
+Asset 🟢 alto + universal + production + L re-open cost → **keep hard**.
+
+## Esempi riusciti
+
+- **Flint achievement system** (PR #1556): 🔴 · single-user · draft · S → killed (research backfire)
+- **Hook post-commit auto-speak** (PR #1558): 🔴 · single-user · draft · XS → killed (friction)
+- **`/meta-checkpoint` command** (PR #1553): 🟢 · universal · production · L → **keep** (riusabile cross-project)
+- **Research-critique §9** (flint/claude-integration): 🟢 · universal · production · M → **keep**
+
+## Output canonico (tabella)
+
+```
+| Dimensione     | Valore                  |
+|----------------|-------------------------|
+| Valore scope   | 🟢 / 🟡 / 🔴            |
+| Applicabilità  | <categoria>             |
+| Stato sviluppo | <stato>                 |
+| Re-open cost   | XS / S / M / L / XL     |
+```
+
+## Cross-ref
+
+- Slash command: `/classify-4d <asset>` (se disponibile)
+- Template archive: `flint/archive-template/MANIFEST-template.md`
+- Workflow origin: kill-60 Flint sessione 2026-04-18 (voto 4/10, 40+ fonti)


### PR DESCRIPTION
## Summary

Estende Flint claude-integration layer v0.2.3:

- **memory/reference_classification_4d.md** — framework 4D standalone riusabile (valore/applicabilità/stato/re-open cost) con esempi kill-60 Flint
- **commands/classify-4d.md** — slash `/classify-4d <asset>` → tabella 4D + raccomandazione atomica (KILL/KEEP/REFACTOR/PROMOTE/PARK)
- **README.md** — aggiornato tree + verify step

## Motivazione

Gap identificato: framework 4D era solo in `archive-template/MANIFEST-template.md` (post-decision). Mancava invocazione pre-decision per classificare asset prima di keep/kill.

Gemello dialettico di `/meta-checkpoint` (self-audit interno) + `/research-critique` (§9 workflow esterno): `/classify-4d` = triage atomico per asset singolo.

## Impatto distribution

`install.py` usa `glob(\"*.md\")` su commands/memory — raccoglie automaticamente i nuovi file. Nessuna modifica install logic.

Adopter esistenti ricevono classify-4d al prossimo `python3 flint/install.py --overwrite`.

## Test plan

- [x] File frontmatter valido (type=reference + user_invocable=true)
- [x] Prettier auto-format (husky pre-commit)
- [x] Cross-ref coerente con archive-template/MANIFEST-template.md
- [ ] Merge: governance CI verde

## Rollback

Revert singolo commit. Zero impact su Flint core (Python CLI) — layer claude-integration additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)