### PR TITLE
feat(play): Sprint A P0 Wave 2 HUD — help + fullscreen + FX + job colors + tooltip

### DIFF
--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -43,12 +43,15 @@
         <aside class="sidebar">
           <h2>Unità</h2>
           <ul id="units"></ul>
-          <h2 id="abilities-title" class="hidden-empty">Abilities</h2>
-          <div id="abilities"></div>
           <h2>Log</h2>
           <div id="log"></div>
         </aside>
       </main>
+      <!-- M4 P0.1 — Ability bar sticky bottom, always-visible (user feedback) -->
+      <div id="ability-bar" class="ability-bar">
+        <span id="abilities-title" class="ability-bar-title hidden-empty">Abilities</span>
+        <div id="abilities" class="ability-bar-row"></div>
+      </div>
       <footer>
         <span id="selected-hint">Seleziona una tua unità per vedere azioni.</span>
         <button id="cancel-pending" class="hidden">✕ Annulla ability</button>

--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -18,10 +18,15 @@
           <div class="pressure-label">SISTEMA — · 0/100 · cap 1 intents/round</div>
           <div class="pressure-bar"><div class="pressure-fill" style="width: 0%"></div></div>
         </div>
+        <div class="header-actions">
+          <button id="fullscreen-toggle" title="Schermo intero">⛶</button>
+          <button id="help-open" title="Aiuto (?)">?</button>
+        </div>
       </header>
       <main>
         <section class="board">
           <canvas id="grid" width="512" height="512"></canvas>
+          <div id="unit-tooltip" class="unit-tooltip hidden"></div>
           <div class="controls">
             <button id="end-turn">Fine turno</button>
             <button id="new-session">Nuova sessione</button>

--- a/apps/play/src/anim.js
+++ b/apps/play/src/anim.js
@@ -1,10 +1,14 @@
-// Minimal animation layer — interpolated unit positions + damage popups.
+// Minimal animation layer — interpolated unit positions + damage popups + flash + attack rays.
 
-const ANIM_MS = 200; // move tween duration
-const POPUP_MS = 900;
+const ANIM_MS = 240; // move tween duration (slight boost per W2.3 visual clarity)
+const POPUP_MS = 1100; // popup fade-out
+const FLASH_MS = 320; // unit flash on hit
+const RAY_MS = 280; // attack ray line
 
 const movers = new Map(); // unit_id → { fromX, fromY, toX, toY, start }
 const popups = []; // [{ x, y, text, color, start }]
+const flashes = new Map(); // unit_id → { start, color }
+const rays = []; // [{ fromX, fromY, toX, toY, color, start }]
 
 export function recordMove(unitId, from, to) {
   if (!from || !to) return;
@@ -20,6 +24,75 @@ export function recordMove(unitId, from, to) {
 
 export function pushPopup(x, y, text, color = '#ff5252') {
   popups.push({ x, y, text: String(text), color, start: performance.now() });
+}
+
+// W2.3 — Flash unit on hit (red tint) o heal (green tint).
+export function flashUnit(unitId, color = '#ff5252') {
+  flashes.set(unitId, { start: performance.now(), color });
+}
+
+// W2.3 — Attack ray: linea animata attaccante → target, auto-expire.
+export function attackRay(from, to, color = '#ffcc00') {
+  if (!from || !to) return;
+  rays.push({
+    fromX: from.x,
+    fromY: from.y,
+    toX: to.x,
+    toY: to.y,
+    color,
+    start: performance.now(),
+  });
+}
+
+export function getFlashAlpha(unitId) {
+  const f = flashes.get(unitId);
+  if (!f) return null;
+  const t = (performance.now() - f.start) / FLASH_MS;
+  if (t >= 1) {
+    flashes.delete(unitId);
+    return null;
+  }
+  // Double-pulse: 0→1→0→1→0
+  const pulse = Math.sin(t * Math.PI * 2) * 0.5 + 0.5;
+  return { alpha: pulse * (1 - t), color: f.color };
+}
+
+export function drawRays(ctx, cellSize, gridH) {
+  const now = performance.now();
+  for (let i = rays.length - 1; i >= 0; i--) {
+    const r = rays[i];
+    const t = (now - r.start) / RAY_MS;
+    if (t >= 1) {
+      rays.splice(i, 1);
+      continue;
+    }
+    const yPxFrom = gridH - 1 - r.fromY;
+    const yPxTo = gridH - 1 - r.toY;
+    const x1 = r.fromX * cellSize + cellSize / 2;
+    const y1 = yPxFrom * cellSize + cellSize / 2;
+    const x2 = r.toX * cellSize + cellSize / 2;
+    const y2 = yPxTo * cellSize + cellSize / 2;
+    // Progress fades from 1 → 0
+    const alpha = 1 - t;
+    // Line extends 0→1 of path
+    const grow = Math.min(t * 2, 1); // burst fast then fade
+    const endX = x1 + (x2 - x1) * grow;
+    const endY = y1 + (y2 - y1) * grow;
+    ctx.globalAlpha = alpha;
+    ctx.strokeStyle = r.color;
+    ctx.lineWidth = 3;
+    ctx.lineCap = 'round';
+    ctx.beginPath();
+    ctx.moveTo(x1, y1);
+    ctx.lineTo(endX, endY);
+    ctx.stroke();
+    // Tip dot
+    ctx.fillStyle = r.color;
+    ctx.beginPath();
+    ctx.arc(endX, endY, 4, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.globalAlpha = 1;
+  }
 }
 
 export function getInterpolatedPos(unitId, currentPos) {
@@ -62,5 +135,5 @@ export function drawPopups(ctx, cellSize, gridH) {
 }
 
 export function hasActiveAnims() {
-  return movers.size > 0 || popups.length > 0;
+  return movers.size > 0 || popups.length > 0 || flashes.size > 0 || rays.length > 0;
 }

--- a/apps/play/src/api.js
+++ b/apps/play/src/api.js
@@ -30,6 +30,28 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ session_id: sid }),
     }),
