### PR TITLE
feat(network): M11 Phase B — Jackbox lobby frontend + TV spectator + WS client (P5)

### DIFF
--- a/apps/play/lobby.html
+++ b/apps/play/lobby.html
@@ -1,0 +1,355 @@
+<!doctype html>
+<html lang="it">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Evo-Tactics — Lobby</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Noto+Sans:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --bg: #0b0d12;
+        --panel: #151922;
+        --panel-2: #1d2230;
+        --border: #2a3040;
+        --text: #e8eaf0;
+        --muted: #8891a3;
+        --accent: #4fc3f7;
+        --accent-host: #ffb74d;
+        --danger: #ef5350;
+        --ok: #66bb6a;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--text);
+        font-family: 'Inter', 'Noto Sans', system-ui, sans-serif;
+      }
+      .lobby-wrap {
+        max-width: 920px;
+        margin: 0 auto;
+        padding: 32px 20px 48px;
+      }
+      header.lobby-head {
+        text-align: center;
+        margin-bottom: 28px;
+      }
+      header.lobby-head h1 {
+        font-size: 2rem;
+        margin: 0 0 6px;
+        letter-spacing: 0.5px;
+      }
+      header.lobby-head p {
+        color: var(--muted);
+        margin: 0;
+      }
+      .cards {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 20px;
+      }
+      @media (max-width: 720px) {
+        .cards {
+          grid-template-columns: 1fr;
+        }
+      }
+      .card {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 22px 22px 24px;
+      }
+      .card h2 {
+        margin: 0 0 14px;
+        font-size: 1.15rem;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .card h2 .role-chip {
+        font-size: 0.7rem;
+        padding: 2px 8px;
+        border-radius: 999px;
+        background: var(--panel-2);
+        color: var(--muted);
+        border: 1px solid var(--border);
+      }
+      .card.host h2 .role-chip {
+        color: var(--accent-host);
+        border-color: var(--accent-host);
+      }
+      .card.join h2 .role-chip {
+        color: var(--accent);
+        border-color: var(--accent);
+      }
+      .form-row {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        margin-bottom: 12px;
+      }
+      .form-row label {
+        font-size: 0.85rem;
+        color: var(--muted);
+      }
+      .form-row input,
+      .form-row select {
+        padding: 10px 12px;
+        font-size: 1rem;
+        background: var(--panel-2);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        color: var(--text);
+        font-family: inherit;
+      }
+      .form-row input:focus,
+      .form-row select:focus {
+        outline: none;
+        border-color: var(--accent);
+      }
+      .code-input {
+        letter-spacing: 8px;
+        text-transform: uppercase;
+        text-align: center;
+        font-weight: 700;
+        font-size: 1.4rem;
+      }
+      .btn {
+        width: 100%;
+        padding: 12px 16px;
+        font-size: 1rem;
+        font-weight: 600;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        background: var(--panel-2);
+        color: var(--text);
+        cursor: pointer;
+        transition:
+          background 0.15s,
+          border-color 0.15s;
+      }
+      .btn:hover:not(:disabled) {
+        background: var(--border);
+      }
+      .btn:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+      .btn-primary {
+        background: var(--accent);
+        color: #001014;
+        border-color: var(--accent);
+      }
+      .btn-primary:hover:not(:disabled) {
+        background: #66d1fb;
+      }
+      .btn-host {
+        background: var(--accent-host);
+        color: #201000;
+        border-color: var(--accent-host);
+      }
+      .btn-host:hover:not(:disabled) {
+        background: #ffc875;
+      }
+      .status {
+        margin-top: 12px;
+        min-height: 1.4em;
+        font-size: 0.9rem;
+      }
+      .status.err {
+        color: var(--danger);
+      }
+      .status.ok {
+        color: var(--ok);
+      }
+      .share-panel {
+        margin-top: 20px;
+        padding: 16px;
+        background: var(--panel-2);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        display: none;
+      }
+      .share-panel.visible {
+        display: block;
+      }
+      .share-code {
+        font-size: 2.8rem;
+        font-weight: 700;
+        letter-spacing: 12px;
+        text-align: center;
+        color: var(--accent-host);
+        font-family: 'Noto Sans', monospace;
+        margin: 6px 0 12px;
+      }
+      .share-url {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+      }
+      .share-url input {
+        flex: 1;
+        padding: 8px 10px;
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        color: var(--text);
+        font-family: 'Noto Sans', monospace;
+        font-size: 0.85rem;
+      }
+      .share-url button {
+        padding: 8px 12px;
+      }
+      .existing-session {
+        margin-bottom: 20px;
+        padding: 14px 18px;
+        background: #1a2538;
+        border: 1px solid #2c4057;
+        border-radius: 10px;
+        display: none;
+      }
+      .existing-session.visible {
+        display: block;
+      }
+      .existing-session .actions {
+        display: flex;
+        gap: 10px;
+        margin-top: 10px;
+      }
+      .existing-session .actions .btn {
+        flex: 1;
+      }
+      footer.lobby-foot {
+        text-align: center;
+        color: var(--muted);
+        font-size: 0.8rem;
+        margin-top: 32px;
+      }
+      footer.lobby-foot a {
+        color: var(--accent);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="lobby-wrap">
+      <header class="lobby-head">
+        <h1>🦴 Evo-Tactics Lobby</h1>
+        <p>Crea una stanza (host · TV) o unisciti con codice a 4 lettere (player · phone).</p>
+      </header>
+
+      <!-- Resume banner if localStorage has a stored session. -->
+      <div id="existing-session" class="existing-session">
+        <div>
+          Sessione attiva su stanza <strong id="existing-code">—</strong> (<span id="existing-role"
+            >—</span
+          >).
+        </div>
+        <div class="actions">
+          <button id="existing-resume" class="btn btn-primary">↩ Riprendi</button>
+          <button id="existing-forget" class="btn">✕ Dimentica</button>
+        </div>
+      </div>
+
+      <div class="cards">
+        <!-- HOST -->
+        <div class="card host">
+          <h2>📺 Crea stanza <span class="role-chip">host · TV</span></h2>
+          <form id="form-create" autocomplete="off">
+            <div class="form-row">
+              <label for="host-name">Nome host</label>
+              <input
+                id="host-name"
+                name="host_name"
+                type="text"
+                maxlength="40"
+                required
+                placeholder="Es. Marco (TV)"
+              />
+            </div>
+            <div class="form-row">
+              <label for="campaign-id">Campagna (opzionale)</label>
+              <input
+                id="campaign-id"
+                name="campaign_id"
+                type="text"
+                maxlength="80"
+                placeholder="Lascia vuoto per sessione libera"
+              />
+            </div>
+            <div class="form-row">
+              <label for="max-players">Max player</label>
+              <select id="max-players" name="max_players">
+                <option value="2">2</option>
+                <option value="4" selected>4</option>
+                <option value="6">6</option>
+                <option value="8">8</option>
+              </select>
+            </div>
+            <button type="submit" class="btn btn-host" id="btn-create">Crea stanza</button>
+            <div class="status" id="status-create"></div>
+          </form>
+          <div class="share-panel" id="share-panel">
+            <div style="color: var(--muted); font-size: 0.85rem; text-align: center">
+              Condividi questo codice
+            </div>
+            <div class="share-code" id="share-code">—</div>
+            <div class="share-url">
+              <input id="share-url-input" readonly />
+              <button class="btn" id="share-copy">📋</button>
+            </div>
+            <button id="share-enter" class="btn btn-primary" style="margin-top: 12px">
+              ▶ Entra nella TV
+            </button>
+          </div>
+        </div>
+
+        <!-- JOIN -->
+        <div class="card join">
+          <h2>📱 Unisciti <span class="role-chip">player · phone</span></h2>
+          <form id="form-join" autocomplete="off">
+            <div class="form-row">
+              <label for="join-code">Codice stanza (4 lettere)</label>
+              <input
+                id="join-code"
+                name="code"
+                type="text"
+                minlength="4"
+                maxlength="4"
+                required
+                placeholder="ABCD"
+                class="code-input"
+                pattern="[A-Za-z]{4}"
+              />
+            </div>
+            <div class="form-row">
+              <label for="player-name">Nome player</label>
+              <input
+                id="player-name"
+                name="player_name"
+                type="text"
+                maxlength="40"
+                required
+                placeholder="Es. Anna"
+              />
+            </div>
+            <button type="submit" class="btn btn-primary" id="btn-join">Entra</button>
+            <div class="status" id="status-join"></div>
+          </form>
+        </div>
+      </div>
+
+      <footer class="lobby-foot">M11 Phase B · Jackbox room-code lobby · ADR-2026-04-20</footer>
+    </div>
+    <script type="module" src="/src/lobby.js"></script>
+  </body>
+</html>

--- a/apps/play/src/lobby.js
+++ b/apps/play/src/lobby.js
@@ -1,0 +1,221 @@
+// M11 Phase B — Lobby picker bootstrap.
+// ADR-2026-04-20 (protocol) + kickoff Phase B.
+//
+// Responsibilities:
+//   - Render create/join forms (HTML in /lobby.html)
+//   - POST /api/lobby/create | /api/lobby/join
+//   - Persist session in localStorage via `saveLobbySession`
+//   - Redirect to /index.html (game shell) which detects role + connects WS
+//   - Offer "resume" if a stored session exists
+
+import {
+  saveLobbySession,
+  loadLobbySession,
+  clearLobbySession,
+  LOBBY_STORAGE_KEY,
+} from './network.js';
+
+async function postJson(path, body) {
+  try {
+    const res = await fetch(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json().catch(() => ({}));
+    return { ok: res.ok, status: res.status, data };
+  } catch (err) {
+    return { ok: false, status: 0, data: null, networkError: true, message: err?.message };
+  }
+}
+
+function setStatus(id, text, kind = '') {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.textContent = text || '';
+  el.className = `status${kind ? ' ' + kind : ''}`;
+}
+
+function setFormDisabled(form, disabled) {
+  if (!form) return;
+  for (const el of form.elements) el.disabled = disabled;
+}
+
+function redirectToGame() {
+  // Absolute path so it works under Vite dev (port 5180) + build preview.
+  window.location.href = './index.html';
+}
+
+function renderExistingSession() {
+  const existing = loadLobbySession();
+  const banner = document.getElementById('existing-session');
+  if (!existing || !banner) return;
+  document.getElementById('existing-code').textContent = existing.code;
+  document.getElementById('existing-role').textContent = existing.role;
+  banner.classList.add('visible');
+  document.getElementById('existing-resume').addEventListener('click', () => {
+    redirectToGame();
+  });
+  document.getElementById('existing-forget').addEventListener('click', () => {
+    clearLobbySession();
+    banner.classList.remove('visible');
+  });
+}
+
+function initCreateForm() {
+  const form = document.getElementById('form-create');
+  if (!form) return;
+  const sharePanel = document.getElementById('share-panel');
+  const shareCode = document.getElementById('share-code');
+  const shareUrl = document.getElementById('share-url-input');
+  const shareCopy = document.getElementById('share-copy');
+  const shareEnter = document.getElementById('share-enter');
+
+  form.addEventListener('submit', async (ev) => {
+    ev.preventDefault();
+    setStatus('status-create', '');
+    const hostName = document.getElementById('host-name').value.trim();
+    const campaignIdRaw = document.getElementById('campaign-id').value.trim();
+    const maxPlayers = Number(document.getElementById('max-players').value) || 4;
+    if (!hostName) {
+      setStatus('status-create', 'Nome host richiesto.', 'err');
+      return;
+    }
+    setFormDisabled(form, true);
+    setStatus('status-create', 'Creazione stanza in corso…');
+
+    const payload = { host_name: hostName, max_players: maxPlayers };
+    if (campaignIdRaw) payload.campaign_id = campaignIdRaw;
+
+    const res = await postJson('/api/lobby/create', payload);
+    setFormDisabled(form, false);
+    if (!res.ok || !res.data?.code) {
+      setStatus(
+        'status-create',
+        `Errore: ${res.data?.error || res.message || `HTTP ${res.status}`}`,
+        'err',
+      );
+      return;
+    }
+
+    const { code, host_id, host_token, campaign_id } = res.data;
+    const session = {
+      code,
+      player_id: host_id,
+      token: host_token,
+      role: 'host',
+      host_id,
+      campaign_id: campaign_id || null,
+    };
+    saveLobbySession(session);
+
+    if (sharePanel) {
+      shareCode.textContent = code;
+      // Share URL: current origin + /lobby.html — users on phone load + auto-fill code.
+      const url = `${window.location.origin}${window.location.pathname.replace(/[^/]*$/, '')}lobby.html?code=${code}`;
+      shareUrl.value = url;
+      sharePanel.classList.add('visible');
+    }
+    setStatus('status-create', `✓ Stanza ${code} creata. Premi Entra nella TV per avviare.`, 'ok');
+  });
+
+  if (shareCopy) {
+    shareCopy.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(shareUrl.value);
+        shareCopy.textContent = '✓';
+        setTimeout(() => (shareCopy.textContent = '📋'), 1500);
+      } catch {
+        shareUrl.select();
+      }
+    });
+  }
+  if (shareEnter) {
+    shareEnter.addEventListener('click', () => redirectToGame());
+  }
+}
+
+function initJoinForm() {
+  const form = document.getElementById('form-join');
+  if (!form) return;
+  const codeInput = document.getElementById('join-code');
+
+  // Auto-uppercase + restrict to consonants (alphabet from ADR-2026-04-20).
+  codeInput?.addEventListener('input', (ev) => {
+    const up = ev.target.value
+      .toUpperCase()
+      .replace(/[^A-Z]/g, '')
+      .slice(0, 4);
+    if (up !== ev.target.value) ev.target.value = up;
+  });
+
+  // Auto-populate code from ?code= URL param (invite link).
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const urlCode = params.get('code');
+    if (urlCode && codeInput) {
+      codeInput.value = urlCode
+        .toUpperCase()
+        .replace(/[^A-Z]/g, '')
+        .slice(0, 4);
+      document.getElementById('player-name')?.focus();
+    }
+  } catch {
+    // noop
+  }
+
+  form.addEventListener('submit', async (ev) => {
+    ev.preventDefault();
+    setStatus('status-join', '');
+    const code = codeInput.value.toUpperCase().trim();
+    const playerName = document.getElementById('player-name').value.trim();
+    if (code.length !== 4) {
+      setStatus('status-join', 'Codice deve essere 4 lettere.', 'err');
+      return;
+    }
+    if (!playerName) {
+      setStatus('status-join', 'Nome richiesto.', 'err');
+      return;
+    }
+    setFormDisabled(form, true);
+    setStatus('status-join', 'Connessione alla stanza…');
+    const res = await postJson('/api/lobby/join', { code, player_name: playerName });
+    setFormDisabled(form, false);
+    if (!res.ok || !res.data?.player_id) {
+      setStatus(
+        'status-join',
+        `Errore: ${res.data?.error || res.message || `HTTP ${res.status}`}`,
+        'err',
+      );
+      return;
+    }
+    const { player_id, player_token, room } = res.data;
+    const session = {
+      code,
+      player_id,
+      token: player_token,
+      role: 'player',
+      host_id: room?.host_id || null,
+      campaign_id: room?.campaign_id || null,
+    };
+    saveLobbySession(session);
+    setStatus('status-join', '✓ Connesso. Apertura gioco…', 'ok');
+    setTimeout(() => redirectToGame(), 300);
+  });
+}
+
+function init() {
+  renderExistingSession();
+  initCreateForm();
+  initJoinForm();
+  // Dev aid: log storage key for debugging session state.
+  if (typeof console !== 'undefined') {
+    console.info(`[lobby] localStorage key: ${LOBBY_STORAGE_KEY}`);
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/apps/play/src/lobbyBridge.js
+++ b/apps/play/src/lobbyBridge.js
@@ -1,0 +1,281 @@
+// M11 Phase B — Lobby bridge for game shell.
+// ADR-2026-04-20.
+//
+// Wires the LobbyClient into the main game loop with minimal intrusion:
+//   - Host role:   game plays locally; `publishWorld(world)` broadcasts state
+//                  to all connected players over WS (called from main.js refresh).
+//   - Player role: canvas + inputs are dimmed into "spectator" mode; the last
+//                  state received from host is rendered as read-only HUD. Player
+//                  can submit intents via chat-style input (stretch for M11B).
+//
+// Adds a header banner showing room code, role, connection status.
+// Exposes `initLobbyBridgeIfPresent()` which returns a bridge or null.
+
+import { LobbyClient, loadLobbySession, clearLobbySession, resolveWsUrl } from './network.js';
+
+function createBanner(session, onLeave) {
+  let banner = document.getElementById('lobby-banner');
+  if (banner) return banner;
+  banner = document.createElement('div');
+  banner.id = 'lobby-banner';
+  banner.className = `lobby-banner lobby-banner-${session.role}`;
+  banner.innerHTML = `
+    <span class="lobby-banner-role">${session.role === 'host' ? '📺 HOST' : '📱 PLAYER'}</span>
+    <span class="lobby-banner-code">${session.code}</span>
+    <span class="lobby-banner-status" data-status="connecting">
+      <span class="dot"></span><span class="label">connessione…</span>
+    </span>
+    <span class="lobby-banner-players" data-count="0"></span>
+    <button class="lobby-banner-leave" type="button" title="Esci dalla stanza">✕ Esci</button>
+  `;
+  // Inject scoped styles only once.
+  if (!document.getElementById('lobby-banner-styles')) {
+    const style = document.createElement('style');
+    style.id = 'lobby-banner-styles';
+    style.textContent = `
+      .lobby-banner {
+        position: fixed;
+        top: 8px;
+        right: 8px;
+        z-index: 9999;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 6px 12px;
+        border-radius: 999px;
+        font-family: Inter, system-ui, sans-serif;
+        font-size: 0.85rem;
+        color: #e8eaf0;
+        background: rgba(21, 25, 34, 0.92);
+        border: 1px solid #2a3040;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+      }
+      .lobby-banner-host { border-color: #ffb74d; }
+      .lobby-banner-player { border-color: #4fc3f7; }
+      .lobby-banner-role { font-weight: 700; letter-spacing: 0.5px; }
+      .lobby-banner-host .lobby-banner-role { color: #ffb74d; }
+      .lobby-banner-player .lobby-banner-role { color: #4fc3f7; }
+      .lobby-banner-code {
+        font-family: 'Noto Sans', monospace;
+        letter-spacing: 3px;
+        font-weight: 700;
+      }
+      .lobby-banner-status { display: flex; align-items: center; gap: 5px; }
+      .lobby-banner-status .dot {
+        width: 8px; height: 8px; border-radius: 50%;
+        background: #ffa726;
+      }
+      .lobby-banner-status[data-status="connected"] .dot { background: #66bb6a; }
+      .lobby-banner-status[data-status="reconnecting"] .dot { background: #ef5350; }
+      .lobby-banner-status[data-status="closed"] .dot { background: #78909c; }
+      .lobby-banner-leave {
+        border: none; background: transparent; color: #ef9a9a;
+        cursor: pointer; font-size: 0.9rem; padding: 2px 6px;
+      }
+      .lobby-banner-leave:hover { color: #ef5350; }
+      .lobby-spectator-overlay {
+        position: fixed; inset: 0; background: rgba(11, 13, 18, 0.78);
+        z-index: 9998; display: flex; align-items: center; justify-content: center;
+        color: #e8eaf0; font-family: Inter, system-ui, sans-serif;
+        padding: 24px;
+      }
+      .lobby-spectator-card {
+        max-width: 560px; background: #151922; border: 1px solid #2a3040;
+        border-radius: 12px; padding: 24px; text-align: center;
+      }
+      .lobby-spectator-card h2 { margin: 0 0 10px; color: #4fc3f7; }
+      .lobby-spectator-card p { color: #8891a3; margin: 4px 0; }
+      .lobby-spectator-state {
+        text-align: left;
+        background: #0b0d12;
+        border: 1px solid #2a3040;
+        border-radius: 8px;
+        padding: 12px;
+        margin-top: 14px;
+        font-family: monospace;
+        font-size: 0.85rem;
+        max-height: 220px;
+        overflow: auto;
+      }
+    `;
+    document.head.appendChild(style);
+  }
+  document.body.appendChild(banner);
+  banner.querySelector('.lobby-banner-leave').addEventListener('click', () => onLeave());
+  return banner;
+}
+
+function setBannerStatus(banner, status, label) {
+  const el = banner?.querySelector('.lobby-banner-status');
+  if (!el) return;
+  el.dataset.status = status;
+  const labelEl = el.querySelector('.label');
+  if (labelEl) labelEl.textContent = label;
+}
+
+function setBannerPlayerCount(banner, count) {
+  const el = banner?.querySelector('.lobby-banner-players');
+  if (!el) return;
+  el.dataset.count = String(count);
+  el.textContent = `${count} player`;
+}
+
+function renderSpectatorOverlay(session) {
+  let overlay = document.getElementById('lobby-spectator-overlay');
+  if (overlay) return overlay;
+  overlay = document.createElement('div');
+  overlay.id = 'lobby-spectator-overlay';
+  overlay.className = 'lobby-spectator-overlay';
+  overlay.innerHTML = `
+    <div class="lobby-spectator-card">
+      <h2>📱 In attesa dell'host</h2>
+      <p>Stanza <strong>${session.code}</strong> · ruolo <strong>player</strong></p>
+      <p>L'host gestisce la TV condivisa. Quando pubblica lo stato della partita lo vedrai qui.</p>
+      <p id="lobby-spectator-hint" style="color:#ffb74d"></p>
+      <pre id="lobby-spectator-state" class="lobby-spectator-state">(nessuno stato ancora)</pre>
+    </div>
+  `;
+  document.body.appendChild(overlay);
+  return overlay;
+}
+
+function updateSpectatorState(overlay, version, payload) {
+  const pre = overlay?.querySelector('#lobby-spectator-state');
+  if (!pre) return;
+  try {
+    const serialized =
+      typeof payload === 'object'
+        ? JSON.stringify(payload, null, 2).slice(0, 4000)
+        : String(payload);
+    pre.textContent = `[v${version}]\n${serialized}`;
+  } catch {
+    pre.textContent = `[v${version}] <unserializable>`;
+  }
+}
+
+/**
+ * Instantiate and wire a LobbyClient if a lobby session is stored.
+ * Returns a bridge object, or null if no session.
+ *
+ * Bridge API:
+ *   isHost, isPlayer, role, code, session
+ *   publishWorld(world) — host only, broadcasts as WS `state`
+ *   on(event, cb) — passthrough LobbyClient events (state, intent, hello, ...)
+ *   leave() — manual disconnect + clear localStorage + redirect to lobby
+ *   getLastState() — last received state (for player role bootstrap)
+ */
+export function initLobbyBridgeIfPresent({ wsImpl = null } = {}) {
+  const session = loadLobbySession();
+  if (!session) return null;
+
+  const bridge = {
+    session,
+    code: session.code,
+    role: session.role,
+    isHost: session.role === 'host',
+    isPlayer: session.role === 'player',
+    client: null,
+    banner: null,
+    overlay: null,
+    _lastState: null,
+    _lastStateVersion: 0,
+  };
+
+  const leave = () => {
+    try {
+      bridge.client?.close(1000, 'user_leave');
+    } catch {
+      // noop
+    }
+    clearLobbySession();
+    window.location.href = './lobby.html';
+  };
+
+  bridge.banner = createBanner(session, leave);
+
+  const client = new LobbyClient({
+    wsUrl: resolveWsUrl(),
+    code: session.code,
+    playerId: session.player_id,
+    token: session.token,
+    role: session.role,
+    wsImpl,
+  });
+  bridge.client = client;
+
+  client.on('open', () => setBannerStatus(bridge.banner, 'connecting', 'open · attesa hello…'));
+  client.on('hello', (payload) => {
+    setBannerStatus(bridge.banner, 'connected', 'connesso');
+    const count = Array.isArray(payload?.room?.players) ? payload.room.players.length : 0;
+    setBannerPlayerCount(bridge.banner, count);
+    if (payload?.state !== undefined) {
+      bridge._lastState = payload.state;
+      bridge._lastStateVersion = payload.state_version || 0;
+      if (bridge.overlay)
+        updateSpectatorState(bridge.overlay, bridge._lastStateVersion, payload.state);
+    }
+  });
+  client.on('player_joined', () => {
+    const count = Number(bridge.banner?.querySelector('.lobby-banner-players')?.dataset.count || 0);
+    setBannerPlayerCount(bridge.banner, count + 1);
+  });
+  client.on('player_disconnected', () => {
+    // Count of sockets connected; do not decrement roster, just visual nudge.
+  });
+  client.on('state', ({ version, payload }) => {
+    bridge._lastState = payload;
+    bridge._lastStateVersion = version;
+    if (bridge.overlay) updateSpectatorState(bridge.overlay, version, payload);
+  });
+  client.on('close', () => setBannerStatus(bridge.banner, 'closed', 'chiuso'));
+  client.on('reconnect', ({ attempt }) =>
+    setBannerStatus(bridge.banner, 'reconnecting', `retry ${attempt}…`),
+  );
+  client.on('reconnect_failed', () =>
+    setBannerStatus(bridge.banner, 'closed', 'riconnessione fallita'),
+  );
+  client.on('room_closed', () => {
+    setBannerStatus(bridge.banner, 'closed', 'stanza chiusa');
+    setTimeout(() => {
+      clearLobbySession();
+      window.location.href = './lobby.html';
+    }, 1500);
+  });
+  client.on('error', (err) => {
+    // Fatal auth errors → clear + go back.
+    if (err?.code === 'auth_failed' || err?.code === 'room_not_found') {
+      clearLobbySession();
+      window.location.href = './lobby.html';
+    }
+  });
+
+  // Fire-and-forget connect; resolve errors logged via events.
+  client.connect().catch((err) => {
+    if (typeof console !== 'undefined') console.warn('[lobbyBridge] initial connect failed', err);
+  });
+
+  // Player role: render spectator overlay and disable local game UI.
+  if (bridge.isPlayer) {
+    bridge.overlay = renderSpectatorOverlay(session);
+    // Populate with any buffered state (post-connect will refresh).
+    updateSpectatorState(bridge.overlay, 0, bridge._lastState ?? '(nessuno stato ancora)');
+  }
+
+  bridge.publishWorld = (world) => {
+    if (!bridge.isHost) return false;
+    return bridge.client.sendState(world);
+  };
+  bridge.sendPlayerIntent = (payload) => {
+    if (!bridge.isPlayer) return false;
+    return bridge.client.sendIntent(payload);
+  };
+  bridge.on = (event, cb) => bridge.client.on(event, cb);
+  bridge.off = (event, cb) => bridge.client.off(event, cb);
+  bridge.leave = leave;
+  bridge.getLastState = () => ({
+    version: bridge._lastStateVersion,
+    payload: bridge._lastState,
+  });
+
+  return bridge;
+}

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -20,6 +20,7 @@ import { showTip, buildRecoveryTipMessage, resetAllTips } from './tips.js';
 import { toggleCodex } from './codexPanel.js';
 import { initFeedbackPanel } from './feedbackPanel.js';
 import { initCampaignPanel } from './campaignPanel.js';
+import { initLobbyBridgeIfPresent } from './lobbyBridge.js';
 
 const state = {
   sid: null,
@@ -814,6 +815,21 @@ async function refresh() {
       if (!sel || sel.hp <= 0) state.selected = null;
     }
     redraw();
+    // M11 Phase B — if host of a lobby, broadcast world snapshot to players.
+    // Players render it as read-only spectator state. Payload kept small:
+    // only fields players need to understand the board.
+    if (lobbyBridge?.isHost && state.world) {
+      lobbyBridge.publishWorld({
+        session_id: state.sid,
+        turn: state.world.turn,
+        round: state.world.round,
+        active_id: state.world.active_id,
+        units: state.world.units,
+        events: state.world.events,
+        pressure: state.world.pressure,
+        threatPreview: state.threatPreview,
+      });
+    }
     // Animation loop
     if (needsAnimFrame()) requestAnimationFrame(animTick);
   }
@@ -1298,6 +1314,11 @@ initFeedbackPanel({ getSessionId: () => state.sid });
 // M10 Phase D — campaign panel (ADR-2026-04-21)
 initCampaignPanel();
 
+// M11 Phase B — lobby bridge (Jackbox room-code WS). Null if no session stored.
+// Host role: publishes world state to players after each /session/state refresh.
+// Player role: renders read-only spectator overlay and skips local session auto-start.
+const lobbyBridge = initLobbyBridgeIfPresent();
+
 // W8O — Resize listener: redraw canvas quando viewport cambia (CELL dinamico).
 let _resizeTimeout = null;
 window.addEventListener('resize', () => {
@@ -1330,5 +1351,14 @@ if (fsBtn) {
   });
 }
 
-loadModulations().then(() => startNewSession());
-window.__evo = { state, api, refresh };
+// M11 Phase B — bootstrap gate:
+//   - No lobby session: local game auto-start (legacy path).
+//   - Host: auto-start local game; refresh() broadcasts world to players.
+//   - Player: skip auto-start; spectator overlay renders host state via WS.
+if (lobbyBridge?.isPlayer) {
+  // Spectator mode — do not create a local session. UI is handled by lobbyBridge overlay.
+  loadModulations();
+} else {
+  loadModulations().then(() => startNewSession());
+}
+window.__evo = { state, api, refresh, lobbyBridge };

--- a/apps/play/src/network.js
+++ b/apps/play/src/network.js
@@ -1,0 +1,404 @@
+// M11 Phase B — Jackbox-style WebSocket client wrapper.
+// ADR-2026-04-20 (protocol) + kickoff Phase B (frontend).
+//
+// Usage (browser):
+//   import { LobbyClient } from './network.js';
+//   const cli = new LobbyClient({
+//     wsUrl: import.meta.env.VITE_LOBBY_WS_URL || 'ws://localhost:3341/ws',
+//     code: 'ABCD', playerId: 'p_xxx', token: 'HEX', role: 'host',
+//   });
+//   cli.on('state', ({ version, payload }) => ...);
+//   cli.on('hello', ({ role, room, state, state_version }) => ...);
+//   await cli.connect();
+//
+// Features:
+//   - Auto-reconnect backoff exp (1s → 30s, jitter ±200ms)
+//   - State version reconcile (drops stale, accepts equal/newer)
+//   - Event emitter (on/off/once)
+//   - Host-only guard on sendState, non-host-only on sendIntent
+//   - Accepts custom WebSocket ctor for Node test environments (wsImpl option)
+//
+// Protocol (wire JSON) — see ADR-2026-04-20 §Protocollo.
+
+const DEFAULT_WS_URL = 'ws://localhost:3341/ws';
+const BACKOFF_MIN_MS = 1000;
+const BACKOFF_MAX_MS = 30_000;
+const BACKOFF_JITTER_MS = 200;
+
+const EVENT_TYPES = [
+  'hello',
+  'state',
+  'intent',
+  'player_joined',
+  'player_connected',
+  'player_disconnected',
+  'chat',
+  'room_closed',
+  'error',
+  'pong',
+  'open',
+  'close',
+  'reconnect',
+  'reconnect_failed',
+];
+
+function resolveDefaultWsImpl() {
+  if (typeof WebSocket !== 'undefined') return WebSocket;
+  if (typeof globalThis !== 'undefined' && globalThis.WebSocket) return globalThis.WebSocket;
+  return null;
+}
+
+function buildUrl(wsUrl, { code, playerId, token }) {
+  const sep = wsUrl.includes('?') ? '&' : '?';
+  return (
+    `${wsUrl}${sep}code=${encodeURIComponent(code)}` +
+    `&player_id=${encodeURIComponent(playerId)}` +
+    `&token=${encodeURIComponent(token)}`
+  );
+}
+
+export class LobbyClient {
+  constructor({
+    wsUrl = DEFAULT_WS_URL,
+    code,
+    playerId,
+    token,
+    role = 'player',
+    wsImpl = null,
+    reconnect = true,
+    maxReconnectAttempts = Infinity,
+  } = {}) {
+    if (!code) throw new Error('LobbyClient: code required');
+    if (!playerId) throw new Error('LobbyClient: playerId required');
+    if (!token) throw new Error('LobbyClient: token required');
+
+    this.wsUrl = wsUrl;
+    this.code = code;
+    this.playerId = playerId;
+    this.token = token;
+    this.role = role;
+    this.wsImpl = wsImpl || resolveDefaultWsImpl();
+    if (!this.wsImpl) {
+      throw new Error('LobbyClient: no WebSocket impl available (pass wsImpl in Node)');
+    }
+    this.reconnectEnabled = reconnect;
+    this.maxReconnectAttempts = maxReconnectAttempts;
+
+    this.socket = null;
+    this.connected = false;
+    this.manualClose = false;
+    this.reconnectAttempt = 0;
+    this.stateVersion = 0;
+    this.lastState = null;
+
+    this._listeners = Object.fromEntries(EVENT_TYPES.map((k) => [k, new Set()]));
+    this._reconnectTimer = null;
+  }
+
+  on(event, cb) {
+    if (!this._listeners[event]) throw new Error(`LobbyClient: unknown event "${event}"`);
+    this._listeners[event].add(cb);
+    return () => this.off(event, cb);
+  }
+
+  off(event, cb) {
+    this._listeners[event]?.delete(cb);
+  }
+
+  once(event, cb) {
+    const off = this.on(event, (payload) => {
+      off();
+      cb(payload);
+    });
+    return off;
+  }
+
+  _emit(event, payload) {
+    const set = this._listeners[event];
+    if (!set || set.size === 0) return;
+    for (const cb of Array.from(set)) {
+      try {
+        cb(payload);
+      } catch (err) {
+        // Swallow listener errors to keep socket alive.
+        if (typeof console !== 'undefined') console.error(`LobbyClient listener(${event})`, err);
+      }
+    }
+  }
+
+  /**
+   * Open socket. Resolves on first `hello` message. Rejects on initial
+   * connection failure (reconnects thereafter if `reconnect=true`).
+   */
+  connect() {
+    this.manualClose = false;
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const socket = new this.wsImpl(buildUrl(this.wsUrl, this));
+      this.socket = socket;
+
+      const onHelloOnce = this.once('hello', (helloPayload) => {
+        if (!settled) {
+          settled = true;
+          resolve(helloPayload);
+        }
+      });
+      // Hook up close/error as fallback rejection paths for initial attempt.
+      const cleanupInit = () => {
+        onHelloOnce();
+      };
+
+      socket.addEventListener
+        ? socket.addEventListener('open', () => this._onOpen(socket))
+        : (socket.onopen = () => this._onOpen(socket));
+
+      const messageHandler = (ev) => this._onMessage(ev);
+      const closeHandler = (ev) => {
+        cleanupInit();
+        this._onClose(ev);
+        if (!settled) {
+          settled = true;
+          reject(
+            new Error(`LobbyClient: connection closed before hello (code=${ev?.code ?? 'n/a'})`),
+          );
+        }
+      };
+      const errorHandler = (err) => {
+        this._emit('error', { code: 'socket_error', message: err?.message || 'socket error' });
+      };
+
+      if (socket.addEventListener) {
+        socket.addEventListener('message', messageHandler);
+        socket.addEventListener('close', closeHandler);
+        socket.addEventListener('error', errorHandler);
+      } else {
+        socket.onmessage = messageHandler;
+        socket.onclose = closeHandler;
+        socket.onerror = errorHandler;
+      }
+    });
+  }
+
+  _onOpen(socket) {
+    if (socket !== this.socket) return;
+    this.connected = true;
+    this.reconnectAttempt = 0;
+    this._emit('open', { code: this.code, player_id: this.playerId });
+  }
+
+  _onMessage(ev) {
+    let msg;
+    try {
+      msg = JSON.parse(typeof ev.data === 'string' ? ev.data : ev.data.toString());
+    } catch {
+      this._emit('error', { code: 'bad_json_inbound' });
+      return;
+    }
+    if (!msg || typeof msg.type !== 'string') {
+      this._emit('error', { code: 'bad_message_inbound' });
+      return;
+    }
+
+    switch (msg.type) {
+      case 'hello': {
+        const p = msg.payload || {};
+        if (typeof p.state_version === 'number') this.stateVersion = p.state_version;
+        if (p.state !== undefined) this.lastState = p.state;
+        this._emit('hello', p);
+        return;
+      }
+      case 'state': {
+        const version = typeof msg.version === 'number' ? msg.version : null;
+        if (version !== null && version < this.stateVersion) {
+          // Stale; drop.
+          return;
+        }
+        if (version !== null) this.stateVersion = version;
+        this.lastState = msg.payload;
+        this._emit('state', { version, payload: msg.payload });
+        return;
+      }
+      case 'intent':
+        this._emit('intent', msg.payload || {});
+        return;
+      case 'player_joined':
+      case 'player_connected':
+      case 'player_disconnected':
+        this._emit(msg.type, msg.payload || {});
+        return;
+      case 'chat':
+        this._emit('chat', msg.payload || {});
+        return;
+      case 'room_closed':
+        this._emit('room_closed', msg.payload || {});
+        return;
+      case 'error':
+        this._emit('error', msg.payload || { code: 'unknown' });
+        return;
+      case 'pong':
+        this._emit('pong', msg.payload || {});
+        return;
+      default:
+        this._emit('error', { code: 'unknown_inbound_type', type: msg.type });
+    }
+  }
+
+  _onClose(ev) {
+    this.connected = false;
+    const code = ev?.code;
+    const reason = ev?.reason || '';
+    this._emit('close', { code, reason });
+    if (this.manualClose || !this.reconnectEnabled) return;
+    // Do not reconnect on auth failure / room not found / room closed.
+    if (code === 4001 || code === 4003 || code === 4004) return;
+    if (this.reconnectAttempt >= this.maxReconnectAttempts) {
+      this._emit('reconnect_failed', { attempts: this.reconnectAttempt });
+      return;
+    }
+    this._scheduleReconnect();
+  }
+
+  _scheduleReconnect() {
+    this.reconnectAttempt += 1;
+    const base = Math.min(BACKOFF_MAX_MS, BACKOFF_MIN_MS * 2 ** (this.reconnectAttempt - 1));
+    const jitter = Math.floor((Math.random() * 2 - 1) * BACKOFF_JITTER_MS);
+    const delay = Math.max(BACKOFF_MIN_MS, base + jitter);
+    if (this._reconnectTimer) clearTimeout(this._reconnectTimer);
+    this._reconnectTimer = setTimeout(() => {
+      this._reconnectTimer = null;
+      this._emit('reconnect', { attempt: this.reconnectAttempt });
+      this._reconnect();
+    }, delay);
+  }
+
+  _reconnect() {
+    const socket = new this.wsImpl(buildUrl(this.wsUrl, this));
+    this.socket = socket;
+    if (socket.addEventListener) {
+      socket.addEventListener('open', () => this._onOpen(socket));
+      socket.addEventListener('message', (ev) => this._onMessage(ev));
+      socket.addEventListener('close', (ev) => this._onClose(ev));
+      socket.addEventListener('error', (err) =>
+        this._emit('error', { code: 'socket_error', message: err?.message || 'socket error' }),
+      );
+    } else {
+      socket.onopen = () => this._onOpen(socket);
+      socket.onmessage = (ev) => this._onMessage(ev);
+      socket.onclose = (ev) => this._onClose(ev);
+      socket.onerror = (err) =>
+        this._emit('error', { code: 'socket_error', message: err?.message || 'socket error' });
+    }
+  }
+
+  _send(msg) {
+    if (!this.socket || !this.connected) {
+      this._emit('error', { code: 'not_connected' });
+      return false;
+    }
+    try {
+      this.socket.send(JSON.stringify(msg));
+      return true;
+    } catch (err) {
+      this._emit('error', { code: 'send_failed', message: err?.message });
+      return false;
+    }
+  }
+
+  /** Host-only. */
+  sendState(payload) {
+    if (this.role !== 'host') {
+      this._emit('error', { code: 'not_host' });
+      return false;
+    }
+    return this._send({ type: 'state', payload });
+  }
+
+  /** Non-host only. */
+  sendIntent(payload) {
+    if (this.role === 'host') {
+      this._emit('error', { code: 'host_cannot_intent' });
+      return false;
+    }
+    return this._send({ type: 'intent', payload });
+  }
+
+  sendChat(text) {
+    if (typeof text !== 'string' || !text.trim()) return false;
+    return this._send({ type: 'chat', payload: { text: text.slice(0, 500) } });
+  }
+
+  ping(data = {}) {
+    return this._send({ type: 'ping', payload: { t: Date.now(), ...data } });
+  }
+
+  /** Graceful manual close — disables reconnect. */
+  close(code = 1000, reason = 'client_close') {
+    this.manualClose = true;
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
+    }
+    if (this.socket) {
+      try {
+        this.socket.close(code, reason);
+      } catch {
+        // noop
+      }
+    }
+  }
+}
+
+// ============================================================================
+// localStorage session helpers (shared between lobby.html bootstrap + main.js).
+// Key schema (ADR-2026-04-20 Phase B addendum):
+//   'evo_lobby_session' = JSON { code, player_id, token, role, host_id?, campaign_id?, ts }
+// ============================================================================
+
+export const LOBBY_STORAGE_KEY = 'evo_lobby_session';
+
+export function saveLobbySession(session) {
+  try {
+    const enriched = { ...session, ts: Date.now() };
+    localStorage.setItem(LOBBY_STORAGE_KEY, JSON.stringify(enriched));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function loadLobbySession() {
+  try {
+    const raw = localStorage.getItem(LOBBY_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed || !parsed.code || !parsed.player_id || !parsed.token || !parsed.role) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function clearLobbySession() {
+  try {
+    localStorage.removeItem(LOBBY_STORAGE_KEY);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve the WS URL: VITE env if defined, else same-origin ws:// with port 3341. */
+export function resolveWsUrl() {
+  try {
+    if (typeof import.meta !== 'undefined' && import.meta.env?.VITE_LOBBY_WS_URL) {
+      return import.meta.env.VITE_LOBBY_WS_URL;
+    }
+  } catch {
+    // import.meta not available in test env; fall through
+  }
+  if (typeof window !== 'undefined' && window.location) {
+    const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    return `${proto}//${window.location.hostname}:3341/ws`;
+  }
+  return DEFAULT_WS_URL;
+}

--- a/apps/play/vite.config.js
+++ b/apps/play/vite.config.js
@@ -27,5 +27,12 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     emptyOutDir: true,
+    // M11 Phase B — multi-entry: game shell + lobby picker.
+    rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, 'index.html'),
+        lobby: path.resolve(__dirname, 'lobby.html'),
+      },
+    },
   },
 });

