### PR TITLE
fix(scenario): objective string -> schema object (PCG G2 P0)

### DIFF
--- a/apps/backend/services/hardcoreScenario.js
+++ b/apps/backend/services/hardcoreScenario.js
@@ -29,7 +29,7 @@ const HARDCORE_SCENARIO_06 = {
   difficulty_rating: 6,
   estimated_turns: 16,
   grid_size: 10,
-  objective: 'elimination',
+  objective: { type: 'elimination' },
   objective_text:
     'Sconfiggi il BOSS Apex (hp 40, AOE psichica su crit) e i suoi 5 guardiani. Party 8 unità vs 6 nemici: il BOSS singolo regge focus-fire 8-way, attenti alle pozze instabili (2 dmg/turn).',
   briefing_pre:
@@ -270,7 +270,7 @@ const HARDCORE_SCENARIO_07_POD_RUSH = {
   difficulty_rating: 7,
   estimated_turns: 10,
   grid_size: 10,
-  objective: 'elimination',
+  objective: { type: 'elimination' },
   objective_text:
     '10 round per eliminare la pattuglia + 3 pod reinforcement. Timer expire → pressure escalate (Apex). No boss: damage distribuito, priority decisioni conteggia più di burst. Party 4 PG quartet.',
   briefing_pre:

--- a/apps/backend/services/tutorialScenario.js
+++ b/apps/backend/services/tutorialScenario.js
@@ -22,7 +22,7 @@ const TUTORIAL_SCENARIO = {
   difficulty_rating: 1,
   estimated_turns: 6,
   grid_size: 6,
-  objective: 'elimination',
+  objective: { type: 'elimination' },
   objective_text: 'Sconfiggi tutte le unità nemiche.',
   briefing_pre:
     'Due predoni nomadi hanno preso posizione nella savana. Avvicinati con cautela e eliminali.',
@@ -39,7 +39,7 @@ const TUTORIAL_SCENARIO_02 = {
   difficulty_rating: 2,
   estimated_turns: 8,
   grid_size: 6,
-  objective: 'elimination',
+  objective: { type: 'elimination' },
   objective_text: 'Sconfiggi tutta la pattuglia: due predoni e un cacciatore corazzato.',
   briefing_pre:
     'La pattuglia nomade questa volta include un cacciatore con corazza pesante. Coordina scout e tank: il danno asimmetrico premia chi sceglie il bersaglio giusto.',
@@ -57,7 +57,7 @@ const TUTORIAL_SCENARIO_03 = {
   difficulty_rating: 3,
   estimated_turns: 10,
   grid_size: 6,
-  objective: 'elimination',
+  objective: { type: 'elimination' },
   objective_text:
     'Elimina i guardiani sotterranei. Attento alle fumarole tossiche: tile (2,2) e (3,3) infliggono danno a fine turno se occupate.',
   briefing_pre:
@@ -82,7 +82,7 @@ const TUTORIAL_SCENARIO_05 = {
   difficulty_rating: 5,
   estimated_turns: 14,
   grid_size: 6,
-  objective: 'elimination',
+  objective: { type: 'elimination' },
   objective_text:
     "Sconfiggi l'apex predatore. Singolo nemico con HP altissimo, attacchi multipli e bonus su critico.",
   briefing_pre:
@@ -102,7 +102,7 @@ const TUTORIAL_SCENARIO_04 = {
   difficulty_rating: 4,
   estimated_turns: 12,
   grid_size: 6,
-  objective: 'elimination',
+  objective: { type: 'elimination' },
   objective_text:
     'Sconfiggi i 3 guardiani della pozza. Attento al lanciere: il suo morso causa emorragia.',
   briefing_pre:


### PR DESCRIPTION
## Summary

P0 fix da audit \`pcg-level-design-illuminator\` 2026-04-26.

8 runtime scenari hardcoded JS avevano \`objective: 'elimination'\` (string), ma \`encounter.schema.json\` + \`objectiveEvaluator.js\` attendono \`objective: { type: 'elimination', ... }\` (object).

Conseguenza: \`objectiveEvaluator\` ignora qualunque non-elimination objective nelle session live. 5 obj types schema (capture_point/escort/sabotage/survival/escape) **mai esercitati runtime**.

## Fix

\`replace_all\`:
- \`tutorialScenario.js\` (5 occorrenze): linee 25, 42, 60, 85, 105
- \`hardcoreScenario.js\` (2 occorrenze): linee 32, 273

\`'elimination'\` → \`{ type: 'elimination' }\`

## Prep step

Apre la strada al PCG G1 (encounter YAML loader, PR successivo) che useranno gli stessi obj types YAML-defined per sbloccare le 5 modalità non-elim.

## Test plan

- [x] AI test 311/311 verde
- [x] Schema drift = 0 (allineamento)
- [ ] objectiveEvaluator regression: assert 'elimination' resolution invariata

## Rollback

\`git revert <sha>\` — restore string \`'elimination'\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)