### PR TITLE
feat(telemetry): tutorial funnel auto-log via telemetry-viz-illuminator P0 #2

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -165,6 +165,35 @@ function createSessionRouter(options = {}) {
   const sessions = new Map();
   let activeSessionId = null;
 
+  // Telemetry helper — append JSONL entry to logs/telemetry_YYYYMMDD.jsonl.
+  // Same schema as POST /telemetry (ts, session_id, player_id, type, payload)
+  // but fired server-side for auto-instrumented events (tutorial_start/complete
+  // funnel — ref telemetry-viz-illuminator agent P0 #2).
+  async function appendTelemetryEvent({ session_id, player_id, type, payload }) {
+    try {
+      const now = new Date();
+      const yyyymmdd = now.toISOString().slice(0, 10).replace(/-/g, '');
+      const telemetryPath = path.join(logsDir, `telemetry_${yyyymmdd}.jsonl`);
+      const entry = {
+        ts: now.toISOString(),
+        session_id: session_id || null,
+        player_id: player_id || null,
+        type: type || 'unknown',
+        payload: payload ?? null,
+      };
+      await fs.mkdir(logsDir, { recursive: true });
+      await fs.appendFile(telemetryPath, JSON.stringify(entry) + '\n', 'utf8');
+    } catch {
+      // Non-blocking telemetry — never crash session on write failure.
+    }
+  }
+
+  // Pattern matcher per tutorial scenario IDs (funnel analysis input).
+  const TUTORIAL_SCENARIO_RE = /^enc_tutorial_\d+/;
+  function isTutorialScenario(scenarioId) {
+    return typeof scenarioId === 'string' && TUTORIAL_SCENARIO_RE.test(scenarioId);
+  }
+
   // V5 SG lifecycle helper: reset per-turn earn counter su tutte le unit vive.
   // Invocato dopo ogni session.turn += 1 (4 sites: advanceThroughAiTurns,
   // /action early-end fallback, sessionRoundBridge round flow x2).
@@ -939,6 +968,20 @@ function createSessionRouter(options = {}) {
       activeSessionId = sessionId;
       await fs.mkdir(logsDir, { recursive: true });
       await fs.writeFile(logFilePath, '[]\n', 'utf8');
+      // Funnel telemetry auto-log (agent telemetry-viz-illuminator P0 #2).
+      // Tutorial session_start → tutorial_start event (non-blocking).
+      if (isTutorialScenario(scenarioId)) {
+        appendTelemetryEvent({
+          session_id: sessionId,
+          player_id: null,
+          type: 'tutorial_start',
+          payload: {
+            scenario_id: scenarioId,
+            encounter_class: encounterClassUsed || 'standard',
+            party_size: units.filter((u) => u.controlled_by === 'player').length,
+          },
+        }).catch(() => {});
+      }
       await appendEvent(session, {
         action_type: 'session_start',
         turn: 0,
@@ -1713,6 +1756,22 @@ function createSessionRouter(options = {}) {
         vc_ennea: vcSnapshot?.ennea ?? null,
         automatic: true,
       });
+      // Funnel telemetry auto-log (agent telemetry-viz-illuminator P0 #2).
+      // Tutorial session_end → tutorial_complete event con outcome (non-blocking).
+      if (isTutorialScenario(session.scenario_id)) {
+        appendTelemetryEvent({
+          session_id: session.session_id,
+          player_id: null,
+          type: 'tutorial_complete',
+          payload: {
+            scenario_id: session.scenario_id,
+            outcome,
+            turns: session.turn,
+            player_alive: playerAlive,
+            sistema_alive: sistemaAlive,
+          },
+        }).catch(() => {});
+      }
       await persistEvents(session);
       const eventsCount = session.events.length;
       const logFile = session.logFilePath;

--- a/tests/api/telemetryTutorialFunnel.test.js
+++ b/tests/api/telemetryTutorialFunnel.test.js
@@ -1,0 +1,131 @@
+// Verifica auto-log tutorial_start + tutorial_complete in logs/telemetry_YYYYMMDD.jsonl
+// via session.js hooks (agent telemetry-viz-illuminator P0 #2).
+//
+// Contract: quando /session/start riceve scenario_id matching `/^enc_tutorial_\d+/`,
+// append entry `tutorial_start` al JSONL. /session/end stesso scenario → `tutorial_complete`.
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const os = require('node:os');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+function todayYyyymmdd() {
+  return new Date().toISOString().slice(0, 10).replace(/-/g, '');
+}
+
+async function readTelemetryJsonl(logsDir) {
+  const file = path.join(logsDir, `telemetry_${todayYyyymmdd()}.jsonl`);
+  try {
+    const content = await fs.readFile(file, 'utf8');
+    return content
+      .split('\n')
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l));
+  } catch {
+    return [];
+  }
+}
+
+async function mkTempLogsDir() {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'evo-telemetry-'));
+  return tmp;
+}
+
+test('/session/start con tutorial scenario emette tutorial_start al telemetry JSONL', async () => {
+  const logsDir = await mkTempLogsDir();
+  const { app, close } = createApp({ databasePath: null, session: { logsDir } });
+  try {
+    const scenarioRes = await request(app).get('/api/tutorial/enc_tutorial_01').expect(200);
+    await request(app)
+      .post('/api/session/start')
+      .send({
+        scenario_id: 'enc_tutorial_01',
+        units: scenarioRes.body.units,
+      })
+      .expect(200);
+    // Allow async append to flush (non-blocking helper).
+    await new Promise((r) => setTimeout(r, 50));
+    const events = await readTelemetryJsonl(logsDir);
+    const tutorialStart = events.find((e) => e.type === 'tutorial_start');
+    assert.ok(tutorialStart, 'tutorial_start event deve essere presente');
+    assert.equal(tutorialStart.payload?.scenario_id, 'enc_tutorial_01');
+    assert.equal(tutorialStart.payload?.party_size, 2);
+    assert.ok(tutorialStart.ts, 'timestamp presente');
+    assert.ok(tutorialStart.session_id, 'session_id presente');
+  } finally {
+    await close();
+  }
+});
+
+test('/session/end con tutorial scenario emette tutorial_complete + outcome', async () => {
+  const logsDir = await mkTempLogsDir();
+  const { app, close } = createApp({ databasePath: null, session: { logsDir } });
+  try {
+    const scenarioRes = await request(app).get('/api/tutorial/enc_tutorial_01').expect(200);
+    const startRes = await request(app)
+      .post('/api/session/start')
+      .send({ scenario_id: 'enc_tutorial_01', units: scenarioRes.body.units })
+      .expect(200);
+    const sid = startRes.body.session_id;
+    await request(app).post('/api/session/end').send({ session_id: sid }).expect(200);
+    await new Promise((r) => setTimeout(r, 50));
+    const events = await readTelemetryJsonl(logsDir);
+    const tutorialComplete = events.find((e) => e.type === 'tutorial_complete');
+    assert.ok(tutorialComplete, 'tutorial_complete event deve essere presente');
+    assert.equal(tutorialComplete.payload?.scenario_id, 'enc_tutorial_01');
+    assert.ok(
+      ['win', 'wipe', 'draw', 'abandon'].includes(tutorialComplete.payload?.outcome),
+      `outcome valido: ${tutorialComplete.payload?.outcome}`,
+    );
+  } finally {
+    await close();
+  }
+});
+
+test('/session/start con scenario non-tutorial NON emette tutorial_start', async () => {
+  const logsDir = await mkTempLogsDir();
+  const { app, close } = createApp({ databasePath: null, session: { logsDir } });
+  try {
+    await request(app)
+      .post('/api/session/start')
+      .send({
+        scenario_id: 'custom_encounter_xyz',
+        units: [{ id: 'u1', controlled_by: 'player', hp: 10 }],
+      })
+      .expect(200);
+    await new Promise((r) => setTimeout(r, 50));
+    const events = await readTelemetryJsonl(logsDir);
+    const tutorialEvents = events.filter((e) => e.type === 'tutorial_start');
+    assert.equal(
+      tutorialEvents.length,
+      0,
+      'non deve emettere tutorial_start per scenario non-tutorial',
+    );
+  } finally {
+    await close();
+  }
+});
+
+test('/session/start senza scenario_id NON emette tutorial_start', async () => {
+  const logsDir = await mkTempLogsDir();
+  const { app, close } = createApp({ databasePath: null, session: { logsDir } });
+  try {
+    await request(app)
+      .post('/api/session/start')
+      .send({ units: [{ id: 'u1', controlled_by: 'player', hp: 10 }] })
+      .expect(200);
+    await new Promise((r) => setTimeout(r, 50));
+    const events = await readTelemetryJsonl(logsDir);
+    const tutorialEvents = events.filter((e) => e.type === 'tutorial_start');
+    assert.equal(tutorialEvents.length, 0, 'scenario_id null → no tutorial_start');
+  } finally {
+    await close();
+  }
+});

