### PR TITLE
feat(mutations): Spore Moderate S3+S6 — MP pool tracker + archetype hydration

### DIFF
--- a/apps/backend/routes/campaign.js
+++ b/apps/backend/routes/campaign.js
@@ -208,6 +208,40 @@ function createCampaignRouter(options = {}) {
     }
     const xpGrantsPayload = { xp_grants: xpGrants };
 
+    // Sprint Spore Moderate (ADR-2026-04-26 §S3) — MP grant post-encounter.
+    // Pure compute: ritorna mp_grants array nel response, NON muta unit
+    // (caller frontend è responsabile di apply su roster locale).
+    // Caller può passare encounter_meta { tier, kill_with_status, biome_match }.
+    let mpGrants = [];
+    if (outcome === 'victory' && Array.isArray(survivors) && survivors.length > 0) {
+      try {
+        const { accrueEncounter } = require('../services/mutations/mpTracker');
+        const meta = req.body?.encounter_meta || {};
+        for (const s of survivors) {
+          if (!s || typeof s !== 'object') continue;
+          // Pure shadow unit: don't mutate caller, just compute earned.
+          const shadow = { mp: Number(s.mp || 0), mp_earned_total: 0 };
+          const r = accrueEncounter(shadow, {
+            tier: Number(meta.tier || 1),
+            kill_with_status: Boolean(meta.kill_with_status),
+            biome_affinity_match: Boolean(meta.biome_match),
+          });
+          if (r.earned > 0) {
+            mpGrants.push({
+              unit_id: s.id || null,
+              earned: r.earned,
+              new_pool: r.new_pool,
+              sources: r.sources,
+              capped: r.capped,
+            });
+          }
+        }
+      } catch (err) {
+        mpGrants = [];
+      }
+    }
+    const mpGrantsPayload = { mp_grants: mpGrants };
+
     // Compute next state
     let updated;
     if (outcome !== 'victory') {
@@ -219,6 +253,7 @@ function createCampaignRouter(options = {}) {
         retry: true,
         ...evolveFlags,
         ...xpGrantsPayload,
+        ...mpGrantsPayload,
       });
     }
 
@@ -242,6 +277,7 @@ function createCampaignRouter(options = {}) {
         choice_node: nextEncEntry.choice,
         ...evolveFlags,
         ...xpGrantsPayload,
+        ...mpGrantsPayload,
       });
     }
 
@@ -262,6 +298,7 @@ function createCampaignRouter(options = {}) {
           campaign_completed: true,
           ...evolveFlags,
           ...xpGrantsPayload,
+          ...mpGrantsPayload,
         });
       }
       // Advance to next act
@@ -276,6 +313,7 @@ function createCampaignRouter(options = {}) {
         act_advanced: true,
         ...evolveFlags,
         ...xpGrantsPayload,
+        ...mpGrantsPayload,
       });
     }
 
@@ -286,6 +324,7 @@ function createCampaignRouter(options = {}) {
       next_encounter_id: nextEncEntry.encounter_id,
       ...evolveFlags,
       ...xpGrantsPayload,
+      ...mpGrantsPayload,
     });
   });
 

