### PR TITLE
feat(narrative): Thought Cabinet Phase 2 — research timer + internalize + passives

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -43,8 +43,17 @@ const {
 } = require('../services/traitEffects');
 const { loadFairnessConfig, checkCapPtBudget, consumeCapPt } = require('../services/fairnessCap');
 const { loadTelemetryConfig, buildVcSnapshot } = require('../services/vcScoring');
-// P4 Thought Cabinet: evaluateThoughts per /thoughts endpoint.
-const { evaluateThoughts: evaluateMbtiThoughts } = require('../services/thoughts/thoughtCabinet');
+// P4 Thought Cabinet: Phase 1 (threshold unlock) + Phase 2 (research → internalize).
+const {
+  evaluateThoughts: evaluateMbtiThoughts,
+  createCabinetState,
+  startResearch: startThoughtResearch,
+  tickResearch: tickThoughtResearch,
+  forgetThought: forgetThoughtFn,
+  passiveBonuses: thoughtPassiveBonuses,
+  snapshotCabinet,
+  mergeUnlocked,
+} = require('../services/thoughts/thoughtCabinet');
 // SPRINT_010 (issue #2): IA estratta in modulo dedicato.
 // Le funzioni decisionali (selectAiPolicy, stepAway) vivono in services/ai/policy.js,
 // l'orchestratore del turno (createSistemaTurnRunner) in services/ai/sistemaTurnRunner.js.
@@ -207,8 +216,29 @@ function createSessionRouter(options = {}) {
       /* sgTracker optional */
     }
   }
-  // P4 Thought Cabinet: sessionId -> Map<unitId, Set<thoughtId>>
+  // P4 Thought Cabinet: sessionId -> Map<unitId, CabinetState>.
+  // Phase 1 discovered ids live in `state.unlocked`; Phase 2 tracks research +
+  // internalized slots for Disco Elysium-style passive effects.
   const thoughtsStore = new Map();
