### PR TITLE
feat(lobby): M11 Phase D — Prisma persistence (opt-in, write-through)

### DIFF
--- a/apps/backend/index.js
+++ b/apps/backend/index.js
@@ -3,6 +3,7 @@ const http = require('node:http');
 const path = require('node:path');
 const { createApp } = require('./app');
 const { createWsServer } = require('./services/network/wsSession');
+const { createLobbyPersistence } = require('./services/network/lobbyPersistence');
 
 // Default port changed from 3333 to 3334 in 2026-04 to avoid collision with
 // the sibling Game-Database service which owns port 3333 for its REST API.
@@ -51,6 +52,27 @@ if (wsEnabled && lobby) {
   console.log('[lobby-ws] WebSocket server disabled (LOBBY_WS_ENABLED=false)');
 }
 
+// M11 Phase D — optional Prisma persistence (ADR-2026-04-26).
+// Opt-in via LOBBY_PRISMA_ENABLED=true. Graceful fallback if @prisma/client
+// not installed or DB unreachable — rooms survive in-memory only.
+let lobbyPersistence = null;
+if (lobby && process.env.LOBBY_PRISMA_ENABLED === 'true') {
+  lobbyPersistence = createLobbyPersistence({ lobby });
+  if (lobbyPersistence.enabled) {
+    lobby.setPersistence(lobbyPersistence);
+    lobbyPersistence
+      .hydrate()
+      .then((stats) => {
+        console.log(`[lobby-prisma] hydrated ${stats.rooms} rooms + ${stats.players} players`);
+      })
+      .catch((err) => console.warn('[lobby-prisma] hydrate failed:', err.message));
+  } else {
+    console.log('[lobby-prisma] client unavailable, skipping persistence');
+  }
+} else {
+  console.log('[lobby-prisma] persistence disabled (LOBBY_PRISMA_ENABLED!=true)');
+}
+
 // Issue #1342: avverti se ORCHESTRATOR_AUTOCLOSE_MS e' settato in modo
 // che potrebbe rompere il backend live (valori bassi pensati per i test).
 const rawAutoclose = process.env.ORCHESTRATOR_AUTOCLOSE_MS;
