### PR TITLE
feat(ai): swap default aggressive profile to commit-window+utility ON

### DIFF
--- a/packs/evo_tactics_pack/data/balance/ai_profiles.yaml
+++ b/packs/evo_tactics_pack/data/balance/ai_profiles.yaml
@@ -27,18 +27,26 @@ profiles:
     description: "Attacca con poca considerazione per HP. Retreat solo in extremis."
     # Utility AI gradual rollout (ADR-2026-04-17 Q-001 T3.1): primo profile flip.
     # 2026-04-29 fix utilityBrain oscillation (action-aware TargetHealth/SelfHealth +
-    # additive scoring) → kill-switch ripristinato a true. Apex tutorial_05 verificato
-    # monotonic forward 5→4→3→2 (range scout). Vedi docs/reports/2026-04-29-utility-ai-oscillation-bug.md.
+    # additive scoring) → kill-switch ripristinato a true.
     #
-    # FASE 2.x rollback 2026-05-09 (PR #2145 + K3 ablation):
-    # tutorial_01 multi-unit kite scenarios mostrano 2026-04-29 fix
-    # INCOMPLETO. N=40 K3 ablation ha confermato utility brain causale:
-    #   - aggressive utility ON   → 65% WR (35% timeout, 29.5 avg rounds)
-    #   - aggressive_no_util ABL  → 95% WR (0% timeout, 24.8 avg rounds)
-    # ΔWR +30pp. Flip kill-switch back to false fino a fix utilityBrain
-    # stickiness/commit-window (K4 follow-up audit).
-    # Cross-ref: docs/research/2026-05-09-aggressive-h1-validation-oscillation.md
-    use_utility_brain: false
+    # FASE 2.x rollback 2026-05-09 (PR #2145 + K3 ablation): rollback to false
+    # post-confirmation utility brain causale (aggressive utility ON 65% WR vs
+    # ablation 95% WR, ΔWR +30pp).
+    #
+    # FASE 2.x SWAP 2026-05-09 sera (PR #2149 K4 Approach B verdict):
+    # commit-window guard deterministico in declareSistemaIntents recovery
+    # +10pp absolute (capped 100% N=40 vs K3 baseline 90% N=20). Re-enable
+    # utility_brain con commit_window: 2 — guard fires su flip detection
+    # (intent reversal OR direzione di movimento opposta a last_move_direction)
+    # forzando intent precedente per 2 turni. Combina exploration utility
+    # brain (weighted considerations) con anti-oscillation determinismo.
+    #
+    # Sweep results validation (PR #2149):
+    #   K3 baseline aggressive utility OFF      90% WR avg 25.0r
+    #   aggressive utility ON + commit_window 2 100% WR avg 24.2r (+10pp, -0.8r)
+    # Cross-ref: docs/research/2026-05-09-k4-commit-window-implementation.md
+    use_utility_brain: true
+    commit_window: 2
     overrides:
       retreat_hp_pct: 0.15
       kite_buffer: 0


### PR DESCRIPTION
## Summary

Promote K4 Approach B configuration come default per il profile `aggressive`, post sweep validation N=40 in PR #2149 (100% WR vs K3 baseline 90% WR, +10pp absolute, avg rounds -0.8).

Profile change in `packs/evo_tactics_pack/data/balance/ai_profiles.yaml`:
- `use_utility_brain: false` → `true`
- `commit_window: 2` (new field, leveraging PR #2149 anti-flip guard logic)

Profile alternativi preservati per ablation testing + reproducibility:
- `aggressive_no_util` (K3 ablation)
- `aggressive_with_stickiness` (K4 sticky 0.15)
- `aggressive_sticky_30` (K4 sticky 0.30)
- `aggressive_commit_window` (explicit K4 Approach B variant)

## Sweep evidence (PR #2149)

| Profile | N | WR | Avg rounds |
|---|---:|---:|---:|
| aggressive (K3 baseline, utility OFF) | 20 | 90% | 25.0 |
| aggressive (NEW default — utility ON + commit_window 2) | 40 | **100%** | **24.2** |

Zero timeouts, zero defeats. Anti-flip guard deterministico in declareSistemaIntents fires on intent reversal OR direzione di movimento opposta a last_move_direction, forzando intent precedente per 2 turni. Riabilita exploration utility brain weighted considerations senza oscillation.

## Test plan

- [x] AI tests verde — `node --test tests/ai/*.test.js` 393/393 passes
- [x] Format check — Prettier verde
- [ ] (raccomandato post-merge) Scenario diversity sweep `aggressive` × enc_tutorial_02..05 + hardcore-* per validare consistency
- [ ] (raccomandato post-merge) Master-dd playtest LIVE conferma balance non over-dominante user-perceived

## Risk

100% WR N=40 enc_tutorial_01 può essere troppo dominante per master-dd playtest LIVE. Se feedback "Sistema feels overwhelmed" → revert single-line YAML (toggle `use_utility_brain: false`) + ablation testing alternative tuning (es. `commit_window: 1` instead of 2).

## Cross-ref

- PR #2149 K4 Approach B implementation + sweep
- PR #2146 K3 prod fix (precedente default utility OFF)
- PR #2147 K4 Approach A negative result
- PR #2145 H1 validation oscillation root cause
- [docs/research/2026-05-09-k4-commit-window-implementation.md](docs/research/2026-05-09-k4-commit-window-implementation.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)