### PR TITLE
feat(traits): Wave 6 sensori_* mechanics (3 entries)

### DIFF
--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -2035,3 +2035,59 @@ traits:
       Derma a densit� elevata con fibre intrecciate che assorbono
       microimpatti e dissipano colpi penetranti. Ogni hit melee subisce
       -2 danno.
+
+  # --- SENSORI (Wave 6) ---
+  # Famiglia sensoriale: percezione fine = bonus condizionali su MoS alto
+  # (acuita' che individua varchi) o riduzione (early warning del campo).
+
+  sensori_geomagnetici:
+    tier: T1
+    category: fisiologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: sensori_geomagnetici_lock
+    description_it: |
+      Cristalli cranici che mappano corridoi geomagnetici invisibili e
+      individuano la firma magnetica del bersaglio. Su MoS >= 5 il colpo
+      sfrutta il lock per +1 danno (target_weakpoint via campo magnetico).
+
+  sensori_planctonici:
+    tier: T1
+    category: fisiologico
+    applies_to: target
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: damage_reduction
+      amount: 1
+      min: 0
+      log_tag: sensori_planctonici_warning
+    description_it: |
+      Sensori diffusi che leggono pattern di plancton memetico e percepiscono
+      le perturbazioni in arrivo. L'early warning consente una micro-schivata
+      che assorbe -1 danno (minimo 0) sui colpi che colpiscono.
+
+  sensori_sismici:
+    tier: T2
+    category: fisiologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+      melee_only: true
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: sensori_sismici_footfall
+    description_it: |
+      Recettori cutanei che leggono microvibrazioni del terreno e
+      anticipano lo spostamento di peso del bersaglio in mischia.
+      Su MoS >= 5 in melee, il colpo entra nell'apertura: +1 danno.

--- a/data/core/traits/glossary.json
+++ b/data/core/traits/glossary.json
@@ -1654,6 +1654,12 @@
       "label_en": "Radiant Paws",
       "description_it": "Zampe che generano pulsazione cinetica al touch-down: +2 danno extra da posizione sopraelevata.",
       "description_en": "Paws that generate kinetic pulse on touchdown: +2 extra damage from elevated position."
+    },
+    "sensori_sismici": {
+      "label_it": "Sensori Sismici",
+      "label_en": "Seismic Sensors",
+      "description_it": "Recettori cutanei che leggono microvibrazioni del terreno e anticipano lo spostamento di peso del bersaglio.",
+      "description_en": "Cutaneous receptors reading ground microvibrations to anticipate the target weight shift."
     }
   }
 }


### PR DESCRIPTION
## Summary
Aggiunge 3 trait mechanics famiglia `sensori_*` in `active_effects.yaml` + 1 glossary entry nuovo (`sensori_sismici`).

### Trait mechanics aggiunte
- **sensori_geomagnetici** (T1, actor): `extra_damage +1` on hit + `min_mos >= 5`. Lock magnetico target_weakpoint.
- **sensori_planctonici** (T1, target): `damage_reduction -1` (min 0) on hit. Early warning micro-schivata.
- **sensori_sismici** (T2, actor, NEW glossary): `extra_damage +1` on hit + `min_mos >= 5` + `melee_only`. Lettura microvibrazioni terreno.

### Glossary
- Nuova entry `sensori_sismici` con `label_it` / `label_en` / `description_it` / `description_en`.

## Test plan
- [x] Schema validation: 111 -> 114 entries (active_effects.yaml)
- [x] Glossary cross-ref: 0 unresolved trait_id (`missing in glossary: []`)
- [x] `node --test tests/ai/*.test.js` -> 311/311 verde
- [x] `prettier --check` pass su entrambi i file modificati
- [x] Encoding UTF-8 verified (0 mojibake `Ã` su entrambi)
- [x] Trigger fields usano solo schema supportato da `traitEffects.js` (`on_result`, `min_mos`, `melee_only`)

Closes Wave 6 ticket A (parallel-sprint validation).