### PR TITLE
feat(combat): FFT Wait action defer turn (P0 Tier S quick-win)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -1499,6 +1499,45 @@ function createSessionRouter(options = {}) {
         });
       }
 
+      // 2026-04-26 P0 quick-win — FFT Wait action (Tier S donor pattern).
+      // Player rinuncia all'azione corrente in cambio di +1 initiative_bonus
+      // sul prossimo round (defer turn, riprendi prima next round).
+      // Costa AP rimanenti (mette a 0) ma NON consuma PT/PP.
+      // Cost zero: pure tactical timing tool, no resource trade.
+      // Source: docs/research/2026-04-26-tier-s-extraction-matrix.md (FFT)
+      if (actionType === 'wait') {
+        const apBefore = Number(actor.ap_remaining ?? actor.ap ?? 0);
+        if (apBefore <= 0) {
+          return res
+            .status(400)
+            .json({ error: 'wait richiede almeno 1 AP rimanente (turno gia consumato)' });
+        }
+        actor.ap_remaining = 0;
+        // Initiative bonus persistente fino a next round_clear (decay manuale via roundOrchestrator).
+        actor.initiative_bonus_next_round = Number(actor.initiative_bonus_next_round || 0) + 1;
+        await appendEvent(session, {
+          ts: new Date().toISOString(),
+          session_id: session.session_id,
+          actor_id: actor.id,
+          actor_species: actor.species,
+          actor_job: actor.job,
+          action_type: 'wait',
+          turn: session.turn,
+          ap_spent: apBefore,
+          ap_before: apBefore,
+          ap_after: 0,
+          initiative_bonus_next_round: actor.initiative_bonus_next_round,
+          trait_effects: [],
+        });
+        return res.json({
+          ok: true,
+          actor_id: actor.id,
+          ap_remaining: 0,
+          initiative_bonus_next_round: actor.initiative_bonus_next_round,
+          state: publicSessionView(session),
+        });
+      }
+
       // SPRINT_022: nuova azione 'turn' per ruotare senza muoversi.
       // Costa 0 AP (libera, come reazione) — cosi' il giocatore puo'
       // riposizionarsi visivamente a fine turno per prevenire backstab


### PR DESCRIPTION
## Summary

P0 quick-win bundle B v2 — Tier S donor pattern (FFT Wait action).

### Pattern
Player rinuncia azione corrente → \`+1 initiative_bonus_next_round\` (defer turn, riprendi prima next round). FFT canonical mechanic.

### Implementation (39 LOC, additivo)
\`session.js\` POST \`/action\` handler accetta \`action_type='wait'\`:
- Require \`ap_remaining >= 1\` (turno non già consumato)
- \`actor.ap_remaining → 0\`
- \`actor.initiative_bonus_next_round += 1\` (cumulative)
- \`appendEvent\` action_type='wait' con \`ap_before/after\` + bonus

### Bonus consumption
\`initiative_bonus_next_round\` persistente fino al next \`round_clear\`. Decay via \`roundOrchestrator\` separate PR (wire follow-up).

## Test plan

- [x] AI test 311/311 verde
- [x] Schema drift = 0
- [ ] E2E manual playtest verify pre-merge (env setup heavy per integration test)
- [ ] Wire roundOrchestrator initiative_bonus consumption (follow-up PR)

## Pillar coverage
**P1 Tattica leggibile** — adds tactical depth without resource trade. Pure timing tool, no PT/PP cost (FFT canonical).

## Effort vs audit
Audit estimate **3h**. Actual **~30min** (single endpoint extension).

## Rollback
\`git revert <sha>\` — rimuove handler \`action_type='wait'\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)