### PR TITLE
feat(pcg): species variety in hardcore scenarios via pcg-level-design-illuminator

### DIFF
--- a/apps/backend/services/hardcoreScenario.js
+++ b/apps/backend/services/hardcoreScenario.js
@@ -78,10 +78,21 @@ function buildHardcoreUnits06() {
     { id: 'p_support_1', job: 'skirmisher', pos: [1, 1], hp: 11, mod: 3, dc: 13 },
     { id: 'p_support_2', job: 'skirmisher', pos: [1, 5], hp: 11, mod: 3, dc: 13 },
   ];
+  // pcg-level-design-illuminator P0 emergence fix: species variety.
+  // Pre: tutti i 8 player = `dune_stalker` (emergence 🔴 LOW).
+  // Post: species-job pairing canonica → 3+ specie distinte in composition.
+  // Ref: docs/qa/2026-04-26-pcg-level-design-illuminator-smoke.md
+  const SPECIES_BY_JOB = {
+    skirmisher: 'dune_stalker', // arid/agile baseline
+    vanguard: 'umbroid_lurker', // shadow/tanky archetype
+    ranger: 'echo_seer', // psionic scout
+    warden: 'mud_sentinel', // defensive support
+  };
   for (const pl of playerLayouts) {
+    const species = SPECIES_BY_JOB[pl.job] || 'dune_stalker';
     players.push({
       id: pl.id,
-      species: 'dune_stalker',
+      species,
       job: pl.job,
       traits: pl.job === 'vanguard' ? ['pelle_elastomera'] : ['zampe_a_molla'],
       hp: pl.hp,
@@ -318,6 +329,13 @@ const HARDCORE_SCENARIO_07_POD_RUSH = {
 };
 
 function buildHardcoreUnits07() {
+  // pcg-level-design-illuminator P0 emergence fix: species variety (4 distinti).
+  const SPECIES_BY_JOB = {
+    skirmisher: 'dune_stalker',
+    vanguard: 'umbroid_lurker',
+    ranger: 'echo_seer',
+    warden: 'mud_sentinel',
+  };
   const players = [
     { id: 'p_scout_1', job: 'skirmisher', pos: [1, 3], hp: 10, mod: 3, dc: 12 },
     { id: 'p_scout_2', job: 'ranger', pos: [1, 6], hp: 10, mod: 3, dc: 12 },
@@ -325,7 +343,7 @@ function buildHardcoreUnits07() {
     { id: 'p_support_1', job: 'warden', pos: [2, 5], hp: 11, mod: 2, dc: 13 },
   ].map((pl) => ({
     id: pl.id,
-    species: 'dune_stalker',
+    species: SPECIES_BY_JOB[pl.job] || 'dune_stalker',
     job: pl.job,
     traits: pl.job === 'vanguard' ? ['pelle_elastomera'] : ['zampe_a_molla'],
     hp: pl.hp,


### PR DESCRIPTION
## Summary

Terza applicazione runtime agent findings (post UI #1749, telemetry #1750).

`pcg-level-design-illuminator` smoke test aveva rilevato **Emergence 🔴 LOW** — tutti gli 8+4 player in hardcore scenarios = singola specie `dune_stalker`. Zero diversity compositional.

## Fix

`SPECIES_BY_JOB` mapping canonico in `buildHardcoreUnits06` + `07`:

```js
const SPECIES_BY_JOB = {
  skirmisher: 'dune_stalker',    // arid/agile baseline
  vanguard:   'umbroid_lurker',  // shadow/tanky
  ranger:     'echo_seer',       // psionic scout
  warden:     'mud_sentinel',    // defensive support
};
```

**Impact**:

- hardcore_06 (8p): 1 specie → 2+ specie distinte
- hardcore_07 (4p quartet): 1 specie → **4 specie distinte** (1 per job)
- Resistance archetype coverage: 4 matrix attive (fisico/psionico/mentale/ionico)
- SIS AI lowest-hp targeting varia per-encounter grazie a HP curves diverse post-perk

## Test plan

- [x] `tests/api/hardcoreScenario.test.js` → 7/7 verde
- [x] `tests/api/hardcoreScenarioTimer.test.js` → 5/5 verde
- [x] AI regression 307/307 verde
- [x] `npm run format:check` → verde
- [x] Backward compat preservata (no hardcoded species assertion)

## Scope out (agent P0 residui)

- Objective variety (rescue/timer/extraction) — 8h, separate PR
- XP budget encounter builder — 6h, richiede ADR
- Tracery briefing narrative — richiede dep evaluation

Ref agent: `.claude/agents/pcg-level-design-illuminator.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `pcg-level-design-illuminator` agent