### PR TITLE
fix(launcher): Node worktree detection + ngrok auth setup helper

### DIFF
--- a/Evo-Tactics-Demo.bat
+++ b/Evo-Tactics-Demo.bat
@@ -18,9 +18,9 @@ if errorlevel 1 (
     exit /b 1
 )
 
-REM Detect se main e' checked out in altro worktree
+REM Detect se main e' checked out in altro worktree (Node helper, no shell escape issues)
 set "MAIN_WT="
-for /f "delims=" %%P in ('powershell -NoProfile -Command "& { (git worktree list ^| Select-String '\[main\]') -replace '\s+\[main\].*', '' -replace '\s+[a-f0-9]{7,}\s*$', '' -replace '^\s+', '' | Select-Object -First 1 }"') do set "MAIN_WT=%%P"
+for /f "usebackq delims=" %%P in (`node scripts\find-main-worktree.cjs 2^>nul`) do set "MAIN_WT=%%P"
 
 REM Detect current branch
 for /f "delims=" %%B in ('git rev-parse --abbrev-ref HEAD 2^>nul') do set "CURRENT_BRANCH=%%B"

--- a/Evo-Tactics-Setup-Ngrok-Auth.bat
+++ b/Evo-Tactics-Setup-Ngrok-Auth.bat
@@ -1,0 +1,73 @@
+@echo off
+REM Evo-Tactics — ngrok authtoken 1-time setup.
+REM Doppio clic UNA volta per setup ngrok account auth.
+REM Master-dd 2026-04-29: Demo launcher fail "ngrok authtoken assente" → fix qui.
+
+setlocal
+chcp 65001 >nul 2>&1
+title Evo-Tactics Setup ngrok auth
+
+echo.
+echo   ===========================================================
+echo                EVO-TACTICS SETUP NGROK AUTHTOKEN
+echo   ===========================================================
+echo.
+echo   Setup 1-volta. Necessario per Demo launcher (tunnel pubblico).
+echo.
+echo   STEP 1 — Account ngrok (gratis 4 connessioni):
+echo            https://ngrok.com/signup
+echo            (skip se gia' account)
+echo.
+echo   STEP 2 — Copy authtoken:
+echo            https://dashboard.ngrok.com/get-started/your-authtoken
+echo.
+echo   ===========================================================
+echo.
+
+REM Verifica ngrok presence
+where ngrok >nul 2>&1
+if errorlevel 1 (
+    echo   [X] ngrok non trovato. Install:
+    echo       https://ngrok.com/download (Windows ZIP, extract in PATH)
+    echo       OR Microsoft Store "ngrok"
+    echo.
+    pause
+    exit /b 1
+)
+
+echo   STEP 3 — Paste token qui sotto, premi INVIO:
+echo.
+set /p NGROK_TOKEN=Token ngrok:
+
+if "%NGROK_TOKEN%"=="" (
+    echo.
+    echo   [X] Token vuoto. Riprova.
+    pause
+    exit /b 1
+)
+
+echo.
+echo   [setup] ngrok config add-authtoken...
+ngrok config add-authtoken %NGROK_TOKEN%
+if errorlevel 1 (
+    echo.
+    echo   [X] Setup fallito. Verifica token corretto + connessione internet.
+    pause
+    exit /b 1
+)
+
+echo.
+echo   ===========================================================
+echo                         SETUP COMPLETATO
+echo   ===========================================================
+echo.
+echo   Authtoken salvato in ngrok config (%%USERPROFILE%%\.ngrok2\ngrok.yml).
+echo.
+echo   Prossimo step:
+echo         Doppio clic icona desktop "Evo-Tactics-Demo"
+echo         per avviare backend + ngrok tunnel pubblico.
+echo.
+echo   ===========================================================
+echo.
+pause
+endlocal

--- a/Evo-Tactics-Sync-Main.bat
+++ b/Evo-Tactics-Sync-Main.bat
@@ -31,9 +31,9 @@ if errorlevel 1 (
     exit /b 1
 )
 
-REM Detect se main e' checked out in altro worktree
+REM Detect se main e' checked out in altro worktree (Node helper, no shell escape issues)
 set "MAIN_WT="
-for /f "delims=" %%P in ('powershell -NoProfile -Command "& { (git worktree list ^| Select-String '\[main\]') -replace '\s+\[main\].*', '' -replace '\s+[a-f0-9]{7,}\s*$', '' -replace '^\s+', '' | Select-Object -First 1 }"') do set "MAIN_WT=%%P"
+for /f "usebackq delims=" %%P in (`node scripts\find-main-worktree.cjs 2^>nul`) do set "MAIN_WT=%%P"
 
 REM Detect current branch
 for /f "delims=" %%B in ('git rev-parse --abbrev-ref HEAD') do set "CURRENT_BRANCH=%%B"

--- a/Evo-Tactics-Toggle-A-Classic.bat
+++ b/Evo-Tactics-Toggle-A-Classic.bat
@@ -8,9 +8,9 @@ chcp 65001 >nul 2>&1
 cd /d "%~dp0"
 title Evo-Tactics Rubric Toggle A (Classic)
 
-REM Hotfix 2026-04-29: detect main worktree, write config there (Demo launcher legge da main worktree)
+REM Hotfix 2026-04-29: detect main worktree (Node helper, no shell escape issues)
 set "MAIN_WT="
-for /f "delims=" %%P in ('powershell -NoProfile -Command "& { (git worktree list ^| Select-String '\[main\]') -replace '\s+\[main\].*', '' -replace '\s+[a-f0-9]{7,}\s*$', '' -replace '^\s+', '' | Select-Object -First 1 }"') do set "MAIN_WT=%%P"
+for /f "usebackq delims=" %%P in (`node scripts\find-main-worktree.cjs 2^>nul`) do set "MAIN_WT=%%P"
 
 if defined MAIN_WT (
     if /i not "%MAIN_WT%"=="%cd%" (

--- a/Evo-Tactics-Toggle-B-BG3lite.bat
+++ b/Evo-Tactics-Toggle-B-BG3lite.bat
@@ -8,9 +8,9 @@ chcp 65001 >nul 2>&1
 cd /d "%~dp0"
 title Evo-Tactics Rubric Toggle B (BG3-lite Tier 1)
 
-REM Hotfix 2026-04-29: detect main worktree, write config there (Demo launcher legge da main worktree)
+REM Hotfix 2026-04-29: detect main worktree (Node helper, no shell escape issues)
 set "MAIN_WT="
-for /f "delims=" %%P in ('powershell -NoProfile -Command "& { (git worktree list ^| Select-String '\[main\]') -replace '\s+\[main\].*', '' -replace '\s+[a-f0-9]{7,}\s*$', '' -replace '^\s+', '' | Select-Object -First 1 }"') do set "MAIN_WT=%%P"
+for /f "usebackq delims=" %%P in (`node scripts\find-main-worktree.cjs 2^>nul`) do set "MAIN_WT=%%P"
 
 if defined MAIN_WT (
     if /i not "%MAIN_WT%"=="%cd%" (

--- a/scripts/find-main-worktree.cjs
+++ b/scripts/find-main-worktree.cjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// Evo-Tactics — find main worktree path helper.
+// Usage: node scripts/find-main-worktree.cjs
+// Output: stdout = main worktree path (no newline) OR empty string if main not in any worktree.
+// Exit: 0 always (empty output handled by caller).
+//
+// Pattern: cross-PC pure Node, NO shell escape issues. Used by .bat launchers
+// (Sync-Main + Demo + Toggle bats) per detect main worktree path automatic.
+
+'use strict';
+
+const { execSync } = require('node:child_process');
+
+try {
+  const output = execSync('git worktree list --porcelain', {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+
+  // Parse porcelain blocks. Each worktree = 3-4 lines:
+  //   worktree <path>
+  //   HEAD <sha>
+  //   branch refs/heads/<name>      (or "detached")
+  //   <empty line>
+
+  const blocks = output.split(/\r?\n\r?\n/);
+  for (const block of blocks) {
+    if (!block.includes('branch refs/heads/main')) continue;
+    const match = block.match(/^worktree (.+)$/m);
+    if (match) {
+      // Output path without trailing newline (cmd %%P picks it cleanly)
+      process.stdout.write(match[1].trim());
+      process.exit(0);
+    }
+  }
+
+  // Main not in any worktree — empty output
+  process.exit(0);
+} catch (err) {
+  // Git error or not in repo — empty output, exit 0 (caller handles)
+  process.exit(0);
+}

--- a/scripts/install-desktop-shortcuts.ps1
+++ b/scripts/install-desktop-shortcuts.ps1
@@ -24,6 +24,12 @@ Write-Host ""
 
 $Shortcuts = @(
   @{
+    Name        = 'Evo-Tactics-Setup-Ngrok-Auth'
+    Target      = 'Evo-Tactics-Setup-Ngrok-Auth.bat'
+    Description = 'Setup 1-volta ngrok authtoken. Necessario per Demo launcher (tunnel pubblico). Salta se gia configurato.'
+    IconHint    = 'shell32.dll, 23'
+  },
+  @{
     Name        = 'Evo-Tactics-Demo'
     Target      = 'Evo-Tactics-Demo.bat'
     Description = '1-click launcher: pre-flight + backend + ngrok tunnel pubblico + auto-open browser. Master-dd start qui.'


### PR DESCRIPTION
## Summary

Hotfix v2 post bug master-dd 2026-04-29: doppio fix.

### Bug 1: Sync-Main.bat git worktree usage error

PowerShell pipe escape pattern (`^|` in cmd) passed letterale dentro `powershell -Command "git worktree list ^| Select-String '\[main\]'"`, git riceveva `|` come argomento NON come pipe → dump usage.

**Fix**: scripts/find-main-worktree.cjs — Node helper pure (cross-PC, no shell escape).

### Bug 2: Demo.bat ngrok authtoken assente

ngrok requires 1-volta `ngrok config add-authtoken <TOKEN>` setup. Master-dd non ha terminal access.

**Fix**: NEW Evo-Tactics-Setup-Ngrok-Auth.bat — prompt user paste token (set /p) + ngrok config add-authtoken automatic. Desktop shortcut via installer update.

## Files

| File | Type | Purpose |
|---|---|---|
| `scripts/find-main-worktree.cjs` | NEW | Pure Node, parse `git worktree list --porcelain`, output main path or empty |
| `Evo-Tactics-Setup-Ngrok-Auth.bat` | NEW | 1-volta ngrok authtoken setup helper |
| `scripts/install-desktop-shortcuts.ps1` | UPDATE | Add Setup-Ngrok-Auth.lnk (5 totale) |
| `Evo-Tactics-Sync-Main.bat` | UPDATE | Use Node helper (replace PowerShell pipe pattern) |
| `Evo-Tactics-Demo.bat` | UPDATE | Same |
| `Evo-Tactics-Toggle-A-Classic.bat` | UPDATE | Same |
| `Evo-Tactics-Toggle-B-BG3lite.bat` | UPDATE | Same |

## Test locale

```
node scripts/find-main-worktree.cjs
# Output: C:/Users/VGit/Desktop/Game/.claude/worktrees/vibrant-curie-e6ddac (65 char)
```

## Master-dd workflow zero-terminal post-merge

1. (1-volta) Doppio clic **Evo-Tactics-Setup-Ngrok-Auth** → paste token from https://dashboard.ngrok.com/get-started/your-authtoken → done
2. Doppio clic **Evo-Tactics-Sync-Main** → main fetch + worktree-aware pull (verde)
3. Doppio clic **Evo-Tactics-Demo** → backend + ngrok pubblico + URL clipboard (verde)
4. Doppio clic **Toggle-A/B** → ui_config edit in main worktree (verde)

## Test plan

- [x] Node helper output verified
- [x] No code change runtime (.bat + .ps1 + helper .cjs only)
- [x] Cross-PC compat (Node only, no shell escape)
- [ ] Master-dd manual smoke post-merge: Sync-Main verde
- [ ] Master-dd manual smoke: Setup-Ngrok-Auth → Demo verde

## Rollback

Revert single commit. Zero runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)