### PR TITLE
feat(campaign): M10 Phase B — /api/campaign routes + store

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -20,6 +20,7 @@ const { createValidatorsRouter } = require('./routes/validators');
 const { createSessionRouter } = require('./routes/session');
 const { createFeedbackRouter } = require('./routes/feedback');
 const { createPartyRouter } = require('./routes/party');
+const { createCampaignRouter } = require('./routes/campaign');
 const { createNebulaTelemetryAggregator } = require('./services/nebulaTelemetryAggregator');
 const { createReleaseReporter } = require('./services/releaseReporter');
 const { createCatalogService } = require('./services/catalog');
@@ -683,6 +684,8 @@ function createApp(options = {}) {
   app.use('/api/party', createPartyRouter());
   // M7 demo playtest: feedback collection (/api/feedback, /api/feedback/summary)
   app.use('/api', createFeedbackRouter(options.feedback || {}));
+  // M10 Phase B: campaign persistence + branching (ADR-2026-04-21)
+  app.use('/api', createCampaignRouter(options.campaign || {}));
 
   app.get('/api/deployments/status', async (req, res) => {
     try {

--- a/apps/backend/routes/campaign.js
+++ b/apps/backend/routes/campaign.js
@@ -1,0 +1,248 @@
+// M10 Phase B — campaign routes.
+//
+// Endpoints (ADR-2026-04-21):
+//   POST /api/campaign/start   — create new campaign session
+//   GET  /api/campaign/state   — fetch current state (?id=<uuid>)
+//   POST /api/campaign/advance — advance to next encounter post outcome
+//   POST /api/campaign/choose  — apply binary branch choice (Descent pattern)
+//   POST /api/campaign/end     — finalize campaign (complete/abandon)
+//   GET  /api/campaign/list    — list campaigns for player (?player_id=)
+//
+// Payload shape canonical:
+//   POST /start       { player_id, campaign_def_id? }
+//   GET  /state       ?id=<uuid>
+//   POST /advance     { id, outcome: 'victory'|'defeat'|'timeout', pe_earned?, pi_earned? }
+//   POST /choose      { id, branch_key: 'cave_path' | 'ruins_path' }
+//   POST /end         { id, final_state: 'completed' | 'abandoned' }
+//   GET  /list        ?player_id=<id>
+
+'use strict';
+
+const express = require('express');
+const {
+  createCampaign,
+  getCampaign,
+  listCampaignsForPlayer,
+  updateCampaign,
+  recordChapter,
+} = require('../services/campaign/campaignStore');
+const {
+  loadCampaign: loadCampaignDef,
+  getEncountersForAct,
+  resolveBranch,
+} = require('../services/campaign/campaignLoader');
+
+function createCampaignRouter(options = {}) {
+  const router = express.Router();
+
+  // POST /api/campaign/start
+  router.post('/campaign/start', (req, res) => {
+    const { player_id, campaign_def_id } = req.body || {};
+    if (!player_id || typeof player_id !== 'string') {
+      return res.status(400).json({ error: 'player_id richiesto (string)' });
+    }
+    const defId = campaign_def_id || 'default_campaign_mvp';
+    const defDoc = loadCampaignDef(defId);
+    if (!defDoc) {
+      return res.status(404).json({ error: `campaign def "${defId}" non trovato` });
+    }
+    const campaign = createCampaign(player_id, defId);
+    const firstAct = defDoc.acts[0];
+    const firstEnc = (firstAct?.encounters || []).find((e) => !e.is_choice_node);
+    return res.status(201).json({
+      campaign,
+      next_encounter_id: firstEnc?.encounter_id || null,
+      campaign_def: {
+        name: defDoc.name,
+        narrative_hook: defDoc.narrative_hook,
+        total_acts: defDoc.total_acts,
+      },
+    });
+  });
+
+  // GET /api/campaign/state
+  router.get('/campaign/state', (req, res) => {
+    const id = req.query.id;
+    if (!id) return res.status(400).json({ error: 'id query param richiesto' });
+    const campaign = getCampaign(id);
+    if (!campaign) return res.status(404).json({ error: 'campaign non trovato' });
+    return res.json({ campaign });
+  });
+
+  // GET /api/campaign/list
+  router.get('/campaign/list', (req, res) => {
+    const playerId = req.query.player_id;
+    if (!playerId) return res.status(400).json({ error: 'player_id query param richiesto' });
+    const campaigns = listCampaignsForPlayer(playerId);
+    return res.json({ campaigns, count: campaigns.length });
+  });
+
+  // POST /api/campaign/advance
+  router.post('/campaign/advance', (req, res) => {
+    const { id, outcome, pe_earned, pi_earned } = req.body || {};
+    if (!id) return res.status(400).json({ error: 'id richiesto' });
+    if (!['victory', 'defeat', 'timeout'].includes(outcome)) {
+      return res.status(400).json({ error: 'outcome deve essere victory|defeat|timeout' });
+    }
+    const campaign = getCampaign(id);
+    if (!campaign) return res.status(404).json({ error: 'campaign non trovato' });
+    if (campaign.finalState) {
+      return res.status(409).json({ error: `campaign già finalizzata (${campaign.finalState})` });
+    }
+
+    const defDoc = loadCampaignDef(campaign.campaignDefId);
+    if (!defDoc) return res.status(500).json({ error: 'campaign def mancante' });
+
+    const act = defDoc.acts.find((a) => a.act_idx === campaign.currentAct);
+    if (!act) return res.status(500).json({ error: 'act corrente non trovato in def' });
+
+    // Find current encounter in act via chapter_idx
+    const currentEncEntry = (act.encounters || []).find(
+      (e) => e.chapter_idx === campaign.currentChapter,
+    );
+    const currentEncId = currentEncEntry?.encounter_id || null;
+
+    // Record chapter outcome
+    const lastBranch =
+      campaign.branchChoices.length > 0
+        ? campaign.branchChoices[campaign.branchChoices.length - 1]
+        : null;
+    recordChapter(id, {
+      chapterIdx: campaign.currentChapter,
+      actIdx: campaign.currentAct,
+      encounterId: currentEncId,
+      outcome,
+      peEarned: pe_earned,
+      piEarned: pi_earned,
+      branchChosen: lastBranch,
+    });
+
+    // Compute next state
+    let updated;
+    if (outcome !== 'victory') {
+      // Defeat/timeout: pause campaign (not finalize). Player can retry same encounter.
+      updated = updateCampaign(id, {}); // just bump updatedAt
+      return res.json({
+        campaign: updated,
+        next_encounter_id: currentEncId, // retry same
+        retry: true,
+      });
+    }
+
+    // Victory: advance chapter
+    const nextChapterIdx = campaign.currentChapter + 1;
+    const allEncounters = act.encounters || [];
+    const branchKey = lastBranch;
+    // Filter encounters for current branch path (if branch started)
+    const pathEncounters = branchKey
+      ? getEncountersForAct(defDoc, campaign.currentAct, branchKey)
+      : allEncounters;
+    const nextEncEntry = pathEncounters.find((e) => e.chapter_idx === nextChapterIdx);
+
+    // If next is choice_node, surface it
+    if (nextEncEntry?.is_choice_node) {
+      updated = updateCampaign(id, { currentChapter: nextChapterIdx });
+      return res.json({
+        campaign: updated,
+        next_encounter_id: null,
+        choice_required: true,
+        choice_node: nextEncEntry.choice,
+      });
+    }
+
+    // If no next encounter in act → check next act
+    if (!nextEncEntry) {
+      const nextActIdx = campaign.currentAct + 1;
+      const nextAct = defDoc.acts.find((a) => a.act_idx === nextActIdx);
+      if (!nextAct) {
+        // Campaign completed
+        updated = updateCampaign(id, {
+          finalState: 'completed',
+          completionPct: 1.0,
+          currentChapter: nextChapterIdx,
+        });
+        return res.json({ campaign: updated, next_encounter_id: null, campaign_completed: true });
+      }
+      // Advance to next act
+      const firstEncNextAct = (nextAct.encounters || []).find((e) => !e.is_choice_node);
+      updated = updateCampaign(id, {
+        currentAct: nextActIdx,
+        currentChapter: firstEncNextAct?.chapter_idx || 1,
+      });
+      return res.json({
+        campaign: updated,
+        next_encounter_id: firstEncNextAct?.encounter_id || null,
+        act_advanced: true,
+      });
+    }
+
+    // Normal advance in same act
+    updated = updateCampaign(id, { currentChapter: nextChapterIdx });
+    return res.json({
+      campaign: updated,
+      next_encounter_id: nextEncEntry.encounter_id,
+    });
+  });
+
+  // POST /api/campaign/choose
+  router.post('/campaign/choose', (req, res) => {
+    const { id, branch_key } = req.body || {};
+    if (!id) return res.status(400).json({ error: 'id richiesto' });
+    if (!branch_key) return res.status(400).json({ error: 'branch_key richiesto' });
+    const campaign = getCampaign(id);
+    if (!campaign) return res.status(404).json({ error: 'campaign non trovato' });
+    if (campaign.finalState) {
+      return res.status(409).json({ error: `campaign già finalizzata (${campaign.finalState})` });
+    }
+
+    const defDoc = loadCampaignDef(campaign.campaignDefId);
+    if (!defDoc) return res.status(500).json({ error: 'campaign def mancante' });
+
+    const nextEncId = resolveBranch(defDoc, campaign.currentAct, branch_key);
+    if (!nextEncId) {
+      return res
+        .status(400)
+        .json({ error: `branch_key "${branch_key}" invalido per act ${campaign.currentAct}` });
+    }
+
+    // Find encounter chapter_idx for next branch encounter
+    const act = defDoc.acts.find((a) => a.act_idx === campaign.currentAct);
+    const nextEncEntry = (act.encounters || []).find(
+      (e) => e.encounter_id === nextEncId && e.branch_key === branch_key,
+    );
+
+    const updated = updateCampaign(id, {
+      branchChoices: [...campaign.branchChoices, branch_key],
+      currentChapter: nextEncEntry?.chapter_idx || campaign.currentChapter + 1,
+    });
+
+    return res.json({
+      campaign: updated,
+      next_encounter_id: nextEncId,
+      branch_key,
+    });
+  });
+
+  // POST /api/campaign/end
+  router.post('/campaign/end', (req, res) => {
+    const { id, final_state } = req.body || {};
+    if (!id) return res.status(400).json({ error: 'id richiesto' });
+    if (!['completed', 'abandoned'].includes(final_state)) {
+      return res.status(400).json({ error: 'final_state deve essere completed|abandoned' });
+    }
+    const campaign = getCampaign(id);
+    if (!campaign) return res.status(404).json({ error: 'campaign non trovato' });
+    if (campaign.finalState) {
+      return res.status(409).json({ error: `già finalizzata (${campaign.finalState})` });
+    }
+    const updated = updateCampaign(id, {
+      finalState: final_state,
+      completionPct: final_state === 'completed' ? 1.0 : campaign.completionPct,
+    });
+    return res.json({ campaign: updated });
+  });
+
+  return router;
+}
+
+module.exports = { createCampaignRouter };

--- a/apps/backend/services/campaign/campaignStore.js
+++ b/apps/backend/services/campaign/campaignStore.js
@@ -1,0 +1,140 @@
+// M10 Phase B — campaign state store.
+//
+// Adapter pattern: in-memory Map storage per MVP demo (NeDB-compatible
+// architettura). Phase B-future swap to Prisma Campaign model quando
+// DATABASE_URL configurato.
+//
+// API:
+//   - createCampaign(playerId, campaignDefId): new session
+//   - getCampaign(id): fetch by UUID
+//   - listCampaignsForPlayer(playerId): all of one player
+//   - updateCampaign(id, patch): apply state mutation
+//   - recordChapter(id, chapter): append Chapter record
+//   - deleteCampaign(id): remove (rollback/reset)
+//
+// State shape coerente con Prisma Campaign model (ADR-2026-04-21):
+//   {
+//     id, playerId, campaignDefId,
+//     currentChapter, currentAct,
+//     branchChoices: [],          // array of binary choice keys
+//     completionPct,
+//     finalState,                 // 'completed' | 'abandoned' | null
+//     chapters: [{chapterIdx, actIdx, encounterId, outcome, peEarned, piEarned, branchChosen}]
+//     partyRoster: [],            // deferred M10 Phase D (Nido integration)
+//     createdAt, updatedAt
+//   }
+
+'use strict';
+
+const crypto = require('node:crypto');
+
+const _campaigns = new Map(); // id → campaign
+const _playerIndex = new Map(); // playerId → Set<campaignId>
+
+function _uuid() {
+  return crypto.randomUUID();
+}
+
+function _now() {
+  return new Date().toISOString();
+}
+
+/**
+ * Create new campaign session.
+ *
+ * @param {string} playerId
+ * @param {string} [campaignDefId='default_campaign_mvp']
+ * @returns {object} new campaign
+ */
+function createCampaign(playerId, campaignDefId = 'default_campaign_mvp') {
+  if (!playerId || typeof playerId !== 'string') {
+    throw new Error('createCampaign: playerId richiesto (string)');
+  }
+  const id = _uuid();
+  const now = _now();
+  const campaign = {
+    id,
+    playerId,
+    campaignDefId,
+    currentChapter: 1,
+    currentAct: 0, // Act 0 = tutorial onboarding
+    branchChoices: [],
+    completionPct: 0.0,
+    finalState: null,
+    chapters: [],
+    partyRoster: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+  _campaigns.set(id, campaign);
+  if (!_playerIndex.has(playerId)) _playerIndex.set(playerId, new Set());
+  _playerIndex.get(playerId).add(id);
+  return campaign;
+}
+
+function getCampaign(id) {
+  return _campaigns.get(id) || null;
+}
+
+function listCampaignsForPlayer(playerId) {
+  const ids = _playerIndex.get(playerId);
+  if (!ids) return [];
+  return [...ids].map((id) => _campaigns.get(id)).filter(Boolean);
+}
+
+/**
+ * Apply partial patch to campaign. Immutable-ish: crea nuova entry +
+ * updates _updatedAt automatically.
+ */
+function updateCampaign(id, patch) {
+  const cur = _campaigns.get(id);
+  if (!cur) return null;
+  const next = { ...cur, ...patch, updatedAt: _now() };
+  _campaigns.set(id, next);
+  return next;
+}
+
+/**
+ * Append chapter record to campaign.chapters.
+ */
+function recordChapter(id, chapter) {
+  const cur = _campaigns.get(id);
+  if (!cur) return null;
+  const entry = {
+    chapterIdx: chapter.chapterIdx,
+    actIdx: chapter.actIdx,
+    encounterId: chapter.encounterId,
+    outcome: chapter.outcome || null,
+    peEarned: Number(chapter.peEarned || 0),
+    piEarned: Number(chapter.piEarned || 0),
+    branchChosen: chapter.branchChosen || null,
+    completedAt: chapter.outcome ? _now() : null,
+  };
+  const nextChapters = [...cur.chapters, entry];
+  return updateCampaign(id, { chapters: nextChapters });
+}
+
+function deleteCampaign(id) {
+  const cur = _campaigns.get(id);
+  if (!cur) return false;
+  _campaigns.delete(id);
+  const playerIds = _playerIndex.get(cur.playerId);
+  if (playerIds) playerIds.delete(id);
+  return true;
+}
+
+/** Reset store (per test). */
+function _resetStore() {
+  _campaigns.clear();
+  _playerIndex.clear();
+}
+
+module.exports = {
+  createCampaign,
+  getCampaign,
+  listCampaignsForPlayer,
+  updateCampaign,
+  recordChapter,
+  deleteCampaign,
+  _resetStore,
+};

--- a/tests/api/campaignRoutes.test.js
+++ b/tests/api/campaignRoutes.test.js
@@ -1,0 +1,208 @@
+// M10 Phase B — /api/campaign routes integration tests.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const http = require('node:http');
+
+const { createCampaignRouter } = require('../../apps/backend/routes/campaign');
+const { _resetStore } = require('../../apps/backend/services/campaign/campaignStore');
+const { _resetCache } = require('../../apps/backend/services/campaign/campaignLoader');
+
+function startTestServer(t) {
+  _resetStore();
+  _resetCache();
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createCampaignRouter());
+  const server = app.listen(0);
+  const port = server.address().port;
+  t.after(() => server.close());
+  return { port, url: `http://127.0.0.1:${port}` };
+}
+
+function request(method, url, body = null) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const opts = {
+      hostname: parsed.hostname,
+      port: parsed.port,
+      path: parsed.pathname + parsed.search,
+      method,
+      headers: { 'content-type': 'application/json' },
+    };
+    const req = http.request(opts, (res) => {
+      let data = '';
+      res.on('data', (c) => (data += c));
+      res.on('end', () => {
+        let parsedBody = null;
+        try {
+          parsedBody = data ? JSON.parse(data) : null;
+        } catch (e) {
+          parsedBody = data;
+        }
+        resolve({ status: res.statusCode, body: parsedBody });
+      });
+    });
+    req.on('error', reject);
+    if (body) req.write(JSON.stringify(body));
+    req.end();
+  });
+}
+
+test('POST /api/campaign/start: creates new campaign', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('POST', `${url}/api/campaign/start`, { player_id: 'p1' });
+  assert.equal(res.status, 201);
+  assert.ok(res.body.campaign.id);
+  assert.equal(res.body.campaign.playerId, 'p1');
+  assert.equal(res.body.campaign.currentAct, 0);
+  assert.equal(res.body.campaign.currentChapter, 1);
+  assert.equal(res.body.next_encounter_id, 'enc_tutorial_01');
+  assert.ok(res.body.campaign_def.narrative_hook);
+});
+
+test('POST /api/campaign/start: missing player_id = 400', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('POST', `${url}/api/campaign/start`, {});
+  assert.equal(res.status, 400);
+});
+
+test('POST /api/campaign/start: invalid campaign_def_id = 404', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('POST', `${url}/api/campaign/start`, {
+    player_id: 'p1',
+    campaign_def_id: 'nonexistent',
+  });
+  assert.equal(res.status, 404);
+});
+
+test('GET /api/campaign/state: fetch campaign by id', async (t) => {
+  const { url } = startTestServer(t);
+  const create = await request('POST', `${url}/api/campaign/start`, { player_id: 'p1' });
+  const id = create.body.campaign.id;
+  const res = await request('GET', `${url}/api/campaign/state?id=${id}`);
+  assert.equal(res.status, 200);
+  assert.equal(res.body.campaign.id, id);
+});
+
+test('GET /api/campaign/state: missing id = 400', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('GET', `${url}/api/campaign/state`);
+  assert.equal(res.status, 400);
+});
+
+test('GET /api/campaign/list: player campaigns', async (t) => {
+  const { url } = startTestServer(t);
+  await request('POST', `${url}/api/campaign/start`, { player_id: 'p1' });
+  await request('POST', `${url}/api/campaign/start`, { player_id: 'p1' });
+  await request('POST', `${url}/api/campaign/start`, { player_id: 'p2' });
+  const res = await request('GET', `${url}/api/campaign/list?player_id=p1`);
+  assert.equal(res.status, 200);
+  assert.equal(res.body.count, 2);
+});
+
+test('POST /api/campaign/advance: victory advances chapter', async (t) => {
+  const { url } = startTestServer(t);
+  const create = await request('POST', `${url}/api/campaign/start`, { player_id: 'p1' });
+  const id = create.body.campaign.id;
+  const res = await request('POST', `${url}/api/campaign/advance`, {
+    id,
+    outcome: 'victory',
+    pe_earned: 3,
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.campaign.currentChapter, 2);
+  assert.equal(res.body.next_encounter_id, 'enc_tutorial_02');
+  assert.equal(res.body.campaign.chapters.length, 1);
+  assert.equal(res.body.campaign.chapters[0].outcome, 'victory');
+  assert.equal(res.body.campaign.chapters[0].peEarned, 3);
+});
+
+test('POST /api/campaign/advance: defeat retries same encounter', async (t) => {
+  const { url } = startTestServer(t);
+  const create = await request('POST', `${url}/api/campaign/start`, { player_id: 'p1' });
+  const id = create.body.campaign.id;
+  const res = await request('POST', `${url}/api/campaign/advance`, {
+    id,
+    outcome: 'defeat',
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.retry, true);
+  assert.equal(res.body.next_encounter_id, 'enc_tutorial_01'); // same
+  // chapter not advanced
+  assert.equal(res.body.campaign.currentChapter, 1);
+});
+
+test('POST /api/campaign/advance: invalid outcome = 400', async (t) => {
+  const { url } = startTestServer(t);
+  const create = await request('POST', `${url}/api/campaign/start`, { player_id: 'p1' });
+  const id = create.body.campaign.id;
+  const res = await request('POST', `${url}/api/campaign/advance`, { id, outcome: 'invalid' });
+  assert.equal(res.status, 400);
+});
+
+test('POST /api/campaign/choose: applies branch + advances', async (t) => {
+  const { url } = startTestServer(t);
+  const create = await request('POST', `${url}/api/campaign/start`, { player_id: 'p1' });
+  const id = create.body.campaign.id;
+
+  // Fast-forward: advance through Act 0 tutorial (5 encounters victory)
+  for (let i = 0; i < 5; i++) {
+    await request('POST', `${url}/api/campaign/advance`, { id, outcome: 'victory' });
+  }
+  // Now should be at Act 1 chapter 6 (enc_savana_01)
+  await request('POST', `${url}/api/campaign/advance`, { id, outcome: 'victory' });
+  // Now chapter 7 = choice_node
+
+  const res = await request('POST', `${url}/api/campaign/choose`, {
+    id,
+    branch_key: 'cave_path',
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.next_encounter_id, 'enc_caverna_02');
+  assert.deepEqual(res.body.campaign.branchChoices, ['cave_path']);
+});
+
+test('POST /api/campaign/choose: invalid branch_key = 400', async (t) => {
+  const { url } = startTestServer(t);
+  const create = await request('POST', `${url}/api/campaign/start`, { player_id: 'p1' });
+  const id = create.body.campaign.id;
+  const res = await request('POST', `${url}/api/campaign/choose`, {
+    id,
+    branch_key: 'invalid_branch',
+  });
+  assert.equal(res.status, 400);
+});
+
+test('POST /api/campaign/end: finalize completed', async (t) => {
+  const { url } = startTestServer(t);
+  const create = await request('POST', `${url}/api/campaign/start`, { player_id: 'p1' });
+  const id = create.body.campaign.id;
+  const res = await request('POST', `${url}/api/campaign/end`, {
+    id,
+    final_state: 'completed',
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.campaign.finalState, 'completed');
+  assert.equal(res.body.campaign.completionPct, 1.0);
+});
+
+test('POST /api/campaign/end: already finalized = 409', async (t) => {
+  const { url } = startTestServer(t);
+  const create = await request('POST', `${url}/api/campaign/start`, { player_id: 'p1' });
+  const id = create.body.campaign.id;
+  await request('POST', `${url}/api/campaign/end`, { id, final_state: 'abandoned' });
+  const res = await request('POST', `${url}/api/campaign/end`, { id, final_state: 'completed' });
+  assert.equal(res.status, 409);
+});
+
+test('POST /api/campaign/advance: on finalized campaign = 409', async (t) => {
+  const { url } = startTestServer(t);
+  const create = await request('POST', `${url}/api/campaign/start`, { player_id: 'p1' });
+  const id = create.body.campaign.id;
+  await request('POST', `${url}/api/campaign/end`, { id, final_state: 'completed' });
+  const res = await request('POST', `${url}/api/campaign/advance`, { id, outcome: 'victory' });
+  assert.equal(res.status, 409);
+});


### PR DESCRIPTION
## Summary

M10 Phase B — 6 REST endpoint per campaign persistence + adapter-pattern store (in-memory MVP, Prisma swap future).

### Endpoints

| Method | Path | Purpose |
|---|---|---|
| POST | /api/campaign/start | Create session |
| GET | /api/campaign/state?id= | Fetch state |
| GET | /api/campaign/list?player_id= | List player campaigns |
| POST | /api/campaign/advance | Outcome victory/defeat/timeout |
| POST | /api/campaign/choose | Binary branch (Descent pattern) |
| POST | /api/campaign/end | Finalize completed/abandoned |

### Files

1. `apps/backend/services/campaign/campaignStore.js` — adapter store (Map-based in-memory, shape Prisma-compat)
2. `apps/backend/routes/campaign.js` — Express router con advance logic (victory chapter++, defeat retry, choice_node surface, act transition, campaign completion)
3. `apps/backend/app.js` — wire `/api` router
4. `tests/api/campaignRoutes.test.js` — 14 test HTTP integration

### Test plan

- [x] 14/14 campaign routes integration
- [x] 18/18 Phase A loader (regression clean)
- [x] 237/237 AI suite (regression clean)
- [ ] CI verde

### Flow validated

```
start → enc_tutorial_01 → advance(victory) × 5 → enc_savana_01
  → advance(victory) → choice_node surface
  → choose(cave_path) → enc_caverna_02
  → advance(victory) → boss enc_tutorial_06_hardcore
  → advance(victory) → act complete → campaign completed
```

### Next phases

- **C** (~3h): campaignEngine.js logic separation + progress calculation
- **D** (~3h): frontend campaignPanel.js UI
- **E** (~2h): end-to-end integration test

### References

- ADR-2026-04-21 Campaign save persistence
- PR #1665 Phase A (YAML + loader)

🤖 Generated with [Claude Code](https://claude.com/claude-code)