### PR TITLE
feat(narrative): Disco MBTI tag debrief insights (P0 Tier S quick-win)

### DIFF
--- a/apps/backend/services/narrative/mbtiInsights.js
+++ b/apps/backend/services/narrative/mbtiInsights.js
@@ -1,0 +1,154 @@
+// 2026-04-26 — Disco MBTI tag debrief (P0 Tier S quick-win, P4 surfacing).
+//
+// Source: docs/research/2026-04-26-tier-s-extraction-matrix.md (Disco Elysium)
+// Pattern donor: Disco Elysium thought cabinet diegetic reveal.
+//
+// Funzione: per ogni actor a fine session, genera 1-2 MBTI insight in
+// italiano narrativo (NO statistic dump). Reveal diegetic con metafora
+// adatta alla persona Skiv (palette deserto-tattica) + altri species.
+//
+// Wire: apps/backend/services/rewardEconomy.js buildDebriefSummary()
+//   aggiunge field debrief.mbti_insights[actor_id] = ['frase 1', 'frase 2']
+//
+// Narrative quality: 1-2 frasi ciascuna, evita "your INTP score 0.85".
+// Invece: "il tuo agire pesa il piano prima del passo" (diegetic).
+
+'use strict';
+
+// MBTI 4-axis insight palette. Italian narrative, action-anchored.
+// Format: { high: string, low: string }  — high = pole positivo (E/N/T/J),
+// low = pole opposite (I/S/F/P).
+const AXIS_INSIGHTS = {
+  E_I: {
+    high: [
+      'Cerchi sempre il primo contatto: il tuo passo va incontro al rischio.',
+      'Le tue azioni dichiarano presenza prima ancora di colpire.',
+    ],
+    low: [
+      'Osservi prima di muovere: la pausa è la tua prima arma.',
+      "Lasci che l'avversario si scopra: il tuo silenzio pesa la stanza.",
+    ],
+  },
+  S_N: {
+    high: [
+      "Vedi pattern dove altri vedono caos: leggi il bioma come una mappa d'intenzioni.",
+      'Il tuo agire pesa il piano prima del passo, anticipa il prossimo nodo.',
+    ],
+    low: [
+      "Conosci ogni pietra del sentiero: l'esperienza concreta guida la tua mano.",
+      'I dati immediati ti bastano: il presente è già una decisione.',
+    ],
+  },
+  T_F: {
+    high: [
+      "Il calcolo precede l'istinto: la tua scelta è una formula.",
+      "Pesi costo e ritorno con la freddezza di chi non si lascia distrarre dall'eco.",
+    ],
+    low: [
+      'I legami contano nei tuoi turni: chi cade pesa più del bilancio del round.',
+      "L'empatia detta il bersaglio: proteggi prima di ottimizzare.",
+    ],
+  },
+  J_P: {
+    high: [
+      'Pianifichi il round prima del primo dado: la struttura è la tua comodità.',
+      'Le tue mosse sono già tre passi avanti: il caos si piega alla tua agenda.',
+    ],
+    low: [
+      "Adatti il piano al rumore della battaglia: l'opportunità è il tuo strumento.",
+      "Cambi rotta a metà turno se la sabbia detta nuove tracce: l'improvvisazione è arma.",
+    ],
+  },
+};
+
+const ENNEA_INSIGHTS = {
+  1: 'Tipo 1 (Riformatore): cerchi la mossa giusta, non solo quella che funziona.',
+  2: 'Tipo 2 (Soccorritore): proteggi anche a costo di esporre te stesso.',
+  3: 'Tipo 3 (Realizzatore): la vittoria conta come segnale, non come fine.',
+  4: 'Tipo 4 (Individualista): scegli la rotta che nessun altro vedrebbe.',
+  5: 'Tipo 5 (Investigatore): trattieni il colpo finché il quadro non è completo.',
+  6: 'Tipo 6 (Lealista): il pattern fidato vince sul colpo brillante.',
+  7: 'Tipo 7 (Esploratore): salti opzioni, raccogli combo prima della fine.',
+  8: 'Tipo 8 (Sfidante): rompi la catena di pressione del Sistema.',
+  9: 'Tipo 9 (Pacificatore): preferisci il riposizionamento al frontale.',
+};
+
+/**
+ * Estrae axis tag dal MBTI type (es. 'INTP' -> ['I','N','T','P']).
+ * Returns null se invalid.
+ */
+function _parseMbtiAxes(mbtiType) {
+  if (!mbtiType || typeof mbtiType !== 'string' || mbtiType.length !== 4) return null;
+  const upper = mbtiType.toUpperCase();
+  const axes = {
+    E_I: upper[0] === 'E' ? 'high' : 'low',
+    S_N: upper[1] === 'N' ? 'high' : 'low',
+    T_F: upper[2] === 'T' ? 'high' : 'low',
+    J_P: upper[3] === 'J' ? 'high' : 'low',
+  };
+  return axes;
+}
+
+/**
+ * Genera 1-2 insight per un singolo actor VC snapshot.
+ *
+ * @param {object} vc — single actor VC: { mbti_type, ennea_archetypes, aggregate_indices, axes_confidence? }
+ * @param {object} opts — { axisCount: number = 1, includeEnnea: boolean = true, maxAxes: 2 }
+ * @returns {Array<string>} array insight strings (1-2 entries)
+ */
+function generateActorInsights(vc, opts = {}) {
+  const { axisCount = 1, includeEnnea = true, maxAxes = 2 } = opts;
+  if (!vc || typeof vc !== 'object') return [];
+
+  const insights = [];
+  const axes = _parseMbtiAxes(vc.mbti_type);
+  if (axes) {
+    // Pick top-N axes by confidence (se confidence map disponibile, altrimenti random stable).
+    const conf = vc.axes_confidence || {};
+    const axisOrder = Object.entries(axes)
+      .map(([k, dir]) => ({ axis: k, dir, conf: Number(conf[k] ?? 0.5) }))
+      .sort((a, b) => b.conf - a.conf)
+      .slice(0, Math.min(maxAxes, Math.max(1, axisCount)));
+
+    for (const { axis, dir } of axisOrder) {
+      const palette = AXIS_INSIGHTS[axis];
+      if (!palette) continue;
+      const lines = palette[dir] || [];
+      if (lines.length === 0) continue;
+      // Stable pick: hash mbti_type + axis -> index (deterministic, no rng).
+      const seed = (vc.mbti_type + axis).split('').reduce((s, c) => s + c.charCodeAt(0), 0);
+      insights.push(lines[seed % lines.length]);
+    }
+  }
+
+  if (includeEnnea && Array.isArray(vc.ennea_archetypes) && vc.ennea_archetypes.length > 0) {
+    const top = vc.ennea_archetypes[0];
+    const enneaNum = Number(top?.type ?? top);
+    if (enneaNum >= 1 && enneaNum <= 9) {
+      insights.push(ENNEA_INSIGHTS[enneaNum]);
+    }
+  }
+
+  return insights;
+}
+
+/**
+ * Build insights map per tutti actors nel vcSnapshot.
+ * Output: { [unitId]: ['insight 1', 'insight 2', ...] }
+ */
+function buildMbtiInsights(vcSnapshot, opts = {}) {
+  const map = {};
+  if (!vcSnapshot || !vcSnapshot.per_actor) return map;
+  for (const [uid, vc] of Object.entries(vcSnapshot.per_actor)) {
+    const insights = generateActorInsights(vc, opts);
+    if (insights.length > 0) map[uid] = insights;
+  }
+  return map;
+}
+
+module.exports = {
+  generateActorInsights,
+  buildMbtiInsights,
+  AXIS_INSIGHTS,
+  ENNEA_INSIGHTS,
+};

