### PR TITLE
feat(launcher): 1-click demo launcher (backend + ngrok + share URL)

### DIFF
--- a/Evo-Tactics-Demo.bat
+++ b/Evo-Tactics-Demo.bat
@@ -1,0 +1,36 @@
+@echo off
+REM 1-click demo launcher. Copia questo file sul Desktop.
+REM Avvia backend demo + ngrok tunnel + stampa URL per amici.
+
+cd /d "%~dp0"
+title Evo-Tactics Demo Launcher
+echo ====================================================
+echo   Evo-Tactics - demo launcher
+echo ====================================================
+echo.
+
+REM Verifica node
+where node >nul 2>&1
+if errorlevel 1 (
+    echo [errore] node non trovato. Installa Node.js 22+.
+    pause
+    exit /b 1
+)
+
+REM Build play se dist mancante
+if not exist "apps\play\dist\lobby.html" (
+    echo [setup] build frontend mancante, eseguo npm run play:build...
+    call npm run play:build
+    if errorlevel 1 (
+        echo [errore] build fallito.
+        pause
+        exit /b 1
+    )
+)
+
+echo [avvio] backend + ngrok tunnel...
+node scripts/run-demo-tunnel.cjs
+
+echo.
+echo [fine] demo terminata.
+pause

--- a/docs/playtest/2026-04-26-demo-launcher.md
+++ b/docs/playtest/2026-04-26-demo-launcher.md
@@ -1,0 +1,84 @@
+---
+title: 'Demo launcher 1-click — setup ngrok + desktop shortcut'
+workstream: playtest
+category: playbook
+status: draft
+owner: master-dd
+created: 2026-04-26
+tags:
+  - launcher
+  - demo
+  - ngrok
+  - windows
+related:
+  - docs/playtest/2026-04-26-demo-one-command.md
+---
+
+# Demo launcher 1-click
+
+Zero terminali. Doppio clic icona Desktop → backend + ngrok + URL amici.
+
+## Setup one-time
+
+1. Installa ngrok: https://ngrok.com/download
+2. Account ngrok free: https://dashboard.ngrok.com/signup
+3. Authtoken: https://dashboard.ngrok.com/get-started/your-authtoken → copia
+4. PowerShell:
+   ```powershell
+   ngrok config add-authtoken <TOKEN>
+   ```
+
+## Crea shortcut Desktop
+
+**Opzione A**: copia `Evo-Tactics-Demo.bat` sul Desktop. Doppio clic = go.
+
+**Opzione B** (shortcut vero):
+
+1. Tasto destro Desktop → Nuovo → **Collegamento**
+2. Percorso: `C:\Users\VGit\Desktop\Game\Evo-Tactics-Demo.bat`
+3. Nome: `Evo-Tactics Demo`
+4. Icona custom: tasto destro → Proprietà → Cambia icona
+
+## Uso quotidiano
+
+1. Doppio clic `Evo-Tactics-Demo` sul Desktop
+2. Attendi ~15-30s setup (prima volta builda frontend, poi istantaneo)
+3. Banner ASCII grande stampa URL tipo:
+
+   ```
+   ========================================================================
+     🦴 EVO-TACTICS DEMO LIVE
+
+     Host (tu): https://abcd.ngrok-free.dev/play/lobby.html
+     Share amici: https://abcd.ngrok-free.dev/play/lobby.html
+   ========================================================================
+   ```
+
+4. Copia URL → share WhatsApp/Discord amici
+5. Tu entri come host, amici come player con codice 4-letter
+6. Fine playtest: `Ctrl+C` nella finestra = stop tutto
+
+## Troubleshooting
+
+| Sintomo                          | Fix                                             |
+| -------------------------------- | ----------------------------------------------- |
+| `ngrok non trovato`              | Installa da ngrok.com, riavvia PowerShell dopo  |
+| `Impossibile recuperare URL` 90s | Controlla http://localhost:4040 dashboard ngrok |
+| Build `play` fail al primo run   | Verifica `npm ci` fatto almeno una volta        |
+| Amici vedono warning page ngrok  | Click `Visit site`, normale per free tier       |
+
+## Limiti ngrok free
+
+- URL cambia ogni restart
+- Max 40 connessioni/min (OK per 4-8 player)
+- Tunnel muore se spegni laptop
+
+## Alternative
+
+- Script equivalente: `npm run demo:tunnel` da terminale
+- Stack cloud stabile: Render + CF Pages (ADR-2026-04-26), URL fisso 24/7
+
+## Note security
+
+- Token ngrok è personal — mai commitare in repo. `~/.ngrok2/ngrok.yml` lo tiene.
+- Lobby state `*` CORS = OK per demo playtest. Tighten in prod.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "play:build": "npm run build --workspace apps/play",
     "demo:build": "npm run build --workspace apps/play",
     "demo:start": "node scripts/run-demo.cjs",
