### PR TITLE
fix(play): tooltip z-index + boundary (M7 demo user feedback)

### DIFF
--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -441,9 +441,26 @@ canvas.addEventListener('mousemove', (ev) => {
     return;
   }
   tooltipEl.innerHTML = buildUnitTooltip(unit);
-  tooltipEl.style.left = `${ev.clientX + 14}px`;
-  tooltipEl.style.top = `${ev.clientY + 14}px`;
+  // M7 fix: boundary-aware positioning. Se tooltip esce da viewport
+  // riposiziona a sx/sopra del cursore. Evita clip dietro canvas/panels.
   tooltipEl.classList.remove('hidden');
+  const ttRect = tooltipEl.getBoundingClientRect();
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  const offset = 14;
+  let left = ev.clientX + offset;
+  let top = ev.clientY + offset;
+  if (left + ttRect.width + 8 > vw) {
+    left = ev.clientX - ttRect.width - offset;
+  }
+  if (top + ttRect.height + 8 > vh) {
+    top = ev.clientY - ttRect.height - offset;
+  }
+  // Clamp a viewport minima
+  left = Math.max(8, left);
+  top = Math.max(8, top);
+  tooltipEl.style.left = `${left}px`;
+  tooltipEl.style.top = `${top}px`;
 });
 
 canvas.addEventListener('mouseleave', () => {

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -1647,10 +1647,12 @@ body.ability-target-mode canvas#grid {
 }
 
 /* W2.5 — Unit hover tooltip (floating) */
+/* M7 fix: z-index era 90 → nascosto dietro panels (100-9000+). Bump a 9700
+   per stare sopra panels/overlays ma sotto feedback modal (9999) + endgame. */
 .unit-tooltip {
   position: fixed;
-  z-index: 90;
-  background: rgba(0, 0, 0, 0.92);
+  z-index: 9700;
+  background: rgba(0, 0, 0, 0.95);
   border: 1px solid var(--accent);
   color: var(--fg);
   padding: 8px 12px;
@@ -1659,7 +1661,7 @@ body.ability-target-mode canvas#grid {
   pointer-events: none;
   max-width: 280px;
   line-height: 1.4;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.8);
 }
 .unit-tooltip.hidden {
   display: none;


### PR DESCRIPTION
## 🎮 Bug user feedback

> "i tooltip a volte si nascondono dietro quello che vogliono mostrare diventando illegibili"

## Root cause

1. `.unit-tooltip` z-index **90** → coperto da panels (100-200), overlays (9000+), endgame (9999)
2. Posizionamento sempre `clientX+14, clientY+14` → near right/bottom edge = tooltip uscito viewport

## Fix

- **z-index 90 → 9700** (sopra panels/overlays, sotto modal 9999)
- **Boundary-aware positioning**: se tooltip uscirebbe viewport, ripos. a sx/sopra cursore. Clamp minimo 8px dal bordo.
- Contrast bump: bg opacity 0.92 → 0.95

## Test

- Tooltip visibile crowded grid hardcore-06 8p
- No clip su bordo dx/basso
- Sopra ability-bar + HUD buttons
- Sotto feedback modal quando aperto

🤖 Generated with [Claude Code](https://claude.com/claude-code)