### PR TITLE
fix(ui): phone composer palette --phone-* token namespace (P1-13)

### DIFF
--- a/apps/play/src/phoneComposerV2.css
+++ b/apps/play/src/phoneComposerV2.css
@@ -4,10 +4,10 @@
   position: fixed;
   inset: 0;
   z-index: 9500;
-  background: radial-gradient(ellipse at top, #111827 0%, #05070c 75%);
+  background: radial-gradient(ellipse at top, var(--phone-bg-top) 0%, var(--phone-bg-bot) 75%);
   overflow-y: auto;
   font-family: Inter, system-ui, sans-serif;
-  color: #e8eaf0;
+  color: var(--phone-fg);
 }
 
 .phv2-wrap {
@@ -26,7 +26,7 @@
   gap: 10px;
   padding: 14px 16px;
   border-radius: 14px;
-  background: #151922;
+  background: var(--phone-panel);
   border: 1px solid #2a3040;
   box-shadow: 0 8px 16px rgba(0, 0, 0, 0.35);
   font-weight: 600;
@@ -34,16 +34,16 @@
 }
 
 .phv2-phase[data-phase='planning'] {
-  border-color: #4caf50;
-  background: linear-gradient(180deg, #1a2a20 0%, #151922 100%);
+  border-color: var(--phone-success);
+  background: linear-gradient(180deg, #1a2a20 0%, var(--phone-panel) 100%);
 }
 .phv2-phase[data-phase='ready'] {
-  border-color: #ffb74d;
-  background: linear-gradient(180deg, #2a2010 0%, #151922 100%);
+  border-color: var(--phone-warn);
+  background: linear-gradient(180deg, #2a2010 0%, var(--phone-panel) 100%);
 }
 .phv2-phase[data-phase='resolving'] {
-  border-color: #4fc3f7;
-  background: linear-gradient(180deg, #102030 0%, #151922 100%);
+  border-color: var(--phone-accent);
+  background: linear-gradient(180deg, #102030 0%, var(--phone-panel) 100%);
   animation: phv2-pulse 1.2s ease-in-out infinite;
 }
 .phv2-phase[data-phase='ended'] {
@@ -76,7 +76,7 @@
 
 /* CARD PG */
 .phv2-card {
-  background: linear-gradient(180deg, #1d2230 0%, #151922 100%);
+  background: linear-gradient(180deg, var(--phone-panel-alt) 0%, var(--phone-panel) 100%);
   border: 1px solid #2a3040;
   border-radius: 14px;
   padding: 14px 16px;
@@ -99,8 +99,8 @@
   align-items: center;
   justify-content: center;
   font-size: 1.8rem;
-  color: #4fc3f7;
-  border: 2px solid #4fc3f7;
+  color: var(--phone-accent);
+  border: 2px solid var(--phone-accent);
   flex-shrink: 0;
 }
 
@@ -112,7 +112,7 @@
 
 .phv2-card-meta {
   font-size: 0.82rem;
-  color: #8891a3;
+  color: var(--phone-fg-dim);
   margin-top: 2px;
 }
 
@@ -123,7 +123,7 @@
 }
 
 .phv2-stat {
-  background: #0b0d12;
+  background: var(--phone-bg-deep);
   border: 1px solid #2a3040;
   border-radius: 8px;
   padding: 8px 6px;
@@ -136,7 +136,7 @@
 
 .phv2-stat-label {
   font-size: 0.7rem;
-  color: #8891a3;
+  color: var(--phone-fg-dim);
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 1px;
@@ -147,7 +147,7 @@
   font-size: 0.78rem;
   text-transform: uppercase;
   letter-spacing: 1.2px;
-  color: #8891a3;
+  color: var(--phone-fg-dim);
   font-weight: 700;
   margin-bottom: 8px;
 }
@@ -160,11 +160,11 @@
 }
 
 .phv2-action-tile {
-  background: #1d2230;
+  background: var(--phone-panel-alt);
   border: 1px solid #2a3040;
   border-radius: 12px;
   padding: 14px 8px;
-  color: #e8eaf0;
+  color: var(--phone-fg);
   font-family: inherit;
   cursor: pointer;
   display: flex;
@@ -184,12 +184,12 @@
 
 .phv2-action-tile:hover:not(:disabled) {
   background: #2a3040;
-  border-color: #4fc3f7;
+  border-color: var(--phone-accent);
 }
 
 .phv2-action-tile.selected {
   background: #1a3a50;
-  border-color: #4fc3f7;
+  border-color: var(--phone-accent);
   box-shadow: 0 0 0 2px rgba(79, 195, 247, 0.25);
 }
 
@@ -215,10 +215,10 @@
   justify-content: space-between;
   align-items: center;
   padding: 12px 14px;
-  background: #1d2230;
+  background: var(--phone-panel-alt);
   border: 1px solid #2a3040;
   border-radius: 10px;
-  color: #e8eaf0;
+  color: var(--phone-fg);
   font-family: inherit;
   cursor: pointer;
   font-size: 0.95rem;
@@ -227,12 +227,12 @@
 
 .phv2-target:hover:not(:disabled) {
   background: #2a3040;
-  border-color: #ef5350;
+  border-color: var(--phone-danger);
 }
 
 .phv2-target.selected {
   background: #3a1a1a;
-  border-color: #ef5350;
+  border-color: var(--phone-danger);
   box-shadow: 0 0 0 2px rgba(239, 83, 80, 0.3);
 }
 
@@ -241,14 +241,14 @@
 }
 .phv2-target-hp {
   font-size: 0.82rem;
-  color: #8891a3;
+  color: var(--phone-fg-dim);
   font-variant-numeric: tabular-nums;
 }
 
 .phv2-empty {
   padding: 12px;
   text-align: center;
-  color: #8891a3;
+  color: var(--phone-fg-dim);
   font-size: 0.85rem;
   font-style: italic;
 }
@@ -265,8 +265,8 @@
   font-size: 1.05rem;
   font-weight: 700;
   border-radius: 12px;
-  border: 1px solid #4caf50;
-  background: #4caf50;
+  border: 1px solid var(--phone-success);
+  background: var(--phone-success);
   color: #001014;
   cursor: pointer;
   font-family: inherit;
@@ -284,16 +284,16 @@
   opacity: 0.35;
   cursor: not-allowed;
   background: #2a3040;
-  color: #8891a3;
+  color: var(--phone-fg-dim);
   border-color: #2a3040;
 }
 
 .phv2-cancel {
   padding: 14px 18px;
   border-radius: 12px;
-  border: 1px solid #ef5350;
+  border: 1px solid var(--phone-danger);
   background: transparent;
-  color: #ef5350;
+  color: var(--phone-danger);
   font-weight: 600;
   cursor: pointer;
   font-family: inherit;
@@ -311,13 +311,13 @@
   min-height: 1.2em;
   font-size: 0.85rem;
   text-align: center;
-  color: #8891a3;
+  color: var(--phone-fg-dim);
 }
 .phv2-status[data-kind='ok'] {
   color: #66bb6a;
 }
 .phv2-status[data-kind='err'] {
-  color: #ef5350;
+  color: var(--phone-danger);
 }
 
 /* PARTY ROSTER */
@@ -332,27 +332,27 @@
   align-items: center;
   gap: 10px;
   padding: 10px 12px;
-  background: #1d2230;
+  background: var(--phone-panel-alt);
   border: 1px solid #2a3040;
   border-radius: 10px;
   font-size: 0.9rem;
 }
 
 .phv2-party-row.ready {
-  border-color: #4caf50;
-  background: linear-gradient(90deg, #1a2a20 0%, #1d2230 70%);
+  border-color: var(--phone-success);
+  background: linear-gradient(90deg, #1a2a20 0%, var(--phone-panel-alt) 70%);
 }
 
 .phv2-party-dot {
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: #8891a3;
+  background: var(--phone-fg-dim);
   flex-shrink: 0;
 }
 
 .phv2-party-row.ready .phv2-party-dot {
-  background: #4caf50;
+  background: var(--phone-success);
 }
 
 .phv2-party-name {
@@ -362,16 +362,16 @@
 
 .phv2-party-status {
   font-size: 0.78rem;
-  color: #8891a3;
+  color: var(--phone-fg-dim);
 }
 
 .phv2-party-row.ready .phv2-party-status {
-  color: #4caf50;
+  color: var(--phone-success);
 }
 
 /* CHAT */
 .phv2-section-chat {
-  background: #0b0d12;
+  background: var(--phone-bg-deep);
   border: 1px solid #2a3040;
   border-radius: 12px;
   padding: 12px;
@@ -400,7 +400,7 @@
 }
 
 .phv2-chat-from {
-  color: #4fc3f7;
+  color: var(--phone-accent);
   font-weight: 600;
   flex-shrink: 0;
   max-width: 30%;
@@ -410,7 +410,7 @@
 }
 
 .phv2-chat-row.self .phv2-chat-from {
-  color: #ffb74d;
+  color: var(--phone-warn);
 }
 
 .phv2-chat-text {
@@ -427,24 +427,24 @@
 .phv2-chat-form input {
   flex: 1;
   padding: 10px 12px;
-  background: #151922;
+  background: var(--phone-panel);
   border: 1px solid #2a3040;
   border-radius: 8px;
-  color: #e8eaf0;
+  color: var(--phone-fg);
   font-family: inherit;
   font-size: 0.9rem;
 }
 
 .phv2-chat-form input:focus {
   outline: none;
-  border-color: #4fc3f7;
+  border-color: var(--phone-accent);
 }
 
 .phv2-chat-form button {
   padding: 10px 14px;
-  background: #4fc3f7;
+  background: var(--phone-accent);
   color: #001014;
-  border: 1px solid #4fc3f7;
+  border: 1px solid var(--phone-accent);
   border-radius: 8px;
   font-weight: 600;
   cursor: pointer;

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -46,6 +46,21 @@
   --hp-full: #4caf50;
   --hp-warn: #ffc107;
   --hp-crit: #f44336;
+
+  /* Phone composer namespace tokens (P1-13 ui-design-illuminator 2026-04-26).
+   * Centralizza palette phoneComposerV2.css per evitare hardcoded hex drift.
+   * Distinct namespace from --bg/--fg/--panel: phone è dark-deep (TV è dark-warm). */
+  --phone-bg-top: #111827;
+  --phone-bg-bot: #05070c;
+  --phone-bg-deep: #0b0d12;
+  --phone-panel: #151922;
+  --phone-panel-alt: #1d2230;
+  --phone-fg: #e8eaf0;
+  --phone-fg-dim: #8891a3;
+  --phone-accent: #4fc3f7;
+  --phone-success: #4caf50;
+  --phone-warn: #ffb74d;
+  --phone-danger: #ef5350;
 }
 
 /* W8 — Bump html base 16→17px per TV-first readability (42-SG).


### PR DESCRIPTION
## Summary

P1 fix da audit \`ui-design-illuminator\` 2026-04-26.

### Problem
\`phoneComposerV2.css\` aveva **22 hex hardcoded distinti**, palette drift vs \`style.css\` canonical tokens. Tre palette parallele (style.css + phoneComposerV2 + render.js) = manutenzione fragile.

### Fix

**1. \`style.css\`: nuovo namespace \`--phone-*\` (11 token)**
\`\`\`css
--phone-bg-top: #111827;
--phone-bg-bot: #05070c;
--phone-bg-deep: #0b0d12;
--phone-panel: #151922;
--phone-panel-alt: #1d2230;
--phone-fg: #e8eaf0;
--phone-fg-dim: #8891a3;
--phone-accent: #4fc3f7;
--phone-success: #4caf50;
--phone-warn: #ffb74d;
--phone-danger: #ef5350;
\`\`\`

**2. \`phoneComposerV2.css\` sed replace** su 11 hex più frequenti: **48 occorrenze sostituite** con \`var(--phone-*)\`.

### Residual hex (9)
Gradient stops + hover variants specifici (\`#001014\`, \`#102030\`, \`#1a2a20\`, \`#1a3a50\`, \`#2a2010\`, \`#2a3040\`, \`#3a1a1a\`, \`#66bb6a\`, \`#66c669\`, \`#66d1fb\`). Bassa priorità: cleanup futuro se servono varianti ulteriori.

## Test plan

- [x] AI test 311/311 verde (no JS impact)
- [x] \`phoneComposerV2.js\` zero hex hardcoded (audit cleared)
- [x] Visual regression: pixel-identical (var() resolve same valori)
- [ ] Validate post-merge: tema chiaro non rompe (no media queries phone-only)

## Rollback

\`git revert <sha>\` — rimuove namespace + restore hex hardcoded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)