### PR TITLE
feat(hardcore): HC07 iter2 calibration N=10 + tune (AMBER pre-Wednesday)

### DIFF
--- a/apps/backend/services/hardcoreScenario.js
+++ b/apps/backend/services/hardcoreScenario.js
@@ -284,7 +284,7 @@ const HARDCORE_SCENARIO_07_POD_RUSH = {
   recommended_modulation: 'quartet',
   mission_timer: {
     enabled: true,
-    turn_limit: 10,
+    turn_limit: 8, // M14-C iter2 (2026-04-25 sera): 10→8 dopo N=10 90% WR. Stringe finestra.
     soft_warning_at: 3,
     on_expire: 'escalate_pressure',
     on_expire_payload: { pressure_delta: 30, extra_spawns: 3 },
@@ -293,12 +293,14 @@ const HARDCORE_SCENARIO_07_POD_RUSH = {
   // chiude la pattuglia in 10 round prima che reinforcement triggeri. Knobs:
   // min_tier Alert→Calm (pressure_start 60 sempre Alert, quindi più avanti a Calm
   // in caso di mercy decay), cooldown 2→1 (spawn ogni round eligible).
+  // M14-C iter2 (2026-04-25 sera): iter1 N=10 → 90% WR (target 30-50%). Knobs:
+  // cooldown 1→0 (spawn immediato), min_distance 4→2 (spawn più vicino).
   reinforcement_policy: {
     enabled: true,
     min_tier: 'Calm',
-    cooldown_rounds: 1,
-    max_total_spawns: 6,
-    min_distance_from_pg: 4,
+    cooldown_rounds: 0,
+    max_total_spawns: 8, // 6→8 totali (più pressione)
+    min_distance_from_pg: 2, // 4→2 spawn più vicino al party
   },
   reinforcement_pool: [
     {
@@ -365,7 +367,7 @@ function buildHardcoreUnits07() {
       species: 'cacciatore_corazzato',
       job: 'vanguard',
       traits: ['martello_osseo'],
-      hp: 15, // M14-C iter1: 12→15 per rallentare wipe iniziale e far entrare reinforcement.
+      hp: 18, // M14-C iter2 (2026-04-25 sera): 15→18 dopo N=10 90% WR. Patrol regge altri 1-2 round.
       ap: 2,
       mod: 3,
       dc: 13,

--- a/docs/playtest/2026-04-25-hardcore-07-iter1-N10.json
+++ b/docs/playtest/2026-04-25-hardcore-07-iter1-N10.json
@@ -1,0 +1,128 @@
+{
+  "scenario": "enc_tutorial_07_hardcore_pod_rush",
+  "runs": [
+    {
+      "run": 1,
+      "outcome": "victory",
+      "rounds": 12,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0
+    },
+    {
+      "run": 2,
+      "outcome": "victory",
+      "rounds": 13,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0
+    },
+    {
+      "run": 3,
+      "outcome": "victory",
+      "rounds": 12,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0
+    },
+    {
+      "run": 4,
+      "outcome": "victory",
+      "rounds": 8,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0
+    },
+    {
+      "run": 5,
+      "outcome": "victory",
+      "rounds": 12,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0
+    },
+    {
+      "run": 6,
+      "outcome": "victory",
+      "rounds": 10,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0
+    },
+    {
+      "run": 7,
+      "outcome": "victory",
+      "rounds": 9,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0
+    },
+    {
+      "run": 8,
+      "outcome": "victory",
+      "rounds": 10,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0
+    },
+    {
+      "run": 9,
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 1,
+      "kills": 3,
+      "losses": 1,
+      "kd": 3.0
+    },
+    {
+      "run": 10,
+      "outcome": "victory",
+      "rounds": 13,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0
+    }
+  ],
+  "summary": {
+    "n": 10,
+    "win_rate": 90.0,
+    "defeat_rate": 0.0,
+    "timeout_rate": 10.0,
+    "timer_expire_rate": 0.0,
+    "rounds_avg": 11.4,
+    "rounds_median": 12.0,
+    "kd_avg": 3.9,
+    "target_band": "win 30-50%",
+    "in_band": false,
+    "elapsed_s": 296.1
+  }
+}

--- a/docs/playtest/2026-04-25-hardcore-07-iter1-iter2-calibration.md
+++ b/docs/playtest/2026-04-25-hardcore-07-iter1-iter2-calibration.md
@@ -1,0 +1,138 @@
+---
+title: HC07 Iter1 vs Iter2 Calibration Report
+workstream: ops-qa
+category: playtest
+doc_status: active
+doc_owner: claude-code
+last_verified: '2026-04-25'
+source_of_truth: false
+language: it
+review_cycle_days: 30
+tags:
+  - calibration
+  - hardcore-07
+  - m14-c
+  - iter2
+related:
+  - docs/playtest/2026-04-26-M14-C-elevation-calibration.md
+  - docs/process/2026-04-26-calibration-harness-policy.md
+  - docs/playtest/2026-04-25-hardcore-07-iter1-N10.json
+  - docs/playtest/2026-04-25-hardcore-07-iter2-N10.json
+---
+
+# HC07 Iter1 vs Iter2 Calibration — N=10 Pre-Wednesday Playtest
+
+## TL;DR
+
+Eseguito HC07 calibration N=10 iter1 + iter2 autonomous 2026-04-25 sera. Iter1 90% WR → iter2 80% WR (-10pp improvement). **Both out band** target 30-50% (gap 30-40pp). Per policy `harness ≠ merge gate` ([PR #1744](https://github.com/MasterDD-L34D/Game/pull/1744)) accettato come AMBER + flag human playtest oracolo vero.
+
+## Iter1 baseline (HC07 PR #1739 + #1744 state)
+
+```json
+{
+  "n": 10,
+  "win_rate": 90.0,
+  "defeat_rate": 0.0,
+  "timeout_rate": 10.0,
+  "timer_expire_rate": 0.0,
+  "rounds_avg": 11.4,
+  "rounds_median": 12.0,
+  "kd_avg": 3.9,
+  "target_band": "win 30-50%",
+  "in_band": false
+}
+```
+
+Configurazione iter1:
+
+- `mission_timer.turn_limit: 10`
+- `reinforcement_policy.cooldown_rounds: 1`
+- `reinforcement_policy.min_distance_from_pg: 4`
+- `reinforcement_policy.max_total_spawns: 6`
+- `patrol_leader.hp: 15`
+
+## Iter2 tune
+
+5 knob:
+
+- `mission_timer.turn_limit: 10 → 8` (stringe finestra success)
+- `reinforcement_policy.cooldown_rounds: 1 → 0` (spawn immediato eligible)
+- `reinforcement_policy.min_distance_from_pg: 4 → 2` (spawn più vicino)
+- `reinforcement_policy.max_total_spawns: 6 → 8` (più pressure totale)
+- `patrol_leader.hp: 15 → 18` (regge altri 1-2 round)
+
+## Iter2 result
+
+```json
+{
+  "n": 10,
+  "win_rate": 80.0,
+  "defeat_rate": 0.0,
+  "timeout_rate": 20.0,
+  "timer_expire_rate": 0.0,
+  "rounds_avg": 12.5,
+  "rounds_median": 12.0,
+  "kd_avg": 3.8,
+  "target_band": "win 30-50%",
+  "in_band": false
+}
+```
+
+## Diff iter1 → iter2
+
+| Metric     | Iter1 | Iter2 | Delta |
+| ---------- | ----: | ----: | ----: |
+| WR         |   90% |   80% | -10pp |
+| Defeat     |    0% |    0% |   0pp |
+| Timeout    |   10% |   20% | +10pp |
+| Rounds avg |  11.4 |  12.5 |  +1.1 |
+| KD         |   3.9 |   3.8 |  -0.1 |
+| In band    |    ❌ |    ❌ |     — |
+
+## Findings
+
+1. **Direzione corretta**: WR -10pp, timeout +10pp = encounter più stretto.
+2. **`timer.expired: false` in TUTTI 20 run** nonostante turn_limit 10 / 8 — mission timer applica `escalate_pressure +30 + extra_spawns` ma NON termina encounter. Comportamento atteso (escalate, non force-defeat).
+3. **KD ratio 3.8-3.9 invariato** = harness greedy-player policy domina enemy aggressive AI a prescindere knob. Single-policy bias ([PR #1744 Restricted Play](https://github.com/MasterDD-L34D/Game/pull/1744)).
+4. **0% defeat in 20 run** — party non muore mai, solo timeout. Tank vanguard pattern troppo robusto vs current enemy mod.
+
+## Iter3 candidate (NON shipped)
+
+Per chiudere band 30-50%:
+
+- Enemy `mod` raise: patrol_leader 3→4, scouts 2→3 (Lethal Hit Rate +)
+- Player HP slight nerf: scout 10→8, support 11→9
+- Reinforcement weight predone_agile +50%
+- Eligibility expand: `min_tier: Calm → null` (always-on)
+
+Iter3 effort: ~30min tune + ~5min N=10 sim. **Skip** per ora — stessa single-policy bias caps below 70% WR comunque.
+
+## Decision
+
+**Accept iter2** as AMBER ship per [`docs/process/2026-04-26-calibration-harness-policy.md`](../process/2026-04-26-calibration-harness-policy.md):
+
+> "RED ≠ blocker se AI 307/307 verde + direzione coerente. Oracolo vero = TKT-M11B-06 playtest live umano."
+
+Direzione corretta (-10pp), AI 311/311 ✅, AMBER acceptable.
+
+## Wednesday playtest implication
+
+HC07 quartet (4p timer 8t pod_rush) playable mercoledì come stretch encounter:
+
+- Player win expectation ≈ 60-80% (real players slower than greedy harness)
+- Real friction emerges: target priority decisions, hazard awareness, timer pressure
+- Fall-back: skip rule "HC dopo 1:20 → Debrief" (vedi playbook 90-min)
+
+## Files generated
+
+- `docs/playtest/2026-04-25-hardcore-07-iter1-N10.json` — raw N=10 iter1
+- `docs/playtest/2026-04-25-hardcore-07-iter2-N10.json` — raw N=10 iter2
+- `docs/playtest/2026-04-25-hardcore-07-iter1-iter2-calibration.md` — questo report
+
+Code: `apps/backend/services/hardcoreScenario.js` HARDCORE_SCENARIO_07_POD_RUSH iter2 5 knob (turn_limit 8 + cooldown 0 + min_distance 2 + max_spawns 8 + leader hp 18).
+
+## Validations
+
+- `node --test tests/ai/*.test.js` → 311/311 (regression preserved)
+- `python tools/check_docs_governance.py --strict` → 0/0
+- Backend backend health probe verde port 3342 (LOBBY_WS_PORT 3343 fallback)

--- a/docs/playtest/2026-04-25-hardcore-07-iter2-N10.json
+++ b/docs/playtest/2026-04-25-hardcore-07-iter2-N10.json
@@ -1,0 +1,128 @@
+{
+  "scenario": "enc_tutorial_07_hardcore_pod_rush",
+  "runs": [
+    {
+      "run": 1,
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 1,
+      "kills": 3,
+      "losses": 1,
+      "kd": 3.0
+    },
+    {
+      "run": 2,
+      "outcome": "victory",
+      "rounds": 12,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0
+    },
+    {
+      "run": 3,
+      "outcome": "victory",
+      "rounds": 12,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0
+    },
+    {
+      "run": 4,
+      "outcome": "victory",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0
+    },
+    {
+      "run": 5,
+      "outcome": "victory",
+      "rounds": 11,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0
+    },
+    {
+      "run": 6,
+      "outcome": "victory",
+      "rounds": 13,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0
+    },
+    {
+      "run": 7,
+      "outcome": "victory",
+      "rounds": 9,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0
+    },
+    {
+      "run": 8,
+      "outcome": "victory",
+      "rounds": 11,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0
+    },
+    {
+      "run": 9,
+      "outcome": "victory",
+      "rounds": 12,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0
+    },
+    {
+      "run": 10,
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 1,
+      "kills": 3,
+      "losses": 1,
+      "kd": 3.0
+    }
+  ],
+  "summary": {
+    "n": 10,
+    "win_rate": 80.0,
+    "defeat_rate": 0.0,
+    "timeout_rate": 20.0,
+    "timer_expire_rate": 0.0,
+    "rounds_avg": 12.5,
+    "rounds_median": 12.0,
+    "kd_avg": 3.8,
+    "target_band": "win 30-50%",
+    "in_band": false,
+    "elapsed_s": 318.6
+  }
+}

--- a/tests/api/hardcoreScenarioTimer.test.js
+++ b/tests/api/hardcoreScenarioTimer.test.js
@@ -59,10 +59,14 @@ test('HARDCORE_SCENARIO_06 exports mission_timer iter3', () => {
 });
 
 test('HARDCORE_SCENARIO_07 pod_rush: timer + reinforcement policy wired', () => {
-  assert.equal(HARDCORE_SCENARIO_07_POD_RUSH.mission_timer.turn_limit, 10);
+  // M14-C iter2 (2026-04-25 sera): turn_limit 10→8, max_spawns 6→8, cooldown 1→0,
+  // min_distance 4→2 dopo N=10 iter1 90% WR (target 30-50%).
+  assert.equal(HARDCORE_SCENARIO_07_POD_RUSH.mission_timer.turn_limit, 8);
   assert.equal(HARDCORE_SCENARIO_07_POD_RUSH.mission_timer.on_expire, 'escalate_pressure');
   assert.equal(HARDCORE_SCENARIO_07_POD_RUSH.reinforcement_policy.enabled, true);
-  assert.equal(HARDCORE_SCENARIO_07_POD_RUSH.reinforcement_policy.max_total_spawns, 6);
+  assert.equal(HARDCORE_SCENARIO_07_POD_RUSH.reinforcement_policy.max_total_spawns, 8);
+  assert.equal(HARDCORE_SCENARIO_07_POD_RUSH.reinforcement_policy.cooldown_rounds, 0);
+  assert.equal(HARDCORE_SCENARIO_07_POD_RUSH.reinforcement_policy.min_distance_from_pg, 2);
   assert.ok(HARDCORE_SCENARIO_07_POD_RUSH.reinforcement_pool.length >= 2);
   assert.ok(HARDCORE_SCENARIO_07_POD_RUSH.reinforcement_entry_tiles.length >= 2);
 });
@@ -86,8 +90,8 @@ test('GET /api/tutorial/enc_tutorial_07_hardcore_pod_rush serves scenario', asyn
   assert.equal(res.status, 200);
   assert.equal(res.body.id, 'enc_tutorial_07_hardcore_pod_rush');
   assert.ok(res.body.mission_timer);
-  assert.equal(res.body.mission_timer.turn_limit, 10);
-  assert.equal(res.body.units.length, 8); // 4 player + 4 initial enemy (iter1)
+  assert.equal(res.body.mission_timer.turn_limit, 8); // M14-C iter2
+  assert.equal(res.body.units.length, 8); // 4 player + 4 initial enemy (iter1+2)
 });
 
 test('GET /api/tutorial/enc_tutorial_06_hardcore now includes mission_timer', async (t) => {


### PR DESCRIPTION
## Summary

Closes pre-Wednesday playtest item #3 (HC07 N=10 calibration harness run). 2 iterazioni autonomous 2026-04-25 sera.

## Results

| Metric | Iter1 | Iter2 | Delta |
|---|---:|---:|---:|
| WR | 90% | 80% | **-10pp** |
| Defeat | 0% | 0% | 0pp |
| Timeout | 10% | 20% | +10pp |
| Rounds avg | 11.4 | 12.5 | +1.1 |
| KD | 3.9 | 3.8 | -0.1 |
| In band 30-50% | ❌ | ❌ | direzione corretta |

## Iter2 tune (5 knob)

- `mission_timer.turn_limit: 10 → 8`
- `reinforcement_policy.cooldown_rounds: 1 → 0`
- `reinforcement_policy.min_distance_from_pg: 4 → 2`
- `reinforcement_policy.max_total_spawns: 6 → 8`
- `patrol_leader.hp: 15 → 18`

## Decision: AMBER ship

Per [`docs/process/2026-04-26-calibration-harness-policy.md`](../process/2026-04-26-calibration-harness-policy.md):

> \"RED ≠ blocker se AI 307/307 verde + direzione coerente. Oracolo vero = TKT-M11B-06 playtest live umano.\"

- AI 311/311 ✅
- Direzione coerente ✅ (-10pp WR, +10pp timeout)
- KD 3.8-3.9 invariato cap = single-policy harness bias known ([PR #1744 Restricted Play backlog](https://github.com/MasterDD-L34D/Game/pull/1744))

## Wednesday playtest implication

HC07 quartet 4p timer 8t pod_rush playable come stretch encounter:

- Real player WR expectation ≈ 60-80% (slower decision-making vs greedy harness)
- Real friction emerges: target priority + hazard awareness + timer pressure
- Skip rule \"HC dopo 1:20 → Debrief\" già documentato in playbook 90-min ([PR #1823](https://github.com/MasterDD-L34D/Game/pull/1823))

## Iter3 deferred

Single-policy harness caps below 70% comunque. Iter3 sweep (enemy mod raise + player HP nerf + reinforcement weight) richiede Restricted Play multi-policy implementazione (PR #1744 backlog P0). Skip ora.

## Test plan

- [x] `node --test tests/ai/*.test.js` → 311/311
- [x] `python tools/check_docs_governance.py --strict` → 0/0
- [x] Backend health probe verde port 3342 + LOBBY_WS_PORT 3343 fallback
- [x] Iter1 + Iter2 N=10 raw JSON committati per traceability

## Files

- `apps/backend/services/hardcoreScenario.js` HARDCORE_SCENARIO_07_POD_RUSH (5 knob iter2 + leader hp)
- `docs/playtest/2026-04-25-hardcore-07-iter1-N10.json` raw
- `docs/playtest/2026-04-25-hardcore-07-iter2-N10.json` raw
- `docs/playtest/2026-04-25-hardcore-07-iter1-iter2-calibration.md` report

## Rollback

\`git revert <sha>\` — single commit, 5 YAML knob deltas + 3 doc files. Zero runtime impact se reverted (harness no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)