### PR TITLE
chore(stato-arte): drift fixes — Disco day pacing + AI War 3/3 + count realignment

### DIFF
--- a/data/core/tickets/merged/TKT-NARRATIVE-DISCO-DAY-PACING.json
+++ b/data/core/tickets/merged/TKT-NARRATIVE-DISCO-DAY-PACING.json
@@ -9,7 +9,9 @@
     "matrix_anchor": "docs/research/2026-04-26-tier-s-extraction-matrix.md#9-disco-elysium-zaum-2019--p4-thought-cabinet"
   },
   "agent_owner": "narrative-design-illuminator",
-  "status": "proposed",
+  "status": "merged",
+  "merged_pr": 1934,
+  "merged_at": "2026-04-27",
   "reuse_level": "minimal",
   "audit_source_doc": "docs/reports/2026-04-27-stato-arte-completo-vertical-slice.md",
   "created_at": "2026-04-27",

--- a/docs/reports/2026-04-27-stato-arte-completo-vertical-slice.md
+++ b/docs/reports/2026-04-27-stato-arte-completo-vertical-slice.md
@@ -238,16 +238,16 @@ Fonte: PR #1891 + report Skiv ADR + 5 reconciliation docs.
 - 🔴 **Liberation campaign region map** (~15h) — region grid + liberation% counter. **In v3.7 §4**.
 - 🔴 **Haven recruitment radio passive growth** (~6h) — pool tick over campaign turns.
 
-#### B.1.8 — Disco Elysium (3 pattern residui — Sprint 6 chiuso #9)
-- 🟢 **Thought Cabinet UI panel + cooldown round-based** (Sprint 6 2026-04-27) — 8 slot mentali, mode='rounds' default scala T1→3 / T2→6 / T3→9 round, end-of-round auto-tick via `applyEndOfRoundSideEffects`, Assign/Forget UI con progress bar, 76/76 test verdi.
+#### B.1.8 — Disco Elysium (4 pattern, 2 residui — ✅ 2/4 shipped)
+- 🟢 **Thought Cabinet UI panel + cooldown round-based** (Sprint 6 2026-04-27 main) — 8 slot mentali, mode='rounds' default scala T1→3 / T2→6 / T3→9 round, end-of-round auto-tick via `applyEndOfRoundSideEffects`, Assign/Forget UI con progress bar, 76/76 test verdi.
 - 🔴 **Internal voice 4-MBTI axes** (~10h) — narrative log debrief con voce-per-axis durante combat hint.
 - 🔴 **Skill check passive vs active popup** (~4h) — surface trigger via popup notification.
