### PR TITLE
feat(lineage): Spore Moderate S5 — propagateLineage + inheritFromLineage cross-gen

### DIFF
--- a/apps/backend/routes/lineage.js
+++ b/apps/backend/routes/lineage.js
@@ -1,0 +1,105 @@
+// Sprint B Spore S5 (ADR-2026-04-26-spore-part-pack-slots) — REST surface
+// for cross-generational lineage propagation.
+//
+// Endpoints (additive, no breaking changes):
+//   POST /api/v1/lineage/propagate
+//        body { legacyUnit, species_id, biome_id }
+//        → { written_traits: [...], pool_size, species_id, biome_id }
+//   POST /api/v1/lineage/inherit
+//        body { newUnit, species_id, biome_id, lineage_id?, opts? }
+//        → { unit, inherited: [...], pool_consumed: false, pool_size }
+//   GET  /api/v1/lineage/pool/:species/:biome
+//        → { species_id, biome_id, mutations: [...], pool_size }
+//
+// IMPORTANT: lifecycle_phase=legacy hook (chi chiama propagateLineage
+// post-mortem unit) è deferred a sprint successivo. Questo è "the plumbing",
+// non "the trigger".
+//
+// Cross-ref:
+// - apps/backend/services/generation/lineagePropagator.js
+// - data/core/species/dune_stalker_lifecycle.yaml `legacy.inheritable_traits`
+
+'use strict';
+
+const { Router } = require('express');
+const {
+  propagateLineage,
+  inheritFromLineage,
+  inspectPool,
+} = require('../services/generation/lineagePropagator');
+
+function createLineageRouter() {
+  const router = Router();
+
+  /**
+   * POST /propagate — body { legacyUnit, species_id, biome_id }.
+   * Writes legacyUnit.applied_mutations to the (species, biome) pool.
+   */
+  router.post('/propagate', (req, res) => {
+    const { legacyUnit, species_id: speciesId, biome_id: biomeId } = req.body || {};
+    if (!legacyUnit || typeof legacyUnit !== 'object') {
+      return res.status(400).json({ error: 'legacyUnit (object) required' });
+    }
+    if (typeof speciesId !== 'string' || !speciesId) {
+      return res.status(400).json({ error: 'species_id (string) required' });
+    }
+    if (typeof biomeId !== 'string' || !biomeId) {
+      return res.status(400).json({ error: 'biome_id (string) required' });
+    }
+    try {
+      const result = propagateLineage(legacyUnit, speciesId, biomeId);
+      res.json(result);
+    } catch (err) {
+      res.status(500).json({ error: 'propagate_failed', message: err.message });
+    }
+  });
+
+  /**
+   * POST /inherit — body { newUnit, species_id, biome_id, lineage_id?, opts? }.
+   * Inherits 1-2 random mutations from pool to newborn (free grant).
+   * opts: { min, max } cap (defaults 1..2). RNG is server-side Math.random.
+   */
+  router.post('/inherit', (req, res) => {
+    const {
+      newUnit,
+      species_id: speciesId,
+      biome_id: biomeId,
+      lineage_id: lineageId = null,
+      opts = {},
+    } = req.body || {};
+    if (!newUnit || typeof newUnit !== 'object') {
+      return res.status(400).json({ error: 'newUnit (object) required' });
+    }
+    if (typeof speciesId !== 'string' || !speciesId) {
+      return res.status(400).json({ error: 'species_id (string) required' });
+    }
+    if (typeof biomeId !== 'string' || !biomeId) {
+      return res.status(400).json({ error: 'biome_id (string) required' });
+    }
+    try {
+      const result = inheritFromLineage(newUnit, speciesId, biomeId, lineageId, {
+        min: typeof opts.min === 'number' ? opts.min : undefined,
+        max: typeof opts.max === 'number' ? opts.max : undefined,
+      });
+      res.json(result);
+    } catch (err) {
+      res.status(500).json({ error: 'inherit_failed', message: err.message });
+    }
+  });
+
+  /**
+   * GET /pool/:species/:biome — read-only inspection.
+   * 200 sempre (pool vuoto → mutations: [], pool_size: 0).
+   */
+  router.get('/pool/:species/:biome', (req, res) => {
+    const { species, biome } = req.params;
+    if (!species || !biome) {
+      return res.status(400).json({ error: 'species and biome route params required' });
+    }
+    res.json(inspectPool(species, biome));
+  });
+
+  return router;
+}
+
+module.exports = { createLineageRouter };

