### PR TITLE
chore(security+docs): gitignore .env + redirect phone smoke doc to deploy-quickstart upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,16 @@ data/derived/unit_diaries/
 
 # Repo-local tools (ngrok official ZIP, etc) - installed per-PC, NOT committed
 .tools/
+
+# Local secrets — AUTH_SECRET et al, populated by deploy-quick.sh / setup-once.sh.
+# Canonical secret path is ~/.config/api-keys/keys.env (vedi CLAUDE.md API Keys section).
+# Game/.env locale OK ma NON committable per evitare AUTH_SECRET / token leak.
+.env
+.env.local
+.env.*.local
+
+# Phone HTML5 build artifacts (mounted by deploy-quick.sh from Game-Godot-v2/dist/web)
+apps/backend/public/phone/
+
+# Cloudflare Tunnel deploy logs
+.deploy-logs/

--- a/docs/playtest/2026-05-05-phone-smoke-step-by-step.md
+++ b/docs/playtest/2026-05-05-phone-smoke-step-by-step.md
@@ -1,5 +1,5 @@
 ---
-title: Phone smoke test setup — step-by-step master-dd userland 2026-05-05
+title: Phone smoke test — userland playbook 2026-05-05
 workstream: ops-qa
 status: active
 owner: master-dd
@@ -7,21 +7,29 @@ last_review: 2026-05-05
 tags: [playtest, phone, smoke, godot-v2, w6, deploy, cloudflare-tunnel, telemetry]
 ---
 
-# Phone smoke test setup — step-by-step master-dd userland 2026-05-05
+# Phone smoke test — userland playbook 2026-05-05
 
