### PR TITLE
feat(progression): M13 P3 — character progression XCOM EU/EW perk-pair (Pilastro 3 🟡+)

### DIFF
--- a/apps/backend/prisma/migrations/0004_unit_progression/migration.sql
+++ b/apps/backend/prisma/migrations/0004_unit_progression/migration.sql
@@ -1,0 +1,23 @@
+-- M13 P3 character progression persistence (ADR-2026-04-24 pending).
+-- Model: UnitProgression. XP + level + picked perks per unit × campaign.
+
+-- CreateTable
+CREATE TABLE "unit_progressions" (
+    "id" TEXT NOT NULL,
+    "campaign_id" TEXT,
+    "unit_id" TEXT NOT NULL,
+    "job" TEXT NOT NULL,
+    "xp_total" INTEGER NOT NULL DEFAULT 0,
+    "level" INTEGER NOT NULL DEFAULT 1,
+    "picked_perks" TEXT NOT NULL DEFAULT '[]',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "unit_progressions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "unit_progressions_campaign_id_unit_id_key" ON "unit_progressions"("campaign_id", "unit_id");
+
+-- CreateIndex
+CREATE INDEX "unit_progressions_campaign_id_idx" ON "unit_progressions"("campaign_id");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -225,6 +225,25 @@ model NestState {
   @@map("nest_states")
 }
 
+// ─── M13 P3 Character progression persistence (ADR-2026-04-24 pending) ────
+// XP + perk-pair picks per unit × campaign.
+
+model UnitProgression {
+  id          String   @id @default(uuid())
+  campaignId  String?  @map("campaign_id")
+  unitId      String   @map("unit_id")
+  job         String
+  xpTotal     Int      @default(0) @map("xp_total")
+  level       Int      @default(1)
+  pickedPerks String   @default("[]") @map("picked_perks") // JSON array of { level, perk_id, choice }
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  @@unique([campaignId, unitId])
+  @@index([campaignId])
+  @@map("unit_progressions")
+}
+
 // ─── M12 Phase D Form evolution persistence (ADR-2026-04-23 addendum) ─────
 // Promotes formSessionStore in-memory Map → DB-backed write-through cache.
 // Adapter preserves in-memory fallback when DATABASE_URL unset (dev/demo/tests).

--- a/apps/backend/routes/progression.js
+++ b/apps/backend/routes/progression.js
@@ -1,0 +1,124 @@
+// M13 P3 — Progression routes.
+// ADR-2026-04-24-p3-character-progression (pending).
+//
+// Endpoints (scoped by optional campaign_id query param):
+//   GET  /api/v1/progression/registry                 — snapshot (xp thresholds + jobs)
+//   GET  /api/v1/progression/jobs/:jobId/perks        — perk tree for job
+//   GET  /api/v1/progression/:unitId?campaign_id=X    — unit state
+//   POST /api/v1/progression/:unitId/seed             — seed { job, xp_total? }
+//   POST /api/v1/progression/:unitId/xp               — grant xp { amount }
+//   POST /api/v1/progression/:unitId/pick             — pick perk { level, choice: 'a'|'b' }
+//   GET  /api/v1/progression/:unitId/effective        — derived stats + passives + ability mods
+//   DELETE /api/v1/progression/campaign/:campaignId   — clear scope
+
+'use strict';
+
+const { Router } = require('express');
+const { ProgressionEngine } = require('../services/progression/progressionEngine');
+const { createProgressionStore } = require('../services/progression/progressionStore');
+
+function createProgressionRouter(opts = {}) {
+  const engine = opts.engine || new ProgressionEngine(opts);
+  const store = opts.store || createProgressionStore({ prisma: opts.prisma || null });
+  const router = Router();
+
+  router.get('/registry', (_req, res) => {
+    res.json(engine.snapshot());
+  });
+
+  router.get('/jobs/:jobId/perks', (req, res) => {
+    const jobId = req.params.jobId;
+    const jobPerks = engine.perks?.jobs?.[jobId];
+    if (!jobPerks) return res.status(404).json({ error: 'job_not_found' });
+    res.json({ job_id: jobId, perks: jobPerks.perks || {} });
+  });
+
+  router.get('/:unitId', (req, res) => {
+    const campaignId = req.query.campaign_id || null;
+    const state = store.get(campaignId, req.params.unitId);
+    if (!state) return res.status(404).json({ error: 'unit_progression_not_found' });
+    res.json(state);
+  });
+
+  router.post('/:unitId/seed', (req, res) => {
+    const { job, xp_total: xpTotal = 0, campaign_id: campaignId = null } = req.body || {};
+    if (!job) return res.status(400).json({ error: 'job required' });
+    if (!engine.perks?.jobs?.[job]) {
+      return res.status(400).json({ error: `unknown job "${job}"` });
+    }
+    const seeded = engine.seed(req.params.unitId, job, { xpTotal: Number(xpTotal) || 0 });
+    const persisted = store.set(campaignId, req.params.unitId, seeded);
+    res.status(201).json(persisted);
+  });
+
+  router.post('/:unitId/xp', (req, res) => {
+    const { amount, campaign_id: campaignId = null } = req.body || {};
+    if (!Number.isFinite(Number(amount))) {
+      return res.status(400).json({ error: 'amount (number) required' });
+    }
+    const unit = store.get(campaignId, req.params.unitId);
+    if (!unit) return res.status(404).json({ error: 'unit_progression_not_found' });
+    const result = engine.applyXp(unit, Number(amount));
+    const persisted = store.set(campaignId, req.params.unitId, result.unit);
+    res.json({
+      ok: true,
+      state: persisted,
+      delta: {
+        xp_granted: result.xp_granted,
+        xp_before: result.xp_before,
+        xp_after: result.xp_after,
+        level_before: result.level_before,
+        level_after: result.level_after,
+        leveled_up: result.leveled_up,
+      },
+      pending_level_ups: engine.pendingLevelUps(persisted),
+    });
+  });
+
+  router.post('/:unitId/pick', (req, res) => {
+    const { level, choice, campaign_id: campaignId = null } = req.body || {};
+    if (!Number.isFinite(Number(level))) {
+      return res.status(400).json({ error: 'level (number) required' });
+    }
+    if (!['a', 'b'].includes(choice)) {
+      return res.status(400).json({ error: "choice must be 'a' or 'b'" });
+    }
+    const unit = store.get(campaignId, req.params.unitId);
+    if (!unit) return res.status(404).json({ error: 'unit_progression_not_found' });
+    try {
+      const result = engine.pickPerk(unit, Number(level), choice);
+      const persisted = store.set(campaignId, req.params.unitId, result.unit);
+      res.json({
+        ok: true,
+        state: persisted,
+        picked_perk: result.picked_perk,
+        pick: result.pick,
+      });
+    } catch (err) {
+      res.status(409).json({ ok: false, error: err.message });
+    }
+  });
+
+  router.get('/:unitId/effective', (req, res) => {
+    const campaignId = req.query.campaign_id || null;
+    const unit = store.get(campaignId, req.params.unitId);
+    if (!unit) return res.status(404).json({ error: 'unit_progression_not_found' });
+    res.json({
+      unit_id: unit.unit_id,
+      level: unit.level,
+      xp_total: unit.xp_total,
+      stats: engine.effectiveStats(unit),
+      passives: engine.listPassives(unit),
+      ability_mods: engine.listAbilityMods(unit),
+    });
+  });
+
+  router.delete('/campaign/:campaignId', (req, res) => {
+    const removed = store.clearCampaign(req.params.campaignId);
+    res.json({ campaign_id: req.params.campaignId, removed });
+  });
+
+  return router;
+}
+
+module.exports = { createProgressionRouter };

--- a/apps/backend/services/pluginLoader.js
+++ b/apps/backend/services/pluginLoader.js
@@ -93,11 +93,29 @@ const formsPlugin = {
   },
 };
 
+// M13 P3 — character progression (XP + perk-pair) engine + routes.
+const progressionPlugin = {
+  name: 'progression',
+  register(app) {
+    const { createProgressionRouter } = require('../routes/progression');
+    const router = createProgressionRouter();
+    app.use('/api/v1/progression', router);
+    app.use('/api/progression', router);
+  },
+};
+
 /**
  * Lista plugin built-in. Aggiungere nuovi plugin qui.
  * Ordine = ordine di registrazione.
  */
