### PR TITLE
feat(p4): Thought Cabinet — Disco Elysium diegetic reveal (P4 🟡→🟡+)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -1651,6 +1651,9 @@ function createSessionRouter(options = {}) {
       const eventsCount = session.events.length;
       const logFile = session.logFilePath;
       sessions.delete(session.session_id);
+      // P4 Thought Cabinet: release per-session unlock cache on teardown.
+      // Prevents linear memory growth over process lifetime (Codex review #1702).
+      thoughtsStore.delete(session.session_id);
       if (activeSessionId === session.session_id) {
         activeSessionId = null;
       }

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -43,6 +43,8 @@ const {
 } = require('../services/traitEffects');
 const { loadFairnessConfig, checkCapPtBudget, consumeCapPt } = require('../services/fairnessCap');
 const { loadTelemetryConfig, buildVcSnapshot } = require('../services/vcScoring');
+// P4 Thought Cabinet: evaluateThoughts per /thoughts endpoint.
+const { evaluateThoughts: evaluateMbtiThoughts } = require('../services/thoughts/thoughtCabinet');
 // SPRINT_010 (issue #2): IA estratta in modulo dedicato.
 // Le funzioni decisionali (selectAiPolicy, stepAway) vivono in services/ai/policy.js,
 // l'orchestratore del turno (createSistemaTurnRunner) in services/ai/sistemaTurnRunner.js.
@@ -160,6 +162,8 @@ function createSessionRouter(options = {}) {
 
   const sessions = new Map();
   let activeSessionId = null;
+  // P4 Thought Cabinet: sessionId -> Map<unitId, Set<thoughtId>>
+  const thoughtsStore = new Map();
 
   function newSessionId() {
     return crypto.randomUUID();
@@ -1698,6 +1702,37 @@ function createSessionRouter(options = {}) {
         pfResult[unitId] = computePfSession(actorVc, formsData);
       }
       res.json({ session_id: session.session_id, pf_session: pfResult });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // P4 Thought Cabinet: on-demand evaluation. Reads current VC snapshot per
+  // actor, crosses mbti_axes against 18 YAML thoughts, cumulatively unlocks
+  // into in-memory store. Returns per-actor { unlocked, newly, details[] }.
+  router.get('/:id/thoughts', (req, res, next) => {
+    try {
+      const { error, session } = resolveSession(req.params.id);
+      if (error) return res.status(error.status).json(error.body);
+      const snapshot = buildVcSnapshot(session, telemetryConfig);
+      let bucket = thoughtsStore.get(session.session_id);
+      if (!bucket) {
+        bucket = new Map();
+        thoughtsStore.set(session.session_id, bucket);
+      }
+      const perActor = {};
+      for (const [unitId, actorVc] of Object.entries(snapshot.per_actor || {})) {
+        const axes = actorVc && actorVc.mbti_axes ? actorVc.mbti_axes : null;
+        let already = bucket.get(unitId);
+        if (!already) {
+          already = new Set();
+          bucket.set(unitId, already);
+        }
+        const { unlocked, newly } = evaluateMbtiThoughts(axes, already);
+        for (const id of newly) already.add(id);
+        perActor[unitId] = { unlocked, newly };
+      }
+      res.json({ session_id: session.session_id, per_actor: perActor });
     } catch (err) {
       next(err);
     }

--- a/apps/backend/services/thoughts/thoughtCabinet.js
+++ b/apps/backend/services/thoughts/thoughtCabinet.js
@@ -1,0 +1,101 @@
+// P4 Thought Cabinet — pattern Disco Elysium diegetic reveal.
+//
+// Evaluates MBTI axes (from buildVcSnapshot per_actor[uid].mbti_axes) and
+// unlocks thoughts once a unit's axis value crosses a progressive threshold.
+// Cumulative: once unlocked, persists across rounds (session state).
+//
+// YAML source: data/core/thoughts/mbti_thoughts.yaml (18 thoughts, 3 axes ×
+// 2 directions × 3 tiers).
+//
+// Pure evaluator: no I/O, no mutation. Caller merges `newly` into session
+// state (e.g. session.meta.thoughts_unlocked[unit_id]).
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+let _cache = null;
+const DEFAULT_YAML_PATH = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  'data',
+  'core',
+  'thoughts',
+  'mbti_thoughts.yaml',
+);
+
+function loadThoughts({ filepath = DEFAULT_YAML_PATH, force = false } = {}) {
+  if (_cache && !force) return _cache;
+  const raw = fs.readFileSync(filepath, 'utf8');
+  const parsed = yaml.load(raw) || {};
+  _cache = {
+    version: parsed.version || '0.0.0',
+    thoughts: parsed.thoughts || {},
+  };
+  return _cache;
+}
+
+function resetCache() {
+  _cache = null;
+}
+
+function thoughtsByAxis(catalog = loadThoughts()) {
+  const out = { E_I: [], S_N: [], T_F: [], J_P: [] };
+  for (const [id, entry] of Object.entries(catalog.thoughts || {})) {
+    if (!out[entry.axis]) continue;
+    out[entry.axis].push({ id, ...entry });
+  }
+  return out;
+}
+
+function matchesThreshold(value, direction, threshold) {
+  if (value === null || value === undefined || Number.isNaN(value)) return false;
+  if (direction === 'low') return value <= threshold;
+  if (direction === 'high') return value >= threshold;
+  return false;
+}
+
+// Pure evaluator. `alreadyUnlocked` can be Array or Set of thought ids.
+function evaluateThoughts(axes, alreadyUnlocked = [], opts = {}) {
+  const catalog = opts.catalog || loadThoughts();
+  const set = new Set(
+    alreadyUnlocked instanceof Set
+      ? alreadyUnlocked
+      : Array.isArray(alreadyUnlocked)
+        ? alreadyUnlocked
+        : [],
+  );
+  const newly = [];
+  if (!axes || typeof axes !== 'object') {
+    return { unlocked: Array.from(set), newly };
+  }
+  for (const [id, entry] of Object.entries(catalog.thoughts || {})) {
+    if (set.has(id)) continue;
+    const axis = axes[entry.axis];
+    const value = axis && typeof axis === 'object' ? axis.value : null;
+    if (!matchesThreshold(value, entry.direction, entry.threshold)) continue;
+    set.add(id);
+    newly.push(id);
+  }
+  return { unlocked: Array.from(set), newly };
+}
+
+function describeThought(id, catalog = loadThoughts()) {
+  const entry = catalog.thoughts?.[id];
+  if (!entry) return null;
+  return { id, ...entry };
+}
+
+module.exports = {
+  loadThoughts,
+  resetCache,
+  evaluateThoughts,
+  thoughtsByAxis,
+  describeThought,
+  matchesThreshold,
+};

--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -113,6 +113,28 @@
             </svg>
             <span class="hud-label">📈 Lv</span>
           </button>
+          <button
+            id="thoughts-open"
+            class="hud-btn"
+            title="Thought Cabinet — MBTI thoughts sbloccati (P4)"
+          >
+            <svg
+              class="hud-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path
+                d="M9 3a4 4 0 0 0-4 4v3a4 4 0 0 0 2 3.46V17a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2v-3.54A4 4 0 0 0 19 10V7a4 4 0 0 0-4-4z"
+              />
+              <path d="M10 21h4" />
+            </svg>
+            <span class="hud-label">🧠 Mente</span>
+          </button>
           <button id="forms-open" class="hud-btn" title="Evoluzione Form — scegli form MBTI (M12)">
             <svg
               class="hud-icon"

--- a/apps/play/src/api.js
+++ b/apps/play/src/api.js
@@ -83,6 +83,7 @@ export const api = {
       body: JSON.stringify({ session_id: sid, auto_resolve: autoResolve }),
     }),
   vc: (sid) => jsonFetch(`/api/session/${encodeURIComponent(sid)}/vc`),
+  thoughts: (sid) => jsonFetch(`/api/session/${encodeURIComponent(sid)}/thoughts`),
   replay: (sid) => jsonFetch(`/api/session/${encodeURIComponent(sid)}/replay`),
   modulations: () => jsonFetch('/api/party/modulations'),
   partyConfig: () => jsonFetch('/api/party/config'),

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -22,6 +22,7 @@ import { initFeedbackPanel } from './feedbackPanel.js';
 import { initCampaignPanel } from './campaignPanel.js';
 import { initLobbyBridgeIfPresent } from './lobbyBridge.js';
 import { initFormsPanel, openFormsPanel } from './formsPanel.js';
+import { initThoughtsPanel, openThoughtsPanel } from './thoughtsPanel.js';
 import { initProgressionPanel, openProgressionPanel } from './progressionPanel.js';
 
 const state = {
@@ -1610,6 +1611,15 @@ async function advanceCampaignWithEvolvePrompt(campaignId, outcome, peEarned = 0
   return res;
 }
 
+// P4 Thought Cabinet — header btn 🧠 + overlay.
+initThoughtsPanel({
+  getSessionId: () => state.sid,
+  getSelectedUnit: () =>
+    state.world && state.selected
+      ? getUnits(state.world).find((u) => u.id === state.selected) || null
+      : null,
+});
+
 window.__evo = {
   state,
   api,
@@ -1617,5 +1627,6 @@ window.__evo = {
   refreshVcSnapshot,
   advanceCampaignWithEvolvePrompt,
   openFormsPanel,
+  openThoughtsPanel,
   lobbyBridge,
 };

--- a/apps/play/src/thoughtsPanel.js
+++ b/apps/play/src/thoughtsPanel.js
@@ -1,0 +1,407 @@
+// P4 Thought Cabinet — overlay UI.
+//
+// Fetches /api/session/:sid/thoughts on open, groups unlocked thoughts by
+// axis (E_I / S_N / J_P) for the selected unit, renders progressive
+// tier cards (tier 1/2/3) with title + flavor + effect hint.
+//
+// Depends on: api.thoughts(sid) + getSelectedUnit.
+
+import { api } from './api.js';
+
+const STATE = {
+  overlayEl: null,
+  getSessionId: () => null,
+  getSelectedUnit: () => null,
+  lastData: null,
+  catalog: null,
+};
+
+const AXIS_LABELS = {
+  E_I: 'Estroversione ⇄ Introversione',
+  S_N: 'Sensazione ⇄ Intuizione',
+  J_P: 'Giudicare ⇄ Percepire',
+};
+
+function injectStyles() {
+  if (document.getElementById('thoughts-panel-styles')) return;
+  const s = document.createElement('style');
+  s.id = 'thoughts-panel-styles';
+  s.textContent = `
+    .thoughts-overlay {
+      position: fixed; inset: 0; z-index: 9995;
+      background: rgba(10, 12, 18, 0.82);
+      display: none; align-items: flex-start; justify-content: center;
+      padding: 32px 16px; overflow-y: auto;
+      font-family: Inter, system-ui, sans-serif; color: #e8eaf0;
+    }
+    .thoughts-overlay.visible { display: flex; }
+    .thoughts-card {
+      max-width: 900px; width: 100%; background: #11141c;
+      border: 1px solid #2a3040; border-radius: 14px; padding: 22px 24px;
+    }
+    .thoughts-head {
+      display: flex; align-items: center; gap: 12px; margin-bottom: 14px;
+    }
+    .thoughts-head h2 { margin: 0; font-size: 1.25rem; color: #c6a0ff; }
+    .thoughts-head .unit-chip {
+      margin-left: auto; background: #0b0d12; border: 1px solid #2a3040;
+      border-radius: 999px; padding: 4px 12px; font-size: 0.85rem;
+    }
+    .thoughts-head .close-btn {
+      background: transparent; border: none; color: #ef9a9a;
+      cursor: pointer; font-size: 1.2rem;
+    }
+    .thoughts-empty {
+      padding: 28px 10px; text-align: center; color: #9aa3b5;
+      font-style: italic;
+    }
+    .thoughts-axis {
+      margin-bottom: 18px; border: 1px solid #2a3040; border-radius: 10px;
+      padding: 14px 16px; background: #0d1118;
+    }
+    .thoughts-axis-head {
+      font-size: 0.9rem; color: #8aa0c7; margin-bottom: 10px;
+      text-transform: uppercase; letter-spacing: 0.05em;
+    }
+    .thoughts-tiers { display: flex; gap: 10px; flex-wrap: wrap; }
+    .thought-card {
+      flex: 1 1 240px; min-width: 240px; background: #1a1f2b;
+      border: 1px solid #2a3040; border-radius: 8px; padding: 10px 12px;
+    }
+    .thought-card.locked { opacity: 0.32; filter: grayscale(0.6); }
+    .thought-card.tier-1 { border-left: 3px solid #66d1fb; }
+    .thought-card.tier-2 { border-left: 3px solid #ffc66b; }
+    .thought-card.tier-3 { border-left: 3px solid #ff7a9a; }
+    .thought-title {
+      display: flex; gap: 6px; align-items: baseline;
+      font-weight: 600; color: #e8eaf0; margin-bottom: 4px;
+    }
+    .thought-title .tier-badge {
+      font-size: 0.72rem; color: #8aa0c7;
+    }
+    .thought-title .pole-badge {
+      margin-left: auto; background: #0b0d12; border-radius: 4px;
+      padding: 1px 6px; font-size: 0.75rem; color: #c6a0ff;
+    }
+    .thought-flavor {
+      font-size: 0.85rem; color: #c8cfdd; margin-bottom: 6px;
+      line-height: 1.35;
+    }
+    .thought-hint {
+      font-size: 0.75rem; color: #8aa0c7; font-style: italic;
+    }
+    .thought-card.newly {
+      animation: thought-unlock 1.8s ease-out;
+      box-shadow: 0 0 18px rgba(198, 160, 255, 0.35);
+    }
+    @keyframes thought-unlock {
+      0% { transform: scale(0.92); box-shadow: 0 0 0 rgba(198, 160, 255, 0); }
+      40% { transform: scale(1.02); box-shadow: 0 0 24px rgba(198, 160, 255, 0.55); }
+      100% { transform: scale(1); box-shadow: 0 0 18px rgba(198, 160, 255, 0.35); }
+    }
+  `;
+  document.head.appendChild(s);
+}
+
+function buildOverlay() {
+  if (STATE.overlayEl) return STATE.overlayEl;
+  injectStyles();
+  const wrap = document.createElement('div');
+  wrap.className = 'thoughts-overlay';
+  wrap.innerHTML = `
+    <div class="thoughts-card">
+      <div class="thoughts-head">
+        <h2>🧠 Thought Cabinet</h2>
+        <span class="unit-chip" data-role="unit-chip">—</span>
+        <button class="close-btn" data-role="close" aria-label="Chiudi">✕</button>
+      </div>
+      <div data-role="body"></div>
+    </div>
+  `;
+  wrap.addEventListener('click', (ev) => {
+    if (ev.target === wrap) closeThoughtsPanel();
+  });
+  wrap.querySelector('[data-role="close"]').addEventListener('click', closeThoughtsPanel);
+  document.body.appendChild(wrap);
+  STATE.overlayEl = wrap;
+  return wrap;
+}
+
+// Load catalog once (small YAML inlined — fetch from backend /thoughts provides IDs only,
+// so we mirror a minimal catalog via an endpoint? No — we expose via thoughts response).
+// Simplification: build static catalog map client-side keyed by thought id.
+const CLIENT_CATALOG = buildClientCatalog();
+
+function buildClientCatalog() {
+  // Mirror of data/core/thoughts/mbti_thoughts.yaml (titles + pole + tier + flavor).
+  // Kept in sync manually; future iteration can serve catalog via /api/thoughts/catalog.
+  return {
+    e_voce_collettiva: [
+      'E_I',
+      'E',
+      1,
+      'Voce Collettiva',
+      'Parla ai compagni anche senza necessità tattica.',
+      'Preferisce ingaggi ravvicinati.',
+    ],
+    e_scintilla_carisma: [
+      'E_I',
+      'E',
+      2,
+      'Scintilla di Carisma',
+      'Ogni azione è spettacolo. Forzare il fronte diventa istinto.',
+      'Intraprende rischi visibili.',
+    ],
+    e_campione_folla: [
+      'E_I',
+      'E',
+      3,
+      'Campione della Folla',
+      "Il silenzio è l'unico nemico. Sempre in prima linea.",
+      'Unlock job aggressivi.',
+    ],
+    i_osservatore: [
+      'E_I',
+      'I',
+      1,
+      'Osservatore',
+      'Preferisce studiare prima di impegnarsi.',
+      'Ingaggi distanti; valuta prima.',
+    ],
+    i_calcolo_silente: [
+      'E_I',
+      'I',
+      2,
+      'Calcolo Silente',
+      'Ogni intervento pesato. Evita il caos.',
+      'Economia azioni alta.',
+    ],
+    i_lupo_solitario: [
+      'E_I',
+      'I',
+      3,
+      'Lupo Solitario',
+      'Opera meglio ai margini, lontano dagli altri.',
+      'Unlock furtivo/esploratore.',
+    ],
+    n_intuizione_terrena: [
+      'S_N',
+      'N',
+      1,
+      'Intuizione Terrena',
+      'Sente pattern nascosti nel biome.',
+      'Alta esplorazione.',
+    ],
+    n_pioniere_possibile: [
+      'S_N',
+      'N',
+      2,
+      'Pioniere del Possibile',
+      'Inventa soluzioni che non esistono nel manuale.',
+      'Preferisce evade/flank.',
+    ],
+    n_visionario: [
+      'S_N',
+      'N',
+      3,
+      'Visionario',
+      'Vede mosse 3 round avanti.',
+      'Unlock esploratore/tattico.',
+    ],
+    s_occhio_pratico: [
+      'S_N',
+      'S',
+      1,
+      'Occhio Pratico',
+      'Si fida di ciò che può toccare.',
+      'Setup ratio alto.',
+    ],
+    s_metodologia_ferro: [
+      'S_N',
+      'S',
+      2,
+      'Metodologia di Ferro',
+      'Setup prima di tutto; non improvvisa.',
+      'Massimizza copertura.',
+    ],
+    s_veterano_terreno: [
+      'S_N',
+      'S',
+      3,
+      'Veterano del Terreno',
+      'Ogni tile nota, ogni copertura memorizzata.',
+      'Unlock sentinella/controllore.',
+    ],
+    p_adattatore: [
+      'J_P',
+      'P',
+      1,
+      'Adattatore',
+      'Cambia piano al volo senza attrito.',
+      'Intent flessibile.',
+    ],
+    p_improvvisatore: [
+      'J_P',
+      'P',
+      2,
+      'Improvvisatore',
+      "Il piano è suggerimento; l'istante è legge.",
+      'Reaction penalty ridotta.',
+    ],
+    p_anima_selvaggia: [
+      'J_P',
+      'P',
+      3,
+      'Anima Selvaggia',
+      'Non pianifica. Reagisce. Vince.',
+      'Unlock furtivo/assaltatore.',
+    ],
+    j_disciplina: [
+      'J_P',
+      'J',
+      1,
+      'Disciplina',
+      'Rispetta il piano anche sotto pressione.',
+      'Bonus mantenimento intent.',
+    ],
+    j_architetto_round: [
+      'J_P',
+      'J',
+      2,
+      'Architetto del Round',
+      'Ogni mossa incastonata.',
+      'Preferisce round planning.',
+    ],
+    j_maestro_ordine: [
+      'J_P',
+      'J',
+      3,
+      'Maestro di Ordine',
+      'Il caos del nemico non lo raggiunge mai.',
+      'Unlock tattico/controllore.',
+    ],
+  };
+}
+
+function renderAxis(axis, unlockedSet, newlySet) {
+  const entries = Object.entries(CLIENT_CATALOG)
+    .filter(([, v]) => v[0] === axis)
+    .map(([id, v]) => ({
+      id,
+      axis: v[0],
+      pole: v[1],
+      tier: v[2],
+      title: v[3],
+      flavor: v[4],
+      hint: v[5],
+    }))
+    .sort((a, b) => {
+      // group by pole then tier
+      if (a.pole !== b.pole) return a.pole < b.pole ? -1 : 1;
+      return a.tier - b.tier;
+    });
+  const cards = entries
+    .map((t) => {
+      const isUnlocked = unlockedSet.has(t.id);
+      const isNewly = newlySet.has(t.id);
+      const cls = [
+        'thought-card',
+        `tier-${t.tier}`,
+        isUnlocked ? '' : 'locked',
+        isNewly ? 'newly' : '',
+      ]
+        .filter(Boolean)
+        .join(' ');
+      const title = isUnlocked ? t.title : '???';
+      const flavor = isUnlocked ? t.flavor : '— ancora celato —';
+      const hint = isUnlocked ? `<div class="thought-hint">${escapeHtml(t.hint)}</div>` : '';
+      return `
+        <div class="${cls}">
+          <div class="thought-title">
+            <span>${escapeHtml(title)}</span>
+            <span class="tier-badge">T${t.tier}</span>
+            <span class="pole-badge">${t.pole}</span>
+          </div>
+          <div class="thought-flavor">${escapeHtml(flavor)}</div>
+          ${hint}
+        </div>
+      `;
+    })
+    .join('');
+  return `
+    <div class="thoughts-axis">
+      <div class="thoughts-axis-head">${escapeHtml(AXIS_LABELS[axis])}</div>
+      <div class="thoughts-tiers">${cards}</div>
+    </div>
+  `;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(
+    /[&<>"']/g,
+    (c) =>
+      ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+      })[c],
+  );
+}
+
+function render(unit, perActorEntry) {
+  const overlay = buildOverlay();
+  const body = overlay.querySelector('[data-role="body"]');
+  const chip = overlay.querySelector('[data-role="unit-chip"]');
+  chip.textContent = unit ? `${unit.label || unit.id}` : 'nessun PG selezionato';
+  if (!unit || !perActorEntry) {
+    body.innerHTML =
+      '<div class="thoughts-empty">Seleziona un PG per vedere i suoi thoughts sbloccati.</div>';
+    return;
+  }
+  const unlocked = new Set(perActorEntry.unlocked || []);
+  const newly = new Set(perActorEntry.newly || []);
+  if (unlocked.size === 0) {
+    body.innerHTML = `
+      <div class="thoughts-empty">
+        Nessun thought ancora sbloccato. Gioca round con pattern MBTI consistente
+        su E_I / S_N / J_P.
+      </div>
+      ${['E_I', 'S_N', 'J_P'].map((a) => renderAxis(a, unlocked, newly)).join('')}
+    `;
+    return;
+  }
+  body.innerHTML = ['E_I', 'S_N', 'J_P'].map((a) => renderAxis(a, unlocked, newly)).join('');
+}
+
+export async function openThoughtsPanel() {
+  const overlay = buildOverlay();
+  overlay.classList.add('visible');
+  const sid = STATE.getSessionId();
+  const unit = STATE.getSelectedUnit();
+  if (!sid) {
+    render(unit, null);
+    return;
+  }
+  const res = await api.thoughts(sid);
+  if (!res.ok || !res.data) {
+    render(unit, null);
+    return;
+  }
+  STATE.lastData = res.data;
+  const uid = unit?.id || null;
+  const entry = uid ? res.data.per_actor?.[uid] : null;
+  render(unit, entry);
+}
+
+export function closeThoughtsPanel() {
+  if (STATE.overlayEl) STATE.overlayEl.classList.remove('visible');
+}
+
+export function initThoughtsPanel(opts = {}) {
+  STATE.getSessionId = opts.getSessionId || STATE.getSessionId;
+  STATE.getSelectedUnit = opts.getSelectedUnit || STATE.getSelectedUnit;
+  const btn = document.getElementById('thoughts-open');
+  if (btn) btn.addEventListener('click', () => openThoughtsPanel());
+}

--- a/data/core/thoughts/mbti_thoughts.yaml
+++ b/data/core/thoughts/mbti_thoughts.yaml
@@ -1,0 +1,203 @@
+# Thought Cabinet MBTI — Evo-Tactics Pillar 4 (P4 completion)
+# Pattern ispirato a Disco Elysium: thoughts diegetici che si sbloccano
+# quando un'unità mostra comportamento consistente su un asse MBTI.
+#
+# Copertura: 3 axes (E_I, S_N, J_P) × 2 direzioni × 3 soglie = 18 thoughts.
+# T_F escluso: già surfacato via job_affinities nei Forms.
+#
+# Convenzione direction (coerente con vcScoring letterOrUncertain):
+#   - axis E_I: low → 'E' (estroverso), high → 'I' (introverso)
+#   - axis S_N: low → 'N' (intuitivo), high → 'S' (sensoriale)
+#   - axis J_P: low → 'P' (percepire), high → 'J' (giudicare)
+#
+# Unlock: cumulative (una volta sbloccato, resta) per session:unit.
+# Reveal: UI formsPanel tooltip + popup evolve.
+
+version: "0.1.0"
+
+thoughts:
+  # --- Asse E_I: Estroverso (low) ---
+  e_voce_collettiva:
+    axis: E_I
+    direction: low
+    threshold: 0.35
+    pole_letter: E
+    tier: 1
+    title_it: "Voce Collettiva"
+    flavor_it: "Parla ai compagni anche senza necessità tattica. Ogni azione è conferma condivisa."
+    effect_hint_it: "Preferisce ingaggi ravvicinati, cerca supporto di squadra."
+
+  e_scintilla_carisma:
+    axis: E_I
+    direction: low
+    threshold: 0.25
+    pole_letter: E
+    tier: 2
+    title_it: "Scintilla di Carisma"
+    flavor_it: "Ogni azione è spettacolo. Forzare il fronte diventa istinto, non scelta."
+    effect_hint_it: "Intraprende rischi visibili; tira il team con sé."
+
+  e_campione_folla:
+    axis: E_I
+    direction: low
+    threshold: 0.15
+    pole_letter: E
+    tier: 3
+    title_it: "Campione della Folla"
+    flavor_it: "Il silenzio è l'unico nemico. Sempre in prima linea, sempre visibile."
+    effect_hint_it: "Pattern estremo E; unlock job aggressivi (assaltatore)."
+
+  # --- Asse E_I: Introverso (high) ---
+  i_osservatore:
+    axis: E_I
+    direction: high
+    threshold: 0.65
+    pole_letter: I
+    tier: 1
+    title_it: "Osservatore"
+    flavor_it: "Preferisce studiare prima di impegnarsi. Ogni mossa ponderata."
+    effect_hint_it: "Ingaggi distanti; valuta prima di committare."
+
+  i_calcolo_silente:
+    axis: E_I
+    direction: high
+    threshold: 0.75
+    pole_letter: I
+    tier: 2
+    title_it: "Calcolo Silente"
+    flavor_it: "Ogni intervento pesato. Evita il caos anche quando potrebbe risolvere."
+    effect_hint_it: "Economia azioni alta; rari utilizzi di abilità rumorose."
+
+  i_lupo_solitario:
+    axis: E_I
+    direction: high
+    threshold: 0.85
+    pole_letter: I
+    tier: 3
+    title_it: "Lupo Solitario"
+    flavor_it: "Opera meglio ai margini, lontano dagli altri. Il team è strumento, non rifugio."
+    effect_hint_it: "Pattern estremo I; unlock job furtivo/esploratore."
+
+  # --- Asse S_N: Intuitivo (low) ---
+  n_intuizione_terrena:
+    axis: S_N
+    direction: low
+    threshold: 0.35
+    pole_letter: N
+    tier: 1
+    title_it: "Intuizione Terrena"
+    flavor_it: "Sente pattern nascosti nel biome. Cerca nuove vie anche senza motivo."
+    effect_hint_it: "Alta esplorazione; new_tiles elevato."
+
+  n_pioniere_possibile:
+    axis: S_N
+    direction: low
+    threshold: 0.25
+    pole_letter: N
+    tier: 2
+    title_it: "Pioniere del Possibile"
+    flavor_it: "Inventa soluzioni che non esistono nel manuale. Il terreno è tela, non mappa."
+    effect_hint_it: "Preferisce evade/flank a setup diretto."
+
+  n_visionario:
+    axis: S_N
+    direction: low
+    threshold: 0.15
+    pole_letter: N
+    tier: 3
+    title_it: "Visionario"
+    flavor_it: "Vede mosse 3 round avanti, a costo di realismo immediato. Il piano è astratto."
+    effect_hint_it: "Pattern estremo N; unlock job esploratore/tattico."
+
+  # --- Asse S_N: Sensoriale (high) ---
+  s_occhio_pratico:
+    axis: S_N
+    direction: high
+    threshold: 0.65
+    pole_letter: S
+    tier: 1
+    title_it: "Occhio Pratico"
+    flavor_it: "Si fida di ciò che può toccare. Il piano prima, l'istinto dopo."
+    effect_hint_it: "Setup ratio alto; basso uso di improvvisazione."
+
+  s_metodologia_ferro:
+    axis: S_N
+    direction: high
+    threshold: 0.75
+    pole_letter: S
+    tier: 2
+    title_it: "Metodologia di Ferro"
+    flavor_it: "Setup prima di tutto. Non improvvisa mai; ogni azione ha un passo precedente."
+    effect_hint_it: "Riduce evasion; massimizza copertura."
+
+  s_veterano_terreno:
+    axis: S_N
+    direction: high
+    threshold: 0.85
+    pole_letter: S
+    tier: 3
+    title_it: "Veterano del Terreno"
+    flavor_it: "Ogni tile nota, ogni copertura memorizzata. Il biome è mappa incisa."
+    effect_hint_it: "Pattern estremo S; unlock job sentinella/controllore."
+
+  # --- Asse J_P: Percepire (low) ---
+  p_adattatore:
+    axis: J_P
+    direction: low
+    threshold: 0.35
+    pole_letter: P
+    tier: 1
+    title_it: "Adattatore"
+    flavor_it: "Cambia piano al volo senza attrito. L'errore di ieri è solo dato nuovo."
+    effect_hint_it: "Cambia intent frequentemente senza penalty."
+
+  p_improvvisatore:
+    axis: J_P
+    direction: low
+    threshold: 0.25
+    pole_letter: P
+    tier: 2
+    title_it: "Improvvisatore"
+    flavor_it: "Il piano è suggerimento; l'istante è legge. Decide quando la carta è in aria."
+    effect_hint_it: "Reaction penalty ridotta; bonus improvvisazione."
+
+  p_anima_selvaggia:
+    axis: J_P
+    direction: low
+    threshold: 0.15
+    pole_letter: P
+    tier: 3
+    title_it: "Anima Selvaggia"
+    flavor_it: "Non pianifica. Reagisce. Vince. Il cervello tattico vive nel presente continuo."
+    effect_hint_it: "Pattern estremo P; unlock job furtivo/assaltatore."
+
+  # --- Asse J_P: Giudicare (high) ---
+  j_disciplina:
+    axis: J_P
+    direction: high
+    threshold: 0.65
+    pole_letter: J
+    tier: 1
+    title_it: "Disciplina"
+    flavor_it: "Rispetta il piano anche sotto pressione. L'improvvisazione è lusso, non strumento."
+    effect_hint_it: "Bonus se mantiene intent round successivo."
+
+  j_architetto_round:
+    axis: J_P
+    direction: high
+    threshold: 0.75
+    pole_letter: J
+    tier: 2
+    title_it: "Architetto del Round"
+    flavor_it: "Ogni mossa incastonata. Fallito = ricalcolo immediato, non panico."
+    effect_hint_it: "Setup ratio alto; preferisce round planning."
+
+  j_maestro_ordine:
+    axis: J_P
+    direction: high
+    threshold: 0.85
+    pole_letter: J
+    tier: 3
+    title_it: "Maestro di Ordine"
+    flavor_it: "Il caos del nemico non lo raggiunge mai. Il piano è prima, durante, dopo."
+    effect_hint_it: "Pattern estremo J; unlock job tattico/controllore."

--- a/tests/api/sessionThoughts.test.js
+++ b/tests/api/sessionThoughts.test.js
@@ -71,3 +71,24 @@ test('GET /:id/thoughts on unknown session → 404', async (t) => {
   const res = await request(app).get('/api/session/not-a-real-id/thoughts');
   assert.equal(res.status, 404);
 });
+
+test('POST /end clears thoughtsStore entry (no memory leak — Codex #1702 P2)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units });
+  const sid = startRes.body.session_id;
+  // Populate thoughtsStore
+  const pre = await request(app).get(`/api/session/${sid}/thoughts`);
+  assert.equal(pre.status, 200);
+  // End session (triggers thoughtsStore.delete)
+  const endRes = await request(app).post('/api/session/end').send({ session_id: sid });
+  assert.equal(endRes.status, 200);
+  // Post-end: session gone → /thoughts 404 (not stale 200 from cache)
+  const post = await request(app).get(`/api/session/${sid}/thoughts`);
+  assert.equal(post.status, 404, 'thoughtsStore entry released with session');
+});

--- a/tests/api/sessionThoughts.test.js
+++ b/tests/api/sessionThoughts.test.js
@@ -1,0 +1,73 @@
+// P4 Thought Cabinet — integration test on /api/session/:id/thoughts.
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+
+test('GET /:id/thoughts returns per_actor unlocked + newly arrays', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  assert.equal(scenario.status, 200);
+
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units });
+  assert.equal(startRes.status, 200);
+  const sid = startRes.body.session_id;
+
+  const res = await request(app).get(`/api/session/${sid}/thoughts`);
+  assert.equal(res.status, 200);
+  assert.equal(res.body.session_id, sid);
+  assert.ok(res.body.per_actor && typeof res.body.per_actor === 'object');
+  for (const [uid, payload] of Object.entries(res.body.per_actor)) {
+    assert.ok(Array.isArray(payload.unlocked), `${uid} unlocked array`);
+    assert.ok(Array.isArray(payload.newly), `${uid} newly array`);
+  }
+});
+
+test('GET /:id/thoughts cumulative — second call has newly=[] if axes static', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units });
+  const sid = startRes.body.session_id;
+
+  const first = await request(app).get(`/api/session/${sid}/thoughts`);
+  const second = await request(app).get(`/api/session/${sid}/thoughts`);
+  assert.equal(second.status, 200);
+  for (const uid of Object.keys(second.body.per_actor || {})) {
+    // newly must be subset-empty on second call (axes unchanged → nothing new)
+    assert.equal(
+      second.body.per_actor[uid].newly.length,
+      0,
+      `${uid} second call must have newly=[]`,
+    );
+    // unlocked total stays the same
+    assert.equal(
+      second.body.per_actor[uid].unlocked.length,
+      first.body.per_actor[uid].unlocked.length,
+    );
+  }
+});
+
+test('GET /:id/thoughts on unknown session → 404', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const res = await request(app).get('/api/session/not-a-real-id/thoughts');
+  assert.equal(res.status, 404);
+});

