### PR TITLE
feat(narrative): Thought Cabinet resolver wire — passive stats at internalize/forget

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -61,6 +61,10 @@ const {
   hasResonance: hasBiomeResonance,
   computeResonanceTier,
 } = require('../services/combat/biomeResonance');
+// Skiv ticket #1: Thought Cabinet resolver wire — apply passive stats on
+// internalize/forget transitions. Reads cabinet snapshot deltas, mutates
+// unit.attack_mod / defense_dc / hp_max etc per effect_bonus / effect_cost.
+const { updateThoughtPassives } = require('../services/thoughts/thoughtPassiveApply');
 // SPRINT_010 (issue #2): IA estratta in modulo dedicato.
 // Le funzioni decisionali (selectAiPolicy, stepAway) vivono in services/ai/policy.js,
 // l'orchestratore del turno (createSistemaTurnRunner) in services/ai/sistemaTurnRunner.js.
@@ -2023,6 +2027,10 @@ function createSessionRouter(options = {}) {
       if (!outcome.ok) {
         return res.status(409).json({ error: outcome.error, thought_id });
       }
+      // Recompute passives post-forget and re-apply to live unit stats.
+      const postPassives = thoughtPassiveBonuses(state);
+      const unit = (session.units || []).find((u) => u && u.id === unit_id);
+      if (unit) updateThoughtPassives(unit, postPassives.bonus, postPassives.cost);
       res.json({
         session_id: session.session_id,
         unit_id,
@@ -2054,6 +2062,11 @@ function createSessionRouter(options = {}) {
       for (const [unitId, state] of iterable) {
         const { promoted } = tickThoughtResearch(state, delta);
         const passives = thoughtPassiveBonuses(state);
+        // Wire passives into live unit stats when thoughts are internalized.
+        if (promoted.length > 0) {
+          const unit = (session.units || []).find((u) => u && u.id === unitId);
+          if (unit) updateThoughtPassives(unit, passives.bonus, passives.cost);
+        }
         perActor[unitId] = {
           ...snapshotCabinet(state),
           promoted,

--- a/apps/backend/services/thoughts/thoughtPassiveApply.js
+++ b/apps/backend/services/thoughts/thoughtPassiveApply.js
@@ -1,0 +1,66 @@
+'use strict';
+
+// Applies / reverts Thought Cabinet passive stat deltas to a unit object.
+// Pattern mirrors progressionApply.js: additive mutation in-place, guarded
+// by a per-unit snapshot (`unit._thought_passive_delta`) for clean revert.
+//
+// Supported stats:
+//   attack_mod  → unit.mod
+//   defense_dc  → unit.dc  (bonus adds, cost subtracts)
+//   hp_max      → unit.hp_max + unit.hp (current HP scales with max)
+//   attack_range → unit.attack_range
+//   ap          → unit.ap  (floored at 1)
+// mov_penalty is aggregated by passiveBonuses() but has no runtime property
+// yet — skipped here (YAML comment: "aggregated but not auto-applied").
+
+function _netDeltas(bonus, cost) {
+  return {
+    mod: (bonus?.attack_mod || 0) - (cost?.attack_mod || 0),
+    dc: (bonus?.defense_dc || 0) - (cost?.defense_dc || 0),
+    hp_max: (bonus?.hp_max || 0) - (cost?.hp_max || 0),
+    attack_range: (bonus?.attack_range || 0) - (cost?.attack_range || 0),
+    ap: (bonus?.ap || 0) - (cost?.ap || 0),
+  };
+}
+
+function _revertDelta(unit, delta) {
+  if (!delta) return;
+  if (delta.mod) unit.mod = Number(unit.mod || 0) - delta.mod;
+  if (delta.dc) unit.dc = Number(unit.dc || 0) - delta.dc;
+  if (delta.hp_max) {
+    unit.hp_max = Math.max(1, Number(unit.hp_max || 0) - delta.hp_max);
+    unit.hp = Math.max(1, Number(unit.hp || 0) - delta.hp_max);
+  }
+  if (delta.attack_range)
+    unit.attack_range = Math.max(1, Number(unit.attack_range || 1) - delta.attack_range);
+  if (delta.ap) unit.ap = Math.max(1, Number(unit.ap || 0) - delta.ap);
+}
+
+/**
+ * Apply (or re-apply) thought passive bonuses/costs to a unit.
+ * Reverts any previously applied delta first, then applies the new one.
+ * Safe to call multiple times: each call is idempotent given the same inputs.
+ *
+ * @param {object} unit  — live session unit (mutated in-place)
+ * @param {object} bonus — passiveBonuses(state).bonus
+ * @param {object} cost  — passiveBonuses(state).cost
+ * @returns {{ ok: boolean, delta: object }}
+ */
+function updateThoughtPassives(unit, bonus, cost) {
+  if (!unit || typeof unit !== 'object') return { ok: false, error: 'no_unit' };
+  _revertDelta(unit, unit._thought_passive_delta);
+  const delta = _netDeltas(bonus, cost);
+  if (delta.mod) unit.mod = Number(unit.mod || 0) + delta.mod;
+  if (delta.dc) unit.dc = Number(unit.dc || 0) + delta.dc;
+  if (delta.hp_max) {
+    unit.hp_max = Math.max(1, Number(unit.hp_max || 0) + delta.hp_max);
+    unit.hp = Math.max(1, Number(unit.hp || 0) + delta.hp_max);
+  }
+  if (delta.attack_range)
+    unit.attack_range = Math.max(1, Number(unit.attack_range || 1) + delta.attack_range);
+  if (delta.ap) unit.ap = Math.max(1, Number(unit.ap || 0) + delta.ap);
+  unit._thought_passive_delta = delta;
+  return { ok: true, delta };
+}
+
+module.exports = { updateThoughtPassives };

--- a/tests/api/thoughtPassiveApply.test.js
+++ b/tests/api/thoughtPassiveApply.test.js
@@ -1,0 +1,80 @@
+// thoughtPassiveApply — unit tests for the stat-delta engine.
+// Tests mirror the progressionApply pattern: stat mutations are additive,
+// reverted cleanly on re-call, floored at minimum values.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  updateThoughtPassives,
+} = require('../../apps/backend/services/thoughts/thoughtPassiveApply');
+
+function makeUnit(overrides = {}) {
+  return { id: 'u1', mod: 2, dc: 12, hp: 10, hp_max: 10, ap: 2, attack_range: 2, ...overrides };
+}
+
+test('updateThoughtPassives: applies attack_mod bonus to unit.mod', () => {
+  const unit = makeUnit();
+  updateThoughtPassives(unit, { attack_mod: 2 }, {});
+  assert.equal(unit.mod, 4); // 2 + 2
+  assert.deepEqual(unit._thought_passive_delta, {
+    mod: 2,
+    dc: 0,
+    hp_max: 0,
+    attack_range: 0,
+    ap: 0,
+  });
+});
+
+test('updateThoughtPassives: applies defense_dc cost as penalty to unit.dc', () => {
+  const unit = makeUnit();
+  updateThoughtPassives(unit, {}, { defense_dc: 1 });
+  assert.equal(unit.dc, 11); // 12 - 1
+});
+
+test('updateThoughtPassives: net delta = bonus - cost for same stat', () => {
+  const unit = makeUnit();
+  // bonus defense_dc +2, cost defense_dc +1 → net +1 to unit.dc
+  updateThoughtPassives(unit, { defense_dc: 2 }, { defense_dc: 1 });
+  assert.equal(unit.dc, 13); // 12 + 1
+});
+
+test('updateThoughtPassives: hp_max bonus raises both hp_max and hp', () => {
+  const unit = makeUnit({ hp: 8, hp_max: 10 });
+  updateThoughtPassives(unit, { hp_max: 2 }, {});
+  assert.equal(unit.hp_max, 12);
+  assert.equal(unit.hp, 10); // 8 + 2
+});
+
+test('updateThoughtPassives: ap cost floored at 1 (cannot go below 1)', () => {
+  const unit = makeUnit({ ap: 1 });
+  // cost ap: 3 would make ap = 1 - 3 = -2; floored at 1
+  updateThoughtPassives(unit, {}, { ap: 3 });
+  assert.equal(unit.ap, 1);
+});
+
+test('updateThoughtPassives: re-apply reverts previous delta then applies new one', () => {
+  const unit = makeUnit();
+  // First apply: attack_mod +1
+  updateThoughtPassives(unit, { attack_mod: 1 }, {});
+  assert.equal(unit.mod, 3); // 2 + 1
+  // Re-apply with different values (e.g. after a thought was forgotten and re-internalized)
+  updateThoughtPassives(unit, { attack_mod: 3 }, {});
+  assert.equal(unit.mod, 5); // 2 + 3 (previous +1 reverted, new +3 applied)
+});
+
+test('updateThoughtPassives: empty bonus/cost leaves unit unchanged', () => {
+  const unit = makeUnit();
+  const { ok } = updateThoughtPassives(unit, {}, {});
+  assert.equal(ok, true);
+  assert.equal(unit.mod, 2);
+  assert.equal(unit.dc, 12);
+});
+
+test('updateThoughtPassives: null unit returns ok=false without throwing', () => {
+  const { ok, error } = updateThoughtPassives(null, { attack_mod: 1 }, {});
+  assert.equal(ok, false);
+  assert.equal(error, 'no_unit');
+});


### PR DESCRIPTION
## Summary

- New `thoughtPassiveApply.js`: pure `updateThoughtPassives(unit, bonus, cost)` that applies net thought passive deltas to live session unit stats, with revert on re-call
- Wired into `POST /:id/thoughts/tick` — calls `updateThoughtPassives` when thoughts get promoted (internalized)
- Wired into `POST /:id/thoughts/forget` — recomputes passives post-forget and re-applies the updated set (reverts the forgotten thought's contribution)
- `resolveAttack` in `sessionHelpers.js` reads `actor.mod` and `target.dc` — **no change needed there**: units already carry correct stats after wiring

## Stats wired

| YAML field | Unit property | Direction |
|---|---|---|
| `effect_bonus.attack_mod` | `unit.mod` | additive |
| `effect_bonus/cost.defense_dc` | `unit.dc` | net (bonus − cost) |
| `effect_bonus/cost.hp_max` | `unit.hp_max` + `unit.hp` | net, floor 1 |
| `effect_bonus.attack_range` | `unit.attack_range` | additive, floor 1 |
| `effect_bonus/cost.ap` | `unit.ap` | net, floor 1 |
| `effect_cost.mov_penalty` | — | skipped (no unit property) |

## Design notes

- Pattern mirrors `progressionApply.js` (M13): additive in-place mutation, guarded by `unit._thought_passive_delta` snapshot for clean revert
- Only called when promoted.length > 0 (tick) or after forget — not on every action (no perf overhead)
- Depends on: Phase 2 Thought Cabinet (#1769) — this PR should be merged after Phase 2 lands on main

## Test plan

- [x] `node --test tests/api/thoughtPassiveApply.test.js` → 8/8 (new)
- [x] `node --test tests/api/thoughtCabinet.test.js` → 39/39
- [x] `node --test tests/ai/*.test.js` → 307/307
- [x] `node --test tests/services/*.test.js` → 306/306
- [x] `npm run format:check` → verde

## Rollback plan

Delete `thoughtPassiveApply.js`, remove the `require` in `session.js`, and revert the 2 wiring blocks in tick/forget handlers. The `thoughtCabinet.js` passiveBonuses() output continues to be returned in API responses (passive_bonus/passive_cost) — just not applied to unit stats.

https://claude.ai/code/session_01Pdu7vhVcmfa3dnWsRUKYUZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pdu7vhVcmfa3dnWsRUKYUZ)_