### PR TITLE
feat(combat): burning status — DoT 2 PT/turno, trait respiro_acido

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -275,6 +275,11 @@ function createSessionRouter(options = {}) {
     };
   }
 
+  // Status duration caps — previene stati permanenti da kill-chain re-apply.
+  const STATUS_DURATION_CAPS = {
+    burning: 3,
+  };
+
   function performAttack(session, actor, target, action = null) {
     // M7-#2 Phase B: boss enrage check. Se actor è boss tier + HP < threshold
     // per encounter class → temporary mod bonus (non-persistente).
@@ -472,7 +477,9 @@ function createSessionRouter(options = {}) {
         const unit = s.target_side === 'actor' ? actor : target;
         if (!unit || unit.hp <= 0 || !unit.status) continue;
         const current = Number(unit.status[s.stato]) || 0;
-        unit.status[s.stato] = Math.max(current, s.turns);
+        const cap = STATUS_DURATION_CAPS[s.stato];
+        const merged = Math.max(current, s.turns);
+        unit.status[s.stato] = cap !== undefined ? Math.min(cap, merged) : merged;
       }
     }
 
@@ -733,6 +740,39 @@ function createSessionRouter(options = {}) {
         killed: unit.hp === 0,
       });
     };
+    // Phase A burning: DoT 2 PT/turno (piu' severo di bleeding 1 PT).
+    const applyBurning = async (unit) => {
+      if (!unit || !unit.status || unit.hp <= 0) return;
+      const burnTurns = Number(unit.status.burning) || 0;
+      if (burnTurns <= 0) return;
+      const dmg = 2;
+      const hpBefore = unit.hp;
+      unit.hp = Math.max(0, unit.hp - dmg);
+      session.damage_taken[unit.id] = (session.damage_taken[unit.id] || 0) + dmg;
+      await appendEvent(session, {
+        ts: new Date().toISOString(),
+        session_id: session.session_id,
+        action_type: 'burning',
+        automatic: true,
+        actor_id: unit.id,
+        actor_species: unit.species,
+        actor_job: unit.job,
+        target_id: unit.id,
+        turn: session.turn,
+        damage_dealt: dmg,
+        result: 'hit',
+        hp_before: hpBefore,
+        hp_after: unit.hp,
+        burning_remaining: burnTurns - 1,
+        trait_effects: [],
+      });
+      bleedingEvents.push({
+        unit_id: unit.id,
+        damage: dmg,
+        hp_after: unit.hp,
+        killed: unit.hp === 0,
+      });
+    };
     const resetAp = (unit) => {
       if (!unit) return;
       const fractureActive = Number(unit.status?.fracture) > 0;
@@ -752,6 +792,7 @@ function createSessionRouter(options = {}) {
       const actor = session.units.find((u) => u.id === session.active_unit);
       if (!actor || actor.controlled_by !== 'sistema' || actor.hp <= 0) break;
       await applyBleeding(actor);
+      if (actor.hp > 0) await applyBurning(actor);
       if (actor.hp > 0) {
         resetAp(actor);
         const actions = await runSistemaTurn(session);
@@ -1643,6 +1684,14 @@ function createSessionRouter(options = {}) {
             unit.hp = Math.max(0, Number(unit.hp) - 1);
             if (session.damage_taken) {
               session.damage_taken[unit.id] = (session.damage_taken[unit.id] || 0) + 1;
+            }
+          }
+          // Burning tick (2 PT/turno)
+          const burnTurns = Number(unit.status?.burning) || 0;
+          if (burnTurns > 0 && unit.hp > 0) {
+            unit.hp = Math.max(0, Number(unit.hp) - 2);
+            if (session.damage_taken) {
+              session.damage_taken[unit.id] = (session.damage_taken[unit.id] || 0) + 2;
             }
           }
           // AP reset

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -594,6 +594,39 @@ function createRoundBridge(deps) {
       });
     }
 
+    // Burning tick (2 PT/turno, più severo di bleeding)
+    for (const unit of session.units) {
+      if (!unit || !unit.status || Number(unit.hp || 0) <= 0) continue;
+      const burnTurns = Number(unit.status.burning) || 0;
+      if (burnTurns <= 0) continue;
+      const dmg = 2;
+      const hpBefore = unit.hp;
+      unit.hp = Math.max(0, unit.hp - dmg);
+      session.damage_taken[unit.id] = (session.damage_taken[unit.id] || 0) + dmg;
+      await appendEvent(session, {
+        ts: new Date().toISOString(),
+        session_id: session.session_id,
+        action_type: 'burning',
+        actor_id: unit.id,
+        actor_species: unit.species,
+        actor_job: unit.job,
+        target_id: unit.id,
+        turn: session.turn,
+        damage_dealt: dmg,
+        result: 'hit',
+        hp_before: hpBefore,
+        hp_after: unit.hp,
+        burning_remaining: burnTurns - 1,
+        trait_effects: [],
+      });
+      bleedingEvents.push({
+        unit_id: unit.id,
+        damage: dmg,
+        hp_after: unit.hp,
+        killed: unit.hp === 0,
+      });
+    }
+
     for (const unit of session.units) {
       if (!unit) continue;
       const fractureActive = Number(unit.status?.fracture) > 0;

--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -160,3 +160,25 @@ traits:
       Protuberanza ossea pesante come una mazza. Ogni critico (MoS >= 8)
       applica 2 turni di frattura: il target perde AP al reset di turno
       (ap_remaining = 1 invece di ap pieno), limitando il movimento.
+
+  # SPRINT_020: stato burning (incendio). Apply da trait respiro_acido.
+  # DoT 2 PT/turno (piu' severo di bleeding 1 PT). Tick in tutti e 3 i
+  # path end-of-round: advanceThroughAiTurns, priority-queue, applyEndOfRoundSideEffects.
+
+  respiro_acido:
+    tier: T1
+    category: fisiologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: apply_status
+      target_side: target
+      stato: burning
+      turns: 3
+      log_tag: respiro_acido_burning
+    description_it: |
+      Ghiandole che spruzzano acido corrosivo incandescente. Ogni hit
+      applica 3 turni di burning: il target subisce 2 PT di danno non
+      riducibile al termine di ogni turno (piu' severo del sanguinamento).

--- a/tests/ai/statusEffectsPhaseA.test.js
+++ b/tests/ai/statusEffectsPhaseA.test.js
@@ -1,0 +1,94 @@
+// tests/ai/statusEffectsPhaseA.test.js
+// Unit tests for Status Effects v2 Phase A: burning (PR-3).
+// Pattern: spec-reimplementation — logic mirrored locally, no server needed.
+// Mirrors sessionRoundStatusSync.test.js pattern.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+// ── burning spec ──────────────────────────────────────────────────────────────
+
+function applyBurningSpec(unit, bleedingEvents) {
+  if (!unit || !unit.status || unit.hp <= 0) return;
+  const burnTurns = Number(unit.status.burning) || 0;
+  if (burnTurns <= 0) return;
+  const dmg = 2;
+  unit.hp = Math.max(0, unit.hp - dmg);
+  bleedingEvents.push({ unit_id: unit.id, damage: dmg, hp_after: unit.hp, killed: unit.hp === 0 });
+}
+
+describe('burning DoT', () => {
+  it('burning active: -2 HP per turno', () => {
+    const unit = { id: 'u1', hp: 8, status: { burning: 3 } };
+    const events = [];
+    applyBurningSpec(unit, events);
+    assert.equal(unit.hp, 6);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].damage, 2);
+    assert.equal(events[0].killed, false);
+  });
+
+  it('burning a 0 turns = nessun danno', () => {
+    const unit = { id: 'u2', hp: 5, status: { burning: 0 } };
+    const events = [];
+    applyBurningSpec(unit, events);
+    assert.equal(unit.hp, 5);
+    assert.equal(events.length, 0);
+  });
+
+  it('burning riduce HP a 0 (non sotto)', () => {
+    const unit = { id: 'u3', hp: 1, status: { burning: 2 } };
+    const events = [];
+    applyBurningSpec(unit, events);
+    assert.equal(unit.hp, 0);
+    assert.equal(events[0].killed, true);
+  });
+
+  it('burning assente in status: nessun danno', () => {
+    const unit = { id: 'u4', hp: 5, status: {} };
+    const events = [];
+    applyBurningSpec(unit, events);
+    assert.equal(unit.hp, 5);
+    assert.equal(events.length, 0);
+  });
+
+  it("unit gia' morta: burning non applicato", () => {
+    const unit = { id: 'u5', hp: 0, status: { burning: 3 } };
+    const events = [];
+    applyBurningSpec(unit, events);
+    assert.equal(unit.hp, 0);
+    assert.equal(events.length, 0);
+  });
+});
+
+// ── STATUS_DURATION_CAPS spec per burning ────────────────────────────────────
+
+function applyStatusWithCapSpec(unit, stato, turns, caps) {
+  if (!unit || !unit.status) return;
+  const current = Number(unit.status[stato]) || 0;
+  const cap = caps[stato];
+  const merged = Math.max(current, turns);
+  unit.status[stato] = cap !== undefined ? Math.min(cap, merged) : merged;
+}
+
+describe('burning duration cap', () => {
+  const CAPS = { burning: 3 };
+
+  it('burning cap a 3 turni massimi', () => {
+    const unit = { status: { burning: 0 } };
+    applyStatusWithCapSpec(unit, 'burning', 5, CAPS);
+    assert.equal(unit.status.burning, 3);
+  });
+
+  it('burning max-merge: prende il maggiore (ma cappato)', () => {
+    const unit = { status: { burning: 2 } };
+    applyStatusWithCapSpec(unit, 'burning', 1, CAPS);
+    assert.equal(unit.status.burning, 2);
+  });
+
+  it('burning applicato correttamente sotto cap', () => {
+    const unit = { status: { burning: 0 } };
+    applyStatusWithCapSpec(unit, 'burning', 3, CAPS);
+    assert.equal(unit.status.burning, 3);
+  });
+});


### PR DESCRIPTION
Superseded by #1955 (rebased onto current main, now merged). Old branch was forked from `488da05`. Closing.