### PR TITLE
feat(ai): AI War Progress meter visibility (P0 Tier S quick-win)

### DIFF
--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -329,6 +329,15 @@ function publicSessionView(session) {
     sistema_pressure: pressure,
     sistema_tier: tier,
     sistema_counter: Number(session.sistema_counter) || 0,
+    // 2026-04-26 P0 quick-win — AI War Progress meter (Tier S donor).
+    // Lazy require + try/catch: missing module non blocca state response.
+    ai_progress: (() => {
+      try {
+        return require('../services/ai/aiProgressMeter').getProgressMeterState(session);
+      } catch {
+        return null;
+      }
+    })(),
     atlas,
     last_round_combos: Array.isArray(session.last_round_combos) ? session.last_round_combos : [],
     previous_round_combos: Array.isArray(session.previous_round_combos)

--- a/apps/backend/services/ai/aiProgressMeter.js
+++ b/apps/backend/services/ai/aiProgressMeter.js
@@ -1,0 +1,107 @@
+// 2026-04-26 — AI War Progress meter (P0 Tier S quick-win, P5 visibility).
+//
+// Source: docs/research/2026-04-26-tier-s-extraction-matrix.md (AI War: Fleet Command)
+// Pattern donor: AI War 'AI Progress meter' visibility globale player-side.
+//
+// AI War lesson: player must SEE pressure escalation in real-time, not solo
+// surface alle azioni passate. Meter mostra:
+//   - tier name corrente (Calm/Alert/Escalated/Critical/Apex)
+//   - pressure value 0..100
+//   - next_tier_threshold per anticipazione
+//   - intents_per_round cap (escalation visibility)
+//   - threat_level human-readable
+//
+// Wire: surface in publicSessionView(session) -> session.ai_progress
+// Frontend wire: deferred (apps/play/src/aiProgressMeter.js future PR)
+// Co-op visibility: M11 host vede meter, players vedono aggregate via WS state
+
+'use strict';
+
+// Mirror sistema_pressure tier definitions da declareSistemaIntents.js.
+// Centralizza qui per single source-of-truth + evitare circular dep.
+const PRESSURE_TIERS = [
+  { threshold: 0, name: 'Calm', threat: 'minimo', intents_per_round: 1 },
+  { threshold: 25, name: 'Alert', threat: 'crescente', intents_per_round: 2 },
+  { threshold: 50, name: 'Escalated', threat: 'serio', intents_per_round: 3 },
+  { threshold: 75, name: 'Critical', threat: 'imminente', intents_per_round: 3 },
+  { threshold: 95, name: 'Apex', threat: 'massimo', intents_per_round: 4 },
+];
+
+/**
+ * Restituisce tier corrente per un pressure value.
+ */
+function tierForPressure(pressure) {
+  const p = Number.isFinite(Number(pressure)) ? Math.max(0, Math.min(100, Number(pressure))) : 0;
+  let current = PRESSURE_TIERS[0];
+  for (const tier of PRESSURE_TIERS) {
+    if (p >= tier.threshold) current = tier;
+  }
+  return { ...current, pressure_value: p };
+}
+
+/**
+ * Trova il prossimo tier (per anticipazione) o null se Apex.
+ */
+function nextTier(pressure) {
+  const p = Number.isFinite(Number(pressure)) ? Number(pressure) : 0;
+  for (const tier of PRESSURE_TIERS) {
+    if (tier.threshold > p) return tier;
+  }
+  return null;
+}
+
+/**
+ * Compute progress meter state da session.
+ * Returns { pressure, tier, next, intents_cap, distance_to_next, history }
+ */
+function getProgressMeterState(session) {
+  if (!session || typeof session !== 'object') {
+    return {
+      pressure: 0,
+      tier: PRESSURE_TIERS[0],
+      next_tier: PRESSURE_TIERS[1],
+      distance_to_next: 25,
+      intents_per_round: 1,
+      threat_level: 'minimo',
+      history: [],
+    };
+  }
+
+  const pressure = Number(session.sistema_pressure || 0);
+  const tier = tierForPressure(pressure);
+  const next = nextTier(pressure);
+  const distance = next ? Math.max(0, next.threshold - pressure) : null;
+
+  // History: ultimi 5 pressure changes da events log (se disponibile).
+  // Filter eventi con pressure tracking; fallback array vuoto.
+  const events = Array.isArray(session.events) ? session.events : [];
+  const pressureHistory = events
+    .filter((e) => e && typeof e.pressure === 'number')
+    .slice(-5)
+    .map((e) => ({
+      turn: e.turn,
+      pressure: e.pressure,
+      action_type: e.action_type,
+    }));
+
+  return {
+    pressure,
+    tier: {
+      name: tier.name,
+      threat: tier.threat,
+      threshold: tier.threshold,
+    },
+    next_tier: next ? { name: next.name, threshold: next.threshold } : null,
+    distance_to_next: distance,
+    intents_per_round: tier.intents_per_round,
+    threat_level: tier.threat,
+    history: pressureHistory,
+  };
+}
+
+module.exports = {
+  PRESSURE_TIERS,
+  tierForPressure,
+  nextTier,
+  getProgressMeterState,
+};

--- a/tests/services/aiProgressMeter.test.js
+++ b/tests/services/aiProgressMeter.test.js
@@ -1,0 +1,91 @@
+// 2026-04-26 — aiProgressMeter tests (P0 Tier S AI War quick-win).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  PRESSURE_TIERS,
+  tierForPressure,
+  nextTier,
+  getProgressMeterState,
+} = require('../../apps/backend/services/ai/aiProgressMeter');
+
+test('PRESSURE_TIERS: 5 tier coverage 0/25/50/75/95', () => {
+  assert.equal(PRESSURE_TIERS.length, 5);
+  assert.equal(PRESSURE_TIERS[0].name, 'Calm');
+  assert.equal(PRESSURE_TIERS[4].name, 'Apex');
+});
+
+test('tierForPressure: 0 -> Calm', () => {
+  const t = tierForPressure(0);
+  assert.equal(t.name, 'Calm');
+  assert.equal(t.intents_per_round, 1);
+});
+
+test('tierForPressure: 50 -> Escalated', () => {
+  const t = tierForPressure(50);
+  assert.equal(t.name, 'Escalated');
+  assert.equal(t.intents_per_round, 3);
+});
+
+test('tierForPressure: 100+ clamps to Apex', () => {
+  const t = tierForPressure(150);
+  assert.equal(t.name, 'Apex');
+  assert.equal(t.pressure_value, 100);
+});
+
+test('tierForPressure: NaN safe -> Calm', () => {
+  const t = tierForPressure(NaN);
+  assert.equal(t.name, 'Calm');
+});
+
+test('nextTier: 0 -> Alert (25)', () => {
+  const next = nextTier(0);
+  assert.equal(next.name, 'Alert');
+  assert.equal(next.threshold, 25);
+});
+
+test('nextTier: 95 (Apex) -> null', () => {
+  assert.equal(nextTier(95), null);
+});
+
+test('getProgressMeterState: empty session -> Calm baseline', () => {
+  const out = getProgressMeterState(null);
+  assert.equal(out.pressure, 0);
+  assert.equal(out.tier.name, 'Calm');
+  assert.equal(out.next_tier.name, 'Alert');
+  assert.equal(out.distance_to_next, 25);
+});
+
+test('getProgressMeterState: session pressure 60 -> Escalated', () => {
+  const session = { sistema_pressure: 60, events: [] };
+  const out = getProgressMeterState(session);
+  assert.equal(out.pressure, 60);
+  assert.equal(out.tier.name, 'Escalated');
+  assert.equal(out.next_tier.name, 'Critical');
+  assert.equal(out.distance_to_next, 15);
+});
+
+test('getProgressMeterState: history extracts pressure-tagged events', () => {
+  const session = {
+    sistema_pressure: 30,
+    events: [
+      { turn: 1, action_type: 'attack', pressure: 10 },
+      { turn: 2, action_type: 'kill', pressure: 30 },
+      { turn: 3, action_type: 'move' }, // no pressure -> skipped
+    ],
+  };
+  const out = getProgressMeterState(session);
+  assert.equal(out.history.length, 2);
+  assert.equal(out.history[0].pressure, 10);
+  assert.equal(out.history[1].pressure, 30);
+});
+
+test('getProgressMeterState: Apex pressure 100 -> next_tier null', () => {
+  const session = { sistema_pressure: 100, events: [] };
+  const out = getProgressMeterState(session);
+  assert.equal(out.tier.name, 'Apex');
+  assert.equal(out.next_tier, null);
+  assert.equal(out.distance_to_next, null);
+});


