### PR TITLE
feat(ui): synergy HUD telegraph — ⚡ badge before attack lands (P1 follow-up #1772)

### DIFF
--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -21,6 +21,7 @@ const {
 
 const { DEFAULT_ATTACK_RANGE } = require('../services/ai/policy');
 const { buildAtlasLive } = require('../services/atlasLive');
+const { applicableSynergies } = require('../services/combat/synergyDetector');
 
 function rollD20(rng) {
   return Math.floor(rng() * 20) + 1;
@@ -275,7 +276,31 @@ function publicSessionView(session) {
     previous_round_synergies: Array.isArray(session.previous_round_synergies)
       ? session.previous_round_synergies
       : [],
+    synergy_preview: buildSynergyPreview(session),
   };
+}
+
+function buildSynergyPreview(session) {
+  const turn = Number(session.turn || 0);
+  const lastFires = session._synergy_last_fire || {};
+  return (session.units || [])
+    .filter((u) => u && u.hp > 0)
+    .map((u) => {
+      const synergies = applicableSynergies(u);
+      if (synergies.length === 0) return null;
+      const onCooldown = lastFires[u.id] !== undefined && lastFires[u.id] === turn;
+      return {
+        unit_id: u.id,
+        synergies: synergies.map((s) => ({
+          id: s.id,
+          name: s.name,
+          bonus_damage: s.effect?.bonus_damage ?? 1,
+        })),
+        on_cooldown: onCooldown,
+        ready: !onCooldown,
+      };
+    })
+    .filter(Boolean);
 }
 
 function buildTurnOrder(units) {
@@ -536,4 +561,5 @@ module.exports = {
   applyPressureDelta,
   SISTEMA_PRESSURE_TIERS,
   PRESSURE_DELTAS,
+  buildSynergyPreview,
 };

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -1171,6 +1171,32 @@ canvas#grid:hover {
 .status-chip .status-svg {
   flex-shrink: 0;
 }
+.synergy-telegraph {
+  margin-top: 4px;
+  font-size: 0.78rem;
+  color: #ffd86e;
+  background: rgba(255, 198, 50, 0.1);
+  border: 1px solid rgba(255, 198, 50, 0.35);
+  border-radius: 6px;
+  padding: 2px 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  animation: syn-pulse 2.4s ease-in-out infinite;
+}
+.synergy-telegraph .syn-bonus {
+  color: #ffaa00;
+  font-weight: 700;
+}
+@keyframes syn-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.6;
+  }
+}
 .unit-ai {
   margin-top: 3px;
   font-size: 0.7rem;

--- a/apps/play/src/ui.js
+++ b/apps/play/src/ui.js
@@ -325,6 +325,19 @@ function renderUnitLi(
         ${u.guardia ? `<span>guardia ${Number(u.guardia) || 0}</span>` : ''}
       </div>
       ${statusChips ? `<div class="unit-status-row">${statusChips}</div>` : ''}
+      ${(() => {
+        if (!isUnitAlive(u)) return '';
+        const preview = Array.isArray(state.synergy_preview)
+          ? state.synergy_preview.find((s) => s.unit_id === u.id && s.ready)
+          : null;
+        if (!preview) return '';
+        const names = preview.synergies
+          .map(
+            (s) => `${esc(s.name)} <span class="syn-bonus">+${Number(s.bonus_damage) || 1}</span>`,
+          )
+          .join(', ');
+        return `<div class="synergy-telegraph" title="Sinergia pronta — si attiva al prossimo colpo">⚡ ${names}</div>`;
+      })()}
       ${u.ai_profile ? `<div class="unit-ai">AI: <code>${esc(u.ai_profile)}</code></div>` : ''}
       ${(() => {
         if (u.controlled_by !== 'player' || !isUnitAlive(u)) return '';

--- a/tests/services/synergyDetector.test.js
+++ b/tests/services/synergyDetector.test.js
@@ -1,4 +1,4 @@
-// Synergy Combo Detection — pure unit tests for the detector module.
+// Synergy Combo Detection — pure unit tests for the detector module + buildSynergyPreview.
 
 'use strict';
 
@@ -16,6 +16,7 @@ const {
   recordSynergyFire,
   resetRoundSynergyTracker,
 } = require('../../apps/backend/services/combat/synergyDetector');
+const { buildSynergyPreview } = require('../../apps/backend/routes/sessionHelpers');
 
 function freshSession() {
   return { turn: 1, damage_taken: {} };
@@ -230,4 +231,75 @@ test('detectSynergyTrigger: explicit actor.parts can fire even on unknown specie
   const out = detectSynergyTrigger(freshSession(), actor, { id: 't1', hp: 5 });
   assert.equal(out.triggered, true);
   assert.equal(out.synergies[0].id, 'echo_backstab');
+});
+
+// ── buildSynergyPreview ─────────────────────────────────────────────────────
+
+test('buildSynergyPreview: unit with applicable synergy appears as ready', () => {
+  resetCache();
+  const session = {
+    turn: 1,
+    units: [{ id: 'p1', species: 'dune_stalker', hp: 10, controlled_by: 'player' }],
+  };
+  const preview = buildSynergyPreview(session);
+  assert.ok(Array.isArray(preview));
+  const entry = preview.find((s) => s.unit_id === 'p1');
+  assert.ok(entry, 'p1 should appear in preview');
+  assert.equal(entry.ready, true);
+  assert.equal(entry.on_cooldown, false);
+  assert.ok(entry.synergies.length >= 1);
+  assert.equal(entry.synergies[0].id, 'echo_backstab');
+});
+
+test('buildSynergyPreview: on_cooldown=true when unit fired this turn', () => {
+  resetCache();
+  const session = {
+    turn: 3,
+    _synergy_last_fire: { p1: 3 },
+    units: [{ id: 'p1', species: 'dune_stalker', hp: 10, controlled_by: 'player' }],
+  };
+  const preview = buildSynergyPreview(session);
+  const entry = preview.find((s) => s.unit_id === 'p1');
+  assert.ok(entry);
+  assert.equal(entry.ready, false);
+  assert.equal(entry.on_cooldown, true);
+});
+
+test('buildSynergyPreview: dead units excluded', () => {
+  resetCache();
+  const session = {
+    turn: 1,
+    units: [{ id: 'p1', species: 'dune_stalker', hp: 0, controlled_by: 'player' }],
+  };
+  const preview = buildSynergyPreview(session);
+  assert.equal(preview.length, 0, 'dead unit should not appear');
+});
+
+test('buildSynergyPreview: unit with no synergies not included', () => {
+  resetCache();
+  const session = {
+    turn: 1,
+    units: [{ id: 'p2', species: 'unknown_no_synergy', hp: 8, controlled_by: 'player' }],
+  };
+  const preview = buildSynergyPreview(session);
+  assert.ok(!preview.find((s) => s.unit_id === 'p2'));
+});
+
+test('buildSynergyPreview: empty units array → empty preview', () => {
+  const preview = buildSynergyPreview({ turn: 1, units: [] });
+  assert.deepEqual(preview, []);
+});
+
+test('buildSynergyPreview: cooldown expires next turn (different turn → ready again)', () => {
+  resetCache();
+  const session = {
+    turn: 4,
+    _synergy_last_fire: { p1: 3 }, // fired turn 3, now turn 4
+    units: [{ id: 'p1', species: 'dune_stalker', hp: 10, controlled_by: 'player' }],
+  };
+  const preview = buildSynergyPreview(session);
+  const entry = preview.find((s) => s.unit_id === 'p1');
+  assert.ok(entry);
+  assert.equal(entry.ready, true);
+  assert.equal(entry.on_cooldown, false);
 });


### PR DESCRIPTION
## Summary

Extends Skiv ticket #2 (synergy combo, shipped in #1772) with a **HUD telegraph** that shows synergy readiness _before_ the attack lands — ITB-pattern "intent preview".

### What was added

**Backend** (`sessionHelpers.js`):
- `buildSynergyPreview(session)` — exported helper, included in `publicSessionView` as `synergy_preview`
- Returns array of `{ unit_id, synergies: [{id, name, bonus_damage}], on_cooldown, ready }` for all living units that have applicable synergies
- `ready=true` iff unit has synergies AND hasn't fired one this turn (cooldown = 1/turn, same as detector)

**Frontend** (`ui.js` + `style.css`):
- `renderUnitLi` reads `state.synergy_preview` (from world state — no extra fetch)
- Renders amber `⚡ <SynergyName> +<bonus>` badge on any living unit with `ready=true`
- `.synergy-telegraph` CSS: `@keyframes syn-pulse` 2.4s glow, amber border, `#ffd86e` text

### Files changed

| File | Change |
|---|---|
| `apps/backend/routes/sessionHelpers.js` | +`buildSynergyPreview()` + `applicableSynergies` import |
| `apps/play/src/ui.js` | Synergy telegraph badge in `renderUnitLi` |
| `apps/play/src/style.css` | `.synergy-telegraph` + `syn-pulse` keyframes |
| `tests/services/synergyDetector.test.js` | +6 `buildSynergyPreview` tests |

## Test plan

- [x] `node --test tests/services/synergyDetector.test.js` → **28/28** (was 22)
- [x] `node --test tests/ai/*.test.js` → **307/307**
- [x] `npm run format:check` → green
- [ ] `stack-quality` CI

## Design notes

- Zero new endpoints — `synergy_preview` rides on existing `/state` response
- Badge visible for sistema units too (shows players the enemy has a combo ready — increases tactical tension)
- Badge is purely cosmetic: the actual bonus_damage is still computed at attack time via `detectSynergyTrigger` in `sessionRoundBridge`

## Rollback plan (03A)

Revert 4 files. No schema changes, no new deps, no DB migration.

https://claude.ai/code/session_01Pdu7vhVcmfa3dnWsRUKYUZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pdu7vhVcmfa3dnWsRUKYUZ)_