### PR TITLE
fix(launcher): strip non-ASCII chars all .bat (cmd parser compat)

### DIFF
--- a/Evo-Tactics-Install-Desktop-Shortcuts.bat
+++ b/Evo-Tactics-Install-Desktop-Shortcuts.bat
@@ -1,5 +1,5 @@
 @echo off
-REM Evo-Tactics — installer 1-click 4 desktop shortcuts.
+REM Evo-Tactics installer 1-click 5 desktop shortcuts ASCII-only.
 REM Run UNA volta per setup (o re-run per refresh post repo move).
 REM Crea: Evo-Tactics-Demo, Evo-Tactics-Sync-Main, Evo-Tactics-Toggle-A-Classic, Evo-Tactics-Toggle-B-BG3lite.
 

--- a/Evo-Tactics-Setup-Ngrok-Auth.bat
+++ b/Evo-Tactics-Setup-Ngrok-Auth.bat
@@ -1,10 +1,9 @@
 @echo off
-REM Evo-Tactics — ngrok authtoken 1-time setup.
+REM Evo-Tactics ngrok authtoken 1-time setup.
 REM Doppio clic UNA volta per setup ngrok account auth.
-REM Master-dd 2026-04-29: Demo launcher fail "ngrok authtoken assente" → fix qui.
+REM ASCII-only per cmd parser compat (no UTF-8 special chars).
 
 setlocal
-chcp 65001 >nul 2>&1
 title Evo-Tactics Setup ngrok auth
 
 echo.
@@ -12,14 +11,14 @@ echo   ===========================================================
 echo                EVO-TACTICS SETUP NGROK AUTHTOKEN
 echo   ===========================================================
 echo.
-echo   Setup 1-volta. Necessario per Demo launcher (tunnel pubblico).
+echo   Setup 1-volta. Necessario per Demo launcher.
 echo.
