### PR TITLE
feat(bundle-b): Citizen Sleeper drift briefing + Wildfrost counter HUD (2 indie quick-wins)

### DIFF
--- a/apps/play/src/render.js
+++ b/apps/play/src/render.js
@@ -376,6 +376,105 @@ function drawStatusIcons(ctx, unit, cx, yPxTop) {
   }
 }
 
+// 2026-04-27 Bundle B.4 — Wildfrost-style counter HUD badges.
+//
+// Disegna fino a 3 badge counter top-right del sprite tile (16x16 corner area).
+// Background semi-transparent (#000a) + numero bianco bold. Mostra in priority
+// order:
+//   1. ability_cooldowns (object map { ability_id: turns_remaining })
+//   2. reaction_cooldown_remaining (singolo numero)
+//   3. status duration numerica (panic, rage, stunned, ...)
+//
+// Hide se counter <= 0 o expired. Anti-pattern guard: max 3 badge per unit
+// (overflow indicator "+N" se più di 3).
+//
+// Ref Tactics Ogre HP bar pattern (PR #1901). Pattern source: Wildfrost
+// counter HUD — vedi docs/research/2026-04-27-indie-meccaniche-perfette.md §2.
+export function collectCounters(unit) {
+  const counters = [];
+  // 1. ability_cooldowns (object): { abilityId: turns }
+  const cds = unit.ability_cooldowns;
+  if (cds && typeof cds === 'object' && !Array.isArray(cds)) {
+    for (const [abilityId, turns] of Object.entries(cds)) {
+      const n = Number(turns);
+      if (Number.isFinite(n) && n > 0) {
+        counters.push({ kind: 'cd', label: String(n), tint: '#5b8def', key: abilityId });
+      }
+    }
+  }
+  // 2. reaction_cooldown_remaining (singolo)
+  const rxCd = Number(unit.reaction_cooldown_remaining || 0);
+  if (rxCd > 0) {
+    counters.push({ kind: 'cd', label: String(rxCd), tint: '#7c4dff', key: 'rx' });
+  }
+  // 3. status durations numeriche (es. panic:2, rage:3, bleeding:1)
+  const status = unit.status || {};
+  for (const [key, val] of Object.entries(status)) {
+    const n = Number(val);
+    if (Number.isFinite(n) && n > 0) {
+      counters.push({ kind: 'status', label: String(n), tint: '#ff7043', key });
+    }
+  }
+  return counters;
+}
+
+function drawCounterBadge(ctx, unit, cx, yPxTop) {
+  const counters = collectCounters(unit);
+  if (counters.length === 0) return;
+  const MAX = 3;
+  const display = counters.slice(0, MAX);
+  const overflow = counters.length - MAX;
+  const size = Math.max(14, Math.round(CELL * 0.18));
+  const gap = 2;
+  // Top-right corner: stack vertically going down from top edge.
+  // Right-align so badges don't collide with status icons (which start from cx + 18%).
+  const startX = cx + CELL * 0.5 - size - 2;
+  const startY = yPxTop + 2;
+  ctx.save();
+  ctx.font = `bold ${Math.max(9, Math.round(size * 0.62))}px "SF Mono", "Menlo", monospace`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  for (let i = 0; i < display.length; i++) {
+    const c = display[i];
+    const bx = startX;
+    const by = startY + i * (size + gap);
+    // Pill bg semi-transparent + tinted border per kind.
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.66)';
+    ctx.beginPath();
+    if (typeof ctx.roundRect === 'function') {
+      ctx.roundRect(bx, by, size, size, 3);
+    } else {
+      ctx.rect(bx, by, size, size);
+    }
+    ctx.fill();
+    ctx.strokeStyle = c.tint;
+    ctx.lineWidth = 1.2;
+    ctx.stroke();
+    // Counter number bianco bold.
+    ctx.fillStyle = '#fff';
+    ctx.fillText(c.label, bx + size / 2, by + size / 2 + 0.5);
+  }
+  // Overflow indicator "+N" (sotto al 3o badge).
+  if (overflow > 0) {
+    const bx = startX;
+    const by = startY + MAX * (size + gap);
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.66)';
+    ctx.beginPath();
+    if (typeof ctx.roundRect === 'function') {
+      ctx.roundRect(bx, by, size, size, 3);
+    } else {
+      ctx.rect(bx, by, size, size);
+    }
+    ctx.fill();
+    ctx.strokeStyle = '#ffd54f';
+    ctx.lineWidth = 1.2;
+    ctx.stroke();
+    ctx.fillStyle = '#fff';
+    ctx.fillText(`+${overflow}`, bx + size / 2, by + size / 2 + 0.5);
+  }
+  ctx.restore();
+}
+
 // QW4 — Lifecycle phase badge: pill scuro + abbrev (HJG/JUV/MTR/APX/LGC).
 // Posizione: bottom-right del tile. Tint ring color come bg, white text + outline.
 function drawLifecycleBadge(ctx, style, cx, yPxTop) {
@@ -638,6 +737,11 @@ function drawUnit(ctx, unit, gridH, highlight = {}) {
 
   // Status icons (top-right)
   if (!dead) drawStatusIcons(ctx, unit, cx, yPx * CELL);
+
+  // 2026-04-27 Bundle B.4 — counter badges (Wildfrost HUD).
+  // Stacked top-right area, accanto agli status icon. ability_cooldowns +
+  // reaction_cooldown_remaining + status duration. Skip se nessun counter.
+  if (!dead) drawCounterBadge(ctx, unit, cx, yPx * CELL);
 
   // QW4 — Lifecycle phase badge (bottom-right, sotto al corpo). Skiv-style:
   // hatchling/juvenile/mature/apex/legacy abbrev su pill scuro.

--- a/data/core/narrative/briefings/drift_briefings.yaml
+++ b/data/core/narrative/briefings/drift_briefings.yaml
@@ -1,0 +1,75 @@
+# Drift briefings — Citizen Sleeper-inspired condizionale su VC axes
+#
+# Pattern source: Citizen Sleeper drift dialogue (Disco Elysium-lite),
+# briefing_pre tutorial gated su MBTI T_F asse del player aggregate.
+#
+# Threshold canonici (gating logic in narrativeEngine.driftBriefing):
+#   - mbti_axes.T_F.value > 0.65  → variant `tech`     (efficienza, sistema)
+#   - mbti_axes.T_F.value < 0.35  → variant `empatic`  (team, persone)
+#   - else                        → variant `neutral`  (sopravvivenza)
+#
+# Threshold simmetrici 0.65/0.35 sono coerenti con dead-band MBTI iter1
+# (vedi services/vcScoring.js deriveMbtiType §events_count<30 → 0.35/0.65).
+#
+# Anti-pattern guard: max 3 varianti per scenario (no combinatorial blowup).
+#
+# Extension scope:
+#   - 3 scenari tutorial (01, 02, 03) → 9 stitches totali
+#   - Solo phase `pre` (drift gating sufficient for onboarding briefing)
+#   - Solo asse T_F (B.1 minimal scope; ennea/altri axes deferred)
+#
+# Companion docs:
+#   - docs/research/2026-04-27-indie-narrative-gameplay.md §1
+#   - docs/reports/2026-04-27-indie-research-classification.md §B.1
+
+schema_version: '1.0'
+
+scenarios:
+  enc_tutorial_01:
+    pre:
+      tech: |
+        Rapporto sintetico — ostili: 2 nomadi predoni. Posizione: savana
+        aperta, copertura assente. Range medio. Vettore d'ingaggio
+        ottimale: lato sopravento, eliminazione sequenziale dal fianco
+        di minore rateo di reazione.
+      empatic: |
+        Due nomadi spaesati nella savana. Hanno paura quanto te. Stanno
+        cercando di sopravvivere — e adesso anche tu. Risolvi rapidamente,
+        nessuno di voi merita di trascinare la cosa per le lunghe.
+      neutral: |
+        Due predoni hanno preso posizione nella savana. Avvicinati con
+        cautela e neutralizza la minaccia. La via deve restare libera.
+
+  enc_tutorial_02:
+    pre:
+      tech: |
+        Rilevata pattuglia mista — 2 unità leggere + 1 cacciatore corazzato.
+        Stima resistenza fisica del cacciatore: +40%. Concentrazione di
+        fuoco sul bersaglio prioritario causa collasso del coordinamento
+        della pattuglia. Procedere con priorità sequenziale.
+      empatic: |
+        Hanno mandato anche il loro più anziano — un cacciatore corazzato.
+        Spera di non doverlo colpire per primo. Forse, se i due leggeri
+        cadono prima, lui si arrenderà. Forse no. Decidi tu come finire la
+        scena.
+      neutral: |
+        Pattuglia nomade: 2 leggeri + 1 cacciatore corazzato. Coordina
+        scout e tank. Il danno asimmetrico premia chi sceglie il bersaglio
+        giusto al momento giusto.
+
+  enc_tutorial_03:
+    pre:
+      tech: |
+        Caverna risonante: 2 hazard tile attivi (fumarole tossiche, danno
+        1/turno se occupate). Guardiani locali: immuni. Path-planning
+        critico — ogni casella di esposizione è un costo opportunità.
+        Ottimizza la rotta.
+      empatic: |
+        La caverna respira veleno. Le creature ci sono nate dentro —
+        è la loro casa, non la tua. Non sei l'invasore di nessuno per
+        scelta, ma lo sei diventato per necessità. Muoviti veloce, esci
+        viva, lascia loro il silenzio.
+      neutral: |
+        Caverna risonante con due fumarole attive. Le creature locali
+        resistono al gas; voi no. Posizionate con cura e usate combo per
+        finire in fretta.

--- a/services/narrative/narrativeEngine.js
+++ b/services/narrative/narrativeEngine.js
@@ -16,9 +16,92 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const yaml = require('js-yaml');
 const { Story } = require('inkjs');
 
 const NARRATIVES_DIR = path.resolve(__dirname, '../../data/narrative');
+
+// 2026-04-27 Bundle B.1 — Citizen Sleeper-style drift briefing pack.
+// Lightweight YAML pack (3 scenarios × 3 variants) gated su MBTI T_F asse.
+// Separato da data/narrative/tutorial_briefings.yaml (engine briefingVariations
+// usa quello). Drift è gating dedicato player-aggregate, non per-replay.
+const DRIFT_BRIEFINGS_DIR = path.resolve(__dirname, '../../data/core/narrative/briefings');
+const DRIFT_BRIEFINGS_DEFAULT = path.join(DRIFT_BRIEFINGS_DIR, 'drift_briefings.yaml');
+
+let _driftPackCache = null;
+
+function _loadDriftPack(pathOverride = null) {
+  if (pathOverride === null && _driftPackCache !== null) return _driftPackCache;
+  const target = pathOverride || DRIFT_BRIEFINGS_DEFAULT;
+  try {
+    const raw = fs.readFileSync(target, 'utf-8');
+    const parsed = yaml.load(raw);
+    if (!parsed || typeof parsed !== 'object' || !parsed.scenarios) return null;
+    if (pathOverride === null) _driftPackCache = parsed;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** Test hook — invalida cache pack drift. */
+function _resetDriftPackCache() {
+  _driftPackCache = null;
+}
+
+/**
+ * Citizen Sleeper drift gating: classifica un VC snapshot in 3 varianti
+ * basate sul T_F MBTI asse aggregato (mean across actors). Threshold simmetrici
+ * 0.65 / 0.35 coerenti con dead-band MBTI iter1 (vedi services/vcScoring.js
+ * deriveMbtiType, events_count<30 → 0.35/0.65).
+ *
+ * @param {object} vcSnapshot — snapshot da buildVcSnapshot (può essere null)
+ * @returns {'tech'|'empatic'|'neutral'} variant key
+ */
+function classifyDriftVariant(vcSnapshot) {
+  const perActor = vcSnapshot?.per_actor;
+  if (!perActor || typeof perActor !== 'object') return 'neutral';
+  const tfValues = [];
+  for (const actor of Object.values(perActor)) {
+    const tf = actor?.mbti_axes?.T_F;
+    if (tf && typeof tf.value === 'number' && Number.isFinite(tf.value)) {
+      tfValues.push(tf.value);
+    }
+  }
+  if (tfValues.length === 0) return 'neutral';
+  const mean = tfValues.reduce((a, b) => a + b, 0) / tfValues.length;
+  if (mean > 0.65) return 'tech';
+  if (mean < 0.35) return 'empatic';
+  return 'neutral';
+}
+
+/**
+ * Bundle B.1 main: seleziona briefing pre-mission per (scenario, vcSnapshot).
+ * Pattern: Citizen Sleeper drift dialogue gated su MBTI T_F.
+ *
+ * @param {string} scenarioId — es. "enc_tutorial_01"
+ * @param {object|null} vcSnapshot — output di buildVcSnapshot (null OK → neutral)
+ * @param {object} [opts]
+ * @param {string|null} [opts.fallback] — testo da ritornare se pack manca
+ * @param {object|null} [opts.pack] — pack precaricato (test hook)
+ * @returns {{ variant: 'tech'|'empatic'|'neutral', text: string, source: 'drift'|'fallback' }|null}
+ */
+function selectDriftBriefing(scenarioId, vcSnapshot, opts = {}) {
+  const fallback = opts.fallback ?? null;
+  const pack = opts.pack || _loadDriftPack();
+  const variant = classifyDriftVariant(vcSnapshot);
+  const stitches = pack?.scenarios?.[scenarioId]?.pre;
+  if (!stitches || typeof stitches !== 'object') {
+    return fallback ? { variant, text: fallback, source: 'fallback' } : null;
+  }
+  const text = stitches[variant] || stitches.neutral || fallback;
+  if (!text) return null;
+  return {
+    variant,
+    text: String(text).trim(),
+    source: pack ? 'drift' : 'fallback',
+  };
+}
 
 /**
  * Carica e inizializza una Story inkjs da file JSON.
@@ -203,6 +286,8 @@ function _resetMbtiPaletteCache() {
 
 module.exports = {
   NARRATIVES_DIR,
+  DRIFT_BRIEFINGS_DIR,
+  DRIFT_BRIEFINGS_DEFAULT,
   loadStory,
   bindSessionData,
   runUntilChoice,
@@ -212,5 +297,8 @@ module.exports = {
   listStories,
   tagDialogueLineWithMbti,
   extractMbtiAxisFromTags,
+  classifyDriftVariant,
+  selectDriftBriefing,
   _resetMbtiPaletteCache,
+  _resetDriftPackCache,
 };

--- a/services/narrative/narrativeRoutes.js
+++ b/services/narrative/narrativeRoutes.js
@@ -22,6 +22,7 @@ const {
   makeChoice,
   listStories,
   saveState,
+  selectDriftBriefing,
 } = require('./narrativeEngine');
 const {
   drawEvent: qbnDrawEvent,
@@ -103,6 +104,48 @@ function createNarrativeRouter() {
         return res.status(404).json({ error: 'story not found' });
       }
       res.json({ storyId, stateJson: saveState(story) });
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  // ── Drift briefing (Bundle B.1 — Citizen Sleeper drift gating) ─────
+  //
+  // POST /briefing/drift
+  //   body: { session_id?, scenario_id, vc_snapshot?, fallback? }
+  //   → { variant, text, source, scenario_id, session_id }
+  //
+  // Selects pre-mission briefing variant (tech / empatic / neutral) basato su
+  // MBTI T_F mean del vc_snapshot fornito. session_id è opzionale (telemetry
+  // tag only — il route non accede direttamente al session store per
+  // mantenere boundary clean tra narrative e session router).
+  //
+  // Caller pattern: client legge GET /api/session/:id/vc → estrae snapshot →
+  // POST /api/v1/narrative/briefing/drift con vc_snapshot inline.
+  router.post('/briefing/drift', (req, res) => {
+    try {
+      const body = req.body || {};
+      const { session_id = null, scenario_id, vc_snapshot = null, fallback = null } = body;
+      if (!scenario_id || typeof scenario_id !== 'string') {
+        return res.status(400).json({ error: 'scenario_id required (string)' });
+      }
+      if (vc_snapshot !== null && (typeof vc_snapshot !== 'object' || Array.isArray(vc_snapshot))) {
+        return res.status(400).json({ error: 'vc_snapshot must be object or null' });
+      }
+      const result = selectDriftBriefing(scenario_id, vc_snapshot, { fallback });
+      if (!result) {
+        return res.status(404).json({
+          error: 'no briefing pack entry for scenario_id',
+          scenario_id,
+        });
+      }
+      res.json({
+        session_id,
+        scenario_id,
+        variant: result.variant,
+        text: result.text,
+        source: result.source,
+      });
     } catch (err) {
       res.status(500).json({ error: err.message });
     }

--- a/tests/api/narrativeBriefingDrift.test.js
+++ b/tests/api/narrativeBriefingDrift.test.js
@@ -1,0 +1,141 @@
+// Bundle B.1 — Citizen Sleeper drift briefing endpoint integration test.
+//
+// Endpoint: POST /api/v1/narrative/briefing/drift
+// Gating:
+//   - mbti_axes.T_F.value > 0.65 → variant 'tech'
+//   - mbti_axes.T_F.value < 0.35 → variant 'empatic'
+//   - else (or missing snapshot) → variant 'neutral'
+//
+// Pack source: data/core/narrative/briefings/drift_briefings.yaml (3 scenarios).
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+function makeSnapshot(tfValue) {
+  return {
+    session_id: 'test-session',
+    per_actor: {
+      u_alpha: {
+        mbti_axes: {
+          T_F: { value: tfValue, coverage: 'full' },
+        },
+      },
+    },
+  };
+}
+
+test('POST /api/v1/narrative/briefing/drift — T_F > 0.65 → tech variant', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const r = await request(app)
+    .post('/api/v1/narrative/briefing/drift')
+    .send({
+      session_id: 'sess-1',
+      scenario_id: 'enc_tutorial_01',
+      vc_snapshot: makeSnapshot(0.8),
+    });
+  assert.equal(r.status, 200);
+  assert.equal(r.body.variant, 'tech');
+  assert.equal(r.body.scenario_id, 'enc_tutorial_01');
+  assert.equal(r.body.session_id, 'sess-1');
+  assert.equal(r.body.source, 'drift');
+  assert.match(r.body.text, /Rapporto sintetico|Range medio|sopravento/i);
+});
+
+test('POST /api/v1/narrative/briefing/drift — T_F < 0.35 → empatic variant', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const r = await request(app)
+    .post('/api/v1/narrative/briefing/drift')
+    .send({
+      session_id: 'sess-2',
+      scenario_id: 'enc_tutorial_02',
+      vc_snapshot: makeSnapshot(0.15),
+    });
+  assert.equal(r.status, 200);
+  assert.equal(r.body.variant, 'empatic');
+  assert.match(r.body.text, /anziano|paura|spera/i);
+});
+
+test('POST /api/v1/narrative/briefing/drift — T_F mid-range → neutral variant', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const r = await request(app)
+    .post('/api/v1/narrative/briefing/drift')
+    .send({
+      session_id: 'sess-3',
+      scenario_id: 'enc_tutorial_03',
+      vc_snapshot: makeSnapshot(0.5),
+    });
+  assert.equal(r.status, 200);
+  assert.equal(r.body.variant, 'neutral');
+  assert.match(r.body.text, /caverna|fumarole|combo/i);
+});
+
+test('POST /api/v1/narrative/briefing/drift — missing vc_snapshot → neutral fallback', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const r = await request(app).post('/api/v1/narrative/briefing/drift').send({
+    scenario_id: 'enc_tutorial_01',
+  });
+  assert.equal(r.status, 200);
+  assert.equal(r.body.variant, 'neutral');
+  assert.equal(r.body.session_id, null);
+  assert.ok(r.body.text.length > 0);
+});
+
+test('POST /api/v1/narrative/briefing/drift — missing scenario_id → 400', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const r = await request(app)
+    .post('/api/v1/narrative/briefing/drift')
+    .send({ session_id: 'sess-x' });
+  assert.equal(r.status, 400);
+  assert.match(r.body.error, /scenario_id/);
+});
+
+test('POST /api/v1/narrative/briefing/drift — unknown scenario → 404 (no fallback)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const r = await request(app)
+    .post('/api/v1/narrative/briefing/drift')
+    .send({
+      scenario_id: 'enc_unknown_99',
+      vc_snapshot: makeSnapshot(0.5),
+    });
+  assert.equal(r.status, 404);
+  assert.match(r.body.error, /no briefing pack/i);
+});
+
+test('POST /api/v1/narrative/briefing/drift — malformed vc_snapshot (array) → 400', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const r = await request(app)
+    .post('/api/v1/narrative/briefing/drift')
+    .send({
+      scenario_id: 'enc_tutorial_01',
+      vc_snapshot: [1, 2, 3],
+    });
+  assert.equal(r.status, 400);
+  assert.match(r.body.error, /vc_snapshot/);
+});

--- a/tests/services/render-counterBadge.test.js
+++ b/tests/services/render-counterBadge.test.js
@@ -1,0 +1,91 @@
+// 2026-04-27 Bundle B.4 — Wildfrost counter HUD (collectCounters helper).
+//
+// Test pure helper export da apps/play/src/render.js:
+//   - collectCounters(unit) → Array<{ kind, label, tint, key }>
+//
+// drawCounterBadge richiede CanvasRenderingContext2D — non testabile DOM-free.
+// Smoke visual = launcher live (fuori scope test). Logic gating + priority
+// + overflow guard testati via collectCounters direttamente.
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+async function loadRender() {
+  return import('../../apps/play/src/render.js');
+}
+
+describe('collectCounters — Bundle B.4 priority + overflow', () => {
+  test('unit senza counter → array vuoto', async () => {
+    const { collectCounters } = await loadRender();
+    assert.deepEqual(collectCounters({}), []);
+    assert.deepEqual(collectCounters({ status: {}, ability_cooldowns: {} }), []);
+  });
+
+  test('ability_cooldowns map → 1 badge per cd > 0', async () => {
+    const { collectCounters } = await loadRender();
+    const result = collectCounters({
+      ability_cooldowns: { fireball: 2, heal: 3, expired_ability: 0 },
+    });
+    assert.equal(result.length, 2);
+    assert.ok(result.every((c) => c.kind === 'cd'));
+    assert.deepEqual(result.map((c) => c.label).sort(), ['2', '3']);
+  });
+
+  test('reaction_cooldown_remaining > 0 → 1 badge cd kind', async () => {
+    const { collectCounters } = await loadRender();
+    const result = collectCounters({ reaction_cooldown_remaining: 1 });
+    assert.equal(result.length, 1);
+    assert.equal(result[0].kind, 'cd');
+    assert.equal(result[0].label, '1');
+    assert.equal(result[0].key, 'rx');
+  });
+
+  test('status numerica > 0 → status badge', async () => {
+    const { collectCounters } = await loadRender();
+    const result = collectCounters({ status: { panic: 2, rage: 3, expired: 0 } });
+    assert.equal(result.length, 2);
+    assert.ok(result.every((c) => c.kind === 'status'));
+  });
+
+  test('mixed inputs preservano priority order (cd → rx → status)', async () => {
+    const { collectCounters } = await loadRender();
+    const result = collectCounters({
+      ability_cooldowns: { fireball: 2 },
+      reaction_cooldown_remaining: 1,
+      status: { panic: 3 },
+    });
+    assert.equal(result.length, 3);
+    assert.equal(result[0].kind, 'cd');
+    assert.equal(result[1].key, 'rx');
+    assert.equal(result[2].kind, 'status');
+  });
+
+  test('overflow > 3 counter ancora presenti in array (drawCounterBadge troncherà a 3 + indicator)', async () => {
+    const { collectCounters } = await loadRender();
+    const result = collectCounters({
+      ability_cooldowns: { a: 1, b: 2, c: 3, d: 4 },
+      status: { panic: 1, rage: 1 },
+    });
+    // Tutti 6 raccolti: caller (drawCounterBadge) applica MAX=3 + overflow indicator.
+    assert.equal(result.length, 6);
+  });
+
+  test('valori non finiti / non numerici filtrati out', async () => {
+    const { collectCounters } = await loadRender();
+    const result = collectCounters({
+      ability_cooldowns: { x: 'foo', y: NaN, z: -1, ok: 2 },
+      status: { panic: null, rage: undefined, focused: 1 },
+    });
+    // Solo x:'foo' (NaN), y:NaN, z:-1 filtrati; ok:2 + focused:1 mantenuti.
+    assert.equal(result.length, 2);
+    assert.deepEqual(result.map((c) => c.key).sort(), ['focused', 'ok']);
+  });
+
+  test('ability_cooldowns array invece di object → ignorato (defensive)', async () => {
+    const { collectCounters } = await loadRender();
+    const result = collectCounters({ ability_cooldowns: [1, 2, 3] });
+    assert.deepEqual(result, []);
+  });
+});


### PR DESCRIPTION
## Summary

Bundle B "small" — 2 indie pattern quick-wins shipped in 1 PR (~7h target).

### Pattern B.1 — Citizen Sleeper drift briefing (~3h, P4 critical)

Briefing tutorial pre-mission gated su MBTI T_F asse aggregato del session vcSnapshot. Pattern source: Citizen Sleeper drift dialogue (Disco Elysium-lite).

- **New endpoint**: `POST /api/v1/narrative/briefing/drift`
  - Body: `{ session_id?, scenario_id, vc_snapshot?, fallback? }`
  - Returns: `{ session_id, scenario_id, variant: 'tech'|'empatic'|'neutral', text, source }`
- **Gating** (threshold simmetrici 0.65/0.35 coerenti con dead-band MBTI iter1):
  - `mbti_axes.T_F.value > 0.65` → variant `tech` (efficienza, sistema)
  - `mbti_axes.T_F.value < 0.35` → variant `empatic` (team, persone)
  - else (or null/missing) → variant `neutral` (sopravvivenza)
- **Pack**: `data/core/narrative/briefings/drift_briefings.yaml` — 3 scenari × 3 varianti = 9 stitches (tutorial 01-03)
- **Helper exports** in `services/narrative/narrativeEngine.js`: `selectDriftBriefing`, `classifyDriftVariant`, `_resetDriftPackCache`

**Anti-pattern guard**: max 3 varianti per knot (no combinatorial explosion). Solo asse T_F (B.1 minimal scope; ennea/altri axes deferred).

**Boundary note**: route accetta `vc_snapshot` inline invece di lookup cross-router su sessions Map. Mantiene clean separation tra narrative router e session router (no closure leak).

### Pattern B.4 — Wildfrost counter HUD (~4h, P1 reinforce)

Badge counter sopra sprite per ability cooldown + status duration. Mirror pattern Tactics Ogre HP bar (PR #1901 già shipped).

- **New helpers** in `apps/play/src/render.js`: `collectCounters(unit)` + `drawCounterBadge(ctx, unit, cx, yPxTop)`
- **Wired** in `drawUnit()` accanto a `drawStatusIcons` (top-right corner area)
- **Priority order**:
  1. `unit.ability_cooldowns` (object map `{ ability_id: turns_remaining }`)
  2. `unit.reaction_cooldown_remaining` (singolo numero)
  3. `unit.status` durations numeriche (panic, rage, stunned, ...)
- **Visual**: pill scura semi-transparent (rgba 0.66) + tinted border per kind (cd=blu, rx=viola, status=arancione) + numero bianco bold monospace
- **Anti-pattern guards**: max 3 badge per unit + overflow indicator "+N", defensive ignore di array/non-numeric values, hide se counter <= 0

**Anti-pattern**: NON copiata l'estetica kawaii Wildfrost. Pattern meccanico isolabile.

## Test plan

- [x] `node --test tests/api/narrativeBriefingDrift.test.js` — 7/7 pass (T>0.65 / T<0.35 / mid / missing snapshot / missing scenario_id / unknown scenario / malformed)
- [x] `node --test tests/services/render-counterBadge.test.js` — 8/8 pass (empty / cd map / rx single / status / mixed priority / overflow / non-finite filter / array defensive)
- [x] `node --test tests/ai/*.test.js` — 311/311 pass (zero regression)
- [x] `npx prettier --check` — all 6 modified files clean
- [ ] Smoke playtest live: launcher con unit `{ ability_cooldowns: { fireball: 2 } }` → badge visibile top-right (manual, deferred)

## Collision flag

Working tree contained uncommitted changes from parallel agent on `feat/bundle-b-big-undo-codex-2026-04-27` (sessionRoundBridge.js, apps/play/index.html, apps/play/src/api.js, apps/play/src/main.js, apps/play/src/style.css, tests/api/sessionUndo.test.js). Those files were NOT committed in this PR — left untouched for the other agent to commit on their own branch. No file overlap with my Bundle B small changes (render.js diff verified pure, no collision).

## Refs

- `docs/research/2026-04-27-indie-narrative-gameplay.md` §1 (Citizen Sleeper)
- `docs/research/2026-04-27-indie-meccaniche-perfette.md` §2 (Wildfrost)
- `docs/reports/2026-04-27-indie-research-classification.md` §B.1 + §B.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)