### PR TITLE
feat(calibration): M7-#2 Phase D — harness verdict vs target_bands

### DIFF
--- a/tests/scripts/test_calibrate_target_bands.py
+++ b/tests/scripts/test_calibrate_target_bands.py
@@ -1,0 +1,88 @@
+"""M7-#2 Phase D: unit tests per load_target_bands + verdict_for.
+
+Verify mini-YAML parser legge correttamente data/core/balance/damage_curves.yaml
+senza dipendere da PyYAML, e che verdict_for classifica GREEN/AMBER/RED
+in linea con ADR-2026-04-20.
+"""
+
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, os.path.join(ROOT, "tools", "py"))
+
+import pytest
+
+from batch_calibrate_hardcore06 import load_target_bands, verdict_for
+
+
+def test_load_all_classes():
+    """Tutte le 5 class note devono ritornare 3 bands each."""
+    expected = {"tutorial", "tutorial_advanced", "standard", "hardcore", "boss"}
+    for cls in expected:
+        bands = load_target_bands(cls)
+        assert bands is not None, f"class {cls} missing from YAML"
+        assert set(bands.keys()) == {"win_rate", "defeat_rate", "timeout_rate"}
+        for k, v in bands.items():
+            assert isinstance(v, list) and len(v) == 2
+            lo, hi = v
+            assert 0.0 <= lo <= hi <= 1.0, f"{cls}.{k}={v} invalid range"
+
+
+def test_load_missing_class_returns_none():
+    assert load_target_bands("nonexistent") is None
+    assert load_target_bands("") is None
+
+
+def test_hardcore_bands_match_adr():
+    """ADR-2026-04-20 §class table: hardcore win 15-25%, defeat 40-55%, timeout 15-25%."""
+    b = load_target_bands("hardcore")
+    assert b["win_rate"] == [0.15, 0.25]
+    assert b["defeat_rate"] == [0.40, 0.55]
+    assert b["timeout_rate"] == [0.15, 0.25]
+
+
+def test_boss_bands_match_adr():
+    """Boss win 5-15% (most punishing tier)."""
+    b = load_target_bands("boss")
+    assert b["win_rate"] == [0.05, 0.15]
+    assert b["defeat_rate"] == [0.55, 0.70]
+
+
+def test_verdict_green_when_in_band():
+    b = load_target_bands("hardcore")
+    v, _ = verdict_for(0.20, 0.50, 0.20, b)
+    assert v == "GREEN"
+
+
+def test_verdict_amber_within_5pp():
+    """±5pp tolerance da band edge."""
+    b = load_target_bands("hardcore")
+    # win_rate 0.28 is 3pp sopra hi (0.25) → AMBER
+    v, reasons = verdict_for(0.28, 0.50, 0.20, b)
+    assert v == "AMBER"
+    assert any("win_rate" in r for r in reasons)
+
+
+def test_verdict_red_when_far():
+    b = load_target_bands("hardcore")
+    # win_rate 0.95 is 70pp sopra hi → RED
+    v, _ = verdict_for(0.95, 0.03, 0.02, b)
+    assert v == "RED"
+
+
+def test_verdict_unknown_when_no_bands():
+    v, reasons = verdict_for(0.5, 0.3, 0.1, None)
+    assert v == "UNKNOWN"
+    assert "no bands" in reasons[0].lower()
+
+
+def test_verdict_tutorial_band_permissive():
+    """Tutorial win 60-80% — sanity case player dominates."""
+    b = load_target_bands("tutorial")
+    v, _ = verdict_for(0.70, 0.15, 0.07, b)
+    assert v == "GREEN"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tools/py/batch_calibrate_hardcore06.py
+++ b/tools/py/batch_calibrate_hardcore06.py
@@ -7,6 +7,8 @@ Target: win_rate 15-25%, turns 14-18, K/D 0.6-0.9.
 
 import argparse
 import json
+import os
+import re
 import statistics
 import sys
 import time
