### PR TITLE
feat(skiv): S1 polish Phase 1 — companion state schema + persistence

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -46,6 +46,7 @@ const {
   traitMechanicsSchema,
   glossarySchema,
   narrativeSchema,
+  skivCompanionSchema,
 } = require('@game/contracts');
 const qualitySuggestionSchema = require('../../schemas/quality/suggestion.schema.json');
 const qualitySuggestionApplySchema = require('../../schemas/quality/suggestions-apply-request.schema.json');
@@ -354,6 +355,11 @@ function createApp(options = {}) {
   schemaValidator.registerSchema(
     speciesBiomesSchema.$id || 'contract://atlas/species-biomes',
     speciesBiomesSchema,
+  );
+  // S1 polish Phase 1 — Skiv portable companion (ADR-2026-04-27).
+  schemaValidator.registerSchema(
+    skivCompanionSchema.$id || 'contract://skiv/companion',
+    skivCompanionSchema,
   );
 
   function validateWithSchema(payload, schemaId) {

--- a/apps/backend/prisma/migrations/0006_skiv_companion_state/migration.sql
+++ b/apps/backend/prisma/migrations/0006_skiv_companion_state/migration.sql
@@ -1,0 +1,19 @@
+-- S1 polish Phase 1 — Skiv portable companion state (ADR-2026-04-27).
+-- Schema additive 0.1.0 → 0.2.0. Adapter preserves in-memory fallback when
+-- DATABASE_URL unset (dev/demo/tests). Privacy whitelist enforced app-level
+-- in apps/backend/services/skiv/companionStateStore.js.
+-- Scope: portable Skiv card state, share URL, crossbreed history, voice diary.
+
+-- CreateTable
+CREATE TABLE "skiv_companion_states" (
+    "lineage_id" TEXT NOT NULL,
+    "schema_version" TEXT NOT NULL DEFAULT '0.2.0',
+    "signature" TEXT,
+    "crossbreed_history" JSONB NOT NULL DEFAULT '[]',
+    "voice_diary_portable" JSONB NOT NULL DEFAULT '[]',
+    "share_url" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "skiv_companion_states_pkey" PRIMARY KEY ("lineage_id")
+);

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -306,6 +306,25 @@ model LobbyPlayer {
   @@map("lobby_players")
 }
 
+// ─── S1 polish Phase 1 — Skiv portable companion state (ADR-2026-04-27) ────
+// Promotes companionStateStore in-memory Map → DB-backed write-through cache.
+// Adapter preserves in-memory fallback when DATABASE_URL unset.
+// Scope: portable Skiv card state, share URL, crossbreed history, voice diary.
+// Privacy: NO PII fields persisted (whitelist enforced server-side in store).
+
+model SkivCompanionState {
+  lineageId          String   @id @map("lineage_id")
+  schemaVersion      String   @default("0.2.0") @map("schema_version")
+  signature          String?  // sha256 hex (64 chars) of canonical-JSON whitelist
+  crossbreedHistory  Json     @default("[]") @map("crossbreed_history")
+  voiceDiaryPortable Json     @default("[]") @map("voice_diary_portable")
+  shareUrl           String?  @map("share_url")
+  createdAt          DateTime @default(now()) @map("created_at")
+  updatedAt          DateTime @updatedAt @map("updated_at")
+
+  @@map("skiv_companion_states")
+}
+
 model MatingEvent {
   id              String      @id @default(uuid())
   relationId      String      @map("relation_id")

--- a/apps/backend/services/skiv/companionStateStore.js
+++ b/apps/backend/services/skiv/companionStateStore.js
@@ -1,0 +1,449 @@
+// S1 polish Phase 1 — Skiv portable companion state store.
+//
+// In-memory storage (Map keyed by lineage_id) + optional Prisma write-through
+// (when DATABASE_URL set + prisma.skivCompanionState delegate present).
+//
+// Privacy: schema whitelist enforced at saveCompanionState() — PII fields
+// (session_id, hp_current, sg_current, _notes, etc.) are stripped pre-persist.
+// Signature recomputed server-side from canonical-JSON whitelist.
+//
+// Cap policy: max 10 ambassador per Nido (Q5 default). FIFO eviction at 11th add.
+//
+// References:
+//   - ADR-2026-04-27 §A schema, §D privacy whitelist, §C cap policy.
+//   - Pattern: apps/backend/services/forms/formSessionStore.js (M12 Phase D).
+
+'use strict';
+
+const crypto = require('node:crypto');
+
+// Defaults Q4-Q8 (master-dd 2026-04-27 sera, accept-all-defaults).
+const AMBASSADOR_CAP_PER_NIDO = 10;
+const VOICE_DIARY_MAX_ENTRIES = 5;
+const CROSSBREED_HISTORY_MAX_ENTRIES = 10;
+const CURRENT_SCHEMA_VERSION = '0.2.0';
+
+// Whitelist campi share-safe per signature + persistenza (ADR §D).
+// NON includere: session_id, hp_current, sg_current, pressure_tier, ap_current,
+// _notes, IP origine, user email/username, diary[] full, partner_card_url.
+const WHITELIST_TOP_FIELDS = Object.freeze([
+  'schema_version',
+  'unit_id',
+  'species_id',
+  'biome_id',
+  'lineage_id',
+  'companion_card_signature',
+  'mbti_axes',
+  'progression',
+  'cabinet',
+  'mutations',
+  'aspect',
+  'crossbreed_history',
+  'voice_diary_portable',
+  'share_url',
+  'generated_at',
+]);
+
+// Blacklist explicit (defense-in-depth — anything not in whitelist is dropped,
+// blacklist is for documentation + extra-strict guard for known PII keys).
+const BLACKLIST_FIELDS = Object.freeze([
+  'session_id',
+  'hp_current',
+  'sg_current',
+  'pressure_tier',
+  'ap_current',
+  '_notes',
+  'ip_address',
+  'email',
+  'username',
+  'user_id',
+  'diary',
+  'partner_card_url',
+  'telemetry',
+]);
+
+/**
+ * Detect if Prisma client exposes the SkivCompanionState delegate.
+ * Stub client doesn't expose it → fallback in-memory only.
+ */
+function prismaSupportsSkivCompanion(prisma) {
+  return Boolean(
+    prisma &&
+      prisma.skivCompanionState &&
+      typeof prisma.skivCompanionState.upsert === 'function' &&
+      typeof prisma.skivCompanionState.findUnique === 'function',
+  );
+}
+
+/**
+ * Sanitize state object, stripping any keys outside the whitelist or
+ * explicitly in blacklist. Returns a NEW object (no mutation).
+ */
+function sanitizeWhitelist(state) {
+  if (!state || typeof state !== 'object') {
+    throw new TypeError('sanitizeWhitelist: state object required');
+  }
+  const out = {};
+  for (const key of WHITELIST_TOP_FIELDS) {
+    if (key in state && state[key] !== undefined) {
+      out[key] = state[key];
+    }
+  }
+  // Defensive: in-development drift guard. Throw if a known PII key sneaks in.
+  for (const black of BLACKLIST_FIELDS) {
+    if (black in state) {
+      // We don't throw — we silently drop. Logging optional via constructor logger.
+      // Drop guarantees PII never reaches signature compute or persisted store.
+    }
+  }
+  return out;
+}
+
+/**
+ * Canonical-JSON serialization for deterministic signature.
+ * Sort object keys recursively, stringify with no whitespace.
+ */
+function canonicalJson(value) {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return '[' + value.map((v) => canonicalJson(v)).join(',') + ']';
+  }
+  const keys = Object.keys(value).sort();
+  const parts = keys.map((k) => JSON.stringify(k) + ':' + canonicalJson(value[k]));
+  return '{' + parts.join(',') + '}';
+}
+
+/**
+ * Deterministic sha256 signature over whitelist subset.
+ * Excludes companion_card_signature itself (chicken-and-egg).
+ */
+function signatureFor(state) {
+  if (!state || typeof state !== 'object') {
+    throw new TypeError('signatureFor: state object required');
+  }
+  const sanitized = sanitizeWhitelist(state);
+  // Strip the signature itself before computing — otherwise the hash would
+  // depend on its own previous value.
+  const { companion_card_signature: _ignore, ...payload } = sanitized;
+  void _ignore;
+  const canonical = canonicalJson(payload);
+  return crypto.createHash('sha256').update(canonical, 'utf8').digest('hex');
+}
+
+/**
+ * Migrate a legacy 0.1.x state to 0.2.0 in-memory shape (backward-compat reader).
+ * Does NOT persist or mutate disk file — caller may choose to re-save.
+ *
+ * Strategy:
+ *   - Pin schema_version to 0.2.0
+ *   - Derive lineage_id from _notes sentinel or fallback unit_id
+ *   - Initialize crossbreed_history=[], voice_diary_portable=[], share_url=null
+ *   - companion_card_signature: null (caller must recompute via signatureFor)
+ */
+function migrateLegacyState(state) {
+  if (!state || typeof state !== 'object') {
+    throw new TypeError('migrateLegacyState: state object required');
+  }
+  const lineageId =
+    state.lineage_id || `skiv-${state.biome_id || 'unknown'}-legacy-${state.unit_id || 'anon'}`;
+  return {
+    ...state,
+    schema_version: CURRENT_SCHEMA_VERSION,
+    lineage_id: lineageId,
+    companion_card_signature: state.companion_card_signature || null,
+    crossbreed_history: Array.isArray(state.crossbreed_history) ? state.crossbreed_history : [],
+    voice_diary_portable: Array.isArray(state.voice_diary_portable)
+      ? state.voice_diary_portable
+      : [],
+    share_url: state.share_url || null,
+  };
+}
+
+function isLegacySchema(state) {
+  if (!state || typeof state !== 'object') return false;
+  const v = state.schema_version;
+  if (typeof v !== 'string') return true;
+  return /^0\.1\./.test(v);
+}
+
+/**
+ * Validate state against schema invariants used at save-time.
+ * Pure check — does not mutate. Throws on violation.
+ *
+ * Note: full AJV validation is the caller's responsibility (registered in
+ * apps/backend/app.js). This adapter enforces only contract invariants
+ * critical to persistence integrity (cap, types, required fields).
+ */
+function assertValid(state) {
+  if (!state || typeof state !== 'object') {
+    throw new TypeError('saveCompanionState: state object required');
+  }
+  if (typeof state.schema_version !== 'string') {
+    throw new Error('saveCompanionState: schema_version (string) required');
+  }
+  if (!/^0\.2\./.test(state.schema_version)) {
+    throw new Error(
+      `saveCompanionState: schema_version must be 0.2.x, got ${state.schema_version}. Run migrateLegacyState() first.`,
+    );
+  }
+  if (typeof state.lineage_id !== 'string' || state.lineage_id.length < 4) {
+    throw new Error('saveCompanionState: lineage_id (string, min 4 chars) required');
+  }
+  if (
+    Array.isArray(state.crossbreed_history) &&
+    state.crossbreed_history.length > CROSSBREED_HISTORY_MAX_ENTRIES
+  ) {
+    throw new Error(
+      `saveCompanionState: crossbreed_history exceeds cap ${CROSSBREED_HISTORY_MAX_ENTRIES}`,
+    );
+  }
+  if (
+    Array.isArray(state.voice_diary_portable) &&
+    state.voice_diary_portable.length > VOICE_DIARY_MAX_ENTRIES
+  ) {
+    throw new Error(
+      `saveCompanionState: voice_diary_portable exceeds cap ${VOICE_DIARY_MAX_ENTRIES}`,
+    );
+  }
+}
+
+/**
+ * Apply FIFO eviction to an append-bounded array.
+ * Returns a new array bounded to maxSize (oldest entries dropped).
+ */
+function fifoBounded(arr, maxSize) {
+  if (!Array.isArray(arr) || arr.length <= maxSize) return arr || [];
+  return arr.slice(arr.length - maxSize);
+}
+
+function fromPrismaRow(row) {
+  return {
+    schema_version: row.schemaVersion || CURRENT_SCHEMA_VERSION,
+    lineage_id: row.lineageId,
+    companion_card_signature: row.signature || null,
+    crossbreed_history: parseJsonSafe(row.crossbreedHistory) || [],
+    voice_diary_portable: parseJsonSafe(row.voiceDiaryPortable) || [],
+    share_url: row.shareUrl || null,
+  };
+}
+
+function parseJsonSafe(raw) {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw === 'object') return raw; // Prisma JSONB → already object
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Factory for the companion state store.
+ *
+ * @param {object} [opts]
+ * @param {object} [opts.prisma] — Prisma client (write-through if delegate present)
+ * @param {object} [opts.logger] — logger fallback to console
+ * @param {number} [opts.ambassadorCap] — override default 10
+ */
+function createCompanionStateStore(opts = {}) {
+  const states = new Map(); // lineage_id → state
+  // FIFO insertion order for cap eviction (Map preserves insertion order in JS).
+  const usePrisma = prismaSupportsSkivCompanion(opts.prisma);
+  const log = opts.logger || console;
+  const ambassadorCap = Number.isFinite(opts.ambassadorCap)
+    ? opts.ambassadorCap
+    : AMBASSADOR_CAP_PER_NIDO;
+
+  function persistAsync(state) {
+    if (!usePrisma) return;
+    const data = {
+      lineageId: state.lineage_id,
+      schemaVersion: state.schema_version,
+      signature: state.companion_card_signature || null,
+      crossbreedHistory: state.crossbreed_history || [],
+      voiceDiaryPortable: state.voice_diary_portable || [],
+      shareUrl: state.share_url || null,
+    };
+    opts.prisma.skivCompanionState
+      .upsert({
+        where: { lineageId: state.lineage_id },
+        create: data,
+        update: {
+          schemaVersion: data.schemaVersion,
+          signature: data.signature,
+          crossbreedHistory: data.crossbreedHistory,
+          voiceDiaryPortable: data.voiceDiaryPortable,
+          shareUrl: data.shareUrl,
+        },
+      })
+      .catch((err) => {
+        log.warn?.(
+          `[companionStateStore] prisma upsert failed for ${state.lineage_id}:`,
+          err?.message || err,
+        );
+      });
+  }
+
+  async function hydrateAsync(lineageId) {
+    if (!usePrisma) return null;
+    try {
+      const row = await opts.prisma.skivCompanionState.findUnique({ where: { lineageId } });
+      if (!row) return null;
+      const state = fromPrismaRow(row);
+      states.set(lineageId, state);
+      return state;
+    } catch (err) {
+      log.warn?.(
+        `[companionStateStore] prisma hydrate failed for ${lineageId}:`,
+        err?.message || err,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Get a companion state by lineage_id. Returns null when not present.
+   * Returns a deep-ish copy (top-level + arrays cloned) to prevent
+   * accidental external mutation.
+   */
+  function getCompanionState(lineageId) {
+    if (!lineageId || typeof lineageId !== 'string') return null;
+    const state = states.get(lineageId);
+    if (!state) return null;
+    return {
+      ...state,
+      crossbreed_history: [...(state.crossbreed_history || [])],
+      voice_diary_portable: [...(state.voice_diary_portable || [])],
+    };
+  }
+
+  /**
+   * Save a companion state. Validates schema invariants, sanitizes whitelist,
+   * recomputes signature server-side, applies cap eviction, persists.
+   *
+   * Returns the canonical stored state (with computed signature).
+   */
+  function saveCompanionState(rawState) {
+    // Step 1: schema_version migrate-if-legacy.
+    const stateInput = isLegacySchema(rawState) ? migrateLegacyState(rawState) : rawState;
+    // Step 2: assert invariants.
+    assertValid(stateInput);
+    // Step 3: sanitize whitelist (drop any PII keys present).
+    const sanitized = sanitizeWhitelist(stateInput);
+    // Defaults for optional arrays.
+    sanitized.crossbreed_history = fifoBounded(
+      sanitized.crossbreed_history || [],
+      CROSSBREED_HISTORY_MAX_ENTRIES,
+    );
+    sanitized.voice_diary_portable = fifoBounded(
+      sanitized.voice_diary_portable || [],
+      VOICE_DIARY_MAX_ENTRIES,
+    );
+    sanitized.share_url = sanitized.share_url ?? null;
+    // Step 4: compute signature server-side (ignore any client-supplied value).
+    sanitized.companion_card_signature = signatureFor(sanitized);
+    // Step 5: ambassador cap FIFO eviction (per Nido = global registry, default 10).
+    if (!states.has(sanitized.lineage_id) && states.size >= ambassadorCap) {
+      const oldestKey = states.keys().next().value;
+      if (oldestKey !== undefined) {
+        states.delete(oldestKey);
+        log.debug?.(
+          `[companionStateStore] FIFO eviction: ambassador cap ${ambassadorCap} reached, dropped ${oldestKey}`,
+        );
+      }
+    }
+    states.set(sanitized.lineage_id, sanitized);
+    persistAsync(sanitized);
+    return getCompanionState(sanitized.lineage_id);
+  }
+
+  /**
+   * Append a crossbreed event to history. FIFO bounded by 10 entries (Q5 default).
+   * Recomputes signature server-side post-append.
+   */
+  function addCrossbreedEvent(lineageId, event) {
+    if (!lineageId || typeof lineageId !== 'string') {
+      throw new TypeError('addCrossbreedEvent: lineageId (string) required');
+    }
+    if (!event || typeof event !== 'object') {
+      throw new TypeError('addCrossbreedEvent: event object required');
+    }
+    const existing = states.get(lineageId);
+    if (!existing) {
+      throw new Error(
+        `addCrossbreedEvent: no state for lineage_id=${lineageId}. Call saveCompanionState first.`,
+      );
+    }
+    const ts = event.ts || new Date().toISOString();
+    const entry = { ...event, ts };
+    const next = {
+      ...existing,
+      crossbreed_history: fifoBounded(
+        [...(existing.crossbreed_history || []), entry],
+        CROSSBREED_HISTORY_MAX_ENTRIES,
+      ),
+    };
+    next.companion_card_signature = signatureFor(next);
+    states.set(lineageId, next);
+    persistAsync(next);
+    return getCompanionState(lineageId);
+  }
+
+  /**
+   * Get crossbreed history for a lineage_id.
+   * Returns [] when not present (graceful, not error).
+   */
+  function getCrossbreedHistory(lineageId) {
+    const state = states.get(lineageId);
+    if (!state) return [];
+    return [...(state.crossbreed_history || [])];
+  }
+
+  function listAmbassadors() {
+    return [...states.keys()];
+  }
+
+  function size() {
+    return states.size;
+  }
+
+  function clearAll() {
+    const n = states.size;
+    states.clear();
+    return n;
+  }
+
+  return {
+    getCompanionState,
+    saveCompanionState,
+    addCrossbreedEvent,
+    getCrossbreedHistory,
+    signatureFor,
+    listAmbassadors,
+    size,
+    clearAll,
+    hydrateAsync,
+    _mode: usePrisma ? 'prisma' : 'in-memory',
+  };
+}
+
+module.exports = {
+  createCompanionStateStore,
+  prismaSupportsSkivCompanion,
+  // Pure helpers exported for tests + reuse.
+  signatureFor,
+  canonicalJson,
+  sanitizeWhitelist,
+  migrateLegacyState,
+  isLegacySchema,
+  fifoBounded,
+  // Constants
+  AMBASSADOR_CAP_PER_NIDO,
+  VOICE_DIARY_MAX_ENTRIES,
+  CROSSBREED_HISTORY_MAX_ENTRIES,
+  CURRENT_SCHEMA_VERSION,
+  WHITELIST_TOP_FIELDS,
+  BLACKLIST_FIELDS,
+};

--- a/data/derived/skiv_saga.json
+++ b/data/derived/skiv_saga.json
@@ -1,9 +1,14 @@
 {
-  "schema_version": "0.1.0",
+  "schema_version": "0.2.0",
   "generated_at": "2026-04-25T12:55:34Z",
   "unit_id": "skiv",
   "species_id": "dune_stalker",
   "biome_id": "savana",
+  "lineage_id": "skiv-savana-2026-0425-canonical",
+  "companion_card_signature": null,
+  "crossbreed_history": [],
+  "voice_diary_portable": [],
+  "share_url": null,
   "mbti_axes": {
     "E_I": {
       "value": 0.68,
@@ -223,5 +228,5 @@
       }
     }
   ],
-  "_notes": "Canonical creature state showcasing 2026-04-25 content sprint #1776 + Skiv 5/8 wishlist + lifecycle/aspect (this PR). Regenerate via tools/py/seed_skiv_saga.py."
+  "_notes": "Canonical creature state showcasing 2026-04-25 content sprint #1776 + Skiv 5/8 wishlist + lifecycle/aspect (this PR). Regenerate via tools/py/seed_skiv_saga.py. Schema 0.2.0 (S1 polish Phase 1) adds lineage_id + companion_card_signature + crossbreed_history[] + voice_diary_portable[] + share_url additive (ADR-2026-04-27)."
 }

--- a/docs/adr/ADR-2026-04-27-skiv-portable-companion-crossbreeding.md
+++ b/docs/adr/ADR-2026-04-27-skiv-portable-companion-crossbreeding.md
@@ -1,6 +1,6 @@
 ---
 title: 'ADR-2026-04-27 — Skiv portable companion + crossbreeding async cross-player'
-doc_status: proposed
+doc_status: accepted
 doc_owner: master-dd
 workstream: cross-cutting
 last_verified: '2026-04-27'
@@ -20,9 +20,10 @@ tags: [skiv, companion, crossbreeding, lineage, portable, async, social]
 
 # ADR-2026-04-27 — Skiv portable companion + crossbreeding async cross-player
 
-**Status**: proposed (sign-off master-dd pending — 5 decision points sezione §7)
+**Status**: accepted (sign-off master-dd 2026-04-27 sera, defaults Q4-Q8 confirmed: privacy whitelist subset, cap 10 ambassador per Nido, permanent ambassador, cooldown 1/campagna, rate-limit 10/h IP. Phase 1 schema + persistence shipped in this PR)
 **Decision date**: 2026-04-27
-**Effort impl**: 25-30h (Sprint S1-polish, 6 phase)
+**Accepted date**: 2026-04-27
+**Effort impl**: 25-30h (Sprint S1-polish, 6 phase). Phase 1 ~7h shipped; Phase 2-6 pending.
 **Prerequisites**: OD-001 Path A Nido shipped (Sprint A→D, 4 PR `9d1182ae`/`9efccc26`/`b7f4fff5`/`639a90f7`), `metaProgression.js:recordOffspring()` + `getLineageChain()` + `getTribesEmergent()` live in main.
 
 ## Context

--- a/packages/contracts/index.js
+++ b/packages/contracts/index.js
@@ -10,6 +10,7 @@ const glossarySchema = require('./schemas/glossary.schema.json');
 const narrativeSchema = require('./schemas/narrative.schema.json');
 const replaySchema = require('./schemas/replay.schema.json');
 const triSorgenteSchema = require('./schemas/tri-sorgente.schema.json');
+const skivCompanionSchema = require('./schemas/skiv_companion.schema.json');
 
 module.exports = {
   generationSnapshotSchema,
@@ -22,4 +23,5 @@ module.exports = {
   narrativeSchema,
   replaySchema,
   triSorgenteSchema,
+  skivCompanionSchema,
 };

--- a/packages/contracts/schemas/skiv_companion.schema.json
+++ b/packages/contracts/schemas/skiv_companion.schema.json
@@ -1,0 +1,170 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contracts.game.local/skiv_companion.schema.json",
+  "title": "SkivCompanionState",
+  "description": "Portable Skiv companion state v0.2.0 — S1 polish Phase 1 schema. Privacy whitelist enforced server-side: NO email, NO telemetria, NO session_id, NO IP. ADR-2026-04-27.",
+  "type": "object",
+  "required": ["schema_version", "lineage_id", "companion_card_signature"],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "pattern": "^0\\.2\\.[0-9]+$",
+      "description": "Schema version pinned to 0.2.x. Reader fallback handles 0.1.x in-memory migration."
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "unit_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[a-z0-9_-]+$"
+    },
+    "species_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[a-z0-9_-]+$"
+    },
+    "biome_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[a-z0-9_-]+$"
+    },
+    "lineage_id": {
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 128,
+      "pattern": "^[a-z0-9_-]+$",
+      "description": "Lineage chain identifier. Wired to metaProgression.recordOffspring(). UUID-like entropy recommended (160bit+) to mitigate enumeration attack."
+    },
+    "companion_card_signature": {
+      "type": ["string", "null"],
+      "description": "sha256 deterministic hash of canonical-JSON whitelist subset. Server verifies on /crossbreed import. Mismatch → reject 400.",
+      "anyOf": [{ "type": "null" }, { "type": "string", "pattern": "^[a-f0-9]{64}$" }]
+    },
+    "mbti_axes": {
+      "type": "object",
+      "properties": {
+        "E_I": { "$ref": "#/$defs/mbti_axis" },
+        "T_F": { "$ref": "#/$defs/mbti_axis" },
+        "S_N": { "$ref": "#/$defs/mbti_axis" },
+        "J_P": { "$ref": "#/$defs/mbti_axis" }
+      },
+      "additionalProperties": false
+    },
+    "progression": {
+      "type": "object",
+      "properties": {
+        "unit_id": { "type": "string" },
+        "job": { "type": "string" },
+        "xp_total": { "type": "integer", "minimum": 0 },
+        "level": { "type": "integer", "minimum": 1 },
+        "picked_perks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "level": { "type": "integer", "minimum": 1 },
+              "perk_id": { "type": "string" },
+              "choice": { "type": "string", "enum": ["a", "b"] }
+            },
+            "additionalProperties": false
+          }
+        },
+        "previous_job": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "cabinet": {
+      "type": "object",
+      "properties": {
+        "unlocked": { "type": "array", "items": { "type": "string" } },
+        "researching": { "type": "array", "items": { "type": "string" } },
+        "internalized": { "type": "array", "items": { "type": "string" } },
+        "slots_max": { "type": "integer", "minimum": 0 },
+        "slots_used": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": true
+    },
+    "mutations": {
+      "type": "array",
+      "maxItems": 3,
+      "description": "Capped to 3 (Pokemon EV cap analogue, ADR-2026-04-27 §C).",
+      "items": { "type": "object" }
+    },
+    "aspect": {
+      "type": "object",
+      "properties": {
+        "lifecycle_phase": { "type": "string" },
+        "label_it": { "type": "string" },
+        "label_en": { "type": "string" },
+        "sprite_ascii": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "crossbreed_history": {
+      "type": "array",
+      "description": "Append-only log of crossbreed events. Max 10 entries (FIFO eviction, Q5 default cap ambassador per Nido).",
+      "maxItems": 10,
+      "items": {
+        "type": "object",
+        "required": ["ts"],
+        "properties": {
+          "ts": { "type": "string", "format": "date-time" },
+          "role": {
+            "type": "string",
+            "enum": ["parent_a", "parent_b", "offspring"]
+          },
+          "with_lineage_id": { "type": "string" },
+          "partner_card_signature": {
+            "type": ["string", "null"],
+            "anyOf": [{ "type": "null" }, { "type": "string", "pattern": "^[a-f0-9]{64}$" }]
+          },
+          "offspring_lineage_id": { "type": ["string", "null"] },
+          "biome_at_crossbreed": { "type": ["string", "null"] },
+          "biome_environmental_mutation": { "type": ["string", "null"] },
+          "tier": {
+            "type": ["string", "null"],
+            "enum": [null, "no-glow", "gold", "rainbow"]
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "voice_diary_portable": {
+      "type": "array",
+      "description": "Subset diary share-safe (max 5 entries). Whitelist: phase + voice_line + trigger_event only. NO session_id, NO PII.",
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "properties": {
+          "ts": { "type": "string", "format": "date-time" },
+          "phase": { "type": "string" },
+          "voice_line": { "type": "string", "maxLength": 280 },
+          "trigger_event": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "share_url": {
+      "type": ["string", "null"],
+      "description": "Public share URL emitted at export. Null until export materialized.",
+      "anyOf": [{ "type": "null" }, { "type": "string", "format": "uri", "maxLength": 512 }]
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "mbti_axis": {
+      "type": "object",
+      "required": ["value"],
+      "properties": {
+        "value": { "type": "number", "minimum": 0, "maximum": 1 },
+        "coverage": { "type": "string" }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/tests/services/skivCompanionState.test.js
+++ b/tests/services/skivCompanionState.test.js
@@ -1,0 +1,388 @@
+// S1 polish Phase 1 — Skiv companion state store + schema invariants.
+//
+// Test coverage:
+//   1. Save + retrieve roundtrip (in-memory)
+//   2. Schema invariant rejection (missing lineage_id, wrong version)
+//   3. Signature deterministic cross-call (same state → same hash)
+//   4. Privacy whitelist enforcement (PII fields stripped pre-persist)
+//   5. Cap 10 ambassador FIFO eviction
+//   6. Backward-compat 0.1.0 reader (migrateLegacyState)
+//   7. Crossbreed history append idempotent + FIFO 10
+//   8. getCrossbreedHistory filtered by lineage_id
+//   9. Signature changes when whitelist content changes
+//  10. AJV schema canonical accepts v0.2.0 valid sample
+//
+// Reference: ADR-2026-04-27 §A schema, §D privacy whitelist, sprint-plan Phase 1.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+// AJV harness aligned with apps/backend/middleware/schemaValidator.js (no ajv-formats dep).
+let Ajv;
+try {
+  Ajv = require('ajv/dist/2020');
+} catch (err) {
+  if (err && err.code !== 'MODULE_NOT_FOUND') throw err;
+  Ajv = require('ajv');
+}
+
+function makeAjv() {
+  const ajv = new Ajv({ strict: false, allErrors: true });
+  ajv.addFormat('date-time', true);
+  ajv.addFormat('uri', true);
+  return ajv;
+}
+
+const {
+  createCompanionStateStore,
+  signatureFor,
+  sanitizeWhitelist,
+  migrateLegacyState,
+  isLegacySchema,
+  fifoBounded,
+  AMBASSADOR_CAP_PER_NIDO,
+  CROSSBREED_HISTORY_MAX_ENTRIES,
+  CURRENT_SCHEMA_VERSION,
+  WHITELIST_TOP_FIELDS,
+} = require('../../apps/backend/services/skiv/companionStateStore');
+
+const skivCompanionSchema = require('../../packages/contracts/schemas/skiv_companion.schema.json');
+
+function makeValidState(overrides = {}) {
+  return {
+    schema_version: '0.2.0',
+    unit_id: 'skiv',
+    species_id: 'dune_stalker',
+    biome_id: 'savana',
+    lineage_id: 'skiv-savana-2026-0427-test',
+    companion_card_signature: null,
+    mbti_axes: {
+      E_I: { value: 0.68, coverage: 'full' },
+      T_F: { value: 0.72, coverage: 'full' },
+      S_N: { value: 0.22, coverage: 'full' },
+      J_P: { value: 0.32, coverage: 'full' },
+    },
+    crossbreed_history: [],
+    voice_diary_portable: [],
+    share_url: null,
+    ...overrides,
+  };
+}
+
+// ─── 1. Save + retrieve roundtrip ───────────────────────────────────────
+
+test('Phase 1: saveCompanionState + getCompanionState roundtrip', () => {
+  const store = createCompanionStateStore();
+  const saved = store.saveCompanionState(makeValidState());
+  assert.equal(saved.lineage_id, 'skiv-savana-2026-0427-test');
+  assert.equal(saved.schema_version, '0.2.0');
+  assert.match(saved.companion_card_signature, /^[a-f0-9]{64}$/);
+  const fetched = store.getCompanionState('skiv-savana-2026-0427-test');
+  assert.deepEqual(fetched, saved);
+  assert.equal(store.getCompanionState('unknown'), null);
+});
+
+// ─── 2. Schema invariant rejection ──────────────────────────────────────
+
+test('Phase 1: saveCompanionState rejects missing lineage_id', () => {
+  const store = createCompanionStateStore();
+  assert.throws(() => store.saveCompanionState(makeValidState({ lineage_id: '' })), /lineage_id/);
+  assert.throws(
+    () => store.saveCompanionState(makeValidState({ lineage_id: undefined })),
+    /lineage_id/,
+  );
+});
+
+test('Phase 1: saveCompanionState rejects wrong schema_version', () => {
+  const store = createCompanionStateStore();
+  assert.throws(
+    () => store.saveCompanionState(makeValidState({ schema_version: '0.3.0' })),
+    /schema_version/,
+  );
+});
+
+// ─── 3. Signature deterministic ─────────────────────────────────────────
+
+test('Phase 1: signatureFor is deterministic across calls (same state → same hash)', () => {
+  const state = makeValidState();
+  const sig1 = signatureFor(state);
+  const sig2 = signatureFor(state);
+  assert.equal(sig1, sig2);
+  assert.match(sig1, /^[a-f0-9]{64}$/);
+  // Property order independence (canonical-JSON sorts keys).
+  const reordered = {
+    biome_id: state.biome_id,
+    schema_version: state.schema_version,
+    unit_id: state.unit_id,
+    species_id: state.species_id,
+    lineage_id: state.lineage_id,
+    companion_card_signature: state.companion_card_signature,
+    mbti_axes: state.mbti_axes,
+    crossbreed_history: state.crossbreed_history,
+    voice_diary_portable: state.voice_diary_portable,
+    share_url: state.share_url,
+  };
+  assert.equal(signatureFor(reordered), sig1);
+});
+
+test('Phase 1: signatureFor changes when whitelist content changes', () => {
+  const a = makeValidState();
+  const b = makeValidState({ biome_id: 'tundra' });
+  assert.notEqual(signatureFor(a), signatureFor(b));
+});
+
+// ─── 4. Privacy whitelist enforcement ───────────────────────────────────
+
+test('Phase 1: sanitizeWhitelist drops PII fields (session_id, _notes, email)', () => {
+  const dirty = {
+    ...makeValidState(),
+    session_id: 'sess_secret_123',
+    _notes: 'private trainer note',
+    email: 'leak@example.com',
+    ip_address: '192.0.2.1',
+    diary: [{ ts: '2026-04-26T00:00:00Z', payload: { secret: true } }],
+  };
+  const clean = sanitizeWhitelist(dirty);
+  assert.equal('session_id' in clean, false);
+  assert.equal('_notes' in clean, false);
+  assert.equal('email' in clean, false);
+  assert.equal('ip_address' in clean, false);
+  assert.equal('diary' in clean, false);
+  // Whitelist fields preserved.
+  assert.equal(clean.unit_id, 'skiv');
+  assert.equal(clean.lineage_id, 'skiv-savana-2026-0427-test');
+});
+
+test('Phase 1: saveCompanionState does not persist PII fields', () => {
+  const store = createCompanionStateStore();
+  const stored = store.saveCompanionState({
+    ...makeValidState(),
+    session_id: 'sess_leaked',
+    _notes: 'should not survive',
+    diary: [{ ts: 'x', payload: 'pii' }],
+  });
+  assert.equal('session_id' in stored, false);
+  assert.equal('_notes' in stored, false);
+  assert.equal('diary' in stored, false);
+  // Signature computed only over whitelist (no PII influence).
+  const cleanSig = signatureFor(makeValidState());
+  assert.equal(stored.companion_card_signature, cleanSig);
+});
+
+// ─── 5. Cap 10 ambassador FIFO eviction ─────────────────────────────────
+
+test('Phase 1: ambassador cap 10 + FIFO eviction at 11th add', () => {
+  const store = createCompanionStateStore();
+  for (let i = 0; i < AMBASSADOR_CAP_PER_NIDO; i++) {
+    store.saveCompanionState(
+      makeValidState({ lineage_id: `skiv-test-${String(i).padStart(2, '0')}-aaaa` }),
+    );
+  }
+  assert.equal(store.size(), AMBASSADOR_CAP_PER_NIDO);
+  assert.equal(store.getCompanionState('skiv-test-00-aaaa').lineage_id, 'skiv-test-00-aaaa');
+  // 11th add → oldest (00) evicted.
+  store.saveCompanionState(makeValidState({ lineage_id: 'skiv-test-99-eleventh' }));
+  assert.equal(store.size(), AMBASSADOR_CAP_PER_NIDO);
+  assert.equal(store.getCompanionState('skiv-test-00-aaaa'), null);
+  assert.equal(
+    store.getCompanionState('skiv-test-99-eleventh').lineage_id,
+    'skiv-test-99-eleventh',
+  );
+});
+
+test('Phase 1: re-saving existing lineage does not trigger eviction', () => {
+  const store = createCompanionStateStore({ ambassadorCap: 3 });
+  store.saveCompanionState(makeValidState({ lineage_id: 'skiv-aaa-test' }));
+  store.saveCompanionState(makeValidState({ lineage_id: 'skiv-bbb-test' }));
+  store.saveCompanionState(makeValidState({ lineage_id: 'skiv-ccc-test' }));
+  assert.equal(store.size(), 3);
+  // Re-save aaa → no eviction (already present).
+  store.saveCompanionState(makeValidState({ lineage_id: 'skiv-aaa-test', biome_id: 'tundra' }));
+  assert.equal(store.size(), 3);
+  assert.equal(store.getCompanionState('skiv-aaa-test').biome_id, 'tundra');
+  assert.notEqual(store.getCompanionState('skiv-bbb-test'), null);
+});
+
+// ─── 6. Backward-compat 0.1.0 reader ────────────────────────────────────
+
+test('Phase 1: isLegacySchema detects 0.1.x', () => {
+  assert.equal(isLegacySchema({ schema_version: '0.1.0' }), true);
+  assert.equal(isLegacySchema({ schema_version: '0.1.99' }), true);
+  assert.equal(isLegacySchema({ schema_version: '0.2.0' }), false);
+  assert.equal(isLegacySchema({}), true); // missing version = legacy
+});
+
+test('Phase 1: migrateLegacyState bumps 0.1.0 → 0.2.0 + initializes new fields', () => {
+  const legacy = {
+    schema_version: '0.1.0',
+    unit_id: 'skiv',
+    species_id: 'dune_stalker',
+    biome_id: 'savana',
+    mbti_axes: { E_I: { value: 0.5, coverage: 'partial' } },
+  };
+  const migrated = migrateLegacyState(legacy);
+  assert.equal(migrated.schema_version, CURRENT_SCHEMA_VERSION);
+  assert.equal(migrated.lineage_id, 'skiv-savana-legacy-skiv');
+  assert.deepEqual(migrated.crossbreed_history, []);
+  assert.deepEqual(migrated.voice_diary_portable, []);
+  assert.equal(migrated.share_url, null);
+  assert.equal(migrated.companion_card_signature, null);
+  // Existing fields preserved.
+  assert.equal(migrated.unit_id, 'skiv');
+  assert.deepEqual(migrated.mbti_axes.E_I, { value: 0.5, coverage: 'partial' });
+});
+
+test('Phase 1: saveCompanionState auto-migrates 0.1.0 input', () => {
+  const store = createCompanionStateStore();
+  const stored = store.saveCompanionState({
+    schema_version: '0.1.0',
+    unit_id: 'skiv',
+    species_id: 'dune_stalker',
+    biome_id: 'savana',
+  });
+  assert.equal(stored.schema_version, '0.2.0');
+  assert.match(stored.companion_card_signature, /^[a-f0-9]{64}$/);
+  assert.deepEqual(stored.crossbreed_history, []);
+});
+
+// ─── 7. Crossbreed history append + FIFO 10 ─────────────────────────────
+
+test('Phase 1: addCrossbreedEvent appends + recomputes signature', () => {
+  const store = createCompanionStateStore();
+  store.saveCompanionState(makeValidState());
+  const sigBefore = store.getCompanionState('skiv-savana-2026-0427-test').companion_card_signature;
+  const updated = store.addCrossbreedEvent('skiv-savana-2026-0427-test', {
+    role: 'parent_a',
+    with_lineage_id: 'skiv-tundra-other',
+    offspring_lineage_id: 'skiv-savana-offspring-x',
+    biome_at_crossbreed: 'savana',
+    biome_environmental_mutation: 'frost_resilience',
+    tier: 'gold',
+  });
+  assert.equal(updated.crossbreed_history.length, 1);
+  assert.equal(updated.crossbreed_history[0].role, 'parent_a');
+  assert.match(updated.crossbreed_history[0].ts, /^\d{4}-\d{2}-\d{2}T/);
+  assert.notEqual(updated.companion_card_signature, sigBefore);
+});
+
+test('Phase 1: addCrossbreedEvent throws on unknown lineage_id', () => {
+  const store = createCompanionStateStore();
+  assert.throws(
+    () => store.addCrossbreedEvent('skiv-nonexistent', { role: 'parent_a' }),
+    /no state for lineage_id/,
+  );
+});
+
+test('Phase 1: crossbreed_history FIFO bounded to 10 entries', () => {
+  const store = createCompanionStateStore();
+  store.saveCompanionState(makeValidState());
+  for (let i = 0; i < 12; i++) {
+    store.addCrossbreedEvent('skiv-savana-2026-0427-test', {
+      role: 'parent_a',
+      with_lineage_id: `partner-${i}`,
+      tier: 'no-glow',
+    });
+  }
+  const history = store.getCrossbreedHistory('skiv-savana-2026-0427-test');
+  assert.equal(history.length, CROSSBREED_HISTORY_MAX_ENTRIES);
+  // Oldest 2 entries (with_lineage_id partner-0, partner-1) evicted FIFO.
+  assert.equal(history[0].with_lineage_id, 'partner-2');
+  assert.equal(history[history.length - 1].with_lineage_id, 'partner-11');
+});
+
+// ─── 8. getCrossbreedHistory filter by lineage_id ───────────────────────
+
+test('Phase 1: getCrossbreedHistory returns [] for unknown lineage', () => {
+  const store = createCompanionStateStore();
+  assert.deepEqual(store.getCrossbreedHistory('unknown'), []);
+});
+
+test('Phase 1: getCrossbreedHistory isolated per lineage_id', () => {
+  const store = createCompanionStateStore();
+  store.saveCompanionState(makeValidState({ lineage_id: 'skiv-aaa-test' }));
+  store.saveCompanionState(makeValidState({ lineage_id: 'skiv-bbb-test' }));
+  store.addCrossbreedEvent('skiv-aaa-test', { role: 'parent_a', tier: 'gold' });
+  store.addCrossbreedEvent('skiv-bbb-test', { role: 'parent_b', tier: 'rainbow' });
+  store.addCrossbreedEvent('skiv-bbb-test', { role: 'offspring', tier: 'no-glow' });
+  assert.equal(store.getCrossbreedHistory('skiv-aaa-test').length, 1);
+  assert.equal(store.getCrossbreedHistory('skiv-bbb-test').length, 2);
+  assert.equal(store.getCrossbreedHistory('skiv-aaa-test')[0].tier, 'gold');
+});
+
+// ─── 9. fifoBounded helper ──────────────────────────────────────────────
+
+test('Phase 1: fifoBounded preserves last N entries', () => {
+  assert.deepEqual(fifoBounded([1, 2, 3], 5), [1, 2, 3]);
+  assert.deepEqual(fifoBounded([1, 2, 3, 4, 5, 6], 3), [4, 5, 6]);
+  assert.deepEqual(fifoBounded([], 5), []);
+  assert.deepEqual(fifoBounded(null, 5), []);
+});
+
+// ─── 10. AJV schema canonical accepts v0.2.0 valid sample ───────────────
+
+test('Phase 1: AJV schema canonical accepts valid v0.2.0 state', () => {
+  const ajv = makeAjv();
+  const validate = ajv.compile(skivCompanionSchema);
+  const state = makeValidState({
+    companion_card_signature: 'a'.repeat(64),
+    crossbreed_history: [
+      {
+        ts: '2026-04-27T12:00:00Z',
+        role: 'parent_a',
+        with_lineage_id: 'partner-x',
+        partner_card_signature: 'b'.repeat(64),
+        offspring_lineage_id: 'skiv-offspring-y',
+        biome_at_crossbreed: 'savana',
+        biome_environmental_mutation: 'frost_resilience',
+        tier: 'gold',
+      },
+    ],
+    voice_diary_portable: [
+      {
+        ts: '2026-04-26T01:00:00Z',
+        phase: 'mature',
+        voice_line: 'Sabbia segue.',
+        trigger_event: 'synergy_triggered',
+      },
+    ],
+  });
+  const ok = validate(state);
+  assert.equal(ok, true, JSON.stringify(validate.errors, null, 2));
+});
+
+test('Phase 1: AJV schema rejects schema_version 0.1.x', () => {
+  const ajv = makeAjv();
+  const validate = ajv.compile(skivCompanionSchema);
+  const state = makeValidState({ schema_version: '0.1.0' });
+  assert.equal(validate(state), false);
+});
+
+test('Phase 1: AJV schema rejects crossbreed_history > 10 entries', () => {
+  const ajv = makeAjv();
+  const validate = ajv.compile(skivCompanionSchema);
+  const state = makeValidState({
+    crossbreed_history: Array.from({ length: 11 }, (_, i) => ({
+      ts: '2026-04-27T12:00:00Z',
+      role: 'parent_a',
+      with_lineage_id: `partner-${i}`,
+    })),
+  });
+  assert.equal(validate(state), false);
+});
+
+// ─── Whitelist coverage (constants are stable across releases) ──────────
+
+test('Phase 1: WHITELIST_TOP_FIELDS includes critical share-safe fields', () => {
+  assert.ok(WHITELIST_TOP_FIELDS.includes('lineage_id'));
+  assert.ok(WHITELIST_TOP_FIELDS.includes('companion_card_signature'));
+  assert.ok(WHITELIST_TOP_FIELDS.includes('crossbreed_history'));
+  assert.ok(WHITELIST_TOP_FIELDS.includes('voice_diary_portable'));
+  // PII MUST NOT be in whitelist (defense-in-depth).
+  assert.equal(WHITELIST_TOP_FIELDS.includes('session_id'), false);
+  assert.equal(WHITELIST_TOP_FIELDS.includes('_notes'), false);
+  assert.equal(WHITELIST_TOP_FIELDS.includes('email'), false);
+  assert.equal(WHITELIST_TOP_FIELDS.includes('diary'), false);
+});


### PR DESCRIPTION
## Summary

Phase 1 di 6 (~7h) del sprint S1 polish portable Skiv crossbreeding async cross-player. Schema additive 0.2.0 + persistence adapter + AJV canonical + Prisma model + 22 test verdi.

ADR-2026-04-27 promosso `proposed → accepted` (sign-off master-dd 2026-04-27 sera, defaults Q4-Q8 confirmed: privacy whitelist subset, cap 10 ambassador per Nido, permanent ambassador, cooldown 1/campagna, rate-limit 10/h IP).

## Scope

- **Schema** `data/derived/skiv_saga.json` 0.1.0 → 0.2.0 (additive): `lineage_id` + `companion_card_signature` + `crossbreed_history[]` + `voice_diary_portable[]` + `share_url`. Backward-compat reader 0.1.x via `migrateLegacyState()`.
- **AJV canonical** `packages/contracts/schemas/skiv_companion.schema.json` registered runtime in `apps/backend/app.js` (id `contract://skiv/companion`).
- **Persistence adapter** `apps/backend/services/skiv/companionStateStore.js`:
  - In-memory `Map` keyed by `lineage_id`
  - Prisma write-through optional (graceful fallback when `DATABASE_URL` unset)
  - Methods: `getCompanionState`, `saveCompanionState`, `addCrossbreedEvent`, `getCrossbreedHistory`, `signatureFor`, `listAmbassadors`, `size`, `clearAll`, `hydrateAsync`
- **Prisma model** `SkivCompanionState` + migration `0006_skiv_companion_state` (JSONB arrays for history + diary).
- **Privacy whitelist** server-side enforcement: 15 share-safe top fields, 13 PII keys explicitly blacklisted (`session_id`, `_notes`, `email`, `ip_address`, `diary`, `telemetry`, etc.). Sanitization + signature recompute server-side.
- **Cap 10 ambassador per Nido** FIFO eviction (Q5 default). Re-saving existing lineage doesn't trigger eviction.
- **Signature** deterministic `sha256(canonicalJson(whitelist))` — cross-process stable, property-order independent.

## Tests

- **`tests/services/skivCompanionState.test.js`**: 22/22 verde (~155ms)
  - Save + retrieve roundtrip
  - Schema invariant rejection (missing lineage_id, wrong version)
  - Signature deterministic + property-order independent + content-changes invariant
  - PII whitelist strip (`sanitizeWhitelist` + `saveCompanionState`)
  - Cap 10 ambassador FIFO eviction + re-save no-eviction
  - Backward-compat 0.1.x reader (`isLegacySchema`, `migrateLegacyState`, auto-migrate via save)
  - Crossbreed history append + signature recompute + FIFO 10
  - `getCrossbreedHistory` lineage isolation
  - `fifoBounded` helper
  - AJV schema accepts valid v0.2.0 / rejects 0.1.x / rejects >10 entries
  - `WHITELIST_TOP_FIELDS` PII guard constants

## Regression

- AI baseline 311/311 verde (`node --test tests/ai/*.test.js`)
- skivRoute 12/12 verde (`node --test tests/api/skivRoute.test.js`)
- `npm run lint:stack` verde
- `npx prettier --check` verde su tutti i file toccati
- Pre-existing `diaryStore.test.js` failure unchanged (orthogonal, su `main` baseline)

## Out of scope

NO endpoint REST (Phase 2). NO UI (Phase 3). NO crossbreed gene mix algorithm (Phase 2). Phase 1 schema + persistence only — caller wiring (`/api/skiv/crossbreed`, `/api/skiv/share/:lineage_id`, etc.) deferred a Phase 2.

## Test plan

- [x] `node --test tests/services/skivCompanionState.test.js` → 22/22
- [x] `node --test tests/ai/*.test.js` → 311/311 (regression baseline)
- [x] `node --test tests/api/skivRoute.test.js` → 12/12 (existing skiv route smoke)
- [x] `npx prettier --check` → verde
- [x] `npm run lint:stack` → verde
- [x] AJV smoke validate canonical `data/derived/skiv_saga.json` → valid

## References

- [ADR-2026-04-27](docs/adr/ADR-2026-04-27-skiv-portable-companion-crossbreeding.md) — accepted, defaults Q4-Q8 confirmed
- [Sprint plan](docs/planning/2026-04-27-skiv-portable-companion-sprint-plan.md) — 6 phase × 25-30h
- [Research summary](docs/reports/2026-04-27-skiv-portable-companion-research-summary.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)