--- a/apps/backend/services/mutations/mpTracker.js
+++ b/apps/backend/services/mutations/mpTracker.js
@@ -1,0 +1,122 @@
+// Sprint Spore Moderate (ADR-2026-04-26 §S3) — MP (Mutation Points) tracker.
+//
+// Pool separato da PE/PI esistenti (ADR canonical). Pure module mirror del
+// pattern V5 sgTracker. Tracks per-unit MP accumulator + caps + spend.
+//
+// API:
+//   initUnit(unit) — ensure MP fields present (idempotent)
+//   accrueEncounter(unit, { tier?, kill_with_status?, biome_affinity_match? })
+//     → { earned, sources: [...], new_pool }
+//   spend(unit, amount=1) → { spent, new_pool, ok }
+//   resetForRun(unit) — campaign reset (rare; MP è cross-encounter pool)
+//
+// Earn formula per ADR §S3:
+//   - encounter completato bersaglio tier ≥ 2 → +2 MP
+//   - kill con status effect attivo (bleed/stun/fracture) → +1 MP
+//   - biome affinity match (specie nel proprio bioma preferito) → +1 MP/encounter
+//
+// Cap: MP_POOL_MAX (default 30). Strategic ceiling — basta per ~3 mutation
+// tier 3 (15 MP cad). Author può raise via env (`MP_POOL_MAX=50`).
+
+'use strict';
+
+const TIER_MEDIUM_MP = 2; // bersaglio tier ≥ 2 vinto
+const KILL_STATUS_MP = 1; // kill con status attivo
+const BIOME_MATCH_MP = 1; // biome affinity match (1 volta per encounter)
+const MP_POOL_MAX = Number(process.env.MP_POOL_MAX) || 30;
+
+/**
+ * Ensure unit has MP fields. Idempotent (safe to call every turn).
+ *
+ * Default initial pool = 5 (basta per 1 mutation tier 1 + 1 buffer). Caller
+ * può override passando unit con `mp` già settato.
+ */
+function initUnit(unit) {
+  if (!unit || typeof unit !== 'object') return unit;
+  if (typeof unit.mp !== 'number') unit.mp = 5;
+  if (typeof unit.mp_earned_total !== 'number') unit.mp_earned_total = 0;
+  return unit;
+}
+
+/**
+ * Accrue MP a fine encounter (post-debrief hook).
+ *
+ * @param {object} unit — mutated in-place
+ * @param {object} params
+ * @param {number} [params.tier=1]                    — encounter tier max
+ * @param {boolean} [params.kill_with_status=false]   — kill con status attivo
+ * @param {boolean} [params.biome_affinity_match=false] — bioma matcha specie
+ * @returns {{ earned: number, sources: string[], new_pool: number, capped: boolean }}
+ */
+function accrueEncounter(
+  unit,
+  { tier = 1, kill_with_status = false, biome_affinity_match = false } = {},
+) {
+  initUnit(unit);
+  let earned = 0;
+  const sources = [];
+
+  if (Number(tier) >= 2) {
+    earned += TIER_MEDIUM_MP;
+    sources.push(`tier_${tier}_clear:+${TIER_MEDIUM_MP}`);
+  }
+  if (kill_with_status) {
+    earned += KILL_STATUS_MP;
+    sources.push(`status_kill:+${KILL_STATUS_MP}`);
+  }
+  if (biome_affinity_match) {
+    earned += BIOME_MATCH_MP;
+    sources.push(`biome_match:+${BIOME_MATCH_MP}`);
+  }
+
+  const oldPool = Number(unit.mp || 0);
+  const candidate = oldPool + earned;
+  const newPool = Math.min(candidate, MP_POOL_MAX);
+  const capped = candidate > MP_POOL_MAX;
+
+  unit.mp = newPool;
+  unit.mp_earned_total = Number(unit.mp_earned_total || 0) + earned;
+
+  return { earned, sources, new_pool: newPool, capped };
+}
+
+/**
+ * Spend MP (called from /api/v1/mutations/apply via applyMutationPure).
+ *
+ * @param {object} unit — mutated in-place
+ * @param {number} amount — MP da scalare (default 1)
+ * @returns {{ spent: number, new_pool: number, ok: boolean }}
+ */
+function spend(unit, amount = 1) {
+  initUnit(unit);
+  const cost = Math.max(0, Number(amount) || 0);
+  const oldPool = Number(unit.mp || 0);
+  if (cost > oldPool) {
+    return { spent: 0, new_pool: oldPool, ok: false };
+  }
+  const newPool = oldPool - cost;
+  unit.mp = newPool;
+  return { spent: cost, new_pool: newPool, ok: true };
+}
+
+/**
+ * Reset cross-campaign (rare). Default policy: MP è long-pool, NON si reset
+ * per-encounter (a differenza di SG). Usa solo per new-game / lineage death.
+ */
+function resetForRun(unit) {
+  initUnit(unit);
+  unit.mp = 5;
+  unit.mp_earned_total = 0;
+  return unit;
+}
+
+module.exports = {
+  initUnit,
+  accrueEncounter,
+  spend,
+  resetForRun,
+  TIER_MEDIUM_MP,
+  KILL_STATUS_MP,
+  BIOME_MATCH_MP,
+  MP_POOL_MAX,
+};

--- a/apps/backend/services/mutations/mutationEngine.js
+++ b/apps/backend/services/mutations/mutationEngine.js
@@ -222,11 +222,37 @@ function computeMutationBingo(unit, catalog) {
   return { counts, archetypes };
 }
 
