### PR TITLE
feat(network): M11 Phase A — Jackbox room-code WebSocket backend (P5)

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -21,6 +21,8 @@ const { createSessionRouter } = require('./routes/session');
 const { createFeedbackRouter } = require('./routes/feedback');
 const { createPartyRouter } = require('./routes/party');
 const { createCampaignRouter } = require('./routes/campaign');
+const { createLobbyRouter } = require('./routes/lobby');
+const { LobbyService } = require('./services/network/wsSession');
 const { createNebulaTelemetryAggregator } = require('./services/nebulaTelemetryAggregator');
 const { createReleaseReporter } = require('./services/releaseReporter');
 const { createCatalogService } = require('./services/catalog');
@@ -686,6 +688,10 @@ function createApp(options = {}) {
   app.use('/api', createFeedbackRouter(options.feedback || {}));
   // M10 Phase B: campaign persistence + branching (ADR-2026-04-21)
   app.use('/api', createCampaignRouter(options.campaign || {}));
+  // M11 Phase A: Jackbox-style co-op lobby (ADR-2026-04-20).
+  // REST only; WebSocket server bootstraps in index.js on port 3341.
+  const lobby = (options.lobby && options.lobby.service) || new LobbyService(options.lobby || {});
+  app.use('/api', createLobbyRouter({ lobby }));
 
   app.get('/api/deployments/status', async (req, res) => {
     try {
@@ -899,7 +905,7 @@ function createApp(options = {}) {
     }
   }
 
-  return { app, repo, generationOrchestrator, close };
+  return { app, repo, generationOrchestrator, lobby, close };
 }
 
 module.exports = { createApp };

--- a/apps/backend/index.js
+++ b/apps/backend/index.js
@@ -2,6 +2,7 @@
 const http = require('node:http');
 const path = require('node:path');
 const { createApp } = require('./app');
+const { createWsServer } = require('./services/network/wsSession');
 
 // Default port changed from 3333 to 3334 in 2026-04 to avoid collision with
 // the sibling Game-Database service which owns port 3333 for its REST API.
@@ -25,7 +26,7 @@ const gameDatabaseEnabled = process.env.GAME_DATABASE_ENABLED === 'true';
 const gameDatabaseTimeoutMs = Number.parseInt(process.env.GAME_DATABASE_TIMEOUT_MS || '', 10);
 const gameDatabaseTtlMs = Number.parseInt(process.env.GAME_DATABASE_TTL_MS || '', 10);
 
-const { app } = createApp({
+const { app, lobby } = createApp({
   dataRoot,
   gameDatabase: {
     enabled: gameDatabaseEnabled,
@@ -34,6 +35,21 @@ const { app } = createApp({
     ttlMs: Number.isFinite(gameDatabaseTtlMs) ? gameDatabaseTtlMs : undefined,
   },
 });
+
+// M11 Phase A — Jackbox WebSocket server on dedicated port (ADR-2026-04-20).
+// Separate port 3341 (default) to avoid collisions with:
+//   HTTP :3334 (this backend), Vite :5180, calibration :3340.
+// Override via LOBBY_WS_PORT env; disable via LOBBY_WS_ENABLED=false.
+const wsEnabled = process.env.LOBBY_WS_ENABLED !== 'false';
+const wsPort = Number.parseInt(process.env.LOBBY_WS_PORT || '3341', 10);
+const wsHost = process.env.LOBBY_WS_HOST || host;
+let lobbyWs = null;
+if (wsEnabled && lobby) {
+  lobbyWs = createWsServer({ lobby, port: wsPort });
+  console.log(`[lobby-ws] WebSocket server online on ws://${wsHost}:${wsPort}/ws`);
+} else {
+  console.log('[lobby-ws] WebSocket server disabled (LOBBY_WS_ENABLED=false)');
+}
 
 // Issue #1342: avverti se ORCHESTRATOR_AUTOCLOSE_MS e' settato in modo
 // che potrebbe rompere il backend live (valori bassi pensati per i test).
@@ -72,10 +88,17 @@ server.listen(port, host, () => {
   }
 });
 
-process.on('SIGTERM', () => {
+async function shutdown(signal) {
+  console.log(`[idea-engine] ${signal} received — shutting down`);
+  if (lobbyWs) {
+    try {
+      await lobbyWs.close();
+    } catch {
+      // noop
+    }
+  }
   server.close(() => process.exit(0));
-});
+}
 
-process.on('SIGINT', () => {
-  server.close(() => process.exit(0));
-});
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));

--- a/apps/backend/routes/lobby.js
+++ b/apps/backend/routes/lobby.js
@@ -1,0 +1,99 @@
+// M11 Phase A — Lobby REST routes.
+// ADR-2026-04-20.
+//
+// Endpoints:
+//   POST /api/lobby/create  — create room, return code + host token
+//   POST /api/lobby/join    — join by code + name, return player token
+//   POST /api/lobby/close   — close room (host only)
+//   GET  /api/lobby/state   — inspect room snapshot (?code=ABCD)
+//   GET  /api/lobby/list    — list open rooms (admin/debug)
+//
+// Auth: host operations require host_token returned from /create.
+// Player operations return a player_token used on WS connect.
+//
+// WebSocket URL shape (Phase A separate server):
+//   ws://host:3341/ws?code=ABCD&player_id=p_xxx&token=YYY
+
+'use strict';
+
+const express = require('express');
+
+function createLobbyRouter({ lobby } = {}) {
+  if (!lobby) throw new Error('createLobbyRouter: lobby service required');
+  const router = express.Router();
+
+  router.post('/lobby/create', (req, res) => {
+    const {
+      host_name: hostName,
+      campaign_id: campaignId = null,
+      max_players: maxPlayers,
+    } = req.body || {};
+    if (!hostName || typeof hostName !== 'string') {
+      return res.status(400).json({ error: 'host_name richiesto (string)' });
+    }
+    try {
+      const result = lobby.createRoom({
+        hostName,
+        campaignId: campaignId || null,
+        maxPlayers: Number.isFinite(Number(maxPlayers)) ? Number(maxPlayers) : undefined,
+      });
+      return res.status(201).json(result);
+    } catch (err) {
+      return res.status(500).json({ error: err.message || 'errore creazione room' });
+    }
+  });
+
+  router.post('/lobby/join', (req, res) => {
+    const { code, player_name: playerName } = req.body || {};
+    if (!code || typeof code !== 'string') {
+      return res.status(400).json({ error: 'code richiesto (string)' });
+    }
+    if (!playerName || typeof playerName !== 'string') {
+      return res.status(400).json({ error: 'player_name richiesto (string)' });
+    }
+    try {
+      const result = lobby.joinRoom({ code, playerName });
+      return res.status(201).json(result);
+    } catch (err) {
+      const code = err.message;
+      if (code === 'room_not_found') return res.status(404).json({ error: code });
+      if (code === 'room_closed' || code === 'room_full') {
+        return res.status(409).json({ error: code });
+      }
+      return res.status(400).json({ error: code });
+    }
+  });
+
+  router.post('/lobby/close', (req, res) => {
+    const { code, host_token: hostToken } = req.body || {};
+    if (!code || !hostToken) {
+      return res.status(400).json({ error: 'code + host_token richiesti' });
+    }
+    try {
+      const result = lobby.closeRoom({ code, hostToken });
+      return res.json(result);
+    } catch (err) {
+      const msg = err.message;
+      if (msg === 'room_not_found') return res.status(404).json({ error: msg });
+      if (msg === 'host_auth_failed') return res.status(403).json({ error: msg });
+      return res.status(400).json({ error: msg });
+    }
+  });
+
+  router.get('/lobby/state', (req, res) => {
+    const code = String(req.query.code || '');
+    if (!code) return res.status(400).json({ error: 'code query param richiesto' });
+    const room = lobby.getRoom(code);
+    if (!room) return res.status(404).json({ error: 'room_not_found' });
+    return res.json({ room: room.snapshot() });
+  });
+
+  router.get('/lobby/list', (req, res) => {
+    const rooms = lobby.listRooms();
+    return res.json({ rooms, count: rooms.length });
+  });
+
+  return router;
+}
+
+module.exports = { createLobbyRouter };

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -1,0 +1,494 @@
+// M11 Phase A — Jackbox-style WebSocket session server.
+// ADR-2026-04-20.
+//
+// Responsibilities:
+//   - In-memory room store (roomCode → Room)
+//   - 4-letter room code generator (20 consonant alphabet, avoid vowels/obscenity)
+//   - Host-authoritative state: only host can mutate; players send intents
+//   - WebSocket server factory: accepts `ws` connections w/ ?code=&token= auth
+//   - Broadcast helpers: room.broadcast, room.sendToPlayer
+//   - Reconnection: token survives disconnect; player re-joins w/ same token
+//
+// Port: 3341 (ADR-2026-04-20). Isolated from HTTP 3334 to avoid
+// collisions with Vite :5180, calibration :3340, demo :3334.
+//
+// Protocol (JSON on wire):
+//   { type: 'hello'        , payload: { role, player_id, name } }          // S→C on connect ack
+//   { type: 'player_joined', payload: { player_id, name, role } }           // S→C broadcast
+//   { type: 'player_left'  , payload: { player_id, reason } }               // S→C broadcast
+//   { type: 'state'        , payload: <arbitrary>, version: N }             // S→C host-authored
+//   { type: 'intent'       , payload: <arbitrary> }                          // C→S player→host
+//   { type: 'chat'         , payload: { from, text } }                      // bidirectional
+//   { type: 'ping'         , payload: { t } } / { type: 'pong', payload: { t } }
+//   { type: 'error'        , payload: { code, message } }                   // S→C
+//
+// NOT in Phase A: persistence, reconnect-backoff client logic, lobby UI.
+// Phase B will layer frontend and deeper campaign integration.
+
+'use strict';
+
+const { WebSocketServer } = require('ws');
+const crypto = require('node:crypto');
+
+const ROOM_CODE_ALPHABET = 'BCDFGHJKLMNPQRSTVWXZ'; // 20 consonants, no vowels, no Y (avoid words)
+const ROOM_CODE_LENGTH = 4;
+const MAX_ROOM_CREATE_RETRIES = 20;
+const DEFAULT_MAX_PLAYERS = 8;
+const DEFAULT_HEARTBEAT_MS = 30_000;
+
+function generateRoomCode() {
+  let out = '';
+  for (let i = 0; i < ROOM_CODE_LENGTH; i += 1) {
+    const idx = crypto.randomInt(0, ROOM_CODE_ALPHABET.length);
+    out += ROOM_CODE_ALPHABET[idx];
+  }
+  return out;
+}
+
+function generateToken() {
+  return crypto.randomBytes(16).toString('hex');
+}
+
+function generatePlayerId() {
+  return `p_${crypto.randomBytes(6).toString('hex')}`;
+}
+
+/**
+ * Room — in-memory Jackbox-style lobby.
+ * Host-authoritative: only host.player_id can publish `state`.
+ * Other roles can emit `intent` + `chat`.
+ */
+class Room {
+  constructor({ code, hostId, hostName, maxPlayers = DEFAULT_MAX_PLAYERS, campaignId = null }) {
+    this.code = code;
+    this.hostId = hostId;
+    this.maxPlayers = maxPlayers;
+    this.campaignId = campaignId;
+    this.createdAt = Date.now();
+    this.closed = false;
+    // player_id → { id, name, role, token, socket?, connected, joinedAt }
+    this.players = new Map();
+    // Host state published, last-write-wins; version monotonic.
+    this.state = null;
+    this.stateVersion = 0;
+    // Intent queue (Phase A: FIFO, host drains on demand)
+    this.intents = [];
+
+    const hostToken = generateToken();
+    this.players.set(hostId, {
+      id: hostId,
+      name: hostName,
+      role: 'host',
+      token: hostToken,
+      socket: null,
+      connected: false,
+      joinedAt: this.createdAt,
+    });
+  }
+
+  addPlayer({ name, role = 'player' }) {
+    if (this.closed) {
+      throw new Error('room_closed');
+    }
+    if (this.players.size >= this.maxPlayers) {
+      throw new Error('room_full');
+    }
+    const playerId = generatePlayerId();
+    const token = generateToken();
+    this.players.set(playerId, {
+      id: playerId,
+      name,
+      role,
+      token,
+      socket: null,
+      connected: false,
+      joinedAt: Date.now(),
+    });
+    return { playerId, token };
+  }
+
+  getPlayer(playerId) {
+    return this.players.get(playerId) || null;
+  }
+
+  authenticate(playerId, token) {
+    const p = this.players.get(playerId);
+    if (!p) return null;
+    if (p.token !== token) return null;
+    return p;
+  }
+
+  attachSocket(playerId, socket) {
+    const p = this.players.get(playerId);
+    if (!p) return false;
+    // Close previous socket silently if reconnecting.
+    if (p.socket && p.socket !== socket && p.socket.readyState === 1) {
+      try {
+        p.socket.close(4000, 'superseded');
+      } catch {
+        // noop
+      }
+    }
+    p.socket = socket;
+    p.connected = true;
+    return true;
+  }
+
+  detachSocket(playerId) {
+    const p = this.players.get(playerId);
+    if (!p) return false;
+    p.socket = null;
+    p.connected = false;
+    return true;
+  }
+
+  publicPlayerList() {
+    return Array.from(this.players.values()).map((p) => ({
+      id: p.id,
+      name: p.name,
+      role: p.role,
+      connected: p.connected,
+      joined_at: p.joinedAt,
+    }));
+  }
+
+  broadcast(message, { except = null } = {}) {
+    const payload = JSON.stringify(message);
+    for (const p of this.players.values()) {
+      if (p.id === except) continue;
+      if (p.socket && p.socket.readyState === 1) {
+        try {
+          p.socket.send(payload);
+        } catch {
+          // swallow — will be cleaned on close event
+        }
+      }
+    }
+  }
+
+  sendTo(playerId, message) {
+    const p = this.players.get(playerId);
+    if (!p || !p.socket || p.socket.readyState !== 1) return false;
+    try {
+      p.socket.send(JSON.stringify(message));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  publishState(newState) {
+    this.stateVersion += 1;
+    this.state = newState;
+    this.broadcast({
+      type: 'state',
+      version: this.stateVersion,
+      payload: newState,
+    });
+    return this.stateVersion;
+  }
+
+  pushIntent({ from, payload }) {
+    const entry = {
+      id: `i_${crypto.randomBytes(4).toString('hex')}`,
+      from,
+      payload,
+      ts: Date.now(),
+    };
+    this.intents.push(entry);
+    // Relay intent directly to host (if connected).
+    this.sendTo(this.hostId, { type: 'intent', payload: entry });
+    return entry;
+  }
+
+  close(reason = 'host_closed') {
+    this.closed = true;
+    for (const p of this.players.values()) {
+      if (p.socket && p.socket.readyState === 1) {
+        try {
+          p.socket.send(JSON.stringify({ type: 'room_closed', payload: { reason } }));
+          p.socket.close(4001, reason);
+        } catch {
+          // noop
+        }
+      }
+    }
+  }
+
+  snapshot() {
+    return {
+      code: this.code,
+      host_id: this.hostId,
+      campaign_id: this.campaignId,
+      created_at: this.createdAt,
+      closed: this.closed,
+      max_players: this.maxPlayers,
+      state_version: this.stateVersion,
+      players: this.publicPlayerList(),
+    };
+  }
+}
+
+/**
+ * LobbyService — in-memory registry of Rooms.
+ * Single process only (Phase A). Redis-adapter swap in Phase B+ if needed.
+ */
+class LobbyService {
+  constructor({ maxPlayers = DEFAULT_MAX_PLAYERS } = {}) {
+    this.rooms = new Map(); // code → Room
+    this.maxPlayers = maxPlayers;
+  }
+
+  createRoom({ hostName, campaignId = null, maxPlayers } = {}) {
+    if (!hostName || typeof hostName !== 'string') {
+      throw new Error('host_name_required');
+    }
+    let code = null;
+    for (let attempt = 0; attempt < MAX_ROOM_CREATE_RETRIES; attempt += 1) {
+      const candidate = generateRoomCode();
+      if (!this.rooms.has(candidate)) {
+        code = candidate;
+        break;
+      }
+    }
+    if (!code) {
+      throw new Error('room_code_exhaustion');
+    }
+    const hostId = generatePlayerId();
+    const room = new Room({
+      code,
+      hostId,
+      hostName,
+      maxPlayers: maxPlayers || this.maxPlayers,
+      campaignId,
+    });
+    this.rooms.set(code, room);
+    const host = room.getPlayer(hostId);
+    return {
+      code,
+      host_id: hostId,
+      host_token: host.token,
+      campaign_id: campaignId,
+      max_players: room.maxPlayers,
+    };
+  }
+
+  joinRoom({ code, playerName }) {
+    if (!code) throw new Error('room_code_required');
+    const normalized = String(code).toUpperCase();
+    const room = this.rooms.get(normalized);
+    if (!room) throw new Error('room_not_found');
+    if (room.closed) throw new Error('room_closed');
+    if (!playerName || typeof playerName !== 'string') {
+      throw new Error('player_name_required');
+    }
+    const { playerId, token } = room.addPlayer({ name: playerName });
+    // Broadcast presence to any already-connected sockets.
+    room.broadcast({
+      type: 'player_joined',
+      payload: { player_id: playerId, name: playerName, role: 'player' },
+    });
+    return { player_id: playerId, player_token: token, room: room.snapshot() };
+  }
+
+  closeRoom({ code, hostToken }) {
+    const normalized = String(code || '').toUpperCase();
+    const room = this.rooms.get(normalized);
+    if (!room) throw new Error('room_not_found');
+    const host = room.getPlayer(room.hostId);
+    if (!host || host.token !== hostToken) {
+      throw new Error('host_auth_failed');
+    }
+    room.close();
+    this.rooms.delete(normalized);
+    return { code: normalized, closed: true };
+  }
+
+  getRoom(code) {
+    if (!code) return null;
+    return this.rooms.get(String(code).toUpperCase()) || null;
+  }
+
+  listRooms() {
+    return Array.from(this.rooms.values()).map((r) => r.snapshot());
+  }
+
+  roomCount() {
+    return this.rooms.size;
+  }
+}
+
+/**
+ * Attach a WebSocketServer to an existing http.Server, gated on path.
+ * Alternatively, pass `port` to spawn a standalone server (useful for tests).
+ *
+ * Connection URL: ws://host:port/ws?code=ABCD&player_id=p_xxx&token=YYY
+ * Auth: player_id + token must match an existing room record.
+ */
+function createWsServer({ lobby, server = null, port = null, path = '/ws' } = {}) {
+  if (!lobby) throw new Error('lobby_required');
+  if (!server && (port === null || port === undefined)) {
+    throw new Error('server_or_port_required');
+  }
+
+  const wssOptions = server ? { server, path } : { port, path };
+  const wss = new WebSocketServer(wssOptions);
+
+  const heartbeat = setInterval(() => {
+    for (const client of wss.clients) {
+      if (client.__alive === false) {
+        try {
+          client.terminate();
+        } catch {
+          // noop
+        }
+        continue;
+      }
+      client.__alive = false;
+      try {
+        client.ping();
+      } catch {
+        // noop
+      }
+    }
+  }, DEFAULT_HEARTBEAT_MS);
+  heartbeat.unref?.();
+
+  wss.on('connection', (socket, req) => {
+    socket.__alive = true;
+    socket.on('pong', () => {
+      socket.__alive = true;
+    });
+
+    const url = new URL(req.url, 'http://localhost');
+    const code = (url.searchParams.get('code') || '').toUpperCase();
+    const playerId = url.searchParams.get('player_id') || '';
+    const token = url.searchParams.get('token') || '';
+
+    const room = lobby.getRoom(code);
+    if (!room) {
+      socket.send(JSON.stringify({ type: 'error', payload: { code: 'room_not_found' } }));
+      socket.close(4004, 'room_not_found');
+      return;
+    }
+    const player = room.authenticate(playerId, token);
+    if (!player) {
+      socket.send(JSON.stringify({ type: 'error', payload: { code: 'auth_failed' } }));
+      socket.close(4003, 'auth_failed');
+      return;
+    }
+
+    room.attachSocket(playerId, socket);
+    // Hello ack + snapshot.
+    socket.send(
+      JSON.stringify({
+        type: 'hello',
+        payload: {
+          role: player.role,
+          player_id: playerId,
+          name: player.name,
+          room: room.snapshot(),
+          state: room.state,
+          state_version: room.stateVersion,
+        },
+      }),
+    );
+    // Announce (re)connection.
+    room.broadcast(
+      {
+        type: 'player_connected',
+        payload: { player_id: playerId, name: player.name, role: player.role },
+      },
+      { except: playerId },
+    );
+
+    socket.on('message', (raw) => {
+      let msg;
+      try {
+        msg = JSON.parse(raw.toString());
+      } catch {
+        socket.send(JSON.stringify({ type: 'error', payload: { code: 'bad_json' } }));
+        return;
+      }
+      if (!msg || typeof msg.type !== 'string') {
+        socket.send(JSON.stringify({ type: 'error', payload: { code: 'bad_message' } }));
+        return;
+      }
+
+      switch (msg.type) {
+        case 'ping':
+          socket.send(JSON.stringify({ type: 'pong', payload: msg.payload || {} }));
+          break;
+
+        case 'state':
+          // Host-authoritative gate.
+          if (player.role !== 'host') {
+            socket.send(JSON.stringify({ type: 'error', payload: { code: 'not_host' } }));
+            return;
+          }
+          room.publishState(msg.payload ?? null);
+          break;
+
+        case 'intent':
+          if (player.role === 'host') {
+            socket.send(JSON.stringify({ type: 'error', payload: { code: 'host_cannot_intent' } }));
+            return;
+          }
+          room.pushIntent({ from: playerId, payload: msg.payload ?? null });
+          break;
+
+        case 'chat': {
+          const text = typeof msg.payload?.text === 'string' ? msg.payload.text.slice(0, 500) : '';
+          if (!text) return;
+          room.broadcast({
+            type: 'chat',
+            payload: { from: playerId, name: player.name, text, ts: Date.now() },
+          });
+          break;
+        }
+
+        default:
+          socket.send(
+            JSON.stringify({ type: 'error', payload: { code: 'unknown_type', type: msg.type } }),
+          );
+      }
+    });
+
+    socket.on('close', () => {
+      room.detachSocket(playerId);
+      room.broadcast({
+        type: 'player_disconnected',
+        payload: { player_id: playerId },
+      });
+    });
+
+    socket.on('error', () => {
+      // swallow; close handler cleans up
+    });
+  });
+
+  return {
+    wss,
+    close: () =>
+      new Promise((resolve) => {
+        clearInterval(heartbeat);
+        for (const client of wss.clients) {
+          try {
+            client.terminate();
+          } catch {
+            // noop
+          }
+        }
+        wss.close(() => resolve());
+      }),
+  };
+}
+
+module.exports = {
+  LobbyService,
+  Room,
+  createWsServer,
+  generateRoomCode,
+  ROOM_CODE_ALPHABET,
+  ROOM_CODE_LENGTH,
+};

--- a/docs/adr/ADR-2026-04-20-m11-jackbox-phase-a.md
+++ b/docs/adr/ADR-2026-04-20-m11-jackbox-phase-a.md
@@ -1,0 +1,150 @@
+---
+title: 'ADR-2026-04-20: M11 Phase A — Jackbox room-code WebSocket backend'
+doc_status: active
+doc_owner: platform-docs
+workstream: cross-cutting
+last_verified: 2026-04-20
+source_of_truth: false
+language: it-en
+review_cycle_days: 30
+related:
+  - docs/adr/ADR-2026-04-16-networking-colyseus.md
+  - docs/adr/ADR-2026-04-16-networking-co-op.md
+  - docs/adr/ADR-2026-04-17-coop-scaling-4to8.md
+  - docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md
+---
+
+# ADR-2026-04-20: M11 Phase A — Jackbox room-code WebSocket backend
+
+- **Data**: 2026-04-20
+- **Stato**: Accepted
+- **Owner**: Backend + Network
+- **Stakeholder**: Player-facing co-op (4-8 friend demo su ngrok), Campaign engine M10
+
+## Contesto
+
+Pilastro #5 (Co-op vs Sistema) era 🟡 nell'audit 2026-04-20: focus-fire locale shipped ma **zero rete**. Sprint M11 lockato: demo live co-op su TV condivisa + phone privati via room-code, stile Jackbox.
+
+Runtime esistente:
+
+- Combat engine round-based single-host autoritativo (ADR-2026-04-16).
+- Campaign engine M10 persiste su Prisma (ADR-2026-04-21).
+- Package `ws@8.18.3` già installato.
+- User vincolo: **1 gioco online senza master**, niente Python rules engine (vedi `services/rules/DEPRECATED.md`).
+
+Phase A scope = **solo backend**: room registry in-memory + WebSocket server. Phase B (next session) layer frontend lobby/TV view.
+
+## Decisione
+
+Implementare Jackbox-style lobby + WS server **senza nuove dipendenze**, sfruttando `ws` già presente. Colyseus (ADR-2026-04-16) resta **fallback tier-2** se Jackbox pattern insufficiente a 4-8 player.
+
+### Architettura
+
+```
+HTTP :3334                    WebSocket :3341
+┌─────────────────┐           ┌──────────────────────┐
+│ POST /api/lobby │           │ ws://host:3341/ws    │
+│   /create       │           │   ?code=ABCD         │
+│   /join         │           │   &player_id=...     │
+│   /close        │           │   &token=...         │
+│ GET  /state     │◄──────────┤                      │
+│      /list      │   lobby   │  host-auth state     │
+└─────────────────┘  (shared) │  relay intents       │
+          │                    │  broadcast presence  │
+          ▼                    └──────────────────────┘
+   LobbyService (in-memory Map<code, Room>)
+```
+
+- **Port 3341** per WS: isolato da HTTP `:3334`, Vite `:5180`, calibration `:3340` (prompt vincolo esplicito).
+- **Code generator**: 4 char da alfabeto 20 consonanti `BCDFGHJKLMNPQRSTVWXZ` (no vocali → evita parole reali/obscenity). Spazio = 160k; retry collisione 20×.
+- **Host-authoritative**: solo `player_id == room.hostId` può pubblicare `state`. Altri mandano `intent`, relayed al solo host.
+- **Auth**: token HEX 16-byte generato al create/join, passato come query string sul WS upgrade. In-memory match.
+- **Reconnection**: stesso token riusabile. `attachSocket` chiude socket precedente con code `4000 superseded`, player marcato `connected=false` su drop, `true` su re-attach.
+
+### Protocollo (JSON on wire)
+
+| Type                  | Direzione | Payload                                                 |
+| --------------------- | :-------: | ------------------------------------------------------- |
+| `hello`               |    S→C    | `{ role, player_id, name, room, state, state_version }` |
+| `player_joined`       |    S→C    | `{ player_id, name, role }` broadcast                   |
+| `player_connected`    |    S→C    | `{ player_id, name, role }` broadcast                   |
+| `player_disconnected` |    S→C    | `{ player_id }` broadcast                               |
+| `state`               |    C→S    | payload arbitrary (host only)                           |
+| `state`               |    S→C    | `{ version, payload }` broadcast                        |
+| `intent`              |    C→S    | payload arbitrary (non-host only)                       |
+| `intent`              |    S→C    | `{ id, from, payload, ts }` relay a host                |
+| `chat`                |   C↔S    | `{ from, name, text, ts }` broadcast                    |
+| `ping`/`pong`         |   C↔S    | `{ t }` keepalive                                       |
+| `error`               |    S→C    | `{ code, message? }`                                    |
+| `room_closed`         |    S→C    | `{ reason }` broadcast su close host                    |
+
+### Heartbeat
+
+`WebSocketServer` setInterval 30s: ping ogni client; se `pong` non ricevuto entro il ciclo successivo, `terminate()`. Interval `unref()` per non bloccare exit.
+
+## Opzioni valutate
+
+### A. Jackbox pattern (ws nativo) ← SCELTA
+
+- **Pro**: zero nuove deps, 3 OSS clone pubblici (hammre/party-box, axlan/jill_box, InvoxiPlayGames/johnbox), match diretto con "4 amici + TV + phone", effort ~10h Phase A.
+- **Contro**: state sync manuale (no diff automatico), reconnect-logic lato client da scrivere Phase B, no matchmaking.
+- **Scope-fit**: single-process demo. Scala fino a 8 player/room per ADR-2026-04-17 cap.
+
+### B. Colyseus (ADR-2026-04-16 proposed)
+
+- **Pro**: delta binary sync, matchmaking, reconnect nativo, SDK multi-platform.
+- **Contro**: nuova dep, abstraction layer in più per un pattern che Jackbox risolve con 250 LOC, overhead eccessivo per MVP demo.
+- **Decisione**: **fallback tier-2** se Jackbox pattern non scala a 8p in playtest live.
+
+### C. Socket.io
+
+- Pro: reconnect polyfill, room broadcast built-in.
+- Contro: overhead protocollo HTTP long-poll fallback non necessario, dep extra.
+- Rigettata: `ws` soddisfa requisiti con meno codice.
+
+## Conseguenze
+
+### Positive
+
+- **Demo live immediato**: 4 friend + ngrok + phones = test concreto Pilastro 5 già da Phase B.
+- **Stack minimo**: `ws@8.18.3` già in `node_modules`, no nuove deps.
+- **Separation of concerns**: lobby REST resta idempotente/testabile via supertest; WS server isolato su porta dedicata.
+- **Integrazione campaign**: `campaign_id` opzionale nel room payload → link a campaign engine M10 in Phase B senza refactor.
+
+### Negative
+
+- **State sync manuale**: Phase B dovrà implementare diff custom se state grande (round snapshot). Fallback Colyseus se necessario.
+- **Single process**: lobby in-memory. Restart backend = tutti i room persi. Prisma persistence deferred a Phase C se necessario.
+- **Port extra**: operatori devono aprire `:3341`. Documentato in README deploy (follow-up M11B).
+
+### Rollback
+
+Disable via `LOBBY_WS_ENABLED=false`. REST routes restano operative (degrade grace to no live sync). Revert PR se regressioni CI.
+
+## Scope Phase A (questo PR)
+
+- `apps/backend/services/network/wsSession.js` (~330 LOC): `LobbyService` + `Room` + `createWsServer`.
+- `apps/backend/routes/lobby.js` (~90 LOC): 5 REST endpoint.
+- Wire in `apps/backend/app.js` + bootstrap WS in `apps/backend/index.js` su `LOBBY_WS_PORT=3341` (override env).
+- Tests:
+  - `tests/api/lobbyRoutes.test.js` — 9 test REST (create/join/close/state/list/cap/case-insensitive/auth).
+  - `tests/api/lobbyWebSocket.test.js` — 6 test WS (4-player sync + host-auth gate + intent relay + reconnect + auth failures).
+
+**Totale nuovi test Phase A**: **15/15** pass. Baseline AI 307/307 + session/playtest 309/309 intatti.
+
+## Fuori scope Phase A (Phase B next session)
+
+- Frontend lobby picker (`apps/play/src/lobby.html`).
+- TV dual-view (shared spectator + phone-private).
+- Client reconnect logic (`apps/play/src/network.js`).
+- Campaign-state live mirroring via WS state channel.
+- Prisma persistence adapter (opzionale, Phase C).
+- Rate-limit / DoS hardening (Phase D se produzione).
+
+## Riferimenti
+
+- Jackbox architecture writeup — https://www.abtach.ae/blog/how-to-build-a-game-like-jackbox/
+- Daikon Games 7-day spike — https://www.patreon.com/posts/free-radish-how-34077166
+- OSS clone: hammre/party-box, axlan/jill_box, InvoxiPlayGames/johnbox
+- Colyseus (tier-2 fallback): https://github.com/colyseus/colyseus
+- `packages/ws` — 8.18.3 già installato

--- a/tests/api/lobbyRoutes.test.js
+++ b/tests/api/lobbyRoutes.test.js
@@ -1,0 +1,157 @@
+// M11 Phase A — Lobby REST endpoint tests.
+// ADR-2026-04-20.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+function newApp() {
+  return createApp({ databasePath: null });
+}
+
+test('POST /api/lobby/create returns 4-letter code + host token', async () => {
+  const { app, close } = newApp();
+  try {
+    const res = await request(app)
+      .post('/api/lobby/create')
+      .send({ host_name: 'Alice' })
+      .expect(201);
+    assert.equal(typeof res.body.code, 'string');
+    assert.match(res.body.code, /^[BCDFGHJKLMNPQRSTVWXZ]{4}$/);
+    assert.equal(typeof res.body.host_id, 'string');
+    assert.equal(typeof res.body.host_token, 'string');
+    assert.equal(res.body.max_players, 8);
+    assert.equal(res.body.campaign_id, null);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/lobby/create 400 on missing host_name', async () => {
+  const { app, close } = newApp();
+  try {
+    await request(app).post('/api/lobby/create').send({}).expect(400);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/lobby/join returns player_token + room snapshot', async () => {
+  const { app, close } = newApp();
+  try {
+    const create = await request(app)
+      .post('/api/lobby/create')
+      .send({ host_name: 'Alice', campaign_id: 'campaign_abc' })
+      .expect(201);
+    const code = create.body.code;
+    const join = await request(app)
+      .post('/api/lobby/join')
+      .send({ code, player_name: 'Bob' })
+      .expect(201);
+    assert.equal(typeof join.body.player_id, 'string');
+    assert.equal(typeof join.body.player_token, 'string');
+    assert.equal(join.body.room.code, code);
+    assert.equal(join.body.room.campaign_id, 'campaign_abc');
+    assert.equal(join.body.room.players.length, 2); // host + Bob
+    const roles = join.body.room.players.map((p) => p.role).sort();
+    assert.deepEqual(roles, ['host', 'player']);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/lobby/join 404 on unknown code', async () => {
+  const { app, close } = newApp();
+  try {
+    await request(app)
+      .post('/api/lobby/join')
+      .send({ code: 'ZZZZ', player_name: 'Ghost' })
+      .expect(404);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/lobby/join case-insensitive code match', async () => {
+  const { app, close } = newApp();
+  try {
+    const create = await request(app)
+      .post('/api/lobby/create')
+      .send({ host_name: 'A' })
+      .expect(201);
+    const lower = create.body.code.toLowerCase();
+    await request(app).post('/api/lobby/join').send({ code: lower, player_name: 'P' }).expect(201);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/lobby/close requires host_token, else 403', async () => {
+  const { app, close } = newApp();
+  try {
+    const create = await request(app)
+      .post('/api/lobby/create')
+      .send({ host_name: 'Alice' })
+      .expect(201);
+    const code = create.body.code;
+    await request(app).post('/api/lobby/close').send({ code, host_token: 'WRONG' }).expect(403);
+    await request(app)
+      .post('/api/lobby/close')
+      .send({ code, host_token: create.body.host_token })
+      .expect(200);
+    // After close, room is gone → 404 on state lookup.
+    await request(app).get(`/api/lobby/state?code=${code}`).expect(404);
+  } finally {
+    await close();
+  }
+});
+
+test('GET /api/lobby/state returns snapshot', async () => {
+  const { app, close } = newApp();
+  try {
+    const create = await request(app)
+      .post('/api/lobby/create')
+      .send({ host_name: 'Alice' })
+      .expect(201);
+    const code = create.body.code;
+    const state = await request(app).get(`/api/lobby/state?code=${code}`).expect(200);
+    assert.equal(state.body.room.code, code);
+    assert.equal(state.body.room.players.length, 1);
+    assert.equal(state.body.room.players[0].role, 'host');
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/lobby/create respects max_players cap', async () => {
+  const { app, close } = newApp();
+  try {
+    const create = await request(app)
+      .post('/api/lobby/create')
+      .send({ host_name: 'Alice', max_players: 3 })
+      .expect(201);
+    const code = create.body.code;
+    // Fill: host + 2 more = 3 total, then reject the 4th.
+    await request(app).post('/api/lobby/join').send({ code, player_name: 'B' }).expect(201);
+    await request(app).post('/api/lobby/join').send({ code, player_name: 'C' }).expect(201);
+    await request(app).post('/api/lobby/join').send({ code, player_name: 'D' }).expect(409);
+  } finally {
+    await close();
+  }
+});
+
+test('GET /api/lobby/list lists open rooms', async () => {
+  const { app, close } = newApp();
+  try {
+    await request(app).post('/api/lobby/create').send({ host_name: 'A' }).expect(201);
+    await request(app).post('/api/lobby/create').send({ host_name: 'B' }).expect(201);
+    const list = await request(app).get('/api/lobby/list').expect(200);
+    assert.equal(list.body.count, 2);
+    assert.ok(Array.isArray(list.body.rooms));
+  } finally {
+    await close();
+  }
+});

--- a/tests/api/lobbyWebSocket.test.js
+++ b/tests/api/lobbyWebSocket.test.js
@@ -1,0 +1,320 @@
+// M11 Phase A — Jackbox WebSocket integration tests.
+// ADR-2026-04-20.
+//
+// Coverage:
+//   - Host + 3 players connect concurrently
+//   - Player roster broadcast
+//   - Host publishes state, all players receive with version
+//   - Non-host state attempt rejected
+//   - Player intent relayed to host only
+//   - Reconnect survives one drop (token reusable)
+//   - Auth failure (bad token) rejected
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const WebSocket = require('ws');
+const { LobbyService, createWsServer } = require('../../apps/backend/services/network/wsSession');
+
+// Buffer all received messages so tests can await past messages without
+// racing the listener attachment. Call `ws.__buf` for the list; `waitForMessage`
+// scans the buffer first then listens for new arrivals.
+function attachBuffer(ws) {
+  ws.__buf = [];
+  ws.__waiters = [];
+  ws.on('message', (raw) => {
+    let msg;
+    try {
+      msg = JSON.parse(raw.toString());
+    } catch {
+      return;
+    }
+    ws.__buf.push(msg);
+    for (const w of ws.__waiters.slice()) {
+      if (w.predicate(msg)) {
+        ws.__waiters = ws.__waiters.filter((x) => x !== w);
+        w.resolve(msg);
+      }
+    }
+  });
+  return ws;
+}
+
+function waitForMessage(ws, predicate, timeoutMs = 3000) {
+  // Check existing buffer.
+  for (const msg of ws.__buf) {
+    if (predicate(msg)) return Promise.resolve(msg);
+  }
+  return new Promise((resolve, reject) => {
+    const waiter = { predicate, resolve, reject };
+    const timer = setTimeout(() => {
+      ws.__waiters = ws.__waiters.filter((x) => x !== waiter);
+      reject(new Error('timeout waiting for ws message'));
+    }, timeoutMs);
+    waiter.resolve = (msg) => {
+      clearTimeout(timer);
+      resolve(msg);
+    };
+    ws.__waiters.push(waiter);
+  });
+}
+
+function openWs(port, { code, player_id, token }) {
+  const url = `ws://127.0.0.1:${port}/ws?code=${encodeURIComponent(code)}&player_id=${encodeURIComponent(player_id)}&token=${encodeURIComponent(token)}`;
+  return attachBuffer(new WebSocket(url));
+}
+
+async function waitOpen(ws) {
+  return new Promise((resolve, reject) => {
+    ws.once('open', () => resolve());
+    ws.once('error', reject);
+  });
+}
+
+async function spinUp() {
+  const lobby = new LobbyService();
+  const wsHandle = createWsServer({ lobby, port: 0 });
+  // Wait for wss to bind so address().port is populated.
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  const port = wsHandle.wss.address().port;
+  return { lobby, port, wsHandle };
+}
+
+test('WS: host + 3 players connect, host publishes state, all receive', async () => {
+  const { lobby, port, wsHandle } = await spinUp();
+  try {
+    const room = lobby.createRoom({ hostName: 'Alice', campaignId: 'c1' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Bob' });
+    const p2 = lobby.joinRoom({ code: room.code, playerName: 'Carol' });
+    const p3 = lobby.joinRoom({ code: room.code, playerName: 'Dan' });
+
+    const hostWs = openWs(port, {
+      code: room.code,
+      player_id: room.host_id,
+      token: room.host_token,
+    });
+    await waitOpen(hostWs);
+    const hostHello = await waitForMessage(hostWs, (m) => m.type === 'hello');
+    assert.equal(hostHello.payload.role, 'host');
+    assert.equal(hostHello.payload.room.code, room.code);
+
+    const p1Ws = openWs(port, {
+      code: room.code,
+      player_id: p1.player_id,
+      token: p1.player_token,
+    });
+    const p2Ws = openWs(port, {
+      code: room.code,
+      player_id: p2.player_id,
+      token: p2.player_token,
+    });
+    const p3Ws = openWs(port, {
+      code: room.code,
+      player_id: p3.player_id,
+      token: p3.player_token,
+    });
+
+    await Promise.all([waitOpen(p1Ws), waitOpen(p2Ws), waitOpen(p3Ws)]);
+    await Promise.all([
+      waitForMessage(p1Ws, (m) => m.type === 'hello'),
+      waitForMessage(p2Ws, (m) => m.type === 'hello'),
+      waitForMessage(p3Ws, (m) => m.type === 'hello'),
+    ]);
+
+    // Host publishes state; all 3 players should receive it.
+    const receivedStates = Promise.all([
+      waitForMessage(p1Ws, (m) => m.type === 'state'),
+      waitForMessage(p2Ws, (m) => m.type === 'state'),
+      waitForMessage(p3Ws, (m) => m.type === 'state'),
+    ]);
+
+    hostWs.send(JSON.stringify({ type: 'state', payload: { scene: 'briefing', turn: 1 } }));
+
+    const states = await receivedStates;
+    for (const s of states) {
+      assert.equal(s.version, 1);
+      assert.deepEqual(s.payload, { scene: 'briefing', turn: 1 });
+    }
+
+    hostWs.close();
+    p1Ws.close();
+    p2Ws.close();
+    p3Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('WS: non-host state attempt rejected with error', async () => {
+  const { lobby, port, wsHandle } = await spinUp();
+  try {
+    const room = lobby.createRoom({ hostName: 'Alice' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Bob' });
+    const p1Ws = openWs(port, {
+      code: room.code,
+      player_id: p1.player_id,
+      token: p1.player_token,
+    });
+    await waitOpen(p1Ws);
+    await waitForMessage(p1Ws, (m) => m.type === 'hello');
+    p1Ws.send(JSON.stringify({ type: 'state', payload: { hacked: true } }));
+    const err = await waitForMessage(p1Ws, (m) => m.type === 'error');
+    assert.equal(err.payload.code, 'not_host');
+    p1Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('WS: player intent relayed to host only (not to peers)', async () => {
+  const { lobby, port, wsHandle } = await spinUp();
+  try {
+    const room = lobby.createRoom({ hostName: 'Alice' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Bob' });
+    const p2 = lobby.joinRoom({ code: room.code, playerName: 'Carol' });
+
+    const hostWs = openWs(port, {
+      code: room.code,
+      player_id: room.host_id,
+      token: room.host_token,
+    });
+    const p1Ws = openWs(port, {
+      code: room.code,
+      player_id: p1.player_id,
+      token: p1.player_token,
+    });
+    const p2Ws = openWs(port, {
+      code: room.code,
+      player_id: p2.player_id,
+      token: p2.player_token,
+    });
+    await Promise.all([waitOpen(hostWs), waitOpen(p1Ws), waitOpen(p2Ws)]);
+    await Promise.all([
+      waitForMessage(hostWs, (m) => m.type === 'hello'),
+      waitForMessage(p1Ws, (m) => m.type === 'hello'),
+      waitForMessage(p2Ws, (m) => m.type === 'hello'),
+    ]);
+
+    const hostRelay = waitForMessage(hostWs, (m) => m.type === 'intent');
+    // p2 should NOT see an intent from p1 — give a short window, then assert silence.
+    let p2GotIntent = false;
+    p2Ws.on('message', (raw) => {
+      try {
+        const m = JSON.parse(raw.toString());
+        if (m.type === 'intent') p2GotIntent = true;
+      } catch {
+        // noop
+      }
+    });
+
+    p1Ws.send(JSON.stringify({ type: 'intent', payload: { action: 'attack', target: 'e1' } }));
+    const intent = await hostRelay;
+    assert.equal(intent.payload.from, p1.player_id);
+    assert.deepEqual(intent.payload.payload, { action: 'attack', target: 'e1' });
+    await new Promise((r) => setTimeout(r, 100));
+    assert.equal(p2GotIntent, false);
+
+    hostWs.close();
+    p1Ws.close();
+    p2Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('WS: reconnect survives one drop — token reusable', async () => {
+  const { lobby, port, wsHandle } = await spinUp();
+  try {
+    const room = lobby.createRoom({ hostName: 'Alice' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Bob' });
+    const hostWs = openWs(port, {
+      code: room.code,
+      player_id: room.host_id,
+      token: room.host_token,
+    });
+    const p1Ws = openWs(port, {
+      code: room.code,
+      player_id: p1.player_id,
+      token: p1.player_token,
+    });
+    await Promise.all([waitOpen(hostWs), waitOpen(p1Ws)]);
+    await Promise.all([
+      waitForMessage(hostWs, (m) => m.type === 'hello'),
+      waitForMessage(p1Ws, (m) => m.type === 'hello'),
+    ]);
+
+    // Drop p1.
+    const hostSawDisconnect = waitForMessage(
+      hostWs,
+      (m) => m.type === 'player_disconnected' && m.payload.player_id === p1.player_id,
+    );
+    p1Ws.close();
+    await hostSawDisconnect;
+
+    // Reconnect with same token.
+    const p1Ws2 = openWs(port, {
+      code: room.code,
+      player_id: p1.player_id,
+      token: p1.player_token,
+    });
+    await waitOpen(p1Ws2);
+    const hello2 = await waitForMessage(p1Ws2, (m) => m.type === 'hello');
+    assert.equal(hello2.payload.player_id, p1.player_id);
+
+    hostWs.close();
+    p1Ws2.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('WS: bad token rejected', async () => {
+  const { lobby, port, wsHandle } = await spinUp();
+  try {
+    const room = lobby.createRoom({ hostName: 'Alice' });
+    const badWs = openWs(port, {
+      code: room.code,
+      player_id: room.host_id,
+      token: 'WRONG',
+    });
+    await new Promise((resolve) => {
+      let closed = false;
+      badWs.on('close', () => {
+        closed = true;
+        resolve();
+      });
+      badWs.on('error', () => {
+        if (!closed) resolve();
+      });
+    });
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('WS: unknown room code rejected', async () => {
+  const { port, wsHandle } = await spinUp();
+  try {
+    const badWs = openWs(port, {
+      code: 'ZZZZ',
+      player_id: 'p_xxx',
+      token: 'XXXX',
+    });
+    await new Promise((resolve) => {
+      let closed = false;
+      badWs.on('close', () => {
+        closed = true;
+        resolve();
+      });
+      badWs.on('error', () => {
+        if (!closed) resolve();
+      });
+    });
+  } finally {
+    await wsHandle.close();
+  }
+});


### PR DESCRIPTION
## Summary

- **Pilastro #5 beachhead**: chiude gap network Phase A per strategy [ADR-2026-04-20](docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md). 4-letter room code + host-authoritative state sync, **zero nuove dipendenze** (`ws@8.18.3` pre-installato). Colyseus (ADR-2026-04-16) resta tier-2 fallback.
- **Lobby backend canonical**: 5 REST endpoint `/api/lobby/*` + WS server su porta dedicata `:3341` (isolato da HTTP 3334, Vite 5180, calibration 3340).
- **Campaign integration**: `campaign_id` opzionale nel room payload → link a campaign engine M10 senza refactor. Phase B wires frontend + state mirror.

## Dettagli tecnici

- `apps/backend/services/network/wsSession.js` (~355 LOC): `LobbyService` (Map-backed) + `Room` (host-auth, intent relay, reconnect via stable token) + `createWsServer` (attach a server o standalone port).
- `apps/backend/routes/lobby.js` (~95 LOC): POST `/create`, `/join`, `/close` + GET `/state`, `/list`.
- `apps/backend/app.js`: lobby service istanziato in `createApp()`, esposto nel return; router montato sotto `/api`.
- `apps/backend/index.js`: bootstrap WS server via `createWsServer({ lobby, port: 3341 })`. Disable env: `LOBBY_WS_ENABLED=false`. Shutdown pulito via `shutdown(signal)` su SIGTERM/SIGINT (chiude WS + HTTP).
- **4-letter code**: 20-consonant alphabet `BCDFGHJKLMNPQRSTVWXZ` (no vocali → no parole reali/obscenity). Spazio = 160k, retry collisione 20×.
- **Heartbeat**: 30s ping/pong, `terminate()` su pong mancato. Interval `unref()` per non bloccare exit.
- **Host-auth**: `state` consentito solo a `player_id == room.hostId`; `intent` consentito solo a non-host, relayed al solo host (non broadcast a peers).
- **Reconnect**: stesso token riusabile; `attachSocket` chiude precedente con close code `4000 superseded`.

## Test plan

- [x] 9/9 REST tests `tests/api/lobbyRoutes.test.js` (create/join/close/state/list, cap, case-insensitive, auth failures)
- [x] 6/6 WS integration tests `tests/api/lobbyWebSocket.test.js` (4-player sync, host-auth gate, intent relay scope, reconnect survives drop, auth failures)
- [x] Baseline `node --test tests/ai/*.test.js` → 307/307 verdi
- [x] Baseline `node --test tests/api/*.test.js` → 299/299 verdi
- [x] Prettier `npx prettier --check` → verde
- [x] Governance check `python tools/check_docs_governance.py --strict` → errors=0

## Rollback plan

- Runtime disable via env: `LOBBY_WS_ENABLED=false` (WS non parte, REST in-memory restano operative senza broadcast).
- Revert PR se regressioni CI baseline.
- Nessuna migrazione DB (in-memory; Prisma adapter deferred Phase C).
- Nessun cambio a guardrail (contracts, migrations, workflows, services/rules tutti intatti).

## Fuori scope (Phase B next session)

- Frontend lobby picker + TV dual-view + client reconnect logic in `apps/play/src/`
- Live campaign-state mirror via WS `state` channel
- Prisma persistence (Phase C opzionale)
- Rate-limit / DoS hardening (Phase D se produzione)

## Riferimenti

- Strategy: [docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md §Sprint M11](docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md)
- Design map: [docs/planning/2026-04-20-integrated-design-map.md §3 L07](docs/planning/2026-04-20-integrated-design-map.md)
- OSS refs: [hammre/party-box](https://github.com/hammre/party-box), [axlan/jill_box](https://github.com/axlan/jill_box), [InvoxiPlayGames/johnbox](https://github.com/InvoxiPlayGames/johnbox)
- Fallback: [ADR-2026-04-16 Colyseus](docs/adr/ADR-2026-04-16-networking-colyseus.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)