### PR TITLE
feat(combat): per-tag enemy-status gate (predator/irascible/wildlife)

### DIFF
--- a/apps/backend/services/traitEffects.js
+++ b/apps/backend/services/traitEffects.js
@@ -51,6 +51,18 @@ const BIOME_COST_STATS_ALLOWED = new Set(['attack_mod', 'defense_mod', 'mobility
 
 let _biomeCostCache = null;
 
+// Per-tag enemy gate (audit follow-up 2026-04-25) — wires runtime-inert
+// ancestor traits gated by enemy taxonomy: predator / irascible / wildlife.
+// Source files: data/core/species.yaml + data/core/species_expansion.yaml
+// (clade_tag + role_tags). Lazy-cached singleton, soft-fail su ENOENT.
+const SPECIES_DEFAULT_PATHS = [
+  path.resolve(__dirname, '..', '..', '..', 'data', 'core', 'species.yaml'),
+  path.resolve(__dirname, '..', '..', '..', 'data', 'core', 'species_expansion.yaml'),
+];
+
+const PREDATOR_ROLE_TAGS = new Set(['predator', 'apex', 'ambusher']);
+let _speciesTagIndexCache = null;
+
 function loadActiveTraitRegistry(yamlPath = DEFAULT_REGISTRY_PATH, logger = console) {
   try {
     const text = fs.readFileSync(yamlPath, 'utf8');
@@ -110,6 +122,97 @@ function hasTargetStatus(target, statusName) {
   return Boolean(entry);
 }
 
+// Per-tag enemy gate — carica species.yaml + species_expansion.yaml e
+// costruisce indice { species_id: { clade_tag, role_tags: Set } }.
+// Lazy + cached. Soft-fail: file mancante → indice vuoto, gate ritorna
+// `wildlife` come default conservativo.
+function loadSpeciesTagIndex(yamlPaths = SPECIES_DEFAULT_PATHS, logger = console) {
+  if (_speciesTagIndexCache !== null) return _speciesTagIndexCache;
+  const index = Object.create(null);
+  for (const yamlPath of yamlPaths) {
+    try {
+      const text = fs.readFileSync(yamlPath, 'utf8');
+      const parsed = yaml.load(text);
+      // Top-level key varia: species.yaml usa `species`, species_expansion.yaml
+      // usa `species_examples`. Accetta entrambe.
+      const list =
+        parsed && Array.isArray(parsed.species)
+          ? parsed.species
+          : parsed && Array.isArray(parsed.species_examples)
+            ? parsed.species_examples
+            : [];
+      for (const sp of list) {
+        if (!sp || !sp.id) continue;
+        const roleTags = Array.isArray(sp.role_tags)
+          ? sp.role_tags.map((t) => String(t).toLowerCase())
+          : [];
+        index[sp.id] = {
+          clade_tag: sp.clade_tag || null,
+          role_tags: new Set(roleTags),
+        };
+      }
+    } catch (err) {
+      if (err && err.code === 'ENOENT') {
+        logger.warn(`[enemy-tag-gate] ${yamlPath} non trovato, skip`);
+        continue;
+      }
+      logger.warn(`[enemy-tag-gate] errore ${yamlPath}:`, err.message || err);
+    }
+  }
+  _speciesTagIndexCache = index;
+  return _speciesTagIndexCache;
+}
+
+function _resetSpeciesTagIndexCache() {
+  _speciesTagIndexCache = null;
+}
+
+// Inferisce i tag enemy ('predator' | 'irascible' | 'wildlife') del target
+// basandosi su species + clade_tag + role_tags. Tassonomia:
+//   - predator: role_tags include predator/apex/ambusher OR clade_tag=Apex
+//   - irascible: clade_tag=Threat AND role_tags presenti AND non predator
+//                (es. [threat, forager], [threat, omnivore])
+//   - wildlife: tutto il resto fra organici (Bridge/Keystone/Support, o
+//     Threat senza role_tags). Default conservativo se species ignota.
+//
+// Ritorna sempre un array (mai null). Multi-tag possibile (un Apex predator
+// e' solo 'predator'; un Threat ambiguo puo' essere predator+wildlife).
+function inferEnemyTags(target, index = null) {
+  if (!target || !target.species) return ['wildlife'];
+  const idx = index || loadSpeciesTagIndex();
+  const entry = idx[target.species];
+  if (!entry) return ['wildlife'];
+  const tags = new Set();
+  const clade = entry.clade_tag;
+  const roles = entry.role_tags || new Set();
+
+  let isPredator = false;
+  for (const r of roles) {
+    if (PREDATOR_ROLE_TAGS.has(r)) {
+      isPredator = true;
+      break;
+    }
+  }
+  if (!isPredator && clade === 'Apex') isPredator = true;
+  if (isPredator) tags.add('predator');
+
+  // Irascible: Threat clade NON predator, con role_tags non-predator
+  // (forager, omnivore, ecc.). Conservativo: richiede role_tags.
+  if (!isPredator && clade === 'Threat' && roles.size > 0) {
+    tags.add('irascible');
+  }
+
+  // Wildlife: organici non classificati (Bridge/Keystone/Support, o Threat
+  // senza role_tags fallback). Esclude Playable.
+  if (!tags.size && clade && clade !== 'Playable') {
+    tags.add('wildlife');
+  }
+
+  // Fallback conservativo: nessun match → wildlife
+  if (!tags.size) tags.add('wildlife');
+  return Array.from(tags);
+}
+
 // Valida i trigger che NON dipendono dallo stato post-attack
 // (on_result, min_mos, requires). Ritorna true se tutti i check
 // statici passano, false se uno blocca.
@@ -127,6 +230,14 @@ function passesBasicTriggers(trigger, actor, target, attackResult, ctx = {}) {
     !hasTargetStatus(target, trigger.requires_target_status)
   )
     return false;
+  if (typeof trigger.requires_target_tag === 'string') {
+    const tags = inferEnemyTags(target, ctx.speciesTagIndex || null);
+    if (!tags.includes(trigger.requires_target_tag)) return false;
+  }
+  if (typeof trigger.requires_actor_tag === 'string') {
+    const tags = inferEnemyTags(actor, ctx.speciesTagIndex || null);
+    if (!tags.includes(trigger.requires_actor_tag)) return false;
+  }
   return true;
 }
 
@@ -385,4 +496,9 @@ module.exports = {
   applyBiomeTraitCosts,
   BIOME_COST_DEFAULT_PATH,
   _resetBiomeCostCache,
+  // Per-tag enemy gate (audit follow-up 2026-04-25)
+  loadSpeciesTagIndex,
+  inferEnemyTags,
+  SPECIES_DEFAULT_PATHS,
+  _resetSpeciesTagIndexCache,
 };

--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -2820,6 +2820,7 @@ traits:
       action_type: attack
       on_result: hit
       min_mos: 5
+      requires_target_tag: predator
     effect:
       kind: apply_status
       target_side: actor
@@ -2843,6 +2844,7 @@ traits:
       action_type: attack
       on_result: hit
       min_mos: 5
+      requires_target_tag: irascible
     effect:
       kind: apply_status
       target_side: actor
@@ -2865,6 +2867,7 @@ traits:
       action_type: attack
       on_result: hit
       min_mos: 5
+      requires_target_tag: wildlife
     effect:
       kind: apply_status
       target_side: actor
@@ -2909,6 +2912,7 @@ traits:
       on_result: hit
       melee_only: true
       min_mos: 3
+      requires_target_tag: irascible
     effect:
       kind: extra_damage
       amount: 1
@@ -2930,6 +2934,7 @@ traits:
       on_result: hit
       melee_only: true
       min_mos: 3
+      requires_target_tag: wildlife
     effect:
       kind: extra_damage
       amount: 1
@@ -2950,6 +2955,7 @@ traits:
       on_result: hit
       melee_only: true
       min_mos: 3
+      requires_target_tag: predator
     effect:
       kind: extra_damage
       amount: 1
@@ -3033,6 +3039,7 @@ traits:
     trigger:
       action_type: attack
       on_result: hit
+      requires_actor_tag: predator
     effect:
       kind: damage_reduction
       amount: 1
@@ -3053,6 +3060,7 @@ traits:
     trigger:
       action_type: attack
       on_result: hit
+      requires_actor_tag: irascible
     effect:
       kind: damage_reduction
       amount: 1
@@ -3073,6 +3081,7 @@ traits:
     trigger:
       action_type: attack
       on_result: hit
+      requires_actor_tag: wildlife
     effect:
       kind: damage_reduction
       amount: 1

--- a/tests/services/enemyTagGate.test.js
+++ b/tests/services/enemyTagGate.test.js
@@ -1,0 +1,314 @@
+// Audit follow-up 2026-04-25: per-tag enemy gate (predator/irascible/wildlife)
+//
+// Copre:
+//   - inferEnemyTags: tassonomia (predator/irascible/wildlife) per species
+//   - passesBasicTriggers indirect via evaluateAttackTraits:
+//     * requires_target_tag: blocca quando tag mismatch
+//     * requires_actor_tag: blocca quando tag mismatch (dodge target-side)
+//     * Multi-tag target: trait fires se tag-match in set
+//     * Edge: missing target/species → fallback wildlife
+//     * Edge: malformed clade → wildlife default
+//   - Regression: trait senza requires_target_tag continua a passare
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const {
+  loadActiveTraitRegistry,
+  evaluateAttackTraits,
+  loadSpeciesTagIndex,
+  inferEnemyTags,
+  _resetSpeciesTagIndexCache,
+} = require('../../apps/backend/services/traitEffects');
+
+const TRAIT_REGISTRY_PATH = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'data',
+  'core',
+  'traits',
+  'active_effects.yaml',
+);
+const registry = loadActiveTraitRegistry(TRAIT_REGISTRY_PATH, {
+  log: () => {},
+  warn: () => {},
+});
+
+// Pre-warm species tag index dal repo reale
+_resetSpeciesTagIndexCache();
+const speciesIndex = loadSpeciesTagIndex(undefined, { warn: () => {} });
+
+function buildUnit(overrides = {}) {
+  return {
+    id: 'unit_test',
+    hp: 10,
+    max_hp: 10,
+    position: { x: 0, y: 0 },
+    traits: [],
+    ...overrides,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────
+// inferEnemyTags — tassonomia base
+// ─────────────────────────────────────────────────────────────────
+
+test('inferEnemyTags: Apex predator species → predator', () => {
+  const target = buildUnit({ species: 'sp_arenavolux_sagittalis' }); // Apex
+  const tags = inferEnemyTags(target, speciesIndex);
+  assert.deepEqual(tags, ['predator']);
+});
+
+test('inferEnemyTags: Threat predator species → predator', () => {
+  const target = buildUnit({ species: 'sp_lithoraptor_acutornis' }); // Threat + predator
+  const tags = inferEnemyTags(target, speciesIndex);
+  assert.deepEqual(tags, ['predator']);
+});
+
+test('inferEnemyTags: Threat ambusher → predator', () => {
+  const target = buildUnit({ species: 'sp_pyrosaltus_celeris' }); // Threat + ambusher
+  const tags = inferEnemyTags(target, speciesIndex);
+  assert.deepEqual(tags, ['predator']);
+});
+
+test('inferEnemyTags: Threat omnivore (non-predator) → irascible', () => {
+  const target = buildUnit({ species: 'sp_tonitrudens_ferox' }); // Threat + omnivore
+  const tags = inferEnemyTags(target, speciesIndex);
+  assert.deepEqual(tags, ['irascible']);
+});
+
+test('inferEnemyTags: Threat forager → irascible', () => {
+  const target = buildUnit({ species: 'sp_vitricyba_punctata' }); // Threat + forager
+  const tags = inferEnemyTags(target, speciesIndex);
+  assert.deepEqual(tags, ['irascible']);
+});
+
+test('inferEnemyTags: Bridge non-predator → wildlife', () => {
+  const target = buildUnit({ species: 'sp_ventornis_longiala' }); // Bridge + scout
+  const tags = inferEnemyTags(target, speciesIndex);
+  assert.deepEqual(tags, ['wildlife']);
+});
+
+test('inferEnemyTags: Keystone scavenger → wildlife', () => {
+  const target = buildUnit({ species: 'sp_ferriscroba_detrita' }); // Keystone + scavenger
+  const tags = inferEnemyTags(target, speciesIndex);
+  assert.deepEqual(tags, ['wildlife']);
+});
+
+test('inferEnemyTags: Support sentinel → wildlife', () => {
+  const target = buildUnit({ species: 'sp_basaltocara_scutata' }); // Support + sentinel
+  const tags = inferEnemyTags(target, speciesIndex);
+  assert.deepEqual(tags, ['wildlife']);
+});
+
+test('inferEnemyTags: missing target → wildlife (fallback)', () => {
+  assert.deepEqual(inferEnemyTags(null, speciesIndex), ['wildlife']);
+});
+
+test('inferEnemyTags: missing species → wildlife (fallback)', () => {
+  const target = buildUnit({ species: undefined });
+  assert.deepEqual(inferEnemyTags(target, speciesIndex), ['wildlife']);
+});
+
+test('inferEnemyTags: unknown species id → wildlife (fallback)', () => {
+  const target = buildUnit({ species: 'sp_does_not_exist_xyz' });
+  assert.deepEqual(inferEnemyTags(target, speciesIndex), ['wildlife']);
+});
+
+test('inferEnemyTags: malformed clade (Playable) → wildlife default closed', () => {
+  // species Playable: gate dovrebbe ritornare wildlife default (no match
+  // predator/irascible). Conservative — Playable non e' un enemy ma il
+  // gate deve fallire chiuso, non aprire.
+  const target = buildUnit({ species: 'sp_calamipes_gracilis' }); // Playable
+  const tags = inferEnemyTags(target, speciesIndex);
+  assert.deepEqual(tags, ['wildlife']);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// passesBasicTriggers via evaluateAttackTraits — requires_target_tag
+// ─────────────────────────────────────────────────────────────────
+
+test('requires_target_tag predator: matches predator → trait fires', () => {
+  const actor = buildUnit({
+    id: 'a',
+    position: { x: 0, y: 0 },
+    traits: ['ancestor_attack_counter_predator'],
+  });
+  const target = buildUnit({
+    id: 't',
+    position: { x: 1, y: 0 },
+    species: 'sp_lithoraptor_acutornis', // predator
+  });
+  const result = evaluateAttackTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 4 },
+    allUnits: [actor, target],
+  });
+  const evt = result.trait_effects.find((e) => e.trait === 'ancestor_attack_counter_predator');
+  assert.equal(evt.triggered, true);
+  assert.equal(result.damage_modifier, 1);
+});
+
+test('requires_target_tag predator: blocks irascible target', () => {
+  const actor = buildUnit({
+    id: 'a',
+    position: { x: 0, y: 0 },
+    traits: ['ancestor_attack_counter_predator'],
+  });
+  const target = buildUnit({
+    id: 't',
+    position: { x: 1, y: 0 },
+    species: 'sp_tonitrudens_ferox', // irascible
+  });
+  const result = evaluateAttackTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 4 },
+    allUnits: [actor, target],
+  });
+  const evt = result.trait_effects.find((e) => e.trait === 'ancestor_attack_counter_predator');
+  assert.equal(evt.triggered, false);
+  assert.equal(result.damage_modifier, 0);
+});
+
+test('requires_target_tag wildlife: matches wildlife target', () => {
+  const actor = buildUnit({
+    id: 'a',
+    position: { x: 0, y: 0 },
+    traits: ['ancestor_attack_counter_wildlife'],
+  });
+  const target = buildUnit({
+    id: 't',
+    position: { x: 1, y: 0 },
+    species: 'sp_ferriscroba_detrita', // wildlife (Keystone+scavenger)
+  });
+  const result = evaluateAttackTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 4 },
+    allUnits: [actor, target],
+  });
+  const evt = result.trait_effects.find((e) => e.trait === 'ancestor_attack_counter_wildlife');
+  assert.equal(evt.triggered, true);
+});
+
+test('requires_target_tag irascible: blocks wildlife target', () => {
+  const actor = buildUnit({
+    id: 'a',
+    position: { x: 0, y: 0 },
+    traits: ['ancestor_attack_counter_irascible'],
+  });
+  const target = buildUnit({
+    id: 't',
+    position: { x: 1, y: 0 },
+    species: 'sp_ferriscroba_detrita', // wildlife
+  });
+  const result = evaluateAttackTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 4 },
+    allUnits: [actor, target],
+  });
+  const evt = result.trait_effects.find((e) => e.trait === 'ancestor_attack_counter_irascible');
+  assert.equal(evt.triggered, false);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// requires_actor_tag (dodge target-side) — gate sull'attaccante
+// ─────────────────────────────────────────────────────────────────
+
+test('requires_actor_tag predator: dodge fires when attacker is predator', () => {
+  const actor = buildUnit({
+    id: 'a',
+    position: { x: 0, y: 0 },
+    species: 'sp_arenavolux_sagittalis', // Apex predator
+  });
+  const target = buildUnit({
+    id: 't',
+    position: { x: 1, y: 0 },
+    traits: ['ancestor_dodge_evasive_predator'],
+  });
+  const result = evaluateAttackTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 2 },
+    allUnits: [actor, target],
+  });
+  const evt = result.trait_effects.find((e) => e.trait === 'ancestor_dodge_evasive_predator');
+  assert.equal(evt.triggered, true);
+  assert.equal(result.damage_modifier, -1);
+});
+
+test('requires_actor_tag predator: dodge blocked when attacker is wildlife', () => {
+  const actor = buildUnit({
+    id: 'a',
+    position: { x: 0, y: 0 },
+    species: 'sp_ferriscroba_detrita', // wildlife
+  });
+  const target = buildUnit({
+    id: 't',
+    position: { x: 1, y: 0 },
+    traits: ['ancestor_dodge_evasive_predator'],
+  });
+  const result = evaluateAttackTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 2 },
+    allUnits: [actor, target],
+  });
+  const evt = result.trait_effects.find((e) => e.trait === 'ancestor_dodge_evasive_predator');
+  assert.equal(evt.triggered, false);
+  assert.equal(result.damage_modifier, 0);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Regression — trait pre-existenti non gated continuano a fire
+// ─────────────────────────────────────────────────────────────────
+
+test('regression: pelle_elastomera (no tag gate) fires on hit indipendentemente da species', () => {
+  const actor = buildUnit({ id: 'a', position: { x: 0, y: 0 } });
+  const target = buildUnit({
+    id: 't',
+    position: { x: 1, y: 0 },
+    traits: ['pelle_elastomera'],
+    species: 'sp_does_not_exist_xyz',
+  });
+  const result = evaluateAttackTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 1 },
+    allUnits: [actor, target],
+  });
+  const evt = result.trait_effects.find((e) => e.trait === 'pelle_elastomera');
+  assert.equal(evt.triggered, true);
+  assert.equal(result.damage_modifier, -1);
+});
+
+test('regression: ancestor_attack_fight_response (no tag gate) fires on melee hit', () => {
+  const actor = buildUnit({
+    id: 'a',
+    position: { x: 0, y: 0 },
+    traits: ['ancestor_attack_fight_response'],
+  });
+  const target = buildUnit({ id: 't', position: { x: 1, y: 0 }, species: 'sp_ventornis_longiala' });
+  const result = evaluateAttackTraits({
+    registry,
+    actor,
+    target,
+    attackResult: { hit: true, mos: 2 },
+    allUnits: [actor, target],
+  });
+  const evt = result.trait_effects.find((e) => e.trait === 'ancestor_attack_fight_response');
+  assert.equal(evt.triggered, true);
+  assert.equal(result.damage_modifier, 1);
+});


