### PR TITLE
feat(balance): MAP-Elites HTTP fitness wrapper (balance-illuminator P0 residual)

### DIFF
--- a/tests/scripts/test_map_elites.py
+++ b/tests/scripts/test_map_elites.py
@@ -16,7 +16,9 @@ from tools.py.map_elites import (  # noqa: E402
     Cell,
     FeatureDim,
     MapElitesArchive,
+    apply_build_to_unit,
     archive_to_dict,
+    build_http_evaluator,
     build_random_solution,
     format_markdown,
     mutate_build,
@@ -346,3 +348,162 @@ def test_balance_feature_dims_normalized():
 
 def test_archetypes_count():
     assert len(ARCHETYPES) == 3
+
+
+# ─────────────────────────────────────────────────────────
+# HTTP fitness wrapper (build_http_evaluator + apply_build_to_unit)
+# ─────────────────────────────────────────────────────────
+
+
+def _sample_build():
+    return {
+        "hp": 14,
+        "mod": 3,
+        "dc": 13,
+        "mbti_t": 0.7,
+        "mbti_n": 0.2,
+        "archetype": "tank",
+    }
+
+
+class _FakeRun:
+    """Minimal stand-in for restricted_play.RunResult."""
+
+    def __init__(self, outcome: str):
+        self.outcome = outcome
+
+
+def test_apply_build_to_unit_overrides_combat_keys():
+    unit = {"id": "u1", "controlled_by": "player", "position": {"x": 1, "y": 2}, "hp": 1}
+    out = apply_build_to_unit(unit, _sample_build())
+    assert out["hp"] == 14
+    assert out["hp_max"] == 14
+    assert out["mod"] == 3
+    assert out["attack_mod"] == 3
+    assert out["dc"] == 13
+    assert out["defense_dc"] == 13
+    assert out["archetype"] == "tank"
+    assert out["mbti"] == {"t": 0.7, "n": 0.2}
+
+
+def test_apply_build_to_unit_preserves_identity_fields():
+    unit = {"id": "u1", "controlled_by": "player", "position": {"x": 1, "y": 2}, "team": "A"}
+    out = apply_build_to_unit(unit, _sample_build())
+    assert out["id"] == "u1"
+    assert out["controlled_by"] == "player"
+    assert out["position"] == {"x": 1, "y": 2}
+    assert out["team"] == "A"
+
+
+def test_apply_build_to_unit_returns_new_dict():
+    unit = {"id": "u1", "hp": 1}
+    out = apply_build_to_unit(unit, _sample_build())
+    assert unit is not out
+    assert unit["hp"] == 1  # source not mutated
+
+
+def test_build_http_evaluator_rejects_invalid_role():
+    with pytest.raises(ValueError, match="role must be"):
+        build_http_evaluator("http://x", "enc", "greedy", n_runs=1, role="nobody")
+
+
+def test_build_http_evaluator_rejects_zero_runs():
+    with pytest.raises(ValueError, match="n_runs"):
+        build_http_evaluator("http://x", "enc", "greedy", n_runs=0)
+
+
+def test_build_http_evaluator_computes_winrate_fitness():
+    """Fitness = (wins / n_runs); 3 victories out of 4 → 0.75."""
+    outcomes = iter(["victory", "victory", "defeat", "victory"])
+    calls = []
+
+    def fake_run_one(host, scenario_id, policy, seed, unit_override=None):
+        calls.append({"host": host, "scenario": scenario_id, "policy": policy, "seed": seed})
+        return _FakeRun(next(outcomes))
+
+    evaluator = build_http_evaluator(
+        host="http://backend",
+        scenario_id="enc_test",
+        policy="greedy",
+        n_runs=4,
+        seed_base=500,
+        run_one_fn=fake_run_one,
+    )
+    fitness, behavior = evaluator(_sample_build())
+    assert fitness == 0.75
+    assert behavior == (0.7, 0.2, ARCHETYPE_INDEX["tank"] / (len(ARCHETYPES) - 1))
+    assert len(calls) == 4
+    assert [c["seed"] for c in calls] == [500, 501, 502, 503]
+    assert all(c["host"] == "http://backend" and c["policy"] == "greedy" for c in calls)
+
+
+def test_build_http_evaluator_override_applies_only_to_matching_role():
+    """Override hook mutates only units with controlled_by == role."""
+    scenario_units = [
+        {"id": "p1", "controlled_by": "player", "hp": 10, "mod": 1, "dc": 10, "archetype": "base"},
+        {"id": "e1", "controlled_by": "sistema", "hp": 5, "mod": 2, "dc": 11, "archetype": "wolf"},
+    ]
+    captured_overrides = []
+
+    def fake_run_one(host, scenario_id, policy, seed, unit_override=None):
+        assert unit_override is not None
+        rewritten = [unit_override(dict(u)) for u in scenario_units]
+        captured_overrides.append(rewritten)
+        return _FakeRun("defeat")
+
+    evaluator = build_http_evaluator(
+        host="http://x", scenario_id="s", policy="greedy", n_runs=1, role="player",
+        run_one_fn=fake_run_one,
+    )
+    fitness, _ = evaluator(_sample_build())
+    assert fitness == 0.0  # no victory
+    player_after, enemy_after = captured_overrides[0]
+    assert player_after["hp"] == 14 and player_after["archetype"] == "tank"
+    assert enemy_after["hp"] == 5 and enemy_after["archetype"] == "wolf"  # untouched
+
+
+def test_build_http_evaluator_role_sistema():
+    """Flip the role to override enemy stats instead of player."""
+    scenario_units = [
+        {"id": "p1", "controlled_by": "player", "hp": 10, "archetype": "base"},
+        {"id": "e1", "controlled_by": "sistema", "hp": 5, "archetype": "wolf"},
+    ]
+    captured = []
+
+    def fake_run_one(host, scenario_id, policy, seed, unit_override=None):
+        captured.append([unit_override(dict(u)) for u in scenario_units])
+        return _FakeRun("victory")
+
+    evaluator = build_http_evaluator(
+        host="http://x", scenario_id="s", policy="greedy", n_runs=2, role="sistema",
+        run_one_fn=fake_run_one,
+    )
+    fitness, _ = evaluator(_sample_build())
+    assert fitness == 1.0  # all victories
+    assert captured[0][0]["hp"] == 10  # player untouched
+    assert captured[0][1]["hp"] == 14 and captured[0][1]["archetype"] == "tank"
+
+
+def test_build_http_evaluator_behavior_vector_stable():
+    """Behavior depends only on solution axes, not on win/loss."""
+
+    def loser(*_a, **_kw):
+        return _FakeRun("defeat")
+
+    def winner(*_a, **_kw):
+        return _FakeRun("victory")
+
+    sol = {"hp": 10, "mod": 2, "dc": 12, "mbti_t": 0.3, "mbti_n": 0.9, "archetype": "skirmisher"}
+    _, b1 = build_http_evaluator("h", "s", "greedy", 1, run_one_fn=loser)(sol)
+    _, b2 = build_http_evaluator("h", "s", "greedy", 1, run_one_fn=winner)(sol)
+    assert b1 == b2
+    assert b1 == (0.3, 0.9, ARCHETYPE_INDEX["skirmisher"] / (len(ARCHETYPES) - 1))
+
+
+def test_build_http_evaluator_n_runs_one_binary_fitness():
+    """n_runs=1 collapses fitness to 0 or 1 exactly."""
+    sol = _sample_build()
+    ev_win = build_http_evaluator("h", "s", "greedy", 1, run_one_fn=lambda *a, **kw: _FakeRun("victory"))
+    ev_lose = build_http_evaluator("h", "s", "greedy", 1, run_one_fn=lambda *a, **kw: _FakeRun("timeout"))
+    assert ev_win(sol)[0] == 1.0
+    assert ev_lose(sol)[0] == 0.0

--- a/tests/scripts/test_restricted_play.py
+++ b/tests/scripts/test_restricted_play.py
@@ -18,6 +18,7 @@ from tools.py.restricted_play import (  # noqa: E402
     plan_greedy,
     plan_random,
     plan_utility,
+    run_one,
 )
 
 
@@ -170,3 +171,84 @@ def test_format_markdown_smoke():
 def test_estimate_human_wr_error_on_no_data():
     """Empty results → error key."""
     assert estimate_human_wr({})["error"] == "no valid WR data"
+
+
+# ─────────────────────────────────────────────────────────
+# run_one unit_override plumbing (no real HTTP)
+# ─────────────────────────────────────────────────────────
+
+
+def test_run_one_unit_override_rewrites_units_before_session_start(monkeypatch):
+    """Hook must be applied to each unit before POST /api/session/start."""
+    from tools.py import restricted_play as rp
+
+    scenario_units = [
+        {"id": "p1", "controlled_by": "player", "hp": 10, "position": {"x": 0, "y": 0}},
+        {"id": "e1", "controlled_by": "sistema", "hp": 5, "position": {"x": 2, "y": 2}},
+    ]
+
+    monkeypatch.setattr(
+        rp, "http_get", lambda url: (200, {"units": scenario_units, "recommended_modulation": "solo"})
+    )
+
+    posts: list[tuple[str, dict]] = []
+
+    def fake_post(url, payload):
+        posts.append((url, payload))
+        if url.endswith("/api/session/start"):
+            # After first post, enemy dead → victory next state.
+            return 200, {
+                "session_id": "sid-test",
+                "state": {
+                    "units": payload["units"],
+                    "grid": {"width": 5, "height": 5},
+                },
+            }
+        if url.endswith("/api/session/round/execute"):
+            return 200, {
+                "state": {
+                    "units": [u for u in payload.get("session_id", []) if False]
+                    + [{"id": "p1", "controlled_by": "player", "hp": 10, "position": {"x": 0, "y": 0}}],
+                    "grid": {"width": 5, "height": 5},
+                }
+            }
+        return 200, {}
+
+    monkeypatch.setattr(rp, "http_post", fake_post)
+
+    def override(u):
+        if u["controlled_by"] == "player":
+            return {**u, "hp": 99, "tag": "hero"}
+        return u
+
+    result = rp.run_one(
+        "http://backend", "enc_test", policy="greedy", seed=1, unit_override=override
+    )
+    start_payload = next(p for url, p in posts if url.endswith("/api/session/start"))
+    assert start_payload["units"][0]["hp"] == 99  # override applied to player
+    assert start_payload["units"][0]["tag"] == "hero"
+    assert start_payload["units"][1]["hp"] == 5  # enemy untouched
+    assert result.outcome in ("victory", "defeat", "timeout")
+
+
+def test_run_one_without_unit_override_passes_units_through(monkeypatch):
+    """Baseline — no hook = no rewrite."""
+    from tools.py import restricted_play as rp
+
+    scenario_units = [
+        {"id": "p1", "controlled_by": "player", "hp": 7, "position": {"x": 0, "y": 0}},
+    ]
+    monkeypatch.setattr(rp, "http_get", lambda url: (200, {"units": scenario_units}))
+    posts: list[tuple[str, dict]] = []
+
+    def fake_post(url, payload):
+        posts.append((url, payload))
+        if url.endswith("/api/session/start"):
+            return 200, {"session_id": "s", "state": {"units": payload["units"], "grid": {"width": 5, "height": 5}}}
+        return 200, {}
+
+    monkeypatch.setattr(rp, "http_post", fake_post)
+
+    rp.run_one("http://backend", "enc", policy="greedy", seed=1)
+    start_payload = next(p for url, p in posts if url.endswith("/api/session/start"))
+    assert start_payload["units"][0]["hp"] == 7  # untouched

--- a/tools/py/map_elites.py
+++ b/tools/py/map_elites.py
@@ -15,8 +15,8 @@ Generic engine + concrete balance use case in the same module:
 - `run_map_elites`: evolution loop (random elite → mutate → evaluate)
 - Balance helpers: `build_random_solution`, `mutate_build`, `synthetic_fitness`
 
-Mock fitness for unit tests + CLI smoke; HTTP integration via
-`restricted_play.run_one` documented (deferred to next PR).
+Mock fitness for unit tests + CLI smoke; HTTP fitness wired via
+`restricted_play.run_one` (see `build_http_evaluator`).
 
 ## Usage
 
@@ -25,11 +25,18 @@ Mock fitness for unit tests + CLI smoke; HTTP integration via
         --iterations 1000 --bins 4 --seed 42 \\
         --out-md docs/balance/2026-04-25-map-elites-archive.md
 
+    # HTTP-backed fitness (needs backend at $MAP_ELITES_HOST or --host)
+    PYTHONPATH=. python3 tools/py/map_elites.py \\
+        --iterations 200 --bins 3 --seed 7 \\
+        --fitness http --scenario enc_tutorial_06_hardcore \\
+        --policy greedy --n-runs 3 --role player \\
+        --out-md docs/balance/$(date +%F)-map-elites-archive-http.md
+
 ## Non-goals
 
-- Live HTTP fitness via run_one (~+2h, separate PR for clarity)
 - CMA-ME / CMA-MEGA gradient variants (Fontaine 2020+)
 - Multi-objective fitness (Pareto MAP-Elites)
+- Session-state clone API (needed for MCTS smart policy, separate P0)
 
 ## References
 
@@ -46,13 +53,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import random
 import statistics
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, Sequence
+from typing import Callable, Optional, Sequence
 
 
 # ─────────────────────────────────────────────────────────
@@ -269,6 +277,76 @@ BALANCE_FEATURE_DIMS = [
 ]
 
 
+DEFAULT_HTTP_HOST = os.environ.get("MAP_ELITES_HOST", "http://localhost:3334")
+
+
+def apply_build_to_unit(unit: dict, build: dict) -> dict:
+    """Inject build stats (hp/mod/dc/mbti/archetype) into a unit dict.
+
+    Only keys meaningful to the combat resolver are overridden; caller-controlled
+    fields (id, controlled_by, position, …) are preserved.
+    """
+    out = dict(unit)
+    out["hp"] = int(build["hp"])
+    out["hp_max"] = int(build["hp"])
+    out["mod"] = int(build["mod"])
+    out["attack_mod"] = int(build["mod"])
+    out["dc"] = int(build["dc"])
+    out["defense_dc"] = int(build["dc"])
+    out["archetype"] = build["archetype"]
+    out["mbti"] = {"t": float(build["mbti_t"]), "n": float(build["mbti_n"])}
+    return out
+
+
+def build_http_evaluator(
+    host: str,
+    scenario_id: str,
+    policy: str,
+    n_runs: int,
+    role: str = "player",
+    seed_base: int = 2000,
+    run_one_fn: Optional[Callable] = None,
+) -> Callable[[dict], tuple[float, tuple[float, float, float]]]:
+    """Return an evaluator that computes fitness via live HTTP sessions.
+
+    Each call: inject the build into every unit with `controlled_by == role`,
+    run `n_runs` sessions with the given policy, return (win_rate, behavior)
+    where behavior = (mbti_t, mbti_n, archetype_idx / 2).
+
+    `run_one_fn` allows test injection; defaults to `restricted_play.run_one`.
+    """
+    if role not in {"player", "sistema"}:
+        raise ValueError(f"role must be 'player' or 'sistema', got {role!r}")
+    if n_runs < 1:
+        raise ValueError("n_runs must be >= 1")
+
+    if run_one_fn is None:
+        from restricted_play import run_one as run_one_fn  # lazy import
+
+    def _evaluator(solution: dict) -> tuple[float, tuple[float, float, float]]:
+        def _override(unit: dict) -> dict:
+            if unit.get("controlled_by") == role:
+                return apply_build_to_unit(unit, solution)
+            return unit
+
+        wins = 0
+        for i in range(n_runs):
+            result = run_one_fn(
+                host, scenario_id, policy, seed=seed_base + i, unit_override=_override
+            )
+            if getattr(result, "outcome", None) == "victory":
+                wins += 1
+        fitness = wins / n_runs
+        behavior = (
+            float(solution["mbti_t"]),
+            float(solution["mbti_n"]),
+            ARCHETYPE_INDEX[solution["archetype"]] / max(1, len(ARCHETYPES) - 1),
+        )
+        return fitness, behavior
+
+    return _evaluator
+
+
 # ─────────────────────────────────────────────────────────
 # Markdown report
 # ─────────────────────────────────────────────────────────
@@ -425,19 +503,54 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--initial", type=int, default=10, help="Initial random solutions")
     parser.add_argument("--out-md", default=None)
     parser.add_argument("--out-json", default=None)
+    parser.add_argument(
+        "--fitness",
+        choices=("synthetic", "http"),
+        default="synthetic",
+        help="synthetic = CI-safe mock; http = live backend via restricted_play.run_one",
+    )
+    parser.add_argument("--host", default=DEFAULT_HTTP_HOST, help="Backend base URL (http only)")
+    parser.add_argument(
+        "--scenario", default=None, help="Scenario id (required for --fitness http)"
+    )
+    parser.add_argument("--policy", default="greedy", choices=("random", "greedy", "utility"))
+    parser.add_argument(
+        "--n-runs", type=int, default=3, help="Sessions per solution eval (http only)"
+    )
+    parser.add_argument("--role", default="player", choices=("player", "sistema"))
     args = parser.parse_args(argv)
+
+    if args.fitness == "http" and not args.scenario:
+        parser.error("--fitness http requires --scenario")
 
     rng = random.Random(args.seed)
     initial_solutions = [build_random_solution(rng) for _ in range(args.initial)]
 
-    print(
-        f"MAP-Elites: iterations={args.iterations} bins={args.bins} "
-        f"seed={args.seed} initial={args.initial}"
-    )
+    if args.fitness == "http":
+        evaluator = build_http_evaluator(
+            host=args.host,
+            scenario_id=args.scenario,
+            policy=args.policy,
+            n_runs=args.n_runs,
+            role=args.role,
+            seed_base=args.seed + 1000,
+        )
+        print(
+            f"MAP-Elites[http]: iterations={args.iterations} bins={args.bins} "
+            f"seed={args.seed} scenario={args.scenario} policy={args.policy} "
+            f"n_runs={args.n_runs} role={args.role}"
+        )
+    else:
+        evaluator = synthetic_fitness
+        print(
+            f"MAP-Elites[synthetic]: iterations={args.iterations} bins={args.bins} "
+            f"seed={args.seed} initial={args.initial}"
+        )
+
     archive, history = run_map_elites(
         initial_solutions=initial_solutions,
         mutator=mutate_build,
-        evaluator=synthetic_fitness,
+        evaluator=evaluator,
         feature_dims=BALANCE_FEATURE_DIMS,
         bins_per_dim=args.bins,
         iterations=args.iterations,

--- a/tools/py/restricted_play.py
+++ b/tools/py/restricted_play.py
@@ -55,6 +55,7 @@ import urllib.request
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+from typing import Callable, Optional
 
 
 DEFAULT_HOST = "http://localhost:3334"
@@ -284,8 +285,19 @@ def detect_outcome(state: dict) -> str | None:
     return None
 
 
-def run_one(host: str, scenario_id: str, policy: str, seed: int) -> RunResult:
-    """Run one session with specified policy. Returns outcome."""
+def run_one(
+    host: str,
+    scenario_id: str,
+    policy: str,
+    seed: int,
+    unit_override: Optional[Callable[[dict], dict]] = None,
+) -> RunResult:
+    """Run one session with specified policy. Returns outcome.
+
+    If `unit_override` is provided it's applied to each unit dict before
+    `/api/session/start`. Enables MAP-Elites or similar tools to inject build
+    stats (hp/mod/dc/…) into specific roles without duplicating the runner.
+    """
     rng = random.Random(seed)
     plan_fn = POLICY_FUNCS[policy]
 
@@ -293,8 +305,11 @@ def run_one(host: str, scenario_id: str, policy: str, seed: int) -> RunResult:
     if status != 200:
         return RunResult(run=-1, outcome="error", rounds=0, players_alive=0, enemies_alive=0, kd=0.0)
 
+    raw_units = sc.get("units", [])
+    if unit_override is not None:
+        raw_units = [unit_override(u) for u in raw_units]
     start_body = {
-        "units": sc.get("units", []),
+        "units": raw_units,
         "modulation": sc.get("recommended_modulation", "quartet"),
         "sistema_pressure_start": sc.get("sistema_pressure_start", 60),
         "hazard_tiles": sc.get("hazard_tiles", []),
@@ -351,11 +366,18 @@ def run_one(host: str, scenario_id: str, policy: str, seed: int) -> RunResult:
     )
 
 
-def run_batch(host: str, scenario_id: str, policy: str, n: int, seed_base: int = 1000) -> dict:
+def run_batch(
+    host: str,
+    scenario_id: str,
+    policy: str,
+    n: int,
+    seed_base: int = 1000,
+    unit_override: Optional[Callable[[dict], dict]] = None,
+) -> dict:
     """Run N sessions with policy; return aggregate WR + stats."""
     runs: list[RunResult] = []
     for i in range(n):
-        r = run_one(host, scenario_id, policy, seed=seed_base + i)
+        r = run_one(host, scenario_id, policy, seed=seed_base + i, unit_override=unit_override)
         r.run = i + 1
         runs.append(r)
     ok = [r for r in runs if r.outcome in ("victory", "defeat", "timeout")]


### PR DESCRIPTION
Closes 2nd balance-illuminator P0 residual from [2026-04-25 handoff](docs/planning/2026-04-25-illuminator-orchestra-handoff.md) — live HTTP fitness that PR #1765 deferred (~2h estimate).

## Summary
- `tools/py/restricted_play.py` — `run_one` + `run_batch` accept optional `unit_override: Callable[[dict], dict]` applied before `/api/session/start`. Backward-compat (default `None`).
- `tools/py/map_elites.py`:
  - `apply_build_to_unit(unit, build)` overrides hp/mod/dc/mbti/archetype, preserves id/controlled_by/position.
  - `build_http_evaluator(host, scenario, policy, n_runs, role, seed_base, run_one_fn=None)` returns `(solution) → (fitness, behavior)`; fitness = wins/n_runs; behavior = `(mbti_t, mbti_n, archetype_idx/2)`.
  - CLI flag `--fitness {synthetic,http}` (synthetic = default, CI-safe) + `--host --scenario --policy --n-runs --role`. `--fitness http` without `--scenario` errors.
  - Docstring non-goals updated; HTTP shipped.
- `run_one_fn` DI on `build_http_evaluator` lets tests stub the runner — zero real HTTP.

## Validation
- **Targeted**: `tests/scripts/test_map_elites.py` + `test_restricted_play.py` → **61/61 pass**, +12 new cases (override + identity preservation + invalid-args guard + win-rate math + role flip + stable behavior vector + backward-compat pass-through)
- **Full pytest**: **948 passed** (was 936; +12 new)
- **AI regression**: 307/307 ✅
- **Services**: 257/257 ✅
- **Format**: `npm run format:check` ✅
- **Governance**: 0 errors / 0 warnings
- **No new deps** (stdlib only)

## Usage
```bash
PYTHONPATH=. python3 tools/py/map_elites.py \
  --iterations 200 --bins 3 --seed 7 \
  --fitness http --scenario enc_tutorial_06_hardcore \
  --policy greedy --n-runs 3 --role player \
  --out-md docs/balance/2026-04-25-map-elites-archive-http.md
```

## Refs
- Parent feature: [#1765](https://github.com/MasterDD-L34D/Game/pull/1765) (MAP-Elites archive)
- Agent: `.claude/agents/balance-illuminator.md`
- Handoff: `docs/planning/2026-04-25-illuminator-orchestra-handoff.md`
- Mouret & Clune 2015 — [Illuminating search spaces](https://arxiv.org/abs/1504.04909)
- Jaffe 2012 — [Restricted Play](https://homes.cs.washington.edu/~zoran/jaffe2012ecg.pdf)

## Test plan
- [x] Targeted pytest: 61/61
- [x] Full pytest: 948/948
- [x] AI 307/307 + Services 257/257
- [x] format:check + governance
- [x] CLI dry-run: `--fitness http` requires `--scenario` guard; `--fitness synthetic` unchanged
- [ ] CI green

## Rollback
Revert this PR — runtime behaviour falls back to synthetic fitness. No schema/migration/route changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)