### PR TITLE
feat(forms): M12 Phase D — campaign trigger + VC pipe + evolve anim + Prisma (Pilastro 2 🟢 candidato)

### DIFF
--- a/apps/backend/prisma/migrations/0003_form_session_state/migration.sql
+++ b/apps/backend/prisma/migrations/0003_form_session_state/migration.sql
@@ -1,0 +1,24 @@
+-- M12 Phase D form session persistence (ADR-2026-04-23 addendum).
+-- Model: FormSessionState. Write-through cache for formSessionStore.
+
+-- CreateTable
+CREATE TABLE "form_session_states" (
+    "id" TEXT NOT NULL,
+    "session_id" TEXT NOT NULL,
+    "unit_id" TEXT NOT NULL,
+    "current_form_id" TEXT,
+    "pe" INTEGER NOT NULL DEFAULT 0,
+    "last_evolve_round" INTEGER,
+    "evolve_count" INTEGER NOT NULL DEFAULT 0,
+    "last_delta" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "form_session_states_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "form_session_states_session_id_unit_id_key" ON "form_session_states"("session_id", "unit_id");
+
+-- CreateIndex
+CREATE INDEX "form_session_states_session_id_idx" ON "form_session_states"("session_id");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -225,6 +225,28 @@ model NestState {
   @@map("nest_states")
 }
 
+// ─── M12 Phase D Form evolution persistence (ADR-2026-04-23 addendum) ─────
+// Promotes formSessionStore in-memory Map → DB-backed write-through cache.
+// Adapter preserves in-memory fallback when DATABASE_URL unset (dev/demo/tests).
+// Scope: per-session unit form state (current form, PE, cooldown, evolve count).
+
+model FormSessionState {
+  id              String   @id @default(uuid())
+  sessionId       String   @map("session_id")
+  unitId          String   @map("unit_id")
+  currentFormId   String?  @map("current_form_id")
+  pe              Int      @default(0)
+  lastEvolveRound Int?     @map("last_evolve_round")
+  evolveCount     Int      @default(0) @map("evolve_count")
+  lastDelta       String?  @map("last_delta") // JSON
+  createdAt       DateTime @default(now()) @map("created_at")
+  updatedAt       DateTime @updatedAt @map("updated_at")
+
+  @@unique([sessionId, unitId])
+  @@index([sessionId])
+  @@map("form_session_states")
+}
+
 model MatingEvent {
   id                String      @id @default(uuid())
   relationId        String      @map("relation_id")

--- a/apps/backend/routes/campaign.js
+++ b/apps/backend/routes/campaign.js
@@ -33,6 +33,21 @@ const {
 } = require('../services/campaign/campaignLoader');
 const { summariseCampaign } = require('../services/campaign/campaignEngine');
 
+// M12 Phase D — evolve opportunity trigger threshold (ADR-2026-04-23 addendum).
+// Victory + pe_earned >= PE_EVOLVE_TRIGGER_THRESHOLD → response.evolve_opportunity=true.
+// Consumed frontend-side (formsPanel auto-open) + lobby campaign mirror.
+const PE_EVOLVE_TRIGGER_THRESHOLD = 8;
+
+function computeEvolveOpportunity(outcome, peEarned) {
+  const pe = Number(peEarned) || 0;
+  const eligible = outcome === 'victory' && pe >= PE_EVOLVE_TRIGGER_THRESHOLD;
+  return {
+    evolve_opportunity: eligible,
+    evolve_pe_threshold: PE_EVOLVE_TRIGGER_THRESHOLD,
+    evolve_pe_earned: pe,
+  };
+}
+
 function createCampaignRouter(options = {}) {
   const router = express.Router();
 
@@ -130,6 +145,9 @@ function createCampaignRouter(options = {}) {
       branchChosen: lastBranch,
     });
 
+    // M12 Phase D — evolve opportunity flag additive (victory + pe ≥ threshold).
+    const evolveFlags = computeEvolveOpportunity(outcome, pe_earned);
+
     // Compute next state
     let updated;
     if (outcome !== 'victory') {
@@ -139,6 +157,7 @@ function createCampaignRouter(options = {}) {
         campaign: updated,
         next_encounter_id: currentEncId, // retry same
         retry: true,
+        ...evolveFlags,
       });
     }
 
@@ -160,6 +179,7 @@ function createCampaignRouter(options = {}) {
         next_encounter_id: null,
         choice_required: true,
         choice_node: nextEncEntry.choice,
+        ...evolveFlags,
       });
     }
 
@@ -174,7 +194,12 @@ function createCampaignRouter(options = {}) {
           completionPct: 1.0,
           currentChapter: nextChapterIdx,
         });
