### PR TITLE
feat(balance): Pathfinder XP budget runtime engine (P1-Tier-E)

### DIFF
--- a/apps/backend/services/balance/xpBudget.js
+++ b/apps/backend/services/balance/xpBudget.js
@@ -1,0 +1,187 @@
+// 2026-04-26 — Pathfinder XP budget runtime engine (P1 Tier-E adoption).
+//
+// Source: docs/research/2026-04-26-tier-e-extraction-matrix.md (Pathfinder XP budget).
+// Donor pattern: Pathfinder TTRPG Encounter Building XP budget approach.
+//
+// Funzione:
+//   - computeUnitXp(unit) — XP value singolo unit basato su stats
+//   - computeEncounterBudget(encounterClass, partySize) — budget atteso
+//   - auditEncounter(encounter, partySize) — confronto budget vs used
+//
+// Wire opzionale in:
+//   - apps/backend/routes/session.js /start (audit warning log)
+//   - tools/py/batch_calibrate_*.py (pre-run sanity check)
+//   - balance-illuminator agent (audit mode)
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const CONFIG_PATH = path.resolve(__dirname, '../../../../data/core/balance/xp_budget.yaml');
+
+let _config = null;
+
+function loadConfig() {
+  if (_config) return _config;
+  try {
+    const raw = fs.readFileSync(CONFIG_PATH, 'utf-8');
+    _config = yaml.load(raw);
+    return _config;
+  } catch (err) {
+    console.warn('[xpBudget] config not loaded:', err.message);
+    _config = {
+      encounter_classes: {},
+      party_size_modifiers: {},
+      unit_xp_formula: {},
+      audit_defaults: {},
+    };
+    return _config;
+  }
+}
+
+/**
+ * Compute XP value of a unit basato su stats.
+ * Formula: hp*w + mod*w + ap*w + range*w + tier_bonus + guardia*w
+ */
+function computeUnitXp(unit) {
+  if (!unit || typeof unit !== 'object') return 0;
+  const cfg = loadConfig().unit_xp_formula || {};
+  const hp = Number(unit.hp || unit.max_hp || 0);
+  const mod = Number(unit.mod || 0);
+  const ap = Number(unit.ap || 0);
+  // Range default = 0 (no XP) per unit incomplete; presupposto: caller fornisce stats reali.
+  const range = Number(unit.range ?? unit.attack_range ?? 0);
+  const guardia = Number(unit.guardia || 0);
+  const tier = String(unit.tier || 'base').toLowerCase();
+  const isBossId = typeof unit.id === 'string' && /_boss\b/.test(unit.id);
+
+  let xp = 0;
+  xp += hp * (cfg.hp_weight || 2.0);
+  xp += mod * (cfg.mod_weight || 8.0);
+  xp += ap * (cfg.ap_weight || 6.0);
+  xp += range * (cfg.range_weight || 4.0);
+  xp += guardia * (cfg.guardia_weight || 5.0);
+
+  // Tier bonus: usa SOLO tier_bonus[tier]. Boss-by-id check aggiunge bonus
+  // SE tier non è già 'boss' (dedup).
+  const tierBonuses = cfg.tier_bonus || {};
+  xp += Number(tierBonuses[tier] ?? tierBonuses.base ?? 0);
+  if (isBossId && tier !== 'boss') {
+    xp += Number(tierBonuses.boss ?? 200);
+  }
+
+  return Math.round(xp);
+}
+
+/**
+ * Compute encounter XP budget per (class, partySize).
+ * Returns 0 se class non in catalog.
+ */
+function computeEncounterBudget(encounterClass, partySize = 4) {
+  const cfg = loadConfig();
+  const classCfg = (cfg.encounter_classes || {})[encounterClass];
+  if (!classCfg) return 0;
+  const base = Number(classCfg.budget_base || 0);
+  const modifiers = cfg.party_size_modifiers || {};
+  const sizeKey = String(Math.max(1, Math.min(8, Number(partySize) || 4)));
+  const mod = Number(modifiers[sizeKey] ?? 1.0);
+  return Math.round(base * mod);
+}
+
+/**
+ * Audit encounter: confronta total enemy XP vs budget atteso.
+ * Returns { budget, used, ratio, status: 'under'|'in_band'|'over'|'critical_over', ... }
+ */
+function auditEncounter(encounter, partySize = 4) {
+  if (!encounter || typeof encounter !== 'object') {
+    return { budget: 0, used: 0, ratio: 0, status: 'no_encounter' };
+  }
+  const cls = encounter.encounter_class || 'standard';
+  const budget = computeEncounterBudget(cls, partySize);
+
+  // Sum XP of all enemy units in waves.
+  const waves = Array.isArray(encounter.waves) ? encounter.waves : [];
+  let used = 0;
+  let unitCount = 0;
+  for (const wave of waves) {
+    const units = Array.isArray(wave.units) ? wave.units : [];
+    for (const uSpec of units) {
+      const count = Number(uSpec.count || 1);
+      // Approximate unit stats da species + tier (hp/mod/ap defaults).
+      const tier = String(uSpec.tier || 'base').toLowerCase();
+      const baseStats = {
+        hp: tier === 'boss' ? 30 : tier === 'elite' || tier === 'apex' ? 12 : 6,
+        mod: tier === 'boss' ? 4 : tier === 'elite' ? 3 : 2,
+        ap: 2,
+        range: 1,
+        guardia: tier === 'boss' ? 3 : tier === 'elite' ? 1 : 0,
+        tier,
+      };
+      const xpPer = computeUnitXp(baseStats);
+      used += xpPer * count;
+      unitCount += count;
+    }
+  }
+
+  // Reinforcement_pool: contribuisce average XP * max_total_spawns (worst-case).
+  const reinfPool = Array.isArray(encounter.reinforcement_pool) ? encounter.reinforcement_pool : [];
+  const reinfPolicy = encounter.reinforcement_policy || {};
+  const maxReinforcement = Number(reinfPolicy.max_total_spawns || 0);
+  if (reinfPool.length > 0 && maxReinforcement > 0) {
+    let avgPoolXp = 0;
+    for (const entry of reinfPool) {
+      const tier = String(entry.tier || 'base').toLowerCase();
+      const baseStats = {
+        hp: tier === 'boss' ? 30 : tier === 'elite' || tier === 'apex' ? 12 : 6,
+        mod: tier === 'boss' ? 4 : tier === 'elite' ? 3 : 2,
+        ap: 2,
+        range: 1,
+        guardia: 0,
+        tier,
+      };
+      avgPoolXp += computeUnitXp(baseStats);
+    }
+    avgPoolXp = avgPoolXp / reinfPool.length;
+    used += Math.round(avgPoolXp * maxReinforcement);
+  }
+
+  const ratio = budget > 0 ? used / budget : 0;
+  const cfg = loadConfig();
+  const cls_cfg = (cfg.encounter_classes || {})[cls] || {};
+  const oobPct = Number(cls_cfg.out_of_band_pct ?? 0.2);
+  const audit = cfg.audit_defaults || {};
+  const criticalOver = 1 + Number(audit.critical_over_pct ?? 0.5);
+
+  let status;
+  if (budget === 0) status = 'no_budget_config';
+  else if (ratio < 1 - oobPct) status = 'under';
+  else if (ratio > criticalOver) status = 'critical_over';
+  else if (ratio > 1 + oobPct) status = 'over';
+  else status = 'in_band';
+
+  return {
+    budget,
+    used,
+    ratio: Math.round(ratio * 100) / 100,
+    status,
+    encounter_class: cls,
+    party_size: partySize,
+    enemy_unit_count: unitCount,
+    reinforcement_max: maxReinforcement,
+    out_of_band_pct: oobPct,
+  };
+}
+
+function _resetCache() {
+  _config = null;
+}
+
+module.exports = {
+  computeUnitXp,
+  computeEncounterBudget,
+  auditEncounter,
+  _resetCache,
+  CONFIG_PATH,
+};

