### PR TITLE
feat(ai): K4 Approach A stickiness term + sweep N=40 negative result

### DIFF
--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -215,7 +215,29 @@ function createDeclareSistemaIntents(deps) {
       const actorUseUtility = resolveUseUtilityBrain(actor);
       let policy;
       if (actorUseUtility) {
-        policy = selectAiPolicyUtility(actor, target, {}, difficultyProfile);
+        // K4 stickiness — merge per-profile stickiness_weight (and
+        // optional direction weight) into the difficultyProfile passed
+        // to selectAction. ai_profiles.yaml entry can declare:
+        //   <profile>:
+        //     stickiness_weight: 0.15
+        //     stickiness_direction_weight: 0.075   (optional, defaults to half)
+        // Profile fallback to base difficultyProfile (zero stickiness).
+        let stickyDifficulty = difficultyProfile;
+        if (aiProfiles && aiProfiles.profiles && actor && actor.ai_profile) {
+          const prof = aiProfiles.profiles[actor.ai_profile];
+          if (prof) {
+            const sw = prof.stickiness_weight;
+            const sdw = prof.stickiness_direction_weight;
+            if (typeof sw === 'number' || typeof sdw === 'number') {
+              stickyDifficulty = {
+                ...difficultyProfile,
+                ...(typeof sw === 'number' ? { stickiness_weight: sw } : {}),
+                ...(typeof sdw === 'number' ? { stickiness_direction_weight: sdw } : {}),
+              };
+            }
+          }
+        }
+        policy = selectAiPolicyUtility(actor, target, {}, stickyDifficulty);
       } else {
         policy = selectAiPolicy(actor, target, null, threatCtx);
       }

--- a/apps/backend/services/ai/sistemaTurnRunner.js
+++ b/apps/backend/services/ai/sistemaTurnRunner.js
@@ -187,6 +187,9 @@ function createSistemaTurnRunner(deps) {
           ia_rule: policy.rule,
           parry,
         });
+        // K4 stickiness state tracking (attack branch).
+        actor.last_action_type = 'attack';
+        actor.last_move_direction = null;
         if (killOccurred) break;
         continue;
       }
@@ -252,15 +255,22 @@ function createSistemaTurnRunner(deps) {
       event.ia_controlled_unit = actor.id;
       await appendEvent(session, event);
       actor.ap_remaining = Math.max(0, actor.ap_remaining - 1);
+      const moveKind = policy.intent === 'retreat' ? 'retreat' : 'move';
       actions.push({
         actor: 'sistema',
         unit_id: actor.id,
-        type: policy.intent === 'retreat' ? 'retreat' : 'move',
+        type: moveKind,
         target: target.id,
         position_from: positionFrom,
         position_to: { ...actor.position },
         ia_rule: policy.rule,
       });
+      // K4 Approach A — track last action + move direction per actor so
+      // utilityBrain.scoreAction stickiness branch can reward consistent
+      // commits next turn. Reduces multi-unit kite oscillation observed
+      // in PR #2145 (aggressive 53.5% WR vs 95% K3 ablation).
+      actor.last_action_type = moveKind;
+      actor.last_move_direction = actor.facing || null;
     }
 
     return actions;

