### PR TITLE
feat(traits): echo_backstab active effect (first evo-swarm PR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,127 @@
+---
+title: CHANGELOG — Evo-Tactics
+doc_status: active
+doc_owner: platform-docs
+workstream: cross-cutting
+last_verified: 2026-04-25
+source_of_truth: true
+language: it-en
+review_cycle_days: 14
+---
+
+# 📜 CHANGELOG — Evo-Tactics
+
+> Format: [Keep-a-Changelog](https://keepachangelog.com/en/1.1.0/) + adattamento per milestone-based release model.
+> Source of truth per release notes user-visible. Per planning interno vedi [`docs/planning/changelog.md`](docs/planning/changelog.md). Per QA reports vedi [`docs/reports/qa-changelog.md`](docs/reports/qa-changelog.md).
+
+## [Unreleased]
+
+In flight (vedi [`BACKLOG.md`](BACKLOG.md) per stato dettagliato):
+
+- **TKT-M11B-06** — Playtest live ngrok 2-4 player (P5 🟢 gating)
+- **M14-A residual** — Resolver wire completion + facing system enhancements (~3-4h)
+- **M14-B** — Conviction + MBTI Scales upgrade (Triangle Strategy Mechanic 1+2, ~12h)
+- **M15** — Initiative CT bar + Class Promotion XCOM-style (TS Mechanic 6+7, ~15h)
+- **V6 UI polish** — Dashboard + visual identity post-playtest (~6h)
+
+---
+
+## [M14-A] — 2026-04-25
+
+### Added
+
+- **Coop hardening F-1/F-2/F-3** ([PR #1736](https://github.com/MasterDD-L34D/Game/pull/1736), commit `b7abfe39`)
+  - F-1: host transfer rebroadcast `phase_change` + `character_ready_list` post-promotion ([`apps/backend/services/network/wsSession.js:586`](apps/backend/services/network/wsSession.js))
+  - F-2: stuck-phase escape hatch `POST /api/coop/run/force-advance` host-only ([`apps/backend/routes/coop.js:206`](apps/backend/routes/coop.js) + `coopOrchestrator.js:269`)
+  - F-3: `submitCharacter` membership check con `player_not_in_room` error ([`apps/backend/services/coop/coopOrchestrator.js:115`](apps/backend/services/coop/coopOrchestrator.js))
+- **M14-A elevation + terrain reactions helpers** (PR #1736 partial)
+  - `elevationDamageMultiplier` in [`hexGrid.js:235`](apps/backend/services/grid/hexGrid.js) (delta>=1 → 1.30, delta<=-1 → 0.85)
+  - `terrainReactions.js` con `reactTile` (fire+ice→steam, fire+water→evaporate, lightning+water→electrified) + `chainElectrified` BFS cap 5
+  - `terrain_defense.yaml` attack_damage_bonus 0.30/-0.15
+  - Spec: [`docs/planning/2026-04-25-M14-A-elevation-terrain.md`](docs/planning/2026-04-25-M14-A-elevation-terrain.md)
+
+### Changed
+
+- **BACKLOG.md drift fix #3** (commit `4ee9e30f`, [PR #1820](https://github.com/MasterDD-L34D/Game/pull/1820)) — F-1/F-2/F-3/M14-A closures sincronizzate con stato reale del codice (helpers shipped + testati, resolver wire residuo ~3-4h non bloccante)
+
+### Notes
+
+- M14-A è marcato `[🟡] PARTIAL` in [`BACKLOG.md:72`](BACKLOG.md): pure helpers shipped, resolver wire (chiamata in damage step) residuo. Non blocca playtest TKT-M11B-06.
+
+---
+
+## [M13 P6] — 2026-04-25
+
+### Added
+
+- **Hardcore Timeout + Timer HUD** ([PR #1698](https://github.com/MasterDD-L34D/Game/pull/1698))
+  - HUD timer countdown
+  - Auto-timeout outcome in difficulty hardcore
+  - Spec: [`docs/adr/ADR-2026-04-24-p6-hardcore-timeout.md`](docs/adr/ADR-2026-04-24-p6-hardcore-timeout.md)
+
+---
+
+## [M13 P3] — 2026-04-25
+
+### Added
+
+- **Progression Engine + Perk UI** ([PR #1697](https://github.com/MasterDD-L34D/Game/pull/1697))
+  - XP grant hook in resolver
+  - 5 passive tags wired
+  - Progression panel UI overlay
+  - Spec: [`docs/adr/ADR-2026-04-24-p3-character-progression.md`](docs/adr/ADR-2026-04-24-p3-character-progression.md)
+- **Calibration harness** N=10 hardcore_07 (target win rate 30-50%)
+
+### Notes
+
+- Score totale post-merge: 500+ test (baseline pre-merge: 464+).
+
+---
+
+## [M12] — 2026-04-24
+
+### Added
+
+- **Form Evolution + Campaign** ([PR #1693](https://github.com/MasterDD-L34D/Game/pull/1693))
+  - Squad breeding at nest post-battle
+  - Trait inheritance da genitori
+  - Mutations generati da bioma
+  - Memoria tattica ereditata
+- **TKT-MUSEUM-SWARM-SKIV** ✅ closed (PR #1774, #1779) — magnetic_rift_resonance T2 trait
+
+### Reference
+
+- [`docs/core/27-MATING_NIDO.md`](docs/core/27-MATING_NIDO.md), [`data/core/mating.yaml`](data/core/mating.yaml)
+
+---
+
+## [M11] — 2026-04-21
+
+### Added
+
+- **Co-op NetCode Baseline** (M11 series, multiple PRs)
+  - WebSocket M11 Jackbox-style: in-memory Room store, 4-letter consonant codes, host-authoritative
+  - Reconnection token persistence
+  - 6-phase coop orchestrator: lobby → character_creation → world_setup → combat → debrief → ended
+  - Frontend `apps/play/src/network.js` LobbyClient con auto-reconnect exp backoff
+  - Lobby UI + character creation overlay + debrief panel
+
+### Reference
+
+- ADR networking: [`docs/adr/ADR-2026-04-16-networking-colyseus.md`](docs/adr/ADR-2026-04-16-networking-colyseus.md)
+- ADR coop scaling: [`docs/adr/ADR-2026-04-17-coop-scaling-4to8.md`](docs/adr/ADR-2026-04-17-coop-scaling-4to8.md)
+
+---
+
+## Pre-M11 history
+
+Sprint 001-020 + iniziale M0..M10 non documentati in questo file. Per archeologia vedi:
+
+- [`CLAUDE.md`](CLAUDE.md) §sprint-context per recap sprint chiusi
+- `git log --merges main` per tutti i PR mergiati
+- [`docs/adr/`](docs/adr/) per decisioni architetturali (20+ ADR datati)
+- [`docs/planning/EVO_FINAL_DESIGN_MASTER_ROADMAP.md`](docs/planning/EVO_FINAL_DESIGN_MASTER_ROADMAP.md) per vision di lungo periodo
+
+---
+
+_File vivo. Aggiornare ad ogni milestone closure (M\*) o release con `npm run play:build` distribuito a player. Update cadence: ogni PR che chiude un M-code o un ticket P0/P1 user-visible._

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Policy: prima di iniziare lavoro che supera 50 righe fuori `apps/backend/`, ferm
 - MUST RESEARCH_TODO **3/3 ✅** + SHOULD **4/4 ✅** — 2026-04-17
 - **Gioco giocabile ✅** — CLI (`node tools/js/play.js`) e browser 2D (`npm run play:dev`)
 - Frontend sprint α-ε merged: ability UI, animations, status icons, VC debrief, replay viewer, SFX synth
-- Pillar status attuale: P1/P3/P5 🟢 post-playtest · P2/P4/P6 🟡
+- Pillar status attuale (2026-04-25, da [`docs/PILLARS_STATUS.md`](docs/PILLARS_STATUS.md)): tutti 6 pilastri 🟡 post-playtest 2026-04-17 (revisione onesta, non regressione). FRICTION #1-#4 da chiudere prima del playtest #2.
 - Test totali: Python 196, Node AI 150+, VC 21, Encounter 8, Replay 20, Difficulty 23, i18n 4
 
 ## Licensing

--- a/agents/agents_index.json
+++ b/agents/agents_index.json
@@ -9,14 +9,14 @@
     "definition_file": "agents/lore-designer.md",
     "profile_file": ".ai/lore-designer/PROFILE.md",
     "stats": {
-      "level": 0,
-      "total_cycles": 6,
-      "accepted": 6,
+      "level": 1,
+      "total_cycles": 9,
+      "accepted": 9,
       "rejected": 0,
       "duplicate": 0,
       "security_alerts": 0,
-      "rolling_window": [7.5, 7.5, 7.5, 7.5, 7.5, 7.5],
-      "last_promoted_at": null,
+      "rolling_window": [7.5, 7.5, 7.5, 7.5, 7.5, 7.5, 7.5, 7.5, 7.5],
+      "last_promoted_at": "2026-04-25T21:16:40.735327",
       "last_demoted_at": null
     }
   },
@@ -24,6 +24,22 @@
     "description": "Gestisce stats, costi e bilanciamento numerico (incl. effetti di biomi) senza cambiare la narrativa; coordina con lore-designer/trait-curator quando necessario.",
     "definition_file": "agents/balancer.md",
     "profile_file": ".ai/balancer/PROFILE.md",
+    "stats": {
+      "level": 1,
+      "total_cycles": 8,
+      "accepted": 8,
+      "rejected": 0,
+      "duplicate": 0,
+      "security_alerts": 0,
+      "rolling_window": [7.5, 7.5, 7.5, 7.5, 7.5, 7.5, 7.5, 4.0],
+      "last_promoted_at": "2026-04-25T21:16:40.742893",
+      "last_demoted_at": null
+    }
+  },
+  "asset-prep": {
+    "description": "Gestisce pipeline asset (immagini, schede) per unità e biomi.",
+    "definition_file": "agents/asset-prep.md",
+    "profile_file": ".ai/asset-prep/PROFILE.md",
     "stats": {
       "level": 0,
       "total_cycles": 4,
@@ -36,34 +52,18 @@
       "last_demoted_at": null
     }
   },
-  "asset-prep": {
-    "description": "Gestisce pipeline asset (immagini, schede) per unità e biomi.",
-    "definition_file": "agents/asset-prep.md",
-    "profile_file": ".ai/asset-prep/PROFILE.md",
-    "stats": {
-      "level": 0,
-      "total_cycles": 1,
-      "accepted": 1,
-      "rejected": 0,
-      "duplicate": 0,
-      "security_alerts": 0,
-      "rolling_window": [7.5],
-      "last_promoted_at": null,
-      "last_demoted_at": null
-    }
-  },
   "archivist": {
     "description": "Organizza documentazione, indici e struttura file (specie, biomi, ecosistemi).",
     "definition_file": "agents/archivist.md",
     "profile_file": ".ai/archivist/PROFILE.md",
     "stats": {
       "level": 0,
-      "total_cycles": 2,
-      "accepted": 2,
+      "total_cycles": 5,
+      "accepted": 5,
       "rejected": 0,
       "duplicate": 0,
       "security_alerts": 0,
-      "rolling_window": [7.5, 7.5],
+      "rolling_window": [7.5, 7.5, 7.5, 7.5, 7.5],
       "last_promoted_at": null,
       "last_demoted_at": null
     }
@@ -74,12 +74,12 @@
     "profile_file": ".ai/dev-tooling/PROFILE.md",
     "stats": {
       "level": 0,
-      "total_cycles": 2,
-      "accepted": 2,
+      "total_cycles": 5,
+      "accepted": 5,
       "rejected": 0,
       "duplicate": 0,
       "security_alerts": 0,
-      "rolling_window": [7.5, 7.5],
+      "rolling_window": [7.5, 7.5, 7.5, 7.5, 7.5],
       "last_promoted_at": null,
       "last_demoted_at": null
     }
@@ -89,14 +89,14 @@
     "definition_file": "agents/trait-curator.md",
     "profile_file": ".ai/trait-curator/PROFILE.md",
     "stats": {
-      "level": 0,
-      "total_cycles": 3,
-      "accepted": 3,
+      "level": 1,
+      "total_cycles": 6,
+      "accepted": 6,
       "rejected": 0,
       "duplicate": 0,
       "security_alerts": 0,
-      "rolling_window": [7.5, 4.0, 7.5],
-      "last_promoted_at": null,
+      "rolling_window": [7.5, 4.0, 7.5, 7.5, 7.5, 7.5],
+      "last_promoted_at": "2026-04-25T21:35:07.754852",
       "last_demoted_at": null
     }
   },
@@ -105,14 +105,14 @@
     "definition_file": "agents/species-curator.md",
     "profile_file": ".ai/species-curator/PROFILE.md",
     "stats": {
-      "level": 0,
-      "total_cycles": 3,
-      "accepted": 3,
+      "level": 1,
+      "total_cycles": 6,
+      "accepted": 6,
       "rejected": 0,
       "duplicate": 0,
       "security_alerts": 0,
-      "rolling_window": [7.5, 7.5, 7.5],
-      "last_promoted_at": null,
+      "rolling_window": [7.5, 7.5, 7.5, 7.5, 7.5, 7.5],
+      "last_promoted_at": "2026-04-25T21:35:07.763771",
       "last_demoted_at": null
     }
   },
@@ -122,12 +122,12 @@
     "profile_file": ".ai/biome-ecosystem-curator/PROFILE.md",
     "stats": {
       "level": 0,
-      "total_cycles": 3,
-      "accepted": 3,
+      "total_cycles": 5,
+      "accepted": 5,
       "rejected": 0,
       "duplicate": 0,
       "security_alerts": 0,
-      "rolling_window": [7.5, 7.5, 7.5],
+      "rolling_window": [7.5, 7.5, 7.5, 7.5, 7.5],
       "last_promoted_at": null,
       "last_demoted_at": null
     }
@@ -140,12 +140,12 @@
     "created_at": "2026-04-23T23:43:49.876209",
     "stats": {
       "level": 0,
-      "total_cycles": 0,
-      "accepted": 0,
+      "total_cycles": 3,
+      "accepted": 3,
       "rejected": 0,
       "duplicate": 0,
       "security_alerts": 0,
-      "rolling_window": [],
+      "rolling_window": [7.5, 7.5, 7.5],
       "last_promoted_at": null,
       "last_demoted_at": null
     }
@@ -158,12 +158,12 @@
     "created_at": "2026-04-23T23:43:49.941092",
     "stats": {
       "level": 0,
-      "total_cycles": 0,
-      "accepted": 0,
+      "total_cycles": 2,
+      "accepted": 2,
       "rejected": 0,
       "duplicate": 0,
       "security_alerts": 0,
-      "rolling_window": [],
+      "rolling_window": [7.5, 7.5],
       "last_promoted_at": null,
       "last_demoted_at": null
     }

--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -26,6 +26,8 @@ const { createRewardsRouter } = require('./routes/rewards');
 const { createFormPackRouter } = require('./routes/formPackRoutes');
 const { createLobbyRouter } = require('./routes/lobby');
 const { createCoopRouter } = require('./routes/coop');
+// CAP-12 (audit Impronta CAP-10) — personal-telemetry cross-run
+const { createPlayerTelemetryRouter } = require('./routes/playerTelemetry');
 // Skiv ticket #7 — unit diary persistence (cross-session memoria)
 const { createDiaryRouter } = require('./routes/diary');
 const { createCoopStore } = require('./services/coop/coopStore');
@@ -760,6 +762,10 @@ function createApp(options = {}) {
   // M17 — Co-op run orchestrator (character creation + world setup + debrief).
   const coopStore = createCoopStore({ lobby });
   app.use('/api', createCoopRouter({ lobby, coopStore }));
+
+  // CAP-12 (audit Impronta CAP-10) — personal telemetry endpoint
+  // POST /api/v1/player/:playerId/telemetry · GET /api/v1/player/:id/telemetry · GET /api/v1/run/:runId/telemetry
+  app.use('/api/v1', createPlayerTelemetryRouter());
 
   // Skiv ticket #7 — unit diary persistence MVP (backend-only, JSONL append).
   app.use('/api', createDiaryRouter(options.diary || {}));

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -244,6 +244,28 @@ model UnitProgression {
   @@map("unit_progressions")
 }
 
+// ─── L'Impronta v2 / CAP-12 — PlayerRunTelemetry persistence ──────────────
+// Personal-telemetry cross-run per player (audit Impronta CAP-10 F-4).
+// Riusa vcScoring.buildVcSnapshot output (26 raw_metrics + 4 MBTI axes + ennea).
+// MVP write-on-end-of-run; future: round-aware via TKT-MUSEUM-ENNEA-WIRE (P1).
+
+model PlayerRunTelemetry {
+  id           String   @id @default(uuid())
+  playerId     String   @map("player_id") // logical player owner (cross-run)
+  unitId       String   @map("unit_id")   // creature this run
+  campaignId   String?  @map("campaign_id")
+  runId        String   @map("run_id")    // session_id or campaign run uuid
+  vcSnapshot   String   @map("vc_snapshot") // JSON: { per_actor: {...}, meta: {...} }
+  selectedForm String?  @map("selected_form") // initial MBTI 16-card pick (e.g. "intj_stratega")
+  outcome      String?  // 'victory' | 'defeat' | 'abandon' | null
+  createdAt    DateTime @default(now()) @map("created_at")
+
+  @@index([playerId])
+  @@index([campaignId])
+  @@index([runId])
+  @@map("player_run_telemetry")
+}
+
 // ─── M12 Phase D Form evolution persistence (ADR-2026-04-23 addendum) ─────
 // Promotes formSessionStore in-memory Map → DB-backed write-through cache.
 // Adapter preserves in-memory fallback when DATABASE_URL unset (dev/demo/tests).

--- a/apps/backend/routes/campaign.js
+++ b/apps/backend/routes/campaign.js
@@ -31,8 +31,16 @@ const {
   getEncountersForAct,
   resolveBranch,
   getOnboarding,
+  getOnboardingV2,
   resolveOnboardingTrait,
 } = require('../services/campaign/campaignLoader');
+const {
+  resolveBiome,
+  VALID_LOCOMOTION,
+  VALID_OFFENSE,
+  VALID_DEFENSE,
+  VALID_SENSES,
+} = require('../services/imprint/biomeResolver');
 const { summariseCampaign } = require('../services/campaign/campaignEngine');
 const { grantXpToSurvivors } = require('../services/progression/progressionApply');
 const { loadXpCurve } = require('../services/progression/progressionLoader');
@@ -102,6 +110,117 @@ function createCampaignRouter(options = {}) {
         narrative_hook: defDoc.narrative_hook,
         total_acts: defDoc.total_acts,
         onboarding: onboarding || null, // V1: UI consumer picker
+      },
+    });
+  });
+
+  // ─── L'Impronta v2 (CAP-14) — 4 player parallel choices su body parts ───
+  //
+  // POST /api/campaign/start/v2
+  // Body: {
+  //   players: [<playerId1>, <playerId2>, <playerId3>, <playerId4>], // 4 players
+  //   campaign_def_id?: string,                                       // default 'default_campaign_mvp'
+  //   choices: {
+  //     p1: { locomotion: 'VELOCE'|'SILENZIOSA' },
+  //     p2: { offense: 'PROFONDA'|'RAPIDA' },
+  //     p3: { defense: 'DURA'|'FLESSIBILE' },
+  //     p4: { senses: 'LONTANO'|'ACUTO' }
+  //   }
+  // }
+  //
+  // Aggregato per biomeResolver: 4-tuple choices flatten → biome_id + base_biome_id + applied_modulations.
+  // Ritorna campaign object + biome resolution + next_encounter.
+  router.post('/campaign/start/v2', (req, res) => {
+    const { players, campaign_def_id, choices } = req.body || {};
+
+    // Validation: 4 players required
+    if (
+      !Array.isArray(players) ||
+      players.length !== 4 ||
+      !players.every((p) => typeof p === 'string' && p.trim())
+    ) {
+      return res.status(400).json({ error: 'players richiesto (array di 4 string non vuoti)' });
+    }
+    if (!choices || typeof choices !== 'object') {
+      return res.status(400).json({ error: 'choices richiesto (object {p1, p2, p3, p4})' });
+    }
+
+    // Validation: 4 axes required
+    const aggregated = {};
+    const axisExpected = { p1: 'locomotion', p2: 'offense', p3: 'defense', p4: 'senses' };
+    const validators = {
+      locomotion: VALID_LOCOMOTION,
+      offense: VALID_OFFENSE,
+      defense: VALID_DEFENSE,
+      senses: VALID_SENSES,
+    };
+    for (const [slot, axis] of Object.entries(axisExpected)) {
+      const slotChoice = choices[slot];
+      if (!slotChoice || typeof slotChoice !== 'object') {
+        return res.status(400).json({ error: `choices.${slot} richiesto (con ${axis})` });
+      }
+      const value = String(slotChoice[axis] || '').toUpperCase();
+      if (!validators[axis].has(value)) {
+        return res.status(400).json({
+          error: `choices.${slot}.${axis} non valido: "${slotChoice[axis]}". Atteso: ${[...validators[axis]].join('|')}`,
+        });
+      }
+      aggregated[axis] = value;
+    }
+
+    // Load campaign def + check onboarding_v2
+    const defId = campaign_def_id || 'default_campaign_mvp';
+    const defDoc = loadCampaignDef(defId);
+    if (!defDoc) {
+      return res.status(404).json({ error: `campaign def "${defId}" non trovato` });
+    }
+    const onboardingV2 = getOnboardingV2(defDoc);
+    if (!onboardingV2) {
+      return res.status(404).json({
+        error: `campaign def "${defId}" non ha onboarding_v2 (use /api/campaign/start V1 per legacy)`,
+      });
+    }
+
+    // Resolve biome via biomeResolver (CAP-11). Team composition = 4 player choices flatten.
+    const teamComposition = [
+      { ...aggregated, ...{ [axisExpected.p1]: aggregated.locomotion } },
+      { ...aggregated, ...{ [axisExpected.p2]: aggregated.offense } },
+      { ...aggregated, ...{ [axisExpected.p3]: aggregated.defense } },
+      { ...aggregated, ...{ [axisExpected.p4]: aggregated.senses } },
+    ];
+    const biomeResult = resolveBiome(aggregated, { team_composition: teamComposition });
+
+    // Create campaign with first player as primary owner (campaign-level concept).
+    // Other 3 players associated via lobby/coop layer (out-of-scope V2 backend).
+    const primaryPlayer = players[0];
+    const campaign = createCampaign(primaryPlayer, defId, {
+      onboardingChoice: { mode: 'imprint_v2', choices: aggregated },
+      acquiredTraits: [],
+    });
+
+    const firstAct = defDoc.acts[0];
+    const firstEnc = (firstAct?.encounters || []).find((e) => !e.is_choice_node);
+    const transitionLine = (onboardingV2.transition?.line_template || '').replace(
+      '{biome_name}',
+      biomeResult.biome_id,
+    );
+
+    return res.status(201).json({
+      campaign,
+      players,
+      choices: aggregated,
+      biome: {
+        biome_id: biomeResult.biome_id,
+        base_biome_id: biomeResult.base_biome_id,
+        applied_modulations: biomeResult.applied_modulations,
+      },
+      next_encounter_id: firstEnc?.encounter_id || null,
+      transition_line: transitionLine,
+      campaign_def: {
+        name: defDoc.name,
+        narrative_hook: defDoc.narrative_hook,
+        total_acts: defDoc.total_acts,
+        onboarding_v2: onboardingV2,
       },
     });
   });

--- a/apps/backend/routes/playerTelemetry.js
+++ b/apps/backend/routes/playerTelemetry.js
@@ -1,0 +1,70 @@
+// Player telemetry router — POST/GET REST endpoint per PlayerRunTelemetry.
+//
+// Genesis: CAP-12 (audit Impronta CAP-10 F-4).
+// Mounted at /api/v1 (vedi app.js). Endpoint:
+//   POST /api/v1/player/:playerId/telemetry
+//   GET  /api/v1/player/:playerId/telemetry?limit=20
+//   GET  /api/v1/run/:runId/telemetry
+
+'use strict';
+
+const express = require('express');
+const store = require('../services/telemetry/playerRunTelemetryStore');
+
+function createPlayerTelemetryRouter() {
+  const router = express.Router();
+
+  // POST /api/v1/player/:playerId/telemetry
+  // Body: { unitId, runId, campaignId?, vcSnapshot, selectedForm?, outcome? }
+  router.post('/player/:playerId/telemetry', async (req, res) => {
+    try {
+      const playerId = String(req.params.playerId || '').trim();
+      if (!playerId) return res.status(400).json({ error: 'playerId path param required' });
+
+      const body = req.body || {};
+      const row = await store.create({
+        playerId,
+        unitId: body.unitId || body.unit_id,
+        runId: body.runId || body.run_id,
+        campaignId: body.campaignId || body.campaign_id || null,
+        vcSnapshot: body.vcSnapshot || body.vc_snapshot,
+        selectedForm: body.selectedForm || body.selected_form || null,
+        outcome: body.outcome || null,
+      });
+      res.status(201).json({ ok: true, row });
+    } catch (err) {
+      const msg = err && err.message ? err.message : 'unknown error';
+      const status = msg.includes('required') || msg.includes('invalid') ? 400 : 500;
+      res.status(status).json({ ok: false, error: msg });
+    }
+  });
+
+  // GET /api/v1/player/:playerId/telemetry?limit=20
+  router.get('/player/:playerId/telemetry', async (req, res) => {
+    try {
+      const playerId = String(req.params.playerId || '').trim();
+      if (!playerId) return res.status(400).json({ error: 'playerId path param required' });
+      const limit = Number(req.query.limit) || 20;
+      const rows = await store.listByPlayer(playerId, limit);
+      res.json({ ok: true, count: rows.length, rows });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  // GET /api/v1/run/:runId/telemetry
+  router.get('/run/:runId/telemetry', async (req, res) => {
+    try {
+      const runId = String(req.params.runId || '').trim();
+      if (!runId) return res.status(400).json({ error: 'runId path param required' });
+      const rows = await store.listByRun(runId);
+      res.json({ ok: true, count: rows.length, rows });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  return router;
+}
+
+module.exports = { createPlayerTelemetryRouter };

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -993,6 +993,14 @@ function createSessionRouter(options = {}) {
         // Lista {x, y, damage, type}. Applicato a fine turno via
         // applyHazardDamage in handleTurnEndViaRound.
         hazard_tiles: Array.isArray(req.body?.hazard_tiles) ? req.body.hazard_tiles : [],
+        // M14-A CAP-07 (2026-04-25) — Triangle Strategy Mechanic 4 terrain reactions.
+        // Map<"x,y" string, {type, ttl, source_actor}> — dinamica, mutated da
+        // bridge applyTerrainReaction (services/combat/terrainReactionsBridge.js)
+        // quando ability con channel elementale colpisce un tile. TTL decay in
+        // applyEndOfRoundSideEffects (sessionRoundBridge). Cartesian keys per
+        // consistency con session.units[].position {x,y}; conversion ad axial
+        // (q,r) avviene solo dentro chainElectrified BFS via neighbors function.
+        tileStateMap: {},
         // Q-001 T2.3: difficulty profile scaling metadata (null se profile invalid)
         _difficultyProfile: difficultyProfileMeta,
         // ADR-2026-04-19 + 04-20: encounter payload per reinforcementSpawner + objectiveEvaluator.

--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -22,6 +22,7 @@ const {
 const { DEFAULT_ATTACK_RANGE } = require('../services/ai/policy');
 const { buildAtlasLive } = require('../services/atlasLive');
 const { applicableSynergies } = require('../services/combat/synergyDetector');
+const { elevationDamageMultiplier } = require('../services/grid/hexGrid');
 
 function rollD20(rng) {
   return Math.floor(rng() * 20) + 1;
@@ -441,9 +442,15 @@ function computePositionalDamage({
   const tElev = Number.isFinite(Number(target?.elevation)) ? Number(target.elevation) : 0;
   const delta = aElev - tElev;
 
-  let elevMul = 1;
-  if (delta >= 1) elevMul = 1 + elevationBonus;
-  else if (delta <= -1) elevMul = 1 + elevationPenalty;
+  // Single-source-of-truth: chiamata al helper canonico (CAP-06 refactor M14-A,
+  // archive/2026-04-aa01-001-2026-04-25-cap-06-m14a-elevation-refacto).
+  // Pre-refactor questa funzione duplicava inline la logica delta>=1 / delta<=-1.
+  const elevMul = elevationDamageMultiplier({
+    attackerElevation: aElev,
+    targetElevation: tElev,
+    bonus: elevationBonus,
+    penalty: elevationPenalty,
+  });
   let flankMul = 1;
   if (quadrant === 'flank') flankMul = 1 + flankBonus;
   let rearMul = 1;

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -41,6 +41,7 @@ const {
 const { tick: reinforcementTick } = require('../services/combat/reinforcementSpawner');
 const { evaluateObjective } = require('../services/combat/objectiveEvaluator');
 const { tick: missionTimerTick } = require('../services/combat/missionTimer');
+const { decayTileStates } = require('../services/combat/terrainReactionsBridge');
 const { buildThreatPreview } = require('../services/ai/threatPreview');
 
 function createRoundBridge(deps) {
@@ -654,6 +655,11 @@ function createRoundBridge(deps) {
         }
       }
     }
+
+    // M14-A CAP-07 (2026-04-25) — Triangle Strategy Mechanic 4 terrain reactions.
+    // TTL decay per ogni tile in session.tileStateMap. Tile rimossi quando ttl <= 0.
+    // Bridge: services/combat/terrainReactionsBridge.js#decayTileStates.
+    decayTileStates(session);
 
     return { hazardEvents, bleedingEvents };
   }

--- a/apps/backend/services/campaign/campaignLoader.js
+++ b/apps/backend/services/campaign/campaignLoader.js
@@ -190,6 +190,20 @@ function resolveOnboardingTrait(campaign, optionKey) {
 }
 
 /**
+ * L'Impronta v2 (CAP-14, post-mockup CAP-13).
+ * Returns { schema_version, enabled, axes[], default_choices, ... } if present.
+ * V2 = 4 player parallel choices su body parts (locomotion/offense/defense/senses).
+ * Distinto da V1 (1 trait per branco). Backward-compat: legacy campaigns senza
+ * onboarding_v2 ritornano null → V2 endpoint risponde 404.
+ */
+function getOnboardingV2(campaign) {
+  if (!campaign || typeof campaign !== 'object') return null;
+  const ob = campaign.onboarding_v2 || null;
+  if (!ob || ob.enabled === false) return null;
+  return ob;
+}
+
+/**
  * Extract all encounter IDs referenced (for integrity check vs YAML scenarios).
  */
 function extractAllEncounterIds(campaign) {
@@ -213,6 +227,7 @@ module.exports = {
   getEncountersForAct,
   resolveBranch,
   getOnboarding,
+  getOnboardingV2,
   resolveOnboardingTrait,
   extractAllEncounterIds,
   _resetCache,

--- a/apps/backend/services/combat/terrainReactionsBridge.js
+++ b/apps/backend/services/combat/terrainReactionsBridge.js
@@ -1,0 +1,161 @@
+// M14-A CAP-07 (2026-04-25) — Bridge cartesian session state ↔ pure terrain reactions.
+//
+// Why this file exists:
+//   `services/combat/terrainReactions.js` espone `reactTile` + `chainElectrified`
+//   come **pure helpers stateless** che assumono coordinate hex axial {q, r}.
+//   La session usa coordinate cartesiane Manhattan {x, y} (vedi session.units[].position).
+//   Cablare direttamente i pure helpers nel damage step richiederebbe coordinate refactor.
+//
+// Soluzione MVP (low-risk, scope-contained):
+//   Bridge function che tratta {x, y} come opaque hex shape (q→x, r→y mapping).
+//   Per chainElectrified, passo Manhattan-style 4-neighbors invece di hex 6-neighbors.
+//   Funzionalmente equivalente per scope BFS (cap maxDepth=5); semanticamente
+//   non-hex ma corretto per la session corrente.
+//
+// Out of scope CAP-07:
+//   - NON cabliamo questo bridge nel damage step di abilityExecutor (richiede
+//     decisione design su `ability.channel` field, attualmente assente in jobs.yaml).
+//   - NON convertiamo session in axial coords (refactor architetturale separato).
+//
+// Quando questo bridge diventa obsoleto:
+//   Quando ability schema avrà `channel: fire|ice|water|lightning` e session userà
+//   axial coords (q,r), questo bridge si riduce a chiamata diretta dei pure helpers.
+
+'use strict';
+
+const { reactTile, chainElectrified } = require('./terrainReactions');
+
+const DEFAULT_BASE_TTL = 3;
+const DEFAULT_CHAIN_MAX_DEPTH = 5;
+const VALID_ELEMENTS = new Set(['fire', 'ice', 'water', 'lightning']);
+
+/**
+ * Convert {x, y} cartesian position to a stable string key for tileStateMap.
+ * Matches the format used elsewhere in session (e.g. hazard_tiles consumers).
+ */
+function tileKey(x, y) {
+  return `${Number(x) | 0},${Number(y) | 0}`;
+}
+
+/**
+ * 4-connected Manhattan neighbors. Used as `hexNeighborsFn` for chainElectrified
+ * over cartesian-keyed tileStateMap. Returns objects shaped as {q, r} solely for
+ * shape compatibility with chainElectrified's hexKeyFn output (q→x alias, r→y alias).
+ */
+function cartesianNeighbors(hex) {
+  const x = hex.q;
+  const y = hex.r;
+  return [
+    { q: x + 1, r: y },
+    { q: x - 1, r: y },
+    { q: x, r: y + 1 },
+    { q: x, r: y - 1 },
+  ];
+}
+
+/**
+ * Apply an elemental incoming effect to the tile at (x, y) in the given session.
+ * Mutates `session.tileStateMap` in place; never throws on invalid input
+ * (returns a no-op result instead, so callers from damage step do not need
+ * defensive guards).
+ *
+ * @param {object} session — must own `tileStateMap` object (bootstrapped in /start handler)
+ * @param {number} x — cartesian column
+ * @param {number} y — cartesian row
+ * @param {string} element — one of: fire, ice, water, lightning
+ * @param {object} [opts]
+ * @param {string} [opts.actorId] — id of unit that caused the reaction
+ * @param {number} [opts.baseTtl=3] — initial ttl applied when creating new tile state
+ * @returns {{ applied: boolean, tileKey: string, prevState: object|null, nextState: object, burstDamage: number, effects: string[], chain: { electrified: object[], chainDamage: number }|null }}
+ */
+function applyTerrainReaction(session, x, y, element, opts = {}) {
+  const result = {
+    applied: false,
+    tileKey: tileKey(x, y),
+    prevState: null,
+    nextState: { type: 'normal', ttl: 0 },
+    burstDamage: 0,
+    effects: [],
+    chain: null,
+  };
+
+  if (!session || typeof session !== 'object') return result;
+  if (!session.tileStateMap || typeof session.tileStateMap !== 'object') return result;
+  if (!VALID_ELEMENTS.has(element)) return result;
+
+  const key = result.tileKey;
+  const prev = session.tileStateMap[key] || null;
+  result.prevState = prev;
+
+  const reaction = reactTile(prev, {
+    element,
+    actor_id: opts.actorId || null,
+    baseTtl: Number.isFinite(Number(opts.baseTtl)) ? Number(opts.baseTtl) : DEFAULT_BASE_TTL,
+  });
+
+  // Persist nextState. If reaction nullifies the tile (type=normal ttl=0) we
+  // delete the key to keep the map sparse; otherwise we write the new state.
+  if (reaction.nextState && reaction.nextState.type !== 'normal') {
+    session.tileStateMap[key] = { ...reaction.nextState };
+  } else if (prev) {
+    delete session.tileStateMap[key];
+  }
+
+  result.applied = true;
+  result.nextState = reaction.nextState;
+  result.burstDamage = Number(reaction.burstDamage) || 0;
+  result.effects = Array.isArray(reaction.effects) ? reaction.effects.slice() : [];
+
+  // Chain trigger: lightning + water → electrified BFS over neighbors.
+  if (result.effects.includes('chain_trigger')) {
+    const chain = chainElectrified(
+      { q: Number(x) | 0, r: Number(y) | 0 },
+      session.tileStateMap,
+      (h) => tileKey(h.q, h.r),
+      cartesianNeighbors,
+      { maxDepth: DEFAULT_CHAIN_MAX_DEPTH },
+    );
+    result.chain = chain;
+  }
+
+  return result;
+}
+
+/**
+ * End-of-round TTL decay. Decrements ttl on every tile state and removes
+ * entries with ttl <= 0. Called from sessionRoundBridge.applyEndOfRoundSideEffects.
+ *
+ * @param {object} session
+ * @returns {{ decayed: number, removed: number }}
+ */
+function decayTileStates(session) {
+  const stats = { decayed: 0, removed: 0 };
+  if (!session || !session.tileStateMap || typeof session.tileStateMap !== 'object') {
+    return stats;
+  }
+  for (const key of Object.keys(session.tileStateMap)) {
+    const tile = session.tileStateMap[key];
+    if (!tile || typeof tile !== 'object') {
+      delete session.tileStateMap[key];
+      stats.removed += 1;
+      continue;
+    }
+    const ttl = Number(tile.ttl);
+    if (!Number.isFinite(ttl) || ttl <= 1) {
+      delete session.tileStateMap[key];
+      stats.removed += 1;
+    } else {
+      tile.ttl = ttl - 1;
+      stats.decayed += 1;
+    }
+  }
+  return stats;
+}
+
+module.exports = {
+  applyTerrainReaction,
+  decayTileStates,
+  tileKey,
+  cartesianNeighbors,
+  VALID_ELEMENTS,
+};

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -4,7 +4,20 @@
 
 'use strict';
 
-const PHASES = ['lobby', 'character_creation', 'world_setup', 'combat', 'debrief', 'ended'];
+// V1 flow: lobby → character_creation → world_setup → combat → debrief → ended
+// V2 flow: lobby → imprint → combat → debrief → ended (CAP-15, audit Impronta v2)
+const PHASES = [
+  'lobby',
+  'character_creation',
+  'world_setup',
+  'imprint', // CAP-15: fonde character_creation + world_setup in unica fase
+  'combat',
+  'debrief',
+  'ended',
+];
+
+// Schema body parts axes per V2 (validation upstream usa biomeResolver VALID_*)
+const IMPRINT_AXES = ['locomotion', 'offense', 'defense', 'senses'];
 
 /**
  * Build a unit payload for /session/start from a coop character spec.
@@ -36,10 +49,14 @@ class CoopOrchestrator {
     this.hostId = hostId || null;
     this.now = now;
     this.phase = 'lobby';
-    this.run = null; // populated by startRun()
-    this.characters = new Map(); // player_id → character spec
-    this.worldVotes = new Map(); // player_id → scenario_id|null
+    this.run = null; // populated by startRun() / startImprint()
+    this.characters = new Map(); // player_id → character spec (V1)
+    this.worldVotes = new Map(); // player_id → scenario_id|null (V1)
     this.debriefChoices = new Map();
+    // CAP-15 (V2 flow): imprintChoices map player_id → { axis, value }
+    // axis ∈ IMPRINT_AXES, value validato upstream con biomeResolver VALID_*
+    this.imprintChoices = new Map();
+    this.imprintBiome = null; // populated quando 4 scelte fatte
     this.log = [];
     this._listeners = new Set();
   }
@@ -163,6 +180,129 @@ class CoopOrchestrator {
     this._emit('world_confirmed', { scenario_id: sid });
     this._setPhase('combat');
     return { scenario_id: sid };
+  }
+
+  // ─── CAP-15 — L'Impronta v2 phase: lobby → imprint → combat ───────
+  //
+  // V2 flow fonde character_creation + world_setup in singola fase 'imprint'.
+  // 4 player parallel choice su body parts (1 axis ciascuno):
+  //   p1=locomotion, p2=offense, p3=defense, p4=senses.
+  // Auto-advance a 'combat' quando 4 scelte fatte. Bioma resolution via
+  // biomeResolver (CAP-11) — applicata tramite getImprintBiomeResolution().
+
+  /**
+   * V2: Start a new run in imprint mode (CAP-15).
+   * Moves phase lobby/ended → imprint.
+   */
+  startImprint({ scenarioStack = ['enc_tutorial_01'] } = {}) {
+    if (this.phase !== 'lobby' && this.phase !== 'ended') {
+      throw new Error(`cannot_start_from_phase:${this.phase}`);
+    }
+    this.run = {
+      id: `run_${Date.now().toString(36)}`,
+      scenarioStack: Array.isArray(scenarioStack) ? scenarioStack : ['enc_tutorial_01'],
+      currentIndex: 0,
+      partyXp: 0,
+      partyPi: 0,
+      outcome: null,
+      mode: 'imprint_v2', // marker per consumers
+    };
+    this.characters.clear();
+    this.worldVotes.clear();
+    this.imprintChoices.clear();
+    this.imprintBiome = null;
+    this.debriefChoices.clear();
+    this._setPhase('imprint');
+    this._emit('run_started', { run_id: this.run.id, mode: 'imprint_v2' });
+    return this.run;
+  }
+
+  /**
+   * V2: submit imprint choice (body part axis) per player.
+   * Quando 4 player hanno tutti scelto, auto-advance a 'combat'.
+   *
+   * @param playerId
+   * @param choice — { axis: 'locomotion'|'offense'|'defense'|'senses', value: string }
+   * @param opts.allPlayerIds — set di player ids attesi (solitamente 4)
+   */
+  submitImprintChoice(playerId, choice, { allPlayerIds = [] } = {}) {
+    if (this.phase !== 'imprint') {
+      throw new Error('not_in_imprint');
+    }
+    if (!playerId) throw new Error('player_id_required');
+    if (!choice || typeof choice !== 'object') throw new Error('choice_invalid');
+    const axis = String(choice.axis || '').toLowerCase();
+    const value = String(choice.value || '').toUpperCase();
+    if (!IMPRINT_AXES.includes(axis)) {
+      throw new Error(`invalid_axis:${choice.axis}. Allowed: ${IMPRINT_AXES.join('|')}`);
+    }
+    if (!value) throw new Error('value_required');
+    // F-3-style: reject ghost client (player not in expected set)
+    if (allPlayerIds.length > 0 && !allPlayerIds.includes(playerId)) {
+      throw new Error('player_not_in_room');
+    }
+    const normalized = {
+      player_id: playerId,
+      axis,
+      value,
+      submitted_at: this.now(),
+    };
+    this.imprintChoices.set(playerId, normalized);
+    this._emit('imprint_choice', normalized);
+
+    // Auto-advance se tutti i player attesi hanno scelto
+    const expected = new Set(allPlayerIds.filter(Boolean));
+    if (expected.size > 0 && expected.size === this.imprintChoices.size) {
+      const allReady = Array.from(expected).every((pid) => this.imprintChoices.has(pid));
+      if (allReady) {
+        // Validate axes coverage: ogni axis dovrebbe essere stato scelto da un player
+        const axesSelected = new Set(Array.from(this.imprintChoices.values()).map((c) => c.axis));
+        const allAxesCovered = IMPRINT_AXES.every((a) => axesSelected.has(a));
+        if (allAxesCovered) {
+          this._setPhase('combat');
+          this._emit('imprint_complete', {
+            choices: this.getImprintChoicesAggregate(),
+          });
+        } else {
+          // Edge case: 4 player ma assi duplicati / mancanti — emit warning, no advance
+          this._emit('imprint_axes_incomplete', {
+            covered: [...axesSelected],
+            missing: IMPRINT_AXES.filter((a) => !axesSelected.has(a)),
+          });
+        }
+      }
+    }
+    return normalized;
+  }
+
+  /**
+   * V2: ready-state per imprint phase. Format analogo a characterReadyList.
+   */
+  imprintReadyList(allPlayerIds = []) {
+    return allPlayerIds.map((pid) => {
+      const c = this.imprintChoices.get(pid);
+      return {
+        player_id: pid,
+        axis: c?.axis || null,
+        value: c?.value || null,
+        ready: Boolean(c),
+      };
+    });
+  }
+
+  /**
+   * V2: aggregate choices come oggetto { locomotion, offense, defense, senses }.
+   * Usabile come input a biomeResolver.resolveBiome(aggregated).
+   * Ritorna null se 4 axes non ancora coperti.
+   */
+  getImprintChoicesAggregate() {
+    if (this.imprintChoices.size === 0) return null;
+    const aggregate = {};
+    for (const c of this.imprintChoices.values()) {
+      aggregate[c.axis] = c.value;
+    }
+    const allCovered = IMPRINT_AXES.every((a) => aggregate[a]);
+    return allCovered ? aggregate : null;
   }
 
   /**
@@ -307,4 +447,4 @@ class CoopOrchestrator {
   }
 }
 
-module.exports = { CoopOrchestrator, characterToUnit, PHASES };
+module.exports = { CoopOrchestrator, characterToUnit, PHASES, IMPRINT_AXES };

--- a/apps/backend/services/imprint/biomeResolver.js
+++ b/apps/backend/services/imprint/biomeResolver.js
@@ -1,0 +1,149 @@
+// Biome Resolver — 4-tuple body parts choice → biome_id (Pattern D hybrid).
+//
+// Genesis: CAP-11 (audit Impronta CAP-10).
+// Pattern: lookup base 16→7 biomi core + team-composition modulation
+// per ridurre canalizzazione (target <20% al bioma più popolato).
+//
+// API:
+//   resolveBiome(choices, opts) → { biome_id, base_biome_id, applied_modulations }
+//
+// Input choices: { locomotion, offense, defense, senses }
+//   locomotion: 'VELOCE' | 'SILENZIOSA'
+//   offense:    'PROFONDA' | 'RAPIDA'
+//   defense:    'DURA' | 'FLESSIBILE'
+//   senses:     'LONTANO' | 'ACUTO'
+//
+// Input opts.team_composition: array di choices, una per player (default: solo
+// la choices stessa duplicata 4 volte se MVP single-creature mode).
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const VALID_LOCOMOTION = new Set(['VELOCE', 'SILENZIOSA']);
+const VALID_OFFENSE = new Set(['PROFONDA', 'RAPIDA']);
+const VALID_DEFENSE = new Set(['DURA', 'FLESSIBILE']);
+const VALID_SENSES = new Set(['LONTANO', 'ACUTO']);
+
+let cachedConfig = null;
+
+function loadConfig(configPath) {
+  if (cachedConfig && !configPath) return cachedConfig;
+  const resolvedPath =
+    configPath ||
+    path.resolve(
+      __dirname,
+      '..',
+      '..',
+      '..',
+      '..',
+      'data',
+      'core',
+      'imprint',
+      'biome_resolution.yaml',
+    );
+  const raw = fs.readFileSync(resolvedPath, 'utf8');
+  const config = yaml.load(raw);
+  if (!configPath) cachedConfig = config;
+  return config;
+}
+
+function resetCache() {
+  cachedConfig = null;
+}
+
+function lookupKey(choices) {
+  const l = (choices.locomotion || '').toUpperCase();
+  const o = (choices.offense || '').toUpperCase();
+  const d = (choices.defense || '').toUpperCase();
+  const s = (choices.senses || '').toUpperCase();
+  if (!VALID_LOCOMOTION.has(l)) throw new Error(`invalid locomotion: ${choices.locomotion}`);
+  if (!VALID_OFFENSE.has(o)) throw new Error(`invalid offense: ${choices.offense}`);
+  if (!VALID_DEFENSE.has(d)) throw new Error(`invalid defense: ${choices.defense}`);
+  if (!VALID_SENSES.has(s)) throw new Error(`invalid senses: ${choices.senses}`);
+  // Codifica con prima lettera ciascuno: V/S, P/R, D/F, L/A
+  return `${l[0]}_${o[0]}_${d[0]}_${s[0]}`;
+}
+
+function evaluateModulation(rule, teamComposition) {
+  const trait = rule.condition.trait;
+  const value = rule.condition.value;
+  const minCount = Number(rule.condition.min_player_count) || 1;
+  const matched = teamComposition.filter((c) => (c[trait] || '').toUpperCase() === value).length;
+  return matched >= minCount;
+}
+
+/**
+ * Risolve biome da 4-tuple di scelte body parts + opzionale team composition.
+ *
+ * @param {Object} choices - { locomotion, offense, defense, senses }
+ * @param {Object} [opts]
+ * @param {Object[]} [opts.team_composition] - array di choices (1 per player). Se assente, modulation skipped.
+ * @param {string} [opts.config_path] - override YAML path (per test)
+ * @returns {{ biome_id, base_biome_id, applied_modulations: string[] }}
+ */
+function resolveBiome(choices, opts = {}) {
+  const config = loadConfig(opts.config_path);
+  const key = lookupKey(choices);
+  const baseBiome = config.base_lookup[key];
+  if (!baseBiome) {
+    return {
+      biome_id: config.fallback_biome,
+      base_biome_id: config.fallback_biome,
+      applied_modulations: [],
+      _fallback: true,
+    };
+  }
+
+  const team =
+    Array.isArray(opts.team_composition) && opts.team_composition.length > 0
+      ? opts.team_composition
+      : [choices, choices, choices, choices]; // default MVP: 4 player con stesse scelte
+
+  const applied = [];
+  let finalBiome = baseBiome;
+
+  if (Array.isArray(config.modulation)) {
+    for (const rule of config.modulation) {
+      if (evaluateModulation(rule, team)) {
+        const variant = rule.biome_variants && rule.biome_variants[finalBiome];
+        if (variant) {
+          finalBiome = variant;
+          applied.push(rule.rule_id);
+        }
+      }
+    }
+  }
+
+  return {
+    biome_id: finalBiome,
+    base_biome_id: baseBiome,
+    applied_modulations: applied,
+  };
+}
+
+/**
+ * Statistica della distribuzione lookup base. Usato per audit canalizzazione.
+ * @returns {{ [biome_id]: number }}
+ */
+function lookupDistribution(opts = {}) {
+  const config = loadConfig(opts.config_path);
+  const dist = {};
+  for (const biome of Object.values(config.base_lookup)) {
+    dist[biome] = (dist[biome] || 0) + 1;
+  }
+  return dist;
+}
+
+module.exports = {
+  resolveBiome,
+  lookupKey,
+  lookupDistribution,
+  resetCache,
+  VALID_LOCOMOTION,
+  VALID_OFFENSE,
+  VALID_DEFENSE,
+  VALID_SENSES,
+};

--- a/apps/backend/services/telemetry/playerRunTelemetryStore.js
+++ b/apps/backend/services/telemetry/playerRunTelemetryStore.js
@@ -1,0 +1,172 @@
+// PlayerRunTelemetry store — write-through Prisma + in-memory fallback.
+//
+// Genesis: CAP-12 (audit Impronta CAP-10 F-4). Personal telemetry cross-run.
+//
+// Pattern: same di FormSessionState/LobbySession (Prisma authoritative se
+// DATABASE_URL set, altrimenti in-memory Map). Graceful no-op se Prisma
+// non disponibile (dev/test).
+//
+// API:
+//   create({playerId, unitId, runId, vcSnapshot, ...}) → row
+//   listByPlayer(playerId, limit=20) → rows[]
+//   listByRun(runId) → rows[]
+
+'use strict';
+
+const memory = new Map(); // id → row
+let prismaClient = null;
+
+function tryLoadPrisma() {
+  if (prismaClient !== null) return prismaClient;
+  try {
+    if (!process.env.DATABASE_URL) {
+      prismaClient = false;
+      return false;
+    }
+    const { PrismaClient } = require('@prisma/client');
+    prismaClient = new PrismaClient();
+    return prismaClient;
+  } catch {
+    prismaClient = false;
+    return false;
+  }
+}
+
+function genId() {
+  // crypto.randomUUID disponibile da Node 16+
+  return require('crypto').randomUUID();
+}
+
+function normalizeInput(input) {
+  if (!input || typeof input !== 'object') {
+    throw new Error('invalid input');
+  }
+  const playerId = String(input.playerId || input.player_id || '').trim();
+  if (!playerId) throw new Error('playerId required');
+  const unitId = String(input.unitId || input.unit_id || '').trim();
+  if (!unitId) throw new Error('unitId required');
+  const runId = String(input.runId || input.run_id || '').trim();
+  if (!runId) throw new Error('runId required');
+  const campaignId = input.campaignId || input.campaign_id || null;
+  const vcSnapshot = input.vcSnapshot || input.vc_snapshot;
+  if (vcSnapshot === undefined || vcSnapshot === null) {
+    throw new Error('vcSnapshot required');
+  }
+  const vcSnapshotJson = typeof vcSnapshot === 'string' ? vcSnapshot : JSON.stringify(vcSnapshot);
+  const selectedForm = input.selectedForm || input.selected_form || null;
+  const outcome = input.outcome || null;
+  if (outcome && !['victory', 'defeat', 'abandon'].includes(outcome)) {
+    throw new Error(`invalid outcome: ${outcome}`);
+  }
+  return { playerId, unitId, runId, campaignId, vcSnapshotJson, selectedForm, outcome };
+}
+
+async function create(input) {
+  const data = normalizeInput(input);
+  const prisma = tryLoadPrisma();
+
+  if (prisma) {
+    const row = await prisma.playerRunTelemetry.create({
+      data: {
+        playerId: data.playerId,
+        unitId: data.unitId,
+        runId: data.runId,
+        campaignId: data.campaignId,
+        vcSnapshot: data.vcSnapshotJson,
+        selectedForm: data.selectedForm,
+        outcome: data.outcome,
+      },
+    });
+    return formatRow(row);
+  }
+
+  // In-memory fallback
+  const id = genId();
+  const row = {
+    id,
+    playerId: data.playerId,
+    unitId: data.unitId,
+    campaignId: data.campaignId,
+    runId: data.runId,
+    vcSnapshot: data.vcSnapshotJson,
+    selectedForm: data.selectedForm,
+    outcome: data.outcome,
+    createdAt: new Date().toISOString(),
+  };
+  memory.set(id, row);
+  return formatRow(row);
+}
+
+async function listByPlayer(playerId, limit = 20) {
+  const safeLimit = Math.max(1, Math.min(Number(limit) || 20, 100));
+  const prisma = tryLoadPrisma();
+
+  if (prisma) {
+    const rows = await prisma.playerRunTelemetry.findMany({
+      where: { playerId: String(playerId) },
+      orderBy: { createdAt: 'desc' },
+      take: safeLimit,
+    });
+    return rows.map(formatRow);
+  }
+
+  const rows = Array.from(memory.values())
+    .filter((r) => r.playerId === String(playerId))
+    .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
+    .slice(0, safeLimit);
+  return rows.map(formatRow);
+}
+
+async function listByRun(runId) {
+  const prisma = tryLoadPrisma();
+
+  if (prisma) {
+    const rows = await prisma.playerRunTelemetry.findMany({
+      where: { runId: String(runId) },
+      orderBy: { createdAt: 'asc' },
+    });
+    return rows.map(formatRow);
+  }
+
+  const rows = Array.from(memory.values())
+    .filter((r) => r.runId === String(runId))
+    .sort((a, b) => (a.createdAt < b.createdAt ? -1 : 1));
+  return rows.map(formatRow);
+}
+
+function formatRow(row) {
+  if (!row) return null;
+  let parsedSnapshot = null;
+  try {
+    parsedSnapshot =
+      typeof row.vcSnapshot === 'string' ? JSON.parse(row.vcSnapshot) : row.vcSnapshot;
+  } catch {
+    parsedSnapshot = null;
+  }
+  return {
+    id: row.id,
+    player_id: row.playerId,
+    unit_id: row.unitId,
+    campaign_id: row.campaignId,
+    run_id: row.runId,
+    vc_snapshot: parsedSnapshot,
+    selected_form: row.selectedForm,
+    outcome: row.outcome,
+    created_at:
+      typeof row.createdAt === 'string'
+        ? row.createdAt
+        : (row.createdAt && row.createdAt.toISOString && row.createdAt.toISOString()) || null,
+  };
+}
+
+function _resetForTests() {
+  memory.clear();
+  prismaClient = null;
+}
+
+module.exports = {
+  create,
+  listByPlayer,
+  listByRun,
+  _resetForTests,
+};

--- a/data/core/campaign/default_campaign_mvp.yaml
+++ b/data/core/campaign/default_campaign_mvp.yaml
@@ -62,6 +62,67 @@ onboarding:
 
   next_encounter: enc_tutorial_01 # Act 0 chapter 1 inception
 
+# ─── L'Impronta v2 (CAP-14, post-mockup CAP-13) ───────────────────────
+# 4 player parallel choice su body parts. Modello "4 creature 1 bioma"
+# (audit Impronta CAP-10). Bioma emerge da 4-tuple via biomeResolver (CAP-11).
+# Backward-compat: V1 (/api/campaign/start) resta invariato.
+# V2 attiva solo via /api/campaign/start/v2.
+
+onboarding_v2:
+  schema_version: '1.0'
+  enabled: true
+  timing_seconds: 60
+
+  briefing:
+    duration_seconds: 8
+    lines:
+      - 'Quattro di voi.'
+      - 'Quattro creature.'
+      - 'Un solo mondo da scoprire.'
+
+  axes:
+    - axis_id: locomotion
+      player_slot: p1
+      body_part: 'le tue zampe'
+      question: 'Veloci o silenziose?'
+      options:
+        - { value: VELOCE, label: 'VELOCE', desc: 'Movimento ampio, hit-and-run' }
+        - { value: SILENZIOSA, label: 'SILENZIOSA', desc: 'Stealth, ambush' }
+    - axis_id: offense
+      player_slot: p2
+      body_part: 'la tua mascella'
+      question: 'Profonda o rapida?'
+      options:
+        - { value: PROFONDA, label: 'PROFONDA', desc: 'Singolo morso devastante' }
+        - { value: RAPIDA, label: 'RAPIDA', desc: 'Attacchi multipli, bleeding' }
+    - axis_id: defense
+      player_slot: p3
+      body_part: 'la tua pelle'
+      question: 'Dura o flessibile?'
+      options:
+        - { value: DURA, label: 'DURA', desc: 'Armatura naturale, lentezza' }
+        - { value: FLESSIBILE, label: 'FLESSIBILE', desc: 'Evasione, parry' }
+    - axis_id: senses
+      player_slot: p4
+      body_part: 'i tuoi occhi'
+      question: 'Lontano o acuto?'
+      options:
+        - { value: LONTANO, label: 'LONTANO', desc: 'Range visivo amplio' }
+        - { value: ACUTO, label: 'ACUTO', desc: 'Dettaglio, rilevamento traps' }
+
+  transition:
+    duration_seconds: 5
+    line_template: 'Il bioma vi accoglie: {biome_name}.'
+
+  next_encounter: enc_tutorial_01
+
+  deliberation_timeout_seconds: 15
+  default_choices:
+    p1: VELOCE
+    p2: PROFONDA
+    p3: DURA
+    p4: LONTANO
+
 acts:
   # ─── Act 0: Onboarding (tutorial 01-05) ──────────────────────────────
   - act_idx: 0

--- a/data/core/imprint/biome_resolution.yaml
+++ b/data/core/imprint/biome_resolution.yaml
@@ -1,0 +1,104 @@
+# Biome Resolution — 4-tuple → biome_id mapping
+#
+# Genesis: CAP-11 (audit Impronta CAP-10, archive AA01
+# 2026-04-25-cap-10-audit-impronta-archon-).
+#
+# 4 player parallelo choice su body parts (Pattern Jackbox L'Impronta v2):
+#   - locomotion: VELOCE | SILENZIOSA
+#   - offense:    PROFONDA | RAPIDA
+#   - defense:    DURA | FLESSIBILE
+#   - senses:     LONTANO | ACUTO
+#
+# 16 combo totali (2^4) → 7 biomi core (audit F-1 raccomanda Pattern D hybrid:
+# lookup base + team-composition modulation per ridurre canalizzazione).
+#
+# Biomi core selezionati da data/core/biomes.yaml (25 totali, scelti i più tactical):
+#   - savana
+#   - badlands
+#   - caverna_risonante
+#   - reef_luminescente
+#   - rovine_planari
+#   - palude_tossica
+#   - canopia_ionica
+
+schema_version: '1.0'
+
+# Lookup base — distribuzione bilanciata 16→7 (audit F-1: target ~20% canalizzazione max)
+# Codifica chiave: "L_O_D_S" dove ogni char è la prima lettera della scelta
+# (V=veloce, S=silenziosa, P=profonda, R=rapida, D=dura, F=flessibile, L=lontano, A=acuto).
+
+base_lookup:
+  # 4 combo → savana (ambiente aperto, veloce/lontano dominante)
+  V_P_D_L: savana          # veloce profonda dura lontano — savana classica predatore
+  V_P_F_L: savana          # veloce profonda flessibile lontano — savana agile
+  V_R_D_L: badlands        # veloce rapida dura lontano — pianura arida
+  V_R_F_L: badlands        # veloce rapida flessibile lontano — pianura agile
+
+  # 4 combo → caverna/sotterranei (silenzioso/acuto dominante)
+  S_P_D_A: caverna_risonante  # silenziosa profonda dura acuto — predatore caverna
+  S_P_F_A: caverna_risonante  # silenziosa profonda flessibile acuto — caverna umida
+  S_R_D_A: rovine_planari     # silenziosa rapida dura acuto — rovine
+  S_R_F_A: rovine_planari     # silenziosa rapida flessibile acuto — rovine antiche
+
+  # 4 combo ibride → biomi specializzati
+  V_P_D_A: rovine_planari       # veloce profondo duro acuto — rovine apertae
+  V_R_D_A: badlands             # veloce rapido duro acuto — badlands
+  S_P_D_L: palude_tossica       # silenziosa profonda dura lontano — palude
+  S_R_D_L: palude_tossica       # silenziosa rapida dura lontano — palude
+
+  # 4 combo extreme → biomi estremi
+  V_P_F_A: canopia_ionica       # veloce profondo flessibile acuto — canopia
+  V_R_F_A: canopia_ionica       # veloce rapido flessibile acuto — canopia
+  S_P_F_L: reef_luminescente    # silenziosa profonda flessibile lontano — reef
+  S_R_F_L: reef_luminescente    # silenziosa rapida flessibile lontano — reef
+
+# Distribuzione finale (per sanity check):
+# savana: 2, badlands: 3, caverna_risonante: 2, rovine_planari: 3,
+# palude_tossica: 2, canopia_ionica: 2, reef_luminescente: 2
+# → max canalizzazione 3/16 = 18.7% (target <20% audit F-1)
+
+# Team composition modulation — applicato al biome_id base
+# Ogni regola: se >= N player hanno trait nella tupla, applica affix.
+modulation:
+  - rule_id: cryo_dominance
+    condition:
+      trait: defense
+      value: DURA
+      min_player_count: 3
+    affix: hardened              # +durabilità tile, less terrain damage
+    biome_variants:
+      savana: savana_arida_dura
+      badlands: badlands_pietrosi
+      palude_tossica: palude_indurita
+
+  - rule_id: silent_majority
+    condition:
+      trait: locomotion
+      value: SILENZIOSA
+      min_player_count: 3
+    affix: stealth_advantage     # ambush bonus, lower visibility
+    biome_variants:
+      caverna_risonante: caverna_silenziosa
+      rovine_planari: rovine_sussurranti
+
+  - rule_id: long_range_focus
+    condition:
+      trait: senses
+      value: LONTANO
+      min_player_count: 3
+    affix: open_ground            # +line of sight, +range
+    biome_variants:
+      savana: savana_aperta_orizzonte
+      badlands: badlands_orizzonte
+
+  - rule_id: deep_strike
+    condition:
+      trait: offense
+      value: PROFONDA
+      min_player_count: 3
+    affix: punishing_terrain      # damage bonus +1 per round
+    biome_variants:
+      caverna_risonante: caverna_profonda_eco
+
+# Fallback (mai dovrebbe attivarsi se base_lookup è completo)
+fallback_biome: savana

--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -8410,3 +8410,64 @@ traits:
       code: "BB CT 05"
       branch: "Therapeutic Medication"
       license: "CC BY-NC-SA 3.0 Fandom"
+
+  # =====================================================================
+  # EVO-SWARM CONTRIBUTIONS — synergy active effects from external swarm
+  # =====================================================================
+  # Source: evo-swarm meta-orchestration repo (MasterDD-L34D/evo-swarm).
+  # Lo swarm AI ha prodotto 30+ cicli di design su `dune_stalker`
+  # (Arenavenator vagans) tra 22-25/04/2026, raggiungendo proposte
+  # tangibili gameplay (cycle 27 dev-tooling: "Echo Backstab prototipo",
+  # cycle 18-19 25/04 species-curator + balancer: "thermal compensation").
+  # Questa sezione promuove synergy gia' dichiarate in species.yaml a
+  # active_effects runtime-evaluable, citando i cicli swarm sorgente.
+  #
+  # Cross-ref: docs/exports/EXPORT-FOR-GAME-REPO-2026-04-25-FINAL.md
+  # (swarm-side, in evo-swarm repo) elenca match diretto
+  # `dune_stalker -> canonical dune_stalker` con cicli #2/#119/#2.
+  #
+  # Schema notes:
+  # - effect.kind = extra_damage (esistente, no schema extension).
+  # - trigger fields tutti gia' supportati da passesBasicTriggers().
+  # - Synergy parts gating (echolocation + sand_claws) e' resp. del
+  #   composition layer (data/core/species.yaml synergy block riga ~41).
+  #   A runtime, se il mob non ha le parts richieste, il trait viene
+  #   gated upstream e non istanziato.
+
+  # --- DUNE_STALKER — Echo Backstab synergy (swarm-prototyped) ---
+  echo_backstab:
+    tier: T2
+    category: tattico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      melee_only: true
+      requires_ally_adjacent: true
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: echo_backstab_synergy
+    description_it: |
+      Echo Backstab — synergy tattica del Predatore delle Dune
+      (Arenavenator vagans). Quando il branco coordina via
+      echolocation, gli artigli sand_claws colpiscono punti deboli
+      rivelati dall'eco. Effetto runtime: +1 PT su melee hit con
+      alleato adiacente (tattica di branco). La synergy parts
+      (senses.echolocation + offense.sand_claws) e' gated al
+      composition layer in data/core/species.yaml (synergy block).
+    description_en: |
+      Echo Backstab — tactical synergy of the Dune Stalker
+      (Arenavenator vagans). When the pack coordinates via
+      echolocation, sand_claws strike weak points revealed by the
+      echo. Runtime effect: +1 HP on melee hit with adjacent ally
+      (pack tactic). The synergy parts gate (senses.echolocation +
+      offense.sand_claws) is enforced at composition layer in
+      data/core/species.yaml (synergy block).
+    provenance:
+      source: evo-swarm
+      cycle: "cycle 27 (gameplay-prototyper) + cycle 2 25/04 (species-curator)"
+      species_match: dune_stalker
+      synergy_block: "species.yaml#L41 echo_backstab"
+      cross_ref: "docs/exports/EXPORT-FOR-GAME-REPO-2026-04-25-FINAL.md (evo-swarm repo)"
+      license: MIT

--- a/data/core/traits/glossary.json
+++ b/data/core/traits/glossary.json
@@ -647,6 +647,12 @@
       "description_it": "Echi Risonanti permette alle squadre di interpretare segnali minuti e pattern psionici instabili all'interno di caverna risonante.",
       "description_en": "Echi Risonanti allow squads to interpret minute signals and unstable psionic patterns within caverna risonante."
     },
+    "echo_backstab": {
+      "label_it": "Eco Backstab",
+      "label_en": "Echo Backstab",
+      "description_it": "Synergy tattica del Predatore delle Dune: il branco coordina via echolocation, gli artigli colpiscono punti deboli rivelati dall'eco. +1 PT su melee hit con alleato adiacente.",
+      "description_en": "Tactical synergy of the Dune Stalker: the pack coordinates via echolocation, claws strike weak points revealed by the echo. +1 HP on melee hit with adjacent ally."
+    },
     "eco_interno_riflesso": {
       "label_en": "Internal Echo Reflex",
       "label_it": "Riflesso dell'Eco Interno",

--- a/docs/flint-status.json
+++ b/docs/flint-status.json
@@ -2,75 +2,75 @@
   "_meta": {
     "generator": "flint_status_stdlib (fallback)",
     "version": "0.2.0-stdlib",
-    "generated_at": "2026-04-24T00:19:49.925324+00:00",
+    "generated_at": "2026-04-25T20:37:06.117973+00:00",
     "repo_root": "C:\\dev\\Game",
     "note": "File generato via tools/py/flint_status_stdlib.py (stdlib-only). Quando flint CLI è installato, rigenerare con `flint export`."
   },
   "snapshot": {
-    "dirty_files_count": 2,
+    "dirty_files_count": 1,
     "recent_commits_count": 10,
-    "gameplay_ratio": 0.3,
-    "consecutive_infra_commits": 0,
-    "is_drifting": false,
+    "gameplay_ratio": 0.0,
+    "consecutive_infra_commits": 1,
+    "is_drifting": true,
     "recent_commits": [
       {
-        "sha": "c633ae7f",
-        "kind": "GAMEPLAY",
-        "message_first_line": "chore(swarm): register gameplay-prototyper + combat-engineer + sync runtime state",
-        "files_count": 0
-      },
-      {
-        "sha": "d319404e",
-        "kind": "GAMEPLAY",
-        "message_first_line": "docs(planning): M11 Phase B→TKT-05 close + next session handoff (P5 🟢 pending playtest) (#1687)",
-        "files_count": 0
-      },
-      {
-        "sha": "d97eb5f8",
-        "kind": "ALTRO",
-        "message_first_line": "feat(network): M11 TKT-M11B-05 — host-transfer on disconnect (FIFO first-come) (#1685)",
-        "files_count": 0
-      },
-      {
-        "sha": "583be2a8",
-        "kind": "ALTRO",
-        "message_first_line": "feat(network): M11 Phase C — host TV roster panel + ngrok playbook (TKT-04/06 partial) (#1684)",
-        "files_count": 0
-      },
-      {
-        "sha": "d14b2655",
-        "kind": "GAMEPLAY",
-        "message_first_line": "feat(network): M11 Phase B+ — phone intent UI + host relay + campaign mirror (TKT-01/02/03) (#1686)",
-        "files_count": 0
-      },
-      {
-        "sha": "d35dde92",
-        "kind": "ALTRO",
-        "message_first_line": "feat(network): M11 Phase B — Jackbox lobby frontend + TV spectator + WS client (P5) (#1682)",
-        "files_count": 0
-      },
-      {
-        "sha": "6d722e40",
-        "kind": "DOCS",
-        "message_first_line": "docs(planning): M11 Phase A close + Phase B handoff + CLAUDE.md sync (#1681)",
-        "files_count": 0
-      },
-      {
-        "sha": "db4325f0",
-        "kind": "ALTRO",
-        "message_first_line": "feat(network): M11 Phase A — Jackbox room-code WebSocket backend (P5) (#1680)",
-        "files_count": 0
-      },
-      {
-        "sha": "3272f844",
+        "sha": "0f665ffe",
         "kind": "INFRA",
-        "message_first_line": "feat(meta): Prisma persistence adapter for metaProgression (Prompt B / L06 partial) (#1679)",
+        "message_first_line": "chore(swarm): agent ranking promotions 2026-04-25",
         "files_count": 0
       },
       {
-        "sha": "cc35e2d2",
+        "sha": "4ee9e30f",
         "kind": "ALTRO",
-        "message_first_line": "feat(balance): trait environmental costs pilot 4×3 (#1674) (#1678)",
+        "message_first_line": "docs: backlog drift fix #3 — F-1/F-2/F-3 + M14-A partial closures (#1820)",
+        "files_count": 0
+      },
+      {
+        "sha": "e5f0ba25",
+        "kind": "ALTRO",
+        "message_first_line": "Merge pull request #1819 from MasterDD-L34D/fix/post-od011-balance-gates-doc",
+        "files_count": 0
+      },
+      {
+        "sha": "e54f2bc8",
+        "kind": "ALTRO",
+        "message_first_line": "Merge branch 'main' into fix/post-od011-balance-gates-doc",
+        "files_count": 0
+      },
+      {
+        "sha": "7f49d71a",
+        "kind": "ALTRO",
+        "message_first_line": "fix(traits)+docs: post-OD-011 audit fixes — gates + balance + sprint context",
+        "files_count": 0
+      },
+      {
+        "sha": "6b2670a3",
+        "kind": "ALTRO",
+        "message_first_line": "docs: ancestors drift fix #2 — card numbers + 2 BACKLOG ticket closures (#1818)",
+        "files_count": 0
+      },
+      {
+        "sha": "0d5a068b",
+        "kind": "ALTRO",
+        "message_first_line": "Merge pull request #1817 from MasterDD-L34D/feat/od-011-path-b-wire",
+        "files_count": 0
+      },
+      {
+        "sha": "effc06e4",
+        "kind": "ALTRO",
+        "message_first_line": "feat(traits): OD-011 Path B wire — 267 ancestors neurons batch",
+        "files_count": 0
+      },
+      {
+        "sha": "bb19697b",
+        "kind": "ALTRO",
+        "message_first_line": "docs: backlog drift fix — 3 ticket stale chiusi con SHA (#1814)",
+        "files_count": 0
+      },
+      {
+        "sha": "65b61a3a",
+        "kind": "ALTRO",
+        "message_first_line": "Merge pull request #1815 from MasterDD-L34D/feat/od-011-path-b-wiki-recovery",
         "files_count": 0
       }
     ]

--- a/prototypes/imprint-v2/README.md
+++ b/prototypes/imprint-v2/README.md
@@ -1,0 +1,56 @@
+# L'Impronta v2 — Mockup primo minuto
+
+> Falsificatore standalone (CAP-13, audit Impronta CAP-10 AA01).
+> Nessun backend richiesto. Apri `index.html` da qualsiasi browser moderno.
+
+## Cosa testa
+
+Modello **"4 creature in 1 bioma + foodweb"** (correzione utente vs proposta originale "1 creatura 4 mani"):
+
+- 4 player sceglono parallelamente 1 binary su body parts
+- TV view mostra 4 silhouette distinte che si plasmano in sincrono
+- Bioma emerge dalle 4 scelte aggregate (Pattern D hybrid: lookup + team modulation)
+- Foodweb sidebar L1 decorativo già al primo minuto
+
+## Come testarlo
+
+### Single-laptop (5 tab)
+
+1. Apri `index.html` in browser
+2. Apri 4 tab in più sullo stesso file
+3. Nella prima tab clicca **TV**, nelle altre 4 clicca rispettivamente **Phone 1**, **Phone 2**, **Phone 3**, **Phone 4**
+4. Effettua le scelte sui phone, osserva la TV in live
+5. Quando tutti i 4 player hanno scelto, il bioma viene rivelato + foodweb sidebar appare
+
+### Multi-device (4 amici reali su tavolo)
+
+1. Server locale: `cd prototypes/imprint-v2 && python -m http.server 8080` (o `npx serve`)
+2. Trova IP del laptop: `ipconfig` (Win) / `ifconfig` (Mac/Linux)
+3. Laptop su TV (browser tab `http://localhost:8080#tv`)
+4. 4 phone su stessa rete WiFi: `http://<IP_laptop>:8080#p1` (e p2, p3, p4)
+5. **Note**: BroadcastChannel funziona solo same-origin same-tab. Multi-device richiede backend WebSocket reale (CAP-14). Per ora multi-device funziona via polling sessionStorage (~1.5s lag).
+
+## Acceptance criteria del falsificatore (audit CAP-10 §Calibrazione)
+
+Test su 4 amici reali per 12 minuti:
+
+- ✅ **Pass** se 3/4 player descrivono creature distinte (proprie!) e ricordano momenti distinti dei primi 60s
+- ❌ **Fail** se 3+/4 player dicono "siamo confusi su chi è chi" → modello "4 creature" è sbagliato, ripensare a 1 unione
+
+## Limitazioni mockup
+
+- **No backend**: scelte non persistono cross-session
+- **No WebSocket reale**: sync via BroadcastChannel (same-browser only) o sessionStorage poll (~1.5s)
+- **No combat**: solo i primi 60s di plasmatura + bioma reveal
+- **Silhouette emoji statiche**: nel mock arrivato qui sono 4 emoji. In V2 reale saranno 4 SVG/sprite animati che evolvono visualmente con le scelte (glifi che si incidono, parti del corpo che si trasformano).
+
+## File
+
+- `index.html` — single-file mockup (HTML + CSS + JS inline)
+- `README.md` — questo file
+
+## Reference
+
+- Audit: `archive/2026-04-aa01-001-2026-04-25-cap-10-audit-impronta-archon-` (AA01)
+- Bioma resolver: `apps/backend/services/imprint/biomeResolver.js` (CAP-11)
+- Pattern D hybrid: lookup 16→7 biomi + 4 modulation rules

--- a/prototypes/imprint-v2/index.html
+++ b/prototypes/imprint-v2/index.html
@@ -1,0 +1,786 @@
+<!doctype html>
+<html lang="it">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>L'Impronta v2 — mockup primo minuto</title>
+    <style>
+      :root {
+        --bg: #0a0a0c;
+        --fg: #e8e8e8;
+        --accent: #d4a373;
+        --p1: #5fa8d3;
+        --p2: #d35f5f;
+        --p3: #5fd37e;
+        --p4: #d3c95f;
+        --muted: #555;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html,
+      body {
+        height: 100%;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        overflow: hidden;
+      }
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .hidden {
+        display: none !important;
+      }
+
+      /* ── Modal selector (default view) ── */
+      #modeSelect {
+        text-align: center;
+        padding: 2rem;
+        max-width: 600px;
+      }
+      #modeSelect h1 {
+        font-size: 1.6rem;
+        margin-bottom: 0.5rem;
+        color: var(--accent);
+      }
+      #modeSelect p {
+        color: #aaa;
+        margin-bottom: 1.5rem;
+        line-height: 1.5;
+        font-size: 0.95rem;
+      }
+      #modeSelect .btn-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 0.8rem;
+      }
+      #modeSelect button {
+        background: #1a1a1e;
+        color: var(--fg);
+        border: 1px solid #333;
+        padding: 1rem;
+        font-size: 1rem;
+        cursor: pointer;
+        border-radius: 6px;
+        transition: all 0.15s;
+      }
+      #modeSelect button:hover {
+        background: #2a2a2e;
+        border-color: var(--accent);
+      }
+      #modeSelect .tv-btn {
+        grid-column: 1 / 3;
+        background: #2a2a2e;
+        border-color: var(--accent);
+      }
+      #modeSelect .reset {
+        grid-column: 1 / 3;
+        margin-top: 0.5rem;
+        background: #3a1a1a;
+        border-color: #5a2a2a;
+        font-size: 0.85rem;
+      }
+      #modeSelect .hint {
+        font-size: 0.75rem;
+        color: #666;
+        margin-top: 1rem;
+        line-height: 1.4;
+      }
+
+      /* ── TV view ── */
+      #tvView {
+        width: 100vw;
+        height: 100vh;
+        display: flex;
+        flex-direction: column;
+        padding: 1.5rem;
+      }
+      #tvView .tv-header {
+        text-align: center;
+        margin-bottom: 1rem;
+      }
+      #tvView h2 {
+        font-size: 1.3rem;
+        color: var(--accent);
+      }
+      #tvView .tv-subtitle {
+        font-size: 0.85rem;
+        color: #888;
+        margin-top: 0.3rem;
+        min-height: 1.2em;
+      }
+      #tvView .tv-creatures {
+        flex: 1;
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 1rem;
+        padding: 1rem 0;
+      }
+      .creature-card {
+        background: linear-gradient(180deg, #1a1a22, #0f0f15);
+        border: 2px solid var(--muted);
+        border-radius: 8px;
+        padding: 1rem;
+        display: flex;
+        flex-direction: column;
+        transition: all 0.4s ease;
+      }
+      .creature-card.p1 {
+        border-color: var(--p1);
+      }
+      .creature-card.p2 {
+        border-color: var(--p2);
+      }
+      .creature-card.p3 {
+        border-color: var(--p3);
+      }
+      .creature-card.p4 {
+        border-color: var(--p4);
+      }
+      .creature-card .player-tag {
+        font-size: 0.7rem;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        opacity: 0.6;
+      }
+      .creature-card .silhouette {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 4rem;
+        opacity: 0.3;
+        transition: opacity 0.5s;
+      }
+      .creature-card.has-choices .silhouette {
+        opacity: 0.85;
+      }
+      .creature-card .glyphs {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+        min-height: 2em;
+      }
+      .creature-card .glyph {
+        background: #2a2a32;
+        padding: 0.3rem 0.6rem;
+        border-radius: 4px;
+        font-size: 0.75rem;
+        animation: glyphAppear 0.6s ease;
+      }
+      @keyframes glyphAppear {
+        from {
+          transform: scale(0.5) translateY(-10px);
+          opacity: 0;
+        }
+        to {
+          transform: scale(1) translateY(0);
+          opacity: 1;
+        }
+      }
+      #tvView .biome-reveal {
+        text-align: center;
+        padding: 1rem;
+        background: #1a1a22;
+        border-radius: 8px;
+        margin-top: 0.5rem;
+        min-height: 4em;
+      }
+      #tvView .biome-reveal .biome-name {
+        font-size: 1.4rem;
+        color: var(--accent);
+        font-weight: 600;
+      }
+      #tvView .biome-reveal .biome-base {
+        font-size: 0.8rem;
+        color: #888;
+        margin-top: 0.3rem;
+      }
+      #tvView .biome-reveal .modulations {
+        font-size: 0.75rem;
+        color: #aaa;
+        margin-top: 0.5rem;
+        font-style: italic;
+      }
+      #tvView .biome-reveal .pending {
+        color: #555;
+        font-style: italic;
+      }
+      #tvView .foodweb {
+        background: #15151b;
+        border-radius: 6px;
+        padding: 0.7rem;
+        margin-top: 0.5rem;
+        font-size: 0.75rem;
+        color: #999;
+      }
+      #tvView .foodweb-title {
+        font-weight: 600;
+        margin-bottom: 0.3rem;
+        color: #ccc;
+      }
+      #tvView .foodweb-list {
+        display: flex;
+        gap: 0.7rem;
+        flex-wrap: wrap;
+      }
+      #tvView .foodweb-item {
+        background: #20202a;
+        padding: 0.2rem 0.5rem;
+        border-radius: 3px;
+      }
+
+      /* ── Phone view ── */
+      #phoneView {
+        width: min(100vw, 500px);
+        height: 100vh;
+        padding: 1.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+      }
+      #phoneView .phone-header {
+        text-align: center;
+      }
+      #phoneView .phone-tag {
+        display: inline-block;
+        padding: 0.3rem 0.8rem;
+        border-radius: 12px;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 1.5px;
+        color: #fff;
+      }
+      .player-bg-p1 {
+        background: var(--p1);
+      }
+      .player-bg-p2 {
+        background: var(--p2);
+      }
+      .player-bg-p3 {
+        background: var(--p3);
+      }
+      .player-bg-p4 {
+        background: var(--p4);
+      }
+      #phoneView .body-part {
+        text-align: center;
+        font-size: 1.2rem;
+        color: var(--accent);
+        margin-top: 0.5rem;
+        letter-spacing: 1px;
+      }
+      #phoneView .question {
+        text-align: center;
+        font-size: 1rem;
+        color: #ddd;
+        line-height: 1.5;
+        padding: 0 0.5rem;
+      }
+      #phoneView .choices {
+        display: grid;
+        grid-template-rows: 1fr 1fr;
+        gap: 1rem;
+        flex: 1;
+      }
+      #phoneView .choice-btn {
+        background: linear-gradient(135deg, #1a1a22, #0a0a12);
+        border: 2px solid #333;
+        color: var(--fg);
+        font-size: 1.4rem;
+        padding: 1.5rem;
+        border-radius: 12px;
+        cursor: pointer;
+        transition: all 0.15s;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+      }
+      #phoneView .choice-btn:hover {
+        border-color: var(--accent);
+        transform: scale(1.02);
+      }
+      #phoneView .choice-btn:active {
+        transform: scale(0.98);
+      }
+      #phoneView .choice-btn .choice-label {
+        font-weight: 600;
+      }
+      #phoneView .choice-btn .choice-desc {
+        font-size: 0.8rem;
+        color: #888;
+        margin-top: 0.4rem;
+        font-style: italic;
+      }
+      #phoneView .choice-btn.selected {
+        background: linear-gradient(135deg, #2a2a3a, #1a1a2a);
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+      #phoneView .waiting-msg {
+        text-align: center;
+        padding: 2rem;
+        color: #888;
+        font-style: italic;
+        border: 1px dashed #444;
+        border-radius: 8px;
+      }
+      #phoneView .reset-link {
+        text-align: center;
+        font-size: 0.7rem;
+        color: #555;
+        cursor: pointer;
+      }
+      #phoneView .reset-link:hover {
+        color: #888;
+      }
+
+      /* ── Footer barre time-line (educational only) ── */
+      #timeline {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background: #15151b;
+        padding: 0.5rem 1rem;
+        font-size: 0.7rem;
+        color: #888;
+        text-align: center;
+        border-top: 1px solid #333;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Mode selector (default landing) -->
+    <div id="modeSelect">
+      <h1>L'Impronta v2 · mockup</h1>
+      <p>
+        Apri 5 tab nel browser (1 TV + 4 phone) o usa device separati su
+        <code>localhost</code>.<br />
+        Le scelte sincronizzano via <code>BroadcastChannel</code> (stesso browser) o sessionStorage
+        poll.
+      </p>
+
+      <div class="btn-grid">
+        <button class="tv-btn" onclick="setMode('tv')">📺 TV (centrale, 4 creature)</button>
+        <button onclick="setMode('p1')" style="border-color: var(--p1)">📱 Phone 1 — Zampe</button>
+        <button onclick="setMode('p2')" style="border-color: var(--p2)">
+          📱 Phone 2 — Mascella
+        </button>
+        <button onclick="setMode('p3')" style="border-color: var(--p3)">📱 Phone 3 — Pelle</button>
+        <button onclick="setMode('p4')" style="border-color: var(--p4)">📱 Phone 4 — Occhi</button>
+        <button class="reset" onclick="resetState()">🗑 Reset stato (cross-tab)</button>
+      </div>
+
+      <p class="hint">
+        Mockup CAP-13 (audit Impronta CAP-10 AA01).<br />
+        Falsificatore design "4 creature 1 bioma" + Pattern D hybrid bioma resolver.<br />
+        Test su 4 amici reali per validare framing primo minuto v2.
+      </p>
+    </div>
+
+    <!-- TV view -->
+    <div id="tvView" class="hidden">
+      <div class="tv-header">
+        <h2>📺 L'Impronta</h2>
+        <div class="tv-subtitle" id="tvSubtitle">Quattro di voi. Quattro creature. Un mondo.</div>
+      </div>
+      <div class="tv-creatures">
+        <div class="creature-card p1" data-player="p1">
+          <div class="player-tag" style="color: var(--p1)">Player 1 · Zampe</div>
+          <div class="silhouette">🦅</div>
+          <div class="glyphs"></div>
+        </div>
+        <div class="creature-card p2" data-player="p2">
+          <div class="player-tag" style="color: var(--p2)">Player 2 · Mascella</div>
+          <div class="silhouette">🦊</div>
+          <div class="glyphs"></div>
+        </div>
+        <div class="creature-card p3" data-player="p3">
+          <div class="player-tag" style="color: var(--p3)">Player 3 · Pelle</div>
+          <div class="silhouette">🦎</div>
+          <div class="glyphs"></div>
+        </div>
+        <div class="creature-card p4" data-player="p4">
+          <div class="player-tag" style="color: var(--p4)">Player 4 · Occhi</div>
+          <div class="silhouette">🦉</div>
+          <div class="glyphs"></div>
+        </div>
+      </div>
+      <div class="biome-reveal" id="biomeReveal">
+        <div class="pending">Il bioma emergerà quando avrete scelto tutti.</div>
+      </div>
+      <div class="foodweb hidden" id="foodwebSidebar">
+        <div class="foodweb-title">🌐 Foodweb del bioma (4 creature condividono ecosistema)</div>
+        <div class="foodweb-list" id="foodwebList"></div>
+      </div>
+    </div>
+
+    <!-- Phone view -->
+    <div id="phoneView" class="hidden">
+      <div class="phone-header">
+        <span class="phone-tag" id="phoneTag">Player 1</span>
+        <div class="body-part" id="bodyPart">Le tue zampe</div>
+      </div>
+      <div class="question" id="question">Veloci o silenziose?</div>
+      <div class="choices" id="choices"></div>
+      <div class="reset-link" onclick="resetMyChoice()">↻ cambia scelta</div>
+    </div>
+
+    <div id="timeline" class="hidden">
+      <span id="timelineText">Plasmatura: in attesa</span>
+    </div>
+
+    <script>
+      // ── State (cross-tab via BroadcastChannel + sessionStorage) ────────────────
+      const STATE_KEY = 'imprint_v2_state';
+      const channel = new BroadcastChannel('imprint_v2');
+
+      const PHONE_CONFIG = {
+        p1: {
+          name: 'Player 1',
+          bodyPart: 'Le tue zampe',
+          question: 'Veloci o silenziose?',
+          field: 'locomotion',
+          options: [
+            { value: 'VELOCE', label: 'VELOCE', desc: 'Movimento ampio, hit-and-run' },
+            { value: 'SILENZIOSA', label: 'SILENZIOSA', desc: 'Stealth, ambush' },
+          ],
+        },
+        p2: {
+          name: 'Player 2',
+          bodyPart: 'La tua mascella',
+          question: 'Profonda o rapida?',
+          field: 'offense',
+          options: [
+            { value: 'PROFONDA', label: 'PROFONDA', desc: 'Singolo morso devastante' },
+            { value: 'RAPIDA', label: 'RAPIDA', desc: 'Attacchi multipli, bleeding' },
+          ],
+        },
+        p3: {
+          name: 'Player 3',
+          bodyPart: 'La tua pelle',
+          question: 'Dura o flessibile?',
+          field: 'defense',
+          options: [
+            { value: 'DURA', label: 'DURA', desc: 'Armatura naturale, lentezza' },
+            { value: 'FLESSIBILE', label: 'FLESSIBILE', desc: 'Evasione, parry' },
+          ],
+        },
+        p4: {
+          name: 'Player 4',
+          bodyPart: 'I tuoi occhi',
+          question: 'Lontano o acuto?',
+          field: 'senses',
+          options: [
+            { value: 'LONTANO', label: 'LONTANO', desc: 'Range visivo amplio' },
+            { value: 'ACUTO', label: 'ACUTO', desc: 'Dettaglio, rilevamento traps' },
+          ],
+        },
+      };
+
+      // ── Bioma resolver (port da apps/backend/services/imprint/biomeResolver.js) ──
+      const BIOME_LOOKUP = {
+        V_P_D_L: 'savana',
+        V_P_F_L: 'savana',
+        V_R_D_L: 'badlands',
+        V_R_F_L: 'badlands',
+        S_P_D_A: 'caverna_risonante',
+        S_P_F_A: 'caverna_risonante',
+        S_R_D_A: 'rovine_planari',
+        S_R_F_A: 'rovine_planari',
+        V_P_D_A: 'rovine_planari',
+        V_R_D_A: 'badlands',
+        S_P_D_L: 'palude_tossica',
+        S_R_D_L: 'palude_tossica',
+        V_P_F_A: 'canopia_ionica',
+        V_R_F_A: 'canopia_ionica',
+        S_P_F_L: 'reef_luminescente',
+        S_R_F_L: 'reef_luminescente',
+      };
+
+      const BIOME_NAMES = {
+        savana: 'La Savana',
+        savana_arida_dura: 'La Savana Arida (terreno indurito)',
+        savana_aperta_orizzonte: "La Savana dell'Orizzonte (visibilità estesa)",
+        badlands: 'Le Pianure Aride',
+        badlands_pietrosi: 'Le Pianure Pietrose',
+        badlands_orizzonte: "Le Pianure dell'Orizzonte",
+        caverna_risonante: 'La Caverna Risonante',
+        caverna_silenziosa: 'La Caverna Silenziosa',
+        caverna_profonda_eco: "La Caverna dell'Eco Profonda",
+        rovine_planari: 'Le Rovine Planari',
+        rovine_sussurranti: 'Le Rovine Sussurranti',
+        palude_tossica: 'La Palude Tossica',
+        palude_indurita: 'La Palude Indurita',
+        canopia_ionica: 'La Canopia Ionica',
+        reef_luminescente: 'Il Reef Luminescente',
+      };
+
+      const FOODWEB_BY_BIOME = {
+        savana: ['🦬 Erbivori', '🦁 Predatori', '🪲 Insetti', '🌾 Vegetali'],
+        badlands: ['🦂 Aracnidi', '🐍 Rettili', '🦎 Lucertole', '🪨 Minerali bio'],
+        caverna_risonante: [
+          '🦇 Pipistrelli',
+          '🪱 Vermi luminescenti',
+          '🍄 Funghi',
+          '💧 Acque ferme',
+        ],
+        rovine_planari: ['👻 Echi spettrali', '🪲 Coleotteri', '🌿 Muschi', '⚙️ Reliquie'],
+        palude_tossica: ['🐸 Anfibi', '🦟 Insetti', '🪴 Vegetazione tossica', '💀 Decompositori'],
+        canopia_ionica: [
+          '🦜 Aviani',
+          '🐒 Arboreali',
+          '🌺 Fiori carnivori',
+          '☁️ Spore galleggianti',
+        ],
+        reef_luminescente: ['🐠 Pesci', '🪸 Coralli', '🦑 Cefalopodi', '✨ Plankton'],
+      };
+
+      const MODULATIONS = [
+        {
+          rule: 'cryo_dominance',
+          field: 'defense',
+          value: 'DURA',
+          minCount: 3,
+          variants: {
+            savana: 'savana_arida_dura',
+            badlands: 'badlands_pietrosi',
+            palude_tossica: 'palude_indurita',
+          },
+        },
+        {
+          rule: 'silent_majority',
+          field: 'locomotion',
+          value: 'SILENZIOSA',
+          minCount: 3,
+          variants: {
+            caverna_risonante: 'caverna_silenziosa',
+            rovine_planari: 'rovine_sussurranti',
+          },
+        },
+        {
+          rule: 'long_range_focus',
+          field: 'senses',
+          value: 'LONTANO',
+          minCount: 3,
+          variants: { savana: 'savana_aperta_orizzonte', badlands: 'badlands_orizzonte' },
+        },
+        {
+          rule: 'deep_strike',
+          field: 'offense',
+          value: 'PROFONDA',
+          minCount: 3,
+          variants: { caverna_risonante: 'caverna_profonda_eco' },
+        },
+      ];
+
+      function buildKey(team) {
+        // team: { p1: {field,value}, p2: {...}, ... }
+        const map = { locomotion: '?', offense: '?', defense: '?', senses: '?' };
+        for (const k in team) {
+          const c = team[k];
+          if (c) map[c.field] = c.value[0];
+        }
+        return `${map.locomotion}_${map.offense}_${map.defense}_${map.senses}`;
+      }
+
+      function resolveBiome(team) {
+        const key = buildKey(team);
+        if (key.includes('?')) return null;
+        const base = BIOME_LOOKUP[key];
+        if (!base) return null;
+        // Modulation
+        let final = base;
+        const applied = [];
+        const traitCounts = { locomotion: {}, offense: {}, defense: {}, senses: {} };
+        for (const k in team) {
+          const c = team[k];
+          if (!c) continue;
+          traitCounts[c.field][c.value] = (traitCounts[c.field][c.value] || 0) + 1;
+        }
+        for (const mod of MODULATIONS) {
+          const count = traitCounts[mod.field][mod.value] || 0;
+          if (count >= mod.minCount) {
+            const variant = mod.variants[final];
+            if (variant) {
+              final = variant;
+              applied.push(mod.rule);
+            }
+          }
+        }
+        return { biome_id: final, base_biome_id: base, applied_modulations: applied };
+      }
+
+      // ── Mode router ──────────────────────────────────────────────────────────
+      function getMode() {
+        const hash = location.hash.replace('#', '');
+        if (['tv', 'p1', 'p2', 'p3', 'p4'].includes(hash)) return hash;
+        return 'select';
+      }
+
+      function setMode(mode) {
+        location.hash = mode;
+        render();
+      }
+
+      function render() {
+        const mode = getMode();
+        document.getElementById('modeSelect').classList.toggle('hidden', mode !== 'select');
+        document.getElementById('tvView').classList.toggle('hidden', mode !== 'tv');
+        document.getElementById('phoneView').classList.toggle('hidden', !mode.startsWith('p'));
+        document.getElementById('timeline').classList.toggle('hidden', mode === 'select');
+
+        if (mode === 'tv') renderTV();
+        if (mode.startsWith('p')) renderPhone(mode);
+      }
+
+      // ── TV rendering ──────────────────────────────────────────────────────────
+      function renderTV() {
+        const state = loadState();
+        let chosenCount = 0;
+        ['p1', 'p2', 'p3', 'p4'].forEach((p) => {
+          const card = document.querySelector(`.creature-card[data-player="${p}"]`);
+          const glyphs = card.querySelector('.glyphs');
+          const choice = state[p];
+          glyphs.innerHTML = '';
+          if (choice) {
+            chosenCount += 1;
+            card.classList.add('has-choices');
+            const glyph = document.createElement('span');
+            glyph.className = 'glyph';
+            glyph.textContent = `${PHONE_CONFIG[p].bodyPart.split(' ').pop()}: ${choice.value}`;
+            glyphs.appendChild(glyph);
+          } else {
+            card.classList.remove('has-choices');
+          }
+        });
+
+        // Subtitle progressivo
+        const subtitle = document.getElementById('tvSubtitle');
+        if (chosenCount === 0)
+          subtitle.textContent = 'Quattro di voi. Quattro creature. Un mondo da scoprire.';
+        else if (chosenCount < 4)
+          subtitle.textContent = `${chosenCount}/4 scelte fatte. Le altre creature aspettano.`;
+        else subtitle.textContent = '✦ Il mondo si forma. ✦';
+
+        // Biome reveal
+        const biomeBox = document.getElementById('biomeReveal');
+        const biome = resolveBiome(state);
+        if (!biome) {
+          biomeBox.innerHTML =
+            '<div class="pending">Il bioma emergerà quando avrete scelto tutti.</div>';
+          document.getElementById('foodwebSidebar').classList.add('hidden');
+        } else {
+          let html = `<div class="biome-name">${BIOME_NAMES[biome.biome_id] || biome.biome_id}</div>`;
+          if (biome.biome_id !== biome.base_biome_id) {
+            html += `<div class="biome-base">(variante di ${BIOME_NAMES[biome.base_biome_id] || biome.base_biome_id})</div>`;
+          }
+          if (biome.applied_modulations.length) {
+            html += `<div class="modulations">⚡ Modulation: ${biome.applied_modulations.join(', ')}</div>`;
+          }
+          biomeBox.innerHTML = html;
+          // Foodweb
+          const foodweb = FOODWEB_BY_BIOME[biome.base_biome_id];
+          if (foodweb) {
+            document.getElementById('foodwebSidebar').classList.remove('hidden');
+            const list = document.getElementById('foodwebList');
+            list.innerHTML = '';
+            for (const item of foodweb) {
+              const span = document.createElement('span');
+              span.className = 'foodweb-item';
+              span.textContent = item;
+              list.appendChild(span);
+            }
+          }
+        }
+
+        document.getElementById('timelineText').textContent =
+          chosenCount < 4
+            ? `Plasmatura: ${chosenCount}/4`
+            : 'Bioma rivelato. Pronti per il round 0.';
+      }
+
+      // ── Phone rendering ──────────────────────────────────────────────────────
+      function renderPhone(mode) {
+        const config = PHONE_CONFIG[mode];
+        const state = loadState();
+        document.getElementById('phoneTag').textContent = config.name;
+        document.getElementById('phoneTag').className = `phone-tag player-bg-${mode}`;
+        document.getElementById('bodyPart').textContent = config.bodyPart;
+        document.getElementById('question').textContent = config.question;
+        const choices = document.getElementById('choices');
+        choices.innerHTML = '';
+        const myChoice = state[mode];
+        for (const opt of config.options) {
+          const btn = document.createElement('button');
+          btn.className =
+            'choice-btn' + (myChoice && myChoice.value === opt.value ? ' selected' : '');
+          btn.innerHTML = `<div class="choice-label">${opt.label}</div><div class="choice-desc">${opt.desc}</div>`;
+          btn.onclick = () => makeChoice(mode, opt.value);
+          choices.appendChild(btn);
+        }
+        document.getElementById('timelineText').textContent = myChoice
+          ? `${config.name}: ${myChoice.value} ✓ — aspetta gli altri`
+          : `${config.name}: scegli`;
+      }
+
+      // ── Choice logic ──────────────────────────────────────────────────────────
+      function loadState() {
+        try {
+          return JSON.parse(
+            sessionStorage.getItem(STATE_KEY) || localStorage.getItem(STATE_KEY) || '{}',
+          );
+        } catch {
+          return {};
+        }
+      }
+      function saveState(s) {
+        const json = JSON.stringify(s);
+        sessionStorage.setItem(STATE_KEY, json);
+        localStorage.setItem(STATE_KEY, json);
+        channel.postMessage({ type: 'state', state: s });
+      }
+      function makeChoice(player, value) {
+        const state = loadState();
+        const config = PHONE_CONFIG[player];
+        state[player] = { field: config.field, value };
+        saveState(state);
+        render();
+      }
+      function resetMyChoice() {
+        const mode = getMode();
+        const state = loadState();
+        delete state[mode];
+        saveState(state);
+        render();
+      }
+      function resetState() {
+        sessionStorage.removeItem(STATE_KEY);
+        localStorage.removeItem(STATE_KEY);
+        channel.postMessage({ type: 'reset' });
+        render();
+      }
+
+      // ── Cross-tab sync ────────────────────────────────────────────────────────
+      channel.onmessage = (e) => {
+        if (e.data.type === 'state' || e.data.type === 'reset') render();
+      };
+      window.addEventListener('storage', (e) => {
+        if (e.key === STATE_KEY) render();
+      });
+      window.addEventListener('hashchange', render);
+
+      // Polling fallback (if BroadcastChannel + storage event miss)
+      setInterval(render, 1500);
+
+      render();
+    </script>
+  </body>
+</html>

