### PR TITLE
feat(coop-m16): P0 fixes + coopOrchestrator skeleton (sprint M16 complete)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -706,7 +706,28 @@ function createSessionRouter(options = {}) {
       const sessionId = newSessionId();
       const now = new Date();
       const logFilePath = path.join(logsDir, `session_${timestampStamp(now)}.json`);
-      let units = normaliseUnitsPayload(req.body?.units);
+
+      // M16 P0-1 (ADR coop-mvp-spec): if `characters` array provided, convert
+      // each character → unit with owner_id = player_id. Enemies from scenario
+      // appended via req.body.units. Both coexist: characters first, then
+      // units (scenario enemies) appended.
+      let characterUnits = [];
+      if (Array.isArray(req.body?.characters) && req.body.characters.length > 0) {
+        const { characterToUnit } = require('../services/coop/coopOrchestrator');
+        characterUnits = req.body.characters
+          .map((ch, idx) => characterToUnit(ch, { index: idx }))
+          .filter(Boolean);
+      }
+      const scenarioUnits = normaliseUnitsPayload(req.body?.units);
+      // If character path used, filter out any default player units from
+      // scenarioUnits to avoid duplicates (keep only sistema-controlled).
+      let units;
+      if (characterUnits.length > 0) {
+        const scenarioEnemies = scenarioUnits.filter((u) => u && u.controlled_by === 'sistema');
+        units = [...normaliseUnitsPayload(characterUnits), ...scenarioEnemies];
+      } else {
+        units = scenarioUnits;
+      }
 
       // Q-001 T2.3 PR-3: applica difficulty profile scaling (opt-in, default normal)
       const requestedProfile =

--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -88,6 +88,11 @@ function normaliseUnit(raw, fallbackIndex) {
     facing,
     position,
     controlled_by: input.controlled_by ? String(input.controlled_by) : 'player',
+    // M16 P0-1 — owner_id mapping player→unit per co-op Jackbox flow.
+    // Set solo per unità player-controlled; enemy restano null.
+    owner_id: input.owner_id ? String(input.owner_id) : null,
+    name: input.name ? String(input.name) : null,
+    form_id: input.form_id ? String(input.form_id) : null,
     resistance_archetype: resistanceArchetype,
   };
 }

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -1,0 +1,231 @@
+// M16 — coopOrchestrator skeleton (ADR-2026-04-26-m15 / coop-mvp-spec.md).
+// Phase machine + character creation + world setup + combat wiring + debrief.
+// Skeleton only: interface defined, wire implementations M17-M19.
+
+'use strict';
+
+const PHASES = ['lobby', 'character_creation', 'world_setup', 'combat', 'debrief', 'ended'];
+
+/**
+ * Build a unit payload for /session/start from a coop character spec.
+ * Used by M16 fix P0-1 (PG mapping to player_id).
+ */
+function characterToUnit(character, { index = 0 } = {}) {
+  if (!character || typeof character !== 'object') return null;
+  const job = character.job_id || character.job || 'guerriero';
+  return {
+    id: character.unit_id || `pg_${character.player_id || index}`,
+    name: character.name || 'PG',
+    species: character.species_id || 'unknown',
+    job,
+    form_id: character.form_id || null,
+    owner_id: character.player_id || null,
+    controlled_by: 'player',
+    hp: character.hp || character.hp_max || 22,
+    max_hp: character.hp_max || character.hp || 22,
+    ap: character.ap_max || 2,
+    traits: Array.isArray(character.traits) ? character.traits : [],
+    position: character.position || { x: index, y: 0 },
+  };
+}
+
+class CoopOrchestrator {
+  constructor({ roomCode, hostId, now = Date.now }) {
+    if (!roomCode) throw new Error('room_code_required');
+    this.roomCode = roomCode;
+    this.hostId = hostId || null;
+    this.now = now;
+    this.phase = 'lobby';
+    this.run = null; // populated by startRun()
+    this.characters = new Map(); // player_id → character spec
+    this.worldVotes = new Map(); // player_id → scenario_id|null
+    this.debriefChoices = new Map();
+    this.log = [];
+    this._listeners = new Set();
+  }
+
+  _emit(kind, payload = {}) {
+    const evt = { kind, payload, ts: this.now(), phase: this.phase };
+    this.log.push(evt);
+    if (this.log.length > 500) this.log.shift();
+    for (const cb of this._listeners) {
+      try {
+        cb(evt);
+      } catch {
+        // swallow
+      }
+    }
+    return evt;
+  }
+
+  on(cb) {
+    if (typeof cb !== 'function') return () => {};
+    this._listeners.add(cb);
+    return () => this._listeners.delete(cb);
+  }
+
+  _setPhase(next) {
+    if (!PHASES.includes(next)) throw new Error(`invalid_phase:${next}`);
+    if (this.phase === next) return;
+    const prev = this.phase;
+    this.phase = next;
+    this._emit('phase_change', { from: prev, to: next });
+  }
+
+  /**
+   * Start a new run. Moves phase lobby → character_creation.
+   */
+  startRun({ scenarioStack = ['enc_tutorial_01'] } = {}) {
+    if (this.phase !== 'lobby' && this.phase !== 'ended') {
+      throw new Error(`cannot_start_from_phase:${this.phase}`);
+    }
+    this.run = {
+      id: `run_${Date.now().toString(36)}`,
+      scenarioStack: Array.isArray(scenarioStack) ? scenarioStack : ['enc_tutorial_01'],
+      currentIndex: 0,
+      partyXp: 0,
+      partyPi: 0,
+      outcome: null,
+    };
+    this.characters.clear();
+    this.worldVotes.clear();
+    this.debriefChoices.clear();
+    this._setPhase('character_creation');
+    this._emit('run_started', { run_id: this.run.id });
+    return this.run;
+  }
+
+  /**
+   * Submit character spec for a player. When all expected players
+   * have submitted, auto-transition to world_setup.
+   *
+   * @param playerId
+   * @param spec — { name, form_id, species_id, job_id? }
+   * @param allPlayerIds — set of player ids expected to participate
+   */
+  submitCharacter(playerId, spec, { allPlayerIds = [] } = {}) {
+    if (this.phase !== 'character_creation') {
+      throw new Error('not_in_character_creation');
+    }
+    if (!playerId) throw new Error('player_id_required');
+    if (!spec || !spec.form_id || !spec.name) {
+      throw new Error('spec_invalid');
+    }
+    const normalized = {
+      player_id: playerId,
+      name: String(spec.name).slice(0, 30),
+      form_id: String(spec.form_id),
+      species_id: spec.species_id ? String(spec.species_id) : null,
+      job_id: spec.job_id ? String(spec.job_id) : 'guerriero',
+      ready: true,
+      submitted_at: this.now(),
+    };
+    this.characters.set(playerId, normalized);
+    this._emit('character_ready', normalized);
+
+    const expected = new Set(allPlayerIds.filter(Boolean));
+    if (expected.size > 0 && expected.size === this.characters.size) {
+      const allReady = Array.from(expected).every((pid) => this.characters.has(pid));
+      if (allReady) this._setPhase('world_setup');
+    }
+    return normalized;
+  }
+
+  /**
+   * Return the current character list ready-state snapshot.
+   */
+  characterReadyList(allPlayerIds = []) {
+    return allPlayerIds.map((pid) => {
+      const ch = this.characters.get(pid);
+      return {
+        player_id: pid,
+        name: ch?.name || null,
+        form_id: ch?.form_id || null,
+        species_id: ch?.species_id || null,
+        ready: Boolean(ch?.ready),
+      };
+    });
+  }
+
+  /**
+   * Confirm scenario for this run. Moves phase world_setup → combat.
+   * Voting logic deferred to M17 (host confirm for MVP).
+   */
+  confirmWorld({ scenarioId } = {}) {
+    if (this.phase !== 'world_setup') throw new Error('not_in_world_setup');
+    const sid = scenarioId || this.run?.scenarioStack?.[this.run.currentIndex];
+    if (!sid) throw new Error('scenario_required');
+    this.run.scenarioStack[this.run.currentIndex] = sid;
+    this._emit('world_confirmed', { scenario_id: sid });
+    this._setPhase('combat');
+    return { scenario_id: sid };
+  }
+
+  /**
+   * Build the /session/start payload from current characters.
+   * Used by M17+ host handler that forwards to existing session route.
+   */
+  buildSessionStartPayload() {
+    const units = [];
+    let idx = 0;
+    for (const ch of this.characters.values()) {
+      units.push(characterToUnit(ch, { index: idx++ }));
+    }
+    return { units };
+  }
+
+  /**
+   * Mark combat outcome. Moves phase combat → debrief.
+   */
+  endCombat({ outcome = 'victory', survivors = [], xpEarned = 0 } = {}) {
+    if (this.phase !== 'combat') throw new Error('not_in_combat');
+    this.run.outcome = outcome;
+    this.run.partyXp += xpEarned;
+    this._emit('combat_ended', { outcome, survivors, xp: xpEarned });
+    this._setPhase('debrief');
+    return { outcome, xp: xpEarned };
+  }
+
+  /**
+   * Submit debrief choice for player. When all submitted, advance.
+   */
+  submitDebriefChoice(playerId, choice, { allPlayerIds = [] } = {}) {
+    if (this.phase !== 'debrief') throw new Error('not_in_debrief');
+    this.debriefChoices.set(playerId, choice);
+    this._emit('debrief_choice', { player_id: playerId, choice });
+    const expected = new Set(allPlayerIds.filter(Boolean));
+    if (expected.size > 0 && this.debriefChoices.size >= expected.size) {
+      return this.advanceScenarioOrEnd();
+    }
+    return null;
+  }
+
+  advanceScenarioOrEnd() {
+    if (!this.run) throw new Error('no_run');
+    this.run.currentIndex += 1;
+    if (this.run.currentIndex >= this.run.scenarioStack.length) {
+      this._setPhase('ended');
+      this._emit('run_ended', { run_id: this.run.id });
+      return { action: 'ended' };
+    }
+    this.characters.forEach((ch) => {
+      ch.ready = true; // carry over
+    });
+    this.debriefChoices.clear();
+    this.worldVotes.clear();
+    this._setPhase('world_setup');
+    return { action: 'next_scenario', index: this.run.currentIndex };
+  }
+
+  snapshot() {
+    return {
+      roomCode: this.roomCode,
+      phase: this.phase,
+      run: this.run,
+      characters: Array.from(this.characters.values()),
+      log: this.log.slice(-50),
+    };
+  }
+}
+
+module.exports = { CoopOrchestrator, characterToUnit, PHASES };

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -278,6 +278,13 @@ class Room {
       if (this.pendingIntents.has(p.id)) ready.push(p.id);
       else missing.push(p.id);
     }
