### PR TITLE
feat(nido): Sprint A — nestHub panel + biome_arc unlock (OD-001 Path A 1/4)

### DIFF
--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -264,6 +264,29 @@ function timestampStamp(date) {
     .replace('T', '_');
 }
 
+// OD-001 Path A Sprint A — Nido unlock gating helper.
+//
+// Checks whether the Nido hub should be exposed to clients (and visible in the
+// HUD header). Sblocco diegetic via narrative arc:
+//   - `state.meta.nido_unlocked === true` (set by narrative engine, Wave 9+)
+//   - OR `state.meta.biome_arc_completed === true` AND
+//        `state.meta.missions_in_biome_count >= 3`
+//   - OR env override `NIDO_UNLOCKED=true` (dev/test bypass)
+//
+// Returns boolean. Pure (no side effects).
+//
+// NOTE: Sprint A non wire ancora trigger reale al narrative engine. Il check
+// supporta sia dev-mode (env flag) che signal narrative future.
+function checkNidoUnlock(session) {
+  if (process.env.NIDO_UNLOCKED === 'true') return true;
+  const meta = (session && session.meta) || {};
+  if (meta.nido_unlocked === true) return true;
+  const biomeArcDone = meta.biome_arc_completed === true;
+  const missionsCount = Number(meta.missions_in_biome_count) || 0;
+  if (biomeArcDone && missionsCount >= 3) return true;
+  return false;
+}
+
 function publicSessionView(session) {
   // A2: expose PP/SG/surge_ready per unit for UI consumption.
   // V5 (ADR-2026-04-26): `sg` è ora pool integer 0..3 (Seed of Growth),
@@ -325,6 +348,8 @@ function publicSessionView(session) {
       session.tile_state_map && typeof session.tile_state_map === 'object'
         ? session.tile_state_map
         : {},
+    // OD-001 Path A Sprint A — Nido unlock flag for HUD btn visibility.
+    nido_unlocked: checkNidoUnlock(session),
   };
 }
 
@@ -610,4 +635,5 @@ module.exports = {
   SISTEMA_PRESSURE_TIERS,
   PRESSURE_DELTAS,
   buildSynergyPreview,
+  checkNidoUnlock,
 };

--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -157,6 +157,27 @@
             </svg>
             <span class="hud-label">🦎 Skiv</span>
           </button>
+          <button
+            id="nest-open"
+            class="hud-btn"
+            title="Nido — Squad / Mating / Lineage / Codex (OD-001 Path A)"
+            style="display: none"
+          >
+            <svg
+              class="hud-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M3 12L12 4l9 8M5 10v10h14V10" />
+              <path d="M9 20v-6h6v6" />
+            </svg>
+            <span class="hud-label">🏠 Nido</span>
+          </button>
           <button id="forms-open" class="hud-btn" title="Evoluzione Form — scegli form MBTI (M12)">
             <svg
               class="hud-icon"

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -25,6 +25,7 @@ import { initFormsPanel, openFormsPanel } from './formsPanel.js';
 import { initThoughtsPanel, openThoughtsPanel } from './thoughtsPanel.js';
 import { initProgressionPanel, openProgressionPanel } from './progressionPanel.js';
 import { initSkivPanel, openSkivPanel } from './skivPanel.js';
