### PR TITLE
feat(nido): Sprint B — debrief recruit wire (OD-001 Path A 2/4)

### DIFF
--- a/apps/backend/routes/meta.js
+++ b/apps/backend/routes/meta.js
@@ -16,8 +16,43 @@
 
 'use strict';
 
+const fs = require('node:fs');
+const path = require('node:path');
 const { Router } = require('express');
+const yaml = require('js-yaml');
 const { createMetaStore } = require('../services/metaProgression');
+
+// OD-001 Path A Sprint B (2026-04-26): debrief-recruit affinity-bypass threshold.
+// Defeated enemies with affinity_at_recruit >= this value can be recruited
+// directly from debrief without going through the npg affinity grind first.
+// Tuned to 1 = "defeated and tagged with positive interaction this encounter".
+const RECRUIT_AFFINITY_BYPASS_THRESHOLD = 1;
+
+// Lazy-loaded MBTI compat table from data/core/mating.yaml. Used by clients
+// (debrief panel) to score enemy affinity post-combat. Cached in-process.
+let _compatTableCache = null;
+function loadCompatTable() {
+  if (_compatTableCache) return _compatTableCache;
+  try {
+    // Try a few candidate locations (worktree vs deployed paths).
+    const candidates = [
+      path.resolve(__dirname, '../../../data/core/mating.yaml'),
+      path.resolve(process.cwd(), 'data/core/mating.yaml'),
+    ];
+    for (const p of candidates) {
+      if (!fs.existsSync(p)) continue;
+      const raw = fs.readFileSync(p, 'utf8');
+      const parsed = yaml.load(raw);
+      const compat = parsed?.compat_forme || {};
+      _compatTableCache = compat;
+      return compat;
+    }
+  } catch {
+    /* fall through */
+  }
+  _compatTableCache = {};
+  return _compatTableCache;
+}
 
 /**
  * @param {object} [opts]
@@ -29,6 +64,18 @@ function createMetaRouter(opts = {}) {
   const router = Router();
   const store =
     opts.store || createMetaStore({ prisma: opts.prisma, campaignId: opts.campaignId ?? null });
+
+  // OD-001 Path A Sprint B (2026-04-26): expose MBTI compat table for
+  // debrief recruit UI scoring. Read-only, cached in-process. Returns
+  // {compat_forme: {...}} matching mating.yaml structure.
+  router.get('/compat', (_req, res, next) => {
+    try {
+      const compat = loadCompatTable();
+      res.json({ compat_forme: compat || {} });
+    } catch (err) {
+      next(err);
+    }
+  });
 
   router.get('/npg', async (_req, res, next) => {
     try {
@@ -70,12 +117,37 @@ function createMetaRouter(opts = {}) {
     }
   });
 
+  // Wildermyth/Hades pattern (OD-001 Path A Sprint B): debrief recruit wire.
+  // Accepts extended payload `{npc_id, source_session_id?, affinity_at_recruit?}`.
+  // When `affinity_at_recruit >= RECRUIT_AFFINITY_BYPASS_THRESHOLD` (default 1)
+  // we bypass the affinity gate by pre-bumping affinity/trust to satisfy the
+  // store gate (affinity>=0 AND trust>=2). This codifies "defeat-then-recruit"
+  // emergent flow without breaking the canonical npg/affinity pipeline.
+  // Already-recruited gate is still respected via store.recruit reason.
   router.post('/recruit', async (req, res, next) => {
     try {
-      const { npc_id } = req.body || {};
+      const { npc_id, source_session_id, affinity_at_recruit } = req.body || {};
       if (!npc_id) return res.status(400).json({ error: 'npc_id required' });
+
+      const affinityBypass =
+        Number.isFinite(Number(affinity_at_recruit)) &&
+        Number(affinity_at_recruit) >= RECRUIT_AFFINITY_BYPASS_THRESHOLD;
+
+      if (affinityBypass) {
+        // Pre-seed affinity + trust so the store gate accepts. The store clamps
+        // to [-2,+2] and [0,5]; values chosen to leave room for downstream
+        // affinity/trust mutations.
+        await store.updateAffinity(npc_id, 1);
+        await store.updateTrust(npc_id, 2);
+      }
+
       const result = await store.recruit(npc_id);
-      res.json(result);
+      const payload = {
+        ...result,
+        ...(source_session_id ? { source_session_id } : {}),
+        ...(affinityBypass ? { affinity_bypass_applied: true } : {}),
+      };
+      res.json(payload);
     } catch (err) {
       next(err);
     }

--- a/apps/play/src/api.js
+++ b/apps/play/src/api.js
@@ -260,10 +260,22 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ npc_id, delta }),
     }),
-  metaRecruit: (npc_id) =>
+  // OD-001 Path A Sprint B (2026-04-26): debrief recruit wire.
+  // Optional sourceSessionId + affinityAtRecruit unlock Wildermyth-style
+  // direct recruit from debrief (defeated enemy → ally) bypassing the
+  // affinity grind gate when affinityAtRecruit >= 1.
+  metaRecruit: (npc_id, sourceSessionId = null, affinityAtRecruit = null) =>
     jsonFetch('/api/meta/recruit', {
       method: 'POST',
-      body: JSON.stringify({ npc_id }),
+      body: JSON.stringify({
+        npc_id,
+        ...(sourceSessionId ? { source_session_id: sourceSessionId } : {}),
+        ...(affinityAtRecruit !== null &&
+        affinityAtRecruit !== undefined &&
+        Number.isFinite(Number(affinityAtRecruit))
+          ? { affinity_at_recruit: Number(affinityAtRecruit) }
+          : {}),
+      }),
     }),
   metaMating: (npc_id, party_member) =>
     jsonFetch('/api/meta/mating', {

--- a/apps/play/src/debriefPanel.css
+++ b/apps/play/src/debriefPanel.css
@@ -394,3 +394,123 @@
 .db-mbti-hint {
   flex: 1;
 }
+
+/* OD-001 Path A Sprint B (2026-04-26): debrief recruit section. */
+.db-recruit-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.db-recruit-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  background: linear-gradient(180deg, #1a1f2c 0%, #12161e 100%);
+  border: 1px solid #2a3040;
+  border-radius: 10px;
+  transition:
+    border-color 0.18s ease,
+    background 0.18s ease;
+}
+
+.db-recruit-card.recruited {
+  border-color: #66bb6a;
+  background: linear-gradient(180deg, #1e2d20 0%, #12161e 100%);
+}
+
+.db-recruit-avatar {
+  font-size: 1.6rem;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #0b0d12;
+  border: 1px solid #2a3040;
+  flex-shrink: 0;
+}
+
+.db-recruit-card.recruited .db-recruit-avatar {
+  border-color: #66bb6a;
+  color: #aed581;
+}
+
+.db-recruit-meta {
+  flex: 1;
+  min-width: 0;
+}
+
+.db-recruit-name {
+  font-weight: 700;
+  color: #ffd180;
+  font-size: 0.95rem;
+  margin-bottom: 4px;
+}
+
+.db-recruit-sub {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+
+.db-recruit-tag {
+  font-family: monospace;
+  font-size: 0.72rem;
+  background: #0b0d12;
+  border: 1px solid #2a3040;
+  border-radius: 4px;
+  padding: 2px 6px;
+  color: #b0b8cc;
+}
+
+.db-recruit-tag.mbti {
+  color: #ffd180;
+}
+
+.db-recruit-aff {
+  font-size: 0.78rem;
+  color: #8891a3;
+}
+
+.db-recruit-aff strong {
+  color: #aed581;
+}
+
+.db-recruit-btn {
+  background: #2d4a2d;
+  color: #e8eaf0;
+  border: 1px solid #3d5542;
+  border-radius: 6px;
+  padding: 8px 14px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  flex-shrink: 0;
+  transition: background 0.18s ease;
+}
+
+.db-recruit-btn:hover:not(:disabled) {
+  background: #3d6a3d;
+}
+
+.db-recruit-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.db-recruit-card.recruited .db-recruit-btn {
+  background: #1e2d20;
+  border-color: #66bb6a;
+  color: #aed581;
+}
+
+.db-recruit-hint {
+  margin-top: 6px;
+  font-size: 0.78rem;
+  color: #8891a3;
+  text-align: right;
+}

--- a/apps/play/src/debriefPanel.js
+++ b/apps/play/src/debriefPanel.js
@@ -7,6 +7,9 @@
 // class="mbti-axis-X">` SOLO se l'asse è rivelato in `mbtiRevealed.revealed[]`.
 // Plain text passa-through invariato (escape HTML safety lo gestisce il helper).
 import { renderMbtiTaggedHtml } from './dialogueRender.js';
+// OD-001 Path A Sprint B: recruit POST goes through api client (network retry +
+// graceful failure handling). Lazy import only if api ever becomes circular.
+import { api } from './api.js';
 
 // OD-001 Path A V3 Mating/Nido (2026-04-26): pure helper DOM-free per identify
 // recruitable enemies post-combat. Filtra unit team !== player/ally con hp<=0.
@@ -24,6 +27,59 @@ export function findRecruitableEnemies(world) {
     return true;
   });
 }
