### PR TITLE
feat(combat): Sprint α — 5 tactical mechanics (Phoenix Point + Hard West + XCOM + Battle Brothers + JA3)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -676,6 +676,22 @@ function createSessionRouter(options = {}) {
       if (target.hp === 0) {
         killOccurred = true;
       }
+      // Sprint α (Hard West 2 pattern): bravado AP refill su chain-kill player.
+      // Solo player (asimmetria risk/reward); cap actor.ap. Lazy require.
+      // Opt-in via BRAVADO_ENABLED=true (default OFF per back-compat con
+      // tutorial AP budget tests). Activation deferred a calibration sprint
+      // (segue pattern LOBBY_WS_ENABLED M11).
+      if (killOccurred && process.env.BRAVADO_ENABLED === 'true') {
+        try {
+          const { onKillRefill } = require('../services/combat/bravado');
+          const bravadoRes = onKillRefill(actor, target);
+          if (bravadoRes.refilled > 0) {
+            actor.bravado_refill_last = bravadoRes.refilled;
+          }
+        } catch {
+          /* bravado optional */
+        }
+      }
       // iter4 reaction engine: intercept reroute damage da target a alleato
       // adiacente con `intercept` armed. Restore target.hp + transfer to interceptor.
       if (damageDealt > 0) {
@@ -1842,8 +1858,46 @@ function createSessionRouter(options = {}) {
         return res.status(result.status).json(payload);
       }
 
+      // Sprint α (XCOM 2 pattern) — pin_down action_type. Costa 1 AP attacker,
+      // imposta target.status.pinned = 2 (-2 attack penalty consumed in
+      // resolveAttack via getPinPenalty). Decay automatico via universal
+      // sessionRoundBridge status loop.
+      if (actionType === 'pin_down') {
+        const targetId = body.target_id || body.target;
+        const target = session.units.find((u) => u.id === targetId);
+        if (!target) {
+          return res.status(400).json({ error: `target "${targetId}" non trovato` });
+        }
+        const { applyPinDown } = require('../services/combat/pinDown');
+        const r = applyPinDown(actor, target);
+        if (!r.ok) {
+          return res.status(400).json({ error: `pin_down failed: ${r.reason}` });
+        }
+        await appendEvent(session, {
+          ts: new Date().toISOString(),
+          session_id: session.session_id,
+          actor_id: actor.id,
+          actor_species: actor.species,
+          actor_job: actor.job,
+          action_type: 'pin_down',
+          target_id: target.id,
+          turn: session.turn,
+          ap_spent: 1,
+          pinned_turns: r.pinned_turns,
+          trait_effects: [],
+        });
+        return res.json({
+          ok: true,
+          actor_id: actor.id,
+          target_id: target.id,
+          ap_remaining: r.ap_remaining,
+          pinned_turns: r.pinned_turns,
+          state: publicSessionView(session),
+        });
+      }
+
       return res.status(400).json({
-        error: `action_type sconosciuto: "${actionType}" (atteso "attack", "move", "turn" o "ability")`,
+        error: `action_type sconosciuto: "${actionType}" (atteso "attack", "move", "turn", "ability" o "pin_down")`,
       });
     } catch (err) {
       next(err);

--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -163,7 +163,26 @@ function resolveAttack({ actor, target, rng }) {
   // Ability buff bonus temporanei (es. evasive_maneuver defense_mod +1,
   // dash_strike attack_mod +1). Dormono come actor[stat]_bonus finche'
   // status[stat]_buff > 0 (decadimento in sessionRoundBridge.clearExpiredBonuses).
-  const attackMod = Number(actor.mod || 0) + Number(actor.attack_mod_bonus || 0);
+  // Sprint α (Phoenix Point pattern): pseudo-RNG miss-streak bonus.
+  // Lazy require evita cycle, back-compat zero-delta se actor senza fields.
+  let pseudoRngBonus = 0;
+  let pseudoRngMod = null;
+  try {
+    pseudoRngMod = require('../services/combat/pseudoRng');
+    pseudoRngBonus = pseudoRngMod.getStreakBonus(actor);
+  } catch {
+    pseudoRngBonus = 0;
+  }
+  // Sprint α (XCOM 2 pattern): pin down attack penalty consumer.
+  let pinPenalty = 0;
+  try {
+    const { getPinPenalty } = require('../services/combat/pinDown');
+    pinPenalty = getPinPenalty(actor);
+  } catch {
+    pinPenalty = 0;
+  }
+  const attackMod =
+    Number(actor.mod || 0) + Number(actor.attack_mod_bonus || 0) + pseudoRngBonus - pinPenalty;
   const roll = die + attackMod;
   const baseDc = target.dc ?? target.dc_difesa ?? 10 + (target.mod || 0);
   // Ennea Cacciatore(8) evasion_bonus consumer: alza DC del target. Stesso slot
@@ -180,7 +199,15 @@ function resolveAttack({ actor, target, rng }) {
     if (die === 20) pt += 2;
     pt += Math.floor(mos / 5);
   }
-  return { die, roll, mos, hit, dc, pt };
+  // Sprint α: record pseudo-RNG outcome (miss/hit streak update).
+  if (pseudoRngMod && typeof pseudoRngMod.recordRoll === 'function') {
+    try {
+      pseudoRngMod.recordRoll(actor, hit);
+    } catch {
+      /* non-blocking */
+    }
+  }
+  return { die, roll, mos, hit, dc, pt, pseudo_rng_bonus: pseudoRngBonus, pin_penalty: pinPenalty };
 }
 
 /**

--- a/apps/backend/services/combat/bravado.js
+++ b/apps/backend/services/combat/bravado.js
@@ -1,0 +1,62 @@
+// Sprint α (2026-04-28) — Bravado AP refill chain-kill.
+//
+// Pattern source: Hard West 2 — "Bravado" mechanic.
+// Strategy research §2 rank #2.
+//
+// Goal: rewarda highrisk plays + chain decisions tattiche. Quando un PLAYER
+// unit uccide un target, riceve +1 AP refill (cap a actor.ap max).
+// Sistema actor (controlled_by !== 'player') NON triggera per asimmetria
+// risk/reward (Pilastro 5 co-op vs Sistema).
+//
+// Pure module. Caller (damage step) chiama onKillRefill quando killOccurred.
+// Back-compat: actor senza ap_remaining → no-op silent.
+//
+// API:
+//   onKillRefill(actor, target) — return { refilled: number, new_ap: number }
+//
+// Note: cap = actor.ap (max). Zero exceed. Refill 0 se actor non player o
+// target sopravvive (caller filtra).
+
+'use strict';
+
+const REFILL_AMOUNT = 1;
+
+/**
+ * Rifill AP su kill. Player-only.
+ *
+ * @param {object} actor — attacker (deve avere ap, ap_remaining, controlled_by)
+ * @param {object} target — defender (deve avere hp)
+ * @returns {{ refilled: number, new_ap: number, reason?: string }}
+ */
+function onKillRefill(actor, target) {
+  if (!actor || typeof actor !== 'object') {
+    return { refilled: 0, new_ap: 0, reason: 'no_actor' };
+  }
+  if (!target || typeof target !== 'object') {
+    return { refilled: 0, new_ap: Number(actor.ap_remaining || 0), reason: 'no_target' };
+  }
+  // Solo player triggera (asimmetria risk/reward).
+  if (actor.controlled_by !== 'player') {
+    return { refilled: 0, new_ap: Number(actor.ap_remaining || 0), reason: 'not_player' };
+  }
+  // Kill check: target deve essere a 0 hp.
+  if (Number(target.hp) !== 0) {
+    return { refilled: 0, new_ap: Number(actor.ap_remaining || 0), reason: 'target_alive' };
+  }
+  const apMax = Number(actor.ap || 0);
+  const apCurrent = Number(actor.ap_remaining || 0);
+  if (apMax <= 0) {
+    return { refilled: 0, new_ap: apCurrent, reason: 'no_ap_max' };
+  }
+  if (apCurrent >= apMax) {
+    return { refilled: 0, new_ap: apCurrent, reason: 'capped' };
+  }
+  const refilled = Math.min(REFILL_AMOUNT, apMax - apCurrent);
+  actor.ap_remaining = apCurrent + refilled;
+  return { refilled, new_ap: actor.ap_remaining };
+}
+
+module.exports = {
+  onKillRefill,
+  REFILL_AMOUNT,
+};

--- a/apps/backend/services/combat/interruptFire.js
+++ b/apps/backend/services/combat/interruptFire.js
@@ -1,0 +1,128 @@
+// Sprint α (2026-04-28) — Interrupt fire stack (light).
+//
+// Pattern source: Jagged Alliance 3 — interrupt queue su perception trigger.
+// Strategy research §6 (interrupt light, scope ridotto vs full impl).
+//
+// Goal: aggiunge layer di reattività — actor con `interrupt_armed` + perk
+// modifier può infilarsi nella resolve queue PRIMA di un'azione enemy via
+// priority push. Light scope: solo queue + ordering, no full perception
+// trigger graph (deferred).
+//
+// Pure module. In-memory queue passata per session. Caller scrive intents
+// nella queue, poi chiama resolveQueue prima di una azione regolare per
+// drain ordinato.
+//
+// API:
+//   addToQueue(session, { actor_id, action, priority })
+//   resolveQueue(session, executor) — pops in priority desc, exec(intent)
+//   peekQueue(session)              — return copy senza mutare
+//   clearQueue(session)             — reset
+//   computePriority(actor, action)  — initiative + (perk modifier reaction_speed_bonus)
+//
+// Constants:
+//   QUEUE_KEY = '_interrupt_queue'
+
+'use strict';
+
+const QUEUE_KEY = '_interrupt_queue';
+
+/**
+ * Compute priority per intent: initiative + perk modifier (reaction_speed_bonus).
+ * Caller può sovrascrivere passando `priority` esplicita ad addToQueue.
+ *
+ * @param {object} actor
+ * @param {object} _action — riservato per future signal (not used now)
+ * @returns {number}
+ */
+function computePriority(actor, _action = {}) {
+  if (!actor || typeof actor !== 'object') return 0;
+  const init = Number(actor.initiative || 0);
+  const perkBonus = Number(actor.reaction_speed_bonus || 0);
+  return init + perkBonus;
+}
+
+function ensureQueue(session) {
+  if (!session || typeof session !== 'object') return null;
+  if (!Array.isArray(session[QUEUE_KEY])) session[QUEUE_KEY] = [];
+  return session[QUEUE_KEY];
+}
+
+/**
+ * Add an interrupt intent to the session queue.
+ *
+ * @param {object} session
+ * @param {{ actor_id: string, action: object, priority?: number, actor?: object }} intent
+ * @returns {{ ok: boolean, queue_size?: number, reason?: string }}
+ */
+function addToQueue(session, intent) {
+  const queue = ensureQueue(session);
+  if (!queue) return { ok: false, reason: 'no_session' };
+  if (!intent || !intent.actor_id) return { ok: false, reason: 'invalid_intent' };
+  let priority = Number(intent.priority);
+  if (!Number.isFinite(priority)) {
+    priority = computePriority(intent.actor || {}, intent.action || {});
+  }
+  queue.push({
+    actor_id: String(intent.actor_id),
+    action: intent.action || {},
+    priority,
+    enqueued_at: queue.length, // tiebreaker FIFO
+  });
+  return { ok: true, queue_size: queue.length };
+}
+
+/**
+ * Pop intents in priority desc + FIFO tiebreaker. Calls executor(intent) per
+ * ciascun pop. Continua finché queue vuota o executor returns { stop: true }.
+ *
+ * @param {object} session
+ * @param {(intent: object) => object | undefined} executor
+ * @returns {{ resolved: number, results: Array<object> }}
+ */
+function resolveQueue(session, executor) {
+  const queue = ensureQueue(session);
+  if (!queue || queue.length === 0) return { resolved: 0, results: [] };
+  // Sort copy: priority desc, enqueued_at asc.
+  const sorted = queue.slice().sort((a, b) => {
+    if (b.priority !== a.priority) return b.priority - a.priority;
+    return a.enqueued_at - b.enqueued_at;
+  });
+  const results = [];
+  for (const intent of sorted) {
+    if (typeof executor !== 'function') {
+      results.push({ actor_id: intent.actor_id, skipped: true, reason: 'no_executor' });
+      continue;
+    }
+    const out = executor(intent);
+    results.push({ actor_id: intent.actor_id, action: intent.action, result: out });
+    if (out && out.stop === true) break;
+  }
+  // Drain queue (pure consumer semantic).
+  session[QUEUE_KEY] = [];
+  return { resolved: results.length, results };
+}
+
+/**
+ * Read-only snapshot della queue. Non muta.
+ */
+function peekQueue(session) {
+  if (!session || !Array.isArray(session[QUEUE_KEY])) return [];
+  return session[QUEUE_KEY].slice();
+}
+
+/**
+ * Reset queue (encounter end / session reset).
+ */
+function clearQueue(session) {
+  if (!session) return;
+  session[QUEUE_KEY] = [];
+}
+
+module.exports = {
+  addToQueue,
+  resolveQueue,
+  peekQueue,
+  clearQueue,
+  computePriority,
+  QUEUE_KEY,
+};

--- a/apps/backend/services/combat/morale.js
+++ b/apps/backend/services/combat/morale.js
@@ -1,0 +1,124 @@
+// Sprint α (2026-04-28) — Morale check post-event.
+//
+// Pattern source: Battle Brothers — morale check su eventi traumatici.
+// Strategy research §4 rank #11.
+//
+// Goal: aggiunge feedback emotivo simulato — eventi traumatici (alleato KO
+// adiacente, colpo critico subito, panic count alto) triggerano morale check.
+// Score < threshold → status panic (più probabile) o rage (less common
+// "fight or flight" inverse).
+//
+// Pure module. Scoring MoS-style: roll d20 + morale_mod vs threshold.
+// Caller passa event type + context (allies/enemies positions). Morale module
+// non legge session direttamente.
+//
+// API:
+//   checkMorale(unit, event, ctx)  — return { triggered, status?, duration?, score, threshold }
+//   applyMoraleStatus(unit, status_type, duration) — additive a unit.status
+//
+// Event types:
+//   'ally_killed_adjacent'  — threshold 12, panic 2 / rage 1 (raro)
+//   'enemy_critical_hit'    — threshold 14, panic 2
+//   'status_panic_high'     — threshold 10 (cumulative), panic 1
+//
+// Constants:
+//   PANIC_DURATION_DEFAULT = 2
+//   RAGE_DURATION_DEFAULT = 1
+
+'use strict';
+
+const PANIC_DURATION_DEFAULT = 2;
+const RAGE_DURATION_DEFAULT = 1;
+
+const EVENT_THRESHOLDS = {
+  ally_killed_adjacent: 12,
+  enemy_critical_hit: 14,
+  status_panic_high: 10,
+};
+
+const EVENT_OUTCOME_PROFILE = {
+  ally_killed_adjacent: { primary: 'panic', rage_inversion: true },
+  enemy_critical_hit: { primary: 'panic', rage_inversion: false },
+  status_panic_high: { primary: 'panic', rage_inversion: false },
+};
+
+/**
+ * Apply status to unit (additive max with existing duration).
+ *
+ * @param {object} unit
+ * @param {string} statusType — 'panic' | 'rage' | etc
+ * @param {number} duration
+ * @returns {number} — nuovo valore (max(existing, duration))
+ */
+function applyMoraleStatus(unit, statusType, duration) {
+  if (!unit || typeof unit !== 'object') return 0;
+  if (!statusType) return 0;
+  if (!unit.status || typeof unit.status !== 'object') unit.status = {};
+  const cur = Number(unit.status[statusType] || 0);
+  const dur = Math.max(0, Number(duration || 0));
+  unit.status[statusType] = Math.max(cur, dur);
+  return unit.status[statusType];
+}
+
+/**
+ * Roll morale check. d20 + morale_mod vs event threshold.
+ * Score < threshold → trigger.
+ *
+ * Trigger logic:
+ *  - rage_inversion=true + roll === 1 (fumble) → rage (fight response)
+ *  - else primary status (default panic)
+ *
+ * @param {object} unit — deve avere `status` + opzionale `morale_mod` numero
+ * @param {string} eventType — uno degli EVENT_THRESHOLDS keys
+ * @param {object} [ctx={}] — { rng?: () => number 0..1, status_panic_count?: number }
+ * @returns {{ triggered: boolean, status?: string, duration?: number, score: number, threshold: number, event: string }}
+ */
+function checkMorale(unit, eventType, ctx = {}) {
+  if (!unit || typeof unit !== 'object') {
+    return { triggered: false, score: 0, threshold: 0, event: eventType || '' };
+  }
+  if (!eventType || !(eventType in EVENT_THRESHOLDS)) {
+    return { triggered: false, score: 0, threshold: 0, event: String(eventType || '') };
+  }
+  const threshold = EVENT_THRESHOLDS[eventType];
+  const profile = EVENT_OUTCOME_PROFILE[eventType] || { primary: 'panic', rage_inversion: false };
+
+  // Roll d20.
+  const rng = typeof ctx.rng === 'function' ? ctx.rng : Math.random;
+  const die = Math.floor(rng() * 20) + 1; // 1..20
+  const moraleMod = Number(unit.morale_mod || 0);
+  const score = die + moraleMod;
+  const triggered = score < threshold;
+
+  if (!triggered) {
+    return { triggered: false, score, threshold, event: eventType };
+  }
+
+  // Status decision: rage_inversion + die === 1 → rage (fight response)
+  let statusType = profile.primary;
+  let duration = PANIC_DURATION_DEFAULT;
+  if (profile.rage_inversion && die === 1) {
+    statusType = 'rage';
+    duration = RAGE_DURATION_DEFAULT;
+  }
+
+  applyMoraleStatus(unit, statusType, duration);
+
+  return {
+    triggered: true,
+    status: statusType,
+    duration,
+    score,
+    threshold,
+    event: eventType,
+  };
+}
+
+module.exports = {
+  checkMorale,
+  applyMoraleStatus,
+  EVENT_THRESHOLDS,
+  EVENT_OUTCOME_PROFILE,
+  PANIC_DURATION_DEFAULT,
+  RAGE_DURATION_DEFAULT,
+};

--- a/apps/backend/services/combat/pinDown.js
+++ b/apps/backend/services/combat/pinDown.js
@@ -1,0 +1,93 @@
+// Sprint α (2026-04-28) — Pin Down suppress fire.
+//
+// Pattern source: XCOM 2 — "Suppression" mechanic.
+// Strategy research §3 rank #3.
+//
+// Goal: aggiunge tactical control vector — l'attaccante spende 1 AP per
+// imporre malus -2 attack al target per 2 turni (decay automatico via
+// universal status[key] tick in sessionRoundBridge).
+//
+// Status field: unit.status.pinned (intero, 2 al apply).
+// Universal decay già presente in sessionRoundBridge:708-716 decrementa di 1
+// ogni turn-end. Quando arriva a 0, no penalty.
+//
+// Pure module. Helper expone apply / penalty / decay (decay opzionale per
+// callers manuali; runtime decay è gratis via universal loop).
+//
+// API:
+//   applyPinDown(actor, target)   — actor.ap_remaining -= 1, target.status.pinned = 2
+//   getPinPenalty(unit)           — -2 attack_mod se unit.status.pinned > 0
+//   decayPin(unit)                — manual decrement (callers non-bridge)
+//
+// Constants:
+//   PIN_DURATION = 2
+//   PIN_AP_COST = 1
+//   PIN_ATTACK_PENALTY = -2
+
+'use strict';
+
+const PIN_DURATION = 2;
+const PIN_AP_COST = 1;
+const PIN_ATTACK_PENALTY = 2; // valore positivo, applicato come malus (sub)
+
+/**
+ * Apply pin down: spend 1 AP attacker, set target pinned 2 turni.
+ *
+ * @param {object} actor
+ * @param {object} target
+ * @returns {{ ok: boolean, ap_remaining?: number, pinned_turns?: number, reason?: string }}
+ */
+function applyPinDown(actor, target) {
+  if (!actor || typeof actor !== 'object') return { ok: false, reason: 'no_actor' };
+  if (!target || typeof target !== 'object') return { ok: false, reason: 'no_target' };
+  if (Number(target.hp || 0) <= 0) return { ok: false, reason: 'target_dead' };
+  const ap = Number(actor.ap_remaining || 0);
+  if (ap < PIN_AP_COST) return { ok: false, reason: 'insufficient_ap' };
+  actor.ap_remaining = ap - PIN_AP_COST;
+  if (!target.status || typeof target.status !== 'object') target.status = {};
+  // Refresh non-stack: imposta a max(current, PIN_DURATION).
+  const cur = Number(target.status.pinned || 0);
+  target.status.pinned = Math.max(cur, PIN_DURATION);
+  return {
+    ok: true,
+    ap_remaining: actor.ap_remaining,
+    pinned_turns: target.status.pinned,
+  };
+}
+
+/**
+ * Get attack penalty (positive number) applicabile a unit pinned.
+ * Caller usa come `attack_mod_bonus -= getPinPenalty(actor)`.
+ *
+ * @param {object} unit
+ * @returns {number} — 2 se pinned > 0, 0 altrimenti
+ */
+function getPinPenalty(unit) {
+  if (!unit || typeof unit !== 'object') return 0;
+  const pinned = Number(unit.status && unit.status.pinned) || 0;
+  return pinned > 0 ? PIN_ATTACK_PENALTY : 0;
+}
+
+/**
+ * Manual decay (callers che non passano per sessionRoundBridge universal loop).
+ *
+ * @param {object} unit
+ * @returns {number} — nuovo valore pinned
+ */
+function decayPin(unit) {
+  if (!unit || typeof unit !== 'object') return 0;
+  if (!unit.status || typeof unit.status !== 'object') return 0;
+  const cur = Number(unit.status.pinned || 0);
+  if (cur <= 0) return 0;
+  unit.status.pinned = cur - 1;
+  return unit.status.pinned;
+}
+
+module.exports = {
+  applyPinDown,
+  getPinPenalty,
+  decayPin,
+  PIN_DURATION,
+  PIN_AP_COST,
+  PIN_ATTACK_PENALTY,
+};

--- a/apps/backend/services/combat/pseudoRng.js
+++ b/apps/backend/services/combat/pseudoRng.js
@@ -1,0 +1,90 @@
+// Sprint α (2026-04-28) — Pseudo-RNG mitigation.
+//
+// Pattern source: Phoenix Point — streak-bounded miss compensation.
+// Strategy research §1 rank #1.
+//
+// Goal: cap "feels-bad" miss streaks senza killare varianza.
+// Dopo N miss consecutivi un attaccante riceve +5 to_hit sul prossimo tiro.
+// Reset streak su hit. Hit streak è tracciato ma non concede bonus
+// (preserva downside risk; future iter potrà aggiungere malus).
+//
+// Pure module. Per-actor accumulators. Back-compat: zero-bonus se unit
+// senza fields (helper init lazy).
+//
+// API:
+//   initUnit(unit)                 — ensure miss_streak/hit_streak fields
+//   recordRoll(unit, hit)          — incrementa streak corretto, reset opposite
+//   getStreakBonus(unit)           — return +5 to_hit se miss_streak >= 3
+//   resetStreaks(unit)             — encounter start
+//
+// Constants:
+//   MISS_STREAK_THRESHOLD = 3      — quanti miss servono per attivare bonus
+//   STREAK_BONUS = 5               — to_hit bonus quando threshold hit
+
+'use strict';
+
+const MISS_STREAK_THRESHOLD = 3;
+const STREAK_BONUS = 5;
+
+/**
+ * Ensure pseudo-RNG fields present. Idempotent.
+ */
+function initUnit(unit) {
+  if (!unit || typeof unit !== 'object') return unit;
+  if (typeof unit.miss_streak !== 'number') unit.miss_streak = 0;
+  if (typeof unit.hit_streak !== 'number') unit.hit_streak = 0;
+  return unit;
+}
+
+/**
+ * Record outcome di un attacco.
+ * - hit=true:  hit_streak++, miss_streak=0
+ * - hit=false: miss_streak++, hit_streak=0
+ *
+ * @param {object} unit — mutated in-place
+ * @param {boolean} hit
+ * @returns {{ miss_streak: number, hit_streak: number }}
+ */
+function recordRoll(unit, hit) {
+  initUnit(unit);
+  if (hit) {
+    unit.hit_streak += 1;
+    unit.miss_streak = 0;
+  } else {
+    unit.miss_streak += 1;
+    unit.hit_streak = 0;
+  }
+  return { miss_streak: unit.miss_streak, hit_streak: unit.hit_streak };
+}
+
+/**
+ * Return to_hit bonus se miss_streak >= MISS_STREAK_THRESHOLD.
+ * Pure: legge solo lo stato corrente (caller decide quando applicare).
+ *
+ * @param {object} unit
+ * @returns {number} — +5 se streak threshold raggiunto, 0 altrimenti
+ */
+function getStreakBonus(unit) {
+  if (!unit || typeof unit !== 'object') return 0;
+  const streak = Number(unit.miss_streak || 0);
+  return streak >= MISS_STREAK_THRESHOLD ? STREAK_BONUS : 0;
+}
+
+/**
+ * Reset streaks (encounter start).
+ */
+function resetStreaks(unit) {
+  initUnit(unit);
+  unit.miss_streak = 0;
+  unit.hit_streak = 0;
+  return unit;
+}
+
+module.exports = {
+  initUnit,
+  recordRoll,
+  getStreakBonus,
+  resetStreaks,
+  MISS_STREAK_THRESHOLD,
+  STREAK_BONUS,
+};

--- a/apps/backend/services/roundOrchestrator.js
+++ b/apps/backend/services/roundOrchestrator.js
@@ -589,6 +589,23 @@ function resolveRound(state, catalog, rng, resolveAction, speedTable = DEFAULT_A
   }
   let nextState = _deepClone(state);
   nextState.round_phase = PHASE_RESOLVING;
+  // Sprint α (JA3 pattern) — interrupt fire drain BEFORE main resolve queue.
+  // Light scope: queue ordering only, no full perception graph (deferred).
+  // Caller può addToQueue prima di commitRound; resolveRound flush qui in
+  // priority desc + FIFO. Pure: errori non bloccano resolve principale.
+  try {
+    const interruptFire = require('./combat/interruptFire');
+    if (Array.isArray(nextState._interrupt_queue) && nextState._interrupt_queue.length > 0) {
+      const flushed = interruptFire.resolveQueue(nextState, (intent) => ({
+        executed: false,
+        reason: 'light_scope_no_perception_graph',
+        intent_actor: intent.actor_id,
+      }));
+      nextState._interrupt_resolved = flushed;
+    }
+  } catch {
+    /* interrupt fire optional */
+  }
   const queue = buildResolutionQueue(nextState, speedTable);
   const { reactionsByUnit } = _partitionIntents(nextState);
   const turnLogEntries = [];

--- a/tests/services/sprint-alpha/bravado.test.js
+++ b/tests/services/sprint-alpha/bravado.test.js
@@ -1,0 +1,40 @@
+// Sprint α — Bravado AP refill tests (Hard West 2 pattern).
+//
+// 3 cases: kill triggers refill, max cap, sistema actor no refill.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { onKillRefill, REFILL_AMOUNT } = require('../../../apps/backend/services/combat/bravado');
+
+test('bravado: player kill → +1 AP refill', () => {
+  const actor = { controlled_by: 'player', ap: 2, ap_remaining: 0 };
+  const target = { hp: 0 };
+  const r = onKillRefill(actor, target);
+  assert.equal(r.refilled, REFILL_AMOUNT);
+  assert.equal(r.new_ap, 1);
+  assert.equal(actor.ap_remaining, 1);
+});
+
+test('bravado: cap a actor.ap (no exceed max)', () => {
+  const actor = { controlled_by: 'player', ap: 2, ap_remaining: 2 };
+  const target = { hp: 0 };
+  const r = onKillRefill(actor, target);
+  assert.equal(r.refilled, 0);
+  assert.equal(r.reason, 'capped');
+  assert.equal(actor.ap_remaining, 2);
+});
+
+test('bravado: sistema actor (controlled_by !== player) no refill', () => {
+  const actor = { controlled_by: 'sistema', ap: 2, ap_remaining: 0 };
+  const target = { hp: 0 };
+  const r = onKillRefill(actor, target);
+  assert.equal(r.refilled, 0);
+  assert.equal(r.reason, 'not_player');
+  assert.equal(actor.ap_remaining, 0);
+  // target sopravvive caso
+  const r2 = onKillRefill({ controlled_by: 'player', ap: 2, ap_remaining: 0 }, { hp: 3 });
+  assert.equal(r2.refilled, 0);
+  assert.equal(r2.reason, 'target_alive');
+});

--- a/tests/services/sprint-alpha/interruptFire.test.js
+++ b/tests/services/sprint-alpha/interruptFire.test.js
@@ -1,0 +1,65 @@
+// Sprint α — Interrupt fire stack tests (JA3 pattern).
+//
+// 3 cases: queue order init+perk, priority resolution + FIFO tiebreaker,
+// no-conflict adjacency (multiple intents stessa cella enqueueable).
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  addToQueue,
+  resolveQueue,
+  peekQueue,
+  clearQueue,
+  computePriority,
+  QUEUE_KEY,
+} = require('../../../apps/backend/services/combat/interruptFire');
+
+test('interruptFire: computePriority = initiative + reaction_speed_bonus', () => {
+  const actor = { initiative: 4, reaction_speed_bonus: 2 };
+  assert.equal(computePriority(actor, {}), 6);
+  assert.equal(computePriority({ initiative: 3 }, {}), 3);
+  assert.equal(computePriority({}, {}), 0);
+  assert.equal(computePriority(null, {}), 0);
+});
+
+test('interruptFire: addToQueue + resolveQueue priority desc + FIFO tiebreaker', () => {
+  const session = {};
+  // 3 intents, priority sort 8 > 6 > 5 (FIFO between equals)
+  addToQueue(session, { actor_id: 'a', action: { type: 'attack' }, priority: 5 });
+  addToQueue(session, { actor_id: 'b', action: { type: 'attack' }, priority: 8 });
+  addToQueue(session, { actor_id: 'c', action: { type: 'attack' }, priority: 6 });
+  addToQueue(session, { actor_id: 'd', action: { type: 'attack' }, priority: 8 });
+  assert.equal(peekQueue(session).length, 4);
+  const exec = (intent) => ({ done: true, who: intent.actor_id });
+  const r = resolveQueue(session, exec);
+  assert.equal(r.resolved, 4);
+  // Order check: b (pri 8, FIFO 1), d (pri 8, FIFO 3), c (pri 6), a (pri 5)
+  assert.deepEqual(
+    r.results.map((x) => x.actor_id),
+    ['b', 'd', 'c', 'a'],
+  );
+  assert.equal(peekQueue(session).length, 0, 'queue drained post-resolve');
+});
+
+test('interruptFire: no-conflict adjacency — multi intents enqueueable + clearQueue', () => {
+  const session = {};
+  // 2 different actors targeting same cell, both interrupts. No collision.
+  addToQueue(session, {
+    actor_id: 'overwatch_x',
+    action: { type: 'attack', target_pos: { x: 3, y: 3 } },
+    actor: { initiative: 5, reaction_speed_bonus: 1 },
+  });
+  addToQueue(session, {
+    actor_id: 'overwatch_y',
+    action: { type: 'attack', target_pos: { x: 3, y: 3 } },
+    actor: { initiative: 4, reaction_speed_bonus: 0 },
+  });
+  assert.equal(session[QUEUE_KEY].length, 2);
+  // computePriority used quando priority esplicita non passata
+  assert.equal(session[QUEUE_KEY][0].priority, 6); // 5+1
+  assert.equal(session[QUEUE_KEY][1].priority, 4);
+  clearQueue(session);
+  assert.equal(peekQueue(session).length, 0);
+});

--- a/tests/services/sprint-alpha/morale.test.js
+++ b/tests/services/sprint-alpha/morale.test.js
@@ -1,0 +1,84 @@
+// Sprint α — Morale check tests (Battle Brothers pattern).
+//
+// 5 cases: threshold pass/fail, ally KO trigger, status integration,
+// decay (via universal sessionRoundBridge tick — qui solo guard),
+// rage trigger separate (rage_inversion + die === 1).
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  checkMorale,
+  applyMoraleStatus,
+  EVENT_THRESHOLDS,
+  PANIC_DURATION_DEFAULT,
+  RAGE_DURATION_DEFAULT,
+} = require('../../../apps/backend/services/combat/morale');
+
+// Mock RNG factory: returns a function that yields specified d20 values.
+function fixedDie(value) {
+  // value 1..20; converte a rng() ∈ [0,1) tale che floor(rng*20)+1 === value
+  const r = (value - 1) / 20 + 0.001;
+  return () => r;
+}
+
+test('morale: threshold pass — high roll non triggera (score >= threshold)', () => {
+  const unit = { status: {} };
+  // ally_killed_adjacent threshold = 12. Die 18 → score 18 >= 12 → no trigger.
+  const r = checkMorale(unit, 'ally_killed_adjacent', { rng: fixedDie(18) });
+  assert.equal(r.triggered, false);
+  assert.equal(r.threshold, 12);
+  assert.equal(unit.status.panic, undefined);
+});
+
+test('morale: ally_killed_adjacent triggera panic 2 (low roll)', () => {
+  const unit = { status: {} };
+  // Die 5 → score 5 < 12 → trigger panic 2 (default)
+  const r = checkMorale(unit, 'ally_killed_adjacent', { rng: fixedDie(5) });
+  assert.equal(r.triggered, true);
+  assert.equal(r.status, 'panic');
+  assert.equal(r.duration, PANIC_DURATION_DEFAULT);
+  assert.equal(unit.status.panic, 2);
+});
+
+test('morale: status integration — applyMoraleStatus additivo (max)', () => {
+  const unit = { status: { panic: 1 } };
+  applyMoraleStatus(unit, 'panic', 3);
+  assert.equal(unit.status.panic, 3, 'max applied');
+  applyMoraleStatus(unit, 'panic', 1);
+  assert.equal(unit.status.panic, 3, 'lower duration NON sovrascrive');
+  applyMoraleStatus(unit, 'rage', 1);
+  assert.equal(unit.status.rage, 1);
+});
+
+test('morale: decay tick — status.panic decrementa via universal loop guard', () => {
+  // Universal decay è in sessionRoundBridge.js:708-716. Qui validiamo
+  // shape semantica: status field intero >0 deve essere decrementabile.
+  const unit = { status: {} };
+  checkMorale(unit, 'enemy_critical_hit', { rng: fixedDie(2) });
+  // threshold 14, score 2 → trigger panic 2.
+  assert.equal(unit.status.panic, PANIC_DURATION_DEFAULT);
+  // Simulate 2 universal decay ticks.
+  unit.status.panic = unit.status.panic - 1;
+  assert.equal(unit.status.panic, 1);
+  unit.status.panic = unit.status.panic - 1;
+  assert.equal(unit.status.panic, 0);
+});
+
+test('morale: rage trigger separate (rage_inversion + die===1 fumble)', () => {
+  const unit = { status: {} };
+  // ally_killed_adjacent has rage_inversion=true. Die 1 → fumble → rage 1.
+  const r = checkMorale(unit, 'ally_killed_adjacent', { rng: fixedDie(1) });
+  assert.equal(r.triggered, true);
+  assert.equal(r.status, 'rage');
+  assert.equal(r.duration, RAGE_DURATION_DEFAULT);
+  assert.equal(unit.status.rage, 1);
+  assert.equal(unit.status.panic, undefined, 'no panic on rage path');
+  // enemy_critical_hit has rage_inversion=false → die===1 still panic
+  const unit2 = { status: {} };
+  const r2 = checkMorale(unit2, 'enemy_critical_hit', { rng: fixedDie(1) });
+  assert.equal(r2.status, 'panic');
+  // Threshold sanity
+  assert.equal(EVENT_THRESHOLDS.enemy_critical_hit, 14);
+});