@@ -93,6 +115,13 @@ async function shutdown(signal) {
   if (lobbyWs) {
     try {
       await lobbyWs.close();
+    } catch {
+      // noop
+    }
+  }
+  if (lobbyPersistence) {
+    try {
+      await lobbyPersistence.close();
     } catch {
       // noop
     }

--- a/apps/backend/prisma/migrations/0005_lobby_persistence/migration.sql
+++ b/apps/backend/prisma/migrations/0005_lobby_persistence/migration.sql
@@ -1,0 +1,42 @@
+-- M11 Phase D lobby persistence (ADR-2026-04-26 addendum to ADR-2026-04-20).
+-- Rooms + players survive backend restart when LOBBY_PRISMA_ENABLED=true.
+
+-- CreateTable
+CREATE TABLE "lobby_rooms" (
+    "code" TEXT NOT NULL,
+    "host_id" TEXT NOT NULL,
+    "host_name" TEXT NOT NULL,
+    "campaign_id" TEXT,
+    "max_players" INTEGER NOT NULL DEFAULT 8,
+    "host_transfer_grace_ms" INTEGER NOT NULL DEFAULT 30000,
+    "closed" BOOLEAN NOT NULL DEFAULT false,
+    "state_version" INTEGER NOT NULL DEFAULT 0,
+    "last_state" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "lobby_rooms_pkey" PRIMARY KEY ("code")
+);
+
+-- CreateTable
+CREATE TABLE "lobby_players" (
+    "id" TEXT NOT NULL,
+    "room_code" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "connected" BOOLEAN NOT NULL DEFAULT false,
+    "joined_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "disconnected_at" TIMESTAMP(3),
+
+    CONSTRAINT "lobby_players_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "lobby_rooms_closed_idx" ON "lobby_rooms"("closed");
+
+-- CreateIndex
+CREATE INDEX "lobby_players_room_code_idx" ON "lobby_players"("room_code");
+
+-- AddForeignKey
+ALTER TABLE "lobby_players" ADD CONSTRAINT "lobby_players_room_code_fkey" FOREIGN KEY ("room_code") REFERENCES "lobby_rooms"("code") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -266,6 +266,41 @@ model FormSessionState {
   @@map("form_session_states")
 }
 
+// M11 Phase D — lobby persistence (ADR-2026-04-26).
+// Rooms + players survive backend restart when LOBBY_PRISMA_ENABLED=true.
+model LobbyRoom {
+  code                String         @id
+  hostId              String         @map("host_id")
+  hostName            String         @map("host_name")
+  campaignId          String?        @map("campaign_id")
+  maxPlayers          Int            @default(8) @map("max_players")
+  hostTransferGraceMs Int            @default(30000) @map("host_transfer_grace_ms")
+  closed              Boolean        @default(false)
+  stateVersion        Int            @default(0) @map("state_version")
+  lastState           String?        @map("last_state")
+  createdAt           DateTime       @default(now()) @map("created_at")
+  updatedAt           DateTime       @updatedAt @map("updated_at")
+  players             LobbyPlayer[]
+
+  @@index([closed])
+  @@map("lobby_rooms")
+}
+
+model LobbyPlayer {
+  id              String    @id
+  roomCode        String    @map("room_code")
+  room            LobbyRoom @relation(fields: [roomCode], references: [code], onDelete: Cascade)
+  name            String
+  role            String
+  token           String
+  connected       Boolean   @default(false)
+  joinedAt        DateTime  @default(now()) @map("joined_at")
+  disconnectedAt  DateTime? @map("disconnected_at")
+
+  @@index([roomCode])
+  @@map("lobby_players")
+}
+
 model MatingEvent {
   id                String      @id @default(uuid())
   relationId        String      @map("relation_id")

--- a/apps/backend/services/network/lobbyPersistence.js
+++ b/apps/backend/services/network/lobbyPersistence.js
@@ -1,0 +1,203 @@
+// M11 Phase D — lobby persistence adapter (ADR-2026-04-26).
+//
+// Write-through pattern (reference_prisma_write_through_adapter.md):
+//   - In-memory LobbyService resta source-of-truth a runtime
+//   - Adapter sync-write a Prisma su createRoom/joinRoom/closeRoom/setConnected
+//   - Graceful: se Prisma assente/fallisce, log warn + continua in-mem
+//   - Hydrate su boot: carica room.closed=false + player attivi → LobbyService
+//
+// Enabled via env `LOBBY_PRISMA_ENABLED=true`. Off = noop (legacy behavior).
+
+'use strict';
+
+function isEnabled() {
+  return process.env.LOBBY_PRISMA_ENABLED === 'true';
+}
+
+function tryLoadPrisma() {
+  try {
+    const { PrismaClient } = require('@prisma/client');
+    return new PrismaClient();
+  } catch (err) {
+    console.warn('[lobby-prisma] client non disponibile:', err.message);
+    return null;
+  }
+}
+
+/**
+ * Create a persistence adapter over a LobbyService. Returns an object with:
+ *   - `hydrate()` — load open rooms from DB into service
+ *   - `persistCreate(code, room, hostToken)` — write room + host on create
+ *   - `persistJoin(code, player)` — write new player
+ *   - `persistClose(code)` — mark room closed
+ *   - `persistConnected(code, playerId, connected)` — toggle flag
+ *   - `persistState(code, version, payload)` — save last state snapshot
+ *   - `close()` — disconnect client
+ *
+ * All methods are no-ops if disabled or prisma client unavailable.
+ */
+function createLobbyPersistence({ lobby, prisma: injected = null } = {}) {
+  if (!lobby) throw new Error('lobby_required');
+  const enabled = isEnabled();
+  const prisma = enabled ? injected || tryLoadPrisma() : null;
+  const active = Boolean(enabled && prisma);
+
+  const safe = async (fn, label) => {
+    if (!active) return null;
+    try {
+      return await fn();
+    } catch (err) {
+      console.warn(`[lobby-prisma] ${label} failed:`, err.message);
+      return null;
+    }
+  };
+
+  return {
+    enabled: active,
+
+    async hydrate() {
+      if (!active) return { rooms: 0, players: 0 };
+      const rows = await safe(
+        () =>
+          prisma.lobbyRoom.findMany({
+            where: { closed: false },
+            include: { players: true },
+          }),
+        'hydrate',
+      );
+      if (!rows) return { rooms: 0, players: 0 };
+      let playerCount = 0;
+      for (const row of rows) {
+        lobby.rehydrateRoom({
+          code: row.code,
+          hostId: row.hostId,
+          hostName: row.hostName,
+          campaignId: row.campaignId,
+          maxPlayers: row.maxPlayers,
+          hostTransferGraceMs: row.hostTransferGraceMs,
+          stateVersion: row.stateVersion,
+          lastState: row.lastState,
+          players: row.players.map((p) => ({
+            id: p.id,
+            name: p.name,
+            role: p.role,
+            token: p.token,
+            connected: false, // WS not yet attached after restart
+            joinedAt: p.joinedAt,
+          })),
+        });
+        playerCount += row.players.length;
+      }
+      return { rooms: rows.length, players: playerCount };
+    },
+
+    async persistCreate(code, room) {
+      return safe(async () => {
+        const host = room.getPlayer(room.hostId);
+        await prisma.lobbyRoom.upsert({
+          where: { code },
+          update: {
+            closed: false,
+            hostId: room.hostId,
+            hostName: host?.name || 'host',
+            campaignId: room.campaignId,
+            maxPlayers: room.maxPlayers,
+            hostTransferGraceMs: room.hostTransferGraceMs,
+          },
+          create: {
+            code,
+            hostId: room.hostId,
+            hostName: host?.name || 'host',
+            campaignId: room.campaignId,
+            maxPlayers: room.maxPlayers,
+            hostTransferGraceMs: room.hostTransferGraceMs,
+            players: host
+              ? {
+                  create: [
+                    {
+                      id: host.id,
+                      name: host.name,
+                      role: host.role,
+                      token: host.token,
+                      connected: false,
+                    },
+                  ],
+                }
+              : undefined,
+          },
+        });
+      }, 'persistCreate');
+    },
+
+    async persistJoin(code, player) {
+      return safe(
+        () =>
+          prisma.lobbyPlayer.upsert({
+            where: { id: player.id },
+            update: {
+              name: player.name,
+              role: player.role,
+              token: player.token,
+              connected: player.connected,
+            },
+            create: {
+              id: player.id,
+              roomCode: code,
+              name: player.name,
+              role: player.role,
+              token: player.token,
+              connected: player.connected,
+            },
+          }),
+        'persistJoin',
+      );
+    },
+
+    async persistClose(code) {
+      return safe(
+        () => prisma.lobbyRoom.update({ where: { code }, data: { closed: true } }),
+        'persistClose',
+      );
+    },
+
+    async persistConnected(code, playerId, connected) {
+      return safe(
+        () =>
+          prisma.lobbyPlayer.update({
+            where: { id: playerId },
+            data: {
+              connected,
+              disconnectedAt: connected ? null : new Date(),
+            },
+          }),
+        'persistConnected',
+      );
+    },
+
+    async persistState(code, version, payload) {
+      return safe(
+        () =>
+          prisma.lobbyRoom.update({
+            where: { code },
+            data: {
+              stateVersion: version,
+              lastState: payload === null ? null : JSON.stringify(payload),
+            },
+          }),
+        'persistState',
+      );
+    },
+
+    async close() {
+      if (prisma && typeof prisma.$disconnect === 'function') {
+        try {
+          await prisma.$disconnect();
+        } catch {
+          // noop
+        }
+      }
+    },
+  };
+}
+
+module.exports = { createLobbyPersistence, isEnabled };

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -316,6 +316,66 @@ class LobbyService {
   constructor({ maxPlayers = DEFAULT_MAX_PLAYERS } = {}) {
     this.rooms = new Map(); // code → Room
     this.maxPlayers = maxPlayers;
+    // ADR-2026-04-26 — optional persistence adapter (opt-in via env).
+    // When set, mutations are sync-written via write-through pattern.
+    this._persistence = null;
+  }
+
+  setPersistence(adapter) {
+    this._persistence = adapter || null;
+  }
+
+  _persist(method, ...args) {
+    const adapter = this._persistence;
+    if (!adapter || typeof adapter[method] !== 'function') return;
+    const p = adapter[method](...args);
+    if (p && typeof p.catch === 'function') {
+      p.catch((err) => console.warn(`[lobby-prisma] ${method} rejected:`, err.message));
+    }
+  }
+
+  /** ADR-2026-04-26 — rehydrate a persisted room at boot. */
+  rehydrateRoom({
+    code,
+    hostId,
+    hostName,
+    campaignId,
+    maxPlayers,
+    hostTransferGraceMs,
+    stateVersion = 0,
+    lastState = null,
+    players = [],
+  }) {
+    if (!code || !hostId) return null;
+    const room = new Room({
+      code,
+      hostId,
+      hostName: hostName || 'host',
+      maxPlayers: maxPlayers || this.maxPlayers,
+      campaignId,
+      hostTransferGraceMs,
+    });
+    // Reset default host player added by constructor — replace with persisted set.
+    room.players.clear();
+    for (const p of players) {
+      room.players.set(p.id, {
+        id: p.id,
+        name: p.name,
+        role: p.role,
+        token: p.token,
+        connected: false,
+        socket: null,
+        joinedAt: p.joinedAt ? new Date(p.joinedAt).getTime() : Date.now(),
+      });
+    }
+    room.stateVersion = stateVersion;
+    try {
+      room.state = lastState ? JSON.parse(lastState) : null;
+    } catch {
+      room.state = null;
+    }
+    this.rooms.set(code, room);
+    return room;
   }
 
   createRoom({ hostName, campaignId = null, maxPlayers, hostTransferGraceMs } = {}) {
@@ -345,6 +405,7 @@ class LobbyService {
     });
     this.rooms.set(code, room);
     const host = room.getPlayer(hostId);
+    this._persist('persistCreate', code, room);
     return {
       code,
       host_id: hostId,
@@ -364,6 +425,14 @@ class LobbyService {
       throw new Error('player_name_required');
     }
     const { playerId, token } = room.addPlayer({ name: playerName });
+    const newPlayer = room.getPlayer(playerId);
+    this._persist('persistJoin', normalized, {
+      id: playerId,
+      name: newPlayer.name,
+      role: newPlayer.role,
+      token,
+      connected: false,
+    });
     // Broadcast presence to any already-connected sockets.
     room.broadcast({
       type: 'player_joined',
@@ -382,6 +451,7 @@ class LobbyService {
     }
     room.close();
     this.rooms.delete(normalized);
+    this._persist('persistClose', normalized);
     return { code: normalized, closed: true };
   }
 
@@ -460,6 +530,7 @@ function createWsServer({ lobby, server = null, port = null, path = '/ws' } = {}
     }
 
     room.attachSocket(playerId, socket);
+    lobby._persist('persistConnected', code, playerId, true);
     // TKT-M11B-05 — if the returning player is (now or still) host, any
     // pending host-transfer timer must be cancelled.
     if (playerId === room.hostId) {
@@ -514,6 +585,7 @@ function createWsServer({ lobby, server = null, port = null, path = '/ws' } = {}
             return;
           }
           room.publishState(msg.payload ?? null);
+          lobby._persist('persistState', code, room.stateVersion, room.state);
           break;
 
         case 'intent':
@@ -543,6 +615,7 @@ function createWsServer({ lobby, server = null, port = null, path = '/ws' } = {}
 
     socket.on('close', () => {
       room.detachSocket(playerId);
+      lobby._persist('persistConnected', code, playerId, false);
       room.broadcast({
         type: 'player_disconnected',
         payload: { player_id: playerId },

--- a/docs/adr/ADR-2026-04-26-m11-phase-d-prisma-persistence.md
+++ b/docs/adr/ADR-2026-04-26-m11-phase-d-prisma-persistence.md
@@ -1,0 +1,118 @@
+---
+title: 'ADR 2026-04-26 — M11 Phase D: Prisma lobby persistence (addendum to ADR-2026-04-20)'
+workstream: cross-cutting
+category: adr
+status: accepted
+owner: master-dd
+created: 2026-04-26
+tags:
+  - adr
+  - m11
+  - coop
+  - lobby
+  - prisma
+  - persistence
+related:
+  - docs/adr/ADR-2026-04-20-m11-jackbox-phase-a.md
+  - docs/playtest/2026-04-26-demo-one-command.md
+---
+
+# ADR 2026-04-26 — M11 Phase D: Prisma lobby persistence
+
+Addendum a [ADR-2026-04-20](ADR-2026-04-20-m11-jackbox-phase-a.md) (LobbyService in-memory). Room + player survivono restart backend quando `LOBBY_PRISMA_ENABLED=true`.
+
+## Contesto
+
+M11 Phase A-C (PR #1680/#1682/#1686/#1684/#1685) ha shippato flow co-op in-memory. Gap noto:
+
+- Restart backend durante playtest → tutte le stanze perdute → amici devono ri-join
+- Durante ngrok playtest, nel caso di crash metà sessione il TKT-M11B-06 test fallisce silenziosamente
+- Handoff `2026-04-26-next-session-kickoff-p4-mbti-playtest.md` lista Prisma come Opzione C (~5h)
+
+## Decisione
+
+Adapter **write-through** opt-in (pattern `reference_prisma_write_through_adapter.md`):
+
+- LobbyService in-memory resta source-of-truth a runtime
+- Mutazioni (createRoom/joinRoom/closeRoom/setConnected/publishState) invocano sync-write su Prisma
+- Boot: hydrate rooms aperte (closed=false) dal DB → LobbyService
+- Graceful: se Prisma assente/fallisce, log warn + continua in-mem senza errori
+
+## Schema
+
+Migration `0005_lobby_persistence`:
+
+```prisma
+model LobbyRoom {
+  code                String         @id
+  hostId              String
+  hostName            String
+  campaignId          String?
+  maxPlayers          Int            @default(8)
+  hostTransferGraceMs Int            @default(30000)
+  closed              Boolean        @default(false)
+  stateVersion        Int            @default(0)
+  lastState           String?        // JSON
+  players             LobbyPlayer[]
+}
+
+model LobbyPlayer {
+  id              String    @id
+  roomCode        String    // FK → LobbyRoom.code
+  name            String
+  role            String
+  token           String
+  connected       Boolean   @default(false)
+  joinedAt        DateTime
+  disconnectedAt  DateTime?
+}
+```
+
+## Invarianti
+
+1. **Opt-in only** — env `LOBBY_PRISMA_ENABLED=true`, default OFF
+2. **Fallback grazioso** — se `@prisma/client` mancante o DB unreachable, log + skip (no crash)
+3. **Write-through** — ogni mutazione scrive immediatamente; nessun batching (ok per scope 4-8 player)
+4. **Read from memory** — nessuna read via Prisma a runtime (solo boot hydrate)
+5. **`lastState` snapshot** — salvato su ogni `publishState`, permette riprendere partita post-crash
+6. **Host auth preservato** — `token` HEX non cambia post-restart; client può reconnect con stesso token
+
+## Flow restart
+
+```
+backend crash / SIGTERM
+ ↓
+process restart
+ ↓
+createLobbyPersistence.hydrate()
+ ↓
+prisma.lobbyRoom.findMany({ closed: false, include: { players } })
+ ↓
+LobbyService.rehydrateRoom({...}) per ogni row
+ ↓
+client WebSocket reconnect backoff (1s→30s) → attachSocket → hello
+```
+
+## Non-obiettivi
+
+- Cross-process sharding (single-process resta)
+- Chat history persistence
+- Replay / time-travel debugging
+- Rate-limit / DoS (tracciato separatamente)
+
+## Rollback
+
+- `LOBBY_PRISMA_ENABLED=false` → noop, back a Phase A-C in-memory puro
+- Tabelle `lobby_rooms`+`lobby_players` possono restare nel DB inutilizzate
+- Migration reversibile via `npm run db:migrate:down`
+
+## Test coverage
+
+- `tests/api/lobbyPersistence.test.js` — 6 unit test fake Prisma (create/join/close/hydrate/failure-swallow/default-noop)
+- `tests/api/lobbyRoutes.test.js` + `lobbyWebSocket.test.js` + `e2e/lobbyEndToEnd.test.mjs` — **26/26 verde senza regressione** (adapter opt-in non interferisce con default OFF)
+
+## Riferimenti
+
+- ADR origine: [ADR-2026-04-20](ADR-2026-04-20-m11-jackbox-phase-a.md)
+- Pattern write-through: memory `reference_prisma_write_through_adapter.md`
+- Esempi simili: migration 0003 (FormSessionState M12.D), 0004 (UnitProgression M13.P3)

--- a/tests/api/lobbyPersistence.test.js
+++ b/tests/api/lobbyPersistence.test.js
@@ -1,0 +1,186 @@
+// Unit tests lobby persistence adapter — fake Prisma, verifies write-through.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { LobbyService } = require('../../apps/backend/services/network/wsSession');
+
+function makeFakePrisma() {
+  const rooms = new Map();
+  const players = new Map();
+  return {
+    _rooms: rooms,
+    _players: players,
+    lobbyRoom: {
+      async findMany({ where, include } = {}) {
+        const all = Array.from(rooms.values());
+        const filtered = where
+          ? all.filter((r) => Object.entries(where).every(([k, v]) => r[k] === v))
+          : all;
+        if (include?.players) {
+          return filtered.map((r) => ({
+            ...r,
+            players: Array.from(players.values()).filter((p) => p.roomCode === r.code),
+          }));
+        }
+        return filtered;
+      },
+      async upsert({ where, update, create }) {
+        if (rooms.has(where.code)) {
+          rooms.set(where.code, { ...rooms.get(where.code), ...update });
+        } else {
+          const { players: playerCreate, ...rest } = create;
+          rooms.set(where.code, { closed: false, stateVersion: 0, lastState: null, ...rest });
+          if (playerCreate?.create) {
+            for (const p of playerCreate.create) {
+              players.set(p.id, { ...p, roomCode: where.code });
+            }
+          }
+        }
+      },
+      async update({ where, data }) {
+        if (!rooms.has(where.code)) throw new Error('not_found');
+        rooms.set(where.code, { ...rooms.get(where.code), ...data });
+      },
+    },
+    lobbyPlayer: {
+      async upsert({ where, update, create }) {
+        if (players.has(where.id)) {
+          players.set(where.id, { ...players.get(where.id), ...update });
+        } else {
+          players.set(where.id, { id: where.id, ...create });
+        }
+      },
+      async update({ where, data }) {
+        if (!players.has(where.id)) throw new Error('not_found');
+        players.set(where.id, { ...players.get(where.id), ...data });
+      },
+    },
+    async $disconnect() {},
+  };
+}
+
+function makeAdapter(lobby, prisma) {
+  process.env.LOBBY_PRISMA_ENABLED = 'true';
+  const {
+    createLobbyPersistence,
+  } = require('../../apps/backend/services/network/lobbyPersistence');
+  const adapter = createLobbyPersistence({ lobby, prisma });
+  lobby.setPersistence(adapter);
+  return adapter;
+}
+
+test.beforeEach(() => {
+  delete require.cache[require.resolve('../../apps/backend/services/network/lobbyPersistence')];
+});
+
+test('persistence disabled by default → setPersistence noop safe', () => {
+  const lobby = new LobbyService();
+  const res = lobby.createRoom({ hostName: 'H' });
+  assert.ok(res.code);
+  assert.ok(res.host_token);
+});
+
+test('createRoom → persistCreate writes room + host player', async () => {
+  const lobby = new LobbyService();
+  const prisma = makeFakePrisma();
+  makeAdapter(lobby, prisma);
+  const { code } = lobby.createRoom({ hostName: 'Alice', maxPlayers: 4 });
+  // wait tick for async persist
+  await new Promise((r) => setImmediate(r));
+  assert.ok(prisma._rooms.has(code));
+  const row = prisma._rooms.get(code);
+  assert.equal(row.hostName, 'Alice');
+  assert.equal(row.maxPlayers, 4);
+  assert.equal(row.closed, false);
+  assert.equal(Array.from(prisma._players.values()).filter((p) => p.roomCode === code).length, 1);
+});
+
+test('joinRoom → persistJoin adds player row', async () => {
+  const lobby = new LobbyService();
+  const prisma = makeFakePrisma();
+  makeAdapter(lobby, prisma);
+  const { code } = lobby.createRoom({ hostName: 'H' });
+  lobby.joinRoom({ code, playerName: 'Bob' });
+  await new Promise((r) => setImmediate(r));
+  const rows = Array.from(prisma._players.values()).filter((p) => p.roomCode === code);
+  assert.equal(rows.length, 2); // host + bob
+  const bob = rows.find((p) => p.name === 'Bob');
+  assert.ok(bob);
+  assert.equal(bob.role, 'player');
+});
+
+test('closeRoom → persistClose marks closed=true', async () => {
+  const lobby = new LobbyService();
+  const prisma = makeFakePrisma();
+  makeAdapter(lobby, prisma);
+  const { code, host_token } = lobby.createRoom({ hostName: 'H' });
+  lobby.closeRoom({ code, hostToken: host_token });
+  await new Promise((r) => setImmediate(r));
+  assert.equal(prisma._rooms.get(code).closed, true);
+});
+
+test('hydrate: open rooms restored into service + closed rooms skipped', async () => {
+  const lobby = new LobbyService();
+  const prisma = makeFakePrisma();
+  // pre-seed DB
+  prisma._rooms.set('ALIV', {
+    code: 'ALIV',
+    hostId: 'p_h1',
+    hostName: 'HostAlive',
+    campaignId: null,
+    maxPlayers: 4,
+    hostTransferGraceMs: 30000,
+    closed: false,
+    stateVersion: 3,
+    lastState: JSON.stringify({ turn: 5 }),
+  });
+  prisma._rooms.set('GONE', {
+    code: 'GONE',
+    hostId: 'p_h2',
+    hostName: 'HostGone',
+    campaignId: null,
+    maxPlayers: 4,
+    hostTransferGraceMs: 30000,
+    closed: true,
+  });
+  prisma._players.set('p_h1', {
+    id: 'p_h1',
+    roomCode: 'ALIV',
+    name: 'HostAlive',
+    role: 'host',
+    token: 'tok-h1',
+    connected: false,
+    joinedAt: new Date(),
+  });
+  const adapter = makeAdapter(lobby, prisma);
+  const stats = await adapter.hydrate();
+  assert.equal(stats.rooms, 1);
+  assert.equal(stats.players, 1);
+  const room = lobby.getRoom('ALIV');
+  assert.ok(room);
+  assert.equal(room.hostId, 'p_h1');
+  assert.equal(room.stateVersion, 3);
+  assert.deepEqual(room.state, { turn: 5 });
+  assert.equal(lobby.getRoom('GONE'), null);
+});
+
+test('persistence write failure is swallowed + logged (service stays healthy)', async () => {
+  const lobby = new LobbyService();
+  const prisma = makeFakePrisma();
+  prisma.lobbyRoom.upsert = async () => {
+    throw new Error('db_down');
+  };
+  const warns = [];
+  const origWarn = console.warn;
+  console.warn = (...args) => warns.push(args.join(' '));
+  try {
+    makeAdapter(lobby, prisma);
+    const res = lobby.createRoom({ hostName: 'H' });
+    await new Promise((r) => setImmediate(r));
+    assert.ok(res.code);
+    assert.ok(warns.some((w) => w.includes('persistCreate failed')));
+  } finally {
+    console.warn = origWarn;
+  }
+});


### PR DESCRIPTION
## Summary

Rooms + players survivono restart backend quando LOBBY_PRISMA_ENABLED=true. Write-through pattern + graceful fallback in-memory.

- Schema +LobbyRoom + LobbyPlayer + migration 0005
- Adapter lobbyPersistence.js (5 hook: hydrate/persistCreate/Join/Close/Connected/State)
- LobbyService hook injection minimo (`_persist` + `rehydrateRoom`)
- Opt-in via env LOBBY_PRISMA_ENABLED, default OFF
- ADR addendum a ADR-2026-04-20

## Test plan

- [x] 6/6 unit test fake Prisma verde (create/join/close/hydrate/failure-swallow/noop-default)
- [x] 26/26 regression lobby suite (routes + WebSocket + e2e) verde
- [x] prettier verde
- [ ] Integration Postgres reale (userland, post-deploy)

## Rollback

- LOBBY_PRISMA_ENABLED=false → back a pure in-memory (zero change)
- Migration 0005 reversibile via db:migrate:down

## Riferimenti

- ADR: docs/adr/ADR-2026-04-26-m11-phase-d-prisma-persistence.md
- Pattern: memory reference_prisma_write_through_adapter.md
- Origine: ADR-2026-04-20

🤖 Generated with [Claude Code](https://claude.com/claude-code)