--- a/tests/api/thoughtCabinet.test.js
+++ b/tests/api/thoughtCabinet.test.js
@@ -1,0 +1,166 @@
+// P4 Thought Cabinet — pure evaluator tests.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  loadThoughts,
+  resetCache,
+  evaluateThoughts,
+  thoughtsByAxis,
+  describeThought,
+  matchesThreshold,
+} = require('../../apps/backend/services/thoughts/thoughtCabinet');
+
+test('loadThoughts: returns 18 thoughts across 3 axes (E_I + S_N + J_P)', () => {
+  resetCache();
+  const catalog = loadThoughts();
+  const ids = Object.keys(catalog.thoughts);
+  assert.equal(ids.length, 18);
+  const by = thoughtsByAxis(catalog);
+  assert.equal(by.E_I.length, 6);
+  assert.equal(by.S_N.length, 6);
+  assert.equal(by.J_P.length, 6);
+  assert.equal(by.T_F.length, 0);
+});
+
+test('loadThoughts: every entry has axis + direction + threshold + title_it', () => {
+  resetCache();
+  const catalog = loadThoughts();
+  for (const [id, e] of Object.entries(catalog.thoughts)) {
+    assert.ok(e.axis, `${id} missing axis`);
+    assert.ok(['low', 'high'].includes(e.direction), `${id} bad direction`);
+    assert.equal(typeof e.threshold, 'number', `${id} bad threshold`);
+    assert.ok(e.title_it, `${id} missing title_it`);
+    assert.ok(e.flavor_it, `${id} missing flavor_it`);
+    assert.ok([1, 2, 3].includes(e.tier), `${id} bad tier`);
+  }
+});
+
+test('matchesThreshold: low direction matches when value ≤ threshold', () => {
+  assert.equal(matchesThreshold(0.3, 'low', 0.35), true);
+  assert.equal(matchesThreshold(0.35, 'low', 0.35), true);
+  assert.equal(matchesThreshold(0.4, 'low', 0.35), false);
+});
+
+test('matchesThreshold: high direction matches when value ≥ threshold', () => {
+  assert.equal(matchesThreshold(0.7, 'high', 0.65), true);
+  assert.equal(matchesThreshold(0.65, 'high', 0.65), true);
+  assert.equal(matchesThreshold(0.6, 'high', 0.65), false);
+});
+
+test('matchesThreshold: null/undefined/NaN never match', () => {
+  assert.equal(matchesThreshold(null, 'low', 0.5), false);
+  assert.equal(matchesThreshold(undefined, 'high', 0.5), false);
+  assert.equal(matchesThreshold(NaN, 'low', 0.5), false);
+});
+
+test('evaluateThoughts: no axes → empty', () => {
+  const res = evaluateThoughts(null);
+  assert.deepEqual(res, { unlocked: [], newly: [] });
+});
+
+test('evaluateThoughts: E extreme (0.12) unlocks all 3 E tiers', () => {
+  resetCache();
+  const axes = { E_I: { value: 0.12, coverage: 'full' } };
+  const { unlocked, newly } = evaluateThoughts(axes);
+  assert.ok(unlocked.includes('e_voce_collettiva'));
+  assert.ok(unlocked.includes('e_scintilla_carisma'));
+  assert.ok(unlocked.includes('e_campione_folla'));
+  assert.equal(newly.length, 3);
+  // opposite pole must NOT unlock
+  assert.ok(!unlocked.includes('i_osservatore'));
+});
+
+test('evaluateThoughts: I moderate (0.68) unlocks only tier 1', () => {
+  const axes = { E_I: { value: 0.68, coverage: 'full' } };
+  const { unlocked } = evaluateThoughts(axes);
+  assert.ok(unlocked.includes('i_osservatore'));
+  assert.ok(!unlocked.includes('i_calcolo_silente'));
+  assert.ok(!unlocked.includes('i_lupo_solitario'));
+});
+
+test('evaluateThoughts: cumulative — alreadyUnlocked not duplicated in newly', () => {
+  // value 0.2 unlocks tier1 (0.35) + tier2 (0.25) but not tier3 (0.15).
+  const axes = { E_I: { value: 0.2, coverage: 'full' } };
+  const already = ['e_voce_collettiva'];
+  const { unlocked, newly } = evaluateThoughts(axes, already);
+  assert.ok(!newly.includes('e_voce_collettiva'));
+  assert.ok(newly.includes('e_scintilla_carisma'));
+  assert.equal(newly.length, 1);
+  assert.equal(unlocked.length, 2);
+});
+
+test('evaluateThoughts: dead-band (0.5) unlocks nothing', () => {
+  const axes = {
+    E_I: { value: 0.5, coverage: 'full' },
+    S_N: { value: 0.5, coverage: 'full' },
+    J_P: { value: 0.5, coverage: 'full' },
+  };
+  const { unlocked, newly } = evaluateThoughts(axes);
+  assert.equal(unlocked.length, 0);
+  assert.equal(newly.length, 0);
+});
+
+test('evaluateThoughts: null axis value skipped cleanly', () => {
+  const axes = {
+    E_I: { value: null, coverage: 'full' },
+    S_N: { value: 0.9, coverage: 'full' },
+  };
+  const { unlocked } = evaluateThoughts(axes);
+  // S 0.9 → passes all 3 S thresholds (0.65, 0.75, 0.85)
+  assert.ok(unlocked.includes('s_occhio_pratico'));
+  assert.ok(unlocked.includes('s_metodologia_ferro'));
+  assert.ok(unlocked.includes('s_veterano_terreno'));
+  // E_I null → no E/I thought
+  assert.ok(!unlocked.includes('e_voce_collettiva'));
+  assert.ok(!unlocked.includes('i_osservatore'));
+});
+
+test('evaluateThoughts: mixed axes with partial coverage', () => {
+  const axes = {
+    E_I: { value: 0.2, coverage: 'full' },
+    S_N: { value: 0.7, coverage: 'partial' },
+    J_P: { value: 0.3, coverage: 'partial' },
+  };
+  const { unlocked } = evaluateThoughts(axes);
+  // E 0.2 → tier 1+2 (0.35, 0.25); tier 3 (0.15) NO
+  assert.ok(unlocked.includes('e_voce_collettiva'));
+  assert.ok(unlocked.includes('e_scintilla_carisma'));
+  assert.ok(!unlocked.includes('e_campione_folla'));
+  // S 0.7 → tier 1 only (0.65)
+  assert.ok(unlocked.includes('s_occhio_pratico'));
+  assert.ok(!unlocked.includes('s_metodologia_ferro'));
+  // P 0.3 → tier 1 (0.35) only
+  assert.ok(unlocked.includes('p_adattatore'));
+  assert.ok(!unlocked.includes('p_improvvisatore'));
+});
+
+test('describeThought: returns shape with id + all fields', () => {
+  const d = describeThought('e_voce_collettiva');
+  assert.equal(d.id, 'e_voce_collettiva');
+  assert.equal(d.axis, 'E_I');
+  assert.equal(d.direction, 'low');
+  assert.equal(d.tier, 1);
+  assert.ok(d.title_it);
+});
+
+test('describeThought: unknown id → null', () => {
+  assert.equal(describeThought('nope_missing'), null);
+});
+
+test('evaluateThoughts: Set input for alreadyUnlocked works', () => {
+  const axes = { E_I: { value: 0.1, coverage: 'full' } };
+  const already = new Set(['e_voce_collettiva']);
+  const { unlocked, newly } = evaluateThoughts(axes, already);
+  assert.equal(unlocked.length, 3);
+  assert.equal(newly.length, 2);
+});
+
+test('evaluateThoughts: axes value exactly at threshold is inclusive', () => {
+  const axes = { E_I: { value: 0.35, coverage: 'full' } };
+  const { unlocked } = evaluateThoughts(axes);
+  assert.ok(unlocked.includes('e_voce_collettiva'));
+});


