### PR TITLE
fix(encounter): biome_id orphan caverna_sotterranea→caverna (P1)

### DIFF
--- a/docs/planning/encounters/enc_survival_01.yaml
+++ b/docs/planning/encounters/enc_survival_01.yaml
@@ -1,6 +1,6 @@
 # =============================================================================
 # Encounter: "Ultimo Fiato" — Survival Hardcore
-# Difficulty: 4/5 · Grid: 8×8 · Bioma: caverna_sotterranea
+# Difficulty: 4/5 · Grid: 8×8 · Bioma: caverna (canonical biomes.yaml)
 # Objective: sopravvivere 10 turni contro wave continue.
 # Pilastro coverage: 1 (tattica leggibile) — obiettivo endurance
 # Schema: schemas/evo/encounter.schema.json
@@ -9,7 +9,7 @@
 
 encounter_id: enc_survival_01
 name: 'Ultimo Fiato'
-biome_id: caverna_sotterranea
+biome_id: caverna
 grid_size: [8, 8]
 difficulty_rating: 4
 estimated_turns: 10


### PR DESCRIPTION
## Summary

P1 fix da audit \`pcg-level-design-illuminator\` 2026-04-26 (G6 partial).

### Problem
\`enc_survival_01.yaml\` usava \`biome_id: caverna_sotterranea\` ma quel ID **NON esiste** in \`data/core/biomes.yaml\` (verified \`grep '^  caverna_sotterranea:'\` = 0 match). Solo \`caverna\` canonical (linea 277).

Conseguenza: \`biomeSpawnBias.js\` fail lookup biomeConfig → silently no-op affix bias + archetype matching = nessun biome flavor runtime.

### Fix
Single line edit YAML:
- \`biome_id: caverna_sotterranea → caverna\`
- Comment metadata header aligned

### PCG audit residual note (rovine_planari false positive)
PCG audit aveva flaggato anche \`rovine_planari\` come orphan, ma verifica:
- \`data/core/biomes.yaml:717\` ha \`rovine_planari:\` in mapping \`biomes:\` (canonical) ✅
- Linea 47 \`rovine_planari\` è dentro \`sentience_distribution:\` mapping (different scope, non duplicato)

**Audit false positive su rovine_planari** — solo \`caverna_sotterranea\` era reale orphan.

## Test plan

- [x] AI test 311/311 verde
- [x] Schema drift = 0 (single string change)
- [ ] Smoke encounterLoader: pendente PR #1873 merge per validation E2E

## Rollback

\`git revert <sha>\` — restore \`biome_id: caverna_sotterranea\` (orphan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)