### PR TITLE
feat(traits): glossary sync Phase A — 5 status-effect traits

### DIFF
--- a/data/core/traits/glossary.json
+++ b/data/core/traits/glossary.json
@@ -3556,6 +3556,36 @@
       "label_en": "Xenobiotic Metabolism",
       "description_it": "The elements used to fight food poisonings are more effective.",
       "description_en": "The elements used to fight food poisonings are more effective."
+    },
+    "tela_appiccicosa": {
+      "label_it": "Tela Appiccicosa",
+      "label_en": "Sticky Web",
+      "description_it": "Ghiandole che secernono fili vischiosi. Ogni hit applica 3 turni di slowed: il target riceve -1 AP al reset turno (minimo 1 AP garantito).",
+      "description_en": "Glands that secrete sticky threads. Each hit applies 3 turns of slowed: the target loses 1 AP on turn reset (minimum 1 AP guaranteed)."
+    },
+    "marchio_predatorio": {
+      "label_it": "Marchio Predatorio",
+      "label_en": "Predatory Mark",
+      "description_it": "Feromoni predatori che segnalano il bersaglio alla squadra. Ogni hit applica 2 turni di marked: il prossimo attacco sul target ottiene +1 danno (il mark viene consumato al primo utilizzo).",
+      "description_en": "Predatory pheromones that signal the target to the squad. Each hit applies 2 turns of marked: the next attack on the target gains +1 damage (the mark is consumed on first use)."
+    },
+    "respiro_acido": {
+      "label_it": "Respiro Acido",
+      "label_en": "Acid Breath",
+      "description_it": "Ghiandole che spruzzano acido corrosivo incandescente. Ogni hit applica 3 turni di burning: il target subisce 2 PT di danno non riducibile al termine di ogni turno (più severo del sanguinamento).",
+      "description_en": "Glands that spray glowing corrosive acid. Each hit applies 3 turns of burning: the target takes 2 unreducible HP damage at the end of each turn (more severe than bleeding)."
+    },
+    "aura_glaciale": {
+      "label_it": "Aura Glaciale",
+      "label_en": "Glacial Aura",
+      "description_it": "Aura criogeina che raffredda i tessuti del bersaglio. Ogni hit applica 2 turni di chilled: il target perde 1 AP al reset di turno e subisce -1 ai tiri d'attacco (riflessi rallentati).",
+      "description_en": "Cryogenic aura that chills the target's tissues. Each hit applies 2 turns of chilled: the target loses 1 AP on turn reset and suffers -1 to attack rolls (slowed reflexes)."
+    },
+    "sussurro_psichico": {
+      "label_it": "Sussurro Psichico",
+      "label_en": "Psychic Whisper",
+      "description_it": "Sussurro sonico disorientante. Ogni hit solido (MoS >= 5) applica 1 turno di disoriented: il target subisce -2 ai tiri d'attacco (confusione sensoriale profonda, ma breve).",
+      "description_en": "Disorienting sonic whisper. Each solid hit (MoS >= 5) applies 1 turn of disoriented: the target suffers -2 to attack rolls (deep sensory confusion, but brief)."
     }
   }
 }

