### PR TITLE
feat(species): OD-008 sentience_tier backfill ALL 45 species (full sweep)

### DIFF
--- a/data/core/species.yaml
+++ b/data/core/species.yaml
@@ -63,6 +63,7 @@ species:
     genus: Arenavenator
     epithet: vagans
     clade_tag: Threat
+    sentience_tier: T2
     display_name_it: Predatore delle Dune
     display_name_en: Dune Stalker
     display_name: Dune Stalker
@@ -101,6 +102,7 @@ species:
     genus: Synaptopus
     epithet: praeco
     clade_tag: Keystone
+    sentience_tier: T5
     display_name_it: Polpo Araldo Sinaptico
     display_name_en: Synaptic Herald Octopus
     display_name: Polpo Araldo Sinaptico
@@ -124,6 +126,7 @@ species:
     genus: Neurolarva
     epithet: gregaria
     clade_tag: Threat
+    sentience_tier: T0
     display_name_it: Sciame di Larve Neurali
     display_name_en: Neural Larva Swarm
     display_name: Sciame di Larve Neurali
@@ -147,6 +150,7 @@ species:
     genus: Resonoleviathan
     epithet: abyssalis
     clade_tag: Apex
+    sentience_tier: T5
     display_name_it: Leviatano Risonante
     display_name_en: Resonant Leviathan
     display_name: Leviatano Risonante
@@ -170,6 +174,7 @@ species:
     genus: Corallosymbion
     epithet: speculans
     clade_tag: Support
+    sentience_tier: T3
     display_name_it: Simbionte Corallino Riflesso
     display_name_en: Mirror Coral Symbiont
     display_name: Simbionte Corallino Riflesso
@@ -193,6 +198,7 @@ species:
     genus: Anguimagnus
     epithet: litoralis
     clade_tag: Bridge
+    sentience_tier: T1
     display_name_it: Anguilla Magnetica
     display_name_en: Magnetic Eel
     display_name: Anguis Magnetica
@@ -221,6 +227,7 @@ species:
     genus: Chemnotela
     epithet: toxifera
     clade_tag: Threat
+    sentience_tier: T2
     display_name_it: Tessitrice Tossica
     display_name_en: Toxic Weaver
     display_name: Chemnotela Toxica
@@ -249,6 +256,7 @@ species:
     genus: Elastovaranus
     epithet: hydraulicus
     clade_tag: Playable
+    sentience_tier: T2
     display_name_it: Varano Idraulico Elastico
     display_name_en: Hydraulic Elastic Varan
     display_name: Elastovaranus Hydrus
@@ -277,6 +285,7 @@ species:
     genus: Gulogluteus
     epithet: scutiger
     clade_tag: Playable
+    sentience_tier: T2
     display_name_it: Scudo Roccioso Prensile
     display_name_en: Prehensile Rock Shield
     display_name: Gulogluteus Scutiger
@@ -305,6 +314,7 @@ species:
     genus: Perfusuas
     epithet: subterraneus
     clade_tag: Bridge
+    sentience_tier: T1
     display_name_it: Miriapode delle Cripte
     display_name_en: Crypt Myriapod
     display_name: Perfusuas Pedes
@@ -333,6 +343,7 @@ species:
     genus: Proteoplasma
     epithet: amoebiforme
     clade_tag: Playable
+    sentience_tier: T0
     display_name_it: Plasma Proteico
     display_name_en: Protean Plasma
     display_name: Proteus Plasma
@@ -361,6 +372,7 @@ species:
     genus: Rupicapra
     epithet: sensoria
     clade_tag: Keystone
+    sentience_tier: T5
     display_name_it: Stambecco Sensoriale
     display_name_en: Sensory Ibex
     display_name: Rupicapra Sensoria
@@ -389,6 +401,7 @@ species:
     genus: Soniptera
     epithet: resonans
     clade_tag: Threat
