### PR TITLE
fix(coop-ws): W4 form_pulse_submit server-side drain (audit close)

### DIFF
--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -61,6 +61,12 @@ class CoopOrchestrator {
     // for the UI-only `world_seed_reveal` transient phase. When all
     // expected players ack, auto-advance world_seed_reveal → world_setup.
     this.revealAcks = new Set();
+    // 2026-05-06 phone smoke W4 — per-player form_pulse axes submitted
+    // during the post-character_creation evolution-tuning step. Drained
+    // server-side via submitFormPulse; phase-agnostic storage so Godot
+    // UI-only `form_pulse` transient phase can populate without strict
+    // coupling to PHASES enum (mirror revealAcks pattern).
+    this.formPulses = new Map(); // player_id → { axes: {k:Number}, ts }
     this.log = [];
     this._listeners = new Set();
     // W5-bb (cross-repo Godot v2 mirror) — world enricher service injection.
@@ -123,6 +129,7 @@ class CoopOrchestrator {
     this.worldVotes.clear();
     this.debriefChoices.clear();
     this.revealAcks.clear();
+    this.formPulses.clear();
     this.onboardingChoice = null;
     this._setPhase('character_creation');
     this._emit('run_started', { run_id: this.run.id });
@@ -156,6 +163,7 @@ class CoopOrchestrator {
     this.worldVotes.clear();
     this.debriefChoices.clear();
     this.revealAcks.clear();
+    this.formPulses.clear();
     this.onboardingChoice = null;
     this._setPhase('onboarding');
     this._emit('run_started', { run_id: this.run.id, with_onboarding: true });
@@ -376,6 +384,64 @@ class CoopOrchestrator {
   }
 
   /**
+   * 2026-05-06 phone smoke W4 — Submit form_pulse axes for player. UI-only
+   * transient phase between character_creation and world_setup (Godot
+   * Sprint W7 form_pulse view). Per-player axes stored independently of
+   * `phase` enum so caller can drain submissions during any post-bootstrap
+   * phase. Mirrors voteWorld pattern (no auto-advance; caller decides
+   * when all axes collected to publishPhaseChange next).
+   *
+   * Pre-fix: phone player sent `intent {action: form_pulse_submit}` →
+   * pushIntent relay to host → Godot host has no GDScript drain → silent
+   * drop. Now drained via this method, broadcast `form_pulse_list`.
+   *
+   * @param playerId — submitting player
+   * @param axes — { [axisKey]: Number } map (alpha/beta/gamma/delta…). Only
+   *               numeric values retained; non-numeric or NaN dropped.
+   * @param allPlayerIds — set of player ids expected to submit (for ready_set tally)
+   * @returns { ready_count, total, all_ready, submitted: [player_id…] }
+   */
+  submitFormPulse(playerId, { axes = {} } = {}, { allPlayerIds = [] } = {}) {
+    if (!playerId) throw new Error('player_id_required');
+    if (!this.run) throw new Error('run_not_started');
+    const cleanAxes = {};
+    if (axes && typeof axes === 'object' && !Array.isArray(axes)) {
+      for (const [k, v] of Object.entries(axes)) {
+        const num = Number(v);
+        if (Number.isFinite(num)) cleanAxes[k] = num;
+      }
+    }
+    this.formPulses.set(playerId, { axes: cleanAxes, ts: this.now() });
+    this._emit('form_pulse_submit', { player_id: playerId, axes: cleanAxes });
+    const expected = new Set(allPlayerIds.filter(Boolean));
+    const total = expected.size || this.formPulses.size;
+    const readyCount = this.formPulses.size;
+    const allReady =
+      expected.size > 0 && Array.from(expected).every((pid) => this.formPulses.has(pid));
+    return {
+      ready_count: readyCount,
+      total,
+      all_ready: allReady,
+      submitted: Array.from(this.formPulses.keys()),
+    };
+  }
+
+  /**
+   * 2026-05-06 phone smoke W4 — Form pulse list for broadcast (per-player
+   * ready + axes snapshot).
+   */
+  formPulseList(allPlayerIds = []) {
+    return allPlayerIds.map((pid) => {
+      const entry = this.formPulses.get(pid);
+      return {
+        player_id: pid,
+        ready: Boolean(entry),
+        axes: entry?.axes || null,
+      };
+    });
+  }
+
+  /**
    * M18 — Tally current world votes. Returns counts + breakdown.
    */
   worldTally(allPlayerIds = []) {
@@ -474,6 +540,8 @@ class CoopOrchestrator {
     });
     this.debriefChoices.clear();
     this.worldVotes.clear();
+    this.formPulses.clear();
+    this.revealAcks.clear();
     this._setPhase('world_setup');
     return { action: 'next_scenario', index: this.run.currentIndex };
   }

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -1510,7 +1510,15 @@ function createWsServer({
                 );
                 return;
               }
-              const allPids = Array.from(room.players.values()).map((p) => p.id);
+              // Exclude host from expected players: Godot phone host doesn't
+              // submit form_pulse_submit (host = arbiter, players = phones).
+              // Without filter, status.total inflates by 1 + all_ready stuck
+              // false. Mirrors routes/coop.js allPlayerIds() helper +
+              // sendCoopSnapshotToPlayer/rebroadcastCoopState exclusion.
+              // Codex review P2 #2073.
+              const allPids = Array.from(room.players.values())
+                .filter((p) => p.id !== room.hostId && p.role !== 'host')
+                .map((p) => p.id);
               const status = orch.submitFormPulse(
                 playerId,
                 { axes: msg.payload?.form_axes || msg.payload?.axes || {} },

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -1494,9 +1494,54 @@ function createWsServer({
             }
             return;
           }
-          // Other lifecycle intents (form_pulse_submit, next_macro):
+          // 2026-05-06 phone smoke W4 fix — drain form_pulse_submit
+          // server-side via coopOrchestrator.submitFormPulse. Pre-fix the
+          // intent was relayed to host Godot via pushIntent → Godot host
+          // has no GDScript drain → silent drop. Now broadcasts
+          // `form_pulse_list` (per-player ready+axes snapshot) so all
+          // clients can render progress + send `form_pulse_accepted` to
+          // sender for ack.
+          if (action === 'form_pulse_submit' && coopStore) {
+            try {
+              const orch = coopStore.get(room.code);
+              if (!orch) {
+                socket.send(
+                  JSON.stringify({ type: 'error', payload: { code: 'run_not_started' } }),
+                );
+                return;
+              }
+              const allPids = Array.from(room.players.values()).map((p) => p.id);
+              const status = orch.submitFormPulse(
+                playerId,
+                { axes: msg.payload?.form_axes || msg.payload?.axes || {} },
+                { allPlayerIds: allPids },
+              );
+              room.broadcast({
+                type: 'form_pulse_list',
+                payload: {
+                  status,
+                  list: orch.formPulseList(allPids),
+                },
+              });
+              socket.send(
+                JSON.stringify({
+                  type: 'form_pulse_accepted',
+                  payload: { status },
+                }),
+              );
+            } catch (err) {
+              socket.send(
+                JSON.stringify({
+                  type: 'error',
+                  payload: { code: err.message || 'form_pulse_failed' },
+                }),
+              );
+            }
+            return;
+          }
+          // Other lifecycle intents (next_macro):
           // TODO drain server-side via coopStore. Tracked as
-          // TKT-P5-WS-FORM-PULSE-DRAIN + TKT-P5-WS-NEXT-MACRO-DESIGN.
+          // TKT-P5-WS-NEXT-MACRO-DESIGN.
           // For now relay to host (legacy web v1 path) — Godot host drops.
           room.pushIntent({ from: playerId, payload: msg.payload ?? null });
           break;

--- a/docs/planning/2026-05-06-sessione-closure-handoff.md
+++ b/docs/planning/2026-05-06-sessione-closure-handoff.md
@@ -31,22 +31,23 @@ ACCEPTED — 2026-05-06
 
 ## PR shipped main (15 cumulative)
 
-| #   | PR                                                       | SHA        | Topic                                           | Wave        |
-| --- | -------------------------------------------------------- | ---------- | ----------------------------------------------- | ----------- |
-| 1   | [#2056](https://github.com/MasterDD-L34D/Game/pull/2056) | `7bf0523a` | docs handoff repo audit next session            | pre-cutover |
-| 2   | [#2057](https://github.com/MasterDD-L34D/Game/pull/2057) | `626ecb51` | Sprint 8.1 ability r3/r4 expansion              | pre-cutover |
-| 3   | [#2058](https://github.com/MasterDD-L34D/Game/pull/2058) | `87ea9ccf` | pre-cutover cleanup audit Phase 3               | cutover     |
-| 4   | [#2059](https://github.com/MasterDD-L34D/Game/pull/2059) | `d0c86c60` | services/rules/ Phase 3 removal                 | cutover     |
-| 5   | [#2060](https://github.com/MasterDD-L34D/Game/pull/2060) | `5dc65315` | mutation aspect_token 36/36                     | feature     |
-| 6   | [#2061](https://github.com/MasterDD-L34D/Game/pull/2061) | `d16cd941` | ennea voice palette Type 5+7                    | feature     |
-| 7   | [#2062](https://github.com/MasterDD-L34D/Game/pull/2062) | `5595c968` | ennea voice 9/9 archetype coverage              | feature     |
-| 8   | [#2063](https://github.com/MasterDD-L34D/Game/pull/2063) | `d109f143` | cleanup stale services/rules comments           | verify      |
-| 9   | [#2064](https://github.com/MasterDD-L34D/Game/pull/2064) | `309741f2` | refresh test artifacts post-verification        | verify      |
-| 10  | [#2065](https://github.com/MasterDD-L34D/Game/pull/2065) | `42727de3` | ADR drop HermeticOrmus + path drift fix         | Wave 1      |
-| 11  | [#2066](https://github.com/MasterDD-L34D/Game/pull/2066) | `a59985ed` | governance drift batch 460 → 218 (-52.6%)       | Wave 2      |
-| 12  | [#2067](https://github.com/MasterDD-L34D/Game/pull/2067) | `e4447575` | coop test coverage +9 negative tests            | Wave 3      |
-| 13  | [#2068](https://github.com/MasterDD-L34D/Game/pull/2068) | `50cbb04d` | docs:smoke fix Windows Node v22+                | Wave 4      |
-| 14  | this PR pending                                          | TBD        | closure bundle: P1.5 + P1.7 gap audit + handoff | bundle      |
+| #   | PR                                                       | SHA        | Topic                                                  | Wave        |
+| --- | -------------------------------------------------------- | ---------- | ------------------------------------------------------ | ----------- |
+| 1   | [#2056](https://github.com/MasterDD-L34D/Game/pull/2056) | `7bf0523a` | docs handoff repo audit next session                   | pre-cutover |
+| 2   | [#2057](https://github.com/MasterDD-L34D/Game/pull/2057) | `626ecb51` | Sprint 8.1 ability r3/r4 expansion                     | pre-cutover |
+| 3   | [#2058](https://github.com/MasterDD-L34D/Game/pull/2058) | `87ea9ccf` | pre-cutover cleanup audit Phase 3                      | cutover     |
+| 4   | [#2059](https://github.com/MasterDD-L34D/Game/pull/2059) | `d0c86c60` | services/rules/ Phase 3 removal                        | cutover     |
+| 5   | [#2060](https://github.com/MasterDD-L34D/Game/pull/2060) | `5dc65315` | mutation aspect_token 36/36                            | feature     |
+| 6   | [#2061](https://github.com/MasterDD-L34D/Game/pull/2061) | `d16cd941` | ennea voice palette Type 5+7                           | feature     |
+| 7   | [#2062](https://github.com/MasterDD-L34D/Game/pull/2062) | `5595c968` | ennea voice 9/9 archetype coverage                     | feature     |
+| 8   | [#2063](https://github.com/MasterDD-L34D/Game/pull/2063) | `d109f143` | cleanup stale services/rules comments                  | verify      |
+| 9   | [#2064](https://github.com/MasterDD-L34D/Game/pull/2064) | `309741f2` | refresh test artifacts post-verification               | verify      |
+| 10  | [#2065](https://github.com/MasterDD-L34D/Game/pull/2065) | `42727de3` | ADR drop HermeticOrmus + path drift fix                | Wave 1      |
+| 11  | [#2066](https://github.com/MasterDD-L34D/Game/pull/2066) | `a59985ed` | governance drift batch 460 → 218 (-52.6%)              | Wave 2      |
+| 12  | [#2067](https://github.com/MasterDD-L34D/Game/pull/2067) | `e4447575` | coop test coverage +9 negative tests                   | Wave 3      |
+| 13  | [#2068](https://github.com/MasterDD-L34D/Game/pull/2068) | `50cbb04d` | docs:smoke fix Windows Node v22+                       | Wave 4      |
+| 14  | this PR pending                                          | TBD        | closure bundle: P1.5 + P1.7 gap audit + handoff        | bundle      |
+| 15  | next PR                                                  | TBD        | W4 `form_pulse_submit` server-side drain (audit close) | post-bundle |
 
 ## Closures sessione (cumulative)
 

--- a/docs/reports/2026-05-06-coop-phase-ws-audit.md
+++ b/docs/reports/2026-05-06-coop-phase-ws-audit.md
@@ -87,13 +87,15 @@ In phase=`character_creation` ENTRAMBI host e player non possono submit. Ws v1 w
 
 ## Gap residui (deferred ticket)
 
-| ID | Action | Status | Ticket | Effort |
-|---|---|---|---|---|
-| W4 | `form_pulse_submit` | NOT drained, no orch method | TKT-P5-WS-FORM-PULSE-DRAIN | ~2h |
-| W7 | `next_macro` | NOT drained, design decision needed | TKT-P5-WS-NEXT-MACRO-DESIGN | ~2h |
-| W8b | `reveal_acknowledge` action drain | NOT drained, no orch method | TKT-P5-WS-REVEAL-ACK-DRAIN | ~1h |
+| ID  | Action               | Status                              | Ticket                       | Effort |
+| --- | -------------------- | ----------------------------------- | ---------------------------- | ------ |
+| W7  | `next_macro`         | NOT drained, design decision needed | TKT-P5-WS-NEXT-MACRO-DESIGN  | ~2h    |
 
-W7 design question: drain server-side via `orch.advanceScenarioOrEnd()` OR keep host-arbiter pattern? Current relay = silent drop su Godot host.
+**W7 design question**: drain server-side via `orch.advanceScenarioOrEnd()` OR keep host-arbiter pattern? Current relay = silent drop su Godot host.
+
+### Closed addendum 2026-05-06 (autonomous)
+
+- **W4 `form_pulse_submit`** ✅ shipped — `coopOrchestrator.submitFormPulse(playerId, {axes}, {allPlayerIds})` + `formPulseList()` + drain branch in `wsSession.js` mirror voteWorld pattern. Phase-agnostic per-player axes Map; non-numeric/NaN axes filtered. +4 unit test (W4 series). Harness scenario 4a GAP→PASS verified live.
 
 ## Combat E2E + reconnect — DEFERRED
 
@@ -103,16 +105,18 @@ Scenario combat 5 round + airplane reconnect non testati programmatic (richiedon
 
 - Harness Node script: `tools/testing/phone-flow-harness.js` (committable, ws node_modules from main repo)
 - Run command: `node tools/testing/phone-flow-harness.js` (backend up :3334 prerequisito)
-- Output: 15 scenari (lobby join + phase transition + char create + lifecycle gap matrix + B6 host gate + W8 phase whitelist + stateVersion)
-- Final: 12 PASS / 0 FAIL / 3 GAP-DOCUMENTED
+- Output: 18 scenari (lobby join + phase transition + char create + lifecycle gap matrix + B6 host gate + W8 phase whitelist + stateVersion + onboarding host-only)
+- Final post-W4 close: **17 PASS / 0 FAIL / 1 GAP-DOCUMENTED** (W7 next_macro residuo, design pending)
 
 Cross-repo tests passing:
 - `node --test tests/api/wsRoomCode.test.js tests/api/coopOrchestrator.test.js` → 23/23 verde
 
 ## Files modified
 
-- `apps/backend/services/network/wsSession.js` — case 'intent' split + 3 lifecycle drain branches (character_create, world_vote, lineage_choice) + KNOWN_PHASES whitelist + case 'phase' auto-bootstrap coop run
-- `tools/testing/phone-flow-harness.js` — extended scenario 4b + 4c + 7a + 7b PASS expectations post-fix
+- `apps/backend/services/network/wsSession.js` — case 'intent' split + 4 lifecycle drain branches (character_create, world_vote, lineage_choice, **form_pulse_submit** W4) + reveal_acknowledge (W8b) + KNOWN_PHASES whitelist + case 'phase' auto-bootstrap coop run
+- `apps/backend/services/coop/coopOrchestrator.js` — `submitFormPulse` + `formPulseList` + `formPulses` Map (W4 close)
+- `tools/testing/phone-flow-harness.js` — extended scenario 4a (W4 PASS) + 4b + 4c + 7a + 7b PASS expectations post-fix
+- `tests/api/coopOrchestrator.test.js` — +4 W4 unit tests (axes filter + ready_set + run_not_started + clear-on-advance)
 
 ## Reversibility
 

--- a/tests/api/coopOrchestrator.test.js
+++ b/tests/api/coopOrchestrator.test.js
@@ -314,6 +314,67 @@ test('F-2: forceAdvance rejected from combat/lobby/ended', () => {
   assert.throws(() => co.forceAdvance(), /force_advance_not_allowed_from:combat/);
 });
 
+// ─────────────────────────────────────────────────────────────────
+// W4 phone smoke fix — submitFormPulse drain (2026-05-06)
+// ─────────────────────────────────────────────────────────────────
+
+test('W4 — submitFormPulse stores per-player axes + returns ready_set', () => {
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  co.startRun();
+  const all = ['p_a', 'p_b'];
+  const r1 = co.submitFormPulse('p_a', { axes: { alpha: 0.5, beta: 0.3 } }, { allPlayerIds: all });
+  assert.equal(r1.ready_count, 1);
+  assert.equal(r1.total, 2);
+  assert.equal(r1.all_ready, false);
+  assert.deepEqual(r1.submitted, ['p_a']);
+  const r2 = co.submitFormPulse('p_b', { axes: { alpha: 0.2 } }, { allPlayerIds: all });
+  assert.equal(r2.ready_count, 2);
+  assert.equal(r2.all_ready, true);
+});
+
+test('W4 — submitFormPulse drops non-numeric axes + accepts re-submit overwrite', () => {
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  co.startRun();
+  const all = ['p_a'];
+  co.submitFormPulse(
+    'p_a',
+    { axes: { alpha: 0.7, beta: 'bad', gamma: NaN, delta: '0.4' } },
+    { allPlayerIds: all },
+  );
+  const list = co.formPulseList(all);
+  assert.equal(list[0].player_id, 'p_a');
+  assert.equal(list[0].ready, true);
+  // 'bad' string + NaN dropped; '0.4' string coerces via Number().
+  assert.deepEqual(list[0].axes, { alpha: 0.7, delta: 0.4 });
+  // Re-submit overwrites.
+  co.submitFormPulse('p_a', { axes: { alpha: 0.1 } }, { allPlayerIds: all });
+  const list2 = co.formPulseList(all);
+  assert.deepEqual(list2[0].axes, { alpha: 0.1 });
+});
+
+test('W4 — submitFormPulse throws when run not started or playerId missing', () => {
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  // No run yet.
+  assert.throws(() => co.submitFormPulse('p_a', { axes: { alpha: 0.5 } }), /run_not_started/);
+  co.startRun();
+  assert.throws(() => co.submitFormPulse(null, { axes: { alpha: 0.5 } }), /player_id_required/);
+});
+
+test('W4 — formPulses cleared on advanceScenarioOrEnd', () => {
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  co.startRun({ scenarioStack: ['enc_a', 'enc_b'] });
+  const all = ['p_a'];
+  co.submitCharacter('p_a', { name: 'Aria', form_id: 'istj' }, { allPlayerIds: all });
+  co.submitFormPulse('p_a', { axes: { alpha: 0.9 } }, { allPlayerIds: all });
+  assert.equal(co.formPulses.size, 1);
+  co.confirmWorld();
+  co.endCombat({ outcome: 'victory' });
+  co.submitDebriefChoice('p_a', { choice: 'skip' }, { allPlayerIds: all });
+  // Next scenario started → formPulses reset.
+  assert.equal(co.phase, 'world_setup');
+  assert.equal(co.formPulses.size, 0);
+});
+
 test('log captures phase_change + run_started events', () => {
   const co = new CoopOrchestrator({ roomCode: 'ABCD' });
   co.startRun();

--- a/tools/testing/phone-flow-harness.js
+++ b/tools/testing/phone-flow-harness.js
@@ -527,35 +527,39 @@ async function main() {
     '\n--- SCENARIO 4: lifecycle intents gap matrix (form_pulse_submit, world_vote, etc.) ---',
   );
 
-  // 4a: form_pulse_submit — NOT drained server-side (relay to host = pushIntent)
-  console.log('\n  4a: form_pulse_submit (expect: relayed to host, NOT drained)');
+  // 4a: form_pulse_submit — W4 fix verify (drains server-side via submitFormPulse)
+  console.log('\n  4a: form_pulse_submit (expect: W4 fix → form_pulse_list broadcast)');
   try {
-    // Player sends form_pulse_submit
     player.send({
       type: 'intent',
       payload: { action: 'form_pulse_submit', form_axes: { alpha: 0.5, beta: 0.3 } },
     });
-    // Host should receive intent relay (type='intent' from pushIntent path)
-    const intentRelay = await host.waitFor(
-      (m) => m.type === 'intent' && m.payload?.payload?.action === 'form_pulse_submit',
-      2000,
-    );
+    const listMsg = await player.waitFor((m) => m.type === 'form_pulse_list', 2000);
+    const status = listMsg.payload?.status || {};
+    const list = listMsg.payload?.list || [];
     console.log(
-      `    Host received relay: type=${intentRelay.type} action=${intentRelay.payload?.payload?.action}`,
+      `    form_pulse_list received: ready_count=${status.ready_count} total=${status.total} all_ready=${status.all_ready}`,
     );
-    gapDoc(
-      '4a: form_pulse_submit',
-      'form_pulse_submit drains server-side via coopOrchestrator (MISSING)',
-      'relayed to host via pushIntent (legacy web v1 path — Godot host has no drain JS)',
-      `GAP-W4: form_pulse_submit NOT server-side drained. wsSession.js:1273 comment "TODO drain server-side". Godot host receives WS intent but has no GDScript handler to process it → silent drop. Fix: add case in intent handler similar to character_create.`,
-    );
+    if (status.ready_count >= 1 && Array.isArray(list)) {
+      pass(
+        '4a: form_pulse_submit',
+        'form_pulse_submit drains via submitFormPulse → form_pulse_list broadcast',
+        `ready_count=${status.ready_count} total=${status.total} list_len=${list.length}`,
+      );
+    } else {
+      gapDoc(
+        '4a: form_pulse_submit',
+        'form_pulse_list payload schema',
+        `received but status.ready_count=${status.ready_count}`,
+        `GAP-W4-residue: drain branch reached but ready_count not incremented. Check submitFormPulse method or formPulses Map state.`,
+      );
+    }
   } catch (err) {
-    // pushIntent relay goes to host socket — if host is the sender this self-echos
     gapDoc(
       '4a: form_pulse_submit',
-      'form_pulse_submit relay to host',
+      'form_pulse_submit drain (W4 fix)',
       `timeout/error: ${err.message}`,
-      `GAP-W4: form_pulse_submit fallthrough to pushIntent. Host may receive but we couldn't detect within 2s. Manually verify host.messages for intent type.`,
+      `GAP-W4-regression: form_pulse_list not broadcast within 2s. Check wsSession.js intent action='form_pulse_submit' branch + coopOrchestrator.submitFormPulse.`,
     );
   }
 

--- a/tools/testing/phone-flow-harness.js
+++ b/tools/testing/phone-flow-harness.js
@@ -540,11 +540,11 @@ async function main() {
     console.log(
       `    form_pulse_list received: ready_count=${status.ready_count} total=${status.total} all_ready=${status.all_ready}`,
     );
-    if (status.ready_count >= 1 && Array.isArray(list)) {
+    if (status.ready_count >= 1 && status.all_ready === true && Array.isArray(list)) {
       pass(
         '4a: form_pulse_submit',
-        'form_pulse_submit drains via submitFormPulse → form_pulse_list broadcast',
-        `ready_count=${status.ready_count} total=${status.total} list_len=${list.length}`,
+        'form_pulse_submit drains via submitFormPulse → form_pulse_list broadcast (host excluded)',
+        `ready_count=${status.ready_count} total=${status.total} all_ready=${status.all_ready} list_len=${list.length}`,
       );
     } else {
       gapDoc(


### PR DESCRIPTION
## Summary

W4 gap closure from [docs/reports/2026-05-06-coop-phase-ws-audit.md](docs/reports/2026-05-06-coop-phase-ws-audit.md). Pre-fix `form_pulse_submit` intent fell through to `pushIntent` relay → Godot host has no GDScript drain → silent drop. Now drained server-side via `coopOrchestrator.submitFormPulse` mirror `voteWorld` pattern.

- `coopOrchestrator.submitFormPulse(playerId, {axes}, {allPlayerIds})` + `formPulseList()` + `formPulses` Map (phase-agnostic per-player axes storage). Non-numeric/NaN values filtered, re-submit overwrites, cleared on `advanceScenarioOrEnd` and run start.
- `wsSession.js` case 'intent' new drain branch broadcasts `form_pulse_list` (per-player ready+axes snapshot) + sends `form_pulse_accepted` to sender.
- `phone-flow-harness.js` scenario 4a updated GAP-DOCUMENTED → PASS expectation.
- Stale TODO comment trimmed (only `next_macro` residuo remains, design pending W7).

## Test plan

- [x] `node --test tests/api/coopOrchestrator.test.js` → **27/27** (+4 W4 unit tests)
- [x] `node --test tests/api/wsRoomCode.test.js` → 4/4
- [x] `node --test tests/ai/*.test.js` → **383/383** baseline preserved
- [x] `node tools/testing/phone-flow-harness.js` (live backend) → **17 PASS / 0 FAIL / 1 GAP-DOCUMENTED** (only W7 next_macro residuo)
- [x] `npm run format:check` → clean

## Files

- `apps/backend/services/coop/coopOrchestrator.js` — `submitFormPulse` + `formPulseList` + `formPulses` Map
- `apps/backend/services/network/wsSession.js` — drain branch + comment cleanup
- `tests/api/coopOrchestrator.test.js` — +4 W4 tests (axes filter + ready_set + run_not_started + clear-on-advance)
- `tools/testing/phone-flow-harness.js` — scenario 4a flip GAP→PASS
- `docs/reports/2026-05-06-coop-phase-ws-audit.md` — gap matrix W4 row removed + closed addendum + final harness counts updated
- `docs/planning/2026-05-06-sessione-closure-handoff.md` — PR table row 15 added

## Reversibility

Additive server-side. Reversible via single `git revert`. Zero breaking change on web v1 path (legacy lifecycle relay-to-host fallback preserved for `next_macro`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)