--- a/apps/backend/services/generation/lineagePropagator.js
+++ b/apps/backend/services/generation/lineagePropagator.js
@@ -1,0 +1,212 @@
+// Sprint B Spore S5 (ADR-2026-04-26-spore-part-pack-slots) — generational
+// lineage propagation.
+//
+// When a unit enters `legacy` lifecycle phase, its `applied_mutations[]` are
+// written to a persistent (in-memory) pool keyed by `(species_id, biome_id)`.
+// New units born of the same species in the same biome can inherit 1-2
+// mutations from that pool **without paying MP cost** (free grant).
+//
+// This is the "plumbing" of S5. The lifecycle hook (who calls
+// propagateLineage when a unit dies / retires) is deferred to a follow-up
+// sprint — see PR description.
+//
+// Pool storage: in-memory Map. Persistence (Prisma write-through) deferred.
+// Cross-lineage isolation deferred: two different `lineage_id` in same
+// (species, biome) currently SHARE the pool.
+//
+// Cross-ref:
+// - data/core/species/dune_stalker_lifecycle.yaml `legacy.inheritable_traits`
+// - apps/backend/services/mutations/mutationEngine.js (Spore Moderate runtime)
+// - docs/research/2026-04-26-spore-deep-extraction.md §1.5 + §S5
+// - card museum mating_nido-engine-orphan.md (V3 mating engine 469 LOC live)
+
+'use strict';
+
+// Pool: Map<species_id, Map<biome_id, Set<mutation_id>>>
+// Set garantisce dedup naturale dei trait/mutation propagati.
+const _pool = new Map();
+
+// Inherit cap defaults — newborn riceve random N in [MIN, MAX].
+const DEFAULT_INHERIT_MIN = 1;
+const DEFAULT_INHERIT_MAX = 2;
+
+function _getOrCreateBiomeMap(speciesId) {
+  let biomeMap = _pool.get(speciesId);
+  if (!biomeMap) {
+    biomeMap = new Map();
+    _pool.set(speciesId, biomeMap);
+  }
+  return biomeMap;
+}
+
+function _getOrCreateMutationSet(speciesId, biomeId) {
+  const biomeMap = _getOrCreateBiomeMap(speciesId);
+  let mutSet = biomeMap.get(biomeId);
+  if (!mutSet) {
+    mutSet = new Set();
+    biomeMap.set(biomeId, mutSet);
+  }
+  return mutSet;
+}
+
+/**
+ * Propagate a legacy unit's applied_mutations to the lineage pool.
+ *
+ * @param {object} legacyUnit — unit object with `applied_mutations: string[]`
+ * @param {string} speciesId
+ * @param {string} biomeId
+ * @returns {{ written_traits: string[], pool_size: number, species_id: string, biome_id: string }}
+ */
+function propagateLineage(legacyUnit, speciesId, biomeId) {
+  if (!legacyUnit || typeof legacyUnit !== 'object') {
+    throw new TypeError('propagateLineage: legacyUnit must be an object');
+  }
+  if (typeof speciesId !== 'string' || !speciesId) {
+    throw new TypeError('propagateLineage: speciesId required');
+  }
+  if (typeof biomeId !== 'string' || !biomeId) {
+    throw new TypeError('propagateLineage: biomeId required');
+  }
+
+  const applied = Array.isArray(legacyUnit.applied_mutations) ? legacyUnit.applied_mutations : [];
+  const mutSet = _getOrCreateMutationSet(speciesId, biomeId);
+  const written = [];
+  for (const mid of applied) {
+    if (typeof mid === 'string' && mid && !mutSet.has(mid)) {
+      mutSet.add(mid);
+      written.push(mid);
+    }
+  }
+  return {
+    written_traits: written,
+    pool_size: mutSet.size,
+    species_id: speciesId,
+    biome_id: biomeId,
+  };
+}
+
+/**
+ * Inherit a random subset of mutations from the lineage pool to a newborn.
+ *
+ * Caller is responsible for persisting the returned `unit` (caller-side
+ * decides if applied_mutations + trait_ids should be written-through).
+ *
+ * @param {object} newUnit — newborn unit (must be plain object; we copy)
+ * @param {string} speciesId
+ * @param {string} biomeId
+ * @param {string|null} [lineageId] — currently informational only
+ *   (cross-lineage isolation deferred)
+ * @param {object} [opts]
+ * @param {number} [opts.min] — minimum inherited count (default 1)
+ * @param {number} [opts.max] — maximum inherited count (default 2)
+ * @param {() => number} [opts.rng] — RNG (default Math.random; caller can
+ *   inject seeded RNG for determinism)
+ * @returns {{
+ *   unit: object,
+ *   inherited: string[],
+ *   pool_consumed: false,
+ *   pool_size: number,
+ *   lineage_id: string|null,
+ * }}
+ */
+function inheritFromLineage(newUnit, speciesId, biomeId, lineageId = null, opts = {}) {
+  if (!newUnit || typeof newUnit !== 'object') {
+    throw new TypeError('inheritFromLineage: newUnit must be an object');
+  }
+  if (typeof speciesId !== 'string' || !speciesId) {
+    throw new TypeError('inheritFromLineage: speciesId required');
+  }
+  if (typeof biomeId !== 'string' || !biomeId) {
+    throw new TypeError('inheritFromLineage: biomeId required');
+  }
+  const min = Number.isInteger(opts.min) ? opts.min : DEFAULT_INHERIT_MIN;
+  const max = Number.isInteger(opts.max) ? opts.max : DEFAULT_INHERIT_MAX;
+  const rng = typeof opts.rng === 'function' ? opts.rng : Math.random;
+
+  const biomeMap = _pool.get(speciesId);
+  const mutSet = biomeMap ? biomeMap.get(biomeId) : null;
+  const poolArr = mutSet ? Array.from(mutSet) : [];
+
+  // Empty pool → no inheritance, return shallow copy.
+  if (poolArr.length === 0) {
+    return {
+      unit: { ...newUnit },
+      inherited: [],
+      pool_consumed: false,
+      pool_size: 0,
+      lineage_id: lineageId,
+    };
+  }
+
+  // Pick random N in [min, max] capped to pool size.
+  const target = Math.min(poolArr.length, Math.max(min, Math.floor(rng() * (max - min + 1)) + min));
+
+  // Fisher-Yates shuffle (in place on copy) using injected rng.
+  const shuffled = poolArr.slice();
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  const inherited = shuffled.slice(0, target);
+
+  // Free grant: append to applied_mutations + trait_ids (no MP charge).
+  // Dedup against existing.
+  const existingApplied = new Set(
+    Array.isArray(newUnit.applied_mutations) ? newUnit.applied_mutations : [],
+  );
+  const existingTraits = new Set(Array.isArray(newUnit.trait_ids) ? newUnit.trait_ids : []);
+  for (const mid of inherited) {
+    existingApplied.add(mid);
+    // S5 grants the mutation_id as a trait too (mirror Spore part-pack
+    // bingo so derived_ability eligibility tracks). Caller can post-process.
+    existingTraits.add(mid);
+  }
+
+  const unit = {
+    ...newUnit,
+    applied_mutations: Array.from(existingApplied),
+    trait_ids: Array.from(existingTraits),
+    lineage_id: lineageId ?? newUnit.lineage_id ?? null,
+  };
+
+  return {
+    unit,
+    inherited,
+    pool_consumed: false, // pool is additive, not consumed by inheritance
+    pool_size: poolArr.length,
+    lineage_id: lineageId,
+  };
+}
+
+/**
+ * Read-only inspection of the pool for a (species, biome) pair.
+ *
+ * @param {string} speciesId
+ * @param {string} biomeId
+ * @returns {{ species_id: string, biome_id: string, mutations: string[], pool_size: number }}
+ */
+function inspectPool(speciesId, biomeId) {
+  const biomeMap = _pool.get(speciesId);
+  const mutSet = biomeMap ? biomeMap.get(biomeId) : null;
+  const mutations = mutSet ? Array.from(mutSet) : [];
+  return {
+    species_id: speciesId,
+    biome_id: biomeId,
+    mutations,
+    pool_size: mutations.length,
+  };
+}
+
+/**
+ * Reset the entire pool. Test-only; not exposed via REST.
+ */
+function reset() {
+  _pool.clear();
+}
+
+module.exports = {
+  propagateLineage,
+  inheritFromLineage,
+  inspectPool,
+  reset,
+};

