### PR TITLE
docs(planning): M11 Phase B→TKT-05 close + next session handoff (P5 🟢 pending playtest)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,6 +286,24 @@ Primary working directory is on Windows, but the shell is bash (Git Bash/MSYS) �
 - Prisma persistence adapter (Phase C opzionale, default in-memory)
 - Rate-limit / DoS hardening (Phase D se produzione pubblica)
 
+**Milestone sessione 2026-04-20 M11 Phase B + B+ + C + TKT-05 (stack 4 PR mergiati)**:
+
+- **PR #1682 merged** `d35dde92` — Phase B: `apps/play/lobby.html` + `apps/play/src/network.js` (LobbyClient + reconnect backoff 1s→30s + stateVersion reconcile) + `apps/play/src/lobbyBridge.js` (banner + spectator overlay) + main.js bootstrap gate + 5 e2e test
+- **PR #1686 merged** `d14b2655` — Phase B+ (TKT-01/02/03): phone intent composer (roster + unit/action/target select) + host `onPlayerIntent` hook → `api.declareIntent` + `setCampaignSummary` + 2 e2e test
+- **PR #1684 merged** `583be2a8` — Phase C (TKT-04/06 partial): host TV roster panel (status dots + collapsible) + `body.lobby-role-{host,player}` classes + ngrok playbook `docs/playtest/2026-04-21-m11-coop-ngrok-playbook.md` + 1 e2e test
+- **PR #1685 merged** `d97eb5f8` — TKT-05 host-transfer: `Room.transferHostAuto` FIFO + `scheduleHostTransfer` grace 30s default + `host_transferred` broadcast backward-compat + bridge re-wire (banner swap + overlay remove + host panel spawn) + 3 e2e test
+- **Test stack lobby**: 11 e2e + 15 Phase A REST/WS + 307 AI = **333/333** · format:check verde
+- **Flow end-to-end programmatico**: phone composer → `sendPlayerIntent` → WS → host `onPlayerIntent` → `api.declareIntent` → round ready → `publishWorld` → player overlay render
+- **Pilastro 5 status**: **🟡** (flow + resilience 100% chiuso) → **🟢 atteso dopo TKT-M11B-06 playtest live** (non-automatizzabile, next session userland)
+- **Handoff doc**: [`docs/planning/2026-04-22-next-session-kickoff-m11-playtest.md`](docs/planning/2026-04-22-next-session-kickoff-m11-playtest.md)
+
+**Residuo backlog M11**:
+
+- TKT-M11B-04 canvas TV widescreen layout (P2, polish)
+- TKT-M11B-06 playtest live execution (P1, userland)
+- Prisma room persistence (P3, deferred)
+- Rate-limit / DoS hardening (P3, solo deploy pubblico)
+
 ### Pilastri di design — stato reale (audit 2026-04-20, rev post deep-audit)
 
 Revisione honest post-M7 + deep-audit Explore agent. Statuses precedenti 6/6 🟢 confondevano **"dataset shipped"** con **"runtime shipped"**.

