### PR TITLE
feat(tools): telemetry_analyze.py — stdlib-only aggregation via telemetry-viz-illuminator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ data/flow-shell/*.bak
 # Setup backlog logs (rigenerati da scripts/setup_*.sh, vedi #1345)
 reports/setup_backlog_*.log
 logs/telemetry_*.jsonl
+.pytest_cache/

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-24T17:52:02+00:00",
+  "generated_at": "2026-04-24T18:06:26+00:00",
   "summary": {
     "total": 6,
     "errors": 0,

--- a/tests/scripts/test_telemetry_analyze.py
+++ b/tests/scripts/test_telemetry_analyze.py
@@ -1,0 +1,220 @@
+"""Tests for tools/py/telemetry_analyze.py — stdlib-only aggregation pipeline."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+pytest.importorskip("tools.py.telemetry_analyze", reason="PYTHONPATH=tools/py required")
+
+from tools.py.telemetry_analyze import (  # noqa: E402
+    FUNNEL_STAGES,
+    KNOWN_EVENT_TYPES,
+    Aggregates,
+    TelemetryEvent,
+    aggregate,
+    format_json,
+    format_markdown,
+    read_events,
+)
+
+
+def _write_jsonl(path: Path, events: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [json.dumps(ev) for ev in events]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+@pytest.fixture
+def tmp_logs(tmp_path: Path) -> Path:
+    """Create a tmp logs dir with 2 telemetry files."""
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    _write_jsonl(
+        logs / "telemetry_20260426.jsonl",
+        [
+            {
+                "ts": "2026-04-26T10:00:00Z",
+                "session_id": "s1",
+                "player_id": "p1",
+                "type": "session_start",
+                "payload": {"scenario_id": "enc_tutorial_01"},
+            },
+            {
+                "ts": "2026-04-26T10:05:00Z",
+                "session_id": "s1",
+                "player_id": "p1",
+                "type": "ability_use",
+                "payload": {"ability": "dash_strike"},
+            },
+            {
+                "ts": "2026-04-26T10:05:10Z",
+                "session_id": "s1",
+                "player_id": "p1",
+                "type": "damage_dealt",
+                "payload": {"damage": 3},
+            },
+            {
+                "ts": "2026-04-26T10:30:00Z",
+                "session_id": "s1",
+                "player_id": "p1",
+                "type": "session_end",
+                "payload": {"scenario_id": "enc_tutorial_01", "outcome": "victory"},
+            },
+            {
+                "ts": "2026-04-26T11:00:00Z",
+                "session_id": "s2",
+                "player_id": "p2",
+                "type": "session_start",
+                "payload": {"scenario_id": "enc_tutorial_01"},
+            },
+            {
+                "ts": "2026-04-26T11:15:00Z",
+                "session_id": "s2",
+                "player_id": "p2",
+                "type": "session_end",
+                "payload": {"scenario_id": "enc_tutorial_01", "outcome": "defeat"},
+            },
+        ],
+    )
+    return logs
+
+
+def test_telemetry_event_from_json_ok():
+    line = '{"ts":"2026-04-26T10:00:00Z","session_id":"s1","type":"ability_use","payload":{}}'
+    ev = TelemetryEvent.from_json(line)
+    assert ev is not None
+    assert ev.type == "ability_use"
+    assert ev.session_id == "s1"
+
+
+def test_telemetry_event_from_json_malformed():
+    assert TelemetryEvent.from_json("not a json") is None
+    assert TelemetryEvent.from_json('"just a string"') is None
+    assert TelemetryEvent.from_json("[1,2,3]") is None
+
+
+def test_aggregate_basic_counts(tmp_logs: Path):
+    agg = aggregate(read_events(tmp_logs))
+    assert agg.total_events == 6
+    assert agg.session_count() == 2
+    assert agg.malformed_lines == 0
+    assert agg.type_counts["session_start"] == 2
+    assert agg.type_counts["session_end"] == 2
+
+
+def test_aggregate_malformed_lines_counted(tmp_path: Path):
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    good = '{"ts":"2026-04-26T10:00:00Z","session_id":"s1","type":"session_start"}'
+    bad1 = "not a json line"
+    bad2 = '{"broken": true'
+    (logs / "telemetry_20260426.jsonl").write_text(
+        "\n".join([good, bad1, bad2, good]) + "\n", encoding="utf-8"
+    )
+    agg = aggregate(read_events(logs))
+    assert agg.total_events == 2
+    assert agg.malformed_lines == 2
+
+
+def test_funnel_counts(tmp_logs: Path):
+    agg = aggregate(read_events(tmp_logs))
+    funnel = agg.funnel_counts()
+    assert funnel["session_start"] == 2
+    assert funnel["ability_use"] == 1
+    assert funnel["damage_dealt"] == 1
+    assert funnel["session_end"] == 2
+
+
+def test_scenario_outcomes(tmp_logs: Path):
+    agg = aggregate(read_events(tmp_logs))
+    outcomes = agg.scenario_outcomes()
+    assert "enc_tutorial_01" in outcomes
+    assert outcomes["enc_tutorial_01"]["victory"] == 1
+    assert outcomes["enc_tutorial_01"]["defeat"] == 1
+
+
+def test_session_durations(tmp_logs: Path):
+    agg = aggregate(read_events(tmp_logs))
+    durations = agg.session_durations_minutes()
+    assert len(durations) == 2
+    assert durations[0] == 30.0
+    assert durations[1] == 15.0
+
+
+def test_read_events_empty_dir(tmp_path: Path):
+    agg = aggregate(read_events(tmp_path))
+    assert agg.total_events == 0
+    assert agg.session_count() == 0
+
+
+def test_read_events_missing_dir(tmp_path: Path):
+    agg = aggregate(read_events(tmp_path / "does-not-exist"))
+    assert agg.total_events == 0
+
+
+def test_unknown_event_types(tmp_path: Path):
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    _write_jsonl(
+        logs / "telemetry_20260426.jsonl",
+        [
+            {"ts": "2026-04-26T10:00:00Z", "session_id": "s1", "type": "mystery_event"},
+            {"ts": "2026-04-26T10:00:01Z", "session_id": "s1", "type": "session_start"},
+        ],
+    )
+    agg = aggregate(read_events(logs))
+    assert "mystery_event" in agg.unknown_types
+    assert "session_start" not in agg.unknown_types
+
+
+def test_date_filter(tmp_path: Path):
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    _write_jsonl(
+        logs / "telemetry_20260425.jsonl",
+        [{"ts": "2026-04-25T10:00:00Z", "session_id": "s-old", "type": "session_start"}],
+    )
+    _write_jsonl(
+        logs / "telemetry_20260426.jsonl",
+        [{"ts": "2026-04-26T10:00:00Z", "session_id": "s-new", "type": "session_start"}],
+    )
+    agg = aggregate(read_events(logs, date_filter="20260426"))
+    assert agg.total_events == 1
+    assert "s-new" in agg.sessions
+
+
+def test_format_markdown_smoke(tmp_logs: Path):
+    agg = aggregate(read_events(tmp_logs))
+    md = format_markdown(agg, date_range="20260426")
+    assert md.startswith("---\n")
+    assert "# Telemetry Analysis" in md
+    assert "Event type distribution" in md
+    assert "Funnel" in md
+    assert "Scenario outcomes" in md
+
+
+def test_format_json_smoke(tmp_logs: Path):
+    agg = aggregate(read_events(tmp_logs))
+    data = format_json(agg)
+    assert data["total_events"] == 6
+    assert data["sessions"] == 2
+    assert "session_start" in data["type_counts"]
+    assert data["funnel"]["session_start"] == 2
+    assert "enc_tutorial_01" in data["scenario_outcomes"]
+
+
+def test_funnel_stages_ordered():
+    """Contract: funnel stages in semantically sensible order."""
+    assert FUNNEL_STAGES[0] == "session_start"
+    assert FUNNEL_STAGES[-1] == "session_end"
+
+
+def test_known_event_types_nonempty():
+    """Guard: schema never drops to empty (breakage sentinel)."""
+    assert "session_start" in KNOWN_EVENT_TYPES
+    assert "session_end" in KNOWN_EVENT_TYPES
+    assert len(KNOWN_EVENT_TYPES) >= 10

--- a/tools/py/telemetry_analyze.py
+++ b/tools/py/telemetry_analyze.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""Telemetry aggregation pipeline — stdlib-only (no DuckDB dep).
+
+Reads `logs/telemetry_YYYYMMDD.jsonl` files from POST /api/session/telemetry
+and produces aggregated report (Markdown + JSON).
+
+Applies P0 findings from telemetry-viz-illuminator agent smoke test
+(docs/qa/2026-04-26-telemetry-viz-illuminator-smoke.md):
+
+    - Event count distribution per type (Tufte small multiples basis)
+    - Session count + duration histograms (retention input)
+    - Funnel analysis: session_start → ability_use → damage_dealt → session_end
+    - Per-scenario win rate (if session_end.payload.outcome present)
+
+Usage:
+    PYTHONPATH=tools/py python3 tools/py/telemetry_analyze.py \\
+        --logs-dir logs --out-md docs/analytics/2026-04-26-telemetry-report.md
+
+Non-goals (deferred):
+    - Real-time streaming (Grafana/OTEL stack)
+    - Spatial heatmap (deck.gl HexagonLayer, post N=100+)
+    - Sankey multi-transition viz (needs Google Charts / D3)
+    - DuckDB SQL queries (policy: no new deps without approval)
+
+Ref agent: .claude/agents/telemetry-viz-illuminator.md
+Ref schema (raw event): apps/backend/routes/session.js:1891 (ts,session_id,player_id,type,payload)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+
+# Event type enum — sync with apps/backend/routes/session.js telemetry schema.
+KNOWN_EVENT_TYPES = frozenset(
+    {
+        "session_start",
+        "turn_end",
+        "ability_use",
+        "damage_taken",
+        "damage_dealt",
+        "reward_offer",
+        "reward_accept",
+        "reward_skip",
+        "sg_earn",
+        "pack_roll",
+        "mbti_projection",
+        "session_end",
+        # M16+ coop events (optional, tolerated):
+        "lobby_join",
+        "char_create",
+        "world_setup",
+        "combat_start",
+        "combat_end",
+        "debrief",
+    }
+)
+
+# Funnel stages (ordered). Each stage = required event type.
+# Completion rate = N(stage_i_reached) / N(stage_0_reached).
+FUNNEL_STAGES = (
+    "session_start",
+    "ability_use",
+    "damage_dealt",
+    "session_end",
+)
+
+
+@dataclass
+class TelemetryEvent:
+    """Single event from JSONL log."""
+
+    ts: str
+    session_id: str | None
+    player_id: str | None
+    type: str
+    payload: dict | None = None
+
+    @classmethod
+    def from_json(cls, line: str) -> "TelemetryEvent | None":
+        """Parse one JSONL line; return None on malformed input."""
+        try:
+            obj = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            return None
+        if not isinstance(obj, dict):
+            return None
+        return cls(
+            ts=str(obj.get("ts", "")),
+            session_id=obj.get("session_id"),
+            player_id=obj.get("player_id"),
+            type=str(obj.get("type", "unknown")),
+            payload=obj.get("payload") if isinstance(obj.get("payload"), dict) else None,
+        )
+
+
+@dataclass
+class Aggregates:
+    """Computed aggregates over a set of events."""
+
+    total_events: int = 0
+    malformed_lines: int = 0
+    type_counts: Counter = field(default_factory=Counter)
+    sessions: dict[str, list[TelemetryEvent]] = field(default_factory=lambda: defaultdict(list))
+    unknown_types: Counter = field(default_factory=Counter)
+
+    def session_count(self) -> int:
+        return len(self.sessions)
+
+    def funnel_counts(self) -> dict[str, int]:
+        """Count sessions that reached each funnel stage."""
+        counts: dict[str, int] = dict.fromkeys(FUNNEL_STAGES, 0)
+        for events in self.sessions.values():
+            reached = {ev.type for ev in events}
+            for stage in FUNNEL_STAGES:
+                if stage in reached:
+                    counts[stage] += 1
+        return counts
+
+    def scenario_outcomes(self) -> dict[str, Counter]:
+        """Collect session_end outcomes per scenario_id in payload."""
+        out: dict[str, Counter] = defaultdict(Counter)
+        for events in self.sessions.values():
+            for ev in events:
+                if ev.type != "session_end":
+                    continue
+                payload = ev.payload or {}
+                scenario = str(payload.get("scenario_id") or payload.get("scenario") or "unknown")
+                outcome = str(payload.get("outcome") or "unknown")
+                out[scenario][outcome] += 1
+        return out
+
+    def session_durations_minutes(self) -> list[float]:
+        """Duration in minutes between first and last event per session."""
+        durations: list[float] = []
+        for events in self.sessions.values():
+            if len(events) < 2:
+                continue
+            timestamps = [_parse_ts(ev.ts) for ev in events if ev.ts]
+            timestamps = [t for t in timestamps if t is not None]
+            if len(timestamps) < 2:
+                continue
+            delta = (max(timestamps) - min(timestamps)).total_seconds() / 60.0
+            durations.append(round(delta, 2))
+        return durations
+
+
+def _parse_ts(ts: str) -> datetime | None:
+    """Parse ISO 8601 timestamp; tolerant of trailing Z."""
+    if not ts:
+        return None
+    normalized = ts.replace("Z", "+00:00") if ts.endswith("Z") else ts
+    try:
+        return datetime.fromisoformat(normalized)
+    except (ValueError, TypeError):
+        return None
+
+
+def read_events(logs_dir: Path, date_filter: str | None = None) -> Iterable[TelemetryEvent]:
+    """Yield events from all telemetry_*.jsonl files in logs_dir.
+
+    Malformed lines are skipped silently (counted in Aggregates.malformed_lines via
+    aggregate()).
+
+    Args:
+        logs_dir: directory containing telemetry_*.jsonl files.
+        date_filter: optional YYYYMMDD; restricts to matching filename.
+    """
+    if not logs_dir.is_dir():
+        return
+    pattern = f"telemetry_{date_filter}.jsonl" if date_filter else "telemetry_*.jsonl"
+    for path in sorted(logs_dir.glob(pattern)):
+        try:
+            with path.open("r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    ev = TelemetryEvent.from_json(line)
+                    if ev is not None:
+                        yield ev
+                    else:
+                        # Signal malformed to caller via sentinel. Use special
+                        # field in payload so aggregate can count it.
+                        yield TelemetryEvent(
+                            ts="",
+                            session_id=None,
+                            player_id=None,
+                            type="__malformed__",
+                        )
+        except OSError:
+            continue
+
+
+def aggregate(events: Iterable[TelemetryEvent]) -> Aggregates:
+    """Consume events stream and return Aggregates."""
+    agg = Aggregates()
+    for ev in events:
+        if ev.type == "__malformed__":
+            agg.malformed_lines += 1
+            continue
+        agg.total_events += 1
+        agg.type_counts[ev.type] += 1
+        if ev.type not in KNOWN_EVENT_TYPES:
+            agg.unknown_types[ev.type] += 1
+        if ev.session_id:
+            agg.sessions[ev.session_id].append(ev)
+    return agg
+
+
+def format_markdown(agg: Aggregates, *, date_range: str | None = None) -> str:
+    """Produce Markdown report from Aggregates (frontmatter + tables)."""
+    today = datetime.now().date().isoformat()
+    lines: list[str] = []
+    lines.append("---")
+    lines.append(f"title: Telemetry Analysis — {date_range or 'all logs'} ({today})")
+    lines.append("workstream: ops-qa")
+    lines.append("category: analytics")
+    lines.append("doc_status: active")
+    lines.append("doc_owner: claude-code")
+    lines.append(f"last_verified: '{today}'")
+    lines.append("source_of_truth: false")
+    lines.append("language: it")
+    lines.append("review_cycle_days: 30")
+    lines.append("tags:")
+    lines.append("  - telemetry")
+    lines.append("  - analytics")
+    lines.append("  - generated")
+    lines.append("---")
+    lines.append("")
+    lines.append(f"# Telemetry Analysis — {date_range or 'all logs'}")
+    lines.append("")
+    lines.append("Report generato da `tools/py/telemetry_analyze.py` (stdlib-only).")
+    lines.append("")
+
+    lines.append("## Summary")
+    lines.append("")
+    lines.append(f"- **Total events**: {agg.total_events}")
+    lines.append(f"- **Sessions**: {agg.session_count()}")
+    lines.append(f"- **Malformed lines skipped**: {agg.malformed_lines}")
+    lines.append(f"- **Unknown event types**: {len(agg.unknown_types)}")
+    lines.append("")
+
+    lines.append("## Event type distribution")
+    lines.append("")
+    lines.append("| Type | Count | % |")
+    lines.append("| --- | ---: | ---: |")
+    total = max(agg.total_events, 1)
+    for t, n in agg.type_counts.most_common():
+        lines.append(f"| `{t}` | {n} | {100 * n / total:.1f}% |")
+    lines.append("")
+
+    funnel = agg.funnel_counts()
+    lines.append("## Funnel (sessions reaching each stage)")
+    lines.append("")
+    lines.append("| Stage | Sessions | % of stage 0 |")
+    lines.append("| --- | ---: | ---: |")
+    stage_0 = max(funnel.get(FUNNEL_STAGES[0], 0), 1)
+    for stage in FUNNEL_STAGES:
+        n = funnel.get(stage, 0)
+        pct = 100 * n / stage_0
+        lines.append(f"| `{stage}` | {n} | {pct:.1f}% |")
+    lines.append("")
+
+    durations = agg.session_durations_minutes()
+    if durations:
+        lines.append("## Session duration (minutes)")
+        lines.append("")
+        lines.append(f"- N = {len(durations)}")
+        lines.append(f"- Mean = {statistics.mean(durations):.2f}")
+        lines.append(f"- Median = {statistics.median(durations):.2f}")
+        if len(durations) > 1:
+            lines.append(f"- Stdev = {statistics.stdev(durations):.2f}")
+        lines.append(f"- Min / Max = {min(durations):.2f} / {max(durations):.2f}")
+        lines.append("")
+
+    outcomes = agg.scenario_outcomes()
+    if outcomes:
+        lines.append("## Scenario outcomes")
+        lines.append("")
+        lines.append("| Scenario | Total | Victory | Defeat | Timeout | Other | Win rate |")
+        lines.append("| --- | ---: | ---: | ---: | ---: | ---: | ---: |")
+        for scenario, counter in sorted(outcomes.items()):
+            total_scenario = sum(counter.values())
+            victory = counter.get("victory", 0)
+            defeat = counter.get("defeat", 0)
+            timeout = counter.get("timeout", 0)
+            other = total_scenario - victory - defeat - timeout
+            wr = 100 * victory / total_scenario if total_scenario else 0.0
+            lines.append(
+                f"| `{scenario}` | {total_scenario} | {victory} | {defeat} | {timeout} | {other} | {wr:.1f}% |"
+            )
+        lines.append("")
+
+    if agg.unknown_types:
+        lines.append("## Unknown event types (schema drift warning)")
+        lines.append("")
+        lines.append("Types non in KNOWN_EVENT_TYPES. Schema drift o telemetry extension:")
+        lines.append("")
+        for t, n in agg.unknown_types.most_common():
+            lines.append(f"- `{t}` — {n} occorrenze")
+        lines.append("")
+
+    lines.append("## Sources")
+    lines.append("")
+    lines.append("- Raw events: `logs/telemetry_*.jsonl` (POST /api/session/telemetry)")
+    lines.append("- Pipeline: `tools/py/telemetry_analyze.py`")
+    lines.append("- Agent: `.claude/agents/telemetry-viz-illuminator.md`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def format_json(agg: Aggregates) -> dict:
+    """Produce JSON summary of Aggregates for machine consumption."""
+    return {
+        "total_events": agg.total_events,
+        "sessions": agg.session_count(),
+        "malformed_lines": agg.malformed_lines,
+        "type_counts": dict(agg.type_counts),
+        "funnel": agg.funnel_counts(),
+        "durations_min": agg.session_durations_minutes(),
+        "scenario_outcomes": {k: dict(v) for k, v in agg.scenario_outcomes().items()},
+        "unknown_types": dict(agg.unknown_types),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--logs-dir", default="logs", help="Directory con telemetry_*.jsonl (default: logs)"
+    )
+    parser.add_argument(
+        "--date", default=None, help="Filtro YYYYMMDD (default: tutti i file disponibili)"
+    )
+    parser.add_argument(
+        "--out-md", default=None, help="Path markdown report output (default: stdout)"
+    )
+    parser.add_argument(
+        "--out-json", default=None, help="Path JSON summary output (default: no JSON)"
+    )
+    args = parser.parse_args(argv)
+
+    logs_dir = Path(args.logs_dir)
+    events = read_events(logs_dir, date_filter=args.date)
+    agg = aggregate(events)
+
+    md = format_markdown(agg, date_range=args.date)
+    if args.out_md:
+        out_path = Path(args.out_md)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(md, encoding="utf-8")
+        print(f"Markdown saved: {out_path}")
+    else:
+        print(md)
+
+    if args.out_json:
+        json_path = Path(args.out_json)
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(json.dumps(format_json(agg), indent=2), encoding="utf-8")
+        print(f"JSON saved: {json_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Seconda applicazione runtime di agent findings (post UI fix #1749).

`telemetry-viz-illuminator` smoke test aveva rilevato: **6 🔴 MISSING** gaps. Questo PR chiude il **P0 #1** — aggregation pipeline — con **zero nuove deps** (stdlib-only per policy compliance).

## Features

- Read `logs/telemetry_YYYYMMDD.jsonl` da `POST /api/session/telemetry`
- Parse JSONL con malformed-line tolerance (counted, not failed)
- Aggregate:
  - **Event type distribution** (Tufte data-ink basis)
  - **Funnel stages** (session_start → ability_use → damage_dealt → session_end)
  - **Scenario outcomes** (win_rate per scenario_id)
  - **Session durations** (min/max/median minutes)
  - **Schema drift detection** (unknown event types)
- Output:
  - Markdown report con frontmatter YAML + tables
  - Optional JSON summary per machine consumption

## CLI

```bash
# Report tutti i log in logs/
PYTHONPATH=. python3 tools/py/telemetry_analyze.py --logs-dir logs

# Report specifico + save
PYTHONPATH=. python3 tools/py/telemetry_analyze.py \
    --logs-dir logs --date 20260426 \
    --out-md docs/analytics/2026-04-26-report.md \
    --out-json docs/analytics/2026-04-26-data.json
```

## Test plan

- [x] `pytest tests/scripts/test_telemetry_analyze.py` → **15/15 verdi**
- [x] CLI smoke test su synthetic log → valid Markdown output
- [x] `npm run format:check` → verde
- [x] `python tools/check_docs_governance.py --strict` → 0 errors

## Deferred (altri P0 dell'agent)

- **P0 #2** funnel tutorial events (`tutorial_start/complete`) — richiede backend schema change
- **P0 #3** Observable Plot dashboard — frontend scope, separate PR
- **P0 #4** telemetry schema explicit (`telemetry.schema.json`) — richiede schema-ripple agent audit
- **P0 #5** deck.gl HexagonLayer POC — post TKT-M11B-06 N=100+

## Compliance

- ✅ Zero new deps (stdlib only)
- ✅ Guardrail sprint rispettato (no workflows/migrations/contracts/generation)
- ✅ Regola 50 LOC fuori apps/backend/: tools/py/ è allowed
- ✅ 4-gate DoD G1-G4 applicata tramite agent smoke test

Ref agent: `.claude/agents/telemetry-viz-illuminator.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `telemetry-viz-illuminator` agent