### PR TITLE
docs: workspace-map sweep finale — Desktop + WRITE-ACCESS-POLICY

### DIFF
--- a/WORKSPACE_MAP.md
+++ b/WORKSPACE_MAP.md
@@ -60,17 +60,29 @@ L'ecosystem Evo-Tactics è composto da **4 GitHub repo core + 3 progetti AI sate
 
 ### `C:/Users/edusc/.openclaw/` — OpenClaw runtime (active)
 
-| Slot                       | Note                                                                  |
-| -------------------------- | --------------------------------------------------------------------- |
-| `agents/dafne`             | Dafne agent profile (gestito anche da OpenClaw, NON solo da `Dafne/`) |
-| `subagents/`               | Subagent definitions                                                  |
-| `sandboxes/`               | Sandbox per agenti (es. `agent-dafne-c52ca5e1`)                       |
-| `skills/`                  | Skill definitions                                                     |
-| `memory/dafne.sqlite`      | Memory persistente Dafne                                              |
-| `telegram/`, `qqbot/`      | Integration bot                                                       |
-| `openclaw.json` + 8 backup | Config attivo (last modify 2026-04-24 20:24)                          |
+| Slot                       | Note                                                                                                                                         |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agents/dafne`             | Dafne agent profile (gestito anche da OpenClaw, NON solo da `Dafne/`)                                                                        |
+| `subagents/`               | Subagent definitions                                                                                                                         |
+| `sandboxes/`               | Sandbox per agenti (es. `agent-dafne-c52ca5e1`)                                                                                              |
+| `skills/`                  | Skill definitions                                                                                                                            |
+| `memory/dafne.sqlite`      | Memory persistente Dafne                                                                                                                     |
+| `telegram/`, `qqbot/`      | Integration bot                                                                                                                              |
+| `workspace/`               | Template generico OpenClaw (IDENTITY.md "Fill this in during first conversation"). NON è Dafne workspace — quello è in `~/Dafne/workspace/`. |
+| `openclaw.json` + 8 backup | Config attivo (last modify 2026-04-24 20:24)                                                                                                 |
 
 **Status**: 🟢 attivo runtime (config touched 2026-04-24, multipli `openclaw.json.clobbered.*` indicano rescue tracking). Coordina Dafne agent.
+
+### Desktop `C:/Users/edusc/Desktop/` — entrypoint diretti
+
+| File                                           | Tipo                     | Note                                                                                                                                                                                                |
+| ---------------------------------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`WRITE-ACCESS-POLICY.md`**                   | Canonical governance doc | 🟢 `source_of_truth: true` — define se/quando/come/quanto un agente swarm può scrivere su repo. Doc anticipato pre-prima esperienza, review cycle "dopo ogni promozione di livello, o ogni 3 mesi". |
+| `Swarm AI Dashboard.url`                       | Browser bookmark         | Local dashboard `http://127.0.0.1:5000` (Dafne swarm runtime UI)                                                                                                                                    |
+| `Dafne.lnk` + `Dafne Widget.lnk` + `Swarm.lnk` | Launcher shortcuts       | Shortcut Windows verso `~/Dafne/start-dafne.cmd` + widget Tauri                                                                                                                                     |
+| `Claude Code.lnk`                              | Launcher                 | Claude Code CLI shortcut                                                                                                                                                                            |
+| `Docker Desktop.lnk`                           | Launcher                 | Docker Desktop shortcut                                                                                                                                                                             |
+| `files.zip`                                    | Zip generic              | Da non confondere con `gioco/_archive/.../files.zip` (era stesso o copia, archiviare se utile)                                                                                                      |
 
 ### `C:/dev/` — Location alternativa lavoro
 
@@ -82,7 +94,7 @@ L'ecosystem Evo-Tactics è composto da **4 GitHub repo core + 3 progetti AI sate
 | `AA01`                    | `C:/dev/AA01/`                    | 🟡 Versione tarball-based (aa01.tar.gz + AGENTS/GUIDE/README), diversa da `~/aa01/`                                                                                                                                                         |
 | `aider-tty-test`          | `C:/dev/aider-tty-test/`          | 🟡 Duplicato di `gioco/aider-tty-test/`                                                                                                                                                                                                     |
 | `backup-20260419-0518/`   | `C:/dev/backup-20260419-0518/`    | Snapshot                                                                                                                                                                                                                                    |
-| `scratch/`, `null/`       | `C:/dev/`                         | Scratch                                                                                                                                                                                                                                     |
+| `scratch/`, `null/`       | `C:/dev/`                         | Scratch (contiene anche `awesome-claude-code-toolkit/` clone `rohitg00/awesome-claude-code-toolkit` — toolkit Claude Code esterno: agents, commands, contexts, hooks, mcp-configs. Reference, NON parte ecosystem Evo-Tactics)              |
 
 **Raccomandazione**: `C:/dev/` contiene principalmente checkout duplicati. Decidere fate (consolidare o purgare) per evitare path-confusion. Path canonical da preferire:
 


### PR DESCRIPTION
## Summary

Sweep finale post user feedback "controlla a fondo". Dopo PR [#1810](https://github.com/MasterDD-L34D/Game/pull/1810) (comprehensive rewrite con Dafne, evo-swarm, OpenClaw, AA01, C:/dev/ duplicati), ulteriore audit ha rivelato 4 elementi mancanti.

## Aggiunti

- **`Desktop/WRITE-ACCESS-POLICY.md`** — CANONICAL governance doc (`source_of_truth: true`, last_verified 2026-04-22) per agenti swarm Evo-Tactics. Define se/quando/come/quanto un agente può scrivere su repo. Doc anticipato pre-prima esperienza, review cycle "dopo ogni promozione di livello, o ogni 3 mesi".
- **`Desktop/Swarm AI Dashboard.url`** — bookmark `http://127.0.0.1:5000` verso UI runtime Dafne swarm.
- **Desktop shortcuts**: `Dafne.lnk`, `Dafne Widget.lnk`, `Swarm.lnk`, `Claude Code.lnk`, `Docker Desktop.lnk` + `files.zip`.
- **`.openclaw/workspace/`** chiarito: NON è Dafne workspace (template generico OpenClaw, IDENTITY.md "Fill this in during first conversation"). Confusione esplicitata.
- **`C:/dev/scratch/awesome-claude-code-toolkit/`** — clone `rohitg00/awesome-claude-code-toolkit` (toolkit Claude Code esterno, reference).

## Changes

- `WORKSPACE_MAP.md` — sezione OpenClaw aggiornata + sezione Desktop NUOVA + nota awesome-claude-code-toolkit (+22 / -10 LOC)

## Final coverage check

Filesystem-wide grep, ecosystem grep, GitHub repos completi: **nessun ulteriore item rimasto fuori scope**. WORKSPACE_MAP ora cattura:

- 4 GitHub core (Game, Game-Database, evo-swarm, codemasterdd-ai-station)
- 3 progetti AI satelliti (Dafne, AA01, OpenClaw)
- 2 location parallele (gioco/, C:/dev/)
- Desktop entrypoints (governance + bookmark + shortcuts)
- 9 repo MasterDD-L34D tangenziali
- Pipeline staging swarm-candidates Game-side

Solo docs, zero runtime/CI/deps impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)