### PR TITLE
feat(spawn): role_templates wire → biomeSpawnBias ecological boost (QW3 M-013)

### DIFF
--- a/apps/backend/services/combat/biomePoolLoader.js
+++ b/apps/backend/services/combat/biomePoolLoader.js
@@ -1,0 +1,88 @@
+// Biome pool loader — QW3 (M-013 worldgen).
+//
+// Memoized loader per `data/core/traits/biome_pools.json`. Evita re-parse
+// del JSON (489 righe) per ogni spawn. Caricamento lazy on first call.
+//
+// API:
+//   getPoolById(biomeId, opts?)            → pool entry or null
+//   getRoleTemplates(biomeId, opts?)       → role_templates array or []
+//   loadAllPools(opts?)                    → cached pools array
+//   resetCache()                           → clear memoization (test only)
+//
+// Encoding: UTF-8 esplicito (CLAUDE.md encoding discipline).
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_POOLS_PATH = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  'data',
+  'core',
+  'traits',
+  'biome_pools.json',
+);
+
+let _cache = null;
+let _cachePath = null;
+
+/**
+ * Load + cache biome pools JSON. Subsequent calls return memoized data.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.poolsPath] override (test only)
+ * @returns {Array} pools array (empty on failure)
+ */
+function loadAllPools(opts = {}) {
+  const poolsPath = opts.poolsPath || DEFAULT_POOLS_PATH;
+  if (_cache && _cachePath === poolsPath) return _cache;
+  try {
+    const raw = fs.readFileSync(poolsPath, { encoding: 'utf8' });
+    const data = JSON.parse(raw);
+    _cache = Array.isArray(data?.pools) ? data.pools : [];
+    _cachePath = poolsPath;
+  } catch {
+    _cache = [];
+    _cachePath = poolsPath;
+  }
+  return _cache;
+}
+
+/**
+ * Get full pool entry by id. Returns null if not found.
+ */
+function getPoolById(biomeId, opts = {}) {
+  if (!biomeId) return null;
+  const pools = loadAllPools(opts);
+  return pools.find((p) => p && p.id === biomeId) || null;
+}
+
+/**
+ * Get role_templates array for a biome. Returns [] if pool/templates missing.
+ */
+function getRoleTemplates(biomeId, opts = {}) {
+  const pool = getPoolById(biomeId, opts);
+  if (!pool || !Array.isArray(pool.role_templates)) return [];
+  return pool.role_templates;
+}
+
+/**
+ * Reset memoization. Test-only.
+ */
+function resetCache() {
+  _cache = null;
+  _cachePath = null;
+}
+
+module.exports = {
+  loadAllPools,
+  getPoolById,
+  getRoleTemplates,
+  resetCache,
+  DEFAULT_POOLS_PATH,
+};

--- a/apps/backend/services/combat/biomeSpawnBias.js
+++ b/apps/backend/services/combat/biomeSpawnBias.js
@@ -1,22 +1,31 @@
-// V7 Biome-aware spawn bias (ADR-2026-04-26).
+// V7 Biome-aware spawn bias (ADR-2026-04-26) + QW3 role_templates (M-013).
 //
 // Pure module. Augments reinforcement/director spawn pool weight based on
-// biome affixes matching unit tags. Closes vision gap in
+// biome affixes matching unit tags + ecological role_templates from
+// data/core/traits/biome_pools.json. Closes vision gap in
 // docs/core/28-NPC_BIOMI_SPAWN.md ("biomi guidano spawn").
 //
 // API:
 //   applyBiomeBias(pool, biomeConfig, opts?)
-//     → pool with weight boosted per affix matching unit.tags/archetype
+//     → pool with weight boosted per affix + role_template match
 //   matchAffix(unit, affix) → boolean
 //   biomeMatchScore(unit, biomeConfig) → 0..1
+//   matchRoleTemplate(unit, roleTemplates) → { matched, role, tier, primary }
 //
