### PR TITLE
feat(sprint-3): codex completion — Tunic Glifi + AncientBeast wiki + Wildermyth flags

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -31,6 +31,8 @@ const { createCoopRouter } = require('./routes/coop');
 const { createDiaryRouter } = require('./routes/diary');
 // Skiv-as-Monitor — git-event-driven creature feed (2026-04-25)
 const { createSkivRouter } = require('./routes/skiv');
+// Sprint 3 §II (2026-04-27) — AncientBeast wiki cross-link slug bridge.
+const { createSpeciesWikiRouter } = require('./routes/speciesWiki');
 const { createCoopStore } = require('./services/coop/coopStore');
 const { LobbyService } = require('./services/network/wsSession');
 const { createNebulaTelemetryAggregator } = require('./services/nebulaTelemetryAggregator');
@@ -779,6 +781,11 @@ function createApp(options = {}) {
   // Reads data/derived/skiv_monitor/{state.json, feed.jsonl} produced by
   // tools/py/skiv_monitor.py via .github/workflows/skiv-monitor.yml.
   app.use('/api', createSkivRouter(options.skiv || {}));
+
+  // Sprint 3 §II (2026-04-27) — AncientBeast wiki cross-link slug bridge.
+  // Cross-link runtime species (data/core/species.yaml) ↔ catalog wiki
+  // (packs/evo_tactics_pack/docs/catalog/species/) via slug normalization.
+  app.use('/api', createSpeciesWikiRouter());
 
   // Bundle B.3 codex routes già registrate sopra (line 758) — single
   // createCodexRouter() ora ospita BOTH glyph-progression (PR #1931) +

--- a/apps/backend/routes/campaign.js
+++ b/apps/backend/routes/campaign.js
@@ -25,6 +25,8 @@ const {
   listCampaignsForPlayer,
   updateCampaign,
   recordChapter,
+  recordPermanentFlag,
+  getPermanentFlag,
 } = require('../services/campaign/campaignStore');
 const {
   loadCampaign: loadCampaignDef,
@@ -399,6 +401,52 @@ function createCampaignRouter(options = {}) {
       next_encounter_id: nextEncId,
       branch_key,
     });
+  });
+
+  // Sprint 3 §III (2026-04-27) — Wildermyth choice→permanent flag.
+  // POST /api/campaign/flag/record { id, key, value?, narrative?, source_chapter? }
+  router.post('/campaign/flag/record', (req, res) => {
+    const { id, key, value, narrative, source_chapter, source_act } = req.body || {};
+    if (!id) return res.status(400).json({ error: 'id richiesto' });
+    if (!key || typeof key !== 'string')
+      return res.status(400).json({ error: 'key richiesto (string)' });
+    const campaign = getCampaign(id);
+    if (!campaign) return res.status(404).json({ error: 'campaign non trovato' });
+    const updated = recordPermanentFlag(id, {
+      key,
+      value: value !== undefined ? value : true,
+      narrative: narrative || null,
+      source_chapter: source_chapter ?? null,
+      source_act: source_act ?? null,
+    });
+    return res.json({
+      campaign_id: id,
+      flag: updated.permanentFlags.find((f) => f.key === key),
+      total_flags: updated.permanentFlags.length,
+    });
+  });
+
+  // GET /api/campaign/:id/flags — list all permanent flags
+  router.get('/campaign/:id/flags', (req, res) => {
+    const id = req.params.id;
+    const campaign = getCampaign(id);
+    if (!campaign) return res.status(404).json({ error: 'campaign non trovato' });
+    return res.json({
+      campaign_id: id,
+      flags: campaign.permanentFlags || [],
+      total: (campaign.permanentFlags || []).length,
+    });
+  });
+
+  // GET /api/campaign/:id/flag/:key — query single flag
+  router.get('/campaign/:id/flag/:key', (req, res) => {
+    const flag = getPermanentFlag(req.params.id, req.params.key);
+    if (!flag) {
+      return res.status(404).json({
+        error: `flag '${req.params.key}' non trovato per campaign '${req.params.id}'`,
+      });
+    }
+    return res.json({ campaign_id: req.params.id, flag });
   });
 
   // POST /api/campaign/end

--- a/apps/backend/routes/speciesWiki.js
+++ b/apps/backend/routes/speciesWiki.js
@@ -1,0 +1,74 @@
+// Species wiki cross-link routes — Sprint 3 §II (2026-04-27).
+//
+// Surface AncientBeast wiki cross-link slug bridge via REST.
+// Source: docs/research/2026-04-26-tier-s-extraction-matrix.md #6 AncientBeast.
+//
+// Endpoints:
+//   GET /api/species/:id/wiki         → { id, slug, url, has_runtime, has_catalog }
+//   GET /api/species/:id/wiki/entry   → full catalog JSON or 404
+//   GET /api/species/wiki/audit       → linked species coverage report
+//
+// Frontend wire opportunity: characterPanel external-link button "Apri scheda Wiki",
+// codexPanel "Specie" tab future. Audit endpoint = governance reporting.
+
+'use strict';
+
+const { Router } = require('express');
+const wikiBridge = require('../services/species/wikiLinkBridge');
+
+function createSpeciesWikiRouter() {
+  const router = Router();
+
+  router.get('/species/wiki/audit', (_req, res) => {
+    const list = wikiBridge.listLinkedSpecies();
+    const total = list.length;
+    const linked = list.filter((e) => e.slug && e.has_catalog && e.has_runtime).length;
+    const missing_catalog = list.filter((e) => e.has_runtime && !e.has_catalog);
+    const missing_runtime = list.filter((e) => e.has_catalog && !e.has_runtime);
+    res.json({
+      total,
+      linked,
+      coverage_pct: total > 0 ? Math.round((linked / total) * 100) : 0,
+      missing_catalog: missing_catalog.map((e) => e.id),
+      missing_runtime: missing_runtime.map((e) => e.id),
+      species: list,
+    });
+  });
+
+  router.get('/species/:id/wiki', (req, res) => {
+    const id = req.params.id;
+    const slug = wikiBridge.getWikiSlug(id);
+    if (!slug) {
+      return res.status(404).json({
+        error: `wiki entry not found for species '${id}'`,
+        species_id: id,
+      });
+    }
+    res.json({
+      id,
+      slug,
+      url: wikiBridge.getWikiUrl(id),
+      url_html: wikiBridge.getWikiUrl(id, { ext: '.html' }),
+    });
+  });
+
+  router.get('/species/:id/wiki/entry', (req, res) => {
+    const id = req.params.id;
+    const entry = wikiBridge.getWikiEntry(id);
+    if (!entry) {
+      return res.status(404).json({
+        error: `catalog entry not found for species '${id}'`,
+        species_id: id,
+      });
+    }
+    res.json({
+      id,
+      slug: wikiBridge.getWikiSlug(id),
+      entry,
+    });
+  });
+
+  return router;
+}
+
+module.exports = { createSpeciesWikiRouter };

