### PR TITLE
feat(mutations): Path B — catalog rebalance +6 entries + lint balance (S6 fairness)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
         evo-tactics-pack dev-stack test-stack ci-stack \
         evo-batch-plan evo-batch-run evo-plan evo-run evo-list evo-lint \
         evo-help evo-validate evo-backlog traits-review update-tracker \
-        ci-log-harvest
+        ci-log-harvest lint-mutations
 
 PYTHON ?= python3
 EVO_AUTOMATION := $(PYTHON) -m tools.automation.evo_batch_runner
@@ -179,3 +179,6 @@ ci-log-harvest:
 		$(if $(CI_LOG_HARVEST_CONFIG),--config "${CI_LOG_HARVEST_CONFIG}",) \
 		$(if $(CI_LOG_HARVEST_DRY_RUN),--dry-run,) \
 		${CI_LOG_HARVEST_ARGS}
+
+lint-mutations:
+	$(PYTHON) tools/py/lint_mutation_balance.py

--- a/data/core/mutations/mutation_catalog.yaml
+++ b/data/core/mutations/mutation_catalog.yaml
@@ -900,3 +900,189 @@ mutations:
       Ferocia ancestrale evolve in midollo iperattivo: rage 3 turni
       passa a rage 3 turni + cascata neuroendocrina prolungata. Apex
       berserker tier.
