### PR TITLE
feat(combat): biome resonance reduces research_cost (Skiv ticket #4 — Sprint A)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -54,6 +54,10 @@ const {
   snapshotCabinet,
   mergeUnlocked,
 } = require('../services/thoughts/thoughtCabinet');
+// Skiv ticket #4: biome resonance reduces research cost when species
+// biome_affinity matches session.biome_id. Looked up at the route layer
+// because thoughtCabinet engine stays YAML-agnostic about species data.
+const { hasResonance: hasBiomeResonance } = require('../services/combat/biomeResonance');
 // SPRINT_010 (issue #2): IA estratta in modulo dedicato.
 // Le funzioni decisionali (selectAiPolicy, stepAway) vivono in services/ai/policy.js,
 // l'orchestratore del turno (createSistemaTurnRunner) in services/ai/sistemaTurnRunner.js.
@@ -1966,8 +1970,13 @@ function createSessionRouter(options = {}) {
         return res.status(400).json({ error: 'unit_id e thought_id obbligatori' });
       }
       const { state } = getOrCreateCabinet(session.session_id, unit_id);
+      // Skiv #4: compute biome resonance from actor.species × session.biome_id.
+      const actor = (session.units || []).find((u) => u && u.id === unit_id);
+      const resonance =
+        actor && session.biome_id ? hasBiomeResonance(actor.species, session.biome_id) : false;
       const outcome = startThoughtResearch(state, thought_id, {
         encounter: req.body?.encounter ?? null,
+        resonance,
       });
       if (!outcome.ok) {
         return res.status(409).json({ error: outcome.error, thought_id });
@@ -1977,6 +1986,8 @@ function createSessionRouter(options = {}) {
         unit_id,
         thought_id,
         cost_total: outcome.cost_total,
+        base_cost: outcome.base_cost,
+        resonance_applied: outcome.resonance_applied,
         cabinet: snapshotCabinet(state),
       });
     } catch (err) {

--- a/apps/backend/services/combat/biomeResonance.js
+++ b/apps/backend/services/combat/biomeResonance.js
@@ -1,0 +1,78 @@
+// =============================================================================
+// Biome Resonance — Skiv ticket #4 (Sprint A).
+//
+// Pillar 4 (Identità) bonus: when a unit's species `biome_affinity` matches
+// the current scenario `biome_id`, the actor "feels" the environment.
+// Concrete effect (Phase 1): -1 research_cost_encounters when starting
+// research on a Thought (clamped at min 1). Future phases can stack other
+// effects (passive +1 res to biome-themed channel, etc.).
+//
+// Pure: no I/O at runtime once cached. Caller looks up resonance and passes
+// the boolean into engines that care (currently thoughtCabinet.startResearch).
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const DEFAULT_SPECIES_YAML = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  'data',
+  'core',
+  'species.yaml',
+);
+
+let _cache = null;
+
+function loadSpeciesAffinityMap({ filepath = DEFAULT_SPECIES_YAML, force = false } = {}) {
+  if (_cache && !force) return _cache;
+  const raw = fs.readFileSync(filepath, 'utf8');
+  const parsed = yaml.load(raw) || {};
+  const map = {};
+  for (const sp of parsed.species || []) {
+    if (!sp || !sp.id) continue;
+    if (typeof sp.biome_affinity === 'string' && sp.biome_affinity) {
+      map[sp.id] = sp.biome_affinity;
+    }
+  }
+  _cache = map;
+  return _cache;
+}
+
+function resetCache() {
+  _cache = null;
+}
+
+/**
+ * Returns the species' declared biome_affinity, or null.
+ */
+function getSpeciesBiomeAffinity(speciesId, opts = {}) {
+  if (!speciesId || typeof speciesId !== 'string') return null;
+  const map = opts.map || loadSpeciesAffinityMap();
+  return map[speciesId] || null;
+}
+
+/**
+ * True iff the species declares a biome_affinity matching biomeId (case-sensitive,
+ * exact string compare). Both inputs must be non-empty strings.
+ */
+function hasResonance(speciesId, biomeId, opts = {}) {
+  if (!speciesId || !biomeId) return false;
+  if (typeof speciesId !== 'string' || typeof biomeId !== 'string') return false;
+  const affinity = getSpeciesBiomeAffinity(speciesId, opts);
+  if (!affinity) return false;
+  return affinity === biomeId;
+}
+
+module.exports = {
+  loadSpeciesAffinityMap,
+  resetCache,
+  getSpeciesBiomeAffinity,
+  hasResonance,
+};

