### PR TITLE
feat(combat): M14-C P1 wire elevation in surge_aoe

### DIFF
--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -1485,9 +1485,19 @@ function createAbilityExecutor(deps) {
     const targets = inArea.filter((u) => u.controlled_by !== actor.controlled_by);
 
     const damaged = [];
+    // M14-C 2026-04-26 — wire elevation multiplier su surge_aoe dice roll.
+    // Unico site in abilityExecutor che bypassa performAttack (L249 session.js)
+    // perche' rolla dadi diretti senza hit check. Per-target perche' ogni
+    // target AoE ha elevation/facing proprio rispetto all'actor.
+    const { computePositionalDamage } = require('../routes/sessionHelpers');
     for (const target of targets) {
       const rolled = rollDice(ability.damage_dice, rng);
-      let damage = Math.max(0, rolled);
+      const positional = computePositionalDamage({
+        actor,
+        target,
+        baseDamage: Math.max(0, rolled),
+      });
+      let damage = positional.damage;
       // Shield assorb su area damage anche
       let absorbed = 0;
       if (Number(target.shield_hp) > 0 && damage > 0) {
@@ -1507,6 +1517,8 @@ function createAbilityExecutor(deps) {
         hp_before: hpBefore,
         hp_after: target.hp,
         killed: target.hp === 0,
+        positional_mult: positional.multiplier,
+        elevation_delta: positional.elevation_delta,
       });
     }
 

--- a/tests/api/abilityExecutor.test.js
+++ b/tests/api/abilityExecutor.test.js
@@ -566,6 +566,39 @@ test('cataclysm: surge_aoe danno area + stress_reset, shield-aware', async (t) =
   for (const d of res.body.damaged) {
     assert.ok(typeof d.damage_dealt === 'number');
     assert.ok(typeof d.shield_absorbed === 'number');
+    // M14-C: positional_mult esposto anche quando elevation=0 (multiplier 1).
+    assert.ok(typeof d.positional_mult === 'number');
+    assert.ok(typeof d.elevation_delta === 'number');
+  }
+});
+
+// M14-C 2026-04-26 — surge_aoe honor elevation: attacker above targets = +30% dmg.
+test('cataclysm surge_aoe: actor elevation 1 vs target 0 → multiplier 1.3 riportato', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  // Usa scenario tutorial_01 ma muta units con elevation raise per p_scout.
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  const units = scenario.body.units.map((u) => (u.id === 'p_scout' ? { ...u, elevation: 1 } : u));
+  const startRes = await request(app).post('/api/session/start').send({ units });
+  const sid = startRes.body.session_id;
+  const res = await request(app)
+    .post('/api/session/action')
+    .send({
+      session_id: sid,
+      action_type: 'ability',
+      actor_id: 'p_scout',
+      ability_id: 'cataclysm',
+      position: { x: 3, y: 3 },
+    });
+  assert.equal(res.status, 200, `surge_aoe elev ok: ${JSON.stringify(res.body)}`);
+  assert.ok(res.body.damaged.length > 0, 'almeno 1 target in area');
+  for (const d of res.body.damaged) {
+    // actor +1 vs target 0. Multiplier in [1.3, 1.3*1.15=1.495] (flank/front quadrant).
+    assert.ok(d.positional_mult >= 1.3, `target ${d.unit_id} elev bonus ≥ 1.3`);
+    assert.equal(d.elevation_delta, 1);
   }
 });
 


### PR DESCRIPTION
## Summary

P1 slice M14-C (follow-up di #1739 P0). Audit `abilityExecutor.js` rileva 5 damage sites (`target.hp = Math.max(0, target.hp - X)`):

- 4 sono **post-performAttack adjustments** (damage_step_mod tweaks su `res.damageDealt` già elevation-multiplied via `session.js#performAttack:249`)
- **1 sola bypassa performAttack**: `executeSurgeAoe` (L1499) rolla dadi diretti + shield absorb + HP sub

Fix: wrap `rolled` in `computePositionalDamage` per-target (ogni target AoE ha facing/elevation proprio rispetto all'actor), poi pass through shield + HP. Expose `positional_mult` + `elevation_delta` in `damaged[]` per UI/telemetry.

## Nota di scope rispetto al handoff

Handoff prevedeva refactor esteso con helper `applyPositionalDamageToUnit` su 6 siti. Audit mostra che `performAttack` (session.js:249) già applica `computePositionalDamage` a TUTTI gli ability che passano per `resolveAttack`: multi_attack, drain, execution, attack_move, attack_push, ranged, team_*, aoe_buff, aoe_debuff. Solo surge_aoe bypassa perche' è pure-dice senza hit check. Refactor helper = over-scope per 1 site.

## Test plan

- [x] `node --test tests/api/abilityExecutor.test.js` → 35/35 (34 esistenti + 1 nuovo elevation)
- [x] `node --test tests/ai/*.test.js` → 307/307
- [x] `node --test tests/services/*.test.js` → 177/177
- [x] `npm run format:check` → verde

## Rollback

Revert 1 edit in `abilityExecutor.js` (rimuovi `computePositionalDamage` wrap → damage = `rolled`). Zero side effect su altri ability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)