--- a/docs/planning/2026-05-09-status-effects-phase-a-audit.md
+++ b/docs/planning/2026-05-09-status-effects-phase-a-audit.md
@@ -1,0 +1,121 @@
+---
+title: 'Status Effects v2 Phase A — Audit 2026-05-09'
+date: 2026-05-09
+doc_status: active
+doc_owner: claude-code
+workstream: combat
+last_verified: '2026-05-09'
+source_of_truth: false
+language: it
+review_cycle_days: 14
+---
+
+# Status Effects v2 Phase A — Audit 2026-05-09
+
+> Sessione autonoma 2026-05-09. Obiettivo iniziale: implementare 5 stati Tier 1
+> come 5 mini-PR sequenziali. Audit Phase 1 ha rilevato che il runtime è già
+> **completo su main** (implementato tra 2026-04-25 e 2026-04-27, handoff
+> `docs/planning/2026-04-27-status-effects-phase-a-handoff.md`).
+> Questa sessione si focalizza sui **gap residui**.
+
+## 1. Stato runtime su main (2026-05-09)
+
+### 1.1 Consumer hooks — TUTTI presenti
+
+| Stato       | File                          | Linea(e) | Effetto                          |
+| ----------- | ----------------------------- | --------- | -------------------------------- |
+| `slowed`    | `sessionHelpers.js`           | 698       | `applyApRefill`: -1 AP (min 1)  |
+| `marked`    | `session.js`                  | 597–600   | +1 dmg next hit, mark consumato |
+| `burning`   | `session.js`                  | 1217+     | DoT 2 PT/turno (3 path)         |
+| `chilled`   | `session.js` + helpers        | 513–517 + 697 | -1 atk pre/revert + -1 AP   |
+| `disoriented`| `session.js`                 | 518–522   | -2 atk pre/revert (1T)          |
+
+### 1.2 STATUS_DURATION_CAPS — TUTTI presenti
+
+`session.js:101–113`:
+```javascript
+slowed: 3, marked: 2, burning: 3, chilled: 2, disoriented: 1
+```
+
+### 1.3 Trait produttori (active_effects.yaml) — TUTTI presenti
+
+| Trait               | Stato        | Linea YAML | Trigger            |
+| ------------------- | ------------ | ---------- | ------------------ |
+| `tela_appiccicosa`  | `slowed`     | ~9451      | hit any range      |
+| `marchio_predatorio`| `marked`     | ~9471      | hit any range      |
+| `respiro_acido`     | `burning`    | ~9430      | hit any range      |
+| `aura_glaciale`     | `chilled`    | ~9386      | hit any range      |
+| `sussurro_psichico` | `disoriented`| ~9408      | hit + min_mos 5    |
+
+### 1.4 Test coverage — 42/42 PASS
+
+| File                          | Tests |
+| ----------------------------- | ----: |
+| `statusEffectsSlowed.test.js` | 3     |
+| `statusEffectsMarked.test.js` | 3     |
+| `statusEffectsBurning.test.js`| 8     |
+| `statusEffectsPhaseA.test.js` | 28    |
+| **Totale**                    | **42**|
+
+Baseline AI test totale: 220 pass / 10 fail (fail = infrastruttura: js-yaml +
+supertest mancanti — pre-esistenti, non regressioni Phase A).
+
+## 2. Gap residui (da April 27 handoff Priority 1+2+3)
+
+### 2.1 Priority 3 — Glossary sync ⚠️ MANCANTE
+
+I 5 trait produttori **non sono in `data/core/traits/glossary.json`** (grep 0 match).
+Necessario per: trait-lint CI check, UI tooltip, catalog readiness.
+
+Traits da aggiungere: `aura_glaciale`, `tela_appiccicosa`, `marchio_predatorio`,
+`respiro_acido`, `sussurro_psichico`.
+
+**Effort stimato**: ~20 min. **Rischio**: zero (additive).
+
+### 2.2 Priority 1 — policy.js AI consumption ⚠️ MANCANTE
+
+`declareSistemaIntents.js` e `policy.js` **non leggono** i 5 nuovi stati per
+decisioni AI. Comportamento AI identico a unità sane.
+
+Opportunità:
+- `slowed` target → AI lo preferisce (mobilità ridotta, facile da raggiungere)
+- `disoriented` target → AI lo attacca (probabilità hit aumentata per 1T)
+- `marked` target → AI coordina attacchi su di esso per consumare il bonus
+- `burning` attore → AI considera che DoT fa il lavoro, risparmia AP su altri
+- `chilled` target → AI lo considera target soft (AP e atk ridotti)
+
+**Effort stimato**: ~1-2h. **Rischio**: basso (additive in `checkEmotionalOverrides`
+extension o `targetSelectionScore` weight — non tocca resolver, non tocca schema).
+
+### 2.3 Priority 2 — Gate 5 HUD surface ⚠️ MANCANTE (out of scope sessione)
+
+Nessuno dei 5 stati ha surface player-visible. Gate 5 violation.
+- Status icon sprite/emoji sotto unit (Godot v2) o HUD overlay (web)
+- Log entry panel quando applicato
+- Tooltip turns rimanenti
+
+**Scope**: frontend Godot v2 — fuori scope sessione backend Node. Deferred.
+
+## 3. Pipeline completa verificata
+
+```
+trait YAML (active_effects.yaml, SPRINT_020)
+  → evaluateStatusTraits (traitEffects.js:376)
+  → status_applies[]
+  → performAttack session.js:877 → unit.status[stato] = min(cap, max(current, turns))
+  → Consumer effect:
+      slowed/chilled → applyApRefill (sessionHelpers.js:698)
+      marked → performAttack pre-damage (session.js:597)
+      burning → end-of-round DoT (session.js:1217, roundBridge)
+      chilled/disoriented → pre/revert attack mod (session.js:513-522)
+  → Decay: handleTurnEnd status countdown (session.js:1254)
+```
+
+## 4. Priorità sessione 2026-05-09
+
+| PR  | Scope                       | Effort   | Rischio |
+| --- | --------------------------- | -------- | ------- |
+| A   | Glossary sync (5 trait)     | ~20 min  | Zero    |
+| B   | policy.js AI slowed/disoriented/marked | ~1-2h | Basso |
+
+HUD surface → deferred sprint successivo (Gate 5 debt backlog).

