### PR TITLE
feat(p2+p5): action 6 — ambition seed skiv-pulverator alleanza (bond/fame gate)

### DIFF
--- a/apps/backend/routes/campaign.js
+++ b/apps/backend/routes/campaign.js
@@ -36,6 +36,13 @@ const {
   resolveOnboardingTrait,
 } = require('../services/campaign/campaignLoader');
 const { summariseCampaign } = require('../services/campaign/campaignEngine');
+const {
+  loadAmbition,
+  progressAmbition,
+  evaluateChoiceRitual,
+  getActiveAmbitions,
+  seedAmbition,
+} = require('../services/campaign/ambitionService');
 const { grantXpToSurvivors } = require('../services/progression/progressionApply');
 const { loadXpCurve } = require('../services/progression/progressionLoader');
 
@@ -466,6 +473,60 @@ function createCampaignRouter(options = {}) {
       completionPct: final_state === 'completed' ? 1.0 : campaign.completionPct,
     });
     return res.json({ campaign: updated });
+  });
+
+  // Action 6 (ADR-2026-04-28 §Action 6) — Ambition routes.
+  // Long-arc campaign goal layer SOPRA session resolver. NO inline session.js edit.
+
+  // GET /api/campaign/ambitions/active
+  // Query: ?session_id=<sid>
+  // Returns: { ambitions: [{ ambition_id, title_it, progress, progress_target, ... }] }
+  router.get('/campaign/ambitions/active', (req, res) => {
+    const sessionId = String(req.query?.session_id || '');
+    if (!sessionId) return res.status(400).json({ error: 'session_id richiesto (query)' });
+    const ambitions = getActiveAmbitions(sessionId);
+    return res.json({ ambitions });
+  });
+
+  // POST /api/campaign/ambitions/:id/seed
+  // Body: { session_id }
+  // Idempotent — initialize progress entry per session.
+  router.post('/campaign/ambitions/:id/seed', (req, res) => {
+    const ambitionId = String(req.params?.id || '');
+    const { session_id } = req.body || {};
+    if (!session_id) return res.status(400).json({ error: 'session_id richiesto' });
+    const ambition = loadAmbition(ambitionId);
+    if (!ambition) return res.status(404).json({ error: `ambition "${ambitionId}" non trovato` });
+    const entry = seedAmbition(session_id, ambitionId);
+    return res.json({ ambition_id: ambitionId, progress: entry });
+  });
+
+  // POST /api/campaign/ambitions/:id/progress
+  // Body: { session_id, encounter_id, outcome }
+  router.post('/campaign/ambitions/:id/progress', (req, res) => {
+    const ambitionId = String(req.params?.id || '');
+    const { session_id, encounter_id, outcome } = req.body || {};
+    if (!session_id) return res.status(400).json({ error: 'session_id richiesto' });
+    if (!encounter_id) return res.status(400).json({ error: 'encounter_id richiesto' });
+    const result = progressAmbition(session_id, ambitionId, { encounter_id, outcome });
+    if (result?.error) return res.status(404).json(result);
+    return res.json(result);
+  });
+
+  // POST /api/campaign/ambitions/:id/choice-ritual
+  // Body: { session_id, choice: 'fame_dominance'|'bond_proposal', bond_hearts? }
+  router.post('/campaign/ambitions/:id/choice-ritual', (req, res) => {
+    const ambitionId = String(req.params?.id || '');
+    const { session_id, choice, bond_hearts } = req.body || {};
+    if (!session_id) return res.status(400).json({ error: 'session_id richiesto' });
+    if (!['fame_dominance', 'bond_proposal'].includes(choice)) {
+      return res.status(400).json({ error: 'choice deve essere fame_dominance|bond_proposal' });
+    }
+    const result = evaluateChoiceRitual(session_id, ambitionId, choice, {
+      bond_hearts: Number(bond_hearts) || 0,
+    });
+    if (result?.error) return res.status(409).json(result);
+    return res.json(result);
   });
 
   return router;

