### PR TITLE
feat(nido): Sprint C — mating roll + 3-tier visual feedback (OD-001 Path A 3/4)

### DIFF
--- a/apps/backend/routes/meta.js
+++ b/apps/backend/routes/meta.js
@@ -17,7 +17,45 @@
 'use strict';
 
 const { Router } = require('express');
+const path = require('node:path');
+const fs = require('node:fs');
 const { createMetaStore } = require('../services/metaProgression');
+
+// Lazy load mating.yaml gene_slots schema + mutation catalog for offspring rolls.
+// Both non-blocking: if files missing, falls back to {} / null.
+let _matingSchemaCache = null;
+function loadMatingSchema() {
+  if (_matingSchemaCache !== null) return _matingSchemaCache;
+  try {
+    const yaml = require('js-yaml');
+    const root = path.resolve(__dirname, '..', '..', '..');
+    const p = path.join(root, 'data', 'core', 'mating.yaml');
+    if (!fs.existsSync(p)) {
+      _matingSchemaCache = {};
+      return _matingSchemaCache;
+    }
+    const raw = fs.readFileSync(p, 'utf8');
+    const doc = yaml.load(raw) || {};
+    _matingSchemaCache = doc.gene_slots || {};
+    return _matingSchemaCache;
+  } catch (_err) {
+    _matingSchemaCache = {};
+    return _matingSchemaCache;
+  }
+}
+
+let _mutationCatalogCache = null;
+function loadCatalog() {
+  if (_mutationCatalogCache !== null) return _mutationCatalogCache;
+  try {
+    const { loadMutationCatalog } = require('../services/mutations/mutationCatalogLoader');
+    _mutationCatalogCache = loadMutationCatalog();
+    return _mutationCatalogCache;
+  } catch (_err) {
+    _mutationCatalogCache = null;
+    return _mutationCatalogCache;
+  }
+}
 
 /**
  * @param {object} [opts]
@@ -113,7 +151,62 @@ function createMetaRouter(opts = {}) {
     }
   });
 
+  // ─── Sprint C — squad-mate offspring roll (MHS 3-tier visual) ─────
+  // Distinct from /mating (NPC pair-bond DC roll). This rolls offspring
+  // spec from two squad creatures + biome at mating time.
+  router.post('/mating/roll', async (req, res, next) => {
+    try {
+      const { parent_a, parent_b, biome_id } = req.body || {};
+      if (!parent_a || !parent_b) {
+        return res.status(400).json({ error: 'parent_a and parent_b (objects with id) required' });
+      }
+      if (!parent_a.id || !parent_b.id) {
+        return res.status(400).json({ error: 'parent_a.id and parent_b.id required' });
+      }
+      const geneSlotsSchema = loadMatingSchema();
+      const mutationCatalog = loadCatalog();
+      const result = await store.rollOffspring({
+        parentA: parent_a,
+        parentB: parent_b,
+        biomeId: biome_id || null,
+        context: { geneSlotsSchema, mutationCatalog },
+      });
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.get('/nest/offspring', async (_req, res, next) => {
+    try {
+      const offspring = await store.listOffspring();
+      res.json({ offspring });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.post('/nest/add_offspring', async (req, res, next) => {
+    try {
+      const { offspring } = req.body || {};
+      if (!offspring || typeof offspring !== 'object') {
+        return res.status(400).json({ error: 'offspring object required' });
+      }
+      const entry = await store.addOffspring(offspring);
+      if (!entry) return res.status(400).json({ error: 'invalid offspring shape' });
+      res.json({ added: entry });
+    } catch (err) {
+      next(err);
+    }
+  });
+
   return router;
 }
 
-module.exports = { createMetaRouter };
+// Test surface — reset module-level YAML caches between tests.
+function _resetCachesForTest() {
+  _matingSchemaCache = null;
+  _mutationCatalogCache = null;
+}
+
+module.exports = { createMetaRouter, _resetCachesForTest };

--- a/apps/backend/services/metaProgression.js
+++ b/apps/backend/services/metaProgression.js
@@ -34,6 +34,7 @@ const MATING_THRESHOLD = 12; // DC base
 function createMetaTracker() {
   const npcs = new Map();
   const nest = { level: 0, biome: null, requirements_met: false };
+  const offspringRegistry = []; // Sprint C — list of offspring spec from rollMatingOffspring
 
   function getOrCreate(npcId) {
     if (!npcs.has(npcId)) {
@@ -144,6 +145,27 @@ function createMetaTracker() {
     return { ...nest };
   }
 
+  // Sprint C — squad-mate offspring roll (MHS 3-tier).
+  // Distinct from `rollMating(npcId, partyMember)` (NPC pair-bond DC roll).
+  function rollOffspring({ parentA, parentB, biomeId, context = {} } = {}) {
+    const result = rollMatingOffspring({ parentA, parentB, biomeId, context });
+    if (result.success && result.offspring) {
+      offspringRegistry.push({ ...result.offspring, created_at: Date.now() });
+    }
+    return result;
+  }
+
+  function listOffspring() {
+    return offspringRegistry.map((o) => ({ ...o }));
+  }
+
+  function addOffspring(offspring) {
+    if (!offspring || typeof offspring !== 'object') return null;
+    const entry = { ...offspring, added_at: Date.now() };
+    offspringRegistry.push(entry);
+    return entry;
+  }
+
   return {
     updateAffinity,
     updateTrust,
@@ -155,6 +177,9 @@ function createMetaTracker() {
     tickCooldowns,
     listNpcs,
     getNest,
+    rollOffspring,
+    listOffspring,
+    addOffspring,
   };
 }
 
@@ -207,6 +232,303 @@ function parseJsonArray(raw) {
     return [];
   }
 }
+
+// ─── Sprint C — Offspring rollMating (MHS 3-tier visual feedback) ────────
+//
+// Pattern Monster Hunter Stories 3 genetics: offspring inherits 2 gene slots
+// (one per parent, weighted by inheritance_weight) + 1 environmental mutation
+// pulled from biome filter. Tier (no-glow/gold/rainbow) determines visual
+// feedback + bonus traits for offspring.
+//
+// Mating mutation = Layer 2 (offspring) ≠ Layer 1 self-encounter mutation
+// (M14 mutation_catalog). Layer 2 uses Layer 1 catalog filtered by biome
+// where mating happened.
+//
+// Refs:
+// - data/core/mating.yaml § gene_slots inheritance_rules
+// - data/core/mutations/mutation_catalog.yaml (M14, biome_boost field)
+// - docs/core/Mating-Reclutamento-Nido.md § Ereditarietà & Mutazioni
+
+const TIER_NO_GLOW = 'no-glow';
+const TIER_GOLD = 'gold';
+const TIER_RAINBOW = 'rainbow';
+
+const TIER_VISUAL_HINTS = {
+  [TIER_NO_GLOW]: { border_color: '#2a3040', glow: false, particles: false, sfx: 'tier_common' },
+  [TIER_GOLD]: { border_color: '#ffd180', glow: true, particles: false, sfx: 'tier_gold' },
+  [TIER_RAINBOW]: {
+    border_color: 'rainbow',
+    glow: true,
+    particles: true,
+    sfx: 'tier_rainbow',
+  },
+};
+
+/**
+ * Deterministic lineage_id from two parent ids.
+ * Format: lineage_<8-hex-prefix> derived from sorted-pair hash so order
+ * doesn't matter (parent_a + parent_b == parent_b + parent_a).
+ */
+function makeLineageId(parentAId, parentBId) {
+  const a = String(parentAId || '');
+  const b = String(parentBId || '');
+  const pair = [a, b].sort().join('|');
+  // FNV-1a-like 32-bit folding hash (deterministic, no external deps).
+  let h = 0x811c9dc5;
+  for (let i = 0; i < pair.length; i++) {
+    h ^= pair.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  const hex = h.toString(16).padStart(8, '0');
+  return `lineage_${hex}`;
+}
+
+/**
+ * Pick gene slots inherited from each parent.
+ * Each parent contributes 1 slot, weighted by slot inheritance_weight if available.
+ *
+ * @param {object} parentA — { id, gene_slots?: Array<{slot_id, value}> }
+ * @param {object} parentB
+ * @param {object} geneSlotsSchema — data/core/mating.yaml gene_slots
+ * @param {function} rng
+ * @returns {Array<{from: string, slot_id, value, label_it?, category}>}
+ */
+function inheritGeneSlots(parentA, parentB, geneSlotsSchema = {}, rng = Math.random) {
+  const inherited = [];
+  for (const [parentLabel, parent] of [
+    ['parent_a', parentA],
+    ['parent_b', parentB],
+  ]) {
+    const slots = Array.isArray(parent?.gene_slots) ? parent.gene_slots : [];
+    if (slots.length === 0) {
+      // No gene_slots on parent — fallback to a synthetic slot derived from parent id.
+      inherited.push({
+        from: parentLabel,
+        slot_id: 'corpo',
+        value: parent?.id || parentLabel,
+        category: 'struttura',
+      });
+      continue;
+    }
+    // Weighted random pick by inheritance_weight (default 0.5 if missing).
+    const weights = slots.map((s) => {
+      const meta = lookupSlotMeta(geneSlotsSchema, s.slot_id);
+      return Math.max(0.05, Number(meta?.inheritance_weight ?? 0.5));
+    });
+    const totalW = weights.reduce((a, b) => a + b, 0);
+    let pick = rng() * totalW;
+    let chosenIdx = 0;
+    for (let i = 0; i < weights.length; i++) {
+      pick -= weights[i];
+      if (pick <= 0) {
+        chosenIdx = i;
+        break;
+      }
+    }
+    const slot = slots[chosenIdx];
+    const meta = lookupSlotMeta(geneSlotsSchema, slot.slot_id);
+    inherited.push({
+      from: parentLabel,
+      slot_id: slot.slot_id,
+      value: slot.value,
+      label_it: meta?.label_it || slot.slot_id,
+      category: meta?.category || 'struttura',
+    });
+  }
+  return inherited;
+}
+
+function lookupSlotMeta(geneSlotsSchema, slotId) {
+  const cats = geneSlotsSchema?.categories || {};
+  for (const [catKey, cat] of Object.entries(cats)) {
+    const slots = cat?.slots || [];
+    for (const s of slots) {
+      if (s.id === slotId) {
+        return { ...s, category: catKey };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Pick 1 environmental mutation filtered by biome_id_at_mating.
+ *
+ * Strategy:
+ *   1. If mutationCatalog is provided AND has entries with biome_boost matching:
+ *      pick weighted-random from those (prefer rare > advanced > base by tier).
+ *   2. Otherwise fallback: pick from biomeTraitsPool (random trait id).
+ *
+ * Returns: { id, type: 'mutation'|'trait', tier: 0|1|2|null, biome_id, source }.
+ */
+function pickEnvironmentalMutation({
+  biomeId,
+  mutationCatalog = null,
+  biomeTraitsPool = [],
+  rng = Math.random,
+}) {
+  // Prefer real mutation catalog entries matching biome.
+  if (mutationCatalog && typeof mutationCatalog === 'object') {
+    const byId = mutationCatalog.byId || {};
+    const matches = [];
+    for (const [id, entry] of Object.entries(byId)) {
+      const boostList = Array.isArray(entry?.biome_boost) ? entry.biome_boost : [];
+      if (biomeId && boostList.includes(biomeId)) {
+        matches.push({ id, entry });
+      }
+    }
+    if (matches.length > 0) {
+      const picked = matches[Math.floor(rng() * matches.length)];
+      const tier = Number(picked.entry?.tier ?? 1);
+      return {
+        id: picked.id,
+        type: 'mutation',
+        tier,
+        biome_id: biomeId || null,
+        source: 'mutation_catalog',
+        name_it: picked.entry?.name_it || picked.id,
+      };
+    }
+  }
+  // Fallback: random trait from biome pool.
+  if (Array.isArray(biomeTraitsPool) && biomeTraitsPool.length > 0) {
+    const traitId = biomeTraitsPool[Math.floor(rng() * biomeTraitsPool.length)];
+    return {
+      id: traitId,
+      type: 'trait',
+      tier: null,
+      biome_id: biomeId || null,
+      source: 'biome_trait_pool',
+      name_it: traitId,
+    };
+  }
+  // Empty fallback (no catalog + no pool).
+  return {
+    id: null,
+    type: 'none',
+    tier: null,
+    biome_id: biomeId || null,
+    source: 'fallback_empty',
+    name_it: null,
+  };
+}
+
+/**
+ * Compute offspring tier (no-glow / gold / rainbow).
+ *
+ * Rules (MHS pattern):
+ * - GOLD: gene_slot match (both inherited slots have same slot_id).
+ * - RAINBOW: environmental_mutation tier === 2 (rare in mutation_catalog).
+ * - NO-GLOW: default common offspring.
+ *
+ * Stochastic edge:
+ * - If neither match, tier remains no-glow (~70%); roll a small random for
+ *   rainbow/gold downgrade tolerance is unnecessary because gates are deterministic.
+ */
+function computeOffspringTier({ inheritedSlots, environmentalMutation }) {
+  const a = inheritedSlots?.[0];
+  const b = inheritedSlots?.[1];
+  const slotMatch = Boolean(a && b && a.slot_id === b.slot_id);
+  const mutTier = Number(environmentalMutation?.tier ?? -1);
+  const isRareMutation = environmentalMutation?.type === 'mutation' && mutTier >= 2;
+
+  if (isRareMutation) return TIER_RAINBOW;
+  if (slotMatch) return TIER_GOLD;
+  return TIER_NO_GLOW;
+}
+
+function tierBonusTraits(tier) {
+  if (tier === TIER_GOLD) return 1;
+  if (tier === TIER_RAINBOW) return 2;
+  return 0;
+}
+
+/**
+ * Sprint C — Roll mating offspring spec.
+ *
+ * Distinct from `rollMating(npcId, partyMember)` (NPC pair-bond MBTI compat
+ * d20 check). This is the **squad-mate roll**: parent_a + parent_b are two
+ * creatures of the player's squad, biome at mating decides environmental
+ * mutation flavor, output is full offspring spec with tier visual feedback.
+ *
+ * @param {object} input
+ * @param {object} input.parentA — { id, mbti_type?, trait_ids?, gene_slots? }
+ * @param {object} input.parentB — { id, mbti_type?, trait_ids?, gene_slots? }
+ * @param {string} input.biomeId
+ * @param {object} [input.context]
+ * @param {object} [input.context.geneSlotsSchema] — data/core/mating.yaml gene_slots
+ * @param {object} [input.context.mutationCatalog] — optional M14 catalog (loadMutationCatalog())
+ * @param {Array<string>} [input.context.biomeTraitsPool]
+ * @param {function} [input.context.rng]
+ * @returns {object} offspring spec + tier + visual_hints
+ */
+function rollMatingOffspring({ parentA, parentB, biomeId, context = {} } = {}) {
+  if (!parentA || !parentB) {
+    throw new Error('rollMatingOffspring: parentA and parentB required');
+  }
+  if (parentA.id && parentB.id && parentA.id === parentB.id) {
+    return {
+      success: false,
+      reason: 'self_mate_prevented',
+      offspring: null,
+      tier: null,
+      visual_hints: null,
+    };
+  }
+  const rng = typeof context.rng === 'function' ? context.rng : Math.random;
+  const geneSlotsSchema = context.geneSlotsSchema || {};
+  const mutationCatalog = context.mutationCatalog || null;
+  const biomeTraitsPool = Array.isArray(context.biomeTraitsPool) ? context.biomeTraitsPool : [];
+
+  const lineageId = makeLineageId(parentA.id, parentB.id);
+  const inheritedSlots = inheritGeneSlots(parentA, parentB, geneSlotsSchema, rng);
+  const environmentalMutation = pickEnvironmentalMutation({
+    biomeId,
+    mutationCatalog,
+    biomeTraitsPool,
+    rng,
+  });
+  const tier = computeOffspringTier({ inheritedSlots, environmentalMutation });
+  const bonusTraits = tierBonusTraits(tier);
+
+  // Compose bonus traits list from union of parent trait pools, picked random,
+  // exclusive of duplicates already in environmental_mutation.id.
+  const parentTraitsAll = [
+    ...new Set([
+      ...(Array.isArray(parentA.trait_ids) ? parentA.trait_ids : []),
+      ...(Array.isArray(parentB.trait_ids) ? parentB.trait_ids : []),
+    ]),
+  ].filter((t) => t !== environmentalMutation?.id);
+
+  const bonus = [];
+  const available = [...parentTraitsAll];
+  for (let i = 0; i < bonusTraits && available.length > 0; i++) {
+    const idx = Math.floor(rng() * available.length);
+    bonus.push(available.splice(idx, 1)[0]);
+  }
+
+  const offspring = {
+    lineage_id: lineageId,
+    gene_slots: inheritedSlots,
+    environmental_mutation: environmentalMutation,
+    tier_bonus_traits: bonus,
+    tier,
+    predicted_lifecycle_phase: 'hatchling',
+    parent_a_id: parentA.id || null,
+    parent_b_id: parentB.id || null,
+    biome_id_at_mating: biomeId || null,
+  };
+
+  return {
+    success: true,
+    offspring,
+    tier,
+    visual_hints: TIER_VISUAL_HINTS[tier],
+  };
+}
+
+// Note: Sprint C exports are appended at the bottom of this file (after the
+// canonical `module.exports = { ... }` block) to avoid being overwritten.
 
 // ─── L06 adapter: Prisma + in-memory fallback ────────────────────────────
 
@@ -438,6 +760,34 @@ function createMetaStore({ prisma, campaignId = null } = {}) {
     };
   }
 
+  // Sprint C — Offspring registry. No Prisma model yet (P0 follow-up
+  // ADR-2026-04-21-meta-progression-prisma adds it). When usePrisma=false,
+  // delegate to fallback tracker so we have a single in-memory source of truth.
+  // When usePrisma=true, use this _offspringMem until Prisma model lands.
+  const _offspringMem = [];
+
+  async function rollOffspring(input = {}) {
+    if (!usePrisma) return fallback.rollOffspring(input);
+    const result = rollMatingOffspring(input);
+    if (result.success && result.offspring) {
+      _offspringMem.push({ ...result.offspring, created_at: Date.now() });
+    }
+    return result;
+  }
+
+  async function listOffspring() {
+    if (!usePrisma) return fallback.listOffspring();
+    return _offspringMem.map((o) => ({ ...o }));
+  }
+
+  async function addOffspring(offspring) {
+    if (!usePrisma) return fallback.addOffspring(offspring);
+    if (!offspring || typeof offspring !== 'object') return null;
+    const entry = { ...offspring, added_at: Date.now() };
+    _offspringMem.push(entry);
+    return entry;
+  }
+
   return {
     updateAffinity,
     updateTrust,
@@ -449,6 +799,9 @@ function createMetaStore({ prisma, campaignId = null } = {}) {
     tickCooldowns,
     listNpcs,
     getNest,
+    rollOffspring,
+    listOffspring,
+    addOffspring,
     // meta
     _mode: usePrisma ? 'prisma' : 'in-memory',
   };
@@ -467,3 +820,16 @@ module.exports = {
   TRUST_MAX,
   MATING_THRESHOLD,
 };
+
+// ─── Sprint C — additive exports (offspring roll + tier visual feedback) ──
+// Appended after the canonical export block so existing keys aren't shadowed.
+// Sprint D and other parallel sprints can also use this additive pattern.
+module.exports.makeLineageId = makeLineageId;
+module.exports.inheritGeneSlots = inheritGeneSlots;
+module.exports.pickEnvironmentalMutation = pickEnvironmentalMutation;
+module.exports.computeOffspringTier = computeOffspringTier;
+module.exports.rollMatingOffspring = rollMatingOffspring;
+module.exports.TIER_NO_GLOW = TIER_NO_GLOW;
+module.exports.TIER_GOLD = TIER_GOLD;
+module.exports.TIER_RAINBOW = TIER_RAINBOW;
+module.exports.TIER_VISUAL_HINTS = TIER_VISUAL_HINTS;

--- a/apps/play/src/api.js
+++ b/apps/play/src/api.js
@@ -276,6 +276,18 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ biome, requirements_met }),
     }),
+  // OD-001 Path A Sprint C — offspring roll (MHS 3-tier visual feedback).
+  metaMatingRoll: (parent_a, parent_b, biome_id) =>
+    jsonFetch('/api/meta/mating/roll', {
+      method: 'POST',
+      body: JSON.stringify({ parent_a, parent_b, biome_id }),
+    }),
+  metaNestOffspringList: () => jsonFetch('/api/meta/nest/offspring'),
+  metaNestAddOffspring: (offspring) =>
+    jsonFetch('/api/meta/nest/add_offspring', {
+      method: 'POST',
+      body: JSON.stringify({ offspring }),
+    }),
   // Skiv-as-Monitor — git-event-driven creature feed (Phase 2 wire 2026-04-25).
   skivStatus: () => jsonFetch('/api/skiv/status'),
   skivFeed: (limit = 20) => jsonFetch(`/api/skiv/feed?limit=${encodeURIComponent(limit)}`),

--- a/apps/play/src/nestHub.js
+++ b/apps/play/src/nestHub.js
@@ -24,6 +24,17 @@ const STATE = {
   // Optional partyMember provider for mating roll (Phase D).
   // Returns { mbti_type, trait_ids } of the active player unit.
   getPartyMember: () => null,
+  // Sprint C — squad creatures provider for offspring mating UI.
+  // Returns Array<{id, name?, mbti_type?, trait_ids?, gene_slots?}>.
+  getSquadCreatures: () => [],
+  // Sprint C — Mating tab UI state.
+  matingTab: {
+    parentAId: null,
+    parentBId: null,
+    rolledThisSession: false,
+    lastResult: null,
+  },
+  activeTab: 'overview',
 };
 
 const BIOME_OPTIONS = [
@@ -112,6 +123,102 @@ function injectStyles() {
     }
     .nest-status.ok { color: #66bb6a; }
     .nest-status.err { color: #ef5350; }
+    /* Sprint C — Tab strip + Mating tab tier visual feedback */
+    .nest-tabs {
+      display: flex; gap: 4px; margin-bottom: 14px; border-bottom: 1px solid #2a3040;
+    }
+    .nest-tab-btn {
+      background: transparent; color: #8891a3; border: none;
+      padding: 8px 14px; cursor: pointer; font-size: 0.9rem;
+      border-bottom: 2px solid transparent;
+    }
+    .nest-tab-btn:hover { color: #ffd180; }
+    .nest-tab-btn.active {
+      color: #ffd180; border-bottom-color: #ffd180; font-weight: 700;
+    }
+    .nest-tab-pane { display: none; }
+    .nest-tab-pane.active { display: block; }
+    /* Mating tab — parent selectors */
+    .mating-parent-grid {
+      display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-bottom: 12px;
+    }
+    .mating-parent-grid select {
+      background: #0b0d12; color: #e8eaf0; border: 1px solid #2a3040;
+      border-radius: 6px; padding: 6px 10px; font-size: 0.9rem; width: 100%;
+    }
+    .mating-parent-label {
+      display: block; font-size: 0.78rem; color: #8891a3; margin-bottom: 4px;
+    }
+    .mating-roll-row {
+      display: flex; align-items: center; gap: 10px; margin-bottom: 12px;
+    }
+    .mating-cooldown-hint {
+      color: #ef9a9a; font-size: 0.78rem;
+    }
+    /* Tier visual feedback — no-glow / gold / rainbow */
+    .offspring-card {
+      background: #0b0d12; border: 2px solid #2a3040; border-radius: 10px;
+      padding: 14px 16px; margin-top: 10px; position: relative;
+      transition: all 0.3s ease;
+    }
+    .offspring-card.tier-no-glow {
+      border-color: #2a3040;
+    }
+    .offspring-card.tier-gold {
+      border-color: #ffd180;
+      box-shadow: 0 0 16px rgba(255, 209, 128, 0.45);
+      background: linear-gradient(180deg, #2a210d 0%, #0b0d12 80%);
+    }
+    .offspring-card.tier-rainbow {
+      border-image: linear-gradient(90deg,
+        #ff6b6b, #ffd93d, #6bcf7f, #4d9de0, #b06bff, #ff6b6b
+      ) 1;
+      box-shadow: 0 0 22px rgba(255, 100, 200, 0.5);
+      background: linear-gradient(180deg, #1a0d2a 0%, #0b0d12 80%);
+      animation: rainbow-pulse 3s ease-in-out infinite;
+    }
+    @keyframes rainbow-pulse {
+      0%, 100% { box-shadow: 0 0 22px rgba(255, 100, 200, 0.5); }
+      50% { box-shadow: 0 0 32px rgba(180, 200, 255, 0.7); }
+    }
+    .offspring-card .tier-badge {
+      display: inline-block; padding: 3px 10px; border-radius: 999px;
+      font-size: 0.72rem; font-weight: 700; letter-spacing: 0.05em;
+      text-transform: uppercase; margin-bottom: 8px;
+    }
+    .tier-badge.tier-no-glow { background: #2a3040; color: #b0b8c5; }
+    .tier-badge.tier-gold { background: #c4a574; color: #1a1410; }
+    .tier-badge.tier-rainbow {
+      background: linear-gradient(90deg, #ff6b6b, #ffd93d, #6bcf7f, #4d9de0, #b06bff);
+      color: #1a1410;
+    }
+    .offspring-lineage {
+      font-family: 'Consolas', monospace; color: #66d1fb;
+      font-size: 0.78rem; margin-bottom: 6px;
+    }
+    .offspring-row {
+      margin: 6px 0; font-size: 0.85rem;
+    }
+    .offspring-row .offspring-label {
+      color: #8891a3; font-size: 0.78rem; margin-right: 6px;
+    }
+    .offspring-slot-chip {
+      display: inline-block; background: #1d2230; border: 1px solid #2a3040;
+      border-radius: 4px; padding: 2px 8px; margin: 0 4px 4px 0;
+      font-size: 0.78rem;
+    }
+    .offspring-slot-chip.from-a { border-color: #4d9de0; }
+    .offspring-slot-chip.from-b { border-color: #ff9d4d; }
+    .offspring-mutation {
+      display: inline-block; background: #1d2230; border: 1px solid #5a4a2f;
+      border-radius: 4px; padding: 2px 8px; font-size: 0.78rem; cursor: help;
+    }
+    .offspring-mutation.tier-rare {
+      border-color: #b06bff; color: #d6b3ff;
+    }
+    .offspring-actions {
+      display: flex; gap: 8px; margin-top: 12px;
+    }
   `;
   document.head.appendChild(style);
 }
@@ -134,28 +241,76 @@ function buildOverlay() {
         <span><strong>Bioma:</strong> <span id="nest-meta-biome">—</span></span>
         <span class="nest-pill" id="nest-meta-req">requisiti?</span>
       </div>
-      <div class="nest-section" id="nest-setup-section" style="display:none">
-        <h3>Setup nido</h3>
-        <div class="nest-setup-row">
-          <select id="nest-biome-select">
-            ${BIOME_OPTIONS.map((b) => `<option value="${b}">${b}</option>`).join('')}
-          </select>
-          <button type="button" class="nest-btn" id="nest-setup-btn">🪺 Inizializza</button>
+      <div class="nest-tabs" role="tablist">
+        <button type="button" class="nest-tab-btn active" data-tab-btn="overview" role="tab">
+          🏠 Overview
+        </button>
+        <button type="button" class="nest-tab-btn" data-tab-btn="mating" role="tab">
+          🧬 Mating
+        </button>
+        <button type="button" class="nest-tab-btn" data-tab-btn="lineage" role="tab">
+          🌳 Lineage
+        </button>
+      </div>
+      <div class="nest-tab-pane active" data-tab="overview">
+        <div class="nest-section" id="nest-setup-section" style="display:none">
+          <h3>Setup nido</h3>
+          <div class="nest-setup-row">
+            <select id="nest-biome-select">
+              ${BIOME_OPTIONS.map((b) => `<option value="${b}">${b}</option>`).join('')}
+            </select>
+            <button type="button" class="nest-btn" id="nest-setup-btn">🪺 Inizializza</button>
+          </div>
+        </div>
+        <div class="nest-section">
+          <h3>NPG nel nido (<span id="nest-npc-count">0</span>)</h3>
+          <div id="nest-npc-list">
+            <div class="nest-empty">Carico…</div>
+          </div>
+        </div>
+        <div class="nest-section" id="nest-mating-section" style="display:none">
+          <h3>NPG mating roll (seleziona 1 NPG)</h3>
+          <div class="nest-setup-row">
+            <button type="button" class="nest-btn" id="nest-mating-btn" disabled>
+              🧬 Tenta riproduzione (NPG)
+            </button>
+            <span id="nest-mating-hint" style="font-size:0.8rem;color:#8891a3"></span>
+          </div>
         </div>
       </div>
-      <div class="nest-section">
-        <h3>NPG nel nido (<span id="nest-npc-count">0</span>)</h3>
-        <div id="nest-npc-list">
-          <div class="nest-empty">Carico…</div>
+      <div class="nest-tab-pane" data-tab="mating">
+        <div class="nest-section">
+          <h3>🧬 Squad mating — offspring (MHS 3-tier)</h3>
+          <p style="font-size:0.78rem;color:#8891a3;margin:0 0 10px">
+            Seleziona due creature della squadra per generare un offspring.
+            Il tier (no-glow / gold / rainbow) è determinato da gene_slot match
+            e mutazione ambientale del bioma corrente.
+          </p>
+          <div class="mating-parent-grid">
+            <div>
+              <label class="mating-parent-label" for="mating-parent-a">Parent A</label>
+              <select id="mating-parent-a"><option value="">— seleziona —</option></select>
+            </div>
+            <div>
+              <label class="mating-parent-label" for="mating-parent-b">Parent B</label>
+              <select id="mating-parent-b"><option value="">— seleziona —</option></select>
+            </div>
+          </div>
+          <div class="mating-roll-row">
+            <button type="button" class="nest-btn" id="mating-roll-btn" disabled>
+              🎲 Roll Mating
+            </button>
+            <span id="mating-cooldown-hint" class="mating-cooldown-hint"></span>
+          </div>
+          <div id="mating-result-host"></div>
         </div>
       </div>
-      <div class="nest-section" id="nest-mating-section" style="display:none">
-        <h3>Mating roll (seleziona 1 NPG)</h3>
-        <div class="nest-setup-row">
-          <button type="button" class="nest-btn" id="nest-mating-btn" disabled>
-            🧬 Tenta riproduzione
-          </button>
-          <span id="nest-mating-hint" style="font-size:0.8rem;color:#8891a3"></span>
+      <div class="nest-tab-pane" data-tab="lineage">
+        <div class="nest-section">
+          <h3>🌳 Lineage</h3>
+          <p style="font-size:0.85rem;color:#8891a3">
+            Sprint D — albero genealogico offspring + tracking parent chain.
+          </p>
         </div>
       </div>
       <div class="nest-status" id="nest-status"></div>
@@ -168,8 +323,36 @@ function buildOverlay() {
   });
   overlay.querySelector('#nest-setup-btn').addEventListener('click', handleSetup);
   overlay.querySelector('#nest-mating-btn').addEventListener('click', handleMating);
+  // Sprint C — tab switch + Mating tab handlers
+  overlay.querySelectorAll('[data-tab-btn]').forEach((btn) => {
+    btn.addEventListener('click', () => switchTab(btn.dataset.tabBtn));
+  });
+  const parentASel = overlay.querySelector('#mating-parent-a');
+  const parentBSel = overlay.querySelector('#mating-parent-b');
+  if (parentASel) parentASel.addEventListener('change', handleParentChange);
+  if (parentBSel) parentBSel.addEventListener('change', handleParentChange);
+  const rollBtn = overlay.querySelector('#mating-roll-btn');
+  if (rollBtn) rollBtn.addEventListener('click', handleMatingRoll);
   STATE.overlayEl = overlay;
   return overlay;
+}
+
+function switchTab(tabName) {
+  if (typeof document === 'undefined') return;
+  if (!tabName) return;
+  STATE.activeTab = tabName;
+  if (!STATE.overlayEl) return;
+  STATE.overlayEl.querySelectorAll('[data-tab-btn]').forEach((btn) => {
+    btn.classList.toggle('active', btn.dataset.tabBtn === tabName);
+  });
+  STATE.overlayEl.querySelectorAll('[data-tab]').forEach((pane) => {
+    pane.classList.toggle('active', pane.dataset.tab === tabName);
+  });
+  // Refresh squad creatures when entering mating tab.
+  if (tabName === 'mating') {
+    populateParentSelects();
+    updateRollButtonState();
+  }
 }
 
 function setStatus(text, kind = '') {
@@ -320,10 +503,202 @@ async function refresh() {
   STATE.cachedNest = res.data?.nest || { level: 0, biome: null, requirements_met: false };
   renderNest(STATE.cachedNest);
   renderNpcs(STATE.cachedNpcs);
+  // Sprint C — refresh Mating tab parent selectors when squad changes.
+  if (STATE.activeTab === 'mating') {
+    populateParentSelects();
+    updateRollButtonState();
+  }
   setStatus(
     `${STATE.cachedNpcs.length} NPG · nido Lv ${STATE.cachedNest.level}${STATE.cachedNest.biome ? ' (' + STATE.cachedNest.biome + ')' : ''}`,
     'ok',
   );
+}
+
+// ─── Sprint C — Mating tab (squad-mate offspring roll) ──────────────────
+
+function getSquadList() {
+  try {
+    const list = STATE.getSquadCreatures?.() || [];
+    return Array.isArray(list) ? list : [];
+  } catch {
+    return [];
+  }
+}
+
+function populateParentSelects() {
+  if (typeof document === 'undefined' || !STATE.overlayEl) return;
+  const aSel = STATE.overlayEl.querySelector('#mating-parent-a');
+  const bSel = STATE.overlayEl.querySelector('#mating-parent-b');
+  if (!aSel || !bSel) return;
+  const squad = getSquadList();
+  const optsHtml = ['<option value="">— seleziona —</option>']
+    .concat(
+      squad.map((c) => {
+        const id = String(c.id || '');
+        const label = c.name || c.id || 'unnamed';
+        return `<option value="${escapeAttr(id)}">${escapeText(label)}</option>`;
+      }),
+    )
+    .join('');
+  // Preserve current selection if still valid.
+  const prevA = STATE.matingTab.parentAId;
+  const prevB = STATE.matingTab.parentBId;
+  aSel.innerHTML = optsHtml;
+  bSel.innerHTML = optsHtml;
+  if (prevA && squad.find((c) => c.id === prevA)) aSel.value = prevA;
+  if (prevB && squad.find((c) => c.id === prevB)) bSel.value = prevB;
+}
+
+function handleParentChange() {
+  if (typeof document === 'undefined' || !STATE.overlayEl) return;
+  const a = STATE.overlayEl.querySelector('#mating-parent-a')?.value || '';
+  const b = STATE.overlayEl.querySelector('#mating-parent-b')?.value || '';
+  STATE.matingTab.parentAId = a || null;
+  STATE.matingTab.parentBId = b || null;
+  updateRollButtonState();
+}
+
+function updateRollButtonState() {
+  if (typeof document === 'undefined' || !STATE.overlayEl) return;
+  const btn = STATE.overlayEl.querySelector('#mating-roll-btn');
+  const hint = STATE.overlayEl.querySelector('#mating-cooldown-hint');
+  if (!btn) return;
+  const a = STATE.matingTab.parentAId;
+  const b = STATE.matingTab.parentBId;
+  const sameParent = a && b && a === b;
+  const onCooldown = STATE.matingTab.rolledThisSession;
+  let canRoll = Boolean(a && b) && !sameParent && !onCooldown;
+  btn.disabled = !canRoll;
+  if (hint) {
+    if (sameParent) hint.textContent = 'Stessa creatura — seleziona due parent diversi';
+    else if (onCooldown) hint.textContent = 'Cooldown attivo (1 mating per sessione)';
+    else if (!a || !b) hint.textContent = '';
+    else hint.textContent = `Ready: ${a} × ${b}`;
+  }
+}
+
+async function handleMatingRoll() {
+  if (typeof document === 'undefined' || !STATE.overlayEl) return;
+  const a = STATE.matingTab.parentAId;
+  const b = STATE.matingTab.parentBId;
+  if (!a || !b || a === b) return;
+  const squad = getSquadList();
+  const parentA = squad.find((c) => c.id === a);
+  const parentB = squad.find((c) => c.id === b);
+  if (!parentA || !parentB) {
+    setStatus('✖ Parent non trovato in squad cache', 'err');
+    return;
+  }
+  const biomeId = STATE.cachedNest?.biome || 'default';
+  setStatus(`Roll mating ${a} × ${b} in ${biomeId}…`);
+  const res = await api.metaMatingRoll(parentA, parentB, biomeId);
+  if (!res.ok) {
+    setStatus(`✖ Backend error: ${res.data?.error || res.status}`, 'err');
+    return;
+  }
+  const data = res.data || {};
+  if (!data.success) {
+    setStatus(`✖ Mating fail: ${data.reason || 'unknown'}`, 'err');
+    renderOffspringResult(null);
+    return;
+  }
+  STATE.matingTab.rolledThisSession = true;
+  STATE.matingTab.lastResult = data;
+  renderOffspringResult(data);
+  updateRollButtonState();
+  const tierLabel = data.tier || 'no-glow';
+  setStatus(
+    `🧬 Offspring ${tierLabel.toUpperCase()} generato (lineage ${data.offspring?.lineage_id || '?'})`,
+    'ok',
+  );
+}
+
+function renderOffspringResult(result) {
+  if (typeof document === 'undefined' || !STATE.overlayEl) return;
+  const host = STATE.overlayEl.querySelector('#mating-result-host');
+  if (!host) return;
+  if (!result || !result.success) {
+    host.innerHTML = '';
+    return;
+  }
+  const o = result.offspring || {};
+  const tier = result.tier || 'no-glow';
+  const tierClass = `tier-${tier}`;
+  const slotsHtml = (o.gene_slots || [])
+    .map((s) => {
+      const fromCls = s.from === 'parent_a' ? 'from-a' : 'from-b';
+      const lab = escapeText(s.label_it || s.slot_id);
+      const val = escapeText(String(s.value || ''));
+      return `<span class="offspring-slot-chip ${fromCls}">${lab}: ${val} <small>(${escapeText(s.from)})</small></span>`;
+    })
+    .join('');
+  const mut = o.environmental_mutation || {};
+  const mutTierCls = mut.tier === 2 ? 'tier-rare' : '';
+  const mutLabel = escapeText(mut.name_it || mut.id || 'nessuna');
+  const mutTooltip = `bioma: ${escapeAttr(mut.biome_id || '?')} | tier: ${mut.tier ?? '—'} | source: ${escapeAttr(mut.source || '?')}`;
+  const lineageDisplay = humanizeLineageId(o.lineage_id);
+  const bonusHtml = (o.tier_bonus_traits || [])
+    .map((t) => `<span class="offspring-slot-chip">${escapeText(t)}</span>`)
+    .join('');
+  host.innerHTML = `
+    <div class="offspring-card ${tierClass}">
+      <span class="tier-badge ${tierClass}">${tier}</span>
+      <div class="offspring-lineage">🆔 ${escapeText(lineageDisplay)}</div>
+      <div class="offspring-row">
+        <span class="offspring-label">Gene slots:</span>${slotsHtml || '—'}
+      </div>
+      <div class="offspring-row">
+        <span class="offspring-label">Mutazione ambientale:</span>
+        <span class="offspring-mutation ${mutTierCls}" title="${mutTooltip}">${mutLabel}</span>
+      </div>
+      ${
+        bonusHtml
+          ? `<div class="offspring-row"><span class="offspring-label">Bonus tier:</span>${bonusHtml}</div>`
+          : ''
+      }
+      <div class="offspring-row">
+        <span class="offspring-label">Phase:</span>
+        <span class="offspring-slot-chip">${escapeText(o.predicted_lifecycle_phase || 'hatchling')}</span>
+      </div>
+      <div class="offspring-actions">
+        <button type="button" class="nest-btn" id="offspring-add-btn">+ Aggiungi al Nido</button>
+      </div>
+    </div>
+  `;
+  const addBtn = host.querySelector('#offspring-add-btn');
+  if (addBtn) addBtn.addEventListener('click', () => handleAddOffspring(o));
+}
+
+async function handleAddOffspring(offspring) {
+  if (!offspring) return;
+  setStatus('Aggiungo al Nido…');
+  const res = await api.metaNestAddOffspring(offspring);
+  if (!res.ok) {
+    setStatus(`✖ Add failed: ${res.data?.error || res.status}`, 'err');
+    return;
+  }
+  setStatus(`✓ Offspring ${offspring.lineage_id} aggiunto al Nido`, 'ok');
+}
+
+function humanizeLineageId(id) {
+  if (!id) return '—';
+  // lineage_a1b2c3d4 → A1B2-C3D4 (more readable)
+  const m = String(id).match(/^lineage_([0-9a-f]+)$/i);
+  if (!m) return id;
+  const hex = m[1].toUpperCase();
+  if (hex.length >= 8) return `Lineage ${hex.slice(0, 4)}-${hex.slice(4, 8)}`;
+  return `Lineage ${hex}`;
+}
+
+function escapeText(s) {
+  return String(s == null ? '' : s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function escapeAttr(s) {
+  return escapeText(s).replace(/"/g, '&quot;');
 }
 
 export function openNestHub() {
@@ -336,15 +711,24 @@ export function closeNestHub() {
   if (STATE.overlayEl) STATE.overlayEl.classList.remove('visible');
 }
 
-export function initNestHub({ getPartyMember, buttonId = 'nest-open' } = {}) {
+export function initNestHub({ getPartyMember, getSquadCreatures, buttonId = 'nest-open' } = {}) {
   STATE.getPartyMember = typeof getPartyMember === 'function' ? getPartyMember : () => null;
+  STATE.getSquadCreatures = typeof getSquadCreatures === 'function' ? getSquadCreatures : () => [];
   buildOverlay();
   if (typeof document === 'undefined') {
-    return { openNestHub, closeNestHub, refresh };
+    return { openNestHub, closeNestHub, refresh, switchTab };
   }
   const btn = document.getElementById(buttonId);
   if (btn) {
     btn.addEventListener('click', openNestHub);
   }
-  return { openNestHub, closeNestHub, refresh };
+  return { openNestHub, closeNestHub, refresh, switchTab };
 }
+
+// Test surface — internal helpers for unit tests.
+export const __nestHubInternal = {
+  humanizeLineageId,
+  escapeText,
+  escapeAttr,
+  STATE,
+};

--- a/tests/api/meta.mating.test.js
+++ b/tests/api/meta.mating.test.js
@@ -1,0 +1,123 @@
+// Sprint C — Mating roll API endpoint tests.
+// POST /api/meta/mating/roll, GET /api/meta/nest/offspring,
+// POST /api/meta/nest/add_offspring.
+//
+// In-memory fallback (no DATABASE_URL).
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+test('POST /api/meta/mating/roll 400 on missing parents', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app).post('/api/meta/mating/roll').send({}).expect(400);
+    await request(app)
+      .post('/api/meta/mating/roll')
+      .send({ parent_a: { id: 'pa' } })
+      .expect(400);
+    await request(app)
+      .post('/api/meta/mating/roll')
+      .send({ parent_a: {}, parent_b: {} })
+      .expect(400);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/meta/mating/roll returns offspring + tier + visual_hints', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app)
+      .post('/api/meta/mating/roll')
+      .send({
+        parent_a: {
+          id: 'skiv_alpha',
+          trait_ids: ['t1'],
+          gene_slots: [{ slot_id: 'corpo', value: 'agile' }],
+        },
+        parent_b: {
+          id: 'echo_beta',
+          trait_ids: ['t2'],
+          gene_slots: [{ slot_id: 'arti', value: 'forti' }],
+        },
+        biome_id: 'savana',
+      })
+      .expect(200);
+    assert.equal(res.body.success, true);
+    assert.ok(res.body.offspring);
+    assert.equal(res.body.offspring.parent_a_id, 'skiv_alpha');
+    assert.equal(res.body.offspring.parent_b_id, 'echo_beta');
+    assert.equal(res.body.offspring.biome_id_at_mating, 'savana');
+    assert.match(res.body.offspring.lineage_id, /^lineage_[0-9a-f]{8}$/);
+    assert.ok(['no-glow', 'gold', 'rainbow'].includes(res.body.tier));
+    assert.ok(res.body.visual_hints);
+    assert.equal(typeof res.body.visual_hints.glow, 'boolean');
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/meta/mating/roll prevents self-mate', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app)
+      .post('/api/meta/mating/roll')
+      .send({
+        parent_a: { id: 'self', trait_ids: [] },
+        parent_b: { id: 'self', trait_ids: [] },
+        biome_id: 'savana',
+      })
+      .expect(200);
+    assert.equal(res.body.success, false);
+    assert.equal(res.body.reason, 'self_mate_prevented');
+  } finally {
+    await close();
+  }
+});
+
+test('GET /api/meta/nest/offspring + POST /api/meta/nest/add_offspring roundtrip', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    // Initially empty.
+    const empty = await request(app).get('/api/meta/nest/offspring').expect(200);
+    assert.deepEqual(empty.body.offspring, []);
+
+    // Add one offspring.
+    const add = await request(app)
+      .post('/api/meta/nest/add_offspring')
+      .send({
+        offspring: {
+          lineage_id: 'lineage_deadbeef',
+          gene_slots: [],
+          tier: 'no-glow',
+        },
+      })
+      .expect(200);
+    assert.ok(add.body.added);
+    assert.equal(add.body.added.lineage_id, 'lineage_deadbeef');
+
+    // List shows entry.
+    const list = await request(app).get('/api/meta/nest/offspring').expect(200);
+    assert.equal(list.body.offspring.length, 1);
+    assert.equal(list.body.offspring[0].lineage_id, 'lineage_deadbeef');
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/meta/nest/add_offspring 400 on invalid body', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app).post('/api/meta/nest/add_offspring').send({}).expect(400);
+    await request(app)
+      .post('/api/meta/nest/add_offspring')
+      .send({ offspring: 'not-an-object' })
+      .expect(400);
+  } finally {
+    await close();
+  }
+});

--- a/tests/api/nestHubMating.test.js
+++ b/tests/api/nestHubMating.test.js
@@ -1,0 +1,59 @@
+// Sprint C — nestHub Mating tab unit tests.
+//
+// Coverage (DOM-free helpers):
+//   - humanizeLineageId formatting
+//   - escapeText / escapeAttr safety
+//   - STATE shape with matingTab + getSquadCreatures provider
+//
+// Browser/DOM rendering verified via preview_verify manual smoke (Phase 2).
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+async function loadPanel() {
+  return import('../../apps/play/src/nestHub.js');
+}
+
+test('humanizeLineageId: lineage_a1b2c3d4 → Lineage A1B2-C3D4', async () => {
+  const { __nestHubInternal } = await loadPanel();
+  assert.equal(__nestHubInternal.humanizeLineageId('lineage_a1b2c3d4'), 'Lineage A1B2-C3D4');
+});
+
+test('humanizeLineageId: empty/null → "—"', async () => {
+  const { __nestHubInternal } = await loadPanel();
+  assert.equal(__nestHubInternal.humanizeLineageId(null), '—');
+  assert.equal(__nestHubInternal.humanizeLineageId(''), '—');
+  assert.equal(__nestHubInternal.humanizeLineageId(undefined), '—');
+});
+
+test('humanizeLineageId: non-matching format passthrough', async () => {
+  const { __nestHubInternal } = await loadPanel();
+  // Doesn't match /^lineage_[0-9a-f]+$/ → returns unchanged
+  assert.equal(__nestHubInternal.humanizeLineageId('not_lineage_123'), 'not_lineage_123');
+});
+
+test('escapeText: HTML special chars escaped', async () => {
+  const { __nestHubInternal } = await loadPanel();
+  assert.equal(__nestHubInternal.escapeText('<script>'), '&lt;script&gt;');
+  assert.equal(__nestHubInternal.escapeText('a & b'), 'a &amp; b');
+  assert.equal(__nestHubInternal.escapeText(null), '');
+});
+
+test('escapeAttr: also escapes double quotes', async () => {
+  const { __nestHubInternal } = await loadPanel();
+  assert.equal(__nestHubInternal.escapeAttr('hello "world"'), 'hello &quot;world&quot;');
+  assert.equal(__nestHubInternal.escapeAttr('<a href="x">'), '&lt;a href=&quot;x&quot;&gt;');
+});
+
+test('STATE shape: includes matingTab + getSquadCreatures provider', async () => {
+  const { __nestHubInternal } = await loadPanel();
+  const s = __nestHubInternal.STATE;
+  assert.equal(typeof s.getSquadCreatures, 'function');
+  assert.equal(typeof s.matingTab, 'object');
+  assert.equal(s.matingTab.parentAId, null);
+  assert.equal(s.matingTab.parentBId, null);
+  assert.equal(s.matingTab.rolledThisSession, false);
+  assert.ok(['overview', 'mating', 'lineage'].includes(s.activeTab));
+});

--- a/tests/services/metaProgression.mating.test.js
+++ b/tests/services/metaProgression.mating.test.js
@@ -1,0 +1,300 @@
+// Sprint C — Mating offspring roll tests (MHS 3-tier visual feedback).
+//
+// Coverage:
+//   - lineage_id determinism (same parents = same id; order-independent)
+//   - gene_slots inheritance (1 per parent, weighted)
+//   - environmental_mutation pick (mutation_catalog vs biome trait fallback)
+//   - tier distribution (no-glow / gold / rainbow rules)
+//   - self-mate prevention
+//   - rollOffspring integration on tracker (offspring registry)
+//
+// Cross-ref:
+//   - apps/backend/services/metaProgression.js rollMatingOffspring
+//   - data/core/mating.yaml gene_slots schema
+//   - data/core/mutations/mutation_catalog.yaml
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createMetaTracker,
+  makeLineageId,
+  inheritGeneSlots,
+  pickEnvironmentalMutation,
+  computeOffspringTier,
+  rollMatingOffspring,
+  TIER_NO_GLOW,
+  TIER_GOLD,
+  TIER_RAINBOW,
+} = require('../../apps/backend/services/metaProgression');
+
+// ─── lineage_id ─────────────────────────────────────────────────────
+
+test('makeLineageId: deterministic — same input produces same id', () => {
+  const id1 = makeLineageId('skiv_alpha', 'echo_beta');
+  const id2 = makeLineageId('skiv_alpha', 'echo_beta');
+  assert.equal(id1, id2);
+  assert.match(id1, /^lineage_[0-9a-f]{8}$/);
+});
+
+test('makeLineageId: order-independent (commutative)', () => {
+  const a = makeLineageId('skiv_alpha', 'echo_beta');
+  const b = makeLineageId('echo_beta', 'skiv_alpha');
+  assert.equal(a, b);
+});
+
+test('makeLineageId: distinct parents → distinct lineage', () => {
+  const x = makeLineageId('skiv_alpha', 'echo_beta');
+  const y = makeLineageId('skiv_alpha', 'crawler_gamma');
+  assert.notEqual(x, y);
+});
+
+// ─── inheritGeneSlots ───────────────────────────────────────────────
+
+test('inheritGeneSlots: returns 2 slots, one from each parent', () => {
+  const a = { id: 'pa', gene_slots: [{ slot_id: 'corpo', value: 'agile' }] };
+  const b = { id: 'pb', gene_slots: [{ slot_id: 'arti', value: 'forti' }] };
+  const slots = inheritGeneSlots(a, b, {}, () => 0.5);
+  assert.equal(slots.length, 2);
+  assert.equal(slots[0].from, 'parent_a');
+  assert.equal(slots[1].from, 'parent_b');
+});
+
+test('inheritGeneSlots: parent without gene_slots → fallback synthetic slot', () => {
+  const a = { id: 'pa' };
+  const b = { id: 'pb' };
+  const slots = inheritGeneSlots(a, b, {}, () => 0.5);
+  assert.equal(slots.length, 2);
+  assert.ok(slots[0].slot_id);
+  assert.ok(slots[1].slot_id);
+});
+
+test('inheritGeneSlots: weighted pick honors inheritance_weight', () => {
+  // schema: corazza weight 0.8, arti weight 0.6 → corazza preferred
+  const schema = {
+    categories: {
+      struttura: {
+        slots: [
+          { id: 'corazza', label_it: 'Corazza', inheritance_weight: 0.8 },
+          { id: 'arti', label_it: 'Arti', inheritance_weight: 0.6 },
+        ],
+      },
+    },
+  };
+  const a = {
+    id: 'pa',
+    gene_slots: [
+      { slot_id: 'corazza', value: 'spessa' },
+      { slot_id: 'arti', value: 'corti' },
+    ],
+  };
+  const b = {
+    id: 'pb',
+    gene_slots: [{ slot_id: 'arti', value: 'lunghi' }],
+  };
+  // rng=0.1 (very low) → first weight slice (corazza w=0.8) selected for parent_a
+  const slots = inheritGeneSlots(a, b, schema, () => 0.1);
+  assert.equal(slots[0].slot_id, 'corazza');
+  assert.equal(slots[0].label_it, 'Corazza');
+});
+
+// ─── pickEnvironmentalMutation ──────────────────────────────────────
+
+test('pickEnvironmentalMutation: mutation_catalog match by biome', () => {
+  const catalog = {
+    byId: {
+      mut_x: { tier: 1, biome_boost: ['savana'], name_it: 'X' },
+      mut_y: { tier: 2, biome_boost: ['cryosteppe'], name_it: 'Y' },
+    },
+  };
+  const mut = pickEnvironmentalMutation({
+    biomeId: 'savana',
+    mutationCatalog: catalog,
+    rng: () => 0,
+  });
+  assert.equal(mut.id, 'mut_x');
+  assert.equal(mut.type, 'mutation');
+  assert.equal(mut.tier, 1);
+});
+
+test('pickEnvironmentalMutation: fallback to biome trait pool when no catalog match', () => {
+  const mut = pickEnvironmentalMutation({
+    biomeId: 'unknown_biome',
+    mutationCatalog: { byId: {} },
+    biomeTraitsPool: ['trait_alpha'],
+    rng: () => 0,
+  });
+  assert.equal(mut.id, 'trait_alpha');
+  assert.equal(mut.type, 'trait');
+  assert.equal(mut.source, 'biome_trait_pool');
+});
+
+test('pickEnvironmentalMutation: empty fallback when no catalog + no pool', () => {
+  const mut = pickEnvironmentalMutation({ biomeId: 'x' });
+  assert.equal(mut.id, null);
+  assert.equal(mut.type, 'none');
+});
+
+// ─── computeOffspringTier ───────────────────────────────────────────
+
+test('computeOffspringTier: GOLD when both gene slots match same slot_id', () => {
+  const tier = computeOffspringTier({
+    inheritedSlots: [
+      { slot_id: 'corpo', from: 'parent_a' },
+      { slot_id: 'corpo', from: 'parent_b' },
+    ],
+    environmentalMutation: { tier: 0 },
+  });
+  assert.equal(tier, TIER_GOLD);
+});
+
+test('computeOffspringTier: RAINBOW when env mutation tier >= 2 (rare)', () => {
+  const tier = computeOffspringTier({
+    inheritedSlots: [
+      { slot_id: 'corpo', from: 'parent_a' },
+      { slot_id: 'arti', from: 'parent_b' },
+    ],
+    environmentalMutation: { type: 'mutation', tier: 2 },
+  });
+  assert.equal(tier, TIER_RAINBOW);
+});
+
+test('computeOffspringTier: NO-GLOW default (no slot match, no rare mutation)', () => {
+  const tier = computeOffspringTier({
+    inheritedSlots: [
+      { slot_id: 'corpo', from: 'parent_a' },
+      { slot_id: 'arti', from: 'parent_b' },
+    ],
+    environmentalMutation: { type: 'mutation', tier: 1 },
+  });
+  assert.equal(tier, TIER_NO_GLOW);
+});
+
+test('computeOffspringTier: RAINBOW takes priority over GOLD', () => {
+  // Both slot match AND rare mutation → rainbow wins.
+  const tier = computeOffspringTier({
+    inheritedSlots: [
+      { slot_id: 'corpo', from: 'parent_a' },
+      { slot_id: 'corpo', from: 'parent_b' },
+    ],
+    environmentalMutation: { type: 'mutation', tier: 2 },
+  });
+  assert.equal(tier, TIER_RAINBOW);
+});
+
+// ─── rollMatingOffspring ────────────────────────────────────────────
+
+test('rollMatingOffspring: returns full offspring spec', () => {
+  const result = rollMatingOffspring({
+    parentA: { id: 'pa', trait_ids: ['t1'], gene_slots: [{ slot_id: 'corpo', value: 'a' }] },
+    parentB: { id: 'pb', trait_ids: ['t2'], gene_slots: [{ slot_id: 'arti', value: 'b' }] },
+    biomeId: 'savana',
+    context: { rng: () => 0.5 },
+  });
+  assert.equal(result.success, true);
+  assert.ok(result.offspring);
+  assert.equal(result.offspring.parent_a_id, 'pa');
+  assert.equal(result.offspring.parent_b_id, 'pb');
+  assert.equal(result.offspring.biome_id_at_mating, 'savana');
+  assert.equal(result.offspring.predicted_lifecycle_phase, 'hatchling');
+  assert.match(result.offspring.lineage_id, /^lineage_[0-9a-f]{8}$/);
+  assert.equal(result.offspring.gene_slots.length, 2);
+  assert.ok(result.visual_hints);
+  assert.ok(['no-glow', 'gold', 'rainbow'].includes(result.tier));
+});
+
+test('rollMatingOffspring: prevents self-mate (parentA.id == parentB.id)', () => {
+  const result = rollMatingOffspring({
+    parentA: { id: 'self' },
+    parentB: { id: 'self' },
+    biomeId: 'savana',
+  });
+  assert.equal(result.success, false);
+  assert.equal(result.reason, 'self_mate_prevented');
+});
+
+test('rollMatingOffspring: throws on missing parents', () => {
+  assert.throws(() => rollMatingOffspring({ parentA: null, parentB: { id: 'b' } }));
+  assert.throws(() => rollMatingOffspring({}));
+});
+
+test('rollMatingOffspring: gold tier when inherited slots same slot_id', () => {
+  // Both parents only have 'corpo' slot → both inherited slots will be 'corpo'.
+  const result = rollMatingOffspring({
+    parentA: { id: 'pa', gene_slots: [{ slot_id: 'corpo', value: 'a' }] },
+    parentB: { id: 'pb', gene_slots: [{ slot_id: 'corpo', value: 'b' }] },
+    biomeId: 'savana',
+    context: { rng: () => 0.5, mutationCatalog: { byId: {} } },
+  });
+  assert.equal(result.success, true);
+  assert.equal(result.tier, TIER_GOLD);
+  assert.ok(result.offspring.tier_bonus_traits.length >= 0);
+});
+
+test('rollMatingOffspring: rainbow tier when env mutation is rare', () => {
+  const catalog = {
+    byId: {
+      mut_rare: { tier: 2, biome_boost: ['cryosteppe'], name_it: 'Rare X' },
+    },
+  };
+  const result = rollMatingOffspring({
+    parentA: {
+      id: 'pa',
+      trait_ids: ['t1', 't2', 't3'],
+      gene_slots: [{ slot_id: 'corpo', value: 'a' }],
+    },
+    parentB: {
+      id: 'pb',
+      trait_ids: ['t4', 't5'],
+      gene_slots: [{ slot_id: 'arti', value: 'b' }],
+    },
+    biomeId: 'cryosteppe',
+    context: { mutationCatalog: catalog, rng: () => 0.5 },
+  });
+  assert.equal(result.tier, TIER_RAINBOW);
+  assert.equal(result.offspring.environmental_mutation.id, 'mut_rare');
+  // Rainbow → +2 bonus traits
+  assert.equal(result.offspring.tier_bonus_traits.length, 2);
+});
+
+// ─── tracker.rollOffspring integration ──────────────────────────────
+
+test('tracker.rollOffspring: appends offspring to registry on success', () => {
+  const tracker = createMetaTracker();
+  const result = tracker.rollOffspring({
+    parentA: { id: 'pa', gene_slots: [{ slot_id: 'corpo', value: 'a' }] },
+    parentB: { id: 'pb', gene_slots: [{ slot_id: 'arti', value: 'b' }] },
+    biomeId: 'savana',
+    context: { rng: () => 0.5 },
+  });
+  assert.equal(result.success, true);
+  const list = tracker.listOffspring();
+  assert.equal(list.length, 1);
+  assert.equal(list[0].parent_a_id, 'pa');
+  assert.ok(list[0].created_at);
+});
+
+test('tracker.rollOffspring: self_mate does NOT append offspring', () => {
+  const tracker = createMetaTracker();
+  const result = tracker.rollOffspring({
+    parentA: { id: 'self' },
+    parentB: { id: 'self' },
+    biomeId: 'savana',
+  });
+  assert.equal(result.success, false);
+  assert.equal(tracker.listOffspring().length, 0);
+});
+
+test('tracker.addOffspring: appends external offspring entry', () => {
+  const tracker = createMetaTracker();
+  const entry = tracker.addOffspring({
+    lineage_id: 'lineage_deadbeef',
+    gene_slots: [],
+    tier: 'no-glow',
+  });
+  assert.ok(entry);
+  assert.ok(entry.added_at);
+  assert.equal(tracker.listOffspring().length, 1);
+});


### PR DESCRIPTION
## Summary

Sprint C of OD-001 Path A V3 Mating/Nido. Pattern **Monster Hunter Stories 3** genetics for offspring rarity feedback. **Layer 2** offspring mutation (biome at mating decides flavor), distinct from Layer 1 self-encounter mutation (M14 catalog reused as filter source).

- **`rollMatingOffspring`** in `metaProgression.js`: deterministic `lineage_id` (FNV-1a 32-bit hash, order-independent) + 2 inherited gene_slots (1 per parent, weighted by `inheritance_weight` from `data/core/mating.yaml`) + 1 environmental mutation pulled from `mutation_catalog.yaml` filtered by `biome_boost` (fallback: random trait from biome pool)
- **3-tier rules**: `rainbow` (mutation tier ≥ 2 rare) > `gold` (gene_slot match) > `no-glow` (default). Bonus traits: 0 / +1 / +2.
- **3 new endpoints** `/api/meta/mating/roll`, `/api/meta/nest/offspring`, `/api/meta/nest/add_offspring`. Lazy-load mating + mutation_catalog (non-blocking fallback).
- **nestHub UI**: tab structure (Overview / Mating / Lineage). Mating tab filled with parent dropdowns + roll button + offspring card with **gold border+glow** / **rainbow gradient border + pulse animation** / no-glow neutral. Lineage tab reserved for Sprint D.

## Conflict-tolerant pattern

- `metaProgression.js` exports appended AFTER canonical `module.exports = {...}` block — no shadowing if Sprint D extends `getLineageChain()`
- `nestHub.js` tab structure with `<div data-tab="mating">` (mine) + `<div data-tab="lineage">` placeholder (Sprint D fills later). Overview tab preserves existing NPG list / setup / NPG-mating UI
- `routes/meta.js` adds 3 endpoints additively; existing routes unchanged

## Tests

32 new tests, all green:

- `tests/services/metaProgression.mating.test.js` (21): lineage determinism + commutativity, inheritance weighted pick, env mutation catalog vs fallback, tier rules (gold/rainbow/no-glow + priority), self-mate prevention, tracker registry integration, `addOffspring`
- `tests/api/meta.mating.test.js` (5): endpoint roll/list/add roundtrip + 400 validation
- `tests/api/nestHubMating.test.js` (6): `humanizeLineageId`, `escapeText`, `escapeAttr`, `STATE` shape

## Test plan

- [x] `node --test tests/services/metaProgression.mating.test.js` — 21/21 ✓
- [x] `node --test tests/api/meta.mating.test.js` — 5/5 ✓
- [x] `node --test tests/api/nestHubMating.test.js` — 6/6 ✓
- [x] AI regression `node --test tests/ai/*.test.js` — **311/311 verde** (zero regression)
- [x] Aggregate (350/350): AI + metaRoutes + Sprint C suite
- [x] `npm run format:check` verde
- [x] `npm run lint:stack` verde
- [ ] Manual smoke: open Nido overlay → switch to Mating tab → select 2 squad creatures → Roll → verify tier visual (gold glow / rainbow pulse). Pending Sprint A merge to wire `getSquadCreatures` provider in `main.js`.

## Notes for parallel sprints

- **Sprint A (skeleton)**: my work assumes a tab-based shell with `<div data-tab="mating">`. Existing `nestHub.js` was single-overlay, so I introduced the tab structure here. If Sprint A merges first with a different tab API, need a small reconcile (data attribute names).
- **Sprint D (Lineage)**: empty `<div data-tab="lineage">` reserved. Append `getLineageChain()` exports to `metaProgression.js` after the additive Sprint C block.

## Stop-on-blocker resolutions

- `mutation_catalog.yaml` exists at `data/core/mutations/mutation_catalog.yaml` (30 entries, biome_boost field). Used as primary source. Fallback to random trait from biome pool if no match.
- `gene_slots` schema in `mating.yaml` is well-defined (`inheritance_weight` per slot). Used as canonical reference for weighted inheritance.

## Refs

- `data/core/mating.yaml` § gene_slots inheritance_rules
- `data/core/mutations/mutation_catalog.yaml` (M14, biome_boost field)
- `docs/core/Mating-Reclutamento-Nido.md` § Ereditarietà & Mutazioni
- `docs/museum/cards/mating_nido-engine-orphan.md` (M-007)

🤖 Generated with [Claude Code](https://claude.com/claude-code)