### PR TITLE
fix(scripts): docs-smoke spawn EINVAL on Windows Node v22+

### DIFF
--- a/scripts/docs-smoke.js
+++ b/scripts/docs-smoke.js
@@ -110,9 +110,13 @@ function streamFile(filePath, res) {
 }
 
 function startApi() {
+  // Node v22+ tightened Windows .cmd/.bat spawn security: require shell:true
+  // or fully-qualified path. Without it, spawn EINVAL fires on emit listen
+  // path. Ref Node v22.12+ release notes — CVE-2024-27980 mitigation.
   const child = spawn(API_COMMAND, API_ARGS, {
     stdio: 'inherit',
     env: process.env,
+    shell: process.platform === 'win32',
   });
 
   child.on('exit', (code, signal) => {


### PR DESCRIPTION
## Summary

Wave 4 timeboxed — fix `docs:smoke` script che falliva con `spawn EINVAL` su Windows + Node v22.12+ (CVE-2024-27980 mitigation tightening su `.cmd`/`.bat` spawn).

Detected durante Wave 1 baseline verification 2026-05-05 (verifiche complete sessione cutover Phase 3): step B.8b emetteva warning EINVAL. Pre-esistente low-priority, fixato Wave 4 timebox.

## Root cause

Node v22.12+ richiede `shell: true` o full-qualified path quando spawn `npm.cmd`/`*.cmd`/`*.bat` su Windows. Senza, `spawn` emette EINVAL on emit-listening path subito dopo `server.listen()` callback.

Stack trace pre-fix:
```
errno: -4071, code: 'EINVAL', syscall: 'spawn'
  at Object.onceWrapper (node:events:622:28)
  at Server.emit (node:events:520:35)
  at emitListeningNT (node:net:1983:10)
```

## Fix

`scripts/docs-smoke.js` — spawn options gain `shell: process.platform === 'win32'`. POSIX (Linux/Mac) path **unchanged** (default `shell: false` preserved → no behavior change).

## Test plan

- [x] `timeout 8 npm run docs:smoke` su Windows → backend boots clean (plugin-loader + trait-effects + idea-engine + lobby-ws all online). Exit 143 = SIGTERM from timeout (expected, smoke kills server).
- [x] `npm run format:check` → clean

## Out of scope

#7 TKT-07 Tutorial sweep #2 N=10 harness run **DEFERRED** — setup heavy (backend live + telemetry capture + N=10 scenario × multi-encounter), timebox 1h cap saturated. Defer separate session quando harness retry+resume infra confirmed.

## Rollback plan

`git revert <commit>` — fix surgical 4 lines, zero side-effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)