### PR TITLE
feat(mutations): Spore Moderate S1 — ADR + schema lock (body_slot/derived_ability_id/mp_cost)

### DIFF
--- a/data/core/mutations/mutation_catalog.yaml
+++ b/data/core/mutations/mutation_catalog.yaml
@@ -25,6 +25,7 @@ mutations:
   artigli_freeze_to_glacier:
     tier: 2
     category: physiological
+    body_slot: appendage
     name_it: "Mutazione: Artigli Glaciali"
     name_en: "Mutation: Glacial Claws"
     prerequisites:
@@ -35,6 +36,8 @@ mutations:
       add: [artigli_sghiaccio_glaciale]
     pe_cost: 12
     pi_cost: 6
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [cryosteppe, caldera_glaciale]
     biome_penalty: [deserto_caldo, dorsale_termale_tropicale]
     mbti_alignment: { S: 1, T: 1 }
@@ -50,6 +53,7 @@ mutations:
   ali_panic_to_resonance:
     tier: 2
     category: physiological
+    body_slot: back
     name_it: "Mutazione: Ali Risonanti"
     name_en: "Mutation: Resonant Wings"
     prerequisites:
@@ -60,6 +64,8 @@ mutations:
       add: [ali_fono_risonanti]
     pe_cost: 12
     pi_cost: 5
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [caverna, canyons_risonanti, frattura_abissale_sinaptica]
     biome_penalty: [stratosfera_tempestosa]
     mbti_alignment: { I: 1, N: 1 }
@@ -75,6 +81,7 @@ mutations:
   denti_bleed_to_chelate:
     tier: 2
     category: physiological
+    body_slot: mouth
     name_it: "Mutazione: Morso Chelante"
     name_en: "Mutation: Chelating Bite"
     prerequisites:
@@ -85,6 +92,8 @@ mutations:
       add: [denti_chelatanti]
     pe_cost: 10
     pi_cost: 5
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [palude, foresta_acida]
     biome_penalty: [pianura_salina_iperarida]
     mbti_alignment: { S: 1, T: 1 }
@@ -100,6 +109,7 @@ mutations:
   scheletro_buffer_upgrade:
     tier: 2
     category: physiological
+    body_slot: tegument
     name_it: "Mutazione: Scheletro Idro-Regolante"
     name_en: "Mutation: Hydro-Regulator Skeleton"
     prerequisites:
@@ -110,6 +120,8 @@ mutations:
       add: [scheletro_idro_regolante]
     pe_cost: 12
     pi_cost: 7
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [palude, reef_luminescente, atollo_obsidiana]
     biome_penalty: [deserto_caldo, pianura_salina_iperarida]
     mbti_alignment: { I: 1, J: 1 }
@@ -125,6 +137,7 @@ mutations:
   carapace_segments_to_phase:
     tier: 3
     category: physiological
+    body_slot: tegument
     name_it: "Mutazione: Carapace a Variazione di Fase"
     name_en: "Mutation: Phase-Variable Carapace"
     prerequisites:
@@ -135,6 +148,8 @@ mutations:
       add: [carapace_fase_variabile]
     pe_cost: 25
     pi_cost: 14
+    derived_ability_id: null
+    mp_cost: 15
     biome_boost: [rovine_planari, mezzanotte_orbitale, atollo_obsidiana]
     biome_penalty: []
     mbti_alignment: { I: 1, T: 1 }
@@ -154,6 +169,7 @@ mutations:
   rage_simple_to_super:
     tier: 3
     category: behavioral
+    body_slot: mouth
     name_it: "Mutazione: Adrenalina Supercritica"
     name_en: "Mutation: Supercritical Adrenaline"
     prerequisites:
@@ -164,6 +180,8 @@ mutations:
       add: [circolazione_supercritica]
     pe_cost: 25
     pi_cost: 12
+    derived_ability_id: null
+    mp_cost: 15
     biome_boost: [savana, badlands, abisso_vulcanico]
     biome_penalty: [cryosteppe, caldera_glaciale]
     mbti_alignment: { E: 1, T: 1 }
@@ -179,6 +197,7 @@ mutations:
   voice_panic_to_summon:
     tier: 2
     category: behavioral
+    body_slot: mouth
     name_it: "Mutazione: Voce di Richiamo"
     name_en: "Mutation: Calling Voice"
     prerequisites:
