### PR TITLE
feat(play): Sprint A P0 Wave 5 — preflight polish (speed + events tail + eval + gov)

### DIFF
--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -225,6 +225,13 @@ function publicSessionView(session) {
     grid: session.grid,
     grid_size: session.grid.width,
     log_events_count: session.events.length,
+    // W5.C — expose last N events tail per frontend FX trigger robustness.
+    // Wave 3 trovò root cause FX mancanti: processNewEvents legge newWorld.events
+    // ma publicSessionView espose solo count. Wire frontend-side via
+    // processIaActions(player+ia actions) copre commit-round flow, ma per legacy
+    // /action flow + generic fallback serve events[] array.
+    // Tail 30 limita payload (full log può essere lungo, multi-round).
+    events: Array.isArray(session.events) ? session.events.slice(-30) : [],
     sistema_pressure: pressure,
     sistema_tier: tier,
     atlas,

--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -31,6 +31,9 @@
             <button id="end-turn">Fine turno</button>
             <button id="new-session">Nuova sessione</button>
             <button id="open-replay">📽 Replay</button>
+            <button id="download-eval" title="Scarica eval set Flint v0.3 (JSONL decision pairs)">
+              📊 Eval
+            </button>
             <button id="toggle-mute" title="Mute SFX">🔊</button>
             <select id="scenario-select">
               <option value="enc_tutorial_01">Tutorial 01 · Primi passi</option>

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -23,7 +23,66 @@ const state = {
   lastResolutionOrder: new Map(),
   // W4.6 — planning timer start timestamp (null = not active)
   planningTimerStart: null,
+  // W5.D — eval set Flint v0.3 decision trace (JSONL pairs per decision)
+  evalSet: [],
 };
+
+// W5.D — Build eval set entry per decision. Each entry = prompt (pre-action state)
+// + response (user choice) pair per Flint v0.3 classifier gate.
+function captureDecision(body) {
+  if (!state.world) return;
+  const actor = (state.world.units || []).find((u) => u.id === body.actor_id);
+  if (!actor) return;
+  const visibleEnemies = (state.world.units || [])
+    .filter((u) => u.controlled_by === 'sistema' && u.hp > 0)
+    .map((u) => ({ id: u.id, hp: `${u.hp}/${u.max_hp}`, pos: [u.position?.x, u.position?.y] }));
+  const entry = {
+    id: `t${state.world.turn}_${actor.id}_${state.evalSet.length + 1}`,
+    ts: new Date().toISOString(),
+    prompt: {
+      session_id: state.sid,
+      turn: state.world.turn,
+      actor: actor.id,
+      actor_job: actor.job,
+      actor_hp: `${actor.hp}/${actor.max_hp}`,
+      actor_ap: `${actor.ap_remaining ?? actor.ap}/${actor.ap}`,
+      actor_pos: [actor.position?.x, actor.position?.y],
+      visible_enemies: visibleEnemies,
+      sistema_pressure: state.world.sistema_pressure,
+      sistema_tier: state.world.sistema_tier,
+    },
+    response: {
+      action_type: body.action_type,
+      target_id: body.target_id || null,
+      position: body.position || null,
+      ability_id: body.ability_id || null,
+    },
+    meta: {
+      round_flow: useRoundFlow() ? 'simultaneous' : 'sequential',
+      confirm_action: useConfirmAction(),
+    },
+  };
+  state.evalSet.push(entry);
+}
+
+// W5.D — Download eval set as JSONL (line-delimited JSON).
+function downloadEvalSet() {
+  if (state.evalSet.length === 0) {
+    alert('Eval set vuoto. Gioca qualche azione prima.');
+    return;
+  }
+  const jsonl = state.evalSet.map((e) => JSON.stringify(e)).join('\n');
+  const blob = new Blob([jsonl], { type: 'application/x-jsonlines' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `eval_set_flint_v0.3_${state.sid?.slice(0, 8) || 'nosid'}_${Date.now()}.jsonl`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+window.__dbg = window.__dbg || {};
+window.__dbg.downloadEvalSet = downloadEvalSet;
+window.__dbg.evalSetSize = () => state.evalSet.length;
 
 // W4.6 — Planning timer 30s config + interval handle
 const PLANNING_TIMER_MS = 30_000;
@@ -340,6 +399,12 @@ async function doAction(body) {
   cancelPendingAbility(true);
   body.session_id = state.sid;
 
+  // W5.D — capture decision pre-commit for Flint v0.3 eval set.
+  // Non duplica su confirm pending (skip primo click confirm).
+  if (!useConfirmAction() || _pendingConfirm != null) {
+    captureDecision(body);
+  }
+
   // Confirm action: primo click pending, secondo click stessa action = commit
   if (useConfirmAction()) {
     if (!confirmMatch(_pendingConfirm, body)) {
@@ -555,6 +620,8 @@ async function startNewSession() {
   state.pendingIntents.clear();
   state.lastResolutionOrder.clear();
   stopPlanningTimer();
+  // W5.D — reset eval set per session
+  state.evalSet = [];
   lastEventsCount = (state.world?.events || []).length;
   appendLog(logEl, `✓ sessione ${state.sid.slice(0, 8)}…`);
   const flags = [];
@@ -569,6 +636,9 @@ document.getElementById('cancel-pending').addEventListener('click', () => cancel
 document.getElementById('new-session').addEventListener('click', () => {
   cancelPendingAbility(true);
   startNewSession();
+});
+document.getElementById('download-eval').addEventListener('click', () => {
+  downloadEvalSet();
 });
 document.getElementById('open-replay').addEventListener('click', () => {
   cancelPendingAbility(true);

--- a/apps/play/src/ui.js
+++ b/apps/play/src/ui.js
@@ -83,6 +83,7 @@ export function renderUnits(ul, state, selectedId, onClick, pendingIntents = nul
         ${u.dc != null ? `<span>DC ${u.dc}</span>` : ''}
         ${u.mod != null ? `<span>+${u.mod}</span>` : ''}
         ${u.attack_range ? `<span>range ${u.attack_range}</span>` : ''}
+        ${u.initiative != null ? `<span title="Reaction speed — priority queue ADR-2026-04-15">⚡ ${u.initiative}</span>` : ''}
         ${u.guardia ? `<span>guardia ${u.guardia}</span>` : ''}
       </div>
       ${statusChips ? `<div class="unit-status-row">${statusChips}</div>` : ''}

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,40 +1,9 @@
 {
-  "generated_at": "2026-04-17T13:35:52+00:00",
+  "generated_at": "2026-04-18T21:55:52+00:00",
   "summary": {
-    "total": 5,
+    "total": 0,
     "errors": 0,
-    "warnings": 5
+    "warnings": 0
   },
-  "issues": [
-    {
-      "level": "warning",
-      "code": "frontmatter_registry_mismatch",
-      "path": "docs/hubs/combat.md",
-      "message": "Campo last_verified differente tra frontmatter (2026-04-17) e registry (2026-04-14)"
-    },
-    {
-      "level": "warning",
-      "code": "frontmatter_registry_mismatch",
-      "path": "docs/core/00-SOURCE-OF-TRUTH.md",
-      "message": "Campo last_verified differente tra frontmatter ('2026-04-16') e registry (2026-04-16)"
-    },
-    {
-      "level": "warning",
-      "code": "frontmatter_registry_mismatch",
-      "path": "docs/core/00-GDD_MASTER.md",
-      "message": "Campo last_verified differente tra frontmatter ('2026-04-16') e registry (2026-04-16)"
-    },
-    {
-      "level": "warning",
-      "code": "frontmatter_registry_mismatch",
-      "path": "docs/core/00B-CANONICAL_PROMOTION_MATRIX.md",
-      "message": "Campo last_verified differente tra frontmatter ('2026-04-16') e registry (2026-04-16)"
-    },
-    {
-      "level": "warning",
-      "code": "frontmatter_registry_mismatch",
-      "path": "docs/core/00E-NAMING_STYLEGUIDE.md",
-      "message": "Campo last_verified differente tra frontmatter ('2026-04-16') e registry (2026-04-16)"
-    }
-  ]
+  "issues": []
 }


### PR DESCRIPTION
## Summary

Wave 5 pre-test polish stacked su PR #1609. 4 fix quick-win pre-user-playtest.

| # | Fix | Effect |
|---|-----|--------|
| W5.A | Governance drift cleanup (5→0 warnings) | CI guaranteed green |
| W5.B | Reaction speed label sidebar (⚡ N) | ADR-2026-04-15 clarity (user capisce priority) |
| W5.C | publicSessionView events[] tail (last 30) | Robustness fallback per FX trigger legacy flow |
| W5.D | Eval set JSONL capture + 📊 Eval btn | TKT-WAVE4-01 CLOSED. Flint v0.3 gate unblock |

## Eval set format (W5.D)

Ogni `doAction()` capture decision pair:

```json
{
  "id": "t1_p_scout_1",
  "ts": "2026-04-19T...",
  "prompt": {
    "session_id": "...",
    "turn": 1,
    "actor": "p_scout",
    "actor_job": "skirmisher",
    "actor_hp": "10/10",
    "actor_ap": "3/3",
    "actor_pos": [1, 2],
    "visible_enemies": [{"id": "e_nomad_1", "hp": "3/3", "pos": [3, 2]}, ...],
    "sistema_pressure": 0,
    "sistema_tier": "CALM"
  },
  "response": {
    "action_type": "attack",
    "target_id": "e_nomad_1",
    "position": null,
    "ability_id": null
  },
  "meta": {
    "round_flow": "simultaneous",
    "confirm_action": false
  }
}
```

Download via btn `📊 Eval` → `eval_set_flint_v0.3_<sid>_<ts>.jsonl`.

## Skip list

| Item | Reason |
|------|--------|
| threat_preview payload | `packages/contracts/` schema extend richiede approval |
| Reactions first-class (ADR §6) | Design work, multi-session scope |
| ACTION_SPEED YAML move | Balance work, coordinamento team rules |
| ai_intent_distribution (TKT-09) | Backend investigation + response shape design |
| TKT-07/08/10/11 | Simulation/investigation tickets non pre-test scope |

## Verify

Browser post-reload (port 5180, backend serverId `263087cc` post-restart):
- 4 unit con ⚡ speed label (15/8/15/15) ✅
- 2 pending intent badge PG preserved ✅
- `#download-eval` button live ✅
- `window.__dbg.evalSetSize() === 0` fresh ✅
- curl `/api/session/start` returns `events` array (len 1 initial) ✅

## Files

| File | LOC |
|------|---:|
| `apps/play/src/main.js` | +64 |
| `apps/play/src/ui.js` | +1 |
| `apps/play/index.html` | +5 |
| `apps/backend/routes/sessionHelpers.js` | +9 |
| `reports/docs/governance_drift_report.json` | +/-6 (drift cleanup) |
| **Total** | **+85 / -35** |

## Stack chain

PR stack: #1606 → #1607 (W2) → #1608 (W3) → #1609 (W4) → **this (W5)**

Merge chain sequenziale quando all approved.

## Rollback

`git revert 6dd6274b` — self-contained, backend change = additive field (non-breaking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)