### PR TITLE
feat(narrative): tutorial briefing variations engine (narrative-illuminator P0)

### DIFF
--- a/apps/backend/routes/tutorial.js
+++ b/apps/backend/routes/tutorial.js
@@ -30,45 +30,90 @@ const {
   buildHardcoreUnits06Quartet,
   buildHardcoreUnits07,
 } = require('../services/hardcoreScenario');
+const { selectBriefing } = require('../services/narrative/briefingVariations');
+
+// Optional briefing variation: when ?variant_seed=N is passed, swap the
+// hardcoded briefing_pre/post with a YAML-pack variant (tutorial_briefings.yaml).
+// Backward-compatible: omitting the param yields the original strings.
+function applyBriefingVariation(scenario, req) {
+  const seed = req.query?.variant_seed;
+  if (seed === undefined || seed === null || seed === '') return scenario;
+  const ctx = {
+    seed,
+    biome: scenario.biome_id,
+    difficulty: scenario.difficulty_rating,
+    replay: req.query.replay === 'true' || req.query.replay === '1',
+    mbti_axes: parseMbtiAxes(req.query.mbti),
+  };
+  const pre = selectBriefing(scenario.id, 'pre', { ...ctx, fallback: scenario.briefing_pre });
+  const post = selectBriefing(scenario.id, 'post', { ...ctx, fallback: scenario.briefing_post });
+  return {
+    ...scenario,
+    briefing_pre: pre?.text || scenario.briefing_pre,
+    briefing_post: post?.text || scenario.briefing_post,
+    briefing_variants: {
+      pre: { id: pre?.id, source: pre?.source },
+      post: { id: post?.id, source: post?.source },
+    },
+  };
+}
+
+// Parses the optional `mbti=T:0.7,N:0.6` query into { T_F, S_N } floats.
+function parseMbtiAxes(raw) {
+  if (typeof raw !== 'string' || !raw.includes(':')) return undefined;
+  const out = {};
+  for (const pair of raw.split(',')) {
+    const [k, v] = pair.split(':').map((s) => s.trim());
+    const num = Number(v);
+    if (Number.isNaN(num)) continue;
+    if (k === 'T') out.T_F = Math.max(0, Math.min(1, num));
+    else if (k === 'F') out.T_F = Math.max(0, Math.min(1, 1 - num));
+    else if (k === 'N') out.S_N = Math.max(0, Math.min(1, num));
+    else if (k === 'S') out.S_N = Math.max(0, Math.min(1, 1 - num));
+    else if (k === 'E') out.E_I = Math.max(0, Math.min(1, num));
+    else if (k === 'P') out.J_P = Math.max(0, Math.min(1, num));
+  }
+  return Object.keys(out).length ? out : undefined;
+}
 
 function createTutorialRouter() {
   const router = Router();
 
-  router.get('/enc_tutorial_01', (_req, res) => {
+  router.get('/enc_tutorial_01', (req, res) => {
     res.json({
-      ...TUTORIAL_SCENARIO,
+      ...applyBriefingVariation(TUTORIAL_SCENARIO, req),
       units: buildTutorialUnits(),
       usage: 'POST the units array to /api/session/start to begin a playable session.',
     });
   });
 
-  router.get('/enc_tutorial_02', (_req, res) => {
+  router.get('/enc_tutorial_02', (req, res) => {
     res.json({
-      ...TUTORIAL_SCENARIO_02,
+      ...applyBriefingVariation(TUTORIAL_SCENARIO_02, req),
       units: buildTutorialUnits02(),
       usage: 'POST the units array to /api/session/start to begin a playable session.',
     });
   });
 
-  router.get('/enc_tutorial_03', (_req, res) => {
+  router.get('/enc_tutorial_03', (req, res) => {
     res.json({
-      ...TUTORIAL_SCENARIO_03,
+      ...applyBriefingVariation(TUTORIAL_SCENARIO_03, req),
       units: buildTutorialUnits03(),
       usage: 'POST the units array to /api/session/start to begin a playable session.',
     });
   });
 
-  router.get('/enc_tutorial_04', (_req, res) => {
+  router.get('/enc_tutorial_04', (req, res) => {
     res.json({
-      ...TUTORIAL_SCENARIO_04,
+      ...applyBriefingVariation(TUTORIAL_SCENARIO_04, req),
       units: buildTutorialUnits04(),
       usage: 'POST the units array to /api/session/start to begin a playable session.',
     });
   });
 
-  router.get('/enc_tutorial_05', (_req, res) => {
+  router.get('/enc_tutorial_05', (req, res) => {
     res.json({
-      ...TUTORIAL_SCENARIO_05,
+      ...applyBriefingVariation(TUTORIAL_SCENARIO_05, req),
       units: buildTutorialUnits05(),
       usage: 'POST the units array to /api/session/start to begin a playable session.',
     });

--- a/apps/backend/services/narrative/briefingVariations.js
+++ b/apps/backend/services/narrative/briefingVariations.js
@@ -1,0 +1,204 @@
+// Tutorial briefing variation engine — narrative-design-illuminator P0.
+//
+// Replaces hardcoded `briefing_pre` / `briefing_post` strings with a
+// deterministic, condition-gated weighted picker over a YAML pack of
+// variants. Pattern: ink/Tracery hybrid — handcrafted variants (Wildermyth
+// style), rule-based selection (Tracery), reproducible seed (mulberry32
+// matching `services/forms/packRoller.js`).
+//
+// Falls back to the original hardcoded scenario string when:
+//   - YAML pack missing or malformed
+//   - scenario_id not in pack
+//   - phase not in pack[scenario_id]
+//   - no variants pass the conditions
+//
+// Backward-compatible: existing `?variant_seed` not provided → original
+// behavior. Adding `?variant_seed=N` to `/api/tutorial/<id>` enables variation.
+//
+// Why not full inkjs? inkjs needs `.ink.json` compiled artifacts
+// (inklecate CLI not in the repo). For static briefing variation the
+// lighter Tracery-style picker keeps zero new deps and remains compilable
+// to ink later (variants → ink alternatives `{a|b|c}`).
+//
+// References:
+//   - .claude/agents/narrative-design-illuminator.md (P0 ink/weave)
+//   - data/narrative/tutorial_briefings.yaml (variant pack)
+//   - services/forms/packRoller.js (mulberry32 seed pattern)
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const DEFAULT_PACK_PATH = path.resolve(
+  __dirname,
+  '../../../../data/narrative/tutorial_briefings.yaml',
+);
+
+let _cached = null;
+
+/**
+ * Load + memoize the YAML variant pack. Returns null on failure (engine
+ * gracefully degrades to fallback).
+ */
+function loadPack(pathOverride = null) {
+  if (pathOverride === null && _cached !== null) return _cached;
+  const target = pathOverride || DEFAULT_PACK_PATH;
+  try {
+    const raw = fs.readFileSync(target, 'utf-8');
+    const parsed = yaml.load(raw);
+    if (!parsed || typeof parsed !== 'object' || !parsed.scenarios) return null;
+    if (pathOverride === null) _cached = parsed;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** Test hook — clears the memoized pack so subsequent loads re-read disk. */
+function clearCache() {
+  _cached = null;
+}
+
+/**
+ * Mulberry32 deterministic RNG. Same pattern as services/forms/packRoller.js
+ * + apps/backend/services/rewards/rewardOffer.js. Returns float ∈ [0, 1).
+ */
+function createRng(seed) {
+  let s = seed >>> 0 || 1;
+  return () => {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Hash a string to a 32-bit integer (FNV-1a). Used so callers can pass
+ * `session_id` directly without manually computing a numeric seed.
+ */
+function hashSeed(str) {
+  let h = 0x811c9dc5;
+  const s = String(str);
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h >>> 0;
+}
+
+/**
+ * Test variant.conditions against the supplied context. Missing fields on
+ * either side are treated permissively (no condition = always pass).
+ */
+function matchConditions(conditions, ctx = {}) {
+  if (!conditions || typeof conditions !== 'object') return true;
+  if (conditions.replay === true && !ctx.replay) return false;
+  if (conditions.replay === false && ctx.replay) return false;
+  if (conditions.biome && ctx.biome !== conditions.biome) return false;
+  if (typeof conditions.min_difficulty === 'number') {
+    if ((ctx.difficulty || 0) < conditions.min_difficulty) return false;
+  }
+  if (typeof conditions.max_difficulty === 'number') {
+    if ((ctx.difficulty || 0) > conditions.max_difficulty) return false;
+  }
+  // MBTI axis thresholds: ctx.mbti_axes = { T_F: 0..1, S_N: 0..1, ... } where
+  // 0 = pure F/S/I/J and 1 = pure T/N/E/P. We test the high-end thresholds.
+  const axes = ctx.mbti_axes || {};
+  if (typeof conditions.mbti_t_min === 'number') {
+    if ((axes.T_F ?? 0.5) < conditions.mbti_t_min) return false;
+  }
+  if (typeof conditions.mbti_f_min === 'number') {
+    if (1 - (axes.T_F ?? 0.5) < conditions.mbti_f_min) return false;
+  }
+  if (typeof conditions.mbti_n_min === 'number') {
+    if ((axes.S_N ?? 0.5) < conditions.mbti_n_min) return false;
+  }
+  if (typeof conditions.mbti_s_min === 'number') {
+    if (1 - (axes.S_N ?? 0.5) < conditions.mbti_s_min) return false;
+  }
+  return true;
+}
+
+/**
+ * Pick a variant by weighted RNG. `variants` is the pre-filtered eligible list.
+ * Returns the picked variant object (with id + text + weight + conditions).
+ */
+function weightedPick(variants, rng) {
+  if (!Array.isArray(variants) || variants.length === 0) return null;
+  const weights = variants.map((v) => Math.max(0, Number(v.weight) || 1));
+  const total = weights.reduce((a, b) => a + b, 0);
+  if (total <= 0) return variants[0];
+  const r = rng() * total;
+  let cum = 0;
+  for (let i = 0; i < variants.length; i++) {
+    cum += weights[i];
+    if (r <= cum) return variants[i];
+  }
+  return variants[variants.length - 1];
+}
+
+/**
+ * Main API: pick a briefing variant for the given (scenario, phase, ctx).
+ *
+ * @param {string} scenarioId — e.g. "enc_tutorial_01"
+ * @param {string} phase — "pre" or "post"
+ * @param {object} ctx
+ * @param {number|string} [ctx.seed] — numeric seed OR string hashed via FNV-1a
+ * @param {boolean}  [ctx.replay]   — whether the player has played this scenario before
+ * @param {string}   [ctx.biome]    — current biome id (for biome-gated variants)
+ * @param {number}   [ctx.difficulty]
+ * @param {object}   [ctx.mbti_axes] — { T_F, S_N, E_I, J_P } each 0..1
+ * @param {string|null} [ctx.fallback] — string to return on miss (default null)
+ * @param {object|null} [pack] — preloaded pack; if omitted, default pack is used
+ * @returns {{ id: string, text: string, source: 'variation'|'fallback' } | null}
+ */
+function selectBriefing(scenarioId, phase, ctx = {}, pack = null) {
+  const fallback = ctx.fallback ?? null;
+  const data = pack || loadPack();
+  if (!data?.scenarios?.[scenarioId]?.[phase]) {
+    return fallback ? { id: 'fallback', text: fallback, source: 'fallback' } : null;
+  }
+  const variants = data.scenarios[scenarioId][phase];
+  if (!Array.isArray(variants) || variants.length === 0) {
+    return fallback ? { id: 'fallback', text: fallback, source: 'fallback' } : null;
+  }
+  const eligible = variants.filter((v) => matchConditions(v.conditions, ctx));
+  if (eligible.length === 0) {
+    return fallback ? { id: 'fallback', text: fallback, source: 'fallback' } : null;
+  }
+  const seed = typeof ctx.seed === 'string' ? hashSeed(ctx.seed) : (ctx.seed ?? 1);
+  const rng = createRng(seed);
+  const picked = weightedPick(eligible, rng);
+  return picked ? { id: picked.id, text: picked.text, source: 'variation' } : null;
+}
+
+/**
+ * Convenience: lists every variant id available for a scenario/phase. Useful
+ * for telemetry and for the route handler to expose discoverability.
+ */
+function listVariants(scenarioId, phase, pack = null) {
+  const data = pack || loadPack();
+  const variants = data?.scenarios?.[scenarioId]?.[phase];
+  if (!Array.isArray(variants)) return [];
+  return variants.map((v) => ({
+    id: v.id,
+    weight: v.weight ?? 1,
+    has_conditions: Boolean(v.conditions),
+  }));
+}
+
+module.exports = {
+  DEFAULT_PACK_PATH,
+  clearCache,
+  createRng,
+  hashSeed,
+  loadPack,
+  matchConditions,
+  selectBriefing,
+  listVariants,
+  weightedPick,
+};

--- a/data/narrative/tutorial_briefings.yaml
+++ b/data/narrative/tutorial_briefings.yaml
@@ -1,0 +1,150 @@
+# Tutorial briefing variations — narrative-design-illuminator P0.
+#
+# Each scenario has multiple `pre` (mission start) and `post` (debrief on
+# victory) variants. Selection is deterministic on (session_id, variant_seed).
+# Optional gating conditions filter eligibility per (replay, mbti_axis, biome).
+#
+# When no variant matches OR the file fails to load, the engine falls back
+# to the hardcoded string in `apps/backend/services/tutorialScenario.js`
+# (backward compatible).
+#
+# Structure:
+#   <scenario_id>:
+#     pre:  list[Variant]
+#     post: list[Variant]
+#
+# Variant shape:
+#   id:          string, unique within scenario+phase
+#   text:        the briefing line
+#   weight:      optional, integer (default 1) — relative pick probability
+#   conditions:  optional, dict of soft gates:
+#     replay:    bool — only when run_count > 0
+#     mbti_t_min, mbti_f_min, mbti_n_min, mbti_s_min: float 0..1
+#     biome:     string match
+#     min_difficulty, max_difficulty: integer
+#
+# Pattern source: ink/inkle weave (text variation by tag) + Tracery grammar
+# (rule-based selection) + Wildermyth (handcrafted variants over procedural).
+#
+# Companion docs:
+#   .claude/agents/narrative-design-illuminator.md
+#   apps/backend/services/narrative/briefingVariations.js
+
+schema_version: '1.0'
+
+scenarios:
+  enc_tutorial_01:
+    pre:
+      - id: default
+        weight: 2
+        text: 'Due predoni nomadi hanno preso posizione nella savana. Avvicinati con cautela e eliminali.'
+      - id: tactical
+        conditions: { mbti_t_min: 0.6 }
+        text: "Rapporto: due ostili in posizione difensiva nella savana. Range medio, copertura assente. Ingaggio raccomandato dal lato sopravento."
+      - id: empathic
+        conditions: { mbti_f_min: 0.6 }
+        text: "Due nomadi spaesati nella savana. Hanno paura quanto te. Risolvi rapidamente — ognuno qui sta solo cercando di sopravvivere."
+      - id: replay
+        conditions: { replay: true }
+        text: 'Conosci già questo terreno. Predoni della savana, due unità, posizione fissa. Mostra cosa hai imparato.'
+    post:
+      - id: default
+        weight: 2
+        text: 'Le sentinelle sono cadute. La via è libera — per ora.'
+      - id: cautious
+        conditions: { mbti_n_min: 0.6 }
+        text: 'Il silenzio della savana torna. Ma se due erano qui in vedetta, altri saranno vicini.'
+      - id: confident
+        conditions: { mbti_s_min: 0.6 }
+        text: 'Predoni neutralizzati. Posizione assicurata, perimetro sgombro. Procedere.'
+
+  enc_tutorial_02:
+    pre:
+      - id: default
+        weight: 2
+        text: 'La pattuglia nomade questa volta include un cacciatore con corazza pesante. Coordina scout e tank: il danno asimmetrico premia chi sceglie il bersaglio giusto.'
+      - id: tactical
+        conditions: { mbti_t_min: 0.6 }
+        text: "Pattuglia mista rilevata: 2 unità leggere + 1 cacciatore corazzato. Resistenza fisica del cacciatore stimata +40%. Concentrare fuoco o aggirare."
+      - id: empathic
+        conditions: { mbti_f_min: 0.6 }
+        text: "Hanno mandato anche il loro più anziano — un cacciatore corazzato. Spera tu non sia obbligato a colpirlo per primo."
+      - id: replay
+        conditions: { replay: true }
+        text: 'La pattuglia asimmetrica torna. Questa volta sai dove cade il loro coordinamento se elimini il cacciatore.'
+    post:
+      - id: default
+        weight: 2
+        text: "La pattuglia è dissolta. Il cacciatore non e' bastato a tenerli insieme."
+      - id: tactical
+        conditions: { mbti_t_min: 0.6 }
+        text: 'Pattuglia neutralizzata. Concentrazione fuoco sul cacciatore = collasso del gruppo confermato.'
+
+  enc_tutorial_03:
+    pre:
+      - id: default
+        weight: 2
+        text: 'Una caverna risonante con due fumarole attive. Le creature locali resistono al gas; voi no. Posizionate con cura e usate combo per finire in fretta.'
+      - id: tactical
+        conditions: { mbti_t_min: 0.6 }
+        text: 'Caverna con 2 hazard tile (fumarole tossiche, danno 1 a turno se occupate). Guardiani locali immuni. Path-planning critico.'
+      - id: empathic
+        conditions: { mbti_f_min: 0.6 }
+        text: 'La caverna respira veleno. Le creature ci sono nate dentro — è la loro casa, non la tua. Muoviti veloce, esci viva.'
+      - id: replay
+        conditions: { replay: true }
+        text: 'La caverna risonante. Già conosci le fumarole — questa volta usale a tuo vantaggio.'
+    post:
+      - id: default
+        weight: 2
+        text: 'I guardiani sono caduti. Il riverbero della caverna si placa.'
+      - id: empathic
+        conditions: { mbti_f_min: 0.6 }
+        text: "Le voci della caverna tacciono. Hanno difeso ciò che potevano. Non c'è gloria in questo, solo necessità."
+
+  enc_tutorial_04:
+    pre:
+      - id: default
+        weight: 2
+        text: 'La pozza acida nasconde 3 guardiani: 2 corrieri rapidi e un lanciere con denti seghettati. Il bleeding accumula danno turno per turno: prioritizza il lanciere o tieni HP alto.'
+      - id: tactical
+        conditions: { mbti_t_min: 0.6 }
+        text: 'Pozza acida + 3 guardiani: 2 mobili + 1 con `denti_seghettati` (bleeding stack). Eliminazione lanciere = priorità target. 3 hazard tile mappati.'
+      - id: empathic
+        conditions: { mbti_f_min: 0.6 }
+        text: "Tre guardiani difendono una pozza che brucia. Il lanciere è il più aggressivo — dolore lo guida. Prendi lui, gli altri si arrenderanno al silenzio."
+      - id: replay
+        conditions: { replay: true }
+        text: 'La foresta acida. Sai già che il lanciere applica bleeding. Tienilo lontano dai tuoi più fragili.'
+    post:
+      - id: default
+        weight: 2
+        text: 'La pozza si calma. I corpi dei guardiani si dissolvono nel liquido.'
+      - id: tactical
+        conditions: { mbti_t_min: 0.6 }
+        text: 'Tre target neutralizzati. Hazard ambientale gestito senza perdite critiche di HP. Operazione concluso entro parametri.'
+
+  enc_tutorial_05:
+    pre:
+      - id: default
+        weight: 2
+        text: 'Le rovine planari celano un Apex: 1v2 a vostro favore, ma il suo HP e i bonus crit possono ribaltare ogni round. Cooperate o cadrete uno alla volta.'
+      - id: tactical
+        conditions: { mbti_t_min: 0.6 }
+        text: "Apex Predator confermato nelle rovine. HP stimato 30+, crit chain attiva, multi-attack 2/turn. 2v1 svantaggio numerico contro statistiche apex. Coop = win condition."
+      - id: empathic
+        conditions: { mbti_f_min: 0.6 }
+        text: "Un Apex. Sopravvissuto a tutto, fino ad ora. Forse il primo della sua linea. Forse l'ultimo. Devi essere tu a chiudere la sua storia."
+      - id: replay
+        conditions: { replay: true }
+        text: "L'Apex aspetta di nuovo nelle rovine. Sai cosa fa il suo crit chain. Sai dove cade quando vacilla. Vai."
+    post:
+      - id: default
+        weight: 2
+        text: "L'Apex si dissolve nelle rovine. Avete fatto la storia."
+      - id: empathic
+        conditions: { mbti_f_min: 0.6 }
+        text: "L'Apex respira l'ultima volta. Le rovine restano in silenzio — il loro guardiano è andato. Avete chiuso un'era."
+      - id: tactical
+        conditions: { mbti_t_min: 0.6 }
+        text: "Apex Predator neutralizzato. Crit chain interrotto al round critico. Operazione 1v2 → vittoria asimmetrica confermata. Database aggiornato."

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-24T23:48:43+00:00",
+  "generated_at": "2026-04-24T23:58:16+00:00",
   "summary": {
     "total": 0,
     "errors": 0,

--- a/tests/services/briefingVariations.test.js
+++ b/tests/services/briefingVariations.test.js
@@ -1,0 +1,370 @@
+// Unit tests for briefingVariations engine — narrative-design-illuminator P0.
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+
+const {
+  clearCache,
+  createRng,
+  hashSeed,
+  loadPack,
+  matchConditions,
+  selectBriefing,
+  listVariants,
+  weightedPick,
+} = require('../../apps/backend/services/narrative/briefingVariations');
+
+// ── createRng ──
+
+test('createRng: deterministic with same seed', () => {
+  const r1 = createRng(42);
+  const r2 = createRng(42);
+  assert.equal(r1(), r2());
+  assert.equal(r1(), r2());
+});
+
+test('createRng: different seeds produce different sequences', () => {
+  const r1 = createRng(1);
+  const r2 = createRng(2);
+  assert.notEqual(r1(), r2());
+});
+
+test('createRng: returns floats in [0, 1)', () => {
+  const rng = createRng(123);
+  for (let i = 0; i < 100; i++) {
+    const v = rng();
+    assert.ok(v >= 0 && v < 1, `out of range: ${v}`);
+  }
+});
+
+test('createRng: zero seed coerced to 1 (avoid degenerate sequence)', () => {
+  const rng = createRng(0);
+  // Should produce non-degenerate output
+  assert.ok(rng() !== 0);
+});
+
+// ── hashSeed ──
+
+test('hashSeed: deterministic for same string', () => {
+  assert.equal(hashSeed('session-001'), hashSeed('session-001'));
+});
+
+test('hashSeed: different strings → different hashes (high prob)', () => {
+  assert.notEqual(hashSeed('session-001'), hashSeed('session-002'));
+});
+
+test('hashSeed: returns 32-bit unsigned int', () => {
+  const h = hashSeed('test');
+  assert.equal(typeof h, 'number');
+  assert.ok(h >= 0 && h < 2 ** 32);
+});
+
+// ── matchConditions ──
+
+test('matchConditions: empty conditions → always true', () => {
+  assert.equal(matchConditions(null, {}), true);
+  assert.equal(matchConditions(undefined, {}), true);
+  assert.equal(matchConditions({}, {}), true);
+});
+
+test('matchConditions: replay flag', () => {
+  assert.equal(matchConditions({ replay: true }, { replay: true }), true);
+  assert.equal(matchConditions({ replay: true }, { replay: false }), false);
+  assert.equal(matchConditions({ replay: true }, {}), false);
+  assert.equal(matchConditions({ replay: false }, { replay: true }), false);
+});
+
+test('matchConditions: biome match', () => {
+  assert.equal(matchConditions({ biome: 'savana' }, { biome: 'savana' }), true);
+  assert.equal(matchConditions({ biome: 'savana' }, { biome: 'caverna' }), false);
+  assert.equal(matchConditions({ biome: 'savana' }, {}), false);
+});
+
+test('matchConditions: difficulty range', () => {
+  assert.equal(matchConditions({ min_difficulty: 3 }, { difficulty: 5 }), true);
+  assert.equal(matchConditions({ min_difficulty: 3 }, { difficulty: 1 }), false);
+  assert.equal(matchConditions({ max_difficulty: 3 }, { difficulty: 1 }), true);
+  assert.equal(matchConditions({ max_difficulty: 3 }, { difficulty: 5 }), false);
+});
+
+test('matchConditions: mbti_t_min threshold', () => {
+  assert.equal(matchConditions({ mbti_t_min: 0.6 }, { mbti_axes: { T_F: 0.7 } }), true);
+  assert.equal(matchConditions({ mbti_t_min: 0.6 }, { mbti_axes: { T_F: 0.5 } }), false);
+  // No axes → defaults to 0.5 → fails 0.6
+  assert.equal(matchConditions({ mbti_t_min: 0.6 }, {}), false);
+});
+
+test('matchConditions: mbti_f_min uses inverted T_F (1-T_F)', () => {
+  assert.equal(matchConditions({ mbti_f_min: 0.6 }, { mbti_axes: { T_F: 0.3 } }), true);
+  assert.equal(matchConditions({ mbti_f_min: 0.6 }, { mbti_axes: { T_F: 0.5 } }), false);
+});
+
+test('matchConditions: mbti_n_min uses S_N axis', () => {
+  assert.equal(matchConditions({ mbti_n_min: 0.6 }, { mbti_axes: { S_N: 0.7 } }), true);
+  assert.equal(matchConditions({ mbti_n_min: 0.6 }, { mbti_axes: { S_N: 0.4 } }), false);
+});
+
+// ── weightedPick ──
+
+test('weightedPick: empty list → null', () => {
+  assert.equal(weightedPick([], createRng(1)), null);
+  assert.equal(weightedPick(null, createRng(1)), null);
+});
+
+test('weightedPick: single variant always picked', () => {
+  const v = { id: 'a', text: 'foo', weight: 1 };
+  assert.equal(weightedPick([v], createRng(42)), v);
+});
+
+test('weightedPick: weight 0 deprioritized', () => {
+  const a = { id: 'a', text: 'A', weight: 0 };
+  const b = { id: 'b', text: 'B', weight: 100 };
+  // 100 trials with very lopsided weights → b dominates
+  let bCount = 0;
+  for (let i = 0; i < 100; i++) {
+    const p = weightedPick([a, b], createRng(i + 1));
+    if (p.id === 'b') bCount++;
+  }
+  assert.ok(bCount >= 95, `expected b ≥95, got ${bCount}`);
+});
+
+test('weightedPick: deterministic with seed', () => {
+  const variants = [
+    { id: 'a', text: 'A', weight: 1 },
+    { id: 'b', text: 'B', weight: 1 },
+    { id: 'c', text: 'C', weight: 1 },
+  ];
+  const p1 = weightedPick(variants, createRng(7));
+  const p2 = weightedPick(variants, createRng(7));
+  assert.equal(p1.id, p2.id);
+});
+
+// ── loadPack ──
+
+test('loadPack: real pack loads with scenarios', () => {
+  clearCache();
+  const pack = loadPack();
+  assert.ok(pack !== null, 'real pack should load');
+  assert.ok(pack.scenarios.enc_tutorial_01, 'scenario 01 expected');
+  assert.ok(Array.isArray(pack.scenarios.enc_tutorial_01.pre));
+});
+
+test('loadPack: missing path → null (graceful)', () => {
+  const pack = loadPack('/nonexistent/path.yaml');
+  assert.equal(pack, null);
+});
+
+test('loadPack: malformed YAML → null', () => {
+  const tmp = path.join(os.tmpdir(), `briefings_bad_${Date.now()}.yaml`);
+  fs.writeFileSync(tmp, 'not: valid: yaml: [unclosed', 'utf-8');
+  const pack = loadPack(tmp);
+  assert.equal(pack, null);
+  fs.unlinkSync(tmp);
+});
+
+test('loadPack: missing scenarios key → null', () => {
+  const tmp = path.join(os.tmpdir(), `briefings_empty_${Date.now()}.yaml`);
+  fs.writeFileSync(tmp, 'foo: bar', 'utf-8');
+  const pack = loadPack(tmp);
+  assert.equal(pack, null);
+  fs.unlinkSync(tmp);
+});
+
+// ── selectBriefing ──
+
+test('selectBriefing: valid scenario+phase returns variant', () => {
+  clearCache();
+  const r = selectBriefing('enc_tutorial_01', 'pre', { seed: 42 });
+  assert.ok(r);
+  assert.equal(typeof r.text, 'string');
+  assert.ok(r.text.length > 0);
+  assert.equal(r.source, 'variation');
+});
+
+test('selectBriefing: deterministic with same seed', () => {
+  clearCache();
+  const r1 = selectBriefing('enc_tutorial_01', 'pre', { seed: 42 });
+  const r2 = selectBriefing('enc_tutorial_01', 'pre', { seed: 42 });
+  assert.equal(r1.id, r2.id);
+  assert.equal(r1.text, r2.text);
+});
+
+test('selectBriefing: string seed hashed', () => {
+  clearCache();
+  const r1 = selectBriefing('enc_tutorial_01', 'pre', { seed: 'session-abc' });
+  const r2 = selectBriefing('enc_tutorial_01', 'pre', { seed: 'session-abc' });
+  assert.equal(r1.id, r2.id);
+});
+
+test('selectBriefing: unknown scenario falls back', () => {
+  clearCache();
+  const r = selectBriefing('enc_unknown', 'pre', {
+    seed: 1,
+    fallback: 'fallback text',
+  });
+  assert.equal(r.text, 'fallback text');
+  assert.equal(r.source, 'fallback');
+});
+
+test('selectBriefing: unknown scenario without fallback → null', () => {
+  clearCache();
+  const r = selectBriefing('enc_unknown', 'pre', { seed: 1 });
+  assert.equal(r, null);
+});
+
+test('selectBriefing: replay condition gates variants', () => {
+  clearCache();
+  const noReplay = selectBriefing('enc_tutorial_01', 'pre', { seed: 1 });
+  // With replay=true, a different variant becomes eligible (variant 'replay').
+  // Multiple seeds should sometimes hit it.
+  let replayHits = 0;
+  for (let s = 1; s < 50; s++) {
+    const r = selectBriefing('enc_tutorial_01', 'pre', { seed: s, replay: true });
+    if (r.id === 'replay') replayHits++;
+  }
+  assert.ok(replayHits > 0, 'replay variant should be reachable when replay=true');
+  assert.notEqual(noReplay.id, 'replay');
+});
+
+test('selectBriefing: post phase returns post variants', () => {
+  clearCache();
+  const r = selectBriefing('enc_tutorial_05', 'post', { seed: 1 });
+  assert.ok(r);
+  assert.ok(['default', 'empathic', 'tactical'].includes(r.id));
+});
+
+test('selectBriefing: empathic variant reachable with mbti_f_min met', () => {
+  clearCache();
+  let empHits = 0;
+  for (let s = 1; s < 30; s++) {
+    const r = selectBriefing('enc_tutorial_01', 'pre', {
+      seed: s,
+      mbti_axes: { T_F: 0.2 }, // F-leaning
+    });
+    if (r.id === 'empathic') empHits++;
+  }
+  assert.ok(empHits > 0, 'empathic should be reachable for F-leaning player');
+});
+
+test('selectBriefing: pack override takes precedence over file load', () => {
+  const customPack = {
+    scenarios: {
+      enc_x: {
+        pre: [{ id: 'only', text: 'custom briefing', weight: 1 }],
+      },
+    },
+  };
+  const r = selectBriefing('enc_x', 'pre', { seed: 1 }, customPack);
+  assert.equal(r.id, 'only');
+  assert.equal(r.text, 'custom briefing');
+});
+
+test('selectBriefing: zero variants for phase → fallback', () => {
+  const customPack = {
+    scenarios: { enc_x: { pre: [] } },
+  };
+  const r = selectBriefing('enc_x', 'pre', { seed: 1, fallback: 'fb' }, customPack);
+  assert.equal(r.text, 'fb');
+  assert.equal(r.source, 'fallback');
+});
+
+test('selectBriefing: all variants gated out → fallback', () => {
+  const customPack = {
+    scenarios: {
+      enc_x: {
+        pre: [
+          { id: 'a', text: 'A', conditions: { replay: true } },
+          { id: 'b', text: 'B', conditions: { biome: 'mars' } },
+        ],
+      },
+    },
+  };
+  const r = selectBriefing(
+    'enc_x',
+    'pre',
+    { seed: 1, replay: false, biome: 'earth', fallback: 'fb' },
+    customPack,
+  );
+  assert.equal(r.text, 'fb');
+});
+
+// ── listVariants ──
+
+test('listVariants: real pack returns ids', () => {
+  clearCache();
+  const variants = listVariants('enc_tutorial_01', 'pre');
+  assert.ok(variants.length >= 3);
+  assert.ok(variants.every((v) => typeof v.id === 'string'));
+  assert.ok(variants.every((v) => typeof v.weight === 'number'));
+  assert.ok(variants.every((v) => typeof v.has_conditions === 'boolean'));
+});
+
+test('listVariants: unknown scenario → empty', () => {
+  clearCache();
+  assert.deepEqual(listVariants('enc_unknown', 'pre'), []);
+});
+
+// ── data integrity (real pack) ──
+
+test('real pack: all 5 scenarios have pre and post variants', () => {
+  clearCache();
+  const pack = loadPack();
+  const expected = [
+    'enc_tutorial_01',
+    'enc_tutorial_02',
+    'enc_tutorial_03',
+    'enc_tutorial_04',
+    'enc_tutorial_05',
+  ];
+  for (const sid of expected) {
+    assert.ok(pack.scenarios[sid], `missing scenario ${sid}`);
+    assert.ok(Array.isArray(pack.scenarios[sid].pre), `missing pre for ${sid}`);
+    assert.ok(Array.isArray(pack.scenarios[sid].post), `missing post for ${sid}`);
+    assert.ok(pack.scenarios[sid].pre.length > 0, `empty pre for ${sid}`);
+    assert.ok(pack.scenarios[sid].post.length > 0, `empty post for ${sid}`);
+  }
+});
+
+test('real pack: every variant has unique id within its phase', () => {
+  clearCache();
+  const pack = loadPack();
+  for (const [sid, scenario] of Object.entries(pack.scenarios)) {
+    for (const phase of ['pre', 'post']) {
+      const ids = scenario[phase].map((v) => v.id);
+      const unique = new Set(ids);
+      assert.equal(unique.size, ids.length, `duplicate ids in ${sid}.${phase}: ${ids}`);
+    }
+  }
+});
+
+test('real pack: every variant has non-empty text', () => {
+  clearCache();
+  const pack = loadPack();
+  for (const [sid, scenario] of Object.entries(pack.scenarios)) {
+    for (const phase of ['pre', 'post']) {
+      for (const v of scenario[phase]) {
+        assert.ok(typeof v.text === 'string', `${sid}.${phase}.${v.id} text not string`);
+        assert.ok(v.text.length > 10, `${sid}.${phase}.${v.id} text too short`);
+      }
+    }
+  }
+});
+
+test('real pack: at least one default variant per phase has no conditions', () => {
+  clearCache();
+  const pack = loadPack();
+  for (const [sid, scenario] of Object.entries(pack.scenarios)) {
+    for (const phase of ['pre', 'post']) {
+      const unconditional = scenario[phase].filter((v) => !v.conditions);
+      assert.ok(
+        unconditional.length > 0,
+        `${sid}.${phase} has no unconditional variant — missing safe fallback`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Closes [`narrative-design-illuminator`](.claude/agents/narrative-design-illuminator.md) P0 #2 — Tutorial briefing ink variation (~4h estimate). Replaces hardcoded `briefing_pre`/`briefing_post` strings with a deterministic, condition-gated weighted picker over a YAML pack of variants.

## Pattern

Hybrid **ink/Tracery**: handcrafted variants (Wildermyth-style) + rule-based selection (Tracery) + reproducible mulberry32 seed (matches existing `services/forms/packRoller.js` + `rewards/rewardOffer.js`).

### Why not full inkjs?

inkjs requires `.ink.json` compiled artifacts (inklecate CLI not in repo). For static briefing variation:

- ✅ keeps **zero new deps** (`js-yaml` already shipped)
- ✅ remains **compilable to ink later** (variants → ink alternatives `{a|b|c}`)
- ✅ **gracefully degrades** on missing/malformed pack (fallback to original strings)

Documented in module header for future migration path.

## Variant pack

5 tutorials × pre/post × 3-4 variants each = ~30 variants. Conditions:

| Condition | Type | Use |
| --- | --- | --- |
| `replay` | bool | gate variants for second+ playthroughs |
| `mbti_t_min` / `mbti_f_min` | float 0..1 | thinking/feeling axis bias |
| `mbti_n_min` / `mbti_s_min` | float 0..1 | intuition/sensing axis bias |
| `biome` | string | match scenario biome |
| `min_difficulty` / `max_difficulty` | int | scenario difficulty range |

Each scenario has at least one **unconditional default variant** (safe fallback enforced by data integrity test).

## API (backward compatible)

`GET /api/tutorial/<id>` unchanged behavior. Adding `?variant_seed=N&replay=1&mbti=T:0.7,N:0.6` enables variation:

```bash
GET /api/tutorial/enc_tutorial_01?variant_seed=42&replay=1
# → tactical OR replay variant based on seed (T-bias)
```

Response now includes optional `briefing_variants: { pre: { id, source }, post: { id, source } }` for telemetry.

## Smoke verification (live)

```
seed=1:        default  | Due predoni nomadi hanno preso posizione...
seed=99:       default  | (default has weight 2, dominates)
T-lean seed=5: tactical | Rapporto: due ostili in posizione difensiva...
replay seed=5: replay   | Conosci già questo terreno. Predoni della savana...
```

## Tests

**39 new node:test cases** (`tests/services/briefingVariations.test.js`):

- `createRng` determinism + range invariants
- `hashSeed` (FNV-1a) collision properties
- `matchConditions` (replay, biome, MBTI axes, difficulty range)
- `weightedPick` (empty, single, weight-0, deterministic)
- `loadPack` (real file, missing path, malformed YAML, missing scenarios key)
- `selectBriefing` (variation source, fallback, unknown scenario, replay gate, empathic via mbti_f_min, custom pack override, all-gated → fallback)
- `listVariants` (real pack ids + shape)
- **Real pack data integrity**: 5 scenarios × 2 phases, unique ids, non-empty text (>10 chars), at least 1 unconditional default per phase

## Quality gates

- [x] `node --test tests/ai/*.test.js` → **307/307** ✅
- [x] `node --test tests/services/*.test.js` → **216/216** (was 177, +39 new) ✅
- [x] `npm run format:check` → ✅
- [x] `python tools/check_docs_governance.py --strict` → 0 errors, 0 warnings ✅
- [x] Smoke live invocation: T-lean → `tactical`, replay → `replay` variant ✅

## Files

- **NEW** `data/narrative/tutorial_briefings.yaml` (5 scenarios × pre+post × 3-4 variants)
- **NEW** `apps/backend/services/narrative/briefingVariations.js` (~210 LOC)
- **NEW** `tests/services/briefingVariations.test.js` (39 node:test)
- **EDIT** `apps/backend/routes/tutorial.js` (wire `applyBriefingVariation` per route)

## Sources

- ink/inkle weave: https://www.inklestudios.com/ink/
- Tracery: https://tracery.io/
- Wildermyth narrative layering pattern
- Companion: `.claude/agents/narrative-design-illuminator.md`

## Future work (deferred)

- Migrate to true `.ink` source files when inklecate CLI is added to dev env
- Hook into V1 onboarding panel for choice-driven briefing branching (Disco Elysium pattern)
- Telemetry: log `briefing_variants.{pre,post}.id` to validate variant distribution post-playtest

🤖 Generated with [Claude Code](https://claude.com/claude-code)