### PR TITLE
feat(meta): Prisma persistence adapter metaProgression (Prompt B / L06)

### DIFF
--- a/apps/backend/prisma/migrations/0002_meta_progression/migration.sql
+++ b/apps/backend/prisma/migrations/0002_meta_progression/migration.sql
@@ -1,0 +1,97 @@
+-- L06 Meta progression persistence (ADR-2026-04-21-meta-progression-prisma)
+-- Models: NpcRelation, AffinityLog, TrustLog, NestState, MatingEvent.
+
+-- CreateTable
+CREATE TABLE "npc_relations" (
+    "id" TEXT NOT NULL,
+    "campaign_id" TEXT,
+    "npc_id" TEXT NOT NULL,
+    "affinity" INTEGER NOT NULL DEFAULT 0,
+    "trust" INTEGER NOT NULL DEFAULT 0,
+    "recruited" BOOLEAN NOT NULL DEFAULT FALSE,
+    "mated" BOOLEAN NOT NULL DEFAULT FALSE,
+    "mating_cooldown" INTEGER NOT NULL DEFAULT 0,
+    "mbti_type" TEXT,
+    "trait_ids" TEXT NOT NULL DEFAULT '[]',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "npc_relations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "npc_relations_campaign_id_npc_id_key" ON "npc_relations"("campaign_id", "npc_id");
+
+-- CreateIndex
+CREATE INDEX "npc_relations_campaign_id_idx" ON "npc_relations"("campaign_id");
+
+-- CreateTable
+CREATE TABLE "affinity_logs" (
+    "id" TEXT NOT NULL,
+    "relation_id" TEXT NOT NULL,
+    "delta" INTEGER NOT NULL,
+    "before" INTEGER NOT NULL,
+    "after" INTEGER NOT NULL,
+    "reason" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "affinity_logs_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "affinity_logs_relation_id_fkey" FOREIGN KEY ("relation_id") REFERENCES "npc_relations"("id") ON DELETE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "affinity_logs_relation_id_created_at_idx" ON "affinity_logs"("relation_id", "created_at");
+
+-- CreateTable
+CREATE TABLE "trust_logs" (
+    "id" TEXT NOT NULL,
+    "relation_id" TEXT NOT NULL,
+    "delta" INTEGER NOT NULL,
+    "before" INTEGER NOT NULL,
+    "after" INTEGER NOT NULL,
+    "reason" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "trust_logs_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "trust_logs_relation_id_fkey" FOREIGN KEY ("relation_id") REFERENCES "npc_relations"("id") ON DELETE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "trust_logs_relation_id_created_at_idx" ON "trust_logs"("relation_id", "created_at");
+
+-- CreateTable
+CREATE TABLE "nest_states" (
+    "id" TEXT NOT NULL,
+    "campaign_id" TEXT,
+    "level" INTEGER NOT NULL DEFAULT 0,
+    "biome" TEXT,
+    "requirements_met" BOOLEAN NOT NULL DEFAULT FALSE,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "nest_states_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "nest_states_campaign_id_key" ON "nest_states"("campaign_id");
+
+-- CreateTable
+CREATE TABLE "mating_events" (
+    "id" TEXT NOT NULL,
+    "relation_id" TEXT NOT NULL,
+    "success" BOOLEAN NOT NULL,
+    "roll" INTEGER NOT NULL,
+    "modifier" INTEGER NOT NULL,
+    "total" INTEGER NOT NULL,
+    "threshold" INTEGER NOT NULL,
+    "offspring_traits" TEXT NOT NULL DEFAULT '[]',
+    "seed_generated" INTEGER NOT NULL DEFAULT 0,
+    "reason" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "mating_events_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "mating_events_relation_id_fkey" FOREIGN KEY ("relation_id") REFERENCES "npc_relations"("id") ON DELETE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "mating_events_relation_id_created_at_idx" ON "mating_events"("relation_id", "created_at");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -157,3 +157,88 @@ model SaveSnapshot {
   @@index([campaignId, createdAt])
   @@map("save_snapshots")
 }
+
+// ─── L06 Meta progression persistence (ADR-2026-04-21-meta-progression-prisma) ────────
+// Promotes metaProgression.js in-memory Map → DB-backed. Adapter pattern
+// preserves in-memory fallback when DATABASE_URL unset (dev/demo ngrok).
+// Scope: NPC affinity/trust, nest state, mating events, audit logs.
+
+model NpcRelation {
+  id              String   @id @default(uuid())
+  campaignId      String?  @map("campaign_id") // optional (legacy in-memory has no campaign)
+  npcId           String   @map("npc_id")
+  affinity        Int      @default(0) // range -2..+2 enforced app-level
+  trust           Int      @default(0) // range 0..5 enforced app-level
+  recruited       Boolean  @default(false)
+  mated           Boolean  @default(false)
+  matingCooldown  Int      @default(0) @map("mating_cooldown")
+  mbtiType        String?  @map("mbti_type")
+  traitIds        String   @default("[]") @map("trait_ids") // JSON array
+  createdAt       DateTime @default(now()) @map("created_at")
+  updatedAt       DateTime @updatedAt @map("updated_at")
+  affinityLogs    AffinityLog[]
+  trustLogs       TrustLog[]
+  matingEvents    MatingEvent[]
+
+  @@unique([campaignId, npcId])
+  @@index([campaignId])
+  @@map("npc_relations")
+}
+
+model AffinityLog {
+  id          String      @id @default(uuid())
+  relationId  String      @map("relation_id")
+  relation    NpcRelation @relation(fields: [relationId], references: [id], onDelete: Cascade)
+  delta       Int
+  before      Int
+  after       Int
+  reason      String?
+  createdAt   DateTime    @default(now()) @map("created_at")
+
+  @@index([relationId, createdAt])
+  @@map("affinity_logs")
+}
+
+model TrustLog {
+  id          String      @id @default(uuid())
+  relationId  String      @map("relation_id")
+  relation    NpcRelation @relation(fields: [relationId], references: [id], onDelete: Cascade)
+  delta       Int
+  before      Int
+  after       Int
+  reason      String?
+  createdAt   DateTime    @default(now()) @map("created_at")
+
+  @@index([relationId, createdAt])
+  @@map("trust_logs")
+}
+
+model NestState {
+  id                String   @id @default(uuid())
+  campaignId        String?  @unique @map("campaign_id") // one nest per campaign (null = legacy global)
+  level             Int      @default(0)
+  biome             String?
+  requirementsMet   Boolean  @default(false) @map("requirements_met")
+  createdAt         DateTime @default(now()) @map("created_at")
+  updatedAt         DateTime @updatedAt @map("updated_at")
+
+  @@map("nest_states")
+}
+
+model MatingEvent {
+  id                String      @id @default(uuid())
+  relationId        String      @map("relation_id")
+  relation          NpcRelation @relation(fields: [relationId], references: [id], onDelete: Cascade)
+  success           Boolean
+  roll              Int
+  modifier          Int
+  total             Int
+  threshold         Int
+  offspringTraits   String      @default("[]") @map("offspring_traits") // JSON array
+  seedGenerated     Int         @default(0) @map("seed_generated")
+  reason            String?     // e.g. 'roll_failed', 'gate_not_met'
+  createdAt         DateTime    @default(now()) @map("created_at")
+
+  @@index([relationId, createdAt])
+  @@map("mating_events")
+}

--- a/apps/backend/routes/meta.js
+++ b/apps/backend/routes/meta.js
@@ -1,6 +1,6 @@
 // D3: Meta progression routes — recruit, mating, nest.
 //
-// Endpoints:
+// Endpoints (backward-compat, shape preserved):
 //   GET  /api/v1/meta/npg         — lista NPC con affinity/trust
 //   POST /api/v1/meta/recruit     — tenta reclutamento
 //   POST /api/v1/meta/mating      — tenta mating
@@ -9,74 +9,108 @@
 //   POST /api/v1/meta/affinity    — aggiorna affinity NPC
 //   POST /api/v1/meta/trust       — aggiorna trust NPC
 //
+// Backing store is an async adapter (Prisma + in-memory fallback).
+// See ADR-2026-04-21-meta-progression-prisma.md.
+//
 // Fonte: Final Design Freeze v0.9 §20-21
 
 'use strict';
 
 const { Router } = require('express');
-const { createMetaTracker } = require('../services/metaProgression');
+const { createMetaStore } = require('../services/metaProgression');
 
-function createMetaRouter() {
+/**
+ * @param {object} [opts]
+ * @param {object} [opts.store] — pre-built store (DI for tests or plugin sharing)
+ * @param {object} [opts.prisma] — Prisma client if creating a fresh store
+ * @param {string|null} [opts.campaignId] — scope NPCs to a campaign
+ */
+function createMetaRouter(opts = {}) {
   const router = Router();
-  // One tracker per server instance (in-memory; persist externally)
-  const tracker = createMetaTracker();
+  const store =
+    opts.store || createMetaStore({ prisma: opts.prisma, campaignId: opts.campaignId ?? null });
 
-  // GET /npg — lista NPC
-  router.get('/npg', (_req, res) => {
-    res.json({
-      npcs: tracker.listNpcs(),
-      nest: tracker.getNest(),
-    });
-  });
-
-  // POST /affinity — { npc_id, delta }
-  router.post('/affinity', (req, res) => {
-    const { npc_id, delta } = req.body || {};
-    if (!npc_id || typeof delta !== 'number') {
-      return res.status(400).json({ error: 'npc_id and delta (number) required' });
+  router.get('/npg', async (_req, res, next) => {
+    try {
+      const [npcs, nest] = await Promise.all([store.listNpcs(), store.getNest()]);
+      res.json({ npcs, nest });
+    } catch (err) {
+      next(err);
     }
-    const npc = tracker.updateAffinity(npc_id, delta);
-    res.json({ npc, can_recruit: tracker.canRecruit(npc_id) });
   });
 
-  // POST /trust — { npc_id, delta }
-  router.post('/trust', (req, res) => {
-    const { npc_id, delta } = req.body || {};
-    if (!npc_id || typeof delta !== 'number') {
-      return res.status(400).json({ error: 'npc_id and delta (number) required' });
+  router.post('/affinity', async (req, res, next) => {
+    try {
+      const { npc_id, delta } = req.body || {};
+      if (!npc_id || typeof delta !== 'number') {
+        return res.status(400).json({ error: 'npc_id and delta (number) required' });
+      }
+      const npc = await store.updateAffinity(npc_id, delta);
+      const can_recruit = await store.canRecruit(npc_id);
+      res.json({ npc, can_recruit });
+    } catch (err) {
+      next(err);
     }
-    const npc = tracker.updateTrust(npc_id, delta);
-    res.json({ npc, can_recruit: tracker.canRecruit(npc_id), can_mate: tracker.canMate(npc_id) });
   });
 
-  // POST /recruit — { npc_id }
-  router.post('/recruit', (req, res) => {
-    const { npc_id } = req.body || {};
-    if (!npc_id) return res.status(400).json({ error: 'npc_id required' });
-    const result = tracker.recruit(npc_id);
-    res.json(result);
-  });
-
-  // POST /mating — { npc_id, party_member: { mbti_type, trait_ids } }
-  router.post('/mating', (req, res) => {
-    const { npc_id, party_member } = req.body || {};
-    if (!npc_id || !party_member) {
-      return res.status(400).json({ error: 'npc_id and party_member required' });
+  router.post('/trust', async (req, res, next) => {
+    try {
+      const { npc_id, delta } = req.body || {};
+      if (!npc_id || typeof delta !== 'number') {
+        return res.status(400).json({ error: 'npc_id and delta (number) required' });
+      }
+      const npc = await store.updateTrust(npc_id, delta);
+      const [can_recruit, can_mate] = await Promise.all([
+        store.canRecruit(npc_id),
+        store.canMate(npc_id),
+      ]);
+      res.json({ npc, can_recruit, can_mate });
+    } catch (err) {
+      next(err);
     }
-    const result = tracker.rollMating(npc_id, party_member);
-    res.json(result);
   });
 
-  // GET /nest
-  router.get('/nest', (_req, res) => {
-    res.json(tracker.getNest());
+  router.post('/recruit', async (req, res, next) => {
+    try {
+      const { npc_id } = req.body || {};
+      if (!npc_id) return res.status(400).json({ error: 'npc_id required' });
+      const result = await store.recruit(npc_id);
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
   });
 
-  // POST /nest/setup — { biome, requirements_met }
-  router.post('/nest/setup', (req, res) => {
-    const { biome, requirements_met } = req.body || {};
-    const nest = tracker.setNest(biome || 'default', requirements_met !== false);
-    res.json(nest);
+  router.post('/mating', async (req, res, next) => {
+    try {
+      const { npc_id, party_member } = req.body || {};
+      if (!npc_id || !party_member) {
+        return res.status(400).json({ error: 'npc_id and party_member required' });
+      }
+      const result = await store.rollMating(npc_id, party_member);
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.get('/nest', async (_req, res, next) => {
+    try {
+      const nest = await store.getNest();
+      res.json(nest);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.post('/nest/setup', async (req, res, next) => {
+    try {
+      const { biome, requirements_met } = req.body || {};
+      const nest = await store.setNest(biome || 'default', requirements_met !== false);
+      res.json(nest);
+    } catch (err) {
+      next(err);
+    }
   });
 
   return router;

--- a/apps/backend/services/metaProgression.js
+++ b/apps/backend/services/metaProgression.js
@@ -1,16 +1,17 @@
 // D1+D2: Meta progression — recruit, trust, mating, nest.
 //
 // Gestisce NPC affinity/trust tracking + mating outcome.
-// State in-memory (Map npcId → { affinity, trust, ... }).
+// Two entry points:
+//   - createMetaTracker(): sync, in-memory (legacy; baseline tests).
+//   - createMetaStore({ prisma, campaignId }): async adapter (Prisma + in-memory fallback).
+//
 // Gate: recruit requires affinity >= 0 AND trust >= 2.
 // Gate: mating requires trust >= 3 + nest requirements.
 //
 // Fonte: Final Design Freeze v0.9 §20-21
+// ADR: docs/adr/ADR-2026-04-21-meta-progression-prisma.md
 
 'use strict';
-
-const fs = require('node:fs');
-const path = require('node:path');
 
 // Gate thresholds (§20.2)
 const RECRUIT_AFFINITY_MIN = 0;
@@ -23,6 +24,8 @@ const AFFINITY_MAX = 2;
 // Trust range: 0..5
 const TRUST_MIN = 0;
 const TRUST_MAX = 5;
+
+const MATING_THRESHOLD = 12; // DC base
 
 /**
  * D1: Creates a meta progression tracker for a party/campaign.
@@ -94,39 +97,17 @@ function createMetaTracker() {
     if (!canMate(npcId)) return { success: false, reason: 'gate_not_met' };
 
     const npc = getOrCreate(npcId);
-    const roll = Math.floor(rng() * 20) + 1; // d20
-
-    // MBTI compatibility modifier
-    let modifier = 0;
-    const playerType = partyMember.mbti_type || 'NEUTRA';
-    const npcType = npc.mbti_type || 'NEUTRA';
-    const compat = compatTable[playerType];
-    if (compat) {
-      if ((compat.likes || []).includes(npcType)) modifier += 3;
-      else if ((compat.dislikes || []).includes(npcType)) modifier -= 3;
-    }
-
-    // Trust bonus
-    modifier += npc.trust - MATING_TRUST_MIN;
-
-    const total = roll + modifier;
-    const threshold = 12; // DC 12 base
-    const success = total >= threshold;
+    const { roll, modifier, total, threshold, success, offspringTraits } = computeMatingRoll({
+      npcMbti: npc.mbti_type,
+      npcTraits: npc.trait_ids,
+      npcTrust: npc.trust,
+      partyMember,
+      compatTable,
+      rng,
+    });
 
     if (success) {
       npc.mated = true;
-      // Offspring trait combination: pick 2 from each parent
-      const parentTraits = partyMember.trait_ids || [];
-      const npcTraits = npc.trait_ids || [];
-      const allTraits = [...new Set([...parentTraits, ...npcTraits])];
-      const offspringCount = Math.min(3, allTraits.length);
-      const offspringTraits = [];
-      const available = [...allTraits];
-      for (let i = 0; i < offspringCount && available.length > 0; i++) {
-        const idx = Math.floor(rng() * available.length);
-        offspringTraits.push(available.splice(idx, 1)[0]);
-      }
-
       return {
         success: true,
         roll,
@@ -138,7 +119,6 @@ function createMetaTracker() {
       };
     }
 
-    // Fail: cooldown 1 mission
     npc.mating_cooldown = 1;
     return { success: false, roll, modifier, total, threshold, reason: 'roll_failed' };
   }
@@ -182,8 +162,302 @@ function clamp(v, lo, hi) {
   return Math.min(hi, Math.max(lo, v));
 }
 
+// ─── Shared mating roll logic (used by both tracker and store) ──────────
+
+function computeMatingRoll({ npcMbti, npcTraits, npcTrust, partyMember, compatTable, rng }) {
+  const roll = Math.floor(rng() * 20) + 1;
+
+  let modifier = 0;
+  const playerType = partyMember.mbti_type || 'NEUTRA';
+  const npcType = npcMbti || 'NEUTRA';
+  const compat = compatTable[playerType];
+  if (compat) {
+    if ((compat.likes || []).includes(npcType)) modifier += 3;
+    else if ((compat.dislikes || []).includes(npcType)) modifier -= 3;
+  }
+
+  modifier += npcTrust - MATING_TRUST_MIN;
+
+  const total = roll + modifier;
+  const success = total >= MATING_THRESHOLD;
+
+  let offspringTraits = [];
+  if (success) {
+    const parentTraits = partyMember.trait_ids || [];
+    const npcTraitsList = Array.isArray(npcTraits) ? npcTraits : parseJsonArray(npcTraits);
+    const allTraits = [...new Set([...parentTraits, ...npcTraitsList])];
+    const offspringCount = Math.min(3, allTraits.length);
+    const available = [...allTraits];
+    for (let i = 0; i < offspringCount && available.length > 0; i++) {
+      const idx = Math.floor(rng() * available.length);
+      offspringTraits.push(available.splice(idx, 1)[0]);
+    }
+  }
+
+  return { roll, modifier, total, threshold: MATING_THRESHOLD, success, offspringTraits };
+}
+
+function parseJsonArray(raw) {
+  if (!raw) return [];
+  if (Array.isArray(raw)) return raw;
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+// ─── L06 adapter: Prisma + in-memory fallback ────────────────────────────
+
+/**
+ * Detect if Prisma client exposes the meta progression delegates.
+ * Stub client (see db/prisma.js) doesn't expose npcRelation → fallback.
+ */
+function prismaSupportsMeta(prisma) {
+  return Boolean(
+    prisma &&
+      prisma.npcRelation &&
+      typeof prisma.npcRelation.findUnique === 'function' &&
+      typeof prisma.npcRelation.upsert === 'function',
+  );
+}
+
+/**
+ * Async adapter. Preserves API shape of createMetaTracker but all ops async.
+ * When prisma unavailable → delegates to in-memory tracker.
+ *
+ * @param {object} opts
+ * @param {object} [opts.prisma] — Prisma client (from db/prisma.js)
+ * @param {string|null} [opts.campaignId] — scope NPC relations per-campaign; null = legacy global
+ */
+function createMetaStore({ prisma, campaignId = null } = {}) {
+  const usePrisma = prismaSupportsMeta(prisma);
+  const fallback = usePrisma ? null : createMetaTracker();
+
+  async function getOrCreateRelation(npcId) {
+    if (!usePrisma) return null;
+    const existing = await prisma.npcRelation.findUnique({
+      where: { campaignId_npcId: { campaignId, npcId } },
+    });
+    if (existing) return existing;
+    return prisma.npcRelation.create({
+      data: { campaignId, npcId },
+    });
+  }
+
+  function toNpcShape(relation) {
+    return {
+      npc_id: relation.npcId,
+      affinity: relation.affinity,
+      trust: relation.trust,
+      recruited: relation.recruited,
+      mated: relation.mated,
+      mating_cooldown: relation.matingCooldown,
+      mbti_type: relation.mbtiType || undefined,
+      trait_ids: parseJsonArray(relation.traitIds),
+    };
+  }
+
+  async function updateAffinity(npcId, delta) {
+    if (!usePrisma) return fallback.updateAffinity(npcId, delta);
+    const rel = await getOrCreateRelation(npcId);
+    const before = rel.affinity;
+    const after = clamp(before + delta, AFFINITY_MIN, AFFINITY_MAX);
+    const updated = await prisma.npcRelation.update({
+      where: { id: rel.id },
+      data: {
+        affinity: after,
+        affinityLogs: { create: { delta, before, after } },
+      },
+    });
+    return toNpcShape(updated);
+  }
+
+  async function updateTrust(npcId, delta) {
+    if (!usePrisma) return fallback.updateTrust(npcId, delta);
+    const rel = await getOrCreateRelation(npcId);
+    const before = rel.trust;
+    const after = clamp(before + delta, TRUST_MIN, TRUST_MAX);
+    const updated = await prisma.npcRelation.update({
+      where: { id: rel.id },
+      data: {
+        trust: after,
+        trustLogs: { create: { delta, before, after } },
+      },
+    });
+    return toNpcShape(updated);
+  }
+
+  async function canRecruit(npcId) {
+    if (!usePrisma) return fallback.canRecruit(npcId);
+    const rel = await getOrCreateRelation(npcId);
+    return rel.affinity >= RECRUIT_AFFINITY_MIN && rel.trust >= RECRUIT_TRUST_MIN && !rel.recruited;
+  }
+
+  async function recruit(npcId) {
+    if (!usePrisma) return fallback.recruit(npcId);
+    const rel = await getOrCreateRelation(npcId);
+    if (rel.affinity < RECRUIT_AFFINITY_MIN || rel.trust < RECRUIT_TRUST_MIN || rel.recruited) {
+      return { success: false, reason: 'gate_not_met' };
+    }
+    const updated = await prisma.npcRelation.update({
+      where: { id: rel.id },
+      data: { recruited: true },
+    });
+    return { success: true, npc: toNpcShape(updated) };
+  }
+
+  async function getNestRecord() {
+    if (!usePrisma) return null;
+    const existing = await prisma.nestState.findUnique({ where: { campaignId } });
+    if (existing) return existing;
+    return prisma.nestState.create({
+      data: { campaignId, level: 0, biome: null, requirementsMet: false },
+    });
+  }
+
+  async function canMate(npcId) {
+    if (!usePrisma) return fallback.canMate(npcId);
+    const rel = await getOrCreateRelation(npcId);
+    const nest = await getNestRecord();
+    return (
+      rel.recruited &&
+      rel.trust >= MATING_TRUST_MIN &&
+      !rel.mated &&
+      rel.matingCooldown <= 0 &&
+      Boolean(nest?.requirementsMet)
+    );
+  }
+
+  async function rollMating(npcId, partyMember, compatTable = {}, rng = Math.random) {
+    if (!usePrisma) return fallback.rollMating(npcId, partyMember, compatTable, rng);
+
+    const rel = await getOrCreateRelation(npcId);
+    const nest = await getNestRecord();
+    const gateOk =
+      rel.recruited &&
+      rel.trust >= MATING_TRUST_MIN &&
+      !rel.mated &&
+      rel.matingCooldown <= 0 &&
+      Boolean(nest?.requirementsMet);
+    if (!gateOk) return { success: false, reason: 'gate_not_met' };
+
+    const { roll, modifier, total, threshold, success, offspringTraits } = computeMatingRoll({
+      npcMbti: rel.mbtiType,
+      npcTraits: rel.traitIds,
+      npcTrust: rel.trust,
+      partyMember,
+      compatTable,
+      rng,
+    });
+
+    if (success) {
+      await prisma.npcRelation.update({
+        where: { id: rel.id },
+        data: {
+          mated: true,
+          matingEvents: {
+            create: {
+              success: true,
+              roll,
+              modifier,
+              total,
+              threshold,
+              offspringTraits: JSON.stringify(offspringTraits),
+              seedGenerated: 1,
+            },
+          },
+        },
+      });
+      return {
+        success: true,
+        roll,
+        modifier,
+        total,
+        threshold,
+        offspring_traits: offspringTraits,
+        seed_generated: 1,
+      };
+    }
+
+    await prisma.npcRelation.update({
+      where: { id: rel.id },
+      data: {
+        matingCooldown: 1,
+        matingEvents: {
+          create: {
+            success: false,
+            roll,
+            modifier,
+            total,
+            threshold,
+            reason: 'roll_failed',
+          },
+        },
+      },
+    });
+    return { success: false, roll, modifier, total, threshold, reason: 'roll_failed' };
+  }
+
+  async function setNest(biome, requirementsMet = true) {
+    if (!usePrisma) return fallback.setNest(biome, requirementsMet);
+    const existing = await getNestRecord();
+    const updated = await prisma.nestState.update({
+      where: { id: existing.id },
+      data: { biome: biome || 'default', level: 1, requirementsMet },
+    });
+    return {
+      level: updated.level,
+      biome: updated.biome,
+      requirements_met: updated.requirementsMet,
+    };
+  }
+
+  async function tickCooldowns() {
+    if (!usePrisma) return fallback.tickCooldowns();
+    await prisma.npcRelation.updateMany({
+      where: { campaignId, matingCooldown: { gt: 0 } },
+      data: { matingCooldown: { decrement: 1 } },
+    });
+  }
+
+  async function listNpcs() {
+    if (!usePrisma) return fallback.listNpcs();
+    const rows = await prisma.npcRelation.findMany({ where: { campaignId } });
+    return rows.map(toNpcShape);
+  }
+
+  async function getNest() {
+    if (!usePrisma) return fallback.getNest();
+    const nest = await getNestRecord();
+    return {
+      level: nest?.level ?? 0,
+      biome: nest?.biome ?? null,
+      requirements_met: Boolean(nest?.requirementsMet),
+    };
+  }
+
+  return {
+    updateAffinity,
+    updateTrust,
+    canRecruit,
+    recruit,
+    canMate,
+    rollMating,
+    setNest,
+    tickCooldowns,
+    listNpcs,
+    getNest,
+    // meta
+    _mode: usePrisma ? 'prisma' : 'in-memory',
+  };
+}
+
 module.exports = {
   createMetaTracker,
+  createMetaStore,
+  prismaSupportsMeta,
   RECRUIT_AFFINITY_MIN,
   RECRUIT_TRUST_MIN,
   MATING_TRUST_MIN,
@@ -191,4 +465,5 @@ module.exports = {
   AFFINITY_MAX,
   TRUST_MIN,
   TRUST_MAX,
+  MATING_THRESHOLD,
 };

--- a/apps/backend/services/pluginLoader.js
+++ b/apps/backend/services/pluginLoader.js
@@ -56,8 +56,13 @@ const metaPlugin = {
   name: 'meta',
   register(app) {
     const { createMetaRouter } = require('../routes/meta');
-    app.use('/api/v1/meta', createMetaRouter());
-    app.use('/api/meta', createMetaRouter());
+    const { createMetaStore } = require('../services/metaProgression');
+    const { prisma } = require('../db/prisma');
+    // Share one store between /api/v1/meta and /api/meta. Pre-adapter, each
+    // mount built its own Map → aliases saw divergent state (latent bug).
+    const store = createMetaStore({ prisma, campaignId: null });
+    app.use('/api/v1/meta', createMetaRouter({ store }));
+    app.use('/api/meta', createMetaRouter({ store }));
   },
 };
 

--- a/docs/adr/ADR-2026-04-21-meta-progression-prisma.md
+++ b/docs/adr/ADR-2026-04-21-meta-progression-prisma.md
@@ -1,0 +1,189 @@
+---
+title: 'ADR 2026-04-21 — Meta progression Prisma persistence (Prompt B / L06 partial)'
+doc_status: active
+doc_owner: master-dd
+workstream: backend
+last_verified: '2026-04-21'
+source_of_truth: true
+language: it
+review_cycle_days: 30
+related:
+  - docs/adr/ADR-2026-04-21-campaign-save-persistence.md
+  - docs/planning/2026-04-20-integrated-design-map.md
+  - docs/planning/2026-04-21-next-session-kickoff.md
+  - apps/backend/prisma/schema.prisma
+  - apps/backend/services/metaProgression.js
+  - apps/backend/routes/meta.js
+---
+
+# ADR-2026-04-21 · Meta progression Prisma persistence
+
+**Stato**: 🟢 ACCEPTED (2026-04-21, Prompt B closure)
+**Trigger**: L06 parziale dal kickoff doc — metaProgression in-memory `Map` non sopravvive al restart del processo. Blocca progressione cross-session + M10 campaign.
+
+## Decisione sintetica
+
+1. **Schema**: 5 nuovi model Prisma (`NpcRelation`, `AffinityLog`, `TrustLog`, `NestState`, `MatingEvent`) in `apps/backend/prisma/schema.prisma`.
+2. **Provider**: **KEEP `postgresql`** (override ADR-2026-04-21 `campaign-save-persistence` SQLite default).
+3. **Adapter pattern**: `createMetaStore({ prisma, campaignId })` async; fallback in-memory quando Prisma client stub (no `DATABASE_URL`).
+4. **API shape**: invariata — 7 endpoint `/api/(v1/)meta/*` già in produzione, zero breaking change.
+
+## Contesto
+
+`apps/backend/services/metaProgression.js` (194 LOC, 11 funzioni) gestiva affinity/trust/nest/mating via `Map` in-memory. Due problemi:
+
+- **Persistence zero**: restart backend → NPC relations azzerate. Blocca campaign cross-session (P2 Pilastro audit 2026-04-20 🟡).
+- **Alias divergent state (latent bug)**: `pluginLoader.js` registrava `createMetaRouter()` due volte (`/api/v1/meta` + `/api/meta`) → due `Map` separate, stessi NPC con stato diverso per client a seconda dell'alias chiamato. Adapter fix questo by design (store condiviso via DI).
+
+Kickoff doc prereq (37/37 baseline test + `metaProgression.js` 194 LOC + 7 route) verificati prima di iniziare. PR #1678 (trait env costs) già merged su main; branch `feat/meta-prisma-persistence` partito da `origin/main` post-merge.
+
+## Q1 — Provider: swap SQLite o keep postgresql?
+
+### Scelta: KEEP postgresql
+
+**Motivo override ADR-04-21**:
+
+- Migration `0001_init` già shipped postgresql (`apps/backend/prisma/migrations/0001_init/migration.sql` usa `SERIAL`, `TEXT[]`, `ARRAY[]::TEXT[]` → non portabili SQLite senza refactor).
+- `migration_lock.toml` locked a `postgresql`.
+- `docker compose up` bootstrappa Postgres auto.
+- M10 Campaign/Chapter/PartyRoster/SaveSnapshot (ADR-04-21) già **postgresql** in `schema.prisma` (line 8 `provider = "postgresql"`, 4 model M10 shipped). Swap breakerebbe M10.
+- Adapter in-memory fallback copre dev/demo (ngrok) senza Postgres.
+
+**Cost swap SQLite** (rejected):
+
+- Rewrite migration 0001 (rimuovere `SERIAL` + `TEXT[]`) ~2h.
+- Rewrite 4 model M10 (SQLite non supporta array nativi, JSON-only string) ~1h.
+- Rewrite docker-compose + CI harness ~1h.
+- Regression risk test campaign/ideas esistenti.
+- **Totale ~4-5h solo per downgrade infra funzionante**.
+
+**Deferred**: swap a SQLite quando/se M11 Jackbox multi-client richiede file locale per partita non condivisa. A quel punto serve multi-provider Prisma o reinstradamento via adapter pattern (già presente). ADR aggiornata in quel momento.
+
+## Q2 — Schema: 5 nuovi model
+
+### NpcRelation
+
+```prisma
+model NpcRelation {
+  id              String   @id @default(uuid())
+  campaignId      String?  // null = legacy global (retro-compat)
+  npcId           String
+  affinity        Int      @default(0)  // -2..+2 app-level
+  trust           Int      @default(0)  // 0..5 app-level
+  recruited       Boolean  @default(false)
+  mated           Boolean  @default(false)
+  matingCooldown  Int      @default(0)
+  mbtiType        String?
+  traitIds        String   @default("[]")  // JSON array
+  @@unique([campaignId, npcId])
+}
+```
+
+- **Unique composite**: `(campaignId, npcId)` → stesso npcId in campaign diverse = record separati.
+- **`campaignId` nullable**: legacy in-memory behavior senza campaign (test + MVP) continua a funzionare con `campaignId = null`.
+- **Range enforcement app-level** (`clamp`): Prisma `Int` è signed 32-bit; enforcement `-2..+2` / `0..5` resta in `metaProgression.js` come prima.
+
+### AffinityLog / TrustLog
+
+Audit trail delta: `{ relationId, delta, before, after, reason?, createdAt }`. Cascade-delete su `NpcRelation`. Serve a debug + analytics future (heat map di choice branching).
+
+### NestState
+
+```prisma
+model NestState {
+  id                String   @id @default(uuid())
+  campaignId        String?  @unique
+  level             Int      @default(0)
+  biome             String?
+  requirementsMet   Boolean  @default(false)
+}
+```
+
+- **`campaignId @unique`**: un nest per campaign (null = nest globale legacy). Attuale codice aveva `nest` come singleton nel tracker → mapping 1:1.
+
+### MatingEvent
+
+Storia rolls: `{ relationId, success, roll, modifier, total, threshold, offspringTraits, seedGenerated, reason?, createdAt }`. Append-only; serve a debug + a feedback loop del design (check empirico RNG fairness).
+
+## Q3 — Adapter pattern
+
+### Scelta: dual export `createMetaTracker` (sync) + `createMetaStore` (async)
+
+- **`createMetaTracker()`** sync in-memory — invariato. Backward-compat per i 37 baseline test in `tests/ai/metaProgression.test.js` (Node test runner, no async).
+- **`createMetaStore({ prisma, campaignId })`** async — API identica a tracker ma `Promise`. Rileva stub Prisma via `prismaSupportsMeta(prisma)` (check `prisma.npcRelation.findUnique` presente) → se stub, delega al tracker in-memory. Quando Prisma client reale disponibile (`DATABASE_URL` set + `prisma generate` eseguito), scrive su DB.
+- **Logic mating roll condivisa** via `computeMatingRoll()` pure function → entrambi i paths producono output identici a parità di `rng`.
+
+### Injection
+
+`createMetaRouter({ store })` accetta store pre-built. `pluginLoader.metaPlugin` ora costruisce **1** store e lo inietta in **entrambi** i mount (`/api/v1/meta` + `/api/meta`) → fix latent bug divergent Map.
+
+### Mode flag
+
+`store._mode` = `'prisma' | 'in-memory'` (introspezione per test + logging).
+
+## Contract API (invariato)
+
+| Method | Path                        | Body                          | Response                                           |
+| ------ | --------------------------- | ----------------------------- | -------------------------------------------------- |
+| GET    | `/api/(v1/)meta/npg`        | —                             | `{ npcs: [...], nest: {...} }`                     |
+| POST   | `/api/(v1/)meta/affinity`   | `{ npc_id, delta }`           | `{ npc, can_recruit }`                             |
+| POST   | `/api/(v1/)meta/trust`      | `{ npc_id, delta }`           | `{ npc, can_recruit, can_mate }`                   |
+| POST   | `/api/(v1/)meta/recruit`    | `{ npc_id }`                  | `{ success, npc? }` o `{ success: false, reason }` |
+| POST   | `/api/(v1/)meta/mating`     | `{ npc_id, party_member }`    | roll result + `offspring_traits` su success        |
+| GET    | `/api/(v1/)meta/nest`       | —                             | `{ level, biome, requirements_met }`               |
+| POST   | `/api/(v1/)meta/nest/setup` | `{ biome, requirements_met }` | nest shape                                         |
+
+## Test coverage
+
+- **Baseline 37/37 verdi** post-refactor: `tests/ai/metaProgression.test.js` (createMetaTracker sync path invariato).
+- **Nuovi 7 contract test** in `tests/api/metaRoutes.test.js`:
+  - `GET /npg` shape
+  - `POST /affinity` update + 400 missing body
+  - `POST /recruit` gate denied → success post trust bump
+  - `POST /nest/setup` + `GET /nest` roundtrip
+  - `POST /mating` 400 missing party_member
+  - Adapter `_mode === 'in-memory'` quando Prisma stub
+- Full AI suite: 307/307 verdi, zero regression.
+
+## Migration workflow
+
+1. `apps/backend/prisma/migrations/0002_meta_progression/migration.sql` — CREATE TABLE + INDEX + FK per 5 tabelle.
+2. Deploy: `npm run db:migrate` o `prisma migrate deploy` (Docker auto via bootstrap marker).
+3. **Dev demo**: senza `DATABASE_URL`, adapter usa tracker in-memory → nessun setup DB richiesto per prototipo.
+
+## Out of scope
+
+Non implementato in questo PR (task successivi dedicati):
+
+- **PI pack spender runtime** → ADR dedicata M10.
+- **UI Nido panel** → M11-adjacent, richiede mission console build (non in questo repo).
+- **Cross-session Prisma seed automatic** → manual seed OK MVP (`prisma db seed`).
+- **Migration backfill di state in-memory esistente** → nessuno stato da migrare (nessun deploy con NPC recruited in-memory prima di L06 closure).
+
+## Conseguenze
+
+### Positive
+
+- L06 parziale chiuso → P2 Pilastro audit unlocked parzialmente (persistence cross-session sbloccata).
+- Audit trail (AffinityLog/TrustLog/MatingEvent) abilita analytics future senza rework.
+- Latent bug divergent alias Map fix.
+- `createMetaStore` riutilizzabile in campaign engine (M10) per scope per-campaign.
+
+### Negative
+
+- **Schema drift doc/ADR-04-21**: decisione SQLite lì non onorata qui. Rationale documentata (§Q1). ADR-04-21 stessa conferma "Prisma ORM supporta SQLite adapter trivial swap (future Postgres upgrade)" — mantenere postgres è quindi coerente con il trajectory declared, non regressione.
+- **Test coverage Prisma-path non eseguito in CI** (no Postgres in test env). Coverage Prisma-path è code-path review + local smoke test + future integration suite quando docker compose CI verde.
+
+## Rollback plan
+
+1. Revert PR (branch `feat/meta-prisma-persistence`).
+2. `prisma migrate resolve --rolled-back 0002_meta_progression` in Postgres prod (solo se migrate già deployed).
+3. `DROP TABLE` per 5 tabelle nuove (schema additive, no alter di tabelle esistenti → rollback sicuro).
+4. Baseline 37/37 test garantisce tracker sync resta funzionante post-revert (createMetaTracker esportato + chiamato invariato).
+
+## Follow-up ticket
+
+- **TKT-META-01**: wire `campaignId` da session engine (`/api/session/start`) a `createMetaStore({ campaignId })`. Oggi tutti gli endpoint usano `campaignId = null` (legacy global). M10 campaign engine dovrà passare il vero `campaignId` attivo.
+- **TKT-META-02**: Prisma integration test in CI. Richiede docker-compose CI + `prisma migrate deploy` step.
+- **TKT-META-03**: API scope `GET /api/meta/npg?campaign_id=X` per query per-campaign (oggi elenca solo scope attivo store).
+- **TKT-META-04**: seed NPC data-driven da `packs/evo_tactics_pack/data/mating.yaml` o `data/core/npcs.yaml` (non esistente ancora — TBD).

--- a/tests/api/metaRoutes.test.js
+++ b/tests/api/metaRoutes.test.js
@@ -1,0 +1,119 @@
+// Contract tests /api/meta/* post Prisma adapter swap.
+// ADR-2026-04-21-meta-progression-prisma.
+//
+// Verify API shape unchanged after adapter refactor. Uses in-memory fallback
+// (no DATABASE_URL) so tests hit the same legacy code path validated by the
+// baseline metaProgression.test.js 37/37.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+test('GET /api/meta/npg returns npcs + nest shape', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app).get('/api/meta/npg').expect(200);
+    assert.ok(Array.isArray(res.body.npcs));
+    assert.ok(res.body.nest);
+    assert.equal(typeof res.body.nest.level, 'number');
+    assert.equal(res.body.nest.level, 0);
+    assert.equal(res.body.nest.requirements_met, false);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/meta/affinity updates + returns can_recruit flag', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app)
+      .post('/api/meta/affinity')
+      .send({ npc_id: 'npc_test_01', delta: 1 })
+      .expect(200);
+    assert.equal(res.body.npc.npc_id, 'npc_test_01');
+    assert.equal(res.body.npc.affinity, 1);
+    assert.equal(typeof res.body.can_recruit, 'boolean');
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/meta/affinity 400 on missing body', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app).post('/api/meta/affinity').send({}).expect(400);
+    await request(app).post('/api/meta/affinity').send({ npc_id: 'npc_x' }).expect(400);
+  } finally {
+    await close();
+  }
+});
+
+test('recruit gate — denied until affinity>=0 AND trust>=2', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    // Initial attempt → gate_not_met (trust 0)
+    let res = await request(app)
+      .post('/api/meta/recruit')
+      .send({ npc_id: 'npc_gate_01' })
+      .expect(200);
+    assert.equal(res.body.success, false);
+    assert.equal(res.body.reason, 'gate_not_met');
+
+    // Bump trust to 2
+    await request(app)
+      .post('/api/meta/trust')
+      .send({ npc_id: 'npc_gate_01', delta: 2 })
+      .expect(200);
+
+    // Retry → success
+    res = await request(app).post('/api/meta/recruit').send({ npc_id: 'npc_gate_01' }).expect(200);
+    assert.equal(res.body.success, true);
+    assert.equal(res.body.npc.recruited, true);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/meta/nest/setup + GET /api/meta/nest roundtrip', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const setup = await request(app)
+      .post('/api/meta/nest/setup')
+      .send({ biome: 'savana', requirements_met: true })
+      .expect(200);
+    assert.equal(setup.body.level, 1);
+    assert.equal(setup.body.biome, 'savana');
+    assert.equal(setup.body.requirements_met, true);
+
+    const nest = await request(app).get('/api/meta/nest').expect(200);
+    assert.equal(nest.body.level, 1);
+    assert.equal(nest.body.biome, 'savana');
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/meta/mating 400 on missing party_member', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app).post('/api/meta/mating').send({ npc_id: 'npc_x' }).expect(400);
+  } finally {
+    await close();
+  }
+});
+
+test('adapter mode falls back to in-memory when no DATABASE_URL', async () => {
+  const { createMetaStore } = require('../../apps/backend/services/metaProgression');
+  const { prisma } = require('../../apps/backend/db/prisma');
+  const store = createMetaStore({ prisma, campaignId: null });
+  // Without a real DATABASE_URL, db/prisma.js returns the stub (no npcRelation)
+  // → store falls back to in-memory tracker.
+  assert.equal(store._mode, 'in-memory');
+
+  // Smoke: async API works through fallback
+  const npc = await store.updateAffinity('npc_fallback_01', 1);
+  assert.equal(npc.affinity, 1);
+});


### PR DESCRIPTION
## Summary

Prompt B closure — L06 parziale. `metaProgression.js` in-memory `Map` → Prisma-backed adapter con fallback in-memory per dev/demo.

- 5 nuovi model Prisma (`NpcRelation`, `AffinityLog`, `TrustLog`, `NestState`, `MatingEvent`) + migration `0002_meta_progression`
- Adapter `createMetaStore({ prisma, campaignId })` async; delega a `createMetaTracker` sync quando Prisma stub
- Routes 7 endpoint shape invariata, plugin store condiviso (fix latent bug alias divergent Map)
- Provider KEPT `postgresql` (ADR override motivato)

## Pre-flight

- Baseline `tests/ai/metaProgression.test.js` **37/37 verdi** (invariato)
- Contract `tests/api/metaRoutes.test.js` **7/7 verdi** (nuovo)
- Full AI suite **307/307 verdi**, zero regression
- `npm run format:check` clean (pre-existing warning `docs/evo-tactics-pack/trait-glossary.json` non-mio)

## Decisioni chiave

**Q1 — Provider**: KEEP `postgresql`. Override ADR-04-21 SQLite rationale:
- Migration 0001 + M10 Campaign models già postgres → swap = 4-5h churn
- Adapter in-memory fallback copre dev/demo (no DATABASE_URL → `_mode: 'in-memory'`)
- docker compose postgres + migration_lock.toml postgresql

**Q2 — Schema**: 5 model additive, zero alter esistenti → rollback sicuro via DROP TABLE.

**Q3 — Adapter dual export**: `createMetaTracker` sync (backward-compat test) + `createMetaStore` async. Logic mating condivisa via `computeMatingRoll` pure function.

## Contract API

| Method | Path | Response |
| ------ | ---- | -------- |
| GET    | `/api/(v1/)meta/npg` | `{ npcs, nest }` |
| POST   | `/api/(v1/)meta/affinity` | `{ npc, can_recruit }` |
| POST   | `/api/(v1/)meta/trust` | `{ npc, can_recruit, can_mate }` |
| POST   | `/api/(v1/)meta/recruit` | `{ success, npc? }` |
| POST   | `/api/(v1/)meta/mating` | roll + `offspring_traits` su success |
| GET    | `/api/(v1/)meta/nest` | `{ level, biome, requirements_met }` |
| POST   | `/api/(v1/)meta/nest/setup` | nest shape |

Zero breaking change per consumatori esistenti.

## Rollback plan (03A)

1. Revert PR → branch eliminato
2. Se migration deployed: `prisma migrate resolve --rolled-back 0002_meta_progression`
3. `DROP TABLE` per 5 tabelle nuove (schema additive)
4. Baseline test 37/37 garantisce tracker sync funzionante post-revert

## Follow-up ticket

- TKT-META-01: wire `campaignId` da session engine
- TKT-META-02: Prisma integration test in CI (docker-compose)
- TKT-META-03: `GET /api/meta/npg?campaign_id=X` scope
- TKT-META-04: seed NPC data-driven da `mating.yaml`

## Test plan

- [x] `node --test tests/ai/metaProgression.test.js` → 37/37
- [x] `node --test tests/api/metaRoutes.test.js` → 7/7
- [x] `node --test tests/ai/*.test.js` → 307/307
- [x] `npm run format:check` → clean (escluso trait-glossary.json pre-existing)
- [x] `python tools/check_docs_governance.py --registry docs/governance/docs_registry.json --strict` → errors=0
- [ ] (deferred) Prisma integration test — richiede docker-compose CI postgres (TKT-META-02)

## ADR

[`docs/adr/ADR-2026-04-21-meta-progression-prisma.md`](docs/adr/ADR-2026-04-21-meta-progression-prisma.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)