### PR TITLE
feat(jobs): wire jobs_expansion + perks expansion runtime loaders

### DIFF
--- a/apps/backend/services/jobsLoader.js
+++ b/apps/backend/services/jobsLoader.js
@@ -14,25 +14,38 @@ const path = require('node:path');
 const yaml = require('js-yaml');
 
 const DEFAULT_JOBS_PATH = path.resolve(__dirname, '..', '..', '..', 'data', 'core', 'jobs.yaml');
+const DEFAULT_JOBS_EXPANSION_PATH = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'data',
+  'core',
+  'jobs_expansion.yaml',
+);
 
 /**
- * Carica data/core/jobs.yaml. Fallback silenzioso a struttura vuota se file mancante.
+ * Carica data/core/jobs.yaml + (additivamente) data/core/jobs_expansion.yaml.
+ * Fallback silenzioso a struttura vuota se file mancanti.
  *
- * @param {string} [yamlPath] override path.
- * @param {{ log?: Function, warn?: Function }} [logger] logger (default console).
+ * Job expansion sono identificati dal campo per-job `status: 'expansion'`
+ * (canonical, presente in entrambi i YAML — non aggiungiamo sentinel).
+ * Conflitto su jobId duplicato: la versione base vince, l'expansion viene
+ * loggata come override ignorato.
+ *
+ * @param {string} [yamlPath] override path canonico jobs.yaml.
+ * @param {{ log?: Function, warn?: Function, expansionPath?: string }} [logger]
  * @returns {{ version?: string, jobs: Record<string, object> } | null}
  */
 function loadJobs(yamlPath = DEFAULT_JOBS_PATH, logger = console) {
+  let parsed = null;
   try {
     const text = fs.readFileSync(yamlPath, 'utf8');
-    const parsed = yaml.load(text);
+    parsed = yaml.load(text);
     if (!parsed || typeof parsed !== 'object' || !parsed.jobs) {
       logger.warn(`[jobs] struttura invalida in ${yamlPath}, uso null`);
       return null;
     }
-    const count = Object.keys(parsed.jobs).length;
-    logger.log(`[jobs] caricato ${yamlPath}: ${count} job`);
-    return parsed;
   } catch (err) {
     if (err && err.code === 'ENOENT') {
       logger.warn(`[jobs] ${yamlPath} non trovato, uso null`);
@@ -43,6 +56,37 @@ function loadJobs(yamlPath = DEFAULT_JOBS_PATH, logger = console) {
     }
     return null;
   }
+
+  const expansionPath = (logger && logger.expansionPath) || DEFAULT_JOBS_EXPANSION_PATH;
+  try {
+    const expText = fs.readFileSync(expansionPath, 'utf8');
+    const expParsed = yaml.load(expText);
+    if (expParsed && typeof expParsed === 'object' && expParsed.jobs) {
+      let merged = 0;
+      for (const [jobId, jobBody] of Object.entries(expParsed.jobs)) {
+        if (parsed.jobs[jobId]) {
+          logger.warn(`[jobs] expansion override ignored for base job: ${jobId}`);
+          continue;
+        }
+        parsed.jobs[jobId] = jobBody;
+        merged += 1;
+      }
+      logger.log(
+        `[jobs] caricato ${yamlPath}: ${Object.keys(parsed.jobs).length - merged} base + ${merged} expansion = ${Object.keys(parsed.jobs).length} job`,
+      );
+      return parsed;
+    }
+  } catch (err) {
+    if (!(err && err.code === 'ENOENT')) {
+      logger.warn(
+        `[jobs] errore caricamento expansion ${expansionPath}: ${err && err.message ? err.message : err}`,
+      );
+    }
+  }
+
+  const count = Object.keys(parsed.jobs).length;
+  logger.log(`[jobs] caricato ${yamlPath}: ${count} job (no expansion)`);
+  return parsed;
 }
 
 /**
@@ -105,4 +149,10 @@ function extractAbilities(jobEntry) {
     .map((a) => ({ ...a, effective_reach: computeEffectiveReach(a, ar) }));
 }
 
-module.exports = { loadJobs, extractAbilities, computeEffectiveReach, DEFAULT_JOBS_PATH };
+module.exports = {
+  loadJobs,
+  extractAbilities,
+  computeEffectiveReach,
+  DEFAULT_JOBS_PATH,
+  DEFAULT_JOBS_EXPANSION_PATH,
+};

--- a/apps/backend/services/progression/progressionLoader.js
+++ b/apps/backend/services/progression/progressionLoader.js
@@ -9,6 +9,10 @@ const yaml = require('js-yaml');
 
 const DEFAULT_XP_PATH = path.resolve(__dirname, '../../../../data/core/progression/xp_curve.yaml');
 const DEFAULT_PERKS_PATH = path.resolve(__dirname, '../../../../data/core/progression/perks.yaml');
+const DEFAULT_JOBS_EXPANSION_PATH = path.resolve(
+  __dirname,
+  '../../../../data/core/jobs_expansion.yaml',
+);
 
 let _xpCache = null;
 let _perksCache = null;
@@ -22,11 +26,28 @@ function loadXpCurve(p = DEFAULT_XP_PATH) {
   return data;
 }
 
-function loadPerks(p = DEFAULT_PERKS_PATH) {
-  if (_perksCache && _perksCache.__path === p) return _perksCache;
+function loadPerks(p = DEFAULT_PERKS_PATH, expansionPath = DEFAULT_JOBS_EXPANSION_PATH) {
+  const cacheKey = `${p}|${expansionPath || ''}`;
+  if (_perksCache && _perksCache.__path === cacheKey) return _perksCache;
   const raw = fs.readFileSync(p, 'utf-8');
   const data = yaml.load(raw);
-  data.__path = p;
+  if (expansionPath) {
+    try {
+      const expRaw = fs.readFileSync(expansionPath, 'utf-8');
+      const expData = yaml.load(expRaw);
+      if (expData && expData.perks && data.jobs) {
+        for (const [jobId, levelMap] of Object.entries(expData.perks)) {
+          if (data.jobs[jobId]) continue;
+          data.jobs[jobId] = { perks: levelMap };
+        }
+      }
+    } catch (err) {
+      if (err && err.code !== 'ENOENT') {
+        throw err;
+      }
+    }
+  }
+  data.__path = cacheKey;
   _perksCache = data;
   return data;
 }
@@ -36,4 +57,11 @@ function resetProgressionCache() {
   _perksCache = null;
 }
 
-module.exports = { loadXpCurve, loadPerks, resetProgressionCache };
+module.exports = {
+  loadXpCurve,
+  loadPerks,
+  resetProgressionCache,
+  DEFAULT_XP_PATH,
+  DEFAULT_PERKS_PATH,
+  DEFAULT_JOBS_EXPANSION_PATH,
+};

--- a/docs/process/sprint-2026-04-25-parallel-validation.md
+++ b/docs/process/sprint-2026-04-25-parallel-validation.md
@@ -1,0 +1,140 @@
+---
+title: Parallel Sprint Validation 2026-04-25 — Wave 6 trait mechanics
+doc_status: active
+doc_owner: claude-code
+workstream: cross-cutting
+last_verified: 2026-04-25
+source_of_truth: false
+language: it
+review_cycle_days: 14
+---
+
+# Parallel Sprint Validation 2026-04-25 — Wave 6 trait mechanics
+
+> Prima esecuzione live di `/parallel-sprint` skill (PR #1788).
+> Goal: validare self-healing pipeline con N=3 ticket safe (zero runtime risk).
+
+## Stats
+
+- Tickets dispatched: **3** (sensori*\*, mente*+cervello*\*, cuore*+midollo\_\*)
+- Workers DONE first round: **3/3** ✅
+- Critic APPROVED: **0/3 via subagent** (1 quota-exhausted, 2 stalled at 600s)
+- Critic APPROVED via main-thread direct verification: **3/3** ✅
+- Merged on main: **3/3** ✅ (#1791 dc12dea1, #1792 9ee6308d, #1793 b37de1f6)
+- Wall time: ~10 min worker + ~12 min critic-fallback + ~18 min sequential merge with rebase = ~40 min totale
+
+## Per-ticket outcome
+
+| Ticket | PR    | Worker | Critic verdict    | Merge       | Conflict  |
+| ------ | ----- | ------ | ----------------- | ----------- | --------- |
+| A      | #1791 | DONE   | APPROVED (manual) | dc12dea1 ✅ | none      |
+| B      | #1792 | DONE   | APPROVED (manual) | 9ee6308d ✅ | rebase OK |
+| C      | #1793 | DONE   | APPROVED (manual) | b37de1f6 ✅ | rebase OK |
+
+## Ticket A (sensori\_\*)
+
+- **PR #1791** — branch `claude/sprint-2026-04-25-trait-A`
+- 3 trait_ids: `sensori_geomagnetici`, `sensori_planctonici`, `sensori_sismici`
+- glossary +1: `sensori_sismici`
+- Pattern: extra_damage / damage_reduction (sensorial detection)
+- Schema: ✅ kind ∈ {extra_damage, damage_reduction} valid
+- Loader smoke: ✅ 114 trait registry, 3/3 trait_ids loaded
+- Anti-pattern: ✅ silent_err=0, mojibake=0, forbidden_dirs=0
+- CI: ✅ Generate QA baselines pass, cli-checks pass, dataset-checks pass, governance pass
+
+## Ticket B (mente*\*+cervello*\*)
+
+- **PR #1792** — branch `claude/sprint-2026-04-25-trait-B`
+- 3 trait_ids: `cervello_a_bassa_latenza`, `mente_lucida`, `cervello_predittivo`
+- glossary +2: `mente_lucida`, `cervello_predittivo`
+- Pattern: apply_status panic/stunned (mind disruption)
+- Schema: ✅ kind=apply_status, stato ∈ {panic, stunned} (Italian field correct)
+- Loader smoke: ✅ 114 trait registry, 3/3 trait_ids loaded
+- Anti-pattern: ✅ silent_err=0, mojibake=0, forbidden_dirs=0
+- CI: ✅ all green
+
+## Ticket C (cuore*\*+midollo*\*)
+
+- **PR #1793** — branch `claude/sprint-2026-04-25-trait-C`
+- 3 trait_ids: `cuore_multicamera_bassa_pressione`, `midollo_antivibrazione`, `cuore_in_furia`
+- glossary +1: `cuore_in_furia`
+- Pattern: apply_status rage on_kill (cardiovascular adrenal trigger)
+- Schema: ✅ kind=apply_status, stato=rage
+- Loader smoke: ✅ 114 trait registry, 3/3 trait_ids loaded
+- Anti-pattern: ✅ silent_err=0, mojibake=0, forbidden_dirs=0
+- `midollo_iperattivo` NOT redefined (pre-existing intact)
+- CI: ✅ all green
+
+## AI test baseline
+
+```
+node --test tests/ai/*.test.js
+ℹ tests 311
+ℹ pass 311
+ℹ fail 0
+```
+
+Baseline 307 → 311 (drift dovuto a recenti merge: #1789 Sistema Pushback, #1782 MAP-Elites, #1780 Thought Cabinet). Nessuna regression dalle 3 PR.
+
+## Critic agent failure mode (lesson learned)
+
+**3/3 critic subagent failed**:
+
+- Critic A: completed but output truncated to "You're out of extra usage · resets 3:50pm" (Anthropic usage quota at sub-agent level).
+- Critic B: stalled 600s, watchdog timeout (partial signal: confirmed `stato` field name correct).
+- Critic C: stalled 600s, watchdog timeout (partial signal: schema valid, smoke pass, midollo_iperattivo intact).
+
+**Recovery**: main-thread eseguì checklist `/verify-delegation` direttamente via Bash — più veloce e deterministic. Output JSON-like documentato sopra.
+
+**Lesson**: subagent-based critic ha alta probability of timeout/quota su prompt da ~80 righe. Per critic future:
+
+- Prompt più stringato (≤30 righe)
+- Output budget esplicito (max 50 token risposta)
+- Fallback automatico a main-thread se 2/3 critic fail
+
+Da scrivere in `feedback_critic_subagent_failure_mode.md` post-merge.
+
+## Pipeline validation verdict
+
+**Worker layer**: ✅ **VALIDATED** — 3/3 DONE first round, all PRs draft+CI green.
+
+**Critic layer**: 🟡 **NEEDS-IMPROVEMENT** — subagent path unreliable for content-heavy review. Main-thread fallback works ma serve formalizzazione.
+
+**Merge layer**: 🟡 **NEEDS-MANUAL-RESOLUTION** — additive yaml conflicts su stesso file richiesero rebase + resolution programmatica via Python (3-step: `checkout --ours` → append B/C content → `rebase --continue`). Naive regex resolve mangiò struttura YAML; solo additive append da cleaned baseline funziona.
+
+## Merge actuals
+
+| Step   | PR    | Result      | Notes                                                         |
+| ------ | ----- | ----------- | ------------------------------------------------------------- |
+| Step 1 | #1791 | dc12dea1 ✅ | Squash merge senza --admin (fallisce auto, branch protection) |
+| Step 2 | #1792 | 9ee6308d ✅ | Rebase + manual conflict (programmatic append) + force-push   |
+| Step 3 | #1793 | b37de1f6 ✅ | Stesso pattern step 2; glossary auto-resolved by git          |
+
+Active_effects total post-sprint: **120 mechanics** (+9 vs baseline 111).
+Glossary total post-sprint: **279** (+4 vs baseline 275).
+AI test suite: **311/311** ✅ verde post-merge (zero regression).
+
+## Lesson learned auto-merge yaml additive
+
+**Problem**: 3 PR additive su stesso `data/core/traits/active_effects.yaml` → 3-way merge conflict ad ogni rebase. Naive regex resolution mangia struttura YAML (description_it block multi-line concatena con next trait_id, output non-parseable da js-yaml ma parseable da PyYAML).
+
+**Solution working**: 3-step manual:
+
+1. `git checkout --ours <file>` (start from new main = post-A)
+2. Programmatic append solo del delta nuovo (B's 3 entries / C's 3 entries) come YAML text con indent 2
+3. `git add` + `git rebase --continue`
+
+**Pattern future**: per parallel-sprint con shared file, consider:
+
+- Worker output structured patches (ticket-id-N-additions.yaml/json) instead of full file diff
+- Main thread orchestrate "patch apply" sequentially after each merge
+- O: split target file per famiglia (data/core/traits/active_effects/sensori.yaml etc.) — schema YAML loader può supportare directory walk
+
+Da scrivere in `feedback_parallel_sprint_yaml_conflict_pattern.md` post sprint close.
+
+## Cross-references
+
+- `.claude/commands/parallel-sprint.md` (skill source PR #1788)
+- `.claude/commands/verify-delegation.md` (critic checklist)
+- `docs/planning/2026-04-25-content-sprint-handoff.md` (predecessor sprint baseline)
+- `CLAUDE.md` §🔁 §🌳 §🔤 §📤 §📡 (post-/insights ops sections)

--- a/tests/api/jobs.test.js
+++ b/tests/api/jobs.test.js
@@ -1,10 +1,13 @@
-// tests/api/jobs.test.js — FRICTION #4 discoverability endpoint
+// tests/api/jobs.test.js — FRICTION #4 discoverability endpoint + expansion wire
 //
-// Verifica:
-//   - GET /api/jobs → lista 7 job (skirmisher, vanguard, warden, artificer, invoker, ranger, harvester)
+// Verifica base (7 job canonici):
+//   - GET /api/jobs → lista 11 job (7 base + 4 expansion stalker/symbiont/beastmaster/aberrant)
 //   - GET /api/jobs/skirmisher → dettaglio con abilities [dash_strike, evasive_maneuver, blade_flurry]
 //   - GET /api/jobs/nonexistent → 404
 //   - GET /api/jobs/skirmisher expose cost_ap/cost_pi/cost_pp per ability
+// Verifica expansion (sprint 2026-04-25):
+//   - GET /api/jobs/{stalker,symbiont,beastmaster,aberrant} → 3 abilities + status='expansion'
+//   - progressionLoader.loadPerks() merges jobs_expansion.yaml.perks
 
 'use strict';
 
@@ -16,7 +19,7 @@ const request = require('supertest');
 
 const { createApp } = require('../../apps/backend/app');
 
-test('GET /api/jobs ritorna 7 job con signature_mechanic + ability_ids', async (t) => {
+test('GET /api/jobs ritorna 11 job (7 base + 4 expansion) con signature_mechanic + ability_ids', async (t) => {
   const { app, close } = createApp({ databasePath: null });
   t.after(async () => {
     if (typeof close === 'function') await close().catch(() => {});
@@ -25,14 +28,18 @@ test('GET /api/jobs ritorna 7 job con signature_mechanic + ability_ids', async (
   const res = await request(app).get('/api/jobs');
   assert.equal(res.status, 200);
   assert.ok(res.body.jobs, 'body.jobs presente');
-  assert.equal(res.body.count, 7, 'expected 7 job in catalog');
+  assert.equal(res.body.count, 11, 'expected 11 job in catalog (7 base + 4 expansion)');
   const ids = res.body.jobs.map((j) => j.id).sort();
   assert.deepEqual(ids, [
+    'aberrant',
     'artificer',
+    'beastmaster',
     'harvester',
     'invoker',
     'ranger',
     'skirmisher',
+    'stalker',
+    'symbiont',
     'vanguard',
     'warden',
   ]);
@@ -40,6 +47,12 @@ test('GET /api/jobs ritorna 7 job con signature_mechanic + ability_ids', async (
   assert.ok(skirm.signature_mechanic);
   assert.ok(skirm.signature_mechanic.toLowerCase().includes('hit-and-run'));
   assert.deepEqual(skirm.ability_ids, ['dash_strike', 'evasive_maneuver', 'blade_flurry']);
+  // Expansion job sentinel: status='expansion' bubbled from YAML
+  const expansionIds = res.body.jobs
+    .filter((j) => j.status === 'expansion')
+    .map((j) => j.id)
+    .sort();
+  assert.deepEqual(expansionIds, ['aberrant', 'beastmaster', 'stalker', 'symbiont']);
 });
 
 test('GET /api/jobs/skirmisher ritorna abilities con cost + effect_type', async (t) => {
@@ -88,4 +101,84 @@ test('GET /api/jobs/nonexistent → 404 con error message', async (t) => {
   assert.equal(res.status, 404);
   assert.ok(res.body.error);
   assert.ok(res.body.error.includes('nonexistent'));
+});
+
+// EXPANSION jobs (data/core/jobs_expansion.yaml — wave 2026-04-25 sprint).
+// Loader merge additivo: 4 nuovi job + 48 perks (12/job).
+
+test('GET /api/jobs/stalker (expansion) ritorna 3 abilities con effect_type validi', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const res = await request(app).get('/api/jobs/stalker');
+  assert.equal(res.status, 200);
+  assert.equal(res.body.id, 'stalker');
+  assert.equal(res.body.status, 'expansion');
+  assert.equal(res.body.role, 'damage');
+  assert.equal(res.body.abilities.length, 3);
+  const ids = res.body.abilities.map((a) => a.ability_id);
+  assert.deepEqual(ids, ['alpha_strike', 'silent_step', 'deathmark']);
+});
+
+test('GET /api/jobs/symbiont (expansion) abilities + role support', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const res = await request(app).get('/api/jobs/symbiont');
+  assert.equal(res.status, 200);
+  assert.equal(res.body.status, 'expansion');
+  assert.equal(res.body.role, 'support');
+  const ids = res.body.abilities.map((a) => a.ability_id);
+  assert.deepEqual(ids, ['symbiotic_bond', 'shared_vitality', 'synaptic_burst']);
+});
+
+test('GET /api/jobs/beastmaster (expansion) abilities + role control', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const res = await request(app).get('/api/jobs/beastmaster');
+  assert.equal(res.status, 200);
+  assert.equal(res.body.status, 'expansion');
+  assert.equal(res.body.role, 'control');
+  const ids = res.body.abilities.map((a) => a.ability_id);
+  assert.deepEqual(ids, ['summon_companion', 'pack_command', 'feral_sacrifice']);
+});
+
+test('GET /api/jobs/aberrant (expansion) abilities + role damage', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const res = await request(app).get('/api/jobs/aberrant');
+  assert.equal(res.status, 200);
+  assert.equal(res.body.status, 'expansion');
+  assert.equal(res.body.role, 'damage');
+  const ids = res.body.abilities.map((a) => a.ability_id);
+  assert.deepEqual(ids, ['mutation_burst', 'phenotype_shift', 'aberrant_overdrive']);
+});
+
+test('progressionLoader.loadPerks() merges expansion perks (stalker level_2)', async () => {
+  const {
+    loadPerks,
+    resetProgressionCache,
+  } = require('../../apps/backend/services/progression/progressionLoader');
+  resetProgressionCache();
+  const perks = loadPerks();
+  assert.ok(perks.jobs, 'perks.jobs presente');
+  assert.ok(perks.jobs.stalker, 'stalker job perks merged');
+  assert.ok(perks.jobs.stalker.perks, 'stalker.perks normalized');
+  const lvl2 = perks.jobs.stalker.perks.level_2;
+  assert.ok(lvl2, 'stalker level_2 entry');
+  assert.ok(lvl2.perk_a && lvl2.perk_a.id, 'stalker level_2 perk_a.id');
+  assert.ok(lvl2.perk_b && lvl2.perk_b.id, 'stalker level_2 perk_b.id');
+  // Expansion perks coexist with base perks (skirmisher non rotto)
+  assert.ok(perks.jobs.skirmisher, 'base skirmisher perks ancora presenti');
+  assert.ok(perks.jobs.skirmisher.perks?.level_2?.perk_a?.id, 'skirmisher level_2 ancora intatto');
 });

--- a/tests/api/progressionEngine.test.js
+++ b/tests/api/progressionEngine.test.js
@@ -139,7 +139,9 @@ test('snapshot exposes jobs + thresholds', () => {
   const snap = engine.snapshot();
   assert.ok(snap.jobs.includes('skirmisher'));
   assert.ok(snap.jobs.includes('harvester'));
-  assert.equal(snap.jobs.length, 7);
+  // 7 base + 4 expansion (stalker/symbiont/beastmaster/aberrant) loaded by progressionLoader
+  assert.equal(snap.jobs.length, 11);
+  assert.ok(snap.jobs.includes('stalker'));
   assert.equal(snap.xp_max_level, 7);
   assert.equal(snap.xp_thresholds[2], 10);
 });

--- a/tests/api/progressionRoutes.test.js
+++ b/tests/api/progressionRoutes.test.js
@@ -53,7 +53,9 @@ test('GET /registry exposes thresholds + jobs', async (t) => {
   const res = await request('GET', `${url}/api/v1/progression/registry`);
   assert.equal(res.status, 200);
   assert.equal(res.body.xp_max_level, 7);
-  assert.equal(res.body.jobs.length, 7);
+  // 7 base + 4 expansion (stalker/symbiont/beastmaster/aberrant)
+  assert.equal(res.body.jobs.length, 11);
+  assert.ok(res.body.jobs.includes('stalker'));
   assert.equal(res.body.xp_thresholds[2], 10);
 });
 


### PR DESCRIPTION
## Summary

Wire jobs_expansion (4 nuovi job + 48 perks) a runtime via additive loader pattern.
Risolve gap shipped da PR autonomous content sprint 2026-04-25 (handoff doc cita "wire jobs_expansion in jobsLoader" come P0 next session).

### Changes

- `apps/backend/services/jobsLoader.js` — `loadJobs()` ora merge additivo `data/core/jobs_expansion.yaml`. Conflitto su jobId duplicato → base wins + warn log. Fallback ENOENT silente.
- `apps/backend/services/progression/progressionLoader.js` — `loadPerks()` normalize+merge `jobs_expansion.yaml.perks` in `data.jobs.<jobId>.perks` (mirror perks.yaml shape per jobs base). 48 perks expansion (4 job × 12).
- `tests/api/jobs.test.js` — count 7 → 11; +4 expansion job tests + 1 progressionLoader test.
- `docs/process/sprint-2026-04-25-parallel-validation.md` — report parallel-sprint validation (PR #1791/#1792/#1793 wave 6).

### API impact

- `GET /api/jobs` ritorna 11 job (7 base + 4 expansion).
- `GET /api/jobs/{stalker,symbiont,beastmaster,aberrant}` ritorna body con `status: 'expansion'` + 3 abilities.
- `progressionLoader.loadPerks().jobs.{stalker|...}.perks.level_2` ora popolato.

## Test plan

- [x] node -e "require('./apps/backend/services/jobsLoader').loadJobs()" → 11 jobs (verified manual smoke)
- [x] Expansion abilities loaded correttamente (alpha_strike/silent_step/deathmark + 3 altri × 3 jobs)
- [x] progressionLoader merges perks correctly (stalker level_2 perk_a/perk_b)
- [x] node --test tests/ai/*.test.js → 311/311 verde (no regression)
- [x] prettier --check pass su 3 file modificati
- [ ] CI: tests/api/jobs.test.js verde (locale npm install non disponibile in worktree → CI verifica)
- [ ] Master DD approval

## Closes

- Handoff TKT P0 #2: "Wire jobs_expansion in jobsLoader" — risolto.
- Sblocca PT3+ unlock condition (4 job expansion playable).

## Rollback plan

`git revert <merge-sha>` reverte i 3 loader changes + test. Datasets `data/core/jobs_expansion.yaml` e `data/core/jobs.yaml` non toccati. Zero schema drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)