--- a/tests/scripts/test_telemetry_analyze.py
+++ b/tests/scripts/test_telemetry_analyze.py
@@ -13,6 +13,7 @@ pytest.importorskip("tools.py.telemetry_analyze", reason="PYTHONPATH=tools/py re
 from tools.py.telemetry_analyze import (  # noqa: E402
     FUNNEL_STAGES,
     KNOWN_EVENT_TYPES,
+    TUTORIAL_FUNNEL_STAGES,
     Aggregates,
     TelemetryEvent,
     aggregate,
@@ -218,3 +219,98 @@ def test_known_event_types_nonempty():
     assert "session_start" in KNOWN_EVENT_TYPES
     assert "session_end" in KNOWN_EVENT_TYPES
     assert len(KNOWN_EVENT_TYPES) >= 10
+
+
+def test_tutorial_funnel_schema_recognized():
+    """tutorial_start + tutorial_complete must be in KNOWN_EVENT_TYPES."""
+    assert "tutorial_start" in KNOWN_EVENT_TYPES
+    assert "tutorial_complete" in KNOWN_EVENT_TYPES
+    assert TUTORIAL_FUNNEL_STAGES == ("tutorial_start", "tutorial_complete")
+
+
+def test_tutorial_funnel_basic(tmp_path: Path):
+    """tutorial_funnel aggregates per scenario with started/completed/rate/outcomes."""
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    _write_jsonl(
+        logs / "telemetry_20260426.jsonl",
+        [
+            # Scenario enc_tutorial_01: 3 start, 2 complete (1 victory + 1 defeat)
+            {"ts": "2026-04-26T10:00:00Z", "session_id": "s1", "type": "tutorial_start",
+             "payload": {"scenario_id": "enc_tutorial_01", "party_size": 2}},
+            {"ts": "2026-04-26T10:30:00Z", "session_id": "s1", "type": "tutorial_complete",
+             "payload": {"scenario_id": "enc_tutorial_01", "outcome": "win"}},
+            {"ts": "2026-04-26T11:00:00Z", "session_id": "s2", "type": "tutorial_start",
+             "payload": {"scenario_id": "enc_tutorial_01", "party_size": 2}},
+            {"ts": "2026-04-26T11:30:00Z", "session_id": "s2", "type": "tutorial_complete",
+             "payload": {"scenario_id": "enc_tutorial_01", "outcome": "wipe"}},
+            {"ts": "2026-04-26T12:00:00Z", "session_id": "s3", "type": "tutorial_start",
+             "payload": {"scenario_id": "enc_tutorial_01", "party_size": 2}},
+            # s3 abandoned (no complete event) — drop-off signal
+            # Scenario enc_tutorial_02: 1 start, 0 complete (100% drop-off)
+            {"ts": "2026-04-26T13:00:00Z", "session_id": "s4", "type": "tutorial_start",
+             "payload": {"scenario_id": "enc_tutorial_02"}},
+        ],
+    )
+    agg = aggregate(read_events(logs))
+    funnel = agg.tutorial_funnel()
+    assert "enc_tutorial_01" in funnel
+    assert funnel["enc_tutorial_01"]["started"] == 3
+    assert funnel["enc_tutorial_01"]["completed"] == 2
+    assert funnel["enc_tutorial_01"]["completion_rate_pct"] == pytest.approx(66.7, rel=0.01)
+    assert funnel["enc_tutorial_01"]["outcomes"]["win"] == 1
+    assert funnel["enc_tutorial_01"]["outcomes"]["wipe"] == 1
+    # tutorial_02 abandoned
+    assert funnel["enc_tutorial_02"]["started"] == 1
+    assert funnel["enc_tutorial_02"]["completed"] == 0
+    assert funnel["enc_tutorial_02"]["completion_rate_pct"] == 0.0
+
+
+def test_tutorial_funnel_empty_returns_empty_dict(tmp_path: Path):
+    """No tutorial events → empty funnel dict."""
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    _write_jsonl(
+        logs / "telemetry_20260426.jsonl",
+        [{"ts": "2026-04-26T10:00:00Z", "session_id": "s1", "type": "session_start"}],
+    )
+    agg = aggregate(read_events(logs))
+    funnel = agg.tutorial_funnel()
+    assert funnel == {}
+
+
+def test_format_markdown_includes_tutorial_funnel(tmp_path: Path):
+    """Markdown report emits 'Tutorial funnel' section when data present."""
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    _write_jsonl(
+        logs / "telemetry_20260426.jsonl",
+        [
+            {"ts": "2026-04-26T10:00:00Z", "session_id": "s1", "type": "tutorial_start",
+             "payload": {"scenario_id": "enc_tutorial_01"}},
+            {"ts": "2026-04-26T10:30:00Z", "session_id": "s1", "type": "tutorial_complete",
+             "payload": {"scenario_id": "enc_tutorial_01", "outcome": "win"}},
+        ],
+    )
+    agg = aggregate(read_events(logs))
+    md = format_markdown(agg)
+    assert "Tutorial funnel" in md
+    assert "enc_tutorial_01" in md
+    assert "Completion %" in md
+
+
+def test_format_json_includes_tutorial_funnel(tmp_path: Path):
+    """JSON summary emits tutorial_funnel key."""
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    _write_jsonl(
+        logs / "telemetry_20260426.jsonl",
+        [
+            {"ts": "2026-04-26T10:00:00Z", "session_id": "s1", "type": "tutorial_start",
+             "payload": {"scenario_id": "enc_tutorial_01"}},
+        ],
+    )
+    agg = aggregate(read_events(logs))
+    data = format_json(agg)
+    assert "tutorial_funnel" in data
+    assert "enc_tutorial_01" in data["tutorial_funnel"]

--- a/tools/py/telemetry_analyze.py
+++ b/tools/py/telemetry_analyze.py
@@ -55,6 +55,9 @@ KNOWN_EVENT_TYPES = frozenset(
         "pack_roll",
         "mbti_projection",
         "session_end",
+        # Tutorial funnel events (server-side auto-log in /session/start + /end):
+        "tutorial_start",
+        "tutorial_complete",
         # M16+ coop events (optional, tolerated):
         "lobby_join",
         "char_create",
@@ -72,6 +75,14 @@ FUNNEL_STAGES = (
     "ability_use",
     "damage_dealt",
     "session_end",
+)
+
+# Tutorial-specific funnel: onboarding drop-off analysis per scenario.
+# Server-side auto-log: tutorial_start on /session/start (scenario matches
+# ^enc_tutorial_\d+), tutorial_complete on /session/end with outcome.
+TUTORIAL_FUNNEL_STAGES = (
+    "tutorial_start",
+    "tutorial_complete",
 )
 
 
@@ -138,6 +149,40 @@ class Aggregates:
                 outcome = str(payload.get("outcome") or "unknown")
                 out[scenario][outcome] += 1
         return out
+
+    def tutorial_funnel(self) -> dict[str, dict]:
+        """Per-scenario tutorial funnel: start → complete + outcome breakdown.
+
+        Uses `tutorial_start` + `tutorial_complete` events (server-side auto-log).
+        Returns per-scenario dict: {started, completed, completion_rate, outcomes}.
+        """
+        by_scenario: dict[str, dict] = defaultdict(
+            lambda: {"started": 0, "completed": 0, "outcomes": Counter()}
+        )
+        # First pass: count starts.
+        for events in self.sessions.values():
+            for ev in events:
+                payload = ev.payload or {}
+                scenario = str(payload.get("scenario_id") or "unknown")
+                if ev.type == "tutorial_start":
+                    by_scenario[scenario]["started"] += 1
+                elif ev.type == "tutorial_complete":
+                    by_scenario[scenario]["completed"] += 1
+                    outcome = str(payload.get("outcome") or "unknown")
+                    by_scenario[scenario]["outcomes"][outcome] += 1
+        # Second pass: compute completion_rate.
+        result: dict[str, dict] = {}
+        for scenario, data in by_scenario.items():
+            started = data["started"] or 0
+            completed = data["completed"] or 0
+            rate = round(100 * completed / started, 1) if started else 0.0
+            result[scenario] = {
+                "started": started,
+                "completed": completed,
+                "completion_rate_pct": rate,
+                "outcomes": dict(data["outcomes"]),
+            }
+        return result
 
     def session_durations_minutes(self) -> list[float]:
         """Duration in minutes between first and last event per session."""
@@ -283,6 +328,27 @@ def format_markdown(agg: Aggregates, *, date_range: str | None = None) -> str:
         lines.append(f"- Min / Max = {min(durations):.2f} / {max(durations):.2f}")
         lines.append("")
 
+    tutorial = agg.tutorial_funnel()
+    if tutorial:
+        lines.append("## Tutorial funnel (onboarding drop-off)")
+        lines.append("")
+        lines.append("Per-scenario: tutorial_start → tutorial_complete + outcome breakdown.")
+        lines.append("")
+        lines.append("| Scenario | Started | Completed | Completion % | Victory | Defeat | Other |")
+        lines.append("| --- | ---: | ---: | ---: | ---: | ---: | ---: |")
+        for scenario, data in sorted(tutorial.items()):
+            started = data.get("started", 0)
+            completed = data.get("completed", 0)
+            rate = data.get("completion_rate_pct", 0.0)
+            outs = data.get("outcomes", {})
+            victory = outs.get("win", 0) + outs.get("victory", 0)
+            defeat = outs.get("wipe", 0) + outs.get("defeat", 0)
+            other = sum(outs.values()) - victory - defeat
+            lines.append(
+                f"| `{scenario}` | {started} | {completed} | {rate:.1f}% | {victory} | {defeat} | {other} |"
+            )
+        lines.append("")
+
     outcomes = agg.scenario_outcomes()
     if outcomes:
         lines.append("## Scenario outcomes")
@@ -327,6 +393,7 @@ def format_json(agg: Aggregates) -> dict:
         "malformed_lines": agg.malformed_lines,
         "type_counts": dict(agg.type_counts),
         "funnel": agg.funnel_counts(),
+        "tutorial_funnel": agg.tutorial_funnel(),
         "durations_min": agg.session_durations_minutes(),
         "scenario_outcomes": {k: dict(v) for k, v in agg.scenario_outcomes().items()},
         "unknown_types": dict(agg.unknown_types),


### PR DESCRIPTION
## Summary

Quinta applicazione runtime agent findings — chiude **P0 #2** del `telemetry-viz-illuminator` agent. Sblocca retention analytics per TKT-M11B-06 playtest.

## Backend auto-log (server-side, zero client change)

**`apps/backend/routes/session.js`**:

- `appendTelemetryEvent(entry)` helper closure-scoped — non-HTTP direct write a `logs/telemetry_YYYYMMDD.jsonl`
- `isTutorialScenario(id)` matcher regex `^enc_tutorial_\d+`
- `/session/start`: scenario tutorial → emit `tutorial_start` con `{scenario_id, encounter_class, party_size}`
- `/session/end`: scenario tutorial → emit `tutorial_complete` con `{scenario_id, outcome, turns, player_alive, sistema_alive}`
- **Non-blocking**: errori write non crashano session

## Analyzer extension

**`tools/py/telemetry_analyze.py`**:

- `KNOWN_EVENT_TYPES` += `tutorial_start`, `tutorial_complete`
- `TUTORIAL_FUNNEL_STAGES` tuple exported
- `Aggregates.tutorial_funnel()` → per-scenario `{started, completed, completion_rate_pct, outcomes}`
- Markdown report: "Tutorial funnel (onboarding drop-off)" table
- JSON summary: `tutorial_funnel` key

## Unblocks retention analytics

Post-TKT-M11B-06 playtest data:

- Drop-off % per tutorial 01 → 02 → 03 → 04 → 05
- Completion rate vs abandon per scenario
- Identifica stuck points (high drop-off = tutorial design issue)

## Test plan

- [x] **Python**: `pytest tests/scripts/test_telemetry_analyze.py` → **20/20 verdi** (15 esistenti + 5 funnel new)
- [x] **Node backend**: `tests/api/telemetryTutorialFunnel.test.js` → **4/4 verdi**
  - /start con tutorial → emit OK
  - /end con tutorial → emit + outcome OK
  - scenario non-tutorial → NO emit
  - scenario_id null → NO emit
- [x] AI regression 307/307 verde
- [x] Tutorial 01/02 batch verde (no interference)
- [x] `npm run format:check` verde

## Scope out

- Observable Plot dashboard (P0 #3, frontend scope, separate PR)
- deck.gl hex heatmap (P0 #5, richiede N=100+)
- D1/D7/D30 retention cohort (richiede stable player_id, V6+)

## Compliance

- ✅ Zero new deps
- ✅ Stdlib-only Python
- ✅ 4-gate DoD agent-driven
- ✅ Guardrail sprint rispettato

Ref agent: `.claude/agents/telemetry-viz-illuminator.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `telemetry-viz-illuminator` agent