### PR TITLE
feat(play): Wave 7 — planning preview + per-PG abilities + defensive reset (user run3 bugs)

### DIFF
--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -30,6 +30,9 @@
           <div class="controls">
             <button id="end-turn">Fine turno</button>
             <button id="new-session">Nuova sessione</button>
+            <button id="reset-round" title="Emergency reset round state (se tutto bloccato)">
+              🔄 Reset
+            </button>
             <button id="open-replay">📽 Replay</button>
             <button id="download-eval" title="Scarica eval set Flint v0.3 (JSONL decision pairs)">
               📊 Eval

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -27,6 +27,37 @@ const state = {
   evalSet: [],
 };
 
+// W7.B — ACTION_SPEED table mirror server-side (roundOrchestrator.py spec ADR-2026-04-15).
+// Usato per predicted priority preview in planning phase (UX: user capisce ordine pre-commit).
+const ACTION_SPEED = {
+  defend: 2,
+  parry: 2,
+  attack: 0,
+  ability: -1,
+  move: -2,
+};
+
+// W7.B — Compute resolve priority order among declared player intents.
+// Formula: unit.initiative + action_speed(action) - status_penalty.
+// NOTE: include solo PG (SIS intents server-side, non esposti in planning).
+function computePlayerPriorityOrder(pendingIntents, units) {
+  const items = [];
+  for (const [uid, intent] of pendingIntents.entries()) {
+    const unit = units.find((u) => u.id === uid);
+    if (!unit) continue;
+    const actSpd = ACTION_SPEED[intent.type] ?? 0;
+    const panic = (unit.status && unit.status.panic) || 0;
+    const disorient = (unit.status && unit.status.disorient) || 0;
+    const statusPenalty = panic * 2 + disorient;
+    const priority = (unit.initiative || 0) + actSpd - statusPenalty;
+    items.push({ uid, priority });
+  }
+  items.sort((a, b) => b.priority - a.priority || a.uid.localeCompare(b.uid));
+  const map = new Map();
+  items.forEach((it, i) => map.set(it.uid, i + 1));
+  return map;
+}
+
 // W5.D — Build eval set entry per decision. Each entry = prompt (pre-action state)
 // + response (user choice) pair per Flint v0.3 classifier gate.
 function captureDecision(body) {
@@ -101,6 +132,7 @@ function redraw() {
     active: state.world.active_unit,
     resolutionOrder: state.lastResolutionOrder,
   });
