### PR TITLE
docs(handoff): bump COMPACT_CONTEXT + handoff for 3 P0 closures (afternoon session)

### DIFF
--- a/COMPACT_CONTEXT.md
+++ b/COMPACT_CONTEXT.md
@@ -8,12 +8,31 @@
 ## Progetto
 
 - **Nome**: Evo-Tactics
-- **Versione compact**: v3 (post 5 P0 illuminator residuals merged sessione 2026-04-25 notte)
-- **Ultimo aggiornamento**: 2026-04-25 (sessione autonoma 5 PR mergiati: SPRT, Macro-economy, PI Monte Carlo, Briefing variations, XP audit, QBN engine)
+- **Versione compact**: v4 (post 3 P0 residuals chiusi sessione 2026-04-25 pomeriggio)
+- **Ultimo aggiornamento**: 2026-04-25 (sessione autonoma 3 PR mergiati: pypdf test fix, MAP-Elites HTTP fitness wrapper, Thought Cabinet Phase 2)
 
 ## ⚡ TL;DR per ripartire
 
-**6 agent illuminator pronti** + **6 P0 chiusi sessione 2026-04-25** + 80 nuovi test services + 24 pytest. Pattern stdlib-only + js-yaml + mulberry32 seed validato 6×. **NON perdere l'approccio research-first agent-driven**. Vedi handoff: [`docs/planning/2026-04-25-illuminator-orchestra-handoff.md`](docs/planning/2026-04-25-illuminator-orchestra-handoff.md).
+**6 agent illuminator pronti** + **10 P0 chiusi totali** (7 sessione notte + 3 sessione pomeriggio) + **9° / 10° P0 chiusi** in questa sessione (HTTP wrapper + thought cabinet internalization). Pattern stdlib-only + js-yaml + mulberry32 + monkeypatch DI validato 7×. **NON perdere l'approccio research-first agent-driven**. Vedi handoff: [`docs/planning/2026-04-25-illuminator-orchestra-handoff.md`](docs/planning/2026-04-25-illuminator-orchestra-handoff.md).
+
+## 🆕 Sessione 2026-04-25 pomeriggio (autonoma, utente trust esteso)
+
+**3 PR mergiati main consecutivi**:
+
+| PR    | Title                                                   | SHA        |
+| ----- | ------------------------------------------------------- | ---------- |
+| #1767 | fix(tests): pytest.importorskip pypdf in collection     | `02832dfc` |
+| #1768 | feat(balance): MAP-Elites HTTP fitness wrapper P0 #2    | `fcd50315` |
+| #1769 | feat(narrative): Thought Cabinet Phase 2 (Disco intern) | `b04f3a92` |
+
+**Tests aggregate**: AI 307/307 · services 257/257 · pytest **948/948** (+12 map_elites/restricted_play) · thoughtCabinet **39/39** · sessionThoughts **11/11** · api **621/621** · governance 0/0.
+
+**P0 residuali chiusi**:
+
+- balance: **MAP-Elites HTTP fitness wrapper** (#1768) — wire `run_one` HTTP, --fitness http|synthetic CLI flag, `unit_override` backward-compat hook su restricted_play, `build_http_evaluator` DI-testable
+- narrative: **Thought Cabinet Phase 2** (#1769) — createCabinetState + startResearch + tickResearch + forgetThought + passiveBonuses, 3 REST route (research/forget/tick), 6 tier-1 thoughts con effect_bonus+effect_cost
+
+**Fix bonus**: PR #1767 pypdf test collection error (local venv parziale) — `pytest.importorskip` allinea al pattern lazy del tool coperto.
 
 ## 🆕 Sessione 2026-04-25 notte (autonoma post user trust)
 
@@ -33,7 +52,7 @@
 
 **7 P0 chiusi**: balance SPRT, economy Machinations diagram, economy PI Monte Carlo, narrative briefing variations, narrative QBN, pcg XP audit, balance MAP-Elites + bonus governance bug fix.
 
-**P0 residuali rimanenti**: balance MCTS (~4h, needs session state clone API), ui intent preview (~4h, UI runtime risk), ui threat zone toggle (~3h, UI), pcg objective variety (~8h), narrative Disco Elysium thought cabinet (~6h).
+**P0 residuali rimanenti** (post sessione pomeriggio): balance MCTS (~4h, blocked by session state clone API), ui intent preview (~4h, UI runtime risk), ui threat zone toggle (~3h, UI runtime risk), pcg objective variety (~8h). Thought Cabinet Phase 2 shipped (#1769) — UI reveal + combat resolver wire = follow-up P1.
 
 ## Stato attuale (post sessione 2026-04-24/25 notte)
 

--- a/docs/planning/2026-04-25-illuminator-orchestra-handoff.md
+++ b/docs/planning/2026-04-25-illuminator-orchestra-handoff.md
@@ -26,9 +26,9 @@ related:
 
 # 🚀 NEXT SESSION HANDOFF — Illuminator Orchestra
 
-**Data handoff**: 2026-04-25
+**Data handoff**: 2026-04-25 (bump pomeriggio — +3 PR chiusi)
 **Per**: Claude Code prossima sessione (autonoma o user-driven)
-**Status**: 🟢 6 agent live + 6 runtime apply + workflow validated 6×
+**Status**: 🟢 6 agent live + **10 P0 runtime apply chiusi** + workflow validated 7×
 **Imperativo**: NON perdere l'approccio agent-driven research-first.
 
 ---
@@ -133,30 +133,38 @@ Use ONLY if dominio non coperto da agenti esistenti.
 
 ### P0 residuali agent esistenti (post 2026-04-25 sessione autonoma)
 
-**Closed in main** (sessione 2026-04-25 notte, 7 PR mergiati):
+**Closed in main** (sessione 2026-04-25 notte + pomeriggio, 10 PR mergiati):
 
-| Agent                        | P0                                           | Effort | PR    | SHA        |
-| ---------------------------- | -------------------------------------------- | :----: | ----- | ---------- |
-| balance-illuminator          | SPRT sequential early-stop                   |  ~2h   | #1758 | `7e17d84c` |
-| economy-design-illuminator   | Machinations diagram artifact                |  ~3h   | #1758 | `7e17d84c` |
-| economy-design-illuminator   | Monte Carlo PI shop sim (follow-up #6)       |  ~4h   | #1759 | `488da05b` |
-| narrative-design-illuminator | Tutorial briefing variations (per-encounter) |  ~4h   | #1760 | `6f397e6d` |
-| pcg-level-design-illuminator | XP budget encounter builder                  |  ~6h   | #1762 | `9901407e` |
-| narrative-design-illuminator | QBN MBTI-gated events (campaign-arc)         |  ~6h   | #1763 | `bec2bcd6` |
-| balance-illuminator          | MAP-Elites lightweight (Mouret 2015)         |  ~6h   | #1765 | `b22fc2b7` |
+| Agent                        | P0                                                  | Effort | PR    | SHA        |
+| ---------------------------- | --------------------------------------------------- | :----: | ----- | ---------- |
+| balance-illuminator          | SPRT sequential early-stop                          |  ~2h   | #1758 | `7e17d84c` |
+| economy-design-illuminator   | Machinations diagram artifact                       |  ~3h   | #1758 | `7e17d84c` |
+| economy-design-illuminator   | Monte Carlo PI shop sim (follow-up #6)              |  ~4h   | #1759 | `488da05b` |
+| narrative-design-illuminator | Tutorial briefing variations (per-encounter)        |  ~4h   | #1760 | `6f397e6d` |
+| pcg-level-design-illuminator | XP budget encounter builder                         |  ~6h   | #1762 | `9901407e` |
+| narrative-design-illuminator | QBN MBTI-gated events (campaign-arc)                |  ~6h   | #1763 | `bec2bcd6` |
+| balance-illuminator          | MAP-Elites lightweight (Mouret 2015)                |  ~6h   | #1765 | `b22fc2b7` |
+| balance-illuminator          | **MAP-Elites HTTP fitness wrapper**                 |  ~2h   | #1768 | `fcd50315` |
+| narrative-design-illuminator | **Thought Cabinet Phase 2 (Disco internalization)** |  ~2h   | #1769 | `b04f3a92` |
 
-**Bonus shipped**: `tools/check_docs_governance.py` parser bug fix (5 false-positive warnings) + `docs/hubs/incoming.md` stale review bumped (in PR #1758) + handoff doc continuity update (#1764).
+**Bonus shipped**: `tools/check_docs_governance.py` parser bug fix (5 false-positive warnings) + `docs/hubs/incoming.md` stale review bumped (in PR #1758) + handoff doc continuity update (#1764) + `tests/test_investigate_sources.py` `pytest.importorskip` (PR #1767, `02832dfc` — unblocks local pytest collection on venv senza pypdf).
 
 **Still residual**:
 
 | Agent                        | P0 residual                                 | Effort |               Risk               |
 | ---------------------------- | ------------------------------------------- | :----: | :------------------------------: |
 | balance-illuminator          | MCTS smart policy (state clone API)         |  ~4h   | mid (needs session clone helper) |
-| balance-illuminator          | MAP-Elites HTTP fitness wrapper             |  ~2h   |   low (extends shipped engine)   |
 | ui-design-illuminator        | Intent preview floating-icon wire           |  ~4h   |        high (UI runtime)         |
 | ui-design-illuminator        | Threat zone toggle phone                    |  ~3h   |        high (UI runtime)         |
 | pcg-level-design-illuminator | Objective variety (rescue/timer/extraction) |  ~8h   |       mid (data + engine)        |
-| narrative-design-illuminator | Disco Elysium thought cabinet               |  ~6h   |    mid (frontend integration)    |
+
+**Follow-up derivati dai P0 chiusi** (P1 candidates):
+
+| Origin PR | Follow-up                                                                                     | Effort |             Risk             |
+| --------- | --------------------------------------------------------------------------------------------- | :----: | :--------------------------: |
+| #1769     | Thought Cabinet: UI thought-sphere reveal + combat resolver wire (passive_bonus/passive_cost) |  ~4h   | high (UI runtime + resolver) |
+| #1769     | Thought Cabinet: populate effects on the remaining 12 tier-2/3 thoughts                       |  ~2h   |   low (content-only YAML)    |
+| #1768     | MAP-Elites HTTP: run archive live + commit report + tune knob exhaustion                      |  ~3h   |   mid (needs backend live)   |
 
 ### Big rocks (userland-bound o BIG effort)
 
@@ -166,14 +174,14 @@ Use ONLY if dominio non coperto da agenti esistenti.
 
 ---
 
-## 🚦 Test baseline (post 2026-04-25 sessione autonoma)
+## 🚦 Test baseline (post 2026-04-25 sessione pomeriggio)
 
 - AI regression `tests/ai/*.test.js` → **307/307 verde**
-- Services `tests/services/*.test.js` → **257/257 verde** (was 177, +80: 39 briefing + 41 QBN)
-- Pytest scripts: **384 totali** (273 pre-existing + 27 SPRT + 24 PI shop + 24 XP budget + 36 MAP-Elites)
-- New tests aggregate sessione: **140 nuovi** (39+41 services + 27+24+24+36 pytest)
-- Format check: verde
-- Governance strict: **0 errors / 0 warnings** (parser bug fix + stale incoming bump in #1758)
+- Services `tests/services/*.test.js` → **257/257 verde**
+- Pytest suite full → **948 verde** (was 936, +12: 9 map_elites + 3 restricted_play in #1768)
+- `tests/api/*.test.js` → **621/621 verde** (includes +30 thoughtCabinet/sessionThoughts Phase 2 in #1769)
+- New tests aggregate pomeriggio: **+42** (12 pytest + 23 unit thought + 7 integration route)
+- Format check: verde · Governance strict: **0 errors / 0 warnings**
 
 **Pre-flight prossima sessione**:
 


### PR DESCRIPTION
Continuity doc bump. Records the 3 PR merged this afternoon, follow-up to the 7-PR night batch documented in #1764.

## Merged this afternoon
- [#1767](https://github.com/MasterDD-L34D/Game/pull/1767) `02832dfc` — `pytest.importorskip('pypdf')` in `tests/test_investigate_sources.py` (unblocks local pytest collection when venv is partial)
- [#1768](https://github.com/MasterDD-L34D/Game/pull/1768) `fcd50315` — MAP-Elites HTTP fitness wrapper (balance-illuminator P0 #2 closed; `unit_override` hook on `restricted_play.run_one`, `build_http_evaluator` DI, `--fitness http` CLI)
- [#1769](https://github.com/MasterDD-L34D/Game/pull/1769) `b04f3a92` — Thought Cabinet Phase 2 (narrative-illuminator P0 closed; research timer + internalize + forget + passiveBonuses + 3 REST routes + 6 tier-1 thoughts with concrete effect_bonus/cost)

## Doc changes
- `COMPACT_CONTEXT.md` — version bumped to v4, adds "Sessione 2026-04-25 pomeriggio" block above the night one
- `docs/planning/2026-04-25-illuminator-orchestra-handoff.md`:
  - Header bumped (status 10 P0 closed, workflow 6× → 7×)
  - "Closed in main" table — added #1768 + #1769 rows
  - "Still residual" — dropped MAP-Elites wrapper + Disco Elysium thought cabinet
  - New "Follow-up derivati dai P0 chiusi" table with the 3 P1 candidates (UI reveal + resolver wire + tier-2/3 content)
  - Test baseline snapshot updated (948 pytest + 621 api + 39/11 thought-specific)

## Validation
- `npm run format:check` ✅
- `tools/check_docs_governance.py --strict` → 0 errors / 0 warnings (pre-commit verified)
- No code change

## Refs
- Companion PRs: #1767, #1768, #1769
- Previous bump: #1764 / #1766

🤖 Generated with [Claude Code](https://claude.com/claude-code)