### PR TITLE
feat(demo): single-tunnel one-command playable demo (ngrok shared HTTP+WS)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,6 +327,12 @@ Primary working directory is on Windows, but the shell is bash (Git Bash/MSYS) �
 - **Pilastro 2 status**: 🔴 → 🟡 (Phase A) → 🟡+ (Phase B) → **🟡++** (Phase C) → 🟢 candidato post-Phase D
 - **Handoff doc**: [`docs/planning/2026-04-24-next-session-kickoff-m12-phase-d.md`](docs/planning/2026-04-24-next-session-kickoff-m12-phase-d.md)
 
+**Sessione 2026-04-25 P3.B + P6.B + verify sweep (3 PR)**:
+
+- **PR #1696 merged** `9319eedd` — Verification post-merge: registry 3 new docs (2 ADR + 1 handoff) + workstream fix `planning` → `cross-cutting`. Governance 0 errors. Baseline 467/467.
+- **PR #1697 merged** `a462d4d5` — M13 P3 Phase B: campaign advance XP grant hook (survivors+xp_per_unit opzionali, response.xp_grants[]). Session /start applyProgressionToUnits (stat bonuses + \_perk_passives/ability_mods). Combat resolver 5 passive tags wired (flank_bonus, first_strike_bonus, execution_bonus, isolated_target_bonus, long_range_bonus). Frontend progressionPanel overlay (pattern formsPanel) + header btn 📈 Lv + auto-open on leveled_up. Balance pass 448 builds validated. **Pilastro 3**: 🟡+ → **🟢 candidato**. +24 test.
+- **PR #1698 merged** `135b5b1f` — M13 P6 Phase B: calibration harness Python tools/py/batch_calibrate_hardcore07.py (N=10 target win 30-50%, execution userland). HUD timer countdown bottom-right overlay + CSS @keyframes mt-pulse (red warning + strikethrough expired). Campaign auto-timeout: state.lastMissionTimer cache → advance override outcome='timeout' quando timer.expired. **Pilastro 6**: 🟡+ → **🟢 candidato**. +10 test.
+
 **Sessione 2026-04-24 M12.D + M13.P3 + M13.P6 (3 PR)**:
 
 - **PR #1693 merged** `2cfd4540` — M12 Phase D: campaign `/advance` response += `evolve_opportunity` additive flag (victory + pe_earned ≥ 8). `main.js refresh` fire-and-forget `api.vc(sid)` → `state.vcSnapshot` pipe. `formsPanel.onEvolveSuccess` callback → `pushPopup('🧬 ' + form_id)` + `flashUnit` + `sfx.select`. Prisma write-through adapter `FormSessionState` model + migration 0003 + graceful in-memory fallback. **Pilastro 2**: 🟡++ → **🟢 candidato**. +10 test (27 campaignRoutes + 6 formSessionStorePrisma).
@@ -349,16 +355,16 @@ Revisione honest post-M7 + deep-audit Explore agent. Statuses precedenti 6/6 �
 - `docs/planning/2026-04-20-pilastri-reality-audit.md` — breakdown dettagliato per Pilastro.
 - `docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md` — roadmap 3-sprint con pattern proven (Wesnoth + XCOM + Jackbox + Long War).
 
-| #   | Pilastro                     |                       Stato                        |
-| --- | ---------------------------- | :------------------------------------------------: |
-| 1   | Tattica leggibile (FFT)      |                         🟢                         |
-| 2   | Evoluzione emergente (Spore) |  🟢 candidato (Phase D shipped, playtest pending)  |
-| 3   | Identità Specie × Job        | 🟡+ (engine + 84 perks live, resolver/UI pending)  |
-| 4   | Temperamenti MBTI/Ennea      |                         🟡                         |
-| 5   | Co-op vs Sistema             |             🟡 (playtest pending → 🟢)             |
-| 6   | Fairness                     | 🟡+ (timer engine live, calibration + HUD pending) |
+| #   | Pilastro                     |                        Stato                         |
+| --- | ---------------------------- | :--------------------------------------------------: |
+| 1   | Tattica leggibile (FFT)      |                          🟢                          |
+| 2   | Evoluzione emergente (Spore) |   🟢 candidato (Phase D shipped, playtest pending)   |
+| 3   | Identità Specie × Job        |   🟢 candidato (Phase B shipped, playtest gating)    |
+| 4   | Temperamenti MBTI/Ennea      |                          🟡                          |
+| 5   | Co-op vs Sistema             |              🟡 (playtest pending → 🟢)              |
+| 6   | Fairness                     | 🟢 candidato (Phase B shipped, calibration userland) |
 