@@ -16,6 +18,116 @@ import urllib.request
 SCENARIO_ID = "enc_tutorial_06_hardcore"
 MAX_ROUNDS = 40
 DEFAULT_HOST = "http://localhost:3340"
+DAMAGE_CURVES_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "..", "data", "core", "balance", "damage_curves.yaml"
+)
+
+
+def load_target_bands(encounter_class):
+    """M7-#2 Phase D: legge target_bands da damage_curves.yaml via
+    mini-YAML parser stdlib-only (no PyYAML dep).
+
+    Ritorna dict {win_rate:[lo,hi], defeat_rate:[lo,hi], timeout_rate:[lo,hi]}
+    o None se class non trovata.
+    """
+    if not os.path.exists(DAMAGE_CURVES_PATH):
+        return None
+    try:
+        with open(DAMAGE_CURVES_PATH, "r", encoding="utf-8") as f:
+            raw = f.read()
+    except OSError:
+        return None
+
+    # Mini parser: cerca blocco "encounter_classes:" → <class>: → target_bands:
+    # Pattern compact. Usa regex line-based (YAML semplice, non flow).
+    lines = raw.splitlines()
+    idx_class = None
+    in_classes = False
+    class_indent = None
+    for i, line in enumerate(lines):
+        if line.startswith("encounter_classes:"):
+            in_classes = True
+            continue
+        if not in_classes:
+            continue
+        # Match "  <name>:"
+        m = re.match(r"^(\s+)(\w+):\s*$", line)
+        if m and m.group(2) == encounter_class:
+            idx_class = i
+            class_indent = len(m.group(1))
+            break
+        # Break out if top-level section ended.
+        if line and not line.startswith(" ") and not line.startswith("#"):
+            break
+    if idx_class is None:
+        return None
+
+    # Scan subsequent lines for target_bands block.
+    bands = {}
+    j = idx_class + 1
+    while j < len(lines):
+        line = lines[j]
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            j += 1
+            continue
+        # End of class block = indent <= class_indent.
+        if line and len(line) - len(line.lstrip()) <= class_indent:
+            break
+        if "target_bands:" in line:
+            # Parse 3 following indented lines.
+            k = j + 1
+            while k < len(lines):
+                bl = lines[k]
+                bstripped = bl.strip()
+                if not bstripped or bstripped.startswith("#"):
+                    k += 1
+                    continue
+                # Expect "      win_rate: [lo, hi]"
+                bm = re.match(r"^\s+(\w+):\s*\[([\d.]+)\s*,\s*([\d.]+)\]", bl)
+                if bm:
+                    bands[bm.group(1)] = [float(bm.group(2)), float(bm.group(3))]
+                    k += 1
+                    continue
+                break
+            break
+        j += 1
+
+    return bands if bands else None
+
+
+def verdict_for(win_rate, defeat_rate, timeout_rate, bands):
+    """Ritorna (verdict, reasons) dati rates vs bands.
+    verdict in {GREEN, AMBER, RED}.
+    """
+    if not bands:
+        return "UNKNOWN", ["no bands for class"]
+    reasons = []
+    score = 0  # 0 green, 1 amber, 2 red
+    for key, observed in [
+        ("win_rate", win_rate),
+        ("defeat_rate", defeat_rate),
+        ("timeout_rate", timeout_rate),
+    ]:
+        band = bands.get(key)
+        if not band:
+            continue
+        lo, hi = band
+        if lo <= observed <= hi:
+            continue
+        # Distance-based amber vs red (±5pp amber tolerance).
+        dist = min(abs(observed - lo), abs(observed - hi))
+        if dist <= 0.05:
+            score = max(score, 1)
+            reasons.append(f"{key}={observed:.2f} near band [{lo},{hi}] (amber)")
+        else:
+            score = 2
+            reasons.append(f"{key}={observed:.2f} out of band [{lo},{hi}] (red)")
+    if score == 0:
+        return "GREEN", ["all rates in band"]
+    if score == 1:
+        return "AMBER", reasons
+    return "RED", reasons
 
 
 def _retry(fn, retries=5, backoff_base=0.5):
