### PR TITLE
feat(session): M6-#1b action.channel routing (unlocks real channel resistance)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -208,7 +208,7 @@ function createSessionRouter(options = {}) {
     };
   }
 
-  function performAttack(session, actor, target) {
+  function performAttack(session, actor, target, action = null) {
     const result = resolveAttack({ actor, target, rng });
     const evaluation = evaluateAttackTraits({
       registry: traitRegistry,
@@ -278,12 +278,11 @@ function createSessionRouter(options = {}) {
             traitResists,
           );
         }
-        // M6-#1 hotfix: `action` non in scope di performAttack(session, actor, target).
-        // Bug merged #1639 causava ReferenceError silenzioso su ogni attack
-        // (evidence: batch iter2 0 damage/0 win su 10 run). Default "fisico"
-        // hardcoded. Channel routing dinamico via action/ability = M6-#1b
-        // follow-up refactor firma.
-        const channel = 'fisico';
+        // M6-#1b: channel routing dinamico via action.channel (post refactor
+        // performAttack firma accetta `action` param). Fallback "fisico"
+        // quando action è null (overwatch lambda) o channel assente.
+        const channel =
+          (action && typeof action.channel === 'string' && action.channel) || 'fisico';
         damageDealt = applyResistance(damageDealt, target._resistances, channel);
       }
       // Consuma guardia solo se parata riuscita (mitigazione cumulativa)

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -322,7 +322,8 @@ function createRoundBridge(deps) {
     const realResolveAction = (state, action, _catalog, _rng) => {
       const next = JSON.parse(JSON.stringify(state));
       if (action.type === 'attack' && action.target_id) {
-        const res = performAttack(session, actor, target);
+        // M6-#1b: passa action per channel routing in performAttack
+        const res = performAttack(session, actor, target, action);
         capturedResults.result = res.result;
         capturedResults.evaluation = res.evaluation;
         capturedResults.damageDealt = res.damageDealt;
@@ -651,7 +652,8 @@ function createRoundBridge(deps) {
         } else {
           const hpBefore = target.hp;
           const targetPosAtk = { ...target.position };
-          const res = performAttack(session, actor, target);
+          // M6-#1b: passa action per channel routing
+          const res = performAttack(session, actor, target, action);
           actor.ap_remaining = Math.max(
             0,
             (actor.ap_remaining ?? actor.ap) - Number(action.ap_cost || 1),
@@ -893,7 +895,8 @@ function createRoundBridge(deps) {
         } else {
           const hpBefore = target.hp;
           const targetPosAtk = { ...target.position };
-          const res = performAttack(session, actor, target);
+          // M6-#1b: passa action per channel routing
+          const res = performAttack(session, actor, target, action);
           actor.ap_remaining = Math.max(
             0,
             (actor.ap_remaining ?? actor.ap) - Number(action.ap_cost || 1),


### PR DESCRIPTION
## 🎮 Cosa cambia (POV giocatore)

**Finalmente il canale dell'attacco conta**.

Ogni abilità dichiara il suo canale (fisico/fuoco/psionico/gelo/ecc.). Il motore resistenza (M6-#1) ora riceve il canale giusto per ogni attacco → calcolo corretto resist/vuln.

**Scenario concreto**:
- Usi ability canale `psionico` contro Corazzato (vuln psionico) → **danno amplificato x1.2**
- Usi ability canale `fisico` contro Corazzato (resist fisico) → **danno ridotto x0.8**
- **La scelta tattica conta** davvero

Prima di M6-#1b: tutti attacchi erano "fisico" default → solo corazzato subiva il calcolo.
Dopo: tutti e 5 gli archetipi (corazzato/bioelettrico/psionico/termico/adattivo) partecipano attivamente.

## Summary tecnico

- Firma `performAttack` ora accetta `action` param opzionale (default null = backward compat)
- Channel resolution: `action?.channel || 'fisico'` fallback
- 5 call sites aggiornati:
  - 3 in sessionRoundBridge.js passano action
  - 2 overwatch lambda (session.js) passano null → default fisico (overwatch non ha ability context)

## Test plan

- [x] 189/189 Node AI verdi
- [x] Backward compat (null action → fallback fisico preservato)
- [ ] CI stack-quality
- [ ] Iter3 calibration post-merge (expected 50% → 30-40% + defeat reali)

## Unlocks

- **Iter3 real calibration** (resistance per canale live)
- Encounter design con match-up specifici
- Tactical reward scegliere canale giusto

## 03A Rollback

Revert PR. Firma torna `(session, actor, target)`. Default fisico preserva.

🤖 Generated with [Claude Code](https://claude.com/claude-code)