### PR TITLE
docs(planning): Action 4 Sprint M.7 re-frame DioField command-latency p95

### DIFF
--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -7969,6 +7969,19 @@
       "review_cycle_days": 90,
       "primary": false,
       "track": "research"
+    },
+    {
+      "path": "docs/research/2026-04-28-godot-phone-composer-spike.md",
+      "title": "Godot phone composer cross-stack spike — DioField command-latency p95 baseline",
+      "doc_status": "draft",
+      "doc_owner": "master-dd",
+      "workstream": "cross-cutting",
+      "last_verified": "2026-04-28",
+      "source_of_truth": false,
+      "language": "it",
+      "review_cycle_days": 14,
+      "primary": false,
+      "track": "research"
     }
   ]
 }

--- a/docs/planning/2026-04-28-master-execution-plan.md
+++ b/docs/planning/2026-04-28-master-execution-plan.md
@@ -680,15 +680,18 @@ Pre-commit Husky port equivalent (mojibake check + path-scoped guard) → `.git/
 
 **Scope minimal POC**:
 
-- Godot HTML5 export → 1 button "ATTACK" pressed → emit WebSocket message → Express WS receive → state log
+- Godot HTML5 export → 1 button "ATTACK" pressed → emit WebSocket message → Express WS receive → state update → echo back → Godot HTML5 client render
 - Test su iOS Safari + Android Chrome real device (browser PWA)
-- Touch input latency measure
+- **Baseline measure web v1 first** (zero-extra-effort, riusa current backend WS `apps/backend/services/lobby/`): 50 sample p95 round-trip via DevTools Network panel + custom timestamp marker su `apps/play` canvas click → `/api/session/action` → state-fetch. Comparison reference per Godot HTML5 measure.
+- **DioField command-latency p95** round-trip button→state-echo (chain: button press → WS upgrade → Express WS receive → state update → echo back → Godot HTML5 client render)
 - Virtual keyboard occlusion test (chat input field)
 - DPI handling 320px width minimum
 
-**Decision binary**: SE prototype works <100ms latency + UI scale OK su 320px → Sprint N gate criterion "phone composer portable" PRE-validated. SE fail → abort Godot decision PRIMA Sprint N.3-N.6 (3-4 settimane risparmio).
+**Decision binary**: SE prototype works **DioField command-latency p95 < 100ms** round-trip + UI scale OK su 320px → Sprint N gate criterion "phone composer portable" PRE-validated. SE p95 > 200ms → abort Godot decision PRIMA Sprint N.3-N.6 (3-4 settimane risparmio).
 
-**Output**: `docs/research/2026-04-28-godot-phone-composer-spike.md` + binary go/no-go signal.
+**Output**: [`docs/research/2026-04-28-godot-phone-composer-spike.md`](../research/2026-04-28-godot-phone-composer-spike.md) + binary go/no-go signal.
+
+**Source ref re-frame**: Action 4 ADR-2026-04-28-deep-research-actions §Action 4 (DioField command-latency design crux F1 + F2 line 97).
 
 **Gate exit Sprint M**: project Godot bootstrappato + plugin install + asset Legacy importati + 1 scene `Main.tscn` aperta + cross-stack spike PASS + CI green + phone composer spike PASS. Tutti 3 spike PASS → Sprint N commitment.
 

--- a/docs/research/2026-04-28-godot-phone-composer-spike.md
+++ b/docs/research/2026-04-28-godot-phone-composer-spike.md
@@ -1,0 +1,101 @@
+---
+title: 2026-04-28 Godot phone composer cross-stack spike — DioField command-latency p95 baseline
+doc_status: draft
+doc_owner: master-dd
+workstream: cross-cutting
+last_verified: 2026-04-28
+language: it
+review_cycle_days: 14
+related:
+  - docs/adr/ADR-2026-04-28-deep-research-actions.md
+  - docs/planning/2026-04-28-master-execution-plan.md
+  - docs/research/2026-04-28-deep-research-synthesis.md
+---
+
+# Godot phone composer cross-stack spike — DioField command-latency p95 baseline
+
+> **Status**: PLACEHOLDER pending Sprint M.7 execution. Doc seed creato 2026-04-28 per ADR-2026-04-28-deep-research-actions §Action 4 cross-link valido. Riempire post-spike con dati reali.
+
+## 1. Scope
+
+POC minimal Godot HTML5 export con 1 button "ATTACK" pressed → WS message → Express WS receive → state update → echo back → Godot HTML5 client render.
+
+Stack target:
+
+- Client: Godot 4.x HTML5 export (browser PWA)
+- Server: Express + `ws@8.18.3` (`apps/backend/services/lobby/`)
+- Transport: WebSocket native (NO Godot MultiplayerAPI)
+
+## 2. Metrica DioField
+
+**Primary**: `command_latency_p95` round-trip button press → state-echo render.
+
+**Chain misurata** (timestamp marker per step):
+
+1. `t0` — button press (Godot input event)
+2. `t1` — WS frame send (client)
+3. `t2` — Express WS receive (server log)
+4. `t3` — state update committed (server)
+5. `t4` — echo frame send (server)
+6. `t5` — Godot client render frame after echo (visual ack)
+
+**p95 calcolato**: `t5 - t0` su N=50 sample.
+
+**Source canonical**: F1 §"DioField" + F2 line 97 in [`docs/research/2026-04-28-deep-research-synthesis.md`](2026-04-28-deep-research-synthesis.md). Research esplicita "command latency" come **design crux** per real-time-adjacent inputs SRPG (NOT generic touch latency).
+
+## 3. Baseline web v1 (measure first)
+
+**Razionale**: zero-extra-effort comparison pre-Godot. Riusa current backend WS + `apps/play` web v1.
+
+**Setup**:
+
+- Backend: `npm run start:api` (port 3334)
+- Client: `apps/play` canvas click → `fetch /api/session/action` → state-fetch
+- Tunnel: ngrok pubblico per real device test
+
+**Sample**: N=50 click "ATTACK" su iOS Safari + Android Chrome.
+
+**Tool**:
+
+- Browser DevTools → Network panel → timing breakdown
+- Custom timestamp marker JS: `performance.now()` su click + state-fetch resolved
+- Dump CSV → percentile p50/p95/p99
+
+**Output baseline atteso**: numero p95 web v1 attuale (NO benchmark esistente — primo measure).
+
+**Reference comparison**: confronta p95 Godot HTML5 spike vs web v1 baseline. Se Godot p95 > 1.5x baseline → red flag stack overhead.
+
+## 4. Threshold pass / abort
+
+| Condizione                                    | Decisione                                                         |
+| --------------------------------------------- | ----------------------------------------------------------------- |
+| p95 < 100ms iOS Safari + Android Chrome       | **PASS** — Sprint N.3-N.6 commitment OK                           |
+| 100ms ≤ p95 ≤ 200ms                           | **CONDITIONAL** — investiga bottleneck pre-commit                 |
+| p95 > 200ms                                   | **ABORT** Godot decision pre Sprint N.3-N.6 (-3-4 sett risparmio) |
+| UI scale broken su 320px                      | **ABORT** anche se latency OK                                     |
+| Virtual keyboard occludes critical chat input | **ABORT** o re-design composer                                    |
+
+## 5. Test environment
+
+- **Backend**: `npm run start:api` su Windows dev machine + ngrok tunnel pubblico
+- **Client iOS**: Safari mobile real device (iPhone, iOS 17+)
+- **Client Android**: Chrome mobile real device (Android 12+)
+- **Godot HTML5**: export deployable via static server (es. `python -m http.server` o GitHub Pages preview)
+- **Network**: WiFi + LTE 4G separato (2 sample set)
+
+## 6. Output binary
+
+Go/no-go signal Sprint N.3-N.6 commitment:
+
+- **GO** → Godot phone composer V2 portable Control nodes confirmed → Sprint R port plan valido
+- **NO-GO** → revert Godot decision, mantieni web v1 stack canvas, re-evaluate Sprint R scope
+
+Output documentato qui post-spike: tabella p95 misurato + screenshot UI 320px + pass/fail flag per ciascuna condizione §4.
+
+## 7. References
+
+- **DioField source**: F1 §"DioField" + F2 line 97 in [`docs/research/2026-04-28-deep-research-synthesis.md`](2026-04-28-deep-research-synthesis.md)
+- **ADR Action 4**: [`docs/adr/ADR-2026-04-28-deep-research-actions.md`](../adr/ADR-2026-04-28-deep-research-actions.md) §Action 4 — Sprint M.7 re-frame DioField command-latency p95
+- **Master plan §M.7**: [`docs/planning/2026-04-28-master-execution-plan.md`](../planning/2026-04-28-master-execution-plan.md) §M.7 — Phone composer Godot HTML5 spike
+- **Backend WS**: `apps/backend/services/lobby/` (LobbyService + Room)
+- **Web v1 client**: `apps/play/`


### PR DESCRIPTION
## Summary

Action 4 doc-only re-frame ($\sim$30min). Re-cast existing Sprint M.7 phone composer Godot HTML5 spike `<100ms latency` generic cap come **DioField command-latency p95 round-trip** (button press → WS → Express WS receive → state update → echo back → Godot HTML5 client render).

- **Master plan §M.7**: chain esplicita misurata + baseline web v1 first (riusa `apps/backend/services/lobby/`) + soglia abort `p95 > 200ms`
- **NEW research doc** `docs/research/2026-04-28-godot-phone-composer-spike.md` placeholder 7 sezioni (scope/metrica/baseline/threshold/env/output/refs) — status draft pending Sprint M.7 execution
- **Registry**: nuova entry research doc

## Rationale

Re-frame existing spike = 0h coding cost + 30min doc work. Maximize value Sprint M.7 spike measurement output (validates phone composer command latency standard industria DioField NOT generic touch latency).

## Source

- F1 §"DioField" + F2 line 97 in `docs/research/2026-04-28-deep-research-synthesis.md`
- ADR canonical [`ADR-2026-04-28-deep-research-actions.md`](docs/adr/ADR-2026-04-28-deep-research-actions.md) §Action 4

## DoD

- [x] `npx prettier --check docs/` verde sui file toccati
- [x] `python tools/check_docs_governance.py --strict` errors=0 warnings=20 (baseline preservato)
- [x] Cross-ref ADR §Action 4 → research doc valido
- [x] Doc registry row aggiunta
- [x] Commit lowercase prefix
- [x] NO code change (zero apps/, zero tests/)
- [x] NO scope creep oltre Action 4

## Test plan

- [ ] Master plan §M.7 link to research doc renderizza
- [ ] Research doc frontmatter parsato correttamente da `tools/check_docs_governance.py`
- [ ] CI docs-governance verde

## Rollback

Revert single commit. Zero runtime impact (doc-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)