### PR TITLE
feat(traits): Wave 6 manuale STEP 4 — +20 trait mechanics additivi

### DIFF
--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -2231,3 +2231,384 @@ traits:
       tributo cardiaco al sangue versato.
 
       '
+
+  # ============================================================================
+  # WAVE 6 manuale (sprint 2026-04-25 STEP 4) - 20 trait additivi
+  # 7 extra_damage + 8 damage_reduction + 5 apply_status
+  # Famiglie coperte: appendici / articolazioni / armatura / baffi / barbigli /
+  #                   barriere / batteri / biochip / bozzolo / branchie / bulbi /
+  #                   canto / coscienza / ghiandole / gusci / lamine / lingua /
+  #                   luminescenza / membrana / pelli
+  # ============================================================================
+
+  branchie_eoliche:
+    tier: T2
+    category: sensoriale
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: wind_read_precision
+    description_it: 'Branchie filtranti che leggono variazioni di pressione dell aria.
+
+      Su MoS >= 5 il bersaglio e anticipato in apertura: +1 PT.
+
+      '
+
+  articolazioni_a_leva_idraulica:
+    tier: T1
+    category: fisiologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      min_mos: 5
+      requires: posizione_sopraelevata
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: hydraulic_leverage
+    description_it: 'Articolazioni a pistoni idraulici amplificano la spinta.
+
+      Attacco da posizione sopraelevata con MoS >= 5: +1 PT.
+
+      '
+
+  coscienza_d_alveare_diffusa:
+    tier: T3
+    category: mentale
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 3
+      requires_ally_adjacent: true
+    effect:
+      kind: extra_damage
+      amount: 2
+      log_tag: hivemind_focus
+    description_it: 'Rete sinaptica inter-individuo temporanea: alleato adiacente
+
+      amplifica il colpo. MoS >= 3 con alleato in Manhattan 1: +2 PT.
+
+      '
+
+  baffi_mareomotori:
+    tier: T2
+    category: sensoriale
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: tidal_whisker_lock
+    description_it: 'Baffi sensori che leggono microcorrenti d acqua e aria.
+
+      Lettura precoce del movimento: MoS >= 5: +1 PT.
+
+      '
+
+  barbigli_sensori_plasma:
+    tier: T2
+    category: sensoriale
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: extra_damage
+      amount: 2
+      log_tag: plasma_barbel_precision
+    description_it: 'Barbigli sensori al plasma estraggono dati elettrici dal target.
+
+      MoS >= 5 entra nel punto debole bioelettrico: +2 PT.
+
+      '
+
+  biochip_memoria:
+    tier: T2
+    category: mentale
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      requires_target_status: bleeding
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: memory_canalization
+    description_it: 'Chip biologico che canalizza pattern di danno precedenti.
+
+      Se target ha bleeding attivo, il colpo successivo +1 PT.
+
+      '
+
+  lingua_cristallina:
+    tier: T2
+    category: sensoriale
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 8
+    effect:
+      kind: extra_damage
+      amount: 2
+      log_tag: crystal_tongue_strike
+    description_it: 'Lingua cristallina che amplifica le micro-vibrazioni del bersaglio.
+
+      MoS >= 8 (critico): +2 PT da risonanza.
+
+      '
+
+  gusci_criovetro:
+    tier: T2
+    category: difensivo
+    applies_to: target
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: damage_reduction
+      amount: 1
+      min: 0
+      log_tag: cryoglass_buffer
+    description_it: 'Gusci di criovetro disperdono l impatto in micro-fratture stabilizzate.
+
+      Ogni hit subisce -1 PT.
+
+      '
+
+  lamine_filtranti_aeree:
+    tier: T1
+    category: difensivo
+    applies_to: target
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: damage_reduction
+      amount: 1
+      min: 0
+      log_tag: aerial_filter
+    description_it: 'Lamine filtranti distribuiscono carichi aerei sul corpo.
+
+      Ogni hit subisce -1 PT per dispersione strutturale.
+
+      '
+
+  luminescenza_aurorale:
+    tier: T2
+    category: difensivo
+    applies_to: target
+    trigger:
+      action_type: attack
+      on_result: hit
+      melee_only: true
+    effect:
+      kind: damage_reduction
+      amount: 1
+      min: 0
+      log_tag: auroral_dazzle
+    description_it: 'Luminescenza aurorale ad alta intensita abbaglia in mischia.
+
+      Attacchi melee subiscono -1 PT per riflesso difensivo.
+
+      '
+
+  membrana_plastica_continua:
+    tier: T2
+    category: difensivo
+    applies_to: target
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: damage_reduction
+      amount: 1
+      min: 0
+      log_tag: plastic_membrane
+    description_it: 'Membrana plastica che assume forme su pressione locale.
+
+      Ogni hit dissipa -1 PT in deformazione.
+
+      '
+
+  pelli_cave:
+    tier: T1
+    category: difensivo
+    applies_to: target
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: damage_reduction
+      amount: 1
+      min: 0
+      log_tag: hollow_skin
+    description_it: 'Tessuti cutanei porosi con sacche d aria interne.
+
+      Barriera termica + riduzione impatto: -1 PT su hit.
+
+      '
+
+  appendici_risonanti_marea:
+    tier: T2
+    category: difensivo
+    applies_to: target
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: damage_reduction
+      amount: 1
+      min: 0
+      log_tag: tidal_resonance
+    description_it: 'Appendici risonanti dispergono energia in onde mareali interne.
+
+      Ogni hit subisce -1 PT per riflusso oscillante.
+
+      '
+
+  armatura_pietra_planare:
+    tier: T3
+    category: difensivo
+    applies_to: target
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: damage_reduction
+      amount: 2
+      min: 0
+      log_tag: planar_stone_armor
+    description_it: 'Corazza scolpita da roccia extradimensionale ad alta densita.
+
+      Assorbimento massiccio: -2 PT su ogni hit.
+
+      '
+
+  bozzolo_magnetico:
+    tier: T2
+    category: difensivo
+    applies_to: target
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: damage_reduction
+      amount: 1
+      min: 0
+      log_tag: magnetic_cocoon
+    description_it: 'Bozzolo magnetico devia proiettili e energia elettromagnetica.
+
+      Ogni hit subisce -1 PT per deflessione.
+
+      '
+
+  canto_infrasonico_tattico:
+    tier: T2
+    category: comportamentale
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: apply_status
+      target_side: target
+      stato: panic
+      turns: 1
+      log_tag: infrasound_disorient
+    description_it: 'Canto infrasonico ad alta pressione disorienta il bersaglio.
+
+      MoS >= 5: panic 1 turno.
+
+      '
+
+  ghiandole_cambio_salino:
+    tier: T2
+    category: fisiologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: apply_status
+      target_side: target
+      stato: bleeding
+      turns: 2
+      log_tag: salt_glandular_burn
+    description_it: 'Ghiandole di scambio salino rilasciano sale ipertonico al contatto.
+
+      MoS >= 5: bleeding 2 turni per shock osmotico.
+
+      '
+
+  barriere_miasma_glaciale:
+    tier: T2
+    category: fisiologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 8
+    effect:
+      kind: apply_status
+      target_side: target
+      stato: stunned
+      turns: 1
+      log_tag: glacial_miasma
+    description_it: 'Miasma glaciale rilascia microcristalli di ghiaccio.
+
+      MoS >= 8: stunned 1 turno per shock termico.
+
+      '
+
+  batteri_termofili_endosimbiosi:
+    tier: T2
+    category: fisiologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      on_kill: true
+    effect:
+      kind: apply_status
+      target_side: actor
+      stato: rage
+      turns: 1
+      log_tag: thermophile_surge
+    description_it: 'Batteri termofili endosimbiotici rilasciano calore post-kill.
+
+      on_kill: rage 1 turno per surge metabolico.
+
+      '
+
+  bulbi_radici_permafrost:
+    tier: T2
+    category: fisiologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      on_kill: true
+    effect:
+      kind: apply_status
+      target_side: actor
+      stato: rage
+      turns: 2
+      log_tag: permafrost_warmth
+    description_it: 'Bulbi radice rilasciano calore al kill, attivando surge.
+
+      on_kill: rage 2 turni per ridistribuzione termica.
+
+      '


