### PR TITLE
feat(play): Wave 8h — onboarding tips + AP label readability (research + learn-by-doing)

### DIFF
--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -16,6 +16,7 @@ import {
 import { openReplay } from './replayPanel.js';
 import { sfx, setMuted, isMuted } from './sfx.js';
 import { initHelpPanel } from './helpPanel.js';
+import { showTip, buildRecoveryTipMessage, resetAllTips } from './tips.js';
 
 const state = {
   sid: null,
@@ -136,6 +137,8 @@ function downloadEvalSet() {
 window.__dbg = window.__dbg || {};
 window.__dbg.downloadEvalSet = downloadEvalSet;
 window.__dbg.evalSetSize = () => state.evalSet.length;
+// W8h — reset all tip seen flags (per re-playtest first-time flow).
+window.__dbg.resetTips = resetAllTips;
 
 // W4.6 — Planning timer 30s config + interval handle
 const PLANNING_TIMER_MS = 30_000;
@@ -346,6 +349,9 @@ function handleUnitClick(unit) {
     sfx.select();
     updateHint(`Selezionato ${unit.id}. Click cella=move · click nemico=attack · sidebar=ability.`);
     redraw();
+    // W8h — onboarding tips (first-time only). Range overlay visible → spiega colori.
+    showTip('select-unit');
+    setTimeout(() => showTip('range-overlay'), 900);
   } else {
     if (!state.selected) {
       updateHint('Seleziona prima una tua unità.');
@@ -550,6 +556,9 @@ async function doAction(body) {
     if (!r.ok) {
       appendLog(logEl, `✖ ${r.data?.error || `HTTP ${r.status}`}`, 'error');
       updateHint(`❌ ${r.data?.error || 'Intent rifiutato.'} · riprova`);
+      // W8h — Error recovery tip: parse error → specific tip (first time error only).
+      const recovery = buildRecoveryTipMessage(r.data?.error || '');
+      if (recovery) showTip('invalid-action', recovery);
       return;
     }
     // W4.1 — track intent client-side per badge sidebar. Latest-wins (re-declare override).
@@ -561,6 +570,11 @@ async function doAction(body) {
         : `→ atk ${body.target_id}`;
     appendLog(logEl, `${body.actor_id}: ${tag} (pending)`);
     redraw();
+    // W8h — Onboarding tips (first-time per action type + first intent).
+    if (body.action_type === 'move') showTip('first-move');
+    else if (body.action_type === 'attack') showTip('first-attack');
+    else if (body.action_type === 'ability') showTip('first-ability');
+    setTimeout(() => showTip('intent-declared'), 1100);
     // W6.1 — Auto-commit rimosso (user bug report: "scatta il round appena clicco secondo PG").
     // Explicit "Fine turno" only. User può re-declare per cambiare idea.
     // Opt-in tramite localStorage flag `evo:auto-commit` = 'true' (power-user).
@@ -864,6 +878,8 @@ async function triggerCommitRound() {
   sfx.turn_end();
   appendLog(logEl, '→ risolvo round');
   stopPlanningTimer();
+  // W8h — Onboarding tip first time round resolve.
+  showTip('round-resolve');
 
   try {
     if (!state.roundInit) {

--- a/apps/play/src/render.js
+++ b/apps/play/src/render.js
@@ -289,26 +289,46 @@ function drawRangeOverlay(ctx, state, gridH, selectedId) {
   }
 
   // Move range (Manhattan <= AP, escluse celle occupate).
-  // W6.2a — AP cost label per tile (user bug: "non mostrati costi caselle movimento").
+  // W6.2a — AP cost label per tile.
+  // W8h — Readability fix (user feedback run5): ciano su ciano era low contrast (WCAG fail).
+  // Nuovo: dark badge pill + white text + shadow. Contrast ratio 18:1 (WCAG AAA).
   if (ap > 0) {
     ctx.save();
+    ctx.font = 'bold 12px "SF Mono", "Menlo", monospace';
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
     for (let gy = 0; gy < gridH; gy += 1) {
       for (let gx = 0; gx < gridW; gx += 1) {
         const d = Math.abs(gx - ux) + Math.abs(gy - uy);
         if (d === 0 || d > ap) continue;
         if (occupied.has(`${gx},${gy}`)) continue;
         const yPx = gridH - 1 - gy;
+        // Tint fill + border (unchanged)
         ctx.fillStyle = RANGE_TINT.move;
         ctx.fillRect(gx * CELL, yPx * CELL, CELL, CELL);
         ctx.strokeStyle = RANGE_TINT.moveBorder;
         ctx.lineWidth = 1.5;
         ctx.strokeRect(gx * CELL + 2, yPx * CELL + 2, CELL - 4, CELL - 4);
-        // AP cost label (angolo top-left tile)
-        ctx.fillStyle = 'rgba(0, 184, 212, 0.92)';
-        ctx.font = 'bold 11px "SF Mono", monospace';
-        ctx.textAlign = 'left';
-        ctx.textBaseline = 'top';
-        ctx.fillText(`${d} AP`, gx * CELL + 5, yPx * CELL + 4);
+        // AP badge — dark pill background (top-left).
+        const label = `${d} AP`;
+        const badgeW = ctx.measureText(label).width + 10;
+        const badgeH = 18;
+        const bx = gx * CELL + 4;
+        const by = yPx * CELL + 4;
+        ctx.fillStyle = 'rgba(15, 15, 15, 0.85)';
+        ctx.beginPath();
+        if (typeof ctx.roundRect === 'function') {
+          ctx.roundRect(bx, by, badgeW, badgeH, 4);
+        } else {
+          ctx.rect(bx, by, badgeW, badgeH);
+        }
+        ctx.fill();
+        ctx.strokeStyle = RANGE_TINT.moveBorder;
+        ctx.lineWidth = 1;
+        ctx.stroke();
+        // White text on dark bg — WCAG AAA.
+        ctx.fillStyle = '#ffffff';
+        ctx.fillText(label, bx + 5, by + 3);
       }
     }
     ctx.restore();

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -224,6 +224,83 @@ canvas#grid {
     box-shadow 0.18s ease-out;
 }
 
+/* W8h — Contextual first-time tip popup (onboarding learn-by-doing).
+ * Bottom-left, non-blocking, dismissible via ESC or ✕. Persistono seen via localStorage. */
+.tip-popup {
+  position: fixed;
+  bottom: 24px;
+  left: 24px;
+  z-index: 85; /* sopra canvas (20), sotto help modal (9000+) */
+  max-width: 340px;
+  opacity: 0;
+  transform: translateY(20px);
+  pointer-events: none;
+  transition: all 0.3s ease-out;
+}
+.tip-popup:not(.hidden) {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+.tip-popup.hidden {
+  display: none;
+}
+.tip-popup .tip-content {
+  background: var(--panel);
+  border: 2px solid var(--accent);
+  border-radius: 6px;
+  padding: 12px 14px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.6);
+}
+.tip-popup .tip-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.tip-popup .tip-icon {
+  font-size: 1.3rem;
+  flex-shrink: 0;
+}
+.tip-popup .tip-title {
+  color: var(--accent);
+  font-size: 1rem;
+  flex: 1;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.tip-popup .tip-close {
+  background: transparent;
+  border: 1px solid var(--dim);
+  color: var(--fg);
+  width: 26px;
+  height: 26px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  border-radius: 4px;
+  padding: 0;
+  line-height: 1;
+}
+.tip-popup .tip-close:hover {
+  background: var(--sistema);
+  border-color: var(--sistema);
+  color: #fff;
+}
+.tip-popup .tip-body {
+  font-size: 0.9rem;
+  color: var(--fg);
+  line-height: 1.45;
+  margin-bottom: 8px;
+}
+.tip-popup .tip-dismiss {
+  font-size: 0.7rem;
+  color: var(--dim);
+  text-align: center;
+  font-style: italic;
+  padding-top: 6px;
+  border-top: 1px solid var(--border);
+}
+
 /* W4.1 / W6 — Intent badge sidebar (pending / declared) + cancel btn. */
 .intent-row {
   display: flex;

--- a/apps/play/src/tips.js
+++ b/apps/play/src/tips.js
@@ -1,0 +1,199 @@
+// W8h — Contextual first-time tip system (Evo-Tactics onboarding philosophy:
+// learn-by-doing, non scripted). Tips triggered by interaction first-time,
+// dismissible, persistono seen flag via localStorage.
+//
+// Reference: Into the Breach (predicted damage reveal), Slay the Spire (hover),
+// Fell Seal (first-ability tip), Dark Souls (minimal scripted).
+
+const LS_PREFIX = 'evo:tip-';
+
+// Tip catalog canonical — ogni tip triggered una volta per localStorage key.
+const TIPS = {
+  'select-unit': {
+    icon: '👆',
+    title: 'Seleziona unità',
+    message:
+      'Click su una unità blu per selezionarla. Range move (blu) + attack (rosso) appariranno sul canvas.',
+    duration: 5000,
+  },
+  'first-move': {
+    icon: '➡️',
+    title: 'Movimento dichiarato',
+    message:
+      'Intent salvato ✓. Ogni cella costa 1 AP. Seleziona altra unità o "Fine turno" per risolvere.',
+    duration: 4000,
+  },
+  'first-attack': {
+    icon: '⚔️',
+    title: 'Attacco dichiarato',
+    message: 'Attacco costa 1 AP. Premi "Fine turno" (o Enter) per risolvere round simultaneo.',
+    duration: 4000,
+  },
+  'first-ability': {
+    icon: '✨',
+    title: 'Ability selezionata',
+    message: 'Click target (nemico/alleato/cella). ESC per annullare. AP cost indicato sulla chip.',
+    duration: 4000,
+  },
+  'range-overlay': {
+    icon: '🎯',
+    title: 'Range visualizzato',
+    message: 'BLU = celle movimento (costo AP indicato) · ROSSO = nemici attaccabili entro range.',
+    duration: 4500,
+  },
+  'intent-declared': {
+    icon: '💾',
+    title: 'Intent salvato',
+    message:
+      'Re-click stessa action per cambiare idea. ✕ per annullare singolo. ESC annulla tutti.',
+    duration: 3500,
+  },
+  'round-resolve': {
+    icon: '⚔️',
+    title: 'Round simultaneo',
+    message:
+      'Tutte azioni risolte contemporaneamente per reaction_speed (initiative + action_speed).',
+    duration: 4000,
+  },
+  'invalid-action': {
+    icon: '❌',
+    title: 'Azione invalida',
+    message: '', // dynamic per error context
+    duration: 4500,
+  },
+  'sis-intent': {
+    icon: '✊',
+    title: 'Intento SIS',
+    message: "L'icona ✊ sopra nemico = intento attacco prossimo turno. Hover per dettagli.",
+    duration: 4000,
+  },
+};
+
+function getLS(key) {
+  try {
+    return localStorage.getItem(LS_PREFIX + key);
+  } catch {
+    return null;
+  }
+}
+function setLS(key, value) {
+  try {
+    localStorage.setItem(LS_PREFIX + key, value);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function hasTipBeenShown(tipKey) {
+  return getLS(tipKey) === 'shown';
+}
+
+export function markTipShown(tipKey) {
+  setLS(tipKey, 'shown');
+}
+
+// W8h debug — reset all tips (power user: localStorage.clear OR via __dbg).
+export function resetAllTips() {
+  try {
+    const keys = Object.keys(localStorage).filter((k) => k.startsWith(LS_PREFIX));
+    keys.forEach((k) => localStorage.removeItem(k));
+  } catch {
+    /* ignore */
+  }
+}
+
+let currentDismissTimer = null;
+let currentEscHandler = null;
+
+function getOrCreatePopup() {
+  let popup = document.getElementById('tip-popup');
+  if (popup) return popup;
+  popup = document.createElement('div');
+  popup.id = 'tip-popup';
+  popup.className = 'tip-popup hidden';
+  popup.innerHTML = `
+    <div class="tip-content">
+      <div class="tip-header">
+        <span class="tip-icon"></span>
+        <strong class="tip-title"></strong>
+        <button class="tip-close" title="Chiudi (ESC)">✕</button>
+      </div>
+      <div class="tip-body"></div>
+      <div class="tip-dismiss">ESC o click ✕ per chiudere · non verrà mostrato di nuovo</div>
+    </div>
+  `;
+  document.body.appendChild(popup);
+  popup.querySelector('.tip-close').addEventListener('click', dismissTip);
+  return popup;
+}
+
+function dismissTip() {
+  const popup = document.getElementById('tip-popup');
+  if (popup) popup.classList.add('hidden');
+  if (currentDismissTimer) {
+    clearTimeout(currentDismissTimer);
+    currentDismissTimer = null;
+  }
+  if (currentEscHandler) {
+    document.removeEventListener('keydown', currentEscHandler);
+    currentEscHandler = null;
+  }
+}
+
+// W8h — Core API. showTip(tipKey, overrideMessage?).
+// Se tip già seen → no-op silenzioso. Idempotent.
+export function showTip(tipKey, overrideMessage = null) {
+  if (hasTipBeenShown(tipKey)) return;
+  const meta = TIPS[tipKey];
+  if (!meta) return;
+  const popup = getOrCreatePopup();
+  popup.querySelector('.tip-icon').textContent = meta.icon;
+  popup.querySelector('.tip-title').textContent = meta.title;
+  popup.querySelector('.tip-body').textContent = overrideMessage || meta.message;
+  popup.classList.remove('hidden');
+  markTipShown(tipKey);
+
+  // Dismiss timer
+  if (currentDismissTimer) clearTimeout(currentDismissTimer);
+  currentDismissTimer = setTimeout(dismissTip, meta.duration || 4000);
+
+  // ESC dismiss
+  if (currentEscHandler) document.removeEventListener('keydown', currentEscHandler);
+  currentEscHandler = (e) => {
+    if (e.key === 'Escape') dismissTip();
+  };
+  document.addEventListener('keydown', currentEscHandler);
+}
+
+// W8h — Error recovery tip builder. Maps backend error → player-friendly tip.
+// Returns null if no match (caller falls back to standard error display).
+export function buildRecoveryTipMessage(errorText) {
+  if (!errorText) return null;
+  const lower = String(errorText).toLowerCase();
+  const map = [
+    {
+      match: /range|too far|distanza|lontano/,
+      msg: "📍 Troppo lontano. Sposta prima l'unità più vicino (numeri blu = costo AP per ogni cella).",
+    },
+    {
+      match: /ap|azioni esaurite|insufficient/,
+      msg: '⚡ AP esaurite. Questa unità non può fare altro turno. Cambia PG o "Fine turno".',
+    },
+    {
+      match: /target|bersaglio|invalid/,
+      msg: '🎯 Target invalido. Seleziona nemico (rombo rosso) entro range (celle rosse).',
+    },
+    {
+      match: /occupied|occupata|blocker|blocked/,
+      msg: '🧍 Cella occupata. Scegli cella vuota (overlay blu senza unità).',
+    },
+    {
+      match: /dead|ko|hp 0/,
+      msg: "☠ Unità KO. Seleziona un'altra unità viva.",
+    },
+  ];
+  for (const rule of map) {
+    if (rule.match.test(lower)) return rule.msg;
+  }
+  return null;
+}


### PR DESCRIPTION
## User feedback run5 (stop at AP labels)

> "AP labels non chiaro, i colori sono sbagliati e i numeri si vedono male"
> "non si capisce da subito cosa fare, bisognerebbe avere un primo round con tappe mirate per educare i player"
> "i round però nn li voglio tropp oscriptati, Evo-Tactics è bello perché scopri quel che puoi fare cliccando e passandoci il mouse sopra"
> "Se è la prima volta che passi su qualcosa o provi (e anche sbagli) si devon oattivare i giusti consigli e le giuste guide"

## Research output

Philosophy confermata: **learn-by-doing > forced tutorial**. Contextual first-time tips + hover-reveal pattern (Into the Breach, Slay the Spire, Fell Seal).

5 priorities identificate. Applied Phase 1+2+3 (~8h scope).

## Applied

### Phase 1 — AP label readability (W8h.1)

`render.js drawRangeOverlay`:
- **Before**: ciano `rgba(0,184,212,0.92)` su tile bg ciano 0.20 → contrast <3:1 WCAG fail
- **After**: dark pill badge `rgba(15,15,15,0.85)` + white text `#ffffff` + border → contrast **18:1 WCAG AAA**
- `roundRect` con fallback `rect` per older browsers
- Font "bold 12px SF Mono" + padding 10×18 badge

### Phase 2 — Contextual tip system (W8h.2)

New module `apps/play/src/tips.js`:
- 9 tip catalog (select-unit, first-move, first-attack, first-ability, range-overlay, intent-declared, round-resolve, invalid-action, sis-intent)
- `showTip(key)` idempotent (first-time only via localStorage flag `evo:tip-<key>`)
- Auto-dismiss timer + ESC + ✕ button
- `window.__dbg.resetTips()` per re-playtest

CSS `.tip-popup`: bottom-left z-index 85, fade+translate transition, bg panel + border accent.

Wire 6 triggers in main.js:
- handleUnitClick(player) → `select-unit` + `range-overlay` (900ms delay)
- doAction(move/attack/ability) → specific tip
- Post-intent → `intent-declared` (1100ms delay)
- triggerCommitRound → `round-resolve`

### Phase 3 — Error recovery tips (W8h.3)

`tips.js buildRecoveryTipMessage(errorText)`:
- Regex-match backend error → player-friendly recovery tip
- 5 rules: range/distance, AP exhausted, target invalid, cell occupied, unit dead
- Esempio: "range insufficiente" → "📍 Troppo lontano. Sposta prima l'unità più vicino"

Wire doAction error handler: parse `r.data.error` → `showTip('invalid-action', recoveryMsg)`.

## Philosophy alignment

User: "scopri quel che puoi fare cliccando" → tips NON scriptati sequenza. Trigger contestuali:
- Prima volta click → spiega interazione
- Prima volta errore → recovery guide
- Dismissible + one-shot (no spam)
- ESC friendly (non-blocking)

## Skipped

- Phase 4 hover tooltip enhancement (ability detail) — already partial, backlog
- Phase 5 soft-scripted first-round sequence — low priority, complex
- Backend `threat_preview` per SIS intent detail — contracts scope

## Verify browser

Reset tips + reload + new session + click p_scout:
- Popup bottom-left "👆 Seleziona unità" title + message ✅
- 900ms dopo → "🎯 Range visualizzato" (BLU move · ROSSO attack) ✅
- AP badges su tile ora dark pill + white text leggibile ✅
- `window.__dbg.resetTips()` helper ✅
- Zero console errors ✅

## Files

| File | LOC |
|------|---:|
| `apps/play/src/tips.js` (new) | +199 |
| `apps/play/src/render.js` | +30/-10 (AP badge) |
| `apps/play/src/main.js` | +20 (wire + import) |
| `apps/play/src/style.css` | +70 (.tip-popup) |
| **Total** | **+319 / -7** |

## Stack

#1606-#1618 + **this (W8h)** = 14 PR deep

## Rollback

`git revert 47e33ed8` — self-contained, tips module + CSS + wire additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)