### PR TITLE
feat(encounters): visual_mood metadata + retrofit 9 scenari (M3.6)

### DIFF
--- a/docs/planning/encounters/enc_capture_01.yaml
+++ b/docs/planning/encounters/enc_capture_01.yaml
@@ -67,3 +67,9 @@ didactic_focus:
   - time_pressure
 
 narrative: {}
+
+# Art direction metadata (docs/core/41-ART-DIRECTION.md)
+visual_mood:
+  mood_tag: archeologico
+  lighting: fredda_obliqua
+  particle_effect: polvere_millenaria

--- a/docs/planning/encounters/enc_caverna_02.yaml
+++ b/docs/planning/encounters/enc_caverna_02.yaml
@@ -63,3 +63,9 @@ tags: [standard]
 narrative:
   briefing_ink: stories/enc_caverna_02_briefing.ink.json
   debrief_ink: stories/enc_caverna_02_debrief.ink.json
+
+# Art direction metadata (docs/core/41-ART-DIRECTION.md)
+visual_mood:
+  mood_tag: claustrofobia
+  lighting: bassa_puntiforme
+  particle_effect: bioluminescenza_drift

--- a/docs/planning/encounters/enc_escort_01.yaml
+++ b/docs/planning/encounters/enc_escort_01.yaml
@@ -73,3 +73,9 @@ didactic_focus:
   - target_prioritization
 
 narrative: {}
+
+# Art direction metadata (docs/core/41-ART-DIRECTION.md)
+visual_mood:
+  mood_tag: esposizione
+  lighting: alta_calda_dall_alto
+  particle_effect: polvere_secca

--- a/docs/planning/encounters/enc_frattura_03.yaml
+++ b/docs/planning/encounters/enc_frattura_03.yaml
@@ -101,3 +101,10 @@ conditions:
     effect: memory_fog
 
 tags: [boss, survival, storm]
+
+# Art direction metadata (docs/core/41-ART-DIRECTION.md)
+visual_mood:
+  mood_tag: tensione_mistero
+  lighting: bassa_bioluminescente
+  particle_effect: onde_sinaptiche
+  accent_override: '#3d1e5a'

--- a/docs/planning/encounters/enc_hardcore_reinf_01.yaml
+++ b/docs/planning/encounters/enc_hardcore_reinf_01.yaml
@@ -80,3 +80,10 @@ didactic_focus:
   - ai_progress_reading
 
 narrative: {}
+
+# Art direction metadata (docs/core/41-ART-DIRECTION.md)
+visual_mood:
+  mood_tag: archeologico
+  lighting: fredda_obliqua
+  particle_effect: cenere_sospesa
+  accent_override: '#b8935a'

--- a/docs/planning/encounters/enc_savana_01.yaml
+++ b/docs/planning/encounters/enc_savana_01.yaml
@@ -56,3 +56,9 @@ tags: [standard]
 narrative:
   briefing_ink: stories/savana_01_briefing.ink.json
   debrief_ink: stories/savana_01_debrief.ink.json
+
+# Art direction metadata (docs/core/41-ART-DIRECTION.md)
+visual_mood:
+  mood_tag: esposizione
+  lighting: alta_calda_dall_alto
+  particle_effect: polvere_secca

--- a/docs/planning/encounters/enc_survival_01.yaml
+++ b/docs/planning/encounters/enc_survival_01.yaml
@@ -70,3 +70,9 @@ didactic_focus:
   - position_retention
 
 narrative: {}
+
+# Art direction metadata (docs/core/41-ART-DIRECTION.md)
+visual_mood:
+  mood_tag: claustrofobia
+  lighting: bassa_puntiforme
+  particle_effect: bioluminescenza_drift

--- a/docs/planning/encounters/enc_tutorial_01.yaml
+++ b/docs/planning/encounters/enc_tutorial_01.yaml
@@ -50,3 +50,9 @@ didactic_focus:
 narrative:
   briefing_ink: stories/tutorial_01_briefing.ink.json
   debrief_ink: stories/tutorial_01_debrief.ink.json
+
+# Art direction metadata (docs/core/41-ART-DIRECTION.md)
+visual_mood:
+  mood_tag: esposizione
+  lighting: alta_calda_dall_alto
+  particle_effect: polvere_secca

