### PR TITLE
feat(combat): synergy combo detection (Skiv ticket #2 — Sprint B)

### DIFF
--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -266,6 +266,12 @@ function publicSessionView(session) {
     previous_round_combos: Array.isArray(session.previous_round_combos)
       ? session.previous_round_combos
       : [],
+    last_round_synergies: Array.isArray(session.last_round_synergies)
+      ? session.last_round_synergies
+      : [],
+    previous_round_synergies: Array.isArray(session.previous_round_synergies)
+      ? session.previous_round_synergies
+      : [],
   };
 }
 

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -32,6 +32,11 @@ const {
   recordAttackForCombo,
   resetRoundAttackTracker,
 } = require('../services/squadCoordination');
+const {
+  detectSynergyTrigger,
+  recordSynergyFire,
+  resetRoundSynergyTracker,
+} = require('../services/combat/synergyDetector');
 const { tick: reinforcementTick } = require('../services/combat/reinforcementSpawner');
 const { evaluateObjective } = require('../services/combat/objectiveEvaluator');
 const { tick: missionTimerTick } = require('../services/combat/missionTimer');
@@ -370,6 +375,31 @@ function createRoundBridge(deps) {
           capturedResults.combo = { ...comboInfo, bonus_applied: applied };
         }
         recordAttackForCombo(session, actor, target, comboInfo);
