### PR TITLE
fix(catalog): wire 8 Bucket B orphan traits into biome_pools (TKT-TRAIT-ORPHAN-ACTIVE)

### DIFF
--- a/data/core/traits/biome_pools.json
+++ b/data/core/traits/biome_pools.json
@@ -1,13 +1,20 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2025-02-18T00:00:00Z",
+  "updated_at": "2026-05-10T03:25:00Z",
   "pools": [
     {
       "id": "cryosteppe_convergence",
       "label": "Convergenza Cryosteppe",
       "summary": "Distese glaciali fratturate dove cristalli piezoelettrici amplificano bufere notturne.",
-      "climate_tags": ["frozen", "wind", "night"],
-      "size": { "min": 3, "max": 6 },
+      "climate_tags": [
+        "frozen",
+        "wind",
+        "night"
+      ],
+      "size": {
+        "min": 3,
+        "max": 6
+      },
       "hazard": {
         "severity": "high",
         "description": "Bombe di ghiaccio sovraccariche e whiteout magnetici che colpiscono i punti di raccolta.",
@@ -18,7 +25,10 @@
       },
       "ecology": {
         "biome_type": "cryosteppe",
-        "primary_resources": ["ghiaccio_piezoelettrico", "gas_ionizzati"],
+        "primary_resources": [
+          "ghiaccio_piezoelettrico",
+          "gas_ionizzati"
+        ],
         "notes": "Colonie nomadi sfruttano ponti di luce per attraversare canyon congelati."
       },
       "traits": {
@@ -26,7 +36,8 @@
           "ghiaccio_piezoelettrico",
           "criostasi_adattiva",
           "capillari_criogenici",
-          "gusci_criovetro"
+          "gusci_criovetro",
+          "aura_glaciale"
         ],
         "support": [
           "ghiandole_nebbia_ionica",
@@ -39,40 +50,68 @@
           "role": "apex",
           "label": "Predatore Risonante",
           "summary": "Trappole soniche e artigli cristallizzati per cacciare attraverso bufere notturne.",
-          "functional_tags": ["criogenico", "imboscata"],
-          "preferred_traits": ["criostasi_adattiva", "ghiaccio_piezoelettrico"],
+          "functional_tags": [
+            "criogenico",
+            "imboscata"
+          ],
+          "preferred_traits": [
+            "criostasi_adattiva",
+            "ghiaccio_piezoelettrico"
+          ],
           "tier": 4
         },
         {
           "role": "keystone",
           "label": "Scultore di Cristalli",
           "summary": "Stabilizza ponti ionici e diffonde segnali guida per le carovane.",
-          "functional_tags": ["supporto", "costruttore"],
-          "preferred_traits": ["capillari_criogenici", "antenne_wideband"],
+          "functional_tags": [
+            "supporto",
+            "costruttore"
+          ],
+          "preferred_traits": [
+            "capillari_criogenici",
+            "antenne_wideband"
+          ],
           "tier": 3
         },
         {
           "role": "bridge",
           "label": "Colportore Luminescente",
           "summary": "Trasporta risorse tra vallate congelate usando scie fotoniche.",
-          "functional_tags": ["logistica", "mobilità"],
-          "preferred_traits": ["foliage_fotocatodico"],
+          "functional_tags": [
+            "logistica",
+            "mobilità"
+          ],
+          "preferred_traits": [
+            "foliage_fotocatodico"
+          ],
           "tier": 2
         },
         {
           "role": "threat",
           "label": "Fiera del Whiteout",
           "summary": "Scatena tempeste mirate contro convogli e basi mobili.",
-          "functional_tags": ["assalto", "area_control"],
-          "preferred_traits": ["ghiandole_nebbia_ionica", "criostasi_adattiva"],
+          "functional_tags": [
+            "assalto",
+            "area_control"
+          ],
+          "preferred_traits": [
+            "ghiandole_nebbia_ionica",
+            "criostasi_adattiva"
+          ],
           "tier": 3
         },
         {
           "role": "event",
           "label": "Cascata di Schegge",
           "summary": "Fenomeno stagionale che rilascia cristalli senzienti e missioni di recupero.",
-          "functional_tags": ["evento", "stagionale"],
-          "preferred_traits": ["gusci_criovetro"],
+          "functional_tags": [
+            "evento",
+            "stagionale"
+          ],
+          "preferred_traits": [
+            "gusci_criovetro"
+          ],
           "tier": 2
         }
       ]
@@ -81,8 +120,15 @@
       "id": "magnetar_badlands",
       "label": "Badlands Magnetar",
       "summary": "Falesie ferrose e canyon plasmati da tempeste elettromagnetiche continue.",
-      "climate_tags": ["arid", "electric", "storm"],
-      "size": { "min": 4, "max": 6 },
+      "climate_tags": [
+        "arid",
+        "electric",
+        "storm"
+      ],
+      "size": {
+        "min": 4,
+        "max": 6
+      },
       "hazard": {
         "severity": "high",
         "description": "Sferzate di polvere ferrosa ionizzata e fulmini che riaccendono rottami dormienti.",
@@ -93,7 +139,10 @@
       },
       "ecology": {
         "biome_type": "badlands",
-        "primary_resources": ["ferro_memoria", "polveri_magnetiche"],
+        "primary_resources": [
+          "ferro_memoria",
+          "polveri_magnetiche"
+        ],
         "notes": "Clan nomadi sfruttano creste conduttive per dirigere le tempeste."
       },
       "traits": {
@@ -106,7 +155,8 @@
         "support": [
           "enzimi_chelatori_rapidi",
           "filamenti_superconduttivi",
-          "antenne_tesla"
+          "antenne_tesla",
+          "aculei_velenosi"
         ]
       },
       "role_templates": [
@@ -114,40 +164,68 @@
           "role": "apex",
           "label": "Dominatore Magnetico",
           "summary": "Canalizza scariche elettromagnetiche per travolgere bersagli corazzati.",
-          "functional_tags": ["offensiva", "controllo_campo"],
-          "preferred_traits": ["carapace_fase_variabile", "antenne_tesla"],
+          "functional_tags": [
+            "offensiva",
+            "controllo_campo"
+          ],
+          "preferred_traits": [
+            "carapace_fase_variabile",
+            "antenne_tesla"
+          ],
           "tier": 4
         },
         {
           "role": "keystone",
           "label": "Forgiatore di Creste",
           "summary": "Stabilizza ponti conduttivi e riattiva infrastrutture ferrose.",
-          "functional_tags": ["supporto", "ingegneria"],
-          "preferred_traits": ["filamenti_superconduttivi", "cuticole_cerose"],
+          "functional_tags": [
+            "supporto",
+            "ingegneria"
+          ],
+          "preferred_traits": [
+            "filamenti_superconduttivi",
+            "cuticole_cerose"
+          ],
           "tier": 3
         },
         {
           "role": "bridge",
           "label": "Pattugliatore dei Canyon",
           "summary": "Apri corridoi sicuri durante le tempeste e guida le spedizioni.",
-          "functional_tags": ["mobilità", "ricognizione"],
-          "preferred_traits": ["coda_frusta_cinetica"],
+          "functional_tags": [
+            "mobilità",
+            "ricognizione"
+          ],
+          "preferred_traits": [
+            "coda_frusta_cinetica"
+          ],
           "tier": 2
         },
         {
           "role": "threat",
           "label": "Sciame Ferruginoso",
           "summary": "Naniti magnetiche che corrodono equipaggiamenti e sovraccaricano difese.",
-          "functional_tags": ["corrosivo", "sabotaggio"],
-          "preferred_traits": ["enzimi_chelatori_rapidi", "foliaggio_spugna"],
+          "functional_tags": [
+            "corrosivo",
+            "sabotaggio"
+          ],
+          "preferred_traits": [
+            "enzimi_chelatori_rapidi",
+            "foliaggio_spugna"
+          ],
           "tier": 3
         },
         {
           "role": "event",
           "label": "Tempesta Ascensionale",
           "summary": "Evento meteorico che solleva piattaforme di rottami verso orbite basse.",
-          "functional_tags": ["evento", "verticalità"],
-          "preferred_traits": ["filamenti_superconduttivi"],
+          "functional_tags": [
+            "evento",
+            "verticalità"
+          ],
+          "preferred_traits": [
+            "filamenti_superconduttivi"
+          ],
           "tier": 2
         }
       ]
