### PR TITLE
feat(nido): Sprint C backend re-apply — mating roll + 3-tier offspring (defer UI from #1877)

### DIFF
--- a/apps/backend/routes/meta.js
+++ b/apps/backend/routes/meta.js
@@ -59,6 +59,43 @@ function loadCompatTable() {
   return _compatTableCache;
 }
 
+// Sprint C — Lazy load mating.yaml gene_slots schema + mutation catalog for
+// offspring rolls. Both non-blocking: if files missing, falls back to {} / null.
+let _matingSchemaCache = null;
+function loadMatingSchema() {
+  if (_matingSchemaCache !== null) return _matingSchemaCache;
+  try {
+    const candidates = [
+      path.resolve(__dirname, '../../../data/core/mating.yaml'),
+      path.resolve(process.cwd(), 'data/core/mating.yaml'),
+    ];
+    for (const p of candidates) {
+      if (!fs.existsSync(p)) continue;
+      const raw = fs.readFileSync(p, 'utf8');
+      const doc = yaml.load(raw) || {};
+      _matingSchemaCache = doc.gene_slots || {};
+      return _matingSchemaCache;
+    }
+  } catch {
+    /* fall through */
+  }
+  _matingSchemaCache = {};
+  return _matingSchemaCache;
+}
+
+let _mutationCatalogCache = null;
+function loadCatalog() {
+  if (_mutationCatalogCache !== null) return _mutationCatalogCache;
+  try {
+    const { loadMutationCatalog } = require('../services/mutations/mutationCatalogLoader');
+    _mutationCatalogCache = loadMutationCatalog();
+    return _mutationCatalogCache;
+  } catch (_err) {
+    _mutationCatalogCache = null;
+    return _mutationCatalogCache;
+  }
+}
+
 /**
  * @param {object} [opts]
  * @param {object} [opts.store] — pre-built store (DI for tests or plugin sharing)
@@ -190,6 +227,55 @@ function createMetaRouter(opts = {}) {
     }
   });
 
+  // ─── Sprint C — squad-mate offspring roll (MHS 3-tier visual) ─────
+  // Distinct from /mating (NPC pair-bond DC roll). This rolls offspring
+  // spec from two squad creatures + biome at mating time.
+  router.post('/mating/roll', async (req, res, next) => {
+    try {
+      const { parent_a, parent_b, biome_id } = req.body || {};
+      if (!parent_a || !parent_b) {
+        return res.status(400).json({ error: 'parent_a and parent_b (objects with id) required' });
+      }
+      if (!parent_a.id || !parent_b.id) {
+        return res.status(400).json({ error: 'parent_a.id and parent_b.id required' });
+      }
+      const geneSlotsSchema = loadMatingSchema();
+      const mutationCatalog = loadCatalog();
+      const result = await store.rollOffspring({
+        parentA: parent_a,
+        parentB: parent_b,
+        biomeId: biome_id || null,
+        context: { geneSlotsSchema, mutationCatalog },
+      });
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.get('/nest/offspring', async (_req, res, next) => {
+    try {
+      const offspring = await store.listOffspring();
+      res.json({ offspring });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.post('/nest/add_offspring', async (req, res, next) => {
+    try {
+      const { offspring } = req.body || {};
+      if (!offspring || typeof offspring !== 'object') {
+        return res.status(400).json({ error: 'offspring object required' });
+      }
+      const entry = await store.addOffspring(offspring);
+      if (!entry) return res.status(400).json({ error: 'invalid offspring shape' });
+      res.json({ added: entry });
+    } catch (err) {
+      next(err);
+    }
+  });
+
   // ─── Sprint D — Lineage chain + Tribe emergent ─────────────────────
   // Tribe = lineage_id chain con >= 3 members. Process-scoped registry
   // popolato da recordOffspring() (Sprint C wire). Documented in
@@ -232,4 +318,11 @@ function createMetaRouter(opts = {}) {
   return router;
 }
 
-module.exports = { createMetaRouter };
+// Test surface — reset module-level YAML caches between tests.
+function _resetCachesForTest() {
+  _compatTableCache = null;
+  _matingSchemaCache = null;
+  _mutationCatalogCache = null;
+}
+
+module.exports = { createMetaRouter, _resetCachesForTest };

--- a/apps/backend/services/metaProgression.js
+++ b/apps/backend/services/metaProgression.js
@@ -34,6 +34,7 @@ const MATING_THRESHOLD = 12; // DC base
 function createMetaTracker() {
   const npcs = new Map();
   const nest = { level: 0, biome: null, requirements_met: false };
+  const offspringRegistry = []; // Sprint C — list of offspring spec from rollMatingOffspring
 
   function getOrCreate(npcId) {
     if (!npcs.has(npcId)) {
@@ -144,6 +145,27 @@ function createMetaTracker() {
     return { ...nest };
   }
 
+  // Sprint C — squad-mate offspring roll (MHS 3-tier).
+  // Distinct from `rollMating(npcId, partyMember)` (NPC pair-bond DC roll).
+  function rollOffspring({ parentA, parentB, biomeId, context = {} } = {}) {
+    const result = rollMatingOffspring({ parentA, parentB, biomeId, context });
+    if (result.success && result.offspring) {
+      offspringRegistry.push({ ...result.offspring, created_at: Date.now() });
+    }
+    return result;
+  }
+
+  function listOffspring() {
+    return offspringRegistry.map((o) => ({ ...o }));
+  }
+
+  function addOffspring(offspring) {
+    if (!offspring || typeof offspring !== 'object') return null;
+    const entry = { ...offspring, added_at: Date.now() };
+    offspringRegistry.push(entry);
+    return entry;
+  }
+
   return {
     updateAffinity,
     updateTrust,
@@ -155,6 +177,9 @@ function createMetaTracker() {
     tickCooldowns,
     listNpcs,
     getNest,
+    rollOffspring,
+    listOffspring,
+    addOffspring,
   };
 }
 
@@ -207,6 +232,303 @@ function parseJsonArray(raw) {
     return [];
   }
 }
+
+// ─── Sprint C — Offspring rollMating (MHS 3-tier visual feedback) ────────
+//
+// Pattern Monster Hunter Stories 3 genetics: offspring inherits 2 gene slots
+// (one per parent, weighted by inheritance_weight) + 1 environmental mutation
+// pulled from biome filter. Tier (no-glow/gold/rainbow) determines visual
+// feedback + bonus traits for offspring.
+//
+// Mating mutation = Layer 2 (offspring) ≠ Layer 1 self-encounter mutation
+// (M14 mutation_catalog). Layer 2 uses Layer 1 catalog filtered by biome
+// where mating happened.
+//
+// Refs:
+// - data/core/mating.yaml § gene_slots inheritance_rules
+// - data/core/mutations/mutation_catalog.yaml (M14, biome_boost field)
+// - docs/core/Mating-Reclutamento-Nido.md § Ereditarietà & Mutazioni
+
+const TIER_NO_GLOW = 'no-glow';
+const TIER_GOLD = 'gold';
+const TIER_RAINBOW = 'rainbow';
+
+const TIER_VISUAL_HINTS = {
+  [TIER_NO_GLOW]: { border_color: '#2a3040', glow: false, particles: false, sfx: 'tier_common' },
+  [TIER_GOLD]: { border_color: '#ffd180', glow: true, particles: false, sfx: 'tier_gold' },
+  [TIER_RAINBOW]: {
+    border_color: 'rainbow',
+    glow: true,
+    particles: true,
+    sfx: 'tier_rainbow',
+  },
+};
+
+/**
+ * Deterministic lineage_id from two parent ids.
+ * Format: lineage_<8-hex-prefix> derived from sorted-pair hash so order
+ * doesn't matter (parent_a + parent_b == parent_b + parent_a).
+ */
+function makeLineageId(parentAId, parentBId) {
+  const a = String(parentAId || '');
+  const b = String(parentBId || '');
+  const pair = [a, b].sort().join('|');
+  // FNV-1a-like 32-bit folding hash (deterministic, no external deps).
+  let h = 0x811c9dc5;
+  for (let i = 0; i < pair.length; i++) {
+    h ^= pair.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  const hex = h.toString(16).padStart(8, '0');
+  return `lineage_${hex}`;
+}
+
+/**
+ * Pick gene slots inherited from each parent.
+ * Each parent contributes 1 slot, weighted by slot inheritance_weight if available.
+ *
+ * @param {object} parentA — { id, gene_slots?: Array<{slot_id, value}> }
+ * @param {object} parentB
+ * @param {object} geneSlotsSchema — data/core/mating.yaml gene_slots
+ * @param {function} rng
+ * @returns {Array<{from: string, slot_id, value, label_it?, category}>}
+ */
+function inheritGeneSlots(parentA, parentB, geneSlotsSchema = {}, rng = Math.random) {
+  const inherited = [];
+  for (const [parentLabel, parent] of [
+    ['parent_a', parentA],
+    ['parent_b', parentB],
+  ]) {
+    const slots = Array.isArray(parent?.gene_slots) ? parent.gene_slots : [];
+    if (slots.length === 0) {
+      // No gene_slots on parent — fallback to a synthetic slot derived from parent id.
+      inherited.push({
+        from: parentLabel,
+        slot_id: 'corpo',
+        value: parent?.id || parentLabel,
+        category: 'struttura',
+      });
+      continue;
+    }
+    // Weighted random pick by inheritance_weight (default 0.5 if missing).
+    const weights = slots.map((s) => {
+      const meta = lookupSlotMeta(geneSlotsSchema, s.slot_id);
+      return Math.max(0.05, Number(meta?.inheritance_weight ?? 0.5));
+    });
+    const totalW = weights.reduce((a, b) => a + b, 0);
+    let pick = rng() * totalW;
+    let chosenIdx = 0;
+    for (let i = 0; i < weights.length; i++) {
+      pick -= weights[i];
+      if (pick <= 0) {
+        chosenIdx = i;
+        break;
+      }
+    }
+    const slot = slots[chosenIdx];
+    const meta = lookupSlotMeta(geneSlotsSchema, slot.slot_id);
+    inherited.push({
+      from: parentLabel,
+      slot_id: slot.slot_id,
+      value: slot.value,
+      label_it: meta?.label_it || slot.slot_id,
+      category: meta?.category || 'struttura',
+    });
+  }
+  return inherited;
+}
+
+function lookupSlotMeta(geneSlotsSchema, slotId) {
+  const cats = geneSlotsSchema?.categories || {};
+  for (const [catKey, cat] of Object.entries(cats)) {
+    const slots = cat?.slots || [];
+    for (const s of slots) {
+      if (s.id === slotId) {
+        return { ...s, category: catKey };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Pick 1 environmental mutation filtered by biome_id_at_mating.
+ *
+ * Strategy:
+ *   1. If mutationCatalog is provided AND has entries with biome_boost matching:
+ *      pick weighted-random from those (prefer rare > advanced > base by tier).
+ *   2. Otherwise fallback: pick from biomeTraitsPool (random trait id).
+ *
+ * Returns: { id, type: 'mutation'|'trait', tier: 0|1|2|null, biome_id, source }.
+ */
+function pickEnvironmentalMutation({
+  biomeId,
+  mutationCatalog = null,
+  biomeTraitsPool = [],
+  rng = Math.random,
+}) {
+  // Prefer real mutation catalog entries matching biome.
+  if (mutationCatalog && typeof mutationCatalog === 'object') {
+    const byId = mutationCatalog.byId || {};
+    const matches = [];
+    for (const [id, entry] of Object.entries(byId)) {
+      const boostList = Array.isArray(entry?.biome_boost) ? entry.biome_boost : [];
+      if (biomeId && boostList.includes(biomeId)) {
+        matches.push({ id, entry });
+      }
+    }
+    if (matches.length > 0) {
+      const picked = matches[Math.floor(rng() * matches.length)];
+      const tier = Number(picked.entry?.tier ?? 1);
+      return {
+        id: picked.id,
+        type: 'mutation',
+        tier,
+        biome_id: biomeId || null,
+        source: 'mutation_catalog',
+        name_it: picked.entry?.name_it || picked.id,
+      };
+    }
+  }
+  // Fallback: random trait from biome pool.
+  if (Array.isArray(biomeTraitsPool) && biomeTraitsPool.length > 0) {
+    const traitId = biomeTraitsPool[Math.floor(rng() * biomeTraitsPool.length)];
+    return {
+      id: traitId,
+      type: 'trait',
+      tier: null,
+      biome_id: biomeId || null,
+      source: 'biome_trait_pool',
+      name_it: traitId,
+    };
+  }
+  // Empty fallback (no catalog + no pool).
+  return {
+    id: null,
+    type: 'none',
+    tier: null,
+    biome_id: biomeId || null,
+    source: 'fallback_empty',
+    name_it: null,
+  };
+}
+
+/**
+ * Compute offspring tier (no-glow / gold / rainbow).
+ *
+ * Rules (MHS pattern):
+ * - GOLD: gene_slot match (both inherited slots have same slot_id).
+ * - RAINBOW: environmental_mutation tier === 2 (rare in mutation_catalog).
+ * - NO-GLOW: default common offspring.
+ *
+ * Stochastic edge:
+ * - If neither match, tier remains no-glow (~70%); roll a small random for
+ *   rainbow/gold downgrade tolerance is unnecessary because gates are deterministic.
+ */
+function computeOffspringTier({ inheritedSlots, environmentalMutation }) {
+  const a = inheritedSlots?.[0];
+  const b = inheritedSlots?.[1];
+  const slotMatch = Boolean(a && b && a.slot_id === b.slot_id);
+  const mutTier = Number(environmentalMutation?.tier ?? -1);
+  const isRareMutation = environmentalMutation?.type === 'mutation' && mutTier >= 2;
+
+  if (isRareMutation) return TIER_RAINBOW;
+  if (slotMatch) return TIER_GOLD;
+  return TIER_NO_GLOW;
+}
+
+function tierBonusTraits(tier) {
+  if (tier === TIER_GOLD) return 1;
+  if (tier === TIER_RAINBOW) return 2;
+  return 0;
+}
+
+/**
+ * Sprint C — Roll mating offspring spec.
+ *
+ * Distinct from `rollMating(npcId, partyMember)` (NPC pair-bond MBTI compat
+ * d20 check). This is the **squad-mate roll**: parent_a + parent_b are two
+ * creatures of the player's squad, biome at mating decides environmental
+ * mutation flavor, output is full offspring spec with tier visual feedback.
+ *
+ * @param {object} input
+ * @param {object} input.parentA — { id, mbti_type?, trait_ids?, gene_slots? }
+ * @param {object} input.parentB — { id, mbti_type?, trait_ids?, gene_slots? }
+ * @param {string} input.biomeId
+ * @param {object} [input.context]
+ * @param {object} [input.context.geneSlotsSchema] — data/core/mating.yaml gene_slots
+ * @param {object} [input.context.mutationCatalog] — optional M14 catalog (loadMutationCatalog())
+ * @param {Array<string>} [input.context.biomeTraitsPool]
+ * @param {function} [input.context.rng]
+ * @returns {object} offspring spec + tier + visual_hints
+ */
+function rollMatingOffspring({ parentA, parentB, biomeId, context = {} } = {}) {
+  if (!parentA || !parentB) {
+    throw new Error('rollMatingOffspring: parentA and parentB required');
+  }
+  if (parentA.id && parentB.id && parentA.id === parentB.id) {
+    return {
+      success: false,
+      reason: 'self_mate_prevented',
+      offspring: null,
+      tier: null,
+      visual_hints: null,
+    };
+  }
+  const rng = typeof context.rng === 'function' ? context.rng : Math.random;
+  const geneSlotsSchema = context.geneSlotsSchema || {};
+  const mutationCatalog = context.mutationCatalog || null;
+  const biomeTraitsPool = Array.isArray(context.biomeTraitsPool) ? context.biomeTraitsPool : [];
+
+  const lineageId = makeLineageId(parentA.id, parentB.id);
+  const inheritedSlots = inheritGeneSlots(parentA, parentB, geneSlotsSchema, rng);
+  const environmentalMutation = pickEnvironmentalMutation({
+    biomeId,
+    mutationCatalog,
+    biomeTraitsPool,
+    rng,
+  });
+  const tier = computeOffspringTier({ inheritedSlots, environmentalMutation });
+  const bonusTraits = tierBonusTraits(tier);
+
+  // Compose bonus traits list from union of parent trait pools, picked random,
+  // exclusive of duplicates already in environmental_mutation.id.
+  const parentTraitsAll = [
+    ...new Set([
+      ...(Array.isArray(parentA.trait_ids) ? parentA.trait_ids : []),
+      ...(Array.isArray(parentB.trait_ids) ? parentB.trait_ids : []),
+    ]),
+  ].filter((t) => t !== environmentalMutation?.id);
+
+  const bonus = [];
+  const available = [...parentTraitsAll];
+  for (let i = 0; i < bonusTraits && available.length > 0; i++) {
+    const idx = Math.floor(rng() * available.length);
+    bonus.push(available.splice(idx, 1)[0]);
+  }
+
+  const offspring = {
+    lineage_id: lineageId,
+    gene_slots: inheritedSlots,
+    environmental_mutation: environmentalMutation,
+    tier_bonus_traits: bonus,
+    tier,
+    predicted_lifecycle_phase: 'hatchling',
+    parent_a_id: parentA.id || null,
+    parent_b_id: parentB.id || null,
+    biome_id_at_mating: biomeId || null,
+  };
+
+  return {
+    success: true,
+    offspring,
+    tier,
+    visual_hints: TIER_VISUAL_HINTS[tier],
+  };
+}
+
+// Note: Sprint C exports are appended at the bottom of this file (after the
+// canonical `module.exports = { ... }` block) to avoid being overwritten.
 
 // ─── L06 adapter: Prisma + in-memory fallback ────────────────────────────
 
@@ -438,6 +760,34 @@ function createMetaStore({ prisma, campaignId = null } = {}) {
     };
   }
 
+  // Sprint C — Offspring registry. No Prisma model yet (P0 follow-up
+  // ADR-2026-04-21-meta-progression-prisma adds it). When usePrisma=false,
+  // delegate to fallback tracker so we have a single in-memory source of truth.
+  // When usePrisma=true, use this _offspringMem until Prisma model lands.
+  const _offspringMem = [];
+
+  async function rollOffspring(input = {}) {
+    if (!usePrisma) return fallback.rollOffspring(input);
+    const result = rollMatingOffspring(input);
+    if (result.success && result.offspring) {
+      _offspringMem.push({ ...result.offspring, created_at: Date.now() });
+    }
+    return result;
+  }
+
+  async function listOffspring() {
+    if (!usePrisma) return fallback.listOffspring();
+    return _offspringMem.map((o) => ({ ...o }));
+  }
+
+  async function addOffspring(offspring) {
+    if (!usePrisma) return fallback.addOffspring(offspring);
+    if (!offspring || typeof offspring !== 'object') return null;
+    const entry = { ...offspring, added_at: Date.now() };
+    _offspringMem.push(entry);
+    return entry;
+  }
+
   return {
     updateAffinity,
     updateTrust,
@@ -449,6 +799,9 @@ function createMetaStore({ prisma, campaignId = null } = {}) {
     tickCooldowns,
     listNpcs,
     getNest,
+    rollOffspring,
+    listOffspring,
+    addOffspring,
     // meta
     _mode: usePrisma ? 'prisma' : 'in-memory',
   };
@@ -662,3 +1015,16 @@ module.exports = {
   listLineageEntries,
   _resetLineageRegistry,
 };
+
+// ─── Sprint C — additive exports (offspring roll + tier visual feedback) ──
+// Appended after the canonical export block so existing keys aren't shadowed.
+// Sprint D and other parallel sprints can also use this additive pattern.
+module.exports.makeLineageId = makeLineageId;
+module.exports.inheritGeneSlots = inheritGeneSlots;
+module.exports.pickEnvironmentalMutation = pickEnvironmentalMutation;
+module.exports.computeOffspringTier = computeOffspringTier;
+module.exports.rollMatingOffspring = rollMatingOffspring;
+module.exports.TIER_NO_GLOW = TIER_NO_GLOW;
+module.exports.TIER_GOLD = TIER_GOLD;
+module.exports.TIER_RAINBOW = TIER_RAINBOW;
+module.exports.TIER_VISUAL_HINTS = TIER_VISUAL_HINTS;

--- a/tests/api/meta.mating.test.js
+++ b/tests/api/meta.mating.test.js
@@ -1,0 +1,123 @@
+// Sprint C — Mating roll API endpoint tests.
+// POST /api/meta/mating/roll, GET /api/meta/nest/offspring,
+// POST /api/meta/nest/add_offspring.
+//
+// In-memory fallback (no DATABASE_URL).
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+test('POST /api/meta/mating/roll 400 on missing parents', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app).post('/api/meta/mating/roll').send({}).expect(400);
+    await request(app)
+      .post('/api/meta/mating/roll')
+      .send({ parent_a: { id: 'pa' } })
+      .expect(400);
+    await request(app)
+      .post('/api/meta/mating/roll')
+      .send({ parent_a: {}, parent_b: {} })
+      .expect(400);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/meta/mating/roll returns offspring + tier + visual_hints', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app)
+      .post('/api/meta/mating/roll')
+      .send({
+        parent_a: {
+          id: 'skiv_alpha',
+          trait_ids: ['t1'],
+          gene_slots: [{ slot_id: 'corpo', value: 'agile' }],
+        },
+        parent_b: {
+          id: 'echo_beta',
+          trait_ids: ['t2'],
+          gene_slots: [{ slot_id: 'arti', value: 'forti' }],
+        },
+        biome_id: 'savana',
+      })
+      .expect(200);
+    assert.equal(res.body.success, true);
+    assert.ok(res.body.offspring);
+    assert.equal(res.body.offspring.parent_a_id, 'skiv_alpha');
+    assert.equal(res.body.offspring.parent_b_id, 'echo_beta');
+    assert.equal(res.body.offspring.biome_id_at_mating, 'savana');
+    assert.match(res.body.offspring.lineage_id, /^lineage_[0-9a-f]{8}$/);
+    assert.ok(['no-glow', 'gold', 'rainbow'].includes(res.body.tier));
+    assert.ok(res.body.visual_hints);
+    assert.equal(typeof res.body.visual_hints.glow, 'boolean');
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/meta/mating/roll prevents self-mate', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app)
+      .post('/api/meta/mating/roll')
+      .send({
+        parent_a: { id: 'self', trait_ids: [] },
+        parent_b: { id: 'self', trait_ids: [] },
+        biome_id: 'savana',
+      })
+      .expect(200);
+    assert.equal(res.body.success, false);
+    assert.equal(res.body.reason, 'self_mate_prevented');
+  } finally {
+    await close();
+  }
+});
+
+test('GET /api/meta/nest/offspring + POST /api/meta/nest/add_offspring roundtrip', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    // Initially empty.
+    const empty = await request(app).get('/api/meta/nest/offspring').expect(200);
+    assert.deepEqual(empty.body.offspring, []);
+
+    // Add one offspring.
+    const add = await request(app)
+      .post('/api/meta/nest/add_offspring')
+      .send({
+        offspring: {
+          lineage_id: 'lineage_deadbeef',
+          gene_slots: [],
+          tier: 'no-glow',
+        },
+      })
+      .expect(200);
+    assert.ok(add.body.added);
+    assert.equal(add.body.added.lineage_id, 'lineage_deadbeef');
+
+    // List shows entry.
+    const list = await request(app).get('/api/meta/nest/offspring').expect(200);
+    assert.equal(list.body.offspring.length, 1);
+    assert.equal(list.body.offspring[0].lineage_id, 'lineage_deadbeef');
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/meta/nest/add_offspring 400 on invalid body', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app).post('/api/meta/nest/add_offspring').send({}).expect(400);
+    await request(app)
+      .post('/api/meta/nest/add_offspring')
+      .send({ offspring: 'not-an-object' })
+      .expect(400);
+  } finally {
+    await close();
+  }
+});

--- a/tests/services/metaProgression.mating.test.js
+++ b/tests/services/metaProgression.mating.test.js
@@ -1,0 +1,300 @@
+// Sprint C — Mating offspring roll tests (MHS 3-tier visual feedback).
+//
+// Coverage:
+//   - lineage_id determinism (same parents = same id; order-independent)
+//   - gene_slots inheritance (1 per parent, weighted)
+//   - environmental_mutation pick (mutation_catalog vs biome trait fallback)
+//   - tier distribution (no-glow / gold / rainbow rules)
+//   - self-mate prevention
+//   - rollOffspring integration on tracker (offspring registry)
+//
+// Cross-ref:
+//   - apps/backend/services/metaProgression.js rollMatingOffspring
+//   - data/core/mating.yaml gene_slots schema
+//   - data/core/mutations/mutation_catalog.yaml
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createMetaTracker,
+  makeLineageId,
+  inheritGeneSlots,
+  pickEnvironmentalMutation,
+  computeOffspringTier,
+  rollMatingOffspring,
+  TIER_NO_GLOW,
+  TIER_GOLD,
+  TIER_RAINBOW,
+} = require('../../apps/backend/services/metaProgression');
+
+// ─── lineage_id ─────────────────────────────────────────────────────
+
+test('makeLineageId: deterministic — same input produces same id', () => {
+  const id1 = makeLineageId('skiv_alpha', 'echo_beta');
+  const id2 = makeLineageId('skiv_alpha', 'echo_beta');
+  assert.equal(id1, id2);
+  assert.match(id1, /^lineage_[0-9a-f]{8}$/);
+});
+
+test('makeLineageId: order-independent (commutative)', () => {
+  const a = makeLineageId('skiv_alpha', 'echo_beta');
+  const b = makeLineageId('echo_beta', 'skiv_alpha');
+  assert.equal(a, b);
+});
+
+test('makeLineageId: distinct parents → distinct lineage', () => {
+  const x = makeLineageId('skiv_alpha', 'echo_beta');
+  const y = makeLineageId('skiv_alpha', 'crawler_gamma');
+  assert.notEqual(x, y);
+});
+
+// ─── inheritGeneSlots ───────────────────────────────────────────────
+
+test('inheritGeneSlots: returns 2 slots, one from each parent', () => {
+  const a = { id: 'pa', gene_slots: [{ slot_id: 'corpo', value: 'agile' }] };
+  const b = { id: 'pb', gene_slots: [{ slot_id: 'arti', value: 'forti' }] };
+  const slots = inheritGeneSlots(a, b, {}, () => 0.5);
+  assert.equal(slots.length, 2);
+  assert.equal(slots[0].from, 'parent_a');
+  assert.equal(slots[1].from, 'parent_b');
+});
+
+test('inheritGeneSlots: parent without gene_slots → fallback synthetic slot', () => {
+  const a = { id: 'pa' };
+  const b = { id: 'pb' };
+  const slots = inheritGeneSlots(a, b, {}, () => 0.5);
+  assert.equal(slots.length, 2);
+  assert.ok(slots[0].slot_id);
+  assert.ok(slots[1].slot_id);
+});
+
+test('inheritGeneSlots: weighted pick honors inheritance_weight', () => {
+  // schema: corazza weight 0.8, arti weight 0.6 → corazza preferred
+  const schema = {
+    categories: {
+      struttura: {
+        slots: [
+          { id: 'corazza', label_it: 'Corazza', inheritance_weight: 0.8 },
+          { id: 'arti', label_it: 'Arti', inheritance_weight: 0.6 },
+        ],
+      },
+    },
+  };
+  const a = {
+    id: 'pa',
+    gene_slots: [
+      { slot_id: 'corazza', value: 'spessa' },
+      { slot_id: 'arti', value: 'corti' },
+    ],
+  };
+  const b = {
+    id: 'pb',
+    gene_slots: [{ slot_id: 'arti', value: 'lunghi' }],
+  };
+  // rng=0.1 (very low) → first weight slice (corazza w=0.8) selected for parent_a
+  const slots = inheritGeneSlots(a, b, schema, () => 0.1);
+  assert.equal(slots[0].slot_id, 'corazza');
+  assert.equal(slots[0].label_it, 'Corazza');
+});
+
+// ─── pickEnvironmentalMutation ──────────────────────────────────────
+
+test('pickEnvironmentalMutation: mutation_catalog match by biome', () => {
+  const catalog = {
+    byId: {
+      mut_x: { tier: 1, biome_boost: ['savana'], name_it: 'X' },
+      mut_y: { tier: 2, biome_boost: ['cryosteppe'], name_it: 'Y' },
+    },
+  };
+  const mut = pickEnvironmentalMutation({
+    biomeId: 'savana',
+    mutationCatalog: catalog,
+    rng: () => 0,
+  });
+  assert.equal(mut.id, 'mut_x');
+  assert.equal(mut.type, 'mutation');
+  assert.equal(mut.tier, 1);
+});
+
+test('pickEnvironmentalMutation: fallback to biome trait pool when no catalog match', () => {
+  const mut = pickEnvironmentalMutation({
+    biomeId: 'unknown_biome',
+    mutationCatalog: { byId: {} },
+    biomeTraitsPool: ['trait_alpha'],
+    rng: () => 0,
+  });
+  assert.equal(mut.id, 'trait_alpha');
+  assert.equal(mut.type, 'trait');
+  assert.equal(mut.source, 'biome_trait_pool');
+});
+
+test('pickEnvironmentalMutation: empty fallback when no catalog + no pool', () => {
+  const mut = pickEnvironmentalMutation({ biomeId: 'x' });
+  assert.equal(mut.id, null);
+  assert.equal(mut.type, 'none');
+});
+
+// ─── computeOffspringTier ───────────────────────────────────────────
+
+test('computeOffspringTier: GOLD when both gene slots match same slot_id', () => {
+  const tier = computeOffspringTier({
+    inheritedSlots: [
+      { slot_id: 'corpo', from: 'parent_a' },
+      { slot_id: 'corpo', from: 'parent_b' },
+    ],
+    environmentalMutation: { tier: 0 },
+  });
+  assert.equal(tier, TIER_GOLD);
+});
+
+test('computeOffspringTier: RAINBOW when env mutation tier >= 2 (rare)', () => {
+  const tier = computeOffspringTier({
+    inheritedSlots: [
+      { slot_id: 'corpo', from: 'parent_a' },
+      { slot_id: 'arti', from: 'parent_b' },
+    ],
+    environmentalMutation: { type: 'mutation', tier: 2 },
+  });
+  assert.equal(tier, TIER_RAINBOW);
+});
+
+test('computeOffspringTier: NO-GLOW default (no slot match, no rare mutation)', () => {
+  const tier = computeOffspringTier({
+    inheritedSlots: [
+      { slot_id: 'corpo', from: 'parent_a' },
+      { slot_id: 'arti', from: 'parent_b' },
+    ],
+    environmentalMutation: { type: 'mutation', tier: 1 },
+  });
+  assert.equal(tier, TIER_NO_GLOW);
+});
+
+test('computeOffspringTier: RAINBOW takes priority over GOLD', () => {
+  // Both slot match AND rare mutation → rainbow wins.
+  const tier = computeOffspringTier({
+    inheritedSlots: [
+      { slot_id: 'corpo', from: 'parent_a' },
+      { slot_id: 'corpo', from: 'parent_b' },
+    ],
+    environmentalMutation: { type: 'mutation', tier: 2 },
+  });
+  assert.equal(tier, TIER_RAINBOW);
+});
+
+// ─── rollMatingOffspring ────────────────────────────────────────────
+
+test('rollMatingOffspring: returns full offspring spec', () => {
+  const result = rollMatingOffspring({
+    parentA: { id: 'pa', trait_ids: ['t1'], gene_slots: [{ slot_id: 'corpo', value: 'a' }] },
+    parentB: { id: 'pb', trait_ids: ['t2'], gene_slots: [{ slot_id: 'arti', value: 'b' }] },
+    biomeId: 'savana',
+    context: { rng: () => 0.5 },
+  });
+  assert.equal(result.success, true);
+  assert.ok(result.offspring);
+  assert.equal(result.offspring.parent_a_id, 'pa');
+  assert.equal(result.offspring.parent_b_id, 'pb');
+  assert.equal(result.offspring.biome_id_at_mating, 'savana');
+  assert.equal(result.offspring.predicted_lifecycle_phase, 'hatchling');
+  assert.match(result.offspring.lineage_id, /^lineage_[0-9a-f]{8}$/);
+  assert.equal(result.offspring.gene_slots.length, 2);
+  assert.ok(result.visual_hints);
+  assert.ok(['no-glow', 'gold', 'rainbow'].includes(result.tier));
+});
+
+test('rollMatingOffspring: prevents self-mate (parentA.id == parentB.id)', () => {
+  const result = rollMatingOffspring({
+    parentA: { id: 'self' },
+    parentB: { id: 'self' },
+    biomeId: 'savana',
+  });
+  assert.equal(result.success, false);
+  assert.equal(result.reason, 'self_mate_prevented');
+});
+
+test('rollMatingOffspring: throws on missing parents', () => {
+  assert.throws(() => rollMatingOffspring({ parentA: null, parentB: { id: 'b' } }));
+  assert.throws(() => rollMatingOffspring({}));
+});
+
+test('rollMatingOffspring: gold tier when inherited slots same slot_id', () => {
+  // Both parents only have 'corpo' slot → both inherited slots will be 'corpo'.
+  const result = rollMatingOffspring({
+    parentA: { id: 'pa', gene_slots: [{ slot_id: 'corpo', value: 'a' }] },
+    parentB: { id: 'pb', gene_slots: [{ slot_id: 'corpo', value: 'b' }] },
+    biomeId: 'savana',
+    context: { rng: () => 0.5, mutationCatalog: { byId: {} } },
+  });
+  assert.equal(result.success, true);
+  assert.equal(result.tier, TIER_GOLD);
+  assert.ok(result.offspring.tier_bonus_traits.length >= 0);
+});
+
+test('rollMatingOffspring: rainbow tier when env mutation is rare', () => {
+  const catalog = {
+    byId: {
+      mut_rare: { tier: 2, biome_boost: ['cryosteppe'], name_it: 'Rare X' },
+    },
+  };
+  const result = rollMatingOffspring({
+    parentA: {
+      id: 'pa',
+      trait_ids: ['t1', 't2', 't3'],
+      gene_slots: [{ slot_id: 'corpo', value: 'a' }],
+    },
+    parentB: {
+      id: 'pb',
+      trait_ids: ['t4', 't5'],
+      gene_slots: [{ slot_id: 'arti', value: 'b' }],
+    },
+    biomeId: 'cryosteppe',
+    context: { mutationCatalog: catalog, rng: () => 0.5 },
+  });
+  assert.equal(result.tier, TIER_RAINBOW);
+  assert.equal(result.offspring.environmental_mutation.id, 'mut_rare');
+  // Rainbow → +2 bonus traits
+  assert.equal(result.offspring.tier_bonus_traits.length, 2);
+});
+
+// ─── tracker.rollOffspring integration ──────────────────────────────
+
+test('tracker.rollOffspring: appends offspring to registry on success', () => {
+  const tracker = createMetaTracker();
+  const result = tracker.rollOffspring({
+    parentA: { id: 'pa', gene_slots: [{ slot_id: 'corpo', value: 'a' }] },
+    parentB: { id: 'pb', gene_slots: [{ slot_id: 'arti', value: 'b' }] },
+    biomeId: 'savana',
+    context: { rng: () => 0.5 },
+  });
+  assert.equal(result.success, true);
+  const list = tracker.listOffspring();
+  assert.equal(list.length, 1);
+  assert.equal(list[0].parent_a_id, 'pa');
+  assert.ok(list[0].created_at);
+});
+
+test('tracker.rollOffspring: self_mate does NOT append offspring', () => {
+  const tracker = createMetaTracker();
+  const result = tracker.rollOffspring({
+    parentA: { id: 'self' },
+    parentB: { id: 'self' },
+    biomeId: 'savana',
+  });
+  assert.equal(result.success, false);
+  assert.equal(tracker.listOffspring().length, 0);
+});
+
+test('tracker.addOffspring: appends external offspring entry', () => {
+  const tracker = createMetaTracker();
+  const entry = tracker.addOffspring({
+    lineage_id: 'lineage_deadbeef',
+    gene_slots: [],
+    tier: 'no-glow',
+  });
+  assert.ok(entry);
+  assert.ok(entry.added_at);
+  assert.equal(tracker.listOffspring().length, 1);
+});


