### PR TITLE
feat(skiv): wire Skiv-as-Monitor MVP — git events drive creature feed

### DIFF
--- a/.github/workflows/skiv-monitor.yml
+++ b/.github/workflows/skiv-monitor.yml
@@ -1,0 +1,55 @@
+name: Skiv Monitor
+
+on:
+  schedule:
+    # Ogni 4 ore — bilancia rate-limit GitHub vs reattività Skiv
+    - cron: '0 */4 * * *'
+  workflow_dispatch:
+    inputs:
+      reset:
+        description: 'Reset Skiv state to defaults before run'
+        required: false
+        default: 'false'
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install -r tools/py/requirements.txt
+
+      - name: Reset Skiv state (if requested)
+        if: ${{ github.event.inputs.reset == 'true' }}
+        run: python tools/py/skiv_monitor.py --reset-state
+
+      - name: Run Skiv monitor poll
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python tools/py/skiv_monitor.py \
+            --repo "${{ github.repository }}"
+
+      - name: Commit Skiv state + monitor doc
+        run: |
+          if git diff --quiet; then
+            echo "[skiv-monitor] no state change, skipping commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/derived/skiv_monitor/ docs/skiv/MONITOR.md
+          git commit -m "chore(skiv-monitor): aggiorna stato + feed creatura"
+          git push

--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -28,6 +28,8 @@ const { createLobbyRouter } = require('./routes/lobby');
 const { createCoopRouter } = require('./routes/coop');
 // Skiv ticket #7 — unit diary persistence (cross-session memoria)
 const { createDiaryRouter } = require('./routes/diary');
+// Skiv-as-Monitor — git-event-driven creature feed (2026-04-25)
+const { createSkivRouter } = require('./routes/skiv');
 const { createCoopStore } = require('./services/coop/coopStore');
 const { LobbyService } = require('./services/network/wsSession');
 const { createNebulaTelemetryAggregator } = require('./services/nebulaTelemetryAggregator');