@@ -156,8 +234,15 @@
       "id": "aerial_canopy",
       "label": "Canopia Iono-Aerostatica",
       "summary": "Foreste sospese con piattaforme elettrostatiche e correnti ascendenti costanti.",
-      "climate_tags": ["temperate", "aerial", "ion"],
-      "size": { "min": 3, "max": 5 },
+      "climate_tags": [
+        "temperate",
+        "aerial",
+        "ion"
+      ],
+      "size": {
+        "min": 3,
+        "max": 5
+      },
       "hazard": {
         "severity": "medium",
         "description": "Cadute da passerelle instabili e archi elettrici spontanei.",
@@ -168,7 +253,10 @@
       },
       "ecology": {
         "biome_type": "canopy",
-        "primary_resources": ["linfa_tampone", "cariche_statiche"],
+        "primary_resources": [
+          "linfa_tampone",
+          "cariche_statiche"
+        ],
         "notes": "Le viti conduttive formano reti di trasporto sospese tra pilastri ionici."
       },
       "traits": {
@@ -181,7 +269,8 @@
         "support": [
           "linfa_tampone",
           "lamine_filtranti_aeree",
-          "appendici_risonanti_marea"
+          "appendici_risonanti_marea",
+          "canto_di_richiamo"
         ]
       },
       "role_templates": [
@@ -189,40 +278,67 @@
           "role": "apex",
           "label": "Predatore Vorticale",
           "summary": "Sfrutta correnti ascensionali e campi ionici per abbattere intrusi dall'alto.",
-          "functional_tags": ["aereo", "imboscata"],
-          "preferred_traits": ["cuscinetti_elettrostatici", "static_vines"],
+          "functional_tags": [
+            "aereo",
+            "imboscata"
+          ],
+          "preferred_traits": [
+            "cuscinetti_elettrostatici",
+            "static_vines"
+          ],
           "tier": 4
         },
         {
           "role": "keystone",
           "label": "Custode delle Liane",
           "summary": "Mantiene il bilanciamento delle passerelle e diffonde energia alle colonie sospese.",
-          "functional_tags": ["supporto", "energia"],
-          "preferred_traits": ["static_vines", "linfa_tampone"],
+          "functional_tags": [
+            "supporto",
+            "energia"
+          ],
+          "preferred_traits": [
+            "static_vines",
+            "linfa_tampone"
+          ],
           "tier": 3
         },
         {
           "role": "bridge",
           "label": "Navigatore delle Correnti",
           "summary": "Guida convogli volanti e sincronizza i flussi tra piattaforme.",
-          "functional_tags": ["mobilità", "coordinazione"],
-          "preferred_traits": ["antenne_waveguide"],
+          "functional_tags": [
+            "mobilità",
+            "coordinazione"
+          ],
+          "preferred_traits": [
+            "antenne_waveguide"
+          ],
           "tier": 2
         },
         {
           "role": "threat",
           "label": "Sciame Ionostatico",
           "summary": "Scarica impulsi che paralizzano cavi e planatori.",
-          "functional_tags": ["disturbo", "crowd_control"],
-          "preferred_traits": ["appendici_risonanti_marea"],
+          "functional_tags": [
+            "disturbo",
+            "crowd_control"
+          ],
+          "preferred_traits": [
+            "appendici_risonanti_marea"
+          ],
           "tier": 3
         },
         {
           "role": "event",
           "label": "Marea Luminescente",
           "summary": "Fenomeno migratorio che ricarica o scarica le piattaforme sospese.",
-          "functional_tags": ["evento", "risorsa"],
-          "preferred_traits": ["foliage_fotocatodico"],
+          "functional_tags": [
+            "evento",
+            "risorsa"
+          ],
+          "preferred_traits": [
+            "foliage_fotocatodico"
+          ],
           "tier": 2
         }
       ]
