### PR TITLE
feat(swarm): OD-012 magnetic_rift_resonance promoted from staging (single trait, pool limited)

### DIFF
--- a/apps/backend/services/combat/biomeResonance.js
+++ b/apps/backend/services/combat/biomeResonance.js
@@ -36,7 +36,7 @@ const BIOME_FAMILIES = {
   cold: ['cryosteppe', 'tundra', 'ghiacciaio', 'alpino'],
   forest: ['foresta_temperata', 'foresta_tropicale', 'giungla'],
   desert: ['deserto_caldo', 'badlands', 'saline', 'aride'],
-  aquatic: ['acquatico_costiero', 'palude', 'lagunare', 'corallino'],
+  aquatic: ['acquatico_costiero', 'palude', 'lagunare', 'corallino', 'atollo_obsidiana'],
   deep: ['frattura_abissale_sinaptica', 'caverna', 'grotta_bioluminescente', 'abissale'],
 };
 
@@ -64,6 +64,10 @@ const BIOME_ARCHETYPE_AFFINITY = {
   lagunare: 'support',
   corallino: 'support',
   grotta_bioluminescente: 'support',
+  // Swarm batch OD-012 (2026-04-25) — atollo magnetico, archetype skirmisher
+  // (raids EMP + piattaforme mobili = mobility-first). Vedi
+  // docs/museum/cards/old_mechanics-magnetic-rift-resonance.md.
+  atollo_obsidiana: 'skirmisher',
 };
 
 const TIER_LABELS = {

--- a/data/core/biome_aliases.yaml
+++ b/data/core/biome_aliases.yaml
@@ -58,3 +58,7 @@ aliases:
     canonical: frattura_abissale_sinaptica
     status: expansion
     notes: "Alias T1 legato alle creste superficiali luminescenti del nuovo bioma."
+  atollo_ossidiana:
+    canonical: atollo_obsidiana
+    status: alias
+    notes: "Variante ortografica IT (doppia 's') usata dal swarm trait-curator (artifact 2026-04-24). Promosso OD-012 2026-04-25."

--- a/data/core/biomes.yaml
+++ b/data/core/biomes.yaml
@@ -99,6 +99,11 @@ biomes:
     summary: Arcipelago magnetico con maree EMP e piattaforme mobili.
     diff_base: 4
     mod_biome: 3
+    # Flag added 2026-04-25 (swarm batch OD-012 promotion). Consumed by
+    # magnetic_rift_resonance trait biome_affinity (data/core/traits/
+    # active_effects.yaml). Range 0.0–1.0; 1.0 = full magnetic field
+    # (canonical atollo). Other biomes default 0.0 (no flag = no resonance).
+    magnetic_field_strength: 1.0
     affixes:
     - resonance_tide
     - shard_storm

--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -2612,3 +2612,91 @@ traits:
       on_kill: rage 2 turni per ridistribuzione termica.
 
       '
+
+  # ── Swarm batch OD-012 (promosso 2026-04-25 da incoming/swarm-candidates/) ──
+  # Provenance: dafne_swarm trait-curator artifact
+  # 2026-04-24T01-08-27.414378.json. Card spec:
+  # docs/museum/cards/old_mechanics-magnetic-rift-resonance.md (P0 minimal path).
+  #
+  # NOTE runtime: il trigger originale del swarm usava action_type=support +
+  # condizione_ambientale (biome_class). L'evaluator corrente
+  # (apps/backend/services/traitEffects.js passesBasicTriggers) supporta solo
+  # action_type=attack. Trigger qui sotto e' stato adattato a action_type=attack
+  # con min_mos alto + on_kill per limitare la firing-rate al boss-finish.
+  # Esposizione canonica del trait + ladder T2 e' il deliverable P0;
+  # l'evaluator extension (action_type=support, biome gating, requires-trait
+  # gating) e' follow-up M-future (vedi card §"Concrete reuse paths" P1).
+  magnetic_rift_resonance:
+    tier: T2
+    category: neurologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      on_kill: true
+      min_mos: 5
+    effect:
+      kind: apply_status
+      target_side: actor
+      stato: telepatic_link
+      turns: 5
+      log_tag: magnetic_resonance_active
+    description_it: |
+      Risonanza Magnetica Rift — i campi magnetici dell'atollo di ossidiana
+      oscillano in sincronia con le frequenze mentali degli abitanti, creando
+      onde di comunicazione tattica tra alleati vicini. Trigger: kill con MoS>=5
+      applica telepatic_link per 5 turni all'attaccante (e per estensione, agli
+      alleati in range — gestione propagazione TBD nell'evaluator). Biome
+      affinity: atollo_obsidiana (vedi data/core/biomes.yaml). Provenance:
+      dafne_swarm trait-curator 2026-04-24.
+    biome_affinity:
+      atollo_obsidiana: 0.9
+    requires_traits:
+    - magnetic_sensitivity
+    - rift_attunement
+
+  # Stub T1 — prerequisito narrativo di magnetic_rift_resonance.
+  # No-op runtime: trigger su action_type=attack ma nessun effect concreto
+  # (apply_status su 'sensed' che non e' consumato da policy.js). Serve come
+  # "marcatore" data-only finche' M-future non aggiunge percezione magnetica
+  # come stat-bonus (es. detection range +1 vs hidden enemies).
+  magnetic_sensitivity:
+    tier: T1
+    category: sensoriale
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: apply_status
+      target_side: actor
+      stato: sensed
+      turns: 1
+      log_tag: magnetic_sensed_passive
+    description_it: |
+      Sensibilita' magnetica passiva — l'unita' percepisce campi magnetici
+      ambientali. Stub data-only (M-future: bonus detection in biomi
+      ferromagnetici). Prerequisito per magnetic_rift_resonance.
+
+  # Stub T2 — biome-affinity locked. Stesso pattern no-op del precedente.
+  rift_attunement:
+    tier: T2
+    category: sensoriale
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 8
+    effect:
+      kind: apply_status
+      target_side: actor
+      stato: attuned
+      turns: 2
+      log_tag: rift_attunement_passive
+    description_it: |
+      Sintonia con le fratture ossidiane — l'unita' canalizza l'energia
+      magnetica del bioma. Stub data-only locked su atollo_obsidiana
+      (M-future: enforcement biome gating). Prerequisito per
+      magnetic_rift_resonance.
+    biome_affinity:
+      atollo_obsidiana: 0.8

--- a/incoming/swarm-candidates/README.md
+++ b/incoming/swarm-candidates/README.md
@@ -20,9 +20,9 @@ Definito in `docs/pipeline-swarm-to-game.md` del repo evo-swarm:
 
 ## Stato integrazione
 
-| Data       | File                                  | Source agent                  | Artifact ID                                     | Status                           |
-| ---------- | ------------------------------------- | ----------------------------- | ----------------------------------------------- | -------------------------------- |
-| 2026-04-24 | `traits/magnetic_rift_resonance.yaml` | trait-curator + lore-designer | `trait-curator_2026-04-24T01-08-27.414378.json` | staging (pending Eduardo review) |
+| Data       | File                                  | Source agent                  | Artifact ID                                     | Status                                                                          |
+| ---------- | ------------------------------------- | ----------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------- |
+| 2026-04-24 | `traits/magnetic_rift_resonance.yaml` | trait-curator + lore-designer | `trait-curator_2026-04-24T01-08-27.414378.json` | **PROMOTED 2026-04-25** (OD-012 batch) → `data/core/traits/active_effects.yaml` |
 
 ## Out of scope del trait environmental costs M11
 

--- a/incoming/swarm-candidates/traits/magnetic_rift_resonance.yaml
+++ b/incoming/swarm-candidates/traits/magnetic_rift_resonance.yaml
@@ -1,6 +1,15 @@
 # magnetic_rift_resonance — staging trait da Dafne swarm
 # Proposto automaticamente dal ciclo lore-designer → trait-curator (2026-04-24 01:08 UTC).
-# NON ancora canonical: vedere incoming/swarm-candidates/README.md per workflow promozione.
+#
+# ━━━ PROMOTED 2026-04-25 (OD-012 swarm batch) ━━━
+# Trait + 2 prereq stub (magnetic_sensitivity, rift_attunement) promossi a
+# data/core/traits/active_effects.yaml. Biome alias atollo_ossidiana →
+# atollo_obsidiana aggiunto a data/core/biome_aliases.yaml. Flag
+# magnetic_field_strength=1.0 aggiunto su atollo_obsidiana in
+# data/core/biomes.yaml. atollo_obsidiana wired in apps/backend/services/
+# combat/biomeResonance.js (BIOME_FAMILIES.aquatic + archetype skirmisher).
+# File staging conservato come reference provenance.
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 version: 1.0
 staging: true # flag: rimuovere quando promosso in data/core/*


### PR DESCRIPTION
## Summary

Closes OD-012 user override 2026-04-25 sera ([PR #1807](https://github.com/MasterDD-L34D/Game/pull/1807)) **partial**. Source pool reality: only 1 trait was ready in `incoming/swarm-candidates/traits/`. Single-trait honest delivery + follow-up for pool expansion.

## Scope reality check

| Field | Override target | Delivered |
|---|---|---|
| Trait count | 5-10 batch | **1** (magnetic_rift_resonance) |
| Stubs | 0 | 2 prereq stubs (magnetic_sensitivity, rift_attunement) |
| Biome | atollo_ossidiana stub | atollo_obsidiana flag + alias |
| Tier ladder wire | T2 | family + archetype maps |

Override 5-10 not achievable without inventing content. Honest scope: ship what is ready, expand pool separately.

## Changes (6 files)

- `data/core/traits/active_effects.yaml` (+88 LOC) — `magnetic_rift_resonance` T2 + 2 prereq stubs
- `data/core/biomes.yaml` (+5) — `magnetic_field_strength: 1.0` flag on existing atollo_obsidiana
- `data/core/biome_aliases.yaml` (+4) — atollo_ossidiana → atollo_obsidiana
- `apps/backend/services/combat/biomeResonance.js` (+5) — biome added aquatic family + skirmisher archetype
- `incoming/swarm-candidates/{README.md, traits/magnetic_rift_resonance.yaml}` — PROMOTED markers

## Schema mapping decisions

- **Spelling**: staging `atollo_ossidiana` → canonical `atollo_obsidiana` (existing). Avoid duplicate.
- **`telepatic_link` status**: no central status registry. New free-string, runtime-inert. Behavior wiring = follow-up.
- **Trigger**: staging `action_type: support + biome gate` adapted to `attack + on_kill + min_mos:5` (passesBasicTriggers only supports attack). Inline caveat documented.
- **biomeResonance tier ladder**: actual structure is `perfect/secondary/class_match/none`, not T1/T2. Structural integration via family + archetype maps.

## Test plan

- [x] `python tools/check_docs_governance.py --strict` → 0/0
- [x] `python3 tools/py/game_cli.py validate-datasets` → 0 avvisi
- [x] `npm run schema:lint` → all pass
- [x] `node --test tests/ai/*.test.js` → **311/311**
- [x] `tests/services/biomeResonance.test.js` → 21/21

## Rollback

\`git revert <sha>\` — single commit, 6 files, no breaking change.

## Follow-up

- **Swarm pool expansion**: produce 4-9 more swarm trait candidates via Dafne swarm regeneration session OR user-driven content design. Pool expansion = orthogonal work to this PR.
- **OD-011 ancestors recovery** (~15-20h, gated zip locate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)