### PR TITLE
chore(claude): P0 insights audit stack — ops rules + PostEdit hook + /handoff

### DIFF
--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -1,0 +1,138 @@
+---
+name: handoff
+description: Generate end-of-session handoff doc with PR list, blockers, next entry point, and memory dump
+user_invocable: true
+---
+
+# Handoff
+
+Codifica del rituale ricorrente "fine sessione → handoff doc per next session". Nasce da insights audit 2026-04-25 (pattern PR-merge-and-handoff ripetuto 8-12x/sessione, sprint compaction).
+
+## Quando usarlo
+
+- Fine sessione con ≥3 PR mergiati o ≥1 milestone chiusa
+- Prima di `/clear` se vuoi continuità nella prossima sessione
+- Dopo un blocco / decisione architetturale che next session deve sapere
+
+## Argomenti
+
+Optional: titolo sprint o milestone (es. `M14-D` o `vision-gap-V8`). Se omesso, infer da branch + commit recenti.
+
+## Step
+
+### 1. Identifica scope sessione
+
+```bash
+git log --oneline --since="6 hours ago" | head -20
+gh pr list --state merged --search "merged:>$(date -u -d '6 hours ago' +%Y-%m-%dT%H:%M:%SZ)" --limit 20 --json number,title,mergedAt,mergeCommit 2>/dev/null || echo "no gh / fallback to git log"
+```
+
+### 2. Scrape PR closure data
+
+Per ogni PR mergiato in finestra:
+
+- numero + titolo
+- SHA merge commit
+- 1-line summary del cambio (NON copiare PR body intero)
+- test impact (test count delta, suite affected)
+
+### 3. Identifica blockers / residual
+
+Cerca segnali nel branch + memoria conversazione:
+
+- `TODO`, `FIXME`, `HACK` aggiunti net (post-sessione)
+- Test skippati
+- File `docs/blockers/*` creati
+- Decisioni rimandate ("deferred", "next session")
+
+### 4. Identifica next entry point
+
+Cosa deve fare la prossima sessione:
+
+- File:line specifico del prossimo edit (se sai dove)
+- Comando da rieseguire (es. calibration harness N=10)
+- Docs da leggere prima (handoff, ADR, planning)
+
+### 5. Memory dump check
+
+Se sessione ha prodotto pattern riutilizzabili:
+
+- Nuovo workflow validato → propose `feedback_*.md` save
+- Decisione progetto durevole → propose `project_*.md` save
+- Path/system esterno scoperto → propose `reference_*.md` save
+
+NON salvare auto. Lista candidati, chiedi conferma user.
+
+### 6. Genera handoff doc
+
+Path: `docs/planning/$(date +%Y-%m-%d)-<slug>-handoff.md` o `docs/process/sprint-$(date +%Y-%m-%d)-<slug>.md`
+
+Template:
+
+```markdown
+---
+title: Handoff <slug>
+date: YYYY-MM-DD
+sprint: <Mxx / vision-gap / etc>
+doc_status: active
+workstream: cross-cutting
+last_verified: YYYY-MM-DD
+source_of_truth: false
+language: it
+---
+
+# Handoff <slug> — YYYY-MM-DD
+
+## TL;DR (gamer recap pattern, opzionale)
+
+3-5 bullet, what shipped + pillars moved + next unblock.
+
+## PR mergiati (N)
+
+| PR    | Scope  | SHA    | Test    |
+| ----- | ------ | ------ | ------- |
+| #XXXX | titolo | abc123 | +X test |
+
+## Pillar / milestone delta
+
+| # | Before | After | Note |
+
+## Blockers residui
+
+- [ ] <ticket>: descrizione + path:line se noto
+- [ ] ...
+
+## Next entry point
+
+1. **First action**: <comando o file:line>
+2. **Reference**: <docs da leggere>
+3. **Estimated effort**: <h>
+
+## Memory candidates
+
+- [ ] feedback\_<slug>: <pattern emerso>
+- [ ] project\_<slug>: <stato durevole>
+- [ ] reference\_<slug>: <sistema esterno>
+```
+
+### 7. Update CLAUDE.md sprint context
+
+Aggiungi block "Sessione YYYY-MM-DD <slug>" in sezione "Sprint context" di CLAUDE.md. Usa pattern già presente nei block precedenti (PR table + bullet milestone). NON cancellare block precedenti — append cronologico.
+
+### 8. Commit handoff
+
+```bash
+git add docs/planning/<file>.md CLAUDE.md
+git commit -m "docs(handoff): <slug> — <N> PR closure + next entry"
+```
+
+## Output finale
+
+```
+✅ Handoff scritto: docs/planning/<file>.md
+✅ CLAUDE.md sprint context aggiornato
+✅ N memory candidate (chiedi conferma per save)
+📌 Next session entry: <first action>
+```
+
+Caveman compatible. Tabelle inline OK fino a ~10 righe, oltre → file solo.