-// Backward compatible: if pool entry has no tags/archetype or biome has
-// no affixes, returns pool unchanged.
+// Backward compatible: if pool entry has no tags/archetype/role and biome
+// has no affixes/biome_id, returns pool unchanged.
 
 'use strict';
 
 const DEFAULT_BOOST_PER_MATCH = 1.5;
 const MAX_BOOST = 3.0;
+// QW3: total cap (affix + role_template combined). Pattern V7 "no dominance".
+const MAX_BOOST_TOTAL = 4.0;
+// QW3: role boost factors. Primary ecological roles get bigger boost than support.
+const ROLE_BOOST_PRIMARY = 2.0; // apex, keystone
+const ROLE_BOOST_SUPPORT = 1.5; // bridge, threat, event
+const PRIMARY_ROLES = new Set(['apex', 'keystone']);
+const SUPPORT_ROLES = new Set(['bridge', 'threat', 'event']);
 
 // Affix → unit tag affinities (canonical vocabulary match).
 // Keys = biome affix, Values = unit tags that biome favors.
@@ -62,24 +71,140 @@ function biomeMatchScore(unit, biomeConfig) {
 }
 
 /**
+ * Estrai i role tag da un'entry di pool. Supporta sia stringa singola
+ * `role: 'apex'` (tipico pool di rinforzo) sia array `role_tags: ['apex','predator']`
+ * (species_expansion.yaml).
+ *
+ * @returns {string[]} normalized lower-case roles
+ */
+function extractEntryRoles(entry) {
+  if (!entry) return [];
+  const out = [];
+  if (typeof entry.role === 'string') out.push(entry.role.toLowerCase());
+  if (Array.isArray(entry.role_tags)) {
+    for (const t of entry.role_tags) if (t) out.push(String(t).toLowerCase());
+  }
+  return out;
+}
+
+/**
+ * Match unit/pool entry against role_templates from biome pool.
+ * Match strategy:
+ *   1. Direct role tag match (entry.role / role_tags ↔ template.role)
+ *   2. Trait overlap (entry.tags / preferred_traits ↔ template.preferred_traits)
+ *   3. Functional tag overlap (entry.functional_tags ↔ template.functional_tags)
+ *
+ * Returns the *best* match (highest tier when multiple match) for one entry.
+ *
+ * @param {object} entry pool entry
+ * @param {Array} roleTemplates from biome_pools.json
+ * @returns {{matched:boolean, role?:string, tier?:number, primary?:boolean, via?:string}}
+ */
+function matchRoleTemplate(entry, roleTemplates) {
+  if (!entry || !Array.isArray(roleTemplates) || roleTemplates.length === 0) {
+    return { matched: false };
+  }
+  const entryRoles = extractEntryRoles(entry);
+  const entryTags = (entry.tags || entry.archetype_tags || entry.preferred_traits || []).map((t) =>
+    String(t).toLowerCase(),
+  );
+  const entryFunctional = (entry.functional_tags || []).map((t) => String(t).toLowerCase());
+
+  let best = null;
+  for (const tmpl of roleTemplates) {
+    if (!tmpl || !tmpl.role) continue;
+    const role = String(tmpl.role).toLowerCase();
+    const tier = Number(tmpl.tier) || 0;
+    let via = null;
+
+    if (entryRoles.includes(role)) {
+      via = 'role';
+    } else if (Array.isArray(tmpl.preferred_traits)) {
+      const preferred = tmpl.preferred_traits.map((t) => String(t).toLowerCase());
+      if (preferred.some((p) => entryTags.includes(p))) via = 'preferred_traits';
+    }
+    if (!via && Array.isArray(tmpl.functional_tags) && entryFunctional.length > 0) {
+      const functional = tmpl.functional_tags.map((t) => String(t).toLowerCase());
+      if (functional.some((f) => entryFunctional.includes(f))) via = 'functional_tags';
+    }
+    if (!via) continue;
+
+    const candidate = {
+      matched: true,
+      role,
+      tier,
+      primary: PRIMARY_ROLES.has(role),
+      via,
+    };
+    if (!best || tier > (best.tier || 0)) best = candidate;
+  }
+  return best || { matched: false };
+}
+
+/**
+ * Compute role-template boost multiplier for an entry.
+ *
+ * @returns {{boost:number, match:object}} boost ∈ [1, ROLE_BOOST_PRIMARY]
+ */
+function roleTemplateBoost(entry, roleTemplates) {
+  const match = matchRoleTemplate(entry, roleTemplates);
+  if (!match.matched) return { boost: 1.0, match };
+  if (PRIMARY_ROLES.has(match.role)) return { boost: ROLE_BOOST_PRIMARY, match };
+  if (SUPPORT_ROLES.has(match.role)) return { boost: ROLE_BOOST_SUPPORT, match };
+  return { boost: 1.0, match };
+}
+
+/**
  * Apply biome bias to spawn pool. Pure (returns new array).
  *
- * @param {Array<{unit_id, weight?, tags?}>} pool
- * @param {{ affixes?, npc_archetypes? }} biomeConfig
+ * Layers (multiplicative, capped at MAX_BOOST_TOTAL):
+ *   1. Archetype match (primary → MAX_BOOST, support → ~mid)
+ *   2. Affix tag match (multiplicative per affix, capped at MAX_BOOST)
+ *   3. QW3 Role template match (apex/keystone → ×2, bridge/threat/event → ×1.5)
+ *
+ * @param {Array<{unit_id, weight?, tags?, role?, role_tags?}>} pool
+ * @param {{ affixes?, npc_archetypes?, biome_id?, role_templates? }} biomeConfig
  * @param {object} [opts]
  * @param {number} [opts.boostPerMatch=1.5]
  * @param {number} [opts.maxBoost=3.0]
- * @returns {Array} new pool with adjusted weights
+ * @param {number} [opts.maxBoostTotal=4.0]
+ * @param {Array}  [opts.roleTemplates] explicit override (skip loader)
+ * @param {object} [opts.poolLoader] override (test only) — must expose getRoleTemplates
+ * @returns {Array} new pool with adjusted weights + _biome_bias debug
  */
 function applyBiomeBias(pool, biomeConfig, opts = {}) {
   if (!Array.isArray(pool) || pool.length === 0) return pool;
-  if (!biomeConfig || !Array.isArray(biomeConfig.affixes)) return pool;
+  if (!biomeConfig) return pool;
+  const hasAffixes = Array.isArray(biomeConfig.affixes);
   const boostPerMatch = opts.boostPerMatch ?? DEFAULT_BOOST_PER_MATCH;
   const maxBoost = opts.maxBoost ?? MAX_BOOST;
+  const maxBoostTotal = opts.maxBoostTotal ?? MAX_BOOST_TOTAL;
 
   // Primary archetype preferences: full max boost
   const primaryArchetypes = new Set(biomeConfig.npc_archetypes?.primary || []);
   const supportArchetypes = new Set(biomeConfig.npc_archetypes?.support || []);
+
+  // QW3: resolve role_templates. Priority:
+  //   1. opts.roleTemplates (explicit override, test)
+  //   2. biomeConfig.role_templates (inline)
+  //   3. loader by biomeConfig.biome_id (memoized JSON load)
+  let roleTemplates = [];
+  if (Array.isArray(opts.roleTemplates)) {
+    roleTemplates = opts.roleTemplates;
+  } else if (Array.isArray(biomeConfig.role_templates)) {
+    roleTemplates = biomeConfig.role_templates;
+  } else if (biomeConfig.biome_id) {
+    try {
+      const loader = opts.poolLoader || require('./biomePoolLoader');
+      roleTemplates = loader.getRoleTemplates(biomeConfig.biome_id) || [];
+    } catch {
+      roleTemplates = [];
+    }
+  }
+  const hasRoleTemplates = roleTemplates.length > 0;
+
+  // If no signal at all → fully unchanged (backward compat with V7 baseline).
+  if (!hasAffixes && !hasRoleTemplates) return pool;
 
   return pool.map((entry) => {
     const baseWeight = Number(entry.weight) || 1;
@@ -93,17 +218,35 @@ function applyBiomeBias(pool, biomeConfig, opts = {}) {
 
     // Affix tag match: multiplicative (per match)
     let affixMatches = 0;
-    for (const affix of biomeConfig.affixes) {
-      if (matchAffix(entry, affix)) affixMatches += 1;
+    if (hasAffixes) {
+      for (const affix of biomeConfig.affixes) {
+        if (matchAffix(entry, affix)) affixMatches += 1;
+      }
+      if (affixMatches > 0) {
+        boost *= Math.min(maxBoost, 1 + boostPerMatch * affixMatches);
+      }
     }
-    if (affixMatches > 0) {
-      boost *= Math.min(maxBoost, 1 + boostPerMatch * affixMatches);
+
+    // QW3: role_template match — additive layer above affix+archetype
+    let roleMatch = { matched: false };
+    if (hasRoleTemplates) {
+      const result = roleTemplateBoost(entry, roleTemplates);
+      roleMatch = result.match;
+      if (result.boost > 1) boost *= result.boost;
     }
+
+    // Final cap (no dominance absoluta).
+    if (boost > maxBoostTotal) boost = maxBoostTotal;
 
     return {
       ...entry,
       weight: baseWeight * boost,
-      _biome_bias: { boost, affix_matches: affixMatches, base_weight: baseWeight },
+      _biome_bias: {
+        boost,
+        affix_matches: affixMatches,
+        role_template_match: roleMatch,
+        base_weight: baseWeight,
+      },
     };
   });
 }
@@ -112,7 +255,15 @@ module.exports = {
   applyBiomeBias,
   matchAffix,
   biomeMatchScore,
+  matchRoleTemplate,
+  roleTemplateBoost,
+  extractEntryRoles,
   AFFIX_TAG_AFFINITIES,
   DEFAULT_BOOST_PER_MATCH,
   MAX_BOOST,
+  MAX_BOOST_TOTAL,
+  ROLE_BOOST_PRIMARY,
+  ROLE_BOOST_SUPPORT,
+  PRIMARY_ROLES,
+  SUPPORT_ROLES,
 };

--- a/tests/api/roleTemplateBias.test.js
+++ b/tests/api/roleTemplateBias.test.js
@@ -1,0 +1,316 @@
+// QW3 Role-template biome spawn bias tests (M-013 worldgen).
+//
+// Tests the additive layer on top of V7 affix bias:
+// role_templates from data/core/traits/biome_pools.json drive
+// ecological-role weight boost. Backward compatible.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const {
+  applyBiomeBias,
+  matchRoleTemplate,
+  roleTemplateBoost,
+  extractEntryRoles,
+  MAX_BOOST_TOTAL,
+  ROLE_BOOST_PRIMARY,
+  ROLE_BOOST_SUPPORT,
+} = require('../../apps/backend/services/combat/biomeSpawnBias');
+
+const poolLoader = require('../../apps/backend/services/combat/biomePoolLoader');
+
+// Sample fixture mirroring data/core/traits/biome_pools.json schema.
+const SAMPLE_TEMPLATES = [
+  {
+    role: 'apex',
+    label: 'Predatore Risonante',
+    functional_tags: ['criogenico', 'imboscata'],
+    preferred_traits: ['criostasi_adattiva', 'ghiaccio_piezoelettrico'],
+    tier: 4,
+  },
+  {
+    role: 'keystone',
+    label: 'Scultore di Cristalli',
+    functional_tags: ['supporto', 'costruttore'],
+    preferred_traits: ['capillari_criogenici', 'antenne_wideband'],
+    tier: 3,
+  },
+  {
+    role: 'bridge',
+    label: 'Colportore Luminescente',
+    functional_tags: ['logistica', 'mobilita'],
+    preferred_traits: ['foliage_fotocatodico'],
+    tier: 2,
+  },
+  {
+    role: 'threat',
+    label: 'Fiera del Whiteout',
+    functional_tags: ['assalto', 'area_control'],
+    preferred_traits: ['ghiandole_nebbia_ionica', 'criostasi_adattiva'],
+    tier: 3,
+  },
+  {
+    role: 'event',
+    label: 'Cascata di Schegge',
+    functional_tags: ['evento', 'stagionale'],
+    preferred_traits: ['gusci_criovetro'],
+    tier: 2,
+  },
+];
+
+test('extractEntryRoles: handles role string', () => {
+  assert.deepEqual(extractEntryRoles({ role: 'Apex' }), ['apex']);
+});
+
+test('extractEntryRoles: handles role_tags array', () => {
+  assert.deepEqual(extractEntryRoles({ role_tags: ['Apex', 'Predator'] }), ['apex', 'predator']);
+});
+
+test('extractEntryRoles: handles both fields', () => {
+  const out = extractEntryRoles({ role: 'keystone', role_tags: ['support'] });
+  assert.deepEqual(out, ['keystone', 'support']);
+});
+
+test('extractEntryRoles: empty entry returns []', () => {
+  assert.deepEqual(extractEntryRoles({}), []);
+  assert.deepEqual(extractEntryRoles(null), []);
+});
+
+test('matchRoleTemplate: direct role match wins highest tier', () => {
+  const entry = { role_tags: ['apex', 'keystone'] };
+  const m = matchRoleTemplate(entry, SAMPLE_TEMPLATES);
+  assert.equal(m.matched, true);
+  assert.equal(m.role, 'apex');
+  assert.equal(m.tier, 4);
+  assert.equal(m.primary, true);
+  assert.equal(m.via, 'role');
+});
+
+test('matchRoleTemplate: preferred_traits overlap', () => {
+  const entry = { tags: ['ghiaccio_piezoelettrico'] };
+  const m = matchRoleTemplate(entry, SAMPLE_TEMPLATES);
+  assert.equal(m.matched, true);
+  assert.equal(m.role, 'apex');
+  assert.equal(m.via, 'preferred_traits');
+});
+
+test('matchRoleTemplate: functional_tags overlap', () => {
+  const entry = { functional_tags: ['logistica'] };
+  const m = matchRoleTemplate(entry, SAMPLE_TEMPLATES);
+  assert.equal(m.matched, true);
+  assert.equal(m.role, 'bridge');
+  assert.equal(m.via, 'functional_tags');
+});
+
+test('matchRoleTemplate: no overlap returns matched=false', () => {
+  const entry = { tags: ['unrelated_xyz'] };
+  const m = matchRoleTemplate(entry, SAMPLE_TEMPLATES);
+  assert.equal(m.matched, false);
+});
+
+test('matchRoleTemplate: empty templates returns matched=false', () => {
+  assert.equal(matchRoleTemplate({ role: 'apex' }, []).matched, false);
+  assert.equal(matchRoleTemplate({ role: 'apex' }, null).matched, false);
+});
+
+test('roleTemplateBoost: primary roles → 2.0 boost', () => {
+  const r = roleTemplateBoost({ role: 'apex' }, SAMPLE_TEMPLATES);
+  assert.equal(r.boost, ROLE_BOOST_PRIMARY);
+});
+
+test('roleTemplateBoost: support roles → 1.5 boost', () => {
+  const r = roleTemplateBoost({ role: 'bridge' }, SAMPLE_TEMPLATES);
+  assert.equal(r.boost, ROLE_BOOST_SUPPORT);
+});
+
+test('roleTemplateBoost: no match → 1.0', () => {
+  const r = roleTemplateBoost({ tags: ['xyz'] }, SAMPLE_TEMPLATES);
+  assert.equal(r.boost, 1.0);
+  assert.equal(r.match.matched, false);
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// applyBiomeBias integration: role_templates additive layer
+// ────────────────────────────────────────────────────────────────────────
+
+test('applyBiomeBias: apex role → 2.0 boost (no affixes)', () => {
+  const pool = [{ unit_id: 'predator_a', role_tags: ['apex'], weight: 1 }];
+  const result = applyBiomeBias(pool, { role_templates: SAMPLE_TEMPLATES });
+  assert.equal(result[0].weight, ROLE_BOOST_PRIMARY);
+  assert.equal(result[0]._biome_bias.role_template_match.matched, true);
+  assert.equal(result[0]._biome_bias.role_template_match.role, 'apex');
+});
+
+test('applyBiomeBias: bridge role → 1.5 boost (no affixes)', () => {
+  const pool = [{ unit_id: 'courier', role_tags: ['bridge'], weight: 1 }];
+  const result = applyBiomeBias(pool, { role_templates: SAMPLE_TEMPLATES });
+  assert.equal(result[0].weight, ROLE_BOOST_SUPPORT);
+});
+
+test('applyBiomeBias: pool senza role_templates → fallback V7 affix-only', () => {
+  // No biome_id, no role_templates inline → only affix layer applies (V7 baseline).
+  const pool = [{ unit_id: 'u1', tags: ['fire'], weight: 1 }];
+  const biome = { affixes: ['termico'] }; // V7 only
+  const result = applyBiomeBias(pool, biome);
+  assert.ok(result[0].weight > 1, 'V7 affix boost still works');
+  assert.equal(result[0]._biome_bias.affix_matches, 1);
+  // No role match expected
+  assert.equal(result[0]._biome_bias.role_template_match.matched, false);
+});
+
+test('applyBiomeBias: biome senza pool entry → no-op safe', () => {
+  // biome_id non esistente → loader returns []
+  const pool = [{ unit_id: 'u1', tags: ['fire'], weight: 2 }];
+  const biome = { biome_id: 'biome_nonexistente_xyz' };
+  poolLoader.resetCache();
+  const result = applyBiomeBias(pool, biome);
+  // Nessun affix, nessun role template → backward compat, ritorna invariato
+  assert.equal(result[0].weight, 2);
+});
+
+test('applyBiomeBias: biome_id reale → loader risolve role_templates', () => {
+  poolLoader.resetCache();
+  const pool = [
+    // Apex template "Predatore Risonante" preferred_traits include ghiaccio_piezoelettrico.
+    { unit_id: 'criostalker', tags: ['ghiaccio_piezoelettrico'], weight: 1 },
+    { unit_id: 'unrelated', tags: ['unrelated_tag'], weight: 1 },
+  ];
+  const biome = { biome_id: 'cryosteppe_convergence' };
+  const result = applyBiomeBias(pool, biome);
+  assert.ok(
+    result[0].weight > result[1].weight,
+    'role_template match boosted vs unrelated baseline',
+  );
+  assert.equal(result[0]._biome_bias.role_template_match.role, 'apex');
+});
+
+test('applyBiomeBias: multi-role match → boost combinato capped a MAX_BOOST_TOTAL', () => {
+  // Entry hits BOTH apex (via role_tags) AND has affix matches → combined boost capped.
+  const pool = [
+    {
+      unit_id: 'super',
+      role_tags: ['apex'],
+      tags: ['fire', 'thermal', 'spore', 'sand'],
+      weight: 1,
+    },
+  ];
+  const biome = {
+    affixes: ['termico', 'spore_diluite', 'sabbia'], // 3 matches → cap MAX_BOOST=3
+    role_templates: SAMPLE_TEMPLATES, // apex → ×2
+    npc_archetypes: { primary: [] },
+  };
+  const result = applyBiomeBias(pool, biome);
+  // Without cap: 3 (affix) × 2 (role) = 6 → cap to MAX_BOOST_TOTAL=4
+  assert.ok(
+    result[0].weight <= MAX_BOOST_TOTAL,
+    `weight ${result[0].weight} should be ≤ MAX_BOOST_TOTAL=${MAX_BOOST_TOTAL}`,
+  );
+  assert.equal(result[0]._biome_bias.boost, MAX_BOOST_TOTAL);
+});
+
+test('applyBiomeBias: affix + role overlap → no double-count (boost separato cap)', () => {
+  // Entry matches affix (fire) AND role (apex). Multiplicative but capped.
+  const pool = [{ unit_id: 'u', role_tags: ['apex'], tags: ['fire'], weight: 1 }];
+  const biome = {
+    affixes: ['termico'],
+    role_templates: SAMPLE_TEMPLATES,
+  };
+  const result = applyBiomeBias(pool, biome);
+  // 1 affix match → 1 + 1.5*1 = 2.5 (capped at MAX_BOOST=3)
+  // role apex → ×2
+  // Combined: 2.5 * 2 = 5.0 → cap MAX_BOOST_TOTAL=4
+  assert.ok(result[0].weight <= MAX_BOOST_TOTAL);
+  assert.equal(result[0]._biome_bias.role_template_match.matched, true);
+  assert.ok(result[0]._biome_bias.affix_matches >= 1);
+});
+
+test('applyBiomeBias: cap totale rispettato sempre', () => {
+  // Worst case: archetype primary (×3) + affix all match (×3) + role apex (×2) = 18
+  const pool = [
+    {
+      unit_id: 'mega',
+      archetype: 'apex_pred',
+      role_tags: ['apex'],
+      tags: ['fire', 'thermal', 'spore'],
+      weight: 1,
+    },
+  ];
+  const biome = {
+    affixes: ['termico', 'spore_diluite'],
+    role_templates: SAMPLE_TEMPLATES,
+    npc_archetypes: { primary: ['apex_pred'] },
+  };
+  const result = applyBiomeBias(pool, biome);
+  assert.ok(result[0].weight <= MAX_BOOST_TOTAL, `weight ${result[0].weight} ≤ ${MAX_BOOST_TOTAL}`);
+});
+
+test('applyBiomeBias: backward compat — biome con solo affixes (V7 path)', () => {
+  // Esattamente come V7: nessun role_template/biome_id. Test V7 baseline non rotto.
+  const pool = [{ unit_id: 'u1', tags: ['fire'], weight: 1 }];
+  const biome = { affixes: ['termico'] };
+  const result = applyBiomeBias(pool, biome);
+  assert.ok(result[0].weight > 1);
+  assert.equal(result[0]._biome_bias.role_template_match.matched, false);
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Performance: loader memoization (no JSON re-parse per spawn)
+// ────────────────────────────────────────────────────────────────────────
+
+test('biomePoolLoader: memoization — load JSON una volta sola', () => {
+  poolLoader.resetCache();
+  const fs = require('node:fs');
+  const originalRead = fs.readFileSync;
+  let readCount = 0;
+  fs.readFileSync = function patched(...args) {
+    if (typeof args[0] === 'string' && args[0].includes('biome_pools.json')) {
+      readCount += 1;
+    }
+    return originalRead.apply(this, args);
+  };
+  try {
+    poolLoader.loadAllPools();
+    poolLoader.loadAllPools();
+    poolLoader.getPoolById('cryosteppe_convergence');
+    poolLoader.getRoleTemplates('cryosteppe_convergence');
+    assert.equal(readCount, 1, 'readFileSync invoked exactly once across 4 calls');
+  } finally {
+    fs.readFileSync = originalRead;
+    poolLoader.resetCache();
+  }
+});
+
+test('biomePoolLoader: getPoolById ritorna null per id sconosciuto', () => {
+  poolLoader.resetCache();
+  assert.equal(poolLoader.getPoolById('biome_inesistente_xyz'), null);
+  assert.equal(poolLoader.getPoolById(''), null);
+  assert.equal(poolLoader.getPoolById(null), null);
+});
+
+test('biomePoolLoader: getRoleTemplates ritorna [] safe per id mancante', () => {
+  poolLoader.resetCache();
+  const t = poolLoader.getRoleTemplates('biome_inesistente_xyz');
+  assert.deepEqual(t, []);
+});
+
+test('biomePoolLoader: pools shipping hanno role_templates', () => {
+  poolLoader.resetCache();
+  const pools = poolLoader.loadAllPools();
+  assert.ok(pools.length >= 8, 'expected ≥8 pools shipping');
+  for (const pool of pools) {
+    assert.ok(
+      Array.isArray(pool.role_templates) && pool.role_templates.length > 0,
+      `pool ${pool.id} missing role_templates`,
+    );
+  }
+});
+
+test('biomePoolLoader: path failure → cache vuota, no throw', () => {
+  poolLoader.resetCache();
+  const pools = poolLoader.loadAllPools({ poolsPath: '/nonexistent/path/xyz.json' });
+  assert.deepEqual(pools, []);
+  poolLoader.resetCache();
+});


### PR DESCRIPTION
## Summary

QW3 (M-013 worldgen) — estende `biomeSpawnBias.js` (V7 PR #1726) per consumare anche `role_templates` da `data/core/traits/biome_pools.json` (489 righe curate, 8 pool shipping × 4-5 ruoli). Spawn weight ora rispetta ruoli ecologici (apex/keystone/bridge/threat/event) oltre agli affixes.

## Cosa cambia

- **Nuovo modulo** `apps/backend/services/combat/biomePoolLoader.js` — JSON loader memoizzato (no re-parse per ogni spawn). API: `getPoolById`, `getRoleTemplates`, `loadAllPools`, `resetCache`.
- **Esteso** `apps/backend/services/combat/biomeSpawnBias.js`:
  - Nuove funzioni: `matchRoleTemplate`, `roleTemplateBoost`, `extractEntryRoles`
  - Layer additivo sopra V7 affix bias
  - Cap totale `MAX_BOOST_TOTAL=4.0` per evitare dominance assoluta
  - `_biome_bias.role_template_match` esposto in debug per testing
- **Backward compatible**:
  - Biome senza `role_templates`/`biome_id` → path V7 invariato
  - Pool entry senza `role`/`role_tags` → no role boost, solo affix
  - `reinforcementSpawner.js` già passa biomeConfig a `applyBiomeBias` via `pickPoolEntry` (no change required upstream)

## Boost ecological roles

| Role     | Boost  | Tipo     |
| -------- | ------ | -------- |
| apex     | ×2.0   | primary  |
| keystone | ×2.0   | primary  |
| bridge   | ×1.5   | support  |
| threat   | ×1.5   | support  |
| event    | ×1.5   | support  |

Match strategy (in ordine):
1. Direct role tag match (`entry.role` / `role_tags` ↔ `template.role`)
2. `preferred_traits` overlap (`entry.tags` ↔ `template.preferred_traits`)
3. `functional_tags` overlap

Quando entry matcha più template (es. apex e keystone), vince il tier più alto.

## Cap totale

Worst case (archetype primary ×3 + affix all match ×3 + role apex ×2 = 18×) hard-capped a `MAX_BOOST_TOTAL=4.0`. Pattern V7 "no dominance".

## Test plan

- [x] `node --test tests/api/roleTemplateBias.test.js` — **26/26 verde** (matching, boost layers, cap, memoization, fallback V7, loader edge cases)
- [x] `node --test tests/api/biomeSpawnBias.test.js` — **14/14 verde** (V7 baseline preservato)
- [x] `node --test tests/services/reinforcementSpawner.test.js` — **13/13 verde** (no regression upstream)
- [x] `node --test tests/ai/*.test.js` — **311/311 verde** (zero regression AI)
- [x] `npx prettier --check` su file toccati — verde

## Performance

- Loader JSON memoizzato: 1 read per processo (489 righe parse una sola volta)
- Test dedicato `biomePoolLoader: memoization` verifica `readFileSync` invocato esattamente 1x su 4 chiamate sequenziali

## Reference

- Card museum M-013 (worldgen-species-emergence-from-ecosystem) — gallery worldgen, Tier 1 #3 reuse path
- Source-of-truth `data/core/traits/biome_pools.json` (8 pool: cryosteppe_convergence, magnetar_badlands, aerial_canopy, abyssal_hydrothermal, mycelial_vaults, fotofase_synaptic_ridge, crepuscolo_synapse_bloom, frattura_void_choir)
- ADR-2026-04-26 (V7 biome-aware spawn bias originale, PR #1726)

## Blast radius ×1.5

Module backend pure, nessun frontend impact. Wire `reinforcementSpawner` già esistente (V7), no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)