### PR TITLE
feat(combat): status engine extension — wire 7 new statuses runtime-active

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -75,6 +75,9 @@ const { createDeclareSistemaIntents } = require('../services/ai/declareSistemaIn
 const { loadAiProfiles } = require('../services/ai/aiProfilesLoader');
 const { createAbilityExecutor } = require('../services/abilityExecutor');
 const reactionEngine = require('../services/reactionEngine');
+// Status engine extension (2026-04-25 audit P0): wire 7 ancestor statuses
+// (linked/fed/healing/attuned/sensed/telepatic_link/frenzy) runtime-active.
+const { computeStatusModifiers } = require('../services/combat/statusModifiers');
 // M7-#2 Phase B: damage scaling curves runtime (ADR-2026-04-20).
 const {
   loadDamageCurves,
@@ -342,6 +345,24 @@ function createSessionRouter(options = {}) {
       // non-blocking: se curves missing, no enrage
     }
 
+    // Status engine extension: stack 7 ancestor statuses on top of ability
+    // bonuses for this resolveAttack call only (revert post). Mirrors the
+    // enrage pattern above to avoid persistent leak into actor.attack_mod_bonus
+    // (owned by the ability executor + clearExpiredBonuses decay).
+    let statusMods = { attackDelta: 0, defenseDelta: 0, log: [] };
+    try {
+      statusMods = computeStatusModifiers(actor, target, session.units || []);
+      if (statusMods.attackDelta !== 0) {
+        actor.attack_mod_bonus = Number(actor.attack_mod_bonus || 0) + statusMods.attackDelta;
+      }
+      if (statusMods.defenseDelta !== 0) {
+        target.defense_mod_bonus = Number(target.defense_mod_bonus || 0) + statusMods.defenseDelta;
+      }
+    } catch (err) {
+      // non-blocking: malformed status payload should never break combat
+      statusMods = { attackDelta: 0, defenseDelta: 0, log: [] };
+    }
+
     const result = resolveAttack({ actor, target, rng });
     const evaluation = evaluateAttackTraits({
       registry: traitRegistry,
@@ -354,6 +375,13 @@ function createSessionRouter(options = {}) {
     // Revert enrage bonus post-attack (non-persistente, solo per questo hit)
     if (enrageApplied) {
       actor.mod = Number(actor.mod || 0) - enrageModBonus;
+    }
+    // Revert status engine deltas (per-attack, non-persistente).
+    if (statusMods.attackDelta !== 0) {
+      actor.attack_mod_bonus = Number(actor.attack_mod_bonus || 0) - statusMods.attackDelta;
+    }
+    if (statusMods.defenseDelta !== 0) {
+      target.defense_mod_bonus = Number(target.defense_mod_bonus || 0) - statusMods.defenseDelta;
     }
     let damageDealt = 0;
     let killOccurred = false;
@@ -512,6 +540,17 @@ function createSessionRouter(options = {}) {
         evaluation.trait_effects = (evaluation.trait_effects || []).concat(
           statusEval.trait_effects,
         );
+      }
+      // Status engine extension: surface status modifier log (linked,
+      // sensed, attuned, frenzy, telepatic_link) under trait_effects so
+      // observability surface is unified.
+      if (Array.isArray(statusMods.log) && statusMods.log.length > 0) {
+        const synthetic = statusMods.log.map((entry) => ({
+          trait: `status:${entry.status}`,
+          triggered: true,
+          effect: { kind: 'status_modifier', side: entry.side, detail: entry.effect },
+        }));
+        evaluation.trait_effects = (evaluation.trait_effects || []).concat(synthetic);
       }
       statusApplies = statusEval.status_applies || [];
       for (const s of statusApplies) {
@@ -1700,6 +1739,15 @@ function createSessionRouter(options = {}) {
             if (session.damage_taken) {
               session.damage_taken[unit.id] = (session.damage_taken[unit.id] || 0) + 1;
             }
+          }
+          // Status engine extension: HP regen ticks (`fed`/`healing`) before decay.
+          try {
+            const {
+              applyTurnRegen: _applyTurnRegen,
+            } = require('../services/combat/statusModifiers');
+            _applyTurnRegen(unit);
+          } catch {
+            /* status regen optional */
           }
           // AP reset (Skiv #5: applyApRefill handles fracture + defy_penalty)
           applyApRefill(unit);

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -42,6 +42,8 @@ const { tick: reinforcementTick } = require('../services/combat/reinforcementSpa
 const { evaluateObjective } = require('../services/combat/objectiveEvaluator');
 const { tick: missionTimerTick } = require('../services/combat/missionTimer');
 const { buildThreatPreview } = require('../services/ai/threatPreview');
+// Status engine extension (2026-04-25 audit P0).
+const { applyTurnRegen } = require('../services/combat/statusModifiers');
 
 function createRoundBridge(deps) {
   const {
@@ -624,6 +626,34 @@ function createRoundBridge(deps) {
         hp_after: unit.hp,
         killed: unit.hp === 0,
       });
+    }
+
+    // Status engine extension: HP regen ticks (`fed` + `healing`).
+    // Applied AFTER bleeding (KO units skipped automatically) and BEFORE
+    // universal status decay so the last live tick still produces regen.
+    const regenEvents = [];
+    for (const unit of session.units) {
+      if (!unit) continue;
+      const ticks = applyTurnRegen(unit);
+      for (const tick of ticks) {
+        await appendEvent(session, {
+          ts: new Date().toISOString(),
+          session_id: session.session_id,
+          action_type: 'regen',
+          actor_id: unit.id,
+          actor_species: unit.species,
+          actor_job: unit.job,
+          target_id: unit.id,
+          turn: session.turn,
+          damage_dealt: -tick.amount,
+          result: 'heal',
+          hp_before: tick.hp_before,
+          hp_after: tick.hp_after,
+          status_source: tick.status,
+          trait_effects: [],
+        });
+        regenEvents.push(tick);
+      }
     }
 
     for (const unit of session.units) {

--- a/apps/backend/services/combat/statusModifiers.js
+++ b/apps/backend/services/combat/statusModifiers.js
@@ -1,0 +1,144 @@
+// apps/backend/services/combat/statusModifiers.js
+//
+// M-future Status Engine Extension (2026-04-25 audit balance-auditor).
+// Wires 7 NEW status names runtime-active that previously were silently
+// no-op (apply_status writes unit.status[stato], but downstream consumers
+// did not read these names). Closes audit P0 status orphan finding —
+// unlocks 68/267 ancestor traits runtime value.
+//
+// Statuses supportati:
+//   • linked           +1 attack_mod actor (only if ally adjacent)
+//   • fed              +1 HP regen at turn end (cap max_hp)
+//   • healing          +1 HP regen at turn end (HoT, decay 1/turn handled
+//                      by universal status decay loop in
+//                      sessionRoundBridge.applyEndOfRoundSideEffects)
+//   • attuned          +1 defense_mod target side
+//   • sensed           +1 attack_mod actor (accuracy proxy)
+//   • telepatic_link   reveal — log marker only (no stat effect)
+//   • frenzy           +1 attack_mod actor, -1 defense_mod actor when
+//                      attacked (rage variant, 2 turns canonical)
+//
+// Decay: integer keys decremented 1/round by the existing universal loop
+// in sessionRoundBridge.js. No new decay code path required.
+//
+// Pattern reference: piggyback on the enrage pattern in session.js:
+//   1. compute deltas (pre-attack)
+//   2. apply to actor.attack_mod_bonus + target.defense_mod_bonus
+//   3. resolveAttack runs
+//   4. revert deltas post-attack
+// This avoids persistent mutation of canonical bonuses written by the
+// ability executor.
+
+'use strict';
+
+function manhattanDistance(a, b) {
+  if (!a || !b) return Infinity;
+  return Math.abs(Number(a.x) - Number(b.x)) + Math.abs(Number(a.y) - Number(b.y));
+}
+
+function isPositive(value) {
+  return Number(value) > 0;
+}
+
+/**
+ * Computes status-driven attack/defense modifiers for a single attack.
+ *
+ * @param {object} actor       Attacking unit (has actor.status, actor.position).
+ * @param {object} target      Defending unit (has target.status, target.position).
+ * @param {Array}  units       Full unit roster (for adjacency scans).
+ * @returns {{
+ *   attackDelta: number,      // delta to add to actor.attack_mod_bonus
+ *   defenseDelta: number,     // delta to add to target.defense_mod_bonus
+ *   log: Array<{status, side, effect}>
+ * }}
+ */
+function computeStatusModifiers(actor, target, units = []) {
+  const log = [];
+  let attackDelta = 0;
+  let defenseDelta = 0;
+
+  const actorStatus = (actor && actor.status) || {};
+  const targetStatus = (target && target.status) || {};
+
+  // ─── Actor-side actor-attack buffs ──────────────────────────────
+  if (isPositive(actorStatus.linked)) {
+    // Requires same-faction ally adjacent (manhattan <= 1, hp > 0,
+    // not the actor itself). If alone, no bonus — design intent.
+    const hasAllyAdjacent = (units || []).some(
+      (u) =>
+        u &&
+        u.id !== actor.id &&
+        Number(u.hp || 0) > 0 &&
+        u.controlled_by === actor.controlled_by &&
+        manhattanDistance(u.position, actor.position) === 1,
+    );
+    if (hasAllyAdjacent) {
+      attackDelta += 1;
+      log.push({ status: 'linked', side: 'actor', effect: '+1 attack_mod (ally adjacent)' });
+    }
+  }
+  if (isPositive(actorStatus.sensed)) {
+    attackDelta += 1;
+    log.push({ status: 'sensed', side: 'actor', effect: '+1 attack_mod (accuracy)' });
+  }
+  if (isPositive(actorStatus.frenzy)) {
+    attackDelta += 1;
+    log.push({ status: 'frenzy', side: 'actor', effect: '+1 attack_mod (rage variant)' });
+  }
+  if (isPositive(actorStatus.telepatic_link)) {
+    // No stat effect — narrative reveal marker only.
+    log.push({ status: 'telepatic_link', side: 'actor', effect: 'reveal (no stat delta)' });
+  }
+
+  // ─── Target-side target-defense buffs/debuffs ───────────────────
+  if (isPositive(targetStatus.attuned)) {
+    defenseDelta += 1;
+    log.push({ status: 'attuned', side: 'target', effect: '+1 defense_mod' });
+  }
+  if (isPositive(targetStatus.frenzy)) {
+    // Frenzy on the defender: lowered guard. -1 defense_mod (attacker
+    // gets an easier hit). This is the "rage variant" downside.
+    defenseDelta -= 1;
+    log.push({ status: 'frenzy', side: 'target', effect: '-1 defense_mod (rage exposure)' });
+  }
+
+  return { attackDelta, defenseDelta, log };
+}
+
+/**
+ * Apply per-turn HP regen from `fed` / `healing` status. Run at turn end
+ * before universal status decay (so the decremented value still triggers
+ * regen on its last live turn). Caps regen to max_hp; KO units excluded.
+ *
+ * Returns log array with one entry per regen tick.
+ *
+ * @param {object} unit Unit with status, hp, max_hp.
+ * @returns {Array<{unit_id, status, amount, hp_before, hp_after}>}
+ */
+function applyTurnRegen(unit) {
+  if (!unit || !unit.status || Number(unit.hp || 0) <= 0) return [];
+  const max = Number(unit.max_hp || unit.hp);
+  const events = [];
+
+  for (const statusName of ['fed', 'healing']) {
+    if (!isPositive(unit.status[statusName])) continue;
+    if (unit.hp >= max) continue;
+    const hpBefore = unit.hp;
+    unit.hp = Math.min(max, unit.hp + 1);
+    events.push({
+      unit_id: unit.id,
+      status: statusName,
+      amount: unit.hp - hpBefore,
+      hp_before: hpBefore,
+      hp_after: unit.hp,
+    });
+  }
+  return events;
+}
+
+module.exports = {
+  computeStatusModifiers,
+  applyTurnRegen,
+  // Exported for tests
+  manhattanDistance,
+};

--- a/tests/services/statusExtension.test.js
+++ b/tests/services/statusExtension.test.js
@@ -1,0 +1,201 @@
+// tests/services/statusExtension.test.js
+//
+// Status Engine Extension (2026-04-25 audit P0).
+// Probes 7 NEW statuses wired in apps/backend/services/combat/statusModifiers.js.
+//
+// Each test isolates a single status apply → expected stat / HP / log effect.
+// Decay is NOT re-tested here (covered by existing universal decay loop in
+// sessionRoundBridge.applyEndOfRoundSideEffects).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  computeStatusModifiers,
+  applyTurnRegen,
+} = require('../../apps/backend/services/combat/statusModifiers');
+
+// ─────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────
+
+function makeUnit(overrides = {}) {
+  return {
+    id: 'u1',
+    hp: 10,
+    max_hp: 10,
+    mod: 0,
+    attack_mod_bonus: 0,
+    defense_mod_bonus: 0,
+    position: { x: 0, y: 0 },
+    controlled_by: 'player',
+    status: {},
+    ...overrides,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────
+// 1. linked — +1 attack_mod when ally adjacent
+// ─────────────────────────────────────────────────────────────────
+
+test('linked: +1 attack_mod when same-faction ally adjacent', () => {
+  const actor = makeUnit({ id: 'a', status: { linked: 2 } });
+  const ally = makeUnit({ id: 'a2', position: { x: 1, y: 0 }, controlled_by: 'player' });
+  const target = makeUnit({ id: 't', position: { x: 3, y: 0 }, controlled_by: 'sistema' });
+  const out = computeStatusModifiers(actor, target, [actor, ally, target]);
+  assert.equal(out.attackDelta, 1);
+  assert.equal(out.defenseDelta, 0);
+  assert.ok(out.log.some((e) => e.status === 'linked'));
+});
+
+test('linked: NO bonus when no ally adjacent (alone)', () => {
+  const actor = makeUnit({ id: 'a', status: { linked: 2 } });
+  const target = makeUnit({ id: 't', position: { x: 3, y: 0 }, controlled_by: 'sistema' });
+  const out = computeStatusModifiers(actor, target, [actor, target]);
+  assert.equal(out.attackDelta, 0);
+  assert.equal(out.log.length, 0);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// 2. fed — +1 HP regen at turn end, cap max_hp
+// ─────────────────────────────────────────────────────────────────
+
+test('fed: +1 HP regen at turn_end, capped at max_hp', () => {
+  const u = makeUnit({ hp: 5, max_hp: 10, status: { fed: 1 } });
+  const events = applyTurnRegen(u);
+  assert.equal(u.hp, 6);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].status, 'fed');
+  assert.equal(events[0].amount, 1);
+
+  // Cap test: at max_hp, no regen.
+  const full = makeUnit({ hp: 10, max_hp: 10, status: { fed: 1 } });
+  const ev2 = applyTurnRegen(full);
+  assert.equal(full.hp, 10);
+  assert.equal(ev2.length, 0);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// 3. healing — HoT regen 2 turns total, then 0
+// ─────────────────────────────────────────────────────────────────
+
+test('healing: regen 2 HP over 2 turns, then 0', () => {
+  const u = makeUnit({ hp: 4, max_hp: 10, status: { healing: 2 } });
+  // Round 1
+  const r1 = applyTurnRegen(u);
+  assert.equal(r1.length, 1);
+  assert.equal(u.hp, 5);
+  // Simulate decay loop (universal): healing 2 → 1
+  u.status.healing -= 1;
+  // Round 2
+  const r2 = applyTurnRegen(u);
+  assert.equal(r2.length, 1);
+  assert.equal(u.hp, 6);
+  // Decay: healing 1 → 0
+  u.status.healing -= 1;
+  // Round 3 — no more regen
+  const r3 = applyTurnRegen(u);
+  assert.equal(r3.length, 0);
+  assert.equal(u.hp, 6);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// 4. attuned — +1 defense_mod target side
+// ─────────────────────────────────────────────────────────────────
+
+test('attuned: +1 defense_mod on target', () => {
+  const actor = makeUnit({ id: 'a' });
+  const target = makeUnit({ id: 't', status: { attuned: 2 } });
+  const out = computeStatusModifiers(actor, target, [actor, target]);
+  assert.equal(out.attackDelta, 0);
+  assert.equal(out.defenseDelta, 1);
+  assert.ok(out.log.some((e) => e.status === 'attuned' && e.side === 'target'));
+});
+
+// ─────────────────────────────────────────────────────────────────
+// 5. sensed — +1 attack_mod actor (accuracy)
+// ─────────────────────────────────────────────────────────────────
+
+test('sensed: +1 attack_mod (accuracy proxy)', () => {
+  const actor = makeUnit({ id: 'a', status: { sensed: 1 } });
+  const target = makeUnit({ id: 't' });
+  const out = computeStatusModifiers(actor, target, [actor, target]);
+  assert.equal(out.attackDelta, 1);
+  assert.equal(out.defenseDelta, 0);
+  assert.ok(out.log.some((e) => e.status === 'sensed' && e.side === 'actor'));
+});
+
+// ─────────────────────────────────────────────────────────────────
+// 6. telepatic_link — log entry only, no stat effect
+// ─────────────────────────────────────────────────────────────────
+
+test('telepatic_link: log marker only, no stat delta', () => {
+  const actor = makeUnit({ id: 'a', status: { telepatic_link: 3 } });
+  const target = makeUnit({ id: 't' });
+  const out = computeStatusModifiers(actor, target, [actor, target]);
+  assert.equal(out.attackDelta, 0);
+  assert.equal(out.defenseDelta, 0);
+  assert.ok(out.log.some((e) => e.status === 'telepatic_link'));
+});
+
+// ─────────────────────────────────────────────────────────────────
+// 7. frenzy — +1 attack_mod actor + -1 defense_mod when target side
+// ─────────────────────────────────────────────────────────────────
+
+test('frenzy: +1 attack_mod (actor) AND -1 defense_mod when frenzied unit is target', () => {
+  // Case A: frenzy on actor → +1 attack
+  const actorA = makeUnit({ id: 'a', status: { frenzy: 2 } });
+  const targetA = makeUnit({ id: 't' });
+  const outA = computeStatusModifiers(actorA, targetA, [actorA, targetA]);
+  assert.equal(outA.attackDelta, 1);
+  assert.equal(outA.defenseDelta, 0);
+
+  // Case B: frenzy on target → -1 defense (exposure)
+  const actorB = makeUnit({ id: 'a' });
+  const targetB = makeUnit({ id: 't', status: { frenzy: 2 } });
+  const outB = computeStatusModifiers(actorB, targetB, [actorB, targetB]);
+  assert.equal(outB.attackDelta, 0);
+  assert.equal(outB.defenseDelta, -1);
+
+  // Case C: frenzy on BOTH (actor attacks frenzied target) → +1 atk and -1 def stack
+  const actorC = makeUnit({ id: 'a', status: { frenzy: 2 } });
+  const targetC = makeUnit({ id: 't', status: { frenzy: 2 } });
+  const outC = computeStatusModifiers(actorC, targetC, [actorC, targetC]);
+  assert.equal(outC.attackDelta, 1);
+  assert.equal(outC.defenseDelta, -1);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Edge cases
+// ─────────────────────────────────────────────────────────────────
+
+test('edge: KO unit (hp=0) gets no regen', () => {
+  const u = makeUnit({ hp: 0, max_hp: 10, status: { fed: 1, healing: 2 } });
+  const events = applyTurnRegen(u);
+  assert.equal(events.length, 0);
+  assert.equal(u.hp, 0);
+});
+
+test('edge: empty status object → zero deltas, empty log', () => {
+  const actor = makeUnit({ id: 'a' });
+  const target = makeUnit({ id: 't' });
+  const out = computeStatusModifiers(actor, target, [actor, target]);
+  assert.equal(out.attackDelta, 0);
+  assert.equal(out.defenseDelta, 0);
+  assert.equal(out.log.length, 0);
+});
+
+test('edge: linked + sensed + frenzy stack on actor when ally adjacent', () => {
+  const actor = makeUnit({
+    id: 'a',
+    status: { linked: 2, sensed: 1, frenzy: 1 },
+    position: { x: 0, y: 0 },
+  });
+  const ally = makeUnit({ id: 'a2', position: { x: 0, y: 1 } });
+  const target = makeUnit({ id: 't', position: { x: 5, y: 5 }, controlled_by: 'sistema' });
+  const out = computeStatusModifiers(actor, target, [actor, ally, target]);
+  assert.equal(out.attackDelta, 3); // linked + sensed + frenzy
+  assert.equal(out.defenseDelta, 0);
+});


### PR DESCRIPTION
## Summary

Closes audit **P0 status orphan finding** ([balance-auditor 2026-04-25 sera](https://github.com/MasterDD-L34D/Game/pull/1819)). Pre-fix: 68/267 ancestor traits (PR #1817) silently no-op — `apply_status` wrote `unit.status[stato]` but no consumer read new names.

## Wire matrix

| Status | Effect | Trait sources |
|---|---|---|
| `linked` | +1 attack_mod when ally adjacent | 20 traits Communication |
| `fed` | +1 HP regen turn_end (cap max_hp) | 21 traits Omnivore + Metabolism |
| `healing` | +1 HP regen turn_end HoT | 24 traits Therapeutic Med |
| `attuned` | +1 defense_mod target | Settlement subset |
| `sensed` | +1 attack_mod actor (accuracy) | Senses subset |
| `telepatic_link` | log marker only (reveal pipe deferred) | magnetic_rift_resonance |
| `frenzy` | +1 attack_mod actor / -1 defense_mod target | rage variants |

## Architecture

- **New helper** `apps/backend/services/combat/statusModifiers.js` (+144 LOC):
  - `computeStatusModifiers(actor, target, allUnits)` → `{atk_delta, def_delta, log[]}`
  - `applyTurnRegen(unit)` → `{hp_delta, log[]}`
- `session.js` `performAttack`: apply mod pre-`resolveAttack` + revert post (mirrors enrage pattern line 326-357)
- `sessionRoundBridge.js` turn_end: `applyTurnRegen` after bleeding, before universal decay
- Decay: zero new code — existing loop ticks all `unit.status[*]` keys 1/round (free ride)

## Test plan

- [x] `tests/services/statusExtension.test.js` → **11/11 NEW** (7 spec + 4 edge: KO skip, empty status, multi-stack, max_hp cap)
- [x] `tests/ai/*.test.js` → **311/311** (baseline preserved)
- [x] `tests/services/traitEffects.test.js` → **21/21**
- [x] `tests/api/*.test.js` → **684/684** (zero regression)
- [x] `prettier --check` verde

Total: **~423 LOC** (well under 500 budget).

## Edge cases handled

- KO units (hp ≤ 0) skipped in `applyTurnRegen` (no necromancy)
- `linked` requires same-faction ally (no `controlled_by` mismatch); alone → 0 bonus
- `max_hp` cap respected; `fed`+`healing` simultaneous can produce up to +2/turn
- `frenzy` stacks both sides cumulatively when both flagged
- `try/catch` non-blocking guards on malformed status payload

## Pillar impact

- **P1 Tattica leggibile 🟢**: 68 ancestor traits move from no-op → observable game effect
- **P2 Evoluzione 🟢c+**: ancestors neuron pool now contributes runtime mechanics, not just data
- **P6 Fairness 🟢c+**: status diversity expands tactical options without breaking balance

## Rollback

\`git revert <sha>\` — helpers additive, caller preserves enrage pattern, decay loop unchanged.

## Follow-up

- **`telepatic_link` real intent-reveal pipe**: wire to `buildThreatPreview` / AI intent disclosure (out of minimal-viable scope)
- **`frenzy` self-defense penalty intent**: confirm with balance-auditor (currently inert when frenzied actor not being attacked)
- **`fed`+`bleeding` ordering policy**: net-zero HP possible — design call deferred
- **13 rage on_kill stacking review** (P2 audit residual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)