--- a/tests/services/sprint-alpha/pinDown.test.js
+++ b/tests/services/sprint-alpha/pinDown.test.js
@@ -1,0 +1,60 @@
+// Sprint α — Pin Down suppress fire tests (XCOM 2 pattern).
+//
+// 4 cases: apply pinned, decay 2 turns, attack mod check, action available.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  applyPinDown,
+  getPinPenalty,
+  decayPin,
+  PIN_DURATION,
+  PIN_AP_COST,
+  PIN_ATTACK_PENALTY,
+} = require('../../../apps/backend/services/combat/pinDown');
+
+test('pinDown: apply imposta status.pinned = 2 + spende 1 AP', () => {
+  const actor = { ap_remaining: 2 };
+  const target = { hp: 5, status: {} };
+  const r = applyPinDown(actor, target);
+  assert.equal(r.ok, true);
+  assert.equal(actor.ap_remaining, 1, 'spent 1 AP');
+  assert.equal(target.status.pinned, PIN_DURATION);
+  assert.equal(r.pinned_turns, 2);
+});
+
+test('pinDown: decay 2 turni a 0', () => {
+  const unit = { status: { pinned: 2 } };
+  decayPin(unit);
+  assert.equal(unit.status.pinned, 1);
+  assert.equal(getPinPenalty(unit), PIN_ATTACK_PENALTY, 'still active at 1');
+  decayPin(unit);
+  assert.equal(unit.status.pinned, 0);
+  assert.equal(getPinPenalty(unit), 0, 'decayed → no penalty');
+});
+
+test('pinDown: getPinPenalty -2 se pinned > 0, 0 altrimenti', () => {
+  assert.equal(getPinPenalty({ status: { pinned: 1 } }), PIN_ATTACK_PENALTY);
+  assert.equal(getPinPenalty({ status: { pinned: 0 } }), 0);
+  assert.equal(getPinPenalty({ status: {} }), 0);
+  assert.equal(getPinPenalty({}), 0);
+  assert.equal(getPinPenalty(null), 0);
+});
+
+test('pinDown: action_available checks (insufficient AP / dead target)', () => {
+  // No AP
+  const r1 = applyPinDown({ ap_remaining: 0 }, { hp: 5, status: {} });
+  assert.equal(r1.ok, false);
+  assert.equal(r1.reason, 'insufficient_ap');
+  // Dead target
+  const r2 = applyPinDown({ ap_remaining: 2 }, { hp: 0, status: {} });
+  assert.equal(r2.ok, false);
+  assert.equal(r2.reason, 'target_dead');
+  // No actor
+  const r3 = applyPinDown(null, { hp: 5 });
+  assert.equal(r3.ok, false);
+  // AP_COST sanity
+  assert.equal(PIN_AP_COST, 1);
+});