+  // ADR-2026-04-15 round model endpoints (wired M4 A.1).
+  // Flow: beginPlanning → N × declareIntent → commitRound(auto_resolve=true)
+  beginPlanning: (sid) =>
+    jsonFetch('/api/session/round/begin-planning', {
+      method: 'POST',
+      body: JSON.stringify({ session_id: sid }),
+    }),
+  declareIntent: (sid, actorId, action) =>
+    jsonFetch('/api/session/declare-intent', {
+      method: 'POST',
+      body: JSON.stringify({ session_id: sid, actor_id: actorId, action }),
+    }),
+  clearIntent: (sid, actorId) =>
+    jsonFetch(`/api/session/clear-intent/${encodeURIComponent(actorId)}`, {
+      method: 'POST',
+      body: JSON.stringify({ session_id: sid }),
+    }),
+  commitRound: (sid, autoResolve = true) =>
+    jsonFetch('/api/session/commit-round', {
+      method: 'POST',
+      body: JSON.stringify({ session_id: sid, auto_resolve: autoResolve }),
+    }),
   vc: (sid) => jsonFetch(`/api/session/${encodeURIComponent(sid)}/vc`),
   replay: (sid) => jsonFetch(`/api/session/${encodeURIComponent(sid)}/replay`),
   modulations: () => jsonFetch('/api/party/modulations'),

--- a/apps/play/src/helpPanel.js
+++ b/apps/play/src/helpPanel.js
@@ -1,0 +1,136 @@
+// M4 P0 Wave 2 — Help / Tutorial panel overlay.
+// Toggle: '?' key o bottone top-right. Default OPEN prima sessione (onboarding),
+// poi default CLOSED (localStorage key 'evo:help-seen').
+
+const HELP_SEEN_KEY = 'evo:help-seen';
+
+const HELP_HTML = `
+  <div class="help-panel-card">
+    <header class="help-panel-header">
+      <h2>🦴 Come si gioca</h2>
+      <button class="help-panel-close" id="help-close" title="Chiudi (ESC)">✕</button>
+    </header>
+    <div class="help-panel-body">
+      <section>
+        <h3>Obiettivo</h3>
+        <p>Sopravvivi al Sistema. Azzera gli HP di tutti i nemici (rombi rossi) prima che il Sistema azzeri i tuoi (triangoli blu).</p>
+      </section>
+
+      <section>
+        <h3>Controlli</h3>
+        <ul>
+          <li><b>Click unità tua</b> (blu) → seleziona</li>
+          <li><b>Click cella vuota</b> → muovi (1 AP per cella)</li>
+          <li><b>Click nemico</b> (rosso) → attacco base (1 AP)</li>
+          <li><b>Click ability</b> (barra in basso) → seleziona skill, poi click target</li>
+          <li><b>Fine turno</b> → passa turno al Sistema</li>
+          <li><b>ESC</b> → annulla ability pending / azione pending</li>
+          <li><b>?</b> → apri/chiudi questo pannello</li>
+        </ul>
+      </section>
+
+      <section>
+        <h3>Punteggi e risorse</h3>
+        <ul>
+          <li><b>HP</b> (barra sopra unità): vita. A 0 = KO.</li>
+          <li><b>AP</b> (Action Points): budget azione per turno. Attaccare = 1 AP, muovere di N celle = N AP.</li>
+          <li><b>PT</b> (Pressure): la barra in alto mostra la pressione del Sistema. Più sale, più il Sistema è aggressivo (tier Calm → Vigilant → Aggressive → Apex).</li>
+        </ul>
+      </section>
+
+      <section>
+        <h3>Icone unità</h3>
+        <ul>
+          <li><span class="help-icon help-icon-player">▲</span> <b>Triangolo blu</b> = tua unità</li>
+          <li><span class="help-icon help-icon-sistema">◆</span> <b>Rombo rosso</b> = Sistema (nemico)</li>
+          <li><span class="help-icon help-icon-intent">✊</span> <b>Pugno rosso sopra nemico</b> = intento attacco al prossimo turno</li>
+          <li><span class="help-icon help-icon-warn">!</span> <b>Punto esclamativo arancio</b> = status panico</li>
+          <li><span class="help-icon help-icon-stun">★</span> <b>Stella viola</b> = stordito</li>
+          <li><span class="help-icon help-icon-bleed">☽</span> <b>Luna rosa</b> = sanguinamento</li>
+        </ul>
+      </section>
+
+      <section>
+        <h3>Suggerimenti tattici</h3>
+        <ul>
+          <li><b>Coordinati</b>: 2+ player stesso target stesso turno = combo focus-fire (+1 danno)</li>
+          <li><b>Ability usano AP</b>: leggi il costo prima di spendere</li>
+          <li><b>Terreno conta</b>: celle erba/pietra danno bonus difesa</li>
+          <li><b>Sistema impara</b>: se sei aggressivo, diventerà aggressivo</li>
+        </ul>
+      </section>
+
+      <footer class="help-panel-footer">
+        <span>Premi <kbd>?</kbd> o <kbd>ESC</kbd> per chiudere.</span>
+      </footer>
+    </div>
+  </div>
+`;
+
+let _rootEl = null;
+let _isOpen = false;
+let _keydownHandler = null;
+
+function ensureRoot() {
+  if (_rootEl) return _rootEl;
+  _rootEl = document.createElement('div');
+  _rootEl.id = 'help-panel';
+  _rootEl.className = 'help-panel hidden';
+  _rootEl.innerHTML = HELP_HTML;
+  document.body.appendChild(_rootEl);
+  _rootEl.addEventListener('click', (ev) => {
+    if (ev.target === _rootEl) closeHelp();
+  });
+  _rootEl.querySelector('#help-close').addEventListener('click', closeHelp);
+  return _rootEl;
+}
+
+export function openHelp() {
+  const el = ensureRoot();
+  el.classList.remove('hidden');
+  _isOpen = true;
+  try {
+    localStorage.setItem(HELP_SEEN_KEY, '1');
+  } catch {
+    /* empty */
+  }
+}
+
+export function closeHelp() {
+  if (!_rootEl) return;
+  _rootEl.classList.add('hidden');
+  _isOpen = false;
+}
+
+export function toggleHelp() {
+  if (_isOpen) closeHelp();
+  else openHelp();
+}
+
+export function initHelpPanel(openBtnId = 'help-open') {
+  ensureRoot();
+  const btn = document.getElementById(openBtnId);
+  if (btn) btn.addEventListener('click', toggleHelp);
+  _keydownHandler = (e) => {
+    if (e.key === '?' || (e.key === '/' && e.shiftKey)) {
+      e.preventDefault();
+      toggleHelp();
+    } else if (e.key === 'Escape' && _isOpen) {
+      closeHelp();
+    }
+  };
+  document.addEventListener('keydown', _keydownHandler);
+
+  // First-run: apri help se mai visto
+  try {
+    if (!localStorage.getItem(HELP_SEEN_KEY)) {
+      setTimeout(openHelp, 400);
+    }
+  } catch {
+    /* empty */
+  }
+}
+
+export function isHelpOpen() {
+  return _isOpen;
+}

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -5,9 +5,10 @@ import { render, canvasToCell, needsAnimFrame } from './render.js';
 import { renderUnits, appendLog, updateStatus } from './ui.js';
 import { renderAbilities, clearAbilities } from './abilityPanel.js';
 import { detectEndgame, showEndgame, hideEndgame, nextScenarioId } from './endgame.js';
