### PR TITLE
feat(forms): M12 Phase A — form evolution engine (Pilastro 2 runtime beachhead)

### DIFF
--- a/apps/backend/routes/forms.js
+++ b/apps/backend/routes/forms.js
@@ -1,0 +1,100 @@
+// M12 Phase A — Forms routes.
+//
+// Endpoints:
+//   GET  /api/v1/forms/registry           — list all 16 MBTI forms + metadata
+//   GET  /api/v1/forms/:id                — single form detail
+//   POST /api/v1/forms/evaluate           — eligibility for a target form
+//   POST /api/v1/forms/options            — scored list of all forms for a unit
+//   POST /api/v1/forms/evolve             — execute transition (mutates unit state)
+//
+// NOTE: routes operate on a caller-supplied unit snapshot. Persistence is
+// deferred to M12.B (integration with meta progression / session store).
+
+'use strict';
+
+const { Router } = require('express');
+const { FormEvolutionEngine } = require('../services/forms/formEvolution');
+
+function createFormsRouter(opts = {}) {
+  const engine = opts.engine || new FormEvolutionEngine(opts);
+  const router = Router();
+
+  router.get('/registry', (_req, res) => {
+    res.json(engine.snapshot());
+  });
+
+  router.get('/:id', (req, res) => {
+    const form = engine.getForm(req.params.id);
+    if (!form) return res.status(404).json({ error: 'form_not_found' });
+    res.json(form);
+  });
+
+  router.post('/evaluate', (req, res) => {
+    const {
+      unit,
+      vc_snapshot: vcSnapshot,
+      target_form_id: targetFormId,
+      current_round: currentRound = 0,
+      extra_pe: extraPe = 0,
+    } = req.body || {};
+    if (!unit || typeof unit !== 'object') {
+      return res.status(400).json({ error: 'unit (object) required' });
+    }
+    if (!targetFormId || typeof targetFormId !== 'string') {
+      return res.status(400).json({ error: 'target_form_id (string) required' });
+    }
+    const report = engine.evaluate(unit, vcSnapshot || {}, targetFormId, {
+      currentRound: Number(currentRound) || 0,
+      extraPe: Number(extraPe) || 0,
+    });
+    res.json(report);
+  });
+
+  router.post('/options', (req, res) => {
+    const {
+      unit,
+      vc_snapshot: vcSnapshot,
+      current_round: currentRound = 0,
+      extra_pe: extraPe = 0,
+    } = req.body || {};
+    if (!unit || typeof unit !== 'object') {
+      return res.status(400).json({ error: 'unit (object) required' });
+    }
+    const scored = engine.evaluateAll(unit, vcSnapshot || {}, {
+      currentRound: Number(currentRound) || 0,
+      extraPe: Number(extraPe) || 0,
+    });
+    res.json({ unit_id: unit.id || null, options: scored });
+  });
+
+  router.post('/evolve', (req, res) => {
+    const {
+      unit,
+      vc_snapshot: vcSnapshot,
+      target_form_id: targetFormId,
+      current_round: currentRound = 0,
+      extra_pe: extraPe = 0,
+    } = req.body || {};
+    if (!unit || typeof unit !== 'object') {
+      return res.status(400).json({ error: 'unit (object) required' });
+    }
+    if (!targetFormId || typeof targetFormId !== 'string') {
+      return res.status(400).json({ error: 'target_form_id (string) required' });
+    }
+    // Clone so caller's object isn't mutated when the route is tested as a
+    // pure function via supertest without a persistence layer.
+    const unitCopy = { ...unit };
+    const result = engine.evolve(unitCopy, vcSnapshot || {}, targetFormId, {
+      currentRound: Number(currentRound) || 0,
+      extraPe: Number(extraPe) || 0,
+    });
+    if (!result.ok) {
+      return res.status(409).json(result);
+    }
+    res.json(result);
+  });
+
+  return router;
+}
+
+module.exports = { createFormsRouter };

