### PR TITLE
feat(play): Sprint A P0 Wave 4 — round feedback layer (pending badges + reveal + priority + auto-commit + timer)

### DIFF
--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -17,7 +17,17 @@ const state = {
   target: null, // target preview (enemy hovered)
   pendingAbility: null, // { ability_id, needs_target, effect_type }
   endgameShown: false,
+  // W4.1 — round model client-side tracking per badge UI
+  pendingIntents: new Map(), // unit_id → intent object (reset post commit)
+  // W4.3 — resolution order from last commit (unit_id → priority rank 1..N)
+  lastResolutionOrder: new Map(),
+  // W4.6 — planning timer start timestamp (null = not active)
+  planningTimerStart: null,
 };
+
+// W4.6 — Planning timer 30s config + interval handle
+const PLANNING_TIMER_MS = 30_000;
+let planningTimerHandle = null;
 
 const canvas = document.getElementById('grid');
 const unitsUl = document.getElementById('units');
@@ -30,8 +40,9 @@ function redraw() {
     selected: state.selected,
     target: state.target,
     active: state.world.active_unit,
+    resolutionOrder: state.lastResolutionOrder,
   });
-  renderUnits(unitsUl, state.world, state.selected, handleUnitClick);
+  renderUnits(unitsUl, state.world, state.selected, handleUnitClick, state.pendingIntents);
   updateStatus(state.world);
   // ability panel
   const selUnit = (state.world.units || []).find((u) => u.id === state.selected);
@@ -376,6 +387,8 @@ async function doAction(body) {
         return;
       }
       state.roundInit = true;
+      // W4.6 — start planning timer on first declare
+      startPlanningTimer();
     }
     const r = await api.declareIntent(state.sid, body.actor_id, action);
     if (!r.ok) {
@@ -383,13 +396,29 @@ async function doAction(body) {
       updateHint(`❌ ${r.data?.error || 'Intent rifiutato.'} · riprova`);
       return;
     }
+    // W4.1 — track intent client-side per badge sidebar
+    state.pendingIntents.set(body.actor_id, action);
     const tag = body.ability_id
       ? `→ ability ${body.ability_id}${body.target_id ? ` → ${body.target_id}` : ''}`
       : body.action_type === 'move'
         ? `→ move [${body.position.x},${body.position.y}]`
         : `→ atk ${body.target_id}`;
     appendLog(logEl, `${body.actor_id}: ${tag} (pending)`);
-    updateHint(`✓ Intent dichiarato ${body.actor_id}. Altri player o "Fine turno" per risolvere.`);
+    redraw();
+    // W4.5 — auto-commit when all alive player units have declared
+    const alivePlayers = (state.world?.units || []).filter(
+      (u) => u.controlled_by === 'player' && u.hp > 0,
+    );
+    const allDeclared = alivePlayers.every((u) => state.pendingIntents.has(u.id));
+    if (allDeclared && alivePlayers.length > 0) {
+      updateHint(`✓ Tutti i player dichiarati (${alivePlayers.length}). Risolvo round…`);
+      setTimeout(() => triggerCommitRound(), 250);
+    } else {
+      const remaining = alivePlayers.length - state.pendingIntents.size;
+      updateHint(
+        `✓ Intent dichiarato ${body.actor_id}. ${remaining} player restante/i o "Fine turno".`,
+      );
+    }
     return;
   }
 
@@ -522,6 +551,10 @@ async function startNewSession() {
   // M4 A.1+A.2: reset flag state per nuova sessione
   state.roundInit = false;
   _pendingConfirm = null;
+  // W4 — reset round tracking
+  state.pendingIntents.clear();
+  state.lastResolutionOrder.clear();
+  stopPlanningTimer();
   lastEventsCount = (state.world?.events || []).length;
   appendLog(logEl, `✓ sessione ${state.sid.slice(0, 8)}…`);
   const flags = [];
@@ -597,56 +630,148 @@ function processIaActions(iaActions) {
   }
 }
 
