### PR TITLE
feat(skiv): Goal 4 — legacy death ritual choice (P2 cross-gen agency)

### DIFF
--- a/apps/backend/routes/lineage.js
+++ b/apps/backend/routes/lineage.js
@@ -26,6 +26,7 @@ const {
   propagateLineage,
   inheritFromLineage,
   inspectPool,
+  computeBondHeartsDelta,
 } = require('../services/generation/lineagePropagator');
 
 function createLineageRouter() {
@@ -97,6 +98,88 @@ function createLineageRouter() {
       return res.status(400).json({ error: 'species and biome route params required' });
     }
     res.json(inspectPool(species, biome));
+  });
+
+  /**
+   * Skiv Goal 4 — legacy death mutation choice ritual endpoint.
+   *
+   * POST /legacy-ritual — body
+   *   { session_id, unit_id, mutationsToLeave: string[],
+   *     legacyUnit?: { id, applied_mutations[] }, species_id, biome_id }
+   *
+   * Allenatore (player) chooses what subset of applied_mutations to leave
+   * to next generation. Decision is irreversible per session (caller-side
+   * lock). Returns narrative beat (bond hearts delta + Skiv voice line)
+   * + propagation result.
+   *
+   * Caller flow (frontend):
+   *   1. legacyRitualPanel.js shows checkbox list of legacyUnit.applied_mutations
+   *   2. User submits subset
+   *   3. Endpoint propagates subset + returns narrative beat
+   *
+   * Note: caller is responsible for passing legacyUnit (server-side has
+   * no notion of "which unit is dying" outside the active session combat
+   * runtime, which already triggers propagateLineage on kill in
+   * routes/session.js). This endpoint exists for the explicit ritual UX
+   * where allenatore wants to pick subset BEFORE the runtime hook fires
+   * (or as override after).
+   */
+  router.post('/legacy-ritual', (req, res) => {
+    const {
+      session_id: sessionId,
+      unit_id: unitId,
+      mutationsToLeave,
+      legacyUnit,
+      species_id: speciesId,
+      biome_id: biomeId,
+    } = req.body || {};
+
+    if (typeof sessionId !== 'string' || !sessionId) {
+      return res.status(400).json({ error: 'session_id (string) required' });
+    }
+    if (typeof unitId !== 'string' || !unitId) {
+      return res.status(400).json({ error: 'unit_id (string) required' });
+    }
+    if (typeof speciesId !== 'string' || !speciesId) {
+      return res.status(400).json({ error: 'species_id (string) required' });
+    }
+    if (typeof biomeId !== 'string' || !biomeId) {
+      return res.status(400).json({ error: 'biome_id (string) required' });
+    }
+    if (!Array.isArray(mutationsToLeave)) {
+      return res.status(400).json({
+        error:
+          'mutationsToLeave (array of mutation_id strings) required — pass [] to leave nothing',
+      });
+    }
+    const cleanLeave = mutationsToLeave.filter((m) => typeof m === 'string' && m);
+
+    // legacyUnit is optional. If absent, fabricate a minimal shape from
+    // mutationsToLeave (allenatore explicitly picked subset; we can still
+    // propagate without the full unit object). This keeps the endpoint
+    // usable from a UI that has only the picked subset in scope.
+    const unit =
+      legacyUnit && typeof legacyUnit === 'object'
+        ? legacyUnit
+        : { id: unitId, applied_mutations: cleanLeave };
+
+    const totalApplied = Array.isArray(unit.applied_mutations) ? unit.applied_mutations.length : 0;
+
+    try {
+      const propagation = propagateLineage(unit, speciesId, biomeId, {
+        mutationsToLeave: cleanLeave,
+      });
+      const narrative = computeBondHeartsDelta(propagation.left_count, totalApplied);
+      res.json({
+        ok: true,
+        session_id: sessionId,
+        unit_id: unitId,
+        propagation,
+        narrative,
+      });
+    } catch (err) {
+      res.status(500).json({ error: 'legacy_ritual_failed', message: err.message });
+    }
   });
 
   return router;

