### PR TITLE
feat(wire): V5 SG runtime + UI wires rewards/packs (vision gap follow-up)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -162,6 +162,20 @@ function createSessionRouter(options = {}) {
 
   const sessions = new Map();
   let activeSessionId = null;
+
+  // V5 SG lifecycle helper: reset per-turn earn counter su tutte le unit vive.
+  // Invocato dopo ogni session.turn += 1 (4 sites: advanceThroughAiTurns,
+  // /action early-end fallback, sessionRoundBridge round flow x2).
+  function sgBeginTurnAll(session) {
+    try {
+      const sgTracker = require('../services/combat/sgTracker');
+      for (const u of session.units || []) {
+        if (u && u.hp > 0) sgTracker.beginTurn(u);
+      }
+    } catch {
+      /* sgTracker optional */
+    }
+  }
   // P4 Thought Cabinet: sessionId -> Map<unitId, Set<thoughtId>>
   const thoughtsStore = new Map();
 
@@ -706,6 +720,7 @@ function createSessionRouter(options = {}) {
       const nextId = nextUnitId(session);
       session.active_unit = nextId;
       session.turn += 1;
+      sgBeginTurnAll(session);
     }
 
     return { iaActions, bleedingEvents };
@@ -901,6 +916,13 @@ function createSessionRouter(options = {}) {
         biome_id: biomeIdRaw,
         biome_costs_log: biomeCostsLog,
       };
+      // V5 SG lifecycle: encounter start reset (ADR-2026-04-26).
+      try {
+        const sgTracker = require('../services/combat/sgTracker');
+        for (const u of session.units || []) sgTracker.resetEncounter(u);
+      } catch {
+        /* sgTracker optional */
+      }
       sessions.set(sessionId, session);
       activeSessionId = sessionId;
       await fs.mkdir(logsDir, { recursive: true });
@@ -1594,6 +1616,7 @@ function createSessionRouter(options = {}) {
           }
         }
         session.turn += 1;
+        sgBeginTurnAll(session);
       }
 
       const eventsEmitted = session.events.slice(eventsCountBefore);

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -55,6 +55,19 @@ function createRoundBridge(deps) {
     defaultAttackRange,
   } = deps;
 
