### PR TITLE
fix(demo): disable hardcore lobby option until M9

### DIFF
--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -138,7 +138,9 @@
               <option value="enc_tutorial_03">Tutorial 03 · Hazard savana</option>
               <option value="enc_tutorial_04">Tutorial 04 · Bleeding foresta</option>
               <option value="enc_tutorial_05">Tutorial 05 · BOSS Apex</option>
-              <option value="enc_tutorial_06_hardcore">Tutorial 06 · HARDCORE 8p</option>
+              <option value="enc_tutorial_06_hardcore" disabled>
+                Tutorial 06 · HARDCORE 8p (WIP M9 — stalemate pattern)
+              </option>
             </select>
             <select id="modulation-select" title="Party composition (co-op 1-8 player)">
               <option value="">Party: auto</option>


### PR DESCRIPTION
## Summary

Post iter7 RED verdict (#1659): `enc_tutorial_06_hardcore` ha 0% defeat + 67% timeout stalemate. Giocatori demo (amici su :3334) avrebbero experience tedioso 40-round senza outcome. Disable opzione lobby finché M9 structural fix.

### Change

- `apps/play/index.html`: hardcore option `disabled` + label "HARDCORE 8p (WIP M9 — stalemate pattern)"
- Amici vedono opzione (discoverable) ma non selezionabile, aspettativa settata

## Demo impact

- Tutorial 01-05 still available (polished + balanced)
- Hardcore temporaneo off fino M9 iter8 post structural fix (timeout=defeat o concentrate aggro)

## Test plan

- [x] Visible in Launch preview panel
- [ ] CI verde
- [ ] Restart backend demo :3334 per propagare + Plan-Reveal M8 (#1658)

🤖 Generated with [Claude Code](https://claude.com/claude-code)