### PR TITLE
feat(combat): chilled status — -1 AP -1 atk/turno, trait aura_glaciale

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -92,6 +92,7 @@ const STATUS_DURATION_CAPS = {
   stunned: 3,
   confused: 3,
   bleeding: 5,
+  chilled: 2,
 };
 // M7-#2 Phase B: damage scaling curves runtime (ADR-2026-04-20).
 const {
@@ -476,6 +477,12 @@ function createSessionRouter(options = {}) {
       biomeAffTarget = { attack_mod: 0, defense_mod: 0, affinity: 'unknown', log: '' };
     }
 
+    // Chilled: -1 attack_mod_bonus per turno (freddo rallenta riflessi). Per-attack, revert post.
+    const chilledPenalty = Number(actor.status?.chilled) > 0 ? 1 : 0;
+    if (chilledPenalty > 0) {
+      actor.attack_mod_bonus = Number(actor.attack_mod_bonus || 0) - chilledPenalty;
+    }
+
     const result = resolveAttack({ actor, target, rng });
     const evaluation = evaluateAttackTraits({
       registry: traitRegistry,
@@ -509,6 +516,10 @@ function createSessionRouter(options = {}) {
     }
     if (statusMods.defenseDelta !== 0) {
       target.defense_mod_bonus = Number(target.defense_mod_bonus || 0) - statusMods.defenseDelta;
+    }
+    // Revert chilled attack penalty (per-attack, non-persistente).
+    if (chilledPenalty > 0) {
+      actor.attack_mod_bonus = Number(actor.attack_mod_bonus || 0) + chilledPenalty;
     }
     let damageDealt = 0;
     let killOccurred = false;

--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -618,6 +618,7 @@ function applyApRefill(unit) {
   let cap = Number(unit.ap || 0);
   if (fractureActive) cap = Math.min(1, cap);
   if (Number(unit.status?.defy_penalty) > 0) cap = Math.max(0, cap - 1);
+  if (Number(unit.status?.chilled) > 0) cap = Math.max(1, cap - 1);
   unit.ap_remaining = cap;
 }
 

--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -9364,3 +9364,25 @@ traits:
       source: qw2_starter_bioma
       starter_biome: abisso_vulcanico
       form_id: ENTJ
+
+  # SPRINT_020: stato chilled. Apply da trait aura_glaciale.
+  # Effetti: -1 AP reset turno (applyApRefill in sessionHelpers.js) + -1 attack_mod_bonus
+  # per attacco (pre/revert in performAttack session.js). Status_duration_cap 2T.
+
+  aura_glaciale:
+    tier: T1
+    category: fisiologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: apply_status
+      target_side: target
+      stato: chilled
+      turns: 2
+      log_tag: aura_glaciale_chilled
+    description_it: |
+      Aura criogeina che raffredda i tessuti del bersaglio. Ogni hit
+      applica 2 turni di chilled: il target perde 1 AP al reset di
+      turno e subisce -1 ai tiri d'attacco (riflessi rallentati).

--- a/tests/ai/statusEffectsPhaseA.test.js
+++ b/tests/ai/statusEffectsPhaseA.test.js
@@ -1,0 +1,103 @@
+// tests/ai/statusEffectsPhaseA.test.js
+// Unit tests for Status Effects v2 Phase A: chilled (PR-4).
+// Pattern: spec-reimplementation — logic mirrored locally, no server needed.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+// ── applyApRefill spec (includes chilled) ────────────────────────────────────
+
+function applyApRefillSpec(unit) {
+  if (!unit) return;
+  const fractureActive = Number(unit.status?.fracture) > 0;
+  let cap = Number(unit.ap || 0);
+  if (fractureActive) cap = Math.min(1, cap);
+  if (Number(unit.status?.defy_penalty) > 0) cap = Math.max(0, cap - 1);
+  if (Number(unit.status?.chilled) > 0) cap = Math.max(1, cap - 1);
+  unit.ap_remaining = cap;
+}
+
+describe('chilled: AP reset', () => {
+  it('chilled active: -1 AP al reset turno', () => {
+    const unit = { ap: 2, status: { chilled: 2 } };
+    applyApRefillSpec(unit);
+    assert.equal(unit.ap_remaining, 1);
+  });
+
+  it('chilled non scende sotto 1 AP', () => {
+    const unit = { ap: 1, status: { chilled: 1 } };
+    applyApRefillSpec(unit);
+    assert.equal(unit.ap_remaining, 1);
+  });
+
+  it('chilled a 0 turns: nessun effetto AP', () => {
+    const unit = { ap: 2, status: { chilled: 0 } };
+    applyApRefillSpec(unit);
+    assert.equal(unit.ap_remaining, 2);
+  });
+
+  it('chilled + fracture: fracture cap 1 prima, chilled lascia a 1 (max 1)', () => {
+    const unit = { ap: 3, status: { fracture: 1, chilled: 1 } };
+    applyApRefillSpec(unit);
+    // fracture: min(1, 3) = 1; chilled: max(1, 1-1) = max(1, 0) = 1
+    assert.equal(unit.ap_remaining, 1);
+  });
+
+  it('assenza status: ap_remaining = ap pieno', () => {
+    const unit = { ap: 2, status: {} };
+    applyApRefillSpec(unit);
+    assert.equal(unit.ap_remaining, 2);
+  });
+});
+
+// ── chilled attack penalty spec ───────────────────────────────────────────────
+
+function computeChilledPenaltySpec(actor) {
+  return Number(actor?.status?.chilled) > 0 ? 1 : 0;
+}
+
+describe('chilled: attack penalty', () => {
+  it("chilled active: penalita' 1 al tiro attacco", () => {
+    const actor = { status: { chilled: 2 }, attack_mod_bonus: 0 };
+    const penalty = computeChilledPenaltySpec(actor);
+    assert.equal(penalty, 1);
+  });
+
+  it("chilled a 0 turns: nessuna penalita'", () => {
+    const actor = { status: { chilled: 0 } };
+    const penalty = computeChilledPenaltySpec(actor);
+    assert.equal(penalty, 0);
+  });
+
+  it("chilled assente: nessuna penalita'", () => {
+    const actor = { status: {} };
+    const penalty = computeChilledPenaltySpec(actor);
+    assert.equal(penalty, 0);
+  });
+});
+
+// ── STATUS_DURATION_CAPS spec per chilled ─────────────────────────────────────
+
+function applyStatusWithCapSpec(unit, stato, turns, caps) {
+  if (!unit || !unit.status) return;
+  const current = Number(unit.status[stato]) || 0;
+  const cap = caps[stato];
+  const merged = Math.max(current, turns);
+  unit.status[stato] = cap !== undefined ? Math.min(cap, merged) : merged;
+}
+
+describe('chilled duration cap', () => {
+  const CAPS = { chilled: 2 };
+
+  it('chilled cap a 2 turni massimi', () => {
+    const unit = { status: { chilled: 0 } };
+    applyStatusWithCapSpec(unit, 'chilled', 5, CAPS);
+    assert.equal(unit.status.chilled, 2);
+  });
+
+  it('chilled max-merge sotto cap', () => {
+    const unit = { status: { chilled: 1 } };
+    applyStatusWithCapSpec(unit, 'chilled', 2, CAPS);
+    assert.equal(unit.status.chilled, 2);
+  });
+});


### PR DESCRIPTION
## Sommario

- Aggiunge stato `chilled` con **doppio effetto**: -1 AP reset turno + -1 attack_mod_bonus per attacco
- `STATUS_DURATION_CAPS.chilled = 2` — turni massimi
- `applyApRefill` (sessionHelpers.js): un solo punto, copre tutti e 3 i path end-of-round
- `performAttack` (session.js): `chilledPenalty` pre/revert intorno a `resolveAttack` — stesso pattern di `statusMods`/`timeMods`/`biomeAff`, zero leak persistente
- Trait `aura_glaciale`: hit → chilled 2T su target (T1/fisiologico)
- 10 nuovi test (5 AP reset + 3 penalty + 2 cap) — **321/321 verde**

## File modificati

| File | Modifica |
|---|---|
| `apps/backend/routes/session.js` | `STATUS_DURATION_CAPS.chilled=2` + chilledPenalty pre/revert |
| `apps/backend/routes/sessionHelpers.js` | `applyApRefill` + chilled cap |
| `data/core/traits/active_effects.yaml` | trait `aura_glaciale` |
| `tests/ai/statusEffectsPhaseA.test.js` | 10 test chilled (AP + penalty + cap) |

## Piano di rollback (03A)

`git revert 3d13bde` — rimuove i 4 file delta senza toccare gli altri stati.

https://claude.ai/code/session_013Po6rosMuNxvabTAR2MGXM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Po6rosMuNxvabTAR2MGXM)_