### PR TITLE
feat(playtest): M7 HUD feedback button + backend collection (demo ngrok)

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -18,6 +18,7 @@ const { createTraitRouter } = require('./routes/traits');
 const { createQualityRouter } = require('./routes/quality');
 const { createValidatorsRouter } = require('./routes/validators');
 const { createSessionRouter } = require('./routes/session');
+const { createFeedbackRouter } = require('./routes/feedback');
 const { createPartyRouter } = require('./routes/party');
 const { createNebulaTelemetryAggregator } = require('./services/nebulaTelemetryAggregator');
 const { createReleaseReporter } = require('./services/releaseReporter');
@@ -680,6 +681,8 @@ function createApp(options = {}) {
   // Stato in memoria, log eventi su disco in logs/session_*.json.
   app.use('/api/session', createSessionRouter(options.session || {}));
   app.use('/api/party', createPartyRouter());
+  // M7 demo playtest: feedback collection (/api/feedback, /api/feedback/summary)
+  app.use('/api', createFeedbackRouter(options.feedback || {}));
 
   app.get('/api/deployments/status', async (req, res) => {
     try {

--- a/apps/backend/routes/feedback.js
+++ b/apps/backend/routes/feedback.js
@@ -1,0 +1,102 @@
+// Feedback collection endpoint — M7 demo playtest (2026-04-20).
+//
+// POST /api/feedback → salva feedback utente a logs/feedback/*.json
+// Supporta 2 shape:
+//   { kind: 'freetext', text: '...', session_id?, player_name? }
+//   { kind: 'form', answers: {q1: 'val', q2: 'val', ...}, session_id?, player_name? }
+//
+// Aggiunge metadata automatici: timestamp, client_ip (hashed), user_agent.
+// Storage flat file: 1 file JSON per feedback, facilmente zip-pable post demo.
+
+'use strict';
+
+const path = require('node:path');
+const fs = require('node:fs/promises');
+const crypto = require('node:crypto');
+const { Router } = require('express');
+
+function sanitize(str, maxLen = 5000) {
+  if (typeof str !== 'string') return '';
+  return str.slice(0, maxLen).trim();
+}
+
+function hashIp(ip) {
+  // One-way hash for anonymization (salt fisso, non reversibile)
+  return crypto
+    .createHash('sha256')
+    .update(`evo-tactics-demo:${ip || 'unknown'}`)
+    .digest('hex')
+    .slice(0, 16);
+}
+
+function createFeedbackRouter(options = {}) {
+  const router = Router();
+  const repoRoot = path.resolve(__dirname, '..', '..', '..');
+  const feedbackDir = options.feedbackDir || path.join(repoRoot, 'logs', 'feedback');
+
+  // POST /api/feedback — submit feedback
+  router.post('/feedback', async (req, res) => {
+    try {
+      const body = req.body || {};
+      const kind = body.kind === 'form' ? 'form' : 'freetext';
+
+      const entry = {
+        timestamp: new Date().toISOString(),
+        kind,
+        player_name: sanitize(body.player_name, 100) || 'anonymous',
+        session_id: sanitize(body.session_id, 64) || null,
+        client_hash: hashIp(req.headers['x-forwarded-for'] || req.ip || req.socket?.remoteAddress),
+        user_agent: sanitize(req.headers['user-agent'], 500),
+      };
+
+      if (kind === 'freetext') {
+        entry.text = sanitize(body.text, 10000);
+        if (!entry.text) {
+          return res.status(400).json({ error: 'text vuoto' });
+        }
+      } else {
+        const answers = body.answers && typeof body.answers === 'object' ? body.answers : {};
+        entry.answers = {};
+        for (const [k, v] of Object.entries(answers)) {
+          entry.answers[sanitize(k, 100)] = sanitize(String(v || ''), 5000);
+        }
+        if (Object.keys(entry.answers).length === 0) {
+          return res.status(400).json({ error: 'answers vuoto' });
+        }
+      }
+
+      await fs.mkdir(feedbackDir, { recursive: true });
+      const filename = `${entry.timestamp.replace(/[:.]/g, '-')}_${kind}_${entry.client_hash}.json`;
+      const filepath = path.join(feedbackDir, filename);
+      await fs.writeFile(filepath, JSON.stringify(entry, null, 2), 'utf8');
+
+      return res.json({
+        status: 'ok',
+        message: 'Grazie! Feedback ricevuto.',
+        filename,
+      });
+    } catch (err) {
+      console.error('[feedback] error:', err);
+      return res.status(500).json({ error: 'internal error' });
+    }
+  });
+
+  // GET /api/feedback/summary — admin dashboard simple
+  router.get('/feedback/summary', async (_req, res) => {
+    try {
+      const files = await fs.readdir(feedbackDir).catch(() => []);
+      const jsonFiles = files.filter((f) => f.endsWith('.json'));
+      return res.json({
+        count: jsonFiles.length,
+        feedback_dir: feedbackDir,
+        latest: jsonFiles.slice(-10),
+      });
+    } catch (err) {
+      return res.status(500).json({ error: err.message });
+    }
+  });
+
+  return router;
+}
+
+module.exports = { createFeedbackRouter };

--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -94,6 +94,27 @@
             </svg>
             <span class="hud-label">Aiuto</span>
           </button>
+          <button
+            id="feedback-open"
+            class="hud-btn hud-btn-primary"
+            title="Invia feedback / report — raccolta playtest"
+          >
+            <svg
+              class="hud-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path
+                d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"
+              />
+            </svg>
+            <span class="hud-label">📣 Feedback</span>
+          </button>
         </div>
       </header>
       <main>
@@ -140,6 +161,116 @@
         <span id="selected-hint">Seleziona una tua unità per vedere azioni.</span>
         <button id="cancel-pending" class="hidden">✕ Annulla ability</button>
       </footer>
+      <!-- M7 demo feedback modal — playtest collection (2026-04-20) -->
+      <div id="feedback-overlay" class="hidden">
+        <div class="feedback-card">
+          <div class="feedback-header">
+            <h2>📣 Feedback playtest</h2>
+            <button id="feedback-close" class="feedback-close">✕</button>
+          </div>
+          <p class="feedback-intro">
+            Grazie per aver provato il gioco! Il tuo feedback è prezioso. Scegli un formato:
+          </p>
+          <div class="feedback-tabs">
+            <button id="feedback-tab-form" class="feedback-tab active">
+              📋 Form rapido (1 min)
+            </button>
+            <button id="feedback-tab-freetext" class="feedback-tab">✍️ Scrittura libera</button>
+          </div>
+          <div id="feedback-player-row">
+            <label
+              >Nome (opzionale):
+              <input
+                type="text"
+                id="feedback-player-name"
+                placeholder="Es. Marco"
+                maxlength="100"
+              />
+            </label>
+          </div>
+          <!-- FORM MODE -->
+          <div id="feedback-form-content" class="feedback-content">
+            <div class="feedback-q">
+              <label>1. Come ti è sembrato il gioco?</label>
+              <div class="feedback-rating" data-q="fun_rating">
+                <button class="rating-btn" data-value="1">😞 1</button>
+                <button class="rating-btn" data-value="2">😐 2</button>
+                <button class="rating-btn" data-value="3">🙂 3</button>
+                <button class="rating-btn" data-value="4">😃 4</button>
+                <button class="rating-btn" data-value="5">🤩 5</button>
+              </div>
+            </div>
+            <div class="feedback-q">
+              <label>2. Difficoltà percepita:</label>
+              <div class="feedback-choice" data-q="difficulty">
+                <button class="choice-btn" data-value="troppo_facile">Troppo facile</button>
+                <button class="choice-btn" data-value="giusta">Giusta</button>
+                <button class="choice-btn" data-value="troppo_difficile">Troppo difficile</button>
+              </div>
+            </div>
+            <div class="feedback-q">
+              <label>3. Il combat aveva tensione/rischio reale?</label>
+              <div class="feedback-choice" data-q="tension">
+                <button class="choice-btn" data-value="si">Sì</button>
+                <button class="choice-btn" data-value="a_tratti">A tratti</button>
+                <button class="choice-btn" data-value="no_stallo">No, stallava</button>
+              </div>
+            </div>
+            <div class="feedback-q">
+              <label>4. Hai notato differenze tra canali di attacco (fisico/psionico/ecc.)?</label>
+              <div class="feedback-choice" data-q="channels_felt">
+                <button class="choice-btn" data-value="si_chiaro">Sì, chiaramente</button>
+                <button class="choice-btn" data-value="si_vago">Un po'</button>
+                <button class="choice-btn" data-value="no">No</button>
+              </div>
+            </div>
+            <div class="feedback-q">
+              <label>5. Cosa ti è piaciuto di più? (opzionale)</label>
+              <textarea
+                id="fb-q-liked"
+                class="feedback-textarea"
+                rows="2"
+                placeholder="Scrivi liberamente..."
+              ></textarea>
+            </div>
+            <div class="feedback-q">
+              <label>6. Cosa miglioreresti? (opzionale)</label>
+              <textarea
+                id="fb-q-improve"
+                class="feedback-textarea"
+                rows="2"
+                placeholder="Scrivi liberamente..."
+              ></textarea>
+            </div>
+            <div class="feedback-q">
+              <label>7. Bug o problemi riscontrati? (opzionale)</label>
+              <textarea
+                id="fb-q-bugs"
+                class="feedback-textarea"
+                rows="2"
+                placeholder="Descrivi il problema..."
+              ></textarea>
+            </div>
+          </div>
+          <!-- FREETEXT MODE -->
+          <div id="feedback-freetext-content" class="feedback-content hidden">
+            <div class="feedback-q">
+              <label>Racconta tutto quello che vuoi sul gioco:</label>
+              <textarea
+                id="fb-freetext"
+                class="feedback-textarea feedback-textarea-large"
+                rows="12"
+                placeholder="Sensazioni generali, momenti divertenti, frustrazioni, bug, suggerimenti..."
+              ></textarea>
+            </div>
+          </div>
+          <div class="feedback-actions">
+            <button id="feedback-submit" class="feedback-submit">📤 Invia feedback</button>
+            <div id="feedback-status" class="feedback-status"></div>
+          </div>
+        </div>
+      </div>
+
       <div id="endgame-overlay" class="hidden">
         <div class="endgame-card">
           <h2 id="endgame-title">—</h2>

--- a/apps/play/src/feedbackPanel.js
+++ b/apps/play/src/feedbackPanel.js
@@ -1,0 +1,174 @@
+// M7 feedback panel — playtest collection (2026-04-20)
+// Gestisce modal feedback con 2 modes: form rapido (7 questions) + freetext.
+
+'use strict';
+
+const STATE = {
+  mode: 'form', // 'form' | 'freetext'
+  formAnswers: {},
+  overlayEl: null,
+  sessionIdGetter: null,
+};
+
+function showStatus(el, msg, type = 'info') {
+  el.textContent = msg;
+  el.className = `feedback-status ${type}`;
+}
+
+function setSelected(container, value) {
+  container.querySelectorAll('.rating-btn, .choice-btn').forEach((btn) => {
+    btn.classList.toggle('selected', btn.dataset.value === value);
+  });
+}
+
+function wireRatingsAndChoices(card) {
+  card.querySelectorAll('.feedback-rating, .feedback-choice').forEach((container) => {
+    const q = container.dataset.q;
+    container.querySelectorAll('.rating-btn, .choice-btn').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        STATE.formAnswers[q] = btn.dataset.value;
+        setSelected(container, btn.dataset.value);
+      });
+    });
+  });
+}
+
+function switchTab(mode) {
+  STATE.mode = mode;
+  const tabForm = document.getElementById('feedback-tab-form');
+  const tabFree = document.getElementById('feedback-tab-freetext');
+  const contentForm = document.getElementById('feedback-form-content');
+  const contentFree = document.getElementById('feedback-freetext-content');
+  tabForm.classList.toggle('active', mode === 'form');
+  tabFree.classList.toggle('active', mode === 'freetext');
+  contentForm.classList.toggle('hidden', mode !== 'form');
+  contentFree.classList.toggle('hidden', mode !== 'freetext');
+}
+
+function buildPayload() {
+  const playerName = document.getElementById('feedback-player-name').value.trim();
+  const sessionId = STATE.sessionIdGetter ? STATE.sessionIdGetter() : null;
+  const base = {
+    player_name: playerName || 'anonymous',
+    session_id: sessionId || null,
+  };
+
+  if (STATE.mode === 'freetext') {
+    return {
+      ...base,
+      kind: 'freetext',
+      text: document.getElementById('fb-freetext').value.trim(),
+    };
+  }
+
+  const answers = { ...STATE.formAnswers };
+  const likedEl = document.getElementById('fb-q-liked');
+  const improveEl = document.getElementById('fb-q-improve');
+  const bugsEl = document.getElementById('fb-q-bugs');
+  if (likedEl.value.trim()) answers.liked = likedEl.value.trim();
+  if (improveEl.value.trim()) answers.improve = improveEl.value.trim();
+  if (bugsEl.value.trim()) answers.bugs = bugsEl.value.trim();
+
+  return { ...base, kind: 'form', answers };
+}
+
+async function submit() {
+  const submitBtn = document.getElementById('feedback-submit');
+  const statusEl = document.getElementById('feedback-status');
+  const payload = buildPayload();
+
+  // Validazione basic
+  if (STATE.mode === 'freetext' && !payload.text) {
+    showStatus(statusEl, 'Scrivi qualcosa prima di inviare.', 'error');
+    return;
+  }
+  if (STATE.mode === 'form' && Object.keys(payload.answers).length === 0) {
+    showStatus(statusEl, 'Rispondi almeno a una domanda.', 'error');
+    return;
+  }
+
+  submitBtn.disabled = true;
+  showStatus(statusEl, 'Invio in corso...', 'info');
+
+  try {
+    const res = await fetch('/api/feedback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (res.ok) {
+      showStatus(statusEl, `✅ ${data.message || 'Grazie per il feedback!'}`, 'success');
+      // Reset form dopo 2s
+      setTimeout(() => {
+        document.getElementById('feedback-overlay').classList.add('hidden');
+        resetForm();
+      }, 2000);
+    } else {
+      showStatus(statusEl, `❌ Errore: ${data.error || 'invio fallito'}`, 'error');
+      submitBtn.disabled = false;
+    }
+  } catch (err) {
+    showStatus(statusEl, `❌ Network: ${err.message}`, 'error');
+    submitBtn.disabled = false;
+  }
+}
+
+function resetForm() {
+  STATE.formAnswers = {};
+  document.getElementById('feedback-submit').disabled = false;
+  document.getElementById('fb-freetext').value = '';
+  document.getElementById('fb-q-liked').value = '';
+  document.getElementById('fb-q-improve').value = '';
+  document.getElementById('fb-q-bugs').value = '';
+  document.getElementById('feedback-player-name').value = '';
+  document.getElementById('feedback-status').textContent = '';
+  document.querySelectorAll('.rating-btn.selected, .choice-btn.selected').forEach((btn) => {
+    btn.classList.remove('selected');
+  });
+  switchTab('form');
+}
+
+function openOverlay() {
+  STATE.overlayEl.classList.remove('hidden');
+}
+
+function closeOverlay() {
+  STATE.overlayEl.classList.add('hidden');
+}
+
+/**
+ * Init feedback panel — wire button + modal events.
+ * @param {object} options
+ * @param {function} options.getSessionId — ritorna current session_id (per log link)
+ */
+export function initFeedbackPanel(options = {}) {
+  STATE.sessionIdGetter = options.getSessionId || (() => null);
+  STATE.overlayEl = document.getElementById('feedback-overlay');
+  if (!STATE.overlayEl) {
+    console.warn('[feedback] overlay element missing in DOM');
+    return;
+  }
+
+  document.getElementById('feedback-open')?.addEventListener('click', openOverlay);
+  document.getElementById('feedback-close')?.addEventListener('click', closeOverlay);
+  document.getElementById('feedback-tab-form')?.addEventListener('click', () => switchTab('form'));
+  document
+    .getElementById('feedback-tab-freetext')
+    ?.addEventListener('click', () => switchTab('freetext'));
+  document.getElementById('feedback-submit')?.addEventListener('click', submit);
+
+  // Close su ESC
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && !STATE.overlayEl.classList.contains('hidden')) {
+      closeOverlay();
+    }
+  });
+
+  // Close su click overlay (fuori dalla card)
+  STATE.overlayEl.addEventListener('click', (e) => {
+    if (e.target === STATE.overlayEl) closeOverlay();
+  });
+
+  wireRatingsAndChoices(STATE.overlayEl);
+}

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -18,6 +18,7 @@ import { sfx, setMuted, isMuted } from './sfx.js';
 import { initHelpPanel } from './helpPanel.js';
 import { showTip, buildRecoveryTipMessage, resetAllTips } from './tips.js';
 import { toggleCodex } from './codexPanel.js';
