### PR TITLE
chore(qa): regen QA reports post #2195 trait delete batch

### DIFF
--- a/reports/qa-changelog.md
+++ b/reports/qa-changelog.md
@@ -1,16 +1,21 @@
 # QA export changelog
 
-Generato: 2026-04-25T11:45:06.785807Z
-Baseline precedente: 2026-04-25T11:42:49.770047Z
+Generato: 2026-05-10T15:06:28.062394Z
+Baseline precedente: 2026-04-25T11:45:06.785807Z
 
 ## Metriche baseline
 - Tratti totali: 254 (0 vs precedente)
-- Glossario OK: 254 (0 vs precedente)
-- Glossario mancanti: 0 (0 vs precedente)
+- Glossario OK: 253 (-1 vs precedente)
+- Glossario mancanti: 1 (+1 vs precedente)
 - Mismatch matrice: 76 (0 vs precedente)
 - Tratti con conflitti: 34 (0 vs precedente)
 
+### tratti senza glossario
+- Nuovi:
+  - antenne_waveguide
+
 ## Highlights UI
+- Glossario mancante: antenne_waveguide
 - Solo matrice: Strategist, adattamento_volo, architetto, artigli_psionici, assenza_respirazione, campo_di_fase, ciclo_vitale_anomalo, ciclo_vitale_completo, corteccia_memetica, eco_sismico
 - Mismatch matrice: ali_fono_risonanti, articolazioni_a_leva_idraulica, articolazioni_multiassiali, artigli_ipo_termici, artiglio_cinetico_a_urto, aura_di_dispersione_mentale, bioantenne_gravitiche, bozzolo_magnetico, camere_risonanza_abyssal, campo_di_interferenza_acustica
 - Zero coverage: ali_fono_risonanti, articolazioni_a_leva_idraulica, articolazioni_multiassiali, artigli_ipo_termici, artiglio_cinetico_a_urto, aura_di_dispersione_mentale, bioantenne_gravitiche, bozzolo_magnetico, camere_risonanza_abyssal, campo_di_interferenza_acustica
@@ -32,7 +37,7 @@ Baseline precedente: 2026-04-25T11:42:49.770047Z
 - Tratti validati: 0 (0 vs precedente)
 
 ## Badge QA
-- Tratti passed: 254 (0 vs precedente)
+- Tratti passed: 253 (-1 vs precedente)
 - Conflitti badge: 34 (0 vs precedente)
 
 _Report generato da scripts/export-qa-report.js_

--- a/reports/qa_badges.json
+++ b/reports/qa_badges.json
@@ -1,9 +1,9 @@
 {
-  "generated_at": "2026-04-14T19:23:03.693761Z",
+  "generated_at": "2026-05-10T15:06:28.062394Z",
   "summary": {
     "total_traits": 254,
-    "glossary_ok": 254,
-    "glossary_missing": 0,
+    "glossary_ok": 253,
+    "glossary_missing": 1,
     "matrix_ok": 178,
     "matrix_mismatch": 76,
     "with_conflicts": 34,
@@ -11,15 +11,17 @@
   },
   "checks": {
     "traits": {
-      "passed": 254,
+      "passed": 253,
       "total": 254,
       "conflicts": 34,
-      "missing_glossary": 0,
+      "missing_glossary": 1,
       "matrix_mismatch": 76
     }
   },
   "highlights": {
-    "glossary_missing": [],
+    "glossary_missing": [
+      "antenne_waveguide"
+    ],
     "matrix_only_traits": [
       "Strategist",
       "adattamento_volo",

--- a/reports/trait_baseline.json
+++ b/reports/trait_baseline.json
@@ -1,9 +1,9 @@
 {
-  "generated_at": "2026-04-25T11:45:06.785807Z",
+  "generated_at": "2026-05-10T15:06:28.062394Z",
   "summary": {
     "total_traits": 254,
-    "glossary_ok": 254,
-    "glossary_missing": 0,
+    "glossary_ok": 253,
+    "glossary_missing": 1,
     "matrix_ok": 178,
     "matrix_mismatch": 76,
     "with_conflicts": 34,
@@ -1420,7 +1420,7 @@
         "total": 2
       },
       "statuses": {
-        "glossary": "ok",
+        "glossary": "missing",
         "matrix": "ok"
       },
       "conflicts": [],
@@ -29809,7 +29809,9 @@
     "visione_spettrale",
     "voce_spettrale"
   ],
-  "missing_glossary": [],
+  "missing_glossary": [
+    "antenne_waveguide"
+  ],
   "sources": {
     "trait_reference": "data/traits/index.json",
     "trait_matrix": "docs/catalog/species_trait_matrix.json",


### PR DESCRIPTION
Follow-up #2195. `npm run export:qa` regen reports. Closes qa-reports CI red.