### PR TITLE
docs(combat): M14-C accuracy fixes — calibration report + ADR pincer

### DIFF
--- a/docs/adr/ADR-2026-04-26-pincer-followup-queue.md
+++ b/docs/adr/ADR-2026-04-26-pincer-followup-queue.md
@@ -157,8 +157,10 @@ resolveRound tick:
    **no follow-up su move** — solo dopo hit confermato. Previene pincer-setup
    exploit (move in, alleato attacca, follow-up).
 3. **Hex vs grid mapping**: detectPincer richiede hex coords (axial). Session.js
-   attualmente usa {x, y} grid orthogonal. Conversion layer `gridToHex` richiesto
-   (banale: `{ q: x, r: y - x/2 }` per flat-top convention). Scope doc, non ADR.
+   attualmente usa {x, y} grid orthogonal. Conversion layer `gridToHex` richiesto;
+   la formula dipende dalla convenzione hex adottata (offset odd-r vs odd-q vs
+   doubled) — decisione rimandata a `ADR-2026-04-16-grid-type-hex-axial.md`
+   follow-up. Scope doc, non ADR.
 
 ## Alternativa valutata e scartata
 
@@ -196,7 +198,7 @@ se flag off.
 
 ## Reference
 
-- `apps/backend/services/grid/hexGrid.js:253` — detectPincer helper (shipped M14-B)
+- `apps/backend/services/grid/hexGrid.js:270` — detectPincer helper (shipped M14-B, docstring L251)
 - `apps/backend/services/roundOrchestrator.js:271` — buildResolutionQueue
 - `docs/research/triangle-strategy-transfer-plan.md:179-283` — Mechanic 3B spec
 - `docs/adr/ADR-2026-04-16-grid-type-hex-axial.md` — hex grid decision

--- a/docs/playtest/2026-04-26-M14-C-elevation-calibration.md
+++ b/docs/playtest/2026-04-26-M14-C-elevation-calibration.md
@@ -53,22 +53,23 @@ durante `normaliseUnit`. Fix: clampa a integer (default 0) e passa attraverso
 session state. Senza questa patch il multiplier Triangle Strategy wired in session.js
 era effettivamente dead code per scenari.
 
-## Smoke tests nuovi (+4)
+## Smoke tests nuovi (+3)
 
-`tests/api/hardcoreScenario.test.js`:
+`tests/api/hardcoreScenario.test.js` (pre-M14-C 4 test → 7 totali):
 
 - `GET hardcore_06 raw units: BOSS + elite vantage = 1, player ground = 0`
 - `POST session start preserva elevation attraverso normalization`
 - `GET hardcore_07 patrol leader elevation=1 (vedetta)`
 
-Plus regression sanity — tutorial 03/04/05 tutti verdi (batch N=10 log invariati per 03/05, +10pp win su 04 dovuto a facing S flank).
+Plus regression sanity — tutorial 03/04/05 tutti verdi (batch N=10: 03/05 invariati
+a livello macro, tutorial 04 + 10pp win per facing S flank nuovo).
 
 ## Calibration N=10
 
 ### Hardcore 06 (full 8p vs BOSS + 2 elite + 3 minion)
 
 ```
-win_rate: 0.0% (target 30-50% post iter2 rework)
+win_rate: 0.0% (target band hardcore class: 15-25%, vedi data/core/balance/damage_curves.yaml)
 defeat_rate: 100.0%
 turns_avg: 25 (max)
 boss_hp_remaining_avg_on_loss: 30.6/40
@@ -76,10 +77,17 @@ dmg_dealt_avg: 39.4
 dmg_taken_avg: 28
 ```
 
