### PR TITLE
feat(play): QW-2 MP badge characterPanel + QW-3 Mutations tab nestHub

### DIFF
--- a/apps/play/src/api.js
+++ b/apps/play/src/api.js
@@ -293,6 +293,17 @@ export const api = {
   metaLineageChain: (lineageId) => jsonFetch(`/api/meta/lineage/${encodeURIComponent(lineageId)}`),
   metaTribesEmergent: () => jsonFetch('/api/meta/tribes'),
   metaTribeForUnit: (unitId) => jsonFetch(`/api/meta/tribe/unit/${encodeURIComponent(unitId)}`),
+  // QW-3 Spore Moderate — mutation registry/eligible/apply/bingo client.
+  mutationsRegistry: () => jsonFetch('/api/v1/mutations/registry'),
+  mutationsEligible: (unit) =>
+    jsonFetch('/api/v1/mutations/eligible', { method: 'POST', body: JSON.stringify({ unit }) }),
+  mutationsApply: (unit, mutation_id, session_id = null) =>
+    jsonFetch('/api/v1/mutations/apply', {
+      method: 'POST',
+      body: JSON.stringify({ unit, mutation_id, session_id }),
+    }),
+  mutationsBingo: (unit) =>
+    jsonFetch('/api/v1/mutations/bingo', { method: 'POST', body: JSON.stringify({ unit }) }),
   // Skiv-as-Monitor — git-event-driven creature feed (Phase 2 wire 2026-04-25).
   skivStatus: () => jsonFetch('/api/skiv/status'),
   skivFeed: (limit = 20) => jsonFetch(`/api/skiv/feed?limit=${encodeURIComponent(limit)}`),

--- a/apps/play/src/characterPanel.js
+++ b/apps/play/src/characterPanel.js
@@ -213,6 +213,45 @@ function injectStyles() {
     .conviction-badge .cv-delta {
       font-size: 0.78rem; color: #8aa0c7; margin-top: 4px; font-style: italic;
     }
+    /* QW-2 Spore Moderate — MP pool + archetype passives section. */
+    .character-mp {
+      background: #0d1118; border: 1px solid #2a3040; border-radius: 10px;
+      padding: 14px 16px; margin-bottom: 16px;
+    }
+    .character-mp h3 {
+      font-size: 0.85rem; color: #8aa0c7; margin: 0 0 10px 0;
+      text-transform: uppercase; letter-spacing: 0.06em;
+    }
+    .mp-pool-row {
+      display: flex; align-items: center; gap: 10px; margin-bottom: 10px;
+    }
+    .mp-pool-row .mp-label {
+      flex: 0 0 90px; font-size: 0.85rem; color: #c8cfdd;
+    }
+    .mp-pool-bar {
+      flex: 1 1 auto; height: 14px; background: #1a1f2b; border-radius: 7px;
+      position: relative; overflow: hidden;
+    }
+    .mp-pool-bar-fill {
+      height: 100%;
+      background: linear-gradient(90deg, #a78bfa 0%, #c084fc 100%);
+      transition: width 0.3s ease-out;
+    }
+    .mp-pool-row .mp-value {
+      flex: 0 0 60px; font-size: 0.85rem; color: #c084fc;
+      font-family: monospace; text-align: right;
+    }
+    .archetype-passives {
+      display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px;
+    }
+    .archetype-chip {
+      background: #1a1f2b; border: 1px solid #c084fc; border-radius: 999px;
+      padding: 4px 10px; font-size: 0.75rem; color: #e8d4ff;
+    }
+    .archetype-chip .arch-icon { margin-right: 4px; }
+    .archetype-empty {
+      font-size: 0.78rem; color: #6b7790; font-style: italic; padding-top: 4px;
+    }
   `;
   document.head.appendChild(s);
 }
@@ -347,6 +386,43 @@ function renderEnneaSection(actorVc) {
   `;
 }
 
+// QW-2 — Spore Moderate MP pool + archetype passive section.
+// Reads `unit.mp` (default 5 backend hydration) + `unit._archetype_meta`
+// (hydrated da applyMutationBingoToUnit ogni session /start).
+function renderMpSection(unit) {
+  const mp = Number(unit?.mp ?? 0);
+  const cap = 30; // MP_POOL_MAX da mpTracker.js
+  const pct = Math.min(100, (mp / cap) * 100);
+  const archetypes = Array.isArray(unit?._archetype_meta) ? unit._archetype_meta : [];
+  const archetypeIcons = {
+    tank_plus: '🛡',
+    ambush_plus: '🗡',
+    scout_plus: '👁',
+    adapter_plus: '🌿',
+    alpha_plus: '⭐',
+  };
+  const chips =
+    archetypes.length === 0
+      ? '<div class="archetype-empty">Nessun archetipo attivo (servono ≥3 mutation stessa categoria).</div>'
+      : `<div class="archetype-passives">${archetypes
+          .map(
+            (a) =>
+              `<span class="archetype-chip" title="${escapeHtml(a.passive_token || '')}"><span class="arch-icon">${archetypeIcons[a.archetype] || '◆'}</span>${escapeHtml(a.label_it || a.archetype)}</span>`,
+          )
+          .join('')}</div>`;
+  return `
+    <div class="character-mp">
+      <h3>Mutation Points &amp; Archetipi (Spore)</h3>
+      <div class="mp-pool-row">
+        <div class="mp-label">MP pool</div>
+        <div class="mp-pool-bar"><div class="mp-pool-bar-fill" style="width:${pct}%"></div></div>
+        <div class="mp-value">${mp}/${cap}</div>
+      </div>
+      ${chips}
+    </div>
+  `;
+}
+
 function render(unit, actorVc) {
   const overlay = buildOverlay();
   const body = overlay.querySelector('[data-role="body"]');
@@ -357,7 +433,7 @@ function render(unit, actorVc) {
       '<div class="character-empty">Seleziona un PG per vedere il suo profilo carattere.</div>';
     return;
   }
-  body.innerHTML = renderMbtiSection(actorVc) + renderEnneaSection(actorVc);
+  body.innerHTML = renderMpSection(unit) + renderMbtiSection(actorVc) + renderEnneaSection(actorVc);
 }
 
 /**

--- a/apps/play/src/nestHub.js
+++ b/apps/play/src/nestHub.js
@@ -21,7 +21,7 @@
 
 import { api } from './api.js';
 
-const TAB_IDS = ['squad', 'mating', 'lineage', 'codex'];
+const TAB_IDS = ['squad', 'mating', 'mutations', 'lineage', 'codex'];
 
 const STATE = {
   overlayEl: null,
@@ -36,6 +36,9 @@ const STATE = {
   expandedLineageId: null,
   expandedChain: [],
   selectedUnitId: null,
+  // QW-3 Spore Moderate — mutations tab state.
+  cachedEligibleMutations: [],
+  cachedMutationsBingo: { archetypes: [], counts: {} },
   openCodex: () => {
     /* fallback no-op */
   },
@@ -174,6 +177,43 @@ function injectStyles() {
     }
     .nest-status.ok { color: #66bb6a; }
     .nest-status.err { color: #ef5350; }
+    /* QW-3 Spore Moderate — Mutations tab. */
+    .nest-mutation-list { display: flex; flex-direction: column; gap: 4px; }
+    .nest-mutation-row {
+      display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+      background: #0b0d12; border: 1px solid #2a3040; border-radius: 6px;
+      padding: 8px 10px; font-size: 0.85rem;
+    }
+    .nest-mutation-row.disabled { opacity: 0.5; }
+    .nest-mutation-row .mut-name { flex: 1 1 200px; color: #c084fc; font-weight: 600; }
+    .nest-mutation-row .mut-tier {
+      background: #1d2230; border: 1px solid #2a3040; border-radius: 4px;
+      padding: 1px 6px; font-family: monospace; font-size: 0.72rem;
+    }
+    .nest-mutation-row .mut-slot {
+      background: #1a1f2b; border: 1px solid #5a4a8c; border-radius: 4px;
+      padding: 1px 6px; font-family: monospace; font-size: 0.72rem; color: #c4a574;
+    }
+    .nest-mutation-row .mut-cost { font-family: monospace; font-size: 0.78rem; color: #a78bfa; }
+    .nest-mutation-row .mut-apply-btn {
+      background: #2d2a4a; color: #e8d4ff; border: 1px solid #5a4a8c;
+      border-radius: 4px; padding: 3px 10px; cursor: pointer; font-size: 0.78rem;
+    }
+    .nest-mutation-row .mut-apply-btn:hover:not(:disabled) { background: #3d3a6a; }
+    .nest-mutation-row .mut-apply-btn:disabled { opacity: 0.3; cursor: not-allowed; }
+    .nest-mutation-bingo {
+      background: #0b0d12; border: 1px solid #5a4a8c; border-radius: 6px;
+      padding: 8px 10px; margin-top: 6px;
+    }
+    .nest-mutation-bingo h4 {
+      margin: 0 0 6px 0; font-size: 0.78rem; color: #c084fc; text-transform: uppercase;
+    }
+    .bingo-counts { display: flex; flex-wrap: wrap; gap: 4px; }
+    .bingo-cat-chip {
+      background: #1a1f2b; border: 1px solid #2a3040; border-radius: 999px;
+      padding: 2px 8px; font-size: 0.75rem; font-family: monospace;
+    }
+    .bingo-cat-chip.completed { border-color: #c084fc; color: #e8d4ff; }
     /* Sprint D — Lineage section (tribe list + tree view). */
     .nest-tribe-list { display: flex; flex-direction: column; gap: 4px; }
     .nest-tribe-row {
@@ -246,6 +286,9 @@ function buildOverlay() {
         <button type="button" class="nest-tab" data-tab="mating" role="tab">
           🧬 Mating
         </button>
+        <button type="button" class="nest-tab" data-tab="mutations" role="tab">
+          🧪 Mutations
+        </button>
         <button type="button" class="nest-tab" data-tab="lineage" role="tab">
           🌳 Lineage
         </button>
@@ -289,6 +332,28 @@ function buildOverlay() {
             </button>
             <span id="nest-mating-hint" style="font-size:0.8rem;color:#8891a3"></span>
           </div>
+        </div>
+      </div>
+
+      <!-- TAB: Mutations — QW-3 Spore Moderate Gate 5 UX. -->
+      <div class="nest-tab-panel" data-tab-panel="mutations">
+        <div class="nest-section" id="nest-mutations-section">
+          <div style="margin-bottom:8px;color:#8891a3;font-size:0.82rem">
+            🧪 Spore Moderate evolution editor — seleziona PG, vedi mutation eligible con MP cost
+            + body_slot, applica per evolvere ability derivata.
+          </div>
+          <div class="nest-setup-row">
+            <select id="nest-mutation-unit-select"></select>
+            <button type="button" class="nest-btn" id="nest-mutation-refresh-btn">
+              🔄 Refresh eligible
+            </button>
+            <span id="nest-mutation-mp" style="font-size:0.85rem;color:#c084fc"></span>
+          </div>
+          <h3>Mutation eligible (<span id="nest-mutations-count">0</span>)</h3>
+          <div class="nest-mutation-list" id="nest-mutation-list">
+            <div class="nest-empty">Seleziona un PG e premi Refresh.</div>
+          </div>
+          <div id="nest-mutation-bingo-wrap" style="margin-top:10px"></div>
         </div>
       </div>
 
@@ -340,6 +405,11 @@ function buildOverlay() {
   overlay.querySelectorAll('.nest-tab').forEach((tabBtn) => {
     tabBtn.addEventListener('click', () => switchTab(tabBtn.dataset.tab));
   });
+  // QW-3 Spore Moderate — mutations tab handlers (refresh-btn + select change).
+  const mutBtn = overlay.querySelector('#nest-mutation-refresh-btn');
+  if (mutBtn) mutBtn.addEventListener('click', () => refreshMutations().catch(() => {}));
+  const mutSel = overlay.querySelector('#nest-mutation-unit-select');
+  if (mutSel) mutSel.addEventListener('change', () => refreshMutations().catch(() => {}));
   STATE.overlayEl = overlay;
   return overlay;
 }
@@ -356,6 +426,10 @@ export function switchTab(tabName) {
   panel.querySelectorAll('.nest-tab-panel').forEach((p) => {
     p.classList.toggle('active', p.dataset.tabPanel === tabName);
   });
+  // QW-3 — auto-refresh mutations tab on switch (lazy fetch).
+  if (tabName === 'mutations') {
+    refreshMutations().catch(() => {});
+  }
 }
 
 function setStatus(text, kind = '') {
@@ -695,11 +769,177 @@ async function refresh() {
   renderNpcs(STATE.cachedNpcs);
   // Sprint D — fetch tribe emergent in parallel; failure non-fatal.
   await refreshLineage().catch(() => {});
+  // QW-3 — populate mutations unit selector from squad list (recruited only).
+  populateMutationUnitSelector();
   const squadCount = filterSquadMembers(STATE.cachedNpcs).length;
   setStatus(
     `${squadCount} creature · ${STATE.cachedNpcs.length} NPG · nido Lv ${STATE.cachedNest.level}${STATE.cachedNest.biome ? ' (' + STATE.cachedNest.biome + ')' : ''} · ${STATE.cachedTribes.length} tribù`,
     'ok',
   );
+}
+
+// ─── QW-3 Spore Moderate — Mutations tab ──────────────────────────────────
+
+function populateMutationUnitSelector() {
+  if (typeof document === 'undefined') return;
+  const sel = document.getElementById('nest-mutation-unit-select');
+  if (!sel) return;
+  const squad = filterSquadMembers(STATE.cachedNpcs);
+  let partyMember = null;
+  try {
+    partyMember = STATE.getPartyMember?.() || null;
+  } catch {
+    /* optional */
+  }
+  const options = [];
+  if (partyMember && (partyMember.id || partyMember.npc_id)) {
+    const pid = partyMember.id || partyMember.npc_id;
+    options.push(`<option value="party:${escapeHtml(pid)}">★ ${escapeHtml(pid)} (you)</option>`);
+  }
+  for (const npc of squad) {
+    options.push(
+      `<option value="npc:${escapeHtml(npc.npc_id)}">${escapeHtml(npc.npc_id)}</option>`,
+    );
+  }
+  if (options.length === 0) {
+    sel.innerHTML = '<option value="">(no eligible units)</option>';
+    sel.disabled = true;
+  } else {
+    sel.innerHTML = options.join('');
+    sel.disabled = false;
+  }
+}
+
+function _selectedMutationUnit() {
+  if (typeof document === 'undefined') return null;
+  const sel = document.getElementById('nest-mutation-unit-select');
+  const v = sel?.value || '';
+  if (!v) return null;
+  const idx = v.indexOf(':');
+  if (idx < 0) return null;
+  const kind = v.slice(0, idx);
+  const id = v.slice(idx + 1);
+  if (kind === 'party') {
+    try {
+      return STATE.getPartyMember?.() || null;
+    } catch {
+      return null;
+    }
+  }
+  if (kind === 'npc') {
+    return STATE.cachedNpcs.find((n) => n && n.npc_id === id) || null;
+  }
+  return null;
+}
+
+function _unitForMutationApi(raw) {
+  if (!raw) return null;
+  return {
+    id: raw.id || raw.npc_id || null,
+    trait_ids: Array.isArray(raw.trait_ids) ? raw.trait_ids : [],
+    applied_mutations: Array.isArray(raw.applied_mutations) ? raw.applied_mutations : [],
+    mp: Number(raw.mp ?? 5),
+  };
+}
+
+async function refreshMutations() {
+  if (typeof document === 'undefined') return;
+  const list = document.getElementById('nest-mutation-list');
+  const count = document.getElementById('nest-mutations-count');
+  const mpEl = document.getElementById('nest-mutation-mp');
+  const raw = _selectedMutationUnit();
+  if (!raw) {
+    if (list) list.innerHTML = '<div class="nest-empty">Seleziona un PG.</div>';
+    if (count) count.textContent = '0';
+    if (mpEl) mpEl.textContent = '';
+    return;
+  }
+  const unit = _unitForMutationApi(raw);
+  if (mpEl) mpEl.textContent = `MP ${unit.mp}/30`;
+  const res = await api.mutationsEligible(unit);
+  const eligible = res.ok && Array.isArray(res.data?.eligible) ? res.data.eligible : [];
+  STATE.cachedEligibleMutations = eligible;
+  if (count) count.textContent = String(eligible.length);
+  if (list) {
+    if (eligible.length === 0) {
+      list.innerHTML = '<div class="nest-empty">Nessuna mutation eligible per questo PG.</div>';
+    } else {
+      list.innerHTML = '';
+      for (const m of eligible) {
+        const row = document.createElement('div');
+        const canAfford = unit.mp >= Number(m.mp_cost ?? 0);
+        row.className = `nest-mutation-row${canAfford ? '' : ' disabled'}`;
+        const slot = m.body_slot ? escapeHtml(m.body_slot) : 'symbiotic';
+        row.innerHTML = `
+          <span class="mut-name">${escapeHtml(m.name_it || m.id)}</span>
+          <span class="mut-tier">T${m.tier}</span>
+          <span class="mut-slot">${slot}</span>
+          <span class="mut-cost">${m.mp_cost} MP</span>
+          <button type="button" class="mut-apply-btn" ${canAfford ? '' : 'disabled'} data-mut-id="${escapeHtml(m.id)}">Apply</button>
+        `;
+        const btn = row.querySelector('.mut-apply-btn');
+        if (btn && canAfford) btn.addEventListener('click', () => handleApplyMutation(m.id));
+        list.appendChild(row);
+      }
+    }
+  }
+  await refreshMutationBingo(unit);
+}
+
+async function refreshMutationBingo(unit) {
+  if (typeof document === 'undefined') return;
+  const wrap = document.getElementById('nest-mutation-bingo-wrap');
+  if (!wrap) return;
+  const res = await api.mutationsBingo(unit);
+  const data = res.ok ? res.data || {} : {};
+  STATE.cachedMutationsBingo = {
+    archetypes: Array.isArray(data.archetypes) ? data.archetypes : [],
+    counts: data.counts || {},
+  };
+  const cats = ['physiological', 'behavioral', 'sensorial', 'environmental', 'symbiotic'];
+  const chips = cats
+    .map((c) => {
+      const n = Number(STATE.cachedMutationsBingo.counts[c] || 0);
+      const completed = n >= 3;
+      return `<span class="bingo-cat-chip${completed ? ' completed' : ''}">${escapeHtml(c)}: ${n}/3${completed ? ' ✓' : ''}</span>`;
+    })
+    .join('');
+  const archetypes = STATE.cachedMutationsBingo.archetypes;
+  const archHtml =
+    archetypes.length > 0
+      ? `<div style="margin-top:6px;color:#e8d4ff;font-size:0.78rem">Archetipo attivo: ${archetypes
+          .map((a) => escapeHtml(a.label_it || a.archetype))
+          .join(', ')}</div>`
+      : '';
+  wrap.innerHTML = `
+    <div class="nest-mutation-bingo">
+      <h4>🧬 Bingo categorie (3-of-a-kind = archetipo passive)</h4>
+      <div class="bingo-counts">${chips}</div>
+      ${archHtml}
+    </div>
+  `;
+}
+
+async function handleApplyMutation(mutationId) {
+  const raw = _selectedMutationUnit();
+  if (!raw) return;
+  const unit = _unitForMutationApi(raw);
+  setStatus(`Applico ${mutationId} → ${unit.id}…`);
+  const res = await api.mutationsApply(unit, mutationId);
+  const d = res.data || {};
+  if (!res.ok || !d.success) {
+    const reason = d.error || `HTTP ${res.status}`;
+    setStatus(`✖ Apply fail: ${reason}`, 'err');
+    return;
+  }
+  if (Array.isArray(d.unit?.trait_ids)) raw.trait_ids = d.unit.trait_ids;
+  if (Array.isArray(d.unit?.applied_mutations)) raw.applied_mutations = d.unit.applied_mutations;
+  if (typeof d.unit?.mp === 'number') raw.mp = d.unit.mp;
+  setStatus(
+    `✓ ${mutationId}: -${d.mp_spent} MP (now ${d.unit?.mp}/30)${d.derived_ability_id ? ' + ability ' + d.derived_ability_id : ''}`,
+    'ok',
+  );
+  await refreshMutations();
 }
 
 export function openNestHub() {

--- a/tests/api/nestHub.test.js
+++ b/tests/api/nestHub.test.js
@@ -15,9 +15,9 @@ async function loadHub() {
   return import('../../apps/play/src/nestHub.js');
 }
 
-test('nestHub exports 4 canonical tab ids: squad / mating / lineage / codex', async () => {
+test('nestHub exports 5 canonical tab ids: squad / mating / mutations / lineage / codex', async () => {
   const { __nestHubInternal } = await loadHub();
-  assert.deepEqual(__nestHubInternal.TAB_IDS, ['squad', 'mating', 'lineage', 'codex']);
+  assert.deepEqual(__nestHubInternal.TAB_IDS, ['squad', 'mating', 'mutations', 'lineage', 'codex']);
 });
 
 test('filterSquadMembers returns only NPCs with recruited:true', async () => {


### PR DESCRIPTION
## Summary
Player-side wires per Spore Moderate runtime engine. Closes "Engine LIVE Surface DEAD" anti-pattern su MP pool + bingo + mutation apply (Gate 5 DoD compliance).

Builds on engine shippato in PR #1913 (S1 schema) + #1915 (S2+S3+S6 engine) + #1916 (S3+S6 MP pool + hydration) + #1917 (QW-1 MP grant toast).

## QW-2 — \`apps/play/src/characterPanel.js\` (+~80 LOC)
- Nuova sezione "Mutation Points & Archetipi (Spore)" sopra MBTI
- MP pool bar gradient viola Spore #a78bfa→#c084fc + numeric N/30
- Archetype passive chips se \`_archetype_meta\` presente (5 archetypes 🛡 🗡 👁 🌿 ⭐)
- Empty state "servono ≥3 mutation stessa categoria"
- Reads \`unit.mp\` + \`unit._archetype_meta\` direct (hydrated da PR #1916)

## QW-3 — \`apps/play/src/nestHub.js\` (+~240 LOC)
- TAB_IDS esteso: squad/mating/**mutations**/lineage/codex (5 tab canonical)
- Nuovo tab 🧪 Mutations (button + panel + CSS)
- Selector unit (party member ★ + squad members)
- Refresh-btn + auto-refresh on \`switchTab('mutations')\`
- Lista mutation eligible (name + tier + body_slot chip + MP cost + Apply btn disabled se mp insufficiente)
- Bingo grid 5 categories con counts /3 + ✓ se completed
- Apply handler: optimistic UI patch + status feedback

## \`apps/play/src/api.js\` (+11 LOC)
- \`mutationsRegistry\` / \`mutationsEligible\` / \`mutationsApply\` / \`mutationsBingo\` client methods

## Test plan
- [x] \`node --test tests/api/nestHub.test.js tests/api/mutationsRoutes.test.js\` → 15/15 ✓
- [x] TAB_IDS test updated 4→5 canonical
- [x] Prettier ok

## Player loop completo post-merge
encounter → MP grant toast (PR #1917) → apri characterPanel vede MP+archetipi → apri Nido > Mutations vede eligible con cost → applica → ability emerge + bingo state aggiorna live.

## Engine wired DoD checklist Spore Moderate
- ✅ Backend engine S1+S2+S3+S6 complete
- ✅ MP grant toast post-encounter (#1917)
- ✅ MP badge characterPanel (this PR)
- ✅ Mutations apply UI nestHub (this PR)
- ⏳ Resolver consumption DR/init/sight (PR #1920 stack)
- 🔮 Lineage propagation (PR #1918 stack — S5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)