### PR DESCRIPTION
## Summary

- P4 completion pivot: iter1 axes formulas (E_I/S_N/J_P) erano **già shipped**; residuo = Thought Cabinet diegetic layer
- 18 thoughts (3 axes × 2 poles × 3 tiers) sbloccati su pattern consistente E_I / S_N / J_P
- Nuovo endpoint `GET /api/session/:id/thoughts` + overlay UI 🧠 Mente (pattern Disco Elysium)

## Files

- `data/core/thoughts/mbti_thoughts.yaml` — 18 thought entries con axis + direction + threshold + tier + title/flavor/hint
- `apps/backend/services/thoughts/thoughtCabinet.js` — pure evaluator + YAML loader
- `apps/backend/routes/session.js` — import + thoughtsStore Map + `GET /:id/thoughts` endpoint
- `apps/play/src/thoughtsPanel.js` — overlay modal, cards per axis grouped pole + tier, locked state + unlock animation
- `apps/play/src/api.js` + `main.js` + `index.html` — wiring btn 🧠 Mente

## Test plan

- [x] `node --test tests/api/thoughtCabinet.test.js tests/api/sessionThoughts.test.js` → **19/19 pass**
- [x] `npm run format:check` → verde
- [x] regression smoke: `tests/api/sessionEndResponse.test.js` + `sessionDifficulty.test.js` → 7/7 pass
- [ ] Playtest live: sblocco tier 1 dopo ~3 round pattern, tier 2 ~8 round (userland, opzione B handoff)

## Rollback

Revert PR; thoughtsStore è isolated in-memory Map, nessuna persistenza DB. `session.js` diff è +32 LOC additive (import + Map + route). Zero modifiche a schemi esistenti.

## Pilastro 4 status

🟡 → **🟡+** (axes iter1 live + diegetic layer live; 🟢 candidato gating = focus group validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)