### PR TITLE
feat(meta): Sprint δ — 4 systemic patterns (DNA encoding + event chain + mutation swap + conviction voting)

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -33,6 +33,7 @@ const { createDiaryRouter } = require('./routes/diary');
 const { createSkivRouter } = require('./routes/skiv');
 // Sprint 3 §II (2026-04-27) — AncientBeast wiki cross-link slug bridge.
 const { createSpeciesWikiRouter } = require('./routes/speciesWiki');
+const { createConvictionRouter } = require('./routes/conviction');
 const { createCoopStore } = require('./services/coop/coopStore');
 const { LobbyService } = require('./services/network/wsSession');
 const { createNebulaTelemetryAggregator } = require('./services/nebulaTelemetryAggregator');
@@ -786,6 +787,9 @@ function createApp(options = {}) {
   // Cross-link runtime species (data/core/species.yaml) ↔ catalog wiki
   // (packs/evo_tactics_pack/docs/catalog/species/) via slug normalization.
   app.use('/api', createSpeciesWikiRouter());
+
+  // Sprint δ Meta Systemic (2026-04-28) — Triangle Strategy conviction voting.
+  app.use('/api', createConvictionRouter());
 
   // Bundle B.3 codex routes già registrate sopra (line 758) — single
   // createCodexRouter() ora ospita BOTH glyph-progression (PR #1931) +

--- a/apps/backend/routes/conviction.js
+++ b/apps/backend/routes/conviction.js
@@ -1,0 +1,63 @@
+// Sprint δ Meta Systemic — Pattern 4 wiring (conviction voting routes).
+//
+// Endpoints:
+//   POST /api/v1/conviction/init   → init ballot for session
+//   POST /api/v1/conviction/vote   → cast/update player vote
+//   GET  /api/v1/conviction/results?session_id=... → current tally
+//   POST /api/v1/conviction/close  → finalize + return outcome
+
+'use strict';
+
+const { Router } = require('express');
+const { initBallot, castVote, tally, closeBallot } = require('../services/meta/convictionVoting');
+
+function createConvictionRouter() {
+  const router = Router();
+
+  router.post('/v1/conviction/init', (req, res) => {
+    const { session_id, choices } = req.body || {};
+    const result = initBallot(session_id, choices);
+    if (!result.ok) {
+      return res.status(400).json({ error: result.reason });
+    }
+    res.json({
+      session_id,
+      ballot_size: result.ballot.choices.size,
+    });
+  });
+
+  router.post('/v1/conviction/vote', (req, res) => {
+    const { session_id, player_id, choice_id, vc_snapshot } = req.body || {};
+    const result = castVote(session_id, player_id, choice_id, vc_snapshot || {});
+    if (!result.ok) {
+      const status = result.reason === 'ballot_not_found' ? 404 : 400;
+      return res.status(status).json({ error: result.reason });
+    }
+    res.json({ vote: result.vote });
+  });
+
+  router.get('/v1/conviction/results', (req, res) => {
+    const session_id = req.query.session_id;
+    if (!session_id || typeof session_id !== 'string') {
+      return res.status(400).json({ error: 'session_id_required' });
+    }
+    const result = tally(session_id);
+    if (!result.ok) {
+      return res.status(404).json({ error: result.reason });
+    }
+    res.json(result);
+  });
+
+  router.post('/v1/conviction/close', (req, res) => {
+    const { session_id } = req.body || {};
+    const result = closeBallot(session_id);
+    if (!result.ok) {
+      return res.status(404).json({ error: result.reason });
+    }
+    res.json(result.result);
+  });
+
+  return router;
+}
+
+module.exports = { createConvictionRouter };

--- a/apps/backend/services/meta/convictionVoting.js
+++ b/apps/backend/services/meta/convictionVoting.js
@@ -1,0 +1,252 @@
+// Sprint δ Meta Systemic — Pattern 4 (Triangle Strategy conviction voting).
+//
+// Multi-player choice resolution with VC-axis weighted votes.
+// Each voter contributes weight derived from VC axis alignment with choice.
+//
+// Pattern source: docs/research/2026-04-27-strategy-games-mechanics-extraction.md §8
+// (Triangle Strategy Scales of Conviction). In Triangle Strategy, branching
+// decisions are decided by liege council vote where each member's vote weight
+// is derived from past character actions (conviction). We adapt this with VC
+// axes (T_F or J_P) so voter weight reflects player MBTI personality slope.
+//
+// Tie-break: prefer status-quo choice (choice_id with `is_status_quo: true`),
+// fallback to alphabetical first choice_id.
+//
+// Missing axis fallback: weight = 1.0 (neutral, equivalent to no influence).
+//
+// Used by: routes/conviction.js (POST /vote, GET /results).
+
+'use strict';
+
+const _activeBallots = new Map(); // session_id → { choices: Map<choice_id, choice_meta>, votes: Map<player_id, vote> }
+
+const VC_AXIS_DEFAULT = 'T_F';
+
+/**
+ * Reset all in-memory ballots (test helper).
+ */
+function _resetBallots() {
+  _activeBallots.clear();
+}
+
+/**
+ * Initialize a ballot for a session with a list of choices.
+ *
+ * Each choice shape:
+ *   { choice_id: string, label_it?: string, vc_axis?: 'T_F'|'J_P'|...,
+ *     vc_target?: number (-1..1), is_status_quo?: boolean }
+ *
+ * `vc_target` represents the alignment direction this choice favors on the
+ * specified axis. Voter weight is derived from |vc_axis_value - vc_target|
+ * inverse — closer alignment ⇒ higher weight.
+ *
+ * @param {string} session_id
+ * @param {object[]} choices
+ * @returns {{ ok: boolean, ballot?: object, reason?: string }}
+ */
+function initBallot(session_id, choices) {
+  if (!session_id || typeof session_id !== 'string') {
+    return { ok: false, reason: 'session_id_required' };
+  }
+  if (!Array.isArray(choices) || choices.length < 2) {
+    return { ok: false, reason: 'choices_min_two_required' };
+  }
+  const choiceMap = new Map();
+  for (const c of choices) {
+    if (!c.choice_id || typeof c.choice_id !== 'string') continue;
+    choiceMap.set(c.choice_id, {
+      choice_id: c.choice_id,
+      label_it: c.label_it || c.choice_id,
+      vc_axis: c.vc_axis || VC_AXIS_DEFAULT,
+      vc_target: typeof c.vc_target === 'number' ? c.vc_target : 0,
+      is_status_quo: c.is_status_quo === true,
+    });
+  }
+  if (choiceMap.size < 2) {
+    return { ok: false, reason: 'invalid_choices_after_validation' };
+  }
+  const ballot = {
+    session_id,
+    choices: choiceMap,
+    votes: new Map(),
+    created_at: new Date().toISOString(),
+  };
+  _activeBallots.set(session_id, ballot);
+  return { ok: true, ballot };
+}
+
+/**
+ * Compute single-vote weight for a player choice.
+ *
+ * Formula:
+ *   weight = 1.0 + (1.0 - normalizedDistance)
+ *   normalizedDistance = clamp(|vc_value - vc_target| / 2.0, 0, 1)
+ *
+ * Range: 1.0 (no alignment / missing axis) → 2.0 (perfect alignment).
+ *
+ * @param {object} choice — { vc_axis, vc_target }
+ * @param {object} vc_snapshot — { axes: { T_F: number, J_P: number, ... } }
+ * @returns {number}
+ */
+function computeVoteWeight(choice, vc_snapshot) {
+  const axes = vc_snapshot?.axes || vc_snapshot || {};
+  const value = Number(axes[choice.vc_axis]);
+  if (Number.isNaN(value)) return 1.0; // fallback: missing axis = neutral weight
+  const target = Number(choice.vc_target ?? 0);
+  const distance = Math.abs(value - target);
+  // Axes typically -1..1, distance max 2.0
+  const normalized = Math.min(distance / 2.0, 1.0);
+  return 1.0 + (1.0 - normalized);
+}
+
+/**
+ * Cast a vote for a player on a session ballot.
+ * Subsequent votes from same player_id replace previous vote.
+ *
+ * @param {string} session_id
+ * @param {string} player_id
+ * @param {string} choice_id
+ * @param {object} vc_snapshot
+ * @returns {{ ok: boolean, vote?: object, reason?: string }}
+ */
+function castVote(session_id, player_id, choice_id, vc_snapshot) {
+  const ballot = _activeBallots.get(session_id);
+  if (!ballot) return { ok: false, reason: 'ballot_not_found' };
+  if (!player_id || typeof player_id !== 'string') {
+    return { ok: false, reason: 'player_id_required' };
+  }
+  const choice = ballot.choices.get(choice_id);
+  if (!choice) return { ok: false, reason: 'choice_not_found' };
+  const weight = computeVoteWeight(choice, vc_snapshot);
+  const vote = {
+    player_id,
+    choice_id,
+    weight,
+    cast_at: new Date().toISOString(),
+  };
+  ballot.votes.set(player_id, vote);
+  return { ok: true, vote };
+}
+
+/**
+ * Tally votes for a session ballot.
+ *
+ * @param {string} session_id
+ * @returns {{
+ *   ok: boolean,
+ *   tally?: { choice_id: string, weight_total: number, voter_count: number }[],
+ *   winner_choice_id?: string|null,
+ *   tie?: boolean,
+ *   reason?: string
+ * }}
+ */
+function tally(session_id) {
+  const ballot = _activeBallots.get(session_id);
+  if (!ballot) return { ok: false, reason: 'ballot_not_found' };
+  const totals = new Map();
+  for (const choice_id of ballot.choices.keys()) {
+    totals.set(choice_id, { choice_id, weight_total: 0, voter_count: 0 });
+  }
+  for (const vote of ballot.votes.values()) {
+    const t = totals.get(vote.choice_id);
+    if (!t) continue;
+    t.weight_total += vote.weight;
+    t.voter_count += 1;
+  }
+  const tallyArr = Array.from(totals.values()).sort(
+    (a, b) => b.weight_total - a.weight_total || a.choice_id.localeCompare(b.choice_id),
+  );
+  let winner = null;
+  let tie = false;
+  if (tallyArr.length > 0) {
+    const top = tallyArr[0];
+    const second = tallyArr[1];
+    if (top.weight_total === 0 && (!second || second.weight_total === 0)) {
+      // No votes cast yet
+      winner = null;
+      tie = true;
+    } else if (second && top.weight_total === second.weight_total) {
+      // Tie: prefer status_quo
+      const tied = tallyArr.filter((t) => t.weight_total === top.weight_total);
+      const sq = tied.find((t) => ballot.choices.get(t.choice_id)?.is_status_quo);
+      winner = sq ? sq.choice_id : top.choice_id;
+      tie = true;
+    } else {
+      winner = top.choice_id;
+    }
+  }
+  return {
+    ok: true,
+    tally: tallyArr,
+    winner_choice_id: winner,
+    tie,
+  };
+}
+
+/**
+ * Tally a list of votes directly without persistent ballot store.
+ * Helper for stateless aggregations.
+ *
+ * @param {object[]} votes — [{ choice_id, weight }, ...]
+ * @param {object[]} choices — [{ choice_id, is_status_quo? }]
+ * @returns {{ winner_choice_id: string|null, tie: boolean, totals: object[] }}
+ */
+function tallyConviction(votes = [], choices = []) {
+  const choiceMap = new Map();
+  for (const c of choices) {
+    if (!c.choice_id) continue;
+    choiceMap.set(c.choice_id, c);
+  }
+  const totals = new Map();
+  for (const c of choiceMap.keys()) totals.set(c, 0);
+  for (const v of votes) {
+    if (!totals.has(v.choice_id)) continue;
+    totals.set(v.choice_id, totals.get(v.choice_id) + Number(v.weight ?? 1));
+  }
+  const totalsArr = Array.from(totals.entries())
+    .map(([choice_id, weight]) => ({ choice_id, weight_total: weight }))
+    .sort((a, b) => b.weight_total - a.weight_total || a.choice_id.localeCompare(b.choice_id));
+  let winner = null;
+  let tie = false;
+  if (totalsArr.length > 0) {
+    const top = totalsArr[0];
+    const second = totalsArr[1];
+    if (top.weight_total === 0) {
+      winner = null;
+      tie = true;
+    } else if (second && top.weight_total === second.weight_total) {
+      const tied = totalsArr.filter((t) => t.weight_total === top.weight_total);
+      const sq = tied.find((t) => choiceMap.get(t.choice_id)?.is_status_quo);
+      winner = sq ? sq.choice_id : top.choice_id;
+      tie = true;
+    } else {
+      winner = top.choice_id;
+    }
+  }
+  return { winner_choice_id: winner, tie, totals: totalsArr };
+}
+
+/**
+ * Close ballot and return final result.
+ *
+ * @param {string} session_id
+ * @returns {{ ok: boolean, result?: object, reason?: string }}
+ */
+function closeBallot(session_id) {
+  const ballot = _activeBallots.get(session_id);
+  if (!ballot) return { ok: false, reason: 'ballot_not_found' };
+  const result = tally(session_id);
+  _activeBallots.delete(session_id);
+  return { ok: true, result };
+}
+
+module.exports = {
+  initBallot,
+  castVote,
+  tally,
+  tallyConviction,
+  closeBallot,
+  computeVoteWeight,
+  _resetBallots,
+  VC_AXIS_DEFAULT,
+};

--- a/apps/backend/services/meta/eventChainScripting.js
+++ b/apps/backend/services/meta/eventChainScripting.js
@@ -1,0 +1,210 @@
+// Sprint δ Meta Systemic — Pattern 2 (Stellaris event chain scripting).
+//
+// Lightweight YAML-driven event chain engine. Conditions evaluated against
+// session state (vcSnapshot axes / session.* fields). Supports linear
+// chain walks + conditional branching (next_event_id selection).
+//
+// Pattern source: docs/research/2026-04-27-strategy-games-tech-extraction.md §2
+// (Stellaris event chains) — Paradox uses scripted scripted_triggers + on_actions
+// to build narrative cascades. We do simplified version: chain = ordered list
+// of events; each event has optional condition gate + next_event_id pointer.
+//
+// Schema YAML (data/core/narrative/event_chains/<chain_id>.yaml):
+//   chain_id: string
+//   events:
+//     - id: string
+//       text_it: string
+//       text_en?: string
+//       condition: { vc_axis, threshold, op } | null
+//       next_event_id: string | null
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const CHAINS_DIR = path.resolve(__dirname, '../../../../data/core/narrative/event_chains');
+
+const _chainCache = new Map(); // chain_id → parsed chain
+
+const CONDITION_OPS = {
+  '>': (a, b) => a > b,
+  '>=': (a, b) => a >= b,
+  '<': (a, b) => a < b,
+  '<=': (a, b) => a <= b,
+  '==': (a, b) => a === b,
+  '!=': (a, b) => a !== b,
+};
+
+/**
+ * Load chain YAML by chain_id (cached).
+ *
+ * @param {string} chain_id
+ * @param {object} [options]
+ * @param {string} [options.chainsDir] — override default dir
+ * @param {boolean} [options.bypassCache=false]
+ * @returns {object|null}
+ */
+function loadChain(chain_id, options = {}) {
+  if (!chain_id || typeof chain_id !== 'string') return null;
+  if (!options.bypassCache && _chainCache.has(chain_id)) {
+    return _chainCache.get(chain_id);
+  }
+  const chainsDir = options.chainsDir || CHAINS_DIR;
+  const targetPath = path.join(chainsDir, `${chain_id}.yaml`);
+  try {
+    const raw = fs.readFileSync(targetPath, 'utf-8');
+    const parsed = yaml.load(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    if (!Array.isArray(parsed.events)) return null;
+    if (!options.bypassCache) _chainCache.set(chain_id, parsed);
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Reset chain cache (test helper).
+ */
+function _resetCache() {
+  _chainCache.clear();
+}
+
+/**
+ * Validate chain shape (used during load testing).
+ *
+ * @param {object} chain
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+function validateChain(chain) {
+  const errors = [];
+  if (!chain || typeof chain !== 'object') {
+    return { valid: false, errors: ['chain_not_object'] };
+  }
+  if (!chain.chain_id || typeof chain.chain_id !== 'string') {
+    errors.push('chain_id_missing_or_not_string');
+  }
+  if (!Array.isArray(chain.events)) {
+    errors.push('events_not_array');
+    return { valid: false, errors };
+  }
+  const ids = new Set();
+  for (const event of chain.events) {
+    if (!event.id || typeof event.id !== 'string') {
+      errors.push(`event_missing_id`);
+      continue;
+    }
+    if (ids.has(event.id)) errors.push(`duplicate_event_id:${event.id}`);
+    ids.add(event.id);
+    if (event.condition && typeof event.condition === 'object') {
+      const op = event.condition.op || '>';
+      if (!CONDITION_OPS[op]) errors.push(`unsupported_op:${op}`);
+    }
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Evaluate a condition against session context.
+ *
+ * Condition shape: { vc_axis: 'T_F', threshold: 0.5, op: '>' }
+ * - Reads session.vcSnapshot.axes[vc_axis] (or session.vc_snapshot or null)
+ * - Returns true when condition matches; null condition → always true
+ *
+ * @param {object|null} condition
+ * @param {object} session
+ * @returns {boolean}
+ */
+function evalCondition(condition, session) {
+  if (!condition || typeof condition !== 'object') return true;
+  const { vc_axis, threshold, op } = condition;
+  const opFn = CONDITION_OPS[op || '>'];
+  if (!opFn) return false;
+  const axes = session?.vcSnapshot?.axes || session?.vc_snapshot?.axes || session?.axes || {};
+  const value = Number(axes[vc_axis]);
+  if (Number.isNaN(value)) return false;
+  return opFn(value, Number(threshold));
+}
+
+/**
+ * Trigger a chain at chain_id, optionally starting from a specific event.
+ * Returns the resolved event sequence walked + final event_id.
+ *
+ * Walk algorithm:
+ *  1. Start at start_event_id (or first event in chain).
+ *  2. Eval current event condition. If true → emit + walk to next_event_id.
+ *  3. If condition false → halt walk on that event (returned in `halted_at`).
+ *  4. Cap depth at 50 to prevent loops.
+ *
+ * @param {string} chain_id
+ * @param {object} session
+ * @param {object} [options]
+ * @param {string} [options.start_event_id]
+ * @param {object} [options.chainsDir]
+ * @returns {{ ok: boolean, chain_id, walked_events: object[], halted_at: string|null, reason: string|null }}
+ */
+function triggerEvent(chain_id, session, options = {}) {
+  const chain = loadChain(chain_id, { chainsDir: options.chainsDir });
+  if (!chain) {
+    return {
+      ok: false,
+      chain_id,
+      walked_events: [],
+      halted_at: null,
+      reason: 'chain_not_found',
+    };
+  }
+  const eventsById = new Map();
+  for (const e of chain.events) eventsById.set(e.id, e);
+  const startId = options.start_event_id || chain.events[0]?.id;
+  if (!startId || !eventsById.has(startId)) {
+    return {
+      ok: false,
+      chain_id,
+      walked_events: [],
+      halted_at: null,
+      reason: 'start_event_not_found',
+    };
+  }
+  const walked = [];
+  let currentId = startId;
+  let safety = 50;
+  while (currentId && eventsById.has(currentId) && safety > 0) {
+    const event = eventsById.get(currentId);
+    if (!evalCondition(event.condition, session)) {
+      return {
+        ok: true,
+        chain_id,
+        walked_events: walked,
+        halted_at: event.id,
+        reason: 'condition_false',
+      };
+    }
+    walked.push({
+      id: event.id,
+      text_it: event.text_it || '',
+      text_en: event.text_en || null,
+    });
+    currentId = event.next_event_id || null;
+    safety--;
+  }
+  return {
+    ok: true,
+    chain_id,
+    walked_events: walked,
+    halted_at: null,
+    reason: walked.length > 0 ? 'chain_complete' : 'empty_walk',
+  };
+}
+
+module.exports = {
+  loadChain,
+  validateChain,
+  evalCondition,
+  triggerEvent,
+  _resetCache,
+  CHAINS_DIR,
+  CONDITION_OPS,
+};

--- a/apps/backend/services/meta/geneEncoder.js
+++ b/apps/backend/services/meta/geneEncoder.js
@@ -1,0 +1,155 @@
+// Sprint δ Meta Systemic — Pattern 1 (CK3 DNA encoding).
+//
+// Encode/decode lineage genome as deterministic SHA1 hash chain.
+// Each generation links to parent_dna for cross-generation lineage chain.
+//
+// Pattern source: docs/research/2026-04-27-strategy-games-tech-extraction.md §6
+// (CK3 DNA encoding) — Crusader Kings III represents character genome as
+// deterministic gene string; offspring inherits chain link to parent DNA.
+//
+// Wire: metaProgression.rollMatingOffspring optional gene chain hook
+// (additive opt-in via context.useGeneEncoder=true).
+
+'use strict';
+
+const crypto = require('node:crypto');
+
+const VERSION = 1;
+const HASH_ALGO = 'sha1';
+const CHAIN_PREFIX = 'gn';
+
+/**
+ * Encode lineage + applied mutations into deterministic DNA chain.
+ *
+ * Shape of returned chain: `gn1:<parent_dna_hash_or_root>:<self_hash>`
+ * - parent_dna: previous-gen DNA chain (null/'root' = first generation)
+ * - self_hash: SHA1(lineage_id + sorted(applied_mutations).join(','))
+ *
+ * Deterministic: same inputs always → same hash.
+ *
+ * @param {object} params
+ * @param {string} params.lineage_id — required
+ * @param {string[]} [params.applied_mutations=[]] — set of mutation_ids
+ * @param {string|null} [params.parent_dna=null] — previous-gen DNA chain
+ * @returns {string} DNA chain string
+ */
+function encode({ lineage_id, applied_mutations = [], parent_dna = null } = {}) {
+  if (!lineage_id || typeof lineage_id !== 'string') {
+    throw new Error('encode: lineage_id required (string)');
+  }
+  const mutations = Array.isArray(applied_mutations) ? [...applied_mutations] : [];
+  // Sort for determinism (set semantics, ignore insertion order)
+  mutations.sort();
+  const payload = `${lineage_id}|${mutations.join(',')}`;
+  const selfHash = crypto.createHash(HASH_ALGO).update(payload).digest('hex').slice(0, 16);
+  const parentSegment = parent_dna || 'root';
+  const parentHash = parentSegment === 'root' ? 'root' : _extractSelfHash(parentSegment);
+  return `${CHAIN_PREFIX}${VERSION}:${parentHash}:${selfHash}`;
+}
+
+/**
+ * Decode DNA chain into structured metadata.
+ *
+ * @param {string} dna_chain
+ * @returns {{ version: number, parent_hash: string, self_hash: string, is_root: boolean } | null}
+ */
+function decode(dna_chain) {
+  if (typeof dna_chain !== 'string') return null;
+  const match = dna_chain.match(/^gn(\d+):([a-f0-9]+|root):([a-f0-9]{16})$/);
+  if (!match) return null;
+  const [, version, parentHash, selfHash] = match;
+  return {
+    version: Number(version),
+    parent_hash: parentHash,
+    self_hash: selfHash,
+    is_root: parentHash === 'root',
+  };
+}
+
+/**
+ * Compute mutation diff between two DNA chains (their unit mutation sets).
+ *
+ * Note: requires the original applied_mutations arrays — DNA chain alone
+ * is one-way hashed and cannot be inverted. This helper compares mutation
+ * sets symbolically (caller must pass arrays).
+ *
+ * @param {string[]} mutations_a
+ * @param {string[]} mutations_b
+ * @returns {{ added: string[], removed: string[], unchanged: string[] }}
+ */
+function diffMutations(mutations_a = [], mutations_b = []) {
+  const a = new Set(Array.isArray(mutations_a) ? mutations_a : []);
+  const b = new Set(Array.isArray(mutations_b) ? mutations_b : []);
+  const added = [];
+  const removed = [];
+  const unchanged = [];
+  for (const m of b) {
+    if (a.has(m)) unchanged.push(m);
+    else added.push(m);
+  }
+  for (const m of a) {
+    if (!b.has(m)) removed.push(m);
+  }
+  added.sort();
+  removed.sort();
+  unchanged.sort();
+  return { added, removed, unchanged };
+}
+
+/**
+ * Verify that childDna chain links to parentDna chain.
+ *
+ * @param {string} parentDna
+ * @param {string} childDna
+ * @returns {boolean}
+ */
+function isChildOf(parentDna, childDna) {
+  const parent = decode(parentDna);
+  const child = decode(childDna);
+  if (!parent || !child) return false;
+  return child.parent_hash === parent.self_hash;
+}
+
+/**
+ * Extract self_hash from a DNA chain (internal helper).
+ */
+function _extractSelfHash(dna_chain) {
+  const decoded = decode(dna_chain);
+  if (!decoded) return 'root';
+  return decoded.self_hash;
+}
+
+/**
+ * Compute lineage generation depth by walking chain history.
+ * Caller must provide `chainResolver(parent_hash)` → previous DNA chain.
+ * Useful when persistence layer stores chain history.
+ *
+ * @param {string} dna_chain
+ * @param {function(string): string|null} chainResolver
+ * @param {number} [maxDepth=100]
+ * @returns {number} generation (0 = root, +1 per parent link)
+ */
+function computeGeneration(dna_chain, chainResolver, maxDepth = 100) {
+  let current = decode(dna_chain);
+  if (!current) return 0;
+  let depth = 0;
+  let safety = maxDepth;
+  while (current && !current.is_root && safety > 0) {
+    const previous = chainResolver(current.parent_hash);
+    if (!previous) break;
+    current = decode(previous);
+    depth++;
+    safety--;
+  }
+  return depth;
+}
+
+module.exports = {
+  encode,
+  decode,
+  diffMutations,
+  isChildOf,
+  computeGeneration,
+  VERSION,
+  CHAIN_PREFIX,
+};

--- a/apps/backend/services/meta/mutationTreeSwap.js
+++ b/apps/backend/services/meta/mutationTreeSwap.js
@@ -1,0 +1,135 @@
+// Sprint δ Meta Systemic — Pattern 3 (MYZ mutation tree swap).
+//
+// Free re-pick alternative path on mutation tree (Mutant Year Zero pattern).
+// Allows player to swap one applied mutation for another without MP penalty
+// extra (only standard apply cost).
+//
+// Pattern source: docs/research/2026-04-27-strategy-games-mechanics-extraction.md §5
+// (MYZ mutation tree). MYZ allows opt-in re-spec on mutations: one slot can
+// be swapped per encounter cycle, costing standard mutation activation cost
+// (no extra penalty for switching).
+//
+// Validation:
+//  - newMutation must NOT cause slot conflict with remaining mutations
+//  - newMutation must fit MP budget (standard mp_cost rule)
+//  - oldMutation must be reversible (catalog flag `irreversible: false` default)
+//
+// Wire: routes/mutations.js POST /api/v1/mutations/swap (separate from /apply).
+
+'use strict';
+
+const {
+  checkSlotConflict,
+  checkMpBudget,
+  applyMutationPure,
+} = require('../mutations/mutationEngine');
+
+/**
+ * Swap an applied mutation for a new mutation on a unit.
+ *
+ * @param {object} unit
+ * @param {string} oldMutationId — currently applied
+ * @param {string} newMutationId — to apply
+ * @param {object} catalog — output of loadMutationCatalog()
+ * @param {object} [options]
+ * @param {boolean} [options.deductMp=true] — deduct MP for new mutation
+ * @returns {{
+ *   ok: boolean,
+ *   reason?: string,
+ *   unit?: object,
+ *   swap_event?: object
+ * }}
+ */
+function swapAppliedMutation(unit, oldMutationId, newMutationId, catalog, options = {}) {
+  if (!unit || typeof unit !== 'object') {
+    return { ok: false, reason: 'unit_required' };
+  }
+  if (!oldMutationId || !newMutationId) {
+    return { ok: false, reason: 'mutation_ids_required' };
+  }
+  if (oldMutationId === newMutationId) {
+    return { ok: false, reason: 'noop_same_id' };
+  }
+  const byId = catalog?.byId || {};
+  const oldEntry = byId[oldMutationId];
+  const newEntry = byId[newMutationId];
+  if (!oldEntry) return { ok: false, reason: 'old_mutation_not_found' };
+  if (!newEntry) return { ok: false, reason: 'new_mutation_not_found' };
+
+  const applied = Array.isArray(unit.applied_mutations) ? unit.applied_mutations : [];
+  if (!applied.includes(oldMutationId)) {
+    return { ok: false, reason: 'old_mutation_not_applied' };
+  }
+
+  // Reversibility check: catalog entry can flag `irreversible: true` to lock
+  if (oldEntry.irreversible === true) {
+    return { ok: false, reason: 'old_mutation_irreversible' };
+  }
+
+  // Step 1: detach oldMutation (reverse trait_swap, remove from applied list)
+  const oldSwap = oldEntry.trait_swap || { add: [], remove: [] };
+  const restoredTraits = Array.isArray(unit.trait_ids) ? [...unit.trait_ids] : [];
+  // Remove what oldMutation added
+  const detachedTraits = restoredTraits.filter((t) => !(oldSwap.add || []).includes(t));
+  // Restore what oldMutation removed (best-effort: re-add removed traits)
+  for (const t of oldSwap.remove || []) {
+    if (!detachedTraits.includes(t)) detachedTraits.push(t);
+  }
+  // Refund MP if oldMutation had a cost
+  const oldMpCost = Number(oldEntry.mp_cost ?? 0);
+  const intermediateUnit = {
+    ...unit,
+    trait_ids: detachedTraits,
+    applied_mutations: applied.filter((id) => id !== oldMutationId),
+    mp: Number(unit.mp ?? 0) + oldMpCost,
+  };
+  // Drop derived ability if any
+  if (oldEntry.derived_ability_id) {
+    intermediateUnit.abilities = (
+      Array.isArray(intermediateUnit.abilities) ? intermediateUnit.abilities : []
+    ).filter((a) => a !== oldEntry.derived_ability_id);
+  }
+
+  // Step 2: validate newMutation eligibility against intermediate unit state
+  const slotCheck = checkSlotConflict(intermediateUnit, newMutationId, catalog);
+  if (slotCheck.conflict) {
+    return {
+      ok: false,
+      reason: 'slot_conflict',
+      conflicting_mutation_id: slotCheck.conflicting_mutation_id,
+      slot: slotCheck.slot,
+    };
+  }
+  const mpCheck = checkMpBudget(intermediateUnit, newEntry);
+  if (!mpCheck.ok) {
+    return {
+      ok: false,
+      reason: 'mp_insufficient',
+      required: mpCheck.required,
+      available: mpCheck.available,
+    };
+  }
+
+  // Step 3: apply new mutation (standard apply rules)
+  const applyResult = applyMutationPure(intermediateUnit, newMutationId, catalog, {
+    deductMp: options.deductMp !== false,
+  });
+
+  return {
+    ok: true,
+    unit: applyResult.unit,
+    swap_event: {
+      type: 'mutation_swapped',
+      old_mutation_id: oldMutationId,
+      new_mutation_id: newMutationId,
+      mp_refunded: oldMpCost,
+      mp_spent: applyResult.mp_spent,
+      derived_ability_id: applyResult.derived_ability_id,
+      timestamp: new Date().toISOString(),
+    },
+  };
+}
+
+module.exports = {
+  swapAppliedMutation,
+};

--- a/apps/backend/services/metaProgression.js
+++ b/apps/backend/services/metaProgression.js
@@ -519,6 +519,29 @@ function rollMatingOffspring({ parentA, parentB, biomeId, context = {} } = {}) {
     biome_id_at_mating: biomeId || null,
   };
 
+  // Sprint δ Meta Systemic — CK3 DNA chain encoding (opt-in).
+  // When context.useGeneEncoder=true, derive offspring DNA chain linking
+  // parent DNA (preserves cross-generation lineage). Additive only.
+  if (context.useGeneEncoder === true) {
+    try {
+      const { encode } = require('./meta/geneEncoder');
+      const offspringMutationSet = [
+        ...(offspring.environmental_mutation?.id ? [offspring.environmental_mutation.id] : []),
+        ...bonus,
+      ];
+      // Prefer parentA.dna_chain if available, else parentB
+      const parentDna = parentA.dna_chain || parentB.dna_chain || null;
+      offspring.dna_chain = encode({
+        lineage_id: lineageId,
+        applied_mutations: offspringMutationSet,
+        parent_dna: parentDna,
+      });
+    } catch (_err) {
+      // Defensive: encoder optional, never block mating roll
+      offspring.dna_chain = null;
+    }
+  }
+
   return {
     success: true,
     offspring,

--- a/apps/backend/services/mutations/mutationEngine.js
+++ b/apps/backend/services/mutations/mutationEngine.js
@@ -247,12 +247,24 @@ function applyMutationBingoToUnit(unit, catalog) {
   return { archetypes: bingo.archetypes, passive_tokens };
 }
 
+// Sprint δ Meta Systemic — re-export swap helper from meta/ (MYZ pattern).
+// Convenience: callers requiring mutationEngine can also access swap without
+// double require.
+let _swapAppliedMutation = null;
+function swapAppliedMutation(...args) {
+  if (!_swapAppliedMutation) {
+    _swapAppliedMutation = require('../meta/mutationTreeSwap').swapAppliedMutation;
+  }
+  return _swapAppliedMutation(...args);
+}
+
 module.exports = {
   checkSlotConflict,
   checkMpBudget,
   applyMutationPure,
   computeMutationBingo,
   applyMutationBingoToUnit,
+  swapAppliedMutation,
   BINGO_ARCHETYPES,
   BINGO_THRESHOLD,
 };

--- a/data/core/narrative/event_chains/caverna_mystery_chain.yaml
+++ b/data/core/narrative/event_chains/caverna_mystery_chain.yaml
@@ -1,0 +1,24 @@
+# Sprint δ Meta Systemic — seed event chain (Stellaris pattern).
+# Placeholder text. D4 writer commission deferred.
+chain_id: caverna_mystery_chain
+description_it: |
+  Catena mistero in caverna. Branching condizionato su asse J_P (planning vs improvising).
+events:
+  - id: enter
+    text_it: "L'oscurità della caverna inghiotte la luce esterna. Echi remoti suggeriscono profondità."
+    text_en: "The cave's darkness swallows external light. Distant echoes suggest depth."
+    condition: null
+    next_event_id: pause_or_rush
+  - id: pause_or_rush
+    text_it: "Ti fermi a calibrare. Una mappa mentale prende forma."
+    text_en: "You pause to calibrate. A mental map takes shape."
+    condition:
+      vc_axis: J_P
+      threshold: 0.0
+      op: '>'
+    next_event_id: discovery
+  - id: discovery
+    text_it: "Una camera nascosta si apre. Sul pavimento, segni antichi."
+    text_en: "A hidden chamber opens. Ancient signs on the floor."
+    condition: null
+    next_event_id: null

--- a/data/core/narrative/event_chains/deserto_drift_chain.yaml
+++ b/data/core/narrative/event_chains/deserto_drift_chain.yaml
@@ -1,0 +1,24 @@
+# Sprint δ Meta Systemic — seed event chain (Stellaris pattern).
+# Placeholder text. D4 writer commission deferred.
+chain_id: deserto_drift_chain
+description_it: |
+  Catena deserto/drift. Branching su asse S_N (sensing vs intuition).
+events:
+  - id: arrival
+    text_it: "Il deserto si estende oltre l'orizzonte. Sabbia rossa al tramonto."
+    text_en: "The desert extends past the horizon. Red sand at dusk."
+    condition: null
+    next_event_id: sense_or_dream
+  - id: sense_or_dream
+    text_it: "Concentri i sensi. Un dettaglio nella sabbia: tracce fresche."
+    text_en: "You focus your senses. A detail in the sand: fresh tracks."
+    condition:
+      vc_axis: S_N
+      threshold: -0.2
+      op: '<'
+    next_event_id: follow
+  - id: follow
+    text_it: "Segui le tracce. Conducono a un'oasi nascosta."
+    text_en: "You follow the tracks. They lead to a hidden oasis."
+    condition: null
+    next_event_id: null

--- a/data/core/narrative/event_chains/savana_intro_chain.yaml
+++ b/data/core/narrative/event_chains/savana_intro_chain.yaml
@@ -1,0 +1,29 @@
+# Sprint δ Meta Systemic — seed event chain (Stellaris pattern).
+# Placeholder text. D4 writer commission deferred (Phase 3 iter).
+chain_id: savana_intro_chain
+description_it: |
+  Catena introduttiva al biome savana. Branching condizionato su asse T_F.
+events:
+  - id: arrive
+    text_it: "Il caldo della savana ti accoglie. L'erba alta nasconde forme che si muovono al vento."
+    text_en: "The savanna's warmth greets you. Tall grass hides shapes moving with the wind."
+    condition: null
+    next_event_id: scout
+  - id: scout
+    text_it: "Distinguete tracce di altre creature. Sono vicine. Si percepisce un odore acre."
+    text_en: "You distinguish tracks of other creatures. They are nearby. An acrid scent lingers."
+    condition: null
+    next_event_id: feeling_check
+  - id: feeling_check
+    text_it: "Cosa senti? Un istinto ti spinge a osservare prima di agire."
+    text_en: "What do you feel? An instinct urges you to observe before acting."
+    condition:
+      vc_axis: T_F
+      threshold: 0.5
+      op: '>'
+    next_event_id: confront_emotional
+  - id: confront_emotional
+    text_it: "Decidi di avvicinarti pacificamente. La compassione precede la lama."
+    text_en: "You decide to approach peacefully. Compassion precedes the blade."
+    condition: null
+    next_event_id: null

--- a/services/narrative/narrativeEngine.js
+++ b/services/narrative/narrativeEngine.js
@@ -284,6 +284,13 @@ function _resetMbtiPaletteCache() {
   _mbtiPaletteCache = null;
 }
 
+// Sprint δ Meta Systemic — Stellaris event chain scripting bridge.
+// Lazy require to avoid coupling narrative engine startup with chain loader.
+function triggerEventChain(chain_id, session, options = {}) {
+  const { triggerEvent } = require('../../apps/backend/services/meta/eventChainScripting');
+  return triggerEvent(chain_id, session, options);
+}
+
 module.exports = {
   NARRATIVES_DIR,
   DRIFT_BRIEFINGS_DIR,
@@ -299,6 +306,7 @@ module.exports = {
   extractMbtiAxisFromTags,
   classifyDriftVariant,
   selectDriftBriefing,
+  triggerEventChain,
   _resetMbtiPaletteCache,
   _resetDriftPackCache,
 };

--- a/tests/api/sprint-delta/convictionRoutes.test.js
+++ b/tests/api/sprint-delta/convictionRoutes.test.js
@@ -1,0 +1,134 @@
+// Sprint δ Meta Systemic — Pattern 4 routes integration tests.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const http = require('node:http');
+
+const { createConvictionRouter } = require('../../../apps/backend/routes/conviction');
+const { _resetBallots } = require('../../../apps/backend/services/meta/convictionVoting');
+
+function startTestServer(t) {
+  _resetBallots();
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createConvictionRouter());
+  const server = app.listen(0);
+  const port = server.address().port;
+  t.after(() => server.close());
+  return { url: `http://127.0.0.1:${port}` };
+}
+
+function request(method, url, body = null) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const opts = {
+      hostname: parsed.hostname,
+      port: parsed.port,
+      path: parsed.pathname + parsed.search,
+      method,
+      headers: { 'content-type': 'application/json' },
+    };
+    const req = http.request(opts, (res) => {
+      let data = '';
+      res.on('data', (c) => (data += c));
+      res.on('end', () => {
+        let parsedBody = null;
+        try {
+          parsedBody = data ? JSON.parse(data) : null;
+        } catch {
+          parsedBody = data;
+        }
+        resolve({ status: res.statusCode, body: parsedBody });
+      });
+    });
+    req.on('error', reject);
+    if (body) req.write(JSON.stringify(body));
+    req.end();
+  });
+}
+
+test('POST /api/v1/conviction/init creates ballot', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('POST', `${url}/api/v1/conviction/init`, {
+    session_id: 's1',
+    choices: [
+      { choice_id: 'attack', vc_axis: 'T_F', vc_target: -0.8 },
+      { choice_id: 'parley', vc_axis: 'T_F', vc_target: 0.8, is_status_quo: true },
+    ],
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.session_id, 's1');
+  assert.equal(res.body.ballot_size, 2);
+});
+
+test('POST /api/v1/conviction/init rejects when fewer than 2 choices', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('POST', `${url}/api/v1/conviction/init`, {
+    session_id: 's2',
+    choices: [{ choice_id: 'lonely' }],
+  });
+  assert.equal(res.status, 400);
+  assert.equal(res.body.error, 'choices_min_two_required');
+});
+
+test('POST /api/v1/conviction/vote casts and tallies', async (t) => {
+  const { url } = startTestServer(t);
+  await request('POST', `${url}/api/v1/conviction/init`, {
+    session_id: 's3',
+    choices: [
+      { choice_id: 'a', vc_axis: 'T_F', vc_target: -0.5 },
+      { choice_id: 'b', vc_axis: 'T_F', vc_target: 0.5 },
+    ],
+  });
+  const vote = await request('POST', `${url}/api/v1/conviction/vote`, {
+    session_id: 's3',
+    player_id: 'p1',
+    choice_id: 'a',
+    vc_snapshot: { axes: { T_F: -0.5 } },
+  });
+  assert.equal(vote.status, 200);
+  assert.equal(vote.body.vote.choice_id, 'a');
+  const results = await request('GET', `${url}/api/v1/conviction/results?session_id=s3`);
+  assert.equal(results.status, 200);
+  assert.equal(results.body.winner_choice_id, 'a');
+});
+
+test('GET /api/v1/conviction/results — ballot not found returns 404', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('GET', `${url}/api/v1/conviction/results?session_id=missing`);
+  assert.equal(res.status, 404);
+});
+
+test('POST /api/v1/conviction/vote — ballot not found returns 404', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('POST', `${url}/api/v1/conviction/vote`, {
+    session_id: 'no_init',
+    player_id: 'p1',
+    choice_id: 'x',
+    vc_snapshot: {},
+  });
+  assert.equal(res.status, 404);
+});
+
+test('POST /api/v1/conviction/close finalizes ballot', async (t) => {
+  const { url } = startTestServer(t);
+  await request('POST', `${url}/api/v1/conviction/init`, {
+    session_id: 's_close',
+    choices: [{ choice_id: 'a' }, { choice_id: 'b', is_status_quo: true }],
+  });
+  await request('POST', `${url}/api/v1/conviction/vote`, {
+    session_id: 's_close',
+    player_id: 'p1',
+    choice_id: 'a',
+    vc_snapshot: {},
+  });
+  const close = await request('POST', `${url}/api/v1/conviction/close`, {
+    session_id: 's_close',
+  });
+  assert.equal(close.status, 200);
+  assert.equal(close.body.winner_choice_id, 'a');
+  const after = await request('GET', `${url}/api/v1/conviction/results?session_id=s_close`);
+  assert.equal(after.status, 404);
+});