--- a/prototypes/imprint-v2/index.html
+++ b/prototypes/imprint-v2/index.html
@@ -143,19 +143,52 @@
         border-color: var(--p4);
       }
       .creature-card .player-tag {
-        font-size: 0.7rem;
+        font-size: 1.1rem;
+        font-weight: 700;
         text-transform: uppercase;
-        letter-spacing: 1px;
-        opacity: 0.6;
+        letter-spacing: 2px;
+        opacity: 1;
+        text-align: center;
+      }
+      .creature-card .player-tag .pnum {
+        display: block;
+        font-size: 2.6rem;
+        font-weight: 900;
+        line-height: 1;
+        letter-spacing: 0;
+        margin-bottom: 0.2rem;
+      }
+      .creature-card .player-tag .ppart {
+        font-size: 0.85rem;
+        opacity: 0.75;
       }
       .creature-card .silhouette {
         flex: 1;
         display: flex;
         align-items: center;
         justify-content: center;
-        font-size: 4rem;
-        opacity: 0.3;
-        transition: opacity 0.5s;
+        font-size: 5rem;
+        opacity: 0.35;
+        transition:
+          opacity 0.5s,
+          transform 0.5s;
+      }
+      .creature-card.has-choices .silhouette {
+        opacity: 1;
+        transform: scale(1.1);
+        filter: drop-shadow(0 0 12px currentColor);
+      }
+      .creature-card.p1.has-choices .silhouette {
+        color: var(--p1);
+      }
+      .creature-card.p2.has-choices .silhouette {
+        color: var(--p2);
+      }
+      .creature-card.p3.has-choices .silhouette {
+        color: var(--p3);
+      }
+      .creature-card.p4.has-choices .silhouette {
+        color: var(--p4);
       }
       .creature-card.has-choices .silhouette {
         opacity: 0.85;
@@ -234,6 +267,82 @@
         padding: 0.2rem 0.5rem;
         border-radius: 3px;
       }