-        return res.json({ campaign: updated, next_encounter_id: null, campaign_completed: true });
+        return res.json({
+          campaign: updated,
+          next_encounter_id: null,
+          campaign_completed: true,
+          ...evolveFlags,
+        });
       }
       // Advance to next act
       const firstEncNextAct = (nextAct.encounters || []).find((e) => !e.is_choice_node);
@@ -186,6 +211,7 @@ function createCampaignRouter(options = {}) {
         campaign: updated,
         next_encounter_id: firstEncNextAct?.encounter_id || null,
         act_advanced: true,
+        ...evolveFlags,
       });
     }
 
@@ -194,6 +220,7 @@ function createCampaignRouter(options = {}) {
     return res.json({
       campaign: updated,
       next_encounter_id: nextEncEntry.encounter_id,
+      ...evolveFlags,
     });
   });
 
@@ -258,4 +285,8 @@ function createCampaignRouter(options = {}) {
   return router;
 }
 
-module.exports = { createCampaignRouter };
+module.exports = {
+  createCampaignRouter,
+  computeEvolveOpportunity,
+  PE_EVOLVE_TRIGGER_THRESHOLD,
+};

--- a/apps/backend/services/forms/formSessionStore.js
+++ b/apps/backend/services/forms/formSessionStore.js
@@ -1,5 +1,5 @@
 // M12 Phase B — In-memory session store for form evolution state.
-// ADR-2026-04-23-m12-phase-a (Phase B extension).
+// M12 Phase D — Prisma write-through adapter (ADR-2026-04-23 addendum).
 //
 // Scopes unit form state per session_id so that /api/v1/forms/session/:sid/*
 // endpoints can read/write without piggybacking on session.js (guardrail:
@@ -8,8 +8,10 @@
 // Storage shape: Map<`${sessionId}:${unitId}`, unitState>
 //   unitState = { current_form_id, pe, last_evolve_round, evolve_count, last_delta?, updated_at }
 //
-// Prisma adapter: constructor accepts `{ prisma }` for future persistence.
-// Phase B ships in-memory only; Phase C wires a Prisma table if deploy needs it.
+// Prisma adapter: constructor accepts `{ prisma }`. When `prisma.formSessionState`
+// is present, writes fire-and-forget upsert + `hydrate(sessionId)` pre-loads
+// the in-memory Map from DB. Keeps route API synchronous; failures log and fall
+// back to in-memory only.
 
 'use strict';
 
@@ -17,9 +19,84 @@ function makeKey(sessionId, unitId) {
   return `${sessionId}:${unitId}`;
 }
 
-function createFormSessionStore({ prisma = null } = {}) {
+function prismaSupportsForms(prisma) {
+  return Boolean(
+    prisma &&
+      prisma.formSessionState &&
+      typeof prisma.formSessionState.upsert === 'function' &&
+      typeof prisma.formSessionState.findMany === 'function',
+  );
+}
+
+function createFormSessionStore({ prisma = null, logger = null } = {}) {
   const states = new Map();
-  const prismaBackend = prisma || null; // reserved for Phase C
+  const usePrisma = prismaSupportsForms(prisma);
+  const log = logger || console;
+
+  function persistAsync(sessionId, unitId, next) {
+    if (!usePrisma) return;
+    const lastDelta = next.last_delta ? JSON.stringify(next.last_delta) : null;
+    prisma.formSessionState
+      .upsert({
+        where: { sessionId_unitId: { sessionId, unitId } },
+        create: {
+          sessionId,
+          unitId,
+          currentFormId: next.current_form_id ?? null,
+          pe: Number(next.pe ?? 0),
+          lastEvolveRound: next.last_evolve_round ?? null,
+          evolveCount: Number(next.evolve_count ?? 0),
+          lastDelta,
+        },
+        update: {
+          currentFormId: next.current_form_id ?? null,
+          pe: Number(next.pe ?? 0),
+          lastEvolveRound: next.last_evolve_round ?? null,
+          evolveCount: Number(next.evolve_count ?? 0),
+          lastDelta,
+        },
+      })
+      .catch((err) => {
+        log.warn?.(
+          `[formSessionStore] prisma upsert failed for ${sessionId}:${unitId}:`,
+          err?.message || err,
+        );
+      });
+  }
+
+  function fromPrismaRow(row) {
+    let lastDelta = null;
+    if (row.lastDelta) {
+      try {
+        lastDelta = JSON.parse(row.lastDelta);
+      } catch {
+        lastDelta = null;
+      }
+    }
+    return {
+      id: row.unitId,
+      current_form_id: row.currentFormId ?? null,
+      pe: row.pe ?? 0,
+      last_evolve_round: row.lastEvolveRound ?? null,
+      evolve_count: row.evolveCount ?? 0,
+      last_delta: lastDelta,
+      updated_at: row.updatedAt ? new Date(row.updatedAt).getTime() : Date.now(),
+    };
+  }
+
+  async function hydrate(sessionId) {
+    if (!usePrisma || !sessionId) return 0;
+    try {
+      const rows = await prisma.formSessionState.findMany({ where: { sessionId } });
+      for (const row of rows) {
+        states.set(makeKey(sessionId, row.unitId), fromPrismaRow(row));
+      }
+      return rows.length;
+    } catch (err) {
+      log.warn?.(`[formSessionStore] hydrate failed for ${sessionId}:`, err?.message || err);
+      return 0;
+    }
+  }
 
   function getUnitState(sessionId, unitId) {
     if (!sessionId || !unitId) return null;
@@ -46,6 +123,7 @@ function createFormSessionStore({ prisma = null } = {}) {
       updated_at: Date.now(),
     };
     states.set(key, next);
+    persistAsync(sessionId, unitId, next);
     return { ...next };
   }
 
@@ -92,6 +170,14 @@ function createFormSessionStore({ prisma = null } = {}) {
         removed += 1;
       }
     }
+    if (usePrisma) {
+      prisma.formSessionState.deleteMany({ where: { sessionId } }).catch((err) => {
+        log.warn?.(
+          `[formSessionStore] prisma deleteMany failed for ${sessionId}:`,
+          err?.message || err,
+        );
+      });
+    }
     return removed;
   }
 