--- a/tests/api/sprint-delta/eventChainIntegration.test.js
+++ b/tests/api/sprint-delta/eventChainIntegration.test.js
@@ -1,0 +1,27 @@
+// Sprint δ Meta Systemic — Pattern 2 integration smoke test.
+//
+// Verifies eventChainScripting integrates via narrativeEngine bridge.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { triggerEventChain } = require('../../../services/narrative/narrativeEngine');
+const { _resetCache } = require('../../../apps/backend/services/meta/eventChainScripting');
+
+test('triggerEventChain via narrative bridge: completes savana chain', () => {
+  _resetCache();
+  const session = { vcSnapshot: { axes: { T_F: 0.7 } } };
+  const result = triggerEventChain('savana_intro_chain', session);
+  assert.equal(result.ok, true);
+  assert.ok(result.walked_events.length > 0);
+  assert.equal(result.walked_events[0].id, 'arrive');
+});
+
+test('triggerEventChain via narrative bridge: chain not found graceful', () => {
+  _resetCache();
+  const result = triggerEventChain('not_a_real_chain', {});
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'chain_not_found');
+});

--- a/tests/services/sprint-delta/convictionVoting.test.js
+++ b/tests/services/sprint-delta/convictionVoting.test.js
@@ -1,0 +1,102 @@
+// Sprint δ Meta Systemic — Pattern 4 tests (Triangle Strategy conviction voting).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  initBallot,
+  castVote,
+  tally,
+  tallyConviction,
+  closeBallot,
+  computeVoteWeight,
+  _resetBallots,
+} = require('../../../apps/backend/services/meta/convictionVoting');
+
+function setupBallot(session_id) {
+  return initBallot(session_id, [
+    { choice_id: 'attack', vc_axis: 'T_F', vc_target: -0.8 },
+    { choice_id: 'parley', vc_axis: 'T_F', vc_target: 0.8, is_status_quo: true },
+  ]);
+}
+
+test('castVote: single voter — outcome reflects choice', () => {
+  _resetBallots();
+  const init = setupBallot('s_single');
+  assert.equal(init.ok, true);
+  const r = castVote('s_single', 'p1', 'attack', { axes: { T_F: -0.6 } });
+  assert.equal(r.ok, true);
+  const t = tally('s_single');
+  assert.equal(t.winner_choice_id, 'attack');
+});
+
+test('castVote: weighted outcome — closer alignment wins', () => {
+  _resetBallots();
+  setupBallot('s_weighted');
+  // Player1: T_F=-0.8 (perfect attack alignment, weight near 2.0)
+  castVote('s_weighted', 'p1', 'attack', { axes: { T_F: -0.8 } });
+  // Player2: T_F=0.5 (weak parley alignment)
+  // Player3: T_F=0.4 (weak parley alignment)
+  castVote('s_weighted', 'p2', 'parley', { axes: { T_F: 0.5 } });
+  castVote('s_weighted', 'p3', 'parley', { axes: { T_F: 0.4 } });
+  const t = tally('s_weighted');
+  // p1 attack weight = 2.0 (perfect), parley weight p2 = 1+(1-0.15)=1.85, p3 = 1+(1-0.20)=1.80
+  // Total: attack=2.0, parley=3.65 → parley wins
+  assert.equal(t.winner_choice_id, 'parley');
+});
+
+test('castVote: tie-break prefers status_quo choice', () => {
+  _resetBallots();
+  setupBallot('s_tie');
+  // Both votes weight 1.0 (no axis match) on different choices
+  castVote('s_tie', 'p1', 'attack', { axes: {} });
+  castVote('s_tie', 'p2', 'parley', { axes: {} });
+  const t = tally('s_tie');
+  assert.equal(t.tie, true);
+  // parley flagged is_status_quo → wins tie
+  assert.equal(t.winner_choice_id, 'parley');
+});
+
+test('computeVoteWeight: missing axis fallback = 1.0', () => {
+  const w = computeVoteWeight({ vc_axis: 'T_F', vc_target: 0.5 }, { axes: {} });
+  assert.equal(w, 1.0);
+});
+
+test('castVote: vote update — same player can change vote', () => {
+  _resetBallots();
+  setupBallot('s_update');
+  castVote('s_update', 'p1', 'attack', { axes: { T_F: -0.8 } });
+  let t = tally('s_update');
+  assert.equal(t.winner_choice_id, 'attack');
+  castVote('s_update', 'p1', 'parley', { axes: { T_F: 0.8 } });
+  t = tally('s_update');
+  assert.equal(t.winner_choice_id, 'parley');
+  assert.equal(t.tally.find((x) => x.choice_id === 'attack').voter_count, 0);
+});
+
+test('tallyConviction: stateless helper produces consistent outcome', () => {
+  const result = tallyConviction(
+    [
+      { choice_id: 'a', weight: 1.5 },
+      { choice_id: 'a', weight: 1.0 },
+      { choice_id: 'b', weight: 2.0 },
+    ],
+    [{ choice_id: 'a' }, { choice_id: 'b', is_status_quo: true }],
+  );
+  assert.equal(result.winner_choice_id, 'a');
+  assert.equal(result.tie, false);
+});
+
+test('closeBallot: returns final result and removes ballot', () => {
+  _resetBallots();
+  setupBallot('s_close');
+  castVote('s_close', 'p1', 'attack', { axes: { T_F: -0.8 } });
+  const close = closeBallot('s_close');
+  assert.equal(close.ok, true);
+  assert.equal(close.result.winner_choice_id, 'attack');
+  // Subsequent tally should fail
+  const post = tally('s_close');
+  assert.equal(post.ok, false);
+});

