### PR TITLE
feat(play): Wave 8e — Enter shortcut + retry intent + responsive breakpoints (research pass 3)

### DIFF
--- a/apps/play/src/api.js
+++ b/apps/play/src/api.js
@@ -29,6 +29,21 @@ async function jsonFetch(path, opts = {}) {
   return { ok: res.ok, status: res.status, data };
 }
 
+// W8e — Retry helper for transient network errors (research pass 3 finding #7).
+// Wraps jsonFetch with 1 retry after delay when networkError flag is set.
+// Used for idempotent POST endpoints (declare-intent/commit-round are re-declarable
+// server-side via latest-wins).
+async function jsonFetchRetry(path, opts = {}, { retries = 1, delayMs = 400 } = {}) {
+  let attempt = 0;
+  let result = await jsonFetch(path, opts);
+  while (result.networkError && attempt < retries) {
+    attempt += 1;
+    await new Promise((r) => setTimeout(r, delayMs));
+    result = await jsonFetch(path, opts);
+  }
+  return result;
+}
+
 export const api = {
   scenario: (id) => jsonFetch(`/api/tutorial/${encodeURIComponent(id)}`),
   start: (units, opts = {}) =>
@@ -52,7 +67,8 @@ export const api = {
       body: JSON.stringify({ session_id: sid }),
     }),
   declareIntent: (sid, actorId, action) =>
-    jsonFetch('/api/session/declare-intent', {
+    // W8e — retry on network drop (idempotent server-side: latest-wins per unit).
+    jsonFetchRetry('/api/session/declare-intent', {
       method: 'POST',
       body: JSON.stringify({ session_id: sid, actor_id: actorId, action }),
     }),

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -292,6 +292,21 @@ document.addEventListener('keydown', (ev) => {
   }
 });
 
+// W8e — Enter key = "Fine turno" shortcut (keyboard alternative to button).
+// Skip se focus è dentro input/textarea/select o help modal aperto.
+document.addEventListener('keydown', (ev) => {
+  if (ev.key !== 'Enter') return;
+  const active = document.activeElement;
+  if (active && /^(input|textarea|select|button)$/i.test(active.tagName)) return;
+  const helpOpen =
+    document.getElementById('help-panel') &&
+    !document.getElementById('help-panel').classList.contains('hidden');
+  if (helpOpen) return;
+  if (!state.sid) return;
+  ev.preventDefault();
+  document.getElementById('end-turn').click();
+});
+
 function handleUnitClick(unit) {
   if (!state.world) return;
   // Ability targeting mode

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -165,6 +165,48 @@ main {
   padding: 16px;
 }
 
+/* W8e — Responsive breakpoints (research pass 3 #3).
+ * Default: TV-first 1fr + 300px sidebar (≥1024px).
+ * <1024px: stacked — canvas sopra, sidebar sotto (laptop small + tablet landscape).
+ * <768px: sidebar sezioni compatte (mobile/tablet portrait). */
+@media (max-width: 1024px) {
+  main {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto;
+  }
+  .sidebar {
+    max-height: 400px;
+  }
+}
+@media (max-width: 768px) {
+  header {
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 8px 12px;
+  }
+  header h1 {
+    font-size: 1.2rem;
+  }
+  .pressure-meter {
+    min-width: 200px;
+  }
+  main {
+    padding: 8px;
+    gap: 8px;
+  }
+  canvas#grid {
+    max-width: 100%;
+    height: auto;
+  }
+  .controls {
+    flex-wrap: wrap;
+  }
+  #units li {
+    padding: 6px 8px;
+    font-size: 0.82rem;
+  }
+}
+
 .board {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Wave 8e stacked su PR #1616. Research pass 3 audit (10 findings su dimensioni non esplorate): applied Q2-Q4 subset actionable-now.

## Research pass 3 (10 findings)

| # | Category | Finding | Applied |
|---|----------|---------|:---:|
| 1 | test | Zero tests per triggerCommitRound/computePlayerPriorityOrder/doAction | ⏭ backlog (infra setup) |
| 2 | i18n | All strings IT hardcoded, no locale layer | ⏭ roadmap decision |
| 3 | mobile | No responsive grid + canvas fixed 512px | ✅ Q4 |
| 4 | obs | Scattered debug, no structured log | ⏭ MVP acceptable |
| 5 | bundle | Color tokens duplicati (canvas + CSS) | ✓ already documented W8c |
| 6 | state | Global mutable state, tight coupling | ⏭ architectural decision |
| 7 | error | declareIntent no retry on network drop | ✅ Q3 |
| 8 | docs | Zero JSDoc, no README apps/play | ✓ README esiste già |
| 9 | arch | renderUnits assumes state shape | ✓ guard già in place |
| 10 | kb | ESC handled, no Enter/WASD/nums | ✅ Q2 (Enter) |

## Applied

### Q2 Keyboard shortcut Enter = End Turn

`main.js` keydown listener:
- Enter → click `#end-turn` button
- Skip se focus in input/button/help modal

Keyboard-first UX gain (TV remote compatibility future + power user desktop).

### Q3 Network retry declareIntent

`api.js` new `jsonFetchRetry(path, opts, {retries=1, delayMs=400})`:
- Wraps `jsonFetch` with 1 retry after 400ms delay on `networkError`
- Applied to `declareIntent` (idempotent: latest-wins server-side)

Previous Wave 8-emergency added retry pattern to `commitRound` + `beginPlanning`. Now `declareIntent` uniform.

### Q4 Responsive breakpoints

`style.css`:
- `≤1024px` (laptop + tablet landscape): `grid-template-columns: 1fr` stacked, sidebar max-height 400px
- `≤768px` (mobile + tablet portrait): header flex-wrap, canvas `max-width: 100%`, padding compact, font sizes ridotte

Default ≥1024px TV-first preservato.

Verify: tablet 768×1024 → main grid 1 column (698.625px), sidebar maxH 400px ✅.

## Skipped

### Strategic (needs roadmap decision)

- i18n (Q1 R3#2): blocks EN market expansion, significant strings extraction
- state factory (Q1 R3#6): architectural, UI framework swap future
- touch events (tablet/mobile scope): UX design decision
- JSDoc full coverage (Q1 R3#8): non-blocking, 150 LOC

### Infra setup required

- Q5 unit test `computePlayerPriorityOrder`: needs vitest apps/play workspace + export from main.js module. Backlog Wave 9 post-infra.

## Preservato 100%

Zero feature cut. Tutte Wave 2-8d intact. Enter non-breaking (ignora se focus input).

## Verify

- Tablet viewport: main 1-column, sidebar max-h 400px ✅
- Zero console errors ✅
- Ability chips + range overlay + FX preserved ✅

## Files

| File | LOC |
|------|---:|
| `apps/play/src/main.js` | +16 |
| `apps/play/src/api.js` | +17/-0 |
| `apps/play/src/style.css` | +41 |
| **Total** | **+74 / -1** |

## Stack

#1606-#1616 + **this (W8e)** = 12 deep

## Rollback

`git revert 892d277a` — self-contained, Enter + retry + @media only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)