### PR TITLE
feat(combat): M14-B wire elevation + flank bonus + pincer detection

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -109,6 +109,8 @@ const {
   pickLowestHpEnemy,
   stepTowards,
   isBackstab,
+  attackQuadrant,
+  computePositionalDamage,
   facingFromMove,
   predictCombat,
 } = require('./sessionHelpers');
@@ -326,7 +328,17 @@ function createSessionRouter(options = {}) {
         backstabBonus +
         perkBonus.bonus +
         parryDelta;
-      damageDealt = Math.max(0, adjusted);
+      // M14-B 2026-04-25 — Triangle Strategy positional multiplier wire.
+      // Elevation delta >=1 → +30% dmg; flank → +15%; rear bonus already
+      // covered by legacy backstabBonus (rearMultiplier stays 0 to avoid
+      // double-apply). When unit.elevation/facing missing, multiplier = 1
+      // → zero behavior change vs pre-M14-B.
+      const positional = computePositionalDamage({
+        actor,
+        target,
+        baseDamage: Math.max(0, adjusted),
+      });
+      damageDealt = positional.damage;
       if (perkBonus.applied.some((p) => p.tag === 'first_strike_bonus')) {
         actor._first_strike_used = true;
       }

--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -340,6 +340,88 @@ function isBackstab(actor, target) {
   return false;
 }
 
+/**
+ * M14-B 2026-04-25 — classify attacker quadrant relative to target facing.
+ * Extends isBackstab() with side-attack detection (flank).
+ * Returns: 'rear' | 'flank' | 'front'.
+ * Ref: docs/research/triangle-strategy-transfer-plan.md:186 (Mechanic 3C)
+ */
+function attackQuadrant(actor, target) {
+  if (!actor?.position || !target?.position) return 'front';
+  const f = target.facing || DEFAULT_FACING;
+  const dx = actor.position.x - target.position.x;
+  const dy = actor.position.y - target.position.y;
+  // Rear matches isBackstab() exactly to preserve legacy backstab semantics.
+  if (f === 'N' && dy > 0) return 'rear';
+  if (f === 'S' && dy < 0) return 'rear';
+  if (f === 'E' && dx < 0) return 'rear';
+  if (f === 'W' && dx > 0) return 'rear';
+  // Front: same side as facing.
+  if (f === 'N' && dy < 0 && dx === 0) return 'front';
+  if (f === 'S' && dy > 0 && dx === 0) return 'front';
+  if (f === 'E' && dx > 0 && dy === 0) return 'front';
+  if (f === 'W' && dx < 0 && dy === 0) return 'front';
+  // Flank: anything orthogonal to facing (side) OR a diagonal that isn't rear/front.
+  return 'flank';
+}
+
+/**
+ * M14-B 2026-04-25 — Triangle Strategy positional damage multiplier.
+ * Pure helper. Caller passes baseDamage + actor + target + opts; receives the
+ * adjusted damage + breakdown for logging.
+ *
+ * Multipliers applied (multiplicatively, TS-style):
+ *   elevation: delta >= 1 → +30% default (mirror penalty -15% when below)
+ *   flank:     side attack → +15% damage (default)
+ *   rear:      rear attack → +0% here; rear bonus remains in session.js as
+ *              legacy +1 flat (do not double-apply). Caller opts in via
+ *              rearMultiplier if desired.
+ *
+ * Cap: final multiplier clamped to [0.1, 2.0] to avoid stacking one-shots.
+ *
+ * Ref: docs/research/triangle-strategy-transfer-plan.md:229 (stacking risk)
+ */
+function computePositionalDamage({
+  actor,
+  target,
+  baseDamage,
+  elevationBonus = 0.3,
+  elevationPenalty = -0.15,
+  flankBonus = 0.15,
+  rearMultiplier = 0, // default 0: legacy +1 rear bonus preserved elsewhere
+} = {}) {
+  const base = Number.isFinite(baseDamage) ? baseDamage : 0;
+  if (base <= 0) {
+    return { damage: 0, quadrant: 'front', elevation_delta: 0, multiplier: 1, parts: {} };
+  }
+  const quadrant = attackQuadrant(actor, target);
+  const aElev = Number.isFinite(Number(actor?.elevation)) ? Number(actor.elevation) : 0;
+  const tElev = Number.isFinite(Number(target?.elevation)) ? Number(target.elevation) : 0;
+  const delta = aElev - tElev;
+
+  let elevMul = 1;
+  if (delta >= 1) elevMul = 1 + elevationBonus;
+  else if (delta <= -1) elevMul = 1 + elevationPenalty;
+  let flankMul = 1;
+  if (quadrant === 'flank') flankMul = 1 + flankBonus;
+  let rearMul = 1;
+  if (quadrant === 'rear') rearMul = 1 + rearMultiplier;
+
+  const total = Math.max(0.1, Math.min(2.0, elevMul * flankMul * rearMul));
+  const damage = Math.max(0, Math.floor(base * total));
+  return {
+    damage,
+    quadrant,
+    elevation_delta: delta,
+    multiplier: Math.round(total * 100) / 100,
+    parts: {
+      elevation: Math.round(elevMul * 100) / 100,
+      flank: Math.round(flankMul * 100) / 100,
+      rear: Math.round(rearMul * 100) / 100,
+    },
+  };
+}
+
 function facingFromMove(from, to) {
   const dx = to.x - from.x;
   const dy = to.y - from.y;
@@ -413,6 +495,8 @@ module.exports = {
   pickLowestHpEnemy,
   stepTowards,
   isBackstab,
+  attackQuadrant,
+  computePositionalDamage,
   facingFromMove,
   predictCombat,
   computeSistemaTier,

--- a/apps/backend/services/grid/hexGrid.js
+++ b/apps/backend/services/grid/hexGrid.js
@@ -248,6 +248,46 @@ function elevationDamageMultiplier({
   return Math.max(mult, 0.1);
 }
 
+/**
+ * M14-B 2026-04-25 — Triangle Strategy Mechanic 3B pincer detection.
+ * Pure helper; does NOT enqueue follow-up intents (round orchestrator untouched).
+ * Caller receives metadata and can decide whether to emit a follow-up intent.
+ *
+ * Rule: an ally forms a pincer with `attacker` on `target` iff the ally sits
+ * on the antipodal hex from `attacker` relative to `target`. On a hex grid
+ * with 6 axial directions, "antipodal" means `ally - target == -(attacker - target)`.
+ *
+ * Requires attacker at hex distance exactly 1 from target (TS opposite-side
+ * adjacent rule).
+ *
+ * @param {{q,r}} attackerHex
+ * @param {{q,r}} targetHex
+ * @param {Array<{q,r,id?}>} allies — ally positions (attacker excluded upstream)
+ * @returns {{ pincer: boolean, opposite_ally_id: string|null, opposite_hex: {q,r}|null }}
+ *
+ * Ref: docs/research/triangle-strategy-transfer-plan.md:187,209
+ */
+function detectPincer(attackerHex, targetHex, allies) {
+  if (!attackerHex || !targetHex) {
+    return { pincer: false, opposite_ally_id: null, opposite_hex: null };
+  }
+  if (hexDistance(attackerHex, targetHex) !== 1) {
+    return { pincer: false, opposite_ally_id: null, opposite_hex: null };
+  }
+  const dq = attackerHex.q - targetHex.q;
+  const dr = attackerHex.r - targetHex.r;
+  const oppositeHex = { q: targetHex.q - dq, r: targetHex.r - dr };
+  if (!Array.isArray(allies)) {
+    return { pincer: false, opposite_ally_id: null, opposite_hex: oppositeHex };
+  }
+  const oppositeAlly = allies.find((a) => a && a.q === oppositeHex.q && a.r === oppositeHex.r);
+  return {
+    pincer: Boolean(oppositeAlly),
+    opposite_ally_id: oppositeAlly?.id ?? null,
+    opposite_hex: oppositeHex,
+  };
+}
+
 module.exports = {
   DIRECTIONS,
   hexKey,
@@ -260,4 +300,5 @@ module.exports = {
   getLineOfSight,
   cubeRound,
   elevationDamageMultiplier,
+  detectPincer,
 };

--- a/tests/services/pincer.test.js
+++ b/tests/services/pincer.test.js
@@ -1,0 +1,81 @@
+// M14-B 2026-04-25 — pincer detection unit tests.
+// Ref: docs/research/triangle-strategy-transfer-plan.md:187,209
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { detectPincer } = require('../../apps/backend/services/grid/hexGrid');
+
+test('pincer: ally on antipodal hex → pincer=true', () => {
+  const attacker = { q: 1, r: 0 };
+  const target = { q: 0, r: 0 };
+  const allies = [{ q: -1, r: 0, id: 'ally_1' }];
+  const result = detectPincer(attacker, target, allies);
+  assert.equal(result.pincer, true);
+  assert.equal(result.opposite_ally_id, 'ally_1');
+  assert.deepEqual(result.opposite_hex, { q: -1, r: 0 });
+});
+
+test('pincer: no ally on antipodal hex → pincer=false but hex exposed', () => {
+  const attacker = { q: 1, r: 0 };
+  const target = { q: 0, r: 0 };
+  const allies = [{ q: 0, r: 1, id: 'ally_side' }];
+  const result = detectPincer(attacker, target, allies);
+  assert.equal(result.pincer, false);
+  assert.equal(result.opposite_ally_id, null);
+  assert.deepEqual(result.opposite_hex, { q: -1, r: 0 });
+});
+
+test('pincer: attacker not adjacent → pincer=false', () => {
+  const attacker = { q: 2, r: 0 };
+  const target = { q: 0, r: 0 };
+  const allies = [{ q: -2, r: 0, id: 'ally_1' }];
+  const result = detectPincer(attacker, target, allies);
+  assert.equal(result.pincer, false);
+  assert.equal(result.opposite_hex, null);
+});
+
+test('pincer: all 6 antipodal hex pairs work (axial directions)', () => {
+  const target = { q: 5, r: 5 };
+  const pairs = [
+    [
+      { q: 6, r: 5 },
+      { q: 4, r: 5 },
+    ], // +q / -q
+    [
+      { q: 6, r: 4 },
+      { q: 4, r: 6 },
+    ], // NE / SW
+    [
+      { q: 5, r: 4 },
+      { q: 5, r: 6 },
+    ], // -r / +r
+  ];
+  for (const [attacker, oppHex] of pairs) {
+    const result = detectPincer(attacker, target, [{ ...oppHex, id: 'opp' }]);
+    assert.equal(result.pincer, true, `expected pincer for attacker ${JSON.stringify(attacker)}`);
+  }
+});
+
+test('pincer: allies=null handled gracefully', () => {
+  const attacker = { q: 1, r: 0 };
+  const target = { q: 0, r: 0 };
+  const result = detectPincer(attacker, target, null);
+  assert.equal(result.pincer, false);
+  assert.deepEqual(result.opposite_hex, { q: -1, r: 0 });
+});
+
+test('pincer: missing attacker/target → pincer=false', () => {
+  assert.equal(detectPincer(null, { q: 0, r: 0 }, []).pincer, false);
+  assert.equal(detectPincer({ q: 1, r: 0 }, null, []).pincer, false);
+});
+
+test('pincer: ally id null when anonymous ally hex present', () => {
+  const result = detectPincer(
+    { q: 1, r: 0 },
+    { q: 0, r: 0 },
+    [{ q: -1, r: 0 }], // no id field
+  );
+  assert.equal(result.pincer, true);
+  assert.equal(result.opposite_ally_id, null);
+});

--- a/tests/services/positionalDamage.test.js
+++ b/tests/services/positionalDamage.test.js
@@ -1,0 +1,127 @@
+// M14-B 2026-04-25 — positional damage + attackQuadrant unit tests.
+// Ref: docs/research/triangle-strategy-transfer-plan.md:186-209
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  attackQuadrant,
+  computePositionalDamage,
+} = require('../../apps/backend/routes/sessionHelpers');
+
+function mkUnit({ x = 0, y = 0, facing = 'S', elevation } = {}) {
+  const u = { position: { x, y }, facing };
+  if (elevation !== undefined) u.elevation = elevation;
+  return u;
+}
+
+test('attackQuadrant: rear matches target facing south, actor above', () => {
+  const target = mkUnit({ x: 3, y: 3, facing: 'S' });
+  const actor = mkUnit({ x: 3, y: 2 }); // behind target (north of S-facing)
+  assert.equal(attackQuadrant(actor, target), 'rear');
+});
+
+test('attackQuadrant: front when actor on facing side', () => {
+  const target = mkUnit({ x: 3, y: 3, facing: 'S' });
+  const actor = mkUnit({ x: 3, y: 4 });
+  assert.equal(attackQuadrant(actor, target), 'front');
+});
+
+test('attackQuadrant: flank on orthogonal side', () => {
+  const target = mkUnit({ x: 3, y: 3, facing: 'S' });
+  const actorE = mkUnit({ x: 4, y: 3 });
+  const actorW = mkUnit({ x: 2, y: 3 });
+  assert.equal(attackQuadrant(actorE, target), 'flank');
+  assert.equal(attackQuadrant(actorW, target), 'flank');
+});
+
+test('attackQuadrant: facing N rotates rear to south-of-target', () => {
+  const target = mkUnit({ x: 3, y: 3, facing: 'N' });
+  const actor = mkUnit({ x: 3, y: 4 });
+  assert.equal(attackQuadrant(actor, target), 'rear');
+});
+
+test('attackQuadrant: missing position → front (safe default)', () => {
+  assert.equal(attackQuadrant({}, mkUnit()), 'front');
+  assert.equal(attackQuadrant(mkUnit(), {}), 'front');
+});
+
+test('positional: baseline no elevation/flank → multiplier 1.0', () => {
+  const actor = mkUnit({ x: 3, y: 4 });
+  const target = mkUnit({ x: 3, y: 3, facing: 'S' });
+  const res = computePositionalDamage({ actor, target, baseDamage: 10 });
+  assert.equal(res.damage, 10);
+  assert.equal(res.quadrant, 'front');
+  assert.equal(res.multiplier, 1);
+});
+
+test('positional: flank attack → +15% damage (11 from 10 floor)', () => {
+  const actor = mkUnit({ x: 4, y: 3 });
+  const target = mkUnit({ x: 3, y: 3, facing: 'S' });
+  const res = computePositionalDamage({ actor, target, baseDamage: 10 });
+  assert.equal(res.quadrant, 'flank');
+  assert.equal(res.damage, 11); // floor(10 * 1.15) = 11
+  assert.equal(res.multiplier, 1.15);
+});
+
+test('positional: elevation above → +30%', () => {
+  const actor = mkUnit({ x: 4, y: 3, elevation: 2 });
+  const target = mkUnit({ x: 3, y: 3, facing: 'S', elevation: 1 });
+  const res = computePositionalDamage({ actor, target, baseDamage: 10 });
+  assert.equal(res.elevation_delta, 1);
+  // flank + elevation: 1.15 * 1.30 = 1.495 → floor(10 * 1.495) = 14
+  assert.equal(res.damage, 14);
+});
+
+test('positional: elevation below → -15% penalty', () => {
+  const actor = mkUnit({ x: 3, y: 4, elevation: 0 });
+  const target = mkUnit({ x: 3, y: 3, facing: 'S', elevation: 2 });
+  const res = computePositionalDamage({ actor, target, baseDamage: 10 });
+  assert.equal(res.quadrant, 'front');
+  assert.equal(res.elevation_delta, -2);
+  assert.equal(res.damage, 8); // floor(10 * 0.85) = 8
+});
+
+test('positional: zero base damage returns 0 + front quadrant', () => {
+  const res = computePositionalDamage({ actor: mkUnit(), target: mkUnit(), baseDamage: 0 });
+  assert.equal(res.damage, 0);
+  assert.equal(res.multiplier, 1);
+});
+
+test('positional: multiplier capped at 2.0 (anti-oneshot)', () => {
+  const actor = mkUnit({ x: 4, y: 3, elevation: 5 });
+  const target = mkUnit({ x: 3, y: 3, facing: 'S', elevation: 0 });
+  const res = computePositionalDamage({
+    actor,
+    target,
+    baseDamage: 10,
+    elevationBonus: 1.5, // hypothetical enormous bonus
+    flankBonus: 0.5,
+    rearMultiplier: 0,
+  });
+  // 2.5 * 1.5 = 3.75 → cap 2.0 → damage = 20
+  assert.ok(res.damage <= 20);
+  assert.ok(res.multiplier <= 2);
+});
+
+test('positional: rear uses legacy flat (rearMultiplier=0 default, no double-apply)', () => {
+  const actor = mkUnit({ x: 3, y: 2 });
+  const target = mkUnit({ x: 3, y: 3, facing: 'S' });
+  const res = computePositionalDamage({ actor, target, baseDamage: 10 });
+  assert.equal(res.quadrant, 'rear');
+  // rearMultiplier=0 default → no extra multiplier; legacy +1 backstab lives in session.js
+  assert.equal(res.multiplier, 1);
+  assert.equal(res.damage, 10);
+});
+
+test('positional: explicit rearMultiplier honored', () => {
+  const actor = mkUnit({ x: 3, y: 2 });
+  const target = mkUnit({ x: 3, y: 3, facing: 'S' });
+  const res = computePositionalDamage({
+    actor,
+    target,
+    baseDamage: 10,
+    rearMultiplier: 0.5,
+  });
+  assert.equal(res.damage, 15);
+});


### PR DESCRIPTION
## Summary

Slice runtime **M14-B** seguito di [#1736](https://github.com/MasterDD-L34D/Game/pull/1736) (M14-A helper). Wire elevation nel damage step + nuovo flank bonus + pincer detection helper. Tutto pure additive, zero behavior change su scenari esistenti.

### 3 meccaniche Triangle Strategy shippate

| Meccanica | Cosa fa | Dove |
|---|---|---|
| **Elevation bonus** (M3A) | +30% dmg da sopra, -15% da sotto | wired in `session.js` damage step |
| **Flank bonus** (M3C) | +15% dmg attacco laterale | `attackQuadrant` + `computePositionalDamage` |
| **Pincer detection** (M3B) | Rileva ally su hex antipodale | pure helper in `hexGrid.js` (no round wire) |

### Wire limitato

Solo `session.js` damage line (~329). Multiplier cap [0.1, 2.0] anti-oneshot (TS stacking cap). **Baseline zero behavior change**: tutorial scenarios senza `unit.elevation`/`facing` configurato → quadrant=front, delta=0, multiplier=1.0.

## Out of scope (deferred)

- Wire elevation in abilityExecutor.js 6 damage points (richiede helper refactor >60 LOC)
- Pincer follow-up intent enqueue (richiede roundOrchestrator.pushFollowup API)
- Weather global modifier (M15)

## Test plan

- [x] AI regression 307/307 verde
- [x] positionalDamage tests 13/13
- [x] pincer tests 8/8
- [x] format:check verde
- [x] Aggregate +21 nuovi = 39/39 services tests

## Rollback 03A

- `session.js`: revert line → \`damageDealt = Math.max(0, adjusted)\`. Helper unused post-revert.
- Helper mai chiamati altrove → safe remove.

## Refs

- docs/research/triangle-strategy-transfer-plan.md §3
- PR #1736 M14-A (helper shipping, now wired)

Generated with Claude Code