### PR TITLE
feat(forms): M12 Phase B — session persistence + PI pack roller

### DIFF
--- a/apps/backend/routes/forms.js
+++ b/apps/backend/routes/forms.js
@@ -1,22 +1,31 @@
-// M12 Phase A — Forms routes.
+// M12 Phase A+B — Forms routes.
 //
-// Endpoints:
-//   GET  /api/v1/forms/registry           — list all 16 MBTI forms + metadata
-//   GET  /api/v1/forms/:id                — single form detail
-//   POST /api/v1/forms/evaluate           — eligibility for a target form
-//   POST /api/v1/forms/options            — scored list of all forms for a unit
-//   POST /api/v1/forms/evolve             — execute transition (mutates unit state)
+// Phase A endpoints (stateless, caller-supplied unit):
+//   GET  /api/v1/forms/registry
+//   GET  /api/v1/forms/:id
+//   POST /api/v1/forms/evaluate
+//   POST /api/v1/forms/options
+//   POST /api/v1/forms/evolve
 //
-// NOTE: routes operate on a caller-supplied unit snapshot. Persistence is
-// deferred to M12.B (integration with meta progression / session store).
+// Phase B endpoints (session-scoped persistence + pack roll):
+//   GET  /api/v1/forms/session/:sid               — list unit states for session
+//   GET  /api/v1/forms/session/:sid/:unitId       — single unit state
+//   POST /api/v1/forms/session/:sid/:unitId/seed  — init unit state
+//   POST /api/v1/forms/session/:sid/:unitId/evolve — evolve + persist + deduct PE
+//   POST /api/v1/forms/pack/roll                  — roll pack (optional d20 seed)
+//   DELETE /api/v1/forms/session/:sid             — clear session scope
 
 'use strict';
 
 const { Router } = require('express');
 const { FormEvolutionEngine } = require('../services/forms/formEvolution');
