### PR TITLE
feat(combat): Defy verb (Skiv ticket #5 — Sprint B 2/2)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -122,7 +122,10 @@ const {
   computePositionalDamage,
   facingFromMove,
   predictCombat,
+  applyApRefill,
 } = require('./sessionHelpers');
+// Skiv ticket #5 (Sprint B): Defy verb — player counter-pressure agency.
+const { applyDefy: applyDefyAction, DEFY_SG_COST } = require('../services/combat/defyEngine');
 const { createRoundBridge } = require('./sessionRoundBridge');
 // M13 P3 Phase B — progression perks apply + runtime passive damage bonus.
 const {
@@ -764,9 +767,8 @@ function createSessionRouter(options = {}) {
       });
     };
     const resetAp = (unit) => {
-      if (!unit) return;
-      const fractureActive = Number(unit.status?.fracture) > 0;
-      unit.ap_remaining = fractureActive ? Math.min(1, unit.ap) : unit.ap;
+      // Skiv #5: applyApRefill centralises fracture + defy_penalty handling.
+      applyApRefill(unit);
     };
     const decrement = (unit) => {
       if (!unit || !unit.status) return;
@@ -988,9 +990,20 @@ function createSessionRouter(options = {}) {
         biome_costs_log: biomeCostsLog,
       };
       // V5 SG lifecycle: encounter start reset (ADR-2026-04-26).
+      // Optional restore: `req.body.initial_sg = { unit_id: pool }` lets
+      // save-load + integration tests seed SG after the encounter zero-pass.
       try {
         const sgTracker = require('../services/combat/sgTracker');
         for (const u of session.units || []) sgTracker.resetEncounter(u);
+        const initialSg = req.body?.initial_sg;
+        if (initialSg && typeof initialSg === 'object') {
+          for (const [uid, pool] of Object.entries(initialSg)) {
+            const unit = (session.units || []).find((u) => u && u.id === uid);
+            if (!unit) continue;
+            const value = Math.max(0, Math.min(3, Math.floor(Number(pool) || 0)));
+            unit.sg = value;
+          }
+        }
       } catch {
         /* sgTracker optional */
       }
@@ -1675,9 +1688,8 @@ function createSessionRouter(options = {}) {
               session.damage_taken[unit.id] = (session.damage_taken[unit.id] || 0) + 1;
             }
           }
