### PR TITLE
feat(narrative): inner voices Disco-style (Skiv ticket #3)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -65,6 +65,9 @@ const {
 // internalize/forget transitions. Reads cabinet snapshot deltas, mutates
 // unit.attack_mod / defense_dc / hp_max etc per effect_bonus / effect_cost.
 const { updateThoughtPassives } = require('../services/thoughts/thoughtPassiveApply');
+// Skiv ticket #3: Inner Voices — 24 Disco Elysium-style diegetic whispers
+// (4 MBTI axes × 2 directions × 3 tiers). Pure evaluator, no combat effects.
+const { evaluateVoiceTriggers } = require('../services/narrative/innerVoice');
 // SPRINT_010 (issue #2): IA estratta in modulo dedicato.
 // Le funzioni decisionali (selectAiPolicy, stepAway) vivono in services/ai/policy.js,
 // l'orchestratore del turno (createSistemaTurnRunner) in services/ai/sistemaTurnRunner.js.
@@ -296,6 +299,8 @@ function createSessionRouter(options = {}) {
   // Phase 1 discovered ids live in `state.unlocked`; Phase 2 tracks research +
   // internalized slots for Disco Elysium-style passive effects.
   const thoughtsStore = new Map();
+  // Skiv #3 Inner Voices: sessionId -> Map<unitId, Set<voiceId>>.
+  const voicesStore = new Map();
 
   function getCabinetBucket(sessionId) {
     let bucket = thoughtsStore.get(sessionId);
@@ -314,6 +319,20 @@ function createSessionRouter(options = {}) {
       bucket.set(unitId, state);
     }
     return { bucket, state };
+  }
+
+  function getVoicesHeard(sessionId, unitId) {
+    let bucket = voicesStore.get(sessionId);
+    if (!bucket) {
+      bucket = new Map();
+      voicesStore.set(sessionId, bucket);
+    }
+    let set = bucket.get(unitId);
+    if (!set) {
+      set = new Set();
+      bucket.set(unitId, set);
+    }
+    return set;
   }
 
   function newSessionId() {
@@ -2473,6 +2492,8 @@ function createSessionRouter(options = {}) {
       // P4 Thought Cabinet: release per-session unlock cache on teardown.
       // Prevents linear memory growth over process lifetime (Codex review #1702).
       thoughtsStore.delete(session.session_id);
+      // Skiv #3: Inner Voices store cleanup.
+      voicesStore.delete(session.session_id);
       if (activeSessionId === session.session_id) {
         activeSessionId = null;
       }
@@ -2575,6 +2596,10 @@ function createSessionRouter(options = {}) {
           actor && session.biome_id
             ? computeResonanceTier(actor.species, session.biome_id, actor.archetype || null)
             : { tier: 'none', label_it: '', discount: 0 };
+        // Skiv #3: Inner Voices — evaluate 24 Disco-style whispers per actor.
+        const voicesHeard = getVoicesHeard(session.session_id, unitId);
+        const { heard, newly_heard } = evaluateVoiceTriggers(axes, voicesHeard);
+        for (const id of newly_heard) voicesHeard.add(id);
         perActor[unitId] = {
           ...snap,
           newly,
@@ -2582,6 +2607,8 @@ function createSessionRouter(options = {}) {
           passive_cost: passives.cost,
           resonance_tier: tierInfo.tier,
           resonance_label: tierInfo.label_it,
+          voices_heard: heard,
+          newly_heard,
         };
       }
       res.json({ session_id: session.session_id, per_actor: perActor });

--- a/apps/backend/services/narrative/innerVoice.js
+++ b/apps/backend/services/narrative/innerVoice.js
@@ -1,0 +1,89 @@
+// Inner Voices — Disco Elysium diegetic pattern (Skiv ticket #3).
+//
+// Pure evaluator: no I/O, no mutation. 24 voices (4 MBTI axes × 2 directions ×
+// 3 tiers). Mirrors thoughtCabinet.js structure so callers can compose both.
+//
+// Trigger: axis value crosses threshold in the declared direction.
+// Cumulative: once heard, persists across rounds (managed by caller).
+//
+// YAML source: data/core/thoughts/inner_voices.yaml
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+let _cache = null;
+
+const DEFAULT_YAML_PATH = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  'data',
+  'core',
+  'thoughts',
+  'inner_voices.yaml',
+);
+
+function loadVoices({ filepath = DEFAULT_YAML_PATH, force = false } = {}) {
+  if (_cache && !force) return _cache;
+  const raw = fs.readFileSync(filepath, 'utf8');
+  const parsed = yaml.load(raw) || {};
+  _cache = {
+    version: parsed.version || '0.0.0',
+    voices: parsed.voices || {},
+  };
+  return _cache;
+}
+
+function resetVoiceCache() {
+  _cache = null;
+}
+
+function matchesVoiceThreshold(value, direction, threshold) {
+  if (value === null || value === undefined || Number.isNaN(value)) return false;
+  if (direction === 'low') return value <= threshold;
+  if (direction === 'high') return value >= threshold;
+  return false;
+}
+
+// Pure evaluator. `alreadyHeard` can be Array or Set of voice ids.
+// Returns { heard: string[], newly_heard: string[] }.
+function evaluateVoiceTriggers(axes, alreadyHeard = [], opts = {}) {
+  const catalog = opts.catalog || loadVoices();
+  const set = new Set(
+    alreadyHeard instanceof Set ? alreadyHeard : Array.isArray(alreadyHeard) ? alreadyHeard : [],
+  );
+  const newly_heard = [];
+  if (!axes || typeof axes !== 'object') {
+    return { heard: Array.from(set), newly_heard };
+  }
+  for (const [id, entry] of Object.entries(catalog.voices || {})) {
+    if (set.has(id)) continue;
+    const axis = axes[entry.axis];
+    const value = axis && typeof axis === 'object' ? axis.value : null;
+    if (!matchesVoiceThreshold(value, entry.direction, entry.threshold)) continue;
+    set.add(id);
+    newly_heard.push(id);
+  }
+  return { heard: Array.from(set), newly_heard };
+}
+
+// Returns the full entry for a voice id, or null.
+function describeVoice(id, catalog = loadVoices()) {
+  const entry = catalog.voices?.[id];
+  if (!entry) return null;
+  return { id, ...entry };
+}
+
+module.exports = {
+  loadVoices,
+  resetVoiceCache,
+  matchesVoiceThreshold,
+  evaluateVoiceTriggers,
+  describeVoice,
+  DEFAULT_YAML_PATH,
+};

--- a/data/core/thoughts/inner_voices.yaml
+++ b/data/core/thoughts/inner_voices.yaml
@@ -1,0 +1,253 @@
+# Inner Voices — Evo-Tactics P4 (Disco Elysium diegetic pattern)
+#
+# 24 brevi voci diegetiche (4 assi MBTI × 2 direzioni × 3 soglie) che si
+# attivano quando un'unità attraversa una soglia sull'asse.
+# Pattern ispirato a Disco Elysium: le voci non hanno effetti meccanici, solo
+# peso narrativo. Trigger: threshold crossing in any direction.
+#
+# Convenzione direction (coerente con vcScoring + mbti_thoughts.yaml):
+#   - axis E_I: low → 'E' (estroverso), high → 'I' (introverso)
+#   - axis S_N: low → 'N' (intuitivo), high → 'S' (sensoriale)
+#   - axis J_P: low → 'P' (percepire), high → 'J' (giudicare)
+#   - axis T_F: low → 'F' (sentimento), high → 'T' (pensiero)
+#     (T_F incluso qui: a differenza di mbti_thoughts.yaml, le voci coprono
+#     tutti e 4 gli assi — solo la superficie narrativa, senza effetti.)
+#
+# Cumulativo: una volta sentita, non viene ribroadcastata (alreadyHeard).
+# Volume: esattamente 24 voci (sweet spot Disco Elysium).
+# Delivery: briefing/debrief overlay o tooltip in formsPanel.
+
+version: "0.1.0"
+
+voices:
+  # ───────────────────────── ASSE T_F ─────────────────────────
+
+  # T_F high → 'T' (pensiero / distanza)
+  tf_pensiero_freddo:
+    axis: T_F
+    direction: high
+    threshold: 0.65
+    tier: 1
+    pole_letter: T
+    voice_it: "Hai sempre ragione, anche quando hai torto."
+    flavor_it: "La voce calma della logica pura. Non teme il silenzio."
+
+  tf_distanza_precisa:
+    axis: T_F
+    direction: high
+    threshold: 0.75
+    tier: 2
+    pole_letter: T
+    voice_it: "I sentimenti sono rumore. I dati, no."
+    flavor_it: "La distanza è chiarezza. E solitudine."
+
+  tf_macchina_vivente:
+    axis: T_F
+    direction: high
+    threshold: 0.85
+    tier: 3
+    pole_letter: T
+    voice_it: "Eri umano, una volta. Forse."
+    flavor_it: "A questo punto, la fredda perfezione ha un prezzo invisibile."
+
+  # T_F low → 'F' (sentimento / connessione)
+  tf_voce_empatica:
+    axis: T_F
+    direction: low
+    threshold: 0.35
+    tier: 1
+    pole_letter: F
+    voice_it: "Li senti? Ti stanno guardando."
+    flavor_it: "Ogni azione ha un volto. Ogni scelta, una conseguenza umana."
+
+  tf_peso_connessione:
+    axis: T_F
+    direction: low
+    threshold: 0.25
+    tier: 2
+    pole_letter: F
+    voice_it: "Sei la somma delle loro speranze. Pesano."
+    flavor_it: "La connessione è forza. E vincolo che non si può spezzare."
+
+  tf_confine_dissolto:
+    axis: T_F
+    direction: low
+    threshold: 0.15
+    tier: 3
+    pole_letter: F
+    voice_it: "Loro sono te, e tu sei loro."
+    flavor_it: "A questo livello, il confine tra sé e gli altri svanisce del tutto."
+
+  # ───────────────────────── ASSE E_I ─────────────────────────
+
+  # E_I low → 'E' (estroverso / collettivo)
+  ei_eco_collettivo:
+    axis: E_I
+    direction: low
+    threshold: 0.35
+    tier: 1
+    pole_letter: E
+    voice_it: "Hai bisogno di loro come dell'aria."
+    flavor_it: "L'energia collettiva è carburante, non conforto."
+
+  ei_vuoto_silenzio:
+    axis: E_I
+    direction: low
+    threshold: 0.25
+    tier: 2
+    pole_letter: E
+    voice_it: "Ogni silenzio è una piccola morte."
+    flavor_it: "La presenza degli altri definisce il confine di te stesso."
+
+  ei_palcoscenico:
+    axis: E_I
+    direction: low
+    threshold: 0.15
+    tier: 3
+    pole_letter: E
+    voice_it: "Se nessuno ti vede, esisti davvero?"
+    flavor_it: "All'estremo: l'attenzione non è desiderata. È ossigeno."
+
+  # E_I high → 'I' (introverso / solitario)
+  ei_rifugio_interno:
+    axis: E_I
+    direction: high
+    threshold: 0.65
+    tier: 1
+    pole_letter: I
+    voice_it: "Il silenzio è più rumoroso di qualsiasi parola."
+    flavor_it: "Sente tutto. Dice poco. Sceglie quando agire."
+
+  ei_bastione_solo:
+    axis: E_I
+    direction: high
+    threshold: 0.75
+    tier: 2
+    pole_letter: I
+    voice_it: "Meglio un errore da soli che un successo in compagnia."
+    flavor_it: "L'autarchia non è orgoglio. È metodo."
+
+  ei_ombra_parlante:
+    axis: E_I
+    direction: high
+    threshold: 0.85
+    tier: 3
+    pole_letter: I
+    voice_it: "Anche l'ombra ha una voce. La tua."
+    flavor_it: "A questo livello: l'invisibilità non è assenza. È identità."
+
+  # ───────────────────────── ASSE S_N ─────────────────────────
+
+  # S_N high → 'S' (sensoriale / concreto)
+  sn_senso_concreto:
+    axis: S_N
+    direction: high
+    threshold: 0.65
+    tier: 1
+    pole_letter: S
+    voice_it: "Fidati di ciò che puoi toccare. Il resto è rumore."
+    flavor_it: "Il presente è reale. Il futuro è speculazione."
+
+  sn_mappa_incisa:
+    axis: S_N
+    direction: high
+    threshold: 0.75
+    tier: 2
+    pole_letter: S
+    voice_it: "Ogni pietra ha già un nome. Il tuo."
+    flavor_it: "La memoria del terreno è arma più affilata dell'istinto."
+
+  sn_radici_terreno:
+    axis: S_N
+    direction: high
+    threshold: 0.85
+    tier: 3
+    pole_letter: S
+    voice_it: "Il terreno non mente. Non l'ha mai fatto."
+    flavor_it: "All'estremo, la realtà fisica è l'unica verità accettata."
+
+  # S_N low → 'N' (intuitivo / visionario)
+  sn_intuizione_aperta:
+    axis: S_N
+    direction: low
+    threshold: 0.35
+    tier: 1
+    pole_letter: N
+    voice_it: "Qualcosa non torna. Non ancora."
+    flavor_it: "Percepisce pattern prima che esistano. A volte ha ragione."
+
+  sn_sentiero_invisibile:
+    axis: S_N
+    direction: low
+    threshold: 0.25
+    tier: 2
+    pole_letter: N
+    voice_it: "La mappa è sbagliata. Il territorio è altrove."
+    flavor_it: "L'intuizione supera il presente. A volte troppo."
+
+  sn_visione_aperta:
+    axis: S_N
+    direction: low
+    threshold: 0.15
+    tier: 3
+    pole_letter: N
+    voice_it: "Vede il finale prima che inizi. Ma chi lo ascolta?"
+    flavor_it: "All'estremo, il visionario vive in un futuro che gli altri non vedono ancora."
+
+  # ───────────────────────── ASSE J_P ─────────────────────────
+
+  # J_P high → 'J' (giudicare / struttura)
+  jp_ordine_preferito:
+    axis: J_P
+    direction: high
+    threshold: 0.65
+    tier: 1
+    pole_letter: J
+    voice_it: "Prima il piano. Poi il mondo."
+    flavor_it: "L'ordine non è vincolo. È fondamenta."
+
+  jp_controllo_totale:
+    axis: J_P
+    direction: high
+    threshold: 0.75
+    tier: 2
+    pole_letter: J
+    voice_it: "Il caos è solo un piano che non hai ancora scritto."
+    flavor_it: "La struttura come identità. Il controllo come conforto."
+
+  jp_architettura_assoluta:
+    axis: J_P
+    direction: high
+    threshold: 0.85
+    tier: 3
+    pole_letter: J
+    voice_it: "L'imprevisto non esiste. Solo preparazione insufficiente."
+    flavor_it: "All'estremo: la realtà deve adattarsi al piano, non viceversa."
+
+  # J_P low → 'P' (percepire / flusso)
+  jp_flusso_libero:
+    axis: J_P
+    direction: low
+    threshold: 0.35
+    tier: 1
+    pole_letter: P
+    voice_it: "Il piano è un suggerimento. L'istante, legge."
+    flavor_it: "La flessibilità è libertà. E a volte, caos."
+
+  jp_onde_mutevoli:
+    axis: J_P
+    direction: low
+    threshold: 0.25
+    tier: 2
+    pole_letter: P
+    voice_it: "Perché fermarsi quando si può ancora cambiare?"
+    flavor_it: "L'adattamento continuo. Nessuna certezza è definitiva."
+
+  jp_pura_reazione:
+    axis: J_P
+    direction: low
+    threshold: 0.15
+    tier: 3
+    pole_letter: P
+    voice_it: "Non hai deciso nulla. Hai solo risposto."
+    flavor_it: "All'estremo: la pianificazione è illusione. Solo il presente conta."

--- a/tests/api/innerVoice.test.js
+++ b/tests/api/innerVoice.test.js
@@ -1,0 +1,135 @@
+// Skiv ticket #3 — Inner Voices (Disco Elysium diegetic, 24 voices).
+// Pure evaluator tests: load, threshold logic, cumulative, axes, edge cases.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  loadVoices,
+  resetVoiceCache,
+  matchesVoiceThreshold,
+  evaluateVoiceTriggers,
+  describeVoice,
+} = require('../../apps/backend/services/narrative/innerVoice');
+
+test('loadVoices: returns exactly 24 voices across 4 axes', () => {
+  resetVoiceCache();
+  const catalog = loadVoices();
+  const ids = Object.keys(catalog.voices);
+  assert.equal(ids.length, 24);
+  const byAxis = { T_F: 0, E_I: 0, S_N: 0, J_P: 0 };
+  for (const e of Object.values(catalog.voices)) {
+    assert.ok(byAxis[e.axis] !== undefined, `unexpected axis ${e.axis}`);
+    byAxis[e.axis]++;
+  }
+  assert.equal(byAxis.T_F, 6, 'T_F needs 6 voices');
+  assert.equal(byAxis.E_I, 6, 'E_I needs 6 voices');
+  assert.equal(byAxis.S_N, 6, 'S_N needs 6 voices');
+  assert.equal(byAxis.J_P, 6, 'J_P needs 6 voices');
+});
+
+test('loadVoices: every entry has required fields', () => {
+  resetVoiceCache();
+  const catalog = loadVoices();
+  for (const [id, e] of Object.entries(catalog.voices)) {
+    assert.ok(e.axis, `${id} missing axis`);
+    assert.ok(['low', 'high'].includes(e.direction), `${id} bad direction`);
+    assert.equal(typeof e.threshold, 'number', `${id} bad threshold`);
+    assert.ok([1, 2, 3].includes(e.tier), `${id} bad tier`);
+    assert.ok(e.pole_letter, `${id} missing pole_letter`);
+    assert.ok(e.voice_it, `${id} missing voice_it`);
+    assert.ok(e.flavor_it, `${id} missing flavor_it`);
+  }
+});
+
+test('matchesVoiceThreshold: low direction matches when value ≤ threshold', () => {
+  assert.equal(matchesVoiceThreshold(0.3, 'low', 0.35), true);
+  assert.equal(matchesVoiceThreshold(0.35, 'low', 0.35), true);
+  assert.equal(matchesVoiceThreshold(0.4, 'low', 0.35), false);
+});
+
+test('matchesVoiceThreshold: high direction matches when value ≥ threshold', () => {
+  assert.equal(matchesVoiceThreshold(0.7, 'high', 0.65), true);
+  assert.equal(matchesVoiceThreshold(0.65, 'high', 0.65), true);
+  assert.equal(matchesVoiceThreshold(0.6, 'high', 0.65), false);
+});
+
+test('matchesVoiceThreshold: null/undefined/NaN never match', () => {
+  assert.equal(matchesVoiceThreshold(null, 'low', 0.5), false);
+  assert.equal(matchesVoiceThreshold(undefined, 'high', 0.5), false);
+  assert.equal(matchesVoiceThreshold(NaN, 'low', 0.5), false);
+});
+
+test('evaluateVoiceTriggers: no axes → empty result', () => {
+  const res = evaluateVoiceTriggers(null);
+  assert.deepEqual(res, { heard: [], newly_heard: [] });
+});
+
+test('evaluateVoiceTriggers: T_F high 0.68 unlocks tier-1 T voice only', () => {
+  resetVoiceCache();
+  const axes = { T_F: { value: 0.68, coverage: 'partial' } };
+  const { heard, newly_heard } = evaluateVoiceTriggers(axes);
+  assert.ok(newly_heard.includes('tf_pensiero_freddo'), 'tier-1 T should trigger at 0.68');
+  assert.ok(!newly_heard.includes('tf_distanza_precisa'), 'tier-2 T needs 0.75');
+  assert.ok(!newly_heard.includes('tf_macchina_vivente'), 'tier-3 T needs 0.85');
+  assert.deepEqual(heard, newly_heard);
+});
+
+test('evaluateVoiceTriggers: T_F high 0.87 unlocks all 3 T tiers', () => {
+  resetVoiceCache();
+  const axes = { T_F: { value: 0.87, coverage: 'full' } };
+  const { newly_heard } = evaluateVoiceTriggers(axes);
+  assert.ok(newly_heard.includes('tf_pensiero_freddo'));
+  assert.ok(newly_heard.includes('tf_distanza_precisa'));
+  assert.ok(newly_heard.includes('tf_macchina_vivente'));
+});
+
+test('evaluateVoiceTriggers: T_F low 0.12 unlocks all 3 F tiers', () => {
+  resetVoiceCache();
+  const axes = { T_F: { value: 0.12, coverage: 'full' } };
+  const { newly_heard } = evaluateVoiceTriggers(axes);
+  assert.ok(newly_heard.includes('tf_voce_empatica'));
+  assert.ok(newly_heard.includes('tf_peso_connessione'));
+  assert.ok(newly_heard.includes('tf_confine_dissolto'));
+});
+
+test('evaluateVoiceTriggers: cumulative — already heard voices not in newly_heard', () => {
+  resetVoiceCache();
+  const axes = { T_F: { value: 0.87 } };
+  const { heard: first } = evaluateVoiceTriggers(axes);
+  assert.equal(first.length, 3);
+
+  const { heard: second, newly_heard: newlySecond } = evaluateVoiceTriggers(axes, first);
+  assert.deepEqual(newlySecond, []);
+  assert.equal(second.length, 3);
+});
+
+test('evaluateVoiceTriggers: mixed axes trigger voices from multiple axes', () => {
+  resetVoiceCache();
+  const axes = {
+    E_I: { value: 0.87 },
+    S_N: { value: 0.12 },
+  };
+  const { newly_heard } = evaluateVoiceTriggers(axes);
+  const eiIds = newly_heard.filter((id) => id.startsWith('ei_'));
+  const snIds = newly_heard.filter((id) => id.startsWith('sn_'));
+  assert.ok(eiIds.length >= 3, 'E_I extreme high: all 3 I tiers');
+  assert.ok(snIds.length >= 3, 'S_N extreme low: all 3 N tiers');
+});
+
+test('describeVoice: returns full entry with id', () => {
+  resetVoiceCache();
+  const entry = describeVoice('tf_pensiero_freddo');
+  assert.equal(entry.id, 'tf_pensiero_freddo');
+  assert.equal(entry.axis, 'T_F');
+  assert.equal(entry.direction, 'high');
+  assert.equal(entry.tier, 1);
+  assert.ok(entry.voice_it.length > 0);
+});
+
+test('describeVoice: unknown id returns null', () => {
+  resetVoiceCache();
+  assert.equal(describeVoice('nonexistent_id'), null);
+});


### PR DESCRIPTION
## Summary

- **24 authored MBTI whispers** (`data/core/thoughts/inner_voices.yaml`) — 4 axes × 2 directions × 3 tiers. Covers T_F axis (excluded from `mbti_thoughts.yaml`; voices are pure narrative, no combat effects).
- **`apps/backend/services/narrative/innerVoice.js`** — pure evaluator mirroring `thoughtCabinet.js` pattern: `loadVoices`, `evaluateVoiceTriggers(axes, alreadyHeard)` → `{ heard, newly_heard }`, `describeVoice`.
- **`GET /:id/thoughts` wire** — `voicesStore` (Map per session×unit) added alongside `thoughtsStore`; each `per_actor` entry now carries additive keys `voices_heard: string[]` + `newly_heard: string[]`. Store cleaned up on session `/end`.
- **13 tests** — load (24 voices, 4 axes), schema fields, threshold low/high/edge, no-axes graceful, T tier-1 only, T all-3 tiers, F all-3 tiers, cumulative no-rebroadcast, mixed axes, describeVoice hit+miss.

## Gating

- Resolver wire (#1780, `thoughtPassiveApply.js`) confirmed merged ✅ — thoughts have passive effect before voices are heard.
- No new npm deps (js-yaml already in tree).
- Guardrails: zero touch to `.github/workflows/`, `migrations/`, `packages/contracts/`, `services/generation/`.

## Test plan

- [x] `node --test tests/api/innerVoice.test.js` → 13/13 green
- [x] `node --test tests/ai/*.test.js tests/api/thoughtCabinet.test.js tests/api/thoughtPassiveApply.test.js tests/api/innerVoice.test.js` → 378/378 green
- [x] `npm run format:check` → clean
- [x] `python3 tools/check_docs_governance.py --strict` → errors=0 warnings=0

## Player surface (Gate 5)

Delivery path: `GET /api/session/:id/thoughts` response → `per_actor[uid].newly_heard` array → formsPanel tooltip / briefing overlay. No new endpoint needed; additive shape on existing route. A player crossing T_F=0.85 for the first time sees: _"Eri umano, una volta. Forse."_

https://claude.ai/code/session_013e3iaiXyV8f9XpgATHWRBz

---
_Generated by [Claude Code](https://claude.ai/code/session_013e3iaiXyV8f9XpgATHWRBz)_