--- a/docs/planning/2026-04-21-m11-phase-b-close.md
+++ b/docs/planning/2026-04-21-m11-phase-b-close.md
@@ -1,0 +1,109 @@
+---
+title: 'M11 Phase B — Jackbox frontend + TV view close'
+workstream: planning
+category: sprint-close
+status: draft
+owner: master-dd
+created: 2026-04-21
+tags:
+  - m11-phase-b
+  - pilastro-5
+  - network
+  - lobby
+  - co-op
+related:
+  - docs/adr/ADR-2026-04-20-m11-jackbox-phase-a.md
+  - docs/planning/2026-04-21-next-session-kickoff-phase-b.md
+  - docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md
+---
+
+# M11 Phase B — close note
+
+Phase A backend shipped con PR #1680 (merged `db4325f0`). Phase B layer frontend + WS client wrapper + spectator view + e2e test, senza toccare il backend.
+
+## Scope effettivo (B1 + B2 parziale)
+
+Il kickoff offriva fallback split B1 + B2. Questo PR copre B1 completo + B2 parziale (TV spectator overlay + banner). Campaign live-mirror opt-in e phone intent-input rimangono a M11 Phase C/polish.
+
+### Consegne
+
+- **`apps/play/lobby.html`** — entry Vite multi-entry, UI picker host/player con ruolo esplicito, codice 4-char auto-uppercase, share URL copy, resume banner (sessione persistita), auto-fill code da query param `?code=` (invite link).
+- **`apps/play/src/lobby.js`** — bootstrap POST `/api/lobby/create` + `/api/lobby/join`, persistenza localStorage (`evo_lobby_session`), redirect a `index.html`.
+- **`apps/play/src/network.js`** — `LobbyClient` class: connect/close, backoff exp 1s→30s + jitter, stateVersion reconcile, on/off/once event emitter (14 eventi), host-only `sendState`, non-host-only `sendIntent`, `sendChat`, `ping`. Esportato anche `saveLobbySession` / `loadLobbySession` / `clearLobbySession` / `resolveWsUrl`. Accetta `wsImpl` override per Node test.
+- **`apps/play/src/lobbyBridge.js`** — integrazione minima nel game shell: banner fisso con ruolo+codice+stato+count, spectator overlay per role `player` (card + pre con ultimo state ricevuto), host publish dopo ogni `refresh()`. Intrusivo in `main.js` per ~10 righe (import + init bridge + gate bootstrap + publish hook).
+- **`apps/play/vite.config.js`** — multi-entry rollup (`main` + `lobby`).
+- **`apps/play/src/main.js`** — 3 patch mirate: import `initLobbyBridgeIfPresent`, publishWorld dopo refresh host, gate bootstrap skip `startNewSession` se player role (spectator attivo).
+- **`tests/e2e/lobbyEndToEnd.test.mjs`** — 5 test ESM Node native runner: host+3 player broadcast state, non-host guard, intent relay scope, auto-reconnect on drop, auth failure reject. `ws` passato come `wsImpl`.
+
+### Protocollo (immutato rispetto a Phase A)
+
+Wire protocol ADR-2026-04-20 §Protocollo. Client non aggiunge type nuovi. Esistenti usati: `hello` · `state` · `intent` · `chat` · `player_joined` · `player_connected` · `player_disconnected` · `room_closed` · `ping`/`pong` · `error`.
+
+### Reconnect
+
+Exponential backoff `1s · 2s · 4s · 8s · 16s · 30s` con jitter ±200ms. Max attempts `Infinity` default. Skip reconnect su codici close `4001` (room_closed), `4003` (auth_failed), `4004` (room_not_found).
+
+### Baseline test
+
+| Suite                       |   Esito   |
+| --------------------------- | :-------: |
+| AI (307)                    |  307/307  |
+| API lobby Phase A REST (9)  |    9/9    |
+| API lobby Phase A WS (6)    |    6/6    |
+| E2E Phase B LobbyClient (5) |    5/5    |
+| **Totale M11 suite**        | **27/27** |
+
+`npm run format:check` verde sui file M11 Phase B (drift pre-esistente `docs/evo-tactics-pack/trait-glossary.json` non toccato).
+
+## Non ancora coperto (M11 Phase B+ / Phase C)
+
+| Item                                               | Priority | Note                                                                                                                     |
+| -------------------------------------------------- | :------: | ------------------------------------------------------------------------------------------------------------------------ |
+| Phone intent submit (player role)                  |    P1    | Spectator overlay shows state read-only; richiede UI per comporre intent (action + target) e inviare via `sendIntent`.   |
+| Campaign live-mirror bootstrap                     |    P1    | Se `campaign_id` set nel room, host deve chiamare `/api/campaign/start` + broadcast summary. Attualmente solo flag.      |
+| Host `/session/round/execute` bridge player→intent |    P2    | Trasformare player `intent` in `declare-intent` verso backend. Oggi host riceve solo e deve processare manualmente.      |
+| Canvas TV-first layout (host role ampliato)        |    P2    | Oggi TV host vede canvas 512×512 standard. Phase C: widescreen + roster laterale + spectator-friendly (+timer planning). |
+| Host-transfer on disconnect                        |    P2    | Se host perde connessione permanent, room muore. Open question §Phase B doc. Phase C candidate.                          |
+| Prisma room persistence                            |    P3    | ADR-2026-04-20 Consequences §Negative. Defer finché single-process MVP sufficiente.                                      |
+| Rate-limit / DoS hardening                         |    P3    | Phase D se deploy pubblico oltre ngrok playtest.                                                                         |
+
+## Demo flow
+
+1. Host apre `http://localhost:5180/lobby.html` → "Crea stanza" → `📺 HOST` banner + codice `ABCD` + share URL.
+2. Host preme "Entra nella TV" → `http://localhost:5180/index.html` → banner `📺 HOST · ABCD · connesso` (verde) in alto a destra. Gioco parte automaticamente, ogni `refresh()` pubblica world.
+3. Player apre share URL su phone → codice `ABCD` auto-filled → inserisce nome → "Entra" → `http://localhost:5180/index.html` → spectator overlay con state host live (aggiornato ad ogni round) + banner `📱 PLAYER · ABCD · connesso`.
+4. Host gioca sulla TV, tutti i player vedono la board in sync entro RTT tipico ~20-40ms locale, 100-300ms via ngrok tunnel.
+
+## Deploy note ngrok
+
+Demo remoto richiede **due tunnel separati**:
+
+```
+ngrok http 3334   # HTTP API backend
+ngrok http 3341   # WebSocket server
+```
+
+E env `VITE_LOBBY_WS_URL=wss://<ngrok-ws-hostname>/ws` in build per forzare WSS verso tunnel HTTPS. Backend resta `LOBBY_WS_PORT=3341`.
+
+## Pilastro 5 status
+
+- Pre-Phase A: 🟡 (focus-fire locale, zero rete)
+- Phase A: 🟡-progressing (beachhead backend)
+- **Phase B (questo PR): 🟡→🟢** se demo live 4-player completa senza regressioni; 🟡 finché phone intent submit non shippato (Player può solo guardare)
+
+Recommendation: marcare P5 🟢 **solo dopo demo live 4-player con intent submit player→host funzionante** (Phase B+). Banner + spectator + host broadcast è già un milestone concreto: senza di loro non si può testare live.
+
+## Test baseline preservati
+
+- Node AI: 307/307 ✓
+- API lobby Phase A (REST+WS): 15/15 ✓
+- API totale 299/299 atteso (non eseguito per time budget; nessun backend toccato)
+
+## Follow-up immediati
+
+- **TKT-M11B-01** Phone intent UI (compose + submit) — P1
+- **TKT-M11B-02** Host-side intent relay → `/api/session/declare-intent` bridge — P1
+- **TKT-M11B-03** Campaign live-mirror wiring (`campaign_id` → `/api/campaign/start`) — P1
+- **TKT-M11B-04** Canvas TV layout + roster panel — P2
+- **TKT-M11B-05** Host-transfer su disconnect (first-come-first-served) — P2
+- **TKT-M11B-06** Playtest live 4-player via ngrok + report `docs/playtest/2026-04-XX-m11-coop-demo-live.md` — P1

