### PR TITLE
feat(balance): encounter XP budget audit (pcg-illuminator P1)

### DIFF
--- a/docs/balance/2026-04-25-encounter-xp-audit.md
+++ b/docs/balance/2026-04-25-encounter-xp-audit.md
@@ -1,0 +1,193 @@
+---
+title: Encounter XP Budget Audit (2026-04-25)
+doc_status: active
+doc_owner: claude-code
+workstream: dataset-pack
+last_verified: '2026-04-25'
+source_of_truth: false
+language: it
+review_cycle_days: 30
+tags:
+  - balance
+  - pcg
+  - encounter
+  - pathfinder-xp
+  - generated
+---
+
+# Encounter XP Budget Audit
+
+Pathfinder-inspired difficulty audit. Closes [pcg-level-design-illuminator P1](.claude/agents/pcg-level-design-illuminator.md). Ratio = enemy_power / (party_power × difficulty_multiplier).
+
+## ⚠️ Lettura del verdetto
+
+Il modello è una **baseline first-pass**: usa stat aggregate (hp + mod + dc + traits) ignorando action economy, pressure tier, hazard tiles, AOE/bleeding. Il verdetto **non sostituisce** il playtest empirico — lo affianca come strumento di sanity-check.
+
+### Calibrazione empirica (CLAUDE.md sprint context)
+
+| Scenario                         | Win rate empirico | Verdetto modello |  Δ  |
+| -------------------------------- | ----------------: | ---------------- | :-: |
+| `enc_tutorial_01`                |              ~80% | balanced         | ✅  |
+| `enc_tutorial_02`                |              ~80% | too_hard         | ⚠️  |
+| `enc_tutorial_03`                |              ~50% | too_easy         | ⚠️  |
+| `enc_tutorial_04`                |              ~30% | too_easy         | ⚠️  |
+| `enc_tutorial_05`                |              ~20% | too_easy         | ⚠️  |
+| `enc_tutorial_06_hardcore` iter2 |              ~85% | too_easy         | ⚠️  |
+
+Il modello **sotto-predice difficulty** per scenari avanzati (tutorial 03+ + hardcore). Cause probabili:
+
+1. **Action economy** ignorata: 1 BOSS hp 40 vs 8 player → focus-fire boss collassa rapidamente in modello, non in pratica (perde turni a manovrare).
+2. **Pressure tier** (`sistema_pressure_start` 0-95) non modellata: AI a tier Apex emette 4 intent/turno = 4× damage output rispetto a tier Calm.
+3. **Hazard tiles + bleeding + AOE traits** sommati come solo +2 power per trait flat (placeholder).
+4. **Multipliers difficulty** lineari (0.6→2.2): forse troppo aggressivi al rialzo per livelli alti.
+
+### Recommended tuning (post-playtest)
+
+- **Calibra `DIFFICULTY_MULTIPLIER`** in [`tools/py/encounter_xp_budget.py`](../../tools/py/encounter_xp_budget.py) usando le win rate empiriche come ground truth.
+- **Pesa traits** per categoria (AOE +5, bleeding +3, focus +2, passive +1) invece di flat +2.
+- **Aggiungi `pressure_modifier`** = 1 + sistema_pressure_start / 100, moltiplica enemy_power.
+- **Modella action economy**: enemy_power \*= (1 + 0.1 × max(0, party_size - enemy_count)) per catturare la "concentrazione".
+
+Queste tuning richiedono ~3-5h di iterazione con dati di playtest reali (vedi `docs/playtest/*` per win rate per scenario).
+
+## Verdict per scenario
+
+| Scenario                            | Diff | Party | Enemy | Expected |     Ratio | Verdict                    |
+| ----------------------------------- | ---: | ----: | ----: | -------: | --------: | -------------------------- |
+| `enc_tutorial_01`                   |    1 |  66.0 |  40.0 |     39.6 |  **1.01** | ✅ balanced                |
+| `enc_tutorial_02`                   |    2 |  66.0 |  73.0 |     56.1 | **1.301** | 🔴 too_hard (enemy power)  |
+| `enc_tutorial_03`                   |    3 |  66.0 |  34.0 |     66.0 | **0.515** | 🟢 too_easy (player power) |
+| `enc_tutorial_04`                   |    4 |  66.0 |  60.0 |     92.4 | **0.649** | 🟢 too_easy (player power) |
+| `enc_tutorial_05`                   |    5 |  86.0 |  39.0 |    146.2 | **0.267** | 🟢 too_easy (player power) |
+| `enc_tutorial_06_hardcore`          |    6 | 282.0 | 190.0 |    620.4 | **0.306** | 🟢 too_easy (player power) |
+| `enc_tutorial_06_hardcore_quartet`  |    6 | 132.0 | 172.0 |    290.4 | **0.592** | 🟢 too_easy (player power) |
+| `enc_tutorial_07_hardcore_pod_rush` |    7 | 136.0 | 100.0 |    353.6 | **0.283** | 🟢 too_easy (player power) |
+
+## Summary
+
+- **balanced**: 1/8 (12.5%)
+- **too_hard**: 1/8 (12.5%)
+- **too_easy**: 6/8 (75.0%)
+
+## Difficulty multiplier table
+
+| Difficulty | Multiplier |
+| ---------: | ---------: |
+|          1 |        0.6 |
+|          2 |       0.85 |
+|          3 |        1.0 |
+|          4 |        1.4 |
+|          5 |        1.7 |
+|          6 |        2.2 |
+|          7 |        2.6 |
+|          8 |        3.0 |
+
+## Per-unit power breakdown
+
+### `enc_tutorial_01`
+
+| Unit        | Side    | Power |   hp |  mod |  dc | traits |
+| ----------- | ------- | ----: | ---: | ---: | --: | -----: |
+| `p_scout`   | player  |  33.0 | 10.0 | 15.0 | 6.0 |    2.0 |
+| `p_tank`    | player  |  33.0 | 12.0 | 10.0 | 9.0 |    2.0 |
+| `e_nomad_1` | sistema |  19.0 |  3.0 | 10.0 | 6.0 |    0.0 |
+| `e_nomad_2` | sistema |  21.0 |  5.0 | 10.0 | 6.0 |    0.0 |
+
+### `enc_tutorial_02`
+
+| Unit        | Side    | Power |   hp |  mod |  dc | traits |
+| ----------- | ------- | ----: | ---: | ---: | --: | -----: |
+| `p_scout`   | player  |  33.0 | 10.0 | 15.0 | 6.0 |    2.0 |
+| `p_tank`    | player  |  33.0 | 12.0 | 10.0 | 9.0 |    2.0 |
+| `e_nomad_1` | sistema |  24.0 |  3.0 | 15.0 | 6.0 |    0.0 |
+| `e_nomad_2` | sistema |  24.0 |  3.0 | 15.0 | 6.0 |    0.0 |
+| `e_hunter`  | sistema |  25.0 |  6.0 | 10.0 | 9.0 |    0.0 |
+
+### `enc_tutorial_03`
+
+| Unit            | Side    | Power |   hp |  mod |  dc | traits |
+| --------------- | ------- | ----: | ---: | ---: | --: | -----: |
+| `p_scout`       | player  |  33.0 | 10.0 | 15.0 | 6.0 |    2.0 |
+| `p_tank`        | player  |  33.0 | 12.0 | 10.0 | 9.0 |    2.0 |
+| `e_guardiano_1` | sistema |  17.0 |  4.0 | 10.0 | 3.0 |    0.0 |
+| `e_guardiano_2` | sistema |  17.0 |  4.0 | 10.0 | 3.0 |    0.0 |
+
+### `enc_tutorial_04`
+
+| Unit           | Side    | Power |   hp |  mod |  dc | traits |
+| -------------- | ------- | ----: | ---: | ---: | --: | -----: |
+| `p_scout`      | player  |  33.0 | 10.0 | 15.0 | 6.0 |    2.0 |
+| `p_tank`       | player  |  33.0 | 12.0 | 10.0 | 9.0 |    2.0 |
+| `e_lanciere`   | sistema |  28.0 |  5.0 | 15.0 | 6.0 |    2.0 |
+| `e_corriere_1` | sistema |  16.0 |  3.0 | 10.0 | 3.0 |    0.0 |
+| `e_corriere_2` | sistema |  16.0 |  3.0 | 10.0 | 3.0 |    0.0 |
+
+### `enc_tutorial_05`
+
+| Unit      | Side    | Power |   hp |  mod |   dc | traits |
+| --------- | ------- | ----: | ---: | ---: | ---: | -----: |
+| `p_scout` | player  |  43.0 | 12.0 | 20.0 |  9.0 |    2.0 |
+| `p_tank`  | player  |  43.0 | 14.0 | 15.0 | 12.0 |    2.0 |
+| `e_apex`  | sistema |  39.0 | 11.0 | 15.0 |  9.0 |    4.0 |
+
+### `enc_tutorial_06_hardcore`
+
+| Unit               | Side    | Power |   hp |  mod |   dc | traits |
+| ------------------ | ------- | ----: | ---: | ---: | ---: | -----: |
+| `p_scout_1`        | player  |  33.0 | 10.0 | 15.0 |  6.0 |    2.0 |
+| `p_scout_2`        | player  |  33.0 | 10.0 | 15.0 |  6.0 |    2.0 |
+| `p_scout_3`        | player  |  33.0 | 10.0 | 15.0 |  6.0 |    2.0 |
+| `p_scout_4`        | player  |  33.0 | 10.0 | 15.0 |  6.0 |    2.0 |
+| `p_tank_1`         | player  |  38.0 | 14.0 | 10.0 | 12.0 |    2.0 |
+| `p_tank_2`         | player  |  38.0 | 14.0 | 10.0 | 12.0 |    2.0 |
+| `p_support_1`      | player  |  37.0 | 11.0 | 15.0 |  9.0 |    2.0 |
+| `p_support_2`      | player  |  37.0 | 11.0 | 15.0 |  9.0 |    2.0 |
+| `e_apex_boss`      | sistema |  73.0 | 40.0 | 15.0 | 12.0 |    6.0 |
+| `e_elite_hunter_1` | sistema |  33.0 |  9.0 | 15.0 |  9.0 |    0.0 |
+| `e_elite_hunter_2` | sistema |  33.0 |  9.0 | 15.0 |  9.0 |    0.0 |
+| `e_minion_1`       | sistema |  17.0 |  4.0 | 10.0 |  3.0 |    0.0 |
+| `e_minion_2`       | sistema |  17.0 |  4.0 | 10.0 |  3.0 |    0.0 |
+| `e_minion_3`       | sistema |  17.0 |  4.0 | 10.0 |  3.0 |    0.0 |
+
+### `enc_tutorial_06_hardcore_quartet`
+
+| Unit               | Side    | Power |   hp |  mod |   dc | traits |
+| ------------------ | ------- | ----: | ---: | ---: | ---: | -----: |
+| `p_scout_1`        | player  |  33.0 | 10.0 | 15.0 |  6.0 |    2.0 |
+| `p_scout_2`        | player  |  33.0 | 10.0 | 15.0 |  6.0 |    2.0 |
+| `p_scout_3`        | player  |  33.0 | 10.0 | 15.0 |  6.0 |    2.0 |
+| `p_scout_4`        | player  |  33.0 | 10.0 | 15.0 |  6.0 |    2.0 |
+| `e_apex_boss`      | sistema |  55.0 | 22.0 | 15.0 | 12.0 |    6.0 |
+| `e_elite_hunter_1` | sistema |  33.0 |  9.0 | 15.0 |  9.0 |    0.0 |
+| `e_elite_hunter_2` | sistema |  33.0 |  9.0 | 15.0 |  9.0 |    0.0 |
+| `e_minion_1`       | sistema |  17.0 |  4.0 | 10.0 |  3.0 |    0.0 |
+| `e_minion_2`       | sistema |  17.0 |  4.0 | 10.0 |  3.0 |    0.0 |
+| `e_minion_3`       | sistema |  17.0 |  4.0 | 10.0 |  3.0 |    0.0 |
+
+### `enc_tutorial_07_hardcore_pod_rush`
+
+| Unit               | Side    | Power |   hp |  mod |   dc | traits |
+| ------------------ | ------- | ----: | ---: | ---: | ---: | -----: |
+| `p_scout_1`        | player  |  33.0 | 10.0 | 15.0 |  6.0 |    2.0 |
+| `p_scout_2`        | player  |  33.0 | 10.0 | 15.0 |  6.0 |    2.0 |
+| `p_tank_1`         | player  |  38.0 | 14.0 | 10.0 | 12.0 |    2.0 |
+| `p_support_1`      | player  |  32.0 | 11.0 | 10.0 |  9.0 |    2.0 |
+| `e_patrol_leader`  | sistema |  41.0 | 15.0 | 15.0 |  9.0 |    2.0 |
+| `e_patrol_scout_1` | sistema |  21.0 |  6.0 | 10.0 |  3.0 |    2.0 |
+| `e_patrol_scout_2` | sistema |  19.0 |  6.0 | 10.0 |  3.0 |    0.0 |
+| `e_patrol_scout_3` | sistema |  19.0 |  6.0 | 10.0 |  3.0 |    0.0 |
+
+## Notes & limits
+
+- Action economy (1 BOSS vs N minion) **non** modellata: 1 boss da 50 power
+  e 5 minion da 10 power dichiarano lo stesso enemy_power totale, ma giocano
+  diversamente (focus-fire vs spread). Calibrazione finale resta empirica.
+- DC contribuisce solo per la parte > 10 (proxy difensivo, non valore assoluto).
+- Traits = +2 power flat per trait (placeholder; trait scaling profondo è in
+  `data/balance/trait_mechanics.yaml`).
+- Multipliers tunable in `tools/py/encounter_xp_budget.py::DIFFICULTY_MULTIPLIER`.
+
+## Sources
+
+- [Pathfinder Encounter Building](https://aonprd.com/Rules.aspx?ID=252)
+- Agent: `.claude/agents/pcg-level-design-illuminator.md`

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -2191,6 +2191,19 @@
       "track": "new"
     },
     {
+      "path": "docs/balance/2026-04-25-encounter-xp-audit.md",
+      "title": "Encounter XP Budget Audit (2026-04-25)",
+      "doc_status": "active",
+      "doc_owner": "claude-code",
+      "workstream": "dataset-pack",
+      "last_verified": "2026-04-25",
+      "source_of_truth": false,
+      "language": "it",
+      "review_cycle_days": 30,
+      "primary": false,
+      "track": "new"
+    },
+    {
       "path": "docs/balance/tutorial-tuning-iter-2026-04-17.md",
       "title": "Tutorial Iter Tuning Pass — 2026-04-17",
       "doc_status": "active",

--- a/reports/balance/scenarios_dump.json
+++ b/reports/balance/scenarios_dump.json
@@ -1,0 +1,1327 @@
+[
+  {
+    "id": "enc_tutorial_01",
+    "name": "Primi Passi nella Savana",
+    "biome_id": "savana",
+    "encounter_class": "tutorial",
+    "difficulty_rating": 1,
+    "estimated_turns": 6,
+    "grid_size": 6,
+    "objective": "elimination",
+    "objective_text": "Sconfiggi tutte le unità nemiche.",
+    "briefing_pre": "Due predoni nomadi hanno preso posizione nella savana. Avvicinati con cautela e eliminali.",
+    "briefing_post": "Le sentinelle sono cadute. La via è libera — per ora.",
+    "sistema_pressure_start": 0,
+    "units": [
+      {
+        "id": "p_scout",
+        "species": "dune_stalker",
+        "job": "skirmisher",
+        "traits": [
+          "zampe_a_molla"
+        ],
+        "hp": 10,
+        "ap": 3,
+        "mod": 3,
+        "dc": 12,
+        "guardia": 1,
+        "position": {
+          "x": 1,
+          "y": 2
+        },
+        "controlled_by": "player",
+        "facing": "E"
+      },
+      {
+        "id": "p_tank",
+        "species": "dune_stalker",
+        "job": "vanguard",
+        "traits": [
+          "pelle_elastomera"
+        ],
+        "hp": 12,
+        "ap": 3,
+        "mod": 2,
+        "dc": 13,
+        "guardia": 1,
+        "position": {
+          "x": 1,
+          "y": 3
+        },
+        "controlled_by": "player",
+        "facing": "E"
+      },
+      {
+        "id": "e_nomad_1",
+        "species": "predoni_nomadi",
+        "job": "skirmisher",
+        "traits": [],
+        "hp": 3,
+        "ap": 2,
+        "mod": 2,
+        "dc": 12,
+        "guardia": 0,
+        "position": {
+          "x": 3,
+          "y": 2
+        },
+        "controlled_by": "sistema",
+        "facing": "W"
+      },
+      {
+        "id": "e_nomad_2",
+        "species": "predoni_nomadi",
+        "job": "skirmisher",
+        "traits": [],
+        "hp": 5,
+        "ap": 2,
+        "mod": 2,
+        "dc": 12,
+        "guardia": 0,
+        "position": {
+          "x": 3,
+          "y": 4
+        },
+        "controlled_by": "sistema",
+        "facing": "W"
+      }
+    ]
+  },
+  {
+    "id": "enc_tutorial_02",
+    "name": "Pattuglia Asimmetrica",
+    "biome_id": "savana",
+    "encounter_class": "tutorial",
+    "difficulty_rating": 2,
+    "estimated_turns": 8,
+    "grid_size": 6,
+    "objective": "elimination",
+    "objective_text": "Sconfiggi tutta la pattuglia: due predoni e un cacciatore corazzato.",
+    "briefing_pre": "La pattuglia nomade questa volta include un cacciatore con corazza pesante. Coordina scout e tank: il danno asimmetrico premia chi sceglie il bersaglio giusto.",
+    "briefing_post": "La pattuglia è dissolta. Il cacciatore non e' bastato a tenerli insieme.",
+    "sistema_pressure_start": 25,
+    "units": [
+      {
+        "id": "p_scout",
+        "species": "dune_stalker",
+        "job": "skirmisher",
+        "traits": [
+          "zampe_a_molla"
+        ],
+        "hp": 10,
+        "ap": 2,
+        "mod": 3,
+        "dc": 12,
+        "guardia": 1,
+        "position": {
+          "x": 1,
+          "y": 2
+        },
+        "controlled_by": "player",
+        "facing": "E"
+      },
+      {
+        "id": "p_tank",
+        "species": "dune_stalker",
+        "job": "vanguard",
+        "traits": [
+          "pelle_elastomera"
+        ],
+        "hp": 12,
+        "ap": 2,
+        "mod": 2,
+        "dc": 13,
+        "guardia": 1,
+        "position": {
+          "x": 1,
+          "y": 3
+        },
+        "controlled_by": "player",
+        "facing": "E"
+      },
+      {
+        "id": "e_nomad_1",
+        "species": "predoni_nomadi",
+        "job": "skirmisher",
+        "traits": [],
+        "hp": 3,
+        "ap": 2,
+        "mod": 3,
+        "dc": 12,
+        "guardia": 0,
+        "position": {
+          "x": 4,
+          "y": 1
+        },
+        "controlled_by": "sistema",
+        "facing": "W"
+      },
+      {
+        "id": "e_nomad_2",
+        "species": "predoni_nomadi",
+        "job": "skirmisher",
+        "traits": [],
+        "hp": 3,
+        "ap": 2,
+        "mod": 3,
+        "dc": 12,
+        "guardia": 0,
+        "position": {
+          "x": 4,
+          "y": 4
+        },
+        "controlled_by": "sistema",
+        "facing": "W"
+      },
+      {
+        "id": "e_hunter",
+        "species": "cacciatore_corazzato",
+        "job": "vanguard",
+        "traits": [],
+        "hp": 6,
+        "ap": 2,
+        "mod": 2,
+        "dc": 13,
+        "guardia": 0,
+        "position": {
+          "x": 3,
+          "y": 3
+        },
+        "controlled_by": "sistema",
+        "ai_profile": "aggressive",
+        "facing": "W"
+      }
+    ]
+  },
+  {
+    "id": "enc_tutorial_03",
+    "name": "Pozzo della Caverna Risonante",
+    "biome_id": "caverna_risonante",
+    "encounter_class": "tutorial_advanced",
+    "difficulty_rating": 3,
+    "estimated_turns": 10,
+    "grid_size": 6,
+    "objective": "elimination",
+    "objective_text": "Elimina i guardiani sotterranei. Attento alle fumarole tossiche: tile (2,2) e (3,3) infliggono danno a fine turno se occupate.",
+    "briefing_pre": "Una caverna risonante con due fumarole attive. Le creature locali resistono al gas; voi no. Posizionate con cura e usate combo per finire in fretta.",
+    "briefing_post": "I guardiani sono caduti. Il riverbero della caverna si placa.",
+    "hazard_tiles": [
+      {
+        "x": 2,
+        "y": 2,
+        "damage": 1,
+        "type": "fumarole_tossica"
+      },
+      {
+        "x": 3,
+        "y": 3,
+        "damage": 1,
+        "type": "fumarole_tossica"
+      }
+    ],
+    "sistema_pressure_start": 50,
+    "units": [
+      {
+        "id": "p_scout",
+        "species": "dune_stalker",
+        "job": "skirmisher",
+        "traits": [
+          "zampe_a_molla"
+        ],
+        "hp": 10,
+        "ap": 2,
+        "mod": 3,
+        "dc": 12,
+        "guardia": 1,
+        "position": {
+          "x": 1,
+          "y": 1
+        },
+        "controlled_by": "player",
+        "facing": "E"
+      },
+      {
+        "id": "p_tank",
+        "species": "dune_stalker",
+        "job": "vanguard",
+        "traits": [
+          "pelle_elastomera"
+        ],
+        "hp": 12,
+        "ap": 2,
+        "mod": 2,
+        "dc": 13,
+        "guardia": 1,
+        "position": {
+          "x": 1,
+          "y": 4
+        },
+        "controlled_by": "player",
+        "facing": "E"
+      },
+      {
+        "id": "e_guardiano_1",
+        "species": "guardiano_caverna",
+        "job": "vanguard",
+        "traits": [],
+        "hp": 4,
+        "ap": 2,
+        "mod": 2,
+        "dc": 11,
+        "guardia": 0,
+        "attack_range": 2,
+        "position": {
+          "x": 2,
+          "y": 2
+        },
+        "controlled_by": "sistema",
+        "ai_profile": "aggressive",
+        "facing": "W"
+      },
+      {
+        "id": "e_guardiano_2",
+        "species": "guardiano_caverna",
+        "job": "vanguard",
+        "traits": [],
+        "hp": 4,
+        "ap": 2,
+        "mod": 2,
+        "dc": 11,
+        "guardia": 0,
+        "attack_range": 2,
+        "position": {
+          "x": 3,
+          "y": 3
+        },
+        "controlled_by": "sistema",
+        "ai_profile": "aggressive",
+        "facing": "N"
+      }
+    ]
+  },
+  {
+    "id": "enc_tutorial_04",
+    "name": "Pozza Acida del Bosco",
+    "biome_id": "foresta_acida",
+    "encounter_class": "tutorial_advanced",
+    "difficulty_rating": 4,
+    "estimated_turns": 12,
+    "grid_size": 6,
+    "objective": "elimination",
+    "objective_text": "Sconfiggi i 3 guardiani della pozza. Attento al lanciere: il suo morso causa emorragia.",
+    "briefing_pre": "La pozza acida nasconde 3 guardiani: 2 corrieri rapidi e un lanciere con denti seghettati. Il bleeding accumula danno turno per turno: prioritizza il lanciere o tieni HP alto.",
+    "briefing_post": "La pozza si calma. I corpi dei guardiani si dissolvono nel liquido.",
+    "hazard_tiles": [
+      {
+        "x": 2,
+        "y": 1,
+        "damage": 1,
+        "type": "pozza_acida"
+      },
+      {
+        "x": 3,
+        "y": 4,
+        "damage": 1,
+        "type": "pozza_acida"
+      },
+      {
+        "x": 2,
+        "y": 3,
+        "damage": 1,
+        "type": "pozza_acida"
+      }
+    ],
+    "sistema_pressure_start": 75,
+    "units": [
+      {
+        "id": "p_scout",
+        "species": "dune_stalker",
+        "job": "skirmisher",
+        "traits": [
+          "zampe_a_molla"
+        ],
+        "hp": 10,
+        "ap": 2,
+        "mod": 3,
+        "dc": 12,
+        "guardia": 1,
+        "position": {
+          "x": 1,
+          "y": 1
+        },
+        "controlled_by": "player",
+        "facing": "E"
+      },
+      {
+        "id": "p_tank",
+        "species": "dune_stalker",
+        "job": "vanguard",
+        "traits": [
+          "pelle_elastomera"
+        ],
+        "hp": 12,
+        "ap": 2,
+        "mod": 2,
+        "dc": 13,
+        "guardia": 1,
+        "position": {
+          "x": 1,
+          "y": 4
+        },
+        "controlled_by": "player",
+        "facing": "E"
+      },
+      {
+        "id": "e_lanciere",
+        "species": "guardiano_pozza",
+        "job": "skirmisher",
+        "traits": [
+          "denti_seghettati"
+        ],
+        "hp": 5,
+        "ap": 2,
+        "mod": 3,
+        "dc": 12,
+        "guardia": 0,
+        "attack_range": 2,
+        "position": {
+          "x": 3,
+          "y": 2
+        },
+        "controlled_by": "sistema",
+        "ai_profile": "aggressive",
+        "facing": "S"
+      },
+      {
+        "id": "e_corriere_1",
+        "species": "guardiano_pozza",
+        "job": "skirmisher",
+        "traits": [],
+        "hp": 3,
+        "ap": 3,
+        "mod": 2,
+        "dc": 11,
+        "guardia": 0,
+        "attack_range": 2,
+        "position": {
+          "x": 4,
+          "y": 0
+        },
+        "controlled_by": "sistema",
+        "facing": "W"
+      },
+      {
+        "id": "e_corriere_2",
+        "species": "guardiano_pozza",
+        "job": "skirmisher",
+        "traits": [],
+        "hp": 3,
+        "ap": 3,
+        "mod": 2,
+        "dc": 11,
+        "guardia": 0,
+        "attack_range": 2,
+        "position": {
+          "x": 4,
+          "y": 5
+        },
+        "controlled_by": "sistema",
+        "facing": "W"
+      }
+    ]
+  },
+  {
+    "id": "enc_tutorial_05",
+    "name": "Solo contro l'Apex",
+    "biome_id": "rovine_planari",
+    "encounter_class": "boss",
+    "difficulty_rating": 5,
+    "estimated_turns": 14,
+    "grid_size": 6,
+    "objective": "elimination",
+    "objective_text": "Sconfiggi l'apex predatore. Singolo nemico con HP altissimo, attacchi multipli e bonus su critico.",
+    "briefing_pre": "Le rovine planari celano un Apex: 1v2 a vostro favore, ma il suo HP e i bonus crit possono ribaltare ogni round. Cooperate o cadrete uno alla volta.",
+    "briefing_post": "L'Apex si dissolve nelle rovine. Avete fatto la storia.",
+    "hazard_tiles": [],
+    "sistema_pressure_start": 95,
+    "units": [
+      {
+        "id": "p_scout",
+        "species": "dune_stalker",
+        "job": "skirmisher",
+        "traits": [
+          "zampe_a_molla"
+        ],
+        "hp": 12,
+        "ap": 2,
+        "mod": 4,
+        "dc": 13,
+        "guardia": 1,
+        "position": {
+          "x": 0,
+          "y": 2
+        },
+        "controlled_by": "player",
+        "facing": "E"
+      },
+      {
+        "id": "p_tank",
+        "species": "dune_stalker",
+        "job": "vanguard",
+        "traits": [
+          "pelle_elastomera"
+        ],
+        "hp": 14,
+        "ap": 2,
+        "mod": 3,
+        "dc": 14,
+        "guardia": 2,
+        "position": {
+          "x": 0,
+          "y": 3
+        },
+        "controlled_by": "player",
+        "facing": "E"
+      },
+      {
+        "id": "e_apex",
+        "species": "apex_predatore",
+        "job": "vanguard",
+        "traits": [
+          "martello_osseo",
+          "ferocia"
+        ],
+        "hp": 11,
+        "ap": 3,
+        "mod": 3,
+        "dc": 13,
+        "guardia": 1,
+        "attack_range": 2,
+        "position": {
+          "x": 5,
+          "y": 2
+        },
+        "controlled_by": "sistema",
+        "ai_profile": "aggressive",
+        "facing": "W"
+      }
+    ]
+  },
+  {
+    "id": "enc_tutorial_06_hardcore",
+    "name": "Cattedrale dell'Apex",
+    "biome_id": "rovine_planari",
+    "encounter_class": "hardcore",
+    "difficulty_rating": 6,
+    "estimated_turns": 16,
+    "grid_size": 10,
+    "objective": "elimination",
+    "objective_text": "Sconfiggi il BOSS Apex (hp 40, AOE psichica su crit) e i suoi 5 guardiani. Party 8 unità vs 6 nemici: il BOSS singolo regge focus-fire 8-way, attenti alle pozze instabili (2 dmg/turn).",
+    "briefing_pre": "Le rovine risuonano del passo pesante dell'Apex. L'aria vibra di pressione psichica — ogni colpo critico del BOSS sprigiona un'onda che ferisce a distanza. Due elite cacciatori difendono i fianchi, tre predoni bloccano i corridoi. Le pozze di rovine instabili (2 dmg/turn) sono trappole mortali. Party al completo (8 schierati): focus-fire totale sul BOSS, ma cura la posizione.",
+    "briefing_post": "L'Apex è caduto. La cattedrale si quieta. Avete dimostrato che 8 mani battono una mandibola.",
+    "hazard_tiles": [
+      {
+        "x": 4,
+        "y": 4,
+        "damage": 2,
+        "type": "rovine_instabili"
+      },
+      {
+        "x": 5,
+        "y": 5,
+        "damage": 2,
+        "type": "rovine_instabili"
+      },
+      {
+        "x": 3,
+        "y": 6,
+        "damage": 2,
+        "type": "rovine_instabili"
+      }
+    ],
+    "sistema_pressure_start": 85,
+    "recommended_modulation": "full",
+    "mission_timer": {
+      "enabled": true,
+      "turn_limit": 15,
+      "soft_warning_at": 3,
+      "on_expire": "escalate_pressure",
+      "on_expire_payload": {
+        "pressure_delta": 30,
+        "extra_spawns": 2
+      }
+    },
+    "units": [
+      {
+        "id": "p_scout_1",
+        "species": "dune_stalker",
+        "job": "skirmisher",
+        "traits": [
+          "zampe_a_molla"
+        ],
+        "hp": 10,
+        "ap": 2,
+        "mod": 3,
+        "dc": 12,
+        "guardia": 1,
+        "position": {
+          "x": 0,
+          "y": 2
+        },
+        "controlled_by": "player",
+        "facing": "E",
+        "elevation": 0
+      },
+      {
+        "id": "p_scout_2",
+        "species": "dune_stalker",
+        "job": "skirmisher",
+        "traits": [
+          "zampe_a_molla"
+        ],
+        "hp": 10,
+        "ap": 2,
+        "mod": 3,
+        "dc": 12,
+        "guardia": 1,
+        "position": {
+          "x": 0,
+          "y": 4
+        },
+        "controlled_by": "player",
+        "facing": "E",
+        "elevation": 0
+      },
+      {
+        "id": "p_scout_3",
+        "species": "dune_stalker",
+        "job": "skirmisher",
+        "traits": [
+          "zampe_a_molla"
+        ],
+        "hp": 10,
+        "ap": 2,
+        "mod": 3,
+        "dc": 12,
+        "guardia": 1,
+        "position": {
+          "x": 0,
+          "y": 6
+        },
+        "controlled_by": "player",
+        "facing": "E",
+        "elevation": 0
+      },
+      {
+        "id": "p_scout_4",
+        "species": "dune_stalker",
+        "job": "skirmisher",
+        "traits": [
+          "zampe_a_molla"
+        ],
+        "hp": 10,
+        "ap": 2,
+        "mod": 3,
+        "dc": 12,
+        "guardia": 1,
+        "position": {
+          "x": 0,
+          "y": 8
+        },
+        "controlled_by": "player",
+        "facing": "E",
+        "elevation": 0
+      },
+      {
+        "id": "p_tank_1",
+        "species": "umbroid_lurker",
+        "job": "vanguard",
+        "traits": [
+          "pelle_elastomera"
+        ],
+        "hp": 14,
+        "ap": 2,
+        "mod": 2,
+        "dc": 14,
+        "guardia": 2,
+        "position": {
+          "x": 1,
+          "y": 3
+        },
+        "controlled_by": "player",
+        "facing": "E",
+        "elevation": 0
+      },
+      {
+        "id": "p_tank_2",
+        "species": "umbroid_lurker",
+        "job": "vanguard",
+        "traits": [
+          "pelle_elastomera"
+        ],
+        "hp": 14,
+        "ap": 2,
+        "mod": 2,
+        "dc": 14,
+        "guardia": 2,
+        "position": {
+          "x": 1,
+          "y": 7
+        },
+        "controlled_by": "player",
+        "facing": "E",
+        "elevation": 0
+      },
+      {
+        "id": "p_support_1",
+        "species": "dune_stalker",
+        "job": "skirmisher",
+        "traits": [
+          "zampe_a_molla"
+        ],
+        "hp": 11,
+        "ap": 2,
+        "mod": 3,
+        "dc": 13,
+        "guardia": 1,
+        "position": {
+          "x": 1,
+          "y": 1
+        },
+        "controlled_by": "player",
+        "facing": "E",
+        "elevation": 0
+      },
+      {
+        "id": "p_support_2",
+        "species": "dune_stalker",
+        "job": "skirmisher",
+        "traits": [
+          "zampe_a_molla"
+        ],
+        "hp": 11,
+        "ap": 2,
+        "mod": 3,
+        "dc": 13,
+        "guardia": 1,
+        "position": {
+          "x": 1,
+          "y": 5
+        },
+        "controlled_by": "player",
+        "facing": "E",
+        "elevation": 0
+      },
+      {
+        "id": "e_apex_boss",
+        "species": "apex_predatore",
+        "job": "vanguard",
+        "traits": [
+          "martello_osseo",
+          "ferocia",
+          "ondata_psichica"
+        ],
+        "hp": 40,
+        "ap": 3,
+        "mod": 3,
+        "dc": 14,
+        "guardia": 4,
+        "attack_range": 3,
+        "position": {
+          "x": 8,
+          "y": 5
+        },
+        "controlled_by": "sistema",
+        "ai_profile": "aggressive",
+        "facing": "W",
+        "elevation": 1
+      },
+      {
+        "id": "e_elite_hunter_1",
+        "species": "cacciatore_corazzato",
+        "job": "vanguard",
+        "traits": [],
+        "hp": 9,
+        "ap": 2,
+        "mod": 3,
+        "dc": 13,
+        "guardia": 1,
+        "attack_range": 2,
+        "position": {
+          "x": 7,
+          "y": 2
+        },
+        "controlled_by": "sistema",
+        "ai_profile": "aggressive",
+        "facing": "W",
+        "elevation": 0
+      },
+      {
+        "id": "e_elite_hunter_2",
+        "species": "cacciatore_corazzato",
+        "job": "vanguard",
+        "traits": [],
+        "hp": 9,
+        "ap": 2,
+        "mod": 3,
+        "dc": 13,
+        "guardia": 1,
+        "attack_range": 2,
+        "position": {
+          "x": 7,
+          "y": 8
+        },
+        "controlled_by": "sistema",
+        "ai_profile": "aggressive",
+        "facing": "W",
+        "elevation": 0
+      },
+      {
+        "id": "e_minion_1",
+        "species": "predoni_nomadi",
+        "job": "skirmisher",
+        "traits": [],
+        "hp": 4,
+        "ap": 2,
+        "mod": 2,
+        "dc": 11,
+        "guardia": 0,
+        "attack_range": 1,
+        "position": {
+          "x": 6,
+          "y": 4
+        },
+        "controlled_by": "sistema",
+        "facing": "W"
+      },
+      {
+        "id": "e_minion_2",
+        "species": "predoni_nomadi",
+        "job": "skirmisher",
+        "traits": [],
+        "hp": 4,
+        "ap": 2,
+        "mod": 2,
+        "dc": 11,
+        "guardia": 0,
+        "attack_range": 1,
+        "position": {
+          "x": 6,
+          "y": 6
+        },
+        "controlled_by": "sistema",
+        "facing": "W"
+      },
+      {
+        "id": "e_minion_3",
+        "species": "predoni_nomadi",
+        "job": "skirmisher",
+        "traits": [],
+        "hp": 4,
+        "ap": 2,
+        "mod": 2,
+        "dc": 11,
+        "guardia": 0,
+        "attack_range": 1,
+        "position": {
+          "x": 9,
+          "y": 5
+        },
+        "controlled_by": "sistema",
+        "facing": "W"
+      }
+    ]
+  },
+  {
+    "id": "enc_tutorial_06_hardcore_quartet",
+    "name": "Cattedrale dell'Apex (Quartet 4p)",
+    "biome_id": "rovine_planari",
+    "encounter_class": "hardcore",
+    "difficulty_rating": 6,
+    "estimated_turns": 16,
+    "grid_size": 10,
+    "objective": "elimination",
+    "objective_text": "Iter 5 variant: 4 PG vs BOSS Apex + 5 guardiani. Quartet modulation bilancia focus-fire (target win_rate 15-25%).",
+    "briefing_pre": "Le rovine risuonano del passo pesante dell'Apex. L'aria vibra di pressione psichica — ogni colpo critico del BOSS sprigiona un'onda che ferisce a distanza. Due elite cacciatori difendono i fianchi, tre predoni bloccano i corridoi. Le pozze di rovine instabili (2 dmg/turn) sono trappole mortali. Party al completo (8 schierati): focus-fire totale sul BOSS, ma cura la posizione.",
+    "briefing_post": "L'Apex è caduto. La cattedrale si quieta. Avete dimostrato che 8 mani battono una mandibola.",
+    "hazard_tiles": [
+      {
+        "x": 4,
+        "y": 4,
+        "damage": 2,
+        "type": "rovine_instabili"
+      },
+      {
+        "x": 5,
+        "y": 5,
+        "damage": 2,
+        "type": "rovine_instabili"
+      },
+      {
+        "x": 3,
+        "y": 6,
+        "damage": 2,
+        "type": "rovine_instabili"
+      }
+    ],
+    "sistema_pressure_start": 85,
+    "recommended_modulation": "quartet",
+    "mission_timer": {
+      "enabled": true,
+      "turn_limit": 15,
+      "soft_warning_at": 3,
+      "on_expire": "escalate_pressure",
+      "on_expire_payload": {
+        "pressure_delta": 30,
+        "extra_spawns": 2
+      }
+    },
+    "units": [
+      {
+        "id": "p_scout_1",
+        "species": "dune_stalker",
+        "job": "skirmisher",
+        "traits": [
+          "zampe_a_molla"
+        ],
+        "hp": 10,
+        "ap": 2,
+        "mod": 3,
+        "dc": 12,
+        "guardia": 1,
+        "position": {
+          "x": 0,
+          "y": 2
+        },
+        "controlled_by": "player",
+        "facing": "E",
+        "elevation": 0
+      },
+      {
+        "id": "p_scout_2",
+        "species": "dune_stalker",
+        "job": "skirmisher",
+        "traits": [
+          "zampe_a_molla"
+        ],
+        "hp": 10,
+        "ap": 2,
+        "mod": 3,
+        "dc": 12,
+        "guardia": 1,
+        "position": {
+          "x": 0,
+          "y": 4
+        },
+        "controlled_by": "player",
+        "facing": "E",
+        "elevation": 0
+      },
+      {
+        "id": "p_scout_3",
+        "species": "dune_stalker",
+        "job": "skirmisher",
+        "traits": [
+          "zampe_a_molla"
+        ],
+        "hp": 10,
+        "ap": 2,
+        "mod": 3,
+        "dc": 12,
+        "guardia": 1,
+        "position": {
+          "x": 0,
+          "y": 6
+        },
+        "controlled_by": "player",
+        "facing": "E",
+        "elevation": 0
+      },
+      {
+        "id": "p_scout_4",
+        "species": "dune_stalker",
+        "job": "skirmisher",
+        "traits": [
+          "zampe_a_molla"
+        ],
+        "hp": 10,
+        "ap": 2,
+        "mod": 3,
+        "dc": 12,
+        "guardia": 1,
+        "position": {
+          "x": 0,
+          "y": 8
+        },
+        "controlled_by": "player",
+        "facing": "E",
+        "elevation": 0
+      },
+      {
+        "id": "e_apex_boss",
+        "species": "apex_predatore",
+        "job": "vanguard",
+        "traits": [
+          "martello_osseo",
+          "ferocia",
+          "ondata_psichica"
+        ],
+        "hp": 22,
+        "ap": 3,
+        "mod": 3,
+        "dc": 14,
+        "guardia": 4,
+        "attack_range": 3,
+        "position": {
+          "x": 8,
+          "y": 5
+        },
+        "controlled_by": "sistema",
+        "ai_profile": "aggressive",
+        "facing": "W",
+        "elevation": 1
+      },
+      {
+        "id": "e_elite_hunter_1",
+        "species": "cacciatore_corazzato",
+        "job": "vanguard",
+        "traits": [],
+        "hp": 9,
+        "ap": 2,
+        "mod": 3,
+        "dc": 13,
+        "guardia": 1,
+        "attack_range": 2,
+        "position": {
+          "x": 7,
+          "y": 2
+        },
+        "controlled_by": "sistema",
+        "ai_profile": "aggressive",
+        "facing": "W",
+        "elevation": 0
+      },
+      {
+        "id": "e_elite_hunter_2",
+        "species": "cacciatore_corazzato",
+        "job": "vanguard",
+        "traits": [],
+        "hp": 9,
+        "ap": 2,
+        "mod": 3,
+        "dc": 13,
+        "guardia": 1,
+        "attack_range": 2,
+        "position": {
+          "x": 7,
+          "y": 8
+        },
+        "controlled_by": "sistema",
+        "ai_profile": "aggressive",
+        "facing": "W",
+        "elevation": 0
+      },
+      {
+        "id": "e_minion_1",
+        "species": "predoni_nomadi",
+        "job": "skirmisher",
+        "traits": [],
+        "hp": 4,
+        "ap": 2,
+        "mod": 2,
+        "dc": 11,
+        "guardia": 0,
+        "attack_range": 1,
+        "position": {
+          "x": 6,
+          "y": 4
+        },
+        "controlled_by": "sistema",
+        "facing": "W"
+      },
+      {
+        "id": "e_minion_2",
+        "species": "predoni_nomadi",
+        "job": "skirmisher",
+        "traits": [],
+        "hp": 4,
+        "ap": 2,
+        "mod": 2,
+        "dc": 11,
+        "guardia": 0,
+        "attack_range": 1,
+        "position": {
+          "x": 6,
+          "y": 6
+        },
+        "controlled_by": "sistema",
+        "facing": "W"
+      },
+      {
+        "id": "e_minion_3",
+        "species": "predoni_nomadi",
+        "job": "skirmisher",
+        "traits": [],
+        "hp": 4,
+        "ap": 2,
+        "mod": 2,
+        "dc": 11,
+        "guardia": 0,
+        "attack_range": 1,
+        "position": {
+          "x": 9,
+          "y": 5
+        },
+        "controlled_by": "sistema",
+        "facing": "W"
+      }
+    ]
+  },
+  {
+    "id": "enc_tutorial_07_hardcore_pod_rush",
+    "name": "Assalto Spietato",
+    "biome_id": "rovine_planari",
+    "encounter_class": "hardcore",
+    "difficulty_rating": 7,
+    "estimated_turns": 10,
+    "grid_size": 10,
+    "objective": "elimination",
+    "objective_text": "10 round per eliminare la pattuglia + 3 pod reinforcement. Timer expire → pressure escalate (Apex). No boss: damage distribuito, priority decisioni conteggia più di burst. Party 4 PG quartet.",
+    "briefing_pre": "La pattuglia è solo il vanguard. Sensori rilevano 3 pod lungo i corridoi laterali: si attivano progressivamente a tier Alert+ (2 unità × pod). 10 round per aprirsi un varco — se l'alarm resta acceso oltre il limite, l'Apex Sistema invia rinforzi ondata finale. Non turtle: muovi, apri, incidi.",
+    "briefing_post": "Il corridoio è libero. L'Apex ancora ignora la tua presenza.",
+    "hazard_tiles": [
+      {
+        "x": 3,
+        "y": 3,
+        "damage": 2,
+        "type": "rovine_instabili"
+      },
+      {
+        "x": 6,
+        "y": 6,
+        "damage": 2,
+        "type": "rovine_instabili"
+      }
+    ],
+    "sistema_pressure_start": 60,
+    "recommended_modulation": "quartet",
+    "mission_timer": {
+      "enabled": true,
+      "turn_limit": 10,
+      "soft_warning_at": 3,
+      "on_expire": "escalate_pressure",
+      "on_expire_payload": {
+        "pressure_delta": 30,
+        "extra_spawns": 3
+      }
+    },
+    "reinforcement_policy": {
+      "enabled": true,
+      "min_tier": "Calm",
+      "cooldown_rounds": 1,
+      "max_total_spawns": 6,
+      "min_distance_from_pg": 4
+    },
+    "reinforcement_pool": [
+      {
+        "unit_id": "cacciatore_corazzato",
+        "hp": 8,
+        "mod": 3,
+        "dc": 12,
+        "ai_profile": "aggressive",
+        "weight": 2,
+        "max_spawns": 3
+      },
+      {
+        "unit_id": "predone_agile",
+        "hp": 6,
+        "mod": 2,
+        "dc": 11,
+        "ai_profile": "aggressive",
+        "weight": 3,
+        "max_spawns": 3
+      }
+    ],
+    "reinforcement_entry_tiles": [
+      [
+        9,
+        0
+      ],
+      [
+        9,
+        9
+      ],
+      [
+        0,
+        0
+      ],
+      [
+        0,
+        9
+      ]
+    ],
+    "units": [
+      {
+        "id": "p_scout_1",
+        "species": "dune_stalker",
+        "job": "skirmisher",
+        "traits": [
+          "zampe_a_molla"
+        ],
+        "hp": 10,
+        "ap": 2,
+        "mod": 3,
+        "dc": 12,
+        "guardia": 1,
+        "position": {
+          "x": 1,
+          "y": 3
+        },
+        "controlled_by": "player",
+        "facing": "E",
+        "elevation": 0
+      },
+      {
+        "id": "p_scout_2",
+        "species": "echo_seer",
+        "job": "ranger",
+        "traits": [
+          "zampe_a_molla"
+        ],
+        "hp": 10,
+        "ap": 2,
+        "mod": 3,
+        "dc": 12,
+        "guardia": 1,
+        "position": {
+          "x": 1,
+          "y": 6
+        },
+        "controlled_by": "player",
+        "facing": "E",
+        "elevation": 0
+      },
+      {
+        "id": "p_tank_1",
+        "species": "umbroid_lurker",
+        "job": "vanguard",
+        "traits": [
+          "pelle_elastomera"
+        ],
+        "hp": 14,
+        "ap": 2,
+        "mod": 2,
+        "dc": 14,
+        "guardia": 2,
+        "position": {
+          "x": 2,
+          "y": 4
+        },
+        "controlled_by": "player",
+        "facing": "E",
+        "elevation": 0
+      },
+      {
+        "id": "p_support_1",
+        "species": "mud_sentinel",
+        "job": "warden",
+        "traits": [
+          "zampe_a_molla"
+        ],
+        "hp": 11,
+        "ap": 2,
+        "mod": 2,
+        "dc": 13,
+        "guardia": 1,
+        "position": {
+          "x": 2,
+          "y": 5
+        },
+        "controlled_by": "player",
+        "facing": "E",
+        "elevation": 0
+      },
+      {
+        "id": "e_patrol_leader",
+        "species": "cacciatore_corazzato",
+        "job": "vanguard",
+        "traits": [
+          "martello_osseo"
+        ],
+        "hp": 15,
+        "ap": 2,
+        "mod": 3,
+        "dc": 13,
+        "guardia": 2,
+        "attack_range": 2,
+        "position": {
+          "x": 6,
+          "y": 4
+        },
+        "controlled_by": "sistema",
+        "ai_profile": "aggressive",
+        "facing": "W",
+        "elevation": 1
+      },
+      {
+        "id": "e_patrol_scout_1",
+        "species": "predone_agile",
+        "job": "skirmisher",
+        "traits": [
+          "denti_seghettati"
+        ],
+        "hp": 6,
+        "ap": 2,
+        "mod": 2,
+        "dc": 11,
+        "guardia": 0,
+        "attack_range": 1,
+        "position": {
+          "x": 7,
+          "y": 2
+        },
+        "controlled_by": "sistema",
+        "ai_profile": "aggressive",
+        "facing": "W"
+      },
+      {
+        "id": "e_patrol_scout_2",
+        "species": "predone_agile",
+        "job": "skirmisher",
+        "traits": [],
+        "hp": 6,
+        "ap": 2,
+        "mod": 2,
+        "dc": 11,
+        "guardia": 0,
+        "attack_range": 1,
+        "position": {
+          "x": 7,
+          "y": 7
+        },
+        "controlled_by": "sistema",
+        "ai_profile": "aggressive",
+        "facing": "W"
+      },
+      {
+        "id": "e_patrol_scout_3",
+        "species": "predone_agile",
+        "job": "skirmisher",
+        "traits": [],
+        "hp": 6,
+        "ap": 2,
+        "mod": 2,
+        "dc": 11,
+        "guardia": 0,
+        "attack_range": 1,
+        "position": {
+          "x": 5,
+          "y": 4
+        },
+        "controlled_by": "sistema",
+        "ai_profile": "aggressive",
+        "facing": "W"
+      }
+    ]
+  }
+]

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-24T23:58:16+00:00",
+  "generated_at": "2026-04-25T00:05:47+00:00",
   "summary": {
     "total": 0,
     "errors": 0,

--- a/tests/scripts/test_encounter_xp_budget.py
+++ b/tests/scripts/test_encounter_xp_budget.py
@@ -1,0 +1,315 @@
+"""Tests for tools/py/encounter_xp_budget.py — Pathfinder-XP encounter audit."""
+
+from __future__ import annotations
+
+import pytest
+
+
+pytest.importorskip("tools.py.encounter_xp_budget", reason="PYTHONPATH=tools/py required")
+
+from tools.py.encounter_xp_budget import (  # noqa: E402
+    DIFFICULTY_MULTIPLIER,
+    EncounterAudit,
+    KNOWN_SCENARIOS,
+    TOO_EASY_MAX,
+    TOO_HARD_MIN,
+    UnitAudit,
+    audit_encounter,
+    audit_to_dict,
+    format_markdown,
+    split_units,
+    unit_power,
+)
+
+
+def _player(uid="p1", hp=10, mod=2, dc=12, traits=None):
+    return {
+        "id": uid,
+        "controlled_by": "player",
+        "hp": hp,
+        "mod": mod,
+        "dc": dc,
+        "traits": traits or [],
+    }
+
+
+def _enemy(uid="e1", hp=8, mod=1, dc=11, traits=None):
+    return {
+        "id": uid,
+        "controlled_by": "sistema",
+        "hp": hp,
+        "mod": mod,
+        "dc": dc,
+        "traits": traits or [],
+    }
+
+
+def _scenario(difficulty=3, players=None, enemies=None, sid="enc_test"):
+    return {
+        "id": sid,
+        "difficulty_rating": difficulty,
+        "units": (players or [_player()]) + (enemies or [_enemy()]),
+    }
+
+
+# ─────────────────────────────────────────────────────────
+# unit_power
+# ─────────────────────────────────────────────────────────
+
+
+def test_unit_power_basic():
+    """hp=10, mod=2, dc=12, 0 traits → 10 + 10 + 6 + 0 = 26."""
+    total, comps = unit_power({"hp": 10, "mod": 2, "dc": 12, "traits": []})
+    assert total == pytest.approx(26.0)
+    assert comps == {"hp": 10.0, "mod": 10.0, "dc": 6.0, "traits": 0.0}
+
+
+def test_unit_power_dc_below_10_floors_to_zero():
+    """DC < 10 → contribution clamped to 0 (no negative power)."""
+    total, comps = unit_power({"hp": 5, "mod": 0, "dc": 5, "traits": []})
+    assert total == 5.0
+    assert comps["dc"] == 0.0
+
+
+def test_unit_power_traits_add_2_each():
+    total, comps = unit_power({"hp": 10, "mod": 0, "dc": 10, "traits": ["a", "b", "c"]})
+    assert comps["traits"] == 6.0
+    assert total == 16.0
+
+
+def test_unit_power_missing_fields_default_safely():
+    """Missing fields → defaults (hp=0, mod=0, dc=10, traits=[])."""
+    total, _ = unit_power({})
+    assert total == 0.0
+
+
+def test_unit_power_string_values_coerced():
+    """Strings from JSON are coerced to floats."""
+    total, _ = unit_power({"hp": "10", "mod": "2", "dc": "12"})
+    assert total == 26.0
+
+
+def test_unit_power_attack_mod_alias():
+    """Field 'attack_mod' is recognized as 'mod' fallback."""
+    total, _ = unit_power({"hp": 5, "attack_mod": 3})
+    assert total == pytest.approx(5 + 15)
+
+
+# ─────────────────────────────────────────────────────────
+# split_units
+# ─────────────────────────────────────────────────────────
+
+
+def test_split_units_partitions_by_controlled_by():
+    sc = _scenario(players=[_player("p1"), _player("p2")], enemies=[_enemy("e1")])
+    players, enemies = split_units(sc)
+    assert len(players) == 2
+    assert len(enemies) == 1
+
+
+def test_split_units_handles_missing_units():
+    players, enemies = split_units({})
+    assert players == []
+    assert enemies == []
+
+
+def test_split_units_skips_unknown_controlled_by():
+    sc = {"units": [{"id": "x", "controlled_by": "neutral"}]}
+    players, enemies = split_units(sc)
+    assert players == []
+    assert enemies == []
+
+
+# ─────────────────────────────────────────────────────────
+# audit_encounter
+# ─────────────────────────────────────────────────────────
+
+
+def test_audit_balanced_scenario():
+    """Designed-balanced: party 26, expected = 26 * 1.0 = 26, enemy = 26 → ratio 1.0."""
+    sc = _scenario(
+        difficulty=3,
+        players=[_player(hp=10, mod=2, dc=12)],
+        enemies=[_enemy(hp=10, mod=2, dc=12)],
+    )
+    a = audit_encounter(sc)
+    assert a.party_power == 26.0
+    assert a.expected_enemy_power == 26.0
+    assert a.ratio == 1.0
+    assert a.verdict == "balanced"
+
+
+def test_audit_too_easy_when_enemies_underpower():
+    """Half-power enemies → ratio < 0.7 → too_easy."""
+    sc = _scenario(
+        difficulty=3,
+        players=[_player(hp=10, mod=2, dc=12)],
+        enemies=[_enemy(hp=2, mod=0, dc=10)],
+    )
+    a = audit_encounter(sc)
+    assert a.ratio < TOO_EASY_MAX
+    assert a.verdict == "too_easy"
+
+
+def test_audit_too_hard_when_enemies_overpower():
+    """Boss with high stats → ratio > 1.3 → too_hard."""
+    sc = _scenario(
+        difficulty=3,
+        players=[_player(hp=10, mod=2, dc=12)],
+        enemies=[_enemy(hp=40, mod=4, dc=15)],
+    )
+    a = audit_encounter(sc)
+    assert a.ratio > TOO_HARD_MIN
+    assert a.verdict == "too_hard"
+
+
+def test_audit_uses_difficulty_multiplier():
+    """Difficulty 6 (hardcore) multiplier 2.2 → enemies need 2.2x party to balance."""
+    sc = _scenario(
+        difficulty=6,
+        players=[_player(hp=10, mod=2, dc=12)],
+        enemies=[_enemy(hp=10, mod=2, dc=12)],
+    )
+    a = audit_encounter(sc)
+    # ratio = 26 / (26 * 2.2) = 0.4545 → too_easy for hardcore
+    assert a.ratio < 0.5
+    assert a.verdict == "too_easy"
+
+
+def test_audit_raises_on_no_players():
+    sc = {"id": "test", "difficulty_rating": 3, "units": [_enemy()]}
+    with pytest.raises(ValueError, match="no player"):
+        audit_encounter(sc)
+
+
+def test_audit_raises_on_no_enemies():
+    sc = {"id": "test", "difficulty_rating": 3, "units": [_player()]}
+    with pytest.raises(ValueError, match="no enemy"):
+        audit_encounter(sc)
+
+
+def test_audit_returns_per_unit_breakdown():
+    sc = _scenario(players=[_player(), _player("p2")], enemies=[_enemy()])
+    a = audit_encounter(sc)
+    assert len(a.units) == 3
+    assert {u.side for u in a.units} == {"player", "sistema"}
+
+
+def test_audit_unknown_difficulty_uses_default():
+    """Unknown difficulty rating (e.g. 99) falls back to multiplier 1.0."""
+    sc = _scenario(difficulty=99, players=[_player()], enemies=[_enemy()])
+    a = audit_encounter(sc)
+    assert a.expected_enemy_power == a.party_power  # multiplier defaulted to 1.0
+
+
+# ─────────────────────────────────────────────────────────
+# Realistic scenario shapes (mirror tutorialScenario.js)
+# ─────────────────────────────────────────────────────────
+
+
+def test_audit_tutorial_01_shape():
+    """Mirrors enc_tutorial_01: 2 players (10 hp, mod 2-3, dc 12) vs 2 enemies."""
+    sc = {
+        "id": "enc_tutorial_01",
+        "difficulty_rating": 1,
+        "units": [
+            {"id": "p1", "controlled_by": "player", "hp": 10, "mod": 3, "dc": 12},
+            {"id": "p2", "controlled_by": "player", "hp": 12, "mod": 2, "dc": 13},
+            {"id": "e1", "controlled_by": "sistema", "hp": 3, "mod": 1, "dc": 11},
+            {"id": "e2", "controlled_by": "sistema", "hp": 5, "mod": 1, "dc": 11},
+        ],
+    }
+    a = audit_encounter(sc)
+    # Party = (10+15+6) + (12+10+9) = 31 + 31 = 62
+    # Enemy = (3+5+3) + (5+5+3) = 11 + 13 = 24
+    # Expected = 62 * 0.6 = 37.2 → ratio 24/37.2 ≈ 0.645 → too_easy
+    assert a.party_power == 62.0
+    assert a.enemy_power == 24.0
+    assert a.expected_enemy_power == pytest.approx(37.2)
+    assert a.verdict == "too_easy"
+
+
+def test_audit_hardcore_06_shape():
+    """Mirrors hardcore_06 boss: 8 players vs 1 BOSS hp=40 + 5 minions."""
+    players = [
+        {"id": f"p{i}", "controlled_by": "player", "hp": 10, "mod": 3, "dc": 12}
+        for i in range(8)
+    ]
+    enemies = [
+        {"id": "boss", "controlled_by": "sistema", "hp": 40, "mod": 5, "dc": 15},
+        {"id": "e1", "controlled_by": "sistema", "hp": 9, "mod": 3, "dc": 13},
+        {"id": "e2", "controlled_by": "sistema", "hp": 9, "mod": 3, "dc": 13},
+        {"id": "e3", "controlled_by": "sistema", "hp": 5, "mod": 2, "dc": 12},
+        {"id": "e4", "controlled_by": "sistema", "hp": 5, "mod": 2, "dc": 12},
+        {"id": "e5", "controlled_by": "sistema", "hp": 5, "mod": 2, "dc": 12},
+    ]
+    sc = {
+        "id": "enc_tutorial_06_hardcore",
+        "difficulty_rating": 6,
+        "units": players + enemies,
+    }
+    a = audit_encounter(sc)
+    # Just sanity: enemies should be present, ratio computed.
+    assert a.party_power > 0
+    assert a.enemy_power > 0
+    assert a.ratio > 0
+    assert a.verdict in {"too_easy", "balanced", "too_hard"}
+
+
+# ─────────────────────────────────────────────────────────
+# Constants contract
+# ─────────────────────────────────────────────────────────
+
+
+def test_difficulty_multiplier_monotonic():
+    """Higher difficulty must require more enemy power (monotonic)."""
+    keys = sorted(DIFFICULTY_MULTIPLIER.keys())
+    values = [DIFFICULTY_MULTIPLIER[k] for k in keys]
+    assert values == sorted(values), f"Multipliers not monotonic: {values}"
+
+
+def test_verdict_thresholds_sane():
+    assert 0 < TOO_EASY_MAX < 1 < TOO_HARD_MIN
+
+
+def test_known_scenarios_lists_real_ids():
+    """All KNOWN_SCENARIOS follow the enc_* naming convention."""
+    for sid in KNOWN_SCENARIOS:
+        assert sid.startswith("enc_")
+    assert "enc_tutorial_01" in KNOWN_SCENARIOS
+    assert "enc_tutorial_06_hardcore" in KNOWN_SCENARIOS
+
+
+# ─────────────────────────────────────────────────────────
+# Output formatting
+# ─────────────────────────────────────────────────────────
+
+
+def test_audit_to_dict_shape():
+    sc = _scenario()
+    a = audit_encounter(sc)
+    d = audit_to_dict(a)
+    assert d["scenario_id"] == "enc_test"
+    assert "party_power" in d
+    assert "ratio" in d
+    assert "verdict" in d
+    assert isinstance(d["units"], list)
+
+
+def test_format_markdown_smoke():
+    sc1 = _scenario(sid="enc_a", difficulty=1)
+    sc2 = _scenario(
+        sid="enc_b",
+        difficulty=6,
+        enemies=[_enemy(hp=40, mod=5, dc=15)],
+    )
+    audits = [audit_encounter(sc1), audit_encounter(sc2)]
+    md = format_markdown(audits)
+    assert md.startswith("---\n")
+    assert "doc_owner: claude-code" in md
+    assert "Encounter XP Budget" in md
+    assert "## Verdict per scenario" in md
+    assert "| `enc_a` |" in md
+    assert "| `enc_b` |" in md
+    assert "## Per-unit power breakdown" in md
+    assert "Pathfinder" in md

--- a/tools/py/encounter_xp_budget.py
+++ b/tools/py/encounter_xp_budget.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""Encounter XP budget audit — Pathfinder-inspired difficulty framework.
+
+Closes pcg-level-design-illuminator P1 — XP budget encounter builder.
+
+Audits existing encounters (tutorials + hardcore) by computing per-unit
+"power" (Pathfinder XP analogue), summing per side, then validating that
+the enemy:player ratio matches the declared `difficulty_rating`.
+
+The formula is intentionally simple and tunable; treat it as a baseline
+proxy. Action-economy distortions (1 BOSS vs 5 minion) and skill-gradient
+multipliers are out of scope (deferred to playtest empirical calibration).
+
+## Usage
+
+    # Audit all known scenarios via live backend
+    REST_PLAY_HOST=http://localhost:3334 python3 tools/py/encounter_xp_budget.py \\
+        --all --out-md docs/balance/2026-04-25-encounter-xp-audit.md
+
+    # Audit a specific scenario JSON dump
+    curl -s http://localhost:3334/api/tutorial/enc_tutorial_03 | \\
+        python3 tools/py/encounter_xp_budget.py --stdin
+
+    # Audit from a JSON file
+    python3 tools/py/encounter_xp_budget.py --json scenario.json
+
+## Formula
+
+    unit_power = hp + mod * 5 + max(0, dc - 10) * 3 + len(traits) * 2
+
+    party_power_per_pc = sum(player_power) / party_size
+    expected_enemy_power = party_power_per_pc * party_size * MULT[difficulty]
+
+    ratio = actual_enemy_power / expected_enemy_power
+
+    verdict:
+      ratio < 0.7       → too_easy
+      0.7 <= ratio <= 1.3 → balanced
+      ratio > 1.3       → too_hard
+
+## Difficulty multiplier table (Pathfinder-inspired)
+
+    1 (tutorial easy)         → 0.6
+    2 (tutorial standard)     → 0.85
+    3 (tutorial advanced)     → 1.0
+    4 (tutorial advanced+)    → 1.4
+    5 (boss)                  → 1.7
+    6 (hardcore)              → 2.2
+
+## References
+
+- Pathfinder Encounter Building: https://aonprd.com/Rules.aspx?ID=252
+- Agent: .claude/agents/pcg-level-design-illuminator.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+
+DEFAULT_HOST = "http://localhost:3334"
+
+# Multipliers per declared difficulty_rating. Tunable post-playtest.
+DIFFICULTY_MULTIPLIER = {
+    1: 0.6,
+    2: 0.85,
+    3: 1.0,
+    4: 1.4,
+    5: 1.7,
+    6: 2.2,
+    7: 2.6,
+    8: 3.0,
+}
+
+# Verdict thresholds on actual/expected ratio.
+TOO_EASY_MAX = 0.7
+TOO_HARD_MIN = 1.3
+
+# Known scenario IDs as of 2026-04-25.
+KNOWN_SCENARIOS = (
+    "enc_tutorial_01",
+    "enc_tutorial_02",
+    "enc_tutorial_03",
+    "enc_tutorial_04",
+    "enc_tutorial_05",
+    "enc_tutorial_06_hardcore",
+    "enc_tutorial_06_hardcore_quartet",
+    "enc_tutorial_07_hardcore_pod_rush",
+)
+
+
+@dataclass
+class UnitAudit:
+    id: str
+    side: str  # 'player' | 'sistema'
+    power: float
+    components: dict
+
+
+@dataclass
+class EncounterAudit:
+    scenario_id: str
+    difficulty_rating: int
+    party_power: float
+    enemy_power: float
+    expected_enemy_power: float
+    ratio: float
+    verdict: str
+    units: list[UnitAudit]
+
+
+# ─────────────────────────────────────────────────────────
+# Power computation
+# ─────────────────────────────────────────────────────────
+
+
+def unit_power(unit: dict) -> tuple[float, dict]:
+    """Compute Pathfinder-inspired power score for one unit.
+
+    Returns (total, components_dict) so reports can attribute the score.
+    """
+    hp = float(unit.get("hp", 0) or 0)
+    mod = float(unit.get("mod", unit.get("attack_mod", 0)) or 0)
+    dc = float(unit.get("dc", unit.get("defense_dc", 10)) or 10)
+    traits = unit.get("traits") or []
+    n_traits = len(traits) if isinstance(traits, list) else 0
+
+    hp_part = hp
+    mod_part = mod * 5
+    dc_part = max(0.0, dc - 10) * 3
+    trait_part = n_traits * 2.0
+
+    total = hp_part + mod_part + dc_part + trait_part
+    return total, {
+        "hp": round(hp_part, 1),
+        "mod": round(mod_part, 1),
+        "dc": round(dc_part, 1),
+        "traits": round(trait_part, 1),
+    }
+
+
+def split_units(scenario: dict) -> tuple[list[dict], list[dict]]:
+    """Partition encounter units into players vs sistema (enemies)."""
+    units = scenario.get("units") or []
+    players = [u for u in units if u.get("controlled_by") == "player"]
+    enemies = [u for u in units if u.get("controlled_by") == "sistema"]
+    return players, enemies
+
+
+# ─────────────────────────────────────────────────────────
+# Encounter audit
+# ─────────────────────────────────────────────────────────
+
+
+def audit_encounter(scenario: dict) -> EncounterAudit:
+    """Run full audit on a scenario JSON dump."""
+    sid = str(scenario.get("id", "<unknown>"))
+    difficulty = int(scenario.get("difficulty_rating", 0) or 0)
+    players, enemies = split_units(scenario)
+
+    if not players:
+        raise ValueError(f"Scenario {sid} has no player units (cannot compute baseline)")
+    if not enemies:
+        raise ValueError(f"Scenario {sid} has no enemy units (cannot audit)")
+
+    p_units, e_units = [], []
+    party_power = 0.0
+    for u in players:
+        total, comps = unit_power(u)
+        party_power += total
+        p_units.append(UnitAudit(id=u.get("id", "?"), side="player", power=total, components=comps))
+
+    enemy_power = 0.0
+    for u in enemies:
+        total, comps = unit_power(u)
+        enemy_power += total
+        e_units.append(UnitAudit(id=u.get("id", "?"), side="sistema", power=total, components=comps))
+
+    multiplier = DIFFICULTY_MULTIPLIER.get(difficulty, 1.0)
+    expected = party_power * multiplier
+    ratio = (enemy_power / expected) if expected > 0 else float("inf")
+
+    if ratio < TOO_EASY_MAX:
+        verdict = "too_easy"
+    elif ratio > TOO_HARD_MIN:
+        verdict = "too_hard"
+    else:
+        verdict = "balanced"
+
+    return EncounterAudit(
+        scenario_id=sid,
+        difficulty_rating=difficulty,
+        party_power=round(party_power, 1),
+        enemy_power=round(enemy_power, 1),
+        expected_enemy_power=round(expected, 1),
+        ratio=round(ratio, 3),
+        verdict=verdict,
+        units=p_units + e_units,
+    )
+
+
+# ─────────────────────────────────────────────────────────
+# HTTP scenario fetcher
+# ─────────────────────────────────────────────────────────
+
+
+def fetch_scenario(host: str, scenario_id: str) -> dict | None:
+    url = f"{host}/api/tutorial/{scenario_id}"
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            if resp.status != 200:
+                return None
+            return json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError):
+        return None
+
+
+# ─────────────────────────────────────────────────────────
+# Markdown report
+# ─────────────────────────────────────────────────────────
+
+
+def format_markdown(audits: list[EncounterAudit]) -> str:
+    today = datetime.now().date().isoformat()
+    lines: list[str] = []
+    lines.append("---")
+    lines.append(f"title: Encounter XP Budget Audit ({today})")
+    lines.append("doc_status: active")
+    lines.append("doc_owner: claude-code")
+    lines.append("workstream: dataset-pack")
+    lines.append(f"last_verified: '{today}'")
+    lines.append("source_of_truth: false")
+    lines.append("language: it")
+    lines.append("review_cycle_days: 30")
+    lines.append("tags:")
+    lines.append("  - balance")
+    lines.append("  - pcg")
+    lines.append("  - encounter")
+    lines.append("  - pathfinder-xp")
+    lines.append("  - generated")
+    lines.append("---")
+    lines.append("")
+    lines.append("# Encounter XP Budget Audit")
+    lines.append("")
+    lines.append(
+        "Pathfinder-inspired difficulty audit. Closes "
+        "[pcg-level-design-illuminator P1](.claude/agents/pcg-level-design-illuminator.md). "
+        "Ratio = enemy_power / (party_power × difficulty_multiplier)."
+    )
+    lines.append("")
+    lines.append("## Verdict per scenario")
+    lines.append("")
+    lines.append("| Scenario | Diff | Party | Enemy | Expected | Ratio | Verdict |")
+    lines.append("| --- | ---: | ---: | ---: | ---: | ---: | --- |")
+    for a in audits:
+        badge = {
+            "balanced": "✅ balanced",
+            "too_easy": "🟢 too_easy (player power)",
+            "too_hard": "🔴 too_hard (enemy power)",
+        }.get(a.verdict, a.verdict)
+        lines.append(
+            f"| `{a.scenario_id}` | {a.difficulty_rating} | "
+            f"{a.party_power} | {a.enemy_power} | {a.expected_enemy_power} | "
+            f"**{a.ratio}** | {badge} |"
+        )
+    lines.append("")
+    lines.append("## Summary")
+    lines.append("")
+    counts: dict[str, int] = {}
+    for a in audits:
+        counts[a.verdict] = counts.get(a.verdict, 0) + 1
+    for verdict, count in counts.items():
+        pct = round(100 * count / len(audits), 1) if audits else 0
+        lines.append(f"- **{verdict}**: {count}/{len(audits)} ({pct}%)")
+    lines.append("")
+    lines.append("## Difficulty multiplier table")
+    lines.append("")
+    lines.append("| Difficulty | Multiplier |")
+    lines.append("| ---: | ---: |")
+    for d, m in sorted(DIFFICULTY_MULTIPLIER.items()):
+        lines.append(f"| {d} | {m} |")
+    lines.append("")
+    lines.append("## Per-unit power breakdown")
+    lines.append("")
+    for a in audits:
+        lines.append(f"### `{a.scenario_id}`")
+        lines.append("")
+        lines.append("| Unit | Side | Power | hp | mod | dc | traits |")
+        lines.append("| --- | --- | ---: | ---: | ---: | ---: | ---: |")
+        for u in a.units:
+            c = u.components
+            lines.append(
+                f"| `{u.id}` | {u.side} | {round(u.power, 1)} | "
+                f"{c['hp']} | {c['mod']} | {c['dc']} | {c['traits']} |"
+            )
+        lines.append("")
+    lines.append("## Notes & limits")
+    lines.append("")
+    lines.append("- Action economy (1 BOSS vs N minion) **non** modellata: 1 boss da 50 power")
+    lines.append("  e 5 minion da 10 power dichiarano lo stesso enemy_power totale, ma giocano")
+    lines.append("  diversamente (focus-fire vs spread). Calibrazione finale resta empirica.")
+    lines.append("- DC contribuisce solo per la parte > 10 (proxy difensivo, non valore assoluto).")
+    lines.append("- Traits = +2 power flat per trait (placeholder; trait scaling profondo è in")
+    lines.append("  `data/balance/trait_mechanics.yaml`).")
+    lines.append("- Multipliers tunable in `tools/py/encounter_xp_budget.py::DIFFICULTY_MULTIPLIER`.")
+    lines.append("")
+    lines.append("## Sources")
+    lines.append("")
+    lines.append("- [Pathfinder Encounter Building](https://aonprd.com/Rules.aspx?ID=252)")
+    lines.append("- Agent: `.claude/agents/pcg-level-design-illuminator.md`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ─────────────────────────────────────────────────────────
+# CLI
+# ─────────────────────────────────────────────────────────
+
+
+def audit_to_dict(a: EncounterAudit) -> dict:
+    return {
+        "scenario_id": a.scenario_id,
+        "difficulty_rating": a.difficulty_rating,
+        "party_power": a.party_power,
+        "enemy_power": a.enemy_power,
+        "expected_enemy_power": a.expected_enemy_power,
+        "ratio": a.ratio,
+        "verdict": a.verdict,
+        "units": [
+            {"id": u.id, "side": u.side, "power": round(u.power, 1), "components": u.components}
+            for u in a.units
+        ],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument("--all", action="store_true", help="Audit all known scenarios via HTTP")
+    src.add_argument("--scenario", help="Single scenario id via HTTP")
+    src.add_argument("--json", help="Path to scenario JSON file")
+    src.add_argument("--stdin", action="store_true", help="Read scenario JSON from stdin")
+    parser.add_argument("--host", default=os.environ.get("REST_PLAY_HOST", DEFAULT_HOST))
+    parser.add_argument("--out-md", default=None)
+    parser.add_argument("--out-json", default=None)
+    args = parser.parse_args(argv)
+
+    scenarios: list[dict] = []
+
+    if args.all:
+        for sid in KNOWN_SCENARIOS:
+            sc = fetch_scenario(args.host, sid)
+            if sc is None:
+                print(f"  warn: failed to fetch {sid}", file=sys.stderr)
+                continue
+            scenarios.append(sc)
+    elif args.scenario:
+        sc = fetch_scenario(args.host, args.scenario)
+        if sc is None:
+            print(f"ERROR: failed to fetch {args.scenario}", file=sys.stderr)
+            return 2
+        scenarios.append(sc)
+    elif args.json:
+        scenarios.append(json.loads(Path(args.json).read_text(encoding="utf-8")))
+    elif args.stdin:
+        scenarios.append(json.loads(sys.stdin.read()))
+
+    if not scenarios:
+        print("ERROR: no scenarios loaded", file=sys.stderr)
+        return 2
+
+    audits: list[EncounterAudit] = []
+    for sc in scenarios:
+        try:
+            audits.append(audit_encounter(sc))
+        except ValueError as e:
+            print(f"  warn: {e}", file=sys.stderr)
+
+    print(f"\nAudit results ({len(audits)} scenarios):")
+    for a in audits:
+        print(
+            f"  {a.scenario_id}: ratio={a.ratio} verdict={a.verdict} "
+            f"(party={a.party_power} enemy={a.enemy_power} expected={a.expected_enemy_power})"
+        )
+
+    if args.out_md:
+        out_path = Path(args.out_md)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(format_markdown(audits), encoding="utf-8")
+        print(f"Markdown saved: {out_path}")
+
+    if args.out_json:
+        out_path = Path(args.out_json)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            json.dumps([audit_to_dict(a) for a in audits], indent=2), encoding="utf-8"
+        )
+        print(f"JSON saved: {out_path}")
+
+    # Exit code 0 if everything balanced, 1 if any imbalance found.
+    return 0 if all(a.verdict == "balanced" for a in audits) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes [`pcg-level-design-illuminator`](.claude/agents/pcg-level-design-illuminator.md) P1 — XP budget encounter builder (~6h estimate). Pathfinder-inspired audit tool that scores per-unit power and validates enemy:player ratio vs declared `difficulty_rating`.

Pure stdlib (zero deps). 24 pytest verde, AI 307/307 preserved.

## Power formula

```
unit_power = hp + mod*5 + max(0, dc-10)*3 + len(traits)*2

expected_enemy = party_power × DIFFICULTY_MULTIPLIER[difficulty]
ratio = enemy_power / expected_enemy

verdict:
  ratio < 0.7        → too_easy
  0.7 <= ratio <= 1.3 → balanced
  ratio > 1.3        → too_hard
```

Multiplier table: 0.6 (diff 1) → 0.85 → 1.0 → 1.4 → 1.7 → 2.2 (hardcore) → 3.0 (8).

## Audit findings (8 scenarios)

| Scenario                            | Ratio | Verdict   | Empirical WR | Δ |
| ----------------------------------- | ----: | --------- | ------------:|:-:|
| enc_tutorial_01                     | 1.01  | balanced  | ~80%        | ✅|
| enc_tutorial_02                     | 1.30  | too_hard  | ~80%        | ⚠️|
| enc_tutorial_03                     | 0.52  | too_easy  | ~50%        | ⚠️|
| enc_tutorial_04                     | 0.65  | too_easy  | ~30%        | ⚠️|
| enc_tutorial_05                     | 0.27  | too_easy  | ~20%        | ⚠️|
| enc_tutorial_06_hardcore            | 0.31  | too_easy  | ~85% iter2  | ⚠️|
| enc_tutorial_06_hardcore_quartet    | 0.59  | too_easy  | n/a         | — |
| enc_tutorial_07_hardcore_pod_rush   | 0.28  | too_easy  | n/a         | — |

**Honest framing**: model first-pass; sotto-predice difficulty per scenari avanzati. Cause documentate in `docs/balance/2026-04-25-encounter-xp-audit.md`:

1. Action economy (1 BOSS vs 8 player) ignorata
2. Pressure tier (`sistema_pressure_start` 0-95) non modellata
3. Traits flat +2 senza pesi per categoria (AOE/bleeding/focus)
4. Multipliers lineari forse troppo aggressivi al rialzo

Doc include **Recommended tuning** section per calibrazione empirica post-playtest (~3-5h con dati reali).

## CLI

```bash
# Audit live via HTTP
REST_PLAY_HOST=http://localhost:3334 python3 tools/py/encounter_xp_budget.py \
    --all --out-md docs/balance/2026-04-25-encounter-xp-audit.md

# Single scenario via stdin
curl -s http://localhost:3334/api/tutorial/enc_tutorial_03 | \
    python3 tools/py/encounter_xp_budget.py --stdin

# Offline JSON file
python3 tools/py/encounter_xp_budget.py --json scenario.json
```

Esce con exit code 0 se tutti balanced, 1 altrimenti — utilizzabile in CI come gate.

## Test plan

- [x] `pytest tests/scripts/test_encounter_xp_budget.py -v` → 24/24 ✅
- [x] `node --test tests/ai/*.test.js` → 307/307 ✅
- [x] `npm run format:check` → ✅
- [x] `python tools/check_docs_governance.py --strict` → 0 errors, 0 warnings ✅
- [x] Real audit via offline JS→JSON dump (8 scenarios) ✅

## Files

- **NEW** `tools/py/encounter_xp_budget.py` (~340 LOC) — audit module + CLI
- **NEW** `tests/scripts/test_encounter_xp_budget.py` (24 pytest)
- **NEW** `docs/balance/2026-04-25-encounter-xp-audit.md` (auto-gen report + calibration section)
- **NEW** `reports/balance/scenarios_dump.json` (offline JS→JSON snapshot)
- **EDIT** `docs/governance/docs_registry.json` (entry per audit report)

## Sources

- Pattern: [Pathfinder Encounter Building](https://aonprd.com/Rules.aspx?ID=252)
- [PF2 Encounter Calculator](https://pf2calc.com/) (multiplier table reference)
- Agent: `.claude/agents/pcg-level-design-illuminator.md`

## Future work (deferred)

- Calibrare `DIFFICULTY_MULTIPLIER` con win rate empiriche da `docs/playtest/*` (~3-5h)
- Aggiungere `pressure_modifier` per modellare AI tier escalation
- Pesare traits per categoria (AOE/bleeding/focus/passive)
- Modellare action economy (focus-fire bonus)

🤖 Generated with [Claude Code](https://claude.com/claude-code)