### PR TITLE
feat(lobby): Prisma write-through persistence + hydrate (Opzione C)

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -690,7 +690,13 @@ function createApp(options = {}) {
   app.use('/api', createCampaignRouter(options.campaign || {}));
   // M11 Phase A: Jackbox-style co-op lobby (ADR-2026-04-20).
   // REST only; WebSocket server bootstraps in index.js on port 3341.
-  const lobby = (options.lobby && options.lobby.service) || new LobbyService(options.lobby || {});
+  // Opzione C (2026-04-26): optional Prisma write-through persistence.
+  // Graceful fallback when DATABASE_URL unset (dev/demo/tests).
+  const lobbyOptions = { ...(options.lobby || {}) };
+  if (!lobbyOptions.service && lobbyOptions.prisma === undefined && repo.prisma) {
+    lobbyOptions.prisma = repo.prisma;
+  }
+  const lobby = lobbyOptions.service || new LobbyService(lobbyOptions);
   app.use('/api', createLobbyRouter({ lobby }));
 
   app.get('/api/deployments/status', async (req, res) => {

--- a/apps/backend/index.js
+++ b/apps/backend/index.js
@@ -47,6 +47,20 @@ let lobbyWs = null;
 if (wsEnabled && lobby) {
   lobbyWs = createWsServer({ lobby, port: wsPort });
   console.log(`[lobby-ws] WebSocket server online on ws://${wsHost}:${wsPort}/ws`);
+  // Opzione C: hydrate rooms from Prisma if persistence wired.
+  // Graceful no-op when DATABASE_URL unset.
+  if (typeof lobby.hydrate === 'function') {
+    lobby
+      .hydrate()
+      .then((count) => {
+        if (count > 0) {
+          console.log(`[lobby-ws] Prisma hydrate: ${count} room(s) restored`);
+        }
+      })
+      .catch((err) => {
+        console.warn('[lobby-ws] Prisma hydrate failed:', err?.message || err);
+      });
+  }
 } else {
   console.log('[lobby-ws] WebSocket server disabled (LOBBY_WS_ENABLED=false)');
 }

--- a/apps/backend/prisma/migrations/0005_lobby_persistence/migration.sql
+++ b/apps/backend/prisma/migrations/0005_lobby_persistence/migration.sql
@@ -1,0 +1,56 @@
+-- M13 P5 lobby persistence (Opzione C handoff 2026-04-26).
+-- Models: LobbySession (Jackbox rooms) + LobbyPlayer.
+-- Adapter preserves in-memory LobbyService fallback when DATABASE_URL unset.
+-- Scope: durable reconnect dopo backend restart.
+
+-- CreateTable
+CREATE TABLE "lobby_sessions" (
+    "id" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "host_id" TEXT NOT NULL,
+    "campaign_id" TEXT,
+    "max_players" INTEGER NOT NULL DEFAULT 8,
+    "state" TEXT,
+    "state_version" INTEGER NOT NULL DEFAULT 0,
+    "closed" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "lobby_sessions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "lobby_players" (
+    "id" TEXT NOT NULL,
+    "session_id" TEXT NOT NULL,
+    "player_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "connected" BOOLEAN NOT NULL DEFAULT false,
+    "joined_at" TIMESTAMP(3) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "lobby_players_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "lobby_sessions_code_key" ON "lobby_sessions"("code");
+
+-- CreateIndex
+CREATE INDEX "lobby_sessions_campaign_id_idx" ON "lobby_sessions"("campaign_id");
+
+-- CreateIndex
+CREATE INDEX "lobby_sessions_created_at_idx" ON "lobby_sessions"("created_at");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "lobby_players_token_key" ON "lobby_players"("token");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "lobby_players_session_id_player_id_key" ON "lobby_players"("session_id", "player_id");
+
+-- CreateIndex
+CREATE INDEX "lobby_players_session_id_idx" ON "lobby_players"("session_id");
+
+-- AddForeignKey
+ALTER TABLE "lobby_players" ADD CONSTRAINT "lobby_players_session_id_fkey" FOREIGN KEY ("session_id") REFERENCES "lobby_sessions"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -46,24 +46,24 @@ model Feedback {
 }
 
 model Species {
-  id             String          @id
+  id             String         @id
   name           String
   classification String?
-  tags           String[]        @default([])
-  createdAt      DateTime        @default(now()) @map("created_at")
-  updatedAt      DateTime        @updatedAt @map("updated_at")
+  tags           String[]       @default([])
+  createdAt      DateTime       @default(now()) @map("created_at")
+  updatedAt      DateTime       @updatedAt @map("updated_at")
   biomes         SpeciesBiome[]
 
   @@map("species")
 }
 
 model Biome {
-  id        String          @id
+  id        String         @id
   name      String
   climate   String?
   region    String?
-  createdAt DateTime        @default(now()) @map("created_at")
-  updatedAt DateTime        @updatedAt @map("updated_at")
+  createdAt DateTime       @default(now()) @map("created_at")
+  updatedAt DateTime       @updatedAt @map("updated_at")
   species   SpeciesBiome[]
 
   @@map("biomes")
@@ -90,69 +90,69 @@ model SpeciesBiome {
 // sync deferred M12+).
 
 model Campaign {
-  id              String        @id @default(uuid())
-  playerId        String        @map("player_id")
-  campaignDefId   String        @default("default_campaign_mvp") @map("campaign_def_id")
-  currentChapter  Int           @default(1) @map("current_chapter")
-  currentAct      Int           @default(0) @map("current_act")
-  branchChoices   String        @default("[]") @map("branch_choices") // JSON array of binary choices
-  completionPct   Float         @default(0.0) @map("completion_pct")
-  finalState      String?       @map("final_state") // 'completed' | 'abandoned' | null
-  createdAt       DateTime      @default(now()) @map("created_at")
-  updatedAt       DateTime      @updatedAt @map("updated_at")
-  chapters        Chapter[]
-  partyRoster     PartyRoster[]
-  saves           SaveSnapshot[]
+  id             String         @id @default(uuid())
+  playerId       String         @map("player_id")
+  campaignDefId  String         @default("default_campaign_mvp") @map("campaign_def_id")
+  currentChapter Int            @default(1) @map("current_chapter")
+  currentAct     Int            @default(0) @map("current_act")
+  branchChoices  String         @default("[]") @map("branch_choices") // JSON array of binary choices
+  completionPct  Float          @default(0.0) @map("completion_pct")
+  finalState     String?        @map("final_state") // 'completed' | 'abandoned' | null
+  createdAt      DateTime       @default(now()) @map("created_at")
+  updatedAt      DateTime       @updatedAt @map("updated_at")
+  chapters       Chapter[]
+  partyRoster    PartyRoster[]
+  saves          SaveSnapshot[]
 
   @@index([playerId])
   @@map("campaigns")
 }
 
 model Chapter {
-  id            String    @id @default(uuid())
-  campaignId    String    @map("campaign_id")
-  campaign      Campaign  @relation(fields: [campaignId], references: [id], onDelete: Cascade)
-  chapterIdx    Int       @map("chapter_idx") // sequential 1..N
-  actIdx        Int       @map("act_idx")     // 0..2 (Act 0 tutorial, Act 1 main, Act 2 endgame post-MVP)
-  encounterId   String    @map("encounter_id") // refs encounter YAML
-  outcome       String?   // 'victory' | 'defeat' | 'timeout' | null
-  peEarned      Int       @default(0) @map("pe_earned")
-  piEarned      Int       @default(0) @map("pi_earned")
-  branchChosen  String?   @map("branch_chosen") // Descent binary choice key
-  completedAt   DateTime? @map("completed_at")
+  id           String    @id @default(uuid())
+  campaignId   String    @map("campaign_id")
+  campaign     Campaign  @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  chapterIdx   Int       @map("chapter_idx") // sequential 1..N
+  actIdx       Int       @map("act_idx") // 0..2 (Act 0 tutorial, Act 1 main, Act 2 endgame post-MVP)
+  encounterId  String    @map("encounter_id") // refs encounter YAML
+  outcome      String? // 'victory' | 'defeat' | 'timeout' | null
+  peEarned     Int       @default(0) @map("pe_earned")
+  piEarned     Int       @default(0) @map("pi_earned")
+  branchChosen String?   @map("branch_chosen") // Descent binary choice key
+  completedAt  DateTime? @map("completed_at")
 
   @@index([campaignId, chapterIdx])
   @@map("chapters")
 }
 
 model PartyRoster {
-  id              String   @id @default(uuid())
-  campaignId      String   @map("campaign_id")
-  campaign        Campaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
-  unitId          String   @map("unit_id") // PG identifier in-encounter
-  species         String
-  job             String
-  tier            String   @default("base") // base/veteran/elite (mythic post-MVP P0 Q58)
-  hpBase          Int      @map("hp_base")
-  traits          String   @default("[]") // JSON array trait IDs (inborn)
-  acquiredTraits  String   @default("[]") @map("acquired_traits") // JSON array (PI pack runtime)
-  xpTotal         Int      @default(0) @map("xp_total")
-  level           Int      @default(1)
-  createdAt       DateTime @default(now()) @map("created_at")
-  updatedAt       DateTime @updatedAt @map("updated_at")
+  id             String   @id @default(uuid())
+  campaignId     String   @map("campaign_id")
+  campaign       Campaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  unitId         String   @map("unit_id") // PG identifier in-encounter
+  species        String
+  job            String
+  tier           String   @default("base") // base/veteran/elite (mythic post-MVP P0 Q58)
+  hpBase         Int      @map("hp_base")
+  traits         String   @default("[]") // JSON array trait IDs (inborn)
+  acquiredTraits String   @default("[]") @map("acquired_traits") // JSON array (PI pack runtime)
+  xpTotal        Int      @default(0) @map("xp_total")
+  level          Int      @default(1)
+  createdAt      DateTime @default(now()) @map("created_at")
+  updatedAt      DateTime @updatedAt @map("updated_at")
 
   @@index([campaignId])
   @@map("party_rosters")
 }
 
 model SaveSnapshot {
-  id             String   @id @default(uuid())
-  campaignId     String   @map("campaign_id")
-  campaign       Campaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
-  sessionId      String?  @map("session_id") // optional: active session during save
-  saveType       String   @map("save_type") // 'auto' | 'manual' | 'checkpoint'
-  snapshotData   String   @map("snapshot_data") // JSON full state serialized
-  createdAt      DateTime @default(now()) @map("created_at")
+  id           String   @id @default(uuid())
+  campaignId   String   @map("campaign_id")
+  campaign     Campaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  sessionId    String?  @map("session_id") // optional: active session during save
+  saveType     String   @map("save_type") // 'auto' | 'manual' | 'checkpoint'
+  snapshotData String   @map("snapshot_data") // JSON full state serialized
+  createdAt    DateTime @default(now()) @map("created_at")
 
   @@index([campaignId, createdAt])
   @@map("save_snapshots")
@@ -164,21 +164,21 @@ model SaveSnapshot {
 // Scope: NPC affinity/trust, nest state, mating events, audit logs.
 
 model NpcRelation {
-  id              String   @id @default(uuid())
-  campaignId      String?  @map("campaign_id") // optional (legacy in-memory has no campaign)
-  npcId           String   @map("npc_id")
-  affinity        Int      @default(0) // range -2..+2 enforced app-level
-  trust           Int      @default(0) // range 0..5 enforced app-level
-  recruited       Boolean  @default(false)
-  mated           Boolean  @default(false)
-  matingCooldown  Int      @default(0) @map("mating_cooldown")
-  mbtiType        String?  @map("mbti_type")
-  traitIds        String   @default("[]") @map("trait_ids") // JSON array
-  createdAt       DateTime @default(now()) @map("created_at")
-  updatedAt       DateTime @updatedAt @map("updated_at")
-  affinityLogs    AffinityLog[]
-  trustLogs       TrustLog[]
-  matingEvents    MatingEvent[]
+  id             String        @id @default(uuid())
+  campaignId     String?       @map("campaign_id") // optional (legacy in-memory has no campaign)
+  npcId          String        @map("npc_id")
+  affinity       Int           @default(0) // range -2..+2 enforced app-level
+  trust          Int           @default(0) // range 0..5 enforced app-level
+  recruited      Boolean       @default(false)
+  mated          Boolean       @default(false)
+  matingCooldown Int           @default(0) @map("mating_cooldown")
+  mbtiType       String?       @map("mbti_type")
+  traitIds       String        @default("[]") @map("trait_ids") // JSON array
+  createdAt      DateTime      @default(now()) @map("created_at")
+  updatedAt      DateTime      @updatedAt @map("updated_at")
+  affinityLogs   AffinityLog[]
+  trustLogs      TrustLog[]
+  matingEvents   MatingEvent[]
 
   @@unique([campaignId, npcId])
   @@index([campaignId])
@@ -186,41 +186,41 @@ model NpcRelation {
 }
 
 model AffinityLog {
-  id          String      @id @default(uuid())
-  relationId  String      @map("relation_id")
-  relation    NpcRelation @relation(fields: [relationId], references: [id], onDelete: Cascade)
-  delta       Int
-  before      Int
-  after       Int
-  reason      String?
-  createdAt   DateTime    @default(now()) @map("created_at")
+  id         String      @id @default(uuid())
+  relationId String      @map("relation_id")
+  relation   NpcRelation @relation(fields: [relationId], references: [id], onDelete: Cascade)
+  delta      Int
+  before     Int
+  after      Int
+  reason     String?
+  createdAt  DateTime    @default(now()) @map("created_at")
 
   @@index([relationId, createdAt])
   @@map("affinity_logs")
 }
 
 model TrustLog {
-  id          String      @id @default(uuid())
-  relationId  String      @map("relation_id")
-  relation    NpcRelation @relation(fields: [relationId], references: [id], onDelete: Cascade)
-  delta       Int
-  before      Int
-  after       Int
-  reason      String?
-  createdAt   DateTime    @default(now()) @map("created_at")
+  id         String      @id @default(uuid())
+  relationId String      @map("relation_id")
+  relation   NpcRelation @relation(fields: [relationId], references: [id], onDelete: Cascade)
+  delta      Int
+  before     Int
+  after      Int
+  reason     String?
+  createdAt  DateTime    @default(now()) @map("created_at")
 
   @@index([relationId, createdAt])
   @@map("trust_logs")
 }
 
 model NestState {
-  id                String   @id @default(uuid())
-  campaignId        String?  @unique @map("campaign_id") // one nest per campaign (null = legacy global)
-  level             Int      @default(0)
-  biome             String?
-  requirementsMet   Boolean  @default(false) @map("requirements_met")
-  createdAt         DateTime @default(now()) @map("created_at")
-  updatedAt         DateTime @updatedAt @map("updated_at")
+  id              String   @id @default(uuid())
+  campaignId      String?  @unique @map("campaign_id") // one nest per campaign (null = legacy global)
+  level           Int      @default(0)
+  biome           String?
+  requirementsMet Boolean  @default(false) @map("requirements_met")
+  createdAt       DateTime @default(now()) @map("created_at")
+  updatedAt       DateTime @updatedAt @map("updated_at")
 
   @@map("nest_states")
 }
@@ -266,19 +266,59 @@ model FormSessionState {
   @@map("form_session_states")
 }
 
+// ─── M13 P5 Lobby persistence (Opzione C handoff 2026-04-26) ──────────────
+// Durable reconnect dopo backend restart. Write-through adapter: in-memory
+// LobbyService Map resta authoritative; Prisma upsert fire-and-forget al
+// mutation + hydrate su init. Graceful fallback quando DATABASE_URL unset.
+
+model LobbySession {
+  id           String        @id @default(uuid())
+  code         String        @unique
+  hostId       String        @map("host_id")
+  campaignId   String?       @map("campaign_id")
+  maxPlayers   Int           @default(8) @map("max_players")
+  state        String? // JSON snapshot of last published host state
+  stateVersion Int           @default(0) @map("state_version")
+  closed       Boolean       @default(false)
+  createdAt    DateTime      @default(now()) @map("created_at")
+  updatedAt    DateTime      @updatedAt @map("updated_at")
+  players      LobbyPlayer[]
+
+  @@index([campaignId])
+  @@index([createdAt])
+  @@map("lobby_sessions")
+}
+
+model LobbyPlayer {
+  id        String       @id @default(uuid())
+  sessionId String       @map("session_id")
+  session   LobbySession @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  playerId  String       @map("player_id")
+  name      String
+  role      String // 'host' | 'player'
+  token     String       @unique
+  connected Boolean      @default(false)
+  joinedAt  DateTime     @map("joined_at")
+  createdAt DateTime     @default(now()) @map("created_at")
+
+  @@unique([sessionId, playerId])
+  @@index([sessionId])
+  @@map("lobby_players")
+}
+
 model MatingEvent {
-  id                String      @id @default(uuid())
-  relationId        String      @map("relation_id")
-  relation          NpcRelation @relation(fields: [relationId], references: [id], onDelete: Cascade)
-  success           Boolean
-  roll              Int
-  modifier          Int
-  total             Int
-  threshold         Int
-  offspringTraits   String      @default("[]") @map("offspring_traits") // JSON array
-  seedGenerated     Int         @default(0) @map("seed_generated")
-  reason            String?     // e.g. 'roll_failed', 'gate_not_met'
-  createdAt         DateTime    @default(now()) @map("created_at")
+  id              String      @id @default(uuid())
+  relationId      String      @map("relation_id")
+  relation        NpcRelation @relation(fields: [relationId], references: [id], onDelete: Cascade)
+  success         Boolean
+  roll            Int
+  modifier        Int
+  total           Int
+  threshold       Int
+  offspringTraits String      @default("[]") @map("offspring_traits") // JSON array
+  seedGenerated   Int         @default(0) @map("seed_generated")
+  reason          String? // e.g. 'roll_failed', 'gate_not_met'
+  createdAt       DateTime    @default(now()) @map("created_at")
 
   @@index([relationId, createdAt])
   @@map("mating_events")

--- a/apps/backend/services/network/lobbyPersistence.js
+++ b/apps/backend/services/network/lobbyPersistence.js
@@ -1,0 +1,162 @@
+// M13 P5 Opzione C — Lobby Prisma write-through adapter.
+//
+// Pattern canonico (stesso di formSessionStore / progressionStore):
+//   - in-memory LobbyService Map resta authoritative
+//   - Prisma upsert fire-and-forget ad ogni mutation significativa
+//   - hydrate(prisma) pre-carica rooms non-chiuse su init dopo restart
+//   - graceful fallback quando DATABASE_URL unset / client senza delegate
+//
+// Shape LobbySession upsert:
+//   { code, hostId, campaignId, maxPlayers, state: JSON|null, stateVersion,
+//     closed, players: LobbyPlayer[] (nested) }
+//
+// Chiamate: persistRoomAsync, persistPlayerAsync, deleteRoomAsync,
+// hydrateRooms. Tutte no-op quando prisma mancante/parziale.
+
+'use strict';
+
+function prismaSupportsLobby(prisma) {
+  return Boolean(
+    prisma &&
+      prisma.lobbySession &&
+      typeof prisma.lobbySession.upsert === 'function' &&
+      typeof prisma.lobbySession.findMany === 'function' &&
+      prisma.lobbyPlayer &&
+      typeof prisma.lobbyPlayer.upsert === 'function',
+  );
+}
+
+function snapshotRoomForDb(room) {
+  return {
+    code: room.code,
+    hostId: room.hostId,
+    campaignId: room.campaignId ?? null,
+    maxPlayers: Number(room.maxPlayers ?? 8),
+    state: room.state ? JSON.stringify(room.state) : null,
+    stateVersion: Number(room.stateVersion ?? 0),
+    closed: Boolean(room.closed),
+  };
+}
+
+function snapshotPlayerForDb(sessionDbId, p) {
+  return {
+    sessionId: sessionDbId,
+    playerId: p.id,
+    name: p.name,
+    role: p.role,
+    token: p.token,
+    connected: Boolean(p.connected),
+    joinedAt: new Date(p.joinedAt || Date.now()),
+  };
+}
+
+async function persistRoomAsync(prisma, room, { logger = console } = {}) {
+  if (!prismaSupportsLobby(prisma)) return null;
+  const data = snapshotRoomForDb(room);
+  try {
+    const saved = await prisma.lobbySession.upsert({
+      where: { code: data.code },
+      create: data,
+      update: {
+        hostId: data.hostId,
+        campaignId: data.campaignId,
+        maxPlayers: data.maxPlayers,
+        state: data.state,
+        stateVersion: data.stateVersion,
+        closed: data.closed,
+      },
+    });
+    // upsert each player (skip socket/connected drift — persisted as last-known).
+    for (const p of room.players.values()) {
+      const pdata = snapshotPlayerForDb(saved.id, p);
+      await prisma.lobbyPlayer
+        .upsert({
+          where: {
+            sessionId_playerId: { sessionId: saved.id, playerId: p.id },
+          },
+          create: pdata,
+          update: {
+            name: pdata.name,
+            role: pdata.role,
+            connected: pdata.connected,
+          },
+        })
+        .catch((err) => {
+          logger.warn?.(`[lobbyPersistence] upsert player ${p.id} failed: ${err?.message || err}`);
+        });
+    }
+    return saved;
+  } catch (err) {
+    logger.warn?.(`[lobbyPersistence] upsert room ${data.code} failed: ${err?.message || err}`);
+    return null;
+  }
+}
+
+async function deleteRoomAsync(prisma, code, { logger = console } = {}) {
+  if (!prismaSupportsLobby(prisma)) return false;
+  try {
+    await prisma.lobbySession.delete({ where: { code } });
+    return true;
+  } catch (err) {
+    // P2025 (record not found) is benign for idempotent delete.
+    if (err?.code !== 'P2025') {
+      logger.warn?.(`[lobbyPersistence] delete ${code} failed: ${err?.message || err}`);
+    }
+    return false;
+  }
+}
+
+async function hydrateRooms(prisma, { logger = console } = {}) {
+  if (!prismaSupportsLobby(prisma)) return [];
+  try {
+    const rows = await prisma.lobbySession.findMany({
+      where: { closed: false },
+      include: { players: true },
+    });
+    return rows.map(rowToRoomSeed);
+  } catch (err) {
+    logger.warn?.(`[lobbyPersistence] hydrate failed: ${err?.message || err}`);
+    return [];
+  }
+}
+
+function rowToRoomSeed(row) {
+  let state = null;
+  if (row.state) {
+    try {
+      state = JSON.parse(row.state);
+    } catch {
+      state = null;
+    }
+  }
+  return {
+    code: row.code,
+    hostId: row.hostId,
+    campaignId: row.campaignId,
+    maxPlayers: row.maxPlayers,
+    state,
+    stateVersion: row.stateVersion,
+    closed: row.closed,
+    createdAt:
+      row.createdAt instanceof Date ? row.createdAt.getTime() : Number(row.createdAt) || Date.now(),
+    players: (row.players || []).map((p) => ({
+      id: p.playerId,
+      name: p.name,
+      role: p.role,
+      token: p.token,
+      connected: false, // on hydrate, clients must reconnect
+      joinedAt:
+        p.joinedAt instanceof Date ? p.joinedAt.getTime() : Number(p.joinedAt) || Date.now(),
+    })),
+  };
+}
+
+module.exports = {
+  prismaSupportsLobby,
+  persistRoomAsync,
+  deleteRoomAsync,
+  hydrateRooms,
+  snapshotRoomForDb,
+  snapshotPlayerForDb,
+  rowToRoomSeed,
+};

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -70,34 +70,63 @@ class Room {
     maxPlayers = DEFAULT_MAX_PLAYERS,
     campaignId = null,
     hostTransferGraceMs = DEFAULT_HOST_TRANSFER_GRACE_MS,
+    // Opzione C: optional persistence hook. Fire-and-forget after mutation.
+    onMutate = null,
+    // Hydrate path: reuse data from Prisma snapshot (skips host player seed).
+    hydrateFromSeed = null,
   }) {
     this.code = code;
     this.hostId = hostId;
     this.maxPlayers = maxPlayers;
     this.campaignId = campaignId;
-    this.createdAt = Date.now();
-    this.closed = false;
+    this.createdAt = hydrateFromSeed?.createdAt || Date.now();
+    this.closed = Boolean(hydrateFromSeed?.closed);
     this.hostTransferGraceMs = hostTransferGraceMs;
     // TKT-M11B-05 — pending host-transfer timer handle.
     this._hostTransferTimer = null;
     // player_id → { id, name, role, token, socket?, connected, joinedAt }
     this.players = new Map();
     // Host state published, last-write-wins; version monotonic.
-    this.state = null;
-    this.stateVersion = 0;
+    this.state = hydrateFromSeed?.state ?? null;
+    this.stateVersion = hydrateFromSeed?.stateVersion ?? 0;
     // Intent queue (Phase A: FIFO, host drains on demand)
     this.intents = [];
+    this._onMutate = typeof onMutate === 'function' ? onMutate : null;
 
-    const hostToken = generateToken();
-    this.players.set(hostId, {
-      id: hostId,
-      name: hostName,
-      role: 'host',
-      token: hostToken,
-      socket: null,
-      connected: false,
-      joinedAt: this.createdAt,
-    });
+    if (hydrateFromSeed?.players?.length) {
+      for (const p of hydrateFromSeed.players) {
+        this.players.set(p.id, {
+          id: p.id,
+          name: p.name,
+          role: p.role,
+          token: p.token,
+          socket: null,
+          connected: false,
+          joinedAt: p.joinedAt,
+        });
+      }
+    } else {
+      const hostToken = generateToken();
+      this.players.set(hostId, {
+        id: hostId,
+        name: hostName,
+        role: 'host',
+        token: hostToken,
+        socket: null,
+        connected: false,
+        joinedAt: this.createdAt,
+      });
+    }
+  }
+
+  _notifyMutate(event) {
+    if (this._onMutate) {
+      try {
+        this._onMutate(this, event);
+      } catch {
+        // persistence errors swallowed: in-memory stays authoritative
+      }
+    }
   }
 
   addPlayer({ name, role = 'player' }) {
@@ -118,6 +147,7 @@ class Room {
       connected: false,
       joinedAt: Date.now(),
     });
+    this._notifyMutate({ kind: 'player_added', playerId });
     return { playerId, token };
   }
 
@@ -199,6 +229,7 @@ class Room {
       version: this.stateVersion,
       payload: newState,
     });
+    this._notifyMutate({ kind: 'state_published', version: this.stateVersion });
     return this.stateVersion;
   }
 
@@ -234,6 +265,7 @@ class Room {
     candidate.role = 'host';
     this.hostId = newHostId;
     this.clearHostTransferTimer();
+    this._notifyMutate({ kind: 'host_transferred', newHostId, previousHostId });
     this.broadcast({
       type: 'host_transferred',
       payload: {
@@ -292,6 +324,7 @@ class Room {
         }
       }
     }
+    this._notifyMutate({ kind: 'closed', reason });
   }
 
   snapshot() {
@@ -311,11 +344,61 @@ class Room {
 /**
  * LobbyService — in-memory registry of Rooms.
  * Single process only (Phase A). Redis-adapter swap in Phase B+ if needed.
+ *
+ * Opzione C (2026-04-26): optional Prisma write-through. Pass `{ prisma }`
+ * to enable persistence; `hydrate()` replays non-closed rooms on boot.
+ * In-memory Map resta authoritative; errori persistenza non rompono il flow.
  */
 class LobbyService {
-  constructor({ maxPlayers = DEFAULT_MAX_PLAYERS } = {}) {
+  constructor({
+    maxPlayers = DEFAULT_MAX_PLAYERS,
+    prisma = null,
+    logger = null,
+    persistence = null,
+  } = {}) {
     this.rooms = new Map(); // code → Room
     this.maxPlayers = maxPlayers;
+    this.prisma = prisma;
+    this.logger = logger || console;
+    // Lazy require to keep module load order permissive when prisma absent.
+    this._persistence = persistence || (prisma ? require('./lobbyPersistence') : null);
+    this._persistEnabled = Boolean(
+      this._persistence && this._persistence.prismaSupportsLobby?.(prisma),
+    );
+  }
+
+  _onMutate() {
+    if (!this._persistEnabled) return () => {};
+    const self = this;
+    return (room /* , event */) => {
+      self._persistence.persistRoomAsync(self.prisma, room, { logger: self.logger }).catch(() => {
+        // persist errors already logged inside adapter; swallow to protect
+        // in-memory flow.
+      });
+    };
+  }
+
+  async hydrate() {
+    if (!this._persistEnabled) return 0;
+    const seeds = await this._persistence.hydrateRooms(this.prisma, { logger: this.logger });
+    let restored = 0;
+    for (const seed of seeds) {
+      if (seed.closed) continue;
+      if (this.rooms.has(seed.code)) continue;
+      const room = new Room({
+        code: seed.code,
+        hostId: seed.hostId,
+        hostName: null, // unused when hydrateFromSeed provides players
+        maxPlayers: seed.maxPlayers,
+        campaignId: seed.campaignId,
+        hostTransferGraceMs: DEFAULT_HOST_TRANSFER_GRACE_MS,
+        onMutate: this._onMutate(),
+        hydrateFromSeed: seed,
+      });
+      this.rooms.set(seed.code, room);
+      restored += 1;
+    }
+    return restored;
   }
 
   createRoom({ hostName, campaignId = null, maxPlayers, hostTransferGraceMs } = {}) {
@@ -342,8 +425,15 @@ class LobbyService {
       campaignId,
       hostTransferGraceMs:
         hostTransferGraceMs !== undefined ? hostTransferGraceMs : DEFAULT_HOST_TRANSFER_GRACE_MS,
+      onMutate: this._onMutate(),
     });
     this.rooms.set(code, room);
+    // Opzione C: initial persist snapshot so reconnect survives restart.
+    if (this._persistEnabled) {
+      this._persistence
+        .persistRoomAsync(this.prisma, room, { logger: this.logger })
+        .catch(() => {});
+    }
     const host = room.getPlayer(hostId);
     return {
       code,
@@ -382,6 +472,11 @@ class LobbyService {
     }
     room.close();
     this.rooms.delete(normalized);
+    if (this._persistEnabled) {
+      this._persistence
+        .deleteRoomAsync(this.prisma, normalized, { logger: this.logger })
+        .catch(() => {});
+    }
     return { code: normalized, closed: true };
   }
 

--- a/tests/api/lobbyPersistence.test.js
+++ b/tests/api/lobbyPersistence.test.js
@@ -1,0 +1,425 @@
+// M13 P5 Opzione C — lobbyPersistence + LobbyService Prisma integration tests.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  prismaSupportsLobby,
+  persistRoomAsync,
+  deleteRoomAsync,
+  hydrateRooms,
+  snapshotRoomForDb,
+  rowToRoomSeed,
+} = require('../../apps/backend/services/network/lobbyPersistence');
+const { LobbyService } = require('../../apps/backend/services/network/wsSession');
+
+// ---------------------------------------------------------------------------
+// Mock Prisma helpers
+// ---------------------------------------------------------------------------
+function createMockPrisma() {
+  const sessions = new Map(); // code → { id, ...data, players: Map<playerId, row> }
+  const calls = [];
+
+  function makeId(prefix) {
+    return `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
+  }
+
+  return {
+    calls,
+    _sessions: sessions,
+    lobbySession: {
+      async upsert({ where, create, update }) {
+        calls.push({ op: 'lobbySession.upsert', where, create, update });
+        const existing = sessions.get(where.code);
+        if (existing) {
+          Object.assign(existing, update);
+          return existing;
+        }
+        const row = {
+          id: makeId('ls'),
+          ...create,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          players: new Map(),
+        };
+        sessions.set(create.code, row);
+        return { ...row, players: undefined };
+      },
+      async findMany({ where, include } = {}) {
+        calls.push({ op: 'lobbySession.findMany', where, include });
+        const rows = Array.from(sessions.values()).filter((r) => {
+          if (where?.closed !== undefined) return r.closed === where.closed;
+          return true;
+        });
+        return rows.map((r) => ({
+          ...r,
+          players: include?.players ? Array.from(r.players.values()) : undefined,
+        }));
+      },
+      async delete({ where }) {
+        calls.push({ op: 'lobbySession.delete', where });
+        if (!sessions.has(where.code)) {
+          const err = new Error('record not found');
+          err.code = 'P2025';
+          throw err;
+        }
+        sessions.delete(where.code);
+        return { code: where.code };
+      },
+    },
+    lobbyPlayer: {
+      async upsert({ where, create, update }) {
+        calls.push({ op: 'lobbyPlayer.upsert', where, create, update });
+        const sessionRow = Array.from(sessions.values()).find(
+          (r) => r.id === where.sessionId_playerId.sessionId,
+        );
+        if (!sessionRow) {
+          const err = new Error('no parent');
+          err.code = 'P2003';
+          throw err;
+        }
+        const key = where.sessionId_playerId.playerId;
+        const existing = sessionRow.players.get(key);
+        if (existing) {
+          Object.assign(existing, update);
+          return existing;
+        }
+        const row = { id: makeId('lp'), ...create };
+        sessionRow.players.set(key, row);
+        return row;
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// prismaSupportsLobby guard
+// ---------------------------------------------------------------------------
+test('prismaSupportsLobby: null/missing methods → false', () => {
+  assert.equal(prismaSupportsLobby(null), false);
+  assert.equal(prismaSupportsLobby({}), false);
+  assert.equal(prismaSupportsLobby({ lobbySession: {} }), false);
+});
+
+test('prismaSupportsLobby: mock with upsert+findMany → true', () => {
+  const p = createMockPrisma();
+  assert.equal(prismaSupportsLobby(p), true);
+});
+
+// ---------------------------------------------------------------------------
+// snapshotRoomForDb shape
+// ---------------------------------------------------------------------------
+test('snapshotRoomForDb: serializes state as JSON string', () => {
+  const room = {
+    code: 'BCDF',
+    hostId: 'p_1',
+    campaignId: 'camp_1',
+    maxPlayers: 4,
+    state: { turn: 3 },
+    stateVersion: 7,
+    closed: false,
+  };
+  const snap = snapshotRoomForDb(room);
+  assert.equal(snap.code, 'BCDF');
+  assert.equal(snap.state, '{"turn":3}');
+  assert.equal(snap.stateVersion, 7);
+  assert.equal(snap.closed, false);
+});
+
+test('snapshotRoomForDb: null state stays null', () => {
+  const room = { code: 'BCDF', hostId: 'p_1', state: null };
+  const snap = snapshotRoomForDb(room);
+  assert.equal(snap.state, null);
+});
+
+// ---------------------------------------------------------------------------
+// persistRoomAsync
+// ---------------------------------------------------------------------------
+test('persistRoomAsync: no-op when prisma lacks delegates', async () => {
+  const res = await persistRoomAsync({}, { code: 'XXXX', hostId: 'p', players: new Map() });
+  assert.equal(res, null);
+});
+
+test('persistRoomAsync: upserts session + all players', async () => {
+  const prisma = createMockPrisma();
+  const room = {
+    code: 'BCDF',
+    hostId: 'p_1',
+    campaignId: null,
+    maxPlayers: 8,
+    state: null,
+    stateVersion: 0,
+    closed: false,
+    players: new Map([
+      [
+        'p_1',
+        {
+          id: 'p_1',
+          name: 'Host',
+          role: 'host',
+          token: 't_abc',
+          connected: true,
+          joinedAt: Date.now(),
+        },
+      ],
+      [
+        'p_2',
+        {
+          id: 'p_2',
+          name: 'Player2',
+          role: 'player',
+          token: 't_xyz',
+          connected: false,
+          joinedAt: Date.now(),
+        },
+      ],
+    ]),
+  };
+  const saved = await persistRoomAsync(prisma, room);
+  assert.ok(saved, 'returns saved session row');
+  // upsert calls: 1 session + 2 players = 3
+  const upsertCalls = prisma.calls.filter((c) => c.op.endsWith('.upsert'));
+  assert.equal(upsertCalls.length, 3);
+});
+
+test('persistRoomAsync: session error logs but does not throw', async () => {
+  const prisma = createMockPrisma();
+  prisma.lobbySession.upsert = async () => {
+    throw new Error('db down');
+  };
+  let warned = 0;
+  const res = await persistRoomAsync(
+    prisma,
+    { code: 'XXXX', hostId: 'p', players: new Map() },
+    { logger: { warn: () => (warned += 1) } },
+  );
+  assert.equal(res, null);
+  assert.equal(warned, 1);
+});
+
+// ---------------------------------------------------------------------------
+// deleteRoomAsync
+// ---------------------------------------------------------------------------
+test('deleteRoomAsync: removes row', async () => {
+  const prisma = createMockPrisma();
+  await persistRoomAsync(prisma, {
+    code: 'BCDF',
+    hostId: 'p',
+    campaignId: null,
+    maxPlayers: 8,
+    state: null,
+    stateVersion: 0,
+    closed: false,
+    players: new Map([
+      [
+        'p',
+        { id: 'p', name: 'H', role: 'host', token: 't', connected: false, joinedAt: Date.now() },
+      ],
+    ]),
+  });
+  const ok = await deleteRoomAsync(prisma, 'BCDF');
+  assert.equal(ok, true);
+  assert.equal(prisma._sessions.size, 0);
+});
+
+test('deleteRoomAsync: P2025 (not found) returns false silently', async () => {
+  const prisma = createMockPrisma();
+  let warned = 0;
+  const ok = await deleteRoomAsync(prisma, 'GONE', { logger: { warn: () => (warned += 1) } });
+  assert.equal(ok, false);
+  assert.equal(warned, 0, 'P2025 is benign');
+});
+
+// ---------------------------------------------------------------------------
+// hydrateRooms + rowToRoomSeed
+// ---------------------------------------------------------------------------
+test('rowToRoomSeed: parses state JSON + maps players', () => {
+  const row = {
+    code: 'ABCD',
+    hostId: 'p_1',
+    campaignId: 'camp',
+    maxPlayers: 4,
+    state: '{"x":1}',
+    stateVersion: 2,
+    closed: false,
+    createdAt: new Date('2026-04-24T10:00:00Z'),
+    players: [
+      {
+        playerId: 'p_1',
+        name: 'Host',
+        role: 'host',
+        token: 't1',
+        connected: true,
+        joinedAt: new Date('2026-04-24T10:00:00Z'),
+      },
+    ],
+  };
+  const seed = rowToRoomSeed(row);
+  assert.equal(seed.code, 'ABCD');
+  assert.deepEqual(seed.state, { x: 1 });
+  assert.equal(seed.players.length, 1);
+  assert.equal(seed.players[0].connected, false, 'hydrate resets connected');
+});
+
+test('rowToRoomSeed: malformed state JSON → null', () => {
+  const seed = rowToRoomSeed({
+    code: 'BAD',
+    hostId: 'p',
+    state: '{not json',
+    stateVersion: 0,
+    closed: false,
+    createdAt: new Date(),
+    players: [],
+  });
+  assert.equal(seed.state, null);
+});
+
+test('hydrateRooms: returns seeds for non-closed rows', async () => {
+  const prisma = createMockPrisma();
+  await persistRoomAsync(prisma, {
+    code: 'BCDF',
+    hostId: 'p',
+    campaignId: null,
+    maxPlayers: 8,
+    state: { ok: true },
+    stateVersion: 1,
+    closed: false,
+    players: new Map([
+      [
+        'p',
+        { id: 'p', name: 'H', role: 'host', token: 't', connected: false, joinedAt: Date.now() },
+      ],
+    ]),
+  });
+  const seeds = await hydrateRooms(prisma);
+  assert.equal(seeds.length, 1);
+  assert.equal(seeds[0].code, 'BCDF');
+  assert.deepEqual(seeds[0].state, { ok: true });
+});
+
+// ---------------------------------------------------------------------------
+// LobbyService integration
+// ---------------------------------------------------------------------------
+test('LobbyService: no prisma → in-memory works, _persistEnabled false', () => {
+  const svc = new LobbyService();
+  assert.equal(svc._persistEnabled, false);
+  const r = svc.createRoom({ hostName: 'H' });
+  assert.ok(r.code);
+  assert.equal(svc.rooms.size, 1);
+});
+
+test('LobbyService: with prisma → createRoom triggers persist', async () => {
+  const prisma = createMockPrisma();
+  const svc = new LobbyService({ prisma });
+  assert.equal(svc._persistEnabled, true);
+  svc.createRoom({ hostName: 'Host1' });
+  // wait microtask for fire-and-forget
+  await new Promise((r) => setImmediate(r));
+  const upserts = prisma.calls.filter((c) => c.op === 'lobbySession.upsert');
+  assert.ok(upserts.length >= 1, 'at least 1 session upsert fired');
+});
+
+test('LobbyService: joinRoom triggers persist via onMutate', async () => {
+  const prisma = createMockPrisma();
+  const svc = new LobbyService({ prisma });
+  const { code } = svc.createRoom({ hostName: 'H' });
+  prisma.calls.length = 0;
+  svc.joinRoom({ code, playerName: 'P2' });
+  await new Promise((r) => setImmediate(r));
+  const sessionUpserts = prisma.calls.filter((c) => c.op === 'lobbySession.upsert');
+  assert.ok(sessionUpserts.length >= 1, 'player_added mutation persisted');
+});
+
+test('LobbyService: closeRoom removes DB row', async () => {
+  const prisma = createMockPrisma();
+  const svc = new LobbyService({ prisma });
+  const created = svc.createRoom({ hostName: 'H' });
+  await new Promise((r) => setImmediate(r));
+  prisma.calls.length = 0;
+  svc.closeRoom({ code: created.code, hostToken: created.host_token });
+  await new Promise((r) => setImmediate(r));
+  const deletes = prisma.calls.filter((c) => c.op === 'lobbySession.delete');
+  assert.equal(deletes.length, 1);
+});
+
+test('LobbyService.hydrate: restores rooms from DB seeds', async () => {
+  const prisma = createMockPrisma();
+  // Pre-seed DB directly.
+  await persistRoomAsync(prisma, {
+    code: 'ABCD',
+    hostId: 'p_host',
+    campaignId: null,
+    maxPlayers: 8,
+    state: { phase: 'planning' },
+    stateVersion: 3,
+    closed: false,
+    players: new Map([
+      [
+        'p_host',
+        {
+          id: 'p_host',
+          name: 'H',
+          role: 'host',
+          token: 'th',
+          connected: false,
+          joinedAt: Date.now(),
+        },
+      ],
+      [
+        'p_2',
+        {
+          id: 'p_2',
+          name: 'P2',
+          role: 'player',
+          token: 'tp',
+          connected: false,
+          joinedAt: Date.now(),
+        },
+      ],
+    ]),
+  });
+  const svc = new LobbyService({ prisma });
+  const restored = await svc.hydrate();
+  assert.equal(restored, 1);
+  assert.equal(svc.rooms.size, 1);
+  const room = svc.getRoom('ABCD');
+  assert.ok(room, 'room present in memory');
+  assert.equal(room.stateVersion, 3);
+  assert.deepEqual(room.state, { phase: 'planning' });
+  assert.equal(room.players.size, 2);
+  // token preserved → reconnect path survives
+  const host = room.getPlayer('p_host');
+  assert.equal(host.token, 'th');
+});
+
+test('LobbyService.hydrate: no prisma → returns 0', async () => {
+  const svc = new LobbyService();
+  const restored = await svc.hydrate();
+  assert.equal(restored, 0);
+});
+
+test('LobbyService.hydrate: skips already-loaded rooms (idempotent)', async () => {
+  const prisma = createMockPrisma();
+  await persistRoomAsync(prisma, {
+    code: 'BCDF',
+    hostId: 'p',
+    campaignId: null,
+    maxPlayers: 8,
+    state: null,
+    stateVersion: 0,
+    closed: false,
+    players: new Map([
+      [
+        'p',
+        { id: 'p', name: 'H', role: 'host', token: 't', connected: false, joinedAt: Date.now() },
+      ],
+    ]),
+  });
+  const svc = new LobbyService({ prisma });
+  await svc.hydrate();
+  const second = await svc.hydrate();
+  assert.equal(second, 0, 'second hydrate is no-op');
+  assert.equal(svc.rooms.size, 1);
+});


### PR DESCRIPTION
## Summary

- Lobby rooms sopravvivono a restart backend via Prisma write-through adapter
- Pattern canonico (stesso di formSessionStore / progressionStore): in-memory Map resta authoritative, upsert fire-and-forget + hydrate su boot
- Zero breaking change: senza DATABASE_URL → in-memory path identico a prima

## Files

**Schema:**
- `apps/backend/prisma/schema.prisma` — models `LobbySession` + `LobbyPlayer`
- `apps/backend/prisma/migrations/0005_lobby_persistence/migration.sql`

**Runtime:**
- `apps/backend/services/network/lobbyPersistence.js` NEW — `prismaSupportsLobby` guard + `persistRoomAsync` + `deleteRoomAsync` + `hydrateRooms` + snapshot helpers
- `apps/backend/services/network/wsSession.js` — Room accetta `onMutate` hook + `hydrateFromSeed` seed; LobbyService accetta `{ prisma }` + metodo `hydrate()` idempotente
- `apps/backend/app.js` — auto-wire `repo.prisma` → LobbyService se disponibile
- `apps/backend/index.js` — `lobby.hydrate()` su boot dopo WS online

**Tests:**
- `tests/api/lobbyPersistence.test.js` NEW — 19 test (guard + snapshot + persist/delete/hydrate + LobbyService integration + idempotent hydrate)

## Test plan

- [x] `node --test tests/api/lobbyPersistence.test.js` → **19/19 pass**
- [x] Regression: `tests/api/lobbyRoutes.test.js` + `lobbyWebSocket.test.js` → **15/15 pass**
- [x] E2E: `tests/e2e/lobbyEndToEnd.test.mjs` → **11/11 pass**
- [x] `npx prisma format` → schema valid
- [x] `npm run format:check` → verde
- [ ] Live test: backend restart con DATABASE_URL → rooms con players restorable (userland, non-automatizzabile in CI)

## Rollback

Revert PR. Persistence path è opt-in via `repo.prisma` presenza. Schema migration è additive (solo CREATE TABLE); rollback DB via `prisma migrate resolve` o drop tables manuale. Nessun dato preesistente impattato.

## Mutation hooks persistiti

| Mutation | Hook |
|---|---|
| `createRoom()` | initial persist (LobbyService) |
| `addPlayer()` | `_notifyMutate('player_added')` → upsert |
| `publishState()` | `_notifyMutate('state_published')` → upsert |
| `transferHostTo()` | `_notifyMutate('host_transferred')` → upsert |
| `close()` | `_notifyMutate('closed')` + `deleteRoomAsync` |

Non-persistiti (intenzionali, in-memory only): `attachSocket`, `detachSocket`, `intents` queue, `_hostTransferTimer` (ricomputato su hydrate).

## Pilastro 5 status

🟡 (Phase A–C shipped PR #1680/#1682/#1684/#1685/#1686) → **🟡 hardened** (reconnect dopo restart live). Resta 🟢 dopo TKT-M11B-06 playtest live ngrok (userland).

🤖 Generated with [Claude Code](https://claude.com/claude-code)