--- a/apps/backend/services/campaign/ambitionService.js
+++ b/apps/backend/services/campaign/ambitionService.js
@@ -1,0 +1,296 @@
+// 2026-04-29 Action 6 (ADR-2026-04-28 §Action 6) — Ambition campaign service.
+//
+// Long-arc campaign goal layer. Coordina:
+//   - ambition definition (YAML) load + validate
+//   - progress tracking per (campaign|player) sessione
+//   - choice ritual evaluation (fame_path | bond_path) post threshold
+//   - narrative beat lookup
+//
+// Pure helpers (no I/O): evaluateProgress, evaluateChoiceRitual, formatAmbitionLabel.
+// Side-effect minimal: in-memory progress map keyed by sessionId+ambitionId.
+// NO direct Prisma — graceful in-memory MVP. Wire-through Prisma deferred.
+//
+// Reuse pattern:
+//   - bond_hearts gate threshold via campaign.bond_hearts (PR #1984)
+//   - lineage merge bond_path → caller invoke propagateLineage opt-in (PR #1918)
+//   - QBN beat trigger → caller advances narrative on outcome
+//
+// Test coverage: tests/services/ambitionService.test.js (10 test).
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const AMBITIONS_DIR = path.join(process.cwd(), 'data', 'core', 'campaign', 'ambitions');
+const NARRATIVE_BEATS_DIR = path.join(process.cwd(), 'data', 'core', 'narrative', 'beats');
+
+const _ambitionCache = new Map(); // ambitionId → parsed YAML
+const _beatsCache = new Map(); // beatsFile → parsed YAML
+
+// In-memory progress store. Keyed by `${sessionId}::${ambitionId}`.
+// Shape: { ambition_id, session_id, progress, completed, choice_made, last_event_at }
+const _progressStore = new Map();
+
+function _now() {
+  return new Date().toISOString();
+}
+
+function _key(sessionId, ambitionId) {
+  return `${sessionId}::${ambitionId}`;
+}
+
+/**
+ * Load ambition YAML by id. Cached.
+ *
+ * @param {string} ambitionId
+ * @param {string} [dir] override per test
+ * @returns {object|null}
+ */
+function loadAmbition(ambitionId, dir = AMBITIONS_DIR) {
+  if (!ambitionId || typeof ambitionId !== 'string') return null;
+  const cacheKey = `${dir}::${ambitionId}`;
+  if (_ambitionCache.has(cacheKey)) return _ambitionCache.get(cacheKey);
+
+  const filePath = path.join(dir, `${ambitionId}.yaml`);
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    const data = yaml.load(raw);
+    if (!data || typeof data !== 'object') return null;
+    if (!data.ambition_id || !data.progress_target) return null;
+    _ambitionCache.set(cacheKey, data);
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load narrative beats file. Returns map of beat_id → beat.
+ */
+function loadNarrativeBeats(beatsFile, dir = NARRATIVE_BEATS_DIR) {
+  if (!beatsFile) return new Map();
+  const cacheKey = `${dir}::${beatsFile}`;
+  if (_beatsCache.has(cacheKey)) return _beatsCache.get(cacheKey);
+
+  const filePath = path.join(dir, `${beatsFile}.yaml`);
+  if (!fs.existsSync(filePath)) return new Map();
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    const data = yaml.load(raw);
+    const beats = Array.isArray(data?.beats) ? data.beats : [];
+    const beatMap = new Map(beats.map((b) => [b.beat_id, b]));
+    _beatsCache.set(cacheKey, beatMap);
+    return beatMap;
+  } catch {
+    return new Map();
+  }
+}
+
+/**
+ * Init / get ambition progress entry for (sessionId, ambitionId).
+ * Lazy create con progress=0.
+ */
+function getProgress(sessionId, ambitionId) {
+  if (!sessionId || !ambitionId) return null;
+  const k = _key(sessionId, ambitionId);
+  if (_progressStore.has(k)) return _progressStore.get(k);
+  const entry = {
+    ambition_id: ambitionId,
+    session_id: sessionId,
+    progress: 0,
+    completed: false,
+    choice_made: null,
+    last_event_at: _now(),
+  };
+  _progressStore.set(k, entry);
+  return entry;
+}
+
+/**
+ * Increment ambition progress on encounter outcome.
+ * Pure-ish: muta entry in store, ritorna new entry.
+ *
+ * @param {string} sessionId
+ * @param {string} ambitionId
+ * @param {object} encounterEvent { encounter_id, outcome }
+ *   outcome: 'victory' | 'defeat' | 'timeout'
+ * @returns {object} updated progress entry + flags
+ *   { progress, completed, choice_ready, ambition }
+ */
+function progressAmbition(sessionId, ambitionId, encounterEvent) {
+  const ambition = loadAmbition(ambitionId);
+  if (!ambition) return { error: 'ambition_not_found', ambition_id: ambitionId };
+  const entry = getProgress(sessionId, ambitionId);
+  if (entry.completed) {
+    return {
+      progress: entry.progress,
+      completed: true,
+      choice_ready: false,
+      ambition,
+      already_completed: true,
+    };
+  }
+
+  const outcome = encounterEvent?.outcome;
+  const matches = (ambition.encounters_sequence || []).some(
+    (e) => e.encounter_id === encounterEvent?.encounter_id,
+  );
+  if (matches && outcome === 'victory') {
+    entry.progress = Math.min(ambition.progress_target, entry.progress + 1);
+    entry.last_event_at = _now();
+  }
+
+  const target = Number(ambition.progress_target) || 0;
+  const choiceReady = entry.progress >= target && !entry.choice_made;
+  return {
+    progress: entry.progress,
+    progress_target: target,
+    completed: entry.completed,
+    choice_ready: choiceReady,
+    choice_made: entry.choice_made,
+    ambition,
+  };
+}
+
+/**
+ * Evaluate choice ritual: fame_path | bond_path submission.
+ *
+ * Gate: bond_hearts >= choice_ritual.bond_hearts_threshold (default 3).
+ * Locked → returns { locked: true, locked_reason } senza mutare state.
+ *
+ * @param {string} sessionId
+ * @param {string} ambitionId
+ * @param {string} choice 'fame_dominance' | 'bond_proposal'
+ * @param {object} ctx { bond_hearts: number }
+ * @returns {object} outcome + narrative beat + side-effect flags
+ */
+function evaluateChoiceRitual(sessionId, ambitionId, choice, ctx = {}) {
+  const ambition = loadAmbition(ambitionId);
+  if (!ambition) return { error: 'ambition_not_found' };
+  const entry = getProgress(sessionId, ambitionId);
+
+  const target = Number(ambition.progress_target) || 0;
+  if (entry.progress < target) {
+    return { error: 'progress_incomplete', progress: entry.progress, progress_target: target };
+  }
+  if (entry.choice_made) {
+    return { error: 'choice_already_made', choice_made: entry.choice_made };
+  }
+
+  const ritual = ambition.choice_ritual || {};
+  const threshold = Number(ritual.bond_hearts_threshold ?? 3);
+  const bondHearts = Number(ctx.bond_hearts) || 0;
+  const paths = ritual.paths || {};
+
+  // Bond path requires bond_hearts >= threshold. Fame path always available.
+  const isBond = choice === 'bond_proposal';
+  if (isBond && bondHearts < threshold) {
+    // Surface locked beat for player feedback.
+    const beats = loadNarrativeBeats('skiv_pulverator_alliance');
+    const lockedBeat = beats.get('skiv_pulverator_choice_locked_low_bond') || null;
+    return {
+      locked: true,
+      locked_reason: 'bond_hearts_below_threshold',
+      bond_hearts: bondHearts,
+      bond_hearts_threshold: threshold,
+      narrative_beat: lockedBeat,
+    };
+  }
+
+  const pathDef = isBond ? paths.bond_path : paths.fame_path;
+  if (!pathDef) return { error: 'invalid_choice', choice };
+
+  const beats = loadNarrativeBeats('skiv_pulverator_alliance');
+  const beat = beats.get(pathDef.narrative_beat_id) || null;
+
+  // Lock state.
+  entry.choice_made = pathDef.key || choice;
+  entry.completed = true;
+  entry.last_event_at = _now();
+
+  return {
+    completed: true,
+    choice: entry.choice_made,
+    outcome: pathDef.outcome,
+    lineage_merge: !!pathDef.lineage_merge,
+    merge_lineage_on_bond: !!pathDef.merge_lineage_on_bond,
+    next_ambition_seed: pathDef.next_ambition_seed || null,
+    narrative_beat: beat,
+    bond_hearts: bondHearts,
+  };
+}
+
+/**
+ * Get active ambitions list for HUD display.
+ * Filtered: sessione corrente, non completed.
+ *
+ * @param {string} sessionId
+ * @returns {Array<object>} [{ ambition_id, title_it, progress, progress_target, ... }]
+ */
+function getActiveAmbitions(sessionId) {
+  if (!sessionId) return [];
+  const out = [];
+  for (const [, entry] of _progressStore) {
+    if (entry.session_id !== sessionId) continue;
+    if (entry.completed) continue;
+    const ambition = loadAmbition(entry.ambition_id);
+    if (!ambition) continue;
+    out.push({
+      ambition_id: entry.ambition_id,
+      title_it: ambition.title_it,
+      title_en: ambition.title_en,
+      campaign_goal: ambition.campaign_goal,
+      progress: entry.progress,
+      progress_target: Number(ambition.progress_target) || 0,
+      ui_overlay: ambition.ui_overlay || null,
+      choice_ready: entry.progress >= (Number(ambition.progress_target) || 0) && !entry.choice_made,
+    });
+  }
+  return out;
+}
+
+/**
+ * Pure helper — format ambition label per HUD.
+ * Replaces `{progress}` + `{progress_target}` placeholders.
+ */
+function formatAmbitionLabel(ambition, progress) {
+  if (!ambition) return '';
+  const fmt = ambition.ui_overlay?.format || '{progress}/{progress_target}';
+  const target = Number(ambition.progress_target) || 0;
+  return String(fmt)
+    .replace('{progress}', String(progress))
+    .replace('{progress_target}', String(target));
+}
+
+/**
+ * Seed ambition for a session (idempotent). Called typically on /start.
+ */
+function seedAmbition(sessionId, ambitionId) {
+  const ambition = loadAmbition(ambitionId);
+  if (!ambition) return null;
+  return getProgress(sessionId, ambitionId);
+}
+
+/** Test/internal hook — clear progress + cache. */
+function _resetState() {
+  _progressStore.clear();
+  _ambitionCache.clear();
+  _beatsCache.clear();
+}
+
+module.exports = {
+  loadAmbition,
+  loadNarrativeBeats,
+  getProgress,
+  progressAmbition,
+  evaluateChoiceRitual,
+  getActiveAmbitions,
+  formatAmbitionLabel,
+  seedAmbition,
+  _resetState,
+};

--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -44,6 +44,14 @@
           aria-live="polite"
           aria-label="Ordine prossimi turni"
         ></div>
+        <!-- Action 6 (ADR-2026-04-28 §Action 6): Ambition HUD strip — long-arc campaign goal. -->
+        <div
+          id="ambition-hud"
+          class="ambition-hud ambition-hidden"
+          role="status"
+          aria-live="polite"
+          aria-label="Obiettivi long-arc"
+        ></div>
         <div class="header-actions">
           <button id="fullscreen-toggle" class="hud-btn" title="Schermo intero — Alt+Enter">
             <svg