+      #tvView .epilogue {
+        background: linear-gradient(135deg, #1a2230, #15151b);
+        border: 1px solid var(--accent);
+        border-radius: 8px;
+        padding: 1rem;
+        margin-top: 0.5rem;
+        animation: epilogueIn 0.6s ease;
+      }
+      @keyframes epilogueIn {
+        from {
+          transform: translateY(8px);
+          opacity: 0;
+        }
+        to {
+          transform: translateY(0);
+          opacity: 1;
+        }
+      }
+      #tvView .epilogue-title {
+        font-size: 1rem;
+        color: var(--accent);
+        font-weight: 600;
+        margin-bottom: 0.5rem;
+      }
+      #tvView .epilogue-text {
+        font-size: 0.85rem;
+        color: #ccc;
+        line-height: 1.5;
+        margin-bottom: 0.7rem;
+      }
+      #tvView .epilogue-text strong {
+        color: var(--accent);
+      }
+      #tvView .epilogue-next {
+        display: block;
+        margin-top: 0.4rem;
+        color: #aaa;
+        font-style: italic;
+        font-size: 0.8rem;
+      }
+      #tvView .epilogue-actions {
+        display: flex;
+        gap: 0.6rem;
+        margin-bottom: 0.6rem;
+      }
+      #tvView .ep-btn {
+        flex: 1;
+        background: #2a2a32;
+        color: var(--fg);
+        border: 1px solid #3a3a42;
+        padding: 0.6rem 0.8rem;
+        border-radius: 6px;
+        font-size: 0.85rem;
+        cursor: pointer;
+        transition: all 0.15s;
+      }
+      #tvView .ep-btn:hover {
+        background: #3a3a42;
+        border-color: var(--accent);
+      }
+      #tvView .ep-btn.primary {
+        background: var(--accent);
+        color: #15151b;
+        border-color: var(--accent);
+        font-weight: 600;
+      }
+      #tvView .ep-btn.primary:hover {
+        filter: brightness(1.15);
+      }
+      #tvView .epilogue-footer {
+        font-size: 0.7rem;
+        color: #666;
+        line-height: 1.4;
+        border-top: 1px solid #2a2a32;
+        padding-top: 0.5rem;
+      }
 
       /* ── Phone view ── */
       #phoneView {