+    sentience_tier: T2
     display_name_it: Ala Risonante
     display_name_en: Resonant Wing
     display_name: Soniptera Resonans
@@ -417,6 +430,7 @@ species:
     genus: Terracetus
     epithet: ambulator
     clade_tag: Keystone
+    sentience_tier: T3
     display_name_it: Cetaceo Terrestre
     display_name_en: Walking Cetacean
     display_name: Terracetus Ambulator
@@ -445,6 +459,7 @@ species:
     genus: Umbralaris
     epithet: silens
     clade_tag: Playable
+    sentience_tier: T3
     display_name_it: Ala d'Ombra
     display_name_en: Shadow Wing
     display_name: Umbra Alaris

--- a/data/core/species_expansion.yaml
+++ b/data/core/species_expansion.yaml
@@ -8,6 +8,7 @@ species_examples:
     genus: Arenavolux
     epithet: sagittalis
     clade_tag: Apex
+    sentience_tier: T2
     display_name_it: "Saettatore delle Dune"
     display_name_en: "Dune Skiver"
     morph_slots:
@@ -25,6 +26,7 @@ species_examples:
     genus: Ferriscroba
     epithet: detrita
     clade_tag: Keystone
+    sentience_tier: T1
     display_name_it: "Spazzino Ferroso"
     display_name_en: "Rust Scavenger"
     morph_slots:
@@ -42,6 +44,7 @@ species_examples:
     genus: Sonapteryx
     epithet: resonans
     clade_tag: Bridge
+    sentience_tier: T2
     display_name_it: "Ala Risonante"
     display_name_en: "Echo Wing"
     morph_slots:
@@ -59,6 +62,7 @@ species_examples:
     genus: Lithoraptor
     epithet: acutornis
     clade_tag: Threat
+    sentience_tier: T1
     display_name_it: "Cacciatore di Schegge"
     display_name_en: "Shard Prowler"
     morph_slots:
@@ -76,6 +80,7 @@ species_examples:
     genus: Salifossa
     epithet: tenebris
     clade_tag: Keystone
+    sentience_tier: T1
     display_name_it: "Scavatore Salino"
     display_name_en: "Salt Burrower"
     morph_slots:
@@ -93,6 +98,7 @@ species_examples:
     genus: Ventornis
     epithet: longiala
     clade_tag: Bridge
+    sentience_tier: T1
     display_name_it: "Aliante della Mesa"
     display_name_en: "Mesa Glider"
     morph_slots:
@@ -110,6 +116,7 @@ species_examples:
     genus: Ferrimordax
     epithet: rutilus
     clade_tag: Apex
+    sentience_tier: T2
     display_name_it: "Martellatore Ferroso"
     display_name_en: "Iron Mauler"
     morph_slots:
@@ -127,6 +134,7 @@ species_examples:
     genus: Pyrosaltus
     epithet: celeris
     clade_tag: Threat
+    sentience_tier: T1
     display_name_it: "Saltatore di Cenere"
     display_name_en: "Cinder Leaper"
     morph_slots:
@@ -144,6 +152,7 @@ species_examples:
     genus: Basaltocara
     epithet: scutata
     clade_tag: Support
+    sentience_tier: T1
     display_name_it: "Custode di Basalto"
     display_name_en: "Basalt Warden"
     morph_slots:
@@ -161,6 +170,7 @@ species_examples:
     genus: Arenaceros
     epithet: placidus
     clade_tag: Keystone
+    sentience_tier: T1
     display_name_it: "Brucatore di Polvere"
     display_name_en: "Dust Grazer"
     morph_slots:
@@ -178,6 +188,7 @@ species_examples:
     genus: Lucinerva
     epithet: filata
     clade_tag: Bridge
+    sentience_tier: T2
     display_name_it: "Tessitore di Luce"
     display_name_en: "Lumen Weaver"
     morph_slots:
@@ -195,6 +206,7 @@ species_examples:
     genus: Radiluma
     epithet: pendula
     clade_tag: Support