@@ -231,8 +347,15 @@
       "id": "abyssal_hydrothermal",
       "label": "Abyssi Idrotermali",
       "summary": "Camini abissali che miscelano acqua supercritica e bio-luminescenza minerale.",
-      "climate_tags": ["aquatic", "pressure", "thermal"],
-      "size": { "min": 3, "max": 5 },
+      "climate_tags": [
+        "aquatic",
+        "pressure",
+        "thermal"
+      ],
+      "size": {
+        "min": 3,
+        "max": 5
+      },
       "hazard": {
         "severity": "high",
         "description": "Geyser supercritici e collassi strutturali che ridistribuiscono intere colonie.",
@@ -243,7 +366,10 @@
       },
       "ecology": {
         "biome_type": "hydrothermal_vents",
-        "primary_resources": ["minerali_risonanti", "microfauna_chemosintetica"],
+        "primary_resources": [
+          "minerali_risonanti",
+          "microfauna_chemosintetica"
+        ],
         "notes": "Conduzioni basaltiche creano reti di scambio tra torri di ventilazione."
       },
       "traits": {
@@ -256,7 +382,8 @@
         "support": [
           "filamenti_digestivi_compattanti",
           "biofilm_glow",
-          "branchie_dual_mode"
+          "branchie_dual_mode",
+          "tentacoli_uncinati"
         ]
       },
       "role_templates": [
@@ -264,40 +391,67 @@
           "role": "apex",
           "label": "Cacciatore Supercritico",
           "summary": "Sfrutta getti idrotermali per proiettarsi su prede ignare.",
-          "functional_tags": ["acquatico", "pressione"],
-          "preferred_traits": ["branchie_turbina", "enzimi_metanoossidanti"],
+          "functional_tags": [
+            "acquatico",
+            "pressione"
+          ],
+          "preferred_traits": [
+            "branchie_turbina",
+            "enzimi_metanoossidanti"
+          ],
           "tier": 4
         },
         {
           "role": "keystone",
           "label": "Custode Chemosintetico",
           "summary": "Regola la distribuzione di nutrienti e bilancia i gradienti termici.",
-          "functional_tags": ["supporto", "nutrizione"],
-          "preferred_traits": ["filamenti_digestivi_compattanti", "biofilm_glow"],
+          "functional_tags": [
+            "supporto",
+            "nutrizione"
+          ],
+          "preferred_traits": [
+            "filamenti_digestivi_compattanti",
+            "biofilm_glow"
+          ],
           "tier": 3
         },
         {
           "role": "bridge",
           "label": "Mappatore di Correnti",
           "summary": "Collega fumarole distanti tramite corridoi di pressione stabilizzati.",
-          "functional_tags": ["ricognizione", "logistica"],
-          "preferred_traits": ["antenne_flusso_mareale"],
+          "functional_tags": [
+            "ricognizione",
+            "logistica"
+          ],
+          "preferred_traits": [
+            "antenne_flusso_mareale"
+          ],
           "tier": 2
         },
         {
           "role": "threat",
           "label": "Sciame Basaltico",
           "summary": "Micro-colonie corrosive che attaccano strutture e habitat temporanei.",
-          "functional_tags": ["corrosivo", "assalto"],
-          "preferred_traits": ["ciste_salmastre"],
+          "functional_tags": [
+            "corrosivo",
+            "assalto"
+          ],
+          "preferred_traits": [
+            "ciste_salmastre"
+          ],
           "tier": 3
         },
         {
           "role": "event",
           "label": "Eruzione di Lumen",
           "summary": "Evento periodico che libera energia bio-luminescente da sfruttare immediatamente.",
-          "functional_tags": ["evento", "risorsa"],
-          "preferred_traits": ["biofilm_glow"],
+          "functional_tags": [
+            "evento",
+            "risorsa"
+          ],
+          "preferred_traits": [
+            "biofilm_glow"
+          ],
           "tier": 2
         }
       ]