+    const allReady = missing.length === 0 && participants.length > 0;
+    // M16 P0-3 — auto-transition planning → ready quando tutti hanno
+    // inviato intent. Host vede phase=ready e drive resolve via REST;
+    // dopo invia round_clear per reset (nextRound planning).
+    if (allReady && this.phase === 'planning') {
+      this.phase = 'ready';
+    }
     this.broadcast({
       type: 'round_ready',
       payload: {
@@ -286,7 +293,7 @@ class Room {
         ready,
         missing,
         total: participants.length,
-        all_ready: missing.length === 0 && participants.length > 0,
+        all_ready: allReady,
         ts: Date.now(),
       },
     });

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -1176,6 +1176,21 @@ async function triggerCommitRound() {
           logEl,
           `✓ round ${state.world?.turn || '?'} risolto (${allActions.length} azioni)`,
         );
+        // M16 P0-2 — co-op Jackbox flow: host notifica clear round intents
+        // post-resolve. Reset pending map server-side + avanza roundIndex +
+        // broadcast round_ready con phase=planning ai player.
+        if (
+          lobbyBridge?.isHost &&
+          lobbyBridge?.client &&
+          typeof lobbyBridge.client.sendRoundClear === 'function'
+        ) {
+          try {
+            lobbyBridge.client.sendRoundClear();
+          } catch (e) {
+            // non-blocking — legacy flow OK se WS down
+            if (typeof console !== 'undefined') console.warn('[main] sendRoundClear', e);
+          }
+        }
       } catch (err) {
         appendLog(logEl, `✖ refresh dopo round: ${err?.message || err}`, 'error');
         await emergencyResetRound();

--- a/tests/api/coopOrchestrator.test.js
+++ b/tests/api/coopOrchestrator.test.js
@@ -1,0 +1,129 @@
+// M16 — coopOrchestrator skeleton unit tests.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  CoopOrchestrator,
+  characterToUnit,
+  PHASES,
+} = require('../../apps/backend/services/coop/coopOrchestrator');
+
+test('PHASES covers lobby→character_creation→world_setup→combat→debrief→ended', () => {
+  assert.deepEqual(PHASES, [
+    'lobby',
+    'character_creation',
+    'world_setup',
+    'combat',
+    'debrief',
+    'ended',
+  ]);
+});
+
+test('startRun transitions lobby → character_creation', () => {
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  assert.equal(co.phase, 'lobby');
+  const run = co.startRun({ scenarioStack: ['enc_tutorial_01'] });
+  assert.equal(co.phase, 'character_creation');
+  assert.ok(run.id.startsWith('run_'));
+  assert.deepEqual(run.scenarioStack, ['enc_tutorial_01']);
+});
+
+test('submitCharacter stores spec + advances when all players ready', () => {
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  co.startRun();
+  const all = ['p_a', 'p_b'];
+  co.submitCharacter('p_a', { name: 'Aria', form_id: 'istj_custode' }, { allPlayerIds: all });
+  assert.equal(co.phase, 'character_creation');
+  co.submitCharacter('p_b', { name: 'Bruno', form_id: 'enfp_catalysta' }, { allPlayerIds: all });
+  assert.equal(co.phase, 'world_setup');
+  const list = co.characterReadyList(all);
+  assert.equal(list.length, 2);
+  assert.ok(list.every((c) => c.ready));
+});
+
+test('submitCharacter rejects invalid spec', () => {
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  co.startRun();
+  assert.throws(() => co.submitCharacter('p_a', { name: 'X' }), /spec_invalid/);
+  assert.throws(() => co.submitCharacter('p_a', { form_id: 'istj' }), /spec_invalid/);
+  assert.throws(() => co.submitCharacter(null, { name: 'X', form_id: 'y' }), /player_id_required/);
+});
+
+test('confirmWorld transitions world_setup → combat', () => {
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  co.startRun();
+  const all = ['p_a'];
+  co.submitCharacter('p_a', { name: 'Aria', form_id: 'istj' }, { allPlayerIds: all });
+  const res = co.confirmWorld({ scenarioId: 'enc_tutorial_01' });
+  assert.equal(co.phase, 'combat');
+  assert.equal(res.scenario_id, 'enc_tutorial_01');
+});
+
+test('endCombat + submitDebriefChoice advance scenario or end', () => {
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  co.startRun({ scenarioStack: ['enc_tutorial_01', 'enc_tutorial_02'] });
+  const all = ['p_a'];
+  co.submitCharacter('p_a', { name: 'Aria', form_id: 'istj' }, { allPlayerIds: all });
+  co.confirmWorld();
+  co.endCombat({ outcome: 'victory', xpEarned: 10 });
+  assert.equal(co.phase, 'debrief');
+  const result = co.submitDebriefChoice('p_a', { choice: 'skip' }, { allPlayerIds: all });
+  assert.equal(result.action, 'next_scenario');
+  assert.equal(co.phase, 'world_setup');
+  assert.equal(co.run.currentIndex, 1);
+});
+
+test('run ends after last scenario', () => {
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  co.startRun({ scenarioStack: ['enc_tutorial_01'] });
+  const all = ['p_a'];
+  co.submitCharacter('p_a', { name: 'Aria', form_id: 'istj' }, { allPlayerIds: all });
+  co.confirmWorld();
+  co.endCombat({ outcome: 'victory' });
+  const result = co.submitDebriefChoice('p_a', { choice: 'skip' }, { allPlayerIds: all });
+  assert.equal(result.action, 'ended');
+  assert.equal(co.phase, 'ended');
+});
+
+test('buildSessionStartPayload produces units with owner_id', () => {
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  co.startRun();
+  const all = ['p_a', 'p_b'];
+  co.submitCharacter(
+    'p_a',
+    { name: 'Aria', form_id: 'istj_custode', species_id: 'scagliato', job_id: 'guerriero' },
+    { allPlayerIds: all },
+  );
+  co.submitCharacter('p_b', { name: 'Bruno', form_id: 'enfp' }, { allPlayerIds: all });
+  co.confirmWorld();
+  const payload = co.buildSessionStartPayload();
+  assert.equal(payload.units.length, 2);
+  assert.equal(payload.units[0].owner_id, 'p_a');
+  assert.equal(payload.units[0].name, 'Aria');
+  assert.equal(payload.units[0].controlled_by, 'player');
+  assert.equal(payload.units[1].owner_id, 'p_b');
+});
+
+test('characterToUnit standalone helper', () => {
+  const u = characterToUnit({
+    player_id: 'p_a',
+    name: 'Aria',
+    form_id: 'istj',
+    species_id: 'scagliato',
+    job_id: 'vanguard',
+  });
+  assert.equal(u.owner_id, 'p_a');
+  assert.equal(u.controlled_by, 'player');
+  assert.equal(u.name, 'Aria');
+  assert.equal(u.species, 'scagliato');
+  assert.equal(u.job, 'vanguard');
+});
+
+test('log captures phase_change + run_started events', () => {
+  const co = new CoopOrchestrator({ roomCode: 'ABCD' });
+  co.startRun();
+  const kinds = co.log.map((e) => e.kind);
+  assert.ok(kinds.includes('phase_change'));
+  assert.ok(kinds.includes('run_started'));
+});


### PR DESCRIPTION
Chiude fase M16 da coop-migration-plan.md. Sblocca M17 (character creation UI).

## Fix P0

- **P0-1** PG mapping player_id: session.js /start accetta characters[] → units con owner_id
- **P0-2** Host round_clear post-resolve (main.js)
- **P0-3** Auto phase transition planning→ready (wsSession)

## Nuovo modulo

apps/backend/services/coop/coopOrchestrator.js skeleton (6 fasi phase machine + character/world/combat/debrief helpers).

## Test

- 10/10 coopOrchestrator lifecycle + validazione
- 30/30 regression lobby+WS+e2e verde
- Smoke live POST /api/session/start con characters OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)