--- a/apps/backend/services/forms/formEvolution.js
+++ b/apps/backend/services/forms/formEvolution.js
@@ -1,0 +1,221 @@
+// M12 Phase A — Form evolution engine.
+//
+// Layer on top of services/personalityProjection.js (projectForm + loadForms)
+// to gate actual transitions between MBTI forms with trigger conditions:
+//   - Axes confidence >= threshold (default 0.55)
+//   - PE cost paid (default 8 PE; tunable via evo_costs.yaml future)
+//   - Cooldown respected (default 3 rounds since last evolve)
+//   - Candidate != current form
+//
+// Entry points:
+//   - new FormEvolutionEngine({ forms, options })
+//   - engine.evaluate(unitState, vcSnapshot) → eligibility report
+//   - engine.evolve(unitState, targetFormId, options) → mutated state + delta
+//   - engine.options(unitState, vcSnapshot) → sorted candidates
+//
+// Unit state shape (minimal):
+//   {
+//     id, current_form_id?, pe?, last_evolve_round?, evolve_count?,
+//   }
+//
+// VC snapshot shape (matches personalityProjection.projectForm input):
+//   { mbti_axes: { E_I:{value}, S_N:{value}, T_F:{value}, J_P:{value} } }
+//
+// Deterministic + side-effect-free for `evaluate`/`options`; `evolve` mutates
+// the passed unit state in place (and returns it for chaining).
+
+'use strict';
+
+const { loadForms, projectForm } = require('../personalityProjection');
+
+const DEFAULT_OPTIONS = {
+  // Minimum confidence (from projectForm) to consider a form eligible.
+  confidenceThreshold: 0.55,
+  // PE cost deducted on evolve.
+  peCost: 8,
+  // Cooldown measured in rounds.
+  cooldownRounds: 3,
+  // Max evolve hops per unit per campaign (null = unlimited).
+  maxEvolutions: null,
+  // Whether to allow re-picking the current form (no-op evolve). Default false.
+  allowSameForm: false,
+};
+
+function clamp(n, min, max) {
+  return Math.max(min, Math.min(max, n));
+}
+
+class FormEvolutionEngine {
+  constructor({ forms = null, options = {} } = {}) {
+    this.forms = forms || loadForms();
+    this.options = { ...DEFAULT_OPTIONS, ...options };
+  }
+
+  /**
+   * Evaluate whether `unit` can evolve into `targetFormId` given its VC
+   * snapshot. Returns a structured report (never throws on missing data).
+   */
+  evaluate(unit, vcSnapshot, targetFormId, { currentRound = 0, extraPe = 0 } = {}) {
+    const reasons = [];
+    const form = this.forms?.forms?.[targetFormId];
+    if (!form) {
+      return {
+        eligible: false,
+        target_form_id: targetFormId,
+        reasons: ['form_not_found'],
+        projection: null,
+      };
+    }
+
+    const projection = projectForm(vcSnapshot?.mbti_axes || {}, this.forms);
+    const distanceToTarget = projection
+      ? this._distanceToForm(vcSnapshot?.mbti_axes || {}, form.axes || {})
+      : null;
+    const confidenceToTarget =
+      distanceToTarget !== null ? Math.max(0, 1 - distanceToTarget / 2) : 0;
+
+    // Rule 1 — confidence threshold.
+    if (confidenceToTarget < this.options.confidenceThreshold) {
+      reasons.push('confidence_below_threshold');
+    }
+    // Rule 2 — PE cost available.
+    const peAvailable = Number(unit?.pe ?? 0) + Number(extraPe);
+    if (peAvailable < this.options.peCost) {
+      reasons.push('insufficient_pe');
+    }
+    // Rule 3 — cooldown.
+    const lastRound = Number(unit?.last_evolve_round ?? -Infinity);
+    if (currentRound - lastRound < this.options.cooldownRounds) {
+      reasons.push('cooldown_active');
+    }
+    // Rule 4 — not already in target.
+    if (!this.options.allowSameForm && unit?.current_form_id === targetFormId) {
+      reasons.push('already_current_form');
+    }
+    // Rule 5 — max evolutions cap.
+    if (
+      this.options.maxEvolutions !== null &&
+      Number(unit?.evolve_count ?? 0) >= this.options.maxEvolutions
+    ) {
+      reasons.push('max_evolutions_reached');
+    }
+
+    return {
+      eligible: reasons.length === 0,
+      target_form_id: targetFormId,
+      target_label: form.label,
+      target_temperament: form.temperament,
+      projection,
+      confidence_to_target: Math.round(confidenceToTarget * 100) / 100,
+      distance_to_target:
+        distanceToTarget !== null ? Math.round(distanceToTarget * 1000) / 1000 : null,
+      reasons,
+      pe_cost: this.options.peCost,
+      pe_available: peAvailable,
+      cooldown_remaining: Math.max(0, this.options.cooldownRounds - (currentRound - lastRound)),
+    };
+  }
+
+  /**
+   * Return all 16 forms scored + eligibility, sorted descending by confidence.
+   * (Renamed from `options` to avoid clash with the constructor-stored config.)
+   */
+  evaluateAll(unit, vcSnapshot, { currentRound = 0, extraPe = 0 } = {}) {
+    const formEntries = Object.keys(this.forms?.forms || {});
+    const scored = formEntries.map((fid) =>
+      this.evaluate(unit, vcSnapshot, fid, { currentRound, extraPe }),
+    );
+    scored.sort((a, b) => b.confidence_to_target - a.confidence_to_target);
+    return scored;
+  }
+
+  /**
+   * Apply evolution in place. Returns { ok, delta, unit }.
+   * Performs its own eligibility check — on fail returns { ok:false, reason }.
+   */
+  evolve(unit, vcSnapshot, targetFormId, { currentRound = 0, extraPe = 0 } = {}) {
+    const report = this.evaluate(unit, vcSnapshot, targetFormId, { currentRound, extraPe });
+    if (!report.eligible) {
+      return {
+        ok: false,
+        reason: report.reasons[0] || 'unknown',
+        all_reasons: report.reasons,
+        report,
+      };
+    }
+    const oldFormId = unit.current_form_id || null;
+    const peBefore = Number(unit.pe ?? 0);
+    const peAfter = Math.max(0, peBefore - this.options.peCost);
+    unit.current_form_id = targetFormId;
+    unit.pe = peAfter;
+    unit.last_evolve_round = currentRound;
+    unit.evolve_count = Number(unit.evolve_count ?? 0) + 1;
+
+    const formMeta = this.forms.forms[targetFormId];
+    return {
+      ok: true,
+      unit,
+      delta: {
+        old_form_id: oldFormId,
+        new_form_id: targetFormId,
+        pe_before: peBefore,
+        pe_after: peAfter,
+        pe_spent: peBefore - peAfter,
+        round: currentRound,
+        label: formMeta.label,
+        temperament: formMeta.temperament,
+        job_affinities: formMeta.job_affinities || [],
+        job_penalties: formMeta.job_penalties || [],
+      },
+      report,
+    };
+  }
+
+  /** Raw form catalog snapshot (for GET /registry). */
+  snapshot() {
+    const out = [];
+    for (const [id, form] of Object.entries(this.forms?.forms || {})) {
+      out.push({
+        id,
+        label: form.label,
+        description_it: form.description_it,
+        temperament: form.temperament,
+        axes: form.axes,
+        job_affinities: form.job_affinities || [],
+        job_penalties: form.job_penalties || [],
+      });
+    }
+    return { version: this.forms?.version || null, forms: out };
+  }
+
+  getForm(formId) {
+    const form = this.forms?.forms?.[formId];
+    if (!form) return null;
+    return {
+      id: formId,
+      label: form.label,
+      description_it: form.description_it,
+      temperament: form.temperament,
+      axes: form.axes,
+      job_affinities: form.job_affinities || [],
+      job_penalties: form.job_penalties || [],
+    };
+  }
+
+  _distanceToForm(observedAxes, targetAxes) {
+    const keys = ['E_I', 'S_N', 'T_F', 'J_P'];
+    let sumSq = 0;
+    for (const k of keys) {
+      const obs =
+        observedAxes[k] && observedAxes[k].value !== undefined ? observedAxes[k].value : 0.5;
+      const tgt = targetAxes[k] !== undefined ? targetAxes[k] : 0.5;
+      sumSq += (clamp(obs, 0, 1) - clamp(tgt, 0, 1)) ** 2;
+    }
+    return Math.sqrt(sumSq);
+  }
+}
+
+module.exports = {
+  FormEvolutionEngine,
+  DEFAULT_OPTIONS,
+};