--- a/apps/backend/services/thoughts/thoughtCabinet.js
+++ b/apps/backend/services/thoughts/thoughtCabinet.js
@@ -153,13 +153,26 @@ function startResearch(state, thoughtId, opts = {}) {
   if (state.internalized.has(thoughtId)) return { ok: false, error: 'already_internalized' };
   if (state.researching.has(thoughtId)) return { ok: false, error: 'already_researching' };
   if (!canResearchMore(state)) return { ok: false, error: 'no_free_slot' };
-  const cost = resolveResearchCost(entry);
+  const baseCost = resolveResearchCost(entry);
+  // Skiv ticket #4: biome resonance reduces research cost by 1 (min 1).
+  // Caller computes resonance via biomeResonance.hasResonance(species, biome_id).
+  const resonance = Boolean(opts.resonance);
+  const cost = resonance ? Math.max(1, baseCost - 1) : baseCost;
+  const resonanceApplied = resonance && cost < baseCost;
   state.researching.set(thoughtId, {
     cost_remaining: cost,
     cost_total: cost,
+    base_cost: baseCost,
+    resonance_applied: resonanceApplied,
     started_at_encounter: Number.isFinite(opts.encounter) ? opts.encounter : null,
   });
-  return { ok: true, state, cost_total: cost };
+  return {
+    ok: true,
+    state,
+    cost_total: cost,
+    base_cost: baseCost,
+    resonance_applied: resonanceApplied,
+  };
 }
 
 function tickResearch(state, delta = 1) {
@@ -218,6 +231,8 @@ function snapshotCabinet(state) {
       id,
       cost_remaining: e.cost_remaining,
       cost_total: e.cost_total,
+      base_cost: e.base_cost ?? e.cost_total,
+      resonance_applied: Boolean(e.resonance_applied),
       started_at_encounter: e.started_at_encounter,
     })),
     internalized: Array.from(state.internalized),

