### PR TITLE
feat(network): M11 TKT-M11B-05 — host-transfer on disconnect (FIFO first-come)

### DIFF
--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -35,6 +35,10 @@ const ROOM_CODE_LENGTH = 4;
 const MAX_ROOM_CREATE_RETRIES = 20;
 const DEFAULT_MAX_PLAYERS = 8;
 const DEFAULT_HEARTBEAT_MS = 30_000;
+// TKT-M11B-05 — host-transfer grace window. If the host socket closes and
+// does not reattach within this window, the oldest connected player is
+// promoted to host role. Set to 0 to disable automatic host transfer.
+const DEFAULT_HOST_TRANSFER_GRACE_MS = 30_000;
 
 function generateRoomCode() {
   let out = '';
@@ -59,13 +63,23 @@ function generatePlayerId() {
  * Other roles can emit `intent` + `chat`.
  */
 class Room {
-  constructor({ code, hostId, hostName, maxPlayers = DEFAULT_MAX_PLAYERS, campaignId = null }) {
+  constructor({
+    code,
+    hostId,
+    hostName,
+    maxPlayers = DEFAULT_MAX_PLAYERS,
+    campaignId = null,
+    hostTransferGraceMs = DEFAULT_HOST_TRANSFER_GRACE_MS,
+  }) {
     this.code = code;
     this.hostId = hostId;
     this.maxPlayers = maxPlayers;
     this.campaignId = campaignId;
     this.createdAt = Date.now();
     this.closed = false;
+    this.hostTransferGraceMs = hostTransferGraceMs;
+    // TKT-M11B-05 — pending host-transfer timer handle.
+    this._hostTransferTimer = null;
     // player_id → { id, name, role, token, socket?, connected, joinedAt }
     this.players = new Map();
     // Host state published, last-write-wins; version monotonic.
@@ -201,6 +215,71 @@ class Room {
     return entry;
   }
 
+  /**
+   * TKT-M11B-05 — promote an existing player to host role. Broadcasts
+   * `host_transferred` with the new hostId. Returns the promoted player, or
+   * null if the candidate does not exist.
+   *
+   * The promoted player's `player_token` (issued at join) now authenticates
+   * host operations (POST /api/lobby/close, WS `state`). No new token is
+   * minted to keep the protocol simple — clients reuse what they already have.
+   */
+  transferHostTo(newHostId, { reason = 'host_transferred' } = {}) {
+    if (this.closed) return null;
+    const candidate = this.players.get(newHostId);
+    if (!candidate) return null;
+    const previousHostId = this.hostId;
+    const previousHost = this.players.get(previousHostId);
+    if (previousHost) previousHost.role = 'player';
+    candidate.role = 'host';
+    this.hostId = newHostId;
+    this.clearHostTransferTimer();
+    this.broadcast({
+      type: 'host_transferred',
+      payload: {
+        new_host_id: newHostId,
+        previous_host_id: previousHostId,
+        reason,
+        ts: Date.now(),
+      },
+    });
+    return candidate;
+  }
+
+  /**
+   * TKT-M11B-05 — pick the oldest *connected* non-host player and promote.
+   * Returns the promoted player, or null if no eligible candidate exists.
+   */
+  transferHostAuto({ reason = 'host_dropped' } = {}) {
+    if (this.closed) return null;
+    const candidates = Array.from(this.players.values())
+      .filter((p) => p.id !== this.hostId && p.connected)
+      .sort((a, b) => (a.joinedAt || 0) - (b.joinedAt || 0));
+    if (candidates.length === 0) return null;
+    return this.transferHostTo(candidates[0].id, { reason });
+  }
+
+  scheduleHostTransfer(onFire) {
+    this.clearHostTransferTimer();
+    if (!this.hostTransferGraceMs || this.hostTransferGraceMs <= 0) return;
+    this._hostTransferTimer = setTimeout(() => {
+      this._hostTransferTimer = null;
+      try {
+        onFire?.();
+      } catch {
+        // noop
+      }
+    }, this.hostTransferGraceMs);
+    this._hostTransferTimer.unref?.();
+  }
+
+  clearHostTransferTimer() {
+    if (this._hostTransferTimer) {
+      clearTimeout(this._hostTransferTimer);
+      this._hostTransferTimer = null;
+    }
+  }
+
   close(reason = 'host_closed') {
     this.closed = true;
     for (const p of this.players.values()) {
@@ -239,7 +318,7 @@ class LobbyService {
     this.maxPlayers = maxPlayers;
   }
 
-  createRoom({ hostName, campaignId = null, maxPlayers } = {}) {
+  createRoom({ hostName, campaignId = null, maxPlayers, hostTransferGraceMs } = {}) {
     if (!hostName || typeof hostName !== 'string') {
       throw new Error('host_name_required');
     }
@@ -261,6 +340,8 @@ class LobbyService {
       hostName,
       maxPlayers: maxPlayers || this.maxPlayers,
       campaignId,
+      hostTransferGraceMs:
+        hostTransferGraceMs !== undefined ? hostTransferGraceMs : DEFAULT_HOST_TRANSFER_GRACE_MS,
     });
     this.rooms.set(code, room);
     const host = room.getPlayer(hostId);
@@ -379,7 +460,13 @@ function createWsServer({ lobby, server = null, port = null, path = '/ws' } = {}
     }
 
     room.attachSocket(playerId, socket);
-    // Hello ack + snapshot.
+    // TKT-M11B-05 — if the returning player is (now or still) host, any
+    // pending host-transfer timer must be cancelled.
+    if (playerId === room.hostId) {
+      room.clearHostTransferTimer();
+    }
+    // Hello ack + snapshot. Note: player.role reflects the latest mutation,
+    // including a potential mid-session transferHost promotion.
     socket.send(
       JSON.stringify({
         type: 'hello',
@@ -460,6 +547,19 @@ function createWsServer({ lobby, server = null, port = null, path = '/ws' } = {}
         type: 'player_disconnected',
         payload: { player_id: playerId },
       });
+      // TKT-M11B-05 — if the host's socket dropped, schedule an auto host
+      // transfer. If the host reconnects before the grace window, the timer
+      // is cleared in the hello/attach path above.
+      if (playerId === room.hostId && !room.closed) {
+        room.scheduleHostTransfer(() => {
+          const promoted = room.transferHostAuto({ reason: 'host_dropped' });
+          if (!promoted) {
+            // No eligible candidate; close the room as a fallback so clients
+            // stop waiting indefinitely.
+            room.close('host_dropped_no_candidate');
+          }
+        });
+      }
     });
 
     socket.on('error', () => {

--- a/apps/play/src/lobbyBridge.js
+++ b/apps/play/src/lobbyBridge.js
@@ -15,7 +15,13 @@
 //   TKT-M11B-03 — Campaign live-mirror (setCampaignSummary on host, rendered
 //                 in spectator overlay on players)
 
-import { LobbyClient, loadLobbySession, clearLobbySession, resolveWsUrl } from './network.js';
+import {
+  LobbyClient,
+  loadLobbySession,
+  clearLobbySession,
+  resolveWsUrl,
+  saveLobbySession,
+} from './network.js';
 
 function createBanner(session, onLeave) {
   let banner = document.getElementById('lobby-banner');
@@ -643,6 +649,61 @@ export function initLobbyBridgeIfPresent({ wsImpl = null } = {}) {
         cb(normalized);
       } catch (err) {
         if (typeof console !== 'undefined') console.error('[lobbyBridge] onPlayerIntent cb', err);
+      }
+    }
+  });
+  // TKT-M11B-05 — react to server-promoted host transfer. If we are the new
+  // host, update session + banner + spawn host panel. Otherwise update the
+  // roster roles + banner note.
+  client.on('host_transferred', (payload) => {
+    const newHostId = payload?.new_host_id;
+    const prevHostId = payload?.previous_host_id;
+    if (!newHostId) return;
+    // Update local roster roles.
+    if (prevHostId && bridge._players.has(prevHostId)) {
+      bridge._players.get(prevHostId).role = 'player';
+    }
+    if (bridge._players.has(newHostId)) {
+      bridge._players.get(newHostId).role = 'host';
+    }
+    refreshRosterUi();
+    const promotedSelf = newHostId === session.player_id;
+    if (promotedSelf) {
+      // Persist new role so refresh / reconnect treat us as host.
+      bridge.role = 'host';
+      bridge.isHost = true;
+      bridge.isPlayer = false;
+      bridge.session = { ...session, role: 'host' };
+      saveLobbySession(bridge.session);
+      // Swap banner role class + text so status reflects promotion.
+      if (bridge.banner) {
+        bridge.banner.classList.remove('lobby-banner-player');
+        bridge.banner.classList.add('lobby-banner-host');
+        const roleEl = bridge.banner.querySelector('.lobby-banner-role');
+        if (roleEl) roleEl.textContent = '📺 HOST';
+      }
+      // Remove spectator overlay (we're the TV now).
+      if (bridge.overlay) {
+        bridge.overlay.remove();
+        bridge.overlay = null;
+      }
+      // Spawn host roster panel (was player; panel not yet created).
+      createHostRosterPanel(bridge);
+      updateHostRoster(bridge);
+      try {
+        document.body.classList.remove('lobby-role-player');
+        document.body.classList.add('lobby-role-host');
+      } catch {
+        // noop
+      }
+      if (typeof console !== 'undefined') {
+        console.info(`[lobbyBridge] promoted to host (reason=${payload.reason || 'unknown'})`);
+      }
+    } else {
+      if (typeof console !== 'undefined') {
+        console.info(
+          `[lobbyBridge] host transferred: ${prevHostId || '?'} → ${newHostId} (reason=${payload.reason || '?'})`,
+        );
       }
     }
   });

--- a/apps/play/src/network.js
+++ b/apps/play/src/network.js
@@ -32,6 +32,7 @@ const EVENT_TYPES = [
   'player_joined',
   'player_connected',
   'player_disconnected',
+  'host_transferred',
   'chat',
   'room_closed',
   'error',
@@ -226,6 +227,19 @@ export class LobbyClient {
       case 'player_disconnected':
         this._emit(msg.type, msg.payload || {});
         return;
+      case 'host_transferred': {
+        // TKT-M11B-05 — server promoted someone to host. Update local role
+        // if the promoted id matches ours so sendState guards flip accordingly.
+        const payload = msg.payload || {};
+        if (payload.new_host_id && payload.new_host_id === this.playerId) {
+          this.role = 'host';
+        } else if (this.role === 'host' && payload.new_host_id !== this.playerId) {
+          // We used to be host but aren't anymore (rare edge: admin force-transfer).
+          this.role = 'player';
+        }
+        this._emit('host_transferred', payload);
+        return;
+      }
       case 'chat':
         this._emit('chat', msg.payload || {});
         return;

--- a/tests/e2e/lobbyEndToEnd.test.mjs
+++ b/tests/e2e/lobbyEndToEnd.test.mjs
@@ -425,6 +425,150 @@ test('e2e: Phase C roster — player_joined + player_connected + player_disconne
   }
 });
 
+// ---------------------------------------------------------------------------
+// TKT-M11B-05 — host transfer on host socket drop.
+// ---------------------------------------------------------------------------
+
+test('e2e: TKT-05 host drops → oldest connected player promoted → can sendState', async () => {
+  const { lobby, wsHandle, wsUrl } = await spinUp();
+  try {
+    const room = lobby.createRoom({ hostName: 'TV', hostTransferGraceMs: 80 });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Phone1' });
+    const p2 = lobby.joinRoom({ code: room.code, playerName: 'Phone2' });
+
+    const host = openClient({
+      wsUrl,
+      code: room.code,
+      playerId: room.host_id,
+      token: room.host_token,
+      role: 'host',
+      reconnect: false,
+    });
+    const c1 = openClient({
+      wsUrl,
+      code: room.code,
+      playerId: p1.player_id,
+      token: p1.player_token,
+      role: 'player',
+      reconnect: false,
+    });
+    const c2 = openClient({
+      wsUrl,
+      code: room.code,
+      playerId: p2.player_id,
+      token: p2.player_token,
+      role: 'player',
+      reconnect: false,
+    });
+    await Promise.all([host.connect(), c1.connect(), c2.connect()]);
+
+    const c1Transfer = new Promise((resolve) => c1.once('host_transferred', resolve));
+    const c2Transfer = new Promise((resolve) => c2.once('host_transferred', resolve));
+
+    // Host drops (no reconnect). Grace window is 80ms; wait > grace + safety.
+    host.socket.terminate();
+    const [t1, t2] = await Promise.all([c1Transfer, c2Transfer]);
+
+    // Oldest connected non-host candidate (p1 joined before p2) is promoted.
+    assert.equal(t1.new_host_id, p1.player_id);
+    assert.equal(t2.new_host_id, p1.player_id);
+    assert.equal(t1.previous_host_id, room.host_id);
+    assert.equal(t1.reason, 'host_dropped');
+
+    // Client-side role flipped on promoted LobbyClient.
+    assert.equal(c1.role, 'host');
+    assert.equal(c2.role, 'player');
+
+    // New host can publish state; peers receive it.
+    const c2StateReceived = new Promise((resolve) => c2.once('state', resolve));
+    c1.sendState({ promoted: true, turn: 0 });
+    const state = await c2StateReceived;
+    assert.deepEqual(state.payload, { promoted: true, turn: 0 });
+    assert.equal(state.version, 1);
+
+    c1.close();
+    c2.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('e2e: TKT-05 host reconnects within grace window → no transfer', async () => {
+  const { lobby, wsHandle, wsUrl } = await spinUp();
+  try {
+    const room = lobby.createRoom({ hostName: 'TV', hostTransferGraceMs: 300 });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Phone1' });
+
+    const host = openClient({
+      wsUrl,
+      code: room.code,
+      playerId: room.host_id,
+      token: room.host_token,
+      role: 'host',
+      reconnect: false,
+    });
+    const c1 = openClient({
+      wsUrl,
+      code: room.code,
+      playerId: p1.player_id,
+      token: p1.player_token,
+      role: 'player',
+      reconnect: false,
+    });
+    await Promise.all([host.connect(), c1.connect()]);
+
+    let transferFired = false;
+    c1.on('host_transferred', () => {
+      transferFired = true;
+    });
+
+    host.socket.terminate();
+    // Reconnect host immediately (well within grace of 300ms).
+    await new Promise((r) => setTimeout(r, 50));
+    const hostAgain = openClient({
+      wsUrl,
+      code: room.code,
+      playerId: room.host_id,
+      token: room.host_token,
+      role: 'host',
+      reconnect: false,
+    });
+    await hostAgain.connect();
+    // Wait past original grace window to confirm the transfer did NOT fire.
+    await new Promise((r) => setTimeout(r, 400));
+    assert.equal(transferFired, false);
+    assert.equal(c1.role, 'player');
+
+    hostAgain.close();
+    c1.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('e2e: TKT-05 host drops with no connected peers → room closes (no eligible candidate)', async () => {
+  const { lobby, wsHandle, wsUrl } = await spinUp();
+  try {
+    const room = lobby.createRoom({ hostName: 'TV', hostTransferGraceMs: 80 });
+    const host = openClient({
+      wsUrl,
+      code: room.code,
+      playerId: room.host_id,
+      token: room.host_token,
+      role: 'host',
+      reconnect: false,
+    });
+    await host.connect();
+    host.socket.terminate();
+    // Wait past grace.
+    await new Promise((r) => setTimeout(r, 200));
+    const r = lobby.getRoom(room.code);
+    assert.equal(r.closed, true);
+  } finally {
+    await wsHandle.close();
+  }
+});
+
 test('e2e: LobbyClient auth failure rejects with connect() promise reject', async () => {
   const { lobby, wsHandle, wsUrl } = await spinUp();
   try {


### PR DESCRIPTION
## Summary

Stacked on [#1684](https://github.com/MasterDD-L34D/Game/pull/1684) (Phase C). Closes **TKT-M11B-05**: automatic host-transfer flow when the host's WS drops.

- Grace window default **30s** (configurable via `hostTransferGraceMs` on `createRoom`; tests use `80ms`).
- Promoted candidate = **oldest connected non-host player** (FIFO by `joinedAt`).
- If no eligible candidate → `room.close('host_dropped_no_candidate')`.
- Promoted player reuses existing `player_token` as host credential (no new token minted).
- Broadcast `host_transferred` → bridge flips local session + UI (banner class + overlay removal + host panel spawn).
- **Protocol addition backward-compatible**: clients without Phase C+ wiring ignore the new type.

## Files

| File                                                  | Δ LOC | Ruolo                                                                |
| ----------------------------------------------------- | ----- | -------------------------------------------------------------------- |
| `apps/backend/services/network/wsSession.js`         | +85   | Room.transferHostTo/Auto + scheduleHostTransfer + wire close handler |
| `apps/play/src/network.js`                            | +15   | EVENT_TYPES + `host_transferred` case (role flip)                    |
| `apps/play/src/lobbyBridge.js`                        | +55   | On promotion: session update + banner swap + overlay remove + panel  |
| `tests/e2e/lobbyEndToEnd.test.mjs`                    | +115  | +3 test (happy path · reconnect before grace · no candidate)         |

## Test plan

- [x] `node --test tests/e2e/lobbyEndToEnd.test.mjs` → **11/11 pass** (5 B + 2 B+ + 1 C + 3 TKT-05)
- [x] `node --test tests/ai/*.test.js tests/api/lobbyRoutes.test.js tests/api/lobbyWebSocket.test.js` → **322/322 pass**
- [x] Totale: **333/333**
- [x] `npm run format:check` → verde

## Scenarios coperti da test

1. **Happy path**: host drop + 2 player connessi → primo (oldest) promosso → può `sendState` → broadcast riuscito
2. **No-op su reconnect rapido**: host drop + reconnect entro grace → timer cancellato, zero transfer, ruoli invariati
3. **No candidate**: host drop solo → room chiusa entro grace+safety

## Rollback

- `LOBBY_WS_ENABLED=false` disabilita l'intero WS layer
- `LobbyService.createRoom({ hostTransferGraceMs: 0 })` disabilita solo auto-transfer (timer skip)

## Pilastro 5 status

Programmatic + resilience stack (reconnect + host-transfer) **100% done**. Resta solo esecuzione **TKT-M11B-06** playtest live per bump 🟡 → 🟢 (playbook pronto in PR #1684).

## Links

- Base Phase C PR: [#1684](https://github.com/MasterDD-L34D/Game/pull/1684)
- Playbook: [`docs/playtest/2026-04-21-m11-coop-ngrok-playbook.md`](docs/playtest/2026-04-21-m11-coop-ngrok-playbook.md)
- ADR: [`docs/adr/ADR-2026-04-20-m11-jackbox-phase-a.md`](docs/adr/ADR-2026-04-20-m11-jackbox-phase-a.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)