### PR TITLE
test(python): fix 3 tests stale post nerf #1869

### DIFF
--- a/tests/snapshots/hydration_caverna.json
+++ b/tests/snapshots/hydration_caverna.json
@@ -63,7 +63,7 @@
         },
         {
           "channel": "fuoco",
-          "modifier_pct": 40
+          "modifier_pct": 30
         }
       ],
       "trait_ids": ["mantello_meteoritico", "sangue_piroforico"],

--- a/tests/test_hydration.py
+++ b/tests/test_hydration.py
@@ -115,14 +115,14 @@ def test_hydrate_caverna_matches_snapshot(catalog):
 
 def test_aggregate_resistances_sums_by_channel(catalog):
     # mantello_meteoritico: fisico +20, fuoco +20
-    # sangue_piroforico: fuoco +20
-    # Atteso: fisico 20, fuoco 40
+    # sangue_piroforico: fuoco +10 (post-nerf #1869: 20→10 fuoco resist)
+    # Atteso: fisico 20, fuoco 30
     result = aggregate_resistances(
         ["mantello_meteoritico", "sangue_piroforico"],
         catalog,
     )
     by_channel = {r["channel"]: r["modifier_pct"] for r in result}
-    assert by_channel == {"fisico": 20, "fuoco": 40}
+    assert by_channel == {"fisico": 20, "fuoco": 30}
 
 
 def test_aggregate_resistances_sorts_alphabetically(catalog):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -360,13 +360,13 @@ def test_attack_armor_clamps_damage_to_zero(catalog):
 
 def test_attack_with_offensive_trait_attack_mod_increases_total(catalog):
     state = _mini_state(catalog)
-    # attaccante con ipertrofia_muscolare_massiva (attack_mod +1, damage_step +1)
+    # attaccante con ipertrofia_muscolare_massiva (post-nerf #1869: attack_mod +1, damage_step +0)
     state["units"][0]["trait_ids"] = ["ipertrofia_muscolare_massiva"]
     # nat 10 -> total = 10 + 1 = 11; CD=12 -> fail senza trait, ma con trait?
     # 10+1 = 11 < 12 -> fail ancora. Alziamo a nat 12 -> total 13 -> success.
-    # mos = 1, step from mos = 0, step from trait = 1 -> total step 1
-    # 1d8 = 4 (base), step_bonus floor(7.5*0.25) = 1 -> pre = 4+3+1 = 8
-    # armor 4 -> 4
+    # mos = 1, step from mos = 0, step from trait = 0 (post-nerf) -> total step 0
+    # 1d8 = 4 (base) + modifier 3 = 7, no step_bonus -> pre = 7
+    # armor 4 -> 3 damage applied
     rng = rng_from_sequence([11 / 20, 3 / 8])
     result = resolve_action(state, _attack(), catalog, rng)
     roll = result["turn_log_entry"]["roll"]
@@ -374,8 +374,8 @@ def test_attack_with_offensive_trait_attack_mod_increases_total(catalog):
     assert roll["modifier"] == 1
     assert roll["total"] == 13
     assert roll["success"] is True
-    assert roll["damage_step"] == 1  # solo dal trait
-    assert result["turn_log_entry"]["damage_applied"] == 4
+    assert roll["damage_step"] == 0  # post-nerf #1869: damage_step 1→0
+    assert result["turn_log_entry"]["damage_applied"] == 3
 
 
 def test_attack_vs_defensive_trait_raises_cd(catalog):


### PR DESCRIPTION
## Summary

Realign 3 python test fixtures + snapshot a trait_mechanics.yaml shipped by PR #1869 (trait nerf outlier).

**Root cause**: PR #1869 ha nerfato:
- \`ipertrofia_muscolare_massiva.damage_step\` 1→0
- \`sangue_piroforico\` fuoco resistance 20→10

Test fixtures non sono stati aggiornati di conseguenza, causando 3 fail su python-tests CI:
1. \`test_aggregate_resistances_sums_by_channel\` — fuoco 40→30
2. \`test_attack_with_offensive_trait_attack_mod_increases_total\` — damage_step 1→0 + damage_applied 4→3
3. \`test_hydrate_caverna_matches_snapshot\` — snapshot regenerated allineato post-nerf

## Verifica locale

- 111/111 \`tests/test_hydration.py\` + \`tests/test_resolver.py\` verde
- 990/990 full python suite (escluso \`flint/smoke_test.py\` che usa subprocess git non rilevante)

## Scope

Solo allineamento fixture/snapshot. **Zero code change in services/rules/**. Nessun gameplay impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)