### PR TITLE
feat(p6): Action 5 BB hardening — injury severity 3-tier + slow_down trigger

### DIFF
--- a/apps/backend/services/combat/statusModifiers.js
+++ b/apps/backend/services/combat/statusModifiers.js
@@ -31,6 +31,29 @@
 
 'use strict';
 
+// Action 5a (2026-04-29) — wounded_perma severity 3-tier attack_mod scaling.
+// Battle Brothers attrition pattern: ferita compromettente compromette accuracy.
+// Mapping integer (attack_mod e' integer scale d20 — 1 step ~5-7% hit chance):
+//   light  → 0   (graffio leggero, default backward-compat — NO regression)
+//   medium → -1  (~ -5/-15% intent ADR §Action 5a)
+//   severe → -2  (~ -30% intent: ferita grave compromesso totale)
+// Default `light` se field assente in unit.status.wounded_perma.
+const WOUNDED_PERMA_ATTACK_PENALTY = Object.freeze({
+  light: 0,
+  medium: -1,
+  severe: -2,
+});
+
+// Action 5b (2026-04-29) — bleeding/fracture severity 3-tier slow_down trigger.
+// User verdetto Q2 2026-04-28: `minor` NO trigger (graffio leggero neutral, NO
+// double-penalty oltre HP drain). `medium` + `major` SI trigger.
+// Convention: unit.status.bleeding_severity / fracture_severity ∈ enum.
+const BLEEDING_FRACTURE_SLOW_DOWN_THRESHOLD = Object.freeze({
+  minor: false, // NO trigger — graffio neutral
+  medium: true, // trigger — ferita compromettente
+  major: true, // trigger — ferita grave totale
+});
+
 function manhattanDistance(a, b) {
   if (!a || !b) return Infinity;
   return Math.abs(Number(a.x) - Number(b.x)) + Math.abs(Number(a.y) - Number(b.y));
@@ -38,6 +61,67 @@ function manhattanDistance(a, b) {
 
 function isPositive(value) {
   return Number(value) > 0;
+}
+
+function normalizeWoundedSeverity(value) {
+  const s = String(value || '').toLowerCase();
+  return s in WOUNDED_PERMA_ATTACK_PENALTY ? s : 'light';
+}
+
+function normalizeBleedingFractureSeverity(value) {
+  const s = String(value || '').toLowerCase();
+  return s in BLEEDING_FRACTURE_SLOW_DOWN_THRESHOLD ? s : 'minor';
+}
+
+/**
+ * Action 5a — read wounded_perma severity off unit.status (object map shape:
+ * { hp_penalty, stacks, severity }) and return integer attack_mod penalty.
+ * Returns 0 if no wound active OR severity unknown (defaults light → 0).
+ *
+ * @param {object} unit
+ * @returns {{ penalty: number, severity: string, active: boolean }}
+ */
+function computeWoundedPermaAttackPenalty(unit) {
+  const status = (unit && unit.status) || {};
+  const wp = status.wounded_perma;
+  if (!wp || typeof wp !== 'object') {
+    return { penalty: 0, severity: 'light', active: false };
+  }
+  const severity = normalizeWoundedSeverity(wp.severity);
+  const penalty = WOUNDED_PERMA_ATTACK_PENALTY[severity] || 0;
+  return { penalty, severity, active: true };
+}
+
+/**
+ * Action 5b — slow_down trigger when ANY of: panic > 0, confused > 0,
+ * bleeding ≥ medium severity, fracture ≥ medium severity. Returns
+ * action_speed reduction amount (1 = "1 tier slower", 0 = no penalty).
+ *
+ * Reads unit.status object-map shape (panic/confused/bleeding/fracture =
+ * turns remaining N; bleeding_severity/fracture_severity = enum string).
+ * Default severity `minor` se field absent (NO trigger — backward-compat).
+ *
+ * @param {object} unit
+ * @returns {{ amount: number, triggers: string[] }}
+ */
+function computeSlowDownPenalty(unit) {
+  const status = (unit && unit.status) || {};
+  const triggers = [];
+  if (isPositive(status.panic)) triggers.push('panic');
+  if (isPositive(status.confused)) triggers.push('confused');
+  if (isPositive(status.bleeding)) {
+    const sev = normalizeBleedingFractureSeverity(status.bleeding_severity);
+    if (BLEEDING_FRACTURE_SLOW_DOWN_THRESHOLD[sev]) {
+      triggers.push(`bleeding:${sev}`);
+    }
+  }
+  if (isPositive(status.fracture)) {
+    const sev = normalizeBleedingFractureSeverity(status.fracture_severity);
+    if (BLEEDING_FRACTURE_SLOW_DOWN_THRESHOLD[sev]) {
+      triggers.push(`fracture:${sev}`);
+    }
+  }
+  return { amount: triggers.length > 0 ? 1 : 0, triggers };
 }
 
 /**
@@ -102,7 +186,44 @@ function computeStatusModifiers(actor, target, units = []) {
     log.push({ status: 'frenzy', side: 'target', effect: '-1 defense_mod (rage exposure)' });
   }
 
-  return { attackDelta, defenseDelta, log };
+  // ─── Action 5a — wounded_perma severity → actor attack_mod penalty ────
+  const wpActor = computeWoundedPermaAttackPenalty(actor);
+  if (wpActor.active && wpActor.penalty !== 0) {
+    attackDelta += wpActor.penalty;
+    log.push({
+      status: 'wounded_perma',
+      side: 'actor',
+      effect: `${wpActor.penalty >= 0 ? '+' : ''}${wpActor.penalty} attack_mod (severity: ${wpActor.severity})`,
+    });
+  }
+
+  // ─── Action 5b — slow_down trigger flags (consumed by roundOrchestrator) ─
+  const actorSlow = computeSlowDownPenalty(actor);
+  const targetSlow = computeSlowDownPenalty(target);
+  if (actorSlow.amount > 0) {
+    log.push({
+      status: 'slow_down',
+      side: 'actor',
+      effect: `-1 action_speed tier (${actorSlow.triggers.join(',')})`,
+    });
+  }
+  if (targetSlow.amount > 0) {
+    log.push({
+      status: 'slow_down',
+      side: 'target',
+      effect: `-1 action_speed tier (${targetSlow.triggers.join(',')})`,
+    });
+  }
+
+  return {
+    attackDelta,
+    defenseDelta,
+    actorSlowDown: actorSlow.amount > 0,
+    targetSlowDown: targetSlow.amount > 0,
+    actorSlowDownTriggers: actorSlow.triggers,
+    targetSlowDownTriggers: targetSlow.triggers,
+    log,
+  };
 }
 
 /**
@@ -139,6 +260,10 @@ function applyTurnRegen(unit) {
 module.exports = {
   computeStatusModifiers,
   applyTurnRegen,
+  computeWoundedPermaAttackPenalty,
+  computeSlowDownPenalty,
   // Exported for tests
   manhattanDistance,
+  WOUNDED_PERMA_ATTACK_PENALTY,
+  BLEEDING_FRACTURE_SLOW_DOWN_THRESHOLD,
 };

--- a/apps/backend/services/combat/woundedPerma.js
+++ b/apps/backend/services/combat/woundedPerma.js
@@ -29,6 +29,17 @@
 const DEFAULT_HP_PENALTY = 1;
 const MAX_STACKS = 3;
 
+// Action 5a (2026-04-29) — injury severity 3-tier (Battle Brothers attrition).
+// Default 'light' backward-compat. Persisted in unit.status.wounded_perma.severity
+// + sessionMap entry. Letto da statusModifiers.js (attack_mod scaling).
+const SEVERITY_ENUM = ['light', 'medium', 'severe'];
+const DEFAULT_SEVERITY = 'light';
+
+function normalizeSeverity(value) {
+  const s = String(value || '').toLowerCase();
+  return SEVERITY_ENUM.includes(s) ? s : DEFAULT_SEVERITY;
+}
+
 /**
  * Initialize an empty session map. Idempotent: returns input map if already
  * an object. Caller stores this on session.lastMissionWoundedPerma.
@@ -57,12 +68,31 @@ function initSessionMap() {
  */
 function applyWound(unit, sessionMap, opts = {}) {
   if (!unit || typeof unit !== 'object' || !unit.id) {
-    return { applied: false, hp_penalty: 0, prior_max_hp: 0, stacks: 0 };
+    return {
+      applied: false,
+      hp_penalty: 0,
+      prior_max_hp: 0,
+      stacks: 0,
+      severity: DEFAULT_SEVERITY,
+    };
   }
   if (!sessionMap || typeof sessionMap !== 'object') {
-    return { applied: false, hp_penalty: 0, prior_max_hp: 0, stacks: 0 };
+    return {
+      applied: false,
+      hp_penalty: 0,
+      prior_max_hp: 0,
+      stacks: 0,
+      severity: DEFAULT_SEVERITY,
+    };
   }
   const requested = Math.max(1, Math.floor(Number(opts.hp_penalty) || DEFAULT_HP_PENALTY));
+  // Action 5a: severity opt-in. Only persisted in status/sessionMap when caller
+  // provides opts.severity (preserva shape pre-Action-5a se non specificato →
+  // back-compat strict per consumer che fanno deepEqual). Read site defaulta
+  // a 'light' se field assent (computeWoundedPermaAttackPenalty), stessa
+  // behavior dell'enum default.
+  const severityProvided = opts.severity !== undefined && opts.severity !== null;
+  const severity = severityProvided ? normalizeSeverity(opts.severity) : DEFAULT_SEVERITY;
   const prior = sessionMap[unit.id] || { hp_penalty: 0, stacks: 0 };
   const priorStacks = Math.max(0, Math.floor(Number(prior.stacks) || 0));
   if (priorStacks >= MAX_STACKS) {
@@ -72,6 +102,7 @@ function applyWound(unit, sessionMap, opts = {}) {
       hp_penalty: prior.hp_penalty || 0,
       prior_max_hp: Number(unit.max_hp || unit.hp || 0),
       stacks: priorStacks,
+      severity: normalizeSeverity(prior.severity),
     };
   }
   const prior_max_hp = Number(unit.max_hp || unit.hp || 0);
@@ -81,13 +112,19 @@ function applyWound(unit, sessionMap, opts = {}) {
   unit.max_hp = newMax;
   if (typeof unit.hp === 'number' && unit.hp > newMax) unit.hp = newMax;
   if (!unit.status || typeof unit.status !== 'object') unit.status = {};
-  unit.status.wounded_perma = { hp_penalty: newPenalty, stacks: newStacks };
-  sessionMap[unit.id] = {
+  const statusEntry = { hp_penalty: newPenalty, stacks: newStacks };
+  const sessionEntry = {
     hp_penalty: newPenalty,
     stacks: newStacks,
     applied_at: new Date().toISOString(),
   };
-  return { applied: true, hp_penalty: newPenalty, prior_max_hp, stacks: newStacks };
+  if (severityProvided || prior.severity !== undefined) {
+    statusEntry.severity = severity;
+    sessionEntry.severity = severity;
+  }
+  unit.status.wounded_perma = statusEntry;
+  sessionMap[unit.id] = sessionEntry;
+  return { applied: true, hp_penalty: newPenalty, prior_max_hp, stacks: newStacks, severity };
 }
 
 /**
@@ -101,34 +138,39 @@ function applyWound(unit, sessionMap, opts = {}) {
  */
 function restoreOnEncounterStart(unit, sessionMap) {
   if (!unit || typeof unit !== 'object' || !unit.id) {
-    return { restored: false, hp_penalty: 0, stacks: 0 };
+    return { restored: false, hp_penalty: 0, stacks: 0, severity: DEFAULT_SEVERITY };
   }
   if (!sessionMap || typeof sessionMap !== 'object') {
-    return { restored: false, hp_penalty: 0, stacks: 0 };
+    return { restored: false, hp_penalty: 0, stacks: 0, severity: DEFAULT_SEVERITY };
   }
   const entry = sessionMap[unit.id];
   if (!entry || !Number(entry.hp_penalty)) {
-    return { restored: false, hp_penalty: 0, stacks: 0 };
+    return { restored: false, hp_penalty: 0, stacks: 0, severity: DEFAULT_SEVERITY };
   }
   const penalty = Math.max(0, Math.floor(Number(entry.hp_penalty) || 0));
   const stacks = Math.max(0, Math.floor(Number(entry.stacks) || 0));
+  const hasSeverity = entry.severity !== undefined && entry.severity !== null;
+  const severity = hasSeverity ? normalizeSeverity(entry.severity) : DEFAULT_SEVERITY;
   if (!unit.status || typeof unit.status !== 'object') unit.status = {};
   const existing = unit.status.wounded_perma;
   if (
     existing &&
     typeof existing === 'object' &&
     Number(existing.hp_penalty) === penalty &&
-    Number(existing.stacks) === stacks
+    Number(existing.stacks) === stacks &&
+    (!hasSeverity || normalizeSeverity(existing.severity) === severity)
   ) {
     // Idempotent: already restored, no double penalty.
-    return { restored: false, hp_penalty: penalty, stacks };
+    return { restored: false, hp_penalty: penalty, stacks, severity };
   }
   const cur_max = Number(unit.max_hp || unit.hp || 0);
   const newMax = Math.max(1, cur_max - penalty);
   unit.max_hp = newMax;
   if (typeof unit.hp === 'number' && unit.hp > newMax) unit.hp = newMax;
-  unit.status.wounded_perma = { hp_penalty: penalty, stacks };
-  return { restored: true, hp_penalty: penalty, stacks };
+  const statusEntry = { hp_penalty: penalty, stacks };
+  if (hasSeverity) statusEntry.severity = severity;
+  unit.status.wounded_perma = statusEntry;
+  return { restored: true, hp_penalty: penalty, stacks, severity };
 }
 
 /**
@@ -140,16 +182,17 @@ function restoreOnEncounterStart(unit, sessionMap) {
  */
 function getActorState(unit, sessionMap) {
   if (!unit || typeof unit !== 'object' || !unit.id) {
-    return { wounded: false, hp_penalty: 0, stacks: 0 };
+    return { wounded: false, hp_penalty: 0, stacks: 0, severity: DEFAULT_SEVERITY };
   }
   if (!sessionMap || typeof sessionMap !== 'object') {
-    return { wounded: false, hp_penalty: 0, stacks: 0 };
+    return { wounded: false, hp_penalty: 0, stacks: 0, severity: DEFAULT_SEVERITY };
   }
   const entry = sessionMap[unit.id];
-  if (!entry) return { wounded: false, hp_penalty: 0, stacks: 0 };
+  if (!entry) return { wounded: false, hp_penalty: 0, stacks: 0, severity: DEFAULT_SEVERITY };
   const penalty = Math.max(0, Math.floor(Number(entry.hp_penalty) || 0));
   const stacks = Math.max(0, Math.floor(Number(entry.stacks) || 0));
-  return { wounded: penalty > 0, hp_penalty: penalty, stacks };
+  const severity = normalizeSeverity(entry.severity);
+  return { wounded: penalty > 0, hp_penalty: penalty, stacks, severity };
 }
 
 /**
@@ -171,6 +214,9 @@ module.exports = {
   restoreOnEncounterStart,
   getActorState,
   clearSession,
+  normalizeSeverity,
   DEFAULT_HP_PENALTY,
   MAX_STACKS,
+  SEVERITY_ENUM,
+  DEFAULT_SEVERITY,
 };

--- a/apps/backend/services/roundOrchestrator.js
+++ b/apps/backend/services/roundOrchestrator.js
@@ -243,12 +243,19 @@ function actionSpeed(action, table = DEFAULT_ACTION_SPEED) {
 }
 
 /**
- * priority = unit.initiative + action_speed - status_penalty
+ * priority = unit.initiative + action_speed - status_penalty - slow_down
  *
- * Status penalty:
+ * Status penalty (legacy `unit.statuses` array shape):
  *   - panic:     -2 per intensity
  *   - disorient: -1 per intensity
  *   - rage / focused / stunned: no penalty here (gestiti altrove)
+ *
+ * Action 5b (2026-04-29) — slow_down trigger (object-map shape `unit.status`):
+ *   - panic > 0 OR confused > 0 → -1
+ *   - bleeding ≥ medium severity → -1
+ *   - fracture ≥ medium severity → -1
+ *   Trigger combinati NON cumulano (cap -1, "1 tier slower" canonical).
+ *   Letto da statusModifiers.computeSlowDownPenalty (lazy require).
  */
 function computeResolvePriority(unit, action, speedTable = DEFAULT_ACTION_SPEED) {
   const base = Number((unit && unit.initiative) || 0);
@@ -261,6 +268,17 @@ function computeResolvePriority(unit, action, speedTable = DEFAULT_ACTION_SPEED)
     if (s.id === 'panic') penalty += intensity * 2;
     else if (s.id === 'disorient') penalty += intensity;
   }
+  // Action 5b — slow_down (object-map status shape). Lazy require evita cycle.
+  let slowDown = 0;
+  if (unit && unit.status && typeof unit.status === 'object') {
+    try {
+      const { computeSlowDownPenalty } = require('./combat/statusModifiers');
+      slowDown = Number(computeSlowDownPenalty(unit).amount) || 0;
+    } catch {
+      slowDown = 0;
+    }
+  }
+  penalty += slowDown;
   // Sprint Spore Moderate (ADR-2026-04-26 §S6) — archetype ambush_plus init+2
   // se action.is_critical OR action.is_flank. Lazy require evita cycle import
   // cross-module; back-compat: zero delta quando passive assente o trigger

--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -122,6 +122,20 @@ traits:
   # SPRINT_019: status fisici (Sanguinamento + Frattura), dal design doc
   # docs/core/10-SISTEMA_TATTICO.md linea 18. Si innestano sul sistema
   # status di sprint-013 + trait pipeline di sprint-018.
+  #
+  # Action 5b (2026-04-29) — severity 3-tier per bleeding + fracture.
+  # Convention shape:
+  #   unit.status.bleeding          = N (turns remaining, esistente)
+  #   unit.status.bleeding_severity = 'minor' | 'medium' | 'major'   (NEW)
+  #   unit.status.fracture          = N (turns remaining, esistente)
+  #   unit.status.fracture_severity = 'minor' | 'medium' | 'major'   (NEW)
+  #
+  # Default `minor` se field assente (backward-compat: graffio leggero =
+  # neutral, NO double-penalty oltre HP drain). Solo `medium`/`major`
+  # triggerano `slow_down` (action_speed -1) in computeSlowDownPenalty
+  # (apps/backend/services/combat/statusModifiers.js).
+  # User verdetto Q2 2026-04-28: minor NO trigger, major SI trigger.
+  # Spec ref: docs/adr/ADR-2026-04-28-deep-research-actions.md §Action 5b.
 
   denti_seghettati:
     tier: T1
@@ -9552,10 +9566,22 @@ traits:
   #
   # Trigger entry "marker_only": evaluator skip silently (no trigger.action_type),
   # serve solo come dichiarazione formale del status type per glossary/lint.
+  # Action 5a (2026-04-29) — injury severity stack 3-tier (Battle Brothers
+  # attrition pattern). `unit.status.wounded_perma.severity` ∈ enum:
+  #   light  → -0 attack_mod (graffio leggero, default backward-compat)
+  #   medium → -1 attack_mod (ferita compromettente)
+  #   severe → -2 attack_mod (ferita grave, "compromesso totale")
+  # Default `light` se field assente (NO surprise difficulty regression).
+  # Letta runtime da apps/backend/services/combat/statusModifiers.js
+  # (computeStatusModifiers — actor-side debuff). Persistenza cross-encounter
+  # via session.lastMissionWoundedPerma map (woundedPerma.applyWound opts.severity).
+  # Spec ref: docs/adr/ADR-2026-04-28-deep-research-actions.md §Action 5a.
   wounded_perma:
     tier: T1
     category: persistente
     applies_to: target
+    severity_enum: [light, medium, severe]
+    severity_default: light
     trigger:
       action_type: marker_only
     effect:
@@ -9568,3 +9594,5 @@ traits:
       runtime via woundedPerma.js quando l'attore protagonista subisce KO in
       encounter con loss_conditions.player_wipe attivo. Cross-encounter via
       session.lastMissionWoundedPerma map (riapplica HP penalty allo start).
+      Severity 3-tier (Action 5a 2026-04-29): light/medium/severe → attack_mod
+      penalty 0/-1/-2 letto da statusModifiers.js. Default `light` backward-compat.

--- a/tests/services/statusModifiers.test.js
+++ b/tests/services/statusModifiers.test.js
@@ -16,6 +16,8 @@ const assert = require('node:assert/strict');
 const {
   computeStatusModifiers,
   applyTurnRegen,
+  computeWoundedPermaAttackPenalty,
+  computeSlowDownPenalty,
   manhattanDistance,
 } = require('../../apps/backend/services/combat/statusModifiers');
 
@@ -119,4 +121,168 @@ test('applyTurnRegen: status not active (0 turns) → no regen', () => {
 
 test('manhattanDistance basic', () => {
   assert.equal(manhattanDistance({ x: 0, y: 0 }, { x: 3, y: 4 }), 7);
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Action 5a — wounded_perma severity 3-tier attack_mod scaling
+// ──────────────────────────────────────────────────────────────────────
+
+test('Action 5a: wounded_perma severity light → 0 attack_mod (backward-compat)', () => {
+  const unit = {
+    id: 'a',
+    status: { wounded_perma: { hp_penalty: 1, stacks: 1, severity: 'light' } },
+  };
+  const r = computeWoundedPermaAttackPenalty(unit);
+  assert.equal(r.penalty, 0);
+  assert.equal(r.severity, 'light');
+  assert.equal(r.active, true);
+});
+
+test('Action 5a: wounded_perma severity medium → -1 attack_mod', () => {
+  const unit = {
+    id: 'a',
+    status: { wounded_perma: { hp_penalty: 2, stacks: 2, severity: 'medium' } },
+  };
+  const r = computeWoundedPermaAttackPenalty(unit);
+  assert.equal(r.penalty, -1);
+  assert.equal(r.severity, 'medium');
+});
+
+test('Action 5a: wounded_perma severity severe → -2 attack_mod', () => {
+  const unit = {
+    id: 'a',
+    status: { wounded_perma: { hp_penalty: 3, stacks: 3, severity: 'severe' } },
+  };
+  const r = computeWoundedPermaAttackPenalty(unit);
+  assert.equal(r.penalty, -2);
+  assert.equal(r.severity, 'severe');
+});
+
+test('Action 5a: wounded_perma absent severity field → default light (NO regression)', () => {
+  // Backward-compat: pre-Action-5a wounded_perma instances had no `severity` field.
+  // Expectation: behaves as `light` → 0 penalty (zero surprise difficulty regression).
+  const unit = { id: 'a', status: { wounded_perma: { hp_penalty: 1, stacks: 1 } } };
+  const r = computeWoundedPermaAttackPenalty(unit);
+  assert.equal(r.penalty, 0);
+  assert.equal(r.severity, 'light');
+  assert.equal(r.active, true);
+});
+
+test('Action 5a: wounded_perma absent → no penalty + active=false', () => {
+  const unit = { id: 'a', status: {} };
+  const r = computeWoundedPermaAttackPenalty(unit);
+  assert.equal(r.penalty, 0);
+  assert.equal(r.active, false);
+});
+
+test('Action 5a: computeStatusModifiers wires wounded_perma medium into attackDelta', () => {
+  const actor = {
+    id: 'a',
+    status: { wounded_perma: { hp_penalty: 2, stacks: 2, severity: 'medium' } },
+  };
+  const target = { id: 'b', status: {} };
+  const r = computeStatusModifiers(actor, target, []);
+  assert.equal(r.attackDelta, -1);
+  assert.ok(r.log.some((e) => e.status === 'wounded_perma' && e.side === 'actor'));
+});
+
+test('Action 5a: computeStatusModifiers severe stacks with linked actor (-2 + +1 ally = -1)', () => {
+  const actor = {
+    id: 'a',
+    controlled_by: 'player',
+    position: { x: 0, y: 0 },
+    status: { linked: 2, wounded_perma: { hp_penalty: 3, stacks: 3, severity: 'severe' } },
+  };
+  const ally = { id: 'b', controlled_by: 'player', position: { x: 1, y: 0 }, hp: 5 };
+  const target = { id: 'enemy', controlled_by: 'sistema', status: {} };
+  const r = computeStatusModifiers(actor, target, [actor, ally, target]);
+  // linked +1 + wounded_perma severe -2 = -1 net
+  assert.equal(r.attackDelta, -1);
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Action 5b — slow_down trigger (panic / confused / bleeding≥medium / fracture≥medium)
+// ──────────────────────────────────────────────────────────────────────
+
+test('Action 5b: panic > 0 → slow_down trigger (-1 action_speed)', () => {
+  const unit = { id: 'a', status: { panic: 2 } };
+  const r = computeSlowDownPenalty(unit);
+  assert.equal(r.amount, 1);
+  assert.ok(r.triggers.includes('panic'));
+});
+
+test('Action 5b: confused > 0 → slow_down trigger', () => {
+  const unit = { id: 'a', status: { confused: 1 } };
+  const r = computeSlowDownPenalty(unit);
+  assert.equal(r.amount, 1);
+  assert.ok(r.triggers.includes('confused'));
+});
+
+test('Action 5b: bleeding medium severity → slow_down trigger', () => {
+  const unit = { id: 'a', status: { bleeding: 2, bleeding_severity: 'medium' } };
+  const r = computeSlowDownPenalty(unit);
+  assert.equal(r.amount, 1);
+  assert.ok(r.triggers.some((t) => t.startsWith('bleeding:medium')));
+});
+
+test('Action 5b: bleeding minor severity → NO trigger (graffio neutral)', () => {
+  const unit = { id: 'a', status: { bleeding: 2, bleeding_severity: 'minor' } };
+  const r = computeSlowDownPenalty(unit);
+  assert.equal(r.amount, 0);
+  assert.equal(r.triggers.length, 0);
+});
+
+test('Action 5b: bleeding major severity → slow_down trigger', () => {
+  const unit = { id: 'a', status: { bleeding: 3, bleeding_severity: 'major' } };
+  const r = computeSlowDownPenalty(unit);
+  assert.equal(r.amount, 1);
+  assert.ok(r.triggers.some((t) => t.startsWith('bleeding:major')));
+});
+
+test('Action 5b: fracture medium severity → slow_down trigger', () => {
+  const unit = { id: 'a', status: { fracture: 2, fracture_severity: 'medium' } };
+  const r = computeSlowDownPenalty(unit);
+  assert.equal(r.amount, 1);
+  assert.ok(r.triggers.some((t) => t.startsWith('fracture:medium')));
+});
+
+// Backward-compat: 2 test (bleeding senza severity = default minor NO trigger /
+// fracture senza severity = default minor NO trigger).
+
+test('Action 5b backward-compat: bleeding senza severity field → default minor, NO trigger', () => {
+  const unit = { id: 'a', status: { bleeding: 2 } };
+  const r = computeSlowDownPenalty(unit);
+  assert.equal(r.amount, 0);
+});
+
+test('Action 5b backward-compat: fracture senza severity field → default minor, NO trigger', () => {
+  const unit = { id: 'a', status: { fracture: 2 } };
+  const r = computeSlowDownPenalty(unit);
+  assert.equal(r.amount, 0);
+});
+
+test('Action 5b: combined panic + confused + bleeding-medium → cap a 1 tier (no stack)', () => {
+  // Spec: trigger combinati NON cumulano. Cap -1 ("1 tier slower" canonical).
+  const unit = {
+    id: 'a',
+    status: { panic: 1, confused: 1, bleeding: 2, bleeding_severity: 'medium' },
+  };
+  const r = computeSlowDownPenalty(unit);
+  assert.equal(r.amount, 1);
+  assert.ok(r.triggers.length >= 3);
+});
+
+test('Action 5b: clean unit → no trigger', () => {
+  const unit = { id: 'a', status: {} };
+  const r = computeSlowDownPenalty(unit);
+  assert.equal(r.amount, 0);
+});
+
+test('Action 5b: computeStatusModifiers exports actorSlowDown flag + log entry', () => {
+  const actor = { id: 'a', status: { panic: 1 } };
+  const target = { id: 'b', status: {} };
+  const r = computeStatusModifiers(actor, target, []);
+  assert.equal(r.actorSlowDown, true);
+  assert.equal(r.targetSlowDown, false);
+  assert.ok(r.log.some((e) => e.status === 'slow_down' && e.side === 'actor'));
 });


### PR DESCRIPTION
## Summary

Action 5a + 5b da [ADR-2026-04-28](docs/adr/ADR-2026-04-28-deep-research-actions.md) §Action 5 (Battle Brothers hardening pre Sprint G v3). Chiude P6 🟡 → 🟢 candidato pre-asset swap.

- **Action 5a — Injury severity stack** (~3h): `wounded_perma.severity` enum `light|medium|severe` → attack_mod penalty `0/-1/-2`. Default `light` backward-compat (zero regression).
- **Action 5b — Slow_down trigger expanded** (~2.5h): action_speed -1 tier su `panic`, `confused`, `bleeding ≥ medium`, `fracture ≥ medium`. Default severity `minor` backward-compat (NO trigger — preserva graffio leggero neutral).

## Scope

| File | Change |
|---|---|
| `data/core/traits/active_effects.yaml` | Doc enum severity per `wounded_perma` (severity_enum, severity_default) + comment block convention `bleeding_severity` / `fracture_severity` |
| `apps/backend/services/combat/woundedPerma.js` | `applyWound` accept `opts.severity`, persist in status + sessionMap. Severity opt-in (preserva shape pre-Action-5a strict back-compat) |
| `apps/backend/services/combat/statusModifiers.js` | `computeWoundedPermaAttackPenalty` + `computeSlowDownPenalty` helpers. Output `actorSlowDown` / `targetSlowDown` flags + log entries |
| `apps/backend/services/roundOrchestrator.js` | `computeResolvePriority` consume `computeSlowDownPenalty` (lazy require, NO cycle) |
| `tests/services/statusModifiers.test.js` | +18 test (7 Action 5a + 11 Action 5b) |

## Test plan

- [x] `node --test tests/services/statusModifiers.test.js` → 31/31 verde
- [x] `node --test tests/ai/*.test.js` → **382/382 verde zero regression**
- [x] `node --test tests/services/woundedPerma.test.js tests/services/roundOrchestrator*.test.js tests/services/statusModifiers.test.js tests/ai/*.test.js` → **455/455 verde**
- [x] `npx prettier --check` su file modificati → verde
- [x] `npm run schema:lint` → verde (9 schemi OK)
- [x] `python tools/check_docs_governance.py --strict` → errors=0
- [x] Diff review — scope localized, NO file fuori scope (no encounter YAML / session.js / render.js / migrations / contracts)

## Rationale lato gamer

**Pre-action**: `wounded_perma` binario flat penalty. `bleeding`/`fracture` zero rallentamento.

**Post-action**: 3 livelli di gravità (graffio/medio/grave). Ferito grave + panicked = creatura compromessa totale (Battle Brothers attrition feel). Death spiral leggibile.

**User verdetto 2026-04-28** (ADR-2026-04-28 §Action 5):
- Q1 — enum string NOT numeric (leggibile playtest debug) + default `light` backward-compat
- Q2 — minor NO trigger (preserva neutral, NO double-penalty oltre HP drain). Major SÌ trigger.

## Pillar impact

| | Pre | Post |
|---|---|---|
| **P6 Fairness** | 🟡 (hardcore-iter7 stalemate residue + status engine wave A) | 🟢 candidato (BB attrition pattern hardening) |

## DoD checklist

- [x] Smoke test: `node --test tests/services/statusModifiers.test.js` verde
- [x] Regression: `node --test tests/ai/*.test.js` 382/382 verde
- [x] Format: `npx prettier --check` verde
- [x] Schema lint: verde
- [x] Diff review: solo file dichiarati, NO scope leak
- [x] Governance: errors=0
- [x] Commit lowercase prefix
- [x] PR title <70 char + body con scope/test/DoD/ADR ref

## Pre-condition

Branch: `feat/action-5-bb-hardening-2026-04-29` da `origin/main` HEAD `16fdebb7` (PR #1996 deep research synthesis).

## Out of scope

- NO Action 7 CT bar lookahead (separato branch post Sprint G v3)
- NO encounter YAML severity wiring (downstream — encounter scripts/abilities settano severity esplicito)
- NO Sprint G v3 asset swap (next dopo questa PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)