### PR TITLE
feat(plan-reveal): M8 P0 — threat_preview backend + frontend consume

### DIFF
--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -34,6 +34,7 @@ const {
 } = require('../services/squadCoordination');
 const { tick: reinforcementTick } = require('../services/combat/reinforcementSpawner');
 const { evaluateObjective } = require('../services/combat/objectiveEvaluator');
+const { buildThreatPreview } = require('../services/ai/threatPreview');
 
 function createRoundBridge(deps) {
   const {
@@ -1135,6 +1136,12 @@ function createRoundBridge(deps) {
 
         await persistEvents(session);
 
+        // M8 Plan-Reveal P0 (ADR-2026-04-18): UI threat preview payload.
+        // SIS intents normalizzati in {actor_id, intent_type, intent_icon,
+        // target_id, threat_tiles} consumati dal frontend render.js +
+        // main.js tooltip. Empty array se nessun SIS intent.
+        const threatPreview = buildThreatPreview(session);
+
         res.json({
           session_id: session.session_id,
           turn: session.turn,
@@ -1142,6 +1149,7 @@ function createRoundBridge(deps) {
           pending_intents: session.roundState.pending_intents,
           sistema_decisions: sisDecisions,
           sistema_intents_count: sisIntents.length,
+          threat_preview: threatPreview,
           hazard_events: hazardEvents,
           side_effects: bleedingEvents,
           state: publicSessionView(session),

--- a/apps/backend/services/ai/threatPreview.js
+++ b/apps/backend/services/ai/threatPreview.js
@@ -1,0 +1,96 @@
+// M8 Plan-Reveal P0 — threat_preview builder (ADR-2026-04-18).
+//
+// Transforms session.roundState.pending_intents (SIS side) into a
+// UI-friendly payload consumed by the frontend during declare phase:
+//
+//   {
+//     actor_id: 'e_nomad_1',
+//     intent_type: 'attack' | 'move' | 'skip' | 'unknown',
+//     intent_icon: 'fist' | 'move' | 'shield' | '?',
+//     target_id: 'p_scout' | null,
+//     threat_tiles: [{ x, y }],
+//   }
+//
+// `threat_tiles` per attack = cella del target (dove sta cadendo il colpo).
+// `threat_tiles` per move = cella di destinazione (dove SIS sta andando).
+// `threat_tiles` per skip = [].
+//
+// NB: legge solo da `session.roundState.pending_intents` → richiede che
+// `declareSistemaIntents` sia già stato chiamato (flow /round/begin-planning).
+// No side effects, no mutazioni.
+
+'use strict';
+
+const INTENT_ICON_MAP = {
+  attack: 'fist',
+  move: 'move',
+  approach: 'move',
+  retreat: 'move',
+  skip: 'shield',
+  defend: 'shield',
+  overwatch: 'shield',
+};
+
+function _iconFor(type) {
+  if (!type || typeof type !== 'string') return '?';
+  return INTENT_ICON_MAP[type] || '?';
+}
+
+function _unitById(session, id) {
+  if (!session || !Array.isArray(session.units) || !id) return null;
+  return session.units.find((u) => u && u.id === id) || null;
+}
+
+function _threatTilesFor(session, intent) {
+  const action = intent && intent.action ? intent.action : {};
+  const type = action.type;
+
+  if (type === 'attack' && action.target_id) {
+    const target = _unitById(session, action.target_id);
+    if (target && target.position) {
+      return [{ x: Number(target.position.x), y: Number(target.position.y) }];
+    }
+  }
+  if ((type === 'move' || type === 'approach' || type === 'retreat') && action.move_to) {
+    return [{ x: Number(action.move_to.x), y: Number(action.move_to.y) }];
+  }
+  return [];
+}
+
+/**
+ * Build threat_preview payload from session roundState.
+ *
+ * @param {object} session — shape `{ units, roundState: { pending_intents } }`
+ * @returns {Array} threat_preview rows (vuoto se roundState o intents assenti)
+ */
+function buildThreatPreview(session) {
+  if (!session || !session.roundState) return [];
+  const pending = session.roundState.pending_intents;
+  if (!Array.isArray(pending) || pending.length === 0) return [];
+
+  const preview = [];
+  for (const intent of pending) {
+    if (!intent || !intent.unit_id) continue;
+    const actor = _unitById(session, intent.unit_id);
+    if (!actor || actor.controlled_by !== 'sistema') continue; // only SIS entries
+    if (Number(actor.hp || 0) <= 0) continue; // skip dead units
+
+    const action = intent.action || {};
+    const intentType = action.type || 'unknown';
+
+    preview.push({
+      actor_id: actor.id,
+      intent_type: intentType,
+      intent_icon: _iconFor(intentType),
+      target_id: action.target_id || null,
+      threat_tiles: _threatTilesFor(session, intent),
+    });
+  }
+  return preview;
+}
+
+module.exports = {
+  buildThreatPreview,
+  // exposed per testing
+  _iconFor,
+};

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -1064,6 +1064,10 @@ async function triggerCommitRound() {
     state.roundInit = false;
     _pendingConfirm = null;
     state.pendingIntents = [];
+    // M8 Plan-Reveal P0: clear threat preview post-resolve (intents consumed).
+    // Fix Codex review #1658: legacy branch reset era dead code su useRoundFlow()=true
+    // → stale SIS intents mostrati post-resolve. Reset qui è l'active path.
+    state.threatPreview = [];
 
     const playerActions = r.data?.player_actions || [];
     const iaActions = r.data?.ia_actions || [];

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -38,6 +38,11 @@ const state = {
   planningTimerStart: null,
   // W5.D — eval set Flint v0.3 decision trace (JSONL pairs per decision)
   evalSet: [],
+  // M8 Plan-Reveal P0 (ADR-2026-04-18): SIS threat_preview da /begin-planning.
+  // Array [{actor_id, intent_type, intent_icon, target_id, threat_tiles}].
+  // Consumato da render.js (icon) + main.js tooltip (label).
+  // Reset a ogni begin-planning (nuovo round) o commit-round (resolved).
+  threatPreview: [],
 };
 
 // W8b — Shared utility helpers (from Wave 8 research audit).
@@ -168,6 +173,8 @@ function redraw() {
     target: state.target,
     active: state.world.active_unit,
     resolutionOrder: state.lastResolutionOrder,
+    // M8 Plan-Reveal P0: SIS intent icons + threat tile highlight
+    threatPreview: state.threatPreview,
   });
   const predictedOrder = computePlayerPriorityOrder(state.pendingIntents, state.world.units || []);
   renderUnits(
@@ -419,9 +426,29 @@ function buildUnitTooltip(unit) {
   const statusTxt = statusKeys.length ? `Status: ${statusKeys.join(', ')}` : '';
   let intentBlock = '';
   if (faction === 'sistema' && unit.hp > 0) {
-    // Stub: icona pugno = intento attacco (mirror drawSisIntentIcon).
-    // TODO ADR-04-18 Plan-Reveal: real intent da threat_preview payload backend.
-    intentBlock = `<span class="tt-intent">✊ Intento: attacco (stub)</span>`;
+    // M8 Plan-Reveal P0 (ADR-2026-04-18): real intent from threat_preview
+    // payload populated on /round/begin-planning. Fallback 'attacco' se
+    // preview vuota (legacy flow / pre-declare phase).
+    const preview = Array.isArray(state.threatPreview) ? state.threatPreview : [];
+    const row = preview.find((r) => r && r.actor_id === unit.id);
+    const glyphMap = { fist: '✊', move: '➜', shield: '🛡', '?': '?' };
+    const labelMap = {
+      attack: 'attacco',
+      move: 'movimento',
+      approach: 'avvicinamento',
+      retreat: 'ritirata',
+      skip: 'difesa',
+      defend: 'difesa',
+      overwatch: 'sentinella',
+    };
+    if (row) {
+      const glyph = glyphMap[row.intent_icon] || '?';
+      const label = labelMap[row.intent_type] || row.intent_type || 'ignoto';
+      const targetTxt = row.target_id ? ` → ${row.target_id}` : '';
+      intentBlock = `<span class="tt-intent">${glyph} Intento: ${label}${targetTxt}</span>`;
+    } else {
+      intentBlock = `<span class="tt-intent">✊ Intento: attacco</span>`;
+    }
   }
   return `
     <strong>${unit.id}</strong>
@@ -627,6 +654,8 @@ async function doAction(body) {
         return;
       }
       state.roundInit = true;
+      // M8 Plan-Reveal P0: store SIS threat preview per render + tooltip
+      state.threatPreview = Array.isArray(bp.data?.threat_preview) ? bp.data.threat_preview : [];
       // W4.6 — start planning timer on first declare
       startPlanningTimer();
     }
@@ -1013,6 +1042,8 @@ async function triggerCommitRound() {
         return;
       }
       state.roundInit = true;
+      // M8 Plan-Reveal P0: store threat_preview
+      state.threatPreview = Array.isArray(bp.data?.threat_preview) ? bp.data.threat_preview : [];
     }
     let r = await api.commitRound(state.sid, true);
     // W8-emergency (bug #5): transient network drop — auto-retry once after 400ms.
@@ -1174,6 +1205,8 @@ document.getElementById('end-turn').addEventListener('click', async () => {
         return;
       }
       state.roundInit = true;
+      // M8 Plan-Reveal P0: store threat_preview (empty array se no intents)
+      state.threatPreview = Array.isArray(bp.data?.threat_preview) ? bp.data.threat_preview : [];
     }
     const r = await api.commitRound(state.sid, true);
     if (!r.ok) {
@@ -1182,6 +1215,8 @@ document.getElementById('end-turn').addEventListener('click', async () => {
     }
     // Reset roundInit per prossimo turno
     state.roundInit = false;
+    // M8 Plan-Reveal P0: clear threat preview post-resolve (intents consumed)
+    state.threatPreview = [];
     _pendingConfirm = null;
     // Process resolution_queue as animations (shape differs da ia_actions)
     const queue = r.data?.resolution_queue || [];

--- a/apps/play/src/render.js
+++ b/apps/play/src/render.js
@@ -365,10 +365,14 @@ function drawUnit(ctx, unit, gridH, highlight = {}) {
   if (!dead) drawStatusIcons(ctx, unit, cx, yPx * CELL);
 
   // M4 P0.3 — SIS enemy intent icon (Slay the Spire pattern).
-  // Stub euristico: SIS controlled_by='sistema' + HP>0 → fist icon (attack intent).
-  // TODO ADR-04-18 Plan-Reveal: real intents da threat_preview payload backend.
+  // M8 Plan-Reveal P0 (ADR-2026-04-18): real intent icon da threat_preview
+  // payload backend (/round/begin-planning). Fallback 'fist' se preview
+  // assente (legacy flow o first-paint pre-begin-planning).
   if (!dead && unit.controlled_by === 'sistema') {
-    drawSisIntentIcon(ctx, unit, cx, yPx * CELL, 'fist');
+    const preview = Array.isArray(highlight.threatPreview) ? highlight.threatPreview : [];
+    const row = preview.find((r) => r && r.actor_id === unit.id);
+    const icon = (row && row.intent_icon) || 'fist';
+    drawSisIntentIcon(ctx, unit, cx, yPx * CELL, icon);
   }
 
   // W4.3 — Resolution priority badge (visible during commit-round reveal phase).

--- a/tests/ai/threatPreview.test.js
+++ b/tests/ai/threatPreview.test.js
@@ -1,0 +1,118 @@
+// M8 Plan-Reveal P0 — threatPreview.js unit tests.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { buildThreatPreview, _iconFor } = require('../../apps/backend/services/ai/threatPreview');
+
+function _session(units, pendingIntents) {
+  return { units, roundState: { pending_intents: pendingIntents } };
+}
+
+test('buildThreatPreview: empty roundState → []', () => {
+  assert.deepEqual(buildThreatPreview({}), []);
+  assert.deepEqual(buildThreatPreview({ roundState: null }), []);
+  assert.deepEqual(buildThreatPreview(null), []);
+});
+
+test('buildThreatPreview: no pending_intents → []', () => {
+  assert.deepEqual(buildThreatPreview(_session([], [])), []);
+  assert.deepEqual(buildThreatPreview(_session([], null)), []);
+});
+
+test('buildThreatPreview: attack intent → fist + target tile', () => {
+  const session = _session(
+    [
+      { id: 'e_nomad_1', controlled_by: 'sistema', hp: 3, position: { x: 3, y: 2 } },
+      { id: 'p_scout', controlled_by: 'player', hp: 10, position: { x: 1, y: 2 } },
+    ],
+    [
+      {
+        unit_id: 'e_nomad_1',
+        action: { type: 'attack', target_id: 'p_scout' },
+      },
+    ],
+  );
+  const result = buildThreatPreview(session);
+  assert.equal(result.length, 1);
+  assert.deepEqual(result[0], {
+    actor_id: 'e_nomad_1',
+    intent_type: 'attack',
+    intent_icon: 'fist',
+    target_id: 'p_scout',
+    threat_tiles: [{ x: 1, y: 2 }],
+  });
+});
+
+test('buildThreatPreview: move intent → arrow + destination tile', () => {
+  const session = _session(
+    [{ id: 'e_hunter', controlled_by: 'sistema', hp: 6, position: { x: 3, y: 3 } }],
+    [
+      {
+        unit_id: 'e_hunter',
+        action: { type: 'move', move_to: { x: 2, y: 3 } },
+      },
+    ],
+  );
+  const result = buildThreatPreview(session);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].intent_icon, 'move');
+  assert.deepEqual(result[0].threat_tiles, [{ x: 2, y: 3 }]);
+});
+
+test('buildThreatPreview: skip intent → shield + no tiles', () => {
+  const session = _session(
+    [{ id: 'e_nomad_1', controlled_by: 'sistema', hp: 3, position: { x: 3, y: 2 } }],
+    [{ unit_id: 'e_nomad_1', action: { type: 'skip' } }],
+  );
+  const result = buildThreatPreview(session);
+  assert.equal(result[0].intent_icon, 'shield');
+  assert.deepEqual(result[0].threat_tiles, []);
+});
+
+test('buildThreatPreview: skips player-controlled intents', () => {
+  const session = _session(
+    [
+      { id: 'p_scout', controlled_by: 'player', hp: 10, position: { x: 1, y: 2 } },
+      { id: 'e_nomad_1', controlled_by: 'sistema', hp: 3, position: { x: 3, y: 2 } },
+    ],
+    [
+      { unit_id: 'p_scout', action: { type: 'attack', target_id: 'e_nomad_1' } },
+      { unit_id: 'e_nomad_1', action: { type: 'attack', target_id: 'p_scout' } },
+    ],
+  );
+  const result = buildThreatPreview(session);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].actor_id, 'e_nomad_1');
+});
+
+test('buildThreatPreview: skips dead units', () => {
+  const session = _session(
+    [{ id: 'e_nomad_1', controlled_by: 'sistema', hp: 0, position: { x: 3, y: 2 } }],
+    [{ unit_id: 'e_nomad_1', action: { type: 'attack', target_id: 'p_scout' } }],
+  );
+  assert.deepEqual(buildThreatPreview(session), []);
+});
+
+test('buildThreatPreview: unknown type → unknown + ?', () => {
+  const session = _session(
+    [{ id: 'e_nomad_1', controlled_by: 'sistema', hp: 3, position: { x: 3, y: 2 } }],
+    [{ unit_id: 'e_nomad_1', action: { type: 'freakshow' } }],
+  );
+  const result = buildThreatPreview(session);
+  assert.equal(result[0].intent_type, 'freakshow');
+  assert.equal(result[0].intent_icon, '?');
+});
+
+test('_iconFor: map exact strings', () => {
+  assert.equal(_iconFor('attack'), 'fist');
+  assert.equal(_iconFor('move'), 'move');
+  assert.equal(_iconFor('approach'), 'move');
+  assert.equal(_iconFor('retreat'), 'move');
+  assert.equal(_iconFor('skip'), 'shield');
+  assert.equal(_iconFor('defend'), 'shield');
+  assert.equal(_iconFor('overwatch'), 'shield');
+  assert.equal(_iconFor(''), '?');
+  assert.equal(_iconFor(null), '?');
+  assert.equal(_iconFor(undefined), '?');
+});


### PR DESCRIPTION
## Summary

Chiude TODO ADR-2026-04-18 Plan-Reveal in frontend (SIS intent stub hardcoded a 'fist'). Real intent + target + icon ora visibile a player durante declare phase, coerente con "Plan & Reveal" model (ADR-2026-04-18).

### Backend

- **New** `apps/backend/services/ai/threatPreview.js`: `buildThreatPreview(session)` legge `session.roundState.pending_intents` (già popolato da `declareSistemaIntents`) e ritorna array normalizzato `[{actor_id, intent_type, intent_icon, target_id, threat_tiles}]`.
- **Extended** `sessionRoundBridge.js` `/round/begin-planning` response: aggiunge `threat_preview` field (additive, backward compatible).
- Icon map: attack → fist, move/approach/retreat → move, skip/defend/overwatch → shield, unknown → ?.
- Threat tiles: attack = target pos · move = destination · skip = [].

### Frontend

- `state.threatPreview` populated post-begin-planning (3 call sites), cleared post-commit-round.
- `render.js drawUnit` legge `highlight.threatPreview` + passa real icon a `drawSisIntentIcon` (fallback 'fist').
- `main.js buildUnitTooltip` mostra intent_type + target_id reali con glyph+label IT (fallback stub se preview vuota).

### Demo-safety

Additive backend field + frontend fallback. Demo `:3334` non richiede restart fino a deploy finale. Nessuna breaking change su legacy `/begin-planning` consumers.

## Test plan

- [x] `node --test tests/ai/threatPreview.test.js` — 9/9 verde (attack/move/skip/unknown/dead/player-skip/empty/iconFor)
- [x] `node --test tests/ai/*.test.js` — 211/211 verde
- [ ] CI verde (workflow on push)
- [ ] Playtest visual check: SIS unit con intent 'move' mostra ➜ non ✊

## References

- ADR-2026-04-18 Plan & Reveal round model
- feedback run4 "SIS intent hidden = player no può reagire"
- Flint verdict 2026-04-20 kill-60: priority M8 P0 user-facing > Status canonical debt

🤖 Generated with [Claude Code](https://claude.com/claude-code)