### PR TITLE
feat(combat): slowed status — -1 AP/turno cap 3T, trait tela_appiccicosa (PR-1)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -92,6 +92,7 @@ const STATUS_DURATION_CAPS = {
   stunned: 3,
   confused: 3,
   bleeding: 5,
+  slowed: 3,
   burning: 3,
   chilled: 2,
   disoriented: 1,

--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -619,6 +619,7 @@ function applyApRefill(unit) {
   if (fractureActive) cap = Math.min(1, cap);
   if (Number(unit.status?.defy_penalty) > 0) cap = Math.max(0, cap - 1);
   if (Number(unit.status?.chilled) > 0) cap = Math.max(1, cap - 1);
+  if (Number(unit.status?.slowed) > 0) cap = Math.max(1, cap - 1);
   unit.ap_remaining = cap;
 }
 

--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -9430,3 +9430,23 @@ traits:
       Ghiandole che spruzzano acido corrosivo incandescente. Ogni hit
       applica 3 turni di burning: il target subisce 2 PT di danno non
       riducibile al termine di ogni turno (piu' severo del sanguinamento).
+
+  # Stato slowed Tier 1: -1 AP al reset turno, cap 3T. Min 1 AP garantito.
+  # Wire: applyApRefill (sessionHelpers.js) centralizza tutti i modificatori AP.
+
+  tela_appiccicosa:
+    tier: T1
+    category: fisiologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: apply_status
+      target_side: target
+      stato: slowed
+      turns: 3
+      log_tag: tela_appiccicosa_slowed
+    description_it: |
+      Ghiandole che secernono fili vischiosi. Ogni hit applica 3 turni di
+      slowed: il target riceve -1 AP al reset turno (minimo 1 AP garantito).

--- a/tests/ai/statusEffectsSlowed.test.js
+++ b/tests/ai/statusEffectsSlowed.test.js
@@ -1,0 +1,83 @@
+// tests/ai/statusEffectsSlowed.test.js
+// Unit tests for Status Effects v2 Phase A: slowed (PR-1).
+// Pattern: spec-reimplementation — logic mirrored locally, no server needed.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+// ── applyApRefill spec (includes slowed) ─────────────────────────────────────
+
+function applyApRefillSpec(unit) {
+  if (!unit) return;
+  const fractureActive = Number(unit.status?.fracture) > 0;
+  let cap = Number(unit.ap || 0);
+  if (fractureActive) cap = Math.min(1, cap);
+  if (Number(unit.status?.defy_penalty) > 0) cap = Math.max(0, cap - 1);
+  if (Number(unit.status?.chilled) > 0) cap = Math.max(1, cap - 1);
+  if (Number(unit.status?.slowed) > 0) cap = Math.max(1, cap - 1);
+  unit.ap_remaining = cap;
+}
+
+describe('slowed: AP reset', () => {
+  it('slowed active: -1 AP al reset turno', () => {
+    const unit = { ap: 2, status: { slowed: 2 } };
+    applyApRefillSpec(unit);
+    assert.equal(unit.ap_remaining, 1);
+  });
+
+  it('slowed non scende sotto 1 AP', () => {
+    const unit = { ap: 1, status: { slowed: 3 } };
+    applyApRefillSpec(unit);
+    assert.equal(unit.ap_remaining, 1);
+  });
+
+  it('slowed a 0 turns: nessun effetto AP', () => {
+    const unit = { ap: 2, status: { slowed: 0 } };
+    applyApRefillSpec(unit);
+    assert.equal(unit.ap_remaining, 2);
+  });
+
+  it('slowed + fracture: fracture cap 1 prima, slowed lascia a 1 (max 1)', () => {
+    const unit = { ap: 3, status: { fracture: 1, slowed: 1 } };
+    applyApRefillSpec(unit);
+    assert.equal(unit.ap_remaining, 1);
+  });
+
+  it('assenza status: ap_remaining = ap pieno', () => {
+    const unit = { ap: 2, status: {} };
+    applyApRefillSpec(unit);
+    assert.equal(unit.ap_remaining, 2);
+  });
+});
+
+// ── STATUS_DURATION_CAPS spec per slowed ─────────────────────────────────────
+
+function applyStatusWithCapSpec(unit, stato, turns, caps) {
+  if (!unit || !unit.status) return;
+  const current = Number(unit.status[stato]) || 0;
+  const cap = caps[stato];
+  const merged = Math.max(current, turns);
+  unit.status[stato] = cap !== undefined ? Math.min(cap, merged) : merged;
+}
+
+describe('slowed duration cap', () => {
+  const CAPS = { slowed: 3 };
+
+  it('slowed cap a 3 turni massimi', () => {
+    const unit = { status: { slowed: 0 } };
+    applyStatusWithCapSpec(unit, 'slowed', 5, CAPS);
+    assert.equal(unit.status.slowed, 3);
+  });
+
+  it('slowed max-merge sotto cap', () => {
+    const unit = { status: { slowed: 2 } };
+    applyStatusWithCapSpec(unit, 'slowed', 1, CAPS);
+    assert.equal(unit.status.slowed, 2);
+  });
+
+  it('slowed applicato correttamente a 3T', () => {
+    const unit = { status: { slowed: 0 } };
+    applyStatusWithCapSpec(unit, 'slowed', 3, CAPS);
+    assert.equal(unit.status.slowed, 3);
+  });
+});


### PR DESCRIPTION
## Summary
- Aggiunge stato `slowed` Tier 1: -1 AP al reset turno, cap 3T, minimo 1 AP garantito
- Wire: `applyApRefill` (sessionHelpers.js) — centralized AP reset, stesso pattern di chilled
- `STATUS_DURATION_CAPS.slowed = 3` in session.js
- Trait `tela_appiccicosa` (T1/fisiologico): hit → slowed 3T
- 8 test spec-reimplementation (5 AP reset + 3 cap)

## Test plan
- [x] `node --test tests/ai/statusEffectsSlowed.test.js` → 8/8 pass
- [x] `npm run format:check` → verde

https://claude.ai/code/session_013Po6rosMuNxvabTAR2MGXM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Po6rosMuNxvabTAR2MGXM)_