### PR TITLE
feat(deploy): Sprint C backbone Min bundle — Render + CF Pages config + ops script

### DIFF
--- a/apps/play/runtime-config.production.js
+++ b/apps/play/runtime-config.production.js
@@ -1,0 +1,19 @@
+// Runtime config — PRODUCTION TEMPLATE.
+// Sprint C bundle Min (docs/research/2026-04-27-backbone-online-deploy-roadmap.md).
+//
+// Sostituire __RENDER_BACKEND_HOST__ con hostname pubblico Render
+// (es. evo-tactics-backend.onrender.com) prima di copiare in apps/play/dist/
+// durante il deploy. scripts/deploy-min.sh esegue il sed automaticamente
+// se RENDER_BACKEND_HOST è esportato in env.
+//
+// Quando deployato:
+//   - Frontend served from CF Pages (https://evo-tactics-play.pages.dev)
+//   - Backend + WS served from Render (https://__RENDER_BACKEND_HOST__)
+//   - WS path: wss://__RENDER_BACKEND_HOST__/ws (LOBBY_WS_SHARED=true side)
+//
+// LOBBY_WS_SAME_ORIGIN = false in cross-origin setup CF Pages → Render.
+// Cliente legge LOBBY_WS_URL esplicito invece di derivare da window.location.
+
+window.LOBBY_WS_URL = 'wss://__RENDER_BACKEND_HOST__/ws';
+window.LOBBY_API_BASE = 'https://__RENDER_BACKEND_HOST__';
+window.LOBBY_WS_SAME_ORIGIN = false;

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -4079,6 +4079,19 @@
       "track": "migrated"
     },
     {
+      "path": "docs/ops/deploy-min-checklist.md",
+      "title": "Deploy Min — checklist operativa Sprint C backbone bundle",
+      "doc_status": "draft",
+      "doc_owner": "master-dd",
+      "workstream": "ops-qa",
+      "last_verified": "2026-04-27",
+      "source_of_truth": false,
+      "language": "it",
+      "review_cycle_days": 30,
+      "primary": false,
+      "track": "migrated"
+    },
+    {
       "path": "docs/ops/drive-sync.md",
       "title": "Sincronizzazione YAML ↔ Google Sheets",
       "doc_status": "draft",

--- a/docs/ops/deploy-min-checklist.md
+++ b/docs/ops/deploy-min-checklist.md
@@ -1,0 +1,308 @@
+---
+title: Deploy Min — checklist operativa Sprint C backbone bundle
+doc_status: draft
+doc_owner: master-dd
+workstream: ops-qa
+last_verified: 2026-04-27
+source_of_truth: false
+language: it
+review_cycle_days: 30
+related:
+  - docs/research/2026-04-27-backbone-online-deploy-roadmap.md
+  - docs/adr/ADR-2026-04-26-hosting-stack-decision.md
+  - docs/playtest/2026-04-26-deploy-render-cf-pages.md
+---
+
+# Deploy Min — checklist operativa Sprint C backbone bundle
+
+> **Stato bundle**: BUNDLE READY — eseguire `bash scripts/deploy-min.sh` con credenziali utente per attivare. Questo PR NON deploya nulla.
+
+Roadmap reference: [`docs/research/2026-04-27-backbone-online-deploy-roadmap.md`](../research/2026-04-27-backbone-online-deploy-roadmap.md) — Opzione B "Min ora".
+
+Stack target:
+
+- **Backend**: Render free web service (Frankfurt, Node 22.19.0)
+- **Frontend**: Cloudflare Pages free (`apps/play/dist`)
+- **Persistence**: in-memory (`LOBBY_PRISMA_ENABLED=false`)
+- **WS**: shared mode (`LOBBY_WS_SHARED=true`, no second public port)
+- **Costo**: $0 (free tier entrambi)
+
+---
+
+## §1 Pre-deploy (one-time setup, ~2h)
+
+### Account + credenziali
+
+- [ ] Account Render free creato (https://render.com → Sign up + GitHub OAuth)
+- [ ] Account Cloudflare creato (https://cloudflare.com → Sign up)
+- [ ] CF Pages project initial scaffolded (`evo-tactics-play`)
+- [ ] Render API key generato → Account Settings → API Keys → Create
+- [ ] Render service ID noto (URL service: `https://dashboard.render.com/web/srv-XXXXXXXXX`)
+- [ ] CF API token generato (Account → API Tokens → "Edit Cloudflare Pages" template) **OPPURE** `wrangler login` OAuth flow eseguito una volta
+- [ ] Tool installati: `gh`, `wrangler`, `curl`, `node 22+`, `npm`
+
+### Secret in canonical path
+
+CRITICO: NESSUN secret in repo `.env*`. Tutti in `~/.config/api-keys/keys.env`.
+
+```bash
+mkdir -p ~/.config/api-keys
+cat >> ~/.config/api-keys/keys.env <<'EOF'
+export RENDER_API_KEY=rnd_xxxxxxxxxxxxxxxxxxxxxxxxxx
+export RENDER_SERVICE_ID=srv-xxxxxxxxxxxxxxxxxxxx
+export RENDER_BACKEND_HOST=evo-tactics-backend.onrender.com
+export CLOUDFLARE_API_TOKEN=cf_xxxxxxxxxxxxxxxxxxxxxxxx
+EOF
+chmod 600 ~/.config/api-keys/keys.env
+```
+
+- [ ] `~/.config/api-keys/keys.env` esiste, perms 600
+- [ ] `RENDER_API_KEY` valid (probe: `curl -H "Authorization: Bearer $RENDER_API_KEY" https://api.render.com/v1/services` ritorna JSON)
+- [ ] `RENDER_BACKEND_HOST` matched al service Render (es. `evo-tactics-backend.onrender.com`)
+
+### Render dashboard env vars (popolati manualmente UNA VOLTA)
+
+`render.yaml` dichiara solo env var SAFE. Secret + override CORS → dashboard service → Environment.
+
+Lista **richiesta** (block deploy se mancante):
+
+| Var           | Valore                               | Note                                           |
+| ------------- | ------------------------------------ | ---------------------------------------------- |
+| `CORS_ORIGIN` | `https://evo-tactics-play.pages.dev` | Override `*` default. Whitelist single origin. |
+
+Lista **opzionale** (default OK per Min):
+
+| Var                                  | Default | Override scenario                                           |
+| ------------------------------------ | ------- | ----------------------------------------------------------- |
+| `AUTH_SECRET`                        | (none)  | Solo Mod scenario quando JWT enable                         |
+| `DATABASE_URL`                       | (none)  | Solo Mod (Postgres Neon free → `LOBBY_PRISMA_ENABLED=true`) |
+| `MUTATION_MP_ENFORCE`                | `true`  | `false` per disabilitare MP gating mutations                |
+| `MP_POOL_MAX`                        | `30`    | Pool max global MP                                          |
+| `IDEA_ENGINE_DISABLE_STATUS_REFRESH` | `1`     | Già impostato in render.yaml                                |
+| `MBTI_REVEAL_THRESHOLD`              | (none)  | Threshold soft-reveal MBTI surface                          |
+| `VC_AXES_ITER`                       | (none)  | Calibration iter mode 1/2                                   |
+| `SKIV_WEBHOOK_SECRET`                | (none)  | Solo se webhook Skiv attivo                                 |
+
+Audit completo env vars: vedi §6 sotto.
+
+- [ ] `CORS_ORIGIN` settato in Render dashboard a CF Pages URL effettivo
+
+---
+
+## §2 Deploy (singolo comando, ~5-8min build + deploy)
+
+```bash
+bash scripts/deploy-min.sh
+```
+
+Lo script esegue:
+
+1. Preflight (gh auth, wrangler, RENDER_API_KEY, anti-pattern guards)
+2. `npm --prefix apps/play install && run build`
+3. Inietta `runtime-config.production.js` → `apps/play/dist/runtime-config.js` con `RENDER_BACKEND_HOST` sostituito
+4. `wrangler pages deploy apps/play/dist --project-name=evo-tactics-play`
+5. `curl POST https://api.render.com/v1/services/$RENDER_SERVICE_ID/deploys` (stamp redeploy)
+6. Smoke probe `/api/health` con 30s retry (15 attempt × 2s)
+7. Print URL pubblici finali
+
+**Dry-run** (skip steps 3-6, solo build + preflight):
+
+```bash
+DRY_RUN=1 bash scripts/deploy-min.sh
+```
+
+- [ ] Script eseguito senza FAIL
+- [ ] CF Pages deploy mostra URL `https://<deployment-hash>.evo-tactics-play.pages.dev`
+- [ ] Render API ritorna `{"id": "dep-..."}` (deploy stamped)
+- [ ] Health probe ritorna 200 entro 30s
+
+---
+
+## §3 Post-deploy verifica (~10-15min smoke)
+
+### Backend smoke
+
+- [ ] `curl https://$RENDER_BACKEND_HOST/api/health` → `200 {"status":"ok",...}`
+- [ ] `curl -X POST https://$RENDER_BACKEND_HOST/api/lobby/create` → `200 {"code":"XXXX","host_token":"..."}` (4-letter code consonanti)
+- [ ] `curl https://$RENDER_BACKEND_HOST/api/lobby/state?code=XXXX` → snapshot room
+
+### WebSocket smoke
+
+```bash
+# install wscat: npm i -g wscat
+wscat -c "wss://$RENDER_BACKEND_HOST/ws?code=XXXX&token=$HOST_TOKEN&role=host"
+# expect: { "type": "hello", ... }
+```
+
+- [ ] WS handshake OK, riceve `hello` event
+- [ ] Heartbeat ping/pong ogni 30s
+
+### Frontend smoke (browser)
+
+- [ ] Apri `https://evo-tactics-play.pages.dev/lobby.html` → vedi UI lobby picker
+- [ ] Inserire code 4-letter → connect → entrare in lobby
+- [ ] DevTools console: zero error, WS connect aperto a `wss://$RENDER_BACKEND_HOST/ws`
+- [ ] Tab 2 incognito → join stesso code → vedere player conta a 2
+
+### Smoke playtest 2-player remoto
+
+- [ ] Share URL CF Pages a 1 amico via Discord/Telegram
+- [ ] Amico apre lobby.html → join code → lobby ha 2 player
+- [ ] Inizia round → action → host vede world update → amico vede update
+- [ ] 5 round completi senza disconnect
+
+---
+
+## §4 Rollback (se deploy rotto)
+
+### Frontend rollback (CF Pages)
+
+```bash
+wrangler pages deployment list --project-name=evo-tactics-play
+# copia ID deployment precedente working
+wrangler pages deployment activate <DEPLOYMENT_ID> --project-name=evo-tactics-play
+```
+
+- [ ] Rollback CF Pages eseguito → URL serve versione previous
+- [ ] Smoke `lobby.html` post-rollback OK
+
+### Backend rollback (Render)
+
+Via dashboard:
+
+1. https://dashboard.render.com/web/srv-XXX → Events tab
+2. Click "Rollback to this deploy" sul deploy precedente
+3. Conferma
+
+Via API (alternativa):
+
+```bash
+PREV_DEPLOY_ID="dep-xxxxxxxxxxxx"  # da Events tab dashboard
+curl -X POST "https://api.render.com/v1/services/$RENDER_SERVICE_ID/deploys/$PREV_DEPLOY_ID/rollback" \
+  -H "Authorization: Bearer $RENDER_API_KEY"
+```
+
+- [ ] Rollback Render eseguito
+- [ ] `/api/health` 200 post-rollback
+
+### Path back ngrok (full revert)
+
+Se entrambi cloud rotti, fallback locale:
+
+```bash
+node scripts/run-demo-tunnel.cjs
+```
+
+- [ ] ngrok URL up
+- [ ] Notifica playtester URL temporaneo
+
+---
+
+## §5 Anti-pattern guards (block list)
+
+Dal roadmap §7 — applicati durante deploy script + dashboard config.
+
+| Guard                                            | Dove enforced                           | Outcome se violato                          |
+| ------------------------------------------------ | --------------------------------------- | ------------------------------------------- |
+| Secret in repo `.env*`                           | `scripts/deploy-min.sh` warn            | Spostare a `~/.config/api-keys/keys.env`    |
+| `RENDER_API_KEY` hardcoded                       | `scripts/deploy-min.sh` FAIL block      | Rimuovere prima di runare                   |
+| `autoDeploy: true` in `render.yaml`              | `render.yaml` set `false` esplicito     | Push accidentale main = downtime cold start |
+| `CORS_ORIGIN: '*'` in production                 | `render.yaml` `sync: false` placeholder | Popolare via dashboard a CF Pages URL       |
+| `LOBBY_PRISMA_ENABLED=true` senza `DATABASE_URL` | `render.yaml` `false` default           | App crash al boot                           |
+| `LOBBY_WS_PORT=3341` come second port pubblico   | `render.yaml` `LOBBY_WS_SHARED=true`    | Render free supporta 1 port solo            |
+
+---
+
+## §6 Audit env vars effettivi backend
+
+Da grep `apps/backend/`. Default + ruolo per scenario Min.
+
+### Required (block boot se mancanti O wrong)
+
+Nessuno. Backend boot OK con defaults (in-memory, no auth, no Game-Database).
+
+### Settati da render.yaml (scenario Min)
+
+| Var                                  | Valore       | Ruolo                                       |
+| ------------------------------------ | ------------ | ------------------------------------------- |
+| `NODE_VERSION`                       | `22.19.0`    | Render runtime                              |
+| `NODE_ENV`                           | `production` | Express prod mode                           |
+| `PORT`                               | (auto)       | Render injects, default `3334`              |
+| `HOST`                               | (default)    | `0.0.0.0`                                   |
+| `LOBBY_WS_ENABLED`                   | `true`       | Abilita WS server                           |
+| `LOBBY_WS_SHARED`                    | `true`       | WS attach a HTTP server stesso PORT         |
+| `LOBBY_WS_PORT`                      | (ignore)     | `3341` default — irrilevante in shared mode |
+| `LOBBY_WS_HOST`                      | (default)    | Eredita HOST                                |
+| `LOBBY_PRISMA_ENABLED`               | `false`      | In-memory only (Min)                        |
+| `GAME_DATABASE_ENABLED`              | `false`      | No HTTP integration sibling repo (Min)      |
+| `IDEA_ENGINE_DISABLE_STATUS_REFRESH` | `1`          | Disable background status refresh           |
+
+### Da popolare in dashboard (override render.yaml)
+
+| Var           | Default              | Min override                                     |
+| ------------- | -------------------- | ------------------------------------------------ |
+| `CORS_ORIGIN` | `*` (codice default) | `https://evo-tactics-play.pages.dev` (whitelist) |
+
+### Opzionali (default OK in Min)
+
+| Var                                     | Default                        | Note                                      |
+| --------------------------------------- | ------------------------------ | ----------------------------------------- |
+| `DATABASE_URL`                          | (none)                         | Solo se `LOBBY_PRISMA_ENABLED=true` (Mod) |
+| `AUTH_SECRET`                           | (none)                         | JWT off se assente (Min OK)               |
+| `AUTH_AUDIENCE` `AUTH_ISSUER`           | (none)                         | JWT validation                            |
+| `AUTH_ROLES_CLAIM`                      | `roles`                        | Claim path                                |
+| `AUTH_USERID_CLAIM`                     | (none)                         | Custom                                    |
+| `AUTH_CLOCK_TOLERANCE`                  | `0`                            | Sec                                       |
+| `AUTH_TOKEN_MAX_AGE` `AUTH_MAX_AGE`     | (none)                         | Token TTL                                 |
+| `AUTH_DEFAULT_ROLES`                    | (none)                         | Fallback roles                            |
+| `TRAIT_EDITOR_TOKEN` `TRAITS_API_TOKEN` | (none)                         | Legacy bearer                             |
+| `GAME_DATABASE_URL`                     | `http://localhost:3333`        | Solo se `GAME_DATABASE_ENABLED=true`      |
+| `GAME_DATABASE_TIMEOUT_MS`              | (parsed)                       | HTTP timeout                              |
+| `GAME_DATABASE_TTL_MS`                  | (parsed)                       | Cache TTL                                 |
+| `MUTATION_MP_ENFORCE`                   | `true`                         | MP enforcement                            |
+| `MP_POOL_MAX`                           | `30`                           | Pool max                                  |
+| `MBTI_REVEAL_THRESHOLD`                 | (none)                         | Soft-reveal threshold                     |
+| `VC_AXES_ITER`                          | (none)                         | Calibration mode `1` o `2`                |
+| `CATALOG_INVALIDATE_TOKEN`              | (empty)                        | Catalog cache invalidate auth             |
+| `PLAY_DIST_PATH`                        | (auto)                         | Override dist path                        |
+| `IDEA_ENGINE_DB`                        | `data/idea_engine.db`          | NeDB path                                 |
+| `PRISMA_LOG_QUERIES`                    | (none)                         | Verbose Prisma                            |
+| `ORCHESTRATOR_AUTOCLOSE_MS`             | (none)                         | Test only                                 |
+| `ORCHESTRATOR_METRICS_DISABLED`         | (none)                         | Disable metrics                           |
+| `PYTHON`                                | `python3`                      | Python orchestrator path                  |
+| `EVO_TACTICS_API_BASE`                  | `https://api.evo-tactics.dev/` | External API                              |
+| `GAME_SPECIES_RESISTANCES_PATH`         | (auto)                         | Override resistances YAML                 |
+| `NIDO_UNLOCKED`                         | `false`                        | Feature flag mating                       |
+| `AUDIT_LOG_PATH`                        | (none)                         | Audit log destination                     |
+| `SKIV_WEBHOOK_SECRET`                   | (none)                         | Skiv webhook auth                         |
+
+Tot: ~36 env var distinct. **Per Min basta `CORS_ORIGIN` override.** Tutto il resto default OK.
+
+---
+
+## §7 Limiti scenario Min noti
+
+- Cold start 30-60s primo request post 15min idle (mitigation: `curl warmup` 5min prima invito)
+- State perso a Render restart (M11 in-memory only — accettabile per playtest 1 sessione)
+- No rate limit → URL Discord pubblico = potenziale abuso (mitigation: invite-only canale privato)
+- No log aggregation → bug invisibile post-mortem (Render logs solo dashboard tail)
+- No custom domain (`*.onrender.com` lungo da condividere)
+
+Upgrade path: scenario Mod (~7-10h aggiuntive) — vedi roadmap §3.
+
+---
+
+## §8 Bundle file map
+
+File aggiunti/modificati Sprint C:
+
+| File                                      | Tipo   | Note                                                        |
+| ----------------------------------------- | ------ | ----------------------------------------------------------- |
+| `render.yaml`                             | modify | `autoDeploy: false`, CORS placeholder, prisma generate      |
+| `wrangler.toml`                           | modify | `[env.pages]` section + comment chiarisce routing           |
+| `apps/play/runtime-config.production.js`  | new    | Template runtime config (sed `RENDER_BACKEND_HOST`)         |
+| `scripts/deploy-min.sh`                   | new    | One-command orchestrator preflight + build + deploy + smoke |
+| `docs/ops/deploy-min-checklist.md`        | new    | Questo documento                                            |
+| `tests/scripts/deploy-min-bundle.test.js` | new    | Sintassi + frontmatter + YAML/TOML valid                    |
+
+Zero behavior change `apps/backend/`. Zero schema change.

--- a/render.yaml
+++ b/render.yaml
@@ -1,11 +1,13 @@
-# Render Blueprint — Evo-Tactics backend (M11 co-op WS)
+# Render Blueprint — Evo-Tactics backend (M11 co-op WS) — Sprint C bundle Min
 # ADR-2026-04-26 — hosting stack decision (free web service, WS keepalive).
+# Roadmap: docs/research/2026-04-27-backbone-online-deploy-roadmap.md (Opzione B Min).
+# Checklist deploy: docs/ops/deploy-min-checklist.md
 #
 # Deploy:
-#   1. Commit this file on main (or target branch).
+#   1. Commit questo file su main (o target branch).
 #   2. Render dashboard → New → Blueprint → connect repo → apply.
-#   3. Env var DATABASE_URL (optional, set if LOBBY_PRISMA_ENABLED=true).
-#   4. Custom domain opzionale.
+#   3. Popola env var SECRET via dashboard (NON in repo): see checklist §pre-deploy.
+#   4. Custom domain opzionale (Mod scenario).
 #
 # Render free tier:
 #   - 512MB RAM, spin-down 15min idle, WS msg keepalive (Feb 2026 update).
@@ -13,8 +15,18 @@
 #
 # WS upgrade: LOBBY_WS_SHARED=true attach WS al server HTTP existente
 # sulla stessa PORT esposta da Render (nessun secondo port pubblico).
+# NON aggiungere LOBBY_WS_PORT pubblico — Render free supporta 1 port solo.
 #
-# Healthcheck: GET /api/lobby/state (no auth, sempre 200).
+# Healthcheck: GET /api/health (dedicated, restituisce { status, uptime }).
+#
+# Anti-pattern guard (vedi roadmap §7):
+#   - autoDeploy ESPLICITAMENTE false: push accidentali su main = downtime cold start
+#     durante session live. Re-deploy manuale via dashboard "Manual Deploy" o
+#     scripts/deploy-min.sh (curl POST API).
+#   - CORS_ORIGIN deve essere whitelist (NON '*') prima di share Discord pubblico.
+#     Tighten a https://evo-tactics-play.pages.dev appena CF Pages URL noto.
+#   - LOBBY_PRISMA_ENABLED=true richiede DATABASE_URL valido O crash al boot:
+#     lascia 'false' in scenario Min.
 
 services:
   - type: web
@@ -26,10 +38,13 @@ services:
     rootDir: .
     # --include=dev forza install devDependencies anche con NODE_ENV=production
     # (vite sta in apps/play/devDependencies — serve al build).
-    buildCommand: npm ci --include=dev && npm run play:build
+    # Prisma generate è no-op se DATABASE_URL non settato ma genera client comunque.
+    buildCommand: npm ci --include=dev && npm --prefix apps/backend exec prisma generate && npm run play:build
     startCommand: node apps/backend/index.js
-    healthCheckPath: /api/lobby/state
-    autoDeploy: true
+    healthCheckPath: /api/health
+    # ANTI-PATTERN GUARD: tenere a false. Push su main NON deve auto-trigger redeploy.
+    # Deploy esplicito via dashboard O scripts/deploy-min.sh stamp endpoint.
+    autoDeploy: false
     envVars:
       - key: NODE_VERSION
         value: 22.19.0
@@ -46,6 +61,15 @@ services:
       - key: IDEA_ENGINE_DISABLE_STATUS_REFRESH
         value: '1'
       # Render injects PORT automaticamente; backend legge process.env.PORT.
-      # CORS wide open per demo (tighten in prod).
+      # CORS_ORIGIN: PLACEHOLDER — popolare via dashboard con CF Pages URL effettivo
+      # (es. https://evo-tactics-play.pages.dev). NON committare '*' come default.
+      # Lasciato qui come reminder esplicito che richiede override.
       - key: CORS_ORIGIN
-        value: '*'
+        sync: false
+      # Secret env var (NON in repo). Popolare via dashboard:
+      #   - AUTH_SECRET: openssl rand -base64 64 (richiesto se JWT enabled in Mod)
+      #   - DATABASE_URL: stringa Postgres (Mod scenario, richiede LOBBY_PRISMA_ENABLED=true)
+      - key: AUTH_SECRET
+        sync: false
+      - key: DATABASE_URL
+        sync: false

--- a/scripts/deploy-min.sh
+++ b/scripts/deploy-min.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# scripts/deploy-min.sh — Sprint C deploy bundle Min orchestrator.
+#
+# Roadmap:   docs/research/2026-04-27-backbone-online-deploy-roadmap.md (Opzione B Min)
+# Checklist: docs/ops/deploy-min-checklist.md
+#
+# Cosa fa:
+#   1. Preflight: verifica gh, wrangler, RENDER_API_KEY, keys.env canonical.
+#   2. Build frontend (npm --prefix apps/play run build).
+#   3. Iniettare runtime-config production (sed RENDER_BACKEND_HOST).
+#   4. Deploy CF Pages (wrangler pages deploy apps/play/dist).
+#   5. Stamp Render redeploy via API (curl POST /v1/services/.../deploys).
+#   6. Smoke probe /api/health post-deploy con 30s retry.
+#   7. Print URL pubblici finali.
+#
+# Anti-pattern guard inline (block):
+#   - CORS_ORIGIN '*' in apps/backend/app.js default → warn (non block, è default codice).
+#   - Render service non configurato (RENDER_SERVICE_ID missing) → block.
+#   - Variabili secret presenti in repo (.env, render.yaml hardcoded) → block.
+#
+# Usage:
+#   export RENDER_API_KEY=...                 # da Render dashboard → Account Settings → API Keys
+#   export RENDER_SERVICE_ID=srv-...          # da URL service Render
+#   export RENDER_BACKEND_HOST=evo-tactics-backend.onrender.com
+#   export CLOUDFLARE_API_TOKEN=...           # opzionale se wrangler login OAuth
+#   bash scripts/deploy-min.sh
+#
+# Dry-run (skip deploy, solo build + preflight):
+#   DRY_RUN=1 bash scripts/deploy-min.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+DRY_RUN="${DRY_RUN:-0}"
+PLAY_DIST="apps/play/dist"
+KEYS_ENV="${HOME}/.config/api-keys/keys.env"
+
+log() { echo "[deploy-min] $*"; }
+warn() { echo "[deploy-min] WARN: $*" >&2; }
+fail() { echo "[deploy-min] FAIL: $*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Step 0 — preflight
+# ---------------------------------------------------------------------------
+log "Step 0/6: preflight checks…"
+
+# Carica eventuali secret da canonical path (override env).
+if [ -f "$KEYS_ENV" ]; then
+  log "loading secrets from $KEYS_ENV"
+  # shellcheck disable=SC1090
+  set -a; . "$KEYS_ENV"; set +a
+else
+  warn "$KEYS_ENV not found — secrets must be exported in current shell."
+fi
+
+# Tool requirements.
+command -v gh >/dev/null 2>&1 || fail "gh CLI missing (install: https://cli.github.com/)"
+command -v wrangler >/dev/null 2>&1 || warn "wrangler missing — CF Pages deploy will be skipped (npm i -g wrangler to enable)"
+command -v curl >/dev/null 2>&1 || fail "curl missing"
+command -v node >/dev/null 2>&1 || fail "node missing"
+command -v npm >/dev/null 2>&1 || fail "npm missing"
+
+gh auth status >/dev/null 2>&1 || fail "gh not authenticated (run: gh auth login)"
+
+# Required env (block).
+if [ "$DRY_RUN" != "1" ]; then
+  [ -n "${RENDER_API_KEY:-}" ] || fail "RENDER_API_KEY missing (Render dashboard → API Keys)"
+  [ -n "${RENDER_SERVICE_ID:-}" ] || fail "RENDER_SERVICE_ID missing (es. srv-xxxxxxxxxxxx)"
+  [ -n "${RENDER_BACKEND_HOST:-}" ] || fail "RENDER_BACKEND_HOST missing (es. evo-tactics-backend.onrender.com)"
+fi
+
+# Anti-pattern guard: secrets in repo .env files (esclude .env.example/.env.template).
+if find . -maxdepth 3 -type f \( -name '.env' -o -name '.env.local' -o -name '.env.production' \) -not -path './node_modules/*' 2>/dev/null | grep -q .; then
+  warn "found .env*/local/production in repo: spostare a $KEYS_ENV per evitare leak"
+fi
+
+# Anti-pattern guard: CORS '*' nel codice (default app.js linea ~413).
+# Non blocchiamo (è default codice runtime override via env), ma warn.
+if grep -q "options.corsOrigin || '\*'" apps/backend/app.js 2>/dev/null; then
+  warn "apps/backend/app.js usa CORS '*' come default — assicurarsi CORS_ORIGIN env var settato in Render dashboard a CF Pages URL"
+fi
+
+# Render API key naming sanity (non in repo).
+if grep -rE "RENDER_API_KEY\s*=\s*['\"][a-zA-Z0-9_-]{10,}" --include='*.yaml' --include='*.json' --include='*.toml' --include='*.sh' --exclude-dir=node_modules --exclude-dir=.git . 2>/dev/null | grep -v 'scripts/deploy-min.sh' | grep -q .; then
+  fail "RENDER_API_KEY hardcoded trovato in repo — RIMUOVERE prima di continuare"
+fi
+
+log "preflight OK."
+
+# ---------------------------------------------------------------------------
+# Step 1 — build frontend
+# ---------------------------------------------------------------------------
+log "Step 1/6: build frontend…"
+
+if [ -d apps/play ]; then
+  if [ -f apps/play/package.json ]; then
+    npm --prefix apps/play install --silent || fail "npm install apps/play failed"
+    npm --prefix apps/play run build || fail "npm run build apps/play failed"
+  else
+    fail "apps/play/package.json missing"
+  fi
+else
+  fail "apps/play missing"
+fi
+
+[ -d "$PLAY_DIST" ] || fail "build output $PLAY_DIST missing"
+log "frontend build OK ($(find "$PLAY_DIST" -type f | wc -l) files)"
+
+# ---------------------------------------------------------------------------
+# Step 2 — inject runtime-config production
+# ---------------------------------------------------------------------------
+log "Step 2/6: inject runtime-config.production.js → dist/runtime-config.js"
+
+if [ -f apps/play/runtime-config.production.js ]; then
+  HOST_ESCAPED=$(printf '%s' "${RENDER_BACKEND_HOST:-__RENDER_BACKEND_HOST__}" | sed 's/[\/&]/\\&/g')
+  sed "s/__RENDER_BACKEND_HOST__/${HOST_ESCAPED}/g" \
+    apps/play/runtime-config.production.js \
+    > "$PLAY_DIST/runtime-config.js"
+  log "runtime-config injected (host=${RENDER_BACKEND_HOST:-PLACEHOLDER})"
+else
+  warn "apps/play/runtime-config.production.js missing — skip injection"
+fi
+
+if [ "$DRY_RUN" = "1" ]; then
+  log "DRY_RUN=1 — skip steps 3-6 (deploy + smoke)."
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3 — deploy CF Pages
+# ---------------------------------------------------------------------------
+log "Step 3/6: deploy Cloudflare Pages…"
+
+if command -v wrangler >/dev/null 2>&1; then
+  wrangler pages deploy "$PLAY_DIST" \
+    --project-name=evo-tactics-play \
+    --commit-dirty=true \
+    || fail "wrangler pages deploy failed"
+  log "CF Pages deploy OK"
+else
+  warn "wrangler missing — skip CF Pages deploy. Run manually: wrangler pages deploy $PLAY_DIST --project-name=evo-tactics-play"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4 — stamp Render redeploy
+# ---------------------------------------------------------------------------
+log "Step 4/6: stamp Render redeploy via API…"
+
+RENDER_DEPLOY_URL="https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys"
+RENDER_RESP=$(curl -sS -X POST "$RENDER_DEPLOY_URL" \
+  -H "Authorization: Bearer ${RENDER_API_KEY}" \
+  -H "Accept: application/json" \
+  -H "Content-Type: application/json" \
+  -d '{"clearCache":"do_not_clear"}' || true)
+
+if echo "$RENDER_RESP" | grep -q '"id"'; then
+  RENDER_DEPLOY_ID=$(echo "$RENDER_RESP" | grep -oE '"id":\s*"[^"]+"' | head -1 | cut -d'"' -f4)
+  log "Render deploy stamped: id=$RENDER_DEPLOY_ID"
+else
+  warn "Render API response inattesa: $RENDER_RESP"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 5 — smoke probe /api/health
+# ---------------------------------------------------------------------------
+log "Step 5/6: smoke probe /api/health (30s retry)…"
+
+HEALTH_URL="https://${RENDER_BACKEND_HOST}/api/health"
+RETRIES=15
+SLEEP=2
+OK=0
+for i in $(seq 1 $RETRIES); do
+  STATUS=$(curl -sS -o /dev/null -w "%{http_code}" "$HEALTH_URL" || echo "000")
+  if [ "$STATUS" = "200" ]; then
+    log "health OK (HTTP 200) after ${i} attempt(s)"
+    OK=1
+    break
+  fi
+  log "health attempt $i/$RETRIES: HTTP $STATUS — retry in ${SLEEP}s…"
+  sleep $SLEEP
+done
+
+if [ "$OK" != "1" ]; then
+  warn "health probe non 200 dopo ${RETRIES} retry — verifica Render dashboard logs"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 6 — print URLs
+# ---------------------------------------------------------------------------
+log "Step 6/6: deploy summary"
+echo ""
+echo "  Backend (Render):   https://${RENDER_BACKEND_HOST}"
+echo "  Health endpoint:    https://${RENDER_BACKEND_HOST}/api/health"
+echo "  Frontend (CF):      https://evo-tactics-play.pages.dev"
+echo "  Lobby create:       curl -X POST https://${RENDER_BACKEND_HOST}/api/lobby/create"
+echo ""
+log "deploy Min complete. Run smoke playtest 2-tab incognito host+player WS connect."

--- a/tests/scripts/deploy-min-bundle.test.js
+++ b/tests/scripts/deploy-min-bundle.test.js
@@ -1,0 +1,184 @@
+// tests/scripts/deploy-min-bundle.test.js
+// Sprint C — deploy bundle Min sanity.
+// Verifica:
+//   - render.yaml è YAML valido + autoDeploy false + healthCheckPath /api/health
+//   - wrangler.toml è TOML valido + assets dir corretta
+//   - scripts/deploy-min.sh ha sintassi bash valida
+//   - apps/play/runtime-config.production.js esiste e ha placeholder
+//   - docs/ops/deploy-min-checklist.md ha frontmatter valido richiesto
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+function read(rel) {
+  return fs.readFileSync(path.join(ROOT, rel), 'utf8');
+}
+
+function exists(rel) {
+  return fs.existsSync(path.join(ROOT, rel));
+}
+
+test('render.yaml exists, parses as YAML, has Sprint C invariants', () => {
+  assert.ok(exists('render.yaml'), 'render.yaml missing');
+  const raw = read('render.yaml');
+
+  // Lazy parse: prova js-yaml se disponibile, altrimenti string assertion.
+  let parsed;
+  try {
+    const yaml = require('js-yaml');
+    parsed = yaml.load(raw);
+  } catch (err) {
+    parsed = null;
+  }
+
+  if (parsed) {
+    assert.ok(Array.isArray(parsed.services), 'services must be array');
+    assert.equal(parsed.services.length, 1, 'expect single service');
+    const svc = parsed.services[0];
+    assert.equal(svc.type, 'web');
+    assert.equal(svc.name, 'evo-tactics-backend');
+    assert.equal(svc.runtime, 'node');
+    assert.equal(svc.plan, 'free');
+    assert.equal(
+      svc.autoDeploy,
+      false,
+      'ANTI-PATTERN: autoDeploy must be false (Sprint C anti-pattern guard)',
+    );
+    assert.equal(
+      svc.healthCheckPath,
+      '/api/health',
+      'healthCheckPath must be /api/health (dedicated endpoint)',
+    );
+    assert.match(svc.buildCommand, /prisma generate/, 'build must include prisma generate');
+    assert.match(svc.startCommand, /node apps\/backend\/index\.js/);
+    const corsVar = svc.envVars.find((e) => e.key === 'CORS_ORIGIN');
+    assert.ok(corsVar, 'CORS_ORIGIN env var must be declared');
+    assert.equal(
+      corsVar.sync,
+      false,
+      'CORS_ORIGIN must use sync:false (no value committed) — anti-pattern guard',
+    );
+    const authSecret = svc.envVars.find((e) => e.key === 'AUTH_SECRET');
+    assert.ok(authSecret, 'AUTH_SECRET must be declared as sync:false placeholder');
+    assert.equal(authSecret.sync, false);
+    const dbUrl = svc.envVars.find((e) => e.key === 'DATABASE_URL');
+    assert.ok(dbUrl, 'DATABASE_URL must be declared as sync:false placeholder');
+    assert.equal(dbUrl.sync, false);
+  } else {
+    // Fallback: string-based smoke checks (js-yaml not installed in this scope).
+    assert.match(raw, /autoDeploy:\s*false/);
+    assert.match(raw, /healthCheckPath:\s*\/api\/health/);
+    assert.match(raw, /key:\s*CORS_ORIGIN[\s\S]+?sync:\s*false/);
+    assert.match(raw, /prisma generate/);
+  }
+});
+
+test('wrangler.toml exists, has expected name + assets directory', () => {
+  assert.ok(exists('wrangler.toml'), 'wrangler.toml missing');
+  const raw = read('wrangler.toml');
+
+  // No native TOML parser in node stdlib; smoke check via regex.
+  assert.match(raw, /^name\s*=\s*"evo"/m, 'wrangler name must be "evo"');
+  assert.match(raw, /^compatibility_date\s*=\s*"\d{4}-\d{2}-\d{2}"/m);
+  assert.match(raw, /\[assets\][\s\S]*?directory\s*=\s*"\.\/apps\/play\/dist"/);
+  assert.match(raw, /not_found_handling\s*=\s*"single-page-application"/);
+  assert.match(raw, /\[env\.pages\][\s\S]*?name\s*=\s*"evo-tactics-play"/);
+});
+
+test('scripts/deploy-min.sh exists, has valid bash syntax', () => {
+  const scriptPath = 'scripts/deploy-min.sh';
+  assert.ok(exists(scriptPath), 'deploy-min.sh missing');
+  const result = spawnSync('bash', ['-n', path.join(ROOT, scriptPath)], {
+    encoding: 'utf8',
+  });
+  assert.equal(
+    result.status,
+    0,
+    `bash -n failed:\nstdout=${result.stdout}\nstderr=${result.stderr}`,
+  );
+});
+
+test('scripts/deploy-min.sh has expected step structure + anti-pattern guards', () => {
+  const raw = read('scripts/deploy-min.sh');
+  // Steps 0-6 declared.
+  assert.match(raw, /Step 0\/6: preflight/);
+  assert.match(raw, /Step 1\/6: build frontend/);
+  assert.match(raw, /Step 2\/6: inject runtime-config/);
+  assert.match(raw, /Step 3\/6: deploy Cloudflare Pages/);
+  assert.match(raw, /Step 4\/6: stamp Render redeploy/);
+  assert.match(raw, /Step 5\/6: smoke probe \/api\/health/);
+  assert.match(raw, /Step 6\/6: deploy summary/);
+
+  // Required env vars enforced.
+  assert.match(raw, /RENDER_API_KEY/);
+  assert.match(raw, /RENDER_SERVICE_ID/);
+  assert.match(raw, /RENDER_BACKEND_HOST/);
+
+  // Anti-pattern guard: CORS check.
+  assert.match(raw, /apps\/backend\/app\.js/);
+  assert.match(raw, /CORS/);
+
+  // Health endpoint hit.
+  assert.match(raw, /\/api\/health/);
+
+  // No secret hardcoded in script.
+  assert.doesNotMatch(
+    raw.replace(/RENDER_API_KEY:?\s*=\s*\$/g, ''), // ignore var assignment patterns
+    /RENDER_API_KEY=['"]rnd_[a-zA-Z0-9_-]{20,}/,
+    'no RENDER_API_KEY value hardcoded',
+  );
+});
+
+test('apps/play/runtime-config.production.js exists with placeholder marker', () => {
+  const rel = 'apps/play/runtime-config.production.js';
+  assert.ok(exists(rel), 'runtime-config.production.js missing');
+  const raw = read(rel);
+  assert.match(raw, /__RENDER_BACKEND_HOST__/, 'must contain placeholder for sed substitution');
+  assert.match(raw, /window\.LOBBY_WS_URL/);
+  assert.match(raw, /window\.LOBBY_API_BASE/);
+  // No real production host hardcoded in assignments (comments allowed for examples).
+  // Strip line comments before checking.
+  const stripped = raw
+    .split('\n')
+    .filter((ln) => !ln.trim().startsWith('//'))
+    .join('\n');
+  assert.doesNotMatch(
+    stripped,
+    /\.onrender\.com/,
+    'no .onrender.com host hardcoded in JS assignments — must use placeholder',
+  );
+});
+
+test('docs/ops/deploy-min-checklist.md has valid frontmatter', () => {
+  const rel = 'docs/ops/deploy-min-checklist.md';
+  assert.ok(exists(rel), 'checklist md missing');
+  const raw = read(rel);
+
+  assert.match(raw, /^---\n/, 'frontmatter must start at top');
+  const fmMatch = raw.match(/^---\n([\s\S]+?)\n---/);
+  assert.ok(fmMatch, 'frontmatter block delimiters required');
+  const fm = fmMatch[1];
+
+  // Required fields per docs/governance/docs_metadata.schema.json
+  for (const field of [
+    'doc_status',
+    'doc_owner',
+    'workstream',
+    'last_verified',
+    'source_of_truth',
+    'language',
+    'review_cycle_days',
+  ]) {
+    assert.match(fm, new RegExp(`^${field}:`, 'm'), `frontmatter missing required: ${field}`);
+  }
+
+  // Workstream must be ops-qa (deployment ops).
+  assert.match(fm, /workstream:\s*ops-qa/);
+  // last_verified ISO date.
+  assert.match(fm, /last_verified:\s*\d{4}-\d{2}-\d{2}/);
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,11 +1,23 @@
-# Cloudflare Workers Assets config — Evo-Tactics play frontend static.
-# ADR-2026-04-26 hosting stack.
+# Cloudflare Workers/Pages config — Evo-Tactics play frontend static.
+# ADR-2026-04-26 hosting stack. Sprint C bundle Min.
+# Roadmap: docs/research/2026-04-27-backbone-online-deploy-roadmap.md
+# Checklist: docs/ops/deploy-min-checklist.md
 #
-# Deploy: push su main → CF Workers auto-detect + deploy apps/play/dist.
-# Build command nel dashboard: npm ci && npm run play:build
+# Deploy paths supportati:
+#   1. CF Pages (raccomandato Min): wrangler pages deploy apps/play/dist
+#      --project-name=evo-tactics-play
+#      Routing/SPA fallback gestito via apps/play/dist/_redirects (già shipped).
+#   2. Workers Assets (alt): push su main → CF Workers auto-detect + deploy
+#      apps/play/dist. Build command nel dashboard: npm ci && npm run play:build
 #
 # Workers Assets serve file statici HTML/JS/CSS via CDN globale CF.
 # SPA fallback: 404 → index.html per permettere client-side routing.
+#
+# Anti-pattern guard:
+#   - NON committare API token CF (CLOUDFLARE_API_TOKEN) in repo: usa
+#     ~/.config/api-keys/keys.env O wrangler login (OAuth).
+#   - apps/play/dist NON in repo (gitignored): build-time artifact.
+#     Deploy script (scripts/deploy-min.sh) chiama npm run play:build prima.
 
 name = "evo"
 compatibility_date = "2025-04-01"
@@ -13,3 +25,11 @@ compatibility_date = "2025-04-01"
 [assets]
 directory = "./apps/play/dist"
 not_found_handling = "single-page-application"
+
+# CF Pages project (alt deploy via wrangler pages):
+# Project name: evo-tactics-play
+# Build output: apps/play/dist
+# Build command: npm ci && npm run play:build
+# Root directory: . (repo root)
+[env.pages]
+name = "evo-tactics-play"


### PR DESCRIPTION
## Stato

**BUNDLE READY — user deve runare `bash scripts/deploy-min.sh` con credenziali sue per attivare. Zero deploy avvenuto in questo PR.**

Sprint C produce il deploy bundle pronto-da-eseguire per scenario Min ([roadmap §3 Opzione B](docs/research/2026-04-27-backbone-online-deploy-roadmap.md)). Stack target: Render free (backend + WS shared mode) + Cloudflare Pages free (frontend `apps/play/dist`). Costo $0, persistence in-memory, 4-8 player playtest 1 sessione.

## Files (7)

| File                                        | Tipo     | Note                                                     |
| ------------------------------------------- | -------- | -------------------------------------------------------- |
| `render.yaml`                               | modify   | `autoDeploy: false` (anti-pattern guard), CORS placeholder, AUTH_SECRET/DATABASE_URL placeholder, healthCheckPath `/api/health`, prisma generate in build |
| `wrangler.toml`                             | modify   | `[env.pages]` section + comment routing + anti-pattern guard |
| `apps/play/runtime-config.production.js`    | new      | Template runtime-config (sed `__RENDER_BACKEND_HOST__`)  |
| `scripts/deploy-min.sh`                     | new      | One-command 6-step orchestrator (preflight + build + inject + CF + Render API stamp + smoke + summary), `DRY_RUN=1` supportato |
| `docs/ops/deploy-min-checklist.md`          | new      | Pre-deploy + deploy + post-deploy verifica + rollback + audit ~36 env vars effettivi |
| `docs/governance/docs_registry.json`        | modify   | Entry checklist                                          |
| `tests/scripts/deploy-min-bundle.test.js`   | new      | YAML/TOML/bash sanity + frontmatter + anti-pattern guard |

## Anti-pattern guards wirati

Tutti dal roadmap §7 + audit insights 2026-04-25 OD-005:

- `autoDeploy: false` esplicito → push main = no auto-redeploy durante session live
- `CORS_ORIGIN` `sync: false` → popolare via dashboard, no `'*'` committato
- `LOBBY_PRISMA_ENABLED=false` default → no crash su missing `DATABASE_URL`
- `LOBBY_WS_SHARED=true` → no second port pubblico (Render free supporta 1 port)
- Secret hardcode block in deploy script: blocca `RENDER_API_KEY`, warn su `.env*` in repo
- Path canonical secrets: `~/.config/api-keys/keys.env` (mai repo `.env`)
- Prisma generate in build (no-op se DATABASE_URL assente, ma genera client per Mod upgrade)

## Audit env vars (~36 distinct)

Vedi checklist §6. Per scenario Min basta `CORS_ORIGIN` override in dashboard. Tutto il resto default OK.

## Test plan

- [x] `node --test tests/scripts/deploy-min-bundle.test.js` → 6/6 verde
- [x] `npx prettier --check` su file nuovi → clean
- [x] `python tools/check_docs_governance.py --strict` → 0 nuovi errors (1 pre-existing unrelated)
- [x] `bash -n scripts/deploy-min.sh` → syntax OK
- [ ] User esegue `DRY_RUN=1 bash scripts/deploy-min.sh` → preflight + build OK
- [ ] User esegue `bash scripts/deploy-min.sh` con credenziali Render+CF → deploy live + smoke
- [ ] User playtest 2-tab incognito host+player WS connect su URL pubblico

## Blocker user-action richiesto

Per attivare deploy, user deve:

1. Account Render free + GitHub OAuth (5 min)
2. Account Cloudflare + GitHub (5 min)
3. CF Pages project `evo-tactics-play` scaffolded (10 min)
4. `RENDER_API_KEY` + `RENDER_SERVICE_ID` + `RENDER_BACKEND_HOST` in `~/.config/api-keys/keys.env`
5. Render dashboard env var `CORS_ORIGIN=https://evo-tactics-play.pages.dev`
6. `bash scripts/deploy-min.sh`

Effort tot ~3-5h prima sessione. Sessioni successive zero overhead.

## Rollback

Vedi checklist §4. Frontend: `wrangler pages deployment activate`. Backend: Render dashboard "Rollback to this deploy" o API. Path back ngrok preservato (`scripts/run-demo-tunnel.cjs`).

## Non toccato

- `.github/workflows/` (CI gate separato)
- `migrations/`
- `packages/contracts/`
- `apps/backend/index.js` (zero behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)