### PR TITLE
M6-#1: native Node resistance engine + session.js wire (channel-specific)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -53,6 +53,15 @@ const { createDeclareSistemaIntents } = require('../services/ai/declareSistemaIn
 const { loadAiProfiles } = require('../services/ai/aiProfilesLoader');
 const { createAbilityExecutor } = require('../services/abilityExecutor');
 const reactionEngine = require('../services/reactionEngine');
+// M6-#1 (ADR-2026-04-19 + spike 2026-04-19): Node native resistance engine.
+// Applica channel-specific resist/vuln su damage pre-hp. Evidence spike:
+// 84.6% → 20% win rate hardcore-06 con flat 50% resist (leva confermata).
+const {
+  loadSpeciesResistances,
+  applyResistance,
+  computeUnitResistances,
+  DEFAULT_SPECIES_RESISTANCES_PATH,
+} = require('../services/combat/resistanceEngine');
 
 // Extracted modules — constants + pure helpers (token optimization).
 // See sessionConstants.js and sessionHelpers.js for the extracted code.
@@ -115,6 +124,21 @@ function createSessionRouter(options = {}) {
   const traitRegistry = options.traitRegistry || loadActiveTraitRegistry();
   const fairnessConfig = options.fairnessConfig || loadFairnessConfig();
   const telemetryConfig = options.telemetryConfig || loadTelemetryConfig();
+  // M6-#1: species resistances data caricato una volta a session-router init.
+  // Override path via env GAME_SPECIES_RESISTANCES_PATH o options.
+  // Failure soft: null se file mancante → no channel resistance applicata.
+  let speciesResistancesData = null;
+  try {
+    const srPath =
+      options.speciesResistancesPath ||
+      process.env.GAME_SPECIES_RESISTANCES_PATH ||
+      DEFAULT_SPECIES_RESISTANCES_PATH;
+    speciesResistancesData = loadSpeciesResistances(srPath);
+  } catch (err) {
+    console.warn(
+      `[session] species_resistances.yaml non caricato (${err.message}). Channel resistance disabilitata.`,
+    );
+  }
 
   const sessions = new Map();
   let activeSessionId = null;
@@ -234,6 +258,29 @@ function createSessionRouter(options = {}) {
         backstabBonus +
         parryDelta;
       damageDealt = Math.max(0, adjusted);
+      // M6-#1 (ADR-2026-04-19): applica channel resistance post damage.
+      // Resolve target.resistances lazy: computa da resistance_archetype +
+      // trait_ids al primo hit (cache su target._resistances).
+      // Channel da action.channel (client-provided) o default "fisico".
+      // Se speciesResistancesData null (file mancante) → no-op.
+      if (speciesResistancesData && damageDealt > 0) {
+        if (!Array.isArray(target._resistances)) {
+          const traitResists = [];
+          for (const tid of Array.isArray(target.traits) ? target.traits : []) {
+            const entry = traitRegistry && traitRegistry[tid];
+            if (entry && Array.isArray(entry.resistances)) {
+              for (const r of entry.resistances) traitResists.push(r);
+            }
+          }
+          target._resistances = computeUnitResistances(
+            target.resistance_archetype || null,
+            speciesResistancesData,
+            traitResists,
+          );
+        }
+        const channel = action && typeof action.channel === 'string' ? action.channel : 'fisico';
+        damageDealt = applyResistance(damageDealt, target._resistances, channel);
+      }
       // Consuma guardia solo se parata riuscita (mitigazione cumulativa)
       if (parryResult && parryResult.success) {
         target.guardia = Math.max(0, Number(target.guardia) - 1);

--- a/apps/backend/services/combat/resistanceEngine.js
+++ b/apps/backend/services/combat/resistanceEngine.js
@@ -1,0 +1,200 @@
+// Resistance Engine — Node native implementation (M6-#1, ADR-2026-04-19).
+//
+// Context: parallel-agent audit 2026-04-19 scoprì che Node session engine
+// (apps/backend/routes/session.js) non implementava channel resistance logic,
+// mentre Python rules engine (services/rules/resolver.py) sì. Spike 2026-04-19
+// validò che resistance è la leva calibrazione hardcore-06 (84.6% → 20% win
+// rate con flat 50% resist).
+//
+// User direction 2026-04-19: "1 solo gioco online, senza master" → runtime
+// canonico = Node. Portiamo resistance a Node (non tracciamento Python bridge).
+//
+// Convention ADR-2026-04-19:
+// - species_resistances.yaml: scale 100-neutral (80=resist, 100=neutro, 120=vuln)
+// - trait_mechanics.yaml trait resistances: delta (+20=resist, -20=vuln)
+// - mergeResistances è unico convertitore species→delta
+// - applyResistance accetta solo delta format
+//
+// Semantic parity con Python services/rules/resolver.py (apply_resistance +
+// merge_resistances) per future contract test.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const RESISTANCE_MIN = -100;
+const RESISTANCE_MAX = 100;
+
+/**
+ * Load species_resistances.yaml → dict {species_archetypes, default_archetype}.
+ *
+ * Shape atteso:
+ * ```yaml
+ * species_archetypes:
+ *   corazzato:
+ *     resistances: {fisico: 80, taglio: 80, psionico: 120, ...}
+ *   ...
+ * default_archetype: adattivo
+ * ```
+ *
+ * Valori pct in scala 100-neutral.
+ *
+ * @param {string} filePath path assoluto o relativo a repo root
+ * @returns {object} data dict
+ */
+function loadSpeciesResistances(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const data = yaml.load(raw);
+  if (!data || typeof data !== 'object') {
+    throw new Error(`species_resistances atteso dict root, trovato: ${typeof data}`);
+  }
+  return data;
+}
+
+/**
+ * Extract archetype resistance dict {channel: pct} (scala 100-neutral).
+ * Fallback a default_archetype quando archetypeId non matcha.
+ *
+ * @param {string|null|undefined} archetypeId es. "corazzato"
+ * @param {object|null|undefined} data output di loadSpeciesResistances
+ * @returns {object|null} dict channel→pct (100-neutral), o null se no data
+ */
+function getArchetypeResistances(archetypeId, data) {
+  if (!data || typeof data !== 'object') return null;
+  const archetypes = data.species_archetypes || {};
+  if (typeof archetypes !== 'object') return null;
+
+  let lookupId = archetypeId && archetypes[archetypeId] ? archetypeId : null;
+  if (!lookupId) {
+    const defaultId = data.default_archetype || 'adattivo';
+    lookupId = archetypes[defaultId] ? defaultId : null;
+  }
+  if (!lookupId) return null;
+
+  const entry = archetypes[lookupId];
+  if (!entry || typeof entry !== 'object' || !entry.resistances) return null;
+  const result = {};
+  for (const [ch, pct] of Object.entries(entry.resistances)) {
+    result[String(ch)] = Number(pct);
+  }
+  return result;
+}
+
+/**
+ * Merge trait resistances (delta format) + species archetype (100-neutral)
+ * → list delta format `[{channel, modifier_pct}]` consumibile da applyResistance.
+ *
+ * Species baseline convertito: merged[ch] = 100 - pct (80→+20 resist, 120→-20 vuln).
+ * Trait delta sommato al baseline.
+ *
+ * Semantic parity con Python resolver.py:merge_resistances.
+ *
+ * @param {Array} traitResistances lista `[{channel, modifier_pct}]` (delta)
+ * @param {object|null} speciesResistances dict channel→pct (100-neutral) o null
+ * @returns {Array} lista `[{channel, modifier_pct}]` (delta, clampata ±100)
+ */
+function mergeResistances(traitResistances, speciesResistances) {
+  const merged = {};
+
+  // 1. Species baseline (100-neutral) → delta conversion
+  if (speciesResistances && typeof speciesResistances === 'object') {
+    for (const [ch, pct] of Object.entries(speciesResistances)) {
+      merged[ch] = 100 - Number(pct);
+    }
+  }
+
+  // 2. Trait delta sum al baseline
+  if (Array.isArray(traitResistances)) {
+    for (const res of traitResistances) {
+      if (!res || typeof res !== 'object') continue;
+      const ch = res.channel;
+      const mod = Number(res.modifier_pct);
+      if (typeof ch !== 'string' || !Number.isFinite(mod)) continue;
+      merged[ch] = (merged[ch] || 0) + mod;
+    }
+  }
+
+  // 3. Clamp + filter zero + sort
+  const result = [];
+  for (const [ch, pct] of Object.entries(merged)) {
+    const clamped = Math.max(RESISTANCE_MIN, Math.min(RESISTANCE_MAX, pct));
+    if (clamped !== 0) {
+      result.push({ channel: ch, modifier_pct: clamped });
+    }
+  }
+  result.sort((a, b) => a.channel.localeCompare(b.channel));
+  return result;
+}
+
+/**
+ * Apply resistance al damage per il canale dell'attacco.
+ *
+ * Formula: `floor(damage * (1 - pct/100))` per pct ∈ [-100, 100] (delta).
+ * - pct=+20 → factor=0.8 (resist 20%)
+ * - pct=-20 → factor=1.2 (amplify/vuln 20%)
+ * - pct=+100 → factor=0 (immune)
+ * - pct=-100 → factor=2 (double damage)
+ *
+ * Canale null o non matched nella lista resistances → damage passa invariato.
+ *
+ * Semantic parity con Python resolver.py:apply_resistance.
+ *
+ * @param {number} damage danno pre-resistance (int)
+ * @param {Array|null|undefined} resistances lista `[{channel, modifier_pct}]` (delta)
+ * @param {string|null|undefined} channel canale attacco es. "fisico"
+ * @returns {number} damage post-resistance (int, floor)
+ */
+function applyResistance(damage, resistances, channel) {
+  if (!Number.isFinite(damage) || damage <= 0) return damage;
+  if (!channel || typeof channel !== 'string') return damage;
+  if (!Array.isArray(resistances)) return damage;
+
+  for (const res of resistances) {
+    if (!res || typeof res !== 'object') continue;
+    if (res.channel !== channel) continue;
+    const pct = Number(res.modifier_pct);
+    if (!Number.isFinite(pct)) continue;
+    const factor = (100 - pct) / 100;
+    const adjusted = Math.floor(damage * factor);
+    // Clamp a 0 (nessun damage negativo anche con vuln oltre 100)
+    return Math.max(0, adjusted);
+  }
+  return damage;
+}
+
+/**
+ * Resolve resistance dict per unit combining species_archetype + unit traits.
+ * Helper che compone merged resistances ready-to-use.
+ *
+ * @param {string|null} archetypeId
+ * @param {object|null} speciesData loadSpeciesResistances output
+ * @param {Array} traitResistances lista trait `[{channel, modifier_pct}]`
+ * @returns {Array} resistances delta list ready per applyResistance
+ */
+function computeUnitResistances(archetypeId, speciesData, traitResistances) {
+  const archetype = getArchetypeResistances(archetypeId, speciesData);
+  return mergeResistances(traitResistances || [], archetype);
+}
+
+// Default path canonical (override-able via env var GAME_SPECIES_RESISTANCES_PATH)
+const DEFAULT_SPECIES_RESISTANCES_PATH = path.join(
+  process.cwd(),
+  'packs',
+  'evo_tactics_pack',
+  'data',
+  'balance',
+  'species_resistances.yaml',
+);
+
+module.exports = {
+  loadSpeciesResistances,
+  getArchetypeResistances,
+  mergeResistances,
+  applyResistance,
+  computeUnitResistances,
+  DEFAULT_SPECIES_RESISTANCES_PATH,
+  RESISTANCE_MIN,
+  RESISTANCE_MAX,
+};

--- a/tests/ai/resistanceEngine.test.js
+++ b/tests/ai/resistanceEngine.test.js
@@ -1,0 +1,182 @@
+// Tests M6-#1 resistance engine Node native.
+// Parity semantic con Python services/rules/resolver.py.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const {
+  loadSpeciesResistances,
+  getArchetypeResistances,
+  mergeResistances,
+  applyResistance,
+  computeUnitResistances,
+  DEFAULT_SPECIES_RESISTANCES_PATH,
+} = require('../../apps/backend/services/combat/resistanceEngine');
+
+// ─── applyResistance ────────────────────────────────────────────
+
+test('applyResistance resist positive → reduced damage floor', () => {
+  const resistances = [{ channel: 'fuoco', modifier_pct: 20 }];
+  assert.equal(applyResistance(10, resistances, 'fuoco'), 8); // floor(10*0.8)=8
+});
+
+test('applyResistance delta negative → amplify damage (vuln)', () => {
+  const resistances = [{ channel: 'fuoco', modifier_pct: -20 }];
+  assert.equal(applyResistance(10, resistances, 'fuoco'), 12); // floor(10*1.2)=12
+});
+
+test('applyResistance 100 immune → zero damage', () => {
+  const resistances = [{ channel: 'fuoco', modifier_pct: 100 }];
+  assert.equal(applyResistance(10, resistances, 'fuoco'), 0);
+});
+
+test('applyResistance -100 double → 2x damage', () => {
+  const resistances = [{ channel: 'fuoco', modifier_pct: -100 }];
+  assert.equal(applyResistance(10, resistances, 'fuoco'), 20);
+});
+
+test('applyResistance channel not matched → damage invariato', () => {
+  const resistances = [{ channel: 'fuoco', modifier_pct: 50 }];
+  assert.equal(applyResistance(10, resistances, 'fisico'), 10);
+});
+
+test('applyResistance null channel → damage invariato', () => {
+  const resistances = [{ channel: 'fuoco', modifier_pct: 50 }];
+  assert.equal(applyResistance(10, resistances, null), 10);
+});
+
+test('applyResistance empty resistances → damage invariato', () => {
+  assert.equal(applyResistance(10, [], 'fuoco'), 10);
+  assert.equal(applyResistance(10, null, 'fuoco'), 10);
+});
+
+test('applyResistance zero/negative damage → pass through', () => {
+  assert.equal(applyResistance(0, [{ channel: 'x', modifier_pct: 50 }], 'x'), 0);
+});
+
+// ─── mergeResistances ──────────────────────────────────────────
+
+test('mergeResistances species only 100-neutral → delta', () => {
+  // psionico archetype: fisico=120 (vuln), psionico=70 (resist), taglio=120
+  const species = { fisico: 120, taglio: 120, psionico: 70 };
+  const result = mergeResistances([], species);
+  const byCh = Object.fromEntries(result.map((r) => [r.channel, r.modifier_pct]));
+  assert.equal(byCh.fisico, -20); // 100-120=-20 (vuln)
+  assert.equal(byCh.taglio, -20);
+  assert.equal(byCh.psionico, 30); // 100-70=+30 (resist)
+});
+
+test('mergeResistances trait only → pass-through delta', () => {
+  const traits = [
+    { channel: 'fuoco', modifier_pct: 20 },
+    { channel: 'fisico', modifier_pct: -15 },
+  ];
+  const result = mergeResistances(traits, null);
+  const byCh = Object.fromEntries(result.map((r) => [r.channel, r.modifier_pct]));
+  assert.equal(byCh.fuoco, 20);
+  assert.equal(byCh.fisico, -15);
+});
+
+test('mergeResistances species + trait stack additivo', () => {
+  // corazzato.psionico: 120 → -20 baseline (vuln)
+  // trait psionico: +30 (resist)
+  // atteso: -20 + 30 = +10
+  const species = { fisico: 80, psionico: 120 };
+  const traits = [{ channel: 'psionico', modifier_pct: 30 }];
+  const result = mergeResistances(traits, species);
+  const byCh = Object.fromEntries(result.map((r) => [r.channel, r.modifier_pct]));
+  assert.equal(byCh.fisico, 20); // only species: 100-80=+20 (resist)
+  assert.equal(byCh.psionico, 10); // -20+30=+10
+});
+
+test('mergeResistances clamp ±100', () => {
+  const species = { fisico: 50 }; // +50 baseline
+  const traits = [{ channel: 'fisico', modifier_pct: 200 }]; // stack +250
+  const result = mergeResistances(traits, species);
+  assert.equal(result[0].modifier_pct, 100); // clamped
+});
+
+test('mergeResistances filter zero sum', () => {
+  const traits = [
+    { channel: 'x', modifier_pct: 50 },
+    { channel: 'x', modifier_pct: -50 },
+  ];
+  assert.deepEqual(mergeResistances(traits, null), []);
+});
+
+test('mergeResistances sorted alphabetical', () => {
+  const species = { fuoco: 80, psionico: 70, fisico: 120 };
+  const result = mergeResistances([], species);
+  const channels = result.map((r) => r.channel);
+  assert.deepEqual(channels, channels.slice().sort());
+});
+
+// ─── getArchetypeResistances ──────────────────────────────────
+
+test('getArchetypeResistances valid id returns dict', () => {
+  const data = {
+    species_archetypes: {
+      psionico: { resistances: { fisico: 120, psionico: 70 } },
+    },
+  };
+  const result = getArchetypeResistances('psionico', data);
+  assert.equal(result.fisico, 120);
+  assert.equal(result.psionico, 70);
+});
+
+test('getArchetypeResistances unknown id → default fallback', () => {
+  const data = {
+    species_archetypes: {
+      adattivo: { resistances: { fisico: 100, taglio: 100 } },
+    },
+    default_archetype: 'adattivo',
+  };
+  const result = getArchetypeResistances('unknown_xyz', data);
+  assert.equal(result.fisico, 100); // neutral
+});
+
+test('getArchetypeResistances no data → null', () => {
+  assert.equal(getArchetypeResistances('corazzato', null), null);
+});
+
+// ─── loadSpeciesResistances (real file) ───────────────────────
+
+test('loadSpeciesResistances reads real YAML', () => {
+  const data = loadSpeciesResistances(DEFAULT_SPECIES_RESISTANCES_PATH);
+  assert.ok(data.species_archetypes);
+  for (const req of ['corazzato', 'psionico', 'adattivo']) {
+    assert.ok(data.species_archetypes[req], `missing archetype ${req}`);
+  }
+  assert.equal(data.species_archetypes.corazzato.resistances.fisico, 80);
+});
+
+// ─── computeUnitResistances integration ───────────────────────
+
+test('computeUnitResistances end-to-end: archetype psionico + trait', () => {
+  const data = loadSpeciesResistances(DEFAULT_SPECIES_RESISTANCES_PATH);
+  const traits = [{ channel: 'fuoco', modifier_pct: 20 }];
+  const result = computeUnitResistances('psionico', data, traits);
+  const byCh = Object.fromEntries(result.map((r) => [r.channel, r.modifier_pct]));
+  assert.equal(byCh.fisico, -20); // psionico.fisico 120 → -20
+  assert.equal(byCh.fuoco, 20); // trait-only, no species entry for fuoco psionico=100
+});
+
+test('computeUnitResistances smoking gun: vulnerability NOT clamped to 0', () => {
+  // Regression guard da balance-auditor spike 2026-04-19
+  const data = loadSpeciesResistances(DEFAULT_SPECIES_RESISTANCES_PATH);
+  const resistances = computeUnitResistances('psionico', data, []);
+  const damage = applyResistance(10, resistances, 'fisico');
+  // psionico vuln fisico: 120 → -20 delta → factor 1.2 → 10*1.2=12
+  assert.equal(damage, 12, `Expected amplify 12, got ${damage}`);
+});
+
+test('computeUnitResistances corazzato resist fisico', () => {
+  const data = loadSpeciesResistances(DEFAULT_SPECIES_RESISTANCES_PATH);
+  const resistances = computeUnitResistances('corazzato', data, []);
+  const damage = applyResistance(10, resistances, 'fisico');
+  // corazzato.fisico: 80 → +20 resist → factor 0.8 → floor(8)
+  assert.equal(damage, 8);
+});


### PR DESCRIPTION
## 🎮 Cosa cambia (POV giocatore)

Il gioco ora può **rispettare le debolezze/resistenze delle creature** per canale di attacco (fisico/fuoco/psionico/ecc.).

**Prima**: tutti gli attacchi danno = stesso danno a tutti.
**Dopo**: attaccare con il canale giusto contro la debolezza della creatura dà più danno (+20%). Attaccare contro la resistenza dà meno (-20%). Scegliere il canale conta.

**Effetto atteso sul tutorial hardcore_06**: win rate scende da 84.6% → ~15-25% (target design band). Evidence spike validato.

## Summary tecnico

- **Nuovo modulo** `apps/backend/services/combat/resistanceEngine.js` (+180 LOC):
  - `loadSpeciesResistances` / `getArchetypeResistances` / `mergeResistances` / `applyResistance` / `computeUnitResistances`
  - Semantic parity con Python `services/rules/resolver.py` (ready per contract test o kill Python)
- **Wire** `apps/backend/routes/session.js::performAttack` (+30 LOC):
  - Load species_resistances.yaml a init (soft fail)
  - Apply resistance post damage calc pre hp
  - Channel da `action.channel` o default "fisico"
  - Target resistances lazy-cached su `target._resistances`
- **Test** `tests/ai/resistanceEngine.test.js` (+21 nuovi test): resist/amplify/clamp/stack/merge/load/end-to-end

## Test plan

- [x] `node --test tests/ai/*.test.js` → **189/189 verdi** (+21 nuovi, 0 regression)
- [x] Backward compat: YAML missing → silent skip
- [x] Backward compat: unit senza archetype → default `adattivo` (neutral, no visible effect finché M6-#2)
- [x] Smoking gun psionico.fisico=120 → damage amplify x1.2 (12 dmg su base 10)

## Follow-up stack

- **M6-#2** (next): campo `resistance_archetype` a species YAML (~45 species) — senza questo il wire resta silente in prod
- **M6-#3**: calibration iter2 hardcore-06 reale (expected 84.6% → 15-25%)
- **M6-#4**: ADR kill `services/rules/` Python engine (user direction: 1 gioco online)
- **M6-#1b**: channel resolution da ability_id/trait (ora default "fisico")

## Guardrail

- Touch `apps/backend/` — scope contained wire, test complete, parity semantic
- Nuovo modulo `services/combat/` consistente con pattern esistente
- Zero touch `services/generation/`, `packages/contracts/`, `migrations/`, workflow

## 03A Rollback

PR revert. Backward compat totale (feature silenziosa senza data M6-#2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)