### PR TITLE
feat(balance): trait environmental costs pilot 4×3 (#1674)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -61,6 +61,11 @@ const {
   shouldEnrageBoss,
   getEnrageModBonus,
 } = require('../services/balance/damageCurves');
+// M11 pilot (ADR-2026-04-21c, issue #1674) — trait environmental costs.
+// Applica penalty/bonus biome-specific a unit basato su trait set × biome_id.
+// Pilot 4×3: thermal_armor, zampe_a_molla, pelle_elastomera, denti_seghettati
+// × savana, caverna_risonante, rovine_planari.
+const { loadTraitEnvironmentalCosts, applyBiomeTraitCosts } = require('../services/traitEffects');
 // M6-#1 (ADR-2026-04-19 + spike 2026-04-19): Node native resistance engine.
 // Applica channel-specific resist/vuln su damage pre-hp. Evidence spike:
 // 84.6% → 20% win rate hardcore-06 con flat 50% resist (leva confermata).
@@ -718,6 +723,31 @@ function createSessionRouter(options = {}) {
         // best-effort: se config non carica, skip profile scaling
       }
 
+      // M11 pilot (ADR-2026-04-21c, issue #1674): apply biome environmental
+      // trait costs. Legge biome_id da req.body (top-level) con fallback
+      // req.body.encounter?.biome_id. Pilot scope 4 trait × 3 biomi = 12 cell.
+      // Session-scoped compute (no Prisma persistence).
+      const biomeIdRaw = req.body?.biome_id || req.body?.encounter?.biome_id || null;
+      let biomeCostsLog = [];
+      if (biomeIdRaw) {
+        try {
+          const biomeCostsRegistry = loadTraitEnvironmentalCosts();
+          if (biomeCostsRegistry && biomeCostsRegistry.trait_costs) {
+            units = units.map((u) => {
+              if (!u) return u;
+              const clone = { ...u };
+              const applied = applyBiomeTraitCosts(clone, biomeIdRaw, biomeCostsRegistry);
+              if (applied && applied.length) {
+                biomeCostsLog.push({ unit_id: clone.id, applied });
+              }
+              return clone;
+            });
+          }
+        } catch (err) {
+          console.warn('[trait-env-costs] apply failed:', err.message);
+        }
+      }
+
       // M7-#2 Phase B: apply damage scaling curves per encounter class.
       // Lo YAML damage_curves.yaml definisce enemy_damage_multiplier per class.
       // Encounter senza class dichiarato → fallback "standard" (1.2x).
@@ -805,6 +835,9 @@ function createSessionRouter(options = {}) {
         // ADR-2026-04-19 + 04-20: encounter payload per reinforcementSpawner + objectiveEvaluator.
         // Feature flag OFF default: se undefined, entrambi moduli ritornano no-op.
         encounter: req.body?.encounter ?? null,
+        // M11 pilot (ADR-2026-04-21c): biome_id + log trait env deltas applicati.
+        biome_id: biomeIdRaw,
+        biome_costs_log: biomeCostsLog,
       };
       sessions.set(sessionId, session);
       activeSessionId = sessionId;

--- a/apps/backend/services/traitEffects.js
+++ b/apps/backend/services/traitEffects.js
@@ -33,6 +33,24 @@ const DEFAULT_REGISTRY_PATH = path.resolve(
   'active_effects.yaml',
 );
 