-Guida operativa userland (~2-4h, no DevOps expertise required) per eseguire smoke test end-to-end stack co-op tactical: phone HTML5 (Godot v2) + Game/ Express REST + Game/ wsSession real-time. Closes drift sync 2026-05-04 Item C3 critical path Fase 3 cutover ADR.
+> **2026-05-05 update — superseded deploy guidance**: Cloudflare Tunnel + named-tunnel setup originale è stato rimpiazzato da `deploy-quick.sh` shared-mode. Questo doc ora copre **solo** smoke test scenarios + verdict template. Per deploy ops vai upstream:
+>
+> - **Canonical no-domain Quick Tunnel**: [Game-Godot-v2 docs/godot-v2/deploy-quickstart.md](https://github.com/MasterDD-L34D/Game-Godot-v2/blob/main/docs/godot-v2/deploy-quickstart.md) — single command `tools/deploy/deploy-quick.sh` end-to-end (~30s subsequent runs).
+> - **Canonical named tunnel + DNS**: [Game-Godot-v2 docs/godot-v2/deploy-master-dd-checklist.md](https://github.com/MasterDD-L34D/Game-Godot-v2/blob/main/docs/godot-v2/deploy-master-dd-checklist.md).
+> - **Background spec**: [Game-Godot-v2 docs/godot-v2/deploy-w6.md](https://github.com/MasterDD-L34D/Game-Godot-v2/blob/main/docs/godot-v2/deploy-w6.md).
+>
+> Originale Cloudflare account / cloudflared install / tunnel auth / ingress sezioni rimosse — risultavano duplicate vs upstream e divergenti rispetto allo shared-mode (1 porta 3334 invece di 3 separate). History pre-rewrite: PR #2045 + #2047.
 
-**Pre-condizioni assunte**: master-dd ha laptop Windows, account Cloudflare free tier, 2 phone (1 iOS + 1 Android) con dati cellulari/Wi-Fi.
+Closes drift sync 2026-05-04 Item C3 critical path Fase 3 cutover ADR.
 
-**Cross-ref upstream**: spec tecnico build pipeline + Tunnel config in [Game-Godot-v2 deploy-w6.md](https://github.com/MasterDD-L34D/Game-Godot-v2/blob/main/docs/godot-v2/deploy-w6.md). Quel doc copre HTML5 export ops; questo doc copre l'esecuzione interactive userland del path completo.
+## Telemetry verdict gate
 
-**Telemetry HUD**: durante test, `TelemetryCollector` (Godot v2 PR #166) traccia round-trip command-latency input→resolved p95. Verdict gate Sprint M.7:
+`TelemetryCollector` (Godot v2 PR #166) traccia round-trip command-latency input→resolved p95. Verdict gate Sprint M.7:
 
 | p95       |    Verdict     |
 | --------- | :------------: |
 | <100ms    |    PASS ✅     |
 | 100-200ms | CONDITIONAL ⚠️ |
 | >200ms    |    ABORT ❌    |
+
+Debug HUD legge p95 cumulative durante combat; verdict computato via `TelemetryCollector.threshold_verdict(p95)`.
 
 ---
 
@@ -31,274 +39,112 @@ Prima di iniziare, verifica che TUTTI i 5 punti siano OK:
 
 - [ ] **Godot 4.6 installato** — `%LOCALAPPDATA%/Godot/godot.cmd --version` deve stampare `4.6.x`. Se manca: download da https://godotengine.org/download/windows/ → unzip → copia in `%LOCALAPPDATA%/Godot/`.
 - [ ] **Project export preset Web esiste** — apri Godot v2 project, menu `Project → Export…`, deve esserci preset `Web` (preset.0). Se manca: Add → Web → Save. Required template: `Project → Tools → Manage Export Templates → Download` (4.6.x).
-- [ ] **Game/ Express startup verificato** — `cd C:/Users/VGit/Desktop/Game && npm run start:api` deve bootare su `http://0.0.0.0:3334` senza errori. Probe: `curl http://localhost:3334/api/health` ritorna 200.
-- [ ] **Game-Godot-v2 main pulled post PR #166** — `cd C:/Users/VGit/Desktop/Game-Godot-v2 && git pull origin main && git log --oneline -5`. Deve includere PR #166 TelemetryCollector commit.
-- [ ] **Browser HTML5 build verified locale** — esegui `./tools/web/build_web.sh --mode=phone --output-dir=dist/web` + `./tools/web/serve_local.sh --port=8080 --dir=dist/web` → apri `http://localhost:8080/` in Chrome desktop, deve caricare PhoneComposerBoot scene senza errori console.
+- [ ] **Game-Godot-v2 main pulled post PR #166** — `cd Game-Godot-v2 && git pull origin main && git log --oneline -5`. Deve includere PR #166 TelemetryCollector + #167 Ennea taxonomy commits.
+- [ ] **cloudflared installed** — `cloudflared --version` deve ritornare `2025.x.x`. Install: `winget install --id Cloudflare.cloudflared`.
+- [ ] **Game/ repo present + npm deps installed** — `cd Game && ls node_modules/express/package.json` deve esistere. Altrimenti: `npm ci`.
 
 Se uno fallisce → ferma, fix prima di procedere.
 
----
+### Workaround bug script Game-Godot-v2 (Windows MSYS, non ancora upstream-fixed)
 
-## Step 1 — Cloudflare account setup (15 min)
+`tools/web/build_web.sh` ha 2 issue su Windows MSYS shell:
 
-Free tier sufficiente per 3 hostname Tunnel.
+- Linea 57 `$USER` unbound (`set -u` enforce). **Fix**: `export USER="$USERNAME"`.
+- Linea 53-58 `command -v "$LOCALAPPDATA/Godot/godot.cmd"` fallisce su MSYS. **Fix**: `export GODOT_BIN="$LOCALAPPDATA/Godot/Godot_v4.6.2-stable_win64_console.exe"` (.exe direct).
 
-1. **Signup**: apri https://dash.cloudflare.com/sign-up → email + password robusta + signup.
-2. **Email verify**: check inbox, click link verify (token valido 24h).
-3. **2FA optional ma raccomandato**: Profile → Authentication → enable TOTP (Google Authenticator / Authy). Salva recovery codes offline.
-4. **Dashboard tour**: scroll sidebar sinistra → cerca `Zero Trust` (Tunnel vive lì). Se prompt "Add team name" → inserisci `evo-tactics-demo` o simile (free plan).
-5. **Verifica plan**: Account Home → Plan deve mostrare `Free` (zero costo, 50 user limit Zero Trust — sufficiente per playtest).
+`tools/web/serve_local.sh` ha bug `path.join(ROOT, url).startsWith(path.resolve(ROOT))` relative-vs-absolute → 403 forbidden. **Workaround**: NON usare serve_local. Usa `deploy-quick.sh` shared-mode che mounta phone in `Game/apps/backend/public/phone/` via Express (route bypass bug).
 
-⚠️ **Domain non strettamente richiesto**: Cloudflare Tunnel può usare `*.trycloudflare.com` ephemeral subdomain (no DNS setup). Se hai già un domain registrato e attivo su Cloudflare, salta a Step 3 ingress. Altrimenti use trycloudflare ephemeral path (più semplice per smoke test one-off).
+⏳ **TODO upstream PR**: fix `build_web.sh` USER/GODOT_BIN + `serve_local.sh` path resolve. Tracking: [docs/playtest/2026-05-05 follow-ups](#).
 
 ---
 
-## Step 2 — Cloudflare Tunnel install (Windows) (10 min)
+## Boot stack — `deploy-quick.sh` shared mode (~30s)
 
-`cloudflared` è il binary tunnel client.
-
-**Path A — winget (raccomandato, Windows 10+ build 1809+)**:
-
-```powershell
-winget install --id Cloudflare.cloudflared
-```
-
-**Path B — manual download**:
-
-1. Apri https://github.com/cloudflare/cloudflared/releases/latest
-2. Download `cloudflared-windows-amd64.exe`
-3. Rinomina → `cloudflared.exe`
-4. Sposta in `C:\Program Files\cloudflared\` (crea dir se serve)
-5. Aggiungi a PATH: System Properties → Environment Variables → Path → New → `C:\Program Files\cloudflared`
-6. Apri NUOVO terminale (PATH update non si propaga a shell aperti)
-
-**Verify**:
+Single-command end-to-end. Sostituisce 3-terminal setup precedente:
 
 ```bash
-cloudflared --version
-# Atteso: cloudflared version 2025.x.x ...
+cd /c/Users/VGit/Desktop/Game-Godot-v2
+export USER=VGit GODOT_BIN="$LOCALAPPDATA/Godot/Godot_v4.6.2-stable_win64_console.exe"
+bash tools/deploy/deploy-quick.sh
 ```
 
-Se `command not found` → PATH non propagato, apri shell nuovo.
+Cosa fa:
+
+1. Genera AUTH_SECRET in `Game/.env` (gitignored, vedi `.gitignore`).
+2. Build phone HTML5 (cache-aware; `FORCE_REBUILD=1` forza).
+3. Copy phone build → `Game/apps/backend/public/phone/`.
+4. Boot Game/ Express **shared mode** porta 3334 (REST + WS + phone same-origin, `LOBBY_WS_SHARED=true`).
+5. Avvia Cloudflare Quick Tunnel.
+6. Stampa URL `https://<random>.trycloudflare.com/phone/`.
+
+**Stop**: `Ctrl+C` — chiude tunnel + backend insieme via trap.
+
+### Deep-link helper (zero typing 4-letter code)
+
+```bash
+TUNNEL="https://<random>.trycloudflare.com"
+CODE=$(curl -s -X POST "$TUNNEL/api/lobby/create" \
+  -H "Content-Type: application/json" \
+  -d '{"host_name":"Eduardo"}' | jq -r .code)
+echo "Phone deep-link: $TUNNEL/phone/?room=$CODE"
+```
+
+`WebOriginResolver.read_url_query("room")` pre-compila `CodeInput`. `?code=XXXX` accettato come fallback.
 
 ---
 
-## Step 3 — Tunnel auth + ingress config (20 min)
+## Smoke test scenarios (45-60 min)
 
-### 3a. Authenticate
-
-```bash
-cloudflared tunnel login
-```
-
-Apre browser → seleziona account Cloudflare → autorizza. Token scritto in `~/.cloudflared/cert.pem`.
-
-### 3b. Create tunnel (one-time)
-
-```bash
-cloudflared tunnel create evo-tactics-demo
-```
-
-Output:
-
-```
-Created tunnel evo-tactics-demo with id <UUID>
-Credentials file: ~/.cloudflared/<UUID>.json
-```
-
-📋 **Salva il `<UUID>`** — serve per config.
-
-### 3c. Ingress config
-
-Crea `~/.cloudflared/config.yml` (Windows path: `C:\Users\<TUO-USER>\.cloudflared\config.yml`):
-
-```yaml
-tunnel: <UUID-HERE>
-credentials-file: C:\Users\<TUO-USER>\.cloudflared\<UUID>.json
-
-ingress:
-  # 1. HTML5 phone composer (HTTPS port 443 → local 8080)
-  - hostname: evo-phone.<YOUR-DOMAIN>
-    service: http://localhost:8080
-  # 2. Game/ Express REST API (HTTPS port 443 → local 3334)
-  - hostname: evo-api.<YOUR-DOMAIN>
-    service: http://localhost:3334
-  # 3. Game/ WebSocket (WSS port 443 → local 3341)
-  - hostname: evo-ws.<YOUR-DOMAIN>
-    service: http://localhost:3341
-  # Catch-all 404
-  - service: http_status:404
-```
-
-Sostituisci `<YOUR-DOMAIN>` con dominio Cloudflare-managed (es. `evo.example.com`).
-
-### 3d. DNS records propagate
-
-```bash
-cloudflared tunnel route dns evo-tactics-demo evo-phone.<YOUR-DOMAIN>
-cloudflared tunnel route dns evo-tactics-demo evo-api.<YOUR-DOMAIN>
-cloudflared tunnel route dns evo-tactics-demo evo-ws.<YOUR-DOMAIN>
-```
-
-Propagation tipica <60s (Cloudflare auto-managed). Verify via:
-
-```bash
-nslookup evo-phone.<YOUR-DOMAIN>
-# Atteso: CNAME → <UUID>.cfargotunnel.com
-```
-
-### 3e. Path B ephemeral (no domain) — Quick Tunnel
-
-Se NO domain Cloudflare-managed → use Quick Tunnel (`*.trycloudflare.com`).
-
-⚠️ **Incompatibility con config.yml**: Cloudflare Quick Tunnels NON funzionano se esiste `~/.cloudflared/config.yml` (conflict: cloudflared tenta load named-tunnel config). Se hai già fatto Step 3b+3c e stai switchando a Path B → **rinomina temp** il config:
-
-```bash
-# Linux/macOS:
-mv ~/.cloudflared/config.yml ~/.cloudflared/config.yml.bak
-# Windows PowerShell:
-Rename-Item ~/.cloudflared/config.yml config.yml.bak
-```
-
-Restore con `mv ... .bak` reverse quando torni a named tunnel.
-
-Then run **3 separate terminali** (Quick Tunnel = 1 subdomain per istanza):
-
-```bash
-# Terminal A — phone HTML5 (port 8080)
-cloudflared tunnel --url http://localhost:8080
-# Stampa: https://<random-A>.trycloudflare.com
-
-# Terminal B — Game/ REST API (port 3334)
-cloudflared tunnel --url http://localhost:3334
-# Stampa: https://<random-B>.trycloudflare.com
-
-# Terminal C — Game/ WebSocket (port 3341)
-cloudflared tunnel --url http://localhost:3341
-# Stampa: https://<random-C>.trycloudflare.com
-```
-
-📋 **Salva i 3 URL** — phone player serve `<random-B>` come host API + `<random-C>` come host WS (vedi Step 5 sostituzione `<YOUR-DOMAIN>`).
-
-**Limitazione**: subdomain auto-generato cambia ogni restart. Per smoke test one-off OK. Per sessioni ripetute → use Path A named tunnel (Step 3a-3d).
-
----
-
-## Step 4 — Game/ Express + Godot HTML5 boot (5 min)
-
-Apri **3 terminali in parallelo** (NON chiudere fino a fine smoke test).
-
-### Terminal 1 — Game/ backend
-
-```bash
-cd C:/Users/VGit/Desktop/Game
-
-# Generate AUTH_SECRET (one-time, then persist in .env):
-node -e "console.log(require('crypto').randomBytes(48).toString('base64url'))"
-# Copia output → ~/.config/api-keys/keys.env (canonical path):
-# AUTH_SECRET=<paste here>
-
-# Source secrets + boot:
-source ~/.config/api-keys/keys.env
-npm run start:api
-# Atteso log: "Idea Engine API listening on 0.0.0.0:3334"
-# WebSocket server: "wsSession listening on 0.0.0.0:3341"
-```
-
-### Terminal 2 — Godot HTML5 build + serve
-
-```bash
-cd C:/Users/VGit/Desktop/Game-Godot-v2
-
-# One-time build (rebuild solo se source change):
-./tools/web/build_web.sh --mode=phone --output-dir=dist/web
-# Atteso: dist/web/{index.html, .pck, .wasm, .js} ~10-15 MB
-
-# Serve con CORS headers required SharedArrayBuffer:
-./tools/web/serve_local.sh --port=8080 --dir=dist/web
-# Atteso: "Serving on http://localhost:8080"
-```
-
-### Terminal 3 — Cloudflare Tunnel
-
-**Path A — named tunnel** (se hai seguito Step 3a-3d con domain):
-
-```bash
-cloudflared tunnel run evo-tactics-demo
-# Atteso log: "Connection registered" x4 (4 edge replicas)
-```
-
-**Path B — Quick Tunnel** (se hai seguito Step 3e no-domain): hai già 3 cloudflared istanze attive (Terminal A/B/C dello Step 3e). NON lanciare `tunnel run` qui — Path B sostituisce Terminal 3 con quei 3 processi separati.
-
-📋 **Smoke locale pre-phone**:
-
-- Path A → apri `https://evo-phone.<YOUR-DOMAIN>` in browser desktop, deve caricare phone composer identica a `http://localhost:8080`.
-- Path B → apri `https://<random-A>.trycloudflare.com` (Step 3e Terminal A output).
-
-Se fail → vedi Troubleshooting #1.
-
-**Step 5 sostituzione hostname** (Path B):
-
-- Sostituisci `evo-phone.<YOUR-DOMAIN>` → `<random-A>.trycloudflare.com` (HTML5 phone)
-- Sostituisci `evo-api.<YOUR-DOMAIN>` → `<random-B>.trycloudflare.com` (REST host field)
-- Sostituisci `evo-ws.<YOUR-DOMAIN>` → `<random-C>.trycloudflare.com` (WSS host field)
-- Port: lascia `443` (Cloudflare TLS termination uguale per entrambi i path).
-
----
-
-## Step 5 — Smoke test scenarios (45-60 min)
-
-4 scenari sequenziali. Ogni scenario: **timer cronometro**, screenshot bug evidenti, annota observation in Step 6 template.
+4 scenari sequenziali. Ogni scenario: cronometro timer, screenshot bug evidenti, annota observation in verdict template.
 
 ### 5a. iOS Safari — lobby create
 
-1. iPhone → Safari → apri `https://evo-phone.<YOUR-DOMAIN>`.
+1. iPhone → Safari → apri tunnel URL `/phone/`.
 2. Phone composer carica → tap **Create Lobby**.
-3. Insert host=`evo-api.<YOUR-DOMAIN>`, port=`443`, player_name=`Master`.
-4. Tap **Create** → riceve **codice 4-letter** (es. `BCDF`).
-5. ✅ **Pass criteria**: codice visibile entro 5s, no error toast, console mobile (Settings → Safari → Advanced → Web Inspector via Mac) zero error.
-6. ❌ **Fail criteria**: timeout >10s, "Network error", whitescreen.
+3. host/port pre-compilati via `WebOriginResolver` (no manual edit).
+4. Tap **Create** → riceve **codice 4-letter**.
+5. ✅ **Pass**: codice visibile entro 5s, no error toast, console mobile zero error.
+6. ❌ **Fail**: timeout >10s, "Network error", whitescreen.
 
-📝 **Annota**: codice ottenuto + tempo create→code ms.
+📝 Annota: codice ottenuto + tempo create→code ms.
 
 ### 5b. Android Chrome — join URL + code
 
-1. Android phone → Chrome → apri `https://evo-phone.<YOUR-DOMAIN>`.
+1. Android phone → Chrome → apri tunnel URL `/phone/?room=<da 5a>`.
 2. Tap **Join Lobby**.
-3. Insert host=`evo-api.<YOUR-DOMAIN>`, port=`443`, code=`<da 5a>`, player_name=`Player2`.
-4. Tap **Join** → ridirezione a **World Setup vote**.
-5. Master (iOS) e Player2 (Android) votano world setup → quando 2/2 vote → entra in scenario tutorial.
-6. ✅ **Pass criteria**: join entro 3s, world setup screen sync su entrambi i phone <500ms, vote tally consistente.
-7. ❌ **Fail criteria**: code "invalid", lobby mostra solo 1 player, vote tally divergente (1/2 vs 2/2).
+3. Player2 join → ridirezione a **World Setup vote**.
+4. Master (iOS) e Player2 (Android) votano world setup → quando 2/2 vote → entra in scenario tutorial.
+5. ✅ **Pass**: join entro 3s, world setup screen sync su entrambi i phone <500ms, vote tally consistente.
+6. ❌ **Fail**: code "invalid", lobby mostra solo 1 player, vote tally divergente.
 
-📝 **Annota**: tempo join + tempo vote sync ms.
+📝 Annota: tempo join + tempo vote sync ms.
 
 ### 5c. Combat scenario tutorial 01 — 5 round play
 
-1. Da World Setup → seleziona **enc_tutorial_01** (default raccomandato per smoke).
+1. Da World Setup → seleziona **enc_tutorial_01**.
 2. 5 round combat play normale: select unit → declare action → commit round → resolve.
-3. Durante 5 round, **TelemetryCollector** (Godot v2 PR #166) raccoglie samples round-trip input→resolved.
-4. Su debug HUD (se enabled), o tramite `print(t.compute_p95_ms())` console Godot remote, leggi p95 cumulative.
-5. ✅ **Pass criteria** per ogni round: action UI responsive <500ms, no desync (entrambi phone vedono stesso state post-resolve), zero crash.
-6. ❌ **Fail criteria**: action button no-op, state divergente fra phone, crash hard.
+3. Durante 5 round, `TelemetryCollector` raccoglie samples round-trip input→resolved.
+4. Su debug HUD (se enabled) o `print(t.compute_p95_ms())` console Godot remote, leggi p95 cumulative.
+5. ✅ **Pass** per ogni round: action UI responsive <500ms, no desync (entrambi phone vedono stesso state post-resolve), zero crash.
+6. ❌ **Fail**: action button no-op, state divergente fra phone, crash hard.
 
-📝 **Annota**: round 1-5 osservation + p95 finale + verdict (PASS/CONDITIONAL/ABORT).
+📝 Annota: round 1-5 osservation + p95 finale + verdict (PASS/CONDITIONAL/ABORT).
 
 ### 5d. Disconnect simulation — reconnect verify
 
 1. Su Android phone, durante combat round attivo, **enable airplane mode 5s**.
 2. Phone deve mostrare overlay "Reconnecting…" (close 4002 `auth_expired` se JWT scaduto, altrimenti close 1006 `network`).
 3. Disable airplane mode dopo 5s.
-4. Phone deve **auto re-join** via `POST /api/lobby/join` con stesso player_token (back-compat hydrated rooms Sprint R).
+4. Phone deve **auto re-join** via `POST /api/lobby/join` con stesso player_token (back-compat hydrated rooms Sprint R codex bundle).
 5. State session deve essere **preserved** (round corrente, HP unit, intent pending).
-6. ✅ **Pass criteria**: reconnect <10s, state identico pre-disconnect, partita riprende senza host intervention.
-7. ❌ **Fail criteria**: phone resta disconnesso, state divergente post-reconnect, host vede Player2 zombie.
+6. ✅ **Pass**: reconnect <10s, state identico pre-disconnect, partita riprende senza host intervention.
+7. ❌ **Fail**: phone resta disconnesso, state divergente post-reconnect, host vede Player2 zombie.
 
-📝 **Annota**: tempo disconnect→reconnect + state diff (se any).
+📝 Annota: tempo disconnect→reconnect + state diff (se any).
 
 ---
 
-## Step 6 — Verdict template
+## Verdict template
 
 Compila tabella post-smoke. Se p95 >100ms → flag CONDITIONAL/ABORT, escalation drift sync Item C3.
 
@@ -327,78 +173,75 @@ Compila tabella post-smoke. Se p95 >100ms → flag CONDITIONAL/ABORT, escalation
 - Verdict overall: ship-ready / iter-needed / abort
 ```
 
-📋 **Submit verdict**: salva tabella compilata in nuovo doc `docs/playtest/2026-05-XX-phone-smoke-results.md` + cross-ref drift sync Item C3 close.
+📋 **Submit verdict**: salva tabella compilata in nuovo doc `docs/playtest/2026-05-XX-phone-smoke-results.md` + cross-ref drift sync 2026-05-04 Item C3 close.
 
 ---
 
 ## Troubleshooting common errors
 
-### #1 — DNS not propagating (Step 3d)
+### #1 — `cloudflared not in PATH` (Boot stack)
 
-**Symptom**: `https://evo-phone.<YOUR-DOMAIN>` → "DNS_PROBE_FINISHED_NXDOMAIN" o timeout.
+**Symptom**: `deploy-quick.sh` exit con `ERROR: cloudflared not in PATH`.
 
-**Fix**:
+**Fix**: `winget install --id Cloudflare.cloudflared` + apri shell nuovo.
 
-- Wait 60-120s (Cloudflare DNS edge propagation).
-- Verify `cloudflared tunnel route dns` returned no error.
-- Probe `nslookup evo-phone.<YOUR-DOMAIN> 1.1.1.1` (force Cloudflare resolver).
-- Check `~/.cloudflared/config.yml` hostname EXACT match con DNS record (typo case-sensitive).
+### #2 — `AUTH_SECRET not configured` (Boot stack)
 
-### #2 — Cloudflare auth fail (Step 3a)
+**Symptom**: backend log "AUTH_SECRET missing, using random per-process" warning.
 
-**Symptom**: `cloudflared tunnel login` → browser "Authorization failed" o token salvato non valido.
+**Fix**: re-run `deploy-quick.sh` — script auto-genera AUTH_SECRET in `Game/.env` se assente. Verify: `grep AUTH_SECRET Game/.env`.
 
-**Fix**:
+### #3 — Backend non parte (deploy-quick Step 4/5)
 
-- Logout/login Cloudflare dashboard, riprova.
-- Verify account ha Zero Trust enabled (Account Home → Zero Trust visible).
-- Delete `~/.cloudflared/cert.pem` + retry login fresh.
-- Se 2FA prompt loop → temporary disable 2FA, login, re-enable.
-
-### #3 — Cross-origin blocked (Step 4 Terminal 2)
-
-**Symptom**: phone composer carica index.html ma stuck su splash, browser console: "SharedArrayBuffer is not defined" o "isolation failed".
+**Symptom**: `ERROR: backend failed to start within 20s`.
 
 **Fix**:
 
-- `serve_local.sh` MUST set headers `Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: require-corp`. Verify via `curl -I http://localhost:8080/` includes both.
-- NO `python -m http.server` (no headers) — use script repo.
-- Cloudflare Tunnel passa headers transparently — se OK locale ma fail via Tunnel, verify config.yml `originRequest` vuoto (nessun header strip).
+- `tail Game-Godot-v2/.deploy-logs/backend.log` per stack trace.
+- Verify port 3334 free: `netstat -ano | grep :3334` → kill process residual se LISTENING.
+- Verify `npm ci` done (deps installed) in Game/.
 
-### #4 — WSS handshake fail (Step 5b/5c)
+### #4 — Quick Tunnel no URL output
 
-**Symptom**: Join lobby OK ma combat scenario non start, console "WebSocket connection to 'wss://evo-ws.<YOUR-DOMAIN>' failed".
-
-**Fix**:
-
-- Verify Game/ ws server boot (Terminal 1 deve loggare "wsSession listening on 0.0.0.0:3341").
-- Cloudflare Tunnel ingress `evo-ws.<YOUR-DOMAIN> → http://localhost:3341` (HTTP, NON HTTPS — Tunnel termina TLS).
-- Check `AUTH_SECRET` env var presente (Sprint R.1 JWT required) — restart Terminal 1 con secret fresh.
-- Phone player deve ricevere player_token JWT da `/api/lobby/join` PRIMA di connect WS — se token assente → REST flow rotto, debug REST endpoint prima.
-
-### #5 — Mobile viewport zoom
-
-**Symptom**: phone composer renders troppo zoom o troppo piccolo, tap target miss.
+**Symptom**: `deploy-quick.sh` Step 5/5 stuck, no `trycloudflare.com` URL.
 
 **Fix**:
 
-- Verify `dist/web/index.html` contiene `<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">`.
-- iOS Safari ignora `maximum-scale` → user può pinch-zoom; non bloccante per smoke ma annota UX impression.
-- Se renders 1/4 screen → Godot HTML5 canvas `stretch_mode` config in `project.godot` deve essere `viewport` (NON `disabled`).
+- Verify internet connection (`ping cloudflare.com`).
+- `tail Game-Godot-v2/.deploy-logs/tunnel.log`.
+- Cloudflare Quick Tunnel può fail occasionalmente — retry script.
+
+### #5 — Phone HTML5 404 (`/phone/` returns Not Found)
+
+**Symptom**: tunnel URL apre, `/phone/` returns 404.
+
+**Fix**:
+
+- Verify build mounted: `ls Game/apps/backend/public/phone/index.html`.
+- Re-run con `FORCE_REBUILD=1 ./tools/deploy/deploy-quick.sh`.
+- Check `build_web.sh` workaround applicato (USER + GODOT_BIN export, vedi pre-flight).
+
+### #6 — WS close 4002 `auth_expired`
+
+**Symptom**: phone disconnect mid-combat, codice 4002.
+
+**Fix**: nessuno richiesto — phone fa REST re-join automatico via `POST /api/lobby/join`. Hydrated rooms back-compat preserva session state (Sprint R codex bundle, Game/ PR #2036).
 
 ---
 
 ## Refs
 
-- [Game-Godot-v2 deploy-w6.md](https://github.com/MasterDD-L34D/Game-Godot-v2/blob/main/docs/godot-v2/deploy-w6.md) — spec build pipeline + Tunnel config upstream
-- [Game-Godot-v2 PR #166 TelemetryCollector](https://github.com/MasterDD-L34D/Game-Godot-v2/pull/166) — round-trip command-latency p95 + threshold verdict
+- [Game-Godot-v2 deploy-quickstart.md](https://github.com/MasterDD-L34D/Game-Godot-v2/blob/main/docs/godot-v2/deploy-quickstart.md) — canonical no-domain Quick Tunnel
+- [Game-Godot-v2 deploy-master-dd-checklist.md](https://github.com/MasterDD-L34D/Game-Godot-v2/blob/main/docs/godot-v2/deploy-master-dd-checklist.md) — canonical named tunnel + DNS
+- [Game-Godot-v2 deploy-w6.md](https://github.com/MasterDD-L34D/Game-Godot-v2/blob/main/docs/godot-v2/deploy-w6.md) — background spec
+- [Game-Godot-v2 PR #166 TelemetryCollector](https://github.com/MasterDD-L34D/Game-Godot-v2/pull/166) — round-trip command-latency p95
 - [Game/ ADR-2026-04-29 master execution plan v3](../planning/2026-04-29-master-execution-plan-v3.md) — M.7 spec parity
-- Cloudflare Tunnel docs: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/
-- Godot HTML5 export: https://docs.godotengine.org/en/stable/tutorials/export/exporting_for_web.html
+- [`tools/deploy/deploy-quick.sh`](https://github.com/MasterDD-L34D/Game-Godot-v2/blob/main/tools/deploy/deploy-quick.sh) — single-command shared-mode boot
 
 ## Out of scope
 
 - Godot HTML5 export setup (covered by Game-Godot-v2 PR #74 deploy-w6.md upstream)
-- Master-dd actual phone test execution (this doc IS the deliverable; user esegue manualmente post-merge)
+- Master-dd actual phone test execution (questo doc IS deliverable; user esegue manualmente post-merge)
 - Production cert hardening (Cloudflare Tunnel managed cert sufficient per smoke + demo public)
 - CI integration `.github/workflows/web-build.yml` (deferred follow-up Game-Godot-v2 side)
+- Upstream fix `build_web.sh` + `serve_local.sh` (separate PR Game-Godot-v2)


### PR DESCRIPTION
## Summary

Two parallel fixes shipped in single PR (file-disjoint, both small).

### A — Security: gitignore `Game/.env`

`Game/.env` populated by `Game-Godot-v2/tools/deploy/deploy-quick.sh` con `AUTH_SECRET` (HS256 JWT shared) ma `.gitignore` non lo escludeva → **risk**: `git add .` accidentale → leak secret to public repo.

**Fix** (`.gitignore` +13 righe):

- `.env` + `.env.local` + `.env.*.local`
- `apps/backend/public/phone/` (HTML5 build artifact mounted by deploy-quick)
- `.deploy-logs/` (Cloudflare Tunnel + backend logs)

Verify: `git check-ignore .env` → ec=0.

Canonical secret path resta `~/.config/api-keys/keys.env` per global secrets (CLAUDE.md API Keys section); Game/.env è OK come local mirror per deploy-quick auto-gen ma NON committable.

### B — Doc redirect superseded sections to upstream canonical

`docs/playtest/2026-05-05-phone-smoke-step-by-step.md` rewritten: **404 LOC → 244 LOC (-40%)**.

Discovery sessione 2026-05-05: Game-Godot-v2 main contiene già infrastruttura deploy completa shared-mode che supersede 3-port setup descritto in PR #2045 + #2047:

- [`docs/godot-v2/deploy-quickstart.md`](https://github.com/MasterDD-L34D/Game-Godot-v2/blob/main/docs/godot-v2/deploy-quickstart.md) — Quick Tunnel no-domain
- [`docs/godot-v2/deploy-master-dd-checklist.md`](https://github.com/MasterDD-L34D/Game-Godot-v2/blob/main/docs/godot-v2/deploy-master-dd-checklist.md) — named tunnel + DNS
- [`tools/deploy/deploy-quick.sh`](https://github.com/MasterDD-L34D/Game-Godot-v2/blob/main/tools/deploy/deploy-quick.sh) — single-command end-to-end (~30s subsequent runs)

Doc Game/ side ora contiene **SOLO content non duplicato upstream**:

- Banner top "superseded deploy guidance" → 3 link upstream
- Telemetry verdict gate (PASS<100/CONDITIONAL/ABORT>200ms)
- Pre-flight 5/5 (Godot 4.6 + preset.0 Web + main post #166 + cloudflared + npm deps)
- Workaround MSYS bugs `build_web.sh` (`$USER` unbound + `godot.cmd` `command -v` fail) + `serve_local.sh` (path resolve 403)
- Boot stack `deploy-quick.sh` summary + deep-link helper
- Smoke scenarios 5a-5d (iOS lobby + Android join + 5 round combat + airplane reconnect)
- Verdict template + bug + UX impressions
- Troubleshooting 6 errori common
- Refs upstream + out of scope

Cloudflare account signup + cloudflared install + tunnel auth + ingress config + 3 hostname setup tutti rimossi (duplicate vs upstream).

History pre-rewrite: PR #2045 + #2047 (origin doc + Codex P1+P2 fix).

## Test plan

- [x] Frontmatter governance (`python tools/check_docs_governance.py`) → 0 errors
- [x] `git check-ignore .env apps/backend/public/phone/` → both gitignored (ec=0)
- [x] Diff stat: -259 +115 (40% reduction net)
- [ ] Master-dd dry-run guida updated post-merge

## Out of scope

- Upstream PR `Game-Godot-v2 build_web.sh` + `serve_local.sh` Windows MSYS bugs — separate PR Godot v2 side
- Master-dd actual phone smoke execution — userland step post-merge
- Production cert hardening — Cloudflare Tunnel managed cert sufficient

🤖 Generated with [Claude Code](https://claude.com/claude-code)