+/**
+ * Hydrate unit con `_archetype_passives` derivati dal bingo state corrente.
+ *
+ * Parallelo a `unit._perk_passives` (M13.P3): array di passive_token consumati
+ * runtime nel resolver damage step / sight calc. Idempotent — sostituisce
+ * ogni call con valori freschi da computeMutationBingo.
+ *
+ * @param {object} unit — mutated in-place (campo `_archetype_passives` set)
+ * @param {object} catalog — output loadMutationCatalog()
+ * @returns {{ archetypes: Array, passive_tokens: string[] }}
+ */
+function applyMutationBingoToUnit(unit, catalog) {
+  if (!unit || typeof unit !== 'object') return { archetypes: [], passive_tokens: [] };
+  const bingo = computeMutationBingo(unit, catalog);
+  const passive_tokens = bingo.archetypes.map((a) => a.passive_token);
+  unit._archetype_passives = passive_tokens;
+  unit._archetype_meta = bingo.archetypes.map((a) => ({
+    archetype: a.archetype,
+    category: a.category,
+    passive_token: a.passive_token,
+    label_it: a.label_it,
+  }));
+  return { archetypes: bingo.archetypes, passive_tokens };
+}
+
 module.exports = {
   checkSlotConflict,
   checkMpBudget,
   applyMutationPure,
   computeMutationBingo,
+  applyMutationBingoToUnit,
   BINGO_ARCHETYPES,
   BINGO_THRESHOLD,
 };

--- a/apps/backend/services/progression/progressionApply.js
+++ b/apps/backend/services/progression/progressionApply.js
@@ -98,6 +98,24 @@ function applyProgressionToUnits(units, opts = {}) {
       ability_mod_count: abilityMods.length,
     });
   }
+
+  // Sprint Spore Moderate (ADR-2026-04-26 §S6) — hydrate _archetype_passives
+  // for ALL units (player + sistema) post perk application. Bingo state is
+  // pure-derived from applied_mutations[]: zero side effect when zero mutations.
+  // Wrapped in try/catch: missing module / catalog error must NOT block session
+  // start (back-compat con sessioni pre-Spore).
+  try {
+    const { applyMutationBingoToUnit } = require('../mutations/mutationEngine');
+    const { loadMutationCatalog } = require('../mutations/mutationCatalogLoader');
+    const catalog = loadMutationCatalog();
+    for (const unit of units) {
+      if (!unit || typeof unit !== 'object') continue;
+      applyMutationBingoToUnit(unit, catalog);
+    }
+  } catch {
+    // Non-blocking: skip archetype hydration on error.
+  }
+
   return { applied, skipped };
 }
 

--- a/tests/api/campaignRoutes.test.js
+++ b/tests/api/campaignRoutes.test.js
@@ -375,6 +375,60 @@ test('advance: victory without survivors → xp_grants empty', async (t) => {
   assert.deepEqual(res.body.xp_grants, []);
 });
 