--- a/apps/backend/services/campaign/campaignStore.js
+++ b/apps/backend/services/campaign/campaignStore.js
@@ -66,6 +66,12 @@ function createCampaign(playerId, campaignDefId = 'default_campaign_mvp', opts =
     // V1 Onboarding Phase B — trait permanent pre-Act 0 shared roster
     onboardingChoice: opts.onboardingChoice || null, // { option_key, trait_id }
     acquiredTraits: Array.isArray(opts.acquiredTraits) ? [...opts.acquiredTraits] : [],
+    // Sprint 3 §III (2026-04-27) — Wildermyth choice→permanent flag pattern.
+    // Source: docs/research/2026-04-26-tier-s-extraction-matrix.md #12 Wildermyth.
+    // Each flag = { key, value, source_chapter, recorded_at, narrative? }.
+    // Used by debriefPanel + storylets registry for "permanent consequence"
+    // narrative weave (es. mid-fight choice → unlocks unique branch later).
+    permanentFlags: Array.isArray(opts.permanentFlags) ? [...opts.permanentFlags] : [],
     createdAt: now,
     updatedAt: now,
   };
@@ -117,6 +123,49 @@ function recordChapter(id, chapter) {
   return updateCampaign(id, { chapters: nextChapters });
 }
 
+/**
+ * Sprint 3 §III (2026-04-27) — record permanent flag (Wildermyth pattern).
+ * Idempotent: if same `key` already exists, updates value + retains original
+ * recorded_at. Returns updated campaign or null when not found.
+ *
+ * @param {string} id campaign id
+ * @param {{key:string, value:any, source_chapter?:number, narrative?:string}} flag
+ * @returns {object|null}
+ */
+function recordPermanentFlag(id, flag) {
+  if (!flag || !flag.key) return null;
+  const cur = _campaigns.get(id);
+  if (!cur) return null;
+  const existing = (cur.permanentFlags || []).findIndex((f) => f.key === flag.key);
+  const recordedAt = existing >= 0 ? cur.permanentFlags[existing].recorded_at : _now();
+  const entry = {
+    key: String(flag.key),
+    value: flag.value !== undefined ? flag.value : true,
+    source_chapter: Number(flag.source_chapter ?? cur.currentChapter) || null,
+    source_act: Number(flag.source_act ?? cur.currentAct) || null,
+    narrative: flag.narrative || null,
+    recorded_at: recordedAt,
+  };
+  const nextFlags = [...(cur.permanentFlags || [])];
+  if (existing >= 0) nextFlags[existing] = entry;
+  else nextFlags.push(entry);
+  return updateCampaign(id, { permanentFlags: nextFlags });
+}
+
+/**
+ * Sprint 3 §III — query permanent flag by key.
+ *
+ * @param {string} id campaign id
+ * @param {string} key
+ * @returns {object|null} flag entry or null
+ */
+function getPermanentFlag(id, key) {
+  const cur = _campaigns.get(id);
+  if (!cur || !key) return null;
+  const list = cur.permanentFlags || [];
+  return list.find((f) => f.key === key) || null;
+}
+
 function deleteCampaign(id) {
   const cur = _campaigns.get(id);
   if (!cur) return false;
@@ -138,6 +187,8 @@ module.exports = {
   listCampaignsForPlayer,
   updateCampaign,
   recordChapter,
+  recordPermanentFlag,
+  getPermanentFlag,
   deleteCampaign,
   _resetStore,
 };

--- a/apps/backend/services/species/wikiLinkBridge.js
+++ b/apps/backend/services/species/wikiLinkBridge.js
@@ -1,0 +1,188 @@
+// AncientBeast wiki cross-link slug bridge — Sprint 3 §II (2026-04-27).
+//
+// Source: docs/research/2026-04-26-tier-s-extraction-matrix.md #6 AncientBeast.
+// Pattern: Beast Showcase wiki style — cross-link tra catalog wiki + runtime species.
+//
+// Match Evo-Tactics:
+//   runtime: data/core/species.yaml { id, legacy_slug, ... }
+//   wiki:    packs/evo_tactics_pack/docs/catalog/species/<slug>.json
+//   index:   packs/evo_tactics_pack/docs/catalog/species-index.json
+//
+// API:
+//   getWikiSlug(speciesId) → slug | null
+//   getWikiUrl(speciesId, opts?) → URL string for client navigation
+//   getWikiEntry(speciesId) → catalog JSON | null
+//   listLinkedSpecies() → [{ id, slug, has_catalog, has_runtime }]
+//
+// Slug normalization rules (Evo runtime ↔ AncientBeast-style catalog):
+//   1. species.yaml `id` underscore_case (es. dune_stalker)
+//   2. catalog uses kebab-case (es. dune-stalker)
+//   3. legacy_slug field can override mapping
+//
+// Wire opportunity: codexPanel "Specie" tab (future), characterPanel external
+// link button, audit dashboard cross-ref.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const SPECIES_INDEX = path.resolve(__dirname, '../../../../data/core/species.yaml');
+const CATALOG_INDEX = path.resolve(
+  __dirname,
+  '../../../../packs/evo_tactics_pack/docs/catalog/species-index.json',
+);
+const CATALOG_DIR = path.resolve(
+  __dirname,
+  '../../../../packs/evo_tactics_pack/docs/catalog/species',
+);
+
+let _runtimeCache = null;
+let _catalogCache = null;
+
+/**
+ * Normalize id underscore_case → catalog kebab-case.
+ * @param {string} id
+ * @returns {string}
+ */
+function toKebabSlug(id) {
+  return String(id || '')
+    .trim()
+    .toLowerCase()
+    .replace(/_/g, '-');
+}
+
+function loadRuntimeSpecies() {
+  if (_runtimeCache) return _runtimeCache;
+  try {
+    const raw = fs.readFileSync(SPECIES_INDEX, 'utf-8');
+    const data = yaml.load(raw);
+    const list = Array.isArray(data?.species) ? data.species : [];
+    _runtimeCache = new Map();
+    for (const entry of list) {
+      if (!entry || !entry.id) continue;
+      _runtimeCache.set(entry.id, entry);
+    }
+  } catch (err) {
+    console.warn('[wikiLinkBridge] runtime species load failed:', err.message);
+    _runtimeCache = new Map();
+  }
+  return _runtimeCache;
+}
+
+function loadCatalogIndex() {
+  if (_catalogCache) return _catalogCache;
+  try {
+    const raw = fs.readFileSync(CATALOG_INDEX, 'utf-8');
+    const data = JSON.parse(raw);
+    const list = Array.isArray(data?.species) ? data.species : [];
+    _catalogCache = new Map();
+    for (const entry of list) {
+      if (!entry || !entry.id) continue;
+      _catalogCache.set(entry.id, entry);
+    }
+  } catch (err) {
+    console.warn('[wikiLinkBridge] catalog index load failed:', err.message);
+    _catalogCache = new Map();
+  }
+  return _catalogCache;
+}
+
+/**
+ * Resolve wiki slug for a runtime species id.
+ * Priority: legacy_slug → toKebabSlug(id).
+ * Returns null if neither runtime species exists nor catalog matches.
+ *
+ * @param {string} speciesId runtime id (data/core/species.yaml)
+ * @returns {string|null}
+ */
+function getWikiSlug(speciesId) {
+  if (!speciesId) return null;
+  const runtime = loadRuntimeSpecies();
+  const catalog = loadCatalogIndex();
+  const entry = runtime.get(speciesId);
+  // Try legacy_slug first (explicit override).
+  if (entry && entry.legacy_slug && catalog.has(entry.legacy_slug)) {
+    return entry.legacy_slug;
+  }
+  // Try kebab-case auto.
+  const kebab = toKebabSlug(speciesId);
+  if (catalog.has(kebab)) return kebab;
+  // Try id as-is (case where catalog already uses underscore).
+  if (catalog.has(speciesId)) return speciesId;
+  return null;
+}
+
+/**
+ * Build wiki URL for client navigation (relative path to catalog HTML).
+ * Frontend can use this to render <a href> buttons next to species names.
+ *
+ * @param {string} speciesId
+ * @param {object} [opts]
+ * @param {string} [opts.basePath='/docs/evo-tactics-pack/catalog/species'] - URL prefix
+ * @param {string} [opts.ext='.json'] - extension served (.html for static, .json for data)
+ * @returns {string|null}
+ */
+function getWikiUrl(speciesId, opts = {}) {
+  const slug = getWikiSlug(speciesId);
+  if (!slug) return null;
+  const base = opts.basePath || '/docs/evo-tactics-pack/catalog/species';
+  const ext = opts.ext || '.json';
+  return `${base}/${slug}${ext}`;
+}
+
+/**
+ * Load full catalog JSON for a species (read-through; not cached deeply).
+ *
+ * @param {string} speciesId
+ * @returns {object|null}
+ */
+function getWikiEntry(speciesId) {
+  const slug = getWikiSlug(speciesId);
+  if (!slug) return null;
+  try {
+    const fpath = path.join(CATALOG_DIR, `${slug}.json`);
+    if (!fs.existsSync(fpath)) return null;
+    return JSON.parse(fs.readFileSync(fpath, 'utf-8'));
+  } catch (err) {
+    console.warn('[wikiLinkBridge] entry load failed:', speciesId, err.message);
+    return null;
+  }
+}
+
+/**
+ * List all species with link audit metadata. Useful for governance reporting.
+ *
+ * @returns {Array<{id:string, slug:string|null, has_catalog:boolean, has_runtime:boolean}>}
+ */
+function listLinkedSpecies() {
+  const runtime = loadRuntimeSpecies();
+  const catalog = loadCatalogIndex();
+  const allIds = new Set([...runtime.keys(), ...catalog.keys()]);
+  const out = [];
+  for (const id of allIds) {
+    const slug = getWikiSlug(id);
+    out.push({
+      id,
+      slug,
+      has_catalog: slug ? catalog.has(slug) : catalog.has(id),
+      has_runtime: runtime.has(id),
+    });
+  }
+  return out.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function _resetCache() {
+  _runtimeCache = null;
+  _catalogCache = null;
+}
+
+module.exports = {
+  getWikiSlug,
+  getWikiUrl,
+  getWikiEntry,
+  listLinkedSpecies,
+  toKebabSlug,
+  _resetCache,
+};

--- a/apps/play/src/api.js
+++ b/apps/play/src/api.js
@@ -90,6 +90,18 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ session_id: sid, page_id: pageId, trigger_data: triggerData }),
     }),
