### PR TITLE
feat(play): Sprint A P0 HUD cosmetic (M4)

### DIFF
--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -43,12 +43,15 @@
         <aside class="sidebar">
           <h2>Unità</h2>
           <ul id="units"></ul>
-          <h2 id="abilities-title" class="hidden-empty">Abilities</h2>
-          <div id="abilities"></div>
           <h2>Log</h2>
           <div id="log"></div>
         </aside>
       </main>
+      <!-- M4 P0.1 — Ability bar sticky bottom, always-visible (user feedback) -->
+      <div id="ability-bar" class="ability-bar">
+        <span id="abilities-title" class="ability-bar-title hidden-empty">Abilities</span>
+        <div id="abilities" class="ability-bar-row"></div>
+      </div>
       <footer>
         <span id="selected-hint">Seleziona una tua unità per vedere azioni.</span>
         <button id="cancel-pending" class="hidden">✕ Annulla ability</button>

--- a/apps/play/src/render.js
+++ b/apps/play/src/render.js
@@ -143,20 +143,59 @@ function drawUnit(ctx, unit, gridH, highlight = {}) {
   ctx.textBaseline = 'middle';
   ctx.fillText(unit.id.slice(0, 4), cx, cy);
 
-  // HP bar below
+  // HP bar — M4 P0.2: float sopra unit sprite (visibile da lontano TV-first).
+  // Legacy: bar sotto tile. New: bar sopra testa + valore numerico chunky.
   if (!dead) {
     const ratio = unit.hp / (unit.max_hp || unit.hp || 1);
-    const barW = CELL * 0.6;
+    const barW = CELL * 0.72;
     const barX = cx - barW / 2;
-    const barY = yPx * CELL + CELL - 8;
-    ctx.fillStyle = '#111';
-    ctx.fillRect(barX, barY, barW, 4);
+    const barY = yPx * CELL + 3;
+    // Background dark per contrast
+    ctx.fillStyle = 'rgba(0,0,0,0.7)';
+    ctx.fillRect(barX - 1, barY - 1, barW + 2, 7);
+    // Fill color coded
     ctx.fillStyle = ratio < 0.3 ? COLORS.hpCrit : ratio < 0.6 ? COLORS.hpWarn : COLORS.hpFull;
-    ctx.fillRect(barX, barY, barW * ratio, 4);
+    ctx.fillRect(barX, barY, barW * ratio, 5);
+    // Numeric value sopra bar (TV-first scan)
+    ctx.fillStyle = '#fff';
+    ctx.font = 'bold 9px "SF Mono", monospace';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'bottom';
+    const maxHp = unit.max_hp || unit.hp || 0;
+    ctx.fillText(`${unit.hp}/${maxHp}`, cx, barY - 1);
   }
 
   // Status icons (top-right)
   if (!dead) drawStatusIcons(ctx, unit, cx, yPx * CELL);
+
+  // M4 P0.3 — SIS enemy intent icon (Slay the Spire pattern).
+  // Stub euristico: SIS controlled_by='sistema' + HP>0 → fist icon (attack intent).
+  // TODO ADR-04-18 Plan-Reveal: real intents da threat_preview payload backend.
+  if (!dead && unit.controlled_by === 'sistema') {
+    drawSisIntentIcon(ctx, unit, cx, yPx * CELL, 'fist');
+  }
+}
+
+// M4 P0.3 — SIS intent icon above unit (fist=attack, arrow=move, shield=defend).
+function drawSisIntentIcon(ctx, unit, cx, yPxTop, kind = 'fist') {
+  const ix = cx + CELL * 0.25;
+  const iy = yPxTop + CELL * 0.08;
+  const size = 14;
+  // Badge bg
+  ctx.fillStyle = 'rgba(80,0,0,0.85)';
+  ctx.beginPath();
+  ctx.arc(ix, iy + size / 2, size / 2 + 2, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.strokeStyle = '#ff5252';
+  ctx.lineWidth = 1.5;
+  ctx.stroke();
+  // Glyph
+  const glyph = kind === 'fist' ? '✊' : kind === 'move' ? '➜' : kind === 'shield' ? '🛡' : '?';
+  ctx.fillStyle = '#fff';
+  ctx.font = 'bold 11px "SF Mono", monospace';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(glyph, ix, iy + size / 2 + 1);
 }
 
 export function render(canvas, state, highlight = {}) {

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -25,6 +25,14 @@ body {
   height: 100%;
 }
 
+/* M4 P0.5 — TV-first safe zone 5% (42-STYLE-GUIDE-UI.md).
+ * Padding orizzontale su #app garantisce nessun UI critico nei bordi 5%
+ * del viewport su TV 1080p @ 3m distance. */
+#app {
+  padding-left: max(env(safe-area-inset-left, 0), 2.5vw);
+  padding-right: max(env(safe-area-inset-right, 0), 2.5vw);
+}
+
 #app {
   display: flex;
   flex-direction: column;
@@ -316,6 +324,52 @@ canvas#grid {
 }
 #log div.error {
   color: var(--sistema);
