### PR TITLE
fix(playtest-prep): preserve V5 SG pool in publicSessionView + cc-preview-packs CSS

### DIFF
--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -214,14 +214,21 @@ function timestampStamp(date) {
 }
 
 function publicSessionView(session) {
-  // A2: expose PP/SG/surge_ready per unit for UI consumption
-  const unitsWithGauges = (session.units || []).map((u) => ({
-    ...u,
-    pp: u.pp || 0,
-    sg: Math.floor((u.stress || 0) * 100),
-    surge_ready: Math.floor((u.stress || 0) * 100) >= 75,
-    pp_tier: (u.pp || 0) >= 10 ? 3 : (u.pp || 0) >= 6 ? 2 : (u.pp || 0) >= 3 ? 1 : 0,
-  }));
+  // A2: expose PP/SG/surge_ready per unit for UI consumption.
+  // V5 (ADR-2026-04-26): `sg` è ora pool integer 0..3 (Seed of Growth),
+  // gestito da sgTracker. Il gauge legacy stress-based (0..100) è esposto
+  // come `stress_gauge` + `surge_ready` per non collidere con V5 pool.
+  const unitsWithGauges = (session.units || []).map((u) => {
+    const stressGauge = Math.floor((u.stress || 0) * 100);
+    return {
+      ...u,
+      pp: u.pp || 0,
+      sg: Number.isFinite(Number(u.sg)) ? Number(u.sg) : 0,
+      stress_gauge: stressGauge,
+      surge_ready: stressGauge >= 75,
+      pp_tier: (u.pp || 0) >= 10 ? 3 : (u.pp || 0) >= 6 ? 2 : (u.pp || 0) >= 3 ? 1 : 0,
+    };
+  });
   const pressure = Number.isFinite(Number(session.sistema_pressure))
     ? Number(session.sistema_pressure)
     : 0;

--- a/apps/play/src/characterCreation.css
+++ b/apps/play/src/characterCreation.css
@@ -181,6 +181,36 @@
   border: 1px solid #2a3040;
 }
 
+.cc-preview-packs {
+  margin-top: 10px;
+  font-size: 0.78rem;
+  color: #c2c9d9;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.cc-preview-packs-title {
+  font-size: 0.72rem;
+  color: #8891a3;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-weight: 700;
+  flex-basis: 100%;
+  margin-bottom: 2px;
+}
+
+.cc-preview-pack {
+  background: #1a2130;
+  border: 1px solid #2f4662;
+  border-radius: 999px;
+  padding: 3px 9px;
+  font-size: 0.72rem;
+  color: #9ec5ff;
+  white-space: nowrap;
+}
+
 .cc-confirm {
   padding: 16px;
   font-size: 1.05rem;


### PR DESCRIPTION
## Summary

Fix 2 pre-playtest blocker trovati in audit doc/memory post PR #1727.

**Bug critico V5**: `publicSessionView` sovrascriveva V5 pool `u.sg` (integer 0..3, sgTracker-managed) con gauge legacy `Math.floor(stress*100)`. V5 runtime accumulava correttamente, ma mai esposto al client. Fix: preserve V5 pool, rename legacy gauge → `stress_gauge` + `surge_ready` invariato.

**UI polish**: `.cc-preview-packs` classes senza stili (PR #1727 ha aggiunto element ma CSS mancante). Styling pill-style cyan per hint PI pacchetti in char creation overlay.

## Test plan

- [x] `node --test tests/ai/*.test.js tests/api/sessionRoundEndpoints.test.js tests/api/sgTracker.test.js` → 330/330
- [x] `npm run format:check` → verde
- [x] `npm run play:build` → 243ms verde
- [ ] Playtest live 4p ngrok (TKT-M11B-06, userland — **unblocked by this PR**)

## Rollback

Revert commit `f87c5583`. Safe: nessun consumer frontend `sg` stress-legacy esistente (grep zero matches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)