### PR TITLE
feat(playwright): canvas-grid visual regression — Tier 1 #3 adoption

### DIFF
--- a/tools/ts/tests/playwright/phone/canvas-visual.spec.ts
+++ b/tools/ts/tests/playwright/phone/canvas-visual.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+import {
+  sampleCanvasGrid,
+  countNonEmptyCells,
+  colorMatchesApprox,
+} from './lib/canvasGrid.js';
+
+// Canvas visual regression smoke (Tier 1 #3 adoption post 2026-05-07).
+//
+// Validates phone HTML5 canvas rendering pipeline at 4x4 grid coordinate
+// level. Catches gross regressions (canvas blank, wrong viewport,
+// rendering pipeline broken) without pixel-perfect snapshot brittleness.
+//
+// Cross-ref:
+//   - tools/ts/tests/playwright/phone/lib/canvasGrid.ts (helper API)
+//   - docs/playtest/AGENT_DRIVEN_WORKFLOW.md Pattern B
+//   - https://dev.to/fonzi/testing-html5-canvas-with-canvasgrid-and-playwright-5h4c
+
+const PHONE_PATH = '/phone/';
+const CANVAS_SELECTOR = 'canvas';
+
+test.describe('phone canvas — visual baseline', () => {
+  test('canvas mounts with non-zero dimensions', async ({ page }) => {
+    await page.goto(PHONE_PATH, { waitUntil: 'load' });
+    // Godot HTML5 splash screen renders within ~5s on dev hardware
+    await page.waitForFunction(
+      (sel) => {
+        const c = document.querySelector(sel) as HTMLCanvasElement | null;
+        return !!c && c.width > 0 && c.height > 0;
+      },
+      CANVAS_SELECTOR,
+      { timeout: 30_000 },
+    );
+    const dims = await page.evaluate((sel) => {
+      const c = document.querySelector(sel) as HTMLCanvasElement;
+      return { width: c.width, height: c.height };
+    }, CANVAS_SELECTOR);
+    expect(dims.width).toBeGreaterThan(100);
+    expect(dims.height).toBeGreaterThan(100);
+  });
+
+  test('canvas renders content post-load (lobby form OR splash)', async ({ page }) => {
+    await page.goto(PHONE_PATH, { waitUntil: 'load' });
+    // Wait for Godot to finish init + first paint past splash
+    await page.waitForFunction(
+      (sel) => {
+        const c = document.querySelector(sel) as HTMLCanvasElement | null;
+        return !!c && c.width > 0 && c.height > 0;
+      },
+      CANVAS_SELECTOR,
+      { timeout: 30_000 },
+    );
+    // Wait for splash to fade + composer to render — empirically ~18s
+    // for cold load. Local dev faster (~8s).
+    await page.waitForTimeout(20_000);
+
+    const grid = await sampleCanvasGrid(page, CANVAS_SELECTOR, {
+      rows: 4,
+      cols: 4,
+      emptyThreshold: 5,
+    });
+
+    // Baseline: at least 50% of cells should have rendered content (form
+    // text, splash logo, etc.). Total black canvas = render pipeline broken.
+    const nonEmpty = countNonEmptyCells(grid);
+    expect(nonEmpty).toBeGreaterThan(8);
+
+    // Top-left cell often contains lobby form heading "Inserisci il codice
+    // della stanza" OR Godot splash text — should be non-black.
+    expect(grid[0]?.[0]?.isEmpty).toBe(false);
+  });
+});
+
+test.describe('phone canvas — color sampling utilities', () => {
+  test('colorMatchesApprox tolerance reasonable', () => {
+    // Pure unit-level check on helper utility (no page interaction).
+    const cell = {
+      avg: { r: 100, g: 200, b: 50, a: 255 },
+      width: 10,
+      height: 10,
+      isEmpty: false,
+    };
+    expect(colorMatchesApprox(cell, { r: 100, g: 200, b: 50 })).toBe(true);
+    expect(colorMatchesApprox(cell, { r: 90, g: 195, b: 60 }, 15)).toBe(true);
+    expect(colorMatchesApprox(cell, { r: 0, g: 0, b: 0 }, 30)).toBe(false);
+  });
+});