@@ -368,7 +480,7 @@ def run_one(host, run_idx):
     }
 
 
-def aggregate(runs):
+def aggregate(runs, encounter_class=None):
     ok = [r for r in runs if "error" not in r]
     if not ok:
         return {"error": "no successful runs"}
@@ -387,9 +499,27 @@ def aggregate(runs):
         for k, v in r["ai_intent_tally"].items():
             ai_global[k] = ai_global.get(k, 0) + v
 
+    n = len(ok)
+    wr = len(wins) / n
+    dr = len(losses) / n
+    tr = len(timeouts) / n
+    # M7-#2 Phase D: verdict vs class target_bands (ADR-2026-04-20).
+    verdict = None
+    verdict_reasons = []
+    bands = None
+    if encounter_class:
+        bands = load_target_bands(encounter_class)
+        verdict, verdict_reasons = verdict_for(wr, dr, tr, bands)
+
     return {
-        "N": len(ok),
-        "win_rate": len(wins) / len(ok),
+        "N": n,
+        "encounter_class": encounter_class,
+        "target_bands": bands,
+        "verdict": verdict,
+        "verdict_reasons": verdict_reasons,
+        "win_rate": wr,
+        "defeat_rate": dr,
+        "timeout_rate": tr,
         "win_count": len(wins),
         "loss_count": len(losses),
         "timeout_count": len(timeouts),
@@ -432,6 +562,10 @@ def main():
     ap.add_argument("--probe", action="store_true",
                     help="Run N=1 verbose probe (schema dump) — REQUIRED prima di batch nuovo. "
                          "Vedi memory feedback_probe_before_batch.md")
+    ap.add_argument("--encounter-class", default="hardcore",
+                    help="M7-#2 Phase D: class key da damage_curves.yaml. "
+                         "Default 'hardcore' (coerente con enc_tutorial_06_hardcore). "
+                         "Valori: tutorial|tutorial_advanced|standard|hardcore|boss")
     args = ap.parse_args()
 
     # Health probe (TKT-08): fail fast se backend non risponde.
@@ -478,7 +612,7 @@ def main():
             jsonl_fh.close()
 
     elapsed = time.time() - t0
-    agg = aggregate(runs)
+    agg = aggregate(runs, encounter_class=args.encounter_class)
     agg["elapsed_sec"] = round(elapsed, 1)
     agg["failures"] = failures
 


### PR DESCRIPTION
## Summary

- Harness `tools/py/batch_calibrate_hardcore06.py` legge `target_bands` da `data/core/balance/damage_curves.yaml` via mini-YAML parser stdlib-only (no PyYAML dep).
- Emette verdict **GREEN/AMBER/RED** vs bands class (ADR-2026-04-20).
- Ricreata branch clean post merge #1654 (Phase C squash → rebase conflict).

### API additions

- `load_target_bands(encounter_class)` — line-based YAML parser
- `verdict_for(wr, dr, tr, bands)` — GREEN (in band) / AMBER (±5pp) / RED (>5pp out)
- `aggregate(runs, encounter_class=None)` — emette verdict + bands + defeat_rate + timeout_rate + reasons
- CLI `--encounter-class` (default 'hardcore')

### Esempio

```
hardcore bands: {'win_rate': [0.15, 0.25], 'defeat_rate': [0.4, 0.55], 'timeout_rate': [0.15, 0.25]}
20% wr / 50% dr / 15% tr → GREEN
28% wr / 50% dr / 20% tr → AMBER (win_rate 3pp over edge)
85% wr / 10% dr / 5% tr  → RED
```

## Test plan

- [x] `pytest tests/scripts/test_calibrate_target_bands.py -v` → 9/9 verde
- [x] CLI `--help` mostra `--encounter-class`
- [x] Tutte 5 class parsed
- [ ] CI verde
- [ ] Next: iter6 N=30 con verdict

## ADR

Phase D chiude ADR-2026-04-20 scope completo (A+B+C+D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)