### PR TITLE
feat(combat): wire reinforcementSpawner + objectiveEvaluator step 1 (ADR-04-19/04-20)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -692,6 +692,9 @@ function createSessionRouter(options = {}) {
         hazard_tiles: Array.isArray(req.body?.hazard_tiles) ? req.body.hazard_tiles : [],
         // Q-001 T2.3: difficulty profile scaling metadata (null se profile invalid)
         _difficultyProfile: difficultyProfileMeta,
+        // ADR-2026-04-19 + 04-20: encounter payload per reinforcementSpawner + objectiveEvaluator.
+        // Feature flag OFF default: se undefined, entrambi moduli ritornano no-op.
+        encounter: req.body?.encounter ?? null,
       };
       sessions.set(sessionId, session);
       activeSessionId = sessionId;

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -32,6 +32,8 @@ const {
   recordAttackForCombo,
   resetRoundAttackTracker,
 } = require('../services/squadCoordination');
+const { tick: reinforcementTick } = require('../services/combat/reinforcementSpawner');
+const { evaluateObjective } = require('../services/combat/objectiveEvaluator');
 
 function createRoundBridge(deps) {
   const {
@@ -942,6 +944,28 @@ function createRoundBridge(deps) {
       );
     }
 
+    // ADR-2026-04-19 + 04-20 wiring (feature flag OFF by default).
+    // session.encounter undefined → both modules return no-op.
+    const reinforcementResult = reinforcementTick(session, session.encounter);
+    for (const rec of reinforcementResult.spawned || []) {
+      if (rec.skipped) continue;
+      await appendEvent(session, {
+        action_type: 'reinforcement_spawn',
+        turn: session.turn,
+        actor_id: rec.spawned_unit_id,
+        target_id: null,
+        damage_dealt: 0,
+        result: 'spawned',
+        position_from: null,
+        position_to: rec.spawn_tile,
+        unit_id: rec.unit_id,
+        wave_index: rec.wave_index,
+        tier_at_spawn: rec.tier_at_spawn,
+        automatic: true,
+      });
+    }
+    const objectiveResult = evaluateObjective(session, session.encounter);
+
     return {
       session_id: session.session_id,
       turn: session.turn,
@@ -954,6 +978,8 @@ function createRoundBridge(deps) {
       round_wrapper: true,
       round_phase: session.roundState.round_phase,
       round_decisions: decisions,
+      reinforcement_spawned: reinforcementResult.spawned || [],
+      objective_state: objectiveResult,
     };
   }
 

--- a/tests/api/sessionEncounterWiring.test.js
+++ b/tests/api/sessionEncounterWiring.test.js
@@ -1,0 +1,86 @@
+// Integration test per ADR-2026-04-19 (reinforcementSpawner) + ADR-2026-04-20
+// (objectiveEvaluator) wiring in sessionRoundBridge.handleTurnEndViaRound.
+//
+// Copre 3 casi feature-flag OFF default:
+//   1. session senza encounter payload → entrambi moduli no-op
+//   2. encounter senza reinforcement_policy → reinforcement_spawned=[] skipped
+//   3. encounter con objective.type='elimination' → objective_state popolato
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createFlaggedApp, startSession, turnEnd, twoUnits } = require('./sessionTestHelpers');
+
+test('turn/end: session senza encounter → reinforcement + objective no-op', async (t) => {
+  const handle = createFlaggedApp('true');
+  t.after(async () => {
+    handle.restore();
+    if (typeof handle.close === 'function') await handle.close().catch(() => {});
+  });
+
+  const sessionId = await startSession(handle.app, twoUnits());
+  const res = await turnEnd(handle.app, sessionId);
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(res.body.reinforcement_spawned, []);
+  assert.equal(res.body.objective_state.reason, 'no_objective');
+  assert.equal(res.body.objective_state.completed, false);
+  assert.equal(res.body.objective_state.failed, false);
+});
+
+test('turn/end: encounter senza reinforcement_policy → skipped policy_disabled', async (t) => {
+  const handle = createFlaggedApp('true');
+  t.after(async () => {
+    handle.restore();
+    if (typeof handle.close === 'function') await handle.close().catch(() => {});
+  });
+
+  const res = await request(handle.app)
+    .post('/api/session/start')
+    .send({
+      units: twoUnits(),
+      encounter: {
+        id: 'enc_test',
+        objective: { type: 'elimination' },
+        // no reinforcement_policy
+      },
+    })
+    .expect(200);
+  const sessionId = res.body.session_id;
+
+  const endRes = await turnEnd(handle.app, sessionId);
+  assert.equal(endRes.status, 200);
+  assert.deepEqual(endRes.body.reinforcement_spawned, []);
+  // objective elimination: SIS alive → not completed
+  assert.equal(endRes.body.objective_state.reason !== 'no_objective', true);
+});
+
+test('turn/end: encounter.objective.type=elimination valuta alive SIS', async (t) => {
+  const handle = createFlaggedApp('true');
+  t.after(async () => {
+    handle.restore();
+    if (typeof handle.close === 'function') await handle.close().catch(() => {});
+  });
+
+  const res = await request(handle.app)
+    .post('/api/session/start')
+    .send({
+      units: twoUnits(),
+      encounter: {
+        id: 'enc_test_elim',
+        objective: { type: 'elimination' },
+      },
+    })
+    .expect(200);
+  const sessionId = res.body.session_id;
+
+  const endRes = await turnEnd(handle.app, sessionId);
+  assert.equal(endRes.status, 200);
+  assert.equal(endRes.body.objective_state.completed, false);
+  // Progress include sistema/player alive counts
+  assert.ok(endRes.body.objective_state.progress);
+});


### PR DESCRIPTION
## Summary

Step 1 wiring sicuro — feature flag OFF default.

- `reinforcementSpawner.tick()` + `evaluateObjective()` invocati in `handleTurnEndViaRound` post side-effects + round-decay
- Graceful no-op se `session.encounter === null` (default) → zero impact scenari esistenti
- Nuovi campi response: `reinforcement_spawned`, `objective_state`
- Raw event `action_type='reinforcement_spawn'` emesso per vcScoring

## Changes

- `apps/backend/routes/session.js` `/start`: accetta `req.body.encounter` payload, stash in `session.encounter` (null default)
- `apps/backend/routes/sessionRoundBridge.js`: +26 LOC wire
- `tests/api/sessionEncounterWiring.test.js`: 3 test integration (3/3 pass)

## Verification

- `node --test tests/api/sessionEncounterWiring.test.js` → 3/3 pass
- `node --test tests/ai/*.test.js` → 161/161 pass (regression OK)
- Net delta: +115 LOC (3 files)

## Scope

- Feature flag OFF default (no schema change, no data change)
- Encounter authoring + schema update deferred a PR separate (step 2+)
- Non tocca `/commit-round` auto_resolve path (follow-up)

## Guardrail

- ✅ 50-line rule: 29 LOC apps/backend/, 86 LOC test
- ✅ No touch `.github/workflows/`, `migrations/`, `packages/contracts/`, `services/generation/`
- ✅ No new npm/pip deps

## Rollback

Revert commit — moduli rimangono pure, no side effects persistenti.

Refs: ADR-2026-04-19 (reinforcementSpawner), ADR-2026-04-20 (objectiveEvaluator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)