--- a/.claude/hooks/post-edit-validate.sh
+++ b/.claude/hooks/post-edit-validate.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# PostToolUse hook: validate config files after Edit/Write.
+# Insights audit 2026-04-25 — kill silent config corruption (LiteLLM enforced_params, denyCommands, Langfuse image).
+# Exit 0 always (warn-only). Output goes to transcript, never blocks tool.
+
+set -uo pipefail
+
+INPUT=$(cat)
+FILE=$(printf '%s' "$INPUT" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d.get("tool_input",{}).get("file_path",""))' 2>/dev/null || true)
+
+[ -z "${FILE:-}" ] && exit 0
+[ ! -f "$FILE" ] && exit 0
+
+case "$FILE" in
+  *.json)
+    if command -v jq >/dev/null 2>&1; then
+      jq empty "$FILE" >/dev/null 2>&1 || echo "[hook] WARN: invalid JSON in $FILE — re-check edit"
+    else
+      python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$FILE" >/dev/null 2>&1 || echo "[hook] WARN: invalid JSON in $FILE — re-check edit"
+    fi
+    ;;
+  *.yaml|*.yml)
+    python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" "$FILE" >/dev/null 2>&1 || echo "[hook] WARN: invalid YAML in $FILE — re-check edit"
+    ;;
+  *.py)
+    if command -v ruff >/dev/null 2>&1; then
+      ruff check "$FILE" 2>&1 | head -5 || true
+    fi
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/post-edit-validate.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,41 @@ multi-step sequences where fragment ambiguity risks misread, user confused or re
 
 ---
 
+## 🔁 Autonomous Execution (always on)
+
+Derived from `/insights` audit 2026-04-25 — friction "stopping early" + "config not applied" recurring.
+
+- **Non fermarsi prematuramente**: continuare fino a goal esplicito O blocking error reale. Se "perché ci fermiamo?" è già stato detto in passato → quel pattern è proibito.
+- **Surface blocker, don't end session**: se mancano prerequisiti (file, dipendenza, env), riporta blocco esplicito e proponi 2-3 path alternativi. Non inventare il piano mancante.
+- **Verify config changes**: dopo ogni edit a `*.json`, `*.yaml`, `.env`, config service → (1) re-read file, (2) restart/reload servizio se applicable, (3) probe live (test API call / `curl /health`). Mai "configurato X" senza i 3 step.
+- **Stop-on-missing-prereq**: se handoff doc / planning file referenziato non esiste, FERMA e chiedi. Non auto-creare il piano mancante per "salvare" la sessione.
+
+## 🌳 Worktree & Path Discipline
+
+Friction ricorrente da insights: 3 sessioni hanno editato main repo invece del worktree.
+
+- **Pre-edit check**: `pwd` + `git rev-parse --show-toplevel` prima di edit non triviali se incerto su contesto. Working directory in CLAUDE_WORKING_DIR ha priorità sui path assunti dalla memoria.
+- **Worktree path detection**: se `pwd` contiene `.claude/worktrees/<slug>/`, sei in worktree isolato. Edit qui, NON nel main repo path.
+- **Missing file = ASK**: se path referenziato non esiste (`docs/planning/2026-XX-XX-*.md`, ADR, handoff), chiedi prima di fabbricare. Lista path candidati via `ls`/`find` se utile.
+
+## 📤 Output Token Limits
+
+3 sessioni perse per output >500 token max.
+
+- **Long deliverables → file**: audit, multi-file summary, analisi ≥30 righe → scrivi in `docs/reports/YYYY-MM-DD-<slug>.md` o `docs/playtest/`, poi referenzia path. NON dump inline.
+- **Recap concisi**: end-of-turn = 1-2 frasi. Tabelle PR / ranked list ≤10 righe inline OK. Oltre → file.
+- **Tool result siphon**: se Read/Bash ritorna >2000 char e ti serve solo summary, riassumi in 5 bullet inline e referenzia il file.
+
+## 📡 System Notification Handling
+
+1 sessione: 12 timeout notifications interpretate come user message.
+
+- **Ripetizioni identiche = system signal**: stesso messaggio/error 2+ volte di fila NON è il user che ripete. È un loop tool / hook / notifier rotto. Diagnostica il sender, non rispondere conversazionalmente.
+- **Subagent timeout 2x = stop retry**: se subagent stesso pattern timeout 2 volte, FERMA. Investiga prompt size / tool config. Non fare 5+ retry sperando vada.
+- **Distinguish hook output vs user**: `<user-prompt-submit-hook>` e similari sono hook. Riconosci tag, non rispondere come a un user.
+
+---
+
 ## Project overview
 
 **Evo-Tactics** is a co-op tactical game (d20-based, modular evolutionary progression) delivered as a polyglot monorepo. It ships YAML datasets, Python + TypeScript CLIs, an Express "Idea Engine" backend, a Vue/Vite dashboard, and publishing/validation pipelines. Most docs, commit messages, and inline comments are written in **Italian** — match that language when editing docs, but code identifiers stay English.


