### PR TITLE
feat(campaign): M10 Phase D — frontend campaign panel UI

### DIFF
--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -95,6 +95,27 @@
             <span class="hud-label">Aiuto</span>
           </button>
           <button
+            id="campaign-open"
+            class="hud-btn hud-btn-primary"
+            title="Campagna — progressione e scelte narrative (M10)"
+          >
+            <svg
+              class="hud-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M3 6l7-3 7 3 4-2v15l-4 2-7-3-7 3z" />
+              <line x1="10" y1="3" x2="10" y2="18" />
+              <line x1="17" y1="6" x2="17" y2="21" />
+            </svg>
+            <span class="hud-label">🗺 Campagna</span>
+          </button>
+          <button
             id="feedback-open"
             class="hud-btn hud-btn-primary"
             title="Invia feedback / report — raccolta playtest"

--- a/apps/play/src/api.js
+++ b/apps/play/src/api.js
@@ -86,4 +86,28 @@ export const api = {
   replay: (sid) => jsonFetch(`/api/session/${encodeURIComponent(sid)}/replay`),
   modulations: () => jsonFetch('/api/party/modulations'),
   partyConfig: () => jsonFetch('/api/party/config'),
+  // M10 Phase D — Campaign API
+  campaignStart: (playerId, campaignDefId = 'default_campaign_mvp') =>
+    jsonFetch('/api/campaign/start', {
+      method: 'POST',
+      body: JSON.stringify({ player_id: playerId, campaign_def_id: campaignDefId }),
+    }),
+  campaignSummary: (id) => jsonFetch(`/api/campaign/summary?id=${encodeURIComponent(id)}`),
+  campaignAdvance: (id, outcome, peEarned = 0, piEarned = 0) =>
+    jsonFetch('/api/campaign/advance', {
+      method: 'POST',
+      body: JSON.stringify({ id, outcome, pe_earned: peEarned, pi_earned: piEarned }),
+    }),
+  campaignChoose: (id, branchKey) =>
+    jsonFetch('/api/campaign/choose', {
+      method: 'POST',
+      body: JSON.stringify({ id, branch_key: branchKey }),
+    }),
+  campaignEnd: (id, finalState = 'abandoned') =>
+    jsonFetch('/api/campaign/end', {
+      method: 'POST',
+      body: JSON.stringify({ id, final_state: finalState }),
+    }),
+  campaignList: (playerId) =>
+    jsonFetch(`/api/campaign/list?player_id=${encodeURIComponent(playerId)}`),
 };