--- a/apps/backend/services/pluginLoader.js
+++ b/apps/backend/services/pluginLoader.js
@@ -82,11 +82,22 @@ const jobsPlugin = {
   },
 };
 
+// M12 Phase A — form evolution engine + routes.
+const formsPlugin = {
+  name: 'forms',
+  register(app) {
+    const { createFormsRouter } = require('../routes/forms');
+    const router = createFormsRouter();
+    app.use('/api/v1/forms', router);
+    app.use('/api/forms', router);
+  },
+};
+
 /**
  * Lista plugin built-in. Aggiungere nuovi plugin qui.
  * Ordine = ordine di registrazione.
  */
-const BUILTIN_PLUGINS = [narrativePlugin, metaPlugin, tutorialPlugin, jobsPlugin];
+const BUILTIN_PLUGINS = [narrativePlugin, metaPlugin, tutorialPlugin, jobsPlugin, formsPlugin];
 
 module.exports = {
   loadPlugins,
@@ -95,4 +106,5 @@ module.exports = {
   metaPlugin,
   tutorialPlugin,
   jobsPlugin,
+  formsPlugin,
 };

--- a/docs/adr/ADR-2026-04-23-m12-phase-a-form-evolution.md
+++ b/docs/adr/ADR-2026-04-23-m12-phase-a-form-evolution.md
@@ -1,0 +1,170 @@
+---
+title: 'ADR-2026-04-23: M12 Phase A — Form evolution engine (Pilastro 2)'
+doc_status: active
+doc_owner: platform-docs
+workstream: cross-cutting
+last_verified: 2026-04-23
+source_of_truth: false
+language: it-en
+review_cycle_days: 30
+related:
+  - docs/core/PI-Pacchetti-Forme.md
+  - docs/planning/2026-04-20-pilastri-reality-audit.md
+  - docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md
+---
+
+# ADR-2026-04-23: M12 Phase A — Form evolution engine
+
+- **Data**: 2026-04-23
+- **Stato**: Accepted
+- **Owner**: Backend + Design
+- **Stakeholder**: Pilastro 2 (Evoluzione emergente), Campaign engine (M10), VC scoring (P4)
+
+## Contesto
+
+Pilastro 2 (Evoluzione emergente, Spore-like) era 🔴 all'audit 2026-04-20:
+
+- Dataset shipped completo (84 species + 16 MBTI forms YAML + packs.yaml)
+- Runtime `metaProgression.js` (recruit + mating + nest) — prima leva, ma NON evoluzione
+- Zero form transitions runtime, zero PI spender integrato, zero trigger
+
+M12 big rock (~35h) restava deferred. Dopo chiusura M11 (PR #1682/#1686/#1684/#1685/#1688), M12 Phase A sblocca il primo piede del Pilastro: **state machine di form transition con trigger deterministici**.
+
+Runtime già disponibile:
+
+- `apps/backend/services/personalityProjection.js` — `loadForms` + `projectForm` (closest MBTI) → inferenza form da VC axes
+- `apps/backend/services/metaProgression.js` — in-memory + Prisma fallback (NPC affinity/trust/nest)
+- `data/core/forms/mbti_forms.yaml` — 16 forms con axes target + job_affinities + temperament
+
+**Mancava**: layer che leghi questi pezzi in un **engine evoluzione** con trigger (confidence, PE, cooldown, cap) + endpoint REST.
+
+## Decisione
+
+Implementare `FormEvolutionEngine` (class) come layer sopra `personalityProjection` con 5 regole di gating + 5 endpoint REST. Persistence deferred a M12.B (integrazione con meta/campaign session store).
+
+### Architettura
+
+```
+                          ┌──────────────────────────────┐
+                          │ data/core/forms/mbti_forms   │
+                          │   .yaml (16 forms + NEUTRA)  │
+                          └────────────┬─────────────────┘
+                                       │ loadForms()
+                                       ▼
+ VC snapshot  ───────▶  personalityProjection.projectForm (closest MBTI)
+ (mbti_axes)                       │
+                                   │ axes + forms registry
+                                   ▼
+                        ┌──────────────────────────────────┐
+                        │ FormEvolutionEngine              │
+                        │   evaluate(unit, vc, target)     │
+                        │   evaluateAll(unit, vc)          │
+                        │   evolve(unit, vc, target)       │
+                        │   snapshot() · getForm(id)       │
+                        └────────────┬─────────────────────┘
+                                     │
+                          /api/v1/forms/{registry, :id,
+                                        evaluate, options, evolve}
+                                     │
+                                     ▼
+                              Campaign/session consumer
+                              (M12.B integration)
+```
+
+### 5 regole di gating (default)
+
+| Regola                       | Check                                                                         | Default  |
+| ---------------------------- | ----------------------------------------------------------------------------- | -------- |
+| `form_not_found`             | `targetFormId` esiste in registry                                             | strict   |
+| `confidence_below_threshold` | `1 - euclideanDistance(observedAxes, targetAxes) / 2` ≥ `confidenceThreshold` | **0.55** |
+| `insufficient_pe`            | `unit.pe + extraPe` ≥ `peCost`                                                | **8 PE** |
+| `cooldown_active`            | `currentRound - unit.last_evolve_round` ≥ `cooldownRounds`                    | **3**    |
+| `already_current_form`       | `unit.current_form_id !== targetFormId` (bypass via `allowSameForm: true`)    | strict   |
+| `max_evolutions_reached`     | `unit.evolve_count < maxEvolutions` (solo se `maxEvolutions !== null`)        | disabled |
+
+Tutte configurabili via `new FormEvolutionEngine({ options: {...} })`.
+
+### Protocollo REST
+
+| Method | Path                     | Input                                        | Output                                         |
+| ------ | ------------------------ | -------------------------------------------- | ---------------------------------------------- |
+| GET    | `/api/v1/forms/registry` | —                                            | `{ version, forms: [...] }`                    |
+| GET    | `/api/v1/forms/:id`      | —                                            | form detail · 404 se unknown                   |
+| POST   | `/api/v1/forms/evaluate` | `{ unit, vc_snapshot, target_form_id, ... }` | eligibility report                             |
+| POST   | `/api/v1/forms/options`  | `{ unit, vc_snapshot, ... }`                 | `{ options: scored[] }` sorted desc confidence |
+| POST   | `/api/v1/forms/evolve`   | `{ unit, vc_snapshot, target_form_id, ... }` | `{ ok, unit, delta, report }` · 409 se fail    |
+
+Mount su **sia** `/api/v1/forms` sia `/api/forms` (backward-compat con convention meta/tutorial/jobs).
+
+### Opzioni valutate
+
+#### A. FormEvolutionEngine class + plugin loader ← SCELTA
+
+- **Pro**: zero nuove deps, riuso `personalityProjection`, separazione clean stato/trigger, test unit + integration facili
+- **Pro**: ownership clear: engine pure / routes thin / persistence deferred
+- **Contro**: stato unit è caller-supplied → M12.B deve orchestrare chi lo chiama e persiste (session store?)
+
+#### B. Trait-like plugin diretto su session.js
+
+- **Pro**: integration nativa con combat loop
+- **Contro**: session.js già 851 LOC + guardrail CLAUDE.md "non toccare senza segnalare". Blast radius alto, DoD complesso.
+- Rigettato.
+
+#### C. Dataset YAML extension + applica via Flow pipeline
+
+- **Pro**: fit con Flow generation
+- **Contro**: Flow genera pre-session blueprint, NON evoluzione runtime emergente. Missing a point.
+- Rigettato — confonderebbe dataset con runtime, stesso pattern identificato nell'audit.
+
+## Conseguenze
+
+### Positive
+
+- **Pilastro 2 gap ridotto**: 🔴 → 🟡 per Phase A (runtime engine + endpoint). M12.B sblocca 🟢 chiudendo persistence + integration.
+- **Zero deps**: engine riusa `js-yaml` + `personalityProjection` esistenti.
+- **Test coverage**: 25 test nuovi (16 unit + 9 route) senza regressioni.
+- **Endpoint contract stabile**: 5 endpoint testati + documentati.
+- **Configurabile**: ogni soglia/cost/cooldown via options → facilita balance tuning senza code changes.
+
+### Negative
+
+- **Persistence assente**: unit state caller-supplied. M12.B deve decidere dove vive (session engine? meta store? campaign Prisma?).
+- **Integrazione VC/PE pending**: PE cost oggi è caller-supplied; M12.B integra con economia PI pack + campaign ledger.
+- **Cooldown in rounds, non in time**: dipende dal caller sapere `currentRound`. Semplice ma accoppia engine al round loop.
+- **Max evolutions disabled default**: design choice da confermare — senza cap, un'unità può hoppare liberamente se PE+axes lo permettono.
+
+### Rollback
+
+- Plugin removal: rimuovere `formsPlugin` da `BUILTIN_PLUGINS` in `pluginLoader.js` → endpoint non esposti.
+- Revert PR: engine + routes + tests rimossi, nessun impatto runtime (non chiamato da altre parti).
+
+## Scope Phase A (questo PR)
+
+- `apps/backend/services/forms/formEvolution.js` (~200 LOC): `FormEvolutionEngine` class
+- `apps/backend/routes/forms.js` (~100 LOC): 5 endpoint
+- `apps/backend/services/pluginLoader.js`: +`formsPlugin` in `BUILTIN_PLUGINS`
+- Tests: `tests/api/formEvolution.test.js` (16 unit) + `tests/api/formsRoutes.test.js` (9 integration)
+
+**Totale nuovi test**: **25/25** pass. Baseline AI 307/307 + lobby 26/26 intatti.
+
+## Fuori scope Phase A (M12.B next sprint, ~12h)
+
+- Persistence: salvare `current_form_id + pe + last_evolve_round + evolve_count` in session/campaign store
+- PI pack spender: integrare `data/packs.yaml` cost system (trait_T1/T2/T3, job_ability, sigillo_forma) con il flusso evolve
+- Integration campaign engine: trigger `evolve` al `campaign/advance` node boundary
+- UX frontend: pannello evoluzione in `apps/play/src/` (form select + preview deltas + PE balance)
+
+## Fuori scope Phase C+ (deferred)
+
+- Visual feedback (anim transition, form sprite swap)
+- Trait acquisition via pack roll durante evolve (Wesnoth advancement pattern)
+- Multi-step evolution path (prerequisiti form → form)
+- Balance tuning via calibration harness
+
+## Riferimenti
+
+- Canvas B design canonical: [`docs/core/PI-Pacchetti-Forme.md`](../core/PI-Pacchetti-Forme.md)
+- MBTI forms YAML: `data/core/forms/mbti_forms.yaml` (16 types + NEUTRA fallback)
+- Pilastri audit: [`docs/planning/2026-04-20-pilastri-reality-audit.md`](../planning/2026-04-20-pilastri-reality-audit.md)
+- Strategy M9-M11: [`docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md`](../planning/2026-04-20-strategy-m9-m11-evidence-based.md)
+- personalityProjection impl: `apps/backend/services/personalityProjection.js`

--- a/tests/api/formEvolution.test.js
+++ b/tests/api/formEvolution.test.js
@@ -1,0 +1,237 @@
+// M12 Phase A — FormEvolutionEngine unit tests.
+// ADR-2026-04-23-m12-phase-a.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { FormEvolutionEngine } = require('../../apps/backend/services/forms/formEvolution');
+
+function vcAxes({ E_I = 0.5, S_N = 0.5, T_F = 0.5, J_P = 0.5 } = {}) {
+  return {
+    mbti_axes: {
+      E_I: { value: E_I },
+      S_N: { value: S_N },
+      T_F: { value: T_F },
+      J_P: { value: J_P },
+    },
+  };
+}
+
+// Baseline — registry loads all 16 MBTI forms (+ NEUTRA if present in YAML).
+test('FormEvolutionEngine.snapshot lists 16 forms with metadata', () => {
+  const engine = new FormEvolutionEngine();
+  const snap = engine.snapshot();
+  assert.ok(snap.forms.length >= 16, `expected >=16 forms, got ${snap.forms.length}`);
+  for (const f of snap.forms) {
+    assert.ok(f.id, 'form has id');
+    assert.ok(f.label, `form ${f.id} has label`);
+    assert.ok(['NT', 'NF', 'SJ', 'SP'].includes(f.temperament), `form ${f.id} temperament valid`);
+    assert.ok(f.axes && typeof f.axes.E_I === 'number', `form ${f.id} axes present`);
+  }
+});
+
+test('FormEvolutionEngine.getForm returns form or null', () => {
+  const engine = new FormEvolutionEngine();
+  assert.equal(engine.getForm('INTJ').id, 'INTJ');
+  assert.equal(engine.getForm('NOPE'), null);
+});
+
+// Evaluate — confidence threshold + PE + cooldown + same-form guards.
+test('evaluate: eligible when axes match INTJ and PE sufficient', () => {
+  const engine = new FormEvolutionEngine();
+  const unit = { id: 'u1', pe: 10, current_form_id: null };
+  const report = engine.evaluate(
+    unit,
+    vcAxes({ E_I: 0.75, S_N: 0.35, T_F: 0.8, J_P: 0.75 }),
+    'INTJ',
+  );
+  assert.equal(report.eligible, true, `reasons=${report.reasons.join(',')}`);
+  assert.equal(report.target_form_id, 'INTJ');
+  assert.ok(report.confidence_to_target >= 0.55);
+  assert.equal(report.pe_cost, 8);
+});
+
+test('evaluate: insufficient_pe when PE < cost', () => {
+  const engine = new FormEvolutionEngine();
+  const unit = { id: 'u1', pe: 3, current_form_id: null };
+  const report = engine.evaluate(
+    unit,
+    vcAxes({ E_I: 0.75, S_N: 0.35, T_F: 0.8, J_P: 0.75 }),
+    'INTJ',
+  );
+  assert.equal(report.eligible, false);
+  assert.ok(report.reasons.includes('insufficient_pe'));
+});
+
+test('evaluate: confidence_below_threshold when axes far from target', () => {
+  const engine = new FormEvolutionEngine();
+  // ESFP axes: E_I:0.3, S_N:0.75, T_F:0.3, J_P:0.3 — very far from INTJ.
+  const unit = { id: 'u1', pe: 20, current_form_id: null };
+  const report = engine.evaluate(unit, vcAxes({ E_I: 0.3, S_N: 0.75, T_F: 0.3, J_P: 0.3 }), 'INTJ');
+  assert.equal(report.eligible, false);
+  assert.ok(report.reasons.includes('confidence_below_threshold'));
+});
+
+test('evaluate: cooldown_active when last_evolve_round within cooldownRounds', () => {
+  const engine = new FormEvolutionEngine();
+  const unit = {
+    id: 'u1',
+    pe: 20,
+    current_form_id: null,
+    last_evolve_round: 5,
+  };
+  const report = engine.evaluate(
+    unit,
+    vcAxes({ E_I: 0.75, S_N: 0.35, T_F: 0.8, J_P: 0.75 }),
+    'INTJ',
+    { currentRound: 6 }, // only 1 round gap, cooldownRounds=3
+  );
+  assert.equal(report.eligible, false);
+  assert.ok(report.reasons.includes('cooldown_active'));
+  assert.ok(report.cooldown_remaining > 0);
+});
+
+test('evaluate: already_current_form when unit already in target', () => {
+  const engine = new FormEvolutionEngine();
+  const unit = { id: 'u1', pe: 20, current_form_id: 'INTJ' };
+  const report = engine.evaluate(
+    unit,
+    vcAxes({ E_I: 0.75, S_N: 0.35, T_F: 0.8, J_P: 0.75 }),
+    'INTJ',
+  );
+  assert.equal(report.eligible, false);
+  assert.ok(report.reasons.includes('already_current_form'));
+});
+
+test('evaluate: form_not_found for unknown targetFormId', () => {
+  const engine = new FormEvolutionEngine();
+  const unit = { id: 'u1', pe: 20, current_form_id: null };
+  const report = engine.evaluate(unit, vcAxes(), 'ZZZZ');
+  assert.equal(report.eligible, false);
+  assert.ok(report.reasons.includes('form_not_found'));
+});
+
+test('evaluate: max_evolutions_reached when cap hit', () => {
+  const engine = new FormEvolutionEngine({ options: { maxEvolutions: 2 } });
+  const unit = {
+    id: 'u1',
+    pe: 20,
+    current_form_id: 'ESFP',
+    evolve_count: 2,
+  };
+  const report = engine.evaluate(
+    unit,
+    vcAxes({ E_I: 0.75, S_N: 0.35, T_F: 0.8, J_P: 0.75 }),
+    'INTJ',
+  );
+  assert.equal(report.eligible, false);
+  assert.ok(report.reasons.includes('max_evolutions_reached'));
+});
+
+// Options — sorted list for UI.
+test('options: returns all forms sorted by confidence desc', () => {
+  const engine = new FormEvolutionEngine();
+  const unit = { id: 'u1', pe: 20, current_form_id: null };
+  const scored = engine.evaluateAll(unit, vcAxes({ E_I: 0.75, S_N: 0.35, T_F: 0.8, J_P: 0.75 }));
+  assert.ok(scored.length >= 16);
+  // Top candidate: INTJ expected.
+  assert.equal(scored[0].target_form_id, 'INTJ');
+  // Monotonic non-increasing confidence.
+  for (let i = 1; i < scored.length; i += 1) {
+    assert.ok(
+      scored[i].confidence_to_target <= scored[i - 1].confidence_to_target,
+      `order violation at ${i}`,
+    );
+  }
+});
+
+// Evolve — state mutation + deltas.
+test('evolve: success mutates unit + returns delta with pe_spent', () => {
+  const engine = new FormEvolutionEngine();
+  const unit = { id: 'u1', pe: 10, current_form_id: null, evolve_count: 0 };
+  const result = engine.evolve(
+    unit,
+    vcAxes({ E_I: 0.75, S_N: 0.35, T_F: 0.8, J_P: 0.75 }),
+    'INTJ',
+    { currentRound: 4 },
+  );
+  assert.equal(result.ok, true, `reason=${result.reason}`);
+  assert.equal(unit.current_form_id, 'INTJ');
+  assert.equal(unit.pe, 2);
+  assert.equal(unit.last_evolve_round, 4);
+  assert.equal(unit.evolve_count, 1);
+  assert.equal(result.delta.pe_spent, 8);
+  assert.equal(result.delta.old_form_id, null);
+  assert.equal(result.delta.new_form_id, 'INTJ');
+  assert.equal(result.delta.label, 'Stratega');
+});
+
+test('evolve: failure preserves unit state', () => {
+  const engine = new FormEvolutionEngine();
+  const unit = { id: 'u1', pe: 3, current_form_id: 'ESFP' };
+  const before = { ...unit };
+  const result = engine.evolve(unit, vcAxes(), 'INTJ');
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'insufficient_pe');
+  assert.deepEqual(unit, before);
+});
+
+test('evolve: chained evolutions respect cooldown', () => {
+  const engine = new FormEvolutionEngine();
+  const unit = { id: 'u1', pe: 20, current_form_id: null };
+  // First evolve at round 1.
+  const r1 = engine.evolve(unit, vcAxes({ E_I: 0.75, S_N: 0.35, T_F: 0.8, J_P: 0.75 }), 'INTJ', {
+    currentRound: 1,
+  });
+  assert.equal(r1.ok, true);
+  // Attempt another at round 2 (cooldown=3 → fails).
+  const r2 = engine.evolve(unit, vcAxes({ E_I: 0.3, S_N: 0.3, T_F: 0.3, J_P: 0.3 }), 'ENFP', {
+    currentRound: 2,
+  });
+  assert.equal(r2.ok, false);
+  assert.equal(r2.reason, 'cooldown_active');
+  // Retry at round 5 (gap=4 ≥ 3).
+  const r3 = engine.evolve(unit, vcAxes({ E_I: 0.3, S_N: 0.25, T_F: 0.3, J_P: 0.25 }), 'ENFP', {
+    currentRound: 5,
+  });
+  assert.equal(r3.ok, true);
+  assert.equal(unit.current_form_id, 'ENFP');
+  assert.equal(unit.evolve_count, 2);
+});
+
+// Option overrides — custom engine config.
+test('engine honors custom options.peCost + options.cooldownRounds', () => {
+  const engine = new FormEvolutionEngine({
+    options: { peCost: 4, cooldownRounds: 0 },
+  });
+  const unit = { id: 'u1', pe: 5, current_form_id: null };
+  const result = engine.evolve(unit, vcAxes({ E_I: 0.75, S_N: 0.35, T_F: 0.8, J_P: 0.75 }), 'INTJ');
+  assert.equal(result.ok, true);
+  assert.equal(result.delta.pe_spent, 4);
+});
+
+test('engine allowSameForm option bypasses already_current_form', () => {
+  const engine = new FormEvolutionEngine({ options: { allowSameForm: true } });
+  const unit = { id: 'u1', pe: 20, current_form_id: 'INTJ' };
+  const report = engine.evaluate(
+    unit,
+    vcAxes({ E_I: 0.75, S_N: 0.35, T_F: 0.8, J_P: 0.75 }),
+    'INTJ',
+  );
+  assert.ok(!report.reasons.includes('already_current_form'));
+});
+
+test('extraPe parameter unlocks evolution when unit.pe insufficient', () => {
+  const engine = new FormEvolutionEngine();
+  const unit = { id: 'u1', pe: 3, current_form_id: null };
+  const report = engine.evaluate(
+    unit,
+    vcAxes({ E_I: 0.75, S_N: 0.35, T_F: 0.8, J_P: 0.75 }),
+    'INTJ',
+    { extraPe: 10 },
+  );
+  assert.equal(report.eligible, true);
+  assert.equal(report.pe_available, 13);
+});

--- a/tests/api/formsRoutes.test.js
+++ b/tests/api/formsRoutes.test.js
@@ -1,0 +1,177 @@
+// M12 Phase A — Forms REST route contract tests.
+// ADR-2026-04-23-m12-phase-a.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+test('GET /api/v1/forms/registry lists all MBTI forms', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app).get('/api/v1/forms/registry').expect(200);
+    assert.ok(Array.isArray(res.body.forms));
+    assert.ok(res.body.forms.length >= 16);
+    const intj = res.body.forms.find((f) => f.id === 'INTJ');
+    assert.ok(intj, 'INTJ present');
+    assert.equal(intj.label, 'Stratega');
+    assert.equal(intj.temperament, 'NT');
+  } finally {
+    await close();
+  }
+});
+
+test('GET /api/forms/:id returns single form detail', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app).get('/api/forms/INTJ').expect(200);
+    assert.equal(res.body.id, 'INTJ');
+    assert.ok(res.body.axes);
+    assert.ok(Array.isArray(res.body.job_affinities));
+  } finally {
+    await close();
+  }
+});
+
+test('GET /api/forms/:id returns 404 for unknown id', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app).get('/api/forms/ZZZZ').expect(404);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/v1/forms/evaluate returns eligibility report', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app)
+      .post('/api/v1/forms/evaluate')
+      .send({
+        unit: { id: 'u1', pe: 10, current_form_id: null },
+        vc_snapshot: {
+          mbti_axes: {
+            E_I: { value: 0.75 },
+            S_N: { value: 0.35 },
+            T_F: { value: 0.8 },
+            J_P: { value: 0.75 },
+          },
+        },
+        target_form_id: 'INTJ',
+        current_round: 0,
+      })
+      .expect(200);
+    assert.equal(res.body.eligible, true);
+    assert.equal(res.body.target_form_id, 'INTJ');
+    assert.equal(res.body.pe_cost, 8);
+    assert.equal(res.body.pe_available, 10);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/forms/evaluate rejects missing unit', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app)
+      .post('/api/forms/evaluate')
+      .send({ target_form_id: 'INTJ' })
+      .expect(400);
+    assert.match(res.body.error, /unit/);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/v1/forms/options returns scored sorted list', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app)
+      .post('/api/v1/forms/options')
+      .send({
+        unit: { id: 'u1', pe: 20, current_form_id: null },
+        vc_snapshot: {
+          mbti_axes: {
+            E_I: { value: 0.75 },
+            S_N: { value: 0.35 },
+            T_F: { value: 0.8 },
+            J_P: { value: 0.75 },
+          },
+        },
+      })
+      .expect(200);
+    assert.ok(Array.isArray(res.body.options));
+    assert.ok(res.body.options.length >= 16);
+    assert.equal(res.body.options[0].target_form_id, 'INTJ');
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/v1/forms/evolve mutates + returns delta', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app)
+      .post('/api/v1/forms/evolve')
+      .send({
+        unit: { id: 'u1', pe: 10, current_form_id: null, evolve_count: 0 },
+        vc_snapshot: {
+          mbti_axes: {
+            E_I: { value: 0.75 },
+            S_N: { value: 0.35 },
+            T_F: { value: 0.8 },
+            J_P: { value: 0.75 },
+          },
+        },
+        target_form_id: 'INTJ',
+        current_round: 3,
+      })
+      .expect(200);
+    assert.equal(res.body.ok, true);
+    assert.equal(res.body.unit.current_form_id, 'INTJ');
+    assert.equal(res.body.unit.pe, 2);
+    assert.equal(res.body.delta.pe_spent, 8);
+    assert.equal(res.body.delta.new_form_id, 'INTJ');
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/v1/forms/evolve returns 409 when ineligible', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app)
+      .post('/api/v1/forms/evolve')
+      .send({
+        unit: { id: 'u1', pe: 2, current_form_id: null },
+        vc_snapshot: {
+          mbti_axes: {
+            E_I: { value: 0.75 },
+            S_N: { value: 0.35 },
+            T_F: { value: 0.8 },
+            J_P: { value: 0.75 },
+          },
+        },
+        target_form_id: 'INTJ',
+      })
+      .expect(409);
+    assert.equal(res.body.ok, false);
+    assert.equal(res.body.reason, 'insufficient_pe');
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/v1/forms/evolve 400 on missing target_form_id', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app)
+      .post('/api/v1/forms/evolve')
+      .send({ unit: { id: 'u1', pe: 10 } })
+      .expect(400);
+  } finally {
+    await close();
+  }
+});


