### PR TITLE
feat(p4): axes iter2 refinement — enemy_target + concrete_action + action_switch (Opzione A)

### DIFF
--- a/apps/backend/services/vcScoring.js
+++ b/apps/backend/services/vcScoring.js
@@ -66,6 +66,20 @@ const DERIVABLE_RAW_KEYS = new Set([
   //             percorso. Componente di `explore`.
   '1vX',
   'new_tiles',
+  // P4 iter2 (2026-04-26): nuove raw metrics additive per axes refinement
+  // MBTI secondo handoff Opzione A. Alimentano computeMbtiAxesIter2 (opt-in
+  // via env VC_AXES_ITER=2). Non mutano iter1 axes (backward compat).
+  //
+  // enemy_target_ratio: eventi con target di team avverso / eventi totali
+  //   con target. Proxy per Extraversion (bias verso contatto con nemico).
+  // concrete_action_ratio: (attacks + moves) / total_actions. Proxy per
+  //   Sensing (azioni fisiche dirette vs abstract ability/buff).
+  // action_switch_rate: numero di transizioni action_type != prev /
+  //   (total_actions - 1). Proxy per Perceiving (alta variance = P,
+  //   bassa = J).
+  'enemy_target_ratio',
+  'concrete_action_ratio',
+  'action_switch_rate',
 ]);
 
 function loadTelemetryConfig(yamlPath = DEFAULT_TELEMETRY_PATH, logger = console) {
@@ -173,6 +187,17 @@ function computeRawMetrics(events, units, gridSize = 6) {
       //   della sessione, per new_tiles (count) in explore.
       oneVxOneAttacks: 0,
       visitedTiles: new Set(),
+      // P4 iter2: raw counters per axes refinement.
+      // events_with_target: eventi che hanno un target_id valorizzato.
+      // events_targeting_enemy: di cui target è team avverso.
+      // action_switches: transizioni action_type diverso da quella precedente.
+      // prev_action_type: cache per switch counting.
+      events_with_target: 0,
+      events_targeting_enemy: 0,
+      action_switches: 0,
+      prev_action_type: null,
+      concrete_action_count: 0,
+      abstract_action_count: 0,
     };
   }
 