--- a/apps/play/src/ambitionChoicePanel.js
+++ b/apps/play/src/ambitionChoicePanel.js
@@ -1,0 +1,281 @@
+// Action 6 (ADR-2026-04-28 §Action 6) — Ambition choice ritual UI.
+//
+// Choice ritual modal: fame_dominance vs bond_proposal post defeat alpha
+// + bond_hearts threshold gate. Mirror pattern legacyRitualPanel.js (G4)
+// + thoughtsRitualPanel (G3) — overlay modale con 30s countdown timer +
+// irreversible session lock.
+//
+// Triggered when ambitionHud detects choice_ready=true.
+
+import { api } from './api.js';
+
+const STATE = {
+  overlayEl: null,
+  getSessionId: () => null,
+  getBondHearts: () => 0,
+  pickedThisSession: new Set(), // ambitionId set — once per ambition.
+  currentAmbitionId: null,
+  timerHandle: null,
+  countdownSec: 30,
+  onCompleteCallback: null,
+};
+
+function injectStyles() {
+  if (document.getElementById('ambition-choice-styles')) return;
+  const s = document.createElement('style');
+  s.id = 'ambition-choice-styles';
+  s.textContent = `
+    .ambition-choice-overlay {
+      position: fixed; inset: 0; z-index: 9995;
+      background: rgba(6, 4, 10, 0.86);
+      display: none; align-items: center; justify-content: center;
+      padding: 24px 16px;
+      font-family: Inter, system-ui, sans-serif; color: #e8eaf0;
+    }
+    .ambition-choice-overlay.visible { display: flex; }
+    .ambition-choice-card {
+      max-width: 600px; width: 100%; background: #100c14;
+      border: 1px solid #4a3520; border-radius: 14px; padding: 22px 24px;
+      box-shadow: 0 0 32px rgba(255, 198, 107, 0.18);
+    }
+    .ambition-choice-head {
+      display: flex; align-items: baseline; gap: 12px; margin-bottom: 6px;
+    }
+    .ambition-choice-head h2 { margin: 0; font-size: 1.3rem; color: #ffc66b; }
+    .ambition-choice-timer {
+      margin-left: auto; background: #0b0d12; border: 1px solid #4a3520;
+      border-radius: 999px; padding: 4px 12px; font-size: 0.85rem; color: #ffc66b;
+    }
+    .ambition-choice-subtitle {
+      color: #c8a78a; font-size: 0.92rem; margin-bottom: 16px;
+      font-style: italic; line-height: 1.5;
+    }
+    .ambition-choice-buttons {
+      display: flex; gap: 14px; margin-top: 14px;
+    }
+    .ambition-choice-btn {
+      flex: 1; padding: 14px 16px; border-radius: 10px;
+      font-size: 0.96rem; cursor: pointer;
+      transition: transform 120ms ease, background 120ms ease;
+      text-align: center;
+    }
+    .ambition-choice-btn:hover { transform: translateY(-1px); }
+    .ambition-choice-btn.disabled { opacity: 0.45; cursor: not-allowed; }
+    .ambition-choice-btn .label { font-weight: 600; margin-bottom: 4px; }
+    .ambition-choice-btn .hint { font-size: 0.78rem; opacity: 0.85; }
+    .choice-ritual-fame {
+      background: rgba(239, 68, 68, 0.12); color: #ef9a9a;
+      border: 1px solid #ef4444;
+    }
+    .choice-ritual-fame:hover { background: rgba(239, 68, 68, 0.2); }
+    .choice-ritual-bond {
+      background: rgba(74, 222, 128, 0.12); color: #4ade80;
+      border: 1px solid #4ade80;
+    }
+    .choice-ritual-bond:hover { background: rgba(74, 222, 128, 0.2); }
+    .ambition-choice-result {
+      margin-top: 14px; padding: 14px 16px;
+      background: rgba(255, 198, 107, 0.08);
+      border-left: 3px solid #ffc66b; border-radius: 4px;
+    }
+    .ambition-choice-result .voice-line {
+      font-style: italic; color: #ffc66b; line-height: 1.45; margin-bottom: 4px;
+    }
+    .ambition-choice-locked {
+      padding: 18px 14px; text-align: center; color: #ffc66b;
+      background: rgba(255, 198, 107, 0.08); border-radius: 8px;
+      font-size: 0.92rem;
+    }
+  `;
+  document.head.appendChild(s);
+}
+
+function escapeHtml(s) {
+  return String(s).replace(
+    /[&<>"']/g,
+    (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c],
+  );
+}
+
+function buildOverlay() {
+  if (STATE.overlayEl) return STATE.overlayEl;
+  injectStyles();
+  const wrap = document.createElement('div');
+  wrap.className = 'ambition-choice-overlay';
+  wrap.setAttribute('role', 'dialog');
+  wrap.setAttribute('aria-label', 'Rituale Scelta — Ambition');
+  wrap.innerHTML = `
+    <div class="ambition-choice-card" data-role="card">
+      <div class="ambition-choice-head">
+        <h2>🤝 Rituale della Scelta</h2>
+        <span class="ambition-choice-timer" data-role="timer">30s</span>
+      </div>
+      <div class="ambition-choice-subtitle" data-role="subtitle">—</div>
+      <div data-role="body"></div>
+    </div>
+  `;
+  document.body.appendChild(wrap);
+  STATE.overlayEl = wrap;
+  return wrap;
+}
+
+function clearTimer() {
+  if (STATE.timerHandle) {
+    clearInterval(STATE.timerHandle);
+    STATE.timerHandle = null;
+  }
+}
+
+function startCountdown(overlay, secs = 30) {
+  clearTimer();
+  STATE.countdownSec = secs;
+  const timerEl = overlay.querySelector('[data-role="timer"]');
+  if (timerEl) timerEl.textContent = `${secs}s`;
+  STATE.timerHandle = setInterval(() => {
+    STATE.countdownSec -= 1;
+    if (timerEl) timerEl.textContent = `${Math.max(0, STATE.countdownSec)}s`;
+    if (STATE.countdownSec <= 0) {
+      clearTimer();
+      // Auto-pick fame on timeout (default conservative).
+      submitChoice('fame_dominance');
+    }
+  }, 1000);
+}
+
+async function submitChoice(choice) {
+  const sid = STATE.getSessionId();
+  const ambitionId = STATE.currentAmbitionId;
+  if (!sid || !ambitionId) {
+    closeChoicePanel();
+    return;
+  }
+  clearTimer();
+
+  const overlay = STATE.overlayEl;
+  if (!overlay) return;
+  // Disable buttons.
+  overlay.querySelectorAll('.ambition-choice-btn').forEach((b) => {
+    b.classList.add('disabled');
+    b.setAttribute('disabled', 'true');
+  });
+
+  const bondHearts = Number(STATE.getBondHearts() || 0);
+  const res = await api.ambitionChoiceRitual(sid, ambitionId, choice, bondHearts);
+
+  const body = overlay.querySelector('[data-role="body"]');
+  if (!body) return;
+
+  if (res?.ok && res.data?.locked) {
+    const beat = res.data.narrative_beat || {};
+    body.innerHTML = `
+      <div class="ambition-choice-locked">
+        <div class="voice-line">${beat.voice_line_skiv ? '"' + escapeHtml(beat.voice_line_skiv) + '"' : '— silenzio —'}</div>
+        <div>Bond hearts: ${escapeHtml(String(res.data.bond_hearts))} / ${escapeHtml(String(res.data.bond_hearts_threshold))}.
+        Servono più legami prima del ritual bond.</div>
+        <div style="margin-top:10px;text-align:right">
+          <button class="ambition-choice-btn choice-ritual-fame" data-action="dismiss">Chiudi</button>
+        </div>
+      </div>
+    `;
+    body
+      .querySelector('button[data-action="dismiss"]')
+      ?.addEventListener('click', closeChoicePanel);
+    return;
+  }
+
+  if (res?.ok && res.data?.completed) {
+    const beat = res.data.narrative_beat || {};
+    STATE.pickedThisSession.add(ambitionId);
+    body.innerHTML = `
+      <div class="ambition-choice-result">
+        <div class="voice-line">${beat.voice_line_skiv ? '"' + escapeHtml(beat.voice_line_skiv) + '"' : '— silenzio —'}</div>
+        <div>Outcome: <strong>${escapeHtml(res.data.outcome || '—')}</strong></div>
+        <div style="margin-top:10px;text-align:right">
+          <button class="ambition-choice-btn choice-ritual-bond" data-action="dismiss">Lascia che il vento porti</button>
+        </div>
+      </div>
+    `;
+    body.querySelector('button[data-action="dismiss"]')?.addEventListener('click', () => {
+      if (typeof STATE.onCompleteCallback === 'function') {
+        try {
+          STATE.onCompleteCallback(res.data);
+        } catch {
+          /* noop */
+        }
+      }
+      closeChoicePanel();
+    });
+    return;
+  }
+
+  // Error fallback.
+  body.innerHTML = `
+    <div class="ambition-choice-locked">
+      ⚠ Il rituale ha vacillato: ${escapeHtml(res?.data?.error || 'errore sconosciuto')}.
+      <div style="margin-top:10px;text-align:right">
+        <button class="ambition-choice-btn choice-ritual-fame" data-action="dismiss">Chiudi</button>
+      </div>
+    </div>
+  `;
+  body.querySelector('button[data-action="dismiss"]')?.addEventListener('click', closeChoicePanel);
+}
+
+export function renderChoiceRitual(ambition) {
+  const overlay = buildOverlay();
+  const subtitle = overlay.querySelector('[data-role="subtitle"]');
+  const body = overlay.querySelector('[data-role="body"]');
+  if (subtitle) {
+    subtitle.textContent = ambition?.title_it || 'Rituale di Scelta';
+  }
+  if (!body) return;
+  body.innerHTML = `
+    <div class="ambition-choice-buttons">
+      <button class="ambition-choice-btn choice-ritual-fame" data-choice="fame_dominance">
+        <div class="label">⚔ Fame</div>
+        <div class="hint">Domina e disperdi. Sangue copre tracce.</div>
+      </button>
+      <button class="ambition-choice-btn choice-ritual-bond" data-choice="bond_proposal">
+        <div class="label">🤝 Bond</div>
+        <div class="hint">Proponi alleanza. Sabbia ricorda nuova forma.</div>
+      </button>
+    </div>
+  `;
+  body.querySelectorAll('button[data-choice]').forEach((btn) => {
+    btn.addEventListener('click', () => submitChoice(btn.getAttribute('data-choice')));
+  });
+}
+
+export function openChoicePanel(ambition, opts = {}) {
+  const sid = STATE.getSessionId();
+  if (!sid || !ambition) return;
+  if (STATE.pickedThisSession.has(ambition.ambition_id)) return;
+  STATE.currentAmbitionId = ambition.ambition_id;
+  STATE.onCompleteCallback = typeof opts.onComplete === 'function' ? opts.onComplete : null;
+  const overlay = buildOverlay();
+  overlay.classList.add('visible');
+  renderChoiceRitual(ambition);
+  startCountdown(overlay, Number(opts.countdownSec) || 30);
+}
+
+export function closeChoicePanel() {
+  clearTimer();
+  if (STATE.overlayEl) STATE.overlayEl.classList.remove('visible');
+  STATE.currentAmbitionId = null;
+}
+
+export function isChoiceLocked(ambitionId) {
+  return STATE.pickedThisSession.has(ambitionId);
+}
+
+export function _resetAmbitionChoiceState() {
+  clearTimer();
+  STATE.pickedThisSession.clear();
+  STATE.currentAmbitionId = null;
+  STATE.onCompleteCallback = null;
+  STATE.overlayEl = null;
+}
+
+export function initAmbitionChoicePanel(opts = {}) {
+  STATE.getSessionId = opts.getSessionId || STATE.getSessionId;
+  STATE.getBondHearts = opts.getBondHearts || STATE.getBondHearts;
+}

--- a/apps/play/src/ambitionHud.js
+++ b/apps/play/src/ambitionHud.js
@@ -1,0 +1,97 @@
+// Action 6 (ADR-2026-04-28 §Action 6) — Ambition HUD top-bar.
+//
+// Engine LIVE: apps/backend/services/campaign/ambitionService.js
+//   tracks long-arc campaign goal progress (progress/progress_target).
+// Surface: this strip in HUD next to ct-bar / biome-chip / objective-bar.
+//
+// Pattern mirror: biomeChip.js (pure helpers + side-effect render),
+// objectivePanel idempotent. Hide gracefully se ambitions empty.
+//
+// Pulse on progress increment: CSS class .ambition-pulse one-shot animation.
+// Choice ritual modal triggered separately by ambitionChoicePanel.js when
+// choice_ready=true.
+
+'use strict';
+
+function escapeHtml(s) {
+  return String(s).replace(
+    /[&<>"']/g,
+    (c) =>
+      ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+      })[c],
+  );
+}
+
+// Pure: ambition entry → HUD label string.
+// Format from ambition.ui_overlay.format placeholder substitution.
+export function formatAmbitionLabel(ambition) {
+  if (!ambition) return '';
+  const fmt = ambition.ui_overlay?.format || '🤝 {progress}/{progress_target}';
+  const progress = Number(ambition.progress) || 0;
+  const target = Number(ambition.progress_target) || 0;
+  return String(fmt)
+    .replace('{progress}', String(progress))
+    .replace('{progress_target}', String(target));
+}
+
+// Pure: ambition list → HTML string. Empty list → ''.
+export function formatAmbitionHud(ambitions) {
+  if (!Array.isArray(ambitions) || ambitions.length === 0) return '';
+  return ambitions
+    .map((a) => {
+      const label = formatAmbitionLabel(a);
+      const ready = a.choice_ready ? ' ambition-ready' : '';
+      return (
+        `<span class="ambition-pill${ready}" data-ambition-id="${escapeHtml(a.ambition_id)}">` +
+        `<span class="ambition-label">${escapeHtml(label)}</span>` +
+        (a.choice_ready ? '<span class="ambition-cta">✦ Rituale</span>' : '') +
+        `</span>`
+      );
+    })
+    .join('');
+}
+
+// Track previous progress per ambition_id to detect increments → pulse.
+const _lastProgress = new Map();
+
+// Side effect: render ambition strip into container.
+// Idempotent. Hide via .ambition-hidden when empty. Pulse on progress++.
+export function renderAmbitionHud(containerEl, ambitions) {
+  if (!containerEl || typeof containerEl.innerHTML !== 'string') return;
+  if (!Array.isArray(ambitions) || ambitions.length === 0) {
+    containerEl.innerHTML = '';
+    if (containerEl.classList && typeof containerEl.classList.add === 'function') {
+      containerEl.classList.add('ambition-hidden');
+    }
+    return;
+  }
+  const html = formatAmbitionHud(ambitions);
+  containerEl.innerHTML = html;
+  if (containerEl.classList && typeof containerEl.classList.remove === 'function') {
+    containerEl.classList.remove('ambition-hidden');
+  }
+  // Pulse logic: compare progress vs previous, add class if increased.
+  for (const a of ambitions) {
+    const prev = _lastProgress.get(a.ambition_id) || 0;
+    if ((a.progress || 0) > prev) {
+      // Apply pulse class (one-shot CSS animation handles cleanup).
+      const querySelector =
+        typeof containerEl.querySelector === 'function' ? containerEl.querySelector : null;
+      if (querySelector) {
+        const pill = containerEl.querySelector(`[data-ambition-id="${a.ambition_id}"]`);
+        if (pill && pill.classList) pill.classList.add('ambition-pulse');
+      }
+    }
+    _lastProgress.set(a.ambition_id, a.progress || 0);
+  }
+}
+
+// Test/internal — clear pulse memory between tests.
+export function _resetAmbitionHudState() {
+  _lastProgress.clear();
+}