--- a/apps/backend/services/ai/utilityBrain.js
+++ b/apps/backend/services/ai/utilityBrain.js
@@ -167,12 +167,32 @@ function manhattanFallback(a, b) {
  * Score a single action using all considerations.
  * Returns { score, breakdown: [{name, raw, curved, weighted}] }.
  */
+// K4 Approach A 2026-05-09 — stickiness term default weight. Bumped
+// pre-vs-post utility-OFF SPRT (#2146 K3 ablation 65%→95% +30pp WR;
+// production fix +36.5pp). Stickiness inhibits oscillation between
+// near-tie actions by giving the previously-committed action a small
+// additive bonus. Caller (sistemaTurnRunner) sets actor.last_action_type
+// + actor.last_move_direction post-commit each turn. Profile-overridable
+// via `stickiness_weight` in ai_profiles.yaml.
+const DEFAULT_STICKINESS_WEIGHT = 0.15;
+const DEFAULT_STICKINESS_DIRECTION_WEIGHT = 0.075;
+
+function _moveDirection(fromPos, toPos) {
+  if (!fromPos || !toPos) return null;
+  const dx = (toPos.x ?? 0) - (fromPos.x ?? 0);
+  const dy = (toPos.y ?? 0) - (fromPos.y ?? 0);
+  if (dx === 0 && dy === 0) return null;
+  if (Math.abs(dx) >= Math.abs(dy)) return dx > 0 ? 'E' : 'W';
+  return dy > 0 ? 'S' : 'N';
+}
+
 function scoreAction(
   action,
   actor,
   state,
   considerations = DEFAULT_CONSIDERATIONS,
   weightOverrides = {},
+  options = {},
 ) {
   // Additive aggregation. Was multiplicative ((weighted+0.01) accumulator)
   // ma sparse considerations (es. TargetHealth=0 su full-HP target) annichilavano
@@ -191,6 +211,26 @@ function scoreAction(
 
     totalScore += weighted;
     breakdown.push({ name, raw, curved, weighted });
+  }
+
+  // K4 stickiness — additive bonus when current action matches the
+  // previously-committed action_type / move direction. Reduces flip-flop
+  // oscillation in multi-unit kite scenarios (PR #2145 H1 validation
+  // captured 1-tile alternation between Sistema units).
+  const stickWeight = options.stickinessWeight ?? 0;
+  const stickDirWeight = options.stickinessDirectionWeight ?? stickWeight * 0.5;
+  if (stickWeight > 0 && actor && actor.last_action_type) {
+    if (action.type === actor.last_action_type) {
+      totalScore += stickWeight;
+      breakdown.push({ name: 'StickyAction', raw: 1, curved: 1, weighted: stickWeight });
+    }
+  }
+  if (stickDirWeight > 0 && action.type === 'move' && actor && actor.last_move_direction) {
+    const newDir = _moveDirection(actor.position, action.target_position);
+    if (newDir && newDir === actor.last_move_direction) {
+      totalScore += stickDirWeight;
+      breakdown.push({ name: 'StickyDirection', raw: 1, curved: 1, weighted: stickDirWeight });
+    }
   }
 
   return { score: totalScore, breakdown };
@@ -213,11 +253,19 @@ function selectAction(
 ) {
   if (!actions || actions.length === 0) return null;
 
-  const { selection = 'argmax', noise = 0 } = difficultyProfile;
+  const {
+    selection = 'argmax',
+    noise = 0,
+    stickiness_weight: stickinessWeight = 0,
+    stickiness_direction_weight: stickinessDirectionWeight,
+  } = difficultyProfile;
 
   // Score all actions
   const scored = actions.map((action) => {
-    const result = scoreAction(action, actor, state, considerations, weightOverrides);
+    const result = scoreAction(action, actor, state, considerations, weightOverrides, {
+      stickinessWeight,
+      stickinessDirectionWeight,
+    });
     // Add noise
     const noisyScore = result.score + (Math.random() - 0.5) * 2 * noise * result.score;
     return { action, score: Math.max(0, noisyScore), breakdown: result.breakdown };

--- a/docs/research/2026-05-09-k4-stickiness-implementation.md
+++ b/docs/research/2026-05-09-k4-stickiness-implementation.md
@@ -1,0 +1,155 @@
+---
+title: K4 stickiness Approach A — implementation + sweep results
+workstream: ops-qa
+category: playtest
+doc_status: active
+source_of_truth: true
+language: it
+last_verified: '2026-05-09'
+tags: [ai, balance, calibration, utility-brain, stickiness, fase2]
+---
+
+# K4 stickiness Approach A — implementation + sweep results
+
+Resume PR #2146 K3 fix. K4 implementation Approach A (additive last-action stickiness) shipped + sweep N=40 vs 90% utility-OFF baseline.
+
+## Implementation
+
+### `apps/backend/services/ai/utilityBrain.js`
+
+`scoreAction` accepts new `options = { stickinessWeight, stickinessDirectionWeight }`:
+
+```js
+function scoreAction(action, actor, state, considerations, weightOverrides, options = {}) {
+  // ... existing additive consideration loop ...
+  const stickWeight = options.stickinessWeight ?? 0;
+  const stickDirWeight = options.stickinessDirectionWeight ?? stickWeight * 0.5;
+  if (stickWeight > 0 && actor && actor.last_action_type) {
+    if (action.type === actor.last_action_type) {
+      totalScore += stickWeight;
+      breakdown.push({ name: 'StickyAction', raw: 1, curved: 1, weighted: stickWeight });
+    }
+  }
+  if (stickDirWeight > 0 && action.type === 'move' && actor && actor.last_move_direction) {
+    const newDir = _moveDirection(actor.position, action.target_position);
+    if (newDir && newDir === actor.last_move_direction) {
+      totalScore += stickDirWeight;
+      breakdown.push({ name: 'StickyDirection', raw: 1, curved: 1, weighted: stickDirWeight });
+    }
+  }
+  return { score: totalScore, breakdown };
+}
+```
+
+`selectAction` reads `stickiness_weight` + `stickiness_direction_weight` da `difficultyProfile` parameter and forwards via options.
+
+### `apps/backend/services/ai/declareSistemaIntents.js`
+
+`selectAiPolicyUtility` invocation merges per-profile stickiness into difficultyProfile:
+
+```js
+let stickyDifficulty = difficultyProfile;
+if (aiProfiles?.profiles?.[actor.ai_profile]) {
+  const prof = aiProfiles.profiles[actor.ai_profile];
+  if (
+    typeof prof.stickiness_weight === 'number' ||
+    typeof prof.stickiness_direction_weight === 'number'
+  ) {
+    stickyDifficulty = {
+      ...difficultyProfile,
+      ...(typeof prof.stickiness_weight === 'number'
+        ? { stickiness_weight: prof.stickiness_weight }
+        : {}),
+      ...(typeof prof.stickiness_direction_weight === 'number'
+        ? { stickiness_direction_weight: prof.stickiness_direction_weight }
+        : {}),
+    };
+  }
+}
+policy = selectAiPolicyUtility(actor, target, {}, stickyDifficulty);
+```
+
+### `apps/backend/services/ai/sistemaTurnRunner.js`
+
+Track `actor.last_action_type` + `actor.last_move_direction` post-commit each turn (attack, move, retreat branches).
+
+### YAML profile schema
+
+`packs/evo_tactics_pack/data/balance/ai_profiles.yaml` — new optional fields:
+
+```yaml
+<profile>:
+  use_utility_brain: true
+  stickiness_weight: 0.15 # additive bonus to last_action match
+  stickiness_direction_weight: 0.075 # additive bonus to last_move_direction match (default = stickiness_weight * 0.5)
+  overrides: { ... }
+```
+
+## Sweep results
+
+Live tunnel `remaining-guidance-jan-number` + `distinction-harper-seems-desktops`. N=20 per profile, max_rounds=40.
+
+| Profile                                     | Sticky w | Sticky dir w | Runs |   V |   D |   T | **Win rate** | Avg rounds |
+| ------------------------------------------- | :------: | :----------: | ---: | --: | --: | --: | -----------: | ---------: |
+| aggressive (utility OFF, **prod baseline**) |    —     |      —       |   20 |  17 |   2 |   1 |      **85%** |       26.4 |
+| aggressive_with_stickiness (0.15)           |   0.15   |    0.075     |   20 |  11 |   0 |   9 |      **55%** |       31.5 |
+| aggressive_sticky_30                        |   0.30   |     0.15     |   20 |  12 |   1 |   7 |      **60%** |        ~30 |
+
+**Trend**: stickiness 0.15 → 0.30 improves +5pp ma rimane **-25pp dal baseline 85%**. Sweep candidate 0.50 disponibile ma trend asintotico suggerisce limite Approach A.
+
+**Conclusion**: K4 Approach A NOT SUFFICIENT to recover utility brain performance vs OFF baseline. Stickiness weight bump improves marginally but cannot overcome score gradient flip-flop in two-unit kite scenarios.
+
+## Hypothesis update
+
+Score gradient analysis suggests TargetHealth/SelfHealth/Distance considerations swap signs based on micro-position changes faster than additive stickiness can compensate. Specifically:
+
+- **Distance quadratic_inverse** at range boundary (range=2) produces steep score gradient
+- **TargetHealth swap** post damage exchange flips approach/retreat preference
+- Two Sistema units score differently → one approaches while other retreats → no mutual reinforcement
+
+Stickiness 0.15-0.30 cannot dominate weighted sum (other considerations 0.4-0.8 each).
+
+## Next steps
+
+| Option                                                                                | Effort  | Expected ΔWR                         |
+| ------------------------------------------------------------------------------------- | ------- | ------------------------------------ |
+| **Approach A** sticky 0.50                                                            | minimal | +5-10pp marginal                     |
+| **Approach B** commit-window guard (deterministic anti-flip in declareSistemaIntents) | ~1h     | +15-25pp likely                      |
+| **Approach C** softmax + temperature (selectAction stochastic)                        | ~1h     | uncertain (introduces stochasticity) |
+| **Stay with K3 prod fix** (utility OFF on aggressive)                                 | 0       | baseline 85-90% WR                   |
+
+**Recommendation**: ship K4 negative result + maintain K3 prod fix. Test Approach B next cycle.
+
+## Production state confirmed
+
+- `aggressive` profile: `use_utility_brain: false` (K3 fix #2146)
+- `aggressive_no_util`: ablation reproduction profile (preserved)
+- `aggressive_with_stickiness` (0.15): K4 sticky failed
+- `aggressive_sticky_30` (0.30): K4 sticky failed
+- Default Sistema balance unchanged for `balanced` (no overrides) + `cautious` (utility OFF)
+
+## Files patched this PR
+
+- `apps/backend/services/ai/utilityBrain.js` — stickiness branch in scoreAction + selectAction wiring
+- `apps/backend/services/ai/sistemaTurnRunner.js` — last_action_type + last_move_direction state tracking
+- `apps/backend/services/ai/declareSistemaIntents.js` — per-profile stickiness merge into difficultyProfile
+- `packs/evo_tactics_pack/data/balance/ai_profiles.yaml` — 2 new sweep profiles (aggressive_with_stickiness + aggressive_sticky_30)
+- `docs/research/2026-05-09-k4-stickiness-implementation.md` (this doc)
+
+## Cross-ref
+
+- PR #2146 K3 prod fix (utility OFF baseline 90% WR)
+- PR #2145 H1 validation (oscillation root cause confirmed)
+- PR #2143 balance-illuminator RCA
+- K4 sticky 0.15 batch: `C:/tmp/ai-sim-runs/batch-2026-05-09T13-02-20-362Z/`
+- K4 sticky 0.30 batch: `C:/tmp/ai-sim-runs/batch-2026-05-09T13-08-45-689Z/`
+
+## Resume triggers
+
+> _"esegui K4 sticky 0.50 sweep — final extreme test Approach A"_
+
+> _"esegui K4 Approach B commit-window — declareSistemaIntents.js anti-flip guard"_
+
+> _"esegui K4 Approach C softmax temperature — selectAction stochastic"_
+
+> _"esegui MAP-Elites K4 grid — sticky × commit-window × softmax cells"_

--- a/packs/evo_tactics_pack/data/balance/ai_profiles.yaml
+++ b/packs/evo_tactics_pack/data/balance/ai_profiles.yaml
@@ -64,6 +64,38 @@ profiles:
       default_attack_range: 2
       threat_passivity_threshold: 2
 
+  # FASE 2.x — K4 Approach A stickiness (PR #2146 follow-up). Re-enable
+  # utility_brain ma con stickiness_weight additivo per inibire flip-flop
+  # oscillation tra azioni near-tie. SPRT plan: confronto vs aggressive
+  # (utility OFF baseline 90% WR):
+  #   ≥ 88% WR → ship sticky come default + deprecate aggressive_no_util
+  #   < 80% WR → escalate Approach B commit-window OR Approach C softmax
+  aggressive_with_stickiness:
+    label: "Aggressivo (utility ON + K4 stickiness 0.15)"
+    description: "Aggressive con utility_brain riabilitato + stickiness term anti-flip-flop."
+    use_utility_brain: true
+    stickiness_weight: 0.15
+    stickiness_direction_weight: 0.075
+    overrides:
+      retreat_hp_pct: 0.15
+      kite_buffer: 0
+      default_attack_range: 2
+      threat_passivity_threshold: 2
+
+  # K4 Approach A — heavier stickiness sweep. 0.15 N=20 N=20 mostra 55% WR
+  # (insufficient vs 85% OFF baseline). 0.30 sweep candidate.
+  aggressive_sticky_30:
+    label: "Aggressivo (utility ON + K4 stickiness 0.30)"
+    description: "Aggressive sticky 2x weight per testare oscillation suppression."
+    use_utility_brain: true
+    stickiness_weight: 0.30
+    stickiness_direction_weight: 0.15
+    overrides:
+      retreat_hp_pct: 0.15
+      kite_buffer: 0
+      default_attack_range: 2
+      threat_passivity_threshold: 2
+
   balanced:
     label: "Bilanciato"
     description: "Comportamento default del Sistema. Nessun override."


### PR DESCRIPTION
## Summary

Resume PR #2146 K3 fix. K4 implementation Approach A — additive last-action stickiness in utilityBrain.scoreAction + state tracking sistemaTurnRunner + per-profile YAML schema. N=40 sweep vs 90% utility-OFF baseline.

## Implementation shipped

- `apps/backend/services/ai/utilityBrain.js` — `scoreAction` accepts options.stickinessWeight + options.stickinessDirectionWeight. Breakdown adds StickyAction + StickyDirection rows.
- `apps/backend/services/ai/declareSistemaIntents.js` — per-profile stickiness merge into difficultyProfile pre-utility invocation.
- `apps/backend/services/ai/sistemaTurnRunner.js` — track `actor.last_action_type` + `actor.last_move_direction` post-commit (attack, move, retreat branches).
- `packs/evo_tactics_pack/data/balance/ai_profiles.yaml` — 2 sweep profiles + schema fields.

## Sweep results

| Profile | Sticky w | Win rate | Δ vs prod |
|---|:-:|---:|---:|
| aggressive (utility OFF, **prod baseline**) | — | **85%** | baseline |
| aggressive_with_stickiness | 0.15 | **55%** | -30pp |
| aggressive_sticky_30 | 0.30 | **60%** | -25pp |

**Trend**: 0.15 → 0.30 = +5pp marginal. Asintotico, Approach A insufficient.

## Hypothesis

Score gradient TargetHealth/SelfHealth/Distance swap signs faster than 0.15-0.30 stickiness can dominate. Two Sistema units score independently → one approaches, other retreats → no mutual reinforcement.

## Next steps

| Option | Effort | Expected ΔWR |
|---|---|---|
| Approach A sticky 0.50 | minimal | +5-10pp marginal |
| **Approach B** commit-window | ~1h | +15-25pp likely |
| Approach C softmax temperature | ~1h | uncertain |
| **Stay K3 prod fix** | 0 | 85-90% baseline |

## Recommendation

Ship K4 negative result + retain K3 prod fix #2146. Production unchanged: `aggressive use_utility_brain: false`. Sweep profiles available for future SPRT comparison.

## Cross-ref

- PR #2146 K3 prod fix (90% WR)
- PR #2145 H1 validation (oscillation root cause)
- K4 sticky 0.15 batch: `C:/tmp/ai-sim-runs/batch-2026-05-09T13-02-20-362Z/`
- K4 sticky 0.30 batch: `C:/tmp/ai-sim-runs/batch-2026-05-09T13-08-45-689Z/`

## Resume triggers

> _"esegui K4 Approach B commit-window — declareSistemaIntents.js anti-flip"_

🤖 Generated with [Claude Code](https://claude.com/claude-code)