### PR TITLE
chore(governance): registry add ERMES planning docs (#2009 follow-up)

### DIFF
--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -4875,6 +4875,28 @@
       "track": "planning"
     },
     {
+      "path": "docs/planning/2026-04-29-ermes-codex-execution-brief.md",
+      "title": "ERMES Codex Execution Brief",
+      "doc_status": "draft",
+      "doc_owner": "master-dd",
+      "workstream": "cross-cutting",
+      "last_verified": "2026-04-29",
+      "source_of_truth": false,
+      "language": "it",
+      "review_cycle_days": 14
+    },
+    {
+      "path": "docs/planning/2026-04-29-ermes-integration-plan.md",
+      "title": "ERMES Integration Plan — Ecosystem Research, Measurement & Evolution System",
+      "doc_status": "draft",
+      "doc_owner": "master-dd",
+      "workstream": "cross-cutting",
+      "last_verified": "2026-04-29",
+      "source_of_truth": false,
+      "language": "it",
+      "review_cycle_days": 14
+    },
+    {
       "path": "docs/planning/EVO_FINAL_DESIGN_BACKLOG_REGISTER.md",
       "title": "Evo Final Design — Backlog Register",
       "doc_status": "draft",


### PR DESCRIPTION
## Summary

Follow-up di [#2009](https://github.com/MasterDD-L34D/Game/pull/2009) (ERMES drop-in). I 2 doc planning shippati con frontmatter draft non erano stati registrati in `docs/governance/docs_registry.json`. Questo PR colma il gap.

Entries aggiunte (2):

```json
{
  "path": "docs/planning/2026-04-29-ermes-codex-execution-brief.md",
  "title": "ERMES Codex Execution Brief",
  "doc_status": "draft",
  "doc_owner": "master-dd",
  "workstream": "cross-cutting",
  "last_verified": "2026-04-29",
  "source_of_truth": false,
  "language": "it",
  "review_cycle_days": 14
},
{
  "path": "docs/planning/2026-04-29-ermes-integration-plan.md",
  "title": "ERMES Integration Plan — Ecosystem Research, Measurement & Evolution System",
  "doc_status": "draft",
  "doc_owner": "master-dd",
  "workstream": "cross-cutting",
  "last_verified": "2026-04-29",
  "source_of_truth": false,
  "language": "it",
  "review_cycle_days": 14
}
```

## Validation

```
$ python tools/check_docs_governance.py --registry docs/governance/docs_registry.json --strict
errors=0 warnings=458   # warnings pre-esistenti, zero ERMES-related
```

Total entries: 621 → **623**.

## Diff scope

Minimal, **+22 LOC, zero re-sort**, zero touch altri file. Insertion inline dopo `docs/planning/2026-04-29-sprint-n7-failure-model-parity-spec.md` (anchor canonical).

## Test plan

- [x] `tools/check_docs_governance.py --strict` → errors=0
- [ ] CI green (Docs Governance check)

## Rollback

```bash
git revert HEAD
```

## Master DD approval

Patch governance pura, scope chirurgico. Approval pending review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)