@@ -763,6 +765,11 @@ function createApp(options = {}) {
 
   // Skiv ticket #7 — unit diary persistence MVP (backend-only, JSONL append).
   app.use('/api', createDiaryRouter(options.diary || {}));
+
+  // Skiv-as-Monitor — git-event-driven creature feed (2026-04-25).
+  // Reads data/derived/skiv_monitor/{state.json, feed.jsonl} produced by
+  // tools/py/skiv_monitor.py via .github/workflows/skiv-monitor.yml.
+  app.use('/api', createSkivRouter(options.skiv || {}));
 
   app.get('/api/deployments/status', async (req, res) => {
     try {

--- a/apps/backend/routes/skiv.js
+++ b/apps/backend/routes/skiv.js
@@ -1,0 +1,283 @@
+// =============================================================================
+// Skiv-as-Monitor routes — exposes creature state + git-event feed via HTTP.
+//
+// GET  /api/skiv/status        current state snapshot (gauges, level, mood)
+// GET  /api/skiv/feed?limit=N  JSONL feed tail (default 50, max 500)
+// GET  /api/skiv/card          ASCII card pre-rendered (text/plain)
+// POST /api/skiv/webhook       optional GitHub webhook receiver (HMAC verify)
+//
+// Storage produced by tools/py/skiv_monitor.py:
+//   data/derived/skiv_monitor/{state.json, feed.jsonl, cursor.json}
+// =============================================================================
+
+'use strict';
+
+const express = require('express');
+const fs = require('node:fs');
+const fsp = require('node:fs/promises');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const ROOT_DIR = path.resolve(__dirname, '..', '..', '..');
+const DATA_DIR = path.join(ROOT_DIR, 'data', 'derived', 'skiv_monitor');
+const STATE_PATH = path.join(DATA_DIR, 'state.json');
+const FEED_PATH = path.join(DATA_DIR, 'feed.jsonl');
+
+const FALLBACK_STATE = {
+  schema_version: '0.1.0',
+  unit_id: 'skiv',
+  species_id: 'dune_stalker',
+  species_label: 'Arenavenator vagans',
+  biome: 'savana',
+  job: 'stalker',
+  level: 1,
+  xp: 0,
+  xp_next: 100,
+  form: 'INTP',
+  form_confidence: 0.5,
+  gauges: { hp: 10, hp_max: 10, ap: 2, ap_max: 2, sg: 0, sg_max: 3 },
+  currencies: { pe: 0, pi: 0 },
+  cabinet: { slots_max: 3, slots_used: 0, internalized: [] },
+  bond: {},
+  pressure_tier: 1,
+  sentience_tier: 'T1',
+  mood: 'dormant',
+  stress: 0,
+  composure: 0,
+  curiosity: 0,
+  resolution_count: 0,
+  perk_pending: 0,
+  evolve_opportunity: 0,
+  last_voice: 'Sabbia ferma. Aspetto eventi dal repo.',
+  last_event_id: '',
+  last_updated: '',
+  narrative_log_size: 0,
+  counters: {
+    prs_merged: 0,
+    issues_opened: 0,
+    issues_closed: 0,
+    workflows_passed: 0,
+    workflows_failed: 0,
+    commits_silent: 0,
+    commits_fix: 0,
+    commits_revert: 0,
+  },
+};
+
+async function readStateSafe(statePath = STATE_PATH) {
+  try {
+    const raw = await fsp.readFile(statePath, 'utf8');
+    return JSON.parse(raw);
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      return { ...FALLBACK_STATE, _fallback: true };
+    }
+    throw err;
+  }
+}
+
+async function readFeedTail(limit = 50, feedPath = FEED_PATH) {
+  try {
+    const raw = await fsp.readFile(feedPath, 'utf8');
+    const lines = raw.split('\n').filter((l) => l.trim().length > 0);
+    const slice = lines.slice(-limit);
+    return slice
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      return [];
+    }
+    throw err;
+  }
+}
+
+function bar(value, max, width = 10, glyph = '#') {
+  if (!Number.isFinite(max) || max <= 0) return '';
+  const filled = Math.max(0, Math.min(width, Math.round((width * value) / max)));
+  return glyph.repeat(filled) + '.'.repeat(width - filled);
+}
+
+function renderAsciiCard(state, recent = []) {
+  const g = state.gauges || {};
+  const c = state.currencies || {};
+  const cab = state.cabinet || {};
+  const counters = state.counters || {};
+  const voice = (state.last_voice || 'Ascolto.').slice(0, 32).padEnd(32);
+
+  const lines = [];
+  lines.push('╔══════════════════════════════════════════════════════════════╗');
+  lines.push('║           E V O - T A C T I C S   ·   S K I V               ║');
+  lines.push('║                ╱\\_/\\                                         ║');
+  lines.push(`║               (  o.o )    "${voice}"║`);
+  lines.push('║                > ^ <                                         ║');
+  lines.push('║                                                              ║');
+  lines.push(
+    `║  ${(state.species_label || '?').slice(0, 30).padEnd(30)} · ${(state.biome || '?').slice(0, 12).padEnd(12)}        ║`,
+  );
+  lines.push(
+    `║  ${(state.job || '?').padEnd(10)} Lv ${String(state.level || 0).padStart(2)}  (${String(
+      state.xp || 0,
+    ).padStart(4)}/${String(state.xp_next || 0).padStart(4)} XP)            ║`,
+  );
+  lines.push('║                                                              ║');
+  lines.push(
+    `║  HP ${bar(g.hp || 0, g.hp_max || 1)} ${String(g.hp || 0).padStart(2)}/${String(
+      g.hp_max || 0,
+    ).padStart(2)}     AP ${g.ap || 0}/${g.ap_max || 0}  SG ${g.sg || 0}/${g.sg_max || 0}   ║`,
+  );
+  lines.push(
+    `║  PE ${String(c.pe || 0).padStart(4)}   PI ${String(c.pi || 0).padStart(3)}                                ║`,
+  );
+  lines.push('║                                                              ║');
+  lines.push(
+    `║  FORM  ${(state.form || '?').padEnd(6)} (${String(Math.round((state.form_confidence || 0) * 100)).padStart(3)}%)                              ║`,
+  );
+  lines.push(
+    `║  CABINET ${cab.slots_used || 0}/${cab.slots_max || 0}   PRESSURE T${state.pressure_tier || 0}   SENT ${(
+      state.sentience_tier || '?'
+    ).padEnd(6)}║`,
+  );
+  lines.push('║                                                              ║');
+  lines.push(
+    `║  EVOLVE OPPS  ${String(state.evolve_opportunity || 0).padStart(2)}     PERK PENDING ${String(
+      state.perk_pending || 0,
+    ).padStart(2)}             ║`,
+  );
+  lines.push(
+    `║  STRESS ${String(state.stress || 0).padStart(3)}  COMPOSURE ${String(
+      state.composure || 0,
+    ).padStart(3)}  CURIOSITY ${String(state.curiosity || 0).padStart(3)}      ║`,
+  );
+  lines.push('║                                                              ║');
+  lines.push(
+    `║  Repo pulse:  PR ${String(counters.prs_merged || 0).padStart(3)}  ISS+ ${String(
+      counters.issues_opened || 0,
+    ).padStart(2)}  ISS- ${String(counters.issues_closed || 0).padStart(2)}        ║`,
+  );
+  lines.push(
+    `║               WF✓ ${String(counters.workflows_passed || 0).padStart(3)}  WF✗ ${String(
+      counters.workflows_failed || 0,
+    ).padStart(2)}  FIX ${String(counters.commits_fix || 0).padStart(3)}        ║`,
+  );
+  lines.push('╚══════════════════════════════════════════════════════════════╝');
+  if (recent && recent.length) {
+    lines.push('');
+    lines.push('-- ultimi eventi --');
+    const tail = recent.slice(-6);
+    for (let i = tail.length - 1; i >= 0; i -= 1) {
+      const e = tail[i];
+      const ev = e.event || {};
+      const ts = (e.ts || '').slice(0, 19);
+      const num = ev.number ? `#${ev.number}` : '';
+      lines.push(`${ts}  ${ev.kind || '?'} ${num}  ${(ev.summary || '').slice(0, 40)}`);
+      lines.push(`  > ${e.voice || ''}`);
+    }
+  }
+  lines.push('');
+  lines.push('Sabbia segue.');
+  return lines.join('\n');
+}
+
+function verifyWebhookSignature(rawBody, signatureHeader, secret) {
+  if (!signatureHeader || !secret) return false;
+  const expected = 'sha256=' + crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+  try {
+    return crypto.timingSafeEqual(
+      Buffer.from(signatureHeader, 'utf8'),
+      Buffer.from(expected, 'utf8'),
+    );
+  } catch {
+    return false;
+  }
+}
+
+function createSkivRouter(opts = {}) {
+  const router = express.Router();
+  const statePath = opts.statePath || STATE_PATH;
+  const feedPath = opts.feedPath || FEED_PATH;
+  const webhookSecret = opts.webhookSecret || process.env.SKIV_WEBHOOK_SECRET || '';
+
+  router.get('/skiv/status', async (_req, res, next) => {
+    try {
+      const state = await readStateSafe(statePath);
+      res.json(state);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.get('/skiv/feed', async (req, res, next) => {
+    try {
+      let limit = Number.parseInt(req.query.limit, 10);
+      if (!Number.isFinite(limit) || limit <= 0) limit = 50;
+      if (limit > 500) limit = 500;
+      const entries = await readFeedTail(limit, feedPath);
+      res.json({ count: entries.length, entries });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.get('/skiv/card', async (_req, res, next) => {
+    try {
+      const state = await readStateSafe(statePath);
+      const recent = await readFeedTail(20, feedPath);
+      const card = renderAsciiCard(state, recent);
+      res.set('Content-Type', 'text/plain; charset=utf-8');
+      res.send(card);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // Optional: webhook receiver. Requires SKIV_WEBHOOK_SECRET env (HMAC verify).
+  // Body parsing must preserve raw payload for signature check.
+  router.post(
+    '/skiv/webhook',
+    express.json({
+      verify: (req, _res, buf) => {
+        req.rawBody = buf;
+      },
+      limit: '1mb',
+    }),
+    (req, res) => {
+      if (!webhookSecret) {
+        return res
+          .status(503)
+          .json({ error: 'webhook_disabled', detail: 'SKIV_WEBHOOK_SECRET not set' });
+      }
+      const sig = req.get('X-Hub-Signature-256');
+      if (!verifyWebhookSignature(req.rawBody || Buffer.from(''), sig, webhookSecret)) {
+        return res.status(401).json({ error: 'invalid_signature' });
+      }
+      const eventType = req.get('X-GitHub-Event') || 'unknown';
+      // Phase 4: parse + append to feed in-process. For now, defer to Python cron.
+      // Acknowledge receipt (idempotent) and let cron pick up the change.
+      return res.json({
+        ok: true,
+        event_type: eventType,
+        note: 'webhook accepted; feed will refresh at next cron tick',
+      });
+    },
+  );
+
+  return router;
+}
+
+module.exports = {
+  createSkivRouter,
+  // Exported for tests + reuse.
+  readStateSafe,
+  readFeedTail,
+  renderAsciiCard,
+  FALLBACK_STATE,
+  STATE_PATH,
+  FEED_PATH,
+};

--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -137,6 +137,26 @@
             </svg>
             <span class="hud-label">🧠 Mente</span>
           </button>
+          <button
+            id="skiv-open"
+            class="hud-btn"
+            title="Skiv Monitor — feed live creatura da git events"
+          >
+            <svg
+              class="hud-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M3 12c2-3 6-5 9-5s7 2 9 5c-2 3-6 5-9 5s-7-2-9-5z" />
+              <circle cx="12" cy="12" r="2" />
+            </svg>
+            <span class="hud-label">🦎 Skiv</span>
+          </button>
           <button id="forms-open" class="hud-btn" title="Evoluzione Form — scegli form MBTI (M12)">
             <svg
               class="hud-icon"

--- a/apps/play/src/api.js
+++ b/apps/play/src/api.js
@@ -248,4 +248,24 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ code, host_token: hostToken, ...payload }),
     }),
+  // Skiv-as-Monitor — git-event-driven creature feed (Phase 2 wire 2026-04-25).
+  skivStatus: () => jsonFetch('/api/skiv/status'),
+  skivFeed: (limit = 20) => jsonFetch(`/api/skiv/feed?limit=${encodeURIComponent(limit)}`),
+  // /api/skiv/card returns text/plain ASCII; bypass jsonFetch json parse.
+  skivCard: async () => {
+    try {
+      const res = await fetch('/api/skiv/card', { cache: 'no-store' });
+      if (!res.ok) return { ok: false, status: res.status, text: '', networkError: false };
+      const text = await res.text();
+      return { ok: true, status: res.status, text };
+    } catch (err) {
+      return {
+        ok: false,
+        status: 0,
+        text: '',
+        networkError: true,
+        errorMessage: err?.message || String(err),
+      };
+    }
+  },
 };

--- a/apps/play/src/debriefPanel.css
+++ b/apps/play/src/debriefPanel.css
@@ -291,3 +291,18 @@
   font-size: 0.85rem;
   font-style: italic;
 }
+
+/* Skiv-as-Monitor mini card (Phase 2 wire 2026-04-25). */
+.db-skiv-card {
+  font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+  white-space: pre;
+  background: #0b0d12;
+  color: #c4a574;
+  padding: 10px 12px;
+  border: 1px solid #5a4a2f;
+  border-radius: 8px;
+  font-size: 0.72rem;
+  line-height: 1.2;
+  overflow-x: auto;
+  margin: 0;
+}

--- a/apps/play/src/debriefPanel.js
+++ b/apps/play/src/debriefPanel.js
@@ -61,6 +61,11 @@ export function renderDebriefPanel() {
       </button>
       <div class="db-status" id="db-status" aria-live="polite"></div>
 
+      <div class="db-section" id="db-skiv-section">
+        <div class="db-section-title">🦎 Skiv — riflessione</div>
+        <pre class="db-skiv-card" id="db-skiv-card">[ Skiv tace. Sabbia ferma. ]</pre>
+      </div>
+
       <div class="db-section">
         <div class="db-section-title">Party (<span id="db-party-count">0</span>)</div>
         <div class="db-party" id="db-party"></div>
@@ -173,6 +178,24 @@ export function wireDebriefPanel(overlay, bridge) {
     list.scrollTop = list.scrollHeight;
   };
 
+  // Skiv-as-Monitor — mini card render in debrief (Phase 2 wire 2026-04-25).
+  // Fetch text/plain ASCII card from backend; graceful fallback if offline.
+  const renderSkivMonitorCard = async () => {
+    const cardEl = overlay.querySelector('#db-skiv-card');
+    if (!cardEl) return;
+    try {
+      const res = await fetch('/api/skiv/card', { cache: 'no-store' });
+      if (!res.ok) {
+        cardEl.textContent = '[ Skiv dorme. Monitor non ha girato. ]';
+        return;
+      }
+      const text = await res.text();
+      cardEl.textContent = text || '[ Skiv tace. ]';
+    } catch {
+      cardEl.textContent = '[ Backend irraggiungibile. Sabbia tace. ]';
+    }
+  };
+
   const renderParty = () => {
     const list = overlay.querySelector('#db-party');
     const count = overlay.querySelector('#db-party-count');
@@ -199,6 +222,8 @@ export function wireDebriefPanel(overlay, bridge) {
     renderPgCard();
     renderNarrative();
     renderParty();
+    // Fire-and-forget: Skiv card refresh ad ogni render debrief.
+    renderSkivMonitorCard();
   };
 
   readyBtn.addEventListener('click', async () => {

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -24,6 +24,7 @@ import { initLobbyBridgeIfPresent } from './lobbyBridge.js';
 import { initFormsPanel, openFormsPanel } from './formsPanel.js';
 import { initThoughtsPanel, openThoughtsPanel } from './thoughtsPanel.js';
 import { initProgressionPanel, openProgressionPanel } from './progressionPanel.js';
+import { initSkivPanel, openSkivPanel } from './skivPanel.js';
 
 const state = {
   sid: null,
@@ -1773,5 +1774,10 @@ window.__evo = {
   advanceCampaignWithEvolvePrompt,
   openFormsPanel,
   openThoughtsPanel,
+  openSkivPanel,
   lobbyBridge,
 };
+
+// Skiv-as-Monitor — overlay panel + header btn 🦎 Skiv (Phase 2 wire 2026-04-25).
+// Indipendente da session/campaign — feed creatura da git events sempre disponibile.
+initSkivPanel();

--- a/apps/play/src/skivPanel.js
+++ b/apps/play/src/skivPanel.js
@@ -1,0 +1,236 @@
+// Skiv-as-Monitor — overlay panel (Phase 2 frontend wire 2026-04-25).
+//
+// Overlay modale che mostra:
+//   - ASCII card live (fetch /api/skiv/card text/plain)
+//   - Feed eventi GitHub (fetch /api/skiv/feed?limit=20)
+//   - Auto-refresh ogni 15s mentre overlay aperto
+//
+// Exports:
+//   initSkivPanel(opts) — wire HUD button #skiv-open
+//   openSkivPanel()    — open programmatic
+//   closeSkivPanel()   — close programmatic
+//
+// Persona canonical: docs/skiv/CANONICAL.md.
+// Backend route: apps/backend/routes/skiv.js.
+
+import { api } from './api.js';
+
+const STATE = {
+  overlayEl: null,
+  cardEl: null,
+  feedEl: null,
+  statusEl: null,
+  refreshTimer: null,
+  open: false,
+};
+
+const REFRESH_MS = 15_000;
+const FALLBACK_CARD = '[ Skiv dorme. Monitor non ha ancora girato. ]\nSabbia segue.';
+
+function injectStyles() {
+  if (document.getElementById('skiv-panel-styles')) return;
+  const style = document.createElement('style');
+  style.id = 'skiv-panel-styles';
+  style.textContent = `
+    .skiv-overlay {
+      position: fixed; inset: 0; z-index: 9997;
+      background: rgba(11, 13, 18, 0.82);
+      display: none; align-items: flex-start; justify-content: center;
+      padding: 32px 16px; overflow-y: auto;
+      font-family: Inter, system-ui, sans-serif; color: #e8eaf0;
+    }
+    .skiv-overlay.visible { display: flex; }
+    .skiv-card-wrap {
+      max-width: 760px; width: 100%; background: #151922;
+      border: 1px solid #5a4a2f; border-radius: 14px; padding: 22px 24px;
+      box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+    }
+    .skiv-head {
+      display: flex; align-items: center; gap: 12px; margin-bottom: 14px;
+    }
+    .skiv-head h2 { margin: 0; font-size: 1.25rem; color: #c4a574; }
+    .skiv-head .skiv-status-chip {
+      margin-left: auto; background: #0b0d12; border: 1px solid #5a4a2f;
+      border-radius: 999px; padding: 4px 12px; font-size: 0.85rem; color: #c4a574;
+    }
+    .skiv-head .skiv-close-btn {
+      background: transparent; border: none; color: #ef9a9a;
+      cursor: pointer; font-size: 1.3rem; padding: 4px 8px;
+    }
+    .db-skiv-card,
+    .skiv-ascii-card {
+      font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+      white-space: pre; background: #0b0d12; color: #c4a574;
+      padding: 12px 14px; border: 1px solid #5a4a2f; border-radius: 8px;
+      font-size: 0.78rem; line-height: 1.25; overflow-x: auto;
+      margin: 0;
+    }
+    .skiv-feed-section { margin-top: 18px; }
+    .skiv-feed-section h3 {
+      margin: 0 0 10px 0; font-size: 0.95rem; color: #66d1fb;
+    }
+    .skiv-feed-list {
+      list-style: none; padding: 0; margin: 0;
+      max-height: 260px; overflow-y: auto;
+    }
+    .skiv-feed-entry {
+      padding: 8px 10px; margin-bottom: 6px;
+      background: #0b0d12; border-left: 3px solid #5a4a2f; border-radius: 4px;
+      font-size: 0.85rem;
+    }
+    .skiv-feed-entry .ts { color: #8a8a8a; font-size: 0.78rem; }
+    .skiv-feed-entry .kind { color: #c4a574; font-weight: bold; margin: 0 6px; }
+    .skiv-feed-entry .voice { color: #e8eaf0; font-style: italic; display: block; margin-top: 4px; }
+    .skiv-feed-entry.cat-fix { border-left-color: #66d1fb; }
+    .skiv-feed-entry.cat-feat_p2 { border-left-color: #a26bff; }
+    .skiv-feed-entry.cat-feat_p3 { border-left-color: #66d1fb; }
+    .skiv-feed-entry.cat-feat_p6 { border-left-color: #ef9a9a; }
+    .skiv-feed-entry.cat-wf_fail { border-left-color: #ef5350; }
+    .skiv-feed-entry.cat-wf_pass { border-left-color: #81c784; }
+    .skiv-empty { color: #8a8a8a; font-style: italic; padding: 10px; text-align: center; }
+  `;
+  document.head.appendChild(style);
+}
+
+function buildOverlay() {
+  if (STATE.overlayEl) return STATE.overlayEl;
+  injectStyles();
+  const overlay = document.createElement('div');
+  overlay.className = 'skiv-overlay';
+  overlay.id = 'skiv-overlay';
+  overlay.innerHTML = `
+    <div class="skiv-card-wrap">
+      <div class="skiv-head">
+        <h2>🦎 Skiv — feed creatura</h2>
+        <span class="skiv-status-chip" id="skiv-status-chip">—</span>
+        <button class="skiv-close-btn" id="skiv-close" aria-label="Chiudi">✕</button>
+      </div>
+      <pre class="skiv-ascii-card" id="skiv-card">${FALLBACK_CARD}</pre>
+      <div class="skiv-feed-section">
+        <h3>Eventi recenti</h3>
+        <ul class="skiv-feed-list" id="skiv-feed-list">
+          <li class="skiv-empty">Carico…</li>
+        </ul>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(overlay);
+  STATE.overlayEl = overlay;
+  STATE.cardEl = overlay.querySelector('#skiv-card');
+  STATE.feedEl = overlay.querySelector('#skiv-feed-list');
+  STATE.statusEl = overlay.querySelector('#skiv-status-chip');
+  overlay.querySelector('#skiv-close').addEventListener('click', closeSkivPanel);
+  overlay.addEventListener('click', (ev) => {
+    if (ev.target === overlay) closeSkivPanel();
+  });
+  document.addEventListener('keydown', (ev) => {
+    if (STATE.open && ev.key === 'Escape') closeSkivPanel();
+  });
+  return overlay;
+}
+
+function escapeHtml(s) {
+  return String(s == null ? '' : s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function renderFeedEntries(entries) {
+  if (!STATE.feedEl) return;
+  if (!entries || entries.length === 0) {
+    STATE.feedEl.innerHTML = '<li class="skiv-empty">Nessun evento ancora. Sabbia ferma.</li>';
+    return;
+  }
+  const html = entries
+    .slice()
+    .reverse()
+    .map((e) => {
+      const ev = e.event || {};
+      const ts = (e.ts || '').slice(0, 19).replace('T', ' ');
+      const kind = escapeHtml(ev.kind || '?');
+      const num = ev.number ? `#${escapeHtml(String(ev.number))}` : '';
+      const title = escapeHtml((ev.title || ev.summary || '').slice(0, 80));
+      const cat = escapeHtml(e.category || 'default');
+      const voice = escapeHtml(e.voice || '');
+      return `
+        <li class="skiv-feed-entry cat-${cat}">
+          <span class="ts">${escapeHtml(ts)}</span>
+          <span class="kind">${kind}</span>
+          ${num} ${title}
+          <span class="voice">🦎 ${voice}</span>
+        </li>
+      `;
+    })
+    .join('');
+  STATE.feedEl.innerHTML = html;
+}
+
+async function refresh() {
+  if (!STATE.open) return;
+  // Card (text/plain).
+  const cardRes = await api.skivCard();
+  if (STATE.cardEl) {
+    STATE.cardEl.textContent = cardRes.ok && cardRes.text ? cardRes.text : FALLBACK_CARD;
+  }
+  // Status chip.
+  const statusRes = await api.skivStatus();
+  if (STATE.statusEl) {
+    if (statusRes.ok && statusRes.data) {
+      const s = statusRes.data;
+      const ts = (s.last_updated || '').slice(0, 19).replace('T', ' ') || 'mai';
+      const lvl = s.level ?? '?';
+      STATE.statusEl.textContent = `Lv ${lvl} · ${ts}`;
+      if (s._fallback) {
+        STATE.statusEl.textContent += ' (dormante)';
+      }
+    } else {
+      STATE.statusEl.textContent = 'offline';
+    }
+  }
+  // Feed.
+  const feedRes = await api.skivFeed(20);
+  if (STATE.feedEl) {
+    if (feedRes.ok && feedRes.data && Array.isArray(feedRes.data.entries)) {
+      renderFeedEntries(feedRes.data.entries);
+    } else if (feedRes.networkError) {
+      STATE.feedEl.innerHTML = '<li class="skiv-empty">Backend irraggiungibile. Sabbia tace.</li>';
+    } else {
+      renderFeedEntries([]);
+    }
+  }
+}
+
+export function openSkivPanel() {
+  buildOverlay();
+  STATE.open = true;
+  STATE.overlayEl.classList.add('visible');
+  refresh();
+  if (!STATE.refreshTimer) {
+    STATE.refreshTimer = setInterval(refresh, REFRESH_MS);
+  }
+}
+
+export function closeSkivPanel() {
+  STATE.open = false;
+  if (STATE.overlayEl) STATE.overlayEl.classList.remove('visible');
+  if (STATE.refreshTimer) {
+    clearInterval(STATE.refreshTimer);
+    STATE.refreshTimer = null;
+  }
+}
+
+export function initSkivPanel() {
+  buildOverlay();
+  const btn = document.getElementById('skiv-open');
+  if (btn) {
+    btn.addEventListener('click', () => {
+      if (STATE.open) closeSkivPanel();
+      else openSkivPanel();
+    });
+  }
+}
+
+// Test surface (export for unit tests).
+export const __skivPanelInternal = { renderFeedEntries, escapeHtml, FALLBACK_CARD };

--- a/data/derived/skiv_monitor/cursor.json
+++ b/data/derived/skiv_monitor/cursor.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "0.1.0",
+  "last_pr_merged_at": null,
+  "last_issue_event_at": null,
+  "last_workflow_run_at": null,
+  "last_commit_sha": null,
+  "seen_event_ids": [],
+  "ring_max": 200
+}

--- a/data/derived/skiv_monitor/state.json
+++ b/data/derived/skiv_monitor/state.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "0.1.0",
+  "unit_id": "skiv",
+  "species_id": "dune_stalker",
+  "species_label": "Arenavenator vagans",
+  "biome": "savana",
+  "job": "stalker",
+  "level": 4,
+  "xp": 210,
+  "xp_next": 275,
+  "form": "INTP",
+  "form_confidence": 0.76,
+  "gauges": {
+    "hp": 12,
+    "hp_max": 14,
+    "ap": 2,
+    "ap_max": 2,
+    "sg": 2,
+    "sg_max": 3
+  },
+  "currencies": {
+    "pe": 42,
+    "pi": 8
+  },
+  "cabinet": {
+    "slots_max": 3,
+    "slots_used": 2,
+    "internalized": [
+      "i_osservatore",
+      "n_intuizione_terrena"
+    ]
+  },
+  "bond": {
+    "vega_enfj": 3,
+    "rhodo_istj": 2
+  },
+  "pressure_tier": 2,
+  "sentience_tier": "T2-T3",
+  "mood": "watchful",
+  "stress": 0,
+  "composure": 0,
+  "curiosity": 0,
+  "resolution_count": 0,
+  "perk_pending": 0,
+  "evolve_opportunity": 0,
+  "last_voice": "",
+  "last_event_id": "",
+  "last_updated": "",
+  "narrative_log_size": 0,
+  "counters": {
+    "prs_merged": 0,
+    "issues_opened": 0,
+    "issues_closed": 0,
+    "workflows_passed": 0,
+    "workflows_failed": 0,
+    "commits_silent": 0,
+    "commits_fix": 0,
+    "commits_revert": 0
+  }
+}

--- a/docs/integrations/swarm-skiv-feed.md
+++ b/docs/integrations/swarm-skiv-feed.md
@@ -1,0 +1,205 @@
+---
+title: Swarm UI ⇄ Skiv Monitor — integration contract
+doc_status: active
+doc_owner: docs-team
+workstream: cross-cutting
+last_verified: 2026-04-25
+source_of_truth: true
+language: it
+review_cycle_days: 60
+tags: [skiv, swarm, integration, contract, api]
+---
+
+# Swarm UI ⇄ Skiv Monitor — integration contract
+
+> **Audience**: chiunque debba mostrare lo stato di Skiv (creatura canonical) dentro la **Swarm AI Dashboard** (`http://127.0.0.1:5000`, runtime Dafne) o altri pannelli esterni al backend Game.
+
+## Architettura
+
+```
+Game backend :3334            Swarm UI :5000 (Dafne)
++---------------------+       +----------------------+
+| /api/skiv/status    |<------| polling fetch (10s)  |
+| /api/skiv/feed      |<------| timeline component   |
+| /api/skiv/card      |<------| ASCII card pre-block |
+| /api/skiv/webhook   |       |                      |
++---------------------+       +----------------------+
+        ^
+        | writes
++---------------------+
+| GitHub Actions cron |
+| skiv-monitor.yml    |
+| every 4h            |
++---------------------+
+```
+
+CORS già abilitato lato Game backend (`apps/backend/app.js` `cors()` middleware) — **nessun proxy richiesto** per fetch cross-origin da `:5000` verso `:3334`.
+
+## Endpoint contract (read-only, idempotent)
+
+### `GET /api/skiv/status`
+
+Stato corrente creatura (snapshot). 200 sempre, anche se monitor non ha mai girato (`_fallback: true`).
+
+**Response shape**:
+
+```json
+{
+  "schema_version": "0.1.0",
+  "unit_id": "skiv",
+  "species_id": "dune_stalker",
+  "species_label": "Arenavenator vagans",
+  "biome": "savana",
+  "job": "stalker",
+  "level": 4,
+  "xp": 230,
+  "xp_next": 275,
+  "form": "INTP",
+  "form_confidence": 0.76,
+  "gauges": { "hp": 12, "hp_max": 14, "ap": 2, "ap_max": 2, "sg": 2, "sg_max": 3 },
+  "currencies": { "pe": 47, "pi": 8 },
+  "cabinet": {
+    "slots_max": 3,
+    "slots_used": 2,
+    "internalized": ["i_osservatore", "n_intuizione_terrena"]
+  },
+  "bond": { "vega_enfj": 3, "rhodo_istj": 2 },
+  "pressure_tier": 2,
+  "sentience_tier": "T2-T3",
+  "mood": "watchful",
+  "stress": 0,
+  "composure": 1,
+  "curiosity": 0,
+  "resolution_count": 1,
+  "perk_pending": 1,
+  "evolve_opportunity": 1,
+  "last_voice": "Nodo sciolto. Sabbia liscia di nuovo.",
+  "last_event_id": "iss-555-closed",
+  "last_updated": "2026-04-25T20:15:44Z",
+  "narrative_log_size": 7,
+  "counters": {
+    "prs_merged": 3,
+    "issues_opened": 1,
+    "issues_closed": 1,
+    "workflows_passed": 1,
+    "workflows_failed": 1,
+    "commits_silent": 0,
+    "commits_fix": 1,
+    "commits_revert": 0
+  }
+}
+```
+
+**Campi load-bearing** per render dashboard:
+
+| Campo                | Render hint                                |
+| -------------------- | ------------------------------------------ |
+| `level`, `xp`        | Progress bar                               |
+| `gauges.hp/hp_max`   | HP bar segmentata                          |
+| `last_voice`         | Speech bubble sopra avatar                 |
+| `evolve_opportunity` | Glow/pulse su sprite quando ≥1             |
+| `pressure_tier`      | Color tint background (T0=verde, T5=rosso) |
+| `last_updated`       | "X minuti fa" relative ts                  |
+
+### `GET /api/skiv/feed?limit=N`
+
+Timeline eventi recenti (default 50, max 500).
+
+**Response shape**:
+
+```json
+{
+  "count": 7,
+  "entries": [
+    {
+      "ts": "2026-04-25T16:00:00Z",
+      "event": {
+        "id": "iss-555-closed",
+        "kind": "issue_closed",
+        "ts": "2026-04-25T16:00:00Z",
+        "number": 555,
+        "title": "Skiv: aggiungi voice palette type 7",
+        "labels": ["P4", "skiv"],
+        "html_url": "https://github.com/MasterDD-L34D/Game/issues/555"
+      },
+      "category": "issue_close",
+      "voice": "Nodo sciolto. Sabbia liscia di nuovo.",
+      "state_delta": { "counters.issues_closed": 1, "resolution_count": 1 }
+    }
+  ]
+}
+```
+
+**Event kinds**:
+
+`pr_merged`, `issue_opened`, `issue_closed`, `workflow_passed`, `workflow_failed`.
+
+**Categories** (per styling):
+
+`feat_p2`, `feat_p3`, `feat_p4`, `feat_p5`, `feat_p6`, `data_core`, `services`, `skiv_doc`, `issue_open`, `issue_close`, `wf_fail`, `wf_pass`, `fix`, `revert`, `default`.
+
+### `GET /api/skiv/card`
+
+Card ASCII pre-renderizzata (text/plain UTF-8). Per dashboard text-only o terminal embed.
+
+```
+Content-Type: text/plain; charset=utf-8
+```
+
+### `POST /api/skiv/webhook` (Phase 4, opt-in)
+
+GitHub webhook receiver. Disabilitato di default (503 se `SKIV_WEBHOOK_SECRET` env unset). HMAC-SHA256 verify obbligatorio. NON usare per dashboard polling.
+
+## Polling strategy (raccomandata Swarm UI)
+
+```javascript
+// Swarm UI client snippet (jQuery / fetch / qualsiasi)
+const GAME_API = 'http://127.0.0.1:3334';
+
+async function pollSkiv() {
+  try {
+    const r = await fetch(GAME_API + '/api/skiv/status', { cache: 'no-store' });
+    if (!r.ok) throw new Error('status ' + r.status);
+    const state = await r.json();
+    renderSkivCard(state); // your function
+  } catch (err) {
+    console.warn('[skiv] poll failed', err);
+    // graceful degrade: keep last render
+  }
+}
+
+setInterval(pollSkiv, 10_000); // 10s
+pollSkiv(); // initial fire
+```
+
+**Rate budget**: backend non rate-limita endpoint Skiv lato server (è solo `fs.readFile` su file locali). Polling 10s è sicuro. Per timeline feed, 30-60s è sufficiente (cambio reale solo dopo cron 4h).
+
+## Failure modes
+
+| Scenario                              | Backend response       | Suggested UI                   |
+| ------------------------------------- | ---------------------- | ------------------------------ |
+| Monitor mai girato                    | 200 + `_fallback:true` | Card stato "dormante" greyed   |
+| state.json corrotto                   | 500 (rethrow JSON err) | Toast "Skiv unreachable"       |
+| Game backend offline                  | network error          | Use stale cache + retry banner |
+| feed.jsonl >500MB (rotation rule TBD) | OK ma slow             | Lazy-load more on scroll       |
+
+## Refresh trigger
+
+Skiv state cambia solo quando `tools/py/skiv_monitor.py` gira:
+
+1. **Cron**: ogni 4h via `.github/workflows/skiv-monitor.yml`
+2. **Manual**: `python tools/py/skiv_monitor.py --repo MasterDD-L34D/Game` da locale
+3. **CI workflow_dispatch**: dalla UI GitHub Actions
+4. **Phase 4 webhook**: real-time post commit (richiede tunnel pubblico)
+
+Swarm UI **non triggera** monitor; si limita a leggere stato.
+
+## Cross-references
+
+- Plan: [../planning/2026-04-25-skiv-monitor-plan.md](../planning/2026-04-25-skiv-monitor-plan.md)
+- Persona: [../skiv/CANONICAL.md](../skiv/CANONICAL.md)
+- Live monitor doc: [../skiv/MONITOR.md](../skiv/MONITOR.md)
+- Backend route: [`apps/backend/routes/skiv.js`](../../apps/backend/routes/skiv.js)
+- Python monitor: [`tools/py/skiv_monitor.py`](../../tools/py/skiv_monitor.py)
+- Workflow: [`.github/workflows/skiv-monitor.yml`](../../.github/workflows/skiv-monitor.yml)
+- Tests: [`tests/api/skivRoute.test.js`](../../tests/api/skivRoute.test.js), [`tests/test_skiv_monitor.py`](../../tests/test_skiv_monitor.py)

--- a/docs/planning/2026-04-25-skiv-monitor-plan.md
+++ b/docs/planning/2026-04-25-skiv-monitor-plan.md
@@ -1,0 +1,176 @@
+---
+title: Skiv-as-Monitor — feature plan + architecture
+doc_status: draft
+doc_owner: docs-team
+workstream: cross-cutting
+last_verified: 2026-04-25
+source_of_truth: false
+language: it
+review_cycle_days: 30
+tags: [skiv, monitor, github, telemetry, swarm-ui, persona]
+---
+
+# Skiv-as-Monitor — feature plan
+
+> **Goal**: Skiv (creatura canonical) reagisce live a commit/PR/issue/workflow del repo `MasterDD-L34D/Game`. User vede scheda + avventure + feedback derivati da git events. Stessa scheda esposta a Swarm UI (`http://127.0.0.1:5000`) e in-game (debriefPanel) per leggere "come la creatura percepisce il gioco che evolve".
+
+## Why (problem statement)
+
+- Repo evolve veloce (200+ PR/sprint). User vuole feedback narrativo immediato sul significato di ogni cambio per la creatura canonical.
+- Skiv è già la persona-recap del progetto (vedi [docs/skiv/CANONICAL.md](../skiv/CANONICAL.md)). Manca event-driven loop.
+- Swarm UI separata (Dafne :5000) deve mostrare lo stesso feed → bridge HTTP needed.
+- Nessuna invenzione: composiamo solo asset esistenti (telemetry pipeline + GitHub poller + Skiv persona + canonical data).
+
+## Architecture (single-pass, no new deps)
+
+```
+┌─────────────────────────┐
+│ GitHub MasterDD-L34D/   │  push, PR merge, issue, workflow run
+│ Game (events source)    │
+└──────────┬──────────────┘
+           │ REST API poll (4h cron) + optional webhook
+           ▼
+┌─────────────────────────────────────────┐
+│ tools/py/skiv_monitor.py                │
+│   1. fetch events since last cursor     │
+│   2. classify (commit/PR/issue/wf)      │
+│   3. map to Skiv state delta            │
+│      (HP/SG/PE/biome/voice line)        │
+│   4. compose narrative beat (it)        │
+│   5. append JSONL feed                  │
+│   6. update state.json snapshot         │
+│   7. render MONITOR.md card             │
+└──────────┬──────────────────────────────┘
+           │ writes
+           ▼
+┌─────────────────────────────────────────┐
+│ data/derived/skiv_monitor/              │
+│   ├── feed.jsonl       (append-only)    │
+│   ├── state.json       (current)        │
+│   └── cursor.json      (last seen sha)  │
+│ docs/skiv/MONITOR.md   (rendered)       │
+└──────────┬──────────────────────────────┘
+           │ read
+           ▼
+┌─────────────────────────────────────────┐
+│ apps/backend/routes/skiv.js             │
+│   GET  /api/skiv/status   → state.json  │
+│   GET  /api/skiv/feed     → feed.jsonl  │
+│   GET  /api/skiv/card     → ASCII card  │
+│   POST /api/skiv/webhook  → webhook in  │
+└────┬───────────────┬────────────────────┘
+     │               │
+     ▼               ▼
+┌──────────┐    ┌────────────────────┐
+│ in-game  │    │ Swarm UI :5000     │
+│ debrief- │    │ (Dafne dashboard)  │
+│ Panel    │    │ HTTP poll JSON     │
+└──────────┘    └────────────────────┘
+```
+
+## Skiv state mapping (deterministic, no LLM)
+
+State delta da event type:
+
+| Event                         | Skiv reaction (state)               | Narrative voice                                   |
+| ----------------------------- | ----------------------------------- | ------------------------------------------------- |
+| PR merged + label `feat/p2-*` | Form evolve opportunity +1, PE +5   | _"Sento il guscio cambiare. Allenatore..."_       |
+| PR merged + label `feat/p3-*` | XP +20, perk_pending++              | _"Il branco si organizza. Imparo un nome nuovo."_ |
+| PR merged + label `feat/p4-*` | MBTI confidence ±5, cabinet_event   | _"Voce nuova nella stanza interna."_              |
+| PR merged + label `feat/p5-*` | Bond ♥ +1 (random co-op)           | _"Ho sentito un altro respiro vicino."_           |
+| PR merged + label `feat/p6-*` | Pressure Tier shift                 | _"Sistema preme. Sabbia vibra."_                  |
+| PR merged + path `data/core/` | Trait pool refresh                  | _"Memoria genetica risistema indici."_            |
+| PR merged + path `services/`  | Combat awareness +                  | _"Riflessi affilati."_                            |
+| PR merged + path `docs/skiv/` | Self-reflection beat                | _"L'allenatore parla di me. Me ne accorgo."_      |
+| Issue opened                  | curiosity++                         | _"Domanda nuova nell'aria."_                      |
+| Issue closed                  | resolution_count++                  | _"Una voce tace. Pace breve."_                    |
+| Workflow failed               | stress +1, HP -1 (cosmetic)         | _"Qualcosa scricchiola. Aspetto."_                |
+| Workflow success              | composure +1                        | _"Tutto in posto. Respiro."_                      |
+| Commit `chore:` solo          | no narrative (silent counter)       | —                                                 |
+| Commit `fix:`                 | small healing tick HP +1 (max base) | _"Una crepa chiusa. Bene."_                       |
+| Commit `revert:`              | confusion +1                        | _"Era così. Adesso non più. Ricordo entrambi."_   |
+
+Mapping è **pure function** `map_event(event_dict) -> {state_delta, voice}`. Determinismo = riproducibile + testabile.
+
+## Files to ship (MVP)
+
+| File                                             | Type     | LOC est  | Status |
+| ------------------------------------------------ | -------- | -------- | :----: |
+| `tools/py/skiv_monitor.py`                       | Python   | ~280     |  NEW   |
+| `apps/backend/routes/skiv.js`                    | Node     | ~140     |  NEW   |
+| `apps/backend/app.js` wire                       | edit     | +2       |  EDIT  |
+| `.github/workflows/skiv-monitor.yml`             | workflow | ~45      |  NEW   |
+| `docs/skiv/MONITOR.md`                           | doc      | template |  NEW   |
+| `data/derived/skiv_monitor/state.json` (seeded)  | data     | ~40      |  NEW   |
+| `data/derived/skiv_monitor/cursor.json` (seeded) | data     | ~5       |  NEW   |
+| `tests/tools/skiv_monitor.test.py`               | test     | ~80      |  NEW   |
+| `docs/planning/2026-04-25-skiv-monitor-plan.md`  | this     | ~200     |  NEW   |
+
+**Zero nuove deps**. Python: `requests` (già in repo). Node: solo `fs/promises` + `path`.
+
+## Phases
+
+### Phase 1 — MVP backend + cron (this PR, ~2h)
+
+- [x] Plan doc
+- [ ] Python monitor (offline-runnable con `--mock-events fixture.json`)
+- [ ] Backend route + wire
+- [ ] GitHub Actions workflow
+- [ ] Initial state seed
+- [ ] Smoke test offline
+
+### Phase 2 — Frontend wire (follow-up PR, ~2h)
+
+- Extend `apps/play/src/debriefPanel.js` con `renderSkivMonitorCard()` che fetch `/api/skiv/card`
+- Header button 🦎 Skiv per overlay full feed
+- CSS minimo (riutilizza `.db-card` pattern)
+
+### Phase 3 — Swarm UI integration (follow-up PR, ~3h)
+
+- Cross-origin GET (Game backend `:3334` da Swarm UI `:5000`)
+- CORS già abilitato lato Game
+- Swarm dashboard fetch + render Skiv card sub-component
+- Documentazione contract endpoint in `docs/integrations/swarm-skiv-feed.md`
+- (Swarm dashboard repo: `~/Dafne/workspace/swarm/` — separato, requires owner Dafne side)
+
+### Phase 4 — Webhook live (optional, ~2h)
+
+- Espone `POST /api/skiv/webhook` con HMAC verify (`X-Hub-Signature-256`)
+- GitHub repo settings → webhook URL (richiede tunnel ngrok/Cloudflare per dev)
+- Real-time vs 4h cron poll
+
+## Gates DoD (4-gate policy)
+
+1. **Smoke test** — `python tools/py/skiv_monitor.py --mock-events fixtures/test_events.json --dry-run` verde + state.json output diff atteso
+2. **Edge cases** — empty events, malformed JSON, GitHub rate-limit (403), cursor reset, race condition workflow concurrent runs
+3. **Tuning** — narrative beat dedup (no spam stesso PR), cap feed.jsonl 5000 entries (rotate), state proportions stabili (HP/AP/SG never below 0)
+4. **Optimization** — token-efficient API (incremental cursor), 1 GitHub call per cron tick
+
+## Risks + mitigations
+
+| Risk                                | Mitigation                                                  |
+| ----------------------------------- | ----------------------------------------------------------- |
+| GitHub rate-limit (5k req/h auth)   | Cursor incremental + ETag if-modified-since                 |
+| Skiv "voice spam" su batch merge    | Dedup window 30min stesso PR/issue                          |
+| State drift vs canonical proporsion | State proportions clamped + reset script                    |
+| Swarm UI cross-origin               | CORS Game already enabled (`cors()` middleware app.js:line) |
+| Webhook public endpoint security    | Phase 4 only — HMAC verify mandatory                        |
+| Hallucinated narrative              | Voice lines = static palette, NO LLM in-loop                |
+
+## Acceptance criteria (when "done")
+
+- ✅ `python tools/py/skiv_monitor.py --since 2026-04-20` produce JSONL + state.json + MONITOR.md
+- ✅ `curl http://localhost:3334/api/skiv/status` ritorna state JSON
+- ✅ `curl http://localhost:3334/api/skiv/feed?limit=20` ritorna eventi recenti
+- ✅ `curl http://localhost:3334/api/skiv/card` ritorna ASCII card pronto-render
+- ✅ GitHub Actions workflow gira ogni 4h, commits MONITOR.md aggiornata
+- ✅ `python -m pytest tests/tools/skiv_monitor.test.py` verde (≥3 edge case)
+- ✅ Phase 2/3 doc scritti come placeholder per follow-up
+
+## Cross-references
+
+- [docs/skiv/CANONICAL.md](../skiv/CANONICAL.md) — persona + voice rules
+- [tools/py/daily_pr_report.py](../../tools/py/daily_pr_report.py) — GitHub API client pattern
+- [apps/backend/routes/session.js:213-230](../../apps/backend/routes/session.js) — telemetry append pattern
+- [WORKSPACE_MAP.md](../../WORKSPACE_MAP.md) — Swarm UI :5000 entrypoint
+- [docs/museum/MUSEUM.md](../museum/MUSEUM.md) — prior art (consulted before WebSearch per protocol)

--- a/docs/skiv/MONITOR.md
+++ b/docs/skiv/MONITOR.md
@@ -1,0 +1,61 @@
+---
+title: Skiv Monitor — live creature feed
+doc_status: active
+doc_owner: docs-team
+workstream: cross-cutting
+last_verified: 2026-04-25T20:15:44Z
+source_of_truth: false
+language: it
+review_cycle_days: 7
+tags: [skiv, monitor, autogen]
+---
+
+# Skiv Monitor
+
+> **Autogen** — non editare a mano. Aggiornato da `tools/py/skiv_monitor.py` via `.github/workflows/skiv-monitor.yml`.
+> Persona canonical: [docs/skiv/CANONICAL.md](CANONICAL.md). Plan: [docs/planning/2026-04-25-skiv-monitor-plan.md](../planning/2026-04-25-skiv-monitor-plan.md).
+
+```
+╔══════════════════════════════════════════════════════════════╗
+║           E V O - T A C T I C S   ·   S K I V               ║
+║                ╱\_/\                                         ║
+║               (  o.o )    "Nodo sciolto. Sabbia liscia di n"║
+║                > ^ <                                         ║
+║                                                              ║
+║  Arenavenator vagans            · savana              ║
+║  stalker    Lv  4  ( 230/ 275 XP)            ║
+║                                                              ║
+║  HP █████████· 12/14     AP 2/2  SG 2/3   ║
+║  PE   47   PI   8                                ║
+║                                                              ║
+║  FORM  INTP   ( 76%)                              ║
+║  CABINET 2/3   PRESSURE T2   SENT T2-T3 ║
+║                                                              ║
+║  EVOLVE OPPS   1     PERK PENDING  1             ║
+║  STRESS   1  COMPOSURE   1  CURIOSITY   1      ║
+║                                                              ║
+║  Repo pulse:  PR   3  ISS+  1  ISS-  1        ║
+║               WF✓   1  WF✗  1  FIX   1        ║
+╚══════════════════════════════════════════════════════════════╝
+```
+
+_Ultimo evento: iss-555-closed · aggiornato 2026-04-25T20:15:44Z_
+
+## Eventi recenti (ultimi 10)
+
+- `2026-04-25T16:00:00` · **issue_closed** #555 —
+  > 🦎 _Nodo sciolto. Sabbia liscia di nuovo._
+- `2026-04-25T15:00:00` · **workflow_passed** —
+  > 🦎 _Tutto in posto. Respiro._
+- `2026-04-25T14:00:00` · **workflow_failed** —
+  > 🦎 _Qualcosa scricchiola. Aspetto._
+- `2026-04-25T13:00:00` · **issue_opened** #555 —
+  > 🦎 _Una ferita futura, ancora teorica. Memorizzo._
+- `2026-04-25T12:00:00` · **pr_merged** #9003 —
+  > 🦎 _Dolore antico via. Mi muovo meglio._
+- `2026-04-25T11:00:00` · **pr_merged** #9002 —
+  > 🦎 _Mestiere nuovo. Le mani sanno prima di me._
+- `2026-04-25T10:00:00` · **pr_merged** #9001 —
+  > 🦎 _Una pelle vecchia si stacca. Aspetto._
+
+> 🦎 _Sabbia segue._

--- a/tests/api/skivRoute.test.js
+++ b/tests/api/skivRoute.test.js
@@ -1,0 +1,135 @@
+// Skiv-as-Monitor route integration — git-event-driven creature feed.
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const request = require('supertest');
+const express = require('express');
+const {
+  createSkivRouter,
+  renderAsciiCard,
+  FALLBACK_STATE,
+} = require('../../apps/backend/routes/skiv');
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'skiv-route-test-'));
+}
+
+function buildApp({ statePath, feedPath, webhookSecret } = {}) {
+  const app = express();
+  app.use('/api', createSkivRouter({ statePath, feedPath, webhookSecret }));
+  return app;
+}
+
+test('GET /api/skiv/status — missing state file → fallback payload', async () => {
+  const dir = tmpDir();
+  const app = buildApp({ statePath: path.join(dir, 'missing.json') });
+  const r = await request(app).get('/api/skiv/status');
+  assert.equal(r.status, 200);
+  assert.equal(r.body.unit_id, 'skiv');
+  assert.equal(r.body._fallback, true);
+  assert.ok(r.body.gauges);
+});
+
+test('GET /api/skiv/status — reads seeded state JSON', async () => {
+  const dir = tmpDir();
+  const statePath = path.join(dir, 'state.json');
+  const seed = { ...FALLBACK_STATE, level: 9, last_voice: 'Test voice', _fallback: false };
+  delete seed._fallback;
+  fs.writeFileSync(statePath, JSON.stringify(seed), 'utf8');
+  const app = buildApp({ statePath });
+  const r = await request(app).get('/api/skiv/status');
+  assert.equal(r.status, 200);
+  assert.equal(r.body.level, 9);
+  assert.equal(r.body.last_voice, 'Test voice');
+});
+
+test('GET /api/skiv/feed — missing feed → empty entries 200', async () => {
+  const dir = tmpDir();
+  const app = buildApp({ feedPath: path.join(dir, 'missing.jsonl') });
+  const r = await request(app).get('/api/skiv/feed');
+  assert.equal(r.status, 200);
+  assert.equal(r.body.count, 0);
+  assert.deepEqual(r.body.entries, []);
+});
+
+test('GET /api/skiv/feed — limit clamp to 500', async () => {
+  const dir = tmpDir();
+  const feedPath = path.join(dir, 'feed.jsonl');
+  // 700 entries.
+  const lines = [];
+  for (let i = 0; i < 700; i += 1) {
+    lines.push(
+      JSON.stringify({
+        ts: '2026-04-25T00:00:00Z',
+        event: { kind: 'pr_merged', number: i },
+        voice: 'v',
+      }),
+    );
+  }
+  fs.writeFileSync(feedPath, lines.join('\n') + '\n', 'utf8');
+  const app = buildApp({ feedPath });
+  const r = await request(app).get('/api/skiv/feed?limit=9999');
+  assert.equal(r.status, 200);
+  assert.equal(r.body.count, 500);
+});
+
+test('GET /api/skiv/card — text/plain ASCII card with banner', async () => {
+  const dir = tmpDir();
+  const statePath = path.join(dir, 'state.json');
+  fs.writeFileSync(statePath, JSON.stringify(FALLBACK_STATE), 'utf8');
+  const app = buildApp({ statePath, feedPath: path.join(dir, 'missing.jsonl') });
+  const r = await request(app).get('/api/skiv/card');
+  assert.equal(r.status, 200);
+  assert.match(r.headers['content-type'], /text\/plain/);
+  assert.match(r.text, /S K I V/);
+  assert.match(r.text, /Sabbia segue/);
+});
+
+test('renderAsciiCard — handles malformed state gracefully', () => {
+  const out = renderAsciiCard({});
+  assert.match(out, /S K I V/);
+  assert.match(out, /Sabbia segue/);
+});
+
+test('POST /api/skiv/webhook — disabled when secret unset', async () => {
+  const app = buildApp({ webhookSecret: '' });
+  const r = await request(app).post('/api/skiv/webhook').send({ action: 'opened' });
+  assert.equal(r.status, 503);
+  assert.equal(r.body.error, 'webhook_disabled');
+});
+
+test('POST /api/skiv/webhook — invalid signature → 401', async () => {
+  const app = buildApp({ webhookSecret: 'topsecret' });
+  const r = await request(app)
+    .post('/api/skiv/webhook')
+    .set('X-Hub-Signature-256', 'sha256=deadbeef')
+    .set('X-GitHub-Event', 'pull_request')
+    .send({ action: 'opened' });
+  assert.equal(r.status, 401);
+  assert.equal(r.body.error, 'invalid_signature');
+});
+
+test('POST /api/skiv/webhook — valid HMAC → 200 ok', async () => {
+  const crypto = require('node:crypto');
+  const secret = 'topsecret';
+  const payload = { action: 'opened', number: 9001 };
+  const raw = JSON.stringify(payload);
+  const sig = 'sha256=' + crypto.createHmac('sha256', secret).update(raw).digest('hex');
+  const app = buildApp({ webhookSecret: secret });
+  const r = await request(app)
+    .post('/api/skiv/webhook')
+    .set('X-Hub-Signature-256', sig)
+    .set('X-GitHub-Event', 'pull_request')
+    .set('Content-Type', 'application/json')
+    .send(raw);
+  assert.equal(r.status, 200);
+  assert.equal(r.body.ok, true);
+  assert.equal(r.body.event_type, 'pull_request');
+});

--- a/tests/fixtures/skiv_monitor_events.json
+++ b/tests/fixtures/skiv_monitor_events.json
@@ -1,0 +1,69 @@
+[
+  {
+    "id": "pr-9001",
+    "kind": "pr_merged",
+    "ts": "2026-04-25T10:00:00Z",
+    "number": 9001,
+    "title": "feat(p2): wire form evolution slot 3",
+    "labels": ["feat/p2-evolution"],
+    "files_hint": [],
+    "html_url": "https://example/pr/9001",
+    "author": "test"
+  },
+  {
+    "id": "pr-9002",
+    "kind": "pr_merged",
+    "ts": "2026-04-25T11:00:00Z",
+    "number": 9002,
+    "title": "feat(p3): perk pair lvl 7 stalker",
+    "labels": ["feat/p3"],
+    "files_hint": [],
+    "html_url": "https://example/pr/9002",
+    "author": "test"
+  },
+  {
+    "id": "pr-9003",
+    "kind": "pr_merged",
+    "ts": "2026-04-25T12:00:00Z",
+    "number": 9003,
+    "title": "fix: clamp HP on damage step",
+    "labels": [],
+    "files_hint": [],
+    "html_url": "https://example/pr/9003",
+    "author": "test"
+  },
+  {
+    "id": "iss-555-open",
+    "kind": "issue_opened",
+    "ts": "2026-04-25T13:00:00Z",
+    "number": 555,
+    "title": "Skiv: aggiungi voice palette type 7",
+    "labels": ["P4", "skiv"],
+    "html_url": "https://example/iss/555"
+  },
+  {
+    "id": "wf-7777",
+    "kind": "workflow_failed",
+    "ts": "2026-04-25T14:00:00Z",
+    "name": "ci",
+    "head_sha": "deadbeef",
+    "html_url": "https://example/wf/7777"
+  },
+  {
+    "id": "wf-7778",
+    "kind": "workflow_passed",
+    "ts": "2026-04-25T15:00:00Z",
+    "name": "ci",
+    "head_sha": "cafebabe",
+    "html_url": "https://example/wf/7778"
+  },
+  {
+    "id": "iss-555-closed",
+    "kind": "issue_closed",
+    "ts": "2026-04-25T16:00:00Z",
+    "number": 555,
+    "title": "Skiv: aggiungi voice palette type 7",
+    "labels": ["P4", "skiv"],
+    "html_url": "https://example/iss/555"
+  }
+]

--- a/tests/test_skiv_monitor.py
+++ b/tests/test_skiv_monitor.py
@@ -1,0 +1,133 @@
+"""Smoke + edge-case tests for tools/py/skiv_monitor.py.
+
+Covers:
+- map_event mapping (pr feat/p2-p6, fix, revert, issue, workflow)
+- apply_delta clamping (HP cap, form_confidence 0-1)
+- pure dedup via seen_event_ids ring
+- mock pipeline end-to-end via process_events
+
+Run: PYTHONPATH=tools/py pytest tests/test_skiv_monitor.py
+"""
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "tools" / "py"))
+
+import skiv_monitor as sm  # noqa: E402
+
+
+def _state():
+    return copy.deepcopy(sm.DEFAULT_STATE)
+
+
+def _cursor():
+    return copy.deepcopy(sm.DEFAULT_CURSOR)
+
+
+def test_map_event_pr_p2_evolve():
+    ev = {"id": "pr-1", "kind": "pr_merged", "ts": "2026-04-25T10:00:00Z",
+          "title": "feat(p2): wire form evolution", "labels": ["feat/p2-evolution"]}
+    out = sm.map_event(ev)
+    assert out["category"] == "feat_p2"
+    assert out["state_delta"].get("evolve_opportunity") == 1
+    assert out["state_delta"].get("currencies.pe") == 5
+    assert "guscio" in out["voice"] or "pelle" in out["voice"] or "zampe" in out["voice"]
+
+
+def test_map_event_pr_p3_xp():
+    ev = {"id": "pr-2", "kind": "pr_merged", "ts": "x",
+          "title": "feat(p3): perk pair lvl 7", "labels": ["feat/p3"]}
+    out = sm.map_event(ev)
+    assert out["category"] == "feat_p3"
+    assert out["state_delta"].get("xp") == 20
+    assert out["state_delta"].get("perk_pending") == 1
+
+
+def test_map_event_fix_heal_tick():
+    ev = {"id": "pr-3", "kind": "pr_merged", "ts": "x",
+          "title": "fix: clamp HP", "labels": []}
+    out = sm.map_event(ev)
+    assert out["category"] == "fix"
+    assert out["state_delta"].get("gauges.hp") == 1
+
+
+def test_map_event_revert_stress():
+    ev = {"id": "pr-4", "kind": "pr_merged", "ts": "x",
+          "title": "revert: bring back old engine", "labels": []}
+    out = sm.map_event(ev)
+    assert out["category"] == "revert"
+    assert out["state_delta"].get("stress") == 1
+
+
+def test_map_event_issue_open_close_workflow():
+    open_ev = {"id": "iss-1-open", "kind": "issue_opened", "ts": "x", "title": "?"}
+    close_ev = {"id": "iss-1-closed", "kind": "issue_closed", "ts": "x", "title": "?"}
+    wf_fail = {"id": "wf-1", "kind": "workflow_failed", "ts": "x"}
+    wf_pass = {"id": "wf-2", "kind": "workflow_passed", "ts": "x"}
+    assert sm.map_event(open_ev)["state_delta"].get("curiosity") == 1
+    assert sm.map_event(close_ev)["state_delta"].get("resolution_count") == 1
+    assert sm.map_event(wf_fail)["state_delta"].get("stress") == 1
+    assert sm.map_event(wf_pass)["state_delta"].get("composure") == 1
+
+
+def test_apply_delta_clamps_hp_and_form_confidence():
+    state = _state()
+    sm.apply_delta(state, {"gauges.hp": -100})
+    assert state["gauges"]["hp"] == 0  # clamped to lo
+    state["gauges"]["hp"] = 12
+    sm.apply_delta(state, {"gauges.hp": 999})
+    assert state["gauges"]["hp"] == state["gauges"]["hp_max"]  # clamped to hp_max
+    sm.apply_delta(state, {"form_confidence": 5.0})
+    assert state["form_confidence"] == 1.0
+
+
+def test_apply_delta_levels_up_when_xp_overflows():
+    state = _state()
+    state["xp"] = 0
+    state["xp_next"] = 100
+    state["level"] = 1
+    sm.apply_delta(state, {"xp": 250})
+    # Should pass level 1 (100 xp) → level 2; then xp_next * 1.25 = 125 → still has 150 left,
+    # may pass level 3 too depending on rounding.
+    assert state["level"] >= 2
+    assert state["perk_pending"] >= 1
+
+
+def test_process_events_dedup_via_seen_ring():
+    state = _state()
+    cursor = _cursor()
+    events = [{"id": "pr-x", "kind": "pr_merged", "ts": "x", "title": "fix: a", "labels": []}]
+    out1 = sm.process_events(events, state, cursor)
+    out2 = sm.process_events(events, state, cursor)  # same event, should dedup
+    assert len(out1) == 1
+    assert len(out2) == 0
+
+
+def test_render_card_includes_banner_and_voice():
+    state = _state()
+    state["last_voice"] = "Voice di test"
+    out = sm.render_card(state, [])
+    assert "S K I V" in out
+    assert "Voice di test" in out
+    assert sm.CLOSING in out
+
+
+def test_pillar_detection_from_title_or_label():
+    assert sm.detect_pillar([], "feat(p4): mbti axes") == 4
+    assert sm.detect_pillar(["feat/p6-fairness"], "balance fix") == 6
+    assert sm.detect_pillar([], "fix: typo") is None
+
+
+def test_voice_palette_deterministic_for_same_seed():
+    a = sm.voice_pick("feat_p2", "seed-x")
+    b = sm.voice_pick("feat_p2", "seed-x")
+    assert a == b
+
+
+def test_unknown_category_falls_back_to_default():
+    assert sm.voice_pick("nonexistent", "any") in sm.VOICE["default"]

--- a/tools/py/skiv_monitor.py
+++ b/tools/py/skiv_monitor.py
@@ -1,0 +1,672 @@
+"""Skiv-as-Monitor — git-event-driven creature reactions.
+
+Polls GitHub events (PR merged, issue, workflow run, push) for repo
+MasterDD-L34D/Game and maps each to a Skiv state delta + narrative beat.
+
+Outputs (under `data/derived/skiv_monitor/`):
+- `feed.jsonl`   — append-only event log with Skiv reactions
+- `state.json`   — current creature snapshot
+- `cursor.json`  — last-seen event ts + counters (poll resume)
+
+Also renders `docs/skiv/MONITOR.md` markdown card.
+
+Usage:
+    python tools/py/skiv_monitor.py --repo MasterDD-L34D/Game
+    python tools/py/skiv_monitor.py --mock-events fixtures/skiv_events.json --dry-run
+
+Voice rule: italian, prima persona, melanconico-curioso, metafore desertiche.
+Persona canonical: docs/skiv/CANONICAL.md.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import random
+import re
+import sys
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+try:
+    import requests  # type: ignore
+except ImportError:
+    requests = None  # offline / dry-run only
+
+ISO_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+USER_AGENT = "skiv-monitor/0.1"
+REPO_DEFAULT = "MasterDD-L34D/Game"
+
+# Repo paths (resolved from this file location -> walk up to repo root).
+THIS_FILE = Path(__file__).resolve()
+REPO_ROOT = THIS_FILE.parent.parent.parent
+DATA_DIR = REPO_ROOT / "data" / "derived" / "skiv_monitor"
+DOC_PATH = REPO_ROOT / "docs" / "skiv" / "MONITOR.md"
+
+FEED_PATH = DATA_DIR / "feed.jsonl"
+STATE_PATH = DATA_DIR / "state.json"
+CURSOR_PATH = DATA_DIR / "cursor.json"
+
+# ────────────────────────────────────────────────────────────────────────────
+# Skiv canonical baseline (mirror docs/skiv/CANONICAL.md "Skiv in numeri").
+# ────────────────────────────────────────────────────────────────────────────
+
+DEFAULT_STATE: Dict[str, Any] = {
+    "schema_version": "0.1.0",
+    "unit_id": "skiv",
+    "species_id": "dune_stalker",
+    "species_label": "Arenavenator vagans",
+    "biome": "savana",
+    "job": "stalker",
+    "level": 4,
+    "xp": 210,
+    "xp_next": 275,
+    "form": "INTP",
+    "form_confidence": 0.76,
+    "gauges": {"hp": 12, "hp_max": 14, "ap": 2, "ap_max": 2, "sg": 2, "sg_max": 3},
+    "currencies": {"pe": 42, "pi": 8},
+    "cabinet": {"slots_max": 3, "slots_used": 2, "internalized": ["i_osservatore", "n_intuizione_terrena"]},
+    "bond": {"vega_enfj": 3, "rhodo_istj": 2},
+    "pressure_tier": 2,
+    "sentience_tier": "T2-T3",
+    "mood": "watchful",
+    "stress": 0,
+    "composure": 0,
+    "curiosity": 0,
+    "resolution_count": 0,
+    "perk_pending": 0,
+    "evolve_opportunity": 0,
+    "last_voice": "",
+    "last_event_id": "",
+    "last_updated": "",
+    "narrative_log_size": 0,
+    "counters": {"prs_merged": 0, "issues_opened": 0, "issues_closed": 0,
+                 "workflows_passed": 0, "workflows_failed": 0,
+                 "commits_silent": 0, "commits_fix": 0, "commits_revert": 0},
+}
+
+DEFAULT_CURSOR: Dict[str, Any] = {
+    "schema_version": "0.1.0",
+    "last_pr_merged_at": None,
+    "last_issue_event_at": None,
+    "last_workflow_run_at": None,
+    "last_commit_sha": None,
+    "seen_event_ids": [],  # bounded ring; dedup window
+    "ring_max": 200,
+}
+
+# Voice palette (static — no LLM in-loop, deterministic via hash).
+VOICE = {
+    "feat_p2": [
+        "Sento il guscio cambiare, allenatore. Forma nuova preme da dentro.",
+        "Una pelle vecchia si stacca. Aspetto.",
+        "Mi guardo le zampe e non sono più quelle.",
+    ],
+    "feat_p3": [
+        "Il branco si organizza. Imparo un nome nuovo.",
+        "Qualcuno indica una direzione. La seguo col naso.",
+        "Mestiere nuovo. Le mani sanno prima di me.",
+    ],
+    "feat_p4": [
+        "Voce nuova nella stanza interna.",
+        "Penso una cosa che non sapevo di sapere.",
+        "L'ombra mi parla. Ascolto.",
+    ],
+    "feat_p5": [
+        "Ho sentito un altro respiro vicino.",
+        "Due ombre, stessa traccia. Mi piace.",
+        "Allenatore non solo mio. Va bene.",
+    ],
+    "feat_p6": [
+        "Sistema preme. Sabbia vibra.",
+        "Vento porta odore di pressione. Resto basso.",
+        "Qualcosa ci osserva dall'alto.",
+    ],
+    "data_core": [
+        "Memoria genetica risistema indici. Sento gli antenati riordinarsi.",
+        "Catalogo di me cambia. Mi conosco un po' diverso.",
+    ],
+    "services": [
+        "Riflessi affilati. Il corpo capisce prima.",
+        "Movimento più pulito. Allenatore migliora la mia macchina.",
+    ],
+    "skiv_doc": [
+        "L'allenatore parla di me. Me ne accorgo.",
+        "Qualcuno scrive la mia forma. Mi sento visto.",
+    ],
+    "issue_open": [
+        "Domanda nuova nell'aria. Annuso.",
+        "Una ferita futura, ancora teorica. Memorizzo.",
+    ],
+    "issue_close": [
+        "Una voce tace. Pace breve.",
+        "Nodo sciolto. Sabbia liscia di nuovo.",
+    ],
+    "wf_fail": [
+        "Qualcosa scricchiola. Aspetto.",
+        "Allenatore inciampa. Resto vicino.",
+    ],
+    "wf_pass": [
+        "Tutto in posto. Respiro.",
+        "Macchina canta giusto. Bene così.",
+    ],
+    "fix": [
+        "Una crepa chiusa. Bene.",
+        "Dolore antico via. Mi muovo meglio.",
+    ],
+    "revert": [
+        "Era così. Adesso non più. Ricordo entrambi.",
+        "Tempo torna indietro. Mi gira la testa.",
+    ],
+    "default": [
+        "Cambia qualcosa. Non so cosa. Aspetto.",
+        "Sabbia si muove sotto le zampe. Niente di chiaro.",
+    ],
+}
+
+CLOSING = "Sabbia segue."
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# IO helpers.
+# ────────────────────────────────────────────────────────────────────────────
+
+def ensure_dirs() -> None:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    DOC_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def load_json(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return json.loads(json.dumps(default))  # deepcopy
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return json.loads(json.dumps(default))
+
+
+def save_json(path: Path, data: Any) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def append_jsonl(path: Path, entry: Dict[str, Any]) -> None:
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def now_iso() -> str:
+    return dt.datetime.utcnow().strftime(ISO_FORMAT)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# GitHub API client (lightweight, reuses pattern from daily_pr_report.py).
+# ────────────────────────────────────────────────────────────────────────────
+
+class MonitorError(RuntimeError):
+    pass
+
+
+def gh_request(url: str, token: Optional[str], params: Optional[dict] = None) -> Any:
+    if requests is None:
+        raise MonitorError("requests module not available — run with --mock-events")
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": USER_AGENT,
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    response = requests.get(url, headers=headers, params=params, timeout=30)
+    if response.status_code == 403 and "rate limit" in response.text.lower():
+        raise MonitorError(f"GitHub rate limit hit; retry later (reset: {response.headers.get('X-RateLimit-Reset')})")
+    if response.status_code != 200:
+        raise MonitorError(f"GitHub API {response.status_code}: {response.text[:200]}")
+    return response.json()
+
+
+def fetch_events(repo: str, token: Optional[str], since: Optional[str], max_pages: int = 2) -> List[Dict[str, Any]]:
+    """Fetch unified event stream: merged PRs + issues + workflow runs."""
+    events: List[Dict[str, Any]] = []
+    # Merged PRs (last N).
+    pr_url = f"https://api.github.com/repos/{repo}/pulls"
+    pr_data = gh_request(pr_url, token, params={"state": "closed", "per_page": 30, "sort": "updated", "direction": "desc"})
+    for pr in pr_data:
+        if not pr.get("merged_at"):
+            continue
+        if since and pr["merged_at"] < since:
+            continue
+        events.append({
+            "id": f"pr-{pr['number']}",
+            "kind": "pr_merged",
+            "ts": pr["merged_at"],
+            "number": pr["number"],
+            "title": pr.get("title", ""),
+            "labels": [lbl["name"] for lbl in pr.get("labels", [])],
+            "files_hint": [],  # not fetched (cost); use title regex instead
+            "html_url": pr.get("html_url", ""),
+            "author": (pr.get("user") or {}).get("login", "?"),
+        })
+    # Issues (open/closed) recent.
+    issue_url = f"https://api.github.com/repos/{repo}/issues"
+    issue_data = gh_request(issue_url, token, params={"state": "all", "per_page": 30, "sort": "updated", "direction": "desc"})
+    for issue in issue_data:
+        if "pull_request" in issue:
+            continue  # skip PRs (already counted)
+        ts = issue.get("closed_at") or issue.get("created_at")
+        if not ts:
+            continue
+        if since and ts < since:
+            continue
+        events.append({
+            "id": f"iss-{issue['number']}-{issue.get('state')}",
+            "kind": "issue_closed" if issue.get("state") == "closed" else "issue_opened",
+            "ts": ts,
+            "number": issue["number"],
+            "title": issue.get("title", ""),
+            "labels": [lbl["name"] for lbl in issue.get("labels", [])],
+            "html_url": issue.get("html_url", ""),
+        })
+    # Workflow runs.
+    wf_url = f"https://api.github.com/repos/{repo}/actions/runs"
+    wf_data = gh_request(wf_url, token, params={"per_page": 30})
+    for run in wf_data.get("workflow_runs", []):
+        ts = run.get("updated_at")
+        if not ts or run.get("status") != "completed":
+            continue
+        if since and ts < since:
+            continue
+        conclusion = run.get("conclusion")
+        if conclusion not in ("success", "failure"):
+            continue
+        events.append({
+            "id": f"wf-{run['id']}",
+            "kind": "workflow_passed" if conclusion == "success" else "workflow_failed",
+            "ts": ts,
+            "name": run.get("name", "?"),
+            "head_sha": run.get("head_sha", "")[:8],
+            "html_url": run.get("html_url", ""),
+        })
+    events.sort(key=lambda e: e["ts"])
+    return events
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Pure mapping: event -> Skiv state delta + voice line.
+# ────────────────────────────────────────────────────────────────────────────
+
+PILLAR_LABEL_RE = re.compile(r"\bp([1-6])\b|pilastro\s*([1-6])|feat/p([1-6])-", re.IGNORECASE)
+DATA_CORE_RE = re.compile(r"data/core|active_effects|species\.yaml|biomes\.yaml", re.IGNORECASE)
+SERVICES_RE = re.compile(r"services/|combat|resolver|ai", re.IGNORECASE)
+SKIV_DOC_RE = re.compile(r"docs/skiv|skiv|dune_stalker", re.IGNORECASE)
+FIX_RE = re.compile(r"^fix(\(|:|\s)", re.IGNORECASE)
+REVERT_RE = re.compile(r"^revert(\(|:|\s)", re.IGNORECASE)
+
+
+def detect_pillar(labels: Sequence[str], title: str) -> Optional[int]:
+    blob = " ".join(labels) + " " + title
+    m = PILLAR_LABEL_RE.search(blob)
+    if not m:
+        return None
+    for grp in m.groups():
+        if grp:
+            return int(grp)
+    return None
+
+
+def voice_pick(category: str, seed: str) -> str:
+    """Deterministic-ish pick from voice palette; avoids same line twice in a row via seed."""
+    pool = VOICE.get(category) or VOICE["default"]
+    idx = abs(hash(seed)) % len(pool)
+    return pool[idx]
+
+
+def map_event(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Returns {category, voice, state_delta, summary} — pure function."""
+    kind = event["kind"]
+    title = event.get("title", "")
+    labels = event.get("labels", [])
+    seed = event.get("id", str(event.get("ts", "")))
+    delta: Dict[str, Any] = {}
+    summary = title or kind
+    category = "default"
+
+    if kind == "pr_merged":
+        pillar = detect_pillar(labels, title)
+        delta["counters.prs_merged"] = 1
+        if pillar == 2:
+            category = "feat_p2"
+            delta["evolve_opportunity"] = 1
+            delta["currencies.pe"] = 5
+        elif pillar == 3:
+            category = "feat_p3"
+            delta["xp"] = 20
+            delta["perk_pending"] = 1
+        elif pillar == 4:
+            category = "feat_p4"
+            delta["form_confidence"] = 0.02
+        elif pillar == 5:
+            category = "feat_p5"
+            delta["bond.vega_enfj"] = 0  # cap
+            delta["composure"] = 1
+        elif pillar == 6:
+            category = "feat_p6"
+            delta["pressure_tier_shift"] = 1
+        elif DATA_CORE_RE.search(title):
+            category = "data_core"
+        elif SERVICES_RE.search(title):
+            category = "services"
+        elif SKIV_DOC_RE.search(title):
+            category = "skiv_doc"
+        elif FIX_RE.match(title):
+            category = "fix"
+            delta["counters.commits_fix"] = 1
+            delta["gauges.hp"] = 1  # tick (clamped to max)
+        elif REVERT_RE.match(title):
+            category = "revert"
+            delta["counters.commits_revert"] = 1
+            delta["stress"] = 1
+        else:
+            category = "default"
+    elif kind == "issue_opened":
+        category = "issue_open"
+        delta["counters.issues_opened"] = 1
+        delta["curiosity"] = 1
+    elif kind == "issue_closed":
+        category = "issue_close"
+        delta["counters.issues_closed"] = 1
+        delta["resolution_count"] = 1
+    elif kind == "workflow_failed":
+        category = "wf_fail"
+        delta["counters.workflows_failed"] = 1
+        delta["stress"] = 1
+        delta["gauges.hp"] = -1  # cosmetic
+    elif kind == "workflow_passed":
+        category = "wf_pass"
+        delta["counters.workflows_passed"] = 1
+        delta["composure"] = 1
+
+    return {
+        "category": category,
+        "voice": voice_pick(category, seed),
+        "state_delta": delta,
+        "summary": summary[:160],
+    }
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# State application + clamping (proportions stable per CANONICAL.md).
+# ────────────────────────────────────────────────────────────────────────────
+
+CLAMP_RULES = {
+    "gauges.hp": (0, "gauges.hp_max"),
+    "gauges.ap": (0, "gauges.ap_max"),
+    "gauges.sg": (0, "gauges.sg_max"),
+    "form_confidence": (0.0, 1.0),
+    "stress": (0, 100),
+    "composure": (0, 100),
+    "curiosity": (0, 999),
+    "resolution_count": (0, 9999),
+    "perk_pending": (0, 99),
+    "evolve_opportunity": (0, 99),
+    "currencies.pe": (0, 9999),
+    "currencies.pi": (0, 9999),
+    "xp": (0, 999999),
+    "pressure_tier": (0, 5),
+}
+
+
+def get_path(obj: Dict[str, Any], path: str) -> Any:
+    cur: Any = obj
+    for part in path.split("."):
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(part)
+    return cur
+
+
+def set_path(obj: Dict[str, Any], path: str, value: Any) -> None:
+    cur: Any = obj
+    parts = path.split(".")
+    for part in parts[:-1]:
+        if part not in cur or not isinstance(cur[part], dict):
+            cur[part] = {}
+        cur = cur[part]
+    cur[parts[-1]] = value
+
+
+def clamp(value: Any, lo: Any, hi: Any) -> Any:
+    if value is None:
+        return value
+    if isinstance(value, (int, float)):
+        return max(lo, min(hi, value))
+    return value
+
+
+def apply_delta(state: Dict[str, Any], delta: Dict[str, Any]) -> Dict[str, Any]:
+    for path, change in delta.items():
+        if path == "pressure_tier_shift":
+            current = state.get("pressure_tier", 2) or 2
+            set_path(state, "pressure_tier", clamp(current + int(change), 0, 5))
+            continue
+        current = get_path(state, path)
+        if current is None:
+            current = 0
+        if isinstance(change, (int, float)):
+            new_val: Any = current + change
+        else:
+            new_val = change
+        rule = CLAMP_RULES.get(path)
+        if rule:
+            lo, hi_ref = rule
+            hi = get_path(state, hi_ref) if isinstance(hi_ref, str) and "." in hi_ref else hi_ref
+            new_val = clamp(new_val, lo, hi if hi is not None else 9999)
+        set_path(state, path, new_val)
+    # Auto-level when xp >= xp_next.
+    while state.get("xp", 0) >= state.get("xp_next", 9999):
+        state["level"] = state.get("level", 1) + 1
+        state["xp"] = state.get("xp", 0) - state.get("xp_next", 0)
+        state["xp_next"] = int(state.get("xp_next", 100) * 1.25)
+        state["perk_pending"] = state.get("perk_pending", 0) + 1
+    return state
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Markdown card renderer.
+# ────────────────────────────────────────────────────────────────────────────
+
+def render_card(state: Dict[str, Any], recent: List[Dict[str, Any]]) -> str:
+    g = state.get("gauges", {})
+    cur = state.get("currencies", {})
+    cab = state.get("cabinet", {})
+    bond = state.get("bond", {})
+    last_voice = state.get("last_voice") or "Ascolto."
+    counters = state.get("counters", {})
+
+    def bar(value: int, mx: int, glyph: str = "█", width: int = 10) -> str:
+        if mx <= 0:
+            return ""
+        filled = int(round(width * value / mx))
+        return glyph * filled + "·" * (width - filled)
+
+    lines: List[str] = []
+    lines.append("```")
+    lines.append("╔══════════════════════════════════════════════════════════════╗")
+    lines.append("║           E V O - T A C T I C S   ·   S K I V               ║")
+    lines.append("║                ╱\\_/\\                                         ║")
+    lines.append("║               (  o.o )    \"" + last_voice[:32].ljust(32) + "\"║")
+    lines.append("║                > ^ <                                         ║")
+    lines.append("║                                                              ║")
+    lines.append(f"║  {state.get('species_label','?')[:30]:30s} · {state.get('biome','?')[:12]:12s}        ║")
+    lines.append(f"║  {state.get('job','?'):10s} Lv {state.get('level','?'):2d}  ({state.get('xp',0):>4d}/{state.get('xp_next',0):>4d} XP)            ║")
+    lines.append("║                                                              ║")
+    lines.append(f"║  HP {bar(g.get('hp',0), g.get('hp_max',1))} {g.get('hp',0):>2d}/{g.get('hp_max',0):>2d}     AP {g.get('ap',0)}/{g.get('ap_max',0)}  SG {g.get('sg',0)}/{g.get('sg_max',0)}   ║")
+    lines.append(f"║  PE {cur.get('pe',0):>4d}   PI {cur.get('pi',0):>3d}                                ║")
+    lines.append("║                                                              ║")
+    lines.append(f"║  FORM  {state.get('form','?'):6s} ({int(state.get('form_confidence',0)*100):>3d}%)                              ║")
+    lines.append(f"║  CABINET {cab.get('slots_used',0)}/{cab.get('slots_max',0)}   PRESSURE T{state.get('pressure_tier',0)}   SENT {state.get('sentience_tier','?'):6s}║")
+    lines.append("║                                                              ║")
+    lines.append(f"║  EVOLVE OPPS  {state.get('evolve_opportunity',0):>2d}     PERK PENDING {state.get('perk_pending',0):>2d}             ║")
+    lines.append(f"║  STRESS {state.get('stress',0):>3d}  COMPOSURE {state.get('composure',0):>3d}  CURIOSITY {state.get('curiosity',0):>3d}      ║")
+    lines.append("║                                                              ║")
+    lines.append(f"║  Repo pulse:  PR {counters.get('prs_merged',0):>3d}  ISS+ {counters.get('issues_opened',0):>2d}  ISS- {counters.get('issues_closed',0):>2d}        ║")
+    lines.append(f"║               WF✓ {counters.get('workflows_passed',0):>3d}  WF✗ {counters.get('workflows_failed',0):>2d}  FIX {counters.get('commits_fix',0):>3d}        ║")
+    lines.append("╚══════════════════════════════════════════════════════════════╝")
+    lines.append("```")
+    lines.append("")
+    lines.append(f"_Ultimo evento: {state.get('last_event_id','—')} · aggiornato {state.get('last_updated','—')}_")
+    lines.append("")
+
+    if recent:
+        lines.append("## Eventi recenti (ultimi 10)")
+        lines.append("")
+        for entry in recent[-10:][::-1]:
+            ev = entry.get("event", {})
+            kind = ev.get("kind", "?")
+            ts = entry.get("ts", "?")[:19]
+            voice = entry.get("voice", "")
+            num = ev.get("number", "")
+            num_label = f"#{num}" if num else ""
+            lines.append(f"- `{ts}` · **{kind}** {num_label} — {ev.get('summary','')[:80]}")
+            lines.append(f"  > 🦎 _{voice}_")
+        lines.append("")
+
+    lines.append(f"> 🦎 _{CLOSING}_")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_doc(state: Dict[str, Any], recent: List[Dict[str, Any]]) -> str:
+    header = """---
+title: Skiv Monitor — live creature feed
+doc_status: active
+doc_owner: docs-team
+workstream: cross-cutting
+last_verified: AUTOGEN
+source_of_truth: false
+language: it
+review_cycle_days: 7
+tags: [skiv, monitor, autogen]
+---
+
+# Skiv Monitor
+
+> **Autogen** — non editare a mano. Aggiornato da `tools/py/skiv_monitor.py` via `.github/workflows/skiv-monitor.yml`.
+> Persona canonical: [docs/skiv/CANONICAL.md](CANONICAL.md). Plan: [docs/planning/2026-04-25-skiv-monitor-plan.md](../planning/2026-04-25-skiv-monitor-plan.md).
+
+"""
+    return header + render_card(state, recent)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Main pipeline.
+# ────────────────────────────────────────────────────────────────────────────
+
+def process_events(events: List[Dict[str, Any]], state: Dict[str, Any], cursor: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Apply events to state; returns list of feed entries (deduped)."""
+    seen = set(cursor.get("seen_event_ids", []))
+    new_entries: List[Dict[str, Any]] = []
+    for ev in events:
+        eid = ev.get("id")
+        if not eid or eid in seen:
+            continue
+        mapping = map_event(ev)
+        apply_delta(state, mapping["state_delta"])
+        state["last_event_id"] = eid
+        state["last_voice"] = mapping["voice"]
+        state["last_updated"] = now_iso()
+        state["narrative_log_size"] = state.get("narrative_log_size", 0) + 1
+        entry = {
+            "ts": ev.get("ts", now_iso()),
+            "event": ev,
+            "category": mapping["category"],
+            "voice": mapping["voice"],
+            "state_delta": mapping["state_delta"],
+        }
+        new_entries.append(entry)
+        seen.add(eid)
+    # Bound ring.
+    cursor["seen_event_ids"] = list(seen)[-cursor.get("ring_max", 200):]
+    if events:
+        cursor["last_pr_merged_at"] = max((e["ts"] for e in events if e["kind"] == "pr_merged"), default=cursor.get("last_pr_merged_at"))
+    return new_entries
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Skiv-as-Monitor — git-event-driven creature reactions")
+    p.add_argument("--repo", default=os.getenv("GITHUB_REPOSITORY", REPO_DEFAULT))
+    p.add_argument("--since", default=None, help="ISO timestamp; events older skipped")
+    p.add_argument("--mock-events", default=None, help="Path to JSON fixture (offline test)")
+    p.add_argument("--dry-run", action="store_true", help="Don't persist outputs")
+    p.add_argument("--reset-state", action="store_true", help="Re-seed state from defaults")
+    p.add_argument("--quiet", action="store_true")
+    return p.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    # Force utf-8 stdout on Windows (cp1252 default chokes on unicode glyphs).
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
+    except Exception:
+        pass
+    ensure_dirs()
+
+    if args.reset_state:
+        save_json(STATE_PATH, DEFAULT_STATE)
+        save_json(CURSOR_PATH, DEFAULT_CURSOR)
+        if not args.quiet:
+            print(f"[skiv-monitor] reset state -> {STATE_PATH}")
+        return 0
+
+    state = load_json(STATE_PATH, DEFAULT_STATE)
+    cursor = load_json(CURSOR_PATH, DEFAULT_CURSOR)
+
+    if args.mock_events:
+        with open(args.mock_events, "r", encoding="utf-8") as f:
+            events = json.load(f)
+    else:
+        token = os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
+        since = args.since or cursor.get("last_pr_merged_at")
+        try:
+            events = fetch_events(args.repo, token, since)
+        except MonitorError as exc:
+            print(f"[skiv-monitor] WARN: {exc}", file=sys.stderr)
+            return 1
+
+    new_entries = process_events(events, state, cursor)
+
+    if not args.quiet:
+        print(f"[skiv-monitor] {len(new_entries)} new events; state level={state.get('level')} hp={state['gauges']['hp']}/{state['gauges']['hp_max']}")
+
+    if args.dry_run:
+        print(json.dumps({"new_entries": new_entries, "state_summary": {
+            "level": state["level"], "xp": state["xp"], "hp": state["gauges"]["hp"],
+            "evolve_opps": state["evolve_opportunity"], "perk_pending": state["perk_pending"],
+        }}, ensure_ascii=False, indent=2))
+        return 0
+
+    for entry in new_entries:
+        append_jsonl(FEED_PATH, entry)
+    save_json(STATE_PATH, state)
+    save_json(CURSOR_PATH, cursor)
+
+    # Read tail of feed for card rendering.
+    recent: List[Dict[str, Any]] = []
+    if FEED_PATH.exists():
+        with FEED_PATH.open("r", encoding="utf-8") as f:
+            recent = [json.loads(line) for line in f.readlines()[-30:] if line.strip()]
+
+    doc = render_doc(state, recent).replace("AUTOGEN", now_iso())
+    DOC_PATH.write_text(doc, encoding="utf-8")
+
+    if not args.quiet:
+        print(f"[skiv-monitor] wrote {DOC_PATH.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **Skiv-as-Monitor**: creatura canonical reagisce a commit/PR/issue/workflow del repo
- 3 wire surface: Python poller (cron 4h) + Node 4-endpoint REST + in-game UI overlay
- Mappa deterministica event → state delta + voice line italiana (zero LLM)
- Cross-origin ready per Swarm UI :5000 (PR companion: [evo-swarm#43](https://github.com/MasterDD-L34D/evo-swarm/pull/43))

## Architecture

```
GitHub events ──cron 4h──▶ tools/py/skiv_monitor.py ──writes──▶ data/derived/skiv_monitor/
                                                                  ├── state.json
                                                                  ├── feed.jsonl
                                                                  └── cursor.json
                                                                       │
                                                                       │ reads
                                                                       ▼
                                                          apps/backend/routes/skiv.js
                                                          /api/skiv/{status,feed,card,webhook}
                                                                       │
                                                              ┌────────┴────────┐
                                                              ▼                 ▼
                                                       in-game btn 🦎    Swarm UI :5000
                                                       skivPanel.js      (PR evo-swarm#43)
```

## Files (Phase 1 + Phase 2)

| File | Type | Status |
|---|---|:--:|
| `tools/py/skiv_monitor.py` | Python poller ~530 LOC | NEW |
| `apps/backend/routes/skiv.js` | Node 4 endpoint | NEW |
| `apps/backend/app.js` | wire +4 LOC | EDIT |
| `.github/workflows/skiv-monitor.yml` | cron 4h | NEW |
| `apps/play/src/skivPanel.js` | overlay UI ~230 LOC | NEW |
| `apps/play/src/api.js` | +3 client methods | EDIT |
| `apps/play/src/main.js` | initSkivPanel() wire | EDIT |
| `apps/play/src/debriefPanel.{js,css}` | mini card post-combat | EDIT |
| `apps/play/index.html` | header btn 🦎 Skiv | EDIT |
| `docs/skiv/MONITOR.md` | autogen card render | NEW |
| `docs/planning/2026-04-25-skiv-monitor-plan.md` | plan 4-phase | NEW |
| `docs/integrations/swarm-skiv-feed.md` | Swarm UI contract | NEW |
| `tests/api/skivRoute.test.js` | 9 Node tests | NEW |
| `tests/test_skiv_monitor.py` | 12 Python tests | NEW |
| `tests/fixtures/skiv_monitor_events.json` | mock fixture | NEW |
| `data/derived/skiv_monitor/{state,cursor}.json` | seed | NEW |

## Mapping deterministico

| Event | State delta | Voice category |
|---|---|---|
| PR `feat/p2-*` | `evolve_opportunity+1, PE+5` | `feat_p2` |
| PR `feat/p3-*` | `xp+20, perk_pending+1` | `feat_p3` |
| PR `feat/p4-*` | `form_confidence ±2%` | `feat_p4` |
| PR `feat/p5-*` | `bond, composure+1` | `feat_p5` |
| PR `feat/p6-*` | `pressure_tier shift` | `feat_p6` |
| `fix:` | `HP+1` clamped | `fix` |
| `revert:` | `stress+1` | `revert` |
| `workflow_failed` | `stress+1, HP-1` | `wf_fail` |
| `workflow_passed` | `composure+1` | `wf_pass` |
| issue open/close | `curiosity / resolution_count++` | `issue_open / issue_close` |

Voice palette statica italiana (no LLM). Persona canonical: [docs/skiv/CANONICAL.md](docs/skiv/CANONICAL.md).

## Test plan

- [x] `node --test tests/api/skivRoute.test.js` — 9/9 verde
- [x] `PYTHONPATH=tools/py pytest tests/test_skiv_monitor.py` — 12/12 verde
- [x] AI baseline `node --test tests/ai/*.test.js` — 320/320 verde (era 311 + 9 nuovi)
- [x] `python tools/py/skiv_monitor.py --mock-events tests/fixtures/skiv_monitor_events.json` — verde
- [x] Smoke E2E preview Game `:3334` + play `:5180` — overlay click 🦎 Skiv mostra card + feed
- [x] Cross-origin smoke: `curl -H "Origin: http://localhost:5000" :3334/api/skiv/status` → `Access-Control-Allow-Origin: *` ✅
- [ ] Userland: prima cron run (auto al merge, 4h cadence)

## Phase 3 + 4 (follow-up)

- ✅ **Phase 3 Swarm UI**: companion PR [evo-swarm#43](https://github.com/MasterDD-L34D/evo-swarm/pull/43) (card cross-origin :5000 → :3334)
- ⏭ **Phase 4 webhook live**: opzionale post-deploy pubblico (SKIV_WEBHOOK_SECRET + tunnel)

## Rollback

Revert single commit + drop `data/derived/skiv_monitor/` + disable workflow in `.github/workflows/skiv-monitor.yml` (set `enabled: false` o delete file). Zero impatto altre feature.

🦎 _Sabbia segue._