### PR TITLE
feat(coop-m17): character creation phase — phone card PG + REST coop router

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -23,6 +23,8 @@ const { createFeedbackRouter } = require('./routes/feedback');
 const { createPartyRouter } = require('./routes/party');
 const { createCampaignRouter } = require('./routes/campaign');
 const { createLobbyRouter } = require('./routes/lobby');
+const { createCoopRouter } = require('./routes/coop');
+const { createCoopStore } = require('./services/coop/coopStore');
 const { LobbyService } = require('./services/network/wsSession');
 const { createNebulaTelemetryAggregator } = require('./services/nebulaTelemetryAggregator');
 const { createReleaseReporter } = require('./services/releaseReporter');
@@ -721,6 +723,9 @@ function createApp(options = {}) {
   }
   const lobby = lobbyOptions.service || new LobbyService(lobbyOptions);
   app.use('/api', createLobbyRouter({ lobby }));
+  // M17 — Co-op run orchestrator (character creation + world setup + debrief).
+  const coopStore = createCoopStore({ lobby });
+  app.use('/api', createCoopRouter({ lobby, coopStore }));
 
   app.get('/api/deployments/status', async (req, res) => {
     try {

--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -1,0 +1,187 @@
+// M17 — Co-op REST endpoints (character creation MVP).
+// ADR coop-mvp-spec.md §2.7 user stories.
+//
+// Endpoints:
+//   POST /api/coop/run/start              (host — starts a run in a room)
+//   POST /api/coop/character/create        (player — submit char spec)
+//   GET  /api/coop/state?code=ABCD         (any — inspect phase + characters)
+//   POST /api/coop/world/confirm           (host — pick scenario, move to combat)
+//   POST /api/coop/debrief/choice          (player — submit debrief choice)
+
+'use strict';
+
+const express = require('express');
+
+function createCoopRouter({ lobby, coopStore } = {}) {
+  if (!lobby) throw new Error('createCoopRouter: lobby required');
+  if (!coopStore) throw new Error('createCoopRouter: coopStore required');
+  const router = express.Router();
+
+  function authHost(roomCode, hostToken) {
+    if (!roomCode || !hostToken) return null;
+    const room = lobby.getRoom(roomCode);
+    if (!room) return null;
+    const host = room.getPlayer?.(room.hostId);
+    if (!host || host.token !== hostToken) return null;
+    return room;
+  }
+
+  function authPlayer(roomCode, playerId, playerToken) {
+    if (!roomCode || !playerId || !playerToken) return null;
+    const room = lobby.getRoom(roomCode);
+    if (!room) return null;
+    const p = room.authenticate?.(playerId, playerToken);
+    return p ? { room, player: p } : null;
+  }
+
+  function allPlayerIds(room) {
+    return Array.from(room.players.values())
+      .filter((p) => p.id !== room.hostId && p.role !== 'host')
+      .map((p) => p.id);
+  }
+
+  function broadcastCoopState(room, orch) {
+    if (!room || typeof room.broadcast !== 'function') return;
+    room.broadcast({
+      type: 'phase_change',
+      payload: {
+        phase: orch.phase,
+        round: orch.run?.currentIndex ?? 0,
+        scenario: orch.run?.scenarioStack?.[orch.run.currentIndex] || null,
+      },
+    });
+    room.broadcast({
+      type: 'character_ready_list',
+      payload: orch.characterReadyList(allPlayerIds(room)),
+    });
+  }
+
+  router.post('/coop/run/start', (req, res) => {
+    const { code, host_token: hostToken, scenario_stack: scenarioStack } = req.body || {};
+    const room = authHost(code, hostToken);
+    if (!room) return res.status(403).json({ error: 'host_auth_failed' });
+    try {
+      const orch = coopStore.getOrCreate(code);
+      const run = orch.startRun({ scenarioStack });
+      broadcastCoopState(room, orch);
+      return res.status(201).json({
+        run_id: run.id,
+        phase: orch.phase,
+        scenario_stack: run.scenarioStack,
+      });
+    } catch (err) {
+      return res.status(400).json({ error: err.message || 'run_start_failed' });
+    }
+  });
+
+  router.post('/coop/character/create', (req, res) => {
+    const {
+      code,
+      player_id: playerId,
+      player_token: playerToken,
+      name,
+      form_id,
+      species_id,
+      job_id,
+    } = req.body || {};
+    const auth = authPlayer(code, playerId, playerToken);
+    if (!auth) return res.status(403).json({ error: 'player_auth_failed' });
+    const { room } = auth;
+    const orch = coopStore.get(code);
+    if (!orch) return res.status(409).json({ error: 'run_not_started' });
+    try {
+      const spec = orch.submitCharacter(
+        playerId,
+        { name, form_id, species_id, job_id },
+        { allPlayerIds: allPlayerIds(room) },
+      );
+      broadcastCoopState(room, orch);
+      return res.status(201).json({
+        character: spec,
+        phase: orch.phase,
+        ready_count: orch.characters.size,
+      });
+    } catch (err) {
+      return res.status(400).json({ error: err.message || 'character_create_failed' });
+    }
+  });
+
+  router.get('/coop/state', (req, res) => {
+    const code = req.query.code;
+    const orch = code ? coopStore.get(code) : null;
+    if (!orch) return res.status(404).json({ error: 'coop_state_not_found' });
+    const room = lobby.getRoom(code);
+    return res.json({
+      snapshot: orch.snapshot(),
+      character_ready_list: room ? orch.characterReadyList(allPlayerIds(room)) : [],
+    });
+  });
+
+  router.post('/coop/world/confirm', (req, res) => {
+    const { code, host_token: hostToken, scenario_id: scenarioId } = req.body || {};
+    const room = authHost(code, hostToken);
+    if (!room) return res.status(403).json({ error: 'host_auth_failed' });
+    const orch = coopStore.get(code);
+    if (!orch) return res.status(409).json({ error: 'run_not_started' });
+    try {
+      const result = orch.confirmWorld({ scenarioId });
+      broadcastCoopState(room, orch);
+      // Return session-start payload so host can forward to /api/session/start.
+      const startPayload = orch.buildSessionStartPayload();
+      return res.json({
+        scenario_id: result.scenario_id,
+        phase: orch.phase,
+        session_start_payload: startPayload,
+      });
+    } catch (err) {
+      return res.status(400).json({ error: err.message || 'world_confirm_failed' });
+    }
+  });
+
+  router.post('/coop/debrief/choice', (req, res) => {
+    const { code, player_id: playerId, player_token: playerToken, choice } = req.body || {};
+    const auth = authPlayer(code, playerId, playerToken);
+    if (!auth) return res.status(403).json({ error: 'player_auth_failed' });
+    const { room } = auth;
+    const orch = coopStore.get(code);
+    if (!orch) return res.status(409).json({ error: 'run_not_started' });
+    try {
+      const result = orch.submitDebriefChoice(playerId, choice, {
+        allPlayerIds: allPlayerIds(room),
+      });
+      broadcastCoopState(room, orch);
+      return res.json({
+        phase: orch.phase,
+        result: result || { pending: true },
+      });
+    } catch (err) {
+      return res.status(400).json({ error: err.message || 'debrief_failed' });
+    }
+  });
+
+  router.post('/coop/combat/end', (req, res) => {
+    // Host notifies combat ended (victory/defeat). MVP: host controls.
+    const {
+      code,
+      host_token: hostToken,
+      outcome = 'victory',
+      xp_earned: xpEarned = 0,
+      survivors = [],
+    } = req.body || {};
+    const room = authHost(code, hostToken);
+    if (!room) return res.status(403).json({ error: 'host_auth_failed' });
+    const orch = coopStore.get(code);
+    if (!orch) return res.status(409).json({ error: 'run_not_started' });
+    try {
+      const result = orch.endCombat({ outcome, xpEarned, survivors });
+      broadcastCoopState(room, orch);
+      return res.json({ phase: orch.phase, result });
+    } catch (err) {
+      return res.status(400).json({ error: err.message || 'combat_end_failed' });
+    }
+  });
+
+  return router;
+}
+
+module.exports = { createCoopRouter };

--- a/apps/backend/services/coop/coopStore.js
+++ b/apps/backend/services/coop/coopStore.js
@@ -1,0 +1,48 @@
+// M17 — coopStore: Map roomCode → CoopOrchestrator.
+// In-memory per MVP. Prisma adapter opzionale M20.
+
+'use strict';
+
+const { CoopOrchestrator } = require('./coopOrchestrator');
+
+function createCoopStore({ lobby } = {}) {
+  const orchestrators = new Map();
+
+  function getOrCreate(roomCode) {
+    if (!roomCode) throw new Error('room_code_required');
+    const code = String(roomCode).toUpperCase();
+    if (!orchestrators.has(code)) {
+      const room = lobby?.getRoom?.(code);
+      orchestrators.set(
+        code,
+        new CoopOrchestrator({
+          roomCode: code,
+          hostId: room?.hostId || null,
+        }),
+      );
+    }
+    return orchestrators.get(code);
+  }
+
+  function get(roomCode) {
+    if (!roomCode) return null;
+    return orchestrators.get(String(roomCode).toUpperCase()) || null;
+  }
+
+  function remove(roomCode) {
+    if (!roomCode) return false;
+    return orchestrators.delete(String(roomCode).toUpperCase());
+  }
+
+  function list() {
+    return Array.from(orchestrators.keys());
+  }
+
+  function clear() {
+    orchestrators.clear();
+  }
+
+  return { getOrCreate, get, remove, list, clear };
+}
+
+module.exports = { createCoopStore };

--- a/apps/play/src/api.js
+++ b/apps/play/src/api.js
@@ -195,4 +195,41 @@ export const api = {
     jsonFetch(`/api/v1/progression/campaign/${encodeURIComponent(campaignId)}`, {
       method: 'DELETE',
     }),
+  // M17 Co-op — run + character + world + debrief + combat end
+  coopRunStart: (code, hostToken, scenarioStack = ['enc_tutorial_01']) =>
+    jsonFetch('/api/coop/run/start', {
+      method: 'POST',
+      body: JSON.stringify({ code, host_token: hostToken, scenario_stack: scenarioStack }),
+    }),
+  coopCharacterCreate: (code, playerId, playerToken, spec) =>
+    jsonFetch('/api/coop/character/create', {
+      method: 'POST',
+      body: JSON.stringify({
+        code,
+        player_id: playerId,
+        player_token: playerToken,
+        ...spec,
+      }),
+    }),
+  coopState: (code) => jsonFetch(`/api/coop/state?code=${encodeURIComponent(code)}`),
+  coopWorldConfirm: (code, hostToken, scenarioId) =>
+    jsonFetch('/api/coop/world/confirm', {
+      method: 'POST',
+      body: JSON.stringify({ code, host_token: hostToken, scenario_id: scenarioId }),
+    }),
+  coopDebriefChoice: (code, playerId, playerToken, choice) =>
+    jsonFetch('/api/coop/debrief/choice', {
+      method: 'POST',
+      body: JSON.stringify({
+        code,
+        player_id: playerId,
+        player_token: playerToken,
+        choice,
+      }),
+    }),
+  coopCombatEnd: (code, hostToken, payload = {}) =>
+    jsonFetch('/api/coop/combat/end', {
+      method: 'POST',
+      body: JSON.stringify({ code, host_token: hostToken, ...payload }),
+    }),
 };

--- a/apps/play/src/characterCreation.css
+++ b/apps/play/src/characterCreation.css
@@ -1,0 +1,308 @@
+/* M17 — Character creation overlay (phone). Dark game-y, mobile-first. */
+
+.char-creation-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9550;
+  background: radial-gradient(ellipse at top, #1a1027 0%, #050108 75%);
+  overflow-y: auto;
+  font-family: Inter, system-ui, sans-serif;
+  color: #e8eaf0;
+}
+
+.char-creation-overlay.cc-hidden {
+  display: none !important;
+}
+
+.cc-wrap {
+  max-width: 560px;
+  margin: 0 auto;
+  padding: 14px 16px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.cc-phase {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: linear-gradient(180deg, #2a1540 0%, #1a1027 100%);
+  border: 1px solid #7e57c2;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.45);
+  font-weight: 600;
+}
+
+.cc-phase-icon {
+  font-size: 1.6rem;
+}
+.cc-phase-label {
+  flex: 1;
+}
+.cc-phase-progress {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #b39ddb;
+  letter-spacing: 1px;
+}
+
+.cc-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cc-label {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+  color: #b39ddb;
+  font-weight: 700;
+}
+
+.cc-wrap input[type='text'] {
+  padding: 14px 16px;
+  font-size: 1.05rem;
+  background: #151922;
+  border: 1px solid #2a3040;
+  border-radius: 10px;
+  color: #e8eaf0;
+  font-family: inherit;
+}
+
+.cc-wrap input[type='text']:focus {
+  outline: none;
+  border-color: #7e57c2;
+}
+
+.cc-wrap input[type='text']:disabled {
+  opacity: 0.5;
+}
+
+.cc-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 6px;
+}
+
+.cc-grid-small {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.cc-card {
+  background: #1d2230;
+  border: 1px solid #2a3040;
+  border-radius: 10px;
+  padding: 10px 8px;
+  color: #e8eaf0;
+  font-family: inherit;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: center;
+  text-align: center;
+  transition:
+    background 0.12s,
+    border 0.12s,
+    transform 0.08s;
+  min-height: 66px;
+}
+
+.cc-card:active {
+  transform: scale(0.97);
+}
+
+.cc-card:hover:not(:disabled) {
+  background: #2a3040;
+  border-color: #7e57c2;
+}
+
+.cc-card:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.cc-card.selected {
+  background: #2a1540;
+  border-color: #b39ddb;
+  box-shadow: 0 0 0 2px rgba(179, 157, 219, 0.3);
+}
+
+.cc-card-title {
+  font-weight: 700;
+  font-size: 0.92rem;
+  line-height: 1.1;
+}
+
+.cc-card-sub {
+  font-size: 0.7rem;
+  color: #9575cd;
+  letter-spacing: 1px;
+  font-weight: 600;
+}
+
+.cc-card-blurb {
+  font-size: 0.72rem;
+  color: #8891a3;
+}
+
+.cc-preview {
+  background: #0b0d12;
+  border: 1px solid #2a3040;
+  border-radius: 12px;
+  padding: 12px 14px;
+}
+
+.cc-preview-title {
+  font-size: 0.78rem;
+  color: #8891a3;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-bottom: 6px;
+  font-weight: 700;
+}
+
+.cc-preview-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 6px;
+}
+
+.cc-preview-stats span {
+  background: #151922;
+  padding: 8px 6px;
+  border-radius: 6px;
+  text-align: center;
+  font-weight: 600;
+  font-size: 0.85rem;
+  border: 1px solid #2a3040;
+}
+
+.cc-confirm {
+  padding: 16px;
+  font-size: 1.05rem;
+  font-weight: 700;
+  border-radius: 12px;
+  border: 1px solid #7e57c2;
+  background: #7e57c2;
+  color: #ffffff;
+  cursor: pointer;
+  font-family: inherit;
+  transition:
+    background 0.15s,
+    opacity 0.15s;
+  min-height: 56px;
+}
+
+.cc-confirm:hover:not(:disabled) {
+  background: #9575cd;
+}
+
+.cc-confirm:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+  background: #2a3040;
+  color: #8891a3;
+  border-color: #2a3040;
+}
+
+.cc-status {
+  min-height: 1.2em;
+  font-size: 0.9rem;
+  text-align: center;
+  color: #8891a3;
+}
+.cc-status[data-kind='ok'] {
+  color: #66bb6a;
+}
+.cc-status[data-kind='err'] {
+  color: #ef5350;
+}
+
+.cc-party {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.cc-party-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: #1d2230;
+  border: 1px solid #2a3040;
+  border-radius: 10px;
+  font-size: 0.9rem;
+}
+
+.cc-party-row.ready {
+  border-color: #7e57c2;
+  background: linear-gradient(90deg, #2a1540 0%, #1d2230 70%);
+}
+
+.cc-party-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #8891a3;
+  flex-shrink: 0;
+}
+.cc-party-row.ready .cc-party-dot {
+  background: #b39ddb;
+}
+
+.cc-party-name {
+  flex: 1;
+  font-weight: 600;
+}
+.cc-party-form {
+  font-size: 0.8rem;
+  color: #8891a3;
+}
+.cc-party-row.ready .cc-party-form {
+  color: #b39ddb;
+}
+
+.cc-empty {
+  padding: 12px;
+  text-align: center;
+  color: #8891a3;
+  font-size: 0.85rem;
+  font-style: italic;
+}
+
+@media (min-width: 900px) {
+  .cc-wrap {
+    max-width: 700px;
+  }
+}
+
+/* Phase waiting overlay (transient between phases) */
+.phase-waiting-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9600;
+  background: rgba(8, 10, 16, 0.88);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  font-family: Inter, system-ui, sans-serif;
+  color: #e8eaf0;
+}
+
+.phase-waiting-card {
+  max-width: 400px;
+  background: #151922;
+  border: 1px solid #2a3040;
+  border-radius: 14px;
+  padding: 28px 24px;
+  text-align: center;
+  font-size: 1.05rem;
+  font-weight: 600;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.55);
+}

--- a/apps/play/src/characterCreation.js
+++ b/apps/play/src/characterCreation.js
@@ -1,0 +1,273 @@
+// M17 — Character Creation overlay (phone).
+// Jackbox pattern: 1 PG per player, scelta nome + form MBTI + species.
+// ADR coop-mvp-spec.md §2.2.
+
+// MVP form pool: 16 MBTI cards. Stats indicativi (real mapping M18+ via
+// data/core/forms/mbti_forms.yaml server-side).
+const FORM_POOL = [
+  { id: 'istj_custode', label: 'Custode', mbti: 'ISTJ', blurb: '+HP +DEF', job: 'vanguard' },
+  { id: 'istp_artigiano', label: 'Artigiano', mbti: 'ISTP', blurb: '+Crit', job: 'skirmisher' },
+  { id: 'isfj_difensore', label: 'Difensore', mbti: 'ISFJ', blurb: '+Heal', job: 'support' },
+  { id: 'isfp_artefice', label: 'Artefice', mbti: 'ISFP', blurb: '+Evasion', job: 'skirmisher' },
+  { id: 'intj_stratega', label: 'Stratega', mbti: 'INTJ', blurb: '+MoS', job: 'gladiator' },
+  { id: 'intp_architetto', label: 'Architetto', mbti: 'INTP', blurb: '+Range', job: 'ranger' },
+  { id: 'infj_mistico', label: 'Mistico', mbti: 'INFJ', blurb: '+Focus', job: 'support' },
+  { id: 'infp_visionario', label: 'Visionario', mbti: 'INFP', blurb: '+Morale', job: 'support' },
+  { id: 'estj_comandante', label: 'Comandante', mbti: 'ESTJ', blurb: '+Cmd', job: 'gladiator' },
+  {
+    id: 'estp_avventuriero',
+    label: 'Avventuriero',
+    mbti: 'ESTP',
+    blurb: '+Speed',
+    job: 'skirmisher',
+  },
+  { id: 'esfj_cortigiano', label: 'Cortigiano', mbti: 'ESFJ', blurb: '+Team', job: 'support' },
+  { id: 'esfp_performer', label: 'Performer', mbti: 'ESFP', blurb: '+Taunt', job: 'gladiator' },
+  { id: 'entj_generale', label: 'Generale', mbti: 'ENTJ', blurb: '+Leader', job: 'gladiator' },
+  {
+    id: 'entp_sperimentatore',
+    label: 'Sperimentatore',
+    mbti: 'ENTP',
+    blurb: '+Combo',
+    job: 'skirmisher',
+  },
+  { id: 'enfj_mentore', label: 'Mentore', mbti: 'ENFJ', blurb: '+Buff', job: 'support' },
+  { id: 'enfp_catalysta', label: 'Catalysta', mbti: 'ENFP', blurb: '+Team', job: 'support' },
+];
+
+const SPECIES_POOL = [
+  { id: 'scagliato', label: 'Scagliato', blurb: 'Corazza' },
+  { id: 'corvide', label: 'Corvide', blurb: 'Velocità' },
+  { id: 'saltatore', label: 'Saltatore', blurb: 'Mobilità' },
+  { id: 'velox', label: 'Velox', blurb: 'Iniziativa' },
+  { id: 'carapax', label: 'Carapax', blurb: 'Difesa' },
+  { id: 'feloid', label: 'Feloid', blurb: 'Agilità' },
+];
+
+function previewStats(form) {
+  const jobStats = {
+    vanguard: { hp: 28, ap: 2, atk: 4, def: 5 },
+    gladiator: { hp: 24, ap: 2, atk: 5, def: 3 },
+    skirmisher: { hp: 18, ap: 3, atk: 3, def: 2 },
+    support: { hp: 20, ap: 2, atk: 2, def: 3 },
+    ranger: { hp: 20, ap: 2, atk: 4, def: 2 },
+  };
+  return jobStats[form.job] || { hp: 22, ap: 2, atk: 3, def: 3 };
+}
+
+export function renderCharacterCreation() {
+  if (typeof document === 'undefined') return null;
+  let overlay = document.getElementById('char-creation-overlay');
+  if (overlay) return overlay;
+  overlay = document.createElement('div');
+  overlay.id = 'char-creation-overlay';
+  overlay.className = 'char-creation-overlay';
+  overlay.innerHTML = `
+    <div class="cc-wrap">
+      <div class="cc-phase">
+        <span class="cc-phase-icon">🎭</span>
+        <span class="cc-phase-label">Crea il tuo PG</span>
+        <span class="cc-phase-progress" id="cc-progress">0/?</span>
+      </div>
+
+      <div class="cc-section">
+        <label class="cc-label" for="cc-name">Nome PG</label>
+        <input type="text" id="cc-name" maxlength="30" placeholder="Aria, Bruno…" />
+      </div>
+
+      <div class="cc-section">
+        <div class="cc-label">Forma (MBTI)</div>
+        <div class="cc-grid" id="cc-form-grid">
+          ${FORM_POOL.map(
+            (f) => `
+            <button type="button" class="cc-card cc-form-card" data-form="${f.id}">
+              <div class="cc-card-title">${f.label}</div>
+              <div class="cc-card-sub">${f.mbti}</div>
+              <div class="cc-card-blurb">${f.blurb}</div>
+            </button>
+          `,
+          ).join('')}
+        </div>
+      </div>
+
+      <div class="cc-section">
+        <div class="cc-label">Specie</div>
+        <div class="cc-grid cc-grid-small" id="cc-species-grid">
+          ${SPECIES_POOL.map(
+            (s) => `
+            <button type="button" class="cc-card cc-species-card" data-species="${s.id}">
+              <div class="cc-card-title">${s.label}</div>
+              <div class="cc-card-blurb">${s.blurb}</div>
+            </button>
+          `,
+          ).join('')}
+        </div>
+      </div>
+
+      <div class="cc-section cc-preview" id="cc-preview">
+        <div class="cc-preview-title">Statistiche preview</div>
+        <div class="cc-preview-stats" id="cc-preview-stats">
+          <span>HP —</span><span>AP —</span><span>ATK —</span><span>DEF —</span>
+        </div>
+      </div>
+
+      <button type="button" class="cc-confirm" id="cc-confirm" disabled>
+        ✓ Conferma PG
+      </button>
+      <div class="cc-status" id="cc-status" aria-live="polite"></div>
+
+      <div class="cc-section">
+        <div class="cc-label">Party (<span id="cc-party-count">0</span>)</div>
+        <div class="cc-party" id="cc-party"></div>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(overlay);
+  return overlay;
+}
+
+export function wireCharacterCreation(overlay, bridge) {
+  if (!overlay || !bridge) return null;
+  const state = {
+    name: '',
+    form: null,
+    species: null,
+    submitted: false,
+    partyList: [],
+  };
+
+  const nameInput = overlay.querySelector('#cc-name');
+  const confirmBtn = overlay.querySelector('#cc-confirm');
+  const statusEl = overlay.querySelector('#cc-status');
+  const previewStatsEl = overlay.querySelector('#cc-preview-stats');
+
+  const setStatus = (msg, kind) => {
+    statusEl.textContent = msg || '';
+    statusEl.dataset.kind = kind || '';
+  };
+
+  const updateConfirm = () => {
+    const valid = !!state.name.trim() && !!state.form && !!state.species && !state.submitted;
+    confirmBtn.disabled = !valid;
+  };
+
+  const renderPreview = () => {
+    if (!state.form) return;
+    const stats = previewStats(state.form);
+    previewStatsEl.innerHTML = `
+      <span>HP ${stats.hp}</span>
+      <span>AP ${stats.ap}</span>
+      <span>ATK ${stats.atk}</span>
+      <span>DEF ${stats.def}</span>
+    `;
+  };
+
+  const renderParty = () => {
+    const list = overlay.querySelector('#cc-party');
+    const count = overlay.querySelector('#cc-party-count');
+    const prog = overlay.querySelector('#cc-progress');
+    const entries = state.partyList || [];
+    if (count) count.textContent = String(entries.length);
+    const readyCount = entries.filter((e) => e.ready).length;
+    if (prog) prog.textContent = `${readyCount}/${entries.length || '?'}`;
+    list.innerHTML = entries.length
+      ? entries
+          .map((e) => {
+            const form = FORM_POOL.find((f) => f.id === e.form_id);
+            return `<div class="cc-party-row ${e.ready ? 'ready' : 'pending'}">
+              <span class="cc-party-dot"></span>
+              <span class="cc-party-name">${e.name || '—'}</span>
+              <span class="cc-party-form">${form ? form.label : e.ready ? '—' : 'scegliendo'}</span>
+            </div>`;
+          })
+          .join('')
+      : '<div class="cc-empty">Solo tu per ora</div>';
+  };
+
+  nameInput.addEventListener('input', () => {
+    state.name = nameInput.value;
+    updateConfirm();
+  });
+
+  overlay.querySelectorAll('.cc-form-card').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      if (state.submitted) return;
+      const id = btn.dataset.form;
+      state.form = FORM_POOL.find((f) => f.id === id);
+      overlay
+        .querySelectorAll('.cc-form-card')
+        .forEach((b) => b.classList.toggle('selected', b === btn));
+      renderPreview();
+      updateConfirm();
+    });
+  });
+
+  overlay.querySelectorAll('.cc-species-card').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      if (state.submitted) return;
+      const id = btn.dataset.species;
+      state.species = SPECIES_POOL.find((s) => s.id === id);
+      overlay
+        .querySelectorAll('.cc-species-card')
+        .forEach((b) => b.classList.toggle('selected', b === btn));
+      updateConfirm();
+    });
+  });
+
+  confirmBtn.addEventListener('click', async () => {
+    if (state.submitted || !state.name || !state.form || !state.species) return;
+    setStatus('Invio PG…');
+    confirmBtn.disabled = true;
+    try {
+      const res = await fetch('/api/coop/character/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          code: bridge.session.code,
+          player_id: bridge.session.player_id,
+          player_token: bridge.session.token,
+          name: state.name.trim(),
+          form_id: state.form.id,
+          species_id: state.species.id,
+          job_id: state.form.job,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setStatus(`Errore: ${data?.error || 'HTTP ' + res.status}`, 'err');
+        confirmBtn.disabled = false;
+        return;
+      }
+      state.submitted = true;
+      setStatus('✓ PG inviato — attendo altri', 'ok');
+      nameInput.disabled = true;
+      overlay.querySelectorAll('.cc-card').forEach((b) => (b.disabled = true));
+    } catch (err) {
+      setStatus(`Errore rete: ${err.message}`, 'err');
+      confirmBtn.disabled = false;
+    }
+  });
+
+  return {
+    onCharacterReadyList(list) {
+      state.partyList = Array.isArray(list) ? list : [];
+      renderParty();
+      // If my own entry is ready but state.submitted is false, sync UI.
+      const myEntry = state.partyList.find((e) => e.player_id === bridge.session.player_id);
+      if (myEntry?.ready && !state.submitted) {
+        state.submitted = true;
+        confirmBtn.disabled = true;
+        nameInput.disabled = true;
+      }
+    },
+    show() {
+      overlay.classList.remove('cc-hidden');
+    },
+    hide() {
+      overlay.classList.add('cc-hidden');
+    },
+    destroy() {
+      overlay.remove();
+    },
+  };
+}

--- a/apps/play/src/lobbyBridge.css
+++ b/apps/play/src/lobbyBridge.css
@@ -409,6 +409,12 @@
   background: rgba(255, 183, 77, 0.05);
 }
 
+.lobby-host-roster-list .char-label {
+  font-size: 0.72rem;
+  color: #b39ddb;
+  margin-left: 4px;
+}
+
 .lobby-host-roster-empty {
   color: #8891a3;
   font-style: italic;

--- a/apps/play/src/lobbyBridge.js
+++ b/apps/play/src/lobbyBridge.js
@@ -277,17 +277,38 @@ function updateHostRoster(bridge) {
     return (a.joinedAt || 0) - (b.joinedAt || 0);
   });
   const readySet = new Set(bridge._readySet || []);
+  // M17 — character creation roster overlay: per-player pg form+species.
+  const charByPlayer = new Map();
+  for (const ch of bridge._characterReadyList || []) {
+    if (ch?.player_id) charByPlayer.set(ch.player_id, ch);
+  }
+  const inCharCreation = bridge._currentPhase === 'character_creation';
   list.innerHTML = entries
     .map((p) => {
       const state = p.connected === false ? 'disconnected' : p.connected ? 'connected' : '';
       const roleCls = p.role === 'host' ? 'host' : 'player';
-      const isReady = readySet.has(p.id);
-      const readyCls = p.role === 'host' ? '' : isReady ? 'intent-ready' : 'intent-pending';
-      const readyIcon = p.role === 'host' ? '' : isReady ? '✅' : '💭';
+      let readyCls = '';
+      let readyIcon = '';
+      let extraLabel = '';
+      if (p.role !== 'host') {
+        if (inCharCreation) {
+          const ch = charByPlayer.get(p.id);
+          const charReady = Boolean(ch?.ready);
+          readyCls = charReady ? 'intent-ready' : 'intent-pending';
+          readyIcon = charReady ? '🎭' : '💭';
+          if (charReady && ch) {
+            extraLabel = ` <span class="char-label">${escapeHtml(ch.name || '—')}${ch.form_id ? ` · ${escapeHtml(ch.form_id)}` : ''}</span>`;
+          }
+        } else {
+          const isReady = readySet.has(p.id);
+          readyCls = isReady ? 'intent-ready' : 'intent-pending';
+          readyIcon = isReady ? '✅' : '💭';
+        }
+      }
       return `
         <li class="${state} ${readyCls}">
           <span class="dot"></span>
-          <span class="name">${escapeHtml(p.name || p.id || '?')}</span>
+          <span class="name">${escapeHtml(p.name || p.id || '?')}${extraLabel}</span>
           <span class="role ${roleCls}">${p.role || 'player'}</span>
           <span class="ready">${readyIcon}</span>
         </li>
@@ -408,6 +429,7 @@ export function initLobbyBridgeIfPresent({ wsImpl = null } = {}) {
     _readySet: [],
     _missingSet: [],
     _currentPhase: 'idle',
+    _characterReadyList: [], // M17 character creation roster
     // TKT-M11B-04 — live roster tracking (Map<id, { name, role, connected, joinedAt }>).
     _players: new Map(),
   };
@@ -512,6 +534,15 @@ export function initLobbyBridgeIfPresent({ wsImpl = null } = {}) {
     bridge._readySet = Array.isArray(payload?.ready) ? payload.ready : [];
     bridge._missingSet = Array.isArray(payload?.missing) ? payload.missing : [];
     bridge._currentPhase = payload?.phase || bridge._currentPhase;
+    if (bridge.isHost) updateHostRoster(bridge);
+  });
+  // M17 — character creation phase: roster shows PG + form per player.
+  client.on('phase_change', (payload) => {
+    bridge._currentPhase = payload?.phase || bridge._currentPhase;
+    if (bridge.isHost) updateHostRoster(bridge);
+  });
+  client.on('character_ready_list', (list) => {
+    bridge._characterReadyList = Array.isArray(list) ? list : [];
     if (bridge.isHost) updateHostRoster(bridge);
   });
   // TKT-M11B-02 — host listens for player intents and fans them out to
@@ -624,6 +655,10 @@ export function initLobbyBridgeIfPresent({ wsImpl = null } = {}) {
     bridge.overlay = renderPhoneOverlayV2(session);
     const phv2 = wirePhoneComposerV2(bridge.overlay, bridge);
     bridge._phv2Api = phv2;
+    // M17 — phase coordinator switches overlay (character creation / world / combat / debrief)
+    const coordinator = createPhaseCoordinator(bridge);
+    bridge._phaseCoordinator = coordinator;
+    coordinator.applyPhase('lobby');
     renderPlayerOnboarding();
 
     client.on('state', ({ payload }) => {
@@ -634,6 +669,13 @@ export function initLobbyBridgeIfPresent({ wsImpl = null } = {}) {
     });
     client.on('chat', (payload) => {
       if (phv2?.onChat) phv2.onChat(payload);
+    });
+    // M17 — phase + character coop broadcasts from server.
+    client.on('phase_change', (payload) => {
+      coordinator.applyPhase(payload?.phase || 'lobby');
+    });
+    client.on('character_ready_list', (list) => {
+      coordinator.onCharacterReadyList(list);
     });
     // keep party roster sync
     const syncPartyToPhv2 = () => {

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -865,6 +865,72 @@ function animTick() {
   if (needsAnimFrame()) requestAnimationFrame(animTick);
 }
 
+/**
+ * M17 — Co-op host flow orchestration.
+ * Returns:
+ *   - null  → no co-op (solo host, no players). Proceed legacy.
+ *   - 'wait' → coop run just started OR phase not ready; caller MUST stop.
+ *   - { characters: [...] } → ready to start combat; caller pipes into api.start.
+ */
+async function maybeRunCoopHostFlow(scenarioId) {
+  if (!lobbyBridge?.isHost) return null;
+  const session = lobbyBridge.session;
+  if (!session?.code || !session?.token) return null;
+  // count players (exclude host)
+  const players = Array.from(lobbyBridge._players?.values?.() || []).filter(
+    (p) => p.role !== 'host' && p.id !== session.player_id,
+  );
+  if (players.length === 0) return null; // solo host dev/test
+
+  // Fetch current coop state
+  let coopState = null;
+  try {
+    const r = await api.coopState(session.code);
+    if (r.ok) coopState = r.data?.snapshot || null;
+  } catch {
+    // ignore — treat as lobby
+  }
+  const phase = coopState?.phase || 'lobby';
+
+  if (phase === 'lobby' || phase === 'ended') {
+    // Start run → auto transitions to character_creation.
+    const r = await api.coopRunStart(session.code, session.token, [scenarioId]);
+    if (!r.ok) {
+      appendLog(logEl, `✖ coop run start: ${r.data?.error || r.status}`, 'error');
+      return null;
+    }
+    appendLog(logEl, `🎭 Run co-op avviata — attendi PG dei ${players.length} player`);
+    updateHint('Fase: creazione PG. Ricliccare "Nuova sessione" quando tutti pronti.');
+    return 'wait';
+  }
+
+  if (phase === 'character_creation') {
+    const readyCount = coopState?.characters?.length || 0;
+    appendLog(logEl, `⏳ Attendi: ${readyCount}/${players.length} player hanno creato PG`, 'warn');
+    return 'wait';
+  }
+
+  if (phase === 'world_setup') {
+    // Confirm scenario + pipe characters into /session/start.
+    const r = await api.coopWorldConfirm(session.code, session.token, scenarioId);
+    if (!r.ok) {
+      appendLog(logEl, `✖ coop world confirm: ${r.data?.error || r.status}`, 'error');
+      return null;
+    }
+    appendLog(logEl, `✓ Scenario confermato, avvio combat con ${coopState.characters.length} PG`);
+    return { characters: coopState.characters };
+  }
+
+  if (phase === 'combat') {
+    appendLog(logEl, '⚠ Combat già in corso — usa Reset prima.', 'warn');
+    return 'wait';
+  }
+
+  // debrief / other phases — defer M19
+  appendLog(logEl, `Phase coop attuale: ${phase} (non gestita M17).`, 'warn');
+  return null;
+}
+
 async function startNewSession() {
   state.endgameShown = false;
   state.pendingAbility = null;
@@ -877,6 +943,11 @@ async function startNewSession() {
     updateHint('Backend non raggiungibile? Verifica npm run start:api.');
     return;
   }
+
+  // M17 — Co-op flow: if host of room with players, orchestrate coop phases.
+  const coopCtx = await maybeRunCoopHostFlow(scenarioId);
+  if (coopCtx === 'wait') return; // esc: wait for players to finish character creation
+  const coopCharacters = coopCtx?.characters || null;
   const modSel = document.getElementById('modulation-select');
   // Se scenario raccomanda modulation (es. hardcore → 'full') e user non ha
   // scelto manualmente, applica recommended (aggiorna dropdown per UI clarity).
@@ -892,6 +963,9 @@ async function startNewSession() {
   // M7-#2 Phase C: pipe encounter_class da scenario a backend per apply
   // damage_curves.yaml multiplier + enrage threshold.
   if (sc.data.encounter_class) startOpts.encounter_class = sc.data.encounter_class;
+  if (coopCharacters && coopCharacters.length > 0) {
+    startOpts.characters = coopCharacters;
+  }
   const st = await api.start(sc.data.units, startOpts);
   if (!st.ok) {
     appendLog(logEl, `✖ session start: ${st.status}`, 'error');

--- a/apps/play/src/network.js
+++ b/apps/play/src/network.js
@@ -43,6 +43,9 @@ const EVENT_TYPES = [
   'reconnect_failed',
   // M15 additions
   'round_ready',
+  // M17 additions
+  'phase_change',
+  'character_ready_list',
 ];
 
 function resolveDefaultWsImpl() {
@@ -247,6 +250,12 @@ export class LobbyClient {
         return;
       case 'round_ready':
         this._emit('round_ready', msg.payload || {});
+        return;
+      case 'phase_change':
+        this._emit('phase_change', msg.payload || {});
+        return;
+      case 'character_ready_list':
+        this._emit('character_ready_list', msg.payload || []);
         return;
       case 'room_closed':
         this._emit('room_closed', msg.payload || {});

--- a/apps/play/src/phaseCoordinator.js
+++ b/apps/play/src/phaseCoordinator.js
@@ -1,0 +1,100 @@
+// M17 — Phase coordinator: switch phone overlay based on coop phase.
+// Phases: lobby | character_creation | world_setup | combat | debrief | ended.
+
+import { renderCharacterCreation, wireCharacterCreation } from './characterCreation.js';
+import './characterCreation.css';
+
+export function createPhaseCoordinator(bridge) {
+  if (!bridge) return null;
+  const state = {
+    currentPhase: null,
+    api: {
+      characterCreation: null,
+    },
+  };
+
+  function ensureCharacterCreation() {
+    if (state.api.characterCreation) return state.api.characterCreation;
+    const overlay = renderCharacterCreation();
+    const api = wireCharacterCreation(overlay, bridge);
+    state.api.characterCreation = api;
+    return api;
+  }
+
+  function hideAllPhaseOverlays() {
+    const cc = document.getElementById('char-creation-overlay');
+    if (cc) cc.classList.add('cc-hidden');
+    const phv2 = document.getElementById('phone-overlay-v2');
+    if (phv2) phv2.style.display = 'none';
+  }
+
+  function showCombatComposer() {
+    const phv2 = document.getElementById('phone-overlay-v2');
+    if (phv2) phv2.style.display = '';
+  }
+
+  function applyPhase(phase) {
+    if (state.currentPhase === phase) return;
+    state.currentPhase = phase;
+    hideAllPhaseOverlays();
+    switch (phase) {
+      case 'character_creation':
+        ensureCharacterCreation().show();
+        break;
+      case 'world_setup':
+        // MVP M17: show waiting card; M18 replaces with world setup UI.
+        showWaitingOverlay("🗺 Scegliete scenario — in attesa dell'host");
+        break;
+      case 'combat':
+      case 'resolving':
+      case 'planning':
+      case 'ready':
+        showCombatComposer();
+        hideWaitingOverlay();
+        break;
+      case 'debrief':
+        // MVP M17: show waiting card; M19 replaces with debrief UI.
+        showWaitingOverlay('🏁 Debrief — in attesa scelta');
+        break;
+      case 'ended':
+        showWaitingOverlay('🏁 Partita finita — grazie per aver giocato');
+        break;
+      case 'lobby':
+      default:
+        showWaitingOverlay("⏸ In attesa dell'host…");
+    }
+  }
+
+  function showWaitingOverlay(msg) {
+    let el = document.getElementById('phase-waiting-overlay');
+    if (!el) {
+      el = document.createElement('div');
+      el.id = 'phase-waiting-overlay';
+      el.className = 'phase-waiting-overlay';
+      el.innerHTML = '<div class="phase-waiting-card"><span id="phase-waiting-msg"></span></div>';
+      document.body.appendChild(el);
+    }
+    const msgEl = el.querySelector('#phase-waiting-msg');
+    if (msgEl) msgEl.textContent = msg;
+    el.style.display = '';
+  }
+
+  function hideWaitingOverlay() {
+    const el = document.getElementById('phase-waiting-overlay');
+    if (el) el.style.display = 'none';
+  }
+
+  function onCharacterReadyList(list) {
+    if (state.api.characterCreation?.onCharacterReadyList) {
+      state.api.characterCreation.onCharacterReadyList(list);
+    }
+  }
+
+  return {
+    applyPhase,
+    onCharacterReadyList,
+    get phase() {
+      return state.currentPhase;
+    },
+  };
+}

--- a/tests/api/coopRoutes.test.js
+++ b/tests/api/coopRoutes.test.js
@@ -1,0 +1,184 @@
+// M17 — REST /api/coop/* integration tests (in-process Express).
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const { createLobbyRouter } = require('../../apps/backend/routes/lobby');
+const { createCoopRouter } = require('../../apps/backend/routes/coop');
+const { createCoopStore } = require('../../apps/backend/services/coop/coopStore');
+const { LobbyService } = require('../../apps/backend/services/network/wsSession');
+
+function buildApp() {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createLobbyRouter({ lobby }));
+  app.use('/api', createCoopRouter({ lobby, coopStore }));
+  return { app, lobby, coopStore };
+}
+
+async function jsonCall(app, method, path, body) {
+  return new Promise((resolve) => {
+    const req = { method, url: path, headers: {}, body };
+    const res = {
+      statusCode: 200,
+      headers: {},
+      _body: null,
+      setHeader() {},
+      getHeader() {},
+      status(c) {
+        this.statusCode = c;
+        return this;
+      },
+      json(obj) {
+        this._body = obj;
+        resolve({ status: this.statusCode, body: obj });
+      },
+      send(obj) {
+        this._body = obj;
+        resolve({ status: this.statusCode, body: obj });
+      },
+      end() {
+        resolve({ status: this.statusCode, body: this._body });
+      },
+    };
+    app._router.handle(req, res, () => resolve({ status: 404, body: null }));
+  });
+}
+
+// Use supertest for cleaner test — fallback to raw if not installed.
+let request;
+try {
+  request = require('supertest');
+} catch {
+  request = null;
+}
+
+async function post(app, path, body) {
+  if (request) {
+    const res = await request(app).post(path).send(body).set('Content-Type', 'application/json');
+    return { status: res.status, body: res.body };
+  }
+  return jsonCall(app, 'POST', path, body);
+}
+async function get(app, path) {
+  if (request) {
+    const res = await request(app).get(path);
+    return { status: res.status, body: res.body };
+  }
+  return jsonCall(app, 'GET', path, null);
+}
+
+test('POST /api/coop/run/start requires host_token', async () => {
+  const { app } = buildApp();
+  const res = await post(app, '/api/coop/run/start', { code: 'ABCD' });
+  assert.equal(res.status, 403);
+});
+
+test('full flow: create room → join → run start → character create → world confirm', async () => {
+  const { app } = buildApp();
+  const createRes = await post(app, '/api/lobby/create', { host_name: 'Host', max_players: 4 });
+  assert.ok(createRes.status === 200 || createRes.status === 201);
+  const { code, host_token: hostToken } = createRes.body;
+
+  const joinRes = await post(app, '/api/lobby/join', { code, player_name: 'Alice' });
+  assert.ok(joinRes.status === 200 || joinRes.status === 201);
+  const { player_id: aliceId, player_token: aliceToken } = joinRes.body;
+
+  const runRes = await post(app, '/api/coop/run/start', {
+    code,
+    host_token: hostToken,
+    scenario_stack: ['enc_tutorial_01'],
+  });
+  assert.equal(runRes.status, 201);
+  assert.equal(runRes.body.phase, 'character_creation');
+
+  const charRes = await post(app, '/api/coop/character/create', {
+    code,
+    player_id: aliceId,
+    player_token: aliceToken,
+    name: 'Aria',
+    form_id: 'istj_custode',
+    species_id: 'scagliato',
+    job_id: 'vanguard',
+  });
+  assert.equal(charRes.status, 201);
+  // Single player = all ready, phase auto transitions
+  assert.equal(charRes.body.phase, 'world_setup');
+
+  const stateRes = await get(app, `/api/coop/state?code=${code}`);
+  assert.equal(stateRes.status, 200);
+  assert.equal(stateRes.body.snapshot.phase, 'world_setup');
+  assert.equal(stateRes.body.snapshot.characters.length, 1);
+  assert.equal(stateRes.body.snapshot.characters[0].name, 'Aria');
+
+  const worldRes = await post(app, '/api/coop/world/confirm', {
+    code,
+    host_token: hostToken,
+    scenario_id: 'enc_tutorial_01',
+  });
+  assert.equal(worldRes.status, 200);
+  assert.equal(worldRes.body.phase, 'combat');
+  assert.ok(Array.isArray(worldRes.body.session_start_payload?.units));
+  assert.equal(worldRes.body.session_start_payload.units[0].owner_id, aliceId);
+});
+
+test('character/create rejects invalid spec', async () => {
+  const { app } = buildApp();
+  const createRes = await post(app, '/api/lobby/create', { host_name: 'H' });
+  const { code, host_token: hostToken } = createRes.body;
+  const joinRes = await post(app, '/api/lobby/join', { code, player_name: 'P' });
+  await post(app, '/api/coop/run/start', { code, host_token: hostToken });
+  const res = await post(app, '/api/coop/character/create', {
+    code,
+    player_id: joinRes.body.player_id,
+    player_token: joinRes.body.player_token,
+    name: '',
+    form_id: '',
+  });
+  assert.equal(res.status, 400);
+});
+
+test('world/confirm requires run started', async () => {
+  const { app } = buildApp();
+  const createRes = await post(app, '/api/lobby/create', { host_name: 'H' });
+  const { code, host_token: hostToken } = createRes.body;
+  const res = await post(app, '/api/coop/world/confirm', {
+    code,
+    host_token: hostToken,
+    scenario_id: 'enc_tutorial_01',
+  });
+  assert.equal(res.status, 409);
+});
+
+test('state endpoint returns 404 for unknown room', async () => {
+  const { app } = buildApp();
+  const res = await get(app, '/api/coop/state?code=ZZZZ');
+  assert.equal(res.status, 404);
+});
+
+test('combat/end transitions combat → debrief (host authed)', async () => {
+  const { app } = buildApp();
+  const createRes = await post(app, '/api/lobby/create', { host_name: 'H' });
+  const { code, host_token: hostToken } = createRes.body;
+  const joinRes = await post(app, '/api/lobby/join', { code, player_name: 'Alice' });
+  await post(app, '/api/coop/run/start', { code, host_token: hostToken });
+  await post(app, '/api/coop/character/create', {
+    code,
+    player_id: joinRes.body.player_id,
+    player_token: joinRes.body.player_token,
+    name: 'Aria',
+    form_id: 'istj',
+  });
+  await post(app, '/api/coop/world/confirm', { code, host_token: hostToken });
+  const endRes = await post(app, '/api/coop/combat/end', {
+    code,
+    host_token: hostToken,
+    outcome: 'victory',
+    xp_earned: 10,
+  });
+  assert.equal(endRes.status, 200);
+  assert.equal(endRes.body.phase, 'debrief');
+});


### PR DESCRIPTION
Sprint M17 completo. Sblocca M18 (world setup UI + auto-combat).

## Backend
- coopStore + routes/coop.js (6 endpoints REST)
- Wire app.js

## Frontend phone
- characterCreation.js + CSS: 16 MBTI cards + 6 species + stats preview
- phaseCoordinator: switch overlay per phase
- Waiting overlay transient (per world/debrief M18/M19)

## Frontend host (TV)
- Host roster ora mostra 🎭 name+form in character_creation phase
- phase_change + character_ready_list events wired

## Flow co-op host
- Click 1 "Nuova sessione" → coopRunStart + return 'wait'
- Players scelgono PG su phone
- Click 2 (phase=world_setup) → coopWorldConfirm + api.start con characters[]

## Test

- 6/6 coopRoutes integration
- 10/10 coopOrchestrator lifecycle (M16)
- 15/15 lobbyRoutes regression
- Build apps/play 31 modules verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)