--- a/docs/planning/2026-05-09-status-effects-phase-a-design.md
+++ b/docs/planning/2026-05-09-status-effects-phase-a-design.md
@@ -1,0 +1,163 @@
+---
+title: 'Status Effects v2 Phase A — Design call 2026-05-09'
+date: 2026-05-09
+doc_status: active
+doc_owner: claude-code
+workstream: combat
+last_verified: '2026-05-09'
+source_of_truth: false
+language: it
+review_cycle_days: 14
+---
+
+# Status Effects v2 Phase A — Design call 2026-05-09
+
+> Complemento all'audit `2026-05-09-status-effects-phase-a-audit.md`.
+> Phase A runtime già completo. Questa sessione copre i 2 gap backendabili:
+> PR-A (glossary) e PR-B (policy AI).
+
+## PR-A — Glossary sync (5 trait Phase A)
+
+### Scope
+
+Aggiungere 5 entry a `data/core/traits/glossary.json` per i trait produttori
+Phase A. Attualmente assenti (grep 0 match), bloccano `trait-lint` CI check.
+
+### Entry da aggiungere
+
+| Trait ID             | label_it                   | label_en              | Stato      |
+| -------------------- | -------------------------- | --------------------- | ---------- |
+| `tela_appiccicosa`   | Tela Appiccicosa           | Sticky Web            | slowed     |
+| `marchio_predatorio` | Marchio Predatorio         | Predatory Mark        | marked     |
+| `respiro_acido`      | Respiro Acido              | Acid Breath           | burning    |
+| `aura_glaciale`      | Aura Glaciale              | Glacial Aura          | chilled    |
+| `sussurro_psichico`  | Sussurro Psichico          | Psychic Whisper       | disoriented|
+
+### Description strategy
+
+Derivato da `description_it` in `active_effects.yaml` (linee 9399–9487).
+Format identico agli entry esistenti: `{ label_it, label_en, description_it, description_en }`.
+
+### Hook point
+
+`data/core/traits/glossary.json` — append prima della chiusura `}`.
+**LOC**: +35 (5 × 7 righe). **Rischio**: zero. **Test**: nessuno da aggiungere
+(test esistenti non toccano glossary entries individuali).
+
+### Anti-pattern guard
+
+- NON modificare `active_effects.yaml` in questo PR (solo glossary.json)
+- Encoding UTF-8 esplicito su scrittura (CLAUDE.md §🔤)
+- Verify: `grep -c "tela_appiccicosa" data/core/traits/glossary.json` → 1
+
+---
+
+## PR-B — policy.js AI status-awareness
+
+### Scope
+
+Rendere l'AI del Sistema consapevole dei 5 nuovi stati per decisioni di
+targeting. Due modifiche additive, nessuna modifica al resolver.
+
+### 1. `DEFAULT_OBJECTIVES` — nuovo obiettivo `attack_debuffed_target`
+
+**File**: `apps/backend/services/ai/policy.js`
+**Dopo**: linea 244 (`maintain_range` objective)
+
+```javascript
+attack_debuffed_target: {
+  checker: (actor, target) => {
+    const s = target?.status;
+    if (!s) return false;
+    return (
+      Number(s.slowed) > 0 ||
+      Number(s.disoriented) > 0 ||
+      Number(s.chilled) > 0 ||
+      Number(s.marked) > 0
+    );
+  },
+  weight: 0.5,
+},
+```
+
+**Rationale**: peso 0.5 < 0.6 (protect_low_hp) = debuffed è preferenza soft,
+non override. L'AI preferisce target debuffati a parità di HP.
+
+**Effetto**: solo su `selectAiPolicyUtility` (utility brain path). Base policy
+non usa `scoreObjectives` direttamente.
+
+### 2. `pickTargetExcluding` — debuff tie-break
+
+**File**: `apps/backend/services/ai/declareSistemaIntents.js`
+**Funzione**: `pickTargetExcluding` (inline line ~153)
+
+Attualmente: puro lowest-HP. Modifica: a parità di HP (±2 PT), preferisce
+target con stato debilitante (slowed/disoriented/chilled/marked).
+
+```javascript
+function hasDebuffStatus(unit) {
+  const s = unit?.status;
+  if (!s) return false;
+  return (
+    Number(s.slowed) > 0 ||
+    Number(s.disoriented) > 0 ||
+    Number(s.chilled) > 0 ||
+    Number(s.marked) > 0
+  );
+}
+```
+
+Modificare `reduce` in `pickTargetExcluding`:
+```javascript
+return candidates.reduce((best, c) => {
+  if (!best) return c;
+  const hpDiff = c.hp - best.hp;
+  if (Math.abs(hpDiff) > 2) return hpDiff < 0 ? c : best;
+  // tie-break: prefer debuffed
+  if (hasDebuffStatus(c) && !hasDebuffStatus(best)) return c;
+  if (!hasDebuffStatus(c) && hasDebuffStatus(best)) return best;
+  return hpDiff < 0 ? c : best;
+}, null);
+```
+
+**Rationale**: `±2 PT` tie-break evita che l'AI ignori un target a 1 HP per
+inseguire un target a 3 HP con debuff. Solo a parità stretta il debuff conta.
+
+**LOC totale PR-B**: ~25 LOC (15 policy.js + 10 declareSistemaIntents.js).
+**Rischio**: basso. Non tocca resolver, schema, contracts.
+
+### Test PR-B (2 nuovi in test/ai/statusEffectsPhaseA.test.js)
+
+1. `hasDebuffStatus: slowed/disoriented/chilled/marked → true` (spec locale)
+2. `attack_debuffed_target objective: fires when target has debuff` (scoreObjectives spec)
+
+---
+
+## Deferred (not this session)
+
+### Gate 5 HUD surface — burning/chilled/slowed icons
+
+- **Where**: Godot v2 `unit_info_panel.gd` + combat log
+- **Effort**: ~3-4h frontend
+- **Trigger**: prima sessione Godot v2 post-Day 7
+
+### Phase B stati — interazioni
+
+- `burning` + `chilled` cancel → reward +1 PT (design call pendente master-dd)
+- `chilled` → `frozen` upgrade su doppia applicazione
+- `burning` resistenza specie acquatiche
+
+### policy.js burning-awareness
+
+Potenziale: AI con unit burning su target non insegue (DoT fa lavoro) →
+risparmia AP. Deferred: richiede HP-prediction logic (quanto il DoT uccide?).
+Medium complexity, basso ROI immediato.
+
+---
+
+## Stop criteria sessione
+
+- 5/5 test status effects pass (baseline invariata 42/42)
+- `grep` verify glossary 5 entries presenti
+- PR-A merged → PR-B starts da main aggiornato
+- AI test totale: 220 pass, 10 fail infrastructure (invariato — no regression)


