### PR TITLE
fix(deploy): npm ci --include=dev per installare vite su Render

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -24,7 +24,9 @@ services:
     region: frankfurt
     branch: main
     rootDir: .
-    buildCommand: npm ci && npm run play:build
+    # --include=dev forza install devDependencies anche con NODE_ENV=production
+    # (vite sta in apps/play/devDependencies — serve al build).
+    buildCommand: npm ci --include=dev && npm run play:build
     startCommand: node apps/backend/index.js
     healthCheckPath: /api/lobby/state
     autoDeploy: true


### PR DESCRIPTION
Bug: NODE_ENV=production fa skippare devDependencies. Vite in apps/play/devDeps → build fallito exit 127.

Fix: flag --include=dev forza install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)