### PR TITLE
feat(balance): M9 P6 — turn_limit_defeat force decision pressure

### DIFF
--- a/apps/backend/services/balance/damageCurves.js
+++ b/apps/backend/services/balance/damageCurves.js
@@ -122,6 +122,31 @@ function getTargetBands(encounterClass, curves = null) {
   return cls.target_bands;
 }
 
+/**
+ * M9 P6: turn_limit_defeat per class. Null = no forced outcome.
+ * Consumed da sessionOutcomeResolver per force decision pressure.
+ *
+ * @returns {number|null} turn threshold, null se disabilitato
+ */
+function getTurnLimitDefeat(encounterClass, curves = null) {
+  const data = curves || loadDamageCurves();
+  if (!data || !data.encounter_classes) return null;
+  const cls = data.encounter_classes[encounterClass];
+  if (!cls || cls.turn_limit_defeat == null) return null;
+  const n = Number(cls.turn_limit_defeat);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+/**
+ * M9 P6: check se session turn corrente viola turn_limit_defeat per class.
+ * Ritorna true se turn >= limit (defeat va applicato).
+ */
+function isTurnLimitExceeded(turn, encounterClass, curves = null) {
+  const limit = getTurnLimitDefeat(encounterClass, curves);
+  if (limit == null) return false;
+  return Number(turn || 0) >= limit;
+}
+
 module.exports = {
   loadDamageCurves,
   getEncounterClass,
@@ -129,6 +154,8 @@ module.exports = {
   shouldEnrageBoss,
   getEnrageModBonus,
   getTargetBands,
+  getTurnLimitDefeat,
+  isTurnLimitExceeded,
   DEFAULT_CLASS,
   DEFAULT_PATH,
   _resetCache,

--- a/data/core/balance/damage_curves.yaml
+++ b/data/core/balance/damage_curves.yaml
@@ -30,6 +30,8 @@ encounter_classes:
       timeout_rate: [0.05, 0.10]
     enemy_damage_multiplier: 1.0
     boss_enrage_threshold_hp: null  # no enrage tutorial tier
+    # M9 P6: turn_limit_defeat null = no forced outcome (tutorial forgiving)
+    turn_limit_defeat: null
 
   tutorial_advanced:
     description: 'Late tutorial (04-05). Introduce mechanics status/boss (apex tier-1).'
@@ -39,6 +41,7 @@ encounter_classes:
       timeout_rate: [0.05, 0.15]
     enemy_damage_multiplier: 1.1
     boss_enrage_threshold_hp: 0.25
+    turn_limit_defeat: null
 
   standard:
     description: 'Mid-game encounters. Balanced threat, most common.'
@@ -48,6 +51,7 @@ encounter_classes:
       timeout_rate: [0.10, 0.20]
     enemy_damage_multiplier: 1.2
     boss_enrage_threshold_hp: 0.30
+    turn_limit_defeat: 30  # soft limit per standard, rare trigger
 
   hardcore:
     description: 'High-difficulty 8p co-op. Team tactical peak required.'
@@ -59,6 +63,11 @@ encounter_classes:
     # Vedi docs/playtest/2026-04-20-m7-iter6-hardcore-verdict.md § Option A+D.
     enemy_damage_multiplier: 1.8
     boss_enrage_threshold_hp: 0.40
+    # M9 P6 (Flint Long War pattern): force decision pressure.
+    # Turn >= 25 + player still alive + objective not completed → defeat.
+    # iter7 median turns_win=28 → budget 25 = risky but reachable con focus-fire.
+    # Elimina stalemate pattern (iter7 timeout 67%).
+    turn_limit_defeat: 25
 
   boss:
     description: 'Apex boss fight. Signature mechanics, dramatic enrage.'
@@ -70,6 +79,8 @@ encounter_classes:
     # Boss 1v2 player (solo fight), scaling piu aggressivo giustificato.
     enemy_damage_multiplier: 2.0
     boss_enrage_threshold_hp: 0.50
+    # M9 P6: boss 1v2 dura media 20 round. Limit 20 = kill boss o perdi.
+    turn_limit_defeat: 20
 
 # ─── Enemy tiers ──────────────────────────────────────────────────────
 # Base stats pre-class multiplier. Encounter spawn li legge + applica

--- a/tests/ai/damageCurves.test.js
+++ b/tests/ai/damageCurves.test.js
@@ -12,6 +12,8 @@ const {
   shouldEnrageBoss,
   getEnrageModBonus,
   getTargetBands,
+  getTurnLimitDefeat,
+  isTurnLimitExceeded,
   DEFAULT_CLASS,
   _resetCache,
 } = require('../../apps/backend/services/balance/damageCurves');
@@ -113,4 +115,54 @@ test('getTargetBands: null on unknown class', () => {
   _resetCache();
   loadDamageCurves();
   assert.equal(getTargetBands('unknown_class'), null);
+});
+
+// M9 P6 — turn_limit_defeat tests
+
+test('getTurnLimitDefeat: hardcore returns 25', () => {
+  _resetCache();
+  loadDamageCurves();
+  assert.equal(getTurnLimitDefeat('hardcore'), 25);
+});
+
+test('getTurnLimitDefeat: boss returns 20', () => {
+  _resetCache();
+  loadDamageCurves();
+  assert.equal(getTurnLimitDefeat('boss'), 20);
+});
+
+test('getTurnLimitDefeat: tutorial returns null (no limit)', () => {
+  _resetCache();
+  loadDamageCurves();
+  assert.equal(getTurnLimitDefeat('tutorial'), null);
+});
+
+test('getTurnLimitDefeat: unknown class returns null', () => {
+  _resetCache();
+  loadDamageCurves();
+  assert.equal(getTurnLimitDefeat('nonexistent'), null);
+});
+
+test('isTurnLimitExceeded: hardcore turn 25 → true', () => {
+  _resetCache();
+  loadDamageCurves();
+  assert.equal(isTurnLimitExceeded(25, 'hardcore'), true);
+});
+
+test('isTurnLimitExceeded: hardcore turn 24 → false', () => {
+  _resetCache();
+  loadDamageCurves();
+  assert.equal(isTurnLimitExceeded(24, 'hardcore'), false);
+});
+
+test('isTurnLimitExceeded: tutorial turn 999 → false (no limit)', () => {
+  _resetCache();
+  loadDamageCurves();
+  assert.equal(isTurnLimitExceeded(999, 'tutorial'), false);
+});
+
+test('isTurnLimitExceeded: turn 0 never triggers', () => {
+  _resetCache();
+  loadDamageCurves();
+  assert.equal(isTurnLimitExceeded(0, 'hardcore'), false);
 });

--- a/tests/scripts/test_calibrate_target_bands.py
+++ b/tests/scripts/test_calibrate_target_bands.py
@@ -13,7 +13,12 @@ sys.path.insert(0, os.path.join(ROOT, "tools", "py"))
 
 import pytest
 
-from batch_calibrate_hardcore06 import load_target_bands, verdict_for
+from batch_calibrate_hardcore06 import (
+    load_target_bands,
+    verdict_for,
+    load_turn_limit_defeat,
+    detect_outcome,
+)
 
 
 def test_load_all_classes():
@@ -82,6 +87,81 @@ def test_verdict_tutorial_band_permissive():
     b = load_target_bands("tutorial")
     v, _ = verdict_for(0.70, 0.15, 0.07, b)
     assert v == "GREEN"
+
+
+# M9 P6 tests — turn_limit_defeat force decision pressure
+
+
+def test_turn_limit_defeat_class_values():
+    assert load_turn_limit_defeat("tutorial") is None
+    assert load_turn_limit_defeat("tutorial_advanced") is None
+    assert load_turn_limit_defeat("standard") == 30
+    assert load_turn_limit_defeat("hardcore") == 25
+    assert load_turn_limit_defeat("boss") == 20
+
+
+def test_turn_limit_defeat_missing_class_returns_none():
+    assert load_turn_limit_defeat("nonexistent") is None
+
+
+def test_detect_outcome_legacy_mode_preserves_behavior():
+    """turn_limit None = legacy (timeout reaches MAX_ROUNDS naturally)."""
+    state_alive = {
+        "units": [
+            {"controlled_by": "player", "hp": 10},
+            {"controlled_by": "sistema", "hp": 5},
+        ],
+        "turn": 40,
+    }
+    assert detect_outcome(state_alive, None) is None
+
+
+def test_detect_outcome_turn_limit_triggers_defeat():
+    """turn >= limit + both alive = defeat (M9 P6)."""
+    state = {
+        "units": [
+            {"controlled_by": "player", "hp": 10},
+            {"controlled_by": "sistema", "hp": 5},
+        ],
+        "turn": 25,
+    }
+    assert detect_outcome(state, 25) == "defeat"
+
+
+def test_detect_outcome_turn_limit_not_yet_reached():
+    """turn < limit + both alive = in progress (None)."""
+    state = {
+        "units": [
+            {"controlled_by": "player", "hp": 10},
+            {"controlled_by": "sistema", "hp": 5},
+        ],
+        "turn": 24,
+    }
+    assert detect_outcome(state, 25) is None
+
+
+def test_detect_outcome_player_wipe_priority_over_turn_limit():
+    """Player wipe = defeat anche a turn < limit (priority)."""
+    state = {
+        "units": [
+            {"controlled_by": "player", "hp": 0},
+            {"controlled_by": "sistema", "hp": 5},
+        ],
+        "turn": 10,
+    }
+    assert detect_outcome(state, 25) == "defeat"
+
+
+def test_detect_outcome_victory_priority_over_turn_limit():
+    """Sistema wipe = victory anche oltre limit."""
+    state = {
+        "units": [
+            {"controlled_by": "player", "hp": 10},
+            {"controlled_by": "sistema", "hp": 0},
+        ],
+        "turn": 30,
+    }
+    assert detect_outcome(state, 25) == "victory"
 
 
 if __name__ == "__main__":

--- a/tools/py/batch_calibrate_hardcore06.py
+++ b/tools/py/batch_calibrate_hardcore06.py
@@ -96,6 +96,63 @@ def load_target_bands(encounter_class):
     return bands if bands else None
 
 
+def load_turn_limit_defeat(encounter_class):
+    """M9 P6: legge turn_limit_defeat da damage_curves.yaml per class.
+    Ritorna int>0 o None (no limit).
+
+    Mini-parser consistente con load_target_bands.
+    """
+    if not os.path.exists(DAMAGE_CURVES_PATH):
+        return None
+    try:
+        with open(DAMAGE_CURVES_PATH, "r", encoding="utf-8") as f:
+            raw = f.read()
+    except OSError:
+        return None
+
+    lines = raw.splitlines()
+    idx_class = None
+    in_classes = False
+    class_indent = None
+    for i, line in enumerate(lines):
+        if line.startswith("encounter_classes:"):
+            in_classes = True
+            continue
+        if not in_classes:
+            continue
+        m = re.match(r"^(\s+)(\w+):\s*$", line)
+        if m and m.group(2) == encounter_class:
+            idx_class = i
+            class_indent = len(m.group(1))
+            break
+        if line and not line.startswith(" ") and not line.startswith("#"):
+            break
+    if idx_class is None:
+        return None
+
+    j = idx_class + 1
+    while j < len(lines):
+        line = lines[j]
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            j += 1
+            continue
+        if line and len(line) - len(line.lstrip()) <= class_indent:
+            break
+        m = re.match(r"^\s+turn_limit_defeat:\s*(\S+)", line)
+        if m:
+            val = m.group(1).strip()
+            if val.lower() in ("null", "~", "none"):
+                return None
+            try:
+                n = int(val)
+                return n if n > 0 else None
+            except ValueError:
+                return None
+        j += 1
+    return None
+
+
 def verdict_for(win_rate, defeat_rate, timeout_rate, bands):
     """Ritorna (verdict, reasons) dati rates vs bands.
     verdict in {GREEN, AMBER, RED}.
@@ -282,12 +339,20 @@ def plan_player_intents(state, occupied):
     return intents
 
 
-def detect_outcome(state):
+def detect_outcome(state, turn_limit_defeat=None):
+    """M9 P6: turn_limit_defeat forza decision pressure.
+    Se turn >= limit + neither faction wiped → 'defeat' (invece di timeout).
+    Param None = legacy behavior (timeout rimane timeout).
+    """
     units = state.get("units", [])
     pa = [u for u in units if u.get("controlled_by") == "player" and u.get("hp", 0) > 0]
     ea = [u for u in units if u.get("controlled_by") == "sistema" and u.get("hp", 0) > 0]
     if not pa: return "defeat"
     if not ea: return "victory"
+    if turn_limit_defeat is not None:
+        current_turn = int(state.get("turn", 0) or 0)
+        if current_turn >= turn_limit_defeat:
+            return "defeat"
     return None
 
 
@@ -372,7 +437,7 @@ def _ai_actions_from_resp(resp, sis_actor_ids):
     return actions
 
 
-def run_one(host, run_idx):
+def run_one(host, run_idx, turn_limit_defeat=None):
     # Fetch scenario.
     status, sc = get(f"{host}/api/tutorial/{SCENARIO_ID}")
     if status != 200:
@@ -401,7 +466,7 @@ def run_one(host, run_idx):
 
     outcome = None
     for rnd in range(1, MAX_ROUNDS + 1):
-        outcome = detect_outcome(state)
+        outcome = detect_outcome(state, turn_limit_defeat)
         if outcome:
             break
         intents = plan_player_intents(state, None)
@@ -416,7 +481,7 @@ def run_one(host, run_idx):
             st_status, st = get(f"{host}/api/session/state?session_id={sid}")
             if st_status == 200:
                 state = st
-                outcome = detect_outcome(state)
+                outcome = detect_outcome(state, turn_limit_defeat)
             break
         state = resp.get("state", state)
         pressure_samples.append(state.get("sistema_pressure", pstart))
@@ -432,7 +497,7 @@ def run_one(host, run_idx):
             ai_intent_tally[key] = ai_intent_tally.get(key, 0) + 1
 
     if outcome is None:
-        outcome = detect_outcome(state) or "timeout"
+        outcome = detect_outcome(state, turn_limit_defeat) or "timeout"
 
     # Final metrics.
     final_units = {u["id"]: u for u in state.get("units", [])}
@@ -585,13 +650,18 @@ def main():
         probe_one(args.host)
         return 0
 
+    # M9 P6: load turn_limit_defeat per class (force decision pressure).
+    turn_limit_defeat = load_turn_limit_defeat(args.encounter_class)
+    if turn_limit_defeat:
+        print(f"M9 P6: turn_limit_defeat={turn_limit_defeat} for class '{args.encounter_class}' (Long War pattern)", flush=True)
+
     runs = []
     jsonl_fh = open(args.jsonl, "a", encoding="utf-8") if args.jsonl else None
     t0 = time.time()
     failures = 0
     try:
         for i in range(args.n):
-            r = run_one(args.host, i)
+            r = run_one(args.host, i, turn_limit_defeat=turn_limit_defeat)
             runs.append(r)
             if "error" in r:
                 failures += 1


### PR DESCRIPTION
## Summary

Evidence-based structural fix per iter7 RED deadlock (67% timeout hardcore). Pattern **Long War 2 mission timers**: timeout = defeat, force decision pressure. Stop multiplier tuning (knob exhausted M7 Phase E).

### Changes

**Data** `data/core/balance/damage_curves.yaml` — turn_limit_defeat per class:
| Class | Limit | Rationale |
|---|---:|---|
| tutorial | null | Forgiving onboarding |
| tutorial_advanced | null | Still onboarding |
| standard | 30 | Soft limit, rare trigger |
| **hardcore** | **25** | iter7 median win=28, tight budget |
| **boss** | **20** | 1v2 solo fight short decisive |

**Backend** `apps/backend/services/balance/damageCurves.js`:
- `getTurnLimitDefeat(class)` → int|null
- `isTurnLimitExceeded(turn, class)` → bool
- Exported

**Harness** `tools/py/batch_calibrate_hardcore06.py`:
- `load_turn_limit_defeat(class)` mini-YAML parser (stdlib-only)
- `detect_outcome(state, turn_limit_defeat=None)` — 3rd case turn>=limit + both alive → defeat
- `run_one()` + `main()` load + pass turn_limit per class
- Legacy behavior preserved se limit=None

### Tests

- `tests/ai/damageCurves.test.js`: +8 cases (getTurnLimitDefeat, isTurnLimitExceeded per class). **31/31 verde**
- `tests/scripts/test_calibrate_target_bands.py`: +7 cases (detect_outcome priorities). **16/16 verde**

## Test plan

- [x] All existing damage curves tests pass
- [x] New P6 tests verify: hardcore=25, boss=20, tutorial=null
- [x] detect_outcome priority: wipe → victory → turn_limit → None
- [ ] CI verde
- [ ] **iter8 N=30 post-merge** per valida verdict RED→GREEN

## References

- docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md § P6
- docs/playtest/2026-04-20-m7-iter7-phase-e-verdict.md § Option F
- Long War wiki [mission timers](https://xcom.substack.com/p/long-war-more-early-game-tactics)

## Next M9

- P4 axes promote partial→full (E_I + S_N + J_P)
- P3 xpLedger proof + stat bump level 1→2

🤖 Generated with [Claude Code](https://claude.com/claude-code)