+    sentience_tier: T2
     display_name_it: "Lanterna di Radici"
     display_name_en: "Root Lantern"
     morph_slots:
@@ -212,6 +224,7 @@ species_examples:
     genus: Limnofalcis
     epithet: serrata
     clade_tag: Threat
+    sentience_tier: T1
     display_name_it: "Trebbiatore di Palude"
     display_name_en: "Mire Thresher"
     morph_slots:
@@ -229,6 +242,7 @@ species_examples:
     genus: Cavatympa
     epithet: sonans
     clade_tag: Bridge
+    sentience_tier: T2
     display_name_it: "Ascoltatore Cavo"
     display_name_en: "Hollow Listener"
     morph_slots:
@@ -246,6 +260,7 @@ species_examples:
     genus: Calamipes
     epithet: gracilis
     clade_tag: Playable
+    sentience_tier: T1
     display_name_it: "Camminatore di Canne"
     display_name_en: "Reed Strider"
     morph_slots:
@@ -263,6 +278,7 @@ species_examples:
     genus: Salisucta
     epithet: alveata
     clade_tag: Keystone
+    sentience_tier: T1
     display_name_it: "Filtratore Salmastro"
     display_name_en: "Brine Filter"
     morph_slots:
@@ -280,6 +296,7 @@ species_examples:
     genus: Nebulocornis
     epithet: mollis
     clade_tag: Support
+    sentience_tier: T1
     display_name_it: "Cervo di Nebbia"
     display_name_en: "Fog Antler"
     morph_slots:
@@ -297,6 +314,7 @@ species_examples:
     genus: Cryptolorca
     epithet: medicata
     clade_tag: Keystone
+    sentience_tier: T2
     display_name_it: "Riparatore Carsico"
     display_name_en: "Karst Mender"
     morph_slots:
@@ -314,6 +332,7 @@ species_examples:
     genus: Glaciolabis
     epithet: nitida
     clade_tag: Bridge
+    sentience_tier: T1
     display_name_it: "Pattinatore Specchio"
     display_name_en: "Mirror Skater"
     morph_slots:
@@ -331,6 +350,7 @@ species_examples:
     genus: Tonitrudens
     epithet: ferox
     clade_tag: Threat
+    sentience_tier: T1
     display_name_it: "Rosicchiatore di Tuono"
     display_name_en: "Thunder Gnawer"
     morph_slots:
@@ -348,6 +368,7 @@ species_examples:
     genus: Rubrospina
     epithet: velox
     clade_tag: Playable
+    sentience_tier: T1
     display_name_it: "Corriere Spinato"
     display_name_en: "Spurback Courier"
     morph_slots:
@@ -365,6 +386,7 @@ species_examples:
     genus: Paludogromus
     epithet: magnus
     clade_tag: Keystone
+    sentience_tier: T1
     display_name_it: "Colosso Palustre"
     display_name_en: "Fen Colossus"
     morph_slots:
@@ -382,6 +404,7 @@ species_examples:
     genus: Cinerastra
     epithet: nodosa
     clade_tag: Threat
+    sentience_tier: T1
     display_name_it: "Spirale di Cenere"
     display_name_en: "Ash Coil"
     morph_slots:
@@ -399,6 +422,7 @@ species_examples:
     genus: Zephyrovum
     epithet: fidelis
     clade_tag: Bridge
+    sentience_tier: T1
     display_name_it: "Nidificatore del Maestrale"
     display_name_en: "Mistral Nester"
     morph_slots:
@@ -416,6 +440,7 @@ species_examples:
     genus: Vitricyba
     epithet: punctata
     clade_tag: Threat
+    sentience_tier: T1
     display_name_it: "Beccatore di Vetro"
     display_name_en: "Glass Peck"
     morph_slots:
@@ -433,6 +458,7 @@ species_examples:
     genus: Fumarisorba
     epithet: sulfurea
     clade_tag: Keystone
