### PR TITLE
feat(hooks): pre-edit worktree-guard + post-edit mojibake-guard (insights quick-wins)

### DIFF
--- a/.claude/hooks/post-edit-validate.sh
+++ b/.claude/hooks/post-edit-validate.sh
@@ -11,6 +11,30 @@ FILE=$(printf '%s' "$INPUT" | python3 -c 'import sys,json; d=json.load(sys.stdin
 [ -z "${FILE:-}" ] && exit 0
 [ ! -f "$FILE" ] && exit 0
 
+# Encoding mojibake guard (insights audit 2026-04-25 — caught the
+# glossary.json corruption AFTER CI failed in PR #1776). The pattern:
+# Python json.load + json.dump on Windows preserves whatever encoding
+# was in the file; if a previous write corrupted UTF-8 to "Ã" mojibake,
+# subsequent reads/writes silently propagate the corruption.
+# Detect: count "Ã" sequences (UTF-8 mojibake signature). >5 = warn.
+mojibake_check() {
+  local f="$1"
+  # Count occurrences (NOT lines) of UTF-8 mojibake signature "Ã".
+  # grep -o emits one match per line; wc -l counts them.
+  # Threshold: >5 occurrences = likely systematic corruption (single
+  # legitimate Italian word like "città" generates 0 false positives,
+  # since the byte 'Ã' only appears as a leading byte for actual
+  # multibyte UTF-8 chars when the file is corrupted).
+  local count
+  count=$(grep -o "Ã" "$f" 2>/dev/null | wc -l | tr -d ' \t\n\r')
+  count="${count:-0}"
+  if [ "$count" -gt 5 ] 2>/dev/null; then
+    echo "[hook] WARN: $count mojibake sequences (Ã) detected in $f"
+    echo "[hook]   likely UTF-8 corruption from cross-platform read/write"
+    echo "[hook]   action: restore from git ('git show HEAD:$f') and re-apply changes with explicit encoding='utf-8'"
+  fi
+}
+
 case "$FILE" in
   *.json)
     if command -v jq >/dev/null 2>&1; then
@@ -18,14 +42,20 @@ case "$FILE" in
     else
       python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$FILE" >/dev/null 2>&1 || echo "[hook] WARN: invalid JSON in $FILE — re-check edit"
     fi
+    mojibake_check "$FILE"
     ;;
   *.yaml|*.yml)
     python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" "$FILE" >/dev/null 2>&1 || echo "[hook] WARN: invalid YAML in $FILE — re-check edit"
+    mojibake_check "$FILE"
+    ;;
+  *.md)
+    mojibake_check "$FILE"
     ;;
   *.py)
     if command -v ruff >/dev/null 2>&1; then
       ruff check "$FILE" 2>&1 | head -5 || true
     fi
+    mojibake_check "$FILE"
     ;;
 esac
 