+// Sprint Spore Moderate (ADR-2026-04-26 §S3) — MP grant hook on victory.
+
+test('advance: victory + survivors + encounter_meta tier=2 → mp_grants emitted', async (t) => {
+  const { url } = startTestServer(t);
+  const create = await request('POST', `${url}/api/campaign/start`, { player_id: 'p1' });
+  const id = create.body.campaign.id;
+  const res = await request('POST', `${url}/api/campaign/advance`, {
+    id,
+    outcome: 'victory',
+    pe_earned: 5,
+    survivors: [
+      { id: 'u_a', job: 'skirmisher', mp: 0 },
+      { id: 'u_b', job: 'vanguard', mp: 5 },
+    ],
+    encounter_meta: { tier: 2, kill_with_status: true, biome_match: false },
+  });
+  assert.equal(res.status, 200);
+  assert.ok(Array.isArray(res.body.mp_grants), 'mp_grants array present');
+  assert.equal(res.body.mp_grants.length, 2);
+  const byId = Object.fromEntries(res.body.mp_grants.map((g) => [g.unit_id, g]));
+  // tier_2 (+2) + status_kill (+1) = +3 each
+  assert.equal(byId.u_a.earned, 3);
+  assert.equal(byId.u_b.earned, 3);
+});
+
+test('advance: victory tier=1 no bonus → mp_grants empty', async (t) => {
+  const { url } = startTestServer(t);
+  const create = await request('POST', `${url}/api/campaign/start`, { player_id: 'p1' });
+  const id = create.body.campaign.id;
+  const res = await request('POST', `${url}/api/campaign/advance`, {
+    id,
+    outcome: 'victory',
+    pe_earned: 5,
+    survivors: [{ id: 'u_a', job: 'skirmisher', mp: 0 }],
+    encounter_meta: { tier: 1 },
+  });
+  assert.equal(res.status, 200);
+  assert.deepEqual(res.body.mp_grants, []);
+});
+
+test('advance: defeat never grants MP even with survivors', async (t) => {
+  const { url } = startTestServer(t);
+  const create = await request('POST', `${url}/api/campaign/start`, { player_id: 'p1' });
+  const id = create.body.campaign.id;
+  const res = await request('POST', `${url}/api/campaign/advance`, {
+    id,
+    outcome: 'defeat',
+    survivors: [{ id: 'u_x', job: 'skirmisher' }],
+    encounter_meta: { tier: 3, kill_with_status: true, biome_match: true },
+  });
+  assert.equal(res.status, 200);
+  assert.deepEqual(res.body.mp_grants, []);
+});
+
 test('advance: defeat never grants XP even with survivors', async (t) => {
   const { url } = startTestServer(t);
   const create = await request('POST', `${url}/api/campaign/start`, { player_id: 'p1' });

--- a/tests/services/mpTracker.test.js
+++ b/tests/services/mpTracker.test.js
@@ -1,0 +1,106 @@
+// Sprint Spore Moderate (ADR-2026-04-26 §S3) — mpTracker pool unit tests.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  initUnit,
+  accrueEncounter,
+  spend,
+  resetForRun,
+  TIER_MEDIUM_MP,
+  KILL_STATUS_MP,
+  BIOME_MATCH_MP,
+  MP_POOL_MAX,
+} = require('../../apps/backend/services/mutations/mpTracker');
+
+test('initUnit: sets default mp=5 + mp_earned_total=0 (idempotent)', () => {
+  const u = {};
+  initUnit(u);
+  assert.equal(u.mp, 5);
+  assert.equal(u.mp_earned_total, 0);
+  // Re-call: no overwrite
+  u.mp = 17;
+  initUnit(u);
+  assert.equal(u.mp, 17);
+});
+
+test('accrueEncounter: tier 2 win → +2 MP', () => {
+  const u = { mp: 0 };
+  const r = accrueEncounter(u, { tier: 2 });
+  assert.equal(r.earned, TIER_MEDIUM_MP);
+  assert.equal(u.mp, 2);
+  assert.ok(r.sources.some((s) => s.startsWith('tier_2_clear')));
+});
+
+test('accrueEncounter: kill with status → +1 MP', () => {
+  const u = { mp: 0 };
+  const r = accrueEncounter(u, { tier: 1, kill_with_status: true });
+  assert.equal(r.earned, KILL_STATUS_MP);
+  assert.equal(u.mp, 1);
+});
+
+test('accrueEncounter: biome match → +1 MP', () => {
+  const u = { mp: 0 };
+  const r = accrueEncounter(u, { tier: 1, biome_affinity_match: true });
+  assert.equal(r.earned, BIOME_MATCH_MP);
+  assert.equal(u.mp, 1);
+});
+
+test('accrueEncounter: full bonus stack tier3+kill+biome → 4 MP', () => {
+  const u = { mp: 0 };
+  const r = accrueEncounter(u, {
+    tier: 3,
+    kill_with_status: true,
+    biome_affinity_match: true,
+  });
+  assert.equal(r.earned, TIER_MEDIUM_MP + KILL_STATUS_MP + BIOME_MATCH_MP);
+  assert.equal(u.mp, 4);
+  assert.equal(r.sources.length, 3);
+});
+
+test('accrueEncounter: tier 1 only no bonus → +0 MP', () => {
+  const u = { mp: 5 };
+  const r = accrueEncounter(u, { tier: 1 });
+  assert.equal(r.earned, 0);
+  assert.equal(u.mp, 5);
+});
+
+test('accrueEncounter: cap at MP_POOL_MAX (capped flag set)', () => {
+  const u = { mp: MP_POOL_MAX - 1 };
+  const r = accrueEncounter(u, { tier: 3, kill_with_status: true, biome_affinity_match: true });
+  assert.equal(u.mp, MP_POOL_MAX);
+  assert.equal(r.capped, true);
+});
+
+test('accrueEncounter: tracks mp_earned_total cumulative (uncapped counter)', () => {
+  const u = { mp: 0, mp_earned_total: 0 };
+  accrueEncounter(u, { tier: 2 }); // +2
+  accrueEncounter(u, { tier: 2, kill_with_status: true }); // +3
+  assert.equal(u.mp_earned_total, 5);
+});
+
+test('spend: deducts and returns ok=true when sufficient', () => {
+  const u = { mp: 10 };
+  const r = spend(u, 8);
+  assert.equal(r.ok, true);
+  assert.equal(r.spent, 8);
+  assert.equal(u.mp, 2);
+});
+
+test('spend: insufficient funds → no deduct + ok=false', () => {
+  const u = { mp: 3 };
+  const r = spend(u, 8);
+  assert.equal(r.ok, false);
+  assert.equal(r.spent, 0);
+  assert.equal(u.mp, 3);
+});
+
+test('resetForRun: pool back to default 5', () => {
+  const u = { mp: 22, mp_earned_total: 100 };
+  resetForRun(u);
+  assert.equal(u.mp, 5);
+  assert.equal(u.mp_earned_total, 0);
+});

--- a/tests/services/mutationEngine.test.js
+++ b/tests/services/mutationEngine.test.js
@@ -16,6 +16,7 @@ const {
   checkMpBudget,
   applyMutationPure,
   computeMutationBingo,
+  applyMutationBingoToUnit,
   BINGO_ARCHETYPES,
   BINGO_THRESHOLD,
 } = require('../../apps/backend/services/mutations/mutationEngine');
@@ -246,4 +247,46 @@ test('computeMutationBingo: ignora applied_mutations id non in catalog', () => {
   );
   assert.equal(r.counts.physiological, 1);
   assert.equal(r.archetypes.length, 0);
+});
+
+// ─── applyMutationBingoToUnit (resolver-side hydration) ───────────────────
+
+test('applyMutationBingoToUnit: hydrates _archetype_passives + _archetype_meta', () => {
+  const catalog = freshCatalog();
+  const unit = {
+    id: 'u',
+    applied_mutations: [
+      'artigli_freeze_to_glacier',
+      'ali_panic_to_resonance',
+      'denti_bleed_to_chelate',
+    ],
+  };
+  const r = applyMutationBingoToUnit(unit, catalog);
+  assert.deepEqual(unit._archetype_passives, ['archetype_tank_plus_dr1']);
+  assert.equal(unit._archetype_meta.length, 1);
+  assert.equal(unit._archetype_meta[0].archetype, 'tank_plus');
+  assert.equal(r.passive_tokens.length, 1);
+});
+
+test('applyMutationBingoToUnit: zero bingo → empty arrays', () => {
+  const catalog = freshCatalog();
+  const unit = { id: 'u', applied_mutations: ['artigli_freeze_to_glacier'] };
+  applyMutationBingoToUnit(unit, catalog);
+  assert.deepEqual(unit._archetype_passives, []);
+  assert.deepEqual(unit._archetype_meta, []);
+});
+
+test('applyMutationBingoToUnit: idempotent (overwrite, not append)', () => {
+  const catalog = freshCatalog();
+  const unit = {
+    id: 'u',
+    _archetype_passives: ['stale_token'], // pre-existing stale value
+    applied_mutations: [
+      'artigli_freeze_to_glacier',
+      'ali_panic_to_resonance',
+      'denti_bleed_to_chelate',
+    ],
+  };
+  applyMutationBingoToUnit(unit, catalog);
+  assert.deepEqual(unit._archetype_passives, ['archetype_tank_plus_dr1']);
 });


