### PR TITLE
feat(combat): disoriented status — -2 atk/turno cap 1T, trait sussurro_psichico

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,6 +378,28 @@ Primary working directory is on Windows, but the shell is bash (Git Bash/MSYS) �
 
 ---
 
+## 🎮 Sprint context (aggiornato: 2026-04-27 — Status Effects v2 Phase A COMPLETA)
+
+**Sessione 2026-04-27 (status effects)**: STEP 3 Phase A completo — 5 stati Tier 1 come 5 mini-PR sequenziali. Tutti i CI verdi. 0 regressioni.
+
+**PR shipaiti** (5, tutti draft in attesa merge):
+
+| PR                                                       | Stato       | Trait                | Effetto           | CI  |
+| -------------------------------------------------------- | ----------- | -------------------- | ----------------- | --- |
+| [#1947](https://github.com/MasterDD-L34D/Game/pull/1947) | slowed      | `tela_appiccicosa`   | -1 AP reset/T     | ✅  |
+| [#1948](https://github.com/MasterDD-L34D/Game/pull/1948) | marked      | `marchio_predatorio` | +1 dmg next hit   | ✅  |
+| [#1950](https://github.com/MasterDD-L34D/Game/pull/1950) | burning     | `respiro_acido`      | DoT 2 PT/T        | ✅  |
+| [#1951](https://github.com/MasterDD-L34D/Game/pull/1951) | chilled     | `aura_glaciale`      | -1 AP -1 atk/T    | ✅  |
+| [#1953](https://github.com/MasterDD-L34D/Game/pull/1953) | disoriented | `sussurro_psichico`  | -2 atk/T (1T cap) | ✅  |
+
+**Test baseline**: 311→319 (+8 disoriented, branche separate ~315-321 per PR). AI suite 0 regressioni.
+
+**Handoff**: [`docs/planning/2026-04-27-status-effects-phase-a-handoff.md`](docs/planning/2026-04-27-status-effects-phase-a-handoff.md).
+
+**Next session candidati**: A) HUD surface per 5 stati (~3-4h, Gate 5 DoD), B) policy.js consumption per AI awareness (~6-8h), C) merge + rebase PR-1/2 su nuovo main, D) Phase B stati avanzati.
+
+---
+
 ## 🎮 Sprint context (aggiornato: 2026-04-27 sera — Spore Moderate FULL + Recovery + Bundle B Indie Quick-Wins)
 
 **Sessione 2026-04-27 sera (continuazione)**: 18 PR mergiati main (Spore S1-S6 stack + lifecycle + UI QW-1/2/3 + recovery 6 deliverables persi + classification + 12 museum cards + Bundle B 4 indie quick-wins).

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -93,6 +93,7 @@ const STATUS_DURATION_CAPS = {
   confused: 3,
   bleeding: 5,
   chilled: 2,
+  disoriented: 1,
 };
 // M7-#2 Phase B: damage scaling curves runtime (ADR-2026-04-20).
 const {
@@ -482,6 +483,11 @@ function createSessionRouter(options = {}) {
     if (chilledPenalty > 0) {
       actor.attack_mod_bonus = Number(actor.attack_mod_bonus || 0) - chilledPenalty;
     }
+    // Disoriented: -2 attack_mod_bonus (confusione sensoriale, dura 1 turno). Per-attack, revert post.
+    const disorientedPenalty = Number(actor.status?.disoriented) > 0 ? 2 : 0;
+    if (disorientedPenalty > 0) {
+      actor.attack_mod_bonus = Number(actor.attack_mod_bonus || 0) - disorientedPenalty;
+    }
 
     const result = resolveAttack({ actor, target, rng });
     const evaluation = evaluateAttackTraits({
@@ -520,6 +526,10 @@ function createSessionRouter(options = {}) {
     // Revert chilled attack penalty (per-attack, non-persistente).
     if (chilledPenalty > 0) {
       actor.attack_mod_bonus = Number(actor.attack_mod_bonus || 0) + chilledPenalty;
+    }
+    // Revert disoriented attack penalty (per-attack, non-persistente).
+    if (disorientedPenalty > 0) {
+      actor.attack_mod_bonus = Number(actor.attack_mod_bonus || 0) + disorientedPenalty;
     }
     let damageDealt = 0;
     let killOccurred = false;

--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -9386,3 +9386,26 @@ traits:
       Aura criogeina che raffredda i tessuti del bersaglio. Ogni hit
       applica 2 turni di chilled: il target perde 1 AP al reset di
       turno e subisce -1 ai tiri d'attacco (riflessi rallentati).
+
+  # SPRINT_020: stato disoriented. Apply da trait sussurro_psichico.
+  # Effetto: -2 attack_mod_bonus per attacco (pre/revert in performAttack session.js).
+  # Duration cap 1T — il piu' breve dei 5 stati Phase A, ottimo per burst psichico.
+
+  sussurro_psichico:
+    tier: T1
+    category: comportamentale
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+      min_mos: 5
+    effect:
+      kind: apply_status
+      target_side: target
+      stato: disoriented
+      turns: 1
+      log_tag: sussurro_psichico_disoriented
+    description_it: |
+      Sussurro sonico disorientante. Ogni hit solido (MoS >= 5) applica
+      1 turno di disoriented: il target subisce -2 ai tiri d'attacco
+      (confusione sensoriale profonda, ma breve).

--- a/docs/planning/2026-04-27-status-effects-phase-a-handoff.md
+++ b/docs/planning/2026-04-27-status-effects-phase-a-handoff.md
@@ -1,0 +1,141 @@
+---
+title: 'Status Effects v2 Phase A — handoff (5 stati Tier 1 completi)'
+date: 2026-04-27
+doc_status: active
+doc_owner: master-dd
+workstream: cross-cutting
+last_verified: '2026-04-27'
+source_of_truth: false
+---
+
+# Status Effects v2 Phase A — handoff
+
+## Goal raggiunto
+
+5 stati Tier 1 implementati come 5 mini-PR sequenziali indipendenti.
+Pipeline completa: trait YAML → evaluateStatusTraits → apply → runtime effect → test.
+
+## PR consegnati
+
+| PR    | Branch                  | Stato | Trait                | Effetto                   | CI    |
+| ----- | ----------------------- | ----- | -------------------- | ------------------------- | ----- |
+| #1947 | feat/status-slowed      | draft | `tela_appiccicosa`   | -1 AP reset/T             | verde |
+| #1948 | feat/status-marked      | draft | `marchio_predatorio` | +1 dmg next hit (consume) | verde |
+| #1950 | feat/status-burning     | draft | `respiro_acido`      | DoT 2 PT/T                | verde |
+| #1951 | feat/status-chilled     | draft | `aura_glaciale`      | -1 AP reset + -1 atk/T    | verde |
+| #1953 | feat/status-disoriented | draft | `sussurro_psichico`  | -2 atk/T (1T cap)         | verde |
+
+## Architettura implementata
+
+### Apply path (uguale per tutti)
+
+```
+trait YAML (active_effects.yaml)
+  → traitEffects.js: evaluateStatusTraits()
+  → status_applies[]
+  → performAttack: unit.status[stato] = min(cap, max(current, turns))
+```
+
+### Effect paths per stato
+
+| Stato       | AP reset (applyApRefill) | Attack modifier (performAttack) | DoT (3 path) |
+| ----------- | ------------------------ | ------------------------------- | ------------ |
+| slowed      | -1 AP (max 1)            | —                               | —            |
+| marked      | —                        | +1 dmg su hit (consume)         | —            |
+| burning     | —                        | —                               | 2 PT/turno   |
+| chilled     | -1 AP (max 1)            | -1 atk pre/revert               | —            |
+| disoriented | —                        | -2 atk pre/revert               | —            |
+
+### DoT 3 path (burning)
+
+1. `advanceThroughAiTurns` (session.js) — `applyBurning` async closure
+2. priority-queue inline (session.js ~line 1685)
+3. `applyEndOfRoundSideEffects` (sessionRoundBridge.js) — loop dopo bleeding
+
+### AP reset (slowed / chilled)
+
+- **origin/main ~488da05**: inline in 3 posti (resetAp closure, pq inline, sessionRoundBridge)
+- **origin/main ~5096d44+**: `applyApRefill` centralizzato in sessionHelpers.js — 1 sola modifica
+
+> **Nota**: PR-1 (slowed) e PR-2 (marked) branciano da 488da05. PR-3/4/5 branciano da 5096d44.
+> Quando PR-1/2 vengono mergiati post-rebase, usare il pattern `applyApRefill` della versione attuale.
+
+### Duration caps
+
+```javascript
+STATUS_DURATION_CAPS = {
+  // pre-esistenti
+  rage: 5,
+  frenzy: 5,
+  panic: 4,
+  stunned: 3,
+  confused: 3,
+  bleeding: 5,
+  // Phase A nuovi
+  slowed: 3, // PR-1
+  marked: 2, // PR-2
+  burning: 3, // PR-3
+  chilled: 2, // PR-4
+  disoriented: 1, // PR-5
+};
+```
+
+## Test coverage
+
+| PR    | File                        | Test count | Baseline totale |
+| ----- | --------------------------- | ---------- | --------------- |
+| #1947 | statusEffectsSlowed.test.js | 3          | 310/310         |
+| #1948 | statusEffectsMarked.test.js | 3          | 313/313         |
+| #1950 | statusEffectsPhaseA.test.js | 8          | 315/315         |
+| #1951 | statusEffectsPhaseA.test.js | 10         | 321/321         |
+| #1953 | statusEffectsPhaseA.test.js | 8          | 319/319         |
+
+## Prossime fasi (Phase B — non bloccanti per playtest)
+
+### Priority 1: policy.js consumption (~6-8h)
+
+I 5 nuovi stati non influenzano ancora le decisioni dell'AI `declareSistemaIntents.js`.
+
+- `slowed`: AI dovrebbe preferire inseguire unit slowed (movimento ridotto)
+- `disoriented`: AI dovrebbe attaccare target disorientati (probabilità hit alta)
+- `chilled`: AI considera target chilled come softer targets
+- `burning`: AI non insegue target già in fiamme (DoT fa il lavoro)
+- `marked`: AI coordina attacchi su target marked per consumare bonus
+
+### Priority 2: HUD surface (~3-4h)
+
+Gate 5 (Engine wired): nessuno dei 5 stati ha surface player-visible.
+
+- Status icon sotto unit sprite (almeno emoji: 🔥🧊💫❄️🎯)
+- Tooltip su hover con turns rimanenti
+- Log entry nel combat panel quando applicato
+
+### Priority 3: trait glossary sync
+
+`aura_glaciale`, `tela_appiccicosa`, `marchio_predatorio`, `respiro_acido`, `sussurro_psichico`
+non sono ancora in `data/traits/glossary.json`. Aggiungere con `trait-lint` skill.
+
+### Priority 4: Phase B stati (medium effort ~15-20h)
+
+- `burning` resistenza per specie acquatiche/acquatiche
+- `chilled` → `frozen` upgrade se doppia applicazione stessa T
+- Stacking rules: burning + chilled = annullamento (design call pendente)
+
+## Entry point prossima sessione
+
+```bash
+# PR-1/2 su vecchio main — rebasing se necessario:
+git log origin/main --oneline -3  # verifica SHA corrente
+# Se SHA != 488da05, fare rebase PR-1/2 su nuovo main
+
+# Approva e mergia tutti e 5 i PR:
+# #1947 #1948 #1950 #1951 #1953 (in ordine, nessuna dipendenza — tutti da main)
+
+# Poi HUD surface sprint:
+# apps/play/src/statusHud.js  (nuovo)
+# apps/play/index.html        (wire)
+```
+
+## Blockers
+
+Nessun blocker tecnico. Decisione design pendente: stacking burning+chilled (annullamento vs somma).

--- a/tests/ai/statusEffectsPhaseA.test.js
+++ b/tests/ai/statusEffectsPhaseA.test.js
@@ -1,5 +1,5 @@
 // tests/ai/statusEffectsPhaseA.test.js
-// Unit tests for Status Effects v2 Phase A: chilled (PR-4).
+// Unit tests for Status Effects v2 Phase A: chilled (PR-4) + disoriented (PR-5).
 // Pattern: spec-reimplementation — logic mirrored locally, no server needed.
 
 import { describe, it } from 'node:test';
@@ -39,7 +39,6 @@ describe('chilled: AP reset', () => {
   it('chilled + fracture: fracture cap 1 prima, chilled lascia a 1 (max 1)', () => {
     const unit = { ap: 3, status: { fracture: 1, chilled: 1 } };
     applyApRefillSpec(unit);
-    // fracture: min(1, 3) = 1; chilled: max(1, 1-1) = max(1, 0) = 1
     assert.equal(unit.ap_remaining, 1);
   });
 
@@ -76,7 +75,49 @@ describe('chilled: attack penalty', () => {
   });
 });
 
-// ── STATUS_DURATION_CAPS spec per chilled ─────────────────────────────────────
+// ── disoriented attack penalty spec ───────────────────────────────────────────
+
+function computeDisorientedPenaltySpec(actor) {
+  return Number(actor?.status?.disoriented) > 0 ? 2 : 0;
+}
+
+describe('disoriented: attack penalty', () => {
+  it("disoriented active: penalita' -2 al tiro attacco", () => {
+    const actor = { status: { disoriented: 1 }, attack_mod_bonus: 0 };
+    const penalty = computeDisorientedPenaltySpec(actor);
+    assert.equal(penalty, 2);
+  });
+
+  it("disoriented a 0 turns: nessuna penalita'", () => {
+    const actor = { status: { disoriented: 0 } };
+    const penalty = computeDisorientedPenaltySpec(actor);
+    assert.equal(penalty, 0);
+  });
+
+  it("disoriented assente: nessuna penalita'", () => {
+    const actor = { status: {} };
+    const penalty = computeDisorientedPenaltySpec(actor);
+    assert.equal(penalty, 0);
+  });
+
+  it('pre/revert: attack_mod_bonus ripristinato dopo attacco', () => {
+    const actor = { status: { disoriented: 1 }, attack_mod_bonus: 3 };
+    const penalty = computeDisorientedPenaltySpec(actor);
+    actor.attack_mod_bonus = Number(actor.attack_mod_bonus) - penalty;
+    actor.attack_mod_bonus = Number(actor.attack_mod_bonus) + penalty;
+    assert.equal(actor.attack_mod_bonus, 3);
+  });
+
+  it("penalita' maggiore di chilled (-2 vs -1): disoriented piu' severo", () => {
+    const actorDis = { status: { disoriented: 1 } };
+    const actorChi = { status: { chilled: 1 } };
+    const penDis = computeDisorientedPenaltySpec(actorDis);
+    const penChi = Number(actorChi.status?.chilled) > 0 ? 1 : 0;
+    assert.ok(penDis > penChi, `disoriented ${penDis} should be > chilled ${penChi}`);
+  });
+});
+
+// ── STATUS_DURATION_CAPS spec (chilled + disoriented) ─────────────────────────
 
 function applyStatusWithCapSpec(unit, stato, turns, caps) {
   if (!unit || !unit.status) return;
@@ -99,5 +140,27 @@ describe('chilled duration cap', () => {
     const unit = { status: { chilled: 1 } };
     applyStatusWithCapSpec(unit, 'chilled', 2, CAPS);
     assert.equal(unit.status.chilled, 2);
+  });
+});
+
+describe('disoriented duration cap', () => {
+  const CAPS = { disoriented: 1 };
+
+  it('disoriented cap a 1 turno massimo', () => {
+    const unit = { status: { disoriented: 0 } };
+    applyStatusWithCapSpec(unit, 'disoriented', 3, CAPS);
+    assert.equal(unit.status.disoriented, 1);
+  });
+
+  it("disoriented rimane a 1 se gia' applicato", () => {
+    const unit = { status: { disoriented: 1 } };
+    applyStatusWithCapSpec(unit, 'disoriented', 1, CAPS);
+    assert.equal(unit.status.disoriented, 1);
+  });
+
+  it('disoriented applicato correttamente a 1T', () => {
+    const unit = { status: { disoriented: 0 } };
+    applyStatusWithCapSpec(unit, 'disoriented', 1, CAPS);
+    assert.equal(unit.status.disoriented, 1);
   });
 });


### PR DESCRIPTION
## Sommario

- Aggiunge stato `disoriented` con penalità **-2 attack_mod_bonus** per attacco
- Il più severo dei 5 stati Phase A sul tiro d'attacco; `STATUS_DURATION_CAPS.disoriented = 1` turno
- `performAttack` (session.js): `disorientedPenalty` pre/revert intorno a `resolveAttack` — stesso pattern di chilled/statusMods/timeMods, zero leak persistente
- Trait `sussurro_psichico`: hit MoS≥5 → disoriented 1T su target (T1/comportamentale)
- 8 nuovi test (5 penalty + 3 cap) — **319/319 verde**

## Confronto stati Phase A (tutti e 5 completati)

| Stato | Effetto | Durata | Trait |
|---|---|---|---|
| `slowed` | -1 AP reset | 2T | `tela_appiccicosa` |
| `marked` | +1 dmg prossimo hit (consume) | 2T | `marchio_predatorio` |
| `burning` | DoT 2 PT/turno | 3T | `respiro_acido` |
| `chilled` | -1 AP reset + -1 atk | 2T | `aura_glaciale` |
| `disoriented` | **-2 atk** | **1T** | `sussurro_psichico` |

## Piano di rollback (03A)

`git revert 4f291dc` — rimuove i 3 file delta senza toccare gli altri stati.

https://claude.ai/code/session_013Po6rosMuNxvabTAR2MGXM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Po6rosMuNxvabTAR2MGXM)_