--- a/apps/play/src/api.js
+++ b/apps/play/src/api.js
@@ -387,6 +387,28 @@ export const api = {
     }),
   mutationsBingo: (unit) =>
     jsonFetch('/api/v1/mutations/bingo', { method: 'POST', body: JSON.stringify({ unit }) }),
+  // Action 6 (ADR-2026-04-28 §Action 6) — Ambition long-arc campaign API.
+  ambitionsActive: (sid) =>
+    jsonFetch(`/api/campaign/ambitions/active?session_id=${encodeURIComponent(sid)}`),
+  ambitionSeed: (sid, ambitionId) =>
+    jsonFetch(`/api/campaign/ambitions/${encodeURIComponent(ambitionId)}/seed`, {
+      method: 'POST',
+      body: JSON.stringify({ session_id: sid }),
+    }),
+  ambitionProgress: (sid, ambitionId, encounterId, outcome) =>
+    jsonFetch(`/api/campaign/ambitions/${encodeURIComponent(ambitionId)}/progress`, {
+      method: 'POST',
+      body: JSON.stringify({ session_id: sid, encounter_id: encounterId, outcome }),
+    }),
+  ambitionChoiceRitual: (sid, ambitionId, choice, bondHearts = 0) =>
+    jsonFetch(`/api/campaign/ambitions/${encodeURIComponent(ambitionId)}/choice-ritual`, {
+      method: 'POST',
+      body: JSON.stringify({
+        session_id: sid,
+        choice,
+        bond_hearts: Number(bondHearts) || 0,
+      }),
+    }),
   // Skiv-as-Monitor — git-event-driven creature feed (Phase 2 wire 2026-04-25).
   skivStatus: () => jsonFetch('/api/skiv/status'),
   skivFeed: (limit = 20) => jsonFetch(`/api/skiv/feed?limit=${encodeURIComponent(limit)}`),

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -40,6 +40,12 @@ import {
 import { renderObjectiveBar } from './objectivePanel.js';
 import { renderBiomeChip } from './biomeChip.js';
 import { renderCtBar } from './ctBar.js';
+import { renderAmbitionHud } from './ambitionHud.js';
+import {
+  initAmbitionChoicePanel,
+  openChoicePanel as openAmbitionChoicePanel,
+  isChoiceLocked as isAmbitionChoiceLocked,
+} from './ambitionChoicePanel.js';
 
 const state = {
   sid: null,
@@ -1070,6 +1076,34 @@ function refreshCtBar() {
   renderCtBar(containerEl, state.world || null, lookahead);
 }
 
+// Action 6 (ADR-2026-04-28 §Action 6) — refresh Ambition HUD strip.
+// Long-arc campaign goal surface. Fetch active ambitions from backend +
+// render pill HUD. On choice_ready=true → auto-open choice ritual modal
+// (once per session per ambition, locked check reused).
+async function refreshAmbitionHud() {
+  const containerEl = document.getElementById('ambition-hud');
+  if (!containerEl || !state.sid) return;
+  let ambitions = [];
+  try {
+    const r = await api.ambitionsActive(state.sid);
+    if (r && r.ok && Array.isArray(r.data?.ambitions)) {
+      ambitions = r.data.ambitions;
+    }
+  } catch {
+    /* network — graceful degrade, hide chip */
+  }
+  renderAmbitionHud(containerEl, ambitions);
+  // Auto-trigger choice ritual modal on choice_ready (idempotent — locked check).
+  for (const a of ambitions) {
+    if (a.choice_ready && !isAmbitionChoiceLocked(a.ambition_id)) {
+      openAmbitionChoicePanel(a, {
+        onComplete: () => refreshAmbitionHud(),
+      });
+      break; // only one ritual modal at a time.
+    }
+  }
+}
+
 // Sprint β Visual UX 2026-04-28 — Frostpunk tension vignette (DOM overlay).
 // Driver: state.world.pressure (0..100). CSS vars --tension-alpha + --tension-color
 // applied to .tension-vignette singleton (created lazily). Pure helpers from
@@ -1160,6 +1194,8 @@ async function refresh() {
     refreshBiomeChip();
     // Action 7 (ADR-2026-04-28 §Action 7): refresh CT bar lookahead 3 turni.
     refreshCtBar();
+    // Action 6 (ADR-2026-04-28 §Action 6): refresh ambition HUD long-arc.
+    refreshAmbitionHud();
     // 2026-04-27 PR-Y1 — Gris pressure palette apply post-state-fetch
     applyPressurePalette(state.world);
     // Sprint β Visual UX 2026-04-28 — Frostpunk tension vignette overlay.
@@ -1331,6 +1367,12 @@ async function startNewSession() {
   refreshBiomeChip();
   // Action 7 (ADR-2026-04-28 §Action 7): refresh CT bar subito su nuova sessione.
   refreshCtBar();
+  // Action 6 (ADR-2026-04-28 §Action 6): seed ambition + refresh HUD subito.
+  // Default seed `skiv_pulverator_alliance` per Skiv long-arc demo. Idempotent.
+  api.ambitionSeed(state.sid, 'skiv_pulverator_alliance').catch(() => {
+    /* graceful degrade — HUD hidden if seed fails */
+  });
+  refreshAmbitionHud();
   // Bundle B.3 — pipe session_id to codex panel for /api/v1/codex/pages.
   setCodexSessionId(state.sid);
   // M11 Phase B+ (TKT-M11B-03) — if host room carries campaign_id, bootstrap
@@ -2175,6 +2217,14 @@ initThoughtsRitualPanel({
     state.world && state.selected
       ? getUnits(state.world).find((u) => u.id === state.selected) || null
       : null,
+});
+
+// Action 6 (ADR-2026-04-28 §Action 6) — Ambition choice ritual panel.
+// Triggered automatically by refreshAmbitionHud when choice_ready=true.
+// bond_hearts read from state.world.bond_hearts (publicSessionView).
+initAmbitionChoicePanel({
+  getSessionId: () => state.sid,
+  getBondHearts: () => Number(state.world?.bond_hearts) || 0,
 });
 
 // Sprint 2026-04-26 telemetria VC compromesso — Carattere panel (🎭).

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -3590,3 +3590,68 @@ body.ability-target-mode canvas#grid {
   color: rgba(232, 232, 232, 0.55);
   font-style: italic;
 }
+
+/* Action 6 (ADR-2026-04-28 §Action 6) — Ambition HUD top-strip.
+ * Long-arc campaign goal surface. Pillar P5 closes "combat isolated" risk.
+ * Mirror pattern .biome-chip pill style. Pulse on progress increment.
+ */
+.ambition-hud {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.ambition-hud.ambition-hidden {
+  display: none;
+}
+.ambition-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  background: rgba(255, 198, 107, 0.1);
+  border: 1px solid #ffc66b;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #ffc66b;
+  letter-spacing: 0.02em;
+  user-select: none;
+  transition:
+    background 0.3s ease,
+    border-color 0.3s ease,
+    transform 0.3s ease;
+}
+.ambition-pill.ambition-ready {
+  background: rgba(74, 222, 128, 0.16);
+  border-color: #4ade80;
+  color: #4ade80;
+  cursor: pointer;
+}
+.ambition-pill .ambition-cta {
+  font-size: 0.74rem;
+  font-style: italic;
+  opacity: 0.9;
+}
+.ambition-pill.ambition-pulse {
+  animation: ambition-progress-pulse 1s ease-in-out;
+}
+@keyframes ambition-progress-pulse {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 0 0 rgba(255, 198, 107, 0);
+  }
+  40% {
+    transform: scale(1.06);
+    box-shadow: 0 0 14px rgba(255, 198, 107, 0.55);
+  }
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 rgba(255, 198, 107, 0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ambition-pill.ambition-pulse {
+    animation: none;
+  }
+}

--- a/data/core/campaign/ambitions/skiv_pulverator_alliance.yaml
+++ b/data/core/campaign/ambitions/skiv_pulverator_alliance.yaml
@@ -1,0 +1,80 @@
+# Action 6 (ADR-2026-04-28 §Action 6) — Ambition seed Skiv-Pulverator alleanza.
+#
+# Long-arc campaign goal MVP minimal. Risolve research warn:
+#   "se troppo poco del gioco sta nel meta-loop, il combat diventa isolato"
+# (F2 §"Questioni aperte").
+#
+# Verdict user Q3 2026-04-28: opzione C "Skiv unisce Pulverator pack fatto bene"
+# + bond/conflict path. Choice ritual POST-defeat alpha (NOT pre-combat).
+#
+# Reuse:
+#   - encounter `enc_savana_skiv_solo_vs_pack` (PR #1982 Pulverator pack)
+#   - `bond_hearts` gate (PR #1984)
+#   - `propagateLineage` con `merge_lineage_on_bond` opt-in (PR #1918 pattern)
+#   - QBN engine narrative beat trigger (PR #1979)
+
+ambition_id: skiv_pulverator_alliance
+title_it: "Branco Skiv unisce Pulverator pack"
+title_en: "Skiv pack unites with Pulverator pack"
+description_it: |
+  Skiv vagans solitario. Pulverator pack rivale aggressivo.
+  L'alleanza emerge attraverso conflict + bond, NON pacifismo facile.
+  Defeat alpha → choice ritual: fame (kill) o bond (alliance).
+campaign_goal: alliance_emergent
+cadence: 4-5 encounter sequenziali
+
+# Encounter sequence che fa progredire l'ambition.
+# Ogni `encounter_pulverator_pack_defeat` outcome=victory → progress +1.
+encounters_sequence:
+  - encounter_id: enc_savana_skiv_solo_vs_pack
+    chapter_idx: 1
+    weight: 1
+  - encounter_id: enc_savana_skiv_solo_vs_pack
+    chapter_idx: 2
+    weight: 1
+  - encounter_id: enc_savana_skiv_solo_vs_pack
+    chapter_idx: 3
+    weight: 1
+  - encounter_id: enc_savana_skiv_solo_vs_pack
+    chapter_idx: 4
+    weight: 1
+  - encounter_id: enc_savana_skiv_solo_vs_pack
+    chapter_idx: 5
+    weight: 1
+
+trigger_events:
+  encounter_completion: "encounter outcome victory → progress increment"
+  bond_hearts_threshold: 3      # gate per choice ritual enable
+  choice_ritual_invoke: "fame_dominance | bond_proposal"
+
+progress_target: 5             # 5 encounter sequence → defeat alpha possibile
+
+# Choice ritual: fired solo quando progress >= progress_target AND bond_hearts >= threshold.
+# Pre-condition (gate): bond_hearts < 3 → choice_ritual_locked, ambition stays in_progress.
+choice_ritual:
+  enabled: true
+  bond_hearts_threshold: 3     # tunable post-playtest (default conservative)
+  paths:
+    fame_path:
+      key: fame_dominance
+      label_it: "Fame — Domina e disperdi"
+      narrative_beat_id: skiv_pulverator_kill_outcome
+      next_ambition_seed: territorial_reclaim_solo
+      outcome: standard_kill
+      lineage_merge: false
+    bond_path:
+      key: bond_proposal
+      label_it: "Bond — Proponi alleanza"
+      narrative_beat_id: skiv_pulverator_reconciliation
+      next_ambition_seed: null
+      outcome: alliance_emergent
+      lineage_merge: true
+      merge_lineage_on_bond: true
+
+ui_overlay:
+  position: top-hud
+  format: "🤝 Alleanza Pulverator: {progress}/{progress_target} incontri"
+  pulse_on_progress: true
+
+status: draft
+last_verified: 2026-04-29

--- a/data/core/narrative/beats/skiv_pulverator_alliance.yaml
+++ b/data/core/narrative/beats/skiv_pulverator_alliance.yaml
@@ -1,0 +1,46 @@
+# Action 6 (ADR-2026-04-28 §Action 6) — Narrative beats Skiv-Pulverator alleanza.
+#
+# Skiv canonical voice (italiano, prima persona implicita, metafore desertiche).
+# Reference: data/skiv/CANONICAL.md → "sabbia, vento, ridge, sole basso".
+
+beats:
+  - beat_id: skiv_pulverator_kill_outcome
+    trigger: ambition.fame_path.outcome
+    body_it: |
+      Pulverator alpha cade. Skiv osserva. Branco rivale disperso nella sabbia.
+      Sole basso. Nessun bond_hearts. Sangue copre tracce.
+    voice_line_skiv: "Sabbia tace."
+    side_effects:
+      bond_hearts_delta: 0
+      lineage_merge: false
+
+  - beat_id: skiv_pulverator_reconciliation
+    trigger: ambition.bond_path.outcome
+    body_it: |
+      Pulverator alpha cade. Skiv si ferma. Bond_hearts vibrano sul ridge.
+      Branco rivale ora seguito. Due ombre contro stesso sole.
+      Sabbia ricorda nuova forma.
+    voice_line_skiv: "Sabbia segue branco doppio."
+    side_effects:
+      bond_hearts_delta: 1
+      lineage_merge: true
+
+  - beat_id: skiv_pulverator_choice_locked_low_bond
+    trigger: ambition.choice_locked.bond_hearts_below_threshold
+    body_it: |
+      Skiv osserva alpha caduto. Bond_hearts deboli. Sabbia non parla ancora.
+      Branco rivale ringhia. Il vento porta solo distanza.
+    voice_line_skiv: "Vento porta distanza. Aspetta."
+    side_effects:
+      bond_hearts_delta: 0
+      lineage_merge: false
+
+  - beat_id: skiv_pulverator_progress_pulse
+    trigger: ambition.progress.increment
+    body_it: |
+      Pulverator pack incontra Skiv di nuovo. Bond_hearts crescono.
+      Sabbia ricorda passi precedenti.
+    voice_line_skiv: "Sabbia segue."
+    side_effects:
+      bond_hearts_delta: 0
+      lineage_merge: false

--- a/tests/play/ambitionHud.test.js
+++ b/tests/play/ambitionHud.test.js
@@ -1,0 +1,200 @@
+// Action 6 (ADR-2026-04-28 §Action 6) — ambitionHud frontend test.
+//
+// Pure helpers (formatAmbitionLabel + formatAmbitionHud) +
+// side-effect renderAmbitionHud via fake DOM container.
+
+'use strict';
+
+const { test, describe, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+async function loadModule() {
+  return import('../../apps/play/src/ambitionHud.js');
+}
+
+function fakeContainer() {
+  const classList = new Set();
+  const children = [];
+  function makeStub(id) {
+    const stub = {
+      _id: id,
+      classList: {
+        _set: new Set(),
+        add: (...c) => c.forEach((x) => stub.classList._set.add(x)),
+        contains: (x) => stub.classList._set.has(x),
+      },
+    };
+    children.push(stub);
+    return stub;
+  }
+  return {
+    innerHTML: '',
+    classList: {
+      add: (...c) => c.forEach((x) => classList.add(x)),
+      remove: (...c) => c.forEach((x) => classList.delete(x)),
+      contains: (x) => classList.has(x),
+    },
+    querySelector: (sel) => {
+      const m = sel.match(/\[data-ambition-id="([^"]+)"\]/);
+      if (!m) return null;
+      const id = m[1];
+      const existing = children.find((c) => c._id === id);
+      return existing || makeStub(id);
+    },
+    _children: children,
+  };
+}
+
+describe('formatAmbitionLabel', () => {
+  test('substitutes {progress} + {progress_target} placeholders', async () => {
+    const { formatAmbitionLabel } = await loadModule();
+    const a = {
+      progress: 2,
+      progress_target: 5,
+      ui_overlay: { format: '🤝 {progress}/{progress_target} incontri' },
+    };
+    assert.equal(formatAmbitionLabel(a), '🤝 2/5 incontri');
+  });
+
+  test('default format when ui_overlay missing', async () => {
+    const { formatAmbitionLabel } = await loadModule();
+    const a = { progress: 3, progress_target: 5 };
+    const label = formatAmbitionLabel(a);
+    assert.ok(label.includes('3'));
+    assert.ok(label.includes('5'));
+  });
+
+  test('null/undefined ambition → empty string', async () => {
+    const { formatAmbitionLabel } = await loadModule();
+    assert.equal(formatAmbitionLabel(null), '');
+    assert.equal(formatAmbitionLabel(undefined), '');
+  });
+});
+
+describe('formatAmbitionHud — pure HTML formatter', () => {
+  test('list of 1 ambition → pill HTML with label', async () => {
+    const { formatAmbitionHud } = await loadModule();
+    const html = formatAmbitionHud([
+      {
+        ambition_id: 'skiv_pulverator_alliance',
+        progress: 1,
+        progress_target: 5,
+        ui_overlay: { format: '🤝 {progress}/{progress_target}' },
+        choice_ready: false,
+      },
+    ]);
+    assert.ok(html.includes('ambition-pill'));
+    assert.ok(html.includes('1/5'));
+    assert.ok(html.includes('skiv_pulverator_alliance'));
+    assert.ok(!html.includes('ambition-cta'));
+  });
+
+  test('choice_ready=true → ambition-ready class + CTA', async () => {
+    const { formatAmbitionHud } = await loadModule();
+    const html = formatAmbitionHud([
+      {
+        ambition_id: 'a1',
+        progress: 5,
+        progress_target: 5,
+        ui_overlay: { format: '{progress}/{progress_target}' },
+        choice_ready: true,
+      },
+    ]);
+    assert.ok(html.includes('ambition-ready'));
+    assert.ok(html.includes('Rituale'));
+  });
+
+  test('empty list → empty string', async () => {
+    const { formatAmbitionHud } = await loadModule();
+    assert.equal(formatAmbitionHud([]), '');
+    assert.equal(formatAmbitionHud(null), '');
+    assert.equal(formatAmbitionHud(undefined), '');
+  });
+});
+
+describe('renderAmbitionHud — DOM side effect', () => {
+  beforeEach(async () => {
+    const { _resetAmbitionHudState } = await loadModule();
+    _resetAmbitionHudState();
+  });
+
+  test('null containerEl → no crash', async () => {
+    const { renderAmbitionHud } = await loadModule();
+    renderAmbitionHud(null, []);
+    assert.ok(true);
+  });
+
+  test('empty list → hide + clear', async () => {
+    const { renderAmbitionHud } = await loadModule();
+    const c = fakeContainer();
+    c.innerHTML = '<span>old</span>';
+    renderAmbitionHud(c, []);
+    assert.equal(c.innerHTML, '');
+    assert.ok(c.classList.contains('ambition-hidden'));
+  });
+
+  test('non-empty list → reveal + populate innerHTML', async () => {
+    const { renderAmbitionHud } = await loadModule();
+    const c = fakeContainer();
+    c.classList.add('ambition-hidden');
+    renderAmbitionHud(c, [
+      {
+        ambition_id: 'a1',
+        progress: 2,
+        progress_target: 5,
+        ui_overlay: { format: '{progress}/{progress_target}' },
+        choice_ready: false,
+      },
+    ]);
+    assert.ok(!c.classList.contains('ambition-hidden'));
+    assert.ok(c.innerHTML.includes('2/5'));
+    assert.ok(c.innerHTML.includes('a1'));
+  });
+
+  test('idempotent — render twice same input yields same innerHTML', async () => {
+    const { renderAmbitionHud, _resetAmbitionHudState } = await loadModule();
+    _resetAmbitionHudState();
+    const c = fakeContainer();
+    const ambitions = [
+      {
+        ambition_id: 'a1',
+        progress: 2,
+        progress_target: 5,
+        ui_overlay: { format: '{progress}/{progress_target}' },
+        choice_ready: false,
+      },
+    ];
+    renderAmbitionHud(c, ambitions);
+    const first = c.innerHTML;
+    renderAmbitionHud(c, ambitions);
+    assert.equal(c.innerHTML, first);
+  });
+
+  test('progress increment → applies ambition-pulse class to pill', async () => {
+    const { renderAmbitionHud, _resetAmbitionHudState } = await loadModule();
+    _resetAmbitionHudState();
+    const c = fakeContainer();
+    renderAmbitionHud(c, [
+      {
+        ambition_id: 'a1',
+        progress: 1,
+        progress_target: 5,
+        ui_overlay: { format: '{progress}/{progress_target}' },
+        choice_ready: false,
+      },
+    ]);
+    // Increment progress → pulse should be added.
+    renderAmbitionHud(c, [
+      {
+        ambition_id: 'a1',
+        progress: 2,
+        progress_target: 5,
+        ui_overlay: { format: '{progress}/{progress_target}' },
+        choice_ready: false,
+      },
+    ]);
+    const pill = c.querySelector('[data-ambition-id="a1"]');
+    assert.ok(pill, 'pill query stub should resolve');
+    assert.ok(pill.classList.contains('ambition-pulse'));
+  });
+});

--- a/tests/services/ambitionService.test.js
+++ b/tests/services/ambitionService.test.js
@@ -1,0 +1,186 @@
+// Action 6 (ADR-2026-04-28 §Action 6) — ambitionService backend test.
+//
+// Coverage 6 test:
+//   1. loadAmbition canonical seed + missing
+//   2. progressAmbition encounter sequence (5 victory) → progress = target
+//   3. progressAmbition defeat outcome → progress unchanged
+//   4. evaluateChoiceRitual fame_path → outcome standard_kill + bond_hearts_delta=0
+//   5. evaluateChoiceRitual bond_path success (bond_hearts >= threshold) → alliance_emergent
+//   6. evaluateChoiceRitual bond_path locked (bond_hearts < threshold) → locked beat
+//   + getActiveAmbitions filter session
+//   + threshold gate guard (progress < target → choice_incomplete)
+
+'use strict';
+
+const { test, describe, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const ambitionService = require('../../apps/backend/services/campaign/ambitionService');
+
+const AMBITION_ID = 'skiv_pulverator_alliance';
+const ENCOUNTER_ID = 'enc_savana_skiv_solo_vs_pack';
+
+function progressFiveVictories(sid) {
+  for (let i = 0; i < 5; i++) {
+    ambitionService.progressAmbition(sid, AMBITION_ID, {
+      encounter_id: ENCOUNTER_ID,
+      outcome: 'victory',
+    });
+  }
+}
+
+describe('ambitionService.loadAmbition', () => {
+  beforeEach(() => ambitionService._resetState());
+
+  test('canonical Skiv-Pulverator seed loads + has progress_target', () => {
+    const a = ambitionService.loadAmbition(AMBITION_ID);
+    assert.ok(a, 'ambition should load');
+    assert.equal(a.ambition_id, AMBITION_ID);
+    assert.equal(a.progress_target, 5);
+    assert.ok(a.choice_ritual);
+    assert.equal(a.choice_ritual.bond_hearts_threshold, 3);
+  });
+
+  test('missing ambition_id → null (graceful)', () => {
+    const a = ambitionService.loadAmbition('nonexistent_ambition_xyz');
+    assert.equal(a, null);
+  });
+});
+
+describe('ambitionService.progressAmbition', () => {
+  beforeEach(() => ambitionService._resetState());
+
+  test('5 victory encounters → progress reaches target + choice_ready', () => {
+    const sid = 'sess-test-1';
+    let last;
+    for (let i = 0; i < 5; i++) {
+      last = ambitionService.progressAmbition(sid, AMBITION_ID, {
+        encounter_id: ENCOUNTER_ID,
+        outcome: 'victory',
+      });
+    }
+    assert.equal(last.progress, 5);
+    assert.equal(last.progress_target, 5);
+    assert.equal(last.choice_ready, true);
+    assert.equal(last.completed, false);
+  });
+
+  test('defeat outcome → progress unchanged', () => {
+    const sid = 'sess-test-2';
+    const r = ambitionService.progressAmbition(sid, AMBITION_ID, {
+      encounter_id: ENCOUNTER_ID,
+      outcome: 'defeat',
+    });
+    assert.equal(r.progress, 0);
+    assert.equal(r.choice_ready, false);
+  });
+
+  test('non-matching encounter_id → progress unchanged', () => {
+    const sid = 'sess-test-3';
+    const r = ambitionService.progressAmbition(sid, AMBITION_ID, {
+      encounter_id: 'enc_unrelated_xyz',
+      outcome: 'victory',
+    });
+    assert.equal(r.progress, 0);
+  });
+});
+
+describe('ambitionService.evaluateChoiceRitual', () => {
+  beforeEach(() => ambitionService._resetState());
+
+  test('fame_path → outcome standard_kill + lineage_merge=false + narrative beat', () => {
+    const sid = 'sess-fame';
+    progressFiveVictories(sid);
+    const r = ambitionService.evaluateChoiceRitual(sid, AMBITION_ID, 'fame_dominance', {
+      bond_hearts: 0,
+    });
+    assert.equal(r.completed, true);
+    assert.equal(r.outcome, 'standard_kill');
+    assert.equal(r.lineage_merge, false);
+    assert.ok(r.narrative_beat);
+    assert.equal(r.narrative_beat.beat_id, 'skiv_pulverator_kill_outcome');
+    assert.equal(r.narrative_beat.voice_line_skiv, 'Sabbia tace.');
+  });
+
+  test('bond_path success (bond_hearts=3) → alliance_emergent + lineage_merge=true', () => {
+    const sid = 'sess-bond-ok';
+    progressFiveVictories(sid);
+    const r = ambitionService.evaluateChoiceRitual(sid, AMBITION_ID, 'bond_proposal', {
+      bond_hearts: 3,
+    });
+    assert.equal(r.completed, true);
+    assert.equal(r.outcome, 'alliance_emergent');
+    assert.equal(r.lineage_merge, true);
+    assert.equal(r.merge_lineage_on_bond, true);
+    assert.ok(r.narrative_beat);
+    assert.equal(r.narrative_beat.beat_id, 'skiv_pulverator_reconciliation');
+    assert.equal(r.narrative_beat.voice_line_skiv, 'Sabbia segue branco doppio.');
+  });
+
+  test('bond_path locked (bond_hearts<3) → locked + locked_beat + state unmutated', () => {
+    const sid = 'sess-bond-locked';
+    progressFiveVictories(sid);
+    const r = ambitionService.evaluateChoiceRitual(sid, AMBITION_ID, 'bond_proposal', {
+      bond_hearts: 1,
+    });
+    assert.equal(r.locked, true);
+    assert.equal(r.locked_reason, 'bond_hearts_below_threshold');
+    assert.equal(r.bond_hearts, 1);
+    assert.equal(r.bond_hearts_threshold, 3);
+    assert.ok(r.narrative_beat);
+    assert.equal(r.narrative_beat.beat_id, 'skiv_pulverator_choice_locked_low_bond');
+    // state must remain unlocked → caller can retry once bond_hearts >= threshold.
+    const entry = ambitionService.getProgress(sid, AMBITION_ID);
+    assert.equal(entry.completed, false);
+    assert.equal(entry.choice_made, null);
+  });
+
+  test('progress incomplete (<target) → error progress_incomplete', () => {
+    const sid = 'sess-incomplete';
+    ambitionService.progressAmbition(sid, AMBITION_ID, {
+      encounter_id: ENCOUNTER_ID,
+      outcome: 'victory',
+    });
+    const r = ambitionService.evaluateChoiceRitual(sid, AMBITION_ID, 'fame_dominance', {
+      bond_hearts: 0,
+    });
+    assert.equal(r.error, 'progress_incomplete');
+    assert.equal(r.progress, 1);
+  });
+});
+
+describe('ambitionService.getActiveAmbitions', () => {
+  beforeEach(() => ambitionService._resetState());
+
+  test('seeded ambition appears in active list with progress + choice_ready flag', () => {
+    const sid = 'sess-active';
+    ambitionService.seedAmbition(sid, AMBITION_ID);
+    const list = ambitionService.getActiveAmbitions(sid);
+    assert.equal(list.length, 1);
+    assert.equal(list[0].ambition_id, AMBITION_ID);
+    assert.equal(list[0].progress, 0);
+    assert.equal(list[0].progress_target, 5);
+    assert.equal(list[0].choice_ready, false);
+  });
+
+  test('completed ambition (post fame ritual) → filtered out from active list', () => {
+    const sid = 'sess-completed';
+    progressFiveVictories(sid);
+    ambitionService.evaluateChoiceRitual(sid, AMBITION_ID, 'fame_dominance', {
+      bond_hearts: 0,
+    });
+    const list = ambitionService.getActiveAmbitions(sid);
+    assert.equal(list.length, 0);
+  });
+});
+
+describe('ambitionService.formatAmbitionLabel', () => {
+  beforeEach(() => ambitionService._resetState());
+
+  test('formats progress + target via {placeholders}', () => {
+    const a = ambitionService.loadAmbition(AMBITION_ID);
+    const label = ambitionService.formatAmbitionLabel(a, 2);
+    assert.ok(label.includes('2/5'));
+    assert.ok(label.includes('Alleanza Pulverator'));
+  });
+});


### PR DESCRIPTION
## Summary

Action 6 (ADR-2026-04-28 §Action 6) — long-arc campaign goal MVP minimal. Risolve research warn _"se troppo poco del gioco sta nel meta-loop, il combat diventa isolato"_ (F2 §Questioni aperte).

User verdict Q3 2026-04-28: opzione **C** _"Skiv unisce Pulverator pack fatto bene"_ + bond/conflict path. Choice ritual **POST defeat alpha** (NOT pre-combat) — il path "non combattere" eliminato by design.

## Cadence + flow

| Step | Trigger | State |
|---|---|---|
| 1. Seed ambition | `POST /campaign/ambitions/:id/seed` (auto on `/start`) | progress=0/5 |
| 2. Encounter sequence | 5x victory `enc_savana_skiv_solo_vs_pack` | progress→5/5 |
| 3. Choice ready | `progress >= target` | HUD pill highlight green CTA |
| 4. Choice ritual modal | auto-open ambitionChoicePanel | 30s countdown + 2 buttons |
| 5a. Fame path | `bond_hearts=N` (sempre disponibile) | `outcome: standard_kill` + beat _"Sabbia tace."_ |
| 5b. Bond path locked | `bond_hearts < 3` | `locked: true` + beat _"Vento porta distanza. Aspetta."_ |
| 5c. Bond path OK | `bond_hearts >= 3` | `outcome: alliance_emergent` + lineage_merge=true + beat _"Sabbia segue branco doppio."_ |

## Scope

**Backend** (data + service + routes):
- `data/core/campaign/ambitions/skiv_pulverator_alliance.yaml` NEW — 1 ambition seed
- `data/core/narrative/beats/skiv_pulverator_alliance.yaml` NEW — 4 beat Skiv canonical voice
- `apps/backend/services/campaign/ambitionService.js` NEW — load + progress + ritual eval + active list
- `apps/backend/routes/campaign.js` — 4 nuovi endpoint `/api/campaign/ambitions/*`

**Frontend** (HUD + modal + wire):
- `apps/play/src/ambitionHud.js` NEW — pure helpers + render side-effect + pulse
- `apps/play/src/ambitionChoicePanel.js` NEW — choice ritual modal 30s timer
- `apps/play/index.html` — `#ambition-hud` slot 4° HUD (next to ct-bar)
- `apps/play/src/style.css` — pill style + pulse keyframe + reduce-motion
- `apps/play/src/main.js` — `refreshAmbitionHud` post-state-fetch + on /start + bootstrap init
- `apps/play/src/api.js` — 4 client endpoint

**Tests** (23 nuovi):
- `tests/services/ambitionService.test.js` — 12 test backend
- `tests/play/ambitionHud.test.js` — 11 test frontend

## Reuse

- `encounter enc_savana_skiv_solo_vs_pack` → PR #1982 (Pulverator pack)
- `bond_hearts` gate threshold → PR #1984 pattern
- `propagateLineage` `merge_lineage_on_bond` opt-in → PR #1918
- `legacyRitualPanel` overlay pattern → reuse style, separate component (no rewrite)
- QBN engine narrative beat path → separate `data/core/narrative/beats/`

## NO touched

- ❌ session.js core resolver (ambition è layer SOPRA session)
- ❌ encounter YAML existing
- ❌ packages/contracts schemas
- ❌ migrations / .github/workflows
- ❌ nuove dipendenze npm/pip

## DoD verde

- ✅ `node --test tests/ai/*.test.js` → 382/382 verde zero regression
- ✅ ambitionService + ambitionHud → 23/23 verde
- ✅ existing campaign tests (campaignRoutes + campaignIntegration + campaignPermanentFlags) → 48/48 verde
- ✅ `npm run format:check` verde
- ✅ `npm run schema:lint` verde
- ✅ `python tools/check_docs_governance.py --strict` errors=0
- ✅ smoke E2E live backend (PORT 3399) → 4 paths verified end-to-end

## Smoke E2E live verified

```
POST /campaign/ambitions/skiv_pulverator_alliance/seed → progress 0/5
GET  /campaign/ambitions/active                         → choice_ready=false
5x POST /campaign/ambitions/.../progress (victory)      → progress 5/5 + choice_ready=true
POST /campaign/ambitions/.../choice-ritual fame_dominance bond=0 → standard_kill + "Sabbia tace."
POST /campaign/ambitions/.../choice-ritual bond_proposal bond=1 → locked + "Vento porta distanza. Aspetta."
POST /campaign/ambitions/.../choice-ritual bond_proposal bond=3 → alliance_emergent + "Sabbia segue branco doppio."
```

## Pillar impact

- **P5 Co-op**: 🟡→🟢 candidato (chiude "combat isolato" risk research warn — meta-loop now drives combat purpose)
- **P2 Evoluzione**: 🟢 def reinforced (bond_path lineage merge cross-gen agency)

## Test plan

- [ ] CI: ai tests + campaign tests + ambition tests verdi
- [ ] CI: format:check + schema:lint + docs-governance verdi
- [ ] Manual smoke: avvia /start sessione, verifica HUD pill `🤝 Alleanza Pulverator: 0/5 incontri` visibile
- [ ] Manual smoke: 5x defeat Pulverator alpha → modal ritual auto-open
- [ ] Manual smoke: pick fame OR bond path → narrative beat surfaced + modal close
- [ ] Followup post-merge: instrument session.js to call `progressAmbition` on encounter outcome (currently caller-driven via API)

## Followup deferred

- Wire automatic `ambitionProgress` call from session.js on encounter outcome (currently HUD seeded on /start, progress requires explicit POST — first iteration MVP)
- Prisma persistence (in-memory only)
- Multi-ambition catalog (only 1 hardcoded seed for now)

Ref: [`docs/adr/ADR-2026-04-28-deep-research-actions.md`](docs/adr/ADR-2026-04-28-deep-research-actions.md) §Action 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)