### PR TITLE
fix(lobby): orch phase sync + rejoin 410 (B-NEW-1-bis + B-NEW-4-bis, smoke iter4)

### DIFF
--- a/apps/backend/routes/lobby.js
+++ b/apps/backend/routes/lobby.js
@@ -78,7 +78,16 @@ function createLobbyRouter({ lobby } = {}) {
       return res.status(400).json({ error: 'code + player_id + player_token richiesti' });
     }
     const room = lobby.getRoom(code);
-    if (!room) return res.status(404).json({ error: 'room_not_found' });
+    if (!room) {
+      // B-NEW-4-bis: distinguish "never existed" from "recently closed".
+      // closeRoom drops the room from the live registry but retains the
+      // code in `_recentlyClosed` for RECENTLY_CLOSED_TTL_MS, so the
+      // returning phone gets 410 (session ended) instead of 404 (typo).
+      if (lobby.wasRecentlyClosed?.(code)) {
+        return res.status(410).json({ error: 'room_closed' });
+      }
+      return res.status(404).json({ error: 'room_not_found' });
+    }
     if (room.closed) return res.status(410).json({ error: 'room_closed' });
     const player = room.authenticate?.(playerId, playerToken);
     if (!player) return res.status(401).json({ error: 'auth_failed' });

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -102,6 +102,10 @@ const KNOWN_PHASES = new Set([
 // (keeps M11 Phase A semantics — players linger forever). Host path
 // is unchanged (existing host_transfer_grace_ms drives host promotion).
 const DEFAULT_GHOST_TIMEOUT_MS = 120_000;
+// B-NEW-4-bis: window during which a closed room code maps to HTTP 410
+// (Gone) on /lobby/rejoin instead of 404 (Not Found). 5 minutes covers
+// typical "phone backgrounded → user reopens" recovery.
+const RECENTLY_CLOSED_TTL_MS = 300_000;
 
 function generateRoomCode() {
   let out = '';
@@ -777,6 +781,16 @@ class LobbyService {
     persistence = null,
   } = {}) {
     this.rooms = new Map(); // code → Room
+    // B-NEW-4-bis fix 2026-05-08 (agent-driven smoke iter4) — TTL Set
+    // tracking recently-closed room codes so /api/lobby/rejoin can return
+    // 410 (room_closed) instead of 404 (room_not_found). Pre-fix: closeRoom
+    // dropped the entry from `rooms`, so a phone that exits + reopens
+    // mid-session got "room_not_found" + cleared its localStorage even
+    // though the canonical reason was "room closed by host". UX wise the
+    // distinction matters: 404 means "room never existed" → user creates
+    // new lobby; 410 means "session ended cleanly" → user goes home.
+    // Entries auto-expire after RECENTLY_CLOSED_TTL_MS.
+    this._recentlyClosed = new Map(); // code → expiry_ts
     this.maxPlayers = maxPlayers;
     this.prisma = prisma;
     this.logger = logger || console;
@@ -905,6 +919,7 @@ class LobbyService {
     }
     room.close();
     this.rooms.delete(normalized);
+    this._recentlyClosed.set(normalized, Date.now() + RECENTLY_CLOSED_TTL_MS);
     if (this._persistEnabled) {
       this._persistence
         .deleteRoomAsync(this.prisma, normalized, { logger: this.logger })
@@ -912,6 +927,22 @@ class LobbyService {
     }
     logLobbyEvent('close', { code: normalized, reason: 'host_closed' });
     return { code: normalized, closed: true };
+  }
+
+  /**
+   * B-NEW-4-bis: was this code closed within the recently-closed TTL?
+   * Used by /api/lobby/rejoin to disambiguate 404 vs 410.
+   */
+  wasRecentlyClosed(code) {
+    if (!code) return false;
+    const normalized = String(code).toUpperCase();
+    const expiry = this._recentlyClosed.get(normalized);
+    if (!expiry) return false;
+    if (Date.now() > expiry) {
+      this._recentlyClosed.delete(normalized);
+      return false;
+    }
+    return true;
   }
 
   getRoom(code) {
@@ -1716,6 +1747,32 @@ function createWsServer({
                   // Non-fatal — log and continue. Character submit will
                   // surface error if orch unhealthy.
                   console.warn('[ws] coop bootstrap failed:', err.message);
+                }
+              }
+              // B-NEW-1-bis fix 2026-05-08 (agent-driven smoke iter4) —
+              // phone host advancing manually via `phase=world_setup` WS
+              // intent updated `room.phase` but NEVER `orch.phase`.
+              // Subsequent `world_vote` intents threw `not_in_world_setup`
+              // and surfaced as no-op taps on the phone (no error toast on
+              // Godot composer). Sync orch phase so the connected-only
+              // quorum logic shipped in #2133 actually runs. Same pattern
+              // for combat / debrief / ended for symmetry — manual phase
+              // override on host phone keeps the orch state machine in
+              // sync. world_seed_reveal stays UI-only (transient).
+              if (
+                coopStore &&
+                (phaseArg === 'world_setup' ||
+                  phaseArg === 'combat' ||
+                  phaseArg === 'debrief' ||
+                  phaseArg === 'ended')
+              ) {
+                try {
+                  const orch = coopStore.get(room.code);
+                  if (orch && orch.phase !== phaseArg) {
+                    orch._setPhase(phaseArg);
+                  }
+                } catch (err) {
+                  console.warn(`[ws] orch phase sync to ${phaseArg} failed:`, err && err.message);
                 }
               }
               // 2026-05-06 narrative onboarding port — bootstrap orch in

--- a/docs/playtest/2026-05-08-agent-driven-smoke-comparison.md
+++ b/docs/playtest/2026-05-08-agent-driven-smoke-comparison.md
@@ -1,0 +1,160 @@
+---
+title: 'Agent-driven smoke iter4 — Godot phone vs web v1 comparison 2026-05-08'
+doc_status: active
+doc_owner: master-dd
+workstream: ops-qa
+last_verified: 2026-05-08
+source_of_truth: false
+language: it
+review_cycle_days: 14
+related:
+  - docs/playtest/AGENT_DRIVEN_WORKFLOW.md
+  - docs/playtest/2026-05-07-phone-smoke-bundle-rca.md
+  - docs/playtest/2026-05-08-phone-smoke-day3-friends-online.md
+tags: [playtest, smoke, comparison, godot-phone, web-v1, b-new, iter4]
+---
+
+# Agent-driven smoke iter4 — Godot phone vs web v1 (2026-05-08)
+
+**Tunnel**: `https://circumstances-lat-status-summary.trycloudflare.com`
+**Backend HEAD**: `67f8dfd8` (post B-NEW bundle iter4)
+**Dist mtime**: May 8 20:23 — FRESH
+**Harness**: Chrome MCP NOT CONNECTED → Pattern B Playwright multi-context + REST/WS Node forensic
+
+---
+
+## 1. Executive summary
+
+- 14/16 Playwright phone smoke tests PASS (39.8s). Regressions B5+B7+B8+B9+B10 all green.
+- B5 (phaseChangeBroadcast.test.js): 6/6 PASS. B2/Airplane (airplaneReconnect.test.js): 5/5 PASS.
+- **B-NEW-5-bis (BUG)**: `POST /api/lobby/character` returns 404 — endpoint never existed in lobby.js. B-NEW-5 fix (idempotent submitCharacter) is WS-only via `intent.action=character_create`; no REST surface. No regression, but REST smoke surfaces the gap.
+- **B-NEW-1-bis (BUG P1)**: `coopOrchestrator.phase` is NOT advanced to `world_setup` when host sends WS `phase=world_setup` directly (without all players submitting characters). `voteWorld` throws `not_in_world_setup`. Connected-only quorum code (B-NEW-1 fix) is unreachable in minimal phone smoke flow. Day 3 friends online P0 world vote stuck is PARTIALLY fixed — full quorum path blocked by orch phase sync gap.
+- **B-NEW-4-bis (P2)**: `/api/lobby/rejoin` returns 404 instead of 410 for closed rooms (room deleted from registry on close, not marked closed). Client cannot distinguish "never existed" from "was closed". Minor UX clarity issue.
+- Canvas visual render test (canvas-visual.spec.ts:42) FAIL: Godot splash renders canvas with non-zero dimensions but pixel content is all-black post-20s load via headless Playwright (no GPU). Known headless limitation — not a runtime bug.
+- WS RTT p95 FAIL: p95=478ms via tunnel (threshold 200ms). Cloudflare tunnel WAN overhead expected; server-local baseline < 5ms per prior session. Not a regression.
+
+---
+
+## 2. Bug nuovi catturati
+
+### B-NEW-1-bis (P1) — coopOrchestrator phase sync gap: world_vote unreachable in minimal phone flow
+
+**Symptom**: Player sends `intent.action=world_vote` in world_setup phase → server returns `error: not_in_world_setup`.
+
+**Root cause**: `wsSession.js` WS `phase` handler only bootstraps coopOrchestrator on `character_creation` (line 1709) and `onboarding` (line 1724). When host sends `phase=world_setup` directly, `room.publishPhaseChange('world_setup')` is called but `coopOrchestrator._setPhase('world_setup')` is NEVER called. The orch stays at `character_creation`. `voteWorld` (line 354) throws `not_in_world_setup` before reaching B-NEW-1 connected-only quorum code.
+
+**File:line**: `apps/backend/services/network/wsSession.js:1709` (missing `world_setup` bootstrap branch)
+
+**Repro**:
+
+1. Create room + join via WS
+2. Host sends `{type:'phase', payload:{phase:'character_creation'}}` → orch bootstrapped
+3. Host sends `{type:'phase', payload:{phase:'world_setup'}}` → room phase updated but orch.phase remains `character_creation`
+4. Player sends `{type:'intent', payload:{action:'world_vote', choice:'accept'}}` → server error `not_in_world_setup`
+
+**Fix path**:
+
+```js
+// wsSession.js ~line 1720, after character_creation bootstrap block:
+if (phaseArg === 'world_setup' && coopStore) {
+  try {
+    const orch = coopStore.get(room.code);
+    if (orch && orch.phase === 'character_creation') {
+      orch._setPhase('world_setup'); // or orch.forceAdvanceToWorldSetup() if exposed
+    }
+  } catch (err) {
+    console.warn('[ws] world_setup phase sync failed:', err.message);
+  }
+}
+```
+
+Alternatively expose `advanceToWorldSetup()` on coopOrchestrator (mirrors `forceAdvanceToWorldSetup` at line 639).
+
+**Test lock**: `tests/api/phaseChangeBroadcast.test.js` — add B5-7 test: `host phase=world_setup → player world_vote → world_tally received`.
+
+---
+
+### B-NEW-4-bis (P2) — rejoin closed room returns 404 not 410
+
+**Symptom**: `POST /api/lobby/rejoin` with valid (but closed) room code returns HTTP 404 instead of 410 Gone.
+
+**Root cause**: `wsSession.js:907` `closeRoom` calls `this.rooms.delete(normalized)` — room fully removed from registry. `getRoom` after close returns null → `lobby.js:81` returns 404. Phone client cannot distinguish "room code typo / never existed" from "room was closed, my session is stale".
+
+**File:line**: `apps/backend/services/network/wsSession.js:907`, `apps/backend/routes/lobby.js:81`
+
+**Fix path option A** (preferred): Keep closed rooms in registry for 5 minutes with `closed=true` flag. `closeRoom` sets `room.closed = true`, starts a 5-min GC timer, THEN deletes. `getRoom` returns null after GC.
+
+**Fix path option B**: Store closed room codes in a `closedRoomCodes: Set` on LobbyService; `rejoin` checks set before 404 → returns 410.
+
+**Impact**: Low — only affects UX of phone resume flow. Functional correctness not broken.
+
+---
+
+### B-NEW-5-bis (P2) — `POST /api/lobby/character` endpoint missing
+
+**Symptom**: `POST /api/lobby/character` returns Express 404 "Cannot POST".
+
+**Root cause**: There is no REST `/api/lobby/character` endpoint. `submitCharacter` is WS-only via `intent.action=character_create`. `lobby.js` only exposes create/join/rejoin/close/state/list. Not a B-NEW-5 regression (B-NEW-5 is WS idempotent logic), but signals no REST probe surface for character submission.
+
+**Impact**: Informational — no REST smoke coverage for character_create path. Accepted gap (WS-only path by design).
+
+---
+
+## 3. Surface comparison matrix — Godot phone vs web v1
+
+| Pillar                   | Phase                                                           | Godot phone                                              | Web v1                                          | Gap                                      |
+| ------------------------ | --------------------------------------------------------------- | -------------------------------------------------------- | ----------------------------------------------- | ---------------------------------------- |
+| P1 Telemetry HUD p95     | combat                                                          | GAP-1 SHIPPED (#204) — debug label in HudView            | No equivalent                                   | Godot AHEAD                              |
+| P2 ThoughtsRitual        | debrief                                                         | GAP-9 SHIPPED (#203) — LegacyRitualPanel instanced       | No equivalent                                   | Godot AHEAD                              |
+| P3 form_pulse axes       | character_creation                                              | W4 intent drain server-side; phone_composer_view.gd wire | No equivalent                                   | Godot AHEAD                              |
+| P4 Ennea debrief 9-canon | debrief                                                         | GAP-2 SHIPPED (#203) — debrief_view top archetype        | No equivalent                                   | Godot AHEAD                              |
+| P5 share screen / lobby  | lobby                                                           | Share screen overlay + deep-link CTA (B1 fix, #169)      | lobby.html full DOM — create/join forms visible | Web v1 richer DOM UX; Godot phone canvas |
+| P5 WS phase broadcast    | lobby→combat                                                    | 14/16 Playwright PASS, B5+B8+B9+B10 fixed                | Same backend shared                             | PARITY                                   |
+| P6 WoundState badge      | combat                                                          | GAP-4 SHIPPED (#204) — unit_info_panel severity          | vcScoring JS computes wound; no UI surface      | Godot AHEAD                              |
+| state machine phases     | lobby→onboarding→char_creation→world_setup→combat→debrief→ended | All phases reachable via WS (Playwright confirmed)       | All phases reachable via WS                     | PARITY                                   |
+| canvas render (headless) | all                                                             | All-black via headless Playwright (GPU-less)             | N/A (DOM-based)                                 | Known headless gap                       |
+| WS RTT p95 (tunnel)      | combat                                                          | 478ms p95 via Cloudflare tunnel                          | Same backend                                    | Tunnel overhead expected                 |
+
+---
+
+## 4. Phase coverage map
+
+| Phase              | Godot phone rendered?                                 | Functional?                                             | Notes                                                    |
+| ------------------ | ----------------------------------------------------- | ------------------------------------------------------- | -------------------------------------------------------- |
+| lobby              | Canvas yes (non-zero dims confirmed)                  | YES — create/join REST verified                         | Share screen overlay available                           |
+| onboarding         | GDScript phone_onboarding_view.gd ported (#193)       | YES (Playwright B5+B8 path)                             | campaign YAML broadcast                                  |
+| character_creation | phone composer mode swap verified B8                  | YES — intent.action=character_create drains server-side | B-NEW-1-bis: world_vote unreachable if direct phase skip |
+| world_setup        | Phase change broadcast verified                       | PARTIAL — world_vote blocked by orch phase sync gap     | B-NEW-1-bis P1 fix needed                                |
+| combat             | 5R p95 harness (#202), combat→debrief Playwright PASS | YES                                                     | Telemetry HUD + WoundState badge live (GAP-1+GAP-4)      |
+| debrief            | combat→debrief→ended e2e Playwright PASS              | YES — ThoughtsRitual + Ennea 9-canon live               | GAP-2 + GAP-9 shipped                                    |
+| ended              | next_macro retreat closes run (Playwright PASS)       | YES                                                     |                                                          |
+
+---
+
+## 5. Top 3 priority fixes
+
+### Fix 1 (P1) — B-NEW-1-bis: coopOrchestrator world_setup phase sync
+
+`apps/backend/services/network/wsSession.js` ~line 1720: add `world_setup` bootstrap branch identical to `character_creation` pattern. Advance `orch._setPhase('world_setup')` (or expose `advanceToWorldSetup()`) when host sends `phase=world_setup` WS intent. Unblocks B-NEW-1 connected-only quorum — the Day 3 P0 world vote stuck is only half-fixed.
+
+Effort: ~30min. Test lock: `phaseChangeBroadcast.test.js` B5-7 addition.
+
+### Fix 2 (P2) — B-NEW-4-bis: rejoin closed room 410 semantic
+
+`apps/backend/services/network/wsSession.js`: LobbyService `closeRoom` stores closed room code in a `this._closedCodes: Set<string>` for 5min TTL. `getRoom` still returns null (GC), but `rejoin` route checks `_closedCodes.has(code)` → 410 before 404 path. Phone resume flow gets clear "room closed, clear session" signal vs "room not found, try again".
+
+Effort: ~30min. No test regression expected.
+
+### Fix 3 (informational) — Canvas smoke gate: skip GPU-less assertion in CI
+
+`tools/ts/tests/playwright/phone/canvas-visual.spec.ts:66`: gate `expect(nonEmpty).toBeGreaterThan(8)` with `test.skip(process.env.CI === 'true', 'Godot canvas GPU-less = all-black in headless CI')`. Reduces noise from known headless limitation. Alternatively set `emptyThreshold: 250` (near-white check) to detect truly broken canvas vs black-because-GPU-absent.
+
+Effort: ~10min.
+
+---
+
+## Harness verdict
+
+14/16 PASS. 2 failures = known external causes (headless GPU + tunnel WAN RTT). 0 regressions from B5/B7/B8/B9/B10 bundle. 1 new P1 bug (B-NEW-1-bis orch phase sync) + 1 P2 (B-NEW-4-bis 404 vs 410). Screenshots not captured (Chrome MCP unavailable; Playwright traces at `tools/ts/test-results/`).
+
+**Chrome MCP blocker**: extension not connected at session start. To retry with full visual screenshot coverage: ensure Chrome extension signed in + active, then re-run this agent.

--- a/tests/api/lobbyRoutes.test.js
+++ b/tests/api/lobbyRoutes.test.js
@@ -217,6 +217,28 @@ test('POST /api/lobby/rejoin 400 on missing fields', async () => {
   }
 });
 
+// B-NEW-4-bis fix 2026-05-08 (agent-driven smoke iter4) — distinguish
+// 404 (never existed) from 410 (recently closed) on the rejoin path.
+test('POST /api/lobby/rejoin 410 on room closed within TTL window', async () => {
+  const { app, close } = newApp();
+  try {
+    const create = await request(app)
+      .post('/api/lobby/create')
+      .send({ host_name: 'Alice' })
+      .expect(201);
+    const { code, host_id, host_token } = create.body;
+    // Close the room → removes from live registry, marks recently_closed.
+    await request(app).post('/api/lobby/close').send({ code, host_token }).expect(200);
+    const res = await request(app)
+      .post('/api/lobby/rejoin')
+      .send({ code, player_id: host_id, player_token: host_token })
+      .expect(410);
+    assert.equal(res.body.error, 'room_closed');
+  } finally {
+    await close();
+  }
+});
+
 test('POST /api/lobby/rejoin 404 on unknown code', async () => {
   const { app, close } = newApp();
   try {


### PR DESCRIPTION
## Summary

Phone-smoke-bot agent run 2026-05-08 sera (post-#2134 retry) caught 2 bugs the original B-NEW bundle did NOT cover.

| Bug | Sev | Original gap |
|---|---|---|
| **B-NEW-1-bis** | P1 | #2133 connected quorum logic UNREACHABLE — orch never enters `world_setup` via WS path |
| **B-NEW-4-bis** | P2 | `/lobby/rejoin` returned 404 (vs 410) on closed room — phone cleared localStorage on session-end |

## Fix

### B-NEW-1-bis
- WS `phase` intent: extend orch sync to `world_setup` / `combat` / `debrief` / `ended`. Pre-fix only `character_creation` + `onboarding` synced.
- Without sync: `room.phase` drifted from `orch.phase` → `world_vote` threw `not_in_world_setup` (phone composer silent on WS errors → no-op taps reported originally).

### B-NEW-4-bis
- `LobbyService` TTL `Map _recentlyClosed` (5 min) tracks closed codes
- `wasRecentlyClosed(code)` public method
- `/lobby/rejoin` checks before 404 → returns 410 with `error: room_closed`

## Verify

- [x] `node --test tests/api/{lobbyRoutes,coopOrchestrator,coopWorldVote,lobbyWebSocket,lobbyOnboarding}.test.{js,mjs}` → 80/80 verde
- [x] Prettier verde
- [x] **Live tunnel probe** `dogs-schools-theatre-license`:
  - rejoin closed → HTTP 410 \`room_closed\`, truly unknown → HTTP 404
  - WS phase=world_setup → orch.phase synced
  - world_vote post-sync → ACK + tally connected_total=1 + all_connected_accepted=true. Zero `not_in_world_setup`.

## Forbidden paths

- \`.github/workflows/\` ✓ — \`migrations/\` ✓ — \`packages/contracts/\` ✓ — \`services/generation/\` ✓ — \`services/rules/\` ✓
- Regola 50: backend allowed unlimited

## Refs

- Bundle origin: phone-smoke-bot agent comparison report at \`docs/playtest/2026-05-08-agent-driven-smoke-comparison.md\` (Pattern B Playwright multi-context + REST/WS forensic; Chrome MCP non disponibile)
- Previous bundle: [#2133](https://github.com/MasterDD-L34D/Game/pull/2133) + [#2134](https://github.com/MasterDD-L34D/Game/pull/2134)

🤖 Generated with [Claude Code](https://claude.com/claude-code)