### PR TITLE
fix(economy): orphan currency + difficulty key + PE->PI gate (P0)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -2018,7 +2018,8 @@ function createSessionRouter(options = {}) {
         vcSnapshot = buildVcSnapshot(session, telemetryConfig);
         const { computeSessionPE, buildDebriefSummary } = require('../services/rewardEconomy');
         const peResult = computeSessionPE(vcSnapshot, {
-          difficulty: session.difficulty || 'standard',
+          // 2026-04-26: encounter_class è canonical (tutorial/standard/hardcore/etc.); session.difficulty legacy fallback
+          difficulty: session.encounter_class || session.difficulty || 'standard',
         });
         debrief = buildDebriefSummary(session, vcSnapshot, peResult);
       } catch {

--- a/apps/backend/services/rewardEconomy.js
+++ b/apps/backend/services/rewardEconomy.js
@@ -8,11 +8,14 @@
 
 'use strict';
 
-// PE generation base values per encounter difficulty
+// PE generation base values per encounter difficulty (encounter_class compatible)
+// Aliases mappano sia categorie legacy (tutorial/standard/elite/boss) sia encounter_class (tutorial_advanced/hardcore).
 const PE_BASE_BY_DIFFICULTY = {
   tutorial: 3,
+  tutorial_advanced: 4,
   standard: 5,
   elite: 8,
+  hardcore: 10,
   boss: 12,
 };
 
@@ -96,7 +99,12 @@ function convertPE(peBalance) {
  * @returns {object} debrief payload
  */
 function buildDebriefSummary(session, vcSnapshot, peResult, pfSession = {}) {
-  const conversion = convertPE(peResult.session_total);
+  // 2026-04-26 (Q19 resolved Opzione A): PE→PI conversion gated su outcome=victory
+  // (StS gold analogy). Defeat/timeout = PE earned ma non convertito; resta in pool campaign-wide.
+  const isVictory = session?.outcome === 'victory';
+  const conversion = isVictory
+    ? convertPE(peResult.session_total)
+    : { pi_gained: 0, pe_remaining: peResult.session_total };
 
   return {
     session_id: session.session_id,
@@ -107,7 +115,8 @@ function buildDebriefSummary(session, vcSnapshot, peResult, pfSession = {}) {
       pe_session_total: peResult.session_total,
       pi_converted: conversion.pi_gained,
       pe_remaining: conversion.pe_remaining,
-      seed_earned: 0, // Seed from mating/harvester — wired in D2
+      conversion_gate: isVictory ? 'victory' : session?.outcome || 'pending',
+      // seed_earned: rimosso 2026-04-26 — orphan currency (zero sink finché V3 mating/harvester live)
     },
     // VC performance
     vc_summary: {

--- a/apps/backend/services/rewards/rewardOffer.js
+++ b/apps/backend/services/rewards/rewardOffer.js
@@ -228,7 +228,7 @@ function buildOffer(pool, context = {}) {
   return {
     offers,
     skip_available: true,
-    skip_fragment_delta: 1, // +1 frammento genetico su skip (M10+ nest consume)
+    skip_fragment_delta: 0, // 2026-04-26: orphan currency disable — re-abilita a 1 quando nest sink (M10+) live
   };
 }
 


### PR DESCRIPTION
## Summary

3 P0 fix da audit economy-design-illuminator 2026-04-26.

### 1. Orphan SF + Seed cleanup
Viola Hades principle (currency emit + zero sink).
- \`rewardOffer.js\`: \`skip_fragment_delta: 1 → 0\` (re-abilita a 1 quando nest sink M10+ live)
- \`rewardEconomy.js\`: rimosso \`seed_earned: 0\` debrief payload

### 2. Difficulty key mismatch (Balance G-01)
Pre-fix: \`hardcore\` encounter → PE=5 (standard fallback) per key mancante.
- \`PE_BASE_BY_DIFFICULTY\`: +aliases \`tutorial_advanced: 4\` + \`hardcore: 10\`
- \`session.js:2021\`: bridge \`session.encounter_class || session.difficulty\`

### 3. Q19 PE→PI checkpoint resolved (Opzione A — StS gold analogy)
- \`buildDebriefSummary\`: conversion gated su \`outcome === 'victory'\`
- defeat/timeout = PE earned ma NON convertito; resta in pool campaign-wide
- +\`conversion_gate\` field nel debrief response

## Test plan

- [x] AI test 311/311 verde
- [x] Schema drift = 0
- [ ] N=10 hardcore sweep post-merge: verifica PE earned correctly = 10 (vs 5 pre)
- [ ] Playtest debrief: verifica pi_converted=0 su defeat outcome

## Rollback

\`git revert <sha>\` — restore PE_BASE_BY_DIFFICULTY senza aliases + skip_fragment_delta=1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)