+        // Skiv ticket #2: synergy combo (`echo_backstab` & co.). Indipendente
+        // dal focus_fire — può sommarsi nello stesso attacco. Cooldown 1/round.
+        const synergyInfo = detectSynergyTrigger(session, actor, target);
+        if (res.result && res.result.hit && synergyInfo.triggered) {
+          let appliedSyn = 0;
+          if (res.damageDealt > 0) {
+            const extra = synergyInfo.bonus_damage;
+            const hpNow = Number(target.hp || 0);
+            appliedSyn = Math.min(extra, hpNow);
+            if (appliedSyn > 0) {
+              target.hp = hpNow - appliedSyn;
+              capturedResults.damageDealt =
+                Number(capturedResults.damageDealt || res.damageDealt) + appliedSyn;
+              if (session.damage_taken) {
+                session.damage_taken[target.id] =
+                  (session.damage_taken[target.id] || 0) + appliedSyn;
+              }
+              if (target.hp <= 0 && !capturedResults.killOccurred) {
+                capturedResults.killOccurred = true;
+              }
+            }
+          }
+          capturedResults.synergy = { ...synergyInfo, bonus_applied: appliedSyn };
+          recordSynergyFire(session, actor, target, synergyInfo, appliedSyn);
+        }
         for (const uOrch of next.units) {
           const uLegacy = session.units.find((u) => u.id === uOrch.id);
           if (uLegacy) {
@@ -512,6 +542,7 @@ function createRoundBridge(deps) {
       parry: capturedResults.parry,
       intercept: capturedResults.intercept || null,
       combo: capturedResults.combo || null,
+      synergy: capturedResults.synergy || null,
       state: publicSessionView(session),
       round_wrapper: true,
       round_phase: result.nextState.round_phase,
@@ -675,6 +706,7 @@ function createRoundBridge(deps) {
           );
 
           let combo = null;
+          let synergy = null;
           if (!isSis) {
             const comboInfo = detectFocusFireCombo(session, actor, target);
             if (res.result && res.result.hit && comboInfo.is_combo && res.damageDealt > 0) {
@@ -692,6 +724,27 @@ function createRoundBridge(deps) {
               combo = { ...comboInfo, bonus_applied: applied };
             }
             recordAttackForCombo(session, actor, target, comboInfo);
+          }
+          // Skiv ticket #2: synergy fires for any actor (player + sistema)
+          // se la specie ha le parts richieste. Cooldown 1/round per actor.
+          const synergyInfo = detectSynergyTrigger(session, actor, target);
+          if (res.result && res.result.hit && synergyInfo.triggered) {
+            let appliedSyn = 0;
+            if (res.damageDealt > 0) {
+              const extra = synergyInfo.bonus_damage;
+              const hpNow = Number(target.hp || 0);
+              appliedSyn = Math.min(extra, hpNow);
+              if (appliedSyn > 0) {
+                target.hp = hpNow - appliedSyn;
+                res.damageDealt = res.damageDealt + appliedSyn;
+                if (session.damage_taken) {
+                  session.damage_taken[target.id] =
+                    (session.damage_taken[target.id] || 0) + appliedSyn;
+                }
+              }
+            }
+            synergy = { ...synergyInfo, bonus_applied: appliedSyn };
+            recordSynergyFire(session, actor, target, synergyInfo, appliedSyn);
           }
 
           const event = buildAttackEvent({
@@ -740,6 +793,7 @@ function createRoundBridge(deps) {
             ia_rule: action.source_ia_rule,
             parry: res.parry,
             combo,
+            synergy,
           });
         }
       } else if (action.type === 'move' && action.move_to) {
@@ -845,6 +899,8 @@ function createRoundBridge(deps) {
     // Reset tracker combo a fine round: archivia last_round_combos come
     // previous_round_combos (letto dal debrief) e pulisce la lista attacchi.
     resetRoundAttackTracker(session);
+    // Skiv ticket #2: reset synergy cooldown + archivia last_round_synergies.
+    resetRoundSynergyTracker(session);
     session.roundState = adaptSessionToRoundState(session);
 
     const { hazardEvents, bleedingEvents } = await applyEndOfRoundSideEffects(session);
@@ -1175,6 +1231,7 @@ function createRoundBridge(deps) {
         if (error) return res.status(error.status).json(error.body);
 
         resetRoundAttackTracker(session);
+        resetRoundSynergyTracker(session);
 
         const { hazardEvents, bleedingEvents } = await applyEndOfRoundSideEffects(session);
 

--- a/apps/backend/services/combat/synergyDetector.js
+++ b/apps/backend/services/combat/synergyDetector.js
@@ -1,0 +1,188 @@
+// =============================================================================
+// Synergy Combo Detection — Pillar 1 (Tattica) + Pillar 4 (Identità)
+//
+// Pattern Skiv ticket #2: la `species.yaml` definisce `catalog.synergies[]`
+// con `when_all: [slot.part, ...]`. Ogni specie ha `default_parts` da cui si
+// derivano le combinazioni `slot.part`. Questo modulo fa il match runtime e
+// emette bonus_damage quando le precondizioni di una synergy sono tutte vere
+// per l'attaccante. Cooldown: 1 fire / actor / round (pattern reaction cap).
+//
+// Effect schema (additivo, opzionale per synergy):
+//   effect:
+//     bonus_damage: 1   # default DEFAULT_BONUS_DAMAGE se assente
+//
+// Tracking session:
+//   - session._synergy_last_fire: { actor_id: turn }   cooldown
+//   - session.last_round_synergies: [{ actor_id, target_id, synergies, bonus_applied, turn }]
+//   - session.previous_round_synergies: archive snapshot al reset
+//
+// Pure: il detector non muta la session. Il record è esplicito.
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const DEFAULT_SPECIES_YAML = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  'data',
+  'core',
+  'species.yaml',
+);
+
+const DEFAULT_BONUS_DAMAGE = 1;
+
+let _cache = null;
+
+function loadSynergyCatalog({ filepath = DEFAULT_SPECIES_YAML, force = false } = {}) {
+  if (_cache && !force) return _cache;
+  const raw = fs.readFileSync(filepath, 'utf8');
+  const parsed = yaml.load(raw) || {};
+  const synergies = (parsed.catalog && parsed.catalog.synergies) || [];
+  const speciesParts = {}; // species_id -> Set<slot.part>
+  for (const sp of parsed.species || []) {
+    if (!sp.id || !sp.default_parts) continue;
+    const set = new Set();
+    for (const [slot, val] of Object.entries(sp.default_parts)) {
+      if (Array.isArray(val)) {
+        for (const part of val) {
+          if (typeof part === 'string' && part) set.add(`${slot}.${part}`);
+        }
+      } else if (typeof val === 'string' && val) {
+        set.add(`${slot}.${val}`);
+      }
+    }
+    speciesParts[sp.id] = set;
+  }
+  _cache = { synergies, speciesParts };
+  return _cache;
+}
+
+function resetCache() {
+  _cache = null;
+}
+
+/**
+ * Estrae il set di `slot.part` per un attore. Override `actor.parts` ha
+ * precedenza, altrimenti deriva da `actor.species` via catalog.
+ */
+function partsForActor(actor, catalog = loadSynergyCatalog()) {
+  if (!actor) return new Set();
+  if (actor.parts && typeof actor.parts === 'object') {
+    const set = new Set();
+    for (const [slot, val] of Object.entries(actor.parts)) {
+      if (Array.isArray(val)) {
+        for (const part of val) {
+          if (typeof part === 'string' && part) set.add(`${slot}.${part}`);
+        }
+      } else if (typeof val === 'string' && val) {
+        set.add(`${slot}.${val}`);
+      }
+    }
+    return set;
+  }
+  if (actor.species && catalog.speciesParts[actor.species]) {
+    return catalog.speciesParts[actor.species];
+  }
+  return new Set();
+}
+
+function applicableSynergies(actor, opts = {}) {
+  const catalog = opts.catalog || loadSynergyCatalog();
+  const parts = partsForActor(actor, catalog);
+  if (parts.size === 0) return [];
+  const out = [];
+  for (const syn of catalog.synergies) {
+    if (!syn || !syn.id) continue;
+    const required = Array.isArray(syn.when_all) ? syn.when_all : [];
+    if (required.length === 0) continue;
+    const allMatch = required.every((req) => parts.has(req));
+    if (allMatch) {
+      out.push({ id: syn.id, name: syn.name || syn.id, effect: syn.effect || null });
+    }
+  }
+  return out;
+}
+
+function effectFor(synergy) {
+  if (synergy && synergy.effect && Number.isFinite(synergy.effect.bonus_damage)) {
+    return { bonus_damage: Math.max(0, Math.floor(synergy.effect.bonus_damage)) };
+  }
+  return { bonus_damage: DEFAULT_BONUS_DAMAGE };
+}
+
+/**
+ * Rileva se l'attacco corrente trigghera una o più synergy per l'attaccante.
+ * Cooldown: max 1 fire / actor / round (lookup turn in session._synergy_last_fire).
+ * NON muta session — record separato via `recordSynergyFire`.
+ */
+function detectSynergyTrigger(session, actor, target, opts = {}) {
+  const empty = { triggered: false, synergies: [], bonus_damage: 0 };
+  if (!actor || !target) return empty;
+  const turn = Number((session && session.turn) || 0);
+  const lastFire =
+    session && session._synergy_last_fire ? session._synergy_last_fire[actor.id] : undefined;
+  if (lastFire !== undefined && lastFire === turn) return empty;
+  const list = applicableSynergies(actor, opts);
+  if (list.length === 0) return empty;
+  let bonus = 0;
+  const fired = [];
+  for (const syn of list) {
+    const eff = effectFor(syn);
+    bonus += eff.bonus_damage || 0;
+    fired.push({ id: syn.id, name: syn.name, bonus_damage: eff.bonus_damage || 0 });
+  }
+  return { triggered: fired.length > 0, synergies: fired, bonus_damage: bonus };
+}
+
+/**
+ * Aggiorna cooldown + popola last_round_synergies. Da chiamare DOPO che
+ * il damage step ha applicato il bonus, per registrare bonus_applied reale.
+ */
+function recordSynergyFire(session, actor, target, triggerInfo, bonusApplied) {
+  if (!session || !actor) return;
+  if (!session._synergy_last_fire) session._synergy_last_fire = {};
+  session._synergy_last_fire[actor.id] = Number(session.turn) || 0;
+  if (!Array.isArray(session.last_round_synergies)) session.last_round_synergies = [];
+  if (triggerInfo && triggerInfo.triggered && target) {
+    session.last_round_synergies.push({
+      actor_id: String(actor.id),
+      target_id: String(target.id),
+      synergies: Array.isArray(triggerInfo.synergies) ? triggerInfo.synergies : [],
+      bonus_damage: Number(triggerInfo.bonus_damage || 0),
+      bonus_applied: Number(bonusApplied || 0),
+      turn: Number(session.turn || 0),
+    });
+  }
+}
+
+/**
+ * Reset tracker round (parallelo a resetRoundAttackTracker per focus_fire).
+ * Archivia in previous_round_synergies, svuota cooldown e last_round_synergies.
+ */
+function resetRoundSynergyTracker(session) {
+  if (!session) return;
+  if (Array.isArray(session.last_round_synergies) && session.last_round_synergies.length > 0) {
+    session.previous_round_synergies = session.last_round_synergies;
+  }
+  session.last_round_synergies = [];
+  session._synergy_last_fire = {};
+}
+
+module.exports = {
+  DEFAULT_BONUS_DAMAGE,
+  loadSynergyCatalog,
+  resetCache,
+  partsForActor,
+  applicableSynergies,
+  effectFor,
+  detectSynergyTrigger,
+  recordSynergyFire,
+  resetRoundSynergyTracker,
+};

--- a/data/core/species.yaml
+++ b/data/core/species.yaml
@@ -33,11 +33,18 @@ catalog:
             res:
               sonic: 1
   synergies:
+    # Schema (additive, runtime read by apps/backend/services/combat/synergyDetector.js):
+    #   id        — slug stabile (telemetria + log)
+    #   name      — label diegetic
+    #   when_all  — list di "slot.part" tutti richiesti per fire
+    #   effect    — opzionale; { bonus_damage: N }. Default 1 se assente.
     - id: echo_backstab
       name: Echo Backstab
       when_all:
         - senses.echolocation
         - offense.sand_claws
+      effect:
+        bonus_damage: 1
 
 global_rules:
   morph_budget:

--- a/tests/api/synergyCombo.test.js
+++ b/tests/api/synergyCombo.test.js
@@ -1,0 +1,170 @@
+// Synergy Combo integration — verifies that dune_stalker (with synergy-eligible
+// species default_parts) emits a synergy event in the action response body.
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+function duneStalkerVsTanker() {
+  return [
+    {
+      id: 'p1',
+      species: 'dune_stalker', // YAML synergy: senses.echolocation + offense.sand_claws
+      job: 'skirmisher',
+      hp: 14,
+      max_hp: 14,
+      ap: 2,
+      attack_mod: 8, // bias to land hits + significant damage so bonus is observable
+      attack_range: 3,
+      initiative: 14,
+      position: { x: 1, y: 1 },
+      controlled_by: 'player',
+      status: {},
+    },
+    {
+      id: 'sis',
+      species: 'carapax',
+      job: 'vanguard',
+      hp: 60,
+      max_hp: 60,
+      ap: 2,
+      defense_dc: 5, // low DC so attacks reliably land
+      attack_range: 1,
+      initiative: 5,
+      position: { x: 2, y: 1 },
+      controlled_by: 'sistema',
+      status: {},
+    },
+  ];
+}
+
+function plainPlayerVsTanker() {
+  // Non-synergy species (no echo+claws combo). Used as control to show synergy
+  // does NOT trigger when species lacks the parts.
+  return [
+    {
+      id: 'p1',
+      species: 'velox',
+      job: 'skirmisher',
+      hp: 14,
+      max_hp: 14,
+      ap: 2,
+      attack_mod: 8,
+      attack_range: 3,
+      initiative: 14,
+      position: { x: 1, y: 1 },
+      controlled_by: 'player',
+      status: {},
+    },
+    {
+      id: 'sis',
+      species: 'carapax',
+      job: 'vanguard',
+      hp: 60,
+      max_hp: 60,
+      ap: 2,
+      defense_dc: 5,
+      attack_range: 1,
+      initiative: 5,
+      position: { x: 2, y: 1 },
+      controlled_by: 'sistema',
+      status: {},
+    },
+  ];
+}
+
+async function startSession(app, units) {
+  const res = await request(app).post('/api/session/start').send({ units }).expect(200);
+  return res.body.session_id;
+}
+
+async function playerAttack(app, sessionId, actorId, targetId) {
+  return request(app).post('/api/session/action').send({
+    session_id: sessionId,
+    actor_id: actorId,
+    action_type: 'attack',
+    target_id: targetId,
+  });
+}
+
+test('dune_stalker triggers echo_backstab synergy on hit', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, duneStalkerVsTanker());
+  // d20 nat-1 always misses → loop with turn/end on miss to retry on full AP.
+  let foundSynergy = false;
+  for (let i = 0; i < 6; i += 1) {
+    const r = await playerAttack(app, sid, 'p1', 'sis');
+    assert.equal(r.status, 200);
+    if (r.body.synergy && r.body.synergy.triggered) {
+      foundSynergy = true;
+      assert.ok(
+        r.body.synergy.synergies.find((s) => s.id === 'echo_backstab'),
+        'echo_backstab in synergies list',
+      );
+      assert.ok(r.body.synergy.bonus_damage >= 1);
+      break;
+    }
+    if (r.body.result && r.body.result.hit) {
+      throw new Error(`hit landed but synergy missing: ${JSON.stringify(r.body.synergy)}`);
+    }
+    // Miss → end the round so cooldown clears and AP refills, then retry
+    await request(app).post('/api/session/turn/end').send({ session_id: sid });
+  }
+  assert.ok(foundSynergy, 'expected at least one synergy fire over 6 attempts');
+});
+
+test('non-synergy species (velox) does NOT trigger synergy', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, plainPlayerVsTanker());
+  // Single attack is enough — velox lacks both senses.echolocation and
+  // offense.sand_claws → no synergy can fire ever.
+  const r = await playerAttack(app, sid, 'p1', 'sis');
+  assert.equal(r.status, 200);
+  assert.ok(
+    !r.body.synergy || !r.body.synergy.triggered,
+    `velox must not trigger synergy, got ${JSON.stringify(r.body.synergy)}`,
+  );
+  const list = (r.body.state && r.body.state.last_round_synergies) || [];
+  assert.equal(list.length, 0, 'last_round_synergies should be empty for non-synergy species');
+});
+
+test('synergy state.last_round_synergies populated after fire', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, duneStalkerVsTanker());
+  // Loop until synergy triggers — same retry pattern as the previous test.
+  let body = null;
+  for (let i = 0; i < 6; i += 1) {
+    const r = await playerAttack(app, sid, 'p1', 'sis');
+    assert.equal(r.status, 200);
+    if (r.body.synergy && r.body.synergy.triggered) {
+      body = r.body;
+      break;
+    }
+    await request(app).post('/api/session/turn/end').send({ session_id: sid });
+  }
+  assert.ok(body, 'expected synergy fire within 6 attempts');
+  const list = (body.state && body.state.last_round_synergies) || [];
+  assert.ok(
+    list.length >= 1,
+    `last_round_synergies should contain >=1 entry, got ${JSON.stringify(list)}`,
+  );
+  const first = list[0];
+  assert.equal(first.actor_id, 'p1');
+  assert.equal(first.target_id, 'sis');
+  assert.ok(Array.isArray(first.synergies));
+  assert.equal(first.synergies[0].id, 'echo_backstab');
+});

