### PR TITLE
feat(diary): unit diary persistente MVP backend (Skiv ticket #7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ data/flow-shell/*.bak
 reports/setup_backlog_*.log
 logs/telemetry_*.jsonl
 .pytest_cache/
+# Skiv ticket #7 — unit diary persistence (runtime, not committed)
+data/derived/unit_diaries/

--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -26,6 +26,8 @@ const { createRewardsRouter } = require('./routes/rewards');
 const { createFormPackRouter } = require('./routes/formPackRoutes');
 const { createLobbyRouter } = require('./routes/lobby');
 const { createCoopRouter } = require('./routes/coop');
+// Skiv ticket #7 — unit diary persistence (cross-session memoria)
+const { createDiaryRouter } = require('./routes/diary');
 const { createCoopStore } = require('./services/coop/coopStore');
 const { LobbyService } = require('./services/network/wsSession');
 const { createNebulaTelemetryAggregator } = require('./services/nebulaTelemetryAggregator');
@@ -732,6 +734,9 @@ function createApp(options = {}) {
   // M17 — Co-op run orchestrator (character creation + world setup + debrief).
   const coopStore = createCoopStore({ lobby });
   app.use('/api', createCoopRouter({ lobby, coopStore }));
+
+  // Skiv ticket #7 — unit diary persistence MVP (backend-only, JSONL append).
+  app.use('/api', createDiaryRouter(options.diary || {}));
 
   app.get('/api/deployments/status', async (req, res) => {
     try {

--- a/apps/backend/routes/diary.js
+++ b/apps/backend/routes/diary.js
@@ -1,0 +1,74 @@
+// =============================================================================
+// Unit Diary routes — Skiv ticket #7 backend MVP.
+//
+// GET /api/diary/:unit_id            tail (default 50, max 500)
+// GET /api/diary/:unit_id/summary    aggregate counts per event_type
+// POST /api/diary/:unit_id           append entry (server-side helpers wire here)
+//
+// Storage handled by services/diary/diaryStore.js (JSONL append-only).
+// =============================================================================
+
+'use strict';
+
+const express = require('express');
+const {
+  appendEntry,
+  tailDiary,
+  summary,
+  ALLOWED_EVENT_TYPES,
+} = require('../services/diary/diaryStore');
+
+function createDiaryRouter(opts = {}) {
+  const router = express.Router();
+  const baseDir = opts.baseDir; // optional override (tests)
+
+  router.get('/diary/:unit_id', (req, res, next) => {
+    try {
+      const unitId = req.params.unit_id;
+      const limit = Number.parseInt(req.query.limit, 10);
+      const reverse = req.query.reverse === 'true' || req.query.reverse === '1';
+      const entries = tailDiary(unitId, {
+        limit: Number.isFinite(limit) ? limit : 50,
+        reverse,
+        baseDir,
+      });
+      // Empty array is valid (no diary yet); return 200 with zero entries.
+      res.json({ unit_id: unitId, count: entries.length, entries });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.get('/diary/:unit_id/summary', (req, res, next) => {
+    try {
+      const unitId = req.params.unit_id;
+      const out = summary(unitId, { baseDir });
+      res.json(out);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.post('/diary/:unit_id', (req, res, next) => {
+    try {
+      const unitId = req.params.unit_id;
+      const body = req.body || {};
+      const outcome = appendEntry(unitId, body, { baseDir });
+      if (!outcome.ok) {
+        const status = outcome.error === 'invalid_unit_id' ? 400 : 409;
+        return res.status(status).json({
+          error: outcome.error,
+          detail: outcome.detail || null,
+          allowed_event_types: Array.from(ALLOWED_EVENT_TYPES),
+        });
+      }
+      res.status(201).json({ ok: true, unit_id: unitId, entry: outcome.entry });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}
+
+module.exports = { createDiaryRouter };

--- a/apps/backend/services/diary/diaryStore.js
+++ b/apps/backend/services/diary/diaryStore.js
@@ -1,0 +1,176 @@
+// =============================================================================
+// Unit Diary Store — Skiv ticket #7 (Sprint C tail).
+//
+// Pillar 5 cross-session continuity: tra una run e l'altra, un'unit perde la
+// sua storia. Diary append-only persistente per unit_id. JSONL per cheap
+// rotation + grep-friendly. MVP backend-only — UI viewer deferred.
+//
+// Schema entry:
+//   { ts, turn?, encounter_id?, event_type, payload }
+//
+// event_type whitelist (V1):
+//   - form_evolved
+//   - thought_internalized
+//   - scenario_completed
+//   - mbti_axis_threshold_crossed
+//   - defy_used
+//   - synergy_triggered
+//
+// Storage: `data/derived/unit_diaries/<sanitised_unit_id>.jsonl` (gitignored).
+// Rotation/cleanup deferred to ops.
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_BASE_DIR = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  'data',
+  'derived',
+  'unit_diaries',
+);
+
+const ALLOWED_EVENT_TYPES = new Set([
+  'form_evolved',
+  'thought_internalized',
+  'scenario_completed',
+  'mbti_axis_threshold_crossed',
+  'defy_used',
+  'synergy_triggered',
+]);
+
+const UNIT_ID_PATTERN = /^[A-Za-z0-9_\-]+$/;
+
+function sanitiseUnitId(unitId) {
+  if (typeof unitId !== 'string') return null;
+  if (!UNIT_ID_PATTERN.test(unitId)) return null;
+  if (unitId.length === 0 || unitId.length > 96) return null;
+  return unitId;
+}
+
+function diaryPath(unitId, baseDir = DEFAULT_BASE_DIR) {
+  const safe = sanitiseUnitId(unitId);
+  if (!safe) return null;
+  return path.join(baseDir, `${safe}.jsonl`);
+}
+
+function ensureBaseDir(baseDir = DEFAULT_BASE_DIR) {
+  fs.mkdirSync(baseDir, { recursive: true });
+}
+
+/**
+ * Append a diary entry. Validates event_type + sanitised unit_id.
+ * Returns { ok, entry?, error? }. Never throws on bad input.
+ */
+function appendEntry(unitId, entry, opts = {}) {
+  const baseDir = opts.baseDir || DEFAULT_BASE_DIR;
+  const safe = sanitiseUnitId(unitId);
+  if (!safe) return { ok: false, error: 'invalid_unit_id' };
+  if (!entry || typeof entry !== 'object') return { ok: false, error: 'invalid_entry' };
+  const eventType = entry.event_type;
+  if (!ALLOWED_EVENT_TYPES.has(eventType)) {
+    return { ok: false, error: 'invalid_event_type', detail: { event_type: eventType } };
+  }
+  const stamped = {
+    ts: entry.ts || new Date().toISOString(),
+    turn: Number.isFinite(Number(entry.turn)) ? Number(entry.turn) : null,
+    encounter_id: typeof entry.encounter_id === 'string' ? entry.encounter_id : null,
+    event_type: eventType,
+    payload: entry.payload && typeof entry.payload === 'object' ? entry.payload : {},
+  };
+  ensureBaseDir(baseDir);
+  const filepath = path.join(baseDir, `${safe}.jsonl`);
+  fs.appendFileSync(filepath, JSON.stringify(stamped) + '\n', 'utf8');
+  return { ok: true, entry: stamped };
+}
+
+/**
+ * Read full diary as array of entries (chronological order). Returns [] if no
+ * file. Each line is parsed; malformed lines are silently skipped.
+ */
+function getDiary(unitId, opts = {}) {
+  const baseDir = opts.baseDir || DEFAULT_BASE_DIR;
+  const safe = sanitiseUnitId(unitId);
+  if (!safe) return [];
+  const filepath = path.join(baseDir, `${safe}.jsonl`);
+  if (!fs.existsSync(filepath)) return [];
+  const raw = fs.readFileSync(filepath, 'utf8');
+  const lines = raw.split('\n').filter(Boolean);
+  const out = [];
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed && typeof parsed === 'object') out.push(parsed);
+    } catch {
+      /* skip malformed line */
+    }
+  }
+  return out;
+}
+
+/**
+ * Tail N entries (default 50). Returns most-recent first when reverse=true,
+ * else chronological. Used by HUD/debrief viewer.
+ */
+function tailDiary(unitId, opts = {}) {
+  const limit = Number.isFinite(Number(opts.limit))
+    ? Math.max(1, Math.min(500, Number(opts.limit)))
+    : 50;
+  const reverse = Boolean(opts.reverse);
+  const all = getDiary(unitId, opts);
+  const tail = all.slice(-limit);
+  return reverse ? tail.slice().reverse() : tail;
+}
+
+/**
+ * Aggregate: count per event_type + total + first_seen / last_seen ts.
+ * Cheap for ≤1000 entries; future ops can swap for a sqlite index.
+ */
+function summary(unitId, opts = {}) {
+  const all = getDiary(unitId, opts);
+  if (all.length === 0) {
+    return { unit_id: unitId, total: 0, by_event_type: {}, first_seen: null, last_seen: null };
+  }
+  const byType = {};
+  for (const entry of all) {
+    const t = entry.event_type;
+    byType[t] = (byType[t] || 0) + 1;
+  }
+  return {
+    unit_id: unitId,
+    total: all.length,
+    by_event_type: byType,
+    first_seen: all[0].ts || null,
+    last_seen: all[all.length - 1].ts || null,
+  };
+}
+
+/**
+ * Test helper — wipe the diary file for a unit. NOT exposed via route.
+ */
+function _resetDiaryForTest(unitId, opts = {}) {
+  const baseDir = opts.baseDir || DEFAULT_BASE_DIR;
+  const safe = sanitiseUnitId(unitId);
+  if (!safe) return;
+  const filepath = path.join(baseDir, `${safe}.jsonl`);
+  if (fs.existsSync(filepath)) fs.unlinkSync(filepath);
+}
+
+module.exports = {
+  ALLOWED_EVENT_TYPES,
+  DEFAULT_BASE_DIR,
+  sanitiseUnitId,
+  diaryPath,
+  ensureBaseDir,
+  appendEntry,
+  getDiary,
+  tailDiary,
+  summary,
+  _resetDiaryForTest,
+};

--- a/tests/api/diaryRoute.test.js
+++ b/tests/api/diaryRoute.test.js
@@ -1,0 +1,129 @@
+// Diary route integration — Skiv ticket #7 (Sprint C tail).
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+function tmpBaseDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'diary-route-test-'));
+}
+
+test('GET /api/diary/:unit_id — empty diary returns 200 with zero entries', async (t) => {
+  const baseDir = tmpBaseDir();
+  const { app, close } = createApp({ databasePath: null, diary: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const r = await request(app).get('/api/diary/skiv');
+  assert.equal(r.status, 200);
+  assert.equal(r.body.unit_id, 'skiv');
+  assert.equal(r.body.count, 0);
+  assert.deepEqual(r.body.entries, []);
+});
+
+test('POST /api/diary/:unit_id — happy path appends + returns 201', async (t) => {
+  const baseDir = tmpBaseDir();
+  const { app, close } = createApp({ databasePath: null, diary: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const r = await request(app)
+    .post('/api/diary/skiv')
+    .send({ event_type: 'defy_used', turn: 5, payload: { relief: 25 } });
+  assert.equal(r.status, 201);
+  assert.equal(r.body.ok, true);
+  assert.equal(r.body.unit_id, 'skiv');
+  assert.equal(r.body.entry.event_type, 'defy_used');
+  assert.equal(r.body.entry.turn, 5);
+});
+
+test('POST /api/diary/:unit_id — invalid event_type → 409 with allowed list', async (t) => {
+  const baseDir = tmpBaseDir();
+  const { app, close } = createApp({ databasePath: null, diary: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const r = await request(app).post('/api/diary/skiv').send({ event_type: 'spurious' });
+  assert.equal(r.status, 409);
+  assert.equal(r.body.error, 'invalid_event_type');
+  assert.ok(Array.isArray(r.body.allowed_event_types));
+  assert.ok(r.body.allowed_event_types.includes('defy_used'));
+});
+
+test('POST /api/diary/:unit_id — invalid unit_id → 400', async (t) => {
+  const baseDir = tmpBaseDir();
+  const { app, close } = createApp({ databasePath: null, diary: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const r = await request(app).post('/api/diary/..%2Fbad').send({ event_type: 'defy_used' });
+  assert.equal(r.status, 400);
+  assert.equal(r.body.error, 'invalid_unit_id');
+});
+
+test('GET /api/diary/:unit_id — returns appended entries chronologically', async (t) => {
+  const baseDir = tmpBaseDir();
+  const { app, close } = createApp({ databasePath: null, diary: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  await request(app).post('/api/diary/skiv').send({ event_type: 'defy_used', turn: 1 });
+  await request(app).post('/api/diary/skiv').send({ event_type: 'synergy_triggered', turn: 2 });
+  const r = await request(app).get('/api/diary/skiv');
+  assert.equal(r.status, 200);
+  assert.equal(r.body.count, 2);
+  assert.equal(r.body.entries[0].event_type, 'defy_used');
+  assert.equal(r.body.entries[1].event_type, 'synergy_triggered');
+});
+
+test('GET /api/diary/:unit_id?limit=1&reverse=true — applies query params', async (t) => {
+  const baseDir = tmpBaseDir();
+  const { app, close } = createApp({ databasePath: null, diary: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  await request(app).post('/api/diary/skiv').send({ event_type: 'defy_used', turn: 1 });
+  await request(app).post('/api/diary/skiv').send({ event_type: 'defy_used', turn: 2 });
+  await request(app).post('/api/diary/skiv').send({ event_type: 'defy_used', turn: 3 });
+  const r = await request(app).get('/api/diary/skiv?limit=1&reverse=true');
+  assert.equal(r.status, 200);
+  assert.equal(r.body.count, 1);
+  assert.equal(r.body.entries[0].turn, 3);
+});
+
+test('GET /api/diary/:unit_id/summary — aggregates counts', async (t) => {
+  const baseDir = tmpBaseDir();
+  const { app, close } = createApp({ databasePath: null, diary: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  await request(app).post('/api/diary/skiv').send({ event_type: 'defy_used', turn: 1 });
+  await request(app).post('/api/diary/skiv').send({ event_type: 'defy_used', turn: 2 });
+  await request(app).post('/api/diary/skiv').send({ event_type: 'synergy_triggered', turn: 3 });
+  const r = await request(app).get('/api/diary/skiv/summary');
+  assert.equal(r.status, 200);
+  assert.equal(r.body.total, 3);
+  assert.equal(r.body.by_event_type.defy_used, 2);
+  assert.equal(r.body.by_event_type.synergy_triggered, 1);
+  assert.ok(r.body.first_seen);
+  assert.ok(r.body.last_seen);
+});
+
+test('GET /api/diary/:unit_id/summary — empty diary → total 0', async (t) => {
+  const baseDir = tmpBaseDir();
+  const { app, close } = createApp({ databasePath: null, diary: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const r = await request(app).get('/api/diary/never/summary');
+  assert.equal(r.status, 200);
+  assert.equal(r.body.total, 0);
+});

--- a/tests/services/diaryStore.test.js
+++ b/tests/services/diaryStore.test.js
@@ -1,0 +1,206 @@
+// Diary store — pure unit tests for Skiv ticket #7 (Sprint C).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  ALLOWED_EVENT_TYPES,
+  sanitiseUnitId,
+  appendEntry,
+  getDiary,
+  tailDiary,
+  summary,
+  _resetDiaryForTest,
+} = require('../../apps/backend/services/diary/diaryStore');
+
+function tmpBaseDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'diary-test-'));
+}
+
+test('ALLOWED_EVENT_TYPES: 6 V1 entries', () => {
+  assert.equal(ALLOWED_EVENT_TYPES.size, 6);
+  assert.ok(ALLOWED_EVENT_TYPES.has('form_evolved'));
+  assert.ok(ALLOWED_EVENT_TYPES.has('thought_internalized'));
+  assert.ok(ALLOWED_EVENT_TYPES.has('scenario_completed'));
+  assert.ok(ALLOWED_EVENT_TYPES.has('mbti_axis_threshold_crossed'));
+  assert.ok(ALLOWED_EVENT_TYPES.has('defy_used'));
+  assert.ok(ALLOWED_EVENT_TYPES.has('synergy_triggered'));
+});
+
+test('sanitiseUnitId: accepts alnum + dash + underscore', () => {
+  assert.equal(sanitiseUnitId('skiv'), 'skiv');
+  assert.equal(sanitiseUnitId('p1-vega'), 'p1-vega');
+  assert.equal(sanitiseUnitId('unit_42'), 'unit_42');
+  assert.equal(sanitiseUnitId('SKIV_42'), 'SKIV_42');
+});
+
+test('sanitiseUnitId: rejects path traversal + special chars', () => {
+  assert.equal(sanitiseUnitId('../etc/passwd'), null);
+  assert.equal(sanitiseUnitId('skiv/foo'), null);
+  assert.equal(sanitiseUnitId('skiv;rm -rf'), null);
+  assert.equal(sanitiseUnitId('skiv with space'), null);
+  assert.equal(sanitiseUnitId(''), null);
+  assert.equal(sanitiseUnitId(null), null);
+  assert.equal(sanitiseUnitId(123), null);
+});
+
+test('sanitiseUnitId: rejects too-long ids (>96 chars)', () => {
+  assert.equal(sanitiseUnitId('a'.repeat(97)), null);
+  assert.equal(sanitiseUnitId('a'.repeat(96)), 'a'.repeat(96));
+});
+
+test('appendEntry: invalid unit_id → invalid_unit_id', () => {
+  const baseDir = tmpBaseDir();
+  const out = appendEntry('../bad', { event_type: 'defy_used' }, { baseDir });
+  assert.equal(out.ok, false);
+  assert.equal(out.error, 'invalid_unit_id');
+});
+
+test('appendEntry: invalid event_type → 409 with detail', () => {
+  const baseDir = tmpBaseDir();
+  const out = appendEntry('skiv', { event_type: 'spurious_event' }, { baseDir });
+  assert.equal(out.ok, false);
+  assert.equal(out.error, 'invalid_event_type');
+  assert.equal(out.detail.event_type, 'spurious_event');
+});
+
+test('appendEntry: missing entry → invalid_entry', () => {
+  const baseDir = tmpBaseDir();
+  assert.equal(appendEntry('skiv', null, { baseDir }).error, 'invalid_entry');
+  assert.equal(appendEntry('skiv', 'string', { baseDir }).error, 'invalid_entry');
+});
+
+test('appendEntry: happy path stamps ts + persists JSONL', () => {
+  const baseDir = tmpBaseDir();
+  const out = appendEntry(
+    'skiv',
+    { event_type: 'defy_used', turn: 5, payload: { relief: 25 } },
+    { baseDir },
+  );
+  assert.equal(out.ok, true);
+  assert.equal(out.entry.event_type, 'defy_used');
+  assert.equal(out.entry.turn, 5);
+  assert.deepEqual(out.entry.payload, { relief: 25 });
+  assert.ok(typeof out.entry.ts === 'string');
+  // Verify written to disk
+  const filepath = path.join(baseDir, 'skiv.jsonl');
+  assert.ok(fs.existsSync(filepath));
+  const raw = fs.readFileSync(filepath, 'utf8');
+  assert.ok(raw.includes('defy_used'));
+});
+
+test('getDiary: returns [] for missing diary', () => {
+  const baseDir = tmpBaseDir();
+  assert.deepEqual(getDiary('never_existed', { baseDir }), []);
+});
+
+test('getDiary: returns chronological entries', () => {
+  const baseDir = tmpBaseDir();
+  appendEntry('skiv', { event_type: 'defy_used', turn: 1 }, { baseDir });
+  appendEntry('skiv', { event_type: 'synergy_triggered', turn: 2 }, { baseDir });
+  appendEntry(
+    'skiv',
+    { event_type: 'thought_internalized', turn: 3, payload: { id: 'i_osservatore' } },
+    { baseDir },
+  );
+  const all = getDiary('skiv', { baseDir });
+  assert.equal(all.length, 3);
+  assert.equal(all[0].event_type, 'defy_used');
+  assert.equal(all[2].event_type, 'thought_internalized');
+  assert.equal(all[2].payload.id, 'i_osservatore');
+});
+
+test('getDiary: malformed JSON lines silently skipped', () => {
+  const baseDir = tmpBaseDir();
+  fs.mkdirSync(baseDir, { recursive: true });
+  const filepath = path.join(baseDir, 'skiv.jsonl');
+  fs.writeFileSync(
+    filepath,
+    `${JSON.stringify({ event_type: 'defy_used', ts: 'a' })}\n` +
+      `not json line\n` +
+      `${JSON.stringify({ event_type: 'synergy_triggered', ts: 'b' })}\n`,
+    'utf8',
+  );
+  const all = getDiary('skiv', { baseDir });
+  assert.equal(all.length, 2);
+  assert.equal(all[0].event_type, 'defy_used');
+  assert.equal(all[1].event_type, 'synergy_triggered');
+});
+
+test('tailDiary: defaults to last 50 chronological', () => {
+  const baseDir = tmpBaseDir();
+  for (let i = 0; i < 60; i += 1) {
+    appendEntry('skiv', { event_type: 'defy_used', turn: i }, { baseDir });
+  }
+  const tail = tailDiary('skiv', { baseDir });
+  assert.equal(tail.length, 50);
+  assert.equal(tail[0].turn, 10); // 60 - 50
+  assert.equal(tail[49].turn, 59);
+});
+
+test('tailDiary: respects custom limit + reverse=true', () => {
+  const baseDir = tmpBaseDir();
+  for (let i = 0; i < 5; i += 1) {
+    appendEntry('skiv', { event_type: 'defy_used', turn: i }, { baseDir });
+  }
+  const tail = tailDiary('skiv', { baseDir, limit: 3, reverse: true });
+  assert.equal(tail.length, 3);
+  assert.equal(tail[0].turn, 4); // most recent first
+  assert.equal(tail[2].turn, 2);
+});
+
+test('tailDiary: limit clamps [1, 500]', () => {
+  const baseDir = tmpBaseDir();
+  appendEntry('skiv', { event_type: 'defy_used' }, { baseDir });
+  // limit=0 → clamped to 1
+  assert.equal(tailDiary('skiv', { baseDir, limit: 0 }).length, 1);
+  // limit huge → clamped to 500 (we have 1 entry so just 1 shown)
+  assert.equal(tailDiary('skiv', { baseDir, limit: 99999 }).length, 1);
+});
+
+test('summary: empty diary → total 0, empty by_event_type', () => {
+  const baseDir = tmpBaseDir();
+  const out = summary('never_existed', { baseDir });
+  assert.equal(out.total, 0);
+  assert.deepEqual(out.by_event_type, {});
+  assert.equal(out.first_seen, null);
+  assert.equal(out.last_seen, null);
+});
+
+test('summary: aggregates counts + first/last ts', () => {
+  const baseDir = tmpBaseDir();
+  appendEntry(
+    'skiv',
+    { event_type: 'defy_used', turn: 1, ts: '2026-04-25T10:00:00Z' },
+    { baseDir },
+  );
+  appendEntry(
+    'skiv',
+    { event_type: 'defy_used', turn: 2, ts: '2026-04-25T10:05:00Z' },
+    { baseDir },
+  );
+  appendEntry(
+    'skiv',
+    { event_type: 'synergy_triggered', turn: 3, ts: '2026-04-25T10:10:00Z' },
+    { baseDir },
+  );
+  const out = summary('skiv', { baseDir });
+  assert.equal(out.total, 3);
+  assert.equal(out.by_event_type.defy_used, 2);
+  assert.equal(out.by_event_type.synergy_triggered, 1);
+  assert.equal(out.first_seen, '2026-04-25T10:00:00Z');
+  assert.equal(out.last_seen, '2026-04-25T10:10:00Z');
+});
+
+test('_resetDiaryForTest: removes diary file', () => {
+  const baseDir = tmpBaseDir();
+  appendEntry('skiv', { event_type: 'defy_used' }, { baseDir });
+  assert.equal(getDiary('skiv', { baseDir }).length, 1);
+  _resetDiaryForTest('skiv', { baseDir });
+  assert.equal(getDiary('skiv', { baseDir }).length, 0);
+});


### PR DESCRIPTION
Closes [Skiv ticket #7](https://github.com/MasterDD-L34D/Game/blob/main/docs/planning/2026-04-25-illuminator-orchestra-handoff.md). Pillar 5 cross-session continuity — JSONL append-only diary per unit_id. MVP backend-only (UI viewer deferred).

> *"Comincio a ricordare. Ho un diario."* — Skiv

## Summary
- **Engine** `apps/backend/services/diary/diaryStore.js` (NEW, ~165 LOC pure):
  - `sanitiseUnitId` regex `[A-Za-z0-9_\-]+` max 96 chars (path-traversal safe)
  - `appendEntry` with whitelist on `event_type` (6 V1: form_evolved, thought_internalized, scenario_completed, mbti_axis_threshold_crossed, defy_used, synergy_triggered)
  - `tailDiary` (clamp [1,500]) + `summary` aggregate per event_type
- **Routes** `apps/backend/routes/diary.js` (NEW):
  - `GET /api/diary/:unit_id` — tail (default 50, query `?limit=N&reverse=true`)
  - `GET /api/diary/:unit_id/summary` — aggregate counts
  - `POST /api/diary/:unit_id` — append entry (server-side hooks wire here)
  - 400 invalid unit_id · 409 invalid event_type with allowed list
- **App wire** `apps/backend/app.js` — `options.diary.baseDir` override for tests
- **gitignore** `data/derived/unit_diaries/` (runtime, not committed)

## Validation
- `tests/services/diaryStore.test.js` — **17/17** (sanitisation, path-traversal, JSONL persist, malformed-skip, clamp, summary)
- `tests/api/diaryRoute.test.js` — **8/8** (empty, POST 201, 409, 400, chronological GET, query params, summary aggregate + empty)
- AI 307/307 · services **323/323** (+17) · pytest 948/948
- `format:check` ✅ · governance 0/0 · no new deps · no schema/contract change

## Future hooks (P1 follow-up)
- Wire `applyDefy` (#1773) → diary append `defy_used`
- Wire `synergyDetector.recordSynergyFire` (#1772) → `synergy_triggered`
- Wire `thoughtCabinet.tickResearch` promote → `thought_internalized`
- Wire `formEvolution.evolve` → `form_evolved`
- Wire campaign `/advance` → `scenario_completed`
- UI viewer page (similar `progressionPanel.js` pattern)

## Test plan
- [x] Unit 17/17
- [x] Integration 8/8
- [x] Full suites green
- [x] format + governance + gitignore guard
- [ ] CI green

## Rollback
Revert this PR — `/api/diary/*` returns 404; `data/derived/unit_diaries/` ignored. No schema migration, no contract churn, no existing route touched.

## Refs
- Skiv wishlist: `~/.claude/projects/.../memory/project_skiv_evolution_wishlist.md`
- Pattern: append-only JSONL (mirrors `logs/telemetry_*.jsonl`)
- Companion PRs: [#1772](../pull/1772) [#1773](../pull/1773) [#1774](../pull/1774)

🤖 Generated with [Claude Code](https://claude.com/claude-code)