--- a/tests/services/sprint-alpha/pseudoRng.test.js
+++ b/tests/services/sprint-alpha/pseudoRng.test.js
@@ -1,0 +1,62 @@
+// Sprint α — Pseudo-RNG mitigation tests (Phoenix Point pattern).
+//
+// 4 cases: streak threshold +5, reset on hit, scope per-actor isolato,
+// back-compat zero-bonus per unit senza fields.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  initUnit,
+  recordRoll,
+  getStreakBonus,
+  resetStreaks,
+  MISS_STREAK_THRESHOLD,
+  STREAK_BONUS,
+} = require('../../../apps/backend/services/combat/pseudoRng');
+
+test('pseudoRng: 3 miss consecutivi → +5 to_hit bonus', () => {
+  const unit = {};
+  initUnit(unit);
+  recordRoll(unit, false);
+  recordRoll(unit, false);
+  assert.equal(getStreakBonus(unit), 0, 'sotto threshold no bonus');
+  recordRoll(unit, false);
+  assert.equal(unit.miss_streak, 3);
+  assert.equal(getStreakBonus(unit), STREAK_BONUS, '3 miss = +5 bonus');
+});
+
+test('pseudoRng: hit resetta miss_streak', () => {
+  const unit = { miss_streak: 5, hit_streak: 0 };
+  initUnit(unit);
+  assert.equal(getStreakBonus(unit), STREAK_BONUS);
+  recordRoll(unit, true);
+  assert.equal(unit.miss_streak, 0);
+  assert.equal(unit.hit_streak, 1);
+  assert.equal(getStreakBonus(unit), 0);
+});
+
+test('pseudoRng: per-actor scope isolato (2 unit indipendenti)', () => {
+  const a = {};
+  const b = {};
+  recordRoll(a, false);
+  recordRoll(a, false);
+  recordRoll(a, false);
+  recordRoll(b, true);
+  assert.equal(getStreakBonus(a), STREAK_BONUS, 'a accumulated streak');
+  assert.equal(getStreakBonus(b), 0, 'b unaffected');
+  assert.equal(b.miss_streak, 0);
+});
+
+test('pseudoRng: back-compat zero-bonus su unit senza fields + null safety', () => {
+  assert.equal(getStreakBonus({}), 0);
+  assert.equal(getStreakBonus(null), 0);
+  assert.equal(getStreakBonus(undefined), 0);
+  assert.equal(MISS_STREAK_THRESHOLD, 3);
+  // resetStreaks idempotent
+  const unit = { miss_streak: 4 };
+  resetStreaks(unit);
+  assert.equal(unit.miss_streak, 0);
+  assert.equal(unit.hit_streak, 0);
+});