@@ -306,8 +460,15 @@
       "id": "mycelial_vaults",
       "label": "Volte Miceliali",
       "summary": "Caverne stratificate illuminate da reti micotiche pulsanti e gas nutritivi.",
-      "climate_tags": ["subterranean", "humid", "bioluminescent"],
-      "size": { "min": 3, "max": 5 },
+      "climate_tags": [
+        "subterranean",
+        "humid",
+        "bioluminescent"
+      ],
+      "size": {
+        "min": 3,
+        "max": 5
+      },
       "hazard": {
         "severity": "medium",
         "description": "Spore caustiche e collassi enzimatici che riconfigurano i tunnel abitati.",
@@ -318,7 +479,10 @@
       },
       "ecology": {
         "biome_type": "fungal",
-        "primary_resources": ["spore_bioattive", "biofilm_nutriente"],
+        "primary_resources": [
+          "spore_bioattive",
+          "biofilm_nutriente"
+        ],
         "notes": "Le camere sono modulabili con ponti micotici che filtrano luce e nutrienti."
       },
       "traits": {
@@ -326,12 +490,14 @@
           "biofilm_glow",
           "appendici_risonanti_marea",
           "foliaggio_spugna",
-          "enzimi_antifase_termica"
+          "enzimi_antifase_termica",
+          "spore_paniche"
         ],
         "support": [
           "ghiandole_fango_coesivo",
           "capsule_paracadute",
-          "camere_nutrienti_vent"
+          "camere_nutrienti_vent",
+          "tela_appiccicosa"
         ]
       },
       "role_templates": [
@@ -339,40 +505,67 @@
           "role": "apex",
           "label": "Sovrano Micelico",
           "summary": "Manipola reti di spore per colpire nemici e deviarli in gallerie trappola.",
-          "functional_tags": ["psionico", "controllo_campo"],
-          "preferred_traits": ["appendici_risonanti_marea", "enzimi_antifase_termica"],
+          "functional_tags": [
+            "psionico",
+            "controllo_campo"
+          ],
+          "preferred_traits": [
+            "appendici_risonanti_marea",
+            "enzimi_antifase_termica"
+          ],
           "tier": 4
         },
         {
           "role": "keystone",
           "label": "Curatore di Volte",
           "summary": "Stabilizza camere e ridistribuisce nutrienti ai cluster abitativi.",
-          "functional_tags": ["supporto", "terraforming"],
-          "preferred_traits": ["biofilm_glow", "camere_nutrienti_vent"],
+          "functional_tags": [
+            "supporto",
+            "terraforming"
+          ],
+          "preferred_traits": [
+            "biofilm_glow",
+            "camere_nutrienti_vent"
+          ],
           "tier": 3
         },
         {
           "role": "bridge",
           "label": "Navetta Sporiale",
           "summary": "Collega grotte lontane tramite corridoi micelici espandibili.",
-          "functional_tags": ["logistica", "mobilità"],
-          "preferred_traits": ["capsule_paracadute"],
+          "functional_tags": [
+            "logistica",
+            "mobilità"
+          ],
+          "preferred_traits": [
+            "capsule_paracadute"
+          ],
           "tier": 2
         },
         {
           "role": "threat",
           "label": "Sciame Caustico",
           "summary": "Rilascia spore corrosive che dissolvono equipaggiamenti e ridistribuiscono biomassa.",
-          "functional_tags": ["corrosivo", "assalto"],
-          "preferred_traits": ["ghiandole_fango_coesivo"],
+          "functional_tags": [
+            "corrosivo",
+            "assalto"
+          ],
+          "preferred_traits": [
+            "ghiandole_fango_coesivo"
+          ],
           "tier": 3
         },
         {
           "role": "event",
           "label": "Fioritura Sincronica",
           "summary": "Evento ciclico che apre nuovi tunnel e rilascia opportunità narrative.",
-          "functional_tags": ["evento", "espansione"],
-          "preferred_traits": ["foliaggio_spugna"],
+          "functional_tags": [
+            "evento",
+            "espansione"
+          ],
+          "preferred_traits": [
+            "foliaggio_spugna"
+          ],
           "tier": 2
         }
       ]