### PR DESCRIPTION
## Summary

Sblocca il primo piede runtime del **Pilastro 2 (Evoluzione emergente)** dopo chiusura M11 full stack. Layer state machine sopra `personalityProjection` con 5 regole di gating + 5 endpoint REST. Persistence deferred a M12.B.

**Pilastro 2 status**: 🔴 → **🟡** (engine live, persistence deferred).

## Design

```
data/core/forms/mbti_forms.yaml  →  personalityProjection.projectForm
                                             │
                                             ▼
                                   FormEvolutionEngine
                                  ┌──────────────────┐
                                  │ evaluate · evolve │
                                  │ evaluateAll       │
                                  │ snapshot · getForm│
                                  └─────────┬────────┘
                                            │
                        /api/v1/forms/{registry, :id, evaluate, options, evolve}
```

## Regole di gating

| Regola | Default | Configurabile |
|---|---|---|
| `form_not_found` | strict | — |
| `confidence_below_threshold` | **0.55** | `options.confidenceThreshold` |
| `insufficient_pe` | **8 PE** | `options.peCost` + `extraPe` param |
| `cooldown_active` | **3 rounds** | `options.cooldownRounds` |
| `already_current_form` | strict | `options.allowSameForm: true` |
| `max_evolutions_reached` | disabled | `options.maxEvolutions: N` |