+const { createFormSessionStore } = require('../services/forms/formSessionStore');
+const { loadPacks, rollPack, seededRng } = require('../services/forms/packRoller');
 
 function createFormsRouter(opts = {}) {
   const engine = opts.engine || new FormEvolutionEngine(opts);
+  const store = opts.store || createFormSessionStore({ prisma: opts.prisma || null });
+  const packs = opts.packs || loadPacks();
   const router = Router();
 
   router.get('/registry', (_req, res) => {
@@ -92,6 +101,94 @@ function createFormsRouter(opts = {}) {
       return res.status(409).json(result);
     }
     res.json(result);
+  });
+
+  // ========================================================================
+  // Phase B — session-scoped persistence routes
+  // ========================================================================
+
+  router.get('/session/:sid', (req, res) => {
+    const units = store.listSession(req.params.sid);
+    res.json({ session_id: req.params.sid, units });
+  });
+
+  router.get('/session/:sid/:unitId', (req, res) => {
+    const state = store.getUnitState(req.params.sid, req.params.unitId);
+    if (!state) return res.status(404).json({ error: 'unit_state_not_found' });
+    res.json(state);
+  });
+
+  router.post('/session/:sid/:unitId/seed', (req, res) => {
+    try {
+      const state = store.seedUnit(req.params.sid, req.params.unitId, req.body || {});
+      res.status(201).json(state);
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
+  router.delete('/session/:sid', (req, res) => {
+    const removed = store.clearSession(req.params.sid);
+    res.json({ session_id: req.params.sid, removed });
+  });
+
+  router.post('/session/:sid/:unitId/evolve', (req, res) => {
+    const sid = req.params.sid;
+    const unitId = req.params.unitId;
+    const {
+      vc_snapshot: vcSnapshot,
+      target_form_id: targetFormId,
+      current_round: currentRound = 0,
+      extra_pe: extraPe = 0,
+      seed_pe: seedPe = null,
+    } = req.body || {};
+    if (!targetFormId) return res.status(400).json({ error: 'target_form_id required' });
+
+    let state = store.getUnitState(sid, unitId);
+    if (!state) {
+      state = store.seedUnit(sid, unitId, {
+        current_form_id: null,
+        pe: Number.isFinite(seedPe) ? seedPe : 0,
+      });
+    }
+    // Build engine-compatible unit snapshot.
+    const unitSnapshot = {
+      id: unitId,
+      current_form_id: state.current_form_id,
+      pe: state.pe,
+      last_evolve_round: state.last_evolve_round,
+      evolve_count: state.evolve_count,
+    };
+    const result = engine.evolve(unitSnapshot, vcSnapshot || {}, targetFormId, {
+      currentRound: Number(currentRound) || 0,
+      extraPe: Number(extraPe) || 0,
+    });
+    if (!result.ok) return res.status(409).json(result);
+    const persisted = store.applyDelta(sid, unitId, result.delta);
+    res.json({ ok: true, state: persisted, delta: result.delta, report: result.report });
+  });
+
+  // ========================================================================
+  // Phase B — pack roll (data/packs.yaml)
+  // ========================================================================
+
+  router.post('/pack/roll', (req, res) => {
+    const { form_id: formId = null, job_id: jobId = null, seed = null } = req.body || {};
+    const rng = typeof seed === 'number' && Number.isFinite(seed) ? seededRng(seed) : Math.random;
+    try {
+      const result = rollPack({ packs, formId, jobId, rng });
+      res.json(result);
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  router.get('/pack/costs', (_req, res) => {
+    res.json({
+      costs: packs.pi_shop?.costs || {},
+      caps: packs.pi_shop?.caps || {},
+      budget_curve: packs.pi_shop?.budget_curve || {},
+    });
   });
 
   return router;

--- a/apps/backend/services/forms/formSessionStore.js
+++ b/apps/backend/services/forms/formSessionStore.js
@@ -1,0 +1,121 @@
+// M12 Phase B — In-memory session store for form evolution state.
+// ADR-2026-04-23-m12-phase-a (Phase B extension).
+//
+// Scopes unit form state per session_id so that /api/v1/forms/session/:sid/*
+// endpoints can read/write without piggybacking on session.js (guardrail:
+// session.js is size-sensitive + owner-locked).
+//
+// Storage shape: Map<`${sessionId}:${unitId}`, unitState>
+//   unitState = { current_form_id, pe, last_evolve_round, evolve_count, last_delta?, updated_at }
+//
+// Prisma adapter: constructor accepts `{ prisma }` for future persistence.
+// Phase B ships in-memory only; Phase C wires a Prisma table if deploy needs it.
+
+'use strict';
+
+function makeKey(sessionId, unitId) {
+  return `${sessionId}:${unitId}`;
+}
+
+function createFormSessionStore({ prisma = null } = {}) {
+  const states = new Map();
+  const prismaBackend = prisma || null; // reserved for Phase C
+
+  function getUnitState(sessionId, unitId) {
+    if (!sessionId || !unitId) return null;
+    const state = states.get(makeKey(sessionId, unitId));
+    return state ? { ...state } : null;
+  }
+
+  function setUnitState(sessionId, unitId, patch) {
+    if (!sessionId || !unitId) {
+      throw new Error('session_id + unit_id required');
+    }
+    const key = makeKey(sessionId, unitId);
+    const prev = states.get(key) || {
+      id: unitId,
+      current_form_id: null,
+      pe: 0,
+      last_evolve_round: null,
+      evolve_count: 0,
+    };
+    const next = {
+      ...prev,
+      ...patch,
+      id: unitId,
+      updated_at: Date.now(),
+    };
+    states.set(key, next);
+    return { ...next };
+  }
+
+  function seedUnit(sessionId, unitId, seed = {}) {
+    const patch = {
+      current_form_id: seed.current_form_id ?? null,
+      pe: Number.isFinite(seed.pe) ? seed.pe : 0,
+      last_evolve_round: seed.last_evolve_round ?? null,
+      evolve_count: seed.evolve_count ?? 0,
+    };
+    return setUnitState(sessionId, unitId, patch);
+  }
+
+  function applyDelta(sessionId, unitId, delta) {
+    if (!delta || typeof delta !== 'object') {
+      throw new Error('delta object required');
+    }
+    const current = getUnitState(sessionId, unitId) || seedUnit(sessionId, unitId);
+    const patch = {
+      current_form_id: delta.new_form_id ?? current.current_form_id,
+      pe: delta.pe_after !== undefined ? delta.pe_after : current.pe,
+      last_evolve_round: delta.round ?? current.last_evolve_round,
+      evolve_count: Number(current.evolve_count ?? 0) + 1,
+      last_delta: delta,
+    };
+    return setUnitState(sessionId, unitId, patch);
+  }
+
+  function listSession(sessionId) {
+    const out = [];
+    const prefix = `${sessionId}:`;
+    for (const [key, val] of states.entries()) {
+      if (key.startsWith(prefix)) out.push({ ...val });
+    }
+    return out;
+  }
+
+  function clearSession(sessionId) {
+    const prefix = `${sessionId}:`;
+    let removed = 0;
+    for (const key of Array.from(states.keys())) {
+      if (key.startsWith(prefix)) {
+        states.delete(key);
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
+  function clearAll() {
+    const n = states.size;
+    states.clear();
+    return n;
+  }
+
+  function size() {
+    return states.size;
+  }
+
+  return {
+    getUnitState,
+    setUnitState,
+    seedUnit,
+    applyDelta,
+    listSession,
+    clearSession,
+    clearAll,
+    size,
+    _prisma: prismaBackend, // reserved
+  };
+}
+
+module.exports = { createFormSessionStore };

--- a/apps/backend/services/forms/packRoller.js
+++ b/apps/backend/services/forms/packRoller.js
@@ -1,0 +1,184 @@
+// M12 Phase B — PI pack roller.
+// ADR-2026-04-23-m12-phase-a (Phase B extension).
+//
+// Loads data/packs.yaml and rolls a pack using:
+//   1. d20 general table (1-10 standard, 11-15 alt, 16-17 BIAS_FORMA, 18-19 BIAS_JOB, 20 SCELTA)
+//   2. d12 form-specific bias table when BIAS_FORMA hits
+//   3. job_bias[jobId] 2-pack rotation when BIAS_JOB hits
+//
+// RNG: caller supplies `rng()` or uses `Math.random`. Deterministic when seeded.
+// Returns { pack_key, combo, source, dice: { d20, d12? }, formId?, jobId? }
+//
+// Cost computation: sum pi_shop.costs[item] across combo (ignoring `PE` entries
+// which are literal rewards, not costs).
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const DEFAULT_PACKS_PATH = path.resolve(__dirname, '../../../../data/packs.yaml');
+
+let _packsCache = null;
+
+function loadPacks(packsPath = DEFAULT_PACKS_PATH) {
+  if (_packsCache && _packsCache.__path === packsPath) return _packsCache;
+  const raw = fs.readFileSync(packsPath, 'utf-8');
+  const data = yaml.load(raw);
+  data.__path = packsPath;
+  _packsCache = data;
+  return data;
+}
+
+function resetPacksCache() {
+  _packsCache = null;
+}
+
+function rollD(rng, sides) {
+  return Math.floor(rng() * sides) + 1;
+}
+
+function rangeIncludes(rangeStr, n) {
+  if (typeof rangeStr !== 'string') return false;
+  if (rangeStr.includes('-')) {
+    const [a, b] = rangeStr.split('-').map((x) => Number(x));
+    return n >= a && n <= b;
+  }
+  return Number(rangeStr) === n;
+}
+
+/**
+ * Roll a general d20 pack. Returns the entry matched (may be BIAS_FORMA /
+ * BIAS_JOB / SCELTA — caller-specific resolution).
+ */
+function rollGeneralD20(packs, rng = Math.random) {
+  const table = packs.random_general_d20 || [];
+  const d20 = rollD(rng, 20);
+  for (const entry of table) {
+    if (rangeIncludes(entry.range, d20)) {
+      return { d20, entry };
+    }
+  }
+  return { d20, entry: null };
+}
+
+/**
+ * Roll a form-specific d12 pack (A/B/C branch).
+ */
+function rollFormD12(packs, formId, rng = Math.random) {
+  const form = packs.forms?.[formId];
+  if (!form) return null;
+  const d12 = rollD(rng, 12);
+  const bias = form.bias_d12 || {};
+  for (const [branch, range] of Object.entries(bias)) {
+    if (rangeIncludes(range, d12)) {
+      return { d12, branch, combo: form[branch] || [] };
+    }
+  }
+  return { d12, branch: null, combo: [] };
+}
+
+/**
+ * Compute total PE cost of a combo using pi_shop.costs. Ignores literal PE
+ * entries (those are rewards). Returns { cost, items, rewards }.
+ */
+function computeComboCost(packs, combo) {
+  const costs = packs.pi_shop?.costs || {};
+  const items = [];
+  const rewards = [];
+  let cost = 0;
+  for (const token of combo || []) {
+    if (typeof token !== 'string') continue;
+    if (token === 'PE') {
+      rewards.push('PE');
+      continue;
+    }
+    // Token can be "key" or "key:value" (e.g., "trait_T1:pianificatore").
+    const key = token.includes(':') ? token.split(':')[0] : token;
+    const price = Number(costs[key] ?? 0);
+    cost += price;
+    items.push({ token, key, cost: price });
+  }
+  return { cost, items, rewards, pe_reward_count: rewards.length };
+}
+
+/**
+ * Full roll flow: d20 → BIAS_FORMA d12 / BIAS_JOB rotation / SCELTA
+ * Returns a structured pack result with combo + cost breakdown.
+ */
+function rollPack({ packs, formId = null, jobId = null, rng = Math.random } = {}) {
+  if (!packs) throw new Error('packs registry required');
+  const { d20, entry } = rollGeneralD20(packs, rng);
+  if (!entry) {
+    return { ok: false, reason: 'no_entry_matched', d20 };
+  }
+  // Resolve bias / scelta indirections.
+  let resolvedEntry = entry;
+  let d12 = null;
+  let branch = null;
+  if (entry.pack === 'BIAS_FORMA') {
+    if (!formId) {
+      return { ok: false, reason: 'form_id_required_for_bias', d20, entry };
+    }
+    const formRoll = rollFormD12(packs, formId, rng);
+    if (!formRoll) return { ok: false, reason: 'form_not_found', formId, d20 };
+    d12 = formRoll.d12;
+    branch = formRoll.branch;
+    resolvedEntry = { pack: `FORMA:${formId}:${branch}`, combo: formRoll.combo };
+  } else if (entry.pack === 'BIAS_JOB') {
+    const bias = packs.job_bias?.[jobId] || packs.job_bias?.default;
+    if (!bias || bias.length === 0) {
+      return { ok: false, reason: 'job_bias_missing', jobId, d20 };
+    }
+    // Pick among the 2-pack bias rotation uniformly.
+    const picked = bias[rollD(rng, bias.length) - 1];
+    const pickedEntry = (packs.random_general_d20 || []).find((e) => e.pack === picked);
+    if (!pickedEntry) return { ok: false, reason: 'bias_job_pack_missing', picked };
+    resolvedEntry = pickedEntry;
+  } else if (entry.pack === 'SCELTA') {
+    // Caller-driven choice — caller can re-call rollPack with explicit pick.
+    return { ok: true, source: 'SCELTA', d20, entry, requires_choice: true };
+  }
+  const combo = resolvedEntry.combo || [];
+  const costBreakdown = computeComboCost(packs, combo);
+  return {
+    ok: true,
+    source: entry.pack,
+    resolved_pack: resolvedEntry.pack,
+    combo,
+    cost: costBreakdown.cost,
+    items: costBreakdown.items,
+    pe_rewards: costBreakdown.pe_reward_count,
+    dice: { d20, d12 },
+    form_id: formId,
+    job_id: jobId,
+    form_branch: branch,
+  };
+}
+
+/**
+ * Deterministic RNG helper (mulberry32) for tests / replay.
+ */
+function seededRng(seed) {
+  let a = seed >>> 0;
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+module.exports = {
+  loadPacks,
+  resetPacksCache,
+  rollGeneralD20,
+  rollFormD12,
+  computeComboCost,
+  rollPack,
+  seededRng,
+  DEFAULT_PACKS_PATH,
+};

--- a/tests/api/formSessionStore.test.js
+++ b/tests/api/formSessionStore.test.js
@@ -1,0 +1,70 @@
+// M12 Phase B — formSessionStore unit tests.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createFormSessionStore } = require('../../apps/backend/services/forms/formSessionStore');
+
+test('store.seedUnit initializes state with defaults', () => {
+  const store = createFormSessionStore();
+  const state = store.seedUnit('sess1', 'u1', { pe: 10 });
+  assert.equal(state.id, 'u1');
+  assert.equal(state.pe, 10);
+  assert.equal(state.current_form_id, null);
+  assert.equal(state.evolve_count, 0);
+  assert.ok(state.updated_at > 0);
+});
+
+test('store.getUnitState returns clone (safe to mutate caller-side)', () => {
+  const store = createFormSessionStore();
+  store.seedUnit('sess1', 'u1', { pe: 10 });
+  const a = store.getUnitState('sess1', 'u1');
+  a.pe = 999;
+  const b = store.getUnitState('sess1', 'u1');
+  assert.equal(b.pe, 10);
+});
+
+test('store.applyDelta mutates + bumps evolve_count', () => {
+  const store = createFormSessionStore();
+  store.seedUnit('sess1', 'u1', { pe: 10 });
+  const updated = store.applyDelta('sess1', 'u1', {
+    new_form_id: 'INTJ',
+    pe_after: 2,
+    round: 3,
+  });
+  assert.equal(updated.current_form_id, 'INTJ');
+  assert.equal(updated.pe, 2);
+  assert.equal(updated.last_evolve_round, 3);
+  assert.equal(updated.evolve_count, 1);
+  assert.ok(updated.last_delta);
+});
+
+test('store.listSession returns scoped entries only', () => {
+  const store = createFormSessionStore();
+  store.seedUnit('sess1', 'u1', { pe: 5 });
+  store.seedUnit('sess1', 'u2', { pe: 7 });
+  store.seedUnit('sess2', 'uX', { pe: 9 });
+  const s1 = store.listSession('sess1');
+  const s2 = store.listSession('sess2');
+  assert.equal(s1.length, 2);
+  assert.equal(s2.length, 1);
+  assert.equal(s2[0].id, 'uX');
+});
+
+test('store.clearSession removes only matching prefix', () => {
+  const store = createFormSessionStore();
+  store.seedUnit('sess1', 'u1', {});
+  store.seedUnit('sess2', 'u2', {});
+  const removed = store.clearSession('sess1');
+  assert.equal(removed, 1);
+  assert.equal(store.size(), 1);
+  assert.equal(store.listSession('sess2').length, 1);
+});
+
+test('store throws on missing session_id / unit_id', () => {
+  const store = createFormSessionStore();
+  assert.throws(() => store.setUnitState('', 'u1', {}), /required/);
+  assert.throws(() => store.setUnitState('sess1', '', {}), /required/);
+});

--- a/tests/api/formsRoutesSessionPack.test.js
+++ b/tests/api/formsRoutesSessionPack.test.js
@@ -1,0 +1,185 @@
+// M12 Phase B — Forms session + pack REST integration tests.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+function vcAxes({ E_I = 0.5, S_N = 0.5, T_F = 0.5, J_P = 0.5 } = {}) {
+  return {
+    mbti_axes: {
+      E_I: { value: E_I },
+      S_N: { value: S_N },
+      T_F: { value: T_F },
+      J_P: { value: J_P },
+    },
+  };
+}
+
+test('GET /api/v1/forms/session/:sid returns empty list initially', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app).get('/api/v1/forms/session/sess_new').expect(200);
+    assert.equal(res.body.session_id, 'sess_new');
+    assert.deepEqual(res.body.units, []);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/v1/forms/session/:sid/:uid/seed + GET retrieves state', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app)
+      .post('/api/v1/forms/session/sess1/u1/seed')
+      .send({ pe: 12, current_form_id: null })
+      .expect(201);
+    const res = await request(app).get('/api/v1/forms/session/sess1/u1').expect(200);
+    assert.equal(res.body.id, 'u1');
+    assert.equal(res.body.pe, 12);
+    assert.equal(res.body.current_form_id, null);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/v1/forms/session/:sid/:uid/evolve persists mutation', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app).post('/api/v1/forms/session/sess2/u1/seed').send({ pe: 10 }).expect(201);
+    const evo = await request(app)
+      .post('/api/v1/forms/session/sess2/u1/evolve')
+      .send({
+        vc_snapshot: vcAxes({ E_I: 0.75, S_N: 0.35, T_F: 0.8, J_P: 0.75 }),
+        target_form_id: 'INTJ',
+        current_round: 2,
+      })
+      .expect(200);
+    assert.equal(evo.body.ok, true);
+    assert.equal(evo.body.state.current_form_id, 'INTJ');
+    assert.equal(evo.body.state.pe, 2);
+    assert.equal(evo.body.state.evolve_count, 1);
+    // Verify persisted via GET.
+    const after = await request(app).get('/api/v1/forms/session/sess2/u1').expect(200);
+    assert.equal(after.body.current_form_id, 'INTJ');
+    assert.equal(after.body.pe, 2);
+  } finally {
+    await close();
+  }
+});
+
+test('POST .../evolve auto-seeds when unit state missing + seed_pe provided', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const evo = await request(app)
+      .post('/api/v1/forms/session/sess3/u_new/evolve')
+      .send({
+        vc_snapshot: vcAxes({ E_I: 0.75, S_N: 0.35, T_F: 0.8, J_P: 0.75 }),
+        target_form_id: 'INTJ',
+        current_round: 2,
+        seed_pe: 15,
+      })
+      .expect(200);
+    assert.equal(evo.body.ok, true);
+    assert.equal(evo.body.state.pe, 7);
+  } finally {
+    await close();
+  }
+});
+
+test('POST .../evolve 409 when ineligible + persists nothing', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app).post('/api/v1/forms/session/sess4/u1/seed').send({ pe: 2 }).expect(201);
+    const evo = await request(app)
+      .post('/api/v1/forms/session/sess4/u1/evolve')
+      .send({
+        vc_snapshot: vcAxes({ E_I: 0.75, S_N: 0.35, T_F: 0.8, J_P: 0.75 }),
+        target_form_id: 'INTJ',
+      })
+      .expect(409);
+    assert.equal(evo.body.reason, 'insufficient_pe');
+    const after = await request(app).get('/api/v1/forms/session/sess4/u1').expect(200);
+    // Unit state unchanged.
+    assert.equal(after.body.pe, 2);
+    assert.equal(after.body.current_form_id, null);
+    assert.equal(after.body.evolve_count, 0);
+  } finally {
+    await close();
+  }
+});
+
+test('DELETE /api/v1/forms/session/:sid clears all unit states', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app).post('/api/v1/forms/session/sess5/u1/seed').send({ pe: 5 }).expect(201);
+    await request(app).post('/api/v1/forms/session/sess5/u2/seed').send({ pe: 7 }).expect(201);
+    const del = await request(app).delete('/api/v1/forms/session/sess5').expect(200);
+    assert.equal(del.body.removed, 2);
+    const after = await request(app).get('/api/v1/forms/session/sess5').expect(200);
+    assert.deepEqual(after.body.units, []);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/v1/forms/pack/roll returns combo + cost with seed', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app)
+      .post('/api/v1/forms/pack/roll')
+      .send({ form_id: 'INTJ', job_id: 'vanguard', seed: 42 })
+      .expect(200);
+    assert.equal(res.body.ok, true);
+    assert.ok(typeof res.body.dice.d20 === 'number');
+    assert.ok(Array.isArray(res.body.combo) || res.body.requires_choice);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/v1/forms/pack/roll deterministic on same seed', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const a = await request(app)
+      .post('/api/v1/forms/pack/roll')
+      .send({ form_id: 'INTJ', job_id: 'vanguard', seed: 12345 })
+      .expect(200);
+    const b = await request(app)
+      .post('/api/v1/forms/pack/roll')
+      .send({ form_id: 'INTJ', job_id: 'vanguard', seed: 12345 })
+      .expect(200);
+    assert.deepEqual(a.body, b.body);
+  } finally {
+    await close();
+  }
+});
+
+test('GET /api/v1/forms/pack/costs exposes pi_shop.costs + caps + budget_curve', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app).get('/api/v1/forms/pack/costs').expect(200);
+    assert.ok(res.body.costs);
+    assert.equal(res.body.costs.trait_T1, 3);
+    assert.equal(res.body.costs.sigillo_forma, 2);
+    assert.ok(res.body.budget_curve.baseline);
+  } finally {
+    await close();
+  }
+});
+
+test("Session isolation: sess A and sess B don't share state", async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app).post('/api/v1/forms/session/iso_a/u1/seed').send({ pe: 100 }).expect(201);
+    await request(app).post('/api/v1/forms/session/iso_b/u1/seed').send({ pe: 5 }).expect(201);
+    const a = await request(app).get('/api/v1/forms/session/iso_a/u1').expect(200);
+    const b = await request(app).get('/api/v1/forms/session/iso_b/u1').expect(200);
+    assert.equal(a.body.pe, 100);
+    assert.equal(b.body.pe, 5);
+  } finally {
+    await close();
+  }
+});

