### PR TITLE
feat(sprint-r4): phantom-disconnect cleanup via ghost timeout

### DIFF
--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -50,6 +50,13 @@ const DEFAULT_HOST_TRANSFER_GRACE_MS = 30_000;
 // `state_version - last_seen_version <= MAX_LEDGER_SIZE`, server replays
 // missed entries; else falls back to full state snapshot.
 const MAX_LEDGER_SIZE = 100;
+// Sprint R.4 — phantom-disconnect cleanup grace window. If a non-host
+// player's socket closes and they do not reconnect within this window,
+// they are removed from `room.players` and a `player_left` broadcast
+// fires with `reason = "ghost_timeout"`. Set to 0 to disable cleanup
+// (keeps M11 Phase A semantics — players linger forever). Host path
+// is unchanged (existing host_transfer_grace_ms drives host promotion).
+const DEFAULT_GHOST_TIMEOUT_MS = 120_000;
 
 function generateRoomCode() {
   let out = '';
@@ -77,6 +84,9 @@ class Room {
     maxPlayers = DEFAULT_MAX_PLAYERS,
     campaignId = null,
     hostTransferGraceMs = DEFAULT_HOST_TRANSFER_GRACE_MS,
+    // Sprint R.4 — phantom-disconnect cleanup window for non-host
+    // players. 0 disables (lingering players, M11 Phase A baseline).
+    ghostTimeoutMs = DEFAULT_GHOST_TIMEOUT_MS,
     // Opzione C: optional persistence hook. Fire-and-forget after mutation.
     onMutate = null,
     // Hydrate path: reuse data from Prisma snapshot (skips host player seed).
@@ -89,8 +99,11 @@ class Room {
     this.createdAt = hydrateFromSeed?.createdAt || Date.now();
     this.closed = Boolean(hydrateFromSeed?.closed);
     this.hostTransferGraceMs = hostTransferGraceMs;
+    this.ghostTimeoutMs = ghostTimeoutMs;
     // TKT-M11B-05 — pending host-transfer timer handle.
     this._hostTransferTimer = null;
+    // Sprint R.4 — pending ghost-cleanup timers per player_id.
+    this._ghostTimers = new Map();
     // player_id → { id, name, role, token, socket?, connected, joinedAt }
     this.players = new Map();
     // Host state published, last-write-wins; version monotonic.
@@ -210,6 +223,9 @@ class Room {
     }
     p.socket = socket;
     p.connected = true;
+    // Sprint R.4 — clear pending ghost-cleanup timer when player
+    // reconnects within the grace window.
+    this._clearGhostTimer(playerId);
     return true;
   }
 
@@ -218,7 +234,56 @@ class Room {
     if (!p) return false;
     p.socket = null;
     p.connected = false;
+    // Sprint R.4 — schedule ghost cleanup. Host path is unchanged
+    // (host_transfer_grace handles host promotion); only non-host
+    // players get auto-removed on grace timeout.
+    if (playerId !== this.hostId) {
+      this._scheduleGhostCleanup(playerId);
+    }
     return true;
+  }
+
+  /**
+   * Sprint R.4 — schedule auto-removal for a disconnected player.
+   * After ghostTimeoutMs ms with no reconnect, the player record is
+   * deleted from `room.players` and `player_left` broadcasts with
+   * `reason = "ghost_timeout"`. Idempotent: re-scheduling resets the
+   * timer (legitimate when same player re-disconnects).
+   */
+  _scheduleGhostCleanup(playerId) {
+    if (!this.ghostTimeoutMs || this.ghostTimeoutMs <= 0) return;
+    if (this.closed) return;
+    this._clearGhostTimer(playerId);
+    const timer = setTimeout(() => {
+      this._ghostTimers.delete(playerId);
+      const p = this.players.get(playerId);
+      // Only fire when player still disconnected. Defense against
+      // races where attachSocket fired between timer schedule and
+      // callback dispatch.
+      if (!p || p.connected) return;
+      this.players.delete(playerId);
+      this.broadcast({
+        type: 'player_left',
+        payload: { player_id: playerId, reason: 'ghost_timeout' },
+      });
+      this._notifyMutate({ kind: 'player_ghost_removed', playerId });
+    }, this.ghostTimeoutMs);
+    timer.unref?.();
+    this._ghostTimers.set(playerId, timer);
+  }
+
+  _clearGhostTimer(playerId) {
+    const timer = this._ghostTimers.get(playerId);
+    if (!timer) return;
+    clearTimeout(timer);
+    this._ghostTimers.delete(playerId);
+  }
+
+  _clearAllGhostTimers() {
+    for (const t of this._ghostTimers.values()) {
+      clearTimeout(t);
+    }
+    this._ghostTimers.clear();
   }
 
   publicPlayerList() {
@@ -509,6 +574,9 @@ class Room {
 
   close(reason = 'host_closed') {
     this.closed = true;
+    // Sprint R.4 — clear any pending ghost timers on hard close.
+    this._clearAllGhostTimers();
+    this.clearHostTransferTimer();
     for (const p of this.players.values()) {
       if (p.socket && p.socket.readyState === 1) {
         try {

--- a/tests/services/network/wsSession-ghost.test.js
+++ b/tests/services/network/wsSession-ghost.test.js
@@ -1,0 +1,276 @@
+// Sprint R.4 — Phantom-disconnect cleanup (ghost timeout).
+//
+// Coverage:
+//   - Non-host detach schedules ghost timer
+//   - Reconnect within window cancels timer
+//   - Timer firing removes player + broadcasts player_left{ghost_timeout}
+//   - Host detach does NOT trigger ghost path (host_transfer_grace owns it)
+//   - ghostTimeoutMs=0 disables cleanup
+//   - close() clears all pending timers
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const WebSocket = require('ws');
+
+process.env.AUTH_SECRET = 'test-secret-must-be-at-least-16-chars-long';
+
+const {
+  LobbyService,
+  Room,
+  createWsServer,
+} = require('../../../apps/backend/services/network/wsSession');
+
+function attachBuffer(ws) {
+  ws.__buf = [];
+  ws.__waiters = [];
+  ws.on('message', (raw) => {
+    let msg;
+    try {
+      msg = JSON.parse(raw.toString());
+    } catch {
+      return;
+    }
+    ws.__buf.push(msg);
+    for (const w of ws.__waiters.slice()) {
+      if (w.predicate(msg)) {
+        ws.__waiters = ws.__waiters.filter((x) => x !== w);
+        w.resolve(msg);
+      }
+    }
+  });
+  return ws;
+}
+
+function waitForMessage(ws, predicate, timeoutMs = 3000) {
+  for (const msg of ws.__buf) {
+    if (predicate(msg)) return Promise.resolve(msg);
+  }
+  return new Promise((resolve, reject) => {
+    const waiter = { predicate, resolve, reject };
+    const timer = setTimeout(() => {
+      ws.__waiters = ws.__waiters.filter((x) => x !== waiter);
+      reject(new Error('timeout waiting for ws message'));
+    }, timeoutMs);
+    waiter.resolve = (msg) => {
+      clearTimeout(timer);
+      resolve(msg);
+    };
+    ws.__waiters.push(waiter);
+  });
+}
+
+function openWs(port, { code, player_id, token }) {
+  const url = `ws://127.0.0.1:${port}/ws?code=${encodeURIComponent(code)}&player_id=${encodeURIComponent(player_id)}&token=${encodeURIComponent(token)}`;
+  return attachBuffer(new WebSocket(url));
+}
+
+async function waitOpen(ws) {
+  return new Promise((resolve, reject) => {
+    ws.once('open', () => resolve());
+    ws.once('error', reject);
+  });
+}
+
+async function spinUp() {
+  const lobby = new LobbyService();
+  const wsHandle = createWsServer({ lobby, port: 0 });
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  return { lobby, port: wsHandle.wss.address().port, wsHandle };
+}
+
+// --- Room unit-level ---
+
+test('Room: non-host detach schedules ghost timer', () => {
+  const room = new Room({
+    code: 'ABCD',
+    hostId: 'p_h',
+    hostName: 'Alice',
+    ghostTimeoutMs: 60_000,
+  });
+  room.addPlayer({ name: 'Bob' });
+  const bobId = Array.from(room.players.keys()).find((k) => k !== 'p_h');
+  room.detachSocket(bobId);
+  assert.equal(room._ghostTimers.has(bobId), true);
+  // cleanup
+  room._clearAllGhostTimers();
+});
+
+test('Room: host detach does NOT schedule ghost timer (host_transfer_grace owns it)', () => {
+  const room = new Room({
+    code: 'ABCD',
+    hostId: 'p_h',
+    hostName: 'Alice',
+    ghostTimeoutMs: 60_000,
+  });
+  room.detachSocket('p_h');
+  assert.equal(room._ghostTimers.has('p_h'), false);
+});
+
+test('Room: reconnect cancels pending ghost timer', () => {
+  const room = new Room({
+    code: 'ABCD',
+    hostId: 'p_h',
+    hostName: 'Alice',
+    ghostTimeoutMs: 60_000,
+  });
+  room.addPlayer({ name: 'Bob' });
+  const bobId = Array.from(room.players.keys()).find((k) => k !== 'p_h');
+  room.detachSocket(bobId);
+  assert.equal(room._ghostTimers.has(bobId), true);
+  // Fake socket — attachSocket only checks readyState if previous exists.
+  const fakeSocket = { readyState: 1 };
+  room.attachSocket(bobId, fakeSocket);
+  assert.equal(room._ghostTimers.has(bobId), false);
+});
+
+test('Room: ghostTimeoutMs=0 disables cleanup', () => {
+  const room = new Room({
+    code: 'ABCD',
+    hostId: 'p_h',
+    hostName: 'Alice',
+    ghostTimeoutMs: 0,
+  });
+  room.addPlayer({ name: 'Bob' });
+  const bobId = Array.from(room.players.keys()).find((k) => k !== 'p_h');
+  room.detachSocket(bobId);
+  assert.equal(room._ghostTimers.has(bobId), false);
+});
+
+test('Room: close() clears all pending ghost timers', () => {
+  const room = new Room({
+    code: 'ABCD',
+    hostId: 'p_h',
+    hostName: 'Alice',
+    ghostTimeoutMs: 60_000,
+  });
+  room.addPlayer({ name: 'Bob' });
+  room.addPlayer({ name: 'Carol' });
+  for (const pid of Array.from(room.players.keys())) {
+    if (pid !== 'p_h') room.detachSocket(pid);
+  }
+  assert.equal(room._ghostTimers.size, 2);
+  room.close();
+  assert.equal(room._ghostTimers.size, 0);
+});
+
+test('Room: ghost timer firing removes player + leaves host intact', async () => {
+  const room = new Room({
+    code: 'ABCD',
+    hostId: 'p_h',
+    hostName: 'Alice',
+    ghostTimeoutMs: 50, // short for test
+  });
+  room.addPlayer({ name: 'Bob' });
+  const bobId = Array.from(room.players.keys()).find((k) => k !== 'p_h');
+  room.detachSocket(bobId);
+  assert.equal(room.players.has(bobId), true);
+  await new Promise((r) => setTimeout(r, 120));
+  assert.equal(room.players.has(bobId), false);
+  assert.equal(room.players.has('p_h'), true);
+});
+
+// --- WS integration ---
+
+test('WS-ghost: timer fires + broadcasts player_left{ghost_timeout}', async () => {
+  const { lobby, port, wsHandle } = await spinUp();
+  try {
+    // Tight ghost window so test is fast.
+    const meta = lobby.createRoom({ hostName: 'Alice' });
+    const room = lobby.getRoom(meta.code);
+    room.ghostTimeoutMs = 80;
+    const p1 = lobby.joinRoom({ code: meta.code, playerName: 'Bob' });
+
+    const hostWs = openWs(port, {
+      code: meta.code,
+      player_id: meta.host_id,
+      token: meta.host_token,
+    });
+    const p1Ws = openWs(port, {
+      code: meta.code,
+      player_id: p1.player_id,
+      token: p1.player_token,
+    });
+    await Promise.all([waitOpen(hostWs), waitOpen(p1Ws)]);
+    await Promise.all([
+      waitForMessage(hostWs, (m) => m.type === 'hello'),
+      waitForMessage(p1Ws, (m) => m.type === 'hello'),
+    ]);
+
+    // p1 drops. Host should receive player_disconnected immediately,
+    // then player_left{ghost_timeout} after grace.
+    p1Ws.close();
+    await waitForMessage(
+      hostWs,
+      (m) => m.type === 'player_disconnected' && m.payload.player_id === p1.player_id,
+    );
+    const left = await waitForMessage(
+      hostWs,
+      (m) =>
+        m.type === 'player_left' &&
+        m.payload.player_id === p1.player_id &&
+        m.payload.reason === 'ghost_timeout',
+      2000,
+    );
+    assert.equal(left.payload.reason, 'ghost_timeout');
+    // Player removed from room.
+    assert.equal(room.players.has(p1.player_id), false);
+
+    hostWs.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('WS-ghost: reconnect within window cancels removal', async () => {
+  const { lobby, port, wsHandle } = await spinUp();
+  try {
+    const meta = lobby.createRoom({ hostName: 'Alice' });
+    const room = lobby.getRoom(meta.code);
+    room.ghostTimeoutMs = 200; // longer so reconnect lands inside
+    const p1 = lobby.joinRoom({ code: meta.code, playerName: 'Bob' });
+
+    const hostWs = openWs(port, {
+      code: meta.code,
+      player_id: meta.host_id,
+      token: meta.host_token,
+    });
+    let p1Ws = openWs(port, {
+      code: meta.code,
+      player_id: p1.player_id,
+      token: p1.player_token,
+    });
+    await Promise.all([waitOpen(hostWs), waitOpen(p1Ws)]);
+    await Promise.all([
+      waitForMessage(hostWs, (m) => m.type === 'hello'),
+      waitForMessage(p1Ws, (m) => m.type === 'hello'),
+    ]);
+
+    p1Ws.close();
+    await waitForMessage(
+      hostWs,
+      (m) => m.type === 'player_disconnected' && m.payload.player_id === p1.player_id,
+    );
+    // Reconnect quickly.
+    await new Promise((r) => setTimeout(r, 50));
+    p1Ws = openWs(port, {
+      code: meta.code,
+      player_id: p1.player_id,
+      token: p1.player_token,
+    });
+    await waitOpen(p1Ws);
+    await waitForMessage(p1Ws, (m) => m.type === 'hello');
+    // Wait past the ghost window — must NOT have been removed.
+    await new Promise((r) => setTimeout(r, 250));
+    assert.equal(room.players.has(p1.player_id), true);
+
+    hostWs.close();
+    p1Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});


### PR DESCRIPTION
## Sprint R.4 — Phantom-disconnect cleanup (Game/-side only)

Closes ghost-player gap. Disconnected non-host players auto-removed after grace window with \`player_left{ghost_timeout}\` broadcast.

## Changes

- New \`DEFAULT_GHOST_TIMEOUT_MS = 120_000\` (2 min). Override per-room via \`Room({ ghostTimeoutMs })\`. \`0\` disables cleanup (preserves M11 Phase A baseline).
- \`Room.detachSocket(playerId)\` schedules \`_scheduleGhostCleanup\` (non-host only — host path stays on existing \`host_transfer_grace_ms\`).
- \`Room.attachSocket(playerId)\` clears pending timer on reconnect within window.
- \`Room.close()\` clears all pending ghost timers.
- Defense: timer callback re-checks \`connected\` flag (race safety).

## Acceptance gate

| Suite | Result |
|---|---|
| \`tests/services/network/wsSession-ghost.test.js\` | 8/8 |
| Full regression (lobby + JWT + resume + state_patch + ghost + coop) | 108/108 |
| Prettier | clean |

## Cross-repo

No Godot change required — existing \`CoopWsPeer.player_left\` signal already propagates any \`reason\` field server emits. Caller can branch on \`reason == "ghost_timeout"\` to decide UI ("Bob disconnected → removed from lobby").

## Out of scope

R.5 ledger replay polish (intent + phase_change + action_resolved event classes) + auth_expired caller wire — separate PR per \`docs/godot-v2/sprint-r-plan.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)