--- a/apps/backend/services/rewardEconomy.js
+++ b/apps/backend/services/rewardEconomy.js
@@ -98,6 +98,17 @@ function convertPE(peBalance) {
 function buildDebriefSummary(session, vcSnapshot, peResult, pfSession = {}) {
   const conversion = convertPE(peResult.session_total);
 
+  // 2026-04-26 P0 quick-win — Disco MBTI tag debrief (Tier S donor).
+  // Genera 1-2 narrative insight per actor (italiano, diegetic, NO statistic dump).
+  // Best-effort: missing module non blocca debrief.
+  let mbtiInsights = {};
+  try {
+    const { buildMbtiInsights } = require('./narrative/mbtiInsights');
+    mbtiInsights = buildMbtiInsights(vcSnapshot, { axisCount: 1, includeEnnea: true });
+  } catch {
+    // narrative module optional
+  }
+
   return {
     session_id: session.session_id,
     turns_played: vcSnapshot.turns_played || 0,
@@ -122,6 +133,8 @@ function buildDebriefSummary(session, vcSnapshot, peResult, pfSession = {}) {
         ]),
       ),
     },
+    // P0 Tier S — Disco MBTI tag debrief (P4 surfacing, narrative diegetic).
+    mbti_insights: mbtiInsights,
     // Personality projection
     pf_session: pfSession,
     // Combat stats

