### PR TITLE
feat(p4): wire enneaEffects.js runtime — 6/9 archetipi (3 mechanical + 3 log_only)

### DIFF
--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -685,7 +685,66 @@ function createRoundBridge(deps) {
       }
     }
 
-    return { hazardEvents, bleedingEvents };
+    // P4 Ennea effects wire (post-OD audit, branch feat/p4-ennea-effects-wire).
+    // Applica buff/debuff per archetipi Ennea triggerati nel VC snapshot.
+    // Lazy-required + try/catch non-blocking: errori loggati, mai propagati.
+    // Skip round 1 (no events accumulated → empty per_actor).
+    const enneaEvents = [];
+    if (Number(session?.turn || 0) > 1) {
+      try {
+        const { buildVcSnapshot, loadTelemetryConfig } = require('../services/vcScoring');
+        const { resolveEnneaEffects, applyEnneaToStatus } = require('../services/enneaEffects');
+        // Cache telemetry config per-bridge-instance: YAML I/O 1x.
+        if (!applyEndOfRoundSideEffects._telemetryCfg) {
+          applyEndOfRoundSideEffects._telemetryCfg = loadTelemetryConfig();
+        }
+        const cfg = applyEndOfRoundSideEffects._telemetryCfg;
+        const snapshot = buildVcSnapshot(session, cfg);
+        const perActor = (snapshot && snapshot.per_actor) || {};
+        for (const unit of session.units) {
+          if (!unit) continue;
+          const actorData = perActor[unit.id];
+          if (!actorData || !Array.isArray(actorData.ennea_archetypes)) continue;
+          const triggered = actorData.ennea_archetypes
+            .filter((a) => a && a.triggered)
+            .map((a) => a.id);
+          if (triggered.length === 0) continue;
+          const effects = resolveEnneaEffects(triggered);
+          if (effects.length === 0) continue;
+          const { applied, skipped } = applyEnneaToStatus(unit, effects);
+          if (applied.length === 0 && skipped.length === 0) continue;
+          await appendEvent(session, {
+            ts: new Date().toISOString(),
+            session_id: session.session_id,
+            action_type: 'ennea_effects',
+            actor_id: unit.id,
+            actor_species: unit.species,
+            actor_job: unit.job,
+            target_id: unit.id,
+            turn: session.turn,
+            damage_dealt: 0,
+            result: 'buff',
+            ennea_applied: applied,
+            ennea_skipped: skipped,
+            triggered_archetypes: triggered,
+            automatic: true,
+          });
+          enneaEvents.push({
+            unit_id: unit.id,
+            applied,
+            skipped,
+            triggered,
+          });
+        }
+      } catch (err) {
+        // Non-blocking: log + continue. VC snapshot OR telemetry config errors
+        // must never break round flow. Surface in console.warn for ops audit.
+        // eslint-disable-next-line no-console
+        console.warn('[ennea-wire] failed:', err && err.message ? err.message : err);
+      }
+    }
+
+    return { hazardEvents, bleedingEvents, enneaEvents };
   }
 
   // ────────────────────────────────────────────────────────────────

--- a/apps/backend/services/enneaEffects.js
+++ b/apps/backend/services/enneaEffects.js
@@ -86,8 +86,96 @@ function applyEnneaBuffs(actor, effects) {
   }
 }
 
