### PR TITLE
feat(campaign): M10 Phase C — engine helpers + /summary endpoint

### DIFF
--- a/apps/backend/routes/campaign.js
+++ b/apps/backend/routes/campaign.js
@@ -31,6 +31,7 @@ const {
   getEncountersForAct,
   resolveBranch,
 } = require('../services/campaign/campaignLoader');
+const { summariseCampaign } = require('../services/campaign/campaignEngine');
 
 function createCampaignRouter(options = {}) {
   const router = express.Router();
@@ -75,6 +76,18 @@ function createCampaignRouter(options = {}) {
     if (!playerId) return res.status(400).json({ error: 'player_id query param richiesto' });
     const campaigns = listCampaignsForPlayer(playerId);
     return res.json({ campaigns, count: campaigns.length });
+  });
+
+  // M10 Phase C: GET /api/campaign/summary — UI state snapshot via engine
+  router.get('/campaign/summary', (req, res) => {
+    const id = req.query.id;
+    if (!id) return res.status(400).json({ error: 'id query param richiesto' });
+    const campaign = getCampaign(id);
+    if (!campaign) return res.status(404).json({ error: 'campaign non trovato' });
+    const defDoc = loadCampaignDef(campaign.campaignDefId);
+    if (!defDoc) return res.status(500).json({ error: 'campaign def mancante' });
+    const summary = summariseCampaign(campaign, defDoc);
+    return res.json(summary);
   });
 
   // POST /api/campaign/advance

