### PR TITLE
docs(flint): replace stale RESEARCH_TODO in export() docstring

### DIFF
--- a/flint/src/flint/cli.py
+++ b/flint/src/flint/cli.py
@@ -230,8 +230,10 @@ def export(
 ) -> None:
     """Esporta stato corrente + metriche in JSON (per skill evo-tactics).
 
-    RESEARCH_TODO S4: produce file committabile con snapshot, achievements,
-    ultimo spoke, metriche aggregate (gameplay_ratio, drift flags).
+    Produce file committabile con snapshot dei commit recenti, ultimo spoke,
+    e metriche aggregate (``gameplay_ratio``, ``consecutive_infra_commits``,
+    ``is_drifting``). Achievements non inclusi: subsystem rimosso in
+    kill-60 2026-04-18 (vedi cli.py:16).
 
     Il file è letto dalla skill `evo-tactics-monitor` prima di fare web fetch,
     per briefing offline più accurati.


### PR DESCRIPTION
## Summary

- Sweep TODO codebase: `flint/src/flint/cli.py:233` `RESEARCH_TODO S4` referenziava feature già live (snapshot, last_spoke, gameplay_ratio, drift) + `achievements` killed.
- `achievements` rimosso in kill-60 2026-04-18 (Liberty/NTNU research backfire) — vedi `cli.py:16` + `flint/README.md:15`.
- Sostituito TODO con descrizione accurata di ciò che `export` produce realmente, nota esplicita su `achievements` non inclusi + ref kill-60.

## Files touched

- `flint/src/flint/cli.py` — docstring `export()` (4 insertions / 2 deletions)

## Test plan

- [x] `python -c "import ast; ast.parse(...)"` — syntax OK
- [x] `python flint/smoke_test.py` — 4 scenari passano senza errori
- [ ] CI verde su PR

## Notes

Altri TODO trovati nel sweep deliberatamente lasciati:
- `services/rules/resolver.py:99` — riferimento ADR a feature non implementate (PT spend types). Non actionable senza scope decision.
- `tools/py/import_external_traits.py:290` — placeholder per draft `famiglia_tipologia` da review manuale, by design.
- `scripts/generate_minimal_fixture.py:78,88` — fixture placeholder volutamente vuoto per test interface.
- `data/traits/_drafts/*.json` — generati da `import_external_traits.py`.

https://claude.ai/code/session_0175xfk3qtqyN4xhvMuHogkP

---
_Generated by [Claude Code](https://claude.ai/code/session_0175xfk3qtqyN4xhvMuHogkP)_