--- a/tests/services/mbtiInsights.test.js
+++ b/tests/services/mbtiInsights.test.js
@@ -1,0 +1,101 @@
+// 2026-04-26 — mbtiInsights tests (P0 Tier S Disco quick-win).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  generateActorInsights,
+  buildMbtiInsights,
+  AXIS_INSIGHTS,
+  ENNEA_INSIGHTS,
+} = require('../../apps/backend/services/narrative/mbtiInsights');
+
+test('generateActorInsights: INTP yields 2 insights (1 axis + 1 ennea)', () => {
+  const vc = {
+    mbti_type: 'INTP',
+    ennea_archetypes: [{ type: 5 }],
+    aggregate_indices: { aggro: 0.4, explore: 0.7 },
+  };
+  const out = generateActorInsights(vc);
+  assert.equal(out.length, 2);
+  assert.ok(out[0].length > 10, 'axis insight non-empty');
+  assert.ok(out[1].includes('Tipo 5'), 'ennea insight Type 5');
+});
+
+test('generateActorInsights: empty mbti returns ennea only if present', () => {
+  const vc = {
+    mbti_type: null,
+    ennea_archetypes: [{ type: 7 }],
+  };
+  const out = generateActorInsights(vc);
+  assert.equal(out.length, 1);
+  assert.ok(out[0].includes('Tipo 7'));
+});
+
+test('generateActorInsights: invalid mbti format returns empty axes', () => {
+  const vc = {
+    mbti_type: 'XYZ', // invalid (3 chars)
+    ennea_archetypes: [],
+  };
+  const out = generateActorInsights(vc);
+  assert.equal(out.length, 0);
+});
+
+test('generateActorInsights: ENFJ axes high/high/low/high', () => {
+  const vc = {
+    mbti_type: 'ENFJ',
+    ennea_archetypes: [],
+  };
+  const out = generateActorInsights(vc);
+  assert.equal(out.length, 1);
+  // ENFJ: E (high E_I), N (high S_N), F (low T_F), J (high J_P)
+  // Pick axisCount=1 default → 1 axis insight
+});
+
+test('generateActorInsights: deterministic stable pick (no rng)', () => {
+  const vc = {
+    mbti_type: 'INTP',
+    ennea_archetypes: [{ type: 5 }],
+  };
+  const out1 = generateActorInsights(vc);
+  const out2 = generateActorInsights(vc);
+  assert.deepEqual(out1, out2, 'same input → same output');
+});
+
+test('buildMbtiInsights: empty vcSnapshot returns {}', () => {
+  assert.deepEqual(buildMbtiInsights(null), {});
+  assert.deepEqual(buildMbtiInsights({}), {});
+  assert.deepEqual(buildMbtiInsights({ per_actor: {} }), {});
+});
+
+test('buildMbtiInsights: 2 actors map by id', () => {
+  const snap = {
+    per_actor: {
+      p1: { mbti_type: 'INTP', ennea_archetypes: [{ type: 5 }] },
+      p2: { mbti_type: 'ESFP', ennea_archetypes: [{ type: 7 }] },
+    },
+  };
+  const out = buildMbtiInsights(snap);
+  assert.ok(out.p1, 'p1 has insights');
+  assert.ok(out.p2, 'p2 has insights');
+  assert.notEqual(out.p1[1], out.p2[1], 'different ennea types');
+});
+
+test('AXIS_INSIGHTS: all 4 axes present con high+low palette', () => {
+  const expected = ['E_I', 'S_N', 'T_F', 'J_P'];
+  for (const axis of expected) {
+    assert.ok(AXIS_INSIGHTS[axis], `${axis} present`);
+    assert.ok(Array.isArray(AXIS_INSIGHTS[axis].high), `${axis}.high array`);
+    assert.ok(Array.isArray(AXIS_INSIGHTS[axis].low), `${axis}.low array`);
+    assert.ok(AXIS_INSIGHTS[axis].high.length > 0, `${axis}.high non-empty`);
+    assert.ok(AXIS_INSIGHTS[axis].low.length > 0, `${axis}.low non-empty`);
+  }
+});
+
+test('ENNEA_INSIGHTS: all 9 types covered', () => {
+  for (let i = 1; i <= 9; i++) {
+    assert.ok(ENNEA_INSIGHTS[i], `Type ${i} present`);
+    assert.ok(ENNEA_INSIGHTS[i].includes(`Tipo ${i}`), `string contains 'Tipo ${i}'`);
+  }
+});


