### PR TITLE
feat(render): Skiv lifecycle_phase + aspect_token visible su TV canvas (QW4)

### DIFF
--- a/apps/play/src/render.js
+++ b/apps/play/src/render.js
@@ -147,6 +147,51 @@ const RANGE_TINT = {
   attackBorder: 'rgba(255, 82, 82, 0.75)',
 };
 
+// QW4 (2026-04-26) — Lifecycle phase visual mapping. Skiv (Arenavenator vagans /
+// dune_stalker) è la creatura canonical: phases sono definite in
+// data/core/species/dune_stalker_lifecycle.yaml ma il sistema è multi-creature
+// ready (ogni unit con `lifecycle_phase` riceve scaling + tint + badge).
+//
+// Phases canoniche (5): hatchling → juvenile → mature → apex → legacy.
+// NOTE: lifecycle YAML usa "mature" non "adult" (ref dune_stalker_lifecycle.yaml).
+//
+// Size scaling: cucciolo più piccolo, apex più grande. Legacy = retired (no growth).
+// Tint: shift di hue lungo la curva di vita (grigio polvere → ocra → ossidiana
+// → cristallo notturno → argento spettrale).
+// Badge: 3 char abbrev top-right per scan TV-side (10-foot rule).
+const LIFECYCLE_PHASE_STYLE = {
+  hatchling: { sizeMul: 0.6, tint: '#bdbdbd', badge: 'HJG' }, // grigio polvere
+  juvenile: { sizeMul: 0.8, tint: '#d9a45b', badge: 'JUV' }, // ocra striato
+  mature: { sizeMul: 1.0, tint: '#7e57c2', badge: 'MTR' }, // ossidiana riflessa
+  apex: { sizeMul: 1.15, tint: '#1565c0', badge: 'APX' }, // brina notturna
+  legacy: { sizeMul: 1.0, tint: '#9e9e9e', badge: 'LGC' }, // argento spettrale
+};
+
+const LIFECYCLE_DEFAULT_STYLE = { sizeMul: 1.0, tint: null, badge: null };
+
+export function getLifecyclePhaseStyle(phase) {
+  if (!phase || typeof phase !== 'string') return LIFECYCLE_DEFAULT_STYLE;
+  return LIFECYCLE_PHASE_STYLE[phase.toLowerCase()] || LIFECYCLE_DEFAULT_STYLE;
+}
+
+// QW4 — Aspect token visual overlay. Token = mutation morphology marker
+// (claws_glass, claws_glacial, scales_chameleon, ears_radar). Reso come
+// piccolo glifo in alto-sinistra del corpo unit. Multi-creature: qualsiasi
+// unit con `aspect_token` campo riceve overlay (token sconosciuto = no-op).
+//
+// Source of truth: data/core/species/dune_stalker_lifecycle.yaml § mutation_morphology.
+const ASPECT_TOKEN_OVERLAY = {
+  claws_glass: { glyph: '◆', color: '#b39ddb' }, // ossidiana trasparente
+  claws_glacial: { glyph: '❄', color: '#90caf9' }, // brina permanente
+  scales_chameleon: { glyph: '◐', color: '#a5d6a7' }, // bio-camo
+  ears_radar: { glyph: '◊', color: '#80deea' }, // echolocation 3D
+};
+
+export function getAspectTokenOverlay(token) {
+  if (!token || typeof token !== 'string') return null;
+  return ASPECT_TOKEN_OVERLAY[token.toLowerCase()] || null;
+}
+
 const STATUS_ICONS = {
   panic: { glyph: '!', bg: '#ff9800' },
   rage: { glyph: '⚡', bg: '#f44336' },
@@ -227,6 +272,64 @@ function drawStatusIcons(ctx, unit, cx, yPxTop) {
   }
 }
 