@@ -189,6 +208,8 @@ mutations:
       add: [canto_di_richiamo]
     pe_cost: 12
     pi_cost: 8
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [foresta_temperata, foresta_miceliale, canyons_risonanti]
     biome_penalty: [deserto_caldo, pianura_salina_iperarida]
     mbti_alignment: { E: 1, F: 1 }
@@ -204,6 +225,7 @@ mutations:
   intimidator_to_dispersal:
     tier: 2
     category: behavioral
+    body_slot: mouth
     name_it: "Mutazione: Aura di Dispersione"
     name_en: "Mutation: Dispersal Aura"
     prerequisites:
@@ -214,6 +236,8 @@ mutations:
       add: [aura_di_dispersione_mentale]
     pe_cost: 12
     pi_cost: 8
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [rovine_planari, mezzanotte_orbitale, frattura_abissale_sinaptica]
     biome_penalty: []
     mbti_alignment: { I: 1, N: 1 }
@@ -234,6 +258,7 @@ mutations:
   eyes_kinetic_to_crystal:
     tier: 2
     category: sensorial
+    body_slot: sense
     name_it: "Mutazione: Occhi a Cristallo Modulare"
     name_en: "Mutation: Modular Crystal Eyes"
     prerequisites:
@@ -244,6 +269,8 @@ mutations:
       add: [occhi_cristallo_modulare]
     pe_cost: 12
     pi_cost: 6
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [rovine_planari, steppe_algoritmiche, mezzanotte_orbitale]
     biome_penalty: [foresta_miceliale, foresta_acida]
     mbti_alignment: { I: 1, T: 1 }
@@ -259,6 +286,7 @@ mutations:
   antenne_track_to_storm:
     tier: 3
     category: sensorial
+    body_slot: sense
     name_it: "Mutazione: Antenne Plasmatiche di Tempesta"
     name_en: "Mutation: Storm Plasma Antennae"
     prerequisites:
@@ -269,6 +297,8 @@ mutations:
       add: [antenne_plasmatiche_tempesta]
     pe_cost: 25
     pi_cost: 15
+    derived_ability_id: null
+    mp_cost: 15
     biome_boost: [stratosfera_tempestosa, canopia_ionica]
     biome_penalty: [caverna, abisso_vulcanico]
     mbti_alignment: { E: 1, N: 1 }
@@ -288,6 +318,7 @@ mutations:
   wings_ion_to_solar:
     tier: 2
     category: sensorial
+    body_slot: back
     name_it: "Mutazione: Ali Solari Fotoniche"
     name_en: "Mutation: Solar Photonic Wings"
     prerequisites:
@@ -298,6 +329,8 @@ mutations:
       add: [ali_solari_fotoni]
     pe_cost: 12
     pi_cost: 7
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [altipiani_solari, deserto_caldo, stratosfera_tempestosa]
     biome_penalty: [caverna, abisso_vulcanico]
     mbti_alignment: { E: 1, S: 1 }
@@ -313,6 +346,7 @@ mutations:
   wings_dive_to_phono:
     tier: 2
     category: sensorial
+    body_slot: back
     name_it: "Mutazione: Ali Fono-Risonanti"
     name_en: "Mutation: Phono-Resonant Wings"
     prerequisites:
@@ -323,6 +357,8 @@ mutations:
       add: [ali_fono_risonanti]
     pe_cost: 12
     pi_cost: 7
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [caverna, canyons_risonanti, frattura_abissale_sinaptica]
     biome_penalty: [stratosfera_tempestosa]
     mbti_alignment: { I: 1, N: 1 }
@@ -342,6 +378,7 @@ mutations:
   symbiosis_chemio_endosymbiont:
     tier: 2
     category: symbiotic
+    body_slot: null
     name_it: "Mutazione: Endosimbiosi Chemio"
     name_en: "Mutation: Chemio Endosymbiosis"
     prerequisites:
@@ -352,6 +389,8 @@ mutations:
       add: [batteri_termofili_endosimbiosi]
     pe_cost: 15
     pi_cost: 9
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [reef_luminescente, abisso_vulcanico, dorsale_termale_tropicale]
     biome_penalty: [cryosteppe, mezzanotte_orbitale]
     mbti_alignment: { F: 1, J: 1 }
@@ -371,6 +410,7 @@ mutations:
   pelle_burn_to_dielectric:
     tier: 2
     category: environmental
+    body_slot: tegument
     name_it: "Mutazione: Epidermide Dielettrica"
     name_en: "Mutation: Dielectric Epidermis"
     prerequisites:
