### PR TITLE
feat(combat): telepatic_link reveal pipe — wire enemy intents disclosure

### DIFF
--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -44,6 +44,15 @@ const { tick: missionTimerTick } = require('../services/combat/missionTimer');
 const { buildThreatPreview } = require('../services/ai/threatPreview');
 // Status engine extension (2026-04-25 audit P0).
 const { applyTurnRegen } = require('../services/combat/statusModifiers');
+// Telepatic-link reveal pipe (2026-04-25 audit follow-up). Lazy-loaded with
+// graceful fallback so missing module never blocks /round/begin-planning.
+let computeTelepathicReveal = null;
+try {
+  // eslint-disable-next-line global-require
+  ({ computeTelepathicReveal } = require('../services/combat/telepathicReveal'));
+} catch (_err) {
+  computeTelepathicReveal = null;
+}
 
 function createRoundBridge(deps) {
   const {
@@ -1345,6 +1354,19 @@ function createRoundBridge(deps) {
         // main.js tooltip. Empty array se nessun SIS intent.
         const threatPreview = buildThreatPreview(session);
 
+        // Telepatic-link reveal (2026-04-25 follow-up): per-actor enemy
+        // intent foresight when status.telepatic_link active. Additive
+        // field: empty array if no actor has the status. Wrapped try/catch
+        // so reveal pipe failure never blocks round planning.
+        let revealedIntents = [];
+        if (typeof computeTelepathicReveal === 'function') {
+          try {
+            revealedIntents = computeTelepathicReveal(session);
+          } catch (_err) {
+            revealedIntents = [];
+          }
+        }
+
         res.json({
           session_id: session.session_id,
           turn: session.turn,
@@ -1353,6 +1375,7 @@ function createRoundBridge(deps) {
           sistema_decisions: sisDecisions,
           sistema_intents_count: sisIntents.length,
           threat_preview: threatPreview,
+          revealed_intents: revealedIntents,
           hazard_events: hazardEvents,
           side_effects: bleedingEvents,
           state: publicSessionView(session),

--- a/apps/backend/services/combat/telepathicReveal.js
+++ b/apps/backend/services/combat/telepathicReveal.js
@@ -1,0 +1,117 @@
+// apps/backend/services/combat/telepathicReveal.js
+//
+// Telepatic-link real intent-reveal pipe (2026-04-25 audit follow-up to
+// PR #1822 status engine extension + PR #1811 magnetic_rift_resonance).
+//
+// Design intent: when a player-side actor has `status.telepatic_link > 0`,
+// the player gains foresight on enemy intents within `range` hex. This
+// turns the trait `magnetic_rift_resonance` (and any future trait that
+// applies `telepatic_link`) from a log marker (status only) into an
+// actionable reveal driving planning-phase decisions.
+//
+// Output shape (per actor with active link):
+//   {
+//     actor_id: 'p_scout',
+//     revealed: [
+//       { enemy_id: 'e_nomad_1', intent_type: 'attack',
+//         target_id: 'p_tank', distance: 2 },
+//       ...
+//     ],
+//   }
+//
+// Skips:
+//   • actor sin telepatic_link <= 0
+//   • actor KO (hp <= 0)
+//   • enemy KO
+//   • enemy out of range
+//   • no roundState.pending_intents (declare phase not started)
+//
+// Pure function. No side effects, no mutation. Lazy-safe consumers can
+// try/catch around the call without breaking core flow.
+
+'use strict';
+
+const DEFAULT_RANGE = 3;
+
+function manhattanDistance(a, b) {
+  if (!a || !b) return Infinity;
+  const dx = Number(a.x) - Number(b.x);
+  const dy = Number(a.y) - Number(b.y);
+  if (!Number.isFinite(dx) || !Number.isFinite(dy)) return Infinity;
+  return Math.abs(dx) + Math.abs(dy);
+}
+
+function _unitById(units, id) {
+  if (!Array.isArray(units) || !id) return null;
+  return units.find((u) => u && u.id === id) || null;
+}
+
+function _isPositive(v) {
+  return Number(v) > 0;
+}
+
+/**
+ * Compute telepathic reveal payload for all actors with active
+ * `telepatic_link` status.
+ *
+ * @param {object} session — `{ units, roundState: { pending_intents } }`
+ * @param {object} [opts]
+ * @param {number} [opts.range=3] — manhattan range in hex
+ * @returns {Array<{actor_id, revealed: Array<{enemy_id, intent_type, target_id, distance}>}>}
+ */
+function computeTelepathicReveal(session, opts = {}) {
+  if (!session || !Array.isArray(session.units) || session.units.length === 0) {
+    return [];
+  }
+  const range = Number.isFinite(Number(opts.range)) ? Number(opts.range) : DEFAULT_RANGE;
+  const roundState = session.roundState;
+  if (!roundState) return [];
+  const pending = Array.isArray(roundState.pending_intents) ? roundState.pending_intents : [];
+  if (pending.length === 0) return [];
+
+  const out = [];
+  for (const actor of session.units) {
+    if (!actor || !actor.id) continue;
+    if (Number(actor.hp || 0) <= 0) continue;
+    const status = actor.status || {};
+    if (!_isPositive(status.telepatic_link)) continue;
+
+    const revealed = [];
+    for (const intent of pending) {
+      if (!intent || !intent.unit_id) continue;
+      const enemy = _unitById(session.units, intent.unit_id);
+      if (!enemy) continue;
+      if (Number(enemy.hp || 0) <= 0) continue;
+      // Only reveal intents from units on opposite faction.
+      if (
+        enemy.controlled_by &&
+        actor.controlled_by &&
+        enemy.controlled_by === actor.controlled_by
+      ) {
+        continue;
+      }
+      const distance = manhattanDistance(actor.position, enemy.position);
+      if (!Number.isFinite(distance) || distance > range) continue;
+
+      const action = intent.action || {};
+      revealed.push({
+        enemy_id: enemy.id,
+        intent_type: action.type || 'unknown',
+        target_id: action.target_id || null,
+        distance,
+      });
+    }
+
+    if (revealed.length > 0) {
+      out.push({ actor_id: actor.id, revealed });
+    }
+  }
+  return out;
+}
+
+module.exports = {
+  computeTelepathicReveal,
+  DEFAULT_RANGE,
+  // exported for tests
+  manhattanDistance,
+};

--- a/tests/services/telepathicReveal.test.js
+++ b/tests/services/telepathicReveal.test.js
@@ -1,0 +1,300 @@
+// tests/services/telepathicReveal.test.js
+//
+// Telepatic-link real intent-reveal pipe (2026-04-25 audit follow-up to
+// PR #1822 + PR #1811 magnetic_rift_resonance).
+//
+// Probes per-actor reveal payload: when actor has status.telepatic_link > 0,
+// enemy intents within range N (default 3) are exposed for planning-phase
+// foresight. Pure helper, additive to threat_preview pipeline.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  computeTelepathicReveal,
+  DEFAULT_RANGE,
+  manhattanDistance,
+} = require('../../apps/backend/services/combat/telepathicReveal');
+
+// ─────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────
+
+function makeUnit(overrides = {}) {
+  return {
+    id: 'u1',
+    hp: 10,
+    max_hp: 10,
+    controlled_by: 'player',
+    position: { x: 0, y: 0 },
+    status: {},
+    ...overrides,
+  };
+}
+
+function makeSession(units, pendingIntents) {
+  return {
+    units,
+    roundState: { pending_intents: pendingIntents },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Sanity / defaults
+// ─────────────────────────────────────────────────────────────────
+
+test('DEFAULT_RANGE is 3', () => {
+  assert.equal(DEFAULT_RANGE, 3);
+});
+
+test('manhattanDistance: basic + null guards', () => {
+  assert.equal(manhattanDistance({ x: 0, y: 0 }, { x: 2, y: 1 }), 3);
+  assert.equal(manhattanDistance({ x: 1, y: 1 }, { x: 1, y: 1 }), 0);
+  assert.equal(manhattanDistance(null, { x: 0, y: 0 }), Infinity);
+  assert.equal(manhattanDistance({ x: 0, y: 0 }, null), Infinity);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Empty / degraded inputs
+// ─────────────────────────────────────────────────────────────────
+
+test('computeTelepathicReveal: null session → []', () => {
+  assert.deepEqual(computeTelepathicReveal(null), []);
+  assert.deepEqual(computeTelepathicReveal({}), []);
+  assert.deepEqual(computeTelepathicReveal({ units: [] }), []);
+});
+
+test('computeTelepathicReveal: no roundState → []', () => {
+  const session = { units: [makeUnit()] };
+  assert.deepEqual(computeTelepathicReveal(session), []);
+});
+
+test('computeTelepathicReveal: empty pending_intents → []', () => {
+  const session = makeSession([makeUnit()], []);
+  assert.deepEqual(computeTelepathicReveal(session), []);
+});
+
+test('computeTelepathicReveal: no actor has telepatic_link → []', () => {
+  const player = makeUnit({ id: 'p_scout', position: { x: 1, y: 1 } });
+  const enemy = makeUnit({
+    id: 'e_nomad_1',
+    controlled_by: 'sistema',
+    position: { x: 2, y: 1 },
+  });
+  const session = makeSession(
+    [player, enemy],
+    [{ unit_id: 'e_nomad_1', action: { type: 'attack', target_id: 'p_scout' } }],
+  );
+  assert.deepEqual(computeTelepathicReveal(session), []);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Active link cases
+// ─────────────────────────────────────────────────────────────────
+
+test('computeTelepathicReveal: active link reveals enemy attack within range', () => {
+  const player = makeUnit({
+    id: 'p_scout',
+    position: { x: 1, y: 1 },
+    status: { telepatic_link: 2 },
+  });
+  const enemy = makeUnit({
+    id: 'e_nomad_1',
+    controlled_by: 'sistema',
+    position: { x: 2, y: 2 }, // distance 2 ≤ 3
+  });
+  const session = makeSession(
+    [player, enemy],
+    [{ unit_id: 'e_nomad_1', action: { type: 'attack', target_id: 'p_scout' } }],
+  );
+  const result = computeTelepathicReveal(session);
+  assert.equal(result.length, 1);
+  assert.deepEqual(result[0], {
+    actor_id: 'p_scout',
+    revealed: [{ enemy_id: 'e_nomad_1', intent_type: 'attack', target_id: 'p_scout', distance: 2 }],
+  });
+});
+
+test('computeTelepathicReveal: enemy out of range NOT revealed', () => {
+  const player = makeUnit({
+    id: 'p_scout',
+    position: { x: 0, y: 0 },
+    status: { telepatic_link: 1 },
+  });
+  const farEnemy = makeUnit({
+    id: 'e_far',
+    controlled_by: 'sistema',
+    position: { x: 5, y: 5 }, // distance 10 > 3
+  });
+  const session = makeSession(
+    [player, farEnemy],
+    [{ unit_id: 'e_far', action: { type: 'move', move_to: { x: 4, y: 5 } } }],
+  );
+  assert.deepEqual(computeTelepathicReveal(session), []);
+});
+
+test('computeTelepathicReveal: respects custom range', () => {
+  const player = makeUnit({
+    id: 'p_scout',
+    position: { x: 0, y: 0 },
+    status: { telepatic_link: 1 },
+  });
+  const enemy = makeUnit({
+    id: 'e_far',
+    controlled_by: 'sistema',
+    position: { x: 5, y: 0 }, // distance 5
+  });
+  const session = makeSession(
+    [player, enemy],
+    [{ unit_id: 'e_far', action: { type: 'attack', target_id: 'p_scout' } }],
+  );
+  // Default 3 → no reveal
+  assert.deepEqual(computeTelepathicReveal(session), []);
+  // Range 6 → reveal
+  const widened = computeTelepathicReveal(session, { range: 6 });
+  assert.equal(widened.length, 1);
+  assert.equal(widened[0].revealed[0].distance, 5);
+});
+
+test('computeTelepathicReveal: KO actor → no reveal', () => {
+  const player = makeUnit({
+    id: 'p_scout',
+    hp: 0,
+    position: { x: 1, y: 1 },
+    status: { telepatic_link: 2 },
+  });
+  const enemy = makeUnit({
+    id: 'e_nomad_1',
+    controlled_by: 'sistema',
+    position: { x: 2, y: 1 },
+  });
+  const session = makeSession(
+    [player, enemy],
+    [{ unit_id: 'e_nomad_1', action: { type: 'attack', target_id: 'p_scout' } }],
+  );
+  assert.deepEqual(computeTelepathicReveal(session), []);
+});
+
+test('computeTelepathicReveal: KO enemy NOT in revealed', () => {
+  const player = makeUnit({
+    id: 'p_scout',
+    position: { x: 1, y: 1 },
+    status: { telepatic_link: 2 },
+  });
+  const deadEnemy = makeUnit({
+    id: 'e_dead',
+    hp: 0,
+    controlled_by: 'sistema',
+    position: { x: 2, y: 1 },
+  });
+  const session = makeSession(
+    [player, deadEnemy],
+    [{ unit_id: 'e_dead', action: { type: 'attack', target_id: 'p_scout' } }],
+  );
+  assert.deepEqual(computeTelepathicReveal(session), []);
+});
+
+test('computeTelepathicReveal: same-faction intent NOT revealed', () => {
+  const player = makeUnit({
+    id: 'p_scout',
+    position: { x: 1, y: 1 },
+    status: { telepatic_link: 2 },
+  });
+  const ally = makeUnit({ id: 'p_tank', position: { x: 2, y: 1 } });
+  const session = makeSession(
+    [player, ally],
+    // ally intent (same player faction) → not revealed
+    [{ unit_id: 'p_tank', action: { type: 'attack', target_id: 'e_x' } }],
+  );
+  assert.deepEqual(computeTelepathicReveal(session), []);
+});
+
+test('computeTelepathicReveal: multi-actor independent reveals', () => {
+  const a = makeUnit({
+    id: 'p_a',
+    position: { x: 0, y: 0 },
+    status: { telepatic_link: 2 },
+  });
+  const b = makeUnit({
+    id: 'p_b',
+    position: { x: 8, y: 8 },
+    status: { telepatic_link: 1 },
+  });
+  const e1 = makeUnit({
+    id: 'e_close_to_a',
+    controlled_by: 'sistema',
+    position: { x: 1, y: 0 }, // distance 1 from a, 15 from b
+  });
+  const e2 = makeUnit({
+    id: 'e_close_to_b',
+    controlled_by: 'sistema',
+    position: { x: 7, y: 8 }, // distance 15 from a, 1 from b
+  });
+  const session = makeSession(
+    [a, b, e1, e2],
+    [
+      { unit_id: 'e_close_to_a', action: { type: 'attack', target_id: 'p_a' } },
+      { unit_id: 'e_close_to_b', action: { type: 'move', move_to: { x: 7, y: 7 } } },
+    ],
+  );
+  const result = computeTelepathicReveal(session);
+  assert.equal(result.length, 2);
+  const byActor = Object.fromEntries(result.map((r) => [r.actor_id, r.revealed]));
+  assert.equal(byActor.p_a.length, 1);
+  assert.equal(byActor.p_a[0].enemy_id, 'e_close_to_a');
+  assert.equal(byActor.p_b.length, 1);
+  assert.equal(byActor.p_b[0].enemy_id, 'e_close_to_b');
+});
+
+test('computeTelepathicReveal: multiple enemies for single actor', () => {
+  const player = makeUnit({
+    id: 'p_scout',
+    position: { x: 0, y: 0 },
+    status: { telepatic_link: 3 },
+  });
+  const e1 = makeUnit({
+    id: 'e_1',
+    controlled_by: 'sistema',
+    position: { x: 1, y: 0 },
+  });
+  const e2 = makeUnit({
+    id: 'e_2',
+    controlled_by: 'sistema',
+    position: { x: 0, y: 2 },
+  });
+  const session = makeSession(
+    [player, e1, e2],
+    [
+      { unit_id: 'e_1', action: { type: 'attack', target_id: 'p_scout' } },
+      { unit_id: 'e_2', action: { type: 'skip' } },
+    ],
+  );
+  const result = computeTelepathicReveal(session);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].revealed.length, 2);
+  const byEnemy = Object.fromEntries(result[0].revealed.map((r) => [r.enemy_id, r]));
+  assert.equal(byEnemy.e_1.intent_type, 'attack');
+  assert.equal(byEnemy.e_1.target_id, 'p_scout');
+  assert.equal(byEnemy.e_2.intent_type, 'skip');
+  assert.equal(byEnemy.e_2.target_id, null);
+});
+
+test('computeTelepathicReveal: zero/negative status value → skip', () => {
+  const player = makeUnit({
+    id: 'p_scout',
+    position: { x: 0, y: 0 },
+    status: { telepatic_link: 0 },
+  });
+  const enemy = makeUnit({
+    id: 'e_nomad_1',
+    controlled_by: 'sistema',
+    position: { x: 1, y: 0 },
+  });
+  const session = makeSession(
+    [player, enemy],
+    [{ unit_id: 'e_nomad_1', action: { type: 'attack', target_id: 'p_scout' } }],
+  );
+  assert.deepEqual(computeTelepathicReveal(session), []);
+});


### PR DESCRIPTION
Closes audit follow-up 'telepatic_link real intent-reveal pipe'. Magnetic_rift_resonance trait now delivers design intent.

## Wire

- NEW helper `apps/backend/services/combat/telepathicReveal.js` (+108 LOC): `computeTelepathicReveal(session, opts)` returns per-actor reveals
- Hook in `sessionRoundBridge.js` `/round/begin-planning` response — same lifecycle as buildThreatPreview
- Lazy import + try/catch graceful degradation

## Test

- 15/15 NEW + 311/311 AI + 409/409 services
- Edges: null/KO/same-faction/out-of-range/multi-actor/status=0

## Files

- `apps/backend/services/combat/telepathicReveal.js` NEW +108
- `apps/backend/routes/sessionRoundBridge.js` +23
- `tests/services/telepathicReveal.test.js` NEW +280

Total: +411 LOC.

🤖 Claude Code