### PR TITLE
feat(play): wire ennea archetypes debrief UI — close Engine LIVE Surface DEAD

### DIFF
--- a/apps/play/src/debriefPanel.css
+++ b/apps/play/src/debriefPanel.css
@@ -551,6 +551,44 @@
   flex: 1;
 }
 
+/* Sprint Surface-DEAD ennea — 9 archetypes manifested grid in debrief. */
+.db-ennea-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+.db-ennea-badge {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 10px 12px;
+  background: linear-gradient(180deg, #1e2433 0%, #131722 100%);
+  border: 1px solid #3a4060;
+  border-radius: 10px;
+  opacity: 0.55;
+}
+.db-ennea-badge.triggered {
+  opacity: 1;
+  border-color: #ffd166;
+  box-shadow: 0 0 12px rgba(255, 209, 102, 0.18);
+}
+.db-ennea-icon {
+  font-size: 1.4rem;
+  margin-right: 6px;
+}
+.db-ennea-label {
+  font-size: 0.92rem;
+  color: #e8eaf0;
+  font-weight: 600;
+  display: inline-block;
+}
+.db-ennea-desc {
+  font-size: 0.72rem;
+  color: #8893b0;
+  line-height: 1.3;
+}
+
 /* OD-001 Path A Sprint B (2026-04-26): debrief recruit section. */
 .db-recruit-list {
   display: flex;

--- a/apps/play/src/debriefPanel.js
+++ b/apps/play/src/debriefPanel.js
@@ -15,6 +15,35 @@ import { renderNarrativeEvent } from './qbnDebriefRender.js';
 // Sprint 12 (Surface-DEAD #4): Mating lifecycle eligibles render in debrief.
 import { renderLineageEligibles } from './lineagePanel.js';
 
+// Sprint Surface-DEAD ennea archetypes — 9 archetypes player surface in debrief.
+// Mirror ENNEA_META da characterPanel.js (kept self-contained per debrief scope).
+const ENNEA_META = {
+  'Riformatore(1)': { icon: '⚖️', label: 'Riformatore', desc: 'Setup metodico, alta precisione.' },
+  'Coordinatore(2)': { icon: '🤝', label: 'Coordinatore', desc: 'Coesione di squadra.' },
+  'Conquistatore(3)': { icon: '🔥', label: 'Conquistatore', desc: 'Aggressione e rischio.' },
+  'Individualista(4)': {
+    icon: '🌙',
+    label: 'Individualista',
+    desc: 'Resilienza in zona critica.',
+  },
+  'Architetto(5)': {
+    icon: '🏛️',
+    label: 'Architetto',
+    desc: 'Strategia metodica, basso rischio.',
+  },
+  'Lealista(6)': { icon: '🛡️', label: 'Lealista', desc: 'Vigilanza e supporto attivo.' },
+  'Esploratore(7)': { icon: '🧭', label: 'Esploratore', desc: 'Scoperta e mobilità.' },
+  'Cacciatore(8)': { icon: '🏹', label: 'Cacciatore', desc: 'Mordi-e-fuggi mirato.' },
+  'Stoico(9)': { icon: '🗿', label: 'Stoico', desc: 'Endurance sotto pressione.' },
+};
+
+function escapeEnneaHtml(s) {
+  return String(s || '').replace(
+    /[<>&"]/g,
+    (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;', '"': '&quot;' })[c],
+  );
+}
+
 // OD-001 Path A V3 Mating/Nido (2026-04-26): pure helper DOM-free per identify
 // recruitable enemies post-combat. Filtra unit team !== player/ally con hp<=0.
 // Preserva name/hp_max/mbti_type per UI label downstream.
@@ -146,6 +175,12 @@ export function renderDebriefPanel() {
         <div class="db-mbti-hidden" id="db-mbti-hidden"></div>
       </div>
 
+      <!-- Sprint R+1 (Surface-DEAD #X ennea archetypes): 9 archetypes player surface. -->
+      <div class="db-section" id="db-ennea-section" style="display:none">
+        <div class="db-section-title">🌀 Archetipi Ennea — manifestati</div>
+        <div class="db-ennea-grid" id="db-ennea-grid"></div>
+      </div>
+
       <!-- Sprint 10 (Surface-DEAD #7): QBN narrative event diegetic. -->
       <div class="db-section db-qbn-section" id="db-qbn-section" style="display:none">
         <div class="db-section-title">📖 Cronaca diegetica</div>
@@ -233,6 +268,9 @@ export function wireDebriefPanel(overlay, bridge) {
     partyList: [],
     readySet: new Set(),
     mbtiRevealed: null,
+    // Sprint Surface-DEAD ennea: archetype list per current player.
+    // Shape accepted: ["Conquistatore(3)", ...] (string) OR [{id, triggered}, ...] (object).
+    enneaArchetypes: [],
     // Sprint 10 (Surface-DEAD #7): QBN narrative event payload from debrief.
     // Shape: {id, title_it, body_it, choices: [{id, label_it}], eligible_count}
     narrativeEvent: null,
@@ -372,6 +410,38 @@ export function wireDebriefPanel(overlay, bridge) {
         })
         .join('');
     }
+  };
+
+  // Sprint Surface-DEAD ennea — render 9 archetypes manifested per current player.
+  // Sezione hidden quando enneaArchetypes vuoto. Accetta shape misto:
+  // - "Conquistatore(3)" (string) → triggered=true implicit
+  // - {id: "Conquistatore(3)", triggered: bool} (object)
+  const renderEnnea = () => {
+    const section = overlay.querySelector('#db-ennea-section');
+    const grid = overlay.querySelector('#db-ennea-grid');
+    if (!section || !grid) return;
+    const archetypes = Array.isArray(state.enneaArchetypes) ? state.enneaArchetypes : [];
+    if (archetypes.length === 0) {
+      section.style.display = 'none';
+      return;
+    }
+    section.style.display = '';
+    grid.innerHTML = archetypes
+      .map((a) => {
+        const id = typeof a === 'string' ? a : a?.id;
+        const triggered = typeof a === 'string' ? true : !!a?.triggered;
+        if (!id) return '';
+        const meta = ENNEA_META[id] || { icon: '◯', label: id, desc: '' };
+        const cls = triggered ? 'db-ennea-badge triggered' : 'db-ennea-badge';
+        return `
+          <div class="${cls}" data-archetype="${escapeEnneaHtml(id)}">
+            <span class="db-ennea-icon">${meta.icon}</span>
+            <span class="db-ennea-label">${escapeEnneaHtml(meta.label)}</span>
+            <div class="db-ennea-desc">${escapeEnneaHtml(meta.desc)}</div>
+          </div>
+        `;
+      })
+      .join('');
   };
 
   // Sprint 10 (Surface-DEAD #7) — render QBN narrative event diegetic.
@@ -728,6 +798,13 @@ export function wireDebriefPanel(overlay, bridge) {
     setLineageEligibles(payload) {
       state.matingEligibles = Array.isArray(payload) ? payload : [];
       renderLineage();
+    },
+    // Sprint Surface-DEAD ennea — set archetypes manifested for current player.
+    // Accepts ["Conquistatore(3)", ...] OR [{id, triggered}, ...] OR null.
+    // Graceful: section nascosta quando vuoto/null.
+    setEnneaArchetypes(payload) {
+      state.enneaArchetypes = Array.isArray(payload) ? payload : [];
+      renderEnnea();
     },
     show() {
       overlay.classList.remove('db-hidden');

--- a/apps/play/src/phaseCoordinator.js
+++ b/apps/play/src/phaseCoordinator.js
@@ -109,8 +109,15 @@ export function createPhaseCoordinator(bridge) {
             ? debriefPayload.mating_eligibles
             : [];
           if (dbApi.setLineageEligibles) dbApi.setLineageEligibles(matingEligibles);
+          // Sprint Surface-DEAD ennea: pipe ennea_archetypes per current player
+          // dal debriefPayload.vc_summary.per_actor[playerId].
+          const playerId = bridge?.session?.player_id || bridge?.session?.actor_id || null;
+          const enneaArchetypes = playerId
+            ? debriefPayload?.vc_summary?.per_actor?.[playerId]?.ennea_archetypes
+            : null;
+          if (dbApi.setEnneaArchetypes) dbApi.setEnneaArchetypes(enneaArchetypes);
         } catch {
-          /* narrative event + lineage optional */
+          /* narrative event + lineage + ennea optional */
         }
         break;
       }


### PR DESCRIPTION
## Summary

Pillar P4 (MBTI/Ennea) gap chiuso: 9 ennea archetypes computed in `vcSnapshot` ma ZERO surface player. **Engine LIVE Surface DEAD** anti-pattern per dominio ennea risolto.

**State pre-PR**:
- ✅ Engine LIVE: `apps/backend/services/enneaEffects.js` 214 LOC, 9/9 archetype mechanical buff (attack/defense/move/evasion/stress reduction)
- ✅ Payload LIVE: `rewardEconomy.buildDebriefSummary` embed `vc_summary.per_actor[uid].ennea_archetypes`
- ❌ UI DEAD: debrief overlay non rendering archetype cards

**State post-PR**: 4/4 LIVE end-to-end.

## Changes

### `apps/play/src/debriefPanel.js` (+77)
- `ENNEA_META` constant — 9 archetype label/icon/desc italiano
- HTML section `db-ennea-section` post `db-mbti-section`
- `state.enneaArchetypes` + `renderEnnea()` con dual-shape support:
  - String array `["Conquistatore(3)", "Stoico(9)"]` → triggered=true implicit
  - Object array `[{id, triggered}]` → opacity differenziata
- Bridge API `setEnneaArchetypes(payload)` — graceful null/[]→hide

### `apps/play/src/phaseCoordinator.js` (+8)
Pipe `vc_summary.per_actor[playerId].ennea_archetypes` da `bridge.lastDebrief` a `dbApi.setEnneaArchetypes` nello stesso try-block di QBN/lineage. playerId fallback `session.player_id || session.actor_id`.

### `apps/play/src/debriefPanel.css` (+38)
- `.db-ennea-grid` 2-col grid
- `.db-ennea-badge` base + `.triggered` golden border #ffd166 + box-shadow + opacity 1
- Non-triggered → opacity 0.55, no glow

## Test plan

Smoke browser preview verificato:
- [x] Empty array → section hidden
- [x] String shape `["Conquistatore(3)", "Stoico(9)"]` → 2 cards triggered
- [x] Object shape `[{id,triggered}]` → dim/glow correct (1/2 triggered)
- [x] Null → section hidden
- [x] Visual screenshot 4 cards 2-col grid (Conquistatore+Architetto golden, Stoico+Lealista dim)
- [x] Zero console errors
- [x] AI baseline 383/383 verde
- [x] `npm run format:check` → All matched files use Prettier code style
- [ ] CI verde

## Rollback

`git revert HEAD` — cleanly removes 3 file edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)