### PR TITLE
docs(playtest): browser smoke iter5 Chrome MCP report (7 nuovi bug)

### DIFF
--- a/apps/backend/routes/lobby.js
+++ b/apps/backend/routes/lobby.js
@@ -78,7 +78,16 @@ function createLobbyRouter({ lobby } = {}) {
       return res.status(400).json({ error: 'code + player_id + player_token richiesti' });
     }
     const room = lobby.getRoom(code);
-    if (!room) return res.status(404).json({ error: 'room_not_found' });
+    if (!room) {
+      // B-NEW-4-bis: distinguish "never existed" from "recently closed".
+      // closeRoom drops the room from the live registry but retains the
+      // code in `_recentlyClosed` for RECENTLY_CLOSED_TTL_MS, so the
+      // returning phone gets 410 (session ended) instead of 404 (typo).
+      if (lobby.wasRecentlyClosed?.(code)) {
+        return res.status(410).json({ error: 'room_closed' });
+      }
+      return res.status(404).json({ error: 'room_not_found' });
+    }
     if (room.closed) return res.status(410).json({ error: 'room_closed' });
     const player = room.authenticate?.(playerId, playerToken);
     if (!player) return res.status(401).json({ error: 'auth_failed' });

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -102,6 +102,10 @@ const KNOWN_PHASES = new Set([
 // (keeps M11 Phase A semantics — players linger forever). Host path
 // is unchanged (existing host_transfer_grace_ms drives host promotion).
 const DEFAULT_GHOST_TIMEOUT_MS = 120_000;
+// B-NEW-4-bis: window during which a closed room code maps to HTTP 410
+// (Gone) on /lobby/rejoin instead of 404 (Not Found). 5 minutes covers
+// typical "phone backgrounded → user reopens" recovery.
+const RECENTLY_CLOSED_TTL_MS = 300_000;
 
 function generateRoomCode() {
   let out = '';
@@ -777,6 +781,16 @@ class LobbyService {
     persistence = null,
   } = {}) {
     this.rooms = new Map(); // code → Room
+    // B-NEW-4-bis fix 2026-05-08 (agent-driven smoke iter4) — TTL Set
+    // tracking recently-closed room codes so /api/lobby/rejoin can return
+    // 410 (room_closed) instead of 404 (room_not_found). Pre-fix: closeRoom
+    // dropped the entry from `rooms`, so a phone that exits + reopens
+    // mid-session got "room_not_found" + cleared its localStorage even
+    // though the canonical reason was "room closed by host". UX wise the
+    // distinction matters: 404 means "room never existed" → user creates
+    // new lobby; 410 means "session ended cleanly" → user goes home.
+    // Entries auto-expire after RECENTLY_CLOSED_TTL_MS.
+    this._recentlyClosed = new Map(); // code → expiry_ts
     this.maxPlayers = maxPlayers;
     this.prisma = prisma;
     this.logger = logger || console;
@@ -905,6 +919,7 @@ class LobbyService {
     }
     room.close();
     this.rooms.delete(normalized);
+    this._recentlyClosed.set(normalized, Date.now() + RECENTLY_CLOSED_TTL_MS);
     if (this._persistEnabled) {
       this._persistence
         .deleteRoomAsync(this.prisma, normalized, { logger: this.logger })
@@ -912,6 +927,22 @@ class LobbyService {
     }
     logLobbyEvent('close', { code: normalized, reason: 'host_closed' });
     return { code: normalized, closed: true };
+  }
+
+  /**
+   * B-NEW-4-bis: was this code closed within the recently-closed TTL?
+   * Used by /api/lobby/rejoin to disambiguate 404 vs 410.
+   */
+  wasRecentlyClosed(code) {
+    if (!code) return false;
+    const normalized = String(code).toUpperCase();
+    const expiry = this._recentlyClosed.get(normalized);
+    if (!expiry) return false;
+    if (Date.now() > expiry) {
+      this._recentlyClosed.delete(normalized);
+      return false;
+    }
+    return true;
   }
 
   getRoom(code) {
@@ -1716,6 +1747,32 @@ function createWsServer({
                   // Non-fatal — log and continue. Character submit will
                   // surface error if orch unhealthy.
                   console.warn('[ws] coop bootstrap failed:', err.message);
+                }
+              }
+              // B-NEW-1-bis fix 2026-05-08 (agent-driven smoke iter4) —
+              // phone host advancing manually via `phase=world_setup` WS
+              // intent updated `room.phase` but NEVER `orch.phase`.
+              // Subsequent `world_vote` intents threw `not_in_world_setup`
+              // and surfaced as no-op taps on the phone (no error toast on
+              // Godot composer). Sync orch phase so the connected-only
+              // quorum logic shipped in #2133 actually runs. Same pattern
+              // for combat / debrief / ended for symmetry — manual phase
+              // override on host phone keeps the orch state machine in
+              // sync. world_seed_reveal stays UI-only (transient).
+              if (
+                coopStore &&
+                (phaseArg === 'world_setup' ||
+                  phaseArg === 'combat' ||
+                  phaseArg === 'debrief' ||
+                  phaseArg === 'ended')
+              ) {
+                try {
+                  const orch = coopStore.get(room.code);
+                  if (orch && orch.phase !== phaseArg) {
+                    orch._setPhase(phaseArg);
+                  }
+                } catch (err) {
+                  console.warn(`[ws] orch phase sync to ${phaseArg} failed:`, err && err.message);
                 }
               }
               // 2026-05-06 narrative onboarding port — bootstrap orch in

--- a/docs/playtest/2026-05-08-agent-driven-smoke-comparison.md
+++ b/docs/playtest/2026-05-08-agent-driven-smoke-comparison.md
@@ -1,0 +1,160 @@
+---
+title: 'Agent-driven smoke iter4 — Godot phone vs web v1 comparison 2026-05-08'
+doc_status: active
+doc_owner: master-dd
+workstream: ops-qa
+last_verified: 2026-05-08
+source_of_truth: false
+language: it
+review_cycle_days: 14
+related:
+  - docs/playtest/AGENT_DRIVEN_WORKFLOW.md
+  - docs/playtest/2026-05-07-phone-smoke-bundle-rca.md
+  - docs/playtest/2026-05-08-phone-smoke-day3-friends-online.md
+tags: [playtest, smoke, comparison, godot-phone, web-v1, b-new, iter4]
+---
+
+# Agent-driven smoke iter4 — Godot phone vs web v1 (2026-05-08)
+
+**Tunnel**: `https://circumstances-lat-status-summary.trycloudflare.com`
+**Backend HEAD**: `67f8dfd8` (post B-NEW bundle iter4)
+**Dist mtime**: May 8 20:23 — FRESH
+**Harness**: Chrome MCP NOT CONNECTED → Pattern B Playwright multi-context + REST/WS Node forensic
+
+---
+
+## 1. Executive summary
+
+- 14/16 Playwright phone smoke tests PASS (39.8s). Regressions B5+B7+B8+B9+B10 all green.
+- B5 (phaseChangeBroadcast.test.js): 6/6 PASS. B2/Airplane (airplaneReconnect.test.js): 5/5 PASS.
+- **B-NEW-5-bis (BUG)**: `POST /api/lobby/character` returns 404 — endpoint never existed in lobby.js. B-NEW-5 fix (idempotent submitCharacter) is WS-only via `intent.action=character_create`; no REST surface. No regression, but REST smoke surfaces the gap.
+- **B-NEW-1-bis (BUG P1)**: `coopOrchestrator.phase` is NOT advanced to `world_setup` when host sends WS `phase=world_setup` directly (without all players submitting characters). `voteWorld` throws `not_in_world_setup`. Connected-only quorum code (B-NEW-1 fix) is unreachable in minimal phone smoke flow. Day 3 friends online P0 world vote stuck is PARTIALLY fixed — full quorum path blocked by orch phase sync gap.
+- **B-NEW-4-bis (P2)**: `/api/lobby/rejoin` returns 404 instead of 410 for closed rooms (room deleted from registry on close, not marked closed). Client cannot distinguish "never existed" from "was closed". Minor UX clarity issue.
+- Canvas visual render test (canvas-visual.spec.ts:42) FAIL: Godot splash renders canvas with non-zero dimensions but pixel content is all-black post-20s load via headless Playwright (no GPU). Known headless limitation — not a runtime bug.
+- WS RTT p95 FAIL: p95=478ms via tunnel (threshold 200ms). Cloudflare tunnel WAN overhead expected; server-local baseline < 5ms per prior session. Not a regression.
+
+---
+
+## 2. Bug nuovi catturati
+
+### B-NEW-1-bis (P1) — coopOrchestrator phase sync gap: world_vote unreachable in minimal phone flow
+
+**Symptom**: Player sends `intent.action=world_vote` in world_setup phase → server returns `error: not_in_world_setup`.
+
+**Root cause**: `wsSession.js` WS `phase` handler only bootstraps coopOrchestrator on `character_creation` (line 1709) and `onboarding` (line 1724). When host sends `phase=world_setup` directly, `room.publishPhaseChange('world_setup')` is called but `coopOrchestrator._setPhase('world_setup')` is NEVER called. The orch stays at `character_creation`. `voteWorld` (line 354) throws `not_in_world_setup` before reaching B-NEW-1 connected-only quorum code.
+
+**File:line**: `apps/backend/services/network/wsSession.js:1709` (missing `world_setup` bootstrap branch)
+
+**Repro**:
+
+1. Create room + join via WS
+2. Host sends `{type:'phase', payload:{phase:'character_creation'}}` → orch bootstrapped
+3. Host sends `{type:'phase', payload:{phase:'world_setup'}}` → room phase updated but orch.phase remains `character_creation`
+4. Player sends `{type:'intent', payload:{action:'world_vote', choice:'accept'}}` → server error `not_in_world_setup`
+
+**Fix path**:
+
+```js
+// wsSession.js ~line 1720, after character_creation bootstrap block:
+if (phaseArg === 'world_setup' && coopStore) {
+  try {
+    const orch = coopStore.get(room.code);
+    if (orch && orch.phase === 'character_creation') {
+      orch._setPhase('world_setup'); // or orch.forceAdvanceToWorldSetup() if exposed
+    }
+  } catch (err) {
+    console.warn('[ws] world_setup phase sync failed:', err.message);
+  }
+}
+```
+
+Alternatively expose `advanceToWorldSetup()` on coopOrchestrator (mirrors `forceAdvanceToWorldSetup` at line 639).
+
+**Test lock**: `tests/api/phaseChangeBroadcast.test.js` — add B5-7 test: `host phase=world_setup → player world_vote → world_tally received`.
+
+---
+
+### B-NEW-4-bis (P2) — rejoin closed room returns 404 not 410
+
+**Symptom**: `POST /api/lobby/rejoin` with valid (but closed) room code returns HTTP 404 instead of 410 Gone.
+
+**Root cause**: `wsSession.js:907` `closeRoom` calls `this.rooms.delete(normalized)` — room fully removed from registry. `getRoom` after close returns null → `lobby.js:81` returns 404. Phone client cannot distinguish "room code typo / never existed" from "room was closed, my session is stale".
+
+**File:line**: `apps/backend/services/network/wsSession.js:907`, `apps/backend/routes/lobby.js:81`
+
+**Fix path option A** (preferred): Keep closed rooms in registry for 5 minutes with `closed=true` flag. `closeRoom` sets `room.closed = true`, starts a 5-min GC timer, THEN deletes. `getRoom` returns null after GC.
+
+**Fix path option B**: Store closed room codes in a `closedRoomCodes: Set` on LobbyService; `rejoin` checks set before 404 → returns 410.
+
+**Impact**: Low — only affects UX of phone resume flow. Functional correctness not broken.
+
+---
+
+### B-NEW-5-bis (P2) — `POST /api/lobby/character` endpoint missing
+
+**Symptom**: `POST /api/lobby/character` returns Express 404 "Cannot POST".
+
+**Root cause**: There is no REST `/api/lobby/character` endpoint. `submitCharacter` is WS-only via `intent.action=character_create`. `lobby.js` only exposes create/join/rejoin/close/state/list. Not a B-NEW-5 regression (B-NEW-5 is WS idempotent logic), but signals no REST probe surface for character submission.
+
+**Impact**: Informational — no REST smoke coverage for character_create path. Accepted gap (WS-only path by design).
+
+---
+
+## 3. Surface comparison matrix — Godot phone vs web v1
+
+| Pillar                   | Phase                                                           | Godot phone                                              | Web v1                                          | Gap                                      |
+| ------------------------ | --------------------------------------------------------------- | -------------------------------------------------------- | ----------------------------------------------- | ---------------------------------------- |
+| P1 Telemetry HUD p95     | combat                                                          | GAP-1 SHIPPED (#204) — debug label in HudView            | No equivalent                                   | Godot AHEAD                              |
+| P2 ThoughtsRitual        | debrief                                                         | GAP-9 SHIPPED (#203) — LegacyRitualPanel instanced       | No equivalent                                   | Godot AHEAD                              |
+| P3 form_pulse axes       | character_creation                                              | W4 intent drain server-side; phone_composer_view.gd wire | No equivalent                                   | Godot AHEAD                              |
+| P4 Ennea debrief 9-canon | debrief                                                         | GAP-2 SHIPPED (#203) — debrief_view top archetype        | No equivalent                                   | Godot AHEAD                              |
+| P5 share screen / lobby  | lobby                                                           | Share screen overlay + deep-link CTA (B1 fix, #169)      | lobby.html full DOM — create/join forms visible | Web v1 richer DOM UX; Godot phone canvas |
+| P5 WS phase broadcast    | lobby→combat                                                    | 14/16 Playwright PASS, B5+B8+B9+B10 fixed                | Same backend shared                             | PARITY                                   |
+| P6 WoundState badge      | combat                                                          | GAP-4 SHIPPED (#204) — unit_info_panel severity          | vcScoring JS computes wound; no UI surface      | Godot AHEAD                              |
+| state machine phases     | lobby→onboarding→char_creation→world_setup→combat→debrief→ended | All phases reachable via WS (Playwright confirmed)       | All phases reachable via WS                     | PARITY                                   |
+| canvas render (headless) | all                                                             | All-black via headless Playwright (GPU-less)             | N/A (DOM-based)                                 | Known headless gap                       |
+| WS RTT p95 (tunnel)      | combat                                                          | 478ms p95 via Cloudflare tunnel                          | Same backend                                    | Tunnel overhead expected                 |
+
+---
+
+## 4. Phase coverage map
+
+| Phase              | Godot phone rendered?                                 | Functional?                                             | Notes                                                    |
+| ------------------ | ----------------------------------------------------- | ------------------------------------------------------- | -------------------------------------------------------- |
+| lobby              | Canvas yes (non-zero dims confirmed)                  | YES — create/join REST verified                         | Share screen overlay available                           |
+| onboarding         | GDScript phone_onboarding_view.gd ported (#193)       | YES (Playwright B5+B8 path)                             | campaign YAML broadcast                                  |
+| character_creation | phone composer mode swap verified B8                  | YES — intent.action=character_create drains server-side | B-NEW-1-bis: world_vote unreachable if direct phase skip |
+| world_setup        | Phase change broadcast verified                       | PARTIAL — world_vote blocked by orch phase sync gap     | B-NEW-1-bis P1 fix needed                                |
+| combat             | 5R p95 harness (#202), combat→debrief Playwright PASS | YES                                                     | Telemetry HUD + WoundState badge live (GAP-1+GAP-4)      |
+| debrief            | combat→debrief→ended e2e Playwright PASS              | YES — ThoughtsRitual + Ennea 9-canon live               | GAP-2 + GAP-9 shipped                                    |
+| ended              | next_macro retreat closes run (Playwright PASS)       | YES                                                     |                                                          |
+
+---
+
+## 5. Top 3 priority fixes
+
+### Fix 1 (P1) — B-NEW-1-bis: coopOrchestrator world_setup phase sync
+
+`apps/backend/services/network/wsSession.js` ~line 1720: add `world_setup` bootstrap branch identical to `character_creation` pattern. Advance `orch._setPhase('world_setup')` (or expose `advanceToWorldSetup()`) when host sends `phase=world_setup` WS intent. Unblocks B-NEW-1 connected-only quorum — the Day 3 P0 world vote stuck is only half-fixed.
+
+Effort: ~30min. Test lock: `phaseChangeBroadcast.test.js` B5-7 addition.
+
+### Fix 2 (P2) — B-NEW-4-bis: rejoin closed room 410 semantic
+
+`apps/backend/services/network/wsSession.js`: LobbyService `closeRoom` stores closed room code in a `this._closedCodes: Set<string>` for 5min TTL. `getRoom` still returns null (GC), but `rejoin` route checks `_closedCodes.has(code)` → 410 before 404 path. Phone resume flow gets clear "room closed, clear session" signal vs "room not found, try again".
+
+Effort: ~30min. No test regression expected.
+
+### Fix 3 (informational) — Canvas smoke gate: skip GPU-less assertion in CI
+
+`tools/ts/tests/playwright/phone/canvas-visual.spec.ts:66`: gate `expect(nonEmpty).toBeGreaterThan(8)` with `test.skip(process.env.CI === 'true', 'Godot canvas GPU-less = all-black in headless CI')`. Reduces noise from known headless limitation. Alternatively set `emptyThreshold: 250` (near-white check) to detect truly broken canvas vs black-because-GPU-absent.
+
+Effort: ~10min.
+
+---
+
+## Harness verdict
+
+14/16 PASS. 2 failures = known external causes (headless GPU + tunnel WAN RTT). 0 regressions from B5/B7/B8/B9/B10 bundle. 1 new P1 bug (B-NEW-1-bis orch phase sync) + 1 P2 (B-NEW-4-bis 404 vs 410). Screenshots not captured (Chrome MCP unavailable; Playwright traces at `tools/ts/test-results/`).
+
+**Chrome MCP blocker**: extension not connected at session start. To retry with full visual screenshot coverage: ensure Chrome extension signed in + active, then re-run this agent.

--- a/docs/playtest/2026-05-09-browser-smoke-iter5-chrome-mcp.md
+++ b/docs/playtest/2026-05-09-browser-smoke-iter5-chrome-mcp.md
@@ -1,0 +1,263 @@
+---
+title: Browser smoke iter5 Chrome MCP — 7 nuovi bug + comparison vs web v1
+workstream: ops-qa
+doc_status: active
+doc_owner: master-dd
+last_verified: 2026-05-09
+source_of_truth: true
+language: it
+review_cycle_days: 30
+status: active
+owner: master-dd
+last_review: 2026-05-09
+tags:
+  [
+    playtest,
+    phone,
+    smoke,
+    godot-v2,
+    chrome-mcp,
+    iter5,
+    browser-driven,
+    bug-bundle,
+    comparison,
+    web-v1,
+  ]
+---
+
+# Browser smoke iter5 Chrome MCP — 2026-05-09
+
+Claude-driven browser smoke via Chrome MCP (`Browser 1` connected). 2-tab simulation host + amico via deep-link `?room=`. Stack live `https://dogs-schools-theatre-license.trycloudflare.com` con backend main `9f89f943` (post-merge B-NEW + B-NEW-bis bundle). 7 nuovi bug catturati. Comparison vs web v1 (`/play/lobby.html`) confermata regressione UX su Godot phone.
+
+## Pre-flight ✅
+
+| Check                        | Status                            |
+| ---------------------------- | --------------------------------- |
+| Chrome MCP connected         | ✅ `Browser 1` (Windows)          |
+| Stack tunnel `dogs-schools`  | ✅ `/api/health` 200              |
+| Backend main HEAD            | ✅ `9f89f943` (B-NEW-1-bis live)  |
+| Godot phone `/phone/`        | ✅ HTML5 dist fresh (May 8 20:23) |
+| Web v1 `/play/lobby.html`    | ✅ Vite build (rebuild this iter) |
+| Structured log lobby-service | ✅ events captured                |
+
+## Bug bundle catturato iter5
+
+### B-NEW-7 P1 — Friend phone join `[network_error: 13]`
+
+**Severity**: P1 — bloccante cross-device WAN smoke
+**Repo target**: Game-Godot-v2 (out of scope this Game/ PR)
+**File:line**: `scripts/net/lobby_api.gd:26 REQUEST_TIMEOUT_S := 10.0`
+**Sintomo**: Friend1 phone via `?room=WDVS` deep-link → input nome → tap `Unisciti` → top banner: `[network_error: 13] Join fallito: network_error: 13`
+
+**Forensic backend**:
+
+- `/api/lobby/list` mostra Friend1 player record presente nel room (`event:join` log captured)
+- HTTP 201 al CLI test diretto da stessa origin
+
+**RCA**: `HTTPRequest.RESULT_TIMEOUT = 13` (Godot 4.x). Timeout client-side 10s troppo corto su cold-start tunnel WAN. Backend riceve + risponde, ma response arriva oltre 10s su prima request fresh tab (WASM load + TLS + DNS cumulative). REST processed + record committed → re-tap fa idempotent join (player_count cresce silently).
+
+**Fix path Godot v2** (~5 LOC):
+
+- Bump `REQUEST_TIMEOUT_S` 10.0 → 30.0
+- Optional: distinguere timeout vs connect-fail in error message UX
+
+**Repro**: aprire 2 tab Chrome separato cold-start tunnel `?room=XXXX` → tap Unisciti su 2nd tab subito post-load.
+
+---
+
+### B-NEW-9 P1 — Phone composer non swappa MODE post `character_accepted`
+
+**Severity**: P1 — riproduce ESATTAMENTE il bug originale master-dd 2026-05-08 sera ("bug su conferma personaggio per host")
+**Repo target**: Game-Godot-v2 (out of scope)
+**File:line**: `scripts/phone/phone_composer_view.gd:778 _on_character_ready_list_received` + `:785 _on_character_accepted_received`
+**Sintomo**: Host phone Crea stanza → Conferma personaggio → status banner aggiornato `Personaggio accettato: Skiv (dune_stalker)` ma view CHARACTER_CREATION FORM **resta mounted**. Submit button **resta clickable**. User re-tap = re-submit (server-side dedupe shipped #2134 ammortizza, ma UX problema invariato).
+
+**Backend confirmed working** (post-#2134):
+
+- `submitCharacter` idempotent on identical spec ✓
+- Dedupe-before-phase ✓ (Codex P2 fix)
+- WS broadcast skip on dedupe ✓
+
+**Frontend gap**:
+
+- `_on_character_accepted_received` linea 785-796 solo `_set_status` (testo banner)
+- ZERO `_swap_mode(MODE_WAITING)` o disable submit button
+- Phase swap dipende da `phase_change` event server-side che fire SOLO quando ALL players submit
+- In single-player smoke (Friend1 timeout) → other_player mai connesso → mai ALL ready → mai `phase_change('world_setup')` → form stuck FOREVER
+
+**Fix path Godot v2** (~15 LOC):
+
+```gdscript
+func _on_character_accepted_received(spec: Dictionary, _phase: String) -> void:
+    # ... existing _set_status ...
+    # NEW: lock submit button + swap to waiting view if not host-led advance
+    if _current_mode == MODE_CHARACTER_CREATION and is_instance_valid(_current_view):
+        var char_view := _current_view as PhoneCharacterCreationView
+        if char_view != null:
+            char_view.lock_submit("Personaggio inviato. Attendo gli altri...")
+```
+
+E `phone_character_creation_view.gd` aggiungere `lock_submit(label: String)`:
+
+```gdscript
+func lock_submit(message: String) -> void:
+    if _submit_button != null:
+        _submit_button.disabled = true
+        _submit_button.text = "✓ Inviato"
+    if _validation_label != null:
+        _validation_label.text = message
+```
+
+---
+
+### B-NEW-3-bis P2 — Godot phone deep-link Crea stanza non demoted
+
+**Severity**: P2 — UX cascade orphan-lobby risk
+**Repo target**: Game-Godot-v2
+**File:line**: `scripts/phone/phone_lobby_join_view.gd:73-78` + `:299` apply_room_code_from_url
+**Sintomo**: deep-link `/phone/?room=WDVS` correttamente pre-fila code field MA Crea stanza button reste fully visible/clickable. Stesso UX cascade B-NEW-3 originale (master-dd 3 lobby orfane in <5min).
+
+**Confronto web v1** (mesh `/play/lobby.html?room=WDVS`):
+
+- Crea stanza card → `.card-secondary { opacity: 0.55 }`
+- Unisciti card → `.card-primary { border-color: accent + box-shadow glow }`
+- Status: `✓ Codice WDVS pronto. Inserisci il tuo nome ed entra.`
+- Scroll Join card into view
+- ✅ User visivamente guidato a Unisciti, NON Crea stanza
+
+**Fix path Godot v2** (~10 LOC):
+
+- In `_ready`: dopo `apply_room_code_from_url`, set `_create_button.disabled = true` o nascondere
+- O label Crea stanza → "Crea nuova stanza (cancella deep-link)" disabled
+
+---
+
+### B-NEW-10 P3 informational — Lobby form expone http/ws port hardcoded fields
+
+**Severity**: P3 — UX confusion
+**Repo target**: Game-Godot-v2
+**File:line**: `scripts/phone/phone_lobby_join_view.gd:54-68` (web platform branch)
+**Sintomo**: form visibile su web HTML5 mostra fields:
+
+- "host" (auto-filled to tunnel hostname)
+- "http port (3334)" placeholder
+- "ws port (3341)" placeholder
+
+User vede 3 campi tecnici (host + 2 port) prima dei 2 reali (codice + nome). Field sono auto-resolved via `WebOriginResolver` ma rimangono visibili — confonde + sembra errore quando placeholder dice 3341 ma deploy-quick è shared mode.
+
+**Fix path Godot v2** (~5 LOC):
+
+- Hide host/http_port/ws_port fields se `OS.has_feature("web")` AND auto-resolved
+- O collassa in un toggle "Avanzate" visibile solo dev mode
+
+---
+
+### B-NEW-11 P3 — Share screen no QR code
+
+**Severity**: P3 — UX gap (master-dd request explicit 2026-04-29)
+**Repo target**: Game-Godot-v2
+**Reference web v1**: `apps/play/lobby.html:380-388` (api.qrserver.com 200x200)
+**Sintomo**: post Crea stanza, share screen mostra solo:
+
+```
+STANZA CREATA
+Codice: WDVS
+Link amici: https://...trycloudflare.com/phone/?room=WDVS
+Tieni questa pagina aperta.
+Tap [Inizia partita ->] quando pronti.
+```
+
+Nessun QR code. Web v1 invece genera QR via `https://api.qrserver.com/v1/create-qr-code/?size=200x200&...`.
+
+**Fix path Godot v2** (~20 LOC): aggiungere `TextureRect` con HTTP fetch QR PNG → applica via `ImageTexture.create_from_image`.
+
+---
+
+### B-NEW-12 P3 — Share URL no copy-to-clipboard button
+
+**Severity**: P3 — UX friction
+**Repo target**: Game-Godot-v2
+**Reference web v1**: `apps/play/lobby.html:377` 📋 button + `apps/play/src/lobby.js:131-141 share-copy handler`
+**Sintomo**: share URL pure text label, user deve manual select+copy. Web v1 ha 📋 button che fa `navigator.clipboard.writeText(shareUrl)` con feedback ✓ 1.5s.
+
+**Fix path Godot v2** (~10 LOC): aggiungere Button "📋 Copia" che chiama `JavaScriptBridge.eval("navigator.clipboard.writeText(...)")`.
+
+---
+
+### B-NEW-13 P2 — Onboarding 4-card option auto-select pre-user-interaction
+
+**Severity**: P2 — narrative beat skipped
+**Repo target**: Game-Godot-v2
+**File:line**: `scripts/phone/phone_onboarding_view.gd` (auto_selected logic)
+**Sintomo**: phone host transitions dopo "Inizia mondo" → MODE_ONBOARDING brief view con narrativa ("Identità del branco / Il tuo branco è stato marcato. L'Apex ti troverà..."). Dopo ~4-6s auto-progress senza opzioni visibili. Backend log mostra `onboarding_chosen { option_key: 'option_a', auto_selected: false }` ma user non ha tappato nulla.
+
+Master-dd vede solo narrative beat passare, nessuna scelta utente. Sprint M.6 narrative onboarding spec implies USER choice, non auto-pick.
+
+**RCA hypothesis**: PhoneOnboardingView ha timer fallback OR layout issue cards offscreen. Card data viene da `onboarding_payload` broadcast (verified backend OK via campaignLoader `default_campaign_mvp`).
+
+**Fix path Godot v2** (~30min RCA + ~10 LOC):
+
+- Verifica PhoneOnboardingView render cards correttamente (probably issue layout bottom-of-viewport)
+- Disable auto-progress timer se card visible
+- Force user choice REQUIRED per advance
+
+---
+
+## Comparison surface Godot phone vs web v1
+
+| Surface          | Godot phone `/phone/`              | Web v1 `/play/lobby.html`                         | Verdict                 |
+| ---------------- | ---------------------------------- | ------------------------------------------------- | ----------------------- |
+| Lobby title      | "Inserisci il codice della stanza" | "🦴 Evo-Tactics Lobby"                            | web v1 better           |
+| Card design      | flat canvas form                   | Card panel + chip badge + emoji                   | web v1 polished         |
+| Host card        | text label "Unisciti alla stanza"  | "📺 Crea stanza" (host · TV)                      | web v1 visual hierarchy |
+| Player card      | shared with host (no separate)     | "📱 Unisciti" (player · phone)                    | web v1 distinct         |
+| Submit button    | text-only generic                  | yellow (host) / cyan (player) high-contrast       | web v1 better           |
+| Form fields      | 5 (incl 3 tecnici visible)         | 3 host (nome+campagna+max) / 2 player (code+nome) | web v1 cleaner          |
+| Deep-link demote | ❌ Crea stanza still clickable     | ✅ `.card-secondary` opacity 0.55                 | web v1 fix shipped      |
+| Status feedback  | text label                         | colored span + emoji ✓/⚠                         | web v1 redundancy       |
+| QR code          | ❌ no                              | ✅ api.qrserver.com 200x200                       | web v1 only             |
+| Copy URL button  | ❌ no                              | ✅ 📋 button                                      | web v1 only             |
+| Footer credits   | none                               | "M11 Phase B · Jackbox · ADR-2026-04-20"          | web v1 contextual       |
+| Mobile keyboard  | MobileKeyboardHelper.attach OK     | native HTML input native                          | parity                  |
+| Validation msg   | inline ("Senza codice tocca...")   | aria-live polite                                  | parity                  |
+
+**Verdict**: Phase A LIVE 2026-05-07 cutover Godot v2 phone primary lasciato regressione UX qualità. 7 di 13 surface-level features web v1 mancanti su Godot phone.
+
+## Phase coverage map (Godot phone)
+
+| Phase               | Render? | Functional?               | Bug                           |
+| ------------------- | :-----: | ------------------------- | ----------------------------- |
+| lobby (form)        |   ✅    | host create OK            | B-NEW-10 (port fields)        |
+| lobby (share)       |   ✅    | code + URL visible        | B-NEW-11 + B-NEW-12 missing   |
+| MODE_WAITING (host) |   ✅    | "Inizia mondo" CTA OK     | -                             |
+| onboarding          |   ⚠️    | narrative visible         | B-NEW-13 auto-skip            |
+| character_creation  |   ✅    | form OK + ACK             | **B-NEW-9 P1 stuck post ACK** |
+| world_setup (vote)  |   ❓    | unreachable single-player | -                             |
+| combat (5R + p95)   |   ❓    | unreachable               | -                             |
+| debrief             |   ❓    | unreachable               | -                             |
+| ended               |   ❓    | unreachable               | -                             |
+
+**Combat 5-round + airplane reconnect + p95 capture** — DEFERRED master-dd hardware test, single-player browser smoke can't validate.
+
+## Top 3 priority fixes (Godot v2 PR cycle)
+
+1. **B-NEW-7 P1 timeout bump** — `REQUEST_TIMEOUT_S 10 → 30` + retry-on-timeout. ~30min effort. Unblocks ALL friends-online smoke (Friend1 join workable).
+2. **B-NEW-9 P1 character_accepted MODE swap** — phone composer post-ACK lock submit + swap to MODE_WAITING. ~1h effort. Resolve UX-side della master-dd "bug conferma personaggio".
+3. **B-NEW-13 P2 onboarding auto-skip** — RCA + force user choice. ~1h effort. Recover narrative beat.
+
+**Cumulative ~2.5h Godot v2 work** chiude UX critical path master-dd phone flow.
+
+## Out of scope this iteration
+
+- Combat 5-round p95 capture (master-dd hardware test richiesto, browser non simula latency)
+- Airplane reconnect 60s (browser non ha airplane mode toggle)
+- Web v1 archive Phase B (post 7gg grace + 1+ playtest pass — ADR-2026-05-05 §6)
+- Mission Console `/docs/mission-console/` audit (out of phone smoke scope)
+
+## Refs
+
+- [PR #2133](https://github.com/MasterDD-L34D/Game/pull/2133) B-NEW-1+2+3+4 server-side
+- [PR #2134](https://github.com/MasterDD-L34D/Game/pull/2134) B-NEW-5 idempotent + dedupe-before-phase
+- [PR #2136](https://github.com/MasterDD-L34D/Game/pull/2136) B-NEW-1-bis orch sync + B-NEW-4-bis 410
+- [Phone-smoke-bot iter4 report](2026-05-08-agent-driven-smoke-comparison.md) Pattern B Playwright (Chrome MCP non disponibile precedente sessione)
+- [ADR-2026-05-05](../adr/ADR-2026-05-05-cutover-fase-3-godot.md) Phase A LIVE

--- a/tests/api/lobbyRoutes.test.js
+++ b/tests/api/lobbyRoutes.test.js
@@ -217,6 +217,28 @@ test('POST /api/lobby/rejoin 400 on missing fields', async () => {
   }
 });
 
+// B-NEW-4-bis fix 2026-05-08 (agent-driven smoke iter4) — distinguish
+// 404 (never existed) from 410 (recently closed) on the rejoin path.
+test('POST /api/lobby/rejoin 410 on room closed within TTL window', async () => {
+  const { app, close } = newApp();
+  try {
+    const create = await request(app)
+      .post('/api/lobby/create')
+      .send({ host_name: 'Alice' })
+      .expect(201);
+    const { code, host_id, host_token } = create.body;
+    // Close the room → removes from live registry, marks recently_closed.
+    await request(app).post('/api/lobby/close').send({ code, host_token }).expect(200);
+    const res = await request(app)
+      .post('/api/lobby/rejoin')
+      .send({ code, player_id: host_id, player_token: host_token })
+      .expect(410);
+    assert.equal(res.body.error, 'room_closed');
+  } finally {
+    await close();
+  }
+});
+
 test('POST /api/lobby/rejoin 404 on unknown code', async () => {
   const { app, close } = newApp();
   try {


### PR DESCRIPTION
## Summary

Browser smoke iter5 via Chrome MCP 2026-05-09 caught 7 nuovi bug runtime + comparison surface Godot phone vs web v1.

| Bug | Sev | Where | Status |
|---|---|---|---|
| **B-NEW-7** | P1 | Godot `lobby_api.gd` REQUEST_TIMEOUT 10s | ✅ Fix shipped Godot v2 [PR #216](https://github.com/MasterDD-L34D/Game-Godot-v2/pull/216) |
| **B-NEW-9** | P1 | Phone composer `character_accepted` no MODE swap | ⏸ Godot v2 follow-up |
| **B-NEW-3-bis** | P2 | Godot phone deep-link Crea stanza non demote | ⏸ Godot v2 follow-up |
| **B-NEW-13** | P2 | Onboarding 4-card auto-skip pre-user-interaction | ⏸ Godot v2 follow-up |
| **B-NEW-10** | P3 | Lobby form host/port fields expose | ⏸ Godot v2 follow-up |
| **B-NEW-11** | P3 | Share screen no QR code | ⏸ Godot v2 follow-up |
| **B-NEW-12** | P3 | Share URL no copy-to-clipboard | ⏸ Godot v2 follow-up |

## Note importante per master-dd

**B-NEW-9 = bug originale "conferma personaggio" master-dd 2026-05-08 sera UX-side NON RISOLTO**

Server-side dedupe shipped #2134 ammortizza re-submission floods, ma il sintomo VISIBILE all'utente (form resta mounted post Conferma) PERSISTE. Phone composer Godot v2 (separate repo) deve aggiungere `_swap_mode(MODE_WAITING)` o lock submit button su `character_accepted` ACK.

## Comparison Godot phone vs web v1

13-row surface table evidenzia 7/13 features mancanti su Godot phone post Phase A LIVE cutover:
- QR code, copy URL, deep-link demote, polished card design, color-coded buttons, max-player select, footer credits

Web v1 (`/play/lobby.html`) UX visibilmente migliore. Phase A LIVE 2026-05-07 cutover ha prodotto regressione UX qualità — documentato per master-dd review.

## Phase coverage

| Phase | Render | Bug |
|---|:-:|---|
| lobby form/share | ✅ | B-NEW-10/11/12 |
| MODE_WAITING | ✅ | - |
| onboarding | ⚠️ | B-NEW-13 auto-skip |
| character_creation | ✅ | **B-NEW-9 stuck post ACK** |
| world_setup → ended | ❓ | unreachable single-player |

Combat 5R + airplane reconnect + p95 capture DEFERRED master-dd hardware test.

## Refs

- Doc: \`docs/playtest/2026-05-09-browser-smoke-iter5-chrome-mcp.md\`
- Godot v2 [PR #216](https://github.com/MasterDD-L34D/Game-Godot-v2/pull/216) (B-NEW-7 fix shipped)
- Game/ PR [#2133](https://github.com/MasterDD-L34D/Game/pull/2133) + [#2134](https://github.com/MasterDD-L34D/Game/pull/2134) + [#2136](https://github.com/MasterDD-L34D/Game/pull/2136) (B-NEW + B-NEW-bis server-side cumulative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)