### PR TITLE
feat(backend): dotenv autoload — eliminate manual $env:AUTH_SECRET workaround

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,10 @@
-# Variabili ambiente per lo stack locale/CI
+# Variabili ambiente per lo stack locale/CI.
+#
+# Backend autoload: `apps/backend/index.js` calls `require('dotenv').config(...)`
+# at boot, so any vars defined here populate `process.env` automatically when
+# you run `npm run start:api`. Override per-shell with explicit env vars when
+# needed (e.g. `PORT=3335 npm run start:api`).
+
 DATABASE_URL=postgresql://game:game@localhost:5432/game?schema=public
 PRISMA_BOOTSTRAP_FILE=.docker-prisma-bootstrapped
 POSTGRES_USER=game

--- a/apps/backend/index.js
+++ b/apps/backend/index.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+// Load .env from repo root before any module reads process.env. Silent if absent
+// (dev fallbacks kick in upstream — see jwtAuth.js AUTH_SECRET handling).
+require('dotenv').config({ path: require('node:path').resolve(__dirname, '..', '..', '.env') });
 const http = require('node:http');
 const path = require('node:path');
 const { createApp } = require('./app');

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -19,6 +19,7 @@
     "@prisma/client": "^6.2.1",
     "ajv": "^8.17.1",
     "cors": "^2.8.5",
+    "dotenv": "^16.6.1",
     "express": "^4.19.2",
     "js-yaml": "^4.1.0",
     "jsonwebtoken": "^9.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@prisma/client": "^6.2.1",
         "ajv": "^8.17.1",
         "cors": "^2.8.5",
+        "dotenv": "^16.6.1",
         "express": "^4.19.2",
         "js-yaml": "^4.1.0",
         "jsonwebtoken": "^9.0.3",

--- a/tests/api/dotenv-autoload.test.js
+++ b/tests/api/dotenv-autoload.test.js
@@ -1,0 +1,55 @@
+// Verify dotenv autoload at backend boot.
+//
+// Eliminates manual `$env:AUTH_SECRET = ...` workaround on Cloudflare deploy
+// session 2026-05-03. Backend `apps/backend/index.js` now calls
+// `require('dotenv').config(...)` before `./app` so JWT secret + autoclose +
+// Game-Database flags all read from `.env` instead of dev fallbacks.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fs = require('node:fs');
+const { spawnSync } = require('node:child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+test('dotenv loads .env from repo root', () => {
+  const tmpEnv = path.join(REPO_ROOT, `.env.dotenv-autoload-fixture-${process.pid}`);
+  fs.writeFileSync(tmpEnv, 'TEST_AUTOLOAD_VAR=loaded-via-dotenv\n');
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        '-e',
+        `require('dotenv').config({path:${JSON.stringify(tmpEnv)}});process.stdout.write(process.env.TEST_AUTOLOAD_VAR||'unset')`,
+      ],
+      { cwd: REPO_ROOT },
+    );
+    assert.equal(result.status, 0, result.stderr.toString());
+    assert.equal(result.stdout.toString(), 'loaded-via-dotenv');
+  } finally {
+    fs.unlinkSync(tmpEnv);
+  }
+});
+
+test('backend index.js wires dotenv before ./app require', () => {
+  const indexSrc = fs.readFileSync(path.join(REPO_ROOT, 'apps/backend/index.js'), 'utf8');
+  const dotenvIdx = indexSrc.indexOf("require('dotenv')");
+  const createAppIdx = indexSrc.indexOf("require('./app')");
+  assert.ok(dotenvIdx >= 0, 'dotenv require missing in index.js');
+  assert.ok(createAppIdx >= 0, './app require missing in index.js');
+  assert.ok(dotenvIdx < createAppIdx, 'dotenv must be required before ./app');
+});
+
+test('absent .env: dotenv config silent (no throw, status 0)', () => {
+  const ghost = path.join(REPO_ROOT, `.env.never-exists-${Date.now()}-${process.pid}`);
+  const result = spawnSync(
+    process.execPath,
+    ['-e', `require('dotenv').config({path:${JSON.stringify(ghost)}});process.stdout.write('ok')`],
+    { cwd: REPO_ROOT },
+  );
+  assert.equal(result.status, 0, result.stderr.toString());
+  assert.equal(result.stdout.toString(), 'ok');
+});


### PR DESCRIPTION
## Summary

Closes Cloudflare deploy smoke 2026-05-03 pure-code follow-up #1.

`apps/backend/index.js` now calls `require('dotenv').config({path: <repo-root>/.env})` before `./app` so all vars in `.env` (`AUTH_SECRET`, `LOBBY_WS_SHARED`, `ORCHESTRATOR_AUTOCLOSE_MS`, etc.) populate `process.env` automatically when running `npm run start:api`.

Eliminates the manual `\$env:AUTH_SECRET = (Get-Content .env | ...)` PowerShell step master-dd had to perform every session before deploy.

## Why

Pre-fix: `[jwtAuth] AUTH_SECRET missing or too short (<16 chars); using dev fallback. NOT FOR PRODUCTION.` — random secret per restart invalidated all in-flight JWTs.

Post-fix: `.env` autoloads → JWT secret stable across restarts → master-dd phone reconnects don't get `auth_expired` from secret rotation.

## Changes

- `apps/backend/package.json` — `dotenv ^16.6.1` workspace dep
- `apps/backend/index.js` — `require('dotenv').config({path: ...})` at top, before `./app`
- `.env.example` — header comment documenting autoload behavior
- `tests/api/dotenv-autoload.test.js` — 3 tests (fixture load + wire-order + absent-file silent)

## Test plan

- [x] `node --test tests/api/dotenv-autoload.test.js` — 3/3 pass
- [x] `node --test tests/api/lobby-jwt.test.js` — 4/4 regression pass (no behavior change to existing JWT path)
- [x] `npx prettier --check apps/backend/index.js tests/api/dotenv-autoload.test.js`
- [ ] Full `npm run test:api` — defer to CI

## Compat

Absent `.env` file → `dotenv.config()` no-op silent (verified in test 3). Existing dev-fallback in `jwtAuth.js` still kicks in. Zero behavior change for CI / Docker compose flows that set env vars externally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)