--- a/tests/services/sprint-delta/eventChainScripting.test.js
+++ b/tests/services/sprint-delta/eventChainScripting.test.js
@@ -1,0 +1,92 @@
+// Sprint δ Meta Systemic — Pattern 2 tests (Stellaris event chain).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const {
+  loadChain,
+  validateChain,
+  evalCondition,
+  triggerEvent,
+  _resetCache,
+} = require('../../../apps/backend/services/meta/eventChainScripting');
+
+const SEED_DIR = path.resolve(__dirname, '../../../data/core/narrative/event_chains');
+
+test('loadChain: loads valid YAML chain from seed dir', () => {
+  _resetCache();
+  const chain = loadChain('savana_intro_chain', { chainsDir: SEED_DIR });
+  assert.ok(chain);
+  assert.equal(chain.chain_id, 'savana_intro_chain');
+  assert.ok(Array.isArray(chain.events));
+  assert.ok(chain.events.length >= 3);
+});
+
+test('triggerEvent: condition true → walks chain to completion', () => {
+  _resetCache();
+  const session = { vcSnapshot: { axes: { T_F: 0.8 } } };
+  const result = triggerEvent('savana_intro_chain', session, { chainsDir: SEED_DIR });
+  assert.equal(result.ok, true);
+  assert.equal(result.halted_at, null);
+  assert.equal(result.reason, 'chain_complete');
+  // arrive → scout → feeling_check (T_F>0.5 true) → confront_emotional
+  assert.equal(result.walked_events.length, 4);
+});
+
+test('triggerEvent: condition false → halts at gating event', () => {
+  _resetCache();
+  const session = { vcSnapshot: { axes: { T_F: 0.2 } } };
+  const result = triggerEvent('savana_intro_chain', session, { chainsDir: SEED_DIR });
+  assert.equal(result.ok, true);
+  assert.equal(result.halted_at, 'feeling_check');
+  assert.equal(result.reason, 'condition_false');
+  // arrive + scout walked, feeling_check halted (not appended)
+  assert.equal(result.walked_events.length, 2);
+});
+
+test('triggerEvent: missing chain_id → returns chain_not_found', () => {
+  _resetCache();
+  const result = triggerEvent('nonexistent_chain', {}, { chainsDir: SEED_DIR });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'chain_not_found');
+});
+
+test('validateChain: detects duplicate ids and unsupported ops', () => {
+  const bad = {
+    chain_id: 'bad',
+    events: [
+      { id: 'a', text_it: 'A' },
+      { id: 'a', text_it: 'A2' },
+      { id: 'b', text_it: 'B', condition: { vc_axis: 'T_F', threshold: 0, op: '~~' } },
+    ],
+  };
+  const result = validateChain(bad);
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((e) => e.startsWith('duplicate_event_id')));
+  assert.ok(result.errors.some((e) => e.startsWith('unsupported_op')));
+});
+
+test('evalCondition: missing axis returns false (defensive)', () => {
+  const result = evalCondition({ vc_axis: 'T_F', threshold: 0.5, op: '>' }, {});
+  assert.equal(result, false);
+});
+
+test('evalCondition: null condition returns true (always-pass)', () => {
+  assert.equal(evalCondition(null, {}), true);
+  assert.equal(evalCondition(undefined, {}), true);
+});
+
+test('triggerEvent: multi-chain isolation — different chains do not interfere', () => {
+  _resetCache();
+  const session = { vcSnapshot: { axes: { T_F: 0.8, J_P: 0.3 } } };
+  const r1 = triggerEvent('savana_intro_chain', session, { chainsDir: SEED_DIR });
+  const r2 = triggerEvent('caverna_mystery_chain', session, { chainsDir: SEED_DIR });
+  assert.equal(r1.ok, true);
+  assert.equal(r2.ok, true);
+  assert.equal(r1.chain_id, 'savana_intro_chain');
+  assert.equal(r2.chain_id, 'caverna_mystery_chain');
+  assert.notDeepEqual(r1.walked_events, r2.walked_events);
+});

