### PR TITLE
fix(coop-ws): W7 next_macro server-side drain + design (audit close)

### DIFF
--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -464,6 +464,61 @@ class CoopOrchestrator {
   }
 
   /**
+   * 2026-05-06 phone smoke W7 — submit post-debrief macro navigation choice.
+   * Host-only (mirror submitOnboardingChoice pattern). Choice ∈
+   * {advance, branch, retreat}. Phase must be `debrief` or `ended` (post
+   * debrief auto-advance). Records in `run.lastMacro` for telemetry +
+   * downstream UI surface.
+   *
+   * Semantics:
+   *  - `advance` — proceed to next scenario in stack. Delegates to
+   *               advanceScenarioOrEnd() if phase=='debrief'. No-op if
+   *               already advanced (phase != debrief).
+   *  - `branch`  — same as advance for MVP; future Sprint Q ETL may pick
+   *               an alternate scenario_id from a branch table.
+   *  - `retreat` — early end. Forces phase='ended' + run.outcome ||=
+   *               'retreated'. Players exit run without next scenario.
+   *
+   * Pre-fix: phone host sent `intent {action: next_macro, choice}` →
+   * pushIntent relay → Godot host had no GDScript drain → silent drop.
+   * Now drained server-side. Audit doc 2026-05-06-coop-phase-ws-audit.md
+   * tracked as TKT-P5-WS-NEXT-MACRO-DESIGN ~2h.
+   *
+   * @param playerId — submitting player (must equal hostId)
+   * @param choice — { choice: 'advance'|'branch'|'retreat' }
+   * @param hostId — current host player id (host-only gate)
+   * @returns { choice, phase, run_state, advance? }
+   */
+  submitNextMacro(playerId, { choice } = {}, { hostId } = {}) {
+    if (!playerId) throw new Error('player_id_required');
+    if (hostId && playerId !== hostId) throw new Error('host_only');
+    if (!this.run) throw new Error('run_not_started');
+    if (this.phase !== 'debrief' && this.phase !== 'ended') {
+      throw new Error(`not_in_post_combat_phase:${this.phase}`);
+    }
+    const VALID_CHOICES = new Set(['advance', 'branch', 'retreat']);
+    if (!VALID_CHOICES.has(choice)) throw new Error('macro_choice_invalid');
+    this.run.lastMacro = { choice, player_id: playerId, ts: this.now() };
+    this._emit('next_macro', { player_id: playerId, choice });
+    let advance = null;
+    if (choice === 'retreat') {
+      if (this.phase !== 'ended') {
+        this.run.outcome = this.run.outcome || 'retreated';
+        this._setPhase('ended');
+        this._emit('run_ended', { run_id: this.run.id, reason: 'retreat' });
+        advance = { action: 'ended', reason: 'retreat' };
+      } else {
+        advance = { action: 'already_ended' };
+      }
+    } else if (this.phase === 'debrief') {
+      advance = this.advanceScenarioOrEnd();
+    } else {
+      advance = { action: 'noop_post_advance' };
+    }
+    return { choice, phase: this.phase, run_state: this.run, advance };
+  }
+
+  /**
    * Build the /session/start payload from current characters.
    * Used by M17+ host handler that forwards to existing session route.
    */

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -493,7 +493,14 @@ class CoopOrchestrator {
     if (!playerId) throw new Error('player_id_required');
     if (hostId && playerId !== hostId) throw new Error('host_only');
     if (!this.run) throw new Error('run_not_started');
-    if (this.phase !== 'debrief' && this.phase !== 'ended') {
+    // Codex P2 review #2075: include `world_setup` to handle the case
+    // where submitDebriefChoice already auto-advanced (last lineage
+    // submission triggered advanceScenarioOrEnd → phase moved to
+    // world_setup). UI may still emit next_macro post-ack; gate must
+    // accept the no-op path documented for advance/branch when already
+    // advanced.
+    const VALID_PHASES = new Set(['debrief', 'world_setup', 'ended']);
+    if (!VALID_PHASES.has(this.phase)) {
       throw new Error(`not_in_post_combat_phase:${this.phase}`);
     }
     const VALID_CHOICES = new Set(['advance', 'branch', 'retreat']);

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -1547,10 +1547,56 @@ function createWsServer({
             }
             return;
           }
-          // Other lifecycle intents (next_macro):
-          // TODO drain server-side via coopStore. Tracked as
-          // TKT-P5-WS-NEXT-MACRO-DESIGN.
-          // For now relay to host (legacy web v1 path) — Godot host drops.
+          // 2026-05-06 phone smoke W7 fix — drain next_macro server-side via
+          // coopOrchestrator.submitNextMacro. Host-only post-debrief macro
+          // navigation choice {advance, branch, retreat}. Pre-fix relay
+          // to Godot host → silent drop, run stuck post-debrief.
+          if (action === 'next_macro' && coopStore) {
+            try {
+              const orch = coopStore.get(room.code);
+              if (!orch) {
+                socket.send(
+                  JSON.stringify({ type: 'error', payload: { code: 'run_not_started' } }),
+                );
+                return;
+              }
+              const result = orch.submitNextMacro(
+                playerId,
+                { choice: msg.payload?.choice },
+                { hostId: room.hostId },
+              );
+              room.broadcast({
+                type: 'next_macro_committed',
+                payload: {
+                  choice: result.choice,
+                  phase: result.phase,
+                  advance: result.advance || null,
+                },
+              });
+              if (result.phase === 'world_setup') {
+                room.publishPhaseChange('world_setup');
+              } else if (result.phase === 'ended') {
+                room.publishPhaseChange('ended');
+              }
+              socket.send(
+                JSON.stringify({
+                  type: 'next_macro_accepted',
+                  payload: { choice: result.choice, phase: result.phase },
+                }),
+              );
+            } catch (err) {
+              socket.send(
+                JSON.stringify({
+                  type: 'error',
+                  payload: { code: err.message || 'next_macro_failed' },
+                }),
+              );
+            }
+            return;
+          }
+          // No more lifecycle drain branches — all 5 server-side now.
+          // Defensive fallback: relay to host (legacy web v1 path) for
+          // any unrecognized lifecycle intent.
           room.pushIntent({ from: playerId, payload: msg.payload ?? null });
           break;
         }

--- a/docs/reports/2026-05-06-coop-phase-ws-audit.md
+++ b/docs/reports/2026-05-06-coop-phase-ws-audit.md
@@ -87,15 +87,12 @@ In phase=`character_creation` ENTRAMBI host e player non possono submit. Ws v1 w
 
 ## Gap residui (deferred ticket)
 
-| ID  | Action               | Status                              | Ticket                       | Effort |
-| --- | -------------------- | ----------------------------------- | ---------------------------- | ------ |
-| W7  | `next_macro`         | NOT drained, design decision needed | TKT-P5-WS-NEXT-MACRO-DESIGN  | ~2h    |
-
-**W7 design question**: drain server-side via `orch.advanceScenarioOrEnd()` OR keep host-arbiter pattern? Current relay = silent drop su Godot host.
+**Tutti i 6 gap audit chiusi 2026-05-06.** Lifecycle drain matrix complete: 5/5 lifecycle action drained server-side (character_create + form_pulse_submit + lineage_choice + reveal_acknowledge + next_macro).
 
 ### Closed addendum 2026-05-06 (autonomous)
 
 - **W4 `form_pulse_submit`** ✅ shipped — `coopOrchestrator.submitFormPulse(playerId, {axes}, {allPlayerIds})` + `formPulseList()` + drain branch in `wsSession.js` mirror voteWorld pattern. Phase-agnostic per-player axes Map; non-numeric/NaN axes filtered. +4 unit test (W4 series). Harness scenario 4a GAP→PASS verified live.
+- **W7 `next_macro`** ✅ shipped — `coopOrchestrator.submitNextMacro(playerId, {choice}, {hostId})` + drain branch in `wsSession.js`. Design verdict: **host-only post-debrief macro pick** {advance, branch, retreat}. `advance|branch` delegate `advanceScenarioOrEnd()` (branch == advance per MVP, future Sprint Q ETL diverges). `retreat` forces phase=`ended` + `run.outcome ||= 'retreated'`. Records in `run.lastMacro`. +5 unit test. Harness scenario 4d GAP→PASS verified live (host-only + phase-gated). PR #2073 follow-up.
 
 ## Combat E2E + reconnect — DEFERRED
 
@@ -106,17 +103,17 @@ Scenario combat 5 round + airplane reconnect non testati programmatic (richiedon
 - Harness Node script: `tools/testing/phone-flow-harness.js` (committable, ws node_modules from main repo)
 - Run command: `node tools/testing/phone-flow-harness.js` (backend up :3334 prerequisito)
 - Output: 18 scenari (lobby join + phase transition + char create + lifecycle gap matrix + B6 host gate + W8 phase whitelist + stateVersion + onboarding host-only)
-- Final post-W4 close: **17 PASS / 0 FAIL / 1 GAP-DOCUMENTED** (W7 next_macro residuo, design pending)
+- Final post-W4+W7 close: **18 PASS / 0 FAIL / 0 GAP** (zero deferred, audit complete)
 
 Cross-repo tests passing:
 - `node --test tests/api/wsRoomCode.test.js tests/api/coopOrchestrator.test.js` → 23/23 verde
 
 ## Files modified
 
-- `apps/backend/services/network/wsSession.js` — case 'intent' split + 4 lifecycle drain branches (character_create, world_vote, lineage_choice, **form_pulse_submit** W4) + reveal_acknowledge (W8b) + KNOWN_PHASES whitelist + case 'phase' auto-bootstrap coop run
-- `apps/backend/services/coop/coopOrchestrator.js` — `submitFormPulse` + `formPulseList` + `formPulses` Map (W4 close)
-- `tools/testing/phone-flow-harness.js` — extended scenario 4a (W4 PASS) + 4b + 4c + 7a + 7b PASS expectations post-fix
-- `tests/api/coopOrchestrator.test.js` — +4 W4 unit tests (axes filter + ready_set + run_not_started + clear-on-advance)
+- `apps/backend/services/network/wsSession.js` — case 'intent' split + 5 lifecycle drain branches (character_create, world_vote, lineage_choice, **form_pulse_submit** W4, **next_macro** W7) + reveal_acknowledge (W8b) + KNOWN_PHASES whitelist + case 'phase' auto-bootstrap coop run
+- `apps/backend/services/coop/coopOrchestrator.js` — `submitFormPulse` + `formPulseList` + `formPulses` Map (W4) + `submitNextMacro` host-only post-debrief macro {advance|branch|retreat} + `run.lastMacro` (W7)
+- `tools/testing/phone-flow-harness.js` — extended scenario 4a (W4 PASS) + 4d (W7 PASS host-only + phase-gated) + 4b + 4c + 7a + 7b PASS expectations post-fix
+- `tests/api/coopOrchestrator.test.js` — +4 W4 unit tests + 5 W7 unit tests (advance + retreat + retreat-default + reject paths + already-ended)
 
 ## Reversibility
 

--- a/tests/api/coopOrchestrator.test.js
+++ b/tests/api/coopOrchestrator.test.js
@@ -368,10 +368,11 @@ test('W7 — submitNextMacro rejects non-host + invalid choice + wrong phase', (
   co.submitCharacter('p_h', { name: 'Host', form_id: 'istj' }, { allPlayerIds: all });
   co.submitCharacter('p_a', { name: 'Aria', form_id: 'enfp' }, { allPlayerIds: all });
   co.confirmWorld();
-  // Wrong phase: world_setup.
+  // Wrong phase: combat → reject not_in_post_combat_phase. Codex P2 #2075
+  // expanded gate to {debrief, world_setup, ended}; combat still rejected.
   assert.throws(
     () => co.submitNextMacro('p_h', { choice: 'advance' }, { hostId: 'p_h' }),
-    /not_in_post_combat_phase/,
+    /not_in_post_combat_phase:combat/,
   );
   co.endCombat({ outcome: 'victory' });
   // Non-host rejected.
@@ -389,6 +390,31 @@ test('W7 — submitNextMacro rejects non-host + invalid choice + wrong phase', (
     () => co.submitNextMacro(null, { choice: 'advance' }, { hostId: 'p_h' }),
     /player_id_required/,
   );
+});
+
+test('W7 — submitNextMacro from world_setup post-debrief auto-advance is no-op (Codex P2 #2075)', () => {
+  // Reproduce Codex P2 scenario: last lineage_choice triggers
+  // advanceScenarioOrEnd → phase=world_setup. Subsequent host next_macro
+  // must succeed as no-op (not throw not_in_post_combat_phase).
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  co.startRun({ scenarioStack: ['enc_a', 'enc_b'] });
+  const all = ['p_h'];
+  co.submitCharacter('p_h', { name: 'Host', form_id: 'istj' }, { allPlayerIds: all });
+  co.confirmWorld();
+  co.endCombat({ outcome: 'victory' });
+  // submitDebriefChoice last submission → auto-advance to world_setup.
+  const advance = co.submitDebriefChoice('p_h', { choice: 'skip' }, { allPlayerIds: all });
+  assert.equal(advance.action, 'next_scenario');
+  assert.equal(co.phase, 'world_setup');
+  // Now host next_macro advance — must succeed as no-op, NOT throw.
+  const r = co.submitNextMacro('p_h', { choice: 'advance' }, { hostId: 'p_h' });
+  assert.equal(r.advance.action, 'noop_post_advance');
+  assert.equal(r.choice, 'advance');
+  assert.equal(co.phase, 'world_setup');
+  // Retreat from world_setup also valid → forces ended.
+  const r2 = co.submitNextMacro('p_h', { choice: 'retreat' }, { hostId: 'p_h' });
+  assert.equal(co.phase, 'ended');
+  assert.equal(r2.advance.reason, 'retreat');
 });
 
 test('W7 — submitNextMacro from ended phase no-ops cleanly', () => {

--- a/tests/api/coopOrchestrator.test.js
+++ b/tests/api/coopOrchestrator.test.js
@@ -315,6 +315,97 @@ test('F-2: forceAdvance rejected from combat/lobby/ended', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────
+// W7 phone smoke fix — submitNextMacro drain (2026-05-06)
+// ─────────────────────────────────────────────────────────────────
+
+test('W7 — submitNextMacro advance from debrief delegates to advanceScenarioOrEnd', () => {
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  co.startRun({ scenarioStack: ['enc_a', 'enc_b'] });
+  const all = ['p_h', 'p_a'];
+  co.submitCharacter('p_h', { name: 'Host', form_id: 'istj' }, { allPlayerIds: all });
+  co.submitCharacter('p_a', { name: 'Aria', form_id: 'enfp' }, { allPlayerIds: all });
+  co.confirmWorld();
+  co.endCombat({ outcome: 'victory' });
+  assert.equal(co.phase, 'debrief');
+  const result = co.submitNextMacro('p_h', { choice: 'advance' }, { hostId: 'p_h' });
+  assert.equal(result.choice, 'advance');
+  assert.equal(co.phase, 'world_setup');
+  assert.equal(result.advance.action, 'next_scenario');
+  assert.equal(co.run.lastMacro.choice, 'advance');
+});
+
+test('W7 — submitNextMacro retreat from debrief forces ended + records outcome', () => {
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  co.startRun({ scenarioStack: ['enc_a', 'enc_b', 'enc_c'] });
+  const all = ['p_h'];
+  co.submitCharacter('p_h', { name: 'Host', form_id: 'istj' }, { allPlayerIds: all });
+  co.confirmWorld();
+  co.endCombat({ outcome: 'victory' });
+  const result = co.submitNextMacro('p_h', { choice: 'retreat' }, { hostId: 'p_h' });
+  assert.equal(co.phase, 'ended');
+  assert.equal(co.run.outcome, 'victory'); // pre-existing outcome preserved
+  assert.equal(result.advance.reason, 'retreat');
+});
+
+test('W7 — submitNextMacro retreat preserves run.outcome=retreated when null', () => {
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  co.startRun({ scenarioStack: ['enc_a'] });
+  const all = ['p_h'];
+  co.submitCharacter('p_h', { name: 'Host', form_id: 'istj' }, { allPlayerIds: all });
+  co.confirmWorld();
+  // Simulate debrief without endCombat outcome (defensive scenario).
+  co.phase = 'debrief';
+  co.run.outcome = null;
+  co.submitNextMacro('p_h', { choice: 'retreat' }, { hostId: 'p_h' });
+  assert.equal(co.run.outcome, 'retreated');
+  assert.equal(co.phase, 'ended');
+});
+
+test('W7 — submitNextMacro rejects non-host + invalid choice + wrong phase', () => {
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  co.startRun({ scenarioStack: ['enc_a'] });
+  const all = ['p_h', 'p_a'];
+  co.submitCharacter('p_h', { name: 'Host', form_id: 'istj' }, { allPlayerIds: all });
+  co.submitCharacter('p_a', { name: 'Aria', form_id: 'enfp' }, { allPlayerIds: all });
+  co.confirmWorld();
+  // Wrong phase: world_setup.
+  assert.throws(
+    () => co.submitNextMacro('p_h', { choice: 'advance' }, { hostId: 'p_h' }),
+    /not_in_post_combat_phase/,
+  );
+  co.endCombat({ outcome: 'victory' });
+  // Non-host rejected.
+  assert.throws(
+    () => co.submitNextMacro('p_a', { choice: 'advance' }, { hostId: 'p_h' }),
+    /host_only/,
+  );
+  // Invalid choice.
+  assert.throws(
+    () => co.submitNextMacro('p_h', { choice: 'sideways' }, { hostId: 'p_h' }),
+    /macro_choice_invalid/,
+  );
+  // Missing playerId.
+  assert.throws(
+    () => co.submitNextMacro(null, { choice: 'advance' }, { hostId: 'p_h' }),
+    /player_id_required/,
+  );
+});
+
+test('W7 — submitNextMacro from ended phase no-ops cleanly', () => {
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  co.startRun({ scenarioStack: ['enc_a'] });
+  const all = ['p_h'];
+  co.submitCharacter('p_h', { name: 'Host', form_id: 'istj' }, { allPlayerIds: all });
+  co.confirmWorld();
+  co.endCombat({ outcome: 'victory' });
+  co.submitDebriefChoice('p_h', { choice: 'skip' }, { allPlayerIds: all });
+  assert.equal(co.phase, 'ended');
+  // Already ended — advance/retreat both no-op or already_ended.
+  const r = co.submitNextMacro('p_h', { choice: 'retreat' }, { hostId: 'p_h' });
+  assert.equal(r.advance.action, 'already_ended');
+});
+
+// ─────────────────────────────────────────────────────────────────
 // W4 phone smoke fix — submitFormPulse drain (2026-05-06)
 // ─────────────────────────────────────────────────────────────────
 

--- a/tools/testing/phone-flow-harness.js
+++ b/tools/testing/phone-flow-harness.js
@@ -625,10 +625,11 @@ async function main() {
   }
 
   // 4d: next_macro — W7 fix verify (drains via submitNextMacro, host-only).
-  // Phase here is world_setup (post W5 vote). submitNextMacro phase gate
-  // requires debrief|ended → expect not_in_post_combat_phase error
-  // confirming drain branch engaged + host-only check.
-  console.log('\n  4d: next_macro (expect: W7 fix → host-only phase-gated)');
+  // Phase here is world_setup (post W5 vote). Codex P2 review #2075:
+  // world_setup is valid post-debrief auto-advance phase, advance/branch
+  // become no-op. We test 2 paths: (a) non-host gets host_only, (b) host
+  // sends invalid choice gets macro_choice_invalid (proves drain engaged).
+  console.log('\n  4d: next_macro (expect: W7 fix → host-only + choice validation)');
   try {
     // Player (non-host) sends → expect host_only error.
     player.send({ type: 'intent', payload: { action: 'next_macro', choice: 'advance' } });
@@ -637,25 +638,30 @@ async function main() {
       2000,
     );
     console.log(`    Player got expected host_only: ${errMsgPlayer.payload?.code}`);
-    // Host sends in wrong phase → expect not_in_post_combat_phase error.
-    host.send({ type: 'intent', payload: { action: 'next_macro', choice: 'advance' } });
+    // Host sends invalid choice → expect macro_choice_invalid.
+    host.send({ type: 'intent', payload: { action: 'next_macro', choice: 'sideways' } });
     const errMsgHost = await host.waitFor(
-      (m) =>
-        m.type === 'error' && String(m.payload?.code || '').startsWith('not_in_post_combat_phase'),
+      (m) => m.type === 'error' && m.payload?.code === 'macro_choice_invalid',
       2000,
     );
-    console.log(`    Host got expected phase gate: ${errMsgHost.payload?.code}`);
+    console.log(`    Host got expected macro_choice_invalid: ${errMsgHost.payload?.code}`);
+    // Host sends valid 'advance' in world_setup → expect next_macro_accepted (no-op path).
+    host.send({ type: 'intent', payload: { action: 'next_macro', choice: 'advance' } });
+    const acceptedMsg = await host.waitFor((m) => m.type === 'next_macro_accepted', 2000);
+    console.log(
+      `    Host got next_macro_accepted: choice=${acceptedMsg.payload?.choice} phase=${acceptedMsg.payload?.phase}`,
+    );
     pass(
       '4d: next_macro',
-      'next_macro drains via submitNextMacro (host-only + phase-gated)',
-      `player_err=${errMsgPlayer.payload?.code} host_err=${errMsgHost.payload?.code}`,
+      'next_macro drains via submitNextMacro (host-only + choice validation + world_setup no-op accepted)',
+      `player_err=${errMsgPlayer.payload?.code} host_err=${errMsgHost.payload?.code} accepted=${acceptedMsg.payload?.choice}`,
     );
   } catch (err) {
     fail(
       '4d: next_macro',
-      'next_macro drain branch host-only + phase gate',
+      'next_macro drain branch host-only + choice + phase no-op',
       err.message,
-      'W7 fix issue — drain branch not engaged or wrong error code path',
+      'W7 fix issue — drain branch not engaged or wrong response path',
     );
   }
 

--- a/tools/testing/phone-flow-harness.js
+++ b/tools/testing/phone-flow-harness.js
@@ -624,13 +624,40 @@ async function main() {
     );
   }
 
-  // 4d: next_macro — NOT drained
-  gapDoc(
-    '4d: next_macro',
-    'next_macro calls coopOrchestrator or advances scenario',
-    'relayed to host via pushIntent (no drain)',
-    `GAP-W7: next_macro falls through to pushIntent. No coopOrchestrator method maps to it directly (maps to host confirming next scenario). Design question: should next_macro trigger orch.advanceScenarioOrEnd() or remain host-arbiter? Current: silent relay → Godot host drops it.`,
-  );
+  // 4d: next_macro — W7 fix verify (drains via submitNextMacro, host-only).
+  // Phase here is world_setup (post W5 vote). submitNextMacro phase gate
+  // requires debrief|ended → expect not_in_post_combat_phase error
+  // confirming drain branch engaged + host-only check.
+  console.log('\n  4d: next_macro (expect: W7 fix → host-only phase-gated)');
+  try {
+    // Player (non-host) sends → expect host_only error.
+    player.send({ type: 'intent', payload: { action: 'next_macro', choice: 'advance' } });
+    const errMsgPlayer = await player.waitFor(
+      (m) => m.type === 'error' && m.payload?.code === 'host_only',
+      2000,
+    );
+    console.log(`    Player got expected host_only: ${errMsgPlayer.payload?.code}`);
+    // Host sends in wrong phase → expect not_in_post_combat_phase error.
+    host.send({ type: 'intent', payload: { action: 'next_macro', choice: 'advance' } });
+    const errMsgHost = await host.waitFor(
+      (m) =>
+        m.type === 'error' && String(m.payload?.code || '').startsWith('not_in_post_combat_phase'),
+      2000,
+    );
+    console.log(`    Host got expected phase gate: ${errMsgHost.payload?.code}`);
+    pass(
+      '4d: next_macro',
+      'next_macro drains via submitNextMacro (host-only + phase-gated)',
+      `player_err=${errMsgPlayer.payload?.code} host_err=${errMsgHost.payload?.code}`,
+    );
+  } catch (err) {
+    fail(
+      '4d: next_macro',
+      'next_macro drain branch host-only + phase gate',
+      err.message,
+      'W7 fix issue — drain branch not engaged or wrong error code path',
+    );
+  }
 
   // 4e: reveal_acknowledge — W8b fix verify (drains via acknowledgeReveal)
   console.log('\n  4e: reveal_acknowledge (expect: W8b fix → reveal_ack_list broadcast)');


### PR DESCRIPTION
## Summary

W7 last gap from [docs/reports/2026-05-06-coop-phase-ws-audit.md](docs/reports/2026-05-06-coop-phase-ws-audit.md). Pre-fix \`next_macro\` intent fell through to \`pushIntent\` relay → Godot host has no GDScript drain → silent drop, run stuck post-debrief.

**Design verdict** (from audit \"design decision needed\"): **host-only post-debrief macro pick**. choices ∈ {\`advance\`, \`branch\`, \`retreat\`}.

- \`advance\` / \`branch\` → delegate to \`advanceScenarioOrEnd()\` when phase=='debrief'. branch == advance for MVP; future Sprint Q ETL may diverge with branch table.
- \`retreat\` → force phase='ended' + \`run.outcome ||= 'retreated'\` (early exit).
- Records in \`run.lastMacro\` for telemetry.
- Host-only enforcement at orch layer (mirror \`submitOnboardingChoice\`).

WS handler broadcasts \`next_macro_committed\` (choice + phase + advance result) + sends \`next_macro_accepted\` to host. Auto-\`publishPhaseChange\` on phase transition (world_setup or ended).

## Test plan

- [x] \`node --test tests/api/coopOrchestrator.test.js\` → **32/32** (+5 W7 unit tests: advance + retreat preserves outcome + retreat-default + reject paths + already-ended)
- [x] \`node --test tests/ai/*.test.js\` → **383/383** baseline preserved
- [x] \`node tools/testing/phone-flow-harness.js\` (live) → **18 PASS / 0 FAIL / 0 GAP** — audit fully closed
- [x] \`npm run format:check\` → clean

## Files

- \`apps/backend/services/coop/coopOrchestrator.js\` — \`submitNextMacro\` + run.lastMacro + retreat → ended logic
- \`apps/backend/services/network/wsSession.js\` — drain branch (5th lifecycle action drained server-side)
- \`tests/api/coopOrchestrator.test.js\` — +5 W7 unit tests
- \`tools/testing/phone-flow-harness.js\` — scenario 4d flip GAP→PASS
- \`docs/reports/2026-05-06-coop-phase-ws-audit.md\` — gap matrix W7 closed + addendum + final harness counts (18/0/0)

## Reversibility

Additive server-side. Reversible via single \`git revert\`. Zero breaking change on web v1 path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)