### PR TITLE
feat(launcher): rewrite demo launcher — preflight + health probe + auto-open + QR

### DIFF
--- a/Evo-Tactics-Demo.bat
+++ b/Evo-Tactics-Demo.bat
@@ -1,34 +1,40 @@
 @echo off
-REM 1-click demo launcher. Copia questo file sul Desktop.
-REM Avvia backend demo + ngrok tunnel + stampa URL per amici.
+REM Evo-Tactics 1-click demo launcher.
+REM Doppio clic (o tramite shortcut Desktop) = go.
 
+setlocal
+chcp 65001 >nul 2>&1
 cd /d "%~dp0"
 title Evo-Tactics Demo Launcher
-echo ====================================================
-echo   Evo-Tactics - demo launcher
-echo ====================================================
-echo.
 
-REM Verifica node
+REM Node presence (fail fast prima di lanciare Node)
 where node >nul 2>&1
 if errorlevel 1 (
-    echo [errore] node non trovato. Installa Node.js 22+.
+    echo.
+    echo   [X] node non trovato. Installa Node.js 18+ da https://nodejs.org
+    echo.
     pause
     exit /b 1
 )
 
-REM Build play sempre — evita stale asset hash (HTML ref file non esistenti)
-echo [setup] build frontend (sincronizza asset hash)...
-call npm run play:build
+REM Build frontend (sincronizza asset hash: evita .html ref file non esistenti)
+echo.
+echo   [setup] build frontend in corso...
+call npm run play:build >nul 2>&1
 if errorlevel 1 (
-    echo [errore] build fallito.
+    echo.
+    echo   [X] build fallito. Ri-lancia con output completo:
+    echo       npm run play:build
+    echo.
     pause
     exit /b 1
 )
+echo   [OK]   frontend buildato
 
-echo [avvio] backend + ngrok tunnel...
+REM Delega tutto (preflight + backend + ngrok + banner + auto-open) al Node launcher
 node scripts/run-demo-tunnel.cjs
 
 echo.
-echo [fine] demo terminata.
+echo   [fine] demo terminata.
 pause
+endlocal

--- a/scripts/run-demo-tunnel.cjs
+++ b/scripts/run-demo-tunnel.cjs
@@ -1,53 +1,329 @@
 #!/usr/bin/env node
-// 1-click demo launcher: backend shared HTTP+WS + ngrok tunnel.
-// Print big banner con share URL pronto per gli amici.
+// 1-click demo launcher: pre-flight + backend + ngrok tunnel + auto-open.
+//
+// UX pattern (from commercial game launchers + LAN-party tools):
+//   1. Splash + version
+//   2. Pre-flight checks (✓/✗ per dep) — fail fast with fix hint
+//   3. Build frontend (shown to user with progress feedback)
+//   4. Start backend (stdout → logs/demo-<ts>.log, non pollute banner)
+//   5. Health probe /api/health (wait backend ready)
+//   6. Start ngrok + poll public URL
+//   7. Clean banner: URL + QR link + "OPEN BROWSER NOW" CTA
+//   8. Auto-open browser + auto-copy URL (Windows: start + clip.exe)
+//
+// Ctrl+C = stop all (backend + ngrok) pulito.
 
-const { spawn } = require('node:child_process');
+'use strict';
+
+const { spawn, spawnSync } = require('node:child_process');
 const http = require('node:http');
+const net = require('node:net');
+const fs = require('node:fs');
 const path = require('node:path');
 
 const PORT = 3334;
 const NGROK_API = 'http://127.0.0.1:4040/api/tunnels';
+const REPO_ROOT = path.resolve(__dirname, '..');
+const LOGS_DIR = path.join(REPO_ROOT, 'logs');
+const VERSION = '0.9.0-demo'; // bump when demo UX changes
 
 process.env.LOBBY_WS_SHARED = 'true';
 process.env.LOBBY_WS_ENABLED = 'true';
 
