### PR TITLE
fix(lobby): phone smoke iter3 B-NEW bundle — rejoin + quorum + log + deep-link

### DIFF
--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -40,6 +40,15 @@ function createCoopRouter({ lobby, coopStore } = {}) {
       .map((p) => p.id);
   }
 
+  // B-NEW-1 fix 2026-05-08 — connected (WS-attached) non-host player ids.
+  // Used by world vote quorum so a disconnected peer doesn't block phase
+  // advance. Mirror of allPlayerIds with extra `connected` filter.
+  function connectedPlayerIds(room) {
+    return Array.from(room.players.values())
+      .filter((p) => p.id !== room.hostId && p.role !== 'host' && p.connected)
+      .map((p) => p.id);
+  }
+
   function broadcastCoopState(room, orch) {
     if (!room || typeof room.broadcast !== 'function') return;
     room.broadcast({
@@ -58,7 +67,7 @@ function createCoopRouter({ lobby, coopStore } = {}) {
     if (orch.phase === 'world_setup') {
       room.broadcast({
         type: 'world_tally',
-        payload: orch.worldTally(allPlayerIds(room)),
+        payload: orch.worldTally(allPlayerIds(room), connectedPlayerIds(room)),
       });
     }
     // M19 — debrief ready list if in debrief.
@@ -152,6 +161,7 @@ function createCoopRouter({ lobby, coopStore } = {}) {
         scenarioId,
         accept,
         allPlayerIds: allPlayerIds(room),
+        connectedPlayerIds: connectedPlayerIds(room),
       });
       broadcastCoopState(room, orch);
       return res.json({ phase: orch.phase, tally });

--- a/apps/backend/routes/lobby.js
+++ b/apps/backend/routes/lobby.js
@@ -4,6 +4,7 @@
 // Endpoints:
 //   POST /api/lobby/create  — create room, return code + host token
 //   POST /api/lobby/join    — join by code + name, return player token
+//   POST /api/lobby/rejoin  — validate stored token + return room snapshot
 //   POST /api/lobby/close   — close room (host only)
 //   GET  /api/lobby/state   — inspect room snapshot (?code=ABCD)
 //   GET  /api/lobby/list    — list open rooms (admin/debug)
@@ -62,6 +63,31 @@ function createLobbyRouter({ lobby } = {}) {
       }
       return res.status(400).json({ error: code });
     }
+  });
+
+  // B-NEW-4 fix 2026-05-08 — rejoin path. Phone close-tab / cross-device
+  // resume needs a way to validate the stored localStorage session before
+  // attempting WS reconnect. Pre-fix: no REST probe → frontend redirected
+  // to game shell, WS attempt failed silently, user saw lobby home with
+  // no rejoin CTA (dead-end UX). Now: client calls /lobby/rejoin first,
+  // gets explicit 404 / 401 / 410 to clear stale session, or 200 + room
+  // snapshot to safely resume WS.
+  router.post('/lobby/rejoin', (req, res) => {
+    const { code, player_id: playerId, player_token: playerToken } = req.body || {};
+    if (!code || !playerId || !playerToken) {
+      return res.status(400).json({ error: 'code + player_id + player_token richiesti' });
+    }
+    const room = lobby.getRoom(code);
+    if (!room) return res.status(404).json({ error: 'room_not_found' });
+    if (room.closed) return res.status(410).json({ error: 'room_closed' });
+    const player = room.authenticate?.(playerId, playerToken);
+    if (!player) return res.status(401).json({ error: 'auth_failed' });
+    return res.json({
+      code: room.code,
+      player_id: playerId,
+      role: player.role,
+      room: room.snapshot(),
+    });
   });
 
   router.post('/lobby/close', (req, res) => {

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -322,7 +322,7 @@ class CoopOrchestrator {
    * M18 — Player casts vote on proposed scenario. accept=true/false.
    * Host remains arbiter and must still confirmWorld() to commit.
    */
-  voteWorld(playerId, { scenarioId, accept = true, allPlayerIds = [] } = {}) {
+  voteWorld(playerId, { scenarioId, accept = true, allPlayerIds = [], connectedPlayerIds } = {}) {
     if (this.phase !== 'world_setup') throw new Error('not_in_world_setup');
     if (!playerId) throw new Error('player_id_required');
     const sid = scenarioId || this.run?.scenarioStack?.[this.run.currentIndex];
@@ -332,7 +332,7 @@ class CoopOrchestrator {
       ts: this.now(),
     });
     this._emit('world_vote', { player_id: playerId, scenario_id: sid, accept });
-    return this.worldTally(allPlayerIds);
+    return this.worldTally(allPlayerIds, connectedPlayerIds);
   }
 
   /**
@@ -443,8 +443,15 @@ class CoopOrchestrator {
 
   /**
    * M18 — Tally current world votes. Returns counts + breakdown.
+   *
+   * B-NEW-1 fix 2026-05-08 — accept optional `connectedPlayerIds` so phone
+   * smoke (Day 3/7 friends online) can compute quorum on connected players
+   * only. Pre-fix: tally pending counted offline players → vote stuck
+   * indefinitely when 2nd player WS dropped mid-vote. Now: caller may use
+   * `all_connected_accepted` flag to advance phase even with offline peers.
+   * Backward compat: when `connectedPlayerIds` omitted, behaves as before.
    */
-  worldTally(allPlayerIds = []) {
+  worldTally(allPlayerIds = [], connectedPlayerIds) {
     let accept = 0;
     let reject = 0;
     const perPlayer = {};
@@ -453,7 +460,7 @@ class CoopOrchestrator {
       else reject += 1;
       perPlayer[pid] = vote;
     }
-    return {
+    const tally = {
       scenario_id: this.run?.scenarioStack?.[this.run.currentIndex] || null,
       accept,
       reject,
@@ -461,6 +468,29 @@ class CoopOrchestrator {
       pending: Math.max(allPlayerIds.length - (accept + reject), 0),
       per_player: perPlayer,
     };
+    if (Array.isArray(connectedPlayerIds)) {
+      const connected = connectedPlayerIds.filter(Boolean);
+      const connectedTotal = connected.length;
+      let connectedAccept = 0;
+      let connectedReject = 0;
+      for (const pid of connected) {
+        const vote = this.worldVotes.get(pid);
+        if (!vote) continue;
+        if (vote.accept) connectedAccept += 1;
+        else connectedReject += 1;
+      }
+      const connectedVoted = connectedAccept + connectedReject;
+      tally.connected_total = connectedTotal;
+      tally.connected_accept = connectedAccept;
+      tally.connected_reject = connectedReject;
+      tally.connected_pending = Math.max(connectedTotal - connectedVoted, 0);
+      // True only when at least one connected player has voted AND every
+      // connected player voted accept. Empty connected set returns false
+      // (caller should not auto-advance with zero participants).
+      tally.all_connected_accepted =
+        connectedTotal > 0 && connectedAccept === connectedTotal && connectedReject === 0;
+    }
+    return tally;
   }
 
   /**

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -37,6 +37,23 @@ const crypto = require('node:crypto');
 const { signPlayerToken, verifyPlayerToken } = require('./jwtAuth');
 const { applyOps: applyJsonPatchOps } = require('./jsonPatch');
 
+// B-NEW-2 RCA aid 2026-05-08 — structured JSON log for lobby lifecycle
+// events (create / join / vote / close / host_grace_fire / ghost_remove).
+// Pre-fix: phone smoke iter3 friends online found 4 lobby orfane in <5min
+// with ZERO log line → root-causing took manual REST snapshot polling.
+// Now: every state-machine transition emits a one-line JSON record on
+// stdout, easy to grep + tail in deploy-quick log capture. Disable via
+// env LOBBY_LOG_DISABLED=1 (smoke runs that prefer silent backend).
+const LOBBY_LOG_DISABLED = process.env.LOBBY_LOG_DISABLED === '1';
+function logLobbyEvent(event, payload = {}) {
+  if (LOBBY_LOG_DISABLED) return;
+  try {
+    console.info(JSON.stringify({ component: 'lobby-service', event, ts: Date.now(), ...payload }));
+  } catch {
+    // log must never break lobby flow.
+  }
+}
+
 const ROOM_CODE_ALPHABET = 'BCDFGHJKLMNPQRSTVWXZ'; // 20 consonants, no vowels, no Y (avoid words)
 const ROOM_CODE_LENGTH = 4;
 const MAX_ROOM_CREATE_RETRIES = 20;
@@ -310,6 +327,7 @@ class Room {
         payload: { player_id: playerId, reason: 'ghost_timeout' },
       });
       this._notifyMutate({ kind: 'player_ghost_removed', playerId });
+      logLobbyEvent('ghost_remove', { code: this.code, player_id: playerId });
     }, this.ghostTimeoutMs);
     timer.unref?.();
     this._ghostTimers.set(playerId, timer);
@@ -706,6 +724,7 @@ class Room {
   }
 
   close(reason = 'host_closed') {
+    if (this.closed) return;
     this.closed = true;
     // Sprint R.4 — clear any pending ghost timers on hard close.
     this._clearAllGhostTimers();
@@ -721,6 +740,11 @@ class Room {
       }
     }
     this._notifyMutate({ kind: 'closed', reason });
+    logLobbyEvent('room_close', {
+      code: this.code,
+      reason,
+      player_count: this.players.size,
+    });
   }
 
   snapshot() {
@@ -831,6 +855,13 @@ class LobbyService {
         .catch(() => {});
     }
     const host = room.getPlayer(hostId);
+    logLobbyEvent('create', {
+      code,
+      host_id: hostId,
+      host_name: hostName,
+      max_players: room.maxPlayers,
+      campaign_id: campaignId,
+    });
     return {
       code,
       host_id: hostId,
@@ -855,6 +886,12 @@ class LobbyService {
       type: 'player_joined',
       payload: { player_id: playerId, name: playerName, role: 'player' },
     });
+    logLobbyEvent('join', {
+      code: normalized,
+      player_id: playerId,
+      player_name: playerName,
+      player_count: room.players.size,
+    });
     return { player_id: playerId, player_token: token, room: room.snapshot() };
   }
 
@@ -873,6 +910,7 @@ class LobbyService {
         .deleteRoomAsync(this.prisma, normalized, { logger: this.logger })
         .catch(() => {});
     }
+    logLobbyEvent('close', { code: normalized, reason: 'host_closed' });
     return { code: normalized, closed: true };
   }
 
@@ -1388,10 +1426,25 @@ function createWsServer({
                 return;
               }
               const allPids = Array.from(room.players.values()).map((p) => p.id);
+              // B-NEW-1 fix 2026-05-08 — connected-only quorum so phone
+              // smoke does not stall when 2nd player WS dropped mid-vote.
+              const connectedPids = Array.from(room.players.values())
+                .filter((p) => p.connected && p.id !== room.hostId && p.role !== 'host')
+                .map((p) => p.id);
               const tally = orch.voteWorld(playerId, {
                 scenarioId: msg.payload?.scenario_id,
                 accept: msg.payload?.choice === 'accept' || msg.payload?.accept === true,
                 allPlayerIds: allPids,
+                connectedPlayerIds: connectedPids,
+              });
+              logLobbyEvent('vote', {
+                code: room.code,
+                player_id: playerId,
+                accept: tally.per_player?.[playerId]?.accept ?? null,
+                accept_count: tally.accept,
+                reject_count: tally.reject,
+                connected_total: tally.connected_total,
+                all_connected_accepted: tally.all_connected_accepted,
               });
               room.broadcast({ type: 'world_tally', payload: tally });
               socket.send(JSON.stringify({ type: 'world_vote_accepted', payload: { tally } }));
@@ -1736,9 +1789,19 @@ function createWsServer({
           if (!promoted) {
             // No eligible candidate; close the room as a fallback so clients
             // stop waiting indefinitely.
+            logLobbyEvent('host_grace_fire_close', {
+              code: room.code,
+              prev_host_id: playerId,
+              reason: 'no_candidate',
+            });
             room.close('host_dropped_no_candidate');
             return;
           }
+          logLobbyEvent('host_grace_fire_transfer', {
+            code: room.code,
+            prev_host_id: playerId,
+            new_host_id: promoted.id,
+          });
           // F-2 2026-04-25 — replay round_ready snapshot to the promoted host
           // (and peers) so combat-phase round state is not lost across host
           // transfer. Without this, a transfer mid-`resolving`/`planning` left

--- a/apps/play/lobby.html
+++ b/apps/play/lobby.html
@@ -75,6 +75,23 @@
         border: 1px solid var(--border);
         border-radius: 12px;
         padding: 22px 22px 24px;
+        transition:
+          opacity 0.25s,
+          border-color 0.25s,
+          box-shadow 0.25s;
+      }
+      /* B-NEW-3 deep-link priority: when ?code=/?room= present, Join card
+         lights up + Create card fades. Reduces orphan-lobby cascade UX. */
+      .card.card-primary {
+        border-color: var(--accent);
+        box-shadow: 0 0 0 2px rgba(79, 195, 247, 0.25);
+      }
+      .card.card-secondary {
+        opacity: 0.55;
+      }
+      .card.card-secondary:hover,
+      .card.card-secondary:focus-within {
+        opacity: 1;
       }
       .card h2 {
         margin: 0 0 14px;

--- a/apps/play/src/lobby.js
+++ b/apps/play/src/lobby.js
@@ -46,6 +46,37 @@ function redirectToGame() {
   window.location.href = './index.html';
 }
 
+async function probeRejoin(session) {
+  // B-NEW-4 fix 2026-05-08 — validate localStorage session via REST before
+  // bouncing to game shell. Pre-fix: phone exit + reopen returned to lobby
+  // home with no rejoin path (game shell WS attempt failed silently).
+  // Post-fix: explicit 200 → safe to redirect; 401/404/410 → clear stale.
+  try {
+    const res = await fetch('/api/lobby/rejoin', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        code: session.code,
+        player_id: session.player_id,
+        player_token: session.token,
+      }),
+    });
+    if (res.ok) return { ok: true };
+    let reason = `HTTP ${res.status}`;
+    try {
+      const data = await res.json();
+      if (data?.error) reason = data.error;
+    } catch {
+      // body not JSON; keep status code
+    }
+    return { ok: false, status: res.status, reason };
+  } catch (err) {
+    // Network failure → keep banner visible so user can retry instead of
+    // silently dropping the session.
+    return { ok: false, status: 0, reason: err?.message || 'network_error', network: true };
+  }
+}
+
 function renderExistingSession() {
   const existing = loadLobbySession();
   const banner = document.getElementById('existing-session');
@@ -53,8 +84,40 @@ function renderExistingSession() {
   document.getElementById('existing-code').textContent = existing.code;
   document.getElementById('existing-role').textContent = existing.role;
   banner.classList.add('visible');
-  document.getElementById('existing-resume').addEventListener('click', () => {
-    redirectToGame();
+  const resumeBtn = document.getElementById('existing-resume');
+  resumeBtn.addEventListener('click', async () => {
+    resumeBtn.disabled = true;
+    const original = resumeBtn.textContent;
+    resumeBtn.textContent = '⏳ Verifico…';
+    const probe = await probeRejoin(existing);
+    if (probe.ok) {
+      redirectToGame();
+      return;
+    }
+    resumeBtn.disabled = false;
+    resumeBtn.textContent = original;
+    if (probe.network) {
+      // Transient network issue: keep session, surface error.
+      const msg = document.createElement('div');
+      msg.className = 'status err';
+      msg.style.marginTop = '8px';
+      msg.textContent = `Errore rete (${probe.reason}). Riprova.`;
+      banner.appendChild(msg);
+      setTimeout(() => msg.remove(), 4000);
+      return;
+    }
+    // Stale session (room closed / token invalid / not found): clear + hide.
+    clearLobbySession();
+    banner.classList.remove('visible');
+    const codeInput = document.getElementById('join-code');
+    if (codeInput && existing.code) {
+      codeInput.value = existing.code;
+    }
+    const status = document.getElementById('status-join');
+    if (status) {
+      status.className = 'status err';
+      status.textContent = `Sessione precedente non più valida (${probe.reason}). Crea o unisciti di nuovo.`;
+    }
   });
   document.getElementById('existing-forget').addEventListener('click', () => {
     clearLobbySession();
@@ -158,15 +221,40 @@ function initJoinForm() {
     if (up !== ev.target.value) ev.target.value = up;
   });
 
-  // Auto-populate code from ?code= URL param (invite link).
+  // Auto-populate code from ?code= or ?room= URL param (invite link).
+  // B-NEW-3 fix 2026-05-08 — accept both `code` (canonical Game/ share)
+  // and `room` (Godot v2 phone share) aliases. Pre-fix: phone deep-link
+  // `?room=XXXX` only filled the input; user still tapped Create CTA by
+  // default → 3 lobby orfane in <5min during friends-online smoke. Now:
+  // when either param present we promote the Join card visually + scroll
+  // it into view + focus the name input so Join is the obvious action.
   try {
     const params = new URLSearchParams(window.location.search);
-    const urlCode = params.get('code');
+    const urlCode = params.get('code') || params.get('room');
     if (urlCode && codeInput) {
-      codeInput.value = urlCode
+      const sanitized = urlCode
         .toUpperCase()
         .replace(/[^A-Z]/g, '')
         .slice(0, 4);
+      codeInput.value = sanitized;
+      const joinCard = form.closest('.card');
+      if (joinCard) {
+        joinCard.classList.add('card-primary');
+        try {
+          joinCard.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        } catch {
+          // older browsers: scrollIntoView() w/o options
+          joinCard.scrollIntoView();
+        }
+      }
+      // De-emphasize Create card so the user does not default-tap it.
+      const createCard = document.getElementById('form-create')?.closest('.card');
+      if (createCard) createCard.classList.add('card-secondary');
+      const status = document.getElementById('status-join');
+      if (status) {
+        status.className = 'status ok';
+        status.textContent = `Codice ${sanitized} pronto. Inserisci il tuo nome ed entra.`;
+      }
       document.getElementById('player-name')?.focus();
     }
   } catch {

--- a/apps/play/src/lobby.js
+++ b/apps/play/src/lobby.js
@@ -61,7 +61,26 @@ async function probeRejoin(session) {
         player_token: session.token,
       }),
     });
-    if (res.ok) return { ok: true };
+    if (res.ok) {
+      // Codex P2 #2133: parse server-canonical role + host_id. Old host
+      // tokens stay valid post host_transfer (TKT-M11B-05 promotes a
+      // player → role moves to candidate, but JWT signature unchanged).
+      // Without this update, a returning ex-host bridge boots `isHost=true`
+      // from stale localStorage and hits host-only UI/API with player
+      // permissions. Caller persists the parsed role pre-redirect.
+      let body = null;
+      try {
+        body = await res.json();
+      } catch {
+        // body absent or non-JSON; ok=true is still trustworthy.
+      }
+      return {
+        ok: true,
+        role: body?.role || null,
+        host_id: body?.room?.host_id || null,
+        campaign_id: body?.room?.campaign_id || null,
+      };
+    }
     let reason = `HTTP ${res.status}`;
     try {
       const data = await res.json();
@@ -91,6 +110,23 @@ function renderExistingSession() {
     resumeBtn.textContent = '⏳ Verifico…';
     const probe = await probeRejoin(existing);
     if (probe.ok) {
+      // Codex P2 #2133: persist server-canonical role/host_id so bridge
+      // boots with current authority (handles host_transfer demotion).
+      const updated = { ...existing };
+      let dirty = false;
+      if (probe.role && probe.role !== existing.role) {
+        updated.role = probe.role;
+        dirty = true;
+      }
+      if (probe.host_id && probe.host_id !== existing.host_id) {
+        updated.host_id = probe.host_id;
+        dirty = true;
+      }
+      if (probe.campaign_id !== null && probe.campaign_id !== existing.campaign_id) {
+        updated.campaign_id = probe.campaign_id;
+        dirty = true;
+      }
+      if (dirty) saveLobbySession(updated);
       redirectToGame();
       return;
     }

--- a/tests/api/coopOrchestrator.test.js
+++ b/tests/api/coopOrchestrator.test.js
@@ -9,6 +9,59 @@ const {
   PHASES,
 } = require('../../apps/backend/services/coop/coopOrchestrator');
 
+// B-NEW-1 fix 2026-05-08 — worldTally now exposes connected-only quorum
+// flags so phone smoke does not stall when a peer drops mid-vote.
+test('worldTally exposes connected-only quorum when connectedPlayerIds passed', () => {
+  const co = new CoopOrchestrator({ roomCode: 'QUOR', hostId: 'p_h' });
+  co.startOnboarding({ scenarioStack: ['enc_demo'] });
+  co._setPhase('world_setup');
+  const allIds = ['p_a', 'p_b'];
+  const connectedIds = ['p_a']; // p_b dropped silently
+  co.voteWorld('p_a', { accept: true, allPlayerIds: allIds, connectedPlayerIds: connectedIds });
+  const tally = co.worldTally(allIds, connectedIds);
+  assert.equal(tally.accept, 1);
+  assert.equal(tally.connected_total, 1);
+  assert.equal(tally.connected_accept, 1);
+  assert.equal(tally.connected_reject, 0);
+  assert.equal(tally.connected_pending, 0);
+  assert.equal(tally.all_connected_accepted, true);
+  // Legacy total/pending unchanged for back-compat callers.
+  assert.equal(tally.total, 2);
+  assert.equal(tally.pending, 1);
+});
+
+test('worldTally all_connected_accepted false when at least one connected reject', () => {
+  const co = new CoopOrchestrator({ roomCode: 'QUOR', hostId: 'p_h' });
+  co.startOnboarding({ scenarioStack: ['enc_demo'] });
+  co._setPhase('world_setup');
+  const allIds = ['p_a', 'p_b'];
+  co.voteWorld('p_a', { accept: true, allPlayerIds: allIds, connectedPlayerIds: allIds });
+  co.voteWorld('p_b', { accept: false, allPlayerIds: allIds, connectedPlayerIds: allIds });
+  const tally = co.worldTally(allIds, allIds);
+  assert.equal(tally.connected_total, 2);
+  assert.equal(tally.connected_accept, 1);
+  assert.equal(tally.connected_reject, 1);
+  assert.equal(tally.all_connected_accepted, false);
+});
+
+test('worldTally all_connected_accepted false when zero connected players', () => {
+  const co = new CoopOrchestrator({ roomCode: 'QUOR', hostId: 'p_h' });
+  co.startOnboarding({ scenarioStack: ['enc_demo'] });
+  co._setPhase('world_setup');
+  const tally = co.worldTally(['p_a'], []);
+  assert.equal(tally.connected_total, 0);
+  assert.equal(tally.all_connected_accepted, false);
+});
+
+test('worldTally back-compat omits connected_* fields when arg missing', () => {
+  const co = new CoopOrchestrator({ roomCode: 'QUOR', hostId: 'p_h' });
+  co.startOnboarding({ scenarioStack: ['enc_demo'] });
+  co._setPhase('world_setup');
+  const tally = co.worldTally(['p_a']);
+  assert.equal(tally.connected_total, undefined);
+  assert.equal(tally.all_connected_accepted, undefined);
+});
+
 test('PHASES covers lobby→onboarding→character_creation→world_setup→combat→debrief→ended', () => {
   // 2026-05-06 narrative onboarding port — `onboarding` inserted between
   // lobby and character_creation per canonical 51-ONBOARDING-60S.md.

--- a/tests/api/lobbyRoutes.test.js
+++ b/tests/api/lobbyRoutes.test.js
@@ -155,3 +155,91 @@ test('GET /api/lobby/list lists open rooms', async () => {
     await close();
   }
 });
+
+// B-NEW-4 fix 2026-05-08 — phone exit + reopen now probes /lobby/rejoin
+// to validate the localStorage session before bouncing to the game shell.
+test('POST /api/lobby/rejoin returns room snapshot for valid host token', async () => {
+  const { app, close } = newApp();
+  try {
+    const create = await request(app)
+      .post('/api/lobby/create')
+      .send({ host_name: 'Alice' })
+      .expect(201);
+    const { code, host_id, host_token } = create.body;
+    const res = await request(app)
+      .post('/api/lobby/rejoin')
+      .send({ code, player_id: host_id, player_token: host_token })
+      .expect(200);
+    assert.equal(res.body.code, code);
+    assert.equal(res.body.player_id, host_id);
+    assert.equal(res.body.role, 'host');
+    assert.equal(res.body.room.code, code);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/lobby/rejoin works for joined player tokens', async () => {
+  const { app, close } = newApp();
+  try {
+    const create = await request(app)
+      .post('/api/lobby/create')
+      .send({ host_name: 'Alice' })
+      .expect(201);
+    const code = create.body.code;
+    const join = await request(app)
+      .post('/api/lobby/join')
+      .send({ code, player_name: 'Bob' })
+      .expect(201);
+    const res = await request(app)
+      .post('/api/lobby/rejoin')
+      .send({ code, player_id: join.body.player_id, player_token: join.body.player_token })
+      .expect(200);
+    assert.equal(res.body.role, 'player');
+    assert.equal(res.body.player_id, join.body.player_id);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/lobby/rejoin 400 on missing fields', async () => {
+  const { app, close } = newApp();
+  try {
+    await request(app).post('/api/lobby/rejoin').send({}).expect(400);
+    await request(app).post('/api/lobby/rejoin').send({ code: 'ABCD' }).expect(400);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/lobby/rejoin 404 on unknown code', async () => {
+  const { app, close } = newApp();
+  try {
+    await request(app)
+      .post('/api/lobby/rejoin')
+      .send({ code: 'ZZZZ', player_id: 'p_x', player_token: 'tok' })
+      .expect(404);
+  } finally {
+    await close();
+  }
+});
+
+test('POST /api/lobby/rejoin 401 on token mismatch', async () => {
+  const { app, close } = newApp();
+  try {
+    const create = await request(app)
+      .post('/api/lobby/create')
+      .send({ host_name: 'Alice' })
+      .expect(201);
+    await request(app)
+      .post('/api/lobby/rejoin')
+      .send({
+        code: create.body.code,
+        player_id: create.body.host_id,
+        player_token: 'WRONG_TOKEN',
+      })
+      .expect(401);
+  } finally {
+    await close();
+  }
+});

--- a/tests/api/lobbyRoutes.test.js
+++ b/tests/api/lobbyRoutes.test.js
@@ -9,7 +9,12 @@ const request = require('supertest');
 const { createApp } = require('../../apps/backend/app');
 
 function newApp() {
-  return createApp({ databasePath: null });
+  const built = createApp({ databasePath: null });
+  // Expose lobby on app.locals for tests that need direct service access
+  // (host_transfer simulation, ghost timers). Routes already receive the
+  // service via DI; this is purely a test ergonomic.
+  built.app.locals.lobby = built.lobby;
+  return built;
 }
 
 test('POST /api/lobby/create returns 4-letter code + host token', async () => {
@@ -219,6 +224,47 @@ test('POST /api/lobby/rejoin 404 on unknown code', async () => {
       .post('/api/lobby/rejoin')
       .send({ code: 'ZZZZ', player_id: 'p_x', player_token: 'tok' })
       .expect(404);
+  } finally {
+    await close();
+  }
+});
+
+// Codex P2 #2133: post host_transfer demotion the old host token still
+// authenticates but the player_role is now `player`. Caller must trust
+// the response role over the local cached one.
+test('POST /api/lobby/rejoin reflects current role after host_transfer demotion', async () => {
+  const { app, close } = newApp();
+  try {
+    const create = await request(app)
+      .post('/api/lobby/create')
+      .send({ host_name: 'Alice' })
+      .expect(201);
+    const code = create.body.code;
+    const join = await request(app)
+      .post('/api/lobby/join')
+      .send({ code, player_name: 'Bob' })
+      .expect(201);
+    // Promote Bob to host (simulates host_transfer fired by grace timer).
+    const {
+      LobbyService: _LobbyService,
+    } = require('../../apps/backend/services/network/wsSession');
+    void _LobbyService; // silence unused-import lint when present.
+    // Reach into app via supertest indirection: call the same global
+    // service used by routes.
+    const lobby = app.locals.lobby;
+    const room = lobby.getRoom(code);
+    room.transferHostTo(join.body.player_id, { reason: 'test_promotion' });
+    // Old host token still authenticates → response now reports role=player.
+    const ex = await request(app)
+      .post('/api/lobby/rejoin')
+      .send({
+        code,
+        player_id: create.body.host_id,
+        player_token: create.body.host_token,
+      })
+      .expect(200);
+    assert.equal(ex.body.role, 'player');
+    assert.equal(ex.body.room.host_id, join.body.player_id);
   } finally {
     await close();
   }


### PR DESCRIPTION
## Summary

Fix bundle 4 bug runtime catturati Day 3/7 friends-online phone smoke (2026-05-08 sera) durante world setup → combat transition con amici online.

| Bug | Sev | Fix |
|---|---|---|
| **B-NEW-4** | P0 | new `POST /api/lobby/rejoin` + lobby.js resume probe |
| **B-NEW-1** | P0 | `worldTally` connected-only quorum (`all_connected_accepted`) |
| **B-NEW-2** | P1 | structured JSON log lobby-service (RCA enabling) |
| **B-NEW-3** | P2 | deep-link `?room=` alias + Join card priority |

## Test plan

- [x] `node --test tests/api/lobbyRoutes.test.js tests/api/coopOrchestrator.test.js tests/api/coopWorldVote.test.js` → 56/56 verde
- [x] Lobby suite full (jwt + onboarding + persistence + websocket) → 97/97 verde
- [x] AI baseline preserved → 383/383 verde
- [x] `prettier --check` su file editati → verde
- [x] Live smoke probe `/api/lobby/rejoin` matrix 200/401/404/400 verificato curl
- [x] Log event captured 4/4 (create/join/room_close/close) deploy-quick equivalent

## Files

- **Backend** (apps/backend/): routes/lobby.js (rejoin endpoint +26 LOC), routes/coop.js (connected quorum wire +12), services/coop/coopOrchestrator.js (worldTally connectedPlayerIds +38), services/network/wsSession.js (structured log + WS quorum wire +63)
- **Frontend** (apps/play/): lobby.html (CSS card-primary/secondary +17), src/lobby.js (rejoin probe + deep-link alias + Join priority +98)
- **Tests**: tests/api/lobbyRoutes.test.js (+5 rejoin scenarios +88), tests/api/coopOrchestrator.test.js (+4 connected quorum scenarios +53)

## Forbidden paths check

- `.github/workflows/` — not touched ✓
- `migrations/` — not touched ✓
- `packages/contracts/` — not touched ✓
- `services/generation/` — not touched ✓
- `services/rules/` — not touched ✓
- Regola 50 righe: `apps/backend/` allowed unlimited; frontend +115 LOC concentrati in lobby UX wire (not new feature)

## Refs

- [docs/playtest/2026-05-08-phone-smoke-results-day3-friends.md](docs/playtest/2026-05-08-phone-smoke-results-day3-friends.md) — bug bundle origin
- Phase A Day 3/7 monitoring impact: phase B trigger gate ≥ 2026-05-15+ pending retry post-merge
- Resume next session: `retry deploy-quick + smoke 4-friends` per validate B-NEW-1+4 + capture combat 5-round p95

🤖 Generated with [Claude Code](https://claude.com/claude-code)