### PR DESCRIPTION
## Summary

Re-apply Sprint C **backend only** (rollMatingOffspring + 3 REST endpoints) cleanly on top of main. Original PR #1877 deferred per user decision 2026-04-27 sera because of frontend `nestHub.js` Mating tab conflict vs Sprint A scaffold tab structure. Backend Sprint C is independent + valuable + non-conflicting → fresh PR.

- **3 new endpoints**: `POST /api/meta/mating/roll`, `GET /api/meta/nest/offspring`, `POST /api/meta/nest/add_offspring` (mounted at both `/api/meta` and `/api/v1/meta` via `pluginLoader`)
- **MHS 3-tier genetics pattern**: deterministic `lineage_id` (FNV-1a hash of sorted parent pair), weighted `inheritGeneSlots` (per `data/core/mating.yaml gene_slots.inheritance_weight`), biome-filtered `pickEnvironmentalMutation` from `mutation_catalog.yaml`, tier priority `rainbow` (env tier ≥2) > `gold` (slot match) > `no-glow`
- **Append-only pattern** (precedente Sprint D): Sprint C exports under canonical `module.exports` block to preserve Sprint B/D exports intact
- **Schema deps verified runtime on main**: `mating.yaml gene_slots` (line 388), `mutation_catalog.yaml` (782 LOC), `mutationCatalogLoader.js` already present — zero new YAML/schema files

