### PR TITLE
feat(combat): Sistema Pushback — symmetric Defy counter for AI (#1773)

### DIFF
--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -264,6 +264,7 @@ function publicSessionView(session) {
     events: Array.isArray(session.events) ? session.events.slice(-30) : [],
     sistema_pressure: pressure,
     sistema_tier: tier,
+    sistema_counter: Number(session.sistema_counter) || 0,
     atlas,
     last_round_combos: Array.isArray(session.last_round_combos) ? session.last_round_combos : [],
     previous_round_combos: Array.isArray(session.previous_round_combos)

--- a/apps/backend/services/ai/sistemaTurnRunner.js
+++ b/apps/backend/services/ai/sistemaTurnRunner.js
@@ -37,6 +37,7 @@
 // oscillare fra approach e retreat.
 
 const { selectAiPolicy, stepAway, DEFAULT_ATTACK_RANGE } = require('./policy');
+const { applySystemaPushback } = require('../combat/defyEngine');
 
 function createSistemaTurnRunner(deps) {
   const {
@@ -63,6 +64,20 @@ function createSistemaTurnRunner(deps) {
 
   return async function runSistemaTurn(session) {
     const effectiveGrid = session.grid?.width || gridSize;
+
+    // Sistema Pushback: fires before the turn loop when counter is charged.
+    const pushback = applySystemaPushback(session);
+    if (pushback.triggered && typeof appendEvent === 'function') {
+      await appendEvent(session, {
+        action_type: 'sistema_pushback',
+        actor_id: 'sistema',
+        turn: session.turn,
+        pressure_restored: pushback.pressure_restored,
+        pressure_after: pushback.after.pressure,
+        sistema_counter_spent: pushback.before.sistema_counter,
+      });
+    }
+
     const actor = session.units.find((u) => u.id === session.active_unit);
     if (!actor) return [];
     if ((actor.ap_remaining ?? 0) <= 0) {

--- a/apps/backend/services/combat/defyEngine.js
+++ b/apps/backend/services/combat/defyEngine.js
@@ -1,17 +1,25 @@
 // =============================================================================
-// Defy Action — Skiv ticket #5 (Sprint B [2/2]).
+// Defy Action — Skiv ticket #5 (Sprint B [2/2]) + Sistema Pushback extension.
 //
 // Pillar 6 (Fairness): the Sistema escalates pressure unilaterally; player has
 // no agency to push back. Defy gives the player a verb to spend SG to reduce
 // pressure tier — explicit tradeoff: -1 AP next turn.
 //
-// Spec:
+// Player Defy spec:
 //   cost: 2 SG (deducted from actor.sg)
 //   effect: pressure -25 (≈ 1 tier step), clamped at 0
 //   penalty: -1 AP next turn (encoded via actor.status.defy_penalty = 2;
 //            decrement loop drops it to 1 right after the action turn ends,
 //            then resetAp consumes it on the subsequent refill, decrement
 //            zeroes it. Net: exactly one AP-deficit turn.)
+//   side-effect: charges session.sistema_counter by +DEFY_COUNTER_CHARGE
+//
+// Sistema Pushback spec (symmetric):
+//   trigger: session.sistema_counter >= PUSHBACK_THRESHOLD (fires on Sistema turn)
+//   cost: resets sistema_counter to 0
+//   effect: pressure +PUSHBACK_PRESSURE_RESTORE, clamped at 100
+//   net: 2 player Defys → counter reaches 30 → Sistema pushback +15 pressure.
+//        Net pressure: -50 + 15 = -35 (player Defy still wins, but costs SG).
 //
 // Pure: validate + propose mutations. The route wraps with side-effects (write
 // pressure, decrement SG, set status, append event). Mirrors the
@@ -23,6 +31,11 @@
 const DEFY_SG_COST = 2;
 const DEFY_PRESSURE_RELIEF = 25;
 const DEFY_AP_PENALTY_TURNS = 2; // see header note for why 2 (decrement happens once before next turn)
+
+// Sistema Pushback constants
+const DEFY_COUNTER_CHARGE = 15; // added to sistema_counter per successful player Defy
+const PUSHBACK_THRESHOLD = 30; // Sistema fires pushback when counter reaches this
+const PUSHBACK_PRESSURE_RESTORE = 15; // pressure added back when Sistema pushes back
 
 const ERR_NOT_FOUND = 'actor_not_found';
 const ERR_NOT_PLAYER = 'not_player_controlled';
@@ -70,12 +83,40 @@ function applyDefy(actor, session) {
   if (!actor.status || typeof actor.status !== 'object') actor.status = {};
   const existing = Number(actor.status.defy_penalty || 0);
   actor.status.defy_penalty = Math.max(existing, DEFY_AP_PENALTY_TURNS);
+  // Charge the Sistema counter — symmetric pushback fuel.
+  const counterBefore = Number(session.sistema_counter) || 0;
+  session.sistema_counter = Math.min(PUSHBACK_THRESHOLD, counterBefore + DEFY_COUNTER_CHARGE);
   return {
     ok: true,
-    before: { sg: sgBefore, pressure: pressureBefore },
-    after: { sg: actor.sg, pressure: pressureAfter, defy_penalty: actor.status.defy_penalty },
+    before: { sg: sgBefore, pressure: pressureBefore, sistema_counter: counterBefore },
+    after: {
+      sg: actor.sg,
+      pressure: pressureAfter,
+      defy_penalty: actor.status.defy_penalty,
+      sistema_counter: session.sistema_counter,
+    },
     relief: pressureBefore - pressureAfter,
     cost: { sg: DEFY_SG_COST, ap_next_turn: 1 },
+  };
+}
+
+/**
+ * Attempt Sistema Pushback. Fires when session.sistema_counter >= PUSHBACK_THRESHOLD.
+ * Resets the counter and restores pressure. Pure — mutates session only if triggered.
+ * @returns {{ triggered: false } | { triggered: true, before, after, pressure_restored }}
+ */
+function applySystemaPushback(session) {
+  const counter = Number(session.sistema_counter) || 0;
+  if (counter < PUSHBACK_THRESHOLD) return { triggered: false };
+  const pressureBefore = Number(session.sistema_pressure) || 0;
+  const pressureAfter = Math.min(100, pressureBefore + PUSHBACK_PRESSURE_RESTORE);
+  session.sistema_pressure = pressureAfter;
+  session.sistema_counter = 0;
+  return {
+    triggered: true,
+    before: { sistema_counter: counter, pressure: pressureBefore },
+    after: { sistema_counter: 0, pressure: pressureAfter },
+    pressure_restored: pressureAfter - pressureBefore,
   };
 }
 
@@ -83,6 +124,9 @@ module.exports = {
   DEFY_SG_COST,
   DEFY_PRESSURE_RELIEF,
   DEFY_AP_PENALTY_TURNS,
+  DEFY_COUNTER_CHARGE,
+  PUSHBACK_THRESHOLD,
+  PUSHBACK_PRESSURE_RESTORE,
   ERR_NOT_FOUND,
   ERR_NOT_PLAYER,
   ERR_KO,
@@ -90,4 +134,5 @@ module.exports = {
   ERR_NO_PRESSURE,
   canDefy,
   applyDefy,
+  applySystemaPushback,
 };

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -156,6 +156,36 @@ header h1 {
     background 0.2s ease-out;
   border-radius: 4px;
 }
+.pushback-label {
+  font-size: 0.7rem;
+  color: #ef9a9a;
+  letter-spacing: 0.03em;
+  margin-top: 3px;
+}
+.pushback-bar {
+  width: 100%;
+  height: 5px;
+  background: rgba(255, 100, 80, 0.15);
+  border-radius: 3px;
+  overflow: hidden;
+  margin-top: 1px;
+}
+.pushback-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #ef9a9a, #ff5252);
+  border-radius: 3px;
+  transition: width 0.4s ease-out;
+  animation: pushback-pulse 2s ease-in-out infinite;
+}
+@keyframes pushback-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.55;
+  }
+}
 
 main {
   flex: 1;

--- a/apps/play/src/ui.js
+++ b/apps/play/src/ui.js
@@ -429,9 +429,17 @@ export function updateStatus(state) {
   const pressureEl = document.getElementById('pressure-meter');
   if (pressureEl) {
     const tier = pressureTier(state.sistema_pressure);
+    const counter = Number(state.sistema_counter) || 0;
+    const counterPct = Math.min(100, Math.round((counter / 30) * 100));
+    const counterHtml =
+      counter > 0
+        ? `<div class="pushback-label">⚔ Pushback ${counter}/30</div>
+           <div class="pushback-bar"><div class="pushback-fill" style="width:${counterPct}%"></div></div>`
+        : '';
     pressureEl.innerHTML = `
       <div class="pressure-label">SISTEMA <strong style="color:${tier.color}">${tier.label}</strong> · ${tier.value}/100 · cap ${tier.intents} intents/round</div>
       <div class="pressure-bar"><div class="pressure-fill" style="width:${tier.value}%;background:${tier.color}"></div></div>
+      ${counterHtml}
     `;
   }
 }

--- a/tests/ai/sistemaTurnRunner.test.js
+++ b/tests/ai/sistemaTurnRunner.test.js
@@ -494,3 +494,50 @@ test('runner: factory valida deps required', () => {
     /performAttack is required/,
   );
 });
+
+// ─── Sistema Pushback integration ──────────────────────────────────────────
+
+test('runner: pushback fires when sistema_counter >= 30, resets counter + restores pressure', async () => {
+  const { runner, appended } = buildRunner();
+  const session = makeSession();
+  session.sistema_pressure = 40;
+  session.sistema_counter = 30;
+  await runner(session);
+  // Counter reset to 0 and pressure increased
+  assert.equal(session.sistema_counter, 0);
+  assert.equal(session.sistema_pressure, 55); // 40 + 15
+  // A sistema_pushback event must have been emitted
+  const pushbackEvent = appended.find((e) => e.action_type === 'sistema_pushback');
+  assert.ok(pushbackEvent, 'sistema_pushback event emitted');
+  assert.equal(pushbackEvent.pressure_restored, 15);
+  assert.equal(pushbackEvent.actor_id, 'sistema');
+});
+
+test('runner: pushback does not fire when sistema_counter < 30', async () => {
+  const { runner, appended } = buildRunner();
+  const session = makeSession();
+  session.sistema_pressure = 40;
+  session.sistema_counter = 15;
+  await runner(session);
+  assert.equal(session.sistema_counter, 15); // unchanged
+  assert.equal(session.sistema_pressure, 40); // unchanged
+  const pushbackEvent = appended.find((e) => e.action_type === 'sistema_pushback');
+  assert.equal(pushbackEvent, undefined);
+});
+
+test('runner: pushback fires even on missing sistema_counter field (legacy sessions safe)', async () => {
+  const { runner } = buildRunner();
+  const session = makeSession(); // no sistema_counter field
+  await runner(session); // must not throw
+  assert.ok(true, 'no throw on missing campo');
+});
+
+test('runner: pushback pressure clamps at 100', async () => {
+  const { runner } = buildRunner();
+  const session = makeSession();
+  session.sistema_pressure = 95;
+  session.sistema_counter = 30;
+  await runner(session);
+  assert.equal(session.sistema_pressure, 100); // capped
+  assert.equal(session.sistema_counter, 0);
+});

--- a/tests/services/defyEngine.test.js
+++ b/tests/services/defyEngine.test.js
@@ -1,4 +1,4 @@
-// Defy engine — pure unit tests for Skiv ticket #5 (Sprint B [2/2]).
+// Defy engine — pure unit tests for Skiv ticket #5 (Sprint B [2/2]) + Sistema Pushback.
 
 'use strict';
 
@@ -9,6 +9,9 @@ const {
   DEFY_SG_COST,
   DEFY_PRESSURE_RELIEF,
   DEFY_AP_PENALTY_TURNS,
+  DEFY_COUNTER_CHARGE,
+  PUSHBACK_THRESHOLD,
+  PUSHBACK_PRESSURE_RESTORE,
   ERR_NOT_FOUND,
   ERR_NOT_PLAYER,
   ERR_KO,
@@ -16,6 +19,7 @@ const {
   ERR_NO_PRESSURE,
   canDefy,
   applyDefy,
+  applySystemaPushback,
 } = require('../../apps/backend/services/combat/defyEngine');
 
 function buildPlayer(overrides = {}) {
@@ -141,4 +145,90 @@ test('applyDefy: actor without status object → creates status', () => {
 test('canDefy: non-finite pressure treated as 0 → blocked', () => {
   const sess = { sistema_pressure: 'invalid' };
   assert.equal(canDefy(buildPlayer(), sess).error, ERR_NO_PRESSURE);
+});
+
+// ─── Sistema Pushback (symmetric Defy extension) ────────────────────────────
+
+test('pushback constants — charge 15, threshold 30, restore 15', () => {
+  assert.equal(DEFY_COUNTER_CHARGE, 15);
+  assert.equal(PUSHBACK_THRESHOLD, 30);
+  assert.equal(PUSHBACK_PRESSURE_RESTORE, 15);
+});
+
+test('applyDefy: charges sistema_counter by DEFY_COUNTER_CHARGE on success', () => {
+  const actor = buildPlayer();
+  const sess = buildSession({ sistema_counter: 0 });
+  applyDefy(actor, sess);
+  assert.equal(sess.sistema_counter, DEFY_COUNTER_CHARGE);
+});
+
+test('applyDefy: counter accumulates across two Defys (capped at PUSHBACK_THRESHOLD)', () => {
+  const actor1 = buildPlayer({ sg: 10 });
+  const sess = buildSession({ sistema_pressure: 80, sistema_counter: 0 });
+  applyDefy(actor1, sess); // first: counter → 15
+  assert.equal(sess.sistema_counter, 15);
+  applyDefy(actor1, sess); // second: counter → 30 (capped at threshold)
+  assert.equal(sess.sistema_counter, PUSHBACK_THRESHOLD);
+});
+
+test('applyDefy: counter does not exceed PUSHBACK_THRESHOLD', () => {
+  const actor = buildPlayer();
+  const sess = buildSession({ sistema_counter: PUSHBACK_THRESHOLD });
+  applyDefy(actor, sess);
+  assert.equal(sess.sistema_counter, PUSHBACK_THRESHOLD);
+});
+
+test('applyDefy: failed Defy does not charge counter', () => {
+  const actor = buildPlayer({ sg: 0 });
+  const sess = buildSession({ sistema_counter: 0 });
+  applyDefy(actor, sess);
+  assert.equal(sess.sistema_counter, 0); // unchanged
+});
+
+test('applyDefy: after exposes sistema_counter in result', () => {
+  const actor = buildPlayer();
+  const sess = buildSession({ sistema_counter: 0 });
+  const out = applyDefy(actor, sess);
+  assert.equal(out.after.sistema_counter, DEFY_COUNTER_CHARGE);
+  assert.equal(out.before.sistema_counter, 0);
+});
+
+test('applySystemaPushback: no trigger when counter < threshold', () => {
+  const sess = buildSession({ sistema_counter: 15 });
+  const out = applySystemaPushback(sess);
+  assert.equal(out.triggered, false);
+  assert.equal(sess.sistema_counter, 15); // unchanged
+  assert.equal(sess.sistema_pressure, 50); // unchanged
+});
+
+test('applySystemaPushback: triggers at threshold — resets counter, restores pressure', () => {
+  const sess = buildSession({ sistema_pressure: 40, sistema_counter: 30 });
+  const out = applySystemaPushback(sess);
+  assert.equal(out.triggered, true);
+  assert.equal(sess.sistema_counter, 0);
+  assert.equal(sess.sistema_pressure, 40 + PUSHBACK_PRESSURE_RESTORE);
+  assert.equal(out.pressure_restored, PUSHBACK_PRESSURE_RESTORE);
+});
+
+test('applySystemaPushback: pressure clamps at 100', () => {
+  const sess = buildSession({ sistema_pressure: 95, sistema_counter: 30 });
+  const out = applySystemaPushback(sess);
+  assert.equal(out.triggered, true);
+  assert.equal(sess.sistema_pressure, 100);
+  assert.equal(out.pressure_restored, 5); // only 5 restored (clamped)
+});
+
+test('applySystemaPushback: missing sistema_counter (legacy session) → no trigger', () => {
+  const sess = buildSession({}); // no sistema_counter field
+  const out = applySystemaPushback(sess);
+  assert.equal(out.triggered, false);
+});
+
+test('applySystemaPushback: reports before/after correctly', () => {
+  const sess = buildSession({ sistema_pressure: 30, sistema_counter: 30 });
+  const out = applySystemaPushback(sess);
+  assert.equal(out.before.sistema_counter, 30);
+  assert.equal(out.before.pressure, 30);
+  assert.equal(out.after.sistema_counter, 0);
+  assert.equal(out.after.pressure, 30 + PUSHBACK_PRESSURE_RESTORE);
 });


### PR DESCRIPTION
## Summary

Closes the last P1 follow-up from the 2026-04-25 illuminator-orchestra handoff (#1773).

- **`defyEngine.js`**: New constants `DEFY_COUNTER_CHARGE=15`, `PUSHBACK_THRESHOLD=30`, `PUSHBACK_PRESSURE_RESTORE=15`. `applyDefy` now increments `session.sistema_counter` on success. New pure fn `applySystemaPushback(session)` resets counter → 0 and restores +15 pressure when threshold is reached.
- **`sistemaTurnRunner.js`**: Calls `applySystemaPushback` at the start of every Sistema turn; emits a `sistema_pushback` event if triggered.
- **`sessionHelpers.js`**: `publicSessionView` exposes `sistema_counter` for the frontend.
- **`ui.js`**: Renders `⚔ Pushback N/30` charge bar below the SISTEMA pressure meter (only visible when counter > 0).
- **`style.css`**: `.pushback-bar`, `.pushback-fill`, `@keyframes pushback-pulse` (red pulsing bar).

**Net math (Fairness balance):** 2 player Defys cost 4 SG and drop pressure by -50. The counter charges to 30, triggering Sistema pushback (+15) on the next Sistema turn. Net: -35 pressure. Player Defy is still net-positive but now costs SG *and* prompts a visible, predictable AI counter-response.

## Test plan

- [ ] `node --test tests/services/defyEngine.test.js` → 26/26 ✅ (11 new)
- [ ] `node --test tests/ai/sistemaTurnRunner.test.js` → 15/15 ✅ (4 new)
- [ ] `node --test tests/ai/*.test.js` → 311/311 ✅
- [ ] `node --test tests/services/*.test.js` → 334/334 ✅
- [ ] `npm run format:check` → verde ✅
- [ ] Playtest: use Defy twice → observe `⚔ Pushback 30/30` charge bar turn red; next Sistema turn resets bar and pressure ticks up +15

## Rollback plan

Revert commit `7063f7f`. Zero schema changes, zero new deps. All mutations are additive (`sistema_counter` defaults to 0 on read via `|| 0`).

https://claude.ai/code/session_01Pdu7vhVcmfa3dnWsRUKYUZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pdu7vhVcmfa3dnWsRUKYUZ)_