+/**
+ * Stat → mappatura runtime consumer.
+ * - 'mechanical': stat consumato live in resolveAttack / resolveX.
+ *   Pattern: increment actor[<stat>_bonus] + set status[<stat>_buff].
+ *   Decay loop in sessionRoundBridge.applyEndOfRoundSideEffects azzera
+ *   bonus quando _buff scende a 0.
+ * - 'log_only': stat dichiarato canonical ma nessun consumer runtime
+ *   (M-future wire). Loggato per audit trail, NON applicato.
+ */
+const STAT_RUNTIME_KIND = {
+  attack_mod: 'mechanical',
+  defense_mod: 'mechanical',
+  evasion_bonus: 'log_only', // M-future: resolveAttack non legge evasion_bonus_bonus
+  move_bonus: 'log_only', // M-future: nessun consumer per move/AP refill
+  stress_reduction: 'log_only', // M-future: ability-level only, no unit-level stash
+};
+
+/**
+ * Applica ennea effects come (bonus + status_buff) coerenti col decay loop
+ * esistente in sessionRoundBridge.applyEndOfRoundSideEffects.
+ *
+ * Per stat 'mechanical' (attack_mod, defense_mod):
+ *   - actor[<stat>_bonus] += amount   ← consumato live in resolveAttack
+ *   - actor.status[<stat>_buff] = max(corrente, duration)  ← stacking-safe
+ * Decay automatico: prossimo end-of-round, decay decrementa _buff a 0,
+ * poi bonus-zero loop azzera <stat>_bonus. Buff persiste 1 round.
+ *
+ * Per stat 'log_only' (evasion_bonus, move_bonus, stress_reduction):
+ *   - skip mutazione, ritorna in skipped[] con reason='no_consumer'.
+ *
+ * @param {object} actor — unit oggetto; muta in place
+ * @param {Array<{archetype, label, buffs}>} effects — output di resolveEnneaEffects
+ * @returns {{applied: Array, skipped: Array}}
+ */
+function applyEnneaToStatus(actor, effects) {
+  const applied = [];
+  const skipped = [];
+  if (!actor || !Array.isArray(effects) || effects.length === 0) {
+    return { applied, skipped };
+  }
+  // KO units skip — mirror applyTurnRegen pattern.
+  if (Number(actor.hp || 0) <= 0) {
+    for (const effect of effects) {
+      for (const buff of effect.buffs || []) {
+        skipped.push({
+          archetype: effect.archetype,
+          stat: buff.stat,
+          reason: 'actor_ko',
+        });
+      }
+    }
+    return { applied, skipped };
+  }
+  if (!actor.status) actor.status = {};
+  for (const effect of effects) {
+    for (const buff of effect.buffs || []) {
+      const stat = buff.stat;
+      const amount = Number(buff.amount) || 0;
+      const duration = Number(buff.duration) || 1;
+      const kind = STAT_RUNTIME_KIND[stat] || 'log_only';
+      if (kind === 'mechanical') {
+        const bonusKey = `${stat}_bonus`;
+        const buffKey = `${stat}_buff`;
+        actor[bonusKey] = (Number(actor[bonusKey]) || 0) + amount;
+        actor.status[buffKey] = Math.max(Number(actor.status[buffKey]) || 0, duration);
+        applied.push({
+          archetype: effect.archetype,
+          stat,
+          amount,
+          duration,
+          bonus_after: actor[bonusKey],
+        });
+      } else {
+        skipped.push({
+          archetype: effect.archetype,
+          stat,
+          amount,
+          duration,
+          reason: 'no_consumer',
+        });
+      }
+    }
+  }
+  return { applied, skipped };
+}
+
 module.exports = {
   ENNEA_EFFECTS,
+  STAT_RUNTIME_KIND,
   resolveEnneaEffects,
   applyEnneaBuffs,
+  applyEnneaToStatus,
 };

--- a/docs/core/00-SOURCE-OF-TRUTH.md
+++ b/docs/core/00-SOURCE-OF-TRUTH.md
@@ -633,7 +633,7 @@ Implementato in `apps/backend/services/statusEffectsMachine.js` come FSM xstate 
 
 **6 archetipi Ennea** (condizionali su metriche): Conquistatore(3), Coordinatore(2), Esploratore(7), Architetto(5), Stoico(9), Cacciatore(8). Trigger: espressioni condizionali in `telemetry.yaml`.
 
-**Effetti Ennea** (`enneaEffects.js`): mappano archetipi a buff combat (attack_mod, defense_mod, move_bonus, stress_reduction, evasion_bonus). ⚠️ **Wire pending** — modulo orfano canonico (93 LOC, mai `require`/`import`). Vedi card museum [M-2026-04-25-006](../museum/cards/enneagramma-enneaeffects-orphan.md). Coverage 6/9 archetipi. Effort wire ~5-6h (`buildVcSnapshot` per-round refactor pre-req).
+**Effetti Ennea** (`enneaEffects.js`): mappano archetipi a buff combat (attack_mod, defense_mod, move_bonus, stress_reduction, evasion_bonus). ✅ **Wire live** (branch `feat/p4-ennea-effects-wire`, 2026-04-25): hook in `sessionRoundBridge.applyEndOfRoundSideEffects` post-decay, lazy-import `buildVcSnapshot` + `loadTelemetryConfig` (cached), apply via `applyEnneaToStatus` con coerenza decay loop esistente. **Coverage runtime 2/5 stat mechanical** (`attack_mod` + `defense_mod` consumati live in `resolveAttack`); 3/5 stat `log_only` (`move_bonus`, `stress_reduction`, `evasion_bonus`) flagged M-future per assenza consumer runtime. **6/9 archetipi configurati** in `telemetry.yaml`; tra questi 3 producono effetti meccanici (Conquistatore, Coordinatore, Architetto), 3 sono log-only (Esploratore, Stoico, Cacciatore). Skip round 1 (no events). Try/catch non-blocking. Card museum [M-2026-04-25-006](../museum/cards/enneagramma-enneaeffects-orphan.md) — reuse_path eseguito.
 
 **16 Forme YAML** (`data/core/forms/mbti_forms.yaml`): tipo MBTI → assi baseline, affinità Job, penalità.
 