--- a/tests/services/synergyDetector.test.js
+++ b/tests/services/synergyDetector.test.js
@@ -1,0 +1,233 @@
+// Synergy Combo Detection — pure unit tests for the detector module.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  DEFAULT_BONUS_DAMAGE,
+  loadSynergyCatalog,
+  resetCache,
+  partsForActor,
+  applicableSynergies,
+  effectFor,
+  detectSynergyTrigger,
+  recordSynergyFire,
+  resetRoundSynergyTracker,
+} = require('../../apps/backend/services/combat/synergyDetector');
+
+function freshSession() {
+  return { turn: 1, damage_taken: {} };
+}
+
+test('loadSynergyCatalog: parses catalog.synergies + species.default_parts', () => {
+  resetCache();
+  const cat = loadSynergyCatalog();
+  assert.ok(Array.isArray(cat.synergies));
+  assert.ok(cat.synergies.length >= 1, 'expected at least one synergy in YAML');
+  // echo_backstab is the seed canonical synergy in species.yaml
+  const echo = cat.synergies.find((s) => s.id === 'echo_backstab');
+  assert.ok(echo, 'echo_backstab must exist');
+  assert.deepEqual(echo.when_all.sort(), ['offense.sand_claws', 'senses.echolocation'].sort());
+  // dune_stalker species default_parts includes both required slots
+  assert.ok(cat.speciesParts.dune_stalker instanceof Set);
+  assert.ok(cat.speciesParts.dune_stalker.has('senses.echolocation'));
+  assert.ok(cat.speciesParts.dune_stalker.has('offense.sand_claws'));
+});
+
+test('partsForActor: explicit actor.parts override beats species lookup', () => {
+  resetCache();
+  const actor = {
+    id: 'u1',
+    species: 'dune_stalker', // would resolve via catalog if no override
+    parts: { offense: ['ice_fang'], senses: ['nightvision'] },
+  };
+  const parts = partsForActor(actor);
+  assert.ok(parts.has('offense.ice_fang'));
+  assert.ok(parts.has('senses.nightvision'));
+  assert.ok(!parts.has('senses.echolocation'), 'override must not leak species defaults');
+});
+
+test('partsForActor: falls back to species default_parts when no actor.parts', () => {
+  resetCache();
+  const actor = { id: 'u1', species: 'dune_stalker' };
+  const parts = partsForActor(actor);
+  assert.ok(parts.has('senses.echolocation'));
+  assert.ok(parts.has('offense.sand_claws'));
+});
+
+test('partsForActor: unknown species + no parts → empty', () => {
+  resetCache();
+  const parts = partsForActor({ id: 'u1', species: 'no_such_species' });
+  assert.equal(parts.size, 0);
+});
+
+test('partsForActor: null/undefined actor → empty', () => {
+  resetCache();
+  assert.equal(partsForActor(null).size, 0);
+  assert.equal(partsForActor(undefined).size, 0);
+});
+
+test('applicableSynergies: dune_stalker triggers echo_backstab from species defaults', () => {
+  resetCache();
+  const synergies = applicableSynergies({ id: 'u1', species: 'dune_stalker' });
+  const ids = synergies.map((s) => s.id);
+  assert.ok(ids.includes('echo_backstab'));
+});
+
+test('applicableSynergies: missing one part → no fire', () => {
+  resetCache();
+  const actor = {
+    id: 'u1',
+    parts: { senses: ['echolocation'] }, // sand_claws missing
+  };
+  const synergies = applicableSynergies(actor);
+  assert.equal(synergies.length, 0);
+});
+
+test('applicableSynergies: empty parts → empty list', () => {
+  resetCache();
+  assert.equal(applicableSynergies({ id: 'u1' }).length, 0);
+});
+
+test('effectFor: explicit effect.bonus_damage wins', () => {
+  assert.deepEqual(effectFor({ effect: { bonus_damage: 3 } }), { bonus_damage: 3 });
+});
+
+test('effectFor: missing effect → DEFAULT_BONUS_DAMAGE', () => {
+  assert.deepEqual(effectFor({}), { bonus_damage: DEFAULT_BONUS_DAMAGE });
+  assert.deepEqual(effectFor(null), { bonus_damage: DEFAULT_BONUS_DAMAGE });
+});
+
+test('effectFor: non-finite bonus_damage falls back on default', () => {
+  assert.deepEqual(effectFor({ effect: { bonus_damage: 'lots' } }), {
+    bonus_damage: DEFAULT_BONUS_DAMAGE,
+  });
+});
+
+test('effectFor: negative bonus clamps to 0', () => {
+  assert.deepEqual(effectFor({ effect: { bonus_damage: -5 } }), { bonus_damage: 0 });
+});
+
+test('detectSynergyTrigger: empty actor/target → no trigger', () => {
+  resetCache();
+  const sess = freshSession();
+  assert.deepEqual(detectSynergyTrigger(sess, null, { id: 't1' }), {
+    triggered: false,
+    synergies: [],
+    bonus_damage: 0,
+  });
+  assert.deepEqual(detectSynergyTrigger(sess, { id: 'a1' }, null), {
+    triggered: false,
+    synergies: [],
+    bonus_damage: 0,
+  });
+});
+
+test('detectSynergyTrigger: dune_stalker fires echo_backstab with default bonus', () => {
+  resetCache();
+  const sess = freshSession();
+  const out = detectSynergyTrigger(
+    sess,
+    { id: 'a1', species: 'dune_stalker' },
+    { id: 't1', hp: 5 },
+  );
+  assert.equal(out.triggered, true);
+  assert.equal(out.bonus_damage, 1);
+  assert.equal(out.synergies.length, 1);
+  assert.equal(out.synergies[0].id, 'echo_backstab');
+});
+
+test('detectSynergyTrigger: cooldown — same actor cannot fire twice in same turn', () => {
+  resetCache();
+  const sess = freshSession();
+  const actor = { id: 'a1', species: 'dune_stalker' };
+  const target = { id: 't1', hp: 5 };
+  const first = detectSynergyTrigger(sess, actor, target);
+  assert.equal(first.triggered, true);
+  recordSynergyFire(sess, actor, target, first, 1);
+  const second = detectSynergyTrigger(sess, actor, target);
+  assert.equal(second.triggered, false, 'cooldown blocks re-trigger same turn');
+  assert.equal(second.bonus_damage, 0);
+});
+
+test('detectSynergyTrigger: cooldown lifts when turn advances', () => {
+  resetCache();
+  const sess = freshSession();
+  const actor = { id: 'a1', species: 'dune_stalker' };
+  const target = { id: 't1', hp: 5 };
+  const first = detectSynergyTrigger(sess, actor, target);
+  recordSynergyFire(sess, actor, target, first, 1);
+  sess.turn += 1;
+  const next = detectSynergyTrigger(sess, actor, target);
+  assert.equal(next.triggered, true, 'new turn → cooldown clear');
+});
+
+test('recordSynergyFire: appends to last_round_synergies with bonus_applied', () => {
+  resetCache();
+  const sess = freshSession();
+  const actor = { id: 'a1', species: 'dune_stalker' };
+  const target = { id: 't1', hp: 5 };
+  const trig = detectSynergyTrigger(sess, actor, target);
+  recordSynergyFire(sess, actor, target, trig, 1);
+  assert.ok(Array.isArray(sess.last_round_synergies));
+  assert.equal(sess.last_round_synergies.length, 1);
+  const log = sess.last_round_synergies[0];
+  assert.equal(log.actor_id, 'a1');
+  assert.equal(log.target_id, 't1');
+  assert.equal(log.bonus_applied, 1);
+  assert.equal(log.synergies[0].id, 'echo_backstab');
+});
+
+test('recordSynergyFire: untriggered info → still bumps cooldown but no log entry', () => {
+  resetCache();
+  const sess = freshSession();
+  const actor = { id: 'a1' };
+  recordSynergyFire(sess, actor, { id: 't1' }, { triggered: false }, 0);
+  assert.equal(sess._synergy_last_fire.a1, sess.turn);
+  assert.deepEqual(sess.last_round_synergies, []);
+});
+
+test('resetRoundSynergyTracker: archives + clears', () => {
+  resetCache();
+  const sess = freshSession();
+  const actor = { id: 'a1', species: 'dune_stalker' };
+  const target = { id: 't1', hp: 5 };
+  const trig = detectSynergyTrigger(sess, actor, target);
+  recordSynergyFire(sess, actor, target, trig, 1);
+  assert.equal(sess.last_round_synergies.length, 1);
+  resetRoundSynergyTracker(sess);
+  assert.deepEqual(sess.last_round_synergies, []);
+  assert.deepEqual(sess._synergy_last_fire, {});
+  assert.ok(Array.isArray(sess.previous_round_synergies));
+  assert.equal(sess.previous_round_synergies.length, 1);
+});
+
+test('resetRoundSynergyTracker: empty round does NOT overwrite previous archive', () => {
+  resetCache();
+  const sess = freshSession();
+  sess.previous_round_synergies = [{ marker: 'keep_me' }];
+  sess.last_round_synergies = []; // empty current
+  resetRoundSynergyTracker(sess);
+  // previous was not overwritten because last_round was empty
+  assert.equal(sess.previous_round_synergies[0].marker, 'keep_me');
+});
+
+test('detectSynergyTrigger: actor without species and without parts → no fire', () => {
+  resetCache();
+  const out = detectSynergyTrigger(freshSession(), { id: 'a1' }, { id: 't1' });
+  assert.equal(out.triggered, false);
+});
+
+test('detectSynergyTrigger: explicit actor.parts can fire even on unknown species', () => {
+  resetCache();
+  const actor = {
+    id: 'a1',
+    species: 'unknown_x',
+    parts: { senses: ['echolocation'], offense: ['sand_claws'] },
+  };
+  const out = detectSynergyTrigger(freshSession(), actor, { id: 't1', hp: 5 });
+  assert.equal(out.triggered, true);
+  assert.equal(out.synergies[0].id, 'echo_backstab');
+});