@@ -114,8 +200,9 @@ function createFormSessionStore({ prisma = null } = {}) {
     clearSession,
     clearAll,
     size,
-    _prisma: prismaBackend, // reserved
+    hydrate,
+    _mode: usePrisma ? 'prisma' : 'in-memory',
   };
 }
 
-module.exports = { createFormSessionStore };
+module.exports = { createFormSessionStore, prismaSupportsForms };

--- a/apps/play/src/formsPanel.js
+++ b/apps/play/src/formsPanel.js
@@ -19,6 +19,7 @@ const STATE = {
   getSessionId: () => null,
   getSelectedUnit: () => null,
   getVcSnapshot: () => ({}),
+  onEvolveSuccess: null,
   lastUnitId: null,
   cachedOptions: null,
   lastPackRoll: null,
@@ -308,6 +309,14 @@ async function handleEvolveClick(opt) {
     `✓ Evoluta in ${res.data.delta.new_form_id} (${res.data.delta.label}) · PE ${res.data.delta.pe_after}`,
     'ok',
   );
+  // M12 Phase D — fire side-effect hook so host can render animation/popup/log.
+  if (typeof STATE.onEvolveSuccess === 'function') {
+    try {
+      STATE.onEvolveSuccess({ unitId: unit.id, delta: res.data.delta });
+    } catch {
+      /* non-critical */
+    }
+  }
   await refresh();
 }
 