--- a/tests/api/packRoller.test.js
+++ b/tests/api/packRoller.test.js
@@ -1,0 +1,132 @@
+// M12 Phase B — packRoller unit tests.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  loadPacks,
+  rollGeneralD20,
+  rollFormD12,
+  computeComboCost,
+  rollPack,
+  seededRng,
+  resetPacksCache,
+} = require('../../apps/backend/services/forms/packRoller');
+
+test('loadPacks parses data/packs.yaml with pi_shop + forms + job_bias', () => {
+  resetPacksCache();
+  const packs = loadPacks();
+  assert.ok(packs.pi_shop);
+  assert.ok(typeof packs.pi_shop.costs.trait_T1 === 'number');
+  assert.ok(Array.isArray(packs.random_general_d20));
+  assert.ok(packs.forms.INTJ);
+  assert.ok(Array.isArray(packs.job_bias.vanguard));
+});
+
+test('seededRng produces deterministic sequence', () => {
+  const r1 = seededRng(42);
+  const r2 = seededRng(42);
+  assert.equal(r1(), r2());
+  assert.equal(r1(), r2());
+  assert.equal(r1(), r2());
+});
+
+test('rollGeneralD20 returns entry matching d20 range', () => {
+  const packs = loadPacks();
+  const rng = seededRng(100);
+  const { d20, entry } = rollGeneralD20(packs, rng);
+  assert.ok(d20 >= 1 && d20 <= 20);
+  assert.ok(entry);
+  assert.ok(entry.pack);
+});
+
+test('rollFormD12 returns INTJ branch with combo from bias_d12', () => {
+  const packs = loadPacks();
+  const rng = seededRng(7);
+  const roll = rollFormD12(packs, 'INTJ', rng);
+  assert.ok(roll);
+  assert.ok(roll.d12 >= 1 && roll.d12 <= 12);
+  assert.ok(['A', 'B', 'C'].includes(roll.branch));
+  assert.ok(Array.isArray(roll.combo));
+});
+
+test('rollFormD12 returns null for unknown form', () => {
+  const packs = loadPacks();
+  const roll = rollFormD12(packs, 'ZZZZ', seededRng(1));
+  assert.equal(roll, null);
+});
+
+test('computeComboCost sums pi_shop.costs, ignoring PE rewards', () => {
+  const packs = loadPacks();
+  const combo = ['trait_T1', 'job_ability', 'PE', 'PE', 'sigillo_forma'];
+  const result = computeComboCost(packs, combo);
+  // trait_T1(3) + job_ability(4) + sigillo_forma(2) = 9
+  assert.equal(result.cost, 9);
+  assert.equal(result.pe_reward_count, 2);
+  assert.equal(result.items.length, 3);
+});
+
+test('computeComboCost handles colon-prefixed tokens (trait_T1:pianificatore)', () => {
+  const packs = loadPacks();
+  const result = computeComboCost(packs, ['trait_T1:pianificatore', 'cap_pt']);
+  // trait_T1(3) + cap_pt(2) = 5
+  assert.equal(result.cost, 5);
+});
+
+test('rollPack deterministic on same seed', () => {
+  const packs = loadPacks();
+  const a = rollPack({ packs, formId: 'INTJ', jobId: 'vanguard', rng: seededRng(555) });
+  const b = rollPack({ packs, formId: 'INTJ', jobId: 'vanguard', rng: seededRng(555) });
+  assert.deepEqual(a, b);
+});
+
+test('rollPack returns BIAS_FORMA resolution when d20 in 16-17 range', () => {
+  // Force BIAS_FORMA by scanning seeds until d20 lands in 16-17.
+  const packs = loadPacks();
+  let result = null;
+  for (let seed = 1; seed < 1000; seed += 1) {
+    const attempt = rollPack({
+      packs,
+      formId: 'INTJ',
+      jobId: 'vanguard',
+      rng: seededRng(seed),
+    });
+    if (attempt.source === 'BIAS_FORMA') {
+      result = attempt;
+      break;
+    }
+  }
+  assert.ok(result, 'found a BIAS_FORMA seed within 1000 tries');
+  assert.match(result.resolved_pack, /^FORMA:INTJ:[ABC]$/);
+  assert.ok(['A', 'B', 'C'].includes(result.form_branch));
+  assert.ok(result.dice.d12 >= 1 && result.dice.d12 <= 12);
+});
+
+test('rollPack returns SCELTA flag when d20=20', () => {
+  const packs = loadPacks();
+  let result = null;
+  for (let seed = 1; seed < 2000; seed += 1) {
+    const attempt = rollPack({ packs, formId: 'INTJ', jobId: 'vanguard', rng: seededRng(seed) });
+    if (attempt.source === 'SCELTA' || attempt.requires_choice) {
+      result = attempt;
+      break;
+    }
+  }
+  assert.ok(result, 'found a SCELTA seed');
+  assert.equal(result.requires_choice, true);
+});
+
+test('rollPack returns error when BIAS_FORMA hit but no formId supplied', () => {
+  const packs = loadPacks();
+  for (let seed = 1; seed < 1000; seed += 1) {
+    const attempt = rollPack({ packs, formId: null, jobId: null, rng: seededRng(seed) });
+    if (attempt.source === 'BIAS_FORMA' || attempt.reason === 'form_id_required_for_bias') {
+      assert.equal(attempt.ok, false);
+      assert.equal(attempt.reason, 'form_id_required_for_bias');
+      return;
+    }
+  }
+  // Not all seeds land on BIAS_FORMA — that's fine; test passes if assertion path never runs.
+});


