### PR TITLE
test(smoke): sistema_decision JSONL telemetry for RCA aggressive timeout

### DIFF
--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -276,6 +276,12 @@ function createDeclareSistemaIntents(deps) {
           intent: 'attack',
           target_id: target.id,
           aggro_override: aggroOverride || undefined,
+          // RCA aggressive timeout (docs/research/2026-05-09-aggressive-profile-calibration.md):
+          // surface utility brain score + per-consideration breakdown when
+          // policy comes from selectAiPolicyUtility. Undefined for legacy
+          // rule-based selectAiPolicy — JSON.stringify drops, no payload bloat.
+          score: policy.score,
+          breakdown: policy.breakdown,
         });
         continue;
       }
@@ -343,6 +349,8 @@ function createDeclareSistemaIntents(deps) {
         target_id: target.id,
         move_to: nextPos,
         aggro_override: aggroOverride || undefined,
+        score: policy.score,
+        breakdown: policy.breakdown,
       });
     }
 

--- a/tests/smoke/ai-driven-sim.js
+++ b/tests/smoke/ai-driven-sim.js
@@ -172,6 +172,34 @@ function logSection(title) {
   log('section', { title });
 }
 
+// RCA aggressive timeout (docs/research/2026-05-09-aggressive-profile-calibration.md):
+// extract Sistema AI decisions from /turn/end response (round_decisions array
+// emitted by handleTurnEndViaRound in sessionRoundBridge.js). One JSONL line
+// per Sistema unit per round documenting:
+//   - rule (UTILITY_AI / REGOLA_001 / REGOLA_002 / NO_TARGET / PRESSURE_CAP / STATO_*)
+//   - intent (attack / approach / retreat / skip)
+//   - target_id, score (utility brain), breakdown (per-consideration scores)
+//   - reason (skip cause: cornered / blocked / no enemy alive / stunned)
+// Distinguishes H1 (utility picks retreat, scoring issue), H2 (stepTowards
+// returns null, pathfinding issue), H3 (threat ctx null, injection issue).
+function logSistemaDecisions(round, body) {
+  if (!body || !Array.isArray(body.round_decisions)) return;
+  for (const d of body.round_decisions) {
+    log('sistema_decision', {
+      round,
+      unit_id: d.unit_id,
+      rule: d.rule || null,
+      intent: d.intent || null,
+      target_id: d.target_id ?? null,
+      score: typeof d.score === 'number' ? d.score : null,
+      breakdown: Array.isArray(d.breakdown) ? d.breakdown : null,
+      reason: d.reason || null,
+      move_to: d.move_to || null,
+      aggro_override: d.aggro_override || false,
+    });
+  }
+}
+
 (async () => {
   console.log(`AI sim run → ${LOG_PATH}`);
   console.log(`Tunnel: ${TUNNEL}`);
@@ -296,7 +324,8 @@ function logSection(title) {
     if (activeUnit.controlled_by === 'sistema') {
       // Server-side sistemaTurnRunner should have advanced the turn already
       // (via /turn/end). Force /turn/end to nudge if stuck.
-      await postJson('/api/session/turn/end', { session_id: sessionId });
+      const teRes = await postJson('/api/session/turn/end', { session_id: sessionId });
+      logSistemaDecisions(rounds, teRes.body);
       continue;
     }
 
@@ -304,7 +333,8 @@ function logSection(title) {
     const action = selectPlayerAction(activeUnit, units);
     if (!action) {
       // No valid target — end turn.
-      await postJson('/api/session/turn/end', { session_id: sessionId });
+      const teRes = await postJson('/api/session/turn/end', { session_id: sessionId });
+      logSistemaDecisions(rounds, teRes.body);
       continue;
     }
 
@@ -323,7 +353,8 @@ function logSection(title) {
 
     // End turn after single action (player AP=2 default; second action
     // optional — keep simple, end turn).
-    await postJson('/api/session/turn/end', { session_id: sessionId });
+    const teRes = await postJson('/api/session/turn/end', { session_id: sessionId });
+    logSistemaDecisions(rounds, teRes.body);
   }
 
   if (!outcome && rounds >= MAX_ROUNDS) outcome = 'timeout';
@@ -376,6 +407,15 @@ function logSection(title) {
   const restCalls = events.filter((e) => e.kind === 'rest').length;
   const wsEvents = events.filter((e) => e.kind === 'ws').length;
   const playerActions = events.filter((e) => e.kind === 'player_action').length;
+  const sistemaDecisions = events.filter((e) => e.kind === 'sistema_decision');
+  const intentDist = sistemaDecisions.reduce((acc, e) => {
+    acc[e.intent || 'unknown'] = (acc[e.intent || 'unknown'] || 0) + 1;
+    return acc;
+  }, {});
+  const ruleDist = sistemaDecisions.reduce((acc, e) => {
+    acc[e.rule || 'unknown'] = (acc[e.rule || 'unknown'] || 0) + 1;
+    return acc;
+  }, {});
   const phaseChanges = events.filter((e) => e.kind === 'ws' && e.type === 'phase_change');
   const totalDuration = events.length > 0 ? events[events.length - 1].ts - events[0].ts : 0;
 
@@ -385,6 +425,9 @@ function logSection(title) {
   console.log(`REST calls: ${restCalls}`);
   console.log(`WS events: ${wsEvents}`);
   console.log(`Player AI actions: ${playerActions}`);
+  console.log(`Sistema decisions: ${sistemaDecisions.length}`);
+  console.log(`  intent dist: ${JSON.stringify(intentDist)}`);
+  console.log(`  rule dist:   ${JSON.stringify(ruleDist)}`);
   console.log(`Combat outcome: ${outcome} (${rounds} rounds)`);
   console.log(`Phase progression: ${phaseChanges.map((e) => e.payload?.phase).join(' → ')}`);
   console.log(`Final phase: ${finalPhase}`);


### PR DESCRIPTION
## Summary

Surface Sistema AI decision per-round per-unit via new JSONL kind `sistema_decision` in `tests/smoke/ai-driven-sim.js`. Distinguishes RCA hypotheses for aggressive profile timeout ([docs/research/2026-05-09-aggressive-profile-calibration.md](docs/research/2026-05-09-aggressive-profile-calibration.md)):

- **H1** utility picks `retreat` instead of `attack` (scoring issue) → visible via `intent="retreat"` + `breakdown[]` per-consideration weights
- **H2** `stepTowards` returns null / grid-blocked (pathfinding) → visible via `intent="skip"` + `reason="cannot approach"` / `"cannot retreat — cornered"`
- **H3** threat ctx null in harness (injection) → visible via `rule` field (`UTILITY_AI` vs `REGOLA_001`)

## Diff

- `apps/backend/services/ai/declareSistemaIntents.js`: plumb `policy.score` + `policy.breakdown` (utility brain) into `decisions[]` for attack + move push. Undefined for legacy `selectAiPolicy` path, JSON.stringify drops, no payload bloat.
- `tests/smoke/ai-driven-sim.js`: new `logSistemaDecisions(round, body)` helper extracts `round_decisions` (already returned by `handleTurnEndViaRound` line 1630 in `sessionRoundBridge.js` — no new endpoint needed) at all 3 `/turn/end` call sites. Aggregate report adds intent + rule distribution.

## JSONL format

\`\`\`jsonl
{\"ts\":1715253900000,\"kind\":\"sistema_decision\",\"round\":3,\"unit_id\":\"sis_01\",\"rule\":\"UTILITY_AI\",\"intent\":\"retreat\",\"target_id\":\"pg_skiv\",\"score\":0.82,\"breakdown\":[{\"name\":\"TargetHealth\",\"raw\":1.0,\"curved\":0.0,\"weighted\":0.0},...],\"reason\":null,\"move_to\":{\"x\":4,\"y\":6},\"aggro_override\":false}
\`\`\`

## Guardrails

- Zero forbidden path touched (no \`.github/workflows/\`, \`migrations/\`, \`packages/contracts/\`, \`services/generation/\`)
- No new deps (npm/pip)
- 54 insertions / 3 deletions, all within \`apps/backend/\` + \`tests/\` scope
- Surface debt: harness-only telemetry, no UI/HUD impact

## Test plan

- [x] AI suite 383/383 verde (\`node --test tests/ai/*.test.js\`)
- [x] Prettier check verde
- [ ] Live run: \`TUNNEL=https://<host>.trycloudflare.com node tests/smoke/ai-driven-sim.js\` → verify JSONL contains \`sistema_decision\` events with score+breakdown for utility-AI profiles
- [ ] RCA query: \`jq 'select(.kind==\"sistema_decision\" and .intent==\"retreat\")' run-*.jsonl\` to confirm H1 vs H2 vs H3

## Rollback

\`git revert\` — additive-only, no schema/state migration. Decisions field optional, harness gracefully no-ops if \`round_decisions\` absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)