-echo   STEP 1 — Account ngrok (gratis 4 connessioni):
-echo            https://ngrok.com/signup
-echo            (skip se gia' account)
+echo   STEP 1: Account ngrok gratis 4 connessioni
+echo           https://ngrok.com/signup
+echo           Salta se gia hai account.
 echo.
-echo   STEP 2 — Copy authtoken:
-echo            https://dashboard.ngrok.com/get-started/your-authtoken
+echo   STEP 2: Copy authtoken
+echo           https://dashboard.ngrok.com/get-started/your-authtoken
 echo.
 echo   ===========================================================
 echo.
@@ -28,14 +27,14 @@ REM Verifica ngrok presence
 where ngrok >nul 2>&1
 if errorlevel 1 (
     echo   [X] ngrok non trovato. Install:
-    echo       https://ngrok.com/download (Windows ZIP, extract in PATH)
+    echo       https://ngrok.com/download Windows ZIP extract in PATH
     echo       OR Microsoft Store "ngrok"
     echo.
     pause
     exit /b 1
 )
 
-echo   STEP 3 — Paste token qui sotto, premi INVIO:
+echo   STEP 3: Paste token qui sotto, premi INVIO
 echo.
 set /p NGROK_TOKEN=Token ngrok:
 
@@ -61,7 +60,7 @@ echo   ===========================================================
 echo                         SETUP COMPLETATO
 echo   ===========================================================
 echo.
-echo   Authtoken salvato in ngrok config (%%USERPROFILE%%\.ngrok2\ngrok.yml).
+echo   Authtoken salvato in ngrok config.
 echo.
 echo   Prossimo step:
 echo         Doppio clic icona desktop "Evo-Tactics-Demo"

--- a/Evo-Tactics-Sync-Main.bat
+++ b/Evo-Tactics-Sync-Main.bat
@@ -1,7 +1,8 @@
 @echo off
-REM Evo-Tactics — Sync main + npm install (esegui prima rubric session se nuove PR mergiate).
-REM Doppio clic desktop shortcut → git pull origin main + npm install (se package.json drift).
+REM Evo-Tactics Sync main + npm install esegui prima rubric session se nuove PR mergiate.
+REM Doppio clic desktop shortcut git pull origin main + npm install se package.json drift.
 REM Hotfix 2026-04-29: worktree-aware. Detect main worktree path se main checked out altrove.
+REM ASCII-only per cmd parser compat.
 
 setlocal
 chcp 65001 >nul 2>&1

--- a/Evo-Tactics-Toggle-A-Classic.bat
+++ b/Evo-Tactics-Toggle-A-Classic.bat
@@ -1,14 +1,14 @@
 @echo off
-REM Evo-Tactics rubric session — toggle MODALITÀ A (grid square classic).
-REM Doppio clic desktop shortcut → set ui_config.json all bg3lite_*: false.
-REM Path A: master-dd rubric session 4 amici tester DIVERSI (ADR-2026-04-28-bg3-lite-plus §9).
+REM Evo-Tactics rubric session toggle MODALITA A grid square classic.
+REM Doppio clic desktop shortcut set ui_config.json all bg3lite false.
+REM Path A: master-dd rubric session 4 amici tester DIVERSI ADR-2026-04-28.
+REM ASCII-only per cmd parser compat.
 
 setlocal
-chcp 65001 >nul 2>&1
 cd /d "%~dp0"
-title Evo-Tactics Rubric Toggle A (Classic)
+title Evo-Tactics Rubric Toggle A Classic
 
-REM Hotfix 2026-04-29: detect main worktree (Node helper, no shell escape issues)
+REM Detect main worktree Node helper no shell escape
 set "MAIN_WT="
 for /f "usebackq delims=" %%P in (`node scripts\find-main-worktree.cjs 2^>nul`) do set "MAIN_WT=%%P"
 
@@ -24,13 +24,13 @@ set "CONFIG_FILE=apps\play\public\data\ui_config.json"
 if not exist "%CONFIG_FILE%" (
     echo.
     echo   [X] %CONFIG_FILE% non trovato.
-    echo       Verifica HEAD branch main >= 9ba3a265 (post Spike POC PR #2003).
+    echo       Verifica HEAD branch main post Spike POC PR 2003.
     echo.
     pause
     exit /b 1
 )
 
-REM Write modalità A — grid square classic (tutti toggle false).
+REM Write modalita A grid square classic tutti toggle false
 > "%CONFIG_FILE%" (
     echo {
     echo   "bg3lite_hide_grid": false,
@@ -42,7 +42,7 @@ REM Write modalità A — grid square classic (tutti toggle false).
 
 echo.
 echo   ===========================================================
-echo                MODALITA' A — GRID SQUARE CLASSIC
+echo                MODALITA A GRID SQUARE CLASSIC
 echo   ===========================================================
 echo.
 echo   Config aggiornata: %CONFIG_FILE%
@@ -54,21 +54,21 @@ echo   ===========================================================
 echo   PROSSIMO STEP rubric session:
 echo   ===========================================================
 echo.
-echo   1. Di' agli amici tester di fare HARD-RELOAD del browser:
-echo         Windows/Linux: Ctrl + Shift + R
-echo         Mac:           Cmd + Shift + R
+echo   1. Di agli amici tester di fare HARD-RELOAD del browser
+echo         Windows/Linux Ctrl + Shift + R
+echo         Mac           Cmd + Shift + R
 echo.
-echo   2. Amici giocano encounter "tutorial_01" ~5 min in modalita' A.
+echo   2. Amici giocano encounter tutorial_01 circa 5 min in modalita A.
 echo.
-echo   3. Annota score 4 criteri (1-5 scale) per ognuno tester:
+echo   3. Annota score 4 criteri 1-5 scale per ognuno tester:
 echo         - Movement smoothness
 echo         - Range readability
-echo         - Combat feel "2024 RPG"
+echo         - Combat feel 2024 RPG
 echo         - Echolocation Skiv lore-faithful
 echo.
-echo   4. Quando finito modalita' A, doppio clic icona desktop:
-echo         "Evo-Tactics-Toggle-B-BG3lite"
-echo      per passare a modalita' B (BG3-lite Tier 1).
+echo   4. Quando finito modalita A, doppio clic icona desktop:
+echo         Evo-Tactics-Toggle-B-BG3lite
+echo      per passare a modalita B BG3-lite Tier 1.
 echo.
 echo   ===========================================================
 echo.

--- a/Evo-Tactics-Toggle-B-BG3lite.bat
+++ b/Evo-Tactics-Toggle-B-BG3lite.bat
@@ -1,14 +1,14 @@
 @echo off
-REM Evo-Tactics rubric session — toggle MODALITÀ B (BG3-lite Tier 1).
-REM Doppio clic desktop shortcut → set ui_config.json all bg3lite_*: true.
-REM Path A: master-dd rubric session 4 amici tester DIVERSI (ADR-2026-04-28-bg3-lite-plus §9).
+REM Evo-Tactics rubric session toggle MODALITA B BG3-lite Tier 1.
+REM Doppio clic desktop shortcut set ui_config.json all bg3lite true.
+REM Path A: master-dd rubric session 4 amici tester DIVERSI ADR-2026-04-28.
+REM ASCII-only per cmd parser compat.
 
 setlocal
-chcp 65001 >nul 2>&1
 cd /d "%~dp0"
-title Evo-Tactics Rubric Toggle B (BG3-lite Tier 1)
+title Evo-Tactics Rubric Toggle B BG3-lite Tier 1
 
-REM Hotfix 2026-04-29: detect main worktree (Node helper, no shell escape issues)
+REM Detect main worktree Node helper no shell escape
 set "MAIN_WT="
 for /f "usebackq delims=" %%P in (`node scripts\find-main-worktree.cjs 2^>nul`) do set "MAIN_WT=%%P"
 
@@ -24,13 +24,13 @@ set "CONFIG_FILE=apps\play\public\data\ui_config.json"
 if not exist "%CONFIG_FILE%" (
     echo.
     echo   [X] %CONFIG_FILE% non trovato.
-    echo       Verifica HEAD branch main >= 9ba3a265 (post Spike POC PR #2003).
+    echo       Verifica HEAD branch main post Spike POC PR 2003.
     echo.
     pause
     exit /b 1
 )
 
-REM Write modalità B — BG3-lite Tier 1 (tutti toggle true).
+REM Write modalita B BG3-lite Tier 1 tutti toggle true
 > "%CONFIG_FILE%" (
     echo {
     echo   "bg3lite_hide_grid": true,
@@ -42,7 +42,7 @@ REM Write modalità B — BG3-lite Tier 1 (tutti toggle true).
 
 echo.
 echo   ===========================================================
-echo              MODALITA' B — BG3-LITE TIER 1 ATTIVA
+echo              MODALITA B BG3-LITE TIER 1 ATTIVA
 echo   ===========================================================
 echo.
 echo   Config aggiornata: %CONFIG_FILE%
@@ -54,24 +54,24 @@ echo   ===========================================================
 echo   PROSSIMO STEP rubric session:
 echo   ===========================================================
 echo.
-echo   1. Di' agli amici tester di fare HARD-RELOAD del browser:
-echo         Windows/Linux: Ctrl + Shift + R
-echo         Mac:           Cmd + Shift + R
+echo   1. Di agli amici tester di fare HARD-RELOAD del browser
+echo         Windows/Linux Ctrl + Shift + R
+echo         Mac           Cmd + Shift + R
 echo.
-echo   2. Amici giocano STESSO encounter "tutorial_01" ~5 min in modalita' B.
+echo   2. Amici giocano STESSO encounter tutorial_01 circa 5 min in modalita B.
 echo.
-echo   3. Annota score 4 criteri (1-5 scale) per ognuno tester:
+echo   3. Annota score 4 criteri 1-5 scale per ognuno tester:
 echo         - Movement smoothness
 echo         - Range readability
-echo         - Combat feel "2024 RPG"
+echo         - Combat feel 2024 RPG
 echo         - Echolocation Skiv lore-faithful
 echo.
-echo   4. Aggregate scores in:
+echo   4. Aggregate scores in
 echo         docs\playtest\2026-04-29-bg3-lite-spike-rubric.md
 echo.
-echo   THRESHOLD PASS (verdict GO Sprint G.2b ~10-12g):
-echo         - Media modalita' B   ^>=  3.5 / 5
-echo         - Zero score 1 in modalita' B
+echo   THRESHOLD PASS verdict GO Sprint G.2b 10-12g:
+echo         - Media modalita B  maggiore o uguale 3.5 / 5
+echo         - Zero score 1 in modalita B
 echo         - Zero criterio rigetto unanime
 echo.
 echo   ===========================================================


### PR DESCRIPTION
Hotfix v3 master-dd 2026-04-29: Setup-Ngrok-Auth.bat cmd parser interpretava echo text come comandi (em-dash + accenti UTF-8 multi-byte). Strip ASCII-only all 6 .bat preventive. Verified zero non-print chars.