--- a/tests/services/sprint-delta/geneEncoder.test.js
+++ b/tests/services/sprint-delta/geneEncoder.test.js
@@ -1,0 +1,91 @@
+// Sprint δ Meta Systemic — Pattern 1 tests (CK3 DNA encoding).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  encode,
+  decode,
+  diffMutations,
+  isChildOf,
+  computeGeneration,
+  CHAIN_PREFIX,
+  VERSION,
+} = require('../../../apps/backend/services/meta/geneEncoder');
+
+test('encode: deterministic — same inputs → same hash', () => {
+  const a = encode({
+    lineage_id: 'lin_alpha',
+    applied_mutations: ['mut_a', 'mut_b', 'mut_c'],
+    parent_dna: null,
+  });
+  const b = encode({
+    lineage_id: 'lin_alpha',
+    applied_mutations: ['mut_c', 'mut_a', 'mut_b'],
+    parent_dna: null,
+  });
+  assert.equal(a, b, 'sorted mutation set should produce same hash');
+  assert.match(a, new RegExp(`^${CHAIN_PREFIX}${VERSION}:root:[a-f0-9]{16}$`));
+});
+
+test('decode: round-trip extracts components', () => {
+  const dna = encode({
+    lineage_id: 'lin_beta',
+    applied_mutations: ['mut_x'],
+    parent_dna: null,
+  });
+  const decoded = decode(dna);
+  assert.ok(decoded);
+  assert.equal(decoded.version, VERSION);
+  assert.equal(decoded.is_root, true);
+  assert.equal(decoded.parent_hash, 'root');
+  assert.match(decoded.self_hash, /^[a-f0-9]{16}$/);
+});
+
+test('encode: parent-child chain links correctly', () => {
+  const parent = encode({
+    lineage_id: 'lin_p',
+    applied_mutations: ['mut_p1'],
+    parent_dna: null,
+  });
+  const child = encode({
+    lineage_id: 'lin_c',
+    applied_mutations: ['mut_c1'],
+    parent_dna: parent,
+  });
+  assert.notEqual(parent, child);
+  assert.ok(isChildOf(parent, child), 'child should link to parent');
+  assert.equal(isChildOf(child, parent), false, 'parent should not link to child');
+});
+
+test('diffMutations: added/removed/unchanged correctly classified', () => {
+  const result = diffMutations(['a', 'b', 'c'], ['b', 'c', 'd']);
+  assert.deepEqual(result.added, ['d']);
+  assert.deepEqual(result.removed, ['a']);
+  assert.deepEqual(result.unchanged, ['b', 'c']);
+});
+
+test('decode: defensive — malformed input returns null', () => {
+  assert.equal(decode(null), null);
+  assert.equal(decode(undefined), null);
+  assert.equal(decode(''), null);
+  assert.equal(decode('not_a_dna_chain'), null);
+  assert.equal(decode('gn1:root'), null); // missing self_hash
+  assert.equal(decode(42), null);
+});
+
+test('computeGeneration: walks parent chain via resolver', () => {
+  const gen0 = encode({ lineage_id: 'g0', applied_mutations: [], parent_dna: null });
+  const gen1 = encode({ lineage_id: 'g1', applied_mutations: [], parent_dna: gen0 });
+  const gen2 = encode({ lineage_id: 'g2', applied_mutations: [], parent_dna: gen1 });
+  const chainStore = new Map();
+  chainStore.set(decode(gen0).self_hash, gen0);
+  chainStore.set(decode(gen1).self_hash, gen1);
+  chainStore.set(decode(gen2).self_hash, gen2);
+  const resolver = (parent_hash) => chainStore.get(parent_hash) || null;
+  assert.equal(computeGeneration(gen0, resolver), 0);
+  assert.equal(computeGeneration(gen1, resolver), 1);
+  assert.equal(computeGeneration(gen2, resolver), 2);
+});

