### PR TITLE
feat(play): Wave 8M HUD icon+label + unit body shapes + species abbrev IT

### DIFF
--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -26,12 +26,74 @@
           <div class="pressure-bar"><div class="pressure-fill" style="width: 0%"></div></div>
         </div>
         <div class="header-actions">
-          <button id="fullscreen-toggle" title="Schermo intero">⛶</button>
-          <button id="timer-toggle" title="Planning timer ON/OFF (localStorage evo:planning-timer)">
-            ⏱
+          <button id="fullscreen-toggle" class="hud-btn" title="Schermo intero — Alt+Enter">
+            <svg
+              class="hud-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M3 7V3h4M17 3h4v4M21 17v4h-4M7 21H3v-4" />
+            </svg>
+            <span class="hud-label">Schermo</span>
           </button>
-          <button id="codex-open" title="Codex — Guida + Glossario + Tips">📖</button>
-          <button id="help-open" title="Aiuto (?)">?</button>
+          <button id="timer-toggle" class="hud-btn" title="Timer planning 30s ON/OFF">
+            <svg
+              class="hud-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="12" cy="13" r="8" />
+              <path d="M12 9v4l2 2M9 1h6M12 5v1" />
+            </svg>
+            <span class="hud-label">Timer</span>
+          </button>
+          <button
+            id="codex-open"
+            class="hud-btn"
+            title="Codex — Guida meccanica + glossario + tips re-read"
+          >
+            <svg
+              class="hud-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path
+                d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V3H6.5A2.5 2.5 0 0 0 4 5.5v14zM4 19.5A2.5 2.5 0 0 0 6.5 22H20v-5"
+              />
+            </svg>
+            <span class="hud-label">Codex</span>
+          </button>
+          <button id="help-open" class="hud-btn" title="Aiuto — tutorial overlay (?)">
+            <svg
+              class="hud-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3M12 17h.01" />
+            </svg>
+            <span class="hud-label">Aiuto</span>
+          </button>
         </div>
       </header>
       <main>

--- a/apps/play/src/render.js
+++ b/apps/play/src/render.js
@@ -1,6 +1,7 @@
 // Canvas 2D rendering — grid + units + animations + status icons.
 
 import { getInterpolatedPos, drawPopups, drawRays, getFlashAlpha, hasActiveAnims } from './anim.js';