+
+  # ============================================================================
+  # SYMBIOTIC — rebalance pass 2026-04-27 (Path B: fix bingo physio dominance)
+  # Aggiunti 3 simbionti per portare category da 2 (6.7%) a 5 (13.9%) — sblocca
+  # archetype "symbiont_plus" reachable in playtest reali, non solo teorici.
+  # ============================================================================
+
+  simbionte_micorriza_radici:
+    tier: 2
+    category: symbiotic
+    body_slot: null
+    name_it: "Mutazione: Simbionte Micorriza Radici"
+    name_en: "Mutation: Mycorrhizal Root Symbiont"
+    prerequisites:
+      traits: [nodi_micorrizici_oracolari]
+      mutations: []
+    trait_swap:
+      remove: []
+      add: [mucillagine_simbionte_mangrovie]
+    pe_cost: 14
+    pi_cost: 8
+    derived_ability_id: null
+    mp_cost: 8
+    biome_boost: [foresta_temperata, foresta_miceliale, palude]
+    biome_penalty: [deserto_caldo, pianura_salina_iperarida]
+    mbti_alignment: { I: 1, F: 1 }
+    trigger_examples:
+      - "8 turni cumulativi in biome forestale/palustre"
+      - "alleato adiacente che subisce status physiological 5+ volte"
+    visual_swap_it: "Tier 2: emerge mucillagine simbionte mangrovie. Filamenti radicali visibili (overlay distinct)."
+    description_it: |
+      Acquisisce simbiosi radicale con micorrize fungali: gli alleati
+      adiacenti per 2+ turni ricevono +1 healing/turno. Trade-off:
+      movement penalty -1 finche' simbionte attivo.
+
+  simbionte_lichene_solare:
+    tier: 2
+    category: symbiotic
+    body_slot: null
+    name_it: "Mutazione: Simbionte Lichene Solare"
+    name_en: "Mutation: Solar Lichen Symbiont"
+    prerequisites:
+      traits: [capillari_fluoridici]
+      mutations: []
+    trait_swap:
+      remove: []
+      add: [olfatto_risonanza_magnetica]
+    pe_cost: 13
+    pi_cost: 7
+    derived_ability_id: null
+    mp_cost: 8
+    biome_boost: [altipiani_solari, deserto_caldo, canopia_ionica]
+    biome_penalty: [caverna, abisso_vulcanico, frattura_abissale_sinaptica]
+    mbti_alignment: { N: 1, P: 1 }
+    trigger_examples:
+      - "5 turni cumulativi sotto luce intensa (biome solare)"
+      - "subito 3 hit fotonici/elettrici senza KO"
+    visual_swap_it: "Tier 2: emerge lichene fotosintetico. Patches verdi-dorate sulla pelle (overlay distinct)."
+    description_it: |
+      Sviluppa simbiosi con licheni fotosintetici: in biome solare
+      rigenera +1 mp/turno (cap 3 turni). Apre a sinergie symbiont
+      job archetype.
+
+  simbionte_batteri_termofili:
+    tier: 3
+    category: symbiotic
+    body_slot: null
+    name_it: "Mutazione: Endosimbiosi Termofila Capstone"
+    name_en: "Mutation: Thermophilic Endosymbiosis Capstone"
+    prerequisites:
+      traits: [batteri_termofili_endosimbiosi]
+      mutations: [symbiosis_chemio_endosymbiont]
+    trait_swap:
+      remove: []
+      add: [batteri_endosimbionti_chemio]
+    pe_cost: 22
+    pi_cost: 12
+    derived_ability_id: null
+    mp_cost: 15
+    biome_boost: [abisso_vulcanico, dorsale_termale_tropicale, reef_luminescente]
+    biome_penalty: [cryosteppe, mezzanotte_orbitale]
+    mbti_alignment: { F: 1, J: 1 }
+    trigger_examples:
+      - "completata mutation symbiosis_chemio_endosymbiont"
+      - "10 turni cumulativi con alleato adiacente in biome termale"
+    visual_swap_it: "Tier 3: doppio simbionte attivo. Aura termica visibile + valvole condotti chemio."
+    description_it: |
+      Capstone della linea simbiotica: doppio endosimbionte attivo
+      (chemio + termofilo). Rage on-kill estende +2 turni con alleato
+      adiacente, healing condiviso 1 hp/turno. Sblocca archetype
+      "symbiont_plus" se 3 mutation symbiotic attive.
+
+  # ============================================================================
+  # BEHAVIORAL — rebalance pass 2026-04-27 (Path B)
+  # Aggiunti 2 behavioral per portare category da 4 (13.3%) a 6 (16.7%)
+  # ============================================================================
+
+  branco_cooperazione_segnalata:
+    tier: 2
+    category: behavioral
+    body_slot: mouth
+    name_it: "Mutazione: Cooperazione di Branco"
+    name_en: "Mutation: Pack Cooperation"
+    prerequisites:
+      traits: [tattiche_di_branco]
+      mutations: []
+    trait_swap:
+      remove: []
+      add: [risonanza_di_branco]
+    pe_cost: 12
+    pi_cost: 7
+    derived_ability_id: null
+    mp_cost: 8
+    biome_boost: [savana, foresta_temperata, badlands]
+    biome_penalty: [mezzanotte_orbitale]
+    mbti_alignment: { E: 1, F: 1 }
+    trigger_examples:
+      - "3 squad combo focus_fire stesso target stesso round"
+      - "alleato della stessa specie KO in adiacenza"
+    visual_swap_it: "Tier 2: emerge risonanza di branco. Postura sincronizzata, vocalizzi udibili."
+    description_it: |
+      Le tattiche di branco evolvono in risonanza vocale: alleati entro
+      2 tile ricevono +1 attack_mod_bonus quando attaccano stesso target
+      del mutante (focus_fire amplificato). Trade-off: -1 defense_mod
+      durante l'effetto.
+
+  gerarchia_dominanza_ritualizzata:
+    tier: 2
+    category: behavioral
+    body_slot: mouth
+    name_it: "Mutazione: Dominanza Ritualizzata"
+    name_en: "Mutation: Ritualized Dominance"
+    prerequisites:
+      traits: [intimidatore]
+      mutations: [intimidator_to_dispersal]
+    trait_swap:
+      remove: []
+      add: [aura_di_dispersione_mentale]
+    pe_cost: 13
+    pi_cost: 8
+    derived_ability_id: null
+    mp_cost: 8
+    biome_boost: [rovine_planari, frattura_abissale_sinaptica, canyons_risonanti]
+    biome_penalty: [foresta_miceliale]
+    mbti_alignment: { E: 1, J: 1 }
+    trigger_examples:
+      - "completata mutation intimidator_to_dispersal"
+      - "panic applicato 12+ volte cumulato post-mutation precedente"
+    visual_swap_it: "Tier 2: postura dominante esibita. Vocalizzi territoriali ad alta intensita'."
+    description_it: |
+      L'aura di dispersione si ritualizza: i nemici panicked entro 3 tile
+      hanno -1 attack_mod aggiuntivo. Doppio source di pressure controllato.
+      Synergy chain con intimidator_to_dispersal capstone.
+
+  # ============================================================================
+  # SENSORIAL — rebalance pass 2026-04-27 (Path B)
+  # Aggiunto 1 sensorial per portare category da 5 (16.7%) a 6 (16.7%)
+  # ============================================================================
+
+  recettori_chimici_seed_tracking:
+    tier: 2
+    category: sensorial
+    body_slot: sense
+    name_it: "Mutazione: Recettori Chimici da Tracking"
+    name_en: "Mutation: Chemical Tracking Receptors"
+    prerequisites:
+      traits: [chemiorecettori_bromuro]
+      mutations: []
+    trait_swap:
+      remove: []
+      add: [olfatto_risonanza_magnetica]
+    pe_cost: 11
+    pi_cost: 6
+    derived_ability_id: null
+    mp_cost: 8
+    biome_boost: [palude, foresta_acida, atollo_obsidiana]
+    biome_penalty: [stratosfera_tempestosa, mezzanotte_orbitale]
+    mbti_alignment: { S: 1, P: 1 }
+    trigger_examples:
+      - "5 hit MoS >= 5 contro stesso target in 1 encounter (lock cinetico)"
+      - "10 turni cumulativi in biome chimicamente attivo"
+    visual_swap_it: "Tier 2: chemiorecettori ipertrofici. Antenne sensitive estensione visibile."
+    description_it: |
+      I chemiorecettori bromuro si specializzano in tracking persistente:
+      target colpiti ricevono debuff -1 defense_mod 2 turni (estende
+      finestra burst del party). Bias verso job Stalker.

