### PR TITLE
feat(traits): Wave 6 cuore_*/midollo_* mechanics (3 entries)

### DIFF
--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -2162,3 +2162,72 @@ traits:
       di reazione previsto, stordendo il target per 2 turni interi.
 
       '
+
+  # SPRINT_2026-04-25 Wave 6: trait famiglia cuore_* + midollo_*.
+  # Pattern apply_status (rage on_kill) per simulare adrenalina cardiovascolare.
+
+  cuore_multicamera_bassa_pressione:
+    tier: T2
+    category: fisiologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      on_kill: true
+    effect:
+      kind: apply_status
+      target_side: actor
+      stato: rage
+      turns: 2
+      log_tag: cuore_multicamera_surge
+    description_it: 'Cuore a quattro camere a bassa pressione che modula il flusso
+
+      sanguigno con precisione: dopo un''uccisione 2 turni di rage
+
+      (no retreat, +1 dmg) grazie alla scarica adrenalinica controllata.
+
+      '
+
+  midollo_antivibrazione:
+    tier: T2
+    category: fisiologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      on_kill: true
+    effect:
+      kind: apply_status
+      target_side: actor
+      stato: rage
+      turns: 1
+      log_tag: midollo_antivibrazione_pulse
+    description_it: 'Midollo osseo gel-smorzante che assorbe il contraccolpo dell''urto
+
+      letale e libera un breve impulso adrenalinico: 1 turno di rage
+
+      (no retreat, +1 dmg) post-kill senza rinculo.
+
+      '
+
+  cuore_in_furia:
+    tier: T2
+    category: fisiologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      on_kill: true
+    effect:
+      kind: apply_status
+      target_side: actor
+      stato: rage
+      turns: 3
+      log_tag: cuore_in_furia_blaze
+    description_it: 'Cuore ipertrofico che entra in tachicardia rituale alla vista
+
+      della preda caduta: 3 turni di rage (no retreat, +1 dmg) come
+
+      tributo cardiaco al sangue versato.
+
+      '

--- a/data/core/traits/glossary.json
+++ b/data/core/traits/glossary.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-04-25T11:50:00Z",
+  "updated_at": "2026-04-25T12:30:00Z",
   "sources": {
     "trait_reference": "data/traits/index.json"
   },
@@ -580,6 +580,12 @@
       "label_en": "Cromofori Alert Acido",
       "description_it": "Cromofori Alert Acido permette alle squadre di ridistribuire carichi e modulare rigidità strutturale all'interno di foresta acida.",
       "description_en": "Cromofori Alert Acido allow squads to redistribute load and modulate structural rigidity within foresta acida."
+    },
+    "cuore_in_furia": {
+      "label_it": "Cuore in Furia",
+      "label_en": "Heart in Fury",
+      "description_it": "Cuore ipertrofico che entra in tachicardia rituale post-kill, scatenando 3 turni di rage adrenalinica.",
+      "description_en": "Hypertrophic heart entering ritual tachycardia post-kill, triggering 3 turns of adrenal rage."
     },
     "cuore_multicamera_bassa_pressione": {
       "label_it": "Cuore Multicamera Bassa Pressione",


### PR DESCRIPTION
## Summary
Aggiunge 3 trait mechanics famiglie cuore_* + midollo_* (apply_status rage on_kill) in active_effects.yaml + 1 glossary entry nuova.

**Trait_ids:**
- `cuore_multicamera_bassa_pressione` (apply_status rage 2t on_kill, log_tag `cuore_multicamera_surge`)
- `midollo_antivibrazione` (apply_status rage 1t on_kill, log_tag `midollo_antivibrazione_pulse`)
- `cuore_in_furia` **NEW glossary + active_effects** (apply_status rage 3t on_kill, log_tag `cuore_in_furia_blaze`)

Theme: cardiovascolare/midollare → adrenal surge post-kill (rage = no retreat, +1 dmg).

## Test plan
- [x] Schema validation: 111 -> 114 entries (+3)
- [x] Glossary cross-ref: 0 unresolved trait_id (276 entries totali, +1 cuore_in_furia)
- [x] `node --test tests/ai/*.test.js` -> **311/311** verde
- [x] `npx prettier --check` pass
- [x] Encoding UTF-8 verified (0 mojibake `Ã` in entrambi file)
- [x] No regressions su trait esistenti (midollo_iperattivo non toccato)

Closes Wave 6 ticket C (parallel-sprint validation).