--- a/tests/services/sprint-delta/mutationTreeSwap.test.js
+++ b/tests/services/sprint-delta/mutationTreeSwap.test.js
@@ -1,0 +1,112 @@
+// Sprint δ Meta Systemic — Pattern 3 tests (MYZ mutation tree swap).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { swapAppliedMutation } = require('../../../apps/backend/services/meta/mutationTreeSwap');
+
+function buildCatalog() {
+  return {
+    byId: {
+      mut_claws: {
+        body_slot: 'appendage',
+        category: 'physiological',
+        mp_cost: 2,
+        trait_swap: { add: ['trait_claws'], remove: [] },
+        derived_ability_id: 'ability_claw_strike',
+        irreversible: false,
+      },
+      mut_blades: {
+        body_slot: 'appendage',
+        category: 'physiological',
+        mp_cost: 3,
+        trait_swap: { add: ['trait_blades'], remove: [] },
+        derived_ability_id: null,
+        irreversible: false,
+      },
+      mut_tongue: {
+        body_slot: 'mouth',
+        category: 'physiological',
+        mp_cost: 1,
+        trait_swap: { add: ['trait_tongue'], remove: [] },
+        irreversible: false,
+      },
+      mut_locked: {
+        body_slot: 'back',
+        category: 'physiological',
+        mp_cost: 5,
+        trait_swap: { add: ['trait_wings'], remove: [] },
+        irreversible: true,
+      },
+    },
+  };
+}
+
+test('swapAppliedMutation: basic swap succeeds', () => {
+  const unit = {
+    id: 'u1',
+    mp: 5,
+    trait_ids: ['trait_claws'],
+    applied_mutations: ['mut_claws'],
+    abilities: ['ability_claw_strike'],
+  };
+  const result = swapAppliedMutation(unit, 'mut_claws', 'mut_blades', buildCatalog());
+  assert.equal(result.ok, true);
+  assert.ok(result.unit.applied_mutations.includes('mut_blades'));
+  assert.equal(result.unit.applied_mutations.includes('mut_claws'), false);
+  assert.ok(result.unit.trait_ids.includes('trait_blades'));
+  assert.equal(result.unit.trait_ids.includes('trait_claws'), false);
+  assert.equal(result.swap_event.type, 'mutation_swapped');
+  // refunded 2 (claws), spent 3 (blades) → mp 5+2-3=4
+  assert.equal(result.unit.mp, 4);
+});
+
+test('swapAppliedMutation: slot conflict — swap targeting occupied alt slot fails', () => {
+  // Apply both claws (appendage) AND tongue (mouth), then try swapping tongue → blades (also appendage)
+  // claws still occupies appendage → conflict
+  const unit = {
+    mp: 5,
+    trait_ids: ['trait_claws', 'trait_tongue'],
+    applied_mutations: ['mut_claws', 'mut_tongue'],
+  };
+  const result = swapAppliedMutation(unit, 'mut_tongue', 'mut_blades', buildCatalog());
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'slot_conflict');
+  assert.equal(result.conflicting_mutation_id, 'mut_claws');
+});
+
+test('swapAppliedMutation: mp insufficient fails', () => {
+  // claws costs 2, blades costs 3 → after refund mp=0+2=2 < 3
+  const unit = {
+    mp: 0,
+    trait_ids: ['trait_claws'],
+    applied_mutations: ['mut_claws'],
+  };
+  const result = swapAppliedMutation(unit, 'mut_claws', 'mut_blades', buildCatalog());
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'mp_insufficient');
+});
+
+test('swapAppliedMutation: irreversible old mutation rejected', () => {
+  const unit = {
+    mp: 10,
+    trait_ids: ['trait_wings'],
+    applied_mutations: ['mut_locked'],
+  };
+  const result = swapAppliedMutation(unit, 'mut_locked', 'mut_blades', buildCatalog());
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'old_mutation_irreversible');
+});
+
+test('swapAppliedMutation: idempotent — same id rejected', () => {
+  const unit = {
+    mp: 5,
+    trait_ids: ['trait_claws'],
+    applied_mutations: ['mut_claws'],
+  };
+  const result = swapAppliedMutation(unit, 'mut_claws', 'mut_claws', buildCatalog());
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'noop_same_id');
+});


