### PR TITLE
M5-#1b: wire species_resistances.yaml in hydration pipeline

### DIFF
--- a/docs/adr/ADR-2026-04-19-resistance-convention.md
+++ b/docs/adr/ADR-2026-04-19-resistance-convention.md
@@ -1,0 +1,105 @@
+---
+title: 'ADR 2026-04-19 — Resistance convention (species 100-neutral + trait delta)'
+doc_status: active
+doc_owner: master-dd
+workstream: combat
+last_verified: 2026-04-19
+source_of_truth: false
+language: it
+review_cycle_days: 30
+related:
+  - 'docs/adr/ADR-2026-04-13-rules-engine-d20.md'
+  - 'docs/hubs/combat.md'
+  - 'packs/evo_tactics_pack/data/balance/species_resistances.yaml'
+  - 'packs/evo_tactics_pack/data/balance/trait_mechanics.yaml'
+---
+
+# ADR-2026-04-19 · Resistance convention
+
+**Stato**: 🟢 ACCEPTED
+**Trigger**: parallel-agent audit 2026-04-19 (balance-auditor + sot-planner + species-reviewer) ha rivelato convention mismatch + wire absence tra `species_resistances.yaml` e `trait_mechanics.yaml`.
+
+## Contesto
+
+Il rules engine d20 applica la resistenza di canale al damage step via `services/rules/resolver.py::apply_resistance(damage, resistances, channel)`. Il dataset di bilanciamento contiene **due convenzioni numeriche diverse** per esprimere resistenza/vulnerabilità:
+
+| Fonte                                                       | Convention      | Significato                                         |
+| ----------------------------------------------------------- | --------------- | --------------------------------------------------- |
+| `species_resistances.yaml`                                  | **100-neutral** | `80` = 20% resist, `100` = neutro, `120` = 20% vuln |
+| `trait_mechanics.yaml` (trait `resistances[].modifier_pct`) | **delta**       | `+20` = 20% resist, `0` = neutro, `-20` = 20% vuln  |
+
+La funzione `merge_resistances(trait_resistances, species_resistances)` (resolver.py:202) converte il formato species→delta via `merged[ch] = 100 - pct` (80→+20, 120→-20), poi somma le trait resistances al baseline. Il risultato `[{channel, modifier_pct}]` è in formato **delta** ed è quello accettato da `apply_resistance`.
+
+**Audit finding (2026-04-19)**:
+
+1. **Wire absence**. `merge_resistances` esiste ma **zero caller**. `hydration.py::aggregate_resistances` somma solo trait resistances e non carica `species_resistances.yaml`. Ogni unità istanziata ha `resistances = trait-only` — il baseline species è invisibile al resolver.
+2. **Convention ambiguity**. Nessuna documentazione lockava la convention. Il balance-auditor ha simulato un scenario dove `pct=120` (species scale) fluiva grezzo ad `apply_resistance` → `factor = (100 - 120) / 100 = -0.20` → damage clamp a 0. È lo scenario che si verifica se un futuro caller passasse species data bypassando `merge_resistances`.
+3. **Data integrity risk**. Sim hardcore-06 N=13 ha dato 84.6% win rate (target 15-25%). La vulnerability mai applicata (species → trait pipeline non wired) è una delle cause identificate. Richiede calibration iter2 post-wire.
+
+## Decisione
+
+**Convention A (lock)**:
+
+- `species_resistances.yaml` **rimane in 100-neutral scale** (`80` = resist, `100` = neutro, `120` = vuln). Human-readable + canonical per documentation + dataset authoring.
+- `trait_mechanics.yaml` trait `resistances[].modifier_pct` **rimane in delta scale** (`+20` = resist, `-20` = vuln). Compone additivamente.
+- `services/rules/resolver.py::merge_resistances()` è l'**unico convertitore** 100-neutral → delta. Firma: `merge_resistances(trait_resistances, species_resistances=None) -> List[{channel, modifier_pct}]` (delta).
+- `services/rules/resolver.py::apply_resistance(damage, resistances, channel)` **accetta solo delta**. La formula `factor = (100 - pct) / 100` è corretta per il formato delta: `pct=+20` → factor=0.8 (resist), `pct=-20` → factor=1.2 (vuln), `pct=+100` → factor=0.0 (immune), `pct=-100` → factor=2.0 (double damage).
+
+**Invariante di pipeline**:
+
+```
+species_resistances.yaml (100-neutral)
+    │
+    └─► merge_resistances(trait_list, species_dict)
+              │
+              ▼
+      resistances: List[{channel, modifier_pct}]  (delta format)
+              │
+              └─► apply_resistance(damage, resistances, channel)
+                        │
+                        ▼
+                  reduced_damage (int)
+```
+
+Qualunque caller che passa dati species grezzi (100-neutral) direttamente ad `apply_resistance` è un **bug**. `merge_resistances` deve essere il checkpoint.
+
+## Conseguenze
+
+**Positive**:
+
+- Convention lock documentata. Future modifiche dataset non rompono silenziosamente.
+- Formula `apply_resistance` resta invariata (nessun break di test esistenti 17 di regressione verdi).
+- Data authoring più leggibile: designer scrive `psionico.fisico: 120` per dichiarare vulnerabilità fisica (intuitivo) piuttosto che `-20` (meno leggibile).
+- `merge_resistances` come single point of conversion è più facile da testare.
+
+**Negative**:
+
+- Convention split richiede disciplina: 2 scale diverse nello stesso dominio è superficie di bug per nuovi contributor. Mitigato da: (a) questo ADR come reference, (b) commento in `species_resistances.yaml` che già documenta la scala, (c) docstring aggiornato in `merge_resistances` che linka a questo ADR, (d) test di regressione end-to-end (vedi sotto).
+- `merge_resistances` non è ancora chiamato dalla pipeline hydration. Fix wire è in PR follow-up **M5-#1b** (`hydration.py::build_*_unit` accetta `species_archetype` param + loader `load_species_resistances`). Questo ADR è docs+test only.
+
+## Test di regressione (M5-#1a)
+
+Nuovo test in `tests/test_resolver.py` aggiunge:
+
+- `test_merge_resistances_species_only` — species dict solo, zero trait: verifica che `psionico.fisico: 120` → `{channel: fisico, modifier_pct: -20}` (amplify).
+- `test_merge_resistances_trait_only` — trait list solo, zero species: verifica che sia pass-through.
+- `test_merge_resistances_species_plus_trait_stack` — species + trait stack: `corazzato.psionico: 120` + trait `psionico +30` → somma `-20 + 30 = +10` (resist 10%).
+- `test_species_vulnerability_end_to_end_smoking_gun` — pipeline completa: species `psionico.fisico: 120` via `merge_resistances`, poi `apply_resistance(10, result, 'fisico')` → 12 damage (20% amplify). Regression guard contro scenario balance-auditor.
+- `test_merge_resistances_clamp_range` — somma extreme (species 120 + trait -200 = -100) clamp a min delta range (opzionale, TBD in wire PR).
+
+Test esistenti rimangono verdi. Lint: `PYTHONPATH=services/rules pytest tests/test_resolver.py` deve passare 17→21+ test.
+
+## Migration path
+
+- **M5-#1a (questo PR)**: docs + test. Zero code change in `services/rules/` o `hydration.py`. Ship safe.
+- **M5-#1b (next PR)**: `hydration.py` load species*resistances.yaml + wire `build*_\_unit(species_archetype=...)`→`merge_resistances`. Per-species archetype mapping (via `data/core/species/_.yaml`field`resistance_archetype`, default `adattivo`) è prerequisito — coordinato con species-reviewer P1-species-02.
+- **M5-#1c (follow-up)**: re-run calibration iter2 hardcore-06 post-wire (target 15-25% win rate). Harness `tools/py/batch_calibrate_hardcore06.py`.
+
+## Rollback
+
+PR-level revert del test file. Zero impatto runtime poiché questo PR non tocca logica.
+
+## Autori
+
+- Agent session-debugger + balance-auditor + sot-planner (audit 2026-04-19)
+- Master DD (approval convention A via sessione 2026-04-19)

