### PR TITLE
feat(play+backend): Wave 8k multi-intent per unit + timer toggle (user feedback run5)

### DIFF
--- a/apps/backend/services/roundOrchestrator.js
+++ b/apps/backend/services/roundOrchestrator.js
@@ -362,9 +362,13 @@ function beginRound(state) {
 }
 
 /**
- * Preview-only: accumula l'intent in pending_intents. Latest-wins per
- * unit_id (sostituisce eventuale main intent precedente ma NON le
- * reaction intents per la stessa unit).
+ * Preview-only: accumula l'intent in pending_intents.
+ *
+ * W8k (2026-04-19) SPEC CHANGE: APPEND invece di latest-wins.
+ * Una unit può dichiarare N main intents per round (es. 2 attacchi stesso
+ * target), fino al limite AP. Override ADR-2026-04-15 canonical per UX user
+ * feedback. Per "cambiare idea" ora: chiamare clearIntent(unitId) prima.
+ * Reaction intents preservati in ogni caso.
  *
  * Raise: se round_phase e' settato ed e' diverso da 'planning'.
  *        Se la fase e' null/undefined, imposta planning implicitamente.
@@ -378,11 +382,8 @@ function declareIntent(state, unitId, action) {
     throw new Error(`unit_id non trovato nello state: ${unitId}`);
   }
   const nextState = _deepClone(state || {});
-  const pending = (nextState.pending_intents || []).filter((i) => {
-    // Rimuovi solo main intents per la stessa unit, preserva reactions
-    if (_isReactionIntent(i)) return true;
-    return String(i.unit_id || '') !== String(unitId);
-  });
+  // W8k — append, non filter per unit_id. Multi-intent supported.
+  const pending = (nextState.pending_intents || []).map((i) => _deepClone(i));
   pending.push({ unit_id: String(unitId), action: _deepClone(action || {}) });
   nextState.pending_intents = pending;
   if (phase === undefined || phase === null) {

--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -27,6 +27,9 @@
         </div>
         <div class="header-actions">
           <button id="fullscreen-toggle" title="Schermo intero">⛶</button>
+          <button id="timer-toggle" title="Planning timer ON/OFF (localStorage evo:planning-timer)">
+            ⏱
+          </button>
           <button id="help-open" title="Aiuto (?)">?</button>
         </div>
       </header>

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -284,24 +284,46 @@ document.addEventListener('keydown', (e) => {
   }
 });
 
-// W6.2b / W8k — Cancel TUTTI intent per una unit (array filter). Per cancel
-// per-index specifico usa handleCancelIntentIndex.
-function handleCancelIntent(unitId) {
+// W6.2b / W8k / W8k2 — Cancel TUTTI intent per una unit.
+// W8k2 CRITICAL FIX (user feedback run5): prima clear solo client-side →
+// backend manteneva pending_intents → timer scaduto → attacchi cancellati
+// partivano comunque. Ora chiamiamo api.clearIntent(sid, unitId) per sync server.
+async function handleCancelIntent(unitId) {
   const before = state.pendingIntents.length;
   state.pendingIntents = state.pendingIntents.filter((pi) => pi.unit_id !== unitId);
   const removed = before - state.pendingIntents.length;
   if (removed === 0) return;
-  appendLog(logEl, `${unitId}: ${removed} intent annullati`);
+  // W8k2 — sync backend: rimuovi pending_intents per questa unit server-side.
+  if (state.sid) {
+    try {
+      await api.clearIntent(state.sid, unitId);
+    } catch {
+      /* backend may be offline; client state già pulito */
+    }
+  }
+  appendLog(logEl, `${unitId}: ${removed} intent annullati (client+server)`);
   updateHint(`${removed} intent ${unitId} annullati. Re-pianifica o "Fine turno".`);
   redraw();
 }
 