@@ -381,16 +574,29 @@
       "id": "fotofase_synaptic_ridge",
       "label": "Cresta Fotofase Sinaptica",
       "summary": "Barriere coralline bioelettriche che convogliano luce e impulsi superficiali.",
-      "climate_tags": ["luminescente", "pelagico_superficiale", "elettroattivo"],
-      "size": { "min": 3, "max": 5 },
+      "climate_tags": [
+        "luminescente",
+        "pelagico_superficiale",
+        "elettroattivo"
+      ],
+      "size": {
+        "min": 3,
+        "max": 5
+      },
       "hazard": {
         "severity": "medium",
         "description": "Impulsi fotonici/elettrostatici che disorientano e stordiscono brevemente.",
-        "stress_modifiers": { "photic_surge": 0.04, "synaptic_glare": 0.05 }
+        "stress_modifiers": {
+          "photic_surge": 0.04,
+          "synaptic_glare": 0.05
+        }
       },
       "ecology": {
         "biome_type": "trench_superficiale",
-        "primary_resources": ["coralli_sinaptici", "nebbia_fotofase"],
+        "primary_resources": [
+          "coralli_sinaptici",
+          "nebbia_fotofase"
+        ],
         "notes": "Corridoi luminosi guidano messaggeri e supporto lungo le creste."
       },
       "traits": {
@@ -403,30 +609,94 @@
         "support": [
           "filamenti_guidalampo",
           "sensori_planctonici",
-          "squame_diffusori_ionici"
+          "squame_diffusori_ionici",
+          "voce_imperiosa"
         ]
       },
       "role_templates": [
-        { "role": "apex", "label": "Araldo Fotofase", "summary": "Domina le correnti luminose infliggendo dazzled/overload.", "functional_tags": ["controllo_campo", "elettrico"], "preferred_traits": ["impulsi_bioluminescenti", "membrane_fotoconvoglianti"], "tier": 4 },
-        { "role": "keystone", "label": "Custode dei Coralli Sinaptici", "summary": "Stabilizza le barriere e amplifica buff di supporto.", "functional_tags": ["supporto", "rigenerazione"], "preferred_traits": ["coralli_sinaptici_fotofase", "nodi_sinaptici_superficiali"], "tier": 3 },
-        { "role": "bridge", "label": "Messaggero Fosfo", "summary": "Traccia percorsi sicuri con segnali bioelettrici.", "functional_tags": ["ricognizione", "logistica"], "preferred_traits": ["filamenti_guidalampo"], "tier": 2 },
-        { "role": "event", "label": "Marea di Spore Luminescenti", "summary": "Duplica buff luminosi ma aumenta glare per 1 scena (CD 3 turni).", "functional_tags": ["evento", "luminescenza"], "preferred_traits": ["impulsi_bioluminescenti"], "tier": 2 }
+        {
+          "role": "apex",
+          "label": "Araldo Fotofase",
+          "summary": "Domina le correnti luminose infliggendo dazzled/overload.",
+          "functional_tags": [
+            "controllo_campo",
+            "elettrico"
+          ],
+          "preferred_traits": [
+            "impulsi_bioluminescenti",
+            "membrane_fotoconvoglianti"
+          ],
+          "tier": 4
+        },
+        {
+          "role": "keystone",
+          "label": "Custode dei Coralli Sinaptici",
+          "summary": "Stabilizza le barriere e amplifica buff di supporto.",
+          "functional_tags": [
+            "supporto",
+            "rigenerazione"
+          ],
+          "preferred_traits": [
+            "coralli_sinaptici_fotofase",
+            "nodi_sinaptici_superficiali"
+          ],
+          "tier": 3
+        },
+        {
+          "role": "bridge",
+          "label": "Messaggero Fosfo",
+          "summary": "Traccia percorsi sicuri con segnali bioelettrici.",
+          "functional_tags": [
+            "ricognizione",
+            "logistica"
+          ],
+          "preferred_traits": [
+            "filamenti_guidalampo"
+          ],
+          "tier": 2
+        },
+        {
+          "role": "event",
+          "label": "Marea di Spore Luminescenti",
+          "summary": "Duplica buff luminosi ma aumenta glare per 1 scena (CD 3 turni).",
+          "functional_tags": [
+            "evento",
+            "luminescenza"
+          ],
+          "preferred_traits": [
+            "impulsi_bioluminescenti"
+          ],
+          "tier": 2
+        }
       ]
     },
     {
       "id": "crepuscolo_synapse_bloom",
       "label": "Soglia Crepuscolare Sinaptica",
       "summary": "Strato di nebbie psioniche che distorcono orientamento e memoria a breve termine.",
-      "climate_tags": ["crepuscolare", "foschia_sinaptica", "elettrico_irregolare"],
-      "size": { "min": 4, "max": 6 },
+      "climate_tags": [
+        "crepuscolare",
+        "foschia_sinaptica",
+        "elettrico_irregolare"
+      ],
+      "size": {
+        "min": 4,
+        "max": 6
+      },
       "hazard": {
         "severity": "high",
         "description": "Nebbie elettro-cognitive che impongono test di controllo/volontà.",
-        "stress_modifiers": { "memory_fog": 0.06, "desync_field": 0.05 }
+        "stress_modifiers": {
+          "memory_fog": 0.06,
+          "desync_field": 0.05
+        }
       },
       "ecology": {
         "biome_type": "trench_crepuscolare",
-        "primary_resources": ["plancton_mnesico", "condensa_ionica"],
+        "primary_resources": [
+          "plancton_mnesico",
+          "condensa_ionica"
+        ],
         "notes": "Lobi risonanti aprono canali sicuri ma mutevoli nella foschia."
       },
       "traits": {
@@ -443,26 +713,91 @@
         ]
       },
       "role_templates": [
-        { "role": "apex", "label": "Predatore Anamnestico", "summary": "Forza confusione e inversione comandi con attacchi psionici.", "functional_tags": ["controllo_mentale", "imboscata"], "preferred_traits": ["nebbia_mnesica", "lobi_risonanti_crepuscolo"], "tier": 4 },
-        { "role": "keystone", "label": "Curatore della Foschia", "summary": "Mantiene la densità della nebbia e concede copertura psioniche.", "functional_tags": ["supporto", "copertura"], "preferred_traits": ["placca_diffusione_foschia", "secrezioni_antistatiche"], "tier": 3 },
-        { "role": "threat", "label": "Sciame Memetico", "summary": "Ruba buff temporanei e li riapplica in forma ridotta.", "functional_tags": ["sabotaggio", "furto_buff"], "preferred_traits": ["ghiandole_mnemoniche", "organi_metacronici"], "tier": 3 },
-        { "role": "event", "label": "Eclisse Sinaptica", "summary": "Blackout sensoriale che resetta i timer delle correnti (CD 3 turni).", "functional_tags": ["evento", "crowd_control"], "preferred_traits": ["nebbia_mnesica"], "tier": 2 }
+        {
+          "role": "apex",
+          "label": "Predatore Anamnestico",
+          "summary": "Forza confusione e inversione comandi con attacchi psionici.",
+          "functional_tags": [
+            "controllo_mentale",
+            "imboscata"
+          ],
+          "preferred_traits": [
+            "nebbia_mnesica",
+            "lobi_risonanti_crepuscolo"
+          ],
+          "tier": 4
+        },
+        {
+          "role": "keystone",
+          "label": "Curatore della Foschia",
+          "summary": "Mantiene la densità della nebbia e concede copertura psioniche.",
+          "functional_tags": [
+            "supporto",
+            "copertura"
+          ],
+          "preferred_traits": [
+            "placca_diffusione_foschia",
+            "secrezioni_antistatiche"
+          ],
+          "tier": 3
+        },
+        {
+          "role": "threat",
+          "label": "Sciame Memetico",
+          "summary": "Ruba buff temporanei e li riapplica in forma ridotta.",
+          "functional_tags": [
+            "sabotaggio",
+            "furto_buff"
+          ],
+          "preferred_traits": [
+            "ghiandole_mnemoniche",
+            "organi_metacronici"
+          ],
+          "tier": 3
+        },
+        {
+          "role": "event",
+          "label": "Eclisse Sinaptica",
+          "summary": "Blackout sensoriale che resetta i timer delle correnti (CD 3 turni).",
+          "functional_tags": [
+            "evento",
+            "crowd_control"
+          ],
+          "preferred_traits": [
+            "nebbia_mnesica"
+          ],
+          "tier": 2
+        }
       ]
     },
     {
       "id": "frattura_void_choir",
       "label": "Frattura Nera – Void Choir",
       "summary": "Abisso risonante dove correnti magnetiche e gravità variabile piegano morfologie e segnali.",
-      "climate_tags": ["abissale", "gravitazionale", "elettrico_profondo", "sinaptico_dissonante"],
-      "size": { "min": 4, "max": 7 },
+      "climate_tags": [
+        "abissale",
+        "gravitazionale",
+        "elettrico_profondo",
+        "sinaptico_dissonante"
+      ],
+      "size": {
+        "min": 4,
+        "max": 7
+      },
       "hazard": {
         "severity": "critical",
         "description": "Risonanze elettro-gravitazionali che distorcono struttura e accumulano stress.",
-        "stress_modifiers": { "gravitic_shear": 0.08, "black_current": 0.09 }
+        "stress_modifiers": {
+          "gravitic_shear": 0.08,
+          "black_current": 0.09
+        }
       },
       "ecology": {
         "biome_type": "trench_abissale",
-        "primary_resources": ["ferro_memoria_profondo", "risonanze_voidsong"],
+        "primary_resources": [
+          "ferro_memoria_profondo",
+          "risonanze_voidsong"
+        ],
         "notes": "Cori di fondo mantengono ritmi per evitare shear e collasso."
       },
       "traits": {
@@ -470,7 +805,8 @@
           "camere_risonanza_abyssal",
           "corazze_ferro_magnetico",
           "bioantenne_gravitiche",
-          "emettitori_voidsong"
+          "emettitori_voidsong",
+          "pungiglione_paralizzante"
         ],
         "support": [
           "emolinfa_conducente",
@@ -479,10 +815,61 @@
         ]
       },
       "role_templates": [
-        { "role": "apex", "label": "Leviatano Modulante", "summary": "Cambia forma per adattarsi a pressione e risonanze.", "functional_tags": ["boss", "forma_variabile"], "preferred_traits": ["camere_risonanza_abyssal", "emettitori_voidsong"], "tier": 5 },
-        { "role": "keystone", "label": "Coro di Fondo", "summary": "Mantiene frequenze di riferimento e riduce danni da shear.", "functional_tags": ["supporto", "riduzione_danno"], "preferred_traits": ["filamenti_echo", "bioantenne_gravitiche"], "tier": 3 },
-        { "role": "threat", "label": "Sferzatore Magnetico", "summary": "Crea campi che spingono/attraggono drenando energia.", "functional_tags": ["controllo_spazio", "drain"], "preferred_traits": ["corazze_ferro_magnetico", "emolinfa_conducente"], "tier": 4 },
-        { "role": "event", "label": "Canto dello Strappo", "summary": "Disallinea temp_traits e può invertirne gli effetti (CD 4 turni).", "functional_tags": ["evento", "anomalia"], "preferred_traits": ["emettitori_voidsong"], "tier": 3 }
+        {
+          "role": "apex",
+          "label": "Leviatano Modulante",
+          "summary": "Cambia forma per adattarsi a pressione e risonanze.",
+          "functional_tags": [
+            "boss",
+            "forma_variabile"
+          ],
+          "preferred_traits": [
+            "camere_risonanza_abyssal",
+            "emettitori_voidsong"
+          ],
+          "tier": 5
+        },
+        {
+          "role": "keystone",
+          "label": "Coro di Fondo",
+          "summary": "Mantiene frequenze di riferimento e riduce danni da shear.",
+          "functional_tags": [
+            "supporto",
+            "riduzione_danno"
+          ],
+          "preferred_traits": [
+            "filamenti_echo",
+            "bioantenne_gravitiche"
+          ],
+          "tier": 3
+        },
+        {
+          "role": "threat",
+          "label": "Sferzatore Magnetico",
+          "summary": "Crea campi che spingono/attraggono drenando energia.",
+          "functional_tags": [
+            "controllo_spazio",
+            "drain"
+          ],
+          "preferred_traits": [
+            "corazze_ferro_magnetico",
+            "emolinfa_conducente"
+          ],
+          "tier": 4
+        },
+        {
+          "role": "event",
+          "label": "Canto dello Strappo",
+          "summary": "Disallinea temp_traits e può invertirne gli effetti (CD 4 turni).",
+          "functional_tags": [
+            "evento",
+            "anomalia"
+          ],
+          "preferred_traits": [
+            "emettitori_voidsong"
+          ],
+          "tier": 3
+        }
       ]
     }
   ]