--- a/data/core/balance/xp_budget.yaml
+++ b/data/core/balance/xp_budget.yaml
@@ -1,0 +1,73 @@
+schema_version: "0.1.0"
+generated_at: "2026-04-26"
+notes: |
+  Pathfinder TTRPG XP budget transfer (P1-Tier-E adoption).
+  Source: docs/research/2026-04-26-tier-e-extraction-matrix.md (Pathfinder XP budget).
+
+  Pattern:
+    1. Encounter ha XP budget target basato su difficulty + party_size
+    2. Unit XP value calcolato da formula stat-based
+    3. Sum unit XP nemici vs budget = audit fairness
+    4. Out-of-band warning per calibration designer
+
+  Cross-ref:
+  - apps/backend/services/balance/xpBudget.js (runtime engine)
+  - apps/backend/services/balance/damageCurves.js (existing class multiplier)
+  - tools/py/batch_calibrate_*.py (future: integration audit pre-batch)
+
+# Encounter XP budget per encounter_class.
+# Formula: budget_total = budget_base * party_size_modifier
+encounter_classes:
+  tutorial:
+    budget_base: 80
+    notes: "Onboarding gentile, alta tolleranza overshoot per teaching."
+    out_of_band_pct: 0.30  # tolleranza ±30%
+  tutorial_advanced:
+    budget_base: 120
+    out_of_band_pct: 0.25
+  standard:
+    budget_base: 200
+    out_of_band_pct: 0.20  # ±20% standard band
+  elite:
+    budget_base: 320
+    out_of_band_pct: 0.20
+  hardcore:
+    budget_base: 400
+    out_of_band_pct: 0.15  # banda stretta - calibration critical
+  boss:
+    budget_base: 600
+    out_of_band_pct: 0.20  # boss spike accettabile
+
+# Party size modifier (Pathfinder-style scaling).
+# 1 player = 0.5x budget (riduce difficulty), 4+ = 1.0x (baseline), 8 = 1.6x.
+party_size_modifiers:
+  1: 0.5
+  2: 0.7
+  3: 0.85
+  4: 1.0   # baseline
+  5: 1.15
+  6: 1.3
+  7: 1.45
+  8: 1.6
+
+# Unit XP value formula:
+#   xp = (hp * hp_weight) + (mod * mod_weight) + (ap * ap_weight)
+#        + (range * range_weight) + tier_bonus + boss_bonus
+# Approssima Pathfinder CR (Challenge Rating) -> XP table.
+unit_xp_formula:
+  hp_weight: 2.0       # 10 HP -> 20 XP
+  mod_weight: 8.0      # mod +3 -> 24 XP
+  ap_weight: 6.0       # ap 2 -> 12 XP, ap 3 -> 18 XP
+  range_weight: 4.0    # range 2 -> 8 XP (vs range 1 -> 4 XP)
+  tier_bonus:
+    base: 0
+    elite: 50
+    apex: 120
+    boss: 200
+  guardia_weight: 5.0  # guardia 1 -> 5 XP
+
+# Default difficulty audit thresholds (cross-encounter aggregate).
+audit_defaults:
+  warn_under_pct: 0.20  # report se used/budget < 0.80
+  warn_over_pct: 0.20   # report se used/budget > 1.20
+  critical_over_pct: 0.50  # P0 imbalance se > 1.50

