### PR TITLE
feat(nido): Sprint D — lineage chain + tribe emergent breakthrough (OD-001 Path A 4/4)

### DIFF
--- a/apps/backend/routes/meta.js
+++ b/apps/backend/routes/meta.js
@@ -17,7 +17,12 @@
 'use strict';
 
 const { Router } = require('express');
-const { createMetaStore } = require('../services/metaProgression');
+const {
+  createMetaStore,
+  getLineageChain,
+  getTribesEmergent,
+  getTribeForUnit,
+} = require('../services/metaProgression');
 
 /**
  * @param {object} [opts]
@@ -108,6 +113,45 @@ function createMetaRouter(opts = {}) {
       const { biome, requirements_met } = req.body || {};
       const nest = await store.setNest(biome || 'default', requirements_met !== false);
       res.json(nest);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // ─── Sprint D — Lineage chain + Tribe emergent ─────────────────────
+  // Tribe = lineage_id chain con >= 3 members. Process-scoped registry
+  // popolato da recordOffspring() (Sprint C wire). Documented in
+  // metaProgression.js + memory feedback_tribe_lineage_emergent_breakthrough.
+
+  router.get('/lineage/:id', (req, res, next) => {
+    try {
+      const { id } = req.params;
+      if (!id) return res.status(400).json({ error: 'lineage id required' });
+      const chain = getLineageChain(id);
+      res.json({ lineage_id: id, members_count: chain.length, chain });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.get('/tribes', (_req, res, next) => {
+    try {
+      const tribes = getTribesEmergent();
+      res.json({ tribes, threshold: 3 });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.get('/tribe/unit/:id', (req, res, next) => {
+    try {
+      const { id } = req.params;
+      if (!id) return res.status(400).json({ error: 'unit id required' });
+      const tribe = getTribeForUnit(id);
+      if (!tribe) {
+        return res.json({ unit_id: id, tribe: null, lone_wolf: true });
+      }
+      res.json({ unit_id: id, tribe, lone_wolf: false });
     } catch (err) {
       next(err);
     }

--- a/apps/backend/services/metaProgression.js
+++ b/apps/backend/services/metaProgression.js
@@ -454,6 +454,193 @@ function createMetaStore({ prisma, campaignId = null } = {}) {
   };
 }
 
+// ─── Sprint D — Lineage chain + Tribe emergent ───────────────────────────
+//
+// Tribe NON è layer aggiuntivo. È conseguenza emergente catena Nido →
+// offspring con `lineage_id` → catena multi-generazionale → N units stesso
+// lineage = tribù implicita. (Memory: feedback_tribe_lineage_emergent_breakthrough)
+//
+// Sprint C estende `rollMating()` per emettere offspring con shape:
+//   { unit_id, lineage_id, parents: [a,b], born_at_session, born_at_biome }
+// Quel record va passato a `recordOffspring()` qui per popolare il registry.
+//
+// Schema offspring entry:
+//   {
+//     unit_id:         string  (immutable, primary key)
+//     lineage_id:      string  (hash combined parents da Sprint C; root may share)
+//     parents:         [string, string] | []  (root units = [])
+//     generation:      number  (0 = root founder, 1 = first offspring, ...)
+//     born_at_session: string | null
+//     born_at_biome:   string | null
+//   }
+//
+// Tribe = group con >= TRIBE_MIN_MEMBERS (3) units stesso lineage_id.
+// Lone wolf = unit con <3 lineage members → getTribeForUnit returns null.
+//
+// In-memory registry: cross-session persistence non goal in Sprint D.
+// Future: migrate to Prisma quando model `Lineage`+`Offspring` shipped.
+
+const TRIBE_MIN_MEMBERS = 3;
+
+// Shared registry (process-scoped). Sprint C deve invocare recordOffspring()
+// dopo ogni mating successo per popolare il grafo.
+const _offspringRegistry = new Map(); // unit_id → entry
+
+/**
+ * Resetta lo store di lignaggio. Solo per test.
+ * @internal
+ */
+function _resetLineageRegistry() {
+  _offspringRegistry.clear();
+}
+
+/**
+ * Registra un'unità nel grafo di lignaggio.
+ *
+ * Idempotent su unit_id (overwrite). Sprint C → chiamare dopo ogni successo
+ * di rollMating per ogni offspring. Anche root units (parents = []) possono
+ * essere registrati come founder.
+ *
+ * @param {object} entry — schema descritto sopra
+ * @returns {object} entry normalizzata
+ */
+function recordOffspring(entry) {
+  if (!entry || typeof entry !== 'object') {
+    throw new TypeError('recordOffspring: entry object required');
+  }
+  if (!entry.unit_id || typeof entry.unit_id !== 'string') {
+    throw new TypeError('recordOffspring: entry.unit_id (string) required');
+  }
+  const parents = Array.isArray(entry.parents) ? entry.parents.filter(Boolean) : [];
+  const normalized = {
+    unit_id: entry.unit_id,
+    lineage_id: entry.lineage_id || entry.unit_id, // fallback: unit_id stesso = solo lignaggio
+    parents,
+    generation: Number.isFinite(entry.generation) ? entry.generation : parents.length === 0 ? 0 : 1,
+    born_at_session: entry.born_at_session || null,
+    born_at_biome: entry.born_at_biome || null,
+  };
+  _offspringRegistry.set(normalized.unit_id, normalized);
+  return normalized;
+}
+
+/**
+ * Ritorna la catena di lignaggio per un dato lineage_id.
+ *
+ * Output: array di units ordinato per `generation` ascending (root → leaves).
+ * Tie-break: insertion order preservato (Map iteration).
+ *
+ * @param {string} lineageId
+ * @returns {Array<object>} — units con quel lineage_id, ordinati per generation
+ */
+function getLineageChain(lineageId) {
+  if (!lineageId) return [];
+  const members = [];
+  for (const entry of _offspringRegistry.values()) {
+    if (entry.lineage_id === lineageId) members.push(entry);
+  }
+  members.sort((a, b) => (a.generation ?? 0) - (b.generation ?? 0));
+  return members;
+}
+
+/**
+ * Ritorna la lista delle tribe emergent.
+ *
+ * Tribe = lineage_id con >= TRIBE_MIN_MEMBERS units. Per ogni tribe ritorna:
+ *   - tribe_id (= lineage_id)
+ *   - members_count
+ *   - primary_biome (most common biome among members; null se tutti null)
+ *   - oldest_generation (max generation reached in chain)
+ *   - lineage_root_unit_id (founder = unit con parents.length === 0;
+ *     fallback unit con generation minima)
+ *
+ * @returns {Array<object>}
+ */
+function getTribesEmergent() {
+  // Group by lineage_id.
+  const byLineage = new Map();
+  for (const entry of _offspringRegistry.values()) {
+    const lid = entry.lineage_id;
+    if (!byLineage.has(lid)) byLineage.set(lid, []);
+    byLineage.get(lid).push(entry);
+  }
+
+  const tribes = [];
+  for (const [lineageId, members] of byLineage.entries()) {
+    if (members.length < TRIBE_MIN_MEMBERS) continue;
+
+    // primary_biome = most common biome among members.
+    const biomeCounts = new Map();
+    for (const m of members) {
+      if (!m.born_at_biome) continue;
+      biomeCounts.set(m.born_at_biome, (biomeCounts.get(m.born_at_biome) || 0) + 1);
+    }
+    let primaryBiome = null;
+    let primaryCount = 0;
+    for (const [biome, count] of biomeCounts.entries()) {
+      if (count > primaryCount) {
+        primaryBiome = biome;
+        primaryCount = count;
+      }
+    }
+
+    // oldest_generation = max generation index (tribe maturity proxy).
+    let oldestGeneration = 0;
+    for (const m of members) {
+      if ((m.generation ?? 0) > oldestGeneration) oldestGeneration = m.generation ?? 0;
+    }
+
+    // lineage_root_unit_id = founder (parents=[]) o unit con generation min.
+    let root = members.find((m) => Array.isArray(m.parents) && m.parents.length === 0);
+    if (!root) {
+      root = members.reduce(
+        (acc, m) => ((m.generation ?? 0) < (acc.generation ?? 0) ? m : acc),
+        members[0],
+      );
+    }
+
+    tribes.push({
+      tribe_id: lineageId,
+      members_count: members.length,
+      primary_biome: primaryBiome,
+      oldest_generation: oldestGeneration,
+      lineage_root_unit_id: root?.unit_id ?? null,
+    });
+  }
+
+  // Sort: most members first (descending), tie-break alphabetic tribe_id.
+  tribes.sort((a, b) => {
+    if (b.members_count !== a.members_count) return b.members_count - a.members_count;
+    return a.tribe_id.localeCompare(b.tribe_id);
+  });
+  return tribes;
+}
+
+/**
+ * Ritorna la tribe info per un dato unit_id.
+ *
+ * Lone wolf (unit non in registry, o tribe con <3 membri) → null.
+ *
+ * @param {string} unitId
+ * @returns {object|null}
+ */
+function getTribeForUnit(unitId) {
+  if (!unitId) return null;
+  const entry = _offspringRegistry.get(unitId);
+  if (!entry) return null;
+  const tribes = getTribesEmergent();
+  return tribes.find((t) => t.tribe_id === entry.lineage_id) || null;
+}
+
+/**
+ * Snapshot del registry. Read-only utility per debug/UI.
+ *
+ * @returns {Array<object>}
+ */
+function listLineageEntries() {
+  return [..._offspringRegistry.values()].map((e) => ({ ...e, parents: [...(e.parents || [])] }));
+}
+
 module.exports = {
   createMetaTracker,
   createMetaStore,
@@ -466,4 +653,12 @@ module.exports = {
   TRUST_MIN,
   TRUST_MAX,
   MATING_THRESHOLD,
+  // Sprint D — lineage + tribe emergent
+  TRIBE_MIN_MEMBERS,
+  recordOffspring,
+  getLineageChain,
+  getTribesEmergent,
+  getTribeForUnit,
+  listLineageEntries,
+  _resetLineageRegistry,
 };

--- a/apps/play/src/api.js
+++ b/apps/play/src/api.js
@@ -276,6 +276,11 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ biome, requirements_met }),
     }),