-**Regressione vs baseline iter2 pre-M14-C (PR #1542)**: 96.7% win → 0% win.
-BOSS + elite a elevation 1 colpiscono con +30% multiplier su tutti gli 8 ground
-players: il focus-fire-swing che rendeva iter2 turtle-deadlock (96.7% win) è stato
-rovesciato completamente. BOSS HP 40 → party ne limalo solo 10 prima di wipe.
+**Regressione vs baseline pre-M14-C**:
+
+- iter0 (PR #1534): 84.6% win — tune iniziale
+- iter1 (PR #1542): 96.7% win — damage spread PEGGIO
+- iter2 (N=10 greedy, PR #1548 addendum): ~80% win — accepted con band greedy→umano
+- **iter2 + M14-C elevation (questa PR)**: **0% win**
+
+BOSS + elite a elevation 1 colpiscono con +30% multiplier su 8 ground players,
+_mentre_ i player dal basso hanno penalty -15% sul ritorno. Doppio swing:
+Apex single-source diventa tanto lethal quanto tanky. BOSS HP 40 → party lima
+~10 prima di wipe.
 
 **Interpretazione**: feature operativa, tuning invalidato. HP/mod re-tune differito
 (fuori scope P0). Iter successiva deve:
@@ -116,7 +124,7 @@ Verde:
 
 - `node --test tests/ai/*.test.js` → **307/307**
 - `node --test tests/services/*.test.js` → **177/177**
-- `node --test tests/api/hardcoreScenario.test.js` → **7/7** (4 nuovi + 3 esistenti)
+- `node --test tests/api/hardcoreScenario.test.js` → **7/7** (3 nuovi + 4 esistenti)
 - Tutorial 03 batch → timeout-heavy invariato (facing N solo, no dmg change)
 - Tutorial 04 batch → 70% → 80% win (+10pp da facing S flank, noise band accettabile per N=10)
 - Tutorial 05 batch → 0/10 timeout invariato vs pre-M14-C
@@ -131,15 +139,17 @@ Verde:
    non re-calibriamo.
 3. **Tutorial 05 elevation rolled back**: Apex + elevation 1 → 0/10 win (vs baseline
    0/10 timeout pre-M14-C). Identiche a livello macro (entrambi no-kill), ma il wire
-   elevation riduceva HP residuo Apex 5.2→7.3/18. Rollbackato per mantenere tuning
-   esistente; Apex elevation reintroducibile post HP/mod re-tune.
+   elevation **aumentava** HP residuo Apex 4.7 (baseline) → 7.3/18 (con elevation):
+   player dal basso penalty -15% dmg + Apex elevato -30% dmg in arrivo = Apex più
+   tanky e più lethal. Rollbackato per mantenere tuning esistente; Apex elevation
+   reintroducibile post HP/mod re-tune.
 
 ## Follow-up (ticket backlog)
 
 - `TKT-M14-C-HARDCORE06-RETUNE` — iter3 post-elevation: BOSS HP 40→25, or drop
-  elite elevation. Target win 30-50%.
+  elite elevation. Target band hardcore class 15-25% win.
 - `TKT-M14-C-HARDCORE07-RETUNE` — patrol +2 enemy start, reinforcement cooldown
-  1. Target win 30-50%.
+  1. Target harness 30-50% win (band definita in tools/py/batch_calibrate_hardcore07.py).
 - `TKT-M14-C-TUTORIAL05-ELEVATION` — re-introduce Apex elevation post
   HP/mod re-tune (probably HP 11→8 + apex ap 3→2).
 


### PR DESCRIPTION
## Summary

Post-review audit dei doc generati in M14-C (#1739 / #1741). 7 fix di accuracy, zero cambio runtime.

### Report `docs/playtest/2026-04-26-M14-C-elevation-calibration.md`

1. **Baseline hardcore_06 attribution** — PR #1542 era iter1 (96.7% win), non iter2. Aggiunti tutti e 3 iter 0/1/2 con PR ref corretti.
2. **Target band hardcore_06** — da "30-50%" (preso per sbaglio da harness hardcore_07) a **15-25%** (band corretta `hardcore` encounter_class in `data/core/balance/damage_curves.yaml`).
3. **Tutorial 05 direction** — wire elevation **aumentava** HP residuo Apex (4.7→7.3/18), non "riduceva 5.2→7.3". Player ground penalty -15% + Apex elevated +30% outgoing = effetto doppio swing.
4. **Smoke tests count** — corretto da "+4 nuovi" a **+3 nuovi** (pre-M14-C 4 → 7 totali; io ho aggiunto 3).
5. **TKT-M14-C-HARDCORE06-RETUNE target** — band hardcore class 15-25%, non 30-50%.

### ADR `docs/adr/ADR-2026-04-26-pincer-followup-queue.md`

6. **Hex conversion formula** — rimosso `{ q: x, r: y - x/2 }` (non rispetta offset odd-r/odd-q convention). Scope rimandato a ADR-2026-04-16 follow-up.
7. **Line ref hexGrid.js** — da `:253` (docstring) a `:270` (function def).

## Test plan

- [x] `npm run format:check` → verde
- [x] `python tools/check_docs_governance.py --strict` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)