@@ -381,6 +421,8 @@ mutations:
       add: [epidermide_dielettrica]
     pe_cost: 10
     pi_cost: 5
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [stratosfera_tempestosa, canopia_ionica, mezzanotte_orbitale]
     biome_penalty: [foresta_temperata, foresta_miceliale]
     mbti_alignment: { S: 1, J: 1 }
@@ -395,6 +437,7 @@ mutations:
   branchie_metalloid_upgrade:
     tier: 2
     category: environmental
+    body_slot: tegument
     name_it: "Mutazione: Branchie Metalloidi"
     name_en: "Mutation: Metalloid Gills"
     prerequisites:
@@ -405,6 +448,8 @@ mutations:
       add: [branchie_metalloidi]
     pe_cost: 12
     pi_cost: 6
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [reef_luminescente, atollo_obsidiana, abisso_vulcanico]
     biome_penalty: [pianura_salina_iperarida, deserto_caldo]
     mbti_alignment: { S: 1, T: 1 }
@@ -418,6 +463,7 @@ mutations:
   capillari_to_photovoltaic:
     tier: 2
     category: environmental
+    body_slot: tegument
     name_it: "Mutazione: Capillari Fotovoltaici"
     name_en: "Mutation: Photovoltaic Capillaries"
     prerequisites:
@@ -428,6 +474,8 @@ mutations:
       add: [capillari_fotovoltaici]
     pe_cost: 12
     pi_cost: 6
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [altipiani_solari, deserto_caldo, stratosfera_tempestosa]
     biome_penalty: [abisso_vulcanico, caverna]
     mbti_alignment: { E: 1, P: 1 }
@@ -446,6 +494,7 @@ mutations:
   cuticole_wax_to_neutralize:
     tier: 2
     category: physiological
+    body_slot: tegument
     name_it: "Mutazione: Cuticole Neutralizzanti"
     name_en: "Mutation: Neutralizing Cuticles"
     prerequisites:
@@ -456,6 +505,8 @@ mutations:
       add: [cuticole_neutralizzanti]
     pe_cost: 10
     pi_cost: 5
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [palude, foresta_acida]
     biome_penalty: []
     mbti_alignment: { S: 1, J: 1 }
@@ -470,6 +521,7 @@ mutations:
   carapace_to_luminescent:
     tier: 2
     category: physiological
+    body_slot: tegument
     name_it: "Mutazione: Carapace Luminiscente"
     name_en: "Mutation: Luminescent Carapace"
     prerequisites:
@@ -480,6 +532,8 @@ mutations:
       add: [carapace_luminiscente_abissale]
     pe_cost: 12
     pi_cost: 6
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [reef_luminescente, abisso_vulcanico, frattura_abissale_sinaptica]
     biome_penalty: [altipiani_solari]
     mbti_alignment: { I: 1, F: 1 }
@@ -499,6 +553,7 @@ mutations:
   artigli_grip_to_glass:
     tier: 2
     category: physiological
+    body_slot: appendage
     name_it: "Mutazione: Artigli Vetrificati"
     name_en: "Mutation: Vitrified Claws"
     prerequisites:
@@ -509,6 +564,8 @@ mutations:
       add: [artigli_vetrificati]
     pe_cost: 12
     pi_cost: 7
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [pianura_salina_iperarida, deserto_caldo, atollo_obsidiana]
     biome_penalty: [palude, foresta_acida]
     mbti_alignment: { S: 1, T: 1 }
@@ -524,6 +581,7 @@ mutations:
   coda_balanced_to_counter:
     tier: 2
     category: physiological
+    body_slot: appendage
     name_it: "Mutazione: Coda Contrappeso"
     name_en: "Mutation: Counterweight Tail"
     prerequisites:
@@ -534,6 +592,8 @@ mutations:
       add: [coda_contrappeso]
     pe_cost: 10
     pi_cost: 5
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [foresta_temperata, savana, badlands]
     biome_penalty: []
     mbti_alignment: { S: 1, J: 1 }
@@ -547,6 +607,7 @@ mutations:
   coda_kinetic_chain:
     tier: 3
     category: physiological
+    body_slot: appendage
     name_it: "Mutazione: Coda Frusta Cinetica"
     name_en: "Mutation: Kinetic Whip Tail"
     prerequisites:
@@ -557,6 +618,8 @@ mutations:
       add: [coda_frusta_cinetica]
     pe_cost: 25
     pi_cost: 12