+  // Sprint 3 §I (2026-04-27) — Tunic glyph progression (campaign-scope).
+  codexGlyphs: (campaignId) =>
+    jsonFetch(`/api/codex/glyphs?campaign_id=${encodeURIComponent(campaignId || '')}`),
+  codexGlyphIncrement: (campaignId, event, delta = 1) =>
+    jsonFetch('/api/codex/glyphs/increment', {
+      method: 'POST',
+      body: JSON.stringify({ campaign_id: campaignId, event, delta }),
+    }),
+  codexGlyphPage: (campaignId, pageId) =>
+    jsonFetch(
+      `/api/codex/page/${encodeURIComponent(pageId)}?campaign_id=${encodeURIComponent(campaignId || '')}`,
+    ),
   commitRound: (sid, autoResolve = true) =>
     jsonFetch('/api/session/commit-round', {
       method: 'POST',

--- a/apps/play/src/codexPanel.js
+++ b/apps/play/src/codexPanel.js
@@ -14,6 +14,12 @@ export function setCodexSessionId(sid) {
   _currentSessionId = sid;
 }
 
+// Sprint 3 §I (2026-04-27) — campaign_id holder for glyph progression.
+let _currentCampaignId = null;
+export function setCodexCampaignId(cid) {
+  _currentCampaignId = cid;
+}
+
 // Glossario terms — canonical meccanica Evo-Tactics.
 const GLOSSARIO = [
   {
@@ -171,6 +177,7 @@ function getOrCreatePanel() {
       </div>
       <nav class="codex-tabs" role="tablist">
         <button class="codex-tab active" data-tab="pagine" role="tab">📜 Pagine</button>
+        <button class="codex-tab" data-tab="glifi" role="tab">⌬ Glifi</button>
         <button class="codex-tab" data-tab="tips" role="tab">💡 Tips</button>
         <button class="codex-tab" data-tab="glossario" role="tab">📖 Glossario</button>
         <button class="codex-tab" data-tab="abilita" role="tab">⚔ Abilità</button>
@@ -178,6 +185,7 @@ function getOrCreatePanel() {
       </nav>
       <div class="codex-panel-body">
         <div class="codex-tab-content" data-tab-content="pagine"></div>
+        <div class="codex-tab-content hidden" data-tab-content="glifi"></div>
         <div class="codex-tab-content hidden" data-tab-content="tips"></div>
         <div class="codex-tab-content hidden" data-tab-content="glossario"></div>
         <div class="codex-tab-content hidden" data-tab-content="abilita"></div>
@@ -211,10 +219,80 @@ function renderTabContent(tabName) {
   const container = document.querySelector(`[data-tab-content="${tabName}"]`);
   if (!container) return;
   if (tabName === 'pagine') renderPagineTab(container);
+  else if (tabName === 'glifi') renderGlifiTab(container);
   else if (tabName === 'tips') renderTipsTab(container);
   else if (tabName === 'glossario') renderGlossarioTab(container);
   else if (tabName === 'abilita') renderAbilitaTab(container);
   else if (tabName === 'statuses') renderStatusesTab(container);
+}
+
+// Sprint 3 §I (2026-04-27) — Glyph progression tab. Tunic decipher pattern:
+// glyphs unlock via gameplay events (kill_species, enter_biome, ecc).
+// Source: data/core/codex/tunic_glyphs.yaml + apps/backend/services/codex/tunicGlyphs.js.
+function renderGlifiTab(el) {
+  if (!_currentCampaignId) {
+    el.innerHTML = `
+      <p class="codex-intro">Avvia una campagna per consultare la lingua degli antichi (Glifi A.L.I.E.N.A.).</p>
+    `;
+    return;
+  }
+  el.innerHTML = `<p class="codex-intro">Caricamento glifi...</p>`;
+  api
+    .codexGlyphs(_currentCampaignId)
+    .then((r) => {
+      if (!r.ok) {
+        el.innerHTML = `<p class="codex-intro">Errore caricamento glifi: ${r.data?.error || r.status}</p>`;
+        return;
+      }
+      const glyphs = Array.isArray(r.data?.glyphs) ? r.data.glyphs : [];
+      const counters = r.data?.counters || {};
+      const unlocked = Number(r.data?.unlocked_count || 0);
+      const total = Number(r.data?.total_count || glyphs.length);
+      const counterRows = Object.entries(counters)
+        .map(([ev, n]) => `<li><code>${ev}</code> · <strong>${n}</strong></li>`)
+        .join('');
+      el.innerHTML = `
+        <p class="codex-intro">
+          Lingua A.L.I.E.N.A. — ${unlocked}/${total} glifi decifrati.
+          Ogni glifo si rivela accumulando eventi specifici (uccidi specie, entra biomi, applica trait).
+        </p>
+        ${
+          counterRows
+            ? `<details class="codex-glyph-counters" open>
+                <summary><strong>Contatori campagna</strong></summary>
+                <ul class="codex-glyph-counter-list">${counterRows}</ul>
+              </details>`
+            : ''
+        }
+        <ul class="codex-glyph-list">
+          ${glyphs
+            .map((g) => {
+              const cls = g.unlocked ? 'codex-glyph unlocked' : 'codex-glyph locked';
+              const sym = g.glyph || '?';
+              const label = g.label || g.id;
+              const prog = g.progress || {};
+              const meaning = g.unlocked
+                ? `<div class="codex-glyph-meaning">${g.description || ''}</div>`
+                : `<div class="codex-glyph-hint">🔒 ${g.hint_unlock || ''} ${
+                    prog.threshold
+                      ? `<span class="codex-glyph-progress">(${prog.current || 0}/${prog.threshold})</span>`
+                      : ''
+                  }</div>`;
+              return `<li class="${cls}" data-glyph-id="${g.id}">
+                <div class="codex-glyph-header">
+                  <span class="codex-glyph-symbol" aria-hidden="true">${g.unlocked ? sym : '███'}</span>
+                  <strong class="codex-glyph-name">${label}</strong>
+                </div>
+                ${meaning}
+              </li>`;
+            })
+            .join('')}
+        </ul>
+      `;
+    })
+    .catch((err) => {
+      el.innerHTML = `<p class="codex-intro">Errore: ${err?.message || err}</p>`;
+    });
 }
 
 // Bundle B.3 — Pagine (decipher tab). Fetch da /api/v1/codex/pages?session_id=...

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -19,7 +19,7 @@ import { openReplay } from './replayPanel.js';
 import { sfx, setMuted, isMuted } from './sfx.js';
 import { initHelpPanel } from './helpPanel.js';
 import { showTip, buildRecoveryTipMessage, resetAllTips } from './tips.js';
-import { toggleCodex, setCodexSessionId } from './codexPanel.js';
+import { toggleCodex, setCodexSessionId, setCodexCampaignId } from './codexPanel.js';
 import { initFeedbackPanel } from './feedbackPanel.js';
 import { initCampaignPanel } from './campaignPanel.js';
 import { initLobbyBridgeIfPresent } from './lobbyBridge.js';
@@ -1087,6 +1087,10 @@ async function startNewSession() {
   // section AND no trait choice persisted for this session, open identity
   // picker overlay pre-tutorial. User picks (or auto-timeout default) → pass
   // initial_trait_choice to /start. Scoped: host only (first session).
+  // Sprint 3 §I (2026-04-27) — pipe campaign_id to codex panel for glyph progression tab.
+  if (lobbyBridge?.session?.campaign_id) {
+    setCodexCampaignId(lobbyBridge.session.campaign_id);
+  }
   if (lobbyBridge?.isHost && lobbyBridge.session.campaign_id) {
     try {
       let initialTraitChoice = null;

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -1153,6 +1153,90 @@ canvas#grid:hover {
   border-left: 2px solid #8b6fb0;
 }
 
+/* Sprint 3 §I (2026-04-27) — Tunic glyph progression list. */
+.codex-glyph-counters {
+  margin: 8px 0 12px;
+  padding: 6px 10px;
+  background: rgba(139, 111, 176, 0.08);
+  border-left: 2px solid #8b6fb0;
+  border-radius: 3px;
+  font-size: 0.85em;
+}
+.codex-glyph-counter-list {
+  list-style: none;
+  padding: 0;
+  margin: 4px 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+}
+.codex-glyph-counter-list code {
+  font-size: 0.85em;
+  opacity: 0.8;
+}
+.codex-glyph-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 10px;
+}
+.codex-glyph {
+  border: 1px solid var(--border);
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 4px;
+}
+.codex-glyph.unlocked {
+  border-color: #6fb04a;
+  background: rgba(111, 176, 74, 0.06);
+}
+.codex-glyph.locked {
+  opacity: 0.7;
+}
+.codex-glyph-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+.codex-glyph-symbol {
+  font-size: 1.6em;
+  line-height: 1;
+  width: 1.4em;
+  text-align: center;
+  color: #d4b8e8;
+}
+.codex-glyph.locked .codex-glyph-symbol {
+  letter-spacing: -2px;
+  font-size: 1em;
+  opacity: 0.5;
+}
+.codex-glyph-name {
+  font-size: 0.95em;
+}
+.codex-glyph-meaning {
+  font-size: 0.85em;
+  line-height: 1.4;
+  color: var(--text);
+  opacity: 0.85;
+}
+.codex-glyph-hint {
+  font-size: 0.8em;
+  font-style: italic;
+  color: #d4b8e8;
+  padding: 4px 6px;
+  background: rgba(139, 111, 176, 0.1);
+  border-left: 2px solid #8b6fb0;
+}
+.codex-glyph-progress {
+  font-style: normal;
+  font-weight: bold;
+  margin-left: 4px;
+  opacity: 0.9;
+}
+
 /* Bundle B.2 — Undo button (TBW Tactical Breach Wizards pattern). */
 .undo-btn {
   background: #4a3a5a !important;

--- a/docs/reports/2026-04-27-stato-arte-completo-vertical-slice.md
+++ b/docs/reports/2026-04-27-stato-arte-completo-vertical-slice.md
@@ -221,7 +221,7 @@ Fonte: PR #1891 + report Skiv ADR + 5 reconciliation docs.
 - 🔴 **Beast Bond reaction trigger** (~5h) — adjacency-trigger per-creature trait.
 - 🔴 **3 nuovi elementi** (earth/wind/dark) (~6h con balance pass).
 - 🔴 **Ability r3/r4 tier** (~10h) — estende `abilities.yaml` r1/r2 esistente.
-- 🔴 **Beast Showcase wiki cross-link** (~3h cosmetic).
+- 🟢 **Beast Showcase wiki cross-link** — Sprint 3 §II shipped (wikiLinkBridge service + 3 REST endpoint + audit coverage report + 10 unit test).
 
 #### B.1.6 — XCOM EW (1 pattern residuo)
 - 🔴 **Officer Training School meta perks** (~10h) — campaign-gated 6-8 meta slot. **In v3.7 §4**.
@@ -253,7 +253,7 @@ Fonte: PR #1891 + report Skiv ADR + 5 reconciliation docs.
 - 🔴 **Permanent visible aspect change battle-scar registry** (~12h) — mid-fight events alterano sprite long-term.
 - 🔴 **Portrait stratificati layered overlay** (~15h) — face + scar + age + clothes via canvas compositing.
 - 🔴 **Companion lifecycle aging cross-session** (~10h) — counter cross-session.
-- 🔴 **Choice → permanent consequence flag in campaign state** (~4h).
+- 🟢 **Choice → permanent consequence flag in campaign state** — Sprint 3 §III shipped (campaignStore.permanentFlags + recordPermanentFlag/getPermanentFlag + 3 REST endpoint + 9 unit test, idempotent on key).
 
 #### B.1.12 — Jackbox / XCOM 2 multi (2 pattern residui)
 - 🔴 **Jack Principles guidance toast per phase** (~5h) — V1 onboarding shipped, estendi a phase-by-phase.

--- a/tests/api/contracts-hydration-snapshot.test.js
+++ b/tests/api/contracts-hydration-snapshot.test.js
@@ -47,11 +47,11 @@ test('hydration snapshot aggrega correttamente resistances per canale', () => {
   const party02 = state.units.find((u) => u.id === 'party-02');
   assert.ok(party02, 'party-02 presente');
   // mantello_meteoritico: fisico +20, fuoco +20
-  // sangue_piroforico: fuoco +20
-  // Atteso aggregato: fisico 20, fuoco 40
+  // sangue_piroforico: fuoco +10 (post nerf #1869 — was +20 pre-balance audit)
+  // Atteso aggregato: fisico 20, fuoco 30
   const byChannel = Object.fromEntries(party02.resistances.map((r) => [r.channel, r.modifier_pct]));
   assert.equal(byChannel.fisico, 20);
-  assert.equal(byChannel.fuoco, 40);
+  assert.equal(byChannel.fuoco, 30);
 });
 
 test('hydration snapshot propaga canale ionico (criostasi_adattiva) su party-03', () => {

--- a/tests/api/contracts-trait-mechanics.test.js
+++ b/tests/api/contracts-trait-mechanics.test.js
@@ -127,13 +127,20 @@ test('trait_mechanics.yaml rispetta le invarianti euristiche documentate nell AD
   const catalog = loadCatalog();
   const t = catalog.traits;
 
-  const breakerTraits = ['artigli_sette_vie', 'sangue_piroforico', 'frusta_fiammeggiante'];
-  for (const id of breakerTraits) {
+  // Post nerf 2026-04-25 #1869: sangue_piroforico ridotto a damage_step 0 +
+  // resistance fuoco 10 (era 20). Resta breaker per attack_mod >=1 ma damage
+  // step lasciato a 0 dopo audit dominance — quindi escluso dal damage_step
+  // invariant check.
+  const breakerTraitsAttack = ['artigli_sette_vie', 'sangue_piroforico', 'frusta_fiammeggiante'];
+  const breakerTraitsDamageStep = ['artigli_sette_vie', 'frusta_fiammeggiante'];
+  for (const id of breakerTraitsAttack) {
     assert.ok(t[id], `breaker trait ${id} presente`);
     assert.ok(
       t[id].attack_mod >= 1,
       `breaker ${id}: attack_mod >= 1 (attuale ${t[id].attack_mod})`,
     );
+  }
+  for (const id of breakerTraitsDamageStep) {
     assert.ok(
       t[id].damage_step >= 1,
       `breaker ${id}: damage_step >= 1 (attuale ${t[id].damage_step})`,

--- a/tests/api/rewardOffer.test.js
+++ b/tests/api/rewardOffer.test.js
@@ -104,7 +104,9 @@ test('buildOffer: returns 3 unique offers', () => {
   const ids = result.offers.map((o) => o.card.id);
   assert.equal(new Set(ids).size, 3);
   assert.equal(result.skip_available, true);
-  assert.equal(result.skip_fragment_delta, 1);
+  // 2026-04-26 #1870 — orphan currency cleanup: skip_fragment_delta resets to 0
+  // (re-enable a 1 quando nest sink M10+ live).
+  assert.equal(result.skip_fragment_delta, 0);
 });
 
 test('buildOffer: empty pool returns empty offers', () => {

--- a/tests/api/tutorial.test.js
+++ b/tests/api/tutorial.test.js
@@ -23,7 +23,8 @@ test('GET /api/tutorial/enc_tutorial_01 returns valid scenario', async (t) => {
   assert.equal(res.status, 200);
   assert.equal(res.body.id, 'enc_tutorial_01');
   assert.equal(res.body.name, 'Primi Passi nella Savana');
-  assert.equal(res.body.objective, 'elimination');
+  // PR #1871 (2026-04-25) — objective JS string promoted to schema object {type, ...}.
+  assert.equal(res.body.objective?.type ?? res.body.objective, 'elimination');
   assert.equal(res.body.grid_size, 6);
   assert.ok(Array.isArray(res.body.units));
   assert.equal(res.body.units.length, 4);

--- a/tests/services/campaignPermanentFlags.test.js
+++ b/tests/services/campaignPermanentFlags.test.js
@@ -1,0 +1,106 @@
+// Sprint 3 §III (2026-04-27) — Wildermyth choice→permanent flag pattern.
+//
+// Source: docs/research/2026-04-26-tier-s-extraction-matrix.md #12 Wildermyth.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createCampaign,
+  getCampaign,
+  recordPermanentFlag,
+  getPermanentFlag,
+  _resetStore,
+} = require('../../apps/backend/services/campaign/campaignStore');
+
+test('createCampaign initializes empty permanentFlags array', () => {
+  _resetStore();
+  const c = createCampaign('p1');
+  assert.deepEqual(c.permanentFlags, []);
+});
+
+test('createCampaign accepts permanentFlags in opts', () => {
+  _resetStore();
+  const c = createCampaign('p1', 'default', {
+    permanentFlags: [{ key: 'preexisting', value: true, recorded_at: '2026-04-27T00:00:00Z' }],
+  });
+  assert.equal(c.permanentFlags.length, 1);
+  assert.equal(c.permanentFlags[0].key, 'preexisting');
+});
+
+test('recordPermanentFlag appends new flag', () => {
+  _resetStore();
+  const c = createCampaign('p1');
+  const updated = recordPermanentFlag(c.id, {
+    key: 'spared_apex',
+    value: true,
+    narrative: 'Hai risparmiato il Predatore — ricorderà.',
+    source_chapter: 3,
+  });
+  assert.equal(updated.permanentFlags.length, 1);
+  const f = updated.permanentFlags[0];
+  assert.equal(f.key, 'spared_apex');
+  assert.equal(f.value, true);
+  assert.equal(f.narrative, 'Hai risparmiato il Predatore — ricorderà.');
+  assert.equal(f.source_chapter, 3);
+  assert.ok(f.recorded_at);
+});
+
+test('recordPermanentFlag idempotent on same key (updates value, retains recorded_at)', () => {
+  _resetStore();
+  const c = createCampaign('p1');
+  const first = recordPermanentFlag(c.id, { key: 'pact_made', value: 'silver' });
+  const recordedAt = first.permanentFlags[0].recorded_at;
+  // Wait a tick (deterministic via two calls) then update
+  const second = recordPermanentFlag(c.id, { key: 'pact_made', value: 'gold' });
+  assert.equal(second.permanentFlags.length, 1, 'no duplicate');
+  assert.equal(second.permanentFlags[0].value, 'gold');
+  assert.equal(second.permanentFlags[0].recorded_at, recordedAt, 'original timestamp preserved');
+});
+
+test('recordPermanentFlag uses currentChapter as default source_chapter', () => {
+  _resetStore();
+  const c = createCampaign('p1');
+  // c.currentChapter = 1 by default
+  const updated = recordPermanentFlag(c.id, { key: 'discovered_glyph' });
+  assert.equal(updated.permanentFlags[0].source_chapter, 1);
+});
+
+test('recordPermanentFlag ignores invalid input', () => {
+  _resetStore();
+  const c = createCampaign('p1');
+  assert.equal(recordPermanentFlag(c.id, null), null);
+  assert.equal(recordPermanentFlag(c.id, { value: 1 }), null, 'no key');
+  assert.equal(recordPermanentFlag('nonexistent_id', { key: 'x' }), null);
+});
+
+test('getPermanentFlag returns the flag entry', () => {
+  _resetStore();
+  const c = createCampaign('p1');
+  recordPermanentFlag(c.id, { key: 'broke_seal', value: 1 });
+  const f = getPermanentFlag(c.id, 'broke_seal');
+  assert.ok(f);
+  assert.equal(f.key, 'broke_seal');
+  assert.equal(f.value, 1);
+});
+
+test('getPermanentFlag returns null when missing', () => {
+  _resetStore();
+  const c = createCampaign('p1');
+  assert.equal(getPermanentFlag(c.id, 'never_set'), null);
+  assert.equal(getPermanentFlag('bad_id', 'x'), null);
+});
+
+test('multiple flags accumulate independently', () => {
+  _resetStore();
+  const c = createCampaign('p1');
+  recordPermanentFlag(c.id, { key: 'flag_a', value: 1 });
+  recordPermanentFlag(c.id, { key: 'flag_b', value: 2 });
+  recordPermanentFlag(c.id, { key: 'flag_c', value: 3 });
+  const fresh = getCampaign(c.id);
+  assert.equal(fresh.permanentFlags.length, 3);
+  const keys = fresh.permanentFlags.map((f) => f.key).sort();
+  assert.deepEqual(keys, ['flag_a', 'flag_b', 'flag_c']);
+});

--- a/tests/services/wikiLinkBridge.test.js
+++ b/tests/services/wikiLinkBridge.test.js
@@ -1,0 +1,91 @@
+// Unit test for AncientBeast wiki cross-link slug bridge — Sprint 3 §II.
+//
+// Source: docs/research/2026-04-26-tier-s-extraction-matrix.md #6 AncientBeast.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  getWikiSlug,
+  getWikiUrl,
+  getWikiEntry,
+  listLinkedSpecies,
+  toKebabSlug,
+  _resetCache,
+} = require('../../apps/backend/services/species/wikiLinkBridge');
+
+test('toKebabSlug normalizes underscore_case to kebab-case', () => {
+  assert.equal(toKebabSlug('dune_stalker'), 'dune-stalker');
+  assert.equal(toKebabSlug('SAND_BURROWER'), 'sand-burrower');
+  assert.equal(toKebabSlug(''), '');
+  assert.equal(toKebabSlug(null), '');
+});
+
+test('getWikiSlug resolves dune_stalker → dune-stalker (catalog hit)', () => {
+  _resetCache();
+  const slug = getWikiSlug('dune_stalker');
+  assert.equal(slug, 'dune-stalker', 'kebab-case match in catalog');
+});
+
+test('getWikiSlug returns null for unknown species', () => {
+  _resetCache();
+  const slug = getWikiSlug('totally_imaginary_xyz_zzz');
+  assert.equal(slug, null);
+});
+
+test('getWikiSlug returns null for empty input', () => {
+  assert.equal(getWikiSlug(''), null);
+  assert.equal(getWikiSlug(null), null);
+});
+
+test('getWikiUrl builds runtime URL for dune_stalker', () => {
+  _resetCache();
+  const url = getWikiUrl('dune_stalker');
+  assert.match(url || '', /dune-stalker\.json$/);
+});
+
+test('getWikiUrl uses custom basePath + ext', () => {
+  _resetCache();
+  const url = getWikiUrl('dune_stalker', { basePath: '/wiki', ext: '.html' });
+  assert.equal(url, '/wiki/dune-stalker.html');
+});
+
+test('getWikiEntry returns full catalog JSON for dune_stalker', () => {
+  _resetCache();
+  const entry = getWikiEntry('dune_stalker');
+  assert.ok(entry, 'catalog entry should exist');
+  assert.equal(typeof entry, 'object');
+});
+
+test('getWikiEntry returns null for unknown species', () => {
+  _resetCache();
+  assert.equal(getWikiEntry('unknown_xyz'), null);
+});
+
+test('listLinkedSpecies returns audit array sorted by id', () => {
+  _resetCache();
+  const list = listLinkedSpecies();
+  assert.ok(Array.isArray(list));
+  assert.ok(list.length > 0, 'should have at least 1 entry');
+  for (const entry of list) {
+    assert.ok(typeof entry.id === 'string');
+    assert.ok(typeof entry.has_runtime === 'boolean');
+    assert.ok(typeof entry.has_catalog === 'boolean');
+  }
+  // Sorted check
+  const ids = list.map((e) => e.id);
+  const sorted = [...ids].sort((a, b) => a.localeCompare(b));
+  assert.deepEqual(ids, sorted);
+});
+
+test('listLinkedSpecies includes dune_stalker as fully linked', () => {
+  _resetCache();
+  const list = listLinkedSpecies();
+  const dune = list.find((e) => e.id === 'dune_stalker');
+  assert.ok(dune, 'dune_stalker present');
+  assert.equal(dune.has_runtime, true);
+  assert.equal(dune.has_catalog, true);
+  assert.equal(dune.slug, 'dune-stalker');
+});


### PR DESCRIPTION
## Summary

Sprint 3 autonomous plan 2026-04-27 — chiude 3 pattern residui da stato-arte §B.1.5 AncientBeast e §B.1.11 Wildermyth.

## §I — Tunic Glyph progression UI surface (Bundle B.3 closure)
- `codexPanel.js`: +tab "⌬ Glifi" (renderGlifiTab — grid layout locked/unlocked + counters + decifra hint)
- `api.js`: +3 metodi (codexGlyphs/Increment/Page)
- `style.css`: +90 LOC CSS `.codex-glyph-*`
- `main.js`: pipe campaign_id to codex panel via setCodexCampaignId

## §II — AncientBeast Beast Showcase wiki cross-link (Tier S #6 — minimal ~3h)
- `wikiLinkBridge.js` NEW — slug normalization (legacy_slug → kebab-case auto)
- `speciesWiki.js` NEW — 3 REST endpoint (resolve slug + entry + audit)
- 10/10 unit test verde (toKebabSlug + dune_stalker resolution + audit array)

## §III — Wildermyth choice→permanent flag campaign state (Tier S #12 — minimal ~4h)
- `campaignStore.js`: +permanentFlags array + recordPermanentFlag/getPermanentFlag
- `campaign.js`: +3 REST endpoint (record + list + single query)
- Idempotent on key (preserva recorded_at, aggiorna value)
- 9/9 unit test verde

## §IV — Stale fixture maintenance (4 fail unrelated to Sprint 3, fix opportunistic)
- `contracts-hydration-snapshot.test.js`: fuoco 40→30 (post #1869 sangue_piroforico nerf)
- `contracts-trait-mechanics.test.js`: split breaker invariants (sangue_piroforico damage_step 0 ok)
- `rewardOffer.test.js`: skip_fragment_delta 1→0 (post #1870 orphan currency cleanup)
- `tutorial.test.js`: objective string→object (post #1871 schema promotion)

## Test plan
- [x] `node --test tests/services/{biomeAffinity,wikiLinkBridge,campaignPermanentFlags,reinforcementSpawner}.test.js` → 41 verde
- [x] `node --test tests/ai/*.test.js` → 311/311 verde (regression baseline)
- [x] `node --test tests/api/{contracts-hydration-snapshot,contracts-trait-mechanics,rewardOffer,tutorial}.test.js` → 43 verde
- [x] **Total: 343/343 verde + 43 fixture restore**
- [x] `prettier --check` verde

## Stato-arte
- §B.1.5 AncientBeast wiki cross-link: 🔴 → **🟢 shipped**
- §B.1.11 Wildermyth choice flag: 🔴 → **🟢 shipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)