### PR TITLE
feat(deploy): Render backend + Cloudflare Pages frontend (ADR-2026-04-26)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,6 +327,12 @@ Primary working directory is on Windows, but the shell is bash (Git Bash/MSYS) �
 - **Pilastro 2 status**: 🔴 → 🟡 (Phase A) → 🟡+ (Phase B) → **🟡++** (Phase C) → 🟢 candidato post-Phase D
 - **Handoff doc**: [`docs/planning/2026-04-24-next-session-kickoff-m12-phase-d.md`](docs/planning/2026-04-24-next-session-kickoff-m12-phase-d.md)
 
+**Sessione 2026-04-25 P3.B + P6.B + verify sweep (3 PR)**:
+
+- **PR #1696 merged** `9319eedd` — Verification post-merge: registry 3 new docs (2 ADR + 1 handoff) + workstream fix `planning` → `cross-cutting`. Governance 0 errors. Baseline 467/467.
+- **PR #1697 merged** `a462d4d5` — M13 P3 Phase B: campaign advance XP grant hook (survivors+xp_per_unit opzionali, response.xp_grants[]). Session /start applyProgressionToUnits (stat bonuses + \_perk_passives/ability_mods). Combat resolver 5 passive tags wired (flank_bonus, first_strike_bonus, execution_bonus, isolated_target_bonus, long_range_bonus). Frontend progressionPanel overlay (pattern formsPanel) + header btn 📈 Lv + auto-open on leveled_up. Balance pass 448 builds validated. **Pilastro 3**: 🟡+ → **🟢 candidato**. +24 test.
+- **PR #1698 merged** `135b5b1f` — M13 P6 Phase B: calibration harness Python tools/py/batch_calibrate_hardcore07.py (N=10 target win 30-50%, execution userland). HUD timer countdown bottom-right overlay + CSS @keyframes mt-pulse (red warning + strikethrough expired). Campaign auto-timeout: state.lastMissionTimer cache → advance override outcome='timeout' quando timer.expired. **Pilastro 6**: 🟡+ → **🟢 candidato**. +10 test.
+
 **Sessione 2026-04-24 M12.D + M13.P3 + M13.P6 (3 PR)**:
 
 - **PR #1693 merged** `2cfd4540` — M12 Phase D: campaign `/advance` response += `evolve_opportunity` additive flag (victory + pe_earned ≥ 8). `main.js refresh` fire-and-forget `api.vc(sid)` → `state.vcSnapshot` pipe. `formsPanel.onEvolveSuccess` callback → `pushPopup('🧬 ' + form_id)` + `flashUnit` + `sfx.select`. Prisma write-through adapter `FormSessionState` model + migration 0003 + graceful in-memory fallback. **Pilastro 2**: 🟡++ → **🟢 candidato**. +10 test (27 campaignRoutes + 6 formSessionStorePrisma).
@@ -349,16 +355,16 @@ Revisione honest post-M7 + deep-audit Explore agent. Statuses precedenti 6/6 �
 - `docs/planning/2026-04-20-pilastri-reality-audit.md` — breakdown dettagliato per Pilastro.
 - `docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md` — roadmap 3-sprint con pattern proven (Wesnoth + XCOM + Jackbox + Long War).
 
-| #   | Pilastro                     |                       Stato                        |
-| --- | ---------------------------- | :------------------------------------------------: |
-| 1   | Tattica leggibile (FFT)      |                         🟢                         |
-| 2   | Evoluzione emergente (Spore) |  🟢 candidato (Phase D shipped, playtest pending)  |
-| 3   | Identità Specie × Job        | 🟡+ (engine + 84 perks live, resolver/UI pending)  |
-| 4   | Temperamenti MBTI/Ennea      |                         🟡                         |
-| 5   | Co-op vs Sistema             |             🟡 (playtest pending → 🟢)             |
-| 6   | Fairness                     | 🟡+ (timer engine live, calibration + HUD pending) |
+| #   | Pilastro                     |                        Stato                         |
+| --- | ---------------------------- | :--------------------------------------------------: |
+| 1   | Tattica leggibile (FFT)      |                          🟢                          |
+| 2   | Evoluzione emergente (Spore) |   🟢 candidato (Phase D shipped, playtest pending)   |
+| 3   | Identità Specie × Job        |   🟢 candidato (Phase B shipped, playtest gating)    |
+| 4   | Temperamenti MBTI/Ennea      |                          🟡                          |
+| 5   | Co-op vs Sistema             |              🟡 (playtest pending → 🟢)              |
+| 6   | Fairness                     | 🟢 candidato (Phase B shipped, calibration userland) |
 
-**Score**: 1/6 🟢 + 1/6 🟢 candidato + 3/6 🟡+ + 2/6 🟡 (zero 🔴).
+**Score**: 1/6 🟢 + **3/6 🟢 candidato** + 2/6 🟡 (zero 🔴).
 
 **Gap principali + evidence-based strategy**:
 

--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const path = require('node:path');
 const fs = require('node:fs/promises');
+const fsSync = require('node:fs');
 const { IdeaRepository, normaliseList } = require('./storage');
 const { buildCodexReport } = require('./report');
 const { createBiomeSynthesizer } = require('../../services/generation/biomeSynthesizer');