--- a/tests/services/xpBudget.test.js
+++ b/tests/services/xpBudget.test.js
@@ -1,0 +1,127 @@
+// 2026-04-26 — xpBudget service tests (P1 Tier-E Pathfinder adoption).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  computeUnitXp,
+  computeEncounterBudget,
+  auditEncounter,
+  _resetCache,
+} = require('../../apps/backend/services/balance/xpBudget');
+
+test('computeUnitXp: base unit (hp 6, mod 2, ap 2, range 1) yields > 0', () => {
+  const xp = computeUnitXp({ hp: 6, mod: 2, ap: 2, range: 1, tier: 'base' });
+  assert.ok(xp > 0, `expected xp > 0, got ${xp}`);
+  // 6*2 + 2*8 + 2*6 + 1*4 = 12+16+12+4 = 44
+  assert.equal(xp, 44);
+});
+
+test('computeUnitXp: boss tier vs base = +200 (no double)', () => {
+  const baseStats = { hp: 30, mod: 4, ap: 3, range: 2, guardia: 3 };
+  const baseXp = computeUnitXp({ ...baseStats, tier: 'base' });
+  const bossXp = computeUnitXp({ ...baseStats, tier: 'boss' });
+  assert.ok(bossXp > baseXp, 'boss > base');
+  // Boss tier_bonus = 200; base tier_bonus = 0. Delta = 200.
+  assert.equal(bossXp - baseXp, 200);
+});
+
+test('computeUnitXp: boss-by-id non-boss-tier adds bonus once', () => {
+  const baseStats = { hp: 30, mod: 4, ap: 3, range: 2, guardia: 3 };
+  const baseXp = computeUnitXp({ ...baseStats, tier: 'base' });
+  const bossIdXp = computeUnitXp({ ...baseStats, id: 'e_apex_boss', tier: 'base' });
+  // id pattern aggiunge boss_bonus 200 anche se tier=base
+  assert.equal(bossIdXp - baseXp, 200);
+});
+
+test('computeUnitXp: elite tier adds 50', () => {
+  const stats = { hp: 12, mod: 3, ap: 2, range: 1 };
+  const baseXp = computeUnitXp({ ...stats, tier: 'base' });
+  const eliteXp = computeUnitXp({ ...stats, tier: 'elite' });
+  assert.equal(eliteXp - baseXp, 50);
+});
+
+test('computeUnitXp: null/empty returns 0', () => {
+  assert.equal(computeUnitXp(null), 0);
+  assert.equal(computeUnitXp(undefined), 0);
+  assert.equal(computeUnitXp({}), 0);
+});
+
+test('computeEncounterBudget: tutorial 4-player = 80 base * 1.0 = 80', () => {
+  assert.equal(computeEncounterBudget('tutorial', 4), 80);
+});
+
+test('computeEncounterBudget: hardcore 8-player = 400 * 1.6 = 640', () => {
+  assert.equal(computeEncounterBudget('hardcore', 8), 640);
+});
+
+test('computeEncounterBudget: standard 1-player = 200 * 0.5 = 100', () => {
+  assert.equal(computeEncounterBudget('standard', 1), 100);
+});
+
+test('computeEncounterBudget: unknown class returns 0', () => {
+  assert.equal(computeEncounterBudget('nonexistent', 4), 0);
+});
+
+test('auditEncounter: standard encounter 4p with 4 base units in_band', () => {
+  const enc = {
+    encounter_class: 'standard',
+    waves: [
+      {
+        units: [{ tier: 'base', count: 4 }],
+      },
+    ],
+  };
+  const audit = auditEncounter(enc, 4);
+  assert.equal(audit.encounter_class, 'standard');
+  assert.equal(audit.budget, 200);
+  assert.ok(audit.used > 0);
+  assert.equal(audit.enemy_unit_count, 4);
+  assert.ok(['under', 'in_band', 'over'].includes(audit.status));
+});
+
+test('auditEncounter: tutorial 4p with 1 boss = critical_over', () => {
+  const enc = {
+    encounter_class: 'tutorial',
+    waves: [
+      {
+        units: [{ tier: 'boss', count: 1 }],
+      },
+    ],
+  };
+  const audit = auditEncounter(enc, 4);
+  assert.equal(audit.budget, 80);
+  // boss xp ~30*2 + 4*8 + 2*6 + 1*4 + 3*5 + 200 = 60+32+12+4+15+200 = 323
+  // ratio 323/80 = 4.04 > 1.50 = critical_over
+  assert.equal(audit.status, 'critical_over');
+});
+
+test('auditEncounter: no encounter returns no_encounter status', () => {
+  const audit = auditEncounter(null);
+  assert.equal(audit.status, 'no_encounter');
+});
+
+test('auditEncounter: unknown class returns no_budget_config', () => {
+  const enc = { encounter_class: 'phantom_class', waves: [] };
+  const audit = auditEncounter(enc, 4);
+  assert.equal(audit.status, 'no_budget_config');
+});
+
+test('auditEncounter: includes reinforcement_pool worst-case', () => {
+  const encNoReinf = {
+    encounter_class: 'hardcore',
+    waves: [{ units: [{ tier: 'elite', count: 2 }] }],
+  };
+  const encWithReinf = {
+    ...encNoReinf,
+    reinforcement_policy: { max_total_spawns: 4 },
+    reinforcement_pool: [{ tier: 'base' }],
+  };
+  const auditNo = auditEncounter(encNoReinf, 4);
+  const auditWith = auditEncounter(encWithReinf, 4);
+  assert.ok(
+    auditWith.used > auditNo.used,
+    `with reinforcement (${auditWith.used}) > without (${auditNo.used})`,
+  );
+});