+
+// OD-001 Path A Sprint B (2026-04-26): debrief recruit wire — affinity scoring.
+// Wildermyth/Hades pattern: defeated enemy → recruitable when affinity exceeds
+// threshold. Scoring rules (additive):
+//   +2 same MBTI type (best resonance)
+//   +1 MBTI compat: enemy in player.compat_forme[player.mbti].likes
+//   -1 MBTI compat: enemy in player.compat_forme[player.mbti].dislikes
+//   +1 enemy is non-boss (regular kill — easier rapport)
+//   +1 enemy is boss defeated (Wildermyth iconic foe — narrative resonance)
+// Default fallback (no MBTI on either side): regular=1 / boss=2 baseline.
+// Threshold 1 = recruitable. Returns {affinity:Number, reasons:string[]}.
+export function computeRecruitAffinity(enemyUnit, playerMember, compatTable = {}) {
+  const reasons = [];
+  let affinity = 0;
+  if (!enemyUnit || typeof enemyUnit !== 'object') {
+    return { affinity: 0, reasons: ['enemy invalido'] };
+  }
+  const enemyMbti = enemyUnit.mbti_type || enemyUnit.mbti || null;
+  const playerMbti = playerMember?.mbti_type || playerMember?.mbti || null;
+  const isBoss = Boolean(
+    enemyUnit.is_boss || enemyUnit.boss || (enemyUnit.tags && enemyUnit.tags.includes?.('boss')),
+  );
+  if (isBoss) {
+    affinity += 1;
+    reasons.push('+1 boss defeated');
+  } else {
+    affinity += 1;
+    reasons.push('+1 regular defeat');
+  }
+  if (enemyMbti && playerMbti) {
+    if (enemyMbti === playerMbti) {
+      affinity += 2;
+      reasons.push(`+2 MBTI risonanza (${playerMbti})`);
+    } else {
+      const compat =
+        compatTable && typeof compatTable === 'object' ? compatTable[playerMbti] : null;
+      if (compat) {
+        if (Array.isArray(compat.likes) && compat.likes.includes(enemyMbti)) {
+          affinity += 1;
+          reasons.push(`+1 MBTI like ${playerMbti}→${enemyMbti}`);
+        } else if (Array.isArray(compat.dislikes) && compat.dislikes.includes(enemyMbti)) {
+          affinity -= 1;
+          reasons.push(`-1 MBTI dislike ${playerMbti}→${enemyMbti}`);
+        }
+      }
+    }
+  }
+  return { affinity, reasons };
+}
+
+// Affinity threshold for showing recruit button (UI gate). Backend bypass
+// threshold is in routes/meta.js. Match them: any positive affinity → eligible.
+export const RECRUIT_AFFINITY_UI_THRESHOLD = 1;
 
 export function renderDebriefPanel() {
   if (typeof document === 'undefined') return null;
@@ -62,6 +118,14 @@ export function renderDebriefPanel() {
             <button type="button" class="db-skip-btn" id="db-evolve-no">⏭ Mantieni</button>
           </div>
         </div>
+      </div>
+
+      <div class="db-section" id="db-recruit-section" style="display:none">
+        <div class="db-section-title">🤝 Reclutabili dal Nido</div>
+        <div class="db-recruit-list" id="db-recruit-list">
+          <div class="db-empty">Nessun nemico reclutabile</div>
+        </div>
+        <div class="db-recruit-hint" id="db-recruit-hint"></div>
       </div>
 
       <div class="db-section" id="db-rewards-section" style="display:none">
@@ -153,6 +217,10 @@ export function wireDebriefPanel(overlay, bridge) {
     partyList: [],
     readySet: new Set(),
     mbtiRevealed: null,
+    // OD-001 Path A Sprint B (2026-04-26): debrief recruit wire.
+    recruitedNpcIds: new Set(),
+    recruitInFlight: new Set(),
+    compatTable: null,
   };
 
   const outcomeEl = overlay.querySelector('#db-outcome');
@@ -283,6 +351,142 @@ export function wireDebriefPanel(overlay, bridge) {
     }
   };
 
+  // OD-001 Path A Sprint B (2026-04-26): debrief recruit section render.
+  // Wildermyth/Hades — defeated enemies con affinity≥threshold get a recruit
+  // button. Player MBTI scored against enemy MBTI via state.compatTable
+  // (loaded async on first render via `loadCompatTable`).
+  const renderRecruit = () => {
+    const section = overlay.querySelector('#db-recruit-section');
+    const list = overlay.querySelector('#db-recruit-list');
+    const hint = overlay.querySelector('#db-recruit-hint');
+    if (!section || !list) return;
+    // Solo su victory (defeat = niente recluta sopra cadaveri tuoi).
+    if (state.outcome !== 'victory') {
+      section.style.display = 'none';
+      return;
+    }
+    const enemies = findRecruitableEnemies(state.lastState);
+    if (!enemies.length) {
+      section.style.display = 'none';
+      return;
+    }
+    const playerMember = readPlayerMember();
+    const compat = state.compatTable || {};
+    // Score + filter affinity >= threshold OR fallback always-show con score.
+    const candidates = enemies.map((u) => {
+      const { affinity, reasons } = computeRecruitAffinity(u, playerMember, compat);
+      return { unit: u, affinity, reasons };
+    });
+    const eligible = candidates.filter((c) => c.affinity >= RECRUIT_AFFINITY_UI_THRESHOLD);
+    if (!eligible.length) {
+      section.style.display = '';
+      list.innerHTML =
+        '<div class="db-empty">Nessun nemico con affinità sufficiente per il reclutamento.</div>';
+      if (hint) hint.textContent = '';
+      return;
+    }
+    section.style.display = '';
+    list.innerHTML = '';
+    for (const c of eligible) {
+      const u = c.unit;
+      const npcId = String(u.id || u.npc_id || u.unit_id || '');
+      if (!npcId) continue;
+      const recruited = state.recruitedNpcIds.has(npcId);
+      const inFlight = state.recruitInFlight.has(npcId);
+      const card = document.createElement('div');
+      card.className = `db-recruit-card${recruited ? ' recruited' : ''}`;
+      card.dataset.npcId = npcId;
+      const safeName = String(u.name || npcId).replace(/[<>&"]/g, '');
+      const safeSpecies = String(u.species || u.species_id || u.archetype || '').replace(
+        /[<>&"]/g,
+        '',
+      );
+      const mbtiLabel = u.mbti_type ? String(u.mbti_type).replace(/[<>&"]/g, '') : '—';
+      const hpMax = u.hp_max ?? u.max_hp ?? '?';
+      const atk = u.atk ?? u.attack ?? u.attack_mod ?? '?';
+      card.innerHTML = `
+        <div class="db-recruit-avatar" aria-hidden="true">${recruited ? '⚡' : '🪺'}</div>
+        <div class="db-recruit-meta">
+          <div class="db-recruit-name">${safeName}</div>
+          <div class="db-recruit-sub">
+            ${safeSpecies ? `<span class="db-recruit-tag">${safeSpecies}</span>` : ''}
+            <span class="db-recruit-tag mbti">MBTI ${mbtiLabel}</span>
+            <span class="db-recruit-tag">HP ${hpMax}</span>
+            <span class="db-recruit-tag">ATK ${atk}</span>
+          </div>
+          <div class="db-recruit-aff" title="${c.reasons.join(' · ')}">
+            Affinità: <strong>${c.affinity}</strong>
+          </div>
+        </div>
+        <button type="button" class="db-recruit-btn" data-npc-id="${npcId}"
+          ${recruited || inFlight ? 'disabled' : ''}>
+          ${recruited ? '✓ Alleato' : inFlight ? '…' : '🤝 Recluta'}
+        </button>
+      `;
+      const btn = card.querySelector('.db-recruit-btn');
+      if (btn) {
+        btn.addEventListener('click', () => handleRecruitClick(npcId, c.affinity));
+      }
+      list.appendChild(card);
+    }
+    if (hint) {
+      hint.textContent = `${eligible.length} reclutabile${eligible.length === 1 ? '' : 'i'}`;
+    }
+  };
+
+  // Toast/feedback in main status line. Reuse setStatus channel.
+  const recruitToast = (msg, kind) => setStatus(msg, kind);
+
+  function readPlayerMember() {
+    // Provider chain: bridge.getPartyMember() (preferred) → my unit → null.
+    let pm = null;
+    try {
+      pm = bridge.getPartyMember?.() || null;
+    } catch {
+      /* optional */
+    }
+    if (pm) return pm;
+    const myUnit = findMyUnit(state.lastState, bridge.session?.player_id);
+    if (myUnit) {
+      return {
+        mbti_type: myUnit.mbti_type || myUnit.mbti || null,
+        trait_ids: myUnit.trait_ids || myUnit.traits || [],
+      };
+    }
+    return null;
+  }
+
+  async function handleRecruitClick(npcId, affinity) {
+    if (state.recruitedNpcIds.has(npcId) || state.recruitInFlight.has(npcId)) return;
+    state.recruitInFlight.add(npcId);
+    renderRecruit();
+    recruitToast(`Reclutamento di ${npcId}…`);
+    try {
+      const sessionId = bridge.session?.session_id || bridge.session?.code || null;
+      const res = await api.metaRecruit(npcId, sessionId, affinity);
+      if (!res.ok) {
+        recruitToast(`✖ Errore rete: HTTP ${res.status}`, 'err');
+        state.recruitInFlight.delete(npcId);
+        renderRecruit();
+        return;
+      }
+      const data = res.data || {};
+      if (data.success) {
+        state.recruitedNpcIds.add(npcId);
+        state.recruitInFlight.delete(npcId);
+        recruitToast(`🤝 ${npcId} si unisce al Nido!`, 'ok');
+      } else {
+        const reason = data.reason || 'unknown';
+        recruitToast(`✖ Reclutamento fallito: ${reason}`, 'err');
+        state.recruitInFlight.delete(npcId);
+      }
+    } catch (err) {
+      recruitToast(`✖ Errore: ${err?.message || String(err)}`, 'err');
+      state.recruitInFlight.delete(npcId);
+    }
+    renderRecruit();
+  }
+
   const renderParty = () => {
     const list = overlay.querySelector('#db-party');
     const count = overlay.querySelector('#db-party-count');
@@ -310,9 +514,31 @@ export function wireDebriefPanel(overlay, bridge) {
     renderNarrative();
     renderParty();
     renderMbti();
+    renderRecruit();
     // Fire-and-forget: Skiv card refresh ad ogni render debrief.
     renderSkivMonitorCard();
+    // Fire-and-forget: lazy-load MBTI compat table on first render.
+    if (state.compatTable === null) {
+      state.compatTable = {}; // mark as loading
+      loadCompatTable().then((tbl) => {
+        state.compatTable = tbl || {};
+        renderRecruit();
+      });
+    }
   };
+
+  // OD-001 Path A Sprint B (2026-04-26): lazy-load MBTI compat table from
+  // backend if exposed via /api/meta/compat. Graceful fallback {} on miss.
+  async function loadCompatTable() {
+    try {
+      const res = await fetch('/api/meta/compat', { cache: 'force-cache' });
+      if (!res.ok) return {};
+      const data = await res.json();
+      return data?.compat_forme || data || {};
+    } catch {
+      return {};
+    }
+  }
 
   readyBtn.addEventListener('click', async () => {
     if (state.submitted) return;
@@ -439,7 +665,22 @@ export function wireDebriefPanel(overlay, bridge) {
       state.submitted = false;
       state.readySet.clear();
       readyBtn.disabled = false;
+      // OD-001 Path A Sprint B: clear recruit state on phase reset.
+      state.recruitedNpcIds.clear();
+      state.recruitInFlight.clear();
       setStatus('');
+    },
+    // OD-001 Path A Sprint B test seam: inject compat table directly.
+    setCompatTable(table) {
+      state.compatTable = table && typeof table === 'object' ? table : {};
+      renderRecruit();
+    },
+    // OD-001 Path A Sprint B test seam: read internal state for assertions.
+    _getRecruitState() {
+      return {
+        recruited: [...state.recruitedNpcIds],
+        inFlight: [...state.recruitInFlight],
+      };
     },
   };
 }

--- a/tests/api/debriefPanelRecruit.test.js
+++ b/tests/api/debriefPanelRecruit.test.js
@@ -1,0 +1,151 @@
+// OD-001 Path A Sprint B (2026-04-26): debriefPanel recruit helpers tests.
+//
+// Coverage:
+//   1. computeRecruitAffinity — base scoring (regular vs boss)
+//   2. MBTI same-type resonance (+2)
+//   3. MBTI compat likes (+1) / dislikes (-1)
+//   4. Missing MBTI on either side → only baseline (no compat term)
+//   5. Threshold export sanity
+//   6. Pure helper does not throw on null/invalid input
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+async function loadHelpers() {
+  return import('../../apps/play/src/debriefPanel.js');
+}
+
+test('computeRecruitAffinity — regular kill baseline +1', async () => {
+  const { computeRecruitAffinity } = await loadHelpers();
+  const out = computeRecruitAffinity({ id: 'e1', mbti_type: null, hp: 0 }, { mbti_type: null }, {});
+  assert.equal(out.affinity, 1);
+  assert.ok(out.reasons.some((r) => r.includes('regular defeat')));
+});
+
+test('computeRecruitAffinity — boss baseline +1', async () => {
+  const { computeRecruitAffinity } = await loadHelpers();
+  const out = computeRecruitAffinity({ id: 'boss', is_boss: true, hp: 0 }, { mbti_type: null }, {});
+  assert.equal(out.affinity, 1);
+  assert.ok(out.reasons.some((r) => r.includes('boss defeated')));
+});
+
+test('computeRecruitAffinity — same MBTI grants +2 resonance', async () => {
+  const { computeRecruitAffinity } = await loadHelpers();
+  const out = computeRecruitAffinity(
+    { id: 'e1', mbti_type: 'INTJ', hp: 0 },
+    { mbti_type: 'INTJ' },
+    {},
+  );
+  // baseline +1 (regular) + 2 (resonance) = 3
+  assert.equal(out.affinity, 3);
+  assert.ok(out.reasons.some((r) => r.includes('risonanza')));
+});
+
+test('computeRecruitAffinity — compat likes grants +1', async () => {
+  const { computeRecruitAffinity } = await loadHelpers();
+  const compat = { INTJ: { likes: ['ENTJ'], dislikes: ['ESFP'] } };
+  const out = computeRecruitAffinity(
+    { id: 'e1', mbti_type: 'ENTJ', hp: 0 },
+    { mbti_type: 'INTJ' },
+    compat,
+  );
+  // baseline +1 + likes +1 = 2
+  assert.equal(out.affinity, 2);
+  assert.ok(out.reasons.some((r) => r.includes('like')));
+});
+
+test('computeRecruitAffinity — compat dislikes grants -1', async () => {
+  const { computeRecruitAffinity } = await loadHelpers();
+  const compat = { INTJ: { likes: ['ENTJ'], dislikes: ['ESFP'] } };
+  const out = computeRecruitAffinity(
+    { id: 'e1', mbti_type: 'ESFP', hp: 0 },
+    { mbti_type: 'INTJ' },
+    compat,
+  );
+  // baseline +1 - dislike 1 = 0 (UI: NOT eligible since threshold=1)
+  assert.equal(out.affinity, 0);
+  assert.ok(out.reasons.some((r) => r.includes('dislike')));
+});
+
+test('computeRecruitAffinity — missing MBTI ignores compat term', async () => {
+  const { computeRecruitAffinity } = await loadHelpers();
+  const compat = { INTJ: { likes: ['ENTJ'] } };
+  const out = computeRecruitAffinity(
+    { id: 'e1', hp: 0 }, // no mbti_type
+    { mbti_type: 'INTJ' },
+    compat,
+  );
+  assert.equal(out.affinity, 1); // baseline only
+});
+
+test('computeRecruitAffinity — null/invalid input returns 0 affinity', async () => {
+  const { computeRecruitAffinity } = await loadHelpers();
+  assert.equal(computeRecruitAffinity(null, null, {}).affinity, 0);
+  assert.equal(computeRecruitAffinity(undefined, null, {}).affinity, 0);
+});
+
+test('RECRUIT_AFFINITY_UI_THRESHOLD exported as 1', async () => {
+  const { RECRUIT_AFFINITY_UI_THRESHOLD } = await loadHelpers();
+  assert.equal(RECRUIT_AFFINITY_UI_THRESHOLD, 1);
+});
+
+test('api.metaRecruit — backward compat (no extra args)', async () => {
+  const { api } = await import('../../apps/play/src/api.js');
+  const calls = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url, opts = {}) => {
+    calls.push({ url, opts });
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return { success: true };
+      },
+      async text() {
+        return '{}';
+      },
+    };
+  };
+  try {
+    await api.metaRecruit('npc_compat_legacy');
+    assert.equal(calls[0].url, '/api/meta/recruit');
+    const body = JSON.parse(calls[0].opts.body);
+    assert.equal(body.npc_id, 'npc_compat_legacy');
+    assert.equal(body.source_session_id, undefined);
+    assert.equal(body.affinity_at_recruit, undefined);
+  } finally {
+    if (original) globalThis.fetch = original;
+    else delete globalThis.fetch;
+  }
+});
+
+test('api.metaRecruit — passes sourceSessionId + affinityAtRecruit when provided', async () => {
+  const { api } = await import('../../apps/play/src/api.js');
+  const calls = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url, opts = {}) => {
+    calls.push({ url, opts });
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return { success: true };
+      },
+      async text() {
+        return '{}';
+      },
+    };
+  };
+  try {
+    await api.metaRecruit('npc_e2e', 'sess_xyz', 2);
+    const body = JSON.parse(calls[0].opts.body);
+    assert.equal(body.npc_id, 'npc_e2e');
+    assert.equal(body.source_session_id, 'sess_xyz');
+    assert.equal(body.affinity_at_recruit, 2);
+  } finally {
+    if (original) globalThis.fetch = original;
+    else delete globalThis.fetch;
+  }
+});

--- a/tests/api/metaRecruit.test.js
+++ b/tests/api/metaRecruit.test.js
@@ -1,0 +1,139 @@
+// OD-001 Path A Sprint B (2026-04-26): /api/meta/recruit endpoint extension.
+// Tests the Wildermyth-style "defeat-then-recruit" affinity-bypass payload.
+//
+// Coverage:
+//   1. Existing gate behavior preserved (no bypass payload → gate_not_met).
+//   2. affinity_at_recruit >= threshold bypasses gate → success on first call.
+//   3. source_session_id echoed in response when provided.
+//   4. Invalid affinity_at_recruit (non-numeric) does NOT trigger bypass.
+//   5. Already-recruited NPG → success false even with bypass.
+//   6. /api/meta/compat returns compat_forme dictionary (or empty obj).
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+test('recruit without bypass — gate denied at trust 0', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app)
+      .post('/api/meta/recruit')
+      .send({ npc_id: 'npc_no_bypass_01' })
+      .expect(200);
+    assert.equal(res.body.success, false);
+    assert.equal(res.body.reason, 'gate_not_met');
+  } finally {
+    await close();
+  }
+});
+
+test('recruit with affinity_at_recruit=1 — bypass applies → success', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app)
+      .post('/api/meta/recruit')
+      .send({
+        npc_id: 'npc_bypass_01',
+        source_session_id: 'sess_test_01',
+        affinity_at_recruit: 1,
+      })
+      .expect(200);
+    assert.equal(res.body.success, true);
+    assert.equal(res.body.npc.recruited, true);
+    assert.equal(res.body.affinity_bypass_applied, true);
+    assert.equal(res.body.source_session_id, 'sess_test_01');
+  } finally {
+    await close();
+  }
+});
+
+test('recruit with affinity_at_recruit=2 — bypass also applies (any positive >=1)', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app)
+      .post('/api/meta/recruit')
+      .send({ npc_id: 'npc_bypass_high', affinity_at_recruit: 2 })
+      .expect(200);
+    assert.equal(res.body.success, true);
+    assert.equal(res.body.affinity_bypass_applied, true);
+  } finally {
+    await close();
+  }
+});
+
+test('recruit with affinity_at_recruit=0 — bypass NOT applied → gate fail', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app)
+      .post('/api/meta/recruit')
+      .send({ npc_id: 'npc_no_bypass_zero', affinity_at_recruit: 0 })
+      .expect(200);
+    assert.equal(res.body.success, false);
+    assert.equal(res.body.reason, 'gate_not_met');
+    assert.equal(res.body.affinity_bypass_applied, undefined);
+  } finally {
+    await close();
+  }
+});
+
+test('recruit with non-numeric affinity_at_recruit — ignored, gate fails', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app)
+      .post('/api/meta/recruit')
+      .send({ npc_id: 'npc_garbage_aff', affinity_at_recruit: 'lots' })
+      .expect(200);
+    assert.equal(res.body.success, false);
+    assert.equal(res.body.reason, 'gate_not_met');
+  } finally {
+    await close();
+  }
+});
+
+test('recruit twice with bypass — second call returns gate_not_met (already recruited)', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const first = await request(app)
+      .post('/api/meta/recruit')
+      .send({ npc_id: 'npc_double', affinity_at_recruit: 1 })
+      .expect(200);
+    assert.equal(first.body.success, true);
+    const second = await request(app)
+      .post('/api/meta/recruit')
+      .send({ npc_id: 'npc_double', affinity_at_recruit: 1 })
+      .expect(200);
+    assert.equal(second.body.success, false);
+    assert.equal(second.body.reason, 'gate_not_met');
+  } finally {
+    await close();
+  }
+});
+
+test('recruit 400 on missing npc_id', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app).post('/api/meta/recruit').send({}).expect(400);
+  } finally {
+    await close();
+  }
+});
+
+test('GET /api/meta/compat returns compat_forme shape', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app).get('/api/meta/compat').expect(200);
+    assert.equal(typeof res.body, 'object');
+    assert.equal(typeof res.body.compat_forme, 'object');
+    // mating.yaml shape: every entry has likes/dislikes lists.
+    // If file present (canonical worktree) → ISTJ entry exists and has likes.
+    // Tolerant on empty result for environments without the YAML file.
+    if (res.body.compat_forme.ISTJ) {
+      assert.ok(Array.isArray(res.body.compat_forme.ISTJ.likes));
+    }
+  } finally {
+    await close();
+  }
+});


