### PR TITLE
feat(integration): wire xpBudget audit + lint_mutations Makefile (B1+B2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,14 @@ evo-validate:
 	else \
 		echo "Skipping traits validation: directory not found (${EVO_VALIDATE_TRAITS})"; \
 	fi
+	@# 2026-04-26 P1 — Voidling Bound Pattern 6 mutation visual_swap_it linter (PR #1893).
+	@# Skip se linter o catalog mancano (graceful prima del merge PR #1893).
+	@if [ -f "tools/py/lint_mutations.py" ] && [ -f "data/core/mutations/mutation_catalog.yaml" ]; then \
+		echo "Running mutation visual_swap_it linter (Voidling Bound Pattern 6)..."; \
+		$(PYTHON) tools/py/lint_mutations.py; \
+	else \
+		echo "Skipping mutation linter: lint_mutations.py o catalog non trovati (pre PR #1893 merge)"; \
+	fi
 
 evo-backlog:
 	@if [ -z "${EVO_BACKLOG_FILE}" ]; then \

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -1257,6 +1257,27 @@ function createSessionRouter(options = {}) {
         sistema_count: units.filter((u) => u.controlled_by === 'sistema').length,
         automatic: true,
       });
+      // 2026-04-26 P1 — Pathfinder XP budget audit log su session start.
+      // Best-effort + lazy require: missing module non blocca session creation.
+      // Audit out_of_band -> warn console (future: telemetry event).
+      try {
+        const { auditEncounter } = require('../services/balance/xpBudget');
+        const partySize = units.filter((u) => u.controlled_by === 'player').length;
+        const audit = auditEncounter(session.encounter, partySize);
+        if (
+          audit &&
+          audit.status &&
+          !['in_band', 'no_encounter', 'no_budget_config'].includes(audit.status)
+        ) {
+          console.warn(
+            `[xpBudget audit] session=${sessionId} class=${audit.encounter_class} ` +
+              `party=${audit.party_size} budget=${audit.budget} used=${audit.used} ` +
+              `ratio=${audit.ratio} status=${audit.status}`,
+          );
+        }
+      } catch {
+        // xpBudget optional
+      }
       // SPRINT_020: se la prima unita' in ordine di iniziativa e' un SIS,
       // esegui immediatamente i suoi turni (e di eventuali successivi SIS)
       // fino a fermarsi al primo player. Il frontend riceve gia' lo stato


### PR DESCRIPTION
## Summary

Wire integration **B** opzione user 2026-04-26: chiude loop \"engine live surface dead\" su 2 PR shipped questa session.

### B1 — Wire xpBudget audit log \`session.js /start\`
Post \`session_start\` event: lazy require \`xpBudget.auditEncounter\`, warn console se status NOT in \`['in_band','no_encounter','no_budget_config']\`.

**Output esempio**:
\`\`\`
[xpBudget audit] session=abc123 class=hardcore party=4 budget=400 used=820 ratio=2.05 status=critical_over
\`\`\`

Best-effort try/catch: missing xpBudget module non blocca session creation. Future: emit telemetry event invece di \`console.warn\`.

### B2 — lint_mutations in Makefile \`evo-validate\`
\`Makefile evo-validate\` target esteso: post species + traits validation, run \`lint_mutations.py\` se esiste catalog + linter.

Graceful: skip se file mancanti (es. pre-merge PR #1893). Echo skip reason.

## Dependencies (best-effort handle)

- \`xpBudget\` module live in **PR #1894** (pending merge)
- \`lint_mutations.py\` + visual_swap_it backfill in **PR #1893** (pending merge)
- **Questo PR safe to merge first**: lazy require + graceful skip handle missing deps

## Test plan
- [x] AI test 311/311 verde (no logic change)
- [x] Schema drift = 0
- [x] Manual smoke: \`make evo-validate\` echo skip se PR #1893 not yet merged
- [ ] Post-merge PR #1894: verify xpBudget audit warn fires su hardcore_06 critical_over

## Effort
B1+B2 combined: **~30min total** (single integration PR).

## Rollback
\`git revert <sha>\` — rimuove audit hook + Makefile target. xpBudget + lint_mutations restano standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)