### PR TITLE
feat(coop-m18): world setup phase — vote UI + tally broadcast (demo-ready)

### DIFF
--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -54,6 +54,13 @@ function createCoopRouter({ lobby, coopStore } = {}) {
       type: 'character_ready_list',
       payload: orch.characterReadyList(allPlayerIds(room)),
     });
+    // M18 — tally world votes if in setup phase.
+    if (orch.phase === 'world_setup') {
+      room.broadcast({
+        type: 'world_tally',
+        payload: orch.worldTally(allPlayerIds(room)),
+      });
+    }
   }
 
   router.post('/coop/run/start', (req, res) => {
@@ -115,6 +122,32 @@ function createCoopRouter({ lobby, coopStore } = {}) {
       snapshot: orch.snapshot(),
       character_ready_list: room ? orch.characterReadyList(allPlayerIds(room)) : [],
     });
+  });
+
+  router.post('/coop/world/vote', (req, res) => {
+    const {
+      code,
+      player_id: playerId,
+      player_token: playerToken,
+      scenario_id: scenarioId,
+      accept = true,
+    } = req.body || {};
+    const auth = authPlayer(code, playerId, playerToken);
+    if (!auth) return res.status(403).json({ error: 'player_auth_failed' });
+    const { room } = auth;
+    const orch = coopStore.get(code);
+    if (!orch) return res.status(409).json({ error: 'run_not_started' });
+    try {
+      const tally = orch.voteWorld(playerId, {
+        scenarioId,
+        accept,
+        allPlayerIds: allPlayerIds(room),
+      });
+      broadcastCoopState(room, orch);
+      return res.json({ phase: orch.phase, tally });
+    } catch (err) {
+      return res.status(400).json({ error: err.message || 'world_vote_failed' });
+    }
   });
 
   router.post('/coop/world/confirm', (req, res) => {

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -162,6 +162,45 @@ class CoopOrchestrator {
   }
 
   /**
+   * M18 — Player casts vote on proposed scenario. accept=true/false.
+   * Host remains arbiter and must still confirmWorld() to commit.
+   */
+  voteWorld(playerId, { scenarioId, accept = true, allPlayerIds = [] } = {}) {
+    if (this.phase !== 'world_setup') throw new Error('not_in_world_setup');
+    if (!playerId) throw new Error('player_id_required');
+    const sid = scenarioId || this.run?.scenarioStack?.[this.run.currentIndex];
+    this.worldVotes.set(playerId, {
+      scenario_id: sid,
+      accept: Boolean(accept),
+      ts: this.now(),
+    });
+    this._emit('world_vote', { player_id: playerId, scenario_id: sid, accept });
+    return this.worldTally(allPlayerIds);
+  }
+
+  /**
+   * M18 — Tally current world votes. Returns counts + breakdown.
+   */
+  worldTally(allPlayerIds = []) {
+    let accept = 0;
+    let reject = 0;
+    const perPlayer = {};
+    for (const [pid, vote] of this.worldVotes.entries()) {
+      if (vote.accept) accept += 1;
+      else reject += 1;
+      perPlayer[pid] = vote;
+    }
+    return {
+      scenario_id: this.run?.scenarioStack?.[this.run.currentIndex] || null,
+      accept,
+      reject,
+      total: allPlayerIds.length || accept + reject,
+      pending: Math.max(allPlayerIds.length - (accept + reject), 0),
+      per_player: perPlayer,
+    };
+  }
+
+  /**
    * Build the /session/start payload from current characters.
    * Used by M17+ host handler that forwards to existing session route.
    */

--- a/apps/play/src/api.js
+++ b/apps/play/src/api.js
@@ -217,6 +217,17 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ code, host_token: hostToken, scenario_id: scenarioId }),
     }),
