### PR TITLE
fix(sprint-r-codex): PR #2031/#2033/#2034 + paired snapshot_required state attach

### DIFF
--- a/apps/backend/services/network/jsonPatch.js
+++ b/apps/backend/services/network/jsonPatch.js
@@ -18,7 +18,15 @@
 'use strict';
 
 function decodePointer(path) {
-  if (typeof path !== 'string' || path.length === 0) return [];
+  // Codex PR #2033 P2 fix: distinguish missing/non-string path
+  // (invalid input) from intentional empty-string root pointer (RFC
+  // 6901 §5). Pre-fix: both produced `[]` segments and applyOp
+  // silently treated them as root replacement → malformed ops without
+  // a path field could corrupt entire room state.
+  if (typeof path !== 'string') {
+    throw new Error('invalid_pointer: path must be string');
+  }
+  if (path.length === 0) return []; // RFC 6901 root pointer.
   if (path === '/') return [''];
   if (path[0] !== '/') throw new Error(`invalid_pointer: ${path}`);
   return path

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -229,9 +229,24 @@ class Room {
     return true;
   }
 
-  detachSocket(playerId) {
+  detachSocket(playerId, socket = null) {
     const p = this.players.get(playerId);
     if (!p) return false;
+    // Codex PR #2034 P1 fix: when attachSocket closes a previous
+    // socket as `superseded`, that older socket later fires `close`
+    // → handler calls detachSocket. By then the NEW socket is already
+    // attached (p.socket === newSocket). Pre-fix: detachSocket
+    // unconditionally cleared p.socket + scheduled ghost cleanup,
+    // marking the actively-connected player as a ghost during the
+    // reconnect race.
+    //
+    // Now: if caller passes the socket that just closed AND it's not
+    // p.socket (i.e. it was already superseded), this call is a stale
+    // close-event no-op. Caller without socket arg keeps legacy
+    // behavior for back-compat.
+    if (socket !== null && p.socket !== null && p.socket !== socket) {
+      return false;
+    }
     p.socket = null;
     p.connected = false;
     // Sprint R.4 — schedule ghost cleanup. Host path is unchanged
@@ -1004,20 +1019,37 @@ function createWsServer({
     // signature authority; client never verifies. On expired token,
     // emit `auth_expired` so clients can trigger REST re-join (mint
     // fresh JWT) without inferring from generic `auth_failed`.
+    //
+    // Codex PR #2031 P1 fix: hydrated pre-JWT rooms retain raw token
+    // strings in player.token (LobbyService.hydrate() restores them
+    // verbatim). Pure JWT-only verify locks out those active rooms on
+    // deploy. Fallback path: if JWT decode fails AND the raw token
+    // matches the stored player record, accept it (legacy compat).
+    // Expired-JWT close is preserved (must re-mint via REST), but
+    // signature/format errors degrade to legacy-token attempt.
     let claims = null;
+    let legacyTokenAccepted = false;
     try {
       claims = verifyPlayerToken(token);
     } catch (err) {
-      const errCode = err.code === 'auth_expired' ? 'auth_expired' : 'auth_failed';
-      const closeCode = errCode === 'auth_expired' ? 4002 : 4003;
-      socket.send(JSON.stringify({ type: 'error', payload: { code: errCode } }));
-      socket.close(closeCode, errCode);
-      return;
+      if (err.code === 'auth_expired') {
+        socket.send(JSON.stringify({ type: 'error', payload: { code: 'auth_expired' } }));
+        socket.close(4002, 'auth_expired');
+        return;
+      }
+      // Not a JWT (or malformed signature) — try legacy token match.
+      // room.authenticate compares against stored raw token.
+      const legacyPlayer = room.authenticate(playerId, token);
+      if (!legacyPlayer) {
+        socket.send(JSON.stringify({ type: 'error', payload: { code: 'auth_failed' } }));
+        socket.close(4003, 'auth_failed');
+        return;
+      }
+      legacyTokenAccepted = true;
     }
-    // Cross-check claims align with query params + stored player record.
-    // Defense in depth: token must match the player record under the
-    // same room_code AND identity must match the URL player_id.
-    if (claims.room_code !== code || claims.player_id !== playerId) {
+    // Cross-check JWT claims (skip when legacy raw token accepted —
+    // raw tokens carry no claims).
+    if (!legacyTokenAccepted && (claims.room_code !== code || claims.player_id !== playerId)) {
       socket.send(JSON.stringify({ type: 'error', payload: { code: 'auth_failed' } }));
       socket.close(4003, 'auth_failed');
       return;
@@ -1085,10 +1117,21 @@ function createWsServer({
           }),
         );
       } else if (room.needsFullSnapshot(lastVersion)) {
+        // Codex PR #98 (Godot v2 paired) P1 fix: client has no path to
+        // surface authoritative snapshot via entries[]-only payload.
+        // Attach current room state + version so client emits its
+        // existing state_received signal directly. Pre-fix clients
+        // without paired update simply ignore the extra fields
+        // (back-compat).
         socket.send(
           JSON.stringify({
             type: 'replay',
-            payload: { entries: [], reason: 'snapshot_required' },
+            payload: {
+              entries: [],
+              reason: 'snapshot_required',
+              state: room.state,
+              state_version: room.stateVersion,
+            },
           }),
         );
       } else {
@@ -1205,7 +1248,9 @@ function createWsServer({
     });
 
     socket.on('close', () => {
-      room.detachSocket(playerId);
+      // Codex PR #2034 P1 fix: pass closing socket so detachSocket can
+      // skip stale close events (superseded reconnect race).
+      room.detachSocket(playerId, socket);
       room.broadcast({
         type: 'player_disconnected',
         payload: { player_id: playerId },

--- a/tests/services/network/wsSession-w55codex.test.js
+++ b/tests/services/network/wsSession-w55codex.test.js
@@ -1,0 +1,106 @@
+// Sprint R codex bundle — fixes for PR #2031 + #2033 + #2034 + #98
+// (Godot paired snapshot_required state attach).
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { LobbyService } = require('../../../apps/backend/services/network/wsSession');
+const jsonPatch = require('../../../apps/backend/services/network/jsonPatch');
+
+// --- Codex PR #2033 P2: jsonPatch reject missing/non-string path ---
+
+test('jsonPatch decodePointer throws on missing path field', () => {
+  assert.throws(
+    () => jsonPatch.applyOp({ foo: 1 }, { op: 'replace', value: 99 }),
+    /invalid_pointer/,
+  );
+});
+
+test('jsonPatch decodePointer throws on non-string path', () => {
+  assert.throws(
+    () => jsonPatch.applyOp({}, { op: 'replace', path: 123, value: 'x' }),
+    /invalid_pointer/,
+  );
+});
+
+test('jsonPatch decodePointer throws on null path', () => {
+  assert.throws(() => jsonPatch.applyOp({}, { op: 'remove', path: null }), /invalid_pointer/);
+});
+
+test('jsonPatch empty-string path still legitimate root op (RFC 6901)', () => {
+  // Empty-string IS a valid root pointer; only missing/non-string is invalid.
+  const result = jsonPatch.applyOp({ a: 1 }, { op: 'replace', path: '', value: { b: 2 } });
+  assert.deepEqual(result, { b: 2 });
+});
+
+test('jsonPatch malformed op without path does NOT silently replace state', () => {
+  // Pre-fix: { op: 'remove' } would clear entire state. Post-fix: throws.
+  assert.throws(() => jsonPatch.applyOp({ critical: 'data' }, { op: 'remove' }), /invalid_pointer/);
+});
+
+// --- Codex PR #2034 P1: ghost cleanup gated on active socket ---
+
+test('detachSocket with stale socket arg is no-op (superseded reconnect race)', () => {
+  const lobby = new LobbyService({ ghostTimeoutMs: 1000 });
+  const { code } = lobby.createRoom({ hostName: 'Host' });
+  const room = lobby.getRoom(code);
+  const join = lobby.joinRoom({ code, playerName: 'Guest' });
+  const playerId = join.player_id;
+  // Simulate first socket attach.
+  const oldSocket = { readyState: 1, close: () => {} };
+  room.attachSocket(playerId, oldSocket);
+  // Simulate reconnect — new socket attaches, old gets superseded.
+  const newSocket = { readyState: 1, close: () => {} };
+  room.attachSocket(playerId, newSocket);
+  // Old socket's deferred close event fires → detachSocket(playerId, oldSocket).
+  // With socket arg, must NOT clear new socket nor schedule ghost.
+  const result = room.detachSocket(playerId, oldSocket);
+  assert.equal(result, false, 'stale close returns false');
+  const p = room.getPlayer(playerId);
+  assert.equal(p.socket, newSocket, 'new socket preserved');
+  assert.equal(p.connected, true, 'still connected');
+});
+
+test('detachSocket with current socket arg clears + schedules ghost', () => {
+  const lobby = new LobbyService({ ghostTimeoutMs: 1000 });
+  const { code } = lobby.createRoom({ hostName: 'Host' });
+  const room = lobby.getRoom(code);
+  const join = lobby.joinRoom({ code, playerName: 'Guest' });
+  const playerId = join.player_id;
+  const sock = { readyState: 1, close: () => {} };
+  room.attachSocket(playerId, sock);
+  const ok = room.detachSocket(playerId, sock);
+  assert.equal(ok, true);
+  const p = room.getPlayer(playerId);
+  assert.equal(p.socket, null);
+  assert.equal(p.connected, false);
+});
+
+test('detachSocket without socket arg keeps legacy behavior', () => {
+  const lobby = new LobbyService({ ghostTimeoutMs: 1000 });
+  const { code } = lobby.createRoom({ hostName: 'Host' });
+  const room = lobby.getRoom(code);
+  const join = lobby.joinRoom({ code, playerName: 'Guest' });
+  const playerId = join.player_id;
+  const sock = { readyState: 1, close: () => {} };
+  room.attachSocket(playerId, sock);
+  // Legacy call without socket — clears unconditionally.
+  const ok = room.detachSocket(playerId);
+  assert.equal(ok, true);
+  assert.equal(room.getPlayer(playerId).connected, false);
+});
+
+// --- Codex PR #2031 P1: legacy raw-token fallback for hydrated rooms ---
+// Note: full WS integration test would require live ws server + JWT signing.
+// Verified at unit level via Room.authenticate accepting raw tokens.
+
+test('Room.authenticate accepts legacy raw token (back-compat for hydrated rooms)', () => {
+  const lobby = new LobbyService();
+  const { code } = lobby.createRoom({ hostName: 'Host' });
+  const room = lobby.getRoom(code);
+  const join = lobby.joinRoom({ code, playerName: 'Guest' });
+  // Room.authenticate compares raw token field; this is what the JWT
+  // fallback path calls when JWT verify fails on legacy tokens.
+  const p = room.authenticate(join.player_id, join.player_token);
+  assert.ok(p, 'raw token authenticated');
+});


### PR DESCRIPTION
## Summary

Bundles 3 codex review findings on Sprint R Game/-side PRs + paired Game/-side fix for Godot PR #98 P1.

## Findings

### 1. PR #2031 P1 — JWT verify breaks hydrated pre-JWT tokens

`LobbyService.hydrate()` restores raw token strings; JWT-only verify locks out active rooms on deploy. **Fix**: legacy raw-token fallback via `room.authenticate()` when JWT signature/format fails. `auth_expired` still closes 4002 to force REST re-mint.

### 2. PR #2033 P2 — jsonPatch silent root replace on missing path

`{ op: 'replace', value: ... }` (no path) decoded to `[]` → root replace. **Fix**: throw `invalid_pointer` on non-string path. Empty-string path remains valid root pointer (RFC 6901).

### 3. PR #2034 P1 — ghost cleanup on superseded close

`detachSocket` cleared player on stale close events from previously-superseded sockets. **Fix**: optional `socket` arg, no-op when `p.socket !== socket`. Legacy no-arg call preserved.

### 4. Godot PR #98 paired — snapshot_required attach state

Server now ships `state` + `state_version` inside `snapshot_required` payload. Godot PR #105 already extracts + emits `state_received`.

## Tests (+9)

`wsSession-w55codex.test.js` — jsonPatch validation, detachSocket gate, raw-token auth back-compat.

Coop+companion+network+routes: 162 → **171** (+9). All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)