### PR TITLE
feat(p4): Ennea 9/9 archetype coverage (Riformatore + Individualista + Lealista)

### DIFF
--- a/apps/backend/services/enneaEffects.js
+++ b/apps/backend/services/enneaEffects.js
@@ -44,6 +44,28 @@ const ENNEA_EFFECTS = {
     buffs: [{ stat: 'evasion_bonus', amount: 1, duration: 1 }],
     description: 'Bonus evasione per tattica hit-and-run',
   },
+  // P4 9/9 coverage extension (2026-04-25, branch feat/p4-ennea-9-of-9-coverage):
+  // Type 1 / 4 / 6 wire. Tutti e 3 mechanical (attack_mod / defense_mod) per
+  // massimizzare runtime impact. Trigger basati su raw metrics derivabili
+  // (setup_ratio, attack_hit_rate, low_hp_time, assists, damage_taken_ratio).
+  'Riformatore(1)': {
+    label: 'Disciplina Etica',
+    buffs: [{ stat: 'attack_mod', amount: 1, duration: 1 }],
+    description:
+      'Bonus attacco per attacchi metodici e precisi (high setup_ratio + attack_hit_rate)',
+  },
+  'Individualista(4)': {
+    label: 'Profondita Emotiva',
+    buffs: [{ stat: 'defense_mod', amount: 1, duration: 1 }],
+    description:
+      'Bonus difesa per resilienza emotiva sotto pressione (low_hp_time alto + contributo attivo)',
+  },
+  'Lealista(6)': {
+    label: 'Vigilanza Difensiva',
+    buffs: [{ stat: 'defense_mod', amount: 1, duration: 2 }],
+    description:
+      'Bonus difesa esteso per supporto team con anticipazione minacce (assists alti + risk basso)',
+  },
 };
 
 /**

--- a/data/core/telemetry.yaml
+++ b/data/core/telemetry.yaml
@@ -68,6 +68,22 @@ ennea_themes:
   #   damage_taken_ratio < 0.4   → risk management: prende meno della meta' del danno totale
   #   first_blood > 0            → ha effettivamente ucciso il bersaglio
   - {id: "Cacciatore(8)",    when: "evasion_ratio>0.6 && attacks_started>=5 && damage_taken_ratio<0.4 && first_blood>0"}
+  # P4 9/9 coverage extension (2026-04-25, branch feat/p4-ennea-9-of-9-coverage).
+  # Trigger basati su raw metrics derivabili dai log correnti (no aggregate
+  # parziali). Soglie conservative — calibrabili in iter2 post-playtest.
+  #
+  # Riformatore(1) — perfezionista/principi: attacco metodico + precisione.
+  #   setup_ratio > 0.5      → maggioranza attacchi preceduti da posizionamento
+  #   attack_hit_rate > 0.65 → alta precisione
+  - {id: "Riformatore(1)",   when: "setup_ratio>0.5 && attack_hit_rate>0.65"}
+  # Individualista(4) — identita/melanconia: resilienza emotiva sotto pressione.
+  #   low_hp_time > 0.4      → tempo significativo in zona critica
+  #   damage_dealt_total > 0 → contribuisce nonostante la sofferenza
+  - {id: "Individualista(4)", when: "low_hp_time>0.4 && damage_dealt_total>0"}
+  # Lealista(6) — sicurezza/vigilanza: difensore di squadra anticipativo.
+  #   assists >= 2              → supporto team attivo
+  #   damage_taken_ratio < 0.35 → risk management (anticipa minacce)
+  - {id: "Lealista(6)",      when: "assists>=2 && damage_taken_ratio<0.35"}
 pe_economy:
   mission_base: {win: 5, draw: 3, dignified_loss: 2}
   style_bonus: {formula: "floor((sum_vc - 2.8)*3)", cap: 3}

--- a/docs/core/00-SOURCE-OF-TRUTH.md
+++ b/docs/core/00-SOURCE-OF-TRUTH.md
@@ -631,9 +631,9 @@ Implementato in `apps/backend/services/statusEffectsMachine.js` come FSM xstate 
 
 **`deriveMbtiType()`** in `vcScoring.js`: soglia 0.5 per asse → tipo 4 lettere.
 
-**6 archetipi Ennea** (condizionali su metriche): Conquistatore(3), Coordinatore(2), Esploratore(7), Architetto(5), Stoico(9), Cacciatore(8). Trigger: espressioni condizionali in `telemetry.yaml`.
+**9 archetipi Ennea** (condizionali su metriche): Conquistatore(3), Coordinatore(2), Esploratore(7), Architetto(5), Stoico(9), Cacciatore(8), Riformatore(1), Individualista(4), Lealista(6). Trigger: espressioni condizionali in `telemetry.yaml`.
 
-**Effetti Ennea** (`enneaEffects.js`): mappano archetipi a buff combat (attack_mod, defense_mod, move_bonus, stress_reduction, evasion_bonus). ✅ **Wire live** (branch `feat/p4-ennea-effects-wire`, 2026-04-25): hook in `sessionRoundBridge.applyEndOfRoundSideEffects` post-decay, lazy-import `buildVcSnapshot` + `loadTelemetryConfig` (cached), apply via `applyEnneaToStatus` con coerenza decay loop esistente. **Coverage runtime 2/5 stat mechanical** (`attack_mod` + `defense_mod` consumati live in `resolveAttack`); 3/5 stat `log_only` (`move_bonus`, `stress_reduction`, `evasion_bonus`) flagged M-future per assenza consumer runtime. **6/9 archetipi configurati** in `telemetry.yaml`; tra questi 3 producono effetti meccanici (Conquistatore, Coordinatore, Architetto), 3 sono log-only (Esploratore, Stoico, Cacciatore). Skip round 1 (no events). Try/catch non-blocking. Card museum [M-2026-04-25-006](../museum/cards/enneagramma-enneaeffects-orphan.md) — reuse_path eseguito.
+**Effetti Ennea** (`enneaEffects.js`): mappano archetipi a buff combat (attack_mod, defense_mod, move_bonus, stress_reduction, evasion_bonus). ✅ **Wire live** (branch `feat/p4-ennea-effects-wire`, 2026-04-25): hook in `sessionRoundBridge.applyEndOfRoundSideEffects` post-decay, lazy-import `buildVcSnapshot` + `loadTelemetryConfig` (cached), apply via `applyEnneaToStatus` con coerenza decay loop esistente. **Coverage runtime 2/5 stat mechanical** (`attack_mod` + `defense_mod` consumati live in `resolveAttack`); 3/5 stat `log_only` (`move_bonus`, `stress_reduction`, `evasion_bonus`) flagged M-future per assenza consumer runtime. **9/9 archetipi configurati** in `telemetry.yaml` (post `feat/p4-ennea-9-of-9-coverage`, 2026-04-25); tra questi **6 producono effetti meccanici** (Conquistatore, Coordinatore, Architetto, **Riformatore**, **Individualista**, **Lealista** — quest'ultimo con `defense_mod` duration 2 round), 3 sono log-only (Esploratore, Stoico, Cacciatore). Skip round 1 (no events). Try/catch non-blocking. Card museum [M-2026-04-25-006](../museum/cards/enneagramma-enneaeffects-orphan.md) — reuse_path eseguito.
 
 **16 Forme YAML** (`data/core/forms/mbti_forms.yaml`): tipo MBTI → assi baseline, affinità Job, penalità.
 
@@ -696,26 +696,26 @@ Pattern Bevy-inspired (V1). Plugin attivi: `narrativePlugin` (monta route narrat
 
 ### 13.8 Mappa design → codice
 
-| Sezione design             | Modulo implementato                                       | Stato                                                                                                                                                        |
-| -------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| §1 Tesi / Combat           | `roundOrchestrator.js`, `resolver.py`                     | Operativo                                                                                                                                                    |
-| §2 Prima partita           | `enc_tutorial_01.yaml` + session engine                   | Definito, non giocabile end-to-end                                                                                                                           |
-| §3 Worldgen                | `biomes.yaml`, ecosystems, foodwebs                       | Dati completi, generatore non runtime                                                                                                                        |
-| §4 Foodweb                 | Validators + data YAML                                    | Validazione completa, non runtime                                                                                                                            |
-| §5 Specie/Trait/Job/Forme  | `species.yaml`, `trait_mechanics.yaml`, `mbti_forms.yaml` | Dati + hydration operativi                                                                                                                                   |
-| §6 TV + companion          | Design docs                                               | Solo design, nessun frontend                                                                                                                                 |
-| §7 Narrativa               | `narrativeEngine.js` + inkjs                              | Engine operativo, contenuti minimi                                                                                                                           |
-| §8 Mappa 4 livelli         | —                                                         | Framework concettuale                                                                                                                                        |
-| §10 Meta-loop Nido         | `mating.yaml`, `27-MATING_NIDO.md`                        | Solo dati, non implementato                                                                                                                                  |
-| VC/MBTI/Ennea              | `vcScoring.js`, `enneaEffects.js`                         | 🟡+ VC + MBTI operativi · Ennea effects 6/9 wired runtime (3 mechanical + 3 log-only M-future) ([M-006](../museum/cards/enneagramma-enneaeffects-orphan.md)) |
-| AI SIS                     | `policy.js`, `declareSistemaIntents.js`                   | Operativo, data-driven                                                                                                                                       |
-| Status system              | `statusEffectsMachine.js`                                 | Operativo (xstate v5)                                                                                                                                        |
-| §14 Grid & Map             | `hexGrid.js` + `terrain_defense.yaml` v0.2                | 🟢 Engine operativo, 23 test                                                                                                                                 |
-| §15 Level Design           | `encounter.schema.json` + 3 encounter YAML                | 🟢 Schema + dati validati                                                                                                                                    |
-| §16 Networking/Co-op       | ADR Colyseus (proposto)                                   | 🟡 ADR proposto, non implementato                                                                                                                            |
-| §17 Screen Flow            | `17-SCREEN_FLOW.md` (mermaid)                             | ✅ Formalizzato                                                                                                                                              |
-| §18 Audience/Accessibilità | —                                                         | 🟡 Proposte, attesa Master DD                                                                                                                                |
-| §19 Decisioni GDD          | 28 domande                                                | 12✅ 9🟡 7🔴                                                                                                                                                 |
+| Sezione design             | Modulo implementato                                       | Stato                                                                                                                                                            |
+| -------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| §1 Tesi / Combat           | `roundOrchestrator.js`, `resolver.py`                     | Operativo                                                                                                                                                        |
+| §2 Prima partita           | `enc_tutorial_01.yaml` + session engine                   | Definito, non giocabile end-to-end                                                                                                                               |
+| §3 Worldgen                | `biomes.yaml`, ecosystems, foodwebs                       | Dati completi, generatore non runtime                                                                                                                            |
+| §4 Foodweb                 | Validators + data YAML                                    | Validazione completa, non runtime                                                                                                                                |
+| §5 Specie/Trait/Job/Forme  | `species.yaml`, `trait_mechanics.yaml`, `mbti_forms.yaml` | Dati + hydration operativi                                                                                                                                       |
+| §6 TV + companion          | Design docs                                               | Solo design, nessun frontend                                                                                                                                     |
+| §7 Narrativa               | `narrativeEngine.js` + inkjs                              | Engine operativo, contenuti minimi                                                                                                                               |
+| §8 Mappa 4 livelli         | —                                                         | Framework concettuale                                                                                                                                            |
+| §10 Meta-loop Nido         | `mating.yaml`, `27-MATING_NIDO.md`                        | Solo dati, non implementato                                                                                                                                      |
+| VC/MBTI/Ennea              | `vcScoring.js`, `enneaEffects.js`                         | 🟡+ VC + MBTI operativi · Ennea effects **9/9** wired runtime (6 mechanical + 3 log-only M-future) ([M-006](../museum/cards/enneagramma-enneaeffects-orphan.md)) |
+| AI SIS                     | `policy.js`, `declareSistemaIntents.js`                   | Operativo, data-driven                                                                                                                                           |
+| Status system              | `statusEffectsMachine.js`                                 | Operativo (xstate v5)                                                                                                                                            |
+| §14 Grid & Map             | `hexGrid.js` + `terrain_defense.yaml` v0.2                | 🟢 Engine operativo, 23 test                                                                                                                                     |
+| §15 Level Design           | `encounter.schema.json` + 3 encounter YAML                | 🟢 Schema + dati validati                                                                                                                                        |
+| §16 Networking/Co-op       | ADR Colyseus (proposto)                                   | 🟡 ADR proposto, non implementato                                                                                                                                |
+| §17 Screen Flow            | `17-SCREEN_FLOW.md` (mermaid)                             | ✅ Formalizzato                                                                                                                                                  |
+| §18 Audience/Accessibilità | —                                                         | 🟡 Proposte, attesa Master DD                                                                                                                                    |
+| §19 Decisioni GDD          | 28 domande                                                | 12✅ 9🟡 7🔴                                                                                                                                                     |
 
 ---
 
@@ -1239,13 +1239,13 @@ La Tri-Sorgente è il ponte tra:
 
 ### 20.4 Stato implementativo
 
-| Componente         | Stato                                                                                                                            |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| Offerta 3 carte    | Non implementato. Richiede UI companion + integrazione vcScoring                                                                 |
-| Sorgente contesto  | Dati disponibili (biomes.yaml, encounter context)                                                                                |
-| Sorgente identità  | 🟡+ vcScoring + deriveMbtiType operativi · enneaEffects wired runtime 6/9 archetipi (3 mechanical + 3 log-only M-future) (M-006) |
-| Sorgente azioni    | Operativo (raw event tracking in session engine)                                                                                 |
-| Frammenti Genetici | Non implementato. Schema valuta da definire                                                                                      |
+| Componente         | Stato                                                                                                                                |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Offerta 3 carte    | Non implementato. Richiede UI companion + integrazione vcScoring                                                                     |
+| Sorgente contesto  | Dati disponibili (biomes.yaml, encounter context)                                                                                    |
+| Sorgente identità  | 🟡+ vcScoring + deriveMbtiType operativi · enneaEffects wired runtime **9/9 archetipi** (6 mechanical + 3 log-only M-future) (M-006) |
+| Sorgente azioni    | Operativo (raw event tracking in session engine)                                                                                     |
+| Frammenti Genetici | Non implementato. Schema valuta da definire                                                                                          |
 
 ---
 

--- a/docs/museum/galleries/enneagramma.md
+++ b/docs/museum/galleries/enneagramma.md
@@ -8,6 +8,7 @@ source_of_truth: false
 language: it
 review_cycle_days: 30
 tags: [archaeology, museum, enneagramma, gallery]
+coverage_runtime: '9/9 archetipi (post feat/p4-ennea-9-of-9-coverage)'
 ---
 
 # Gallery — Enneagramma (3 card aggregata)
@@ -32,15 +33,20 @@ Il dominio Enneagramma in Evo-Tactics ha una storia paradossale: **dataset full 
                         └── all incoming/ Ennagramma files touched (NO functional update)
 
 2026-04-25  [TODAY]   Excavated → curated → reviewed (this gallery)
+
+2026-04-25  feat/p4-ennea-9-of-9-coverage   Coverage 6/9 → 9/9 archetipi
+                        ├── apps/backend/services/enneaEffects.js +Riformatore(1)/Individualista(4)/Lealista(6)
+                        ├── data/core/telemetry.yaml +3 ennea_themes (raw-metric trigger)
+                        └── tests/services/enneaEffectsWire.test.js +9 test (24/24 verde)
 ```
 
 ### Il puzzle
 
-| Pezzo        | Cosa fa                                                                  | Stato        | Card                                                 |
-| ------------ | ------------------------------------------------------------------------ | ------------ | ---------------------------------------------------- |
-| **Dataset**  | 9 tipi schema 1.0.0 (id, fear, desire, passion, wings, stress/growth_to) | unintegrated | [M-003](../cards/enneagramma-dataset-9-types.md)     |
-| **Registry** | 16 hook eligibility/trigger/effects schema completo                      | unintegrated | [M-002](../cards/enneagramma-mechanics-registry.md)  |
-| **Effects**  | 93 LOC mappa archetipi → buff combat (6/9 archetipi)                     | abandoned    | [M-006](../cards/enneagramma-enneaeffects-orphan.md) |
+| Pezzo        | Cosa fa                                                                  | Stato                   | Card                                                 |
+| ------------ | ------------------------------------------------------------------------ | ----------------------- | ---------------------------------------------------- |
+| **Dataset**  | 9 tipi schema 1.0.0 (id, fear, desire, passion, wings, stress/growth_to) | unintegrated            | [M-003](../cards/enneagramma-dataset-9-types.md)     |
+| **Registry** | 16 hook eligibility/trigger/effects schema completo                      | unintegrated            | [M-002](../cards/enneagramma-mechanics-registry.md)  |
+| **Effects**  | 142 LOC mappa archetipi → buff combat (**9/9 archetipi** wired runtime)  | wired (post 2026-04-25) | [M-006](../cards/enneagramma-enneaeffects-orphan.md) |
 
 **Sintesi**: hai i dati (M-003), hai gli hook (M-002), hai il consumer (M-006). Mancano 5 righe di `require()` + 50 righe di mapping per chiudere il cerchio.
 

--- a/tests/services/enneaEffectsWire.test.js
+++ b/tests/services/enneaEffectsWire.test.js
@@ -221,3 +221,185 @@ test('STAT_RUNTIME_KIND: 2 mechanical (attack_mod, defense_mod) + 3 log_only', (
   assert.deepEqual(mech, ['attack_mod', 'defense_mod']);
   assert.deepEqual(log, ['evasion_bonus', 'move_bonus', 'stress_reduction']);
 });
+
+// ─────────────────────────────────────────────────────────────────
+// P4 9/9 coverage extension — Type 1 / 4 / 6 wire
+// ─────────────────────────────────────────────────────────────────
+
+test('ENNEA_EFFECTS: 9/9 archetype coverage', () => {
+  const ids = Object.keys(ENNEA_EFFECTS).sort();
+  assert.deepEqual(ids, [
+    'Architetto(5)',
+    'Cacciatore(8)',
+    'Conquistatore(3)',
+    'Coordinatore(2)',
+    'Esploratore(7)',
+    'Individualista(4)',
+    'Lealista(6)',
+    'Riformatore(1)',
+    'Stoico(9)',
+  ]);
+});
+
+test('applyEnneaToStatus: Riformatore(1) → attack_mod_bonus +1 + status.attack_mod_buff:1', () => {
+  const actor = makeActor();
+  const effects = resolveEnneaEffects(['Riformatore(1)']);
+  const { applied, skipped } = applyEnneaToStatus(actor, effects);
+  assert.equal(actor.attack_mod_bonus, 1);
+  assert.equal(actor.status.attack_mod_buff, 1);
+  assert.equal(applied.length, 1);
+  assert.equal(applied[0].archetype, 'Riformatore(1)');
+  assert.equal(applied[0].stat, 'attack_mod');
+  assert.equal(applied[0].duration, 1);
+  assert.equal(skipped.length, 0);
+});
+
+test('applyEnneaToStatus: Individualista(4) → defense_mod_bonus +1 + status.defense_mod_buff:1', () => {
+  const actor = makeActor();
+  const effects = resolveEnneaEffects(['Individualista(4)']);
+  const { applied, skipped } = applyEnneaToStatus(actor, effects);
+  assert.equal(actor.defense_mod_bonus, 1);
+  assert.equal(actor.status.defense_mod_buff, 1);
+  assert.equal(applied.length, 1);
+  assert.equal(applied[0].stat, 'defense_mod');
+  assert.equal(applied[0].duration, 1);
+  assert.equal(skipped.length, 0);
+});
+
+test('applyEnneaToStatus: Lealista(6) → defense_mod_bonus +1 + status.defense_mod_buff:2 (extended)', () => {
+  const actor = makeActor();
+  const effects = resolveEnneaEffects(['Lealista(6)']);
+  const { applied, skipped } = applyEnneaToStatus(actor, effects);
+  assert.equal(actor.defense_mod_bonus, 1);
+  // Lealista has duration 2 — buff lasts longer than other defense buffs.
+  assert.equal(actor.status.defense_mod_buff, 2);
+  assert.equal(applied.length, 1);
+  assert.equal(applied[0].stat, 'defense_mod');
+  assert.equal(applied[0].duration, 2);
+  assert.equal(skipped.length, 0);
+});
+
+test('applyEnneaToStatus: stack Riformatore + Architetto → attack_mod_bonus +2', () => {
+  const actor = makeActor();
+  const effects = resolveEnneaEffects(['Riformatore(1)', 'Architetto(5)']);
+  assert.equal(effects.length, 2);
+  const { applied, skipped } = applyEnneaToStatus(actor, effects);
+  assert.equal(actor.attack_mod_bonus, 2);
+  assert.equal(actor.status.attack_mod_buff, 1);
+  assert.equal(applied.length, 2);
+  assert.equal(skipped.length, 0);
+});
+
+test('applyEnneaToStatus: stack Lealista(2) + Coordinatore(1) → defense_mod_bonus +2, buff=max(2,1)=2', () => {
+  const actor = makeActor();
+  const effects = resolveEnneaEffects(['Lealista(6)', 'Coordinatore(2)']);
+  assert.equal(effects.length, 2);
+  const { applied, skipped } = applyEnneaToStatus(actor, effects);
+  assert.equal(actor.defense_mod_bonus, 2);
+  // Lealista duration 2 wins over Coordinatore duration 1 via Math.max.
+  assert.equal(actor.status.defense_mod_buff, 2);
+  assert.equal(applied.length, 2);
+  assert.equal(skipped.length, 0);
+});
+
+test('decay coerenza: Lealista(6) duration=2 → buff persiste 2 round end', () => {
+  const actor = makeActor();
+  const effects = resolveEnneaEffects(['Lealista(6)']);
+  applyEnneaToStatus(actor, effects);
+  assert.equal(actor.defense_mod_bonus, 1);
+  assert.equal(actor.status.defense_mod_buff, 2);
+
+  // Round 1 end: decrement
+  for (const key of Object.keys(actor.status)) {
+    const v = Number(actor.status[key]);
+    if (v > 0) actor.status[key] = v - 1;
+  }
+  // After round 1: buff still > 0, bonus must NOT be zeroed.
+  assert.equal(actor.status.defense_mod_buff, 1);
+  for (const key of Object.keys(actor.status)) {
+    if (!key.endsWith('_buff')) continue;
+    if (Number(actor.status[key]) > 0) continue;
+    const stat = key.slice(0, -'_buff'.length);
+    const bonusKey = `${stat}_bonus`;
+    if (actor[bonusKey] !== undefined) actor[bonusKey] = 0;
+  }
+  assert.equal(actor.defense_mod_bonus, 1);
+
+  // Round 2 end: now decay to 0, bonus zeroed.
+  for (const key of Object.keys(actor.status)) {
+    const v = Number(actor.status[key]);
+    if (v > 0) actor.status[key] = v - 1;
+  }
+  for (const key of Object.keys(actor.status)) {
+    if (!key.endsWith('_buff')) continue;
+    if (Number(actor.status[key]) > 0) continue;
+    const stat = key.slice(0, -'_buff'.length);
+    const bonusKey = `${stat}_bonus`;
+    if (actor[bonusKey] !== undefined) actor[bonusKey] = 0;
+  }
+  assert.equal(actor.status.defense_mod_buff, 0);
+  assert.equal(actor.defense_mod_bonus, 0);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// computeEnneaArchetypes config-driven trigger eval (raw-metrics)
+// ─────────────────────────────────────────────────────────────────
+
+test('computeEnneaArchetypes: Riformatore(1) trigger when setup_ratio>0.5 && attack_hit_rate>0.65', () => {
+  const { computeEnneaArchetypes } = require('../../apps/backend/services/vcScoring');
+  const config = {
+    ennea_themes: [{ id: 'Riformatore(1)', when: 'setup_ratio>0.5 && attack_hit_rate>0.65' }],
+  };
+  const aggregate = {};
+  const triggered = computeEnneaArchetypes(aggregate, config, {
+    setup_ratio: 0.6,
+    attack_hit_rate: 0.7,
+  });
+  assert.equal(triggered.length, 1);
+  assert.equal(triggered[0].id, 'Riformatore(1)');
+  assert.equal(triggered[0].triggered, true);
+
+  const notTrig = computeEnneaArchetypes(aggregate, config, {
+    setup_ratio: 0.3,
+    attack_hit_rate: 0.7,
+  });
+  assert.equal(notTrig[0].triggered, false);
+});
+
+test('computeEnneaArchetypes: Individualista(4) trigger when low_hp_time>0.4 && damage_dealt_total>0', () => {
+  const { computeEnneaArchetypes } = require('../../apps/backend/services/vcScoring');
+  const config = {
+    ennea_themes: [{ id: 'Individualista(4)', when: 'low_hp_time>0.4 && damage_dealt_total>0' }],
+  };
+  const aggregate = {};
+  const triggered = computeEnneaArchetypes(aggregate, config, {
+    low_hp_time: 0.5,
+    damage_dealt_total: 3,
+  });
+  assert.equal(triggered[0].triggered, true);
+
+  const notTrig = computeEnneaArchetypes(aggregate, config, {
+    low_hp_time: 0.5,
+    damage_dealt_total: 0,
+  });
+  assert.equal(notTrig[0].triggered, false);
+});
+
+test('computeEnneaArchetypes: Lealista(6) trigger when assists>=2 && damage_taken_ratio<0.35', () => {
+  const { computeEnneaArchetypes } = require('../../apps/backend/services/vcScoring');
+  const config = {
+    ennea_themes: [{ id: 'Lealista(6)', when: 'assists>=2 && damage_taken_ratio<0.35' }],
+  };
+  const aggregate = {};
+  const triggered = computeEnneaArchetypes(aggregate, config, {
+    assists: 3,
+    damage_taken_ratio: 0.2,
+  });
+  assert.equal(triggered[0].triggered, true);
+
+  const notTrig = computeEnneaArchetypes(aggregate, config, {
+    assists: 1,
+    damage_taken_ratio: 0.2,
+  });
+  assert.equal(notTrig[0].triggered, false);
+});


### PR DESCRIPTION
Closes audit follow-up '9/9 archetype coverage'. P4 🟡+ → 🟢 candidato path.

## 3 NEW archetypes

| Type | Label | Stat | Duration | Trigger |
|---|---|---|---|---|
| Riformatore(1) | Disciplina Etica | attack_mod +1 | 1t | setup_ratio>0.5 + hit_rate>0.65 |
| Individualista(4) | Profondità Emotiva | defense_mod +1 | 1t | low_hp_time>0.4 + damage_dealt>0 |
| Lealista(6) | Vigilanza Difensiva | defense_mod +1 | **2t** | assists>=2 + damage_taken<0.35 |

All 3 mechanical (attack_mod/defense_mod) — maximizes runtime impact vs log_only. Lealista uses duration 2 per 'extended vigilance' theme.

## Test plan

- [x] tests/services/enneaEffectsWire.test.js → **24/24** (was 15, +9 NEW)
- [x] tests/ai/*.test.js → 311/311
- [x] tests/services/*.test.js → 394/394
- [x] governance + prettier → verde

Total: +261 / -35 LOC.

🤖 Claude Code