--- a/apps/backend/services/campaign/campaignEngine.js
+++ b/apps/backend/services/campaign/campaignEngine.js
@@ -1,0 +1,185 @@
+// M10 Phase C — campaign engine pure functions.
+//
+// Pure logic extractable (no store mutation, no I/O):
+//   - computeProgress(campaign, def): % completion basato su chapter
+//   - getCurrentEncounter(campaign, def): encounter attuale da state
+//   - getNextEncounter(campaign, def): next post-advance logic
+//   - canAdvance(campaign): può advance?
+//   - canChoose(campaign, def): choice_node reachable?
+//   - getBranchPath(campaign): history binary choices
+//   - summariseCampaign(campaign, def): full UI state snapshot
+//
+// Usage:
+//   const engine = require('./campaignEngine');
+//   const summary = engine.summariseCampaign(campaign, defDoc);
+//   res.json(summary); // frontend consumes
+//
+// Ref ADR-2026-04-21.
+
+'use strict';
+
+/**
+ * Count total non-choice encounter entries in def (for progress calc).
+ * Exclude choice_node entries (not "playable", just branch markers).
+ */
+function _totalPlayableEncounters(def) {
+  if (!def || !Array.isArray(def.acts)) return 0;
+  let total = 0;
+  for (const act of def.acts) {
+    const enc = act.encounters || [];
+    total += enc.filter((e) => !e.is_choice_node && e.encounter_id).length;
+  }
+  return total;
+}
+
+/**
+ * Compute % completion.
+ * Pure: non muta campaign.
+ *
+ * Formula: (chapters.filter(victory).length / totalPlayable) clamped [0, 1].
+ * finalState=completed → 1.0 forced. abandoned → whatever achieved (not 1.0).
+ */
+function computeProgress(campaign, def) {
+  if (!campaign) return 0.0;
+  if (campaign.finalState === 'completed') return 1.0;
+  const total = _totalPlayableEncounters(def);
+  if (total === 0) return 0.0;
+  const completed = (campaign.chapters || []).filter((c) => c.outcome === 'victory').length;
+  return Math.min(1.0, Math.max(0.0, completed / total));
+}
+
+/**
+ * Get current encounter entry from def based on campaign.currentAct + chapter.
+ * Factoring in branch_key if reached.
+ */
+function getCurrentEncounter(campaign, def) {
+  if (!campaign || !def) return null;
+  const act = (def.acts || []).find((a) => a.act_idx === campaign.currentAct);
+  if (!act) return null;
+  const branchKey = getBranchPath(campaign).slice(-1)[0] || null;
+  const encounters = act.encounters || [];
+  // Match chapter_idx + branch (if in branch, filter)
+  const candidates = encounters.filter((e) => {
+    if (e.chapter_idx !== campaign.currentChapter) return false;
+    if (!e.branch_key) return true; // linear
+    return e.branch_key === branchKey;
+  });
+  return candidates[0] || null;
+}
+
+/**
+ * Peek next encounter (post-hypothetical-victory) without mutating state.
+ * Returns {next_encounter_id, choice_required, next_act} object.
+ */
+function getNextEncounter(campaign, def) {
+  if (!campaign || !def) return { next_encounter_id: null };
+  const act = (def.acts || []).find((a) => a.act_idx === campaign.currentAct);
+  if (!act) return { next_encounter_id: null };
+  const nextChapterIdx = campaign.currentChapter + 1;
+  const branchKey = getBranchPath(campaign).slice(-1)[0] || null;
+  const encounters = act.encounters || [];
+  const pathEncounters = branchKey
+    ? encounters.filter((e) => !e.branch_key || e.branch_key === branchKey || e.is_choice_node)
+    : encounters;
+  const nextEntry = pathEncounters.find((e) => e.chapter_idx === nextChapterIdx);
+
+  if (nextEntry?.is_choice_node) {
+    return {
+      next_encounter_id: null,
+      choice_required: true,
+      choice_node: nextEntry.choice,
+    };
+  }
+  if (nextEntry) {
+    return { next_encounter_id: nextEntry.encounter_id };
+  }
+  // Check next act
+  const nextActIdx = campaign.currentAct + 1;
+  const nextAct = (def.acts || []).find((a) => a.act_idx === nextActIdx);
+  if (!nextAct) {
+    return { next_encounter_id: null, campaign_completed: true };
+  }
+  const firstEnc = (nextAct.encounters || []).find((e) => !e.is_choice_node);
+  return {
+    next_encounter_id: firstEnc?.encounter_id || null,
+    next_act: nextActIdx,
+  };
+}
+
+/**
+ * Can campaign be advanced? False se finalizzata.
+ */
+function canAdvance(campaign) {
+  if (!campaign) return false;
+  return !campaign.finalState;
+}
+
+/**
+ * Is current chapter a choice_node requiring player input?
+ */
+function canChoose(campaign, def) {
+  if (!canAdvance(campaign)) return false;
+  if (!def) return false;
+  const act = (def.acts || []).find((a) => a.act_idx === campaign.currentAct);
+  if (!act) return false;
+  const currentEnc = (act.encounters || []).find((e) => e.chapter_idx === campaign.currentChapter);
+  return !!(currentEnc && currentEnc.is_choice_node);
+}
+
+/**
+ * Extract branch path history (array binary choice keys).
+ */
+function getBranchPath(campaign) {
+  if (!campaign || !Array.isArray(campaign.branchChoices)) return [];
+  return [...campaign.branchChoices];
+}
+
+/**
+ * Full summary for UI. Composable output per frontend.
+ *
+ * @returns {object} { campaign, current_encounter, next_encounter,
+ *                     progress, can_advance, can_choose, branch_path,
+ *                     completion_status }
+ */
+function summariseCampaign(campaign, def) {
+  if (!campaign) return null;
+  const currentEnc = getCurrentEncounter(campaign, def);
+  const next = getNextEncounter(campaign, def);
+  const progress = computeProgress(campaign, def);
+  const completion_status = campaign.finalState
+    ? campaign.finalState
+    : progress >= 1.0
+      ? 'completed'
+      : 'in_progress';
+  return {
+    campaign,
+    current_encounter: currentEnc
+      ? {
+          encounter_id: currentEnc.encounter_id || null,
+          chapter_idx: currentEnc.chapter_idx,
+          act_idx: campaign.currentAct,
+          narrative_pre: currentEnc.narrative_pre || null,
+          narrative_post: currentEnc.narrative_post || null,
+          is_choice_node: !!currentEnc.is_choice_node,
+          choice: currentEnc.choice || null,
+        }
+      : null,
+    next_encounter: next,
+    progress,
+    can_advance: canAdvance(campaign),
+    can_choose: canChoose(campaign, def),
+    branch_path: getBranchPath(campaign),
+    completion_status,
+  };
+}
+
+module.exports = {
+  computeProgress,
+  getCurrentEncounter,
+  getNextEncounter,
+  canAdvance,
+  canChoose,
+  getBranchPath,
+  summariseCampaign,
+  _totalPlayableEncounters,
+};

