### PR TITLE
fix(balance): nerf trait outliers ipertrofia + sangue_piroforico (P0)

### DIFF
--- a/packs/evo_tactics_pack/data/balance/trait_mechanics.yaml
+++ b/packs/evo_tactics_pack/data/balance/trait_mechanics.yaml
@@ -310,10 +310,10 @@ traits:
   sangue_piroforico:
     attack_mod: 1
     defense_mod: 0
-    damage_step: 1
+    damage_step: 0
     cost_ap: 2
     resistances:
-      - { channel: fuoco, modifier_pct: 20 }
+      - { channel: fuoco, modifier_pct: 10 }
     active_effects:
       - ability_id: ignition_surge
         name_it: "Innesco Piroforico"
@@ -323,6 +323,7 @@ traits:
         buff_amount: 2
         buff_duration: 2
         target: self
+    notes: "nerf 2026-04-26: rimosso damage_step+1 perm + fuoco resist 20%->10% (4-stack benefit eccessivo)"
   respiro_a_scoppio:
     attack_mod: 0
     defense_mod: 0
@@ -528,7 +529,7 @@ traits:
   ipertrofia_muscolare_massiva:
     attack_mod: 1
     defense_mod: 0
-    damage_step: 1
+    damage_step: 0
     cost_ap: 2
     resistances: []
     active_effects:
@@ -539,7 +540,7 @@ traits:
         damage_dice: { count: 2, sides: 6, modifier: 2 }
         channel: fisico
         target: enemy
-    notes: "hybrid (TRT-02): massa muscolare aumenta sia attacco che danno"
+    notes: "hybrid (TRT-02): massa muscolare aumenta attacco; nerf 2026-04-26: rimosso damage_step+1 perm (z=+2.55 outlier — ridotto a singolo bonus offensivo)"
   pelage_idrorepellente_avanzato:
     attack_mod: 0
     defense_mod: 1


### PR DESCRIPTION
## Summary

P0 fix da audit `balance-auditor` 2026-04-26 (catalog corpus deep analysis).

2 trait outlier z-score >+2σ rispetto efficiency mean=0.888 nel pool 33 trait:

- **ipertrofia_muscolare_massiva** (z=+2.55): rimuovi `damage_step: 1` permanente. Resta `attack_mod: +1` + ability 2d6+2 (EV=9). Era double-stacked offensive su cost_ap=2.
- **sangue_piroforico**: rimuovi `damage_step: 1` permanente + `fuoco resist 20%→10%`. Era 4-stack benefit eccessivo (perm atk+1 + perm dmg_step+1 + resist 20% + ability buff +2 atk x2t).

## Test plan

- [x] AI test suite 311/311 verde post-edit
- [x] Schema drift = 0 (no field changes, solo numeri)
- [x] Prettier check verde
- [ ] N=10 sweep post-merge per validare nuova band balance

## Ref

- `docs/reports/2026-04-26-deep-analysis-outliers.md` P0 #1 + #2 (in PR docs separato)
- `docs/reports/2026-04-26-deep-analysis-balance.md` (in PR docs separato)

## Rollback

`git revert <sha>` — restore numeri pre-nerf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)