### PR DESCRIPTION
## Summary

Sprint δ Meta Systemic ships 4 mechanical patterns extracted from cross-game research (CK3 / Stellaris / MYZ / Triangle Strategy) into the meta progression layer.

### Patterns shipped

1. **CK3 DNA gene encoding** (`apps/backend/services/meta/geneEncoder.js`, ~140 LOC)
   - Deterministic SHA1 hash chain encoding (lineage_id + sorted mutation set)
   - Cross-generation parent_dna chain link (`gn1:<parent_hash>:<self_hash>`)
   - Helpers: `encode`, `decode`, `diffMutations`, `isChildOf`, `computeGeneration`
   - Wired in `metaProgression.rollMatingOffspring` via opt-in `context.useGeneEncoder=true` (additive, defensive)

2. **Stellaris event chain scripting** (`apps/backend/services/meta/eventChainScripting.js`, ~210 LOC)
   - YAML-driven chains with conditional branching on `session.vcSnapshot` axes
   - 6 supported ops: `>`, `>=`, `<`, `<=`, `==`, `!=`
   - 3 seed chains: `savana_intro_chain`, `caverna_mystery_chain`, `deserto_drift_chain` (placeholder text — D4 writer commission deferred)
   - Bridged via `narrativeEngine.triggerEventChain`