--- a/tests/ai/campaignEngine.test.js
+++ b/tests/ai/campaignEngine.test.js
@@ -1,0 +1,201 @@
+// M10 Phase C — campaignEngine.js unit tests.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  computeProgress,
+  getCurrentEncounter,
+  getNextEncounter,
+  canAdvance,
+  canChoose,
+  getBranchPath,
+  summariseCampaign,
+  _totalPlayableEncounters,
+} = require('../../apps/backend/services/campaign/campaignEngine');
+
+const {
+  loadCampaign,
+  _resetCache,
+} = require('../../apps/backend/services/campaign/campaignLoader');
+
+function _baseCampaign(overrides = {}) {
+  return {
+    id: 'test-uuid',
+    playerId: 'p1',
+    campaignDefId: 'default_campaign_mvp',
+    currentChapter: 1,
+    currentAct: 0,
+    branchChoices: [],
+    completionPct: 0.0,
+    finalState: null,
+    chapters: [],
+    partyRoster: [],
+    createdAt: '2026-04-20T00:00:00Z',
+    updatedAt: '2026-04-20T00:00:00Z',
+    ...overrides,
+  };
+}
+
+test('_totalPlayableEncounters: default_campaign_mvp = 9', () => {
+  _resetCache();
+  const def = loadCampaign('default_campaign_mvp');
+  // 5 tutorial (Act 0) + 4 Act 1 (savana + 2 branch alts only 1 playable at a time) + boss
+  // Real count: 5 + 4 = 9 playable encounter entries (excl. choice node)
+  const total = _totalPlayableEncounters(def);
+  assert.equal(total, 9);
+});
+
+test('computeProgress: zero chapters = 0.0', () => {
+  _resetCache();
+  const def = loadCampaign('default_campaign_mvp');
+  const camp = _baseCampaign();
+  assert.equal(computeProgress(camp, def), 0);
+});
+
+test('computeProgress: 5 victory over 9 = 0.55', () => {
+  _resetCache();
+  const def = loadCampaign('default_campaign_mvp');
+  const camp = _baseCampaign({
+    chapters: [
+      { outcome: 'victory' },
+      { outcome: 'victory' },
+      { outcome: 'victory' },
+      { outcome: 'victory' },
+      { outcome: 'victory' },
+    ],
+  });
+  const prog = computeProgress(camp, def);
+  assert.ok(prog >= 0.55 && prog <= 0.56, `got ${prog}`);
+});
+
+test('computeProgress: finalState completed = 1.0', () => {
+  _resetCache();
+  const def = loadCampaign('default_campaign_mvp');
+  const camp = _baseCampaign({ finalState: 'completed' });
+  assert.equal(computeProgress(camp, def), 1.0);
+});
+
+test('computeProgress: defeat chapters not counted', () => {
+  _resetCache();
+  const def = loadCampaign('default_campaign_mvp');
+  const camp = _baseCampaign({
+    chapters: [{ outcome: 'defeat' }, { outcome: 'timeout' }, { outcome: 'victory' }],
+  });
+  const prog = computeProgress(camp, def);
+  assert.ok(prog >= 0.11 && prog <= 0.12, `got ${prog}`);
+});
+
+test('getCurrentEncounter: chapter 1 Act 0 = enc_tutorial_01', () => {
+  _resetCache();
+  const def = loadCampaign('default_campaign_mvp');
+  const camp = _baseCampaign();
+  const enc = getCurrentEncounter(camp, def);
+  assert.ok(enc);
+  assert.equal(enc.encounter_id, 'enc_tutorial_01');
+});
+
+test('getNextEncounter: chapter 1 victory → chapter 2 = enc_tutorial_02', () => {
+  _resetCache();
+  const def = loadCampaign('default_campaign_mvp');
+  const camp = _baseCampaign();
+  const next = getNextEncounter(camp, def);
+  assert.equal(next.next_encounter_id, 'enc_tutorial_02');
+});
+
+test('getNextEncounter: Act 0 last (ch 5) → Act 1 transition = enc_savana_01', () => {
+  _resetCache();
+  const def = loadCampaign('default_campaign_mvp');
+  const camp = _baseCampaign({ currentChapter: 5, currentAct: 0 });
+  const next = getNextEncounter(camp, def);
+  assert.equal(next.next_encounter_id, 'enc_savana_01');
+  assert.equal(next.next_act, 1);
+});
+
+test('getNextEncounter: chapter 6 → chapter 7 choice_node required', () => {
+  _resetCache();
+  const def = loadCampaign('default_campaign_mvp');
+  const camp = _baseCampaign({ currentChapter: 6, currentAct: 1 });
+  const next = getNextEncounter(camp, def);
+  assert.equal(next.choice_required, true);
+  assert.ok(next.choice_node);
+  assert.equal(next.choice_node.option_a.branch_key, 'cave_path');
+});
+
+test('getNextEncounter: boss defeated → campaign_completed', () => {
+  _resetCache();
+  const def = loadCampaign('default_campaign_mvp');
+  const camp = _baseCampaign({
+    currentChapter: 9,
+    currentAct: 1,
+    branchChoices: ['cave_path'],
+  });
+  const next = getNextEncounter(camp, def);
+  assert.equal(next.campaign_completed, true);
+});
+
+test('canAdvance: false if finalState set', () => {
+  const camp = _baseCampaign({ finalState: 'completed' });
+  assert.equal(canAdvance(camp), false);
+});
+
+test('canAdvance: true default', () => {
+  const camp = _baseCampaign();
+  assert.equal(canAdvance(camp), true);
+});
+
+test('canChoose: false if not at choice_node', () => {
+  _resetCache();
+  const def = loadCampaign('default_campaign_mvp');
+  const camp = _baseCampaign();
+  assert.equal(canChoose(camp, def), false);
+});
+
+test('canChoose: true at Act 1 chapter 7 (choice_node)', () => {
+  _resetCache();
+  const def = loadCampaign('default_campaign_mvp');
+  const camp = _baseCampaign({ currentChapter: 7, currentAct: 1 });
+  assert.equal(canChoose(camp, def), true);
+});
+
+test('getBranchPath: empty default', () => {
+  const camp = _baseCampaign();
+  assert.deepEqual(getBranchPath(camp), []);
+});
+
+test('getBranchPath: returns cave_path after choice', () => {
+  const camp = _baseCampaign({ branchChoices: ['cave_path'] });
+  assert.deepEqual(getBranchPath(camp), ['cave_path']);
+});
+
+test('summariseCampaign: null campaign returns null', () => {
+  assert.equal(summariseCampaign(null, null), null);
+});
+
+test('summariseCampaign: default campaign full shape', () => {
+  _resetCache();
+  const def = loadCampaign('default_campaign_mvp');
+  const camp = _baseCampaign();
+  const summary = summariseCampaign(camp, def);
+  assert.ok(summary);
+  assert.ok(summary.campaign);
+  assert.ok(summary.current_encounter);
+  assert.equal(summary.current_encounter.encounter_id, 'enc_tutorial_01');
+  assert.equal(summary.next_encounter.next_encounter_id, 'enc_tutorial_02');
+  assert.equal(summary.progress, 0.0);
+  assert.equal(summary.can_advance, true);
+  assert.equal(summary.can_choose, false);
+  assert.deepEqual(summary.branch_path, []);
+  assert.equal(summary.completion_status, 'in_progress');
+});
+
+test('summariseCampaign: finalized campaign status completed', () => {
+  _resetCache();
+  const def = loadCampaign('default_campaign_mvp');
+  const camp = _baseCampaign({ finalState: 'completed', completionPct: 1.0 });
+  const summary = summariseCampaign(camp, def);
+  assert.equal(summary.completion_status, 'completed');
+  assert.equal(summary.can_advance, false);
+  assert.equal(summary.progress, 1.0);
+});

