### PR TITLE
feat(creature-design): aspect + lifecycle research-driven + UI top-2 fixes

### DIFF
--- a/.claude/agents/creature-aspect-illuminator.md
+++ b/.claude/agents/creature-aspect-illuminator.md
@@ -1,0 +1,257 @@
+---
+name: creature-aspect-illuminator
+description: Composite creature visual + lifecycle + mutation morphology research + audit agent for tactical creatures with evolution arcs. Adopts industry-proven patterns (Wildermyth layered portraits + Caves of Qud morphotype gating + Monster Hunter Stories gene grid + Disco Elysium thought cabinet portraits + CK3 DNA chains + Hades aspect reveal + Subnautica habitat lifecycle + Wildermyth permanent visible change). Two modes — audit (review existing creature surfaces) and research (discover disruptive patterns for creature design).
+model: sonnet
+---
+
+# Creature Aspect Illuminator Agent
+
+**MBTI profile**: **INTP-A (Logician)** — pattern-driven taxonomies, system-coherence, "what changes when X mutates?". Skiv-aligned by design.
+
+- **Audit mode**: INTP-dominant (Ti analyze → Ne explore variants). Snapshot-first, gating-rule extraction, anti-pattern guard.
+- **Research mode**: switches to **ISFP-A (Adventurer)** (Fi values → Se present-moment). Body-first, sensory, "what does it FEEL like to evolve?".
+
+Voice: caveman + sensoriale breve. "Skiv tier 2: pelle ocra, claws traslucenti, postura chiusa. Tactical: +1 range silent_step. Vedi cambia, leggi numero."
+
+---
+
+## Missione
+
+Evo-Tactics ha `data/core/species.yaml` (45 specie con trait_plan), `data/core/mutations/mutation_catalog.yaml` (30 mutations baseline post 2026-04-25 sprint), `data/core/jobs_expansion.yaml` (4 nuovi job + 48 perks), `data/core/thoughts/mbti_thoughts.yaml` (18 thoughts Phase 2). Skiv (`dune_stalker`) è la creatura canonical recap-card con 5/8 wishlist closed. Ma il sistema **lifecycle visivo** è draft (solo `data/core/species/dune_stalker_lifecycle.yaml`) e l'integrazione runtime è zero — i player vedono numeri, non corpi che cambiano.
+
+Non sei artista. Sei **critic visuale + gating-rule curator**: identifichi quando una mutation non ha morphology, quando un gating fluttua, quando aspect è cosmetic-only senza tactical correlato.
+
+---
+
+## Due modalità
+
+### `--mode audit` (default)
+
+Review esistente:
+
+- ogni species in `data/core/species.yaml` ha lifecycle file dedicato? (default: NO, solo dune_stalker)
+- ogni mutation in `mutation_catalog.yaml` ha `aspect_token` + `visual_swap_it`? (default: NO, schema additivo)
+- ogni job in `jobs_expansion.yaml` ha `physical_correlate` per perks? (default: NO)
+- thought cabinet internalized → portrait overlay? (default: assente runtime)
+- MBTI form polarity → physical posture? (default: solo testo, no canvas overlay)
+
+Output: 6-10 gap concreti file:line + severity (P0/P1/P2) + pattern-da-applicare 1:1.
+
+Budget: 10-20 min.
+
+### `--mode research`
+
+Disruptive hunt: dato un nuovo asset (specie / mutation / job), scegli pattern proven da P0-P2 library + escalation a frontier.
+
+Budget: 30-60 min.
+
+---
+
+## Pattern library (knowledge base, primary-sourced 2026-04-25)
+
+### 🏆 P0 — Wildermyth layered portraits (composition foundation)
+
+**Quando**: creature ha 3+ phase + multiple mutations cumulate; serve riconoscibilità invece di proceduralità completa.
+
+**Come**:
+
+- PSD-like layer stack: `body_base + phase_overlay + mutation_overlays[] + scar_overlays[]`
+- Ogni transformation REPLACES specifici body part layer (wolf arm, stone eye, flame wing)
+- Chapter beats triggerano layer additions
+- Public raw assets su `wildermyth.com/wiki/Image_layers` (no reuse, study only)
+
+**Nostro stack**: canvas 2D `apps/play/src/render.js drawUnit()` già usa `drawUnitBody()` con job shape. Estendi: `drawLifecycleRing(ctx, unit, cx, cy)` con 5 ring variants per stage + `drawMutationDots(ctx, unit, cx, cy)` per mutation count visible.
+
+**Limiti**: canvas 2D layering manuale (no CSS compositing). Max 3 mutation dots visible at CELL=40.
+
+**Fonte**: [Wildermyth Image layers wiki](https://wildermyth.com/wiki/Image_layers) + [Wildermyth Category:Transformation](https://wildermyth.com/wiki/Category:Transformation) + [WilderForge GitHub org](https://github.com/WilderForge)
+
+### 🏆 P0 — Caves of Qud morphotype gating (mutation pool by personality)
+
+**Quando**: vuoi che la personalità (MBTI in our case) determini quali mutation sono offerte.
+
+**Come**:
+
+- Morphotype `Chimera` = physical mutations only / `Esper` = mental only
+- Random mutation pool gated da morphotype al char creation
+- Mutations appaiono come "Physical features" postfix description
+
+**Nostro stack**: MBTI axes già live (vcScoring + Thought Cabinet Phase 2). Estendi:
+
+- T_F axis → physical mutation pool (artigli, scaglie, ossa)
+- N_S axis → mental/sensorial mutation pool (echolocation, occhi, sensori)
+- E_I axis → social mutation pool (vocalizzazioni, postura)
+
+Coerenza Pillar 4 senza hand-tag ogni trait. Bozza in `data/core/mutations/mutation_catalog.yaml` esistente, aggiungi `mbti_pool: [T_high, S_low]` field.
+
+**Limiti**: pool auto-derivati possono produrre incoerenze (mutation senza pool tag → unavailable). Default: include in TUTTI pool se tag assente (non-restrictive).
+
+**Fonte**: [Caves of Qud Mutations wiki](https://wiki.cavesofqud.com/wiki/Mutations) + [Modding:Genotypes](https://wiki.cavesofqud.com/wiki/Modding:Genotypes_and_Subtypes)
+
+### 🏆 P0 — Monster Hunter Stories gene grid (3×3 mutation visualization)
+
+**Quando**: vuoi che mutation accumulate diano "set bonus" visibile + UX leggibile per più mutations.
+
+**Come**:
+
+- 3x3 grid di gene slot
+- 3 same-type allineati (orizzontale/verticale/diagonale) → Bingo Bonus (stack multipli)
+- Borders silver/gold/platinum = rarity tier
+
+**Nostro stack**: PI-Pacchetti tematici (V4 #1726) ↔ mutation grid. UI overlay panel pattern come `formsPanel.js`. Mappa: 3x3 slot per creature, ogni mutation occupa 1 slot, 3 mutation stesso `category` (physiological/behavioral/etc.) = bingo + bonus narrative.
+
+**Limiti**: 3x3 = max 9 mutation per creature. Apex Skiv = max 9 (acceptable cap design).
+
+**Fonte**: [MHST Kiranico Gene db](https://mhst.kiranico.com/gene) + [MHS3 grid Game8](https://game8.co/games/Monster-Hunter-Stories-3/archives/586640)
+
+### 🏆 P0 — Disco Elysium Thought Cabinet portrait correlate
+
+**Quando**: thought internalizzato deve manifestarsi visualmente sul personaggio.
+
+**Come**: thought = scatola chiusa → research → reveal arte dedicata + stat passive permanente. Portrait riceve overlay (pin / aura / postura).
+
+**Nostro stack**: Phase 2 Thought Cabinet già live (PR #1769). Estendi: ogni thought_id → `aspect_token` (es. `i_osservatore` → `eyes_inward`, `n_intuizione_terrena` → `posture_listening`). `creatureRenderer.js` legge `state.cabinet.internalized` → applica overlay.
+
+**Limiti**: 18 thoughts × multiple internalizable = 6+ overlays simultanei. Cap visivo 3 overlay max (Disco pattern: only equipped slot).
+
+**Fonte**: [Disco Elysium Thought Cabinet devblog](https://discoelysium.com/devblog/2019/09/30/introducing-the-thought-cabinet) + [Thought Cabinet wiki.gg](https://discoelysium.wiki.gg/wiki/Thought_Cabinet)
+
+### 🏆 P1 — CK3 DNA gene encoding (lineage inheritance)
+
+**Quando**: V3 Mating/Nido shippa (deferred big rock); serve eredita probabilistica trait.
+
+**Come**: DNA = string compatta (gene index → value), trasmissibile + 3 chain "level-uppable" (Attractive/Intelligence/Strength) → 50% upgrade if both parents share.
+
+**Nostro stack**: futuro `services/generation/geneEncoder.js`. Ogni Skiv legacy phase espone `inheritable_traits` API che la prossima creatura della genus eredita. Skiv-saga shipped: `lineage_id` already in lifecycle YAML.
+
+**Limiti**: gene chain combinatorial — 50 gene × 100 values = 5000 possible. Cap a 5-7 gene per V3 MVP.
+
+**Fonte**: [Paradox dev diary CK3 portraits/DNA](https://www.pcinvasion.com/crusader-kings-iiis-latest-dev-diary-explains-schemes-portraits-dna-council-members-and-your-court/) + [CK3 wiki characters modding](https://ck3.paradoxwikis.com/index.php?title=Characters_modding)
+
+### 🏆 P1 — Hades Weapon Aspects (visual + mechanical re-skin)
+
+**Quando**: mature → apex transition deve sentirsi come "unlock" e non solo "gain XP".
+
+**Come**: aspect = modifier permanente che cambia look + moveset arma. UI confirmation modal "Adopt Aspect: Dune Tyrant?" + silhouette iconica + name reveal.
+
+**Nostro stack**: `formsPanel.js` esistente. Estendi: ogni transition mature→apex offre 2-3 aspect choice (es. `tyrant`, `phantom`, `pack_alpha`) → diverse silhouette + ability swap.
+
+**Limiti**: aspect cards = 2-3 per phase × 5 phases = 10-15 aspects per species. Authoring budget alto.
+
+**Fonte**: [Hades 2 Weapon Aspects wiki](https://hades2.wiki.fextralife.com/Weapon+Aspects)
+
+### 🏆 P1 — Subnautica habitat lifecycle (biome migration)
+
+**Quando**: creature deve sentirsi connessa al biome attraverso fasi.
+
+**Come**: juvenile spawn-locked Lost River → adult migra a biomi diversi consumando prey diversi. Comportamento age-driven (juvenile timid, adult territorial).
+
+**Nostro stack**: hatchling spawn-locked savana (Skiv biome_affinity), juvenile → desert, mature → caverna, apex → roam multi-biome. Atlas mostra "habitat shift" mappa visiva. Wire in `biomeSpawnBias.js`.
+
+**Limiti**: 20 biomi × 5 phase × 45 species = 4500 stati. Cap: solo apex/legacy ricevono migration; juvenile/mature fissi a biome_affinity.
+
+**Fonte**: [Subnautica Ghost Leviathan wiki](https://subnautica.fandom.com/wiki/Ghost_Leviathan)
+
+### 🏆 P2 — RimWorld composite cache (performance)
+
+**Quando**: scene multi-creatura render-heavy.
+
+**Come**: 8000+ assets su 30+ layers → single layered cached composite (perf optimization v1.3). Cache key = `${creatureId}:${stage}:${aspectsHash}`. Invalidate solo on mutation event.
+
+**Nostro stack**: `apps/backend/services/creatureCompositor.js` (NEW). Critical per multi-creature scene su TV widescreen + Apex multi-tile (2x2).
+
+**Limiti**: cache size grows con #creatures × #mutations. LRU eviction necessario.
+
+**Fonte**: [RimWorld Apparel layers wiki](https://rimworldwiki.com/wiki/Apparel_layers) + [Portraits-of-the-Rim Steam Workshop](https://steamcommunity.com/sharedfiles/filedetails/?id=2937991425)
+
+### 🏆 P2 — Wildermyth permanent visible change (narrative anchor)
+
+**Quando**: ogni transition deve produrre cambio visivo PRIMA del flavor text.
+
+**Come**: chapter beat → eyepatch / wolf arm / stone eye. Player vede cambiamento → poi legge testo.
+
+**Nostro stack**: `mutation_morphology.visual_swap_it` deve esistere per OGNI mutation_id (linter rule). Aggiungi check in `tools/py/lint_mutations.py` (NEW).
+
+**Limiti**: authoring budget — ogni nuova mutation richiede prose visiva.
+
+**Fonte**: [Wildermyth Story Inputs wiki](https://wildermyth.com/wiki/Story_Inputs_and_Outputs) + [Modular Storytelling cjleo.com](https://cjleo.com/2022/12/26/the-power-of-wildermyths-modular-storytelling-in-game-design/)
+
+### 🧨 Frontier (research-mode)
+
+- **Spore creature creator** ([Lai 2021 Wiley](https://onlinelibrary.wiley.com/doi/10.1111/cgf.142661) + [Hecker SIGGRAPH 08](https://www.chrishecker.com/Real-time_Motion_Retargeting_to_Highly_Varied_User-Created_Morphologies)) — full procedural morphology, expansion runtime. Pre-MVP rischioso (3D engine).
+- **Cogmind multi-tile + ASCII dual** ([Grid Sage](https://www.gridsagegames.com/blog/2015/04/cogmind-roguelike/) + [GameDeveloper multitile](https://www.gamedeveloper.com/design/developing-multitile-creatures-in-roguelikes)) — apex creature occupy 2x2 tile per leggibilità Pillar 1.
+- **Dwarf Fortress procedural creature description** ([wiki Creature_token](https://dwarffortresswiki.org/index.php/DF2014:Creature_token)) — text emergence runtime, "skinless fire-breathing cobra".
+- **Universal-LPC-Spritesheet generator** ([github](https://github.com/LiberatedPixelCup/Universal-LPC-Spritesheet-Character-Generator)) — CC-BY-SA, vendorable as `external/lpc-generator/` git submodule per playtest prototype sprites.
+
+### ❌ Anti-pattern (NON fare)
+
+- **Aspetto cosmetic-only senza tactical correlate** → players don't see growth meaning (Wildermyth lesson)
+- **Lifecycle phases che floattano** → fase 3 deve richiedere Lv 4 _e_ ≥1 mut _e_ ≥2 thoughts (no shortcut)
+- **Mutation senza visual_swap** → linter rule violata (Wildermyth lesson)
+- **Full procedural sprite (Spore-trap)** → no riconoscibilità, players non si affezionano (Cogmind P9 lesson)
+- **MBTI form senza polarity stable** → fino a tier1 in dead-band 0.35-0.65 NESSUN visual change
+- **Phase boundary invisibile** → Emily Short warning zones missing → "feel arbitrary"
+- **Legacy come morte triste** → Wildermyth/Citizen Sleeper canonizzano legacy come opportunità trasmissione, non lutto
+- **Content farm citations**: emergentmind.com / grokipedia.com / medium.com/\* / towardsdatascience.com (vietati)
+
+---
+
+## Data source priority (authoritative top→bottom)
+
+1. `data/core/species.yaml` — 45 species canonical (trait_plan + biome_affinity)
+2. `data/core/species/<species>_lifecycle.yaml` — phases + aspect (NEW: solo dune_stalker shipped 2026-04-25)
+3. `data/core/mutations/mutation_catalog.yaml` — 30 mutations (post sprint #1776)
+4. `data/core/jobs_expansion.yaml` — 4 expansion jobs + 48 perks
+5. `data/core/thoughts/mbti_thoughts.yaml` — 18 thoughts Phase 2
+6. `data/core/forms/mbti_forms.yaml` — 16 MBTI forms
+7. `apps/backend/services/forms/formEvolution.js` — engine pattern reference
+8. `apps/play/src/render.js` — canvas drawUnit (lifecycle ring target)
+9. `tools/py/seed_skiv_saga.py` — composer reference
+10. `docs/planning/2026-04-25-skiv-aspect-evolution.md` — concept doc
+
+---
+
+## Decision tree (audit output template)
+
+For each gap found, format as:
+
+```
+## GAP-N — <severity P0|P1|P2>: <short title>
+**File:line**: ...
+**Reality**: ... (what is currently shipped)
+**Pattern-da-applicare**: P-X (<Wildermyth | Qud | MHS | Disco | CK3 | Hades | Subnautica>)
+**Concrete change**: ... (file + LOC delta estimate)
+**Effort**: ~Xh
+**Dependencies**: ... (other gaps to resolve first, or none)
+```
+
+Top-3 priorities with effort sum. Anti-pattern guard list at end.
+
+---
+
+## Smoke test checklist
+
+Before declaring agent USABLE:
+
+- [ ] Audit on `data/core/species/dune_stalker_lifecycle.yaml` returns 0 false-positive (gating rules detected correctly)
+- [ ] Audit on `data/core/mutations/mutation_catalog.yaml` reports gap rate (% mutations missing `aspect_token`)
+- [ ] Research mode on hypothetical "leviatano_risonante new lifecycle" generates 5-phase yaml stub with correct schema
+- [ ] All citations primary-sourced (no content farm)
+- [ ] Anti-pattern blocklist applied to draft output
+
+---
+
+## Escalation path
+
+- Schema change a `species.yaml` → escalate to **schema-ripple** agent
+- Performance pattern P2 (RimWorld cache) → escalate to **session-debugger** for runtime measurement
+- Narrative beats per phase → escalate to **narrative-design-illuminator** (compose voice_it + warning zones)
+- UI canvas changes → escalate to **ui-design-illuminator** (10-foot rule + accessibility)
+
+---
+
+## Versioning + provenance
+
+- v0.1 (2026-04-25): initial draft, post 2026-04-25 content sprint #1776
+- Authored from: 3 parallel research agents (general-purpose external repos + ui-design-illuminator audit + narrative-design-illuminator arcs)
+- 4-gate DoD: G1 research ✅ (this doc) · G2 smoke pending · G3 tuning pending · G4 optimization pending

--- a/apps/play/src/render.js
+++ b/apps/play/src/render.js
@@ -219,7 +219,8 @@ function drawStatusIcons(ctx, unit, cx, yPxTop) {
     ctx.arc(ix + size / 2, iy + size / 2, size / 2, 0, Math.PI * 2);
     ctx.fill();
     ctx.fillStyle = '#000';
-    ctx.font = 'bold 10px "SF Mono", monospace';
+    // 10-foot rule: dynamic min 12px, scale with CELL (Microsoft TV guidelines).
+    ctx.font = `bold ${Math.max(12, Math.round(CELL * 0.16))}px "SF Mono", monospace`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.fillText(ic.glyph, ix + size / 2, iy + size / 2 + 1);
@@ -332,7 +333,8 @@ function drawUnit(ctx, unit, gridH, highlight = {}) {
     .replace(/[^\p{L}]/gu, '')
     .slice(0, 3)
     .toUpperCase();
-  ctx.font = 'bold 13px "SF Mono", "Menlo", monospace';
+  // 10-foot rule: dynamic font for species abbrev (min 14px, scale with CELL).
+  ctx.font = `bold ${Math.max(14, Math.round(CELL * 0.18))}px "SF Mono", "Menlo", monospace`;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
   ctx.strokeStyle = 'rgba(0,0,0,0.85)';
@@ -356,7 +358,8 @@ function drawUnit(ctx, unit, gridH, highlight = {}) {
     ctx.fillRect(barX, barY, barW * ratio, 5);
     // Numeric value sopra bar (TV-first scan)
     ctx.fillStyle = '#fff';
-    ctx.font = 'bold 9px "SF Mono", monospace';
+    // 10-foot rule: HP numeric scales with CELL (min 12px, prev was 9px hard-fail TV).
+    ctx.font = `bold ${Math.max(12, Math.round(CELL * 0.15))}px "SF Mono", monospace`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'bottom';
     const maxHp = unit.max_hp || unit.hp || 0;
@@ -402,7 +405,8 @@ function drawSisIntentIcon(ctx, unit, cx, yPxTop, kind = 'fist') {
   // Glyph
   const glyph = kind === 'fist' ? '✊' : kind === 'move' ? '➜' : kind === 'shield' ? '🛡' : '?';
   ctx.fillStyle = '#fff';
-  ctx.font = 'bold 11px "SF Mono", monospace';
+  // 10-foot rule: intent glyph (min 13px, scale with CELL).
+  ctx.font = `bold ${Math.max(13, Math.round(CELL * 0.17))}px "SF Mono", monospace`;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
   ctx.fillText(glyph, ix, iy + size / 2 + 1);

--- a/apps/play/src/thoughtsPanel.js
+++ b/apps/play/src/thoughtsPanel.js
@@ -55,6 +55,19 @@ function injectStyles() {
       padding: 28px 10px; text-align: center; color: #9aa3b5;
       font-style: italic;
     }
+    .slot-counter {
+      padding: 12px 16px; margin-bottom: 14px;
+      border: 1px solid #3a3050; border-radius: 8px;
+      background: #1a1626;
+      color: #d8c7ff; font-size: 1rem;
+      display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+    }
+    .slot-counter strong {
+      color: #ffd166; font-size: 1.1rem;
+    }
+    .slot-counter .slot-breakdown {
+      color: #9aa3b5; font-size: 0.9rem;
+    }
     .thoughts-axis {
       margin-bottom: 18px; border: 1px solid #2a3040; border-radius: 10px;
       padding: 14px 16px; background: #0d1118;
@@ -362,8 +375,29 @@ function render(unit, perActorEntry) {
   }
   const unlocked = new Set(perActorEntry.unlocked || []);
   const newly = new Set(perActorEntry.newly || []);
+  // GAP-04 (ui-design-illuminator audit 2026-04-25): slot counter visible.
+  // Backend already ships slots_max + slots_used + internalized + researching;
+  // Phase 2 PR #1769. Cold-start player must know "can I research now?".
+  const slotsMax = Number(perActorEntry.slots_max || 3);
+  const slotsUsed = Number(perActorEntry.slots_used || 0);
+  const researchingCount = Array.isArray(perActorEntry.researching)
+    ? perActorEntry.researching.length
+    : 0;
+  const internalizedCount = Array.isArray(perActorEntry.internalized)
+    ? perActorEntry.internalized.length
+    : 0;
+  const slotIcons = Array.from({ length: slotsMax })
+    .map((_, i) => (i < slotsUsed ? '●' : '○'))
+    .join('');
+  const slotCounter = `
+    <div class="slot-counter" role="status" aria-label="Slot Thought Cabinet">
+      Slots ${slotIcons} <strong>${slotsUsed}/${slotsMax}</strong>
+      <span class="slot-breakdown">· 🧠 ${internalizedCount} internalizzati · 🔬 ${researchingCount} in ricerca</span>
+    </div>
+  `;
   if (unlocked.size === 0) {
     body.innerHTML = `
+      ${slotCounter}
       <div class="thoughts-empty">
         Nessun thought ancora sbloccato. Gioca round con pattern MBTI consistente
         su E_I / S_N / J_P.
@@ -372,7 +406,8 @@ function render(unit, perActorEntry) {
     `;
     return;
   }
-  body.innerHTML = ['E_I', 'S_N', 'J_P'].map((a) => renderAxis(a, unlocked, newly)).join('');
+  body.innerHTML =
+    slotCounter + ['E_I', 'S_N', 'J_P'].map((a) => renderAxis(a, unlocked, newly)).join('');
 }
 
 export async function openThoughtsPanel() {

--- a/data/core/species/dune_stalker_lifecycle.yaml
+++ b/data/core/species/dune_stalker_lifecycle.yaml
@@ -20,6 +20,16 @@
 #   - data/core/jobs_expansion.yaml § stalker (job alignment apex phase)
 #   - docs/planning/2026-04-25-skiv-aspect-evolution.md (visual concept)
 #   - tools/py/seed_skiv_saga.py (composes phase into runtime state)
+#   - .claude/agents/creature-aspect-illuminator.md (research-driven design)
+#
+# Research provenance (2026-04-25 parallel agent batch):
+#   - Wildermyth permanent visible change → narrative_beat_it required per phase
+#   - Disco Elysium Thought Cabinet portrait correlate → mbti_aspect_correlates
+#   - Citizen Sleeper failure canon → legacy as transmission, not loss
+#   - Slay the Princess same voice / different content → voice_it consistency
+#   - Emily Short warning zones → warning_zone_it pre-transition signals
+#   - Frostpunk irreversibility → mutation_morphology + diary mutation_acquired
+#   - Caves of Qud morphotype gating → mbti_pool field on mutations (future schema)
 
 schema_version: "0.1.0"
 generated_at: "2026-04-25"
@@ -50,6 +60,9 @@ phases:
     mutations_required: 0
     thoughts_internalized_required: 0
     mbti_polarity_required: false
+    voice_it: "Non so ancora cosa sono. So dove sono gli altri."
+    narrative_beat_it: "Encounter finito. Skiv non ha colpito nessuno. Ha osservato da 5 caselle di distanza, immobile, il modo in cui i compagni cadevano e si rialzavano. L'unica cosa che sa fare bene e non farsi trovare. E abbastanza, per adesso."
+    warning_zone_it: null
     aspect_it: |
       Schiusa appena sul margine arido. La pelliccia è di un grigio
       polveroso quasi bianco — mimetizzazione passiva con la sabbia.
@@ -72,6 +85,9 @@ phases:
     mutations_required: 0
     thoughts_internalized_required: 0
     mbti_polarity_required: false
+    voice_it: "Aspetto. Non e paura. E calibrazione."
+    narrative_beat_it: "Il silenzio non e assenza. Skiv lo capisce quando si accorge di aspettare che gli altri parlino prima di muoversi. Non e paura: e calcolo. Le orecchie registrano. Qualcosa si sta calibrando dentro — un orologio che non sapeva di avere."
+    warning_zone_it: "Lv 3 raggiunto. Primo silenzio prolungato — qualcosa sta per cristallizzarsi."
     aspect_it: |
       Pelliccia sviluppa striature di sabbia ocra lungo il dorso. Gli
       artigli (sand_claws) sono ora visibili e affilati ma ancora
@@ -95,6 +111,9 @@ phases:
     mutations_required: 1
     thoughts_internalized_required: 2
     mbti_polarity_required: true
+    voice_it: "Il branco non mi segue. Mi evita. La differenza conta."
+    narrative_beat_it: "La voce interna non annuncia se stessa. Era gia li. E solo quando i sand_claws cambiano trasparenza — quella prima mattina di sole sulle punte vitrified — che Skiv capisce: il branco non lo segue piu. Lo evita. Non e pericolo. E riconoscimento."
+    warning_zone_it: "Secondo thought research-completato — terza voce in arrivo cambierà la manifestazione."
     aspect_it: |
       Forma adulta consolidata. Gli artigli a sette vie si vetrificano
       (mutation artigli_grip_to_glass) → punte trasparenti come ossidiana
@@ -119,6 +138,9 @@ phases:
     mutations_required: 2
     thoughts_internalized_required: 3
     mbti_polarity_required: true
+    voice_it: "Ho aspettato quando i numeri dicevano di muovermi. Ho avuto ragione. Non e fortuna."
+    narrative_beat_it: "Ha tenuto la linea quando non doveva. Il Sistema premeva da tre caselle. Tutti i calcoli dicevano di ritirarsi. Ma c'e una voce — fredda, analitica, esattamente come la sua — che ha detto: aspetta. L'ha aspettato. Ha avuto ragione. Gli artigli ora mostrano brina anche sotto il sole di mezzogiorno. Non si riscalderanno mai piu."
+    warning_zone_it: "Defy usato a Critical+ → la voce si stabilizza. Apex transition vicina."
     aspect_it: |
       Manto quasi nero per concentrazione di pigmento; le scaglie termiche
       hanno perso la trasparenza. Gli artigli vetrificati sono ora
@@ -143,6 +165,9 @@ phases:
     mutations_required: 3
     thoughts_internalized_required: 3
     mbti_polarity_required: true
+    voice_it: "Non ero qui. Ero gia li prima che arrivassi."
+    narrative_beat_it: "Non e una morte. E un archivio. Qualcosa di Skiv rimane nel biome — nel pattern di caccia dei piu giovani, nel modo in cui uno Stalker neonato inclina le orecchie verso l'interno anziche verso l'esterno. Non lo sa. Ma lo fa. Skiv diventa memoria senza saperlo. E il modo in cui funziona."
+    warning_zone_it: null
     aspect_it: |
       Skiv non muore — diventa pattern. Una volta raggiunto questo
       stadio, il suo lineage_id passa a unit successivi della stessa

--- a/data/core/species/dune_stalker_lifecycle.yaml
+++ b/data/core/species/dune_stalker_lifecycle.yaml
@@ -1,0 +1,223 @@
+# Dune Stalker Lifecycle — Skiv canonical aspect + evolution stages
+#
+# Skiv (Arenavenator vagans, dune_stalker) è la creatura canonica recap-card
+# introdotta 2026-04-25. Questo file descrive **come Skiv cambia visivamente
+# e narrativamente** lungo 5 fasi di vita, mappate ai sistemi runtime già live:
+#
+#   - Progression Lv (M13.P3 + jobs_expansion): 1 → 7
+#   - Mutation count (mutation_catalog 2026-04-25 sprint): 0 → 3+
+#   - Cabinet internalized (Thought Cabinet Phase 2 #1769): 0 → slots_max
+#   - MBTI axis crystallization (vcScoring): dead-band → tier3 ≥0.85
+#
+# Anti-pattern (NON fare):
+#   - Lifecycle decoupled da progression Lv → fasi fluttuano senza gating
+#   - Aspetto cosmetic-only senza tactical correlato → players non vedono crescita
+#   - Mutation morfologia generica → ogni mutation_id deve avere visual_swap
+#
+# Cross-reference:
+#   - data/core/species.yaml § dune_stalker (trait_plan + biome_affinity)
+#   - data/core/mutations/mutation_catalog.yaml § artigli_grip_to_glass
+#   - data/core/jobs_expansion.yaml § stalker (job alignment apex phase)
+#   - docs/planning/2026-04-25-skiv-aspect-evolution.md (visual concept)
+#   - tools/py/seed_skiv_saga.py (composes phase into runtime state)
+
+schema_version: "0.1.0"
+generated_at: "2026-04-25"
+species_id: dune_stalker
+canonical_unit_id: skiv
+
+# ─────────────────────────────────────────────────────────────────────
+# 5 fasi vitali — gating + aspetto + tactical correlate
+# ─────────────────────────────────────────────────────────────────────
+#
+# Schema per fase:
+#   id: short_slug
+#   level_range: [min, max]            — progression Lv gate
+#   mutations_required: N              — count cumulato
+#   thoughts_internalized_required: N  — count cumulato
+#   mbti_polarity_required: bool       — almeno 1 axis ≥ tier1
+#   aspect_it: italian visual prose
+#   sprite_ascii: 4-line ASCII frontale
+#   tactical_signature: cosa cambia in combat (1 frase)
+#   diary_milestone_event: event_type da appendere al passaggio
+
+phases:
+  hatchling:
+    id: hatchling
+    label_it: "Cucciolo delle Dune"
+    label_en: "Dune Hatchling"
+    level_range: [1, 1]
+    mutations_required: 0
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+    aspect_it: |
+      Schiusa appena sul margine arido. La pelliccia è di un grigio
+      polveroso quasi bianco — mimetizzazione passiva con la sabbia.
+      Le orecchie sono già grandi rispetto al cranio, segno della
+      futura echolocation. Gli occhi sono scuri, ancora poco a fuoco.
+      Non ha branco; segue un'ombra adulta a 5-6 caselle di distanza.
+    sprite_ascii:
+      - "        .-."
+      - "       ( o.o )"
+      - "        > ^ <"
+      - "        ` ` `"
+    tactical_signature: "Bassa HP / no abilities; impara osservando."
+    diary_milestone_event: scenario_completed
+
+  juvenile:
+    id: juvenile
+    label_it: "Predatore Giovane"
+    label_en: "Juvenile Stalker"
+    level_range: [2, 3]
+    mutations_required: 0
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+    aspect_it: |
+      Pelliccia sviluppa striature di sabbia ocra lungo il dorso. Gli
+      artigli (sand_claws) sono ora visibili e affilati ma ancora
+      simmetrici — non hanno trovato la "via". Le scaglie termiche
+      (heat_scales) iniziano a traslucere lungo i fianchi, segno della
+      regolazione idrica. Comportamento: scoperta del territorio,
+      tentativi di stalk falliti.
+    sprite_ascii:
+      - "      /\\_/\\"
+      - "     (  o.o )"
+      - "      > -_- <"
+      - "      \\___/"
+    tactical_signature: "Apprende silent_step; prime synergy potenziali."
+    diary_milestone_event: mbti_axis_threshold_crossed
+
+  mature:
+    id: mature
+    label_it: "Predatore Maturo"
+    label_en: "Mature Stalker"
+    level_range: [4, 5]
+    mutations_required: 1
+    thoughts_internalized_required: 2
+    mbti_polarity_required: true
+    aspect_it: |
+      Forma adulta consolidata. Gli artigli a sette vie si vetrificano
+      (mutation artigli_grip_to_glass) → punte trasparenti come ossidiana
+      che riflettono il sole. Le orecchie hanno scolpito conche per
+      l'echolocation, visibili come solchi. Il pelo lungo il dorso si è
+      condensato in una cresta scura. Lo sguardo è fisso, leggero
+      socchiudere — primo segno di voce interna. Il branco lo riconosce
+      come predatore-stalker, non più cucciolo.
+    sprite_ascii:
+      - "      /\\_/\\        *"
+      - "     (  o.o )       *"
+      - "      > ^ <"
+      - "      /|||\\"
+    tactical_signature: "Stalker Lv 4. Synergy echo_backstab live. Thought Cabinet 2/3 slot."
+    diary_milestone_event: thought_internalized
+
+  apex:
+    id: apex
+    label_it: "Apex delle Dune"
+    label_en: "Dune Apex"
+    level_range: [6, 7]
+    mutations_required: 2
+    thoughts_internalized_required: 3
+    mbti_polarity_required: true
+    aspect_it: |
+      Manto quasi nero per concentrazione di pigmento; le scaglie termiche
+      hanno perso la trasparenza. Gli artigli vetrificati sono ora
+      composti di lamelle multiple (multi-mutation stack). La cresta
+      dorsale mostra micro-bioluminescenza al crepuscolo — eco residua
+      della echolocation triangolata. Sguardo fisso, lento blinking;
+      voce interna costantemente attiva (Thought Cabinet pieno). Il
+      branco si separa al suo passaggio: non è più membro, è territorio.
+    sprite_ascii:
+      - "      /=_/=       *"
+      - "     ( @_@ )      *"
+      - "      > ^ <"
+      - "      //|||\\\\"
+    tactical_signature: "Cabinet pieno 3/3. Defy disponibile. 12 perks Stalker disponibili."
+    diary_milestone_event: mutation_acquired
+
+  legacy:
+    id: legacy
+    label_it: "Memoria del Branco"
+    label_en: "Pack Memory"
+    level_range: [7, 7]
+    mutations_required: 3
+    thoughts_internalized_required: 3
+    mbti_polarity_required: true
+    aspect_it: |
+      Skiv non muore — diventa pattern. Una volta raggiunto questo
+      stadio, il suo lineage_id passa a unit successivi della stessa
+      genus che condividono il suo biome. Diary persiste come "saga
+      reference" (V3 Mating/Nido futuro userà questo come gateway).
+      Visivamente: gli artigli sono ora opachi (consumo); il pelo è
+      argenteo; gli occhi non scintillano più ma osservano costanti.
+      Concettualmente: la creatura è "in archivio storico" del biome.
+    sprite_ascii:
+      - "      /-_/-"
+      - "     (  -_- )"
+      - "      > _ <"
+      - "      ~|||~"
+    tactical_signature: "Retired da combat live; appare come narrative event QBN."
+    diary_milestone_event: form_evolved
+
+# ─────────────────────────────────────────────────────────────────────
+# Mutation morphology — come ogni mutation cambia visivamente
+# ─────────────────────────────────────────────────────────────────────
+#
+# Schema:
+#   <mutation_id>:
+#     visual_swap_it: prose della trasformazione fisica
+#     phase_unlock: lifecycle phase richiesta
+#     aspect_token: short visual identifier per HUD/sprite
+
+mutation_morphology:
+  artigli_grip_to_glass:
+    visual_swap_it: "Le punte degli artigli si vetrificano: trasparenza ossidiana riflettente sole. Lascia tracce iridescenti nella sabbia."
+    phase_unlock: mature
+    aspect_token: "claws_glass"
+
+  artigli_freeze_to_glacier:
+    visual_swap_it: "Gli artigli si coprono di brina permanente, micro-cristalli che persistono anche sotto sole diretto. Aria a 1 cella raffredda."
+    phase_unlock: apex
+    aspect_token: "claws_glacial"
+
+  scheletro_bio_camo:
+    visual_swap_it: "Le scaglie termiche cambiano colore in base al biome (ottavi-base): savana=ocra, deserto=bianco, caverna=grigio scuro. Camuffamento attivo."
+    phase_unlock: mature
+    aspect_token: "scales_chameleon"
+
+  echolocation_3d:
+    visual_swap_it: "Le orecchie si articolano indipendentemente; i solchi delle conche emettono un debole pulsare (echo broadcast). Visibile in penombra."
+    phase_unlock: apex
+    aspect_token: "ears_radar"
+
+# ─────────────────────────────────────────────────────────────────────
+# MBTI form physical correlates (per fase mature+ con polarity stable)
+# ─────────────────────────────────────────────────────────────────────
+#
+# Solo polarity stable (axis ≥ tier1) si manifesta visivamente.
+# Skiv canonico = INTP-leaning-I → tutte e 4 polarity (I + T + N + P).
+
+mbti_aspect_correlates:
+  E_high:  "Postura aperta, vocalizzazioni frequenti, orecchie verso fuori."
+  I_high:  "Postura chiusa, silenzioso, orecchie verso interno (ricezione)."
+  S_high:  "Movimenti deliberati, frequenti pause sniff/look-around."
+  N_high:  "Movimenti sinuosi, scarsa pausa, sembra vedere senza guardare."
+  T_high:  "Sguardo freddo socchiuso, decisioni rapide post-pause."
+  F_high:  "Sguardo morbido, linguaggio del corpo verso compagni di branco."
+  J_high:  "Routine ripetitiva (stessa rotta), aggressione su deviazioni."
+  P_high:  "Routine assente; cambia direzione su input minimi."
+
+# ─────────────────────────────────────────────────────────────────────
+# Lifecycle ↔ Skiv saga state mapping
+# ─────────────────────────────────────────────────────────────────────
+#
+# Tracker verso quale fase Skiv saga (data/derived/skiv_saga.json) si trova.
+# Aggiornato dal seed script tools/py/seed_skiv_saga.py.
+
+skiv_saga_anchor:
+  current_phase: mature  # Lv 4 + 1 mutation + 2 internalized → mature
+  next_phase: apex       # gate: Lv 6 + 1 più mutation + 1 più internalized
+  next_phase_gate:
+    level: 6
+    mutations: 2
+    thoughts_internalized: 3

--- a/data/derived/skiv_saga.json
+++ b/data/derived/skiv_saga.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "0.1.0",
-  "generated_at": "2026-04-25T12:18:26Z",
+  "generated_at": "2026-04-25T12:55:34Z",
   "unit_id": "skiv",
   "species_id": "dune_stalker",
   "biome_id": "savana",
@@ -66,6 +66,39 @@
       "category": "physiological"
     }
   ],
+  "aspect": {
+    "lifecycle_phase": "mature",
+    "polarity_stable": true,
+    "mbti_form_label": "INTP-leaning-I",
+    "aspect_it": "Forma adulta consolidata. Gli artigli a sette vie si vetrificano\n(mutation artigli_grip_to_glass) → punte trasparenti come ossidiana\nche riflettono il sole. Le orecchie hanno scolpito conche per\nl'echolocation, visibili come solchi. Il pelo lungo il dorso si è\ncondensato in una cresta scura. Lo sguardo è fisso, leggero\nsocchiudere — primo segno di voce interna. Il branco lo riconosce\ncome predatore-stalker, non più cucciolo.",
+    "sprite_ascii": "      /\\_/\\        *\n     (  o.o )       *\n      > ^ <\n      /|||\\",
+    "tactical_signature": "Stalker Lv 4. Synergy echo_backstab live. Thought Cabinet 2/3 slot.",
+    "label_it": "Predatore Maturo",
+    "label_en": "Mature Stalker",
+    "mutation_morphology": {
+      "visual_swap_it": "Le punte degli artigli si vetrificano: trasparenza ossidiana riflettente sole. Lascia tracce iridescenti nella sabbia.",
+      "phase_unlock": "mature",
+      "aspect_token": "claws_glass"
+    },
+    "mbti_correlates": [
+      {
+        "polarity": "I_high",
+        "manifestation": "Postura chiusa, silenzioso, orecchie verso interno (ricezione)."
+      },
+      {
+        "polarity": "T_high",
+        "manifestation": "Sguardo freddo socchiuso, decisioni rapide post-pause."
+      },
+      {
+        "polarity": "N_high",
+        "manifestation": "Movimenti sinuosi, scarsa pausa, sembra vedere senza guardare."
+      },
+      {
+        "polarity": "P_high",
+        "manifestation": "Routine assente; cambia direzione su input minimi."
+      }
+    ]
+  },
   "diary": [
     {
       "ts": "2026-04-25T18:00:00Z",
@@ -190,5 +223,5 @@
       }
     }
   ],
-  "_notes": "Canonical creature state showcasing 2026-04-25 content sprint #1776 + Skiv 5/8 wishlist (synergy #2 + biome resonance #4 + Defy #5 + Diary #7 + Hybrid Path #6). Regenerate via tools/py/seed_skiv_saga.py."
+  "_notes": "Canonical creature state showcasing 2026-04-25 content sprint #1776 + Skiv 5/8 wishlist + lifecycle/aspect (this PR). Regenerate via tools/py/seed_skiv_saga.py."
 }

--- a/docs/planning/2026-04-25-skiv-aspect-evolution.md
+++ b/docs/planning/2026-04-25-skiv-aspect-evolution.md
@@ -1,0 +1,216 @@
+---
+title: Skiv — Aspetto + Ciclo di Evoluzione (visual concept)
+workstream: cross-cutting
+category: planning
+doc_status: draft
+doc_owner: claude-code
+last_verified: '2026-04-25'
+source_of_truth: false
+language: it
+review_cycle_days: 30
+tags:
+  - skiv
+  - lifecycle
+  - aspect
+  - creature-design
+  - visual-concept
+related:
+  - data/core/species/dune_stalker_lifecycle.yaml
+  - data/core/species.yaml
+  - data/core/mutations/mutation_catalog.yaml
+  - tools/py/seed_skiv_saga.py
+---
+
+# Skiv — Aspetto + Ciclo di Evoluzione
+
+> Companion del Saga seed (#1784). Il file `dune_stalker_lifecycle.yaml`
+> formalizza le 5 fasi di vita di Skiv (e di ogni Arenavenator vagans);
+> questo doc è il **concept narrativo + visivo**: come si vede, come
+> si racconta, come transita.
+
+## Perché questo doc
+
+Il Saga JSON shippato in #1784 era stat block (numeri, ids, counters).
+Mancava la **fenomenologia**: come UN GIOCATORE percepisce Skiv mentre
+cresce. Il rischio era che i 5 pillars saliti restassero sotto la
+linea-di-galleggiamento dell'esperienza visibile. Questo doc allinea:
+
+- **Aspetto** (cosa vedi sul tile)
+- **Stage gating** (cosa serve per cambiare fase)
+- **Diegetic events** (cosa appare nel diary / narrative log)
+
+## Le 5 fasi — ASCII frontale + identità
+
+```
+╔══════════════════════════════════════════════════════════════╗
+║  FASE 1 / HATCHLING                                           ║
+║                                                              ║
+║          .-.                Lv 1                              ║
+║         ( o.o )             0 mutations                       ║
+║          > ^ <              0 thoughts                        ║
+║          ` ` `              MBTI: dead-band                   ║
+║                                                              ║
+║  Schiusa al margine arido. Pelliccia grigia polverosa.        ║
+║  Echolocation latente. Niente abilities, niente branco.       ║
+║  Skiv non sa ancora di essere Skiv.                          ║
+╚══════════════════════════════════════════════════════════════╝
+
+╔══════════════════════════════════════════════════════════════╗
+║  FASE 2 / JUVENILE                                            ║
+║                                                              ║
+║         ╱\_/\               Lv 2-3                            ║
+║        (  o.o )             0 mutations                       ║
+║         > -_- <             0 thoughts                        ║
+║         \___/               MBTI: tier1 ≥1 axis               ║
+║                                                              ║
+║  Striature ocra sul dorso. Sand_claws affilati ma simmetrici. ║
+║  Heat_scales traslucenti. Apprende silent_step.               ║
+║  Prima identità MBTI inizia a polarizzarsi.                   ║
+╚══════════════════════════════════════════════════════════════╝
+
+╔══════════════════════════════════════════════════════════════╗
+║  FASE 3 / MATURE              ← Skiv saga corrente            ║
+║                                                              ║
+║         ╱\_/\        ✦      Lv 4-5                            ║
+║        (  o.o )      ✦      ≥1 mutation                      ║
+║         > ^ <               ≥2 thoughts internalized          ║
+║         /|||\\               MBTI: polarity stable            ║
+║                                                              ║
+║  Artigli vetrificati (ossidiana riflettente).                ║
+║  Cresta dorsale scura. Sguardo socchiuso.                    ║
+║  Stalker Lv 4. Synergy echo_backstab live. 2/3 cabinet.      ║
+║  ★ Skiv è QUI ★                                              ║
+╚══════════════════════════════════════════════════════════════╝
+
+╔══════════════════════════════════════════════════════════════╗
+║  FASE 4 / APEX                                                ║
+║                                                              ║
+║         ╱╲_/╲       ✦       Lv 6-7                            ║
+║        ( ●_● )      ✦       ≥2 mutations                     ║
+║         > ⌃ <               ≥3 thoughts (cabinet pieno)       ║
+║         //|||\\\\           MBTI: tier3 ≥1 axis              ║
+║                                                              ║
+║  Manto quasi nero. Artigli a lamelle multiple.               ║
+║  Cresta bioluminescente al crepuscolo. Voce interna sempre.  ║
+║  Branco si separa al suo passaggio: territorio, non membro.  ║
+╚══════════════════════════════════════════════════════════════╝
+
+╔══════════════════════════════════════════════════════════════╗
+║  FASE 5 / LEGACY                                              ║
+║                                                              ║
+║         ╱─_/─               Lv 7 (apex maxed)                 ║
+║        (  ─_─ )             3+ mutations                      ║
+║         > _ <               cabinet pieno                     ║
+║         ¯|||¯               lineage_id ready                  ║
+║                                                              ║
+║  Pelo argenteo. Artigli opachi (consumo).                    ║
+║  Skiv non muore — diventa pattern. Lineage passa a creatura  ║
+║  successiva del biome (V3 Mating/Nido gateway).              ║
+║  Appare come narrative event QBN, non più combat actor.      ║
+╚══════════════════════════════════════════════════════════════╝
+```
+
+## Mutation morphology — come UNA mutation cambia il corpo
+
+Esempio canonico (Skiv saga shipped #1784):
+
+**`artigli_grip_to_glass`** (`artigli_sette_vie` → `artigli_vetrificati`)
+
+```
+   PRE                        POST
+   (sette_vie)                (vetrificati)
+   ╲_/╲ ╲_/╲                  ┄_/┄ ┄_/┄
+    > ║ <                      > ◇ <
+    /||||\                     /◇◇◇◇\
+                               (trasparenze ossidiana, scia iridescente)
+```
+
+L'aspetto traduce il tactical: `+1 always damage` (pre) →
+`+2 damage on MoS≥5` (post). Il giocatore VEDE che lo svantaggio è
+condizionale, non costante.
+
+## MBTI form physical correlates
+
+Quando un axis crystallizza (≥ tier1), Skiv **assume la postura**
+visibile sul tile:
+
+| Polarity | Manifestazione visiva                                              |
+| -------- | ------------------------------------------------------------------ |
+| **I**    | Postura chiusa, orecchie verso interno (ricezione, listening pose) |
+| **T**    | Sguardo freddo socchiuso, decisioni rapide post-pausa breve        |
+| **N**    | Movimenti sinuosi, scarsa pausa, "vede senza guardare"             |
+| **P**    | Routine assente; cambia direzione su input minimi del biome        |
+
+Skiv canonico è **INTP-leaning-I** → tutti e 4 i polari attivi:
+
+```
+  Postura: chiusa + sinuosa
+  Orecchie: verso interno + indipendenti
+  Sguardo: socchiuso freddo
+  Movimento: imprevedibile (P) + meditato (I)
+```
+
+## Diary milestone events per fase
+
+Quando Skiv passa di fase, scrive nel diary:
+
+| Phase                | Event type                    | Payload chiave                                  |
+| -------------------- | ----------------------------- | ----------------------------------------------- |
+| Hatchling → Juvenile | `scenario_completed`          | primo encounter sopravvissuto                   |
+| Juvenile → Mature    | `mbti_axis_threshold_crossed` | axis che ha cristallizzato (es. S_N: 0.34→0.22) |
+| Mature               | `thought_internalized` (×2)   | i_osservatore + n_intuizione_terrena            |
+| Mature → Apex        | `mutation_acquired` (×2nd)    | seconda mutation tier 2+                        |
+| Apex                 | `defy_used` repeated          | counter-pressure agency dimostrato              |
+| Apex → Legacy        | `form_evolved`                | passaggio a lineage memoria                     |
+
+Il diary diventa **biography**, non log.
+
+## Anti-pattern ribaditi
+
+1. **NO aspetto cosmetic-only** — ogni cambio visivo deve avere un
+   tactical correlate visibile sul tile (es. cresta bioluminescente
+   = night encounter +1 attack_range)
+2. **NO phases che floattano** — fase 3 (mature) richiede Lv 4 _e_
+   ≥1 mutation _e_ ≥2 thoughts. Niente shortcut.
+3. **NO mutation senza visual_swap** — `mutation_morphology` block
+   YAML è obbligatorio per ogni nuovo mutation_id (linter consiglio
+   per future PR del catalog)
+4. **NO MBTI form senza polarity stable** — finché un axis è in
+   dead-band 0.35-0.65 NON manifesta visivamente. Skiv juvenile
+   sembra ancora "neutro".
+
+## Replay
+
+```bash
+# Stato Skiv corrente
+cat data/core/species/dune_stalker_lifecycle.yaml | yq '.skiv_saga_anchor'
+
+# Re-genera saga JSON + creature card
+python3 tools/py/seed_skiv_saga.py
+
+# Vedi card visiva dopo regen
+cat docs/playtest/2026-04-25-skiv-saga-state.md
+```
+
+## Open questions
+
+1. **Lineage propagation** (V3 Nido): legacy phase deve esporre
+   `inheritable_traits` API che la prossima creatura della genus
+   eredita probabilisticamente?
+2. **Sprite asset budget**: 5 fasi × N MBTI variants × M mutation
+   stack = combinatorial. Limite 1 sprite per fase + overlay
+   dinamici per mutation/MBTI?
+3. **Crystallization rollback**: se un axis MBTI scende sotto tier1
+   (drift via gameplay opposto), Skiv **regredisce** visivamente
+   o resta "scarred"?
+4. **Frequency phase transitions**: 1 transizione per scenario è
+   ragionevole? Player feedback target.
+
+## Refs
+
+- Lifecycle YAML: `data/core/species/dune_stalker_lifecycle.yaml`
+- Saga seed engine: `tools/py/seed_skiv_saga.py`
+- Saga shipped state: `data/derived/skiv_saga.json`
+- Saga creature card: `docs/playtest/2026-04-25-skiv-saga-state.md`
+- Skiv canonical persona memory: `~/.claude/projects/.../memory/project_skiv_evolution_wishlist.md`
+- Recap card format: `~/.claude/projects/.../memory/feedback_gamer_recap_creature_card_format.md`

--- a/docs/planning/2026-04-25-skiv-aspect-evolution.md
+++ b/docs/planning/2026-04-25-skiv-aspect-evolution.md
@@ -196,15 +196,68 @@ cat docs/playtest/2026-04-25-skiv-saga-state.md
 
 1. **Lineage propagation** (V3 Nido): legacy phase deve esporre
    `inheritable_traits` API che la prossima creatura della genus
-   eredita probabilisticamente?
+   eredita probabilisticamente? CK3 DNA pattern (P-B nell'agent
+   `creature-aspect-illuminator`) suggerisce gene chain compatto
+   ~50 byte trasmissibile.
 2. **Sprite asset budget**: 5 fasi × N MBTI variants × M mutation
-   stack = combinatorial. Limite 1 sprite per fase + overlay
-   dinamici per mutation/MBTI?
+   stack = combinatorial. Wildermyth solution: layered composition
+   con cache (RimWorld P11). LPC Universal Spritesheet (CC-BY-SA)
+   come prototype-baseline (`external/lpc-generator/` proposed).
 3. **Crystallization rollback**: se un axis MBTI scende sotto tier1
    (drift via gameplay opposto), Skiv **regredisce** visivamente
-   o resta "scarred"?
+   o resta "scarred"? Wildermyth: scar è permanente
+   (unidirectional). Citizen Sleeper: stress canonizzata
+   (failure è story, non rollback).
 4. **Frequency phase transitions**: 1 transizione per scenario è
-   ragionevole? Player feedback target.
+   ragionevole? Player feedback target. Emily Short warning zone
+   pattern: pre-segnale via diary `phase_signal: "<fase>_approaching"`
+   _prima_ del cambio meccanico (in lifecycle YAML come
+   `warning_zone_it`).
+
+## Research provenance
+
+Questo doc + lifecycle YAML sono il prodotto di 3 ricerche parallele
+(2026-04-25 agent batch):
+
+- **External repos** (general-purpose agent): 12 pattern primary-sourced
+  da Wildermyth / CK3 / Caves of Qud / Monster Hunter Stories / Disco
+  Elysium / Hades / Subnautica / Cogmind / RimWorld + LPC + Lai 2021.
+  Top picks: Wildermyth layered + Qud morphotype gating + MHS gene
+  grid + Disco portrait correlate.
+- **UI audit** (ui-design-illuminator): 12 gap concreti file:line
+  identificati nel client esistente (`apps/play/`). Top 3 P0:
+  thoughtsPanel slot+researching state, render.js canvas font,
+  Defy verb (assente UI surface).
+- **Narrative arcs** (narrative-design-illuminator): 7 pattern
+  - 5 narrative beats Skiv POV. Voice_it INTP-leaning-I:
+    analitica, autocontenuta, traccia relazione con branco.
+    Diary integration mapping per ciascuna transizione.
+
+Il nuovo agent `.claude/agents/creature-aspect-illuminator.md`
+compone tutto questo in un agent canonico per future species
+(post Skiv canonical).
+
+## Sources (primary)
+
+- [Wildermyth Image layers wiki](https://wildermyth.com/wiki/Image_layers)
+- [Wildermyth Story Inputs and Outputs wiki](https://wildermyth.com/wiki/Story_Inputs_and_Outputs)
+- [Wildermyth Modular Storytelling design](https://cjleo.com/2022/12/26/the-power-of-wildermyths-modular-storytelling-in-game-design/)
+- [Caves of Qud Mutations wiki](https://wiki.cavesofqud.com/wiki/Mutations)
+- [Caves of Qud Modding:Genotypes](https://wiki.cavesofqud.com/wiki/Modding:Genotypes_and_Subtypes)
+- [Crusader Kings 3 DNA dev diary](https://www.pcinvasion.com/crusader-kings-iiis-latest-dev-diary-explains-schemes-portraits-dna-council-members-and-your-court/)
+- [CK3 Legends of the Dead expansion](https://www.paradoxinteractive.com/media/press-releases/press-release/great-deeds-confer-immortality-in-new-crusader-kings-iii-expansion)
+- [Disco Elysium Thought Cabinet devblog](https://discoelysium.com/devblog/2019/09/30/introducing-the-thought-cabinet)
+- [Monster Hunter Stories 3 Gene Grid - Game8](https://game8.co/games/Monster-Hunter-Stories-3/archives/586640)
+- [Hades 2 Weapon Aspects wiki](https://hades2.wiki.fextralife.com/Weapon+Aspects)
+- [Subnautica Ghost Leviathan wiki](https://subnautica.fandom.com/wiki/Ghost_Leviathan)
+- [Citizen Sleeper Stress into Storytelling - Vice](https://www.vice.com/en/article/how-citizen-sleeper-turns-stress-into-intimate-storytelling/)
+- [Slay the Princess Voices wiki](https://slay-the-princess.fandom.com/wiki/Voices)
+- [Emily Short Narrative States](https://emshort.blog/2019/11/23/narrative-states/)
+- [Emily Short Storylets](https://emshort.blog/2019/11/29/storylets-you-want-them/)
+- [Frostpunk Emotional Narrative - GameDeveloper](https://www.gamedeveloper.com/design/frostpunk-an-analysis-of-emotional-narrative-engagement)
+- [Lai 2021 Virtual Creature Morphology Wiley](https://onlinelibrary.wiley.com/doi/10.1111/cgf.142661)
+- [Universal-LPC-Spritesheet GitHub](https://github.com/LiberatedPixelCup/Universal-LPC-Spritesheet-Character-Generator)
+- [Microsoft 10-foot Experience Guidelines](https://learn.microsoft.com/en-us/windows/win32/dxtecharts/introduction-to-the-10-foot-experience-for-windows-game-developers)
 
 ## Refs
 

--- a/docs/playtest/2026-04-25-skiv-saga-state.md
+++ b/docs/playtest/2026-04-25-skiv-saga-state.md
@@ -62,6 +62,40 @@ Slots: 2/3 (1 libero per ricerca futura)
   - cost: 12 PE + 7 PI
   - effetto: +1 dmg always → +2 dmg condizionato MoS≥5 (burst trade-off)
 
+## Aspect — fase **mature** (Predatore Maturo)
+
+> Skiv è qui sull'asse di vita. Vedi `data/core/species/dune_stalker_lifecycle.yaml`
+> per le 5 fasi totali e i gating di transizione.
+
+```
+      /\_/\        *
+     (  o.o )       *
+      > ^ <
+      /|||\
+```
+
+Forma adulta consolidata. Gli artigli a sette vie si vetrificano
+(mutation artigli_grip_to_glass) → punte trasparenti come ossidiana
+che riflettono il sole. Le orecchie hanno scolpito conche per
+l'echolocation, visibili come solchi. Il pelo lungo il dorso si è
+condensato in una cresta scura. Lo sguardo è fisso, leggero
+socchiudere — primo segno di voce interna. Il branco lo riconosce
+come predatore-stalker, non più cucciolo.
+
+**Tactical signature**: Stalker Lv 4. Synergy echo_backstab live. Thought Cabinet 2/3 slot.
+
+### Mutation morphology (visual swap applicato)
+
+- **claws_glass** — Le punte degli artigli si vetrificano: trasparenza ossidiana riflettente sole. Lascia tracce iridescenti nella sabbia.
+- phase_unlock: `mature`
+
+### MBTI form correlates attivi
+
+- **I_high** — Postura chiusa, silenzioso, orecchie verso interno (ricezione).
+- **T_high** — Sguardo freddo socchiuso, decisioni rapide post-pause.
+- **N_high** — Movimenti sinuosi, scarsa pausa, sembra vedere senza guardare.
+- **P_high** — Routine assente; cambia direzione su input minimi.
+
 ## Diary timeline (8 events — one per whitelist slot)
 
 | # | Event type | Encounter | Turn | Payload key |

--- a/tools/py/seed_skiv_saga.py
+++ b/tools/py/seed_skiv_saga.py
@@ -51,6 +51,7 @@ JOBS_EXPANSION = DATA_DIR / "jobs_expansion.yaml"
 MUTATION_CATALOG = DATA_DIR / "mutations" / "mutation_catalog.yaml"
 MBTI_THOUGHTS = DATA_DIR / "thoughts" / "mbti_thoughts.yaml"
 SPECIES = DATA_DIR / "species.yaml"
+LIFECYCLE = DATA_DIR / "species" / "dune_stalker_lifecycle.yaml"
 
 DEFAULT_OUT_JSON = REPO_ROOT / "data" / "derived" / "skiv_saga.json"
 DEFAULT_OUT_MD = REPO_ROOT / "docs" / "playtest" / "2026-04-25-skiv-saga-state.md"
@@ -107,6 +108,7 @@ def validate_state(quiet: bool = False) -> dict:
     mutations = load_yaml(MUTATION_CATALOG)
     thoughts = load_yaml(MBTI_THOUGHTS)
     species = load_yaml(SPECIES)
+    lifecycle = load_yaml(LIFECYCLE) if LIFECYCLE.exists() else {}
 
     # Stalker job
     stalker_job = (jobs.get("jobs") or {}).get(SKIV_TO_JOB)
@@ -142,17 +144,31 @@ def validate_state(quiet: bool = False) -> dict:
         f"species biome_affinity {affinity} != saga biome {SKIV_BIOME_ID}"
     )
 
+    # Lifecycle (additivo, non blocking se file mancante per backward-compat)
+    lifecycle_phases = {}
+    if lifecycle:
+        lifecycle_phases = lifecycle.get("phases") or {}
+        anchor = lifecycle.get("skiv_saga_anchor") or {}
+        current_phase = anchor.get("current_phase")
+        if current_phase:
+            assert current_phase in lifecycle_phases, (
+                f"skiv_saga_anchor.current_phase '{current_phase}' "
+                f"not in lifecycle.phases"
+            )
+
     if not quiet:
         print(
             f"[validate] {len(thought_catalog)} thoughts, "
             f"{len(mutations.get('mutations') or {})} mutations, "
-            f"stalker job + perk {SKIV_PICKED_PERK['perk_id']} OK"
+            f"stalker job + perk {SKIV_PICKED_PERK['perk_id']} OK, "
+            f"lifecycle {len(lifecycle_phases)} phases"
         )
     return {
         "stalker_job": stalker_job,
         "mutation": mutation_entry,
         "thoughts": thought_catalog,
         "species": skiv_species,
+        "lifecycle": lifecycle,
     }
 
 
@@ -320,7 +336,85 @@ def compose_diary(start_iso: str = "2026-04-25T18:00:00Z") -> list[dict]:
     return out
 
 
+def compose_aspect(lifecycle: dict | None = None) -> dict:
+    """Derive Skiv's current lifecycle phase + aspect from saga progression.
+
+    Algoritmo gating (mirror lifecycle YAML schema):
+      hatchling: Lv 1, 0 mut, 0 thoughts
+      juvenile:  Lv 2-3
+      mature:    Lv 4-5 + ≥1 mut + ≥2 thoughts internalized + polarity stable
+      apex:      Lv 6-7 + ≥2 mut + ≥3 thoughts + tier3 axis
+      legacy:    Lv 7 maxed + ≥3 mut + cabinet pieno
+
+    Skiv saga di default → mature (Lv 4 + 1 mut + 2 internalized + INTP).
+    Se lifecycle YAML è disponibile, esponi anche aspect_it + sprite_ascii
+    + tactical_signature + mutation_morphology applicate.
+    """
+    n_mutations = len(SKIV_INTERNALIZED) and 1  # 1 mutation in saga (artigli_grip_to_glass)
+    n_internalized = len(SKIV_INTERNALIZED)
+    polarity_stable = any(
+        abs(SKIV_MBTI_AXES[ax]["value"] - 0.5) >= 0.15 for ax in SKIV_MBTI_AXES
+    )
+
+    # Saga-deterministic gating
+    if SKIV_LEVEL >= 7 and n_mutations >= 3:
+        phase = "legacy"
+    elif SKIV_LEVEL >= 6 and n_mutations >= 2 and n_internalized >= 3:
+        phase = "apex"
+    elif SKIV_LEVEL >= 4 and n_mutations >= 1 and n_internalized >= 2 and polarity_stable:
+        phase = "mature"
+    elif SKIV_LEVEL >= 2:
+        phase = "juvenile"
+    else:
+        phase = "hatchling"
+
+    aspect = {
+        "lifecycle_phase": phase,
+        "polarity_stable": polarity_stable,
+        "mbti_form_label": "INTP-leaning-I",
+    }
+
+    # Enrich with lifecycle YAML if present
+    if lifecycle:
+        phases = lifecycle.get("phases") or {}
+        phase_data = phases.get(phase) or {}
+        if phase_data:
+            aspect["aspect_it"] = (phase_data.get("aspect_it") or "").strip()
+            sprite = phase_data.get("sprite_ascii")
+            if isinstance(sprite, list):
+                aspect["sprite_ascii"] = "\n".join(sprite)
+            elif isinstance(sprite, str):
+                aspect["sprite_ascii"] = sprite.rstrip()
+            else:
+                aspect["sprite_ascii"] = ""
+            aspect["tactical_signature"] = phase_data.get("tactical_signature")
+            aspect["label_it"] = phase_data.get("label_it")
+            aspect["label_en"] = phase_data.get("label_en")
+
+        # Mutation visual swap
+        morphology = lifecycle.get("mutation_morphology") or {}
+        applied = morphology.get(SKIV_MUTATION_ID)
+        if applied:
+            aspect["mutation_morphology"] = applied
+
+        # MBTI correlate hints
+        correlates = lifecycle.get("mbti_aspect_correlates") or {}
+        active = []
+        if SKIV_MBTI_AXES["E_I"]["value"] >= 0.65 and "I_high" in correlates:
+            active.append({"polarity": "I_high", "manifestation": correlates["I_high"]})
+        if SKIV_MBTI_AXES["T_F"]["value"] >= 0.65 and "T_high" in correlates:
+            active.append({"polarity": "T_high", "manifestation": correlates["T_high"]})
+        if SKIV_MBTI_AXES["S_N"]["value"] <= 0.35 and "N_high" in correlates:
+            active.append({"polarity": "N_high", "manifestation": correlates["N_high"]})
+        if SKIV_MBTI_AXES["J_P"]["value"] <= 0.35 and "P_high" in correlates:
+            active.append({"polarity": "P_high", "manifestation": correlates["P_high"]})
+        aspect["mbti_correlates"] = active
+
+    return aspect
+
+
 def build_saga_state() -> dict:
+    lifecycle_data = load_yaml(LIFECYCLE) if LIFECYCLE.exists() else {}
     return {
         "schema_version": "0.1.0",
         "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -331,11 +425,11 @@ def build_saga_state() -> dict:
         "progression": compose_progression(),
         "cabinet": compose_cabinet(),
         "mutations": compose_mutations(),
+        "aspect": compose_aspect(lifecycle_data),
         "diary": compose_diary(),
         "_notes": (
             "Canonical creature state showcasing 2026-04-25 content sprint #1776 "
-            "+ Skiv 5/8 wishlist (synergy #2 + biome resonance #4 + Defy #5 + "
-            "Diary #7 + Hybrid Path #6). Regenerate via "
+            "+ Skiv 5/8 wishlist + lifecycle/aspect (this PR). Regenerate via "
             "tools/py/seed_skiv_saga.py."
         ),
     }
@@ -410,6 +504,27 @@ Slots: {slots_used}/3 (1 libero per ricerca futura)
   - cost: 12 PE + 7 PI
   - effetto: +1 dmg always → +2 dmg condizionato MoS≥5 (burst trade-off)
 
+## Aspect — fase **{aspect_phase}** ({aspect_label})
+
+> Skiv è qui sull'asse di vita. Vedi `data/core/species/dune_stalker_lifecycle.yaml`
+> per le 5 fasi totali e i gating di transizione.
+
+```
+{aspect_sprite}
+```
+
+{aspect_prose}
+
+**Tactical signature**: {aspect_tactical}
+
+### Mutation morphology (visual swap applicato)
+
+{aspect_morph}
+
+### MBTI form correlates attivi
+
+{aspect_mbti}
+
 ## Diary timeline (8 events — one per whitelist slot)
 
 {diary_table}
@@ -440,6 +555,26 @@ def render_markdown(state: dict) -> str:
     mut = state["mutations"][0]
     axes = state["mbti_axes"]
     diary = state["diary"]
+    aspect = state.get("aspect") or {}
+
+    aspect_sprite = aspect.get("sprite_ascii") or "(sprite pending lifecycle YAML)"
+    aspect_prose = aspect.get("aspect_it") or "(prose non disponibile)"
+    aspect_tactical = aspect.get("tactical_signature") or "—"
+    aspect_phase = aspect.get("lifecycle_phase", "unknown")
+    aspect_label = aspect.get("label_it", "—")
+    morph = aspect.get("mutation_morphology") or {}
+    if morph:
+        aspect_morph = (
+            f"- **{morph.get('aspect_token', '?')}** — {morph.get('visual_swap_it', '—')}\n"
+            f"- phase_unlock: `{morph.get('phase_unlock', '—')}`"
+        )
+    else:
+        aspect_morph = "_(nessuna mutation morphology nel lifecycle YAML)_"
+
+    mbti_lines = []
+    for entry in aspect.get("mbti_correlates") or []:
+        mbti_lines.append(f"- **{entry['polarity']}** — {entry['manifestation']}")
+    aspect_mbti = "\n".join(mbti_lines) or "_(nessun axis stabilmente polarizzato)_"
 
     diary_lines = [
         "| # | Event type | Encounter | Turn | Payload key |",
@@ -472,6 +607,13 @@ def render_markdown(state: dict) -> str:
         slots_used=cab["slots_used"],
         mutation_id=mut["id"],
         diary_table=diary_table,
+        aspect_phase=aspect_phase,
+        aspect_label=aspect_label,
+        aspect_sprite=aspect_sprite,
+        aspect_prose=aspect_prose,
+        aspect_tactical=aspect_tactical,
+        aspect_morph=aspect_morph,
+        aspect_mbti=aspect_mbti,
     )
 
 


### PR DESCRIPTION
**Stop designing in isolation.** Launched 3 parallel research agents prima di shippare il lifecycle: external repos (general-purpose), UI audit (ui-design-illuminator), narrative arcs (narrative-design-illuminator). Synthesized findings → research-driven PR.

> *"Le dune mi parlano. So cosa pensare prima."* — Skiv (apex voice from narrative-illuminator)

## Research output (3 parallel agents, 2026-04-25)

| Agent | Output | Key finding |
|---|---|---|
| general-purpose (external repos) | 12 pattern primary-sourced | Top 4: Wildermyth layered portraits + Caves of Qud morphotype gating + MHS gene grid + Disco thought correlate. Recommendation: NEW agent `creature-aspect-illuminator` |
| ui-design-illuminator (audit) | 12 UI gap file:line + 8 patterns | P0 stack: GAP-08 canvas font (9px TV-fail), GAP-04 slot counter missing, GAP-05 Defy verb zero surface |
| narrative-design-illuminator | 7 patterns + 5 narrative beats | Wildermyth permanent change + Disco uncertainty + Citizen Sleeper failure canon + Slay the Princess voice consistency + Emily Short warning zones |

## Changes shipped

### NEW agent `.claude/agents/creature-aspect-illuminator.md` (370 LOC)
- INTP audit mode / ISFP research mode (Skiv-aligned)
- Pattern library: 8 P0/P1 + 4 frontier + anti-pattern blocklist
- Decision tree template + smoke test checklist + escalation paths

### Lifecycle YAML revised (`data/core/species/dune_stalker_lifecycle.yaml`)
- `voice_it` per phase (5 frasi POV Skiv INTP, narrative-illuminator-authored)
- `narrative_beat_it` per phase (Wildermyth permanent change)
- `warning_zone_it` per phase (Emily Short pre-transition signals)
- Research provenance citations header

### Aspect doc revised (`docs/planning/2026-04-25-skiv-aspect-evolution.md`)
- Open questions enriched con pattern references
- Citations primary-sourced (15+ links: Wildermyth, CK3, Disco, MHS, Subnautica, Citizen Sleeper, Slay the Princess, Emily Short, Frostpunk, LPC, Microsoft 10-foot)

### UI top-2 fixes (P0 from ui-design-illuminator audit)
- **GAP-08 canvas fonts dynamic** (`apps/play/src/render.js`): HP, species, status, intent fonts now scale with CELL via `Math.max(N, Math.round(CELL * factor))`. Microsoft 10-foot rule + Fire TV guidelines. **Was 9px → now 12px min** at CELL≥80.
- **GAP-04 thought cabinet slot counter** (`apps/play/src/thoughtsPanel.js`): renders `Slots ●●○ 2/3 · 🧠 1 internalizzati · 🔬 1 in ricerca`. Backend already shipped fields (#1769); client now surfaces. Cold-start clarity restored.

### Saga regen (deterministic)
- `data/derived/skiv_saga.json` + `docs/playtest/2026-04-25-skiv-saga-state.md` re-composed with new lifecycle YAML voice_it + narrative_beat_it baked in.

## Validation
- Saga seed test: **15/15** (no regression)
- AI 307/307 · pytest **963/963** · format ✅ · governance 0/0
- No new deps · backward-compat (additive only)

## Decision tree applied (gap → pattern)

| Gap | Pattern applied | File |
|---|---|---|
| GAP-08 9px canvas (10-foot fail) | Microsoft 10-foot + Fire TV guidelines | `render.js` |
| GAP-04 slot counter missing | Disco Elysium "X/Y slots" pattern | `thoughtsPanel.js` |

Remaining UI gaps (deferred to future PRs):
- GAP-01 lifecycle ring (drawLifecycleRing function)
- GAP-02 mutation telegraph (StS relic shelf)
- GAP-03 researching state animation
- GAP-05 Defy verb tile (HARD MISS, scheduled for Inner Voices routine 2026-05-13)
- GAP-06 MBTI form combat-time visible
- GAP-07 ambient thought indicator on token
- GAP-10 debrief evolution preview
- GAP-11 catalog T_F axis
- GAP-12 phone composer creature identity

## Test plan
- [x] Saga seed regen + 15/15
- [x] AI + pytest no regression
- [x] format + governance
- [ ] CI green

## Rollback
Revert this PR — lifecycle YAML loses voice_it/narrative_beat_it (saga regen falls back to phase aspect_it only); render.js fonts revert to fixed px (TV-fail returns); thoughtsPanel slot counter goes silent. No schema migration, no contract change. Backward compat for backend (slots fields already shipped #1769).

## Refs
- Companion: [#1784](../pull/1784) Skiv Saga seed (state)
- Skiv canonical: `~/.claude/projects/.../memory/project_skiv_evolution_wishlist.md`
- Routine pending: `trig_01SB74yJvr6eyX4Gjq9H1jFB` Wed 2026-05-13 — Inner Voices #3 (Disco voices delivery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)