### PR TITLE
docs(core): SOURCE-OF-TRUTH §13.4 — fix P4 Ennea false claim (audit-driven)

### DIFF
--- a/docs/core/00-SOURCE-OF-TRUTH.md
+++ b/docs/core/00-SOURCE-OF-TRUTH.md
@@ -633,7 +633,7 @@ Implementato in `apps/backend/services/statusEffectsMachine.js` come FSM xstate 
 
 **6 archetipi Ennea** (condizionali su metriche): Conquistatore(3), Coordinatore(2), Esploratore(7), Architetto(5), Stoico(9), Cacciatore(8). Trigger: espressioni condizionali in `telemetry.yaml`.
 
-**Effetti Ennea** (`enneaEffects.js`): mappano archetipi a buff combat (attack_mod, defense_mod, move_bonus, stress_reduction, evasion_bonus). Applicati dopo ogni round.
+**Effetti Ennea** (`enneaEffects.js`): mappano archetipi a buff combat (attack_mod, defense_mod, move_bonus, stress_reduction, evasion_bonus). ⚠️ **Wire pending** — modulo orfano canonico (93 LOC, mai `require`/`import`). Vedi card museum [M-2026-04-25-006](../museum/cards/enneagramma-enneaeffects-orphan.md). Coverage 6/9 archetipi. Effort wire ~5-6h (`buildVcSnapshot` per-round refactor pre-req).
 
 **16 Forme YAML** (`data/core/forms/mbti_forms.yaml`): tipo MBTI → assi baseline, affinità Job, penalità.
 
