### PR TITLE
fix(rules): TKT-06 predict_combat + resolve_action include unit.mod parity

### DIFF
--- a/services/rules/resolver.py
+++ b/services/rules/resolver.py
@@ -610,10 +610,14 @@ def resolve_action(
                 elif pt_spend.get("type") == "spinta":
                     spinta_active = True
 
-        attack_mod = aggregate_mod(actor.get("trait_ids", []), catalog, "attack_mod")
+        # TKT-06 parity con JS resolveAttack: include actor.mod + target.mod
+        # (stat base species/job) nei modifier aggregati.
+        attack_mod = aggregate_mod(actor.get("trait_ids", []), catalog, "attack_mod") + int(
+            actor.get("mod", 0)
+        )
         defense_mod_target = aggregate_mod(
             target.get("trait_ids", []), catalog, "defense_mod"
-        )
+        ) + int(target.get("mod", 0))
         trait_damage_step = aggregate_mod(
             actor.get("trait_ids", []), catalog, "damage_step"
         )
@@ -1120,10 +1124,14 @@ def predict_combat(
     """
     import copy
 
-    attack_mod = aggregate_mod(attacker.get("trait_ids", []), catalog, "attack_mod")
+    # TKT-06 parity con JS resolveAttack: include unit.mod stat in attack_mod + cd.
+    # aggregate_mod copre solo i trait; unit.mod è lo stat base species/job.
+    attack_mod = aggregate_mod(attacker.get("trait_ids", []), catalog, "attack_mod") + int(
+        attacker.get("mod", 0)
+    )
     defense_mod_target = aggregate_mod(
         target.get("trait_ids", []), catalog, "defense_mod"
-    )
+    ) + int(target.get("mod", 0))
     terrain_defense = int(target.get("terrain_defense_mod", 0))
     cd = ATTACK_CD_BASE + int(target.get("tier", 1)) + defense_mod_target + terrain_defense
     trait_step = aggregate_mod(attacker.get("trait_ids", []), catalog, "damage_step")

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -63,6 +63,7 @@ from rules.resolver import (  # noqa: E402
     compute_step_count,
     compute_step_flat_bonus,
     get_status,
+    predict_combat,
     resolve_action,
     resolve_parry,
 )
@@ -1238,3 +1239,50 @@ def test_pp_accumulates_without_cap(catalog):
     )
     # 9 + 1 (hit) + 2 (kill) = 12
     assert actor_after["pp"] == 12
+
+
+# --- TKT-06: unit.mod parity con JS resolveAttack --------------------------
+
+
+def test_predict_combat_includes_attacker_mod(catalog):
+    """TKT-06: predict_combat somma attacker.mod allo attack_mod aggregato.
+
+    Parity con JS sessionHelpers.predictCombat che usa `actor.mod` come base.
+    """
+    attacker = {"mod": 3, "trait_ids": [], "damage_dice": {"count": 1, "sides": 6, "modifier": 0}}
+    target = {"hp": 10, "tier": 1, "trait_ids": []}
+    baseline = predict_combat({"mod": 0, "trait_ids": []}, target, catalog, n=100)
+    boosted = predict_combat(attacker, target, catalog, n=100)
+    assert boosted["attack_mod"] == baseline["attack_mod"] + 3
+    # Più attack_mod → più hit_pct a parità di CD
+    assert boosted["hit_pct"] >= baseline["hit_pct"]
+
+
+def test_predict_combat_includes_target_mod(catalog):
+    """TKT-06: predict_combat somma target.mod al CD (via defense_mod)."""
+    attacker = {"mod": 0, "trait_ids": [], "damage_dice": {"count": 1, "sides": 6, "modifier": 0}}
+    baseline = predict_combat(attacker, {"hp": 10, "tier": 1, "mod": 0, "trait_ids": []}, catalog, n=100)
+    armored = predict_combat(attacker, {"hp": 10, "tier": 1, "mod": 4, "trait_ids": []}, catalog, n=100)
+    assert armored["cd"] == baseline["cd"] + 4
+    # Più CD → meno hit_pct
+    assert armored["hit_pct"] <= baseline["hit_pct"]
+
+
+def test_resolve_action_includes_actor_mod(catalog):
+    """TKT-06: resolve_action(attack) include actor.mod nel total tiro.
+
+    nat 8 + actor.mod 4 = 12 vs CD 12 (power 4 tier 2) → success mos 0.
+    Senza fix (pre-TKT-06), total sarebbe 8 < 12 → miss.
+    """
+    state = _mini_state(catalog)
+    actor = state["units"][0]
+    actor["mod"] = 4
+    rng = rng_from_sequence([
+        7 / 20,  # nat 8
+        4 / 8,   # damage 5
+    ])
+    result = resolve_action(state, _attack(), catalog, rng)
+    roll = result["turn_log_entry"]["roll"]
+    assert roll["natural"] == 8
+    assert roll["success"] is True, "actor.mod=4 deve promuovere nat 8 a hit (total 12 = CD 12)"
+    assert roll["mos"] == 0


### PR DESCRIPTION
## Summary

Python rules engine (`services/rules/resolver.py`) computava `attack_mod` usando solo `aggregate_mod(trait_ids)` ignorando `actor.mod` + `target.mod` (stat base species/job). Divergenza con JS `resolveAttack` + `predictCombat` in `apps/backend/routes/sessionHelpers.js` che usa `actor.mod` direttamente.

Closes: **TKT-06** (FU-M3 backlog, `project_sprint_m3_telemetry_adr.md`)

## Changes

- `resolve_attack_v2` (line 613-616): `attack_mod = aggregate_mod + actor.mod`; `defense_mod_target += target.mod`
- `predict_combat` (line 1123-1128): stesso pattern applicato su attacker/target

## Test

- 3 nuovi test `tests/test_resolver.py`:
  - `test_predict_combat_includes_attacker_mod`
  - `test_predict_combat_includes_target_mod`
  - `test_resolve_action_includes_actor_mod` (nat 8 + actor.mod=4 = 12 vs CD 12 → success)
- **Regression: 223/223 rules+hydration+round+demo_cli pass** (76+18+106+23)
- Zero breaking: fixture `build_party_unit` + `build_hostile_unit_from_group` non settano unit.mod → `int(actor.get("mod", 0))` = 0, existing test invariati

## Impact

- Harness Python (`tools/py/simulate_balance.py`, `tools/py/batch_calibrate_hardcore06.py`) ora produce predizioni consistenti con session live JS
- `demo_cli.py` + `worker.py` beneficiano della stessa parity
- Zero impact su production backend (usa JS resolver, già corretto)

## Rollback

Revert singolo commit. Zero breaking su test esistenti.

🤖 Generated with [Claude Code](https://claude.com/claude-code)