### PR TITLE
feat(sprint-alpha): A+E residuals — SG starter + reward telemetry + QBN debrief wire

### DIFF
--- a/apps/backend/routes/rewards.js
+++ b/apps/backend/routes/rewards.js
@@ -15,6 +15,8 @@
 
 'use strict';
 
+const fs = require('fs').promises;
+const path = require('path');
 const { Router } = require('express');
 const {
   buildOffer,
@@ -23,6 +25,30 @@ const {
 } = require('../services/rewards/rewardOffer');
 const { loadPool } = require('../services/rewards/rewardPoolLoader');
 const { addFragments, getFragments } = require('../services/rewards/skipFragmentStore');
+
+// A-residual #2 (2026-04-27) — Reward auto-log telemetry JSONL.
+// Mirror del pattern session.js appendTelemetryEvent (best-effort, non-blocking).
+// Logs su `logs/telemetry_YYYYMMDD.jsonl` per analisi funnel reward_offer/skip.
+const LOGS_DIR = path.resolve(__dirname, '../../../logs');
+async function appendRewardTelemetry({ campaign_id, actor_id, type, payload }) {
+  try {
+    const now = new Date();
+    const yyyymmdd = now.toISOString().slice(0, 10).replace(/-/g, '');
+    const telemetryPath = path.join(LOGS_DIR, `telemetry_${yyyymmdd}.jsonl`);
+    const entry = {
+      ts: now.toISOString(),
+      session_id: null,
+      campaign_id: campaign_id || null,
+      player_id: actor_id || null,
+      type: type || 'unknown',
+      payload: payload ?? null,
+    };
+    await fs.mkdir(LOGS_DIR, { recursive: true });
+    await fs.appendFile(telemetryPath, JSON.stringify(entry) + '\n', 'utf8');
+  } catch {
+    // Non-blocking telemetry — never crash request on write failure.
+  }
+}
 
 function createRewardsRouter() {
   const router = Router();
@@ -57,6 +83,19 @@ function createRewardsRouter() {
       offerSize: offer_size || DEFAULT_OFFER_SIZE,
       temperature: temperature || DEFAULT_TEMPERATURE,
     });
+    // A-residual #2 — auto-log reward_offer event (funnel analysis input).
+    appendRewardTelemetry({
+      campaign_id: campaign_id || null,
+      actor_id: actor_id || null,
+      type: 'reward_offer',
+      payload: {
+        pool_id: poolDoc.pool_id,
+        offer_size: result.offers.length,
+        offer_ids: result.offers.map((o) => o?.id || null),
+        skip_available: result.skip_available,
+        roll_bucket: roll_bucket || null,
+      },
+    });
     res.json({
       campaign_id: campaign_id || null,
       actor_id: actor_id || null,
@@ -72,6 +111,16 @@ function createRewardsRouter() {
     const { campaign_id, reason } = req.body || {};
     if (!campaign_id) return res.status(400).json({ error: 'campaign_id richiesto' });
     const newCount = addFragments(campaign_id, 1, { reason: reason || 'skip_offer' });
+    // A-residual #2 — auto-log reward_skip event (funnel analysis input).
+    appendRewardTelemetry({
+      campaign_id,
+      actor_id: null,
+      type: 'reward_skip',
+      payload: {
+        reason: reason || 'skip_offer',
+        fragment_count: newCount,
+      },
+    });
     res.json({ campaign_id, fragment_count: newCount, delta: 1 });
   });
 

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -1223,6 +1223,8 @@ function createSessionRouter(options = {}) {
       // V5 SG lifecycle: encounter start reset (ADR-2026-04-26).
       // Optional restore: `req.body.initial_sg = { unit_id: pool }` lets
       // save-load + integration tests seed SG after the encounter zero-pass.
+      // A-residual #1 (2026-04-27): tutorial player units start with SG=1
+      // so first ability con cost SG è immediately disponibile (UX onboard).
       try {
         const sgTracker = require('../services/combat/sgTracker');
         for (const u of session.units || []) sgTracker.resetEncounter(u);
@@ -1233,6 +1235,13 @@ function createSessionRouter(options = {}) {
             if (!unit) continue;
             const value = Math.max(0, Math.min(3, Math.floor(Number(pool) || 0)));
             unit.sg = value;
+          }
+        } else if (isTutorialScenario(scenarioId)) {
+          // Tutorial onboard: player units start with SG=1.
+          for (const u of session.units || []) {
+            if (u && u.controlled_by === 'player' && u.hp > 0) {
+              u.sg = 1;
+            }
           }
         }
       } catch {

--- a/apps/backend/services/rewardEconomy.js
+++ b/apps/backend/services/rewardEconomy.js
@@ -117,6 +117,35 @@ function buildDebriefSummary(session, vcSnapshot, peResult, pfSession = {}) {
     // narrative module optional
   }
 
+  // E-residual #2 (2026-04-27) — QBN debrief wire (Surface-DEAD sweep).
+  // QBN engine (qbnEngine.drawEvent) era orphan: 17 events YAML caricati,
+  // zero chiamate da session route. Wire here per esporre 1 narrative event
+  // per debrief, basato su VC qualities + history. Best-effort, non blocca.
+  let narrativeEvent = null;
+  try {
+    const { drawEvent } = require('./narrative/qbnEngine');
+    const result = drawEvent({
+      vcSnapshot,
+      runState: {
+        turns_played: vcSnapshot.turns_played || 0,
+        victories: isVictory ? 1 : 0,
+      },
+      history: session?.qbn_history || {},
+      seed: session?.session_id || 'debrief',
+    });
+    if (result && result.event) {
+      narrativeEvent = {
+        id: result.event.id,
+        title_it: result.event.title_it || result.event.title || null,
+        body_it: result.event.body_it || result.event.body || null,
+        choices: Array.isArray(result.event.choices) ? result.event.choices : [],
+        eligible_count: result.eligible_count,
+      };
+    }
+  } catch {
+    // qbnEngine optional / pack missing — non blocca debrief
+  }
+
   return {
     session_id: session.session_id,
     turns_played: vcSnapshot.turns_played || 0,
@@ -144,6 +173,8 @@ function buildDebriefSummary(session, vcSnapshot, peResult, pfSession = {}) {
     },
     // P0 Tier S — Disco MBTI tag debrief (P4 surfacing, narrative diegetic).
     mbti_insights: mbtiInsights,
+    // E-residual #2 — QBN narrative event (1 event per debrief, eligible by VC).
+    narrative_event: narrativeEvent,
     // Personality projection
     pf_session: pfSession,
     // Combat stats

--- a/tests/services/rewardEconomy.test.js
+++ b/tests/services/rewardEconomy.test.js
@@ -136,6 +136,8 @@ test('convertPE 5:1 — exact + remainder + zero', () => {
 test('buildDebriefSummary returns expected canonical shape', () => {
   const session = {
     session_id: 'sess_1',
+    // 2026-04-26 Q19 Opzione A: PE→PI conversion gated on outcome=victory.
+    outcome: 'victory',
     events: [{ a: 1 }, { a: 2 }],
     damage_taken: { u1: 0, u2: 5, u3: -3 },
   };
@@ -156,10 +158,10 @@ test('buildDebriefSummary returns expected canonical shape', () => {
   assert.equal(debrief.turns_played, 7);
   assert.ok(debrief.economy);
   assert.equal(debrief.economy.pe_session_total, peResult.session_total);
-  // 5+3+1=9 → 1 PI + 4 remainder
+  // 5+3+1=9 → 1 PI + 4 remainder (post-victory gate)
   assert.equal(debrief.economy.pi_converted, 1);
   assert.equal(debrief.economy.pe_remaining, 4);
-  assert.equal(debrief.economy.seed_earned, 0, 'seed wired in D2 (placeholder 0)');
+  // seed_earned removed 2026-04-26 (orphan currency cleanup PR #1870)
   assert.equal(debrief.combat.total_events, 2);
   // damage_taken values <= 0 count as kill: u1=0 + u3=-3 → 2
   assert.equal(debrief.combat.kills, 2);


### PR DESCRIPTION
## Summary

Sprint Option α (post-audit empirico): chiuso **3 residual non-blocked** che restavano dopo la wave 32 PR cross-PC + i fix automatici altro PC.

**Reality check** (vedi [`stato-arte-completo-vertical-slice.md`](docs/reports/2026-04-27-stato-arte-completo-vertical-slice.md) §G):
- Opzione D Status engine = già **SHIPPED 100%** (24/24 test verde)
- Opzione A polish = ~70% shipped pre-sprint
- Opzione E = 1 target shipped (objectiveEvaluator), 4 blocked, 3 done qui

## Shipped

### A1 — SG +1 starter tutorial
`apps/backend/routes/session.js`: tutorial player units start con SG=1 (UX onboard, prima ability cost SG immediately available).

### A2 — Reward auto-log JSONL telemetry
`apps/backend/routes/rewards.js`: `POST /rewards/offer` + `/rewards/skip` emettono telemetry event JSONL (`logs/telemetry_YYYYMMDD.jsonl`) per funnel analysis.

### E2 — QBN debrief wire (Surface-DEAD anti-pattern fix)
`apps/backend/services/rewardEconomy.js`: `buildDebriefSummary` chiama `qbnEngine.drawEvent` per produrre 1 `narrative_event` per debrief, eligible by VC qualities + history. **17 events YAML che erano orphan ora esposti**.

### Test fix
`tests/services/rewardEconomy.test.js`: fixture stale post-Q19 PE→PI conversion gate (2026-04-26). Aggiunto `outcome: 'victory'` + rimosso `seed_earned` assertion obsoleta.

## Skip rationale

- **A3** (light terrain penalty): engine extension trait×terrain non triviale
- **A4** (ADR retry text drift): no drift detectable cross-doc
- **E1** (biomeSpawnBias initial wave universal): schema extension `initial_wave_pool` non presente
- **HP floating + drawMutationDots + Mating gene_slots + Thought Cabinet**: blocked overlap PR altro PC O blocked OD-001 V3 O authoring 30 mutations

## Test plan

- [x] `node --test tests/services/rewardEconomy.test.js` — 12/12 verde
- [x] `node --test tests/ai/*.test.js tests/api/rewardsRoute.test.js tests/services/rewardEconomy.test.js` — **323/323 verde**
- [ ] Backend smoke: `curl POST /api/rewards/offer` produce telemetry entry in logs/
- [ ] Backend smoke: `/api/session/start` con tutorial scenario_id produce unit.sg=1 player units

## Rollback

\`git revert <sha>\` — rimuove SG starter + reward telemetry + QBN debrief wire. Test fixture restore manuale post-revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)