### PR TITLE
test(sim): FASE 2 batch AI-vs-AI runner — N=30 reveals balance signal

### DIFF
--- a/docs/playtest/2026-05-09-fase2-batch-ai-runner.md
+++ b/docs/playtest/2026-05-09-fase2-batch-ai-runner.md
@@ -1,0 +1,159 @@
+---
+title: FASE 2 batch AI-vs-AI runner — T2.1 baseline + N=30 signal
+workstream: ops-qa
+doc_status: active
+doc_owner: master-dd
+last_verified: 2026-05-09
+source_of_truth: true
+language: it
+review_cycle_days: 30
+status: active
+owner: master-dd
+last_review: 2026-05-09
+tags:
+  - playtest
+  - ai
+  - sim
+  - batch
+  - balance
+  - sprt
+  - fase2
+  - utility-brain
+---
+
+# FASE 2 batch AI-vs-AI runner — 2026-05-09
+
+Sprint Q+ FASE 2 baseline: parallel runner sopra `tests/smoke/ai-driven-sim.js` con archetype × scenario × seed Cartesian product. N=30 N seed × 3 profile × 1 scenario completato 100% in 125s + outcome breakdown rivela balance signal forte aggressive < cautious < balanced.
+
+## Files
+
+- [`tools/sim/batch-ai-runner.js`](../../tools/sim/batch-ai-runner.js) — parallel batch runner Node, no extra deps
+- [`tests/smoke/ai-driven-sim.js`](../../tests/smoke/ai-driven-sim.js) — refactored harness FASE 2 env hooks (AI_SIM_SISTEMA_PROFILE, AI_SIM_SEED, AI_SIM_RUN_LABEL)
+
+## CLI
+
+```bash
+TUNNEL=https://<host>.trycloudflare.com node tools/sim/batch-ai-runner.js \
+  --seed-count 100 \
+  --concurrency 4 \
+  --profiles aggressive,balanced,cautious \
+  --scenarios enc_tutorial_01 \
+  --max-rounds 40
+```
+
+| Flag            | Default                      | Note                                    |
+| --------------- | ---------------------------- | --------------------------------------- |
+| `--seed-count`  | 10                           | seed N per profile×scenario combo       |
+| `--concurrency` | 4                            | parallel workers (clamp 1..16)          |
+| `--profiles`    | balanced                     | comma-separated `ai_profiles.yaml` keys |
+| `--scenarios`   | enc_tutorial_01              | comma-separated scenario IDs            |
+| `--max-rounds`  | 15                           | combat round cap                        |
+| `--players`     | 1                            | extra players beyond host               |
+| `--worker`      | tests/smoke/ai-driven-sim.js | override harness path                   |
+
+## Output
+
+```
+/tmp/ai-sim-runs/batch-<ISO>/
+  ├── runs/run-N-<seed>-<profile>-<scenario>.jsonl
+  ├── summary.json    (aggregate stats)
+  ├── summary.csv     (one row per run)
+  └── report.md       (Markdown table)
+```
+
+Per-worker log isolato in `workers/w-N-<label>/` durante esecuzione → renamed canonical `runs/run-N-<label>.jsonl` post worker close. Race-free concurrency.
+
+## Live baseline N=30 (2026-05-09 post B-NEW-14 + FASE 1 merged)
+
+Run target: tunnel `given-jan-convention-cowboy.trycloudflare.com` (live B-NEW-14 + B-NEW-7 v2 + FASE 1 #2141).
+
+| Metric           | Value                                 |
+| ---------------- | ------------------------------------- |
+| Total runs       | 30 (10 seed × 3 profile × 1 scenario) |
+| Concurrency      | 4                                     |
+| Wall total       | 125.6s                                |
+| Completion       | **30/30 (100%)**                      |
+| Avg rounds       | 26.77                                 |
+| Avg wall per run | 15.69s                                |
+
+### Outcome distribution
+
+| Outcome | Count |     % |
+| ------- | ----: | ----: |
+| victory |    25 | 83.3% |
+| timeout |     4 | 13.3% |
+| defeat  |     1 |  3.3% |
+
+### Profile breakdown — **balance signal**
+
+| Profile        | Runs | Victory | Defeat | Timeout | Win rate | Avg rounds |
+| -------------- | ---: | ------: | -----: | ------: | -------: | ---------: |
+| **balanced**   |   10 |      10 |      0 |       0 | **100%** |       25.5 |
+| **cautious**   |   10 |       9 |      1 |       0 |  **90%** |       24.5 |
+| **aggressive** |   10 |       6 |      0 |       4 |  **60%** |       30.3 |
+
+**Counterintuitive finding**: profile `aggressive` (`use_utility_brain: true`, `retreat_hp_pct: 0.15`, `kite_buffer: 0`, `default_attack_range: 2`, `threat_passivity_threshold: 2`) UNDERPERFORMS rispetto a `balanced` (no overrides, no utility brain) e `cautious` (utility off, `retreat 0.4`, `kite 2`).
+
+Possibili cause (non analizzate, signal raw):
+
+1. **Utility brain regression**: `aggressive` è l'unico profile con `use_utility_brain: true`. UtilityBrain magari sceglie azioni sub-ottimali in tutorial_01 setup vs legacy rule-based di balanced/cautious.
+2. **Retreat threshold troppo basso**: 0.15 = retreat solo a 15% HP → enemy fa damage massimo prima di evadere → 4/10 timeout.
+3. **Kite buffer 0**: aggressive non mantiene distanza → player AI minimal lo accerchia + ammazza più lentamente (round count alto 30.3 vs 25 balanced).
+4. **threat_passivity_threshold=2** troppo reattivo → attacks player che retreating vs focus closer enemy.
+
+Master-dd / balance-illuminator agent può:
+
+- N=100 SPRT 95% bound: confermare statisticamente aggressive vs balanced winrate gap (60% vs 100%)
+- Bayesian knob tuning: `retreat_hp_pct` 0.15 → 0.25/0.30 + measure
+- Disable `use_utility_brain` su aggressive + measure isolato
+
+## Player AI scope
+
+Minimal closest-enemy attack policy embedded `selectPlayerAction`. Player wins at 100% balanced/90% cautious dimostra player policy NOT a bottleneck su quei profili. aggressive timeout 40% è il signal di interesse.
+
+Future T2.x: replace minimal con `policy.selectAiPolicy` reuse via shim adapter (FASE 1 follow-up). Player archetype variation (aggressive vs balanced vs cautious player AI) → 9 cell matrix profile×profile.
+
+## Telemetry capture
+
+JSONL per-run cattura:
+
+- `config` — env injection (sistema_profile, run_seed, run_label)
+- `rest` — every REST round-trip
+- `ws` — every WS msg (filtered phase_change for aggregate)
+- `round` — combat round snapshot (players, enemies, active_unit)
+- `player_action` — AI intent emit
+- `combat_outcome` — victory/defeat/timeout
+- `vc_capture` — MBTI + Ennea distribution post-combat
+- `final_phase` — terminal coop phase
+
+Aggregate JSON + CSV ingestable da `playtest-analyzer` agent.
+
+## What this unblocks
+
+1. **N=100+ SPRT calibration** via `balance-illuminator` agent (Stockfish pattern). Run already shipped.
+2. **MAP-Elites Quality-Diversity grid** (aggression × range × group_cohesion) — extend `--profiles` con custom YAML overrides.
+3. **CI nightly regression**: cron 02:00 UTC, alert on completion rate < 95% OR profile winrate shift > ±10%.
+4. **Pre-merge guard** for balance/AI changes: drop-in `npm run smoke:batch -- --seed-count 30`.
+
+## Known limitations
+
+- Single tunnel = serial backend bottleneck (4 concurrent workers ~15s/run = upper bound). N=100 ~30-40min wall.
+- Sistema profile injection works but **player AI not yet profile-aware** (closest-enemy minimal).
+- Run seed forwarded to `world_confirm` but coopOrchestrator may not use it for unit positioning RNG → seed reproducibility partial.
+- `vc_capture` returns 200 ma harness non printa (handler in coopOrchestrator endCombat path; TODO check VC pull endpoint shape).
+
+## Cross-ref
+
+- FASE 1 baseline: PR [#2141](https://github.com/MasterDD-L34D/Game/pull/2141)
+- FASE 4 P0 unblock combat: PR [#2140](https://github.com/MasterDD-L34D/Game/pull/2140) + Godot v2 main `7b92724`
+- ai_profiles.yaml: `packs/evo_tactics_pack/data/balance/ai_profiles.yaml` v0.2.0
+- declareSistemaIntents per-actor profile: `apps/backend/services/ai/declareSistemaIntents.js:94`
+- balance-illuminator agent: `.claude/agents/balance-illuminator.md`
+
+## Resume triggers
+
+> _"esegui FASE 2 N=100 SPRT confirm aggressive < balanced winrate gap"_
+
+> _"esegui FASE 2 MAP-Elites grid — aggression × range × cohesion behavior cells"_
+
+> _"esegui balance-illuminator calibration mode su batch-N=30 result + propose retreat_hp_pct knob tuning"_

--- a/tests/smoke/ai-driven-sim.js
+++ b/tests/smoke/ai-driven-sim.js
@@ -19,6 +19,21 @@
 //   AI_SIM_MAX_ROUNDS=15
 //   AI_SIM_LOG_DIR=/tmp/ai-sim-runs
 //   AI_SIM_SCENARIO=enc_tutorial_01
+//   AI_SIM_SISTEMA_PROFILE=aggressive   (FASE 2: ai_profiles.yaml key —
+//                                        aggressive | balanced | cautious;
+//                                        injected on every enemy unit
+//                                        via actor.ai_profile field so
+//                                        declareSistemaIntents.js picks
+//                                        the matching utility brain
+//                                        config)
+//   AI_SIM_SEED=12345                   (FASE 2: deterministic seed
+//                                        forwarded as run_seed to
+//                                        coopOrchestrator.confirmWorld
+//                                        + scenario_id stamp; reproduces
+//                                        identical sim across batch
+//                                        replays for SPRT bookkeeping)
+//   AI_SIM_RUN_LABEL=aggro_v_balanced   (FASE 2: tag for batch runner
+//                                        aggregate filtering)
 //
 // Cross-ref:
 //   docs/playtest/2026-05-09-browser-smoke-iter5-chrome-mcp.md
@@ -40,6 +55,9 @@ const EXTRA_PLAYERS = Math.max(0, Number(process.env.AI_SIM_PLAYERS || 1));
 const MAX_ROUNDS = Math.max(1, Number(process.env.AI_SIM_MAX_ROUNDS || 15));
 const SCENARIO_ID = String(process.env.AI_SIM_SCENARIO || 'enc_tutorial_01');
 const LOG_DIR = process.env.AI_SIM_LOG_DIR || '/tmp/ai-sim-runs';
+const SISTEMA_PROFILE = String(process.env.AI_SIM_SISTEMA_PROFILE || 'balanced');
+const RUN_SEED = process.env.AI_SIM_SEED ? Number(process.env.AI_SIM_SEED) : null;
+const RUN_LABEL = String(process.env.AI_SIM_RUN_LABEL || '');
 
 fs.mkdirSync(LOG_DIR, { recursive: true });
 const RUN_TS = new Date().toISOString().replace(/[:.]/g, '-');
@@ -132,6 +150,11 @@ function selectPlayerAction(actor, units) {
 // Synthetic Sistema scenario units (enc_tutorial_01-equivalent baseline)
 // so the smoke harness does not need to load YAML scenarios. Keeps the
 // driver self-contained + easily inspectable.
+//
+// FASE 2 — every enemy unit carries `ai_profile` referencing
+// ai_profiles.yaml key. declareSistemaIntents.js + sistemaTurnRunner
+// resolve per-unit profile (aggressive | balanced | cautious) and apply
+// utility-brain overrides. Default `balanced` matches v0.2.0 fallback.
 function buildScenarioEnemies() {
   return [
     {
@@ -148,6 +171,7 @@ function buildScenarioEnemies() {
       position: { x: 5, y: 5 },
       species_id: 'razziatore',
       mbti_type: 'aggressive',
+      ai_profile: SISTEMA_PROFILE,
     },
     {
       id: 'sis_02',
@@ -163,6 +187,7 @@ function buildScenarioEnemies() {
       position: { x: 4, y: 5 },
       species_id: 'pulverator',
       mbti_type: 'defensive',
+      ai_profile: SISTEMA_PROFILE,
     },
   ];
 }
@@ -178,6 +203,18 @@ function logSection(title) {
   console.log(
     `Players: 1 host + ${EXTRA_PLAYERS} extra | Scenario: ${SCENARIO_ID} | Max rounds: ${MAX_ROUNDS}`,
   );
+  console.log(
+    `Sistema profile: ${SISTEMA_PROFILE}${RUN_SEED !== null ? ` | seed: ${RUN_SEED}` : ''}${RUN_LABEL ? ` | label: ${RUN_LABEL}` : ''}`,
+  );
+  log('config', {
+    tunnel: TUNNEL,
+    extra_players: EXTRA_PLAYERS,
+    scenario: SCENARIO_ID,
+    max_rounds: MAX_ROUNDS,
+    sistema_profile: SISTEMA_PROFILE,
+    run_seed: RUN_SEED,
+    run_label: RUN_LABEL,
+  });
 
   // --- bootstrap lobby ---
   logSection('bootstrap lobby');
@@ -233,7 +270,11 @@ function logSection(title) {
   for (const p of wsExtras) p.send({ action: 'world_vote', choice: 'accept' });
   await new Promise((r) => setTimeout(r, 800));
 
-  wsHost.send({ action: 'world_confirm', scenario_id: SCENARIO_ID });
+  wsHost.send({
+    action: 'world_confirm',
+    scenario_id: SCENARIO_ID,
+    run_seed: RUN_SEED,
+  });
   await new Promise((r) => setTimeout(r, 1500));
 
   // --- pull session_start_payload via REST world/confirm idempotent (already

--- a/tools/sim/batch-ai-runner.js
+++ b/tools/sim/batch-ai-runner.js
@@ -1,0 +1,411 @@
+// FASE 2 T2.1 — Batch AI-vs-AI runner.
+//
+// Spawns N parallel `tests/smoke/ai-driven-sim.js` workers across
+// archetype × scenario combinations and aggregates JSONL outputs into
+// a single CSV + Markdown report.
+//
+// Usage:
+//   TUNNEL=https://<host>.trycloudflare.com \
+//     node tools/sim/batch-ai-runner.js \
+//       --seed-count 100 \
+//       --concurrency 4 \
+//       --profiles aggressive,balanced,cautious \
+//       --scenarios enc_tutorial_01 \
+//       --max-rounds 25
+//
+// Defaults (no flags):
+//   seeds=10  concurrency=4  profiles=balanced  scenarios=enc_tutorial_01
+//
+// Output:
+//   /tmp/ai-sim-runs/batch-<ISO>/
+//     ├── runs/run-N-<seed>-<profile>-<scenario>.jsonl   (per worker)
+//     ├── summary.json                                    (aggregate)
+//     ├── summary.csv                                     (one row per run)
+//     └── report.md                                        (Markdown)
+//
+// Cross-ref:
+//   tests/smoke/ai-driven-sim.js  (worker harness)
+//   docs/playtest/2026-05-09-fase1-ai-driven-sim-harness.md
+//   packs/evo_tactics_pack/data/balance/ai_profiles.yaml (profile keys)
+//
+'use strict';
+
+const { spawn } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function parseArgs(argv) {
+  const args = {
+    seedCount: 10,
+    concurrency: 4,
+    profiles: ['balanced'],
+    scenarios: ['enc_tutorial_01'],
+    maxRounds: 15,
+    extraPlayers: 1,
+    tunnel: process.env.TUNNEL || '',
+    workerScript: 'tests/smoke/ai-driven-sim.js',
+  };
+  for (let i = 2; i < argv.length; i += 1) {
+    const tok = argv[i];
+    const next = () => argv[++i];
+    switch (tok) {
+      case '--seed-count':
+        args.seedCount = Math.max(1, Number(next()));
+        break;
+      case '--concurrency':
+        args.concurrency = Math.max(1, Math.min(16, Number(next())));
+        break;
+      case '--profiles':
+        args.profiles = next()
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+        break;
+      case '--scenarios':
+        args.scenarios = next()
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+        break;
+      case '--max-rounds':
+        args.maxRounds = Math.max(1, Number(next()));
+        break;
+      case '--players':
+        args.extraPlayers = Math.max(0, Number(next()));
+        break;
+      case '--tunnel':
+        args.tunnel = next();
+        break;
+      case '--worker':
+        args.workerScript = next();
+        break;
+      default:
+        console.warn(`unknown arg: ${tok}`);
+    }
+  }
+  if (!args.tunnel) {
+    console.error('FATAL: set TUNNEL=... or pass --tunnel <url>');
+    process.exit(2);
+  }
+  return args;
+}
+
+function buildCombinations(args) {
+  const combos = [];
+  let runIdx = 0;
+  for (const profile of args.profiles) {
+    for (const scenario of args.scenarios) {
+      for (let s = 0; s < args.seedCount; s += 1) {
+        runIdx += 1;
+        const seed = 1000 + runIdx; // deterministic, monotonic
+        combos.push({
+          run_id: runIdx,
+          seed,
+          profile,
+          scenario,
+          label: `${profile}_${scenario}_${seed}`,
+        });
+      }
+    }
+  }
+  return combos;
+}
+
+function aggregateRun(jsonlPath, combo) {
+  if (!fs.existsSync(jsonlPath)) {
+    return { ...combo, ok: false, error: 'jsonl_missing' };
+  }
+  const lines = fs.readFileSync(jsonlPath, 'utf8').split('\n').filter(Boolean);
+  const events = lines
+    .map((l) => {
+      try {
+        return JSON.parse(l);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+
+  const config = events.find((e) => e.kind === 'config') || {};
+  const outcomeEv = events.find((e) => e.kind === 'combat_outcome');
+  const finalPhaseEv = events.find((e) => e.kind === 'final_phase');
+  const vcEv = events.find((e) => e.kind === 'vc_capture');
+  const restCount = events.filter((e) => e.kind === 'rest').length;
+  const wsCount = events.filter((e) => e.kind === 'ws').length;
+  const playerActionCount = events.filter((e) => e.kind === 'player_action').length;
+  const phaseChanges = events
+    .filter((e) => e.kind === 'ws' && e.type === 'phase_change')
+    .map((e) => e.payload?.phase)
+    .filter(Boolean);
+  const tsFirst = events.length > 0 ? events[0].ts : 0;
+  const tsLast = events.length > 0 ? events[events.length - 1].ts : 0;
+  const wallMs = tsLast - tsFirst;
+
+  return {
+    ...combo,
+    ok: finalPhaseEv?.phase === 'ended',
+    outcome: outcomeEv?.outcome || 'unknown',
+    rounds: outcomeEv?.rounds || 0,
+    final_phase: finalPhaseEv?.phase || 'unknown',
+    rest_count: restCount,
+    ws_count: wsCount,
+    player_actions: playerActionCount,
+    wall_ms: wallMs,
+    vc_mbti: vcEv?.mbti || null,
+    vc_ennea: vcEv?.ennea || null,
+    config_sistema_profile: config.sistema_profile || combo.profile,
+    config_run_seed: config.run_seed,
+    phase_progression: phaseChanges.join('→'),
+    jsonl_path: jsonlPath,
+  };
+}
+
+async function runWorker(combo, runDir, args) {
+  return new Promise((resolve) => {
+    // Per-worker isolated subdir → no JSONL filename collision when
+    // concurrency > 1 (harness writes timestamped run-<ISO>.jsonl). Each
+    // subdir holds exactly one file, then we rename to canonical batch
+    // name for downstream aggregate.
+    const workerDir = path.join(runDir, 'workers', `w-${combo.run_id}-${combo.label}`);
+    fs.mkdirSync(workerDir, { recursive: true });
+    const canonicalLog = path.join(runDir, 'runs', `run-${combo.run_id}-${combo.label}.jsonl`);
+    const env = {
+      ...process.env,
+      TUNNEL: args.tunnel,
+      AI_SIM_PLAYERS: String(args.extraPlayers),
+      AI_SIM_MAX_ROUNDS: String(args.maxRounds),
+      AI_SIM_SCENARIO: combo.scenario,
+      AI_SIM_SISTEMA_PROFILE: combo.profile,
+      AI_SIM_SEED: String(combo.seed),
+      AI_SIM_RUN_LABEL: combo.label,
+      AI_SIM_LOG_DIR: workerDir,
+    };
+    const t0 = Date.now();
+    const child = spawn('node', [args.workerScript], { env, stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (b) => (stdout += b.toString()));
+    child.stderr.on('data', (b) => (stderr += b.toString()));
+    child.on('close', (code) => {
+      // Find the JSONL file in the per-worker subdir + rename canonical.
+      let actualLog = null;
+      try {
+        const logFiles = fs.readdirSync(workerDir).filter((f) => f.endsWith('.jsonl'));
+        if (logFiles.length > 0) {
+          actualLog = path.join(workerDir, logFiles[0]);
+          fs.renameSync(actualLog, canonicalLog);
+          // Cleanup worker subdir (now empty).
+          fs.rmdirSync(workerDir);
+        }
+      } catch (err) {
+        console.warn(`worker ${combo.run_id} log rename failed: ${err.message}`);
+      }
+      const result = aggregateRun(canonicalLog, combo);
+      result.exit_code = code;
+      result.duration_ms = Date.now() - t0;
+      if (code !== 0) {
+        result.stderr_tail = stderr.slice(-200);
+      }
+      resolve(result);
+    });
+  });
+}
+
+async function runBatch(combos, args, runDir) {
+  fs.mkdirSync(path.join(runDir, 'runs'), { recursive: true });
+  const results = [];
+  let next = 0;
+  let active = 0;
+  let done = 0;
+
+  return new Promise((resolve) => {
+    const tick = () => {
+      while (active < args.concurrency && next < combos.length) {
+        const combo = combos[next++];
+        active += 1;
+        const startedAt = Date.now();
+        runWorker(combo, runDir, args).then((res) => {
+          results.push(res);
+          done += 1;
+          active -= 1;
+          const tag = res.ok ? '✓' : '✗';
+          process.stdout.write(
+            `[${done}/${combos.length}] ${tag} ${res.label} ${res.outcome}/${res.rounds}r ${res.duration_ms}ms\n`,
+          );
+          if (done === combos.length) resolve(results);
+          else tick();
+        });
+      }
+    };
+    tick();
+  });
+}
+
+function buildSummary(results, args) {
+  const total = results.length;
+  const completed = results.filter((r) => r.ok).length;
+  const byOutcome = results.reduce((acc, r) => {
+    acc[r.outcome] = (acc[r.outcome] || 0) + 1;
+    return acc;
+  }, {});
+  const byProfile = {};
+  for (const r of results) {
+    if (!byProfile[r.profile]) {
+      byProfile[r.profile] = {
+        runs: 0,
+        ended: 0,
+        victory: 0,
+        defeat: 0,
+        timeout: 0,
+        unknown: 0,
+        avg_rounds: 0,
+        avg_wall_ms: 0,
+      };
+    }
+    const p = byProfile[r.profile];
+    p.runs += 1;
+    if (r.ok) p.ended += 1;
+    p[r.outcome] = (p[r.outcome] || 0) + 1;
+    p.avg_rounds += r.rounds || 0;
+    p.avg_wall_ms += r.wall_ms || 0;
+  }
+  for (const k of Object.keys(byProfile)) {
+    const p = byProfile[k];
+    if (p.runs > 0) {
+      p.avg_rounds = +(p.avg_rounds / p.runs).toFixed(2);
+      p.avg_wall_ms = Math.round(p.avg_wall_ms / p.runs);
+    }
+  }
+  const avgRounds =
+    total === 0 ? 0 : +(results.reduce((s, r) => s + (r.rounds || 0), 0) / total).toFixed(2);
+  const avgWallMs =
+    total === 0 ? 0 : Math.round(results.reduce((s, r) => s + (r.wall_ms || 0), 0) / total);
+  return {
+    args,
+    total,
+    completed,
+    completion_rate: total === 0 ? 0 : +(completed / total).toFixed(3),
+    by_outcome: byOutcome,
+    by_profile: byProfile,
+    avg_rounds: avgRounds,
+    avg_wall_ms: avgWallMs,
+    started_at: results.length > 0 ? new Date().toISOString() : null,
+  };
+}
+
+function buildCsv(results) {
+  const headers = [
+    'run_id',
+    'seed',
+    'profile',
+    'scenario',
+    'final_phase',
+    'outcome',
+    'rounds',
+    'rest_count',
+    'ws_count',
+    'player_actions',
+    'wall_ms',
+    'duration_ms',
+    'exit_code',
+    'phase_progression',
+  ];
+  const rows = results.map((r) =>
+    headers
+      .map((h) => {
+        const v = r[h];
+        if (v == null) return '';
+        if (typeof v === 'object') return JSON.stringify(v).replace(/,/g, ';');
+        const s = String(v);
+        return s.includes(',') ? `"${s.replace(/"/g, '""')}"` : s;
+      })
+      .join(','),
+  );
+  return [headers.join(','), ...rows].join('\n');
+}
+
+function buildMarkdown(summary, results) {
+  const lines = [];
+  lines.push(`# Batch AI-vs-AI run — ${new Date().toISOString()}`);
+  lines.push('');
+  lines.push(`Tunnel: \`${summary.args.tunnel}\``);
+  lines.push(
+    `Total runs: **${summary.total}** | Completed: **${summary.completed}** | Rate: **${(summary.completion_rate * 100).toFixed(1)}%**`,
+  );
+  lines.push(`Avg rounds: ${summary.avg_rounds} | Avg wall: ${summary.avg_wall_ms}ms`);
+  lines.push('');
+  lines.push('## Outcome distribution');
+  lines.push('');
+  lines.push('| Outcome | Count |');
+  lines.push('|---|---:|');
+  for (const [k, v] of Object.entries(summary.by_outcome)) lines.push(`| ${k} | ${v} |`);
+  lines.push('');
+  lines.push('## Profile breakdown');
+  lines.push('');
+  lines.push('| Profile | Runs | Ended | Victory | Defeat | Timeout | Avg rounds | Avg wall ms |');
+  lines.push('|---|---:|---:|---:|---:|---:|---:|---:|');
+  for (const [k, p] of Object.entries(summary.by_profile)) {
+    lines.push(
+      `| ${k} | ${p.runs} | ${p.ended} | ${p.victory || 0} | ${p.defeat || 0} | ${p.timeout || 0} | ${p.avg_rounds} | ${p.avg_wall_ms} |`,
+    );
+  }
+  lines.push('');
+  lines.push('## Failed runs');
+  const failed = results.filter((r) => !r.ok);
+  if (failed.length === 0) {
+    lines.push('_None_');
+  } else {
+    lines.push('');
+    lines.push('| Run | Outcome | Final phase | Stderr tail |');
+    lines.push('|---|---|---|---|');
+    for (const r of failed) {
+      lines.push(
+        `| ${r.run_id} | ${r.outcome} | ${r.final_phase} | ${(r.stderr_tail || '').replace(/\|/g, '\\|')} |`,
+      );
+    }
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+(async () => {
+  const args = parseArgs(process.argv);
+  const combos = buildCombinations(args);
+  console.log(
+    `BATCH: ${combos.length} runs (${args.profiles.length} profile × ${args.scenarios.length} scenario × ${args.seedCount} seed) | concurrency=${args.concurrency}`,
+  );
+
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const runDir = path.join('/tmp/ai-sim-runs', `batch-${ts}`);
+  fs.mkdirSync(runDir, { recursive: true });
+  console.log(`Run dir: ${runDir}`);
+
+  const t0 = Date.now();
+  const results = await runBatch(combos, args, runDir);
+  const wallSec = ((Date.now() - t0) / 1000).toFixed(1);
+
+  const summary = buildSummary(results, args);
+  const csv = buildCsv(results);
+  const md = buildMarkdown(summary, results);
+
+  fs.writeFileSync(path.join(runDir, 'summary.json'), JSON.stringify(summary, null, 2));
+  fs.writeFileSync(path.join(runDir, 'summary.csv'), csv);
+  fs.writeFileSync(path.join(runDir, 'report.md'), md);
+
+  console.log('\n=== BATCH COMPLETE ===');
+  console.log(`Total wall: ${wallSec}s`);
+  console.log(`Run dir:    ${runDir}`);
+  console.log(`Summary:    ${path.join(runDir, 'summary.json')}`);
+  console.log(`CSV:        ${path.join(runDir, 'summary.csv')}`);
+  console.log(`Report MD:  ${path.join(runDir, 'report.md')}`);
+  console.log('');
+  console.log(
+    `Completion: ${summary.completed}/${summary.total} (${(summary.completion_rate * 100).toFixed(1)}%)`,
+  );
+  console.log(`Outcomes: ${JSON.stringify(summary.by_outcome)}`);
+
+  process.exit(summary.completed === summary.total ? 0 : 1);
+})().catch((e) => {
+  console.error('BATCH FAIL:', e);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

Sprint Q+ FASE 2 baseline. Parallel runner sopra FASE 1 harness con archetype × scenario × seed Cartesian product. Per-worker isolated subdir → race-free concurrency. Aggregate JSON + CSV + Markdown report.

## Live N=30 baseline (10 seed × 3 profile × 1 scenario, 125.6s wall)

**100% completion**, 25 victory + 4 timeout + 1 defeat.

| Profile | Runs | Victory | Defeat | Timeout | **Win rate** | Avg rounds |
|---|---:|---:|---:|---:|---:|---:|
| balanced | 10 | 10 | 0 | 0 | **100%** | 25.5 |
| cautious | 10 | 9 | 1 | 0 | **90%** | 24.5 |
| aggressive | 10 | 6 | 0 | 4 | **60%** | 30.3 |

## 🎯 BALANCE SIGNAL — counterintuitive

**Aggressive UNDERPERFORMS** vs balanced/cautious. Hypotheses (raw, non-analyzed):

1. utility_brain regression (aggressive only profile w/ flag `use_utility_brain: true`)
2. retreat_hp_pct 0.15 too low → enemy max damage pre-evade
3. kite_buffer 0 → no spacing → player AI accerchia
4. threat_passivity_threshold 2 too reactive

balance-illuminator agent / master-dd può:
- N=100 SPRT 95% bound (statistical confirm winrate gap 60% vs 100%)
- Bayesian knob tuning retreat_hp_pct 0.15 → 0.25/0.30
- Disable use_utility_brain isolated → measure delta

## Files

- `tools/sim/batch-ai-runner.js` parallel runner (no deps beyond Node)
- `tests/smoke/ai-driven-sim.js` refactor: AI_SIM_SISTEMA_PROFILE + AI_SIM_SEED + AI_SIM_RUN_LABEL env hooks
- `docs/playtest/2026-05-09-fase2-batch-ai-runner.md`

## CLI

\`\`\`bash
TUNNEL=https://<host>.trycloudflare.com node tools/sim/batch-ai-runner.js \
  --seed-count 100 --concurrency 4 \
  --profiles aggressive,balanced,cautious \
  --scenarios enc_tutorial_01 \
  --max-rounds 40
\`\`\`

## Output

\`\`\`
/tmp/ai-sim-runs/batch-<ISO>/
  ├── runs/run-N-<seed>-<profile>-<scenario>.jsonl
  ├── summary.json    (aggregate stats by_outcome + by_profile)
  ├── summary.csv     (one row per run, ingestable Excel/pandas)
  └── report.md       (Markdown table for PR / docs)
\`\`\`

## Unblocks

- N=100+ SPRT calibration via balance-illuminator agent
- MAP-Elites Quality-Diversity grid (extend --profiles w/ custom YAML)
- CI nightly regression workflow
- Pre-merge guard \`npm run smoke:batch -- --seed-count 30\`

## Cross-ref

- PR #2141 FASE 1 harness baseline (merged)
- PR #2140 + Godot v2 7b92724 B-NEW-14 (combat reachable phone-only)
- packs/evo_tactics_pack/data/balance/ai_profiles.yaml v0.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)