### PR TITLE
perf(harness): TKT-D batch_calibrate_hardcore06 legge vc_snapshot da /end

### DIFF
--- a/tools/py/batch_calibrate_hardcore06.py
+++ b/tools/py/batch_calibrate_hardcore06.py
@@ -308,12 +308,18 @@ def run_one(host, run_idx):
                            for u_id, u in final_units.items() if u.get("controlled_by") == "player")
     boss_hp_remaining = final_units.get("e_apex_boss", {}).get("hp", 0)
 
-    # VC scores.
-    vc_status, vc = get(f"{host}/api/session/{sid}/vc")
-    vc_data = vc if vc_status == 200 else {}
-
-    # Cleanup.
-    post(f"{host}/api/session/end", {"session_id": sid})
+    # VC scores — TKT-D FU-M3: PR #1564 espone vc_snapshot direttamente
+    # nel response di /end, risparmiando una GET /vc per run.
+    end_status, end_res = post(f"{host}/api/session/end", {"session_id": sid})
+    vc_data = {}
+    if end_status == 200 and isinstance(end_res, dict):
+        vc_snapshot = end_res.get("vc_snapshot") or {}
+        vc_data = vc_snapshot
+    else:
+        # Fallback legacy: GET /vc se /end non ha vc_snapshot (non dovrebbe mai
+        # accadere post PR #1564, tenuto per sicurezza).
+        vc_status, vc = get(f"{host}/api/session/{sid}/vc")
+        vc_data = vc if vc_status == 200 else {}
 
     return {
         "run": run_idx,


### PR DESCRIPTION
## Summary

FU-M3 TKT-D: allineamento harness batch_calibrate_hardcore06 a [PR #1564](https://github.com/MasterDD-L34D/Game/pull/1564) che espone \`vc_snapshot\` nel response di \`POST /api/session/end\`.

## Changes

- **Prima**: sequence \`GET /vc\` + \`POST /end\` = 2 HTTP roundtrip per run
- **Dopo**: capture \`end_res.get(\"vc_snapshot\")\` = 1 roundtrip per run
- Fallback legacy \`GET /vc\` mantenuto per safety

## Impact

- N=30 batch run → ~30 HTTP call risparmiate (~0.5-1s per batch totale)
- Harness parity con response shape ottimizzato PR #1564

## Test

Syntax verify: \`python -m ast tools/py/batch_calibrate_hardcore06.py\` pass.
Esecuzione reale richiede backend running + enc_hardcore_06 scenario — out of scope CI.

## Closes

FU-M3 TKT-D

🤖 Generated with [Claude Code](https://claude.com/claude-code)