### PR TITLE
feat(balance): MAP-Elites lightweight QD archive (balance-illuminator P1)

### DIFF
--- a/docs/balance/2026-04-25-map-elites-archive.md
+++ b/docs/balance/2026-04-25-map-elites-archive.md
@@ -1,0 +1,78 @@
+---
+title: MAP-Elites Balance Archive (2026-04-25)
+doc_status: active
+doc_owner: claude-code
+workstream: dataset-pack
+last_verified: '2026-04-25'
+source_of_truth: false
+language: it
+review_cycle_days: 30
+tags:
+  - balance
+  - map-elites
+  - quality-diversity
+  - generated
+---
+
+# MAP-Elites Balance Archive
+
+Quality-Diversity illumination of the build design space. Closes [balance-illuminator P1](.claude/agents/balance-illuminator.md). Pattern: Mouret & Clune 2015 + Fontaine 2019 (FDG).
+
+## Run config
+
+- Iterations: **1500**
+- Feature dims: ['mbti_t', 'mbti_n', 'archetype_idx']
+- Bins per dim: **5** (total cells: 125)
+- Fitness: synthetic (mock — production should wire `restricted_play.run_one`)
+
+## Archive stats
+
+- Cells filled: **75** / 125
+- Coverage: **60.0%**
+- Fitness max: 1.0000
+- Fitness avg: 0.9850
+- Fitness min: 0.8750
+
+## Top 10 elites
+
+| Cell      | Fitness |  hp | mod |  dc | mbti_t | mbti_n | archetype    |
+| --------- | ------: | --: | --: | --: | -----: | -----: | ------------ |
+| (1, 1, 4) |  1.0000 |  12 |   3 |  13 |  0.371 |  0.366 | `support`    |
+| (2, 0, 0) |  1.0000 |  12 |   3 |  13 |  0.531 |  0.042 | `tank`       |
+| (3, 2, 4) |  1.0000 |  12 |   3 |  13 |  0.602 |  0.561 | `support`    |
+| (2, 1, 0) |  1.0000 |  12 |   3 |  13 |  0.538 |   0.27 | `tank`       |
+| (1, 1, 2) |  1.0000 |  12 |   3 |  13 |  0.371 |  0.365 | `skirmisher` |
+| (0, 4, 4) |  1.0000 |  12 |   3 |  13 |    0.0 |  0.952 | `support`    |
+| (2, 0, 2) |  1.0000 |  12 |   3 |  13 |  0.531 |  0.042 | `skirmisher` |
+| (3, 3, 0) |  1.0000 |  12 |   3 |  13 |  0.608 |  0.736 | `tank`       |
+| (1, 3, 2) |  1.0000 |  12 |   3 |  13 |  0.344 |  0.712 | `skirmisher` |
+| (4, 3, 4) |  1.0000 |  12 |   3 |  13 |  0.825 |  0.757 | `support`    |
+
+## Convergence trajectory
+
+| Iter | Fitness | Accepted | Coverage |
+| ---: | ------: | :------: | -------: |
+|    1 |  0.7222 |    ✅    |    15.2% |
+|  376 |  1.0000 |    —     |    52.8% |
+|  751 |  0.9167 |    —     |    56.8% |
+| 1126 |  0.8889 |    —     |    58.4% |
+| 1500 |  1.0000 |    —     |    60.0% |
+
+## How to read
+
+- **Coverage** = breadth of viable design space discovered. Low (<30%) means the engine struggled to find diverse builds; high (>70%) means the design space is broad and the fitness function permissive.
+- **Fitness max** = single best build found. Compare to fitness avg: large gap = some cells dominate, small gap = uniform competence.
+- **Convergence trajectory** = acceptance rate over iterations. Drops naturally as the archive fills (most mutations no longer beat the elite).
+
+## Limits + next steps
+
+- **Synthetic fitness only**: replace `synthetic_fitness` with a wrapper around `restricted_play.run_one` to evaluate against the real combat engine (~+2h, separate PR). Until then, this is design-space sketching, not balance verdict.
+- **Single-objective**: extend to Pareto MAP-Elites (Cully 2021) to trade off fitness vs diversity vs novelty.
+- **Variance**: re-run with multiple seeds and aggregate coverage to distinguish algorithm-stable patterns from RNG luck.
+
+## Sources
+
+- [Mouret & Clune 2015 — Illuminating search spaces](https://arxiv.org/abs/1504.04909)
+- [Fontaine et al. 2019 — Mapping Hearthstone Deck Spaces](https://arxiv.org/abs/1904.10656)
+- [Cully 2021 — Quality-Diversity Optimization survey](https://arxiv.org/abs/2012.04322)
+- Agent: `.claude/agents/balance-illuminator.md`

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -2204,6 +2204,19 @@
       "track": "new"
     },
     {
+      "path": "docs/balance/2026-04-25-map-elites-archive.md",
+      "title": "MAP-Elites Balance Archive (2026-04-25)",
+      "doc_status": "active",
+      "doc_owner": "claude-code",
+      "workstream": "dataset-pack",
+      "last_verified": "2026-04-25",
+      "source_of_truth": false,
+      "language": "it",
+      "review_cycle_days": 30,
+      "primary": false,
+      "track": "new"
+    },
+    {
       "path": "docs/balance/tutorial-tuning-iter-2026-04-17.md",
       "title": "Tutorial Iter Tuning Pass — 2026-04-17",
       "doc_status": "active",

--- a/reports/balance/map-elites-archive.json
+++ b/reports/balance/map-elites-archive.json
@@ -1,0 +1,1605 @@
+{
+  "dims": [
+    {
+      "name": "mbti_t",
+      "low": 0.0,
+      "high": 1.0
+    },
+    {
+      "name": "mbti_n",
+      "low": 0.0,
+      "high": 1.0
+    },
+    {
+      "name": "archetype_idx",
+      "low": 0.0,
+      "high": 1.0
+    }
+  ],
+  "bins": 5,
+  "stats": {
+    "count": 75,
+    "total_cells": 125,
+    "coverage": 0.6,
+    "fitness_max": 1.0,
+    "fitness_avg": 0.985,
+    "fitness_min": 0.875
+  },
+  "cells": [
+    {
+      "cell": [
+        1,
+        1,
+        4
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.371,
+        0.366,
+        1.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.371,
+        "mbti_n": 0.366,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        2,
+        0,
+        0
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.531,
+        0.042,
+        0.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.531,
+        "mbti_n": 0.042,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        3,
+        2,
+        4
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.602,
+        0.561,
+        1.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.602,
+        "mbti_n": 0.561,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        2,
+        1,
+        0
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.538,
+        0.27,
+        0.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.538,
+        "mbti_n": 0.27,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        1,
+        1,
+        2
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.371,
+        0.365,
+        0.5
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.371,
+        "mbti_n": 0.365,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        0,
+        4,
+        4
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.0,
+        0.952,
+        1.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.0,
+        "mbti_n": 0.952,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        2,
+        0,
+        2
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.531,
+        0.042,
+        0.5
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.531,
+        "mbti_n": 0.042,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        4,
+        3,
+        2
+      ],
+      "fitness": 0.9583333333333334,
+      "behavior": [
+        1.0,
+        0.6,
+        0.5
+      ],
+      "solution": {
+        "hp": 13,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 1.0,
+        "mbti_n": 0.6,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        3,
+        3,
+        0
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.608,
+        0.736,
+        0.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.608,
+        "mbti_n": 0.736,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        1,
+        3,
+        2
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.344,
+        0.712,
+        0.5
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.344,
+        "mbti_n": 0.712,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        0,
+        3,
+        0
+      ],
+      "fitness": 0.9583333333333334,
+      "behavior": [
+        0.151,
+        0.679,
+        0.0
+      ],
+      "solution": {
+        "hp": 11,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.151,
+        "mbti_n": 0.679,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        4,
+        3,
+        4
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.825,
+        0.757,
+        1.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.825,
+        "mbti_n": 0.757,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        3,
+        0,
+        0
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.633,
+        0.132,
+        0.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.633,
+        "mbti_n": 0.132,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        2,
+        4,
+        4
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.587,
+        0.836,
+        1.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.587,
+        "mbti_n": 0.836,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        0,
+        3,
+        4
+      ],
+      "fitness": 0.875,
+      "behavior": [
+        0.14,
+        0.647,
+        1.0
+      ],
+      "solution": {
+        "hp": 15,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.14,
+        "mbti_n": 0.647,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        4,
+        1,
+        0
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.898,
+        0.331,
+        0.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.898,
+        "mbti_n": 0.331,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        0,
+        0,
+        0
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.031,
+        0.189,
+        0.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.031,
+        "mbti_n": 0.189,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        3,
+        2,
+        2
+      ],
+      "fitness": 0.9583333333333334,
+      "behavior": [
+        0.658,
+        0.445,
+        0.5
+      ],
+      "solution": {
+        "hp": 13,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.658,
+        "mbti_n": 0.445,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        2,
+        1,
+        2
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.424,
+        0.365,
+        0.5
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.424,
+        "mbti_n": 0.365,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        0,
+        3,
+        2
+      ],
+      "fitness": 0.9027777777777778,
+      "behavior": [
+        0.151,
+        0.778,
+        0.5
+      ],
+      "solution": {
+        "hp": 11,
+        "mod": 3,
+        "dc": 12,
+        "mbti_t": 0.151,
+        "mbti_n": 0.778,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        2,
+        2,
+        0
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.549,
+        0.445,
+        0.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.549,
+        "mbti_n": 0.445,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        0,
+        1,
+        2
+      ],
+      "fitness": 0.9583333333333334,
+      "behavior": [
+        0.031,
+        0.24,
+        0.5
+      ],
+      "solution": {
+        "hp": 11,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.031,
+        "mbti_n": 0.24,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        3,
+        0,
+        4
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.736,
+        0.183,
+        1.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.736,
+        "mbti_n": 0.183,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        4,
+        2,
+        2
+      ],
+      "fitness": 0.9583333333333334,
+      "behavior": [
+        0.898,
+        0.412,
+        0.5
+      ],
+      "solution": {
+        "hp": 13,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.898,
+        "mbti_n": 0.412,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        3,
+        2,
+        0
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.602,
+        0.561,
+        0.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.602,
+        "mbti_n": 0.561,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        4,
+        3,
+        0
+      ],
+      "fitness": 0.9583333333333334,
+      "behavior": [
+        1.0,
+        0.788,
+        0.0
+      ],
+      "solution": {
+        "hp": 13,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 1.0,
+        "mbti_n": 0.788,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        0,
+        1,
+        0
+      ],
+      "fitness": 0.9583333333333334,
+      "behavior": [
+        0.161,
+        0.281,
+        0.0
+      ],
+      "solution": {
+        "hp": 11,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.161,
+        "mbti_n": 0.281,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        2,
+        4,
+        0
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.587,
+        0.836,
+        0.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.587,
+        "mbti_n": 0.836,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        0,
+        1,
+        4
+      ],
+      "fitness": 0.9583333333333334,
+      "behavior": [
+        0.031,
+        0.24,
+        1.0
+      ],
+      "solution": {
+        "hp": 11,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.031,
+        "mbti_n": 0.24,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        3,
+        0,
+        2
+      ],
+      "fitness": 0.9583333333333334,
+      "behavior": [
+        0.738,
+        0.132,
+        0.5
+      ],
+      "solution": {
+        "hp": 11,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.738,
+        "mbti_n": 0.132,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        0,
+        0,
+        4
+      ],
+      "fitness": 0.9583333333333334,
+      "behavior": [
+        0.031,
+        0.189,
+        1.0
+      ],
+      "solution": {
+        "hp": 11,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.031,
+        "mbti_n": 0.189,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        1,
+        4,
+        2
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.386,
+        0.938,
+        0.5
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.386,
+        "mbti_n": 0.938,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        3,
+        1,
+        0
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.736,
+        0.296,
+        0.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.736,
+        "mbti_n": 0.296,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        1,
+        1,
+        0
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.371,
+        0.365,
+        0.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.371,
+        "mbti_n": 0.365,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        2,
+        3,
+        2
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.458,
+        0.679,
+        0.5
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.458,
+        "mbti_n": 0.679,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        0,
+        0,
+        2
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.031,
+        0.189,
+        0.5
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.031,
+        "mbti_n": 0.189,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        1,
+        0,
+        2
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.371,
+        0.19,
+        0.5
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.371,
+        "mbti_n": 0.19,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        3,
+        4,
+        4
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.637,
+        0.836,
+        1.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.637,
+        "mbti_n": 0.836,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        0,
+        4,
+        0
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.178,
+        0.839,
+        0.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.178,
+        "mbti_n": 0.839,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        4,
+        1,
+        4
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.898,
+        0.352,
+        1.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.898,
+        "mbti_n": 0.352,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        2,
+        3,
+        0
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.497,
+        0.73,
+        0.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.497,
+        "mbti_n": 0.73,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        1,
+        0,
+        4
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.371,
+        0.19,
+        1.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.371,
+        "mbti_n": 0.19,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        1,
+        4,
+        0
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.364,
+        0.839,
+        0.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.364,
+        "mbti_n": 0.839,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        1,
+        0,
+        0
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.341,
+        0.03,
+        0.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.341,
+        "mbti_n": 0.03,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        0,
+        4,
+        2
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.0,
+        0.952,
+        0.5
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.0,
+        "mbti_n": 0.952,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        2,
+        4,
+        2
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.458,
+        0.84,
+        0.5
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.458,
+        "mbti_n": 0.84,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        4,
+        0,
+        2
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.953,
+        0.192,
+        0.5
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.953,
+        "mbti_n": 0.192,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        3,
+        1,
+        2
+      ],
+      "fitness": 0.9166666666666666,
+      "behavior": [
+        0.736,
+        0.296,
+        0.5
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 2,
+        "dc": 13,
+        "mbti_t": 0.736,
+        "mbti_n": 0.296,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        1,
+        3,
+        4
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.344,
+        0.679,
+        1.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.344,
+        "mbti_n": 0.679,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        4,
+        4,
+        0
+      ],
+      "fitness": 0.9583333333333334,
+      "behavior": [
+        0.898,
+        0.804,
+        0.0
+      ],
+      "solution": {
+        "hp": 13,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.898,
+        "mbti_n": 0.804,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        3,
+        3,
+        4
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.767,
+        0.698,
+        1.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.767,
+        "mbti_n": 0.698,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        4,
+        2,
+        4
+      ],
+      "fitness": 0.9583333333333334,
+      "behavior": [
+        0.898,
+        0.412,
+        1.0
+      ],
+      "solution": {
+        "hp": 13,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.898,
+        "mbti_n": 0.412,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        2,
+        2,
+        2
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.556,
+        0.445,
+        0.5
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.556,
+        "mbti_n": 0.445,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        1,
+        2,
+        2
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.371,
+        0.445,
+        0.5
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.371,
+        "mbti_n": 0.445,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        1,
+        2,
+        4
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.371,
+        0.445,
+        1.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.371,
+        "mbti_n": 0.445,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        4,
+        0,
+        0
+      ],
+      "fitness": 0.9444444444444444,
+      "behavior": [
+        1.0,
+        0.0,
+        0.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 14,
+        "mbti_t": 1.0,
+        "mbti_n": 0.0,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        0,
+        2,
+        0
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.132,
+        0.453,
+        0.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.132,
+        "mbti_n": 0.453,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        2,
+        2,
+        4
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.556,
+        0.45,
+        1.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.556,
+        "mbti_n": 0.45,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        4,
+        2,
+        0
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.898,
+        0.416,
+        0.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.898,
+        "mbti_n": 0.416,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        2,
+        0,
+        4
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.531,
+        0.03,
+        1.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.531,
+        "mbti_n": 0.03,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        1,
+        3,
+        0
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.344,
+        0.679,
+        0.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.344,
+        "mbti_n": 0.679,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        4,
+        1,
+        2
+      ],
+      "fitness": 0.9583333333333334,
+      "behavior": [
+        0.88,
+        0.259,
+        0.5
+      ],
+      "solution": {
+        "hp": 11,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.88,
+        "mbti_n": 0.259,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        2,
+        3,
+        4
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.587,
+        0.634,
+        1.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.587,
+        "mbti_n": 0.634,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        3,
+        1,
+        4
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.692,
+        0.259,
+        1.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.692,
+        "mbti_n": 0.259,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        1,
+        2,
+        0
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.371,
+        0.445,
+        0.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.371,
+        "mbti_n": 0.445,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        3,
+        4,
+        2
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.637,
+        0.836,
+        0.5
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.637,
+        "mbti_n": 0.836,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        2,
+        1,
+        4
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.538,
+        0.27,
+        1.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.538,
+        "mbti_n": 0.27,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        4,
+        0,
+        4
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.843,
+        0.183,
+        1.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.843,
+        "mbti_n": 0.183,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        1,
+        4,
+        4
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.333,
+        0.839,
+        1.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.333,
+        "mbti_n": 0.839,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        0,
+        2,
+        2
+      ],
+      "fitness": 0.9444444444444444,
+      "behavior": [
+        0.132,
+        0.453,
+        0.5
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 14,
+        "mbti_t": 0.132,
+        "mbti_n": 0.453,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        0,
+        2,
+        4
+      ],
+      "fitness": 0.875,
+      "behavior": [
+        0.14,
+        0.469,
+        1.0
+      ],
+      "solution": {
+        "hp": 15,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.14,
+        "mbti_n": 0.469,
+        "archetype": "support"
+      }
+    },
+    {
+      "cell": [
+        3,
+        4,
+        0
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.73,
+        0.836,
+        0.0
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.73,
+        "mbti_n": 0.836,
+        "archetype": "tank"
+      }
+    },
+    {
+      "cell": [
+        3,
+        3,
+        2
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.637,
+        0.693,
+        0.5
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.637,
+        "mbti_n": 0.693,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        4,
+        4,
+        2
+      ],
+      "fitness": 1.0,
+      "behavior": [
+        0.825,
+        0.836,
+        0.5
+      ],
+      "solution": {
+        "hp": 12,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.825,
+        "mbti_n": 0.836,
+        "archetype": "skirmisher"
+      }
+    },
+    {
+      "cell": [
+        4,
+        4,
+        4
+      ],
+      "fitness": 0.9583333333333334,
+      "behavior": [
+        0.825,
+        0.836,
+        1.0
+      ],
+      "solution": {
+        "hp": 13,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.825,
+        "mbti_n": 0.836,
+        "archetype": "support"
+      }
+    }
+  ]
+}

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-25T00:18:26+00:00",
+  "generated_at": "2026-04-25T00:28:25+00:00",
   "summary": {
     "total": 0,
     "errors": 0,

--- a/tests/scripts/test_map_elites.py
+++ b/tests/scripts/test_map_elites.py
@@ -1,0 +1,348 @@
+"""Tests for tools/py/map_elites.py — Quality-Diversity archive."""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+
+pytest.importorskip("tools.py.map_elites", reason="PYTHONPATH=tools/py required")
+
+from tools.py.map_elites import (  # noqa: E402
+    ARCHETYPES,
+    ARCHETYPE_INDEX,
+    BALANCE_FEATURE_DIMS,
+    Cell,
+    FeatureDim,
+    MapElitesArchive,
+    archive_to_dict,
+    build_random_solution,
+    format_markdown,
+    mutate_build,
+    run_map_elites,
+    synthetic_fitness,
+)
+
+
+# ─────────────────────────────────────────────────────────
+# FeatureDim + MapElitesArchive
+# ─────────────────────────────────────────────────────────
+
+
+def test_feature_dim_dataclass_shape():
+    d = FeatureDim("x", 0.0, 1.0)
+    assert d.name == "x"
+    assert d.low == 0.0
+    assert d.high == 1.0
+
+
+def test_archive_total_cells():
+    arc = MapElitesArchive([FeatureDim("a", 0, 1), FeatureDim("b", 0, 1)], bins_per_dim=4)
+    assert arc.total_cells() == 16  # 4^2
+
+
+def test_archive_validation_empty_dims():
+    with pytest.raises(ValueError, match="non-empty"):
+        MapElitesArchive([], bins_per_dim=4)
+
+
+def test_archive_validation_bad_bins():
+    with pytest.raises(ValueError, match="bins_per_dim"):
+        MapElitesArchive([FeatureDim("a", 0, 1)], bins_per_dim=0)
+
+
+def test_archive_validation_bad_dim_range():
+    with pytest.raises(ValueError, match="low"):
+        MapElitesArchive([FeatureDim("a", 1, 0)], bins_per_dim=4)
+
+
+def test_cell_for_basic():
+    arc = MapElitesArchive([FeatureDim("a", 0, 1)], bins_per_dim=4)
+    # 0..0.25 → bin 0, 0.25..0.5 → bin 1, etc.
+    assert arc.cell_for([0.1]) == (0,)
+    assert arc.cell_for([0.3]) == (1,)
+    assert arc.cell_for([0.6]) == (2,)
+    assert arc.cell_for([0.9]) == (3,)
+
+
+def test_cell_for_clamps_out_of_range():
+    arc = MapElitesArchive([FeatureDim("a", 0, 1)], bins_per_dim=4)
+    assert arc.cell_for([-1.0]) == (0,)
+    assert arc.cell_for([2.0]) == (3,)
+
+
+def test_cell_for_high_value_lands_in_top_bin():
+    """Value exactly at high should land in last bin (not overflow)."""
+    arc = MapElitesArchive([FeatureDim("a", 0, 1)], bins_per_dim=4)
+    assert arc.cell_for([1.0]) == (3,)
+
+
+def test_cell_for_dim_count_mismatch():
+    arc = MapElitesArchive([FeatureDim("a", 0, 1)], bins_per_dim=4)
+    with pytest.raises(ValueError, match="behavior length"):
+        arc.cell_for([0.5, 0.5])
+
+
+def test_archive_add_accepts_first():
+    arc = MapElitesArchive([FeatureDim("a", 0, 1)], bins_per_dim=4)
+    assert arc.add({"x": 1}, fitness=0.5, behavior=[0.5]) is True
+    assert len(arc.archive) == 1
+
+
+def test_archive_add_replaces_when_better():
+    arc = MapElitesArchive([FeatureDim("a", 0, 1)], bins_per_dim=4)
+    arc.add({"x": 1}, 0.5, [0.5])
+    assert arc.add({"x": 2}, 0.7, [0.5]) is True
+    assert arc.archive[(2,)].solution == {"x": 2}
+    assert arc.archive[(2,)].fitness == 0.7
+
+
+def test_archive_add_rejects_when_worse_or_equal():
+    arc = MapElitesArchive([FeatureDim("a", 0, 1)], bins_per_dim=4)
+    arc.add({"x": 1}, 0.5, [0.5])
+    assert arc.add({"x": 2}, 0.3, [0.5]) is False
+    assert arc.add({"x": 3}, 0.5, [0.5]) is False  # equal → reject (strict >)
+    assert arc.archive[(2,)].solution == {"x": 1}
+
+
+def test_archive_coverage_empty():
+    arc = MapElitesArchive([FeatureDim("a", 0, 1)], bins_per_dim=4)
+    assert arc.coverage() == 0.0
+
+
+def test_archive_coverage_full():
+    arc = MapElitesArchive([FeatureDim("a", 0, 1)], bins_per_dim=4)
+    for v in [0.1, 0.3, 0.6, 0.9]:
+        arc.add({"x": v}, 0.5, [v])
+    assert arc.coverage() == 1.0
+
+
+def test_archive_stats_empty():
+    arc = MapElitesArchive([FeatureDim("a", 0, 1)], bins_per_dim=4)
+    s = arc.stats()
+    assert s["count"] == 0
+    assert s["fitness_max"] is None
+    assert s["coverage"] == 0.0
+
+
+def test_archive_stats_populated():
+    arc = MapElitesArchive([FeatureDim("a", 0, 1)], bins_per_dim=4)
+    arc.add({"x": 1}, 0.3, [0.1])
+    arc.add({"x": 2}, 0.7, [0.5])
+    s = arc.stats()
+    assert s["count"] == 2
+    assert s["fitness_max"] == 0.7
+    assert s["fitness_min"] == 0.3
+    assert s["fitness_avg"] == 0.5
+
+
+# ─────────────────────────────────────────────────────────
+# run_map_elites
+# ─────────────────────────────────────────────────────────
+
+
+def test_run_map_elites_basic():
+    rng = random.Random(0)
+    initial = [build_random_solution(rng) for _ in range(5)]
+    archive, history = run_map_elites(
+        initial_solutions=initial,
+        mutator=mutate_build,
+        evaluator=synthetic_fitness,
+        feature_dims=BALANCE_FEATURE_DIMS,
+        bins_per_dim=4,
+        iterations=100,
+        seed=42,
+    )
+    assert archive.total_cells() == 64  # 4^3
+    assert len(history) == 100
+    assert all("iter" in h and "fitness" in h and "accepted" in h for h in history)
+
+
+def test_run_map_elites_deterministic_with_seed():
+    rng = random.Random(0)
+    initial = [build_random_solution(rng) for _ in range(5)]
+    a1, _ = run_map_elites(initial, mutate_build, synthetic_fitness, BALANCE_FEATURE_DIMS, 4, 50, seed=7)
+    a2, _ = run_map_elites(initial, mutate_build, synthetic_fitness, BALANCE_FEATURE_DIMS, 4, 50, seed=7)
+    assert a1.stats() == a2.stats()
+    # Same cell keys, same fitness per cell.
+    assert set(a1.archive.keys()) == set(a2.archive.keys())
+    for k in a1.archive:
+        assert a1.archive[k].fitness == a2.archive[k].fitness
+
+
+def test_run_map_elites_zero_iterations_only_seeds():
+    rng = random.Random(0)
+    initial = [build_random_solution(rng) for _ in range(5)]
+    archive, history = run_map_elites(
+        initial, mutate_build, synthetic_fitness, BALANCE_FEATURE_DIMS, 4, iterations=0, seed=1
+    )
+    assert history == []
+    assert len(archive.archive) > 0  # seeds populated
+
+
+def test_run_map_elites_negative_iterations_raises():
+    with pytest.raises(ValueError, match="iterations"):
+        run_map_elites([], mutate_build, synthetic_fitness, BALANCE_FEATURE_DIMS, 4, -1)
+
+
+def test_run_map_elites_no_seeds_no_evolution():
+    """Empty initial pool → can't evolve (nothing to mutate)."""
+    archive, history = run_map_elites(
+        initial_solutions=[],
+        mutator=mutate_build,
+        evaluator=synthetic_fitness,
+        feature_dims=BALANCE_FEATURE_DIMS,
+        bins_per_dim=4,
+        iterations=10,
+        seed=1,
+    )
+    assert history == []
+    assert len(archive.archive) == 0
+
+
+def test_run_map_elites_coverage_grows_with_iterations():
+    """More iterations → broader coverage (in expectation)."""
+    rng = random.Random(0)
+    initial = [build_random_solution(rng) for _ in range(5)]
+    a_short, _ = run_map_elites(initial, mutate_build, synthetic_fitness, BALANCE_FEATURE_DIMS, 4, 20, seed=1)
+    a_long, _ = run_map_elites(initial, mutate_build, synthetic_fitness, BALANCE_FEATURE_DIMS, 4, 500, seed=1)
+    assert a_long.coverage() >= a_short.coverage()
+
+
+# ─────────────────────────────────────────────────────────
+# Balance helpers
+# ─────────────────────────────────────────────────────────
+
+
+def test_archetypes_index_consistent():
+    assert tuple(ARCHETYPES) == tuple(ARCHETYPE_INDEX.keys())
+    for i, a in enumerate(ARCHETYPES):
+        assert ARCHETYPE_INDEX[a] == i
+
+
+def test_build_random_solution_shape():
+    rng = random.Random(0)
+    sol = build_random_solution(rng)
+    assert "hp" in sol and 8 <= sol["hp"] <= 16
+    assert "mod" in sol and 1 <= sol["mod"] <= 5
+    assert "dc" in sol and 10 <= sol["dc"] <= 16
+    assert 0 <= sol["mbti_t"] <= 1
+    assert 0 <= sol["mbti_n"] <= 1
+    assert sol["archetype"] in ARCHETYPES
+
+
+def test_build_random_solution_deterministic():
+    s1 = build_random_solution(random.Random(7))
+    s2 = build_random_solution(random.Random(7))
+    assert s1 == s2
+
+
+def test_mutate_build_respects_bounds():
+    rng = random.Random(0)
+    sol = {"hp": 16, "mod": 5, "dc": 16, "mbti_t": 1.0, "mbti_n": 1.0, "archetype": "tank"}
+    for seed in range(50):
+        new = mutate_build(sol, random.Random(seed), rate=1.0)
+        assert 8 <= new["hp"] <= 16
+        assert 1 <= new["mod"] <= 5
+        assert 10 <= new["dc"] <= 16
+        assert 0 <= new["mbti_t"] <= 1
+        assert 0 <= new["mbti_n"] <= 1
+        assert new["archetype"] in ARCHETYPES
+
+
+def test_mutate_build_preserves_unmodified_fields():
+    rng = random.Random(0)
+    sol = {"hp": 12, "mod": 3, "dc": 13, "mbti_t": 0.5, "mbti_n": 0.5, "archetype": "tank"}
+    # rate=0 → no mutation → same dict
+    new = mutate_build(sol, rng, rate=0.0)
+    assert new == sol
+
+
+def test_synthetic_fitness_at_ideal():
+    """Ideal build (hp=12, mod=3, dc=13) → fitness 1.0."""
+    sol = {"hp": 12, "mod": 3, "dc": 13, "mbti_t": 0.5, "mbti_n": 0.5, "archetype": "tank"}
+    f, b = synthetic_fitness(sol)
+    assert f == pytest.approx(1.0)
+    assert b == (0.5, 0.5, 0.0)
+
+
+def test_synthetic_fitness_far_from_ideal_lower():
+    sol_ideal = {"hp": 12, "mod": 3, "dc": 13, "mbti_t": 0.5, "mbti_n": 0.5, "archetype": "tank"}
+    sol_off = {"hp": 8, "mod": 1, "dc": 16, "mbti_t": 0.5, "mbti_n": 0.5, "archetype": "tank"}
+    f_ideal, _ = synthetic_fitness(sol_ideal)
+    f_off, _ = synthetic_fitness(sol_off)
+    assert f_off < f_ideal
+
+
+def test_synthetic_fitness_clamped_non_negative():
+    """Worst-case build → fitness >= 0 (clamped)."""
+    sol = {"hp": 8, "mod": 5, "dc": 16, "mbti_t": 0.5, "mbti_n": 0.5, "archetype": "tank"}
+    f, _ = synthetic_fitness(sol)
+    assert f >= 0
+
+
+def test_synthetic_fitness_behavior_archetype_normalized():
+    """Behavior 3rd dim ∈ [0, 1] across all archetypes."""
+    for arch in ARCHETYPES:
+        sol = {"hp": 12, "mod": 3, "dc": 13, "mbti_t": 0.5, "mbti_n": 0.5, "archetype": arch}
+        _, b = synthetic_fitness(sol)
+        assert 0 <= b[2] <= 1
+
+
+# ─────────────────────────────────────────────────────────
+# Markdown + JSON output
+# ─────────────────────────────────────────────────────────
+
+
+def test_archive_to_dict_shape():
+    rng = random.Random(0)
+    initial = [build_random_solution(rng) for _ in range(3)]
+    archive, _ = run_map_elites(initial, mutate_build, synthetic_fitness, BALANCE_FEATURE_DIMS, 4, 10, seed=1)
+    d = archive_to_dict(archive)
+    assert "dims" in d and len(d["dims"]) == 3
+    assert "bins" in d and d["bins"] == 4
+    assert "stats" in d and "count" in d["stats"]
+    assert "cells" in d and isinstance(d["cells"], list)
+
+
+def test_format_markdown_smoke():
+    rng = random.Random(0)
+    initial = [build_random_solution(rng) for _ in range(5)]
+    archive, history = run_map_elites(
+        initial, mutate_build, synthetic_fitness, BALANCE_FEATURE_DIMS, 4, 100, seed=1
+    )
+    md = format_markdown(archive, history, iterations=100)
+    assert md.startswith("---\n")
+    assert "doc_owner: claude-code" in md
+    assert "MAP-Elites Balance Archive" in md
+    assert "## Run config" in md
+    assert "## Archive stats" in md
+    assert "## Top 10 elites" in md
+    assert "## Convergence trajectory" in md
+    assert "## Sources" in md
+    assert "Mouret" in md
+
+
+def test_format_markdown_empty_archive():
+    """Empty archive → markdown still well-formed (no crashes on None stats)."""
+    archive = MapElitesArchive(BALANCE_FEATURE_DIMS, bins_per_dim=4)
+    md = format_markdown(archive, history=[], iterations=0)
+    assert md.startswith("---\n")
+    assert "Cells filled: **0**" in md
+
+
+# ─────────────────────────────────────────────────────────
+# Constants contract
+# ─────────────────────────────────────────────────────────
+
+
+def test_balance_feature_dims_normalized():
+    """All balance dims should be in [0, 1] for stability with synthetic fitness."""
+    for d in BALANCE_FEATURE_DIMS:
+        assert d.low == 0.0
+        assert d.high == 1.0
+
+
+def test_archetypes_count():
+    assert len(ARCHETYPES) == 3

--- a/tools/py/map_elites.py
+++ b/tools/py/map_elites.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python3
+"""MAP-Elites lightweight — Quality-Diversity archive for balance illumination.
+
+Closes balance-illuminator P1 — MAP-Elites lightweight implementation
+(~6h estimate). Pattern: Mouret & Clune 2015, applied to balance per
+Fontaine et al. 2019 (Hearthstone deck illumination).
+
+Where SPRT (PR #1758) decides "is build A in band X-Y?", MAP-Elites
+asks the broader question: "WHICH builds are viable, and where do they
+sit in the design space?". Surfaces exploits + boring optima
+simultaneously, by design.
+
+Generic engine + concrete balance use case in the same module:
+- `MapElitesArchive`: behaviour-space → best-fitness solution mapping
+- `run_map_elites`: evolution loop (random elite → mutate → evaluate)
+- Balance helpers: `build_random_solution`, `mutate_build`, `synthetic_fitness`
+
+Mock fitness for unit tests + CLI smoke; HTTP integration via
+`restricted_play.run_one` documented (deferred to next PR).
+
+## Usage
+
+    # Synthetic (CI-safe, no backend)
+    PYTHONPATH=. python3 tools/py/map_elites.py \\
+        --iterations 1000 --bins 4 --seed 42 \\
+        --out-md docs/balance/2026-04-25-map-elites-archive.md
+
+## Non-goals
+
+- Live HTTP fitness via run_one (~+2h, separate PR for clarity)
+- CMA-ME / CMA-MEGA gradient variants (Fontaine 2020+)
+- Multi-objective fitness (Pareto MAP-Elites)
+
+## References
+
+- Mouret & Clune 2015 — "Illuminating search spaces by mapping elites"
+  https://arxiv.org/abs/1504.04909
+- Fontaine et al. 2019 — "Mapping Hearthstone Deck Spaces" (FDG)
+  https://arxiv.org/abs/1904.10656
+- Cully 2021 survey — "Quality-Diversity Optimization"
+  https://arxiv.org/abs/2012.04322
+- Agent: .claude/agents/balance-illuminator.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import statistics
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Sequence
+
+
+# ─────────────────────────────────────────────────────────
+# Generic MAP-Elites archive
+# ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class FeatureDim:
+    """One axis of the behaviour space."""
+
+    name: str
+    low: float
+    high: float
+
+
+@dataclass
+class Cell:
+    solution: dict
+    fitness: float
+    behavior: tuple[float, ...]
+
+
+class MapElitesArchive:
+    """Behaviour-space grid storing the best-fitness solution per cell.
+
+    Behaviour vectors are bucketed into `bins_per_dim ** len(feature_dims)`
+    cells. `add()` returns True iff the new solution is accepted (cell empty
+    or strictly higher fitness than the current elite).
+    """
+
+    def __init__(self, feature_dims: Sequence[FeatureDim], bins_per_dim: int):
+        if not feature_dims:
+            raise ValueError("feature_dims must be non-empty")
+        if bins_per_dim < 1:
+            raise ValueError("bins_per_dim must be >= 1")
+        for d in feature_dims:
+            if d.low >= d.high:
+                raise ValueError(f"dim {d.name}: low ({d.low}) must be < high ({d.high})")
+        self.dims = list(feature_dims)
+        self.bins = bins_per_dim
+        self.archive: dict[tuple[int, ...], Cell] = {}
+
+    def total_cells(self) -> int:
+        return self.bins ** len(self.dims)
+
+    def cell_for(self, behavior: Sequence[float]) -> tuple[int, ...]:
+        if len(behavior) != len(self.dims):
+            raise ValueError(
+                f"behavior length {len(behavior)} != dims {len(self.dims)}"
+            )
+        idx = []
+        for value, dim in zip(behavior, self.dims):
+            clamped = max(dim.low, min(dim.high, float(value)))
+            normalized = (clamped - dim.low) / (dim.high - dim.low)
+            bin_i = int(normalized * self.bins)
+            if bin_i >= self.bins:
+                bin_i = self.bins - 1
+            idx.append(bin_i)
+        return tuple(idx)
+
+    def add(self, solution: dict, fitness: float, behavior: Sequence[float]) -> bool:
+        cell = self.cell_for(behavior)
+        existing = self.archive.get(cell)
+        if existing is None or existing.fitness < fitness:
+            self.archive[cell] = Cell(
+                solution=dict(solution),
+                fitness=float(fitness),
+                behavior=tuple(behavior),
+            )
+            return True
+        return False
+
+    def coverage(self) -> float:
+        return len(self.archive) / self.total_cells()
+
+    def stats(self) -> dict:
+        if not self.archive:
+            return {
+                "count": 0,
+                "total_cells": self.total_cells(),
+                "coverage": 0.0,
+                "fitness_max": None,
+                "fitness_avg": None,
+                "fitness_min": None,
+            }
+        fits = [c.fitness for c in self.archive.values()]
+        return {
+            "count": len(self.archive),
+            "total_cells": self.total_cells(),
+            "coverage": round(self.coverage(), 4),
+            "fitness_max": round(max(fits), 4),
+            "fitness_avg": round(statistics.mean(fits), 4),
+            "fitness_min": round(min(fits), 4),
+        }
+
+
+# ─────────────────────────────────────────────────────────
+# Evolution loop
+# ─────────────────────────────────────────────────────────
+
+
+def run_map_elites(
+    initial_solutions: list[dict],
+    mutator: Callable[[dict, random.Random], dict],
+    evaluator: Callable[[dict], tuple[float, Sequence[float]]],
+    feature_dims: Sequence[FeatureDim],
+    bins_per_dim: int,
+    iterations: int,
+    seed: int = 1000,
+) -> tuple[MapElitesArchive, list[dict]]:
+    """Run MAP-Elites: seed → evolve.
+
+    Returns (archive, history) where history[i] = {iter, fitness, accepted, coverage}.
+    """
+    if iterations < 0:
+        raise ValueError("iterations must be >= 0")
+    rng = random.Random(seed)
+    archive = MapElitesArchive(feature_dims, bins_per_dim)
+
+    # Seed phase: evaluate initial solutions.
+    for sol in initial_solutions:
+        f, b = evaluator(sol)
+        archive.add(sol, f, b)
+
+    history: list[dict] = []
+    for i in range(iterations):
+        if not archive.archive:
+            # No seed survived → can't evolve.
+            break
+        cell_keys = list(archive.archive.keys())
+        elite_cell = cell_keys[rng.randrange(len(cell_keys))]
+        elite = archive.archive[elite_cell]
+        new_sol = mutator(elite.solution, rng)
+        f, b = evaluator(new_sol)
+        accepted = archive.add(new_sol, f, b)
+        history.append(
+            {
+                "iter": i + 1,
+                "fitness": round(f, 4),
+                "accepted": accepted,
+                "coverage": round(archive.coverage(), 4),
+            }
+        )
+
+    return archive, history
+
+
+# ─────────────────────────────────────────────────────────
+# Balance-specific helpers (concrete use case)
+# ─────────────────────────────────────────────────────────
+
+
+ARCHETYPES = ("tank", "skirmisher", "support")
+ARCHETYPE_INDEX = {a: i for i, a in enumerate(ARCHETYPES)}
+
+
+def build_random_solution(rng: random.Random) -> dict:
+    """Random tactical-build solution for the balance use case."""
+    return {
+        "hp": rng.randint(8, 16),
+        "mod": rng.randint(1, 5),
+        "dc": rng.randint(10, 16),
+        "mbti_t": round(rng.random(), 3),
+        "mbti_n": round(rng.random(), 3),
+        "archetype": rng.choice(ARCHETYPES),
+    }
+
+
+def mutate_build(sol: dict, rng: random.Random, rate: float = 0.3) -> dict:
+    """Per-field mutation with probability `rate`. Bounded to schema."""
+    new = dict(sol)
+    if rng.random() < rate:
+        new["hp"] = max(8, min(16, int(new["hp"]) + rng.choice([-1, 1])))
+    if rng.random() < rate:
+        new["mod"] = max(1, min(5, int(new["mod"]) + rng.choice([-1, 1])))
+    if rng.random() < rate:
+        new["dc"] = max(10, min(16, int(new["dc"]) + rng.choice([-1, 1])))
+    if rng.random() < rate:
+        new["mbti_t"] = round(max(0.0, min(1.0, float(new["mbti_t"]) + rng.uniform(-0.2, 0.2))), 3)
+    if rng.random() < rate:
+        new["mbti_n"] = round(max(0.0, min(1.0, float(new["mbti_n"]) + rng.uniform(-0.2, 0.2))), 3)
+    if rng.random() < rate:
+        new["archetype"] = rng.choice(ARCHETYPES)
+    return new
+
+
+def synthetic_fitness(sol: dict) -> tuple[float, tuple[float, float, float]]:
+    """Mock fitness for CI-safe testing + initial illumination.
+
+    Higher fitness when build is closer to "ideal balance" baseline:
+    - hp ~ 12, mod ~ 3, dc ~ 13.
+    Behaviour vector = (mbti_t, mbti_n, archetype_index/2 ∈ [0, 1]).
+
+    Replace with real run_one(...) HTTP fitness for production use.
+    """
+    ideal_hp, ideal_mod, ideal_dc = 12, 3, 13
+    hp_err = abs(int(sol["hp"]) - ideal_hp) / 8
+    mod_err = abs(int(sol["mod"]) - ideal_mod) / 4
+    dc_err = abs(int(sol["dc"]) - ideal_dc) / 6
+    fitness = max(0.0, 1.0 - (hp_err + mod_err + dc_err) / 3)
+    behavior = (
+        float(sol["mbti_t"]),
+        float(sol["mbti_n"]),
+        ARCHETYPE_INDEX[sol["archetype"]] / max(1, len(ARCHETYPES) - 1),
+    )
+    return fitness, behavior
+
+
+BALANCE_FEATURE_DIMS = [
+    FeatureDim("mbti_t", 0.0, 1.0),
+    FeatureDim("mbti_n", 0.0, 1.0),
+    FeatureDim("archetype_idx", 0.0, 1.0),
+]
+
+
+# ─────────────────────────────────────────────────────────
+# Markdown report
+# ─────────────────────────────────────────────────────────
+
+
+def format_markdown(archive: MapElitesArchive, history: list[dict], iterations: int) -> str:
+    today = datetime.now().date().isoformat()
+    stats = archive.stats()
+    lines: list[str] = []
+    lines.append("---")
+    lines.append(f"title: MAP-Elites Balance Archive ({today})")
+    lines.append("doc_status: active")
+    lines.append("doc_owner: claude-code")
+    lines.append("workstream: dataset-pack")
+    lines.append(f"last_verified: '{today}'")
+    lines.append("source_of_truth: false")
+    lines.append("language: it")
+    lines.append("review_cycle_days: 30")
+    lines.append("tags:")
+    lines.append("  - balance")
+    lines.append("  - map-elites")
+    lines.append("  - quality-diversity")
+    lines.append("  - generated")
+    lines.append("---")
+    lines.append("")
+    lines.append("# MAP-Elites Balance Archive")
+    lines.append("")
+    lines.append(
+        "Quality-Diversity illumination of the build design space. Closes "
+        "[balance-illuminator P1](.claude/agents/balance-illuminator.md). "
+        "Pattern: Mouret & Clune 2015 + Fontaine 2019 (FDG)."
+    )
+    lines.append("")
+    lines.append("## Run config")
+    lines.append("")
+    lines.append(f"- Iterations: **{iterations}**")
+    lines.append(f"- Feature dims: {[d.name for d in archive.dims]}")
+    lines.append(f"- Bins per dim: **{archive.bins}** (total cells: {archive.total_cells()})")
+    lines.append(f"- Fitness: synthetic (mock — production should wire `restricted_play.run_one`)")
+    lines.append("")
+    lines.append("## Archive stats")
+    lines.append("")
+    lines.append(f"- Cells filled: **{stats['count']}** / {stats['total_cells']}")
+    lines.append(f"- Coverage: **{stats['coverage'] * 100:.1f}%**")
+    if stats["fitness_max"] is not None:
+        lines.append(f"- Fitness max: {stats['fitness_max']:.4f}")
+        lines.append(f"- Fitness avg: {stats['fitness_avg']:.4f}")
+        lines.append(f"- Fitness min: {stats['fitness_min']:.4f}")
+    lines.append("")
+    lines.append("## Top 10 elites")
+    lines.append("")
+    lines.append("| Cell | Fitness | hp | mod | dc | mbti_t | mbti_n | archetype |")
+    lines.append("| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |")
+    cells_sorted = sorted(
+        archive.archive.items(), key=lambda kv: -kv[1].fitness
+    )[:10]
+    for cell_idx, cell in cells_sorted:
+        s = cell.solution
+        lines.append(
+            f"| {cell_idx} | {cell.fitness:.4f} | "
+            f"{s.get('hp')} | {s.get('mod')} | {s.get('dc')} | "
+            f"{s.get('mbti_t')} | {s.get('mbti_n')} | `{s.get('archetype')}` |"
+        )
+    lines.append("")
+    lines.append("## Convergence trajectory")
+    lines.append("")
+    lines.append("| Iter | Fitness | Accepted | Coverage |")
+    lines.append("| ---: | ---: | :---: | ---: |")
+    sample_steps = [0, len(history) // 4, len(history) // 2, 3 * len(history) // 4, len(history) - 1]
+    sample_steps = [s for s in sample_steps if 0 <= s < len(history)]
+    for s in sample_steps:
+        h = history[s]
+        lines.append(
+            f"| {h['iter']} | {h['fitness']:.4f} | "
+            f"{'✅' if h['accepted'] else '—'} | {h['coverage'] * 100:.1f}% |"
+        )
+    lines.append("")
+    lines.append("## How to read")
+    lines.append("")
+    lines.append(
+        "- **Coverage** = breadth of viable design space discovered. Low (<30%)"
+        " means the engine struggled to find diverse builds; high (>70%) means"
+        " the design space is broad and the fitness function permissive."
+    )
+    lines.append(
+        "- **Fitness max** = single best build found. Compare to fitness avg:"
+        " large gap = some cells dominate, small gap = uniform competence."
+    )
+    lines.append(
+        "- **Convergence trajectory** = acceptance rate over iterations. Drops"
+        " naturally as the archive fills (most mutations no longer beat the elite)."
+    )
+    lines.append("")
+    lines.append("## Limits + next steps")
+    lines.append("")
+    lines.append(
+        "- **Synthetic fitness only**: replace `synthetic_fitness` with a wrapper"
+        " around `restricted_play.run_one` to evaluate against the real combat"
+        " engine (~+2h, separate PR). Until then, this is design-space sketching,"
+        " not balance verdict."
+    )
+    lines.append(
+        "- **Single-objective**: extend to Pareto MAP-Elites (Cully 2021) to"
+        " trade off fitness vs diversity vs novelty."
+    )
+    lines.append(
+        "- **Variance**: re-run with multiple seeds and aggregate coverage to"
+        " distinguish algorithm-stable patterns from RNG luck."
+    )
+    lines.append("")
+    lines.append("## Sources")
+    lines.append("")
+    lines.append(
+        "- [Mouret & Clune 2015 — Illuminating search spaces](https://arxiv.org/abs/1504.04909)"
+    )
+    lines.append(
+        "- [Fontaine et al. 2019 — Mapping Hearthstone Deck Spaces](https://arxiv.org/abs/1904.10656)"
+    )
+    lines.append(
+        "- [Cully 2021 — Quality-Diversity Optimization survey](https://arxiv.org/abs/2012.04322)"
+    )
+    lines.append("- Agent: `.claude/agents/balance-illuminator.md`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ─────────────────────────────────────────────────────────
+# CLI
+# ─────────────────────────────────────────────────────────
+
+
+def archive_to_dict(archive: MapElitesArchive) -> dict:
+    return {
+        "dims": [{"name": d.name, "low": d.low, "high": d.high} for d in archive.dims],
+        "bins": archive.bins,
+        "stats": archive.stats(),
+        "cells": [
+            {
+                "cell": list(idx),
+                "fitness": cell.fitness,
+                "behavior": list(cell.behavior),
+                "solution": cell.solution,
+            }
+            for idx, cell in archive.archive.items()
+        ],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--iterations", type=int, default=1000)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--bins", type=int, default=4, help="Bins per feature dim")
+    parser.add_argument("--initial", type=int, default=10, help="Initial random solutions")
+    parser.add_argument("--out-md", default=None)
+    parser.add_argument("--out-json", default=None)
+    args = parser.parse_args(argv)
+
+    rng = random.Random(args.seed)
+    initial_solutions = [build_random_solution(rng) for _ in range(args.initial)]
+
+    print(
+        f"MAP-Elites: iterations={args.iterations} bins={args.bins} "
+        f"seed={args.seed} initial={args.initial}"
+    )
+    archive, history = run_map_elites(
+        initial_solutions=initial_solutions,
+        mutator=mutate_build,
+        evaluator=synthetic_fitness,
+        feature_dims=BALANCE_FEATURE_DIMS,
+        bins_per_dim=args.bins,
+        iterations=args.iterations,
+        seed=args.seed,
+    )
+
+    stats = archive.stats()
+    print(
+        f"  cells={stats['count']}/{stats['total_cells']} "
+        f"coverage={stats['coverage'] * 100:.1f}% "
+        f"fitness max={stats['fitness_max']} avg={stats['fitness_avg']}"
+    )
+
+    if args.out_md:
+        out_path = Path(args.out_md)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(format_markdown(archive, history, args.iterations), encoding="utf-8")
+        print(f"Markdown saved: {out_path}")
+
+    if args.out_json:
+        out_path = Path(args.out_json)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(archive_to_dict(archive), indent=2), encoding="utf-8")
+        print(f"JSON saved: {out_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes [`balance-illuminator`](.claude/agents/balance-illuminator.md) P1 — MAP-Elites lightweight implementation (~6h estimate). Pattern: Mouret & Clune 2015 + Fontaine et al. 2019 (Hearthstone deck illumination, FDG).

Pure stdlib, zero new deps. 36 pytest verde, AI 307/307 preserved.

## Why MAP-Elites in addition to SPRT?

| Tool | Question answered |
| --- | --- |
| SPRT (PR #1758) | "Is build A in target win-rate band X-Y?" — point estimate |
| MAP-Elites (this PR) | "WHICH builds are viable, and where do they sit in the design space?" — illumination |

By design surfaces exploits + boring optima simultaneously (Quality-Diversity, not single-objective optimization).

## Module: `tools/py/map_elites.py`

**Generic primitives** (reusable for any QD problem):

| API | Purpose |
| --- | --- |
| `FeatureDim(name, low, high)` | one named axis of behaviour space |
| `MapElitesArchive(dims, bins_per_dim)` | grid of elites with `cell_for`, `add`, `coverage`, `stats` |
| `run_map_elites(initial, mutator, evaluator, dims, bins, iterations, seed)` | evolution loop |

**Balance use case helpers** (concrete):

- `ARCHETYPES = (tank, skirmisher, support)`
- `BALANCE_FEATURE_DIMS = mbti_t × mbti_n × archetype_idx` (3D, normalized 0..1)
- `build_random_solution` / `mutate_build` / `synthetic_fitness`

**Synthetic fitness** (CI-safe mock):

```
f = 1 - normalized_distance_from_ideal(hp=12, mod=3, dc=13)
behavior = (mbti_t, mbti_n, archetype_idx / 2)
```

Real fitness via `restricted_play.run_one` HTTP wrapper deferred to follow-up PR (~+2h).

## Sample run (N=1500 iter, 5 bins/dim, seed=42)

```
cells=75/125 coverage=60.0% fitness max=1.0 avg=0.985
```

Doc generato include:

- Top 10 elites sorted by fitness
- Convergence trajectory (5 sample iterations: start, 25%, 50%, 75%, end)
- "How to read" section (coverage / fitness gap / convergence interpretation)
- Limits & next steps (synthetic only / single-objective / variance considerations)

## CLI

```bash
PYTHONPATH=. python3 tools/py/map_elites.py \
    --iterations 1500 --bins 5 --seed 42 --initial 20 \
    --out-md docs/balance/2026-04-25-map-elites-archive.md \
    --out-json reports/balance/map-elites-archive.json
```

## Test plan

- [x] `pytest tests/scripts/test_map_elites.py -v` → 36/36 ✅
- [x] `node --test tests/ai/*.test.js` → 307/307 ✅
- [x] `npm run format:check` → ✅
- [x] `python tools/check_docs_governance.py --strict` → 0 errors, 0 warnings ✅
- [x] Real run N=1500 produces non-trivial coverage (60%) ✅

## Files

- **NEW** `tools/py/map_elites.py` (~340 LOC) — generic engine + balance helpers
- **NEW** `tests/scripts/test_map_elites.py` (36 pytest)
- **NEW** `docs/balance/2026-04-25-map-elites-archive.md` (auto-gen report)
- **NEW** `reports/balance/map-elites-archive.json` (JSON dump)
- **EDIT** `docs/governance/docs_registry.json` (entry per nuovo report)

## Sources

- [Mouret & Clune 2015 — Illuminating search spaces by mapping elites](https://arxiv.org/abs/1504.04909)
- [Fontaine et al. 2019 — Mapping Hearthstone Deck Spaces (FDG)](https://arxiv.org/abs/1904.10656)
- [Cully 2021 — Quality-Diversity Optimization survey](https://arxiv.org/abs/2012.04322)
- Agent: `.claude/agents/balance-illuminator.md`

## Future work (deferred)

- HTTP fitness wrapping `restricted_play.run_one` (~+2h, separate PR) — turns this from "design-space sketching" into "real balance verdict"
- CMA-ME / CMA-MEGA gradient variants (Fontaine 2020+) for faster convergence
- Pareto MAP-Elites for multi-objective fitness (Cully 2021)

🤖 Generated with [Claude Code](https://claude.com/claude-code)