### PR DESCRIPTION
## Summary

Cross-domain audit BACKLOG follow-up — Bucket B wire ship. **Critical correction**: balance-auditor agent verdict rivela orphan count actual = **17 non-ancestor actionable** (NOT 59 prior estimate). Categorizzazione finale:

- **Bucket A**: 7 + 18 ancestor trigger-set = **25 keep-as-content**
- **Bucket B**: **8 wire-now** (ship questo PR)
- **Bucket C**: **2 delete-candidates** (master-dd verdict pending)
- **EXEMPT**: 285 ancestor (handled by kind via existing handlers)

## Changes

`data/core/traits/biome_pools.json` extension — 8 trait wired to biome pools per agent semantic fit:

| Trait | Status | Biome target | Section |
|-------|--------|--------------|:---:|
| aculei_velenosi | bleeding | magnetar_badlands | support |
| pungiglione_paralizzante | stunned | frattura_void_choir | core |
| tentacoli_uncinati | fracture | abyssal_hydrothermal | support |
| spore_paniche | panic | mycelial_vaults | core |
| voce_imperiosa | panic | fotofase_synaptic_ridge | support |
| canto_di_richiamo | rage | aerial_canopy | support |
| aura_glaciale | chilled | cryosteppe_convergence | core |
| tela_appiccicosa | slowed | mycelial_vaults | support |

Effect handlers già wired (session.js status tick + passiveStatusApplier per attuned/sensed). Solo missing era assignment path → ora 8/8 coperti via biome_pools rotation.

## Test plan

- [x] JSON parse verde post-edit
- [x] 8 pools detected + updated_at refresh
- [ ] CI gates verde (paths-filter + governance + dataset-checks)

## Impact

- 1 file changed, +485/-98 LOC (heavy = JSON re-format pretty-print)
- Net actual additions = 8 trait IDs
- Zero forbidden path
- Zero backend code change (handlers existing canonical)
- Zero test baseline impact

## Out of scope

- Bucket A 25 trait keep-as-content (no action — flag come future content backlog)
- Bucket C 2 delete candidates (sussurro_psichico + respiro_acido) — master-dd verdict per delete confirmation (semantic uncertain `disoriented` vs `burning` duplicates con `voce_imperiosa` + `sangue_piroforico`)
- 285 ancestor EXEMPT (handled by kind, no action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)