## Files

| File | LOC | Ruolo |
|---|---|---|
| `apps/backend/services/forms/formEvolution.js` | ~200 | `FormEvolutionEngine` class |
| `apps/backend/routes/forms.js` | ~100 | 5 endpoint REST |
| `apps/backend/services/pluginLoader.js` | +14 | `formsPlugin` in `BUILTIN_PLUGINS` |
| `tests/api/formEvolution.test.js` | +230 | 16 unit test |
| `tests/api/formsRoutes.test.js` | +170 | 9 route integration test |
| `docs/adr/ADR-2026-04-23-m12-phase-a-form-evolution.md` | — | Accepted ADR |

## Test plan

- [x] `node --test tests/api/formEvolution.test.js` → **16/16 pass**
- [x] `node --test tests/api/formsRoutes.test.js` → **9/9 pass**
- [x] `node --test tests/ai/*.test.js` → **307/307 pass** (baseline)
- [x] `node --test tests/api/lobbyRoutes.test.js tests/api/lobbyWebSocket.test.js tests/e2e/lobbyEndToEnd.test.mjs` → **26/26 pass** (lobby baseline)
- [x] **Totale: 358/358**
- [x] `npm run format:check` → verde

## Protocollo esempio

```http
POST /api/v1/forms/evolve
Content-Type: application/json

{
  "unit": {"id": "u1", "pe": 10, "current_form_id": null, "evolve_count": 0},
  "vc_snapshot": {
    "mbti_axes": {
      "E_I": {"value": 0.75}, "S_N": {"value": 0.35},
      "T_F": {"value": 0.8}, "J_P": {"value": 0.75}
    }
  },
  "target_form_id": "INTJ",
  "current_round": 3
}
```