--- a/tests/api/sessionThoughts.test.js
+++ b/tests/api/sessionThoughts.test.js
@@ -155,8 +155,32 @@ test('POST /:id/thoughts/research — happy path on an unlocked thought', async 
   assert.equal(res.body.unit_id, target.unit_id);
   assert.equal(res.body.thought_id, target.thought_id);
   assert.ok(res.body.cost_total >= 1);
+  // Skiv #4: response now plumbs base_cost + resonance_applied for HUD.
+  assert.ok(Number.isFinite(res.body.base_cost), 'base_cost is a number');
+  assert.equal(typeof res.body.resonance_applied, 'boolean');
   assert.equal(res.body.cabinet.slots_used, 1);
   assert.equal(res.body.cabinet.researching[0].id, target.thought_id);
+});
+
+test('POST /:id/thoughts/research — resonance_applied=false when biome_id missing', async (t) => {
+  // tutorial_01 bootstrap path doesn't pass biome_id → session.biome_id null,
+  // so resonance must always be false regardless of species.
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const { sid } = await bootstrap(app);
+  const snap = await request(app).get(`/api/session/${sid}/thoughts`);
+  const target = anyUnlockedActor(snap.body.per_actor);
+  if (!target) {
+    t.skip('no unlocked thoughts in tutorial 01 seed state');
+    return;
+  }
+  const res = await request(app)
+    .post(`/api/session/${sid}/thoughts/research`)
+    .send({ unit_id: target.unit_id, thought_id: target.thought_id });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.resonance_applied, false);
 });
 
 test('POST /:id/thoughts/research — 400 when unit_id or thought_id missing', async (t) => {

--- a/tests/api/thoughtCabinet.test.js
+++ b/tests/api/thoughtCabinet.test.js
@@ -432,3 +432,62 @@ test('full lifecycle: unlock → research → tick → internalize → forget �
   assert.equal(f1.freed_from, 'internalized');
   assert.equal(canResearchMore(s), true);
 });
+
+// ─────────────────────────────────────────────────────────
+// Skiv ticket #4 — biome resonance reduces research_cost
+// ─────────────────────────────────────────────────────────
+
+test('startResearch: resonance=true reduces tier-2 cost from 2 to 1', () => {
+  resetCache();
+  const s = createCabinetState();
+  mergeUnlocked(s, ['n_pioniere_possibile']); // tier 2 → cost 2
+  const out = startResearch(s, 'n_pioniere_possibile', { resonance: true });
+  assert.equal(out.ok, true);
+  assert.equal(out.cost_total, 1);
+  assert.equal(out.base_cost, 2);
+  assert.equal(out.resonance_applied, true);
+});
+
+test('startResearch: resonance=true on tier-1 (cost 1) does NOT clamp below 1', () => {
+  resetCache();
+  const s = createCabinetState();
+  mergeUnlocked(s, ['e_voce_collettiva']); // tier 1 → cost 1
+  const out = startResearch(s, 'e_voce_collettiva', { resonance: true });
+  assert.equal(out.ok, true);
+  assert.equal(out.cost_total, 1, 'min 1 enforced');
+  assert.equal(out.base_cost, 1);
+  assert.equal(out.resonance_applied, false, 'no reduction reported when no actual saving');
+});
+
+test('startResearch: resonance=false (default) leaves cost untouched', () => {
+  resetCache();
+  const s = createCabinetState();
+  mergeUnlocked(s, ['n_visionario']); // tier 3 → cost 3
+  const out = startResearch(s, 'n_visionario');
+  assert.equal(out.ok, true);
+  assert.equal(out.cost_total, 3);
+  assert.equal(out.base_cost, 3);
+  assert.equal(out.resonance_applied, false);
+});
+
+test('startResearch: resonance reduces tier-3 cost from 3 to 2', () => {
+  resetCache();
+  const s = createCabinetState();
+  mergeUnlocked(s, ['n_visionario']);
+  const out = startResearch(s, 'n_visionario', { resonance: true });
+  assert.equal(out.cost_total, 2);
+  assert.equal(out.base_cost, 3);
+  assert.equal(out.resonance_applied, true);
+});
+
+test('snapshotCabinet: exposes resonance_applied + base_cost on researching entries', () => {
+  resetCache();
+  const s = createCabinetState();
+  mergeUnlocked(s, ['n_pioniere_possibile']);
+  startResearch(s, 'n_pioniere_possibile', { resonance: true });
+  const snap = snapshotCabinet(s);
+  assert.equal(snap.researching.length, 1);
+  assert.equal(snap.researching[0].cost_total, 1);
+  assert.equal(snap.researching[0].base_cost, 2);
+  assert.equal(snap.researching[0].resonance_applied, true);
+});

--- a/tests/services/biomeResonance.test.js
+++ b/tests/services/biomeResonance.test.js
@@ -1,0 +1,92 @@
+// Biome resonance — pure unit tests for Skiv ticket #4 (Sprint A).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  loadSpeciesAffinityMap,
+  resetCache,
+  getSpeciesBiomeAffinity,
+  hasResonance,
+} = require('../../apps/backend/services/combat/biomeResonance');
+
+test('loadSpeciesAffinityMap: parses biome_affinity from species YAML', () => {
+  resetCache();
+  const map = loadSpeciesAffinityMap();
+  // dune_stalker has biome_affinity: savana per species.yaml
+  assert.equal(map.dune_stalker, 'savana');
+  // polpo_araldo_sinaptico has biome_affinity: frattura_abissale_sinaptica
+  assert.equal(map.polpo_araldo_sinaptico, 'frattura_abissale_sinaptica');
+});
+
+test('loadSpeciesAffinityMap: caches result; force=true reloads', () => {
+  resetCache();
+  const a = loadSpeciesAffinityMap();
+  const b = loadSpeciesAffinityMap();
+  assert.equal(a, b, 'same reference when cached');
+  const c = loadSpeciesAffinityMap({ force: true });
+  // After force reload the content equals but the reference may differ.
+  assert.deepEqual(a, c);
+});
+
+test('getSpeciesBiomeAffinity: returns affinity string', () => {
+  resetCache();
+  assert.equal(getSpeciesBiomeAffinity('dune_stalker'), 'savana');
+});
+
+test('getSpeciesBiomeAffinity: returns null for unknown species', () => {
+  resetCache();
+  assert.equal(getSpeciesBiomeAffinity('no_such_species'), null);
+});
+
+test('getSpeciesBiomeAffinity: null/empty input → null', () => {
+  resetCache();
+  assert.equal(getSpeciesBiomeAffinity(''), null);
+  assert.equal(getSpeciesBiomeAffinity(null), null);
+  assert.equal(getSpeciesBiomeAffinity(undefined), null);
+  assert.equal(getSpeciesBiomeAffinity(123), null); // non-string
+});
+
+test('hasResonance: matching species + biome → true', () => {
+  resetCache();
+  assert.equal(hasResonance('dune_stalker', 'savana'), true);
+});
+
+test('hasResonance: mismatched biome → false', () => {
+  resetCache();
+  assert.equal(hasResonance('dune_stalker', 'frattura_abissale_sinaptica'), false);
+});
+
+test('hasResonance: unknown species → false', () => {
+  resetCache();
+  assert.equal(hasResonance('no_such', 'savana'), false);
+});
+
+test('hasResonance: null/empty inputs → false', () => {
+  resetCache();
+  assert.equal(hasResonance('', 'savana'), false);
+  assert.equal(hasResonance('dune_stalker', ''), false);
+  assert.equal(hasResonance(null, 'savana'), false);
+  assert.equal(hasResonance('dune_stalker', null), false);
+});
+
+test('hasResonance: non-string types → false', () => {
+  resetCache();
+  assert.equal(hasResonance(123, 'savana'), false);
+  assert.equal(hasResonance('dune_stalker', { biome: 'savana' }), false);
+});
+
+test('hasResonance: case-sensitive match required', () => {
+  resetCache();
+  assert.equal(hasResonance('dune_stalker', 'Savana'), false);
+  assert.equal(hasResonance('dune_stalker', 'SAVANA'), false);
+});
+
+test('hasResonance: with explicit map override', () => {
+  const customMap = { test_species: 'test_biome' };
+  assert.equal(hasResonance('test_species', 'test_biome', { map: customMap }), true);
+  assert.equal(hasResonance('test_species', 'other', { map: customMap }), false);
+  assert.equal(hasResonance('unknown', 'test_biome', { map: customMap }), false);
+});


