### PR TITLE
chore(rules): cleanup stale services/rules references post Phase 3 removal

### DIFF
--- a/apps/backend/services/combat/resistanceEngine.js
+++ b/apps/backend/services/combat/resistanceEngine.js
@@ -2,7 +2,7 @@
 //
 // Context: parallel-agent audit 2026-04-19 scoprì che Node session engine
 // (apps/backend/routes/session.js) non implementava channel resistance logic,
-// mentre Python rules engine (services/rules/resolver.py) sì. Spike 2026-04-19
+// mentre Python rules engine (ex-services/rules/resolver.py, rimosso #2059) sì. Spike 2026-04-19
 // validò che resistance è la leva calibrazione hardcore-06 (84.6% → 20% win
 // rate con flat 50% resist).
 //
@@ -15,8 +15,8 @@
 // - mergeResistances è unico convertitore species→delta
 // - applyResistance accetta solo delta format
 //
-// Semantic parity con Python services/rules/resolver.py (apply_resistance +
-// merge_resistances) per future contract test.
+// Semantic parity con ex-Python services/rules/resolver.py (apply_resistance +
+// merge_resistances). Python rimosso PR #2059 (ADR-2026-04-19 Phase 3 closed).
 
 'use strict';
 

--- a/apps/backend/services/roundOrchestrator.js
+++ b/apps/backend/services/roundOrchestrator.js
@@ -2,8 +2,9 @@
 //
 // Porta il loop shared-planning -> commit -> ordered-resolution sopra
 // un `resolveAction` atomico iniettato dal caller. Mirror della
-// `services/rules/round_orchestrator.py` del rules engine Python
-// (source of truth del contratto).
+// ex-`services/rules/round_orchestrator.py` del rules engine Python
+// (rimosso PR #2059, ADR-2026-04-19 Phase 3). Contratto semantico canonical
+// ora vive qui in JS.
 //
 // Funzioni pubbliche:
 //   - beginRound(state) -> { nextState, expired, bleedingTotal }
@@ -33,8 +34,8 @@
 //   - Reaction matching: prima reaction non consumata per (targetId, event).
 //   - Nessun uso di Date.now/Math.random: il rng viene dal caller.
 //
-// Contratto semantico: vedi `services/rules/round_orchestrator.py` e
-// `docs/combat/round-loop.md` §3 (round lifecycle) + §4 (CombatState).
+// Contratto semantico: vedi `docs/combat/round-loop.md` §3 (round lifecycle)
+// + §4 (CombatState). Reference storica ex-Python rimossa PR #2059.
 
 'use strict';
 

--- a/tests/ai/resistanceEngine.test.js
+++ b/tests/ai/resistanceEngine.test.js
@@ -1,5 +1,5 @@
 // Tests M6-#1 resistance engine Node native.
-// Parity semantic con Python services/rules/resolver.py.
+// Parity semantic con ex-Python services/rules/resolver.py (rimosso #2059).
 
 'use strict';
 

--- a/tests/services/roundOrchestrator.test.js
+++ b/tests/services/roundOrchestrator.test.js
@@ -1,13 +1,14 @@
 // Round orchestrator JS foundation — unit test suite.
 //
 // Copre il modulo `apps/backend/services/roundOrchestrator.js`, port
-// in JS della reference Python `services/rules/round_orchestrator.py`.
+// in JS della reference ex-Python `services/rules/round_orchestrator.py`
+// (rimosso PR #2059, ADR-2026-04-19 Phase 3).
 //
 // Il modulo e' completamente isolato: zero wiring a session.js, zero
 // endpoint, zero import da apps/backend/routes/*. Tutti i test
 // costruiscono lo state minimale inline e usano un mock resolveAction
-// deterministico (nessuna dipendenza da catalog reale, da
-// services/traitEffects, o da resolver Python).
+// deterministico (nessuna dipendenza da catalog reale o da
+// services/traitEffects).
 //
 // Sezioni di test (25 test totali):
 //   1. Phase machine (5)


### PR DESCRIPTION
## Summary

- Update 6 doc comments in `resistanceEngine.js` + `roundOrchestrator.js` (src + relative tests) per marcare ex-Python `services/rules/*.py` come rimosso in [#2059](https://github.com/MasterDD-L34D/Game/pull/2059) (ADR-2026-04-19 Phase 3 closed).
- Reference storica preservata per ADR provenance / contract semantic.
- Cleanup orphan empty dir `services/rules/` + `__pycache__/` leftover post-#2059 (git non tracka empty dirs, dir era sopravvissuta locale).

## Files

- `apps/backend/services/combat/resistanceEngine.js` — 2 commenti
- `apps/backend/services/roundOrchestrator.js` — 2 commenti
- `tests/ai/resistanceEngine.test.js` — 1 commento
- `tests/services/roundOrchestrator.test.js` — 2 commenti

## Test plan

- [x] `npm run format:check` → clean
- [x] `node --test tests/ai/resistanceEngine.test.js tests/services/roundOrchestrator.test.js` → 63/63 pass
- [x] `node --test tests/ai/*.test.js` → 383/383 pass (sessione baseline)
- [x] `grep -rn "services/rules" apps/ services/ tools/ tests/` → solo 5 ref documentary "ex-services/rules" rimaste (intenzionali)
- [x] No behavior change (comments-only)

## Rollback plan

`git revert <commit>` — zero side-effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)