### PR DESCRIPTION
Closes the second [Skiv evolution wishlist](https://github.com/MasterDD-L34D/Game/blob/main/docs/planning/2026-04-25-illuminator-orchestra-handoff.md) ticket. The YAML in `data/core/species.yaml` declared `catalog.synergies[]` (e.g. `echo_backstab` for `senses.echolocation` + `offense.sand_claws`) since species_pack v1.7, but the combat resolver ignored them. Now: when an actor's `default_parts` (or explicit `actor.parts` override) match a synergy's `when_all`, the attack emits a `synergy` event with `bonus_damage`. Cooldown 1 fire / actor / round (mirror `squadCoordination` pattern).

> *"Sento il sussulto. Quando schiocco l'eco e affondo gli artigli, qualcosa si chiude."* — Skiv

## Summary
- **Engine** `apps/backend/services/combat/synergyDetector.js` (NEW, pure):
  - `loadSynergyCatalog` indexes `catalog.synergies[]` + `species.default_parts` per species_id
  - `partsForActor` — explicit `actor.parts` overrides species fallback
  - `applicableSynergies` — `when_all` match
  - `effectFor` — explicit `effect.bonus_damage` wins; default 1; negative clamps; non-finite falls back
  - `detectSynergyTrigger` / `recordSynergyFire` / `resetRoundSynergyTracker` — cooldown via `session._synergy_last_fire`, log via `session.last_round_synergies`
- **YAML** `data/core/species.yaml` — `echo_backstab` populated with explicit `effect.bonus_damage: 1` + schema comment for future synergies
- **Wire** `apps/backend/routes/sessionRoundBridge.js` — 2 hit-paths (round wrapper line ~352 + sistema-incl. line ~679) + 2 reset sites + additive `synergy` field on attack response
- **State** `apps/backend/routes/sessionHelpers.js` — `publicSessionView` exposes `last_round_synergies` + `previous_round_synergies` (mirror combos exposure)

## Validation
- `tests/services/synergyDetector.test.js` — **22/22** (catalog parse, parts override + fallback, effect explicit + default + clamp, cooldown lift, log + archive)
- `tests/api/synergyCombo.test.js` — **3/3** integration (dune_stalker fires + velox inert + state populated). Stress 5× clean.
- Full `tests/api/*.test.js` — **624/624** (was 621, +3)
- `tests/services/*.test.js` — **279/279** (was 257, +22)
- AI regression — 307/307
- Pytest — 948/948
- `format:check` ✅ · governance 0/0
- No new deps

## Skiv evolution status
- **Pillar P1 (Tattica)**: 🟢 → 🟢+ (synergy beats live, not just numbers)
- **Sprint B partial**: ticket #2 done, ticket #3 (Defy verb, P6 two-way pressure) next

## Test plan
- [x] Unit 22/22
- [x] Integration 3/3 (× 5 stress)
- [x] Full suites green (624 + 279 + 307 + 948)
- [x] Format + governance
- [ ] CI green

## Rollback
Revert this PR — `synergy` field on responses goes silent; `last_round_synergies` returns empty arrays; existing focus_fire combo unaffected. No schema migration, no route rename. The new synergyDetector module is consumed only via `sessionRoundBridge` import.

## Refs
- Skiv ticket #2: `~/.claude/projects/.../memory/project_skiv_evolution_wishlist.md`
- Pattern: data-driven matcher + per-actor cooldown (mirrors `squadCoordination.recordAttackForCombo`)
- YAML foundation: `data/core/species.yaml` `catalog.synergies[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)