-document.getElementById('end-turn').addEventListener('click', async () => {
+// W4 — commit-round factored out so auto-commit (W4.5) e end-turn button
+// possono condividere la stessa logica + reveal overlay + priority badge.
+async function triggerCommitRound() {
   if (!state.sid) return;
   sfx.turn_end();
-  appendLog(logEl, '→ fine turno');
+  appendLog(logEl, '→ risolvo round');
+  stopPlanningTimer();
 
-  // M4 A.1 — Round model simultaneous: commit-round auto_resolve
-  if (useRoundFlow()) {
-    // Ensure begin-planning called almeno una volta (first turn may skip if no declare)
-    if (!state.roundInit) {
-      const bp = await api.beginPlanning(state.sid);
-      if (!bp.ok) {
-        appendLog(logEl, `✖ begin-planning: ${bp.data?.error || bp.status}`, 'error');
-        return;
-      }
-      state.roundInit = true;
-    }
-    const r = await api.commitRound(state.sid, true);
-    if (!r.ok) {
-      appendLog(logEl, `✖ commit-round: ${r.data?.error || r.status}`, 'error');
+  if (!state.roundInit) {
+    const bp = await api.beginPlanning(state.sid);
+    if (!bp.ok) {
+      appendLog(logEl, `✖ begin-planning: ${bp.data?.error || bp.status}`, 'error');
       return;
     }
-    // Reset roundInit per prossimo turno
-    state.roundInit = false;
-    _pendingConfirm = null;
-    // W3 fix #2/#3 — Process player_actions + ia_actions via processIaActions.
-    // Root cause precedente: publicSessionView no expose events[], solo count.
-    // processNewEvents mai triggerato in simultaneous flow → no FX visivi.
-    // Shape player_actions == ia_actions (sessionRoundBridge.js buildUnifiedRoundResolver
-    // usa stessa bucket.push({type, unit_id, target, position_from, position_to, damage_dealt})).
-    const playerActions = r.data?.player_actions || [];
-    const iaActions = r.data?.ia_actions || [];
-    const allActions = [...playerActions, ...iaActions];
-    if (allActions.length > 0) processIaActions(allActions);
-    const totalDelay = allActions.length * 350 + 200;
-    setTimeout(async () => {
-      await refresh();
-      appendLog(logEl, `✓ round ${state.world?.turn || '?'} risolto (${allActions.length} azioni)`);
-    }, totalDelay);
+    state.roundInit = true;
+  }
+  const r = await api.commitRound(state.sid, true);
+  if (!r.ok) {
+    appendLog(logEl, `✖ commit-round: ${r.data?.error || r.status}`, 'error');
     return;
   }
+  state.roundInit = false;
+  _pendingConfirm = null;
+  state.pendingIntents.clear();
 
-  // Legacy flow (default)
+  const playerActions = r.data?.player_actions || [];
+  const iaActions = r.data?.ia_actions || [];
+  const resolutionQueue = r.data?.resolution_queue || [];
+  const allActions = [...playerActions, ...iaActions];
+
+  // W4.3 — build resolution order map: unit_id → rank (1-based).
+  // Preferisci resolution_queue (server-computed priority), fallback ordine allActions.
+  state.lastResolutionOrder.clear();
+  const queueItems = resolutionQueue.length > 0 ? resolutionQueue : allActions;
+  queueItems.forEach((item, idx) => {
+    const uid = item.unit_id || item.actor_id;
+    if (uid && !state.lastResolutionOrder.has(uid)) {
+      state.lastResolutionOrder.set(uid, idx + 1);
+    }
+  });
+
+  // W4.2 — commit reveal overlay pre-animations (700ms)
+  const turnNum = (state.world?.turn || 0) + 1;
+  showCommitReveal(turnNum, allActions.length);
+
+  const REVEAL_MS = 700;
+  setTimeout(() => {
+    if (allActions.length > 0) processIaActions(allActions);
+  }, REVEAL_MS);
+
+  const totalDelay = REVEAL_MS + allActions.length * 350 + 200;
+  setTimeout(async () => {
+    await refresh();
+    state.lastResolutionOrder.clear();
+    redraw();
+    appendLog(logEl, `✓ round ${state.world?.turn || '?'} risolto (${allActions.length} azioni)`);
+  }, totalDelay);
+}
+
+// W4.2 — Commit reveal overlay: "⚔ ROUND N · X azioni simultanee" flash 700ms.
+function showCommitReveal(turnNum, actionCount) {
+  let overlay = document.getElementById('commit-reveal');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'commit-reveal';
+    document.body.appendChild(overlay);
+  }
+  overlay.innerHTML = `<div class="cr-inner"><div class="cr-title">⚔ ROUND ${turnNum}</div><div class="cr-sub">${actionCount} azione${actionCount === 1 ? '' : 'i'} simultanea${actionCount === 1 ? '' : 'e'}</div></div>`;
+  overlay.classList.remove('fade-out');
+  overlay.classList.add('visible');
+  setTimeout(() => {
+    overlay.classList.add('fade-out');
+    overlay.classList.remove('visible');
+  }, 650);
+}
+
+// W4.6 — Planning timer: 30s countdown, auto-commit on expiry.
+function startPlanningTimer() {
+  stopPlanningTimer();
+  state.planningTimerStart = performance.now();
+  const el = getPlanningTimerEl();
+  el.classList.remove('hidden');
+  planningTimerHandle = setInterval(() => {
+    if (state.planningTimerStart == null) return;
+    const elapsed = performance.now() - state.planningTimerStart;
+    const remaining = Math.max(0, PLANNING_TIMER_MS - elapsed);
+    updatePlanningTimerUI(remaining);
+    if (remaining <= 0) {
+      appendLog(logEl, `⏱ Timer scaduto — auto-commit`);
+      stopPlanningTimer();
+      triggerCommitRound();
+    }
+  }, 100);
+}
+
+function stopPlanningTimer() {
+  if (planningTimerHandle) clearInterval(planningTimerHandle);
+  planningTimerHandle = null;
+  state.planningTimerStart = null;
+  const el = document.getElementById('planning-timer');
+  if (el) el.classList.add('hidden');
+}
+
+function getPlanningTimerEl() {
+  let el = document.getElementById('planning-timer');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'planning-timer';
+    el.className = 'hidden';
+    el.innerHTML = `<span class="pt-label">Planning</span><div class="pt-bar"><div class="pt-fill"></div></div><span class="pt-value">30</span>`;
+    const status = document.querySelector('header .status') || document.querySelector('header');
+    if (status) status.appendChild(el);
+  }
+  return el;
+}
+
+function updatePlanningTimerUI(remainingMs) {
+  const el = document.getElementById('planning-timer');
+  if (!el) return;
+  const secs = Math.ceil(remainingMs / 1000);
+  const ratio = remainingMs / PLANNING_TIMER_MS;
+  el.querySelector('.pt-value').textContent = String(secs);
+  const fill = el.querySelector('.pt-fill');
+  fill.style.width = `${(ratio * 100).toFixed(1)}%`;
+  fill.style.background = ratio < 0.2 ? '#f44336' : ratio < 0.5 ? '#ffc107' : '#4caf50';
+}
+
+document.getElementById('end-turn').addEventListener('click', async () => {
+  if (!state.sid) return;
+  if (useRoundFlow()) {
+    await triggerCommitRound();
+    return;
+  }
+  // Legacy flow (default off): immediate end-turn
+  sfx.turn_end();
+  appendLog(logEl, '→ fine turno');
   const r = await api.endTurn(state.sid);
   if (!r.ok) {
     appendLog(logEl, `✖ end turn: ${r.status}`, 'error');
     return;
   }
-  // Process SIS actions animations
   if (r.data?.ia_actions) processIaActions(r.data.ia_actions);
-  // Wait for all SIS actions animated then refresh state
   const totalDelay = Array.isArray(r.data?.ia_actions) ? r.data.ia_actions.length * 350 + 200 : 200;
   setTimeout(async () => {
     await refresh();

--- a/apps/play/src/render.js
+++ b/apps/play/src/render.js
@@ -105,6 +105,27 @@ function drawStatusIcons(ctx, unit, cx, yPxTop) {
   }
 }
 
+// W4.3 — Priority rank badge (resolution order 1..N) during resolve phase.
+function drawPriorityBadge(ctx, rank, cx, yPxTop) {
+  const size = 18;
+  const ix = cx - CELL * 0.32;
+  const iy = yPxTop + CELL * 0.08;
+  ctx.save();
+  ctx.fillStyle = 'rgba(255, 204, 0, 0.92)';
+  ctx.strokeStyle = '#000';
+  ctx.lineWidth = 1.5;
+  ctx.beginPath();
+  ctx.arc(ix, iy + size / 2, size / 2, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.stroke();
+  ctx.fillStyle = '#000';
+  ctx.font = 'bold 12px "SF Mono", monospace';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(String(rank), ix, iy + size / 2 + 1);
+  ctx.restore();
+}
+
 function drawUnit(ctx, unit, gridH, highlight = {}) {
   if (!unit.position) return;
   // Interpolate position via anim module
@@ -215,6 +236,14 @@ function drawUnit(ctx, unit, gridH, highlight = {}) {
   // TODO ADR-04-18 Plan-Reveal: real intents da threat_preview payload backend.
   if (!dead && unit.controlled_by === 'sistema') {
     drawSisIntentIcon(ctx, unit, cx, yPx * CELL, 'fist');
+  }
+
+  // W4.3 — Resolution priority badge (visible during commit-round reveal phase).
+  if (!dead && highlight.resolutionOrder) {
+    const rank = highlight.resolutionOrder.get
+      ? highlight.resolutionOrder.get(unit.id)
+      : highlight.resolutionOrder[unit.id];
+    if (rank) drawPriorityBadge(ctx, rank, cx, yPx * CELL);
   }
 }
 

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -115,6 +115,124 @@ canvas#grid {
     border-color 0.18s ease-out,
     box-shadow 0.18s ease-out;
 }
+
+/* W4.1 — Intent badge sidebar (pending / declared). */
+.intent-badge {
+  margin-top: 4px;
+  padding: 2px 6px;
+  font-size: 0.68rem;
+  border-radius: 3px;
+  display: inline-block;
+  font-weight: bold;
+  letter-spacing: 0.02em;
+}
+.intent-badge.pending {
+  background: rgba(128, 128, 128, 0.18);
+  color: #bdbdbd;
+  font-style: italic;
+  font-weight: normal;
+}
+.intent-badge.declared {
+  background: rgba(76, 175, 80, 0.22);
+  color: #81c784;
+  border-left: 2px solid #4caf50;
+}
+
+/* W4.2 — Commit reveal overlay: "⚔ ROUND N · X azioni simultanee" fullscreen flash. */
+#commit-reveal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 9000;
+  opacity: 0;
+  background: rgba(0, 0, 0, 0);
+  transition:
+    opacity 0.22s ease-out,
+    background 0.22s ease-out;
+}
+#commit-reveal.visible {
+  opacity: 1;
+  background: rgba(0, 0, 0, 0.55);
+}
+#commit-reveal.fade-out {
+  opacity: 0;
+  background: rgba(0, 0, 0, 0);
+}
+#commit-reveal .cr-inner {
+  text-align: center;
+  animation: cr-pulse 0.7s ease-out;
+}
+#commit-reveal .cr-title {
+  font-size: 2.8rem;
+  color: var(--accent);
+  font-weight: bold;
+  text-shadow: 0 0 24px rgba(255, 204, 0, 0.7);
+  letter-spacing: 0.05em;
+}
+#commit-reveal .cr-sub {
+  font-size: 1.1rem;
+  color: var(--fg);
+  margin-top: 6px;
+  letter-spacing: 0.08em;
+}
+@keyframes cr-pulse {
+  0% {
+    transform: scale(0.6);
+    opacity: 0;
+  }
+  30% {
+    transform: scale(1.12);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+/* W4.6 — Planning timer header widget. */
+#planning-timer {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 140px;
+  font-size: 0.78rem;
+  color: var(--dim);
+}
+#planning-timer.hidden {
+  display: none;
+}
+#planning-timer .pt-label {
+  letter-spacing: 0.04em;
+}
+#planning-timer .pt-bar {
+  flex: 1;
+  height: 6px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 3px;
+  overflow: hidden;
+  min-width: 70px;
+}
+#planning-timer .pt-fill {
+  height: 100%;
+  width: 100%;
+  background: #4caf50;
+  transition:
+    width 0.1s linear,
+    background 0.3s ease-out;
+}
+#planning-timer .pt-value {
+  min-width: 20px;
+  text-align: right;
+  font-weight: bold;
+  color: var(--fg);
+}
 canvas#grid:hover {
   border-color: var(--accent);
   box-shadow: 0 0 12px rgba(255, 204, 0, 0.28);