--- a/tools/ts/tests/playwright/phone/lib/canvasGrid.ts
+++ b/tools/ts/tests/playwright/phone/lib/canvasGrid.ts
@@ -1,0 +1,159 @@
+// Canvas grid visual regression helper (Tier 1 #3 adoption post 2026-05-07).
+//
+// Asserts HTML5 canvas regions via NxM grid coordinates without pixel-perfect
+// snapshot brittleness. Use cases:
+//   - Skiv echolocation pulse rendering (cyan #66d1fb in expected radius)
+//   - CT bar visual lookahead 3 turni (color sequence per cell)
+//   - Range overlay shape detection (cerchio pixel pattern)
+//   - Phase indicator color (e.g., onboarding=blue, character_create=green)
+//
+// API:
+//   const grid = await sampleCanvasGrid(page, '#canvas', { rows: 4, cols: 4 });
+//   expect(grid[0][0].avg.r).toBeGreaterThan(100); // top-left red dominant
+//   expect(grid[2][2]).toBeNonBlack();             // center has content
+//
+// Cross-ref:
+//   - docs/playtest/AGENT_DRIVEN_WORKFLOW.md Pattern B (Playwright)
+//   - https://dev.to/fonzi/testing-html5-canvas-with-canvasgrid-and-playwright-5h4c
+
+import type { Page } from '@playwright/test';
+
+export type GridCellSample = {
+  /** Average RGBA across all pixels in the cell. */
+  avg: { r: number; g: number; b: number; a: number };
+  /** Cell pixel dimensions (canvas-space). */
+  width: number;
+  height: number;
+  /** True if cell is fully transparent or pure black (#000 alpha=0). */
+  isEmpty: boolean;
+};
+
+export type CanvasGridOptions = {
+  rows: number;
+  cols: number;
+  /** Tolerance for "empty" detection — cells with avg sum below this are treated as empty. Default 5. */
+  emptyThreshold?: number;
+};
+
+/**
+ * Sample HTML5 canvas via getImageData inside page context. Returns NxM
+ * grid of RGBA averages per cell.
+ *
+ * Throws if canvas selector doesn't exist OR returns 0x0 size.
+ *
+ * Note: works on Godot HTML5 canvas (#canvas) only when canvas isn't
+ * cross-origin tainted. WebGL contexts require `preserveDrawingBuffer:true`
+ * OR readPixels equivalent. Godot 4.6 HTML5 export sets this flag by default.
+ */
+export async function sampleCanvasGrid(
+  page: Page,
+  canvasSelector: string,
+  options: CanvasGridOptions,
+): Promise<GridCellSample[][]> {
+  const { rows, cols, emptyThreshold = 5 } = options;
+  if (rows < 1 || cols < 1) {
+    throw new Error(`canvasGrid: rows=${rows} cols=${cols} must be >= 1`);
+  }
+
+  const result = await page.evaluate(
+    ({ selector, rows: r, cols: c, emptyThreshold: et }) => {
+      const canvas = document.querySelector(selector) as HTMLCanvasElement | null;
+      if (!canvas) {
+        throw new Error(`canvasGrid: selector ${selector} not found`);
+      }
+      if (canvas.width === 0 || canvas.height === 0) {
+        throw new Error(
+          `canvasGrid: ${selector} dimensions ${canvas.width}x${canvas.height} (canvas not rendered)`,
+        );
+      }
+      // Try 2d context first; if WebGL-backed, fall back to drawImage to a 2d
+      // shadow canvas (Godot HTML5 typically WebGL). readPixels would also
+      // work but adds GL boilerplate; drawImage roundtrip simpler.
+      const cellW = Math.floor(canvas.width / c);
+      const cellH = Math.floor(canvas.height / r);
+      const shadow = document.createElement('canvas');
+      shadow.width = canvas.width;
+      shadow.height = canvas.height;
+      const sctx = shadow.getContext('2d');
+      if (!sctx) {
+        throw new Error('canvasGrid: shadow 2d context unavailable');
+      }
+      try {
+        sctx.drawImage(canvas, 0, 0);
+      } catch (err) {
+        throw new Error(
+          `canvasGrid: drawImage failed (canvas may be tainted): ${(err as Error).message}`,
+        );
+      }
+      const grid: Array<
+        Array<{
+          avg: { r: number; g: number; b: number; a: number };
+          width: number;
+          height: number;
+          isEmpty: boolean;
+        }>
+      > = [];
+      for (let row = 0; row < r; row += 1) {
+        const rowSamples: typeof grid[number] = [];
+        for (let col = 0; col < c; col += 1) {
+          const x = col * cellW;
+          const y = row * cellH;
+          const data = sctx.getImageData(x, y, cellW, cellH).data;
+          let sumR = 0;
+          let sumG = 0;
+          let sumB = 0;
+          let sumA = 0;
+          const pixelCount = data.length / 4;
+          for (let i = 0; i < data.length; i += 4) {
+            sumR += data[i]!;
+            sumG += data[i + 1]!;
+            sumB += data[i + 2]!;
+            sumA += data[i + 3]!;
+          }
+          const avgR = sumR / pixelCount;
+          const avgG = sumG / pixelCount;
+          const avgB = sumB / pixelCount;
+          const avgA = sumA / pixelCount;
+          rowSamples.push({
+            avg: { r: avgR, g: avgG, b: avgB, a: avgA },
+            width: cellW,
+            height: cellH,
+            isEmpty: avgR + avgG + avgB < et && avgA < et,
+          });
+        }
+        grid.push(rowSamples);
+      }
+      return grid;
+    },
+    { selector: canvasSelector, rows, cols, emptyThreshold },
+  );
+  return result as GridCellSample[][];
+}
+
+/**
+ * Convenience: count cells in a sampled grid that are non-empty (have rendered content).
+ */
+export function countNonEmptyCells(grid: GridCellSample[][]): number {
+  let count = 0;
+  for (const row of grid) {
+    for (const cell of row) {
+      if (!cell.isEmpty) count += 1;
+    }
+  }
+  return count;
+}
+
+/**
+ * Convenience: assert RGB average matches expected within tolerance (per channel).
+ */
+export function colorMatchesApprox(
+  cell: GridCellSample,
+  expected: { r: number; g: number; b: number },
+  tolerance = 30,
+): boolean {
+  return (
+    Math.abs(cell.avg.r - expected.r) <= tolerance &&
+    Math.abs(cell.avg.g - expected.g) <= tolerance &&
+    Math.abs(cell.avg.b - expected.b) <= tolerance
+  );
+}


