### PR TITLE
test(coop): wave-3 negative coverage — 7 new tests audit 2026-04-24 §coop

### DIFF
--- a/tests/api/coopOrchestrator.test.js
+++ b/tests/api/coopOrchestrator.test.js
@@ -157,6 +157,100 @@ test('F-2: forceAdvance from debrief delegates to advanceScenarioOrEnd', () => {
   assert.equal(result.action, 'next_scenario');
 });
 
+// ─────────────────────────────────────────────────────────────────
+// Wave 3 negative-tests (audit 2026-04-24 §coop-phase-validator)
+// ─────────────────────────────────────────────────────────────────
+
+test('Wave 3 #1 — confirmWorld() from lobby throws not_in_world_setup', () => {
+  // Phase-skip negative: confirmWorld() must reject when phase is lobby
+  // (no run started). Audit list §1.
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  assert.equal(co.phase, 'lobby');
+  assert.throws(
+    () => co.confirmWorld({ scenarioId: 'enc_tutorial_01' }),
+    /not_in_world_setup/,
+    'confirmWorld() in lobby phase must throw not_in_world_setup',
+  );
+  // Phase invariato post-throw
+  assert.equal(co.phase, 'lobby');
+});
+
+test('Wave 3 #1b — confirmWorld() from character_creation throws not_in_world_setup', () => {
+  // Defensive: confirmWorld() must also reject mid character_creation
+  // (caratteri non ancora completati). Strengthen audit §1.
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  co.startRun();
+  assert.equal(co.phase, 'character_creation');
+  assert.throws(() => co.confirmWorld({ scenarioId: 'enc_tutorial_01' }), /not_in_world_setup/);
+  assert.equal(co.phase, 'character_creation');
+});
+
+test('Wave 3 #5 — startRun() from combat phase throws cannot_start_from_phase', () => {
+  // Audit list §5: startRun() from combat phase untested.
+  // Expected: throws `cannot_start_from_phase:combat` per existing
+  // guard in coopOrchestrator.js:90.
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  co.startRun();
+  const all = ['p_a'];
+  co.submitCharacter('p_a', { name: 'Aria', form_id: 'istj' }, { allPlayerIds: all });
+  co.confirmWorld({ scenarioId: 'enc_tutorial_01' });
+  assert.equal(co.phase, 'combat');
+  assert.throws(
+    () => co.startRun({ scenarioStack: ['enc_other'] }),
+    /cannot_start_from_phase:combat/,
+    'startRun() in combat must throw',
+  );
+  assert.equal(co.phase, 'combat'); // phase invariato
+});
+
+test('Wave 3 #5b — startRun() from character_creation + world_setup + debrief throws', () => {
+  // Defensive sweep: startRun() reject from all non-(lobby|ended) phases.
+  // Documented contract via guard `if (this.phase !== 'lobby' && this.phase !== 'ended')`.
+  const all = ['p_a'];
+
+  // Phase character_creation
+  const coCC = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  coCC.startRun();
+  assert.throws(() => coCC.startRun(), /cannot_start_from_phase:character_creation/);
+
+  // Phase world_setup
+  const coWS = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  coWS.startRun();
+  coWS.submitCharacter('p_a', { name: 'Aria', form_id: 'istj' }, { allPlayerIds: all });
+  assert.equal(coWS.phase, 'world_setup');
+  assert.throws(() => coWS.startRun(), /cannot_start_from_phase:world_setup/);
+
+  // Phase debrief
+  const coDB = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  coDB.startRun();
+  coDB.submitCharacter('p_a', { name: 'Aria', form_id: 'istj' }, { allPlayerIds: all });
+  coDB.confirmWorld({ scenarioId: 'enc_tutorial_01' });
+  coDB.endCombat({ outcome: 'victory' });
+  assert.equal(coDB.phase, 'debrief');
+  assert.throws(() => coDB.startRun(), /cannot_start_from_phase:debrief/);
+});
+
+test('Wave 3 #5c — startRun() from ended phase succeeds (re-run after run completion)', () => {
+  // Companion contract: phase=ended is the SECOND legal entry to startRun()
+  // (lobby + ended). Verify re-run path lavora end-to-end.
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  co.startRun({ scenarioStack: ['enc_tutorial_01'] });
+  const all = ['p_a'];
+  co.submitCharacter('p_a', { name: 'Aria', form_id: 'istj' }, { allPlayerIds: all });
+  co.confirmWorld({ scenarioId: 'enc_tutorial_01' });
+  co.endCombat({ outcome: 'victory' });
+  co.submitDebriefChoice('p_a', { choice: 'skip' }, { allPlayerIds: all });
+  assert.equal(co.phase, 'ended');
+
+  // Re-run from ended must work
+  const run2 = co.startRun({ scenarioStack: ['enc_tutorial_02'] });
+  assert.equal(co.phase, 'character_creation');
+  assert.ok(run2.id.startsWith('run_'));
+  assert.deepEqual(run2.scenarioStack, ['enc_tutorial_02']);
+  // Characters cleared on new run (verified via internal state)
+  assert.equal(co.characters.size, 0);
+});
+
 test('F-2: forceAdvance rejected from combat/lobby/ended', () => {
   const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
   assert.throws(() => co.forceAdvance(), /force_advance_not_allowed_from:lobby/);

--- a/tests/api/wsRoomCode.test.js
+++ b/tests/api/wsRoomCode.test.js
@@ -1,0 +1,84 @@
+// Wave 3 #4 (audit 2026-04-24 §4) — Room-code alphabet regex purity test.
+//
+// Verifica `generateRoomCode()` produce SOLO consonanti BCDFGHJKLMNPQRSTVWXZ
+// (20 char canonical, ZERO vocali, ZERO Y per evitare parole sense). Test
+// statistical su N codes per copertura distribuzione.
+//
+// Ref: apps/backend/services/network/wsSession.js:40 ROOM_CODE_ALPHABET.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  generateRoomCode,
+  ROOM_CODE_ALPHABET,
+} = require('../../apps/backend/services/network/wsSession');
+
+const ROOM_CODE_REGEX = /^[BCDFGHJKLMNPQRSTVWXZ]{4}$/;
+const VOWELS = ['A', 'E', 'I', 'O', 'U', 'Y'];
+
+test('ROOM_CODE_ALPHABET has 20 consonants, zero vowels (incl. Y)', () => {
+  assert.equal(ROOM_CODE_ALPHABET.length, 20, 'alphabet must be exactly 20 chars');
+  for (const v of VOWELS) {
+    assert.ok(
+      !ROOM_CODE_ALPHABET.includes(v),
+      `alphabet must not contain vowel ${v}, found in: ${ROOM_CODE_ALPHABET}`,
+    );
+  }
+  // Verify uppercase only
+  assert.equal(ROOM_CODE_ALPHABET, ROOM_CODE_ALPHABET.toUpperCase());
+  // Verify each char unique (no duplicates)
+  const set = new Set(ROOM_CODE_ALPHABET.split(''));
+  assert.equal(set.size, 20, 'alphabet must have 20 unique chars');
+});
+
+test('generateRoomCode produces 4-char codes matching alphabet regex', () => {
+  // Single-shot smoke
+  const code = generateRoomCode();
+  assert.ok(
+    ROOM_CODE_REGEX.test(code),
+    `code "${code}" does not match alphabet regex ${ROOM_CODE_REGEX}`,
+  );
+});
+
+test('generateRoomCode 1000 samples — 100% match alphabet, no vowels', () => {
+  // Statistical purity: 1000 samples × 4 char = 4000 char total. With 20-char
+  // alphabet uniform random, P(zero vowels in 4000 char) approx 1 (alphabet has zero).
+  // Failure indicates alphabet drift / RNG broken / regex broken.
+  const N = 1000;
+  const failed = [];
+  const charFreq = {};
+  for (let i = 0; i < N; i += 1) {
+    const code = generateRoomCode();
+    if (!ROOM_CODE_REGEX.test(code)) {
+      failed.push(code);
+    }
+    for (const ch of code) {
+      charFreq[ch] = (charFreq[ch] || 0) + 1;
+    }
+  }
+  assert.deepEqual(failed, [], `${failed.length}/${N} codes failed regex: ${failed.slice(0, 5)}`);
+
+  // Verify NO vowel appears across all 4000 chars
+  for (const v of VOWELS) {
+    assert.equal(charFreq[v] || 0, 0, `vowel ${v} appeared ${charFreq[v]} times in ${N} codes`);
+  }
+
+  // Verify all 20 alphabet chars used at least once (RNG distribution sanity).
+  // With 4000 char + 20 alphabet uniform, expected ~200 per char. Floor 1
+  // catches RNG dead-spots.
+  const alphabetChars = ROOM_CODE_ALPHABET.split('');
+  const unused = alphabetChars.filter((c) => !charFreq[c]);
+  assert.deepEqual(unused, [], `alphabet chars unused in ${N} samples: ${unused.join(',')}`);
+});
+
+test('generateRoomCode produces uppercase only, no spaces, no punctuation', () => {
+  for (let i = 0; i < 100; i += 1) {
+    const code = generateRoomCode();
+    assert.equal(code, code.toUpperCase(), `code "${code}" contains lowercase`);
+    assert.ok(!/\s/.test(code), `code "${code}" contains whitespace`);
+    assert.ok(!/[^A-Z]/.test(code), `code "${code}" contains non-letter char`);
+    assert.equal(code.length, 4, `code "${code}" has wrong length ${code.length}`);
+  }
+});


### PR DESCRIPTION
## Summary

Wave 3 coop test coverage — chiude 3/5 audit list items dal coop-phase-validator audit 2026-04-24 (`docs/qa/2026-04-24-coop-phase-validation-pre-playtest.md`).

| Audit item | Status |
|---|---|
| #1 Phase-skip negative (`confirmWorld()` from lobby) | ✅ shipped (+1b defensive extra) |
| #2 Multi-player disconnect race | ⚠️ **DEFERRED** — requires 3+ player WS setup with concurrent disconnect timing, timebox risk |
| #3 Host-transfer + coop-state sync e2e | ⚠️ **DEFERRED** — partially covered da `tests/api/coopWsRebroadcast.test.js` F-1, full e2e per separate session |
| #4 Room-code alphabet regex purity | ✅ shipped (NEW file `wsRoomCode.test.js`, 4 tests) |
| #5 `startRun()` from combat phase untested | ✅ shipped (+5b sweep + 5c companion re-run path) |

## Tests added

### `tests/api/coopOrchestrator.test.js` (5 new)

- Wave 3 #1: `confirmWorld()` from lobby → throws `not_in_world_setup`
- Wave 3 #1b: `confirmWorld()` from `character_creation` → throws (defensive)
- Wave 3 #5: `startRun()` from `combat` → throws `cannot_start_from_phase:combat`
- Wave 3 #5b: `startRun()` from `character_creation` / `world_setup` / `debrief` → throws (sweep)
- Wave 3 #5c: `startRun()` from `ended` → succeeds (re-run companion contract)

### `tests/api/wsRoomCode.test.js` (NEW, 4 tests)

- `ROOM_CODE_ALPHABET` 20 consonants zero vowels Y excluded + uppercase + unique
- `generateRoomCode` single-shot regex match
- `generateRoomCode` 1000 samples — 100% match + alphabet uniformity check
- `generateRoomCode` uppercase / no-spaces / no-punctuation invariants

## Test impact

- Pre: 18 tests `coopOrchestrator.test.js` + 0 `wsRoomCode.test.js` = 18
- Post: 23 + 4 = **27** (+9 net)
- AI baseline 383/383 → **383/383** zero regression
- `npm run format:check` → clean

## Latent bug surfaced

**ZERO**. All 9 tests pass against existing implementation. Production code unchanged.

## Rollback plan

`git revert <commit>` — additive test only, zero side-effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)