### PR TITLE
feat(calibration): M7-#2 Phase D — harness verdict vs target_bands

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -53,6 +53,14 @@ const { createDeclareSistemaIntents } = require('../services/ai/declareSistemaIn
 const { loadAiProfiles } = require('../services/ai/aiProfilesLoader');
 const { createAbilityExecutor } = require('../services/abilityExecutor');
 const reactionEngine = require('../services/reactionEngine');
+// M7-#2 Phase B: damage scaling curves runtime (ADR-2026-04-20).
+const {
+  loadDamageCurves,
+  getEncounterClass,
+  applyEnemyDamageMultiplier,
+  shouldEnrageBoss,
+  getEnrageModBonus,
+} = require('../services/balance/damageCurves');
 // M6-#1 (ADR-2026-04-19 + spike 2026-04-19): Node native resistance engine.
 // Applica channel-specific resist/vuln su damage pre-hp. Evidence spike:
 // 84.6% → 20% win rate hardcore-06 con flat 50% resist (leva confermata).
@@ -209,6 +217,28 @@ function createSessionRouter(options = {}) {
   }
 
   function performAttack(session, actor, target, action = null) {
+    // M7-#2 Phase B: boss enrage check. Se actor è boss tier + HP < threshold
+    // per encounter class → temporary mod bonus (non-persistente).
+    // Identificazione boss: id contains "_boss" OR actor.tier === 'boss'.
+    let enrageApplied = false;
+    let enrageModBonus = 0;
+    try {
+      const actorIsBoss =
+        (actor && typeof actor.id === 'string' && /_boss\b/.test(actor.id)) ||
+        actor?.tier === 'boss';
+      if (actorIsBoss && session?.encounter_class) {
+        if (shouldEnrageBoss(actor, session.encounter_class)) {
+          enrageModBonus = getEnrageModBonus();
+          if (enrageModBonus > 0) {
+            actor.mod = Number(actor.mod || 0) + enrageModBonus;
+            enrageApplied = true;
+          }
+        }
+      }
+    } catch (err) {
+      // non-blocking: se curves missing, no enrage
+    }
+
     const result = resolveAttack({ actor, target, rng });
     const evaluation = evaluateAttackTraits({
       registry: traitRegistry,
@@ -216,6 +246,11 @@ function createSessionRouter(options = {}) {
       target,
       attackResult: result,
     });
+
+    // Revert enrage bonus post-attack (non-persistente, solo per questo hit)
+    if (enrageApplied) {
+      actor.mod = Number(actor.mod || 0) - enrageModBonus;
+    }
     let damageDealt = 0;
     let killOccurred = false;
     let adjacencyBonus = 0;
@@ -683,6 +718,28 @@ function createSessionRouter(options = {}) {
         // best-effort: se config non carica, skip profile scaling
       }
 
+      // M7-#2 Phase B: apply damage scaling curves per encounter class.
+      // Lo YAML damage_curves.yaml definisce enemy_damage_multiplier per class.
+      // Encounter senza class dichiarato → fallback "standard" (1.2x).
+      // Idempotente: se class=tutorial (multiplier 1.0) no-op.
+      let encounterClassUsed = null;
+      try {
+        const curves = loadDamageCurves();
+        if (curves) {
+          const encCls = getEncounterClass(req.body, curves);
+          encounterClassUsed = encCls;
+          units = units.map((u) => {
+            if (!u) return u;
+            if (u.controlled_by !== 'sistema') return u;
+            const clone = { ...u };
+            applyEnemyDamageMultiplier(clone, encCls, curves);
+            return clone;
+          });
+        }
+      } catch (err) {
+        console.warn('[damage-curves] apply failed:', err.message);
+      }
+
       // ADR-2026-04-17: grid auto-scale basato su deployed PG count (party.yaml)
       let gridW = GRID_SIZE;
       let gridH = GRID_SIZE;
@@ -713,6 +770,8 @@ function createSessionRouter(options = {}) {
       const session = {
         session_id: sessionId,
         scenario_id: scenarioId,
+        // M7-#2 Phase B: persist encounter class per enrage check runtime
+        encounter_class: encounterClassUsed || 'standard',
         pressure_start: pressureStart,
         pressure: pressureStart,
         turn: 1,

--- a/apps/backend/services/balance/damageCurves.js
+++ b/apps/backend/services/balance/damageCurves.js
@@ -1,0 +1,135 @@
+// M7-#2 Phase B — damage curves loader + apply pipeline.
+//
+// Runtime consumer di data/core/balance/damage_curves.yaml (ADR-2026-04-20).
+// Funzioni:
+//   - loadDamageCurves(path): carica YAML singleton, cache in-memory
+//   - getEncounterClass(encounter): estrae class da encounter.encounter_class
+//     fallback "standard"
+//   - applyEnemyDamageMultiplier(unit, encounterClass): scale unit.mod
+//   - shouldEnrageBoss(boss, encounterClass): boolean se boss HP < threshold
+//   - getEnrageModBonus(encounterClass): bonus mod da applicare on enrage
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const DEFAULT_PATH = path.join(process.cwd(), 'data', 'core', 'balance', 'damage_curves.yaml');
+
+const DEFAULT_CLASS = 'standard';
+
+let _cached = null;
+
+/**
+ * Load + cache damage_curves.yaml. Idempotente (subsequent calls ritornano cached).
+ * Soft-fail se missing (ritorna null → consumer usano defaults fallback).
+ */
+function loadDamageCurves(filePath = DEFAULT_PATH) {
+  if (_cached !== null) return _cached;
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    _cached = yaml.load(raw);
+    return _cached;
+  } catch (err) {
+    console.warn(`[damage-curves] non caricato (${err.message}). Default multiplier=1.0`);
+    _cached = null;
+    return null;
+  }
+}
+
+/** Reset cache (per test). */
+function _resetCache() {
+  _cached = null;
+}
+
+/**
+ * Estrae encounter class da config encounter.
+ * Fallback "standard" se campo assente o class non esiste nel YAML.
+ */
+function getEncounterClass(encounter, curves = null) {
+  if (!encounter) return DEFAULT_CLASS;
+  const raw = encounter.encounter_class || encounter.encounter_class_id || DEFAULT_CLASS;
+  const data = curves || loadDamageCurves();
+  if (!data || !data.encounter_classes || !data.encounter_classes[raw]) {
+    return DEFAULT_CLASS;
+  }
+  return raw;
+}
+
+/**
+ * Apply enemy_damage_multiplier to unit.mod.
+ * Static application: unit.mod modificato una volta durante session init.
+ * Round floor (damage deve essere int).
+ *
+ * @returns {boolean} true se mod modificato
+ */
+function applyEnemyDamageMultiplier(unit, encounterClass, curves = null) {
+  if (!unit) return false;
+  const data = curves || loadDamageCurves();
+  if (!data) return false;
+  const cls = data.encounter_classes[encounterClass];
+  if (!cls) return false;
+  const mult = Number(cls.enemy_damage_multiplier) || 1.0;
+  if (mult === 1.0) return false;
+  const before = Number(unit.mod || 0);
+  unit.mod = Math.round(before * mult);
+  unit._mod_base = before; // track per debug / possible revert
+  unit._mod_multiplier_applied = mult;
+  return true;
+}
+
+/**
+ * Check se boss deve enrage basato su hp corrente vs threshold class.
+ * Enrage attivato quando hp_current / hp_max < threshold_hp.
+ *
+ * @param {object} boss unit (hp, max_hp)
+ * @param {string} encounterClass
+ * @param {object} curves optional (dependency injection)
+ * @returns {boolean}
+ */
+function shouldEnrageBoss(boss, encounterClass, curves = null) {
+  if (!boss || !boss.max_hp) return false;
+  const data = curves || loadDamageCurves();
+  if (!data) return false;
+  const cls = data.encounter_classes[encounterClass];
+  if (!cls || cls.boss_enrage_threshold_hp === null || cls.boss_enrage_threshold_hp === undefined) {
+    return false;
+  }
+  const ratio = Number(boss.hp || 0) / Number(boss.max_hp);
+  return ratio < Number(cls.boss_enrage_threshold_hp);
+}
+
+/**
+ * Bonus mod aggiunto su attack quando boss enrage.
+ * Da damage_curves.yaml enemy_tiers.boss.enrage_mod_bonus.
+ */
+function getEnrageModBonus(curves = null) {
+  const data = curves || loadDamageCurves();
+  if (!data || !data.enemy_tiers || !data.enemy_tiers.boss) return 0;
+  return Number(data.enemy_tiers.boss.enrage_mod_bonus) || 0;
+}
+
+/**
+ * Estrae target_bands per una class (consumed da calibration harness).
+ * @returns {object|null} {win_rate, defeat_rate, timeout_rate} o null
+ */
+function getTargetBands(encounterClass, curves = null) {
+  const data = curves || loadDamageCurves();
+  if (!data || !data.encounter_classes) return null;
+  const cls = data.encounter_classes[encounterClass];
+  if (!cls || !cls.target_bands) return null;
+  return cls.target_bands;
+}
+
+module.exports = {
+  loadDamageCurves,
+  getEncounterClass,
+  applyEnemyDamageMultiplier,
+  shouldEnrageBoss,
+  getEnrageModBonus,
+  getTargetBands,
+  DEFAULT_CLASS,
+  DEFAULT_PATH,
+  _resetCache,
+};

--- a/apps/backend/services/hardcoreScenario.js
+++ b/apps/backend/services/hardcoreScenario.js
@@ -24,6 +24,8 @@ const HARDCORE_SCENARIO_06 = {
   id: 'enc_tutorial_06_hardcore',
   name: "Cattedrale dell'Apex",
   biome_id: 'rovine_planari',
+  // M7-#2 Phase C: hardcore class (multiplier 1.4x + enrage 40% HP)
+  encounter_class: 'hardcore',
   difficulty_rating: 6,
   estimated_turns: 16,
   grid_size: 10,

--- a/apps/backend/services/tutorialScenario.js
+++ b/apps/backend/services/tutorialScenario.js
@@ -17,6 +17,8 @@ const TUTORIAL_SCENARIO = {
   id: 'enc_tutorial_01',
   name: 'Primi Passi nella Savana',
   biome_id: 'savana',
+  // M7-#2 Phase C: tutorial class (multiplier 1.0x, no enrage)
+  encounter_class: 'tutorial',
   difficulty_rating: 1,
   estimated_turns: 6,
   grid_size: 6,
@@ -32,6 +34,7 @@ const TUTORIAL_SCENARIO_02 = {
   id: 'enc_tutorial_02',
   name: 'Pattuglia Asimmetrica',
   biome_id: 'savana',
+  encounter_class: 'tutorial',
   difficulty_rating: 2,
   estimated_turns: 8,
   grid_size: 6,
@@ -47,6 +50,7 @@ const TUTORIAL_SCENARIO_03 = {
   id: 'enc_tutorial_03',
   name: 'Pozzo della Caverna Risonante',
   biome_id: 'caverna_risonante',
+  encounter_class: 'tutorial_advanced',
   difficulty_rating: 3,
   estimated_turns: 10,
   grid_size: 6,
@@ -70,6 +74,8 @@ const TUTORIAL_SCENARIO_05 = {
   id: 'enc_tutorial_05',
   name: "Solo contro l'Apex",
   biome_id: 'rovine_planari',
+  // M7-#2 Phase C: boss class (multiplier 1.6x + enrage 50% HP) — apex solo fight
+  encounter_class: 'boss',
   difficulty_rating: 5,
   estimated_turns: 14,
   grid_size: 6,
@@ -87,6 +93,9 @@ const TUTORIAL_SCENARIO_04 = {
   id: 'enc_tutorial_04',
   name: 'Pozza Acida del Bosco',
   biome_id: 'foresta_acida',
+  // M7-#2 Phase C: tutorial_advanced class (multiplier 1.2x, no enrage)
+  // Bleeding + hazard + 2v3 → difficulty gap prima del boss (tutorial_05)
+  encounter_class: 'tutorial_advanced',
   difficulty_rating: 4,
   estimated_turns: 12,
   grid_size: 6,

--- a/apps/backend/services/tutorialScenario.js
+++ b/apps/backend/services/tutorialScenario.js
@@ -34,6 +34,7 @@ const TUTORIAL_SCENARIO_02 = {
   id: 'enc_tutorial_02',
   name: 'Pattuglia Asimmetrica',
   biome_id: 'savana',
+  // M7-#2 Phase C: tutorial class (multiplier 1.0x, no enrage)
   encounter_class: 'tutorial',
   difficulty_rating: 2,
   estimated_turns: 8,
@@ -50,6 +51,8 @@ const TUTORIAL_SCENARIO_03 = {
   id: 'enc_tutorial_03',
   name: 'Pozzo della Caverna Risonante',
   biome_id: 'caverna_risonante',
+  // M7-#2 Phase C: tutorial_advanced class (multiplier 1.1x + enrage 25% HP)
+  // Hazard tiles + guardiani tank → skill check tier-3
   encounter_class: 'tutorial_advanced',
   difficulty_rating: 3,
   estimated_turns: 10,
@@ -93,7 +96,7 @@ const TUTORIAL_SCENARIO_04 = {
   id: 'enc_tutorial_04',
   name: 'Pozza Acida del Bosco',
   biome_id: 'foresta_acida',
-  // M7-#2 Phase C: tutorial_advanced class (multiplier 1.2x, no enrage)
+  // M7-#2 Phase C: tutorial_advanced class (multiplier 1.1x + enrage 25% HP)
   // Bleeding + hazard + 2v3 → difficulty gap prima del boss (tutorial_05)
   encounter_class: 'tutorial_advanced',
   difficulty_rating: 4,

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -819,6 +819,9 @@ async function startNewSession() {
     hazard_tiles: sc.data.hazard_tiles || [],
   };
   if (modulation) startOpts.modulation = modulation;
+  // M7-#2 Phase C: pipe encounter_class da scenario a backend per apply
+  // damage_curves.yaml multiplier + enrage threshold.
+  if (sc.data.encounter_class) startOpts.encounter_class = sc.data.encounter_class;
   const st = await api.start(sc.data.units, startOpts);
   if (!st.ok) {
     appendLog(logEl, `✖ session start: ${st.status}`, 'error');

--- a/docs/planning/encounters/enc_capture_01.yaml
+++ b/docs/planning/encounters/enc_capture_01.yaml
@@ -13,6 +13,8 @@ biome_id: rovine_planari
 grid_size: [10, 10]
 difficulty_rating: 3
 estimated_turns: 10
+# M7-#2 Phase C (ADR-2026-04-20): standard class (multiplier 1.0x, no enrage)
+encounter_class: standard
 
 objective:
   type: capture_point

--- a/docs/planning/encounters/enc_caverna_02.yaml
+++ b/docs/planning/encounters/enc_caverna_02.yaml
@@ -11,6 +11,8 @@ biome_id: caverna
 grid_size: [10, 10]
 difficulty_rating: 3
 estimated_turns: 12
+# M7-#2 Phase C (ADR-2026-04-20): standard class (multiplier 1.0x, no enrage)
+encounter_class: standard
 
 objective:
   type: capture_point

--- a/docs/planning/encounters/enc_escort_01.yaml
+++ b/docs/planning/encounters/enc_escort_01.yaml
@@ -14,6 +14,8 @@ biome_id: savana
 grid_size: [12, 8]
 difficulty_rating: 3
 estimated_turns: 12
+# M7-#2 Phase C (ADR-2026-04-20): standard class (multiplier 1.0x, no enrage)
+encounter_class: standard
 
 objective:
   type: escort

--- a/docs/planning/encounters/enc_frattura_03.yaml
+++ b/docs/planning/encounters/enc_frattura_03.yaml
@@ -15,6 +15,9 @@ biome_id: frattura_abissale_sinaptica
 grid_size: [12, 12]
 difficulty_rating: 5
 estimated_turns: 16
+# M7-#2 Phase C (ADR-2026-04-20): hardcore class (multiplier 1.4x + enrage 40% HP)
+# Multi-wave survival, no singolo boss — damage scaling enemy-wide.
+encounter_class: hardcore
 
 objective:
   type: survival

--- a/docs/planning/encounters/enc_hardcore_reinf_01.yaml
+++ b/docs/planning/encounters/enc_hardcore_reinf_01.yaml
@@ -14,6 +14,9 @@ biome_id: rovine_planari
 grid_size: [10, 10]
 difficulty_rating: 5
 estimated_turns: 15
+# M7-#2 Phase C (ADR-2026-04-20): hardcore class (multiplier 1.4x + enrage 40% HP)
+# Reinforcement waves continue → damage scaling pressure-amplificato.
+encounter_class: hardcore
 
 objective:
   type: elimination

--- a/docs/planning/encounters/enc_savana_01.yaml
+++ b/docs/planning/encounters/enc_savana_01.yaml
@@ -11,6 +11,9 @@ biome_id: savana
 grid_size: [10, 10]
 difficulty_rating: 2
 estimated_turns: 10
+# M7-#2 Phase C (ADR-2026-04-20): standard class (multiplier 1.0x, no enrage)
+# Prima missione non-tutorial. No boss, gating baseline Pilastro 1.
+encounter_class: standard
 
 objective:
   type: elimination

--- a/docs/planning/encounters/enc_survival_01.yaml
+++ b/docs/planning/encounters/enc_survival_01.yaml
@@ -13,6 +13,8 @@ biome_id: caverna_sotterranea
 grid_size: [8, 8]
 difficulty_rating: 4
 estimated_turns: 10
+# M7-#2 Phase C (ADR-2026-04-20): hardcore class (multiplier 1.4x + enrage 40% HP)
+encounter_class: hardcore
 
 objective:
   type: survival

--- a/docs/planning/encounters/enc_tutorial_01.yaml
+++ b/docs/planning/encounters/enc_tutorial_01.yaml
@@ -11,6 +11,8 @@ biome_id: savana
 grid_size: [8, 8]
 difficulty_rating: 1
 estimated_turns: 6
+# M7-#2 Phase C (ADR-2026-04-20): tutorial class (multiplier 1.0x, no enrage)
+encounter_class: tutorial
 
 objective:
   type: elimination

--- a/docs/planning/encounters/enc_tutorial_02.yaml
+++ b/docs/planning/encounters/enc_tutorial_02.yaml
@@ -11,6 +11,8 @@ biome_id: savana
 grid_size: [8, 8]
 difficulty_rating: 1
 estimated_turns: 8
+# M7-#2 Phase C (ADR-2026-04-20): tutorial class (multiplier 1.0x, no enrage)
+encounter_class: tutorial
 
 objective:
   type: survival

--- a/schemas/evo/encounter.schema.json
+++ b/schemas/evo/encounter.schema.json
@@ -278,6 +278,11 @@
         "min_distance_from_pg": { "type": "integer", "minimum": 0, "default": 3 }
       }
     },
+    "encounter_class": {
+      "type": "string",
+      "enum": ["tutorial", "tutorial_advanced", "standard", "hardcore", "boss"],
+      "description": "M7-#2 Phase C (ADR-2026-04-20): damage scaling class. Controls enemy_damage_multiplier (1.0→1.6) + boss_enrage_threshold_hp. Vedi data/core/balance/damage_curves.yaml."
+    },
     "visual_mood": {
       "type": "object",
       "description": "Art direction metadata per encounter (docs/core/41-ART-DIRECTION.md). Referenzia palette bioma + lighting + particle effect + optional accent override. Opzionale, no-op runtime.",

--- a/tests/ai/damageCurves.test.js
+++ b/tests/ai/damageCurves.test.js
@@ -1,0 +1,113 @@
+// M7-#2 Phase B — damage curves runtime tests.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  loadDamageCurves,
+  getEncounterClass,
+  applyEnemyDamageMultiplier,
+  shouldEnrageBoss,
+  getEnrageModBonus,
+  getTargetBands,
+  DEFAULT_CLASS,
+  _resetCache,
+} = require('../../apps/backend/services/balance/damageCurves');
+
+test('loadDamageCurves: reads real YAML', () => {
+  _resetCache();
+  const data = loadDamageCurves();
+  assert.ok(data, 'should load YAML');
+  assert.ok(data.encounter_classes, 'should have encounter_classes');
+  assert.ok(data.enemy_tiers, 'should have enemy_tiers');
+});
+
+test('loadDamageCurves: returns null on missing file', () => {
+  _resetCache();
+  const data = loadDamageCurves('/nonexistent/path.yaml');
+  assert.equal(data, null);
+  _resetCache();
+});
+
+test('getEncounterClass: fallback standard on missing field', () => {
+  _resetCache();
+  loadDamageCurves();
+  assert.equal(getEncounterClass({}), 'standard');
+  assert.equal(getEncounterClass(null), 'standard');
+  assert.equal(getEncounterClass({ encounter_class: 'unknown_xyz' }), 'standard');
+});
+
+test('getEncounterClass: explicit class passes through', () => {
+  _resetCache();
+  loadDamageCurves();
+  assert.equal(getEncounterClass({ encounter_class: 'hardcore' }), 'hardcore');
+  assert.equal(getEncounterClass({ encounter_class: 'boss' }), 'boss');
+});
+
+test('applyEnemyDamageMultiplier: scales mod by class multiplier', () => {
+  _resetCache();
+  const unit = { mod: 5 };
+  const applied = applyEnemyDamageMultiplier(unit, 'hardcore'); // mult 1.4
+  assert.equal(applied, true);
+  assert.equal(unit.mod, 7); // round(5 * 1.4) = 7
+  assert.equal(unit._mod_base, 5);
+  assert.equal(unit._mod_multiplier_applied, 1.4);
+});
+
+test('applyEnemyDamageMultiplier: no-op on tutorial class (mult 1.0)', () => {
+  _resetCache();
+  const unit = { mod: 5 };
+  const applied = applyEnemyDamageMultiplier(unit, 'tutorial');
+  assert.equal(applied, false);
+  assert.equal(unit.mod, 5);
+});
+
+test('applyEnemyDamageMultiplier: boss class multiplier 1.6', () => {
+  _resetCache();
+  const unit = { mod: 5 };
+  applyEnemyDamageMultiplier(unit, 'boss');
+  assert.equal(unit.mod, 8); // round(5 * 1.6) = 8
+});
+
+test('shouldEnrageBoss: boss HP below threshold → true', () => {
+  _resetCache();
+  const boss = { hp: 7, max_hp: 20 }; // 35%
+  // hardcore class threshold 40%
+  assert.equal(shouldEnrageBoss(boss, 'hardcore'), true);
+});
+
+test('shouldEnrageBoss: boss HP above threshold → false', () => {
+  _resetCache();
+  const boss = { hp: 15, max_hp: 20 }; // 75%
+  assert.equal(shouldEnrageBoss(boss, 'hardcore'), false);
+});
+
+test('shouldEnrageBoss: tutorial class → never enrage (threshold null)', () => {
+  _resetCache();
+  const boss = { hp: 1, max_hp: 20 }; // 5%
+  assert.equal(shouldEnrageBoss(boss, 'tutorial'), false);
+});
+
+test('getEnrageModBonus: returns boss tier bonus', () => {
+  _resetCache();
+  loadDamageCurves();
+  assert.equal(getEnrageModBonus(), 1);
+});
+
+test('getTargetBands: returns 3 rate ranges for class', () => {
+  _resetCache();
+  loadDamageCurves();
+  const bands = getTargetBands('hardcore');
+  assert.ok(bands);
+  assert.deepEqual(bands.win_rate, [0.15, 0.25]);
+  assert.deepEqual(bands.defeat_rate, [0.4, 0.55]);
+  assert.deepEqual(bands.timeout_rate, [0.15, 0.25]);
+});
+
+test('getTargetBands: null on unknown class', () => {
+  _resetCache();
+  loadDamageCurves();
+  assert.equal(getTargetBands('unknown_class'), null);
+});

--- a/tests/scripts/test_calibrate_target_bands.py
+++ b/tests/scripts/test_calibrate_target_bands.py
@@ -1,0 +1,88 @@
+"""M7-#2 Phase D: unit tests per load_target_bands + verdict_for.
+
+Verify mini-YAML parser legge correttamente data/core/balance/damage_curves.yaml
+senza dipendere da PyYAML, e che verdict_for classifica GREEN/AMBER/RED
+in linea con ADR-2026-04-20.
+"""
+
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, os.path.join(ROOT, "tools", "py"))
+
+import pytest
+
+from batch_calibrate_hardcore06 import load_target_bands, verdict_for
+
+
+def test_load_all_classes():
+    """Tutte le 5 class note devono ritornare 3 bands each."""
+    expected = {"tutorial", "tutorial_advanced", "standard", "hardcore", "boss"}
+    for cls in expected:
+        bands = load_target_bands(cls)
+        assert bands is not None, f"class {cls} missing from YAML"
+        assert set(bands.keys()) == {"win_rate", "defeat_rate", "timeout_rate"}
+        for k, v in bands.items():
+            assert isinstance(v, list) and len(v) == 2
+            lo, hi = v
+            assert 0.0 <= lo <= hi <= 1.0, f"{cls}.{k}={v} invalid range"
+
+
+def test_load_missing_class_returns_none():
+    assert load_target_bands("nonexistent") is None
+    assert load_target_bands("") is None
+
+
+def test_hardcore_bands_match_adr():
+    """ADR-2026-04-20 §class table: hardcore win 15-25%, defeat 40-55%, timeout 15-25%."""
+    b = load_target_bands("hardcore")
+    assert b["win_rate"] == [0.15, 0.25]
+    assert b["defeat_rate"] == [0.40, 0.55]
+    assert b["timeout_rate"] == [0.15, 0.25]
+
+
+def test_boss_bands_match_adr():
+    """Boss win 5-15% (most punishing tier)."""
+    b = load_target_bands("boss")
+    assert b["win_rate"] == [0.05, 0.15]
+    assert b["defeat_rate"] == [0.55, 0.70]
+
+
+def test_verdict_green_when_in_band():
+    b = load_target_bands("hardcore")
+    v, _ = verdict_for(0.20, 0.50, 0.20, b)
+    assert v == "GREEN"
+
+
+def test_verdict_amber_within_5pp():
+    """±5pp tolerance da band edge."""
+    b = load_target_bands("hardcore")
+    # win_rate 0.28 is 3pp sopra hi (0.25) → AMBER
+    v, reasons = verdict_for(0.28, 0.50, 0.20, b)
+    assert v == "AMBER"
+    assert any("win_rate" in r for r in reasons)
+
+
+def test_verdict_red_when_far():
+    b = load_target_bands("hardcore")
+    # win_rate 0.95 is 70pp sopra hi → RED
+    v, _ = verdict_for(0.95, 0.03, 0.02, b)
+    assert v == "RED"
+
+
+def test_verdict_unknown_when_no_bands():
+    v, reasons = verdict_for(0.5, 0.3, 0.1, None)
+    assert v == "UNKNOWN"
+    assert "no bands" in reasons[0].lower()
+
+
+def test_verdict_tutorial_band_permissive():
+    """Tutorial win 60-80% — sanity case player dominates."""
+    b = load_target_bands("tutorial")
+    v, _ = verdict_for(0.70, 0.15, 0.07, b)
+    assert v == "GREEN"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tools/py/batch_calibrate_hardcore06.py
+++ b/tools/py/batch_calibrate_hardcore06.py
@@ -7,6 +7,8 @@ Target: win_rate 15-25%, turns 14-18, K/D 0.6-0.9.
 
 import argparse
 import json
+import os
+import re
 import statistics
 import sys
 import time
@@ -16,6 +18,116 @@ import urllib.request
 SCENARIO_ID = "enc_tutorial_06_hardcore"
 MAX_ROUNDS = 40
 DEFAULT_HOST = "http://localhost:3340"
+DAMAGE_CURVES_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "..", "data", "core", "balance", "damage_curves.yaml"
+)
+
+
+def load_target_bands(encounter_class):
+    """M7-#2 Phase D: legge target_bands da damage_curves.yaml via
+    mini-YAML parser stdlib-only (no PyYAML dep).
+
+    Ritorna dict {win_rate:[lo,hi], defeat_rate:[lo,hi], timeout_rate:[lo,hi]}
+    o None se class non trovata.
+    """
+    if not os.path.exists(DAMAGE_CURVES_PATH):
+        return None
+    try:
+        with open(DAMAGE_CURVES_PATH, "r", encoding="utf-8") as f:
+            raw = f.read()
+    except OSError:
+        return None
+
+    # Mini parser: cerca blocco "encounter_classes:" → <class>: → target_bands:
+    # Pattern compact. Usa regex line-based (YAML semplice, non flow).
+    lines = raw.splitlines()
+    idx_class = None
+    in_classes = False
+    class_indent = None
+    for i, line in enumerate(lines):
+        if line.startswith("encounter_classes:"):
+            in_classes = True
+            continue
+        if not in_classes:
+            continue
+        # Match "  <name>:"
+        m = re.match(r"^(\s+)(\w+):\s*$", line)
+        if m and m.group(2) == encounter_class:
+            idx_class = i
+            class_indent = len(m.group(1))
+            break
+        # Break out if top-level section ended.
+        if line and not line.startswith(" ") and not line.startswith("#"):
+            break
+    if idx_class is None:
+        return None
+
+    # Scan subsequent lines for target_bands block.
+    bands = {}
+    j = idx_class + 1
+    while j < len(lines):
+        line = lines[j]
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            j += 1
+            continue
+        # End of class block = indent <= class_indent.
+        if line and len(line) - len(line.lstrip()) <= class_indent:
+            break
+        if "target_bands:" in line:
+            # Parse 3 following indented lines.
+            k = j + 1
+            while k < len(lines):
+                bl = lines[k]
+                bstripped = bl.strip()
+                if not bstripped or bstripped.startswith("#"):
+                    k += 1
+                    continue
+                # Expect "      win_rate: [lo, hi]"
+                bm = re.match(r"^\s+(\w+):\s*\[([\d.]+)\s*,\s*([\d.]+)\]", bl)
+                if bm:
+                    bands[bm.group(1)] = [float(bm.group(2)), float(bm.group(3))]
+                    k += 1
+                    continue
+                break
+            break
+        j += 1
+
+    return bands if bands else None
+
+
+def verdict_for(win_rate, defeat_rate, timeout_rate, bands):
+    """Ritorna (verdict, reasons) dati rates vs bands.
+    verdict in {GREEN, AMBER, RED}.
+    """
+    if not bands:
+        return "UNKNOWN", ["no bands for class"]
+    reasons = []
+    score = 0  # 0 green, 1 amber, 2 red
+    for key, observed in [
+        ("win_rate", win_rate),
+        ("defeat_rate", defeat_rate),
+        ("timeout_rate", timeout_rate),
+    ]:
+        band = bands.get(key)
+        if not band:
+            continue
+        lo, hi = band
+        if lo <= observed <= hi:
+            continue
+        # Distance-based amber vs red (±5pp amber tolerance).
+        dist = min(abs(observed - lo), abs(observed - hi))
+        if dist <= 0.05:
+            score = max(score, 1)
+            reasons.append(f"{key}={observed:.2f} near band [{lo},{hi}] (amber)")
+        else:
+            score = 2
+            reasons.append(f"{key}={observed:.2f} out of band [{lo},{hi}] (red)")
+    if score == 0:
+        return "GREEN", ["all rates in band"]
+    if score == 1:
+        return "AMBER", reasons
+    return "RED", reasons
 
 
 def _retry(fn, retries=5, backoff_base=0.5):
@@ -368,7 +480,7 @@ def run_one(host, run_idx):
     }
 
 
-def aggregate(runs):
+def aggregate(runs, encounter_class=None):
     ok = [r for r in runs if "error" not in r]
     if not ok:
         return {"error": "no successful runs"}
@@ -387,9 +499,27 @@ def aggregate(runs):
         for k, v in r["ai_intent_tally"].items():
             ai_global[k] = ai_global.get(k, 0) + v
 
+    n = len(ok)
+    wr = len(wins) / n
+    dr = len(losses) / n
+    tr = len(timeouts) / n
+    # M7-#2 Phase D: verdict vs class target_bands (ADR-2026-04-20).
+    verdict = None
+    verdict_reasons = []
+    bands = None
+    if encounter_class:
+        bands = load_target_bands(encounter_class)
+        verdict, verdict_reasons = verdict_for(wr, dr, tr, bands)
+
     return {
-        "N": len(ok),
-        "win_rate": len(wins) / len(ok),
+        "N": n,
+        "encounter_class": encounter_class,
+        "target_bands": bands,
+        "verdict": verdict,
+        "verdict_reasons": verdict_reasons,
+        "win_rate": wr,
+        "defeat_rate": dr,
+        "timeout_rate": tr,
         "win_count": len(wins),
         "loss_count": len(losses),
         "timeout_count": len(timeouts),
@@ -432,6 +562,10 @@ def main():
     ap.add_argument("--probe", action="store_true",
                     help="Run N=1 verbose probe (schema dump) — REQUIRED prima di batch nuovo. "
                          "Vedi memory feedback_probe_before_batch.md")
+    ap.add_argument("--encounter-class", default="hardcore",
+                    help="M7-#2 Phase D: class key da damage_curves.yaml. "
+                         "Default 'hardcore' (coerente con enc_tutorial_06_hardcore). "
+                         "Valori: tutorial|tutorial_advanced|standard|hardcore|boss")
     args = ap.parse_args()
 
     # Health probe (TKT-08): fail fast se backend non risponde.
@@ -478,7 +612,7 @@ def main():
             jsonl_fh.close()
 
     elapsed = time.time() - t0
-    agg = aggregate(runs)
+    agg = aggregate(runs, encounter_class=args.encounter_class)
     agg["elapsed_sec"] = round(elapsed, 1)
     agg["failures"] = failures
 


### PR DESCRIPTION
## Summary

- Harness `tools/py/batch_calibrate_hardcore06.py` ora legge `target_bands` da `data/core/balance/damage_curves.yaml` via mini-YAML parser stdlib-only (no PyYAML dep) ed emette verdict **GREEN/AMBER/RED** vs bands class (ADR-2026-04-20).
- Stacked su #1654 (Phase C encounter_class annotation). Rebase-to-main quando #1654 merga.

### API additions

- `load_target_bands(encounter_class) -> {win_rate, defeat_rate, timeout_rate}` — line-based parser YAML compact
- `verdict_for(wr, dr, tr, bands) -> ('GREEN'|'AMBER'|'RED'|'UNKNOWN', reasons[])` — GREEN (all in band) / AMBER (±5pp edge) / RED (>5pp out)
- `aggregate(runs, encounter_class=None)` — aggiunge `verdict`, `target_bands`, `defeat_rate`, `timeout_rate`, `verdict_reasons` a output
- CLI `--encounter-class` (default 'hardcore')

### Esempio output (da verdict_for)

```
hardcore bands: {'win_rate': [0.15, 0.25], 'defeat_rate': [0.4, 0.55], 'timeout_rate': [0.15, 0.25]}
20% wr / 50% dr / 15% tr → ('GREEN', ['all rates in band'])
28% wr / 50% dr / 20% tr → ('AMBER', ['win_rate=0.28 near band [0.15,0.25]'])
85% wr / 10% dr / 5% tr  → ('RED', ['win_rate=0.85 out of band ...'])
```

## Test plan

- [x] `python3 -m pytest tests/scripts/test_calibrate_target_bands.py -v` → 9/9 verde
- [x] CLI `--help` mostra `--encounter-class`
- [x] Tutte 5 class (tutorial, tutorial_advanced, standard, hardcore, boss) parsed correttamente
- [ ] CI verde (workflow on push)
- [ ] Next session: fire iter6 N=30 con verdict per validare M7-#2 damage curves wiring end-to-end.

## ADR

- [ADR-2026-04-20-damage-scaling-curves.md](docs/adr/ADR-2026-04-20-damage-scaling-curves.md) — **Phase D closes ADR implementation fully (A+B+C+D)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)