### PR TITLE
feat(w5-bb): backend services for Godot v2 W5 wire (cross-repo)

### DIFF
--- a/.claude/skills/asset-workflow.md
+++ b/.claude/skills/asset-workflow.md
@@ -1,0 +1,159 @@
+---
+name: asset-workflow
+description: Orchestrate asset creation workflow Path 1+2+3+4 (Kenney+modify / AI+human / reference+redraw / audio process). Trigger su "asset workflow", "Skiv asset", "Path 1|2|3", "crea icona|sprite|SFX|portrait", "recipe Skiv", "echolocation pulse", "wounded perma", `/asset-workflow`. Pulls workflow doc + workspace HANDOFF recipes + MANIFEST.json. Origine sessione 2026-04-29 workspace 184GB cataloged + 32136 file license-classified.
+---
+
+# /asset-workflow
+
+**Quando invocare**: user chiede _"crea/genera asset / icona / sprite / portrait / SFX / animation / Skiv recipe / Path 1|2|3 / asset workflow"_.
+
+**Quando NON invocare**: bug-fix puntuale code asset-rendering (no creazione), playtest live (no asset gen during runtime), ADR/research doc (separate scope).
+
+## Pre-requisito: leggi workflow canonical
+
+PRIMA di procedere, leggi in ordine:
+
+1. [`docs/guide/asset-creation-workflow.md`](../../docs/guide/asset-creation-workflow.md) — Path 1+2+3 canonical workflow shipping
+2. `~/Documents/evo-tactics-refs/HANDOFF.md` — recipes Skiv asset class + restore guide
+3. `~/Documents/evo-tactics-refs/SKIV_REFS_EXTRACTED.md` — filename-level extracted assets
+4. (opzionale se specific file) `~/Documents/evo-tactics-refs/MANIFEST.json` — 32136 file searchable
+
+Se workspace local NON esiste su questo PC: bootstrap via `git clone https://github.com/MasterDD-L34D/evo-tactics-refs-meta.git ~/Documents/evo-tactics-refs` + run `robust_download.py urls-*.txt` → ~2h bandwidth.
+
+## Flow operativo
+
+### Step 1 — Identify asset target
+
+Match user request to category:
+
+- **Portrait HUD / sprite creature** → 32x32 / 64x64 / 128x128 RGBA PNG
+- **Animation sprite sheet** → multi-frame strip @ N×height
+- **Tile / tileset biome** → 16x16 / 32x32 grid
+- **Ability icon** → 24x24 / 32x32 / 48x48 RGBA
+- **FX overlay** (echolocation, status) → animated PNG strip o GIF
+- **Audio** → idle vocal / combat roar / footstep / ambient / music
+
+### Step 2 — Pick path
+
+| Path                                       | Quando                           | Speed    | Indemnification                      |
+| ------------------------------------------ | -------------------------------- | -------- | ------------------------------------ |
+| **Path 1** Kenney/CC0 base + modify        | Asset standard riconoscibili     | 5-30min  | CC0 explicit modify+commercial OK    |
+| **Path 2** AI Retro Diffusion + human edit | Custom non disponibile CC0       | 10-60min | Retro Diffusion enterprise ToS       |
+| **Path 3** Reference legali + redraw fresh | Anatomy complessi, posing custom | 1-2h     | Original work, idea/expression       |
+| **Path 4** Audio process                   | Vocal/SFX/music                  | 10-30min | Sonniss royalty-free perpetual o CC0 |
+
+### Step 3 — Find source asset (workspace local)
+
+Scan `~/Documents/evo-tactics-refs/references/` per match:
+
+```bash
+# Skiv-feline 32x32 sprite
+ls ~/Documents/evo-tactics-refs/references/pixel-art-retro/denzi/.../monsters/cat/
+
+# Wolf rigged 3D
+ls ~/Documents/evo-tactics-refs/references/3d-models/quaternius-animals/.../FBX/Wolf.fbx
+
+# Sand desert tile
+ls ~/Documents/evo-tactics-refs/references/textures-pbr/ambientcg-sand/
+
+# Skiv echolocation SFX
+ls ~/Documents/evo-tactics-refs/references/sound-fx/skiv-audio-kit/vocals/sand-spell.flac
+
+# MANIFEST query (file-level search)
+python -c "
+import json
+m = json.load(open('~/Documents/evo-tactics-refs/MANIFEST.json'))
+matches = [f for f in m['files'] if 'wolf' in f['path'].lower() and f['ext'] == '.fbx']
+"
+```
+
+### Step 4 — Tool orchestration
+
+| Need                   | Tool                                 | Path                                                                          |
+| ---------------------- | ------------------------------------ | ----------------------------------------------------------------------------- |
+| Pixel art edit/animate | Pixelorama (preferred) o LibreSprite | `~/Documents/evo-tactics-refs/tools-install/pixelorama/.../Pixelorama.exe`    |
+| Audio edit/mix         | Audacity                             | `~/Documents/evo-tactics-refs/tools-install/audacity/.../Audacity.exe`        |
+| Normal map gen 2D      | Laigter                              | `~/Documents/evo-tactics-refs/tools-install/laigter/.../laigter.exe`          |
+| 3D viewer (no install) | https://3dviewer.net                 | browser drag .fbx/.blend/.dae                                                 |
+| 3D model edit          | Blender (manual install 300MB)       | not auto-installed                                                            |
+| Format convert         | Noesis                               | `~/Documents/evo-tactics-refs/tools-install/noesis/Noesis64.exe`              |
+| Procedural tile/biome  | WaveFunctionCollapse mxgmn           | `~/Documents/evo-tactics-refs/tools-install/wfc/.../WaveFunctionCollapse.exe` |
+
+### Step 5 — Output staging + provenance
+
+1. Save WIP in `~/Documents/evo-tactics-refs/output-staging/<asset-slug>/`
+2. Compile session log da template: `~/Documents/evo-tactics-refs/session-logs/<YYYY-MM-DD>-<asset>.md`
+3. Anti-pattern check (NO trace, NO paint-over, NO AI img2img da proprietary, NO style-replication living artist)
+4. Copy final → `Game/assets/<category>/<file>.png`
+5. Update `Game/CREDITS.md` provenance entry:
+   ```
+   - Asset: <name>
+   - Source: <Kenney pack X / Retro Diffusion enterprise / original work inspired by ...>
+   - Modifications: <palette swap, layer composition, ...>
+   - License: <CC0 / Sonniss royalty-free / Retro Diffusion enterprise>
+   - Path: assets/<category>/<file>.png
+   - Date: <YYYY-MM-DD>
+   ```
+6. Commit branch repo Game con message standard: `assets: add <name> (<path-source>)`.
+
+## Recipes Skiv-direct (vedi HANDOFF.md per full)
+
+### Skiv portrait HUD 64x64 (Path 1, ~10min)
+
+```
+1. Pixelorama → open ~/Documents/evo-tactics-refs/references/pixel-art-retro/skiv-desert-pack/All/Wild Animals/Fox/Fox_Idle.png
+2. Slice frame 1 (36x36 base)
+3. Scale 36→64 nearest-neighbor
+4. Palette swap → Skiv canon (sandy/dust/bone)
+5. Add dorsal stripes + ridge marker
+6. Export → output-staging/skiv-portrait-64.png
+```
+
+### Skiv echolocation pulse SFX 800ms (Path 4)
+
+```
+1. Audacity → ~/Documents/evo-tactics-refs/references/sound-fx/skiv-audio-kit/vocals/sand-spell.flac
+2. Trim to 800ms one-shot
+3. EQ high-pass 2kHz (cyan tone)
+4. Reverb tail short
+5. Export → Game/assets/audio/skiv-echolocation-pulse.wav
+6. CREDITS: HF OGA-CC0 sand-spell.flac (CC0)
+```
+
+### Skiv run cycle 36x36 sprite sheet (Path 1, ~30min)
+
+```
+1. Pixelorama → Fox_Run.png (384x36, 10 frame)
+2. Slice into 10 frames
+3. Modify palette + dorsal markers consistent across frames
+4. Export PNG strip 384x36
+5. Game/assets/catalog/skiv-run-cycle.png
+```
+
+### Skiv combat roar (Path 4)
+
+```
+1. Audacity → ~/Documents/evo-tactics-refs/references/sound-fx/skiv-audio-kit/creature-pack/80-CC0-creature/roar_01.ogg
+2. Layer with whoosh-impact/Punch-Elem Whoosh1 01.wav
+3. Mix + master normalize -3dB
+4. Export → Game/assets/audio/skiv-attack-roar.wav
+```
+
+## Anti-pattern (vedi ADR-2026-04-18 + workflow doc)
+
+- ❌ Commit reference asset locali a repo (DMCA fastlane on public repo)
+- ❌ Trace su sprite proprietary (anche layer separato)
+- ❌ Paint-over fan-rip / spriters-resource / vg-resource / models-resource
+- ❌ AI img2img da asset proprietary
+- ❌ Style prompt che cita artisti viventi
+- ❌ Skip provenance log `CREDITS.md`
+
+## Cross-ref
+
+- ADR zero-cost: [`docs/adr/ADR-2026-04-18-zero-cost-asset-policy.md`](../../docs/adr/ADR-2026-04-18-zero-cost-asset-policy.md)
+- Policy canonical: [`docs/core/43-ASSET-SOURCING.md`](../../docs/core/43-ASSET-SOURCING.md)
+- Workflow shipping: [`docs/guide/asset-creation-workflow.md`](../../docs/guide/asset-creation-workflow.md)
+- Skiv canonical: [`docs/skiv/CANONICAL.md`](../../docs/skiv/CANONICAL.md)
+- Workspace handoff: `~/Documents/evo-tactics-refs/HANDOFF.md`
+- Backup meta repo: https://github.com/MasterDD-L34D/evo-tactics-refs-meta
+- Memory: [`reference_asset_workspace.md`](~/.claude/projects/C--Users-VGit-Desktop-Game/memory/reference_asset_workspace.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -619,3 +619,22 @@ Diagnosticato 2026-04-26: ~30% delle 61 voci catalogate (18/61) hanno **runtime 
 - Quando review PR autonomous mode
 
 Ref memoria: vedi pattern dominante in [`docs/research/2026-04-26-cross-game-extraction-MASTER.md §4`](docs/research/2026-04-26-cross-game-extraction-MASTER.md), [`docs/research/2026-04-26-agent-integration-plan-DETAILED.md §4`](docs/research/2026-04-26-agent-integration-plan-DETAILED.md), [`docs/reports/2026-04-27-stato-arte-completo-vertical-slice.md §C.2`](docs/reports/2026-04-27-stato-arte-completo-vertical-slice.md).
+
+## 🎨 Asset workflow (canonical 2026-04-29)
+
+Per creare/acquisire asset visivi/audio Evo-Tactics:
+
+1. **Workflow doc primary**: [`docs/guide/asset-creation-workflow.md`](docs/guide/asset-creation-workflow.md) — Path 1 (Kenney+modify) / Path 2 (AI Retro Diffusion + human edit) / Path 3 (reference legali + redraw fresh).
+2. **Workspace locale** (out-of-repo, gitignored by design DMCA mitigation): `~/Documents/evo-tactics-refs/` 184GB — 32136 file CC0+PD+Sonniss royalty-free 100% license-classified, 10/14 tools auto-installed, recipes Skiv asset class in `HANDOFF.md` + `SKIV_REFS_EXTRACTED.md`.
+3. **Backup meta repo** (private): [`MasterDD-L34D/evo-tactics-refs-meta`](https://github.com/MasterDD-L34D/evo-tactics-refs-meta) — doc + scripts (`robust_download.py` + `gen_manifest.py`) + URL lists pre-scraped (Kenney/HF/Sonniss/archive.org) + MANIFEST.json file-level index. Asset binaries NON committati (rebuildable cross-PC ~2h via bootstrap).
+4. **Skill on-demand**: invoca `/asset-workflow` per orchestrate Path 1+2+3+4 con recipes Skiv direct.
+5. **Trigger phrase user**: _"asset workflow / Skiv asset / Path 1|2|3 / crea icona|sprite|SFX / recipe Skiv"_ → leggi workflow doc + apri `~/Documents/evo-tactics-refs/HANDOFF.md`.
+
+**Anti-pattern check** (vedi ADR-2026-04-18 + workflow doc):
+
+- ❌ Commit reference asset locali a repo (DMCA fastlane on public repo)
+- ❌ Trace su sprite proprietary
+- ❌ Paint-over fan-rip
+- ❌ AI img2img da asset proprietary
+- ❌ Style prompt artisti viventi
+- ❌ Skip provenance log `CREDITS.md`

--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -161,21 +161,42 @@ function createCoopRouter({ lobby, coopStore } = {}) {
   });
 
   router.post('/coop/world/confirm', (req, res) => {
-    const { code, host_token: hostToken, scenario_id: scenarioId } = req.body || {};
+    const {
+      code,
+      host_token: hostToken,
+      scenario_id: scenarioId,
+      // W5-bb cross-repo (Godot v2 mirror): rich payload inputs.
+      biome_id: biomeId,
+      form_axes: formAxes,
+      run_seed: runSeed,
+      trainer_canonical: trainerCanonical,
+    } = req.body || {};
     const room = authHost(code, hostToken);
     if (!room) return res.status(403).json({ error: 'host_auth_failed' });
     const orch = coopStore.get(code);
     if (!orch) return res.status(409).json({ error: 'run_not_started' });
     try {
-      const result = orch.confirmWorld({ scenarioId });
+      const result = orch.confirmWorld({
+        scenarioId,
+        biomeId,
+        formAxes,
+        runSeed,
+        trainerCanonical,
+      });
       broadcastCoopState(room, orch);
       // Return session-start payload so host can forward to /api/session/start.
       const startPayload = orch.buildSessionStartPayload();
-      return res.json({
+      const response = {
         scenario_id: result.scenario_id,
         phase: orch.phase,
         session_start_payload: startPayload,
-      });
+      };
+      // W5-bb: surface enriched world (world/ermes/aliena/custode) when
+      // biomeId provided. Godot v2 WorldSetupState consumes these fields.
+      if (result.enriched_world) {
+        Object.assign(response, result.enriched_world);
+      }
+      return res.json(response);
     } catch (err) {
       return res.status(400).json({ error: err.message || 'world_confirm_failed' });
     }

--- a/apps/backend/services/companion/companionPicker.js
+++ b/apps/backend/services/companion/companionPicker.js
@@ -1,0 +1,160 @@
+// W5-bb (cross-repo Godot v2 mirror) — Companion Picker service.
+//
+// Mirrors Godot v2 `scripts/data/companion_picker.gd` (PR #62):
+//   https://github.com/MasterDD-L34D/Game-Godot-v2/blob/main/scripts/data/companion_picker.gd
+//
+// Loads skiv_archetype_pool.yaml + deterministic pick logic (B3 hybrid
+// override + species + name (RNG seeded) + closing + MBTI bias).
+//
+// Schema source: data/core/companion/skiv_archetype_pool.yaml v0.1
+//
+// Surface: companionPicker.pick({ poolPath?, biomeId, formAxes?, runSeed?, trainerCanonical? })
+//   → { display_name, species_id, biome_origin_id, voice_it,
+//       opening_line, closing_ritual, voice_modifier }
+//
+// B3 hybrid: trainerCanonical=true AND biomeId="savana" → Skiv canonical.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const DEFAULT_POOL_PATH = path.resolve(
+  __dirname,
+  '../../../../data/core/companion/skiv_archetype_pool.yaml',
+);
+
+const CANONICAL_SKIV = Object.freeze({
+  display_name: 'Skiv',
+  species_id: 'dune_stalker',
+  biome_origin_id: 'savana',
+  voice_it: 'Allenatore, sento il calore salire prima che il sole sia visibile.',
+  opening_line: 'Allenatore, riconosco il tuo passo.',
+  closing_ritual: 'Sabbia segue.',
+  voice_modifier: 'canonical',
+});
+
+let _cachedPool = null;
+let _cachedPoolPath = null;
+
+function _loadPool(poolPath = DEFAULT_POOL_PATH) {
+  if (_cachedPool && _cachedPoolPath === poolPath) return _cachedPool;
+  if (!fs.existsSync(poolPath)) return null;
+  const raw = fs.readFileSync(poolPath, 'utf8');
+  const data = yaml.load(raw);
+  if (!data || typeof data !== 'object') return null;
+  _cachedPool = data;
+  _cachedPoolPath = poolPath;
+  return data;
+}
+
+// Test-only: clear cached pool so tests with custom pool paths re-load.
+function _resetCache() {
+  _cachedPool = null;
+  _cachedPoolPath = null;
+}
+
+// Deterministic seeded RNG (mulberry32). Matches Godot
+// RandomNumberGenerator behavior closely enough for parity tests.
+function _seededRng(seed) {
+  let s = seed | 0 || 1;
+  return function () {
+    s = (s + 0x6d2b79f5) | 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function _resolveBiomePool(pool, biomeId) {
+  const pools = pool && pool.biome_pools ? pool.biome_pools : {};
+  if (pools[biomeId]) return { biomePool: pools[biomeId], biomeOriginId: biomeId };
+  // Fallback per skiv_archetype_pool.yaml §generative_rules.fallback rule
+  // ("primary_biome NOT in biome_species_pool → use savana pool").
+  const fallback = pools.savana;
+  if (fallback) return { biomePool: fallback, biomeOriginId: 'savana' };
+  return { biomePool: null, biomeOriginId: biomeId };
+}
+
+function _resolveVoiceModifier(pool, formAxes = {}) {
+  const threshold = 0.6;
+  const t = Number.isFinite(formAxes.T) ? formAxes.T : 0.5;
+  const f = Number.isFinite(formAxes.F) ? formAxes.F : 0.5;
+  const n = Number.isFinite(formAxes.N) ? formAxes.N : 0.5;
+  const s = Number.isFinite(formAxes.S) ? formAxes.S : 0.5;
+  const mods = (pool && pool.generative_rules && pool.generative_rules.mbti_personality_bias) || {};
+  if (t >= threshold && t > f) return mods.solitari_t_high?.voice_modifier || 'fredda_analitica';
+  if (f >= threshold && f > t) return mods.simbionti_f_high?.voice_modifier || 'empatica_branco';
+  if (n >= threshold && n > s)
+    return mods.esploratori_n_high?.voice_modifier || 'visionaria_intuitiva';
+  if (s >= threshold && s > n)
+    return mods.sensoriali_s_high?.voice_modifier || 'sensoriale_presente';
+  return '';
+}
+
+function _trimSuffixDot(s) {
+  return s.endsWith('.') ? s.slice(0, -1) : s;
+}
+
+/**
+ * Deterministic companion archetype pick.
+ *
+ * @param {object} opts
+ * @param {string} [opts.poolPath]            — skiv_archetype_pool.yaml path
+ * @param {string} opts.biomeId               — primary biome slug
+ * @param {object} [opts.formAxes]            — party MBTI {T,F,N,S} ∈ [0,1]
+ * @param {number} [opts.runSeed=0]           — deterministic name+closing seed
+ * @param {boolean} [opts.trainerCanonical]   — B3 hybrid override flag
+ * @returns {object} CompanionInstance or {} when pool missing
+ */
+function pick(opts = {}) {
+  const {
+    poolPath = DEFAULT_POOL_PATH,
+    biomeId,
+    formAxes = {},
+    runSeed = 0,
+    trainerCanonical = false,
+  } = opts;
+  if (!biomeId || typeof biomeId !== 'string') return {};
+  // B3 hybrid override: canonical trainer in savana → Skiv canonical.
+  if (trainerCanonical && biomeId === 'savana') {
+    return { ...CANONICAL_SKIV };
+  }
+  const pool = _loadPool(poolPath);
+  if (!pool) return {};
+  const { biomePool, biomeOriginId } = _resolveBiomePool(pool, biomeId);
+  if (!biomePool) return {};
+  const speciesPool = Array.isArray(biomePool.species_pool) ? biomePool.species_pool : [];
+  const namePool = Array.isArray(biomePool.name_pool) ? biomePool.name_pool : [];
+  const metaphorSet = Array.isArray(biomePool.biome_metaphor_set)
+    ? biomePool.biome_metaphor_set
+    : [];
+  const closingPool = Array.isArray(biomePool.closing_pool) ? biomePool.closing_pool : [];
+  // Species pick: first entry deterministic. Role-gap refinement deferred
+  // until ERMES eco_pressure_score available (W5.5).
+  const speciesId = speciesPool[0] && typeof speciesPool[0] === 'object' ? speciesPool[0].id : '';
+  const rng = _seededRng(runSeed);
+  const name = namePool.length > 0 ? namePool[Math.floor(rng() * namePool.length)] : '';
+  const closing = closingPool.length > 0 ? closingPool[Math.floor(rng() * closingPool.length)] : '';
+  const metaphor =
+    metaphorSet.length > 0 ? metaphorSet[Math.floor(rng() * metaphorSet.length)] : '';
+  const voiceModifier = _resolveVoiceModifier(pool, formAxes);
+  return {
+    display_name: name,
+    species_id: typeof speciesId === 'string' ? speciesId : '',
+    biome_origin_id: biomeOriginId,
+    voice_it: metaphor ? `Allenatore, ${_trimSuffixDot(metaphor)}.` : '',
+    opening_line: metaphor ? `Allenatore, ${_trimSuffixDot(metaphor)}.` : '',
+    closing_ritual: closing,
+    voice_modifier: voiceModifier,
+  };
+}
+
+module.exports = {
+  pick,
+  CANONICAL_SKIV,
+  _resetCache,
+  DEFAULT_POOL_PATH,
+};

--- a/apps/backend/services/coop/alienaGenerator.js
+++ b/apps/backend/services/coop/alienaGenerator.js
@@ -1,0 +1,75 @@
+// W5-bb (cross-repo Godot v2 mirror) — A.L.I.E.N.A. authoring service.
+//
+// Surfaces player-facing world summary (`aliena_summary_it`) without ever
+// labeling the system itself to player. Doctrine: A.L.I.E.N.A. is a
+// behind-the-scenes coherence framework; player sees only the world
+// statement it produces.
+//
+// Phase A (W5-bb MVP): static per-biome template lookup. Static strings
+// match Godot v2 sample JSON (`data/world_setup/sample_world_setup_*.json`).
+//
+// Phase B (deferred W5.5+): LLM-prompted dynamic generation OR
+// template-based with biome × party form_axes parameterization.
+
+'use strict';
+
+// Static per-biome aliena_summary_it. Mirrors Godot v2 sample JSON content.
+// Keys MUST match biomes.yaml ids verbatim.
+const STATIC_SUMMARIES = Object.freeze({
+  savana:
+    'Savana al margine arido: predatori in branco si contendono il territorio sotto pressione idrica crescente. La memoria del bioma favorisce predatori veloci e tattiche di flanking.',
+  caverna:
+    "Caverna risonante: il buio è una rete sensoriale; chi non sa leggere l'eco resta indietro. La pressione moltiplica gli errori, ma rivela anche le scorciatoie del branco.",
+  atollo_obsidiana:
+    'Atollo di ossidiana: il magnetismo qui non è ostacolo, è linguaggio. Le creature locali navigano dove altri si perdono — la forma del territorio cambia più veloce della memoria.',
+  foresta_temperata:
+    'Foresta temperata in equilibrio: il bosco osserva e ricorda. Predatori aerei dominano la canopia; chi sa muoversi nel sottobosco senza interrompere i suoni passa indisturbato.',
+  badlands:
+    'Calanchi ferromagnetici: il ferro nel terreno tira ogni movimento. Sopravvive chi capisce quando cedere alla pressione e quando spingere oltre la rovina.',
+  foresta_miceliale:
+    'Foresta miceliale: il sottobosco pulsa di reti vegetali interconnesse. Chi parla la lingua delle spore trova alleati invisibili.',
+  abisso_vulcanico:
+    'Abisso vulcanico: il calore impone ritmo. Le creature locali si muovono in finestre termiche che chi non legge le fumarole ignora a proprio rischio.',
+  reef_luminescente:
+    'Reef luminescente: la luce viene dal basso e racconta storie. Il branco si orienta per fotofase, non per gravità.',
+  caldera_glaciale:
+    'Caldera glaciale: il gelo conserva memoria. Chi cammina lascia traccia chimica per stagioni, e qualcuno la legge sempre.',
+  pianura_salina_iperarida:
+    'Pianura salina iperarida: il sale corrode ogni passo lento. Sopravvive chi ha imparato a muoversi in finestre brevi, prima che la disidratazione arbitra.',
+  mezzanotte_orbitale:
+    'Mezzanotte orbitale: il vuoto custodisce piccole voci. Le orbite suggeriscono rotte invisibili a chi non ha pazienza.',
+  frattura_abissale_sinaptica:
+    'Frattura abissale sinaptica: la rete neurale del bioma decide prima del corpo. Chi entra senza ascoltare la rete viene scartato come segnale spurio.',
+  foresta_acida:
+    "Foresta acida: ogni passo richiede gradiente chimico. Le creature locali vivono dove l'acidità è linguaggio, non ostacolo.",
+});
+
+const FALLBACK_SUMMARY =
+  'Il bioma respira con regole proprie. Osserva prima di decidere: il mondo si forma intorno a chi sa ascoltare.';
+
+/**
+ * Generate player-facing aliena_summary_it for a biome.
+ *
+ * @param {string} biomeId — biome slug
+ * @param {object} [opts]
+ * @returns {string} player-facing summary (never labeled "ALIENA")
+ */
+function generateAlienaSummary(biomeId, _opts = {}) {
+  if (!biomeId || typeof biomeId !== 'string') return FALLBACK_SUMMARY;
+  return STATIC_SUMMARIES[biomeId] || FALLBACK_SUMMARY;
+}
+
+/**
+ * Generate authoring tags (debug-only / never player-facing).
+ * Deferred to W5.5+; returns empty array for MVP.
+ */
+function generateAuthoringTags(_biomeId, _opts = {}) {
+  return [];
+}
+
+module.exports = {
+  generateAlienaSummary,
+  generateAuthoringTags,
+  STATIC_SUMMARIES,
+  FALLBACK_SUMMARY,
+};

--- a/apps/backend/services/coop/biomeAdapter.js
+++ b/apps/backend/services/coop/biomeAdapter.js
@@ -1,0 +1,124 @@
+// W5-bb (cross-repo Godot v2 mirror) — Biome adapter service.
+//
+// Maps biomeSynthesizer/biomes.yaml output → W5 canonical schema
+// consumed by Godot v2 WorldSetupState (`scripts/session/world_setup_state.gd`):
+//
+//   {
+//     biome_id: 'savana',
+//     biome_label_it: 'Savana del Crepuscolo',
+//     pressure: 'medium' | 'low' | 'high',
+//     hazards: ['sandstorm_intermittent', 'predator_pack_cycle']
+//   }
+//
+// Source: data/core/biomes.yaml (single source, 20+ biomes per Q.2 ETL).
+//
+// Pressure derivation: maps biome.diff_base (1-5) + biome.hazard.severity →
+// 'low' | 'medium' | 'high' bucket. ERMES eco_pressure_score (W5.5) will
+// override at runtime when available.
+//
+// Hazard list: extracts biome.hazard.description first, supplements with
+// ecological hazards via biome.affixes (e.g., heat_resistance, pack_cycle).
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const DEFAULT_BIOMES_PATH = path.resolve(__dirname, '../../../../data/core/biomes.yaml');
+
+let _cachedBiomes = null;
+let _cachedPath = null;
+
+function _loadBiomes(biomesPath = DEFAULT_BIOMES_PATH) {
+  if (_cachedBiomes && _cachedPath === biomesPath) return _cachedBiomes;
+  if (!fs.existsSync(biomesPath)) return null;
+  const raw = fs.readFileSync(biomesPath, 'utf8');
+  const data = yaml.load(raw);
+  if (!data || typeof data !== 'object') return null;
+  _cachedBiomes = data;
+  _cachedPath = biomesPath;
+  return data;
+}
+
+function _resetCache() {
+  _cachedBiomes = null;
+  _cachedPath = null;
+}
+
+// Pressure bucketization heuristic (W5 minimal). ERMES override (W5.5)
+// will derive pressure from eco_pressure_score directly.
+function _derivePressure(biome) {
+  const diff = Number(biome && biome.diff_base) || 1;
+  const severity = biome && biome.hazard && biome.hazard.severity;
+  if (diff >= 4 || severity === 'high') return 'high';
+  if (diff >= 2 || severity === 'medium') return 'medium';
+  return 'low';
+}
+
+// Hazard list extraction. Combines biome.hazard.description tokens +
+// biome.affixes (ecological tags).
+function _deriveHazards(biome) {
+  const out = [];
+  const hazard = biome && biome.hazard;
+  if (hazard && typeof hazard === 'object') {
+    if (hazard.id && typeof hazard.id === 'string') out.push(hazard.id);
+    else if (hazard.description && typeof hazard.description === 'string') {
+      // Slugify description if no canonical id
+      const slug = hazard.description
+        .toLowerCase()
+        .replace(/[^\w\s-]/g, '')
+        .replace(/\s+/g, '_');
+      if (slug) out.push(slug);
+    }
+  }
+  const affixes = Array.isArray(biome && biome.affixes) ? biome.affixes : [];
+  for (const aff of affixes) {
+    if (typeof aff === 'string' && !out.includes(aff)) out.push(aff);
+  }
+  return out;
+}
+
+/**
+ * Map biome (from data/core/biomes.yaml) to W5 schema dict.
+ *
+ * @param {string} biomeId — biome slug (e.g. "savana", "atollo_obsidiana")
+ * @param {object} [opts]
+ * @param {string} [opts.biomesPath] — override yaml path
+ * @returns {object} W5 schema {biome_id, biome_label_it, pressure, hazards} or {} on miss
+ */
+function adaptBiome(biomeId, opts = {}) {
+  if (!biomeId || typeof biomeId !== 'string') return {};
+  const { biomesPath = DEFAULT_BIOMES_PATH } = opts;
+  const biomes = _loadBiomes(biomesPath);
+  if (!biomes) return {};
+  const biome = biomes[biomeId] || biomes.biomes?.[biomeId];
+  if (!biome || typeof biome !== 'object') return {};
+  return {
+    biome_id: biomeId,
+    biome_label_it: String(biome.display_name_it || biome.label || biome.display_name || biomeId),
+    pressure: _derivePressure(biome),
+    hazards: _deriveHazards(biome),
+  };
+}
+
+/**
+ * List all known biome ids from data file.
+ */
+function listBiomeIds(opts = {}) {
+  const { biomesPath = DEFAULT_BIOMES_PATH } = opts;
+  const biomes = _loadBiomes(biomesPath);
+  if (!biomes) return [];
+  // biomes.yaml may be flat dict OR { biomes: {...} } nested.
+  const dict = biomes.biomes && typeof biomes.biomes === 'object' ? biomes.biomes : biomes;
+  return Object.keys(dict).filter(
+    (k) => k !== 'version' && k !== 'schema_version' && !k.startsWith('_'),
+  );
+}
+
+module.exports = {
+  adaptBiome,
+  listBiomeIds,
+  _resetCache,
+  DEFAULT_BIOMES_PATH,
+};

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -30,7 +30,7 @@ function characterToUnit(character, { index = 0 } = {}) {
 }
 
 class CoopOrchestrator {
-  constructor({ roomCode, hostId, now = Date.now }) {
+  constructor({ roomCode, hostId, now = Date.now, worldEnricher = null } = {}) {
     if (!roomCode) throw new Error('room_code_required');
     this.roomCode = roomCode;
     this.hostId = hostId || null;
@@ -42,6 +42,17 @@ class CoopOrchestrator {
     this.debriefChoices = new Map();
     this.log = [];
     this._listeners = new Set();
+    // W5-bb (cross-repo Godot v2 mirror) — world enricher service injection.
+    // Default lazy-loads the canonical service module on first use.
+    this._worldEnricher = worldEnricher;
+    this.enrichedWorld = null; // populated by confirmWorld() with rich schema
+  }
+
+  _getWorldEnricher() {
+    if (this._worldEnricher) return this._worldEnricher;
+    // eslint-disable-next-line global-require
+    this._worldEnricher = require('./worldEnricher');
+    return this._worldEnricher;
   }
 
   _emit(kind, payload = {}) {
@@ -155,14 +166,37 @@ class CoopOrchestrator {
    * Confirm scenario for this run. Moves phase world_setup → combat.
    * Voting logic deferred to M17 (host confirm for MVP).
    */
-  confirmWorld({ scenarioId } = {}) {
+  confirmWorld({ scenarioId, biomeId, formAxes, runSeed, trainerCanonical } = {}) {
     if (this.phase !== 'world_setup') throw new Error('not_in_world_setup');
     const sid = scenarioId || this.run?.scenarioStack?.[this.run.currentIndex];
     if (!sid) throw new Error('scenario_required');
     this.run.scenarioStack[this.run.currentIndex] = sid;
-    this._emit('world_confirmed', { scenario_id: sid });
+    // W5-bb cross-repo: enrich with rich W5 schema (world+ermes+aliena+custode)
+    // when biomeId provided. Backwards-compat: caller may omit biomeId for
+    // legacy paths; enriched_world stays null.
+    let enrichedWorld = null;
+    if (biomeId && typeof biomeId === 'string') {
+      try {
+        const enricher = this._getWorldEnricher();
+        enrichedWorld = enricher.enrichWorld({
+          biomeId,
+          formAxes: formAxes || {},
+          runSeed: Number.isFinite(runSeed) ? runSeed : 0,
+          trainerCanonical: Boolean(trainerCanonical),
+        });
+        this.enrichedWorld = enrichedWorld;
+      } catch (err) {
+        // Enricher failure must not break confirmWorld phase transition.
+        // Log but proceed — Godot client falls back to sample JSON gracefully.
+        this._emit('world_enricher_failed', { error: String(err && err.message) });
+      }
+    }
+    this._emit('world_confirmed', { scenario_id: sid, biome_id: biomeId || null });
     this._setPhase('combat');
-    return { scenario_id: sid };
+    return {
+      scenario_id: sid,
+      enriched_world: enrichedWorld,
+    };
   }
 
   /**

--- a/apps/backend/services/coop/ermesExporter.js
+++ b/apps/backend/services/coop/ermesExporter.js
@@ -1,0 +1,152 @@
+// W5-bb (cross-repo Godot v2 mirror) — ERMES eco_pressure exporter.
+//
+// Reads `prototypes/ermes_lab/outputs/latest_eco_pressure_report.json`
+// when populated, falls back to per-biome static defaults.
+//
+// W5-bb MVP: file-based read + static fallback. Phase B (W5.5+) will
+// wire ERMES lab runtime computation (currently prototype isolated).
+//
+// Output (W5 schema consumed by Godot v2 WorldSetupState.ermes):
+//   {
+//     eco_pressure_score: 0.62,        // float [0, 1]
+//     bias: {                          // bias keys mapped to player-readable
+//       predator_density: 0.7,
+//       resource_scarcity: 0.55
+//     }
+//   }
+//
+// Doctrine: ERMES system name NEVER surfaces to player. Output is
+// diegetic (eco_pressure_score → "Pressione ecosistemica: 62%").
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DEFAULT_REPORT_PATH = path.resolve(
+  __dirname,
+  '../../../../prototypes/ermes_lab/outputs/latest_eco_pressure_report.json',
+);
+
+// Per-biome ERMES static defaults (mirror sample JSON variants).
+const STATIC_FALLBACKS = Object.freeze({
+  savana: {
+    eco_pressure_score: 0.62,
+    bias: {
+      predator_density: 0.7,
+      resource_scarcity: 0.55,
+    },
+  },
+  caverna: {
+    eco_pressure_score: 0.78,
+    bias: {
+      ambush_risk: 0.65,
+      echo_chain_disorient: 0.5,
+    },
+  },
+  atollo_obsidiana: {
+    eco_pressure_score: 0.45,
+    bias: {
+      magnetic_interference: 0.7,
+      tide_unpredictability: 0.6,
+    },
+  },
+  foresta_temperata: {
+    eco_pressure_score: 0.32,
+    bias: {
+      canopy_ambush: 0.55,
+      mist_disorient: 0.4,
+    },
+  },
+  badlands: {
+    eco_pressure_score: 0.55,
+    bias: {
+      magnetic_pull: 0.6,
+      ruin_collapse: 0.5,
+    },
+  },
+});
+
+const NEUTRAL_FALLBACK = Object.freeze({
+  eco_pressure_score: 0.5,
+  bias: {},
+});
+
+let _cachedReport = null;
+let _cachedPath = null;
+let _cachedMissing = false;
+
+function _loadReport(reportPath) {
+  if (reportPath === _cachedPath) {
+    if (_cachedMissing) return null;
+    if (_cachedReport) return _cachedReport;
+  }
+  _cachedPath = reportPath;
+  if (!fs.existsSync(reportPath)) {
+    _cachedMissing = true;
+    _cachedReport = null;
+    return null;
+  }
+  try {
+    const raw = fs.readFileSync(reportPath, 'utf8');
+    if (!raw.trim()) {
+      _cachedMissing = true;
+      return null;
+    }
+    const data = JSON.parse(raw);
+    _cachedMissing = false;
+    _cachedReport = data;
+    return data;
+  } catch (_err) {
+    _cachedMissing = true;
+    _cachedReport = null;
+    return null;
+  }
+}
+
+function _resetCache() {
+  _cachedReport = null;
+  _cachedPath = null;
+  _cachedMissing = false;
+}
+
+/**
+ * Get ERMES eco_pressure data for a biome.
+ *
+ * @param {string} biomeId — biome slug
+ * @param {object} [opts]
+ * @param {string} [opts.reportPath] — override report path
+ * @returns {object} {eco_pressure_score, bias} W5 schema
+ */
+function getErmesForBiome(biomeId, opts = {}) {
+  if (!biomeId || typeof biomeId !== 'string') return { ...NEUTRAL_FALLBACK };
+  const { reportPath = DEFAULT_REPORT_PATH } = opts;
+  const report = _loadReport(reportPath);
+  // Runtime report shape: { biomes: { savana: {eco_pressure_score, bias}, ... } }
+  if (report && report.biomes && typeof report.biomes === 'object') {
+    const biomeReport = report.biomes[biomeId];
+    if (biomeReport && typeof biomeReport === 'object') {
+      return {
+        eco_pressure_score: Number(biomeReport.eco_pressure_score) || 0,
+        bias:
+          biomeReport.bias && typeof biomeReport.bias === 'object' ? { ...biomeReport.bias } : {},
+      };
+    }
+  }
+  // Static fallback per biome.
+  if (STATIC_FALLBACKS[biomeId]) {
+    return {
+      eco_pressure_score: STATIC_FALLBACKS[biomeId].eco_pressure_score,
+      bias: { ...STATIC_FALLBACKS[biomeId].bias },
+    };
+  }
+  return { ...NEUTRAL_FALLBACK };
+}
+
+module.exports = {
+  getErmesForBiome,
+  STATIC_FALLBACKS,
+  NEUTRAL_FALLBACK,
+  _resetCache,
+  DEFAULT_REPORT_PATH,
+};

--- a/apps/backend/services/coop/worldEnricher.js
+++ b/apps/backend/services/coop/worldEnricher.js
@@ -1,0 +1,62 @@
+// W5-bb (cross-repo Godot v2 mirror) — World enricher facade.
+//
+// Single entrypoint that combines biomeAdapter + alienaGenerator +
+// ermesExporter + companionPicker to produce W5-canonical rich payload
+// consumed by Godot v2 WorldSetupState.
+//
+// Output shape (matches `data/world_setup/sample_world_setup_*.json` in
+// Game-Godot-v2 repo):
+//
+//   {
+//     world: { biome_id, biome_label_it, pressure, hazards },
+//     ermes: { eco_pressure_score, bias },
+//     aliena_summary_it: '...',
+//     custode: { display_name, species_id, biome_origin_id, voice_it,
+//                opening_line, closing_ritual, voice_modifier },
+//   }
+//
+// Stateless: pure function over inputs + service dependencies. Services
+// are injectable for tests.
+
+'use strict';
+
+const biomeAdapterDefault = require('./biomeAdapter');
+const alienaGeneratorDefault = require('./alienaGenerator');
+const ermesExporterDefault = require('./ermesExporter');
+const companionPickerDefault = require('../companion/companionPicker');
+
+/**
+ * Enrich a confirmed world with full W5 schema rich fields.
+ *
+ * @param {object} input
+ * @param {string} input.biomeId — primary biome slug
+ * @param {object} [input.formAxes] — party MBTI {T,F,N,S}
+ * @param {number} [input.runSeed=0] — deterministic name+closing seed
+ * @param {boolean} [input.trainerCanonical] — B3 hybrid override (Skiv)
+ * @param {object} [services] — service injection for tests
+ * @returns {object} {world, ermes, aliena_summary_it, custode}
+ */
+function enrichWorld(input = {}, services = {}) {
+  const { biomeId, formAxes = {}, runSeed = 0, trainerCanonical = false } = input;
+  const biomeAdapter = services.biomeAdapter || biomeAdapterDefault;
+  const alienaGenerator = services.alienaGenerator || alienaGeneratorDefault;
+  const ermesExporter = services.ermesExporter || ermesExporterDefault;
+  const companionPicker = services.companionPicker || companionPickerDefault;
+  if (!biomeId || typeof biomeId !== 'string') {
+    return { world: {}, ermes: {}, aliena_summary_it: '', custode: {} };
+  }
+  const world = biomeAdapter.adaptBiome(biomeId);
+  const ermes = ermesExporter.getErmesForBiome(biomeId);
+  const aliena_summary_it = alienaGenerator.generateAlienaSummary(biomeId);
+  const custode = companionPicker.pick({
+    biomeId,
+    formAxes,
+    runSeed,
+    trainerCanonical,
+  });
+  return { world, ermes, aliena_summary_it, custode };
+}
+
+module.exports = {
+  enrichWorld,
+};

--- a/tests/services/companion/companionPicker.test.js
+++ b/tests/services/companion/companionPicker.test.js
@@ -1,0 +1,150 @@
+// W5-bb — companionPicker.js tests. Mirrors Godot v2
+// `tests/unit/test_companion_picker.gd` (PR #62) for parity.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const {
+  pick,
+  CANONICAL_SKIV,
+  _resetCache,
+  DEFAULT_POOL_PATH,
+} = require('../../../apps/backend/services/companion/companionPicker');
+
+function reset() {
+  _resetCache();
+}
+
+// --- happy path biome picks ---
+
+test('savana pick returns dune_stalker species', () => {
+  reset();
+  const c = pick({ biomeId: 'savana', runSeed: 42 });
+  assert.equal(c.species_id, 'dune_stalker');
+  assert.equal(c.biome_origin_id, 'savana');
+});
+
+test('caverna pick returns perfusuas_pedes species', () => {
+  reset();
+  const c = pick({ biomeId: 'caverna', runSeed: 42 });
+  assert.equal(c.species_id, 'perfusuas_pedes');
+  assert.equal(c.biome_origin_id, 'caverna');
+});
+
+test('atollo_obsidiana pick returns anguis_magnetica species', () => {
+  reset();
+  const c = pick({ biomeId: 'atollo_obsidiana', runSeed: 42 });
+  assert.equal(c.species_id, 'anguis_magnetica');
+});
+
+// --- determinism ---
+
+test('same seed returns same name', () => {
+  reset();
+  const c1 = pick({ biomeId: 'savana', runSeed: 12345 });
+  const c2 = pick({ biomeId: 'savana', runSeed: 12345 });
+  assert.equal(c1.display_name, c2.display_name);
+});
+
+// --- B3 hybrid override (canonical Skiv) ---
+
+test('canonical_trainer + savana returns Skiv canonical', () => {
+  reset();
+  const c = pick({ biomeId: 'savana', runSeed: 42, trainerCanonical: true });
+  assert.equal(c.display_name, 'Skiv');
+  assert.equal(c.species_id, 'dune_stalker');
+  assert.equal(c.voice_modifier, 'canonical');
+});
+
+test('canonical_trainer + non-savana NO override', () => {
+  reset();
+  const c = pick({ biomeId: 'caverna', runSeed: 42, trainerCanonical: true });
+  assert.notEqual(c.display_name, 'Skiv');
+  assert.equal(c.species_id, 'perfusuas_pedes');
+});
+
+// --- fallback rule ---
+
+test('unknown biome falls back to savana pool', () => {
+  reset();
+  const c = pick({ biomeId: 'biome_inesistente', runSeed: 42 });
+  assert.equal(c.species_id, 'dune_stalker');
+  assert.equal(c.biome_origin_id, 'savana');
+});
+
+// --- MBTI voice modifier ---
+
+test('T-dominant assigns solitari modifier', () => {
+  reset();
+  const c = pick({ biomeId: 'savana', formAxes: { T: 0.85, F: 0.15, N: 0.5, S: 0.5 } });
+  assert.equal(c.voice_modifier, 'fredda_analitica');
+});
+
+test('F-dominant assigns simbionti modifier', () => {
+  reset();
+  const c = pick({ biomeId: 'savana', formAxes: { T: 0.2, F: 0.8, N: 0.5, S: 0.5 } });
+  assert.equal(c.voice_modifier, 'empatica_branco');
+});
+
+test('N-dominant assigns esploratori modifier', () => {
+  reset();
+  const c = pick({ biomeId: 'savana', formAxes: { T: 0.5, F: 0.5, N: 0.8, S: 0.2 } });
+  assert.equal(c.voice_modifier, 'visionaria_intuitiva');
+});
+
+test('S-dominant assigns sensoriali modifier', () => {
+  reset();
+  const c = pick({ biomeId: 'savana', formAxes: { T: 0.5, F: 0.5, N: 0.2, S: 0.8 } });
+  assert.equal(c.voice_modifier, 'sensoriale_presente');
+});
+
+test('neutral axes no modifier', () => {
+  reset();
+  const c = pick({ biomeId: 'savana', formAxes: { T: 0.5, F: 0.5, N: 0.5, S: 0.5 } });
+  assert.equal(c.voice_modifier, '');
+});
+
+// --- output shape ---
+
+test('voice_it format matches Godot CompanionPicker', () => {
+  reset();
+  const c = pick({ biomeId: 'savana', runSeed: 42 });
+  assert.match(c.voice_it, /^Allenatore,/);
+  assert.match(c.voice_it, /\.$/);
+});
+
+test('closing_ritual is from biome closing_pool', () => {
+  reset();
+  const c = pick({ biomeId: 'savana', runSeed: 42 });
+  assert.ok(typeof c.closing_ritual === 'string' && c.closing_ritual.length > 0);
+});
+
+// --- guards ---
+
+test('missing biomeId returns empty', () => {
+  reset();
+  const c = pick({ biomeId: '', runSeed: 42 });
+  assert.deepEqual(c, {});
+});
+
+test('missing pool path returns empty', () => {
+  reset();
+  const c = pick({ poolPath: '/tmp/nonexistent_pool.yaml', biomeId: 'savana' });
+  assert.deepEqual(c, {});
+});
+
+// --- canonical Skiv structure ---
+
+test('CANONICAL_SKIV exposes required fields', () => {
+  assert.equal(CANONICAL_SKIV.display_name, 'Skiv');
+  assert.equal(CANONICAL_SKIV.species_id, 'dune_stalker');
+  assert.equal(CANONICAL_SKIV.biome_origin_id, 'savana');
+  assert.ok(CANONICAL_SKIV.voice_it.startsWith('Allenatore,'));
+});
+
+// --- DEFAULT_POOL_PATH ---
+
+test('DEFAULT_POOL_PATH points to skiv_archetype_pool.yaml', () => {
+  assert.match(DEFAULT_POOL_PATH, /skiv_archetype_pool\.yaml$/);
+});

--- a/tests/services/coop/alienaGenerator.test.js
+++ b/tests/services/coop/alienaGenerator.test.js
@@ -1,0 +1,63 @@
+// W5-bb — alienaGenerator.js tests.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  generateAlienaSummary,
+  generateAuthoringTags,
+  STATIC_SUMMARIES,
+  FALLBACK_SUMMARY,
+} = require('../../../apps/backend/services/coop/alienaGenerator');
+
+test('generateAlienaSummary savana returns canonical text', () => {
+  const s = generateAlienaSummary('savana');
+  assert.match(s, /Savana al margine arido/);
+});
+
+test('generateAlienaSummary caverna returns canonical text', () => {
+  const s = generateAlienaSummary('caverna');
+  assert.match(s, /Caverna risonante/);
+});
+
+test('generateAlienaSummary unknown biome returns fallback', () => {
+  const s = generateAlienaSummary('biome_inesistente');
+  assert.equal(s, FALLBACK_SUMMARY);
+});
+
+test('generateAlienaSummary empty string returns fallback', () => {
+  const s = generateAlienaSummary('');
+  assert.equal(s, FALLBACK_SUMMARY);
+});
+
+test('generateAlienaSummary null returns fallback', () => {
+  const s = generateAlienaSummary(null);
+  assert.equal(s, FALLBACK_SUMMARY);
+});
+
+test('STATIC_SUMMARIES never includes word "ALIENA" (doctrine)', () => {
+  // A.L.I.E.N.A. system name MUST never surface to player.
+  for (const [biomeId, summary] of Object.entries(STATIC_SUMMARIES)) {
+    assert.ok(
+      !summary.toLowerCase().includes('aliena'),
+      `${biomeId} summary contains "aliena" — doctrine breach`,
+    );
+  }
+});
+
+test('FALLBACK_SUMMARY never contains "ALIENA"', () => {
+  assert.ok(!FALLBACK_SUMMARY.toLowerCase().includes('aliena'));
+});
+
+test('generateAuthoringTags returns empty array (W5-bb MVP)', () => {
+  const tags = generateAuthoringTags('savana');
+  assert.deepEqual(tags, []);
+});
+
+test('STATIC_SUMMARIES covers minimum 5 biomes', () => {
+  const keys = Object.keys(STATIC_SUMMARIES);
+  assert.ok(keys.length >= 5);
+  for (const k of ['savana', 'caverna', 'atollo_obsidiana', 'foresta_temperata']) {
+    assert.ok(keys.includes(k), `${k} missing from STATIC_SUMMARIES`);
+  }
+});

--- a/tests/services/coop/biomeAdapter.test.js
+++ b/tests/services/coop/biomeAdapter.test.js
@@ -1,0 +1,54 @@
+// W5-bb — biomeAdapter.js tests.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  adaptBiome,
+  listBiomeIds,
+  _resetCache,
+} = require('../../../apps/backend/services/coop/biomeAdapter');
+
+function reset() {
+  _resetCache();
+}
+
+test('adaptBiome savana returns canonical W5 schema', () => {
+  reset();
+  const w = adaptBiome('savana');
+  assert.equal(w.biome_id, 'savana');
+  assert.ok(typeof w.biome_label_it === 'string' && w.biome_label_it.length > 0);
+  assert.ok(['low', 'medium', 'high'].includes(w.pressure));
+  assert.ok(Array.isArray(w.hazards));
+});
+
+test('adaptBiome unknown biome returns empty', () => {
+  reset();
+  const w = adaptBiome('biome_inesistente');
+  assert.deepEqual(w, {});
+});
+
+test('adaptBiome empty biomeId returns empty', () => {
+  reset();
+  const w = adaptBiome('');
+  assert.deepEqual(w, {});
+});
+
+test('listBiomeIds returns non-empty array', () => {
+  reset();
+  const ids = listBiomeIds();
+  assert.ok(Array.isArray(ids));
+  assert.ok(ids.length >= 5);
+});
+
+test('listBiomeIds includes savana', () => {
+  reset();
+  const ids = listBiomeIds();
+  assert.ok(ids.includes('savana'));
+});
+
+test('adaptBiome custom biomesPath fallback', () => {
+  reset();
+  const w = adaptBiome('savana', { biomesPath: '/tmp/nonexistent.yaml' });
+  assert.deepEqual(w, {});
+});

--- a/tests/services/coop/coopOrchestrator-w5bb.test.js
+++ b/tests/services/coop/coopOrchestrator-w5bb.test.js
@@ -1,0 +1,117 @@
+// W5-bb — CoopOrchestrator.confirmWorld extension tests.
+// Mirrors Godot v2 CoopApi.confirmWorld payload contract.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { CoopOrchestrator } = require('../../../apps/backend/services/coop/coopOrchestrator');
+
+function buildOrch() {
+  const orch = new CoopOrchestrator({ roomCode: 'TEST', hostId: 'p_h' });
+  orch.startRun({ scenarioStack: ['enc_tutorial_01'] });
+  // Bypass character_creation by manually advancing phase (test scaffold).
+  orch.phase = 'world_setup';
+  return orch;
+}
+
+test('confirmWorld without biomeId preserves legacy behavior', () => {
+  const orch = buildOrch();
+  const result = orch.confirmWorld({ scenarioId: 'enc_tutorial_01' });
+  assert.equal(result.scenario_id, 'enc_tutorial_01');
+  assert.equal(result.enriched_world, null);
+  assert.equal(orch.phase, 'combat');
+});
+
+test('confirmWorld with biomeId enriches world payload', () => {
+  const orch = buildOrch();
+  const result = orch.confirmWorld({
+    scenarioId: 'enc_tutorial_01',
+    biomeId: 'savana',
+    runSeed: 42,
+  });
+  assert.equal(result.scenario_id, 'enc_tutorial_01');
+  assert.ok(result.enriched_world);
+  assert.equal(result.enriched_world.world.biome_id, 'savana');
+  assert.equal(result.enriched_world.custode.species_id, 'dune_stalker');
+  assert.match(result.enriched_world.aliena_summary_it, /Savana/);
+});
+
+test('confirmWorld with B3 hybrid trainerCanonical returns Skiv', () => {
+  const orch = buildOrch();
+  const result = orch.confirmWorld({
+    scenarioId: 'enc_tutorial_01',
+    biomeId: 'savana',
+    trainerCanonical: true,
+  });
+  assert.equal(result.enriched_world.custode.display_name, 'Skiv');
+});
+
+test('confirmWorld stores enrichedWorld on orch instance', () => {
+  const orch = buildOrch();
+  assert.equal(orch.enrichedWorld, null);
+  orch.confirmWorld({
+    scenarioId: 'enc_tutorial_01',
+    biomeId: 'caverna',
+  });
+  assert.ok(orch.enrichedWorld);
+  assert.equal(orch.enrichedWorld.world.biome_id, 'caverna');
+});
+
+test('confirmWorld injectable worldEnricher (test isolation)', () => {
+  const mockEnricher = {
+    enrichWorld: ({ biomeId }) => ({
+      world: { biome_id: biomeId, biome_label_it: 'Mock' },
+      ermes: { eco_pressure_score: 0.5, bias: {} },
+      aliena_summary_it: 'mock',
+      custode: { display_name: 'Mock' },
+    }),
+  };
+  const orch = new CoopOrchestrator({
+    roomCode: 'TEST',
+    hostId: 'p_h',
+    worldEnricher: mockEnricher,
+  });
+  orch.startRun({ scenarioStack: ['enc_tutorial_01'] });
+  orch.phase = 'world_setup';
+  const result = orch.confirmWorld({
+    scenarioId: 'enc_tutorial_01',
+    biomeId: 'savana',
+  });
+  assert.equal(result.enriched_world.world.biome_label_it, 'Mock');
+  assert.equal(result.enriched_world.custode.display_name, 'Mock');
+});
+
+test('confirmWorld enricher exception does not break phase transition', () => {
+  const failingEnricher = {
+    enrichWorld: () => {
+      throw new Error('mock_failure');
+    },
+  };
+  const orch = new CoopOrchestrator({
+    roomCode: 'TEST',
+    hostId: 'p_h',
+    worldEnricher: failingEnricher,
+  });
+  orch.startRun({ scenarioStack: ['enc_tutorial_01'] });
+  orch.phase = 'world_setup';
+  const result = orch.confirmWorld({
+    scenarioId: 'enc_tutorial_01',
+    biomeId: 'savana',
+  });
+  // Phase still advances, enriched_world null
+  assert.equal(orch.phase, 'combat');
+  assert.equal(result.enriched_world, null);
+  // Event emitted
+  const failureEvent = orch.log.find((e) => e.kind === 'world_enricher_failed');
+  assert.ok(failureEvent);
+});
+
+test('confirmWorld preserves backward-compat (legacy callers)', () => {
+  const orch = buildOrch();
+  // Legacy call with just scenarioId — no biomeId
+  const result = orch.confirmWorld({ scenarioId: 'enc_tutorial_01' });
+  // Should still work, just no enriched_world
+  assert.equal(result.scenario_id, 'enc_tutorial_01');
+  assert.equal(result.enriched_world, null);
+  assert.equal(orch.enrichedWorld, null);
+});

--- a/tests/services/coop/ermesExporter.test.js
+++ b/tests/services/coop/ermesExporter.test.js
@@ -1,0 +1,106 @@
+// W5-bb — ermesExporter.js tests.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const {
+  getErmesForBiome,
+  STATIC_FALLBACKS,
+  NEUTRAL_FALLBACK,
+  _resetCache,
+} = require('../../../apps/backend/services/coop/ermesExporter');
+
+function reset() {
+  _resetCache();
+}
+
+test('savana returns static fallback when no runtime report', () => {
+  reset();
+  const e = getErmesForBiome('savana', { reportPath: '/tmp/no_such_report.json' });
+  assert.equal(e.eco_pressure_score, 0.62);
+  assert.equal(e.bias.predator_density, 0.7);
+});
+
+test('caverna returns static fallback', () => {
+  reset();
+  const e = getErmesForBiome('caverna', { reportPath: '/tmp/no_such_report.json' });
+  assert.equal(e.eco_pressure_score, 0.78);
+  assert.ok(e.bias.ambush_risk > 0);
+});
+
+test('unknown biome returns neutral fallback', () => {
+  reset();
+  const e = getErmesForBiome('biome_inesistente', { reportPath: '/tmp/no_such_report.json' });
+  assert.deepEqual(e, NEUTRAL_FALLBACK);
+});
+
+test('empty biomeId returns neutral fallback', () => {
+  reset();
+  const e = getErmesForBiome('');
+  assert.equal(e.eco_pressure_score, 0.5);
+});
+
+test('runtime report overrides static fallback', () => {
+  reset();
+  const tmp = path.join(os.tmpdir(), `ermes_test_${Date.now()}.json`);
+  fs.writeFileSync(
+    tmp,
+    JSON.stringify({
+      biomes: {
+        savana: {
+          eco_pressure_score: 0.99,
+          bias: { runtime_only: 1.0 },
+        },
+      },
+    }),
+  );
+  try {
+    const e = getErmesForBiome('savana', { reportPath: tmp });
+    assert.equal(e.eco_pressure_score, 0.99);
+    assert.equal(e.bias.runtime_only, 1.0);
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});
+
+test('runtime report missing biome falls back to static', () => {
+  reset();
+  const tmp = path.join(os.tmpdir(), `ermes_test_${Date.now()}.json`);
+  fs.writeFileSync(tmp, JSON.stringify({ biomes: { caverna: { eco_pressure_score: 0.1 } } }));
+  try {
+    const e = getErmesForBiome('savana', { reportPath: tmp });
+    // savana not in runtime, falls to static
+    assert.equal(e.eco_pressure_score, 0.62);
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});
+
+test('STATIC_FALLBACKS covers minimum 5 biomes', () => {
+  const keys = Object.keys(STATIC_FALLBACKS);
+  assert.ok(keys.length >= 5);
+  for (const k of ['savana', 'caverna', 'atollo_obsidiana', 'foresta_temperata', 'badlands']) {
+    assert.ok(keys.includes(k), `${k} missing from STATIC_FALLBACKS`);
+  }
+});
+
+test('NEUTRAL_FALLBACK has 0.5 score', () => {
+  assert.equal(NEUTRAL_FALLBACK.eco_pressure_score, 0.5);
+  assert.deepEqual(NEUTRAL_FALLBACK.bias, {});
+});
+
+test('malformed json report returns static fallback', () => {
+  reset();
+  const tmp = path.join(os.tmpdir(), `ermes_test_${Date.now()}.json`);
+  fs.writeFileSync(tmp, '{ invalid json');
+  try {
+    const e = getErmesForBiome('savana', { reportPath: tmp });
+    // Should fall back gracefully to static
+    assert.equal(e.eco_pressure_score, 0.62);
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});

--- a/tests/services/coop/worldEnricher.test.js
+++ b/tests/services/coop/worldEnricher.test.js
@@ -1,0 +1,92 @@
+// W5-bb — worldEnricher facade tests.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { enrichWorld } = require('../../../apps/backend/services/coop/worldEnricher');
+
+test('enrichWorld empty biomeId returns empty payload', () => {
+  const r = enrichWorld({ biomeId: '' });
+  assert.deepEqual(r.world, {});
+  assert.deepEqual(r.ermes, {});
+  assert.equal(r.aliena_summary_it, '');
+  assert.deepEqual(r.custode, {});
+});
+
+test('enrichWorld savana returns full W5 schema', () => {
+  const r = enrichWorld({ biomeId: 'savana', runSeed: 42 });
+  // world
+  assert.equal(r.world.biome_id, 'savana');
+  assert.ok(typeof r.world.biome_label_it === 'string' && r.world.biome_label_it.length > 0);
+  assert.ok(['low', 'medium', 'high'].includes(r.world.pressure));
+  // ermes
+  assert.equal(r.ermes.eco_pressure_score, 0.62);
+  assert.equal(r.ermes.bias.predator_density, 0.7);
+  // aliena
+  assert.match(r.aliena_summary_it, /Savana/);
+  // custode
+  assert.equal(r.custode.species_id, 'dune_stalker');
+  assert.equal(r.custode.biome_origin_id, 'savana');
+});
+
+test('enrichWorld caverna returns full W5 schema', () => {
+  const r = enrichWorld({ biomeId: 'caverna', runSeed: 42 });
+  assert.equal(r.world.biome_id, 'caverna');
+  assert.equal(r.ermes.eco_pressure_score, 0.78);
+  assert.match(r.aliena_summary_it, /Caverna/);
+  assert.equal(r.custode.species_id, 'perfusuas_pedes');
+});
+
+test('enrichWorld B3 hybrid override Skiv canonical', () => {
+  const r = enrichWorld({ biomeId: 'savana', runSeed: 42, trainerCanonical: true });
+  assert.equal(r.custode.display_name, 'Skiv');
+  assert.equal(r.custode.voice_modifier, 'canonical');
+});
+
+test('enrichWorld MBTI bias propagates to custode', () => {
+  const r = enrichWorld({
+    biomeId: 'savana',
+    formAxes: { T: 0.85, F: 0.15, N: 0.5, S: 0.5 },
+  });
+  assert.equal(r.custode.voice_modifier, 'fredda_analitica');
+});
+
+test('enrichWorld doctrine: aliena_summary never says "ALIENA"', () => {
+  const r = enrichWorld({ biomeId: 'savana', runSeed: 42 });
+  assert.ok(!r.aliena_summary_it.toLowerCase().includes('aliena'));
+});
+
+test('enrichWorld services injection works', () => {
+  const mockBiomeAdapter = {
+    adaptBiome: (b) => ({ biome_id: b, biome_label_it: 'Mock', pressure: 'low', hazards: [] }),
+  };
+  const mockAlienaGenerator = { generateAlienaSummary: () => 'mock summary' };
+  const mockErmesExporter = {
+    getErmesForBiome: () => ({ eco_pressure_score: 0.0, bias: {} }),
+  };
+  const mockCompanionPicker = {
+    pick: () => ({ display_name: 'MockCompanion' }),
+  };
+  const r = enrichWorld(
+    { biomeId: 'savana' },
+    {
+      biomeAdapter: mockBiomeAdapter,
+      alienaGenerator: mockAlienaGenerator,
+      ermesExporter: mockErmesExporter,
+      companionPicker: mockCompanionPicker,
+    },
+  );
+  assert.equal(r.world.biome_label_it, 'Mock');
+  assert.equal(r.aliena_summary_it, 'mock summary');
+  assert.equal(r.custode.display_name, 'MockCompanion');
+});
+
+test('enrichWorld unknown biome graceful fallback', () => {
+  const r = enrichWorld({ biomeId: 'biome_inesistente' });
+  assert.deepEqual(r.world, {}); // biomeAdapter empty
+  assert.equal(r.ermes.eco_pressure_score, 0.5); // ermes neutral fallback
+  // aliena fallback summary
+  assert.ok(r.aliena_summary_it.length > 0);
+  // custode fallback to savana pool
+  assert.equal(r.custode.species_id, 'dune_stalker');
+});


### PR DESCRIPTION
## Summary

Cross-repo W5-bb sprint from [Game-Godot-v2 sessione 2026-05-01](https://github.com/MasterDD-L34D/Game-Godot-v2). Adds 4 services + orchestrator extension + route surface to provide W5 rich-schema payload for Godot v2 WorldSetupState consumption.

**Mirrors Godot v2 stack**:
- Godot CompanionPicker ([Game-Godot-v2 PR #62](https://github.com/MasterDD-L34D/Game-Godot-v2/pull/62)) → `companionPicker.js`
- Godot BiomePalette + sample JSON → `biomeAdapter.js`
- Godot sample aliena_summary_it → `alienaGenerator.js`
- Godot ERMES sample → `ermesExporter.js`

## What ships

### 4 new services

| File | Purpose |
|------|---------|
| `apps/backend/services/companion/companionPicker.js` | Loads `data/core/companion/skiv_archetype_pool.yaml`. B3 hybrid override + species + name (mulberry32 seeded RNG) + MBTI voice modifier + fallback. |
| `apps/backend/services/coop/biomeAdapter.js` | Maps `data/core/biomes.yaml` → W5 schema {biome_id, biome_label_it, pressure, hazards}. |
| `apps/backend/services/coop/alienaGenerator.js` | Static per-biome aliena_summary_it (13 biomes). Doctrine: never includes "ALIENA" literal. |
| `apps/backend/services/coop/ermesExporter.js` | Reads `prototypes/ermes_lab/outputs/latest_eco_pressure_report.json` runtime, falls back static (5 biomes) + neutral fallback. |

### Facade

`apps/backend/services/coop/worldEnricher.js` — single `enrichWorld({biomeId, formAxes, runSeed, trainerCanonical})` combining all 4 services. Stateless. Services injectable for tests.

### Orchestrator extension

`apps/backend/services/coop/coopOrchestrator.js`:
- Constructor accepts optional `worldEnricher` injection
- `confirmWorld({scenarioId, biomeId, formAxes, runSeed, trainerCanonical})` enriches when biomeId provided
- Stores `orch.enrichedWorld` for state inspection
- Enricher exception isolated (does not break phase transition)

### Route surface

`POST /api/coop/world/confirm` body now accepts `biome_id`, `form_axes`, `run_seed`, `trainer_canonical`. Response merges enriched_world fields when present. Backward-compat preserved.

## Tests (+57)

| File | Tests |
|------|-------|
| companionPicker.test.js | 18 |
| biomeAdapter.test.js | 6 |
| alienaGenerator.test.js | 9 |
| ermesExporter.test.js | 9 |
| worldEnricher.test.js | 8 |
| coopOrchestrator-w5bb.test.js | 7 |
| **Total** | **57 new** |

All 71 tests pass (57 new + 14 existing coopOrchestrator).

## Doctrine enforcement (verified by tests)

- ✅ aliena_summary_it NEVER contains "ALIENA" literal (test_static_summaries_never_includes_word_aliena)
- ✅ ERMES system name NEVER surfaces (output is diegetic eco_pressure_score + bias)
- ✅ B3 hybrid Skiv override only triggers in savana with trainerCanonical=true
- ✅ Phase transition isolated from enricher exceptions

## Backward compatibility

Legacy callers (without biome_id) get pre-W5-bb response shape unchanged. `enriched_world: null` in result. No breaking changes.

## Next cross-repo step

Godot v2 side already has CoopApi.confirm_world() builder ([Game-Godot-v2 PR #55](https://github.com/MasterDD-L34D/Game-Godot-v2/pull/55)) + WorldSetupState rich field accessors (PR #62). Once this merges + deploys, Godot v2 phone composer + world setup view can drive backend live (replacing sample JSON load).

## Refs

- Godot v2 PR #55-#73 (W4 wire + W4.5 + W5-Godot + W6 stack + verify)
- Godot v2 sample JSON: `data/world_setup/sample_world_setup_*.json`
- `docs/skiv/CANONICAL.md` (B3 hybrid override rule)
- ADR-2026-04-26-spore-part-pack-slots (lineage propagator parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)