### PR TITLE
feat(lobby): onboarding overlay player + host share hint (UX pre-playtest)

### DIFF
--- a/apps/play/src/lobbyBridge.css
+++ b/apps/play/src/lobbyBridge.css
@@ -421,3 +421,174 @@
     max-width: 360px;
   }
 }
+
+/* M11 onboarding — primo accesso player */
+.lobby-onboarding {
+  position: fixed;
+  inset: 0;
+  z-index: 10010;
+  background: rgba(8, 10, 16, 0.78);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  font-family: Inter, system-ui, sans-serif;
+}
+
+.lobby-onboarding-card {
+  max-width: 480px;
+  width: 100%;
+  background: #151922;
+  border: 1px solid #2a3040;
+  border-radius: 14px;
+  padding: 24px 24px 20px;
+  color: #e8eaf0;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.55);
+}
+
+.lobby-onboarding-card h2 {
+  margin: 6px 0 10px;
+  font-size: 1.2rem;
+}
+
+.lobby-onboarding-card p {
+  margin: 0 0 18px;
+  line-height: 1.5;
+  color: #c7cbd6;
+}
+
+.lobby-onboarding-progress {
+  font-size: 0.8rem;
+  color: #8891a3;
+  letter-spacing: 1px;
+}
+
+.lobby-onboarding-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.lobby-onboarding-actions button {
+  padding: 9px 14px;
+  font-size: 0.92rem;
+  border-radius: 8px;
+  border: 1px solid #2a3040;
+  background: #1d2230;
+  color: #e8eaf0;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.lobby-onboarding-actions button:hover:not(:disabled) {
+  background: #2a3040;
+}
+
+.lobby-onboarding-actions button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.lobby-onboarding-actions .lobby-onboarding-next {
+  background: #4fc3f7;
+  color: #001014;
+  border-color: #4fc3f7;
+}
+
+.lobby-onboarding-actions .lobby-onboarding-next:hover {
+  background: #66d1fb;
+}
+
+.lobby-onboarding-actions .lobby-onboarding-skip {
+  margin-right: auto;
+  color: #8891a3;
+  background: transparent;
+  border-color: transparent;
+}
+
+.lobby-onboarding-actions .lobby-onboarding-skip:hover {
+  color: #e8eaf0;
+  background: #1d2230;
+}
+
+/* Host share hint */
+.lobby-host-share-hint {
+  position: fixed;
+  top: 80px;
+  right: 20px;
+  z-index: 9998;
+  max-width: 340px;
+  font-family: Inter, system-ui, sans-serif;
+}
+
+.lobby-host-share-card {
+  background: linear-gradient(180deg, #1a2538 0%, #151922 100%);
+  border: 1px solid #ffb74d;
+  border-radius: 12px;
+  padding: 16px 18px;
+  color: #e8eaf0;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+}
+
+.lobby-host-share-title {
+  font-size: 0.88rem;
+  color: #ffb74d;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+
+.lobby-host-share-code {
+  font-size: 2.4rem;
+  font-weight: 700;
+  letter-spacing: 8px;
+  text-align: center;
+  color: #ffb74d;
+  margin: 8px 0 12px;
+  font-family: 'Noto Sans', monospace;
+}
+
+.lobby-host-share-row {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.lobby-host-share-url {
+  flex: 1;
+  min-width: 0;
+  padding: 7px 9px;
+  background: #0b0d12;
+  border: 1px solid #2a3040;
+  border-radius: 6px;
+  color: #c7cbd6;
+  font-family: 'Noto Sans', monospace;
+  font-size: 0.78rem;
+}
+
+.lobby-host-share-copy {
+  padding: 7px 12px;
+  font-size: 0.85rem;
+  background: #ffb74d;
+  color: #201000;
+  border: 1px solid #ffb74d;
+  border-radius: 6px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.lobby-host-share-copy:hover {
+  background: #ffc875;
+}
+
+.lobby-host-share-status {
+  font-size: 0.78rem;
+  color: #66bb6a;
+  min-height: 1.1em;
+  margin-bottom: 6px;
+}
+
+.lobby-host-share-hint-body {
+  font-size: 0.78rem;
+  color: #8891a3;
+  line-height: 1.4;
+}

--- a/apps/play/src/lobbyBridge.js
+++ b/apps/play/src/lobbyBridge.js
@@ -23,6 +23,11 @@ import {
   saveLobbySession,
 } from './network.js';
 import './lobbyBridge.css';
+import {
+  renderPlayerOnboarding,
+  renderHostShareHint,
+  dismissHostShareHint,
+} from './lobbyOnboarding.js';
 
 function createBanner(session, onLeave) {
   let banner = document.getElementById('lobby-banner');
@@ -461,6 +466,9 @@ export function initLobbyBridgeIfPresent({ wsImpl = null } = {}) {
         joinedAt: Date.now(),
       });
       refreshRosterUi();
+      if (bridge.isHost && payload.player_id !== session.player_id) {
+        dismissHostShareHint();
+      }
     }
   });
   client.on('player_connected', (payload) => {
@@ -594,6 +602,7 @@ export function initLobbyBridgeIfPresent({ wsImpl = null } = {}) {
     bridge.overlay = renderSpectatorOverlay(session);
     wireComposer(bridge.overlay, bridge);
     updateSpectatorState(bridge.overlay, 0, bridge._lastState ?? {}, bridge);
+    renderPlayerOnboarding();
   }
   if (bridge.isHost) {
     // TKT-M11B-04 — roster panel bottom-left showing who's in the room.
@@ -608,6 +617,8 @@ export function initLobbyBridgeIfPresent({ wsImpl = null } = {}) {
       joinedAt: Date.now(),
     });
     updateHostRoster(bridge);
+    // Share hint: code prominente + copy-URL finché stanza vuota.
+    renderHostShareHint({ session });
     // Tag body for CSS hooks (TV layout polish).
     try {
       document.body.classList.add('lobby-role-host');

--- a/apps/play/src/lobbyOnboarding.js
+++ b/apps/play/src/lobbyOnboarding.js
@@ -1,0 +1,149 @@
+// M11 onboarding overlay — primo-accesso tour per player + host share hint.
+// Dismissible. Persistenza via localStorage. No deps esterne.
+
+const STORAGE_KEY = 'lobby_onboarding_v1_seen';
+
+function seen() {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function markSeen() {
+  try {
+    localStorage.setItem(STORAGE_KEY, '1');
+  } catch {
+    // noop
+  }
+}
+
+const PLAYER_STEPS = [
+  {
+    title: 'Benvenuto!',
+    body: 'Sei in una partita co-op. Il TV del tuo amico host mostra la mappa; tu controlli uno dei personaggi dal tuo telefono.',
+  },
+  {
+    title: 'Componi intent',
+    body: 'Quando inizia la sessione, qui sotto vedi un form. Scegli il tuo PG, poi l\'azione (attack, move, defend) e il target. Tocca "Invia intent".',
+  },
+  {
+    title: 'Il TV risolve il round',
+    body: 'Dopo che tutti hanno inviato, il TV mostra il risultato del round. Puoi scrollare lo state JSON per i dettagli.',
+  },
+];
+
+export function renderPlayerOnboarding({ force = false } = {}) {
+  if (typeof document === 'undefined') return null;
+  if (!force && seen()) return null;
+  if (document.getElementById('lobby-onboarding')) return null;
+
+  const root = document.createElement('div');
+  root.id = 'lobby-onboarding';
+  root.className = 'lobby-onboarding';
+  root.setAttribute('role', 'dialog');
+  root.setAttribute('aria-modal', 'true');
+  root.setAttribute('aria-labelledby', 'lobby-onboarding-title');
+
+  let step = 0;
+  const render = () => {
+    const s = PLAYER_STEPS[step];
+    root.innerHTML = `
+      <div class="lobby-onboarding-card">
+        <div class="lobby-onboarding-progress">${step + 1} / ${PLAYER_STEPS.length}</div>
+        <h2 id="lobby-onboarding-title">${s.title}</h2>
+        <p>${s.body}</p>
+        <div class="lobby-onboarding-actions">
+          <button type="button" class="lobby-onboarding-skip">Salta</button>
+          <button type="button" class="lobby-onboarding-prev" ${step === 0 ? 'disabled' : ''}>Indietro</button>
+          <button type="button" class="lobby-onboarding-next">
+            ${step === PLAYER_STEPS.length - 1 ? 'Inizia' : 'Avanti'}
+          </button>
+        </div>
+      </div>
+    `;
+    root.querySelector('.lobby-onboarding-skip').addEventListener('click', close);
+    root.querySelector('.lobby-onboarding-prev').addEventListener('click', () => {
+      if (step > 0) {
+        step -= 1;
+        render();
+      }
+    });
+    root.querySelector('.lobby-onboarding-next').addEventListener('click', () => {
+      if (step < PLAYER_STEPS.length - 1) {
+        step += 1;
+        render();
+      } else {
+        close();
+      }
+    });
+  };
+
+  const close = () => {
+    markSeen();
+    root.remove();
+  };
+
+  document.body.appendChild(root);
+  render();
+  return root;
+}
+
+export function renderHostShareHint({ session, container }) {
+  if (typeof document === 'undefined') return null;
+  if (!session?.code) return null;
+  const parent = container || document.body;
+  if (parent.querySelector('#lobby-host-share-hint')) return null;
+
+  const hint = document.createElement('div');
+  hint.id = 'lobby-host-share-hint';
+  hint.className = 'lobby-host-share-hint';
+  const shareUrl = buildShareUrl(session.code);
+  hint.innerHTML = `
+    <div class="lobby-host-share-card">
+      <div class="lobby-host-share-title">📢 Condividi con i tuoi amici</div>
+      <div class="lobby-host-share-code" title="Codice stanza">${session.code}</div>
+      <div class="lobby-host-share-row">
+        <input type="text" readonly value="${shareUrl}" class="lobby-host-share-url" />
+        <button type="button" class="lobby-host-share-copy">Copia</button>
+      </div>
+      <div class="lobby-host-share-status" aria-live="polite"></div>
+      <div class="lobby-host-share-hint-body">
+        In attesa di almeno un player. L'indicatore scompare quando qualcuno entra.
+      </div>
+    </div>
+  `;
+  parent.appendChild(hint);
+
+  const input = hint.querySelector('.lobby-host-share-url');
+  const status = hint.querySelector('.lobby-host-share-status');
+  hint.querySelector('.lobby-host-share-copy').addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      status.textContent = '✓ Copiato';
+      setTimeout(() => {
+        status.textContent = '';
+      }, 2000);
+    } catch {
+      input.select();
+      status.textContent = 'Seleziona e Ctrl+C';
+    }
+  });
+  return hint;
+}
+
+export function dismissHostShareHint() {
+  const hint = document.getElementById('lobby-host-share-hint');
+  if (hint) hint.remove();
+}
+
+function buildShareUrl(code) {
+  if (typeof window === 'undefined' || !window.location) return `?code=${code}`;
+  const { origin, pathname } = window.location;
+  const dir = pathname.replace(/\/[^/]*$/, '/');
+  return `${origin}${dir}lobby.html?code=${encodeURIComponent(code)}`;
+}
+
+// Export utils for tests
+export const __testing = { seen, markSeen, buildShareUrl, STORAGE_KEY };

--- a/tests/api/lobbyOnboarding.test.mjs
+++ b/tests/api/lobbyOnboarding.test.mjs
@@ -1,0 +1,96 @@
+// Unit tests lobbyOnboarding — pure logic (storage gating + share URL).
+// DOM render tested via Playwright E2E (see tests/e2e/).
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+class FakeStorage {
+  constructor() {
+    this.store = new Map();
+  }
+  getItem(k) {
+    return this.store.has(k) ? this.store.get(k) : null;
+  }
+  setItem(k, v) {
+    this.store.set(k, String(v));
+  }
+  removeItem(k) {
+    this.store.delete(k);
+  }
+}
+
+function setupEnv() {
+  globalThis.window = {
+    location: {
+      origin: 'https://demo.ngrok-free.app',
+      pathname: '/play/lobby.html',
+    },
+  };
+  globalThis.localStorage = new FakeStorage();
+}
+
+async function importFresh() {
+  const url = new URL('../../apps/play/src/lobbyOnboarding.js', import.meta.url);
+  return import(`${url.href}?t=${Date.now()}_${Math.random()}`);
+}
+
+test.afterEach(() => {
+  delete globalThis.window;
+  delete globalThis.localStorage;
+});
+
+test('seen flag default false when storage empty', async () => {
+  setupEnv();
+  const { __testing } = await importFresh();
+  assert.equal(__testing.seen(), false);
+});
+
+test('markSeen persists flag + seen returns true', async () => {
+  setupEnv();
+  const { __testing } = await importFresh();
+  __testing.markSeen();
+  assert.equal(globalThis.localStorage.getItem(__testing.STORAGE_KEY), '1');
+  assert.equal(__testing.seen(), true);
+});
+
+test('buildShareUrl preserves dir + encodes code', async () => {
+  setupEnv();
+  const { __testing } = await importFresh();
+  const url = __testing.buildShareUrl('ABCD');
+  assert.equal(url, 'https://demo.ngrok-free.app/play/lobby.html?code=ABCD');
+});
+
+test('buildShareUrl preserves root path when no dir', async () => {
+  globalThis.window = {
+    location: { origin: 'https://x.ngrok-free.app', pathname: '/lobby.html' },
+  };
+  globalThis.localStorage = new FakeStorage();
+  const { __testing } = await importFresh();
+  assert.equal(__testing.buildShareUrl('WXYZ'), 'https://x.ngrok-free.app/lobby.html?code=WXYZ');
+});
+
+test('buildShareUrl fallback when no window', async () => {
+  delete globalThis.window;
+  globalThis.localStorage = new FakeStorage();
+  const { __testing } = await importFresh();
+  assert.equal(__testing.buildShareUrl('ABCD'), '?code=ABCD');
+});
+
+test('renderPlayerOnboarding returns null without document', async () => {
+  setupEnv();
+  const { renderPlayerOnboarding } = await importFresh();
+  assert.equal(renderPlayerOnboarding(), null);
+});
+
+test('renderHostShareHint returns null without document', async () => {
+  setupEnv();
+  const { renderHostShareHint } = await importFresh();
+  assert.equal(renderHostShareHint({ session: { code: 'ABCD' } }), null);
+});
+
+test('renderHostShareHint returns null without session code', async () => {
+  setupEnv();
+  globalThis.document = { body: {}, getElementById: () => null };
+  const { renderHostShareHint } = await importFresh();
+  assert.equal(renderHostShareHint({ session: {} }), null);
+  delete globalThis.document;
+});


### PR DESCRIPTION
## Summary

- Player 3-step tour dismissible + localStorage flag `lobby_onboarding_v1_seen`
- Host share hint: code prominente + copy-URL, auto-dismiss su first player_joined
- Riduce "cosa devo fare?" questions durante playtest (complementa #1700 + #1701)

## Test plan

- [x] 8/8 unit test lobbyOnboarding (storage + share URL + null-safe)
- [x] prettier verde
- [x] npm run build apps/play (27 modules transformed)
- [x] lobby.html loads clean in Vite dev server
- [ ] Playtest userland valida flow (TKT-M11B-06)

## Rollback

- localStorage flag `lobby_onboarding_v1_seen` manuale rimosso restart tour
- Revert commit → zero breaking (nuovo file + call opzionali)

🤖 Generated with [Claude Code](https://claude.com/claude-code)