### PR TITLE
fix(w5.5-codex): PR #2029 P1 party + P2 archetype unknown-biome handling

### DIFF
--- a/apps/backend/services/companion/companionPicker.js
+++ b/apps/backend/services/companion/companionPicker.js
@@ -165,7 +165,11 @@ function listArchetypesForBiome(biomeId, opts = {}) {
   const { poolPath = DEFAULT_POOL_PATH } = opts;
   const pool = _loadPool(poolPath);
   if (!pool) return [];
-  const { biomePool } = _resolveBiomePool(pool, biomeId);
+  // Codex W5.5 P2 fix: don't use _resolveBiomePool's savana fallback —
+  // /api/companion/pool consumers expect [] for unknown biome (per
+  // function doc), not echo of unknown id with savana archetypes.
+  const pools = pool && pool.biome_pools ? pool.biome_pools : {};
+  const biomePool = pools[biomeId];
   if (!biomePool) return [];
   return Array.isArray(biomePool.species_pool) ? biomePool.species_pool.slice() : [];
 }

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -178,9 +178,14 @@ class CoopOrchestrator {
     if (biomeId && typeof biomeId === 'string') {
       try {
         const enricher = this._getWorldEnricher();
+        // Codex W5.5 P1 fix: pass confirmed party to enricher so
+        // ermes.role_gap reflects the actual party composition. Without
+        // this, role_gap was always computed from [] → every demanded
+        // role reported as fully under-represented (false negative).
         enrichedWorld = enricher.enrichWorld({
           biomeId,
           formAxes: formAxes || {},
+          party: Array.from(this.characters.values()),
           runSeed: Number.isFinite(runSeed) ? runSeed : 0,
           trainerCanonical: Boolean(trainerCanonical),
         });

--- a/tests/services/companion/companionPicker.w55codex.test.js
+++ b/tests/services/companion/companionPicker.w55codex.test.js
@@ -1,0 +1,42 @@
+// W5.5 codex fix — listArchetypesForBiome unknown-biome handling tests.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  listArchetypesForBiome,
+  _resetCache,
+} = require('../../../apps/backend/services/companion/companionPicker');
+
+function reset() {
+  _resetCache();
+}
+
+test('listArchetypesForBiome unknown biome returns empty (no savana fallback)', () => {
+  reset();
+  // Codex W5.5 P2 fix: function doc says "[] when biome unknown" but
+  // _resolveBiomePool falls back to savana. Direct lookup must match
+  // doc contract: unknown → [].
+  const result = listArchetypesForBiome('alien_world');
+  assert.deepEqual(result, []);
+});
+
+test('listArchetypesForBiome empty/non-string returns empty', () => {
+  reset();
+  assert.deepEqual(listArchetypesForBiome(''), []);
+  assert.deepEqual(listArchetypesForBiome(null), []);
+  assert.deepEqual(listArchetypesForBiome(undefined), []);
+});
+
+test('listArchetypesForBiome savana returns non-empty list', () => {
+  reset();
+  const result = listArchetypesForBiome('savana');
+  assert.ok(Array.isArray(result));
+  assert.ok(result.length > 0, 'savana pool exists in YAML');
+});
+
+test('listArchetypesForBiome missing pool path returns empty', () => {
+  reset();
+  const result = listArchetypesForBiome('savana', { poolPath: '/tmp/nonexistent.yaml' });
+  assert.deepEqual(result, []);
+});

--- a/tests/services/coop/coopOrchestrator-w55codex.test.js
+++ b/tests/services/coop/coopOrchestrator-w55codex.test.js
@@ -1,0 +1,78 @@
+// W5.5 codex P1 fix — coopOrchestrator confirmWorld passes party to enricher.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { CoopOrchestrator } = require('../../../apps/backend/services/coop/coopOrchestrator');
+
+function buildOrch({ withCharacters = false } = {}) {
+  const orch = new CoopOrchestrator({ roomCode: 'TEST', hostId: 'p_h' });
+  orch.startRun({ scenarioStack: ['enc_tutorial_01'] });
+  if (withCharacters) {
+    // Inject characters directly (bypass character_creation phase for test).
+    orch.characters.set('p1', {
+      player_id: 'p1',
+      name: 'Alice',
+      species_id: 'dune_stalker',
+      job_id: 'esploratore',
+      ready: true,
+    });
+    orch.characters.set('p2', {
+      player_id: 'p2',
+      name: 'Bob',
+      species_id: 'dune_stalker',
+      job_id: 'guerriero',
+      ready: true,
+    });
+  }
+  orch.phase = 'world_setup';
+  return orch;
+}
+
+test('confirmWorld passes party to enricher (role_gap reflects characters)', () => {
+  const orch = buildOrch({ withCharacters: true });
+  let capturedParty = null;
+  const stubEnricher = {
+    enrichWorld: (input) => {
+      capturedParty = input.party;
+      return {
+        world: { biome_id: input.biomeId },
+        ermes: { eco_pressure_score: 0.5, bias: {}, role_gap: {} },
+        aliena_summary_it: 'x',
+        aliena_version: 'template_v1',
+        custode: {},
+      };
+    },
+  };
+  orch._getWorldEnricher = () => stubEnricher;
+  orch.confirmWorld({ scenarioId: 'enc_tutorial_01', biomeId: 'savana' });
+  assert.ok(Array.isArray(capturedParty), 'party array passed to enricher');
+  assert.equal(capturedParty.length, 2);
+  assert.equal(capturedParty[0].job_id, 'esploratore');
+  assert.equal(capturedParty[1].job_id, 'guerriero');
+});
+
+test('confirmWorld with no characters passes empty party (no crash)', () => {
+  const orch = buildOrch({ withCharacters: false });
+  let capturedParty = null;
+  orch._getWorldEnricher = () => ({
+    enrichWorld: (input) => {
+      capturedParty = input.party;
+      return { world: {}, ermes: {}, aliena_summary_it: '', aliena_version: '', custode: {} };
+    },
+  });
+  orch.confirmWorld({ scenarioId: 'enc_tutorial_01', biomeId: 'savana' });
+  assert.deepEqual(capturedParty, []);
+});
+
+test('confirmWorld real enricher: role_gap correct for confirmed party', () => {
+  const orch = buildOrch({ withCharacters: true });
+  // Use REAL enricher (no stub) → integration smoke.
+  const result = orch.confirmWorld({ scenarioId: 'enc_tutorial_01', biomeId: 'savana' });
+  assert.ok(result.enriched_world, 'enriched_world populated');
+  const roleGap = result.enriched_world.ermes.role_gap;
+  // Savana demands {esploratore: 1, guerriero: 1}.
+  // Party has 1 esploratore + 1 guerriero → all zeros.
+  assert.equal(roleGap.esploratore, 0, 'esploratore matched');
+  assert.equal(roleGap.guerriero, 0, 'guerriero matched');
+});


### PR DESCRIPTION
## Summary

Bundles 2 codex review findings on PR #2029.

### P1 — `confirmWorld` pass party to `enrichWorld`

`coopOrchestrator.confirmWorld` called `enricher.enrichWorld()` without `party`. `enrichWorld` then computed `ermes.role_gap` from `[]` → every demanded role reported as under-represented. Production flow always misreported.

**Fix**: pass `Array.from(this.characters.values())` so role_gap reflects actual confirmed party.

### P2 — `listArchetypesForBiome` unknown biome → `[]`

Doc says "[] when biome unknown" but `_resolveBiomePool` falls back to savana. `/api/companion/pool?biome_id=alien_world` returned savana archetypes echoed with unknown id.

**Fix**: direct `pools[biomeId]` lookup (no savana fallback). `pick` path preserves existing fallback behavior.

## Tests (+7)

- `tests/services/companion/companionPicker.w55codex.test.js` (4)
- `tests/services/coop/coopOrchestrator-w55codex.test.js` (3) — including real enricher integration assertion

Coop + companion + routes: **94/94** pass (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)