### PR TITLE
docs(closure-final): fill 3 TBD-closure placeholders + count audit fresh post #2125

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,7 +397,9 @@ Primary working directory is on Windows, but the shell is bash (Git Bash/MSYS) â
 | [#2120](https://github.com/MasterDD-L34D/Game/pull/2120) | `9d57a2c5` | OD-022 add: evo-swarm pipeline cross-verification gate pre run #6 (~7-9h Sprint Q+ candidate)      |
 | [#2121](https://github.com/MasterDD-L34D/Game/pull/2121) | `1ee6fd94` | Triage run #5 5/7 questions closed canonical grep (~25min, 2 deferred Sprint Q+)                   |
 | [#2117](https://github.com/MasterDD-L34D/Game/pull/2117) | `2656640c` | Skiv Monitor auto-update admin merge (canonical pattern post #2115 lesson)                         |
-| TBD-closure                                              | TBD        | Day 3 closure cumulative: BACKLOG + COMPACT + CLAUDE.md + memory + handoff fill TBDs (this commit) |
+| [#2122](https://github.com/MasterDD-L34D/Game/pull/2122) | `95ac1ef3` | Day 3 closure cumulative: BACKLOG + COMPACT + CLAUDE.md + memory + handoff fill TBDs               |
+| [#2123](https://github.com/MasterDD-L34D/Game/pull/2123) | `bec82f12` | OD audit cleanup OD-016 sposta + OD-022 cross-link (drift, corrected by #2125)                     |
+| [#2125](https://github.com/MasterDD-L34D/Game/pull/2125) | `e6e0ba0a` | Completionist enrichment + museum card M-2026-05-08-001 + lesson codify CLAUDE.md                  |
 
 **Synthetic iter2 evidence**: Tier 1 phone smoke 15/16 PASS + 1 skip in 39.8s vs iter1 39.4s = noise. Iter3 hardware-equivalent reconnect 30.9s + WS RTT p95 441ms = zero degradation.
 
@@ -406,8 +408,8 @@ Primary working directory is on Windows, but the shell is bash (Git Bash/MSYS) â
 **Cumulative Phase A PR count audit (gh ground truth UTC)**:
 
 - UTC 2026-05-07 Day 1: 26 Game/ + 14 Godot v2 = 40 PR
-- UTC 2026-05-08 Day 2 + Day 3 trigger sera: 9 Game/ (#2115 Skiv admin + #2116 memory + #2117 Skiv admin + #2118 iter2 + #2108 swarm + #2119 normalize + #2120 OD-022 + #2121 triage + this closure)
-- **Total = 49 PR cross-repo Phase A monitoring window UTC Day 1+2**
+- UTC 2026-05-08 Day 2 + Day 3 trigger sera: 11 Game/ (#2115 Skiv admin + #2116 memory + #2117 Skiv admin + #2118 iter2 + #2108 swarm + #2119 normalize + #2120 OD-022 + #2121 triage + #2122 closure + #2123 OD audit + #2125 completionist)
+- **Total = 51 PR cross-repo Phase A monitoring window UTC Day 1+2** (+1 PR #2124 chiuso senza merge come revert direction wrong)
 
 **OD aperte tracking master-dd**: 5 â†’ 6 (+OD-022 evo-swarm cross-verification gate pre run #6).
 

--- a/COMPACT_CONTEXT.md
+++ b/COMPACT_CONTEXT.md
@@ -35,7 +35,9 @@ OR (post 7gg grace 2026-05-14):
 - [#2120](https://github.com/MasterDD-L34D/Game/pull/2120) `9d57a2c5` OD-022 add evo-swarm cross-verification gate pre run #6
 - [#2121](https://github.com/MasterDD-L34D/Game/pull/2121) `1ee6fd94` triage run #5 5/7 closed canonical grep (2 deferred Sprint Q+)
 - [#2117](https://github.com/MasterDD-L34D/Game/pull/2117) `2656640c` Skiv Monitor auto-update admin merge
-- TBD closure cumulative: BACKLOG + COMPACT + CLAUDE.md + memory + handoff fill TBDs (this commit)
+- [#2122](https://github.com/MasterDD-L34D/Game/pull/2122) `95ac1ef3` Day 3 closure cumulative: BACKLOG + COMPACT + CLAUDE.md + memory + handoff fill TBDs
+- [#2123](https://github.com/MasterDD-L34D/Game/pull/2123) `bec82f12` OD audit cleanup OD-016 sposta Aperte→Risolte (drift, corrected by #2125)
+- [#2125](https://github.com/MasterDD-L34D/Game/pull/2125) `e6e0ba0a` Completionist enrichment + museum card M-2026-05-08-001 + lesson codify CLAUDE.md §"No anticipated judgment"
 
 **Synthetic iter2 evidence**:
 
@@ -52,7 +54,7 @@ OR (post 7gg grace 2026-05-14):
 - ✅ Zero functional regression Day 1 → Day 2 → Day 3
 - ✅ ADR §4.4 critical bug regression trigger NOT fired
 
-**Cumulative Phase A gh ground truth Day 1+2 UTC** = 43 PR cross-repo (29 Game/ + 14 Godot v2). Vecchio tracking "21 Claude-shipped autonomous" sotto-stimava cross-repo + Codex iter rounds.
+**Cumulative Phase A gh ground truth Day 1+2 UTC** = 51 PR cross-repo (37 Game/ + 14 Godot v2; +1 PR #2124 closed senza merge revert direction). Vecchio tracking "21 Claude-shipped autonomous" sotto-stimava cross-repo + Codex iter rounds.
 
 **Day 4 (2026-05-10) skip per OD-021** (Day 3+5+7 only). Day 5 scheduled iter3 = 2026-05-11.
 

--- a/docs/planning/2026-05-07-phase-a-handoff-next-session.md
+++ b/docs/planning/2026-05-07-phase-a-handoff-next-session.md
@@ -331,7 +331,9 @@ Causa: user trigger phrase anticipato. Razionale per accettarlo:
 | [#2120](https://github.com/MasterDD-L34D/Game/pull/2120) | `9d57a2c5` | OD-022 add: evo-swarm pipeline cross-verification gate pre run #6                              |
 | [#2121](https://github.com/MasterDD-L34D/Game/pull/2121) | `1ee6fd94` | Triage run #5 5/7 questions closed via canonical grep (2 deferred Sprint Q+)                   |
 | [#2117](https://github.com/MasterDD-L34D/Game/pull/2117) | `2656640c` | Skiv Monitor auto-update admin merge (canonical pattern)                                       |
-| TBD-closure                                              | TBD        | Day 3 closure cumulative: BACKLOG + COMPACT + CLAUDE.md + memory + handoff fill TBDs           |
+| [#2122](https://github.com/MasterDD-L34D/Game/pull/2122) | `95ac1ef3` | Day 3 closure cumulative: BACKLOG + COMPACT + CLAUDE.md + memory + handoff fill TBDs           |
+| [#2123](https://github.com/MasterDD-L34D/Game/pull/2123) | `bec82f12` | OD audit cleanup OD-016 sposta + OD-022 cross-link (drift, corrected by #2125)                 |
+| [#2125](https://github.com/MasterDD-L34D/Game/pull/2125) | `e6e0ba0a` | Completionist enrichment + museum card M-2026-05-08-001 + lesson codify CLAUDE.md              |
 
 ### Synthetic iter2 evidence
 

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-08T12:49:17+00:00",
+  "generated_at": "2026-05-08T13:21:26+00:00",
   "summary": {
     "total": 1,
     "errors": 0,


### PR DESCRIPTION
## Summary

Final completionist closure Day 3/7 sera. Fill 3 TBD residue + count audit fresh post recent merges.

## TBD-closure fills

3 file canonical avevano `TBD-closure | TBD` placeholder pre-merge:

- `COMPACT_CONTEXT.md` TL;DR Day 3 PR list
- `CLAUDE.md` sprint context Day 3 PR table
- `docs/planning/2026-05-07-phase-a-handoff-next-session.md` Day 3 PR table

Filled with [#2122](https://github.com/MasterDD-L34D/Game/pull/2122) `95ac1ef3` + [#2123](https://github.com/MasterDD-L34D/Game/pull/2123) `bec82f12` + [#2125](https://github.com/MasterDD-L34D/Game/pull/2125) `e6e0ba0a`.

## Count audit fresh

| Metric | Pre | Post |
|--------|-----|------|
| Game/ Day 2-3 UTC | 9 PR | **11 PR** |
| Cross-repo cumulative Day 1+2 UTC | 49 PR | **51 PR** |

+#2124 chiuso senza merge come revert direction wrong (anti-completionist) — preserved nel count tracking.

## Phase A status

- 5/6 🟢++ + 2/6 🟢 cand invariati
- No regression Day 1→2→3
- Tier 1 functional gate stable
- Day 5 iter3 schedule confirmed 2026-05-11
- OD aperte tracking master-dd: 7 totali
- Open PR: 0 cross-repo (post questa)

## Files

- `COMPACT_CONTEXT.md` (TBD fill + count Day 1+2 UTC)
- `CLAUDE.md` (TBD fill sprint Day 3 + count audit)
- `docs/planning/2026-05-07-phase-a-handoff-next-session.md` (TBD fill)
- `reports/docs/governance_drift_report.json` (auto-regen)

## Test plan

- [x] Format check verde 4 file
- [x] Governance strict pass (errors=0)
- [x] gh PR list count audit cross-verified
- [x] All TBD placeholders filled
- [x] Memory cumulative consistency

## Auto-merge L3

Eligible per [ADR-2026-05-07-auto-merge-authorization-l3](https://github.com/MasterDD-L34D/Game/blob/main/docs/adr/ADR-2026-05-07-auto-merge-authorization-l3.md):

- ✅ Doc-only change (4 files, 13+/7-)
- ✅ Zero forbidden paths
- ✅ Zero new deps
- ✅ Format + governance verde
- ✅ Pure factual cleanup (TBD fill + count update gh ground truth, NOT design judgment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)