-          // AP reset
-          const fractureActive = Number(unit.status?.fracture) > 0;
-          unit.ap_remaining = fractureActive ? Math.min(1, unit.ap) : unit.ap;
+          // AP reset (Skiv #5: applyApRefill handles fracture + defy_penalty)
+          applyApRefill(unit);
           // Status decay + bonus clear
           if (unit.status) {
             for (const key of Object.keys(unit.status)) {
@@ -1714,6 +1726,51 @@ function createSessionRouter(options = {}) {
         events_emitted_count: eventsEmitted.length,
         events: eventsEmitted,
         ap_consumed: apByUnit,
+        state: publicSessionView(session),
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // Skiv ticket #5 (Sprint B 2/2): Defy verb. Player counter-pressure agency.
+  // Body: { session_id, actor_id }. Validates SG ≥ DEFY_SG_COST + actor is
+  // player-controlled + alive + pressure > 0; on success spends 2 SG, drops
+  // sistema_pressure by DEFY_PRESSURE_RELIEF (clamped at 0), and sets
+  // actor.status.defy_penalty so the actor refills with -1 AP next turn.
+  router.post('/defy', async (req, res, next) => {
+    try {
+      const body = req.body || {};
+      const { error, session } = resolveSession(body.session_id);
+      if (error) return res.status(error.status).json(error.body);
+      const actor = session.units.find((u) => u.id === body.actor_id);
+      if (!actor) {
+        return res.status(400).json({ error: 'actor_not_found', actor_id: body.actor_id || null });
+      }
+      const outcome = applyDefyAction(actor, session);
+      if (!outcome.ok) {
+        return res
+          .status(409)
+          .json({ error: outcome.error, detail: outcome.detail || null, actor_id: actor.id });
+      }
+      // Append narrative event for HUD/debrief consumption.
+      const event = {
+        event_type: 'defy',
+        actor_id: actor.id,
+        turn: Number(session.turn || 0),
+        sg_before: outcome.before.sg,
+        sg_after: outcome.after.sg,
+        pressure_before: outcome.before.pressure,
+        pressure_after: outcome.after.pressure,
+        relief: outcome.relief,
+        sg_cost: outcome.cost.sg,
+        ap_penalty_next_turn: outcome.cost.ap_next_turn,
+      };
+      if (Array.isArray(session.events)) session.events.push(event);
+      res.json({
+        session_id: session.session_id,
+        actor_id: actor.id,
+        ...outcome,
         state: publicSessionView(session),
       });
     } catch (err) {

--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -101,6 +101,9 @@ function normaliseUnit(raw, fallbackIndex) {
     name: input.name ? String(input.name) : null,
     form_id: input.form_id ? String(input.form_id) : null,
     resistance_archetype: resistanceArchetype,
+    // V5 SG pool — preserve from input so save-load + tests carry value through.
+    // sgTracker.initUnit will keep this if already set, otherwise default to 0.
+    sg: Number.isFinite(Number(input.sg)) ? Number(input.sg) : 0,
   };
 }
 
@@ -472,6 +475,22 @@ function applyPressureDelta(current, delta) {
   return Math.max(0, Math.min(100, base + d));
 }
 
+/**
+ * Refill `unit.ap_remaining` honoring active modifiers:
+ *   - fracture status: cap at 1 AP
+ *   - defy_penalty (Skiv ticket #5): -1 AP for one turn after Defy use
+ *
+ * Mutates the unit. Single source of truth so future modifiers go here.
+ */
+function applyApRefill(unit) {
+  if (!unit) return;
+  const fractureActive = Number(unit.status?.fracture) > 0;
+  let cap = Number(unit.ap || 0);
+  if (fractureActive) cap = Math.min(1, cap);
+  if (Number(unit.status?.defy_penalty) > 0) cap = Math.max(0, cap - 1);
+  unit.ap_remaining = cap;
+}
+
 // Mirror dei delta events da sistema_pressure.yaml.
 // Mantenuto qui per evitare YAML loader in hot path (round flow).
 // Sync con packs/evo_tactics_pack/data/balance/sistema_pressure.yaml §deltas.
@@ -502,6 +521,7 @@ module.exports = {
   resolveAttack,
   timestampStamp,
   publicSessionView,
+  applyApRefill,
   buildTurnOrder,
   nextUnitId,
   manhattanDistance,

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -26,6 +26,7 @@ const {
   facingFromMove,
   applyPressureDelta,
   PRESSURE_DELTAS,
+  applyApRefill,
 } = require('./sessionHelpers');
 const {
   detectFocusFireCombo,
@@ -627,8 +628,8 @@ function createRoundBridge(deps) {
 
     for (const unit of session.units) {
       if (!unit) continue;
-      const fractureActive = Number(unit.status?.fracture) > 0;
-      unit.ap_remaining = fractureActive ? Math.min(1, unit.ap) : unit.ap;
+      // Skiv #5: applyApRefill centralises fracture + defy_penalty handling.
+      applyApRefill(unit);
       if (unit.status) {
         for (const key of Object.keys(unit.status)) {
           const v = Number(unit.status[key]);

--- a/apps/backend/services/combat/defyEngine.js
+++ b/apps/backend/services/combat/defyEngine.js
@@ -1,0 +1,93 @@
+// =============================================================================
+// Defy Action — Skiv ticket #5 (Sprint B [2/2]).
+//
+// Pillar 6 (Fairness): the Sistema escalates pressure unilaterally; player has
+// no agency to push back. Defy gives the player a verb to spend SG to reduce
+// pressure tier — explicit tradeoff: -1 AP next turn.
+//
+// Spec:
+//   cost: 2 SG (deducted from actor.sg)
+//   effect: pressure -25 (≈ 1 tier step), clamped at 0
+//   penalty: -1 AP next turn (encoded via actor.status.defy_penalty = 2;
+//            decrement loop drops it to 1 right after the action turn ends,
+//            then resetAp consumes it on the subsequent refill, decrement
+//            zeroes it. Net: exactly one AP-deficit turn.)
+//
+// Pure: validate + propose mutations. The route wraps with side-effects (write
+// pressure, decrement SG, set status, append event). Mirrors the
+// thoughtCabinet pattern (state machine returns { ok, error? }).
+// =============================================================================
+
+'use strict';
+
+const DEFY_SG_COST = 2;
+const DEFY_PRESSURE_RELIEF = 25;
+const DEFY_AP_PENALTY_TURNS = 2; // see header note for why 2 (decrement happens once before next turn)
+
+const ERR_NOT_FOUND = 'actor_not_found';
+const ERR_NOT_PLAYER = 'not_player_controlled';
+const ERR_KO = 'actor_ko';
+const ERR_INSUFFICIENT_SG = 'insufficient_sg';
+const ERR_NO_PRESSURE = 'no_pressure_to_relieve';
+
+/**
+ * Validate that an actor can call Defy. Pure — no mutation.
+ * @returns {{ ok: true } | { ok: false, error: string, detail?: object }}
+ */
+function canDefy(actor, session) {
+  if (!actor) return { ok: false, error: ERR_NOT_FOUND };
+  if (actor.controlled_by !== 'player') return { ok: false, error: ERR_NOT_PLAYER };
+  if (Number(actor.hp || 0) <= 0) return { ok: false, error: ERR_KO };
+  const sg = Number(actor.sg || 0);
+  if (sg < DEFY_SG_COST) {
+    return { ok: false, error: ERR_INSUFFICIENT_SG, detail: { sg, required: DEFY_SG_COST } };
+  }
+  const pressure = Number(session && session.sistema_pressure);
+  if (!Number.isFinite(pressure) || pressure <= 0) {
+    return { ok: false, error: ERR_NO_PRESSURE, detail: { pressure: pressure || 0 } };
+  }
+  return { ok: true };
+}
+
+/**
+ * Apply Defy: decrement SG, drop pressure by relief amount, mark AP penalty
+ * via status counter. Mutates `actor` and `session` in place.
+ * Returns { ok, before, after } describing the transition for telemetry/event log.
+ */
+function applyDefy(actor, session) {
+  const guard = canDefy(actor, session);
+  if (!guard.ok) return { ok: false, error: guard.error, detail: guard.detail || null };
+  const sgBefore = Number(actor.sg || 0);
+  const pressureBefore = Number(session.sistema_pressure || 0);
+  // SG cost
+  actor.sg = Math.max(0, sgBefore - DEFY_SG_COST);
+  // Pressure relief (clamped at 0)
+  const pressureAfter = Math.max(0, pressureBefore - DEFY_PRESSURE_RELIEF);
+  session.sistema_pressure = pressureAfter;
+  // AP penalty: bump status counter; decrement loop will drop it to
+  // (DEFY_AP_PENALTY_TURNS - 1) at end of current turn, then resetAp consumes
+  // -1 AP next turn, decrement again → 0.
+  if (!actor.status || typeof actor.status !== 'object') actor.status = {};
+  const existing = Number(actor.status.defy_penalty || 0);
+  actor.status.defy_penalty = Math.max(existing, DEFY_AP_PENALTY_TURNS);
+  return {
+    ok: true,
+    before: { sg: sgBefore, pressure: pressureBefore },
+    after: { sg: actor.sg, pressure: pressureAfter, defy_penalty: actor.status.defy_penalty },
+    relief: pressureBefore - pressureAfter,
+    cost: { sg: DEFY_SG_COST, ap_next_turn: 1 },
+  };
+}
+
+module.exports = {
+  DEFY_SG_COST,
+  DEFY_PRESSURE_RELIEF,
+  DEFY_AP_PENALTY_TURNS,
+  ERR_NOT_FOUND,
+  ERR_NOT_PLAYER,
+  ERR_KO,
+  ERR_INSUFFICIENT_SG,
+  ERR_NO_PRESSURE,
+  canDefy,
+  applyDefy,
+};

--- a/tests/api/defyRoute.test.js
+++ b/tests/api/defyRoute.test.js
@@ -1,0 +1,189 @@
+// Defy route integration — Skiv ticket #5 (Sprint B 2/2).
+// Verifies POST /api/session/defy + AP penalty wired via applyApRefill.
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+function basePlayer(overrides = {}) {
+  return {
+    id: 'p1',
+    species: 'velox',
+    job: 'skirmisher',
+    hp: 12,
+    max_hp: 12,
+    ap: 2,
+    sg: 3,
+    attack_range: 3,
+    initiative: 14,
+    position: { x: 1, y: 1 },
+    controlled_by: 'player',
+    status: {},
+    ...overrides,
+  };
+}
+
+function baseSistema(overrides = {}) {
+  return {
+    id: 'sis',
+    species: 'carapax',
+    job: 'vanguard',
+    hp: 30,
+    max_hp: 30,
+    ap: 2,
+    attack_range: 1,
+    initiative: 5,
+    position: { x: 5, y: 5 },
+    controlled_by: 'sistema',
+    status: {},
+    ...overrides,
+  };
+}
+
+async function startSession(app, units, sistema_pressure = 60) {
+  // Initial SG seeding: build a map from unit.sg in the test fixture, since
+  // session start zeros SG via sgTracker.resetEncounter (encounter lifecycle).
+  const initial_sg = {};
+  for (const u of units) {
+    if (Number.isFinite(Number(u.sg)) && Number(u.sg) > 0) initial_sg[u.id] = u.sg;
+  }
+  const res = await request(app)
+    .post('/api/session/start')
+    .send({ units, sistema_pressure_start: sistema_pressure, initial_sg })
+    .expect(200);
+  return res.body.session_id;
+}
+
+test('POST /defy happy path — drops pressure, spends SG, sets defy_penalty', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, [basePlayer({ sg: 3 }), baseSistema()], 75);
+  const r = await request(app).post('/api/session/defy').send({ session_id: sid, actor_id: 'p1' });
+  assert.equal(r.status, 200);
+  assert.equal(r.body.ok, true);
+  assert.equal(r.body.before.sg, 3);
+  assert.equal(r.body.after.sg, 1);
+  assert.equal(r.body.before.pressure, 75);
+  assert.equal(r.body.after.pressure, 50);
+  assert.equal(r.body.relief, 25);
+  assert.deepEqual(r.body.cost, { sg: 2, ap_next_turn: 1 });
+  // state pressure mirrors after
+  assert.equal(r.body.state.sistema_pressure, 50);
+  assert.equal(r.body.state.sistema_tier.label, 'Escalated');
+});
+
+test('POST /defy: 409 insufficient_sg', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, [basePlayer({ sg: 1 }), baseSistema()]);
+  const r = await request(app).post('/api/session/defy').send({ session_id: sid, actor_id: 'p1' });
+  assert.equal(r.status, 409);
+  assert.equal(r.body.error, 'insufficient_sg');
+  assert.equal(r.body.detail.sg, 1);
+  assert.equal(r.body.detail.required, 2);
+});
+
+test('POST /defy: 409 no_pressure_to_relieve when pressure 0', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, [basePlayer({ sg: 3 }), baseSistema()], 0);
+  const r = await request(app).post('/api/session/defy').send({ session_id: sid, actor_id: 'p1' });
+  assert.equal(r.status, 409);
+  assert.equal(r.body.error, 'no_pressure_to_relieve');
+});
+
+test('POST /defy: 409 not_player_controlled when actor is sistema', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, [basePlayer(), baseSistema()]);
+  const r = await request(app).post('/api/session/defy').send({ session_id: sid, actor_id: 'sis' });
+  assert.equal(r.status, 409);
+  assert.equal(r.body.error, 'not_player_controlled');
+});
+
+test('POST /defy: 400 actor_not_found', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, [basePlayer(), baseSistema()]);
+  const r = await request(app)
+    .post('/api/session/defy')
+    .send({ session_id: sid, actor_id: 'ghost' });
+  assert.equal(r.status, 400);
+  assert.equal(r.body.error, 'actor_not_found');
+});
+
+test('POST /defy: pressure clamps at 0 on overshoot', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, [basePlayer({ sg: 3 }), baseSistema()], 10);
+  const r = await request(app).post('/api/session/defy').send({ session_id: sid, actor_id: 'p1' });
+  assert.equal(r.status, 200);
+  assert.equal(r.body.after.pressure, 0);
+  assert.equal(r.body.relief, 10);
+});
+
+test('POST /defy: AP penalty applied on next turn refill (status decay cycle)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, [basePlayer({ sg: 3 }), baseSistema()], 60);
+  // Defy on current turn
+  const defyRes = await request(app)
+    .post('/api/session/defy')
+    .send({ session_id: sid, actor_id: 'p1' });
+  assert.equal(defyRes.status, 200);
+  // End turn → next round refills AP. defy_penalty=2 → after decrement is 1
+  // before refill of NEXT actor turn happens, then refill applies -1 AP, then
+  // decrement to 0. The exact site of refill depends on the turn loop.
+  // Acceptance criterion: at least one full round must observe ap_remaining=1
+  // for the player after refill (default ap=2, defy −1 = 1).
+  let observedReducedAp = false;
+  for (let i = 0; i < 4; i += 1) {
+    const turn = await request(app).post('/api/session/turn/end').send({ session_id: sid });
+    assert.equal(turn.status, 200);
+    const player = turn.body.state.units.find((u) => u.id === 'p1');
+    if (player && Number(player.ap_remaining) === 1 && Number(player.ap) === 2) {
+      observedReducedAp = true;
+      break;
+    }
+  }
+  assert.ok(
+    observedReducedAp,
+    'expected ap_remaining=1 (defy penalty) on at least one turn refill',
+  );
+});
+
+test('POST /defy: event appended to session.events', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, [basePlayer({ sg: 3 }), baseSistema()], 60);
+  const r = await request(app).post('/api/session/defy').send({ session_id: sid, actor_id: 'p1' });
+  assert.equal(r.status, 200);
+  const events = (r.body.state && r.body.state.events) || [];
+  const defy = events.find((e) => e.event_type === 'defy');
+  assert.ok(defy, 'expected defy event in session.events');
+  assert.equal(defy.actor_id, 'p1');
+  assert.equal(defy.relief, 25);
+  assert.equal(defy.sg_cost, 2);
+  assert.equal(defy.ap_penalty_next_turn, 1);
+});