--- a/apps/play/src/campaignPanel.js
+++ b/apps/play/src/campaignPanel.js
@@ -1,0 +1,294 @@
+// M10 Phase D — campaign panel UI.
+//
+// Overlay modal: start new campaign, show progress, handle choice_node,
+// display narrative briefing pre-encounter.
+//
+// Consumer di /api/campaign/* endpoints. Persistence UUID in localStorage
+// per demo (single-player, zero auth).
+//
+// API:
+//   initCampaignPanel(options): wire up HUD button + modal overlay
+//   openCampaignOverlay(): show modal
+//   closeCampaignOverlay(): hide modal
+//
+// Ref ADR-2026-04-21.
+
+import { api } from './api.js';
+
+const LS_KEY_CAMPAIGN_ID = 'evoTacticsCampaignId';
+const LS_KEY_PLAYER_ID = 'evoTacticsPlayerId';
+
+const STATE = {
+  campaignId: null,
+  playerId: null,
+  summary: null,
+  overlayEl: null,
+};
+
+function _loadStoredIds() {
+  try {
+    STATE.campaignId = localStorage.getItem(LS_KEY_CAMPAIGN_ID) || null;
+    STATE.playerId = localStorage.getItem(LS_KEY_PLAYER_ID) || null;
+  } catch {
+    STATE.campaignId = null;
+    STATE.playerId = null;
+  }
+}
+
+function _saveIds() {
+  try {
+    if (STATE.campaignId) localStorage.setItem(LS_KEY_CAMPAIGN_ID, STATE.campaignId);
+    if (STATE.playerId) localStorage.setItem(LS_KEY_PLAYER_ID, STATE.playerId);
+  } catch {
+    /* ignore localStorage errors */
+  }
+}
+
+function _clearStoredIds() {
+  try {
+    localStorage.removeItem(LS_KEY_CAMPAIGN_ID);
+    localStorage.removeItem(LS_KEY_PLAYER_ID);
+  } catch {
+    /* ignore */
+  }
+  STATE.campaignId = null;
+  STATE.playerId = null;
+  STATE.summary = null;
+}
+
+function _ensurePlayerId() {
+  if (STATE.playerId) return STATE.playerId;
+  STATE.playerId = `p_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+  _saveIds();
+  return STATE.playerId;
+}
+
+async function _fetchSummary() {
+  if (!STATE.campaignId) return null;
+  const res = await api.campaignSummary(STATE.campaignId);
+  if (res.ok) {
+    STATE.summary = res.data;
+    return res.data;
+  }
+  if (res.status === 404) {
+    _clearStoredIds();
+    return null;
+  }
+  return null;
+}
+
+async function _startNewCampaign() {
+  const playerId = _ensurePlayerId();
+  const res = await api.campaignStart(playerId);
+  if (!res.ok) return null;
+  STATE.campaignId = res.data.campaign.id;
+  _saveIds();
+  await _fetchSummary();
+  return res.data;
+}
+
+async function _abandon() {
+  if (!STATE.campaignId) return;
+  if (!confirm('Abbandonare questa campagna?')) return;
+  await api.campaignEnd(STATE.campaignId, 'abandoned');
+  _clearStoredIds();
+  _render();
+}
+
+async function _chooseBranch(branchKey) {
+  if (!STATE.campaignId) return;
+  const res = await api.campaignChoose(STATE.campaignId, branchKey);
+  if (res.ok) {
+    await _fetchSummary();
+    _render();
+  }
+}
+
+function _renderProgressBar(pct) {
+  const p = Math.round((pct || 0) * 100);
+  return `
+    <div class="camp-progress">
+      <div class="camp-progress-bar" style="width:${p}%"></div>
+      <span class="camp-progress-label">${p}% completato</span>
+    </div>
+  `;
+}
+
+function _renderChoiceNode(choice) {
+  if (!choice) return '';
+  return `
+    <div class="camp-choice">
+      <h3>⚔️ Scelta richiesta</h3>
+      <p class="camp-choice-desc">${choice.description || ''}</p>
+      <div class="camp-choice-options">
+        <button class="camp-choice-btn" data-branch="${choice.option_a.branch_key}">
+          <strong>${choice.option_a.label}</strong>
+          <small>${choice.option_a.narrative || ''}</small>
+        </button>
+        <button class="camp-choice-btn" data-branch="${choice.option_b.branch_key}">
+          <strong>${choice.option_b.label}</strong>
+          <small>${choice.option_b.narrative || ''}</small>
+        </button>
+      </div>
+    </div>
+  `;
+}
+
+function _renderEncounterBriefing(current) {
+  if (!current) return '';
+  return `
+    <div class="camp-briefing">
+      <div class="camp-act-info">Atto ${current.act_idx} · Capitolo ${current.chapter_idx}</div>
+      <h3>${current.encounter_id || 'Nessun encounter'}</h3>
+      <p class="camp-narrative">${current.narrative_pre || 'Nessuna narrativa.'}</p>
+    </div>
+  `;
+}
+
+function _renderBody() {
+  const s = STATE.summary;
+  if (!s) {
+    return `
+      <div class="camp-empty">
+        <h2>Nessuna campagna attiva</h2>
+        <p>Inizia "Sopravvivi all'Apex" — 2 atti, branching narrativo, ~9 mission.</p>
+        <button id="camp-start" class="hud-btn-primary">🗺 Inizia Campagna</button>
+      </div>
+    `;
+  }
+
+  const camp = s.campaign;
+  const def = s.campaign; // campaign_def not included in summary, use from start response cache
+  const header = `
+    <div class="camp-header">
+      <h2>🗺 Sopravvivi all'Apex</h2>
+      <div class="camp-status-pills">
+        <span class="camp-pill camp-pill-status-${s.completion_status}">${s.completion_status}</span>
+        <span class="camp-pill">Atto ${camp.currentAct} · Cap ${camp.currentChapter}</span>
+        ${camp.branchChoices.length ? `<span class="camp-pill">↪ ${camp.branchChoices.join(', ')}</span>` : ''}
+      </div>
+    </div>
+  `;
+
+  let bodyParts = [header, _renderProgressBar(s.progress)];
+
+  if (s.can_choose && s.current_encounter?.choice) {
+    bodyParts.push(_renderChoiceNode(s.current_encounter.choice));
+  } else if (s.current_encounter) {
+    bodyParts.push(_renderEncounterBriefing(s.current_encounter));
+  }
+
+  if (s.completion_status === 'completed') {
+    bodyParts.push(`
+      <div class="camp-completed">
+        <h3>🏆 Campagna Completata</h3>
+        <p>Hai sopravvissuto all'Apex. Il tuo branco è libero.</p>
+      </div>
+    `);
+  }
+
+  bodyParts.push(`
+    <div class="camp-actions">
+      <button id="camp-refresh" class="hud-btn">🔄 Refresh</button>
+      ${!camp.finalState ? '<button id="camp-abandon" class="hud-btn-danger">✕ Abbandona</button>' : ''}
+      ${camp.finalState ? '<button id="camp-new" class="hud-btn-primary">🗺 Nuova Campagna</button>' : ''}
+    </div>
+  `);
+
+  return bodyParts.join('\n');
+}
+
+function _render() {
+  if (!STATE.overlayEl) return;
+  const card = STATE.overlayEl.querySelector('.camp-card-body');
+  if (!card) return;
+  card.innerHTML = _renderBody();
+
+  // Wire event handlers (delegation not needed, single render)
+  const startBtn = card.querySelector('#camp-start');
+  if (startBtn) {
+    startBtn.addEventListener('click', async () => {
+      await _startNewCampaign();
+      _render();
+    });
+  }
+  const refreshBtn = card.querySelector('#camp-refresh');
+  if (refreshBtn) {
+    refreshBtn.addEventListener('click', async () => {
+      await _fetchSummary();
+      _render();
+    });
+  }
+  const abandonBtn = card.querySelector('#camp-abandon');
+  if (abandonBtn) abandonBtn.addEventListener('click', _abandon);
+  const newBtn = card.querySelector('#camp-new');
+  if (newBtn) {
+    newBtn.addEventListener('click', async () => {
+      _clearStoredIds();
+      await _startNewCampaign();
+      _render();
+    });
+  }
+  card.querySelectorAll('.camp-choice-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const key = btn.dataset.branch;
+      if (key) _chooseBranch(key);
+    });
+  });
+}
+
+export async function openCampaignOverlay() {
+  if (!STATE.overlayEl) return;
+  await _fetchSummary();
+  _render();
+  STATE.overlayEl.classList.remove('hidden');
+}
+
+export function closeCampaignOverlay() {
+  if (!STATE.overlayEl) return;
+  STATE.overlayEl.classList.add('hidden');
+}
+
+export function initCampaignPanel(_options = {}) {
+  _loadStoredIds();
+
+  // Build overlay if missing
+  let overlay = document.getElementById('campaign-overlay');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'campaign-overlay';
+    overlay.className = 'feedback-overlay hidden'; // reuse feedback styles
+    overlay.innerHTML = `
+      <div class="feedback-card camp-card">
+        <div class="feedback-header">
+          <h2>Campagna</h2>
+          <button id="campaign-close" class="feedback-close" aria-label="Chiudi">✕</button>
+        </div>
+        <div class="camp-card-body feedback-body"></div>
+      </div>
+    `;
+    document.body.appendChild(overlay);
+  }
+  STATE.overlayEl = overlay;
+
+  const closeBtn = overlay.querySelector('#campaign-close');
+  if (closeBtn) closeBtn.addEventListener('click', closeCampaignOverlay);
+
+  // ESC close
+  document.addEventListener('keydown', (ev) => {
+    if (ev.key === 'Escape' && !overlay.classList.contains('hidden')) {
+      closeCampaignOverlay();
+    }
+  });
+
+  // Click outside card = close
+  overlay.addEventListener('click', (ev) => {
+    if (ev.target === overlay) closeCampaignOverlay();
+  });
+
+  // Wire HUD button
+  const hudBtn = document.getElementById('campaign-open');
+  if (hudBtn) {
+    hudBtn.addEventListener('click', openCampaignOverlay);
+  }
+}

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -19,6 +19,7 @@ import { initHelpPanel } from './helpPanel.js';
 import { showTip, buildRecoveryTipMessage, resetAllTips } from './tips.js';
 import { toggleCodex } from './codexPanel.js';
 import { initFeedbackPanel } from './feedbackPanel.js';
+import { initCampaignPanel } from './campaignPanel.js';
 
 const state = {
   sid: null,
@@ -1294,6 +1295,8 @@ async function loadModulations() {
 initHelpPanel('help-open');
 // M7 feedback panel — playtest collection
 initFeedbackPanel({ getSessionId: () => state.sid });
+// M10 Phase D — campaign panel (ADR-2026-04-21)
+initCampaignPanel();
 
 // W8O — Resize listener: redraw canvas quando viewport cambia (CELL dinamico).
 let _resizeTimeout = null;

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -2067,3 +2067,230 @@ body.ability-target-mode canvas#grid {
     padding: 6px 10px;
   }
 }
+
+/* ═══════════════════════════════════════════════════════════════ */
+/*   M10 Phase D — Campaign panel UI                                */
+/* ═══════════════════════════════════════════════════════════════ */
+
+#campaign-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.95;
+}
+#campaign-overlay.hidden {
+  display: none;
+}
+
+.camp-card {
+  max-width: 720px;
+  width: 90%;
+}
+
+.camp-header h2 {
+  margin: 0 0 8px 0;
+  color: #ffcc00;
+  font-size: 1.4em;
+}
+
+.camp-status-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 14px;
+}
+
+.camp-pill {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 12px;
+  padding: 3px 10px;
+  font-size: 0.85em;
+  color: #e8e8e8;
+}
+
+.camp-pill-status-completed {
+  background: rgba(76, 175, 80, 0.25);
+  border-color: #4caf50;
+  color: #aed581;
+}
+
+.camp-pill-status-in_progress {
+  background: rgba(0, 184, 212, 0.2);
+  border-color: #00b8d4;
+  color: #80deea;
+}
+
+.camp-pill-status-abandoned {
+  background: rgba(244, 67, 54, 0.25);
+  border-color: #f44336;
+  color: #ef9a9a;
+}
+
+.camp-progress {
+  position: relative;
+  width: 100%;
+  height: 24px;
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 12px;
+  overflow: hidden;
+  margin-bottom: 16px;
+}
+
+.camp-progress-bar {
+  height: 100%;
+  background: linear-gradient(90deg, #0288d1, #4caf50);
+  transition: width 0.4s ease;
+}
+
+.camp-progress-label {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.9em;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
+}
+
+.camp-empty {
+  text-align: center;
+  padding: 30px 10px;
+}
+
+.camp-empty h2 {
+  color: #ffcc00;
+  margin-bottom: 8px;
+}
+
+.camp-empty p {
+  color: #bbb;
+  margin-bottom: 20px;
+}
+
+.camp-briefing {
+  background: rgba(0, 0, 0, 0.3);
+  border-left: 3px solid #00b8d4;
+  padding: 14px 18px;
+  margin-bottom: 14px;
+  border-radius: 4px;
+}
+
+.camp-act-info {
+  color: #80deea;
+  font-size: 0.85em;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+
+.camp-briefing h3 {
+  margin: 0 0 10px 0;
+  color: #e8e8e8;
+  font-size: 1.1em;
+}
+
+.camp-narrative {
+  color: #bdbdbd;
+  line-height: 1.5;
+  font-style: italic;
+  margin: 0;
+}
+
+.camp-choice {
+  background: rgba(255, 204, 0, 0.08);
+  border: 2px solid #ffcc00;
+  padding: 16px;
+  margin: 14px 0;
+  border-radius: 6px;
+}
+
+.camp-choice h3 {
+  margin: 0 0 8px 0;
+  color: #ffcc00;
+}
+
+.camp-choice-desc {
+  color: #e8e8e8;
+  margin-bottom: 14px;
+  font-style: italic;
+}
+
+.camp-choice-options {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.camp-choice-btn {
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 204, 0, 0.4);
+  color: #fff;
+  padding: 12px 14px;
+  border-radius: 4px;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-family: inherit;
+}
+
+.camp-choice-btn:hover {
+  background: rgba(255, 204, 0, 0.15);
+  border-color: #ffcc00;
+  transform: translateX(3px);
+}
+
+.camp-choice-btn strong {
+  display: block;
+  color: #ffcc00;
+  margin-bottom: 3px;
+}
+
+.camp-choice-btn small {
+  color: #bdbdbd;
+  line-height: 1.4;
+}
+
+.camp-completed {
+  background: rgba(76, 175, 80, 0.1);
+  border-left: 4px solid #4caf50;
+  padding: 16px;
+  border-radius: 4px;
+  margin: 14px 0;
+  text-align: center;
+}
+
+.camp-completed h3 {
+  color: #aed581;
+  margin: 0 0 6px 0;
+}
+
+.camp-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 18px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.hud-btn-danger {
+  background: linear-gradient(135deg, #c62828, #b71c1c);
+  color: #fff;
+  border: 1px solid #d32f2f;
+  padding: 8px 14px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: all 0.15s;
+}
+
+.hud-btn-danger:hover {
+  background: linear-gradient(135deg, #d32f2f, #c62828);
+}


### PR DESCRIPTION
## Summary

M10 Phase D — overlay modal UI per campaign navigation. Demo-friendly single-player localStorage persistence.

### Changes

- `apps/play/index.html` — HUD button "🗺 Campagna" (SVG map icon)
- `apps/play/src/api.js` — 6 wrapper campaignStart/Summary/Advance/Choose/End/List
- `apps/play/src/campaignPanel.js` NEW — STATE module + _render states (empty/active/choice/completed)
- `apps/play/src/main.js` — wire initCampaignPanel
- `apps/play/src/style.css` +~220 LOC — overlay + progress bar + choice modal + completed screen

### UX flow demo

1. Click "🗺 Campagna" → modal opens
2. If no campaign → "Inizia Campagna" button
3. Active campaign → status pills (act/chapter/branch), progress bar %, narrative briefing
4. Choice node → 2 option buttons with narrative preview
5. Completed → success screen
6. Actions: Refresh / Abbandona / Nuova Campagna

### Pending Phase E

- Wire `/api/campaign/advance` on session end hook
- Wire session start auto-launch per `campaign.next_encounter_id`
- End-to-end integration test

### Test plan

- [x] HTML index button visible (preview panel)
- [x] JS imports + module loads senza errori syntax
- [ ] Manual demo playthrough empty→start→choice→advance
- [ ] CI verde

### References

- ADR-2026-04-21 Campaign save persistence
- PR stack: #1665 A + #1666 B + #1667 C

🤖 Generated with [Claude Code](https://claude.com/claude-code)