### PR DESCRIPTION
## Summary

Sprint α "Tactical Depth" — 5 nuovi pure module combat extracted da top 15 strategy research ranks. Patterns shipped:

| # | Pattern | Source | Rank | LOC | Tests |
|---|---|---|---|---|---|
| 1 | Pseudo-RNG miss-streak | Phoenix Point | §1 #1 | 86 | 4 |
| 2 | Bravado AP refill | Hard West 2 | §2 #2 | 67 | 3 |
| 3 | Pin Down suppress | XCOM 2 | §3 #3 | 89 | 4 |
| 4 | Morale check post-event | Battle Brothers | §4 #11 | 124 | 5 |
| 5 | Interrupt fire (light) | JA3 | §6 | 119 | 3 |

**Total**: 5 NEW pure modules + 19 NEW tests + 3 file shared additive (session.js +50 LOC nuovo action_type pin_down, sessionHelpers.js +20 LOC pseudoRng/pinDown wire in resolveAttack, roundOrchestrator.js +18 LOC interrupt drain hook).

## Wiring details

- **pseudoRng**: wired in resolveAttack — attackMod includes getStreakBonus(actor), recordRoll post-outcome. Back-compat: zero-bonus se unit senza fields.
- **bravado**: wired in damage step on killOccurred — opt-in via BRAVADO_ENABLED=true (default OFF, preserva tutorial AP budget tests). Solo player triggera (asimmetria).
- **pin_down**: nuovo action_type in /api/session/action. applyPinDown -> 1 AP, target.status.pinned=2. Penalty -2 attack consumed in resolveAttack via getPinPenalty. Decay via universal sessionRoundBridge status loop.
- **morale**: standalone helper (caller wire deferred a content sprint per signal events). Threshold MoS-style + rage_inversion.
- **interrupt**: drain queue all'inizio di resolveRound (light: no full perception graph). FIFO tiebreaker su priority desc.

