### PR TITLE
feat(combat): marked status — +1 dmg on hit cap 2T, trait marchio_predatorio (PR-2)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -92,6 +92,7 @@ const STATUS_DURATION_CAPS = {
   stunned: 3,
   confused: 3,
   bleeding: 5,
+  marked: 2,
   slowed: 3,
   burning: 3,
   chilled: 2,
@@ -537,6 +538,7 @@ function createSessionRouter(options = {}) {
     let killOccurred = false;
     let adjacencyBonus = 0;
     let rageBonus = 0;
+    let markedBonus = 0;
     let backstabBonus = 0;
     let wasBackstab = false;
     let panicTriggered = false;
@@ -562,6 +564,11 @@ function createSessionRouter(options = {}) {
       if (actor.status && Number(actor.status.rage) > 0) {
         rageBonus = 1;
       }
+      // Phase A marked: target marcato → +1 dmg al prossimo attaccante, mark consumato.
+      if (target.status && Number(target.status.marked) > 0) {
+        markedBonus = 1;
+        target.status.marked = 0;
+      }
       // SPRINT_022: bonus backstab — se l'actor attacca dalle spalle del
       // target (posizione dietro il suo facing), +1 damage. Cumulativo con
       // adjacency e rage. Inoltre: un backstab BYPASSA la parata (sorpresa).
@@ -582,6 +589,7 @@ function createSessionRouter(options = {}) {
         evaluation.damage_modifier +
         adjacencyBonus +
         rageBonus +
+        markedBonus +
         backstabBonus +
         perkBonus.bonus +
         parryDelta;

--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -9450,3 +9450,24 @@ traits:
     description_it: |
       Ghiandole che secernono fili vischiosi. Ogni hit applica 3 turni di
       slowed: il target riceve -1 AP al reset turno (minimo 1 AP garantito).
+
+  # Stato marked Tier 1: prossimo attaccante ottiene +1 dmg, mark consumato.
+  # Wire: performAttack (session.js) controlla + consuma il mark prima del danno.
+
+  marchio_predatorio:
+    tier: T1
+    category: comportamentale
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: apply_status
+      target_side: target
+      stato: marked
+      turns: 2
+      log_tag: marchio_predatorio_marked
+    description_it: |
+      Feromoni predatori che segnalano il bersaglio alla squadra. Ogni hit
+      applica 2 turni di marked: il prossimo attacco sul target ottiene
+      +1 danno (il mark viene consumato al primo utilizzo).

--- a/tests/ai/statusEffectsMarked.test.js
+++ b/tests/ai/statusEffectsMarked.test.js
@@ -1,0 +1,82 @@
+// tests/ai/statusEffectsMarked.test.js
+// Unit tests for Status Effects v2 Phase A: marked (PR-2).
+// Pattern: spec-reimplementation — logic mirrored locally, no server needed.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+// ── marked bonus spec ─────────────────────────────────────────────────────────
+
+function computeMarkedBonusSpec(target) {
+  if (!target?.status || !(Number(target.status.marked) > 0)) return 0;
+  target.status.marked = 0;
+  return 1;
+}
+
+describe('marked: attack bonus', () => {
+  it('marked active: +1 dmg al prossimo hit, mark consumato', () => {
+    const target = { status: { marked: 2 } };
+    const bonus = computeMarkedBonusSpec(target);
+    assert.equal(bonus, 1);
+    assert.equal(target.status.marked, 0);
+  });
+
+  it('marked a 0 turns: nessun bonus', () => {
+    const target = { status: { marked: 0 } };
+    const bonus = computeMarkedBonusSpec(target);
+    assert.equal(bonus, 0);
+    assert.equal(target.status.marked, 0);
+  });
+
+  it('marked assente: nessun bonus, status invariato', () => {
+    const target = { status: {} };
+    const bonus = computeMarkedBonusSpec(target);
+    assert.equal(bonus, 0);
+    assert.deepEqual(target.status, {});
+  });
+
+  it('marked status null: 0 bonus (graceful)', () => {
+    const target = { status: null };
+    const bonus = computeMarkedBonusSpec(target);
+    assert.equal(bonus, 0);
+  });
+
+  it('marked: consumato al primo hit (non persiste)', () => {
+    const target = { status: { marked: 1 } };
+    computeMarkedBonusSpec(target);
+    const secondBonus = computeMarkedBonusSpec(target);
+    assert.equal(secondBonus, 0);
+  });
+});
+
+// ── STATUS_DURATION_CAPS spec per marked ─────────────────────────────────────
+
+function applyStatusWithCapSpec(unit, stato, turns, caps) {
+  if (!unit || !unit.status) return;
+  const current = Number(unit.status[stato]) || 0;
+  const cap = caps[stato];
+  const merged = Math.max(current, turns);
+  unit.status[stato] = cap !== undefined ? Math.min(cap, merged) : merged;
+}
+
+describe('marked duration cap', () => {
+  const CAPS = { marked: 2 };
+
+  it('marked cap a 2 turni massimi', () => {
+    const unit = { status: { marked: 0 } };
+    applyStatusWithCapSpec(unit, 'marked', 5, CAPS);
+    assert.equal(unit.status.marked, 2);
+  });
+
+  it('marked max-merge sotto cap', () => {
+    const unit = { status: { marked: 1 } };
+    applyStatusWithCapSpec(unit, 'marked', 2, CAPS);
+    assert.equal(unit.status.marked, 2);
+  });
+
+  it('marked applicato correttamente a 2T', () => {
+    const unit = { status: { marked: 0 } };
+    applyStatusWithCapSpec(unit, 'marked', 2, CAPS);
+    assert.equal(unit.status.marked, 2);
+  });
+});


### PR DESCRIPTION
## Summary
- Aggiunge stato `marked` Tier 1: prossimo attaccante sul target +1 dmg, mark consumato, cap 2T
- Wire: `performAttack` (session.js) — controlla `target.status.marked > 0`, applica bonus, azzera mark
- `STATUS_DURATION_CAPS.marked = 2` in session.js
- Trait `marchio_predatorio` (T1/comportamentale): hit → marked 2T
- 8 test spec-reimplementation (5 bonus/consume + 3 cap)

## Test plan
- [x] `node --test tests/ai/statusEffectsMarked.test.js` → 8/8 pass
- [x] `npm run format:check` → verde

https://claude.ai/code/session_013Po6rosMuNxvabTAR2MGXM

---
_Generated by [Claude Code](https://claude.ai/code/session_013Po6rosMuNxvabTAR2MGXM)_