3. **MYZ mutation tree swap** (`apps/backend/services/meta/mutationTreeSwap.js`, ~135 LOC)
   - Free re-pick alt path: detach old mutation, refund MP, validate new (slot conflict + MP budget + reversibility)
   - Catalog flag `irreversible: true` locks specific mutations
   - Re-exported from `mutationEngine.swapAppliedMutation` (lazy, no startup coupling)

4. **Triangle Strategy conviction voting** (`apps/backend/services/meta/convictionVoting.js`, ~225 LOC + `apps/backend/routes/conviction.js`)
   - Multi-player choice resolution with VC-axis weighted votes
   - Endpoints: `POST /api/v1/conviction/init`, `POST /vote`, `GET /results`, `POST /close`
   - Tie-break prefers status-quo; missing axis fallback weight = 1.0 (neutral)
   - Stateless `tallyConviction` helper for ad-hoc aggregation

### Tests

- **34 new tests** total, all green:
  - `tests/services/sprint-delta/geneEncoder.test.js` — 6 tests (determinism, decode, parent-child chain, diff, defensive, generation walk)
  - `tests/services/sprint-delta/eventChainScripting.test.js` — 8 tests (load, walk, condition gating, validate, isolation)
  - `tests/services/sprint-delta/mutationTreeSwap.test.js` — 5 tests (basic swap, slot conflict, MP insufficient, irreversible, idempotent)
  - `tests/services/sprint-delta/convictionVoting.test.js` — 7 tests (single voter, weighted, tie-break, missing axis, vote update, stateless tally, close)
  - `tests/api/sprint-delta/convictionRoutes.test.js` — 6 tests (init, vote, results, close, error paths)
  - `tests/api/sprint-delta/eventChainIntegration.test.js` — 2 tests (bridge integration smoke)
