### PR TITLE
chore(gitignore): ignore local dev artifacts (.claude/worktrees, Lib/, pip*.exe)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,13 @@ reports/backups/**/*.zip
 # Claude Code per-user whitelist (auto-aggiornato dai hook)
 .claude/settings.local.json
 
+# Claude Code sub-worktrees (local dev state, non da committare)
+.claude/worktrees/
+
+# Python venv artifact (creati da pip install side effect su Windows)
+Lib/
+scripts/pip*.exe
+
 # Backend runtime artifacts (log audit, snapshot di stato)
 apps/backend/logs/
 reports/status.json


### PR DESCRIPTION
## Summary

Aggiunge pattern .gitignore per artefatti locali Windows/Claude Code noise (+37086 LOC).

## Patterns

- `.claude/worktrees/` — sub-worktrees Claude Code (local dev state)
- `Lib/` — Python venv site-packages (pip install side effect su Windows)
- `scripts/pip*.exe` — pip executables

## Trigger

Working tree post-sessione M3.5 + M3.6 mostrava +37086 LOC untracked (principalmente `Lib/site-packages/` Python venv). Tutti artefatti locali, NON da committare.

## Verification

- `git status` post-patch: untracked list pulita (solo `reports/docs/governance_drift_report.json` modificato, già tracked)

## Guardrail

- ✅ Un solo file modificato (.gitignore)
- ✅ Zero code/schema change
- ✅ No deletion file esistenti

🤖 Generated with [Claude Code](https://claude.com/claude-code)