-- 🔴 **Day/time pacing flavor copy** (~2h) — "Giorno N di Aurora" nei debrief.
+- 🟢 **Day/time pacing flavor copy** — Sprint 1 §I shipped (PR #1934: `formatDayPacing(currentChapter, currentAct)` in `apps/backend/routes/campaign.js` + 4 response sites: defeat retry + choice_node + advance + act_advanced. "Giorno N di Aurora" diegetic copy).
 
-#### B.1.9 — AI War: Fleet Command (3 pattern residui)
-- 🔴 **Asymmetric rules registry doc** (~2h) — codify pattern AI ha rule diverse.
-- 🔴 **Decentralized unit AI doc** (~1h) — reference utility brain.
-- 🔴 **Defender's advantage modifier** (~3h) — +50% AI defensive vs player aggressive.
+#### B.1.9 — AI War: Fleet Command (3 pattern, 0 residui — ✅ tutti shipped)
+- 🟢 **Asymmetric rules registry doc** — Sprint 1 §III shipped (PR #1934: `docs/design/2026-04-27-ai-war-asymmetric-rules.md` canonical reference, codifica Sistema asymmetric pattern per Pillar 5+6).
+- 🟢 **Decentralized unit AI doc** — Sprint 1 §IV shipped (PR #1934: `docs/design/2026-04-27-ai-war-decentralized-architecture.md` reference utility brain per-unit autonomous).
+- 🟢 **Defender's advantage modifier** — Sprint 1 §II shipped (PR #1934: `apps/backend/services/combat/defenderAdvantageModifier.js` `getDefenderAdvantage` wired in `session.js:445` + `DEFENDER_ADVANTAGE_BONUS=1`).
 
 #### B.1.10 — Fallout Tactics (3 pattern residui)
 - 🔴 **Encounter authoring CLI YAML extension** (~6h) — `tools/py/master_dm.py` REPL → YAML generator + validator.
@@ -265,7 +265,7 @@ Fonte: PR #1891 + report Skiv ADR + 5 reconciliation docs.
 - 🔴 **Jack Principles guidance toast per phase** (~5h) — V1 onboarding shipped, estendi a phase-by-phase.
 - 🔴 **XCOM 2 points-buy pre-game** (~8h) — point budget shared per build squad.
 
-**Tier S residuo cumulato**: ~38 pattern, **~190h totali** se tutti adottati.
+**Tier S residuo cumulato**: ~32 pattern, **~175h totali** se tutti adottati. (Drift fix 2026-04-27: §B.1.5 channel resistance #1964 + §B.1.8 day pacing #1934 + Thought Cabinet main + §B.1.9 3/3 AI War #1934 shipped — 6 pattern segnati post-merge.)
 
 ### B.2 — Tier A residuo (oltre i 2 shipped: pathfinder + voidling)
 
@@ -335,11 +335,11 @@ Fonte: PR #1891 + report Skiv ADR + 5 reconciliation docs.
 
 | Tier | Pattern residui | Effort cumulato Min |
 |---|---:|---:|
-| Tier S (13 giochi) | 38 | ~190h |
+| Tier S (13 giochi) | 32 | ~175h |
 | Tier A (11 giochi) | 11 | ~54h |
 | Tier B (15 giochi) | 11 (4 archive) | ~115h |
 | Tier E (20 voci tech) | 13 (4 blocked) | ~150h |
-| **TOTALE** | **73 pattern residui** | **~509h Min** |
+| **TOTALE** | **67 pattern residui** | **~494h Min** |
 
 **Quick wins ≤5h totali (cross-tier)**: ~16 pattern × media 4h = **~64h** = ~2 settimane sprint single-dev.
 


### PR DESCRIPTION
## Summary

Quick win drift cleanup post Sprint 6 (PR #1964) + Sprint 6 Disco Thought Cabinet (PR #1966) concurrent merge. Audit ha rivelato 6 pattern segnati 🔴 in `docs/reports/2026-04-27-stato-arte-completo-vertical-slice.md` mentre erano già shipped. Pattern: stato-arte doc upkeep mandatory (memory `feedback_stato_arte_doc_upkeep`).

> Supersedes #1968 (rebased onto latest main per resolvere conflict con #1966 Thought Cabinet che è atterrato concorrentemente).

## Drift fixes

- **§B.1.8 Disco Elysium**:
  - Thought Cabinet UI panel 🟢 (PR #1966 Sprint 6 main, 76/76 test verdi)
  - Day/time pacing 🟢 (PR #1934, `apps/backend/routes/campaign.js` formatDayPacing 4 response sites)
- **§B.1.9 AI War: Fleet Command** — tutti e 3 i pattern 🟢 shipped via PR #1934:
  - Asymmetric rules registry doc → [docs/design/2026-04-27-ai-war-asymmetric-rules.md](docs/design/2026-04-27-ai-war-asymmetric-rules.md)
  - Decentralized unit AI doc → [docs/design/2026-04-27-ai-war-decentralized-architecture.md](docs/design/2026-04-27-ai-war-decentralized-architecture.md)
  - Defender's advantage modifier → [apps/backend/services/combat/defenderAdvantageModifier.js](apps/backend/services/combat/defenderAdvantageModifier.js) wired session.js:445

## Cumulative count delta (6 pattern shipped)

| Tier | Pre | Post |
|------|-----|------|
| Tier S residuo | 38 pattern (~190h) | 32 pattern (~175h) |
| **TOTALE residui** | **73 pattern (~509h Min)** | **67 pattern (~494h Min)** |

## Ticket lifecycle

- `data/core/tickets/proposed/TKT-NARRATIVE-DISCO-DAY-PACING.json` → `data/core/tickets/merged/` (status='merged' + merged_pr=1934 + merged_at='2026-04-27')

## Test plan

- [x] Doc-only changes (zero codice runtime modificato)
- [x] Cross-reference verified: `grep -rn "formatDayPacing\|defenderAdvantage" apps/backend/` confirms runtime live
- [x] `ls docs/design/` confirms 2 AI War design docs present
- [x] `git mv` ticket file persisted as rename (R status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)