+  // V5 SG lifecycle helper (ADR-2026-04-26): reset earn-per-turn counter
+  // su tutte le unit vive dopo ogni round advance.
+  function sgBeginTurnAll(session) {
+    try {
+      const sgTracker = require('../services/combat/sgTracker');
+      for (const u of session.units || []) {
+        if (u && u.hp > 0) sgTracker.beginTurn(u);
+      }
+    } catch {
+      /* sgTracker optional */
+    }
+  }
+
   // Validates a player intent action against current session state.
   // Returns null if valid, { code, message } on rejection.
   function validatePlayerIntent(session, actorId, action) {
@@ -1019,6 +1032,7 @@ function createRoundBridge(deps) {
 
     await persistEvents(session);
     session.turn += 1;
+    sgBeginTurnAll(session);
 
     // Round decay (AI War pattern — sistema_pressure.yaml §deltas.round_decay):
     // pressure cala di 1 per round senza eventi di victory/defeat.
@@ -1307,6 +1321,7 @@ function createRoundBridge(deps) {
         await postResolveKills(session, kills);
         await persistEvents(session);
         session.turn += 1;
+        sgBeginTurnAll(session);
 
         if (typeof session.sistema_pressure === 'number') {
           session.sistema_pressure = applyPressureDelta(

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -128,6 +128,20 @@ function createAbilityExecutor(deps) {
     rng = Math.random,
   } = deps;
 
+  // V5 SG earn (ADR-2026-04-26 Opzione C mixed): accumulate dealt+taken
+  // su ogni damage step triggered da ability. Wrapped in try per non
+  // rompere flow se sgTracker module assente.
+  function applySgEarn(actor, target, damageDealt) {
+    if (!(Number(damageDealt) > 0)) return;
+    try {
+      const sgTracker = require('./combat/sgTracker');
+      sgTracker.accumulate(actor, { damage_dealt: damageDealt });
+      sgTracker.accumulate(target, { damage_taken: damageDealt });
+    } catch {
+      /* sgTracker optional */
+    }
+  }
+
   // Applica buff self come status[buffStat_buff] + actor[buffStat_bonus].
   // L'applicazione puntuale del bonus (es. a attack_mod effettivo) e'
   // demandata al consumer: qui tracciamo solo il buff per il log e per
@@ -226,6 +240,7 @@ function createAbilityExecutor(deps) {
     if (buffApplied && (ability.buff_stat || 'attack_mod') === 'attack_mod') {
       actor.attack_mod_bonus = Math.max(0, (actor.attack_mod_bonus || 0) - buffApplied.amount);
     }
+    applySgEarn(actor, target, res.damageDealt);
 
     const attackEvent = buildAttackEvent({
       session,
@@ -307,6 +322,7 @@ function createAbilityExecutor(deps) {
     const res = performAttack(session, actor, target, {
       channel: ability && ability.channel ? ability.channel : null,
     });
+    applySgEarn(actor, target, res.damageDealt);
     const attackEvent = buildAttackEvent({
       session,
       actor,
@@ -568,6 +584,7 @@ function createAbilityExecutor(deps) {
           adjustedDamage = res.damageDealt + extra;
         }
       }
+      applySgEarn(actor, target, adjustedDamage);
 
       const event = buildAttackEvent({
         session,
@@ -642,6 +659,7 @@ function createAbilityExecutor(deps) {
     const res = performAttack(session, actor, target, {
       channel: ability && ability.channel ? ability.channel : null,
     });
+    applySgEarn(actor, target, res.damageDealt);
 
     const trigger = String(ability.effect_trigger || 'on_hit');
     const allowEffect = (trigger === 'always' || res.result.hit) && target.hp > 0;
@@ -845,6 +863,7 @@ function createAbilityExecutor(deps) {
         adjustedDamage = res.damageDealt + extra;
       }
     }
+    applySgEarn(actor, target, adjustedDamage);
 
     // Conditional status: { condition: "mos >= 10", status_id, duration }
     let appliedStatus = null;
@@ -926,6 +945,7 @@ function createAbilityExecutor(deps) {
     const res = performAttack(session, actor, target, {
       channel: ability && ability.channel ? ability.channel : null,
     });
+    applySgEarn(actor, target, res.damageDealt);
 
     const lifestealPct = Number(ability.lifesteal_pct || 0);
     let healed = 0;
@@ -1057,6 +1077,7 @@ function createAbilityExecutor(deps) {
         }
       }
     }
+    applySgEarn(actor, target, adjustedDamage);
 
     const event = buildAttackEvent({
       session,
@@ -1477,6 +1498,7 @@ function createAbilityExecutor(deps) {
       const hpBefore = target.hp;
       target.hp = Math.max(0, target.hp - damage);
       session.damage_taken[target.id] = (session.damage_taken[target.id] || 0) + damage;
+      applySgEarn(actor, target, damage);
       damaged.push({
         unit_id: target.id,
         rolled,

--- a/apps/play/src/characterCreation.js
+++ b/apps/play/src/characterCreation.js
@@ -109,6 +109,7 @@ export function renderCharacterCreation() {
         <div class="cc-preview-stats" id="cc-preview-stats">
           <span>HP —</span><span>AP —</span><span>ATK —</span><span>DEF —</span>
         </div>
+        <div class="cc-preview-packs" id="cc-preview-packs" aria-live="polite"></div>
       </div>
 
       <button type="button" class="cc-confirm" id="cc-confirm" disabled>
@@ -151,6 +152,8 @@ export function wireCharacterCreation(overlay, bridge) {
     confirmBtn.disabled = !valid;
   };
 
+  const packsEl = overlay.querySelector('#cc-preview-packs');
+
   const renderPreview = () => {
     if (!state.form) return;
     const stats = previewStats(state.form);
@@ -160,7 +163,38 @@ export function wireCharacterCreation(overlay, bridge) {
       <span>ATK ${stats.atk}</span>
       <span>DEF ${stats.def}</span>
     `;
+    fetchPacksForForm(state.form.id, state.form.job);
   };
+
+  // V4 PI-Pacchetti tematici — fetch form-appropriate pack bias hint.
+  async function fetchPacksForForm(formId, jobId) {
+    if (!packsEl || !formId) return;
+    packsEl.textContent = 'Pacchetti PI consigliati…';
+    try {
+      const res = await fetch(`/api/forms/${encodeURIComponent(formId)}/packs`);
+      if (!res.ok) {
+        packsEl.textContent = '';
+        return;
+      }
+      const data = await res.json();
+      const universal = Array.isArray(data.universal) ? data.universal.slice(0, 3) : [];
+      const biasForm = Array.isArray(data.bias_forma) ? data.bias_forma.slice(0, 3) : [];
+      const biasJob =
+        jobId && data.bias_job && Array.isArray(data.bias_job[jobId])
+          ? data.bias_job[jobId].slice(0, 3)
+          : [];
+      const list = [...biasForm, ...biasJob, ...universal];
+      if (!list.length) {
+        packsEl.textContent = '';
+        return;
+      }
+      packsEl.innerHTML =
+        `<div class="cc-preview-packs-title">Pacchetti PI consigliati</div>` +
+        list.map((p) => `<span class="cc-preview-pack">${p.label || p.id || p}</span>`).join(' ');
+    } catch {
+      packsEl.textContent = '';
+    }
+  }
 
   const renderParty = () => {
     const list = overlay.querySelector('#cc-party');

--- a/apps/play/src/phaseCoordinator.js
+++ b/apps/play/src/phaseCoordinator.js
@@ -83,6 +83,15 @@ export function createPhaseCoordinator(bridge) {
         dbApi.reset();
         if (state.lastWorldState) dbApi.setState(state.lastWorldState, null);
         dbApi.show();
+        // V2 Tri-Sorgente — fetch reward offer if campaign present.
+        try {
+          const summary = bridge?.getCampaignSummary?.();
+          const cid = summary?.id || summary?.campaign_id || null;
+          const actorId = bridge?.session?.player_id || bridge?.session?.actor_id || null;
+          if (cid && dbApi.showRewardOffer) dbApi.showRewardOffer(cid, actorId);
+        } catch {
+          /* reward offer optional */
+        }
         break;
       }
       case 'ended':


### PR DESCRIPTION
## Summary

Follow-up runtime + UI post [PR #1726](https://github.com/MasterDD-L34D/Game/pull/1726) (Vision Gap V1-V7 merged). Chiude residuo autonomous.

- **V5 SG runtime** in abilityExecutor.js (7 damage sites: move_attack/attack_move/multi_attack/attack_push/ranged_attack/drain_attack/execution_attack + surge_aoe) via helper `applySgEarn`
- **V5 lifecycle hooks**: `sgTracker.resetEncounter` on `/start`, `sgBeginTurnAll` dopo ogni `session.turn += 1` (4 siti: advanceThroughAiTurns + 2 round-bridge + 1 early-end)
- **V2 UI wire**: `phaseCoordinator` fires `showRewardOffer(campaign_id, actor_id)` su phase=debrief tramite `bridge.getCampaignSummary()`
- **V4 UI wire**: `characterCreation` fetch `/api/forms/:id/packs` su form select, render top-3 bias_forma + bias_job + universal come preview hint

## Test plan

- [x] `node --test tests/ai/*.test.js` → 307/307
- [x] `node --test tests/api/sessionRoundEndpoints.test.js tests/api/roundExecute.test.js tests/api/abilityExecutor.test.js` → 51/51
- [x] `node --test tests/api/sgTracker.test.js` → 46/46 (engine)
- [x] `npm run format:check` → verde
- [ ] Playtest live 4p ngrok (TKT-M11B-06, userland)

## Rollback

Revert commit `9419272b`. Tutti wiring guardati in try/catch: fallback in-memory safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)