### PR TITLE
feat(forms): M12 Phase C — evolution panel UI + api.js client

### DIFF
--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -94,6 +94,21 @@
             </svg>
             <span class="hud-label">Aiuto</span>
           </button>
+          <button id="forms-open" class="hud-btn" title="Evoluzione Form — scegli form MBTI (M12)">
+            <svg
+              class="hud-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M12 2v20M5 12h14M8 6l8 12M16 6l-8 12" />
+            </svg>
+            <span class="hud-label">🧬 Evo</span>
+          </button>
           <button
             id="campaign-open"
             class="hud-btn hud-btn-primary"

--- a/apps/play/src/api.js
+++ b/apps/play/src/api.js
@@ -110,4 +110,51 @@ export const api = {
     }),
   campaignList: (playerId) =>
     jsonFetch(`/api/campaign/list?player_id=${encodeURIComponent(playerId)}`),
+  // M12 Phase A+B+C — Forms / evolution engine.
+  formsRegistry: () => jsonFetch('/api/v1/forms/registry'),
+  formsGet: (id) => jsonFetch(`/api/v1/forms/${encodeURIComponent(id)}`),
+  formsEvaluate: (body) =>
+    jsonFetch('/api/v1/forms/evaluate', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+  formsOptions: (body) =>
+    jsonFetch('/api/v1/forms/options', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+  formsEvolve: (body) =>
+    jsonFetch('/api/v1/forms/evolve', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+  formsSessionList: (sid) => jsonFetch(`/api/v1/forms/session/${encodeURIComponent(sid)}`),
+  formsSessionGet: (sid, unitId) =>
+    jsonFetch(`/api/v1/forms/session/${encodeURIComponent(sid)}/${encodeURIComponent(unitId)}`),
+  formsSessionSeed: (sid, unitId, body) =>
+    jsonFetch(
+      `/api/v1/forms/session/${encodeURIComponent(sid)}/${encodeURIComponent(unitId)}/seed`,
+      {
+        method: 'POST',
+        body: JSON.stringify(body || {}),
+      },
+    ),
+  formsSessionEvolve: (sid, unitId, body) =>
+    jsonFetch(
+      `/api/v1/forms/session/${encodeURIComponent(sid)}/${encodeURIComponent(unitId)}/evolve`,
+      {
+        method: 'POST',
+        body: JSON.stringify(body),
+      },
+    ),
+  formsSessionClear: (sid) =>
+    jsonFetch(`/api/v1/forms/session/${encodeURIComponent(sid)}`, {
+      method: 'DELETE',
+    }),
+  formsPackRoll: (body) =>
+    jsonFetch('/api/v1/forms/pack/roll', {
+      method: 'POST',
+      body: JSON.stringify(body || {}),
+    }),
+  formsPackCosts: () => jsonFetch('/api/v1/forms/pack/costs'),
 };

--- a/apps/play/src/formsPanel.js
+++ b/apps/play/src/formsPanel.js
@@ -1,0 +1,364 @@
+// M12 Phase C — Forms evolution panel.
+//
+// Overlay modal listing 16 MBTI forms for the currently selected PG:
+//   - Confidence bar (distance → 0..1 score)
+//   - Eligibility chip + reasons if ineligible
+//   - Evolve button → POST /api/v1/forms/session/:sid/:uid/evolve
+//   - Pack roll preview → POST /api/v1/forms/pack/roll
+//
+// Exports:
+//   initFormsPanel({ getSessionId, getSelectedUnit, getVcSnapshot }) — wire HUD
+//
+// Consumer: apps/play/src/main.js attaches a header button '🧬 Evo'.
+// Ref ADR-2026-04-23-m12-phase-a.
+
+import { api } from './api.js';
+
+const STATE = {
+  overlayEl: null,
+  getSessionId: () => null,
+  getSelectedUnit: () => null,
+  getVcSnapshot: () => ({}),
+  lastUnitId: null,
+  cachedOptions: null,
+  lastPackRoll: null,
+};
+
+// ---------------------------------------------------------------------------
+// VC axes inference (from game state — fallback to neutral 0.5).
+// ---------------------------------------------------------------------------
+export function inferVcAxes(vcSnapshot) {
+  const axes = vcSnapshot?.mbti_axes || vcSnapshot?.axes || {};
+  const keys = ['E_I', 'S_N', 'T_F', 'J_P'];
+  const out = {};
+  for (const k of keys) {
+    const entry = axes[k];
+    if (entry && typeof entry.value === 'number') {
+      out[k] = { value: entry.value };
+    } else if (typeof entry === 'number') {
+      out[k] = { value: entry };
+    } else {
+      out[k] = { value: 0.5 };
+    }
+  }
+  return { mbti_axes: out };
+}
+
+// ---------------------------------------------------------------------------
+// Overlay DOM.
+// ---------------------------------------------------------------------------
+function injectStyles() {
+  if (document.getElementById('forms-panel-styles')) return;
+  const style = document.createElement('style');
+  style.id = 'forms-panel-styles';
+  style.textContent = `
+    .forms-overlay {
+      position: fixed; inset: 0; z-index: 9996;
+      background: rgba(11, 13, 18, 0.78);
+      display: none; align-items: flex-start; justify-content: center;
+      padding: 32px 16px; overflow-y: auto;
+      font-family: Inter, system-ui, sans-serif; color: #e8eaf0;
+    }
+    .forms-overlay.visible { display: flex; }
+    .forms-card {
+      max-width: 880px; width: 100%; background: #151922;
+      border: 1px solid #2a3040; border-radius: 14px; padding: 22px 24px;
+    }
+    .forms-card-head {
+      display: flex; align-items: center; gap: 12px; margin-bottom: 10px;
+    }
+    .forms-card-head h2 { margin: 0; font-size: 1.25rem; color: #66d1fb; }
+    .forms-card-head .unit-chip {
+      margin-left: auto; background: #0b0d12; border: 1px solid #2a3040;
+      border-radius: 999px; padding: 4px 12px; font-size: 0.85rem;
+    }
+    .forms-card-head .close-btn {
+      background: transparent; border: none; color: #ef9a9a;
+      cursor: pointer; font-size: 1.2rem;
+    }
+    .forms-meta {
+      display: flex; gap: 14px; flex-wrap: wrap;
+      background: #0b0d12; border: 1px solid #2a3040; border-radius: 8px;
+      padding: 10px 14px; margin-bottom: 14px; font-size: 0.85rem;
+    }
+    .forms-meta strong { color: #ffb74d; }
+    .forms-grid {
+      display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      gap: 10px;
+    }
+    .form-entry {
+      background: #1d2230; border: 1px solid #2a3040; border-radius: 10px;
+      padding: 12px 14px; display: flex; flex-direction: column; gap: 6px;
+    }
+    .form-entry.eligible { border-color: #66bb6a; }
+    .form-entry.ineligible { opacity: 0.72; }
+    .form-entry .row-main {
+      display: flex; align-items: baseline; gap: 8px;
+    }
+    .form-entry .form-id {
+      font-weight: 700; color: #ffb74d; letter-spacing: 0.5px;
+    }
+    .form-entry .form-label { color: #e8eaf0; font-size: 0.9rem; }
+    .form-entry .form-temp {
+      margin-left: auto; font-size: 0.7rem; color: #8891a3;
+      text-transform: uppercase;
+    }
+    .form-entry .confidence-bar {
+      background: #0b0d12; border-radius: 4px; height: 6px; overflow: hidden;
+      position: relative;
+    }
+    .form-entry .confidence-bar .fill {
+      height: 100%; background: #4fc3f7; transition: width 0.2s;
+    }
+    .form-entry.eligible .confidence-bar .fill { background: #66bb6a; }
+    .form-entry .row-bottom {
+      display: flex; justify-content: space-between; align-items: center;
+      font-size: 0.78rem; color: #8891a3;
+    }
+    .form-entry .reasons { color: #ef9a9a; font-size: 0.75rem; }
+    .form-entry button.evolve-btn {
+      background: #66bb6a; color: #001014; border: none;
+      border-radius: 6px; padding: 6px 10px; font-weight: 700;
+      cursor: pointer; font-size: 0.85rem;
+    }
+    .form-entry button.evolve-btn:disabled {
+      background: #2a3040; color: #8891a3; cursor: not-allowed;
+    }
+    .forms-pack-row {
+      margin-top: 16px; display: flex; gap: 10px; align-items: center;
+      background: #0b0d12; border: 1px solid #2a3040; border-radius: 8px;
+      padding: 10px 14px;
+    }
+    .forms-pack-row button {
+      background: #ffb74d; color: #201000; border: none;
+      border-radius: 6px; padding: 8px 12px; font-weight: 700; cursor: pointer;
+    }
+    .forms-pack-row .roll-result {
+      flex: 1; font-family: monospace; font-size: 0.85rem; color: #e8eaf0;
+    }
+    .forms-status {
+      margin-top: 10px; min-height: 1.2em; font-size: 0.85rem;
+    }
+    .forms-status.ok { color: #66bb6a; }
+    .forms-status.err { color: #ef5350; }
+  `;
+  document.head.appendChild(style);
+}
+
+function buildOverlay() {
+  if (STATE.overlayEl) return STATE.overlayEl;
+  injectStyles();
+  const overlay = document.createElement('div');
+  overlay.id = 'forms-overlay';
+  overlay.className = 'forms-overlay';
+  overlay.innerHTML = `
+    <div class="forms-card" role="dialog" aria-label="Evoluzione Form">
+      <div class="forms-card-head">
+        <h2>🧬 Evoluzione Form</h2>
+        <span class="unit-chip" id="forms-unit-chip">—</span>
+        <button type="button" class="close-btn" id="forms-close">✕</button>
+      </div>
+      <div class="forms-meta" id="forms-meta">
+        <span><strong>PE:</strong> <span id="forms-meta-pe">—</span></span>
+        <span><strong>Form attuale:</strong> <span id="forms-meta-current">—</span></span>
+        <span><strong>Cooldown:</strong> <span id="forms-meta-cd">—</span></span>
+        <span><strong>Evolve count:</strong> <span id="forms-meta-count">—</span></span>
+      </div>
+      <div class="forms-grid" id="forms-grid"></div>
+      <div class="forms-pack-row">
+        <button type="button" id="forms-pack-btn">🎲 Roll pack</button>
+        <span class="roll-result" id="forms-pack-result">Nessun roll effettuato.</span>
+      </div>
+      <div class="forms-status" id="forms-status"></div>
+    </div>
+  `;
+  document.body.appendChild(overlay);
+  overlay.querySelector('#forms-close').addEventListener('click', closeFormsPanel);
+  overlay.querySelector('#forms-pack-btn').addEventListener('click', handlePackRoll);
+  overlay.addEventListener('click', (ev) => {
+    if (ev.target === overlay) closeFormsPanel();
+  });
+  STATE.overlayEl = overlay;
+  return overlay;
+}
+
+function setStatus(text, kind = '') {
+  const el = document.getElementById('forms-status');
+  if (!el) return;
+  el.textContent = text || '';
+  el.className = `forms-status${kind ? ' ' + kind : ''}`;
+}
+
+function renderMeta(state) {
+  const peEl = document.getElementById('forms-meta-pe');
+  const curEl = document.getElementById('forms-meta-current');
+  const cdEl = document.getElementById('forms-meta-cd');
+  const countEl = document.getElementById('forms-meta-count');
+  if (peEl) peEl.textContent = String(state?.pe ?? 0);
+  if (curEl) curEl.textContent = state?.current_form_id ?? '—';
+  if (cdEl)
+    cdEl.textContent =
+      state?.last_evolve_round !== null && state?.last_evolve_round !== undefined
+        ? `ultima round ${state.last_evolve_round}`
+        : '—';
+  if (countEl) countEl.textContent = String(state?.evolve_count ?? 0);
+}
+
+function renderOptions(options) {
+  const grid = document.getElementById('forms-grid');
+  if (!grid) return;
+  grid.innerHTML = '';
+  if (!Array.isArray(options) || options.length === 0) {
+    grid.innerHTML = '<div style="grid-column:1/-1;color:#8891a3">Nessun form disponibile.</div>';
+    return;
+  }
+  for (const opt of options) {
+    const entry = document.createElement('div');
+    entry.className = `form-entry ${opt.eligible ? 'eligible' : 'ineligible'}`;
+    const pct = Math.max(0, Math.min(1, opt.confidence_to_target || 0));
+    const reasonTxt = (opt.reasons || []).join(', ');
+    entry.innerHTML = `
+      <div class="row-main">
+        <span class="form-id">${opt.target_form_id}</span>
+        <span class="form-label">${opt.target_label || ''}</span>
+        <span class="form-temp">${opt.target_temperament || ''}</span>
+      </div>
+      <div class="confidence-bar"><div class="fill" style="width:${(pct * 100).toFixed(0)}%"></div></div>
+      <div class="row-bottom">
+        <span>conf ${(pct * 100).toFixed(0)}% · PE ${opt.pe_cost}/${opt.pe_available}</span>
+        <button type="button" class="evolve-btn" data-form="${opt.target_form_id}" ${opt.eligible ? '' : 'disabled'}>Evolvi</button>
+      </div>
+      ${reasonTxt ? `<div class="reasons">✖ ${reasonTxt}</div>` : ''}
+    `;
+    entry.querySelector('.evolve-btn').addEventListener('click', () => handleEvolveClick(opt));
+    grid.appendChild(entry);
+  }
+}
+
+async function refresh() {
+  const sid = STATE.getSessionId();
+  const unit = STATE.getSelectedUnit();
+  const vc = STATE.getVcSnapshot() || {};
+  if (!sid) {
+    setStatus('✖ Nessuna sessione attiva.', 'err');
+    return;
+  }
+  if (!unit?.id) {
+    setStatus('✖ Nessuna unità selezionata. Scegli un PG dalla board.', 'err');
+    return;
+  }
+  STATE.lastUnitId = unit.id;
+  const unitChip = document.getElementById('forms-unit-chip');
+  if (unitChip) unitChip.textContent = `${unit.id}${unit.job ? ' · ' + unit.job : ''}`;
+  setStatus('Carico opzioni…');
+
+  // Load current session state (auto-seed with PE if backend says not_found).
+  let state = await api.formsSessionGet(sid, unit.id);
+  if (!state.ok) {
+    const seedPe = Number(unit.pe ?? unit.pe_remaining ?? 10);
+    const currentForm = unit.current_form_id || unit.form_id || null;
+    state = await api.formsSessionSeed(sid, unit.id, {
+      pe: seedPe,
+      current_form_id: currentForm,
+    });
+  }
+  const unitState = state.data || {};
+  renderMeta(unitState);
+
+  // Load options.
+  const axes = inferVcAxes(vc);
+  const opts = await api.formsOptions({
+    unit: {
+      id: unit.id,
+      pe: unitState.pe,
+      current_form_id: unitState.current_form_id,
+      last_evolve_round: unitState.last_evolve_round,
+      evolve_count: unitState.evolve_count,
+    },
+    vc_snapshot: axes,
+    current_round: vc.round ?? vc.turn ?? 0,
+  });
+  if (!opts.ok) {
+    setStatus(`✖ Options: ${opts.data?.error || opts.status}`, 'err');
+    return;
+  }
+  STATE.cachedOptions = opts.data?.options || [];
+  renderOptions(STATE.cachedOptions);
+  const eligibleCount = STATE.cachedOptions.filter((o) => o.eligible).length;
+  setStatus(`${eligibleCount}/${STATE.cachedOptions.length} form eleggibili.`, 'ok');
+}
+
+async function handleEvolveClick(opt) {
+  const sid = STATE.getSessionId();
+  const unit = STATE.getSelectedUnit();
+  if (!sid || !unit?.id) return;
+  setStatus(`Evolving → ${opt.target_form_id}…`);
+  const vc = STATE.getVcSnapshot() || {};
+  const axes = inferVcAxes(vc);
+  const res = await api.formsSessionEvolve(sid, unit.id, {
+    target_form_id: opt.target_form_id,
+    vc_snapshot: axes,
+    current_round: vc.round ?? vc.turn ?? 0,
+  });
+  if (!res.ok) {
+    setStatus(`✖ ${res.data?.reason || 'errore'}`, 'err');
+    return;
+  }
+  setStatus(
+    `✓ Evoluta in ${res.data.delta.new_form_id} (${res.data.delta.label}) · PE ${res.data.delta.pe_after}`,
+    'ok',
+  );
+  await refresh();
+}
+
+async function handlePackRoll() {
+  const unit = STATE.getSelectedUnit();
+  if (!unit?.id) {
+    setStatus('✖ Seleziona un PG per roll pack.', 'err');
+    return;
+  }
+  const state = STATE.cachedOptions?.[0];
+  const formId = state?.target_form_id || null;
+  const jobId = unit.job || null;
+  const res = await api.formsPackRoll({ form_id: formId, job_id: jobId });
+  const resultEl = document.getElementById('forms-pack-result');
+  if (!resultEl) return;
+  if (!res.ok) {
+    resultEl.textContent = `✖ ${res.data?.error || 'roll fallito'}`;
+    return;
+  }
+  STATE.lastPackRoll = res.data;
+  if (res.data.requires_choice) {
+    resultEl.textContent = `d20=${res.data.dice.d20} · SCELTA (d20=20, pack a scelta player)`;
+    return;
+  }
+  const combo = Array.isArray(res.data.combo) ? res.data.combo.join(', ') : '—';
+  resultEl.textContent = `${res.data.source}${res.data.resolved_pack ? ' → ' + res.data.resolved_pack : ''} · [${combo}] · cost ${res.data.cost} PE · d20=${res.data.dice.d20}${res.data.dice.d12 ? ', d12=' + res.data.dice.d12 : ''}`;
+}
+
+export function openFormsPanel() {
+  buildOverlay();
+  STATE.overlayEl.classList.add('visible');
+  refresh();
+}
+
+export function closeFormsPanel() {
+  if (STATE.overlayEl) STATE.overlayEl.classList.remove('visible');
+}
+
+export function initFormsPanel({
+  getSessionId,
+  getSelectedUnit,
+  getVcSnapshot,
+  buttonId = 'forms-open',
+} = {}) {
+  STATE.getSessionId = typeof getSessionId === 'function' ? getSessionId : () => null;
+  STATE.getSelectedUnit = typeof getSelectedUnit === 'function' ? getSelectedUnit : () => null;
+  STATE.getVcSnapshot = typeof getVcSnapshot === 'function' ? getVcSnapshot : () => ({});
+  buildOverlay();
+  const btn = document.getElementById(buttonId);
+  if (btn) {
+    btn.addEventListener('click', openFormsPanel);
+  }
+  return { openFormsPanel, closeFormsPanel, refresh };
+}

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -21,6 +21,7 @@ import { toggleCodex } from './codexPanel.js';
 import { initFeedbackPanel } from './feedbackPanel.js';
 import { initCampaignPanel } from './campaignPanel.js';
 import { initLobbyBridgeIfPresent } from './lobbyBridge.js';
+import { initFormsPanel } from './formsPanel.js';
 
 const state = {
   sid: null,
@@ -1339,6 +1340,27 @@ initHelpPanel('help-open');
 initFeedbackPanel({ getSessionId: () => state.sid });
 // M10 Phase D — campaign panel (ADR-2026-04-21)
 initCampaignPanel();
+// M12 Phase C — forms evolution panel (ADR-2026-04-23-m12-phase-a)
+initFormsPanel({
+  getSessionId: () => state.sid,
+  getSelectedUnit: () =>
+    state.world && state.selected
+      ? getUnits(state.world).find((u) => u.id === state.selected) || null
+      : null,
+  getVcSnapshot: () => ({
+    // Placeholder axes; real VC data lives backend-side.
+    // Until /api/session/:id/vc is piped into state, we return neutral defaults
+    // so panel works, and backend projectForm falls back to center of grid.
+    round: state.world?.round ?? state.world?.turn ?? 0,
+    turn: state.world?.turn ?? 0,
+    mbti_axes: state.world?.vc_snapshot?.mbti_axes || {
+      E_I: { value: 0.5 },
+      S_N: { value: 0.5 },
+      T_F: { value: 0.5 },
+      J_P: { value: 0.5 },
+    },
+  }),
+});
 
 // M11 Phase B — lobby bridge (Jackbox room-code WS). Null if no session stored.
 // Host role: publishes world state to players after each /session/state refresh.

--- a/tests/api/formsPanelInfer.test.js
+++ b/tests/api/formsPanelInfer.test.js
@@ -1,0 +1,67 @@
+// M12 Phase C — formsPanel helper unit tests.
+// Only the DOM-free export `inferVcAxes` is tested here (panel rendering
+// requires jsdom; browser integration covered by preview_verify manually).
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+// Dynamic import of ESM module.
+async function loadPanel() {
+  return import('../../apps/play/src/formsPanel.js');
+}
+
+test('inferVcAxes normalizes mbti_axes.{E_I,S_N,T_F,J_P}.value to {value}', async () => {
+  const { inferVcAxes } = await loadPanel();
+  const vc = {
+    mbti_axes: {
+      E_I: { value: 0.75 },
+      S_N: { value: 0.35 },
+      T_F: { value: 0.8 },
+      J_P: { value: 0.75 },
+    },
+  };
+  const out = inferVcAxes(vc);
+  assert.equal(out.mbti_axes.E_I.value, 0.75);
+  assert.equal(out.mbti_axes.S_N.value, 0.35);
+  assert.equal(out.mbti_axes.T_F.value, 0.8);
+  assert.equal(out.mbti_axes.J_P.value, 0.75);
+});
+
+test('inferVcAxes accepts shorthand axes: number form', async () => {
+  const { inferVcAxes } = await loadPanel();
+  const out = inferVcAxes({ axes: { E_I: 0.6, S_N: 0.4, T_F: 0.7, J_P: 0.3 } });
+  assert.equal(out.mbti_axes.E_I.value, 0.6);
+  assert.equal(out.mbti_axes.T_F.value, 0.7);
+});
+
+test('inferVcAxes falls back to 0.5 for missing axes', async () => {
+  const { inferVcAxes } = await loadPanel();
+  const out = inferVcAxes({});
+  assert.equal(out.mbti_axes.E_I.value, 0.5);
+  assert.equal(out.mbti_axes.S_N.value, 0.5);
+  assert.equal(out.mbti_axes.T_F.value, 0.5);
+  assert.equal(out.mbti_axes.J_P.value, 0.5);
+});
+
+test('inferVcAxes fills only missing axes, preserves provided', async () => {
+  const { inferVcAxes } = await loadPanel();
+  const out = inferVcAxes({
+    mbti_axes: {
+      T_F: { value: 0.9 },
+      // E_I / S_N / J_P missing
+    },
+  });
+  assert.equal(out.mbti_axes.T_F.value, 0.9);
+  assert.equal(out.mbti_axes.E_I.value, 0.5);
+  assert.equal(out.mbti_axes.S_N.value, 0.5);
+  assert.equal(out.mbti_axes.J_P.value, 0.5);
+});
+
+test('inferVcAxes returns new object (does not mutate input)', async () => {
+  const { inferVcAxes } = await loadPanel();
+  const vc = { mbti_axes: { E_I: { value: 0.1 } } };
+  inferVcAxes(vc);
+  assert.deepEqual(vc, { mbti_axes: { E_I: { value: 0.1 } } });
+});


### PR DESCRIPTION
## Summary

Sblocca il tier **frontend** del Pilastro 2 dopo Phase A+B ([#1689](https://github.com/MasterDD-L34D/Game/pull/1689) + [#1690](https://github.com/MasterDD-L34D/Game/pull/1690) merged). Pannello overlay modale che espone 16 MBTI forms con confidence bar + eligibility chip + evolve button + pack roll preview.

**Pilastro 2**: 🟡+ → **🟡++** (frontend UI discoverable + usable).

## UX flow

1. User seleziona PG dalla board → `state.selected`
2. Click **🧬 Evo** header button → overlay apre
3. Panel fetch session state (auto-seed se missing)
4. Panel fetch options ordered by confidence
5. 16 cards con: form id + label + temperament + confidence bar + PE cost / available + Evolve button + reasons se ineligible
6. Click Evolve → mutate backend + refresh panel
7. Click 🎲 Roll pack → d20/d12/SCELTA roll + combo + cost + dice display

## Files

| File | Ruolo |
|---|---|
| `apps/play/src/api.js` | +13 metodi client (registry, session/*, pack/*) |
| `apps/play/src/formsPanel.js` NEW | `initFormsPanel` + overlay + composer |
| `apps/play/index.html` | +header button `🧬 Evo` |
| `apps/play/src/main.js` | +`initFormsPanel({ getSessionId, getSelectedUnit, getVcSnapshot })` |
| `tests/api/formsPanelInfer.test.js` NEW | 5 unit test `inferVcAxes` |

## Test plan

- [x] `node --test tests/api/formsPanelInfer.test.js` → **5/5 pass**
- [x] `node --test tests/api/formEvolution.test.js tests/api/formsRoutes.test.js tests/api/formSessionStore.test.js tests/api/packRoller.test.js tests/api/formsRoutesSessionPack.test.js` → **52/52** (M12.A+B intact)
- [x] `node --test tests/ai/*.test.js tests/api/lobbyRoutes.test.js tests/api/lobbyWebSocket.test.js tests/e2e/lobbyEndToEnd.test.mjs` → **333/333** (baseline intact)
- [x] **Grand total: 390/390**
- [x] `npm run format:check` → verde
- [x] Preview verify: 🧬 Evo button click apre overlay — meta + 16 grid + roll pack row rendered OK

## Rollback

Revert PR: pannello non costruito (button + overlay + api client rimossi). Backend Phase A+B intatto.

## Fuori scope (Phase D ~4-6h)

- Campaign advance trigger: response additive `evolve_opportunity: true` su victory + `pe_earned >= 8`
- VC snapshot live pipe: `state.world.vc_snapshot` da `/api/session/:id/vc` (oggi panel usa fallback neutral 0.5×4)
- Animated form transition on evolve (sprite swap + toast)
- Prisma adapter wire (`formSessionStore._prisma`)

## Links

- Base M12.A ADR: [`docs/adr/ADR-2026-04-23-m12-phase-a-form-evolution.md`](docs/adr/ADR-2026-04-23-m12-phase-a-form-evolution.md)
- Canvas B: [`docs/core/PI-Pacchetti-Forme.md`](docs/core/PI-Pacchetti-Forme.md)
- Pilastri audit: [`docs/planning/2026-04-20-pilastri-reality-audit.md`](docs/planning/2026-04-20-pilastri-reality-audit.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)