--- a/docs/planning/encounters/enc_tutorial_02.yaml
+++ b/docs/planning/encounters/enc_tutorial_02.yaml
@@ -61,3 +61,10 @@ didactic_focus:
 narrative:
   briefing_ink: stories/tutorial_02_briefing.ink.json
   debrief_ink: stories/tutorial_02_debrief.ink.json
+
+# Art direction metadata (docs/core/41-ART-DIRECTION.md)
+visual_mood:
+  mood_tag: esposizione
+  lighting: alta_calda_dall_alto
+  particle_effect: polvere_secca
+  accent_override: '#d4884a'

--- a/schemas/evo/encounter.schema.json
+++ b/schemas/evo/encounter.schema.json
@@ -277,6 +277,30 @@
         "max_total_spawns": { "type": "integer", "minimum": 0 },
         "min_distance_from_pg": { "type": "integer", "minimum": 0, "default": 3 }
       }
+    },
+    "visual_mood": {
+      "type": "object",
+      "description": "Art direction metadata per encounter (docs/core/41-ART-DIRECTION.md). Referenzia palette bioma + lighting + particle effect + optional accent override. Opzionale, no-op runtime.",
+      "additionalProperties": false,
+      "properties": {
+        "mood_tag": {
+          "type": "string",
+          "description": "Mood from 41-AD palette matrix (es. esposizione, claustrofobia, tensione_mistero, densita_tossica, onirico_sporale, archeologico, vivacita_acquatica, pericolo_calore, astratto_digitale)"
+        },
+        "lighting": {
+          "type": "string",
+          "description": "Light direction from 41-AD (es. alta_calda_dall_alto, bassa_puntiforme, filtrata_verdastra, diffusa_violacea, fredda_obliqua, bassa_bioluminescente, chiaroscuro_subacqueo, calda_dal_basso, neutra_diffusa)"
+        },
+        "particle_effect": {
+          "type": "string",
+          "description": "Particelle ambientali semantiche (es. polvere_secca, spore_fluttuanti, bioluminescenza_drift, scintille_magma, onde_sinaptiche, bolle_reef, cenere_sospesa)"
+        },
+        "accent_override": {
+          "type": "string",
+          "pattern": "^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$",
+          "description": "Optional palette accent override per encounter (hex 6 o 8 digit). Override accent 1 del bioma se presente."
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Schema `encounter.schema.json` estende con `visual_mood` object opzionale (ref `41-ART-DIRECTION.md` palette matrix). Retrofit 9 encounter YAML.

## Schema change

```json
"visual_mood": {
  "type": "object",
  "properties": {
    "mood_tag": "string",           // da 41-AD palette matrix
    "lighting": "string",            // from 41-AD light direction
    "particle_effect": "string",     // semantiche ambientali
    "accent_override": "string"      // hex ^#[0-9a-fA-F]{6,8}$
  }
}
```

Backward compatible: campo opzionale. Runtime no-op (consumato solo da art tools + future renderer).

## Retrofit 9 encounter

| Encounter | Bioma | mood_tag | lighting |
|-----------|-------|----------|----------|
| enc_tutorial_01 | savana | esposizione | alta_calda_dall_alto |
| enc_tutorial_02 | savana | esposizione | alta_calda_dall_alto |
| enc_savana_01 | savana | esposizione | alta_calda_dall_alto |
| enc_escort_01 | savana | esposizione | alta_calda_dall_alto |
| enc_caverna_02 | caverna | claustrofobia | bassa_puntiforme |
| enc_survival_01 | caverna_sotterranea | claustrofobia | bassa_puntiforme |
| enc_frattura_03 | frattura_abissale_sinaptica | tensione_mistero | bassa_bioluminescente |
| enc_capture_01 | rovine_planari | archeologico | fredda_obliqua |
| enc_hardcore_reinf_01 | rovine_planari | archeologico | fredda_obliqua |

## Verification

- `node --test tests/scripts/encounterSchema.test.js` → 12/12 pass (9 encounter + schema valid JSON + visual_mood pattern)

## Guardrail

- ✅ Schema change minimal (1 nuovo field opzionale)
- ✅ No code change runtime
- ✅ No breaking change scenari esistenti

Parent: #1577 (ADR), #1578 (41-AD), #1579 (42-SG)
Refs: ADR-2026-04-18, docs/core/41-ART-DIRECTION.md §palette matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)