### PR TITLE
feat(forms): 16 starter_bioma trait + formPackRecommender wire (QW2 M-017)

### DIFF
--- a/apps/backend/routes/formPackRoutes.js
+++ b/apps/backend/routes/formPackRoutes.js
@@ -3,6 +3,10 @@
 // Endpoints:
 //   GET  /api/forms/:formId/packs          — static form recommendation
 //   POST /api/forms/:formId/recommend      — d20/d12 dynamic recommendation
+//
+// QW2 / M-017 starter bioma routes (GET /api/forms/starter-biomas + GET
+// /api/forms/:formId/starter-bioma) live in routes/forms.js to avoid
+// shadow conflicts with the /api/forms/:id catch-all registered there.
 
 'use strict';
 

--- a/apps/backend/routes/forms.js
+++ b/apps/backend/routes/forms.js
@@ -21,6 +21,7 @@ const { Router } = require('express');
 const { FormEvolutionEngine } = require('../services/forms/formEvolution');
 const { createFormSessionStore } = require('../services/forms/formSessionStore');
 const { loadPacks, rollPack, seededRng } = require('../services/forms/packRoller');
+const { resolveStarterBioma, listStarterBiomas } = require('../services/forms/formPackRecommender');
 
 function createFormsRouter(opts = {}) {
   const engine = opts.engine || new FormEvolutionEngine(opts);
@@ -30,6 +31,18 @@ function createFormsRouter(opts = {}) {
 
   router.get('/registry', (_req, res) => {
     res.json(engine.snapshot());
+  });
+
+  // QW2 / M-017 — list 16 form -> starter bioma map. MUST stay before /:id.
+  router.get('/starter-biomas', (_req, res) => {
+    res.json({ count: 16, items: listStarterBiomas() });
+  });
+
+  // QW2 / M-017 — single form starter bioma resolution. MUST stay before /:id.
+  router.get('/:formId/starter-bioma', (req, res) => {
+    const resolved = resolveStarterBioma(req.params.formId);
+    if (!resolved) return res.status(404).json({ error: 'form not found' });
+    res.json({ form_id: req.params.formId, ...resolved });
   });
 
   router.get('/:id', (req, res) => {

--- a/apps/backend/services/forms/formPackRecommender.js
+++ b/apps/backend/services/forms/formPackRecommender.js
@@ -23,6 +23,29 @@ const yaml = require('js-yaml');
 const BIAS_FILE = path.join(process.cwd(), 'data', 'core', 'forms', 'form_pack_bias.yaml');
 let _cache = null;
 
+// QW2 / M-017: Form -> starter bioma mapping (slot `starter_bioma` resolution).
+// Each Form has a thematic biome + dedicated trait `starter_bioma_<form_id>`
+// defined in data/core/traits/active_effects.yaml + glossary.json.
+// Wire UI onboarding panel = follow-up PR.
+const STARTER_BIOMA_MAP = Object.freeze({
+  ISTJ: { biome_id: 'steppe_algoritmiche', trait_id: 'starter_bioma_istj' },
+  ISFJ: { biome_id: 'foresta_temperata', trait_id: 'starter_bioma_isfj' },
+  INFJ: { biome_id: 'foresta_miceliale', trait_id: 'starter_bioma_infj' },
+  INTJ: { biome_id: 'rovine_planari', trait_id: 'starter_bioma_intj' },
+  ISTP: { biome_id: 'caverna', trait_id: 'starter_bioma_istp' },
+  ISFP: { biome_id: 'reef_luminescente', trait_id: 'starter_bioma_isfp' },
+  INFP: { biome_id: 'foresta_acida', trait_id: 'starter_bioma_infp' },
+  INTP: { biome_id: 'canyons_risonanti', trait_id: 'starter_bioma_intp' },
+  ESTP: { biome_id: 'savana', trait_id: 'starter_bioma_estp' },
+  ESFP: { biome_id: 'dorsale_termale_tropicale', trait_id: 'starter_bioma_esfp' },
+  ENFP: { biome_id: 'canopia_ionica', trait_id: 'starter_bioma_enfp' },
+  ENTP: { biome_id: 'atollo_obsidiana', trait_id: 'starter_bioma_entp' },
+  ESTJ: { biome_id: 'badlands', trait_id: 'starter_bioma_estj' },
+  ESFJ: { biome_id: 'pianura_salina_iperarida', trait_id: 'starter_bioma_esfj' },
+  ENFJ: { biome_id: 'palude', trait_id: 'starter_bioma_enfj' },
+  ENTJ: { biome_id: 'abisso_vulcanico', trait_id: 'starter_bioma_entj' },
+});
+
 function loadBias() {
   if (_cache) return _cache;
   if (!fs.existsSync(BIAS_FILE)) return null;
@@ -42,6 +65,9 @@ function _resetCache() {
 
 /**
  * Get form-specific packs.
+ *
+ * Returns {pack_a, pack_b, pack_c, d12_bias, starter_bioma}.
+ * starter_bioma is the resolved biome+trait pair for slot `starter_bioma`.
  */
 function getFormPacks(formId) {
   const bias = loadBias();
@@ -54,7 +80,37 @@ function getFormPacks(formId) {
     pack_b: form.pack_b,
     pack_c: form.pack_c,
     d12_bias: form.d12_bias,
+    starter_bioma: resolveStarterBioma(formId),
   };
+}
+
+/**
+ * Resolve `starter_bioma` slot for a given Form to {biome_id, trait_id}.
+ *
+ * QW2 / M-017: every MBTI Form maps to a thematic biome + a dedicated
+ * trait `starter_bioma_<form_id>` (defined in active_effects.yaml).
+ * NEUTRA / unknown forms return null (caller handles fallback).
+ *
+ * @param {string} formId  MBTI form id (e.g. 'INTJ')
+ * @returns {{biome_id: string, trait_id: string}|null}
+ */
+function resolveStarterBioma(formId) {
+  if (!formId || typeof formId !== 'string') return null;
+  return STARTER_BIOMA_MAP[formId] || null;
+}
+
+/**
+ * List all 16 form -> starter bioma mappings.
+ * Used by UI onboarding + tests + diagnostics.
+ *
+ * @returns {Array<{form_id, biome_id, trait_id}>}
+ */
+function listStarterBiomas() {
+  return Object.entries(STARTER_BIOMA_MAP).map(([form_id, v]) => ({
+    form_id,
+    biome_id: v.biome_id,
+    trait_id: v.trait_id,
+  }));
 }
 
 /**
@@ -103,6 +159,8 @@ function recommendPacks({ form_id, job_id, d20_roll = null, d12_roll = null } = 
   if (!bias) return { error: 'bias data missing' };
   const form = bias.forms[form_id] || bias.forms.NEUTRA;
   const jobBias = bias.job_bias[job_id] || bias.job_bias.any;
+  // QW2 / M-017: starter bioma resolution (null for NEUTRA / unknown forms).
+  const starterBioma = resolveStarterBioma(form_id);
 
   // If no d20 given, return form packs as default recommendation
   if (d20_roll == null) {
@@ -114,6 +172,7 @@ function recommendPacks({ form_id, job_id, d20_roll = null, d12_roll = null } = 
         { key: 'pack_c', ...form.pack_c },
       ],
       job_bias: jobBias,
+      starter_bioma: starterBioma,
       reason: 'form-based default (no d20 provided)',
     };
   }
@@ -126,6 +185,7 @@ function recommendPacks({ form_id, job_id, d20_roll = null, d12_roll = null } = 
       d20_roll,
       pack_key: d20.pack,
       combo: bias.universal_packs[d20.pack],
+      starter_bioma: starterBioma,
       reason: `d20=${d20_roll} → universal pack ${d20.pack}`,
     };
   }
@@ -140,6 +200,7 @@ function recommendPacks({ form_id, job_id, d20_roll = null, d12_roll = null } = 
       pack_key: key,
       combo: pack?.combo || 'form pack missing',
       tags: pack?.tags || [],
+      starter_bioma: starterBioma,
       reason: `d20=${d20_roll} Bias Forma → d12=${d12_roll} → ${key}`,
     };
   }
@@ -153,6 +214,7 @@ function recommendPacks({ form_id, job_id, d20_roll = null, d12_roll = null } = 
       pack_key: packKey,
       combo: bias.universal_packs[packKey],
       alternatives: jobBias.slice(1).map((k) => ({ key: k, combo: bias.universal_packs[k] })),
+      starter_bioma: starterBioma,
       reason: `d20=${d20_roll} Bias Job (${job_id}) → ${packKey}`,
     };
   }
@@ -162,6 +224,7 @@ function recommendPacks({ form_id, job_id, d20_roll = null, d12_roll = null } = 
     d20_roll,
     all_packs: Object.entries(bias.universal_packs).map(([k, v]) => ({ key: k, combo: v })),
     form_packs: [form.pack_a, form.pack_b, form.pack_c],
+    starter_bioma: starterBioma,
     reason: `d20=${d20_roll} Scelta → player choice`,
   };
 }
@@ -172,5 +235,8 @@ module.exports = {
   recommendPacks,
   resolveD12Pack,
   resolveD20Pack,
+  resolveStarterBioma,
+  listStarterBiomas,
+  STARTER_BIOMA_MAP,
   _resetCache,
 };

--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -8452,3 +8452,335 @@ traits:
       code: "BB CT 05"
       branch: "Therapeutic Medication"
       license: "CC BY-NC-SA 3.0 Fandom"
+
+  # =========================================================================
+  # QW2 / M-017: Starter Bioma trait — adattamento del Form al bioma di
+  # partenza. Slot `starter_bioma` nei pack di form_pack_bias.yaml viene
+  # risolto da formPackRecommender.js a `starter_bioma_<form_id>`.
+  #
+  # Schema: tier T1, kind=extra_damage, amount=1, trigger min_mos=5 (solo
+  # solid hit). Tier 1 leggibile + non combat-breaking (max +1 conditional).
+  # Il campo provenance.starter_biome documenta il bioma tematico associato
+  # al Form (mapping derivato da archetype theme + biomes.yaml shipping).
+  # Wire UI onboarding panel -> follow-up PR.
+  # =========================================================================
+
+  starter_bioma_istj:
+    tier: T1
+    category: ecologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: starter_bioma_istj
+    description_it: |
+      Adattamento ISTJ alle Steppe Algoritmiche: terreno ordinato,
+      letture stabili. +1 danno sui colpi solidi (MoS >= 5).
+    provenance:
+      source: qw2_starter_bioma
+      starter_biome: steppe_algoritmiche
+      form_id: ISTJ
+
+  starter_bioma_isfj:
+    tier: T1
+    category: ecologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: starter_bioma_isfj
+    description_it: |
+      Adattamento ISFJ alla Foresta Temperata: ambienti familiari,
+      branco coeso. +1 danno sui colpi solidi (MoS >= 5).
+    provenance:
+      source: qw2_starter_bioma
+      starter_biome: foresta_temperata
+      form_id: ISFJ
+
+  starter_bioma_infj:
+    tier: T1
+    category: ecologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: starter_bioma_infj
+    description_it: |
+      Adattamento INFJ alla Foresta Miceliale: rete sottile,
+      intuizioni. +1 danno sui colpi solidi (MoS >= 5).
+    provenance:
+      source: qw2_starter_bioma
+      starter_biome: foresta_miceliale
+      form_id: INFJ
+
+  starter_bioma_intj:
+    tier: T1
+    category: ecologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: starter_bioma_intj
+    description_it: |
+      Adattamento INTJ alle Rovine Planari: geometria,
+      pianificazione. +1 danno sui colpi solidi (MoS >= 5).
+    provenance:
+      source: qw2_starter_bioma
+      starter_biome: rovine_planari
+      form_id: INTJ
+
+  starter_bioma_istp:
+    tier: T1
+    category: ecologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: starter_bioma_istp
+    description_it: |
+      Adattamento ISTP alla Caverna: agilita' tecnica,
+      trappole. +1 danno sui colpi solidi (MoS >= 5).
+    provenance:
+      source: qw2_starter_bioma
+      starter_biome: caverna
+      form_id: ISTP
+
+  starter_bioma_isfp:
+    tier: T1
+    category: ecologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: starter_bioma_isfp
+    description_it: |
+      Adattamento ISFP al Reef Luminescente: flusso aggraziato,
+      mobilita'. +1 danno sui colpi solidi (MoS >= 5).
+    provenance:
+      source: qw2_starter_bioma
+      starter_biome: reef_luminescente
+      form_id: ISFP
+
+  starter_bioma_infp:
+    tier: T1
+    category: ecologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: starter_bioma_infp
+    description_it: |
+      Adattamento INFP alla Foresta Acida: empatia mutualistica,
+      simbiosi. +1 danno sui colpi solidi (MoS >= 5).
+    provenance:
+      source: qw2_starter_bioma
+      starter_biome: foresta_acida
+      form_id: INFP
+
+  starter_bioma_intp:
+    tier: T1
+    category: ecologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: starter_bioma_intp
+    description_it: |
+      Adattamento INTP ai Canyons Risonanti: eco analitica,
+      focus. +1 danno sui colpi solidi (MoS >= 5).
+    provenance:
+      source: qw2_starter_bioma
+      starter_biome: canyons_risonanti
+      form_id: INTP
+
+  starter_bioma_estp:
+    tier: T1
+    category: ecologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: starter_bioma_estp
+    description_it: |
+      Adattamento ESTP alla Savana: spazio aperto,
+      velocita' offensiva. +1 danno sui colpi solidi (MoS >= 5).
+    provenance:
+      source: qw2_starter_bioma
+      starter_biome: savana
+      form_id: ESTP
+
+  starter_bioma_esfp:
+    tier: T1
+    category: ecologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: starter_bioma_esfp
+    description_it: |
+      Adattamento ESFP alla Dorsale Termale Tropicale: vibrante,
+      branco predatorio. +1 danno sui colpi solidi (MoS >= 5).
+    provenance:
+      source: qw2_starter_bioma
+      starter_biome: dorsale_termale_tropicale
+      form_id: ESFP
+
+  starter_bioma_enfp:
+    tier: T1
+    category: ecologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: starter_bioma_enfp
+    description_it: |
+      Adattamento ENFP alla Canopia Ionica: esplorazione aerea,
+      pathfinding. +1 danno sui colpi solidi (MoS >= 5).
+    provenance:
+      source: qw2_starter_bioma
+      starter_biome: canopia_ionica
+      form_id: ENFP
+
+  starter_bioma_entp:
+    tier: T1
+    category: ecologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: starter_bioma_entp
+    description_it: |
+      Adattamento ENTP all'Atollo di Ossidiana: volatilita' EMP,
+      combo sperimentali. +1 danno sui colpi solidi (MoS >= 5).
+    provenance:
+      source: qw2_starter_bioma
+      starter_biome: atollo_obsidiana
+      form_id: ENTP
+
+  starter_bioma_estj:
+    tier: T1
+    category: ecologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: starter_bioma_estj
+    description_it: |
+      Adattamento ESTJ alle Badlands: territorio ostile,
+      carica strutturata. +1 danno sui colpi solidi (MoS >= 5).
+    provenance:
+      source: qw2_starter_bioma
+      starter_biome: badlands
+      form_id: ESTJ
+
+  starter_bioma_esfj:
+    tier: T1
+    category: ecologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: starter_bioma_esfj
+    description_it: |
+      Adattamento ESFJ alla Pianura Salina Iperarida: comunita'
+      in scarsita', cura mutua. +1 danno sui colpi solidi (MoS >= 5).
+    provenance:
+      source: qw2_starter_bioma
+      starter_biome: pianura_salina_iperarida
+      form_id: ESFJ
+
+  starter_bioma_enfj:
+    tier: T1
+    category: ecologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: starter_bioma_enfj
+    description_it: |
+      Adattamento ENFJ alla Palude: ambiente nutriente,
+      leadership empatica. +1 danno sui colpi solidi (MoS >= 5).
+    provenance:
+      source: qw2_starter_bioma
+      starter_biome: palude
+      form_id: ENFJ
+
+  starter_bioma_entj:
+    tier: T1
+    category: ecologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: starter_bioma_entj
+    description_it: |
+      Adattamento ENTJ all'Abisso Vulcanico: dominio territoriale,
+      pressione strategica. +1 danno sui colpi solidi (MoS >= 5).
+    provenance:
+      source: qw2_starter_bioma
+      starter_biome: abisso_vulcanico
+      form_id: ENTJ

--- a/data/core/traits/glossary.json
+++ b/data/core/traits/glossary.json
@@ -1678,6 +1678,102 @@
       "label_en": "Predictive Brain",
       "description_it": "Corteccia che anticipa i prossimi secondi del bersaglio.",
       "description_en": "Cortex that anticipates the target's next seconds of motion."
+    },
+    "starter_bioma_istj": {
+      "label_it": "Adattamento Steppe (ISTJ)",
+      "label_en": "Steppe Adaptation (ISTJ)",
+      "description_it": "Adattamento ISTJ alle Steppe Algoritmiche: terreno ordinato, letture stabili. +1 danno sui colpi solidi (MoS >= 5).",
+      "description_en": "ISTJ adaptation to the Algorithmic Steppes: ordered terrain, stable readings. +1 damage on solid hits (MoS >= 5)."
+    },
+    "starter_bioma_isfj": {
+      "label_it": "Adattamento Foresta Temperata (ISFJ)",
+      "label_en": "Temperate Forest Adaptation (ISFJ)",
+      "description_it": "Adattamento ISFJ alla Foresta Temperata: ambienti familiari, branco coeso. +1 danno sui colpi solidi (MoS >= 5).",
+      "description_en": "ISFJ adaptation to the Temperate Forest: familiar terrain, cohesive pack. +1 damage on solid hits (MoS >= 5)."
+    },
+    "starter_bioma_infj": {
+      "label_it": "Adattamento Foresta Miceliale (INFJ)",
+      "label_en": "Mycelial Forest Adaptation (INFJ)",
+      "description_it": "Adattamento INFJ alla Foresta Miceliale: rete sottile, intuizioni. +1 danno sui colpi solidi (MoS >= 5).",
+      "description_en": "INFJ adaptation to the Mycelial Forest: subtle network, intuition. +1 damage on solid hits (MoS >= 5)."
+    },
+    "starter_bioma_intj": {
+      "label_it": "Adattamento Rovine Planari (INTJ)",
+      "label_en": "Planar Ruins Adaptation (INTJ)",
+      "description_it": "Adattamento INTJ alle Rovine Planari: geometria, pianificazione. +1 danno sui colpi solidi (MoS >= 5).",
+      "description_en": "INTJ adaptation to the Planar Ruins: geometry, planning. +1 damage on solid hits (MoS >= 5)."
+    },
+    "starter_bioma_istp": {
+      "label_it": "Adattamento Caverna (ISTP)",
+      "label_en": "Cavern Adaptation (ISTP)",
+      "description_it": "Adattamento ISTP alla Caverna: agilita' tecnica, trappole. +1 danno sui colpi solidi (MoS >= 5).",
+      "description_en": "ISTP adaptation to the Cavern: technical agility, traps. +1 damage on solid hits (MoS >= 5)."
+    },
+    "starter_bioma_isfp": {
+      "label_it": "Adattamento Reef Luminescente (ISFP)",
+      "label_en": "Luminescent Reef Adaptation (ISFP)",
+      "description_it": "Adattamento ISFP al Reef Luminescente: flusso aggraziato, mobilita'. +1 danno sui colpi solidi (MoS >= 5).",
+      "description_en": "ISFP adaptation to the Luminescent Reef: graceful flow, mobility. +1 damage on solid hits (MoS >= 5)."
+    },
+    "starter_bioma_infp": {
+      "label_it": "Adattamento Foresta Acida (INFP)",
+      "label_en": "Acid Forest Adaptation (INFP)",
+      "description_it": "Adattamento INFP alla Foresta Acida: empatia mutualistica, simbiosi. +1 danno sui colpi solidi (MoS >= 5).",
+      "description_en": "INFP adaptation to the Acid Forest: mutualistic empathy, symbiosis. +1 damage on solid hits (MoS >= 5)."
+    },
+    "starter_bioma_intp": {
+      "label_it": "Adattamento Canyons Risonanti (INTP)",
+      "label_en": "Resonant Canyons Adaptation (INTP)",
+      "description_it": "Adattamento INTP ai Canyons Risonanti: eco analitica, focus. +1 danno sui colpi solidi (MoS >= 5).",
+      "description_en": "INTP adaptation to the Resonant Canyons: analytical echo, focus. +1 damage on solid hits (MoS >= 5)."
+    },
+    "starter_bioma_estp": {
+      "label_it": "Adattamento Savana (ESTP)",
+      "label_en": "Savanna Adaptation (ESTP)",
+      "description_it": "Adattamento ESTP alla Savana: spazio aperto, velocita' offensiva. +1 danno sui colpi solidi (MoS >= 5).",
+      "description_en": "ESTP adaptation to the Savanna: open space, offensive speed. +1 damage on solid hits (MoS >= 5)."
+    },
+    "starter_bioma_esfp": {
+      "label_it": "Adattamento Dorsale Tropicale (ESFP)",
+      "label_en": "Tropical Ridge Adaptation (ESFP)",
+      "description_it": "Adattamento ESFP alla Dorsale Termale Tropicale: vibrante, branco predatorio. +1 danno sui colpi solidi (MoS >= 5).",
+      "description_en": "ESFP adaptation to the Tropical Thermal Ridge: vibrant, predatory pack. +1 damage on solid hits (MoS >= 5)."
+    },
+    "starter_bioma_enfp": {
+      "label_it": "Adattamento Canopia Ionica (ENFP)",
+      "label_en": "Ionic Canopy Adaptation (ENFP)",
+      "description_it": "Adattamento ENFP alla Canopia Ionica: esplorazione aerea, pathfinding. +1 danno sui colpi solidi (MoS >= 5).",
+      "description_en": "ENFP adaptation to the Ionic Canopy: aerial exploration, pathfinding. +1 damage on solid hits (MoS >= 5)."
+    },
+    "starter_bioma_entp": {
+      "label_it": "Adattamento Atollo Obsidiana (ENTP)",
+      "label_en": "Obsidian Atoll Adaptation (ENTP)",
+      "description_it": "Adattamento ENTP all'Atollo di Ossidiana: volatilita' EMP, combo sperimentali. +1 danno sui colpi solidi (MoS >= 5).",
+      "description_en": "ENTP adaptation to the Obsidian Atoll: EMP volatility, experimental combos. +1 damage on solid hits (MoS >= 5)."
+    },
+    "starter_bioma_estj": {
+      "label_it": "Adattamento Badlands (ESTJ)",
+      "label_en": "Badlands Adaptation (ESTJ)",
+      "description_it": "Adattamento ESTJ alle Badlands: territorio ostile, carica strutturata. +1 danno sui colpi solidi (MoS >= 5).",
+      "description_en": "ESTJ adaptation to the Badlands: hostile territory, structured charge. +1 damage on solid hits (MoS >= 5)."
+    },
+    "starter_bioma_esfj": {
+      "label_it": "Adattamento Pianura Salina (ESFJ)",
+      "label_en": "Saline Plain Adaptation (ESFJ)",
+      "description_it": "Adattamento ESFJ alla Pianura Salina Iperarida: comunita' in scarsita', cura mutua. +1 danno sui colpi solidi (MoS >= 5).",
+      "description_en": "ESFJ adaptation to the Hyperarid Saline Plain: community in scarcity, mutual care. +1 damage on solid hits (MoS >= 5)."
+    },
+    "starter_bioma_enfj": {
+      "label_it": "Adattamento Palude (ENFJ)",
+      "label_en": "Swamp Adaptation (ENFJ)",
+      "description_it": "Adattamento ENFJ alla Palude: ambiente nutriente, leadership empatica. +1 danno sui colpi solidi (MoS >= 5).",
+      "description_en": "ENFJ adaptation to the Swamp: nourishing environment, empathic leadership. +1 damage on solid hits (MoS >= 5)."
+    },
+    "starter_bioma_entj": {
+      "label_it": "Adattamento Abisso Vulcanico (ENTJ)",
+      "label_en": "Volcanic Abyss Adaptation (ENTJ)",
+      "description_it": "Adattamento ENTJ all'Abisso Vulcanico: dominio territoriale, pressione strategica. +1 danno sui colpi solidi (MoS >= 5).",
+      "description_en": "ENTJ adaptation to the Volcanic Abyss: territorial dominance, strategic pressure. +1 damage on solid hits (MoS >= 5)."
     }
   }
 }

--- a/tests/api/formPackRecommender.test.js
+++ b/tests/api/formPackRecommender.test.js
@@ -11,6 +11,9 @@ const {
   recommendPacks,
   resolveD12Pack,
   resolveD20Pack,
+  resolveStarterBioma,
+  listStarterBiomas,
+  STARTER_BIOMA_MAP,
   _resetCache,
 } = require('../../apps/backend/services/forms/formPackRecommender');
 
@@ -121,5 +124,156 @@ test('all 16 MBTI forms have valid combo strings', () => {
     assert.ok(p.pack_a.combo, `${f} pack_a combo`);
     assert.ok(p.pack_b.combo, `${f} pack_b combo`);
     assert.ok(p.pack_c.combo, `${f} pack_c combo`);
+  }
+});
+
+// ===========================================================================
+// QW2 / M-017: starter_bioma resolution per Form
+// ===========================================================================
+
+const ALL_16_FORMS = [
+  'ISTJ',
+  'ISFJ',
+  'INFJ',
+  'INTJ',
+  'ISTP',
+  'ISFP',
+  'INFP',
+  'INTP',
+  'ESTP',
+  'ESFP',
+  'ENFP',
+  'ENTP',
+  'ESTJ',
+  'ESFJ',
+  'ENFJ',
+  'ENTJ',
+];
+
+test('STARTER_BIOMA_MAP: 16 entries exactly (no NEUTRA)', () => {
+  assert.equal(Object.keys(STARTER_BIOMA_MAP).length, 16);
+  for (const f of ALL_16_FORMS) {
+    assert.ok(STARTER_BIOMA_MAP[f], `${f} present`);
+  }
+});
+
+test('resolveStarterBioma: 16 forms map to {biome_id, trait_id}', () => {
+  for (const f of ALL_16_FORMS) {
+    const r = resolveStarterBioma(f);
+    assert.ok(r, `${f} resolves`);
+    assert.equal(typeof r.biome_id, 'string');
+    assert.equal(typeof r.trait_id, 'string');
+    assert.equal(r.trait_id, `starter_bioma_${f.toLowerCase()}`);
+  }
+});
+
+test('resolveStarterBioma: unknown / NEUTRA returns null', () => {
+  assert.equal(resolveStarterBioma('XXXX'), null);
+  assert.equal(resolveStarterBioma('NEUTRA'), null);
+  assert.equal(resolveStarterBioma(null), null);
+  assert.equal(resolveStarterBioma(''), null);
+  assert.equal(resolveStarterBioma(undefined), null);
+});
+
+test('listStarterBiomas: returns 16 items with form_id+biome_id+trait_id', () => {
+  const list = listStarterBiomas();
+  assert.equal(list.length, 16);
+  for (const item of list) {
+    assert.ok(ALL_16_FORMS.includes(item.form_id));
+    assert.ok(item.biome_id.length > 0);
+    assert.ok(item.trait_id.startsWith('starter_bioma_'));
+  }
+});
+
+test('starter_bioma biome_ids are unique across 16 forms', () => {
+  const biomes = listStarterBiomas().map((x) => x.biome_id);
+  const uniq = new Set(biomes);
+  assert.equal(biomes.length, uniq.size, 'no duplicate biome_id assignments');
+});
+
+test('starter_bioma trait_ids are unique across 16 forms', () => {
+  const traits = listStarterBiomas().map((x) => x.trait_id);
+  const uniq = new Set(traits);
+  assert.equal(traits.length, uniq.size, 'no duplicate trait_id assignments');
+});
+
+test('getFormPacks: includes starter_bioma resolved field', () => {
+  const p = getFormPacks('INTJ');
+  assert.ok(p.starter_bioma);
+  assert.equal(p.starter_bioma.biome_id, 'rovine_planari');
+  assert.equal(p.starter_bioma.trait_id, 'starter_bioma_intj');
+});
+
+test('getFormPacks: NEUTRA fallback has starter_bioma=null', () => {
+  const p = getFormPacks('NEUTRA');
+  assert.equal(p.starter_bioma, null);
+});
+
+test('recommendPacks: static recommendation includes starter_bioma', () => {
+  const r = recommendPacks({ form_id: 'ENFP', job_id: 'invoker' });
+  assert.ok(r.starter_bioma);
+  assert.equal(r.starter_bioma.biome_id, 'canopia_ionica');
+  assert.equal(r.starter_bioma.trait_id, 'starter_bioma_enfp');
+});
+
+test('recommendPacks: universal pack includes starter_bioma for known form', () => {
+  const r = recommendPacks({ form_id: 'INTJ', job_id: 'invoker', d20_roll: 5 });
+  assert.equal(r.type, 'universal');
+  assert.ok(r.starter_bioma);
+  assert.equal(r.starter_bioma.trait_id, 'starter_bioma_intj');
+});
+
+test('recommendPacks: bias_forma includes starter_bioma', () => {
+  const r = recommendPacks({ form_id: 'ISTP', job_id: 'skirmisher', d20_roll: 16, d12_roll: 3 });
+  assert.equal(r.type, 'bias_forma');
+  assert.ok(r.starter_bioma);
+  assert.equal(r.starter_bioma.biome_id, 'caverna');
+});
+
+test('recommendPacks: NEUTRA caller -> starter_bioma null', () => {
+  const r = recommendPacks({ form_id: 'NEUTRA', job_id: 'any' });
+  assert.equal(r.starter_bioma, null);
+});
+
+test('all 16 starter_bioma trait ids present in active_effects.yaml', () => {
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const yaml = require('js-yaml');
+  const file = path.join(process.cwd(), 'data', 'core', 'traits', 'active_effects.yaml');
+  const doc = yaml.load(fs.readFileSync(file, 'utf8'));
+  for (const f of ALL_16_FORMS) {
+    const id = `starter_bioma_${f.toLowerCase()}`;
+    assert.ok(doc.traits[id], `${id} defined in active_effects.yaml`);
+    assert.equal(doc.traits[id].tier, 'T1');
+    assert.equal(doc.traits[id].effect.kind, 'extra_damage');
+    assert.equal(doc.traits[id].effect.amount, 1);
+    assert.equal(doc.traits[id].provenance.form_id, f);
+  }
+});
+
+test('all 16 starter_bioma trait ids cross-referenced in glossary.json', () => {
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const file = path.join(process.cwd(), 'data', 'core', 'traits', 'glossary.json');
+  const doc = JSON.parse(fs.readFileSync(file, 'utf8'));
+  for (const f of ALL_16_FORMS) {
+    const id = `starter_bioma_${f.toLowerCase()}`;
+    assert.ok(doc.traits[id], `${id} present in glossary`);
+    assert.ok(doc.traits[id].label_it, `${id} label_it`);
+    assert.ok(doc.traits[id].label_en, `${id} label_en`);
+    assert.ok(doc.traits[id].description_it, `${id} description_it`);
+    assert.ok(doc.traits[id].description_en, `${id} description_en`);
+  }
+});
+
+test('all 16 starter_bioma biome_ids exist in data/core/biomes.yaml', () => {
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const yaml = require('js-yaml');
+  const file = path.join(process.cwd(), 'data', 'core', 'biomes.yaml');
+  const doc = yaml.load(fs.readFileSync(file, 'utf8'));
+  const biomes = doc.biomes || {};
+  for (const item of listStarterBiomas()) {
+    assert.ok(biomes[item.biome_id], `biome ${item.biome_id} (${item.form_id}) exists`);
   }
 });

--- a/tests/api/formPackRoutes.test.js
+++ b/tests/api/formPackRoutes.test.js
@@ -45,3 +45,65 @@ test('POST /api/forms/INTJ/recommend: no d20 → static recommendation', async (
   assert.equal(res.body.type, 'static_form_recommendation');
   assert.equal(res.body.form_packs.length, 3);
 });
+
+// ===========================================================================
+// QW2 / M-017: starter bioma route surface
+// ===========================================================================
+
+test('GET /api/forms/starter-biomas: returns 16 form -> bioma map', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const res = await request(app).get('/api/forms/starter-biomas');
+  assert.equal(res.status, 200);
+  assert.equal(res.body.count, 16);
+  assert.equal(res.body.items.length, 16);
+  const intj = res.body.items.find((x) => x.form_id === 'INTJ');
+  assert.ok(intj);
+  assert.equal(intj.trait_id, 'starter_bioma_intj');
+  assert.equal(intj.biome_id, 'rovine_planari');
+});
+
+test('GET /api/forms/INTJ/starter-bioma: resolves single form', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const res = await request(app).get('/api/forms/INTJ/starter-bioma');
+  assert.equal(res.status, 200);
+  assert.equal(res.body.form_id, 'INTJ');
+  assert.equal(res.body.trait_id, 'starter_bioma_intj');
+  assert.equal(res.body.biome_id, 'rovine_planari');
+});
+
+test('GET /api/forms/XXXX/starter-bioma: 404 for unknown form', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const res = await request(app).get('/api/forms/XXXX/starter-bioma');
+  assert.equal(res.status, 404);
+});
+
+test('GET /api/forms/INTJ/packs: payload includes starter_bioma resolved field', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const res = await request(app).get('/api/forms/INTJ/packs');
+  assert.equal(res.status, 200);
+  assert.ok(res.body.starter_bioma);
+  assert.equal(res.body.starter_bioma.trait_id, 'starter_bioma_intj');
+});
+
+test('POST /api/forms/INTJ/recommend: payload includes starter_bioma', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const res = await request(app).post('/api/forms/INTJ/recommend').send({ job_id: 'invoker' });
+  assert.equal(res.status, 200);
+  assert.ok(res.body.starter_bioma);
+  assert.equal(res.body.starter_bioma.biome_id, 'rovine_planari');
+});


### PR DESCRIPTION
## Summary

Chiude il gap **QW2 / M-017** documentato in `docs/museum/cards/worldgen-forme-mbti-as-evolutionary-seed.md`:
`form_pack_bias.yaml` referenzia lo slot `starter_bioma` ma nessun contenuto reale era definito —
il recommender citava il nome ma non lo risolveva.

Questa PR definisce 16 trait Tier 1 (uno per Form MBTI) e li wira nel `formPackRecommender`,
esponendoli via REST. **Nessuna integrazione UI** (follow-up PR).

## Cosa fa

- **16 trait `starter_bioma_<form_id>`** in `data/core/traits/active_effects.yaml`:
  - `tier: T1`, `applies_to: actor`
  - `effect.kind: extra_damage`, `amount: 1` (Tier 1 leggibile + non combat-breaking)
  - `trigger: { action_type: attack, on_result: hit, min_mos: 5 }` — fires solo su solid hit
  - `provenance.starter_biome` + `provenance.form_id` per future biome-aware logic
- **16 entry glossary.json** (label_it/en + description_it/en) coerenti
- **`formPackRecommender.js`** estende:
  - `STARTER_BIOMA_MAP` (16 form -> {biome_id, trait_id})
  - `resolveStarterBioma(formId)` / `listStarterBiomas()`
  - `getFormPacks()` + `recommendPacks()` ora restituiscono campo `starter_bioma`
- **Endpoint REST** in `routes/forms.js` (prima di `/:id` per evitare shadow):
  - `GET /api/forms/starter-biomas` -> `{count: 16, items: [...]}`
  - `GET /api/forms/:formId/starter-bioma` -> `{form_id, biome_id, trait_id}`
  - Disponibili anche su `/api/v1/forms/...` (mount duale via pluginLoader)

## Form -> bioma mapping

| Form | Biome (data/core/biomes.yaml) |
|------|-------------------------------|
| ISTJ | steppe_algoritmiche |
| ISFJ | foresta_temperata |
| INFJ | foresta_miceliale |
| INTJ | rovine_planari |
| ISTP | caverna |
| ISFP | reef_luminescente |
| INFP | foresta_acida |
| INTP | canyons_risonanti |
| ESTP | savana |
| ESFP | dorsale_termale_tropicale |
| ENFP | canopia_ionica |
| ENTP | atollo_obsidiana |
| ESTJ | badlands |
| ESFJ | pianura_salina_iperarida |
| ENFJ | palude |
| ENTJ | abisso_vulcanico |

Mapping derivato da archetype theme MBTI x biomi shipping (verificato: tutti 16 biomi presenti
in `data/core/biomes.yaml`, nessun duplicato).

## Test plan

- [x] `node --test tests/api/formPackRecommender.test.js` -> 27/27 verde
  - 12 esistenti + 15 nuovi (STARTER_BIOMA_MAP shape, resolve null/unknown,
    biome+trait id unicita', cross-check active_effects+glossary+biomes)
- [x] `node --test tests/api/formPackRoutes.test.js` -> 8/8 verde
  - 3 esistenti + 5 nuovi (list endpoint, single resolution, 404, payload includes starter_bioma)
- [x] `node --test tests/ai/*.test.js` -> 311/311 verde (zero regression)
- [x] `node --test tests/services/traitEffects.test.js` -> 21/21 verde
- [x] `npm run format:check` -> verde
- [x] Mojibake guard (`grep -c Ã`) = 0 su tutti i file modificati
- [x] `[trait-effects] 449 trait attivi caricati` (era 433, +16 atteso)

## Out of scope

- UI onboarding panel wire (`apps/play/src/onboardingPanel.js` -> `/api/forms/:formId/starter-bioma`)
- Biome-match conditional bonus (al momento `extra_damage` fires su qualsiasi solid hit;
  applicare il bonus solo quando `unit.biome === provenance.starter_biome` richiede nuova
  trigger logic in `traitEffects.js` -> follow-up PR)

## Files

- `data/core/traits/active_effects.yaml` (+332)
- `data/core/traits/glossary.json` (+96)
- `apps/backend/services/forms/formPackRecommender.js` (+66)
- `apps/backend/routes/forms.js` (+13)
- `apps/backend/routes/formPackRoutes.js` (+4 doc-only refactor)
- `tests/api/formPackRecommender.test.js` (+154)
- `tests/api/formPackRoutes.test.js` (+62)

Total: +727 LOC (additive).