### PR TITLE
fix(coop): idempotent submitCharacter on resubmit (B-NEW-5)

### DIFF
--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -121,7 +121,10 @@ function createCoopRouter({ lobby, coopStore } = {}) {
         { name, form_id, species_id, job_id },
         { allPlayerIds: allPlayerIds(room) },
       );
-      broadcastCoopState(room, orch);
+      // B-NEW-5 fix 2026-05-08 — skip rebroadcast on idempotent resubmit.
+      if (!spec._deduplicated) {
+        broadcastCoopState(room, orch);
+      }
       return res.status(201).json({
         character: spec,
         phase: orch.phase,

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -249,6 +249,33 @@ class CoopOrchestrator {
       ready: true,
       submitted_at: this.now(),
     };
+    // B-NEW-5 fix 2026-05-08 — idempotent submission. Phone smoke iter4
+    // friends-online (lobby XHPV) shipped 19 character_ready emissions in
+    // 175s with last 5 within 700ms: phone composer doesn't lock submit
+    // button post-tap, plus WS reconnect flushes buffered intents → backend
+    // re-emits + re-broadcasts identical state. Pre-fix: every retry rebuilt
+    // the character ledger entry + fired character_ready downstream. Now:
+    // when same player resubmits an equivalent spec (name + form_id +
+    // species_id + job_id + traits identical), reuse the prior submitted_at
+    // and skip the emit/setPhase pass. Returned spec stays consistent so
+    // WS handler sends a fresh `character_create_accepted` ack to the
+    // client without polluting the broadcast bus.
+    const prior = this.characters.get(playerId);
+    const sameSpec =
+      prior &&
+      prior.name === normalized.name &&
+      prior.form_id === normalized.form_id &&
+      prior.species_id === normalized.species_id &&
+      prior.job_id === normalized.job_id &&
+      Array.isArray(prior.traits) &&
+      prior.traits.length === baseTraits.length &&
+      prior.traits.every((t, i) => t === baseTraits[i]);
+    if (sameSpec) {
+      // Surface a non-enumerable marker so WS/REST handlers can skip the
+      // downstream broadcast. JSON-serialized response (REST) won't include
+      // the underscore prefix in any case; ack still fires for client UX.
+      return Object.assign({}, prior, { _deduplicated: true });
+    }
     this.characters.set(playerId, normalized);
     this._emit('character_ready', normalized);
 

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -211,16 +211,9 @@ class CoopOrchestrator {
    * @param allPlayerIds — set of player ids expected to participate
    */
   submitCharacter(playerId, spec, { allPlayerIds = [] } = {}) {
-    if (this.phase !== 'character_creation') {
-      throw new Error('not_in_character_creation');
-    }
     if (!playerId) throw new Error('player_id_required');
     if (!spec || !spec.form_id || !spec.name) {
       throw new Error('spec_invalid');
-    }
-    // F-3 2026-04-25 — reject stale/ghost client with valid token but no longer in room.
-    if (allPlayerIds.length > 0 && !allPlayerIds.includes(playerId)) {
-      throw new Error('player_not_in_room');
     }
     // 2026-05-06 TKT-P3-INNATA-TRAIT-GRANT — apply innata trait from form.
     // Canonical PI-Pacchetti-Forme: ogni Forma assegna 1 trait garantito.
@@ -239,6 +232,41 @@ class CoopOrchestrator {
     } catch {
       // formInnataTrait helper optional — non blocca character submit.
     }
+    // B-NEW-5 fix 2026-05-08 — idempotent submission. Phone smoke iter4
+    // friends-online (lobby XHPV) shipped 19 character_ready emissions in
+    // 175s with last 5 within 700ms: phone composer doesn't lock submit
+    // button post-tap, plus WS reconnect flushes buffered intents → backend
+    // re-emits + re-broadcasts identical state. Now: when same player
+    // resubmits an equivalent spec (name + form_id + species_id + job_id +
+    // traits identical), reuse the prior submitted_at + skip emit/setPhase.
+    //
+    // Codex P2 #2134 follow-up: dedupe runs BEFORE the phase gate so a
+    // retry burst arriving after auto-advance to world_setup (last ready
+    // player edge) still short-circuits to a fresh ACK. Pre-fix the gate
+    // threw not_in_character_creation, surfacing a spurious error toast on
+    // the phone immediately after a successful confirmation.
+    const prior = this.characters.get(playerId);
+    const sameSpec =
+      prior &&
+      prior.name === String(spec.name).slice(0, 30) &&
+      prior.form_id === String(spec.form_id) &&
+      prior.species_id === (spec.species_id ? String(spec.species_id) : null) &&
+      prior.job_id === (spec.job_id ? String(spec.job_id) : 'guerriero') &&
+      Array.isArray(prior.traits) &&
+      prior.traits.length === baseTraits.length &&
+      prior.traits.every((t, i) => t === baseTraits[i]);
+    if (sameSpec) {
+      // Returned object surfaces a `_deduplicated` flag so WS/REST handlers
+      // skip the downstream broadcast. ACK still fires for client UX.
+      return Object.assign({}, prior, { _deduplicated: true });
+    }
+    if (this.phase !== 'character_creation') {
+      throw new Error('not_in_character_creation');
+    }
+    // F-3 2026-04-25 — reject stale/ghost client with valid token but no longer in room.
+    if (allPlayerIds.length > 0 && !allPlayerIds.includes(playerId)) {
+      throw new Error('player_not_in_room');
+    }
     const normalized = {
       player_id: playerId,
       name: String(spec.name).slice(0, 30),
@@ -249,33 +277,6 @@ class CoopOrchestrator {
       ready: true,
       submitted_at: this.now(),
     };
-    // B-NEW-5 fix 2026-05-08 — idempotent submission. Phone smoke iter4
-    // friends-online (lobby XHPV) shipped 19 character_ready emissions in
-    // 175s with last 5 within 700ms: phone composer doesn't lock submit
-    // button post-tap, plus WS reconnect flushes buffered intents → backend
-    // re-emits + re-broadcasts identical state. Pre-fix: every retry rebuilt
-    // the character ledger entry + fired character_ready downstream. Now:
-    // when same player resubmits an equivalent spec (name + form_id +
-    // species_id + job_id + traits identical), reuse the prior submitted_at
-    // and skip the emit/setPhase pass. Returned spec stays consistent so
-    // WS handler sends a fresh `character_create_accepted` ack to the
-    // client without polluting the broadcast bus.
-    const prior = this.characters.get(playerId);
-    const sameSpec =
-      prior &&
-      prior.name === normalized.name &&
-      prior.form_id === normalized.form_id &&
-      prior.species_id === normalized.species_id &&
-      prior.job_id === normalized.job_id &&
-      Array.isArray(prior.traits) &&
-      prior.traits.length === baseTraits.length &&
-      prior.traits.every((t, i) => t === baseTraits[i]);
-    if (sameSpec) {
-      // Surface a non-enumerable marker so WS/REST handlers can skip the
-      // downstream broadcast. JSON-serialized response (REST) won't include
-      // the underscore prefix in any case; ack still fires for client UX.
-      return Object.assign({}, prior, { _deduplicated: true });
-    }
     this.characters.set(playerId, normalized);
     this._emit('character_ready', normalized);
 

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -1389,12 +1389,18 @@ function createWsServer({
                 },
                 { allPlayerIds: allPids },
               );
-              room.broadcast({
-                type: 'character_ready_list',
-                payload: orch.characterReadyList(allPids),
-              });
-              if (orch.phase === 'world_setup') {
-                room.publishPhaseChange('world_setup');
+              // B-NEW-5 fix 2026-05-08 — skip downstream broadcast on
+              // idempotent resubmit (phone retry burst / WS reconnect
+              // intent flush). Ack still fires so the client gets visual
+              // confirmation per tap, but ready-list bus stays quiet.
+              if (!spec._deduplicated) {
+                room.broadcast({
+                  type: 'character_ready_list',
+                  payload: orch.characterReadyList(allPids),
+                });
+                if (orch.phase === 'world_setup') {
+                  room.publishPhaseChange('world_setup');
+                }
               }
               socket.send(
                 JSON.stringify({

--- a/tests/api/coopOrchestrator.test.js
+++ b/tests/api/coopOrchestrator.test.js
@@ -35,6 +35,50 @@ test('submitCharacter idempotent on identical spec (no re-emit, reuse prior)', (
   assert.equal(first._deduplicated, undefined);
 });
 
+// Codex P2 #2134: dedupe must run BEFORE phase gate. Last ready player
+// retry burst arrives after auto-advance to world_setup → pre-fix threw
+// not_in_character_creation → phone shows spurious error toast post-success.
+test('submitCharacter idempotent dedupe runs after phase advance to world_setup', () => {
+  const co = new CoopOrchestrator({ roomCode: 'IDMP', hostId: 'p_h' });
+  co.startOnboarding({ scenarioStack: ['enc_demo'] });
+  co._setPhase('character_creation');
+  const events = [];
+  co.on((evt) => {
+    if (evt.kind === 'character_ready') events.push(evt.payload);
+  });
+  const spec = {
+    name: 'Solo',
+    form_id: 'form_solo',
+    species_id: 's_solo',
+    job_id: 'guerriero',
+  };
+  // Single-player roster: first submit auto-advances to world_setup.
+  const first = co.submitCharacter('p_solo', spec, { allPlayerIds: ['p_solo'] });
+  assert.equal(co.phase, 'world_setup');
+  // Retry of identical spec post auto-advance must dedupe, NOT throw.
+  const second = co.submitCharacter('p_solo', spec, { allPlayerIds: ['p_solo'] });
+  assert.equal(second._deduplicated, true);
+  assert.equal(second.submitted_at, first.submitted_at);
+  // Only 1 event emitted total.
+  assert.equal(events.length, 1);
+});
+
+test('submitCharacter throws not_in_character_creation only when no prior + wrong phase', () => {
+  const co = new CoopOrchestrator({ roomCode: 'IDMP', hostId: 'p_h' });
+  co.startOnboarding({ scenarioStack: ['enc_demo'] });
+  co._setPhase('world_setup');
+  // Fresh player, no prior submission, wrong phase → throw.
+  assert.throws(
+    () =>
+      co.submitCharacter(
+        'p_new',
+        { name: 'A', form_id: 'f', species_id: 's', job_id: 'guerriero' },
+        { allPlayerIds: ['p_new'] },
+      ),
+    /not_in_character_creation/,
+  );
+});
+
 test('submitCharacter re-emits when spec changes (name swap)', () => {
   const co = new CoopOrchestrator({ roomCode: 'IDMP', hostId: 'p_h' });
   co.startOnboarding({ scenarioStack: ['enc_demo'] });

--- a/tests/api/coopOrchestrator.test.js
+++ b/tests/api/coopOrchestrator.test.js
@@ -9,6 +9,54 @@ const {
   PHASES,
 } = require('../../apps/backend/services/coop/coopOrchestrator');
 
+// B-NEW-5 fix 2026-05-08 — idempotent submitCharacter so phone retry +
+// WS reconnect flush does not flood character_ready emissions (lobby
+// XHPV shipped 19 events in 175s, 5 within 700ms).
+test('submitCharacter idempotent on identical spec (no re-emit, reuse prior)', () => {
+  const co = new CoopOrchestrator({ roomCode: 'IDMP', hostId: 'p_h' });
+  co.startOnboarding({ scenarioStack: ['enc_demo'] });
+  co._setPhase('character_creation');
+  const events = [];
+  co.on((evt) => {
+    if (evt.kind === 'character_ready') events.push(evt.payload);
+  });
+  const spec = {
+    name: 'Liev',
+    form_id: 'form_umbra_alaris',
+    species_id: 'umbra_alaris',
+    job_id: 'custode',
+  };
+  const first = co.submitCharacter('p_h', spec, { allPlayerIds: ['p_h', 'p_a'] });
+  const second = co.submitCharacter('p_h', spec, { allPlayerIds: ['p_h', 'p_a'] });
+  // 2nd call returns the SAME submitted_at (prior reused); no fresh emit.
+  assert.equal(events.length, 1);
+  assert.equal(second.submitted_at, first.submitted_at);
+  assert.equal(second._deduplicated, true);
+  assert.equal(first._deduplicated, undefined);
+});
+
+test('submitCharacter re-emits when spec changes (name swap)', () => {
+  const co = new CoopOrchestrator({ roomCode: 'IDMP', hostId: 'p_h' });
+  co.startOnboarding({ scenarioStack: ['enc_demo'] });
+  co._setPhase('character_creation');
+  const events = [];
+  co.on((evt) => {
+    if (evt.kind === 'character_ready') events.push(evt.payload);
+  });
+  co.submitCharacter(
+    'p_h',
+    { name: 'Liev', form_id: 'form_a', species_id: 's_a', job_id: 'guerriero' },
+    { allPlayerIds: ['p_h', 'p_b'] },
+  );
+  co.submitCharacter(
+    'p_h',
+    { name: 'Renamed', form_id: 'form_a', species_id: 's_a', job_id: 'guerriero' },
+    { allPlayerIds: ['p_h', 'p_b'] },
+  );
+  assert.equal(events.length, 2);
+  assert.equal(events[1].name, 'Renamed');
+});
+
 // B-NEW-1 fix 2026-05-08 — worldTally now exposes connected-only quorum
 // flags so phone smoke does not stall when a peer drops mid-vote.
 test('worldTally exposes connected-only quorum when connectedPlayerIds passed', () => {


### PR DESCRIPTION
## Summary

Phone smoke iter4 friends-online 2026-05-08 sera (lobby XHPV) caught host \`character_ready\` resubmit loop: **19 emissioni in 175s**, last 5 within 700ms. Phone composer (Godot v2) doesn't lock submit button post-tap; WS reconnect flushes buffered intents → backend re-emits + re-broadcasts identical state.

Master-dd quote: _"bug su conferma personaggio per host"_.

## Fix

**Server-side idempotency** in \`coopOrchestrator.submitCharacter\`:
- Compare spec (name + form_id + species_id + job_id + traits) against \`characters.get(playerId)\`
- Match → return prior with non-enumerable \`_deduplicated\` flag, no \`character_ready\` emit
- Mismatch → normal flow + emit + auto-advance check

**Caller skip-broadcast** when \`_deduplicated\`:
- WS \`character_create\` handler: skip \`character_ready_list\` broadcast + phase advance
- REST \`/coop/character/create\`: skip \`broadcastCoopState\`
- Both still send ACK (\`character_accepted\` WS / 201 REST) so phone gets visual feedback per tap

## Verify

- [x] \`node --test tests/api/coopOrchestrator.test.js\` 39/39 verde (incl. +2 idempotent tests)
- [x] Bundle 100/100 lobby + coop suite verde
- [x] Prettier verde
- [x] **Live runtime probe** via Cloudflare tunnel (\`bathrooms-creates-invision-educational\`):
  - 5 identical \`character_create\` WS intents → 1 broadcast (was 5 pre-fix), 5 acks
  - Name change → +1 broadcast (correctly re-emits)

## Forbidden paths

- \`.github/workflows/\` ✓ — \`migrations/\` ✓ — \`packages/contracts/\` ✓ — \`services/generation/\` ✓ — \`services/rules/\` ✓
- Regola 50: backend allowed unlimited (concentrato \`apps/backend/\`)

## Follow-up Godot v2 (separate cycle)

\`scripts/phone/phone_composer_view.gd\` \`_on_character_submit_pressed\`: disable submit button after first tap + listen \`character_ready_list\` for self.ready → swap MODE to WAITING. Defense in depth on top of server idempotency.

## Refs

- Bug bundle origin: phone smoke iter4 friends-online (post-#2133 retry deploy-quick)
- Previous bundle: [PR #2133](https://github.com/MasterDD-L34D/Game/pull/2133) B-NEW-1+B-NEW-4 (rejoin + connected quorum + log + deep-link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)