+import { initFeedbackPanel } from './feedbackPanel.js';
 
 const state = {
   sid: null,
@@ -1232,6 +1233,8 @@ async function loadModulations() {
 
 // M4 P0 W2 — Help panel (? key, top-right button, auto-open prima sessione)
 initHelpPanel('help-open');
+// M7 feedback panel — playtest collection
+initFeedbackPanel({ getSessionId: () => state.sid });
 
 // W8O — Resize listener: redraw canvas quando viewport cambia (CELL dinamico).
 let _resizeTimeout = null;

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -1799,3 +1799,269 @@ body.ability-target-mode canvas#grid {
   border-left-width: 5px;
   border-left-color: #d32f2f; /* dark-red */
 }
+
+/* ═══ M7 Feedback modal (2026-04-20) ═══ */
+
+.hud-btn-primary {
+  background: linear-gradient(135deg, #2e7d32, #1b5e20);
+  color: #fff;
+  font-weight: 700;
+  box-shadow: 0 0 12px rgba(76, 175, 80, 0.4);
+  border: 2px solid #4caf50;
+}
+
+.hud-btn-primary:hover {
+  background: linear-gradient(135deg, #388e3c, #2e7d32);
+  box-shadow: 0 0 18px rgba(76, 175, 80, 0.6);
+}
+
+#feedback-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  padding: 20px;
+  overflow-y: auto;
+}
+
+#feedback-overlay.hidden {
+  display: none;
+}
+
+.feedback-card {
+  background: #1e1e2a;
+  border: 2px solid #4caf50;
+  border-radius: 12px;
+  padding: 24px;
+  max-width: 680px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  color: #e0e0e0;
+  font-family: 'Inter', 'Noto Sans', sans-serif;
+}
+
+.feedback-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.feedback-header h2 {
+  margin: 0;
+  color: #81c784;
+  font-size: 1.5em;
+}
+
+.feedback-close {
+  background: transparent;
+  border: 1px solid #555;
+  color: #aaa;
+  font-size: 1.2em;
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.feedback-close:hover {
+  background: #333;
+  color: #fff;
+}
+
+.feedback-intro {
+  margin: 8px 0 16px;
+  color: #bbb;
+  font-size: 0.95em;
+}
+
+.feedback-tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid #333;
+  padding-bottom: 12px;
+}
+
+.feedback-tab {
+  flex: 1;
+  background: #2a2a38;
+  border: 1px solid #444;
+  color: #bbb;
+  padding: 10px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.95em;
+  transition: all 0.2s;
+}
+
+.feedback-tab:hover {
+  background: #353548;
+  color: #fff;
+}
+
+.feedback-tab.active {
+  background: #2e7d32;
+  border-color: #4caf50;
+  color: #fff;
+  font-weight: 600;
+}
+
+#feedback-player-row {
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #333;
+}
+
+#feedback-player-row label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.95em;
+}
+
+#feedback-player-name {
+  flex: 1;
+  background: #2a2a38;
+  border: 1px solid #444;
+  color: #fff;
+  padding: 8px 10px;
+  border-radius: 6px;
+  font-size: 0.95em;
+  max-width: 300px;
+}
+
+.feedback-content.hidden {
+  display: none;
+}
+
+.feedback-q {
+  margin-bottom: 16px;
+}
+
+.feedback-q label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: #81c784;
+}
+
+.feedback-rating,
+.feedback-choice {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.rating-btn,
+.choice-btn {
+  background: #2a2a38;
+  border: 1px solid #444;
+  color: #ddd;
+  padding: 8px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.95em;
+  transition: all 0.2s;
+}
+
+.rating-btn:hover,
+.choice-btn:hover {
+  background: #353548;
+  border-color: #666;
+}
+
+.rating-btn.selected,
+.choice-btn.selected {
+  background: #2e7d32;
+  border-color: #4caf50;
+  color: #fff;
+  font-weight: 600;
+}
+
+.feedback-textarea {
+  width: 100%;
+  background: #2a2a38;
+  border: 1px solid #444;
+  color: #fff;
+  padding: 10px;
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 0.95em;
+  resize: vertical;
+}
+
+.feedback-textarea:focus {
+  outline: none;
+  border-color: #4caf50;
+}
+
+.feedback-textarea-large {
+  min-height: 200px;
+}
+
+.feedback-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid #333;
+}
+
+.feedback-submit {
+  background: linear-gradient(135deg, #2e7d32, #1b5e20);
+  border: 2px solid #4caf50;
+  color: #fff;
+  padding: 12px 24px;
+  border-radius: 8px;
+  font-size: 1em;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.feedback-submit:hover {
+  background: linear-gradient(135deg, #388e3c, #2e7d32);
+  box-shadow: 0 0 18px rgba(76, 175, 80, 0.6);
+}
+
+.feedback-submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.feedback-status {
+  flex: 1;
+  font-size: 0.9em;
+  color: #aaa;
+}
+
+.feedback-status.success {
+  color: #81c784;
+  font-weight: 600;
+}
+
+.feedback-status.error {
+  color: #ff6b6b;
+  font-weight: 600;
+}
+
+@media (max-width: 600px) {
+  .feedback-card {
+    padding: 16px;
+  }
+  .feedback-tab {
+    font-size: 0.85em;
+    padding: 8px;
+  }
+  .rating-btn,
+  .choice-btn {
+    font-size: 0.85em;
+    padding: 6px 10px;
+  }
+}

--- a/apps/play/vite.config.js
+++ b/apps/play/vite.config.js
@@ -14,6 +14,9 @@ export default defineConfig({
     // Allow import da data/art/ (M3.9-M3.10 assets) fuori apps/play/.
     // M4 step A integration: render.js può import faction SVG + tileset PNG.
     fs: { allow: [repoRoot] },
+    // M7 demo ngrok: allow tunnel host. `true` = skip DNS rebinding check.
+    // Solo per demo playtest — no auth gate, non-production.
+    allowedHosts: true,
     proxy: {
       '/api': {
         target: 'http://localhost:3334',


### PR DESCRIPTION
## 🎮 Cosa aggiunge

**Bottone verde 📣 Feedback** nell'HUD (dopo "Aiuto"). Amici playtester possono inviare:
- **Form 7 domande** (1 min): rating, difficoltà, tensione, canali, liked/improve/bugs
- **Scrittura libera**: textarea grande

Backend scrive file JSON in `logs/feedback/` per ogni submit. Post-demo zip folder → review.

## Files

- `apps/backend/routes/feedback.js` nuovo + mount in app.js
- `apps/play/index.html`: bottone + modal
- `apps/play/src/feedbackPanel.js` nuovo (+180 LOC)
- `apps/play/src/style.css`: modal styling (dark + green accent)
- `apps/play/src/main.js`: init wire
- `apps/play/vite.config.js`: `allowedHosts: true` (tunnel ngrok)

## Test E2E ✅

- Local POST `/api/feedback` freetext → 200 + file scritto
- E2E via ngrok URL pubblico → 200 + file scritto
- Form validation OK
- Sanitize (maxLen) attivo
- IP anonimizzato (SHA256 hash 16-char)

## Demo live

URL attivo: `https://average-residency-economic.ngrok-free.dev`

Backend 3334 + Vite 5180 + ngrok tunnel = stack pronto per condivisione amici.

## Post-demo analisi

```bash
zip -r playtest_2026-04-20.zip logs/feedback/
# Review 1 file per submission + aggregate stats
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)