### PR TITLE
fix(play): vite base './' per asset path relativi (fix 404 /play mount)

### DIFF
--- a/apps/play/vite.config.js
+++ b/apps/play/vite.config.js
@@ -8,6 +8,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..', '..');
 
 export default defineConfig({
+  // base relativa: asset path risolvibili sotto qualsiasi mount (/play/ o /).
+  // Fix: HTML bundled referenzia /assets/... absolute ma backend serve
+  // sotto /play/assets/... → 404. Con './' diventa assets/ relativi.
+  base: './',
   server: {
     port: 5180,
     host: '127.0.0.1',


### PR DESCRIPTION
Fix 404 JS quando backend serve apps/play/dist sotto /play/. Root cause "Crea stanza" silently failing.

Verified: POST /api/lobby/create 201 post-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)