### PR TITLE
docs(playtest): pre-session checklist + bug/session report templates (kit M11)

### DIFF
--- a/docs/playtest/2026-04-26-pre-session-checklist.md
+++ b/docs/playtest/2026-04-26-pre-session-checklist.md
@@ -1,0 +1,79 @@
+---
+title: 'Pre-session checklist — demo playtest M11 co-op'
+workstream: playtest
+category: checklist
+status: draft
+owner: master-dd
+created: 2026-04-26
+tags:
+  - playtest
+  - m11
+  - coop
+  - demo
+  - tkt-m11b-06
+related:
+  - docs/playtest/2026-04-26-demo-one-command.md
+  - docs/playtest/2026-04-21-m11-coop-ngrok-playbook.md
+---
+
+# Pre-session checklist — demo playtest co-op
+
+Da eseguire **prima che arrivino gli amici** (~10 min).
+
+## T-30 min · ambiente
+
+- [ ] `git pull origin main` → demo one-tunnel PR mergiata
+- [ ] `npm ci` se package.json cambiato
+- [ ] `npm run demo` gira → log `[play-static] serving`, `[lobby-ws] shared mode`, `API online`
+- [ ] Apri `http://localhost:3334/play/lobby.html` in browser host → UI carica senza errori console
+- [ ] Crea stanza test local → codice 4-char visibile
+- [ ] Apri 2nd browser Incognito → join stanza con codice → overlay composer compare
+- [ ] `Ctrl+C` demo → server chiude pulito
+
+## T-15 min · network
+
+- [ ] `ngrok http 3334` in terminal separato
+- [ ] Copia `https://<rand>.ngrok-free.app` → salva in clipboard manager
+- [ ] `curl https://<rand>.ngrok-free.app/play/runtime-config.js` → ritorna `window.LOBBY_WS_SAME_ORIGIN=true;`
+- [ ] Apri `https://<rand>.ngrok-free.app/play/lobby.html` da phone/rete esterna → UI carica
+- [ ] Verifica latenza: ping tunnel <100ms preferibile
+
+## T-10 min · TV/host
+
+- [ ] TV/monitor fullscreen browser (F11)
+- [ ] Disabilita notifiche desktop (slack/email/discord)
+- [ ] Backup audio: speaker esterni se TV muto
+- [ ] Apri tab separato con logs backend (monitor crash)
+
+## T-5 min · playtest
+
+- [ ] Player 1-4 ricevono share URL `https://<rand>.../play/lobby.html?code=XXXX`
+- [ ] Ciascun player inserisce nome + click Entra
+- [ ] Roster host-side mostra 4 player verdi
+- [ ] Host seleziona scenario `enc_tutorial_01` + modulation `quartet`
+- [ ] Click "Nuova sessione" → world bootstrap broadcast
+
+## Durante sessione
+
+- [ ] Cronometra RTT primo intent player → broadcast
+- [ ] Note bug/confusion real-time (usa bug-report template sottostante)
+- [ ] Screenshot momenti chiave (onboarding, combat, fine)
+- [ ] Registra audio commenti (opzionale, con consenso)
+
+## Post-sessione
+
+- [ ] Compila `2026-04-XX-playtest-session-report.md` (template in kit)
+- [ ] Raccogli form feedback da ciascun player (link `/api/feedback`)
+- [ ] Se 3+ round completati senza crash + ≥4 player + fun ≥4/5 → **bump P5 🟢**
+- [ ] Update `CLAUDE.md` sprint context + memory file session
+
+## Troubleshooting fast lane
+
+| Sintomo                          | Fix rapido                                           |
+| -------------------------------- | ---------------------------------------------------- |
+| Player banner `chiuso` subito    | Check ngrok tunnel alive; riavvia `ngrok http 3334`  |
+| WS handshake 502 via ngrok       | Account ngrok free limits → riavvia tunnel           |
+| Overlay `in attesa dell'host`    | Host click "Nuova sessione"                          |
+| Share URL copia `localhost:3334` | Host deve aprire URL ngrok, non locale               |
+| Roster player mancanti           | Player deve fare refresh dopo ngrok restart          |
+| Backend crash metà sessione      | Salva log → `kill -0 $(pgrep node)` + `npm run demo` |