--- a/apps/backend/services/pluginLoader.js
+++ b/apps/backend/services/pluginLoader.js
@@ -116,6 +116,20 @@ const mutationsPlugin = {
   },
 };
 
+// Sprint B Spore S5 (ADR-2026-04-26-spore-part-pack-slots) — generational
+// lineage propagation. Pool indexato (species, biome) populated quando una
+// unit entra in `legacy` lifecycle phase; nuove unit ereditano 1-2 mutation
+// random senza pagare MP cost.
+const lineagePlugin = {
+  name: 'lineage',
+  register(app) {
+    const { createLineageRouter } = require('../routes/lineage');
+    const router = createLineageRouter();
+    app.use('/api/v1/lineage', router);
+    app.use('/api/lineage', router);
+  },
+};
+
 /**
  * Lista plugin built-in. Aggiungere nuovi plugin qui.
  * Ordine = ordine di registrazione.
@@ -128,6 +142,7 @@ const BUILTIN_PLUGINS = [
   formsPlugin,
   progressionPlugin,
   mutationsPlugin,
+  lineagePlugin,
 ];
 
 module.exports = {
@@ -140,4 +155,5 @@ module.exports = {
   formsPlugin,
   progressionPlugin,
   mutationsPlugin,
+  lineagePlugin,
 };

--- a/data/core/species/dune_stalker_lifecycle.yaml
+++ b/data/core/species/dune_stalker_lifecycle.yaml
@@ -265,6 +265,15 @@ phases:
       - "      ~|||~"
     tactical_signature: "Retired da combat live; appare come narrative event QBN."
     diary_milestone_event: form_evolved
+    # Sprint B Spore S5 (ADR-2026-04-26-spore-part-pack-slots):
+    # Pool delle mutation ereditabili dal lineage. Popolato runtime via
+    # `propagateLineage()` quando una unit entra in legacy phase: scrive le sue
+    # `applied_mutations[]` nel pool indexato per (species_id, biome_id).
+    # Una nuova unit dello stesso species nello stesso biome eredita 1-2
+    # mutation random via `inheritFromLineage()` SENZA pagare MP cost.
+    # Schema doc-only: il campo NON è letto staticamente — runtime usa
+    # in-memory Map registry (apps/backend/services/generation/lineagePropagator.js).
+    inheritable_traits: []
 
 # ─────────────────────────────────────────────────────────────────────
 # Mutation morphology — come ogni mutation cambia visivamente

--- a/tests/api/lineageRoutes.test.js
+++ b/tests/api/lineageRoutes.test.js
@@ -1,0 +1,202 @@
+// Sprint B Spore S5 — lineage REST routes contract tests.
+
+'use strict';
+
+const { test, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+const { reset } = require('../../apps/backend/services/generation/lineagePropagator');
+
+// Pool è module-level singleton; reset prima di ogni test per isolation.
+beforeEach(() => {
+  reset();
+});
+
+// --- propagate happy ----------------------------------------------------
+
+test('POST /api/v1/lineage/propagate writes legacy mutations to pool (200)', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app)
+      .post('/api/v1/lineage/propagate')
+      .send({
+        legacyUnit: { id: 'u-skiv', applied_mutations: ['mut_a', 'mut_b'] },
+        species_id: 'dune_stalker',
+        biome_id: 'savana',
+      })
+      .expect(200);
+    assert.equal(res.body.pool_size, 2);
+    assert.deepEqual(res.body.written_traits.sort(), ['mut_a', 'mut_b']);
+    assert.equal(res.body.species_id, 'dune_stalker');
+    assert.equal(res.body.biome_id, 'savana');
+  } finally {
+    await close();
+  }
+});
+
+// --- propagate bad path -------------------------------------------------
+
+test('POST /propagate missing legacyUnit → 400', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app)
+      .post('/api/v1/lineage/propagate')
+      .send({ species_id: 'x', biome_id: 'y' })
+      .expect(400);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /propagate missing species_id → 400', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app)
+      .post('/api/v1/lineage/propagate')
+      .send({ legacyUnit: { id: 'u' }, biome_id: 'y' })
+      .expect(400);
+  } finally {
+    await close();
+  }
+});
+
+// --- inherit happy ------------------------------------------------------
+
+test('POST /api/v1/lineage/inherit grants random mutation from pool (200)', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    // Seed pool first.
+    await request(app)
+      .post('/api/v1/lineage/propagate')
+      .send({
+        legacyUnit: { id: 'src', applied_mutations: ['mut_x', 'mut_y', 'mut_z'] },
+        species_id: 'dune_stalker',
+        biome_id: 'savana',
+      })
+      .expect(200);
+
+    const res = await request(app)
+      .post('/api/v1/lineage/inherit')
+      .send({
+        newUnit: { id: 'newborn', applied_mutations: [], trait_ids: [] },
+        species_id: 'dune_stalker',
+        biome_id: 'savana',
+        lineage_id: 'lineage-pup',
+      })
+      .expect(200);
+    assert.ok(res.body.inherited.length >= 1 && res.body.inherited.length <= 2);
+    assert.equal(res.body.pool_consumed, false);
+    assert.equal(res.body.pool_size, 3);
+    assert.equal(res.body.lineage_id, 'lineage-pup');
+    // Each inherited mut is in unit.applied_mutations + trait_ids.
+    for (const mid of res.body.inherited) {
+      assert.ok(res.body.unit.applied_mutations.includes(mid));
+      assert.ok(res.body.unit.trait_ids.includes(mid));
+    }
+  } finally {
+    await close();
+  }
+});
+
+test('POST /inherit empty pool → inherited [] (200)', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app)
+      .post('/api/v1/lineage/inherit')
+      .send({
+        newUnit: { id: 'newborn', applied_mutations: [], trait_ids: ['innate'] },
+        species_id: 'dune_stalker',
+        biome_id: 'tundra',
+      })
+      .expect(200);
+    assert.deepEqual(res.body.inherited, []);
+    assert.equal(res.body.pool_size, 0);
+    assert.deepEqual(res.body.unit.trait_ids, ['innate']);
+  } finally {
+    await close();
+  }
+});
+
+// --- inherit bad path ---------------------------------------------------
+
+test('POST /inherit missing newUnit → 400', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app)
+      .post('/api/v1/lineage/inherit')
+      .send({ species_id: 'x', biome_id: 'y' })
+      .expect(400);
+  } finally {
+    await close();
+  }
+});
+
+// --- pool inspection ----------------------------------------------------
+
+test('GET /api/v1/lineage/pool/:species/:biome read-only (200)', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    // Empty pool → 200 con array vuoto.
+    const empty = await request(app).get('/api/v1/lineage/pool/dune_stalker/savana').expect(200);
+    assert.equal(empty.body.pool_size, 0);
+    assert.deepEqual(empty.body.mutations, []);
+
+    // Populate.
+    await request(app)
+      .post('/api/v1/lineage/propagate')
+      .send({
+        legacyUnit: { id: 'u', applied_mutations: ['m1', 'm2'] },
+        species_id: 'dune_stalker',
+        biome_id: 'savana',
+      })
+      .expect(200);
+
+    const pop = await request(app).get('/api/v1/lineage/pool/dune_stalker/savana').expect(200);
+    assert.equal(pop.body.pool_size, 2);
+    assert.deepEqual(pop.body.mutations.sort(), ['m1', 'm2']);
+  } finally {
+    await close();
+  }
+});
+
+test('GET /pool cross-biome isolation (savana pool ≠ deserto pool)', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app)
+      .post('/api/v1/lineage/propagate')
+      .send({
+        legacyUnit: { id: 'u', applied_mutations: ['savana_only'] },
+        species_id: 'dune_stalker',
+        biome_id: 'savana',
+      })
+      .expect(200);
+
+    const deserto = await request(app).get('/api/v1/lineage/pool/dune_stalker/deserto').expect(200);
+    assert.equal(deserto.body.pool_size, 0);
+
+    const savana = await request(app).get('/api/v1/lineage/pool/dune_stalker/savana').expect(200);
+    assert.equal(savana.body.pool_size, 1);
+  } finally {
+    await close();
+  }
+});
+
+// --- alias mount --------------------------------------------------------
+
+test('Alias mount /api/lineage/* parity with /api/v1/lineage/*', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app)
+      .post('/api/lineage/propagate')
+      .send({
+        legacyUnit: { id: 'u', applied_mutations: ['alias_mut'] },
+        species_id: 'dune_stalker',
+        biome_id: 'savana',
+      })
+      .expect(200);
+    assert.equal(res.body.pool_size, 1);
+  } finally {
+    await close();
+  }
+});

--- a/tests/services/lineagePropagator.test.js
+++ b/tests/services/lineagePropagator.test.js
@@ -1,0 +1,187 @@
+// Sprint B Spore S5 — lineagePropagator unit tests.
+
+'use strict';
+
+const { test, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  propagateLineage,
+  inheritFromLineage,
+  inspectPool,
+  reset,
+} = require('../../apps/backend/services/generation/lineagePropagator');
+
+beforeEach(() => {
+  reset();
+});
+
+// --- propagate -----------------------------------------------------------
+
+test('propagateLineage: legacy unit with 3 mutations → pool size 3', () => {
+  const legacy = {
+    id: 'u-skiv-001',
+    applied_mutations: [
+      'artigli_freeze_to_glacier',
+      'denti_bleed_to_chelate',
+      'mantello_camouflage',
+    ],
+  };
+  const result = propagateLineage(legacy, 'dune_stalker', 'savana');
+  assert.equal(result.pool_size, 3);
+  assert.deepEqual(result.written_traits.sort(), [
+    'artigli_freeze_to_glacier',
+    'denti_bleed_to_chelate',
+    'mantello_camouflage',
+  ]);
+  assert.equal(result.species_id, 'dune_stalker');
+  assert.equal(result.biome_id, 'savana');
+});
+
+test('propagateLineage: dedup across multiple legacy units', () => {
+  propagateLineage({ id: 'u1', applied_mutations: ['mut_a', 'mut_b'] }, 'dune_stalker', 'savana');
+  const r2 = propagateLineage(
+    { id: 'u2', applied_mutations: ['mut_b', 'mut_c'] },
+    'dune_stalker',
+    'savana',
+  );
+  // mut_b already in pool → only mut_c written this call.
+  assert.deepEqual(r2.written_traits, ['mut_c']);
+  assert.equal(r2.pool_size, 3);
+});
+
+test('propagateLineage: empty applied_mutations → no-op, pool_size 0', () => {
+  const result = propagateLineage({ id: 'u', applied_mutations: [] }, 'dune_stalker', 'savana');
+  assert.equal(result.pool_size, 0);
+  assert.deepEqual(result.written_traits, []);
+});
+
+test('propagateLineage: missing applied_mutations field → graceful no-op', () => {
+  const result = propagateLineage({ id: 'u' }, 'dune_stalker', 'savana');
+  assert.equal(result.pool_size, 0);
+  assert.deepEqual(result.written_traits, []);
+});
+
+test('propagateLineage: invalid input throws', () => {
+  assert.throws(() => propagateLineage(null, 'dune_stalker', 'savana'), TypeError);
+  assert.throws(() => propagateLineage({}, '', 'savana'), TypeError);
+  assert.throws(() => propagateLineage({}, 'dune_stalker', ''), TypeError);
+});
+
+// --- inherit -------------------------------------------------------------
+
+test('inheritFromLineage: pool with 5 mutations → newborn riceve 1-2 random', () => {
+  propagateLineage(
+    { id: 'src', applied_mutations: ['m1', 'm2', 'm3', 'm4', 'm5'] },
+    'dune_stalker',
+    'savana',
+  );
+  // Deterministic RNG: always returns 0.5 → middle picks.
+  const rng = () => 0.5;
+  const result = inheritFromLineage(
+    { id: 'newborn', applied_mutations: [], trait_ids: [] },
+    'dune_stalker',
+    'savana',
+    'lineage-skiv',
+    { rng },
+  );
+  assert.ok(result.inherited.length >= 1 && result.inherited.length <= 2);
+  // Inherited mutations should appear in unit.applied_mutations + trait_ids (free grant).
+  for (const mid of result.inherited) {
+    assert.ok(result.unit.applied_mutations.includes(mid));
+    assert.ok(result.unit.trait_ids.includes(mid));
+  }
+  assert.equal(result.pool_consumed, false);
+  assert.equal(result.pool_size, 5);
+  assert.equal(result.lineage_id, 'lineage-skiv');
+});
+
+test('inheritFromLineage: pool vuoto → newborn riceve [] (graceful)', () => {
+  const result = inheritFromLineage(
+    { id: 'newborn', applied_mutations: [], trait_ids: ['base_trait'] },
+    'dune_stalker',
+    'tundra',
+  );
+  assert.deepEqual(result.inherited, []);
+  assert.equal(result.pool_size, 0);
+  // Unit preserved (no mutation added).
+  assert.deepEqual(result.unit.trait_ids, ['base_trait']);
+});
+
+test('inheritFromLineage: cross-biome isolation — savana pool NON ereditata in deserto', () => {
+  propagateLineage(
+    { id: 'src', applied_mutations: ['savana_mut_1', 'savana_mut_2'] },
+    'dune_stalker',
+    'savana',
+  );
+  const result = inheritFromLineage(
+    { id: 'newborn-deserto', applied_mutations: [], trait_ids: [] },
+    'dune_stalker',
+    'deserto',
+  );
+  assert.deepEqual(result.inherited, []);
+  assert.equal(result.pool_size, 0);
+});
+
+test('inheritFromLineage: same-species cross-lineage — pool condiviso (per ora)', () => {
+  // Lineage A propaga
+  propagateLineage({ id: 'src-a', applied_mutations: ['mut_lineage_a'] }, 'dune_stalker', 'savana');
+  // Lineage B propaga nello stesso (species, biome)
+  propagateLineage({ id: 'src-b', applied_mutations: ['mut_lineage_b'] }, 'dune_stalker', 'savana');
+  // Newborn lineage C eredita da pool condiviso → può ricevere o A o B.
+  const result = inheritFromLineage(
+    { id: 'newborn-c', applied_mutations: [], trait_ids: [] },
+    'dune_stalker',
+    'savana',
+    'lineage-c',
+    { min: 2, max: 2 }, // forza 2 per testare entrambi
+  );
+  assert.equal(result.inherited.length, 2);
+  assert.deepEqual(result.inherited.sort(), ['mut_lineage_a', 'mut_lineage_b']);
+});
+
+test('inheritFromLineage: rispetta cap min/max e non eccede pool size', () => {
+  propagateLineage({ id: 'src', applied_mutations: ['only_one'] }, 'dune_stalker', 'savana');
+  // Anche se max=5, pool ha 1 → eredita 1.
+  const result = inheritFromLineage(
+    { id: 'newborn', applied_mutations: [], trait_ids: [] },
+    'dune_stalker',
+    'savana',
+    null,
+    { min: 1, max: 5 },
+  );
+  assert.equal(result.inherited.length, 1);
+  assert.equal(result.inherited[0], 'only_one');
+});
+
+test('inheritFromLineage: newborn con applied_mutations preesistenti → dedup', () => {
+  propagateLineage(
+    { id: 'src', applied_mutations: ['shared_mut', 'unique_mut'] },
+    'dune_stalker',
+    'savana',
+  );
+  const result = inheritFromLineage(
+    { id: 'newborn', applied_mutations: ['shared_mut'], trait_ids: ['shared_mut', 'innate'] },
+    'dune_stalker',
+    'savana',
+    null,
+    { min: 2, max: 2 },
+  );
+  // shared_mut già presente → applied_mutations resta dedup.
+  const sharedCount = result.unit.applied_mutations.filter((m) => m === 'shared_mut').length;
+  assert.equal(sharedCount, 1);
+  assert.ok(result.unit.trait_ids.includes('innate'));
+});
+
+// --- inspectPool ---------------------------------------------------------
+
+test('inspectPool: read-only inspection di pool popolato vs vuoto', () => {
+  const empty = inspectPool('dune_stalker', 'savana');
+  assert.equal(empty.pool_size, 0);
+  assert.deepEqual(empty.mutations, []);
+
+  propagateLineage({ id: 'u', applied_mutations: ['m1', 'm2'] }, 'dune_stalker', 'savana');
+  const populated = inspectPool('dune_stalker', 'savana');
+  assert.equal(populated.pool_size, 2);
+  assert.deepEqual(populated.mutations.sort(), ['m1', 'm2']);
+});


### PR DESCRIPTION
## Summary

Sprint B Spore Pattern S5 (generational inheritance) per [ADR-2026-04-26-spore-part-pack-slots](docs/adr/ADR-2026-04-26-spore-part-pack-slots.md). Chiude il loop **Pilastro 2 trans-generazionale**: una unit che entra in `legacy` lifecycle phase puo lasciare in eredita le sue `applied_mutations[]` a futuri membri della stessa species nello stesso biome, **senza pagare MP cost** (free grant).

Decoupled da V3 mating engine (Path A 4/4) — pool sharing via `(species_id, biome_id)` key, lineage_id informational only (cross-lineage isolation deferred).

## Files

- **NEW** `apps/backend/services/generation/lineagePropagator.js` (~210 LOC) — pure module: `propagateLineage()`, `inheritFromLineage()` (Fisher-Yates shuffle + injectable RNG per determinismo test), `inspectPool()`, `reset()` (test-only)
- **NEW** `apps/backend/routes/lineage.js` (~95 LOC) — 3 endpoint REST: `POST /propagate`, `POST /inherit`, `GET /pool/:species/:biome`
- **MOD** `apps/backend/services/pluginLoader.js` — registra `lineagePlugin` mount `/api/v1/lineage` + alias `/api/lineage`
- **MOD** `data/core/species/dune_stalker_lifecycle.yaml` — campo opzionale `legacy.inheritable_traits: []` (doc-only, runtime usa in-memory Map)
- **NEW** `tests/services/lineagePropagator.test.js` — 12 unit test (propagate dedup, cross-biome isolation, RNG injection, cap min/max, dedup applied_mutations, edge case input invalid)
- **NEW** `tests/api/lineageRoutes.test.js` — 9 contract test (happy + 400 + cross-biome + alias mount parity)

## Test results

- 12/12 service tests pass
- 9/9 REST tests pass
- 311/311 AI baseline verde (zero regression)
- Plugin loader log: `8 plugins loaded: ..., lineage`
- Prettier check verde (5 file)

## Pool semantics

- **Storage**: in-memory `Map<species_id, Map<biome_id, Set<mutation_id>>>` — Set garantisce dedup
- **Cross-biome**: pool savana NON ereditata in deserto (verified test)
- **Cross-lineage same-(species, biome)**: pool condiviso (per ora — cross-lineage isolation deferred)
- **Free grant**: inherited mutations appended a `applied_mutations[]` + `trait_ids[]` (mirror Spore part-pack bingo per derived_ability eligibility)

## Deferred items espliciti (NON in questo PR)

1. **Lifecycle hook**: chi chiama `propagateLineage()` quando una unit entra in `legacy` phase post-mortem. Questo PR e "the plumbing", non "the trigger". Hook candidate: `campaign.js /advance` survivor-loop, oppure `sessionRoundBridge` su KO + lifecycle promotion.
2. **Cross-lineage isolation**: due `lineage_id` diversi in same (species, biome) attualmente condividono pool. Future: keyed `(species, biome, lineage_id)` con genealogy graph.
3. **Prisma write-through**: pool e in-memory only. Pattern formSessionStore (M12.D) candidato per persistence.
4. **Surface UI**: nessun render frontend (Gate 5 "Engine wired" deferred a sprint successivo). Endpoint REST e debug-friendly via curl / dev-console.
5. **Seeded RNG end-to-end**: REST `/inherit` usa Math.random server-side. Test usano injected rng. Determinismo full E2E richiede campaign-scoped seed.

## Rollback plan

Rimuovere `lineagePlugin` da `BUILTIN_PLUGINS` in `pluginLoader.js`; cancellare i 4 file nuovi. Schema YAML `inheritable_traits` campo additivo, non breaking. Zero ripple su altri service.

## Test plan

- [ ] `node --test tests/services/lineagePropagator.test.js` 12/12 verde
- [ ] `node --test tests/api/lineageRoutes.test.js` 9/9 verde
- [ ] `node --test tests/ai/*.test.js` 311/311 verde (regression)
- [ ] `npm run format:check` verde (5 file)
- [ ] Smoke probe: `curl POST /api/v1/lineage/propagate` e seguente `GET /api/v1/lineage/pool/:species/:biome` ritorna pool popolato

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>