### PR TITLE
docs(playtest): fix Codex P1+P2 — Quick Tunnel coherent path + config.yml warn

### DIFF
--- a/docs/playtest/2026-05-05-phone-smoke-step-by-step.md
+++ b/docs/playtest/2026-05-05-phone-smoke-step-by-step.md
@@ -147,15 +147,40 @@ nslookup evo-phone.<YOUR-DOMAIN>
 # Atteso: CNAME → <UUID>.cfargotunnel.com
 ```
 
-### 3e. Path B ephemeral (no domain)
+### 3e. Path B ephemeral (no domain) — Quick Tunnel
 
-Se NO domain Cloudflare-managed:
+Se NO domain Cloudflare-managed → use Quick Tunnel (`*.trycloudflare.com`).
+
+⚠️ **Incompatibility con config.yml**: Cloudflare Quick Tunnels NON funzionano se esiste `~/.cloudflared/config.yml` (conflict: cloudflared tenta load named-tunnel config). Se hai già fatto Step 3b+3c e stai switchando a Path B → **rinomina temp** il config:
 
 ```bash
-cloudflared tunnel --url http://localhost:8080
+# Linux/macOS:
+mv ~/.cloudflared/config.yml ~/.cloudflared/config.yml.bak
+# Windows PowerShell:
+Rename-Item ~/.cloudflared/config.yml config.yml.bak
 ```
 
-Stampa subdomain auto-generato `https://<random>.trycloudflare.com`. **Limitazione**: 1 subdomain per istanza → serve apri 3 terminali separati per phone/api/ws (1 cloudflared per service). Ricorda di copiare i 3 URL — phone player serve api+ws URL espliciti.
+Restore con `mv ... .bak` reverse quando torni a named tunnel.
+
+Then run **3 separate terminali** (Quick Tunnel = 1 subdomain per istanza):
+
+```bash
+# Terminal A — phone HTML5 (port 8080)
+cloudflared tunnel --url http://localhost:8080
+# Stampa: https://<random-A>.trycloudflare.com
+
+# Terminal B — Game/ REST API (port 3334)
+cloudflared tunnel --url http://localhost:3334
+# Stampa: https://<random-B>.trycloudflare.com
+
+# Terminal C — Game/ WebSocket (port 3341)
+cloudflared tunnel --url http://localhost:3341
+# Stampa: https://<random-C>.trycloudflare.com
+```
+
+📋 **Salva i 3 URL** — phone player serve `<random-B>` come host API + `<random-C>` come host WS (vedi Step 5 sostituzione `<YOUR-DOMAIN>`).
+
+**Limitazione**: subdomain auto-generato cambia ogni restart. Per smoke test one-off OK. Per sessioni ripetute → use Path A named tunnel (Step 3a-3d).
 
 ---
 
@@ -196,12 +221,28 @@ cd C:/Users/VGit/Desktop/Game-Godot-v2
 
 ### Terminal 3 — Cloudflare Tunnel
 
+**Path A — named tunnel** (se hai seguito Step 3a-3d con domain):
+
 ```bash
 cloudflared tunnel run evo-tactics-demo
 # Atteso log: "Connection registered" x4 (4 edge replicas)
 ```
 
-**Smoke locale pre-phone**: apri `https://evo-phone.<YOUR-DOMAIN>` in browser desktop → deve caricare phone composer identica a `http://localhost:8080`. Se fail → vedi Troubleshooting #1.
+**Path B — Quick Tunnel** (se hai seguito Step 3e no-domain): hai già 3 cloudflared istanze attive (Terminal A/B/C dello Step 3e). NON lanciare `tunnel run` qui — Path B sostituisce Terminal 3 con quei 3 processi separati.
+
+📋 **Smoke locale pre-phone**:
+
+- Path A → apri `https://evo-phone.<YOUR-DOMAIN>` in browser desktop, deve caricare phone composer identica a `http://localhost:8080`.
+- Path B → apri `https://<random-A>.trycloudflare.com` (Step 3e Terminal A output).
+
+Se fail → vedi Troubleshooting #1.
+
+**Step 5 sostituzione hostname** (Path B):
+
+- Sostituisci `evo-phone.<YOUR-DOMAIN>` → `<random-A>.trycloudflare.com` (HTML5 phone)
+- Sostituisci `evo-api.<YOUR-DOMAIN>` → `<random-B>.trycloudflare.com` (REST host field)
+- Sostituisci `evo-ws.<YOUR-DOMAIN>` → `<random-C>.trycloudflare.com` (WSS host field)
+- Port: lascia `443` (Cloudflare TLS termination uguale per entrambi i path).
 
 ---
 


### PR DESCRIPTION
## Summary

Fix 2 Codex review findings on PR #2045 phone smoke test guide:

- **P1** Step 4 Terminal 3 hardcoded `cloudflared tunnel run evo-tactics-demo` (named tunnel) — non valido per no-domain Quick Tunnel branch dello Step 3e. Smoke procedure non-executable per user che segue path advertised. **Fix**: split Terminal 3 in Path A (named) vs Path B (Quick Tunnel = 3 cloudflared istanze). Add Step 5 hostname substitution table per Path B.
- **P2** Step 3e Quick Tunnel incompatible con `~/.cloudflared/config.yml` esistente (Cloudflare official: Quick Tunnels NON load se config file present). User che segue guida exact hits tunnel startup failure. **Fix**: warn rinominare temp `config.yml.bak` (Linux/macOS `mv` + Windows `Rename-Item`) prima Quick Tunnel. Restore reverse quando torna named.

## Files

- `docs/playtest/2026-05-05-phone-smoke-step-by-step.md` (+45 / -4)

## Test plan

- [x] Frontmatter governance (`python tools/check_docs_governance.py`) → 0 errors
- [x] Diff coherence: Path A (Step 3a-3d named) e Path B (Step 3e Quick Tunnel) ora end-to-end consistent fino a Step 5
- [ ] Master-dd dry-run guida post-merge

## Refs

- Origin PR: #2045 merged `2f0b94b9`
- Codex review comments: P1 (Step 4 Terminal 3) + P2 (Step 3e config.yml conflict)
- Cloudflare docs: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/trycloudflare/

🤖 Generated with [Claude Code](https://claude.com/claude-code)