--- a/apps/backend/services/generation/lineagePropagator.js
+++ b/apps/backend/services/generation/lineagePropagator.js
@@ -52,12 +52,31 @@ function _getOrCreateMutationSet(speciesId, biomeId) {
 /**
  * Propagate a legacy unit's applied_mutations to the lineage pool.
  *
+ * Skiv Goal 4 (legacy death ritual choice) extension: optional
+ * `options.mutationsToLeave: string[]` filters the applied_mutations subset
+ * to propagate. When omitted (default behavior preserved, BACK-COMPAT) all
+ * applied_mutations propagate as before. When provided, ONLY mutations in
+ * the array intersection of `applied_mutations ∩ mutationsToLeave` are written.
+ * Empty array → nothing propagated (allenatore decided to leave nothing).
+ *
  * @param {object} legacyUnit — unit object with `applied_mutations: string[]`
  * @param {string} speciesId
  * @param {string} biomeId
- * @returns {{ written_traits: string[], pool_size: number, species_id: string, biome_id: string }}
+ * @param {object} [options]
+ * @param {string[]} [options.mutationsToLeave] — opt-in subset filter. When
+ *   omitted, default behavior preserved (all applied_mutations propagated).
+ *   When provided (even if empty), filters to subset.
+ * @returns {{
+ *   written_traits: string[],
+ *   pool_size: number,
+ *   species_id: string,
+ *   biome_id: string,
+ *   filtered: boolean,
+ *   total_applied: number,
+ *   left_count: number,
+ * }}
  */
-function propagateLineage(legacyUnit, speciesId, biomeId) {
+function propagateLineage(legacyUnit, speciesId, biomeId, options) {
   if (!legacyUnit || typeof legacyUnit !== 'object') {
     throw new TypeError('propagateLineage: legacyUnit must be an object');
   }
@@ -69,9 +88,26 @@ function propagateLineage(legacyUnit, speciesId, biomeId) {
   }
 
   const applied = Array.isArray(legacyUnit.applied_mutations) ? legacyUnit.applied_mutations : [];
+
+  // Skiv Goal 4 — opt-in filter. Default (options omitted) preserves
+  // original behavior: tutto lasciato. Anti-foot-gun: malformed
+  // `mutationsToLeave` (non-array) → throw rather than silent drop.
+  let filtered = false;
+  let toPropagate = applied;
+  if (options && Object.prototype.hasOwnProperty.call(options, 'mutationsToLeave')) {
+    if (!Array.isArray(options.mutationsToLeave)) {
+      throw new TypeError(
+        'propagateLineage: options.mutationsToLeave must be an array of mutation_id strings',
+      );
+    }
+    filtered = true;
+    const leaveSet = new Set(options.mutationsToLeave.filter((m) => typeof m === 'string' && m));
+    toPropagate = applied.filter((mid) => leaveSet.has(mid));
+  }
+
   const mutSet = _getOrCreateMutationSet(speciesId, biomeId);
   const written = [];
-  for (const mid of applied) {
+  for (const mid of toPropagate) {
     if (typeof mid === 'string' && mid && !mutSet.has(mid)) {
       mutSet.add(mid);
       written.push(mid);
@@ -82,6 +118,9 @@ function propagateLineage(legacyUnit, speciesId, biomeId) {
     pool_size: mutSet.size,
     species_id: speciesId,
     biome_id: biomeId,
+    filtered,
+    total_applied: applied.length,
+    left_count: toPropagate.length,
   };
 }
 
@@ -204,9 +243,52 @@ function reset() {
   _pool.clear();
 }
 
+/**
+ * Skiv Goal 4 — narrative beat bond hearts delta calculator.
+ *
+ * Pure helper, no side effects. Computes bond hearts delta + Skiv canonical
+ * voice line based on subset choice during legacy death ritual.
+ *
+ * Rules:
+ *   - 0 applied → 0 delta, no voice (graceful, no ritual narrative)
+ *   - leftCount === totalApplied AND totalApplied > 0 → +1 (gave it all)
+ *   - leftCount / totalApplied < 0.5 → -1 (kept too much for self)
+ *   - else → 0 (neutral middle ground)
+ *
+ * @param {number} leftCount — applied_mutations subset propagated
+ * @param {number} totalApplied — applied_mutations.length pre-ritual
+ * @returns {{ delta: number, voice_it: string|null, threshold: string }}
+ */
+function computeBondHeartsDelta(leftCount, totalApplied) {
+  if (!Number.isFinite(leftCount) || !Number.isFinite(totalApplied) || totalApplied <= 0) {
+    return { delta: 0, voice_it: null, threshold: 'no_mutations' };
+  }
+  const ratio = leftCount / totalApplied;
+  if (leftCount === totalApplied) {
+    return {
+      delta: +1,
+      voice_it: 'Hai dato tutto. La sabbia ricorda.',
+      threshold: 'full',
+    };
+  }
+  if (ratio < 0.5) {
+    return {
+      delta: -1,
+      voice_it: 'Il vento porta solo certe ossa.',
+      threshold: 'partial_low',
+    };
+  }
+  return {
+    delta: 0,
+    voice_it: 'La sabbia segue. Quello che lasci lo lasci.',
+    threshold: 'partial_high',
+  };
+}
+
 module.exports = {
   propagateLineage,
   inheritFromLineage,
   inspectPool,
   reset,
+  computeBondHeartsDelta,
 };

--- a/apps/play/src/api.js
+++ b/apps/play/src/api.js
@@ -150,6 +150,23 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ unit_id: unitId, thought_id: thoughtId, mode: 'rounds' }),
     }),
+  // Skiv Goal 4 — legacy death mutation choice ritual (P2 cross-gen agency).
+  // Allenatore picks subset of applied_mutations to leave to next generation.
+  // Backend propagates filtered subset + returns narrative beat (bond hearts
+  // delta + Skiv canonical voice line). Default behavior preserved if caller
+  // passes mutationsToLeave === all applied_mutations (back-compat).
+  legacyRitualSubmit: (sid, unitId, mutationsToLeave, extra = {}) =>
+    jsonFetch('/api/v1/lineage/legacy-ritual', {
+      method: 'POST',
+      body: JSON.stringify({
+        session_id: sid,
+        unit_id: unitId,
+        mutationsToLeave: Array.isArray(mutationsToLeave) ? mutationsToLeave : [],
+        species_id: extra.species_id || extra.speciesId || null,
+        biome_id: extra.biome_id || extra.biomeId || null,
+        legacyUnit: extra.legacyUnit || null,
+      }),
+    }),
   replay: (sid) => jsonFetch(`/api/session/${encodeURIComponent(sid)}/replay`),
   modulations: () => jsonFetch('/api/party/modulations'),
   partyConfig: () => jsonFetch('/api/party/config'),

--- a/apps/play/src/legacyRitualPanel.js
+++ b/apps/play/src/legacyRitualPanel.js
@@ -1,0 +1,376 @@
+// Skiv Goal 4 — Legacy death mutation choice ritual UI (P2 cross-gen agency).
+//
+// Overlay modale spawn-on-event: trigger su actor.lifecycle_phase === 'legacy'
+// (transition to legacy phase). Allenatore vede checkbox lista
+// applied_mutations e decide cosa lasciare alla prossima generazione.
+//
+// Default: tutto lasciato (back-compat). Decisione irreversible per session.
+// Narrative beat (Skiv canonical voice, italiano + desert metaphor):
+//   - 100% lasciato → bond hearts +1 — "Hai dato tutto. La sabbia ricorda."
+//   - < 50% lasciato → bond hearts -1 — "Il vento porta solo certe ossa."
+//   - 50-99% → bond hearts 0 — "La sabbia segue. Quello che lasci lo lasci."
+
+import { api } from './api.js';
+
+const STATE = {
+  overlayEl: null,
+  getSessionId: () => null,
+  getSelectedUnit: () => null,
+  pickedThisSession: new Set(), // unitId set — one ritual per unit per session.
+  currentUnit: null,
+  currentSpeciesId: null,
+  currentBiomeId: null,
+  onCompleteCallback: null,
+};
+
+function injectStyles() {
+  if (document.getElementById('legacy-ritual-styles')) return;
+  const s = document.createElement('style');
+  s.id = 'legacy-ritual-styles';
+  s.textContent = `
+    .legacy-ritual-overlay {
+      position: fixed; inset: 0; z-index: 9996;
+      background: rgba(6, 4, 10, 0.88);
+      display: none; align-items: center; justify-content: center;
+      padding: 24px 16px; overflow-y: auto;
+      font-family: Inter, system-ui, sans-serif; color: #e8eaf0;
+    }
+    .legacy-ritual-overlay.visible { display: flex; }
+    .legacy-ritual-card {
+      max-width: 640px; width: 100%; background: #100c14;
+      border: 1px solid #4a3520; border-radius: 14px; padding: 22px 24px;
+      box-shadow: 0 0 32px rgba(255, 198, 107, 0.18);
+    }
+    .legacy-ritual-head { display: flex; align-items: baseline; gap: 12px; margin-bottom: 6px; }
+    .legacy-ritual-head h2 { margin: 0; font-size: 1.3rem; color: #ffc66b; }
+    .legacy-ritual-head .unit-chip {
+      margin-left: auto; background: #0b0d12; border: 1px solid #4a3520;
+      border-radius: 999px; padding: 4px 12px; font-size: 0.85rem; color: #ffc66b;
+    }
+    .legacy-ritual-subtitle {
+      color: #c8a78a; font-size: 0.92rem; margin-bottom: 16px;
+      font-style: italic; line-height: 1.5;
+    }
+    .legacy-ritual-list {
+      display: flex; flex-direction: column; gap: 8px; margin-bottom: 14px;
+      max-height: 360px; overflow-y: auto;
+    }
+    .legacy-ritual-row {
+      display: flex; align-items: center; gap: 10px;
+      padding: 10px 12px; background: #1a1208; border: 1px solid #4a3520;
+      border-radius: 8px; cursor: pointer; transition: border-color 160ms ease;
+    }
+    .legacy-ritual-row:hover { border-color: #ffc66b; }
+    .legacy-ritual-row input[type="checkbox"] {
+      width: 18px; height: 18px; accent-color: #ffc66b; cursor: pointer;
+    }
+    .legacy-ritual-row .mut-id { font-weight: 600; color: #e8eaf0; flex: 1; }
+    .legacy-ritual-row.left-yes { background: #2a1f10; }
+    .legacy-ritual-summary {
+      padding: 10px 12px; background: #0b0d12; border-radius: 8px;
+      font-size: 0.88rem; color: #c8cfdd; margin-bottom: 14px;
+      display: flex; justify-content: space-between; align-items: center;
+    }
+    .legacy-ritual-summary .ratio { color: #ffc66b; font-weight: 600; }
+    .legacy-ritual-actions { display: flex; gap: 10px; justify-content: flex-end; }
+    .legacy-ritual-btn {
+      background: #2a1f10; color: #ffc66b; border: 1px solid #ffc66b;
+      border-radius: 6px; padding: 8px 16px; font-size: 0.92rem;
+      cursor: pointer; transition: background 120ms ease;
+    }
+    .legacy-ritual-btn:hover { background: #4a3520; }
+    .legacy-ritual-btn.secondary {
+      background: #1a1f2b; color: #9aa3b5; border-color: #2a3040;
+    }
+    .legacy-ritual-btn.secondary:hover { background: #2a3040; color: #c8cfdd; }
+    .legacy-ritual-btn.disabled { opacity: 0.45; cursor: not-allowed; }
+    .legacy-ritual-result {
+      margin-top: 12px; padding: 14px 16px;
+      background: rgba(255, 198, 107, 0.08); border-left: 3px solid #ffc66b;
+      border-radius: 4px;
+    }
+    .legacy-ritual-result.delta-pos { border-left-color: #4ade80; background: rgba(74, 222, 128, 0.08); }
+    .legacy-ritual-result.delta-neg { border-left-color: #ef4444; background: rgba(239, 68, 68, 0.08); }
+    .legacy-ritual-result .voice-line {
+      font-style: italic; color: #ffc66b; margin-bottom: 4px; line-height: 1.45;
+    }
+    .legacy-ritual-result.delta-pos .voice-line { color: #4ade80; }
+    .legacy-ritual-result.delta-neg .voice-line { color: #ef9a9a; }
+    .legacy-ritual-result .delta-line {
+      font-size: 0.84rem; color: #c8cfdd;
+    }
+    .legacy-ritual-empty {
+      padding: 28px 12px; text-align: center; color: #9aa3b5;
+      font-style: italic;
+    }
+    .legacy-ritual-locked {
+      padding: 18px 14px; text-align: center; color: #ffc66b;
+      background: rgba(255, 198, 107, 0.08); border-radius: 8px;
+      font-size: 0.92rem;
+    }
+  `;
+  document.head.appendChild(s);
+}
+
+function escapeHtml(s) {
+  return String(s).replace(
+    /[&<>"']/g,
+    (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c],
+  );
+}
+
+function buildOverlay() {
+  if (STATE.overlayEl) return STATE.overlayEl;
+  injectStyles();
+  const wrap = document.createElement('div');
+  wrap.className = 'legacy-ritual-overlay';
+  wrap.setAttribute('role', 'dialog');
+  wrap.setAttribute('aria-label', 'Rituale Legacy — Skiv Goal 4');
+  wrap.innerHTML = `
+    <div class="legacy-ritual-card" data-role="card">
+      <div class="legacy-ritual-head">
+        <h2>🦴 Rituale del Lascito</h2>
+        <span class="unit-chip" data-role="unit-chip">—</span>
+      </div>
+      <div class="legacy-ritual-subtitle" data-role="subtitle">
+        Il vento si volta. Decidi quali ossa la sabbia porterà alla prossima generazione.
+        Quello che non lasci muore con te.
+      </div>
+      <div data-role="body"></div>
+    </div>
+  `;
+  document.body.appendChild(wrap);
+  STATE.overlayEl = wrap;
+  return wrap;
+}
+
+function updateSummary(overlay) {
+  const list = overlay.querySelector('[data-role="body"] .legacy-ritual-list');
+  const summary = overlay.querySelector('[data-role="body"] .legacy-ritual-summary .ratio');
+  if (!list || !summary) return;
+  const total = list.querySelectorAll('input[type="checkbox"]').length;
+  const left = list.querySelectorAll('input[type="checkbox"]:checked').length;
+  summary.textContent = `${left} / ${total}`;
+  list.querySelectorAll('.legacy-ritual-row').forEach((row) => {
+    const cb = row.querySelector('input[type="checkbox"]');
+    if (cb && cb.checked) row.classList.add('left-yes');
+    else row.classList.remove('left-yes');
+  });
+}
+
+export function renderRitual(unit) {
+  const overlay = buildOverlay();
+  const body = overlay.querySelector('[data-role="body"]');
+  const chip = overlay.querySelector('[data-role="unit-chip"]');
+  chip.textContent = unit ? `${unit.label || unit.id}` : 'nessun PG';
+
+  const lockKey = unit && unit.id;
+  if (lockKey && STATE.pickedThisSession.has(lockKey)) {
+    body.innerHTML = `
+      <div class="legacy-ritual-locked">
+        🔒 Hai già celebrato il rituale legacy per ${escapeHtml(unit?.label || unit?.id || 'questa creatura')}
+        in questa sessione. La decisione è irreversibile — la sabbia ha già preso.
+      </div>
+    `;
+    return;
+  }
+
+  const applied = Array.isArray(unit?.applied_mutations) ? unit.applied_mutations : [];
+
+  if (applied.length === 0) {
+    body.innerHTML = `
+      <div class="legacy-ritual-empty">
+        Nessuna mutazione applicata da lasciare. Il sangue è puro,
+        il vento non porta nulla. <em>La sabbia segue.</em>
+        <div style="margin-top:14px">
+          <button class="legacy-ritual-btn secondary" data-action="close">Chiudi</button>
+        </div>
+      </div>
+    `;
+    body.querySelector('button[data-action="close"]')?.addEventListener('click', closeRitualPanel);
+    return;
+  }
+
+  const rows = applied
+    .map((mid) => {
+      // Default: tutto lasciato (back-compat).
+      return `
+        <label class="legacy-ritual-row left-yes">
+          <input type="checkbox" checked data-mut-id="${escapeHtml(mid)}">
+          <span class="mut-id">${escapeHtml(mid)}</span>
+        </label>
+      `;
+    })
+    .join('');
+
+  body.innerHTML = `
+    <div class="legacy-ritual-list">${rows}</div>
+    <div class="legacy-ritual-summary">
+      <span>Mutazioni che lasci:</span>
+      <span class="ratio">${applied.length} / ${applied.length}</span>
+    </div>
+    <div class="legacy-ritual-actions">
+      <button class="legacy-ritual-btn secondary" data-action="close">Annulla</button>
+      <button class="legacy-ritual-btn" data-action="submit">✦ Sigilla il lascito</button>
+    </div>
+    <div data-role="result-slot"></div>
+  `;
+
+  body.querySelectorAll('input[type="checkbox"]').forEach((cb) => {
+    cb.addEventListener('change', () => updateSummary(overlay));
+  });
+  body.querySelector('button[data-action="close"]')?.addEventListener('click', closeRitualPanel);
+  body.querySelector('button[data-action="submit"]')?.addEventListener('click', submitRitual);
+}
+
+function collectChecked(overlay) {
+  const checks = overlay.querySelectorAll(
+    '[data-role="body"] .legacy-ritual-list input[type="checkbox"]:checked',
+  );
+  return Array.from(checks)
+    .map((cb) => cb.getAttribute('data-mut-id'))
+    .filter(Boolean);
+}
+
+async function submitRitual() {
+  const sid = STATE.getSessionId();
+  const unit = STATE.currentUnit;
+  if (!sid || !unit || !unit.id) {
+    closeRitualPanel();
+    return;
+  }
+  const overlay = STATE.overlayEl;
+  if (!overlay) return;
+
+  const submitBtn = overlay.querySelector('button[data-action="submit"]');
+  if (submitBtn) {
+    submitBtn.classList.add('disabled');
+    submitBtn.disabled = true;
+  }
+
+  const mutationsToLeave = collectChecked(overlay);
+  const totalApplied = Array.isArray(unit.applied_mutations) ? unit.applied_mutations.length : 0;
+
+  try {
+    const res = await api.legacyRitualSubmit(sid, unit.id, mutationsToLeave, {
+      species_id: STATE.currentSpeciesId || unit.species_id || unit.species || null,
+      biome_id: STATE.currentBiomeId || null,
+      legacyUnit: {
+        id: unit.id,
+        applied_mutations: unit.applied_mutations || [],
+      },
+    });
+    if (res && res.ok && res.data) {
+      STATE.pickedThisSession.add(unit.id);
+      const slot = overlay.querySelector('[data-role="result-slot"]');
+      const narrative = res.data.narrative || {};
+      const propagation = res.data.propagation || {};
+      const delta = Number(narrative.delta || 0);
+      const cls = delta > 0 ? 'delta-pos' : delta < 0 ? 'delta-neg' : '';
+      const sign = delta > 0 ? '+' : delta < 0 ? '−' : '±';
+      const heartsLine =
+        delta === 0
+          ? 'Bond hearts: invariato.'
+          : `Bond hearts: ${sign}${Math.abs(delta)} (allenatore).`;
+      if (slot) {
+        slot.innerHTML = `
+          <div class="legacy-ritual-result ${cls}">
+            <div class="voice-line">${narrative.voice_it ? '"' + escapeHtml(narrative.voice_it) + '"' : '<em>— silenzio —</em>'}</div>
+            <div class="delta-line">
+              ${escapeHtml(heartsLine)}
+              Lasciato: <strong>${propagation.left_count ?? mutationsToLeave.length}</strong> /
+              ${propagation.total_applied ?? totalApplied}.
+              Pool size: <strong>${propagation.pool_size ?? '?'}</strong>.
+            </div>
+            <div style="margin-top:10px;text-align:right">
+              <button class="legacy-ritual-btn secondary" data-action="dismiss">Lascia che il vento porti</button>
+            </div>
+          </div>
+        `;
+        slot.querySelector('button[data-action="dismiss"]')?.addEventListener('click', () => {
+          if (typeof STATE.onCompleteCallback === 'function') {
+            try {
+              STATE.onCompleteCallback({ delta, propagation, narrative });
+            } catch {
+              /* noop */
+            }
+          }
+          closeRitualPanel();
+        });
+      }
+    } else {
+      const slot = overlay.querySelector('[data-role="result-slot"]');
+      const errMsg = res?.data?.error || res?.errorMessage || 'errore sconosciuto';
+      if (slot) {
+        slot.innerHTML = `
+          <div class="legacy-ritual-result delta-neg">
+            <div class="voice-line">⚠ Il rituale ha vacillato: ${escapeHtml(errMsg)}</div>
+            <div class="delta-line">Riprova o chiudi.</div>
+          </div>
+        `;
+      }
+      if (submitBtn) {
+        submitBtn.classList.remove('disabled');
+        submitBtn.disabled = false;
+      }
+    }
+  } catch (err) {
+    console.warn('[legacy-ritual] submit failed', err);
+    if (submitBtn) {
+      submitBtn.classList.remove('disabled');
+      submitBtn.disabled = false;
+    }
+  }
+}
+
+export async function openRitualPanel(unit, opts = {}) {
+  const sid = STATE.getSessionId();
+  const u = unit || STATE.getSelectedUnit();
+  if (!sid || !u || !u.id) return;
+  STATE.currentUnit = u;
+  STATE.currentSpeciesId = opts.speciesId || opts.species_id || u.species_id || u.species || null;
+  STATE.currentBiomeId = opts.biomeId || opts.biome_id || null;
+  STATE.onCompleteCallback = typeof opts.onComplete === 'function' ? opts.onComplete : null;
+  const overlay = buildOverlay();
+  overlay.classList.add('visible');
+  renderRitual(u);
+}
+
+export function closeRitualPanel() {
+  if (STATE.overlayEl) STATE.overlayEl.classList.remove('visible');
+  STATE.currentUnit = null;
+}
+
+export function isRitualLocked(unitId) {
+  return STATE.pickedThisSession.has(unitId);
+}
+
+// Test/debug hook — drop overlay reference + reset lock cache.
+export function _resetLegacyRitualState() {
+  STATE.pickedThisSession.clear();
+  STATE.currentUnit = null;
+  STATE.currentSpeciesId = null;
+  STATE.currentBiomeId = null;
+  STATE.onCompleteCallback = null;
+  STATE.overlayEl = null;
+}
+
+export function initLegacyRitualPanel(opts = {}) {
+  STATE.getSessionId = opts.getSessionId || STATE.getSessionId;
+  STATE.getSelectedUnit = opts.getSelectedUnit || STATE.getSelectedUnit;
+  // Listen for lifecycle_phase_changed event (fired when actor enters
+  // legacy phase). When triggered, auto-open ritual for the unit.
+  // Default: trigger on transition to 'legacy' phase only.
+  window.addEventListener('lifecycle_phase_changed', (ev) => {
+    const detail = ev?.detail || {};
+    const phase = detail.lifecycle_phase || detail.phase;
+    if (phase !== 'legacy') return;
+    const unitId = detail.unit_id || detail.unitId;
+    const unit = detail.unit || STATE.getSelectedUnit();
+    if (unitId && unit && unit.id !== unitId) return;
+    openRitualPanel(unit, {
+      speciesId: detail.species_id || detail.speciesId,
+      biomeId: detail.biome_id || detail.biomeId,
+    });
+  });
+}

--- a/docs/planning/2026-04-27-skiv-personal-sprint-handoff.md
+++ b/docs/planning/2026-04-27-skiv-personal-sprint-handoff.md
@@ -357,11 +357,11 @@ Push + PR title 'feat(skiv): Goal 4 — legacy death ritual choice (P2 cross-gen
 | ---------------------------- | :--------: | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | G3 Thoughts ritual choice UI | ✅ SHIPPED | [#1983](https://github.com/MasterDD-L34D/Game/pull/1983) | thoughtsRitualPanel.js + GET /thoughts/candidates (top-3 ranked) + auto-open trigger event 'research_completed' + 30s timer + irreversible session lock; 10/10 test, voice preview wired |
 
-### Phase 3 (G4) — gated on G3 merged
+### Phase 3 (G4) — ✅ COMPLETE
 
-| Goal                            |     Status     | PR  | Notes                                                         |
-| ------------------------------- | :------------: | --- | ------------------------------------------------------------- |
-| G4 Legacy death mutation ritual | ⬜ GATED on G3 | —   | Depends on api.js + session.js post Phase 2 (shared additive) |
+| Goal                            |   Status   | PR     | Notes                                                                                                                                                                                                                                                   |
+| ------------------------------- | :--------: | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| G4 Legacy death mutation ritual | ✅ SHIPPED | #PRTBD | propagateLineage `options.mutationsToLeave` opt-in filter (back-compat preserved) + computeBondHeartsDelta narrative beat + POST /api/v1/lineage/legacy-ritual + legacyRitualPanel.js overlay (lifecycle_phase=legacy auto-trigger) + 10/10 ritual test |
 
 ### Phase 4 — synthesis
 

--- a/tests/services/lineagePropagatorRitual.test.js
+++ b/tests/services/lineagePropagatorRitual.test.js
@@ -1,0 +1,169 @@
+// Skiv Goal 4 — legacy death mutation choice ritual tests.
+//
+// Covers:
+//   1) Default behavior preserved (no options → all mutations propagated, BACK-COMPAT)
+//   2) Subset filter (options.mutationsToLeave = ['m1', 'm2'] → only those propagated)
+//   3) Empty array (options.mutationsToLeave = [] → no mutations propagated)
+//   4) Bond hearts delta calc (50% threshold + 100% bonus + edge cases)
+//
+// Cross-ref: apps/backend/services/generation/lineagePropagator.js
+
+'use strict';
+
+const { test, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  propagateLineage,
+  inspectPool,
+  reset,
+  computeBondHeartsDelta,
+} = require('../../apps/backend/services/generation/lineagePropagator');
+
+beforeEach(() => {
+  reset();
+});
+
+// --- 1) BACK-COMPAT: default behavior preserved -----------------------------
+
+test('Goal 4 BACK-COMPAT: propagateLineage senza options propaga TUTTI applied_mutations (default behavior preserved)', () => {
+  const legacy = {
+    id: 'u-skiv-legacy-1',
+    applied_mutations: ['mut_a', 'mut_b', 'mut_c'],
+  };
+  const result = propagateLineage(legacy, 'dune_stalker', 'savana');
+  // Pre-Goal4 contract: tutto propagato.
+  assert.equal(result.pool_size, 3);
+  assert.deepEqual(result.written_traits.sort(), ['mut_a', 'mut_b', 'mut_c']);
+  // New fields default to "no filter applied" semantics.
+  assert.equal(result.filtered, false);
+  assert.equal(result.total_applied, 3);
+  assert.equal(result.left_count, 3);
+
+  // Pool reflects full set.
+  const pool = inspectPool('dune_stalker', 'savana');
+  assert.deepEqual(pool.mutations.sort(), ['mut_a', 'mut_b', 'mut_c']);
+});
+
+// --- 2) Subset filter -------------------------------------------------------
+
+test('Goal 4 SUBSET: options.mutationsToLeave filtra applied_mutations al subset specificato', () => {
+  const legacy = {
+    id: 'u-skiv-legacy-2',
+    applied_mutations: ['mut_a', 'mut_b', 'mut_c', 'mut_d'],
+  };
+  const result = propagateLineage(legacy, 'dune_stalker', 'savana', {
+    mutationsToLeave: ['mut_a', 'mut_c'],
+  });
+  // Solo 'mut_a' e 'mut_c' propagati; 'mut_b' e 'mut_d' restano fuori.
+  assert.equal(result.filtered, true);
+  assert.equal(result.total_applied, 4);
+  assert.equal(result.left_count, 2);
+  assert.deepEqual(result.written_traits.sort(), ['mut_a', 'mut_c']);
+  assert.equal(result.pool_size, 2);
+
+  // Verifica isolamento pool.
+  const pool = inspectPool('dune_stalker', 'savana');
+  assert.deepEqual(pool.mutations.sort(), ['mut_a', 'mut_c']);
+  assert.ok(!pool.mutations.includes('mut_b'));
+  assert.ok(!pool.mutations.includes('mut_d'));
+});
+
+test('Goal 4 SUBSET: mutationsToLeave referencia ID NON in applied_mutations → ignorato (intersection-only)', () => {
+  const legacy = {
+    id: 'u-skiv-legacy-2b',
+    applied_mutations: ['mut_a', 'mut_b'],
+  };
+  const result = propagateLineage(legacy, 'dune_stalker', 'savana', {
+    mutationsToLeave: ['mut_a', 'mut_unknown_xyz'],
+  });
+  // Solo 'mut_a' propagato; 'mut_unknown_xyz' non era in applied → ignorato.
+  assert.equal(result.left_count, 1);
+  assert.deepEqual(result.written_traits, ['mut_a']);
+  assert.equal(result.pool_size, 1);
+});
+
+// --- 3) Empty array ---------------------------------------------------------
+
+test('Goal 4 EMPTY: options.mutationsToLeave = [] → nessuna mutation propagata (allenatore decide nulla)', () => {
+  const legacy = {
+    id: 'u-skiv-legacy-3',
+    applied_mutations: ['mut_a', 'mut_b', 'mut_c'],
+  };
+  const result = propagateLineage(legacy, 'dune_stalker', 'savana', {
+    mutationsToLeave: [],
+  });
+  assert.equal(result.filtered, true);
+  assert.equal(result.total_applied, 3);
+  assert.equal(result.left_count, 0);
+  assert.deepEqual(result.written_traits, []);
+  assert.equal(result.pool_size, 0);
+
+  // Pool resta vuoto.
+  const pool = inspectPool('dune_stalker', 'savana');
+  assert.equal(pool.pool_size, 0);
+});
+
+// --- 4) Bond hearts delta calc ---------------------------------------------
+
+test('Goal 4 BOND DELTA: 100% lasciato → +1 heart, voice "Hai dato tutto"', () => {
+  const r = computeBondHeartsDelta(3, 3);
+  assert.equal(r.delta, +1);
+  assert.equal(r.threshold, 'full');
+  assert.match(r.voice_it, /Hai dato tutto/i);
+});
+
+test('Goal 4 BOND DELTA: < 50% lasciato → -1 heart, voice "Il vento porta solo certe ossa"', () => {
+  // 1/3 = 33% < 50%
+  const r = computeBondHeartsDelta(1, 3);
+  assert.equal(r.delta, -1);
+  assert.equal(r.threshold, 'partial_low');
+  assert.match(r.voice_it, /vento|ossa/i);
+});
+
+test('Goal 4 BOND DELTA: 50-99% lasciato → 0 heart neutral, voice neutral desert metaphor', () => {
+  // 2/3 ≈ 66% (>= 50% e < 100%)
+  const r = computeBondHeartsDelta(2, 3);
+  assert.equal(r.delta, 0);
+  assert.equal(r.threshold, 'partial_high');
+  assert.match(r.voice_it, /sabbia|lasci/i);
+
+  // Edge case 50% esatto = neutral (>= 0.5).
+  const r50 = computeBondHeartsDelta(2, 4);
+  assert.equal(r50.delta, 0);
+  assert.equal(r50.threshold, 'partial_high');
+});
+
+test('Goal 4 BOND DELTA: zero applied_mutations → delta 0, no voice (graceful)', () => {
+  const r = computeBondHeartsDelta(0, 0);
+  assert.equal(r.delta, 0);
+  assert.equal(r.threshold, 'no_mutations');
+  assert.equal(r.voice_it, null);
+});
+
+// --- 5) Malformed input edge cases (Gate 3 graceful degradation) -----------
+
+test('Goal 4 EDGE: malformed mutationsToLeave (non-array) → throw TypeError', () => {
+  const legacy = { id: 'u', applied_mutations: ['mut_a'] };
+  assert.throws(
+    () =>
+      propagateLineage(legacy, 'dune_stalker', 'savana', {
+        mutationsToLeave: 'mut_a',
+      }),
+    TypeError,
+  );
+  assert.throws(
+    () =>
+      propagateLineage(legacy, 'dune_stalker', 'savana', {
+        mutationsToLeave: { 0: 'mut_a' },
+      }),
+    TypeError,
+  );
+});
+
+test('Goal 4 EDGE: applied_mutations vuoto + mutationsToLeave omitted → no-op preserved', () => {
+  const result = propagateLineage({ id: 'u', applied_mutations: [] }, 'dune_stalker', 'savana');
+  assert.equal(result.pool_size, 0);
+  assert.equal(result.filtered, false);
+  assert.equal(result.left_count, 0);
+});


### PR DESCRIPTION
## Summary

Skiv Personal Sprint **Phase 3 / Goal 4** (final goal, OPZIONALE Opzione A confermata). Allenatore decide cosa lasciare alla prossima generazione quando creatura entra in `lifecycle_phase === 'legacy'`. Cross-gen agency: inheritance non più automatica, scelta esplicita con narrative beat (bond hearts ±1).

Cross-ref: [`docs/planning/2026-04-27-skiv-personal-sprint-handoff.md` §2 Goal 4](../blob/feat/skiv-goal-4-legacy-ritual-2026-04-28/docs/planning/2026-04-27-skiv-personal-sprint-handoff.md).

Phase 1 + 2 already shipped (G1 #1982 + G2 #1977 + G3 #1983). This is the closer.

## Changes

### Backend
- **`apps/backend/services/generation/lineagePropagator.js`** (modify):
  - `propagateLineage(legacyUnit, speciesId, biomeId, options)` — added optional `options.mutationsToLeave: string[]` filter param
  - **BACK-COMPAT MANDATORY preserved**: senza `options` o senza `options.mutationsToLeave`, behavior identico al pre-PR (tutte le `applied_mutations` propagate)
  - Response shape additive: `{ ..., filtered: bool, total_applied: int, left_count: int }` (existing fields invariati)
  - New helper `computeBondHeartsDelta(leftCount, totalApplied)` — pure narrative beat calculator
- **`apps/backend/routes/lineage.js`** (additive endpoint): `POST /api/v1/lineage/legacy-ritual`
  - Body: `{ session_id, unit_id, mutationsToLeave: string[], legacyUnit?, species_id, biome_id }`
  - Response: `{ ok, session_id, unit_id, propagation, narrative: { delta, voice_it, threshold } }`
  - Edge cases: 4xx con messaggio chiaro su input malformato, no crash
  - **Note deviation**: scope spec dice `routes/session.js`, ma il path `/api/v1/lineage/*` è già mounted via `routes/lineage.js`. Adding the endpoint in lineage.js è architetturalmente corretto (URL prefix ownership). Both files are scope-permitted (related cluster).

### Frontend
- **`apps/play/src/legacyRitualPanel.js`** (NEW ~340 LOC):
  - Overlay modale con checkbox lista `applied_mutations` (default tutto checked = back-compat UX)
  - Live summary `N / M` updating su toggle
  - Submit handler → `api.legacyRitualSubmit` → narrative beat panel inline
  - Decision irreversible per session (Set lock per `unitId`)
  - Auto-trigger su event `lifecycle_phase_changed` con `phase === 'legacy'`
  - Skiv canonical voice: italiano + desert metaphor (sabbia, vento, ossa)
- **`apps/play/src/api.js`** (additive +1 method): `legacyRitualSubmit(sid, unitId, mutationsToLeave, extra)`

### Tests (NEW)
- **`tests/services/lineagePropagatorRitual.test.js`** — 10 test:
  - BACK-COMPAT default behavior preserved (no options → all mutations propagated)
  - SUBSET filter (`['m1', 'm2']` → only those propagated, intersection-only ignora unknown ID)
  - EMPTY array (`[]` → no mutations propagated, allenatore decide nulla)
  - BOND DELTA: 100% → +1, < 50% → -1, 50-99% → 0, zero applied → 0+null
  - EDGE: malformed `mutationsToLeave` (non-array) → throws TypeError
  - EDGE: applied vuoto + omitted options → no-op preserved

## DoD checklist (4-gate + Gate 5)

- [x] **Gate 1 research**: existing `propagateLineage` signature read, `formsPanel` + `thoughtsRitualPanel` overlay pattern read, `applied_mutations` shape verified
- [x] **Gate 2 smoke tests**: `node --test tests/services/lineagePropagatorRitual.test.js` → **10/10 verde**
- [x] **Gate 3 tuning edge cases**: zero applied_mutations graceful, malformed `mutationsToLeave` non-array → throws TypeError, missing required body fields → 4xx clean message non crash
- [x] **Gate 4 optimization**:
  - Existing `tests/services/lineagePropagator.test.js` → **12/12 verde** (back-compat regression-free)
  - `node --test tests/ai/*.test.js` → **382/382 verde** (zero AI regression)
  - `npx prettier --check` → All files Prettier code style verde
  - `python tools/check_docs_governance.py --strict` → 0 errors / 0 warnings
- [x] **Gate 5 surface wired**: overlay VISIBLE in dev server `apps/play`. Smoke probe via `preview_start` + `preview_eval`:
  - Overlay opens with title "🦴 Rituale del Lascito"
  - 3 mutation rows render con checkbox tutti checked di default (back-compat)
  - Live summary `3 / 3` updating a `1 / 3` quando 2 checkbox toggled OFF
  - Visual `.left-yes` class persists su rows ancora checked
  - Skiv subtitle render: _"Il vento si volta. Decidi quali ossa la sabbia porterà alla prossima generazione. Quello che non lasci muore con te."_

## Live smoke probe — backend endpoint

Backend started on `:3360`, 5 cases verified:

```
SUBSET 2/4 → delta 0, voice "La sabbia segue. Quello che lasci lo lasci." ✓
EMPTY 0/2 → delta -1, voice "Il vento porta solo certe ossa." ✓
100% 2/2 → delta +1, voice "Hai dato tutto. La sabbia ricorda." ✓
malformed mutationsToLeave (string) → 400 "mutationsToLeave (array of mutation_id strings) required" ✓
missing biome_id → 400 "biome_id (string) required" ✓
```

## Sample voice lines (Skiv canonical)

| Threshold | Bond hearts | Voice line |
|-----------|:---:|---|
| 100% lasciato (gave all) | **+1** | _"Hai dato tutto. La sabbia ricorda."_ |
| 50-99% (middle ground) | **0** | _"La sabbia segue. Quello che lasci lo lasci."_ |
| < 50% (kept too much) | **-1** | _"Il vento porta solo certe ossa."_ |

Italiano + desert metaphor (sabbia, vento, ossa) per CLAUDE.md Skiv canonical creature voice rule.

## Back-compat statement

**Default `propagateLineage(unit, species, biome)` call (no options) → identical to pre-PR behavior**: all `applied_mutations` propagated unfiltered. Test `Goal 4 BACK-COMPAT` esplicitamente assertisce questo. The 12 existing `lineagePropagator.test.js` tests pass unchanged. The runtime hook in `routes/session.js` (line 824-841) chiamata su `killOccurred && applied_mutations.length > 0` continua a chiamare `propagateLineage` senza options → no behavioral change runtime.

## §6 progress update

Updated `docs/planning/2026-04-27-skiv-personal-sprint-handoff.md` Phase 3 row → ✅ SHIPPED. See commit `7eeec011`.

## Test plan

- [x] `node --test tests/services/lineagePropagatorRitual.test.js` — 10/10 verde
- [x] `node --test tests/services/lineagePropagator.test.js` — 12/12 verde (back-compat)
- [x] `node --test tests/ai/*.test.js` — 382/382 verde
- [x] `npx prettier --check` 5 modified files — All Prettier code style
- [x] `python tools/check_docs_governance.py --strict` — 0 errors / 0 warnings
- [x] Live backend smoke probe — endpoint risponde JSON narrative + propagation, 4xx graceful su input malformato
- [x] Live frontend smoke via `preview_start` apps/play — overlay renders, checkbox toggle live, summary updates, Skiv voice subtitle visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)