-import { recordMove, pushPopup } from './anim.js';
+import { recordMove, pushPopup, flashUnit, attackRay } from './anim.js';
 import { openReplay } from './replayPanel.js';
 import { sfx, setMuted, isMuted } from './sfx.js';
+import { initHelpPanel } from './helpPanel.js';
 
 const state = {
   sid: null,
@@ -191,6 +192,53 @@ function findUnitAt(x, y) {
     (u) => u.hp > 0 && u.position && u.position.x === x && u.position.y === y,
   );
 }
+
+// W2.5 — Hover tooltip su canvas: intent SIS, HP/AP, job, status
+const tooltipEl = document.getElementById('unit-tooltip');
+
+function buildUnitTooltip(unit) {
+  if (!unit) return '';
+  const faction = unit.controlled_by === 'player' ? 'player' : 'sistema';
+  const factionLabel = faction === 'player' ? 'Tua unità' : 'Sistema';
+  const job = unit.job || unit.class || '—';
+  const hp = `${unit.hp}/${unit.max_hp || unit.hp}`;
+  const ap = unit.ap_remaining != null ? `${unit.ap_remaining}/${unit.ap || 0}` : `${unit.ap || 0}`;
+  const statusKeys = Object.entries(unit.status || {})
+    .filter(([, v]) => v !== undefined && v !== null && (typeof v !== 'number' || v > 0))
+    .map(([k]) => k);
+  const statusTxt = statusKeys.length ? `Status: ${statusKeys.join(', ')}` : '';
+  let intentBlock = '';
+  if (faction === 'sistema' && unit.hp > 0) {
+    // Stub: icona pugno = intento attacco (mirror drawSisIntentIcon).
+    // TODO ADR-04-18 Plan-Reveal: real intent da threat_preview payload backend.
+    intentBlock = `<span class="tt-intent">✊ Intento: attacco (stub)</span>`;
+  }
+  return `
+    <strong>${unit.id}</strong>
+    <div class="tt-faction-${faction}">${factionLabel} · <em>${job}</em></div>
+    <div>HP ${hp} · AP ${ap}</div>
+    ${statusTxt ? `<div>${statusTxt}</div>` : ''}
+    ${intentBlock}
+  `;
+}
+
+canvas.addEventListener('mousemove', (ev) => {
+  if (!state.world || !tooltipEl) return;
+  const { x, y } = canvasToCell(canvas, ev, state.world.grid.height);
+  const unit = findUnitAt(x, y);
+  if (!unit) {
+    tooltipEl.classList.add('hidden');
+    return;
+  }
+  tooltipEl.innerHTML = buildUnitTooltip(unit);
+  tooltipEl.style.left = `${ev.clientX + 14}px`;
+  tooltipEl.style.top = `${ev.clientY + 14}px`;
+  tooltipEl.classList.remove('hidden');
+});
+
+canvas.addEventListener('mouseleave', () => {
+  if (tooltipEl) tooltipEl.classList.add('hidden');
+});
 
 canvas.addEventListener('click', (ev) => {
   if (!state.world) return;
@@ -387,10 +435,18 @@ function processNewEvents(prevWorld, newWorld) {
       ev.target_id
     ) {
       const target = (newWorld.units || []).find((u) => u.id === ev.target_id);
+      const actor = (newWorld.units || []).find((u) => u.id === ev.actor_id);
+      // W2.3 — Attack ray actor → target
+      if (actor?.position && target?.position) {
+        const rayColor = actor.controlled_by === 'sistema' ? '#ff5252' : '#ffcc00';
+        attackRay(actor.position, target.position, rayColor);
+      }
       if (target && target.position && ev.damage_dealt !== 0) {
         const color = ev.damage_dealt < 0 ? '#4caf50' : '#ff5252';
         const txt = ev.damage_dealt < 0 ? `+${-ev.damage_dealt}` : `-${ev.damage_dealt}`;
         pushPopup(target.position.x, target.position.y, txt, color);
+        // W2.3 — Flash target
+        flashUnit(ev.target_id, color);
       }
       // SFX
       if (ev.damage_dealt < 0) sfx.heal();
@@ -510,6 +566,11 @@ function processIaActions(iaActions) {
         sfx.sis_turn();
       } else if (type === 'attack' || type === 'ability') {
         const target = (state.world?.units || []).find((u) => u.id === targetId);
+        const actor = (state.world?.units || []).find((u) => u.id === actorId);
+        // W2.3 — Attack ray + flash for SIS
+        if (actor?.position && target?.position) {
+          attackRay(actor.position, target.position, '#ff5252');
+        }
         if (target && target.position && dmg) {
           pushPopup(
             target.position.x,
@@ -517,6 +578,7 @@ function processIaActions(iaActions) {
             dmg < 0 ? `+${-dmg}` : `-${dmg}`,
             dmg < 0 ? '#4caf50' : '#ff5252',
           );
+          flashUnit(targetId, dmg < 0 ? '#4caf50' : '#ff5252');
         }
         if (dmg < 0) sfx.heal();
         else if (dmg > 0) Number(dmg) >= 6 ? sfx.crit() : sfx.hit();
@@ -623,6 +685,32 @@ async function loadModulations() {
   modSel.value = current;
   // Riavvia sessione se user cambia modulation (default: auto → 6x6)
   modSel.addEventListener('change', () => startNewSession());
+}
+
+// M4 P0 W2 — Help panel (? key, top-right button, auto-open prima sessione)
+initHelpPanel('help-open');
+
+// M4 P0 W2 — Fullscreen toggle
+const fsBtn = document.getElementById('fullscreen-toggle');
+if (fsBtn) {
+  fsBtn.addEventListener('click', async () => {
+    try {
+      if (!document.fullscreenElement) {
+        await document.documentElement.requestFullscreen();
+        fsBtn.textContent = '⛶⃞';
+        fsBtn.title = 'Esci da schermo intero';
+      } else {
+        await document.exitFullscreen();
+        fsBtn.textContent = '⛶';
+        fsBtn.title = 'Schermo intero';
+      }
+    } catch (e) {
+      appendLog(logEl, `✖ fullscreen: ${e.message}`, 'error');
+    }
+  });
+  document.addEventListener('fullscreenchange', () => {
+    fsBtn.textContent = document.fullscreenElement ? '⛶⃞' : '⛶';
+  });
 }
 
 loadModulations().then(() => startNewSession());

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -125,8 +125,16 @@ function handleAbilitySelect(ab) {
 }
 
 document.addEventListener('keydown', (e) => {
-  if (e.key === 'Escape' && state.pendingAbility) {
-    cancelPendingAbility();
+  if (e.key === 'Escape') {
+    if (state.pendingAbility) {
+      cancelPendingAbility();
+    }
+    // M4 A.2 — ESC cancella pending confirm action
+    if (_pendingConfirm) {
+      _pendingConfirm = null;
+      updateHint('Pending cancellato. Seleziona unità o altra azione.');
+      redraw();
+    }
   }
 });
 
@@ -219,11 +227,123 @@ canvas.addEventListener('click', (ev) => {
   doAction({ action_type: 'move', actor_id: state.selected, position: { x, y } });
 });
 
+// M4 A.1 — Feature flag round model simultaneous.
+// Toggle: localStorage.setItem('evo:round-flow','simultaneous') + reload.
+// Default OFF = legacy /api/session/action + /api/session/turn/end (ADR pre-04-15).
+// ON = /api/session/declare-intent + /commit-round (ADR-2026-04-15 round model).
+function useRoundFlow() {
+  try {
+    return localStorage.getItem('evo:round-flow') === 'simultaneous';
+  } catch {
+    return false;
+  }
+}
+
+// M4 A.2 — Feature flag confirm action (2-step commit).
+// Toggle: localStorage.setItem('evo:confirm-action','true') + reload.
+// ON = primo click = pending preview (ghost), secondo click stessa cella/target = confirm.
+function useConfirmAction() {
+  try {
+    return localStorage.getItem('evo:confirm-action') === 'true';
+  } catch {
+    return false;
+  }
+}
+
+// Pending confirm state: { body, tag, ts }. Reset su cancel o commit.
+let _pendingConfirm = null;
+// Debug: expose pending per inspect via preview_eval
+window.__dbg = window.__dbg || {};
+Object.defineProperty(window.__dbg, 'pendingConfirm', {
+  get() {
+    return _pendingConfirm;
+  },
+});
+
+function confirmMatch(prev, next) {
+  if (!prev) return false;
+  if (prev.body.action_type !== next.action_type) return false;
+  if (prev.body.actor_id !== next.actor_id) return false;
+  if (next.action_type === 'attack' || next.action_type === 'ability') {
+    return prev.body.target_id === next.target_id;
+  }
+  if (next.action_type === 'move') {
+    return prev.body.position?.x === next.position?.x && prev.body.position?.y === next.position?.y;
+  }
+  return false;
+}
+
 async function doAction(body) {
   if (!state.sid) return;
   // Safety: hard clear any pending ability + target mode prima di ogni action
   cancelPendingAbility(true);
   body.session_id = state.sid;
+
+  // Confirm action: primo click pending, secondo click stessa action = commit
+  if (useConfirmAction()) {
+    if (!confirmMatch(_pendingConfirm, body)) {
+      _pendingConfirm = { body: { ...body }, ts: Date.now() };
+      const tag = body.ability_id
+        ? `ability ${body.ability_id}${body.target_id ? ` → ${body.target_id}` : ''}`
+        : body.action_type === 'move'
+          ? `move [${body.position.x},${body.position.y}]`
+          : `atk ${body.target_id}`;
+      updateHint(`⏳ PENDING ${tag} — click di nuovo per confermare, ESC per annullare`);
+      redraw();
+      return;
+    }
+    // Seconda click = confirm
+    _pendingConfirm = null;
+  }
+
+  // Round flow simultaneous: declare intent invece di action immediate
+  if (useRoundFlow()) {
+    // Map body → action shape per declareIntent
+    const action = {
+      type: body.action_type,
+      actor_id: body.actor_id,
+      ap_cost:
+        body.action_type === 'attack'
+          ? 1
+          : body.action_type === 'move'
+            ? manhattanApCost(body)
+            : body.action_type === 'ability'
+              ? body.ap_cost || 1
+              : 0,
+    };
+    if (body.action_type === 'attack') action.target_id = body.target_id;
+    if (body.action_type === 'move') action.move_to = body.position;
+    if (body.action_type === 'ability') {
+      action.ability_id = body.ability_id;
+      action.target_id = body.target_id;
+      if (body.position) action.position = body.position;
+    }
+    // Ensure roundState initialized
+    if (!state.roundInit) {
+      const bp = await api.beginPlanning(state.sid);
+      if (!bp.ok) {
+        appendLog(logEl, `✖ begin-planning: ${bp.data?.error || bp.status}`, 'error');
+        return;
+      }
+      state.roundInit = true;
+    }
+    const r = await api.declareIntent(state.sid, body.actor_id, action);
+    if (!r.ok) {
+      appendLog(logEl, `✖ ${r.data?.error || `HTTP ${r.status}`}`, 'error');
+      updateHint(`❌ ${r.data?.error || 'Intent rifiutato.'} · riprova`);
+      return;
+    }
+    const tag = body.ability_id
+      ? `→ ability ${body.ability_id}${body.target_id ? ` → ${body.target_id}` : ''}`
+      : body.action_type === 'move'
+        ? `→ move [${body.position.x},${body.position.y}]`
+        : `→ atk ${body.target_id}`;
+    appendLog(logEl, `${body.actor_id}: ${tag} (pending)`);
+    updateHint(`✓ Intent dichiarato ${body.actor_id}. Altri player o "Fine turno" per risolvere.`);
+    return;
+  }
+
+  // Legacy flow (default OFF): action immediate
   const r = await api.action(body);
   if (!r.ok) {
     appendLog(logEl, `✖ ${r.data?.error || `HTTP ${r.status}`}`, 'error');
@@ -237,6 +357,15 @@ async function doAction(body) {
       : `atk ${body.target_id}`;
   appendLog(logEl, `${body.actor_id}: ${tag}`);
   await refresh();
+}
+
+function manhattanApCost(body) {
+  if (!state.world || !body.actor_id || !body.position) return 1;
+  const actor = (state.world.units || []).find((u) => u.id === body.actor_id);
+  if (!actor || !actor.position) return 1;
+  return (
+    Math.abs(body.position.x - actor.position.x) + Math.abs(body.position.y - actor.position.y)
+  );
 }
 
 // Track last events count to detect new events for anim
@@ -332,9 +461,16 @@ async function startNewSession() {
   state.world = st.data.state;
   state.selected = null;
   state.target = null;
+  // M4 A.1+A.2: reset flag state per nuova sessione
+  state.roundInit = false;
+  _pendingConfirm = null;
   lastEventsCount = (state.world?.events || []).length;
   appendLog(logEl, `✓ sessione ${state.sid.slice(0, 8)}…`);
-  updateHint('Sessione iniziata. Seleziona una tua unità.');
+  const flags = [];
+  if (useRoundFlow()) flags.push('round=simultaneous');
+  if (useConfirmAction()) flags.push('confirm=on');
+  const hint = flags.length > 0 ? ` [${flags.join(', ')}]` : '';
+  updateHint(`Sessione iniziata${hint}. Seleziona una tua unità.`);
   redraw();
 }
 
@@ -401,6 +537,47 @@ document.getElementById('end-turn').addEventListener('click', async () => {
   if (!state.sid) return;
   sfx.turn_end();
   appendLog(logEl, '→ fine turno');
+
+  // M4 A.1 — Round model simultaneous: commit-round auto_resolve
+  if (useRoundFlow()) {
+    // Ensure begin-planning called almeno una volta (first turn may skip if no declare)
+    if (!state.roundInit) {
+      const bp = await api.beginPlanning(state.sid);
+      if (!bp.ok) {
+        appendLog(logEl, `✖ begin-planning: ${bp.data?.error || bp.status}`, 'error');
+        return;
+      }
+      state.roundInit = true;
+    }
+    const r = await api.commitRound(state.sid, true);
+    if (!r.ok) {
+      appendLog(logEl, `✖ commit-round: ${r.data?.error || r.status}`, 'error');
+      return;
+    }
+    // Reset roundInit per prossimo turno
+    state.roundInit = false;
+    _pendingConfirm = null;
+    // Process resolution_queue as animations (shape differs da ia_actions)
+    const queue = r.data?.resolution_queue || [];
+    if (queue.length > 0) {
+      // Animazioni stagger per ogni action risolta
+      queue.forEach((action, i) => {
+        setTimeout(() => {
+          // Popup only, actual state refresh post-all
+        }, i * 200);
+      });
+    }
+    setTimeout(
+      async () => {
+        await refresh();
+        appendLog(logEl, `✓ round ${state.world?.turn || '?'} risolto (${queue.length} azioni)`);
+      },
+      queue.length * 200 + 300,
+    );
+    return;
+  }
+
+  // Legacy flow (default)
   const r = await api.endTurn(state.sid);
   if (!r.ok) {
     appendLog(logEl, `✖ end turn: ${r.status}`, 'error');

--- a/apps/play/src/render.js
+++ b/apps/play/src/render.js
@@ -1,6 +1,6 @@
 // Canvas 2D rendering — grid + units + animations + status icons.
 
-import { getInterpolatedPos, drawPopups, hasActiveAnims } from './anim.js';
+import { getInterpolatedPos, drawPopups, drawRays, getFlashAlpha, hasActiveAnims } from './anim.js';
 
 const CELL = 64; // pixel per cell
 const COLORS = {
@@ -16,6 +16,22 @@ const COLORS = {
   hpFull: '#4caf50',
   hpWarn: '#ffc107',
   hpCrit: '#f44336',
+};
+
+// W2.4 — Job/class color accent (outer ring oltre faction).
+// Mirror sidebar CSS `#units li[data-job=...]` palette.
+const JOB_COLORS = {
+  vanguard: '#5d4037',
+  tank: '#5d4037',
+  skirmisher: '#7e57c2',
+  scout: '#66bb6a',
+  sniper: '#ffb300',
+  ranged: '#ffb300',
+  healer: '#29b6f6',
+  support: '#29b6f6',
+  controller: '#ab47bc',
+  mage: '#ab47bc',
+  boss: '#d32f2f',
 };
 
 const STATUS_ICONS = {
@@ -97,13 +113,31 @@ function drawUnit(ctx, unit, gridH, highlight = {}) {
       ? COLORS.player
       : COLORS.sistema;
 
-  // Body circle
+  // Body circle — job accent ring first, then body.
+  const jobColor = JOB_COLORS[(unit.job || unit.class || '').toLowerCase()] || null;
+  if (!dead && jobColor) {
+    ctx.fillStyle = jobColor;
+    ctx.beginPath();
+    ctx.arc(cx, cy, CELL * 0.38, 0, Math.PI * 2);
+    ctx.fill();
+  }
   ctx.fillStyle = color;
   ctx.globalAlpha = dead ? 0.4 : 1;
   ctx.beginPath();
   ctx.arc(cx, cy, CELL * 0.32, 0, Math.PI * 2);
   ctx.fill();
   ctx.globalAlpha = 1;
+
+  // W2.3 — Flash overlay on hit/heal
+  const flash = !dead ? getFlashAlpha(unit.id) : null;
+  if (flash) {
+    ctx.globalAlpha = flash.alpha;
+    ctx.fillStyle = flash.color;
+    ctx.beginPath();
+    ctx.arc(cx, cy, CELL * 0.42, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.globalAlpha = 1;
+  }
 
   // Selected ring
   if (highlight.selected === unit.id) {
@@ -216,6 +250,9 @@ export function render(canvas, state, highlight = {}) {
 
   // Units
   for (const u of state.units || []) drawUnit(ctx, u, h, highlight);
+
+  // W2.3 — Attack rays (sopra unità, sotto popups)
+  drawRays(ctx, CELL, h);
 
   // Damage popups on top
   drawPopups(ctx, CELL, h);

--- a/apps/play/src/render.js
+++ b/apps/play/src/render.js
@@ -143,20 +143,59 @@ function drawUnit(ctx, unit, gridH, highlight = {}) {
   ctx.textBaseline = 'middle';
   ctx.fillText(unit.id.slice(0, 4), cx, cy);
 
-  // HP bar below
+  // HP bar — M4 P0.2: float sopra unit sprite (visibile da lontano TV-first).
+  // Legacy: bar sotto tile. New: bar sopra testa + valore numerico chunky.
   if (!dead) {
     const ratio = unit.hp / (unit.max_hp || unit.hp || 1);
-    const barW = CELL * 0.6;
+    const barW = CELL * 0.72;
     const barX = cx - barW / 2;
-    const barY = yPx * CELL + CELL - 8;
-    ctx.fillStyle = '#111';
-    ctx.fillRect(barX, barY, barW, 4);
+    const barY = yPx * CELL + 3;
+    // Background dark per contrast
+    ctx.fillStyle = 'rgba(0,0,0,0.7)';
+    ctx.fillRect(barX - 1, barY - 1, barW + 2, 7);
+    // Fill color coded
     ctx.fillStyle = ratio < 0.3 ? COLORS.hpCrit : ratio < 0.6 ? COLORS.hpWarn : COLORS.hpFull;
-    ctx.fillRect(barX, barY, barW * ratio, 4);
+    ctx.fillRect(barX, barY, barW * ratio, 5);
+    // Numeric value sopra bar (TV-first scan)
+    ctx.fillStyle = '#fff';
+    ctx.font = 'bold 9px "SF Mono", monospace';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'bottom';
+    const maxHp = unit.max_hp || unit.hp || 0;
+    ctx.fillText(`${unit.hp}/${maxHp}`, cx, barY - 1);
   }
 
   // Status icons (top-right)
   if (!dead) drawStatusIcons(ctx, unit, cx, yPx * CELL);
+
+  // M4 P0.3 — SIS enemy intent icon (Slay the Spire pattern).
+  // Stub euristico: SIS controlled_by='sistema' + HP>0 → fist icon (attack intent).
+  // TODO ADR-04-18 Plan-Reveal: real intents da threat_preview payload backend.
+  if (!dead && unit.controlled_by === 'sistema') {
+    drawSisIntentIcon(ctx, unit, cx, yPx * CELL, 'fist');
+  }
+}
+
+// M4 P0.3 — SIS intent icon above unit (fist=attack, arrow=move, shield=defend).
+function drawSisIntentIcon(ctx, unit, cx, yPxTop, kind = 'fist') {
+  const ix = cx + CELL * 0.25;
+  const iy = yPxTop + CELL * 0.08;
+  const size = 14;
+  // Badge bg
+  ctx.fillStyle = 'rgba(80,0,0,0.85)';
+  ctx.beginPath();
+  ctx.arc(ix, iy + size / 2, size / 2 + 2, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.strokeStyle = '#ff5252';
+  ctx.lineWidth = 1.5;
+  ctx.stroke();
+  // Glyph
+  const glyph = kind === 'fist' ? '✊' : kind === 'move' ? '➜' : kind === 'shield' ? '🛡' : '?';
+  ctx.fillStyle = '#fff';
+  ctx.font = 'bold 11px "SF Mono", monospace';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(glyph, ix, iy + size / 2 + 1);
 }
 
 export function render(canvas, state, highlight = {}) {

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -25,6 +25,14 @@ body {
   height: 100%;
 }
 
+/* M4 P0.5 — TV-first safe zone 5% (42-STYLE-GUIDE-UI.md).
+ * Padding orizzontale su #app garantisce nessun UI critico nei bordi 5%
+ * del viewport su TV 1080p @ 3m distance. */
+#app {
+  padding-left: max(env(safe-area-inset-left, 0), 2.5vw);
+  padding-right: max(env(safe-area-inset-right, 0), 2.5vw);
+}
+
 #app {
   display: flex;
   flex-direction: column;
@@ -316,6 +324,52 @@ canvas#grid {
 }
 #log div.error {
   color: var(--sistema);
+}
+
+/* M4 P0.1 — Ability bar sticky bottom, always-visible (user feedback) */
+.ability-bar {
+  position: sticky;
+  bottom: 0;
+  background: var(--panel);
+  border-top: 2px solid var(--accent);
+  padding: 10px 24px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-height: 80px;
+  z-index: 20;
+  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.4);
+}
+.ability-bar-title {
+  font-size: 0.9rem;
+  color: var(--accent);
+  font-weight: bold;
+  white-space: nowrap;
+}
+.ability-bar-title.hidden-empty {
+  display: inline;
+  opacity: 0.4;
+}
+.ability-bar-row {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  flex: 1;
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
+.ability-bar-row .ability-row {
+  min-width: 180px;
+  max-width: 260px;
+  margin-bottom: 0 !important;
+  flex-shrink: 0;
+}
+.ability-bar-row:empty::before {
+  content: 'Seleziona una tua unità per vedere le ability';
+  color: var(--dim);
+  font-style: italic;
+  font-size: 0.85rem;
+  padding: 8px 0;
 }
 
 footer {

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -646,3 +646,236 @@ body.ability-target-mode canvas#grid {
 #replay-event-info code {
   color: var(--accent);
 }
+
+/* M4 P0 Wave 2 — Help panel overlay */
+.help-panel {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 150;
+  padding: 20px;
+  overflow-y: auto;
+}
+.help-panel.hidden {
+  display: none;
+}
+.help-panel-card {
+  background: var(--panel);
+  border: 2px solid var(--accent);
+  width: min(780px, 95vw);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  border-radius: 4px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.7);
+}
+.help-panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 24px;
+  background: linear-gradient(90deg, rgba(255, 204, 0, 0.15), transparent);
+  border-bottom: 1px solid var(--border);
+}
+.help-panel-header h2 {
+  margin: 0;
+  color: var(--accent);
+  font-size: 1.2rem;
+}
+.help-panel-close {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--fg);
+  width: 32px;
+  height: 32px;
+  font-size: 1rem;
+  cursor: pointer;
+  border-radius: 3px;
+}
+.help-panel-close:hover {
+  background: var(--sistema);
+  color: #fff;
+}
+.help-panel-body {
+  padding: 20px 24px;
+  overflow-y: auto;
+  line-height: 1.5;
+}
+.help-panel-body section {
+  margin-bottom: 20px;
+}
+.help-panel-body h3 {
+  margin: 0 0 8px;
+  color: var(--accent);
+  font-size: 1rem;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 4px;
+}
+.help-panel-body p {
+  margin: 0 0 8px;
+  font-size: 0.9rem;
+}
+.help-panel-body ul {
+  margin: 0;
+  padding-left: 20px;
+  font-size: 0.85rem;
+}
+.help-panel-body li {
+  margin-bottom: 5px;
+}
+.help-panel-body b {
+  color: var(--fg);
+}
+.help-panel-body kbd {
+  background: var(--cell);
+  border: 1px solid var(--border);
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-family: inherit;
+  font-size: 0.8rem;
+  color: var(--accent);
+}
+.help-panel-footer {
+  padding: 12px 24px;
+  border-top: 1px solid var(--border);
+  font-size: 0.8rem;
+  color: var(--dim);
+  text-align: center;
+}
+.help-icon {
+  display: inline-block;
+  width: 22px;
+  text-align: center;
+  font-weight: bold;
+  margin-right: 4px;
+}
+.help-icon-player {
+  color: var(--player);
+}
+.help-icon-sistema {
+  color: var(--sistema);
+}
+.help-icon-intent {
+  color: #ff8a65;
+}
+.help-icon-warn {
+  color: #ff9800;
+}
+.help-icon-stun {
+  color: #9c27b0;
+}
+.help-icon-bleed {
+  color: #e91e63;
+}
+
+/* W2.5 — Unit hover tooltip (floating) */
+.unit-tooltip {
+  position: fixed;
+  z-index: 90;
+  background: rgba(0, 0, 0, 0.92);
+  border: 1px solid var(--accent);
+  color: var(--fg);
+  padding: 8px 12px;
+  font-size: 0.8rem;
+  border-radius: 4px;
+  pointer-events: none;
+  max-width: 280px;
+  line-height: 1.4;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
+}
+.unit-tooltip.hidden {
+  display: none;
+}
+.unit-tooltip strong {
+  color: var(--accent);
+}
+.unit-tooltip .tt-intent {
+  color: var(--sistema);
+  font-weight: bold;
+  display: block;
+  margin-top: 4px;
+  padding-top: 4px;
+  border-top: 1px solid var(--border);
+}
+.unit-tooltip .tt-faction-player {
+  color: var(--player);
+}
+.unit-tooltip .tt-faction-sistema {
+  color: var(--sistema);
+}
+
+/* Help open button — top-right of header */
+#help-open {
+  background: var(--cell);
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  width: 34px;
+  height: 34px;
+  font-size: 1rem;
+  font-weight: bold;
+  cursor: pointer;
+  border-radius: 50%;
+}
+#help-open:hover {
+  background: var(--accent);
+  color: var(--bg);
+}
+
+/* Fullscreen toggle button */
+#fullscreen-toggle {
+  background: var(--cell);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  padding: 6px 10px;
+  cursor: pointer;
+  font-family: inherit;
+  border-radius: 3px;
+}
+#fullscreen-toggle:hover {
+  background: var(--accent);
+  color: var(--bg);
+}
+
+/* Header right-side cluster */
+.header-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+/* Unit sidebar job accent (W2.4 color per tipo) */
+#units li[data-job='vanguard'],
+#units li[data-job='tank'] {
+  border-left-width: 5px;
+  border-left-color: #5d4037; /* brown-earth */
+}
+#units li[data-job='skirmisher'] {
+  border-left-width: 5px;
+  border-left-color: #7e57c2; /* purple */
+}
+#units li[data-job='scout'] {
+  border-left-width: 5px;
+  border-left-color: #66bb6a; /* green */
+}
+#units li[data-job='sniper'],
+#units li[data-job='ranged'] {
+  border-left-width: 5px;
+  border-left-color: #ffb300; /* amber */
+}
+#units li[data-job='healer'],
+#units li[data-job='support'] {
+  border-left-width: 5px;
+  border-left-color: #29b6f6; /* light-blue */
+}
+#units li[data-job='controller'],
+#units li[data-job='mage'] {
+  border-left-width: 5px;
+  border-left-color: #ab47bc; /* magenta */
+}
+#units li[data-job='boss'] {
+  border-left-width: 5px;
+  border-left-color: #d32f2f; /* dark-red */
+}

--- a/apps/play/src/ui.js
+++ b/apps/play/src/ui.js
@@ -36,6 +36,9 @@ export function renderUnits(ul, state, selectedId, onClick) {
     if (u.hp <= 0) li.classList.add('dead');
     if (u.id === state.active_unit) li.classList.add('active');
     if (u.id === selectedId) li.classList.add('selected');
+    // W2.4 — data-job attribute drives CSS accent per job class
+    const jobKey = (u.job || u.class || '').toString().toLowerCase().trim();
+    if (jobKey) li.setAttribute('data-job', jobKey);
 
     const ratio = u.hp / (u.max_hp || u.hp || 1);
     const hpClass = ratio < 0.3 ? 'crit' : ratio < 0.6 ? 'warn' : '';


### PR DESCRIPTION
## Summary

Sprint A **P0 Wave 2** stacked su PR #1606. Applica 6 fix da feedback player post primo playtest (enc_tutorial_01 win T3).

| # | Fix | Status |
|---|-----|:--:|
| W2.1 | Help panel overlay (? key + auto-open first run) | ✅ |
| W2.2 | Fullscreen toggle (⛶ header button) | ✅ |
| W2.3 | Visual effects SIS (flash + attack ray) | ✅ |
| W2.4 | Color per tipo job (7 job: vanguard/skirmisher/scout/sniper/healer/controller/boss) | ✅ |
| W2.5 | Unit tooltip on hover (faction+job+HP+AP+status+intent) | ✅ |
| W2.6 | Safe zone no-op (era solo commento interno) | ✅ |

## Feedback player risolto

> "non c'è scritto nulla nel tutorial (si apre la pagina col gioco ma non c'è scritto cosa va fatto, cosa puoi fare, cosa sono i vari punteggi etc)" → **W2.1 help panel auto-open**

> "non si autoapre a grandezza di schermo intero" → **W2.2 fullscreen button**

> "le azioni che avvengono a fine turno non mi piace vederle solo scritte ma vorrei degli effetti visivi" → **W2.3 flash + attack ray**

> "dare un colore per tipo di unità in modo da renderle più intuitive" → **W2.4 job colors sidebar+canvas**

> "non so cosa sia la fist icon sis" → **W2.5 tooltip hover spiega intent**

## Files touched

| File | LOC |
|---|--:|
| `apps/play/src/helpPanel.js` (new) | +136 |
| `apps/play/src/style.css` | +233 |
| `apps/play/src/main.js` | +90 |
| `apps/play/src/anim.js` | +81 |
| `apps/play/src/render.js` | +41 |
| `apps/play/src/ui.js` | +3 |
| `apps/play/index.html` | +5 |
| **Total** | **+582 / -7** |

## Test plan

- [x] Browser verify (port 5180): help auto-open ✓
- [x] data-job attr su 4 unit li, border-left 5px colorato ✓
- [x] Tooltip su hover e_nomad_1 → "✊ Intento: attacco (stub)" ✓
- [x] Fullscreen button + help button in header, titles corretti ✓
- [x] 0 console errors
- [ ] User playtest post-merge: help leggibile + FX visibili end-turn + fullscreen funziona su Windows
- [ ] Follow-up: wire tooltip intent da threat_preview reale (ADR-2026-04-18 Plan-Reveal)

## Rollback

`git revert bac64f5e` — self-contained commit, nessun schema/contract touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)