### PR TITLE
test(coverage): C3+C4 reactionEngine + rewardEconomy unit tests (+25 NEW)

### DIFF
--- a/tests/services/reactionEngine.test.js
+++ b/tests/services/reactionEngine.test.js
@@ -1,0 +1,288 @@
+// Unit test for reactionEngine — coverage gap closed (archeologist excavate 2026-04-25).
+//
+// Scope: triggerOnDamage (intercept) + triggerOnMove (overwatch_shot) +
+// helpers findReaction / consumeReaction. Pure logic, no side effects fuori
+// da session/units mutati in place.
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const reactionEngine = require('../../apps/backend/services/reactionEngine');
+
+// ─────────────────────────────────────────────────────────────────
+// Fixture builders
+// ─────────────────────────────────────────────────────────────────
+
+function makeUnit(overrides = {}) {
+  return {
+    id: 'u1',
+    controlled_by: 'player',
+    position: { x: 0, y: 0 },
+    hp: 10,
+    max_hp: 10,
+    attack_range: 2,
+    reactions: [],
+    status: {},
+    ...overrides,
+  };
+}
+
+function makeSession(units = []) {
+  return {
+    session_id: 'sess_test',
+    units,
+    damage_taken: {},
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────
+// findReaction / consumeReaction
+// ─────────────────────────────────────────────────────────────────
+
+test('findReaction returns matching reaction with index', () => {
+  const unit = makeUnit({
+    reactions: [
+      { trigger: 'ally_attacked_adjacent', ability_id: 'intercept' },
+      { trigger: 'enemy_moves_in_range', ability_id: 'overwatch_shot' },
+    ],
+  });
+  const found = reactionEngine.findReaction(unit, 'enemy_moves_in_range');
+  assert.equal(found.index, 1);
+  assert.equal(found.reaction.ability_id, 'overwatch_shot');
+});
+
+test('findReaction returns null on missing unit / no match', () => {
+  assert.equal(reactionEngine.findReaction(null, 'ally_attacked_adjacent'), null);
+  assert.equal(reactionEngine.findReaction({ reactions: [] }, 'x'), null);
+  const unit = makeUnit({ reactions: [{ trigger: 'foo' }] });
+  assert.equal(reactionEngine.findReaction(unit, 'bar'), null);
+});
+
+test('consumeReaction removes by index, returns removed entry', () => {
+  const unit = makeUnit({
+    reactions: [{ ability_id: 'a' }, { ability_id: 'b' }],
+  });
+  const removed = reactionEngine.consumeReaction(unit, 0);
+  assert.equal(removed.ability_id, 'a');
+  assert.equal(unit.reactions.length, 1);
+  assert.equal(unit.reactions[0].ability_id, 'b');
+});
+
+// ─────────────────────────────────────────────────────────────────
+// triggerOnDamage — intercept
+// ─────────────────────────────────────────────────────────────────
+
+test('triggerOnDamage fires intercept when ally adjacent has reaction armed', () => {
+  const target = makeUnit({ id: 'target', position: { x: 5, y: 5 }, hp: 5, max_hp: 10 });
+  const interceptor = makeUnit({
+    id: 'warden',
+    position: { x: 5, y: 6 }, // adjacent (manhattan=1)
+    hp: 8,
+    reactions: [{ trigger: 'ally_attacked_adjacent', ability_id: 'intercept' }],
+  });
+  const attacker = makeUnit({ id: 'attacker', controlled_by: 'sistema' });
+  const session = makeSession([target, interceptor, attacker]);
+  session.damage_taken = { target: 5 };
+
+  const res = reactionEngine.triggerOnDamage(session, attacker, target, 5);
+
+  assert.ok(res, 'should return result object');
+  assert.equal(res.interceptor_id, 'warden');
+  assert.equal(res.damage_rerouted, 5);
+  assert.equal(target.hp, 10, 'target hp restored capped at max_hp');
+  assert.equal(interceptor.hp, 3, 'interceptor took the damage');
+  assert.equal(interceptor.reactions.length, 0, 'reaction consumed');
+  assert.equal(session.damage_taken.target, 0, 'target damage_taken decremented');
+  assert.equal(session.damage_taken.warden, 5, 'interceptor damage_taken incremented');
+});
+
+test('triggerOnDamage skips when no ally adjacent has intercept armed', () => {
+  const target = makeUnit({ id: 'target', position: { x: 0, y: 0 } });
+  const ally = makeUnit({
+    id: 'ally',
+    position: { x: 5, y: 5 }, // far away
+    reactions: [{ trigger: 'ally_attacked_adjacent', ability_id: 'intercept' }],
+  });
+  const session = makeSession([target, ally]);
+  const res = reactionEngine.triggerOnDamage(session, null, target, 5);
+  assert.equal(res, null);
+  assert.equal(ally.reactions.length, 1, 'reaction not consumed');
+});
+
+test('triggerOnDamage skips KO target / zero damage / null inputs', () => {
+  const target = makeUnit({ id: 't', hp: 0 });
+  const session = makeSession([target]);
+  assert.equal(reactionEngine.triggerOnDamage(session, null, target, 5), null);
+  assert.equal(reactionEngine.triggerOnDamage(null, null, target, 5), null);
+  assert.equal(reactionEngine.triggerOnDamage(session, null, null, 5), null);
+  assert.equal(
+    reactionEngine.triggerOnDamage(session, null, makeUnit(), 0),
+    null,
+    'zero damage skipped',
+  );
+});
+
+test('triggerOnDamage skips stunned interceptor + opposing-team unit', () => {
+  const target = makeUnit({ id: 'target', position: { x: 5, y: 5 } });
+  const stunnedAlly = makeUnit({
+    id: 'stunned',
+    position: { x: 5, y: 6 },
+    reactions: [{ trigger: 'ally_attacked_adjacent' }],
+    status: { stunned: 1 },
+  });
+  const enemyAdjacent = makeUnit({
+    id: 'enemy',
+    controlled_by: 'sistema',
+    position: { x: 5, y: 4 },
+    reactions: [{ trigger: 'ally_attacked_adjacent' }],
+  });
+  const session = makeSession([target, stunnedAlly, enemyAdjacent]);
+  const res = reactionEngine.triggerOnDamage(session, null, target, 4);
+  assert.equal(res, null, 'stunned + cross-team filtered');
+});
+
+test('triggerOnDamage detects interceptor killed when damage exceeds hp', () => {
+  const target = makeUnit({ id: 't', position: { x: 0, y: 0 }, hp: 5, max_hp: 10 });
+  const fragileInterceptor = makeUnit({
+    id: 'fragile',
+    position: { x: 1, y: 0 },
+    hp: 3,
+    reactions: [{ trigger: 'ally_attacked_adjacent' }],
+  });
+  const session = makeSession([target, fragileInterceptor]);
+  const res = reactionEngine.triggerOnDamage(session, null, target, 5);
+  assert.ok(res);
+  assert.equal(res.interceptor_killed, true);
+  assert.equal(fragileInterceptor.hp, 0);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// triggerOnMove — overwatch_shot
+// ─────────────────────────────────────────────────────────────────
+
+test('triggerOnMove fires overwatch when enemy moves INTO range', () => {
+  const overwatcher = makeUnit({
+    id: 'ranger',
+    controlled_by: 'player',
+    position: { x: 5, y: 5 },
+    attack_range: 2,
+    reactions: [{ trigger: 'enemy_moves_in_range', ability_id: 'overwatch_shot' }],
+  });
+  const mover = makeUnit({
+    id: 'enemy',
+    controlled_by: 'sistema',
+    position: { x: 6, y: 5 }, // distance 1 (in range)
+    hp: 8,
+  });
+  const fromPos = { x: 9, y: 5 }; // distance 4 (out of range before)
+  const session = makeSession([overwatcher, mover]);
+
+  const performAttack = (atk, mov) => ({
+    result: { hit: true, mos: 3, die: 14, roll: 14 },
+    damageDealt: 3,
+  });
+
+  const res = reactionEngine.triggerOnMove(session, mover, fromPos, performAttack);
+  assert.ok(res);
+  assert.equal(res.overwatch_id, 'ranger');
+  assert.equal(res.hit, true);
+  assert.equal(overwatcher.reactions.length, 0, 'reaction consumed');
+});
+
+test('triggerOnMove skips when mover already was in range (no INTO)', () => {
+  const overwatcher = makeUnit({
+    id: 'ranger',
+    position: { x: 5, y: 5 },
+    attack_range: 2,
+    reactions: [{ trigger: 'enemy_moves_in_range' }],
+  });
+  const mover = makeUnit({
+    id: 'enemy',
+    controlled_by: 'sistema',
+    position: { x: 6, y: 5 },
+  });
+  const fromPos = { x: 4, y: 5 }; // already distance 1 → still in range
+  const session = makeSession([overwatcher, mover]);
+  const performAttack = () => ({ result: { hit: true }, damageDealt: 3 });
+  const res = reactionEngine.triggerOnMove(session, mover, fromPos, performAttack);
+  assert.equal(res, null);
+  assert.equal(overwatcher.reactions.length, 1, 'reaction NOT consumed');
+});
+
+test('triggerOnMove damage_step_mod=-1 refunds damage from mover', () => {
+  const overwatcher = makeUnit({
+    id: 'ranger',
+    position: { x: 5, y: 5 },
+    attack_range: 2,
+    reactions: [
+      { trigger: 'enemy_moves_in_range', ability_id: 'overwatch_shot', damage_step_mod: -1 },
+    ],
+  });
+  const mover = makeUnit({
+    id: 'enemy',
+    controlled_by: 'sistema',
+    position: { x: 6, y: 5 },
+    hp: 8,
+    max_hp: 10,
+  });
+  const fromPos = { x: 9, y: 5 };
+  const session = makeSession([overwatcher, mover]);
+
+  // performAttack pre-applies damage to mover (3 dmg → hp 5)
+  mover.hp = 5;
+  const performAttack = () => ({ result: { hit: true, mos: 3 }, damageDealt: 3 });
+  const res = reactionEngine.triggerOnMove(session, mover, fromPos, performAttack);
+  assert.ok(res);
+  assert.equal(res.damage_dealt, 2, 'damage reduced by mod');
+  assert.equal(mover.hp, 6, 'refund 1 hp applied');
+});
+
+test('triggerOnMove skips when no fromPos / KO mover / null inputs', () => {
+  const session = makeSession([]);
+  const mover = makeUnit({ id: 'm' });
+  assert.equal(
+    reactionEngine.triggerOnMove(session, mover, null, () => ({})),
+    null,
+  );
+  assert.equal(
+    reactionEngine.triggerOnMove(null, mover, { x: 0, y: 0 }, () => ({})),
+    null,
+  );
+  const koMover = makeUnit({ id: 'm', hp: 0 });
+  assert.equal(
+    reactionEngine.triggerOnMove(session, koMover, { x: 5, y: 5 }, () => ({})),
+    null,
+  );
+});
+
+test('triggerOnMove respects single-actor reaction cap (consumed not refireable)', () => {
+  const overwatcher = makeUnit({
+    id: 'ranger',
+    position: { x: 5, y: 5 },
+    attack_range: 2,
+    reactions: [{ trigger: 'enemy_moves_in_range', ability_id: 'overwatch_shot' }],
+  });
+  const mover = makeUnit({
+    id: 'enemy',
+    controlled_by: 'sistema',
+    position: { x: 6, y: 5 },
+    hp: 10,
+  });
+  const session = makeSession([overwatcher, mover]);
+  const performAttack = () => ({ result: { hit: true, mos: 2 }, damageDealt: 2 });
+
+  const res1 = reactionEngine.triggerOnMove(session, mover, { x: 9, y: 5 }, performAttack);
+  assert.ok(res1, 'first move fires');
+
+  // Second move (mover steps out then in again) — reaction already consumed
+  mover.position = { x: 9, y: 5 };
+  const res2 = reactionEngine.triggerOnMove(session, mover, { x: 9, y: 5 }, performAttack);
+  // mover.position == fromPos so distNow==4, but distBefore==4 → not INTO. Use real movement:
+  mover.position = { x: 6, y: 5 };
+  const res3 = reactionEngine.triggerOnMove(session, mover, { x: 9, y: 5 }, performAttack);
+  assert.equal(res3, null, 'reaction not refired (cap 1/actor)');
+});

--- a/tests/services/rewardEconomy.test.js
+++ b/tests/services/rewardEconomy.test.js
@@ -1,0 +1,190 @@
+// Unit test for rewardEconomy — coverage gap closed (archeologist excavate 2026-04-25).
+//
+// Scope: computeSessionPE (per-actor PE w/ VC + Ennea bonus), convertPE (5:1
+// PE→PI), buildDebriefSummary (debrief payload shape). Pure logic, no IO.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  PE_BASE_BY_DIFFICULTY,
+  PE_PER_PI,
+  computeSessionPE,
+  convertPE,
+  buildDebriefSummary,
+} = require('../../apps/backend/services/rewardEconomy');
+
+// ─────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────
+
+function makeVcSnapshot(perActor = {}, turns = 5) {
+  return { turns_played: turns, per_actor: perActor };
+}
+
+function makeActorVc({ indices = {}, mbti = null, ennea = [] } = {}) {
+  return {
+    aggregate_indices: indices,
+    mbti_type: mbti,
+    ennea_archetypes: ennea,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────
+// computeSessionPE — base + bonus tiers
+// ─────────────────────────────────────────────────────────────────
+
+test('computeSessionPE applies tutorial base (3) when difficulty=tutorial', () => {
+  const snap = makeVcSnapshot({
+    u1: makeActorVc({ indices: { agg: 0.0 } }),
+  });
+  const res = computeSessionPE(snap, { difficulty: 'tutorial' });
+  assert.equal(res.per_actor.u1.pe_base, 3);
+  assert.equal(res.per_actor.u1.pe_total, 3, 'no bonus at avg=0');
+  assert.equal(res.session_total, 3);
+});
+
+test('computeSessionPE defaults to standard base (5) when difficulty unknown', () => {
+  const snap = makeVcSnapshot({ u1: makeActorVc({ indices: { x: 0.0 } }) });
+  const res = computeSessionPE(snap, { difficulty: 'unknown_xyz' });
+  assert.equal(res.per_actor.u1.pe_base, 5);
+});
+
+test('computeSessionPE applies eccellente bonus (+3) when avg >= 0.7', () => {
+  const snap = makeVcSnapshot({
+    hero: makeActorVc({ indices: { dom: 0.8, sup: 0.7 } }), // avg 0.75
+  });
+  const res = computeSessionPE(snap, { difficulty: 'standard' });
+  assert.equal(res.per_actor.hero.pe_vc_bonus, 3);
+  assert.equal(res.per_actor.hero.bonus_reason, 'eccellente');
+  assert.equal(res.per_actor.hero.pe_total, 5 + 3);
+});
+
+test('computeSessionPE applies tier thresholds in order (buono / sufficiente / nessuno)', () => {
+  const snap = makeVcSnapshot({
+    a: makeActorVc({ indices: { v: 0.55 } }), // buono +2
+    b: makeActorVc({ indices: { v: 0.35 } }), // sufficiente +1
+    c: makeActorVc({ indices: { v: 0.1 } }), // nessuno
+  });
+  const res = computeSessionPE(snap, { difficulty: 'standard' });
+  assert.equal(res.per_actor.a.pe_vc_bonus, 2);
+  assert.equal(res.per_actor.a.bonus_reason, 'buono');
+  assert.equal(res.per_actor.b.pe_vc_bonus, 1);
+  assert.equal(res.per_actor.c.pe_vc_bonus, 0);
+  assert.equal(res.per_actor.c.bonus_reason, 'nessun bonus');
+});
+
+test('computeSessionPE adds ennea bonus capped at 2', () => {
+  const snap = makeVcSnapshot({
+    multiArc: makeActorVc({ indices: { v: 0.0 }, ennea: ['t1', 't2', 't3', 't4'] }),
+    oneArc: makeActorVc({ indices: { v: 0.0 }, ennea: ['t1'] }),
+    none: makeActorVc({ indices: { v: 0.0 }, ennea: [] }),
+  });
+  const res = computeSessionPE(snap, { difficulty: 'standard' });
+  assert.equal(res.per_actor.multiArc.pe_ennea_bonus, 2, 'capped at 2');
+  assert.equal(res.per_actor.oneArc.pe_ennea_bonus, 1);
+  assert.equal(res.per_actor.none.pe_ennea_bonus, 0);
+});
+
+test('computeSessionPE handles boss difficulty + multi-actor session_total', () => {
+  const snap = makeVcSnapshot({
+    a: makeActorVc({ indices: { v: 0.8 }, ennea: ['x'] }), // 12 + 3 + 1 = 16
+    b: makeActorVc({ indices: { v: 0.4 } }), // 12 + 1 = 13
+  });
+  const res = computeSessionPE(snap, { difficulty: 'boss' });
+  assert.equal(res.per_actor.a.pe_base, 12);
+  assert.equal(res.per_actor.a.pe_total, 16);
+  assert.equal(res.per_actor.b.pe_total, 13);
+  assert.equal(res.session_total, 29);
+});
+
+test('computeSessionPE empty per_actor → session_total=0', () => {
+  const snap = makeVcSnapshot({});
+  const res = computeSessionPE(snap, { difficulty: 'standard' });
+  assert.deepEqual(res.per_actor, {});
+  assert.equal(res.session_total, 0);
+});
+
+test('computeSessionPE filters non-numeric / null index values when computing avg', () => {
+  const snap = makeVcSnapshot({
+    u1: makeActorVc({
+      indices: { real: 0.8, missing: null, str: 'noise', undef: undefined },
+    }),
+  });
+  const res = computeSessionPE(snap, { difficulty: 'standard' });
+  assert.equal(res.per_actor.u1.vc_performance, 0.8, 'avg only on numeric');
+  assert.equal(res.per_actor.u1.pe_vc_bonus, 3);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// convertPE — 5:1 ratio
+// ─────────────────────────────────────────────────────────────────
+
+test('convertPE 5:1 — exact + remainder + zero', () => {
+  assert.deepEqual(convertPE(15), { pi_gained: 3, pe_remaining: 0 });
+  assert.deepEqual(convertPE(13), { pi_gained: 2, pe_remaining: 3 });
+  assert.deepEqual(convertPE(0), { pi_gained: 0, pe_remaining: 0 });
+  assert.deepEqual(convertPE(4), { pi_gained: 0, pe_remaining: 4 });
+});
+
+// ─────────────────────────────────────────────────────────────────
+// buildDebriefSummary — payload shape
+// ─────────────────────────────────────────────────────────────────
+
+test('buildDebriefSummary returns expected canonical shape', () => {
+  const session = {
+    session_id: 'sess_1',
+    events: [{ a: 1 }, { a: 2 }],
+    damage_taken: { u1: 0, u2: 5, u3: -3 },
+  };
+  const vcSnapshot = makeVcSnapshot(
+    {
+      u1: makeActorVc({
+        indices: { v: 0.8 },
+        mbti: 'ENTJ',
+        ennea: ['t8'],
+      }),
+    },
+    7,
+  );
+  const peResult = computeSessionPE(vcSnapshot, { difficulty: 'standard' });
+  const debrief = buildDebriefSummary(session, vcSnapshot, peResult);
+
+  assert.equal(debrief.session_id, 'sess_1');
+  assert.equal(debrief.turns_played, 7);
+  assert.ok(debrief.economy);
+  assert.equal(debrief.economy.pe_session_total, peResult.session_total);
+  // 5+3+1=9 → 1 PI + 4 remainder
+  assert.equal(debrief.economy.pi_converted, 1);
+  assert.equal(debrief.economy.pe_remaining, 4);
+  assert.equal(debrief.economy.seed_earned, 0, 'seed wired in D2 (placeholder 0)');
+  assert.equal(debrief.combat.total_events, 2);
+  // damage_taken values <= 0 count as kill: u1=0 + u3=-3 → 2
+  assert.equal(debrief.combat.kills, 2);
+  assert.deepEqual(debrief.vc_summary.per_actor.u1, {
+    aggregate_indices: { v: 0.8 },
+    mbti_type: 'ENTJ',
+    ennea_archetypes: ['t8'],
+  });
+});
+
+test('buildDebriefSummary tolerates missing events / damage_taken / pf_session', () => {
+  const session = { session_id: 'sess_2' };
+  const snap = makeVcSnapshot({}, 0);
+  const pe = computeSessionPE(snap, {});
+  const debrief = buildDebriefSummary(session, snap, pe);
+  assert.equal(debrief.combat.total_events, 0);
+  assert.equal(debrief.combat.kills, 0);
+  assert.deepEqual(debrief.pf_session, {});
+  assert.equal(debrief.economy.pe_session_total, 0);
+});
+
+test('exports surface canonical constants', () => {
+  assert.equal(PE_PER_PI, 5);
+  assert.equal(PE_BASE_BY_DIFFICULTY.tutorial, 3);
+  assert.equal(PE_BASE_BY_DIFFICULTY.standard, 5);
+  assert.equal(PE_BASE_BY_DIFFICULTY.elite, 8);
+  assert.equal(PE_BASE_BY_DIFFICULTY.boss, 12);
+});


### PR DESCRIPTION
Excavated by repo-archaeologist 2026-04-25 sera. 2 services live in runtime hot path con zero direct coverage.

## Coverage closed

| Service | Tests NEW | LOC | Hot path |
|---|:-:|---|---|
| reactionEngine.js | 13 | +224 | session.js:77 intercept + overwatch |
| rewardEconomy.js | 12 | +167 | session.js:1900 debrief |

## Test plan

- [x] tests/services/reactionEngine.test.js → 13/13 NEW
- [x] tests/services/rewardEconomy.test.js → 12/12 NEW
- [x] tests/ai/*.test.js → 311/311 baseline
- [x] tests/services/*.test.js → **461/461** (+25 NEW)
- [x] prettier check → clean

## Edge cases (highlights)

**reactionEngine**: intercept HP transfer + cap, KO/cross-team filter, INTO-range gate (overwatch), reaction cap 1/actor consumed.
**rewardEconomy**: 4 difficulty bases, 4 VC bonus tiers, Ennea +2 cap, convertPE 5:1, buildDebriefSummary shape full.

Pure additive — zero production code changes.

🤖 Claude Code