### PR DESCRIPTION
## Summary

P0 quick-win bundle B v2 — Tier S donor pattern (Disco Elysium thought cabinet).

## Pattern
Disco Elysium diegetic reveal: per ogni unit player a fine session, cita 1-2 \"MBTI tag insight\" basato su VC. **NO statistic dump**. Esempio:
> _\"Il tuo agire pesa il piano prima del passo, anticipa il prossimo nodo.\"_
> _\"Tipo 5 (Investigatore): trattieni il colpo finché il quadro non è completo.\"_

## Components

### \`apps/backend/services/narrative/mbtiInsights.js\` NEW (~140 LOC)
- \`AXIS_INSIGHTS\` — 4 axes E_I/S_N/T_F/J_P × high/low palette italiano narrativo
- \`ENNEA_INSIGHTS\` — 9 types (Riformatore/Soccorritore/Realizzatore/Individualista/Investigatore/Lealista/Esploratore/Sfidante/Pacificatore)
- \`generateActorInsights(vc, opts)\` — 1-2 insight per actor (deterministic stable pick via hash)
- \`buildMbtiInsights(vcSnapshot, opts)\` — map \`{ actor_id: [insights] }\`

### \`apps/backend/services/rewardEconomy.js\` (+11 LOC)
\`buildDebriefSummary\` aggiunge field \`mbti_insights\`. Best-effort try/catch (missing module non blocca debrief).

### \`tests/services/mbtiInsights.test.js\` NEW (9 test verdi)

## Test plan
- [x] mbtiInsights 9/9 verde
- [x] AI 311/311 verde
- [x] Schema drift = 0
- [ ] Frontend wire debrief panel (follow-up PR — surface insights in UI)

## Pillar coverage
**P4 MBTI/Ennea** — surfacing post-session diegetic. Closes deep-analysis gap N-02 (reveal_text_it 18 mbti_thoughts) parziale.

## Effort vs audit
Audit estimate **3h**. Actual **~30min** (palette + render + test).

## Rollback
\`git revert <sha>\` — rimuove insights module + wire. Debrief torna a vc_summary statistico solo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)