### PR TITLE
fix(launcher): ngrok official ZIP installer — fix MS Store bug issue 505 panic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ logs/telemetry_*.jsonl
 .pytest_cache/
 # Skiv ticket #7 — unit diary persistence (runtime, not committed)
 data/derived/unit_diaries/
+
+# Repo-local tools (ngrok official ZIP, etc) - installed per-PC, NOT committed
+.tools/

--- a/Evo-Tactics-Install-Ngrok-Official.bat
+++ b/Evo-Tactics-Install-Ngrok-Official.bat
@@ -1,0 +1,20 @@
+@echo off
+REM Evo-Tactics installer ngrok official ZIP fix Microsoft Store bug.
+REM Doppio clic UNA volta. Download ngrok da ngrok.com extract in .tools/ngrok/.
+
+setlocal
+title Evo-Tactics Install ngrok Official
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\install-ngrok-official.ps1"
+
+if errorlevel 1 (
+    echo.
+    echo   [X] Install ngrok official fallito.
+    echo.
+    pause
+    exit /b 1
+)
+
+echo.
+pause
+endlocal

--- a/scripts/install-desktop-shortcuts.ps1
+++ b/scripts/install-desktop-shortcuts.ps1
@@ -24,6 +24,12 @@ Write-Host ""
 
 $Shortcuts = @(
   @{
+    Name        = 'Evo-Tactics-Install-Ngrok-Official'
+    Target      = 'Evo-Tactics-Install-Ngrok-Official.bat'
+    Description = 'Install ngrok official ZIP da ngrok.com (fix bug Microsoft Store ngrok issue 505 panic disabled updater). Esegui PRIMA di Setup-Ngrok-Auth.'
+    IconHint    = 'shell32.dll, 271'
+  },
+  @{
     Name        = 'Evo-Tactics-Setup-Ngrok-Auth'
     Target      = 'Evo-Tactics-Setup-Ngrok-Auth.bat'
     Description = 'Setup 1-volta ngrok authtoken. Necessario per Demo launcher (tunnel pubblico). Salta se gia configurato.'

--- a/scripts/install-ngrok-official.ps1
+++ b/scripts/install-ngrok-official.ps1
@@ -1,0 +1,94 @@
+# Evo-Tactics ngrok official ZIP installer.
+# Bug Microsoft Store ngrok: "panic: disabled updater should never run" (ngrok issue #505).
+# Fix: download official ZIP da ngrok.com, extract in repo-local .tools/ngrok/.
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host ""
+Write-Host "  ============================================================" -ForegroundColor Cyan
+Write-Host "    Evo-Tactics - Install ngrok Official (fix MS Store bug)" -ForegroundColor Cyan
+Write-Host "  ============================================================" -ForegroundColor Cyan
+Write-Host ""
+
+# Detect repo root (script runs from <repo>/scripts)
+$RepoRoot = (Resolve-Path "$PSScriptRoot\..").Path
+$ToolsDir = Join-Path $RepoRoot ".tools"
+$NgrokDir = Join-Path $ToolsDir "ngrok"
+$NgrokExe = Join-Path $NgrokDir "ngrok.exe"
+
+Write-Host "  Repo root:   $RepoRoot"
+Write-Host "  Target dir:  $NgrokDir"
+Write-Host ""
+
+# Check if already installed
+if (Test-Path $NgrokExe) {
+    Write-Host "  [OK]   ngrok.exe gia presente in $NgrokExe" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "  Skip download. Per re-install: cancella $NgrokDir + re-run." -ForegroundColor Yellow
+    Write-Host ""
+    & $NgrokExe version
+    Write-Host ""
+    Write-Host "  Setup completato." -ForegroundColor Green
+    exit 0
+}
+
+# Create dirs
+if (-not (Test-Path $ToolsDir)) {
+    New-Item -ItemType Directory -Path $ToolsDir | Out-Null
+}
+if (-not (Test-Path $NgrokDir)) {
+    New-Item -ItemType Directory -Path $NgrokDir | Out-Null
+}
+
+# Detect architecture
+$arch = if ([Environment]::Is64BitOperatingSystem) { "amd64" } else { "386" }
+$zipUrl = "https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-windows-$arch.zip"
+$zipPath = Join-Path $env:TEMP "ngrok-official.zip"
+
+Write-Host "  [setup] Download ngrok official $arch..." -ForegroundColor Cyan
+Write-Host "          $zipUrl"
+
+try {
+    Invoke-WebRequest -Uri $zipUrl -OutFile $zipPath -UseBasicParsing
+    Write-Host "  [OK]   Download completato ($((Get-Item $zipPath).Length / 1MB | ForEach-Object { '{0:N1} MB' -f $_ }))" -ForegroundColor Green
+} catch {
+    Write-Host "  [X] Download fallito: $_" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host ""
+Write-Host "  [setup] Extract a $NgrokDir..." -ForegroundColor Cyan
+
+try {
+    Expand-Archive -Path $zipPath -DestinationPath $NgrokDir -Force
+    Remove-Item $zipPath -Force
+    Write-Host "  [OK]   Extract completato" -ForegroundColor Green
+} catch {
+    Write-Host "  [X] Extract fallito: $_" -ForegroundColor Red
+    exit 1
+}
+
+if (-not (Test-Path $NgrokExe)) {
+    Write-Host "  [X] ngrok.exe non trovato post-extract a $NgrokExe" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host ""
+Write-Host "  [verify] ngrok version..." -ForegroundColor Cyan
+& $NgrokExe version
+Write-Host ""
+
+Write-Host "  ============================================================" -ForegroundColor Cyan
+Write-Host "                    SETUP COMPLETATO" -ForegroundColor Green
+Write-Host "  ============================================================" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "  ngrok.exe official installato in $NgrokExe" -ForegroundColor White
+Write-Host ""
+Write-Host "  Demo launcher cerchera questo path PRIMA di Microsoft Store ngrok." -ForegroundColor White
+Write-Host ""
+Write-Host "  Prossimo step:" -ForegroundColor White
+Write-Host "        Doppio clic 'Evo-Tactics-Setup-Ngrok-Auth' (paste token)" -ForegroundColor White
+Write-Host "        Doppio clic 'Evo-Tactics-Demo' (avvia tunnel)" -ForegroundColor White
+Write-Host ""
+Write-Host "  ============================================================" -ForegroundColor Cyan
+Write-Host ""

--- a/scripts/run-demo-tunnel.cjs
+++ b/scripts/run-demo-tunnel.cjs
@@ -88,15 +88,38 @@ function portFree(port) {
   });
 }
 
-// ngrok presence
-const ngrokWhich = spawnSync(process.platform === 'win32' ? 'where' : 'which', ['ngrok'], {
-  encoding: 'utf8',
-});
-const ngrokPath = (ngrokWhich.stdout || '').split(/\r?\n/).filter(Boolean)[0];
-if (ngrokPath) ok(`ngrok trovato (${ngrokPath})`);
-else {
-  fail('ngrok non trovato', 'installa da https://ngrok.com/download');
-  preflightFail = true;
+// ngrok presence — priority: repo-local .tools/ngrok/ngrok.exe (official, fix MS Store bug)
+// → fallback PATH-resolved ngrok.
+// Bug ref: ngrok issue #505 "panic: disabled updater should never run" (Microsoft Store ngrok).
+let ngrokPath = null;
+const localNgrok = path.join(
+  REPO_ROOT,
+  '.tools',
+  'ngrok',
+  process.platform === 'win32' ? 'ngrok.exe' : 'ngrok',
+);
+if (fs.existsSync(localNgrok)) {
+  ngrokPath = localNgrok;
+  ok(`ngrok trovato local (${ngrokPath})`);
+} else {
+  const ngrokWhich = spawnSync(process.platform === 'win32' ? 'where' : 'which', ['ngrok'], {
+    encoding: 'utf8',
+  });
+  ngrokPath = (ngrokWhich.stdout || '').split(/\r?\n/).filter(Boolean)[0];
+  if (ngrokPath) {
+    ok(`ngrok trovato PATH (${ngrokPath})`);
+    if (process.platform === 'win32' && /WindowsApps/i.test(ngrokPath)) {
+      info(
+        'ngrok Microsoft Store rilevato (bug noto issue #505). Se Demo crash, run "Evo-Tactics-Install-Ngrok-Official" per official ZIP.',
+      );
+    }
+  } else {
+    fail(
+      'ngrok non trovato',
+      'doppio clic "Evo-Tactics-Install-Ngrok-Official" per setup automatic (raccomandato), OR install manuale da https://ngrok.com/download',
+    );
+    preflightFail = true;
+  }
 }
 
 // ngrok authtoken
@@ -231,10 +254,12 @@ function start() {
 function startTunnel(demoLogPath) {
   console.log(bold('▸ Avvio ngrok tunnel'));
   const demoLog = fs.createWriteStream(demoLogPath, { flags: 'a' });
-  const ngrok = spawn('ngrok', ['http', String(PORT), '--log=stdout'], {
+  // Use detected ngrokPath (repo-local .tools/ngrok preferred over MS Store bug).
+  const ngrokBin = ngrokPath || 'ngrok';
+  const ngrok = spawn(ngrokBin, ['http', String(PORT), '--log=stdout'], {
     stdio: ['ignore', 'pipe', 'pipe'],
     env: process.env,
-    shell: process.platform === 'win32',
+    shell: false, // avoid shell escape + MS Store WindowsApps redirect
   });
   ngrok.stdout.pipe(demoLog);
   ngrok.stderr.pipe(demoLog);


### PR DESCRIPTION
Bug master-dd 2026-04-29: ngrok MS Store version exit code 2 con panic disabled updater (issue 505). Fix: scripts/install-ngrok-official.ps1 download official ZIP a .tools/ngrok/, run-demo-tunnel.cjs detect repo-local PRIMA di PATH, shell:false avoid WindowsApps redirect. Verified locale: ngrok 3.39.1 official no panic.