### PR TITLE
chore(governance): final residue cleanup (4 -> 0, semantic doc_status fix)

### DIFF
--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -5056,13 +5056,13 @@
     {
       "path": "docs/planning/EVO_FINAL_DESIGN_SOURCE_AUTHORITY_MAP.md",
       "title": "Evo Final Design — Source Authority Map",
-      "doc_status": "historical_ref",
+      "doc_status": "draft",
       "doc_owner": "platform-docs",
       "workstream": "cross-cutting",
       "last_verified": "2026-05-06",
       "source_of_truth": true,
       "language": "it-en",
-      "review_cycle_days": 180,
+      "review_cycle_days": 14,
       "primary": true,
       "track": "authored"
     },
@@ -6930,13 +6930,13 @@
     {
       "path": "docs/reports/PILLAR-LIVE-STATUS.md",
       "title": "PILLAR-LIVE-STATUS — runtime status canonical (volatile)",
-      "doc_status": "historical_ref",
+      "doc_status": "active",
       "doc_owner": "master-dd",
       "workstream": "cross-cutting",
       "last_verified": "2026-05-06",
       "source_of_truth": true,
       "language": "it",
-      "review_cycle_days": 180,
+      "review_cycle_days": 7,
       "primary": false,
       "track": "active"
     },


### PR DESCRIPTION
## Summary

Closes the governance warnings cleanup arc (Wave 1-5 PRs #2078-#2083, 460→4).
Syncs registry `doc_status` + `review_cycle_days` with actual frontmatter for
the 2 files preserved out-of-scope from prior bulk batches due to semantic
mismatch requiring per-file audit.

| File | Registry (before) | Frontmatter (canonical) | Registry (after) |
|------|-------------------|-------------------------|------------------|
| `docs/planning/EVO_FINAL_DESIGN_SOURCE_AUTHORITY_MAP.md` | `historical_ref` / 180 | `draft` / 14 | `draft` / 14 |
| `docs/reports/PILLAR-LIVE-STATUS.md` | `historical_ref` / 180 | `active` / 7 | `active` / 7 |

## Audit reasoning

Both files had registry bulk-set to `historical_ref/180` in prior wave but
frontmatter values were semantically correct vs file content:

- **EVO_FINAL_DESIGN_SOURCE_AUTHORITY_MAP**: v1 canonical authority map being
  actively iterated (defines who wins in conflict between freeze/hub/ADR/core
  data). Status `draft` + 14d cycle correct since not yet promoted to stable.
- **PILLAR-LIVE-STATUS**: explicitly self-described in body as "runtime status
  canonical (volatile)" per drift audit 2026-04-28 Opzione B (separation
  spec stable + runtime volatile). Weekly bump cadence per pillar sprint.

Frontmatter wins per source-of-truth precedence (file content > registry).

## Verification

- `python tools/check_docs_governance.py --registry docs/governance/docs_registry.json --strict` → **errors=0 warnings=0** ✅
- `npm run format:check` → All matched files use Prettier code style ✅
- Diff: 4 lines (2 fields × 2 entries), frontmatter not touched ✅

## Test plan

- [x] Governance check: errors=0 warnings=0 (target hit, -100% from 4)
- [x] Prettier format clean
- [x] Frontmatter not modified (registry-only change)
- [x] No body content edits (governance scope only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)