## Files changed

- `apps/backend/services/metaProgression.js` (additive: +366 LOC, append-only exports)
- `apps/backend/routes/meta.js` (additive: +95 LOC, lazy schema loaders + 3 endpoints + `_resetCachesForTest`)
- `tests/services/metaProgression.mating.test.js` (NEW, 21 test)
- `tests/api/meta.mating.test.js` (NEW, 5 test)

## Skipped — deferred to follow-up sprint

- `apps/play/src/nestHub.js` Mating tab UI fill (conflict frontend Sprint A)
- `apps/play/src/api.js` Mating client methods
- `tests/play/nestHub.mating.test.js`

## Test plan

- [x] `node --test tests/services/metaProgression.mating.test.js` → 21/21 verde (lineage_id determinism, gene_slots weighted, env mutation pick, tier rules, self-mate prevention, tracker integration)
- [x] `node --test tests/api/meta.mating.test.js` → 5/5 verde (REST endpoint smoke + 400 validation + roundtrip + self-mate)
- [x] `node --test tests/services/metaProgression.lineage.test.js` (Sprint D regression) → 18/18 verde
- [x] `node --test tests/api/metaRecruit.test.js tests/api/meta.lineage.test.js tests/api/metaRoutes.test.js tests/api/debriefPanelRecruit.test.js` → 32/32 verde (Sprint B + Sprint D + others)
- [x] `node --test tests/ai/*.test.js` → 311/311 AI regression verde
- [x] `npm run format:check` → All matched files use Prettier code style!
- [x] `git diff` self-review: 460 insertions, 1 deletion (just export-line replacement to add `_resetCachesForTest`); zero touches to Sprint A/B/D files

