### PR TITLE
feat(sprint-r2): resume token + state version cursor for co-op WS

### DIFF
--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -45,6 +45,10 @@ const DEFAULT_HEARTBEAT_MS = 30_000;
 // does not reattach within this window, the oldest connected player is
 // promoted to host role. Set to 0 to disable automatic host transfer.
 const DEFAULT_HOST_TRANSFER_GRACE_MS = 30_000;
+// Sprint R.2 — intent/state ledger size cap. On reconnect, if
+// `state_version - last_seen_version <= MAX_LEDGER_SIZE`, server replays
+// missed entries; else falls back to full state snapshot.
+const MAX_LEDGER_SIZE = 100;
 
 function generateRoomCode() {
   let out = '';
@@ -100,6 +104,13 @@ class Room {
     this.phase = 'idle';
     // Round counter (advances on clearRoundIntents).
     this.roundIndex = 0;
+    // Sprint R.2 — versioned event ledger for resume-on-reconnect.
+    // Each entry: { version, type, payload, ts }. Capped at
+    // MAX_LEDGER_SIZE (oldest evicted). `version` shares the
+    // monotonic counter with stateVersion (incremented on every
+    // append). A reconnect with `last_version=N` replays entries
+    // > N; if delta exceeds cap, full state snapshot used instead.
+    this._ledger = [];
     this._onMutate = typeof onMutate === 'function' ? onMutate : null;
 
     if (hydrateFromSeed?.players?.length) {
@@ -244,9 +255,61 @@ class Room {
     }
   }
 
+  /**
+   * Sprint R.2 — append an entry to the resume ledger. Each entry carries
+   * the monotonic `version` (== current stateVersion AFTER bump on state
+   * pushes; for non-state events, an in-band tick that does NOT advance
+   * stateVersion is fine — but for the R.2 baseline we only ledger entries
+   * that bump version). Returns the appended entry.
+   */
+  _appendLedger(type, payload) {
+    const entry = {
+      version: this.stateVersion,
+      type,
+      payload,
+      ts: Date.now(),
+    };
+    this._ledger.push(entry);
+    if (this._ledger.length > MAX_LEDGER_SIZE) {
+      this._ledger.shift();
+    }
+    return entry;
+  }
+
+  /**
+   * Sprint R.2 — return ledger entries with version > sinceVersion.
+   * Empty array when sinceVersion is at or beyond ledger head.
+   */
+  ledgerSince(sinceVersion) {
+    if (!Number.isFinite(sinceVersion)) return this._ledger.slice();
+    return this._ledger.filter((e) => e.version > sinceVersion);
+  }
+
+  /**
+   * Sprint R.2 — diagnostic / test accessor.
+   */
+  ledgerSize() {
+    return this._ledger.length;
+  }
+
+  /**
+   * Sprint R.2 — true when full snapshot needed (delta exceeds cap OR
+   * ledger empty / pre-version request older than oldest entry).
+   */
+  needsFullSnapshot(sinceVersion) {
+    if (!Number.isFinite(sinceVersion) || sinceVersion < 0) return true;
+    if (sinceVersion >= this.stateVersion) return false; // up to date
+    if (this._ledger.length === 0) return true;
+    const oldest = this._ledger[0].version;
+    return sinceVersion < oldest - 1; // requested range pre-dates ledger
+  }
+
   publishState(newState) {
     this.stateVersion += 1;
     this.state = newState;
+    // Sprint R.2 — record state push in resume ledger BEFORE broadcast
+    // so reconnecting peers can replay.
+    this._appendLedger('state', newState);
     this.broadcast({
       type: 'state',
       version: this.stateVersion,
@@ -732,6 +795,12 @@ function createWsServer({
     const code = (url.searchParams.get('code') || '').toUpperCase();
     const playerId = url.searchParams.get('player_id') || '';
     const token = url.searchParams.get('token') || '';
+    // Sprint R.2 — optional resume cursor. Client sends
+    // `?last_version=N` on reconnect to request ledger replay of state
+    // pushes since N. Absent / non-finite → fresh hello path (no replay).
+    const lastVersionRaw = url.searchParams.get('last_version');
+    const lastVersion = Number(lastVersionRaw);
+    const hasResumeCursor = lastVersionRaw !== null && Number.isFinite(lastVersion);
 
     const room = lobby.getRoom(code);
     if (!room) {
@@ -809,6 +878,37 @@ function createWsServer({
         },
       }),
     );
+    // Sprint R.2 — resume replay dispatch. After hello, if client sent
+    // `last_version=N` and the ledger covers the gap, send a `replay`
+    // message with the missed entries. Otherwise (delta too large or
+    // pre-ledger) the hello state already represents authoritative
+    // current snapshot — client falls back to full-state path.
+    if (hasResumeCursor) {
+      if (lastVersion === room.stateVersion) {
+        // Up to date — no replay needed.
+        socket.send(
+          JSON.stringify({
+            type: 'replay',
+            payload: { entries: [], reason: 'up_to_date' },
+          }),
+        );
+      } else if (room.needsFullSnapshot(lastVersion)) {
+        socket.send(
+          JSON.stringify({
+            type: 'replay',
+            payload: { entries: [], reason: 'snapshot_required' },
+          }),
+        );
+      } else {
+        const entries = room.ledgerSince(lastVersion);
+        socket.send(
+          JSON.stringify({
+            type: 'replay',
+            payload: { entries, reason: 'incremental' },
+          }),
+        );
+      }
+    }
     // Announce (re)connection.
     room.broadcast(
       {

--- a/tests/services/network/wsSession-resume.test.js
+++ b/tests/services/network/wsSession-resume.test.js
@@ -1,0 +1,288 @@
+// Sprint R.2 — Resume token + state version cursor tests.
+//
+// Coverage:
+//   - Room ledger appends on publishState only (intent does NOT bump version)
+//   - Ledger capped at MAX_LEDGER_SIZE (oldest evicted)
+//   - Room.ledgerSince(N) filters strictly > N
+//   - Room.needsFullSnapshot heuristic (pre-ledger, up-to-date, in-window)
+//   - WS reconnect with last_version=current emits up_to_date replay
+//   - WS reconnect with last_version=N receives entries > N (incremental)
+//   - WS reconnect with stale last_version triggers snapshot_required
+//   - WS connect without last_version skips replay (back-compat)
+//   - replay arrives AFTER hello (ordering invariant)
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const WebSocket = require('ws');
+
+process.env.AUTH_SECRET = 'test-secret-must-be-at-least-16-chars-long';
+
+const {
+  LobbyService,
+  Room,
+  createWsServer,
+} = require('../../../apps/backend/services/network/wsSession');
+
+function attachBuffer(ws) {
+  ws.__buf = [];
+  ws.__waiters = [];
+  ws.on('message', (raw) => {
+    let msg;
+    try {
+      msg = JSON.parse(raw.toString());
+    } catch {
+      return;
+    }
+    ws.__buf.push(msg);
+    for (const w of ws.__waiters.slice()) {
+      if (w.predicate(msg)) {
+        ws.__waiters = ws.__waiters.filter((x) => x !== w);
+        w.resolve(msg);
+      }
+    }
+  });
+  return ws;
+}
+
+function waitForMessage(ws, predicate, timeoutMs = 3000) {
+  for (const msg of ws.__buf) {
+    if (predicate(msg)) return Promise.resolve(msg);
+  }
+  return new Promise((resolve, reject) => {
+    const waiter = { predicate, resolve, reject };
+    const timer = setTimeout(() => {
+      ws.__waiters = ws.__waiters.filter((x) => x !== waiter);
+      reject(new Error('timeout waiting for ws message'));
+    }, timeoutMs);
+    waiter.resolve = (msg) => {
+      clearTimeout(timer);
+      resolve(msg);
+    };
+    ws.__waiters.push(waiter);
+  });
+}
+
+function openWs(port, { code, player_id, token, last_version }) {
+  let url = `ws://127.0.0.1:${port}/ws?code=${encodeURIComponent(code)}&player_id=${encodeURIComponent(player_id)}&token=${encodeURIComponent(token)}`;
+  if (last_version !== undefined && last_version !== null) {
+    url += `&last_version=${last_version}`;
+  }
+  return attachBuffer(new WebSocket(url));
+}
+
+async function waitOpen(ws) {
+  return new Promise((resolve, reject) => {
+    ws.once('open', () => resolve());
+    ws.once('error', reject);
+  });
+}
+
+async function spinUp() {
+  const lobby = new LobbyService();
+  const wsHandle = createWsServer({ lobby, port: 0 });
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  return { lobby, port: wsHandle.wss.address().port, wsHandle };
+}
+
+// --- Room ledger unit-level ---
+
+test('Room: publishState appends ledger entry with type=state and current version', () => {
+  const room = new Room({ code: 'ABCD', hostId: 'p_h', hostName: 'Alice' });
+  assert.equal(room.ledgerSize(), 0);
+  room.publishState({ scene: 'briefing' });
+  assert.equal(room.ledgerSize(), 1);
+  const e1 = room.ledgerSince(0)[0];
+  assert.equal(e1.type, 'state');
+  assert.equal(e1.version, 1);
+  assert.deepEqual(e1.payload, { scene: 'briefing' });
+
+  room.publishState({ scene: 'combat' });
+  assert.equal(room.ledgerSize(), 2);
+  const all = room.ledgerSince(0);
+  assert.equal(all[1].version, 2);
+  assert.equal(all[1].payload.scene, 'combat');
+});
+
+test('Room: ledger capped at 100 — oldest evicted', () => {
+  const room = new Room({ code: 'ABCD', hostId: 'p_h', hostName: 'Alice' });
+  for (let i = 0; i < 150; i += 1) {
+    room.publishState({ tick: i });
+  }
+  assert.equal(room.ledgerSize(), 100);
+  const all = room.ledgerSince(0);
+  assert.equal(all[0].version, 51);
+  assert.equal(all[99].version, 150);
+});
+
+test('Room: ledgerSince(N) returns entries strictly > N', () => {
+  const room = new Room({ code: 'ABCD', hostId: 'p_h', hostName: 'Alice' });
+  for (let i = 0; i < 5; i += 1) room.publishState({ tick: i });
+  const since3 = room.ledgerSince(3);
+  assert.equal(since3.length, 2);
+  assert.equal(since3[0].version, 4);
+  assert.equal(since3[1].version, 5);
+});
+
+test('Room: needsFullSnapshot heuristic', () => {
+  const room = new Room({ code: 'ABCD', hostId: 'p_h', hostName: 'Alice' });
+  assert.equal(room.needsFullSnapshot(undefined), true);
+  assert.equal(room.needsFullSnapshot(-1), true);
+  room.publishState({ tick: 1 });
+  assert.equal(room.needsFullSnapshot(0), false);
+  assert.equal(room.needsFullSnapshot(1), false);
+  assert.equal(room.needsFullSnapshot(2), false);
+  for (let i = 0; i < 200; i += 1) room.publishState({ tick: i });
+  assert.equal(room.needsFullSnapshot(50), true);
+  assert.equal(room.needsFullSnapshot(150), false);
+});
+
+test('Room: pushIntent does NOT bump stateVersion (R.1 invariant preserved)', () => {
+  const room = new Room({ code: 'ABCD', hostId: 'p_h', hostName: 'Alice' });
+  for (let i = 0; i < 5; i += 1) room.publishState({ tick: i });
+  assert.equal(room.stateVersion, 5);
+  room.players.set('p_x', {
+    id: 'p_x',
+    name: 'Bob',
+    role: 'player',
+    token: 't',
+    socket: null,
+    connected: false,
+    joinedAt: Date.now(),
+  });
+  room.pushIntent({ from: 'p_x', payload: { action: 'attack' } });
+  assert.equal(room.stateVersion, 5);
+  assert.equal(room.ledgerSize(), 5);
+});
+
+// --- WS reconnect integration ---
+
+test('WS-resume: connect without last_version skips replay (back-compat)', async () => {
+  const { lobby, port, wsHandle } = await spinUp();
+  try {
+    const room = lobby.createRoom({ hostName: 'Alice' });
+    const hostWs = openWs(port, {
+      code: room.code,
+      player_id: room.host_id,
+      token: room.host_token,
+    });
+    await waitOpen(hostWs);
+    await waitForMessage(hostWs, (m) => m.type === 'hello');
+    let gotReplay = false;
+    hostWs.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(raw.toString());
+        if (msg.type === 'replay') gotReplay = true;
+      } catch {
+        // noop
+      }
+    });
+    await new Promise((r) => setTimeout(r, 100));
+    assert.equal(gotReplay, false);
+    hostWs.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('WS-resume: reconnect with last_version=current emits up_to_date replay', async () => {
+  const { lobby, port, wsHandle } = await spinUp();
+  try {
+    const meta = lobby.createRoom({ hostName: 'Alice' });
+    const room = lobby.getRoom(meta.code);
+    room.publishState({ scene: 'briefing' });
+    room.publishState({ scene: 'combat' });
+    const hostWs = openWs(port, {
+      code: meta.code,
+      player_id: meta.host_id,
+      token: meta.host_token,
+      last_version: room.stateVersion,
+    });
+    await waitOpen(hostWs);
+    const replay = await waitForMessage(hostWs, (m) => m.type === 'replay');
+    assert.equal(replay.payload.reason, 'up_to_date');
+    assert.deepEqual(replay.payload.entries, []);
+    hostWs.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('WS-resume: reconnect with last_version=N receives entries > N (incremental)', async () => {
+  const { lobby, port, wsHandle } = await spinUp();
+  try {
+    const meta = lobby.createRoom({ hostName: 'Alice' });
+    const room = lobby.getRoom(meta.code);
+    room.publishState({ tick: 1 });
+    room.publishState({ tick: 2 });
+    room.publishState({ tick: 3 });
+    const hostWs = openWs(port, {
+      code: meta.code,
+      player_id: meta.host_id,
+      token: meta.host_token,
+      last_version: 1,
+    });
+    await waitOpen(hostWs);
+    const replay = await waitForMessage(hostWs, (m) => m.type === 'replay');
+    assert.equal(replay.payload.reason, 'incremental');
+    assert.equal(replay.payload.entries.length, 2);
+    assert.equal(replay.payload.entries[0].version, 2);
+    assert.equal(replay.payload.entries[1].version, 3);
+    assert.equal(replay.payload.entries[0].type, 'state');
+    hostWs.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('WS-resume: stale last_version triggers snapshot_required', async () => {
+  const { lobby, port, wsHandle } = await spinUp();
+  try {
+    const meta = lobby.createRoom({ hostName: 'Alice' });
+    const room = lobby.getRoom(meta.code);
+    for (let i = 0; i < 200; i += 1) {
+      room.publishState({ tick: i });
+    }
+    const hostWs = openWs(port, {
+      code: meta.code,
+      player_id: meta.host_id,
+      token: meta.host_token,
+      last_version: 5,
+    });
+    await waitOpen(hostWs);
+    const replay = await waitForMessage(hostWs, (m) => m.type === 'replay');
+    assert.equal(replay.payload.reason, 'snapshot_required');
+    assert.deepEqual(replay.payload.entries, []);
+    hostWs.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('WS-resume: replay arrives AFTER hello (ordering invariant)', async () => {
+  const { lobby, port, wsHandle } = await spinUp();
+  try {
+    const meta = lobby.createRoom({ hostName: 'Alice' });
+    const room = lobby.getRoom(meta.code);
+    room.publishState({ tick: 1 });
+    const hostWs = openWs(port, {
+      code: meta.code,
+      player_id: meta.host_id,
+      token: meta.host_token,
+      last_version: 0,
+    });
+    await waitOpen(hostWs);
+    await waitForMessage(hostWs, (m) => m.type === 'replay');
+    const helloIdx = hostWs.__buf.findIndex((m) => m.type === 'hello');
+    const replayIdx = hostWs.__buf.findIndex((m) => m.type === 'replay');
+    assert.ok(helloIdx >= 0 && replayIdx >= 0);
+    assert.ok(helloIdx < replayIdx, 'hello must precede replay');
+    hostWs.close();
+  } finally {
+    await wsHandle.close();
+  }
+});


### PR DESCRIPTION
## Sprint R.2 — Resume on reconnect

Closes mid-session reconnect gap. Server tracks versioned event ledger; client appends \`last_version=N\` on reconnect; server replays missed entries (or signals snapshot fallback when delta exceeds ledger window).

## Changes

- \`Room\` adds:
  - \`_ledger: Array<{version, type, payload, ts}>\` size-capped \`MAX_LEDGER_SIZE=100\` (oldest evicted)
  - \`_appendLedger(type, payload)\` helper invoked by \`publishState\`
  - \`ledgerSince(N)\` — entries strictly > N
  - \`needsFullSnapshot(N)\` — heuristic for delta vs ledger window
  - \`ledgerSize()\` — diagnostic accessor
- \`pushIntent\` UNCHANGED — preserves R.1 invariant (\`stateVersion\` bumps only on state pushes).
- WS connection handler:
  - Parses optional \`last_version\` query param.
  - After hello, dispatches \`replay\` message:
    - \`reason: \"up_to_date\"\` when last_version == stateVersion (empty entries)
    - \`reason: \"incremental\"\` with entries > N when delta within ledger
    - \`reason: \"snapshot_required\"\` when delta exceeds ledger window — caller treats hello.payload.state as authoritative full snapshot
  - Connect without last_version → no replay sent (back-compat with R.1 clients).

## Acceptance gate

| Suite | Result |
|---|---|
| \`tests/services/network/wsSession-resume.test.js\` | 10/10 |
| Full regression (lobby + JWT + coop) | 74/74 |
| Prettier | clean |

R.1 invariant verified: \`stateVersion\` monotonic on \`publishState\` calls only, intents do NOT advance counter.

## Cross-repo parity

Godot v2 PR (incoming): wires \`ResumeTokenManager\` (from R.0 onset PR #92 scaffold) into \`CoopWsPeer\` — reconnect path appends cursor, hello + state messages advance cursor, replay messages dispatch via \`apply_replay_batch\` + emit \`replay_received\` signal.

## Out of scope (R.3-R.5)

R.3 state diff broadcast / R.4 phantom-disconnect cleanup / R.5 ledger replay polish — separate PRs per \`docs/godot-v2/sprint-r-plan.md\`. R.5 will refine ledger to include intent + phase_change + action_resolved event classes; R.2 baseline ledger covers state pushes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)