### PR TITLE
docs(playtest): drop MSYS workaround — Game-Godot-v2 PR #168 fix-shipped (DRAFT, gated)

### DIFF
--- a/docs/playtest/2026-05-05-phone-smoke-step-by-step.md
+++ b/docs/playtest/2026-05-05-phone-smoke-step-by-step.md
@@ -45,17 +45,6 @@ Prima di iniziare, verifica che TUTTI i 5 punti siano OK:
 
 Se uno fallisce → ferma, fix prima di procedere.
 
-### Workaround bug script Game-Godot-v2 (Windows MSYS, non ancora upstream-fixed)
-
-`tools/web/build_web.sh` ha 2 issue su Windows MSYS shell:
-
-- Linea 57 `$USER` unbound (`set -u` enforce). **Fix**: `export USER="$USERNAME"`.
-- Linea 53-58 `command -v "$LOCALAPPDATA/Godot/godot.cmd"` fallisce su MSYS. **Fix**: `export GODOT_BIN="$LOCALAPPDATA/Godot/Godot_v4.6.2-stable_win64_console.exe"` (.exe direct).
-
-`tools/web/serve_local.sh` ha bug `path.join(ROOT, url).startsWith(path.resolve(ROOT))` relative-vs-absolute → 403 forbidden. **Workaround**: NON usare serve_local. Usa `deploy-quick.sh` shared-mode che mounta phone in `Game/apps/backend/public/phone/` via Express (route bypass bug).
-
-⏳ **TODO upstream PR**: fix `build_web.sh` USER/GODOT_BIN + `serve_local.sh` path resolve. Tracking: [docs/playtest/2026-05-05 follow-ups](#).
-
 ---
 
 ## Boot stack — `deploy-quick.sh` shared mode (~30s)
@@ -64,9 +53,10 @@ Single-command end-to-end. Sostituisce 3-terminal setup precedente:
 
 ```bash
 cd /c/Users/VGit/Desktop/Game-Godot-v2
-export USER=VGit GODOT_BIN="$LOCALAPPDATA/Godot/Godot_v4.6.2-stable_win64_console.exe"
 bash tools/deploy/deploy-quick.sh
 ```
+
+> ℹ️ Windows MSYS shell: bug `$USER` unbound + `command -v godot.cmd` fix-shipped via [Game-Godot-v2 PR #168](https://github.com/MasterDD-L34D/Game-Godot-v2/pull/168). Pre-#168 user dovevano `export USER=$USERNAME GODOT_BIN=…/.exe` manuale; post-merge zero env required.
 
 Cosa fa:
 
@@ -237,6 +227,7 @@ Compila tabella post-smoke. Se p95 >100ms → flag CONDITIONAL/ABORT, escalation
 - [Game-Godot-v2 PR #166 TelemetryCollector](https://github.com/MasterDD-L34D/Game-Godot-v2/pull/166) — round-trip command-latency p95
 - [Game/ ADR-2026-04-29 master execution plan v3](../planning/2026-04-29-master-execution-plan-v3.md) — M.7 spec parity
 - [`tools/deploy/deploy-quick.sh`](https://github.com/MasterDD-L34D/Game-Godot-v2/blob/main/tools/deploy/deploy-quick.sh) — single-command shared-mode boot
+- [Game-Godot-v2 PR #168](https://github.com/MasterDD-L34D/Game-Godot-v2/pull/168) — MSYS compat fix `build_web.sh` + `serve_local.sh` (post-merge: zero env required)
 
 ## Out of scope
 
@@ -244,4 +235,3 @@ Compila tabella post-smoke. Se p95 >100ms → flag CONDITIONAL/ABORT, escalation
 - Master-dd actual phone test execution (questo doc IS deliverable; user esegue manualmente post-merge)
 - Production cert hardening (Cloudflare Tunnel managed cert sufficient per smoke + demo public)
 - CI integration `.github/workflows/web-build.yml` (deferred follow-up Game-Godot-v2 side)
-- Upstream fix `build_web.sh` + `serve_local.sh` (separate PR Game-Godot-v2)


### PR DESCRIPTION
## Summary

Followup di PR #2048: rimuove sezione "Workaround bug script Game-Godot-v2 (Windows MSYS, non ancora upstream-fixed)" + drop `export USER GODOT_BIN` da Boot stack snippet, sostituendo con info link Game-Godot-v2 PR #168.

**Pre-#168** master-dd doveva manuale:

```bash
export USER=$USERNAME GODOT_BIN="$LOCALAPPDATA/Godot/.../*.exe"
```

**Post-#168**: zero env required.

- `build_web.sh` fallback chain risolve binary via `$LOCALAPPDATA` + `$USERNAME` bilingual fallback
- `serve_local.sh` guard rebuilt `path.resolve` both sides

Note inline conserva memoria del fix per chi clona repo old version. Refs ora include PR #168 esplicito.

Doc 244 → 237 LOC (-7).

## ⚠️ MERGE GATING

Questo PR mergeable **SOLO POST-MERGE** di entrambi:

- [ ] [Game-Godot-v2 PR #168](https://github.com/MasterDD-L34D/Game-Godot-v2/pull/168) — fix MSYS shipped upstream
- [ ] Game/ PR #2048 — parent (base branch `chore/gitignore-env-and-doc-redirect`)

Se #2048 mergea before #168: doc temporaneamente referenzia fix non shipped (non rotture, ma misleading).
Se #168 mergea before #2048: questo PR può fast-forward post #2048 merge.

## Test plan

- [x] Frontmatter governance (`python tools/check_docs_governance.py`) → 0 errors
- [x] `git diff` clean: -13 +3 (workaround section completamente removed)
- [ ] Master-dd verify `deploy-quick.sh` zero env post-#168 merge

## Refs

- Parent: PR #2048 (gitignore .env + doc redirect upstream)
- Upstream fix: Game-Godot-v2 PR #168 (build_web.sh + serve_local.sh)
- Origin: PR #2045 (origin doc) + PR #2047 (Codex P1+P2 fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)