--- a/reports/lint/mutation_balance.json
+++ b/reports/lint/mutation_balance.json
@@ -1,0 +1,33 @@
+{
+  "ok": true,
+  "total": 36,
+  "categories": {
+    "behavioral": {
+      "count": 6,
+      "percentage": 16.67
+    },
+    "environmental": {
+      "count": 5,
+      "percentage": 13.89
+    },
+    "physiological": {
+      "count": 14,
+      "percentage": 38.89
+    },
+    "sensorial": {
+      "count": 6,
+      "percentage": 16.67
+    },
+    "symbiotic": {
+      "count": 5,
+      "percentage": 13.89
+    }
+  },
+  "warnings": [],
+  "errors": [],
+  "thresholds": {
+    "warn_pct": 40.0,
+    "error_pct": 50.0,
+    "min_per_category": 4
+  }
+}

--- a/tests/api/mutationsRoutes.test.js
+++ b/tests/api/mutationsRoutes.test.js
@@ -7,13 +7,14 @@ const assert = require('node:assert/strict');
 const request = require('supertest');
 const { createApp } = require('../../apps/backend/app');
 
-test('GET /api/v1/mutations/registry returns 30 mutations + indexes', async () => {
+test('GET /api/v1/mutations/registry returns 36 mutations + indexes', async () => {
   const { app, close } = createApp({ databasePath: null });
   try {
     const res = await request(app).get('/api/v1/mutations/registry').expect(200);
-    assert.equal(res.body.count, 30);
+    // Path B rebalance 2026-04-27: 30 → 36 entries.
+    assert.equal(res.body.count, 36);
     assert.ok(Array.isArray(res.body.mutations));
-    assert.equal(res.body.mutations.length, 30);
+    assert.equal(res.body.mutations.length, 36);
     assert.equal(res.body.schema_version, '0.1.0');
     assert.ok(res.body.by_category && typeof res.body.by_category === 'object');
     assert.ok(res.body.by_tier && typeof res.body.by_tier === 'object');

--- a/tests/services/mutationCatalogLoader.test.js
+++ b/tests/services/mutationCatalogLoader.test.js
@@ -17,13 +17,20 @@ const {
   _resetCacheForTest,
 } = require('../../apps/backend/services/mutations/mutationCatalogLoader');
 
-test('loadMutationCatalog: returns parsed catalog with all 30 entries + indexes', () => {
+test('loadMutationCatalog: returns parsed catalog with all 36 entries + indexes', () => {
   _resetCacheForTest();
   const data = loadMutationCatalog({ refresh: true });
   const entries = Object.keys(data.byId);
-  assert.equal(entries.length, 30, 'expected 30 mutations in shipped catalog');
+  // Path B rebalance 2026-04-27: 30 → 36 (+3 symbiotic +2 behavioral +1 sensorial).
+  // Fixes anti-pattern S6 (ADR-2026-04-26): physiological dominance 47% → 38.9%.
+  assert.equal(
+    entries.length,
+    36,
+    'expected 36 mutations in shipped catalog (post Path B rebalance)',
+  );
   assert.ok(data.byId.artigli_freeze_to_glacier, 'artigli_freeze_to_glacier present');
   assert.ok(data.byId.ferocia_to_supercritical, 'ferocia_to_supercritical present');
+  assert.ok(data.byId.simbionte_micorriza_radici, 'simbionte_micorriza_radici (Path B) present');
   assert.equal(data.schema_version, '0.1.0');
   assert.ok(data.byCategory.physiological && data.byCategory.physiological.length > 0);
   assert.ok(data.byTier['2'] && data.byTier['2'].length > 0);
@@ -40,11 +47,11 @@ test('byId / byCategory / byTier indexes are correct', () => {
   // byCategory groups all entries.
   let totalByCategory = 0;
   for (const arr of Object.values(data.byCategory)) totalByCategory += arr.length;
-  assert.equal(totalByCategory, 30);
+  assert.equal(totalByCategory, 36);
   // byTier groups all entries.
   let totalByTier = 0;
   for (const arr of Object.values(data.byTier)) totalByTier += arr.length;
-  assert.equal(totalByTier, 30);
+  assert.equal(totalByTier, 36);
 });
 
 test('listEligibleForUnit: filters by trait prerequisites', () => {

--- a/tests/services/mutationEngine.test.js
+++ b/tests/services/mutationEngine.test.js
@@ -117,7 +117,7 @@ test('applyMutationPure: trait_swap applied + mutation tracked + mp deducted', (
 });
 
 test('applyMutationPure: derived_ability_id emerges into unit.abilities when set', () => {
-  // derived_ability_id è null per tutte 30 entries shipped — patch catalog inline
+  // derived_ability_id è null per tutte 36 entries shipped — patch catalog inline
   const catalog = freshCatalog();
   catalog.byId.artigli_freeze_to_glacier.derived_ability_id = 'ability_glacial_bite';
   const unit = {

--- a/tools/py/lint_mutation_balance.py
+++ b/tools/py/lint_mutation_balance.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Lint mutation_catalog.yaml category balance (Path B 2026-04-27).
+
+Fixes anti-pattern S6 (ADR-2026-04-26 spore-part-pack-slots): pre-rebalance
+14/30 physiological mutations (47%) made bingo physiological quasi-garantito.
+Target post-rebalance: nessuna category > 40% (warn) and > 50% (error).
+
+Output:
+  - JSON report: reports/lint/mutation_balance.json
+  - stdout: human-readable summary
+  - exit 0 = ok, exit 1 = hard error (any category > 50% or no entries)
+
+Usage:
+  python tools/py/lint_mutation_balance.py
+  python tools/py/lint_mutation_balance.py --catalog path/to/custom.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CATALOG = REPO_ROOT / "data" / "core" / "mutations" / "mutation_catalog.yaml"
+DEFAULT_REPORT = REPO_ROOT / "reports" / "lint" / "mutation_balance.json"
+
+WARN_THRESHOLD_PCT = 40.0
+ERROR_THRESHOLD_PCT = 50.0
+MIN_ENTRIES_PER_CATEGORY = 4
+SYMBIOTIC_MIN_EXEMPT = True  # symbiotic intentionally rarer (ADR §S1)
+
+
+def load_catalog(path: Path) -> dict:
+    with open(path, encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def analyze(catalog: dict) -> dict:
+    mutations = catalog.get("mutations") or {}
+    total = len(mutations)
+    if total == 0:
+        return {
+            "ok": False,
+            "total": 0,
+            "categories": {},
+            "warnings": ["catalog_empty"],
+            "errors": ["no_mutations_in_catalog"],
+        }
+
+    cats = Counter(m.get("category", "_unknown") for m in mutations.values())
+    warnings: list[str] = []
+    errors: list[str] = []
+
+    cat_report: dict[str, dict] = {}
+    for cat, n in sorted(cats.items()):
+        pct = 100.0 * n / total
+        cat_report[cat] = {"count": n, "percentage": round(pct, 2)}
+        if pct > ERROR_THRESHOLD_PCT:
+            errors.append(
+                f"category_dominance:{cat}={pct:.1f}% > {ERROR_THRESHOLD_PCT}%"
+            )
+        elif pct > WARN_THRESHOLD_PCT:
+            warnings.append(
+                f"category_dominance_warn:{cat}={pct:.1f}% > {WARN_THRESHOLD_PCT}%"
+            )
+        if n < MIN_ENTRIES_PER_CATEGORY:
+            if SYMBIOTIC_MIN_EXEMPT and cat == "symbiotic":
+                warnings.append(
+                    f"category_low_count:{cat}={n} (symbiotic exempt from min)"
+                )
+            else:
+                errors.append(
+                    f"category_low_count:{cat}={n} < {MIN_ENTRIES_PER_CATEGORY}"
+                )
+
+    return {
+        "ok": len(errors) == 0,
+        "total": total,
+        "categories": cat_report,
+        "warnings": warnings,
+        "errors": errors,
+        "thresholds": {
+            "warn_pct": WARN_THRESHOLD_PCT,
+            "error_pct": ERROR_THRESHOLD_PCT,
+            "min_per_category": MIN_ENTRIES_PER_CATEGORY,
+        },
+    }
+
+
+def write_report(report: dict, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(report, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
+
+
+def render_summary(report: dict) -> str:
+    lines = [
+        f"Mutation balance lint ({report['total']} entries)",
+        "Categories:",
+    ]
+    for cat, info in sorted(report["categories"].items()):
+        lines.append(f"  {cat}: {info['count']} ({info['percentage']}%)")
+    if report["warnings"]:
+        lines.append("Warnings:")
+        for w in report["warnings"]:
+            lines.append(f"  - {w}")
+    if report["errors"]:
+        lines.append("Errors:")
+        for e in report["errors"]:
+            lines.append(f"  - {e}")
+    lines.append("Status: " + ("OK" if report["ok"] else "FAIL"))
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", type=Path, default=DEFAULT_CATALOG)
+    parser.add_argument("--report", type=Path, default=DEFAULT_REPORT)
+    parser.add_argument(
+        "--quiet", action="store_true", help="Suppress stdout summary (report still written)"
+    )
+    args = parser.parse_args()
+
+    if not args.catalog.exists():
+        print(f"ERROR: catalog not found: {args.catalog}", file=sys.stderr)
+        return 2
+
+    try:
+        catalog = load_catalog(args.catalog)
+    except yaml.YAMLError as exc:
+        print(f"ERROR: YAML parse failure: {exc}", file=sys.stderr)
+        return 2
+
+    report = analyze(catalog)
+    write_report(report, args.report)
+
+    if not args.quiet:
+        print(render_summary(report))
+        print(f"Report: {args.report}")
+
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Mitigation per **ADR-2026-04-26 §S6** anti-pattern noted: pre-rebalance 14/30 (47%) mutation `physiological` garantiva bingo physio quasi-certo, schiacciando varietà archetype emergente in playtest.

## Cambiamenti

- **`data/core/mutations/mutation_catalog.yaml`**: +6 entries additive
  - +3 symbiotic: `simbionte_micorriza_radici`, `simbionte_lichene_solare`, `simbionte_batteri_termofili` (capstone)
  - +2 behavioral: `branco_cooperazione_segnalata`, `gerarchia_dominanza_ritualizzata`
  - +1 sensorial: `recettori_chimici_seed_tracking`
- **`tools/py/lint_mutation_balance.py` NEW** (~140 LOC): warn>40% / error>50% per category, min 4 entries (symbiotic exempt), JSON report `reports/lint/mutation_balance.json`
- **`Makefile`**: target `lint-mutations` + .PHONY entry
- **Tests**: count assertion 30 -> 36 (mutationCatalogLoader, mutationsRoutes + comment update mutationEngine)

## Distribuzione

\`\`\`
                Pre        Post
behavioral:      4 (13.3%) ->  6 (16.67%)
environmental:   5 (16.7%) ->  5 (13.89%)
physiological:  14 (46.7%) -> 14 (38.89%)  <- < 40% warn threshold
sensorial:       5 (16.7%) ->  6 (16.67%)
symbiotic:       2 ( 6.7%) ->  5 (13.89%)
Total:          30          36
\`\`\`

## Lint output

\`\`\`
Mutation balance lint (36 entries)
Categories:
  behavioral: 6 (16.67%)
  environmental: 5 (13.89%)
  physiological: 14 (38.89%)
  sensorial: 6 (16.67%)
  symbiotic: 5 (13.89%)
Status: OK
\`\`\`

## Validation

- Tutti i \`trait_id\` in \`trait_swap.add[]\` e \`prerequisites.traits[]\` validati contro \`data/core/traits/glossary.json\` (592 entries) OK
- mutationCatalogLoader 12/12 + mutationEngine 22/22 + mutationsRoutes 9/9 verde OK
- AI baseline 311/311 verde regression OK
- Prettier ok (auto-applied via lint-staged) OK

## Impact

- **Bingo varietà**: archetype \`symbiont_plus\` ora reachable in playtest reali (3+ symbiotic mutation possibili — pre era impossibile dato pool size 2).
- **Fairness S6**: physiological dominance scesa da 47% (warn-territory) a 38.89% (sotto soglia warn).
- **Additive only**: nessuna entry esistente modificata, zero risk di regression su catalog consumer (mutationEngine, mutationsRoutes, formEvolution).

## Test plan

- [x] \`python tools/py/lint_mutation_balance.py\` exit 0
- [x] \`node --test tests/services/mutation*.test.js tests/api/mutationsRoutes.test.js\` verde (43/43)
- [x] \`node --test tests/ai/*.test.js\` verde (311/311)
- [x] YAML parsable + UTF-8 encoding esplicito
- [x] Glossary trait_id validation cross-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)