--- a/services/rules/hydration.py
+++ b/services/rules/hydration.py
@@ -28,6 +28,11 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
 
 import yaml
 
+# Lazy-safe: resolver.py does not import hydration, so direct import is safe.
+# ADR-2026-04-19 locks merge_resistances as the single convertitore
+# species-scale (100-neutral) -> delta format consumed by apply_resistance.
+from rules.resolver import merge_resistances
+
 #: Range di clamp per le resistenze aggregate (coerente con
 #: ``combat.schema.json#/$defs/resistance_entry`` che ammette ``[-100, 100]``).
 RESISTANCE_MIN = -100
@@ -173,6 +178,116 @@ def aggregate_resistances(
     ]
 
 
+def load_species_resistances(path: Path) -> Dict[str, Any]:
+    """Carica ``species_resistances.yaml`` e restituisce il dict completo.
+
+    Shape atteso (ADR-2026-04-19):
+
+    .. code-block:: yaml
+
+        version: "0.1.0"
+        species_archetypes:
+          corazzato:
+            label: "Corazzato"
+            resistances: {fisico: 80, taglio: 80, psionico: 120, ...}
+          ...
+        default_archetype: adattivo
+
+    I valori ``pct`` sono in scala **100-neutral**: ``80`` = 20% resist,
+    ``120`` = 20% vuln. Solo ``merge_resistances`` li converte in delta.
+    """
+
+    with open(path, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if not isinstance(data, Mapping):
+        raise ValueError(
+            f"species_resistances atteso dict root, trovato: {type(data).__name__}"
+        )
+    return dict(data)
+
+
+def get_archetype_resistances(
+    archetype_id: Optional[str],
+    species_resistances_data: Optional[Mapping[str, Any]],
+) -> Optional[Dict[str, int]]:
+    """Estrae il dict ``{channel: pct}`` (100-neutral) per un archetipo.
+
+    Se ``archetype_id`` e' ``None`` o non matcha, usa ``default_archetype``
+    definito nel YAML (default ``adattivo`` se assente). Se anche il default
+    non esiste, ritorna ``None`` (nessun baseline species applicato).
+    """
+    if not species_resistances_data:
+        return None
+    archetypes = species_resistances_data.get("species_archetypes") or {}
+    if not isinstance(archetypes, Mapping):
+        return None
+
+    lookup_id = archetype_id if archetype_id in archetypes else None
+    if lookup_id is None:
+        default_id = species_resistances_data.get("default_archetype", "adattivo")
+        lookup_id = default_id if default_id in archetypes else None
+    if lookup_id is None:
+        return None
+
+    entry = archetypes.get(lookup_id)
+    if not isinstance(entry, Mapping):
+        return None
+    resistances = entry.get("resistances")
+    if not isinstance(resistances, Mapping):
+        return None
+    return {str(ch): int(pct) for ch, pct in resistances.items()}
+
+
+def _resistances_with_species(
+    trait_ids: Iterable[str],
+    catalog: Mapping[str, Any],
+    species_archetype: Optional[Mapping[str, int]],
+) -> List[Dict[str, Any]]:
+    """Compone resistenze species (100-neutral) + trait (delta).
+
+    Se ``species_archetype`` e' ``None``, fallback puro a
+    ``aggregate_resistances`` (backward compat: pre-ADR-2026-04-19).
+
+    Se presente, raccoglie il trait list raw dalle entry del catalog
+    (NON somma pre-clamp) e delega a ``merge_resistances`` che:
+
+    1. Converte species 100-neutral -> delta (``merged[ch] = 100 - pct``)
+    2. Somma trait delta
+    3. Ritorna lista ``{channel, modifier_pct}`` in formato delta.
+
+    Il clamp finale ``[-100, 100]`` viene applicato qui per coerenza con
+    ``aggregate_resistances`` e ``combat.schema.json#/$defs/resistance_entry``.
+    """
+    if species_archetype is None:
+        return aggregate_resistances(trait_ids, catalog)
+
+    trait_resistances: List[Dict[str, Any]] = []
+    for trait_id in trait_ids:
+        entry = catalog.get(trait_id)
+        if not isinstance(entry, Mapping):
+            continue
+        for res in entry.get("resistances") or []:
+            channel = res.get("channel")
+            mod = res.get("modifier_pct")
+            if not isinstance(channel, str) or not isinstance(mod, int):
+                continue
+            trait_resistances.append({"channel": channel, "modifier_pct": mod})
+
+    merged = merge_resistances(trait_resistances, species_archetype)
+    # Clamp finale + sort + noise reduction (zero filter) in linea con
+    # aggregate_resistances. merge_resistances non applica clamp.
+    return [
+        {
+            "channel": entry["channel"],
+            "modifier_pct": _clamp(
+                int(entry["modifier_pct"]), RESISTANCE_MIN, RESISTANCE_MAX
+            ),
+        }
+        for entry in sorted(merged, key=lambda r: r["channel"])
+        if int(entry.get("modifier_pct", 0)) != 0
+    ]
+
+
 def build_party_unit(
     unit_id: str,
     species_id: str,
@@ -183,11 +298,19 @@ def build_party_unit(
     armor: int = DEFAULT_PARTY_ARMOR,
     initiative: int = DEFAULT_PARTY_INITIATIVE,
     tier: int = DEFAULT_PARTY_TIER,
+    species_archetype: Optional[Mapping[str, int]] = None,
 ) -> Dict[str, Any]:
     """Costruisce un ``CombatUnit`` per un membro party.
 
     I valori di default sono baseline piatti; il chiamante puo' sovrascrivere
     ``hp``, ``armor``, ``initiative`` e ``tier`` per calibrare singole unita'.
+
+    ``species_archetype`` (ADR-2026-04-19, M5-#1b wire) e' il dict
+    ``{channel: pct}`` in scala 100-neutral per l'archetipo della specie
+    (es. ``{fisico: 80, psionico: 120, ...}``). Se presente, le resistenze
+    finali sono composte come species-baseline + trait-delta via
+    ``merge_resistances``. Se ``None``, fallback backward-compat a
+    ``aggregate_resistances`` (trait-only).
     """
 
     return {
@@ -201,7 +324,7 @@ def build_party_unit(
         "initiative": initiative,
         "stress": 0.0,
         "statuses": [],
-        "resistances": aggregate_resistances(trait_ids, catalog),
+        "resistances": _resistances_with_species(trait_ids, catalog, species_archetype),
         "trait_ids": list(trait_ids),
         "pt": DEFAULT_PT_POOL,
         "reactions": {"current": DEFAULT_REACTIONS_MAX, "max": DEFAULT_REACTIONS_MAX},
@@ -214,6 +337,8 @@ def build_hostile_unit_from_group(
     group: Mapping[str, Any],
     trait_ids: Sequence[str],
     catalog: Mapping[str, Any],
+    *,
+    species_archetype: Optional[Mapping[str, int]] = None,
 ) -> Dict[str, Any]:
     """Costruisce un ``CombatUnit`` ostile dai dati di un ``group`` encounter.
 
@@ -223,6 +348,9 @@ def build_hostile_unit_from_group(
       power 4 ~ 80 HP tier 2-bridge)
     - ``armor = clamp(2 + power // 2, 2, 12)`` (range osservato 2-11)
     - ``initiative = 8 + power``
+
+    ``species_archetype`` (ADR-2026-04-19, M5-#1b wire): vedi
+    ``build_party_unit`` per semantica. Fallback backward-compat se ``None``.
     """
 
     power = int(group.get("power", 0))
@@ -242,7 +370,7 @@ def build_hostile_unit_from_group(
         "initiative": initiative,
         "stress": 0.0,
         "statuses": [],
-        "resistances": aggregate_resistances(trait_ids, catalog),
+        "resistances": _resistances_with_species(trait_ids, catalog, species_archetype),
         "trait_ids": list(trait_ids),
         "pt": DEFAULT_PT_POOL,
         "reactions": {"current": DEFAULT_REACTIONS_MAX, "max": DEFAULT_REACTIONS_MAX},
@@ -258,6 +386,9 @@ def hydrate_encounter(
     encounter_id: Optional[str] = None,
     hostile_species_ids: Optional[Sequence[str]] = None,
     hostile_trait_ids: Optional[Sequence[Sequence[str]]] = None,
+    species_resistances_data: Optional[Mapping[str, Any]] = None,
+    party_archetypes: Optional[Sequence[Optional[str]]] = None,
+    hostile_archetypes: Optional[Sequence[Optional[str]]] = None,
 ) -> Dict[str, Any]:
     """Produce un ``CombatState`` iniziale da encounter + party + catalog.
 
@@ -266,17 +397,39 @@ def hydrate_encounter(
     Se assenti o incompleti, ai gruppi restanti viene assegnato un placeholder
     ``hostile_<role>`` senza trait_ids. Nessun RNG e' consumato qui: il seed
     viene propagato al ``CombatState`` per l'uso futuro del resolver.
+
+    **ADR-2026-04-19 (M5-#1b wire)**: parametri species_archetype:
+
+    - ``species_resistances_data``: dict caricato da
+      ``load_species_resistances()`` (species_resistances.yaml shape).
+      Se ``None``, nessun baseline species applicato (backward compat).
+    - ``party_archetypes`` / ``hostile_archetypes``: liste parallele a
+      ``party`` e ai ``groups`` dell'encounter, contengono archetype_id
+      (es. ``"corazzato"``) o ``None`` (fallback su ``default_archetype``).
+      Quando ``species_resistances_data`` e' None, questi sono ignorati.
     """
 
     units: List[Dict[str, Any]] = []
 
-    for member in party:
+    party_archetypes_list = list(party_archetypes or [])
+    hostile_archetypes_list = list(hostile_archetypes or [])
+
+    for index, member in enumerate(party):
+        archetype_id = (
+            party_archetypes_list[index]
+            if index < len(party_archetypes_list)
+            else None
+        )
+        species_archetype_dict = get_archetype_resistances(
+            archetype_id, species_resistances_data
+        )
         units.append(
             build_party_unit(
                 unit_id=str(member["id"]),
                 species_id=str(member["species_id"]),
                 trait_ids=list(member.get("trait_ids") or []),
                 catalog=catalog,
+                species_archetype=species_archetype_dict,
             )
         )
 
@@ -296,6 +449,14 @@ def hydrate_encounter(
             if index < len(hostile_trait_ids)
             else []
         )
+        archetype_id = (
+            hostile_archetypes_list[index]
+            if index < len(hostile_archetypes_list)
+            else None
+        )
+        species_archetype_dict = get_archetype_resistances(
+            archetype_id, species_resistances_data
+        )
         units.append(
             build_hostile_unit_from_group(
                 unit_id=unit_id,
@@ -303,6 +464,7 @@ def hydrate_encounter(
                 group=group,
                 trait_ids=traits,
                 catalog=catalog,
+                species_archetype=species_archetype_dict,
             )
         )
 
@@ -350,8 +512,10 @@ __all__ = [
     "build_hostile_unit_from_group",
     "build_party_unit",
     "derive_tier_from_power",
+    "get_archetype_resistances",
     "hydrate_encounter",
     "load_active_effects_registry",
+    "load_species_resistances",
     "load_trait_mechanics",
     "_resolve_inheritance",
 ]

--- a/tests/test_hydration.py
+++ b/tests/test_hydration.py
@@ -36,7 +36,9 @@ from rules.hydration import (  # noqa: E402
     build_hostile_unit_from_group,
     build_party_unit,
     derive_tier_from_power,
+    get_archetype_resistances,
     hydrate_encounter,
+    load_species_resistances,
     load_trait_mechanics,
 )
 
@@ -47,6 +49,14 @@ MECHANICS_PATH = (
     / "data"
     / "balance"
     / "trait_mechanics.yaml"
+)
+SPECIES_RESISTANCES_PATH = (
+    PROJECT_ROOT
+    / "packs"
+    / "evo_tactics_pack"
+    / "data"
+    / "balance"
+    / "species_resistances.yaml"
 )
 ENCOUNTER_PATH = PROJECT_ROOT / "docs" / "examples" / "encounter_caverna.txt"
 SNAPSHOT_PATH = PROJECT_ROOT / "tests" / "snapshots" / "hydration_caverna.json"
@@ -320,3 +330,162 @@ def test_hydrate_encounter_without_explicit_hostile_species(catalog):
     hostile = [u for u in state["units"] if u["side"] == "hostile"][0]
     assert hostile["species_id"] == "hostile_control"
     assert state["vc"] is None
+
+
+# --- ADR-2026-04-19 M5-#1b wire: species_resistances.yaml + build_*_unit
+# Test la pipeline completa species archetype (100-neutral) -> merge_resistances
+# -> delta -> resistances field della unit. Verifica backward compat (param
+# species_archetype opzionale = fallback ad aggregate_resistances trait-only).
+
+
+def test_load_species_resistances_reads_yaml():
+    data = load_species_resistances(SPECIES_RESISTANCES_PATH)
+    assert "species_archetypes" in data
+    archetypes = data["species_archetypes"]
+    for required_id in ("corazzato", "psionico", "adattivo"):
+        assert required_id in archetypes
+    corazzato = archetypes["corazzato"]["resistances"]
+    assert corazzato["fisico"] == 80  # 20% resist
+    assert corazzato["psionico"] == 120  # 20% vuln
+    assert data.get("default_archetype") == "adattivo"
+
+
+def test_get_archetype_resistances_returns_dict_for_valid_id():
+    data = load_species_resistances(SPECIES_RESISTANCES_PATH)
+    result = get_archetype_resistances("psionico", data)
+    assert result is not None
+    assert result["fisico"] == 120  # vuln in 100-neutral scale
+    assert result["psionico"] == 70  # resist
+
+
+def test_get_archetype_resistances_falls_back_to_default():
+    data = load_species_resistances(SPECIES_RESISTANCES_PATH)
+    result = get_archetype_resistances("unknown_archetype_xyz", data)
+    # fallback su default_archetype "adattivo" -> tutti canali 100 (neutro)
+    assert result is not None
+    assert all(pct == 100 for pct in result.values())
+
+
+def test_get_archetype_resistances_returns_none_if_no_data():
+    assert get_archetype_resistances("corazzato", None) is None
+
+
+def test_build_party_unit_with_species_archetype_applies_baseline(catalog):
+    """ADR-2026-04-19 smoking gun: psionico vulnerability + trait stack."""
+    species_data = load_species_resistances(SPECIES_RESISTANCES_PATH)
+    archetype_dict = get_archetype_resistances("psionico", species_data)
+    unit = build_party_unit(
+        unit_id="p1",
+        species_id="test_psionico",
+        trait_ids=[],
+        catalog=catalog,
+        species_archetype=archetype_dict,
+    )
+    # Atteso format delta dopo merge_resistances:
+    # psionico.fisico: 120 (vuln) -> {channel: fisico, modifier_pct: -20}
+    by_channel = {r["channel"]: r["modifier_pct"] for r in unit["resistances"]}
+    assert by_channel["fisico"] == -20
+    assert by_channel["taglio"] == -20
+    assert by_channel["psionico"] == 30  # 100-70
+
+
+def test_build_party_unit_backward_compat_without_archetype(catalog):
+    """Senza species_archetype: fallback trait-only (pre-ADR behavior)."""
+    unit_baseline = build_party_unit("p1", "sp", [], catalog)
+    assert unit_baseline["resistances"] == []  # trait-only, vuoto
+
+    unit_with_trait = build_party_unit(
+        "p2", "sp", ["mantello_meteoritico"], catalog
+    )
+    by_channel = {r["channel"]: r["modifier_pct"] for r in unit_with_trait["resistances"]}
+    # mantello_meteoritico ha resistances, trait-only passa invariato
+    assert len(by_channel) > 0
+
+
+def test_build_party_unit_species_plus_trait_stack_additive(catalog):
+    """species corazzato + trait additivo: somma algebrica delta format."""
+    species_data = load_species_resistances(SPECIES_RESISTANCES_PATH)
+    archetype_dict = get_archetype_resistances("corazzato", species_data)
+    # mantello_meteoritico aggiunge fisico+20 (resist)
+    unit = build_party_unit(
+        "p1",
+        "sp",
+        ["mantello_meteoritico"],
+        catalog,
+        species_archetype=archetype_dict,
+    )
+    by_channel = {r["channel"]: r["modifier_pct"] for r in unit["resistances"]}
+    # corazzato.fisico: 80 -> +20 baseline; trait mantello_meteoritico fisico+20
+    # somma atteso: +40 (resist 40%)
+    assert by_channel["fisico"] == 40
+
+
+def test_build_hostile_unit_with_species_archetype(catalog):
+    species_data = load_species_resistances(SPECIES_RESISTANCES_PATH)
+    archetype_dict = get_archetype_resistances("bioelettrico", species_data)
+    group = {"power": 5, "role": "threat", "affixes": []}
+    unit = build_hostile_unit_from_group(
+        "h1", "bioelettrico_drone", group, [], catalog,
+        species_archetype=archetype_dict,
+    )
+    # bioelettrico.elettrico: 70 -> +30 resist; .fisico: 120 -> -20 vuln
+    by_channel = {r["channel"]: r["modifier_pct"] for r in unit["resistances"]}
+    assert by_channel["elettrico"] == 30
+    assert by_channel["fisico"] == -20
+
+
+def test_hydrate_encounter_with_species_resistances_end_to_end(catalog):
+    """Integration test: YAML load -> hydrate_encounter -> unit.resistances."""
+    species_data = load_species_resistances(SPECIES_RESISTANCES_PATH)
+    encounter = {
+        "biome": "test",
+        "tb": 5,
+        "groups": [
+            {"power": 4, "role": "threat"},
+            {"power": 6, "role": "keystone"},
+        ],
+        "party_vc": None,
+    }
+    party = [{"id": "p1", "species_id": "sp", "trait_ids": []}]
+    state = hydrate_encounter(
+        encounter,
+        party,
+        catalog,
+        "seed",
+        "sid",
+        species_resistances_data=species_data,
+        party_archetypes=["psionico"],
+        hostile_archetypes=["corazzato", "bioelettrico"],
+    )
+    party_unit = state["units"][0]
+    # psionico: fisico=120 -> -20 vuln
+    assert any(
+        r["channel"] == "fisico" and r["modifier_pct"] == -20
+        for r in party_unit["resistances"]
+    )
+    hostile_0 = state["units"][1]  # corazzato
+    assert any(
+        r["channel"] == "fisico" and r["modifier_pct"] == 20
+        for r in hostile_0["resistances"]
+    )
+    hostile_1 = state["units"][2]  # bioelettrico
+    assert any(
+        r["channel"] == "fisico" and r["modifier_pct"] == -20
+        for r in hostile_1["resistances"]
+    )
+
+
+def test_hydrate_encounter_no_species_data_backward_compat(catalog):
+    """Senza species_resistances_data: comportamento pre-ADR invariato."""
+    encounter = {
+        "biome": "test",
+        "tb": 5,
+        "groups": [{"power": 3, "role": "control"}],
+        "party_vc": None,
+    }
+    party = [{"id": "p1", "species_id": "sp", "trait_ids": []}]
+    # Non passare species_resistances_data + archetypes: deve usare
+    # aggregate_resistances (trait-only).
+    state = hydrate_encounter(encounter, party, catalog, "s", "ss")
+    assert state["units"][0]["resistances"] == []
+    assert state["units"][1]["resistances"] == []

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -63,6 +63,7 @@ from rules.resolver import (  # noqa: E402
     compute_step_count,
     compute_step_flat_bonus,
     get_status,
+    merge_resistances,
     predict_combat,
     resolve_action,
     resolve_parry,
@@ -189,6 +190,80 @@ def test_apply_resistance_multiplicative_floor():
 def test_apply_resistance_negative_pct_amplifies():
     # -20% vulnerability -> floor(10 * 1.2) = 12
     assert apply_resistance(10, [{"channel": "fuoco", "modifier_pct": -20}], "fuoco") == 12
+
+
+# --- ADR-2026-04-19 Resistance convention: species (100-neutral) + trait (delta)
+# Lock convention tramite regression test. Scenario end-to-end smoking gun
+# (species vulnerability fluisce correttamente tramite merge_resistances ->
+# apply_resistance) previene regressione segnalata da parallel-agent audit
+# 2026-04-19 (balance-auditor + sot-planner).
+
+
+def test_merge_resistances_species_only_converts_100_neutral_to_delta():
+    """species scale 100-neutral -> delta format via merge_resistances.
+
+    psionico.fisico: 120 (20% vuln in species scale)
+        -> {channel: fisico, modifier_pct: -20}  (delta)
+    """
+    species = {"fisico": 120, "taglio": 120, "psionico": 70}
+    result = merge_resistances([], species)
+    by_channel = {r["channel"]: r["modifier_pct"] for r in result}
+    assert by_channel["fisico"] == -20  # 100 - 120 = -20 (vuln)
+    assert by_channel["taglio"] == -20
+    assert by_channel["psionico"] == 30  # 100 - 70 = +30 (resist)
+
+
+def test_merge_resistances_trait_only_passes_through_delta():
+    """trait list solo (zero species): delta format invariato."""
+    traits = [
+        {"channel": "fuoco", "modifier_pct": 20},
+        {"channel": "fisico", "modifier_pct": -15},
+    ]
+    result = merge_resistances(traits, None)
+    by_channel = {r["channel"]: r["modifier_pct"] for r in result}
+    assert by_channel["fuoco"] == 20
+    assert by_channel["fisico"] == -15
+
+
+def test_merge_resistances_species_plus_trait_stack_additive():
+    """species baseline + trait stack: somma algebrica in delta format.
+
+    corazzato.psionico: 120 -> -20 baseline (vulnerabilità)
+    trait psionico: +30 (resistenza)
+    risultato atteso: -20 + 30 = +10 (10% resist netto)
+    """
+    species = {"fisico": 80, "psionico": 120}
+    traits = [{"channel": "psionico", "modifier_pct": 30}]
+    result = merge_resistances(traits, species)
+    by_channel = {r["channel"]: r["modifier_pct"] for r in result}
+    assert by_channel["fisico"] == 20  # solo species: 100 - 80 = +20 (resist)
+    assert by_channel["psionico"] == 10  # -20 + 30 = +10
+
+
+def test_species_vulnerability_end_to_end_smoking_gun():
+    """REGRESSION GUARD: parallel-agent audit 2026-04-19.
+
+    Pipeline completa species 100-neutral -> merge_resistances -> delta
+    -> apply_resistance. Verifica che species vulnerability (pct > 100)
+    produca amplify damage, NON clamp a zero.
+
+    Scenario balance-auditor: psionico archetype con fisico: 120
+    vs attacker fisico damage=10. Atteso: 10 * 1.2 = 12 (amplify 20%).
+    Bug storico se caller passa species dict raw a apply_resistance:
+    factor = (100 - 120) / 100 = -0.20 -> floor(10 * -0.20) = -2 -> clamp 0.
+    Test forza passaggio via merge_resistances (ADR-2026-04-19 invariant).
+    """
+    species_psionico = {"fisico": 120, "taglio": 120, "psionico": 70}
+    merged = merge_resistances([], species_psionico)
+    # merged è delta format, pronto per apply_resistance
+    damage_after = apply_resistance(10, merged, "fisico")
+    assert damage_after == 12, (
+        f"Species vulnerability non applicata. Expected 12 (amplify 20%),"
+        f" got {damage_after}. ADR-2026-04-19 convention broken."
+    )
+    # controllo canale resistant stesso archetype
+    damage_psionico = apply_resistance(10, merged, "psionico")
+    assert damage_psionico == 7  # floor(10 * 0.70) = 7
 
 
 def test_apply_armor_sottrae_flat():

--- a/tests/test_round_orchestrator.py
+++ b/tests/test_round_orchestrator.py
@@ -780,7 +780,10 @@ def test_full_round_end_to_end_preview_then_commit_then_resolve(catalog):
     state = declare_intent(state, "bravo", _attack("bravo", "alpha"))["next_state"]
     assert state["round_phase"] == PHASE_PLANNING
     assert state["units"][0]["ap"]["current"] == ap_snapshot
-    # Cambio idea: alpha ora difende invece di attaccare
+    # Cambio idea: alpha ora difende invece di attaccare.
+    # W8k (2026-04-19): declare_intent ora APPEND invece di latest-wins.
+    # Per "cambiare idea": clear_intent prima di nuovo declare.
+    state = clear_intent(state, "alpha")["next_state"]
     state = declare_intent(state, "alpha", _defend("alpha"))["next_state"]
     assert len(state["pending_intents"]) == 2
 


### PR DESCRIPTION
## Summary

- **Wire species_resistances.yaml** end-to-end: load YAML -> `build_*_unit(species_archetype=)` -> `_resistances_with_species` -> `merge_resistances` (resolver.py) -> `unit.resistances` (delta format).
- **Backward compat preserved**: nuovi kwarg opzionali; chiamate esistenti invariate.
- **ADR-2026-04-19 invariant respected**: unico path species (100-neutral) -> delta via `merge_resistances`.
- **243/243 test verdi** locali (hydration 28 + resolver 83 + round_orchestrator 124 + trait_effects 25 + validators 5).

## Stack

- **Base**: `feat/m5-resistance-convention-adr` (#1629 M5-#1a). **Dipende da merge di #1629 prima**.
- **Merge order**: #1629 -> main, poi questo PR rebase su main + merge.

## Scope (vedi commit body per dettagli)

`services/rules/hydration.py` (+170 LOC):
- `load_species_resistances(path)`
- `get_archetype_resistances(archetype_id, data)` con fallback `default_archetype`
- `_resistances_with_species(trait_ids, catalog, species_archetype)` helper clamp+sort
- `build_party_unit(..., *, species_archetype=None)`
- `build_hostile_unit_from_group(..., *, species_archetype=None)`
- `hydrate_encounter(..., species_resistances_data, party_archetypes, hostile_archetypes)`

`tests/test_hydration.py` (+169 LOC, 10 nuovi test):
- Loader + archetype lookup + fallback
- Smoking gun psionico.fisico 120 -> delta -20 via wire
- Backward compat trait-only
- Species + trait stack additivo
- Integration YAML -> hydrate_encounter -> unit.resistances

## Test plan

- [x] `PYTHONPATH=services/rules:tools/py:services pytest tests/test_hydration.py tests/test_resolver.py tests/test_round_orchestrator.py tests/test_trait_effects.py tests/validators/test_rules.py` — **243/243 verdi**
- [x] Backward compat: tutti test `_without_archetype` / `_backward_compat` passano invariati
- [x] Snapshot test `test_hydrate_caverna_matches_snapshot` invariato (chiamata senza archetype)
- [x] Smoking gun end-to-end: `build_party_unit` + archetype `psionico` -> `fisico: -20` nella unit
- [ ] CI: python-tests verde
- [ ] Reviewer: conferma API signature + migration path caller side (session.js wire follow-up M5-#1c)

## Follow-up stack

- **M5-#1c**: caller integration `apps/backend/services/session.js` + `sessionRoundBridge.js` — propagare `species_resistances_data` + archetype al hydrate bridge. Apre calibration iter2.
- **M5-#1d (= M5-#7 originale)**: re-run calibration hardcore-06 N=30 post-wire. Target 15-25% win rate (era 84.6%).
- **P1-species-02** (species-reviewer): campo `resistance_archetype` in `data/core/species/*.yaml` per popolare archetypes arrays automaticamente.

## 03A Rollback

- Revert del PR: file modificati sono isolati a `services/rules/hydration.py` + `tests/test_hydration.py`. Nessun caller ancora consuma i nuovi kwarg (M5-#1c). Revert safe.
- Config flag: non necessario (backward compat via default=None).

## Guardrail

170 LOC net in `services/rules/` (>50 threshold). Segnalato upfront in sessione M5 kickoff, approvato da Master DD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)