### PR TITLE
fix(ui): WCAG AA contrast + threat tile overlay (ITB telegraph) P0

### DIFF
--- a/apps/play/src/render.js
+++ b/apps/play/src/render.js
@@ -580,6 +580,45 @@ function drawUnit(ctx, unit, gridH, highlight = {}) {
 }
 
 // M4 P0.3 — SIS intent icon above unit (fist=attack, arrow=move, shield=defend).
+// 2026-04-26 ITB telegraph — threat tile overlay (semi-transparent rosso/giallo/blu per intent type).
+// Schema row: { actor_id, intent_type, intent_icon, target_id, threat_tiles: [{x, y}, ...] }
+// Colore: attack=rosso (kill zone), move=giallo (movement preview), defend/overwatch/skip=blu.
+// Pulse: alpha oscilla 0.25-0.45 a 1Hz per attirare attenzione (Into the Breach pattern).
+function drawThreatTileOverlay(ctx, threatPreview, gridH) {
+  const t = (Date.now() % 1000) / 1000; // 0..1 ciclico
+  const pulse = 0.35 + Math.sin(t * Math.PI * 2) * 0.1; // 0.25..0.45
+  for (const row of threatPreview) {
+    if (!row || !Array.isArray(row.threat_tiles) || row.threat_tiles.length === 0) continue;
+    let fill;
+    let stroke;
+    if (row.intent_type === 'attack') {
+      fill = `rgba(244, 67, 54, ${pulse})`; // rosso #f44336
+      stroke = 'rgba(244, 67, 54, 0.85)';
+    } else if (
+      row.intent_type === 'move' ||
+      row.intent_type === 'approach' ||
+      row.intent_type === 'retreat'
+    ) {
+      fill = `rgba(255, 170, 0, ${pulse * 0.7})`; // giallo
+      stroke = 'rgba(255, 170, 0, 0.7)';
+    } else {
+      fill = `rgba(79, 195, 247, ${pulse * 0.55})`; // blu defensive
+      stroke = 'rgba(79, 195, 247, 0.55)';
+    }
+    for (const tile of row.threat_tiles) {
+      if (!tile || typeof tile.x !== 'number' || typeof tile.y !== 'number') continue;
+      const yPx = gridH - 1 - tile.y;
+      const px = tile.x * CELL;
+      const py = yPx * CELL;
+      ctx.fillStyle = fill;
+      ctx.fillRect(px + 1, py + 1, CELL - 2, CELL - 2);
+      ctx.strokeStyle = stroke;
+      ctx.lineWidth = 2;
+      ctx.strokeRect(px + 2, py + 2, CELL - 4, CELL - 4);
+    }
+  }
+}
+
 function drawSisIntentIcon(ctx, unit, cx, yPxTop, kind = 'fist') {
   const ix = cx + CELL * 0.25;
   const iy = yPxTop + CELL * 0.08;
@@ -707,6 +746,12 @@ export function render(canvas, state, highlight = {}) {
 
   // W3.1 — Range overlay BEFORE units (so unit rings/icons overlap on top).
   if (highlight.selected) drawRangeOverlay(ctx, state, h, highlight.selected);
+
+  // 2026-04-26 ITB telegraph — threat tile overlay rosso/giallo per SIS pending intents.
+  // Disegnato DOPO range overlay (player vede sue mosse possibili) e PRIMA delle unità.
+  if (Array.isArray(highlight.threatPreview) && highlight.threatPreview.length > 0) {
+    drawThreatTileOverlay(ctx, highlight.threatPreview, h);
+  }
 
   // Units
   for (const u of state.units || []) drawUnit(ctx, u, h, highlight);

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -4,7 +4,7 @@
   --accent: #ffcc00;
   --player: #00b8d4;
   --sistema: #ff5252;
-  --dim: #666;
+  --dim: #888;
   --cell: #2a2a2a;
   --cell-alt: #303030;
   --panel: #222;
@@ -848,11 +848,11 @@ canvas#grid {
   overflow-y: auto;
 }
 .unit-log li {
-  padding: 1px 4px;
+  padding: 2px 5px;
   margin-bottom: 1px;
   border-left: 2px solid rgba(0, 184, 212, 0.45);
   background: rgba(0, 184, 212, 0.05);
-  font-size: 0.65rem;
+  font-size: 0.85rem;
 }
 
 /* W4.2 — Commit reveal overlay: "⚔ ROUND N · X azioni simultanee" fullscreen flash. */
@@ -1058,9 +1058,9 @@ canvas#grid:hover {
   letter-spacing: -0.01em;
 }
 .unit-tech-id {
-  font-size: 0.62rem;
+  font-size: 0.8rem;
   color: var(--dim);
-  opacity: 0.6;
+  opacity: 0.7;
   margin-left: 4px;
   font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
 }


### PR DESCRIPTION
## Summary

2 P0 fix da audit \`ui-design-illuminator\` 2026-04-26. Diff additivo +50 / -5 (no destructive).

### Fix #1 — WCAG AA contrast + font readability (style.css, 3 line edit)
- \`--dim: #666\` (2.9:1 contrast fail) → \`#888\` (4.5:1 AA compliant)
- \`.unit-log li\` font \`0.65rem → 0.85rem\` (TV 3m readable)
- \`.unit-tech-id\` font \`0.62rem → 0.8rem\` + opacity \`0.6 → 0.7\`

Root cause: TV-first @ 3m distance, font sub-1rem illegible.

### Fix #6 — Threat tile overlay rosso (ITB telegraph rule)
- Nuovo \`drawThreatTileOverlay()\` 38 LOC in render.js
- attack → rosso #f44336 pulse (alpha 0.25-0.45 @ 1Hz)
- move/approach/retreat → giallo
- defend/overwatch/skip → blu
- Wired in \`render()\` DOPO range overlay PRIMA delle units (4 LOC)

Root cause: backend genera \`threatPreview\` array con \`threat_tiles[]\` ma frontend non disegnava → player vedeva solo badge intent sopra unit, non capiva quale casella sarebbe stata colpita. ITB telegraph rule violata.

## Test plan

- [x] AI test 311/311 verde (no backend impact)
- [x] Schema drift = 0
- [x] Diff additivo (+50 / -5, no removals)
- [ ] Playtest visual regression: verifica pulse animation visibile

## Rollback

\`git revert <sha>\` — rimuove drawThreatTileOverlay function + wire + 3 CSS edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)