### PR TITLE
feat(codex): Tunic decipher glyph progression — §H.4 ADOPT (5 glyphs + 2 pages)

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -23,6 +23,7 @@ const { createFeedbackRouter } = require('./routes/feedback');
 const { createPartyRouter } = require('./routes/party');
 const { createCampaignRouter } = require('./routes/campaign');
 const { createRewardsRouter } = require('./routes/rewards');
+const { createCodexRouter } = require('./routes/codex');
 const { createFormPackRouter } = require('./routes/formPackRoutes');
 const { createLobbyRouter } = require('./routes/lobby');
 const { createCoopRouter } = require('./routes/coop');
@@ -753,6 +754,8 @@ function createApp(options = {}) {
   app.use('/api', createCampaignRouter(options.campaign || {}));
   // V2 Tri-Sorgente post-match reward (2026-04-26 sprint V2)
   app.use('/api', createRewardsRouter());
+  // Tunic decipher Codex (2026-04-27 §H.4 ADOPT) — glyph language progression
+  app.use('/api', createCodexRouter());
   // V4 PI-Pacchetti tematici (2026-04-26 sprint V4) — form recommend expose
   app.use('/api', createFormPackRouter());
   // M11 Phase A: Jackbox-style co-op lobby (ADR-2026-04-20).

--- a/apps/backend/routes/codex.js
+++ b/apps/backend/routes/codex.js
@@ -1,0 +1,58 @@
+// Codex routes — Tunic decipher pages + glyph progression.
+//
+// Endpoints:
+//   GET  /api/codex/glyphs?campaign_id=X        — list glyphs with state
+//   POST /api/codex/glyphs/increment             — { campaign_id, event, delta? }
+//   GET  /api/codex/page/:pageId?campaign_id=X   — render page with glyph state
+//
+// Source: docs/research/2026-04-27-indie-concept-rubabili.md (Tunic).
+// Decision: docs/reports/2026-04-27-stato-arte-completo-vertical-slice.md §H.4 ADOPT.
+
+'use strict';
+
+const { Router } = require('express');
+const tunic = require('../services/codex/tunicGlyphs');
+
+function createCodexRouter() {
+  const router = Router();
+
+  router.get('/codex/glyphs', (req, res) => {
+    const campaignId = req.query.campaign_id;
+    if (!campaignId) return res.status(400).json({ error: 'campaign_id query richiesto' });
+    const glyphs = tunic.listGlyphsForCampaign(campaignId);
+    const state = tunic.getCodexState(campaignId);
+    res.json({
+      campaign_id: campaignId,
+      glyphs,
+      counters: state.counters,
+      unlocked_count: state.unlocked.length,
+      total_count: glyphs.length,
+    });
+  });
+
+  router.post('/codex/glyphs/increment', (req, res) => {
+    const { campaign_id, event, delta = 1 } = req.body || {};
+    if (!campaign_id) return res.status(400).json({ error: 'campaign_id richiesto' });
+    if (!event) return res.status(400).json({ error: 'event richiesto' });
+    const result = tunic.incrementCounter(campaign_id, event, delta);
+    res.json({
+      campaign_id,
+      event,
+      delta: Number(delta) || 0,
+      counter: result.counter,
+      unlocked_new: result.unlocked_new,
+    });
+  });
+
+  router.get('/codex/page/:pageId', (req, res) => {
+    const campaignId = req.query.campaign_id;
+    if (!campaignId) return res.status(400).json({ error: 'campaign_id query richiesto' });
+    const page = tunic.getPage(req.params.pageId, campaignId);
+    if (!page) return res.status(404).json({ error: `page '${req.params.pageId}' non trovata` });
+    res.json({ campaign_id: campaignId, page });
+  });
+
+  return router;
+}
+
+module.exports = { createCodexRouter };

--- a/apps/backend/services/codex/tunicGlyphs.js
+++ b/apps/backend/services/codex/tunicGlyphs.js
@@ -1,0 +1,141 @@
+// Tunic decipher Codex — backend logic.
+//
+// Source: docs/research/2026-04-27-indie-concept-rubabili.md (Tunic decipher pages).
+// Decision codified: docs/reports/2026-04-27-stato-arte-completo-vertical-slice.md §H.4 ADOPT.
+//
+// Pattern: glyph language progressively-decifrabile via gameplay events.
+// Player accumula counter per evento (attacks_executed, defends_executed,
+// mutations_applied, ally_adjacent_attacks, biomes_visited) → glyph unlock
+// quando counter >= threshold.
+//
+// API:
+//   loadGlyphs() → { glyphs, pages } da YAML
+//   getCodexState(campaignId) → { unlocked: [glyph_id], counters: { event: N } }
+//   incrementCounter(campaignId, event, delta=1) → { unlocked_new: [glyph_id] }
+//   listGlyphsForCampaign(campaignId) → glyphs annotated con state (locked/unlocked)
+//
+// State storage: in-memory Map per campaign_id (Prisma write-through TBD).
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const YAML_PATH = path.resolve(__dirname, '../../../../data/core/codex/tunic_glyphs.yaml');
+
+let _catalog = null;
+const _campaignState = new Map(); // campaign_id -> { unlocked: Set, counters: {} }
+
+function loadGlyphs() {
+  if (_catalog) return _catalog;
+  try {
+    const raw = fs.readFileSync(YAML_PATH, 'utf-8');
+    _catalog = yaml.load(raw);
+    return _catalog;
+  } catch (err) {
+    console.warn('[tunicGlyphs] config not loaded:', err.message);
+    _catalog = { glyphs: {}, pages: {} };
+    return _catalog;
+  }
+}
+
+function _ensureState(campaignId) {
+  let s = _campaignState.get(campaignId);
+  if (!s) {
+    s = { unlocked: new Set(), counters: {} };
+    _campaignState.set(campaignId, s);
+  }
+  return s;
+}
+
+function getCodexState(campaignId) {
+  const s = _ensureState(campaignId);
+  return {
+    unlocked: [...s.unlocked],
+    counters: { ...s.counters },
+  };
+}
+
+function _checkUnlocks(campaignId) {
+  const cat = loadGlyphs();
+  const s = _ensureState(campaignId);
+  const newlyUnlocked = [];
+  for (const [gid, g] of Object.entries(cat.glyphs || {})) {
+    if (s.unlocked.has(gid)) continue;
+    const cond = g.unlock_condition || {};
+    const ev = cond.event;
+    const thr = Number(cond.threshold || 0);
+    if (ev && (s.counters[ev] || 0) >= thr) {
+      s.unlocked.add(gid);
+      newlyUnlocked.push(gid);
+    }
+  }
+  return newlyUnlocked;
+}
+
+function incrementCounter(campaignId, event, delta = 1) {
+  if (!campaignId || !event) return { unlocked_new: [] };
+  const s = _ensureState(campaignId);
+  s.counters[event] = (s.counters[event] || 0) + Math.max(0, Number(delta) || 0);
+  const unlockedNew = _checkUnlocks(campaignId);
+  return { unlocked_new: unlockedNew, counter: s.counters[event] };
+}
+
+function listGlyphsForCampaign(campaignId) {
+  const cat = loadGlyphs();
+  const s = _ensureState(campaignId);
+  return Object.entries(cat.glyphs || {}).map(([gid, g]) => {
+    const isUnlocked = s.unlocked.has(gid);
+    return {
+      id: gid,
+      glyph: g.glyph,
+      label: isUnlocked ? g.label_unlocked : g.label_locked,
+      hint_unlock: g.hint_unlock,
+      description: isUnlocked ? g.description_unlocked : null,
+      unlocked: isUnlocked,
+      progress: {
+        event: g.unlock_condition?.event || null,
+        current: s.counters[g.unlock_condition?.event] || 0,
+        threshold: Number(g.unlock_condition?.threshold || 0),
+      },
+      page_id: g.page_id || null,
+    };
+  });
+}
+
+function getPage(pageId, campaignId) {
+  const cat = loadGlyphs();
+  const page = (cat.pages || {})[pageId];
+  if (!page) return null;
+  const s = _ensureState(campaignId);
+  // Render body con glyph references — locked glyphs shown as bare symbol,
+  // unlocked glyphs shown as label text. Pattern Tunic decifer.
+  return {
+    id: pageId,
+    title_it: page.title_it,
+    body_it: page.body_it,
+    glyphs_referenced: (page.glyphs_referenced || []).map((gid) => {
+      const g = (cat.glyphs || {})[gid];
+      return {
+        id: gid,
+        glyph: g?.glyph || gid,
+        unlocked: s.unlocked.has(gid),
+      };
+    }),
+  };
+}
+
+function _resetState() {
+  _campaignState.clear();
+  _catalog = null;
+}
+
+module.exports = {
+  loadGlyphs,
+  getCodexState,
+  incrementCounter,
+  listGlyphsForCampaign,
+  getPage,
+  _resetState,
+};

--- a/data/core/codex/tunic_glyphs.yaml
+++ b/data/core/codex/tunic_glyphs.yaml
@@ -1,0 +1,109 @@
+# Tunic decipher Codex — pilot 5 glyph progressively-decipherable.
+#
+# Source: docs/research/2026-04-27-indie-concept-rubabili.md (Tunic decipher pages).
+# Decision codified: docs/reports/2026-04-27-stato-arte-completo-vertical-slice.md §H.4 ADOPT.
+#
+# Pattern: glyph language inizialmente locked (mostra glyph art come simbolo
+# ma description criptica). Gameplay events trigger unlock (decifrazione
+# progressiva). 1 page sample come narrative beat.
+#
+# Schema:
+#   glyph_id: { glyph: '◆', label_locked, label_unlocked, hint_unlock,
+#               unlock_condition: { event, threshold }, page_id }
+#
+# unlock_condition events:
+#   attacks_executed | defends_executed | mutations_applied |
+#   ally_adjacent_attacks | biomes_visited | victories | session_count
+
+schema_version: '1.0'
+codex_id: tunic_glyphs
+
+glyphs:
+  glyph_attacco:
+    glyph: '◆'
+    label_locked: 'Glifo angolare ◆'
+    label_unlocked: 'Furia — predazione'
+    hint_unlock: 'Compi 5 attacchi'
+    description_unlocked: |
+      Il glifo angolare nasce quando la creatura si lancia in avanti.
+      Le specie predatrici lo incidono sui denti e sugli artigli.
+      Suo opposto: glifo curvo (difesa).
+    unlock_condition:
+      event: attacks_executed
+      threshold: 5
+    page_id: page_predazione
+
+  glyph_difesa:
+    glyph: '◖'
+    label_locked: 'Glifo curvo ◖'
+    label_unlocked: 'Scudo — postura'
+    hint_unlock: 'Difendi 3 volte'
+    description_unlocked: |
+      La curva è un fianco esposto trasformato in muro. I corpi
+      che proteggono altri lasciano questa traccia. Suo opposto:
+      glifo angolare (predazione).
+    unlock_condition:
+      event: defends_executed
+      threshold: 3
+    page_id: page_postura
+
+  glyph_evoluzione:
+    glyph: '✺'
+    label_locked: 'Glifo radiante ✺'
+    label_unlocked: 'Mutamento — radice'
+    hint_unlock: 'Applica 1 mutazione'
+    description_unlocked: |
+      Il glifo radiante è la firma del cambiamento. Ogni raggio è
+      una scelta diversa che il corpo prende sotto pressione del
+      bioma. Le mutazioni lo accendono.
+    unlock_condition:
+      event: mutations_applied
+      threshold: 1
+    page_id: page_mutamento
+
+  glyph_alleanza:
+    glyph: '⌬'
+    label_locked: 'Glifo intrecciato ⌬'
+    label_unlocked: 'Vincolo — eco'
+    hint_unlock: 'Alleato adiacente attacca'
+    description_unlocked: |
+      Quando due creature combattono fianco a fianco, le loro
+      tracce si intrecciano. Il glifo intrecciato segna un legame
+      che amplifica entrambe.
+    unlock_condition:
+      event: ally_adjacent_attacks
+      threshold: 1
+    page_id: page_vincolo
+
+  glyph_mistero:
+    glyph: '⌑'
+    label_locked: 'Glifo cavo ⌑'
+    label_unlocked: 'Soglia — bioma'
+    hint_unlock: 'Visita 3 biomi diversi'
+    description_unlocked: |
+      Il glifo cavo è una soglia tra ambienti. Si rivela solo
+      a chi attraversa più biomi e ne osserva i bordi. Lega
+      la mappa al codex.
+    unlock_condition:
+      event: biomes_visited
+      threshold: 3
+    page_id: page_soglia
+
+# Page sample — composizione narrative beat con glyph references.
+# Player vede pagina con glyph misti (locked = simbolo only, unlocked = full text).
+pages:
+  page_predazione:
+    title_it: 'Sul cacciatore'
+    body_it: |
+      Quando la creatura ◆, il bioma ricorda. Non è la fame
+      — è la geometria della spinta. Il ◆ resta inciso nei
+      passi, finché un altro ◖ non lo cancella.
+    glyphs_referenced: [glyph_attacco, glyph_difesa]
+
+  page_mutamento:
+    title_it: 'Sulle mutazioni'
+    body_it: |
+      ✺ non è scelta. È pressione del bioma che trova un canale
+      libero. La creatura che cambia non sa di cambiare — solo
+      il glifo lo registra. Più ✺ accumuli, più la specie diverge.
+    glyphs_referenced: [glyph_evoluzione]

--- a/tests/services/tunicGlyphs.test.js
+++ b/tests/services/tunicGlyphs.test.js
@@ -1,0 +1,77 @@
+// Unit test for Tunic decipher Codex glyph progression.
+//
+// Source: docs/research/2026-04-27-indie-concept-rubabili.md (Tunic).
+// Decision: docs/reports/2026-04-27-stato-arte-completo-vertical-slice.md §H.4.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const tunic = require('../../apps/backend/services/codex/tunicGlyphs');
+
+test('initial state is empty', () => {
+  tunic._resetState();
+  const s = tunic.getCodexState('camp1');
+  assert.deepEqual(s.unlocked, []);
+  assert.deepEqual(s.counters, {});
+});
+
+test('incrementCounter triggers unlock at threshold', () => {
+  tunic._resetState();
+  const r1 = tunic.incrementCounter('camp1', 'attacks_executed', 4);
+  assert.deepEqual(r1.unlocked_new, [], 'no unlock below threshold');
+  assert.equal(r1.counter, 4);
+  const r2 = tunic.incrementCounter('camp1', 'attacks_executed', 1);
+  assert.deepEqual(r2.unlocked_new, ['glyph_attacco'], 'unlocks at threshold 5');
+  assert.equal(r2.counter, 5);
+});
+
+test('listGlyphsForCampaign distinguishes unlocked vs locked', () => {
+  tunic._resetState();
+  tunic.incrementCounter('camp2', 'attacks_executed', 5);
+  const glyphs = tunic.listGlyphsForCampaign('camp2');
+  const attacco = glyphs.find((g) => g.id === 'glyph_attacco');
+  const difesa = glyphs.find((g) => g.id === 'glyph_difesa');
+  assert.equal(attacco.unlocked, true);
+  assert.ok(attacco.description, 'unlocked has description');
+  assert.equal(difesa.unlocked, false);
+  assert.equal(difesa.description, null, 'locked has null description');
+});
+
+test('campaigns isolated', () => {
+  tunic._resetState();
+  tunic.incrementCounter('campA', 'attacks_executed', 5);
+  const sA = tunic.getCodexState('campA');
+  const sB = tunic.getCodexState('campB');
+  assert.equal(sA.unlocked.length, 1);
+  assert.equal(sB.unlocked.length, 0);
+});
+
+test('getPage shows glyph state per campaign', () => {
+  tunic._resetState();
+  tunic.incrementCounter('campC', 'attacks_executed', 5);
+  const page = tunic.getPage('page_predazione', 'campC');
+  assert.ok(page);
+  assert.equal(page.id, 'page_predazione');
+  assert.equal(page.glyphs_referenced.length, 2);
+  const attacco = page.glyphs_referenced.find((g) => g.id === 'glyph_attacco');
+  const difesa = page.glyphs_referenced.find((g) => g.id === 'glyph_difesa');
+  assert.equal(attacco.unlocked, true);
+  assert.equal(difesa.unlocked, false);
+});
+
+test('getPage returns null for unknown page', () => {
+  tunic._resetState();
+  assert.equal(tunic.getPage('page_inexistent', 'camp'), null);
+});
+
+test('multiple events accumulate independently', () => {
+  tunic._resetState();
+  tunic.incrementCounter('camp3', 'mutations_applied', 1);
+  tunic.incrementCounter('camp3', 'biomes_visited', 3);
+  const s = tunic.getCodexState('camp3');
+  assert.equal(s.counters.mutations_applied, 1);
+  assert.equal(s.counters.biomes_visited, 3);
+  assert.equal(s.unlocked.length, 2, 'glyph_evoluzione + glyph_mistero');
+});


### PR DESCRIPTION
## Summary

Bundle TBW + Tunic ADOPT (§H.4). TBW Undo libero **discovery: GIÀ SHIPPED 100%**. Questo PR ship solo Tunic Codex.

## TBW Undo libero — discovery

| Component | Status |
|---|---|
| Endpoint \`POST /api/session/clear-intent/:actorId\` | ✅ GIÀ shipped (\`sessionRoundBridge.js:1521\`) |
| Client \`api.clearIntent(sid, actorId)\` | ✅ GIÀ shipped (\`api.js:75\`) |
| ESC keyboard global cancel ALL intents | ✅ GIÀ wired (\`main.js:349\`) |
| \`handleCancelIntent(unitId)\` single unit | ✅ GIÀ wired (\`main.js:330\`) |

**Verdict**: TBW Undo libero pattern già completamente adopted end-to-end. Nessuna azione necessaria.

## Tunic decipher Codex — NEW

5 glyph pilot progressively-decifrabile via gameplay events:
- ◆ \`glyph_attacco\` → 5 attacchi → "Furia — predazione"
- ◖ \`glyph_difesa\` → 3 defends → "Scudo — postura"
- ✺ \`glyph_evoluzione\` → 1 mutation → "Mutamento — radice"
- ⌬ \`glyph_alleanza\` → 1 ally adjacent attack → "Vincolo — eco"
- ⌑ \`glyph_mistero\` → 3 biomi visitati → "Soglia — bioma"

3 endpoint REST:
- \`GET /api/codex/glyphs?campaign_id=X\`
- \`POST /api/codex/glyphs/increment\` { campaign_id, event, delta? }
- \`GET /api/codex/page/:pageId?campaign_id=X\`

Files: 5 nuovi (yaml + service + route + test + app.js wire).

## Test plan

- [x] \`node --test tests/services/tunicGlyphs.test.js\` → 7/7 verde
- [x] \`node --test tests/ai/*.test.js\` → 311/311 verde (regression)
- [x] \`python tools/check_docs_governance.py --strict\` → errors=0
- [x] Backend smoke: \`node -e "tunic.incrementCounter(...)\"\` → unlock check verde

## Note

Frontend codexPanel.js tab "Glifi" extension DEFER follow-up PR — backend API surface = Gate 5 compliant (endpoint exists for player via debug + CLI consumer + future UI integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)