### PR DESCRIPTION
## Summary

P0 quick-win bundle B v2 — Tier S donor pattern (AI War: Fleet Command).

## Pattern
**AI War 'AI Progress meter'** visibility globale player-side.

Lesson: player must SEE pressure escalation in real-time, not solo surface alle azioni passate.

## Components

### \`apps/backend/services/ai/aiProgressMeter.js\` NEW (~80 LOC)
- \`PRESSURE_TIERS\` canonical (Calm/Alert/Escalated/Critical/Apex 0/25/50/75/95)
- \`tierForPressure(p)\` — \`{ name, threat, threshold, intents_per_round }\`
- \`nextTier(p)\` — prossimo tier o null (Apex)
- \`getProgressMeterState(session)\` — full state snapshot:
  \`{ pressure, tier, next_tier, distance_to_next, intents_per_round, threat_level, history (last 5) }\`

### \`apps/backend/routes/sessionHelpers.js\` (+10 LOC)
\`publicSessionView\` aggiunge field \`ai_progress\` lazy require + try/catch. Surface su \`/state\` response per ogni session call.

### \`tests/services/aiProgressMeter.test.js\` NEW (11 test verdi)
Coverage: 5 tier + boundary (0/50/100+/NaN) + nextTier (0/95) + session empty/Escalated/Apex + history extraction.

## Test plan
- [x] aiProgressMeter 11/11 verde
- [x] AI 311/311 verde
- [x] Schema drift = 0
- [ ] Frontend wire \`apps/play/src/aiProgressMeter.js\` (deferred separate PR — render meter dynamic con tier name + pressure bar + next_tier anticipation)

## Pillar coverage
**P5 Co-op vs Sistema** — visibility AI threat real-time. P5 visibility gap chiuso (deep-analysis 2026-04-26).

## Effort vs audit
Audit estimate **5h**. Actual **~30min** (single service + wire + test).

## Rollback
\`git revert <sha>\` — rimuove service + wire. \`/state\` response perde \`ai_progress\` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)