### PR DESCRIPTION
## Summary

Stacked on [#1689](https://github.com/MasterDD-L34D/Game/pull/1689) (Phase A). Adds **session-scoped persistence store** + **deterministic PI pack roller** on top of `FormEvolutionEngine`. 6 new REST endpoint, **27 new test**.

**Pilastro 2 status**: 🟡 → **🟡+** (engine + endpoint + persistence + pack roller live).

## Stack layers

```
FormEvolutionEngine          (Phase A)
    ↑
FormSessionStore             ← new: in-memory Map<sid:uid, state>
    ↑
PackRoller                   ← new: data/packs.yaml + d20/d12/SCELTA
    ↑
/api/v1/forms/{session/*, pack/*}  ← new routes (Phase B)
```

## Endpoints

| Method | Path | Ruolo |
|---|---|---|
| GET | `/api/v1/forms/session/:sid` | List unit states for session |
| GET | `/api/v1/forms/session/:sid/:uid` | Single state (404 missing) |
| POST | `/api/v1/forms/session/:sid/:uid/seed` | Init state |
| POST | `/api/v1/forms/session/:sid/:uid/evolve` | Evolve + persist (auto-seed if missing) |
| DELETE | `/api/v1/forms/session/:sid` | Clear scope |
| POST | `/api/v1/forms/pack/roll` | Roll (seed? → deterministic) |
| GET | `/api/v1/forms/pack/costs` | pi_shop costs + caps + budget_curve |

## Files

| File | LOC | Ruolo |
|---|---|---|
| `apps/backend/services/forms/formSessionStore.js` | ~110 | Keyed in-memory store, clone-safe, Prisma-ready |
| `apps/backend/services/forms/packRoller.js` | ~180 | loadPacks · seededRng · rollGeneralD20 · rollFormD12 · computeComboCost · rollPack |
| `apps/backend/routes/forms.js` | +90 | +7 endpoint (session CRUD + pack roll/costs) |
| `tests/api/formSessionStore.test.js` | 6 unit | seed/get/applyDelta/list/clear/errors |
| `tests/api/packRoller.test.js` | 11 unit | parse/seed/d20/d12/cost/determinism/bias/SCELTA |
| `tests/api/formsRoutesSessionPack.test.js` | 10 route | CRUD persist, evolve auto-seed, 409 ineligible, pack deterministic, costs, isolation |

## Test plan

- [x] `node --test tests/api/formSessionStore.test.js` → **6/6**
- [x] `node --test tests/api/packRoller.test.js` → **11/11**
- [x] `node --test tests/api/formsRoutesSessionPack.test.js` → **10/10**
- [x] `node --test tests/api/formEvolution.test.js tests/api/formsRoutes.test.js` → **25/25** (Phase A intact)
- [x] `node --test tests/ai/*.test.js tests/api/lobbyRoutes.test.js tests/api/lobbyWebSocket.test.js tests/e2e/lobbyEndToEnd.test.mjs` → **333/333** (baseline intact)
- [x] **Grand total: 385/385**
- [x] `npm run format:check` → verde

## Pack roll determinism

```http
POST /api/v1/forms/pack/roll  { "form_id": "INTJ", "job_id": "vanguard", "seed": 12345 }
```

Stesso seed → stesso `{ source, resolved_pack, combo, cost, items, dice: { d20, d12? } }`.
mulberry32 RNG per replay reliable.

## Session persistence flow

```http
POST /api/v1/forms/session/sess2/u1/seed   { "pe": 10 }                     → 201
POST /api/v1/forms/session/sess2/u1/evolve { vc, target_form_id, round }    → 200 persist
GET  /api/v1/forms/session/sess2/u1                                          → state aggiornato
DELETE /api/v1/forms/session/sess2                                           → cleanup
```

Auto-seed su evolve se unit mai inizializzata + `seed_pe` param.
409 preserva stato unit su ineligible (PE non dedotti, form non cambiato).

## Design choice: store separate from session.js

`apps/backend/routes/session.js` è size-sensitive + owner-locked (CLAUDE.md guardrail). Invece di instrumentare la sua Map interna, il bridge è store indipendente keyed per `session_id`. Caller-responsibility per `DELETE /session/:sid` cleanup quando game session chiude.

## Rollback

- `opts.store` / `opts.packs` DI → test override
- Rimuovere routes Phase B: Phase A stateless flow resta intatto
- `formsPlugin` remove da `BUILTIN_PLUGINS` → intero layer off

## Fuori scope (Phase C ~8-10h)

- Campaign engine trigger (auto-evolve opportunity su `/api/campaign/advance` node boundary)
- Frontend UI pannello evoluzione in `apps/play/src/`
- Prisma room persistence adapter (wire `_prisma` slot)
- Pack cost → evolve delta integration (oggi rollPack + evolve sono indipendenti, by design)

## Links

- Base Phase A PR: [#1689](https://github.com/MasterDD-L34D/Game/pull/1689)
- ADR: [`docs/adr/ADR-2026-04-23-m12-phase-a-form-evolution.md`](docs/adr/ADR-2026-04-23-m12-phase-a-form-evolution.md)
- Canvas B: [`docs/core/PI-Pacchetti-Forme.md`](docs/core/PI-Pacchetti-Forme.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)