### PR TITLE
fix(play): Wave 8N AP budget check per multi-intent pending

### DIFF
--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -564,10 +564,11 @@ async function doAction(body) {
           : body.action_type === 'ability'
             ? body.ap_cost || 1
             : 0;
+    const apCost = Math.max(0, Number(rawApCost) || 0);
     const action = {
       type: body.action_type,
       actor_id: body.actor_id,
-      ap_cost: Math.max(0, Number(rawApCost) || 0),
+      ap_cost: apCost,
     };
     if (body.action_type === 'attack') action.target_id = body.target_id;
     if (body.action_type === 'move') action.move_to = body.position;
@@ -575,6 +576,30 @@ async function doAction(body) {
       action.ability_id = body.ability_id;
       action.target_id = body.target_id;
       if (body.position) action.position = body.position;
+    }
+    // W8N — AP budget check client-side: somma ap_cost pending per actor,
+    // verifica (total + apCost) ≤ actor.ap. User feedback: multi-intent non
+    // teneva conto del budget AP. Reject + tip se insufficient.
+    const actorUnit = getUnits(state.world).find((u) => u.id === body.actor_id);
+    const actorAp = Number(actorUnit?.ap_remaining ?? actorUnit?.ap ?? 0);
+    const alreadyPending = state.pendingIntents
+      .filter((pi) => pi.unit_id === body.actor_id)
+      .reduce((sum, pi) => sum + (Number(pi.action?.ap_cost) || 0), 0);
+    const remaining = actorAp - alreadyPending;
+    if (apCost > remaining) {
+      appendLog(
+        logEl,
+        `✖ ${body.actor_id}: AP insufficiente (serve ${apCost}, residuo ${remaining}/${actorAp})`,
+        'error',
+      );
+      updateHint(
+        `❌ AP insufficiente: ${body.actor_id} ha ${remaining}/${actorAp} AP, questa azione costa ${apCost}. Annulla un intent o scegli azione meno costosa.`,
+      );
+      showTip(
+        'invalid-action',
+        `⚡ AP insufficiente. ${body.actor_id} ha già ${alreadyPending} AP pending su ${actorAp} totali. Serve ${apCost} AP per questa azione ma restano solo ${remaining}. Rimuovi un intent (✕ sidebar) o ESC per reset totale.`,
+      );
+      return;
     }
     // Ensure roundState initialized
     if (!state.roundInit) {

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -654,6 +654,18 @@ canvas#grid {
   margin-top: 0;
   flex: 1;
 }
+/* W8N — AP pending indicator: mostra AP già impegnati in intent pending. */
+.ap-pending {
+  display: inline-block;
+  margin-left: 3px;
+  padding: 0 4px;
+  background: rgba(255, 152, 0, 0.22);
+  color: #ffb74d;
+  border-radius: 2px;
+  font-weight: 700;
+  font-size: 0.85em;
+}
+
 /* W8k — Multi-intent list per unit (stacked badges). */
 .intent-row-multi {
   align-items: flex-start;

--- a/apps/play/src/ui.js
+++ b/apps/play/src/ui.js
@@ -304,7 +304,16 @@ function renderUnitLi(
         <div class="bar-row">
           <span class="bar-label">AP</span>
           <span class="ap-bar"><span style="width:${Math.max(0, apRatio * 100).toFixed(0)}%"></span></span>
-          <span class="bar-value">${Number(apRemaining) || 0}/${Number(apMax) || 0}</span>
+          <span class="bar-value">${Number(apRemaining) || 0}/${Number(apMax) || 0}${(() => {
+            // W8N — AP pending delta: mostra AP consumato da intent pending
+            // per questa unit (es. "3/3 −2" = 3 totali, 2 già impegnati).
+            if (!Array.isArray(pendingIntents) || pendingIntents.length === 0) return '';
+            const pendingSum = pendingIntents
+              .filter((pi) => pi.unit_id === u.id)
+              .reduce((s, pi) => s + (Number(pi.action?.ap_cost) || 0), 0);
+            if (pendingSum <= 0) return '';
+            return ` <span class="ap-pending" title="AP già impegnati in intent pending">−${pendingSum}</span>`;
+          })()}</span>
         </div>
       </div>
       <div class="unit-stats">


### PR DESCRIPTION
User run5: multi-intent non decrementa AP. Fix: client-side check (actor.ap - sum pending ap_cost) in doAction + UI indicator '−N' accanto AP value. Reject + tip se insufficient.