-const BUILTIN_PLUGINS = [narrativePlugin, metaPlugin, tutorialPlugin, jobsPlugin, formsPlugin];
+const BUILTIN_PLUGINS = [
+  narrativePlugin,
+  metaPlugin,
+  tutorialPlugin,
+  jobsPlugin,
+  formsPlugin,
+  progressionPlugin,
+];
 
 module.exports = {
   loadPlugins,
@@ -107,4 +125,5 @@ module.exports = {
   tutorialPlugin,
   jobsPlugin,
   formsPlugin,
+  progressionPlugin,
 };

--- a/apps/backend/services/progression/progressionEngine.js
+++ b/apps/backend/services/progression/progressionEngine.js
@@ -1,0 +1,237 @@
+// M13 P3 — Progression engine.
+// ADR-2026-04-24-p3-character-progression (pending).
+//
+// Responsibility: XP → level mapping, level-up detection, perk pick validation,
+// stat/passive projection. Pure functions + class wrapping cached YAML.
+//
+// Data model:
+//   UnitProgression = {
+//     unit_id: string,
+//     job: string,
+//     xp_total: number,
+//     level: number,           // derived from xp_total via curve
+//     picked_perks: [           // caller-owned append-only
+//       { level: 2, perk_id: 'sk_r1_flank_specialist' },
+//       ...
+//     ],
+//   }
+//
+// Engine API:
+//   computeLevel(xp, curve)                     → number (1..max_level)
+//   computePendingLevelUps(unit, curve)         → [{ level, perk_choice: {a,b} }, ...]
+//   applyXp(unit, amount, { curve })            → { unit, leveled_up: bool, new_level }
+//   pickPerk(unit, level, choice, { perks })    → { unit, picked_perk } | throws
+//   effectiveStats(unit, perksData)             → { attack_mod, defense_mod, hp_max, ap, initiative, attack_range }
+//   listPassives(unit, perksData)               → [{ tag, payload, source_perk_id }]
+//   listAbilityMods(unit, perksData)            → [{ ability_id, field, delta, source_perk_id }]
+
+'use strict';
+
+const { loadXpCurve, loadPerks } = require('./progressionLoader');
+
+function computeLevel(xpTotal, curve) {
+  const thresholds = curve?.level_xp_thresholds || { 1: 0 };
+  const levels = Object.keys(thresholds)
+    .map(Number)
+    .sort((a, b) => a - b);
+  let level = 1;
+  for (const l of levels) {
+    if (xpTotal >= thresholds[l]) level = l;
+  }
+  return level;
+}
+
+function getLevelPerkChoice(perksData, jobId, level) {
+  const jobPerks = perksData?.jobs?.[jobId]?.perks;
+  if (!jobPerks) return null;
+  const entry = jobPerks[`level_${level}`];
+  if (!entry) return null;
+  return {
+    level,
+    perk_a: entry.perk_a,
+    perk_b: entry.perk_b,
+  };
+}
+
+function computePendingLevelUps(unit, perksData) {
+  const pickedByLevel = new Set((unit.picked_perks || []).map((p) => p.level));
+  const out = [];
+  for (let l = 2; l <= unit.level; l += 1) {
+    if (pickedByLevel.has(l)) continue;
+    const choice = getLevelPerkChoice(perksData, unit.job, l);
+    if (choice) out.push({ level: l, choice });
+  }
+  return out;
+}
+
+function applyXp(unit, amount, { curve } = {}) {
+  const xpCurve = curve || loadXpCurve();
+  const grantAmount = Math.max(0, Number(amount) || 0);
+  const xpBefore = Number(unit.xp_total || 0);
+  const levelBefore = Number(unit.level || 1);
+  const maxLevel = xpCurve.max_level || 7;
+
+  const xpAfter = xpBefore + grantAmount;
+  const rawLevel = computeLevel(xpAfter, xpCurve);
+  const newLevel = Math.min(rawLevel, maxLevel);
+
+  const updated = {
+    ...unit,
+    xp_total: xpAfter,
+    level: newLevel,
+  };
+  return {
+    unit: updated,
+    xp_granted: grantAmount,
+    xp_before: xpBefore,
+    xp_after: xpAfter,
+    level_before: levelBefore,
+    level_after: newLevel,
+    leveled_up: newLevel > levelBefore,
+  };
+}
+
+function pickPerk(unit, level, choice, { perks } = {}) {
+  const perksData = perks || loadPerks();
+  if (!['a', 'b'].includes(choice)) {
+    throw new Error(`invalid choice "${choice}": must be 'a' or 'b'`);
+  }
+  if (unit.level < level) {
+    throw new Error(`unit level ${unit.level} < required level ${level}`);
+  }
+  const existing = (unit.picked_perks || []).find((p) => p.level === level);
+  if (existing) {
+    throw new Error(`perk at level ${level} already picked: ${existing.perk_id}`);
+  }
+  const pair = getLevelPerkChoice(perksData, unit.job, level);
+  if (!pair) {
+    throw new Error(`no perk pair defined for job ${unit.job} level ${level}`);
+  }
+  const perk = choice === 'a' ? pair.perk_a : pair.perk_b;
+  const pickRecord = { level, perk_id: perk.id, choice };
+  const updated = {
+    ...unit,
+    picked_perks: [...(unit.picked_perks || []), pickRecord],
+  };
+  return { unit: updated, picked_perk: perk, pick: pickRecord };
+}
+
+function collectPerkEffects(unit, perksData) {
+  const effects = [];
+  for (const pick of unit.picked_perks || []) {
+    const pair = getLevelPerkChoice(perksData, unit.job, pick.level);
+    if (!pair) continue;
+    const perk =
+      pair[`perk_${pick.choice}`] || (pair.perk_a?.id === pick.perk_id ? pair.perk_a : pair.perk_b);
+    if (!perk) continue;
+    effects.push({ perk_id: perk.id, effect: perk.effect || {}, level: pick.level });
+  }
+  return effects;
+}
+
+const STAT_KEYS = ['hp_max', 'ap', 'attack_mod', 'defense_mod', 'initiative', 'attack_range'];
+
+function effectiveStats(unit, perksData) {
+  const data = perksData || loadPerks();
+  const bonuses = Object.fromEntries(STAT_KEYS.map((k) => [k, 0]));
+  for (const { effect } of collectPerkEffects(unit, data)) {
+    for (const [key, val] of Object.entries(effect)) {
+      if (!key.startsWith('stat_bonus')) continue;
+      if (!val || typeof val !== 'object') continue;
+      if (STAT_KEYS.includes(val.stat)) {
+        bonuses[val.stat] += Number(val.amount) || 0;
+      }
+    }
+  }
+  return bonuses;
+}
+
+function listPassives(unit, perksData) {
+  const data = perksData || loadPerks();
+  const out = [];
+  for (const { perk_id: perkId, effect } of collectPerkEffects(unit, data)) {
+    if (effect.passive && effect.passive.tag) {
+      out.push({
+        tag: effect.passive.tag,
+        payload: effect.passive.payload || {},
+        source_perk_id: perkId,
+      });
+    }
+  }
+  return out;
+}
+
+function listAbilityMods(unit, perksData) {
+  const data = perksData || loadPerks();
+  const out = [];
+  for (const { perk_id: perkId, effect } of collectPerkEffects(unit, data)) {
+    if (effect.ability_mod) {
+      out.push({
+        ability_id: effect.ability_mod.ability_id,
+        field: effect.ability_mod.field,
+        delta: Number(effect.ability_mod.delta) || 0,
+        source_perk_id: perkId,
+      });
+    }
+  }
+  return out;
+}
+
+class ProgressionEngine {
+  constructor({ xpCurve = null, perks = null } = {}) {
+    this.xpCurve = xpCurve || loadXpCurve();
+    this.perks = perks || loadPerks();
+  }
+  seed(unitId, job, { xpTotal = 0 } = {}) {
+    const level = Math.min(computeLevel(xpTotal, this.xpCurve), this.xpCurve.max_level || 7);
+    return {
+      unit_id: unitId,
+      job,
+      xp_total: xpTotal,
+      level,
+      picked_perks: [],
+    };
+  }
+  applyXp(unit, amount) {
+    return applyXp(unit, amount, { curve: this.xpCurve });
+  }
+  pendingLevelUps(unit) {
+    return computePendingLevelUps(unit, this.perks);
+  }
+  pickPerk(unit, level, choice) {
+    return pickPerk(unit, level, choice, { perks: this.perks });
+  }
+  effectiveStats(unit) {
+    return effectiveStats(unit, this.perks);
+  }
+  listPassives(unit) {
+    return listPassives(unit, this.perks);
+  }
+  listAbilityMods(unit) {
+    return listAbilityMods(unit, this.perks);
+  }
+  getPerkPair(jobId, level) {
+    return getLevelPerkChoice(this.perks, jobId, level);
+  }
+  snapshot() {
+    const jobs = Object.keys(this.perks?.jobs || {});
+    return {
+      version: this.perks?.version || null,
+      xp_max_level: this.xpCurve?.max_level || 7,
+      xp_thresholds: this.xpCurve?.level_xp_thresholds || {},
+      jobs,
+    };
+  }
+}
+
+module.exports = {
+  ProgressionEngine,
+  computeLevel,
+  computePendingLevelUps,
+  applyXp,
+  pickPerk,
+  effectiveStats,
+  listPassives,
+  listAbilityMods,
+  getLevelPerkChoice,
+};

--- a/apps/backend/services/progression/progressionLoader.js
+++ b/apps/backend/services/progression/progressionLoader.js
@@ -1,0 +1,39 @@
+// M13 P3 — YAML loader for progression (xp_curve + perks).
+// ADR-2026-04-24-p3-character-progression (pending).
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const DEFAULT_XP_PATH = path.resolve(__dirname, '../../../../data/core/progression/xp_curve.yaml');
+const DEFAULT_PERKS_PATH = path.resolve(__dirname, '../../../../data/core/progression/perks.yaml');
+
+let _xpCache = null;
+let _perksCache = null;
+
+function loadXpCurve(p = DEFAULT_XP_PATH) {
+  if (_xpCache && _xpCache.__path === p) return _xpCache;
+  const raw = fs.readFileSync(p, 'utf-8');
+  const data = yaml.load(raw);
+  data.__path = p;
+  _xpCache = data;
+  return data;
+}
+
+function loadPerks(p = DEFAULT_PERKS_PATH) {
+  if (_perksCache && _perksCache.__path === p) return _perksCache;
+  const raw = fs.readFileSync(p, 'utf-8');
+  const data = yaml.load(raw);
+  data.__path = p;
+  _perksCache = data;
+  return data;
+}
+
+function resetProgressionCache() {
+  _xpCache = null;
+  _perksCache = null;
+}
+
+module.exports = { loadXpCurve, loadPerks, resetProgressionCache };

--- a/apps/backend/services/progression/progressionStore.js
+++ b/apps/backend/services/progression/progressionStore.js
@@ -1,0 +1,157 @@
+// M13 P3 — Progression store (in-memory + optional Prisma write-through).
+// Mirrors formSessionStore M12 Phase D adapter pattern.
+//
+// Key: `${campaignId}:${unitId}` (campaignId null → global scope for tests).
+
+'use strict';
+
+function makeKey(campaignId, unitId) {
+  return `${campaignId || '__global__'}:${unitId}`;
+}
+
+function prismaSupports(prisma) {
+  return Boolean(
+    prisma &&
+      prisma.unitProgression &&
+      typeof prisma.unitProgression.upsert === 'function' &&
+      typeof prisma.unitProgression.findMany === 'function',
+  );
+}
+
+function createProgressionStore({ prisma = null, logger = null } = {}) {
+  const states = new Map();
+  const usePrisma = prismaSupports(prisma);
+  const log = logger || console;
+
+  function persistAsync(campaignId, unitId, next) {
+    if (!usePrisma) return;
+    const pickedJson = JSON.stringify(next.picked_perks || []);
+    prisma.unitProgression
+      .upsert({
+        where: {
+          campaignId_unitId: { campaignId: campaignId || null, unitId },
+        },
+        create: {
+          campaignId: campaignId || null,
+          unitId,
+          job: next.job,
+          xpTotal: Number(next.xp_total || 0),
+          level: Number(next.level || 1),
+          pickedPerks: pickedJson,
+        },
+        update: {
+          job: next.job,
+          xpTotal: Number(next.xp_total || 0),
+          level: Number(next.level || 1),
+          pickedPerks: pickedJson,
+        },
+      })
+      .catch((err) => {
+        log.warn?.(
+          `[progressionStore] prisma upsert failed for ${campaignId || '__global__'}:${unitId}:`,
+          err?.message || err,
+        );
+      });
+  }
+
+  function fromRow(row) {
+    let picked = [];
+    if (row.pickedPerks) {
+      try {
+        picked = JSON.parse(row.pickedPerks);
+      } catch {
+        picked = [];
+      }
+    }
+    return {
+      unit_id: row.unitId,
+      job: row.job,
+      xp_total: row.xpTotal || 0,
+      level: row.level || 1,
+      picked_perks: Array.isArray(picked) ? picked : [],
+      updated_at: row.updatedAt ? new Date(row.updatedAt).getTime() : Date.now(),
+    };
+  }
+
+  function get(campaignId, unitId) {
+    const state = states.get(makeKey(campaignId, unitId));
+    return state ? { ...state, picked_perks: [...(state.picked_perks || [])] } : null;
+  }
+
+  function set(campaignId, unitId, state) {
+    if (!unitId) throw new Error('unit_id required');
+    const next = {
+      ...state,
+      unit_id: unitId,
+      updated_at: Date.now(),
+    };
+    states.set(makeKey(campaignId, unitId), next);
+    persistAsync(campaignId, unitId, next);
+    return { ...next, picked_perks: [...(next.picked_perks || [])] };
+  }
+
+  function list(campaignId) {
+    const prefix = `${campaignId || '__global__'}:`;
+    const out = [];
+    for (const [key, val] of states.entries()) {
+      if (key.startsWith(prefix)) out.push({ ...val });
+    }
+    return out;
+  }
+
+  function clearCampaign(campaignId) {
+    const prefix = `${campaignId || '__global__'}:`;
+    let removed = 0;
+    for (const key of Array.from(states.keys())) {
+      if (key.startsWith(prefix)) {
+        states.delete(key);
+        removed += 1;
+      }
+    }
+    if (usePrisma) {
+      prisma.unitProgression
+        .deleteMany({ where: { campaignId: campaignId || null } })
+        .catch((err) => log.warn?.('[progressionStore] deleteMany failed:', err?.message || err));
+    }
+    return removed;
+  }
+
+  async function hydrate(campaignId) {
+    if (!usePrisma) return 0;
+    try {
+      const rows = await prisma.unitProgression.findMany({
+        where: { campaignId: campaignId || null },
+      });
+      for (const row of rows) {
+        states.set(makeKey(campaignId, row.unitId), fromRow(row));
+      }
+      return rows.length;
+    } catch (err) {
+      log.warn?.(`[progressionStore] hydrate failed:`, err?.message || err);
+      return 0;
+    }
+  }
+
+  function size() {
+    return states.size;
+  }
+
+  function clearAll() {
+    const n = states.size;
+    states.clear();
+    return n;
+  }
+
+  return {
+    get,
+    set,
+    list,
+    clearCampaign,
+    hydrate,
+    size,
+    clearAll,
+    _mode: usePrisma ? 'prisma' : 'in-memory',
+  };
+}
+
+module.exports = { createProgressionStore, prismaSupports };

--- a/data/core/progression/perks.yaml
+++ b/data/core/progression/perks.yaml
@@ -1,0 +1,599 @@
+# M13 P3 — Perk-pair system canonical (XCOM EU/EW pattern).
+# Each job gets 6 promotion levels (2-7); each level offers binary choice
+# between perk_a and perk_b. Choice is permanent per unit (campaign-scoped).
+#
+# Design constraint (§P3 strategy 2026-04-20):
+#   - 7 jobs × 6 levels × 2 perks = 84 perks total
+#   - Each perk MUST affect combat behavior (no vanity/flavor-only)
+#   - Pairs are deliberately divergent (offense vs defense, specialist vs
+#     generalist) to force role crystallization
+#   - Effects compose with base job abilities (don't unlock new abilities;
+#     modify existing ones with additive/multiplicative bonuses)
+#
+# Effect schema:
+#   stat_bonus: { stat: 'attack_mod'|'defense_mod'|'hp_max'|'ap'|'initiative'|'attack_range', amount: int }
+#   ability_mod: { ability_id: str, field: str, delta: number }
+#   passive: { tag: str, payload?: obj }  # handled by resolver via tag lookup
+#
+# Perks evaluate additively unless noted. Stats applied at unit load time;
+# passive tags checked per-action via progressionEngine.listPassives(unitId).
+
+version: '0.1.0'
+
+jobs:
+  skirmisher:
+    perks:
+      level_2:
+        perk_a:
+          id: sk_r1_flank_specialist
+          name_it: 'Specialista di Fianco'
+          description_it: '+2 damage su bersagli attaccati da adiacenza alleata (flank).'
+          effect:
+            passive: { tag: flank_bonus, payload: { damage: 2 } }
+        perk_b:
+          id: sk_r1_run_and_gun
+          name_it: 'Corri e Spara'
+          description_it: '+1 move_distance su dash_strike, invariato cost_ap.'
+          effect:
+            ability_mod: { ability_id: dash_strike, field: move_distance, delta: 1 }
+      level_3:
+        perk_a:
+          id: sk_r2_lightfoot
+          name_it: 'Piede Leggero'
+          description_it: '+1 AP base (da 2 a 3). Trade-off: -1 hp_max.'
+          effect:
+            stat_bonus: { stat: ap, amount: 1 }
+            stat_bonus_2: { stat: hp_max, amount: -1 }
+        perk_b:
+          id: sk_r2_opportunist
+          name_it: 'Opportunista'
+          description_it: '+2 damage sul primo attacco di ogni round.'
+          effect:
+            passive: { tag: first_strike_bonus, payload: { damage: 2 } }
+      level_4:
+        perk_a:
+          id: sk_r3_killer_instinct
+          name_it: 'Istinto Omicida'
+          description_it: 'Dopo KO di un nemico, guadagna 1 AP (max 1/round).'
+          effect:
+            passive: { tag: kill_restore_ap, payload: { ap: 1, cap_per_round: 1 } }
+        perk_b:
+          id: sk_r3_blade_master
+          name_it: 'Maestro delle Lame'
+          description_it: 'blade_flurry: 4 attacchi invece di 3.'
+          effect:
+            ability_mod: { ability_id: blade_flurry, field: attack_count, delta: 1 }
+      level_5:
+        perk_a:
+          id: sk_r4_evasion
+          name_it: 'Evasione'
+          description_it: '+2 defense_mod quando hp_remaining >= 50%.'
+          effect:
+            passive: { tag: defense_when_healthy, payload: { threshold: 0.5, defense_mod: 2 } }
+        perk_b:
+          id: sk_r4_execution
+          name_it: 'Esecuzione'
+          description_it: '+4 damage su bersagli con hp_remaining < 25%.'
+          effect:
+            passive: { tag: execution_bonus, payload: { threshold: 0.25, damage: 4 } }
+      level_6:
+        perk_a:
+          id: sk_r5_untouchable
+          name_it: 'Intangibile'
+          description_it: 'Il primo attacco subito in ogni round è ridotto del 50%.'
+          effect:
+            passive: { tag: damage_reduction_first_hit, payload: { multiplier: 0.5 } }
+        perk_b:
+          id: sk_r5_duelist
+          name_it: 'Duellante'
+          description_it: '+3 damage contro nemici isolati (no alleati adiacenti al bersaglio).'
+          effect:
+            passive: { tag: isolated_target_bonus, payload: { damage: 3 } }
+      level_7:
+        perk_a:
+          id: sk_r6_phantom_blade
+          name_it: 'Lama Fantasma'
+          description_it: '1x/mission: attacco che ignora defense_mod del bersaglio.'
+          effect:
+            passive: { tag: pierce_defense_once_per_mission, payload: {} }
+        perk_b:
+          id: sk_r6_shadowdance
+          name_it: 'Danza delle Ombre'
+          description_it: '+2 initiative. evasive_maneuver dura 2 turni invece di 1.'
+          effect:
+            stat_bonus: { stat: initiative, amount: 2 }
+            ability_mod: { ability_id: evasive_maneuver, field: buff_duration, delta: 1 }
+
+  vanguard:
+    perks:
+      level_2:
+        perk_a:
+          id: va_r1_shieldwall
+          name_it: 'Muro di Scudi'
+          description_it: '+2 defense_mod quando adiacente ad almeno 1 alleato.'
+          effect:
+            passive: { tag: adjacent_ally_defense, payload: { defense_mod: 2 } }
+        perk_b:
+          id: va_r1_taunt_master
+          name_it: 'Maestro delle Provocazioni'
+          description_it: 'aggro_pull: +1 range.'
+          effect:
+            ability_mod: { ability_id: aggro_pull, field: range, delta: 1 }
+      level_3:
+        perk_a:
+          id: va_r2_stalwart
+          name_it: 'Saldo'
+          description_it: '+3 hp_max.'
+          effect:
+            stat_bonus: { stat: hp_max, amount: 3 }
+        perk_b:
+          id: va_r2_counterstrike
+          name_it: 'Contrattacco'
+          description_it: "Dopo aver subito un attacco, infligge 2 damage all'attaccante (1x/round)."
+          effect:
+            passive: { tag: retaliate_on_hit, payload: { damage: 2, cap_per_round: 1 } }
+      level_4:
+        perk_a:
+          id: va_r3_fortify
+          name_it: 'Fortifica'
+          description_it: '+1 defense_mod permanente.'
+          effect:
+            stat_bonus: { stat: defense_mod, amount: 1 }
+        perk_b:
+          id: va_r3_aegis
+          name_it: 'Egida'
+          description_it: "shield: scudo aumenta del 50%."
+          effect:
+            ability_mod: { ability_id: shield, field: shield_amount, delta: 2 }
+      level_5:
+        perk_a:
+          id: va_r4_unyielding
+          name_it: 'Irremovibile'
+          description_it: 'Immune a push e knockback.'
+          effect:
+            passive: { tag: immune_displacement, payload: {} }
+        perk_b:
+          id: va_r4_bulwark
+          name_it: 'Baluardo'
+          description_it: '+2 defense_mod quando hp_remaining < 50% (cornered bonus).'
+          effect:
+            passive: { tag: defense_when_low, payload: { threshold: 0.5, defense_mod: 2 } }
+      level_6:
+        perk_a:
+          id: va_r5_shield_bash
+          name_it: 'Colpo di Scudo'
+          description_it: 'Attack base: +1 damage se unità ha shield attivo.'
+          effect:
+            passive: { tag: shield_bash_bonus, payload: { damage: 1 } }
+        perk_b:
+          id: va_r5_guardian
+          name_it: 'Guardiano'
+          description_it: "Intercept reaction: danno subito dall'alleato protetto è dimezzato."
+          effect:
+            passive: { tag: intercept_damage_halved, payload: { multiplier: 0.5 } }
+      level_7:
+        perk_a:
+          id: va_r6_last_stand
+          name_it: 'Ultima Resistenza'
+          description_it: 'Alla prima caduta a 0 hp, sopravvive con 1 hp (1x/mission).'
+          effect:
+            passive: { tag: survive_death_once, payload: { hp_remaining: 1 } }
+        perk_b:
+          id: va_r6_inspiring_presence
+          name_it: 'Presenza Ispiratrice'
+          description_it: 'Alleati adiacenti guadagnano +1 attack_mod.'
+          effect:
+            passive: { tag: aura_attack_bonus, payload: { range: 1, attack_mod: 1 } }
+
+  warden:
+    perks:
+      level_2:
+        perk_a:
+          id: wa_r1_healer
+          name_it: 'Guaritore'
+          description_it: 'heal: +1 healing.'
+          effect:
+            ability_mod: { ability_id: heal, field: heal_amount, delta: 1 }
+        perk_b:
+          id: wa_r1_ward
+          name_it: 'Salvaguardia'
+          description_it: "team_buff: durata +1 turno."
+          effect:
+            ability_mod: { ability_id: team_buff, field: buff_duration, delta: 1 }
+      level_3:
+        perk_a:
+          id: wa_r2_field_medic
+          name_it: 'Medico da Campo'
+          description_it: '+1 range su heal.'
+          effect:
+            ability_mod: { ability_id: heal, field: range, delta: 1 }
+        perk_b:
+          id: wa_r2_purifier
+          name_it: 'Purificatore'
+          description_it: 'heal rimuove anche 1 status negativo (bleeding/panic/stunned).'
+          effect:
+            passive: { tag: heal_cleanses_status, payload: {} }
+      level_4:
+        perk_a:
+          id: wa_r3_revitalize
+          name_it: 'Rivitalizza'
+          description_it: 'team_heal: +1 healing.'
+          effect:
+            ability_mod: { ability_id: team_heal, field: heal_amount, delta: 1 }
+        perk_b:
+          id: wa_r3_savior
+          name_it: 'Salvatore'
+          description_it: 'Se heal porta target sopra 50% hp: target guadagna +1 AP next turn.'
+          effect:
+            passive: { tag: heal_grants_ap_over_threshold, payload: { threshold: 0.5, ap: 1 } }
+      level_5:
+        perk_a:
+          id: wa_r4_fortifier
+          name_it: 'Fortificatore'
+          description_it: '+2 hp_max agli alleati adiacenti.'
+          effect:
+            passive: { tag: aura_hp_bonus, payload: { range: 1, hp_max: 2 } }
+        perk_b:
+          id: wa_r4_cleanser
+          name_it: 'Purificatrice'
+          description_it: 'aoe_buff: range +1.'
+          effect:
+            ability_mod: { ability_id: aoe_buff, field: range, delta: 1 }
+      level_6:
+        perk_a:
+          id: wa_r5_guardian_angel
+          name_it: "Angelo Custode"
+          description_it: 'Alleati adiacenti subiscono -1 damage dai nemici.'
+          effect:
+            passive: { tag: aura_damage_reduction, payload: { range: 1, damage: 1 } }
+        perk_b:
+          id: wa_r5_chain_heal
+          name_it: 'Cura a Catena'
+          description_it: 'heal rimbalza su 1 alleato adiacente al target con 50% del healing.'
+          effect:
+            passive: { tag: chain_heal, payload: { bounce: 1, multiplier: 0.5 } }
+      level_7:
+        perk_a:
+          id: wa_r6_resurrection
+          name_it: 'Resurrezione'
+          description_it: "1x/mission: revive alleato KO con 50% hp."
+          effect:
+            passive: { tag: revive_once_per_mission, payload: { hp_ratio: 0.5 } }
+        perk_b:
+          id: wa_r6_sanctuary
+          name_it: 'Santuario'
+          description_it: 'aoe_buff evolve in team_heal + buff combo (heal 2 + attack_mod +1).'
+          effect:
+            passive: { tag: aoe_buff_adds_heal, payload: { heal: 2 } }
+
+  artificer:
+    perks:
+      level_2:
+        perk_a:
+          id: ar_r1_overcharge
+          name_it: 'Sovraccarico'
+          description_it: '+1 damage su tutte le abilità ranged.'
+          effect:
+            passive: { tag: ranged_attack_bonus, payload: { damage: 1 } }
+        perk_b:
+          id: ar_r1_precision
+          name_it: 'Precisione'
+          description_it: '+1 attack_range base.'
+          effect:
+            stat_bonus: { stat: attack_range, amount: 1 }
+      level_3:
+        perk_a:
+          id: ar_r2_volatile
+          name_it: 'Volatile'
+          description_it: 'AoE abilities: +1 damage.'
+          effect:
+            passive: { tag: aoe_damage_bonus, payload: { damage: 1 } }
+        perk_b:
+          id: ar_r2_trickshot
+          name_it: 'Tiro Acrobatico'
+          description_it: "ranged_attack ignora la prima cella di cover sulla traiettoria."
+          effect:
+            passive: { tag: pierce_cover_one, payload: {} }
+      level_4:
+        perk_a:
+          id: ar_r3_engineer
+          name_it: 'Ingegnere'
+          description_it: '+1 AP base.'
+          effect:
+            stat_bonus: { stat: ap, amount: 1 }
+        perk_b:
+          id: ar_r3_sapper
+          name_it: 'Guastatore'
+          description_it: 'debuff: durata +1 turno.'
+          effect:
+            ability_mod: { ability_id: debuff, field: buff_duration, delta: 1 }
+      level_5:
+        perk_a:
+          id: ar_r4_missile
+          name_it: 'Missile'
+          description_it: 'Surge_aoe: range +1.'
+          effect:
+            ability_mod: { ability_id: surge_aoe, field: range, delta: 1 }
+        perk_b:
+          id: ar_r4_ballistics
+          name_it: 'Balistica'
+          description_it: '+1 damage_step_mod su attacchi ranged contro bersagli a distanza >= 3.'
+          effect:
+            passive: { tag: long_range_bonus, payload: { min_distance: 3, damage: 2 } }
+      level_6:
+        perk_a:
+          id: ar_r5_plasma
+          name_it: 'Plasma'
+          description_it: 'attacchi ignorano 1 punto di defense_mod del bersaglio.'
+          effect:
+            passive: { tag: pierce_defense, payload: { amount: 1 } }
+        perk_b:
+          id: ar_r5_overload
+          name_it: 'Sovraccarico Critico'
+          description_it: 'Ogni 3 attacchi riusciti: prossimo attacco +3 damage.'
+          effect:
+            passive: { tag: combo_damage_bonus, payload: { combo_count: 3, damage: 3 } }
+      level_7:
+        perk_a:
+          id: ar_r6_nuke
+          name_it: 'Bomba Termobarica'
+          description_it: "1x/mission: AoE 3x3 per 10 damage ignorando defense."
+          effect:
+            passive: { tag: nuke_once_per_mission, payload: { range: 3, damage: 10 } }
+        perk_b:
+          id: ar_r6_master_engineer
+          name_it: 'Maestro Ingegnere'
+          description_it: '+1 AP permanente e +1 attack_mod.'
+          effect:
+            stat_bonus: { stat: ap, amount: 1 }
+            stat_bonus_2: { stat: attack_mod, amount: 1 }
+
+  invoker:
+    perks:
+      level_2:
+        perk_a:
+          id: in_r1_focused
+          name_it: 'Focalizzato'
+          description_it: '+1 damage su single-target ability.'
+          effect:
+            passive: { tag: single_target_bonus, payload: { damage: 1 } }
+        perk_b:
+          id: in_r1_channeler
+          name_it: 'Canalizzatore'
+          description_it: "drain_attack: +1 healing restituito all'invoker."
+          effect:
+            ability_mod: { ability_id: drain_attack, field: drain_amount, delta: 1 }
+      level_3:
+        perk_a:
+          id: in_r2_mind_over_matter
+          name_it: 'Mente sulla Materia'
+          description_it: '+1 defense_mod e +1 hp_max.'
+          effect:
+            stat_bonus: { stat: defense_mod, amount: 1 }
+            stat_bonus_2: { stat: hp_max, amount: 1 }
+        perk_b:
+          id: in_r2_curse
+          name_it: 'Maledizione'
+          description_it: 'debuff: +1 effetto (stack 2 penalità invece di 1).'
+          effect:
+            passive: { tag: debuff_stacks, payload: { extra_stack: 1 } }
+      level_4:
+        perk_a:
+          id: in_r3_arcane_shield
+          name_it: 'Scudo Arcano'
+          description_it: 'shield: +1 shield amount.'
+          effect:
+            ability_mod: { ability_id: shield, field: shield_amount, delta: 1 }
+        perk_b:
+          id: in_r3_drain_master
+          name_it: 'Maestro del Drenaggio'
+          description_it: "drain_attack: AP cost -1 (min 1)."
+          effect:
+            ability_mod: { ability_id: drain_attack, field: cost_ap, delta: -1 }
+      level_5:
+        perk_a:
+          id: in_r4_mind_link
+          name_it: 'Legame Mentale'
+          description_it: 'team_buff: applica anche +1 defense_mod.'
+          effect:
+            passive: { tag: team_buff_adds_defense, payload: { defense_mod: 1 } }
+        perk_b:
+          id: in_r4_hex_weaver
+          name_it: 'Tessitore di Hex'
+          description_it: 'aoe_debuff: range +1.'
+          effect:
+            ability_mod: { ability_id: aoe_debuff, field: range, delta: 1 }
+      level_6:
+        perk_a:
+          id: in_r5_soul_reaper
+          name_it: 'Mietitore di Anime'
+          description_it: "KO con drain_attack: +2 hp temporanei."
+          effect:
+            passive: { tag: kill_grants_temp_hp, payload: { hp: 2 } }
+        perk_b:
+          id: in_r5_mystic
+          name_it: 'Mistico'
+          description_it: '+1 attack_mod contro bersagli con status negativi.'
+          effect:
+            passive: { tag: debuff_target_bonus, payload: { attack_mod: 1 } }
+      level_7:
+        perk_a:
+          id: in_r6_ascendant
+          name_it: 'Ascendente'
+          description_it: '+2 attack_mod permanenti.'
+          effect:
+            stat_bonus: { stat: attack_mod, amount: 2 }
+        perk_b:
+          id: in_r6_void_master
+          name_it: 'Maestro del Vuoto'
+          description_it: "1x/mission: aoe_debuff con 2x effect su tutti i nemici entro 3 celle."
+          effect:
+            passive: { tag: master_debuff_once_per_mission, payload: { range: 3, multiplier: 2 } }
+
+  ranger:
+    perks:
+      level_2:
+        perk_a:
+          id: ra_r1_sharpshooter
+          name_it: 'Tiratore Scelto'
+          description_it: '+1 damage su attacchi ranged contro bersagli a distanza >= 3.'
+          effect:
+            passive: { tag: long_range_bonus, payload: { min_distance: 3, damage: 1 } }
+        perk_b:
+          id: ra_r1_scout
+          name_it: 'Esploratore'
+          description_it: '+1 initiative + +1 move_distance.'
+          effect:
+            stat_bonus: { stat: initiative, amount: 1 }
+            passive: { tag: move_bonus, payload: { distance: 1 } }
+      level_3:
+        perk_a:
+          id: ra_r2_steady_aim
+          name_it: 'Mira Stabile'
+          description_it: 'Se non si muove in un turno: +2 damage al prossimo attacco.'
+          effect:
+            passive: { tag: stationary_damage_bonus, payload: { damage: 2 } }
+        perk_b:
+          id: ra_r2_trapper
+          name_it: 'Cacciatore di Trappole'
+          description_it: "debuff: applica bleeding anche senza trait denti_seghettati."
+          effect:
+            passive: { tag: debuff_adds_bleeding, payload: {} }
+      level_4:
+        perk_a:
+          id: ra_r3_hunter
+          name_it: 'Cacciatore'
+          description_it: '+2 damage contro nemici isolati.'
+          effect:
+            passive: { tag: isolated_target_bonus, payload: { damage: 2 } }
+        perk_b:
+          id: ra_r3_marksman
+          name_it: 'Bersagliere'
+          description_it: '+1 attack_range permanente.'
+          effect:
+            stat_bonus: { stat: attack_range, amount: 1 }
+      level_5:
+        perk_a:
+          id: ra_r4_bow_master
+          name_it: "Maestro dell'Arco"
+          description_it: 'ranged_attack: +1 damage.'
+          effect:
+            ability_mod: { ability_id: ranged_attack, field: damage, delta: 1 }
+        perk_b:
+          id: ra_r4_skirmish
+          name_it: 'Schermaglia'
+          description_it: "Dopo ranged_attack: move 1 cella senza provocare reazioni."
+          effect:
+            passive: { tag: attack_move_free, payload: { distance: 1 } }
+      level_6:
+        perk_a:
+          id: ra_r5_lethal
+          name_it: 'Letale'
+          description_it: '+1 damage_step_mod su tutti gli attacchi.'
+          effect:
+            passive: { tag: damage_step_bonus, payload: { amount: 1 } }
+        perk_b:
+          id: ra_r5_eagle_eye
+          name_it: "Occhio d'Aquila"
+          description_it: 'Ignora cover e hazard sulla traiettoria.'
+          effect:
+            passive: { tag: ignore_cover_all, payload: {} }
+      level_7:
+        perk_a:
+          id: ra_r6_apex_predator
+          name_it: 'Predatore Apex'
+          description_it: '+2 attack_mod e +1 attack_range permanenti.'
+          effect:
+            stat_bonus: { stat: attack_mod, amount: 2 }
+            stat_bonus_2: { stat: attack_range, amount: 1 }
+        perk_b:
+          id: ra_r6_deadshot
+          name_it: 'Tiro Mortale'
+          description_it: "1x/mission: attacco che infligge 3x damage step."
+          effect:
+            passive: { tag: triple_damage_once_per_mission, payload: {} }
+
+  harvester:
+    perks:
+      level_2:
+        perk_a:
+          id: ha_r1_gatherer
+          name_it: 'Raccoglitore'
+          description_it: '+1 PE per kill partecipato.'
+          effect:
+            passive: { tag: kill_pe_bonus, payload: { pe: 1 } }
+        perk_b:
+          id: ha_r1_forager
+          name_it: 'Foraggiatore'
+          description_it: '+5 hp_max (resistente).'
+          effect:
+            stat_bonus: { stat: hp_max, amount: 5 }
+      level_3:
+        perk_a:
+          id: ha_r2_overseer
+          name_it: 'Sovrintendente'
+          description_it: '+1 AP base.'
+          effect:
+            stat_bonus: { stat: ap, amount: 1 }
+        perk_b:
+          id: ha_r2_scavenger
+          name_it: 'Saccheggiatore'
+          description_it: 'KO nemico: restituisce 2 hp.'
+          effect:
+            passive: { tag: kill_heal, payload: { hp: 2 } }
+      level_4:
+        perk_a:
+          id: ha_r3_endurance
+          name_it: 'Resistenza'
+          description_it: '+2 defense_mod.'
+          effect:
+            stat_bonus: { stat: defense_mod, amount: 2 }
+        perk_b:
+          id: ha_r3_supplier
+          name_it: 'Fornitore'
+          description_it: "Inizio battaglia: 1 alleato casuale +1 AP (round 1)."
+          effect:
+            passive: { tag: initial_ap_boost, payload: { round: 1, ap: 1, random_ally: true } }
+      level_5:
+        perk_a:
+          id: ha_r4_industrialist
+          name_it: 'Industriale'
+          description_it: '+2 hp_max a tutti gli alleati.'
+          effect:
+            passive: { tag: global_hp_bonus, payload: { hp_max: 2 } }
+        perk_b:
+          id: ha_r4_bulk
+          name_it: 'Massa'
+          description_it: "+3 hp_max, -1 initiative."
+          effect:
+            stat_bonus: { stat: hp_max, amount: 3 }
+            stat_bonus_2: { stat: initiative, amount: -1 }
+      level_6:
+        perk_a:
+          id: ha_r5_stockpile
+          name_it: "Scorta d'Emergenza"
+          description_it: "1x/mission: ripristina tutti gli AP degli alleati adiacenti."
+          effect:
+            passive: { tag: ap_refresh_once_per_mission, payload: { range: 1 } }
+        perk_b:
+          id: ha_r5_overflow
+          name_it: 'Sovrabbondanza'
+          description_it: '+2 PE per kill (stack con Raccoglitore).'
+          effect:
+            passive: { tag: kill_pe_bonus, payload: { pe: 2 } }
+      level_7:
+        perk_a:
+          id: ha_r6_apex_harvester
+          name_it: 'Apex Harvester'
+          description_it: '+1 a tutte le stat primarie (hp/ap/attack/defense).'
+          effect:
+            stat_bonus: { stat: hp_max, amount: 1 }
+            stat_bonus_2: { stat: ap, amount: 1 }
+            stat_bonus_3: { stat: attack_mod, amount: 1 }
+            stat_bonus_4: { stat: defense_mod, amount: 1 }
+        perk_b:
+          id: ha_r6_commander
+          name_it: 'Comandante'
+          description_it: 'Inizio mission: tutti gli alleati +1 attack_mod round 1.'
+          effect:
+            passive: { tag: mission_start_team_buff, payload: { round: 1, attack_mod: 1 } }

--- a/data/core/progression/xp_curve.yaml
+++ b/data/core/progression/xp_curve.yaml
@@ -1,0 +1,31 @@
+# M13 P3 — XP curve canonical (ADR-2026-04-24 pending).
+# Inspired by XCOM EU/EW 7-promotion ladder. Cumulative XP required to reach level N.
+# Level 1 = starting level (0 XP). Level 7 = max (colonel-tier).
+# Sources: xcom_eu_progression (Squaddie→Colonel 7 steps), tuned for Evo-Tactics mission length.
+
+version: '0.1.0'
+
+# Cumulative XP required for reaching each level.
+# level_xp_thresholds[N] = XP needed to BE level N.
+level_xp_thresholds:
+  1: 0     # start
+  2: 10    # 1 encounter vittoria baseline (~8 PE → XP parity)
+  3: 25    # +15: 2nd encounter
+  4: 50    # +25: 3rd-4th encounter
+  5: 100   # +50: mid-campaign
+  6: 175   # +75: act 2 transition
+  7: 275   # +100: pre-endgame
+
+# XP grant tiers per combat outcome. Scales from encounter yaml.pe_reward.
+# Default scalars; encounter YAML can override.
+xp_grants:
+  kill_trash: 3
+  kill_elite: 8
+  kill_boss: 25
+  survive_round: 1         # per round survived (cap 5 rounds)
+  mission_victory: 12      # flat bonus on victory outcome
+  mission_participation: 5 # flat for all survivors even on defeat
+
+# Level cap + prestige system placeholder (deferred Phase C).
+max_level: 7
+prestige_enabled: false

--- a/docs/adr/ADR-2026-04-24-p3-character-progression.md
+++ b/docs/adr/ADR-2026-04-24-p3-character-progression.md
@@ -1,0 +1,149 @@
+---
+title: 'ADR-2026-04-24: M13 P3 — Character progression (XCOM EU/EW perk-pair)'
+doc_status: active
+doc_owner: platform-docs
+workstream: cross-cutting
+last_verified: 2026-04-24
+source_of_truth: false
+language: it-en
+review_cycle_days: 30
+related:
+  - docs/planning/2026-04-20-pilastri-reality-audit.md
+  - docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md
+  - docs/core/PI-Pacchetti-Forme.md
+  - data/core/jobs.yaml
+---
+
+# ADR-2026-04-24: M13 P3 — Character progression (XCOM EU/EW perk-pair)
+
+- **Data**: 2026-04-24
+- **Stato**: Accepted
+- **Owner**: Backend + Design
+- **Stakeholder**: Pilastro 3 (Identità Specie × Job), Campaign engine (M10), combat resolver
+
+## Contesto
+
+Pilastro 3 (Identità Specie × Job) 🟡 all'audit 2026-04-20:
+
+- 7 jobs live con abilities R1/R2 (data/core/jobs.yaml)
+- Level curves YAML-only, zero runtime progression
+- Nessuna differenziazione tra due Skirmisher nello stesso partito post-mission 3
+
+Strategy doc raccomandava pattern **XCOM EU/EW**: 7 livelli promotion × 2 perks binari per livello. Favorisce differentiation role + risposta alla research-passi (multiple playthrough XCOM mostrano perk choice come #1 driver di attachment emotivo).
+
+## Decisione
+
+Implementare `ProgressionEngine` (XP + perk-pair pick) come layer separato:
+
+- **Data YAML**: `data/core/progression/xp_curve.yaml` (7 livelli max, cumulative thresholds 0-275) + `data/core/progression/perks.yaml` (7 jobs × 6 promotion levels × 2 perks = 84 perks)
+- **Engine**: `apps/backend/services/progression/progressionEngine.js` (class + 6 pure helpers)
+- **Store**: `apps/backend/services/progression/progressionStore.js` (in-memory + Prisma write-through, pattern formSessionStore M12 Phase D)
+- **Routes**: `apps/backend/routes/progression.js` (8 endpoint REST /api/v1/progression)
+- **Persistence**: `UnitProgression` Prisma model + migration 0004_unit_progression (campaignId × unitId unique)
+
+### Architettura
+
+```
+                          ┌────────────────────────────────────┐
+                          │ data/core/progression/              │
+                          │   xp_curve.yaml (7 level thresholds)│
+                          │   perks.yaml (7×6×2 = 84 perks)     │
+                          └─────────────┬──────────────────────┘
+                                        │
+                                        ▼
+┌──────────────────┐            ┌──────────────────────────┐
+│ ProgressionEngine│            │ progressionStore         │
+│ - seed           │ ────uses──▶│ - get/set/list/clear     │
+│ - applyXp        │            │ - hydrate(campaignId)    │
+│ - pickPerk       │            │ - write-through Prisma   │
+│ - effectiveStats │            └─────────────┬────────────┘
+│ - listPassives   │                          │
+│ - listAbilityMods│                          ▼
+└──────┬───────────┘              ┌──────────────────────────┐
+       │                          │ Prisma                   │
+       │                          │   UnitProgression        │
+       ▼                          │   (campaignId × unitId)  │
+┌─────────────────────┐           └──────────────────────────┘
+│ /api/v1/progression │
+│   /registry         │
+│   /jobs/:id/perks   │
+│   /:unitId          │
+│   /:unitId/seed     │
+│   /:unitId/xp       │
+│   /:unitId/pick     │
+│   /:unitId/effective│
+│   /campaign/:id     │
+└─────────────────────┘
+```
+
+### Perk effect schema
+
+Ogni perk ha `effect` con 3 tipi possibili (componibili):
+
+- **stat_bonus** (additive): `{ stat: 'attack_mod'|'defense_mod'|'hp_max'|'ap'|'initiative'|'attack_range', amount: int }` — collected by `effectiveStats()`, applicati load-time.
+- **ability_mod** (additive): `{ ability_id: str, field: str, delta: number }` — collected by `listAbilityMods()`, applicati quando resolver valuta `ability_id`.
+- **passive** (tag-based): `{ tag: str, payload: obj }` — collected by `listPassives()`, resolver risolve via tag lookup in future Phase B.
+
+Multiple effect entries: prefix `stat_bonus_2`, `stat_bonus_3`, etc. per permettere perk che danno trade-off (es. `+1 AP / -1 HP`).
+
+### XP curve (XCOM EU/EW inspired)
+
+```yaml
+level_xp_thresholds: { 1: 0, 2: 10, 3: 25, 4: 50, 5: 100, 6: 175, 7: 275 }
+xp_grants: { kill_trash: 3, kill_elite: 8, kill_boss: 25, mission_victory: 12, ... }
+```
+
+Target: unità attiva in 5 encounter tutorial arriva Lv4 (50 XP) circa a metà campagna. Lv7 (275 XP) è realistico solo post Act 2 endgame.
+
+### Trade-off e conseguenze
+
+- **Perk power ceiling**: 6 scelte × stat_bonus cumulativi su stessa stat possono creare builds estremi. Mitigato da:
+  - Max 1 perk per level (no double-pick)
+  - Design review perks divergenti (offense vs defense, specialist vs generalist)
+  - Ability_mod delta capped dalle abilities' own validation
+- **Content burden**: 84 perks × test coverage richiede balance iteration (M13 Phase B).
+- **UI non ancora wired**: endpoint live ma no frontend pick UI (Phase B scope).
+- **Campaign integration assente**: XP grant hook post-victory non chiamato dal campaign/advance flow (Phase B scope).
+
+### Rollback
+
+- Plugin removal: rimuovere `progressionPlugin` da `BUILTIN_PLUGINS` in `pluginLoader.js`.
+- Revert PR: engine + routes + store + tests + perks YAML rimossi, nessun impatto runtime session/campaign.
+- Migration: `DROP TABLE unit_progressions;` — reversibile.
+
+## Scope Phase A (questo PR)
+
+- `data/core/progression/xp_curve.yaml` (33 LOC): thresholds + grants
+- `data/core/progression/perks.yaml` (449 LOC): 84 perks canonical
+- `apps/backend/services/progression/progressionLoader.js` (45 LOC): YAML loader + cache
+- `apps/backend/services/progression/progressionEngine.js` (220 LOC): engine class + 6 pure helpers
+- `apps/backend/services/progression/progressionStore.js` (155 LOC): in-memory + Prisma adapter
+- `apps/backend/routes/progression.js` (130 LOC): 8 endpoint
+- `apps/backend/services/pluginLoader.js`: +`progressionPlugin`
+- `apps/backend/prisma/schema.prisma`: +`UnitProgression` model
+- `apps/backend/prisma/migrations/0004_unit_progression/migration.sql`
+- Tests: `tests/api/progressionEngine.test.js` (13 unit) + `tests/api/progressionRoutes.test.js` (11 integration)
+
+**Totale nuovi test**: **24/24** pass. Baseline preservato (AI 307 + lobby 26 + e2e 11 + M12 63 + campaign 27).
+
+## Fuori scope Phase A (Phase B next sprint, ~8h)
+
+- Campaign integration: hook `/api/campaign/advance` → grant XP a unit sopravvissuti
+- Combat resolver wire: `effectiveStats()` applicato in unit load, `listAbilityMods()` applicato in `abilityExecutor`, `listPassives()` consumati da resolver (passive tag lookup)
+- Frontend UI: pick perk overlay post-mission (riusa pattern `formsPanel`)
+- Balance pass: playtest N=10 simulation per validare non-degenerate build discovery
+- Prestige system: deferred post-Lv7 arrivo canonicamente
+
+## Fuori scope Phase C+ (deferred)
+
+- Multi-class / respec / perk reset
+- Job mastery (switch job mid-campaign)
+- Legendary perks (Lv8+ tier, post-prestige)
+- Species-specific perk pool modifier
+
+## Riferimenti
+
+- Strategy M9-M11: [`docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md`](../planning/2026-04-20-strategy-m9-m11-evidence-based.md)
+- Pilastri audit: [`docs/planning/2026-04-20-pilastri-reality-audit.md`](../planning/2026-04-20-pilastri-reality-audit.md)
+- Jobs canonical: `data/core/jobs.yaml`
+- ADR-2026-04-23 M12 Phase D (pattern Prisma write-through adapter): [`docs/adr/ADR-2026-04-23-m12-phase-a-form-evolution.md`](ADR-2026-04-23-m12-phase-a-form-evolution.md)

--- a/tests/api/progressionEngine.test.js
+++ b/tests/api/progressionEngine.test.js
@@ -1,0 +1,181 @@
+// M13 P3 — progressionEngine unit tests.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  ProgressionEngine,
+  computeLevel,
+  applyXp,
+  pickPerk,
+  computePendingLevelUps,
+} = require('../../apps/backend/services/progression/progressionEngine');
+
+test('computeLevel maps XP to correct level', () => {
+  const curve = { level_xp_thresholds: { 1: 0, 2: 10, 3: 25, 4: 50 }, max_level: 4 };
+  assert.equal(computeLevel(0, curve), 1);
+  assert.equal(computeLevel(9, curve), 1);
+  assert.equal(computeLevel(10, curve), 2);
+  assert.equal(computeLevel(24, curve), 2);
+  assert.equal(computeLevel(25, curve), 3);
+  assert.equal(computeLevel(1000, curve), 4);
+});
+
+test('ProgressionEngine seed + applyXp chains into level up', () => {
+  const engine = new ProgressionEngine();
+  const unit = engine.seed('u1', 'skirmisher');
+  assert.equal(unit.level, 1);
+  assert.equal(unit.xp_total, 0);
+  assert.deepEqual(unit.picked_perks, []);
+
+  const r1 = engine.applyXp(unit, 10);
+  assert.equal(r1.leveled_up, true);
+  assert.equal(r1.unit.level, 2);
+  assert.equal(r1.xp_after, 10);
+
+  const r2 = engine.applyXp(r1.unit, 15);
+  assert.equal(r2.leveled_up, true);
+  assert.equal(r2.unit.level, 3);
+});
+
+test('applyXp caps at max_level', () => {
+  const curve = {
+    level_xp_thresholds: { 1: 0, 2: 10 },
+    max_level: 2,
+  };
+  const r = applyXp({ xp_total: 0, level: 1 }, 9999, { curve });
+  assert.equal(r.unit.level, 2);
+  assert.equal(r.unit.xp_total, 9999);
+});
+
+test('pendingLevelUps lists unpicked levels only', () => {
+  const engine = new ProgressionEngine();
+  const unit = engine.seed('u1', 'skirmisher', { xpTotal: 50 });
+  // Level 4 reached → pending level_2, 3, 4
+  const pending = engine.pendingLevelUps(unit);
+  assert.equal(pending.length, 3);
+  assert.deepEqual(
+    pending.map((p) => p.level),
+    [2, 3, 4],
+  );
+  // Pick level 2
+  const picked = engine.pickPerk(unit, 2, 'a');
+  const pending2 = engine.pendingLevelUps(picked.unit);
+  assert.equal(pending2.length, 2);
+  assert.deepEqual(
+    pending2.map((p) => p.level),
+    [3, 4],
+  );
+});
+
+test('pickPerk rejects invalid choice + duplicate + below-level', () => {
+  const engine = new ProgressionEngine();
+  const unit = engine.seed('u1', 'skirmisher', { xpTotal: 10 }); // level 2
+  assert.throws(() => engine.pickPerk(unit, 2, 'x'), /invalid choice/);
+  assert.throws(() => engine.pickPerk(unit, 3, 'a'), /unit level 2/);
+  const picked = engine.pickPerk(unit, 2, 'a');
+  assert.throws(() => engine.pickPerk(picked.unit, 2, 'b'), /already picked/);
+});
+
+test('pickPerk records id + choice + appends', () => {
+  const engine = new ProgressionEngine();
+  let unit = engine.seed('u1', 'skirmisher', { xpTotal: 25 }); // level 3
+  const r1 = engine.pickPerk(unit, 2, 'a');
+  assert.equal(r1.picked_perk.id, 'sk_r1_flank_specialist');
+  assert.equal(r1.pick.level, 2);
+  assert.equal(r1.pick.choice, 'a');
+  const r2 = engine.pickPerk(r1.unit, 3, 'b');
+  assert.equal(r2.picked_perk.id, 'sk_r2_opportunist');
+  assert.equal(r2.unit.picked_perks.length, 2);
+});
+
+test('effectiveStats sums stat_bonus additively', () => {
+  const engine = new ProgressionEngine();
+  let unit = engine.seed('u1', 'skirmisher', { xpTotal: 50 }); // level 4
+  // Level 3 perk_a: +1 AP, -1 HP
+  const r1 = engine.pickPerk(unit, 3, 'a');
+  const stats = engine.effectiveStats(r1.unit);
+  assert.equal(stats.ap, 1);
+  assert.equal(stats.hp_max, -1);
+});
+
+test('listPassives returns tag + payload + source', () => {
+  const engine = new ProgressionEngine();
+  const unit = engine.seed('u1', 'skirmisher', { xpTotal: 10 }); // level 2
+  const picked = engine.pickPerk(unit, 2, 'a'); // flank_specialist
+  const passives = engine.listPassives(picked.unit);
+  assert.equal(passives.length, 1);
+  assert.equal(passives[0].tag, 'flank_bonus');
+  assert.equal(passives[0].payload.damage, 2);
+  assert.equal(passives[0].source_perk_id, 'sk_r1_flank_specialist');
+});
+
+test('listAbilityMods returns delta per ability', () => {
+  const engine = new ProgressionEngine();
+  const unit = engine.seed('u1', 'skirmisher', { xpTotal: 10 });
+  const picked = engine.pickPerk(unit, 2, 'b'); // run_and_gun: dash_strike move +1
+  const mods = engine.listAbilityMods(picked.unit);
+  assert.equal(mods.length, 1);
+  assert.equal(mods[0].ability_id, 'dash_strike');
+  assert.equal(mods[0].field, 'move_distance');
+  assert.equal(mods[0].delta, 1);
+});
+
+test('getPerkPair returns a+b for each job×level', () => {
+  const engine = new ProgressionEngine();
+  const pair = engine.getPerkPair('warden', 5);
+  assert.ok(pair);
+  assert.ok(pair.perk_a);
+  assert.ok(pair.perk_b);
+  assert.notEqual(pair.perk_a.id, pair.perk_b.id);
+  assert.equal(engine.getPerkPair('skirmisher', 99), null);
+  assert.equal(engine.getPerkPair('nope_job', 2), null);
+});
+
+test('snapshot exposes jobs + thresholds', () => {
+  const engine = new ProgressionEngine();
+  const snap = engine.snapshot();
+  assert.ok(snap.jobs.includes('skirmisher'));
+  assert.ok(snap.jobs.includes('harvester'));
+  assert.equal(snap.jobs.length, 7);
+  assert.equal(snap.xp_max_level, 7);
+  assert.equal(snap.xp_thresholds[2], 10);
+});
+
+test('all 7 jobs have perks for levels 2-7 (14 perks each, 98 total)', () => {
+  const engine = new ProgressionEngine();
+  let total = 0;
+  for (const jobId of [
+    'skirmisher',
+    'vanguard',
+    'warden',
+    'artificer',
+    'invoker',
+    'ranger',
+    'harvester',
+  ]) {
+    for (let l = 2; l <= 7; l += 1) {
+      const pair = engine.getPerkPair(jobId, l);
+      assert.ok(pair, `missing pair for ${jobId} level ${l}`);
+      assert.ok(pair.perk_a.id, `missing perk_a.id for ${jobId} level ${l}`);
+      assert.ok(pair.perk_b.id, `missing perk_b.id for ${jobId} level ${l}`);
+      total += 2;
+    }
+  }
+  assert.equal(total, 84); // 7 × 6 × 2
+});
+
+test('all perk ids are globally unique', () => {
+  const engine = new ProgressionEngine();
+  const ids = [];
+  for (const job of Object.values(engine.perks.jobs)) {
+    for (const lvl of Object.values(job.perks || {})) {
+      if (lvl.perk_a?.id) ids.push(lvl.perk_a.id);
+      if (lvl.perk_b?.id) ids.push(lvl.perk_b.id);
+    }
+  }
+  const unique = new Set(ids);
+  assert.equal(unique.size, ids.length, `duplicate perk ids: ${ids.length - unique.size}`);
+});

--- a/tests/api/progressionRoutes.test.js
+++ b/tests/api/progressionRoutes.test.js
@@ -1,0 +1,179 @@
+// M13 P3 — progression routes integration tests.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const http = require('node:http');
+
+const { createProgressionRouter } = require('../../apps/backend/routes/progression');
+
+function startTestServer(t) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/progression', createProgressionRouter());
+  const server = app.listen(0);
+  const port = server.address().port;
+  t.after(() => server.close());
+  return { port, url: `http://127.0.0.1:${port}` };
+}
+
+function request(method, url, body = null) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const opts = {
+      hostname: parsed.hostname,
+      port: parsed.port,
+      path: parsed.pathname + parsed.search,
+      method,
+      headers: { 'content-type': 'application/json' },
+    };
+    const req = http.request(opts, (res) => {
+      let data = '';
+      res.on('data', (c) => (data += c));
+      res.on('end', () => {
+        let parsedBody = null;
+        try {
+          parsedBody = data ? JSON.parse(data) : null;
+        } catch {
+          parsedBody = data;
+        }
+        resolve({ status: res.statusCode, body: parsedBody });
+      });
+    });
+    req.on('error', reject);
+    if (body) req.write(JSON.stringify(body));
+    req.end();
+  });
+}
+
+test('GET /registry exposes thresholds + jobs', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('GET', `${url}/api/v1/progression/registry`);
+  assert.equal(res.status, 200);
+  assert.equal(res.body.xp_max_level, 7);
+  assert.equal(res.body.jobs.length, 7);
+  assert.equal(res.body.xp_thresholds[2], 10);
+});
+
+test('GET /jobs/:jobId/perks 200 + 404 for unknown', async (t) => {
+  const { url } = startTestServer(t);
+  const ok = await request('GET', `${url}/api/v1/progression/jobs/skirmisher/perks`);
+  assert.equal(ok.status, 200);
+  assert.equal(ok.body.job_id, 'skirmisher');
+  assert.ok(ok.body.perks.level_2);
+
+  const miss = await request('GET', `${url}/api/v1/progression/jobs/nope/perks`);
+  assert.equal(miss.status, 404);
+});
+
+test('POST /seed creates unit progression', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('POST', `${url}/api/v1/progression/u1/seed`, {
+    job: 'skirmisher',
+    xp_total: 10,
+  });
+  assert.equal(res.status, 201);
+  assert.equal(res.body.unit_id, 'u1');
+  assert.equal(res.body.level, 2);
+});
+
+test('POST /seed: unknown job = 400', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('POST', `${url}/api/v1/progression/u1/seed`, { job: 'nope' });
+  assert.equal(res.status, 400);
+});
+
+test('POST /xp grants + levels up + returns pending', async (t) => {
+  const { url } = startTestServer(t);
+  await request('POST', `${url}/api/v1/progression/u1/seed`, { job: 'vanguard' });
+  const grant = await request('POST', `${url}/api/v1/progression/u1/xp`, { amount: 50 });
+  assert.equal(grant.status, 200);
+  assert.equal(grant.body.delta.leveled_up, true);
+  assert.equal(grant.body.delta.level_after, 4);
+  assert.equal(grant.body.pending_level_ups.length, 3);
+});
+
+test('POST /pick validates + persists', async (t) => {
+  const { url } = startTestServer(t);
+  await request('POST', `${url}/api/v1/progression/u1/seed`, { job: 'warden' });
+  await request('POST', `${url}/api/v1/progression/u1/xp`, { amount: 25 });
+  const pick = await request('POST', `${url}/api/v1/progression/u1/pick`, {
+    level: 2,
+    choice: 'a',
+  });
+  assert.equal(pick.status, 200);
+  assert.equal(pick.body.picked_perk.id, 'wa_r1_healer');
+
+  const dup = await request('POST', `${url}/api/v1/progression/u1/pick`, {
+    level: 2,
+    choice: 'b',
+  });
+  assert.equal(dup.status, 409);
+});
+
+test('POST /pick: invalid choice = 400', async (t) => {
+  const { url } = startTestServer(t);
+  await request('POST', `${url}/api/v1/progression/u1/seed`, { job: 'ranger' });
+  await request('POST', `${url}/api/v1/progression/u1/xp`, { amount: 25 });
+  const res = await request('POST', `${url}/api/v1/progression/u1/pick`, {
+    level: 2,
+    choice: 'x',
+  });
+  assert.equal(res.status, 400);
+});
+
+test('GET /:unitId/effective returns stats + passives + mods', async (t) => {
+  const { url } = startTestServer(t);
+  await request('POST', `${url}/api/v1/progression/u1/seed`, { job: 'artificer' });
+  await request('POST', `${url}/api/v1/progression/u1/xp`, { amount: 50 });
+  await request('POST', `${url}/api/v1/progression/u1/pick`, { level: 2, choice: 'b' }); // precision → +1 attack_range
+  await request('POST', `${url}/api/v1/progression/u1/pick`, { level: 4, choice: 'a' }); // engineer → +1 ap
+  const res = await request('GET', `${url}/api/v1/progression/u1/effective`);
+  assert.equal(res.status, 200);
+  assert.equal(res.body.stats.attack_range, 1);
+  assert.equal(res.body.stats.ap, 1);
+  assert.equal(res.body.level, 4);
+});
+
+test('GET /:unitId 404 when not seeded', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('GET', `${url}/api/v1/progression/nope`);
+  assert.equal(res.status, 404);
+});
+
+test('DELETE /campaign/:id clears scope only', async (t) => {
+  const { url } = startTestServer(t);
+  await request('POST', `${url}/api/v1/progression/u1/seed`, {
+    job: 'harvester',
+    campaign_id: 'c1',
+  });
+  await request('POST', `${url}/api/v1/progression/u2/seed`, {
+    job: 'skirmisher',
+    campaign_id: 'c2',
+  });
+  const clear = await request('DELETE', `${url}/api/v1/progression/campaign/c1`);
+  assert.equal(clear.status, 200);
+  assert.equal(clear.body.removed, 1);
+  const gone = await request('GET', `${url}/api/v1/progression/u1?campaign_id=c1`);
+  assert.equal(gone.status, 404);
+  const kept = await request('GET', `${url}/api/v1/progression/u2?campaign_id=c2`);
+  assert.equal(kept.status, 200);
+});
+
+test('campaign scope isolation: same unit_id in different campaigns', async (t) => {
+  const { url } = startTestServer(t);
+  await request('POST', `${url}/api/v1/progression/u1/seed`, {
+    job: 'skirmisher',
+    campaign_id: 'cA',
+  });
+  await request('POST', `${url}/api/v1/progression/u1/seed`, {
+    job: 'vanguard',
+    campaign_id: 'cB',
+  });
+  const a = await request('GET', `${url}/api/v1/progression/u1?campaign_id=cA`);
+  const b = await request('GET', `${url}/api/v1/progression/u1?campaign_id=cB`);
+  assert.equal(a.body.job, 'skirmisher');
+  assert.equal(b.body.job, 'vanguard');
+});