### PR DESCRIPTION
## Summary

P1 fix da audit \`balance-illuminator\` + Tier E extraction matrix 2026-04-26.

### Source pattern
Pathfinder TTRPG Encounter Building XP budget approach.

Source: \`docs/research/2026-04-26-tier-e-extraction-matrix.md\` (Pathfinder XP).
Sprint backlog: P0 swap proposal (default B v2 ~21h full pillar coverage).

## Components

### \`data/core/balance/xp_budget.yaml\` NEW (~70 LOC)
Config table:
- **encounter_classes**: tutorial 80, tutorial_advanced 120, standard 200, elite 320, hardcore 400, boss 600 (\`budget_base\` + \`out_of_band_pct\` per class)
- **party_size_modifiers**: 1p=0.5x → 8p=1.6x (Pathfinder-style scaling)
- **unit_xp_formula**: \`hp_weight\`, \`mod_weight\`, \`ap_weight\`, \`range_weight\`, \`guardia_weight\`, \`tier_bonus\` per base/elite/apex/boss
- **audit_defaults**: warn thresholds under/over/critical_over

### \`apps/backend/services/balance/xpBudget.js\` NEW (~150 LOC)

3 funzioni public:
- \`computeUnitXp(unit)\` — XP value singolo unit
- \`computeEncounterBudget(class, partySize)\` — budget atteso
- \`auditEncounter(encounter, partySize)\` — confronto + status: \`under\` / \`in_band\` / \`over\` / \`critical_over\`. Include \`reinforcement_pool\` worst-case (\`max_total_spawns * avg_pool_xp\`)

### \`tests/services/xpBudget.test.js\` NEW (14 test verdi)
- computeUnitXp: base/boss-tier/boss-by-id/elite/null edge cases
- computeEncounterBudget: 4 class × party size
- auditEncounter: in_band / critical_over / no_encounter / no_budget_config / reinforcement worst-case

## Use case sblocco

- **balance-illuminator** agent può audit encounter pre-ship
- **Calibration harness** pre-N=10 sanity check (auto-skip se \`critical_over\` senza calibration)
- **Future** TKT-CREATURE-SPORE-XP per part-pack runtime audit (vedi spore extraction agent output)

## Effort vs audit

Audit estimate **5-7h**. Actual **~1.5h** (config + service + test).

## Test plan

- [x] AI test 311/311 verde
- [x] xpBudget 14/14 verde
- [x] Schema drift = 0
- [ ] Wire opzionale: future PR integration in \`session.js /start\` audit log
- [ ] Wire opzionale: \`tools/py/batch_calibrate_*.py\` pre-run sanity check

## Rollback

\`git revert <sha>\` — rimuove config + service + tests. Zero impatto runtime (no wire downstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)