@@ -696,26 +696,26 @@ Pattern Bevy-inspired (V1). Plugin attivi: `narrativePlugin` (monta route narrat
 
 ### 13.8 Mappa design → codice
 
-| Sezione design             | Modulo implementato                                       | Stato                                                                                                       |
-| -------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| §1 Tesi / Combat           | `roundOrchestrator.js`, `resolver.py`                     | Operativo                                                                                                   |
-| §2 Prima partita           | `enc_tutorial_01.yaml` + session engine                   | Definito, non giocabile end-to-end                                                                          |
-| §3 Worldgen                | `biomes.yaml`, ecosystems, foodwebs                       | Dati completi, generatore non runtime                                                                       |
-| §4 Foodweb                 | Validators + data YAML                                    | Validazione completa, non runtime                                                                           |
-| §5 Specie/Trait/Job/Forme  | `species.yaml`, `trait_mechanics.yaml`, `mbti_forms.yaml` | Dati + hydration operativi                                                                                  |
-| §6 TV + companion          | Design docs                                               | Solo design, nessun frontend                                                                                |
-| §7 Narrativa               | `narrativeEngine.js` + inkjs                              | Engine operativo, contenuti minimi                                                                          |
-| §8 Mappa 4 livelli         | —                                                         | Framework concettuale                                                                                       |
-| §10 Meta-loop Nido         | `mating.yaml`, `27-MATING_NIDO.md`                        | Solo dati, non implementato                                                                                 |
-| VC/MBTI/Ennea              | `vcScoring.js`, `enneaEffects.js`                         | 🟡 VC + MBTI operativi · Ennea effects orphan ([M-006](../museum/cards/enneagramma-enneaeffects-orphan.md)) |
-| AI SIS                     | `policy.js`, `declareSistemaIntents.js`                   | Operativo, data-driven                                                                                      |
-| Status system              | `statusEffectsMachine.js`                                 | Operativo (xstate v5)                                                                                       |
-| §14 Grid & Map             | `hexGrid.js` + `terrain_defense.yaml` v0.2                | 🟢 Engine operativo, 23 test                                                                                |
-| §15 Level Design           | `encounter.schema.json` + 3 encounter YAML                | 🟢 Schema + dati validati                                                                                   |
-| §16 Networking/Co-op       | ADR Colyseus (proposto)                                   | 🟡 ADR proposto, non implementato                                                                           |
-| §17 Screen Flow            | `17-SCREEN_FLOW.md` (mermaid)                             | ✅ Formalizzato                                                                                             |
-| §18 Audience/Accessibilità | —                                                         | 🟡 Proposte, attesa Master DD                                                                               |
-| §19 Decisioni GDD          | 28 domande                                                | 12✅ 9🟡 7🔴                                                                                                |
+| Sezione design             | Modulo implementato                                       | Stato                                                                                                                                                        |
+| -------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| §1 Tesi / Combat           | `roundOrchestrator.js`, `resolver.py`                     | Operativo                                                                                                                                                    |
+| §2 Prima partita           | `enc_tutorial_01.yaml` + session engine                   | Definito, non giocabile end-to-end                                                                                                                           |
+| §3 Worldgen                | `biomes.yaml`, ecosystems, foodwebs                       | Dati completi, generatore non runtime                                                                                                                        |
+| §4 Foodweb                 | Validators + data YAML                                    | Validazione completa, non runtime                                                                                                                            |
+| §5 Specie/Trait/Job/Forme  | `species.yaml`, `trait_mechanics.yaml`, `mbti_forms.yaml` | Dati + hydration operativi                                                                                                                                   |
+| §6 TV + companion          | Design docs                                               | Solo design, nessun frontend                                                                                                                                 |
+| §7 Narrativa               | `narrativeEngine.js` + inkjs                              | Engine operativo, contenuti minimi                                                                                                                           |
+| §8 Mappa 4 livelli         | —                                                         | Framework concettuale                                                                                                                                        |
+| §10 Meta-loop Nido         | `mating.yaml`, `27-MATING_NIDO.md`                        | Solo dati, non implementato                                                                                                                                  |
+| VC/MBTI/Ennea              | `vcScoring.js`, `enneaEffects.js`                         | 🟡+ VC + MBTI operativi · Ennea effects 6/9 wired runtime (3 mechanical + 3 log-only M-future) ([M-006](../museum/cards/enneagramma-enneaeffects-orphan.md)) |
+| AI SIS                     | `policy.js`, `declareSistemaIntents.js`                   | Operativo, data-driven                                                                                                                                       |
+| Status system              | `statusEffectsMachine.js`                                 | Operativo (xstate v5)                                                                                                                                        |
+| §14 Grid & Map             | `hexGrid.js` + `terrain_defense.yaml` v0.2                | 🟢 Engine operativo, 23 test                                                                                                                                 |
+| §15 Level Design           | `encounter.schema.json` + 3 encounter YAML                | 🟢 Schema + dati validati                                                                                                                                    |
+| §16 Networking/Co-op       | ADR Colyseus (proposto)                                   | 🟡 ADR proposto, non implementato                                                                                                                            |
+| §17 Screen Flow            | `17-SCREEN_FLOW.md` (mermaid)                             | ✅ Formalizzato                                                                                                                                              |
+| §18 Audience/Accessibilità | —                                                         | 🟡 Proposte, attesa Master DD                                                                                                                                |
+| §19 Decisioni GDD          | 28 domande                                                | 12✅ 9🟡 7🔴                                                                                                                                                 |
 
 ---
 
@@ -1239,13 +1239,13 @@ La Tri-Sorgente è il ponte tra:
 
 ### 20.4 Stato implementativo
 
-| Componente         | Stato                                                                 |
-| ------------------ | --------------------------------------------------------------------- |
-| Offerta 3 carte    | Non implementato. Richiede UI companion + integrazione vcScoring      |
-| Sorgente contesto  | Dati disponibili (biomes.yaml, encounter context)                     |
-| Sorgente identità  | 🟡 vcScoring + deriveMbtiType operativi · enneaEffects orphan (M-006) |
-| Sorgente azioni    | Operativo (raw event tracking in session engine)                      |
-| Frammenti Genetici | Non implementato. Schema valuta da definire                           |
+| Componente         | Stato                                                                                                                            |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| Offerta 3 carte    | Non implementato. Richiede UI companion + integrazione vcScoring                                                                 |
+| Sorgente contesto  | Dati disponibili (biomes.yaml, encounter context)                                                                                |
+| Sorgente identità  | 🟡+ vcScoring + deriveMbtiType operativi · enneaEffects wired runtime 6/9 archetipi (3 mechanical + 3 log-only M-future) (M-006) |
+| Sorgente azioni    | Operativo (raw event tracking in session engine)                                                                                 |
+| Frammenti Genetici | Non implementato. Schema valuta da definire                                                                                      |
 
 ---
 

--- a/tests/services/enneaEffectsWire.test.js
+++ b/tests/services/enneaEffectsWire.test.js
@@ -1,0 +1,223 @@
+// P4 Ennea effects runtime wire — branch feat/p4-ennea-effects-wire.
+//
+// Scope: verifica che applyEnneaToStatus muti correttamente
+// actor[<stat>_bonus] + actor.status[<stat>_buff] per stat 'mechanical'
+// (attack_mod, defense_mod) e skippi log_only stat (evasion_bonus,
+// move_bonus, stress_reduction) come M-future.
+//
+// Coverage:
+//   - mechanical wire: attack_mod, defense_mod
+//   - log_only skip: evasion_bonus, move_bonus, stress_reduction
+//   - multi-archetype stack (Conquistatore + Architetto = +2 attack_mod_bonus)
+//   - decay coerenza: dopo 1 round end, _buff → 0 → bonus zeroed
+//   - KO unit skip
+//   - Empty / null effects safe
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  ENNEA_EFFECTS,
+  STAT_RUNTIME_KIND,
+  resolveEnneaEffects,
+  applyEnneaToStatus,
+} = require('../../apps/backend/services/enneaEffects');
+
+function makeActor(overrides = {}) {
+  return {
+    id: 'unit_1',
+    hp: 10,
+    mod: 0,
+    attack_mod_bonus: 0,
+    defense_mod_bonus: 0,
+    status: {},
+    ...overrides,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────
+// resolveEnneaEffects — sanity
+// ─────────────────────────────────────────────────────────────────
+
+test('resolveEnneaEffects: filtra archetipi sconosciuti', () => {
+  const effects = resolveEnneaEffects(['Conquistatore(3)', 'Sconosciuto(99)']);
+  assert.equal(effects.length, 1);
+  assert.equal(effects[0].archetype, 'Conquistatore(3)');
+});
+
+test('resolveEnneaEffects: array vuoto → []', () => {
+  const effects = resolveEnneaEffects([]);
+  assert.deepEqual(effects, []);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// applyEnneaToStatus — mechanical (attack_mod, defense_mod)
+// ─────────────────────────────────────────────────────────────────
+
+test('applyEnneaToStatus: Conquistatore(3) → attack_mod_bonus +1 + status.attack_mod_buff:1', () => {
+  const actor = makeActor();
+  const effects = resolveEnneaEffects(['Conquistatore(3)']);
+  const { applied, skipped } = applyEnneaToStatus(actor, effects);
+  assert.equal(actor.attack_mod_bonus, 1);
+  assert.equal(actor.status.attack_mod_buff, 1);
+  assert.equal(applied.length, 1);
+  assert.equal(applied[0].archetype, 'Conquistatore(3)');
+  assert.equal(applied[0].stat, 'attack_mod');
+  assert.equal(applied[0].amount, 1);
+  assert.equal(applied[0].duration, 1);
+  assert.equal(applied[0].bonus_after, 1);
+  assert.equal(skipped.length, 0);
+});
+
+test('applyEnneaToStatus: Coordinatore(2) → defense_mod_bonus +1 + status.defense_mod_buff:1', () => {
+  const actor = makeActor();
+  const effects = resolveEnneaEffects(['Coordinatore(2)']);
+  const { applied, skipped } = applyEnneaToStatus(actor, effects);
+  assert.equal(actor.defense_mod_bonus, 1);
+  assert.equal(actor.status.defense_mod_buff, 1);
+  assert.equal(applied.length, 1);
+  assert.equal(applied[0].stat, 'defense_mod');
+  assert.equal(skipped.length, 0);
+});
+
+test('applyEnneaToStatus: multi-archetype Conquistatore + Architetto → attack_mod_bonus +2 (stacking)', () => {
+  const actor = makeActor();
+  const effects = resolveEnneaEffects(['Conquistatore(3)', 'Architetto(5)']);
+  assert.equal(effects.length, 2);
+  const { applied, skipped } = applyEnneaToStatus(actor, effects);
+  assert.equal(actor.attack_mod_bonus, 2);
+  assert.equal(actor.status.attack_mod_buff, 1);
+  assert.equal(applied.length, 2);
+  assert.equal(skipped.length, 0);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// applyEnneaToStatus — log_only (evasion, move, stress)
+// ─────────────────────────────────────────────────────────────────
+
+test('applyEnneaToStatus: Esploratore(7) move_bonus → log_only skip', () => {
+  const actor = makeActor();
+  const effects = resolveEnneaEffects(['Esploratore(7)']);
+  const { applied, skipped } = applyEnneaToStatus(actor, effects);
+  assert.equal(applied.length, 0);
+  assert.equal(skipped.length, 1);
+  assert.equal(skipped[0].archetype, 'Esploratore(7)');
+  assert.equal(skipped[0].stat, 'move_bonus');
+  assert.equal(skipped[0].reason, 'no_consumer');
+  // Nessuna mutazione bonus o status:
+  assert.equal(actor.move_bonus_bonus, undefined);
+  assert.equal(actor.status.move_bonus_buff, undefined);
+});
+
+test('applyEnneaToStatus: Stoico(9) stress_reduction → log_only skip', () => {
+  const actor = makeActor();
+  const effects = resolveEnneaEffects(['Stoico(9)']);
+  const { skipped } = applyEnneaToStatus(actor, effects);
+  assert.equal(skipped.length, 1);
+  assert.equal(skipped[0].stat, 'stress_reduction');
+  assert.equal(skipped[0].reason, 'no_consumer');
+});
+
+test('applyEnneaToStatus: Cacciatore(8) evasion_bonus → log_only skip', () => {
+  const actor = makeActor();
+  const effects = resolveEnneaEffects(['Cacciatore(8)']);
+  const { skipped } = applyEnneaToStatus(actor, effects);
+  assert.equal(skipped.length, 1);
+  assert.equal(skipped[0].stat, 'evasion_bonus');
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Edge cases
+// ─────────────────────────────────────────────────────────────────
+
+test('applyEnneaToStatus: KO unit (hp=0) → skip apply, all effects in skipped[]', () => {
+  const actor = makeActor({ hp: 0 });
+  const effects = resolveEnneaEffects(['Conquistatore(3)']);
+  const { applied, skipped } = applyEnneaToStatus(actor, effects);
+  assert.equal(applied.length, 0);
+  assert.equal(skipped.length, 1);
+  assert.equal(skipped[0].reason, 'actor_ko');
+  // Nessuna mutazione su KO:
+  assert.equal(actor.attack_mod_bonus, 0);
+});
+
+test('applyEnneaToStatus: empty effects → no mutation', () => {
+  const actor = makeActor();
+  const { applied, skipped } = applyEnneaToStatus(actor, []);
+  assert.equal(applied.length, 0);
+  assert.equal(skipped.length, 0);
+  assert.equal(actor.attack_mod_bonus, 0);
+});
+
+test('applyEnneaToStatus: null actor safe', () => {
+  const effects = resolveEnneaEffects(['Conquistatore(3)']);
+  const { applied, skipped } = applyEnneaToStatus(null, effects);
+  assert.equal(applied.length, 0);
+  assert.equal(skipped.length, 0);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Decay coerenza — verifica integrazione col loop esistente
+// in sessionRoundBridge.applyEndOfRoundSideEffects (line 663-676).
+// Dopo apply: status.attack_mod_buff=1.
+// Simuliamo decay (decrement -1) → status.attack_mod_buff=0 → bonus zeroed.
+// ─────────────────────────────────────────────────────────────────
+
+test('decay coerenza: dopo apply + 1 round end, attack_mod_buff=0 + bonus zeroed', () => {
+  const actor = makeActor();
+  const effects = resolveEnneaEffects(['Conquistatore(3)']);
+  applyEnneaToStatus(actor, effects);
+  assert.equal(actor.attack_mod_bonus, 1);
+  assert.equal(actor.status.attack_mod_buff, 1);
+
+  // Simula decay loop in sessionRoundBridge:
+  //   1) decrement status: v - 1
+  //   2) if _buff <= 0 → zero <stat>_bonus
+  for (const key of Object.keys(actor.status)) {
+    const v = Number(actor.status[key]);
+    if (v > 0) actor.status[key] = v - 1;
+  }
+  for (const key of Object.keys(actor.status)) {
+    if (!key.endsWith('_buff')) continue;
+    if (Number(actor.status[key]) > 0) continue;
+    const stat = key.slice(0, -'_buff'.length);
+    const bonusKey = `${stat}_bonus`;
+    if (actor[bonusKey] !== undefined) actor[bonusKey] = 0;
+  }
+  assert.equal(actor.status.attack_mod_buff, 0);
+  assert.equal(actor.attack_mod_bonus, 0);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// STAT_RUNTIME_KIND — registry consistency
+// ─────────────────────────────────────────────────────────────────
+
+test('STAT_RUNTIME_KIND: tutti gli stat in ENNEA_EFFECTS sono mappati', () => {
+  const usedStats = new Set();
+  for (const def of Object.values(ENNEA_EFFECTS)) {
+    for (const buff of def.buffs || []) {
+      usedStats.add(buff.stat);
+    }
+  }
+  for (const stat of usedStats) {
+    assert.ok(
+      stat in STAT_RUNTIME_KIND,
+      `stat '${stat}' usato in ENNEA_EFFECTS ma non in STAT_RUNTIME_KIND`,
+    );
+  }
+});
+
+test('STAT_RUNTIME_KIND: 2 mechanical (attack_mod, defense_mod) + 3 log_only', () => {
+  const mech = Object.entries(STAT_RUNTIME_KIND)
+    .filter(([, v]) => v === 'mechanical')
+    .map(([k]) => k)
+    .sort();
+  const log = Object.entries(STAT_RUNTIME_KIND)
+    .filter(([, v]) => v === 'log_only')
+    .map(([k]) => k)
+    .sort();
+  assert.deepEqual(mech, ['attack_mod', 'defense_mod']);
+  assert.deepEqual(log, ['evasion_bonus', 'move_bonus', 'stress_reduction']);
+});


### PR DESCRIPTION
## Summary

Closes audit P4 status drift. Card [M-2026-04-25-006](docs/museum/cards/enneagramma-enneaeffects-orphan.md) reuse_path implementation.

**Pre-fix**: `apps/backend/services/enneaEffects.js` ([PR #1433](https://github.com/MasterDD-L34D/Game/pull/1433), 93 LOC) canonical orphan — never `require`/`import`. SOURCE-OF-TRUTH §13.4 false claim \"Operativo P4 completo\" corretto a 🟡 in [PR #1805](https://github.com/MasterDD-L34D/Game/pull/1805).

## Architecture

- `enneaEffects.js`: aggiunto `STAT_RUNTIME_KIND` registry (`mechanical` vs `log_only`) + `applyEnneaToStatus(actor, effects)` adapter che mappa archetipi → existing buff infrastructure (`status[<stat>_buff]` + `actor[<stat>_bonus]`)
- `sessionRoundBridge.js`: hook in `applyEndOfRoundSideEffects` post status decay, lazy-import `buildVcSnapshot` + `loadTelemetryConfig`, gate `session.turn > 1`, KO-skip
- Decay: **zero new code** — esistente loop `status[_buff]` decrement + `_bonus` zero-on-expire gestisce ennea buffs gratis

## Stat mapping

| Archetype | Stat | Kind | Effect |
|---|---|:-:|---|
| Conquistatore(3) | attack_mod | mechanical | +1 per 1 round |
| Coordinatore(2) | defense_mod | mechanical | +1 per 1 round |
| Architetto(5) | attack_mod | mechanical | +1 per 1 round (stack con Conqu) |
| Esploratore(7) | move_bonus | log_only | M-future ~2-3h |
| Stoico(9) | stress_reduction | log_only | M-future ~4-5h |
| Cacciatore(8) | evasion_bonus | log_only | M-future ~1-2h |

3/6 mechanical live + 3/6 log_only follow-up.

## Edge cases

- Round 1 skip (turn > 1 gate)
- KO unit skip (mirror `applyTurnRegen`)
- Multi-archetype stacking: `_bonus` additive, `_buff` `Math.max` (no doppia decay)
- try/catch non-blocking: VC snapshot errors → warn + continue
- Telemetry config caching: 1× I/O per bridge instance (static field)
- Registry consistency meta-test guard against drift

## Test plan

- [x] `tests/services/enneaEffectsWire.test.js` → **14/14 NEW**
- [x] `tests/ai/*.test.js` → **311/311** (baseline preserved)
- [x] `tests/services/traitEffects.test.js` → 21/21
- [x] `tests/services/statusExtension.test.js` → 11/11
- [x] `tests/services/*.test.js` → **374/374** full suite
- [x] `tests/api/roundExecute*.test.js` → 12/12 bridge integration
- [x] `python tools/check_docs_governance.py --strict` → 0/0
- [x] `npx prettier --check` → all formatted

Total: ~349 LOC (sopra budget 150-300 ma test edge cases mandatori).

## Pillar P4 progression

🟡 (orphan) → **🟡+ verificable** (3/6 archetipi mechanical live, P4 closure path 🟢 candidato richiede +7-10h M-future per 3 stat consumers + 9/9 archetype coverage + UI HUD).

## Rollback

\`git revert <sha>\` — helpers additive, callers preserve hook pattern, decay loop unchanged.

## Follow-up M-future

- **`move_bonus` consumer** wire (~2-3h): integrazione `actor.move_bonus_bonus` in `validatePlayerIntent` move range + AI move generator
- **`stress_reduction` consumer** wire (~4-5h): rework SG/stress accumulator per leggere `actor.stress_reduction_bonus` su damage taken
- **`evasion_bonus` consumer** wire (~1-2h): aggiunta termine `target.evasion_bonus_bonus` a DC calculation
- **9/9 archetype coverage** extension via `vcScoring.computeEnneaArchetypes` (3 missing: 1 Reformer, 4 Individualist, 6 Loyalist)
- **UI HUD ennea_archetype badge** (post-playtest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)