### PR TITLE
fix(traits): martello_osseo + ferocia glossary (M5 cross-PR orphan)

### DIFF
--- a/data/core/traits/glossary.json
+++ b/data/core/traits/glossary.json
@@ -1570,6 +1570,18 @@
       "label_en": "Root Capillary Networks",
       "description_it": "Microvascolatura dermica connessa a terminazioni radicali simbiotiche, rimuovendo calore e scambiando fluidi con substrati vegetali per regolare la temperatura basale.",
       "description_en": "Dermal microvasculature connected to symbiotic root terminals, shedding heat and exchanging fluids with plant substrates to regulate core temperature."
+    },
+    "martello_osseo": {
+      "label_it": "Martello Osseo",
+      "label_en": "Bone Hammer",
+      "description_it": "Protuberanza ossea terminale (coda o arto) che concentra massa per impatti pesanti; amplifica il danno fisico a scapito della velocità di recupero.",
+      "description_en": "Terminal bony protrusion (tail or limb) concentrating mass for heavy impacts; amplifies physical damage at the cost of recovery speed."
+    },
+    "ferocia": {
+      "label_it": "Ferocia",
+      "label_en": "Ferocity",
+      "description_it": "Stato psicofisico predatoriale che aumenta l'aggressività e la potenza offensiva sotto stress; favorisce attacchi multipli consecutivi.",
+      "description_en": "Predatory psycho-physical state increasing aggression and offensive power under stress; favors consecutive multi-attacks."
     }
   }
 }


### PR DESCRIPTION
## Summary

Post-merge M5 batch: CI guard `speciesTraitReferences.test.js` (da #1633) fail su main con 2 nuovi orfani `martello_osseo` + `ferocia`, referenziati da `apex_predatore.yaml` (stub M5-#3 #1632).

## Root cause

Cross-PR gap:
- **#1632** M5-#3 ha creato phantom species stubs inclusi `apex_predatore` con `traits: [martello_osseo, ferocia]`
- **#1633** M5-#4 ha creato glossary guard + aggiunto 7 termoregolazione traits
- Nessuno dei due ha validato intersezione post-merge → silent orphan breakthrough

## Fix

Add 2 glossary entries in `data/core/traits/glossary.json`:

| ID | IT | EN |
|---|---|---|
| `martello_osseo` | Martello Osseo | Bone Hammer |
| `ferocia` | Ferocia | Ferocity |

Entrambi descriptor passivi tutorial-boss (apex_predatore tutorial_05).

## Test plan

- [x] `node --test tests/scripts/*.test.js` → all green
- [x] `node --test tests/ai/*.test.js` → 168/168
- [ ] CI dataset-checks verde

## 03A Rollback

PR revert. Re-introduces orphan but non-blocking (apex_predatore stub-only ref).

## Lessons

Cross-PR gap analysis: quando stack-by-branch su origin/main pre-merge, CI guard di un PR non vede stub di un altro PR. **Follow-up**: aggiungi pre-merge validation che esegue guard di TUTTI PR aperti sull'attuale HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)