### PR TITLE
fix(tests): restore 6 baseline-drift service test failures

### DIFF
--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-11T19:02:51+00:00",
+  "generated_at": "2026-05-11T19:32:08+00:00",
   "summary": {
     "total": 8,
     "errors": 0,

--- a/tests/services/beastBondCatalogIntegrity.test.js
+++ b/tests/services/beastBondCatalogIntegrity.test.js
@@ -1,13 +1,13 @@
 // Catalog + balance invariants for Beast Bond reaction trigger (Sprint 6).
 //
-// 1. Active trait registry: 3 nuovi trait caricati con schema corretto
+// 1. Active trait registry: 2 nuovi trait caricati con schema corretto
 //    (range, species_filter, atk_delta, def_delta, duration valorizzati).
+//    Note: pack_tactics rimosso in V10 C delete batch 2026-05-10
+//    (species predoni_nomadi non esiste in species.yaml/species_expansion.yaml).
 // 2. data/core/species.yaml: ogni species i cui trait_plan referenzia un
 //    trait Beast Bond deve usare un trait_id che il registry conosce.
 // 3. Balance invariant: con N (=2) holder bonded adiacenti all'attacker, il
 //    totale reactions emesse e' esattamente N (no double-count).
-// 4. Balance invariant: pack_tactics species_filter è 'pack:predoni_nomadi'
-//    (NON 'predatori_nomadi' — IDs della species canonical).
 
 'use strict';
 
@@ -20,7 +20,7 @@ const yaml = require('js-yaml');
 const { checkBeastBondReactions } = require('../../apps/backend/services/combat/beastBondReaction');
 const { loadActiveTraitRegistry } = require('../../apps/backend/services/traitEffects');
 
-const BOND_TRAIT_IDS = ['legame_di_branco', 'spirito_combattivo', 'pack_tactics'];
+const BOND_TRAIT_IDS = ['legame_di_branco', 'spirito_combattivo'];
 
 function loadCatalog() {
   const yamlPath = path.resolve(__dirname, '..', '..', 'data', 'core', 'species.yaml');
@@ -29,7 +29,7 @@ function loadCatalog() {
   return parsed && parsed.species ? parsed.species : [];
 }
 
-test('catalog: registry loads 3 Beast Bond traits with valid schema', () => {
+test('catalog: registry loads 2 Beast Bond traits with valid schema', () => {
   const registry = loadActiveTraitRegistry();
   for (const traitId of BOND_TRAIT_IDS) {
     const def = registry[traitId];
@@ -42,16 +42,6 @@ test('catalog: registry loads 3 Beast Bond traits with valid schema', () => {
     assert.equal(typeof cfg.def_delta, 'number', `${traitId}.def_delta is number`);
     assert.equal(typeof cfg.duration, 'number', `${traitId}.duration is number`);
   }
-});
-
-test('catalog: pack_tactics species_filter uses canonical predoni_nomadi ID', () => {
-  const registry = loadActiveTraitRegistry();
-  const cfg = registry.pack_tactics.triggers_on_ally_attack;
-  assert.equal(
-    cfg.species_filter,
-    'pack:predoni_nomadi',
-    'must match tutorial enemy species id (NOT predatori_*)',
-  );
 });
 
 test('catalog: species.yaml trait_plan only references known trait IDs', () => {
@@ -163,7 +153,7 @@ test('balance invariant: range=1 strict — Manhattan=2 holders never trigger', 
     controlled_by: 'sistema',
     hp: 5,
     position: { x: 2, y: 0 }, // Manhattan = 2
-    traits: ['legame_di_branco', 'spirito_combattivo', 'pack_tactics'],
+    traits: ['legame_di_branco', 'spirito_combattivo'],
     status: {},
   };
   const reactions = checkBeastBondReactions(attacker, [attacker, farHolder], registry);

--- a/tests/services/diaryStore.test.js
+++ b/tests/services/diaryStore.test.js
@@ -22,8 +22,8 @@ function tmpBaseDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'diary-test-'));
 }
 
-test('ALLOWED_EVENT_TYPES: 8 entries post 2026-04-25 content sprint', () => {
-  assert.equal(ALLOWED_EVENT_TYPES.size, 8);
+test('ALLOWED_EVENT_TYPES: 12 entries post 2026-04-25 content sprint + Skiv diary waves', () => {
+  assert.equal(ALLOWED_EVENT_TYPES.size, 12);
   assert.ok(ALLOWED_EVENT_TYPES.has('form_evolved'));
   assert.ok(ALLOWED_EVENT_TYPES.has('thought_internalized'));
   assert.ok(ALLOWED_EVENT_TYPES.has('scenario_completed'));

--- a/tests/services/enneaEffectsWire.test.js
+++ b/tests/services/enneaEffectsWire.test.js
@@ -87,15 +87,18 @@ test('applyEnneaToStatus: Coordinatore(2) → defense_mod_bonus +1 + status.defe
   assert.equal(skipped.length, 0);
 });
 
-test('applyEnneaToStatus: multi-archetype Conquistatore + Architetto → attack_mod_bonus +2 (stacking)', () => {
+test('applyEnneaToStatus: multi-archetype Conquistatore + Architetto → attack_mod_bonus +1 (dedup best-wins)', () => {
+  // 2026-05-10 TKT-ENNEA-1-5-DOUBLE-TRIGGER dedup: when two archetypes target
+  // same stat with equal amount, best-per-stat wins; other is skipped as superseded.
   const actor = makeActor();
   const effects = resolveEnneaEffects(['Conquistatore(3)', 'Architetto(5)']);
   assert.equal(effects.length, 2);
   const { applied, skipped } = applyEnneaToStatus(actor, effects);
-  assert.equal(actor.attack_mod_bonus, 2);
+  assert.equal(actor.attack_mod_bonus, 1);
   assert.equal(actor.status.attack_mod_buff, 1);
-  assert.equal(applied.length, 2);
-  assert.equal(skipped.length, 0);
+  assert.equal(applied.length, 1);
+  assert.equal(skipped.length, 1);
+  assert.equal(skipped[0].reason, 'dedup_superseded');
 });
 
 // ─────────────────────────────────────────────────────────────────
@@ -294,27 +297,30 @@ test('applyEnneaToStatus: Lealista(6) → defense_mod_bonus +1 + status.defense_
   assert.equal(skipped.length, 0);
 });
 
-test('applyEnneaToStatus: stack Riformatore + Architetto → attack_mod_bonus +2', () => {
+test('applyEnneaToStatus: dedup Riformatore + Architetto → attack_mod_bonus +1 (same stat, one superseded)', () => {
   const actor = makeActor();
   const effects = resolveEnneaEffects(['Riformatore(1)', 'Architetto(5)']);
   assert.equal(effects.length, 2);
   const { applied, skipped } = applyEnneaToStatus(actor, effects);
-  assert.equal(actor.attack_mod_bonus, 2);
+  assert.equal(actor.attack_mod_bonus, 1);
   assert.equal(actor.status.attack_mod_buff, 1);
-  assert.equal(applied.length, 2);
-  assert.equal(skipped.length, 0);
+  assert.equal(applied.length, 1);
+  assert.equal(skipped.length, 1);
+  assert.equal(skipped[0].reason, 'dedup_superseded');
 });
 
-test('applyEnneaToStatus: stack Lealista(2) + Coordinatore(1) → defense_mod_bonus +2, buff=max(2,1)=2', () => {
+test('applyEnneaToStatus: dedup Lealista(6) + Coordinatore(2) → defense_mod_bonus +1, buff=2 (Lealista wins longer duration)', () => {
+  // Both give defense_mod +1; dedup keeps one. Lealista(6) duration=2 wins
+  // (same amount, first-encountered in Map insertion order → Lealista kept).
   const actor = makeActor();
   const effects = resolveEnneaEffects(['Lealista(6)', 'Coordinatore(2)']);
   assert.equal(effects.length, 2);
   const { applied, skipped } = applyEnneaToStatus(actor, effects);
-  assert.equal(actor.defense_mod_bonus, 2);
-  // Lealista duration 2 wins over Coordinatore duration 1 via Math.max.
+  assert.equal(actor.defense_mod_bonus, 1);
   assert.equal(actor.status.defense_mod_buff, 2);
-  assert.equal(applied.length, 2);
-  assert.equal(skipped.length, 0);
+  assert.equal(applied.length, 1);
+  assert.equal(skipped.length, 1);
+  assert.equal(skipped[0].reason, 'dedup_superseded');
 });
 
 test('decay coerenza: Lealista(6) duration=2 → buff persiste 2 round end', () => {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **diaryStore.test.js**: count `8→12` — 4 event types added post-#1776 (`phase_transition`, `phase_signal`, `repo_event`, `weekly_digest`)
- **beastBondCatalogIntegrity.test.js**: remove `pack_tactics` from `BOND_TRAIT_IDS` and delete its species_filter test — trait deleted in V10 C delete batch 2026-05-10 (`predoni_nomadi` species non-existent)
- **enneaEffectsWire.test.js**: update 3 stacking tests → dedup best-wins semantics (TKT-ENNEA-1-5-DOUBLE-TRIGGER 2026-05-10 dedup logic)

All failures were baseline drift from prior content/fix sprints; none were regressions in this session.

## Pre-flight check (post-session)

All 3 P1 follow-ups from `2026-04-25-illuminator-orchestra-handoff.md` verified already shipped:
- Thought Cabinet tier-2/3 effects (#1778) — 59/59 ✅
- Thought Cabinet resolver wire (#1780) — 8/8 ✅
- MAP-Elites HTTP archive (#1782) — `docs/balance/2026-04-25-map-elites-archive-http.md` exists ✅

## Test plan

- `node --test tests/services/*.test.js` → 982/982 verde (was 977/983)
- `node --test tests/ai/*.test.js` → 395/395 verde
- `node --test tests/api/thoughtCabinet.test.js tests/api/thoughtPassiveApply.test.js` → 67/67 verde
- `npm run lint:stack` → verde
- `python tools/check_docs_governance.py --strict` → 0 errors

## Rollback plan

`git revert 643cd9d` — test-only change, zero runtime impact.

https://claude.ai/code/session_017uk29L73tmzUmYiTFnajHc
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017uk29L73tmzUmYiTFnajHc)_