### PR TITLE
feat(traits): Wave 6 mente_*/cervello_* mechanics (3 entries)

### DIFF
--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -2091,3 +2091,74 @@ traits:
       Recettori cutanei che leggono microvibrazioni del terreno e
       anticipano lo spostamento di peso del bersaglio in mischia.
       Su MoS >= 5 in melee, il colpo entra nell'apertura: +1 danno.
+
+  # SPRINT_2026-04-25 Wave 6: trait famiglia mente_* + cervello_*.
+  # Pattern apply_status (panic|stunned) per simulare effetti mentali su target.
+
+  cervello_a_bassa_latenza:
+    tier: T2
+    category: mentale
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: apply_status
+      target_side: target
+      stato: stunned
+      turns: 1
+      log_tag: bassa_latenza_stun
+    description_it: 'Sistema neurale a bassa latenza che processa traiettorie e tempi
+
+      di reazione del bersaglio. Su MoS >= 5 il colpo arriva nel
+
+      microsecondo cieco della reazione avversaria, stordendo il
+
+      target per 1 turno.
+
+      '
+
+  mente_lucida:
+    tier: T2
+    category: mentale
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 3
+    effect:
+      kind: apply_status
+      target_side: target
+      stato: panic
+      turns: 2
+      log_tag: mente_lucida_panic
+    description_it: 'Coscienza tattica ferma e affilata. Quando l''attore colpisce con
+
+      MoS >= 3, il bersaglio percepisce di essere stato "visto" oltre
+
+      ogni difesa: l''incertezza diventa panico per 2 turni.
+
+      '
+
+  cervello_predittivo:
+    tier: T3
+    category: mentale
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 6
+    effect:
+      kind: apply_status
+      target_side: target
+      stato: stunned
+      turns: 2
+      log_tag: cervello_predittivo_stun
+    description_it: 'Corteccia predittiva che simula in tempo reale i prossimi due
+
+      secondi del bersaglio. Su MoS >= 6 il colpo cade nel punto cieco
+
+      di reazione previsto, stordendo il target per 2 turni interi.
+
+      '

--- a/data/core/traits/glossary.json
+++ b/data/core/traits/glossary.json
@@ -1660,6 +1660,18 @@
       "label_en": "Seismic Sensors",
       "description_it": "Recettori cutanei che leggono microvibrazioni del terreno e anticipano lo spostamento di peso del bersaglio.",
       "description_en": "Cutaneous receptors reading ground microvibrations to anticipate the target weight shift."
+    },
+    "mente_lucida": {
+      "label_it": "Mente Lucida",
+      "label_en": "Lucid Mind",
+      "description_it": "Coscienza tattica ferma che legge il bersaglio oltre la difesa.",
+      "description_en": "Steady tactical awareness that reads the target beyond defenses."
+    },
+    "cervello_predittivo": {
+      "label_it": "Cervello Predittivo",
+      "label_en": "Predictive Brain",
+      "description_it": "Corteccia che anticipa i prossimi secondi del bersaglio.",
+      "description_en": "Cortex that anticipates the target's next seconds of motion."
     }
   }
 }


### PR DESCRIPTION
## Summary

Aggiunge 3 trait mechanics famiglie `mente_*` + `cervello_*` (apply_status panic/stunned) in `active_effects.yaml` + 2 nuove glossary entries.

| Trait                          | Tier | Trigger        | Effect                  |
| ------------------------------ | :--: | -------------- | ----------------------- |
| `cervello_a_bassa_latenza`     |  T2  | hit, MoS >= 5  | stunned target, 1 turn  |
| `mente_lucida` (NEW)           |  T2  | hit, MoS >= 3  | panic target, 2 turns   |
| `cervello_predittivo` (NEW)    |  T3  | hit, MoS >= 6  | stunned target, 2 turns |

Pattern compatibile con `intimidatore` / `stordimento` (sprint_018): `effect.kind = apply_status`, `target_side = target`, gestito da `traitEffects.js` + `performAttack`.

## Test plan

- [x] Schema validation: 111 -> 114 entries (yaml.safe_load OK)
- [x] Glossary cross-ref: 0 unresolved trait_id (275 -> 277 glossary)
- [x] `node --test tests/ai/*.test.js` -> 311/311 pass
- [x] `npx prettier --check` -> All matched files use Prettier code style
- [x] Encoding UTF-8 verified (0 real mojibake; 31 0xC3 bytes = legit accented chars città/sopra/etc.)
- [x] All 3 trait_ids resolve in both glossary + active_effects

## Files changed

- `data/core/traits/active_effects.yaml` (+69)
- `data/core/traits/glossary.json` (+14)

Closes Wave 6 ticket B (parallel-sprint validation).

DO NOT MERGE — draft per cross-validation pipeline.