## DoD checklist

- [x] `metaProgression.rollMatingOffspring` exported (append-only, line ~858)
- [x] 3 REST endpoint live: `/mating/roll`, `/nest/offspring`, `/nest/add_offspring`
- [x] 26 backend test new (21 service + 5 API) verdi
- [x] AI regression 311/311 verde
- [x] `format:check` verde
- [x] PR opened against `main`
- [x] PR cita #1877 deferred frontend

## Notes for reviewer

- **Schema compatibility con Sprint D `recordOffspring()`**: Sprint C output is `{lineage_id, gene_slots, environmental_mutation, tier, parent_a_id, parent_b_id, biome_id_at_mating, predicted_lifecycle_phase}`. Sprint D `recordOffspring()` aspetta `{unit_id, lineage_id, parents:[a,b], born_at_session, born_at_biome}`. **Adapter wire NOT in this PR** (Sprint C source code didn't include it; out of scope for backend-only re-apply). Suggested follow-up: bridge function in `routes/meta.js POST /mating/roll` that, after `rollOffspring` success, also calls `recordOffspring({unit_id: lineage_id+'_offspring_N', lineage_id, parents:[parent_a_id,parent_b_id], born_at_biome: biome_id_at_mating})` to populate Sprint D registry. Lascio open per design call.
- **Prisma persistence**: `_offspringMem` in-memory only (no `OffspringSpec` Prisma model). ADR-2026-04-21-meta-progression-prisma follow-up tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)