+  coopWorldVote: (code, playerId, playerToken, scenarioId, accept = true) =>
+    jsonFetch('/api/coop/world/vote', {
+      method: 'POST',
+      body: JSON.stringify({
+        code,
+        player_id: playerId,
+        player_token: playerToken,
+        scenario_id: scenarioId,
+        accept,
+      }),
+    }),
   coopDebriefChoice: (code, playerId, playerToken, choice) =>
     jsonFetch('/api/coop/debrief/choice', {
       method: 'POST',

--- a/apps/play/src/lobbyBridge.js
+++ b/apps/play/src/lobbyBridge.js
@@ -670,22 +670,26 @@ export function initLobbyBridgeIfPresent({ wsImpl = null } = {}) {
     client.on('chat', (payload) => {
       if (phv2?.onChat) phv2.onChat(payload);
     });
-    // M17 — phase + character coop broadcasts from server.
+    // M17/M18 — phase + character + world coop broadcasts from server.
     client.on('phase_change', (payload) => {
-      coordinator.applyPhase(payload?.phase || 'lobby');
+      coordinator.onPhaseChange(payload);
     });
     client.on('character_ready_list', (list) => {
       coordinator.onCharacterReadyList(list);
     });
-    // keep party roster sync
-    const syncPartyToPhv2 = () => {
-      if (!phv2?.onPlayersChanged) return;
-      phv2.onPlayersChanged(Array.from(bridge._players.values()));
+    client.on('world_tally', (tally) => {
+      coordinator.onWorldTally(tally);
+    });
+    // keep party roster sync (phv2 + world setup)
+    const syncPartyToAll = () => {
+      const list = Array.from(bridge._players.values());
+      if (phv2?.onPlayersChanged) phv2.onPlayersChanged(list);
+      if (coordinator?.onPlayersChanged) coordinator.onPlayersChanged(list);
     };
-    client.on('hello', syncPartyToPhv2);
-    client.on('player_joined', syncPartyToPhv2);
-    client.on('player_connected', syncPartyToPhv2);
-    client.on('player_disconnected', syncPartyToPhv2);
+    client.on('hello', syncPartyToAll);
+    client.on('player_joined', syncPartyToAll);
+    client.on('player_connected', syncPartyToAll);
+    client.on('player_disconnected', syncPartyToAll);
   }
   if (bridge.isHost) {
     // TKT-M11B-04 — roster panel bottom-left showing who's in the room.

--- a/apps/play/src/network.js
+++ b/apps/play/src/network.js
@@ -46,6 +46,8 @@ const EVENT_TYPES = [
   // M17 additions
   'phase_change',
   'character_ready_list',
+  // M18 additions
+  'world_tally',
 ];
 
 function resolveDefaultWsImpl() {
@@ -256,6 +258,9 @@ export class LobbyClient {
         return;
       case 'character_ready_list':
         this._emit('character_ready_list', msg.payload || []);
+        return;
+      case 'world_tally':
+        this._emit('world_tally', msg.payload || {});
         return;
       case 'room_closed':
         this._emit('room_closed', msg.payload || {});

--- a/apps/play/src/phaseCoordinator.js
+++ b/apps/play/src/phaseCoordinator.js
@@ -1,8 +1,10 @@
-// M17 — Phase coordinator: switch phone overlay based on coop phase.
+// M17/M18 — Phase coordinator: switch phone overlay based on coop phase.
 // Phases: lobby | character_creation | world_setup | combat | debrief | ended.
 
 import { renderCharacterCreation, wireCharacterCreation } from './characterCreation.js';
 import './characterCreation.css';
+import { renderWorldSetup, wireWorldSetup } from './worldSetup.js';
+import './worldSetup.css';
 
 export function createPhaseCoordinator(bridge) {
   if (!bridge) return null;
@@ -10,6 +12,7 @@ export function createPhaseCoordinator(bridge) {
     currentPhase: null,
     api: {
       characterCreation: null,
+      worldSetup: null,
     },
   };
 
@@ -21,9 +24,19 @@ export function createPhaseCoordinator(bridge) {
     return api;
   }
 
+  function ensureWorldSetup() {
+    if (state.api.worldSetup) return state.api.worldSetup;
+    const overlay = renderWorldSetup();
+    const api = wireWorldSetup(overlay, bridge);
+    state.api.worldSetup = api;
+    return api;
+  }
+
   function hideAllPhaseOverlays() {
     const cc = document.getElementById('char-creation-overlay');
     if (cc) cc.classList.add('cc-hidden');
+    const ws = document.getElementById('world-setup-overlay');
+    if (ws) ws.classList.add('ws-hidden');
     const phv2 = document.getElementById('phone-overlay-v2');
     if (phv2) phv2.style.display = 'none';
   }
@@ -42,8 +55,7 @@ export function createPhaseCoordinator(bridge) {
         ensureCharacterCreation().show();
         break;
       case 'world_setup':
-        // MVP M17: show waiting card; M18 replaces with world setup UI.
-        showWaitingOverlay("🗺 Scegliete scenario — in attesa dell'host");
+        ensureWorldSetup().show();
         break;
       case 'combat':
       case 'resolving':
@@ -53,7 +65,7 @@ export function createPhaseCoordinator(bridge) {
         hideWaitingOverlay();
         break;
       case 'debrief':
-        // MVP M17: show waiting card; M19 replaces with debrief UI.
+        // MVP M18: show waiting card; M19 replaces with debrief UI.
         showWaitingOverlay('🏁 Debrief — in attesa scelta');
         break;
       case 'ended':
@@ -90,9 +102,31 @@ export function createPhaseCoordinator(bridge) {
     }
   }
 
+  function onWorldTally(tally) {
+    if (state.api.worldSetup?.onWorldTally) {
+      state.api.worldSetup.onWorldTally(tally);
+    }
+  }
+
+  function onPhaseChange(payload) {
+    applyPhase(payload?.phase || 'lobby');
+    if (state.api.worldSetup?.onPhaseChange) {
+      state.api.worldSetup.onPhaseChange(payload);
+    }
+  }
+
+  function onPlayersChanged(players) {
+    if (state.api.worldSetup?.onPlayersChanged) {
+      state.api.worldSetup.onPlayersChanged(players);
+    }
+  }
+
   return {
     applyPhase,
     onCharacterReadyList,
+    onWorldTally,
+    onPhaseChange,
+    onPlayersChanged,
     get phase() {
       return state.currentPhase;
     },

--- a/apps/play/src/worldSetup.css
+++ b/apps/play/src/worldSetup.css
@@ -1,0 +1,215 @@
+/* M18 — World setup overlay (phone) */
+
+.world-setup-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9520;
+  background: radial-gradient(ellipse at top, #0f2027 0%, #05070c 75%);
+  overflow-y: auto;
+  font-family: Inter, system-ui, sans-serif;
+  color: #e8eaf0;
+}
+
+.world-setup-overlay.ws-hidden {
+  display: none !important;
+}
+
+.ws-wrap {
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 14px 16px 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.ws-phase {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: linear-gradient(180deg, #122a3a 0%, #0f2027 100%);
+  border: 1px solid #4fc3f7;
+  font-weight: 600;
+}
+
+.ws-phase-icon {
+  font-size: 1.5rem;
+}
+.ws-phase-label {
+  flex: 1;
+}
+
+.ws-card {
+  background: linear-gradient(180deg, #1d2230 0%, #151922 100%);
+  border: 1px solid #2a3040;
+  border-radius: 14px;
+  padding: 16px;
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.4);
+}
+
+.ws-card-header {
+  margin-bottom: 12px;
+}
+
+.ws-card-title {
+  font-weight: 700;
+  font-size: 1.15rem;
+}
+
+.ws-card-biome {
+  font-size: 0.85rem;
+  color: #4fc3f7;
+  margin-top: 4px;
+}
+
+.ws-card-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.ws-stat {
+  background: #0b0d12;
+  border: 1px solid #2a3040;
+  border-radius: 8px;
+  padding: 8px 6px;
+  text-align: center;
+  font-size: 0.82rem;
+  font-weight: 600;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ws-stat span:first-child {
+  font-size: 0.68rem;
+  color: #8891a3;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-weight: 500;
+}
+
+.ws-card-blurb {
+  font-size: 0.9rem;
+  color: #c7cbd6;
+  line-height: 1.4;
+}
+
+.ws-vote-row {
+  display: flex;
+  gap: 8px;
+}
+
+.ws-vote {
+  flex: 1;
+  padding: 16px;
+  font-size: 1.02rem;
+  font-weight: 700;
+  border-radius: 12px;
+  cursor: pointer;
+  font-family: inherit;
+  transition:
+    background 0.15s,
+    opacity 0.15s,
+    transform 0.08s;
+  min-height: 56px;
+}
+
+.ws-vote:active {
+  transform: scale(0.97);
+}
+.ws-vote:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ws-vote-accept {
+  background: #4caf50;
+  color: #001014;
+  border: 1px solid #4caf50;
+}
+.ws-vote-accept:hover:not(:disabled) {
+  background: #66c669;
+}
+.world-setup-overlay.voted-accept .ws-vote-accept {
+  box-shadow: 0 0 0 3px rgba(76, 175, 80, 0.4);
+}
+
+.ws-vote-reject {
+  background: #ef5350;
+  color: #ffffff;
+  border: 1px solid #ef5350;
+}
+.ws-vote-reject:hover:not(:disabled) {
+  background: #f37775;
+}
+.world-setup-overlay.voted-reject .ws-vote-reject {
+  box-shadow: 0 0 0 3px rgba(239, 83, 80, 0.4);
+}
+
+.ws-status {
+  min-height: 1.2em;
+  font-size: 0.9rem;
+  text-align: center;
+  color: #8891a3;
+}
+.ws-status[data-kind='ok'] {
+  color: #66bb6a;
+}
+.ws-status[data-kind='err'] {
+  color: #ef5350;
+}
+
+.ws-section-title {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+  color: #8891a3;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.ws-tally {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ws-tally-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 12px;
+  background: #1d2230;
+  border: 1px solid #2a3040;
+  border-radius: 10px;
+  font-size: 0.9rem;
+}
+
+.ws-tally-row.accept {
+  border-color: #4caf50;
+  background: linear-gradient(90deg, #1a2a20 0%, #1d2230 70%);
+}
+
+.ws-tally-row.reject {
+  border-color: #ef5350;
+  background: linear-gradient(90deg, #2a1a1a 0%, #1d2230 70%);
+}
+
+.ws-tally-name {
+  font-weight: 600;
+}
+.ws-tally-vote {
+  font-size: 1.1rem;
+}
+
+.ws-empty {
+  padding: 12px;
+  text-align: center;
+  color: #8891a3;
+  font-size: 0.85rem;
+  font-style: italic;
+}

--- a/apps/play/src/worldSetup.js
+++ b/apps/play/src/worldSetup.js
@@ -1,0 +1,243 @@
+// M18 — World setup overlay (phone).
+// Party vota scenario proposto dall'host.
+// ADR coop-mvp-spec.md §2.4.
+
+const SCENARIO_INFO = {
+  enc_tutorial_01: {
+    title: 'Tutorial 01 · Primi Passi',
+    biome: 'Savana Dorata',
+    difficulty: 1,
+    duration: '~10 min',
+    enemies: 2,
+    blurb: 'Incontro base. Nessun boss. Ideale per imparare.',
+  },
+  enc_tutorial_02: {
+    title: 'Tutorial 02 · Pattuglia',
+    biome: 'Savana Asimmetrica',
+    difficulty: 2,
+    duration: '~12 min',
+    enemies: 3,
+    blurb: 'Nemico flanker. Serve coordinazione.',
+  },
+  enc_tutorial_03: {
+    title: 'Tutorial 03 · Hazard Savana',
+    biome: 'Savana con fuoco',
+    difficulty: 3,
+    duration: '~15 min',
+    enemies: 3,
+    blurb: 'Tile hazard attivi. Movimento conta.',
+  },
+  enc_tutorial_04: {
+    title: 'Tutorial 04 · Foresta Sanguinante',
+    biome: 'Foresta Umida',
+    difficulty: 3,
+    duration: '~15 min',
+    enemies: 3,
+    blurb: 'Trait bleeding. Status matter.',
+  },
+  enc_tutorial_05: {
+    title: 'Tutorial 05 · BOSS Apex',
+    biome: 'Radura centrale',
+    difficulty: 4,
+    duration: '~20 min',
+    enemies: 4,
+    blurb: 'Boss fight. Focus fire obbligatorio.',
+  },
+};
+
+function getScenarioInfo(id) {
+  return (
+    SCENARIO_INFO[id] || {
+      title: id || 'Scenario',
+      biome: '—',
+      difficulty: 2,
+      duration: '~15 min',
+      enemies: 3,
+      blurb: 'Scenario personalizzato.',
+    }
+  );
+}
+
+export function renderWorldSetup() {
+  if (typeof document === 'undefined') return null;
+  let overlay = document.getElementById('world-setup-overlay');
+  if (overlay) return overlay;
+  overlay = document.createElement('div');
+  overlay.id = 'world-setup-overlay';
+  overlay.className = 'world-setup-overlay';
+  overlay.innerHTML = `
+    <div class="ws-wrap">
+      <div class="ws-phase">
+        <span class="ws-phase-icon">🗺</span>
+        <span class="ws-phase-label">Scegliete insieme scenario</span>
+      </div>
+
+      <div class="ws-card" id="ws-card">
+        <div class="ws-card-header">
+          <div class="ws-card-title" id="ws-title">—</div>
+          <div class="ws-card-biome" id="ws-biome">—</div>
+        </div>
+        <div class="ws-card-stats">
+          <div class="ws-stat"><span>Diff</span><span id="ws-diff">—</span></div>
+          <div class="ws-stat"><span>Durata</span><span id="ws-duration">—</span></div>
+          <div class="ws-stat"><span>Nemici</span><span id="ws-enemies">—</span></div>
+        </div>
+        <div class="ws-card-blurb" id="ws-blurb">—</div>
+      </div>
+
+      <div class="ws-vote-row">
+        <button type="button" class="ws-vote ws-vote-accept" id="ws-accept">
+          👍 D'accordo
+        </button>
+        <button type="button" class="ws-vote ws-vote-reject" id="ws-reject">
+          👎 Altro
+        </button>
+      </div>
+      <div class="ws-status" id="ws-status" aria-live="polite"></div>
+
+      <div class="ws-section">
+        <div class="ws-section-title">Tally (<span id="ws-tally-count">0</span>)</div>
+        <div class="ws-tally" id="ws-tally">
+          <div class="ws-empty">In attesa dei voti…</div>
+        </div>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(overlay);
+  return overlay;
+}
+
+export function wireWorldSetup(overlay, bridge) {
+  if (!overlay || !bridge) return null;
+  const state = {
+    proposedScenarioId: null,
+    lastVote: null, // 'accept' | 'reject' | null
+    tally: { accept: 0, reject: 0, pending: 0 },
+    partyList: [], // [{player_id, name}]
+  };
+
+  const titleEl = overlay.querySelector('#ws-title');
+  const biomeEl = overlay.querySelector('#ws-biome');
+  const diffEl = overlay.querySelector('#ws-diff');
+  const durEl = overlay.querySelector('#ws-duration');
+  const enEl = overlay.querySelector('#ws-enemies');
+  const blurbEl = overlay.querySelector('#ws-blurb');
+  const statusEl = overlay.querySelector('#ws-status');
+  const acceptBtn = overlay.querySelector('#ws-accept');
+  const rejectBtn = overlay.querySelector('#ws-reject');
+
+  const setStatus = (msg, kind) => {
+    statusEl.textContent = msg || '';
+    statusEl.dataset.kind = kind || '';
+  };
+
+  const renderProposal = () => {
+    const info = getScenarioInfo(state.proposedScenarioId);
+    titleEl.textContent = info.title;
+    biomeEl.textContent = info.biome;
+    diffEl.textContent = '●'.repeat(info.difficulty) + '○'.repeat(Math.max(0, 5 - info.difficulty));
+    durEl.textContent = info.duration;
+    enEl.textContent = String(info.enemies);
+    blurbEl.textContent = info.blurb;
+  };
+
+  const renderTally = () => {
+    const list = overlay.querySelector('#ws-tally');
+    const count = overlay.querySelector('#ws-tally-count');
+    const t = state.tally || {};
+    if (count) count.textContent = String((t.accept || 0) + (t.reject || 0));
+    const party = state.partyList || [];
+    const perPlayer = t.per_player || {};
+    if (!party.length) {
+      list.innerHTML = '<div class="ws-empty">In attesa dei voti…</div>';
+      return;
+    }
+    list.innerHTML = party
+      .map((p) => {
+        const v = perPlayer[p.id];
+        const kind = v?.accept === true ? 'accept' : v?.accept === false ? 'reject' : 'pending';
+        const icon = kind === 'accept' ? '👍' : kind === 'reject' ? '👎' : '💭';
+        return `<div class="ws-tally-row ${kind}">
+          <span class="ws-tally-name">${p.name || p.id}</span>
+          <span class="ws-tally-vote">${icon}</span>
+        </div>`;
+      })
+      .join('');
+  };
+
+  const sendVote = async (accept) => {
+    if (!state.proposedScenarioId) {
+      setStatus('Scenario non caricato', 'err');
+      return;
+    }
+    setStatus('Invio voto…');
+    acceptBtn.disabled = true;
+    rejectBtn.disabled = true;
+    try {
+      const res = await fetch('/api/coop/world/vote', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          code: bridge.session.code,
+          player_id: bridge.session.player_id,
+          player_token: bridge.session.token,
+          scenario_id: state.proposedScenarioId,
+          accept,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setStatus(`Errore: ${data?.error || 'HTTP ' + res.status}`, 'err');
+        acceptBtn.disabled = false;
+        rejectBtn.disabled = false;
+        return;
+      }
+      state.lastVote = accept ? 'accept' : 'reject';
+      setStatus(accept ? "👍 D'accordo — attendi altri" : '👎 Rifiutato', 'ok');
+      overlay.classList.toggle('voted-accept', accept);
+      overlay.classList.toggle('voted-reject', !accept);
+      // Re-enable buttons to allow changing vote before confirm.
+      acceptBtn.disabled = false;
+      rejectBtn.disabled = false;
+    } catch (err) {
+      setStatus(`Errore rete: ${err.message}`, 'err');
+      acceptBtn.disabled = false;
+      rejectBtn.disabled = false;
+    }
+  };
+
+  acceptBtn.addEventListener('click', () => sendVote(true));
+  rejectBtn.addEventListener('click', () => sendVote(false));
+
+  return {
+    onPhaseChange(payload) {
+      const sid = payload?.scenario || null;
+      if (sid && sid !== state.proposedScenarioId) {
+        state.proposedScenarioId = sid;
+        state.lastVote = null;
+        overlay.classList.remove('voted-accept', 'voted-reject');
+        renderProposal();
+        setStatus('');
+      }
+    },
+    onWorldTally(tally) {
+      state.tally = tally || state.tally;
+      renderTally();
+    },
+    onPlayersChanged(players) {
+      state.partyList = players
+        .filter((p) => p.role !== 'host')
+        .map((p) => ({ id: p.id, name: p.name || p.id }));
+      renderTally();
+    },
+    show() {
+      overlay.classList.remove('ws-hidden');
+    },
+    hide() {
+      overlay.classList.add('ws-hidden');
+    },
+    destroy() {
+      overlay.remove();
+    },
+  };
+}

--- a/tests/api/coopWorldVote.test.js
+++ b/tests/api/coopWorldVote.test.js
@@ -1,0 +1,123 @@
+// M18 — World vote integration tests.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+const { createLobbyRouter } = require('../../apps/backend/routes/lobby');
+const { createCoopRouter } = require('../../apps/backend/routes/coop');
+const { createCoopStore } = require('../../apps/backend/services/coop/coopStore');
+const { LobbyService } = require('../../apps/backend/services/network/wsSession');
+
+function buildApp() {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createLobbyRouter({ lobby }));
+  app.use('/api', createCoopRouter({ lobby, coopStore }));
+  return { app };
+}
+
+async function bootstrapWorldSetup(app) {
+  const { body: h } = await request(app).post('/api/lobby/create').send({ host_name: 'H' });
+  const { body: j1 } = await request(app)
+    .post('/api/lobby/join')
+    .send({ code: h.code, player_name: 'Alice' });
+  const { body: j2 } = await request(app)
+    .post('/api/lobby/join')
+    .send({ code: h.code, player_name: 'Bruno' });
+  await request(app).post('/api/coop/run/start').send({ code: h.code, host_token: h.host_token });
+  await request(app).post('/api/coop/character/create').send({
+    code: h.code,
+    player_id: j1.player_id,
+    player_token: j1.player_token,
+    name: 'Aria',
+    form_id: 'istj',
+  });
+  await request(app).post('/api/coop/character/create').send({
+    code: h.code,
+    player_id: j2.player_id,
+    player_token: j2.player_token,
+    name: 'Bruno',
+    form_id: 'enfp',
+  });
+  return { host: h, p1: j1, p2: j2 };
+}
+
+test('POST /api/coop/world/vote records accept + updates tally', async () => {
+  const { app } = buildApp();
+  const { host, p1 } = await bootstrapWorldSetup(app);
+  const res = await request(app).post('/api/coop/world/vote').send({
+    code: host.code,
+    player_id: p1.player_id,
+    player_token: p1.player_token,
+    accept: true,
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.phase, 'world_setup');
+  assert.equal(res.body.tally.accept, 1);
+  assert.equal(res.body.tally.reject, 0);
+});
+
+test('player may change vote (latest wins)', async () => {
+  const { app } = buildApp();
+  const { host, p1 } = await bootstrapWorldSetup(app);
+  await request(app).post('/api/coop/world/vote').send({
+    code: host.code,
+    player_id: p1.player_id,
+    player_token: p1.player_token,
+    accept: true,
+  });
+  const res = await request(app).post('/api/coop/world/vote').send({
+    code: host.code,
+    player_id: p1.player_id,
+    player_token: p1.player_token,
+    accept: false,
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.tally.accept, 0);
+  assert.equal(res.body.tally.reject, 1);
+});
+
+test('vote rejected with bad token', async () => {
+  const { app } = buildApp();
+  const { host, p1 } = await bootstrapWorldSetup(app);
+  const res = await request(app).post('/api/coop/world/vote').send({
+    code: host.code,
+    player_id: p1.player_id,
+    player_token: 'bad',
+    accept: true,
+  });
+  assert.equal(res.status, 403);
+});
+
+test('vote rejected outside world_setup phase (after confirm)', async () => {
+  const { app } = buildApp();
+  const { host, p1 } = await bootstrapWorldSetup(app);
+  await request(app)
+    .post('/api/coop/world/confirm')
+    .send({ code: host.code, host_token: host.host_token });
+  const res = await request(app).post('/api/coop/world/vote').send({
+    code: host.code,
+    player_id: p1.player_id,
+    player_token: p1.player_token,
+    accept: true,
+  });
+  assert.equal(res.status, 400);
+});
+
+test('tally includes pending for not-yet-voted players', async () => {
+  const { app } = buildApp();
+  const { host, p1 } = await bootstrapWorldSetup(app);
+  const res = await request(app).post('/api/coop/world/vote').send({
+    code: host.code,
+    player_id: p1.player_id,
+    player_token: p1.player_token,
+    accept: true,
+  });
+  assert.equal(res.body.tally.accept, 1);
+  assert.equal(res.body.tally.pending, 1);
+  assert.equal(res.body.tally.total, 2);
+});


### PR DESCRIPTION
Sprint M18 completo. **Demo-ready post-merge**.

## Backend
- coopOrchestrator: voteWorld + worldTally
- /api/coop/world/vote (player auth)
- world_tally broadcast automatico

## Frontend phone
- worldSetup.js + CSS (card scenario + vote buttons + tally)
- phaseCoordinator switch a world_setup overlay

## Test
- 5 M18 + 6 M17 + 10 M16 + 15 lobby = **36/36 verde**
- Build apps/play verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)