### PR DESCRIPTION
## Summary

Sprint B di OD-001 Path A (4-sprint sequence) — wire post-combat **debrief recruit** seguendo Wildermyth + Hades emergent-recruit pattern.

- Backend `/api/meta/recruit` accetta `{npc_id, source_session_id?, affinity_at_recruit?}`. Quando `affinity_at_recruit ≥ 1`, pre-seed affinity/trust per soddisfare il store gate canonical (npg/affinity flow preservato). Already-recruited gate ancora rispettato.
- Nuovo endpoint `/api/meta/compat` lazy-loaded da `data/core/mating.yaml` (cached, graceful empty-object fallback).
- Frontend `debriefPanel.js` aggiunge sezione "🤝 Reclutabili dal Nido" tra evolve e rewards: card per nemico defeated con avatar/nome/MBTI/HP/ATK + score affinity (`computeRecruitAffinity` — baseline +1 + same-MBTI +2 + likes +/- dislikes ±1) + bottone "Recluta" → POST → border verde + "✓ Alleato" + toast "X si unisce al Nido". Lazy-load compat table on first render.
- Conflict-tolerant: `metaProgression.js` NON toccato (read-only, route adatta payload). Sprint C/D possono modificare api.js/route in parallelo senza collisione.

## Test plan

- [x] `node --test tests/api/metaRecruit.test.js` — 8/8 verde (bypass paths + already-recruited replay + 400 missing + compat shape)
- [x] `node --test tests/api/debriefPanelRecruit.test.js` — 10/10 verde (pure-helper scoring + threshold export + api client backward compat)
- [x] `node --test tests/api/v3MatingApi.test.js tests/api/metaRoutes.test.js` — 21/21 regression verde
- [x] `node --test tests/ai/*.test.js` — 311/311 verde (zero AI regression)
- [x] `npm run format:check` — verde
- [ ] **Userland** (Sprint C/D follow-up): playtest live debrief recruit flow end-to-end con 2-4 amici (chiude P5 🟢 definitivo)

