### PR TITLE
fix(skiv-monitor): add pull-requests:write + use --force

### DIFF
--- a/.github/workflows/skiv-monitor.yml
+++ b/.github/workflows/skiv-monitor.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -59,7 +60,10 @@ jobs:
           git checkout -B "$BRANCH"
           git add data/derived/skiv_monitor/ docs/skiv/MONITOR.md
           git commit -m "chore(skiv-monitor): aggiorna stato + feed creatura"
-          git push --force-with-lease origin "$BRANCH"
+          # Fetch first so force-with-lease lease isn't stale (workflow checkout
+          # not aware of remote branch updates from previous run).
+          git fetch origin "$BRANCH" 2>/dev/null || true
+          git push --force origin "$BRANCH"
           # Open or refresh PR (idempotent — gh pr create fails harmlessly if exists).
           if gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' | grep -q .; then
             echo "[skiv-monitor] PR already open for $BRANCH"


### PR DESCRIPTION
## Summary

Due fix runtime in workflow Skiv Monitor (entrambi confermati live in run `24941222903` + `24941255197`):

1. **`GraphQL: Resource not accessible by integration`** quando workflow chiama `gh pr create`
   - Default `GITHUB_TOKEN` con `contents: write` non basta
   - Add `pull-requests: write` alla sezione permissions

2. **`--force-with-lease: stale info`** push rejected su branch auto-aggiornato
   - Workflow checkout non vede remote updates → lease cached errato
   - Pre-fetch branch + downgrade a `--force` (branch workflow-owned, no human commits)

## Post-merge

Cron 4h gira fully automatic:
- Skiv reads GitHub events (PR/issue/workflow)
- Updates state.json + feed.jsonl + MONITOR.md
- Force-pushes `auto/skiv-monitor-update` branch
- Auto-opens or refreshes PR (idempotent)

Master DD merge il PR auto consolida in main → Skiv vivo cross-PC.

## Test plan

- [x] CI green
- [ ] Post-merge: trigger workflow_dispatch → verify auto PR opens senza errori
- [ ] Cron tick: 4h cadence successivo update PR esistente (no duplicates)

🦎 _Sabbia segue._