+    derived_ability_id: null
+    mp_cost: 15
     biome_boost: [savana, badlands, foresta_temperata]
     biome_penalty: []
     mbti_alignment: { E: 1, T: 1 }
@@ -576,6 +639,7 @@ mutations:
   ghiandole_ink_to_acid:
     tier: 2
     category: physiological
+    body_slot: tegument
     name_it: "Mutazione: Ghiandole di Nebbia Acida"
     name_en: "Mutation: Acid Mist Glands"
     prerequisites:
@@ -586,6 +650,8 @@ mutations:
       add: [ghiandole_nebbia_acida]
     pe_cost: 12
     pi_cost: 6
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [palude, foresta_acida]
     biome_penalty: [stratosfera_tempestosa]
     mbti_alignment: { S: 1, F: -1 }
@@ -600,6 +666,7 @@ mutations:
   enzimi_chelanti_to_rapid:
     tier: 2
     category: physiological
+    body_slot: mouth
     name_it: "Mutazione: Enzimi Chelatori Rapidi"
     name_en: "Mutation: Rapid Chelator Enzymes"
     prerequisites:
@@ -610,6 +677,8 @@ mutations:
       add: [enzimi_chelatori_rapidi]
     pe_cost: 12
     pi_cost: 6
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [palude, foresta_acida, abisso_vulcanico]
     biome_penalty: [pianura_salina_iperarida]
     mbti_alignment: { S: 1, P: 1 }
@@ -628,6 +697,7 @@ mutations:
   martello_simple_to_osseo:
     tier: 2
     category: physiological
+    body_slot: appendage
     name_it: "Mutazione: Martello Osseo"
     name_en: "Mutation: Bone Hammer"
     prerequisites:
@@ -638,6 +708,8 @@ mutations:
       add: [martello_osseo]
     pe_cost: 15
     pi_cost: 8
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [caverna, badlands, abisso_vulcanico]
     biome_penalty: []
     mbti_alignment: { S: 1, T: 1 }
@@ -657,6 +729,7 @@ mutations:
   occhi_tension_to_kinetic:
     tier: 2
     category: sensorial
+    body_slot: sense
     name_it: "Mutazione: Occhi Cinetici"
     name_en: "Mutation: Kinetic Eyes"
     prerequisites:
@@ -667,6 +740,8 @@ mutations:
       add: [occhi_cinetici]
     pe_cost: 10
     pi_cost: 5
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [savana, foresta_temperata, canyons_risonanti]
     biome_penalty: []
     mbti_alignment: { S: 1, P: 1 }
@@ -685,6 +760,7 @@ mutations:
   cartilagini_to_metallic:
     tier: 2
     category: environmental
+    body_slot: tegument
     name_it: "Mutazione: Cartilagini Pseudometalliche"
     name_en: "Mutation: Pseudo-Metallic Cartilage"
     prerequisites:
@@ -695,6 +771,8 @@ mutations:
       add: [cartilagini_pseudometalliche]
     pe_cost: 12
     pi_cost: 7
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [atollo_obsidiana, abisso_vulcanico, mezzanotte_orbitale]
     biome_penalty: [foresta_miceliale]
     mbti_alignment: { S: 1, J: 1 }
@@ -709,6 +787,7 @@ mutations:
   membrane_pneumatic_to_photonic:
     tier: 2
     category: environmental
+    body_slot: tegument
     name_it: "Mutazione: Membrane Fotoconvoglianti"
     name_en: "Mutation: Photonic Conducting Membranes"
     prerequisites:
@@ -719,6 +798,8 @@ mutations:
       add: [membrane_fotoconvoglianti]
     pe_cost: 12
     pi_cost: 7
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [reef_luminescente, canopia_ionica, altipiani_solari]
     biome_penalty: [caverna, frattura_abissale_sinaptica]
     mbti_alignment: { N: 1, F: 1 }
@@ -736,6 +817,7 @@ mutations:
   filamenti_super_to_echo:
     tier: 2
     category: symbiotic
+    body_slot: null
     name_it: "Mutazione: Filamenti Echo"
     name_en: "Mutation: Echo Filaments"
     prerequisites:
@@ -746,6 +828,8 @@ mutations:
       add: [filamenti_echo]
     pe_cost: 15
     pi_cost: 8
+    derived_ability_id: null
+    mp_cost: 8
     biome_boost: [canyons_risonanti, frattura_abissale_sinaptica, caverna]
     biome_penalty: [stratosfera_tempestosa]
     mbti_alignment: { I: 1, F: 1 }