### PR DESCRIPTION
## Summary

Tier 1 #3 from agent-driven playtest workflow doc (PR #2092). NxM grid sampling helper per HTML5 canvas pixel assertions senza snapshot brittleness.

## Use cases

- Skiv echolocation pulse rendering (cyan #66d1fb radius)
- CT bar visual lookahead 3 turni (color sequence per cell)
- Range overlay shape detection (cerchio pixel pattern)
- Phase indicator color (onboarding=blue, char_create=green)

## API

\`tools/ts/tests/playwright/phone/lib/canvasGrid.ts\` (~145 LOC):

- \`sampleCanvasGrid(page, '#canvas', { rows: 4, cols: 4 })\` → \`GridCellSample[][]\`
- \`countNonEmptyCells(grid)\` → number of cells with rendered content
- \`colorMatchesApprox(cell, { r, g, b }, tolerance)\` → boolean

Implementation: shadow 2d canvas + drawImage + getImageData per cell. Handles WebGL-backed Godot HTML5 canvas via roundtrip. Returns RGBA average + cell dimensions + isEmpty flag.

## Spec coverage

\`canvas-visual.spec.ts\` 3 test:

| Test | Validates |
|---|---|
| canvas mounts non-zero dimensions | Godot HTML5 init verde |
| canvas renders content post-load | ≥50% cells non-empty post-splash (~20s wait) |
| colorMatchesApprox tolerance | Helper unit-level |

## Local smoke verde

\`\`\`
6 passed (22.3s)
- phone-multi.spec.ts × 3 (PR #2093 baseline preserved)
- canvas-visual.spec.ts × 3 (this PR)
\`\`\`

## Force-add note

Root \`.gitignore\` line 59 has \`Lib/\` rule (Godot convention). Case-insensitive Windows match → \`tools/ts/tests/playwright/phone/lib/canvasGrid.ts\` ignored. Used \`git add -f\` to commit. Alternative rename (\`helpers/\` instead of \`lib/\`) deferred — \`lib/\` convention familiar Playwright/jest pattern.

## Adoption roadmap progress

- [x] Tier 1 #1 Playwright multi-context (PR #2093 MERGED \`4662e1c\`)
- [x] Tier 1 #2 Artillery WS scenarios (PR #2094 MERGED \`31b198f\`)
- [x] **Tier 1 #3 canvas-grid visual regression** (~1h budgeted, ~45min actual) ← this PR
- [ ] Tier 1 #4 gamestudio-subagents profile mining (~1h)

## Test plan

- [x] Local smoke verde 6/6 (22.3s)
- [x] Helper API documented + 3 test scopes (mount, content, tolerance)
- [ ] Master-dd review patterns
- [ ] Future: extend with Skiv pulse-specific spec when echolocation surface refactored
- [ ] CI integration follow-up (needs backend bootstrap hook + Chromium install)

## Cross-ref

- [PR #2092 canonical workflow doc](https://github.com/MasterDD-L34D/Game/pull/2092) (MERGED \`b3667b2\`)
- [PR #2093 Playwright phone smoke](https://github.com/MasterDD-L34D/Game/pull/2093) (MERGED \`4662e1c\`)
- [PR #2094 Artillery WS load](https://github.com/MasterDD-L34D/Game/pull/2094) (MERGED \`31b198f\`)
- [research source](https://dev.to/fonzi/testing-html5-canvas-with-canvasgrid-and-playwright-5h4c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)