200: `{ ok, unit (mutated), delta: { pe_spent, old/new form_id, label, temperament, ... }, report }`
409: `{ ok: false, reason, all_reasons, report }` (eligibility fail)

## Rollback

Remove `formsPlugin` from `BUILTIN_PLUGINS` → endpoint non esposti. Revert PR: zero impact runtime (nessun caller).

## Fuori scope Phase A

M12.B next sprint (~12h):
- Persistence: salvare `current_form_id + pe + last_evolve_round + evolve_count` in session/campaign store
- PI pack spender: integrare `data/packs.yaml` (trait_T1/T2/T3, job_ability, sigillo_forma)
- Campaign trigger a node boundary
- Frontend UI (pannello evoluzione in `apps/play/src/`)

## Links

- ADR: [`docs/adr/ADR-2026-04-23-m12-phase-a-form-evolution.md`](docs/adr/ADR-2026-04-23-m12-phase-a-form-evolution.md)
- Canvas B design: [`docs/core/PI-Pacchetti-Forme.md`](docs/core/PI-Pacchetti-Forme.md)
- Pilastri audit: [`docs/planning/2026-04-20-pilastri-reality-audit.md`](docs/planning/2026-04-20-pilastri-reality-audit.md)
- Strategy M9-M11: [`docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md`](docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)