### PR TITLE
feat(combat): encounter YAML loader opt-in (PCG G1 P0)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -1129,6 +1129,21 @@ function createSessionRouter(options = {}) {
       const pressureStart = Number.isFinite(Number(req.body?.pressure_start))
         ? Number(req.body.pressure_start)
         : null;
+      // 2026-04-26 (PCG G1 fix): encounter YAML loader opt-in.
+      // Se body.encounter_id passato + YAML trovato → popola encounter payload.
+      // Sblocca: objectiveEvaluator non-elim + biomeSpawnBias initial waves + conditions.
+      // Non override se body.encounter già fornito (preserve scenario JS flow).
+      let encounterPayload = req.body?.encounter ?? null;
+      const encounterIdFromBody = req.body?.encounter_id;
+      if (!encounterPayload && encounterIdFromBody) {
+        try {
+          const { loadEncounter } = require('../services/combat/encounterLoader');
+          const loaded = loadEncounter(encounterIdFromBody);
+          if (loaded) encounterPayload = loaded;
+        } catch (err) {
+          console.warn('[session/start] encounterLoader failed:', err.message);
+        }
+      }
       const session = {
         session_id: sessionId,
         scenario_id: scenarioId,
@@ -1172,8 +1187,8 @@ function createSessionRouter(options = {}) {
         // Q-001 T2.3: difficulty profile scaling metadata (null se profile invalid)
         _difficultyProfile: difficultyProfileMeta,
         // ADR-2026-04-19 + 04-20: encounter payload per reinforcementSpawner + objectiveEvaluator.
-        // Feature flag OFF default: se undefined, entrambi moduli ritornano no-op.
-        encounter: req.body?.encounter ?? null,
+        // 2026-04-26: anche YAML-loaded via encounter_id (PCG G1 wire).
+        encounter: encounterPayload,
         // M11 pilot (ADR-2026-04-21c): biome_id + log trait env deltas applicati.
         biome_id: biomeIdRaw,
         biome_costs_log: biomeCostsLog,

--- a/apps/backend/services/combat/encounterLoader.js
+++ b/apps/backend/services/combat/encounterLoader.js
@@ -1,0 +1,69 @@
+// 2026-04-26 — Encounter YAML loader (PCG G1 fix).
+//
+// Carica `docs/planning/encounters/*.yaml` come encounter runtime opt-in.
+// Sblocca: objectiveEvaluator (5 obj non-elim), biomeSpawnBias initial waves,
+// conditions runtime, narrative ink wiring. Templates erano orphaned.
+//
+// API:
+//   loadEncounter(encounterId)  → encounter object | null
+//   listEncounters()            → array string IDs disponibili
+//   _resetCache()               → testing only
+//
+// Wire: `apps/backend/routes/session.js /start` legge `body.encounter_id`.
+// Se YAML trovato + parse OK → usa quello; altrimenti fallback a JS scenario.
+// Zero breaking change su scenari hardcoded esistenti.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const ENCOUNTER_DIR = path.resolve(__dirname, '../../../../docs/planning/encounters');
+
+let _cache = null;
+let _availableIds = null;
+
+function _loadAll() {
+  if (_cache) return _cache;
+  _cache = {};
+  _availableIds = [];
+  let files = [];
+  try {
+    files = fs.readdirSync(ENCOUNTER_DIR).filter((f) => f.endsWith('.yaml'));
+  } catch (err) {
+    console.warn('[encounterLoader] dir not found:', ENCOUNTER_DIR, err.message);
+    return _cache;
+  }
+  for (const fname of files) {
+    try {
+      const raw = fs.readFileSync(path.join(ENCOUNTER_DIR, fname), 'utf-8');
+      const parsed = yaml.load(raw);
+      if (parsed && parsed.encounter_id) {
+        _cache[parsed.encounter_id] = parsed;
+        _availableIds.push(parsed.encounter_id);
+      }
+    } catch (err) {
+      console.warn('[encounterLoader] parse failed:', fname, err.message);
+    }
+  }
+  return _cache;
+}
+
+function loadEncounter(encounterId) {
+  if (!encounterId || typeof encounterId !== 'string') return null;
+  const all = _loadAll();
+  return all[encounterId] || null;
+}
+
+function listEncounters() {
+  _loadAll();
+  return _availableIds ? [..._availableIds] : [];
+}
+
+function _resetCache() {
+  _cache = null;
+  _availableIds = null;
+}
+
+module.exports = { loadEncounter, listEncounters, _resetCache };


### PR DESCRIPTION
## Summary

P0 fix da audit \`pcg-level-design-illuminator\` 2026-04-26.

### Problem
9 YAML templates in \`docs/planning/encounters/*.yaml\` **mai loaded runtime**. Tutti gli scontri live usano scenari hardcoded JS (\`tutorialScenario.js\`, \`hardcoreScenario.js\`).

Conseguenza: \`objectiveEvaluator\` (5 obj non-elim) + \`biomeSpawnBias\` initial waves + conditions runtime → **tutti dead weight**.

### Fix

**1. \`apps/backend/services/combat/encounterLoader.js\` (~70 LOC, NEW)**
- \`loadEncounter(encounterId)\` → encounter object | null
- \`listEncounters()\` → array string IDs
- \`_resetCache()\` testing only
- Cached \`fs.readdir\` + \`js-yaml\` parse, graceful fallback

**2. \`apps/backend/routes/session.js /start\` wire**
- \`body.encounter_id\` → loader → popola encounter payload
- Non override se \`body.encounter\` già fornito (preserve scenario JS flow)
- try/catch graceful (loader fail = log + fallback)

### Sblocca
- 9 YAML encounters consumibili runtime (4 obj types: elimination, capture_point, escort, survival)
- \`objectiveEvaluator\` 5 obj non-elim now exercise-able (prep PR #1871 schema fix)
- \`biomeSpawnBias\` initial waves via \`biome_id\` YAML
- Conditions runtime (fog/stress_wave/terrain_collapse/env_mutation)

## Test plan

- [x] AI + sessionEncounterWiring + sessionEndResponse: 316/316 verde
- [x] Smoke loader: \`node -e\` 9 IDs caricati, \`capture_point\` objective normalizzato OK
- [x] Schema drift = 0 (additive, opt-in via \`encounter_id\` body field)
- [x] 0 breaking change su scenari hardcoded esistenti
- [ ] E2E: \`POST /api/session/start { encounter_id: 'enc_capture_01' }\` post-merge

## Effort

Audit estimate **4-6h**. Actual **~1h** (50 LOC service + 18 LOC wire).

## Rollback

\`git revert <sha>\` — rimuove loader + wire. Scenari JS hardcoded continuano funzionare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)