### PR TITLE
fix(session): M6-#1 hotfix —  undefined scope in resistance wire

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -278,7 +278,12 @@ function createSessionRouter(options = {}) {
             traitResists,
           );
         }
-        const channel = action && typeof action.channel === 'string' ? action.channel : 'fisico';
+        // M6-#1 hotfix: `action` non in scope di performAttack(session, actor, target).
+        // Bug merged #1639 causava ReferenceError silenzioso su ogni attack
+        // (evidence: batch iter2 0 damage/0 win su 10 run). Default "fisico"
+        // hardcoded. Channel routing dinamico via action/ability = M6-#1b
+        // follow-up refactor firma.
+        const channel = 'fisico';
         damageDealt = applyResistance(damageDealt, target._resistances, channel);
       }
       // Consuma guardia solo se parata riuscita (mitigazione cumulativa)


### PR DESCRIPTION
## 🚨 Bug critico production

M6-#1 (#1639) merged con `action.channel` referenziato fuori scope → **ogni attacco enemy ReferenceError silenzioso**. Batch iter2 evidence: N=8, 0% win, 0 damage, 3 rounds stall.

## Fix

Hardcode `const channel = 'fisico'` default. Channel routing dinamico → M6-#1b follow-up.

## Evidence post-fix

Batch iter2b N=10: **50% win rate**, 63.5 avg damage, 33.8 avg turns. Combat works.

## Test plan

- [x] `node --test tests/ai/*.test.js` → 189/189 verdi
- [ ] CI dataset-checks

## Lesson

Stesso pattern del P0 c87e66cc 48h fa (replace_all typo). **Follow-up**: integration test che lancia sessione + verifica damage > 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)