### PR TITLE
feat(balance): M7-#2 Phase B — damage curves runtime wiring (session + enrage)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -53,6 +53,14 @@ const { createDeclareSistemaIntents } = require('../services/ai/declareSistemaIn
 const { loadAiProfiles } = require('../services/ai/aiProfilesLoader');
 const { createAbilityExecutor } = require('../services/abilityExecutor');
 const reactionEngine = require('../services/reactionEngine');
+// M7-#2 Phase B: damage scaling curves runtime (ADR-2026-04-20).
+const {
+  loadDamageCurves,
+  getEncounterClass,
+  applyEnemyDamageMultiplier,
+  shouldEnrageBoss,
+  getEnrageModBonus,
+} = require('../services/balance/damageCurves');
 // M6-#1 (ADR-2026-04-19 + spike 2026-04-19): Node native resistance engine.
 // Applica channel-specific resist/vuln su damage pre-hp. Evidence spike:
 // 84.6% → 20% win rate hardcore-06 con flat 50% resist (leva confermata).
@@ -209,6 +217,28 @@ function createSessionRouter(options = {}) {
   }
 
   function performAttack(session, actor, target, action = null) {
+    // M7-#2 Phase B: boss enrage check. Se actor è boss tier + HP < threshold
+    // per encounter class → temporary mod bonus (non-persistente).
+    // Identificazione boss: id contains "_boss" OR actor.tier === 'boss'.
+    let enrageApplied = false;
+    let enrageModBonus = 0;
+    try {
+      const actorIsBoss =
+        (actor && typeof actor.id === 'string' && /_boss\b/.test(actor.id)) ||
+        actor?.tier === 'boss';
+      if (actorIsBoss && session?.encounter_class) {
+        if (shouldEnrageBoss(actor, session.encounter_class)) {
+          enrageModBonus = getEnrageModBonus();
+          if (enrageModBonus > 0) {
+            actor.mod = Number(actor.mod || 0) + enrageModBonus;
+            enrageApplied = true;
+          }
+        }
+      }
+    } catch (err) {
+      // non-blocking: se curves missing, no enrage
+    }
+
     const result = resolveAttack({ actor, target, rng });
     const evaluation = evaluateAttackTraits({
       registry: traitRegistry,
@@ -216,6 +246,11 @@ function createSessionRouter(options = {}) {
       target,
       attackResult: result,
     });
+
+    // Revert enrage bonus post-attack (non-persistente, solo per questo hit)
+    if (enrageApplied) {
+      actor.mod = Number(actor.mod || 0) - enrageModBonus;
+    }
     let damageDealt = 0;
     let killOccurred = false;
     let adjacencyBonus = 0;
@@ -683,6 +718,28 @@ function createSessionRouter(options = {}) {
         // best-effort: se config non carica, skip profile scaling
       }
 
+      // M7-#2 Phase B: apply damage scaling curves per encounter class.
+      // Lo YAML damage_curves.yaml definisce enemy_damage_multiplier per class.
+      // Encounter senza class dichiarato → fallback "standard" (1.2x).
+      // Idempotente: se class=tutorial (multiplier 1.0) no-op.
+      let encounterClassUsed = null;
+      try {
+        const curves = loadDamageCurves();
+        if (curves) {
+          const encCls = getEncounterClass(req.body, curves);
+          encounterClassUsed = encCls;
+          units = units.map((u) => {
+            if (!u) return u;
+            if (u.controlled_by !== 'sistema') return u;
+            const clone = { ...u };
+            applyEnemyDamageMultiplier(clone, encCls, curves);
+            return clone;
+          });
+        }
+      } catch (err) {
+        console.warn('[damage-curves] apply failed:', err.message);
+      }
+
       // ADR-2026-04-17: grid auto-scale basato su deployed PG count (party.yaml)
       let gridW = GRID_SIZE;
       let gridH = GRID_SIZE;
@@ -713,6 +770,8 @@ function createSessionRouter(options = {}) {
       const session = {
         session_id: sessionId,
         scenario_id: scenarioId,
+        // M7-#2 Phase B: persist encounter class per enrage check runtime
+        encounter_class: encounterClassUsed || 'standard',
         pressure_start: pressureStart,
         pressure: pressureStart,
         turn: 1,

--- a/apps/backend/services/balance/damageCurves.js
+++ b/apps/backend/services/balance/damageCurves.js
@@ -1,0 +1,135 @@
+// M7-#2 Phase B — damage curves loader + apply pipeline.
+//
+// Runtime consumer di data/core/balance/damage_curves.yaml (ADR-2026-04-20).
+// Funzioni:
+//   - loadDamageCurves(path): carica YAML singleton, cache in-memory
+//   - getEncounterClass(encounter): estrae class da encounter.encounter_class
+//     fallback "standard"
+//   - applyEnemyDamageMultiplier(unit, encounterClass): scale unit.mod
+//   - shouldEnrageBoss(boss, encounterClass): boolean se boss HP < threshold
+//   - getEnrageModBonus(encounterClass): bonus mod da applicare on enrage
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const DEFAULT_PATH = path.join(process.cwd(), 'data', 'core', 'balance', 'damage_curves.yaml');
+
+const DEFAULT_CLASS = 'standard';
+
+let _cached = null;
+
+/**
+ * Load + cache damage_curves.yaml. Idempotente (subsequent calls ritornano cached).
+ * Soft-fail se missing (ritorna null → consumer usano defaults fallback).
+ */
+function loadDamageCurves(filePath = DEFAULT_PATH) {
+  if (_cached !== null) return _cached;
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    _cached = yaml.load(raw);
+    return _cached;
+  } catch (err) {
+    console.warn(`[damage-curves] non caricato (${err.message}). Default multiplier=1.0`);
+    _cached = null;
+    return null;
+  }
+}
+
+/** Reset cache (per test). */
+function _resetCache() {
+  _cached = null;
+}
+
+/**
+ * Estrae encounter class da config encounter.
+ * Fallback "standard" se campo assente o class non esiste nel YAML.
+ */
+function getEncounterClass(encounter, curves = null) {
+  if (!encounter) return DEFAULT_CLASS;
+  const raw = encounter.encounter_class || encounter.encounter_class_id || DEFAULT_CLASS;
+  const data = curves || loadDamageCurves();
+  if (!data || !data.encounter_classes || !data.encounter_classes[raw]) {
+    return DEFAULT_CLASS;
+  }
+  return raw;
+}
+
+/**
+ * Apply enemy_damage_multiplier to unit.mod.
+ * Static application: unit.mod modificato una volta durante session init.
+ * Round floor (damage deve essere int).
+ *
+ * @returns {boolean} true se mod modificato
+ */
+function applyEnemyDamageMultiplier(unit, encounterClass, curves = null) {
+  if (!unit) return false;
+  const data = curves || loadDamageCurves();
+  if (!data) return false;
+  const cls = data.encounter_classes[encounterClass];
+  if (!cls) return false;
+  const mult = Number(cls.enemy_damage_multiplier) || 1.0;
+  if (mult === 1.0) return false;
+  const before = Number(unit.mod || 0);
+  unit.mod = Math.round(before * mult);
+  unit._mod_base = before; // track per debug / possible revert
+  unit._mod_multiplier_applied = mult;
+  return true;
+}
+
+/**
+ * Check se boss deve enrage basato su hp corrente vs threshold class.
+ * Enrage attivato quando hp_current / hp_max < threshold_hp.
+ *
+ * @param {object} boss unit (hp, max_hp)
+ * @param {string} encounterClass
+ * @param {object} curves optional (dependency injection)
+ * @returns {boolean}
+ */
+function shouldEnrageBoss(boss, encounterClass, curves = null) {
+  if (!boss || !boss.max_hp) return false;
+  const data = curves || loadDamageCurves();
+  if (!data) return false;
+  const cls = data.encounter_classes[encounterClass];
+  if (!cls || cls.boss_enrage_threshold_hp === null || cls.boss_enrage_threshold_hp === undefined) {
+    return false;
+  }
+  const ratio = Number(boss.hp || 0) / Number(boss.max_hp);
+  return ratio < Number(cls.boss_enrage_threshold_hp);
+}
+
+/**
+ * Bonus mod aggiunto su attack quando boss enrage.
+ * Da damage_curves.yaml enemy_tiers.boss.enrage_mod_bonus.
+ */
+function getEnrageModBonus(curves = null) {
+  const data = curves || loadDamageCurves();
+  if (!data || !data.enemy_tiers || !data.enemy_tiers.boss) return 0;
+  return Number(data.enemy_tiers.boss.enrage_mod_bonus) || 0;
+}
+
+/**
+ * Estrae target_bands per una class (consumed da calibration harness).
+ * @returns {object|null} {win_rate, defeat_rate, timeout_rate} o null
+ */
+function getTargetBands(encounterClass, curves = null) {
+  const data = curves || loadDamageCurves();
+  if (!data || !data.encounter_classes) return null;
+  const cls = data.encounter_classes[encounterClass];
+  if (!cls || !cls.target_bands) return null;
+  return cls.target_bands;
+}
+
+module.exports = {
+  loadDamageCurves,
+  getEncounterClass,
+  applyEnemyDamageMultiplier,
+  shouldEnrageBoss,
+  getEnrageModBonus,
+  getTargetBands,
+  DEFAULT_CLASS,
+  DEFAULT_PATH,
+  _resetCache,
+};

--- a/tests/ai/damageCurves.test.js
+++ b/tests/ai/damageCurves.test.js
@@ -1,0 +1,113 @@
+// M7-#2 Phase B — damage curves runtime tests.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  loadDamageCurves,
+  getEncounterClass,
+  applyEnemyDamageMultiplier,
+  shouldEnrageBoss,
+  getEnrageModBonus,
+  getTargetBands,
+  DEFAULT_CLASS,
+  _resetCache,
+} = require('../../apps/backend/services/balance/damageCurves');
+
+test('loadDamageCurves: reads real YAML', () => {
+  _resetCache();
+  const data = loadDamageCurves();
+  assert.ok(data, 'should load YAML');
+  assert.ok(data.encounter_classes, 'should have encounter_classes');
+  assert.ok(data.enemy_tiers, 'should have enemy_tiers');
+});
+
+test('loadDamageCurves: returns null on missing file', () => {
+  _resetCache();
+  const data = loadDamageCurves('/nonexistent/path.yaml');
+  assert.equal(data, null);
+  _resetCache();
+});
+
+test('getEncounterClass: fallback standard on missing field', () => {
+  _resetCache();
+  loadDamageCurves();
+  assert.equal(getEncounterClass({}), 'standard');
+  assert.equal(getEncounterClass(null), 'standard');
+  assert.equal(getEncounterClass({ encounter_class: 'unknown_xyz' }), 'standard');
+});
+
+test('getEncounterClass: explicit class passes through', () => {
+  _resetCache();
+  loadDamageCurves();
+  assert.equal(getEncounterClass({ encounter_class: 'hardcore' }), 'hardcore');
+  assert.equal(getEncounterClass({ encounter_class: 'boss' }), 'boss');
+});
+
+test('applyEnemyDamageMultiplier: scales mod by class multiplier', () => {
+  _resetCache();
+  const unit = { mod: 5 };
+  const applied = applyEnemyDamageMultiplier(unit, 'hardcore'); // mult 1.4
+  assert.equal(applied, true);
+  assert.equal(unit.mod, 7); // round(5 * 1.4) = 7
+  assert.equal(unit._mod_base, 5);
+  assert.equal(unit._mod_multiplier_applied, 1.4);
+});
+
+test('applyEnemyDamageMultiplier: no-op on tutorial class (mult 1.0)', () => {
+  _resetCache();
+  const unit = { mod: 5 };
+  const applied = applyEnemyDamageMultiplier(unit, 'tutorial');
+  assert.equal(applied, false);
+  assert.equal(unit.mod, 5);
+});
+
+test('applyEnemyDamageMultiplier: boss class multiplier 1.6', () => {
+  _resetCache();
+  const unit = { mod: 5 };
+  applyEnemyDamageMultiplier(unit, 'boss');
+  assert.equal(unit.mod, 8); // round(5 * 1.6) = 8
+});
+
+test('shouldEnrageBoss: boss HP below threshold → true', () => {
+  _resetCache();
+  const boss = { hp: 7, max_hp: 20 }; // 35%
+  // hardcore class threshold 40%
+  assert.equal(shouldEnrageBoss(boss, 'hardcore'), true);
+});
+
+test('shouldEnrageBoss: boss HP above threshold → false', () => {
+  _resetCache();
+  const boss = { hp: 15, max_hp: 20 }; // 75%
+  assert.equal(shouldEnrageBoss(boss, 'hardcore'), false);
+});
+
+test('shouldEnrageBoss: tutorial class → never enrage (threshold null)', () => {
+  _resetCache();
+  const boss = { hp: 1, max_hp: 20 }; // 5%
+  assert.equal(shouldEnrageBoss(boss, 'tutorial'), false);
+});
+
+test('getEnrageModBonus: returns boss tier bonus', () => {
+  _resetCache();
+  loadDamageCurves();
+  assert.equal(getEnrageModBonus(), 1);
+});
+
+test('getTargetBands: returns 3 rate ranges for class', () => {
+  _resetCache();
+  loadDamageCurves();
+  const bands = getTargetBands('hardcore');
+  assert.ok(bands);
+  assert.deepEqual(bands.win_rate, [0.15, 0.25]);
+  assert.deepEqual(bands.defeat_rate, [0.4, 0.55]);
+  assert.deepEqual(bands.timeout_rate, [0.15, 0.25]);
+});
+
+test('getTargetBands: null on unknown class', () => {
+  _resetCache();
+  loadDamageCurves();
+  assert.equal(getTargetBands('unknown_class'), null);
+});


### PR DESCRIPTION
## 🎮 Cosa cambia

Runtime wiring per ADR-2026-04-20 damage scaling curves. Session init applica `enemy_damage_multiplier` per encounter_class. Boss enrage check in performAttack: HP < threshold → mod bonus temporaneo.

**Demo live ngrok NON affetta** finché user non riavvia backend. User controls deploy timing.

## Changes

- `apps/backend/services/balance/damageCurves.js` nuovo (+160 LOC): loader + apply pipeline
- `apps/backend/routes/session.js`: wire /start + performAttack enrage hook
- `tests/ai/damageCurves.test.js` nuovo (+120 LOC, 13 test)

## Test

- 13/13 damageCurves test verdi
- 200+ full tests/ai verdi, zero regression
- Backward compat: missing YAML → soft-fail null
- Encounter senza class → "standard" fallback

## Phase C next

Annotate 10 encounter YAML con `encounter_class`. Senza annotazione → default "standard" (mild 1.2x threat increase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)