+import { initNestHub, openNestHub } from './nestHub.js';
 
 const state = {
   sid: null,
@@ -854,6 +855,9 @@ async function refresh() {
       if (!sel || sel.hp <= 0) state.selected = null;
     }
     redraw();
+    // OD-001 Path A Sprint A — toggle Nido btn visibility quando state.world.nido_unlocked.
+    // Hidden by default (display:none in index.html); inline override via JS.
+    updateNestButtonVisibility(state.world?.nido_unlocked === true);
     // M11 Phase B — if host of a lobby, broadcast world snapshot to players.
     // Players render it as read-only spectator state. Payload kept small:
     // only fields players need to understand the board.
@@ -1781,3 +1785,25 @@ window.__evo = {
 // Skiv-as-Monitor — overlay panel + header btn 🦎 Skiv (Phase 2 wire 2026-04-25).
 // Indipendente da session/campaign — feed creatura da git events sempre disponibile.
 initSkivPanel();
+
+// OD-001 Path A Sprint A — Nest Hub overlay + header btn 🏠 Nido.
+// Visibility gated by state.world.nido_unlocked (toggled in refresh()).
+function updateNestButtonVisibility(unlocked) {
+  const btn = document.getElementById('nest-open');
+  if (!btn) return;
+  btn.style.display = unlocked ? '' : 'none';
+}
+initNestHub({
+  getPartyMember: () => {
+    if (!state.world || !state.selected) return null;
+    const u = getUnits(state.world).find((u) => u.id === state.selected);
+    if (!u) return null;
+    return {
+      mbti_type: u.mbti_type || 'NEUTRA',
+      trait_ids: Array.isArray(u.trait_ids) ? u.trait_ids : [],
+    };
+  },
+  openCodex: () => toggleCodex(),
+});
+window.__evo = window.__evo || {};
+window.__evo.openNestHub = openNestHub;

--- a/apps/play/src/nestHub.js
+++ b/apps/play/src/nestHub.js
@@ -1,29 +1,39 @@
-// OD-001 Path A — V3 Nest Hub overlay (NEW 2026-04-25).
+// OD-001 Path A — Sprint A: V3 Nest Hub overlay (4-tab scaffold).
 //
-// Minimal viable UI for V3 Mating/Nido meta progression engine wire.
-// Reads /api/meta/npg + /api/meta/nest and renders:
-//   - Nest state (level, biome, requirements_met)
-//   - Nest setup form (biome picker + setup button) when level=0
-//   - NPG list (recruited NPCs + affinity/trust/cooldown chips)
-//   - Mating preview (Phase D, 2-NPG select + roll attempt) — minimal
+// Nido = housing+evolution+mutation hub post-unlock (Pokopia/Stardew CC pattern).
+// Sbloccato da `biome_arc_completed` + ≥3 missioni nel bioma affinity (vedi
+// sessionHelpers.checkNidoUnlock). Una volta sbloccato, sempre accessibile.
 //
-// Pattern clonato da progressionPanel.js (overlay + injectStyles + refresh).
-// Consumer: main.js attaches header btn "🪺 Nido" via id="nest-open".
+// Layout 4 tab:
+//   - Squad   → lista creature owned (NPG recruited via /api/meta/npg)
+//   - Mating  → mating roll UI (Sprint C riempie full UI; Sprint A: stub
+//               minimal preserva engine wire — single NPG select → roll)
+//   - Lineage → placeholder "Coming soon" (Sprint D riempie genealogy tree)
+//   - Codex   → link che apre codexPanel esistente (in-game wiki)
+//
+// Pattern clonato da skivPanel.js / codexPanel.js (overlay + injectStyles).
+// Consumer: main.js attaches header btn "🏠 Nido" via id="nest-open".
+// Visibility: btn-nest hidden by default, mostrato quando state.world.nido_unlocked === true.
 //
 // Engine: apps/backend/services/metaProgression.js
-// Routes: apps/backend/routes/meta.js (mounted at /api/meta and /api/v1/meta)
-// Card: docs/museum/cards/mating_nido-engine-orphan.md (M-007)
+// Routes: apps/backend/routes/meta.js (mounted /api/meta + /api/v1/meta)
+// Report: docs/reports/2026-04-26-nido-pokopia-housing-pattern.md
 
 import { api } from './api.js';
+
+const TAB_IDS = ['squad', 'mating', 'lineage', 'codex'];
 
 const STATE = {
   overlayEl: null,
   cachedNpcs: [],
   cachedNest: { level: 0, biome: null, requirements_met: false },
   selectedNpgIds: new Set(),
-  // Optional partyMember provider for mating roll (Phase D).
-  // Returns { mbti_type, trait_ids } of the active player unit.
+  currentTab: 'squad',
+  // Optional providers wired da main.js.
   getPartyMember: () => null,
+  openCodex: () => {
+    /* fallback no-op */
+  },
 };
 
 const BIOME_OPTIONS = [
@@ -35,6 +45,19 @@ const BIOME_OPTIONS = [
   'deserto',
   'default',
 ];
+
+// Pure helper — Squad tab uses recruited NPCs as "creature owned" placeholder
+// finché schema squad runtime separato non esiste (Sprint B+).
+export function filterSquadMembers(npcs) {
+  if (!Array.isArray(npcs)) return [];
+  return npcs.filter((n) => n && n.recruited === true);
+}
+
+// Pure helper — eligible per mating roll (recruited + non-mated + cooldown ok).
+export function filterMatingEligible(npcs) {
+  if (!Array.isArray(npcs)) return [];
+  return npcs.filter((n) => n && n.recruited === true && !n.mated && (n.mating_cooldown ?? 0) <= 0);
+}
 
 function injectStyles() {
   if (typeof document === 'undefined') return;
@@ -62,6 +85,22 @@ function injectStyles() {
       margin-left: auto; background: transparent; border: none; color: #ef9a9a;
       cursor: pointer; font-size: 1.2rem;
     }
+    .nest-tabs {
+      display: flex; gap: 4px; border-bottom: 1px solid #2a3040;
+      margin-bottom: 14px;
+    }
+    .nest-tab {
+      background: transparent; border: 1px solid transparent; border-bottom: none;
+      color: #8891a3; padding: 8px 14px; cursor: pointer;
+      font-size: 0.9rem; border-radius: 6px 6px 0 0;
+    }
+    .nest-tab.active {
+      background: #0b0d12; border-color: #2a3040; color: #ffd180;
+      position: relative; top: 1px;
+    }
+    .nest-tab:hover:not(.active) { color: #e8eaf0; }
+    .nest-tab-panel { display: none; }
+    .nest-tab-panel.active { display: block; }
     .nest-meta {
       display: flex; gap: 14px; flex-wrap: wrap;
       background: #0b0d12; border: 1px solid #2a3040; border-radius: 8px;
@@ -93,20 +132,38 @@ function injectStyles() {
     .nest-empty {
       color: #8891a3; font-style: italic; padding: 8px 0;
     }
+    .tab-stub {
+      background: #0b0d12; border: 1px dashed #2a3040; border-radius: 8px;
+      padding: 22px; text-align: center; color: #8891a3; font-style: italic;
+    }
+    .tab-stub strong { color: #ffd180; font-style: normal; display: block;
+      margin-bottom: 6px; }
+    .nest-creature-row,
     .nest-npc-row {
       display: flex; align-items: center; gap: 10px;
       background: #0b0d12; border: 1px solid #2a3040; border-radius: 8px;
       padding: 8px 12px; margin-bottom: 6px;
     }
     .nest-npc-row.selected { border-color: #66bb6a; background: #1e2d20; }
+    .nest-creature-avatar,
+    .nest-npc-row .npc-avatar {
+      width: 36px; height: 36px; border-radius: 50%;
+      background: #1d2230; border: 1px solid #2a3040;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 1.1rem; flex-shrink: 0;
+    }
+    .nest-creature-row .creature-name,
     .nest-npc-row .npc-name { font-weight: 700; color: #ffb74d; min-width: 140px; }
+    .nest-creature-row .creature-stats,
     .nest-npc-row .npc-stats { display: flex; gap: 6px; flex: 1; flex-wrap: wrap; }
-    .nest-npc-row .stat-chip {
+    .stat-chip {
       background: #151922; border: 1px solid #2a3040; border-radius: 4px;
       padding: 2px 8px; font-family: monospace; font-size: 0.78rem;
     }
-    .nest-npc-row .stat-chip.recruited { color: #a5d6a7; border-color: #3d5542; }
-    .nest-npc-row .stat-chip.cooldown { color: #ef9a9a; border-color: #5e3d3d; }
+    .stat-chip.recruited { color: #a5d6a7; border-color: #3d5542; }
+    .stat-chip.cooldown { color: #ef9a9a; border-color: #5e3d3d; }
+    .stat-chip.phase { color: #66d1fb; border-color: #2a4a5e; }
+    .stat-chip.lineage { color: #c4a574; border-color: #5a4a2f; }
     .nest-status {
       margin-top: 12px; min-height: 1.2em; font-size: 0.85rem;
     }
@@ -124,9 +181,9 @@ function buildOverlay() {
   overlay.id = 'nest-overlay';
   overlay.className = 'nest-overlay';
   overlay.innerHTML = `
-    <div class="nest-card" role="dialog" aria-label="Nest Hub">
+    <div class="nest-card" role="dialog" aria-label="Nido Hub">
       <div class="nest-card-head">
-        <h2>🪺 Nido — V3 Mating/Reclutamento</h2>
+        <h2>🏠 Nido</h2>
         <button type="button" class="close-btn" id="nest-close">✕</button>
       </div>
       <div class="nest-meta" id="nest-meta">
@@ -134,30 +191,79 @@ function buildOverlay() {
         <span><strong>Bioma:</strong> <span id="nest-meta-biome">—</span></span>
         <span class="nest-pill" id="nest-meta-req">requisiti?</span>
       </div>
-      <div class="nest-section" id="nest-setup-section" style="display:none">
-        <h3>Setup nido</h3>
-        <div class="nest-setup-row">
-          <select id="nest-biome-select">
-            ${BIOME_OPTIONS.map((b) => `<option value="${b}">${b}</option>`).join('')}
-          </select>
-          <button type="button" class="nest-btn" id="nest-setup-btn">🪺 Inizializza</button>
+      <nav class="nest-tabs" role="tablist">
+        <button type="button" class="nest-tab active" data-tab="squad" role="tab">
+          🐾 Squad
+        </button>
+        <button type="button" class="nest-tab" data-tab="mating" role="tab">
+          🧬 Mating
+        </button>
+        <button type="button" class="nest-tab" data-tab="lineage" role="tab">
+          🌳 Lineage
+        </button>
+        <button type="button" class="nest-tab" data-tab="codex" role="tab">
+          📖 Codex
+        </button>
+      </nav>
+
+      <!-- TAB: Squad (default attivo) -->
+      <div class="nest-tab-panel active" data-tab-panel="squad">
+        <div class="nest-section">
+          <h3>Creature nel nido (<span id="nest-squad-count">0</span>)</h3>
+          <div id="nest-squad-list">
+            <div class="nest-empty">Carico…</div>
+          </div>
         </div>
       </div>
-      <div class="nest-section">
-        <h3>NPG nel nido (<span id="nest-npc-count">0</span>)</h3>
-        <div id="nest-npc-list">
-          <div class="nest-empty">Carico…</div>
+
+      <!-- TAB: Mating (Sprint A stub minimal — Sprint C riempie full UI) -->
+      <div class="nest-tab-panel" data-tab-panel="mating">
+        <div class="nest-section" id="nest-setup-section" style="display:none">
+          <h3>Setup nido</h3>
+          <div class="nest-setup-row">
+            <select id="nest-biome-select">
+              ${BIOME_OPTIONS.map((b) => `<option value="${b}">${b}</option>`).join('')}
+            </select>
+            <button type="button" class="nest-btn" id="nest-setup-btn">🪺 Inizializza</button>
+          </div>
+        </div>
+        <div class="nest-section">
+          <h3>NPG (<span id="nest-npc-count">0</span>) — Sprint A stub</h3>
+          <div id="nest-npc-list">
+            <div class="nest-empty">Carico…</div>
+          </div>
+        </div>
+        <div class="nest-section" id="nest-mating-section" style="display:none">
+          <h3>Mating roll (seleziona 1 NPG)</h3>
+          <div class="nest-setup-row">
+            <button type="button" class="nest-btn" id="nest-mating-btn" disabled>
+              🧬 Tenta riproduzione
+            </button>
+            <span id="nest-mating-hint" style="font-size:0.8rem;color:#8891a3"></span>
+          </div>
         </div>
       </div>
-      <div class="nest-section" id="nest-mating-section" style="display:none">
-        <h3>Mating roll (seleziona 1 NPG)</h3>
-        <div class="nest-setup-row">
-          <button type="button" class="nest-btn" id="nest-mating-btn" disabled>
-            🧬 Tenta riproduzione
-          </button>
-          <span id="nest-mating-hint" style="font-size:0.8rem;color:#8891a3"></span>
+
+      <!-- TAB: Lineage (placeholder Sprint D) -->
+      <div class="nest-tab-panel" data-tab-panel="lineage">
+        <div class="tab-stub">
+          <strong>🌳 Lineage tree</strong>
+          Coming soon — Sprint D wire genealogy multi-gen + inheritance bias.
+          <br>
+          <small>OD-001 Path A 4/4. Engine: <code>metaProgression.js</code> rollMating offspring_traits.</small>
         </div>
       </div>
+
+      <!-- TAB: Codex (link a codexPanel esistente) -->
+      <div class="nest-tab-panel" data-tab-panel="codex">
+        <div class="tab-stub">
+          <strong>📖 Codex — wiki in-game</strong>
+          Apri il Codex completo (Tips / Glossario / Abilità / Statuses).
+          <br><br>
+          <button type="button" class="nest-btn" id="nest-codex-link">Apri Codex →</button>
+        </div>
+      </div>
+
       <div class="nest-status" id="nest-status"></div>
     </div>
   `;
@@ -168,8 +274,33 @@ function buildOverlay() {
   });
   overlay.querySelector('#nest-setup-btn').addEventListener('click', handleSetup);
   overlay.querySelector('#nest-mating-btn').addEventListener('click', handleMating);
+  overlay.querySelector('#nest-codex-link').addEventListener('click', () => {
+    closeNestHub();
+    try {
+      STATE.openCodex?.();
+    } catch {
+      /* ignore */
+    }
+  });
+  overlay.querySelectorAll('.nest-tab').forEach((tabBtn) => {
+    tabBtn.addEventListener('click', () => switchTab(tabBtn.dataset.tab));
+  });
   STATE.overlayEl = overlay;
   return overlay;
+}
+
+export function switchTab(tabName) {
+  if (!TAB_IDS.includes(tabName)) return;
+  STATE.currentTab = tabName;
+  if (typeof document === 'undefined') return;
+  const panel = STATE.overlayEl;
+  if (!panel) return;
+  panel.querySelectorAll('.nest-tab').forEach((t) => {
+    t.classList.toggle('active', t.dataset.tab === tabName);
+  });
+  panel.querySelectorAll('.nest-tab-panel').forEach((p) => {
+    p.classList.toggle('active', p.dataset.tabPanel === tabName);
+  });
 }
 
 function setStatus(text, kind = '') {
@@ -198,6 +329,50 @@ function renderNest(nest) {
   }
 }
 
+// Squad tab — render creature owned (NPG recruited filtered).
+// Sprint A: avatar + nome + lifecycle_phase (placeholder) + MBTI form (se presente)
+// + lineage_id placeholder (Sprint D popola).
+function renderSquad(npcs) {
+  if (typeof document === 'undefined') return;
+  const list = document.getElementById('nest-squad-list');
+  const count = document.getElementById('nest-squad-count');
+  const squad = filterSquadMembers(npcs);
+  if (count) count.textContent = String(squad.length);
+  if (!list) return;
+  if (squad.length === 0) {
+    list.innerHTML =
+      '<div class="nest-empty">Nessuna creatura nel nido. Recluta un NPG dal debrief campagna.</div>';
+    return;
+  }
+  list.innerHTML = '';
+  for (const n of squad) {
+    const row = document.createElement('div');
+    row.className = 'nest-creature-row';
+    const phase = n.lifecycle_phase || 'mature'; // placeholder finché schema runtime non esiste
+    const mbti = n.mbti_revealed && n.mbti_type ? n.mbti_type : null;
+    const lineageId = n.lineage_id || `lin_${String(n.npc_id || '?').slice(0, 6)}`;
+    const avatarGlyph = mbti ? mbti.charAt(0) : (n.npc_id || '?').charAt(0).toUpperCase();
+    row.innerHTML = `
+      <span class="nest-creature-avatar">${avatarGlyph}</span>
+      <span class="creature-name">${escapeHtml(n.npc_id || '?')}</span>
+      <span class="creature-stats">
+        <span class="stat-chip phase">phase: ${escapeHtml(phase)}</span>
+        ${mbti ? `<span class="stat-chip recruited">MBTI: ${escapeHtml(mbti)}</span>` : '<span class="stat-chip">MBTI: ?</span>'}
+        <span class="stat-chip lineage">lineage: ${escapeHtml(lineageId)}</span>
+      </span>
+    `;
+    list.appendChild(row);
+  }
+}
+
+function escapeHtml(s) {
+  return String(s == null ? '' : s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 function renderNpcs(npcs) {
   if (typeof document === 'undefined') return;
   const list = document.getElementById('nest-npc-list');
@@ -222,7 +397,7 @@ function renderNpcs(npcs) {
         : '';
     const matedChip = n.mated ? '<span class="stat-chip recruited">✓ mated</span>' : '';
     row.innerHTML = `
-      <span class="npc-name">${n.npc_id}</span>
+      <span class="npc-name">${escapeHtml(n.npc_id || '?')}</span>
       <span class="npc-stats">
         <span class="stat-chip">aff ${n.affinity ?? 0}</span>
         <span class="stat-chip">trust ${n.trust ?? 0}</span>
@@ -231,7 +406,7 @@ function renderNpcs(npcs) {
         ${cooldownChip}
       </span>
     `;
-    if (n.recruited && !n.mated && n.mating_cooldown <= 0) {
+    if (n.recruited && !n.mated && (n.mating_cooldown ?? 0) <= 0) {
       row.style.cursor = 'pointer';
       row.addEventListener('click', () => toggleNpgSelect(n.npc_id));
     }
@@ -242,7 +417,7 @@ function renderNpcs(npcs) {
   const matingBtn = document.getElementById('nest-mating-btn');
   const matingHint = document.getElementById('nest-mating-hint');
   if (matingSection && matingBtn && matingHint) {
-    const eligible = npcs.filter((n) => n.recruited && !n.mated && n.mating_cooldown <= 0);
+    const eligible = filterMatingEligible(npcs);
     matingSection.style.display = eligible.length > 0 ? '' : 'none';
     const sel = [...STATE.selectedNpgIds];
     matingBtn.disabled = sel.length !== 1;
@@ -319,9 +494,11 @@ async function refresh() {
   STATE.cachedNpcs = Array.isArray(res.data?.npcs) ? res.data.npcs : [];
   STATE.cachedNest = res.data?.nest || { level: 0, biome: null, requirements_met: false };
   renderNest(STATE.cachedNest);
+  renderSquad(STATE.cachedNpcs);
   renderNpcs(STATE.cachedNpcs);
+  const squadCount = filterSquadMembers(STATE.cachedNpcs).length;
   setStatus(
-    `${STATE.cachedNpcs.length} NPG · nido Lv ${STATE.cachedNest.level}${STATE.cachedNest.biome ? ' (' + STATE.cachedNest.biome + ')' : ''}`,
+    `${squadCount} creature · ${STATE.cachedNpcs.length} NPG · nido Lv ${STATE.cachedNest.level}${STATE.cachedNest.biome ? ' (' + STATE.cachedNest.biome + ')' : ''}`,
     'ok',
   );
 }
@@ -336,15 +513,24 @@ export function closeNestHub() {
   if (STATE.overlayEl) STATE.overlayEl.classList.remove('visible');
 }
 
-export function initNestHub({ getPartyMember, buttonId = 'nest-open' } = {}) {
+export function initNestHub({ getPartyMember, openCodex, buttonId = 'nest-open' } = {}) {
   STATE.getPartyMember = typeof getPartyMember === 'function' ? getPartyMember : () => null;
+  STATE.openCodex = typeof openCodex === 'function' ? openCodex : () => {};
   buildOverlay();
   if (typeof document === 'undefined') {
-    return { openNestHub, closeNestHub, refresh };
+    return { openNestHub, closeNestHub, refresh, switchTab };
   }
   const btn = document.getElementById(buttonId);
   if (btn) {
     btn.addEventListener('click', openNestHub);
   }
-  return { openNestHub, closeNestHub, refresh };
+  return { openNestHub, closeNestHub, refresh, switchTab };
 }
+
+// Test surface (export DOM-free helpers for unit tests).
+export const __nestHubInternal = {
+  TAB_IDS,
+  filterSquadMembers,
+  filterMatingEligible,
+  escapeHtml,
+};

--- a/docs/reports/2026-04-26-nido-pokopia-housing-pattern.md
+++ b/docs/reports/2026-04-26-nido-pokopia-housing-pattern.md
@@ -1,0 +1,105 @@
+---
+title: Nido Pokopia Housing Pattern — Sprint A scaffold report
+doc_status: draft
+doc_owner: eduardo
+workstream: cross-cutting
+last_verified: 2026-04-26
+source_of_truth: false
+language: it
+review_cycle_days: 30
+tags:
+  - nido
+  - od-001
+  - sprint-a
+  - mating
+  - lineage
+summary: >
+  Report di context per Sprint A-Nido (OD-001 Path A 1/4). Nido = housing+
+  evolution+mutation pattern Pokopia-style. Sbloccato narrativamente da
+  evento `biome_arc_completed` + ≥3 missioni nel bioma affinity. Una volta
+  sbloccato, sempre accessibile dal menu tra missioni (Stardew Community
+  Center pattern). Sprint A = scaffold UI 4-tab + unlock trigger backend.
+---
+
+# Nido Pokopia Housing Pattern — Sprint A scaffold report
+
+**Sprint:** A (1/4 di OD-001 Path A mini-accept)
+**Effort:** ~5h scaffold work
+**Dipendenze:** B/C/D in parallelo da altri agent (potrebbero toccare gli
+stessi file — pattern conflict-tolerant additivo).
+
+## TL;DR (5 bullet)
+
+1. **Nido = hub permanente housing+evolution+mutation post-unlock**.
+   Sbloccato da evento diegetic narrative (`biome_arc_completed` +
+   ≥3 missioni nel bioma affinity), poi sempre accessibile.
+2. **Pattern reference**: Pokopia housing/breeding (Pokémon-like
+   collection meta) + Stardew Valley Community Center (unlock una
+   volta, accessible sempre).
+3. **Sprint A scope**: scaffold UI 4-tab (Squad / Mating / Lineage / Codex)
+   + header button con `display:none` default + sessionHelpers
+   `checkNidoUnlock` helper. Squad tab attivo (lista NPG recruited);
+   Mating/Lineage placeholder (Sprint C/D).
+4. **Unlock trigger backend**: `publicSessionView` espone
+   `nido_unlocked: boolean` derivato da `state.meta?.nido_unlocked`
+   o env override `NIDO_UNLOCKED=true` (dev/test). Wire reale al
+   narrative engine = Wave 9+ (post Sprint A-D).
+5. **Conflict-tolerant**: `nestHub.js` shared con Sprint C (Mating tab)
+   e Sprint D (Lineage tab) — placeholder visible "Coming soon" nelle
+   tab altrui, no import di moduli inesistenti.
+
+## Verdict OD-001 Path A
+
+**Path A** scelto su Path B/C in audit 2026-04-25 sera (vedi CLAUDE.md
+sprint context). Path A = scope mini-accept (4 sub-sprint sequenziali
+~23h totali). Path B = full Form evoluzione (sunk cost engine 50-80h,
+frontend zero). Path C = skip definitivo OD-001.
+
+Path A copre:
+- **Sprint A** (questo): scaffold panel 4-tab + unlock trigger
+- **Sprint B**: housing modules (Dormitori, Bio-Lab, Resonance Anchor,
+  Hangar) — tier 0-3, costi risorse
+- **Sprint C**: Mating tab full wire (NPG select → mating roll →
+  offspring traits visualizzati)
+- **Sprint D**: Lineage tab full wire (genealogy tree multi-gen,
+  inheritance bias visualization)
+
+## Reference
+
+- `docs/core/Mating-Reclutamento-Nido.md` — design canonical Canvas D
+- `apps/backend/services/metaProgression.js` — engine 469 LOC live
+  (`createMetaTracker` + `createMetaStore` Prisma adapter)
+- `apps/backend/routes/meta.js` — 7 endpoint /api/meta/*
+- `apps/play/src/skivPanel.js`, `apps/play/src/codexPanel.js` —
+  pattern reference (overlay modal con tab)
+- Memory: `feedback_tribe_lineage_emergent_breakthrough` — design
+  rationale lineage emergente
+
+## Stop-on-blocker (Sprint A)
+
+- Se `metaProgression.js` non ha endpoint per "lista creature owned" →
+  **risolto**: `/api/meta/npg` ritorna `{ npcs[], nest }`. Filtraggio
+  client-side `recruited:true` per Squad tab.
+- Conflict shared file `apps/play/src/main.js` con altri sprint
+  paralleli → APPEND, non riscrivere.
+
+## File touched (Sprint A)
+
+- **MODIFY** `apps/play/src/nestHub.js` (transform existing → 4-tab
+  layout preservando Mating logic in Mating tab)
+- **MODIFY** `apps/play/index.html` (add `<button id="nest-open">`)
+- **MODIFY** `apps/play/src/main.js` (import `initNestHub` + wire
+  visibility on `state.world.nido_unlocked`)
+- **MODIFY** `apps/backend/routes/sessionHelpers.js` (export
+  `checkNidoUnlock` + add `nido_unlocked` field to
+  `publicSessionView`)
+- **NEW** `tests/api/nestHub.test.js` (DOM-free helper tests)
+- **NEW** `tests/api/sessionHelpers.nido.test.js` (checkNidoUnlock)
+
+## Out of scope (Sprint A)
+
+- Wire reale al narrative engine (Wave 9+)
+- Mating roll full UI (Sprint C)
+- Lineage tree multi-gen (Sprint D)
+- Housing modules cost/tier (Sprint B)
+- E2E test playtest live (post Sprint D)

--- a/tests/api/nestHub.test.js
+++ b/tests/api/nestHub.test.js
@@ -1,0 +1,83 @@
+// OD-001 Path A Sprint A — nestHub helper unit tests.
+//
+// DOM-free helpers only (TAB_IDS, filterSquadMembers, filterMatingEligible,
+// switchTab guard). Browser integration covered manually via preview_verify.
+//
+// Pattern clonato da tests/api/formsPanelInfer.test.js.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+// Dynamic import of ESM module (apps/play/src is browser-side ESM).
+async function loadHub() {
+  return import('../../apps/play/src/nestHub.js');
+}
+
+test('nestHub exports 4 canonical tab ids: squad / mating / lineage / codex', async () => {
+  const { __nestHubInternal } = await loadHub();
+  assert.deepEqual(__nestHubInternal.TAB_IDS, ['squad', 'mating', 'lineage', 'codex']);
+});
+
+test('filterSquadMembers returns only NPCs with recruited:true', async () => {
+  const { filterSquadMembers } = await loadHub();
+  const npcs = [
+    { npc_id: 'a', recruited: true },
+    { npc_id: 'b', recruited: false },
+    { npc_id: 'c', recruited: true, mated: true },
+    { npc_id: 'd' }, // no recruited flag
+    null, // garbage entry
+  ];
+  const out = filterSquadMembers(npcs);
+  assert.equal(out.length, 2);
+  assert.equal(out[0].npc_id, 'a');
+  assert.equal(out[1].npc_id, 'c');
+});
+
+test('filterSquadMembers returns [] for non-array input', async () => {
+  const { filterSquadMembers } = await loadHub();
+  assert.deepEqual(filterSquadMembers(null), []);
+  assert.deepEqual(filterSquadMembers(undefined), []);
+  assert.deepEqual(filterSquadMembers({}), []);
+  assert.deepEqual(filterSquadMembers([]), []);
+});
+
+test('filterMatingEligible: recruited + non-mated + cooldown<=0', async () => {
+  const { filterMatingEligible } = await loadHub();
+  const npcs = [
+    { npc_id: 'a', recruited: true, mated: false, mating_cooldown: 0 }, // ✓
+    { npc_id: 'b', recruited: false, mated: false, mating_cooldown: 0 }, // ✗ not recruited
+    { npc_id: 'c', recruited: true, mated: true, mating_cooldown: 0 }, // ✗ already mated
+    { npc_id: 'd', recruited: true, mated: false, mating_cooldown: 2 }, // ✗ cooldown
+    { npc_id: 'e', recruited: true, mated: false }, // ✓ undefined cooldown = 0
+  ];
+  const out = filterMatingEligible(npcs);
+  assert.equal(out.length, 2);
+  assert.deepEqual(
+    out.map((n) => n.npc_id),
+    ['a', 'e'],
+  );
+});
+
+test('escapeHtml escapes &, <, >, "', async () => {
+  const { __nestHubInternal } = await loadHub();
+  const { escapeHtml } = __nestHubInternal;
+  assert.equal(escapeHtml('<script>'), '&lt;script&gt;');
+  assert.equal(escapeHtml('a & b'), 'a &amp; b');
+  assert.equal(escapeHtml('"quoted"'), '&quot;quoted&quot;');
+  assert.equal(escapeHtml(null), '');
+  assert.equal(escapeHtml(undefined), '');
+});
+
+test('switchTab guards against non-canonical tab ids (silent no-op)', async () => {
+  const { switchTab, __nestHubInternal } = await loadHub();
+  // No throw on invalid input — function is a guard.
+  assert.doesNotThrow(() => switchTab('invalid_tab'));
+  assert.doesNotThrow(() => switchTab(null));
+  assert.doesNotThrow(() => switchTab(undefined));
+  // Valid inputs also no-throw (no DOM in node-test env, switchTab returns early).
+  for (const id of __nestHubInternal.TAB_IDS) {
+    assert.doesNotThrow(() => switchTab(id));
+  }
+});

--- a/tests/api/sessionHelpers.nido.test.js
+++ b/tests/api/sessionHelpers.nido.test.js
@@ -1,0 +1,90 @@
+// OD-001 Path A Sprint A — checkNidoUnlock helper tests.
+//
+// Pure helper, no I/O, no closure. Test matrix:
+//   - default (empty session): false
+//   - meta.nido_unlocked === true: true
+//   - biome_arc_completed + missions_in_biome_count >= 3: true
+//   - biome_arc_completed + count < 3: false
+//   - env NIDO_UNLOCKED=true override: true
+//   - publicSessionView includes nido_unlocked field
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { checkNidoUnlock, publicSessionView } = require('../../apps/backend/routes/sessionHelpers');
+
+test('checkNidoUnlock: empty session returns false', () => {
+  assert.equal(checkNidoUnlock({}), false);
+  assert.equal(checkNidoUnlock(null), false);
+  assert.equal(checkNidoUnlock(undefined), false);
+});
+
+test('checkNidoUnlock: meta.nido_unlocked === true returns true', () => {
+  const session = { meta: { nido_unlocked: true } };
+  assert.equal(checkNidoUnlock(session), true);
+});
+
+test('checkNidoUnlock: biome_arc_completed + 3 missions returns true', () => {
+  const session = {
+    meta: { biome_arc_completed: true, missions_in_biome_count: 3 },
+  };
+  assert.equal(checkNidoUnlock(session), true);
+});
+
+test('checkNidoUnlock: biome_arc_completed + 2 missions returns false', () => {
+  const session = {
+    meta: { biome_arc_completed: true, missions_in_biome_count: 2 },
+  };
+  assert.equal(checkNidoUnlock(session), false);
+});
+
+test('checkNidoUnlock: biome_arc_completed=false even with 5 missions returns false', () => {
+  const session = {
+    meta: { biome_arc_completed: false, missions_in_biome_count: 5 },
+  };
+  assert.equal(checkNidoUnlock(session), false);
+});
+
+test('checkNidoUnlock: env NIDO_UNLOCKED=true overrides everything', () => {
+  const original = process.env.NIDO_UNLOCKED;
+  try {
+    process.env.NIDO_UNLOCKED = 'true';
+    assert.equal(checkNidoUnlock({}), true);
+    assert.equal(checkNidoUnlock({ meta: { nido_unlocked: false } }), true);
+  } finally {
+    if (original === undefined) delete process.env.NIDO_UNLOCKED;
+    else process.env.NIDO_UNLOCKED = original;
+  }
+});
+
+test('publicSessionView exposes nido_unlocked: false by default', () => {
+  // Minimal session shape for publicSessionView (uses grid + units + events).
+  const session = {
+    session_id: 's1',
+    turn: 0,
+    active_unit: null,
+    units: [],
+    grid: { width: 6, height: 6 },
+    events: [],
+    sistema_pressure: 0,
+  };
+  const view = publicSessionView(session);
+  assert.equal(view.nido_unlocked, false);
+});
+
+test('publicSessionView exposes nido_unlocked: true when meta flag set', () => {
+  const session = {
+    session_id: 's1',
+    turn: 0,
+    active_unit: null,
+    units: [],
+    grid: { width: 6, height: 6 },
+    events: [],
+    sistema_pressure: 0,
+    meta: { nido_unlocked: true },
+  };
+  const view = publicSessionView(session);
+  assert.equal(view.nido_unlocked, true);
+});


### PR DESCRIPTION
## Summary

Sprint A scaffold per **OD-001 Path A** (mini-accept, 4 sub-sprint sequenziali ~23h totali). Crea il panel **🏠 Nido** 4-tab + unlock trigger backend. Nido = housing+evolution+mutation hub Pokopia-style, sbloccato narrativamente, sempre accessibile post-unlock (Stardew Community Center pattern).

- **UI 4-tab**: Squad (default, lista creature owned) / Mating (Sprint C wire) / Lineage (Sprint D wire) / Codex (apre codexPanel esistente)
- **Backend**: `checkNidoUnlock(session)` helper + `nido_unlocked` field in `publicSessionView`. Trigger: `meta.nido_unlocked` OR `biome_arc_completed && missions_in_biome_count>=3` OR env `NIDO_UNLOCKED=true` (dev/test)
- **Frontend**: header btn `#nest-open` con `display:none` default, mostrato in `refresh()` quando `state.world.nido_unlocked===true`

## Files touched

| File | Type | LOC |
|---|---|---|
| `apps/play/src/nestHub.js` | refactor (4-tab) | 536 |
| `apps/play/index.html` | add btn 🏠 Nido | +21 |
| `apps/play/src/main.js` | wire init + visibility | +26 |
| `apps/backend/routes/sessionHelpers.js` | checkNidoUnlock + view field | +28 |
| `tests/api/nestHub.test.js` | NEW (helper tests) | 83 |
| `tests/api/sessionHelpers.nido.test.js` | NEW (backend tests) | 90 |
| `docs/reports/2026-04-26-nido-pokopia-housing-pattern.md` | NEW (context doc) | 105 |

## Conflict-tolerant pattern

`nestHub.js` shared con Sprint C (Mating tab full wire) e Sprint D (Lineage tree multi-gen). Placeholder "Coming soon" visible nelle tab altrui — no import di moduli inesistenti. Mating tab preserva l'UI engine wire del precedente draft (single NPG select → roll) come baseline per Sprint C.

## Verify-before-claim (DoD)

- [x] `node --test tests/api/nestHub.test.js` → **6/6 verde**
- [x] `node --test tests/api/sessionHelpers.nido.test.js` → **8/8 verde**
- [x] `node --test tests/ai/*.test.js` → **311/311 verde** (zero regression)
- [x] `node --test tests/services/synergyDetector.test.js tests/services/positionalDamage.test.js` → **41/41 verde** (sessionHelpers consumers OK)
- [x] `npm run format:check` → verde
- [x] `npm run lint:stack` → verde
- [x] `python tools/check_docs_governance.py --strict` → 0 errors / 0 warnings

NB: `tests/api/predict-combat.test.js` fallisce su `Cannot find module '@game/contracts'` ma è **regressione pre-esistente in worktree** (riproducibile post `git stash`), non causata da queste modifiche.

## Out of scope (Sprint A)

- Wire reale al narrative engine per `biome_arc_completed` (Wave 9+)
- Housing modules cost/tier — Dormitori/Bio-Lab/Anchor/Hangar (Sprint B)
- Mating roll full UI con offspring traits visualization (Sprint C)
- Lineage tree multi-gen + inheritance bias (Sprint D)
- E2E playtest live (post Sprint D)

## Refs

- Report context: [`docs/reports/2026-04-26-nido-pokopia-housing-pattern.md`](docs/reports/2026-04-26-nido-pokopia-housing-pattern.md)
- Memory: [`feedback_tribe_lineage_emergent_breakthrough`](https://github.com/MasterDD-L34D/Game) (cross-session, lineage emergente design rationale)
- Design canonical: [`docs/core/Mating-Reclutamento-Nido.md`](docs/core/Mating-Reclutamento-Nido.md)
- Engine: [`apps/backend/services/metaProgression.js`](apps/backend/services/metaProgression.js) (469 LOC live, READ-ONLY in Sprint A)

## Test plan

- [x] Unit test helper functions (DOM-free): `filterSquadMembers`, `filterMatingEligible`, `escapeHtml`, `switchTab` guard
- [x] Unit test backend `checkNidoUnlock` matrix (empty / meta flag / biome_arc count / env override)
- [x] Unit test `publicSessionView` includes `nido_unlocked` field correctly propagated
- [x] AI baseline regression 311/311
- [ ] Manual smoke playtest: avvia backend con `NIDO_UNLOCKED=true`, verifica btn 🏠 Nido appaia, click apre overlay 4-tab, Squad mostra creature recruited (placeholder fallback se zero), tab switch funziona, Codex link apre codexPanel — userland post-merge
- [ ] Sprint C/D integration smoke: verifica che `nestHub.js` non rompa quando Sprint C/D estendono Mating/Lineage tab — userland post-Sprint-C/D-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)