--- a/docs/planning/2026-04-22-next-session-kickoff-m11-playtest.md
+++ b/docs/planning/2026-04-22-next-session-kickoff-m11-playtest.md
@@ -1,0 +1,147 @@
+---
+title: 'Next session kickoff — M11 live playtest + Pilastro 5 🟢 close'
+workstream: planning
+category: handoff
+status: draft
+owner: master-dd
+created: 2026-04-22
+tags:
+  - kickoff
+  - session-handoff
+  - m11-phase-d
+  - tkt-m11b-06
+  - pilastro-5
+related:
+  - docs/adr/ADR-2026-04-20-m11-jackbox-phase-a.md
+  - docs/planning/2026-04-21-m11-phase-b-close.md
+  - docs/playtest/2026-04-21-m11-coop-ngrok-playbook.md
+---
+
+# Next session kickoff — M11 live playtest (Pilastro 5 🟢)
+
+Sessione 2026-04-20 chiude l'intera sprint M11 Phase B → Phase C + TKT-05 host-transfer. **Stack 4 PR mergiati in main**:
+
+| PR                                                       | Commit     | Scope                                                                                                        | Test   |
+| -------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------ | ------ |
+| [#1682](https://github.com/MasterDD-L34D/Game/pull/1682) | `d35dde92` | M11 Phase B — lobby.html + network.js (LobbyClient + reconnect) + spectator overlay + basic bridge           | 5 e2e  |
+| [#1686](https://github.com/MasterDD-L34D/Game/pull/1686) | `d14b2655` | M11 Phase B+ — phone intent UI composer + host relay → `declareIntent` + campaign live-mirror (TKT-01/02/03) | +2 e2e |
+| [#1684](https://github.com/MasterDD-L34D/Game/pull/1684) | `583be2a8` | M11 Phase C — host TV roster panel + body role classes + ngrok playbook (TKT-04/06 partial)                  | +1 e2e |
+| [#1685](https://github.com/MasterDD-L34D/Game/pull/1685) | `d97eb5f8` | M11 TKT-05 — host-transfer on disconnect, FIFO first-come, backward-compatible `host_transferred` broadcast  | +3 e2e |
+
+**Test totali lobby stack**: 11 e2e + 15 Phase A REST/WS + 307 AI = **333/333**. Format:check verde. Zero nuove deps (ws@8.18.3 pre-installato da Phase A).
+
+## Stato Pilastro 5 (Co-op vs Sistema)
+
+- Pre-M11: 🟡 (zero rete)
+- Phase A (2026-04-20): 🟡 beachhead backend
+- Phase B/B+/C/TKT-05 (2026-04-20): **🟡 (flow + resilience 100% chiuso)**
+- **TKT-M11B-06 playtest live ngrok → 🟢**
+
+Manca solo esecuzione userland. Playbook pronto: [`docs/playtest/2026-04-21-m11-coop-ngrok-playbook.md`](../playtest/2026-04-21-m11-coop-ngrok-playbook.md).
+
+## Prompt next session
+
+### Opzione A — TKT-M11B-06 playtest live (P1, chiude P5 🟢)
+
+```text
+Leggi:
+- docs/playtest/2026-04-21-m11-coop-ngrok-playbook.md (setup + script)
+- docs/adr/ADR-2026-04-20-m11-jackbox-phase-a.md (protocollo)
+
+Task: eseguire playtest live M11 co-op.
+
+Setup (prompt aiuta user, NON autonomo):
+1. User configura 2 tunnel ngrok (HTTP 3334 + WS 3341)
+2. User build frontend con VITE_LOBBY_WS_URL
+3. User recluta 2-4 amici via share URL
+4. User esegue 3 scenario dal playbook (Tutorial 01 duo → Tutorial 05 quartet → Campaign mirror)
+
+Durante sessione:
+- Monitorare backend log per ✖ intent relay / errori WS
+- Catturare metriche (RTT, reconnect success rate, fun rating)
+- Annotare bug runtime (P0/P1/P2)
+
+Output post-playtest:
+- docs/playtest/2026-04-XX-m11-coop-demo-live.md report
+- Ticket nuovi per bug trovati
+- Se successo: update CLAUDE.md §Pilastri → 🟢
+- Se failure: analisi + Phase D plan (persistence / rate-limit / host-transfer tuning)
+```
+
+### Opzione B — M12 big rock P2 full Form evoluzione (~35h, Spore-core)
+
+Se user non disponibile per playtest live, big rock successivo:
+
+```text
+Leggi:
+- docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md §Sprint M12
+- docs/planning/2026-04-20-pilastri-reality-audit.md §P2
+- docs/core/15-PI-PACK-FORME.md (reference design)
+
+Task: M12 Sprint kickoff — Pilastro 2 full evoluzione ciclo runtime.
+
+Scope: deferito da M10. Richiede Form runtime + evoluzione triggered + PI pack
+spender integrato in campaign loop. Pattern Spore (non Wesnoth).
+
+Effort: ~35h, 2-3 sprint. Split:
+- M12.A (~12h): Form registry + evoluzione trigger + state machine
+- M12.B (~12h): PI pack spender runtime integration + UX
+- M12.C (~11h): Visual feedback + tests + playtest
+```
+
+### Opzione C — Refactor/polish P2/P3 residuali
+
+- TKT-M11B-04 widescreen TV canvas layout polish (P2, ~3h)
+- Prisma room persistence adapter (P3, ~5h) — utile se deploy pubblico post-playtest
+- Rate-limit / DoS hardening su wsSession (P3, ~3h)
+
+## Baseline snapshot post-merge
+
+```bash
+cd /c/Users/VGit/Desktop/Game
+git fetch origin main
+git checkout main  # d97eb5f8
+node --test tests/ai/*.test.js                                # 307/307 ✓
+node --test tests/api/lobbyRoutes.test.js tests/api/lobbyWebSocket.test.js  # 15/15 ✓
+node --test tests/e2e/lobbyEndToEnd.test.mjs                  # 11/11 ✓
+npm run format:check                                          # verde (salvo drift pre-esistente trait-glossary.json)
+```
+
+## Quick start — co-op demo locale (dev)
+
+```bash
+# Terminal 1
+cd /c/Users/VGit/Desktop/Game
+npm run start:api                      # backend :3334 + WS :3341
+
+# Terminal 2
+npm run play:dev                       # Vite :5180
+
+# Browser
+open http://localhost:5180/lobby.html  # host crea stanza
+# phone / altro browser tab usa share URL
+open http://localhost:5180/lobby.html?code=XXXX  # player joins
+```
+
+## Warning / constraint next session
+
+- **NON toccare `apps/backend/services/network/wsSession.js`** senza ADR addendum — protocollo wire stabile post-TKT-05.
+- **NON toccare `apps/play/src/network.js` LobbyClient event schema** — downstream bridge + tests dipendono.
+- **NON committare binari** sotto `reports/backups/**` (lint:backups enforcement).
+- **Caveman mode attivo** di default per tutte le risposte tecniche.
+
+## Follow-up tracked
+
+- **TKT-M11B-04** canvas TV widescreen polish (P2)
+- **TKT-M11B-06** playtest live (P1, questo doc)
+- **M12 P2 Spore evo** (big rock, deferred)
+- Prisma room persistence (P3)
+- Rate-limit (P3)
+
+## Riferimenti utili
+
+- ADR protocollo: [`docs/adr/ADR-2026-04-20-m11-jackbox-phase-a.md`](../adr/ADR-2026-04-20-m11-jackbox-phase-a.md)
+- Phase B close: [`docs/planning/2026-04-21-m11-phase-b-close.md`](2026-04-21-m11-phase-b-close.md)
+- Playbook ngrok: [`docs/playtest/2026-04-21-m11-coop-ngrok-playbook.md`](../playtest/2026-04-21-m11-coop-ngrok-playbook.md)
+- Strategy M9-M11: [`docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md`](2026-04-20-strategy-m9-m11-evidence-based.md)
+- Pilastri audit: [`docs/planning/2026-04-20-pilastri-reality-audit.md`](2026-04-20-pilastri-reality-audit.md)


### PR DESCRIPTION
## Summary

Closes documentation loop after the M11 stack merge (#1682 · #1686 · #1684 · #1685). Delivers:

- **CLAUDE.md §Sprint context sync** — new milestone block listing the 4 merged PRs + test totals (333/333) + flow end-to-end + Pilastro 5 status
- **docs/planning/2026-04-22-next-session-kickoff-m11-playtest.md** NEW — next-session kickoff with 3 ready-to-paste prompts (TKT-06 playtest · M12 Spore evo · polish residuali)

## Pilastro 5 final position

- Programmatic + resilience stack 100% chiuso (lobby + spectator + composer + host relay + campaign mirror + roster + host-transfer)
- **🟡 → 🟢** require solo esecuzione TKT-M11B-06 playtest live (non-automatizzabile, userland) — playbook pronto in [`docs/playtest/2026-04-21-m11-coop-ngrok-playbook.md`](docs/playtest/2026-04-21-m11-coop-ngrok-playbook.md)

## Test plan

- [x] `python tools/check_docs_governance.py --registry docs/governance/docs_registry.json --strict` → errors=0 (4 warning pre-esistenti unrelated)
- [x] `npm run format:check` → verde sui file aggiornati

## Rollback

Revert PR: handoff doc + CLAUDE.md milestone rimossi. Nessun impatto runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)