### PR DESCRIPTION
Closes the fourth [Skiv evolution wishlist](https://github.com/MasterDD-L34D/Game/blob/main/docs/planning/2026-04-25-illuminator-orchestra-handoff.md) ticket. Pillar 4 (Identità): when actor's species `biome_affinity` matches scenario `biome_id`, Thought Cabinet research costs -1 encounter (clamp ≥1).

> *"Le dune mi parlano. So cosa pensare prima."* — Skiv

## Summary
- **Engine** `apps/backend/services/combat/biomeResonance.js` (NEW, pure):
  - `loadSpeciesAffinityMap` caches species → biome_affinity from `data/core/species.yaml`
  - `hasResonance(speciesId, biomeId)` boolean (case-sensitive, exact match)
  - `getSpeciesBiomeAffinity` for future tier-aware extensions
- **Cabinet** `apps/backend/services/thoughts/thoughtCabinet.js`:
  - `startResearch(state, thoughtId, opts)` accepts `opts.resonance: boolean`
  - When true and `baseCost > 1`, decrements by 1 (clamp min 1)
  - Returns + stores `base_cost` + `resonance_applied` so HUD can show "saved 1 turn thanks to biome resonance"
  - `snapshotCabinet` exposes both per researching entry
- **Route** `apps/backend/routes/session.js`:
  - `POST /:id/thoughts/research` looks up actor by unit_id, computes `hasResonance(actor.species, session.biome_id)`, passes to engine

## Validation
- `tests/services/biomeResonance.test.js` (NEW) — **12/12** (catalog parse, affinity lookup, match + miss, null/empty guards, case-sensitivity, custom map override)
- `tests/api/thoughtCabinet.test.js` — **44/44** (was 39, +5: tier-2 reduction 2→1, tier-1 clamp ≥1, tier-3 reduction 3→2, default-false, snapshot exposure)
- `tests/api/sessionThoughts.test.js` — **13/13** (1 new test verifying resonance_applied=false when biome_id missing)
- AI 307/307 · services **306/306** (+12) · api **633/633** (+1)
- pytest unaffected
- `format:check` ✅ · governance 0/0
- No new deps

## Sprint A status post-PR
- Ticket #1 resolver wire — ⏳ remote agent 2026-05-11
- **Ticket #4 biome resonance — ✅ this PR**

## Test plan
- [x] Unit 12/12 (biomeResonance) + 5 new in cabinet
- [x] Integration 1 new (sessionThoughts)
- [x] Full suites green (306 + 633 + 307)
- [x] format + governance
- [ ] CI green

## Rollback
Revert this PR — research cost calculation reverts to pure base_cost (no resonance lookup); response shape loses `base_cost`/`resonance_applied` fields (frontend currently doesn't consume them, additive). No schema migration, no contract change.

## Refs
- Wishlist: `~/.claude/projects/.../memory/project_skiv_evolution_wishlist.md`
- YAML source: `data/core/species.yaml.species[].biome_affinity`
- Pattern: data-driven matcher (mirrors `synergyDetector.partsForActor`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)