### PR TITLE
docs(guide): asset-creation-workflow — add Workspace locale (out-of-repo) section

### DIFF
--- a/docs/guide/asset-creation-workflow.md
+++ b/docs/guide/asset-creation-workflow.md
@@ -15,6 +15,27 @@ Guida operativa per creare/acquisire asset visivi per Evo-Tactics nel rispetto d
 
 3 path canonici, applicabili in parallelo o sequenza. Tutti compatibili con build pubblica + license commerciale.
 
+## Workspace locale (out-of-repo)
+
+Reference asset library + tools vivono **fuori repo** in `~/Documents/evo-tactics-refs/` (mai sync con repo Game, gitignore by design — vedi `docs/adr/ADR-2026-04-18-zero-cost-asset-policy.md`).
+
+Bootstrap pattern (~30-60 min download bandwidth):
+
+1. Crea folder: `mkdir -p ~/Documents/evo-tactics-refs/{tools-install,references,output-staging,session-logs}`
+2. Genera URL lists per fonte (Kenney pack URLs scraped da `kenney.nl/assets/<slug>`, HF dataset via `huggingface.co/api/datasets/nyuuzyou/OpenGameArt-CC0/tree/main`, Sonniss bundles via `archive.org/metadata/<id>`).
+3. Run robust download script con verify+retry+size-check (canonical helper in workspace).
+4. Estrai pack rilevanti per workflow Path 1 (esistenti) o Path 2 (placeholder AI) o Path 3 (reference + redraw).
+
+**Vincoli workspace**:
+
+- ❌ Mai committare reference asset locali a repo (DMCA fastlane on public repo)
+- ❌ Mai sync workspace via cloud Drive condiviso
+- ✅ License coverage 100% (CC0 + PD + Sonniss royalty-free perpetual + tool licenses GPL/MIT/Apache2)
+- ✅ MANIFEST.json file-level index searchable
+- ✅ Workflow recipes per Skiv portrait/run cycle/echolocation/idle vocal/combat roar in workspace HANDOFF.md
+
+Asset finali polished → copy a `Game/assets/<category>/` + provenance log mandatory `CREDITS.md`.
+
 ## Path 1 — Kenney / itch.io CC0 base + modifica
 
 **Quando**: asset standard riconoscibili (icone UI, tile dungeon, creature low-poly, sprite generici).


### PR DESCRIPTION
## Summary

Estende `docs/guide/asset-creation-workflow.md` (merged in #2011) con section **Workspace locale (out-of-repo)** che documenta invariante operativo: reference asset library + tools vivono fuori repo in `~/Documents/evo-tactics-refs/`, gitignore by design (rationale: ADR-2026-04-18 zero-cost policy + DMCA fastlane mitigation su public repo).

### Cosa aggiunge

- **Bootstrap pattern** 4-step per replicare workspace su altro PC:
  1. Folder structure
  2. URL lists scrape (Kenney/HF/Sonniss/archive.org)
  3. Robust download script (verify+retry+size-check)
  4. Extract per Path 1+2+3 workflow

- **Vincoli workspace** esplicitati:
  - ❌ Mai committare reference locali (DMCA fastlane on public repo)
  - ❌ Mai sync workspace via cloud Drive condiviso
  - ✅ License coverage 100% (CC0 + PD + Sonniss royalty-free perpetual + tool licenses GPL/MIT/Apache2)
  - ✅ MANIFEST.json file-level index searchable
  - ✅ Workflow recipes per Skiv asset class in workspace HANDOFF.md

### Pattern derives from

Operational session 2026-04-29: workspace 184GB curated + 32136 file 100% license-classified. Pattern provata reproducible cross-PC.

## Files changed

- `docs/guide/asset-creation-workflow.md` (+21 righe — section addition only, zero behavior change)

## Test plan

- [x] `python tools/check_docs_governance.py --strict` → errors=0
- [x] No backend/frontend code change → no AI test impact
- [x] No new dependencies npm/pip
- [x] Frontmatter unchanged
- [x] Section additive (no existing content modified)

## Rollback plan (03A)

Single revert. Section additive, no data migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)