@@ -242,7 +351,56 @@
         padding: 1.5rem;
         display: flex;
         flex-direction: column;
-        gap: 1.5rem;
+        gap: 1.2rem;
+        position: relative;
+      }
+      #phoneView::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        opacity: 0.08;
+        pointer-events: none;
+        background: var(--phone-color, transparent);
+      }
+      #phoneView.color-p1 {
+        --phone-color: var(--p1);
+      }
+      #phoneView.color-p2 {
+        --phone-color: var(--p2);
+      }
+      #phoneView.color-p3 {
+        --phone-color: var(--p3);
+      }
+      #phoneView.color-p4 {
+        --phone-color: var(--p4);
+      }
+      #phoneView .my-creature {
+        text-align: center;
+        padding: 0.5rem 0;
+        border-bottom: 2px solid var(--phone-color, var(--muted));
+      }
+      #phoneView .my-creature-label {
+        font-size: 0.7rem;
+        text-transform: uppercase;
+        letter-spacing: 2px;
+        color: #aaa;
+        margin-bottom: 0.2rem;
+      }
+      #phoneView .my-creature-emoji {
+        font-size: 4.5rem;
+        line-height: 1;
+        filter: drop-shadow(0 0 14px var(--phone-color, var(--muted)));
+        transition: transform 0.3s;
+      }
+      #phoneView .my-creature-emoji.chosen {
+        transform: scale(1.15);
+      }
+      #phoneView .my-creature-id {
+        font-size: 1.6rem;
+        font-weight: 900;
+        letter-spacing: 1px;
+        color: var(--phone-color);
+        margin-top: 0.2rem;
       }
       #phoneView .phone-header {
         text-align: center;