## Files changed

- `apps/backend/routes/meta.js` (+76 / -1) — `/recruit` extension + `/compat` endpoint + YAML loader
- `apps/play/src/api.js` (+12 / -3) — `metaRecruit(id, sourceSessionId?, affinityAtRecruit?)`
- `apps/play/src/debriefPanel.js` (+241) — `computeRecruitAffinity` + recruit section render + handler + test seams
- `apps/play/src/debriefPanel.css` (+120) — recruit card styling (avatar, tags, affinity, button states, recruited green border)
- `tests/api/metaRecruit.test.js` (NEW, 8 tests) — backend endpoint behavior
- `tests/api/debriefPanelRecruit.test.js` (NEW, 10 tests) — frontend helper + api client

## Sprint context

OD-001 Path A 4-sprint sequenziali: A (nestHub UI ✅) + **B (recruit wire — questo PR)** + C (mating) + D (lineage). Sprint A+B paralleli safe.

User direction (sessione 2026-04-26): _"il debrief deve permettere di reclutare ex-nemici dopo un encounter risolto. Pattern Wildermyth/Hades — conseguenza emergente del combat, non menu separato."_

Reference report: `docs/reports/2026-04-26-nido-pokopia-housing-pattern.md` — base pattern Wildermyth + Hades emergent-recruit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>