### PR TITLE
feat(ui): Tactics Ogre AP pip indicator float (P0 Tier S quick-win)

### DIFF
--- a/apps/play/src/render.js
+++ b/apps/play/src/render.js
@@ -538,6 +538,30 @@ function drawUnit(ctx, unit, gridH, highlight = {}) {
     ctx.textBaseline = 'bottom';
     const maxHp = unit.max_hp || unit.hp || 0;
     ctx.fillText(`${unit.hp}/${maxHp}`, cx, barY - 1);
+
+    // 2026-04-26 P0 quick-win — Tactics Ogre AP indicator float sotto HP bar.
+    // Pattern donor: Tactics Ogre Reborn ATB pip overhead unit (scan TV-first).
+    // Source: docs/research/2026-04-26-tier-s-extraction-matrix.md (Tactics Ogre)
+    // Mostra ap_remaining come pip discreti (es. ●●○ = 2/3 AP). Posizione
+    // 4px sotto HP bar. Solo per unit player o sistema attivo (non KO).
+    const apRemaining = Number(unit.ap_remaining ?? unit.ap ?? 0);
+    const apMax = Number(unit.ap ?? 0);
+    if (apMax > 0 && apMax <= 5) {
+      const pipRadius = 2.5;
+      const pipGap = 2;
+      const pipsW = apMax * pipRadius * 2 + (apMax - 1) * pipGap;
+      const pipsX = cx - pipsW / 2 + pipRadius;
+      const pipsY = barY + 9;
+      for (let i = 0; i < apMax; i += 1) {
+        ctx.beginPath();
+        ctx.arc(pipsX + i * (pipRadius * 2 + pipGap), pipsY, pipRadius, 0, Math.PI * 2);
+        ctx.fillStyle = i < apRemaining ? '#ffcc00' : 'rgba(0,0,0,0.5)';
+        ctx.fill();
+        ctx.strokeStyle = 'rgba(255,255,255,0.6)';
+        ctx.lineWidth = 0.5;
+        ctx.stroke();
+      }
+    }
   }
 
   // Status icons (top-right)


### PR DESCRIPTION
## Summary

P0 quick-win bundle B v2 — Tier S donor (Tactics Ogre Reborn).

### Pattern
Tactics Ogre Reborn ATB pip overhead unit (scan TV-first 10-foot rule). Mostra \`ap_remaining\` come pip gialli/scuri sotto HP bar (es. ●●○ = 2/3 AP).

### Implementation (additive +24 LOC, NO removals)
\`render.js drawUnit()\` post HP bar:
- \`pipMax = unit.ap\` (cap 5 per readability)
- \`pipFilled = unit.ap_remaining\`
- 4px sotto HP bar, centrato su unit
- Filled: \`#ffcc00\` (accent gold) · Empty: black 50% transparent
- Stroke white 60% per contrast su tile colorato

### Discovery
HP bar floating SOPRA sprite era **già live** (M4 P0.2 shipped passato, \`render.js:520-541\`). Audit Tier S Tactics Ogre proponeva _\"refactor render.js HUD sostituendo sidebar HP\"_. Skip refactor (rischio rompere sidebar UI).

Adottato pattern **complementare additivo**: AP pip overhead.

## Test plan
- [x] AI test 311/311 verde (no logic, only canvas draw)
- [x] Schema drift = 0
- [x] Diff +24 / -0 (additive, no removals)
- [ ] Visual regression playtest: verifica pip overlay visibile TV 3m distance

## Pillar coverage
**P1 UI** — AP visibility TV-first scan.

## Effort vs audit
Audit estimate **5h** (refactor sidebar). Actual **~20min** (pip overhead additive).

## Rollback
\`git revert <sha>\` — rimuove pip overlay. HP bar floating + sidebar restano invariati.

🤖 Generated with [Claude Code](https://claude.com/claude-code)