-    "demo": "npm run demo:build && npm run demo:start"
+    "demo": "npm run demo:build && npm run demo:start",
+    "demo:tunnel": "node scripts/run-demo-tunnel.cjs"
   },
   "lint-staged": {
     "*.{js,cjs,mjs,ts,tsx,jsx,json,md,yml,yaml,css,html}": [

--- a/scripts/run-demo-tunnel.cjs
+++ b/scripts/run-demo-tunnel.cjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+// 1-click demo launcher: backend shared HTTP+WS + ngrok tunnel.
+// Print big banner con share URL pronto per gli amici.
+
+const { spawn } = require('node:child_process');
+const http = require('node:http');
+const path = require('node:path');
+
+const PORT = 3334;
+const NGROK_API = 'http://127.0.0.1:4040/api/tunnels';
+
+process.env.LOBBY_WS_SHARED = 'true';
+process.env.LOBBY_WS_ENABLED = 'true';
+
+const backendEntry = path.resolve(__dirname, '..', 'apps', 'backend', 'index.js');
+
+const banner = (msg) => {
+  const line = '='.repeat(72);
+  console.log(`\n${line}\n${msg}\n${line}\n`);
+};
+
+console.log('[launcher] avvio backend demo (shared HTTP+WS)...');
+const backend = spawn(process.execPath, [backendEntry], {
+  stdio: 'inherit',
+  env: process.env,
+});
+
+console.log('[launcher] avvio ngrok tunnel su porta ' + PORT + '...');
+const ngrok = spawn('ngrok', ['http', String(PORT), '--log=stdout'], {
+  stdio: ['ignore', 'pipe', 'pipe'],
+  env: process.env,
+  shell: process.platform === 'win32',
+});
+
+ngrok.on('error', (err) => {
+  console.error('\n[launcher] ERRORE: ngrok non trovato. Installa da https://ngrok.com/download');
+  console.error('         Dopo installazione: ngrok config add-authtoken <TUO-TOKEN>');
+  console.error('         Error:', err.message);
+  backend.kill();
+  process.exit(1);
+});
+
+// ngrok log buffer per debug
+ngrok.stdout?.on('data', () => {});
+ngrok.stderr?.on('data', () => {});
+
+let printed = false;
+async function pollTunnel() {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    await new Promise((r) => setTimeout(r, 1500));
+    try {
+      const url = await new Promise((resolve, reject) => {
+        const req = http.get(NGROK_API, (res) => {
+          let body = '';
+          res.on('data', (c) => (body += c));
+          res.on('end', () => {
+            try {
+              const data = JSON.parse(body);
+              const tunnels = data.tunnels || [];
+              const https = tunnels.find((t) => t.public_url?.startsWith('https'));
+              resolve(https?.public_url || null);
+            } catch (e) {
+              reject(e);
+            }
+          });
+        });
+        req.on('error', reject);
+        req.setTimeout(1000, () => {
+          req.destroy();
+          resolve(null);
+        });
+      });
+      if (url) return url;
+    } catch {
+      // noop, ritenta
+    }
+  }
+  return null;
+}
+
+pollTunnel().then((url) => {
+  if (!url) {
+    console.error('\n[launcher] Impossibile recuperare URL ngrok dopo 90s.');
+    console.error('          Controlla dashboard ngrok: http://localhost:4040');
+    return;
+  }
+  printed = true;
+  const shareUrl = `${url}/play/lobby.html`;
+  banner(
+    `  🦴 EVO-TACTICS DEMO LIVE\n\n` +
+      `  Host (tu): ${shareUrl}\n` +
+      `  Share amici: ${shareUrl}\n\n` +
+      `  Dashboard ngrok: http://localhost:4040\n` +
+      `  Ctrl+C per fermare tutto`,
+  );
+});
+
+const shutdown = () => {
+  console.log('\n[launcher] stop...');
+  try {
+    backend.kill();
+  } catch {}
+  try {
+    ngrok.kill();
+  } catch {}
+  process.exit(0);
+};
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+
+backend.on('exit', (code) => {
+  console.log(`[launcher] backend exit ${code}`);
+  try {
+    ngrok.kill();
+  } catch {}
+  process.exit(code ?? 0);
+});
+
+ngrok.on('exit', (code) => {
+  if (!printed) {
+    console.error(`[launcher] ngrok exit ${code} prima di stampare URL.`);
+  }
+  try {
+    backend.kill();
+  } catch {}
+  process.exit(code ?? 0);
+});


### PR DESCRIPTION
Zero-terminal launcher per demo playtest. Doppio clic .bat sul desktop → tutto up.

- scripts/run-demo-tunnel.cjs: spawn backend + ngrok + poll API + banner URL
- Evo-Tactics-Demo.bat: Windows desktop shortcut
- package.json: npm run demo:tunnel
- docs/playtest/2026-04-26-demo-launcher.md: setup + troubleshooting

🤖 Generated with [Claude Code](https://claude.com/claude-code)