-// W8k — ESC global: annulla tutti pending intents.
-document.addEventListener('keydown', (ev) => {
+// W8k / W8k2 — ESC global: annulla TUTTI pending intents (client + server).
+document.addEventListener('keydown', async (ev) => {
   if (ev.key === 'Escape' && state.pendingIntents.length > 0 && !state.pendingAbility) {
     const n = state.pendingIntents.length;
+    const uniqueUnits = [...new Set(state.pendingIntents.map((pi) => pi.unit_id))];
     state.pendingIntents = [];
-    appendLog(logEl, `ESC: ${n} intent annullati`);
+    // W8k2 CRITICAL — backend clear per ogni unit affetta (altrimenti timer
+    // scaduto risolverebbe intent già annullati client-side).
+    if (state.sid) {
+      for (const uid of uniqueUnits) {
+        try {
+          await api.clearIntent(state.sid, uid);
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+    appendLog(logEl, `ESC: ${n} intent annullati (client+server)`);
     updateHint(`${n} intent cleared. Ri-pianifica round.`);
     redraw();
   }
@@ -804,28 +826,29 @@ document.getElementById('new-session').addEventListener('click', () => {
 document.getElementById('reset-round')?.addEventListener('click', async () => {
   await emergencyResetRound();
 });
-// W8k — timer toggle header btn (user request: disable timer during testing).
+// W8k / W8k2 — timer toggle header btn. DEFAULT OFF (user feedback).
+// User clicca per opt-in ON.
 document.getElementById('timer-toggle')?.addEventListener('click', (ev) => {
   const btn = ev.currentTarget;
-  const wasOff = getLocalStorageFlag('evo:planning-timer', 'off');
+  const wasOn = getLocalStorageFlag('evo:planning-timer', 'on');
   try {
-    localStorage.setItem('evo:planning-timer', wasOff ? 'on' : 'off');
+    localStorage.setItem('evo:planning-timer', wasOn ? 'off' : 'on');
   } catch {
     /* ignore */
   }
-  const nowOff = !wasOff;
-  btn.style.opacity = nowOff ? '0.4' : '1';
-  btn.title = `Planning timer ${nowOff ? 'OFF' : 'ON'} (click per toggle)`;
-  if (nowOff) stopPlanningTimer();
-  appendLog(logEl, `⏱ Timer planning ${nowOff ? 'OFF' : 'ON'}`);
+  const nowOn = !wasOn;
+  btn.style.opacity = nowOn ? '1' : '0.4';
+  btn.title = `Planning timer ${nowOn ? 'ON' : 'OFF'} (click per toggle)`;
+  if (!nowOn) stopPlanningTimer();
+  appendLog(logEl, `⏱ Timer planning ${nowOn ? 'ON' : 'OFF'}`);
 });
-// Init button state on load
+// Init button state on load — default OFF (dimmed).
 (() => {
   const btn = document.getElementById('timer-toggle');
   if (!btn) return;
-  const off = getLocalStorageFlag('evo:planning-timer', 'off');
-  btn.style.opacity = off ? '0.4' : '1';
-  btn.title = `Planning timer ${off ? 'OFF' : 'ON'} (click per toggle)`;
+  const on = getLocalStorageFlag('evo:planning-timer', 'on');
+  btn.style.opacity = on ? '1' : '0.4';
+  btn.title = `Planning timer ${on ? 'ON' : 'OFF'} (click per toggle)`;
 })();
 document.getElementById('download-eval').addEventListener('click', () => {
   downloadEvalSet();
@@ -1021,13 +1044,13 @@ function showCommitReveal(turnNum, actionCount) {
   }, 650);
 }
 
-// W4.6 / W8k — Planning timer: 30s countdown, auto-commit on expiry.
-// W8k: opt-out via localStorage flag `evo:planning-timer:off` (user feedback:
-// "in fase di test è scomodo"). Toggleable da header btn.
+// W4.6 / W8k / W8k2 — Planning timer: 30s countdown, auto-commit on expiry.
+// W8k2 (user feedback run5): DEFAULT OFF. User opts-in via header btn ⏱
+// (localStorage flag `evo:planning-timer=on`). Prima era default ON fastidioso.
 function startPlanningTimer() {
   stopPlanningTimer();
-  // W8k — skip timer se flag off.
-  if (getLocalStorageFlag('evo:planning-timer', 'off')) {
+  // W8k2 — skip timer unless flag explicit 'on'.
+  if (!getLocalStorageFlag('evo:planning-timer', 'on')) {
     return;
   }
   state.planningTimerStart = performance.now();

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -25,8 +25,11 @@ const state = {
   target: null, // target preview (enemy hovered)
   pendingAbility: null, // { ability_id, needs_target, effect_type }
   endgameShown: false,
-  // W4.1 — round model client-side tracking per badge UI
-  pendingIntents: new Map(), // unit_id → intent object (reset post commit)
+  // W4.1 / W8k — round model client-side tracking per badge UI.
+  // W8k: era Map<unit_id, intent> (latest-wins), ora array [{unit_id, action, ts}]
+  // (append per multi-intent support). User può dichiarare N intents per unit
+  // finché AP sufficiente (sum controlled backend side).
+  pendingIntents: [],
   // W4.3 — resolution order from last commit (unit_id → priority rank 1..N)
   lastResolutionOrder: new Map(),
   // W4.6 — planning timer start timestamp (null = not active)
@@ -63,17 +66,23 @@ const ACTION_SPEED = {
 // W7.B — Compute resolve priority order among declared player intents.
 // Formula: unit.initiative + action_speed(action) - status_penalty.
 // NOTE: include solo PG (SIS intents server-side, non esposti in planning).
+// W8k — pendingIntents is array [{unit_id, action, ts}]. Compute priority per
+// unique unit_id (primo intent determina rank base; multi-intent stessa unit
+// risolti in ordine di declare per ADR-04-15 resolution queue ordering).
 function computePlayerPriorityOrder(pendingIntents, units) {
+  const seen = new Set();
   const items = [];
-  for (const [uid, intent] of pendingIntents.entries()) {
-    const unit = units.find((u) => u.id === uid);
+  for (const pi of pendingIntents) {
+    if (seen.has(pi.unit_id)) continue;
+    seen.add(pi.unit_id);
+    const unit = units.find((u) => u.id === pi.unit_id);
     if (!unit) continue;
-    const actSpd = ACTION_SPEED[intent.type] ?? 0;
+    const actSpd = ACTION_SPEED[pi.action?.type] ?? 0;
     const panic = (unit.status && unit.status.panic) || 0;
     const disorient = (unit.status && unit.status.disorient) || 0;
     const statusPenalty = panic * 2 + disorient;
     const priority = (unit.initiative || 0) + actSpd - statusPenalty;
-    items.push({ uid, priority });
+    items.push({ uid: pi.unit_id, priority });
   }
   items.sort((a, b) => b.priority - a.priority || a.uid.localeCompare(b.uid));
   const map = new Map();
@@ -275,20 +284,23 @@ document.addEventListener('keydown', (e) => {
   }
 });
 
-// W6.2b — Cancel pending intent for a specific PG.
+// W6.2b / W8k — Cancel TUTTI intent per una unit (array filter). Per cancel
+// per-index specifico usa handleCancelIntentIndex.
 function handleCancelIntent(unitId) {
-  if (!state.pendingIntents.has(unitId)) return;
-  state.pendingIntents.delete(unitId);
-  appendLog(logEl, `${unitId}: intent annullato`);
-  updateHint(`Intent ${unitId} annullato. Re-pianifica o "Fine turno" per risolvere.`);
+  const before = state.pendingIntents.length;
+  state.pendingIntents = state.pendingIntents.filter((pi) => pi.unit_id !== unitId);
+  const removed = before - state.pendingIntents.length;
+  if (removed === 0) return;
+  appendLog(logEl, `${unitId}: ${removed} intent annullati`);
+  updateHint(`${removed} intent ${unitId} annullati. Re-pianifica o "Fine turno".`);
   redraw();
 }
 
-// W6.2b — ESC global: annulla tutti pending intents (planning reset).
+// W8k — ESC global: annulla tutti pending intents.
 document.addEventListener('keydown', (ev) => {
-  if (ev.key === 'Escape' && state.pendingIntents.size > 0 && !state.pendingAbility) {
-    const n = state.pendingIntents.size;
-    state.pendingIntents.clear();
+  if (ev.key === 'Escape' && state.pendingIntents.length > 0 && !state.pendingAbility) {
+    const n = state.pendingIntents.length;
+    state.pendingIntents = [];
     appendLog(logEl, `ESC: ${n} intent annullati`);
     updateHint(`${n} intent cleared. Ri-pianifica round.`);
     redraw();
@@ -561,8 +573,9 @@ async function doAction(body) {
       if (recovery) showTip('invalid-action', recovery);
       return;
     }
-    // W4.1 — track intent client-side per badge sidebar. Latest-wins (re-declare override).
-    state.pendingIntents.set(body.actor_id, action);
+    // W4.1 / W8k — track intent client-side per badge sidebar. Multi-intent
+    // per unit (array append). Backend anche append post-W8k.
+    state.pendingIntents.push({ unit_id: body.actor_id, action, ts: Date.now() });
     const tag = body.ability_id
       ? `→ ability ${body.ability_id}${body.target_id ? ` → ${body.target_id}` : ''}`
       : body.action_type === 'move'
@@ -581,7 +594,9 @@ async function doAction(body) {
     const alivePlayers = (state.world?.units || []).filter(
       (u) => u.controlled_by === 'player' && u.hp > 0,
     );
-    const allDeclared = alivePlayers.every((u) => state.pendingIntents.has(u.id));
+    // W8k — allDeclared true se ogni PG vivo ha almeno 1 intent in array.
+    const declaredUnitIds = new Set(state.pendingIntents.map((pi) => pi.unit_id));
+    const allDeclared = alivePlayers.every((u) => declaredUnitIds.has(u.id));
     if (allDeclared && alivePlayers.length > 0) {
       const autoCommit = getLocalStorageFlag('evo:auto-commit');
       if (autoCommit) {
@@ -593,7 +608,7 @@ async function doAction(body) {
         );
       }
     } else {
-      const remaining = alivePlayers.length - state.pendingIntents.size;
+      const remaining = alivePlayers.length - declaredUnitIds.size;
       updateHint(
         `✓ Intent dichiarato ${body.actor_id}. ${remaining} PG restante/i. Click "Fine turno" per risolvere.`,
       );
@@ -749,7 +764,7 @@ async function startNewSession() {
   state.roundInit = false;
   _pendingConfirm = null;
   // W4 — reset round tracking
-  state.pendingIntents.clear();
+  state.pendingIntents = [];
   state.lastResolutionOrder.clear();
   stopPlanningTimer();
   // W5.D — reset eval set per session
@@ -789,6 +804,29 @@ document.getElementById('new-session').addEventListener('click', () => {
 document.getElementById('reset-round')?.addEventListener('click', async () => {
   await emergencyResetRound();
 });
+// W8k — timer toggle header btn (user request: disable timer during testing).
+document.getElementById('timer-toggle')?.addEventListener('click', (ev) => {
+  const btn = ev.currentTarget;
+  const wasOff = getLocalStorageFlag('evo:planning-timer', 'off');
+  try {
+    localStorage.setItem('evo:planning-timer', wasOff ? 'on' : 'off');
+  } catch {
+    /* ignore */
+  }
+  const nowOff = !wasOff;
+  btn.style.opacity = nowOff ? '0.4' : '1';
+  btn.title = `Planning timer ${nowOff ? 'OFF' : 'ON'} (click per toggle)`;
+  if (nowOff) stopPlanningTimer();
+  appendLog(logEl, `⏱ Timer planning ${nowOff ? 'OFF' : 'ON'}`);
+});
+// Init button state on load
+(() => {
+  const btn = document.getElementById('timer-toggle');
+  if (!btn) return;
+  const off = getLocalStorageFlag('evo:planning-timer', 'off');
+  btn.style.opacity = off ? '0.4' : '1';
+  btn.title = `Planning timer ${off ? 'OFF' : 'ON'} (click per toggle)`;
+})();
 document.getElementById('download-eval').addEventListener('click', () => {
   downloadEvalSet();
 });
@@ -848,7 +886,7 @@ function processIaActions(iaActions) {
 // Clear tutti flag round + overlay + re-fetch state server per recover da block.
 async function emergencyResetRound() {
   state.roundInit = false;
-  state.pendingIntents.clear();
+  state.pendingIntents = [];
   state.lastResolutionOrder.clear();
   _pendingConfirm = null;
   stopPlanningTimer();
@@ -918,7 +956,7 @@ async function triggerCommitRound() {
     }
     state.roundInit = false;
     _pendingConfirm = null;
-    state.pendingIntents.clear();
+    state.pendingIntents = [];
 
     const playerActions = r.data?.player_actions || [];
     const iaActions = r.data?.ia_actions || [];
@@ -983,9 +1021,15 @@ function showCommitReveal(turnNum, actionCount) {
   }, 650);
 }
 
-// W4.6 — Planning timer: 30s countdown, auto-commit on expiry.
+// W4.6 / W8k — Planning timer: 30s countdown, auto-commit on expiry.
+// W8k: opt-out via localStorage flag `evo:planning-timer:off` (user feedback:
+// "in fase di test è scomodo"). Toggleable da header btn.
 function startPlanningTimer() {
   stopPlanningTimer();
+  // W8k — skip timer se flag off.
+  if (getLocalStorageFlag('evo:planning-timer', 'off')) {
+    return;
+  }
   state.planningTimerStart = performance.now();
   const el = getPlanningTimerEl();
   el.classList.remove('hidden');

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -404,6 +404,22 @@ canvas#grid {
   margin-top: 0;
   flex: 1;
 }
+/* W8k — Multi-intent list per unit (stacked badges). */
+.intent-row-multi {
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+.intent-row-multi .intent-list {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.intent-row-multi .intent-badge {
+  margin: 0;
+  font-size: 0.72rem;
+}
 .intent-badge.pending {
   background: rgba(128, 128, 128, 0.18);
   color: #bdbdbd;

--- a/apps/play/src/ui.js
+++ b/apps/play/src/ui.js
@@ -320,16 +320,24 @@ function renderUnitLi(
       ${(() => {
         if (u.controlled_by !== 'player' || !isUnitAlive(u)) return '';
         if (!pendingIntents) return '';
-        const intent = pendingIntents.get ? pendingIntents.get(u.id) : pendingIntents[u.id];
-        if (intent) {
+        // W8k — pendingIntents è array [{unit_id, action, ts}] — filter per questa unit.
+        const arr = Array.isArray(pendingIntents) ? pendingIntents : [];
+        const unitIntents = arr.filter((pi) => pi.unit_id === u.id);
+        if (unitIntents.length > 0) {
           const rank = predictedOrder && predictedOrder.get ? predictedOrder.get(u.id) : null;
           const rankHtml = rank
             ? `<span class="priority-rank" title="Ordine predetto (initiative + action_speed − status_penalty)">#${Number(rank) || 0}</span>`
             : '';
-          return `<div class="intent-row">
+          const intentsHtml = unitIntents
+            .map(
+              (pi, idx) =>
+                `<div class="intent-badge declared" title="Intent #${idx + 1}">✓ ${idx + 1}. ${esc(formatIntent(pi.action))}</div>`,
+            )
+            .join('');
+          return `<div class="intent-row intent-row-multi">
             ${rankHtml}
-            <div class="intent-badge declared" title="Intent dichiarato">✓ ${esc(formatIntent(intent))}</div>
-            <button class="intent-cancel" data-unit-id="${esc(u.id)}" title="Annulla intent (re-click action per nuovo)">✕</button>
+            <div class="intent-list">${intentsHtml}</div>
+            <button class="intent-cancel" data-unit-id="${esc(u.id)}" title="Annulla TUTTI ${unitIntents.length} intent di questa unità">✕ ${unitIntents.length}</button>
           </div>`;
         }
         return `<div class="intent-badge pending" title="Nessun intent dichiarato">⏳ in attesa</div>`;

--- a/services/rules/round_orchestrator.py
+++ b/services/rules/round_orchestrator.py
@@ -516,10 +516,16 @@ def declare_intent(
 ) -> Dict[str, Any]:
     """Registra un intent nella fase di planning. Preview-only.
 
-    NON muta AP/HP/log dello stato. Se l'unita' ha gia' un intent dichiarato
-    nel round corrente, viene sostituito (latest-wins). Questo riflette il
-    flusso UI: il giocatore puo' cambiare idea quante volte vuole prima del
-    commit.
+    NON muta AP/HP/log dello stato.
+
+    W8k (2026-04-19): SPEC CHANGE — ora APPEND invece di latest-wins.
+    Un'unita' puo' dichiarare N intents per round (es. 2 attacchi stesso target),
+    fino al limite AP. Backend non enforce limite (frontend filtra). Rationale:
+    user feedback "Sto cercando di fare 2 att con lo scout ma posso registrarne
+    solo uno". Override ADR-2026-04-15 latest-wins canonical per UX.
+
+    Per "cambiare idea" ora: chiamare ``clear_intent(unit_id)`` prima di nuovo
+    declare_intent (client-side: re-click azione).
 
     Raises:
         ValueError: se ``state.round_phase`` non e' ``'planning'``
@@ -535,11 +541,8 @@ def declare_intent(
     if _find_unit(state, unit_id) is None:
         raise KeyError(f"unit_id non trovato nello state: {unit_id}")
     next_state = copy.deepcopy(state)
-    intents = [
-        dict(i)
-        for i in next_state.get("pending_intents", [])
-        if str(i.get("unit_id", "")) != unit_id
-    ]
+    # W8k — append, no filter per unit_id (multi-intent per unit supported).
+    intents = [dict(i) for i in next_state.get("pending_intents", [])]
     intents.append({"unit_id": unit_id, "action": dict(action)})
     next_state["pending_intents"] = intents
     # Se era None, imposta planning per rendere esplicita la fase

--- a/tests/test_round_orchestrator.py
+++ b/tests/test_round_orchestrator.py
@@ -365,13 +365,22 @@ def test_declare_intent_records_action_without_consuming_ap(catalog):
     assert next_state["pending_intents"][0]["action"]["type"] == "attack"
 
 
-def test_declare_intent_replaces_previous_intent_for_same_unit(catalog):
+def test_declare_intent_appends_multiple_intents_for_same_unit(catalog):
+    # W8k override ADR-2026-04-15 canonical: multi-intent per unit supported.
+    # User feedback 2026-04-19: "Sto cercando di fare 2 att con lo scout ma
+    # posso registrarne solo uno". Backend ora append invece di latest-wins.
     state = begin_round(_make_state(catalog))["next_state"]
     state = declare_intent(state, "alpha", _attack("alpha", "bravo"))["next_state"]
-    # Cambia idea: ora muove invece di attaccare
+    # Secondo intent stessa unit — APPEND invece di replace.
+    state = declare_intent(state, "alpha", _move("alpha"))["next_state"]
+    assert len(state["pending_intents"]) == 2
+    assert state["pending_intents"][0]["action"]["type"] == "attack"
+    assert state["pending_intents"][1]["action"]["type"] == "move"
+    # Per "cambiare idea" ora: clear_intent(unit_id) prima di nuovo declare.
+    state = clear_intent(state, "alpha")["next_state"]
+    assert len(state["pending_intents"]) == 0
     state = declare_intent(state, "alpha", _move("alpha"))["next_state"]
     assert len(state["pending_intents"]) == 1
-    assert state["pending_intents"][0]["action"]["type"] == "move"
 
 
 def test_declare_intent_accepts_multiple_units(catalog):


### PR DESCRIPTION
Wave 8k 2 fix: (1) timer disable header btn ⏱ + localStorage flag; (2) multi-intent per unit override ADR-04-15 latest-wins. Backend append + frontend pendingIntents Array. User can now declare 2+ actions per unit per round (e.g. 2 attacks).