### PR DESCRIPTION
## Summary
Step 5.D+E sprint Spore Moderate. Builds on PR #1915.

## S3 — MP pool (\`apps/backend/services/mutations/mpTracker.js\`, ~120 LOC)
- \`accrueEncounter\` — tier≥2 +2, status-kill +1, biome-match +1, cap 30
- \`spend\` / \`resetForRun\` / \`initUnit\` (idempotent)
- Wire \`POST /api/campaign/advance\` → response \`mp_grants[]\` additivo (pure compute, no caller mutation)

## S6 — archetype hydration
- \`applyMutationBingoToUnit(unit, catalog)\` esposto da mutationEngine
- Wired in \`applyProgressionToUnits()\` (session /start hook) — hydration TUTTE units
- Try/catch graceful (back-compat sessioni pre-Spore)

## Test
- [x] mutationEngine 23/23 (incluso 3 hydration test)
- [x] mpTracker 11/11 (5 accrue + 2 spend + reset + cap)
- [x] mutationsRoutes 9/9 (PR #1915 carryover)
- [x] campaignRoutes 33/33 (3 mp_grants nuovi)
- [x] progressionApply 43/43 (additive hook non-blocking)
- [x] Prettier ok

## Pillar impact
P2 Evoluzione 🟢c+ → **🟢 candidato** (loop runtime evolution completo).

## Deferred follow-up
- Resolver consumption \`archetype_tank_plus_dr1\` etc. (defender-side hook damage step) — scope separato evitare ripple resolver
- S4 visual layer canvas (15h authoring \`aspect_token\` × 30 entries)
- S5 generational inheritance (\`propagateLineage\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)