--- a/.claude/hooks/pre-edit-worktree-guard.sh
+++ b/.claude/hooks/pre-edit-worktree-guard.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# PreToolUse hook: warn (non-blocking) when Edit/Write/MultiEdit happens
+# OUTSIDE the current worktree. Stops the recurring "edit on main repo
+# instead of worktree" mistake (insights audit 2026-04-25, friction
+# category "wrong path/scope assumptions").
+#
+# Behavior: warn-only (exit 0). Output goes to transcript so the model
+# sees it and can self-correct. Never blocks the tool call.
+#
+# Detects 3 problem patterns:
+#   1. Edit target outside the current git worktree root
+#   2. Edit on main repo while a worktree exists for the active branch
+#   3. Edit on a /tmp/ or transient path (likely accident)
+
+set -uo pipefail
+
+INPUT=$(cat)
+
+# Extract file_path from tool_input
+FILE=$(printf '%s' "$INPUT" | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d.get("tool_input", {}).get("file_path", ""))
+except Exception:
+    pass
+' 2>/dev/null || true)
+
+[ -z "${FILE:-}" ] && exit 0
+
+# Resolve current worktree root (where this hook runs)
+CWD_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+[ -z "$CWD_ROOT" ] && exit 0
+
+# Normalize paths to Windows form (C:/foo) regardless of input form.
+# Handles: C:\foo, C:/foo, c:/foo, /c/foo, /C/foo
+normalize_path() {
+  printf '%s' "$1" \
+    | sed 's|\\|/|g' \
+    | sed -E 's|^/([a-zA-Z])/|\U\1:/|' \
+    | sed -E 's|^([a-z]):|\U\1:|'
+}
+FILE_NORM=$(normalize_path "$FILE")
+CWD_ROOT_NORM=$(normalize_path "$CWD_ROOT")
+
+# Check 1: file outside current worktree
+case "$FILE_NORM" in
+  "$CWD_ROOT_NORM"/*)
+    : # OK — inside current worktree
+    ;;
+  /tmp/*|/var/folders/*|*/AppData/Local/Temp/*)
+    echo "[worktree-guard] INFO: editing transient path $FILE_NORM (likely intentional)"
+    ;;
+  *)
+    # File path is absolute but outside current worktree
+    if [[ "$FILE_NORM" == /* ]] || [[ "$FILE_NORM" =~ ^[A-Za-z]:/ ]]; then
+      echo "[worktree-guard] WARN: edit target OUTSIDE current worktree"
+      echo "[worktree-guard]   target: $FILE_NORM"
+      echo "[worktree-guard]   worktree: $CWD_ROOT_NORM"
+      echo "[worktree-guard]   action: verify intent — Claude should usually edit inside the worktree"
+    fi
+    ;;
+esac
+
+# Check 2: edit on main repo while in a worktree
+if [[ "$CWD_ROOT_NORM" == */.claude/worktrees/* ]]; then
+  # We are in a worktree. Check if file_path points to the main repo.
+  MAIN_REPO=$(printf '%s' "$CWD_ROOT_NORM" | sed 's|/\.claude/worktrees/.*||')
+  if [[ -n "$MAIN_REPO" && "$FILE_NORM" == "$MAIN_REPO"/* ]] && [[ "$FILE_NORM" != "$CWD_ROOT_NORM"/* ]]; then
+    echo "[worktree-guard] WARN: editing MAIN REPO while in worktree"
+    echo "[worktree-guard]   main repo: $MAIN_REPO"
+    echo "[worktree-guard]   worktree:  $CWD_ROOT_NORM"
+    echo "[worktree-guard]   target:    $FILE_NORM"
+    echo "[worktree-guard]   action: should this go in the worktree instead?"
+  fi
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/pre-edit-worktree-guard.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write|MultiEdit",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,15 @@ Friction ricorrente da insights: 3 sessioni hanno editato main repo invece del w
 - **Pre-edit check**: `pwd` + `git rev-parse --show-toplevel` prima di edit non triviali se incerto su contesto. Working directory in CLAUDE_WORKING_DIR ha priorità sui path assunti dalla memoria.
 - **Worktree path detection**: se `pwd` contiene `.claude/worktrees/<slug>/`, sei in worktree isolato. Edit qui, NON nel main repo path.
 - **Missing file = ASK**: se path referenziato non esiste (`docs/planning/2026-XX-XX-*.md`, ADR, handoff), chiedi prima di fabbricare. Lista path candidati via `ls`/`find` se utile.
+- **Auto-enforced**: hook `PreToolUse` `.claude/hooks/pre-edit-worktree-guard.sh` (warn-only) emette `[worktree-guard] WARN` quando target Edit/Write/MultiEdit è fuori dal worktree corrente o tocca main repo da worktree. Se vedi il warn, ferma e verifica intent.
+
+## 🔤 Encoding Discipline
+
+Friction concreta sprint 2026-04-25 PR #1776: glossary.json aveva 37 char mojibake `Ã` da Python `json.dump` cross-platform. Bug invisibile finché CI `Generate QA baselines` ha failed.
+
+- **Sempre encoding esplicito**: `open(path, encoding='utf-8')` per read, `open(path, 'w', encoding='utf-8')` + `json.dump(..., ensure_ascii=False, indent=2)` per write. Nessun default-encoding implicito.
+- **Restore-from-git pattern**: se file ha mojibake, NON correggere in-place (rischio doppia corruzione). Restore da `git show origin/main:<path>` su file pulito + ri-applica modifiche con encoding UTF-8 esplicito.
+- **Auto-enforced**: hook `PostToolUse` `.claude/hooks/post-edit-validate.sh` emette `[hook] WARN: N mojibake sequences (Ã)` per file con >5 occorrenze di `Ã`. Threshold scelto per zero falsi positivi su Italian normale (es. "città" pulito = 0 match).
 
 ## 📤 Output Token Limits
 


### PR DESCRIPTION
## Summary

Quick-wins from `/insights` audit 2026-04-25 — automatize 2 friction patterns previously documented in CLAUDE.md but Claude self-policed (inconsistent).

**3 changes, 4 files, +128 lines, all warn-only (zero blocking)**:

1. **NEW** `.claude/hooks/pre-edit-worktree-guard.sh` (PreToolUse) — detects edit outside current worktree + edit on main repo from worktree
2. **EXTENDED** `.claude/hooks/post-edit-validate.sh` — added mojibake guard (catches PR #1776's exact bug)
3. **CLAUDE.md** — extended §🌳 Worktree Discipline + new §🔤 Encoding Discipline micro-section

## Friction caught (real history)

- **Worktree confusion**: insights report flagged "3 sessions edited main repo instead of worktree" (friction category "wrong path/scope assumptions")
- **Encoding mojibake**: PR #1776 had 37 corrupt `Ã` chars in `glossary.json` from Python `json.dump` cross-platform — silent until CI `Generate QA baselines` failed. Hook now catches at write time.

## Smoke tests passed

| Test | Result |
|---|---|
| Pre-edit T1 (inside worktree) | ✅ silent, exit 0 |
| Pre-edit T2 (outside worktree) | ✅ WARN emitted, exit 0 |
| Pre-edit T3 (main repo from wt) | ✅ double WARN (outside + main-from-wt), exit 0 |
| Pre-edit T4 (/tmp transient) | ✅ INFO only, exit 0 |
| Post-edit T1 (clean JSON `Città`) | ✅ silent, exit 0 |
| Post-edit T2 (8 mojibake chars) | ✅ WARN: 8 mojibake sequences, exit 0 |
| Post-edit T3 (invalid JSON) | ✅ WARN invalid + exit 0 |
| Post-edit T4 (clean Italian YAML `perché`) | ✅ silent, exit 0 |
| AI test suite | ✅ 307/307 |
| Prettier --check | ✅ clean |

## Design choices

- **Warn-only (exit 0 always)**: hooks emit to transcript so model sees feedback but never blocks autonomous sessions. Aligns with CLAUDE.md §🔁 "Surface blocker, don't end session".
- **Threshold >5 mojibake**: zero false positives on legitimate Italian text. `città` (clean UTF-8) → 0 grep matches; `CittÃƒÂ ` (corrupted) → 2 matches per word.
- **Path normalization**: handles MSYS `/c/foo`, Windows `C:/foo`, mixed case, backslash → all canonicalized to `C:/foo`.

## Test plan

- [x] Pre-edit hook smoke (4 cases)
- [x] Post-edit hook smoke (4 cases incl. mojibake & valid Italian)
- [x] Settings.json valid JSON
- [x] AI test suite 307/307
- [x] Prettier check clean
- [ ] Live observation next session — does Claude actually see/act on `[worktree-guard] WARN` and `[hook] WARN: N mojibake`? (userland)

## Rollback

`git revert <sha>` — pure additive (1 new file + 3 edits to additive sections). Zero impact on runtime/CI/contracts.

## Master DD approval

User direction explicit: "vai" + selected option 1 (A+B+C) from /insights audit response. Auto mode active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)