### PR TITLE
feat(bundle-b): TBW Undo libero + Tunic decipher Codex (2 indie quick-wins)

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -780,6 +780,10 @@ function createApp(options = {}) {
   // tools/py/skiv_monitor.py via .github/workflows/skiv-monitor.yml.
   app.use('/api', createSkivRouter(options.skiv || {}));
 
+  // Bundle B.3 codex routes già registrate sopra (line 758) — single
+  // createCodexRouter() ora ospita BOTH glyph-progression (PR #1931) +
+  // session decipher pages (Bundle B.3).
+
   app.get('/api/deployments/status', async (req, res) => {
     try {
       const refresh = shouldRefreshStatusFlag(req.query.refresh);

--- a/apps/backend/routes/codex.js
+++ b/apps/backend/routes/codex.js
@@ -1,20 +1,33 @@
 // Codex routes — Tunic decipher pages + glyph progression.
 //
-// Endpoints:
+// Endpoints (campaign-scope, glyph progression — PR #1931):
 //   GET  /api/codex/glyphs?campaign_id=X        — list glyphs with state
 //   POST /api/codex/glyphs/increment             — { campaign_id, event, delta? }
 //   GET  /api/codex/page/:pageId?campaign_id=X   — render page with glyph state
 //
+// Endpoints (session-scope, decipher pages — Bundle B.3):
+//   GET  /api/v1/codex/pages?session_id=        — list pages with deciphered flag
+//   POST /api/v1/codex/decipher                 — { session_id, page_id, trigger_data }
+//
 // Source: docs/research/2026-04-27-indie-concept-rubabili.md (Tunic).
 // Decision: docs/reports/2026-04-27-stato-arte-completo-vertical-slice.md §H.4 ADOPT.
+//
+// Entrambi gli endpoint set coesistono — campaign-scope (long-lived glyph
+// counter) e session-scope (per-session decipher state) sono complementari,
+// non overlap. Glyph counter accumula cross-encounter (kill_species,
+// enter_biome ecc), decipher pages = blurred→clear toggle per session
+// corrente.
 
 'use strict';
 
 const { Router } = require('express');
 const tunic = require('../services/codex/tunicGlyphs');
+const codexState = require('../services/codex/codexState');
 
 function createCodexRouter() {
   const router = Router();
+
+  // ─── Campaign-scope glyph progression (PR #1931) ─────────────────────────
 
   router.get('/codex/glyphs', (req, res) => {
     const campaignId = req.query.campaign_id;
@@ -50,6 +63,53 @@ function createCodexRouter() {
     const page = tunic.getPage(req.params.pageId, campaignId);
     if (!page) return res.status(404).json({ error: `page '${req.params.pageId}' non trovata` });
     res.json({ campaign_id: campaignId, page });
+  });
+
+  // ─── Session-scope decipher pages (Bundle B.3) ───────────────────────────
+
+  router.get('/v1/codex/pages', (req, res) => {
+    const sessionId = req.query?.session_id;
+    if (!sessionId) {
+      return res.status(400).json({ error: 'session_id richiesto (query string)' });
+    }
+    const pages = codexState.listPagesForSession(String(sessionId));
+    res.json({
+      session_id: String(sessionId),
+      pages,
+      total: pages.length,
+      deciphered_count: pages.filter((p) => p.deciphered).length,
+    });
+  });
+
+  router.post('/v1/codex/decipher', (req, res) => {
+    const body = req.body || {};
+    const { session_id: sessionId, page_id: pageId, trigger_data: triggerData } = body;
+    if (!sessionId) {
+      return res.status(400).json({ error: 'session_id richiesto' });
+    }
+    if (!pageId) {
+      return res.status(400).json({ error: 'page_id richiesto' });
+    }
+    const page = codexState.findPage(pageId);
+    if (!page) {
+      return res.status(404).json({ error: `page_id "${pageId}" non trovato` });
+    }
+    const valid = codexState.validateTrigger(page, triggerData || {});
+    if (!valid) {
+      return res.status(409).json({
+        error: 'trigger_data non soddisfa decipher_trigger della pagina',
+        code: 'TRIGGER_MISMATCH',
+        expected: page.decipher_trigger || null,
+      });
+    }
+    const { added } = codexState.markDeciphered(String(sessionId), pageId);
+    res.json({
+      session_id: String(sessionId),
+      page_id: pageId,
+      deciphered: true,
+      newly_added: added,
+      content: page.content_clear || '',
+    });
   });
 
   return router;

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -1541,6 +1541,72 @@ function createRoundBridge(deps) {
       }
     });
 
+    // Bundle B.2 — Tactical Breach Wizards Undo libero (2026-04-27).
+    // POP last main intent for actor (LIFO). Reactions preserved.
+    // Restricted to PHASE_PLANNING: undo dopo commit-round → 409.
+    // Empty stack → 200 no-op (idempotent UX).
+    router.post('/undo-action', (req, res, next) => {
+      try {
+        const body = req.body || {};
+        const sessionId = body.session_id;
+        const actorId = body.actor_id;
+        const { error, session } = resolveSession(sessionId);
+        if (error) return res.status(error.status).json(error.body);
+        if (!actorId || typeof actorId !== 'string') {
+          return res.status(400).json({ error: 'actor_id richiesto (string)' });
+        }
+        if (!session.roundState) {
+          return res
+            .status(400)
+            .json({ error: 'roundState non inizializzato (chiama prima /declare-intent)' });
+        }
+        const phase = session.roundState.round_phase;
+        if (phase !== PHASE_PLANNING) {
+          return res.status(409).json({
+            error: `undo-action consentita solo in planning phase (corrente: '${phase}')`,
+            code: 'UNDO_PHASE_INVALID',
+            round_phase: phase,
+          });
+        }
+        const pending = Array.isArray(session.roundState.pending_intents)
+          ? session.roundState.pending_intents
+          : [];
+        // Trova ultimo main intent (non reaction) per actorId. LIFO pop.
+        let popIdx = -1;
+        for (let i = pending.length - 1; i >= 0; i -= 1) {
+          const it = pending[i];
+          if (!it) continue;
+          if (String(it.unit_id || '') !== String(actorId)) continue;
+          if (it.reaction_trigger) continue; // skip reactions
+          popIdx = i;
+          break;
+        }
+        if (popIdx === -1) {
+          // No-op: stack vuoto per actor o solo reactions.
+          return res.json({
+            session_id: session.session_id,
+            round_phase: phase,
+            pending_intents: pending,
+            popped: null,
+          });
+        }
+        const popped = pending[popIdx];
+        const nextPending = pending.slice(0, popIdx).concat(pending.slice(popIdx + 1));
+        session.roundState = {
+          ...session.roundState,
+          pending_intents: nextPending,
+        };
+        res.json({
+          session_id: session.session_id,
+          round_phase: session.roundState.round_phase,
+          pending_intents: nextPending,
+          popped,
+        });
+      } catch (err) {
+        next(err);
+      }
+    });
+
     router.post('/commit-round', async (req, res, next) => {
       try {
         const body = req.body || {};

--- a/apps/backend/services/codex/codexState.js
+++ b/apps/backend/services/codex/codexState.js
@@ -1,0 +1,142 @@
+// Bundle B.3 — Tunic decipher Codex state management.
+//
+// In-memory store per session_id → Set<page_id> deciphered.
+// Loader YAML pages from data/core/codex/pages/*.yaml.
+// API:
+//   - loadCodexPages() -> { pages: [...] }   (cached singleton)
+//   - getDeciphered(sessionId) -> Set<string>
+//   - markDeciphered(sessionId, pageId) -> { added: bool }
+//   - validateTrigger(page, triggerData) -> bool
+//   - listPagesForSession(sessionId) -> [{ ...page, deciphered }]
+//   - resetSession(sessionId) -> void
+//
+// Trigger types supported:
+//   - always              → tutorial pages always_deciphered=true
+//   - enter_biome         → triggerData.biome_id matches condition.biome_id
+//   - kill_species        → triggerData.species_id matches condition.species_id
+//   - apply_trait         → triggerData.trait_id matches condition.trait_id
+//   - mating_attempt      → triggerData.species_a + species_b match (any order)
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const PAGES_DIR = path.resolve(__dirname, '../../../../data/core/codex/pages');
+
+let _cachedPages = null;
+const _bySession = new Map(); // sessionId → Set<pageId>
+
+function loadCodexPages({ force = false } = {}) {
+  if (_cachedPages && !force) return _cachedPages;
+  const pages = [];
+  if (!fs.existsSync(PAGES_DIR)) {
+    _cachedPages = { pages: [] };
+    return _cachedPages;
+  }
+  const files = fs.readdirSync(PAGES_DIR).filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'));
+  for (const f of files) {
+    const raw = fs.readFileSync(path.join(PAGES_DIR, f), 'utf8');
+    const parsed = yaml.load(raw);
+    const arr = Array.isArray(parsed?.pages) ? parsed.pages : [];
+    for (const p of arr) {
+      if (!p || !p.id) continue;
+      pages.push(p);
+    }
+  }
+  _cachedPages = { pages };
+  return _cachedPages;
+}
+
+function getDeciphered(sessionId) {
+  if (!sessionId) return new Set();
+  if (!_bySession.has(sessionId)) {
+    // Auto-decipher always-true pages on first access.
+    const set = new Set();
+    const { pages } = loadCodexPages();
+    for (const p of pages) {
+      if (p.always_deciphered === true || p?.decipher_trigger?.type === 'always') {
+        set.add(p.id);
+      }
+    }
+    _bySession.set(sessionId, set);
+  }
+  return _bySession.get(sessionId);
+}
+
+function markDeciphered(sessionId, pageId) {
+  const set = getDeciphered(sessionId);
+  if (set.has(pageId)) return { added: false };
+  set.add(pageId);
+  return { added: true };
+}
+
+function validateTrigger(page, triggerData) {
+  if (!page || !page.decipher_trigger) return false;
+  const trig = page.decipher_trigger;
+  const td = triggerData || {};
+  if (trig.type === 'always') return true;
+  const cond = trig.condition || {};
+  if (trig.type === 'enter_biome') {
+    return Boolean(cond.biome_id) && String(td.biome_id) === String(cond.biome_id);
+  }
+  if (trig.type === 'kill_species') {
+    return Boolean(cond.species_id) && String(td.species_id) === String(cond.species_id);
+  }
+  if (trig.type === 'apply_trait') {
+    return Boolean(cond.trait_id) && String(td.trait_id) === String(cond.trait_id);
+  }
+  if (trig.type === 'mating_attempt') {
+    if (!cond.species_a || !cond.species_b) return false;
+    const td1 = String(td.species_a || '');
+    const td2 = String(td.species_b || '');
+    return (
+      (td1 === String(cond.species_a) && td2 === String(cond.species_b)) ||
+      (td1 === String(cond.species_b) && td2 === String(cond.species_a))
+    );
+  }
+  return false;
+}
+
+function listPagesForSession(sessionId) {
+  const { pages } = loadCodexPages();
+  const set = getDeciphered(sessionId);
+  return pages.map((p) => {
+    const deciphered = set.has(p.id);
+    return {
+      id: p.id,
+      title: p.title,
+      category: p.category || null,
+      deciphered,
+      content: deciphered ? p.content_clear || '' : p.content_blurred || '',
+      decipher_hint: deciphered ? null : p?.decipher_trigger?.description || null,
+      decipher_trigger_type: p?.decipher_trigger?.type || null,
+    };
+  });
+}
+
+function findPage(pageId) {
+  const { pages } = loadCodexPages();
+  return pages.find((p) => p.id === pageId) || null;
+}
+
+function resetSession(sessionId) {
+  _bySession.delete(sessionId);
+}
+
+function _resetAll() {
+  _bySession.clear();
+  _cachedPages = null;
+}
+
+module.exports = {
+  loadCodexPages,
+  getDeciphered,
+  markDeciphered,
+  validateTrigger,
+  listPagesForSession,
+  findPage,
+  resetSession,
+  _resetAll,
+};

--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -263,6 +263,9 @@
           <div id="unit-tooltip" class="unit-tooltip hidden"></div>
           <div class="controls">
             <button id="end-turn">Fine turno</button>
+            <button id="undo-action" class="undo-btn hidden" title="Annulla ultima azione (Ctrl+Z)">
+              ↶ Undo
+            </button>
             <button id="new-session">Nuova sessione</button>
             <button id="reset-round" title="Emergency reset round state (se tutto bloccato)">
               🔄 Reset

--- a/apps/play/src/api.js
+++ b/apps/play/src/api.js
@@ -77,6 +77,19 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ session_id: sid }),
     }),
+  // Bundle B.2 — Tactical Breach Wizards Undo libero (planning-phase only).
+  undoAction: (sid, actorId) =>
+    jsonFetch('/api/session/undo-action', {
+      method: 'POST',
+      body: JSON.stringify({ session_id: sid, actor_id: actorId }),
+    }),
+  // Bundle B.3 — Tunic decipher Codex pages.
+  codexPages: (sid) => jsonFetch(`/api/v1/codex/pages?session_id=${encodeURIComponent(sid || '')}`),
+  codexDecipher: (sid, pageId, triggerData = {}) =>
+    jsonFetch('/api/v1/codex/decipher', {
+      method: 'POST',
+      body: JSON.stringify({ session_id: sid, page_id: pageId, trigger_data: triggerData }),
+    }),
   commitRound: (sid, autoResolve = true) =>
     jsonFetch('/api/session/commit-round', {
       method: 'POST',

--- a/apps/play/src/codexPanel.js
+++ b/apps/play/src/codexPanel.js
@@ -1,10 +1,18 @@
 // W8L — Codex MVP minimal (in-game wiki + tip re-reader).
+// Bundle B.3 (2026-04-27) — Tunic decipher Pages tab: blurred → clear via gameplay trigger.
 // User feedback run5: "manca ancora il sistema Aliena o simile dove rileggere
-// i tip e molto altro!". Minimal first-cut: 4 tab (Tips / Glossario / Abilità /
+// i tip e molto altro!". Minimal first-cut: 5 tab (Pagine / Tips / Glossario / Abilità /
 // Statuses). A.L.I.E.N.A. full integration = Wave 9+ (vedi docs/planning/
 // codex-in-game-aliena-integration.md).
 
 import { showTip, hasTipBeenShown, resetAllTips } from './tips.js';
+import { api } from './api.js';
+
+// Bundle B.3 — current session_id holder (set by main.js on session start).
+let _currentSessionId = null;
+export function setCodexSessionId(sid) {
+  _currentSessionId = sid;
+}
 
 // Glossario terms — canonical meccanica Evo-Tactics.
 const GLOSSARIO = [
@@ -145,7 +153,7 @@ const STATUSES_INFO = [
 ];
 
 let isOpen = false;
-let currentTab = 'tips';
+let currentTab = 'pagine';
 
 function getOrCreatePanel() {
   let panel = document.getElementById('codex-panel-root');
@@ -162,13 +170,15 @@ function getOrCreatePanel() {
         <button class="codex-close-btn" title="Chiudi (ESC)">✕</button>
       </div>
       <nav class="codex-tabs" role="tablist">
-        <button class="codex-tab active" data-tab="tips" role="tab">💡 Tips</button>
+        <button class="codex-tab active" data-tab="pagine" role="tab">📜 Pagine</button>
+        <button class="codex-tab" data-tab="tips" role="tab">💡 Tips</button>
         <button class="codex-tab" data-tab="glossario" role="tab">📖 Glossario</button>
         <button class="codex-tab" data-tab="abilita" role="tab">⚔ Abilità</button>
         <button class="codex-tab" data-tab="statuses" role="tab">🌀 Status</button>
       </nav>
       <div class="codex-panel-body">
-        <div class="codex-tab-content" data-tab-content="tips"></div>
+        <div class="codex-tab-content" data-tab-content="pagine"></div>
+        <div class="codex-tab-content hidden" data-tab-content="tips"></div>
         <div class="codex-tab-content hidden" data-tab-content="glossario"></div>
         <div class="codex-tab-content hidden" data-tab-content="abilita"></div>
         <div class="codex-tab-content hidden" data-tab-content="statuses"></div>
@@ -200,10 +210,56 @@ function switchTab(tabName) {
 function renderTabContent(tabName) {
   const container = document.querySelector(`[data-tab-content="${tabName}"]`);
   if (!container) return;
-  if (tabName === 'tips') renderTipsTab(container);
+  if (tabName === 'pagine') renderPagineTab(container);
+  else if (tabName === 'tips') renderTipsTab(container);
   else if (tabName === 'glossario') renderGlossarioTab(container);
   else if (tabName === 'abilita') renderAbilitaTab(container);
   else if (tabName === 'statuses') renderStatusesTab(container);
+}
+
+// Bundle B.3 — Pagine (decipher tab). Fetch da /api/v1/codex/pages?session_id=...
+function renderPagineTab(el) {
+  if (!_currentSessionId) {
+    el.innerHTML = `<p class="codex-intro">Avvia una sessione per consultare le pagine A.L.I.E.N.A.</p>`;
+    return;
+  }
+  el.innerHTML = `<p class="codex-intro">Caricamento pagine A.L.I.E.N.A....</p>`;
+  api
+    .codexPages(_currentSessionId)
+    .then((r) => {
+      if (!r.ok) {
+        el.innerHTML = `<p class="codex-intro">Errore caricamento codex: ${r.data?.error || r.status}</p>`;
+        return;
+      }
+      const pages = Array.isArray(r.data?.pages) ? r.data.pages : [];
+      const total = r.data?.total || 0;
+      const dec = r.data?.deciphered_count || 0;
+      el.innerHTML = `
+        <p class="codex-intro">
+          Archivio enciclopedico A.L.I.E.N.A. — ${dec}/${total} pagine decifrate.
+          Le pagine ███████ si rivelano attraverso il gameplay (entra biomi, uccidi specie, applica trait).
+        </p>
+        <ul class="codex-pages-list">
+          ${pages
+            .map((p) => {
+              const cls = p.deciphered ? 'codex-page deciphered' : 'codex-page blurred';
+              const hint = p.deciphered
+                ? ''
+                : `<div class="codex-page-hint">🔒 Decifra: ${p.decipher_hint || '(trigger sconosciuto)'}</div>`;
+              return `<li class="${cls}" data-page-id="${p.id}">
+                <div class="codex-page-title"><strong>${p.title || p.id}</strong>
+                  <span class="codex-page-cat">${p.category || ''}</span></div>
+                <pre class="codex-page-content">${p.content || ''}</pre>
+                ${hint}
+              </li>`;
+            })
+            .join('')}
+        </ul>
+      `;
+    })
+    .catch((err) => {
+      el.innerHTML = `<p class="codex-intro">Errore: ${err?.message || err}</p>`;
+    });
 }
 
 function renderTipsTab(el) {

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -19,7 +19,7 @@ import { openReplay } from './replayPanel.js';
 import { sfx, setMuted, isMuted } from './sfx.js';
 import { initHelpPanel } from './helpPanel.js';
 import { showTip, buildRecoveryTipMessage, resetAllTips } from './tips.js';
-import { toggleCodex } from './codexPanel.js';
+import { toggleCodex, setCodexSessionId } from './codexPanel.js';
 import { initFeedbackPanel } from './feedbackPanel.js';
 import { initCampaignPanel } from './campaignPanel.js';
 import { initLobbyBridgeIfPresent } from './lobbyBridge.js';
@@ -203,6 +203,14 @@ function redraw() {
     predictedOrder,
   );
   updateStatus(state.world);
+  // Bundle B.2 — Undo button visibility (planning phase + selected unit has pending).
+  const undoBtn = document.getElementById('undo-action');
+  if (undoBtn) {
+    const hasPending =
+      state.selected &&
+      state.pendingIntents.some((pi) => pi.unit_id === state.selected && !pi.reaction_trigger);
+    undoBtn.classList.toggle('hidden', !hasPending);
+  }
   // ability panel
   const selUnit = (state.world.units || []).find((u) => u.id === state.selected);
   if (selUnit && selUnit.controlled_by === 'player' && selUnit.hp > 0) {
@@ -381,6 +389,36 @@ document.addEventListener('keydown', (ev) => {
   if (!state.sid) return;
   ev.preventDefault();
   document.getElementById('end-turn').click();
+});
+
+// Bundle B.2 — Ctrl+Z = Undo last action (planning phase only).
+async function handleUndoAction() {
+  if (!state.sid || !state.selected) return;
+  const before = state.pendingIntents.length;
+  // Pop last intent for selected unit client-side (mirror server LIFO).
+  for (let i = state.pendingIntents.length - 1; i >= 0; i -= 1) {
+    if (state.pendingIntents[i].unit_id === state.selected) {
+      state.pendingIntents.splice(i, 1);
+      break;
+    }
+  }
+  const r = await api.undoAction(state.sid, state.selected);
+  if (!r.ok) {
+    appendLog(logEl, `✖ undo: ${r.data?.error || r.status}`, 'warn');
+    return;
+  }
+  if (state.pendingIntents.length < before) {
+    appendLog(logEl, `↶ undo: 1 intent rimosso (${state.selected})`);
+    updateHint(`Ultima azione di ${state.selected} annullata.`);
+    redraw();
+  }
+}
+document.addEventListener('keydown', (ev) => {
+  if (!(ev.ctrlKey || ev.metaKey) || ev.key !== 'z') return;
+  const active = document.activeElement;
+  if (active && /^(input|textarea|select)$/i.test(active.tagName)) return;
+  ev.preventDefault();
+  handleUndoAction();
 });
 
 function handleUnitClick(unit) {
@@ -1041,6 +1079,8 @@ async function startNewSession() {
   state.world = st.data.state;
   state.selected = null;
   state.target = null;
+  // Bundle B.3 — pipe session_id to codex panel for /api/v1/codex/pages.
+  setCodexSessionId(state.sid);
   // M11 Phase B+ (TKT-M11B-03) — if host room carries campaign_id, bootstrap
   // campaign runtime and cache summary so publishWorld mirrors it to players.
   // V1 Onboarding Phase B (2026-04-26): if campaign def carries `onboarding`
@@ -1143,6 +1183,8 @@ document.getElementById('new-session').addEventListener('click', () => {
 document.getElementById('reset-round')?.addEventListener('click', async () => {
   await emergencyResetRound();
 });
+// Bundle B.2 — Undo last action button (planning phase only, Ctrl+Z mirror).
+document.getElementById('undo-action')?.addEventListener('click', () => handleUndoAction());
 // W8L — Codex btn header (in-game wiki: Tips re-read + Glossario + Abilità + Status).
 document.getElementById('codex-open')?.addEventListener('click', () => {
   toggleCodex();

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -1100,6 +1100,73 @@ canvas#grid:hover {
   color: var(--bg);
 }
 
+/* Bundle B.3 — Tunic decipher Codex pages (blurred → clear via gameplay). */
+.codex-pages-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.codex-page {
+  border: 1px solid var(--border);
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 4px;
+}
+.codex-page.blurred .codex-page-content {
+  filter: blur(3px);
+  opacity: 0.5;
+  user-select: none;
+  font-family: 'Courier New', monospace;
+  letter-spacing: 0.5px;
+}
+.codex-page.deciphered {
+  border-color: #6fb04a;
+  background: rgba(111, 176, 74, 0.06);
+}
+.codex-page-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 6px;
+}
+.codex-page-cat {
+  font-size: 0.75em;
+  opacity: 0.6;
+  text-transform: uppercase;
+}
+.codex-page-content {
+  white-space: pre-wrap;
+  font-size: 0.85em;
+  margin: 6px 0;
+  line-height: 1.4;
+}
+.codex-page-hint {
+  font-size: 0.8em;
+  font-style: italic;
+  color: #d4b8e8;
+  margin-top: 6px;
+  padding: 4px 6px;
+  background: rgba(139, 111, 176, 0.1);
+  border-left: 2px solid #8b6fb0;
+}
+
+/* Bundle B.2 — Undo button (TBW Tactical Breach Wizards pattern). */
+.undo-btn {
+  background: #4a3a5a !important;
+  border-color: #8b6fb0 !important;
+  color: #d4b8e8 !important;
+}
+.undo-btn:hover {
+  background: #6b4f87 !important;
+  color: #fff !important;
+}
+.undo-btn.hidden {
+  display: none;
+}
+
 .sidebar {
   background: var(--panel);
   padding: 12px;

--- a/data/core/codex/pages/biomes.yaml
+++ b/data/core/codex/pages/biomes.yaml
@@ -1,0 +1,87 @@
+# Bundle B.3 — Tunic decipher Codex pages (biomes domain).
+# Schema: { id, title, category, content_clear, content_blurred,
+#           decipher_trigger: { type, condition: {...}, description } }
+# Trigger types: kill_species, enter_biome, apply_trait, mating_attempt
+# Tutorial pages (always_deciphered: true) sempre visible.
+
+pages:
+  - id: codex_biome_savana
+    title: Savana
+    category: biome
+    content_clear: |
+      Savana — pianura erbosa con visibilità ampia. Hazard: insolazione (stress modifier +0.05 turn 4+).
+      Specie endemiche: lupo_pianura, carapax. Tile dominante: erba secca (cover -1).
+      Strategia: melee veloce favorita, ranged limitato da ostacoli rari.
+    content_blurred: |
+      ███████ — █████████ ███████ con visibilità █████. Hazard: ███████████ (stress modifier ████ turn █+).
+      Specie endemiche: ████████, ████████. Tile dominante: ████ ████ (cover ██).
+      Strategia: █████ ██████ favorita, ██████ █████████ da ostacoli ████.
+    decipher_trigger:
+      type: enter_biome
+      condition:
+        biome_id: savana
+      description: Entra nel bioma Savana
+
+  - id: codex_biome_caverna
+    title: Caverna
+    category: biome
+    content_clear: |
+      Caverna — ambiente chiuso, bassa luce. Hazard: stalattiti (random 5% damage 2 a fine turno).
+      Specie endemiche: pipistrello_eco, ragno_velenoso. Tile: pietra (cover +1, blocks LOS).
+      Strategia: ranged sfavorito da LOS bloccato, ability area-of-effect favorite.
+    content_blurred: |
+      ████████ — ███████ chiuso, █████ ████. Hazard: ███████████ (random ██% damage █ a fine turno).
+      Specie endemiche: ████████████, ███████████. Tile: ██████ (cover ██, █████ ███).
+      Strategia: ██████ sfavorito da ███ ████████, █████ █████-██-██████ favorite.
+    decipher_trigger:
+      type: enter_biome
+      condition:
+        biome_id: caverna
+      description: Entra nel bioma Caverna
+
+  - id: codex_biome_foresta
+    title: Foresta
+    category: biome
+    content_clear: |
+      Foresta — copertura densa, multipath. Hazard: rampicanti tossici (bleeding 1 turn su trigger).
+      Specie endemiche: lince_silente, vipera_arborea. Tile: foglie (cover +1, no blocks).
+      Strategia: stealth ambush ottimale, melee burst su corridoi naturali.
+    content_blurred: |
+      ███████ — ████████ █████, ████████. Hazard: ████████████ ████████ (████████ █ ████ su trigger).
+      Specie endemiche: ████████████, ███████████. Tile: ██████ (cover ██, ██ ██████).
+      Strategia: ███████ ██████ ottimale, █████ █████ su corridoi naturali.
+    decipher_trigger:
+      type: enter_biome
+      condition:
+        biome_id: foresta
+      description: Entra nel bioma Foresta
+
+  - id: codex_tutorial_intro
+    title: A.L.I.E.N.A. — Introduzione
+    category: tutorial
+    always_deciphered: true
+    content_clear: |
+      Codex A.L.I.E.N.A. — archivio enciclopedico in-game. Le pagine vengono decifrate
+      attraverso l'esperienza di gioco: uccidi una specie, entra in un bioma, applica un trait.
+      Ogni pagina blurred mostra il "trigger" richiesto. Esplora per scoprire.
+    content_blurred: ""
+    decipher_trigger:
+      type: always
+      description: Sempre disponibile (tutorial)
+
+  - id: codex_species_lupo_pianura
+    title: Lupo della Pianura
+    category: species
+    content_clear: |
+      Lupo della Pianura (Canis vaganensis) — predatore agile, pack hunter.
+      HP base 8, AP 2, attack range 1. Trait: scatto_predatorio (+1 dmg charge).
+      Debolezza: panico se isolato dal branco (status panic se ally count < 2).
+    content_blurred: |
+      █████ ████ ██████ (██████ █████████████) — ██████ ████, █████ █████.
+      ██ ████ █, ██ █, ██████ █████ █. Trait: ████████████████ (██ █████).
+      Debolezza: ██████ se █████████ ███ ███████ (████ ███ se ally █████ █ █).
+    decipher_trigger:
+      type: kill_species
+      condition:
+        species_id: lupo_pianura
+      description: Uccidi 1 Lupo della Pianura

--- a/tests/api/codexRoutes.test.js
+++ b/tests/api/codexRoutes.test.js
@@ -1,0 +1,153 @@
+// Bundle B.3 — Tunic decipher Codex pages route tests.
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+const codexState = require('../../apps/backend/services/codex/codexState');
+
+function freshSid() {
+  return `test_codex_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+test('codex: GET /pages registry ritorna ≥5 pages with deciphered flag', async (t) => {
+  codexState._resetAll();
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = freshSid();
+  const r = await request(app).get('/api/v1/codex/pages').query({ session_id: sid });
+  assert.equal(r.status, 200);
+  assert.ok(Array.isArray(r.body.pages), 'pages array');
+  assert.ok(r.body.total >= 5, `expected ≥5 pages, got ${r.body.total}`);
+  // Tutorial sempre deciphered
+  const tut = r.body.pages.find((p) => p.id === 'codex_tutorial_intro');
+  assert.ok(tut, 'tutorial page presente');
+  assert.equal(tut.deciphered, true, 'tutorial sempre decifrato');
+  // Biome page non-deciphered di default
+  const savana = r.body.pages.find((p) => p.id === 'codex_biome_savana');
+  assert.ok(savana);
+  assert.equal(savana.deciphered, false);
+  assert.ok(savana.decipher_hint, 'hint visibile su pagina blurred');
+});
+
+test('codex: POST /decipher kill_species marks page deciphered', async (t) => {
+  codexState._resetAll();
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = freshSid();
+  const r = await request(app)
+    .post('/api/v1/codex/decipher')
+    .send({
+      session_id: sid,
+      page_id: 'codex_species_lupo_pianura',
+      trigger_data: { species_id: 'lupo_pianura' },
+    });
+  assert.equal(r.status, 200);
+  assert.equal(r.body.deciphered, true);
+  assert.equal(r.body.newly_added, true);
+  assert.ok(r.body.content.includes('Canis vaganensis'), 'clear content esposto');
+});
+
+test('codex: POST /decipher con trigger sbagliato → 409', async (t) => {
+  codexState._resetAll();
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = freshSid();
+  const r = await request(app)
+    .post('/api/v1/codex/decipher')
+    .send({
+      session_id: sid,
+      page_id: 'codex_biome_savana',
+      // Wrong trigger: biome_id mismatch
+      trigger_data: { biome_id: 'caverna' },
+    });
+  assert.equal(r.status, 409);
+  assert.equal(r.body.code, 'TRIGGER_MISMATCH');
+  assert.ok(r.body.expected, 'expected trigger esposto in error');
+});
+
+test('codex: persistence cross-call (decipher poi GET ritorna deciphered)', async (t) => {
+  codexState._resetAll();
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = freshSid();
+  // Step 1: decipher savana via enter_biome
+  const d = await request(app)
+    .post('/api/v1/codex/decipher')
+    .send({
+      session_id: sid,
+      page_id: 'codex_biome_savana',
+      trigger_data: { biome_id: 'savana' },
+    });
+  assert.equal(d.status, 200);
+  // Step 2: GET pages, savana deve essere deciphered
+  const g = await request(app).get('/api/v1/codex/pages').query({ session_id: sid });
+  assert.equal(g.status, 200);
+  const savana = g.body.pages.find((p) => p.id === 'codex_biome_savana');
+  assert.equal(savana.deciphered, true);
+  assert.ok(savana.content.includes('insolazione'));
+  // Other session = isolated state
+  const sid2 = freshSid();
+  const g2 = await request(app).get('/api/v1/codex/pages').query({ session_id: sid2 });
+  const savana2 = g2.body.pages.find((p) => p.id === 'codex_biome_savana');
+  assert.equal(savana2.deciphered, false, 'session isolation');
+});
+
+test('codex: GET /pages 400 se session_id mancante', async (t) => {
+  codexState._resetAll();
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const r = await request(app).get('/api/v1/codex/pages');
+  assert.equal(r.status, 400);
+  assert.match(r.body.error, /session_id/);
+});
+
+test('codex: POST /decipher 404 se page_id inesistente', async (t) => {
+  codexState._resetAll();
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const r = await request(app)
+    .post('/api/v1/codex/decipher')
+    .send({ session_id: freshSid(), page_id: 'codex_nonexistent_xyz', trigger_data: {} });
+  assert.equal(r.status, 404);
+});
+
+test('codex: idempotente — re-decipher stessa page → newly_added false', async (t) => {
+  codexState._resetAll();
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = freshSid();
+  await request(app)
+    .post('/api/v1/codex/decipher')
+    .send({
+      session_id: sid,
+      page_id: 'codex_biome_caverna',
+      trigger_data: { biome_id: 'caverna' },
+    });
+  const r2 = await request(app)
+    .post('/api/v1/codex/decipher')
+    .send({
+      session_id: sid,
+      page_id: 'codex_biome_caverna',
+      trigger_data: { biome_id: 'caverna' },
+    });
+  assert.equal(r2.status, 200);
+  assert.equal(r2.body.deciphered, true);
+  assert.equal(r2.body.newly_added, false);
+});

--- a/tests/api/sessionUndo.test.js
+++ b/tests/api/sessionUndo.test.js
@@ -1,0 +1,210 @@
+// Bundle B.2 — Tactical Breach Wizards Undo libero (planning-phase pop LIFO).
+//
+// Endpoint: POST /api/session/undo-action body { session_id, actor_id }
+// Pop ultima main intent (non reaction) per actor da pending_intents.
+// 409 se phase != 'planning'. 200 no-op se stack vuoto / solo reactions.
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+const { startSession, twoUnits } = require('./sessionTestHelpers');
+
+async function declare(app, sid, actorId, action) {
+  return request(app)
+    .post('/api/session/declare-intent')
+    .send({ session_id: sid, actor_id: actorId, action });
+}
+
+async function undo(app, sid, actorId) {
+  return request(app).post('/api/session/undo-action').send({ session_id: sid, actor_id: actorId });
+}
+
+test('undo: pop ultimo move intent da pending stack', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, twoUnits({ p1Pos: { x: 2, y: 2 }, sisPos: { x: 5, y: 5 } }));
+  // Declare 1 move
+  const r1 = await declare(app, sid, 'p1', {
+    id: 'p1-mv',
+    type: 'move',
+    actor_id: 'p1',
+    move_to: { x: 2, y: 3 },
+    ap_cost: 1,
+  });
+  assert.equal(r1.status, 200);
+  assert.equal(r1.body.pending_intents.length, 1);
+  // Undo
+  const r2 = await undo(app, sid, 'p1');
+  assert.equal(r2.status, 200);
+  assert.equal(r2.body.pending_intents.length, 0);
+  assert.ok(r2.body.popped, 'popped intent ritornato');
+  assert.equal(r2.body.popped.unit_id, 'p1');
+  assert.equal(r2.body.popped.action.type, 'move');
+});
+
+test('undo: LIFO pop ultimo intent quando 2+ presenti', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, twoUnits({ p1Pos: { x: 2, y: 2 }, sisPos: { x: 3, y: 2 } }));
+  // 2 declared intents: move + attack
+  await declare(app, sid, 'p1', {
+    id: 'mv1',
+    type: 'move',
+    actor_id: 'p1',
+    move_to: { x: 2, y: 3 },
+    ap_cost: 1,
+  });
+  await declare(app, sid, 'p1', {
+    id: 'atk1',
+    type: 'attack',
+    actor_id: 'p1',
+    target_id: 'sis',
+    ap_cost: 1,
+  });
+  const r = await undo(app, sid, 'p1');
+  assert.equal(r.status, 200);
+  // LIFO: attack rimosso, move resta
+  assert.equal(r.body.pending_intents.length, 1);
+  assert.equal(r.body.pending_intents[0].action.type, 'move');
+  assert.equal(r.body.popped.action.type, 'attack');
+});
+
+test('undo: 409 se phase != planning (post commit-round)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, twoUnits({ p1Pos: { x: 2, y: 2 }, sisPos: { x: 3, y: 2 } }));
+  await declare(app, sid, 'p1', {
+    id: 'mv1',
+    type: 'move',
+    actor_id: 'p1',
+    move_to: { x: 2, y: 3 },
+    ap_cost: 1,
+  });
+  // Commit round (no auto_resolve → fase passes a 'committed')
+  const cr = await request(app)
+    .post('/api/session/commit-round')
+    .send({ session_id: sid, auto_resolve: false });
+  assert.equal(cr.status, 200);
+  // Undo dopo commit → 409
+  const r = await undo(app, sid, 'p1');
+  assert.equal(r.status, 409);
+  assert.equal(r.body.code, 'UNDO_PHASE_INVALID');
+});
+
+test('undo: 200 no-op se stack vuoto', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, twoUnits({ p1Pos: { x: 2, y: 2 }, sisPos: { x: 3, y: 2 } }));
+  // Declare poi clear → stack vuoto ma roundState esiste
+  await declare(app, sid, 'p1', {
+    id: 'mv1',
+    type: 'move',
+    actor_id: 'p1',
+    move_to: { x: 2, y: 3 },
+    ap_cost: 1,
+  });
+  await request(app).post('/api/session/clear-intent/p1').send({ session_id: sid });
+  // Undo su stack vuoto → 200, popped: null
+  const r = await undo(app, sid, 'p1');
+  assert.equal(r.status, 200);
+  assert.equal(r.body.popped, null);
+  assert.equal(r.body.pending_intents.length, 0);
+});
+
+test('undo: 400 se actor_id mancante', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, twoUnits({ p1Pos: { x: 2, y: 2 }, sisPos: { x: 3, y: 2 } }));
+  await declare(app, sid, 'p1', {
+    id: 'mv1',
+    type: 'move',
+    actor_id: 'p1',
+    move_to: { x: 2, y: 3 },
+    ap_cost: 1,
+  });
+  const r = await request(app).post('/api/session/undo-action').send({ session_id: sid });
+  assert.equal(r.status, 400);
+  assert.match(r.body.error, /actor_id/);
+});
+
+test('undo: pop solo intent del actor specificato (non altri)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const units = [
+    {
+      id: 'p1',
+      species: 'velox',
+      job: 'skirmisher',
+      hp: 10,
+      max_hp: 10,
+      ap: 2,
+      attack_range: 2,
+      initiative: 14,
+      position: { x: 0, y: 0 },
+      controlled_by: 'player',
+      status: {},
+    },
+    {
+      id: 'p2',
+      species: 'carapax',
+      job: 'vanguard',
+      hp: 10,
+      max_hp: 10,
+      ap: 2,
+      attack_range: 2,
+      initiative: 12,
+      position: { x: 1, y: 0 },
+      controlled_by: 'player',
+      status: {},
+    },
+    {
+      id: 'sis',
+      species: 'lupo',
+      job: 'vanguard',
+      hp: 10,
+      max_hp: 10,
+      ap: 2,
+      attack_range: 1,
+      initiative: 8,
+      position: { x: 5, y: 5 },
+      controlled_by: 'sistema',
+      status: {},
+    },
+  ];
+  const sid = await startSession(app, units);
+  await declare(app, sid, 'p1', {
+    id: 'mv1',
+    type: 'move',
+    actor_id: 'p1',
+    move_to: { x: 0, y: 1 },
+    ap_cost: 1,
+  });
+  await declare(app, sid, 'p2', {
+    id: 'mv2',
+    type: 'move',
+    actor_id: 'p2',
+    move_to: { x: 2, y: 0 },
+    ap_cost: 1,
+  });
+  const r = await undo(app, sid, 'p1');
+  assert.equal(r.status, 200);
+  // Solo intent p1 rimosso, p2 preservato
+  assert.equal(r.body.pending_intents.length, 1);
+  assert.equal(r.body.pending_intents[0].unit_id, 'p2');
+  assert.equal(r.body.popped.unit_id, 'p1');
+});


### PR DESCRIPTION
## Summary

Bundle B "big" — 2 patterns indie quick-wins shipped in 1 PR (~9h target). Zero collision con sibling bundle-b-small (drift+counter) — file ownership disjoint verificato.

### Pattern B.2 — Tactical Breach Wizards Undo libero (P1, ~4h)

Undo move/action gratis durante planning phase (escape sperimentale tutorial-friendly).

- Backend: `POST /api/session/undo-action` — pop ultimo main intent (LIFO) per actor da `pending_intents`. Reactions preservati. 409 `UNDO_PHASE_INVALID` se phase != planning.
- Frontend: btn `↶ Undo` HUD bottom (visibile solo planning + selected unit ha pending) + Ctrl+Z / Cmd+Z keybinding.
- **6 tests**: pop move, LIFO 2-intent, 409 phase-invalid, no-op stack vuoto, 400 actor_id missing, isolation per-actor.

### Pattern B.3 — Tunic decipher Codex pages (cross-cutting TOP REC, ~5h)

A.L.I.E.N.A. wiki in-game con pages "blurred" decifrabili via gameplay.

- 5 seed pages YAML (`data/core/codex/pages/biomes.yaml`): 3 biomi (savana/caverna/foresta) + 1 tutorial sempre-deciphered + 1 species (lupo_pianura).
- Backend: `apps/backend/services/codex/codexState.js` (in-memory store + YAML loader + trigger validator) + `apps/backend/routes/codex.js` (2 endpoint REST).
- Trigger types: `always` | `enter_biome` | `kill_species` | `apply_trait` | `mating_attempt`.
- Frontend: codex panel "📜 Pagine" tab (default) — CSS `filter: blur(3px)` + opacity 0.4 + decipher hint banner per page non-deciphered.
- **7 tests**: registry ≥5 pages, decipher kill_species, 409 trigger mismatch, persistence cross-call + session isolation, 400 missing sid, 404 page, idempotent re-decipher.

## Test results

- **AI baseline**: 311/311 verde (zero regression)
- **New tests**: 13 (6 undo + 7 codex), tutti pass
- **Format check**: verde su 11 file modificati/nuovi
- **LOC delta** api.js+main.js: 55 LOC (+5 over 50 budget — entrambe le wire essenziali)

## Test plan

- [ ] CI: `node --test tests/ai/*.test.js` verde (311/311)
- [ ] CI: `node --test tests/api/sessionUndo.test.js` verde (6/6)
- [ ] CI: `node --test tests/api/codexRoutes.test.js` verde (7/7)
- [ ] CI: `npm run format:check` verde
- [ ] Manual: avvia tutorial 01, declare attack, premi Ctrl+Z → intent rimosso
- [ ] Manual: apri Codex (header btn) → tab Pagine default → 5 page (1 deciphered, 4 blurred)

## Impact statement

- **Pattern B.2 (TBW Undo)**: tutorial-friendly UX (riduce frizione "ho cliccato sbagliato") senza compromettere strategy depth (limit planning-phase only). Mirror del pattern Tactical Breach Wizards "free undo until commit".
- **Pattern B.3 (Tunic decipher)**: chiude V-gap "A.L.I.E.N.A. integration W9+" con MVP. Pages blurred = surface UX nuova per content existing (biomi + species + trait). Foundation per future P4 thought-cabinet-style reveal.
- **Anti-pattern "Engine LIVE Surface DEAD" mitigato**: Codex feature wired backend + frontend + 7 test. Trigger types low threshold (1-3 actions) rispetta anti-pattern doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)