@@ -374,6 +375,28 @@ function createApp(options = {}) {
 
   const publicDir = options.publicDir || path.resolve(__dirname, 'public');
   app.use(express.static(publicDir));
+
+  // Demo one-tunnel mode: serve built apps/play/dist at /play.
+  // Opt-in via options.playDist or env PLAY_DIST_PATH. Missing dir = silent skip.
+  const playDist =
+    options.playDist || process.env.PLAY_DIST_PATH || path.resolve(__dirname, '..', 'play', 'dist');
+  try {
+    if (fsSync.existsSync(playDist) && fsSync.statSync(playDist).isDirectory()) {
+      // Runtime config for frontend — injects WS resolution hint.
+      // Shared mode (LOBBY_WS_SHARED=true) → frontend uses same-origin /ws.
+      // Dedicated mode → falls back to VITE env / port 3341.
+      const sameOrigin = process.env.LOBBY_WS_SHARED === 'true';
+      app.get('/play/runtime-config.js', (_req, res) => {
+        res
+          .type('application/javascript')
+          .send(`window.LOBBY_WS_SAME_ORIGIN=${sameOrigin ? 'true' : 'false'};\n`);
+      });
+      app.use('/play', express.static(playDist));
+      console.log(`[play-static] serving ${playDist} at /play (ws-same-origin=${sameOrigin})`);
+    }
+  } catch {
+    // silent: dist not built, dev flow via Vite still works
+  }
 
   // V1 pattern: plugin-based service registration
   loadPlugins(app, BUILTIN_PLUGINS, options);

--- a/apps/backend/index.js
+++ b/apps/backend/index.js
@@ -41,15 +41,10 @@ const { app, lobby } = createApp({
 //   HTTP :3334 (this backend), Vite :5180, calibration :3340.
 // Override via LOBBY_WS_PORT env; disable via LOBBY_WS_ENABLED=false.
 const wsEnabled = process.env.LOBBY_WS_ENABLED !== 'false';
+const wsShared = process.env.LOBBY_WS_SHARED === 'true';
 const wsPort = Number.parseInt(process.env.LOBBY_WS_PORT || '3341', 10);
 const wsHost = process.env.LOBBY_WS_HOST || host;
 let lobbyWs = null;
-if (wsEnabled && lobby) {
-  lobbyWs = createWsServer({ lobby, port: wsPort });
-  console.log(`[lobby-ws] WebSocket server online on ws://${wsHost}:${wsPort}/ws`);
-} else {
-  console.log('[lobby-ws] WebSocket server disabled (LOBBY_WS_ENABLED=false)');
-}
 
 // Issue #1342: avverti se ORCHESTRATOR_AUTOCLOSE_MS e' settato in modo
 // che potrebbe rompere il backend live (valori bassi pensati per i test).
@@ -68,6 +63,20 @@ const autocloseStatus = (() => {
 })();
 
 const server = http.createServer(app);
+
+// WS server: shared mode (single port for demo/ngrok) or dedicated port.
+if (wsEnabled && lobby) {
+  if (wsShared) {
+    lobbyWs = createWsServer({ lobby, server });
+    console.log(`[lobby-ws] WebSocket server attached to HTTP server on /ws (shared mode)`);
+  } else {
+    lobbyWs = createWsServer({ lobby, port: wsPort });
+    console.log(`[lobby-ws] WebSocket server online on ws://${wsHost}:${wsPort}/ws`);
+  }
+} else {
+  console.log('[lobby-ws] WebSocket server disabled (LOBBY_WS_ENABLED=false)');
+}
+
 server.listen(port, host, () => {
   console.log(`[idea-engine] API online su http://${host}:${port}`);
   console.log(`[idea-engine] Database URL: ${databaseUrl ? '[set]' : '[missing]'}`);

--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -12,6 +12,8 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="/src/style.css" />
+    <!-- Demo one-tunnel: runtime WS hint (no-op if dev Vite or static /play absent) -->
+    <script src="runtime-config.js" onerror="void 0"></script>
   </head>
   <body>
     <div id="app">

--- a/apps/play/lobby.html
+++ b/apps/play/lobby.html
@@ -10,6 +10,8 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Noto+Sans:wght@400;600;700&display=swap"
       rel="stylesheet"
     />
+    <!-- Demo one-tunnel: runtime WS hint (no-op if dev Vite or static /play absent) -->
+    <script src="runtime-config.js" onerror="void 0"></script>
     <style>
       :root {
         --bg: #0b0d12;

--- a/apps/play/public/_headers
+++ b/apps/play/public/_headers
@@ -1,0 +1,14 @@
+# Cloudflare Pages headers — Evo-Tactics play frontend
+# Forza HTTPS + cache assets + CORS su runtime-config.
+
+/*
+  X-Frame-Options: SAMEORIGIN
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/runtime-config.js
+  Cache-Control: no-store
+  Access-Control-Allow-Origin: *

--- a/apps/play/public/_redirects
+++ b/apps/play/public/_redirects
@@ -1,0 +1,6 @@
+# Cloudflare Pages redirects — SPA-like fallback per sub-route.
+# Index = game shell, /lobby.html = room picker.
+# Nessuna 404, fall-through su index per route non fisici.
+
+/lobby  /lobby.html  200
+/play   /index.html  200

--- a/apps/play/src/network.js
+++ b/apps/play/src/network.js
@@ -401,8 +401,31 @@ export function clearLobbySession() {
   }
 }
 
-/** Resolve the WS URL: VITE env if defined, else same-origin ws:// with port 3341. */
+/**
+ * Resolve the WS URL. Priority (demo one-tunnel friendly):
+ *   1. URL query `?ws=wss://...` (shareable override, per-session)
+ *   2. `window.LOBBY_WS_URL` (runtime injection, e.g. inline <script>)
+ *   3. `window.LOBBY_WS_SAME_ORIGIN === true` → same-origin `/ws` (shared HTTP+WS)
+ *   4. VITE_LOBBY_WS_URL (build-time env)
+ *   5. same-origin host with port 3341 (default dedicated-port backend)
+ */
 export function resolveWsUrl() {
+  if (typeof window !== 'undefined' && window.location) {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const q = params.get('ws');
+      if (q) return q;
+    } catch {
+      // noop
+    }
+    if (typeof window.LOBBY_WS_URL === 'string' && window.LOBBY_WS_URL) {
+      return window.LOBBY_WS_URL;
+    }
+    if (window.LOBBY_WS_SAME_ORIGIN === true) {
+      const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+      return `${proto}//${window.location.host}/ws`;
+    }
+  }
   try {
     if (typeof import.meta !== 'undefined' && import.meta.env?.VITE_LOBBY_WS_URL) {
       return import.meta.env.VITE_LOBBY_WS_URL;

--- a/docs/adr/ADR-2026-04-26-hosting-stack-decision.md
+++ b/docs/adr/ADR-2026-04-26-hosting-stack-decision.md
@@ -1,0 +1,123 @@
+---
+title: 'ADR 2026-04-26 — Hosting stack decision: Render (pilot) + Cloudflare Pages + Durable Objects (M14)'
+workstream: cross-cutting
+category: adr
+status: accepted
+owner: master-dd
+created: 2026-04-26
+tags:
+  - adr
+  - hosting
+  - deploy
+  - render
+  - cloudflare
+  - m11
+  - m14
+related:
+  - docs/adr/ADR-2026-04-20-m11-jackbox-phase-a.md
+  - docs/playtest/2026-04-26-demo-one-command.md
+---
+
+# ADR 2026-04-26 — Hosting stack co-op online
+
+Decisione infra dopo research approfondito free-tier 2026. Filosofia applicata: `02_LIBRARY/01_Foundation_and_System.md` (Reference→Adattamento→Workflow) + `06_OpenCode_Ollama_Local_Cloud_Workflow.md` ("Locale prima. Cloud dopo. Cloud solo se porta valore reale").
+
+## Contesto
+
+TKT-M11B-06 playtest live richiede URL stabile 24/7. ngrok tunnel laptop-host è demo-only. Vincoli user:
+
+1. **Budget**: free tier obbligatorio
+2. **Persistenza**: scelta migliore ("se serve")
+3. **Mobile**: desktop-first, PWA dopo
+4. **Dominio**: subdomain provider OK
+
+## Verità first principles
+
+- **Verità gioco**: 1 host + 4-8 amici room live → 1 nodo logico per room
+- **Verità sistema**: WS long-lived + state in-memory → NO serverless stateless (Vercel fn, Lambda)
+- **Verità repo**: `LobbyService` class isomorfa a DurableObject → migration path pulita futura
+
+## Opzioni considerate (research 2026-04-26)
+
+| Provider                       | Free perpetual? | WS  | Verdict                                          |
+| ------------------------------ | :-------------: | :-: | ------------------------------------------------ |
+| Fly.io                         |       ❌        | ✅  | Trial 7gg only (rimosso 2024-10)                 |
+| Railway                        |       ❌        | ✅  | $5/mese minimo post trial 30gg                   |
+| Koyeb                          |       ⚠️        | ✅  | Starter $0 ma no always-on senza Pro $29         |
+| **Render**                     |       ✅        | ✅  | Free + WS msg mantengono alive (Feb 2026 update) |
+| **Cloudflare Durable Objects** |       ✅        | ✅  | 100k req/day + WS hibernation + no cold start    |
+| **Cloudflare Pages** (FE)      |       ✅        | N/A | Unlimited bandwidth, 500 builds/mese             |
+
+Sources: vedi `docs/planning/2026-04-26-hosting-research-brief.md`.
+
+## Decisione
+
+**Stack pilot (M11 close)**:
+
+- **Frontend**: **Cloudflare Pages** — free perpetual, unlimited bandwidth, CDN globale, zero ops
+- **Backend**: **Render free web service** — Express+ws zero refactor, Feb 2026 WS keepalive fix
+
+**Stack M14 long-term (pianificato)**:
+
+- **Backend**: **Cloudflare Durable Objects** (wrapper PartyKit o native) — LobbyService→DO naturale, zero cold start, scaling automatico, natural sharding per-room
+- Trigger: dopo 1-2 playtest userland reali che validano design. Evita rewrite premature.
+
+## Invarianti
+
+1. **Free perpetual** (M11): zero credit-card required, zero scadenza
+2. **WS-first backend**: WS upgrade deve rimanere long-lived, no serverless stateless
+3. **Reversibilità**: path back a laptop+ngrok in <5 min (revert render.yaml)
+4. **Opt-in cloud**: build locale + dev locale invariati (Vite dev + `npm run demo`)
+
+## Deployment architettura
+
+```
+┌─ Player phone ─────┐     ┌─ Player phone ─────┐
+│ browser → HTTPS   │     │ browser → HTTPS   │
+└──────┬──────────────┘     └──────┬──────────────┘
+       │                           │
+       ▼                           ▼
+  CDN Cloudflare Pages (apps/play/dist)
+  https://evo-play.pages.dev
+       │ static HTML/JS/CSS
+       │ runtime-config.js → ws URL
+       ▼
+  WSS wss://evo-backend.onrender.com/ws
+       ↕ WebSocket upgrade (shared HTTP+WS)
+  ┌──────────────────────────────────┐
+  │ Render free web service          │
+  │ Node 22 + Express + ws           │
+  │ LobbyService in-memory           │
+  │ LOBBY_WS_SHARED=true             │
+  │ LOBBY_PRISMA_ENABLED=false (M11) │
+  └──────────────────────────────────┘
+```
+
+## Limiti noti Render free tier
+
+- **Cold start 30-60s** primo request dopo 15 min inattività (mitigazione: WS msg keepalive, Feb 2026 update — pingare TV ogni 10min basta)
+- **512MB RAM** — sufficiente per LobbyService + 10 rooms × 8 player
+- **Spin-down** preserva durata build artifact, ma stato in-memory perso. `LOBBY_PRISMA_ENABLED=true` + Postgres free (Neon) se serve recovery. M11 scope = no persist.
+
+## Mobile/PWA readiness (deferred M12)
+
+Desktop-first ora. Mobile checklist pre-beta:
+
+- [ ] `manifest.json` + icons per add-to-home
+- [ ] Service worker cache static assets
+- [ ] `<meta viewport>` + touch targets ≥48px
+- [ ] iOS Safari WS gotcha (background tab kill WS) — reconnect backoff già copre
+
+## Rollback
+
+| Layer      | Rollback                                                             |
+| ---------- | -------------------------------------------------------------------- |
+| Frontend   | Revert CF Pages deploy → precedente commit via git push              |
+| Backend    | Revert Render deploy via dashboard 1-click / `fly.toml` non presente |
+| Full stack | `npm run demo` + `ngrok http 3334` → back a laptop self-host         |
+
+## Riferimenti
+
+- Research brief: `docs/planning/2026-04-26-hosting-research-brief.md`
+- Playbook deploy: `docs/playtest/2026-04-26-deploy-render-cf-pages.md`
+- Filosofia sorgente: `C:\Users\VGit\Desktop\Archivio_Libreria_Operativa_Progetti\02_LIBRARY\01_Foundation_and_System.md` + `06_OpenCode_Ollama_Local_Cloud_Workflow.md`

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -4564,6 +4564,17 @@
       "review_cycle_days": 14
     },
     {
+      "path": "docs/planning/2026-04-26-next-session-kickoff-p4-mbti-playtest.md",
+      "title": "Next session kickoff — P4 MBTI completamento / playtest live gating / Prisma lobby",
+      "doc_status": "draft",
+      "doc_owner": "master-dd",
+      "workstream": "cross-cutting",
+      "last_verified": "2026-04-26",
+      "source_of_truth": false,
+      "language": "it-en",
+      "review_cycle_days": 14
+    },
+    {
       "path": "docs/planning/EVO_FINAL_DESIGN_BACKLOG_REGISTER.md",
       "title": "Evo Final Design — Backlog Register",
       "doc_status": "draft",

--- a/docs/planning/2026-04-26-hosting-research-brief.md
+++ b/docs/planning/2026-04-26-hosting-research-brief.md
@@ -1,0 +1,123 @@
+---
+title: 'Research brief — hosting free tier 2026 (Evo-Tactics M11 co-op)'
+workstream: cross-cutting
+category: research
+status: complete
+owner: master-dd
+created: 2026-04-26
+tags:
+  - research
+  - hosting
+  - free-tier
+  - m11
+related:
+  - docs/adr/ADR-2026-04-26-hosting-stack-decision.md
+---
+
+# Research brief — hosting WS backend + FE static (free tier 2026)
+
+Compilato 2026-04-26 via WebSearch su docs ufficiali (fly.io, railway.com, koyeb.com, render.com, cloudflare.com). Conoscenza pre-cutoff integrata con docs live 2026.
+
+## TL;DR
+
+**Pilot M11**: Render free backend + Cloudflare Pages frontend. Zero refactor, zero budget.
+**M14 long-term**: Cloudflare Durable Objects (via PartyKit wrapper). Zero cold start, natural sharding.
+
+## Free tier reality 2026 — providers verificati
+
+### ❌ Rimossi / no free perpetual
+
+| Provider           | Stato                     | Note                                                     |
+| ------------------ | ------------------------- | -------------------------------------------------------- |
+| Fly.io             | Free tier rimosso 2024-10 | Solo trial 2 VM hour o 7gg. Pay-as-you-go post.          |
+| Railway            | $5/mese minimo            | Trial 30gg con $5 credit, poi Hobby $5/mese obbligatorio |
+| Heroku             | Free rimosso 2022         | —                                                        |
+| Glitch             | Free rimosso 2025 mid     | Progetti as-hosting deprecati                            |
+| Deta Space         | Shutdown 2024 end         | —                                                        |
+| Replit Deployments | No free 2024+             | —                                                        |
+
+### ⚠️ Free con condizioni critiche
+
+| Provider     | Free tier   | Gotcha M11                                     |
+| ------------ | ----------- | ---------------------------------------------- |
+| Koyeb        | Starter $0  | 1 service max, no always-on senza Pro $29/mese |
+| Adaptable.io | Sì          | Sconosciuto WS track record, audit separato    |
+| Northflank   | Sandbox dev | Limiti RAM/CPU stringenti verifica             |
+| Zeabur       | Sì          | Regione Asia, latency EU peggiore              |
+
+### ✅ Free perpetual con WS OK
+
+| Provider                       | Free limits                           | WS verdict                                      |
+| ------------------------------ | ------------------------------------- | ----------------------------------------------- |
+| **Render** (web service)       | 512MB RAM, 750h/mese, spin-down 15min | **WS msg keepalive Feb 2026** → OK 1-3h session |
+| **Cloudflare Workers + DO**    | 100k req/day, 1GB SQLite DO           | **Zero cold start + hibernation API** → optimal |
+| **Cloudflare Pages** (FE only) | Unlimited bandwidth, 500 builds/mese  | Non applicabile WS backend                      |
+
+## Deep dive Render free
+
+- Plan Free: $0/mese, 512MB RAM, 0.1 CPU, 100GB egress
+- Spin-down: dopo **15 min senza traffic** (HTTP **e** WS msg — fix Feb 2026)
+- Cold start: 30-60s primo request post-spin
+- Build: 500 min/mese
+- Region: Frankfurt + Oregon + Singapore disponibili
+- WS: supportato nativo, no config extra richiesta
+
+**Gotcha mitigato**: prima di Feb 2026, solo HTTP teneva alive → WS cadevano mid-session. Ora WS msg bastano. Per playtest 1-3h = sicuro se activity continua.
+
+Workaround extra robustezza: UptimeRobot ping `/api/lobby/state` ogni 5min gratis.
+
+## Deep dive Cloudflare Durable Objects
+
+- **Free tier**: 100k requests/day + 1GB SQLite storage/DO
+- **WS**: `state.acceptWebSocket()` API + hibernation → duration charges evitate post-handler
+- **Pricing ratio 20:1** messaggi WS→request billing
+- **Natural sharding**: 1 room = 1 DO istanza → no shared state across rooms
+- **State persistence**: SQLite built-in, survive restart automaticamente
+
+PartyKit (acquisita CF 2024-04) fornisce wrapper ergonomico: `room.ts` class con lifecycle API.
+
+**Effort migrazione M14**: ~4-6h per riscrivere `LobbyService` → DO, route `/api/lobby/*` → Worker routes. Tests esistenti restano validi (shape API preservata).
+
+## Frontend free tier
+
+| Provider             | Bandwidth  | Builds        | Custom domain   | Verdict                          |
+| -------------------- | ---------- | ------------- | --------------- | -------------------------------- |
+| **Cloudflare Pages** | Unlimited  | 500/mese      | 100/project     | **Raccomandato**                 |
+| Vercel               | 100GB/mese | 6000 min/mese | 100/project     | Buon second-best, CDN US-centric |
+| Netlify              | 100GB/mese | 300 min/mese  | Unlimited       | Build minutes limitati           |
+| GitHub Pages         | 100GB soft | No CI         | 1 custom domain | SPA routing con limiti           |
+
+## Decision matrix
+
+| Criterio          | Render+Pages (A) | DO+Pages (B) |
+| ----------------- | :--------------: | :----------: |
+| Effort deploy (h) |        2         |      5       |
+| Zero refactor     |        ✅        |      ❌      |
+| Zero cold start   |        ❌        |      ✅      |
+| Scale natural     |        ⚠️        |      ✅      |
+| Rollback easy     |        ✅        |      ⚠️      |
+| Free perpetual    |        ✅        |      ✅      |
+
+## Sorgenti verificate 2026-04-26
+
+- Fly.io pricing: https://fly.io/docs/about/pricing/
+- Fly.io community free plan: https://community.fly.io/t/free-plan-clarification/18661
+- Railway pricing: https://railway.com/pricing + https://docs.railway.com/reference/pricing/free-trial
+- Koyeb pricing FAQ: https://www.koyeb.com/docs/faqs/pricing
+- Render WebSockets: https://render.com/docs/websocket
+- Render WS keepalive changelog Feb 2026: https://render.com/changelog/free-web-services-now-remain-active-while-receiving-websocket-messages
+- Render free: https://render.com/docs/free
+- Cloudflare Workers pricing: https://developers.cloudflare.com/workers/platform/pricing/
+- Cloudflare Durable Objects pricing: https://developers.cloudflare.com/durable-objects/platform/pricing/
+- Durable Objects WS: https://developers.cloudflare.com/durable-objects/best-practices/websockets/
+- Cloudflare Pages limits: https://developers.cloudflare.com/pages/platform/limits/
+- Cloudflare acquires PartyKit: https://blog.cloudflare.com/cloudflare-acquires-partykit/
+- PartyKit for Workers: https://github.com/cloudflare/partykit
+
+## Next steps
+
+1. ~~Deploy Render backend via `render.yaml`~~ → PR aperta
+2. ~~Deploy CF Pages frontend via dashboard~~ → PR aperta
+3. Smoke test live URL stabile
+4. Playtest userland 4 amici → chiude P5 🟢 definitivo
+5. M14: rewrite DO dopo 1-2 playtest validation

--- a/docs/planning/2026-04-26-next-session-kickoff-p4-mbti-playtest.md
+++ b/docs/planning/2026-04-26-next-session-kickoff-p4-mbti-playtest.md
@@ -1,0 +1,145 @@
+---
+title: 'Next session kickoff — P4 MBTI completamento / playtest live gating 🟢 / Prisma lobby'
+workstream: cross-cutting
+category: handoff
+status: draft
+owner: master-dd
+created: 2026-04-26
+tags:
+  - kickoff
+  - session-handoff
+  - p4-mbti
+  - playtest-live
+related:
+  - docs/adr/ADR-2026-04-24-p3-character-progression.md
+  - docs/adr/ADR-2026-04-24-p6-hardcore-timeout.md
+  - docs/planning/2026-04-20-pilastri-reality-audit.md
+---
+
+# Next session kickoff — post M13 P3.B + P6.B close
+
+Sessione 2026-04-25 chiude **Phase B stack** (P3 + P6) + verification sweep. **6 PR** totali in main 2026-04-24/25.
+
+## Stack PR 2026-04-24/25
+
+| PR                                                       | Commit     | Scope              |
+| -------------------------------------------------------- | ---------- | ------------------ |
+| [#1693](https://github.com/MasterDD-L34D/Game/pull/1693) | `2cfd4540` | M12 Phase D        |
+| [#1694](https://github.com/MasterDD-L34D/Game/pull/1694) | `24169c41` | M13 P3 Phase A     |
+| [#1695](https://github.com/MasterDD-L34D/Game/pull/1695) | `3e308708` | M13 P6 Phase A     |
+| [#1696](https://github.com/MasterDD-L34D/Game/pull/1696) | `9319eedd` | Verification sweep |
+| [#1697](https://github.com/MasterDD-L34D/Game/pull/1697) | `a462d4d5` | M13 P3 Phase B     |
+| [#1698](https://github.com/MasterDD-L34D/Game/pull/1698) | `135b5b1f` | M13 P6 Phase B     |
+
+## Pilastri post-sessione 2026-04-25
+
+| #   | Stato pre |    Stato post    | Residuo 🟢                                       |
+| --- | :-------: | :--------------: | ------------------------------------------------ |
+| 1   |    🟢     |        🟢        | —                                                |
+| 2   |   🟡++    | **🟢 candidato** | playtest live userland                           |
+| 3   |    🟡     | **🟢 candidato** | playtest live validation pick perk + stat impact |
+| 4   |    🟡     |        🟡        | Disco Elysium diegetic 3 axes (~8h)              |
+| 5   |    🟡     |        🟡        | TKT-M11B-06 playtest ngrok (userland)            |
+| 6   |    🟡     | **🟢 candidato** | calibration N=10 harness execution (userland)    |
+
+**Score**: 1/6 🟢 + **3/6 🟢 candidato** + 2/6 🟡 (zero 🔴).
+
+## Prompt next session
+
+### Opzione A — P4 MBTI completamento 3 axes (~8h autonomous) ⭐ raccomandato
+
+```text
+Leggi:
+- apps/backend/services/vcScoring.js (deriveMbtiType + axes computation)
+- data/core/forms/mbti_forms.yaml (16 forms + axes target)
+- docs/planning/2026-04-20-strategy-m9-m11-evidence-based.md (Disco Elysium pattern)
+
+Task: P4 MBTI completare 3 axes residui (E_I, S_N, J_P).
+
+Scope (~8h):
+1. VC scoring refinement per E_I, S_N, J_P (~2h each = 6h):
+   - E_I: ratio (intents_targeting_enemy) / (total_intents) per extraversion proxy
+   - S_N: ratio (concrete_actions: attack/move) / (abstract: ability/heal/buff) per sensing
+   - J_P: variance nel turn time / round planning change count per judging
+2. Thought Cabinet pattern (~2h):
+   - data/core/thoughts/mbti_thoughts.yaml: 3 axes × 2 poli × 3 soglie = 18 thoughts
+   - Runtime: session.thoughts_unlocked[] cumulativo per unit
+   - UI: tooltip reveal su pick perk / form change
+```
+
+### Opzione B — Playtest live 3 Pilastri 🟢 gating (userland, closes 3 🟢)
+
+Non-autonomous. Richiede user + 2 amici + 1 session ~2h.
+
+```text
+Scenario test (~2h):
+- 1 run enc_tutorial_01-05 (baseline Pilastro 1 🟢 stability)
+- 1 run enc_tutorial_06_hardcore con timer (Pilastro 6 validation)
+- 1 run campaign con pick perk + form evolve (P2 + P3 validation)
+
+Checklist gating:
+- [ ] P2: evolve opportunity flag fires on pe_earned ≥ 8; formsPanel auto-open
+- [ ] P3: leveled_up survivor → progressionPanel auto-open; perk click persists
+- [ ] P6: timer HUD visible bottom-right; warning red pulse @ ≤3 rounds; expired override outcome to timeout
+
+Output: docs/playtest/2026-04-XX-gating-validation.md
+Se 3/3 pass → bump 3 🟢 definitivi + update CLAUDE.md.
+```
+
+### Opzione C — Prisma P3 lobby persistence (~5h autonomous)
+
+```text
+Task: wire Prisma adapter per wsSession lobby rooms.
+
+Scope:
+1. Schema migration LobbyRoom + RoomMember tables
+2. wsSession.Room persistence optional (env LOBBY_PRISMA_ENABLED)
+3. Reconnect dopo restart backend → hydrate rooms dal DB
+```
+
+### Opzione D — Pausa + verifica userland
+
+Esegui playtest live Opzione B manualmente senza AI driving.
+
+## Backlog globale
+
+| Item                                                   |  P  |  Autonomo?  |
+| ------------------------------------------------------ | :-: | :---------: |
+| **P4 MBTI** 3 axes + Thought Cabinet                   | P1  |     ✅      |
+| **Playtest gating** 3 🟢 validation                    | P1  | ❌ userland |
+| **TKT-M11B-06** playtest ngrok co-op                   | P1  | ❌ userland |
+| **Prisma lobby** P3 rooms persistence                  | P2  |     ✅      |
+| **Calibration hardcore 07** N=10 harness execute       | P2  | ❌ userland |
+| **Phase C** ability_mod runtime + passive tags residui | P3  |     ✅      |
+
+## Baseline snapshot post-sessione 2026-04-25
+
+```bash
+cd /c/Users/VGit/Desktop/Game
+git fetch origin main
+node --test tests/ai/*.test.js                                                         # 307/307
+node --test tests/api/progressionEngine.test.js tests/api/progressionRoutes.test.js tests/api/progressionApply.test.js tests/api/progressionBalance.test.js  # 44/44
+node --test tests/api/missionTimer.test.js tests/api/hardcoreScenarioTimer.test.js tests/api/missionTimerHud.test.js  # 27/27
+node --test tests/api/formEvolution.test.js tests/api/formsRoutes.test.js tests/api/formSessionStore.test.js tests/api/packRoller.test.js tests/api/formsRoutesSessionPack.test.js tests/api/formsPanelInfer.test.js tests/api/formSessionStorePrisma.test.js  # 63/63
+node --test tests/api/campaignRoutes.test.js tests/api/campaignIntegration.test.js     # 31/31
+node --test tests/api/lobbyRoutes.test.js tests/api/lobbyWebSocket.test.js              # 15/15
+node --test tests/e2e/lobbyEndToEnd.test.mjs                                            # 11/11
+node --test tests/scripts/tutorialSpeciesExistence.test.js                              # 3/3
+npm run format:check                                                                    # verde
+```
+
+**Grand total**: ~**500+/500+** verde.
+
+## Warning / constraint
+
+- **NON toccare** `apps/backend/routes/session.js` senza justification (guardrail 2000 LOC)
+- **NON toccare** `apps/backend/services/network/wsSession.js` senza ADR addendum
+- **NON committare** binari sotto `reports/backups/**`
+- **Caveman mode** attivo default
+
+## Riferimenti
+
+- Memory sintesi: [`~/.claude/projects/C--Users-VGit-Desktop-Game/memory/project_sprint_m13_session_2026_04_24.md`](file:~/.claude/projects/C--Users-VGit-Desktop-Game/memory/project_sprint_m13_session_2026_04_24.md)
+- ADR P3: [`docs/adr/ADR-2026-04-24-p3-character-progression.md`](../adr/ADR-2026-04-24-p3-character-progression.md)
+- ADR P6: [`docs/adr/ADR-2026-04-24-p6-hardcore-timeout.md`](../adr/ADR-2026-04-24-p6-hardcore-timeout.md)
+- Handoff prec: [`docs/planning/2026-04-25-next-session-kickoff-m13-phase-b.md`](2026-04-25-next-session-kickoff-m13-phase-b.md)

--- a/docs/playtest/2026-04-26-demo-one-command.md
+++ b/docs/playtest/2026-04-26-demo-one-command.md
@@ -1,0 +1,82 @@
+---
+title: 'Demo one-command — single tunnel ngrok playable con amici'
+workstream: playtest
+category: playbook
+status: draft
+owner: master-dd
+created: 2026-04-26
+tags:
+  - demo
+  - ngrok
+  - coop
+  - m11
+  - tkt-m11b-06
+related:
+  - docs/playtest/2026-04-21-m11-coop-ngrok-playbook.md
+  - docs/adr/ADR-2026-04-20-m11-jackbox-phase-a.md
+---
+
+# Demo one-command — playable con amici
+
+Shortcut per il playbook ngrok. **Un comando + un tunnel** grazie a shared HTTP+WS.
+
+## Prerequisiti
+
+- `npm ci` eseguito
+- `ngrok` CLI installato + account free
+- 4 device (phone/browser) + 1 TV/monitor
+
+## One-liner
+
+```bash
+# Terminal 1 — build + start backend (serve /play static + WS su /ws)
+npm run demo
+
+# Terminal 2 — single tunnel
+ngrok http 3334
+# → copia https://<rand>.ngrok-free.app
+```
+
+## Share
+
+- **Host / TV**: `https://<rand>.ngrok-free.app/play/lobby.html`
+  - crea stanza → click "Entra nella TV" → F11 fullscreen
+- **Player** (4x phone): condividi link dalla card host, formato `.../play/lobby.html?code=ABCD`
+
+## Come funziona
+
+- `LOBBY_WS_SHARED=true` (settato da `scripts/run-demo.cjs`) fa attach del `WebSocketServer` all'HTTP server esistente sulla stessa porta 3334, path `/ws`.
+- Backend serve `apps/play/dist` sotto `/play/*` + genera `/play/runtime-config.js` con `window.LOBBY_WS_SAME_ORIGIN=true`.
+- Frontend `resolveWsUrl()` vede il flag → usa `wss://<host-corrente>/ws` → stesso tunnel ngrok, no secondo URL da configurare.
+- Query override disponibile: `?ws=wss://altro-host/ws` (utile per test con backend remoto diverso).
+
+## Modalità classica (2 tunnel, dedicated WS)
+
+Se preferisci WS isolato su porta 3341 (playbook originale):
+
+```bash
+# Terminal 1
+npm run start:api
+# Terminal 2
+npm run play:dev
+# Terminal 3 + 4 — 2 ngrok tunnel (vedi playbook originale)
+```
+
+Vedi [`2026-04-21-m11-coop-ngrok-playbook.md`](2026-04-21-m11-coop-ngrok-playbook.md) per dettaglio.
+
+## Rollback
+
+- `LOBBY_WS_SHARED=false npm run start:api` → back a dedicated port
+- `rm -rf apps/play/dist` → static /play non servito, dev flow via Vite
+
+## Smoke checklist
+
+- [ ] `curl https://<rand>.ngrok-free.app/play/runtime-config.js` → `window.LOBBY_WS_SAME_ORIGIN=true;`
+- [ ] browser devtools Network: WebSocket `wss://<rand>.ngrok-free.app/ws` status 101
+- [ ] host crea stanza → 4-char code
+- [ ] player con `?code=ABCD` vede overlay composer
+- [ ] intent player → host log relay
+
+## Follow-up
+
+Playbook completo metriche + scenari in [`2026-04-21-m11-coop-ngrok-playbook.md`](2026-04-21-m11-coop-ngrok-playbook.md).

--- a/docs/playtest/2026-04-26-deploy-render-cf-pages.md
+++ b/docs/playtest/2026-04-26-deploy-render-cf-pages.md
@@ -1,0 +1,175 @@
+---
+title: 'Deploy playbook — Render backend + Cloudflare Pages frontend (stack pilot M11)'
+workstream: playtest
+category: playbook
+status: draft
+owner: master-dd
+created: 2026-04-26
+tags:
+  - playbook
+  - deploy
+  - render
+  - cloudflare-pages
+  - m11
+  - tkt-m11b-06
+related:
+  - docs/adr/ADR-2026-04-26-hosting-stack-decision.md
+  - docs/playtest/2026-04-26-demo-one-command.md
+---
+
+# Deploy playbook — Render + Cloudflare Pages
+
+Stack pilot **free tier perpetual** per TKT-M11B-06 playtest live. Zero laptop 24/7, URL stabile, no ngrok. ADR: [`ADR-2026-04-26`](../adr/ADR-2026-04-26-hosting-stack-decision.md).
+
+## Prerequisiti
+
+- Account GitHub collegato al repo `MasterDD-L34D/Game`
+- Account **Render** free (sign-up con GitHub, no CC required)
+- Account **Cloudflare** free (sign-up, no CC required)
+- Merge PR #1700 (demo one-tunnel, `LOBBY_WS_SHARED=true`) su main
+
+## Step 1 — Backend su Render (~20 min)
+
+### 1.1 Creazione service
+
+1. Render dashboard → **New** → **Blueprint**
+2. Connect `MasterDD-L34D/Game` → branch `main`
+3. Render legge `render.yaml` → preview service config:
+   - Name: `evo-tactics-backend`
+   - Plan: **Free**
+   - Region: **Frankfurt** (EU vicino)
+   - Build: `npm ci && npm run play:build`
+   - Start: `node apps/backend/index.js`
+   - Healthcheck: `/api/lobby/state`
+4. Click **Apply** → primo deploy ~3-5 min
+
+### 1.2 Env vars (pre-seeded da blueprint)
+
+| Key                     | Value      | Note                                    |
+| ----------------------- | ---------- | --------------------------------------- |
+| `NODE_VERSION`          | 22.19.0    | Match locale                            |
+| `NODE_ENV`              | production |                                         |
+| `LOBBY_WS_ENABLED`      | true       |                                         |
+| `LOBBY_WS_SHARED`       | true       | **Critico**: WS sulla stessa porta HTTP |
+| `LOBBY_PRISMA_ENABLED`  | false      | M11 scope = no persist (attiva in M14)  |
+| `GAME_DATABASE_ENABLED` | false      |                                         |
+| `CORS_ORIGIN`           | `*`        | Tighten post-beta                       |
+
+### 1.3 Verifica
+
+```bash
+# Sostituisci con URL Render reale (dashboard → service → copy URL)
+export BE=https://evo-tactics-backend.onrender.com
+
+curl -sf $BE/api/lobby/state       # {...}
+curl -sf $BE/play/runtime-config.js # window.LOBBY_WS_SAME_ORIGIN=true;
+curl -sf $BE/play/lobby.html | head -5  # <!doctype html>
+```
+
+> **Cold start**: primo request dopo 15 min idle = 30-60s. Keepalive: il servizio resta alive finché ci sono WS messages in corso (Feb 2026 update Render).
+
+## Step 2 — Frontend su Cloudflare Pages (~15 min)
+
+### 2.1 Creazione project
+
+1. Cloudflare dashboard → **Workers & Pages** → **Create** → **Pages** → **Connect to Git**
+2. Seleziona `MasterDD-L34D/Game` → branch `main`
+3. Build config:
+   - **Framework preset**: None
+   - **Build command**: `npm ci && npm run play:build`
+   - **Build output directory**: `apps/play/dist`
+   - **Root directory**: `/` (default)
+4. Env vars build-time:
+
+| Key                 | Value                                       |
+| ------------------- | ------------------------------------------- |
+| `VITE_LOBBY_WS_URL` | `wss://evo-tactics-backend.onrender.com/ws` |
+| `NODE_VERSION`      | `22.19.0`                                   |
+
+5. **Save and Deploy** → primo deploy ~2-3 min
+
+### 2.2 Note runtime-config.js su CF Pages
+
+Il file `/play/runtime-config.js` è backend-served (Render, shared mode). Su CF Pages **404** atteso — gestito via `onerror="void 0"` nei tag `<script>`. La WS URL arriva da `VITE_LOBBY_WS_URL` baked al build.
+
+### 2.3 Verifica
+
+```bash
+export FE=https://evo-tactics.pages.dev  # URL assegnato da Pages
+
+curl -sfI $FE/lobby.html      # 200
+curl -sfI $FE/assets/         # 200 con cache headers _headers
+```
+
+Apri `$FE/lobby.html` → UI carica, crea stanza → WS connect a Render backend.
+
+## Step 3 — Smoke test live (~10 min)
+
+1. **Host**: apri `$FE/lobby.html` → crea stanza → codice 4-char
+2. **Browser Incognito** (simula player): apri stessa URL → join con codice
+3. **Network tab** (player): `WS wss://evo-tactics-backend.onrender.com/ws?code=...` → status **101**
+4. Host side → click "Nuova sessione" → stato broadcast
+5. Player overlay riceve world → compose intent → invia
+6. Host log mostra intent relay
+
+## Step 4 — Share amici (live playtest)
+
+```
+https://evo-tactics.pages.dev/lobby.html
+```
+
+Host entra, crea stanza, condivide link con `?code=XXXX`. 4 amici connettono. Nessun laptop acceso necessario.
+
+## Monitoring
+
+- **Render logs**: dashboard → service → Logs tab (real-time)
+- **Cloudflare Pages**: analytics free (req/bandwidth per deploy)
+- **Uptime**: usa [UptimeRobot](https://uptimerobot.com) free (ping `/api/lobby/state` ogni 5min → previene spin-down durante eventi)
+
+## Cold start mitigation
+
+Render free spin-down 15min idle. Workaround pre-playtest:
+
+```bash
+# 5 min prima del playtest, warmup:
+curl https://evo-tactics-backend.onrender.com/api/lobby/state
+sleep 30
+curl https://evo-tactics-backend.onrender.com/api/lobby/state
+# Service ora warm per ~15 min
+```
+
+## Troubleshooting
+
+| Sintomo                                     | Diagnosi                   | Fix                                                      |
+| ------------------------------------------- | -------------------------- | -------------------------------------------------------- |
+| Player banner `chiuso` subito               | WS URL sbagliato in bundle | Verifica `VITE_LOBBY_WS_URL` in CF Pages env + rebuild   |
+| WS handshake 503                            | Render service spin-down   | Primo request warmup, poi ritry                          |
+| 404 su `/play/runtime-config.js` (CF Pages) | Expected (backend-served)  | `onerror="void 0"` gestisce silently                     |
+| `room_not_found` post-restart               | In-memory lost             | Attiva `LOBBY_PRISMA_ENABLED=true` + Neon Postgres (M14) |
+
+## Rollback
+
+### Rollback frontend
+
+Dashboard CF Pages → Deployments → click precedente deploy → **Rollback**. <30s.
+
+### Rollback backend
+
+Dashboard Render → service → Deploys tab → click precedente → **Redeploy**. ~2 min.
+
+### Rollback full (back a laptop+ngrok)
+
+1. Render: **Suspend** service
+2. CF Pages: disable auto-deploy
+3. Locale: `npm run demo` + `ngrok http 3334` → demo one-tunnel
+
+## Follow-up M14
+
+Path B pianificato: rewrite `LobbyService` → Cloudflare Durable Objects (via PartyKit pattern). Zero cold start + natural sharding. Effort ~4-6h post-playtest validation.
+
+## Riferimenti
+
+- ADR: [`ADR-2026-04-26`](../adr/ADR-2026-04-26-hosting-stack-decision.md)
+- Demo one-tunnel (alternativa laptop): [`docs/playtest/2026-04-26-demo-one-command.md`](2026-04-26-demo-one-command.md)
+- Render docs WS: https://render.com/docs/websocket
+- CF Pages limits: https://developers.cloudflare.com/pages/platform/limits/

--- a/package.json
+++ b/package.json
@@ -46,7 +46,10 @@
     "docs:migrate:dry": "python tools/docs_governance_migrator.py generate-frontmatter --dry-run",
     "docs:migrate:report": "python tools/docs_governance_migrator.py report",
     "play:dev": "npm run dev --workspace apps/play",
-    "play:build": "npm run build --workspace apps/play"
+    "play:build": "npm run build --workspace apps/play",
+    "demo:build": "npm run build --workspace apps/play",
+    "demo:start": "node scripts/run-demo.cjs",
+    "demo": "npm run demo:build && npm run demo:start"
   },
   "lint-staged": {
     "*.{js,cjs,mjs,ts,tsx,jsx,json,md,yml,yaml,css,html}": [

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,49 @@
+# Render Blueprint — Evo-Tactics backend (M11 co-op WS)
+# ADR-2026-04-26 — hosting stack decision (free web service, WS keepalive).
+#
+# Deploy:
+#   1. Commit this file on main (or target branch).
+#   2. Render dashboard → New → Blueprint → connect repo → apply.
+#   3. Env var DATABASE_URL (optional, set if LOBBY_PRISMA_ENABLED=true).
+#   4. Custom domain opzionale.
+#
+# Render free tier:
+#   - 512MB RAM, spin-down 15min idle, WS msg keepalive (Feb 2026 update).
+#   - Build minutes: 500/mese, sufficiente per solo-dev.
+#
+# WS upgrade: LOBBY_WS_SHARED=true attach WS al server HTTP existente
+# sulla stessa PORT esposta da Render (nessun secondo port pubblico).
+#
+# Healthcheck: GET /api/lobby/state (no auth, sempre 200).
+
+services:
+  - type: web
+    name: evo-tactics-backend
+    runtime: node
+    plan: free
+    region: frankfurt
+    branch: main
+    rootDir: .
+    buildCommand: npm ci && npm run play:build
+    startCommand: node apps/backend/index.js
+    healthCheckPath: /api/lobby/state
+    autoDeploy: true
+    envVars:
+      - key: NODE_VERSION
+        value: 22.19.0
+      - key: NODE_ENV
+        value: production
+      - key: LOBBY_WS_ENABLED
+        value: 'true'
+      - key: LOBBY_WS_SHARED
+        value: 'true'
+      - key: LOBBY_PRISMA_ENABLED
+        value: 'false'
+      - key: GAME_DATABASE_ENABLED
+        value: 'false'
+      - key: IDEA_ENGINE_DISABLE_STATUS_REFRESH
+        value: '1'
+      # Render injects PORT automaticamente; backend legge process.env.PORT.
+      # CORS wide open per demo (tighten in prod).
+      - key: CORS_ORIGIN
+        value: '*'

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-23T20:40:47+00:00",
+  "generated_at": "2026-04-23T21:15:45+00:00",
   "summary": {
     "total": 5,
     "errors": 0,

--- a/scripts/run-demo.cjs
+++ b/scripts/run-demo.cjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+// Demo one-tunnel runner: single HTTP+WS server, single ngrok tunnel.
+// Sets LOBBY_WS_SHARED=true so WS attaches to the same HTTP server,
+// and the static /play route advertises same-origin /ws.
+
+const { spawn } = require('node:child_process');
+const path = require('node:path');
+
+process.env.LOBBY_WS_SHARED = 'true';
+process.env.LOBBY_WS_ENABLED = process.env.LOBBY_WS_ENABLED || 'true';
+
+const backendEntry = path.resolve(__dirname, '..', 'apps', 'backend', 'index.js');
+const child = spawn(process.execPath, [backendEntry], {
+  stdio: 'inherit',
+  env: process.env,
+});
+
+const forward = (sig) => () => {
+  if (!child.killed) child.kill(sig);
+};
+process.on('SIGINT', forward('SIGINT'));
+process.on('SIGTERM', forward('SIGTERM'));
+
+child.on('exit', (code) => process.exit(code ?? 0));

--- a/tests/api/resolveWsUrl.test.mjs
+++ b/tests/api/resolveWsUrl.test.mjs
@@ -1,0 +1,57 @@
+// Unit tests for resolveWsUrl runtime priority (demo one-tunnel support).
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const ORIGINAL_WINDOW = globalThis.window;
+
+function setWindow({
+  protocol = 'https:',
+  host = 'demo.ngrok-free.app',
+  search = '',
+  extra = {},
+} = {}) {
+  globalThis.window = {
+    location: { protocol, host, hostname: host.split(':')[0], search },
+    ...extra,
+  };
+}
+
+async function importFresh() {
+  const url = new URL('../../apps/play/src/network.js', import.meta.url);
+  return import(`${url.href}?t=${Date.now()}_${Math.random()}`);
+}
+
+test.afterEach(() => {
+  globalThis.window = ORIGINAL_WINDOW;
+});
+
+test('resolveWsUrl: query ?ws= overrides everything', async () => {
+  setWindow({
+    search: '?ws=wss://override.example/ws',
+    extra: { LOBBY_WS_URL: 'wss://ignored/ws' },
+  });
+  const { resolveWsUrl } = await importFresh();
+  assert.equal(resolveWsUrl(), 'wss://override.example/ws');
+});
+
+test('resolveWsUrl: window.LOBBY_WS_URL beats same-origin flag', async () => {
+  setWindow({ extra: { LOBBY_WS_URL: 'wss://runtime/ws', LOBBY_WS_SAME_ORIGIN: true } });
+  const { resolveWsUrl } = await importFresh();
+  assert.equal(resolveWsUrl(), 'wss://runtime/ws');
+});
+
+test('resolveWsUrl: same-origin flag → wss://<host>/ws (no port 3341)', async () => {
+  setWindow({
+    protocol: 'https:',
+    host: 'demo.ngrok-free.app',
+    extra: { LOBBY_WS_SAME_ORIGIN: true },
+  });
+  const { resolveWsUrl } = await importFresh();
+  assert.equal(resolveWsUrl(), 'wss://demo.ngrok-free.app/ws');
+});
+
+test('resolveWsUrl: default → same hostname with port 3341', async () => {
+  setWindow({ protocol: 'http:', host: 'localhost:5180' });
+  const { resolveWsUrl } = await importFresh();
+  assert.equal(resolveWsUrl(), 'ws://localhost:3341/ws');
+});


### PR DESCRIPTION
## Summary

Free tier perpetual stack per playtest live 24/7, zero laptop. Rebase post-merge #1700.

**Pilot M11**: Render free + CF Pages free (2h deploy, zero refactor)
**M14 long-term**: Cloudflare Durable Objects

## Files

- render.yaml: blueprint Node 22 Frankfurt + env LOBBY_WS_SHARED=true
- apps/play/public/_headers + _redirects: CF Pages routing + cache
- docs/adr/ADR-2026-04-26-hosting-stack-decision.md
- docs/planning/2026-04-26-hosting-research-brief.md
- docs/playtest/2026-04-26-deploy-render-cf-pages.md

## Test plan

- [x] prettier verde
- [ ] Deploy Render dashboard smoke
- [ ] Deploy CF Pages smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)