### PR TITLE
fix(ai): cautious profile retreat_hp_pct 0.3→0.4 (P1)

### DIFF
--- a/packs/evo_tactics_pack/data/balance/ai_profiles.yaml
+++ b/packs/evo_tactics_pack/data/balance/ai_profiles.yaml
@@ -49,7 +49,10 @@ profiles:
       # Balance audit 2026-04-25: retreat_hp_pct 0.5→0.3 (allinea al default
       # ai_intent_scores.yaml:23). Soglia 0.5 causava timeout deadlock hardcore
       # (66.7% timeout iter7, docs/playtest/2026-04-20-m7-iter7-phase-e-verdict.md:25).
-      retreat_hp_pct: 0.3
+      # Balance-auditor 2026-04-26: 0.3 = default = ZERO differentiation vs balanced.
+      # Compromesso 0.4 (+33% vs default, -20% vs origin 0.5 deadlock-causante).
+      # Restore behavioral cautious distinct senza regredire timeout fix.
+      retreat_hp_pct: 0.4
       kite_buffer: 2
       default_attack_range: 2
       threat_passivity_threshold: 5 # tollera piu passivita prima di escalare


### PR DESCRIPTION
## Summary

P1 fix da audit \`balance-auditor\` 2026-04-26.

### Problem
Cautious profile \`retreat_hp_pct: 0.3\` == default \`ai_intent_scores.yaml:23\` == balanced default. **ZERO differentiation comportamentale**. Solo residua: \`kite_buffer: 2\`.

### History
- iter origin: \`0.5\` (deadlock hardcore 66.7% timeout iter7)
- balance-audit 2026-04-25: \`0.5 → 0.3\` fix deadlock ma rimosso differentiation
- balance-audit 2026-04-26: \`0.3\` dead, propose \`0.45\`

### Fix
**Compromesso \`0.4\`**: +33% vs default (cautious distinct), -20% vs deadlock-origin \`0.5\`. Restore behavioral distinction senza regredire timeout fix.

## Test plan

- [x] AI test 311/311 verde (no logic change)
- [ ] N=10 hardcore sweep post-merge: verifica timeout < 30%
- [ ] Behavioral observation playtest: cauto vs balanced distinct in kite/retreat

## Rollback

\`git revert <sha>\` — restore \`retreat_hp_pct: 0.3\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)