### PR TITLE
fix(ci): paths-filter blind spot — YAML data triggers stack-quality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,14 @@ jobs:
               - 'services/**/*.js'
               - 'tests/**/*.js'
               - 'apps/trait-editor/**'
+              # 2026-05-11 — paths-filter blind spot fix post-PR #2223.
+              # YAML data files consumed by backend AJV schema validation
+              # (npm run test:api). Pack-only / data-only edits previously
+              # skipped stack-quality, allowing schema regressions to slip
+              # (e.g. on_hit_status.status_id enum violation in #2223).
+              - 'data/core/**/*.yaml'
+              - 'packs/**/*.yaml'
+              - 'packages/contracts/schemas/**'
             site_audit:
               - 'ops/site-audit/**'
               - 'Makefile'


### PR DESCRIPTION
## Summary

Post-PR #2223 lesson learned. YAML-only diff (`packs/evo_tactics_pack/data/balance/trait_mechanics.yaml`) ha skippato stack-quality perché \`stack\` filter NON includeva data paths. Schema regression \`on_hit_status.status_id: stunned\` (non-enum) ha slippato fino a #2224 fix-forward.

## Root cause

`stack-quality` (line 202 ci.yml) gated da \`needs.paths-filter.outputs.stack == 'true'\`. \`stack\` filter (line 72-81) coverage:
- ✅ package.json, Makefile, scripts/lint-stack.mjs
- ✅ apps/backend/**, services/**/*.js, tests/**/*.js, apps/trait-editor/**
- ❌ data/**/*.yaml — MISSING
- ❌ packs/**/*.yaml — MISSING
- ❌ packages/contracts/schemas/** — MISSING

YAML data files sono consumati da backend AJV schema validation (\`npm run test:api\` chiama \`tests/api/*.test.js\` che loadano \`packs/.../trait_mechanics.yaml\`). Quando YAML-only diff → stack=false → backend AJV schema skip → regression slip.

## Fix

3 line additions to \`stack\` filter:
- \`data/core/**/*.yaml\`
- \`packs/**/*.yaml\`
- \`packages/contracts/schemas/**\`

## Test plan

- [x] YAML syntax valid (js-yaml load)
- [x] Branch creato post #2224 (working tree clean main HEAD)
- [ ] CI verifica: this PR itself touches `.github/workflows/ci.yml` → stack filter NOT match (workflows path NOT in stack) but governance pass
- [ ] Future test: PR YAML-only data edit → stack-quality DOES run

## Trade-off

- **Costo**: ~+10-15% CI minutes su data-only PR (stack-quality run aggiuntivo)
- **Benefit**: backend AJV schema catch errori pre-merge (#2223 regression wouldn't have shipped)

## Rollback

Single-file revert su \`.github/workflows/ci.yml\` (8 line additions, isolated).

## Notes

- \`.github/workflows/\` è FORBIDDEN PATH per CLAUDE.md guardrails — user grant esplicito per questo fix specifico ("paths-filter blind spot fix — YAML-only diff trigger stack-quality, post-#2223 lesson").
- ADR non necessario — fix tecnico isolato CI workflow, decisione scoped (no design implications).

🤖 Generated with [Claude Code](https://claude.com/claude-code)