+  const predictedOrder = computePlayerPriorityOrder(state.pendingIntents, state.world.units || []);
   renderUnits(
     unitsUl,
     state.world,
@@ -108,6 +140,7 @@ function redraw() {
     handleUnitClick,
     state.pendingIntents,
     handleCancelIntent,
+    predictedOrder,
   );
   updateStatus(state.world);
   // ability panel
@@ -674,10 +707,18 @@ async function startNewSession() {
   redraw();
 }
 
+// W7.D — re-render quando abilities fetched per popolare chips per-unit.
+unitsUl.addEventListener('abilities-ready', () => {
+  if (state.world) redraw();
+});
+
 document.getElementById('cancel-pending').addEventListener('click', () => cancelPendingAbility());
 document.getElementById('new-session').addEventListener('click', () => {
   cancelPendingAbility(true);
   startNewSession();
+});
+document.getElementById('reset-round')?.addEventListener('click', async () => {
+  await emergencyResetRound();
 });
 document.getElementById('download-eval').addEventListener('click', () => {
   downloadEvalSet();
@@ -744,61 +785,105 @@ function processIaActions(iaActions) {
 
 // W4 — commit-round factored out so auto-commit (W4.5) e end-turn button
 // possono condividere la stessa logica + reveal overlay + priority badge.
+// W7.A — Emergency reset state (usato da error handler o user "Reset" button).
+// Clear tutti flag round + overlay + re-fetch state server per recover da block.
+async function emergencyResetRound() {
+  state.roundInit = false;
+  state.pendingIntents.clear();
+  state.lastResolutionOrder.clear();
+  _pendingConfirm = null;
+  stopPlanningTimer();
+  const overlay = document.getElementById('commit-reveal');
+  if (overlay) {
+    overlay.classList.add('fade-out');
+    overlay.classList.remove('visible');
+  }
+  if (state.sid) {
+    try {
+      const r = await api.state(state.sid);
+      if (r.ok) {
+        state.world = r.data;
+        redraw();
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+  updateHint(`🔄 Reset stato round. Pianifica di nuovo.`);
+}
+window.__dbg = window.__dbg || {};
+window.__dbg.emergencyResetRound = emergencyResetRound;
+
 async function triggerCommitRound() {
   if (!state.sid) return;
   sfx.turn_end();
   appendLog(logEl, '→ risolvo round');
   stopPlanningTimer();
 
-  if (!state.roundInit) {
-    const bp = await api.beginPlanning(state.sid);
-    if (!bp.ok) {
-      appendLog(logEl, `✖ begin-planning: ${bp.data?.error || bp.status}`, 'error');
+  try {
+    if (!state.roundInit) {
+      const bp = await api.beginPlanning(state.sid);
+      if (!bp.ok) {
+        appendLog(logEl, `✖ begin-planning: ${bp.data?.error || bp.status}`, 'error');
+        await emergencyResetRound();
+        return;
+      }
+      state.roundInit = true;
+    }
+    const r = await api.commitRound(state.sid, true);
+    if (!r.ok) {
+      appendLog(logEl, `✖ commit-round: ${r.data?.error || r.status}`, 'error');
+      await emergencyResetRound();
       return;
     }
-    state.roundInit = true;
-  }
-  const r = await api.commitRound(state.sid, true);
-  if (!r.ok) {
-    appendLog(logEl, `✖ commit-round: ${r.data?.error || r.status}`, 'error');
-    return;
-  }
-  state.roundInit = false;
-  _pendingConfirm = null;
-  state.pendingIntents.clear();
+    state.roundInit = false;
+    _pendingConfirm = null;
+    state.pendingIntents.clear();
 
-  const playerActions = r.data?.player_actions || [];
-  const iaActions = r.data?.ia_actions || [];
-  const resolutionQueue = r.data?.resolution_queue || [];
-  const allActions = [...playerActions, ...iaActions];
+    const playerActions = r.data?.player_actions || [];
+    const iaActions = r.data?.ia_actions || [];
+    const resolutionQueue = r.data?.resolution_queue || [];
+    const allActions = [...playerActions, ...iaActions];
 
-  // W4.3 — build resolution order map: unit_id → rank (1-based).
-  // Preferisci resolution_queue (server-computed priority), fallback ordine allActions.
-  state.lastResolutionOrder.clear();
-  const queueItems = resolutionQueue.length > 0 ? resolutionQueue : allActions;
-  queueItems.forEach((item, idx) => {
-    const uid = item.unit_id || item.actor_id;
-    if (uid && !state.lastResolutionOrder.has(uid)) {
-      state.lastResolutionOrder.set(uid, idx + 1);
-    }
-  });
-
-  // W4.2 — commit reveal overlay pre-animations (700ms)
-  const turnNum = (state.world?.turn || 0) + 1;
-  showCommitReveal(turnNum, allActions.length);
-
-  const REVEAL_MS = 700;
-  setTimeout(() => {
-    if (allActions.length > 0) processIaActions(allActions);
-  }, REVEAL_MS);
-
-  const totalDelay = REVEAL_MS + allActions.length * 350 + 200;
-  setTimeout(async () => {
-    await refresh();
+    // W4.3 — build resolution order map: unit_id → rank (1-based).
+    // Preferisci resolution_queue (server-computed priority), fallback ordine allActions.
     state.lastResolutionOrder.clear();
-    redraw();
-    appendLog(logEl, `✓ round ${state.world?.turn || '?'} risolto (${allActions.length} azioni)`);
-  }, totalDelay);
+    const queueItems = resolutionQueue.length > 0 ? resolutionQueue : allActions;
+    queueItems.forEach((item, idx) => {
+      const uid = item.unit_id || item.actor_id;
+      if (uid && !state.lastResolutionOrder.has(uid)) {
+        state.lastResolutionOrder.set(uid, idx + 1);
+      }
+    });
+
+    // W4.2 — commit reveal overlay pre-animations (700ms)
+    const turnNum = (state.world?.turn || 0) + 1;
+    showCommitReveal(turnNum, allActions.length);
+
+    const REVEAL_MS = 700;
+    setTimeout(() => {
+      if (allActions.length > 0) processIaActions(allActions);
+    }, REVEAL_MS);
+
+    const totalDelay = REVEAL_MS + allActions.length * 350 + 200;
+    setTimeout(async () => {
+      try {
+        await refresh();
+        state.lastResolutionOrder.clear();
+        redraw();
+        appendLog(
+          logEl,
+          `✓ round ${state.world?.turn || '?'} risolto (${allActions.length} azioni)`,
+        );
+      } catch (err) {
+        appendLog(logEl, `✖ refresh dopo round: ${err?.message || err}`, 'error');
+        await emergencyResetRound();
+      }
+    }, totalDelay);
+  } catch (err) {
+    appendLog(logEl, `✖ commit-round exception: ${err?.message || err}`, 'error');
+    await emergencyResetRound();
+  }
 }
 
 // W4.2 — Commit reveal overlay: "⚔ ROUND N · X azioni simultanee" flash 700ms.

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -162,6 +162,39 @@ canvas#grid {
   background: rgba(244, 67, 54, 0.2);
 }
 
+/* W7.B — Priority rank preview badge (visible in planning once intent declared). */
+.priority-rank {
+  display: inline-block;
+  background: var(--accent);
+  color: #000;
+  font-weight: bold;
+  font-size: 0.7rem;
+  padding: 1px 5px;
+  border-radius: 3px;
+  letter-spacing: 0.02em;
+  min-width: 18px;
+  text-align: center;
+}
+
+/* W7.D — Per-player ability chips (inline mini-list). */
+.unit-abilities {
+  margin-top: 4px;
+  font-size: 0.68rem;
+  color: var(--dim);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  align-items: center;
+}
+.unit-abilities .ab-chip {
+  background: rgba(255, 204, 0, 0.12);
+  color: var(--accent);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-weight: bold;
+  border: 1px solid rgba(255, 204, 0, 0.3);
+}
+
 /* W6.3 — Per-PG expanded HUD: traits row + recent unit events log. */
 .unit-traits {
   margin-top: 4px;

--- a/apps/play/src/ui.js
+++ b/apps/play/src/ui.js
@@ -73,6 +73,44 @@ function formatEventLine(ev, unitId) {
   return t;
 }
 
+// W7.D — Lazy cache abilities per job from /api/jobs. Populated on first render.
+const _abilitiesCache = new Map(); // job → [{ability_id, display_name, ap_cost}]
+let _abilitiesFetchPromise = null;
+
+async function ensureAbilities() {
+  if (_abilitiesFetchPromise) return _abilitiesFetchPromise;
+  _abilitiesFetchPromise = fetch('/api/jobs')
+    .then((r) => r.json())
+    .then((data) => {
+      const jobs = Array.isArray(data?.jobs) ? data.jobs : [];
+      for (const j of jobs) {
+        const key = (j.id || j.job || '').toLowerCase();
+        if (!key) continue;
+        const raw = Array.isArray(j.abilities)
+          ? j.abilities
+          : Array.isArray(j.ability_ids)
+            ? j.ability_ids
+            : [];
+        // Normalize: support sia array of strings che array of objects.
+        const normalized = raw.map((x) =>
+          typeof x === 'string'
+            ? { ability_id: x, display_name: x.replace(/_/g, ' ') }
+            : x && typeof x === 'object'
+              ? x
+              : { ability_id: String(x) },
+        );
+        _abilitiesCache.set(key, normalized);
+      }
+      return _abilitiesCache;
+    })
+    .catch(() => _abilitiesCache);
+  return _abilitiesFetchPromise;
+}
+
+function getAbilitiesForJob(job) {
+  return _abilitiesCache.get((job || '').toLowerCase()) || [];
+}
+
 export function renderUnits(
   ul,
   state,
@@ -80,7 +118,15 @@ export function renderUnits(
   onClick,
   pendingIntents = null,
   onCancelIntent = null,
+  predictedOrder = null,
 ) {
+  // Kick off abilities fetch (idempotent, populates cache for next render).
+  ensureAbilities().then(() => {
+    // Trigger re-render only if abilities weren't available first pass.
+    if (ul.dataset.abilitiesRefetched) return;
+    ul.dataset.abilitiesRefetched = '1';
+    ul.dispatchEvent(new CustomEvent('abilities-ready'));
+  });
   ul.innerHTML = '';
   for (const u of state.units || []) {
     const li = document.createElement('li');
@@ -133,7 +179,12 @@ export function renderUnits(
         if (!pendingIntents) return '';
         const intent = pendingIntents.get ? pendingIntents.get(u.id) : pendingIntents[u.id];
         if (intent) {
+          const rank = predictedOrder && predictedOrder.get ? predictedOrder.get(u.id) : null;
+          const rankHtml = rank
+            ? `<span class="priority-rank" title="Ordine predetto (initiative + action_speed − status_penalty)">#${rank}</span>`
+            : '';
           return `<div class="intent-row">
+            ${rankHtml}
             <div class="intent-badge declared" title="Intent dichiarato">✓ ${formatIntent(intent)}</div>
             <button class="intent-cancel" data-unit-id="${u.id}" title="Annulla intent (re-click action per nuovo)">✕</button>
           </div>`;
@@ -141,20 +192,30 @@ export function renderUnits(
         return `<div class="intent-badge pending" title="Nessun intent dichiarato">⏳ in attesa</div>`;
       })()}
       ${(() => {
-        // W6.3 — Per-PG expanded HUD: traits + recent events filtered per unit.
-        // Mostrato solo per player PG vivi (info combattimento personalizzata).
+        // W6.3 / W7.C — Per-PG expanded HUD: traits + abilities + recent events filtered.
+        // W7.C: default <details open> perché user non trovava la sezione collapsed.
+        // W7.D: ability chips inline per player (prima era solo shared bottom bar).
         if (u.controlled_by !== 'player' || u.hp <= 0) return '';
         const traits = Array.isArray(u.traits) ? u.traits : [];
+        const abilities = getAbilitiesForJob(u.job);
         const evRows = recentUnitEvents(state, u.id, 4);
         const traitsHtml = traits.length
           ? `<div class="unit-traits" title="Trait attivi (evoluzione)">🧬 ${traits.map((t) => `<code>${t}</code>`).join(' ')}</div>`
           : '';
+        const abilitiesHtml = abilities.length
+          ? `<div class="unit-abilities" title="Abilities conosciute">⚔ ${abilities
+              .map(
+                (a) =>
+                  `<span class="ab-chip" title="${(a.effect_type || '').toString()} · AP ${a.ap_cost ?? 1}">${a.display_name || a.ability_id}</span>`,
+              )
+              .join('')}</div>`
+          : '';
         const eventsHtml = evRows.length
-          ? `<details class="unit-log-details"><summary>📜 Ultimi eventi (${evRows.length})</summary><ul class="unit-log">${evRows
+          ? `<details class="unit-log-details" open><summary>📜 Ultimi eventi (${evRows.length})</summary><ul class="unit-log">${evRows
               .map((e) => `<li>T${e.turn || '?'}: ${formatEventLine(e, u.id)}</li>`)
               .join('')}</ul></details>`
           : '';
-        return `${traitsHtml}${eventsHtml}`;
+        return `${traitsHtml}${abilitiesHtml}${eventsHtml}`;
       })()}
     `;
     li.addEventListener('click', (ev) => {


### PR DESCRIPTION
## Summary

Wave 7 stacked su PR #1611. Fix 4 bug scoperti in user playtest run3 post Wave 6 merge.

## User feedback verbatim

> "al turn 3 si blocca tutto"

> "la consecuzione delle azioni non è ancora chiara né modificabile"

> "non si vedono le HUD personali dei player e le loro ability"

## Fix

| # | Bug | File | Change |
|---|-----|------|--------|
| W7.A | Turn 3 block | `main.js` + `index.html` | try/catch wrap `triggerCommitRound` + `emergencyResetRound` helper + 🔄 Reset btn header |
| W7.B | Consecuzione non chiara | `main.js` + `ui.js` + `style.css` | ACTION_SPEED table mirror + `computePlayerPriorityOrder` client formula ADR-04-15. Badge `#1`/`#2` yellow visibile su declared intents IN planning |
| W7.C | HUD non visibile | `ui.js` | `<details open>` default per unit-log (prima collapsed → user non trovava) |
| W7.D | Abilities non per-PG | `ui.js` + `style.css` | `ensureAbilities()` fetch /api/jobs cached + normalizza ability_ids → inline chip list "⚔ dash strike, evasive maneuver" per player |

## Priority preview (W7.B)

Formula mirror ADR-2026-04-15:
```
resolve_priority = unit.initiative + action_speed(intent.type) - status_penalty
```

- `ACTION_SPEED = {defend:2, parry:2, attack:0, ability:-1, move:-2}`
- `status_penalty = panic * 2 + disorient`
- Tiebreak: alphabetical `unit_id`

Map<unit_id, rank> passed to `renderUnits` via new param `predictedOrder`. Badge appare in intent-row subito dopo declare.

Include solo player PG (SIS intents server-side, non esposti in planning). Limitation documented: user vede predicted order TRA PG, non include SIS.

## Per-player ability chips (W7.D)

Ogni `li.player` ora mostra:
- p_scout [skirmisher]: ⚔ dash strike, evasive maneuver, blade flurry
- p_tank [vanguard]: ⚔ shield bash, taunt, fortify
- etc.

Lazy fetch + cache via `ensureAbilities()` — one `/api/jobs` request, populate cache, dispatch `abilities-ready` event per re-render inizial pass.

## Defensive (W7.A)

Tre layer:

1. **try/catch** in `triggerCommitRound`: begin-planning failure, commit-round failure, refresh post-resolve failure → all catch → `emergencyResetRound()`
2. **emergencyResetRound helper**: clear `state.roundInit` + `pendingIntents` + `lastResolutionOrder` + reveal overlay + `state/refresh` da server
3. **🔄 Reset button** header: user rescue path se situazione bloccata nonostante auto-recovery

Also exposes `window.__dbg.emergencyResetRound()` per debugging.

## Limitation

**Turn 3 root cause NON identificato** senza repro logs (backend/console errors empty quando testato). Defensive code permette recovery, ma bug potrebbe ripresentarsi. Follow-up W8: aggiungere console.log telemetry su round transitions + catch unhandled promise rejections.

## Verify browser

Session post-reload:
- 4 unit rendered
- Player li con ⚔ 3 ability chips each (skirmisher/vanguard) ✅
- 🔄 Reset button live in header ✅
- Traits 🧬 row preserved ✅
- Priority #rank badge renderizza post-declareIntent (user test gameplay richiesto)

## Files

| File | LOC |
|------|---:|
| `apps/play/src/main.js` | +110/-14 |
| `apps/play/src/ui.js` | +72/-8 |
| `apps/play/src/style.css` | +38 |
| `apps/play/index.html` | +3 |
| **Total** | **+228 / -46** |

## Stack

PR stack: #1606 → #1607 (W2) → #1608 (W3) → #1609 (W4) → #1610 (W5) → #1611 (W6) → **this (W7)**

## Rollback

`git revert fb927f60` — self-contained, zero backend/contract touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)