+import { getSpeciesDisplayIt } from './speciesNames.js';
 
 const CELL = 64; // pixel per cell
 const COLORS = {
@@ -35,6 +36,101 @@ const JOB_COLORS = {
   mage: '#ab47bc',
   boss: '#d32f2f',
 };
+
+// W8M — Job-to-shape map (silhouette profile per class). User feedback: "i pg
+// e i SiS sono ancora meri pallini nei quali si leggono orribili scritte
+// p-sc p-ta e-no". Replace circle con polygon per job differentiation.
+// Reference 41-ART-DIRECTION.md: "job-to-shape mapping".
+const JOB_SHAPE_MAP = {
+  skirmisher: 'triangle_up', // offensive lean, forward-pointing
+  assassin: 'triangle_up',
+  vanguard: 'shield', // defensive wide base
+  tank: 'shield',
+  guardian: 'shield',
+  scout: 'pentagon_low', // crouched low profile
+  ranger: 'pentagon_low',
+  sniper: 'rectangle_tall', // elongated ranged
+  ranged: 'rectangle_tall',
+  healer: 'hexagon_round', // soft supportive
+  support: 'hexagon_round',
+  artefice: 'hexagon_round',
+  invocatore: 'star', // controller chaotic energy
+  controller: 'star',
+  mage: 'star',
+  raccoglitore: 'hexagon_organic', // harvester balanced
+  boss: 'shield', // scaled +50% applied via size param
+};
+
+function drawUnitBody(ctx, cx, cy, job, radius) {
+  const shape = JOB_SHAPE_MAP[(job || '').toLowerCase()] || 'circle';
+  ctx.beginPath();
+  switch (shape) {
+    case 'triangle_up': {
+      ctx.moveTo(cx, cy - radius);
+      ctx.lineTo(cx + radius * 0.92, cy + radius * 0.6);
+      ctx.lineTo(cx - radius * 0.92, cy + radius * 0.6);
+      ctx.closePath();
+      break;
+    }
+    case 'shield': {
+      const w = radius * 1.0;
+      const h = radius * 0.95;
+      ctx.moveTo(cx - w, cy - h * 0.55);
+      ctx.lineTo(cx + w, cy - h * 0.55);
+      ctx.lineTo(cx + w, cy + h * 0.2);
+      ctx.quadraticCurveTo(cx, cy + h * 1.1, cx - w, cy + h * 0.2);
+      ctx.closePath();
+      break;
+    }
+    case 'pentagon_low': {
+      ctx.moveTo(cx, cy - radius * 0.85);
+      ctx.lineTo(cx + radius * 0.95, cy - radius * 0.1);
+      ctx.lineTo(cx + radius * 0.6, cy + radius * 0.85);
+      ctx.lineTo(cx - radius * 0.6, cy + radius * 0.85);
+      ctx.lineTo(cx - radius * 0.95, cy - radius * 0.1);
+      ctx.closePath();
+      break;
+    }
+    case 'rectangle_tall': {
+      const w = radius * 0.6;
+      const h = radius * 1.05;
+      ctx.moveTo(cx - w, cy - h);
+      ctx.lineTo(cx + w, cy - h);
+      ctx.lineTo(cx + w, cy + h * 0.7);
+      ctx.lineTo(cx, cy + h);
+      ctx.lineTo(cx - w, cy + h * 0.7);
+      ctx.closePath();
+      break;
+    }
+    case 'hexagon_round':
+    case 'hexagon_organic': {
+      for (let i = 0; i < 6; i += 1) {
+        const a = (i / 6) * Math.PI * 2 - Math.PI / 2;
+        const x = cx + Math.cos(a) * radius;
+        const y = cy + Math.sin(a) * radius;
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      ctx.closePath();
+      break;
+    }
+    case 'star': {
+      const points = 6;
+      for (let i = 0; i < points * 2; i += 1) {
+        const a = (i / (points * 2)) * Math.PI * 2 - Math.PI / 2;
+        const r = i % 2 === 0 ? radius : radius * 0.55;
+        const x = cx + Math.cos(a) * r;
+        const y = cy + Math.sin(a) * r;
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      ctx.closePath();
+      break;
+    }
+    default:
+      ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+  }
+}
 
 // W3.1 — Range overlay tints (Wave 3 fix #5).
 const RANGE_TINT = {
@@ -144,18 +240,22 @@ function drawUnit(ctx, unit, gridH, highlight = {}) {
       ? COLORS.player
       : COLORS.sistema;
 
-  // Body circle — job accent ring first, then body.
-  const jobColor = JOB_COLORS[(unit.job || unit.class || '').toLowerCase()] || null;
+  // W8M — Body: job-shape silhouette (no more circles). Ring outer = jobColor,
+  // interior = faction. Boss scale +50% per drawUnitBody ring/body.
+  const jobKey = (unit.job || unit.class || '').toString().toLowerCase();
+  const isBoss = jobKey === 'boss' || unit.is_boss === true;
+  const sizeMul = isBoss ? 1.5 : 1;
+  const jobColor = JOB_COLORS[jobKey] || null;
+  // Outer job ring
   if (!dead && jobColor) {
     ctx.fillStyle = jobColor;
-    ctx.beginPath();
-    ctx.arc(cx, cy, CELL * 0.38, 0, Math.PI * 2);
+    drawUnitBody(ctx, cx, cy, jobKey, CELL * 0.42 * sizeMul);
     ctx.fill();
   }
+  // Inner faction body
   ctx.fillStyle = color;
   ctx.globalAlpha = dead ? 0.4 : 1;
-  ctx.beginPath();
-  ctx.arc(cx, cy, CELL * 0.32, 0, Math.PI * 2);
+  drawUnitBody(ctx, cx, cy, jobKey, CELL * 0.33 * sizeMul);
   ctx.fill();
   ctx.globalAlpha = 1;
 
@@ -201,12 +301,22 @@ function drawUnit(ctx, unit, gridH, highlight = {}) {
     ctx.fill();
   }
 
-  // Unit label (first 2 chars)
-  ctx.fillStyle = '#fff';
-  ctx.font = 'bold 12px "SF Mono", monospace';
+  // W8M — Label: species IT abbrev (3 char upper) instead of raw id. Outline
+  // stroke nera per contrast su body color. User feedback: "scritte orribili
+  // p-sc p-ta e-no" replaced with "PRE" (Predatore) / "PRE" (Predoni).
+  const speciesIt = getSpeciesDisplayIt(unit.species);
+  const abbrev = (speciesIt ? speciesIt : unit.id || '???')
+    .replace(/[^\p{L}]/gu, '')
+    .slice(0, 3)
+    .toUpperCase();
+  ctx.font = 'bold 13px "SF Mono", "Menlo", monospace';
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  ctx.fillText(unit.id.slice(0, 4), cx, cy);
+  ctx.strokeStyle = 'rgba(0,0,0,0.85)';
+  ctx.lineWidth = 3;
+  ctx.strokeText(abbrev, cx, cy);
+  ctx.fillStyle = '#fff';
+  ctx.fillText(abbrev, cx, cy);
 
   // HP bar — M4 P0.2: float sopra unit sprite (visibile da lontano TV-first).
   // Legacy: bar sotto tile. New: bar sopra testa + valore numerico chunky.

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -1691,8 +1691,53 @@ body.ability-target-mode canvas#grid {
 /* Header right-side cluster */
 .header-actions {
   display: flex;
-  gap: 8px;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+/* W8M — HUD btn redesign: icon SVG + mini-label sotto (TV-first visible label).
+ * User feedback: "icone senza scritte non si capiscono". Ora ogni btn ha label
+ * sempre visibile + icon SVG consistent (replace emoji OS-variante). */
+.hud-btn {
+  display: flex;
+  flex-direction: column;
   align-items: center;
+  gap: 3px;
+  background: var(--cell);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  padding: 6px 8px;
+  border-radius: 5px;
+  cursor: pointer;
+  min-width: 56px;
+  font-family: inherit;
+  transition:
+    background 0.15s ease-out,
+    border-color 0.15s ease-out,
+    color 0.15s ease-out;
+}
+.hud-btn:hover {
+  background: var(--accent);
+  color: var(--bg);
+  border-color: var(--accent);
+}
+.hud-btn:focus-visible {
+  outline: 2px solid var(--player);
+  outline-offset: 2px;
+}
+.hud-btn .hud-icon {
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  display: block;
+}
+.hud-btn .hud-label {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  white-space: nowrap;
+  text-transform: uppercase;
 }
 
 /* Unit sidebar job accent (W2.4 color per tipo) */


### PR DESCRIPTION
W8M MVP: (1) HUD 4 btn con SVG icon + mini-label sempre visibile + CSS hud-btn (Lucide-style). (2) Canvas unit: JOB_SHAPE_MAP polygon per job (triangle skirmisher, shield vanguard, etc.) + species abbrev IT 3-char con outline stroke. Elimina emoji OS-variant + 'p_sc/e_no' ugly text.