+// M11 pilot (ADR-2026-04-21c, issue #1674) — trait environmental costs.
+// YAML pilot 4 trait × 3 biomi, 12 cell, stat delta ±1/±2. Session-scoped
+// compute (no Prisma, no new economy channel).
+const BIOME_COST_DEFAULT_PATH = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'data',
+  'core',
+  'balance',
+  'trait_environmental_costs.yaml',
+);
+
+const BIOME_COST_STATS_ALLOWED = new Set(['attack_mod', 'defense_mod', 'mobility']);
+
+let _biomeCostCache = null;
+
 function loadActiveTraitRegistry(yamlPath = DEFAULT_REGISTRY_PATH, logger = console) {
   try {
     const text = fs.readFileSync(yamlPath, 'utf8');
@@ -233,10 +251,98 @@ function evaluateStatusTraits({ registry, actor, target, attackResult, killOccur
   return { trait_effects: traitEffects, status_applies: statusApplies };
 }
 
+// M11 pilot (ADR-2026-04-21c, issue #1674) — biome penalty loader.
+// Carica `trait_environmental_costs.yaml` (4 trait × 3 biomi = 12 cell).
+// Cache singleton: chiamate successive ritornano cached (idempotent).
+// Soft-fail su ENOENT → registry vuoto, biome penalty no-op.
+function loadTraitEnvironmentalCosts(yamlPath = BIOME_COST_DEFAULT_PATH, logger = console) {
+  if (_biomeCostCache !== null) return _biomeCostCache;
+  try {
+    const text = fs.readFileSync(yamlPath, 'utf8');
+    const parsed = yaml.load(text);
+    _biomeCostCache = parsed && typeof parsed === 'object' ? parsed : {};
+    return _biomeCostCache;
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      logger.warn(`[trait-env-costs] ${yamlPath} non trovato, biome penalty no-op`);
+      _biomeCostCache = {};
+      return _biomeCostCache;
+    }
+    logger.warn(`[trait-env-costs] errore ${yamlPath}:`, err.message || err);
+    _biomeCostCache = {};
+    return _biomeCostCache;
+  }
+}
+
+// Reset cache (per test isolation).
+function _resetBiomeCostCache() {
+  _biomeCostCache = null;
+}
+
+// Applica penalty/bonus biome-specific a unit.attack_mod_bonus /
+// unit.defense_mod_bonus / unit.mobility basato su trait × biome_id.
+//
+// Mutates `unit` in place. Idempotent via marker `_biome_costs_applied`:
+// chiamate ripetute su stessa unit sono no-op. Per rebase (hot-swap biome)
+// il caller deve resettare il marker esplicitamente.
+//
+// @param unit — { traits: [], mod, attack_mod_bonus, defense_mod_bonus, mobility, ... }
+// @param biomeId — 'savana' | 'caverna_risonante' | 'rovine_planari' | ...
+// @param data — optional pre-loaded registry (dependency injection per test)
+// @returns array { trait, biome, delta: { stat: n, ... } } applied per log.
+function applyBiomeTraitCosts(unit, biomeId, data) {
+  if (!unit || !biomeId) return [];
+  if (unit._biome_costs_applied) return [];
+  const registry = data || loadTraitEnvironmentalCosts();
+  const traitCosts = registry && registry.trait_costs ? registry.trait_costs : null;
+  if (!traitCosts) return [];
+
+  const unitTraits = Array.isArray(unit.traits) ? unit.traits : [];
+  const applied = [];
+
+  for (const traitId of unitTraits) {
+    const traitEntry = traitCosts[traitId];
+    if (!traitEntry) continue;
+    const cell = traitEntry[biomeId];
+    // Cell vuota (biome neutral per questo trait) → skip, no delta.
+    if (!cell || typeof cell !== 'object' || Object.keys(cell).length === 0) continue;
+
+    const delta = {};
+    for (const [stat, rawValue] of Object.entries(cell)) {
+      if (stat === 'rationale') continue;
+      if (!BIOME_COST_STATS_ALLOWED.has(stat)) continue;
+      const n = Number(rawValue);
+      if (!Number.isFinite(n) || n === 0) continue;
+
+      if (stat === 'attack_mod') {
+        unit.attack_mod_bonus = Number(unit.attack_mod_bonus || 0) + n;
+      } else if (stat === 'defense_mod') {
+        unit.defense_mod_bonus = Number(unit.defense_mod_bonus || 0) + n;
+      } else if (stat === 'mobility') {
+        unit.mobility = Number(unit.mobility || 0) + n;
+      }
+      delta[stat] = n;
+    }
+
+    if (Object.keys(delta).length > 0) {
+      applied.push({ trait: traitId, biome: biomeId, delta });
+    }
+  }
+
+  unit._biome_costs_applied = true;
+  unit._biome_costs_log = applied;
+  return applied;
+}
+
 module.exports = {
   loadActiveTraitRegistry,
   evaluateAttackTraits,
   evaluateStatusTraits,
   isElevated,
   DEFAULT_REGISTRY_PATH,
+  // M11 pilot — biome penalty
+  loadTraitEnvironmentalCosts,
+  applyBiomeTraitCosts,
+  BIOME_COST_DEFAULT_PATH,
+  _resetBiomeCostCache,
 };

--- a/data/core/balance/trait_environmental_costs.yaml
+++ b/data/core/balance/trait_environmental_costs.yaml
@@ -1,0 +1,92 @@
+# Trait environmental costs — M11 pilot (ADR-2026-04-21c, issue #1674).
+#
+# Pilot scope STRICT: 4 trait × 3 biomi = 12 cell. NON generalizzare
+# pre-playtest validation (vedi ADR Scope guard).
+#
+# Runtime wire:
+#   session.js /start → legge biome_id da req.body (fallback encounter.biome_id)
+#   → applyBiomeTraitCosts(unit, biome_id) in apps/backend/services/traitEffects.js
+#   → muta unit.attack_mod_bonus / unit.defense_mod_bonus / unit.mobility
+#
+# NO economy channel nuovo: penalty sono stat_delta runtime session-scoped.
+# NO Prisma persistence: ricalcolato a ogni session.start.
+#
+# Vedi: docs/adr/ADR-2026-04-21c-trait-environmental-costs.md
+
+version: '1.0'
+schema_version: '1.0.0'
+
+# ─── Matrix 4 trait × 3 biomi ─────────────────────────────────────────
+# Delta range ±1/±2. Cell vuota `{}` = bioma neutral per quel trait.
+# Rationale breve per audit balance. Playtest follow-up: validate o revert.
+
+trait_costs:
+  thermal_armor:
+    savana:
+      defense_mod: -1
+      mobility: -1
+      rationale: 'Caldo arido: corazza termica surriscalda, rallenta e riduce efficienza difensiva.'
+    caverna_risonante:
+      defense_mod: 2
+      rationale: 'Freddo umido: isolamento termico premium, corazza attiva protezione massima.'
+    rovine_planari: {}  # neutral
+
+  zampe_a_molla:
+    savana:
+      mobility: 1
+      rationale: 'Terreno aperto secco: slancio efficace, pushoff pulito.'
+    caverna_risonante:
+      mobility: -1
+      rationale: 'Superficie umida scivolosa: rebound instabile.'
+    rovine_planari: {}  # neutral
+
+  pelle_elastomera:
+    savana:
+      defense_mod: -1
+      rationale: 'Calore estremo degrada elasticità polimerica.'
+    caverna_risonante:
+      defense_mod: 1
+      rationale: 'Umidità preserva modulo elastico: assorbimento colpo migliora.'
+    rovine_planari: {}  # neutral
+
+  denti_seghettati:
+    savana:
+      attack_mod: 1
+      rationale: 'Prede ossee abbondanti affilano naturalmente i denti.'
+    caverna_risonante:
+      attack_mod: -1
+      rationale: 'Dieta molle scarsa di prede dure: denti rimangono smussati.'
+    rovine_planari: {}  # neutral
+
+# ─── Biome metadata ───────────────────────────────────────────────────
+# Climate axis per future extension M12+. Pilot usa biome_id diretto.
+
+biomes:
+  savana:
+    climate: hot_arid
+    description: 'Savana calda arida pilot (tutorial_01/02).'
+  caverna_risonante:
+    climate: cold_humid
+    description: 'Caverna umida fresca pilot (tutorial_03).'
+  rovine_planari:
+    climate: neutral
+    description: 'Rovine planari neutrale pilot (tutorial_05 boss).'
+
+# ─── Validation ───────────────────────────────────────────────────────
+
+validation:
+  stats_allowed: [attack_mod, defense_mod, mobility]
+  delta_range_min: -2
+  delta_range_max: 2
+  pilot_trait_count: 4
+  pilot_biome_count: 3
+  pilot_cell_count: 12
+  enforcement: 'tests/ai/traitEnvironmentalCosts.test.js'
+
+# ─── Riferimenti ──────────────────────────────────────────────────────
+
+references:
+  adr: 'docs/adr/ADR-2026-04-21c-trait-environmental-costs.md'
+  issue: 'https://github.com/MasterDD-L34D/Game/issues/1674'
+  trait_mechanics: 'packs/evo_tactics_pack/data/balance/trait_mechanics.yaml'
+  triage_source: 'docs/planning/2026-04-21-triage-exploration-notes.md'

--- a/docs/adr/ADR-2026-04-21c-trait-environmental-costs.md
+++ b/docs/adr/ADR-2026-04-21c-trait-environmental-costs.md
@@ -1,0 +1,120 @@
+---
+title: 'ADR 2026-04-21c — Costo ambientale trait (pilot 4 trait × 3 biomi)'
+doc_status: active
+doc_owner: master-dd
+workstream: combat
+last_verified: '2026-04-21'
+source_of_truth: true
+language: it
+review_cycle_days: 30
+related:
+  - data/core/balance/trait_environmental_costs.yaml
+  - apps/backend/services/traitEffects.js
+  - apps/backend/routes/session.js
+  - tests/ai/traitEnvironmentalCosts.test.js
+  - packs/evo_tactics_pack/data/balance/trait_mechanics.yaml
+  - docs/planning/2026-04-21-triage-exploration-notes.md
+---
+
+# ADR-2026-04-21c · Costo ambientale trait — pilot 4×3
+
+**Stato**: 🟢 ACCEPTED (user direction Prompt C 2026-04-21)
+**Chiude parziale**: L06 P2 runtime trait contextual + L08 biome runtime Node gap
+**Scope**: pilot strict 4 trait × 3 biomi = 12 cell. **NON generalizza** pre-playtest validation.
+**Trigger**: exploration-note deck v2 Nota 2 + triage Prompt 3 raccomandazione (a) pilot
+**Issue**: [#1674](https://github.com/MasterDD-L34D/Game/issues/1674)
+
+## Contesto
+
+Oggi `trait_mechanics.yaml` definisce solo costi numerici flat (PI, stat baseline). Guida Evo-Tactics Pack v2 + SoT §5 parlano di "adattamento ambientale" ma non lo traducono in penalty/bonus numeriche per-bioma.
+
+Exploration-note deck v2 propone pattern proven (Into the Breach environment penalty, XCOM terrain effect): ogni trait dovrebbe avere costo context-dependent — es. `thermal_armor` premia in bioma freddo, penalizza in bioma caldo.
+
+Rischio scope-creep 🔴 ALTO se generalizzato: 84 species × 10 trait × 7 biomi = ~5880 cell tuning. Kill-60 Flint + §19.3 Freeze guidance → **pilot limitato** + playtest gate prima di generalizzare.
+
+## Decisione
+
+**Ship pilot 4 trait × 3 biomi** runtime wired in session /start:
+
+- **4 trait**: `thermal_armor`, `zampe_a_molla`, `pelle_elastomera`, `denti_seghettati`
+- **3 biomi**: `savana` (hot_arid), `caverna_risonante` (cold_humid), `rovine_planari` (neutral)
+- **12 cell** con delta `attack_mod` / `defense_mod` / `mobility` in range ±1/±2
+
+**Matrix shipping (rationale audit-trail in YAML)**:
+
+| trait \ biome    | savana         | caverna_risonante | rovine_planari |
+| ---------------- | -------------- | ----------------- | -------------- |
+| thermal_armor    | def −1, mob −1 | def +2            | —              |
+| zampe_a_molla    | mob +1         | mob −1            | —              |
+| pelle_elastomera | def −1         | def +1            | —              |
+| denti_seghettati | atk +1         | atk −1            | —              |
+
+**Runtime wire**:
+
+1. `data/core/balance/trait_environmental_costs.yaml` — schema v1.0 + 12 cell + rationale
+2. `apps/backend/services/traitEffects.js` — `loadTraitEnvironmentalCosts()` + `applyBiomeTraitCosts(unit, biomeId, data?)`. Soft-fail su ENOENT. Cache singleton con reset test.
+3. `apps/backend/routes/session.js /start` — legge `req.body.biome_id` (fallback `req.body.encounter.biome_id`), applica delta a ogni unit via `map` post-normalise, persiste `session.biome_id` + `session.biome_costs_log`.
+4. Delta target keys: `unit.attack_mod_bonus`, `unit.defense_mod_bonus` (consumati già in `resolveAttack`/`predictCombat` via sessionHelpers), `unit.mobility` (nuovo slot, consumer futuro M12+).
+
+**Idempotency**: marker `unit._biome_costs_applied = true` previene doppio apply. Session-scoped (no Prisma persistence).
+
+## Scope guard STRICT
+
+- **NO generalizzare** oltre 4×3 pilot pre-playtest validation. Aggiungere trait/biome #5 richiede nuova ADR.
+- **NO nuovo economy channel**: penalty = stat_delta runtime. PE/PI/Seed/Trust restano 4 sole currency (Freeze §19.3).
+- **NO Prisma persistence**: costi ricalcolati a ogni `/start`. Se playtest valida → M12+ considerare persistenza per roster history, non prima.
+- **NO UI overlay dedicata M11**: applied log passa via `session.biome_costs_log` per debug console, ma Mission Console non mostra ancora "perché hai perso −1 def" al player.
+
+## Criteria promotion / revert (post-playtest)
+
+Dopo N=10 run batch su tutorial_01..05 + hardcore_06 con biome_id set:
+
+- **Promotion**: feedback Master DM "penalty percettibile ma non frustrante" + win rate non shift >5pp vs baseline pre-wire. → Generalizza altre 3-4 trait shipping, stessa matrice.
+- **Kill**: feedback "confuso o invisibile" o win rate shift >10pp senza design intent. → Revert YAML a empty + rimuovi wire con PR cleanup.
+- **Tune**: shift 5-10pp o feedback misto → iterate delta magnitude (±1 diventa ±0.5 floor / ±2 diventa ±1).
+
+Harness calibration: `tools/py/batch_calibrate_*.py` legge `session.biome_costs_log` per per-run attribution.
+
+## Conseguenze
+
+**Positive**:
+
+- Chiude L06 P2 runtime parziale (trait economy diventa contextual vs flat).
+- Aggancia L08 biome runtime Node (prima lettura effettiva `biome_id` in session engine).
+- Pattern proven (ItB, XCOM) applicato a scope safe.
+
+**Negative / Debito**:
+
+- 12 cell tuning manuale — audit balance dipende da playtest qualitativo.
+- `unit.mobility` non ancora consumato da movement system → delta applicato ma silent per mobility finché consumer wire. M12+.
+- Registry YAML non gated da schema AJV (pilot scope non giustifica schema JSON ora). Aggiungere se promosso.
+
+**Rischio mitigato**:
+
+- Scope-creep bloccato da ADR text + test `validation: delta range [-2, 2]`.
+- Revert banale: rimuovi 4 require + 1 block /start + YAML empty. < 30 LOC.
+
+## Test coverage
+
+`tests/ai/traitEnvironmentalCosts.test.js` — 14 test:
+
+- Loader carica YAML reale, 4 trait × 3 biomi verificati
+- Soft-fail ENOENT
+- 4 scenario canonici trait × biome (inclusi rovine_planari neutral)
+- zampe_a_molla simmetrico savana/caverna
+- Multi-trait aggregation (thermal_armor + denti_seghettati × savana)
+- Idempotency chiamate ripetute
+- Unknown trait / biome / null → no-op
+- YAML validation delta ∈ [−2, +2] \ {0}
+
+## Playtest follow-up
+
+Post-merge: schedulare batch N=10 su `enc_tutorial_01` (savana) + `enc_tutorial_03` (caverna_risonante) + `enc_tutorial_05` (rovine_planari). Report in `docs/playtest/2026-04-21-trait-env-costs-pilot.md`.
+
+## Riferimenti
+
+- `docs/planning/2026-04-21-triage-exploration-notes.md` §Issue Draft 2
+- [Issue #1674](https://github.com/MasterDD-L34D/Game/issues/1674)
+- `packs/evo_tactics_pack/data/balance/trait_mechanics.yaml`
+- `docs/planning/2026-04-20-integrated-design-map.md` §4 exploration note 2
+- ADR-2026-04-20-damage-scaling-curves (pattern: balance YAML + runtime apply)

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -427,6 +427,19 @@
       "track": "new"
     },
     {
+      "path": "docs/adr/ADR-2026-04-21c-trait-environmental-costs.md",
+      "title": "ADR 2026-04-21c — Costo ambientale trait (pilot 4\u00d73)",
+      "doc_status": "active",
+      "doc_owner": "master-dd",
+      "workstream": "combat",
+      "last_verified": "2026-04-21",
+      "source_of_truth": true,
+      "language": "it",
+      "review_cycle_days": 30,
+      "primary": false,
+      "track": "new"
+    },
+    {
       "path": "docs/playtest/2026-04-19-m6-iter2b-baseline.md",
       "title": "M6 iter2b baseline — 50% win rate hardcore-06 post-resistance wire",
       "doc_status": "active",

--- a/docs/planning/2026-04-21-next-session-kickoff.md
+++ b/docs/planning/2026-04-21-next-session-kickoff.md
@@ -1,0 +1,288 @@
+---
+title: 'Next session kickoff — 3 sprint prompt pronti (C → B → A)'
+workstream: planning
+category: handoff
+status: draft
+owner: master-dd
+created: 2026-04-21
+tags:
+  - kickoff
+  - session-handoff
+  - sprint-prep
+  - token-optimization
+related:
+  - docs/planning/2026-04-20-integrated-design-map.md
+  - docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md
+---
+
+# Next session kickoff — 3 sprint pronti
+
+Session 2026-04-20/21 chiuso con 15+ PR merged + 5/5 P0 closed. Questo doc contiene **3 prompt ready-to-paste** ottimizzati per Claude Code next session(s). Sequenza raccomandata: **C → B → A** (warm-up → medium → big rock).
+
+## Quick stats session chiusa
+
+| Item                   |                          Valore |
+| ---------------------- | ------------------------------: |
+| PR merged today        |                              15 |
+| Lines changed          |                           ~22k+ |
+| Issues aperte          | 2 (#1673 parked, #1674 pending) |
+| P0 gap closed          |                             5/5 |
+| Prerequisites Prompt 4 |                     ✅ verified |
+
+## Sessione strategy — perché multi-session
+
+**Sequential 1-per-volta** è best practice:
+
+- Branch indipendenti → zero merge conflict
+- Context window Claude Code fresco per sprint (compaction-safe)
+- Token burn ammortizzato (session che supera 500k tok su stesso task = ridotto ROI)
+
+Soglia **kill-60 intra-session**: se un singolo task supera 3-4h wall-clock → ferma, WIP commit, nuova session continua.
+
+## Branch naming convention (preparato)
+
+Incolla i prompt su branch preesistenti o lascia Claude Code auto-crearli:
+
+- Prompt C: `feat/trait-env-costs-pilot` (issue #1674)
+- Prompt B: `feat/meta-prisma-persistence` (Prompt 4)
+- Prompt A: `feat/m11-jackbox-network-phase-a` (M11 big rock)
+
+---
+
+## Prompt C — Costo ambientale trait pilot (~6-8h, START HERE)
+
+**Scope**: chiude issue #1674. Pattern proven. Warm-up per verifica flow.
+
+```text
+Leggi:
+- docs/planning/2026-04-21-triage-exploration-notes.md §Issue Draft 2
+- GitHub issue #1674
+- packs/evo_tactics_pack/data/balance/trait_mechanics.yaml
+- data/core/balance/damage_curves.yaml (pattern schema reference)
+- apps/backend/services/traitEffects.js (target wire)
+
+Task: ship pilot 4 trait × 3 biomi.
+- 4 trait shipping: thermal_armor, zampe_a_molla, pelle_elastomera, denti_seghettati
+- 3 biomi shipping: savana, caverna_risonante, rovine_planari
+- Matrix 12 cell stat modifier ±1/±2
+
+Deliverable atomici:
+1. data/core/balance/trait_environmental_costs.yaml NEW — schema v1.0 + 12 cell
+2. apps/backend/services/traitEffects.js — nuovo hook biome penalty su session init
+3. tests/ai/traitEnvironmentalCosts.test.js — 4 scenari (trait × biome applica delta)
+4. docs/adr/ADR-2026-04-21c-trait-environmental-costs.md — ACCEPTED con scope
+   pilot limit
+5. docs/governance/docs_registry.json — registra ADR
+6. Close GitHub issue #1674 al merge
+
+Scope creep guard STRICT:
+- NO generalizzare oltre 4×3 pre-playtest validation
+- NO nuovo economy channel (solo stat_delta runtime)
+- NO Prisma persistence (trait costs sono session-scoped compute)
+
+Effort target: ~6-8h single session.
+```
+
+**Perché prima**: effort contenuto, pattern YAML-driven già proven (damage_curves), test-first easy. Verifica che Claude Code aggancia GitHub issue correttamente.
+
+---
+
+## Prompt B — Prisma persistence metaProgression (~11h)
+
+**Scope**: chiude L06 parziale. Prereq verificati + baseline test shippato in questo PR (`tests/ai/metaProgression.test.js` 37/37 verdi).
+
+```text
+Leggi:
+- docs/planning/2026-04-20-integrated-design-map.md §3 L06 + §5 Prompt 4
+- apps/backend/services/metaProgression.js (194 LOC, 11 funzioni in-memory)
+- apps/backend/routes/meta.js (7 endpoint, NON 6 come diceva integrated-map)
+- apps/backend/prisma/schema.prisma (ha già 4 model M10: Campaign, Chapter,
+  PartyRoster, SaveSnapshot)
+- tests/ai/metaProgression.test.js (baseline 37/37 safety net — NON rompere)
+
+Task: progetta persistence Prisma per metaProgression.
+
+Schema proposto (RENAME per evitare collision con PartyRoster):
+- NpcRelation (NON "SquadMember", evita confusion con PartyRoster PG-controlled)
+- AffinityLog (audit trail delta affinity)
+- TrustLog (audit trail delta trust)
+- NestState (nest level + biome + requirements)
+- MatingEvent (roll history + outcome + offspring traits)
+
+Migration strategy:
+1. Baseline test (shipped): 37/37 verdi. Mantenere verdi end-to-end.
+2. Adapter pattern: metaProgression.js wrappa Prisma client + fallback
+   in-memory se DATABASE_URL non set (dev demo ngrok compat).
+3. routes/meta.js NON cambia shape API (7 endpoint backward-compat).
+4. Migration file generate via `prisma migrate dev --name add_meta_progression`.
+
+Warning pre-impl:
+- Datasource schema.prisma attualmente postgresql (line 9). ADR-04-21 diceva
+  SQLite. Decidere: swap o keep?
+- Contract test: POST /api/meta/affinity + GET /api/meta/npg post-swap
+  deve returnare stessa shape JSON.
+
+NON implementare:
+- PI pack spender runtime (task successivo, ADR dedicata)
+- UI Nido panel (M11-adjacent)
+- Cross-session Prisma seed automatic (manual seed OK MVP)
+
+Effort target: ~11h (schema 2h + migration 3h + adapter 3h + contract test 3h).
+
+Output PR:
+- ADR-202X-meta-progression-prisma
+- schema.prisma extended + migration file
+- services/metaProgression.js adapter
+- tests baseline 37/37 verdi + nuovi contract test (~5 test post-swap)
+```
+
+**Perché seconda**: hi-value P2 closure (L06 part), prerequisiti verified, baseline test pronto. Rischio regression ridotto dal safety net.
+
+---
+
+## Prompt A — M11 Jackbox co-op TV (~20h, big rock)
+
+**Scope**: chiude Pilastro 5 network multi-client. Spezza in 2 sub-session se serve.
+
+```text
+Leggi:
+- docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md §Sprint M11
+- docs/planning/2026-04-20-integrated-design-map.md §3 L07
+- memory reference_external_repos.md §Tier Jackbox/Colyseus
+- apps/backend/app.js (wire router pattern esistente)
+
+Task: M11 Phase A — Jackbox room-code WebSocket backend.
+
+Scope Phase A (~8-10h):
+- services/network/wsSession.js NEW: WebSocket server + 4-letter room code
+  generator + host-authoritative state
+- routes/lobby.js NEW: POST /api/lobby/create, POST /api/lobby/join,
+  POST /api/lobby/close, GET /api/lobby/state
+- Integration con campaign engine esistente (host fa choice vincolante)
+- Tests integration 4-player sync + reconnect edge cases
+
+Pattern proven (3 OSS clones):
+- hammre/party-box (WebSocket + 4-letter code)
+- axlan/jill_box (React+Python WS server)
+- InvoxiPlayGames/johnbox (Jackbox reimpl)
+
+Fallback Colyseus (tier 2 se Jackbox pattern insufficient):
+- docs/adr/ADR-2026-04-14-networking-colyseus.md già proposed
+- Adattivo: keep Jackbox se 4-player funziona OK
+
+Non toccare:
+- Demo :3334 backend fino a merge + deploy finale (user restart ngrok autonomo)
+- Frontend lobby UI (Phase B next session)
+- Campaign engine (già shipped M10, reuse routes esistenti)
+
+Warning:
+- WebSocket ports Windows: 3334 demo + 5180 Vite + 3340 calibration riservati.
+  Scegli 3341 o 8080 per WS.
+- Phase B UI frontend: ~6-10h next session dopo Phase A merge.
+
+Effort Phase A: ~8-10h. Se finisce in 1 session, open PR draft +
+next session Phase B UI picker frontend.
+
+Output PR:
+- ADR-202X-m11-jackbox-phase-a (network architecture + room-code spec)
+- services/network/wsSession.js + routes/lobby.js
+- tests/api/lobbyRoutes.test.js (4-player + reconnect)
+- app.js wire
+```
+
+**Perché ultima**: big rock 20h totale. Best attention unbroken. Spezzabile in A1 (backend ~10h) + A2 (frontend ~10h) se serve.
+
+---
+
+## Ottimizzazioni cross-session
+
+### Ridurre token burn
+
+1. **Skip markdown playtest per-iter** (Flint kill-ceremony applicato). Solo commit msg + INDEX.md 1-line per calibration runs.
+2. **Non pre-write ADR stub** per tutti e 3 — troppo presuntuoso. Scriverai al momento.
+3. **Reuse test pattern** da campaignRoutes.test.js (Phase B M10) — già proven HTTP integration.
+4. **No deep audit inside single sprint** — if audit needed, spawn separate session.
+
+### Session-startup optimization
+
+Apertura Claude Code in terminale:
+
+```bash
+cd /c/Users/VGit/Desktop/Game
+claude
+```
+
+Prima linea conversazione: **incolla UN solo prompt** sopra. Claude Code:
+
+- Crea branch da origin/main fresh
+- Legge i file indicati
+- Execute task + test + commit + push + PR
+- Close GitHub issue se applicabile
+
+### Warning comuni
+
+1. **Codex P2 bot review** inevitable. Fix piccolo + push. Non saltare.
+2. **Prettier pre-commit hook** autoformats. File show come modificato post-commit = linter, non tuo.
+3. **Replace_all safety hook** triggera su `state/action/turn/player` rename massive. Controllato, puoi ignorare warning se replace_all non usato intenzionalmente.
+4. **Docs governance registry**: ogni nuovo canonical doc (`source_of_truth: true`) DEVE essere registrato. Imparato da Codex review #1676.
+
+### Demo :3334 ngrok
+
+Demo frozen post-sessione. Per riavviare:
+
+```bash
+cd /c/Users/VGit/Desktop/Game
+PORT=3334 nohup node apps/backend/index.js > /tmp/demo-backend.log 2>&1 &
+cd apps/play
+nohup npx vite --host 0.0.0.0 --port 5180 > /tmp/demo-vite.log 2>&1 &
+# ngrok http 5180 (in altro terminale)
+```
+
+Note: ngrok serve `vite` porta 5180, che fa proxy `/api` → backend 3334 via `vite.config.js` esistente.
+
+---
+
+## Session-startup checklist
+
+Copia-incolla ogni volta:
+
+1. [ ] `cd /c/Users/VGit/Desktop/Game`
+2. [ ] `git fetch origin main && git status` — verify working tree pulito
+3. [ ] Apri Claude Code
+4. [ ] Incolla UN solo prompt (C o B o A)
+5. [ ] Attendi Claude completi task + PR aperta
+6. [ ] Review Codex bot comments (P2/P1 se presenti)
+7. [ ] Fix + push se Codex warning
+8. [ ] Merge PR quando CI verde
+9. [ ] (Se issue legata) verify GitHub issue chiusa
+10. [ ] Chiudi sessione, log riposo
+
+## Metadati sessione 2026-04-20/21 (reference)
+
+### PR merged (15)
+
+`#1657, #1658, #1659, #1660, #1661, #1662, #1663, #1664, #1665, #1666, #1667, #1668, #1669, #1670, #1671, #1672, #1676`
+
+### Issues
+
+- #1673 BiomeMemory — parked M12+
+- #1674 Costo ambientale trait — **pending Prompt C**
+- #1675 Onboarding 60s — **closed by #1676**
+
+### Ultimo sprint
+
+M10 Campaign cluster COMPLETO (A-E), P6 turn_limit_defeat validated (iter8 win IN BAND), concept material tracked (47 file), Prompt 1+2+3 integrated-map executed, L05 P0 Onboarding closed.
+
+## Reminders cross-session
+
+1. **M11 Jackbox LOCKED** dopo M10 per strategy
+2. **Prompt 4 prerequisites** ✅ verified (L02+L03 closed)
+3. **Baseline test metaProgression** 37/37 verdi shipped
+4. **Playtest M3 human** pending user schedule (T04/T05 FRICTION #5/#6/#7)
+5. **Issue #1674** P0 pilot, start Prompt C
+
+## Autori
+
+- Master DD (next-session prep request)
+- Claude Opus 4.7 (kickoff doc + baseline tests)
+- Flint advisor (kill-60 multi-session discipline)

--- a/tests/ai/metaProgression.test.js
+++ b/tests/ai/metaProgression.test.js
@@ -1,0 +1,355 @@
+// Baseline tests for metaProgression.js — protects against regression
+// during Prompt 4 Prisma persistence migration (integrated-map L06).
+//
+// Shipped: 2026-04-21 as safety net BEFORE impl swap in-memory → Prisma.
+// Coverage: affinity/trust clamps + recruit/mate gates + rollMating
+// compatibility + cooldowns + nest state.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createMetaTracker,
+  RECRUIT_AFFINITY_MIN,
+  RECRUIT_TRUST_MIN,
+  MATING_TRUST_MIN,
+  AFFINITY_MIN,
+  AFFINITY_MAX,
+  TRUST_MIN,
+  TRUST_MAX,
+} = require('../../apps/backend/services/metaProgression');
+
+// ─── Constants (canonical P0 Q11 B — Freeze scale) ─────────────────
+
+test('constants: Affinity range -2..+2 (Freeze §20)', () => {
+  assert.equal(AFFINITY_MIN, -2);
+  assert.equal(AFFINITY_MAX, 2);
+});
+
+test('constants: Trust range 0..5 (Freeze §20)', () => {
+  assert.equal(TRUST_MIN, 0);
+  assert.equal(TRUST_MAX, 5);
+});
+
+test('constants: gate thresholds', () => {
+  assert.equal(RECRUIT_AFFINITY_MIN, 0);
+  assert.equal(RECRUIT_TRUST_MIN, 2);
+  assert.equal(MATING_TRUST_MIN, 3);
+});
+
+// ─── Factory ───────────────────────────────────────────────────────
+
+test('createMetaTracker: returns API shape', () => {
+  const tracker = createMetaTracker();
+  assert.equal(typeof tracker.updateAffinity, 'function');
+  assert.equal(typeof tracker.updateTrust, 'function');
+  assert.equal(typeof tracker.canRecruit, 'function');
+  assert.equal(typeof tracker.recruit, 'function');
+  assert.equal(typeof tracker.canMate, 'function');
+  assert.equal(typeof tracker.rollMating, 'function');
+  assert.equal(typeof tracker.setNest, 'function');
+  assert.equal(typeof tracker.tickCooldowns, 'function');
+  assert.equal(typeof tracker.listNpcs, 'function');
+  assert.equal(typeof tracker.getNest, 'function');
+});
+
+test('createMetaTracker: new tracker has empty npc list + default nest', () => {
+  const tracker = createMetaTracker();
+  assert.deepEqual(tracker.listNpcs(), []);
+  const nest = tracker.getNest();
+  assert.equal(nest.level, 0);
+  assert.equal(nest.biome, null);
+  assert.equal(nest.requirements_met, false);
+});
+
+// ─── Affinity ──────────────────────────────────────────────────────
+
+test('updateAffinity: creates NPC on first call with defaults', () => {
+  const tracker = createMetaTracker();
+  const npc = tracker.updateAffinity('npc_1', 1);
+  assert.equal(npc.affinity, 1);
+  assert.equal(npc.trust, 0);
+  assert.equal(npc.recruited, false);
+});
+
+test('updateAffinity: clamps to AFFINITY_MAX', () => {
+  const tracker = createMetaTracker();
+  const npc = tracker.updateAffinity('npc_1', 10);
+  assert.equal(npc.affinity, 2);
+});
+
+test('updateAffinity: clamps to AFFINITY_MIN', () => {
+  const tracker = createMetaTracker();
+  const npc = tracker.updateAffinity('npc_1', -10);
+  assert.equal(npc.affinity, -2);
+});
+
+test('updateAffinity: cumulative deltas', () => {
+  const tracker = createMetaTracker();
+  tracker.updateAffinity('npc_1', 1);
+  tracker.updateAffinity('npc_1', 1);
+  const npc = tracker.updateAffinity('npc_1', -1);
+  assert.equal(npc.affinity, 1);
+});
+
+// ─── Trust ─────────────────────────────────────────────────────────
+
+test('updateTrust: clamps to TRUST_MAX (5)', () => {
+  const tracker = createMetaTracker();
+  const npc = tracker.updateTrust('npc_1', 100);
+  assert.equal(npc.trust, 5);
+});
+
+test('updateTrust: clamps to TRUST_MIN (0), never negative', () => {
+  const tracker = createMetaTracker();
+  const npc = tracker.updateTrust('npc_1', -100);
+  assert.equal(npc.trust, 0);
+});
+
+test('updateTrust: from 0, cumulative', () => {
+  const tracker = createMetaTracker();
+  tracker.updateTrust('npc_1', 3);
+  const npc = tracker.updateTrust('npc_1', 1);
+  assert.equal(npc.trust, 4);
+});
+
+// ─── Recruit gate ──────────────────────────────────────────────────
+
+test('canRecruit: false by default (affinity 0, trust 0)', () => {
+  const tracker = createMetaTracker();
+  tracker.updateAffinity('npc_1', 0); // create
+  assert.equal(tracker.canRecruit('npc_1'), false);
+});
+
+test('canRecruit: true when affinity >= 0 AND trust >= 2', () => {
+  const tracker = createMetaTracker();
+  tracker.updateAffinity('npc_1', 0);
+  tracker.updateTrust('npc_1', 2);
+  assert.equal(tracker.canRecruit('npc_1'), true);
+});
+
+test('canRecruit: false if trust < 2 even with affinity high', () => {
+  const tracker = createMetaTracker();
+  tracker.updateAffinity('npc_1', 2);
+  tracker.updateTrust('npc_1', 1);
+  assert.equal(tracker.canRecruit('npc_1'), false);
+});
+
+test('canRecruit: false if affinity < 0 even with high trust', () => {
+  const tracker = createMetaTracker();
+  tracker.updateAffinity('npc_1', -1);
+  tracker.updateTrust('npc_1', 5);
+  assert.equal(tracker.canRecruit('npc_1'), false);
+});
+
+test('recruit: success marks recruited + gate consumes', () => {
+  const tracker = createMetaTracker();
+  tracker.updateAffinity('npc_1', 1);
+  tracker.updateTrust('npc_1', 3);
+  const result = tracker.recruit('npc_1');
+  assert.equal(result.success, true);
+  assert.equal(result.npc.recruited, true);
+  // Second recruit fails (already recruited)
+  const retry = tracker.recruit('npc_1');
+  assert.equal(retry.success, false);
+  assert.equal(retry.reason, 'gate_not_met');
+});
+
+test('recruit: fails when gate not met', () => {
+  const tracker = createMetaTracker();
+  const result = tracker.recruit('npc_never_met');
+  assert.equal(result.success, false);
+  assert.equal(result.reason, 'gate_not_met');
+});
+
+// ─── Mate gate ─────────────────────────────────────────────────────
+
+test('canMate: false without recruitment', () => {
+  const tracker = createMetaTracker();
+  tracker.updateTrust('npc_1', 5);
+  assert.equal(tracker.canMate('npc_1'), false);
+});
+
+test('canMate: false without nest requirements met', () => {
+  const tracker = createMetaTracker();
+  tracker.updateAffinity('npc_1', 1);
+  tracker.updateTrust('npc_1', 4);
+  tracker.recruit('npc_1');
+  // Nest requirements NOT met yet
+  assert.equal(tracker.canMate('npc_1'), false);
+});
+
+test('canMate: true when recruited + trust >= 3 + nest ready', () => {
+  const tracker = createMetaTracker();
+  tracker.updateAffinity('npc_1', 1);
+  tracker.updateTrust('npc_1', 3);
+  tracker.recruit('npc_1');
+  tracker.setNest('savana', true);
+  assert.equal(tracker.canMate('npc_1'), true);
+});
+
+test('canMate: false if trust < 3 even recruited', () => {
+  const tracker = createMetaTracker();
+  tracker.updateAffinity('npc_1', 1);
+  tracker.updateTrust('npc_1', 2);
+  tracker.recruit('npc_1');
+  tracker.setNest('savana', true);
+  assert.equal(tracker.canMate('npc_1'), false);
+});
+
+// ─── rollMating ────────────────────────────────────────────────────
+
+function _setupMatable(tracker, npcId = 'npc_1', trust = 4) {
+  tracker.updateAffinity(npcId, 2);
+  tracker.updateTrust(npcId, trust);
+  tracker.recruit(npcId);
+  tracker.setNest('savana', true);
+}
+
+test('rollMating: gate_not_met if not recruited', () => {
+  const tracker = createMetaTracker();
+  const result = tracker.rollMating('npc_1', { mbti_type: 'NEUTRA' });
+  assert.equal(result.success, false);
+  assert.equal(result.reason, 'gate_not_met');
+});
+
+test('rollMating: deterministic success with fixed rng', () => {
+  const tracker = createMetaTracker();
+  _setupMatable(tracker);
+  // rng returns 0.95 → d20 = floor(0.95 * 20) + 1 = 19 + 1 = 20
+  const result = tracker.rollMating('npc_1', { mbti_type: 'NEUTRA' }, {}, () => 0.95);
+  assert.equal(result.success, true);
+  assert.equal(result.roll, 20);
+  assert.ok(Array.isArray(result.offspring_traits));
+});
+
+test('rollMating: deterministic fail with low rng', () => {
+  const tracker = createMetaTracker();
+  _setupMatable(tracker, 'npc_1', 3); // trust exactly MATING_TRUST_MIN, bonus 0
+  // rng 0.05 → d20 = 1 + 1 = 2, fail threshold 12
+  const result = tracker.rollMating('npc_1', { mbti_type: 'NEUTRA' }, {}, () => 0.05);
+  assert.equal(result.success, false);
+  assert.equal(result.reason, 'roll_failed');
+});
+
+test('rollMating: MBTI like bonus +3', () => {
+  const tracker = createMetaTracker();
+  _setupMatable(tracker);
+  const compatTable = { ESTJ: { likes: ['NEUTRA'], dislikes: [] } };
+  // Setup npc.mbti_type = NEUTRA (default), player ESTJ likes NEUTRA
+  const result = tracker.rollMating('npc_1', { mbti_type: 'ESTJ' }, compatTable, () => 0.5);
+  // roll = 11, modifier = +3 like + (trust 4 - 3) = +4, total = 15 >= 12
+  assert.equal(result.modifier, 4);
+  assert.equal(result.success, true);
+});
+
+test('rollMating: MBTI dislike penalty -3', () => {
+  const tracker = createMetaTracker();
+  _setupMatable(tracker, 'npc_1', 3); // no trust bonus
+  const compatTable = { ESTJ: { likes: [], dislikes: ['NEUTRA'] } };
+  const result = tracker.rollMating('npc_1', { mbti_type: 'ESTJ' }, compatTable, () => 0.5);
+  // roll = 11, modifier = -3, total = 8 < 12 → fail
+  assert.equal(result.modifier, -3);
+  assert.equal(result.success, false);
+});
+
+test('rollMating: fail sets cooldown 1', () => {
+  const tracker = createMetaTracker();
+  _setupMatable(tracker, 'npc_1', 3);
+  tracker.rollMating('npc_1', { mbti_type: 'NEUTRA' }, {}, () => 0.05);
+  // Retry immediately should fail gate (cooldown)
+  assert.equal(tracker.canMate('npc_1'), false);
+});
+
+test('rollMating: offspring traits merge parent + npc', () => {
+  const tracker = createMetaTracker();
+  _setupMatable(tracker);
+  const result = tracker.rollMating(
+    'npc_1',
+    { mbti_type: 'NEUTRA', trait_ids: ['zampe_a_molla', 'pelle_elastomera'] },
+    {},
+    () => 0.99,
+  );
+  assert.equal(result.success, true);
+  assert.ok(result.offspring_traits.length >= 1 && result.offspring_traits.length <= 3);
+  // All offspring traits must come from parent pool
+  for (const t of result.offspring_traits) {
+    assert.ok(['zampe_a_molla', 'pelle_elastomera'].includes(t));
+  }
+});
+
+test('rollMating: seed_generated=1 on success', () => {
+  const tracker = createMetaTracker();
+  _setupMatable(tracker);
+  const result = tracker.rollMating('npc_1', { mbti_type: 'NEUTRA' }, {}, () => 0.99);
+  assert.equal(result.seed_generated, 1);
+});
+
+// ─── Cooldown ──────────────────────────────────────────────────────
+
+test('tickCooldowns: decrements mating_cooldown', () => {
+  const tracker = createMetaTracker();
+  _setupMatable(tracker, 'npc_1', 3);
+  tracker.rollMating('npc_1', { mbti_type: 'NEUTRA' }, {}, () => 0.05); // fail → cooldown 1
+  tracker.tickCooldowns();
+  const npc = tracker.listNpcs().find((n) => n.npc_id === 'npc_1');
+  assert.equal(npc.mating_cooldown, 0);
+});
+
+test('tickCooldowns: idempotent at 0', () => {
+  const tracker = createMetaTracker();
+  tracker.updateAffinity('npc_1', 0);
+  tracker.tickCooldowns();
+  const npc = tracker.listNpcs()[0];
+  assert.equal(npc.mating_cooldown, 0);
+});
+
+// ─── Nest ──────────────────────────────────────────────────────────
+
+test('setNest: bumps level 0 → 1 + biome + requirements_met', () => {
+  const tracker = createMetaTracker();
+  const nest = tracker.setNest('savana', true);
+  assert.equal(nest.level, 1);
+  assert.equal(nest.biome, 'savana');
+  assert.equal(nest.requirements_met, true);
+});
+
+test('setNest: requirements_met false allowed', () => {
+  const tracker = createMetaTracker();
+  const nest = tracker.setNest('caverna_risonante', false);
+  assert.equal(nest.requirements_met, false);
+});
+
+test('getNest: returns copy (no mutation)', () => {
+  const tracker = createMetaTracker();
+  tracker.setNest('savana', true);
+  const snapshot = tracker.getNest();
+  snapshot.level = 99;
+  assert.equal(tracker.getNest().level, 1);
+});
+
+// ─── listNpcs ──────────────────────────────────────────────────────
+
+test('listNpcs: returns all tracked NPCs', () => {
+  const tracker = createMetaTracker();
+  tracker.updateAffinity('npc_a', 1);
+  tracker.updateAffinity('npc_b', -1);
+  tracker.updateAffinity('npc_c', 0);
+  const list = tracker.listNpcs();
+  assert.equal(list.length, 3);
+  const ids = list.map((n) => n.npc_id);
+  assert.ok(ids.includes('npc_a'));
+  assert.ok(ids.includes('npc_b'));
+  assert.ok(ids.includes('npc_c'));
+});
+
+// ─── Isolation ─────────────────────────────────────────────────────
+
+test('isolation: separate trackers do not share state', () => {
+  const t1 = createMetaTracker();
+  const t2 = createMetaTracker();
+  t1.updateAffinity('npc_1', 2);
+  assert.equal(t2.listNpcs().length, 0);
+});

--- a/tests/ai/traitEnvironmentalCosts.test.js
+++ b/tests/ai/traitEnvironmentalCosts.test.js
@@ -1,0 +1,232 @@
+// M11 pilot (ADR-2026-04-21c, issue #1674) — trait environmental costs tests.
+//
+// Pilot scope: 4 trait × 3 biomi = 12 cell.
+// Verifica loader + applyBiomeTraitCosts mutations + idempotency + wire.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  loadTraitEnvironmentalCosts,
+  applyBiomeTraitCosts,
+  _resetBiomeCostCache,
+} = require('../../apps/backend/services/traitEffects');
+
+test('loadTraitEnvironmentalCosts: carica YAML reale con 4 trait × 3 biomi', () => {
+  _resetBiomeCostCache();
+  const data = loadTraitEnvironmentalCosts();
+  assert.ok(data, 'YAML deve caricare');
+  assert.ok(data.trait_costs, 'trait_costs presente');
+  const traits = Object.keys(data.trait_costs);
+  assert.equal(traits.length, 4, 'esattamente 4 trait pilot');
+  assert.ok(traits.includes('thermal_armor'));
+  assert.ok(traits.includes('zampe_a_molla'));
+  assert.ok(traits.includes('pelle_elastomera'));
+  assert.ok(traits.includes('denti_seghettati'));
+  // Ogni trait ha 3 biomi
+  for (const tid of traits) {
+    const biomes = Object.keys(data.trait_costs[tid]);
+    assert.equal(biomes.length, 3, `${tid} deve avere 3 biomi`);
+    assert.ok(biomes.includes('savana'));
+    assert.ok(biomes.includes('caverna_risonante'));
+    assert.ok(biomes.includes('rovine_planari'));
+  }
+});
+
+test('loadTraitEnvironmentalCosts: soft-fail su path missing → registry vuoto', () => {
+  _resetBiomeCostCache();
+  const data = loadTraitEnvironmentalCosts('/nonexistent/path.yaml', {
+    warn: () => {},
+    log: () => {},
+  });
+  assert.deepEqual(data, {}, 'registry vuoto su ENOENT');
+  _resetBiomeCostCache();
+});
+
+// ─── Scenario 1: thermal_armor × savana — penalty doppio ────────────
+test('Scenario 1: thermal_armor × savana → defense_mod_bonus -1, mobility -1', () => {
+  _resetBiomeCostCache();
+  const unit = {
+    id: 'u1',
+    traits: ['thermal_armor'],
+    attack_mod_bonus: 0,
+    defense_mod_bonus: 0,
+    mobility: 3,
+  };
+  const applied = applyBiomeTraitCosts(unit, 'savana');
+  assert.equal(applied.length, 1);
+  assert.equal(applied[0].trait, 'thermal_armor');
+  assert.equal(applied[0].biome, 'savana');
+  assert.equal(applied[0].delta.defense_mod, -1);
+  assert.equal(applied[0].delta.mobility, -1);
+  assert.equal(unit.defense_mod_bonus, -1);
+  assert.equal(unit.mobility, 2);
+  assert.equal(unit.attack_mod_bonus, 0, 'attack non toccato');
+});
+
+// ─── Scenario 2: thermal_armor × caverna → bonus +2 ─────────────────
+test('Scenario 2: thermal_armor × caverna_risonante → defense_mod_bonus +2', () => {
+  _resetBiomeCostCache();
+  const unit = {
+    id: 'u2',
+    traits: ['thermal_armor'],
+    attack_mod_bonus: 0,
+    defense_mod_bonus: 0,
+    mobility: 3,
+  };
+  const applied = applyBiomeTraitCosts(unit, 'caverna_risonante');
+  assert.equal(applied.length, 1);
+  assert.equal(applied[0].delta.defense_mod, 2);
+  assert.equal(unit.defense_mod_bonus, 2);
+  assert.equal(unit.mobility, 3, 'mobility non toccata');
+});
+
+// ─── Scenario 3: denti_seghettati × savana → attack +1 ──────────────
+test('Scenario 3: denti_seghettati × savana → attack_mod_bonus +1', () => {
+  _resetBiomeCostCache();
+  const unit = {
+    id: 'u3',
+    traits: ['denti_seghettati'],
+    attack_mod_bonus: 0,
+    defense_mod_bonus: 0,
+    mobility: 3,
+  };
+  const applied = applyBiomeTraitCosts(unit, 'savana');
+  assert.equal(applied.length, 1);
+  assert.equal(applied[0].delta.attack_mod, 1);
+  assert.equal(unit.attack_mod_bonus, 1);
+});
+
+// ─── Scenario 4: qualsiasi trait × rovine_planari → no-op (neutral) ──
+test('Scenario 4: rovine_planari è neutral per tutti i 4 trait pilot', () => {
+  _resetBiomeCostCache();
+  for (const traitId of [
+    'thermal_armor',
+    'zampe_a_molla',
+    'pelle_elastomera',
+    'denti_seghettati',
+  ]) {
+    const unit = {
+      id: `u-${traitId}`,
+      traits: [traitId],
+      attack_mod_bonus: 0,
+      defense_mod_bonus: 0,
+      mobility: 3,
+    };
+    const applied = applyBiomeTraitCosts(unit, 'rovine_planari');
+    assert.equal(applied.length, 0, `${traitId} × rovine_planari è neutral`);
+    assert.equal(unit.attack_mod_bonus, 0);
+    assert.equal(unit.defense_mod_bonus, 0);
+    assert.equal(unit.mobility, 3);
+  }
+});
+
+// ─── Extra coverage: zampe_a_molla × savana vs caverna ──────────────
+test('zampe_a_molla: savana +1 mobility, caverna -1 mobility', () => {
+  _resetBiomeCostCache();
+  const u1 = { id: 'u', traits: ['zampe_a_molla'], mobility: 3 };
+  applyBiomeTraitCosts(u1, 'savana');
+  assert.equal(u1.mobility, 4);
+
+  const u2 = { id: 'u', traits: ['zampe_a_molla'], mobility: 3 };
+  applyBiomeTraitCosts(u2, 'caverna_risonante');
+  assert.equal(u2.mobility, 2);
+});
+
+// ─── Extra coverage: pelle_elastomera caverna +1 def ────────────────
+test('pelle_elastomera × caverna_risonante → defense_mod_bonus +1', () => {
+  _resetBiomeCostCache();
+  const unit = {
+    id: 'u',
+    traits: ['pelle_elastomera'],
+    defense_mod_bonus: 0,
+  };
+  applyBiomeTraitCosts(unit, 'caverna_risonante');
+  assert.equal(unit.defense_mod_bonus, 1);
+});
+
+// ─── Multi-trait aggregation ────────────────────────────────────────
+test('multi-trait: thermal_armor + denti_seghettati × savana aggregano delta', () => {
+  _resetBiomeCostCache();
+  const unit = {
+    id: 'u',
+    traits: ['thermal_armor', 'denti_seghettati'],
+    attack_mod_bonus: 0,
+    defense_mod_bonus: 0,
+    mobility: 3,
+  };
+  const applied = applyBiomeTraitCosts(unit, 'savana');
+  assert.equal(applied.length, 2);
+  // thermal: -1 def, -1 mob; denti: +1 atk
+  assert.equal(unit.defense_mod_bonus, -1);
+  assert.equal(unit.mobility, 2);
+  assert.equal(unit.attack_mod_bonus, 1);
+});
+
+// ─── Idempotency guard ───────────────────────────────────────────────
+test('idempotent: chiamate ripetute non accumulano delta', () => {
+  _resetBiomeCostCache();
+  const unit = {
+    id: 'u',
+    traits: ['thermal_armor'],
+    defense_mod_bonus: 0,
+    mobility: 3,
+  };
+  applyBiomeTraitCosts(unit, 'savana');
+  applyBiomeTraitCosts(unit, 'savana');
+  applyBiomeTraitCosts(unit, 'savana');
+  assert.equal(unit.defense_mod_bonus, -1, 'delta applicato una sola volta');
+  assert.equal(unit.mobility, 2);
+  assert.equal(unit._biome_costs_applied, true);
+});
+
+// ─── Unknown trait / unknown biome → skip silently ──────────────────
+test('unknown trait → no-op senza throw', () => {
+  _resetBiomeCostCache();
+  const unit = { id: 'u', traits: ['trait_inesistente'], mobility: 3 };
+  const applied = applyBiomeTraitCosts(unit, 'savana');
+  assert.equal(applied.length, 0);
+  assert.equal(unit.mobility, 3);
+});
+
+test('unknown biome → no-op (fuori scope pilot)', () => {
+  _resetBiomeCostCache();
+  const unit = {
+    id: 'u',
+    traits: ['thermal_armor'],
+    defense_mod_bonus: 0,
+  };
+  const applied = applyBiomeTraitCosts(unit, 'bioma_sconosciuto_mXX');
+  assert.equal(applied.length, 0);
+  assert.equal(unit.defense_mod_bonus, 0);
+});
+
+test('biomeId null/undefined → no-op', () => {
+  _resetBiomeCostCache();
+  const unit = { id: 'u', traits: ['thermal_armor'], defense_mod_bonus: 0 };
+  assert.deepEqual(applyBiomeTraitCosts(unit, null), []);
+  assert.deepEqual(applyBiomeTraitCosts(unit, undefined), []);
+  assert.deepEqual(applyBiomeTraitCosts(unit, ''), []);
+  assert.equal(unit.defense_mod_bonus, 0);
+});
+
+// ─── Validation: YAML cell delta range ±1/±2 ────────────────────────
+test('validation: tutti i delta YAML in range [-2, 2]', () => {
+  _resetBiomeCostCache();
+  const data = loadTraitEnvironmentalCosts();
+  assert.ok(data.trait_costs);
+  for (const [traitId, biomeMap] of Object.entries(data.trait_costs)) {
+    for (const [biomeId, cell] of Object.entries(biomeMap)) {
+      for (const [stat, value] of Object.entries(cell)) {
+        if (stat === 'rationale') continue;
+        const n = Number(value);
+        assert.ok(
+          n >= -2 && n <= 2 && n !== 0,
+          `${traitId}×${biomeId}.${stat}=${value} fuori range pilot ±1/±2`,
+        );
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Ship pilot 4 trait × 3 biomi runtime wire (ADR-2026-04-21c). Chiude #1674 al merge.

- 12 cell matrix stat delta ±1/±2 (`attack_mod_bonus` / `defense_mod_bonus` / `mobility`)
- Session-scoped compute (no Prisma, no economy channel nuovo)
- Scope guard STRICT: non generalizzare pre-playtest validation

## Matrix

| trait \ biome    | savana         | caverna_risonante | rovine_planari |
| ---------------- | -------------- | ----------------- | -------------- |
| thermal_armor    | def −1, mob −1 | def +2            | —              |
| zampe_a_molla    | mob +1         | mob −1            | —              |
| pelle_elastomera | def −1         | def +1            | —              |
| denti_seghettati | atk +1         | atk −1            | —              |

## Deliverable

1. `data/core/balance/trait_environmental_costs.yaml` — schema v1.0 + 12 cell + rationale
2. `apps/backend/services/traitEffects.js` — `loadTraitEnvironmentalCosts` + `applyBiomeTraitCosts` (idempotent, soft-fail ENOENT)
3. `apps/backend/routes/session.js /start` — hook biome penalty post-normalise units
4. `tests/ai/traitEnvironmentalCosts.test.js` — 14 test (4 canonical scenari + multi-trait + idempotency + YAML range)
5. `docs/adr/ADR-2026-04-21c-trait-environmental-costs.md` — ACCEPTED, criteria promote/kill/tune
6. `docs/governance/docs_registry.json` — registra ADR

## Test plan

- [x] `node --test tests/ai/*.test.js` → 307/307 pass (+14 new biome)
- [x] `node --test tests/api/sessionEncounterWiring*.test.js tests/api/sessionDifficulty.test.js` → 11/11
- [x] `npm run format:check` su file modificati — clean
- [x] `python tools/check_docs_governance.py --registry docs/governance/docs_registry.json --strict` → 0 errors
- [ ] Playtest follow-up N=10 su enc_tutorial_01 (savana) + 03 (caverna) + 05 (rovine) — deferred post-merge

## Rollback plan

Revert banale <30 LOC:
- Rimuovi `require` + hook block in `session.js /start`
- Delete YAML + ADR + test file
- Drop registry entry

## Scope guard

- NO generalizzare oltre 4×3 pilot (aggiungere trait/biome #5 richiede nuova ADR)
- NO nuovo economy channel (PE/PI/Seed/Trust intatti — Freeze §19.3)
- NO Prisma persistence (ricalcolato a ogni `/start`)
- NO UI overlay M11 (applied log solo debug via `session.biome_costs_log`)

## Riferimenti

- Issue: #1674
- Triage: `docs/planning/2026-04-21-triage-exploration-notes.md` §Issue Draft 2
- Deck v2 Nota 2 (exploration-note)

Closes #1674

🤖 Generated with [Claude Code](https://claude.com/claude-code)