+  // OD-001 Path A Sprint D — lineage chain + tribe emergent (2026-04-26).
+  // Tribe = lineage_id with >= 3 members (emergent from mating chain).
+  metaLineageChain: (lineageId) => jsonFetch(`/api/meta/lineage/${encodeURIComponent(lineageId)}`),
+  metaTribesEmergent: () => jsonFetch('/api/meta/tribes'),
+  metaTribeForUnit: (unitId) => jsonFetch(`/api/meta/tribe/unit/${encodeURIComponent(unitId)}`),
   // Skiv-as-Monitor — git-event-driven creature feed (Phase 2 wire 2026-04-25).
   skivStatus: () => jsonFetch('/api/skiv/status'),
   skivFeed: (limit = 20) => jsonFetch(`/api/skiv/feed?limit=${encodeURIComponent(limit)}`),

--- a/apps/play/src/nestHub.js
+++ b/apps/play/src/nestHub.js
@@ -24,6 +24,11 @@ const STATE = {
   // Optional partyMember provider for mating roll (Phase D).
   // Returns { mbti_type, trait_ids } of the active player unit.
   getPartyMember: () => null,
+  // Sprint D — lineage tab state (cached tribe + currently expanded lineage).
+  cachedTribes: [],
+  expandedLineageId: null,
+  expandedChain: [],
+  selectedUnitId: null,
 };
 
 const BIOME_OPTIONS = [
@@ -112,6 +117,49 @@ function injectStyles() {
     }
     .nest-status.ok { color: #66bb6a; }
     .nest-status.err { color: #ef5350; }
+    /* Sprint D — Lineage section (tribe list + tree view). */
+    .nest-tribe-list { display: flex; flex-direction: column; gap: 4px; }
+    .nest-tribe-row {
+      display: flex; align-items: center; gap: 8px;
+      background: #0b0d12; border: 1px solid #2a3040; border-radius: 6px;
+      padding: 6px 10px; cursor: pointer; font-size: 0.85rem;
+    }
+    .nest-tribe-row:hover { border-color: #ffd180; }
+    .nest-tribe-row.expanded { border-color: #ffb74d; background: #1f1a10; }
+    .nest-tribe-row .tribe-id {
+      font-family: monospace; color: #ffd180; min-width: 120px;
+    }
+    .nest-tribe-row .tribe-stat {
+      background: #151922; border: 1px solid #2a3040; border-radius: 4px;
+      padding: 1px 6px; font-family: monospace; font-size: 0.75rem;
+    }
+    .nest-lineage-tree {
+      margin-top: 8px; padding: 8px 12px;
+      background: #0b0d12; border: 1px solid #2a3040; border-radius: 6px;
+      font-family: monospace; font-size: 0.78rem;
+    }
+    .nest-lineage-node {
+      padding: 3px 0 3px 0;
+      border-left: 2px solid #2a3040;
+      padding-left: 8px;
+      cursor: pointer;
+    }
+    .nest-lineage-node:hover { background: #151922; }
+    .nest-lineage-node.selected {
+      background: #1e2d20; border-left-color: #66bb6a;
+    }
+    .nest-lineage-node .gen-badge {
+      display: inline-block; background: #1d2230; border: 1px solid #2a3040;
+      color: #ffb74d; padding: 0 5px; border-radius: 3px; margin-right: 6px;
+      font-size: 0.72rem;
+    }
+    .nest-lineage-node .unit-id { color: #e8eaf0; }
+    .nest-lineage-node .unit-meta { color: #8891a3; margin-left: 6px; }
+    .nest-lineage-info {
+      margin-top: 6px; padding: 6px 10px;
+      background: #1d2230; border: 1px solid #ffd180; border-radius: 6px;
+      font-size: 0.78rem; color: #ffd180;
+    }
   `;
   document.head.appendChild(style);
 }
@@ -157,6 +205,15 @@ function buildOverlay() {
           </button>
           <span id="nest-mating-hint" style="font-size:0.8rem;color:#8891a3"></span>
         </div>
+      </div>
+      <div class="nest-section" data-tab="lineage" id="nest-lineage-section">
+        <h3>🧬 Lignaggio &amp; Tribù emergent (<span id="nest-tribes-count">0</span>)</h3>
+        <div class="nest-tribe-list" id="nest-tribe-list">
+          <div class="nest-empty">
+            Nessuna tribù emerge ancora (servono ≥3 unità con lo stesso lineage).
+          </div>
+        </div>
+        <div id="nest-lineage-tree-wrap"></div>
       </div>
       <div class="nest-status" id="nest-status"></div>
     </div>
@@ -309,6 +366,148 @@ async function handleMating() {
   await refresh();
 }
 
+// ─── Sprint D — Lineage tab rendering ───────────────────────────────────
+
+function renderTribes(tribes) {
+  if (typeof document === 'undefined') return;
+  const list = document.getElementById('nest-tribe-list');
+  const count = document.getElementById('nest-tribes-count');
+  if (count) count.textContent = String(tribes?.length || 0);
+  if (!list) return;
+  if (!tribes || tribes.length === 0) {
+    list.innerHTML =
+      '<div class="nest-empty">Nessuna tribù emerge ancora (servono ≥3 unità con lo stesso lineage).</div>';
+    return;
+  }
+  list.innerHTML = '';
+  for (const t of tribes) {
+    const row = document.createElement('div');
+    const isExpanded = STATE.expandedLineageId === t.tribe_id;
+    row.className = `nest-tribe-row${isExpanded ? ' expanded' : ''}`;
+    row.innerHTML = `
+      <span class="tribe-id">${t.tribe_id}</span>
+      <span class="tribe-stat">${t.members_count}m</span>
+      <span class="tribe-stat">gen ${t.oldest_generation}</span>
+      <span class="tribe-stat">${t.primary_biome || '—'}</span>
+      <span style="margin-left:auto;color:#8891a3;font-size:0.78rem">
+        root ${t.lineage_root_unit_id || '—'}
+      </span>
+    `;
+    row.addEventListener('click', () => toggleLineageExpand(t.tribe_id));
+    list.appendChild(row);
+  }
+}
+
+function renderLineageTree() {
+  if (typeof document === 'undefined') return;
+  const wrap = document.getElementById('nest-lineage-tree-wrap');
+  if (!wrap) return;
+  if (!STATE.expandedLineageId || !STATE.expandedChain.length) {
+    wrap.innerHTML = '';
+    return;
+  }
+  // Group by generation, max 3 generations visible.
+  const byGen = new Map();
+  for (const u of STATE.expandedChain) {
+    const g = u.generation ?? 0;
+    if (!byGen.has(g)) byGen.set(g, []);
+    byGen.get(g).push(u);
+  }
+  const sortedGens = [...byGen.keys()].sort((a, b) => a - b).slice(0, 3);
+
+  let html = `<div class="nest-lineage-tree" data-lineage="${STATE.expandedLineageId}">`;
+  html += `<div style="color:#ffd180;margin-bottom:6px">
+    Lineage <strong>${STATE.expandedLineageId}</strong> · chain ${STATE.expandedChain.length} unità
+  </div>`;
+  for (const g of sortedGens) {
+    const units = byGen.get(g) || [];
+    for (const u of units) {
+      const isSel = STATE.selectedUnitId === u.unit_id;
+      const parents =
+        Array.isArray(u.parents) && u.parents.length === 2
+          ? `← ${u.parents[0]} × ${u.parents[1]}`
+          : 'founder';
+      const indent = '  '.repeat(Math.min(g, 2));
+      html += `<div class="nest-lineage-node${isSel ? ' selected' : ''}"
+        data-unit-id="${u.unit_id}" style="margin-left:${g * 14}px">
+        <span class="gen-badge">G${g}</span>
+        <span class="unit-id">${indent}${u.unit_id}</span>
+        <span class="unit-meta">${parents}${u.born_at_biome ? ' · ' + u.born_at_biome : ''}</span>
+      </div>`;
+    }
+  }
+  if (sortedGens.length < byGen.size) {
+    const hidden = byGen.size - sortedGens.length;
+    html += `<div style="margin-top:6px;color:#8891a3;font-style:italic">
+      …e altre ${hidden} generazion${hidden === 1 ? 'e' : 'i'} (max 3 visibili)
+    </div>`;
+  }
+  if (STATE.selectedUnitId) {
+    const sel = STATE.expandedChain.find((u) => u.unit_id === STATE.selectedUnitId);
+    if (sel) {
+      html += `<div class="nest-lineage-info">
+        ▸ <strong>${sel.unit_id}</strong>
+        · gen ${sel.generation ?? 0}
+        · session ${sel.born_at_session || '—'}
+        · biome ${sel.born_at_biome || '—'}
+      </div>`;
+    }
+  }
+  html += '</div>';
+  wrap.innerHTML = html;
+  // Wire click → highlight unit info.
+  wrap.querySelectorAll('.nest-lineage-node').forEach((node) => {
+    node.addEventListener('click', () => {
+      const uid = node.getAttribute('data-unit-id');
+      STATE.selectedUnitId = STATE.selectedUnitId === uid ? null : uid;
+      renderLineageTree();
+    });
+  });
+}
+
+async function toggleLineageExpand(lineageId) {
+  if (STATE.expandedLineageId === lineageId) {
+    STATE.expandedLineageId = null;
+    STATE.expandedChain = [];
+    STATE.selectedUnitId = null;
+    renderTribes(STATE.cachedTribes);
+    renderLineageTree();
+    return;
+  }
+  STATE.expandedLineageId = lineageId;
+  STATE.selectedUnitId = null;
+  STATE.expandedChain = [];
+  renderTribes(STATE.cachedTribes);
+  renderLineageTree();
+  // Fetch chain async.
+  const res = await api.metaLineageChain(lineageId);
+  if (res.ok && Array.isArray(res.data?.chain)) {
+    STATE.expandedChain = res.data.chain;
+    renderLineageTree();
+  }
+}
+
+async function refreshLineage() {
+  const res = await api.metaTribesEmergent();
+  if (!res.ok) {
+    STATE.cachedTribes = [];
+    renderTribes([]);
+    return;
+  }
+  STATE.cachedTribes = Array.isArray(res.data?.tribes) ? res.data.tribes : [];
+  renderTribes(STATE.cachedTribes);
+  // Re-render expanded tree if still expanded (registry may have grown).
+  if (STATE.expandedLineageId) {
+    const stillThere = STATE.cachedTribes.some((t) => t.tribe_id === STATE.expandedLineageId);
+    if (!stillThere) {
+      STATE.expandedLineageId = null;
+      STATE.expandedChain = [];
+      STATE.selectedUnitId = null;
+    }
+    renderLineageTree();
+  }
+}
+
 async function refresh() {
   setStatus('Carico…');
   const res = await api.metaNpgList();
@@ -320,8 +519,10 @@ async function refresh() {
   STATE.cachedNest = res.data?.nest || { level: 0, biome: null, requirements_met: false };
   renderNest(STATE.cachedNest);
   renderNpcs(STATE.cachedNpcs);
+  // Sprint D — fetch tribe emergent in parallel; failure non-fatal.
+  await refreshLineage().catch(() => {});
   setStatus(
-    `${STATE.cachedNpcs.length} NPG · nido Lv ${STATE.cachedNest.level}${STATE.cachedNest.biome ? ' (' + STATE.cachedNest.biome + ')' : ''}`,
+    `${STATE.cachedNpcs.length} NPG · nido Lv ${STATE.cachedNest.level}${STATE.cachedNest.biome ? ' (' + STATE.cachedNest.biome + ')' : ''} · ${STATE.cachedTribes.length} tribù`,
     'ok',
   );
 }

--- a/tests/api/meta.lineage.test.js
+++ b/tests/api/meta.lineage.test.js
@@ -1,0 +1,131 @@
+// Sprint D — Lineage chain + Tribe emergent endpoints.
+// GET /api/meta/lineage/:id · GET /api/meta/tribes · GET /api/meta/tribe/unit/:id.
+//
+// Mounted via pluginLoader at /api/meta and /api/v1/meta (shared store).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+const {
+  recordOffspring,
+  _resetLineageRegistry,
+} = require('../../apps/backend/services/metaProgression');
+
+function seedTribe(lineageId, count, biome = 'savana') {
+  _resetLineageRegistry();
+  for (let i = 1; i <= count; i++) {
+    recordOffspring({
+      unit_id: `${lineageId}_u${i}`,
+      lineage_id: lineageId,
+      parents: i === 1 ? [] : [`${lineageId}_u1`, 'partner_x'],
+      generation: i === 1 ? 0 : 1,
+      born_at_session: 'sess_test',
+      born_at_biome: biome,
+    });
+  }
+}
+
+test('GET /api/meta/lineage/:id returns chain shape', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    seedTribe('lin_e2e', 3, 'palude');
+    const res = await request(app).get('/api/meta/lineage/lin_e2e').expect(200);
+    assert.equal(res.body.lineage_id, 'lin_e2e');
+    assert.equal(res.body.members_count, 3);
+    assert.ok(Array.isArray(res.body.chain));
+    assert.equal(res.body.chain.length, 3);
+    // Generation ascending check
+    assert.equal(res.body.chain[0].generation, 0);
+  } finally {
+    _resetLineageRegistry();
+    await close();
+  }
+});
+
+test('GET /api/meta/lineage/:id returns empty chain for unknown lineage', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    _resetLineageRegistry();
+    const res = await request(app).get('/api/meta/lineage/lin_phantom').expect(200);
+    assert.equal(res.body.members_count, 0);
+    assert.deepEqual(res.body.chain, []);
+  } finally {
+    await close();
+  }
+});
+
+test('GET /api/meta/tribes returns tribe list with threshold meta', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    seedTribe('lin_t_alpha', 4, 'foresta_pluviale');
+    const res = await request(app).get('/api/meta/tribes').expect(200);
+    assert.ok(Array.isArray(res.body.tribes));
+    assert.equal(res.body.threshold, 3);
+    const t = res.body.tribes.find((x) => x.tribe_id === 'lin_t_alpha');
+    assert.ok(t);
+    assert.equal(t.members_count, 4);
+    assert.equal(t.primary_biome, 'foresta_pluviale');
+  } finally {
+    _resetLineageRegistry();
+    await close();
+  }
+});
+
+test('GET /api/meta/tribes excludes lineage <3 members', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    seedTribe('lin_pair', 2);
+    const res = await request(app).get('/api/meta/tribes').expect(200);
+    const found = res.body.tribes.find((x) => x.tribe_id === 'lin_pair');
+    assert.equal(found, undefined);
+  } finally {
+    _resetLineageRegistry();
+    await close();
+  }
+});
+
+test('GET /api/meta/tribe/unit/:id returns lone_wolf=true when no tribe', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    _resetLineageRegistry();
+    recordOffspring({ unit_id: 'u_solo', lineage_id: 'lin_solo', parents: [], generation: 0 });
+    const res = await request(app).get('/api/meta/tribe/unit/u_solo').expect(200);
+    assert.equal(res.body.unit_id, 'u_solo');
+    assert.equal(res.body.lone_wolf, true);
+    assert.equal(res.body.tribe, null);
+  } finally {
+    _resetLineageRegistry();
+    await close();
+  }
+});
+
+test('GET /api/meta/tribe/unit/:id returns tribe info when qualified', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    seedTribe('lin_packed', 5, 'caverna_umida');
+    const res = await request(app).get('/api/meta/tribe/unit/lin_packed_u3').expect(200);
+    assert.equal(res.body.lone_wolf, false);
+    assert.equal(res.body.tribe.tribe_id, 'lin_packed');
+    assert.equal(res.body.tribe.members_count, 5);
+  } finally {
+    _resetLineageRegistry();
+    await close();
+  }
+});
+
+test('Sprint D endpoints also mounted at /api/v1/meta', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    seedTribe('lin_v1', 3);
+    const a = await request(app).get('/api/v1/meta/tribes').expect(200);
+    assert.ok(Array.isArray(a.body.tribes));
+    const b = await request(app).get('/api/v1/meta/lineage/lin_v1').expect(200);
+    assert.equal(b.body.members_count, 3);
+  } finally {
+    _resetLineageRegistry();
+    await close();
+  }
+});

--- a/tests/services/metaProgression.lineage.test.js
+++ b/tests/services/metaProgression.lineage.test.js
@@ -1,0 +1,310 @@
+// Sprint D — Lineage chain + Tribe emergent (OD-001 Path A 4/4).
+//
+// Tribe = lineage_id chain con >= 3 members. Pure unit tests; in-memory
+// registry (process-scoped). Sprint C consumer wire (rollMating →
+// recordOffspring) coperto altrove.
+//
+// Reference: feedback_tribe_lineage_emergent_breakthrough.md.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  TRIBE_MIN_MEMBERS,
+  recordOffspring,
+  getLineageChain,
+  getTribesEmergent,
+  getTribeForUnit,
+  listLineageEntries,
+  _resetLineageRegistry,
+} = require('../../apps/backend/services/metaProgression');
+
+function reset() {
+  _resetLineageRegistry();
+}
+
+// ─── Constants ──────────────────────────────────────────────────────────
+
+test('Sprint D: TRIBE_MIN_MEMBERS = 3', () => {
+  assert.equal(TRIBE_MIN_MEMBERS, 3);
+});
+
+// ─── recordOffspring ────────────────────────────────────────────────────
+
+test('Sprint D: recordOffspring throws when entry missing unit_id', () => {
+  reset();
+  assert.throws(() => recordOffspring({}), /unit_id/);
+  assert.throws(() => recordOffspring(null), /entry object/);
+  assert.throws(() => recordOffspring({ unit_id: 123 }), /unit_id/);
+});
+
+test('Sprint D: recordOffspring normalizes parents=[] → generation=0 (founder)', () => {
+  reset();
+  const founder = recordOffspring({ unit_id: 'u_root', lineage_id: 'lin_alpha', parents: [] });
+  assert.equal(founder.generation, 0);
+  assert.deepEqual(founder.parents, []);
+  assert.equal(founder.lineage_id, 'lin_alpha');
+});
+
+test('Sprint D: recordOffspring uses unit_id as fallback lineage_id', () => {
+  reset();
+  const lone = recordOffspring({ unit_id: 'u_solo' });
+  assert.equal(lone.lineage_id, 'u_solo');
+  assert.equal(lone.generation, 0);
+});
+
+test('Sprint D: recordOffspring is idempotent (overwrite by unit_id)', () => {
+  reset();
+  recordOffspring({ unit_id: 'u_x', lineage_id: 'lin_a', generation: 0 });
+  recordOffspring({ unit_id: 'u_x', lineage_id: 'lin_a', generation: 1 });
+  const all = listLineageEntries();
+  assert.equal(all.length, 1);
+  assert.equal(all[0].generation, 1);
+});
+
+// ─── getLineageChain ────────────────────────────────────────────────────
+
+test('Sprint D: getLineageChain returns [] for unknown lineage', () => {
+  reset();
+  assert.deepEqual(getLineageChain('lin_nonexistent'), []);
+  assert.deepEqual(getLineageChain(''), []);
+  assert.deepEqual(getLineageChain(null), []);
+});
+
+test('Sprint D: getLineageChain single-gen (parent + 1 offspring)', () => {
+  reset();
+  recordOffspring({
+    unit_id: 'u_parent_a',
+    lineage_id: 'lin_beta',
+    parents: [],
+    generation: 0,
+    born_at_session: 's1',
+    born_at_biome: 'savana',
+  });
+  recordOffspring({
+    unit_id: 'u_off_1',
+    lineage_id: 'lin_beta',
+    parents: ['u_parent_a', 'u_parent_b'],
+    generation: 1,
+    born_at_session: 's1',
+    born_at_biome: 'savana',
+  });
+  const chain = getLineageChain('lin_beta');
+  assert.equal(chain.length, 2);
+  assert.equal(chain[0].generation, 0);
+  assert.equal(chain[1].generation, 1);
+  assert.equal(chain[0].unit_id, 'u_parent_a');
+});
+
+test('Sprint D: getLineageChain multi-gen sorts by generation ascending', () => {
+  reset();
+  // Insert out-of-order to test sort
+  recordOffspring({
+    unit_id: 'u_g2_1',
+    lineage_id: 'lin_g',
+    parents: ['u_g1_1', 'x'],
+    generation: 2,
+  });
+  recordOffspring({ unit_id: 'u_root', lineage_id: 'lin_g', parents: [], generation: 0 });
+  recordOffspring({
+    unit_id: 'u_g1_1',
+    lineage_id: 'lin_g',
+    parents: ['u_root', 'y'],
+    generation: 1,
+  });
+  recordOffspring({
+    unit_id: 'u_g3_1',
+    lineage_id: 'lin_g',
+    parents: ['u_g2_1', 'z'],
+    generation: 3,
+  });
+  const chain = getLineageChain('lin_g');
+  assert.equal(chain.length, 4);
+  assert.deepEqual(
+    chain.map((c) => c.generation),
+    [0, 1, 2, 3],
+  );
+});
+
+// ─── getTribesEmergent ──────────────────────────────────────────────────
+
+test('Sprint D: getTribesEmergent returns [] when registry empty', () => {
+  reset();
+  assert.deepEqual(getTribesEmergent(), []);
+});
+
+test('Sprint D: tribe threshold — 2 members = no tribe', () => {
+  reset();
+  recordOffspring({ unit_id: 'u_a', lineage_id: 'lin_pair', parents: [], generation: 0 });
+  recordOffspring({ unit_id: 'u_b', lineage_id: 'lin_pair', parents: ['u_a', 'x'], generation: 1 });
+  assert.deepEqual(getTribesEmergent(), []);
+});
+
+test('Sprint D: tribe threshold — 3 members = tribe emerges', () => {
+  reset();
+  recordOffspring({
+    unit_id: 'u_root',
+    lineage_id: 'lin_trio',
+    parents: [],
+    generation: 0,
+    born_at_biome: 'foresta_pluviale',
+  });
+  recordOffspring({
+    unit_id: 'u_off_1',
+    lineage_id: 'lin_trio',
+    parents: ['u_root', 'x'],
+    generation: 1,
+    born_at_biome: 'foresta_pluviale',
+  });
+  recordOffspring({
+    unit_id: 'u_off_2',
+    lineage_id: 'lin_trio',
+    parents: ['u_root', 'y'],
+    generation: 1,
+    born_at_biome: 'savana',
+  });
+  const tribes = getTribesEmergent();
+  assert.equal(tribes.length, 1);
+  const t = tribes[0];
+  assert.equal(t.tribe_id, 'lin_trio');
+  assert.equal(t.members_count, 3);
+  assert.equal(t.lineage_root_unit_id, 'u_root');
+  assert.equal(t.oldest_generation, 1);
+  // Most common biome among members = foresta_pluviale (2 vs savana 1).
+  assert.equal(t.primary_biome, 'foresta_pluviale');
+});
+
+test('Sprint D: tribe primary_biome detects most-common biome', () => {
+  reset();
+  // 3 offspring same lineage, biome distribution: savana 2, deserto 1 → savana wins.
+  recordOffspring({
+    unit_id: 'u1',
+    lineage_id: 'lin_b',
+    parents: [],
+    generation: 0,
+    born_at_biome: 'deserto',
+  });
+  recordOffspring({
+    unit_id: 'u2',
+    lineage_id: 'lin_b',
+    parents: ['u1', 'x'],
+    generation: 1,
+    born_at_biome: 'savana',
+  });
+  recordOffspring({
+    unit_id: 'u3',
+    lineage_id: 'lin_b',
+    parents: ['u1', 'y'],
+    generation: 1,
+    born_at_biome: 'savana',
+  });
+  const tribes = getTribesEmergent();
+  assert.equal(tribes.length, 1);
+  assert.equal(tribes[0].primary_biome, 'savana');
+});
+
+test('Sprint D: tribe primary_biome=null when all members biome=null', () => {
+  reset();
+  for (let i = 1; i <= 3; i++) {
+    recordOffspring({
+      unit_id: `u_${i}`,
+      lineage_id: 'lin_blank',
+      parents: i === 1 ? [] : ['u_1', 'x'],
+      generation: i === 1 ? 0 : 1,
+      born_at_biome: null,
+    });
+  }
+  const t = getTribesEmergent()[0];
+  assert.equal(t.primary_biome, null);
+});
+
+test('Sprint D: getTribesEmergent sorts by members_count desc', () => {
+  reset();
+  // Tribe small: 3 members
+  for (let i = 1; i <= 3; i++) {
+    recordOffspring({
+      unit_id: `s${i}`,
+      lineage_id: 'lin_small',
+      parents: i === 1 ? [] : ['s1', 'x'],
+      generation: i === 1 ? 0 : 1,
+    });
+  }
+  // Tribe big: 5 members
+  for (let i = 1; i <= 5; i++) {
+    recordOffspring({
+      unit_id: `b${i}`,
+      lineage_id: 'lin_big',
+      parents: i === 1 ? [] : ['b1', 'x'],
+      generation: i === 1 ? 0 : 1,
+    });
+  }
+  const tribes = getTribesEmergent();
+  assert.equal(tribes.length, 2);
+  assert.equal(tribes[0].tribe_id, 'lin_big');
+  assert.equal(tribes[0].members_count, 5);
+  assert.equal(tribes[1].tribe_id, 'lin_small');
+});
+
+test('Sprint D: tribe oldest_generation = max gen in chain', () => {
+  reset();
+  recordOffspring({ unit_id: 'r', lineage_id: 'lin_d', parents: [], generation: 0 });
+  recordOffspring({ unit_id: 'g1', lineage_id: 'lin_d', parents: ['r', 'x'], generation: 1 });
+  recordOffspring({ unit_id: 'g4', lineage_id: 'lin_d', parents: ['g1', 'y'], generation: 4 });
+  const t = getTribesEmergent()[0];
+  assert.equal(t.oldest_generation, 4);
+});
+
+// ─── getTribeForUnit ────────────────────────────────────────────────────
+
+test('Sprint D: getTribeForUnit returns null for unknown unit', () => {
+  reset();
+  assert.equal(getTribeForUnit('u_phantom'), null);
+  assert.equal(getTribeForUnit(''), null);
+  assert.equal(getTribeForUnit(null), null);
+});
+
+test('Sprint D: getTribeForUnit returns null for lone wolf (lineage <3 members)', () => {
+  reset();
+  recordOffspring({ unit_id: 'u_lone', lineage_id: 'lin_singleton', parents: [], generation: 0 });
+  recordOffspring({
+    unit_id: 'u_pair',
+    lineage_id: 'lin_singleton',
+    parents: ['u_lone', 'x'],
+    generation: 1,
+  });
+  // Only 2 in this lineage — under threshold.
+  assert.equal(getTribeForUnit('u_lone'), null);
+  assert.equal(getTribeForUnit('u_pair'), null);
+});
+
+test('Sprint D: getTribeForUnit returns tribe info when lineage qualifies', () => {
+  reset();
+  recordOffspring({
+    unit_id: 'a',
+    lineage_id: 'lin_q',
+    parents: [],
+    generation: 0,
+    born_at_biome: 'tundra',
+  });
+  recordOffspring({
+    unit_id: 'b',
+    lineage_id: 'lin_q',
+    parents: ['a', 'x'],
+    generation: 1,
+    born_at_biome: 'tundra',
+  });
+  recordOffspring({
+    unit_id: 'c',
+    lineage_id: 'lin_q',
+    parents: ['a', 'y'],
+    generation: 1,
+    born_at_biome: 'tundra',
+  });
+  const tribe = getTribeForUnit('b');
+  assert.ok(tribe);
+  assert.equal(tribe.tribe_id, 'lin_q');
+  assert.equal(tribe.members_count, 3);
+  assert.equal(tribe.primary_biome, 'tundra');
+});


### PR DESCRIPTION
## Summary

Sprint D di OD-001 Path A — chiude il bundle 4/4. Implementa la **catena di lignaggio** + **tribe emergent endpoint** consumabile da Sprint C (rollMating).

**Tribe NON è layer aggiuntivo**. È conseguenza emergente della catena Nido → offspring con `lineage_id` → catena multi-generazionale → N units stesso lineage = tribù implicita. User direction esplicita 2026-04-26: _"tribe = lignaggio + Nido condiviso + bioma comune. Non un rename forzato di job."_

Refs:
- Memory `feedback_tribe_lineage_emergent_breakthrough.md` (breakthrough 2026-04-26 da convergenza 2 agent indipendenti)
- Report `docs/reports/2026-04-26-tribe-mechanic-discovery.md` (verdict PARTIAL, archive 4-clan)
- Report `docs/reports/2026-04-26-nido-pokopia-housing-pattern.md` (housing pattern base)

## Changes

### Backend — `apps/backend/services/metaProgression.js`
Append-only export, zero break su Sprint A/B/C esistenti:
- `recordOffspring(entry)` — registra unit nel registry. Schema:
  ```
  { unit_id, lineage_id, parents: [a, b], generation, born_at_session, born_at_biome }
  ```
  Sprint C deve invocarlo dopo ogni `rollMating()` successo per popolare il grafo.
- `getLineageChain(lineageId)` → array units ordinato per `generation` ascending (root → leaves).
- `getTribesEmergent()` → lista tribe con `>= 3` members. Per ogni tribe:
  - `tribe_id` (= lineage_id)
  - `members_count`
  - `primary_biome` (most-common biome among members)
  - `oldest_generation`
  - `lineage_root_unit_id` (founder con parents=[] o min generation)
  - Sorted descending by members_count.
- `getTribeForUnit(unitId)` → tribe info; lone wolf (lineage <3) → `null`.
- `_resetLineageRegistry()` + `listLineageEntries()` — utility (test/debug).

### Backend — `apps/backend/routes/meta.js`
3 nuovi endpoint montati sia su `/api/meta` che `/api/v1/meta` (shared store via pluginLoader):
- `GET /api/meta/lineage/:id` → `{ lineage_id, members_count, chain[] }`
- `GET /api/meta/tribes` → `{ tribes[], threshold: 3 }`
- `GET /api/meta/tribe/unit/:id` → `{ unit_id, tribe, lone_wolf: bool }`

### Frontend — `apps/play/src/nestHub.js`
Aggiunge nuova section `data-tab="lineage"` (additive, non interferisce con sezioni Sprint A o tab Mating Sprint C):
- Lista tribe con stat chip (members / oldest gen / primary biome / root)
- Click su tribe → expand inline tree view (max 3 generazioni visibili, indented per generation)
- Click su unit → highlight + info card (gen / session / biome)
- Auto-refresh tribe list nel flow `refresh()` esistente

### Frontend — `apps/play/src/api.js`
3 nuovi client helper: `metaLineageChain`, `metaTribesEmergent`, `metaTribeForUnit`.

### Tests (25 nuovi)
- `tests/services/metaProgression.lineage.test.js` (**18**) — registry idempotency, threshold = 3 (negative + positive), primary_biome detection (most-common + null fallback), oldest_generation, sort by members_count, lone wolf null, getTribeForUnit edge cases.
- `tests/api/meta.lineage.test.js` (**7**) — 3 endpoint shape contracts + lone_wolf flag + dual mount `/api/meta` + `/api/v1/meta`.

## Sprint C interop (NOT yet merged)

Questo PR **NON modifica `rollMating()`**. Sprint C dovrà invocare:
```js
recordOffspring({
  unit_id: 'u_off_xxx',
  lineage_id: 'lin_xxx',     // hash combined parents (Sprint C produce)
  parents: [parentAId, parentBId],
  born_at_session: sessionId,
  born_at_biome: currentBiome,
});
```
Se Sprint C usa schema diverso, l'adapter `recordOffspring()` ha fallback safe (parents normalizzato a `[]`, lineage_id fallback = unit_id). Adapter trasparente.

## Verification

- ✅ Sprint D test 25/25 verdi (18 service + 7 API)
- ✅ Meta baseline 44/44 verdi (zero regression `metaRoutes` + `metaProgression`)
- ✅ AI regression 311/311 verde (0 break)
- ✅ Full API suite 739/739 verdi
- ✅ `npm run format:check` verde
- ✅ `npm run lint:stack` verde

## Stop-on-blocker note

- Registry **process-scoped** (in-memory). Cross-session persistence non è goal Sprint D — esplicito da task spec. Future: Prisma model `Lineage` + `Offspring` quando Path A esce da MVP.

## Test plan

- [ ] Smoke: `node --test tests/services/metaProgression.lineage.test.js` → 18/18
- [ ] Smoke: `node --test tests/api/meta.lineage.test.js` → 7/7
- [ ] Regression: `node --test tests/ai/*.test.js` → 311/311
- [ ] Regression: `node --test tests/api/*.test.js` → 739/739
- [ ] Manual: avviare backend, `POST /api/meta/affinity` (dummy NPC) + chiamata diretta `recordOffspring` via REPL → `GET /api/meta/tribes` riflette state
- [ ] UI: aprire Nest Hub → sezione "Lignaggio & Tribù emergent" visibile (vuota fino a Sprint C wire)

🤖 Generated with [Claude Code](https://claude.com/claude-code)