### PR TITLE
docs(handoff): bump for 7th P0 closure (MAP-Elites #1765)

### DIFF
--- a/COMPACT_CONTEXT.md
+++ b/COMPACT_CONTEXT.md
@@ -17,7 +17,7 @@
 
 ## 🆕 Sessione 2026-04-25 notte (autonoma post user trust)
 
-**5 PR mergiati main consecutivi** (#1758 → #1763, ~5h work in 1.5h cycle ciascuno):
+**7 PR mergiati main consecutivi** (#1758 → #1765, ~7h work in 1.5h cycle ciascuno):
 
 | PR    | Title                                               | SHA        |
 | ----- | --------------------------------------------------- | ---------- |
@@ -26,12 +26,14 @@
 | #1760 | Tutorial briefing variations (~30 variants)         | `6f397e6d` |
 | #1762 | Encounter XP budget audit (Pathfinder framework)    | `9901407e` |
 | #1763 | QBN engine MBTI-gated events (12 events + 3 routes) | `bec2bcd6` |
+| #1764 | Handoff doc update (continuity per next session)    | `15ca7425` |
+| #1765 | MAP-Elites lightweight QD archive (Mouret 2015)     | `b22fc2b7` |
 
-**Tests aggregate post-merge**: AI 307/307 + services 257/257 + pytest 348/348 + governance 0/0.
+**Tests aggregate post-merge**: AI 307/307 + services 257/257 + pytest **384/384** (+36 MAP-Elites) + governance 0/0.
 
-**P0 chiusi**: balance SPRT, economy Machinations diagram, economy PI Monte Carlo, narrative briefing variations, narrative QBN, pcg XP audit + bonus governance bug fix.
+**7 P0 chiusi**: balance SPRT, economy Machinations diagram, economy PI Monte Carlo, narrative briefing variations, narrative QBN, pcg XP audit, balance MAP-Elites + bonus governance bug fix.
 
-**P0 residuali rimanenti**: balance MCTS (~4h), balance MAP-Elites (~6h), ui intent preview (~4h, UI runtime risk), ui threat zone toggle (~3h, UI), pcg objective variety (~8h), narrative Disco Elysium thought cabinet (~6h).
+**P0 residuali rimanenti**: balance MCTS (~4h, needs session state clone API), ui intent preview (~4h, UI runtime risk), ui threat zone toggle (~3h, UI), pcg objective variety (~8h), narrative Disco Elysium thought cabinet (~6h).
 
 ## Stato attuale (post sessione 2026-04-24/25 notte)
 

--- a/docs/planning/2026-04-25-illuminator-orchestra-handoff.md
+++ b/docs/planning/2026-04-25-illuminator-orchestra-handoff.md
@@ -133,7 +133,7 @@ Use ONLY if dominio non coperto da agenti esistenti.
 
 ### P0 residuali agent esistenti (post 2026-04-25 sessione autonoma)
 
-**Closed in main** (sessione 2026-04-25 notte, 5 PR mergiati):
+**Closed in main** (sessione 2026-04-25 notte, 7 PR mergiati):
 
 | Agent                        | P0                                           | Effort | PR    | SHA        |
 | ---------------------------- | -------------------------------------------- | :----: | ----- | ---------- |
@@ -143,15 +143,16 @@ Use ONLY if dominio non coperto da agenti esistenti.
 | narrative-design-illuminator | Tutorial briefing variations (per-encounter) |  ~4h   | #1760 | `6f397e6d` |
 | pcg-level-design-illuminator | XP budget encounter builder                  |  ~6h   | #1762 | `9901407e` |
 | narrative-design-illuminator | QBN MBTI-gated events (campaign-arc)         |  ~6h   | #1763 | `bec2bcd6` |
+| balance-illuminator          | MAP-Elites lightweight (Mouret 2015)         |  ~6h   | #1765 | `b22fc2b7` |
 
-**Bonus shipped**: `tools/check_docs_governance.py` parser bug fix (5 false-positive warnings) + `docs/hubs/incoming.md` stale review bumped (in PR #1758).
+**Bonus shipped**: `tools/check_docs_governance.py` parser bug fix (5 false-positive warnings) + `docs/hubs/incoming.md` stale review bumped (in PR #1758) + handoff doc continuity update (#1764).
 
 **Still residual**:
 
 | Agent                        | P0 residual                                 | Effort |               Risk               |
 | ---------------------------- | ------------------------------------------- | :----: | :------------------------------: |
 | balance-illuminator          | MCTS smart policy (state clone API)         |  ~4h   | mid (needs session clone helper) |
-| balance-illuminator          | MAP-Elites lightweight implementation       |  ~6h   |      mid (new architecture)      |
+| balance-illuminator          | MAP-Elites HTTP fitness wrapper             |  ~2h   |   low (extends shipped engine)   |
 | ui-design-illuminator        | Intent preview floating-icon wire           |  ~4h   |        high (UI runtime)         |
 | ui-design-illuminator        | Threat zone toggle phone                    |  ~3h   |        high (UI runtime)         |
 | pcg-level-design-illuminator | Objective variety (rescue/timer/extraction) |  ~8h   |       mid (data + engine)        |
@@ -169,8 +170,8 @@ Use ONLY if dominio non coperto da agenti esistenti.
 
 - AI regression `tests/ai/*.test.js` → **307/307 verde**
 - Services `tests/services/*.test.js` → **257/257 verde** (was 177, +80: 39 briefing + 41 QBN)
-- Pytest scripts: **348 totali** (273 pre-existing + 27 SPRT + 24 PI shop + 24 XP budget)
-- New tests aggregate sessione: **104 nuovi** (39+41 services + 24 SPRT + 24 PI shop + 24 XP budget)
+- Pytest scripts: **384 totali** (273 pre-existing + 27 SPRT + 24 PI shop + 24 XP budget + 36 MAP-Elites)
+- New tests aggregate sessione: **140 nuovi** (39+41 services + 27+24+24+36 pytest)
 - Format check: verde
 - Governance strict: **0 errors / 0 warnings** (parser bug fix + stale incoming bump in #1758)
 


### PR DESCRIPTION
## Summary

Reflects PR [#1765](https://github.com/MasterDD-L34D/Game/pull/1765) (MAP-Elites lightweight balance illumination) merged into main. Updates session count 5 → 7 PRs, test totals (pytest 348 → 384), and moves MAP-Elites from "still residual" to "closed" table.

Adds new "still residual" entry: MAP-Elites HTTP fitness wrapper (~2h, low risk — extends shipped engine via `restricted_play.run_one`).

## Quality gates

- [x] `npm run format:check` → ✅
- [x] `python tools/check_docs_governance.py --strict` → 0 errors, 0 warnings ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)