### PR TITLE
docs(adr): 2 draft ADR per master-dd verdict — Ennea taxonomy + cutover gate

### DIFF
--- a/docs/adr/ADR-2026-05-04-cutover-godot-v2-decision-gate.md
+++ b/docs/adr/ADR-2026-05-04-cutover-godot-v2-decision-gate.md
@@ -1,0 +1,171 @@
+---
+title: 'ADR-2026-05-04: Cutover Godot v2 decision gate — criteria + web v1 archive plan'
+doc_status: draft
+doc_owner: master-dd
+workstream: cross-cutting
+last_verified: 2026-05-04
+source_of_truth: false
+language: it
+review_cycle_days: 30
+related:
+  - docs/planning/2026-05-04-plan-v3-drift-sync-godot-realtime.md
+  - docs/planning/2026-04-29-master-execution-plan-v3.md
+  - docs/adr/ADR-2026-04-29-pivot-godot-immediate.md
+  - docs/adr/ADR-2026-05-04-ennea-taxonomy-canonical.md
+  - docs/planning/2026-04-29-sprint-n7-failure-model-parity-spec.md
+---
+
+# ADR-2026-05-04: Cutover Godot v2 decision gate
+
+- **Data**: 2026-05-04
+- **Stato**: **DRAFT — pre-conditions pending**
+- **Owner**: Master DD
+- **Stakeholder**: Tutti workstream + master-dd manual ops
+
+## 1. Contesto
+
+Plan v3 §"Fase 3 cutover ~4-8 sett" prevede full session engine port + co-op WS Godot HTML5 + cutover Godot v2 OR archive R&D web v1 final.
+
+Drift sync 2026-05-04 ([plan-v3-drift-sync](../planning/2026-05-04-plan-v3-drift-sync-godot-realtime.md)) ha identificato:
+
+- ✅ **Godot OVERSHOT plan v3 expectation in 5-6 giorni** (vs 6-8 sett Fase 2 estimate)
+- ✅ Sprint M-N-O-P-Q-R-W7 ALL closed Godot side
+- ✅ Co-op WS multiplayer COMPLETE (Sprint R + W4-W6 phone composer)
+- ✅ Caller-wire pipeline LIVE end-to-end W7.x (2/4 adapter)
+- ✅ Cross-repo sync: 6/6 endpoints LIVE, 0 schema drift contract level
+- 🟡 **2 verifiche parity revisited PARTIAL** (M.7 + N.7) — gating
+- ❌ **NEW drift discovered**: Ennea taxonomy schema mismatch 9 vs 6 — gating
+- ❌ Master-dd manual ops (phone smoke test) pending
+- ❌ Skiv asset Path 3 portrait + lifecycle stages NON shipped
+
+**Decisione richiesta**: quando triggerare formal cutover ADR ACCEPTED + web v1 archive?
+
+## 2. Pre-conditions cutover gate
+
+### 2.1 Critical path MANDATORY (gate non passabile senza ALL ✅)
+
+| #   | Pre-condition                                  | Stato attuale |  Effort residual   | Owner                |
+| --- | ---------------------------------------------- | :-----------: | :----------------: | -------------------- |
+| C1  | N.7 failure-model parity 5/5 close             |    🟡 3/5     |   ~14-16h Godot    | gameplay-programmer  |
+| C2  | M.7 DioField p95 timing instrumentation + test |  🟡 PARTIAL   |    ~4-6h Godot     | gameplay-programmer  |
+| C3  | Phone composer real-device smoke 2-device      |  ❌ pending   |   ~2-4h userland   | **MASTER-DD MANUAL** |
+| C4  | Ennea taxonomy ADR Accepted + impl close       |   🟡 DRAFT    | ~3-5h post-verdict | master-dd verdict    |
+| C5  | Cross-repo sync regression test pass           |    ✅ LIVE    |         0          | gameplay-programmer  |
+| C6  | Godot GUT baseline ≥1500 asserts pass          | 🟡 1488 (97%) |       ~minor       | dev                  |
+
+**Critical path totale**: ~24-31h dev/userland post master-dd verdict Item C4.
+
+### 2.2 Soft criteria DESIDERATA (gate passabile senza ma raccomandato)
+
+| #   | Soft criteria                                      |    Stato    |       Effort       | Note                      |
+| --- | -------------------------------------------------- | :---------: | :----------------: | ------------------------- |
+| S1  | Skiv asset Path 3 portrait + lifecycle stages      |     ❌      |   ~6-9h userland   | Recap-card visual quality |
+| S2  | Character creation TV scene Bible §0               |     ❌      |    ~6-10h Godot    | Full vertical slice       |
+| S3  | Beehave A.2 role overlays + registry               | 🟡 A.1 OPEN |    ~6-8h Godot     | AI behavior richness      |
+| S4  | 2 deferred adapter emitter wire (forecast/overlay) | 🟡 deferred |    ~3-5h Godot     | UX polish                 |
+| S5  | Sprint I playtest userland 2-3 device              |     ❌      | ~1-2 sett userland | Demo readiness            |
+
+**Soft criteria totale**: ~22-39h dev + 1-2 sett userland.
+
+### 2.3 Post-cutover deferred (non gating)
+
+| #   | Item                       |    Stato     | Note                          |
+| --- | -------------------------- | :----------: | ----------------------------- |
+| D1  | ERMES E7-E8 runtime bridge | ⏸ deferred  | Plan v3 explicit "non gating" |
+| D2  | Web v1 archive cleanup     | post-cutover | Solo dopo cutover Accepted    |
+
+## 3. Decision matrix scenarios
+
+### Scenario 1 — Cutover MINIMAL gate (only critical path)
+
+- Trigger: C1+C2+C3+C4+C5+C6 ✅
+- Effort: ~24-31h
+- Demo readiness: vertical slice tactical funzionante, NO Skiv signature visual, NO character creation TV
+- Risk: cutover demo "rough edges" visible
+
+### Scenario 2 — Cutover FULL gate (critical + soft selected)
+
+- Trigger: C1-C6 + S1+S2+S5 ✅
+- Effort: ~50-70h + 1-2 sett userland
+- Demo readiness: Skiv visual recap-card quality + character creation full + playtest validated
+- Risk: cutover delay 2-3 sett extra
+
+### Scenario 3 — Cutover STAGED (canary)
+
+- Phase A: cutover MINIMAL (Scenario 1) → web v1 stays alive in parallel
+- Phase B: post-cutover sprint completes soft criteria → archive web v1 formal
+- Pro: faster initial cutover trigger + safety net web v1 fallback
+- Contro: maintenance overhead 2 stack contemporanei N giorni
+
+## 4. Mia raccomandazione
+
+**Scenario 3 — Cutover STAGED (canary)** con thresholds:
+
+- **Phase A trigger** (cutover Godot v2 = primary, web v1 = fallback alive):
+  - C1+C2+C3+C4+C5+C6 ✅ (~24-31h dev + master-dd verdict)
+- **Phase B trigger** (web v1 archive formal):
+  - S1+S2+S5 ✅ (~50-70h cumulative)
+  - 1+ playtest session pass post-cutover
+  - 0 critical bug regression Phase A
+
+**Reasoning**:
+
+1. **Faster initial validation**: Phase A trigger ~24-31h vs ~50-70h FULL gate. Stage A unblocca primo demo Godot v2.
+2. **Safety net**: web v1 stays alive durante Phase A. Se Godot v2 fallisce demo, fallback rapido a web v1.
+3. **Iterative quality**: soft criteria S1+S2 polish post-Phase A senza pressing deadline.
+4. **Web v1 archive formal Phase B**: cutover irreversible solo dopo validation.
+
+## 5. Web v1 archive plan (Phase B)
+
+Quando Phase B trigger ✅, eseguire:
+
+### 5.1 Tag preservation
+
+```bash
+git tag web-v1-final $(git log --oneline | grep "0e044312" | cut -d' ' -f1)
+git push origin web-v1-final
+```
+
+Nota: web v1 ha già web-v1-final tag preservation 2026-04-29 (PR #2023 commit `91876ac0`). Aggiornare a HEAD post-Phase A se cutover stable.
+
+### 5.2 Frontend deprecate
+
+- `apps/play/src/` → move `apps/play.archive/`
+- `apps/play/package.json` → mark `"deprecated": true` + `"private": true`
+- `package.json` script `play:dev` → remove (o redirect Godot HTML5 export)
+- README + CLAUDE.md: aggiornare "Web v1 ARCHIVED, primary frontend = Godot v2"
+
+### 5.3 Backend preserve
+
+- `apps/backend/` cross-stack persiste Fase 3 (plan v3 explicit decision)
+- Endpoint surface `routes/coop.js` + `routes/companion.js` LIVE per Godot HTML5 client
+- ERMES bridge `prototypes/ermes_lab/` isolated, no impact
+
+### 5.4 Documentation update
+
+- ADR-2026-05-XX-cutover-godot-v2 → status `Accepted`
+- Plan v3 → mark Fase 3 `CHIUSA` + add cutover date
+- CLAUDE.md sprint context → update post-cutover state
+- Memory file ritual snapshot
+
+## 6. Decision request
+
+Master-dd specifica:
+
+1. **Scenario**: 1 (MINIMAL) / 2 (FULL) / 3 (STAGED canary)
+2. **Phase A timing**: ASAP / aspetta soft criteria S1 (Skiv asset visual)
+3. **Web v1 archive trigger**: post Phase A success / 7gg post-Phase A grace / Phase B explicit
+4. **Authorize impl**: ✅ proceed Fase 3 cutover OR ❌ defer pending
+
+**Default se no verdict 14gg**: Scenario 3 + Phase A ASAP post critical-path close + web v1 archive trigger 7gg post-Phase A grace.
+
+## 7. Status
+
+**DRAFT** — pre-conditions critical path NOT yet met:
+
+- C1 N.7 close: pending (~14-16h Godot)
+- C2 M.7 timing: pending (~4-6h Godot)
+- C3 phone smoke: pending (master-dd manual)
+- C4 Ennea ADR: DRAFT separate ADR pending master-dd verdict
+
+ADR Accepted SOLO quando C1-C4 chiusi.

--- a/docs/adr/ADR-2026-05-04-ennea-taxonomy-canonical.md
+++ b/docs/adr/ADR-2026-05-04-ennea-taxonomy-canonical.md
@@ -1,0 +1,141 @@
+---
+title: 'ADR-2026-05-04: Ennea taxonomy canonical — 9 full enneagram vs 6 archetypes simplified'
+doc_status: draft
+doc_owner: master-dd
+workstream: cross-cutting
+last_verified: 2026-05-04
+source_of_truth: false
+language: it
+review_cycle_days: 30
+related:
+  - docs/planning/2026-05-04-plan-v3-drift-sync-godot-realtime.md
+  - docs/planning/2026-04-29-master-execution-plan-v3.md
+  - docs/adr/ADR-2026-04-29-pivot-godot-immediate.md
+---
+
+# ADR-2026-05-04: Ennea taxonomy canonical decision
+
+- **Data**: 2026-05-04
+- **Stato**: **DRAFT — master-dd verdict pending**
+- **Owner**: Master DD
+- **Stakeholder**: gameplay-programmer Game/ + Godot v2 + dataset-pack curator
+
+## 1. Contesto
+
+Drift sync 2026-05-04 ([plan-v3-drift-sync](../planning/2026-05-04-plan-v3-drift-sync-godot-realtime.md)) ha rivelato **schema mismatch cross-stack** Pillar P4 MBTI/Ennea:
+
+**Game/ web v1** (`apps/play/src/debriefPanel.js` + `characterPanel.js`, PR #2041):
+
+- 9 ENNEA_META full enneagram canon: Riformatore(1)/Coordinatore(2)/Conquistatore(3)/Individualista(4)/Architetto(5)/Lealista(6)/Esploratore(7)/Cacciatore(8)/Stoico(9)
+- Backend dataset `data/external/psychometrics/enneagramma/enneagramma_master.yaml` 100+ entries (core_emotion + basic_fear + basic_desire + passion + fixation + virtue + stress_to + growth_to + wings)
+- `apps/backend/services/enneaEffects.js` 214 LOC mechanical buff: 9 archetype × stat modifier (attack/defense/move/evasion/stress reduction)
+
+**Godot v2** (`scripts/ai/vc_scoring.gd`, Sprint O.5):
+
+- 6 ENNEA_ARCHETYPES winner-take-all simplified: warrior + 5 altri (clustering)
+- Sprint O.5 design intent: "Sprint O.5 winner-take-all simplified" da plan v3
+
+**Conseguenza**: `vcSnapshot.per_actor[uid].ennea_archetypes` payload Godot side produces 6-archetype array, Game side payload aspetta 9-type strings. Cross-stack incompatibility = blocker formal cutover Fase 3.
+
+## 2. Decision points
+
+Master-dd verdict richiesto su 3 dimensioni:
+
+### 2.1 Canonical taxonomy
+
+**Opzione A — 9 full enneagram canonical**:
+
+- Pro: pillar P4 design canon enneagramma riconosciuto + dataset 100+ entry curato + thought cabinet 9-type richness narrative + matching backend `enneaEffects.js` mechanical wire
+- Contro: complessità balance combat tactical (9 × wing × tritype...)
+- Effort port: ~3-5h Godot side rewrite `vc_scoring.gd::compute_ennea_archetypes()` + `ENNEA_ARCHETYPES` const 6→9 + GUT test update
+- Reuse: web v1 PR #2041 wire diretto in Godot debrief view (architecture pattern transferable)
+
+**Opzione B — 6 archetypes simplified canonical**:
+
+- Pro: snello combat tactical + winner-take-all clean + Sprint O.5 already shipped Godot
+- Contro: perdi richness narrative thought cabinet 9-type + dataset enneagramma_master.yaml diventa orphan reference
+- Effort migrate: ~3-5h Game side dataset rework + apps/backend/services/enneaEffects.js refactor 9→6 + characterPanel.js + debriefPanel.js (PR #2041 wire) reduce ENNEA_META 9→6
+
+**Opzione C — Hybrid 6+3 cluster**:
+
+- Sub-set 6 archetype tactical (combat) + 3 narrative wing/tritype overlay (debrief diegetic only)
+- Pro: best-of-both — clean tactical + richness narrative
+- Contro: complessità schema dual-track + maintenance overhead
+- Effort: ~6-10h cross-repo design + impl
+
+### 2.2 Migration timing
+
+**Opzione T1 — Pre-cutover (mandatory)**:
+
+- Fix taxonomy now, Game side migrate o Godot side port
+- Pro: cutover Fase 3 schema canonical da day-1
+- Contro: blocca cutover gate fino completion (~3-10h)
+
+**Opzione T2 — Post-cutover (deferred)**:
+
+- Cutover con schema mismatch tollerato, fix post
+- Pro: cutover non gated
+- Contro: web v1 stays 9-type alive durante cutover transition + Godot 6-type production data — incompatible state per N giorni
+
+### 2.3 Dataset preservation
+
+**Opzione D1 — Preserve enneagramma_master.yaml**:
+
+- Dataset 100+ entry full curato resta canonical reference. Anche se Opzione B vince, dataset NOT deleted — re-purpose come narrative seed library.
+
+**Opzione D2 — Archive dataset**:
+
+- Move `data/external/psychometrics/enneagramma/` → `docs/museum/excavations/` se Opzione B vince. Cleanup repo.
+
+## 3. Mia raccomandazione tecnica
+
+**Opzione A + T1 + D1** = full enneagram + pre-cutover fix + preserve dataset.
+
+**Reasoning**:
+
+1. **P4 pillar canon**: enneagramma 9-type è IP-defining feature del progetto. Plan v3 §P4 stato "🟡++ MBTI/Ennea + thought cabinet UI + tactical AI templates" implica richness 9-type.
+2. **Effort similar**: 3-5h Godot port (Opzione A) ≈ 3-5h Game migrate (Opzione B). Cost-equal ma Opzione A preserva richness.
+3. **6 derivable da 9**: clustering 9→6 è view-layer optimization (es. winner-take-all su top-3 archetype score). Fixed schema 9 con clustering helper = best-of-both.
+4. **Dataset asset**: 100+ entry psychometric = effort accumulato 3+ mesi. Discard via Opzione B = sunk cost loss.
+
+**Anti-pattern noted**: Opzione B "Sprint O.5 simplified" decisione era contestuale Sprint O.5 (Godot port speed), NON canonical product decision. Riconsiderare ora pre-cutover.
+
+## 4. Action plan se Opzione A approvata
+
+### Fase 1 — Godot side port (~3-5h)
+
+1. `scripts/ai/vc_scoring.gd::ENNEA_ARCHETYPES` const: 6 → 9 (Riformatore/Coordinatore/Conquistatore/Individualista/Architetto/Lealista/Esploratore/Cacciatore/Stoico)
+2. `compute_ennea_archetypes(aggregate, raw, config)`: rewrite trigger logic 9-archetype thresholds (mirror `apps/backend/services/vcScoring.js` Game side)
+3. GUT `tests/unit/test_vc_scoring_full.gd::test_ennea_archetypes_constant_count`: assert_eq 9 (not 6)
+4. Godot debrief view wire (mirror Game/ PR #2041 `debriefPanel.js` pattern): `ennea_archetypes` array render in ritual screen post-encounter
+
+### Fase 2 — Cross-stack verification (~1h)
+
+1. Smoke test: stesso input event payload → Game backend produces 9-type array == Godot vc_scoring produces 9-type array
+2. Schema lock: aggiorna `packages/contracts/schemas/` con ennea_archetypes 9-type enum (se applicable)
+3. Regression test cross-repo: Godot HTML5 build + Game/ Express dev → run encounter → debrief verify 9-archetype rendered
+
+### Fase 3 — Decision documented
+
+1. ADR aggiornato `Stato: Accepted` post master-dd verdict
+2. Plan v3 drift sync §"Item Ennea" stato "RESOLVED Opzione A"
+3. Memory file aggiornato
+
+## 5. Decision matrix sintetico
+
+| Opzione              |      Effort       | Richness P4 | Cutover gating | Dataset reuse |   Canonical   |
+| -------------------- | :---------------: | :---------: | :------------: | :-----------: | :-----------: |
+| A — 9 full enneagram |    3-5h Godot     |    ✅✅     |  T1 mandatory  |  ✅ preserve  |   ✅ canon    |
+| B — 6 simplified     | 3-5h Game migrate | 🟡 reduced  |  T1 mandatory  |  ❌ archive   |   🟡 ad-hoc   |
+| C — Hybrid 6+3       | 6-10h cross-repo  |    ✅✅     |  T1 mandatory  |  ✅ preserve  | 🟡 dual-track |
+
+## 6. Master-dd verdict request
+
+Per accettare ADR, master-dd specifica:
+
+1. **Taxonomy**: A / B / C
+2. **Timing**: T1 (pre-cutover) / T2 (post-cutover)
+3. **Dataset**: D1 (preserve) / D2 (archive)
+4. **Authorize impl**: ✅ proceed Fase 1-3 OR ❌ defer
+
+**Default se no verdict 7gg**: Opzione A + T1 + D1 (raccomandazione tecnica) trigger automatic.


### PR DESCRIPTION
## Summary

2 ADR drafts ship per master-dd verdict pre-cutover Fase 3:

1. **ADR-2026-05-04-ennea-taxonomy-canonical** — risolve schema mismatch 9 vs 6
2. **ADR-2026-05-04-cutover-godot-v2-decision-gate** — criteria + web v1 archive plan

## Decision request 1 — Ennea taxonomy

| Opzione | Effort | Richness P4 | Dataset reuse |
|---|:-:|:-:|:-:|
| **A — 9 full enneagram** (RECCOMANDATO) | 3-5h Godot port | ✅✅ | ✅ preserve |
| B — 6 simplified | 3-5h Game migrate | 🟡 reduced | ❌ archive |
| C — Hybrid 6+3 | 6-10h cross-repo | ✅✅ | ✅ preserve |

Default 7gg no verdict: A + T1 (pre-cutover) + D1 (preserve).

## Decision request 2 — Cutover gate

| Scenario | Effort | Risk |
|---|:-:|:-:|
| 1 MINIMAL | ~24-31h | demo rough edges |
| 2 FULL | ~50-70h + 1-2 sett userland | delay 2-3 sett |
| **3 STAGED canary** (RECCOMANDATO) | Phase A 24-31h + Phase B post-validation | best-of-both |

Default 14gg no verdict: Scenario 3 + Phase A ASAP + archive 7gg post-Phase A.

## Test plan

- [x] Governance check `errors=0 warnings=459` invariato
- [ ] CI verde
- [ ] Master-dd verdict on:
  - Ennea: A/B/C + T1/T2 + D1/D2
  - Cutover: 1/2/3 + Phase A timing + archive trigger

## Rollback

\`git revert HEAD\` — rimuove 2 ADR drafts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)