--- a/tests/services/defyEngine.test.js
+++ b/tests/services/defyEngine.test.js
@@ -1,0 +1,144 @@
+// Defy engine — pure unit tests for Skiv ticket #5 (Sprint B [2/2]).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  DEFY_SG_COST,
+  DEFY_PRESSURE_RELIEF,
+  DEFY_AP_PENALTY_TURNS,
+  ERR_NOT_FOUND,
+  ERR_NOT_PLAYER,
+  ERR_KO,
+  ERR_INSUFFICIENT_SG,
+  ERR_NO_PRESSURE,
+  canDefy,
+  applyDefy,
+} = require('../../apps/backend/services/combat/defyEngine');
+
+function buildPlayer(overrides = {}) {
+  return {
+    id: 'p1',
+    controlled_by: 'player',
+    hp: 10,
+    sg: DEFY_SG_COST,
+    status: {},
+    ap: 2,
+    ...overrides,
+  };
+}
+
+function buildSession(overrides = {}) {
+  return { sistema_pressure: 50, ...overrides };
+}
+
+test('constants — cost 2 SG, relief 25, penalty 2 status counters', () => {
+  assert.equal(DEFY_SG_COST, 2);
+  assert.equal(DEFY_PRESSURE_RELIEF, 25);
+  assert.equal(DEFY_AP_PENALTY_TURNS, 2);
+});
+
+test('canDefy: null actor → actor_not_found', () => {
+  assert.deepEqual(canDefy(null, buildSession()), { ok: false, error: ERR_NOT_FOUND });
+});
+
+test('canDefy: sistema actor → not_player_controlled', () => {
+  const sis = buildPlayer({ controlled_by: 'sistema' });
+  assert.deepEqual(canDefy(sis, buildSession()), { ok: false, error: ERR_NOT_PLAYER });
+});
+
+test('canDefy: KO actor (hp=0) → actor_ko', () => {
+  const dead = buildPlayer({ hp: 0 });
+  assert.deepEqual(canDefy(dead, buildSession()), { ok: false, error: ERR_KO });
+});
+
+test('canDefy: insufficient SG → insufficient_sg with detail', () => {
+  const lowSg = buildPlayer({ sg: 1 });
+  const r = canDefy(lowSg, buildSession());
+  assert.equal(r.ok, false);
+  assert.equal(r.error, ERR_INSUFFICIENT_SG);
+  assert.equal(r.detail.sg, 1);
+  assert.equal(r.detail.required, 2);
+});
+
+test('canDefy: pressure 0 → no_pressure_to_relieve (no-op forbidden)', () => {
+  assert.equal(
+    canDefy(buildPlayer(), buildSession({ sistema_pressure: 0 })).error,
+    ERR_NO_PRESSURE,
+  );
+});
+
+test('canDefy: happy path → ok:true', () => {
+  assert.deepEqual(canDefy(buildPlayer(), buildSession()), { ok: true });
+});
+
+test('applyDefy: spends SG and drops pressure by relief amount', () => {
+  const actor = buildPlayer({ sg: 3 });
+  const sess = buildSession({ sistema_pressure: 75 });
+  const out = applyDefy(actor, sess);
+  assert.equal(out.ok, true);
+  assert.equal(actor.sg, 1); // 3 - 2
+  assert.equal(sess.sistema_pressure, 50); // 75 - 25
+  assert.equal(out.relief, 25);
+  assert.equal(out.before.sg, 3);
+  assert.equal(out.before.pressure, 75);
+  assert.equal(out.after.sg, 1);
+  assert.equal(out.after.pressure, 50);
+});
+
+test('applyDefy: pressure clamps at 0 even if relief overshoots', () => {
+  const actor = buildPlayer();
+  const sess = buildSession({ sistema_pressure: 10 });
+  const out = applyDefy(actor, sess);
+  assert.equal(out.ok, true);
+  assert.equal(sess.sistema_pressure, 0);
+  assert.equal(out.relief, 10); // partial relief reported
+});
+
+test('applyDefy: sets actor.status.defy_penalty for AP throttle', () => {
+  const actor = buildPlayer();
+  const sess = buildSession();
+  applyDefy(actor, sess);
+  assert.equal(actor.status.defy_penalty, DEFY_AP_PENALTY_TURNS);
+});
+
+test('applyDefy: existing defy_penalty taken as max (no double-stacking down)', () => {
+  const actor = buildPlayer({ status: { defy_penalty: 3 } });
+  const sess = buildSession();
+  applyDefy(actor, sess);
+  assert.equal(actor.status.defy_penalty, 3); // existing higher kept
+});
+
+test('applyDefy: validation error returns { ok:false, error } without mutation', () => {
+  const actor = buildPlayer({ sg: 0 });
+  const sess = buildSession();
+  const out = applyDefy(actor, sess);
+  assert.equal(out.ok, false);
+  assert.equal(out.error, ERR_INSUFFICIENT_SG);
+  assert.equal(actor.sg, 0); // unchanged
+  assert.equal(sess.sistema_pressure, 50); // unchanged
+  assert.ok(!actor.status.defy_penalty);
+});
+
+test('applyDefy: returns cost shape { sg, ap_next_turn }', () => {
+  const actor = buildPlayer();
+  const sess = buildSession();
+  const out = applyDefy(actor, sess);
+  assert.deepEqual(out.cost, { sg: 2, ap_next_turn: 1 });
+});
+
+test('applyDefy: actor without status object → creates status', () => {
+  const actor = buildPlayer();
+  delete actor.status;
+  const sess = buildSession();
+  applyDefy(actor, sess);
+  assert.equal(typeof actor.status, 'object');
+  assert.equal(actor.status.defy_penalty, DEFY_AP_PENALTY_TURNS);
+});
+
+test('canDefy: non-finite pressure treated as 0 → blocked', () => {
+  const sess = { sistema_pressure: 'invalid' };
+  assert.equal(canDefy(buildPlayer(), sess).error, ERR_NO_PRESSURE);
+});