@@ -208,6 +233,33 @@ function computeRawMetrics(events, units, gridSize = 6) {
     const bucketId = event.ia_controlled_unit || actorId;
     const bucket = perActor[bucketId];
     if (!bucket) continue;
+
+    // P4 iter2 sidecar: target-team + action-type tracking, independent
+    // from iter1 branches. Triggered solo per action_type "significativi"
+    // (attack/move/ability). Exclude: kill/assist/bleeding/session_* che
+    // sono eventi automatici o di tracking derivato.
+    const ITER2_ACTION_TYPES = new Set(['attack', 'move', 'ability']);
+    if (ITER2_ACTION_TYPES.has(event.action_type)) {
+      // action_switches + concrete/abstract count
+      if (bucket.prev_action_type !== null && bucket.prev_action_type !== event.action_type) {
+        bucket.action_switches += 1;
+      }
+      bucket.prev_action_type = event.action_type;
+      if (event.action_type === 'attack' || event.action_type === 'move') {
+        bucket.concrete_action_count += 1;
+      } else if (event.action_type === 'ability') {
+        bucket.abstract_action_count += 1;
+      }
+      // enemy_target tracking: event con target_id di team avverso
+      if (event.target_id && event.target_id !== bucketId) {
+        bucket.events_with_target += 1;
+        const actorTeam = unitTeamMap[bucketId];
+        const targetTeam = unitTeamMap[event.target_id];
+        if (actorTeam && targetTeam && actorTeam !== targetTeam) {
+          bucket.events_targeting_enemy += 1;
+        }
+      }
+    }
 
     if (event.action_type === 'attack') {
       bucket.attacks_started += 1;
@@ -376,6 +428,17 @@ function computeRawMetrics(events, units, gridSize = 6) {
     const newTilesRaw = bucket.visitedTiles.size;
     const newTilesNorm = safeDivide(newTilesRaw, Math.max(1, gridSize * gridSize));
 
+    // P4 iter2 derived metrics.
+    const enemyTargetRatio =
+      bucket.events_with_target > 0
+        ? bucket.events_targeting_enemy / bucket.events_with_target
+        : null;
+    const iter2Total = bucket.concrete_action_count + bucket.abstract_action_count;
+    const concreteActionRatio = iter2Total > 0 ? bucket.concrete_action_count / iter2Total : null;
+    // action_switch_rate: numero switch / (iter2Total - 1). Quando iter2Total
+    // <=1 non derivabile (nessuna transizione possibile).
+    const actionSwitchRate = iter2Total > 1 ? bucket.action_switches / (iter2Total - 1) : null;
+
     finalRaw[unitId] = {
       attacks_started: attacksStarted,
       attack_hit_rate: attackHitRate,
@@ -400,6 +463,10 @@ function computeRawMetrics(events, units, gridSize = 6) {
       '1vX': oneVxOneRatio,
       new_tiles: newTilesNorm,
       new_tiles_count: newTilesRaw,
+      // P4 iter2 additive.
+      enemy_target_ratio: enemyTargetRatio,
+      concrete_action_ratio: concreteActionRatio,
+      action_switch_rate: actionSwitchRate,
     };
   }
 
@@ -532,6 +599,56 @@ function letterOrUncertain(value, lo, hi) {
   if (value < MBTI_DEAD_BAND_LOW) return lo;
   if (value > MBTI_DEAD_BAND_HIGH) return hi;
   return null; // dead-band: indeterminato → propaga null
+}
+
+/**
+ * P4 iter2 (2026-04-26) — axes refinement con raw metrics canoniche.
+ *
+ * Handoff spec:
+ *   - E_I: enemy_target_ratio (extraversion proxy diretto; bias verso nemico)
+ *   - S_N: concrete_action_ratio (sensing proxy; azioni fisiche vs astratte)
+ *   - J_P: action_switch_rate (perceiving proxy; alta variance tipo action = P)
+ *   - T_F: invariato rispetto iter1 (utility + support_bias)
+ *
+ * Coverage = 'full' quando la raw metric primaria è non-null. Convenzione
+ * direzione coerente con iter1 letterOrUncertain: value basso = lettera
+ * iniziale del pair (E/N/F/P), value alto = seconda (I/S/T/J).
+ *
+ * Opt-in: `buildVcSnapshot` usa iter2 quando env `VC_AXES_ITER=2` oppure
+ * `telemetryConfig.use_axes_iter2 === true`. Default = iter1 (backward compat).
+ */
+function computeMbtiAxesIter2(raw) {
+  const axes = { E_I: null, S_N: null, T_F: null, J_P: null };
+
+  // E_I: extravert attacca nemico → basso value. Invertiamo: value = 1 - ratio.
+  const enemyRatio = raw.enemy_target_ratio;
+  if (enemyRatio !== null && enemyRatio !== undefined) {
+    axes.E_I = { value: clamp01(1 - enemyRatio), coverage: 'full' };
+  }
+
+  // S_N: sensing = concreto (attacco/move) → alto value (vicino 1 = S).
+  // concrete_action_ratio alto = S side (letterOrUncertain high=S).
+  const concreteRatio = raw.concrete_action_ratio;
+  if (concreteRatio !== null && concreteRatio !== undefined) {
+    axes.S_N = { value: clamp01(concreteRatio), coverage: 'full' };
+  }
+
+  // T_F: invariato (stesso formula iter1).
+  const utility = clamp01(raw.utility_actions);
+  const support = clamp01(raw.support_bias);
+  if (utility !== null && support !== null) {
+    const value = 1 - 0.5 * utility + 0.5 * support;
+    axes.T_F = { value: clamp01(value), coverage: 'full' };
+  }
+
+  // J_P: high switch rate = P side (improvvisa). letterOrUncertain P=low,
+  // J=high → invertiamo: value = 1 - switch_rate.
+  const switchRate = raw.action_switch_rate;
+  if (switchRate !== null && switchRate !== undefined) {
+    axes.J_P = { value: clamp01(1 - switchRate), coverage: 'full' };
+  }
+
+  return axes;
 }
 
 function deriveMbtiType(axes) {
@@ -706,10 +823,18 @@ function buildVcSnapshot(session, config) {
   const gridSize = session?.grid?.width || 6;
   const raw = computeRawMetrics(events, units, gridSize);
 
+  // P4 iter2 opt-in: env VC_AXES_ITER=2 o config.use_axes_iter2.
+  // Default = iter1 (backward compat). Config override ha priorità su env
+  // per permettere test isolati.
+  const iter2 =
+    config?.use_axes_iter2 === true ||
+    (config?.use_axes_iter2 === undefined && process.env.VC_AXES_ITER === '2');
+  const axesFn = iter2 ? computeMbtiAxesIter2 : computeMbtiAxes;
+
   const perActor = {};
   for (const [unitId, rawMetrics] of Object.entries(raw)) {
     const aggregate = computeAggregateIndices(rawMetrics, config);
-    const mbti = computeMbtiAxes(rawMetrics);
+    const mbti = axesFn(rawMetrics);
     const ennea = computeEnneaArchetypes(aggregate, config, rawMetrics);
     perActor[unitId] = {
       raw_metrics: rawMetrics,
@@ -763,6 +888,7 @@ module.exports = {
   computeRawMetrics,
   computeAggregateIndices,
   computeMbtiAxes,
+  computeMbtiAxesIter2,
   deriveMbtiType,
   computeEnneaArchetypes,
   buildVcSnapshot,

--- a/tests/services/vcScoringIter2.test.js
+++ b/tests/services/vcScoringIter2.test.js
@@ -1,0 +1,290 @@
+// P4 iter2 (2026-04-26) — axes refinement tests (Opzione A handoff).
+//
+// Coverage:
+//   - raw metrics nuove (enemy_target_ratio, concrete_action_ratio,
+//     action_switch_rate) derivabili dagli events
+//   - computeMbtiAxesIter2 formule corrette con direzione letters
+//   - buildVcSnapshot opt-in via config.use_axes_iter2 / env VC_AXES_ITER
+//   - backward compat: iter1 default invariato
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  computeRawMetrics,
+  computeMbtiAxes,
+  computeMbtiAxesIter2,
+  buildVcSnapshot,
+  loadTelemetryConfig,
+} = require('../../apps/backend/services/vcScoring');
+
+// Minimal units fixture: 1 player + 1 sistema.
+const UNITS = [
+  { id: 'u1', controlled_by: 'player', attack_range: 1, max_hp: 10, hp: 10 },
+  { id: 'u2', controlled_by: 'sistema', attack_range: 1, max_hp: 10, hp: 10 },
+];
+
+function ev(actor_id, action_type, extra = {}) {
+  return {
+    actor_id,
+    action_type,
+    turn: extra.turn || 1,
+    ...extra,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Raw metrics
+// ---------------------------------------------------------------------------
+test('iter2 raw: enemy_target_ratio = 1.0 when all attacks target enemy', () => {
+  const events = [
+    ev('u1', 'attack', { target_id: 'u2', result: 'miss' }),
+    ev('u1', 'attack', { target_id: 'u2', result: 'miss' }),
+  ];
+  const raw = computeRawMetrics(events, UNITS, 6);
+  assert.equal(raw.u1.enemy_target_ratio, 1.0);
+});
+
+test('iter2 raw: enemy_target_ratio = 0.5 when half target ally', () => {
+  const units = [
+    ...UNITS,
+    { id: 'u3', controlled_by: 'player', attack_range: 1, max_hp: 10, hp: 10 },
+  ];
+  // u1 ability on u3 (ally) + attack u2 (enemy)
+  const events = [
+    ev('u1', 'ability', { target_id: 'u3' }),
+    ev('u1', 'attack', { target_id: 'u2', result: 'miss' }),
+  ];
+  const raw = computeRawMetrics(events, units, 6);
+  assert.equal(raw.u1.enemy_target_ratio, 0.5);
+});
+
+test('iter2 raw: enemy_target_ratio = null when no events with target', () => {
+  const events = [ev('u1', 'move', { position_from: { x: 0, y: 0 }, position_to: { x: 1, y: 0 } })];
+  const raw = computeRawMetrics(events, UNITS, 6);
+  assert.equal(raw.u1.enemy_target_ratio, null);
+});
+
+test('iter2 raw: concrete_action_ratio = 1.0 attacks+moves only', () => {
+  const events = [
+    ev('u1', 'attack', { target_id: 'u2', result: 'miss' }),
+    ev('u1', 'move', { position_from: { x: 0, y: 0 }, position_to: { x: 1, y: 0 } }),
+  ];
+  const raw = computeRawMetrics(events, UNITS, 6);
+  assert.equal(raw.u1.concrete_action_ratio, 1.0);
+});
+
+test('iter2 raw: concrete_action_ratio = 0.5 half abilities', () => {
+  const events = [
+    ev('u1', 'attack', { target_id: 'u2', result: 'miss' }),
+    ev('u1', 'ability', { target_id: 'u2' }),
+    ev('u1', 'ability', { target_id: 'u2' }),
+    ev('u1', 'move', { position_from: { x: 0, y: 0 }, position_to: { x: 1, y: 0 } }),
+  ];
+  const raw = computeRawMetrics(events, UNITS, 6);
+  assert.equal(raw.u1.concrete_action_ratio, 0.5);
+});
+
+test('iter2 raw: action_switch_rate = 1.0 alternating types', () => {
+  // attack → move → attack → move = 3 switches over 3 transitions = 1.0
+  const events = [
+    ev('u1', 'attack', { target_id: 'u2', result: 'miss' }),
+    ev('u1', 'move', { position_from: { x: 0, y: 0 }, position_to: { x: 1, y: 0 } }),
+    ev('u1', 'attack', { target_id: 'u2', result: 'miss' }),
+    ev('u1', 'move', { position_from: { x: 1, y: 0 }, position_to: { x: 2, y: 0 } }),
+  ];
+  const raw = computeRawMetrics(events, UNITS, 6);
+  assert.equal(raw.u1.action_switch_rate, 1.0);
+});
+
+test('iter2 raw: action_switch_rate = 0 same type streak', () => {
+  const events = [
+    ev('u1', 'attack', { target_id: 'u2', result: 'miss' }),
+    ev('u1', 'attack', { target_id: 'u2', result: 'miss' }),
+    ev('u1', 'attack', { target_id: 'u2', result: 'miss' }),
+  ];
+  const raw = computeRawMetrics(events, UNITS, 6);
+  assert.equal(raw.u1.action_switch_rate, 0);
+});
+
+test('iter2 raw: action_switch_rate = null with single event', () => {
+  const events = [ev('u1', 'attack', { target_id: 'u2', result: 'miss' })];
+  const raw = computeRawMetrics(events, UNITS, 6);
+  assert.equal(raw.u1.action_switch_rate, null);
+});
+
+// ---------------------------------------------------------------------------
+// computeMbtiAxesIter2 direction sanity
+// ---------------------------------------------------------------------------
+test('iter2 axes: high enemy_target_ratio → low E_I value (E pole)', () => {
+  const axes = computeMbtiAxesIter2({
+    enemy_target_ratio: 0.9,
+    concrete_action_ratio: 0.5,
+    action_switch_rate: 0.5,
+    utility_actions: 0.5,
+    support_bias: 0.5,
+  });
+  // Extravert: low value → E (letterOrUncertain 'E'|'I' w/ low=E).
+  assert.ok(axes.E_I.value < 0.45, `E_I ${axes.E_I.value} should fall in E zone`);
+  assert.equal(axes.E_I.coverage, 'full');
+});
+
+test('iter2 axes: low enemy_target_ratio → high E_I value (I pole)', () => {
+  const axes = computeMbtiAxesIter2({
+    enemy_target_ratio: 0.1,
+    concrete_action_ratio: 0.5,
+    action_switch_rate: 0.5,
+    utility_actions: 0.5,
+    support_bias: 0.5,
+  });
+  assert.ok(axes.E_I.value > 0.55);
+});
+
+test('iter2 axes: high concrete_action_ratio → S_N high (S pole)', () => {
+  const axes = computeMbtiAxesIter2({
+    enemy_target_ratio: 0.5,
+    concrete_action_ratio: 0.9,
+    action_switch_rate: 0.5,
+    utility_actions: 0.5,
+    support_bias: 0.5,
+  });
+  // letterOrUncertain 'N'|'S' with high=S → value 0.9 = S
+  assert.ok(axes.S_N.value > 0.55);
+});
+
+test('iter2 axes: high switch_rate → low J_P (P pole)', () => {
+  const axes = computeMbtiAxesIter2({
+    enemy_target_ratio: 0.5,
+    concrete_action_ratio: 0.5,
+    action_switch_rate: 0.9,
+    utility_actions: 0.5,
+    support_bias: 0.5,
+  });
+  // letterOrUncertain 'P'|'J' with low=P → value 1-0.9=0.1 → P
+  assert.ok(axes.J_P.value < 0.45);
+});
+
+test('iter2 axes: null raw metric → axis null', () => {
+  const axes = computeMbtiAxesIter2({
+    enemy_target_ratio: null,
+    concrete_action_ratio: null,
+    action_switch_rate: null,
+    utility_actions: 0.5,
+    support_bias: 0.5,
+  });
+  assert.equal(axes.E_I, null);
+  assert.equal(axes.S_N, null);
+  assert.equal(axes.J_P, null);
+  // T_F invariato — derivable from utility + support
+  assert.ok(axes.T_F !== null);
+});
+
+// ---------------------------------------------------------------------------
+// buildVcSnapshot gating
+// ---------------------------------------------------------------------------
+test('buildVcSnapshot: default (no flag) uses iter1 axes', () => {
+  delete process.env.VC_AXES_ITER;
+  const session = {
+    session_id: 's1',
+    units: UNITS,
+    events: [
+      ev('u1', 'attack', { target_id: 'u2', result: 'miss', position_from: { x: 0, y: 0 } }),
+    ],
+    grid: { width: 6 },
+  };
+  const config = loadTelemetryConfig();
+  const snap = buildVcSnapshot(session, config);
+  // iter1 E_I formula uses close_engage + support_bias + time_to_commit.
+  // With single attack and no move, time_to_commit = 0, close_engage = 0 (no
+  // position_from + target_position_at_attack). iter1 E_I may be null or
+  // partial; iter2 would be derivable from the attack alone.
+  // Just assert snapshot returned a structure.
+  assert.ok(snap.per_actor.u1);
+});
+
+test('buildVcSnapshot: config.use_axes_iter2=true enables iter2', () => {
+  const session = {
+    session_id: 's1',
+    units: UNITS,
+    events: [
+      ev('u1', 'attack', { target_id: 'u2', result: 'miss' }),
+      ev('u1', 'ability', { target_id: 'u2' }),
+    ],
+    grid: { width: 6 },
+  };
+  const config = { ...loadTelemetryConfig(), use_axes_iter2: true };
+  const snap = buildVcSnapshot(session, config);
+  const axes = snap.per_actor.u1.mbti_axes;
+  // iter2 E_I uses enemy_target_ratio = 1.0 → value = 0 → E
+  assert.ok(axes.E_I !== null, 'iter2 E_I derivable');
+  assert.ok(axes.E_I.value < 0.45);
+  // iter2 S_N uses concrete_ratio = 0.5 → 0.5 dead-band
+  assert.ok(axes.S_N !== null);
+});
+
+test('buildVcSnapshot: env VC_AXES_ITER=2 enables iter2 (config unset)', () => {
+  process.env.VC_AXES_ITER = '2';
+  try {
+    const session = {
+      session_id: 's1',
+      units: UNITS,
+      events: [ev('u1', 'attack', { target_id: 'u2', result: 'miss' })],
+      grid: { width: 6 },
+    };
+    // Pass a config WITHOUT use_axes_iter2 to exercise env fallback.
+    const config = loadTelemetryConfig();
+    delete config.use_axes_iter2;
+    const snap = buildVcSnapshot(session, config);
+    assert.ok(snap.per_actor.u1.mbti_axes.E_I !== null);
+  } finally {
+    delete process.env.VC_AXES_ITER;
+  }
+});
+
+test('buildVcSnapshot: config.use_axes_iter2=false overrides env ON', () => {
+  process.env.VC_AXES_ITER = '2';
+  try {
+    const session = {
+      session_id: 's1',
+      units: UNITS,
+      events: [ev('u1', 'attack', { target_id: 'u2', result: 'miss' })],
+      grid: { width: 6 },
+    };
+    // Explicit false should respect caller over env.
+    const config = { ...loadTelemetryConfig(), use_axes_iter2: false };
+    const snap = buildVcSnapshot(session, config);
+    // With iter1 on 1 attack + no move, E_I should be null (requires
+    // close_engage + support_bias + time_to_commit chain).
+    const ei = snap.per_actor.u1.mbti_axes.E_I;
+    // iter1 path — E_I may be partial/null depending on raw; just assert it's
+    // different from iter2 result (iter2 would be derivable from attack).
+    // Fallback: axes.E_I coverage 'partial' or null (iter1 needs more data).
+    assert.ok(ei === null || ei.coverage !== 'full' || ei.value !== 0);
+  } finally {
+    delete process.env.VC_AXES_ITER;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Backward compat guard: iter1 computeMbtiAxes signature unchanged.
+// ---------------------------------------------------------------------------
+test('backward compat: iter1 computeMbtiAxes still works with new raw keys', () => {
+  const axes = computeMbtiAxes({
+    close_engage: 0.3,
+    support_bias: 0.2,
+    time_to_commit: 0.4,
+    new_tiles: 0.5,
+    setup_ratio: 0.4,
+    evasion_ratio: 0.3,
+    utility_actions: 0.5,
+    // iter2 keys present but iter1 ignores them
+    enemy_target_ratio: 0.9,
+    concrete_action_ratio: 0.1,
+    action_switch_rate: 0.9,
+  });
+  // iter1 E_I fully derivable with these inputs
+  assert.ok(axes.E_I !== null);
+  assert.equal(axes.E_I.coverage, 'full');
+});


### PR DESCRIPTION
## Summary

- Handoff 2026-04-26 **Opzione A originale**: refine formule MBTI con raw metrics canoniche per-handoff spec
- **Additive + opt-in** feature flag: iter2 OFF di default, zero regressione su iter1 + tests + downstream (Forms eligibility, Ennea)
- Permette A/B via env `VC_AXES_ITER=2` o `config.use_axes_iter2=true` per comparative playtest

## Nuove raw metrics

| Metric | Formula | Proxy axis |
|---|---|---|
| `enemy_target_ratio` | `events_targeting_enemy / events_with_target` | E_I (Extraversion) |
| `concrete_action_ratio` | `(attacks + moves) / (attacks + moves + abilities)` | S_N (Sensing) |
| `action_switch_rate` | `action_switches / (iter2_total - 1)` | J_P (Perceiving) |

## Formule iter2 axes

| Axis | iter1 (current) | iter2 (new) |
|---|---|---|
| E_I | `1 - 0.5×close_engage - 0.25×support - 0.25×(1-time_to_commit)` | `1 - enemy_target_ratio` |
| S_N | `1 - 0.4×new_tiles + 0.3×setup - 0.3×evasion` | `concrete_action_ratio` |
| T_F | `1 - 0.5×utility + 0.5×support` | **invariato** |
| J_P | `1 - 0.75×setup - 0.25×time_to_commit` | `1 - action_switch_rate` |

## Gating

```js
const iter2 =
  config?.use_axes_iter2 === true ||
  (config?.use_axes_iter2 === undefined && process.env.VC_AXES_ITER === '2');
```

Explicit `use_axes_iter2: false` overrides env ON (test isolation + forced-iter1 path).

## Test plan

- [x] `node --test tests/services/vcScoringIter2.test.js` → **18/18 pass**
- [x] Regression `tests/services/vcScoring.test.js` → **26/26 pass** (iter1 invariato)
- [x] Regression `sessionEndResponse + sessionDifficulty + campaignRoutes` → **32/32 pass**
- [x] `npm run format:check` → verde
- [ ] Playtest A/B iter1 vs iter2 per calibrazione empirica (userland, ~2h)

## Rollback

Revert PR. Gating OFF-default garantisce che flag non-settato = comportamento pre-PR identico. iter1 formule/tests invariate. Storage raw metrics nuove additive (non rimuove raw esistenti).

## Pilastro 4 status

🟡+ (post Thought Cabinet PR #1702) → **🟡++** (due percorsi axes live, A/B-ready). Bump 🟢 definitivo gate playtest comparative validation.

## Note

Risolta controversia handoff: iter1 axes E_I/S_N/J_P **già shipped** usavano proxy indiretti (close_engage/setup_ratio/evasion/new_tiles). Handoff Opzione A chiedeva semantic diretta (enemy target %, concrete %, switch %). Entrambe ora coesistono per evidence-based selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)