--- a/tests/api/campaignRoutes.test.js
+++ b/tests/api/campaignRoutes.test.js
@@ -206,3 +206,34 @@ test('POST /api/campaign/advance: on finalized campaign = 409', async (t) => {
   const res = await request('POST', `${url}/api/campaign/advance`, { id, outcome: 'victory' });
   assert.equal(res.status, 409);
 });
+
+// M10 Phase C: summary endpoint
+
+test('GET /api/campaign/summary: returns full UI snapshot', async (t) => {
+  const { url } = startTestServer(t);
+  const create = await request('POST', `${url}/api/campaign/start`, { player_id: 'p1' });
+  const id = create.body.campaign.id;
+  const res = await request('GET', `${url}/api/campaign/summary?id=${id}`);
+  assert.equal(res.status, 200);
+  assert.ok(res.body.campaign);
+  assert.ok(res.body.current_encounter);
+  assert.equal(res.body.current_encounter.encounter_id, 'enc_tutorial_01');
+  assert.equal(res.body.next_encounter.next_encounter_id, 'enc_tutorial_02');
+  assert.equal(res.body.progress, 0);
+  assert.equal(res.body.can_advance, true);
+  assert.equal(res.body.can_choose, false);
+  assert.deepEqual(res.body.branch_path, []);
+  assert.equal(res.body.completion_status, 'in_progress');
+});
+
+test('GET /api/campaign/summary: missing id = 400', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('GET', `${url}/api/campaign/summary`);
+  assert.equal(res.status, 400);
+});
+
+test('GET /api/campaign/summary: unknown id = 404', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('GET', `${url}/api/campaign/summary?id=nonexistent-uuid`);
+  assert.equal(res.status, 404);
+});


### PR DESCRIPTION
## Summary

M10 Phase C — pure logic extraction + UI-focused endpoint. 19/19 engine + 17/17 routes + 256/256 AI regression.

### Files

1. `apps/backend/services/campaign/campaignEngine.js` — pure functions:
   - `computeProgress` (% completion)
   - `getCurrentEncounter` / `getNextEncounter`
   - `canAdvance` / `canChoose`
   - `getBranchPath`
   - `summariseCampaign` (full UI snapshot)

2. `apps/backend/routes/campaign.js` — `GET /api/campaign/summary?id=` consume engine

3. `tests/ai/campaignEngine.test.js` — 19 unit test
4. `tests/api/campaignRoutes.test.js` — +3 test /summary

### Test plan

- [x] 19/19 engine tests
- [x] 17/17 routes tests (incl /summary)
- [x] 256/256 AI regression
- [ ] CI verde

### Next phases

- **D** (~3h): `apps/play/src/campaignPanel.js` UI consumes /summary
- **E** (~2h): end-to-end integration tests

### References

- ADR-2026-04-21 Campaign save persistence
- PR #1665 Phase A + #1666 Phase B

🤖 Generated with [Claude Code](https://claude.com/claude-code)