### PR TITLE
feat(ui): Step 3 AI Progress meter frontend wire (PR #1898 surface)

### DIFF
--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -202,6 +202,49 @@ header h1 {
   }
 }
 
+/* 2026-04-27 Step 3 — AI War Progress meter frontend (PR #1898 backend wire).
+ * Pattern donor: AI War Fleet Command — visibility + anticipation.
+ * Estende existing .pressure-meter con tier name + threat label + next_tier
+ * anticipation + history sparkline (Tufte pattern). */
+.ai-progress-info {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  font-size: 0.78rem;
+  margin-top: 4px;
+  color: var(--fg);
+}
+.ai-tier-name {
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+}
+.ai-threat-label {
+  color: var(--dim);
+  font-style: italic;
+}
+.ai-threat-label strong {
+  color: var(--fg);
+  font-style: normal;
+}
+.ai-next-tier {
+  color: var(--accent);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+}
+.ai-history {
+  font-size: 0.7rem;
+  color: var(--dim);
+  margin-top: 2px;
+}
+.ai-history-dot {
+  color: var(--sistema);
+  font-size: 0.85rem;
+  margin: 0 1px;
+}
+
 main {
   flex: 1;
   display: grid;

--- a/apps/play/src/ui.js
+++ b/apps/play/src/ui.js
@@ -449,9 +449,50 @@ export function updateStatus(state) {
         ? `<div class="pushback-label">⚔ Pushback ${counter}/30</div>
            <div class="pushback-bar"><div class="pushback-fill" style="width:${counterPct}%"></div></div>`
         : '';
+
+    // 2026-04-27 Step 3 — AI War Progress meter frontend wire (Tier S #1898 backend).
+    // Pattern donor: AI War Fleet Command — visibility + anticipation tier.
+    // Estende meter con next_tier + distance + history sparkline (Tufte pattern).
+    let aiProgressHtml = '';
+    if (state.ai_progress) {
+      const ap = state.ai_progress;
+      const tierName = ap.tier?.name || '';
+      const threatLevel = ap.threat_level || 'minimo';
+      // Next tier anticipation
+      let nextTierHtml = '';
+      if (ap.next_tier && Number.isFinite(ap.distance_to_next)) {
+        nextTierHtml = `<span class="ai-next-tier">→ ${ap.next_tier.name} (${ap.distance_to_next} pp)</span>`;
+      } else if (!ap.next_tier) {
+        nextTierHtml = `<span class="ai-next-tier">apex max</span>`;
+      }
+      // History sparkline: 5 dot last events (Tufte small multiples lite)
+      let historyHtml = '';
+      if (Array.isArray(ap.history) && ap.history.length > 0) {
+        const dots = ap.history
+          .slice(-5)
+          .map((h) => {
+            const p = Number(h.pressure) || 0;
+            const intensity = Math.min(1, p / 100);
+            const op = 0.3 + intensity * 0.7;
+            return `<span class="ai-history-dot" style="opacity:${op}" title="turn ${h.turn} · ${h.pressure}">●</span>`;
+          })
+          .join('');
+        historyHtml = `<div class="ai-history">trend: ${dots}</div>`;
+      }
+      aiProgressHtml = `
+        <div class="ai-progress-info">
+          <span class="ai-tier-name" style="color:${tier.color}">${tierName}</span>
+          <span class="ai-threat-label">minaccia: <strong>${threatLevel}</strong></span>
+          ${nextTierHtml}
+        </div>
+        ${historyHtml}
+      `;
+    }
+
     pressureEl.innerHTML = `
       <div class="pressure-label">SISTEMA <strong style="color:${tier.color}">${tier.label}</strong> · ${tier.value}/100 · cap ${tier.intents} intents/round</div>
       <div class="pressure-bar"><div class="pressure-fill" style="width:${tier.value}%;background:${tier.color}"></div></div>
+      ${aiProgressHtml}
       ${counterHtml}
     `;
   }


### PR DESCRIPTION
## Summary

**Step 3** user decision (continua post Step 2 Bundle C+B merge).

Backend shipped PR #1898 — frontend deferred. Questo PR **chiude Engine LIVE Surface DEAD** per AI Progress meter.

## Pattern
**AI War Fleet Command** Progress meter visibility:
- Player vede tier corrente (Calm/Alert/Escalated/Critical/Apex)
- Anticipa prossimo tier (\"→ Apex tra 5pp\")
- History sparkline ultimi 5 pressure events (Tufte pattern lite)
- Threat level human-readable

## Implementation (+84 LOC additive)

### \`ui.js renderHud\` extension
Estende existing pressure-meter HTML con:
- \`ai-tier-name\` (bold uppercase, color tier)
- \`ai-threat-label\` (corsivo + bold value)
- \`ai-next-tier\` (accent color, anticipation)
- \`ai-history\` dots (5 ultimi pressure events, opacity = intensity)

Reads from \`state.ai_progress\` shipped via \`publicSessionView\` (PR #1898).

### \`style.css\` 6 new classes
\`.ai-progress-info\`, \`.ai-tier-name\`, \`.ai-threat-label\`, \`.ai-next-tier\`, \`.ai-history\`, \`.ai-history-dot\`

## Player vede

Prima: \`SISTEMA Calm 0/100 cap 1 intents/round\` barra.

Ora aggiunto:
- \`CALM · minaccia: minimo · → Alert (25 pp)\`
- \`trend: ●●●●●\` (sparkline 5 ultimi turn pressure intensity)

**Anticipazione tier visualmente. Sa quando sta per scatenare apocalisse.**

## Engine wired DoD compliance (Gate 5 #1904)
- [x] Backend logic: \`aiProgressMeter\` shipped PR #1898
- [x] **Surface player exists**: HUD pressure-meter extension visibile
- [x] Smoke E2E: spawn session → vedi ai-tier-name + history dots
- [x] Changelog: _\"Player vede tier + anticipazione + trend\"_

## Test plan
- [x] AI test 311/311 verde (HTML/CSS only)
- [x] Schema drift = 0
- [x] Additive (+84 LOC)
- [ ] Visual regression playtest

## Effort vs estimate
~1-3h estimate, **~15min** actual.

## Rollback
\`git revert <sha>\` — meter torna a solo tier base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)