### PR TITLE
feat(play): TKT-BOND-HUD-SURFACE Phase B — surface bond_reaction in log player-visible

### DIFF
--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -947,6 +947,31 @@ async function doAction(body) {
       ? `move [${body.position.x},${body.position.y}]`
       : `atk ${body.target_id}`;
   appendLog(logEl, `${body.actor_id}: ${tag}`);
+
+  // 2026-05-10 TKT-BOND-HUD-SURFACE Phase B (verdict #A2 = A).
+  // Surface bond_reaction trigger nel log player-visible. Backend
+  // emette bond_reaction field in /api/session/action response
+  // (apps/backend/routes/session.js:932). Pre-fix: response field
+  // ignorato → engine LIVE / surface DEAD Gate 5 violation.
+  if (r.data?.bond_reaction?.triggered) {
+    const bond = r.data.bond_reaction;
+    const buffSummary = bond.buff_applied
+      ? `${bond.buff_applied.stat} +${bond.buff_applied.amount} (${bond.buff_applied.duration}t)`
+      : '';
+    appendLog(
+      logEl,
+      `🔗 LEGAME ${bond.bond_id || '?'}: ${bond.actor_id}+${bond.ally_id} → ${buffSummary}`,
+      'success',
+    );
+  }
+  // Multi-bond stack (line 939: beast_bond_reactions: [...]).
+  if (Array.isArray(r.data?.beast_bond_reactions) && r.data.beast_bond_reactions.length > 0) {
+    for (const bb of r.data.beast_bond_reactions) {
+      if (bb?.triggered) {
+        appendLog(logEl, `🔗 Bond stack ${bb.bond_id}: ${bb.actor_id}+${bb.ally_id}`, 'success');
+      }
+    }
+  }
   await refresh();
 }
 


### PR DESCRIPTION
## Summary

Wave 10 ship TKT-BOND-HUD-SURFACE Phase B (verdict #A2 = A) — adapted scope.

**Adapted scope rationale**: Mission Console source recovered (#2169) è **design canvas** (Flow+Atlas+Nebula), NOT combat UI. Combat UI vive in `apps/play/` JS-based. Bond surface ship qui.

## Pre-fix Gate 5 violation

Backend emits `bond_reaction` field in `/api/session/action` response (`apps/backend/routes/session.js:932`). Frontend NON surface → player non vede mai bond fire. **ENGINE LIVE / SURFACE DEAD** pattern.

## Changes

`apps/play/src/main.js doAction`: post-action handler

```js
if (r.data?.bond_reaction?.triggered) {
  const bond = r.data.bond_reaction;
  const buffSummary = bond.buff_applied
    ? `${bond.buff_applied.stat} +${bond.buff_applied.amount} (${bond.buff_applied.duration}t)`
    : '';
  appendLog(logEl, `🔗 LEGAME ${bond.bond_id}: ${bond.actor_id}+${bond.ally_id} → ${buffSummary}`, 'success');
}
// Multi-bond stack
if (Array.isArray(r.data?.beast_bond_reactions)) {
  for (const bb of r.data.beast_bond_reactions) {
    if (bb?.triggered) {
      appendLog(logEl, `🔗 Bond stack ${bb.bond_id}: ${bb.actor_id}+${bb.ally_id}`, 'success');
    }
  }
}
```

Style: success log entry (green via existing log severity).

## Test plan

- [x] `node --check` verde
- [ ] Smoke E2E richiede creature_bonds.yaml setup encounter (deferred — TKT-BOND-SMOKE-E2E next ticket post-creature-pair scenario authored)

## Impact

- 1 file changed, +25 LOC
- Zero forbidden path
- Zero schema breaking
- Backward-compat: zero impatto se bond_reaction null/absent
- Gate 5 violation **CHIUSO** per bond reaction visibility

## Out of scope

- Vue component toast (Mission Console scope mismatched — design canvas)
- Visual popup overlay (ambitionHud.js pattern future upgrade)
- Bond pair badge in unit info panel (separate ticket)
- Multi-bond stack visualization (log dump sufficient Phase B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)