### PR TITLE
fix(ai): preserve ai_profile in normaliseUnit + Utility AI kill-switch (P1)

### DIFF
--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -121,6 +121,11 @@ function normaliseUnit(raw, fallbackIndex) {
     mp: Number.isFinite(Number(input.mp)) ? Number(input.mp) : 5,
     lineage_id: input.lineage_id ? String(input.lineage_id) : null,
     abilities: Array.isArray(input.abilities) ? input.abilities.slice() : [],
+    // ADR-2026-04-17 Q-001 T3.1: preserve ai_profile per Utility AI gradual rollout.
+    // Senza questo campo, declareSistemaIntents.resolveUseUtilityBrain() cade su
+    // useUtilityAi global (default false) → Utility AI mai attivo per /start sessions.
+    // Bot-flagged 2026-04-29 PR #1495 review.
+    ai_profile: input.ai_profile ? String(input.ai_profile) : null,
   };
 }
 

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -6814,6 +6814,19 @@
       "track": "active"
     },
     {
+      "path": "docs/reports/2026-04-29-utility-ai-oscillation-bug.md",
+      "title": "Utility AI Oscillation Bug — Kill-Switch 2026-04-29",
+      "doc_status": "active",
+      "doc_owner": "ai-team",
+      "workstream": "ops-qa",
+      "last_verified": "2026-04-29",
+      "source_of_truth": false,
+      "language": "it",
+      "review_cycle_days": 30,
+      "primary": false,
+      "track": "active"
+    },
+    {
       "path": "docs/reports/PILLAR-LIVE-STATUS.md",
       "title": "PILLAR-LIVE-STATUS — runtime status canonical (volatile)",
       "doc_status": "active",

--- a/docs/reports/2026-04-29-utility-ai-oscillation-bug.md
+++ b/docs/reports/2026-04-29-utility-ai-oscillation-bug.md
@@ -1,0 +1,88 @@
+---
+title: Utility AI Oscillation Bug — Kill-Switch 2026-04-29
+doc_status: active
+doc_owner: ai-team
+workstream: ops-qa
+last_verified: 2026-04-29
+source_of_truth: false
+language: it
+review_cycle_days: 30
+---
+
+# Utility AI Oscillation Bug — Kill-Switch 2026-04-29
+
+Bug latente in `apps/backend/services/ai/utilityBrain.js` esposto dal fix `normaliseUnit` (PR #2008). SIS unità con `ai_profile: 'aggressive'` oscilla tra approach e retreat senza chiudere distanza. Encounter unwinnable.
+
+## Reproducibility
+
+- **Branch repro**: `fix/preserve-ai-profile-normalise-unit` (origin/main + ai_profile preservation fix)
+- **Test fail**: `tests/api/tutorial05.test.js` — `player attacks 0 < N_RUNS=10 — combat engine silently broken`
+- **Pre-fix (main)**: ai_profile dropped → SIS legacy AI → tests pass
+- **Post-fix (#2008)**: ai_profile preserved → SIS Utility AI → bug exposed
+
+## Trace
+
+Tutorial 05 BOSS FIGHT, scenario:
+- player p_scout (0,2), p_tank (0,3), attack_range 2 e 1
+- e_apex (5,2), `ai_profile: 'aggressive'`, AP 3, hp 11
+
+Sequence (debug repro):
+
+| Round | Apex pos | Distance | Player attack |
+|-------|----------|----------|---------------|
+| R1 | (5,2) | 5 | 400 out of range |
+| R2 | (4,2) | 4 | 400 out of range |
+| R3 | (5,2) | 5 | 400 out of range |
+| R4 | (4,2) | 4 | 400 out of range |
+| R5 | (5,2) | 5 | 400 out of range |
+
+Forward → backward → forward → backward, mai chiude. Player attacks 0/10 runs.
+
+**Main legacy AI (origin/main)**: monotonic forward — R1=5, R2=4, R3=3, R4 player hits.
+
+## Root cause hypothesis
+
+`utilityBrain.scoreAction` o `enumerateLegalActions` produce score oscillante per Apex `aggressive`:
+
+- Possibile: `linearInverse(distance)` favorisce retreat quando distance bassa, approach quando alta → flip-flop al confine.
+- Possibile: `threat consideration` su Apex HP alto trigger retreat erroneo.
+- Possibile: AP 3 multi-action genera "approach + retreat = +0 net" bug.
+
+**Investigation pending** — non risolto in questa sessione.
+
+## Kill-switch applicato (PR #2008)
+
+`packs/evo_tactics_pack/data/balance/ai_profiles.yaml`:
+
+```yaml
+aggressive:
+  use_utility_brain: false  # was: true (ADR-2026-04-17 first flip)
+```
+
+Effetto: SIS aggressive cade su `selectAiPolicy` legacy (REGOLA_001-004). Apex movimento monotonic forward, encounter playable.
+
+## Re-flip criterion
+
+Re-attivare `aggressive.use_utility_brain: true` solo dopo:
+
+1. Fix `utilityBrain.scoreAction` per Apex-class enemies (HP alto + AP 3+ multi-action)
+2. Test repro: 5x N=10 tutorial_05 → mean ≥1 victory + 0 timeouts non-balance-related
+3. Smoke check Apex movimento monotonic in `debug-multi.js` style
+
+## Cross-ref
+
+- PR #2008: `fix(ai): preserve ai_profile in normaliseUnit (PR #1495 bot P1)` — fix di base + kill-switch atomico
+- PR #1495: ADR-2026-04-17 Q-001 T3.1 wiring originale (non bug, solo wiring)
+- PR #1497: `balance(tutorial): wire Utility AI on tutorial 02-05 enemies` — sprint 17/04 ha flagged Apex/lanciere/guardiani come `aggressive`. Affected per kill-switch.
+- ADR-2026-04-16: AI Utility Architecture (architettura mantiene status accepted, runtime kill-switched)
+- ADR-2026-04-17: Utility AI Default Activation Decision (rollout sequence aggiornata: aspetta fix utilityBrain)
+
+## Investigation TODO
+
+Branch dedicato `fix/utility-brain-oscillation` (when scheduled):
+
+- [ ] Aggiungere log `[utility] action=approach/retreat score=N.NN` per debug
+- [ ] Repro `debug-multi.js` con 5 round Apex tutorial_05
+- [ ] Identificare quale consideration flip-flop (curve linearInverse?)
+- [ ] Patch + verify monotonic
+- [ ] Re-enable aggressive.use_utility_brain + ship

--- a/packs/evo_tactics_pack/data/balance/ai_profiles.yaml
+++ b/packs/evo_tactics_pack/data/balance/ai_profiles.yaml
@@ -25,8 +25,12 @@ profiles:
   aggressive:
     label: "Aggressivo"
     description: "Attacca con poca considerazione per HP. Retreat solo in extremis."
-    # Utility AI gradual rollout (ADR-2026-04-17 Q-001 T3.1): primo profile flip
-    use_utility_brain: true
+    # Utility AI gradual rollout (ADR-2026-04-17 Q-001 T3.1): primo profile flip.
+    # KILL-SWITCH 2026-04-29: utilityBrain.scoreAction oscilla approach↔retreat
+    # quando ai_profile preserved (post fix normaliseUnit). Apex tutorial_05
+    # forward(5→4)→backward(4→5) loop, encounter unwinnable. Tracked separately —
+    # re-flip a `true` dopo fix utilityBrain scoring (vedi PR #2008 description).
+    use_utility_brain: false
     overrides:
       retreat_hp_pct: 0.15
       kite_buffer: 0

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,11 +1,917 @@
 {
-  "generated_at": "2026-04-28T23:04:01+00:00",
+  "generated_at": "2026-04-29T18:58:12+00:00",
   "summary": {
-    "total": 20,
+    "total": 458,
     "errors": 0,
-    "warnings": 20
+    "warnings": 458
   },
   "issues": [
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "AGENTS.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "AGENT_WORKFLOW_GUIDE.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "CLAUDE.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "CONTRIBUTING.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "MASTER_PROMPT.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "PULL_REQUEST_TEMPLATE.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "agent.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "agent_constitution.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/adr/ADR-2025-11-18-cli-rollout.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/adr/ADR-2025-11-refactor-cli.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/adr/ADR-2025-12-07-generation-orchestrator.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/adr/ADR-2026-04-13-rules-engine-d20.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/adr/ADR-XXX-refactor-cli.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/appendici/ALIENA_documento_integrato.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/appendici/STYLE_GUIDE_NAMING.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/appendici/prontuario_metriche_ucum.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/appendici/sandbox/README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/architecture/flusso-richieste-idea-engine.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/architecture/tri-sorgente/overview.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/architecture/tri-sorgente/qa.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/evo-tactics/README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/evo-tactics/guida-ai-tratti-1.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/evo-tactics/guida-ai-tratti-2.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/evo-tactics/guida-ai-tratti-3-database.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/evo-tactics/guida-ai-tratti-3-evo-tactics.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/evo-tactics/guides/codex-readme.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/evo-tactics/guides/ptpf-seed-template.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/evo-tactics/guides/security-ops.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/evo-tactics/guides/template-ptpf.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/evo-tactics/guides/vision-and-structure-notes.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/evo-tactics/guides/visione-struttura.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/evo-tactics/integration-log.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/evo-tactics/integrazioni-v2.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/evo-tactics/security-readme.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/docs/wireframes/generatore.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/docs/wireframes/homepage.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/home/oai/share/evo_tactics_game_creatures_traits_package/docs/GDD.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/home/oai/share/evo_tactics_game_creatures_traits_package/docs/analysis/species_analysis_report.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/home/oai/share/evo_tactics_game_creatures_traits_package/docs/analysis/step1_summary.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/home/oai/share/evo_tactics_game_creatures_traits_package/docs/analysis/step2_summary.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/home/oai/share/evo_tactics_game_creatures_traits_package/docs/analysis/step3_summary.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/home/oai/share/evo_tactics_game_creatures_traits_package/docs/analysis/step4_summary.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/home/oai/share/evo_tactics_game_creatures_traits_package/docs/analysis/step5_summary.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/home/oai/share/evo_tactics_game_creatures_traits_package/docs/analysis/step6_summary.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/home/oai/share/evo_tactics_game_creatures_traits_package/docs/analysis/step7_summary.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/home/oai/share/evo_tactics_game_creatures_traits_package/docs/analysis/trait_analysis_summary.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/home/oai/share/evo_tactics_game_creatures_traits_package/docs/analysis/trait_merge_proposals.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/home/oai/share/evo_tactics_game_creatures_traits_package/docs/analysis/trait_review_report.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/home/oai/share/evo_tactics_game_creatures_traits_package/docs/games_overview.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/home/oai/share/evo_tactics_game_creatures_traits_package/docs/security/incident_response.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/home/oai/share/evo_tactics_game_creatures_traits_package/docs/security/policy.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/home/oai/share/evo_tactics_game_creatures_traits_package/docs/security/risk_register.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/home/oai/share/evo_tactics_game_creatures_traits_package/docs/security/threat_model.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/home/oai/share/evo_tactics_game_creatures_traits_package/docs/species_catalog.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-11-15_evo_cleanup/lavoro_da_classificare/home/oai/share/evo_tactics_game_creatures_traits_package/docs/traits_catalog.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/GDD.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/Game_EvoTactics_Guida_Pacchetto_v2.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/INTEGRAZIONE_GUIDE.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/README_CI.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/README_HOWTO_AUTHOR_TRAIT.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/README_NO_PROXY.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/docs/GDD.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/docs/INTEGRAZIONE_GUIDE.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/docs/QA_TRAITS_V2.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/docs/README_HOWTO_AUTHOR_TRAIT.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/docs/STYLE_GUIDE_NAMING.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/docs/analysis/trait_analysis_summary.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/docs/analysis/trait_review_report.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/docs/prontuario_metriche_ucum.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/docs/security/incident_response.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/docs/security/policy.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/docs/security/risk_register.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/docs/security/threat_model.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/docs/traits_reference.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/evo_tactics_game_database_guide.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/evo_tactics_game_guide.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/evo_tactics_guide.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/games_overview.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/species_analysis_report.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/species_catalog.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/step1_summary.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/step2_summary.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/step3_summary.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/step4_summary.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/step5_summary.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/step6_summary.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/step7_summary.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/trait_merge_proposals.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/lavoro_da_classificare/traits_catalog.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/playbook_security_ops.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/playbook_template_ptpf.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2025-12-19_inventory_cleanup/playbook_visione_struttura.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2026-04-14_incoming_backlog.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2026-04-16_reports_cleanup/02A_validator_rerun.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2026-04-16_reports_cleanup/memo_verifiche_2026-09-14.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2026-04-16_reports_cleanup/orchestrator_load_review.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2026-04-16_reports_cleanup/pipeline_simulation.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/2026-04-16_reports_cleanup/readiness_01B01C_status.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/INDEX.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/decompressed-index.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/documents/README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/historical-snapshots/incoming-scripts-readme.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/02A_validator_report.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_BACKUP_AND_ROLLBACK.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_CORE_DERIVED_MATRIX.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_INCOMING_CATALOG.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_MIGRATION_PHASE0-4_LOG.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_MIGRATION_PHASE0_KICKOFF.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_MIGRATION_PHASE1_DESIGN.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_MIGRATION_PHASE2_MODELING.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_MIGRATION_PHASE3_BALANCING.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_MIGRATION_PHASE4_VALIDATION.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_MIGRATION_PHASE5_ASSET_CATALOG.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_MIGRATION_PHASE6_DOC_ARCHIVE.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_MIGRATION_PHASE7_EXEC_PLAN_PATCHSET.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_PACKS_AND_DERIVED.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_PATCHSET_02A_TO_03AB_RUNBOOK.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_PATCHSET_03A_03B_CHECKLIST.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_PLANNING_RIPRESA_2026.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_REDIRECT_PLAN_STAGING.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_REPO_MIGRATION_PLAN.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_REPO_PATCH_PROPOSTA.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_REPO_SCOPE.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_REPO_SOURCES_OF_TRUTH.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/REF_TOOLING_AND_CI.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/TKT-03AB-FREEZE.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/agenda_PATCHSET-00_2025-12-07.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/ci-inventory.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/ci-log-automation.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/planning-reference/migration_targeted_workplan.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/archive/qa-playbook.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/balance/Frattura_Abissale_Sinaptica_balance_draft.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/biomes/Frattura_Abissale_Sinaptica_biome.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/biomes/Frattura_Abissale_Sinaptica_lore.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/biomes/biomes.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/biomes/manifest.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/catalog/Frattura_Abissale_Sinaptica_assets_draft.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/catalog/bioma_frattura_abissale_sinaptica.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/catalog/trait_reference.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/ci/README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/combat/README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/combat/action-types-guide.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/combat/data-flow.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/combat/determinism.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/combat/resolver-api.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/combat/status-effects-guide.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/combat/testing.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/combat/trait-mechanics-guide.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/combat/worker-bridge.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
     {
       "level": "warning",
       "code": "frontmatter_registry_mismatch",
@@ -26,9 +932,75 @@
     },
     {
       "level": "warning",
+      "code": "stale_document",
+      "path": "docs/core/01-VISIONE.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
       "code": "frontmatter_registry_mismatch",
       "path": "docs/core/02-PILASTRI.md",
       "message": "Campo last_verified differente tra frontmatter (2026-04-28) e registry (2026-04-27)"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/core/03-LOOP.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/core/10-SISTEMA_TATTICO.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/core/20-SPECIE_E_PARTI.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/core/22-FORME_BASE_16.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/core/24-TELEMETRIA_VC.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/core/25-REGOLE_SBLOCCO_PE.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/core/27-MATING_NIDO.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/core/28-NPC_BIOMI_SPAWN.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/core/30-UI_TV_IDENTITA.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/core/40-ROADMAP.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
     },
     {
       "level": "warning",
@@ -41,6 +1013,210 @@
       "code": "frontmatter_registry_mismatch",
       "path": "docs/core/90-FINAL-DESIGN-FREEZE.md",
       "message": "Campo last_verified differente tra frontmatter (2026-04-28) e registry (2026-04-15)"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/core/Guida_Evo_Tactics_Pack_v2.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/core/Mating-Reclutamento-Nido.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/core/PI-Pacchetti-Forme.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/core/SistemaNPG-PF-Mutazioni.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/core/Telemetria-VC.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics-pack/DEPLOYING.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics-pack/README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics-pack/db-schema.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics-pack/deploy.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics-pack/ennea-themes.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics-pack/generator-benchmarks.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics-pack/handover-summary.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics-pack/internal-announcement.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics/README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics/evo_tactics_game_guide.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics/evo_tactics_guide.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics/guida-ai-tratti-1.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics/guida-ai-tratti-2.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics/guida-ai-tratti-3-database.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics/guida-ai-tratti-3-evo-tactics.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics/guides/codex-readme.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics/guides/ptpf-seed-template.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics/guides/security-ops.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics/guides/template-ptpf.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics/guides/vision-and-structure-notes.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics/guides/visione-struttura.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/evo-tactics/integrazioni-v2.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/frontend/feature-updates.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/frontend/mockups_evo.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/frontend/styleguide.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/frontend/wireframes/evo/README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/frontend/wireframes/evo/mockup_evo_tactics.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/frontend/wireframes/generatore.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/frontend/wireframes/homepage.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
     },
     {
       "level": "warning",
@@ -63,14 +1239,98 @@
     {
       "level": "warning",
       "code": "stale_document",
+      "path": "docs/governance/rollout_plan.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
       "path": "docs/governance/workstream_matrix.md",
       "message": "Documento stale: revisione scaduta il 2026-04-27"
     },
     {
       "level": "warning",
       "code": "stale_document",
+      "path": "docs/guide/CONTRIBUTING_SITE.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/guide/INTEGRAZIONE_GUIDE.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/guide/README_HOWTO_AUTHOR_TRAIT.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/guide/README_SENTIENCE.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/guide/contributing/traits.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/guide/data-guidelines.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/guide/faq.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/guide/git-setup.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/guide/structure_overview.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/guide/templates/MODELLI_RIF_EVO_TACTICS.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/guide/templates/incoming_triage_meeting.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/guide/templates/obsidian_template.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
       "path": "docs/hubs/README.md",
       "message": "Documento stale: revisione scaduta il 2026-04-27"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/hubs/atlas.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
     },
     {
       "level": "warning",
@@ -125,6 +1385,1374 @@
       "code": "stale_document",
       "path": "docs/hubs/ops-qa.md",
       "message": "Documento stale: revisione scaduta il 2026-04-27"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/incoming/lavoro_da_classificare/INTEGRATION_PLAN.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/incoming/lavoro_da_classificare/TASKS_BREAKDOWN.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/logs/exports/2025-11-08-filter-selections.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/logs/incoming_triage_agenti.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/logs/incoming_triage_slack_plan_2025-11-10.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/logs/link-fix-2025-12-21.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/logs/pilot-2025-11-12/README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/logs/pilot-2025-11-12/media/README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/logs/playtests/2025-02-26/media/README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/logs/playtests/2025-02-27-vc/media/README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/logs/tooling/2025-10-24-tooling.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/logs/tooling/accessibility-generator.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/logs/tooling/generator_ui_mock.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/logs/trait_audit.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/logs/traits_tracking.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/logs/web_status.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/ops/AGENT_COMMANDS_CHEATSHEET.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/ops/AI_AGENT_AUDIT_LOG.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/ops/COMMAND_LIBRARY.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/ops/agent_telemetry.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/ops/chatgpt_sync_status.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/ops/cli-tools.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/ops/dependency_audit.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/ops/drive-sync.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/ops/evo-tooling.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/ops/nebula-rollout.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/ops/npm-proxy-migration.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/ops/observability.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/ops/publishing_calendar.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/ops/qa-window-checklist.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/ops/site-audit.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/ops/tool_run_report.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/ops/workflow_diff.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/BIOME_FEATURE_CHECKS.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/FAS2D_step1_briefing.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/Frattura_Abissale_Sinaptica_execution_plan.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/Frattura_Abissale_Sinaptica_pipeline_run.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/GOLDEN_PATH.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/GOLDEN_PATH_FEATURE.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/GOLDEN_PATH_FEATURE_Urban_Flood_Missions.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step1.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step10.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step2.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step3.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step4.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step5.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step6.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step7.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step8.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/PIPELINE_EXECUTION_Frattura_Abissale_Step9.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/PIPELINE_SIMULATION_Frattura_Abissale_Sinaptica.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/PIPELINE_SPECIES_BIOMES_Frattura_Abissale_Sinaptica.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/PIPELINE_SPECIES_BIOMES_STANDARD.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/PIPELINE_SPECIE_BIOMA_Frattura_Abissale_Sinaptica.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/PIPELINE_TEMPLATES.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/PIPELINE_TRAIT_STANDARD.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/ci-gap-analysis.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/ci-pipeline.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/ci.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/drive_sync.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/ema-metrics.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/gh-cli-manual-dispatch.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/pipelines/roadmap_generator.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/EchoWake/EchoWake_Modules_Expanded_v2_2.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/EchoWake/README_DEVKIT.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/EchoWake/flowchart-game-design-framework.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/changelog.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/evo-enum-review.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/feature-map/FEATURE_MAP_EVO_TACTICS.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/ideas/IDEAS_INDEX.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/ideas/README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/ideas/changelog.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/ideas/feedback.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/ideas/refresh-plan.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/readme-refresh-notes.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/research/README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/research/enneagram-addon/GAME_COMPAT_README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/research/enneagram-addon/README_ADDON_PER_PACCHETTO.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/research/enneagram-addon/README_ENNEAGRAMMA.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/research/enneagram-addon/README_INTEGRAZIONE_MECCANICHE.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/research/enneagram-addon/README_INTEGRAZIONE_MECCANICHE_v2.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/research/enneagram-addon/README_SCAN_STAT_EVENTI.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/research/enneagram-addon/dataset/README_ENNEAGRAMMA.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/research/lore_concepts.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/research/refs/2008_spore.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/research/sentience-branch-layout/CHANGELOG.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/research/sentience-branch-layout/CHECKLIST_TODO.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/research/sentience-branch-layout/README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/research/sentience-branch-layout/ROADMAP.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/research/sentience-branch-layout/pull_request_template.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/research/sentience-rfc/RFC_Sentience_Traits_v0.1.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/research/sentience-rfc/sources.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/roadmap/evo-rollout-checklists.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/roadmap/evo-rollout-schedule.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/roadmap/evo-rollout-status.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/roadmap/maintenance.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/roadmap/status/evo-weekly-20251029.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/roadmap/status/evo-weekly-20251202.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/roadmap/status/evo-weekly-20251203.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/planning/roadmap_operativa.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/playtest/BAL-03-ondata4-playbook.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/playtest/EVT-02-session-plan.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/playtest/INSIGHTS-2025-11.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/playtest/REPORT-2025-11-06-bal03.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/playtest/SESSION-2025-02-26.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/playtest/SESSION-2025-02-26/feedback/andrea-conti.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/playtest/SESSION-2025-02-26/feedback/giulia-parodi.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/playtest/SESSION-2025-02-26/feedback/luca-rinaldi.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/playtest/SESSION-2025-02-26/feedback/sara-neri.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/playtest/SESSION-2025-11-12.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/playtest/SESSION-2025-11-12/feedback/README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/playtest/SESSION-template.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/playtest/feedback-template.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/playtest/pilot-session-2025-11-12.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/playtest/procedura-post-sessione.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/playtest/scenari-critici.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/playtest/scenari-test.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/playtest/tickets/EVT-02-event-special.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/playtest/tickets/encounter-bug-146-evt02-nar-01.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/playtest/tickets/encounter-bug-147-evt02-nar-02.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/presentations/2025-02-vc-briefing.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/presentations/2025-11-18-onboarding.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/presentations/2025-11-onboarding-recordings.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/presentations/assets/vc-hud-briefing-deck.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/presentations/demo-walkthrough-script.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/presentations/walkthrough-demo-vc.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/action-items.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/bug-intake.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/bug-template.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/clone-setup.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/demo-release.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/feedback_collection_pipeline.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/incident_reporting_table.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/incoming_agent_streams.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/incoming_review_log.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/incoming_triage.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/incoming_triage_pipeline.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/localization.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/milestones.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/operations_calendar.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/project-setup-todo.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/qa_hud.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/qa_reporting_schema.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/sentience_rollout_plan.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/telemetry.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/telemetry_ingestion_pipeline.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/ticket-2025-10-27-playwright-deploy-checks.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/token-rotation.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/tooling_maintenance_log.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/training/trait_style_session.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/trait_data_reference.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/trait_review.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/trait_rollout_plan.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/traits_checklist.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/vc_playtest_plan.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/web_handoff.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/process/web_pipeline.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/public/sentience_sdk.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/qa/QA.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/qa/QA_TRAITS_V2.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/qa/nebula-webapp-checklist.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/qa/playbooks/eventi.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/qa/playbooks/loadout.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/qa/playbooks/moderazione.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/qa/playtest-log-guidelines.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/qa/qa-checklist.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/qa/rollout_checklist.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/Frattura_Abissale_Sinaptica_archivist_final.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/Frattura_Abissale_Sinaptica_patchset.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/Frattura_Abissale_Sinaptica_validation_commands.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/Frattura_Abissale_Sinaptica_validation_report.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/analytics-toolkit.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/data_inventory.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/evo-tactics-showcase-dossier-report.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/evo/README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/evo/integration_propagation_review.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/evo/inventory_audit.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/evo/qa/status.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/evo/rollout/documentation_gap.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/evo/rollout/next_batch_checklist.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/evo/rollout/species_ecosystem_gap.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/evo/species_analysis_report.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/evo/species_summary.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/evo/trait_review_report.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/incoming/inventory-2025-10-30.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/progress-dashboard.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/qa-changelog.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/species/species_summary.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/styleguide_compliance.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/styleguide_status_review.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/trait-env-alignment.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/trait_balance_summary.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/trait_merge_proposals.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/trait_progress.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/trait_taxonomy_analysis.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/traits/audit_duplicates_TRT-01.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/traits/merge_analysis.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/traits/pipeline_executor_step1_locomotivo.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/reports/traits/pipeline_simulator_locomotivo.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/species/Frattura_Abissale_Sinaptica_species_draft.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/traits/Frattura_Abissale_Sinaptica_trait_draft.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/traits/README_TRAITS.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/traits/manuale/01-introduzione.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/traits/manuale/02-modello-dati.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/traits/manuale/03-tassonomia-famiglie.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/traits/manuale/04-collegamenti-cross-dataset.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/traits/manuale/05-workflow-strumenti.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/traits/manuale/06-standalone-trait-editor.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/traits/manuale/README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/traits/next_steps_trait_migration.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/traits/trait-editor-api.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/traits/trait-editor.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/traits/trait_reference_manual.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/traits/traits_evo_pack_alignment.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/traits/traits_scheda_operativa.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/traits/traits_template.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/tutorials/README.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/tutorials/adaptive-engine-quickstart.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/tutorials/cli-quickstart.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/tutorials/dashboard-tour.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/tutorials/feedback-form.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/tutorials/hud-overlay-quickstart.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/tutorials/idea-engine-feedback.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "docs/tutorials/idea-engine.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "reports/qa-changelog.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "reports/trait_progress.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
+    },
+    {
+      "level": "warning",
+      "code": "stale_document",
+      "path": "router.md",
+      "message": "Documento stale: revisione scaduta il 2026-04-28"
     }
   ]
 }

--- a/tests/ai/utilityAiProfileWiring.test.js
+++ b/tests/ai/utilityAiProfileWiring.test.js
@@ -12,14 +12,18 @@
 
 'use strict';
 
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
+const request = require('supertest');
 
 const { loadAiProfiles } = require('../../apps/backend/services/ai/aiProfilesLoader');
 const {
   createDeclareSistemaIntents,
 } = require('../../apps/backend/services/ai/declareSistemaIntents');
+const { createApp } = require('../../apps/backend/app');
 
 // Silent logger per non inquinare test output.
 const silentLogger = { log: () => {}, warn: () => {} };
@@ -34,13 +38,12 @@ test('loadAiProfiles: carica ai_profiles.yaml e ritorna 3+ profile', () => {
   assert.ok(names.includes('cautious'), 'profile cautious presente');
 });
 
-test('loadAiProfiles: profile aggressive ha use_utility_brain=true (ADR first flip)', () => {
+test('loadAiProfiles: profile aggressive use_utility_brain campo presente (boolean)', () => {
+  // KILL-SWITCH 2026-04-29 PR #2008: aggressive.use_utility_brain=false
+  // dopo bug oscillazione utilityBrain.scoreAction (Apex tutorial_05).
+  // Re-flip a true post-fix utilityBrain. Test verifica field shape, non value.
   const data = loadAiProfiles(undefined, silentLogger);
-  assert.equal(
-    data.profiles.aggressive.use_utility_brain,
-    true,
-    'aggressive.use_utility_brain deve essere true (ADR-2026-04-17)',
-  );
+  assert.equal(typeof data.profiles.aggressive.use_utility_brain, 'boolean');
 });
 
 test('loadAiProfiles: profile balanced/cautious hanno use_utility_brain=false (gradual rollout)', () => {
@@ -147,4 +150,81 @@ test('declareSistemaIntents: aiProfiles=null ignora profile, fallback useUtility
     /^REGOLA_/.test(d.rule) || d.rule === 'no_target' || d.rule === 'intents_cap_reached',
     `aiProfiles=null + ai_profile valido → fallback legacy, ha ricevuto: ${d.rule}`,
   );
+});
+
+// ── Integration test: bot review fix 2026-04-29 ──
+// Bug catched: normaliseUnit dropped ai_profile field → /api/session/start
+// stripped ai_profile, Utility AI never active for real API sessions despite
+// loader being wired. Smoke test missed because used factory directly.
+// Fix: ai_profile preserved in normaliseUnit. Verify end-to-end via HTTP.
+
+test('POST /api/session/start preserves ai_profile through normaliseUnit', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const units = [
+    {
+      id: 'p1',
+      species: 'velox',
+      job: 'skirmisher',
+      controlled_by: 'player',
+      hp: 10,
+      mod: 3,
+      dc: 12,
+      position: { x: 0, y: 0 },
+    },
+    {
+      id: 'sis_aggressive',
+      species: 'apex_predatore',
+      job: 'vanguard',
+      controlled_by: 'sistema',
+      hp: 8,
+      mod: 3,
+      dc: 13,
+      ai_profile: 'aggressive',
+      position: { x: 5, y: 5 },
+    },
+    {
+      id: 'sis_balanced',
+      species: 'predoni_nomadi',
+      job: 'skirmisher',
+      controlled_by: 'sistema',
+      hp: 4,
+      mod: 2,
+      dc: 12,
+      ai_profile: 'balanced',
+      position: { x: 4, y: 5 },
+    },
+  ];
+
+  const startRes = await request(app).post('/api/session/start').send({ units });
+  assert.equal(startRes.status, 200);
+  const sid = startRes.body.session_id;
+  assert.ok(sid, 'session_id present');
+
+  const stateRes = await request(app).get('/api/session/state').query({ session_id: sid });
+  assert.equal(stateRes.status, 200);
+
+  const sisAggressive = stateRes.body.units.find((u) => u.id === 'sis_aggressive');
+  const sisBalanced = stateRes.body.units.find((u) => u.id === 'sis_balanced');
+  const player = stateRes.body.units.find((u) => u.id === 'p1');
+  assert.ok(sisAggressive, 'sis_aggressive present in state');
+  assert.ok(sisBalanced, 'sis_balanced present in state');
+  assert.ok(player, 'p1 present in state');
+
+  // Critical assertion: ai_profile preserved through normaliseUnit
+  assert.equal(
+    sisAggressive.ai_profile,
+    'aggressive',
+    'ai_profile preserved on sis_aggressive (was dropped pre-fix)',
+  );
+  assert.equal(
+    sisBalanced.ai_profile,
+    'balanced',
+    'ai_profile preserved on sis_balanced (was dropped pre-fix)',
+  );
+  // Player without ai_profile → null (not undefined)
+  assert.equal(player.ai_profile, null, 'unit senza ai_profile → null');
 });


### PR DESCRIPTION
## Summary

Closes bot review P1 on PR #1495 + adds **kill-switch** for Utility AI oscillation bug exposed by the fix.

## Bot review (P1)

> Passing `aiProfiles` to `createDeclareSistemaIntents` does not activate the rollout for real `/start` sessions because `normaliseUnit` currently drops unknown fields, including `ai_profile`. `resolveUseUtilityBrain(actor)` always falls back to the global default (false). SIS units created through the API will never hit the `aggressive.use_utility_brain=true` path even though the loader is wired.

## Investigation results

Local repro su `fix/preserve-ai-profile-normalise-unit` (origin/main + ai_profile preservation):

| Round | Apex pos | Distance | Player |
|-------|----------|----------|--------|
| R1 | (5,2) | 5 | 400 out of range |
| R2 | (4,2) | 4 | 400 out of range |
| R3 | (5,2) | 5 | 400 out of range |
| R4 | (4,2) | 4 | 400 out of range |
| R5 | (5,2) | 5 | 400 out of range |

**Forward → backward → forward → backward.** Encounter unwinnable. `tutorial05.test.js` sanity asserts fail (`player attacks 0 < N_RUNS=10`).

**Main legacy AI**: monotonic forward (R1=5, R2=4, R3=3, R4 player hits) → tests pass.

Root cause: `utilityBrain.scoreAction` produces oscillating scores per Apex-class enemies (high HP + AP 3+ multi-action). Investigation pending.

## Atomic fix shipped here

1. **Wiring fix** — `apps/backend/routes/sessionHelpers.js::normaliseUnit()` aggiunge `ai_profile: input.ai_profile ? String(input.ai_profile) : null` al return whitelist.
2. **Kill-switch** — `packs/evo_tactics_pack/data/balance/ai_profiles.yaml` flip `aggressive.use_utility_brain: true → false` con commento esplicativo + criterion re-flip.
3. **Test integration** — `tests/ai/utilityAiProfileWiring.test.js` aggiunge E2E `POST /start → GET /state` verifying preservation.
4. **Bug report** — `docs/reports/2026-04-29-utility-ai-oscillation-bug.md` documenta repro + kill-switch + investigation TODO.

## Effect post-merge

- **Wiring corretto**: future re-flip `aggressive.use_utility_brain: true` immediately attiva Utility AI senza re-deploy code (zero refactor).
- **Encounter playable**: SIS aggressive units (Tutorial 02-05) cadono su legacy `selectAiPolicy` → comportamento monotonic, tests verdi.
- **No regression**: ADR-2026-04-16/17 status invariato (architettura accepted, runtime kill-switched temporaneamente).

## Test plan

- [x] `node --test tests/ai/utilityAiProfileWiring.test.js tests/api/tutorial05.test.js` → 10/10 verdi locale
- [x] Governance `errors=0`
- [x] Bug repro documentato + investigation TODO listato

## Re-flip criterion (post-merge)

Re-attivare `aggressive.use_utility_brain: true` quando:
1. Fix `utilityBrain.scoreAction` per Apex-class enemies (HP alto + AP 3+ multi-action)
2. Repro 5x N=10 tutorial_05 → mean ≥1 victory + 0 timeouts non-balance-related
3. Smoke check Apex movimento monotonic

## Rollback plan

Revert single commit. Whitelist field-only + YAML flag + new doc report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)