@@ -765,6 +849,7 @@ mutations:
   zampe_spring_to_radiant:
     tier: 3
     category: physiological
+    body_slot: appendage
     name_it: "Mutazione: Zampe Radianti"
     name_en: "Mutation: Radiant Paws"
     prerequisites:
@@ -775,6 +860,8 @@ mutations:
       add: [zampe_radianti]
     pe_cost: 20
     pi_cost: 10
+    derived_ability_id: null
+    mp_cost: 15
     biome_boost: [savana, badlands, altipiani_solari]
     biome_penalty: [palude, foresta_acida]
     mbti_alignment: { E: 1, S: 1 }
@@ -789,6 +876,7 @@ mutations:
   ferocia_to_supercritical:
     tier: 3
     category: behavioral
+    body_slot: mouth
     name_it: "Mutazione: Ferocia Supercritica"
     name_en: "Mutation: Supercritical Ferocity"
     prerequisites:
@@ -799,6 +887,8 @@ mutations:
       add: [midollo_iperattivo]
     pe_cost: 25
     pi_cost: 14
+    derived_ability_id: null
+    mp_cost: 15
     biome_boost: [savana, badlands, abisso_vulcanico]
     biome_penalty: []
     mbti_alignment: { E: 1, T: 1 }

--- a/docs/adr/ADR-2026-04-26-spore-part-pack-slots.md
+++ b/docs/adr/ADR-2026-04-26-spore-part-pack-slots.md
@@ -1,0 +1,192 @@
+---
+title: 'ADR-2026-04-26 — Spore part-pack slots — schema lock + Moderate scope'
+doc_status: active
+doc_owner: master-dd
+workstream: cross-cutting
+last_verified: '2026-04-27'
+source_of_truth: true
+language: it
+review_cycle_days: 180
+related:
+  - docs/research/2026-04-26-spore-deep-extraction.md
+  - docs/core/02-PILASTRI.md
+  - docs/core/22-FORME_BASE_16.md
+  - data/core/mutations/mutation_catalog.yaml
+  - apps/backend/services/forms/formEvolution.js
+  - apps/backend/services/progression/progressionEngine.js
+  - apps/backend/services/rewards/rewardOffer.js
+---
+
+# ADR-2026-04-26 — Spore part-pack slots (Pilastro 2 evoluzione runtime)
+
+## Status
+
+**ACCEPTED** — 2026-04-26 (impl Sprint 2026-04-27)
+
+Chiude debito Pilastro 2 "Evoluzione emergente" — runtime evolution engine assente
+nonostante 30 mutation YAML + 84 specie shippate. Ref `docs/research/2026-04-26-spore-deep-extraction.md`.
+
+## Context
+
+Pilastro 2 stato pre-ADR: 🟢c+ (Vision Gap Sprint V2 chiuso tri-sorgente reward,
+mating engine 469 LOC backend, ma **nessuna mutation è mai applicata a runtime**).
+Player non può evolvere la propria creatura nel ciclo encounter → reward → editor
+→ next encounter. Mutation_catalog è inerte.
+
+Spore Creature Stage offre il template canonico:
+
+- **Slot anatomici** (mouth/arms/feet/back/...) — max 1 parte attiva per slot
+- **Ability emergenti** dalla parte (no perk-pick esplicito; bite ability nasce da mouth carnivore)
+- **Budget DP** spesa per acquisire/swappare parti
+- **Visual swap** prima del testo: il player VEDE la parte cambiare
+
+Estrazione completa in `docs/research/2026-04-26-spore-deep-extraction.md` ha 6
+pattern (S1..S6). 3 livelli reuse: Minimal (5h schema-only), **Moderate (~21h
+runtime semplificato)**, Full (~50h con inheritance + biome gates).
+
+## Decision
+
+**Adottare scope Moderate** (Pattern S1 + S2 + S3 + S4 parziale + S6).
+Posticipare Pattern S5 (generational inheritance) e S4 completo (visual layer
+canvas) a sprint successivo.
+
+### Scope incluso (Sprint 2026-04-27, ~21h budget)
+
+| Pattern | Scope                                                  | Effort |
+| ------- | ------------------------------------------------------ | -----: |
+| **S1**  | `body_slot` field + slot-conflict gating rule          |     3h |
+| **S2**  | `derived_ability_id` field + `applyMutation()` runtime |     6h |
+| **S3**  | Pool MP (Mutation Points) + earn/spend wire            |     4h |
+| **S4**  | `aspect_token` + `visual_swap_it` schema lock + linter |     1h |
+| **S6**  | Bingo 3×category → passive bonus                       |     7h |
+
+Totale: ~21h. Authoring `aspect_token` per 30 mutation entries differito
+(15h authoring debt). Solo 4/30 esistenti (skiv lifecycle) wirate visualmente
+nel S4 partial.
+
+### Scope ESCLUSO esplicito
+
+- **S4 completo** (canvas overlay `drawMutationDots`) — differito post primo
+  playtest live (richiede authoring 26 entries × 30min = 13h). Schema lock OK ora.
+- **S5** (generational inheritance via `propagateLineage`) — richiede V3 Mating
+  engine wire (separato da Pilastro 2 evolution editor; OD-001 Path A 4/4 già
+  chiuso plumbing). Sprint successivo.
+- **CK3 geneEncoder** — futuro V3 Mating only.
+- **Biome-aware mutation unlock gates** — già parzialmente coperto da
+  `biome_boost`/`biome_penalty` esistenti nel catalog. Wire runtime futuro.
+
+### Schema canonico body_slot (S1)
+
+5 slot anatomici lockati. Ogni mutation deve dichiarare `body_slot ∈`:
+
+```yaml
+body_slot: mouth      # bite/spit/jaw — combat oral
+body_slot: appendage  # claw/hand/spike/wing — limb-derived
+body_slot: sense      # eye/ear/antenna — perception
+body_slot: tegument   # skin/scale/plate — defense layer
+body_slot: back       # spine/wing-pair/sail — locomotion + display
+```
+
+**Eccezione `category: symbiotic`**: `body_slot: null` permesso (le simbiosi
+sono soprapposizioni biologiche per definizione, no slot fisico esclusivo).
+
+### Pool MP (Mutation Points) — Pattern S3
+
+Pool separato da PE/PI esistenti (Tri-Sorgente reward R/A/P già live in V2).
+MP accumula da:
+
+- Encounter complete con bersaglio tier ≥ 2 → `+2 MP`
+- Kill con status effect attivo (bleed/stun/fracture) → `+1 MP`
+- Biome affinity match (specie nel proprio bioma preferito) → `+1 MP/encounter`
+
+MP spende: ogni mutation ha `mp_cost` (range 3..15 in base a tier 1/2/3).
+PE/PI restano per perk progression. **Niente conversione MP↔PE**: pool separati
+forzano scelta strategica (perk vs mutation budget).
+
+### Bingo 3×category (S6)
+
+Trigger: 3 mutation della stessa `category` su una creatura → bonus passivo:
+
+| Category      | 3-mutation bonus                                                           |
+| ------------- | -------------------------------------------------------------------------- |
+| physiological | `archetype: tank_plus`, +1 DR unconditional                                |
+| behavioral    | `archetype: ambush_plus`, +2 init quando crit/flank                        |
+| sensorial     | `archetype: scout_plus`, +2 sight range, ignora low-cover                  |
+| environmental | `archetype: adapter_plus`, immune ad un hazard biome-locked                |
+| symbiotic     | `archetype: alpha_plus`, +1 affinity passive a tutti gli alleati adiacenti |
+
+**Anti-pattern noto**: 14/30 mutation sono `physiological`. Bingo a 3 = quasi
+garantito. Mitigazione: lint rule `mutation_catalog_balance.py` (NEW) → warn se
+una category > 40% del totale catalog. Authoring debt: rebalance verso 6 entries
+per category minimum nel sprint successivo.
+
+## Consequences
+
+### Positive
+
+- **Pilastro 2 🟢c+ → 🟢 candidato**: runtime evolution loop funzionante
+  (encounter → MP → mutation pick → ability emerge → next encounter)
+- **Schema lock prima authoring**: nessun rework di 30 entries dopo decisione
+- **Tri-Sorgente reward extension natural**: pool R/A/P → R/A/P/M coerente con V2
+- **Bingo emergente**: trasforma `category` da tag inerte a meccanica strategica
+- **Differimento esplicito**: visual canvas + inheritance non bloccano il
+  primo playtest (Step 6 backbone deploy può procedere senza)
+
+### Negative
+
+- **15h authoring debt** (`aspect_token` × 30 entries) accumulato esplicitamente
+- **Catalog imbalance** (14 physiological vs 2 symbiotic) → bingo physiological
+  spesso garantito; rebalance authoring TO-DO
+- **No generational closing loop** ancora (S5 differito) → l'evoluzione resta
+  per-run, non trans-generazionale fino a sprint successivo
+
+### Neutral
+
+- **Body_slot exception per symbiotic**: documentato, non un bug
+- **MP separato da PE**: scelta deliberata, non dimenticanza di unificare
+
+## Implementation plan
+
+Ordinato per dipendenze (no PR può essere unwound senza i precedenti):
+
+1. **PR-S1** schema: `body_slot` + `derived_ability_id` + `mp_cost` field aggiunti
+   ai 30 mutation entries. Linter `lint_mutations.py` verifica presenza.
+2. **PR-S2** runtime: `progressionEngine.applyMutation()` + `POST /api/session/:id/mutation/apply`
+   endpoint. Gating: slot-conflict + MP budget check.
+3. **PR-S3** pool: `mpTracker.js` modello (mirror `sgTracker.js` pattern V2),
+   wire in `damage step` per kill+status, wire `rewardOffer.js` softmax pool M.
+4. **PR-S6** bingo: `computeMutationBingo()` in progressionEngine, apply
+   `archetype_*_plus` passives. Test 5 categories.
+5. **PR-S4 partial** linter: `tools/py/lint_mutations.py` — verifica
+   `aspect_token` presenza per ogni entry; warn se manca (no fail). Authoring
+   schema lock per sprint successivo.
+
+Tutti i PR additivi, nessun breaking change su file esistenti runtime.
+
+## Rollback plan
+
+- **Disattivazione runtime**: `MUTATION_ENGINE_ENABLED=false` env flag
+  (default `true`) disabilita `/api/session/:id/mutation/apply` endpoint +
+  blocca `applyMutation()` con `MutationDisabledError`
+- **Pool MP**: fallback a 0 se flag off, no metric leak
+- **Bingo**: `computeMutationBingo()` ritorna `{}` se flag off
+- **Linter**: warn-only, no CI block
+
+## Verification (DoD)
+
+- [ ] Mutation catalog: 30/30 entries con `body_slot` + `derived_ability_id` + `mp_cost`
+- [ ] `node --test tests/services/mutationEngine.test.js` → almeno 12 test verde
+- [ ] `node --test tests/api/mutation.apply.test.js` → 5 endpoint test verde
+- [ ] `node --test tests/services/mpTracker.test.js` → 6 test verde
+- [ ] `node --test tests/services/mutationBingo.test.js` → 5 test (1/category) verde
+- [ ] `python tools/py/lint_mutations.py` → 0 schema errors
+- [ ] `prettier --check` → ok
+- [ ] Pilastro 2 status update in CLAUDE.md sprint context
+
+## References
+
+- Spore Creature Stage analysis: `docs/research/2026-04-26-spore-deep-extraction.md`
+- Tri-Sorgente reward (V2 reference): `apps/backend/services/rewards/rewardOffer.js`
+- SG tracker pattern (V5 reference): `apps/backend/services/combat/sgTracker.js`
+- Forme 16 base canonical: `docs/core/22-FORME_BASE_16.md`
+- Pilastri canonical: `docs/core/02-PILASTRI.md`

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -484,6 +484,17 @@
       "review_cycle_days": 180
     },
     {
+      "path": "docs/adr/ADR-2026-04-26-spore-part-pack-slots.md",
+      "title": "ADR-2026-04-26 — Spore part-pack slots — schema lock + Moderate scope",
+      "doc_status": "active",
+      "doc_owner": "master-dd",
+      "workstream": "cross-cutting",
+      "last_verified": "2026-04-27",
+      "source_of_truth": true,
+      "language": "it",
+      "review_cycle_days": 180
+    },
+    {
       "path": "docs/adr/ADR-XXX-refactor-cli.md",
       "title": "ADR-XXX: Motivazioni refactor CLI e allineamento toolchain",
       "doc_status": "active",

--- a/tests/services/mutationCatalogLoader.test.js
+++ b/tests/services/mutationCatalogLoader.test.js
@@ -140,3 +140,66 @@ test('getMutation: direct lookup', () => {
 test('DEFAULT_CATALOG_PATH points to a real file', () => {
   assert.ok(fs.existsSync(DEFAULT_CATALOG_PATH), `expected ${DEFAULT_CATALOG_PATH} to exist`);
 });
+
+// ─── Sprint Spore Moderate (ADR-2026-04-26) — schema lock ─────────────────
+//
+// Verifica che ogni mutation abbia i 3 nuovi campi shippati nello sprint
+// Spore Moderate (Pattern S1+S2+S3): body_slot + derived_ability_id + mp_cost.
+// Slot canonici: mouth, appendage, sense, tegument, back. Eccezione esplicita:
+// `category: symbiotic` può avere body_slot=null (le simbiosi sono biologicamente
+// soprapposte, no slot fisico esclusivo per ADR §S1).
+
+const VALID_BODY_SLOTS = ['mouth', 'appendage', 'sense', 'tegument', 'back'];
+
+test('Schema lock — every mutation has body_slot (canonical slot or null for symbiotic)', () => {
+  _resetCacheForTest();
+  const data = loadMutationCatalog({ refresh: true });
+  for (const [id, entry] of Object.entries(data.byId)) {
+    assert.ok('body_slot' in entry, `${id} missing body_slot field`);
+    if (entry.body_slot === null) {
+      assert.equal(
+        entry.category,
+        'symbiotic',
+        `${id} has body_slot=null but category=${entry.category} (only symbiotic exempted)`,
+      );
+    } else {
+      assert.ok(
+        VALID_BODY_SLOTS.includes(entry.body_slot),
+        `${id} body_slot=${entry.body_slot} not in canonical set ${VALID_BODY_SLOTS.join('|')}`,
+      );
+    }
+  }
+});
+
+test('Schema lock — every mutation has derived_ability_id field (nullable)', () => {
+  _resetCacheForTest();
+  const data = loadMutationCatalog({ refresh: true });
+  for (const [id, entry] of Object.entries(data.byId)) {
+    assert.ok('derived_ability_id' in entry, `${id} missing derived_ability_id field`);
+    const v = entry.derived_ability_id;
+    assert.ok(
+      v === null || typeof v === 'string',
+      `${id} derived_ability_id must be null or string`,
+    );
+  }
+});
+
+test('Schema lock — every mutation has mp_cost (positive integer per tier)', () => {
+  _resetCacheForTest();
+  const data = loadMutationCatalog({ refresh: true });
+  // Per ADR: tier 1 → 3 MP, tier 2 → 8 MP, tier 3 → 15 MP.
+  const TIER_MP_EXPECTED = { 1: 3, 2: 8, 3: 15 };
+  for (const [id, entry] of Object.entries(data.byId)) {
+    assert.ok('mp_cost' in entry, `${id} missing mp_cost field`);
+    assert.equal(typeof entry.mp_cost, 'number', `${id} mp_cost must be number`);
+    assert.ok(entry.mp_cost > 0, `${id} mp_cost must be > 0`);
+    const expected = TIER_MP_EXPECTED[entry.tier];
+    if (expected !== undefined) {
+      assert.equal(
+        entry.mp_cost,
+        expected,
+        `${id} mp_cost=${entry.mp_cost} expected ${expected} for tier ${entry.tier}`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Summary
Step 5.A+B di sprint Spore Moderate (Pilastro 2 evoluzione runtime).

## ADR — \`docs/adr/ADR-2026-04-26-spore-part-pack-slots.md\` (ACCEPTED)
- Scope Moderate ~21h: Pattern S1+S2+S3+S4 partial+S6 da \`docs/research/2026-04-26-spore-deep-extraction.md\`
- Differiti: S4 completo (canvas overlay), S5 (generational inheritance)
- Slot canonici: \`mouth | appendage | sense | tegument | back\` (5)
- Eccezione esplicita: \`category=symbiotic → body_slot=null\`
- Pool MP separato da PE/PI (no conversione, scelta strategica forzata)
- Bingo 3×category → \`archetype_*_plus\` passive
- Anti-pattern flagged: 14/30 physiological → bingo physiological quasi garantito

## Schema lock — \`data/core/mutations/mutation_catalog.yaml\` (additive)
- \`body_slot\`: 30/30 entries (10 tegument + 6 appendage + 6 mouth + 3 back + 3 sense + 2 null/symbiotic)
- \`derived_ability_id\`: 30/30 (placeholder null, S2 wire next)
- \`mp_cost\`: 30/30 (tier 1=3, tier 2=8, tier 3=15)

## Test plan
- [x] \`node --test tests/services/mutationCatalogLoader.test.js\` → 11/11 ✓ (3 nuovi schema-lock test)
- [x] Prettier ok
- [x] Governance \`errors=0 warnings=0\`

## Next
PR-S2 (\`progressionEngine.applyMutation()\` + endpoint) builds on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)