### PR DESCRIPTION
## Summary

- Aggiunge 5 entry mancanti in `data/core/traits/glossary.json` per i trait produttori Status Effects v2 Phase A (runtime già su main dal 2026-04-27, mai sincronizzati con glossary)
- `tela_appiccicosa` → slowed (-1 AP reset/T)
- `marchio_predatorio` → marked (+1 dmg next hit, consume)
- `respiro_acido` → burning (DoT 2 PT/T)
- `aura_glaciale` → chilled (-1 AP + -1 atk/T)
- `sussurro_psichico` → disoriented (-2 atk/T, 1T cap)
- Audit doc + design call 2026-05-09 inclusi

## Verify gate

- ✅ JSON valid, 592 → 597 traits
- ✅ 5/5 entry con 4/4 campi obbligatori (label_it/en, description_it/en)
- ✅ 0 mojibake, Prettier clean
- ✅ No active_effects.yaml toccato
- ✅ Status tests 42/42 pass

## Test plan

- [ ] `node -e "const g=require('./data/core/traits/glossary.json'); ['tela_appiccicosa','marchio_predatorio','respiro_acido','aura_glaciale','sussurro_psichico'].forEach(k=>console.log(k,!!g.traits[k]))"` → tutti true
- [ ] `npm run format:check` verde
- [ ] `node --test tests/ai/statusEffects*.test.js` → 42/42 pass

## Rollback

`git revert HEAD` — additive-only, zero runtime impact.

https://claude.ai/code/session_01AtENNK6WP2fk8LJ2ro1WYb

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtENNK6WP2fk8LJ2ro1WYb)_