### PR DESCRIPTION
Closes audit follow-up 'Per-tag enemy-status check'. Activates 9 ancestor trait design intent.

## Tag taxonomy

- **predator**: role_tags ∩ {predator,apex,ambusher} OR clade_tag=Apex
- **irascible**: clade_tag=Threat AND role_tags non-empty AND NOT predator
- **wildlife**: organici non classificati + default fail-closed fallback

## Helper

`inferEnemyTags(target)` pure function in `traitEffects.js`, lazy-cached species index da `species.yaml` + `species_expansion.yaml`.

## Gate

`passesBasicTriggers` extended:
- `requires_target_tag` (applies_to: actor)
- `requires_actor_tag` (applies_to: target)

## 9 ancestor traits gated

`ancestor_self_control_process_speed_{predator,irascible,wildlife}` + `ancestor_attack_counter_{predator,irascible,wildlife}` + `ancestor_dodge_evasive_{predator,irascible,wildlife}`.

## Test plan

- [x] tests/services/enemyTagGate.test.js → **20/20 NEW**
- [x] tests/services/traitEffects.test.js → 21/21 (regression)
- [x] tests/ai/*.test.js → 311/311 (baseline)
- [x] tests/services/*.test.js → 414/414 full

Total: ~439 LOC (helper +116 + 9 gate + tests +314).

🤖 Claude Code