+// QW4 — Lifecycle phase badge: pill scuro + abbrev (HJG/JUV/MTR/APX/LGC).
+// Posizione: bottom-right del tile. Tint ring color come bg, white text + outline.
+function drawLifecycleBadge(ctx, style, cx, yPxTop) {
+  const label = style.badge;
+  const fontSize = Math.max(9, Math.round(CELL * 0.11));
+  ctx.save();
+  ctx.font = `bold ${fontSize}px "SF Mono", "Menlo", monospace`;
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'top';
+  const padX = 4;
+  const padY = 2;
+  const textW = ctx.measureText(label).width;
+  const badgeW = textW + padX * 2;
+  const badgeH = fontSize + padY * 2;
+  const bx = cx + CELL * 0.18;
+  const by = yPxTop + CELL - badgeH - 4;
+  // Pill bg (dark) + tint border
+  ctx.fillStyle = 'rgba(15, 15, 15, 0.88)';
+  ctx.beginPath();
+  if (typeof ctx.roundRect === 'function') {
+    ctx.roundRect(bx, by, badgeW, badgeH, 4);
+  } else {
+    ctx.rect(bx, by, badgeW, badgeH);
+  }
+  ctx.fill();
+  ctx.strokeStyle = style.tint || '#888';
+  ctx.lineWidth = 1.5;
+  ctx.stroke();
+  // White text con outline nero (TV scan ready).
+  ctx.fillStyle = '#ffffff';
+  ctx.fillText(label, bx + padX, by + padY);
+  ctx.restore();
+}
+
+// QW4 — Aspect token overlay glifo: piccolo marker top-left del tile per
+// mutation morphology (claws_glass/glacial/scales_chameleon/ears_radar).
+function drawAspectTokenOverlay(ctx, overlay, cx, yPxTop) {
+  const size = Math.max(14, Math.round(CELL * 0.18));
+  const ix = cx - CELL * 0.32;
+  const iy = yPxTop + CELL * 0.55;
+  ctx.save();
+  // Disc bg semi-trans
+  ctx.fillStyle = 'rgba(15, 15, 15, 0.78)';
+  ctx.beginPath();
+  ctx.arc(ix, iy, size / 2 + 1, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.strokeStyle = overlay.color;
+  ctx.lineWidth = 1.5;
+  ctx.stroke();
+  // Glyph
+  ctx.fillStyle = overlay.color;
+  ctx.font = `bold ${size - 2}px "SF Mono", "Menlo", monospace`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(overlay.glyph, ix, iy + 1);
+  ctx.restore();
+}
+
 // W4.3 — Priority rank badge (resolution order 1..N) during resolve phase.
 function drawPriorityBadge(ctx, rank, cx, yPxTop) {
   const size = 18;
@@ -266,15 +369,30 @@ function drawUnit(ctx, unit, gridH, highlight = {}) {
 
   // W8M — Body: job-shape silhouette (no more circles). Ring outer = jobColor,
   // interior = faction. Boss scale +50% per drawUnitBody ring/body.
+  // QW4 (2026-04-26) — Lifecycle phase scaling: hatchling 0.6× → apex 1.15×.
+  // Skiv visibility: phase visualmente leggibile da TV scan (10-foot rule).
+  // Multi-creature ready: qualsiasi unit con `lifecycle_phase` campo riceve
+  // scaling + tint + badge (token sconosciuto / phase mancante = fallback safe).
   const jobKey = (unit.job || unit.class || '').toString().toLowerCase();
   const isBoss = jobKey === 'boss' || unit.is_boss === true;
-  const sizeMul = isBoss ? 1.5 : 1;
+  const lifecycleStyle = getLifecyclePhaseStyle(unit.lifecycle_phase);
+  const sizeMul = (isBoss ? 1.5 : 1) * lifecycleStyle.sizeMul;
   const jobColor = JOB_COLORS[jobKey] || null;
   // Outer job ring
   if (!dead && jobColor) {
     ctx.fillStyle = jobColor;
     drawUnitBody(ctx, cx, cy, jobKey, CELL * 0.42 * sizeMul);
     ctx.fill();
+  }
+  // QW4 — Lifecycle phase tint ring (intermediate layer between job ring and
+  // faction body). Visibile solo se phase nota; semi-trans per leggere job sotto.
+  if (!dead && lifecycleStyle.tint) {
+    ctx.save();
+    ctx.globalAlpha = 0.55;
+    ctx.fillStyle = lifecycleStyle.tint;
+    drawUnitBody(ctx, cx, cy, jobKey, CELL * 0.38 * sizeMul);
+    ctx.fill();
+    ctx.restore();
   }
   // Inner faction body
   ctx.fillStyle = color;
@@ -368,6 +486,22 @@ function drawUnit(ctx, unit, gridH, highlight = {}) {
 
   // Status icons (top-right)
   if (!dead) drawStatusIcons(ctx, unit, cx, yPx * CELL);
+
+  // QW4 — Lifecycle phase badge (bottom-right, sotto al corpo). Skiv-style:
+  // hatchling/juvenile/mature/apex/legacy abbrev su pill scuro.
+  if (!dead && lifecycleStyle.badge) {
+    drawLifecycleBadge(ctx, lifecycleStyle, cx, yPx * CELL);
+  }
+
+  // QW4 — Aspect token overlay (top-left). Mutation morphology marker
+  // (claws_glass/claws_glacial/scales_chameleon/ears_radar). Glifo piccolo,
+  // colore tematico. No-op se token assente o sconosciuto.
+  if (!dead) {
+    const aspectOverlay = getAspectTokenOverlay(unit.aspect_token);
+    if (aspectOverlay) {
+      drawAspectTokenOverlay(ctx, aspectOverlay, cx, yPx * CELL);
+    }
+  }
 
   // M4 P0.3 — SIS enemy intent icon (Slay the Spire pattern).
   // M8 Plan-Reveal P0 (ADR-2026-04-18): real intent icon da threat_preview

--- a/scripts/run-test-api.cjs
+++ b/scripts/run-test-api.cjs
@@ -23,6 +23,7 @@ const steps = [
   'node --test tests/scripts/damageCurvesIntegrity.test.js',
   'node --test tests/scripts/crossPlatformRunners.test.js',
   'node --test tests/i18n/parity.test.js',
+  'node --test tests/play/*.test.js',
 ];
 
 const env = {

--- a/tests/play/renderLifecycle.test.js
+++ b/tests/play/renderLifecycle.test.js
@@ -1,0 +1,198 @@
+// QW4 (2026-04-26) — render.js lifecycle_phase + aspect_token visibility.
+//
+// Test pure helper exports da apps/play/src/render.js:
+//   - getLifecyclePhaseStyle(phase) → { sizeMul, tint, badge }
+//   - getAspectTokenOverlay(token)   → { glyph, color } | null
+//
+// Skiv (Arenavenator vagans / dune_stalker) è la creatura canonical che usa
+// queste fasi: data/core/species/dune_stalker_lifecycle.yaml definisce 5 fasi
+// (hatchling → juvenile → mature → apex → legacy) + 4 mutation_morphology token.
+// Sistema multi-creature: qualsiasi unit con `lifecycle_phase` field riceve
+// scaling + tint + badge senza modifica al render layer.
+//
+// Canvas drawing è coperto solo indirettamente: helpers sono pure → testabili
+// senza jsdom / canvas mock. Visual smoke = launcher live (fuori scope test).
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+async function loadRender() {
+  return import('../../apps/play/src/render.js');
+}
+
+describe('getLifecyclePhaseStyle — 5 phases canonical da dune_stalker_lifecycle.yaml', () => {
+  test('hatchling → sizeMul 0.6, badge HJG, tint definito', async () => {
+    const { getLifecyclePhaseStyle } = await loadRender();
+    const s = getLifecyclePhaseStyle('hatchling');
+    assert.equal(s.sizeMul, 0.6);
+    assert.equal(s.badge, 'HJG');
+    assert.ok(s.tint && typeof s.tint === 'string');
+  });
+
+  test('juvenile → sizeMul 0.8, badge JUV', async () => {
+    const { getLifecyclePhaseStyle } = await loadRender();
+    const s = getLifecyclePhaseStyle('juvenile');
+    assert.equal(s.sizeMul, 0.8);
+    assert.equal(s.badge, 'JUV');
+  });
+
+  test('mature → sizeMul 1.0, badge MTR', async () => {
+    const { getLifecyclePhaseStyle } = await loadRender();
+    const s = getLifecyclePhaseStyle('mature');
+    assert.equal(s.sizeMul, 1.0);
+    assert.equal(s.badge, 'MTR');
+  });
+
+  test('apex → sizeMul 1.15 (largest), badge APX', async () => {
+    const { getLifecyclePhaseStyle } = await loadRender();
+    const s = getLifecyclePhaseStyle('apex');
+    assert.equal(s.sizeMul, 1.15);
+    assert.equal(s.badge, 'APX');
+  });
+
+  test('legacy → sizeMul 1.0 (retired), badge LGC', async () => {
+    const { getLifecyclePhaseStyle } = await loadRender();
+    const s = getLifecyclePhaseStyle('legacy');
+    assert.equal(s.sizeMul, 1.0);
+    assert.equal(s.badge, 'LGC');
+  });
+
+  test('size scaling è strettamente crescente da hatchling ad apex', async () => {
+    const { getLifecyclePhaseStyle } = await loadRender();
+    const ordered = ['hatchling', 'juvenile', 'mature', 'apex'];
+    const sizes = ordered.map((p) => getLifecyclePhaseStyle(p).sizeMul);
+    for (let i = 1; i < sizes.length; i += 1) {
+      assert.ok(
+        sizes[i] > sizes[i - 1],
+        `${ordered[i]} (${sizes[i]}) deve essere > ${ordered[i - 1]} (${sizes[i - 1]})`,
+      );
+    }
+  });
+
+  test('le 5 phase hanno tint colors distinti (fingerprint visivo)', async () => {
+    const { getLifecyclePhaseStyle } = await loadRender();
+    const phases = ['hatchling', 'juvenile', 'mature', 'apex', 'legacy'];
+    const tints = phases.map((p) => getLifecyclePhaseStyle(p).tint);
+    const unique = new Set(tints);
+    assert.equal(unique.size, 5, 'ogni phase deve avere tint univoco');
+  });
+
+  test('le 5 phase hanno badge abbrev distinti (3 char)', async () => {
+    const { getLifecyclePhaseStyle } = await loadRender();
+    const phases = ['hatchling', 'juvenile', 'mature', 'apex', 'legacy'];
+    const badges = phases.map((p) => getLifecyclePhaseStyle(p).badge);
+    const unique = new Set(badges);
+    assert.equal(unique.size, 5, 'ogni phase deve avere badge univoco');
+    badges.forEach((b) => assert.equal(b.length, 3, `badge "${b}" deve essere 3 char`));
+  });
+});
+
+describe('getLifecyclePhaseStyle — fallback safe (no breaking change)', () => {
+  test('phase undefined → default (sizeMul 1.0, no tint, no badge)', async () => {
+    const { getLifecyclePhaseStyle } = await loadRender();
+    const s = getLifecyclePhaseStyle(undefined);
+    assert.equal(s.sizeMul, 1.0);
+    assert.equal(s.tint, null);
+    assert.equal(s.badge, null);
+  });
+
+  test('phase null → default', async () => {
+    const { getLifecyclePhaseStyle } = await loadRender();
+    const s = getLifecyclePhaseStyle(null);
+    assert.equal(s.sizeMul, 1.0);
+    assert.equal(s.badge, null);
+  });
+
+  test('phase empty string → default', async () => {
+    const { getLifecyclePhaseStyle } = await loadRender();
+    const s = getLifecyclePhaseStyle('');
+    assert.equal(s.sizeMul, 1.0);
+    assert.equal(s.badge, null);
+  });
+
+  test('phase sconosciuta → default (no crash)', async () => {
+    const { getLifecyclePhaseStyle } = await loadRender();
+    const s = getLifecyclePhaseStyle('unknown_phase_xyz');
+    assert.equal(s.sizeMul, 1.0);
+    assert.equal(s.tint, null);
+  });
+
+  test('phase non-string (number) → default', async () => {
+    const { getLifecyclePhaseStyle } = await loadRender();
+    const s = getLifecyclePhaseStyle(42);
+    assert.equal(s.sizeMul, 1.0);
+  });
+
+  test('phase case-insensitive (HATCHLING == hatchling)', async () => {
+    const { getLifecyclePhaseStyle } = await loadRender();
+    const upper = getLifecyclePhaseStyle('HATCHLING');
+    const lower = getLifecyclePhaseStyle('hatchling');
+    assert.equal(upper.sizeMul, lower.sizeMul);
+    assert.equal(upper.badge, lower.badge);
+  });
+});
+
+describe('getAspectTokenOverlay — mutation morphology marker da YAML', () => {
+  test('claws_glass → glyph + color definiti', async () => {
+    const { getAspectTokenOverlay } = await loadRender();
+    const o = getAspectTokenOverlay('claws_glass');
+    assert.ok(o, 'claws_glass dovrebbe ritornare overlay');
+    assert.ok(o.glyph && typeof o.glyph === 'string');
+    assert.ok(o.color && typeof o.color === 'string');
+  });
+
+  test('claws_glacial → overlay distinto da claws_glass', async () => {
+    const { getAspectTokenOverlay } = await loadRender();
+    const glass = getAspectTokenOverlay('claws_glass');
+    const glacial = getAspectTokenOverlay('claws_glacial');
+    assert.ok(glacial);
+    assert.notEqual(glass.color, glacial.color, 'token diversi → color diversi');
+  });
+
+  test('scales_chameleon → overlay disponibile', async () => {
+    const { getAspectTokenOverlay } = await loadRender();
+    const o = getAspectTokenOverlay('scales_chameleon');
+    assert.ok(o);
+  });
+
+  test('ears_radar → overlay disponibile', async () => {
+    const { getAspectTokenOverlay } = await loadRender();
+    const o = getAspectTokenOverlay('ears_radar');
+    assert.ok(o);
+  });
+
+  test('i 4 token canonici hanno tutti glyph distinti', async () => {
+    const { getAspectTokenOverlay } = await loadRender();
+    const tokens = ['claws_glass', 'claws_glacial', 'scales_chameleon', 'ears_radar'];
+    const glyphs = tokens.map((t) => getAspectTokenOverlay(t).glyph);
+    const unique = new Set(glyphs);
+    assert.equal(unique.size, 4, 'ogni token deve avere glyph univoco');
+  });
+
+  test('token sconosciuto → null (no-op safe)', async () => {
+    const { getAspectTokenOverlay } = await loadRender();
+    assert.equal(getAspectTokenOverlay('not_a_real_token'), null);
+  });
+
+  test('token undefined / null / empty → null', async () => {
+    const { getAspectTokenOverlay } = await loadRender();
+    assert.equal(getAspectTokenOverlay(undefined), null);
+    assert.equal(getAspectTokenOverlay(null), null);
+    assert.equal(getAspectTokenOverlay(''), null);
+  });
+
+  test('token non-string → null (no crash)', async () => {
+    const { getAspectTokenOverlay } = await loadRender();
+    assert.equal(getAspectTokenOverlay(42), null);
+    assert.equal(getAspectTokenOverlay({}), null);
+  });
+
+  test('token case-insensitive', async () => {
+    const { getAspectTokenOverlay } = await loadRender();
+    const upper = getAspectTokenOverlay('CLAWS_GLASS');
+    const lower = getAspectTokenOverlay('claws_glass');
+    assert.deepEqual(upper, lower);
+  });
+});


### PR DESCRIPTION
## Summary

Quick-win QW4: `apps/play/src/render.js drawUnit()` ora legge `unit.lifecycle_phase` + `unit.aspect_token` invece di mostrare "PRE" identico da hatchling ad apex. Skiv (Arenavenator vagans / dune_stalker) finalmente visibilmente diverso lungo le 5 fasi vitali sul canvas TV-side.

## Cosa cambia

- **Pure helper `getLifecyclePhaseStyle(phase)`** → `{ sizeMul, tint, badge }`
  - hatchling 0.6× · juvenile 0.8× · mature 1.0× · apex 1.15× · legacy 1.0×
  - Tint colors distinti (grigio polvere → ocra → ossidiana → brina notturna → argento spettrale)
  - Badge 3 char abbrev (HJG · JUV · MTR · APX · LGC) reso pill bottom-right
- **Pure helper `getAspectTokenOverlay(token)`** → `{ glyph, color } | null`
  - Mappa 4 token canonici da `dune_stalker_lifecycle.yaml § mutation_morphology` (claws_glass · claws_glacial · scales_chameleon · ears_radar)
  - Glifo overlay top-left, semi-trans disc bg
- **`drawUnit()` wired**: tint ring intermedio tra job ring e faction body, size moltiplicato con `isBoss` factor (preservato), badge + overlay disegnati dopo status icons
- **Multi-creature ready**: qualsiasi unit con `lifecycle_phase` o `aspect_token` field riceve trattamento, non solo Skiv. Phase/token mancanti o sconosciuti → fallback no-op senza breaking change
- **Runner**: `scripts/run-test-api.cjs` aggiornato per pickup `tests/play/*.test.js`

## File toccati

- `apps/play/src/render.js` — +135 LOC (helpers + drawing functions + drawUnit integration)
- `tests/play/renderLifecycle.test.js` — NEW, 23 test
- `scripts/run-test-api.cjs` — +1 line (test runner pickup)

## DoD checklist

- [x] Test pure-helper 23/23 verde (`tests/play/renderLifecycle.test.js`): 8 phase mapping + 6 fallback safe + 9 aspect token
- [x] AI regression 311/311 verde (`node --test tests/ai/*.test.js`)
- [x] Skiv route 12/12 verde (`tests/api/skivRoute.test.js`)
- [x] `format:check` verde su file toccati
- [x] Diff scope clean: 3 file modificati, nessun fuori-scope
- [x] Commit lowercase prefix `feat(render):`
- [x] Italian commit + PR body
- [x] Worktree isolato: `.claude/worktrees/agent-a5e7712b805ca5736`

## Anti-pattern guards

- ❌ Nessun hardcode Skiv-only — sistema funziona per ogni unit con quei field
- ❌ Nessuna modifica a `docs/skiv/CANONICAL.md` o `dune_stalker_lifecycle.yaml`
- ❌ Nessuna nuova dipendenza npm
- ❌ Nessuna modifica a contracts/schema (additive su unit object già spread via `...u` in `publicSessionView`)

## Note upstream

Backend wire-up per popolare `unit.lifecycle_phase` + `unit.aspect_token` su `publicSessionView` resta separato (fuori scope QW4: render layer è ready a leggere quando i field arrivano, da `seed_skiv_saga.py` o futuro session bootstrap hook). `publicSessionView` già fa spread `...u` quindi qualsiasi field nuovo passa-through senza modifica wire.

## Test plan

- [ ] `node --test tests/play/renderLifecycle.test.js` (23/23)
- [ ] `node --test tests/ai/*.test.js` (311/311 baseline)
- [ ] `npm run format:check`
- [ ] Visual smoke (userland, fuori auto-mode): avvia `npm run play:dev`, mock unit con `lifecycle_phase: 'apex'` + `aspect_token: 'claws_glass'` → verifica badge APX bottom-right + tint blu + glifo ◆ top-left