--- a/docs/playtest/templates/bug-report-template.md
+++ b/docs/playtest/templates/bug-report-template.md
@@ -1,0 +1,65 @@
+---
+title: 'Bug report template — playtest session'
+workstream: playtest
+category: template
+status: draft
+owner: master-dd
+created: 2026-04-26
+tags:
+  - playtest
+  - bug-report
+  - template
+---
+
+# Bug report — [SCENARIO] · [DATA]
+
+## Meta
+
+- **Session ID**: `sess_xxx`
+- **Round**: N
+- **Scenario**: `enc_tutorial_XX`
+- **Modulation**: solo / duo / trio / quartet / full
+- **Player affected**: `p_xxx` (role: host / player)
+- **Device**: browser + OS + screen size
+
+## Sintomo
+
+1 riga cosa vedi.
+
+## Repro
+
+1. Step
+2. Step
+3. Bug
+
+## Atteso vs osservato
+
+- **Atteso**: ...
+- **Osservato**: ...
+
+## Severità
+
+- **P0** crash / blocker / data loss
+- **P1** flow spezzato, workaround esiste
+- **P2** UX confusion, non blocca
+- **P3** cosmetic
+
+## Console/logs
+
+```
+[paste relevant backend log + browser console]
+```
+
+## Screenshot
+
+`[link]`
+
+## Ipotesi causa
+
+Opzionale. File:line se noto.
+
+## Assegnato
+
+- **TKT**: `TKT-PLAYTEST-XX`
+- **Owner**: master-dd / claude / codex
+- **Priority sprint**: M14 / backlog

--- a/docs/playtest/templates/session-report-template.md
+++ b/docs/playtest/templates/session-report-template.md
@@ -1,0 +1,84 @@
+---
+title: 'Session report template — M11 co-op playtest'
+workstream: playtest
+category: template
+status: draft
+owner: master-dd
+created: 2026-04-26
+tags:
+  - playtest
+  - session-report
+  - template
+  - m11
+---
+
+# Playtest session — [DATA]
+
+## Meta
+
+- **Data**: YYYY-MM-DD
+- **Durata**: Xh Ym
+- **Player count**: N (incluso host)
+- **Scenari giocati**: `enc_tutorial_XX`, ...
+- **Build**: commit `xxxxxxx` su `main`
+- **Network**: ngrok tunnel / LAN / localhost
+
+## Flow
+
+### Round count + outcome per scenario
+
+| Scenario        | Round completati | Outcome | Durata | Note   |
+| --------------- | :--------------: | :-----: | ------ | ------ |
+| enc_tutorial_01 |        5         |   win   | 8m     | smooth |
+| ...             |                  |         |        |        |
+
+## Metriche
+
+| Metrica                        | Valore | Target        | Pass |
+| ------------------------------ | ------ | ------------- | :--: |
+| RTT intent → broadcast p50     | Xms    | <1500ms ngrok | ✓/✗  |
+| RTT intent → broadcast p95     | Xms    | <3000ms ngrok | ✓/✗  |
+| Reconnect success rate         | X/Y    | ≥90%          | ✓/✗  |
+| Host log relay success         | X/Y    | 100%          | ✓/✗  |
+| Crash count                    | N      | 0             | ✓/✗  |
+| UX confusion questions / round | N      | ≤1            | ✓/✗  |
+| Fun rating media (1-5)         | X.X    | ≥4.0          | ✓/✗  |
+
+## Bug trovati
+
+Link bug report per ciascuno in `templates/bug-report-template.md`:
+
+- [ ] TKT-PLAYTEST-01 — P0 — ...
+- [ ] TKT-PLAYTEST-02 — P1 — ...
+- ...
+
+## UX insights
+
+### Positivi
+
+- ...
+
+### Frustrations
+
+- ...
+
+### Requests
+
+- ...
+
+## Decisions
+
+- [ ] **P5 🟢 bump?** Criteria: 3+ round/scenario + ≥4 player + 0 P0 + fun ≥4/5 → sì/no perché
+- [ ] Fix prioritari next sprint
+- [ ] Modifiche scope M12/M13/M14
+
+## Follow-up
+
+- [ ] Update `CLAUDE.md` sprint context
+- [ ] Update memory `project_playtest_YYYY_MM_DD.md`
+- [ ] Open ticket backlog per bug P0/P1
+- [ ] Se 🟢 bump: `docs/planning/2026-04-20-pilastri-reality-audit.md` update
+
+## Raw notes
+
+Dump inline note sessione.


### PR DESCRIPTION
## Summary

- Operational kit per playtest demo M11 co-op (complementa #1700)
- Pre-session checklist T-30/-15/-10/-5 min + fast-lane troubleshooting
- Bug report template + session report template (metriche + decision gating P5 🟢)

## Test plan

- [x] prettier --check verde
- [ ] Usato in sessione playtest reale (TKT-M11B-06)

🤖 Generated with [Claude Code](https://claude.com/claude-code)