-**Score**: 1/6 🟢 + 1/6 🟢 candidato + 3/6 🟡+ + 2/6 🟡 (zero 🔴).
+**Score**: 1/6 🟢 + **3/6 🟢 candidato** + 2/6 🟡 (zero 🔴).
 
 **Gap principali + evidence-based strategy**:
 

--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const path = require('node:path');
 const fs = require('node:fs/promises');
+const fsSync = require('node:fs');
 const { IdeaRepository, normaliseList } = require('./storage');
 const { buildCodexReport } = require('./report');
 const { createBiomeSynthesizer } = require('../../services/generation/biomeSynthesizer');
@@ -374,6 +375,28 @@ function createApp(options = {}) {
 
   const publicDir = options.publicDir || path.resolve(__dirname, 'public');
   app.use(express.static(publicDir));
+
+  // Demo one-tunnel mode: serve built apps/play/dist at /play.
+  // Opt-in via options.playDist or env PLAY_DIST_PATH. Missing dir = silent skip.
+  const playDist =
+    options.playDist || process.env.PLAY_DIST_PATH || path.resolve(__dirname, '..', 'play', 'dist');
+  try {
+    if (fsSync.existsSync(playDist) && fsSync.statSync(playDist).isDirectory()) {
+      // Runtime config for frontend — injects WS resolution hint.
+      // Shared mode (LOBBY_WS_SHARED=true) → frontend uses same-origin /ws.
+      // Dedicated mode → falls back to VITE env / port 3341.
+      const sameOrigin = process.env.LOBBY_WS_SHARED === 'true';
+      app.get('/play/runtime-config.js', (_req, res) => {
+        res
+          .type('application/javascript')
+          .send(`window.LOBBY_WS_SAME_ORIGIN=${sameOrigin ? 'true' : 'false'};\n`);
+      });
+      app.use('/play', express.static(playDist));
+      console.log(`[play-static] serving ${playDist} at /play (ws-same-origin=${sameOrigin})`);
+    }
+  } catch {
+    // silent: dist not built, dev flow via Vite still works
+  }
 
   // V1 pattern: plugin-based service registration
   loadPlugins(app, BUILTIN_PLUGINS, options);

--- a/apps/backend/index.js
+++ b/apps/backend/index.js
@@ -41,15 +41,10 @@ const { app, lobby } = createApp({
 //   HTTP :3334 (this backend), Vite :5180, calibration :3340.
 // Override via LOBBY_WS_PORT env; disable via LOBBY_WS_ENABLED=false.
 const wsEnabled = process.env.LOBBY_WS_ENABLED !== 'false';
+const wsShared = process.env.LOBBY_WS_SHARED === 'true';
 const wsPort = Number.parseInt(process.env.LOBBY_WS_PORT || '3341', 10);
 const wsHost = process.env.LOBBY_WS_HOST || host;
 let lobbyWs = null;
-if (wsEnabled && lobby) {
-  lobbyWs = createWsServer({ lobby, port: wsPort });
-  console.log(`[lobby-ws] WebSocket server online on ws://${wsHost}:${wsPort}/ws`);
-} else {
-  console.log('[lobby-ws] WebSocket server disabled (LOBBY_WS_ENABLED=false)');
-}
 
 // Issue #1342: avverti se ORCHESTRATOR_AUTOCLOSE_MS e' settato in modo
 // che potrebbe rompere il backend live (valori bassi pensati per i test).
@@ -68,6 +63,20 @@ const autocloseStatus = (() => {
 })();
 
 const server = http.createServer(app);
+
+// WS server: shared mode (single port for demo/ngrok) or dedicated port.
+if (wsEnabled && lobby) {
+  if (wsShared) {
+    lobbyWs = createWsServer({ lobby, server });
+    console.log(`[lobby-ws] WebSocket server attached to HTTP server on /ws (shared mode)`);
+  } else {
+    lobbyWs = createWsServer({ lobby, port: wsPort });
+    console.log(`[lobby-ws] WebSocket server online on ws://${wsHost}:${wsPort}/ws`);
+  }
+} else {
+  console.log('[lobby-ws] WebSocket server disabled (LOBBY_WS_ENABLED=false)');
+}
+
 server.listen(port, host, () => {
   console.log(`[idea-engine] API online su http://${host}:${port}`);
   console.log(`[idea-engine] Database URL: ${databaseUrl ? '[set]' : '[missing]'}`);

--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -12,6 +12,8 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="/src/style.css" />
+    <!-- Demo one-tunnel: runtime WS hint (no-op if dev Vite or static /play absent) -->
+    <script src="runtime-config.js" onerror="void 0"></script>
   </head>
   <body>
     <div id="app">

--- a/apps/play/lobby.html
+++ b/apps/play/lobby.html
@@ -10,6 +10,8 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Noto+Sans:wght@400;600;700&display=swap"
       rel="stylesheet"
     />
+    <!-- Demo one-tunnel: runtime WS hint (no-op if dev Vite or static /play absent) -->
+    <script src="runtime-config.js" onerror="void 0"></script>
     <style>
       :root {
         --bg: #0b0d12;

--- a/apps/play/src/network.js
+++ b/apps/play/src/network.js
@@ -401,8 +401,31 @@ export function clearLobbySession() {
   }
 }
 
-/** Resolve the WS URL: VITE env if defined, else same-origin ws:// with port 3341. */
+/**
+ * Resolve the WS URL. Priority (demo one-tunnel friendly):
+ *   1. URL query `?ws=wss://...` (shareable override, per-session)
+ *   2. `window.LOBBY_WS_URL` (runtime injection, e.g. inline <script>)
+ *   3. `window.LOBBY_WS_SAME_ORIGIN === true` → same-origin `/ws` (shared HTTP+WS)
+ *   4. VITE_LOBBY_WS_URL (build-time env)
+ *   5. same-origin host with port 3341 (default dedicated-port backend)
+ */
 export function resolveWsUrl() {
+  if (typeof window !== 'undefined' && window.location) {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const q = params.get('ws');
+      if (q) return q;
+    } catch {
+      // noop
+    }
+    if (typeof window.LOBBY_WS_URL === 'string' && window.LOBBY_WS_URL) {
+      return window.LOBBY_WS_URL;
+    }
+    if (window.LOBBY_WS_SAME_ORIGIN === true) {
+      const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+      return `${proto}//${window.location.host}/ws`;
+    }
+  }
   try {
     if (typeof import.meta !== 'undefined' && import.meta.env?.VITE_LOBBY_WS_URL) {
       return import.meta.env.VITE_LOBBY_WS_URL;

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -4564,6 +4564,17 @@
       "review_cycle_days": 14
     },
     {
+      "path": "docs/planning/2026-04-26-next-session-kickoff-p4-mbti-playtest.md",
+      "title": "Next session kickoff — P4 MBTI completamento / playtest live gating / Prisma lobby",
+      "doc_status": "draft",
+      "doc_owner": "master-dd",
+      "workstream": "cross-cutting",
+      "last_verified": "2026-04-26",
+      "source_of_truth": false,
+      "language": "it-en",
+      "review_cycle_days": 14
+    },
+    {
       "path": "docs/planning/EVO_FINAL_DESIGN_BACKLOG_REGISTER.md",
       "title": "Evo Final Design — Backlog Register",
       "doc_status": "draft",

--- a/docs/planning/2026-04-26-next-session-kickoff-p4-mbti-playtest.md
+++ b/docs/planning/2026-04-26-next-session-kickoff-p4-mbti-playtest.md
@@ -1,0 +1,145 @@
+---
+title: 'Next session kickoff — P4 MBTI completamento / playtest live gating 🟢 / Prisma lobby'
+workstream: cross-cutting
+category: handoff
+status: draft
+owner: master-dd
+created: 2026-04-26
+tags:
+  - kickoff
+  - session-handoff
+  - p4-mbti
+  - playtest-live
+related:
+  - docs/adr/ADR-2026-04-24-p3-character-progression.md
+  - docs/adr/ADR-2026-04-24-p6-hardcore-timeout.md
+  - docs/planning/2026-04-20-pilastri-reality-audit.md
+---
+
+# Next session kickoff — post M13 P3.B + P6.B close
+
+Sessione 2026-04-25 chiude **Phase B stack** (P3 + P6) + verification sweep. **6 PR** totali in main 2026-04-24/25.
+
+## Stack PR 2026-04-24/25
+
+| PR                                                       | Commit     | Scope              |
+| -------------------------------------------------------- | ---------- | ------------------ |
+| [#1693](https://github.com/MasterDD-L34D/Game/pull/1693) | `2cfd4540` | M12 Phase D        |
+| [#1694](https://github.com/MasterDD-L34D/Game/pull/1694) | `24169c41` | M13 P3 Phase A     |
+| [#1695](https://github.com/MasterDD-L34D/Game/pull/1695) | `3e308708` | M13 P6 Phase A     |
+| [#1696](https://github.com/MasterDD-L34D/Game/pull/1696) | `9319eedd` | Verification sweep |
+| [#1697](https://github.com/MasterDD-L34D/Game/pull/1697) | `a462d4d5` | M13 P3 Phase B     |
+| [#1698](https://github.com/MasterDD-L34D/Game/pull/1698) | `135b5b1f` | M13 P6 Phase B     |
+
+## Pilastri post-sessione 2026-04-25
+
+| #   | Stato pre |    Stato post    | Residuo 🟢                                       |
+| --- | :-------: | :--------------: | ------------------------------------------------ |
+| 1   |    🟢     |        🟢        | —                                                |
+| 2   |   🟡++    | **🟢 candidato** | playtest live userland                           |
+| 3   |    🟡     | **🟢 candidato** | playtest live validation pick perk + stat impact |
+| 4   |    🟡     |        🟡        | Disco Elysium diegetic 3 axes (~8h)              |
+| 5   |    🟡     |        🟡        | TKT-M11B-06 playtest ngrok (userland)            |
+| 6   |    🟡     | **🟢 candidato** | calibration N=10 harness execution (userland)    |
+
+**Score**: 1/6 🟢 + **3/6 🟢 candidato** + 2/6 🟡 (zero 🔴).
+
+## Prompt next session
+
+### Opzione A — P4 MBTI completamento 3 axes (~8h autonomous) ⭐ raccomandato
+
+```text
+Leggi:
+- apps/backend/services/vcScoring.js (deriveMbtiType + axes computation)
+- data/core/forms/mbti_forms.yaml (16 forms + axes target)
+- docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md (Disco Elysium pattern)
+
+Task: P4 MBTI completare 3 axes residui (E_I, S_N, J_P).
+
+Scope (~8h):
+1. VC scoring refinement per E_I, S_N, J_P (~2h each = 6h):
+   - E_I: ratio (intents_targeting_enemy) / (total_intents) per extraversion proxy
+   - S_N: ratio (concrete_actions: attack/move) / (abstract: ability/heal/buff) per sensing
+   - J_P: variance nel turn time / round planning change count per judging
+2. Thought Cabinet pattern (~2h):
+   - data/core/thoughts/mbti_thoughts.yaml: 3 axes × 2 poli × 3 soglie = 18 thoughts
+   - Runtime: session.thoughts_unlocked[] cumulativo per unit
+   - UI: tooltip reveal su pick perk / form change
+```
+
+### Opzione B — Playtest live 3 Pilastri 🟢 gating (userland, closes 3 🟢)
+
+Non-autonomous. Richiede user + 2 amici + 1 session ~2h.
+
+```text
+Scenario test (~2h):
+- 1 run enc_tutorial_01-05 (baseline Pilastro 1 🟢 stability)
+- 1 run enc_tutorial_06_hardcore con timer (Pilastro 6 validation)
+- 1 run campaign con pick perk + form evolve (P2 + P3 validation)
+
+Checklist gating:
+- [ ] P2: evolve opportunity flag fires on pe_earned ≥ 8; formsPanel auto-open
+- [ ] P3: leveled_up survivor → progressionPanel auto-open; perk click persists
+- [ ] P6: timer HUD visible bottom-right; warning red pulse @ ≤3 rounds; expired override outcome to timeout
+
+Output: docs/playtest/2026-04-XX-gating-validation.md
+Se 3/3 pass → bump 3 🟢 definitivi + update CLAUDE.md.
+```
+
+### Opzione C — Prisma P3 lobby persistence (~5h autonomous)
+
+```text
+Task: wire Prisma adapter per wsSession lobby rooms.
+
+Scope:
+1. Schema migration LobbyRoom + RoomMember tables
+2. wsSession.Room persistence optional (env LOBBY_PRISMA_ENABLED)
+3. Reconnect dopo restart backend → hydrate rooms dal DB
+```
+
+### Opzione D — Pausa + verifica userland
+
+Esegui playtest live Opzione B manualmente senza AI driving.
+
+## Backlog globale
+
+| Item                                                   |  P  |  Autonomo?  |
+| ------------------------------------------------------ | :-: | :---------: |
+| **P4 MBTI** 3 axes + Thought Cabinet                   | P1  |     ✅      |
+| **Playtest gating** 3 🟢 validation                    | P1  | ❌ userland |
+| **TKT-M11B-06** playtest ngrok co-op                   | P1  | ❌ userland |
+| **Prisma lobby** P3 rooms persistence                  | P2  |     ✅      |
+| **Calibration hardcore 07** N=10 harness execute       | P2  | ❌ userland |
+| **Phase C** ability_mod runtime + passive tags residui | P3  |     ✅      |
+
+## Baseline snapshot post-sessione 2026-04-25
+
+```bash
+cd /c/Users/VGit/Desktop/Game
+git fetch origin main
+node --test tests/ai/*.test.js                                                         # 307/307
+node --test tests/api/progressionEngine.test.js tests/api/progressionRoutes.test.js tests/api/progressionApply.test.js tests/api/progressionBalance.test.js  # 44/44
+node --test tests/api/missionTimer.test.js tests/api/hardcoreScenarioTimer.test.js tests/api/missionTimerHud.test.js  # 27/27
+node --test tests/api/formEvolution.test.js tests/api/formsRoutes.test.js tests/api/formSessionStore.test.js tests/api/packRoller.test.js tests/api/formsRoutesSessionPack.test.js tests/api/formsPanelInfer.test.js tests/api/formSessionStorePrisma.test.js  # 63/63
+node --test tests/api/campaignRoutes.test.js tests/api/campaignIntegration.test.js     # 31/31
+node --test tests/api/lobbyRoutes.test.js tests/api/lobbyWebSocket.test.js              # 15/15
+node --test tests/e2e/lobbyEndToEnd.test.mjs                                            # 11/11
+node --test tests/scripts/tutorialSpeciesExistence.test.js                              # 3/3
+npm run format:check                                                                    # verde
+```
+
+**Grand total**: ~**500+/500+** verde.
+
+## Warning / constraint
+
+- **NON toccare** `apps/backend/routes/session.js` senza justification (guardrail 2000 LOC)
+- **NON toccare** `apps/backend/services/network/wsSession.js` senza ADR addendum
+- **NON committare** binari sotto `reports/backups/**`
+- **Caveman mode** attivo default
+
+## Riferimenti
+
+- Memory sintesi: [`~/.claude/projects/C--Users-VGit-Desktop-Game/memory/project_sprint_m13_session_2026_04_24.md`](file:~/.claude/projects/C--Users-VGit-Desktop-Game/memory/project_sprint_m13_session_2026_04_24.md)
+- ADR P3: [`docs/adr/ADR-2026-04-24-p3-character-progression.md`](../adr/ADR-2026-04-24-p3-character-progression.md)
+- ADR P6: [`docs/adr/ADR-2026-04-24-p6-hardcore-timeout.md`](../adr/ADR-2026-04-24-p6-hardcore-timeout.md)
+- Handoff prec: [`docs/planning/2026-04-25-next-session-kickoff-m13-phase-b.md`](2026-04-25-next-session-kickoff-m13-phase-b.md)

--- a/docs/playtest/2026-04-26-demo-one-command.md
+++ b/docs/playtest/2026-04-26-demo-one-command.md
@@ -1,0 +1,82 @@
+---
+title: 'Demo one-command — single tunnel ngrok playable con amici'
+workstream: playtest
+category: playbook
+status: draft
+owner: master-dd
+created: 2026-04-26
+tags:
+  - demo
+  - ngrok
+  - coop
+  - m11
+  - tkt-m11b-06
+related:
+  - docs/playtest/2026-04-21-m11-coop-ngrok-playbook.md
+  - docs/adr/ADR-2026-04-20-m11-jackbox-phase-a.md
+---
+
+# Demo one-command — playable con amici
+
+Shortcut per il playbook ngrok. **Un comando + un tunnel** grazie a shared HTTP+WS.
+
+## Prerequisiti
+
+- `npm ci` eseguito
+- `ngrok` CLI installato + account free
+- 4 device (phone/browser) + 1 TV/monitor
+
+## One-liner
+
+```bash
+# Terminal 1 — build + start backend (serve /play static + WS su /ws)
+npm run demo
+
+# Terminal 2 — single tunnel
+ngrok http 3334
+# → copia https://<rand>.ngrok-free.app
+```
+
+## Share
+
+- **Host / TV**: `https://<rand>.ngrok-free.app/play/lobby.html`
+  - crea stanza → click "Entra nella TV" → F11 fullscreen
+- **Player** (4x phone): condividi link dalla card host, formato `.../play/lobby.html?code=ABCD`
+
+## Come funziona
+
+- `LOBBY_WS_SHARED=true` (settato da `scripts/run-demo.cjs`) fa attach del `WebSocketServer` all'HTTP server esistente sulla stessa porta 3334, path `/ws`.
+- Backend serve `apps/play/dist` sotto `/play/*` + genera `/play/runtime-config.js` con `window.LOBBY_WS_SAME_ORIGIN=true`.
+- Frontend `resolveWsUrl()` vede il flag → usa `wss://<host-corrente>/ws` → stesso tunnel ngrok, no secondo URL da configurare.
+- Query override disponibile: `?ws=wss://altro-host/ws` (utile per test con backend remoto diverso).
+
+## Modalità classica (2 tunnel, dedicated WS)
+
+Se preferisci WS isolato su porta 3341 (playbook originale):
+
+```bash
+# Terminal 1
+npm run start:api
+# Terminal 2
+npm run play:dev
+# Terminal 3 + 4 — 2 ngrok tunnel (vedi playbook originale)
+```
+
+Vedi [`2026-04-21-m11-coop-ngrok-playbook.md`](2026-04-21-m11-coop-ngrok-playbook.md) per dettaglio.
+
+## Rollback
+
+- `LOBBY_WS_SHARED=false npm run start:api` → back a dedicated port
+- `rm -rf apps/play/dist` → static /play non servito, dev flow via Vite
+
+## Smoke checklist
+
+- [ ] `curl https://<rand>.ngrok-free.app/play/runtime-config.js` → `window.LOBBY_WS_SAME_ORIGIN=true;`
+- [ ] browser devtools Network: WebSocket `wss://<rand>.ngrok-free.app/ws` status 101
+- [ ] host crea stanza → 4-char code
+- [ ] player con `?code=ABCD` vede overlay composer
+- [ ] intent player → host log relay
+
+## Follow-up
+
+Playbook completo metriche + scenari in [`2026-04-21-m11-coop-ngrok-playbook.md`](2026-04-21-m11-coop-ngrok-playbook.md).

--- a/package.json
+++ b/package.json
@@ -46,7 +46,10 @@
     "docs:migrate:dry": "python tools/docs_governance_migrator.py generate-frontmatter --dry-run",
     "docs:migrate:report": "python tools/docs_governance_migrator.py report",
     "play:dev": "npm run dev --workspace apps/play",
-    "play:build": "npm run build --workspace apps/play"
+    "play:build": "npm run build --workspace apps/play",
+    "demo:build": "npm run build --workspace apps/play",
+    "demo:start": "node scripts/run-demo.cjs",
+    "demo": "npm run demo:build && npm run demo:start"
   },
   "lint-staged": {
     "*.{js,cjs,mjs,ts,tsx,jsx,json,md,yml,yaml,css,html}": [

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-23T20:40:47+00:00",
+  "generated_at": "2026-04-23T21:15:45+00:00",
   "summary": {
     "total": 5,
     "errors": 0,

--- a/scripts/run-demo.cjs
+++ b/scripts/run-demo.cjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+// Demo one-tunnel runner: single HTTP+WS server, single ngrok tunnel.
+// Sets LOBBY_WS_SHARED=true so WS attaches to the same HTTP server,
+// and the static /play route advertises same-origin /ws.
+
+const { spawn } = require('node:child_process');
+const path = require('node:path');
+
+process.env.LOBBY_WS_SHARED = 'true';
+process.env.LOBBY_WS_ENABLED = process.env.LOBBY_WS_ENABLED || 'true';
+
+const backendEntry = path.resolve(__dirname, '..', 'apps', 'backend', 'index.js');
+const child = spawn(process.execPath, [backendEntry], {
+  stdio: 'inherit',
+  env: process.env,
+});
+
+const forward = (sig) => () => {
+  if (!child.killed) child.kill(sig);
+};
+process.on('SIGINT', forward('SIGINT'));
+process.on('SIGTERM', forward('SIGTERM'));
+
+child.on('exit', (code) => process.exit(code ?? 0));

--- a/tests/api/resolveWsUrl.test.mjs
+++ b/tests/api/resolveWsUrl.test.mjs
@@ -1,0 +1,57 @@
+// Unit tests for resolveWsUrl runtime priority (demo one-tunnel support).
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const ORIGINAL_WINDOW = globalThis.window;
+
+function setWindow({
+  protocol = 'https:',
+  host = 'demo.ngrok-free.app',
+  search = '',
+  extra = {},
+} = {}) {
+  globalThis.window = {
+    location: { protocol, host, hostname: host.split(':')[0], search },
+    ...extra,
+  };
+}
+
+async function importFresh() {
+  const url = new URL('../../apps/play/src/network.js', import.meta.url);
+  return import(`${url.href}?t=${Date.now()}_${Math.random()}`);
+}
+
+test.afterEach(() => {
+  globalThis.window = ORIGINAL_WINDOW;
+});
+
+test('resolveWsUrl: query ?ws= overrides everything', async () => {
+  setWindow({
+    search: '?ws=wss://override.example/ws',
+    extra: { LOBBY_WS_URL: 'wss://ignored/ws' },
+  });
+  const { resolveWsUrl } = await importFresh();
+  assert.equal(resolveWsUrl(), 'wss://override.example/ws');
+});
+
+test('resolveWsUrl: window.LOBBY_WS_URL beats same-origin flag', async () => {
+  setWindow({ extra: { LOBBY_WS_URL: 'wss://runtime/ws', LOBBY_WS_SAME_ORIGIN: true } });
+  const { resolveWsUrl } = await importFresh();
+  assert.equal(resolveWsUrl(), 'wss://runtime/ws');
+});
+
+test('resolveWsUrl: same-origin flag → wss://<host>/ws (no port 3341)', async () => {
+  setWindow({
+    protocol: 'https:',
+    host: 'demo.ngrok-free.app',
+    extra: { LOBBY_WS_SAME_ORIGIN: true },
+  });
+  const { resolveWsUrl } = await importFresh();
+  assert.equal(resolveWsUrl(), 'wss://demo.ngrok-free.app/ws');
+});
+
+test('resolveWsUrl: default → same hostname with port 3341', async () => {
+  setWindow({ protocol: 'http:', host: 'localhost:5180' });
+  const { resolveWsUrl } = await importFresh();
+  assert.equal(resolveWsUrl(), 'ws://localhost:3341/ws');
+});


### PR DESCRIPTION
## Summary

- Single ngrok tunnel + single command per playtest live M11 co-op. Closes friction TKT-M11B-06.
- `LOBBY_WS_SHARED=true` → WS attach all'HTTP server esistente su `/ws`, stessa porta API (3334)
- Backend serve `apps/play/dist` a `/play` + runtime-config.js dinamico → `window.LOBBY_WS_SAME_ORIGIN`
- `resolveWsUrl()` priority: query `?ws=` → `window.LOBBY_WS_URL` → same-origin → VITE env → legacy port 3341
- Backward compat preservato (dedicated-port mode = default)

## Usage

```bash
npm run demo           # build play + start backend shared HTTP+WS
ngrok http 3334        # one tunnel
# share: https://<rand>.ngrok-free.app/play/lobby.html
```

## Test plan

- [x] 15/15 lobbyRoutes + lobbyWebSocket verde
- [x] 11/11 lobbyEndToEnd e2e verde
- [x] 4/4 nuovi resolveWsUrl unit test verde
- [x] npm run format:check verde
- [x] Smoke live: /play/runtime-config.js → window.LOBBY_WS_SAME_ORIGIN=true;
- [x] Smoke live: [lobby-ws] attached shared mode
- [x] Smoke live: /play/lobby.html serve con runtime-config script
- [ ] Playtest live userland 4 player via ngrok (TKT-M11B-06)

## Rollback

- LOBBY_WS_SHARED=false → back a dedicated port 3341
- rm -rf apps/play/dist → static /play non servito, dev Vite continua
- Revert commit: tutto opt-in via env flag, zero breaking change

## Riferimenti

- Quickstart: docs/playtest/2026-04-26-demo-one-command.md
- Playbook originale: docs/playtest/2026-04-21-m11-coop-ngrok-playbook.md
- ADR protocollo: docs/adr/ADR-2026-04-20-m11-jackbox-phase-a.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)