+}
+
+/* M4 P0.1 — Ability bar sticky bottom, always-visible (user feedback) */
+.ability-bar {
+  position: sticky;
+  bottom: 0;
+  background: var(--panel);
+  border-top: 2px solid var(--accent);
+  padding: 10px 24px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-height: 80px;
+  z-index: 20;
+  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.4);
+}
+.ability-bar-title {
+  font-size: 0.9rem;
+  color: var(--accent);
+  font-weight: bold;
+  white-space: nowrap;
+}
+.ability-bar-title.hidden-empty {
+  display: inline;
+  opacity: 0.4;
+}
+.ability-bar-row {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  flex: 1;
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
+.ability-bar-row .ability-row {
+  min-width: 180px;
+  max-width: 260px;
+  margin-bottom: 0 !important;
+  flex-shrink: 0;
+}
+.ability-bar-row:empty::before {
+  content: 'Seleziona una tua unità per vedere le ability';
+  color: var(--dim);
+  font-style: italic;
+  font-size: 0.85rem;
+  padding: 8px 0;
 }
 
 footer {


### PR DESCRIPTION
## Summary

Sprint A P0 HUD cosmetic. Stack su #1605 (round simultaneous + confirm).

## User feedback trigger

Post-playtest: "barra abilità sparisce + troppo in basso + estetica HUD invariata". P0 applies immediate visual changes.

## Changes

### P0.1 — Ability bar sticky bottom ✅

Move `#abilities` fuori sidebar, nuovo `<div id="ability-bar">` sticky `bottom: 0`. Always-visible, flex horizontal scroll. Min-height 80px, z-index 20. Empty state hint via `::before`.

### P0.2 — HP float sopra unit ✅

`drawUnit` render.js: HP bar ora TOP del tile (was bottom). Aggiunto valore numerico "HP/maxHP" chunky. TV-first scan path.

### P0.3 — SIS enemy intent icon ✅

`drawSisIntentIcon` stub fist (✊) in badge rosso sopra SIS unit. Slay the Spire pattern. TODO: real intent mapping da Plan-Reveal backend.

### P0.5 — Safe zone 5% ✅

`#app` padding `max(env(safe-area-inset-X, 0), 2.5vw)`. TV-first compliance.

### P0.4 — Threat tile (deferred)

Richiede Plan-Reveal backend endpoint (ADR-04-18 draft). Placeholder.

## Verified browser

- Ability bar sticky visible bottom ✅
- 3 ability populate post-select ✅
- No console errors ✅

## Parent stack

- Base: #1605 (round + confirm)
- Depends: #1602 (SVG render flag)
- Refs: #1603 (44-HUD research), #1604 (Plan-Reveal ADR)

## Rollback

Reverse commit. Layout back to sidebar. Zero destructive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)