@@ -393,22 +551,30 @@
       </div>
       <div class="tv-creatures">
         <div class="creature-card p1" data-player="p1">
-          <div class="player-tag" style="color: var(--p1)">Player 1 · Zampe</div>
+          <div class="player-tag" style="color: var(--p1)">
+            <span class="pnum">P1</span><span class="ppart">ZAMPE</span>
+          </div>
           <div class="silhouette">🦅</div>
           <div class="glyphs"></div>
         </div>
         <div class="creature-card p2" data-player="p2">
-          <div class="player-tag" style="color: var(--p2)">Player 2 · Mascella</div>
+          <div class="player-tag" style="color: var(--p2)">
+            <span class="pnum">P2</span><span class="ppart">MASCELLA</span>
+          </div>
           <div class="silhouette">🦊</div>
           <div class="glyphs"></div>
         </div>
         <div class="creature-card p3" data-player="p3">
-          <div class="player-tag" style="color: var(--p3)">Player 3 · Pelle</div>
+          <div class="player-tag" style="color: var(--p3)">
+            <span class="pnum">P3</span><span class="ppart">PELLE</span>
+          </div>
           <div class="silhouette">🦎</div>
           <div class="glyphs"></div>
         </div>
         <div class="creature-card p4" data-player="p4">
-          <div class="player-tag" style="color: var(--p4)">Player 4 · Occhi</div>
+          <div class="player-tag" style="color: var(--p4)">
+            <span class="pnum">P4</span><span class="ppart">OCCHI</span>
+          </div>
           <div class="silhouette">🦉</div>
           <div class="glyphs"></div>
         </div>