### PR DESCRIPTION
Closes the third [Skiv evolution wishlist](https://github.com/MasterDD-L34D/Game/blob/main/docs/planning/2026-04-25-illuminator-orchestra-handoff.md) ticket — Pillar 6 (Fairness) two-way pressure agency. Player can now spend 2 SG to drop sistema pressure by 25 (≈ 1 tier step), accepting -1 AP next turn as the explicit tradeoff (Long War 2 mission-timer logic, framed as a player verb).

> *"Sento la voce nel petto. Ho detto NO."* — Skiv

## Summary
- **Engine** `apps/backend/services/combat/defyEngine.js` (NEW, pure):
  - `DEFY_SG_COST=2`, `DEFY_PRESSURE_RELIEF=25`, `DEFY_AP_PENALTY_TURNS=2`
  - `canDefy` — 5 error paths (`actor_not_found`, `not_player_controlled`, `actor_ko`, `insufficient_sg`, `no_pressure_to_relieve`)
  - `applyDefy` — mutates SG / pressure / `actor.status.defy_penalty`; returns `{ ok, before, after, relief, cost }`
- **Helper refactor** `apps/backend/routes/sessionHelpers.js`:
  - New `applyApRefill(unit)` — single source of truth for AP refill, honours fracture (existing) + defy_penalty (new). Replaces 3 inline blocks across `session.js` + `sessionRoundBridge.js`.
  - `normaliseUnit` now preserves `input.sg` (was being dropped). sgTracker.resetEncounter still zeros for production encounter starts.
- **Save-load surface** `apps/backend/routes/session.js`:
  - `/start` accepts optional `initial_sg = { unit_id: pool }` map applied AFTER encounter zero-pass. Useful for save-load + integration tests.
  - NEW `POST /api/session/defy` — appends `defy` event to `session.events` for HUD/debrief consumption.

## Validation
- `tests/services/defyEngine.test.js` — **15/15** pure (constants, canDefy guards, applyDefy spend + relief + clamp + status mutate + non-mutating on fail + cost shape)
- `tests/api/defyRoute.test.js` — **8/8** integration (happy, insufficient_sg, no_pressure, not_player_controlled, actor_not_found, clamp at 0, **AP penalty applied on next refill cycle**, defy event in state.events)
- AI 307/307 · services **294/294** (+15) · api **632/632** (+8)
- pytest unaffected (Python untouched)
- `format:check` ✅ · governance 0/0
- No new deps

## Pillar status post-PR

| | Pre Sprint B | Post Sprint B (1/2) | Post Sprint B (2/2 = this PR) |
|---|---|---|---|
| P1 Tattica | 🟢 | 🟢+ (synergy beats #1772) | 🟢+ |
| P6 Fairness | 🟢 candidato | 🟢 candidato | **🟢** (two-way pressure live) |

Sprint B complete. Sprint C residual (voices + diary + hybrid path) waits for resolver wire (remote agent 2026-05-11).

## Test plan
- [x] Unit 15/15
- [x] Integration 8/8 incl. AP-penalty cycle
- [x] Full suites green (294 + 632 + 307)
- [x] format + governance
- [ ] CI green

## Rollback
Revert this PR — `/api/session/defy` returns 404; `applyApRefill` change reverts to inline blocks (semantically equivalent on existing fields); `initial_sg` payload field is silently ignored on revert. No schema migration, no contract change.

## Refs
- Wishlist: `~/.claude/projects/.../memory/project_skiv_evolution_wishlist.md`
- Pattern: status counter + decrement loop (mirrors fracture/bleeding)
- Long War 2 lesson: counter-pressure as a player verb with SG cost + AP penalty

🤖 Generated with [Claude Code](https://claude.com/claude-code)