+    sentience_tier: T1
     display_name_it: "Bevitore di Fumarole"
     display_name_en: "Fumarole Drinker"
     morph_slots:
@@ -450,6 +476,7 @@ species_examples:
     genus: Arboryxis
     epithet: lenis
     clade_tag: Bridge
+    sentience_tier: T1
     display_name_it: "Vagabondo della Volta"
     display_name_en: "Canopy Drifter"
     morph_slots:
@@ -467,6 +494,7 @@ species_examples:
     genus: Noctipedis
     epithet: umbrata
     clade_tag: Apex
+    sentience_tier: T2
     display_name_it: "Corridore Notturno"
     display_name_en: "Night Loper"
     morph_slots:
@@ -484,6 +512,7 @@ species_examples:
     genus: Magnetocola
     epithet: pastoris
     clade_tag: Support
+    sentience_tier: T2
     display_name_it: "Pastore Ferrico"
     display_name_en: "Ferric Shepherd"
     morph_slots:
@@ -501,6 +530,7 @@ species_examples:
     genus: Siltovena
     epithet: bifida
     clade_tag: Threat
+    sentience_tier: T1
     display_name_it: "Divisore del Delta"
     display_name_en: "Delta Splitter"
     morph_slots:


### PR DESCRIPTION
## Summary

Closes OD-008 user override 2026-04-25 sera ([PR #1807](https://github.com/MasterDD-L34D/Game/pull/1807)). Backfill `sentience_tier` field on ALL 45 species in single PR, sweeping schema enum drift (`schemas/core/enums.json:15-18` defined T0-T6 6 mesi fa, zero species adoption).

## Heuristic mapping

| Tier | Criteria | Count |
|---|---|---|
| **T0** Reactive automata | swarm/larva, no synergies | 2 |
| **T1** Reflex animals | simple Threat baseline | 23 |
| **T2** Learning animals | standard Threat/Keystone, full trait_plan | 14 |
| **T3** Social/cooperative | synergy_hints + mutualism | 3 |
| **T4** Apex sapient | clade Apex + complex (none currently match) | 0 |
| **T5** Communicative/network | synaptic/sonoro/coscienza_alveare keywords | 3 |
| **T6** Sentient NPG-eligible | explicit sentient markers (none yet) | 0 |
| **Total** | | **45** ✅ |

## Examples

- `sciame_larve_neurali` (swarm) → **T0**
- `dune_stalker` (Threat baseline) → **T2**
- `polpo_araldo_sinaptico` (Synaptopus praeco, sinaptico) → **T5**
- `leviatano_risonante` (Apex + risonante communicative) → **T5**
- `simbionte_corallino_riflesso` (Support symbiont) → **T3**

## Uncertain assignments (user review welcome)

- `rupicapra_sensoria` → T5 (coscienza_alveare_diffusa keyword) vs possibile T4
- Expansion Apex (sagittalis/rutilus/noctipedis) → T2 (minimal data — apex w/o synergy_hints lookup)
- `terracetus_ambulator`/`umbra_alaris` → T3 (canto/comunicazione cooperative ma non network-scale)

## Test plan

- [x] `python tools/check_docs_governance.py --strict` → 0 errors / 0 warnings
- [x] `python3 tools/py/game_cli.py validate-datasets` → 14 controlli, 0 avvisi
- [x] `npm run schema:lint` → All schemas pass structural validation
- [x] `node --test tests/ai/*.test.js` → **311/311 pass** (>307 baseline, +4 from recent merges)
- [x] Diff: 2 files, 45 insertions, additive only, no key reorder

## Rollback

\`git revert <sha>\` — single commit. Schema enum already live, additive only.

## Follow-up

- OD-011 ancestors recovery (~15-20h, gated zip locate)
- OD-012 swarm batch 5-10 trait (~10h)

🤖 Generated with [Claude Code](https://claude.com/claude-code)