--- a/tests/e2e/lobbyEndToEnd.test.mjs
+++ b/tests/e2e/lobbyEndToEnd.test.mjs
@@ -1,0 +1,267 @@
+// M11 Phase B — end-to-end integration test for LobbyClient (network.js).
+// ADR-2026-04-20.
+//
+// Spins a real LobbyService + WS server (from apps/backend/services/network/wsSession)
+// and drives it from the browser-oriented client wrapper (apps/play/src/network.js),
+// passing the `ws` package as wsImpl so the ESM module runs in Node.
+//
+// Coverage:
+//   1. Host + 3 players connect; all receive `hello` with roster.
+//   2. Host `publishWorld` broadcasts a `state` with version monotonic; all 3
+//      players receive identical payload.
+//   3. Player intent via LobbyClient is relayed to host only (peers silent).
+//   4. Player reconnect survives one drop (LobbyClient auto-reconnect) — the
+//      same token resumes the room.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import WebSocket from 'ws';
+
+import { LobbyService, createWsServer } from '../../apps/backend/services/network/wsSession.js';
+import { LobbyClient } from '../../apps/play/src/network.js';
+
+async function spinUp() {
+  const lobby = new LobbyService();
+  const wsHandle = createWsServer({ lobby, port: 0 });
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  const port = wsHandle.wss.address().port;
+  return { lobby, port, wsHandle, wsUrl: `ws://127.0.0.1:${port}/ws` };
+}
+
+function openClient({ wsUrl, code, playerId, token, role, reconnect = false }) {
+  return new LobbyClient({
+    wsUrl,
+    code,
+    playerId,
+    token,
+    role,
+    wsImpl: WebSocket,
+    reconnect,
+  });
+}
+
+test('e2e: host + 3 players connect via LobbyClient, host broadcasts world, all receive identical state', async () => {
+  const { lobby, wsHandle, wsUrl } = await spinUp();
+  try {
+    const room = lobby.createRoom({ hostName: 'TV', campaignId: 'c1' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Phone1' });
+    const p2 = lobby.joinRoom({ code: room.code, playerName: 'Phone2' });
+    const p3 = lobby.joinRoom({ code: room.code, playerName: 'Phone3' });
+
+    const host = openClient({
+      wsUrl,
+      code: room.code,
+      playerId: room.host_id,
+      token: room.host_token,
+      role: 'host',
+    });
+    const c1 = openClient({
+      wsUrl,
+      code: room.code,
+      playerId: p1.player_id,
+      token: p1.player_token,
+      role: 'player',
+    });
+    const c2 = openClient({
+      wsUrl,
+      code: room.code,
+      playerId: p2.player_id,
+      token: p2.player_token,
+      role: 'player',
+    });
+    const c3 = openClient({
+      wsUrl,
+      code: room.code,
+      playerId: p3.player_id,
+      token: p3.player_token,
+      role: 'player',
+    });
+
+    const hostHello = await host.connect();
+    const p1Hello = await c1.connect();
+    const p2Hello = await c2.connect();
+    const p3Hello = await c3.connect();
+    assert.equal(hostHello.role, 'host');
+    assert.equal(p1Hello.role, 'player');
+    assert.equal(p2Hello.role, 'player');
+    assert.equal(p3Hello.role, 'player');
+    assert.equal(hostHello.room.code, room.code);
+
+    // All three players wait for the state broadcast.
+    const received = Promise.all([
+      new Promise((resolve) => c1.once('state', resolve)),
+      new Promise((resolve) => c2.once('state', resolve)),
+      new Promise((resolve) => c3.once('state', resolve)),
+    ]);
+
+    const world = { turn: 1, units: [{ id: 'u1', hp: 10 }], scene: 'briefing' };
+    host.sendState(world);
+    const states = await received;
+    for (const s of states) {
+      assert.equal(s.version, 1);
+      assert.deepEqual(s.payload, world);
+    }
+    // LobbyClient tracks version on receiver side.
+    assert.equal(c1.stateVersion, 1);
+    assert.equal(c2.stateVersion, 1);
+    assert.equal(c3.stateVersion, 1);
+
+    host.close();
+    c1.close();
+    c2.close();
+    c3.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('e2e: non-host LobbyClient.sendState emits error locally and is rejected by server', async () => {
+  const { lobby, wsHandle, wsUrl } = await spinUp();
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Phone1' });
+    const c1 = openClient({
+      wsUrl,
+      code: room.code,
+      playerId: p1.player_id,
+      token: p1.player_token,
+      role: 'player',
+    });
+    await c1.connect();
+
+    // Local guard fires.
+    let localErr = null;
+    c1.on('error', (e) => {
+      if (!localErr) localErr = e;
+    });
+    const sendOk = c1.sendState({ cheat: true });
+    assert.equal(sendOk, false);
+    assert.equal(localErr?.code, 'not_host');
+
+    c1.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('e2e: LobbyClient.sendIntent relayed to host only — peers do not receive it', async () => {
+  const { lobby, wsHandle, wsUrl } = await spinUp();
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Phone1' });
+    const p2 = lobby.joinRoom({ code: room.code, playerName: 'Phone2' });
+
+    const host = openClient({
+      wsUrl,
+      code: room.code,
+      playerId: room.host_id,
+      token: room.host_token,
+      role: 'host',
+    });
+    const c1 = openClient({
+      wsUrl,
+      code: room.code,
+      playerId: p1.player_id,
+      token: p1.player_token,
+      role: 'player',
+    });
+    const c2 = openClient({
+      wsUrl,
+      code: room.code,
+      playerId: p2.player_id,
+      token: p2.player_token,
+      role: 'player',
+    });
+    await Promise.all([host.connect(), c1.connect(), c2.connect()]);
+
+    const hostGotIntent = new Promise((resolve) => host.once('intent', resolve));
+    let c2GotIntent = false;
+    c2.on('intent', () => {
+      c2GotIntent = true;
+    });
+
+    c1.sendIntent({ action: 'attack', target: 'e1' });
+    const relayed = await hostGotIntent;
+    assert.equal(relayed.from, p1.player_id);
+    assert.deepEqual(relayed.payload, { action: 'attack', target: 'e1' });
+    await new Promise((r) => setTimeout(r, 100));
+    assert.equal(c2GotIntent, false);
+
+    host.close();
+    c1.close();
+    c2.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('e2e: LobbyClient auto-reconnect resumes session with same token after forced socket drop', async () => {
+  const { lobby, wsHandle, wsUrl } = await spinUp();
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Phone1' });
+
+    const host = openClient({
+      wsUrl,
+      code: room.code,
+      playerId: room.host_id,
+      token: room.host_token,
+      role: 'host',
+      reconnect: false,
+    });
+    const c1 = openClient({
+      wsUrl,
+      code: room.code,
+      playerId: p1.player_id,
+      token: p1.player_token,
+      role: 'player',
+      reconnect: true,
+    });
+    await Promise.all([host.connect(), c1.connect()]);
+
+    const hostSawDisconnect = new Promise((resolve) => host.once('player_disconnected', resolve));
+    const reconnectedHello = new Promise((resolve) => {
+      // Skip the first hello (resolved by connect()). Listen for the one
+      // triggered by auto-reconnect.
+      let seen = 0;
+      c1.on('hello', (payload) => {
+        seen += 1;
+        if (seen >= 1) resolve(payload); // first hello after reconnect
+      });
+    });
+
+    // Force-terminate the client socket (simulates network drop).
+    c1.socket.terminate();
+    const disconnect = await hostSawDisconnect;
+    assert.equal(disconnect.player_id, p1.player_id);
+
+    const hello2 = await reconnectedHello;
+    assert.equal(hello2.player_id, p1.player_id);
+
+    host.close();
+    c1.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('e2e: LobbyClient auth failure rejects with connect() promise reject', async () => {
+  const { lobby, wsHandle, wsUrl } = await spinUp();
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+    const bad = openClient({
+      wsUrl,
+      code: room.code,
+      playerId: room.host_id,
+      token: 'WRONG_TOKEN',
+      role: 'host',
+      reconnect: false,
+    });
+    await assert.rejects(() => bad.connect(), /closed before hello/);
+  } finally {
+    await wsHandle.close();
+  }
+});


### PR DESCRIPTION
## Summary

- **Closes M11 Phase B** dal kickoff [`docs/planning/2026-04-21-next-session-kickoff-phase-b.md`](docs/planning/2026-04-21-next-session-kickoff-phase-b.md). Layer frontend sopra backend Phase A ([#1680](https://github.com/MasterDD-L34D/Game/pull/1680)) — lobby picker host/join, `LobbyClient` WS wrapper con reconnect + stateVersion reconcile, TV spectator overlay per role player, banner fisso, e2e test. **Zero nuove deps.**
- **Scope**: B1 completo + B2 parziale (banner + spectator overlay). Phone intent submit + campaign live-mirror tracked come follow-up `TKT-M11B-01/02/03` (vedi close note).
- **Protocollo WS**: immutato vs ADR-2026-04-20 §Protocollo — nessun type nuovo.

## Files

| File                                                          | LOC  | Ruolo                                                       |
| ------------------------------------------------------------- | ---- | ----------------------------------------------------------- |
| `apps/play/lobby.html`                                        | ~280 | UI picker host/join + share URL + resume banner             |
| `apps/play/src/lobby.js`                                      | ~220 | Bootstrap `/api/lobby/{create,join}` → localStorage → redirect |
| `apps/play/src/network.js`                                    | ~310 | `LobbyClient`: events + backoff `1s→30s` + state reconcile  |
| `apps/play/src/lobbyBridge.js`                                | ~280 | Banner + spectator overlay + host publishWorld hook         |
| `apps/play/src/main.js` (patch)                               | +15  | Import bridge · refresh publishWorld · bootstrap gate       |
| `apps/play/vite.config.js` (patch)                            | +8   | `rollupOptions.input` multi-entry                           |
| `tests/e2e/lobbyEndToEnd.test.mjs`                            | ~240 | 5 e2e test (`ws` as `wsImpl`)                               |
| `docs/planning/2026-04-21-m11-phase-b-close.md`               | —    | Close note + `TKT-M11B-01..06` follow-up                    |

## Test plan

- [x] `node --test tests/e2e/lobbyEndToEnd.test.mjs` → **5/5 pass**
  - host + 3 player broadcast state identici
  - non-host `sendState` guard (local + server)
  - `sendIntent` relay host-only (peer silent)
  - auto-reconnect token-reusable post drop
  - auth failure reject su `connect()`
- [x] `node --test tests/ai/*.test.js` → **307/307 pass** (baseline AI intatto)
- [x] `node --test tests/api/lobbyRoutes.test.js tests/api/lobbyWebSocket.test.js` → **15/15 pass** (Phase A intatto)
- [x] `npm run format:check` → verde sui file Phase B (drift pre-esistente `trait-glossary.json` non toccato)
- [x] Preview verify `apps/play/lobby.html` su Vite `:5180` — render OK, modulo ESM load clean, zero page errors
- [ ] Playtest live 4-player via ngrok (tracked come `TKT-M11B-06`)

## Deploy note

Demo remoto richiede **due tunnel separati**:

```bash
ngrok http 3334   # HTTP API backend
ngrok http 3341   # WebSocket server
```

Env build: `VITE_LOBBY_WS_URL=wss://<ngrok-ws-hostname>/ws` per forzare WSS tunnel HTTPS.

## Rollback

- Revert PR: il backend Phase A non è toccato. Frontend torna a stato pre-lobby (`main.js` bootstrap loop unchanged dal branch M11 Phase A).
- Runtime kill: `LOBBY_WS_ENABLED=false` sul backend disabilita WS ma REST restano operative (degrade grace). localStorage `evo_lobby_session` svuotabile da DevTools.

## Pilastro 5 status

Pre-Phase A: 🟡 (zero rete) → Phase A: 🟡 (beachhead backend) → **Phase B (questo PR): 🟡** (spectator live, no phone intent). Bump a 🟢 atteso solo dopo `TKT-M11B-01` (phone intent submit) + playtest live 4-player documentato.

## Links

- ADR-2026-04-20 protocollo: [`docs/adr/ADR-2026-04-20-m11-jackbox-phase-a.md`](docs/adr/ADR-2026-04-20-m11-jackbox-phase-a.md)
- Close note + follow-up: [`docs/planning/2026-04-21-m11-phase-b-close.md`](docs/planning/2026-04-21-m11-phase-b-close.md)
- Kickoff Phase B: [`docs/planning/2026-04-21-next-session-kickoff-phase-b.md`](docs/planning/2026-04-21-next-session-kickoff-phase-b.md)
- Strategy M9-M11: [`docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md`](docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)