@@ -696,26 +696,26 @@ Pattern Bevy-inspired (V1). Plugin attivi: `narrativePlugin` (monta route narrat
 
 ### 13.8 Mappa design → codice
 
-| Sezione design             | Modulo implementato                                       | Stato                                 |
-| -------------------------- | --------------------------------------------------------- | ------------------------------------- |
-| §1 Tesi / Combat           | `roundOrchestrator.js`, `resolver.py`                     | Operativo                             |
-| §2 Prima partita           | `enc_tutorial_01.yaml` + session engine                   | Definito, non giocabile end-to-end    |
-| §3 Worldgen                | `biomes.yaml`, ecosystems, foodwebs                       | Dati completi, generatore non runtime |
-| §4 Foodweb                 | Validators + data YAML                                    | Validazione completa, non runtime     |
-| §5 Specie/Trait/Job/Forme  | `species.yaml`, `trait_mechanics.yaml`, `mbti_forms.yaml` | Dati + hydration operativi            |
-| §6 TV + companion          | Design docs                                               | Solo design, nessun frontend          |
-| §7 Narrativa               | `narrativeEngine.js` + inkjs                              | Engine operativo, contenuti minimi    |
-| §8 Mappa 4 livelli         | —                                                         | Framework concettuale                 |
-| §10 Meta-loop Nido         | `mating.yaml`, `27-MATING_NIDO.md`                        | Solo dati, non implementato           |
-| VC/MBTI/Ennea              | `vcScoring.js`, `enneaEffects.js`                         | Operativo (P4 completo)               |
-| AI SIS                     | `policy.js`, `declareSistemaIntents.js`                   | Operativo, data-driven                |
-| Status system              | `statusEffectsMachine.js`                                 | Operativo (xstate v5)                 |
-| §14 Grid & Map             | `hexGrid.js` + `terrain_defense.yaml` v0.2                | 🟢 Engine operativo, 23 test          |
-| §15 Level Design           | `encounter.schema.json` + 3 encounter YAML                | 🟢 Schema + dati validati             |
-| §16 Networking/Co-op       | ADR Colyseus (proposto)                                   | 🟡 ADR proposto, non implementato     |
-| §17 Screen Flow            | `17-SCREEN_FLOW.md` (mermaid)                             | ✅ Formalizzato                       |
-| §18 Audience/Accessibilità | —                                                         | 🟡 Proposte, attesa Master DD         |
-| §19 Decisioni GDD          | 28 domande                                                | 12✅ 9🟡 7🔴                          |
+| Sezione design             | Modulo implementato                                       | Stato                                                                                                       |
+| -------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| §1 Tesi / Combat           | `roundOrchestrator.js`, `resolver.py`                     | Operativo                                                                                                   |
+| §2 Prima partita           | `enc_tutorial_01.yaml` + session engine                   | Definito, non giocabile end-to-end                                                                          |
+| §3 Worldgen                | `biomes.yaml`, ecosystems, foodwebs                       | Dati completi, generatore non runtime                                                                       |
+| §4 Foodweb                 | Validators + data YAML                                    | Validazione completa, non runtime                                                                           |
+| §5 Specie/Trait/Job/Forme  | `species.yaml`, `trait_mechanics.yaml`, `mbti_forms.yaml` | Dati + hydration operativi                                                                                  |
+| §6 TV + companion          | Design docs                                               | Solo design, nessun frontend                                                                                |
+| §7 Narrativa               | `narrativeEngine.js` + inkjs                              | Engine operativo, contenuti minimi                                                                          |
+| §8 Mappa 4 livelli         | —                                                         | Framework concettuale                                                                                       |
+| §10 Meta-loop Nido         | `mating.yaml`, `27-MATING_NIDO.md`                        | Solo dati, non implementato                                                                                 |
+| VC/MBTI/Ennea              | `vcScoring.js`, `enneaEffects.js`                         | 🟡 VC + MBTI operativi · Ennea effects orphan ([M-006](../museum/cards/enneagramma-enneaeffects-orphan.md)) |
+| AI SIS                     | `policy.js`, `declareSistemaIntents.js`                   | Operativo, data-driven                                                                                      |
+| Status system              | `statusEffectsMachine.js`                                 | Operativo (xstate v5)                                                                                       |
+| §14 Grid & Map             | `hexGrid.js` + `terrain_defense.yaml` v0.2                | 🟢 Engine operativo, 23 test                                                                                |
+| §15 Level Design           | `encounter.schema.json` + 3 encounter YAML                | 🟢 Schema + dati validati                                                                                   |
+| §16 Networking/Co-op       | ADR Colyseus (proposto)                                   | 🟡 ADR proposto, non implementato                                                                           |
+| §17 Screen Flow            | `17-SCREEN_FLOW.md` (mermaid)                             | ✅ Formalizzato                                                                                             |
+| §18 Audience/Accessibilità | —                                                         | 🟡 Proposte, attesa Master DD                                                                               |
+| §19 Decisioni GDD          | 28 domande                                                | 12✅ 9🟡 7🔴                                                                                                |
 
 ---
 
@@ -1239,13 +1239,13 @@ La Tri-Sorgente è il ponte tra:
 
 ### 20.4 Stato implementativo
 
-| Componente         | Stato                                                            |
-| ------------------ | ---------------------------------------------------------------- |
-| Offerta 3 carte    | Non implementato. Richiede UI companion + integrazione vcScoring |
-| Sorgente contesto  | Dati disponibili (biomes.yaml, encounter context)                |
-| Sorgente identità  | Operativo (vcScoring.js, deriveMbtiType, enneaEffects)           |
-| Sorgente azioni    | Operativo (raw event tracking in session engine)                 |
-| Frammenti Genetici | Non implementato. Schema valuta da definire                      |
+| Componente         | Stato                                                                 |
+| ------------------ | --------------------------------------------------------------------- |
+| Offerta 3 carte    | Non implementato. Richiede UI companion + integrazione vcScoring      |
+| Sorgente contesto  | Dati disponibili (biomes.yaml, encounter context)                     |
+| Sorgente identità  | 🟡 vcScoring + deriveMbtiType operativi · enneaEffects orphan (M-006) |
+| Sorgente azioni    | Operativo (raw event tracking in session engine)                      |
+| Frammenti Genetici | Non implementato. Schema valuta da definire                           |
 
 ---
 


### PR DESCRIPTION
## Summary

Audit-driven SOURCE-OF-TRUTH correction following museum card [M-2026-04-25-006](docs/museum/cards/enneagramma-enneaeffects-orphan.md) (delivered by repo-archaeologist [PR #1796](https://github.com/MasterDD-L34D/Game/pull/1796)).

## Drift detected

`apps/backend/services/enneaEffects.js` (PR #1433, 2026-04-16) is a **canonical orphan**: 93 LOC, zero `require/import`. The SOURCE-OF-TRUTH claimed P4 was \"complete\" and Ennea effects \"applied after every round\" — both **false** at runtime.

## Changes

3 fixes in `docs/core/00-SOURCE-OF-TRUTH.md`:

| Line | Before | After |
|---|---|---|
| §13.4 (l. 636) | \"Applicati dopo ogni round\" | \"⚠️ Wire pending\" + ref M-006 |
| §13 stato (l. 710) | \"Operativo (P4 completo)\" | \"🟡 VC+MBTI ok · Ennea effects orphan\" |
| §20.4 (l. 1246) | \"Sorgente identità Operativo\" | \"🟡 ... orphan (M-006)\" |

## Why doc-only (not wire fix)

Card M-006 audit-revised wire effort 2h → **5-6h** real:
- Pre-req: `buildVcSnapshot` per-round mode refactor (today only end-session)
- `unit.ennea_archetypes` not populated on units state — lives only in `vcSnapshot.per_actor[uid]`
- Hot path combat = high blast radius — needs explicit user buy-in + 5-6h focused session

Doc fix unblocks **anti-pattern guard**: next agent reading §13.4 sees P4 = 🟡 real, not 🟢 aspirational.

## Test plan

- [x] `python tools/check_docs_governance.py --strict` → 0 errors / 0 warnings
- [x] `npx prettier --check docs/core/00-SOURCE-OF-TRUTH.md` → verde
- [x] Zero runtime impact (doc-only)

## Rollback

\`git revert <sha>\` — single commit, doc-only.

## Follow-up (not in this PR)

- M-006 wire effort: ~5-6h tracked in card. Skiv Sprint C path quando user decide priority.
- M-002 registry hooks (16 stub) integration: dipende M-006 wire chiuso.
- OD-007 \"Ennea source canonical\" — card propone hybrid (pack encyclopedia + data/core/ runtime + sync script). User decision pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)