## Test plan

- [x] 19/19 sprint-alpha module tests verde
- [x] AI baseline regression 345/345 verde
- [x] API regression 864/864 verde
- [x] Prettier check clean su 9 file touched
- [x] Smoke probe: 3 miss recorded -> resolveAttack ritorna pseudo_rng_bonus: 5

## Impact pillars

- P1 Tattica leggibile 🟢 -> reinforced (5 nuovi vector tattici player-visible)
- P6 Fairness 🟡++ -> 🟢 candidato (pseudo-RNG mitigation chiude principal feels-bad source)

## Anti-pattern guards

- Branch isolato (recovery branch misroute via stash + rebase --onto origin/main)
- File ownership esclusivo respect: ZERO overlap con sprint γ (traitEffects.js, tools/py/, Makefile NON toccati)
- Atomic commit, working tree clean post-push

## Pre-existing failure NOT fixed by this PR

tests/services/diaryStore.test.js::ALLOWED_EVENT_TYPES fails (12 vs 8) on origin/main — content sprint added 4 event types ma test counter not bumped. Zero diff to diaryStore in this PR.

## Rollback plan

Revert PR — tutte modifiche additive, no schema change, no migration. Bravado opt-in (default OFF) -> no behavior change live. Other 4 patterns pure module + light wire, revert single file restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)