### PR DESCRIPTION
## Summary

Prima leva di Pilastro 3 runtime. XP + level-up + perk-pair binary pick scoped per `campaign_id × unit_id`. Pattern XCOM EU/EW 7-promotion ladder.

## Scope

- **Data canonical** (`data/core/progression/`):
  - `xp_curve.yaml`: 7 levels, thresholds cumulative 0→275, xp_grants per outcome (kill_trash 3, kill_elite 8, kill_boss 25, mission_victory 12)
  - `perks.yaml`: **7 jobs × 6 promotion levels × 2 perks = 84 perks canonical** (skirmisher/vanguard/warden/artificer/invoker/ranger/harvester)
- **Engine** (`apps/backend/services/progression/progressionEngine.js`, 220 LOC): class + 6 pure helpers (computeLevel, applyXp, pickPerk, effectiveStats, listPassives, listAbilityMods)
- **Store** (`progressionStore.js`, 155 LOC): in-memory Map + Prisma write-through (pattern formSessionStore M12 Phase D)
- **Routes** (`apps/backend/routes/progression.js`, 130 LOC): 8 endpoint REST `/api/v1/progression/*`
- **Prisma**: `UnitProgression` model + migration `0004_unit_progression`
- **Plugin wire**: +`progressionPlugin` in `BUILTIN_PLUGINS`

