### PR TITLE
fix(tests): skip test_investigate_sources if pypdf missing

### DIFF
--- a/tests/test_investigate_sources.py
+++ b/tests/test_investigate_sources.py
@@ -8,7 +8,10 @@ import sys
 import zipfile
 from pathlib import Path
 
-from pypdf import PdfWriter
+import pytest
+
+pypdf = pytest.importorskip("pypdf", reason="pypdf non installato; vedi tools/py/requirements.txt")
+PdfWriter = pypdf.PdfWriter
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 TOOLS_PY = PROJECT_ROOT / "tools" / "py"


### PR DESCRIPTION
## Summary
- `tests/test_investigate_sources.py:11` hard-imports `pypdf` at top of module → pytest **collection** fail on any venv that hasn't installed `tools/py/requirements.txt` (dep listed line 5)
- Align test with the tool it covers (`tools/py/investigate_sources.py:179` already does lazy import + friendly error)
- Swap `from pypdf import PdfWriter` → `pytest.importorskip("pypdf", ...)` pattern
- Unrelated: pre-existing `datetime.utcnow()` DeprecationWarning in `tests/playtests/test_balance_progression.py` + `services/generation/species_builder.py:408` (not fixed here)

## Impact
- CI: unaffected (installs full requirements) → green
- Local pytest `PYTHONPATH=tools/py pytest tests/ --ignore=tests/test_rules_engine.py`:
  - **Before**: collection error, 0 tests run
  - **After**: **936 passed** in 3.63s (previously 935 + this 1 once pypdf installed)

## Test plan
- [x] `pip install pypdf>=4.0.0` local → test runs → 1 passed
- [x] Full pytest suite `PYTHONPATH=tools/py pytest tests/ --ignore=tests/test_rules_engine.py` → 936 passed
- [x] `node --test tests/ai/*.test.js` → 307/307 verdi (regression gate)
- [x] `node --test tests/services/*.test.js` → 257/257 verdi
- [x] `npm run format:check` → verde
- [x] `python tools/check_docs_governance.py --strict` → 0 err / 0 warn
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)