--- a/apps/play/src/ui.js
+++ b/apps/play/src/ui.js
@@ -28,7 +28,19 @@ function renderStatusChips(unit) {
   return chips.join('');
 }
 
-export function renderUnits(ul, state, selectedId, onClick) {
+// W4.1 — Format pending intent for sidebar badge display.
+function formatIntent(intent) {
+  if (!intent) return '';
+  const t = intent.type || intent.action_type;
+  if (t === 'move' && intent.move_to) return `move [${intent.move_to.x},${intent.move_to.y}]`;
+  if (t === 'move' && intent.position) return `move [${intent.position.x},${intent.position.y}]`;
+  if (t === 'attack') return `atk ${intent.target_id || intent.target || '?'}`;
+  if (t === 'ability')
+    return `ability ${intent.ability_id || '?'}${intent.target_id ? ` → ${intent.target_id}` : ''}`;
+  return t || 'intent';
+}
+
+export function renderUnits(ul, state, selectedId, onClick, pendingIntents = null) {
   ul.innerHTML = '';
   for (const u of state.units || []) {
     const li = document.createElement('li');
@@ -75,6 +87,15 @@ export function renderUnits(ul, state, selectedId, onClick) {
       </div>
       ${statusChips ? `<div class="unit-status-row">${statusChips}</div>` : ''}
       ${u.ai_profile ? `<div class="unit-ai">AI: <code>${u.ai_profile}</code></div>` : ''}
+      ${(() => {
+        if (u.controlled_by !== 'player' || u.hp <= 0) return '';
+        if (!pendingIntents) return '';
+        const intent = pendingIntents.get ? pendingIntents.get(u.id) : pendingIntents[u.id];
+        if (intent) {
+          return `<div class="intent-badge declared" title="Intent dichiarato">✓ ${formatIntent(intent)}</div>`;
+        }
+        return `<div class="intent-badge pending" title="Nessun intent dichiarato">⏳ in attesa</div>`;
+      })()}
     `;
     li.addEventListener('click', () => onClick(u));
     ul.appendChild(li);


### PR DESCRIPTION
## Summary

Wave 4 stacked su PR #1608. Allinea UX round al ADR-2026-04-15 spec (shared-planning → commit → ordered-resolution). Wave 3 ha shippato meccaniche core; Wave 4 chiude gap percezione.

## Items implementati

| # | Item | File | Effect |
|---|------|------|--------|
| W4.1 | Pending intents badge | `ui.js` renderUnits | Sidebar mostra ⏳ "in attesa" / ✓ "atk e_nomad_1" per PG vivo |
| W4.2 | Commit reveal overlay | `main.js` showCommitReveal | Flash fullscreen "⚔ ROUND N · X azioni simultanee" 700ms pre-FX |
| W4.3 | Priority badge canvas | `render.js` drawPriorityBadge | Cerchio giallo 1/2/3/4 sopra unit durante resolve |
| W4.5 | Auto-commit all-declared | `main.js` declareIntent counter | setTimeout 250ms → triggerCommitRound quando tutti PG vivi hanno intent |
| W4.6 | Planning timer 30s | `main.js` startPlanningTimer | Widget header (progress bar + secs). Auto-commit su expiry |

Refactor: commit-round logic estratta in `triggerCommitRound()` — shared da auto-commit + end-turn button.

## Skip (Wave 5+)

- **Item 4 threat_preview payload** — richiede `packages/contracts/` schema extend (guardrail approval)
- **Reactions first-class** — ADR follow-up §6
- **Preview ghost su declareIntent** — dipende da threat_preview

## Gap ADR vs reality (closure)

| Gap pre-Wave 4 | Post-Wave 4 |
|---|---|
| No pending indicator per PG | ✅ W4.1 |
| No commit moment visual | ✅ W4.2 |
| No priority reveal visual | ✅ W4.3 |
| No auto-commit | ✅ W4.5 |
| No planning timer | ✅ W4.6 (opzionale) |
| Reazioni non first-class | ⏭ Wave 5 (ADR follow-up) |
| No preview ghost | ⏭ Wave 5 (needs threat_preview) |
| No reaction_speed label sidebar | ⏭ Wave 5 |

## Verify

Browser reload (port 5180, session fresh):
- 4 unit list con 2 `⏳ in attesa` badge su PG player
- Cursor `crosshair` (W3.4 preserved)
- Range overlay visible post-select (W3.5 preserved)
- Wave 4 CSS new: `.intent-badge.pending/.declared`, `#commit-reveal` keyframe, `#planning-timer` widget

End-to-end flow (user test richiesto):
1. Click p_scout → select → range overlay + badge stays ⏳
2. Click enemy → declareIntent → badge → ✓ atk e_nomad_1
3. Planning timer bar appare in header, countdown 30s
4. Click p_tank → declareIntent → badge ✓
5. **Auto-commit** trigger (all players declared) → overlay "⚔ ROUND 1 · 2 azioni simultanee"
6. FX fire staggered con priority badge 1/2 visible sopra unità

## Files

| File | LOC |
|------|---:|
| `apps/play/src/main.js` | +~140 / -40 |
| `apps/play/src/ui.js` | +27 |
| `apps/play/src/render.js` | +32 |
| `apps/play/src/style.css` | +115 |
| **Total** | **+332 / -39** |

## Rollback

`git revert 14c3cba3` — self-contained, nessun schema/contract/backend touch.

## Stack

PR stack: #1606 → #1607 (Wave 2) → #1608 (Wave 3) → **#XXXX (Wave 4)** — merge chain quando all approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)