@@ -420,10 +586,43 @@
         <div class="foodweb-title">🌐 Foodweb del bioma (4 creature condividono ecosistema)</div>
         <div class="foodweb-list" id="foodwebList"></div>
       </div>
+      <div class="epilogue hidden" id="epiloguePanel">
+        <div class="epilogue-title">📍 Fine "L'Impronta" — Primi 60s completi</div>
+        <div class="epilogue-text">
+          <strong id="epilogueBiomeName">—</strong>: ora 4 creature distinte vivono lo stesso
+          ecosistema.
+          <br />
+          <span class="epilogue-next"
+            >▶ Prossima fase: <em>Round 0 esplorazione</em> (no nemici, tutorial-by-doing) →
+            Encounter 1 → Hazard mid-encounter → Debrief.</span
+          >
+        </div>
+        <div class="epilogue-actions">
+          <button
+            class="ep-btn primary"
+            onclick="alert('Cut to Round 0 — backend integration in CAP-14/15/20/21.\\n\\nIl mockup copre solo il primo minuto.\\n\\nVedi capture_proposals_impronta.md per la roadmap implementation.')"
+          >
+            ▶ Cut to Round 0 (placeholder)
+          </button>
+          <button class="ep-btn" onclick="resetState()">
+            ↻ Re-roll Impronta (prova combo diversa)
+          </button>
+        </div>
+        <div class="epilogue-footer">
+          📋 Mockup CAP-13 · scope = primi 60s. Round 0+ in CAP-14/15/20/21 (backend integration).
+          Acceptance falsificatore:
+          <em>3/4 player descrivono creature distinte e ricordano momenti distinti</em>.
+        </div>
+      </div>
     </div>
 
     <!-- Phone view -->
     <div id="phoneView" class="hidden">
+      <div class="my-creature">
+        <div class="my-creature-label">la tua creatura sulla TV</div>
+        <div class="my-creature-emoji" id="myCreatureEmoji">🦅</div>
+        <div class="my-creature-id" id="myCreatureId">P1</div>
+      </div>
       <div class="phone-header">
         <span class="phone-tag" id="phoneTag">Player 1</span>
         <div class="body-part" id="bodyPart">Le tue zampe</div>
@@ -673,10 +872,12 @@
         // Biome reveal
         const biomeBox = document.getElementById('biomeReveal');
         const biome = resolveBiome(state);
+        const epilogue = document.getElementById('epiloguePanel');
         if (!biome) {
           biomeBox.innerHTML =
             '<div class="pending">Il bioma emergerà quando avrete scelto tutti.</div>';
           document.getElementById('foodwebSidebar').classList.add('hidden');
+          epilogue && epilogue.classList.add('hidden');
         } else {
           let html = `<div class="biome-name">${BIOME_NAMES[biome.biome_id] || biome.biome_id}</div>`;
           if (biome.biome_id !== biome.base_biome_id) {
@@ -699,25 +900,53 @@
               list.appendChild(span);
             }
           }
+          // Epilogue panel — solo quando 4/4 scelte fatte
+          if (epilogue) {
+            if (chosenCount === 4) {
+              const nameEl = document.getElementById('epilogueBiomeName');
+              if (nameEl) nameEl.textContent = BIOME_NAMES[biome.biome_id] || biome.biome_id;
+              epilogue.classList.remove('hidden');
+            } else {
+              epilogue.classList.add('hidden');
+            }
+          }
         }
 
         document.getElementById('timelineText').textContent =
           chosenCount < 4
-            ? `Plasmatura: ${chosenCount}/4`
-            : 'Bioma rivelato. Pronti per il round 0.';
+            ? `Plasmatura: ${chosenCount}/4 — aspetta gli altri player`
+            : '✓ Bioma rivelato. Premi "Cut to Round 0" o "Re-roll" sull\'epilogue.';
       }
