### PR TITLE
feat(combat): Spore Moderate S6 resolver — archetype DR/init/sight consumption

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -165,6 +165,12 @@ const {
   applyProgressionToUnits,
   computePerkDamageBonus,
 } = require('../services/progression/progressionApply');
+// Sprint Spore Moderate (ADR-2026-04-26 §S6) — archetype passive consumers.
+// DR-1 (defender) + sight+2 (actor). Init+2 lives in roundOrchestrator.
+const {
+  applyDamageReduction: applyArchetypeDR,
+  effectiveAttackRange: archetypeEffectiveRange,
+} = require('../services/combat/archetypePassives');
 // M14-A 2026-04-25 — Triangle Strategy terrain reactions wire (post damage step).
 // Lazy require + try/catch in call sites: missing module never breaks combat.
 const {
@@ -543,6 +549,18 @@ function createSessionRouter(options = {}) {
         target.shield_hp = Math.max(0, Number(target.shield_hp) - absorbed);
         damageDealt = Math.max(0, damageDealt - absorbed);
         target.shield_absorbed_last = absorbed;
+      }
+      // Sprint Spore Moderate (ADR-2026-04-26 §S6) — archetype tank_plus DR-1.
+      // Defender-side passive: -1 damage unconditional su ogni colpo subito,
+      // min 0 floor. Applied DOPO shield absorption (shield = ablative HP,
+      // DR = innate mitigation). Back-compat: zero behavior change quando
+      // target._archetype_passives non include archetype_tank_plus_dr1.
+      if (damageDealt > 0) {
+        const drResult = applyArchetypeDR(damageDealt, target);
+        if (drResult.reduced > 0) {
+          damageDealt = drResult.damage;
+          target.archetype_dr_last = drResult.reduced;
+        }
       }
       // SPRINT_003 fase 0: traccia damage_taken cumulativo per unita'.
       // Lo stato e' in memoria (non nel log) — VC scoring lo ricalcola
@@ -1398,7 +1416,11 @@ function createSessionRouter(options = {}) {
             .json({ error: 'AP insufficienti per attaccare (termina il turno)' });
         }
         const attackDist = manhattanDistance(actor.position, target.position);
-        const range = actor.attack_range ?? DEFAULT_ATTACK_RANGE;
+        // Sprint Spore Moderate (ADR-2026-04-26 §S6) — archetype scout_plus
+        // sight+2: estende attack_range effettivo +2 se actor ha passive.
+        // Back-compat: zero delta quando _archetype_passives assente.
+        const baseRange = actor.attack_range ?? DEFAULT_ATTACK_RANGE;
+        const range = archetypeEffectiveRange(actor, baseRange);
         if (attackDist > range) {
           return res.status(400).json({
             error: `bersaglio fuori range (distanza ${attackDist} > range ${range})`,

--- a/apps/backend/services/combat/archetypePassives.js
+++ b/apps/backend/services/combat/archetypePassives.js
@@ -1,0 +1,109 @@
+// Sprint Spore Moderate (ADR-2026-04-26 §S6) — resolver-side consumption
+// di archetype passives shippati con PR #1916 (mutationEngine bingo).
+//
+// Pattern: applyMutationBingoToUnit hydrates `unit._archetype_passives`
+// con array di passive_token strings. Questo modulo wirea i 3 token
+// runtime-active nel resolver:
+//
+//   - archetype_tank_plus_dr1     (defender) → -1 damage (min 0)
+//   - archetype_ambush_plus_init2 (actor)    → +2 initiative se crit/flank
+//   - archetype_scout_plus_sight2 (actor)    → +2 attack_range / sight
+//
+// Deferred S6.B (biome/social-side, follow-up):
+//   - archetype_adapter_plus_hazard (richiede biome hazard registry)
+//   - archetype_alpha_plus_aff1     (richiede affinity passive system)
+//
+// Pure helpers, zero I/O. Caller passa unit + ctx.
+// Back-compat: unit senza _archetype_passives = zero behavior change
+// (tutti gli helper ritornano 0 / range invariato).
+//
+// Ref: docs/adr/ADR-2026-04-26-spore-part-pack-slots.md §S6
+//      apps/backend/services/mutations/mutationEngine.js (BINGO_ARCHETYPES)
+
+'use strict';
+
+const TANK_PLUS_DR1 = 'archetype_tank_plus_dr1';
+const AMBUSH_PLUS_INIT2 = 'archetype_ambush_plus_init2';
+const SCOUT_PLUS_SIGHT2 = 'archetype_scout_plus_sight2';
+
+/**
+ * Defender-side: ritorna damage reduction da applicare al damage step.
+ * Sottrae 1 al damage finale (min 0 garantito dal caller).
+ *
+ * @param {object} target — defender unit (può essere null/undefined)
+ * @returns {number} — DR amount (0 se passive assente)
+ */
+function getDamageReduction(target) {
+  if (!target || typeof target !== 'object') return 0;
+  const passives = Array.isArray(target._archetype_passives) ? target._archetype_passives : [];
+  return passives.includes(TANK_PLUS_DR1) ? 1 : 0;
+}
+
+/**
+ * Actor-side: ritorna initiative bonus se actor ha ambush_plus E
+ * (action.is_critical OR action.is_flank). Caller somma al sortKey/priority.
+ *
+ * @param {object} actor — attacker unit
+ * @param {object} action — { is_critical?: boolean, is_flank?: boolean }
+ * @returns {number} — init delta (0 se passive assente o trigger non match)
+ */
+function getInitiativeBonus(actor, action) {
+  if (!actor || typeof actor !== 'object') return 0;
+  const passives = Array.isArray(actor._archetype_passives) ? actor._archetype_passives : [];
+  if (!passives.includes(AMBUSH_PLUS_INIT2)) return 0;
+  const isCritical = !!(action && action.is_critical);
+  const isFlank = !!(action && action.is_flank);
+  if (!isCritical && !isFlank) return 0;
+  return 2;
+}
+
+/**
+ * Actor-side: ritorna sight/attack range delta se actor ha scout_plus.
+ * Caller somma al `attack_range` durante targeting / range gating.
+ *
+ * @param {object} actor — attacker unit
+ * @returns {number} — range delta (0 se passive assente, +2 altrimenti)
+ */
+function getSightRangeBonus(actor) {
+  if (!actor || typeof actor !== 'object') return 0;
+  const passives = Array.isArray(actor._archetype_passives) ? actor._archetype_passives : [];
+  return passives.includes(SCOUT_PLUS_SIGHT2) ? 2 : 0;
+}
+
+/**
+ * Convenience: ritorna effective attack_range = base + sight bonus.
+ * @param {object} actor
+ * @param {number} baseRange
+ * @returns {number}
+ */
+function effectiveAttackRange(actor, baseRange) {
+  const base = Number(baseRange);
+  if (!Number.isFinite(base)) return baseRange;
+  return base + getSightRangeBonus(actor);
+}
+
+/**
+ * Apply DR-1 to damageDealt with min 0 floor.
+ * @param {number} damageDealt
+ * @param {object} target
+ * @returns {{ damage: number, reduced: number }}
+ */
+function applyDamageReduction(damageDealt, target) {
+  const dmg = Number(damageDealt) || 0;
+  if (dmg <= 0) return { damage: dmg, reduced: 0 };
+  const dr = getDamageReduction(target);
+  if (dr <= 0) return { damage: dmg, reduced: 0 };
+  const reduced = Math.min(dr, dmg);
+  return { damage: Math.max(0, dmg - reduced), reduced };
+}
+
+module.exports = {
+  TANK_PLUS_DR1,
+  AMBUSH_PLUS_INIT2,
+  SCOUT_PLUS_SIGHT2,
+  getDamageReduction,
+  getInitiativeBonus,
+  getSightRangeBonus,
+  effectiveAttackRange,
+  applyDamageReduction,
+};

--- a/apps/backend/services/roundOrchestrator.js
+++ b/apps/backend/services/roundOrchestrator.js
@@ -261,7 +261,22 @@ function computeResolvePriority(unit, action, speedTable = DEFAULT_ACTION_SPEED)
     if (s.id === 'panic') penalty += intensity * 2;
     else if (s.id === 'disorient') penalty += intensity;
   }
-  return base + speed - penalty;
+  // Sprint Spore Moderate (ADR-2026-04-26 §S6) — archetype ambush_plus init+2
+  // se action.is_critical OR action.is_flank. Lazy require evita cycle import
+  // cross-module; back-compat: zero delta quando passive assente o trigger
+  // non match. Pattern: passive token check fast-path inline (avoid require
+  // per chiamata se passives empty).
+  let archetypeInitBonus = 0;
+  const passives = Array.isArray(unit && unit._archetype_passives) ? unit._archetype_passives : [];
+  if (passives.length > 0) {
+    try {
+      const { getInitiativeBonus } = require('./combat/archetypePassives');
+      archetypeInitBonus = getInitiativeBonus(unit, action);
+    } catch {
+      archetypeInitBonus = 0;
+    }
+  }
+  return base + speed - penalty + archetypeInitBonus;
 }
 
 /**

--- a/tests/services/archetypePassives.test.js
+++ b/tests/services/archetypePassives.test.js
@@ -1,0 +1,141 @@
+// Sprint Spore Moderate (ADR-2026-04-26 §S6) — resolver consumption tests.
+//
+// Verifies passive_token consumers wire correctly:
+//   - archetype_tank_plus_dr1     → -1 damage (min 0 floor)
+//   - archetype_ambush_plus_init2 → +2 init se action.is_critical/is_flank
+//   - archetype_scout_plus_sight2 → +2 effective attack_range
+//
+// Back-compat: unit senza _archetype_passives = zero behavior change.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  TANK_PLUS_DR1,
+  AMBUSH_PLUS_INIT2,
+  SCOUT_PLUS_SIGHT2,
+  getDamageReduction,
+  getInitiativeBonus,
+  getSightRangeBonus,
+  effectiveAttackRange,
+  applyDamageReduction,
+} = require('../../apps/backend/services/combat/archetypePassives');
+const { computeResolvePriority } = require('../../apps/backend/services/roundOrchestrator');
+
+// ─── tank_plus DR-1 ─────────────────────────────────────────────
+
+test('tank_plus DR-1: reduces damage by 1', () => {
+  const target = { _archetype_passives: [TANK_PLUS_DR1] };
+  const r = applyDamageReduction(5, target);
+  assert.equal(r.damage, 4);
+  assert.equal(r.reduced, 1);
+});
+
+test('tank_plus DR-1: floor at 0 (does not go negative)', () => {
+  const target = { _archetype_passives: [TANK_PLUS_DR1] };
+  const r = applyDamageReduction(1, target);
+  assert.equal(r.damage, 0);
+  assert.equal(r.reduced, 1);
+  // damage 0 input → DR not applied (no negative reduce)
+  const r0 = applyDamageReduction(0, target);
+  assert.equal(r0.damage, 0);
+  assert.equal(r0.reduced, 0);
+});
+
+test('tank_plus DR-1: back-compat — unit without _archetype_passives unchanged', () => {
+  assert.equal(getDamageReduction({}), 0);
+  assert.equal(getDamageReduction(null), 0);
+  assert.equal(getDamageReduction({ _archetype_passives: [] }), 0);
+  const r = applyDamageReduction(5, { hp: 10 });
+  assert.equal(r.damage, 5);
+  assert.equal(r.reduced, 0);
+});
+
+// ─── ambush_plus init+2 ─────────────────────────────────────────
+
+test('ambush_plus init+2: triggers on critical or flank action', () => {
+  const actor = { _archetype_passives: [AMBUSH_PLUS_INIT2] };
+  assert.equal(getInitiativeBonus(actor, { is_critical: true }), 2);
+  assert.equal(getInitiativeBonus(actor, { is_flank: true }), 2);
+  assert.equal(getInitiativeBonus(actor, { is_critical: true, is_flank: true }), 2);
+});
+
+test('ambush_plus init+2: NO trigger when neither crit nor flank', () => {
+  const actor = { _archetype_passives: [AMBUSH_PLUS_INIT2] };
+  assert.equal(getInitiativeBonus(actor, {}), 0);
+  assert.equal(getInitiativeBonus(actor, { is_critical: false, is_flank: false }), 0);
+  assert.equal(getInitiativeBonus(actor, null), 0);
+});
+
+test('ambush_plus init+2: wired in computeResolvePriority', () => {
+  // Same unit + action: priority differs by exactly 2 with passive on critical.
+  const baseUnit = { initiative: 10 };
+  const ambushUnit = {
+    initiative: 10,
+    _archetype_passives: [AMBUSH_PLUS_INIT2],
+  };
+  const action = { type: 'attack', is_critical: true };
+  const basePriority = computeResolvePriority(baseUnit, action);
+  const ambushPriority = computeResolvePriority(ambushUnit, action);
+  assert.equal(ambushPriority - basePriority, 2);
+  // Without crit/flank trigger, no delta
+  const calmAction = { type: 'attack' };
+  assert.equal(
+    computeResolvePriority(ambushUnit, calmAction),
+    computeResolvePriority(baseUnit, calmAction),
+  );
+});
+
+// ─── scout_plus sight+2 ─────────────────────────────────────────
+
+test('scout_plus sight+2: extends effective attack_range by 2', () => {
+  const actor = { _archetype_passives: [SCOUT_PLUS_SIGHT2] };
+  assert.equal(getSightRangeBonus(actor), 2);
+  assert.equal(effectiveAttackRange(actor, 3), 5);
+  assert.equal(effectiveAttackRange(actor, 1), 3);
+});
+
+test('scout_plus sight+2: back-compat — unit without passive unchanged', () => {
+  assert.equal(getSightRangeBonus({}), 0);
+  assert.equal(getSightRangeBonus(null), 0);
+  assert.equal(effectiveAttackRange({}, 3), 3);
+  assert.equal(effectiveAttackRange({ _archetype_passives: [] }, 5), 5);
+});
+
+// ─── combo: tank + ambush + scout do not interfere ─────────────
+
+test('combo: all three passives stack independently without interference', () => {
+  const actor = {
+    initiative: 5,
+    _archetype_passives: [TANK_PLUS_DR1, AMBUSH_PLUS_INIT2, SCOUT_PLUS_SIGHT2],
+  };
+  // tank DR works
+  const dr = applyDamageReduction(4, actor);
+  assert.equal(dr.damage, 3);
+  assert.equal(dr.reduced, 1);
+  // ambush init bonus on flank
+  assert.equal(getInitiativeBonus(actor, { is_flank: true }), 2);
+  // scout sight bonus
+  assert.equal(effectiveAttackRange(actor, 2), 4);
+  // computeResolvePriority sees the +2 only when crit/flank set
+  const prioCrit = computeResolvePriority(actor, { type: 'attack', is_critical: true });
+  const prioCalm = computeResolvePriority(actor, { type: 'attack' });
+  assert.equal(prioCrit - prioCalm, 2);
+});
+
+// ─── full back-compat sweep ─────────────────────────────────────
+
+test('back-compat: zero behavior change when _archetype_passives undefined', () => {
+  // Mirror real session unit shape (no Spore mutations applied).
+  const plainActor = { id: 'u1', initiative: 8, hp: 10, mod: 2 };
+  const plainTarget = { id: 'u2', hp: 10, dc: 12 };
+  // Damage path
+  const dr = applyDamageReduction(7, plainTarget);
+  assert.equal(dr.damage, 7);
+  // Init path
+  const prio = computeResolvePriority(plainActor, { type: 'attack', is_critical: true });
+  assert.equal(prio, 8); // initiative 8 + speed 0 - penalty 0 + archetype 0
+  // Sight path
+  assert.equal(effectiveAttackRange(plainActor, 2), 2);
+});


### PR DESCRIPTION
## Summary

Sprint A backend implementation di **ADR-2026-04-26 §S6** — chiude il gap _engine LIVE / surface DEAD_ tra `mutationEngine` (PR #1916, MERGED) e il resolver di combattimento.

`applyMutationBingoToUnit` hydrates `unit._archetype_passives` con `passive_token` strings, ma resolver/damage step non li consumava: il player non vedeva l'effetto di un bingo physiological (DR-1) anche se runtime espone `_archetype_passives`. Questo PR wirea i 3 token runtime-active.

### Passive consumers wired

| Token | Side | Effect | Site |
|---|---|---|---|
| `archetype_tank_plus_dr1` | defender | -1 damage step (min 0 floor) | `apps/backend/routes/session.js` post shield_hp |
| `archetype_ambush_plus_init2` | actor | +2 initiative se `is_critical OR is_flank` | `apps/backend/services/roundOrchestrator.js` `computeResolvePriority` |
| `archetype_scout_plus_sight2` | actor | +2 effective `attack_range` per targeting | `apps/backend/routes/session.js` range gate |

**Deferred S6.B** (follow-up PR): `archetype_adapter_plus_hazard` (richiede biome hazard registry) + `archetype_alpha_plus_aff1` (richiede affinity passive system). Documentati in commento del nuovo modulo.

## Files modified

- **NEW** `apps/backend/services/combat/archetypePassives.js` (109 LOC) — pure helpers, zero I/O. Export `getDamageReduction`/`getInitiativeBonus`/`getSightRangeBonus`/`effectiveAttackRange`/`applyDamageReduction` + `*_TOKEN` constants.
- **MOD** `apps/backend/routes/session.js` (+24/-2) — import block + DR consumer (post shield, pre HP) + sight consumer (range gate).
- **MOD** `apps/backend/services/roundOrchestrator.js` (+18/-1) — init+2 in `computeResolvePriority` con lazy require pattern (evita cycle import + zero overhead se passives empty).
- **NEW** `tests/services/archetypePassives.test.js` (+150 LOC) — 10 test (3 tank + 3 ambush + 2 scout + 1 combo + 1 back-compat sweep).

## Test plan

- [x] 10/10 archetypePassives tests verde (`node --test tests/services/archetypePassives.test.js`)
- [x] 311/311 AI regression verde (`node --test tests/ai/*.test.js`) — zero ripple
- [x] `npx prettier --check` su 4 file touched verde
- [x] Back-compat verificato: unit senza `_archetype_passives` = zero behavior change (tutti gli helper ritornano 0/range invariato; integration test esplicito)
- [x] Combo test: tank + ambush + scout su stessa unit = 3 effetti indipendenti
- [x] Floor test: DR-1 non porta damage sotto 0 (min 0 garantito)
- [x] Trigger guard: ambush init+2 NO trigger se né `is_critical` né `is_flank`

## Impact

Chiude pattern dominante _Engine LIVE Surface DEAD_ (CLAUDE.md §Gate 5) per Spore Moderate S6. Player con bingo physiological (Tank archetype) vede ora -1 damage subito; bingo predator (Ambush) vede +2 init su crit; bingo recon (Scout) vede +2 range targeting.

**Pillar 2 (Evoluzione)** progresses 🟢c → 🟢c+ runtime archetype_passives consumed.

## Constraints honored

- Nessun touch a `.github/workflows/`, `migrations/`, `packages/contracts/`, `services/generation/`, `data/core/traits/active_effects.yaml`, `apps/backend/services/mutations/`
- Nessuna nuova dipendenza npm/pip
- Lazy require pattern per evitare cycle import resolver↔orchestrator
- Pure helpers (zero I/O, zero closure state) facilita test + audit

Ref: `docs/adr/ADR-2026-04-26-spore-part-pack-slots.md` §S6 + PR #1916 (mutationEngine BINGO_ARCHETYPES).

🤖 Generated with [Claude Code](https://claude.com/claude-code)