- **AI baseline regression**: 353/353 ✅
- **metaProgression + mutation + narrative regression**: 73/73 ✅
- **Prettier**: clean ✅
- **Smoke probe live**: gene encoder hook + event chain conditional walk verified via `node -e` invocation

### File ownership respected

Touched only files in Sprint δ scope. NOT touched: `apps/play/src/*` (Sprint β), `apps/backend/services/combat/*` (Sprint α), `apps/backend/services/perf/*` + `tools/py/*` + `Makefile` (Sprint γ), `.github/workflows/`, `migrations/`, `packages/contracts/`. Zero collision expected.

### Pillar impact

- **P2 Evoluzione** 🟢 def → 🟢 def++ (mating chain link + mutation re-spec free path)
- **P5 Co-op** 🟢 candidato → 🟢 candidato refined (conviction voting wire baseline for multi-player choice)

### Default recommendations applied (handoff §4)

- TKT-09 deferred (event chains parziale OK)
- D4 placeholder text (writer commission Phase 3)
- D-mech-3 morale already mediated by Sprint α (no overlap)

## Test plan

- [x] `node --test tests/services/sprint-delta/*.test.js tests/api/sprint-delta/*.test.js` → 34/34 green
- [x] `node --test tests/ai/*.test.js` → 353/353 green
- [x] `node --test tests/services/metaProgression*.test.js tests/services/mutationEngine*.test.js tests/services/narrativeEngine*.test.js` → 73/73 green
- [x] `npx prettier --check` → clean on all touched files
- [x] Smoke probe: `node -e` exercising gene encoder + event chain trigger live