### PR TITLE
play: M4 first user playtest enc_tutorial_01 — win T3

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -25,6 +25,12 @@
       "runtimeArgs": ["run", "start:api"],
       "port": 3335,
       "env": { "PORT": "3335" }
+    },
+    {
+      "name": "play",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "play:dev"],
+      "port": 5180
     }
   ]
 }

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -4804,6 +4804,19 @@
       "track": "new"
     },
     {
+      "path": "docs/playtest/2026-04-18-M4-user-playtest-enc_tutorial_01.md",
+      "title": "M4 User playtest — enc_tutorial_01 (Primi passi nella Savana)",
+      "doc_status": "active",
+      "doc_owner": "master-dd",
+      "workstream": "ops-qa",
+      "last_verified": "2026-04-18",
+      "source_of_truth": false,
+      "language": "it",
+      "review_cycle_days": 30,
+      "primary": false,
+      "track": "new"
+    },
+    {
       "path": "docs/playtest/BAL-03-ondata4-playbook.md",
       "title": "Playbook BAL-03 — Ondata 4 (richiesta QA)",
       "doc_status": "historical_ref",

--- a/docs/playtest/2026-04-18-M4-user-playtest-enc_tutorial_01.md
+++ b/docs/playtest/2026-04-18-M4-user-playtest-enc_tutorial_01.md
@@ -1,0 +1,173 @@
+---
+title: M4 User playtest — enc_tutorial_01 (Primi passi nella Savana)
+doc_status: active
+doc_owner: master-dd
+workstream: ops-qa
+last_verified: '2026-04-18'
+source_of_truth: false
+language: it
+review_cycle_days: 30
+---
+
+# M4 User playtest — enc_tutorial_01 (Primi passi nella Savana)
+
+Primo playtest reale user-driven post-sessione 28 PR (2026-04-18). Obiettivi: validare kill-60 feature decisions, raccogliere gameplay trace per eval set Flint v0.3, testare UI `apps/play/` end-to-end su canvas 2D.
+
+## Setup
+
+- **Date**: 2026-04-18 15:18–15:31 (13 min totali)
+- **Scenario**: `enc_tutorial_01` (savana, diff 1/5, grid 6×6 — note: YAML dichiara 8×8, session internal usa 6×6 default)
+- **Party**: 2 PG (p_scout skirmisher + p_tank vanguard) vs 2 SIS (e_nomad_1 + e_nomad_2)
+- **Interface**: browser canvas 2D `apps/play/` port 5180 (Vite dev server)
+- **Backend**: port 3334 (npm run start:api), session `ae96d108-762a-48a6-a4a1-d393c88114e5`
+- **Player**: Master DD, decisione user-driven via browser click (sample zero-AI-ghostwriting)
+- **Trace persisted**: `logs/m4_playtest_enc_tutorial_01_ae96d108.json` (17 eventi)
+
+## Outcome
+
+🏆 **VITTORIA turno 3**
+
+| Metrica             |         Valore         |
+| ------------------- | :--------------------: |
+| Turni totali        |           3            |
+| HP persi PG         | 3 (p_scout hit turn 1) |
+| HP inflitti Sistema |   8 (total kill 3+5)   |
+| p_scout HP finale   |          7/10          |
+| p_tank HP finale    |         12/12          |
+| Enemies alive       |          0/2           |
+
+## Trace completo (17 eventi)
+
+### Turn 1 (6 eventi)
+
+```
+p_scout → atk e_nomad_1 : miss
+p_scout → atk e_nomad_1 : hit 1 dmg
+p_scout → atk e_nomad_1 : hit 1 dmg  (e_nomad_1 3→1 HP)
+p_tank → move
+p_tank → move             (da [1,3] verso [3,3])
+sistema → atk p_scout : hit 3 dmg  (p_scout 10→7 HP, PANIC status triggered)
+```
+
+**Observation T1**: p_scout ha speso 3 AP in attacks (3 attack invece 1 move+1 attack). Panic status applicato da SIS hit.
+
+### Turn 2 (8 eventi)
+
+```
+p_scout → atk e_nomad_1 : miss
+p_scout → atk e_nomad_1 : hit 5 dmg  (CRIT — 5 dmg overkill su 1HP remaining)
+p_scout → kill e_nomad_1  (automatic event)
+p_scout → move
+p_tank → atk e_nomad_2 : hit 2 dmg  (e_nomad_2 5→3 HP)
+p_tank → ability e_nomad_2 : hit 2 dmg  (shield_bash: 3→1 HP + push + sbilanciato status)
+p_tank → move
+sistema → move  (auto)
+```
+
+**Observation T2**:
+
+- p_scout ha finalmente killato e_nomad_1 al secondo tentativo (primo miss)
+- p_tank ha executed user strategia: attack + shield_bash (ability) + move — 3 AP consumati coerenti
+- shield_bash hit 2 dmg + applica sbilanciato (1 turn) coerente con spec `abilities vanguard`
+
+### Turn 3 (3 eventi)
+
+```
+p_tank → move  (raggiunto e_nomad_2 post-push)
+p_tank → atk e_nomad_2 : hit 4 dmg  (1→0 HP)
+p_tank → kill e_nomad_2  (automatic)
+```
+
+**Observation T3**: chiusura pulita, p_tank finisce e_nomad_2 post-push shield_bash.
+
+## Kill-60 validation — features under test
+
+| Feature                                         | Testato |            Verdetto            |
+| ----------------------------------------------- | :-----: | :----------------------------: |
+| UI Canvas 2D tile-based (42-SG hierarchy)       |   ✅    |          🟢 leggibile          |
+| HP bar color coded (verde/giallo/rosso)         |   ✅    |          🟢 funziona           |
+| Active unit marker (yellow triangolo)           |   ✅    | 🟡 divergenza header vs canvas |
+| Status icon chip sopra unit (Panic (2))         |   ✅    |      🟢 visibile + label       |
+| Faction color coding (cyan player, red sistema) |   ✅    |           🟢 chiaro            |
+| AP consumption feedback in sidebar              |   ✅    |          🟢 realtime           |
+| Error messages AP insufficienti                 |   ✅    |        🟢 testo chiaro         |
+| Ability sidebar (shield_bash)                   |   ✅    |          🟢 funziona           |
+| End-game modal "Vittoria!" con metriche         |   ✅    |    🟢 leggibile + metriche     |
+
+**Scorecard**: 8/9 🟢, 1/9 🟡.
+
+## Findings
+
+### ⚠ Bug UX #1 — Divergenza active marker
+
+Turn 2 header dice `Active: p_scout` ma canvas yellow triangolo visibile su `p_tank`. Inconsistenza:
+
+- Se p_scout è active, yellow triangle dovrebbe essere su p_scout
+- Possibile cause: active_unit state non sync con canvas render post-action
+
+**Severity**: medio (confusione UX ma non blocca gameplay)
+**Reproducible**: sì, turn 2 screenshot ricostruibile
+**Next step**: file issue `apps/play/render.js` active marker sync
+
+### ⚠ Bug UX #2 — Grid mismatch YAML vs session
+
+YAML encounter_tutorial_01 dichiara `grid_size: [8, 8]` ma session internal usa 6×6 default (GRID_SIZE constant). Canvas render 6×6.
+
+**Severity**: basso (no gameplay impact per tutorial_01, ma scenari larger potrebbero rompere)
+**Next step**: verify backend session creation rispetta scenario.grid_size OR documenta override intentional
+
+### ✅ Positive UX #1 — Error messages AP
+
+`"AP insufficienti per muoversi di 5 celle (ap residui 1)"` — messaggio italiano chiaro, include distanza + AP rimasti. Buon segnale UX M3.8+ spec.
+
+### ✅ Positive UX #2 — Ability UI working
+
+shield_bash cliccato da sidebar → applied + status sbilanciato + push 1 cell. Flow ability end-to-end OK.
+
+## Engagement curve reale
+
+| Turn | Decisioni player                       | Tempo dal start |           Engagement            |
+| :--: | -------------------------------------- | :-------------: | :-----------------------------: |
+|  1   | 3 attack p_scout + 2 move p_tank       |     ~5 min      | Medium (apprendimento controls) |
+|  2   | split focus (p_scout ksy, p_tank bash) |     ~3 min      |    High (tattica sinergica)     |
+|  3   | finish (p_tank move + kill)            |     ~2 min      |          Low (mop-up)           |
+
+**Curva**: start plateau → peak T2 → decline T3. Tutorial pacing accettabile per first playtest.
+
+## Eval set Flint v0.3 — positive samples
+
+Trace `logs/m4_playtest_enc_tutorial_01_ae96d108.json` usabile come positive sample per:
+
+- **play: commit classification** (questo commit stesso = sample)
+- **Gameplay decision patterns** (split focus vs overkill)
+- **Error recovery UX** (AP insufficienti → user re-click)
+
+## Q-OPEN da playtest
+
+- Q-OPEN-28: grid_size YAML override vs default — conservare?
+- Q-OPEN-29: active_unit sync canvas render (bug UX #1)
+- Q-OPEN-30: crit chance p_scout (hit 5 dmg su base weapon mod 3) — balance o intended?
+
+## Follow-up M4
+
+| ID  | Task                                                              | Priorità |
+| --- | ----------------------------------------------------------------- | :------: |
+| A   | File bug report active marker divergence                          |    🟢    |
+| B   | Verify grid_size backend consumption enc_tutorial_01              |    🟡    |
+| C   | Playtest enc_tutorial_02 → 05 stessa modalità (curva progressiva) |    🟡    |
+| D   | Eval set aggregator: raccogliere trace multiple per Flint v0.3    |    ⚪    |
+
+## Memo guardrail rispettati
+
+- Regola 50 righe: doc only, zero code
+- Zero meta-checkpoint (race memory con sessione parallela)
+- Trace committed in `logs/` (non in data/ per separation)
+- Prefix commit: `play:` (positive sample Flint v0.3)
+
+## Riferimenti
+
+- `logs/m4_playtest_enc_tutorial_01_ae96d108.json` — trace 17 eventi
+- `apps/play/` — UI Canvas 2D browser
+- `tools/py/master_dm.py` — alternative CLI path (non usato)
+- `docs/core/42-STYLE-GUIDE-UI.md` — hierarchy tested
+- `docs/core/41-ART-DIRECTION.md` — faction colors tested

--- a/logs/m4_playtest_enc_tutorial_01_ae96d108.json
+++ b/logs/m4_playtest_enc_tutorial_01_ae96d108.json
@@ -1,0 +1,537 @@
+[
+  {
+    "ts": "2026-04-18T13:22:18.003Z",
+    "session_id": "ae96d108-762a-48a6-a4a1-d393c88114e5",
+    "actor_id": "p_scout",
+    "actor_species": "dune_stalker",
+    "actor_job": "skirmisher",
+    "action_type": "attack",
+    "target_id": "e_nomad_1",
+    "turn": 1,
+    "ap_spent": 1,
+    "target_position_at_attack": {
+      "x": 3,
+      "y": 2
+    },
+    "die": 3,
+    "roll": 6,
+    "dc": 12,
+    "mos": -6,
+    "result": "miss",
+    "pt": 0,
+    "damage_dealt": 0,
+    "trait_effects": [
+      {
+        "trait": "zampe_a_molla",
+        "triggered": false,
+        "effect": "none"
+      }
+    ],
+    "target_hp_before": 3,
+    "target_hp_after": 3,
+    "position_from": {
+      "x": 1,
+      "y": 2
+    },
+    "position_to": {
+      "x": 1,
+      "y": 2
+    },
+    "action_index": 0,
+    "automatic": false
+  },
+  {
+    "ts": "2026-04-18T13:22:24.864Z",
+    "session_id": "ae96d108-762a-48a6-a4a1-d393c88114e5",
+    "actor_id": "p_scout",
+    "actor_species": "dune_stalker",
+    "actor_job": "skirmisher",
+    "action_type": "attack",
+    "target_id": "e_nomad_1",
+    "turn": 1,
+    "ap_spent": 1,
+    "target_position_at_attack": {
+      "x": 3,
+      "y": 2
+    },
+    "die": 10,
+    "roll": 13,
+    "dc": 12,
+    "mos": 1,
+    "result": "hit",
+    "pt": 0,
+    "damage_dealt": 1,
+    "trait_effects": [
+      {
+        "trait": "zampe_a_molla",
+        "triggered": false,
+        "effect": "none"
+      }
+    ],
+    "target_hp_before": 3,
+    "target_hp_after": 2,
+    "position_from": {
+      "x": 1,
+      "y": 2
+    },
+    "position_to": {
+      "x": 1,
+      "y": 2
+    },
+    "action_index": 1,
+    "automatic": false
+  },
+  {
+    "ts": "2026-04-18T13:22:27.529Z",
+    "session_id": "ae96d108-762a-48a6-a4a1-d393c88114e5",
+    "actor_id": "p_scout",
+    "actor_species": "dune_stalker",
+    "actor_job": "skirmisher",
+    "action_type": "attack",
+    "target_id": "e_nomad_1",
+    "turn": 1,
+    "ap_spent": 1,
+    "target_position_at_attack": {
+      "x": 3,
+      "y": 2
+    },
+    "die": 11,
+    "roll": 14,
+    "dc": 12,
+    "mos": 2,
+    "result": "hit",
+    "pt": 0,
+    "damage_dealt": 1,
+    "trait_effects": [
+      {
+        "trait": "zampe_a_molla",
+        "triggered": false,
+        "effect": "none"
+      }
+    ],
+    "target_hp_before": 2,
+    "target_hp_after": 1,
+    "position_from": {
+      "x": 1,
+      "y": 2
+    },
+    "position_to": {
+      "x": 1,
+      "y": 2
+    },
+    "action_index": 2,
+    "automatic": false
+  },
+  {
+    "ts": "2026-04-18T13:22:34.345Z",
+    "session_id": "ae96d108-762a-48a6-a4a1-d393c88114e5",
+    "actor_id": "p_tank",
+    "actor_species": "dune_stalker",
+    "actor_job": "vanguard",
+    "action_type": "move",
+    "turn": 1,
+    "ap_spent": 1,
+    "position_from": {
+      "x": 1,
+      "y": 3
+    },
+    "position_to": {
+      "x": 2,
+      "y": 3
+    },
+    "trait_effects": [],
+    "action_index": 3,
+    "automatic": false
+  },
+  {
+    "ts": "2026-04-18T13:22:40.609Z",
+    "session_id": "ae96d108-762a-48a6-a4a1-d393c88114e5",
+    "actor_id": "p_tank",
+    "actor_species": "dune_stalker",
+    "actor_job": "vanguard",
+    "action_type": "move",
+    "turn": 1,
+    "ap_spent": 1,
+    "position_from": {
+      "x": 2,
+      "y": 3
+    },
+    "position_to": {
+      "x": 3,
+      "y": 3
+    },
+    "trait_effects": [],
+    "action_index": 4,
+    "automatic": false
+  },
+  {
+    "ts": "2026-04-18T13:22:44.993Z",
+    "session_id": "ae96d108-762a-48a6-a4a1-d393c88114e5",
+    "actor_id": "sistema",
+    "actor_species": "predoni_nomadi",
+    "actor_job": "skirmisher",
+    "action_type": "attack",
+    "target_id": "p_scout",
+    "turn": 1,
+    "ap_spent": 1,
+    "target_position_at_attack": {
+      "x": 1,
+      "y": 2
+    },
+    "die": 18,
+    "roll": 20,
+    "dc": 12,
+    "mos": 8,
+    "result": "hit",
+    "pt": 2,
+    "damage_dealt": 3,
+    "trait_effects": [],
+    "target_hp_before": 10,
+    "target_hp_after": 7,
+    "position_from": {
+      "x": 3,
+      "y": 2
+    },
+    "position_to": {
+      "x": 3,
+      "y": 2
+    },
+    "ia_rule": "REGOLA_001",
+    "ia_controlled_unit": "e_nomad_1",
+    "parry": {
+      "die": 3,
+      "guardia_used": 1,
+      "total": 4,
+      "dc": 12,
+      "success": false,
+      "damage_delta": 0,
+      "pt_defensive": 0
+    }
+  },
+  {
+    "ts": "2026-04-18T13:27:33.497Z",
+    "session_id": "ae96d108-762a-48a6-a4a1-d393c88114e5",
+    "actor_id": "p_scout",
+    "actor_species": "dune_stalker",
+    "actor_job": "skirmisher",
+    "action_type": "attack",
+    "target_id": "e_nomad_1",
+    "turn": 2,
+    "ap_spent": 1,
+    "target_position_at_attack": {
+      "x": 3,
+      "y": 2
+    },
+    "die": 3,
+    "roll": 6,
+    "dc": 12,
+    "mos": -6,
+    "result": "miss",
+    "pt": 0,
+    "damage_dealt": 0,
+    "trait_effects": [
+      {
+        "trait": "zampe_a_molla",
+        "triggered": false,
+        "effect": "none"
+      }
+    ],
+    "target_hp_before": 1,
+    "target_hp_after": 1,
+    "position_from": {
+      "x": 1,
+      "y": 2
+    },
+    "position_to": {
+      "x": 1,
+      "y": 2
+    },
+    "action_index": 6,
+    "automatic": false
+  },
+  {
+    "ts": "2026-04-18T13:27:35.290Z",
+    "session_id": "ae96d108-762a-48a6-a4a1-d393c88114e5",
+    "actor_id": "p_scout",
+    "actor_species": "dune_stalker",
+    "actor_job": "skirmisher",
+    "action_type": "attack",
+    "target_id": "e_nomad_1",
+    "turn": 2,
+    "ap_spent": 1,
+    "target_position_at_attack": {
+      "x": 3,
+      "y": 2
+    },
+    "die": 20,
+    "roll": 23,
+    "dc": 12,
+    "mos": 11,
+    "result": "hit",
+    "pt": 4,
+    "damage_dealt": 5,
+    "trait_effects": [
+      {
+        "trait": "zampe_a_molla",
+        "triggered": false,
+        "effect": "none"
+      }
+    ],
+    "target_hp_before": 1,
+    "target_hp_after": 0,
+    "position_from": {
+      "x": 1,
+      "y": 2
+    },
+    "position_to": {
+      "x": 1,
+      "y": 2
+    },
+    "action_index": 7,
+    "automatic": false
+  },
+  {
+    "ts": "2026-04-18T13:27:35.291Z",
+    "session_id": "ae96d108-762a-48a6-a4a1-d393c88114e5",
+    "action_type": "kill",
+    "automatic": true,
+    "actor_id": "p_scout",
+    "actor_species": "dune_stalker",
+    "actor_job": "skirmisher",
+    "target_id": "e_nomad_1",
+    "turn": 2,
+    "killing_blow": {
+      "die": 20,
+      "roll": 23,
+      "mos": 11,
+      "pt": 4,
+      "damage_dealt": 5
+    },
+    "action_index": 8
+  },
+  {
+    "ts": "2026-04-18T13:27:39.559Z",
+    "session_id": "ae96d108-762a-48a6-a4a1-d393c88114e5",
+    "actor_id": "p_scout",
+    "actor_species": "dune_stalker",
+    "actor_job": "skirmisher",
+    "action_type": "move",
+    "turn": 2,
+    "ap_spent": 1,
+    "position_from": {
+      "x": 1,
+      "y": 2
+    },
+    "position_to": {
+      "x": 1,
+      "y": 3
+    },
+    "trait_effects": [],
+    "action_index": 9,
+    "automatic": false
+  },
+  {
+    "ts": "2026-04-18T13:27:42.625Z",
+    "session_id": "ae96d108-762a-48a6-a4a1-d393c88114e5",
+    "actor_id": "p_tank",
+    "actor_species": "dune_stalker",
+    "actor_job": "vanguard",
+    "action_type": "attack",
+    "target_id": "e_nomad_2",
+    "turn": 2,
+    "ap_spent": 1,
+    "target_position_at_attack": {
+      "x": 3,
+      "y": 4
+    },
+    "die": 13,
+    "roll": 15,
+    "dc": 12,
+    "mos": 3,
+    "result": "hit",
+    "pt": 0,
+    "damage_dealt": 2,
+    "trait_effects": [],
+    "target_hp_before": 5,
+    "target_hp_after": 3,
+    "position_from": {
+      "x": 3,
+      "y": 3
+    },
+    "position_to": {
+      "x": 3,
+      "y": 3
+    },
+    "action_index": 10,
+    "automatic": false
+  },
+  {
+    "ts": "2026-04-18T13:27:47.350Z",
+    "session_id": "ae96d108-762a-48a6-a4a1-d393c88114e5",
+    "actor_id": "p_tank",
+    "actor_species": "dune_stalker",
+    "actor_job": "vanguard",
+    "action_type": "ability",
+    "target_id": "e_nomad_2",
+    "turn": 2,
+    "ap_spent": 1,
+    "target_position_at_attack": {
+      "x": 3,
+      "y": 4
+    },
+    "die": 12,
+    "roll": 14,
+    "dc": 12,
+    "mos": 2,
+    "result": "hit",
+    "pt": 0,
+    "damage_dealt": 2,
+    "trait_effects": [],
+    "target_hp_before": 3,
+    "target_hp_after": 1,
+    "position_from": {
+      "x": 3,
+      "y": 3
+    },
+    "position_to": {
+      "x": 3,
+      "y": 3
+    },
+    "ability_id": "shield_bash",
+    "effect_type": "attack_push",
+    "effect_trigger": "on_hit",
+    "pushed": {
+      "from": {
+        "x": 3,
+        "y": 4
+      },
+      "to": {
+        "x": 3,
+        "y": 5
+      }
+    },
+    "applied_status": {
+      "id": "sbilanciato",
+      "duration": 1
+    },
+    "action_index": 11,
+    "automatic": false
+  },
+  {
+    "ts": "2026-04-18T13:27:51.446Z",
+    "session_id": "ae96d108-762a-48a6-a4a1-d393c88114e5",
+    "actor_id": "p_tank",
+    "actor_species": "dune_stalker",
+    "actor_job": "vanguard",
+    "action_type": "move",
+    "turn": 2,
+    "ap_spent": 1,
+    "position_from": {
+      "x": 3,
+      "y": 3
+    },
+    "position_to": {
+      "x": 3,
+      "y": 4
+    },
+    "trait_effects": [],
+    "action_index": 12,
+    "automatic": false
+  },
+  {
+    "ts": "2026-04-18T13:29:11.776Z",
+    "session_id": "ae96d108-762a-48a6-a4a1-d393c88114e5",
+    "actor_id": "sistema",
+    "actor_species": "predoni_nomadi",
+    "actor_job": "skirmisher",
+    "action_type": "move",
+    "turn": 2,
+    "ap_spent": 1,
+    "position_from": {
+      "x": 3,
+      "y": 5
+    },
+    "position_to": {
+      "x": 4,
+      "y": 5
+    },
+    "trait_effects": [],
+    "ia_rule": "REGOLA_002",
+    "ia_controlled_unit": "e_nomad_2"
+  },
+  {
+    "ts": "2026-04-18T13:29:21.667Z",
+    "session_id": "ae96d108-762a-48a6-a4a1-d393c88114e5",
+    "actor_id": "p_tank",
+    "actor_species": "dune_stalker",
+    "actor_job": "vanguard",
+    "action_type": "move",
+    "turn": 3,
+    "ap_spent": 1,
+    "position_from": {
+      "x": 3,
+      "y": 4
+    },
+    "position_to": {
+      "x": 4,
+      "y": 4
+    },
+    "trait_effects": [],
+    "action_index": 14,
+    "automatic": false
+  },
+  {
+    "ts": "2026-04-18T13:29:22.995Z",
+    "session_id": "ae96d108-762a-48a6-a4a1-d393c88114e5",
+    "actor_id": "p_tank",
+    "actor_species": "dune_stalker",
+    "actor_job": "vanguard",
+    "action_type": "attack",
+    "target_id": "e_nomad_2",
+    "turn": 3,
+    "ap_spent": 1,
+    "target_position_at_attack": {
+      "x": 4,
+      "y": 5
+    },
+    "die": 19,
+    "roll": 21,
+    "dc": 12,
+    "mos": 9,
+    "result": "hit",
+    "pt": 2,
+    "damage_dealt": 4,
+    "trait_effects": [],
+    "target_hp_before": 1,
+    "target_hp_after": 0,
+    "position_from": {
+      "x": 4,
+      "y": 4
+    },
+    "position_to": {
+      "x": 4,
+      "y": 4
+    },
+    "action_index": 15,
+    "automatic": false
+  },
+  {
+    "ts": "2026-04-18T13:29:22.996Z",
+    "session_id": "ae96d108-762a-48a6-a4a1-d393c88114e5",
+    "action_type": "kill",
+    "automatic": true,
+    "actor_id": "p_tank",
+    "actor_species": "dune_stalker",
+    "actor_job": "vanguard",
+    "target_id": "e_nomad_2",
+    "turn": 3,
+    "killing_blow": {
+      "die": 19,
+      "roll": 21,
+      "mos": 9,
+      "pt": 2,
+      "damage_dealt": 4
+    },
+    "action_index": 16
+  }
+]


### PR DESCRIPTION
## Summary

Primo **playtest reale user-driven** post-sessione 28 PR (2026-04-18). Direzione M4. Validato kill-60 feature decisions + raccolto trace per eval set Flint v0.3.

## Outcome

🏆 **VITTORIA turno 3** (session `ae96d108`).

| Metrica | Valore |
|---------|:--:|
| Turni | 3 |
| HP persi PG | 3 |
| HP inflitti SIS | 8 |
| Events trace | 17 |

## Kill-60 validation scorecard

**8/9 🟢 + 1 🟡** — grande maggioranza feature kept post-kill-60 funzionano:

| Feature | Verdetto |
|---------|:--:|
| UI Canvas 2D (42-SG hierarchy) | 🟢 |
| HP bar color coded | 🟢 |
| Active marker triangle | 🟡 (bug #1 divergenza) |
| Status icon chip (Panic) | 🟢 |
| Faction color coding | 🟢 |
| AP feedback sidebar | 🟢 |
| Error messages AP insufficienti | 🟢 |
| Ability sidebar shield_bash | 🟢 |
| End-game modal metriche | 🟢 |

## Findings

- **Bug UX #1**: active marker yellow triangle non sync con header "Active: X" (turn 2)
- **Bug UX #2**: grid_size YAML [8,8] vs session internal 6×6 default
- **Positive UX #1**: error msg AP italiano chiaro con residui AP
- **Positive UX #2**: shield_bash flow completo (push + sbilanciato status)

## Trace + artifacts

- `logs/m4_playtest_enc_tutorial_01_ae96d108.json` — 17 events timeline
- `.claude/launch.json` — entry `play` aggiunta per future preview_start
- Q-OPEN nuove: 28 (grid override), 29 (active sync), 30 (crit chance balance)

## Follow-up M4

- A 🟢 File bug active marker
- B 🟡 Verify grid_size backend consumption
- C 🟡 Playtest tutorial_02..05 progressive
- D ⚪ Eval set aggregator Flint v0.3

## Constraints

- Zero meta-checkpoint (race memory con altra sessione)
- Zero AI ghostwriting — user decisioni via browser, Claude executor via preview_eval
- Prefix `play:` = positive sample Flint classifier

## Verification

- `python tools/check_docs_governance.py --strict` → 0 errors, 0 warnings

## Guardrail

- ✅ Docs + logs + launch.json only
- ✅ Zero code `apps/backend/`
- ✅ Zero schema change

Refs: sessione 2026-04-18 continuation memory, Flint kill-60 enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)