-const backendEntry = path.resolve(__dirname, '..', 'apps', 'backend', 'index.js');
+// ── ANSI helpers (disabled on legacy Windows CMD without VT) ───────────
+const supportsColor =
+  process.stdout.isTTY && (process.platform !== 'win32' || process.env.WT_SESSION);
+const c = (code) => (s) => (supportsColor ? `\x1b[${code}m${s}\x1b[0m` : s);
+const bold = c('1');
+const dim = c('2');
+const red = c('31');
+const green = c('32');
+const yellow = c('33');
+const cyan = c('36');
+const mag = c('35');
 
-const banner = (msg) => {
-  const line = '='.repeat(72);
-  console.log(`\n${line}\n${msg}\n${line}\n`);
+const ok = (m) => console.log(`  ${green('✓')} ${m}`);
+const fail = (m, hint) => {
+  console.log(`  ${red('✗')} ${m}`);
+  if (hint) console.log(`    ${dim(`→ ${hint}`)}`);
 };
+const info = (m) => console.log(`  ${cyan('ℹ')} ${m}`);
 
-console.log('[launcher] avvio backend demo (shared HTTP+WS)...');
-const backend = spawn(process.execPath, [backendEntry], {
-  stdio: 'inherit',
-  env: process.env,
+// ── Splash ─────────────────────────────────────────────────────────────
+console.log('');
+console.log(bold(cyan('╔══════════════════════════════════════════════════════════════════╗')));
+console.log(bold(cyan('║                                                                  ║')));
+console.log(
+  cyan('║') + bold('           🦴  E V O - T A C T I C S   D E M O  🦴             ') + cyan('║'),
+);
+console.log(
+  cyan('║') + dim(`                      launcher v${VERSION}                       `) + cyan('║'),
+);
+console.log(bold(cyan('║                                                                  ║')));
+console.log(bold(cyan('╚══════════════════════════════════════════════════════════════════╝')));
+console.log('');
+
+// ── Pre-flight ─────────────────────────────────────────────────────────
+console.log(bold('▸ Pre-flight checks'));
+
+let preflightFail = false;
+
+// Node version
+const [nodeMajor] = process.versions.node.split('.').map(Number);
+if (nodeMajor >= 18) ok(`Node.js v${process.versions.node}`);
+else {
+  fail(`Node.js v${process.versions.node} troppo vecchio`, 'installa Node 18+ da nodejs.org');
+  preflightFail = true;
+}
+
+// Port 3334 free
+function portFree(port) {
+  return new Promise((resolve) => {
+    const s = net.createServer();
+    s.once('error', () => resolve(false));
+    s.once('listening', () => {
+      s.close(() => resolve(true));
+    });
+    s.listen(port, '127.0.0.1');
+  });
+}
+
+// ngrok presence
+const ngrokWhich = spawnSync(process.platform === 'win32' ? 'where' : 'which', ['ngrok'], {
+  encoding: 'utf8',
 });
+const ngrokPath = (ngrokWhich.stdout || '').split(/\r?\n/).filter(Boolean)[0];
+if (ngrokPath) ok(`ngrok trovato (${ngrokPath})`);
+else {
+  fail('ngrok non trovato', 'installa da https://ngrok.com/download');
+  preflightFail = true;
+}
 
-console.log('[launcher] avvio ngrok tunnel su porta ' + PORT + '...');
-const ngrok = spawn('ngrok', ['http', String(PORT), '--log=stdout'], {
-  stdio: ['ignore', 'pipe', 'pipe'],
-  env: process.env,
-  shell: process.platform === 'win32',
-});
+// ngrok authtoken
+function ngrokTokenConfigured() {
+  const candidates = [
+    path.join(process.env.LOCALAPPDATA || '', 'ngrok', 'ngrok.yml'),
+    path.join(process.env.USERPROFILE || '', 'AppData', 'Local', 'ngrok', 'ngrok.yml'),
+    path.join(process.env.HOME || '', '.config', 'ngrok', 'ngrok.yml'),
+    path.join(process.env.HOME || '', 'Library', 'Application Support', 'ngrok', 'ngrok.yml'),
+  ];
+  for (const p of candidates) {
+    try {
+      const body = fs.readFileSync(p, 'utf8');
+      if (/authtoken:\s*\S+/i.test(body)) return p;
+    } catch {
+      /* file missing */
+    }
+  }
+  return null;
+}
+const tokenPath = ngrokTokenConfigured();
+if (tokenPath) ok('ngrok authtoken configurato');
+else
+  fail(
+    'ngrok authtoken assente',
+    'ngrok config add-authtoken <TOKEN> (https://dashboard.ngrok.com/get-started/your-authtoken)',
+  );
+// Missing token → warn but continue (ngrok shows clear error itself)
 
-ngrok.on('error', (err) => {
-  console.error('\n[launcher] ERRORE: ngrok non trovato. Installa da https://ngrok.com/download');
-  console.error('         Dopo installazione: ngrok config add-authtoken <TUO-TOKEN>');
-  console.error('         Error:', err.message);
-  backend.kill();
-  process.exit(1);
-});
+// dist freschezza (warn se mancante; sarà buildato dal .bat step precedente)
+const distIndex = path.join(REPO_ROOT, 'apps', 'play', 'dist', 'index.html');
+if (fs.existsSync(distIndex)) ok('frontend dist presente');
+else {
+  fail('apps/play/dist/index.html mancante', "lancia 'npm run play:build' prima");
+  preflightFail = true;
+}
 
-// ngrok log buffer per debug
-ngrok.stdout?.on('data', () => {});
-ngrok.stderr?.on('data', () => {});
+// Check porta libera solo se pre-flight passa (altrimenti sbagliamo errore)
+(async () => {
+  if (preflightFail) {
+    console.log('');
+    console.log(red(bold('Pre-flight fallito. Risolvi sopra e riprova.')));
+    process.exit(1);
+  }
 
-let printed = false;
+  const free = await portFree(PORT);
+  if (free) ok(`porta ${PORT} libera`);
+  else {
+    fail(`porta ${PORT} occupata`, 'chiudi altra istanza backend o killa processo');
+    process.exit(1);
+  }
+
+  console.log('');
+  start();
+})();
+
+// ── Launch sequence ─────────────────────────────────────────────────────
+function start() {
+  fs.mkdirSync(LOGS_DIR, { recursive: true });
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const demoLogPath = path.join(LOGS_DIR, `demo-${ts}.log`);
+  const demoLog = fs.createWriteStream(demoLogPath, { flags: 'a' });
+
+  console.log(bold('▸ Avvio backend'));
+  info(`log → ${path.relative(REPO_ROOT, demoLogPath)}`);
+
+  const backendEntry = path.resolve(REPO_ROOT, 'apps', 'backend', 'index.js');
+  const backend = spawn(process.execPath, [backendEntry], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: process.env,
+  });
+  backend.stdout.pipe(demoLog);
+  backend.stderr.pipe(demoLog);
+
+  backend.on('error', (err) => {
+    fail(`backend spawn error: ${err.message}`);
+    process.exit(1);
+  });
+
+  // ── Health probe ───────────────────────────────────────────────────
+  let backendReady = false;
+  async function probeBackend() {
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      await sleep(500);
+      try {
+        const r = await httpGet(`http://127.0.0.1:${PORT}/api/health`, 800);
+        if (r && r.statusCode === 200) return true;
+      } catch {
+        /* retry */
+      }
+    }
+    return false;
+  }
+
+  probeBackend().then((ready) => {
+    if (!ready) {
+      fail('backend non risponde dopo 20s', `controlla ${path.relative(REPO_ROOT, demoLogPath)}`);
+      backend.kill();
+      process.exit(1);
+    }
+    backendReady = true;
+    ok(`backend live su http://127.0.0.1:${PORT}`);
+    console.log('');
+    startTunnel(demoLogPath);
+  });
+
+  // Shutdown handlers (installed subito per Ctrl+C durante probe)
+  const shutdown = () => {
+    console.log('');
+    console.log(dim('[launcher] stop backend + ngrok...'));
+    try {
+      backend.kill();
+    } catch {}
+    process.exit(0);
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+  process.on('exit', () => {
+    try {
+      backend.kill();
+    } catch {}
+  });
+
+  backend.on('exit', (code) => {
+    if (!backendReady) return; // probe already exits
+    console.log('');
+    console.log(yellow(`[launcher] backend chiuso (code ${code}). Stop tunnel.`));
+    process.exit(code ?? 0);
+  });
+}
+
+function startTunnel(demoLogPath) {
+  console.log(bold('▸ Avvio ngrok tunnel'));
+  const demoLog = fs.createWriteStream(demoLogPath, { flags: 'a' });
+  const ngrok = spawn('ngrok', ['http', String(PORT), '--log=stdout'], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: process.env,
+    shell: process.platform === 'win32',
+  });
+  ngrok.stdout.pipe(demoLog);
+  ngrok.stderr.pipe(demoLog);
+  ngrok.on('error', (err) => {
+    fail(`ngrok spawn error: ${err.message}`);
+    process.exit(1);
+  });
+  ngrok.on('exit', (code) => {
+    console.log('');
+    console.log(yellow(`[launcher] ngrok chiuso (code ${code}).`));
+    process.exit(code ?? 0);
+  });
+
+  (async () => {
+    const url = await pollTunnel();
+    if (!url) {
+      fail(
+        'impossibile recuperare URL ngrok dopo 90s',
+        'controlla dashboard http://localhost:4040',
+      );
+      return;
+    }
+    ok(`tunnel pubblico attivo`);
+    const shareUrl = `${url}/play/lobby.html`;
+    const qrImg = `https://api.qrserver.com/v1/create-qr-code/?data=${encodeURIComponent(shareUrl)}&size=220x220`;
+
+    // Auto-copy URL to clipboard
+    copyToClipboard(shareUrl).then((copied) => {
+      if (copied) info('URL copiato negli appunti (Ctrl+V per incollare)');
+    });
+
+    printReadyBanner(shareUrl, qrImg);
+
+    // Auto-open browser dopo 800ms (dá tempo banner di essere letto)
+    setTimeout(() => {
+      openInBrowser(shareUrl);
+    }, 800);
+  })();
+}
+
+// ── Banner ready ────────────────────────────────────────────────────────
+function printReadyBanner(shareUrl, qrImg) {
+  const w = 72;
+  const line = (s) => {
+    const pad = Math.max(0, w - stripAnsi(s).length - 4);
+    return `${mag('║')}  ${s}${' '.repeat(pad)}  ${mag('║')}`;
+  };
+  console.log('');
+  console.log(mag('╔' + '═'.repeat(w - 2) + '╗'));
+  console.log(mag('║') + ' '.repeat(w - 2) + mag('║'));
+  console.log(line(bold(green('🎮  DEMO LIVE — pronto per giocare!'))));
+  console.log(mag('║') + ' '.repeat(w - 2) + mag('║'));
+  console.log(line(bold('Share amici:')));
+  console.log(line(cyan(shareUrl)));
+  console.log(mag('║') + ' '.repeat(w - 2) + mag('║'));
+  console.log(line(dim('QR mobile:')));
+  console.log(line(dim(qrImg)));
+  console.log(mag('║') + ' '.repeat(w - 2) + mag('║'));
+  console.log(line(dim('Dashboard ngrok: http://localhost:4040')));
+  console.log(line(dim('Ctrl+C per fermare tutto')));
+  console.log(mag('║') + ' '.repeat(w - 2) + mag('║'));
+  console.log(mag('╚' + '═'.repeat(w - 2) + '╝'));
+  console.log('');
+  console.log(bold(yellow('→ Apro browser host automaticamente...')));
+  console.log('');
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function httpGet(url, timeoutMs = 1500) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, (res) => {
+      res.resume();
+      resolve(res);
+    });
+    req.on('error', reject);
+    req.setTimeout(timeoutMs, () => {
+      req.destroy();
+      reject(new Error('timeout'));
+    });
+  });
+}
+
 async function pollTunnel() {
   for (let attempt = 0; attempt < 60; attempt += 1) {
-    await new Promise((r) => setTimeout(r, 1500));
+    await sleep(1500);
     try {
       const url = await new Promise((resolve, reject) => {
         const req = http.get(NGROK_API, (res) => {
@@ -72,57 +348,41 @@ async function pollTunnel() {
       });
       if (url) return url;
     } catch {
-      // noop, ritenta
+      /* retry */
     }
   }
   return null;
 }
 
-pollTunnel().then((url) => {
-  if (!url) {
-    console.error('\n[launcher] Impossibile recuperare URL ngrok dopo 90s.');
-    console.error('          Controlla dashboard ngrok: http://localhost:4040');
-    return;
+function openInBrowser(url) {
+  const cmd =
+    process.platform === 'win32' ? 'start' : process.platform === 'darwin' ? 'open' : 'xdg-open';
+  const args = process.platform === 'win32' ? ['""', url] : [url];
+  try {
+    spawn(cmd, args, { shell: true, detached: true, stdio: 'ignore' }).unref();
+  } catch {
+    // ignore — user can click URL manually
   }
-  printed = true;
-  const shareUrl = `${url}/play/lobby.html`;
-  banner(
-    `  🦴 EVO-TACTICS DEMO LIVE\n\n` +
-      `  Host (tu): ${shareUrl}\n` +
-      `  Share amici: ${shareUrl}\n\n` +
-      `  Dashboard ngrok: http://localhost:4040\n` +
-      `  Ctrl+C per fermare tutto`,
-  );
-});
+}
 
-const shutdown = () => {
-  console.log('\n[launcher] stop...');
-  try {
-    backend.kill();
-  } catch {}
-  try {
-    ngrok.kill();
-  } catch {}
-  process.exit(0);
-};
+function copyToClipboard(text) {
+  return new Promise((resolve) => {
+    const cmd =
+      process.platform === 'win32' ? 'clip' : process.platform === 'darwin' ? 'pbcopy' : 'xclip';
+    const args = process.platform === 'linux' ? ['-selection', 'clipboard'] : [];
+    try {
+      const p = spawn(cmd, args, { stdio: ['pipe', 'ignore', 'ignore'] });
+      p.on('error', () => resolve(false));
+      p.on('exit', (code) => resolve(code === 0));
+      p.stdin.write(text);
+      p.stdin.end();
+    } catch {
+      resolve(false);
+    }
+  });
+}
 
-process.on('SIGINT', shutdown);
-process.on('SIGTERM', shutdown);
-
-backend.on('exit', (code) => {
-  console.log(`[launcher] backend exit ${code}`);
-  try {
-    ngrok.kill();
-  } catch {}
-  process.exit(code ?? 0);
-});
-
-ngrok.on('exit', (code) => {
-  if (!printed) {
-    console.error(`[launcher] ngrok exit ${code} prima di stampare URL.`);
-  }
-  try {
-    backend.kill();
-  } catch {}
-  process.exit(code ?? 0);
-});
+function stripAnsi(s) {
+  // eslint-disable-next-line no-control-regex
+  return String(s).replace(/\x1b\[[0-9;]*m/g, '');
+}


### PR DESCRIPTION
## Summary

UX upgrade launcher demo per playtest live. Research-driven da pattern commercial launcher (Steam/itch.io/LAN-party).

**Prima** (pre PR):
- User doveva fixare manualmente errori runtime (cryptic EADDRINUSE, ngrok authtoken mancante, dist stale)
- Doveva copiare URL manualmente dal banner
- Doveva aprire browser manualmente
- Nessun feedback se backend crashed pre-ngrok
- Banner inquinato da backend stdout noisy

**Dopo**:
- ✓ 5 preflight checks con fix hint inline (Node/ngrok/authtoken/dist/port)
- ✓ Health probe `/api/health` prima di dichiarare ready
- ✓ Banner pulito (backend log → `logs/demo-<ts>.log`)
- ✓ Auto-copy URL in clipboard
- ✓ Auto-open browser host
- ✓ QR code URL per mobile friends
- ✓ Graceful shutdown Ctrl+C

## Test plan

- [x] Smoke end-to-end locale: preflight 5/5 + backend /api/health OK + ngrok tunnel + browser auto-open + clipboard confermati
- [x] `node --check` syntax OK
- [x] `npm run format:check` verde
- [ ] Smoke via launcher .bat (userland — pronto per run)

## Rollback

Revert commit `f5b4bc60`. Zero impatto runtime backend/gameplay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)