## Effect schema (componibile)

- `stat_bonus` (additive): sommato in `effectiveStats()` (attack_mod, defense_mod, hp_max, ap, initiative, attack_range)
- `ability_mod` (additive delta per campo abilità): consumato da resolver via `listAbilityMods()`
- `passive` (tag + payload): lookup tag-based per resolver via `listPassives()`

Multi-effect: prefix `stat_bonus_2`, `stat_bonus_3` per perks con trade-off (es. `+1 AP / -1 HP`).

## Test plan

- [x] `node --test tests/api/progressionEngine.test.js` → 13/13 (engine + snapshot + 84 perks coverage + global id uniqueness)
- [x] `node --test tests/api/progressionRoutes.test.js` → 11/11 (all 8 endpoints + scope isolation + 400/404/409 error paths)
- [x] `node --test tests/ai/*.test.js` → 307/307 baseline preserved
- [x] `npm run format:check` → verde

**Grand total**: 307 AI + 24 progression = 331+ (baseline + 24 nuovi).

## Rollback

- Plugin removal: rimuovere `progressionPlugin` da `BUILTIN_PLUGINS` in `pluginLoader.js` → endpoint non esposti.
- Revert PR: zero impatto runtime (non chiamato da session.js / campaign.js / abilityExecutor).
- Migration reversibile: `DROP TABLE unit_progressions;`.

## Pilastro 3 progression

- Pre-M13: 🟡 (7 jobs abilities R1/R2 live, level curves YAML-only, zero runtime)
- **Post-Phase A**: **🟡+** (engine + REST + 84 perks shipped; integration resolver/UI pending Phase B ~8h)

## Fuori scope Phase B (follow-up)

- Campaign integration: hook `/api/campaign/advance` → grant XP a survivors
- Combat resolver wire: `effectiveStats()` in unit load, `listAbilityMods()` in abilityExecutor, `listPassives()` tag lookup
- Frontend pick perk overlay post-mission
- Balance pass N=10 sim per non-degenerate builds

## Riferimenti

- ADR: [`docs/adr/ADR-2026-04-24-p3-character-progression.md`](docs/adr/ADR-2026-04-24-p3-character-progression.md)
- Strategy M9-M11: [`docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md`](docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md)
- Pilastri audit: [`docs/planning/2026-04-20-pilastri-reality-audit.md`](docs/planning/2026-04-20-pilastri-reality-audit.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)