+
+  function getCabinetBucket(sessionId) {
+    let bucket = thoughtsStore.get(sessionId);
+    if (!bucket) {
+      bucket = new Map();
+      thoughtsStore.set(sessionId, bucket);
+    }
+    return bucket;
+  }
+
+  function getOrCreateCabinet(sessionId, unitId) {
+    const bucket = getCabinetBucket(sessionId);
+    let state = bucket.get(unitId);
+    if (!state) {
+      state = createCabinetState();
+      bucket.set(unitId, state);
+    }
+    return { bucket, state };
+  }
 
   function newSessionId() {
     return crypto.randomUUID();
@@ -1837,30 +1867,120 @@ function createSessionRouter(options = {}) {
 
   // P4 Thought Cabinet: on-demand evaluation. Reads current VC snapshot per
   // actor, crosses mbti_axes against 18 YAML thoughts, cumulatively unlocks
-  // into in-memory store. Returns per-actor { unlocked, newly, details[] }.
+  // into in-memory CabinetState. Response carries Phase 1 keys (unlocked,
+  // newly) + Phase 2 additive keys (researching, internalized, slots_max,
+  // slots_used, passive_bonus, passive_cost).
   router.get('/:id/thoughts', (req, res, next) => {
     try {
       const { error, session } = resolveSession(req.params.id);
       if (error) return res.status(error.status).json(error.body);
       const snapshot = buildVcSnapshot(session, telemetryConfig);
-      let bucket = thoughtsStore.get(session.session_id);
-      if (!bucket) {
-        bucket = new Map();
-        thoughtsStore.set(session.session_id, bucket);
-      }
       const perActor = {};
       for (const [unitId, actorVc] of Object.entries(snapshot.per_actor || {})) {
         const axes = actorVc && actorVc.mbti_axes ? actorVc.mbti_axes : null;
-        let already = bucket.get(unitId);
-        if (!already) {
-          already = new Set();
-          bucket.set(unitId, already);
-        }
-        const { unlocked, newly } = evaluateMbtiThoughts(axes, already);
-        for (const id of newly) already.add(id);
-        perActor[unitId] = { unlocked, newly };
+        const { state } = getOrCreateCabinet(session.session_id, unitId);
+        const { newly } = evaluateMbtiThoughts(axes, state.unlocked);
+        mergeUnlocked(state, newly);
+        const snap = snapshotCabinet(state);
+        const passives = thoughtPassiveBonuses(state);
+        perActor[unitId] = {
+          ...snap,
+          newly,
+          passive_bonus: passives.bonus,
+          passive_cost: passives.cost,
+        };
       }
       res.json({ session_id: session.session_id, per_actor: perActor });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // P4 Phase 2 — begin research on an unlocked thought (Disco Elysium
+  // internalization). Body: { unit_id, thought_id }. Fails if the thought
+  // is not unlocked, already researching/internalized, or cabinet has no
+  // free slot (slots_max=3 by default).
+  router.post('/:id/thoughts/research', (req, res, next) => {
+    try {
+      const { error, session } = resolveSession(req.params.id);
+      if (error) return res.status(error.status).json(error.body);
+      const { unit_id, thought_id } = req.body || {};
+      if (!unit_id || !thought_id) {
+        return res.status(400).json({ error: 'unit_id e thought_id obbligatori' });
+      }
+      const { state } = getOrCreateCabinet(session.session_id, unit_id);
+      const outcome = startThoughtResearch(state, thought_id, {
+        encounter: req.body?.encounter ?? null,
+      });
+      if (!outcome.ok) {
+        return res.status(409).json({ error: outcome.error, thought_id });
+      }
+      res.json({
+        session_id: session.session_id,
+        unit_id,
+        thought_id,
+        cost_total: outcome.cost_total,
+        cabinet: snapshotCabinet(state),
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // P4 Phase 2 — forget a researching or internalized thought to free a
+  // slot. Body: { unit_id, thought_id }. Symmetric with research.
+  router.post('/:id/thoughts/forget', (req, res, next) => {
+    try {
+      const { error, session } = resolveSession(req.params.id);
+      if (error) return res.status(error.status).json(error.body);
+      const { unit_id, thought_id } = req.body || {};
+      if (!unit_id || !thought_id) {
+        return res.status(400).json({ error: 'unit_id e thought_id obbligatori' });
+      }
+      const { state } = getOrCreateCabinet(session.session_id, unit_id);
+      const outcome = forgetThoughtFn(state, thought_id);
+      if (!outcome.ok) {
+        return res.status(409).json({ error: outcome.error, thought_id });
+      }
+      res.json({
+        session_id: session.session_id,
+        unit_id,
+        thought_id,
+        freed_from: outcome.freed_from,
+        cabinet: snapshotCabinet(state),
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // P4 Phase 2 — advance research timers. Body: { delta?: 1, unit_ids?: [] }.
+  // Decrements cost_remaining for every researching thought on the listed
+  // units (all units if `unit_ids` omitted); thoughts hitting 0 are
+  // promoted to internalized. Intended to be called on encounter/campaign
+  // advance by the caller; round orchestrator stays untouched.
+  router.post('/:id/thoughts/tick', (req, res, next) => {
+    try {
+      const { error, session } = resolveSession(req.params.id);
+      if (error) return res.status(error.status).json(error.body);
+      const delta = Number.isFinite(req.body?.delta) ? req.body.delta : 1;
+      const unitIds = Array.isArray(req.body?.unit_ids) ? req.body.unit_ids : null;
+      const bucket = getCabinetBucket(session.session_id);
+      const perActor = {};
+      const iterable = unitIds
+        ? unitIds.map((id) => [id, bucket.get(id)]).filter(([, v]) => v)
+        : Array.from(bucket.entries());
+      for (const [unitId, state] of iterable) {
+        const { promoted } = tickThoughtResearch(state, delta);
+        const passives = thoughtPassiveBonuses(state);
+        perActor[unitId] = {
+          ...snapshotCabinet(state),
+          promoted,
+          passive_bonus: passives.bonus,
+          passive_cost: passives.cost,
+        };
+      }
+      res.json({ session_id: session.session_id, delta, per_actor: perActor });
     } catch (err) {
       next(err);
     }

--- a/apps/backend/services/thoughts/thoughtCabinet.js
+++ b/apps/backend/services/thoughts/thoughtCabinet.js
@@ -91,6 +91,141 @@ function describeThought(id, catalog = loadThoughts()) {
   return { id, ...entry };
 }
 
+// ──────────────────────────────────────────────────────────────
+// Phase 2 — Disco Elysium internalization (research → permanent effect)
+//
+// Each unit owns a CabinetState:
+//   {
+//     unlocked:    Set<thoughtId>   — discovered via MBTI threshold (Phase 1)
+//     researching: Map<id, {cost_remaining, cost_total, started_at_encounter}>
+//     internalized: Set<thoughtId>  — permanent, grants effect_bonus + effect_cost
+//     slots_max:   number (default 3)
+//   }
+//
+// Pure state machines: callers read (unlocked) to offer research, call
+// startResearch() when player clicks, tickResearch() on encounter advance,
+// internalize() happens automatically on tick when cost_remaining hits 0,
+// forgetThought() frees a slot.
+// passiveBonuses() aggregates internalized effects into {bonus, cost} deltas
+// for the combat resolver to apply.
+
+const DEFAULT_SLOTS_MAX = 3;
+
+function createCabinetState(opts = {}) {
+  const slots = Number.isFinite(opts.slotsMax)
+    ? Math.max(1, Math.floor(opts.slotsMax))
+    : DEFAULT_SLOTS_MAX;
+  return {
+    unlocked: new Set(opts.unlocked || []),
+    researching: new Map(),
+    internalized: new Set(opts.internalized || []),
+    slots_max: slots,
+  };
+}
+
+function slotsUsed(state) {
+  return state.internalized.size + state.researching.size;
+}
+
+function canResearchMore(state) {
+  return slotsUsed(state) < state.slots_max;
+}
+
+function resolveResearchCost(entry) {
+  if (!entry) return 1;
+  const explicit = entry.research_cost_encounters;
+  if (Number.isFinite(explicit) && explicit > 0) return Math.floor(explicit);
+  const tier = Number.isFinite(entry.tier) ? entry.tier : 1;
+  return Math.max(1, tier);
+}
+
+function mergeUnlocked(state, newlyUnlockedIds) {
+  if (!Array.isArray(newlyUnlockedIds) || newlyUnlockedIds.length === 0) return state;
+  for (const id of newlyUnlockedIds) state.unlocked.add(id);
+  return state;
+}
+
+function startResearch(state, thoughtId, opts = {}) {
+  const catalog = opts.catalog || loadThoughts();
+  const entry = catalog.thoughts?.[thoughtId];
+  if (!entry) return { ok: false, error: 'thought_not_found' };
+  if (!state.unlocked.has(thoughtId)) return { ok: false, error: 'not_unlocked' };
+  if (state.internalized.has(thoughtId)) return { ok: false, error: 'already_internalized' };
+  if (state.researching.has(thoughtId)) return { ok: false, error: 'already_researching' };
+  if (!canResearchMore(state)) return { ok: false, error: 'no_free_slot' };
+  const cost = resolveResearchCost(entry);
+  state.researching.set(thoughtId, {
+    cost_remaining: cost,
+    cost_total: cost,
+    started_at_encounter: Number.isFinite(opts.encounter) ? opts.encounter : null,
+  });
+  return { ok: true, state, cost_total: cost };
+}
+
+function tickResearch(state, delta = 1) {
+  const step = Number.isFinite(delta) && delta > 0 ? Math.floor(delta) : 1;
+  const promoted = [];
+  for (const [id, entry] of state.researching) {
+    const next = entry.cost_remaining - step;
+    if (next <= 0) {
+      state.researching.delete(id);
+      state.internalized.add(id);
+      promoted.push(id);
+    } else {
+      entry.cost_remaining = next;
+    }
+  }
+  return { state, promoted };
+}
+
+function forgetThought(state, thoughtId) {
+  if (state.internalized.has(thoughtId)) {
+    state.internalized.delete(thoughtId);
+    return { ok: true, state, freed_from: 'internalized' };
+  }
+  if (state.researching.has(thoughtId)) {
+    state.researching.delete(thoughtId);
+    return { ok: true, state, freed_from: 'researching' };
+  }
+  return { ok: false, error: 'not_active' };
+}
+
+function addDeltas(target, deltas) {
+  if (!deltas || typeof deltas !== 'object') return;
+  for (const [k, v] of Object.entries(deltas)) {
+    if (!Number.isFinite(v)) continue;
+    target[k] = (target[k] || 0) + v;
+  }
+}
+
+function passiveBonuses(state, opts = {}) {
+  const catalog = opts.catalog || loadThoughts();
+  const bonus = {};
+  const cost = {};
+  for (const id of state.internalized) {
+    const entry = catalog.thoughts?.[id];
+    if (!entry) continue;
+    addDeltas(bonus, entry.effect_bonus);
+    addDeltas(cost, entry.effect_cost);
+  }
+  return { bonus, cost, internalized: Array.from(state.internalized) };
+}
+
+function snapshotCabinet(state) {
+  return {
+    unlocked: Array.from(state.unlocked),
+    researching: Array.from(state.researching.entries()).map(([id, e]) => ({
+      id,
+      cost_remaining: e.cost_remaining,
+      cost_total: e.cost_total,
+      started_at_encounter: e.started_at_encounter,
+    })),
+    internalized: Array.from(state.internalized),
+    slots_max: state.slots_max,
+    slots_used: slotsUsed(state),
+  };
+}
+
 module.exports = {
   loadThoughts,
   resetCache,
@@ -98,4 +233,16 @@ module.exports = {
   thoughtsByAxis,
   describeThought,
   matchesThreshold,
+  // Phase 2
+  DEFAULT_SLOTS_MAX,
+  createCabinetState,
+  slotsUsed,
+  canResearchMore,
+  resolveResearchCost,
+  mergeUnlocked,
+  startResearch,
+  tickResearch,
+  forgetThought,
+  passiveBonuses,
+  snapshotCabinet,
 };

--- a/data/core/thoughts/mbti_thoughts.yaml
+++ b/data/core/thoughts/mbti_thoughts.yaml
@@ -12,6 +12,15 @@
 #
 # Unlock: cumulative (una volta sbloccato, resta) per session:unit.
 # Reveal: UI formsPanel tooltip + popup evolve.
+#
+# Phase 2 additions (Disco Elysium internalization — optional per-thought):
+#   research_cost_encounters: N   # default = tier (1|2|3). Encounters needed
+#                                 # after startResearch → internalized.
+#   effect_bonus: {stat: delta}   # permanent passive bonus once internalized.
+#   effect_cost:  {stat: delta}   # permanent commitment malus.
+#   effect_cost_hint_it: "…"      # UI malus description.
+# Stats supported by engine: attack_mod, defense_dc, hp_max, attack_range, ap,
+# aggro_mult, mov_penalty. Unknown keys are aggregated but not auto-applied.
 
 version: "0.1.0"
 
@@ -26,6 +35,12 @@ thoughts:
     title_it: "Voce Collettiva"
     flavor_it: "Parla ai compagni anche senza necessità tattica. Ogni azione è conferma condivisa."
     effect_hint_it: "Preferisce ingaggi ravvicinati, cerca supporto di squadra."
+    research_cost_encounters: 1
+    effect_bonus:
+      attack_mod: 1     # +1 attack mod quando adiacente ad alleato (engine plumbing pending)
+    effect_cost:
+      defense_dc: 1     # -1 DC quando isolato (da wire al resolver)
+    effect_cost_hint_it: "-1 DC quando isolato (nessun alleato a 2 caselle)."
 
   e_scintilla_carisma:
     axis: E_I
@@ -57,6 +72,12 @@ thoughts:
     title_it: "Osservatore"
     flavor_it: "Preferisce studiare prima di impegnarsi. Ogni mossa ponderata."
     effect_hint_it: "Ingaggi distanti; valuta prima di committare."
+    research_cost_encounters: 1
+    effect_bonus:
+      attack_range: 1   # +1 range quando attacca per la prima volta nel round
+    effect_cost:
+      ap: 1             # -1 AP effettivo nel primo turno (studio iniziale)
+    effect_cost_hint_it: "-1 AP nel turno iniziale; richiede osservazione prima di agire."
 
   i_calcolo_silente:
     axis: E_I
@@ -88,6 +109,12 @@ thoughts:
     title_it: "Intuizione Terrena"
     flavor_it: "Sente pattern nascosti nel biome. Cerca nuove vie anche senza motivo."
     effect_hint_it: "Alta esplorazione; new_tiles elevato."
+    research_cost_encounters: 1
+    effect_bonus:
+      attack_range: 1    # +1 range su tile hazard/coperture (biome awareness)
+    effect_cost:
+      defense_dc: 1      # -1 DC fuori dalla copertura (pattern-seeker espone)
+    effect_cost_hint_it: "-1 DC quando fuori da copertura o hazard tile."
 
   n_pioniere_possibile:
     axis: S_N
@@ -119,6 +146,12 @@ thoughts:
     title_it: "Occhio Pratico"
     flavor_it: "Si fida di ciò che può toccare. Il piano prima, l'istinto dopo."
     effect_hint_it: "Setup ratio alto; basso uso di improvvisazione."
+    research_cost_encounters: 1
+    effect_bonus:
+      defense_dc: 1      # +1 DC fisso quando usa azione setup/aim
+    effect_cost:
+      mov_penalty: 1     # -1 max move (metodico, non reactive)
+    effect_cost_hint_it: "-1 max move: metodico, evita sprint."
 
   s_metodologia_ferro:
     axis: S_N
@@ -150,6 +183,12 @@ thoughts:
     title_it: "Adattatore"
     flavor_it: "Cambia piano al volo senza attrito. L'errore di ieri è solo dato nuovo."
     effect_hint_it: "Cambia intent frequentemente senza penalty."
+    research_cost_encounters: 1
+    effect_bonus:
+      ap: 1              # +1 AP quando cambia intent rispetto al round precedente
+    effect_cost:
+      defense_dc: 1      # -1 DC round di transizione
+    effect_cost_hint_it: "-1 DC nel round in cui cambia intent."
 
   p_improvvisatore:
     axis: J_P
@@ -181,6 +220,12 @@ thoughts:
     title_it: "Disciplina"
     flavor_it: "Rispetta il piano anche sotto pressione. L'improvvisazione è lusso, non strumento."
     effect_hint_it: "Bonus se mantiene intent round successivo."
+    research_cost_encounters: 1
+    effect_bonus:
+      attack_mod: 1      # +1 attack mod se ripete intent come round precedente
+    effect_cost:
+      ap: 1              # -1 AP nel round di cambio intent (rigidità)
+    effect_cost_hint_it: "-1 AP nel round in cui cambia tipo di azione."
 
   j_architetto_round:
     axis: J_P

--- a/tests/api/sessionThoughts.test.js
+++ b/tests/api/sessionThoughts.test.js
@@ -92,3 +92,170 @@ test('POST /end clears thoughtsStore entry (no memory leak — Codex #1702 P2)',
   const post = await request(app).get(`/api/session/${sid}/thoughts`);
   assert.equal(post.status, 404, 'thoughtsStore entry released with session');
 });
+
+// ─────────────────────────────────────────────────────────
+// Phase 2 — research + forget + tick route integration
+// ─────────────────────────────────────────────────────────
+
+async function bootstrap(app) {
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units });
+  const sid = startRes.body.session_id;
+  return { sid, scenario };
+}
+
+function anyUnlockedActor(perActor) {
+  for (const [uid, entry] of Object.entries(perActor || {})) {
+    if (Array.isArray(entry.unlocked) && entry.unlocked.length > 0) {
+      return { unit_id: uid, thought_id: entry.unlocked[0], entry };
+    }
+  }
+  return null;
+}
+
+test('GET /:id/thoughts includes Phase 2 keys (researching, internalized, slots, passives)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const { sid } = await bootstrap(app);
+  const res = await request(app).get(`/api/session/${sid}/thoughts`);
+  assert.equal(res.status, 200);
+  for (const [uid, entry] of Object.entries(res.body.per_actor || {})) {
+    assert.ok(Array.isArray(entry.unlocked), `${uid} unlocked array`);
+    assert.ok(Array.isArray(entry.newly), `${uid} newly array`);
+    assert.ok(Array.isArray(entry.researching), `${uid} researching array`);
+    assert.ok(Array.isArray(entry.internalized), `${uid} internalized array`);
+    assert.equal(typeof entry.slots_max, 'number');
+    assert.equal(typeof entry.slots_used, 'number');
+    assert.equal(typeof entry.passive_bonus, 'object');
+    assert.equal(typeof entry.passive_cost, 'object');
+  }
+});
+
+test('POST /:id/thoughts/research — happy path on an unlocked thought', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const { sid } = await bootstrap(app);
+  const snap = await request(app).get(`/api/session/${sid}/thoughts`);
+  const target = anyUnlockedActor(snap.body.per_actor);
+  if (!target) {
+    // Tutorial 01 does not surface unlocked thoughts for every actor. Skip.
+    t.skip('no unlocked thoughts in tutorial 01 seed state');
+    return;
+  }
+  const res = await request(app)
+    .post(`/api/session/${sid}/thoughts/research`)
+    .send({ unit_id: target.unit_id, thought_id: target.thought_id });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.unit_id, target.unit_id);
+  assert.equal(res.body.thought_id, target.thought_id);
+  assert.ok(res.body.cost_total >= 1);
+  assert.equal(res.body.cabinet.slots_used, 1);
+  assert.equal(res.body.cabinet.researching[0].id, target.thought_id);
+});
+
+test('POST /:id/thoughts/research — 400 when unit_id or thought_id missing', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const { sid } = await bootstrap(app);
+  const r1 = await request(app).post(`/api/session/${sid}/thoughts/research`).send({});
+  assert.equal(r1.status, 400);
+  const r2 = await request(app)
+    .post(`/api/session/${sid}/thoughts/research`)
+    .send({ unit_id: 'x' });
+  assert.equal(r2.status, 400);
+});
+
+test('POST /:id/thoughts/research — 409 on not_unlocked', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const { sid } = await bootstrap(app);
+  const snap = await request(app).get(`/api/session/${sid}/thoughts`);
+  const uid = Object.keys(snap.body.per_actor || {})[0];
+  assert.ok(uid, 'at least one actor');
+  const res = await request(app)
+    .post(`/api/session/${sid}/thoughts/research`)
+    .send({ unit_id: uid, thought_id: 'bogus_missing_id' });
+  assert.equal(res.status, 409);
+  assert.equal(res.body.error, 'thought_not_found');
+});
+
+test('POST /:id/thoughts/tick — advances researching + promotes when cost hits 0', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const { sid } = await bootstrap(app);
+  const snap = await request(app).get(`/api/session/${sid}/thoughts`);
+  const target = anyUnlockedActor(snap.body.per_actor);
+  if (!target) {
+    t.skip('no unlocked thoughts in tutorial 01 seed state');
+    return;
+  }
+  // Start research for the unlocked thought
+  const start = await request(app)
+    .post(`/api/session/${sid}/thoughts/research`)
+    .send({ unit_id: target.unit_id, thought_id: target.thought_id });
+  assert.equal(start.status, 200);
+  const costTotal = start.body.cost_total;
+  // Tick enough to internalize.
+  const tick = await request(app)
+    .post(`/api/session/${sid}/thoughts/tick`)
+    .send({ delta: costTotal });
+  assert.equal(tick.status, 200);
+  const actor = tick.body.per_actor[target.unit_id];
+  assert.ok(actor.promoted.includes(target.thought_id));
+  assert.ok(actor.internalized.includes(target.thought_id));
+  assert.equal(actor.researching.length, 0);
+});
+
+test('POST /:id/thoughts/forget — frees slot after internalization', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const { sid } = await bootstrap(app);
+  const snap = await request(app).get(`/api/session/${sid}/thoughts`);
+  const target = anyUnlockedActor(snap.body.per_actor);
+  if (!target) {
+    t.skip('no unlocked thoughts in tutorial 01 seed state');
+    return;
+  }
+  const start = await request(app)
+    .post(`/api/session/${sid}/thoughts/research`)
+    .send({ unit_id: target.unit_id, thought_id: target.thought_id });
+  await request(app)
+    .post(`/api/session/${sid}/thoughts/tick`)
+    .send({ delta: start.body.cost_total });
+  const forget = await request(app)
+    .post(`/api/session/${sid}/thoughts/forget`)
+    .send({ unit_id: target.unit_id, thought_id: target.thought_id });
+  assert.equal(forget.status, 200);
+  assert.equal(forget.body.freed_from, 'internalized');
+  assert.equal(forget.body.cabinet.slots_used, 0);
+});
+
+test('POST /:id/thoughts/forget — 409 when thought is not active (not researching/internalized)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const { sid } = await bootstrap(app);
+  const snap = await request(app).get(`/api/session/${sid}/thoughts`);
+  const uid = Object.keys(snap.body.per_actor || {})[0];
+  assert.ok(uid);
+  const res = await request(app)
+    .post(`/api/session/${sid}/thoughts/forget`)
+    .send({ unit_id: uid, thought_id: 'bogus_id' });
+  assert.equal(res.status, 409);
+  assert.equal(res.body.error, 'not_active');
+});

--- a/tests/api/thoughtCabinet.test.js
+++ b/tests/api/thoughtCabinet.test.js
@@ -12,6 +12,17 @@ const {
   thoughtsByAxis,
   describeThought,
   matchesThreshold,
+  DEFAULT_SLOTS_MAX,
+  createCabinetState,
+  slotsUsed,
+  canResearchMore,
+  resolveResearchCost,
+  mergeUnlocked,
+  startResearch,
+  tickResearch,
+  forgetThought,
+  passiveBonuses,
+  snapshotCabinet,
 } = require('../../apps/backend/services/thoughts/thoughtCabinet');
 
 test('loadThoughts: returns 18 thoughts across 3 axes (E_I + S_N + J_P)', () => {
@@ -163,4 +174,261 @@ test('evaluateThoughts: axes value exactly at threshold is inclusive', () => {
   const axes = { E_I: { value: 0.35, coverage: 'full' } };
   const { unlocked } = evaluateThoughts(axes);
   assert.ok(unlocked.includes('e_voce_collettiva'));
+});
+
+// ─────────────────────────────────────────────────────────
+// Phase 2 — Disco Elysium internalization (research timer + slots + effects)
+// ─────────────────────────────────────────────────────────
+
+test('createCabinetState: defaults to 3 slots, empty collections', () => {
+  const s = createCabinetState();
+  assert.equal(s.slots_max, DEFAULT_SLOTS_MAX);
+  assert.equal(s.slots_max, 3);
+  assert.equal(s.unlocked.size, 0);
+  assert.equal(s.internalized.size, 0);
+  assert.equal(s.researching.size, 0);
+  assert.equal(slotsUsed(s), 0);
+  assert.equal(canResearchMore(s), true);
+});
+
+test('createCabinetState: slotsMax override clamps to >=1 and floors', () => {
+  assert.equal(createCabinetState({ slotsMax: 5 }).slots_max, 5);
+  assert.equal(createCabinetState({ slotsMax: 2.9 }).slots_max, 2);
+  assert.equal(createCabinetState({ slotsMax: 0 }).slots_max, 1);
+  assert.equal(createCabinetState({ slotsMax: -3 }).slots_max, 1);
+});
+
+test('mergeUnlocked: adds new ids, ignores empty input', () => {
+  const s = createCabinetState();
+  mergeUnlocked(s, ['a', 'b']);
+  assert.equal(s.unlocked.size, 2);
+  mergeUnlocked(s, []);
+  mergeUnlocked(s, null);
+  assert.equal(s.unlocked.size, 2);
+  mergeUnlocked(s, ['a', 'c']);
+  assert.equal(s.unlocked.size, 3);
+});
+
+test('resolveResearchCost: explicit field wins; falls back on tier; defaults to 1', () => {
+  assert.equal(resolveResearchCost({ research_cost_encounters: 4, tier: 2 }), 4);
+  assert.equal(resolveResearchCost({ tier: 3 }), 3);
+  assert.equal(resolveResearchCost({ tier: 1 }), 1);
+  assert.equal(resolveResearchCost({}), 1);
+  assert.equal(resolveResearchCost(null), 1);
+  // Negative / zero explicit cost → fall back on tier default (1)
+  assert.equal(resolveResearchCost({ research_cost_encounters: 0, tier: 2 }), 2);
+});
+
+test('startResearch: unknown thought → thought_not_found', () => {
+  const s = createCabinetState();
+  assert.deepEqual(startResearch(s, 'bogus_id'), { ok: false, error: 'thought_not_found' });
+});
+
+test('startResearch: not_unlocked if thought never passed MBTI threshold', () => {
+  const s = createCabinetState();
+  assert.deepEqual(startResearch(s, 'e_voce_collettiva'), {
+    ok: false,
+    error: 'not_unlocked',
+  });
+});
+
+test('startResearch: happy path consumes a slot + sets timer', () => {
+  const s = createCabinetState();
+  mergeUnlocked(s, ['e_voce_collettiva']);
+  const out = startResearch(s, 'e_voce_collettiva', { encounter: 5 });
+  assert.equal(out.ok, true);
+  assert.equal(out.cost_total, 1);
+  assert.equal(s.researching.size, 1);
+  assert.equal(slotsUsed(s), 1);
+  const entry = s.researching.get('e_voce_collettiva');
+  assert.equal(entry.cost_remaining, 1);
+  assert.equal(entry.cost_total, 1);
+  assert.equal(entry.started_at_encounter, 5);
+});
+
+test('startResearch: already_researching blocks double-start', () => {
+  const s = createCabinetState();
+  mergeUnlocked(s, ['i_osservatore']);
+  startResearch(s, 'i_osservatore');
+  assert.deepEqual(startResearch(s, 'i_osservatore'), {
+    ok: false,
+    error: 'already_researching',
+  });
+});
+
+test('startResearch: already_internalized blocks re-research', () => {
+  const s = createCabinetState();
+  mergeUnlocked(s, ['i_osservatore']);
+  s.internalized.add('i_osservatore');
+  assert.deepEqual(startResearch(s, 'i_osservatore'), {
+    ok: false,
+    error: 'already_internalized',
+  });
+});
+
+test('startResearch: no_free_slot when slots full', () => {
+  const s = createCabinetState({ slotsMax: 1 });
+  mergeUnlocked(s, ['e_voce_collettiva', 'i_osservatore']);
+  startResearch(s, 'e_voce_collettiva');
+  assert.deepEqual(startResearch(s, 'i_osservatore'), {
+    ok: false,
+    error: 'no_free_slot',
+  });
+});
+
+test('tickResearch: decrements cost_remaining per call', () => {
+  resetCache();
+  const s = createCabinetState();
+  mergeUnlocked(s, ['n_pioniere_possibile']); // tier 2 → cost 2 (default)
+  startResearch(s, 'n_pioniere_possibile');
+  assert.equal(s.researching.get('n_pioniere_possibile').cost_remaining, 2);
+  tickResearch(s);
+  assert.equal(s.researching.get('n_pioniere_possibile').cost_remaining, 1);
+  assert.equal(s.internalized.size, 0);
+  const { promoted } = tickResearch(s);
+  assert.deepEqual(promoted, ['n_pioniere_possibile']);
+  assert.equal(s.researching.size, 0);
+  assert.ok(s.internalized.has('n_pioniere_possibile'));
+});
+
+test('tickResearch: delta > 1 skips rounds', () => {
+  const s = createCabinetState();
+  mergeUnlocked(s, ['n_visionario']); // tier 3 → cost 3
+  startResearch(s, 'n_visionario');
+  const { promoted } = tickResearch(s, 3);
+  assert.deepEqual(promoted, ['n_visionario']);
+});
+
+test('tickResearch: non-finite delta treated as 1', () => {
+  const s = createCabinetState();
+  mergeUnlocked(s, ['e_voce_collettiva']);
+  startResearch(s, 'e_voce_collettiva');
+  tickResearch(s, 'not-a-number');
+  assert.ok(s.internalized.has('e_voce_collettiva'));
+});
+
+test('tickResearch: multiple thoughts progress independently', () => {
+  const s = createCabinetState();
+  mergeUnlocked(s, ['e_voce_collettiva', 'n_pioniere_possibile']);
+  startResearch(s, 'e_voce_collettiva'); // cost 1
+  startResearch(s, 'n_pioniere_possibile'); // cost 2
+  const first = tickResearch(s);
+  assert.deepEqual(first.promoted, ['e_voce_collettiva']); // hit 0
+  assert.equal(s.researching.get('n_pioniere_possibile').cost_remaining, 1);
+  const second = tickResearch(s);
+  assert.deepEqual(second.promoted, ['n_pioniere_possibile']);
+});
+
+test('forgetThought: removes from internalized + frees slot', () => {
+  const s = createCabinetState();
+  mergeUnlocked(s, ['e_voce_collettiva']);
+  s.internalized.add('e_voce_collettiva');
+  assert.equal(slotsUsed(s), 1);
+  const out = forgetThought(s, 'e_voce_collettiva');
+  assert.deepEqual(out.ok ? { ok: out.ok, freed_from: out.freed_from } : out, {
+    ok: true,
+    freed_from: 'internalized',
+  });
+  assert.equal(slotsUsed(s), 0);
+});
+
+test('forgetThought: removes from researching + returns freed_from=researching', () => {
+  const s = createCabinetState();
+  mergeUnlocked(s, ['i_osservatore']);
+  startResearch(s, 'i_osservatore');
+  const out = forgetThought(s, 'i_osservatore');
+  assert.equal(out.ok, true);
+  assert.equal(out.freed_from, 'researching');
+  assert.equal(slotsUsed(s), 0);
+});
+
+test('forgetThought: not_active if thought neither researching nor internalized', () => {
+  const s = createCabinetState();
+  mergeUnlocked(s, ['e_voce_collettiva']);
+  assert.deepEqual(forgetThought(s, 'e_voce_collettiva'), { ok: false, error: 'not_active' });
+});
+
+test('passiveBonuses: empty cabinet → empty deltas', () => {
+  const s = createCabinetState();
+  const out = passiveBonuses(s);
+  assert.deepEqual(out.bonus, {});
+  assert.deepEqual(out.cost, {});
+  assert.deepEqual(out.internalized, []);
+});
+
+test('passiveBonuses: aggregates bonus + cost across internalized thoughts', () => {
+  resetCache();
+  const s = createCabinetState();
+  // e_voce_collettiva: +attack_mod 1 / cost defense_dc 1
+  // i_osservatore: +attack_range 1 / cost ap 1
+  // Both tier 1 with defined effects in YAML.
+  mergeUnlocked(s, ['e_voce_collettiva', 'i_osservatore']);
+  s.internalized.add('e_voce_collettiva');
+  s.internalized.add('i_osservatore');
+  const out = passiveBonuses(s);
+  assert.equal(out.bonus.attack_mod, 1);
+  assert.equal(out.bonus.attack_range, 1);
+  assert.equal(out.cost.defense_dc, 1);
+  assert.equal(out.cost.ap, 1);
+  assert.equal(out.internalized.length, 2);
+});
+
+test('passiveBonuses: stacks when the same stat appears in multiple thoughts', () => {
+  resetCache();
+  const s = createCabinetState();
+  // p_adattatore bonus ap 1 + j_disciplina bonus attack_mod 1.
+  // e_voce_collettiva bonus attack_mod 1 → stacks with j_disciplina.
+  mergeUnlocked(s, ['e_voce_collettiva', 'j_disciplina']);
+  s.internalized.add('e_voce_collettiva');
+  s.internalized.add('j_disciplina');
+  const out = passiveBonuses(s);
+  assert.equal(out.bonus.attack_mod, 2);
+});
+
+test('passiveBonuses: thoughts without effect_bonus/cost contribute nothing', () => {
+  resetCache();
+  const s = createCabinetState();
+  // tier 2 thought: no effect_bonus defined in YAML (only tier 1 populated)
+  mergeUnlocked(s, ['e_scintilla_carisma']);
+  s.internalized.add('e_scintilla_carisma');
+  const out = passiveBonuses(s);
+  assert.deepEqual(out.bonus, {});
+  assert.deepEqual(out.cost, {});
+  assert.deepEqual(out.internalized, ['e_scintilla_carisma']);
+});
+
+test('snapshotCabinet: returns serialisable shape with slots stats', () => {
+  const s = createCabinetState({ slotsMax: 2 });
+  mergeUnlocked(s, ['e_voce_collettiva', 'i_osservatore']);
+  startResearch(s, 'e_voce_collettiva');
+  s.internalized.add('i_osservatore');
+  const snap = snapshotCabinet(s);
+  assert.deepEqual(Object.keys(snap).sort(), [
+    'internalized',
+    'researching',
+    'slots_max',
+    'slots_used',
+    'unlocked',
+  ]);
+  assert.equal(snap.slots_max, 2);
+  assert.equal(snap.slots_used, 2);
+  assert.equal(snap.researching.length, 1);
+  assert.equal(snap.researching[0].id, 'e_voce_collettiva');
+  assert.equal(snap.researching[0].cost_remaining, 1);
+  assert.deepEqual(snap.internalized, ['i_osservatore']);
+});
+
+test('full lifecycle: unlock → research → tick → internalize → forget → slot freed', () => {
+  resetCache();
+  const s = createCabinetState({ slotsMax: 1 });
+  mergeUnlocked(s, ['e_voce_collettiva']);
+  const r1 = startResearch(s, 'e_voce_collettiva');
+  assert.equal(r1.ok, true);
+  const t1 = tickResearch(s);
+  assert.deepEqual(t1.promoted, ['e_voce_collettiva']);
+  assert.equal(canResearchMore(s), false); // 1 slot, internalized
+  const f1 = forgetThought(s, 'e_voce_collettiva');
+  assert.equal(f1.ok, true);
+  assert.equal(f1.freed_from, 'internalized');
+  assert.equal(canResearchMore(s), true);
 });


### PR DESCRIPTION
Closes narrative-illuminator P0 residual (Disco Elysium Thought Cabinet) from [2026-04-25 handoff](docs/planning/2026-04-25-illuminator-orchestra-handoff.md). Phase 1 (threshold unlock) already shipped. This PR wires Phase 2: **research slot → wait N encounters → permanent passive effect + commitment cost, with explicit forget**.

## Summary
- **YAML schema** — 4 optional fields per thought: `research_cost_encounters` (falls back on tier), `effect_bonus`/`effect_cost` (stat→delta dicts), `effect_cost_hint_it` (UI). 6 tier-1 thoughts (E/I/N/S/P/J) populated with concrete effects; the other 12 remain effect-less until content follow-up.
- **Pure state machine** in `thoughtCabinet.js` — `createCabinetState`, `slotsUsed`, `canResearchMore`, `resolveResearchCost`, `mergeUnlocked`, `startResearch`, `tickResearch`, `forgetThought`, `passiveBonuses`, `snapshotCabinet`. Default `slots_max=3`. Transitions return `{ ok, error? }`.
- **Routes** on `session.js`:
  - `GET /:id/thoughts` — now additively returns `researching`, `internalized`, `slots_max`, `slots_used`, `passive_bonus`, `passive_cost` on top of existing `unlocked`/`newly` (Phase 1 clients unaffected)
  - `POST /:id/thoughts/research { unit_id, thought_id, encounter? }` — 409 on `thought_not_found|not_unlocked|already_researching|already_internalized|no_free_slot`
  - `POST /:id/thoughts/forget { unit_id, thought_id }` — 409 on `not_active`, frees slot whether researching or internalized
  - `POST /:id/thoughts/tick { delta?=1, unit_ids? }` — advances timers; promotes to internalized on hit 0. Caller-driven (round orchestrator untouched)
- Session store migrated from `Map<unitId, Set>` → `Map<unitId, CabinetState>`; teardown cleanup preserved (Codex #1702).

## Out of scope (follow-up)
- Combat resolver wire for `passive_bonus`/`passive_cost` (engine + API shipped now; resolver integration + UI thought-sphere reveal = separate PRs)
- Effects on the remaining 12 tier-2/3 thoughts (design-content follow-up)

## Validation
- `tests/api/thoughtCabinet.test.js` — **39/39** (16 Phase 1 preserved + 23 new)
- `tests/api/sessionThoughts.test.js` — **11/11** (4 Phase 1 preserved + 7 new integration)
- Full `node --test tests/api/*.test.js` — **621/621** (no regression)
- AI 307/307 · Services 257/257 · Pytest **948/948** · `format:check` · governance 0/0
- No new deps

## Refs
- Agent: [.claude/agents/narrative-design-illuminator.md](.claude/agents/narrative-design-illuminator.md) P0 block (line 96-112)
- Parent Phase 1: existing `data/core/thoughts/mbti_thoughts.yaml` + `thoughtCabinet.js`
- Disco Elysium Thought Cabinet devblog — https://discoelysium.com/devblog/2019/09/30/introducing-the-thought-cabinet

## Test plan
- [x] `node --test tests/api/thoughtCabinet.test.js` → 39/39
- [x] `ORCHESTRATOR_AUTOCLOSE_MS=2000 node --test tests/api/sessionThoughts.test.js` → 11/11
- [x] Full api suite 621/621
- [x] Pytest 948/948
- [x] Format + governance
- [ ] CI green

## Rollback
Revert this PR — GET endpoint returns additive Phase 2 keys as empty (clients reading only Phase 1 keys unaffected). No schema migration, no route rename, no new dep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)