### PR DESCRIPTION
## Summary

Sprint 2026-04-25 STEP 4 (post-merge handoff): porta `active_effects.yaml` da **120 → 140** trait mechanics additivi (+20 entries, 0 cross-ref unresolved).

### Distribuzione

| kind             | count | esempio                                                  |
| ---------------- | ----- | -------------------------------------------------------- |
| extra_damage     | 7     | branchie_eoliche, articolazioni_a_leva_idraulica, ...    |
| damage_reduction | 8     | gusci_criovetro, armatura_pietra_planare, pelli_cave ... |
| apply_status     | 5     | canto_infrasonico_tattico (panic), ghiandole_cambio_salino (bleeding), barriere_miasma_glaciale (stunned), batteri_termofili_endosimbiosi (rage on_kill), bulbi_radici_permafrost (rage on_kill) |

### Famiglie coperte (20 nuove)

`appendici` · `articolazioni` · `armatura` · `baffi` · `barbigli` · `barriere` · `batteri` · `biochip` · `bozzolo` · `branchie` · `bulbi` · `canto` · `coscienza` · `ghiandole` · `gusci` · `lamine` · `lingua` · `luminescenza` · `membrana` · `pelli`

Una entry per famiglia (coverage uniforme).

## Test plan

- [x] Schema validation: 120 → 140 entries, 0 missing in glossary
- [x] Loader smoke: `traitEffects.loadActiveTraitRegistry()` → 140
- [x] AI test: `node --test tests/ai/*.test.js` → 311/311 verde
- [x] Prettier: pass `--check`
- [x] Encoding UTF-8: 0 mojibake (verified via grep `Ã`)
- [x] Italian field name `stato:` (PR #1792 convention)
- [ ] CI: governance + dataset-checks (auto)

## Closes

STEP 4 from `docs/planning/2026-04-25-parallel-sprint-jobs-wire-handoff.md` — Content wave 6 manuale ~20 trait residui (additive bookmark).

Sprint counter post-merge: trait mechanics 111 → **140** (+29 questa sessione totale).

## Rollback plan

`git revert <merge-sha>` reverte solo data additive. Zero cambi runtime / schema / contracts. Reverso totale pulito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)