@@ -350,11 +359,13 @@ export function initFormsPanel({
   getSessionId,
   getSelectedUnit,
   getVcSnapshot,
+  onEvolveSuccess,
   buttonId = 'forms-open',
 } = {}) {
   STATE.getSessionId = typeof getSessionId === 'function' ? getSessionId : () => null;
   STATE.getSelectedUnit = typeof getSelectedUnit === 'function' ? getSelectedUnit : () => null;
   STATE.getVcSnapshot = typeof getVcSnapshot === 'function' ? getVcSnapshot : () => ({});
+  STATE.onEvolveSuccess = typeof onEvolveSuccess === 'function' ? onEvolveSuccess : null;
   buildOverlay();
   const btn = document.getElementById(buttonId);
   if (btn) {

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -21,7 +21,7 @@ import { toggleCodex } from './codexPanel.js';
 import { initFeedbackPanel } from './feedbackPanel.js';
 import { initCampaignPanel } from './campaignPanel.js';
 import { initLobbyBridgeIfPresent } from './lobbyBridge.js';
-import { initFormsPanel } from './formsPanel.js';
+import { initFormsPanel, openFormsPanel } from './formsPanel.js';
 
 const state = {
   sid: null,
@@ -46,6 +46,10 @@ const state = {
   // Consumato da render.js (icon) + main.js tooltip (label).
   // Reset a ogni begin-planning (nuovo round) o commit-round (resolved).
   threatPreview: [],
+  // M12 Phase D — VC snapshot live pipe (ADR-2026-04-23 addendum).
+  // Shape: { session_id, per_actor: { uid: { mbti_axes, mbti_type, ennea_themes, ... } }, round }.
+  // Fetched from /api/session/:id/vc post-commitRound refresh, consumed by formsPanel.
+  vcSnapshot: null,
 };
 
 // W8b — Shared utility helpers (from Wave 8 research audit).
@@ -805,12 +809,27 @@ function processNewEvents(prevWorld, newWorld) {
   lastEventsCount = (newWorld?.events || []).length;
 }
 
+// M12 Phase D — pipe VC snapshot to state for formsPanel.
+// Fire-and-forget: failures are non-critical (panel falls back to neutral 0.5).
+async function refreshVcSnapshot() {
+  if (!state.sid) return;
+  try {
+    const r = await api.vc(state.sid);
+    if (r.ok) {
+      state.vcSnapshot = r.data;
+    }
+  } catch {
+    /* non-critical */
+  }
+}
+
 async function refresh() {
   const r = await api.state(state.sid);
   if (r.ok) {
     const prev = state.world;
     state.world = r.data;
     processNewEvents(prev, state.world);
+    refreshVcSnapshot();
     if (state.selected) {
       const sel = state.world.units.find((u) => u.id === state.selected);
       if (!sel || sel.hp <= 0) state.selected = null;
@@ -1340,26 +1359,46 @@ initHelpPanel('help-open');
 initFeedbackPanel({ getSessionId: () => state.sid });
 // M10 Phase D — campaign panel (ADR-2026-04-21)
 initCampaignPanel();
-// M12 Phase C — forms evolution panel (ADR-2026-04-23-m12-phase-a)
+// M12 Phase C+D — forms evolution panel (ADR-2026-04-23-m12-phase-a).
+// Phase D: live VC snapshot pipe (state.vcSnapshot) + evolve animation callback.
 initFormsPanel({
   getSessionId: () => state.sid,
   getSelectedUnit: () =>
     state.world && state.selected
       ? getUnits(state.world).find((u) => u.id === state.selected) || null
       : null,
-  getVcSnapshot: () => ({
-    // Placeholder axes; real VC data lives backend-side.
-    // Until /api/session/:id/vc is piped into state, we return neutral defaults
-    // so panel works, and backend projectForm falls back to center of grid.
-    round: state.world?.round ?? state.world?.turn ?? 0,
-    turn: state.world?.turn ?? 0,
-    mbti_axes: state.world?.vc_snapshot?.mbti_axes || {
-      E_I: { value: 0.5 },
-      S_N: { value: 0.5 },
-      T_F: { value: 0.5 },
-      J_P: { value: 0.5 },
-    },
-  }),
+  getVcSnapshot: () => {
+    const selUid = state.selected;
+    const perActor = state.vcSnapshot?.per_actor || {};
+    const actorVc = selUid ? perActor[selUid] : null;
+    const mbti = actorVc?.mbti_axes;
+    return {
+      round: state.world?.round ?? state.world?.turn ?? 0,
+      turn: state.world?.turn ?? 0,
+      mbti_axes:
+        mbti && Object.keys(mbti).length > 0
+          ? mbti
+          : {
+              E_I: { value: 0.5 },
+              S_N: { value: 0.5 },
+              T_F: { value: 0.5 },
+              J_P: { value: 0.5 },
+            },
+      mbti_type: actorVc?.mbti_type || null,
+    };
+  },
+  onEvolveSuccess: ({ unitId, delta }) => {
+    const unit = state.world ? getUnits(state.world).find((u) => u.id === unitId) : null;
+    if (unit?.position) {
+      pushPopup(unit.position.x, unit.position.y, `🧬 ${delta.new_form_id}`, '#66d1fb');
+    }
+    flashUnit(unitId, '#66d1fb');
+    sfx.select();
+    appendLog(
+      logEl,
+      `🧬 ${unitId} → ${delta.new_form_id} (${delta.label}) · PE ${delta.pe_before}→${delta.pe_after}`,
+    );
+  },
 });
 
 // M11 Phase B — lobby bridge (Jackbox room-code WS). Null if no session stored.
@@ -1450,4 +1489,28 @@ if (lobbyBridge?.isPlayer) {
 } else {
   loadModulations().then(() => startNewSession());
 }
-window.__evo = { state, api, refresh, lobbyBridge };
+// M12 Phase D — campaign advance helper with evolve auto-open.
+// Wraps api.campaignAdvance; if backend returns evolve_opportunity=true, opens
+// the forms panel after the encounter outcome is recorded. Consumed by campaign
+// flow triggers (manual user action, harness, host-bridge mirror).
+async function advanceCampaignWithEvolvePrompt(campaignId, outcome, peEarned = 0, piEarned = 0) {
+  const res = await api.campaignAdvance(campaignId, outcome, peEarned, piEarned);
+  if (res.ok && res.data?.evolve_opportunity) {
+    appendLog(
+      logEl,
+      `🧬 Evolve opportunity unlocked (+${res.data.evolve_pe_earned} PE ≥ ${res.data.evolve_pe_threshold})`,
+    );
+    openFormsPanel();
+  }
+  return res;
+}
+
+window.__evo = {
+  state,
+  api,
+  refresh,
+  refreshVcSnapshot,
+  advanceCampaignWithEvolvePrompt,
+  openFormsPanel,
+  lobbyBridge,
+};

--- a/docs/adr/ADR-2026-04-23-m12-phase-a-form-evolution.md
+++ b/docs/adr/ADR-2026-04-23-m12-phase-a-form-evolution.md
@@ -168,3 +168,69 @@ Mount su **sia** `/api/v1/forms` sia `/api/forms` (backward-compat con conventio
 - Pilastri audit: [`docs/planning/2026-04-20-pilastri-reality-audit.md`](../planning/2026-04-20-pilastri-reality-audit.md)
 - Strategy M9-M11: [`docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md`](../planning/2026-04-20-strategy-m9-m11-evidence-based.md)
 - personalityProjection impl: `apps/backend/services/personalityProjection.js`
+
+---
+
+## Addendum M12 Phase D (2026-04-24) — campaign trigger + VC pipe + anim + Prisma
+
+Phase D chiude Pilastro 2 (🟡++ → 🟢 candidato) con 4 wire aggiuntivi sopra l'engine A+B+C.
+
+### 1. Campaign advance trigger
+
+`POST /api/campaign/advance` aggiunge in response i campi additivi:
+
+```json
+{ "evolve_opportunity": boolean, "evolve_pe_threshold": 8, "evolve_pe_earned": N }
+```
+
+Regola: `outcome === 'victory' && pe_earned >= 8`. Helper puro `computeEvolveOpportunity(outcome, peEarned)` esportato da `apps/backend/routes/campaign.js` per consumers backend. **Frontend wire**: `window.__evo.advanceCampaignWithEvolvePrompt(id, outcome, pe, pi)` in `apps/play/src/main.js` chiama `api.campaignAdvance` e apre automaticamente `formsPanel` se flag set.
+
+### 2. VC snapshot live pipe
+
+`refresh()` in `main.js` ora fa fire-and-forget di `api.vc(sid)` dopo ogni state refresh, caching `state.vcSnapshot` (shape `{ per_actor: { uid: { mbti_axes, mbti_type, ennea_themes } }, round }`). `formsPanel.getVcSnapshot()` restituisce i veri axes del PG selezionato (non più fallback 0.5 ovunque).
+
+### 3. Animated form transition
+
+`formsPanel` espone `onEvolveSuccess({ unitId, delta })` callback. Consumer in `main.js`: `pushPopup('🧬 ' + new_form_id)` + `flashUnit(unitId, '#66d1fb')` + `sfx.select()` + log entry. Non bloccante, riusa stack FX esistente (`apps/play/src/anim.js`).
+
+### 4. Prisma write-through adapter
+
+Nuova tabella `FormSessionState` (migration `0003_form_session_state`). `formSessionStore` ora rileva `prisma.formSessionState` disponibile → `_mode: 'prisma'` + write-through upsert fire-and-forget su ogni `setUnitState/applyDelta/clearSession`. Sync API preservata (nessun breaking change route). Async `hydrate(sessionId)` preload per sessioni ripristinate post-restart.
+
+Failure mode: errore Prisma → log warn, in-memory cache resta autoritativo (graceful degrade pattern `metaProgression.createMetaStore`).
+
+### Schema migration
+
+```sql
+CREATE TABLE form_session_states (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  unit_id TEXT NOT NULL,
+  current_form_id TEXT,
+  pe INTEGER NOT NULL DEFAULT 0,
+  last_evolve_round INTEGER,
+  evolve_count INTEGER NOT NULL DEFAULT 0,
+  last_delta TEXT,
+  created_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE UNIQUE INDEX form_session_states_session_id_unit_id_key ON form_session_states(session_id, unit_id);
+CREATE INDEX form_session_states_session_id_idx ON form_session_states(session_id);
+```
+
+### Test delta Phase D
+
+- `tests/api/campaignRoutes.test.js` +4 test `evolve_opportunity` variants (27/27 totale)
+- `tests/api/formSessionStorePrisma.test.js` +6 test adapter (supports detection, mode, write-through, hydrate, clear, failure fallback)
+
+**Totale test M12 suite**: 25 (A) + 27 (B) + 5 (C) + 4 (D-campaign) + 6 (D-prisma) = **67**. Baseline full-stack: **360+/360+** (307 AI + 26 lobby + 27 campaign routes + 67 M12 + altri).
+
+### Pilastro 2 post-Phase D
+
+- Pre-M12: 🔴 (dataset only)
+- Post-A: 🟡 (engine + REST)
+- Post-B: 🟡+ (session persistence + pack roller)
+- Post-C: 🟡++ (frontend panel UI)
+- **Post-D**: **🟢 candidato** (campaign trigger + VC pipe + animation + DB persistence)
+
+Residuo gating 🟢: end-to-end playtest validation in-session (non-automatizzabile, userland), campaign integration live test (hooked via `window.__evo.advanceCampaignWithEvolvePrompt` ma non ancora chiamato dallo scenario loop).

--- a/tests/api/campaignRoutes.test.js
+++ b/tests/api/campaignRoutes.test.js
@@ -237,3 +237,60 @@ test('GET /api/campaign/summary: unknown id = 404', async (t) => {
   const res = await request('GET', `${url}/api/campaign/summary?id=nonexistent-uuid`);
   assert.equal(res.status, 404);
 });
+
+// M12 Phase D — evolve_opportunity flag (ADR-2026-04-23 addendum).
+
+test('advance: victory + pe_earned >= 8 sets evolve_opportunity=true', async (t) => {
+  const { url } = startTestServer(t);
+  const create = await request('POST', `${url}/api/campaign/start`, { player_id: 'p1' });
+  const id = create.body.campaign.id;
+  const res = await request('POST', `${url}/api/campaign/advance`, {
+    id,
+    outcome: 'victory',
+    pe_earned: 8,
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.evolve_opportunity, true);
+  assert.equal(res.body.evolve_pe_threshold, 8);
+  assert.equal(res.body.evolve_pe_earned, 8);
+});
+
+test('advance: victory + pe_earned < 8 sets evolve_opportunity=false', async (t) => {
+  const { url } = startTestServer(t);
+  const create = await request('POST', `${url}/api/campaign/start`, { player_id: 'p1' });
+  const id = create.body.campaign.id;
+  const res = await request('POST', `${url}/api/campaign/advance`, {
+    id,
+    outcome: 'victory',
+    pe_earned: 5,
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.evolve_opportunity, false);
+  assert.equal(res.body.evolve_pe_earned, 5);
+});
+
+test('advance: defeat never triggers evolve_opportunity', async (t) => {
+  const { url } = startTestServer(t);
+  const create = await request('POST', `${url}/api/campaign/start`, { player_id: 'p1' });
+  const id = create.body.campaign.id;
+  const res = await request('POST', `${url}/api/campaign/advance`, {
+    id,
+    outcome: 'defeat',
+    pe_earned: 20,
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.retry, true);
+  assert.equal(res.body.evolve_opportunity, false);
+});
+
+test('computeEvolveOpportunity exported pure helper', () => {
+  const mod = require('../../apps/backend/routes/campaign');
+  assert.equal(mod.PE_EVOLVE_TRIGGER_THRESHOLD, 8);
+  assert.deepEqual(mod.computeEvolveOpportunity('victory', 8), {
+    evolve_opportunity: true,
+    evolve_pe_threshold: 8,
+    evolve_pe_earned: 8,
+  });
+  assert.equal(mod.computeEvolveOpportunity('victory', 7).evolve_opportunity, false);
+  assert.equal(mod.computeEvolveOpportunity('timeout', 50).evolve_opportunity, false);
+});

--- a/tests/api/formSessionStorePrisma.test.js
+++ b/tests/api/formSessionStorePrisma.test.js
@@ -1,0 +1,145 @@
+// M12 Phase D — formSessionStore Prisma write-through adapter tests.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createFormSessionStore,
+  prismaSupportsForms,
+} = require('../../apps/backend/services/forms/formSessionStore');
+
+function createMockPrisma() {
+  const rows = new Map(); // `${sid}:${uid}` → row
+  const silentLogger = { warn: () => {} };
+  const client = {
+    formSessionState: {
+      async upsert({ where, create, update }) {
+        const { sessionId, unitId } = where.sessionId_unitId;
+        const key = `${sessionId}:${unitId}`;
+        const existing = rows.get(key);
+        const now = new Date();
+        if (existing) {
+          const merged = { ...existing, ...update, updatedAt: now };
+          rows.set(key, merged);
+          return merged;
+        }
+        const fresh = {
+          id: `row-${rows.size + 1}`,
+          sessionId,
+          unitId,
+          createdAt: now,
+          updatedAt: now,
+          ...create,
+        };
+        rows.set(key, fresh);
+        return fresh;
+      },
+      async findMany({ where }) {
+        return Array.from(rows.values()).filter((r) => r.sessionId === where.sessionId);
+      },
+      async deleteMany({ where }) {
+        let n = 0;
+        for (const [k, v] of rows.entries()) {
+          if (v.sessionId === where.sessionId) {
+            rows.delete(k);
+            n += 1;
+          }
+        }
+        return { count: n };
+      },
+    },
+  };
+  return { client, rows, logger: silentLogger };
+}
+
+test('prismaSupportsForms: detects compatible client', () => {
+  const { client } = createMockPrisma();
+  assert.equal(prismaSupportsForms(client), true);
+  assert.equal(prismaSupportsForms(null), false);
+  assert.equal(prismaSupportsForms({ formSessionState: {} }), false);
+});
+
+test('store._mode reports prisma when adapter detected', () => {
+  const { client, logger } = createMockPrisma();
+  const store = createFormSessionStore({ prisma: client, logger });
+  assert.equal(store._mode, 'prisma');
+  const mem = createFormSessionStore();
+  assert.equal(mem._mode, 'in-memory');
+});
+
+test('seedUnit + applyDelta write-through to prisma', async () => {
+  const { client, rows, logger } = createMockPrisma();
+  const store = createFormSessionStore({ prisma: client, logger });
+  store.seedUnit('sess1', 'u1', { pe: 10, current_form_id: 'ESTP' });
+  store.applyDelta('sess1', 'u1', { new_form_id: 'INTJ', pe_after: 2, round: 3 });
+  // Writes are fire-and-forget; wait a tick for microtasks to flush.
+  await new Promise((r) => setImmediate(r));
+  const row = rows.get('sess1:u1');
+  assert.ok(row);
+  assert.equal(row.currentFormId, 'INTJ');
+  assert.equal(row.pe, 2);
+  assert.equal(row.lastEvolveRound, 3);
+  assert.equal(row.evolveCount, 1);
+  const parsed = JSON.parse(row.lastDelta);
+  assert.equal(parsed.new_form_id, 'INTJ');
+});
+
+test('hydrate populates in-memory map from prisma rows', async () => {
+  const { client, rows, logger } = createMockPrisma();
+  // Pre-seed DB outside the store.
+  rows.set('sess2:uA', {
+    id: 'rowA',
+    sessionId: 'sess2',
+    unitId: 'uA',
+    currentFormId: 'ENFP',
+    pe: 7,
+    lastEvolveRound: 2,
+    evolveCount: 1,
+    lastDelta: JSON.stringify({ new_form_id: 'ENFP' }),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  const store = createFormSessionStore({ prisma: client, logger });
+  assert.equal(store.getUnitState('sess2', 'uA'), null);
+  const n = await store.hydrate('sess2');
+  assert.equal(n, 1);
+  const state = store.getUnitState('sess2', 'uA');
+  assert.equal(state.current_form_id, 'ENFP');
+  assert.equal(state.pe, 7);
+  assert.equal(state.evolve_count, 1);
+  assert.equal(state.last_delta.new_form_id, 'ENFP');
+});
+
+test('clearSession deletes prisma rows + in-memory entries', async () => {
+  const { client, rows, logger } = createMockPrisma();
+  const store = createFormSessionStore({ prisma: client, logger });
+  store.seedUnit('sess3', 'u1', { pe: 5 });
+  store.seedUnit('sess3', 'u2', { pe: 5 });
+  store.seedUnit('sess4', 'uX', { pe: 5 });
+  await new Promise((r) => setImmediate(r));
+  assert.equal(rows.size, 3);
+  const removed = store.clearSession('sess3');
+  assert.equal(removed, 2);
+  await new Promise((r) => setImmediate(r));
+  assert.equal(rows.size, 1);
+  assert.ok(rows.has('sess4:uX'));
+});
+
+test('prisma upsert failure does not throw; in-memory still updated', async () => {
+  const failingClient = {
+    formSessionState: {
+      upsert: () => Promise.reject(new Error('db down')),
+      findMany: async () => [],
+      deleteMany: async () => ({ count: 0 }),
+    },
+  };
+  const store = createFormSessionStore({ prisma: failingClient, logger: { warn: () => {} } });
+  const state = store.seedUnit('sess5', 'u1', { pe: 4 });
+  assert.equal(state.pe, 4);
+  await new Promise((r) => setImmediate(r));
+  // In-memory cache kept consistent even when prisma upsert fails.
+  const again = store.getUnitState('sess5', 'u1');
+  assert.equal(again.pe, 4);
+});


### PR DESCRIPTION
## Summary

M12 Phase D chiude Pilastro 2 (🟡++ → 🟢 candidato). 4 wire sopra engine A+B+C shipped last session:

1. **Campaign advance trigger** — `/api/campaign/advance` response += `{ evolve_opportunity, evolve_pe_threshold: 8, evolve_pe_earned }` su `victory + pe_earned >= 8`. Helper puro `computeEvolveOpportunity` esportato. Frontend wire via `window.__evo.advanceCampaignWithEvolvePrompt(id, outcome, pe, pi)` apre `formsPanel` automaticamente se flag set.
2. **VC snapshot live pipe** — `main.js refresh()` chiama `api.vc(sid)` fire-and-forget, caching `state.vcSnapshot` (per_actor mbti_axes + mbti_type). `formsPanel.getVcSnapshot()` restituisce axes reali del PG selezionato (non più 0.5 fallback).
3. **Evolve animation** — `formsPanel.onEvolveSuccess({unitId, delta})` callback → `pushPopup('🧬 ' + new_form_id, '#66d1fb')` + `flashUnit` + `sfx.select` + log entry. Non bloccante.
4. **Prisma write-through adapter** — nuovo model `FormSessionState` (migration 0003) + `formSessionStore` mode 'prisma' con upsert fire-and-forget. Async `hydrate(sessionId)` preload. In-memory fallback quando `DATABASE_URL` unset (graceful degrade pattern `metaProgression.createMetaStore`).

## Scope

- Backend: +`computeEvolveOpportunity` helper + additive response fields (solo victory/completed/act_advanced/choice branches). Defeat+timeout → `evolve_opportunity=false`.
- Frontend: main.js state.vcSnapshot + advanceCampaignWithEvolvePrompt + onEvolveSuccess wire. `openFormsPanel` export diretto.
- Prisma: schema FormSessionState + migration SQL 0003. formSessionStore detection via `prismaSupportsForms(prisma)`.
- ADR addendum: sezione Phase D in ADR-2026-04-23-m12-phase-a.

## Test plan

- [x] `node --test tests/api/campaignRoutes.test.js` → 21→27/27 (+4 evolve_opportunity variants, +1 helper export)
- [x] `node --test tests/api/formSessionStorePrisma.test.js` → 6/6 (supports detection, _mode, write-through, hydrate, clearSession delete, failure fallback)
- [x] `node --test tests/api/formEvolution.test.js tests/api/formsRoutes.test.js tests/api/formSessionStore.test.js tests/api/packRoller.test.js tests/api/formsRoutesSessionPack.test.js tests/api/formsPanelInfer.test.js` → 63/63 (+6 vs baseline 57)
- [x] `node --test tests/ai/*.test.js` → 307/307
- [x] `node --test tests/api/lobbyRoutes.test.js tests/api/lobbyWebSocket.test.js` → 15/15
- [x] `node --test tests/e2e/lobbyEndToEnd.test.mjs` → 11/11
- [x] `npm run format:check` → verde

**Grand total**: 307 AI + 26 lobby/e2e + 63 M12 suite + 27 campaignRoutes = 423+ (baseline 390 + 10 nuovi test Phase D + altri preservati).

## Rollback

- Campaign flag: rimuovere spread `...evolveFlags` da response branches → shape back-compat (nessun consumer breaking).
- Frontend: rimuovere wire `onEvolveSuccess` + `refreshVcSnapshot` → panel torna fallback 0.5.
- Prisma: migration reversibile `DROP TABLE form_session_states;` + rimuovere model da schema. formSessionStore mantiene API sync: senza `prisma.formSessionState` → `_mode: 'in-memory'` automatico.

## Pilastro 2 progression

- Pre-M12: 🔴 (dataset only)
- Post-A: 🟡 (engine + REST)
- Post-B: 🟡+ (session persistence + pack roller)
- Post-C: 🟡++ (frontend panel UI)
- **Post-D**: **🟢 candidato** — residuo gating: playtest live end-to-end (non-automatizzabile)

## Files changed

- `apps/backend/routes/campaign.js` (+35) — evolve_opportunity flags
- `apps/backend/services/forms/formSessionStore.js` (+97) — Prisma write-through adapter
- `apps/backend/prisma/schema.prisma` (+22) — FormSessionState model
- `apps/backend/prisma/migrations/0003_form_session_state/migration.sql` (NEW, 23 LOC)
- `apps/play/src/main.js` (+95) — VC pipe + advance wrapper + onEvolveSuccess
- `apps/play/src/formsPanel.js` (+11) — onEvolveSuccess callback
- `tests/api/campaignRoutes.test.js` (+57) — evolve_opportunity tests
- `tests/api/formSessionStorePrisma.test.js` (NEW, 130 LOC) — adapter tests
- `docs/adr/ADR-2026-04-23-m12-phase-a-form-evolution.md` (+66) — Phase D addendum

🤖 Generated with [Claude Code](https://claude.com/claude-code)