### PR DESCRIPTION
## Summary

Stack P0 derivato da `/insights` audit 2026-04-25 (51 sessioni / 161 commit / 31 analizzate, 7 giorni). Chiude 4 friction pattern ricorrenti senza nuove dipendenze.

- **CLAUDE.md +4 sezioni operative** (autonomous execution, worktree discipline, output token limits, system notification handling) — kill 4 friction pattern ricorrenti dell'audit
- **PostToolUse hook** warn-only su `Edit|Write|MultiEdit` — valida JSON/YAML/Python dopo ogni edit. Avrebbe pescato LiteLLM enforced_params + Langfuse image + denyCommands silent corruption documentati nel report
- **`/handoff` slash command** — codifica rituale ricorrente PR-merge-and-handoff (8-12x/sessione observati). Template doc + memory candidate prompt + CLAUDE.md sprint context append cronologico

## File changed

| File | LOC | Effetto |
|------|----:|---------|
| `CLAUDE.md` | +35 | 4 nuove sezioni operative |
| `.claude/settings.json` | +15 | hook config |
| `.claude/hooks/post-edit-validate.sh` | +32 | warn-only validator |
| `.claude/commands/handoff.md` | +138 | nuovo slash command |

**Total**: +220, -0 · 4 file nuovi/modificati · zero dipendenze nuove.

## Smoke test (eseguito pre-commit)

- bad JSON → `[hook] WARN: invalid JSON in /tmp/bad.json` ✅
- good JSON → silent ✅
- non-config file (es. `.md`) → silent ✅
- `/handoff` registrato e visibile in skill list runtime ✅

## Test plan

- [x] `python3 -c "import json; json.load(open('.claude/settings.json'))"` passa
- [x] Hook smoke test 3 cases (bad/good/non-config)
- [x] `/handoff` appare in slash command registry runtime
- [ ] Verifica next-session: hook attivo all'edit di un `.json` (validation in vivo)
- [ ] Verifica next-session: `/handoff` produce doc in `docs/planning/` con template completo

## Changelog

- Aggiunto: 4 sezioni operative permanenti in CLAUDE.md (autonomous, worktree, output, signals)
- Aggiunto: PostToolUse hook warn-only validazione JSON/YAML/Python
- Aggiunto: `/handoff` slash command end-of-session ritual

## 03A Rollback Plan

1. `git revert <merge-commit>` su main
2. Affected: solo `.claude/` scope (hook + skill + CLAUDE.md ops sections)
3. Data migration: nessuna
4. Monitoring: post-revert, hook deve smettere di emettere `[hook] WARN` lines; `/handoff` deve sparire da skill list runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)