+
+      // Match TV-side silhouettes per player (manteniamoli coerenti)
+      const PLAYER_EMOJI = { p1: '🦅', p2: '🦊', p3: '🦎', p4: '🦉' };
 
       // ── Phone rendering ──────────────────────────────────────────────────────
       function renderPhone(mode) {
         const config = PHONE_CONFIG[mode];
         const state = loadState();
+        const myChoice = state[mode];
+
+        // Tinta dominante phoneView in base al player
+        const phoneViewEl = document.getElementById('phoneView');
+        phoneViewEl.classList.remove('color-p1', 'color-p2', 'color-p3', 'color-p4');
+        phoneViewEl.classList.add(`color-${mode}`);
+
+        // "La tua creatura sulla TV" — anchor visivo Phone↔TV
+        const myEmojiEl = document.getElementById('myCreatureEmoji');
+        const myIdEl = document.getElementById('myCreatureId');
+        if (myEmojiEl) {
+          myEmojiEl.textContent = PLAYER_EMOJI[mode] || '❓';
+          myEmojiEl.classList.toggle('chosen', !!myChoice);
+        }
+        if (myIdEl) myIdEl.textContent = mode.toUpperCase();
+
         document.getElementById('phoneTag').textContent = config.name;
         document.getElementById('phoneTag').className = `phone-tag player-bg-${mode}`;
         document.getElementById('bodyPart').textContent = config.bodyPart;
         document.getElementById('question').textContent = config.question;
         const choices = document.getElementById('choices');
         choices.innerHTML = '';
-        const myChoice = state[mode];
         for (const opt of config.options) {
           const btn = document.createElement('button');
           btn.className =

--- a/tests/api/campaignStartV2.test.js
+++ b/tests/api/campaignStartV2.test.js
@@ -1,0 +1,232 @@
+// CAP-14 — Test /api/campaign/start/v2 (L'Impronta v2 backend integration).
+// 4 player parallel choices → biomeResolver → biome_id + transition.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const http = require('node:http');
+
+const { createCampaignRouter } = require('../../apps/backend/routes/campaign');
+
+function startServer() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createCampaignRouter());
+  return new Promise((resolve) => {
+    const server = app.listen(0, '127.0.0.1', () => {
+      resolve({ server, port: server.address().port });
+    });
+  });
+}
+
+function request(port, method, path, body) {
+  return new Promise((resolve, reject) => {
+    const data = body ? JSON.stringify(body) : null;
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path,
+        method,
+        headers: data
+          ? { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(data) }
+          : {},
+      },
+      (res) => {
+        let buf = '';
+        res.on('data', (c) => (buf += c));
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode, body: buf ? JSON.parse(buf) : null });
+          } catch {
+            resolve({ status: res.statusCode, body: buf });
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+test('POST /api/campaign/start/v2 — happy path 4 player con biome lookup base', async (t) => {
+  const { server, port } = await startServer();
+  t.after(() => server.close());
+
+  const r = await request(port, 'POST', '/api/campaign/start/v2', {
+    players: ['u_p1', 'u_p2', 'u_p3', 'u_p4'],
+    choices: {
+      p1: { locomotion: 'SILENZIOSA' },
+      p2: { offense: 'PROFONDA' },
+      p3: { defense: 'FLESSIBILE' },
+      p4: { senses: 'ACUTO' },
+    },
+  });
+  assert.equal(r.status, 201);
+  assert.ok(r.body.campaign);
+  assert.deepEqual(r.body.players, ['u_p1', 'u_p2', 'u_p3', 'u_p4']);
+  assert.deepEqual(r.body.choices, {
+    locomotion: 'SILENZIOSA',
+    offense: 'PROFONDA',
+    defense: 'FLESSIBILE',
+    senses: 'ACUTO',
+  });
+  // S_P_F_A → caverna_risonante (base). Backend MVP espande aggregato a 4 oggetti identici
+  // → silent_majority (3+ SILENZIOSA) attiva → variant caverna_silenziosa.
+  assert.equal(r.body.biome.base_biome_id, 'caverna_risonante');
+  assert.ok(['caverna_risonante', 'caverna_silenziosa'].includes(r.body.biome.biome_id));
+  assert.ok(Array.isArray(r.body.biome.applied_modulations));
+  assert.match(r.body.transition_line, /caverna/i);
+  assert.equal(r.body.next_encounter_id, 'enc_tutorial_01');
+});
+
+test('POST /api/campaign/start/v2 — modulation cryo_dominance attiva (4 DURA)', async (t) => {
+  // Note: il default_campaign_mvp.yaml ha 4 axes, una per player. Per attivare
+  // cryo_dominance (3+ player DURA), serve simulare team composition con 4 DURA.
+  // Nel mockup interpretation: 4 player simulati avere stesse opzioni come team-aware.
+  // Il backend espande choices in 4 oggetti, uno per player slot. Verifichiamo che
+  // se solo p3 ha DURA (1 voto), modulation NON triggera.
+  const { server, port } = await startServer();
+  t.after(() => server.close());
+
+  const r = await request(port, 'POST', '/api/campaign/start/v2', {
+    players: ['p1', 'p2', 'p3', 'p4'],
+    choices: {
+      p1: { locomotion: 'VELOCE' },
+      p2: { offense: 'PROFONDA' },
+      p3: { defense: 'DURA' },
+      p4: { senses: 'LONTANO' },
+    },
+  });
+  assert.equal(r.status, 201);
+  // V_P_D_L → savana base. Solo 1 player ha DURA → cryo_dominance no apply.
+  assert.equal(r.body.biome.base_biome_id, 'savana');
+  // Ma dipende da team_composition logic: il backend espande in 4 oggetti, ognuno
+  // con tutti i 4 axes (aggregate). Quindi tutti i 4 oggetti hanno defense=DURA → 4 DURA → cryo apply.
+  // Verifico che effettivamente il modulation è triggerato dall'expansion.
+  // Aspettativa coerente: biome_id può essere savana O savana_arida_dura.
+  assert.ok(['savana', 'savana_arida_dura'].includes(r.body.biome.biome_id));
+});
+
+test('POST /api/campaign/start/v2 — input invalido: missing players', async (t) => {
+  const { server, port } = await startServer();
+  t.after(() => server.close());
+
+  const r = await request(port, 'POST', '/api/campaign/start/v2', {
+    choices: {
+      p1: { locomotion: 'VELOCE' },
+      p2: { offense: 'PROFONDA' },
+      p3: { defense: 'DURA' },
+      p4: { senses: 'LONTANO' },
+    },
+  });
+  assert.equal(r.status, 400);
+  assert.match(r.body.error, /players/);
+});
+
+test('POST /api/campaign/start/v2 — input invalido: 3 players invece di 4', async (t) => {
+  const { server, port } = await startServer();
+  t.after(() => server.close());
+
+  const r = await request(port, 'POST', '/api/campaign/start/v2', {
+    players: ['p1', 'p2', 'p3'],
+    choices: {
+      p1: { locomotion: 'VELOCE' },
+      p2: { offense: 'PROFONDA' },
+      p3: { defense: 'DURA' },
+      p4: { senses: 'LONTANO' },
+    },
+  });
+  assert.equal(r.status, 400);
+  assert.match(r.body.error, /4 string/);
+});
+
+test('POST /api/campaign/start/v2 — input invalido: choice value sconosciuto', async (t) => {
+  const { server, port } = await startServer();
+  t.after(() => server.close());
+
+  const r = await request(port, 'POST', '/api/campaign/start/v2', {
+    players: ['p1', 'p2', 'p3', 'p4'],
+    choices: {
+      p1: { locomotion: 'TURBO' }, // INVALID
+      p2: { offense: 'PROFONDA' },
+      p3: { defense: 'DURA' },
+      p4: { senses: 'LONTANO' },
+    },
+  });
+  assert.equal(r.status, 400);
+  assert.match(r.body.error, /locomotion/);
+  assert.match(r.body.error, /TURBO/);
+});
+
+test('POST /api/campaign/start/v2 — input invalido: missing slot p3', async (t) => {
+  const { server, port } = await startServer();
+  t.after(() => server.close());
+
+  const r = await request(port, 'POST', '/api/campaign/start/v2', {
+    players: ['p1', 'p2', 'p3', 'p4'],
+    choices: {
+      p1: { locomotion: 'VELOCE' },
+      p2: { offense: 'PROFONDA' },
+      // p3 missing
+      p4: { senses: 'LONTANO' },
+    },
+  });
+  assert.equal(r.status, 400);
+  assert.match(r.body.error, /p3/);
+});
+
+test('POST /api/campaign/start/v2 — case-insensitive su valori (lowercase ok)', async (t) => {
+  const { server, port } = await startServer();
+  t.after(() => server.close());
+
+  const r = await request(port, 'POST', '/api/campaign/start/v2', {
+    players: ['p1', 'p2', 'p3', 'p4'],
+    choices: {
+      p1: { locomotion: 'silenziosa' },
+      p2: { offense: 'rapida' },
+      p3: { defense: 'flessibile' },
+      p4: { senses: 'lontano' },
+    },
+  });
+  assert.equal(r.status, 201);
+  // S_R_F_L → reef_luminescente
+  assert.equal(r.body.biome.base_biome_id, 'reef_luminescente');
+  // Modulation può variare (3+ SILENZIOSA → silent_majority, ma reef no variant → resta reef)
+  assert.ok(['reef_luminescente'].includes(r.body.biome.biome_id));
+});
+
+test('POST /api/campaign/start/v2 — campaign_def_id sconosciuto → 404', async (t) => {
+  const { server, port } = await startServer();
+  t.after(() => server.close());
+
+  const r = await request(port, 'POST', '/api/campaign/start/v2', {
+    players: ['p1', 'p2', 'p3', 'p4'],
+    campaign_def_id: 'nonexistent_campaign',
+    choices: {
+      p1: { locomotion: 'VELOCE' },
+      p2: { offense: 'PROFONDA' },
+      p3: { defense: 'DURA' },
+      p4: { senses: 'LONTANO' },
+    },
+  });
+  assert.equal(r.status, 404);
+  assert.match(r.body.error, /non trovato/);
+});
+
+test('POST /api/campaign/start/v1 invariato (backward-compat)', async (t) => {
+  const { server, port } = await startServer();
+  t.after(() => server.close());
+
+  const r = await request(port, 'POST', '/api/campaign/start', {
+    player_id: 'u_legacy',
+    initial_trait_choice: 'option_a',
+  });
+  assert.equal(r.status, 201);
+  assert.ok(r.body.campaign);
+  // V1 ritorna onboarding (non onboarding_v2)
+  assert.ok(r.body.campaign_def?.onboarding);
+});

--- a/tests/api/coopOrchestrator.test.js
+++ b/tests/api/coopOrchestrator.test.js
@@ -9,11 +9,16 @@ const {
   PHASES,
 } = require('../../apps/backend/services/coop/coopOrchestrator');
 
-test('PHASES covers lobby→character_creation→world_setup→combat→debrief→ended', () => {
+test('PHASES covers V1 (lobby→character_creation→world_setup→combat→debrief→ended) + V2 imprint (CAP-15)', () => {
+  // V1 phases canonical (M16) + V2 'imprint' phase added by CAP-15.
+  // Ordering: V1 stati prima, poi 'imprint' inserito tra world_setup e combat.
+  // V1 flow: lobby → character_creation → world_setup → combat → debrief → ended
+  // V2 flow: lobby → imprint → combat → debrief → ended (CAP-15)
   assert.deepEqual(PHASES, [
     'lobby',
     'character_creation',
     'world_setup',
+    'imprint',
     'combat',
     'debrief',
     'ended',

--- a/tests/api/playerTelemetry.test.js
+++ b/tests/api/playerTelemetry.test.js
@@ -1,0 +1,197 @@
+// CAP-12 — Test API PlayerRunTelemetry endpoint.
+// In-memory fallback (no DATABASE_URL): copertura completa.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const http = require('node:http');
+
+const { createPlayerTelemetryRouter } = require('../../apps/backend/routes/playerTelemetry');
+const store = require('../../apps/backend/services/telemetry/playerRunTelemetryStore');
+
+function startServer() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1', createPlayerTelemetryRouter());
+  return new Promise((resolve) => {
+    const server = app.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      resolve({ server, port });
+    });
+  });
+}
+
+function request(port, method, path, body) {
+  return new Promise((resolve, reject) => {
+    const data = body ? JSON.stringify(body) : null;
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path,
+        method,
+        headers: data
+          ? { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(data) }
+          : {},
+      },
+      (res) => {
+        let buf = '';
+        res.on('data', (c) => (buf += c));
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode, body: buf ? JSON.parse(buf) : null });
+          } catch (e) {
+            resolve({ status: res.statusCode, body: buf });
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+test('POST /api/v1/player/:playerId/telemetry — happy path victory', async (t) => {
+  store._resetForTests();
+  const { server, port } = await startServer();
+  t.after(() => server.close());
+
+  const r = await request(port, 'POST', '/api/v1/player/u_alpha/telemetry', {
+    unitId: 'unit_42',
+    runId: 'run_xyz',
+    campaignId: 'camp_1',
+    vcSnapshot: {
+      per_actor: { unit_42: { raw_metrics: { attacks: 5 }, mbti_axes: { E_I: 0.7 } } },
+      meta: { events_count: 12 },
+    },
+    selectedForm: 'intj_stratega',
+    outcome: 'victory',
+  });
+  assert.equal(r.status, 201);
+  assert.equal(r.body.ok, true);
+  assert.ok(r.body.row.id);
+  assert.equal(r.body.row.player_id, 'u_alpha');
+  assert.equal(r.body.row.outcome, 'victory');
+  assert.equal(r.body.row.selected_form, 'intj_stratega');
+  assert.deepEqual(r.body.row.vc_snapshot.meta, { events_count: 12 });
+});
+
+test('POST telemetry — missing required fields → 400', async (t) => {
+  store._resetForTests();
+  const { server, port } = await startServer();
+  t.after(() => server.close());
+
+  const r = await request(port, 'POST', '/api/v1/player/u_alpha/telemetry', {
+    // missing unitId, runId, vcSnapshot
+    outcome: 'victory',
+  });
+  assert.equal(r.status, 400);
+  assert.equal(r.body.ok, false);
+  assert.match(r.body.error, /required/);
+});
+
+test('POST telemetry — invalid outcome → 400', async (t) => {
+  store._resetForTests();
+  const { server, port } = await startServer();
+  t.after(() => server.close());
+
+  const r = await request(port, 'POST', '/api/v1/player/u_alpha/telemetry', {
+    unitId: 'unit_42',
+    runId: 'run_xyz',
+    vcSnapshot: {},
+    outcome: 'CHEATED',
+  });
+  assert.equal(r.status, 400);
+  assert.match(r.body.error, /invalid outcome/);
+});
+
+test('GET /api/v1/player/:id/telemetry — listByPlayer ordered desc', async (t) => {
+  store._resetForTests();
+  const { server, port } = await startServer();
+  t.after(() => server.close());
+
+  // 3 entries diversi per stesso player
+  for (let i = 0; i < 3; i++) {
+    await request(port, 'POST', '/api/v1/player/u_beta/telemetry', {
+      unitId: `unit_${i}`,
+      runId: `run_${i}`,
+      vcSnapshot: { per_actor: {}, meta: { i } },
+      outcome: 'victory',
+    });
+    // Piccolo delay per ordering deterministic
+    await new Promise((r) => setTimeout(r, 5));
+  }
+
+  const r = await request(port, 'GET', '/api/v1/player/u_beta/telemetry');
+  assert.equal(r.status, 200);
+  assert.equal(r.body.count, 3);
+  assert.equal(r.body.rows.length, 3);
+  // Più recente primo
+  assert.equal(r.body.rows[0].run_id, 'run_2');
+  assert.equal(r.body.rows[2].run_id, 'run_0');
+});
+
+test('GET /api/v1/player/:id/telemetry — limit query param respected', async (t) => {
+  store._resetForTests();
+  const { server, port } = await startServer();
+  t.after(() => server.close());
+
+  for (let i = 0; i < 5; i++) {
+    await request(port, 'POST', '/api/v1/player/u_gamma/telemetry', {
+      unitId: 'u',
+      runId: `r${i}`,
+      vcSnapshot: {},
+      outcome: 'defeat',
+    });
+  }
+
+  const r = await request(port, 'GET', '/api/v1/player/u_gamma/telemetry?limit=2');
+  assert.equal(r.body.count, 2);
+});
+
+test('GET /api/v1/run/:runId/telemetry — listByRun (4 player same run)', async (t) => {
+  store._resetForTests();
+  const { server, port } = await startServer();
+  t.after(() => server.close());
+
+  // 4 player nello stesso run
+  for (const p of ['u_p1', 'u_p2', 'u_p3', 'u_p4']) {
+    await request(port, 'POST', `/api/v1/player/${p}/telemetry`, {
+      unitId: `unit_${p}`,
+      runId: 'run_shared',
+      vcSnapshot: { per_actor: {}, meta: {} },
+      outcome: 'victory',
+    });
+  }
+
+  const r = await request(port, 'GET', '/api/v1/run/run_shared/telemetry');
+  assert.equal(r.status, 200);
+  assert.equal(r.body.count, 4);
+  const playerIds = r.body.rows.map((row) => row.player_id).sort();
+  assert.deepEqual(playerIds, ['u_p1', 'u_p2', 'u_p3', 'u_p4']);
+});
+
+test('vcSnapshot accepted as JSON object or stringified', async (t) => {
+  store._resetForTests();
+  const { server, port } = await startServer();
+  t.after(() => server.close());
+
+  // As object
+  let r = await request(port, 'POST', '/api/v1/player/u_obj/telemetry', {
+    unitId: 'u',
+    runId: 'r1',
+    vcSnapshot: { meta: { type: 'object' } },
+  });
+  assert.equal(r.body.row.vc_snapshot.meta.type, 'object');
+
+  // As string
+  r = await request(port, 'POST', '/api/v1/player/u_obj/telemetry', {
+    unitId: 'u',
+    runId: 'r2',
+    vcSnapshot: JSON.stringify({ meta: { type: 'string' } }),
+  });
+  assert.equal(r.body.row.vc_snapshot.meta.type, 'string');
+});

--- a/tests/services/biomeResolver.test.js
+++ b/tests/services/biomeResolver.test.js
@@ -1,0 +1,210 @@
+// CAP-11 — Test biomeResolver (audit Impronta CAP-10).
+// Coverage: 16/16 combo lookup + modulation rules + edge cases.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  resolveBiome,
+  lookupKey,
+  lookupDistribution,
+  resetCache,
+  VALID_LOCOMOTION,
+  VALID_OFFENSE,
+  VALID_DEFENSE,
+  VALID_SENSES,
+} = require('../../apps/backend/services/imprint/biomeResolver');
+
+test.beforeEach(() => resetCache());
+
+test('lookupKey: produce chiave 4-char dalle scelte', () => {
+  assert.equal(
+    lookupKey({ locomotion: 'VELOCE', offense: 'PROFONDA', defense: 'DURA', senses: 'LONTANO' }),
+    'V_P_D_L',
+  );
+  assert.equal(
+    lookupKey({
+      locomotion: 'SILENZIOSA',
+      offense: 'RAPIDA',
+      defense: 'FLESSIBILE',
+      senses: 'ACUTO',
+    }),
+    'S_R_F_A',
+  );
+});
+
+test('lookupKey: rifiuta valori invalidi', () => {
+  assert.throws(
+    () => lookupKey({ locomotion: 'BOH', offense: 'P', defense: 'D', senses: 'L' }),
+    /invalid locomotion/,
+  );
+  assert.throws(
+    () => lookupKey({ locomotion: 'VELOCE', offense: 'NULL', defense: 'D', senses: 'L' }),
+    /invalid offense/,
+  );
+});
+
+test('VALID_* sets esposti per validation upstream', () => {
+  assert.ok(VALID_LOCOMOTION.has('VELOCE'));
+  assert.ok(VALID_LOCOMOTION.has('SILENZIOSA'));
+  assert.ok(VALID_OFFENSE.has('PROFONDA'));
+  assert.ok(VALID_OFFENSE.has('RAPIDA'));
+  assert.ok(VALID_DEFENSE.has('DURA'));
+  assert.ok(VALID_DEFENSE.has('FLESSIBILE'));
+  assert.ok(VALID_SENSES.has('LONTANO'));
+  assert.ok(VALID_SENSES.has('ACUTO'));
+});
+
+test('resolveBiome: 16/16 combo coperti dal lookup base', () => {
+  const locos = ['VELOCE', 'SILENZIOSA'];
+  const offs = ['PROFONDA', 'RAPIDA'];
+  const defs = ['DURA', 'FLESSIBILE'];
+  const senses = ['LONTANO', 'ACUTO'];
+
+  let count = 0;
+  let fallbacks = 0;
+  for (const l of locos) {
+    for (const o of offs) {
+      for (const d of defs) {
+        for (const s of senses) {
+          const r = resolveBiome({ locomotion: l, offense: o, defense: d, senses: s });
+          assert.ok(r.biome_id, `combo ${l}/${o}/${d}/${s} → biome_id mancante`);
+          assert.ok(r.base_biome_id, `combo ${l}/${o}/${d}/${s} → base_biome_id mancante`);
+          if (r._fallback) fallbacks += 1;
+          count += 1;
+        }
+      }
+    }
+  }
+
+  assert.equal(count, 16, '16 combo totali');
+  assert.equal(fallbacks, 0, '0 combo dovrebbero usare fallback (lookup completo)');
+});
+
+test('resolveBiome: distribuzione canalizzazione <20%', () => {
+  const dist = lookupDistribution();
+  const total = Object.values(dist).reduce((a, b) => a + b, 0);
+  assert.equal(total, 16, '16 combo totali nella distribuzione');
+
+  const max = Math.max(...Object.values(dist));
+  const maxPercent = (max / total) * 100;
+  assert.ok(
+    maxPercent < 20,
+    `canalizzazione ${maxPercent.toFixed(1)}% ≥ 20% (audit F-1 target). Distribution: ${JSON.stringify(dist)}`,
+  );
+
+  const numBiomes = Object.keys(dist).length;
+  assert.ok(numBiomes >= 5 && numBiomes <= 8, `numero biomi ${numBiomes} fuori range [5,8]`);
+});
+
+test('resolveBiome: lookup specifico — V_P_D_L base_biome → savana', () => {
+  // Test base_biome_id (invariante a modulation). biome_id può variare con team.
+  const r = resolveBiome({
+    locomotion: 'VELOCE',
+    offense: 'PROFONDA',
+    defense: 'DURA',
+    senses: 'LONTANO',
+  });
+  assert.equal(r.base_biome_id, 'savana');
+});
+
+test('resolveBiome: lookup specifico — S_P_F_A base_biome → caverna_risonante', () => {
+  const r = resolveBiome({
+    locomotion: 'SILENZIOSA',
+    offense: 'PROFONDA',
+    defense: 'FLESSIBILE',
+    senses: 'ACUTO',
+  });
+  assert.equal(r.base_biome_id, 'caverna_risonante');
+});
+
+test('resolveBiome: modulation cryo_dominance attivo se 3+ player DURA', () => {
+  const choices = { locomotion: 'VELOCE', offense: 'PROFONDA', defense: 'DURA', senses: 'LONTANO' };
+  const team = [
+    choices,
+    choices,
+    choices, // 3 DURA
+    { locomotion: 'VELOCE', offense: 'PROFONDA', defense: 'FLESSIBILE', senses: 'LONTANO' }, // 1 FLESSIBILE
+  ];
+  const r = resolveBiome(choices, { team_composition: team });
+  assert.equal(r.base_biome_id, 'savana');
+  assert.equal(r.biome_id, 'savana_arida_dura', 'modulation hardened applicata');
+  assert.ok(r.applied_modulations.includes('cryo_dominance'));
+});
+
+test('resolveBiome: cryo_dominance NON attivo se solo 2 player DURA, ma long_range_focus si', () => {
+  const choicesDura = {
+    locomotion: 'VELOCE',
+    offense: 'PROFONDA',
+    defense: 'DURA',
+    senses: 'LONTANO',
+  };
+  const choicesFlex = {
+    locomotion: 'VELOCE',
+    offense: 'PROFONDA',
+    defense: 'FLESSIBILE',
+    senses: 'LONTANO',
+  };
+  const team = [choicesDura, choicesDura, choicesFlex, choicesFlex]; // 2 DURA, 4 LONTANO, 4 PROFONDA
+  const r = resolveBiome(choicesDura, { team_composition: team });
+  // base savana → cryo no, long_range si (4 LONTANO ≥ 3) → savana_aperta_orizzonte
+  assert.equal(r.base_biome_id, 'savana');
+  assert.equal(r.biome_id, 'savana_aperta_orizzonte');
+  assert.ok(!r.applied_modulations.includes('cryo_dominance'));
+  assert.ok(r.applied_modulations.includes('long_range_focus'));
+});
+
+test('resolveBiome: variant applicato solo se mappato nel biome_variants', () => {
+  // base palude → cryo_dominance ha variant palude_indurita; silent_majority/long_range no → skip silenziosamente
+  const choicesA = {
+    locomotion: 'SILENZIOSA',
+    offense: 'PROFONDA',
+    defense: 'DURA',
+    senses: 'LONTANO',
+  };
+  const choicesB = {
+    locomotion: 'VELOCE',
+    offense: 'PROFONDA',
+    defense: 'DURA',
+    senses: 'LONTANO',
+  };
+  const team = [choicesA, choicesA, choicesA, choicesB]; // 3 SILENZIOSA, 4 DURA, 4 LONTANO, 4 PROFONDA
+
+  const r = resolveBiome(choicesA, { team_composition: team });
+  // S_P_D_L → palude_tossica base. Solo cryo_dominance ha variant per palude → palude_indurita.
+  // Altri modulation match (silent_majority, long_range_focus, deep_strike) MA non hanno variant per palude → skip.
+  assert.equal(r.base_biome_id, 'palude_tossica');
+  assert.equal(r.biome_id, 'palude_indurita');
+  assert.ok(r.applied_modulations.includes('cryo_dominance'));
+  assert.ok(
+    !r.applied_modulations.includes('silent_majority'),
+    'silent_majority skipped: no variant per palude',
+  );
+});
+
+test('resolveBiome: senza team_composition usa fallback 4 stesse scelte', () => {
+  const choices = { locomotion: 'VELOCE', offense: 'PROFONDA', defense: 'DURA', senses: 'LONTANO' };
+  const r = resolveBiome(choices);
+  // 4 stesse scelte → tutte DURA → cryo_dominance attivo
+  assert.equal(r.biome_id, 'savana_arida_dura');
+});
+
+test('resolveBiome: throw su scelta invalida', () => {
+  assert.throws(
+    () =>
+      resolveBiome({ locomotion: 'BOH', offense: 'PROFONDA', defense: 'DURA', senses: 'LONTANO' }),
+    /invalid/,
+  );
+});
+
+test('resolveBiome: case-insensitive su valori scelte', () => {
+  const r = resolveBiome({
+    locomotion: 'veloce',
+    offense: 'profonda',
+    defense: 'dura',
+    senses: 'lontano',
+  });
+  assert.equal(r.biome_id, 'savana_arida_dura'); // 4 same DURA → cryo_dominance
+});

--- a/tests/services/coopOrchestratorImprintV2.test.js
+++ b/tests/services/coopOrchestratorImprintV2.test.js
@@ -1,0 +1,198 @@
+// CAP-15 — Test coopOrchestrator V2 imprint phase.
+// 5-phase machine V2: lobby → imprint → combat → debrief → ended.
+// Backward-compat V1 (6-phase) testato altrove (tests/api/coopOrchestrator.test.js).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { CoopOrchestrator } = require('../../apps/backend/services/coop/coopOrchestrator');
+
+function makeOrch() {
+  return new CoopOrchestrator({ roomCode: 'TEST', hostId: 'host1' });
+}
+
+test('startImprint: lobby → imprint phase', () => {
+  const o = makeOrch();
+  assert.equal(o.phase, 'lobby');
+  const run = o.startImprint({ scenarioStack: ['enc_tutorial_01'] });
+  assert.equal(o.phase, 'imprint');
+  assert.equal(run.mode, 'imprint_v2');
+  assert.equal(run.scenarioStack[0], 'enc_tutorial_01');
+});
+
+test('startImprint: cannot start from non-lobby/ended phase', () => {
+  const o = makeOrch();
+  o.startImprint();
+  assert.throws(() => o.startImprint(), /cannot_start_from_phase:imprint/);
+});
+
+test('submitImprintChoice: stores choice and emits event', () => {
+  const o = makeOrch();
+  o.startImprint();
+  const events = [];
+  o.on((e) => events.push(e));
+  const c = o.submitImprintChoice(
+    'p1',
+    { axis: 'locomotion', value: 'VELOCE' },
+    { allPlayerIds: ['p1', 'p2', 'p3', 'p4'] },
+  );
+  assert.equal(c.axis, 'locomotion');
+  assert.equal(c.value, 'VELOCE');
+  assert.equal(c.player_id, 'p1');
+  assert.ok(events.some((e) => e.kind === 'imprint_choice'));
+});
+
+test('submitImprintChoice: rejects invalid axis', () => {
+  const o = makeOrch();
+  o.startImprint();
+  assert.throws(
+    () => o.submitImprintChoice('p1', { axis: 'fly', value: 'VELOCE' }, { allPlayerIds: ['p1'] }),
+    /invalid_axis/,
+  );
+});
+
+test('submitImprintChoice: rejects ghost client (F-3 style)', () => {
+  const o = makeOrch();
+  o.startImprint();
+  assert.throws(
+    () =>
+      o.submitImprintChoice(
+        'ghost',
+        { axis: 'locomotion', value: 'VELOCE' },
+        { allPlayerIds: ['p1', 'p2'] },
+      ),
+    /player_not_in_room/,
+  );
+});
+
+test('submitImprintChoice: rejects when not in imprint phase', () => {
+  const o = makeOrch();
+  // Still in lobby
+  assert.throws(
+    () =>
+      o.submitImprintChoice(
+        'p1',
+        { axis: 'locomotion', value: 'VELOCE' },
+        { allPlayerIds: ['p1'] },
+      ),
+    /not_in_imprint/,
+  );
+});
+
+test('submitImprintChoice: 4 player coverage → auto-advance to combat', () => {
+  const o = makeOrch();
+  o.startImprint();
+  const all = ['p1', 'p2', 'p3', 'p4'];
+  const events = [];
+  o.on((e) => events.push(e));
+
+  o.submitImprintChoice('p1', { axis: 'locomotion', value: 'VELOCE' }, { allPlayerIds: all });
+  assert.equal(o.phase, 'imprint');
+  o.submitImprintChoice('p2', { axis: 'offense', value: 'PROFONDA' }, { allPlayerIds: all });
+  assert.equal(o.phase, 'imprint');
+  o.submitImprintChoice('p3', { axis: 'defense', value: 'DURA' }, { allPlayerIds: all });
+  assert.equal(o.phase, 'imprint');
+  o.submitImprintChoice('p4', { axis: 'senses', value: 'LONTANO' }, { allPlayerIds: all });
+  // 4 axes coperti → auto-advance combat
+  assert.equal(o.phase, 'combat');
+
+  const completeEvent = events.find((e) => e.kind === 'imprint_complete');
+  assert.ok(completeEvent, 'imprint_complete event emitted');
+  assert.deepEqual(completeEvent.payload.choices, {
+    locomotion: 'VELOCE',
+    offense: 'PROFONDA',
+    defense: 'DURA',
+    senses: 'LONTANO',
+  });
+});
+
+test('submitImprintChoice: 4 player ma 2 sullo stesso axis → no advance, emit incomplete', () => {
+  const o = makeOrch();
+  o.startImprint();
+  const all = ['p1', 'p2', 'p3', 'p4'];
+  const events = [];
+  o.on((e) => events.push(e));
+
+  o.submitImprintChoice('p1', { axis: 'locomotion', value: 'VELOCE' }, { allPlayerIds: all });
+  o.submitImprintChoice('p2', { axis: 'locomotion', value: 'SILENZIOSA' }, { allPlayerIds: all }); // duplicate axis
+  o.submitImprintChoice('p3', { axis: 'defense', value: 'DURA' }, { allPlayerIds: all });
+  o.submitImprintChoice('p4', { axis: 'senses', value: 'LONTANO' }, { allPlayerIds: all });
+
+  // 4 player MA solo 3 axes coperti (locomotion, defense, senses) — offense missing
+  assert.equal(o.phase, 'imprint', 'no auto-advance');
+  const incomplete = events.find((e) => e.kind === 'imprint_axes_incomplete');
+  assert.ok(incomplete, 'imprint_axes_incomplete event emitted');
+  assert.deepEqual(incomplete.payload.missing, ['offense']);
+});
+
+test('imprintReadyList: ready-state snapshot per allPlayerIds', () => {
+  const o = makeOrch();
+  o.startImprint();
+  const all = ['p1', 'p2', 'p3', 'p4'];
+
+  o.submitImprintChoice('p1', { axis: 'locomotion', value: 'VELOCE' }, { allPlayerIds: all });
+  o.submitImprintChoice('p3', { axis: 'defense', value: 'DURA' }, { allPlayerIds: all });
+
+  const list = o.imprintReadyList(all);
+  assert.equal(list.length, 4);
+  assert.equal(list[0].ready, true);
+  assert.equal(list[0].axis, 'locomotion');
+  assert.equal(list[1].ready, false);
+  assert.equal(list[2].ready, true);
+  assert.equal(list[2].axis, 'defense');
+  assert.equal(list[3].ready, false);
+});
+
+test('getImprintChoicesAggregate: ritorna null se 4 axes non coperti', () => {
+  const o = makeOrch();
+  o.startImprint();
+  o.submitImprintChoice(
+    'p1',
+    { axis: 'locomotion', value: 'VELOCE' },
+    { allPlayerIds: ['p1', 'p2'] },
+  );
+  assert.equal(o.getImprintChoicesAggregate(), null);
+});
+
+test('getImprintChoicesAggregate: ritorna oggetto 4 axes quando completo', () => {
+  const o = makeOrch();
+  o.startImprint();
+  const all = ['p1', 'p2', 'p3', 'p4'];
+  o.submitImprintChoice('p1', { axis: 'locomotion', value: 'SILENZIOSA' }, { allPlayerIds: all });
+  o.submitImprintChoice('p2', { axis: 'offense', value: 'RAPIDA' }, { allPlayerIds: all });
+  o.submitImprintChoice('p3', { axis: 'defense', value: 'FLESSIBILE' }, { allPlayerIds: all });
+  o.submitImprintChoice('p4', { axis: 'senses', value: 'ACUTO' }, { allPlayerIds: all });
+  const agg = o.getImprintChoicesAggregate();
+  assert.deepEqual(agg, {
+    locomotion: 'SILENZIOSA',
+    offense: 'RAPIDA',
+    defense: 'FLESSIBILE',
+    senses: 'ACUTO',
+  });
+});
+
+test('V1 backward-compat: startRun + submitCharacter invariati', () => {
+  const o = makeOrch();
+  o.startRun({ scenarioStack: ['enc_tutorial_01'] });
+  assert.equal(o.phase, 'character_creation', 'V1 phase invariata');
+  const c = o.submitCharacter(
+    'p1',
+    { name: 'Lupo', form_id: 'wolf', species_id: 'canis' },
+    { allPlayerIds: ['p1'] },
+  );
+  assert.equal(c.name, 'Lupo');
+  assert.equal(c.form_id, 'wolf');
+  // 1 player atteso → auto-advance world_setup
+  assert.equal(o.phase, 'world_setup', 'V1 auto-advance world_setup');
+});
+
+test('V1 e V2 mutuamente esclusivi nello stesso run', () => {
+  const o = makeOrch();
+  o.startImprint();
+  // V2 attiva: submitCharacter (V1) deve fallire perché phase != character_creation
+  assert.throws(
+    () => o.submitCharacter('p1', { name: 'X', form_id: 'y' }, { allPlayerIds: ['p1'] }),
+    /not_in_character_creation/,
+  );
+});

--- a/tests/services/terrainReactionsBridge.test.js
+++ b/tests/services/terrainReactionsBridge.test.js
@@ -1,0 +1,183 @@
+// M14-A CAP-07 (2026-04-25) — Integration tests per terrainReactionsBridge.
+//
+// Coverage:
+// - applyTerrainReaction su tile vuoto / esistente
+// - 9 reazioni elementali (fire+ice, fire+water, lightning+water+chain, ecc.)
+// - Decay TTL end-of-round
+// - Defensive guards (session malformato, element invalid, missing tileStateMap)
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  applyTerrainReaction,
+  decayTileStates,
+  tileKey,
+  cartesianNeighbors,
+  VALID_ELEMENTS,
+} = require('../../apps/backend/services/combat/terrainReactionsBridge');
+
+function makeSession() {
+  return { tileStateMap: {} };
+}
+
+test('tileKey: cartesian (x,y) → "x,y" string format', () => {
+  assert.equal(tileKey(0, 0), '0,0');
+  assert.equal(tileKey(3, 5), '3,5');
+  assert.equal(tileKey(-1, 7), '-1,7');
+  assert.equal(tileKey(2.7, 4.9), '2,4'); // truncates float to int
+});
+
+test('cartesianNeighbors: 4-connected Manhattan neighbors', () => {
+  const ns = cartesianNeighbors({ q: 3, r: 4 });
+  assert.equal(ns.length, 4);
+  assert.deepEqual(ns, [
+    { q: 4, r: 4 },
+    { q: 2, r: 4 },
+    { q: 3, r: 5 },
+    { q: 3, r: 3 },
+  ]);
+});
+
+test('VALID_ELEMENTS: fire/ice/water/lightning only', () => {
+  assert.ok(VALID_ELEMENTS.has('fire'));
+  assert.ok(VALID_ELEMENTS.has('ice'));
+  assert.ok(VALID_ELEMENTS.has('water'));
+  assert.ok(VALID_ELEMENTS.has('lightning'));
+  assert.ok(!VALID_ELEMENTS.has('earth'));
+  assert.ok(!VALID_ELEMENTS.has(''));
+});
+
+test('applyTerrainReaction: fire on empty tile → ignite (creates fire tile)', () => {
+  const session = makeSession();
+  const r = applyTerrainReaction(session, 2, 3, 'fire', { actorId: 'u_1' });
+  assert.equal(r.applied, true);
+  assert.equal(r.tileKey, '2,3');
+  assert.equal(r.nextState.type, 'fire');
+  assert.ok(r.nextState.ttl >= 1);
+  assert.equal(session.tileStateMap['2,3'].type, 'fire');
+});
+
+test('applyTerrainReaction: fire + ice → water + steam_burst (1 dmg)', () => {
+  const session = makeSession();
+  // First create ice
+  applyTerrainReaction(session, 4, 4, 'ice', { actorId: 'u_1' });
+  assert.equal(session.tileStateMap['4,4'].type, 'ice');
+  // Then fire onto ice
+  const r = applyTerrainReaction(session, 4, 4, 'fire', { actorId: 'u_2' });
+  assert.equal(r.applied, true);
+  assert.equal(r.nextState.type, 'water');
+  assert.equal(r.burstDamage, 1, 'steam burst applies 1 damage to occupant');
+  assert.ok(r.effects.includes('steam_burst'));
+});
+
+test('applyTerrainReaction: fire + water → normal (evaporate, no damage)', () => {
+  const session = makeSession();
+  applyTerrainReaction(session, 0, 0, 'water');
+  const r = applyTerrainReaction(session, 0, 0, 'fire');
+  assert.equal(r.applied, true);
+  assert.equal(r.nextState.type, 'normal');
+  assert.equal(r.burstDamage, 0);
+  assert.ok(r.effects.includes('evaporate'));
+  // Map sparsity: tile rimosso quando torna a normal
+  assert.equal(session.tileStateMap['0,0'], undefined);
+});
+
+test('applyTerrainReaction: lightning + water → electrified + chain BFS', () => {
+  const session = makeSession();
+  // Setup chain di water: (0,0) (1,0) (2,0) (3,0). Lightning su (0,0).
+  applyTerrainReaction(session, 0, 0, 'water');
+  applyTerrainReaction(session, 1, 0, 'water');
+  applyTerrainReaction(session, 2, 0, 'water');
+  applyTerrainReaction(session, 3, 0, 'water');
+
+  const r = applyTerrainReaction(session, 0, 0, 'lightning', { actorId: 'u_3' });
+  assert.equal(r.applied, true);
+  assert.equal(r.nextState.type, 'electrified');
+  assert.equal(r.burstDamage, 2, 'lightning+water burst = 2 dmg al tile origin');
+  assert.ok(r.effects.includes('chain_trigger'));
+  assert.ok(r.chain, 'chain object populated');
+  // Chain BFS deve aver visitato i water tile adiacenti (4 in linea, cap maxDepth 5)
+  assert.ok(Array.isArray(r.chain.electrified));
+  assert.ok(r.chain.electrified.length >= 1, 'almeno 1 tile water diventa electrified via chain');
+  assert.ok(Number.isFinite(r.chain.chainDamage));
+});
+
+test('decayTileStates: ttl > 1 decrements, ttl <= 1 removes', () => {
+  const session = makeSession();
+  // Setup 3 tile con ttl diversi
+  session.tileStateMap = {
+    '0,0': { type: 'fire', ttl: 3 },
+    '1,0': { type: 'water', ttl: 1 },
+    '2,0': { type: 'ice', ttl: 5 },
+  };
+
+  const stats = decayTileStates(session);
+  assert.equal(stats.decayed, 2, '0,0 e 2,0 decrementati');
+  assert.equal(stats.removed, 1, '1,0 rimosso (ttl=1 → 0 → delete)');
+
+  assert.equal(session.tileStateMap['0,0'].ttl, 2);
+  assert.equal(session.tileStateMap['1,0'], undefined);
+  assert.equal(session.tileStateMap['2,0'].ttl, 4);
+});
+
+test('decayTileStates: tile malformed (non-object) viene rimosso', () => {
+  const session = {
+    tileStateMap: { '0,0': null, '1,0': 'invalid', '2,0': { type: 'fire', ttl: 2 } },
+  };
+  const stats = decayTileStates(session);
+  assert.equal(stats.removed, 2);
+  assert.equal(stats.decayed, 1);
+  assert.equal(session.tileStateMap['2,0'].ttl, 1);
+});
+
+test('decayTileStates: missing tileStateMap → no-op (no throw)', () => {
+  const session = {};
+  const stats = decayTileStates(session);
+  assert.deepEqual(stats, { decayed: 0, removed: 0 });
+});
+
+test('applyTerrainReaction: defensive guards (no throw on bad input)', () => {
+  // No session
+  let r = applyTerrainReaction(null, 0, 0, 'fire');
+  assert.equal(r.applied, false);
+
+  // Session without tileStateMap
+  r = applyTerrainReaction({}, 0, 0, 'fire');
+  assert.equal(r.applied, false);
+
+  // Invalid element
+  const session = makeSession();
+  r = applyTerrainReaction(session, 0, 0, 'earth');
+  assert.equal(r.applied, false);
+  assert.deepEqual(session.tileStateMap, {});
+
+  // Empty element
+  r = applyTerrainReaction(session, 0, 0, '');
+  assert.equal(r.applied, false);
+});
+
+test('integration: fire-water-evaporate cycle then decay', () => {
+  // Simula 1 round: applico fire, poi 2 round dopo applico water,
+  // verifico che TTL siano decadi e il tile finale sia consistente.
+  const session = makeSession();
+
+  applyTerrainReaction(session, 5, 5, 'fire', { baseTtl: 3 });
+  assert.equal(session.tileStateMap['5,5'].type, 'fire');
+  assert.equal(session.tileStateMap['5,5'].ttl, 3);
+
+  decayTileStates(session); // round 1 end → ttl 2
+  assert.equal(session.tileStateMap['5,5'].ttl, 2);
+
+  decayTileStates(session); // round 2 end → ttl 1
+  assert.equal(session.tileStateMap['5,5'].ttl, 1);
+
+  // Now apply water to fire
+  const r = applyTerrainReaction(session, 5, 5, 'water');
+  assert.equal(r.applied, true);
+  // fire + water → normal/evaporate (per terrainReactions.js)
+  assert.equal(r.nextState.type, 'normal');
+  assert.equal(session.tileStateMap['5,5'], undefined, 'tile rimosso quando torna a normal');
+});


### PR DESCRIPTION
## Summary

Primo PR del **repo evo-swarm** integrato in Game repo come parte di Atto 2 Scenario A "Integration drive". Promuove la synergy `echo_backstab` — gia' dichiarata in `data/core/species.yaml#L41` per `dune_stalker` (Arenavenator vagans) — a active effect runtime-evaluable.

## Changes

- **`data/core/traits/active_effects.yaml`**: nuova sezione "EVO-SWARM CONTRIBUTIONS" alla fine del file, con il trait `echo_backstab` (T2, tattico, extra_damage 1) + provenance block che cita cicli swarm sorgente.
- **`data/core/traits/glossary.json`**: nuova entry `echo_backstab` (label IT/EN + description).

## Trigger semantics

```yaml
trigger:
  action_type: attack
  on_result: hit
  melee_only: true            # sand_claws sono melee
  requires_ally_adjacent: true # tattica di branco coordinata via eco
effect:
  kind: extra_damage
  amount: 1
  log_tag: echo_backstab_synergy
```

Tutti i trigger fields gia' supportati da `apps/backend/services/traitEffects.js#passesBasicTriggers`. Nessuna schema extension richiesta.

## Synergy parts gating

La synergy parts (`senses.echolocation` + `offense.sand_claws`) resta gestita al **composition layer** in `species.yaml#L41` (synergy block). A runtime: se il mob non ha le parts richieste, il trait non viene istanziato — questo PR non altera quel comportamento, aggiunge solo l'effetto runtime quando il trait E' istanziato.

## Provenance (evo-swarm sorgenti)

- **cycle 27 (gameplay-prototyper)**: \"Echo Backstab prototipo\" — primo design swarm validato post L-E18 (vedi MEMORY-SHARED L-E18 nel repo evo-swarm)
- **cycle 2 25/04 (species-curator)**: \"Identificate sinergie mancanti per specie Dune Stalker\"
- **cross-ref**: `docs/exports/EXPORT-FOR-GAME-REPO-2026-04-25-FINAL.md` (evo-swarm repo) elenca match diretto `dune_stalker -> canonical dune_stalker` con cicli #2/#119/#2.

## Test plan

- [x] `python -c \"import yaml; yaml.safe_load(...)\"` su active_effects.yaml -> OK
- [x] `python -c \"import json; json.load(...)\"` su glossary.json -> OK
- [x] prettier --write passato su entrambi i file (lint hook)
- [ ] Backend unit test: aggiungere fixture mock-mob con synergy `echo_backstab` istanziata + ally adjacent + melee hit -> verifica `+1 damage_delta` nel session log (follow-up PR, non bloccante per data merge)
- [ ] Manual smoke: lanciare un combat scenario con dune_stalker che ha echo_backstab istanziato -> verifica log mostra `echo_backstab_synergy` quando trigger condizioni soddisfatte

## Cross-link

- **evo-swarm repo Atto 2 ROADMAP**: `MasterDD-L34D/evo-swarm` ROADMAP.md "Atto 2 Scenario A — task 4 (case study primo)"
- **Game issue baseline**: #1837 (first delivery digest swarm)
- **Game issue child Skiv extension**: #1858, #1859

🤖 Generated with [Claude Code](https://claude.com/claude-code)