### PR TITLE
feat(combat): TKT-P6 rewind safety valve — 3-snapshot buffer + endpoint + 13 test

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -196,6 +196,14 @@ const {
   ELEMENTS: TERRAIN_ELEMENTS,
 } = require('../services/combat/terrainReactions');
 
+// TKT-P6 — Rewind safety valve (snapshot pre-action + rewind endpoint).
+const {
+  snapshotSession,
+  rewindSession,
+  resetRewind,
+  rewindStateSummary,
+} = require('../services/combat/rewindBuffer');
+
 // Italian channel → terrainReactions element mapping. Action.channel is the
 // canonical attack channel string ("fuoco", "ghiaccio", ...). Only mapped
 // channels trigger reactions; everything else (fisico, perforante, ...) skips.
@@ -1765,6 +1773,18 @@ function createSessionRouter(options = {}) {
 
       const actionType = body.action_type;
 
+      // TKT-P6 — Snapshot pre-action state for potential rewind.
+      // Only player-controlled actor actions push snapshots (sistema AI
+      // actions are deterministic given seed, no rewind UX needed). Skip when
+      // session._rewind_disabled flag set (PvP / replay modes).
+      if (actor.controlled_by === 'player' && !session._rewind_disabled) {
+        try {
+          snapshotSession(session);
+        } catch {
+          // best-effort: never block action on snapshot failure
+        }
+      }
+
       if (actionType === 'attack') {
         const targetId = body.target_id || body.target;
         const target = session.units.find((u) => u.id === targetId);
@@ -2530,11 +2550,67 @@ function createSessionRouter(options = {}) {
     }
   });
 
+  // TKT-P6 — Rewind safety valve endpoint.
+  // POST /api/session/:id/rewind — restore most recent snapshot, decrement
+  // rewind budget. Returns 409 when budget exhausted or buffer empty.
+  router.post('/:id/rewind', (req, res, next) => {
+    try {
+      const { error, session } = resolveSession(req.params.id);
+      if (error) return res.status(error.status).json(error.body);
+      const result = rewindSession(session);
+      if (!result.ok) {
+        return res.status(409).json({
+          error: 'rewind_unavailable',
+          reason: result.reason,
+          budget_remaining: result.budget_remaining ?? 0,
+          rewind: rewindStateSummary(session),
+        });
+      }
+      // Append rewind audit event (forward-only log).
+      try {
+        if (Array.isArray(session.events)) {
+          session.events.push({
+            action_type: 'rewind',
+            turn: session.turn,
+            actor_id: null,
+            target_id: null,
+            damage_dealt: 0,
+            result: 'ok',
+            position_from: null,
+            position_to: null,
+            budget_remaining: result.budget_remaining,
+            automatic: false,
+          });
+        }
+      } catch {
+        /* event log best-effort */
+      }
+      return res.json({
+        session_id: session.session_id,
+        rewind: {
+          rewound: true,
+          budget_remaining: result.budget_remaining,
+          snapshots_remaining: result.snapshots_remaining,
+        },
+        state: publicSessionView(session),
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
   router.post('/end', async (req, res, next) => {
     try {
       const body = req.body || {};
       const { error, session } = resolveSession(body.session_id);
       if (error) return res.status(error.status).json(error.body);
+      // TKT-P6 — reset rewind buffer + budget on combat end (next encounter
+      // starts fresh budget).
+      try {
+        resetRewind(session);
+      } catch {
+        /* best-effort */
+      }
       // Telemetry B (TKT-03/05): compute outcome + VC snapshot, persist
       // session_end event prima della finalizzazione.
       const sistemaAlive = session.units.filter(

--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -431,6 +431,17 @@ function publicSessionView(session) {
       session.biome_modifiers && typeof session.biome_modifiers === 'object'
         ? session.biome_modifiers
         : { diff_base: 1.0, hp_mult: 1.0, pressure_mult: 0, pressure_initial_bonus: 0 },
+    // TKT-P6 — Rewind safety valve summary for HUD undo button. Always present
+    // (default budget=3 even on fresh session, snapshots=0 until first action).
+    rewind: (() => {
+      try {
+        // eslint-disable-next-line global-require
+        const { rewindStateSummary } = require('../services/combat/rewindBuffer');
+        return rewindStateSummary(session);
+      } catch {
+        return { budget_remaining: 3, budget_max: 3, snapshots_count: 0, buffer_size: 3 };
+      }
+    })(),
     // Sprint 11 (Surface-DEAD #6): expose biome_id per HUD biome chip surface.
     // session.biome_id viene popolato in /start dal body biome_id raw. Fallback
     // a session.encounter?.biome_id quando encounter_id YAML loader popola

--- a/apps/backend/services/combat/rewindBuffer.js
+++ b/apps/backend/services/combat/rewindBuffer.js
@@ -1,0 +1,202 @@
+'use strict';
+
+/**
+ * TKT-P6 — Rewind safety valve.
+ *
+ * Scope ticket §4: anti-frustration ammortizer per OD-014. Undo button N times
+ * per battle. Snapshot state pre-action, rewind on player request.
+ *
+ * Design:
+ * - Ring buffer FIFO, default size 3 (configurable via REWIND_BUFFER_SIZE env).
+ * - Each snapshot = deep clone subset critical state: units, turn, active_unit,
+ *   sistema_pressure, sistema_counter, turn_index, encounter? events tail.
+ * - Budget separate from buffer: how many rewinds player still has this combat.
+ *   Default 3, reset on encounter end / new combat.
+ * - snapshot() pushes; rewind() pops most recent snapshot and decrements budget.
+ *   Returns the popped state for caller to merge back into session.
+ *
+ * Non goals: full event log rollback. Persisted events stay in log; rewind only
+ * touches in-memory mutable session fields. Telemetry events for rewind itself
+ * are appended forward, NOT removed.
+ */
+
+const DEFAULT_BUFFER_SIZE = 3;
+const DEFAULT_BUDGET = 3;
+
+function envBufferSize() {
+  const raw = Number(process.env.REWIND_BUFFER_SIZE);
+  if (Number.isFinite(raw) && raw >= 1 && raw <= 10) return Math.floor(raw);
+  return DEFAULT_BUFFER_SIZE;
+}
+
+function envBudget() {
+  const raw = Number(process.env.REWIND_BUDGET_PER_BATTLE);
+  if (Number.isFinite(raw) && raw >= 0 && raw <= 10) return Math.floor(raw);
+  return DEFAULT_BUDGET;
+}
+
+/**
+ * Deep clone via JSON round-trip. Adequate for plain-data session fields.
+ * Functions / Date / Map are NOT preserved — we only clone POD state.
+ */
+function deepClone(value) {
+  if (value === null || value === undefined) return value;
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract the snapshot-able subset of session state.
+ * Keeps the buffer payload focused (avoids cloning logs / config).
+ */
+function pickSnapshotState(session) {
+  if (!session || typeof session !== 'object') return null;
+  return {
+    turn: session.turn,
+    active_unit: session.active_unit,
+    turn_index: session.turn_index,
+    turn_order: deepClone(session.turn_order),
+    units: deepClone(session.units),
+    sistema_pressure: session.sistema_pressure,
+    sistema_counter: session.sistema_counter,
+    tile_state_map: deepClone(session.tile_state_map),
+    last_round_combos: deepClone(session.last_round_combos),
+    last_round_synergies: deepClone(session.last_round_synergies),
+    // events count marker — used to truncate event tail on restore.
+    events_count: Array.isArray(session.events) ? session.events.length : 0,
+  };
+}
+
+/**
+ * Apply a popped snapshot back onto session in place. Caller is responsible
+ * for invoking this; rewindBuffer only stores and returns the snapshot.
+ */
+function applySnapshot(session, snapshot) {
+  if (!session || !snapshot) return false;
+  if (Number.isFinite(snapshot.turn)) session.turn = snapshot.turn;
+  if (snapshot.active_unit !== undefined) session.active_unit = snapshot.active_unit;
+  if (Number.isFinite(snapshot.turn_index)) session.turn_index = snapshot.turn_index;
+  if (Array.isArray(snapshot.turn_order)) session.turn_order = snapshot.turn_order;
+  if (Array.isArray(snapshot.units)) session.units = snapshot.units;
+  if (Number.isFinite(snapshot.sistema_pressure))
+    session.sistema_pressure = snapshot.sistema_pressure;
+  if (Number.isFinite(snapshot.sistema_counter)) session.sistema_counter = snapshot.sistema_counter;
+  if (snapshot.tile_state_map && typeof snapshot.tile_state_map === 'object') {
+    session.tile_state_map = snapshot.tile_state_map;
+  }
+  if (Array.isArray(snapshot.last_round_combos))
+    session.last_round_combos = snapshot.last_round_combos;
+  if (Array.isArray(snapshot.last_round_synergies))
+    session.last_round_synergies = snapshot.last_round_synergies;
+  // Truncate event tail: log entries written between snapshot + rewind are
+  // discarded from session.events (still on disk log file). Forward audit log
+  // includes the rewind event itself appended by caller post-apply.
+  if (Number.isFinite(snapshot.events_count) && Array.isArray(session.events)) {
+    if (session.events.length > snapshot.events_count) {
+      session.events.length = snapshot.events_count;
+    }
+  }
+  return true;
+}
+
+/**
+ * Factory: create per-session rewind buffer state. Attach to session via
+ * ensureRewindState(session).
+ *
+ * Public API:
+ *   - snapshot(session): clones state subset + pushes into ring buffer.
+ *   - rewind(session): pops latest snapshot, decrements budget, returns snapshot
+ *                      OR null if buffer empty / budget exhausted.
+ *   - budget(state): remaining rewind budget.
+ *   - reset(state): clear buffer + restore default budget (call on combat end).
+ *   - state(state): summary { budget_remaining, snapshots_count, buffer_size }.
+ */
+function createRewindBuffer({ size = envBufferSize(), budget = envBudget() } = {}) {
+  return {
+    size,
+    budget_max: budget,
+    budget_remaining: budget,
+    snapshots: [],
+  };
+}
+
+function ensureRewindState(session) {
+  if (!session) return null;
+  if (!session._rewind_state) {
+    session._rewind_state = createRewindBuffer();
+  }
+  return session._rewind_state;
+}
+
+function snapshotSession(session) {
+  const state = ensureRewindState(session);
+  if (!state) return false;
+  const snap = pickSnapshotState(session);
+  if (!snap) return false;
+  state.snapshots.push(snap);
+  // Ring trim: drop oldest if exceeds size.
+  while (state.snapshots.length > state.size) {
+    state.snapshots.shift();
+  }
+  return true;
+}
+
+function rewindSession(session) {
+  const state = ensureRewindState(session);
+  if (!state) return { ok: false, reason: 'no_state' };
+  if (state.budget_remaining <= 0) {
+    return { ok: false, reason: 'budget_exhausted', budget_remaining: 0 };
+  }
+  if (state.snapshots.length === 0) {
+    return { ok: false, reason: 'buffer_empty', budget_remaining: state.budget_remaining };
+  }
+  const snap = state.snapshots.pop();
+  state.budget_remaining -= 1;
+  const applied = applySnapshot(session, snap);
+  return {
+    ok: applied,
+    reason: applied ? 'rewound' : 'apply_failed',
+    budget_remaining: state.budget_remaining,
+    snapshots_remaining: state.snapshots.length,
+  };
+}
+
+function resetRewind(session) {
+  if (!session) return false;
+  session._rewind_state = createRewindBuffer();
+  return true;
+}
+
+function rewindStateSummary(session) {
+  const state = session && session._rewind_state ? session._rewind_state : null;
+  if (!state) {
+    return {
+      budget_remaining: envBudget(),
+      budget_max: envBudget(),
+      snapshots_count: 0,
+      buffer_size: envBufferSize(),
+    };
+  }
+  return {
+    budget_remaining: state.budget_remaining,
+    budget_max: state.budget_max,
+    snapshots_count: state.snapshots.length,
+    buffer_size: state.size,
+  };
+}
+
+module.exports = {
+  createRewindBuffer,
+  ensureRewindState,
+  snapshotSession,
+  rewindSession,
+  resetRewind,
+  rewindStateSummary,
+  pickSnapshotState,
+  applySnapshot,
+  // Exported for tests
+  __internals: { envBufferSize, envBudget, deepClone },
+};

--- a/tests/ai/rewindBuffer.test.js
+++ b/tests/ai/rewindBuffer.test.js
@@ -1,0 +1,161 @@
+// TKT-P6 — Rewind safety valve unit tests.
+//
+// Scope: rewindBuffer.js — buffer ring + budget + state pick/apply.
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createRewindBuffer,
+  ensureRewindState,
+  snapshotSession,
+  rewindSession,
+  resetRewind,
+  rewindStateSummary,
+  pickSnapshotState,
+  applySnapshot,
+} = require('../../apps/backend/services/combat/rewindBuffer');
+
+function buildSession(overrides = {}) {
+  return {
+    session_id: 'sess-rewind-test',
+    turn: 1,
+    active_unit: 'pg1',
+    turn_index: 0,
+    turn_order: ['pg1', 'enemy1'],
+    units: [
+      { id: 'pg1', controlled_by: 'player', hp: 10, ap_remaining: 2, position: { x: 0, y: 0 } },
+      { id: 'enemy1', controlled_by: 'sistema', hp: 8, ap_remaining: 2, position: { x: 3, y: 0 } },
+    ],
+    sistema_pressure: 5,
+    sistema_counter: 0,
+    tile_state_map: {},
+    last_round_combos: [],
+    last_round_synergies: [],
+    events: [{ action_type: 'session_start', turn: 0 }],
+    ...overrides,
+  };
+}
+
+test('createRewindBuffer initializes defaults', () => {
+  const buf = createRewindBuffer();
+  assert.equal(buf.size, 3);
+  assert.equal(buf.budget_max, 3);
+  assert.equal(buf.budget_remaining, 3);
+  assert.deepEqual(buf.snapshots, []);
+});
+
+test('snapshotSession pushes deep clone state', () => {
+  const session = buildSession();
+  const ok = snapshotSession(session);
+  assert.equal(ok, true);
+  const state = ensureRewindState(session);
+  assert.equal(state.snapshots.length, 1);
+  // Mutate session post-snapshot, snapshot must remain pristine.
+  session.units[0].hp = 1;
+  assert.equal(state.snapshots[0].units[0].hp, 10);
+});
+
+test('ring buffer drops oldest beyond size', () => {
+  const session = buildSession();
+  snapshotSession(session);
+  session.turn = 2;
+  snapshotSession(session);
+  session.turn = 3;
+  snapshotSession(session);
+  session.turn = 4;
+  snapshotSession(session);
+  const state = ensureRewindState(session);
+  assert.equal(state.snapshots.length, 3);
+  // Oldest (turn=1) was dropped; first remaining is turn=2.
+  assert.equal(state.snapshots[0].turn, 2);
+  assert.equal(state.snapshots[2].turn, 4);
+});
+
+test('rewindSession pops snapshot + decrements budget + restores state', () => {
+  const session = buildSession();
+  snapshotSession(session);
+  // Mutate state to simulate action.
+  session.turn = 5;
+  session.units[0].hp = 1;
+  session.units[1].hp = 0;
+  session.events.push({ action_type: 'attack', turn: 5 });
+
+  const result = rewindSession(session);
+  assert.equal(result.ok, true);
+  assert.equal(result.budget_remaining, 2);
+  assert.equal(result.snapshots_remaining, 0);
+  // State restored.
+  assert.equal(session.turn, 1);
+  assert.equal(session.units[0].hp, 10);
+  assert.equal(session.units[1].hp, 8);
+  // Event tail truncated (events_count snapshotted was 1).
+  assert.equal(session.events.length, 1);
+});
+
+test('rewindSession returns 409-equivalent when buffer empty', () => {
+  const session = buildSession();
+  const result = rewindSession(session);
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'buffer_empty');
+  assert.equal(result.budget_remaining, 3);
+});
+
+test('rewindSession rejects when budget exhausted', () => {
+  const session = buildSession();
+  // Force budget=0
+  ensureRewindState(session).budget_remaining = 0;
+  snapshotSession(session);
+  const result = rewindSession(session);
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'budget_exhausted');
+});
+
+test('budget decrements once per rewind, not per snapshot', () => {
+  const session = buildSession();
+  snapshotSession(session);
+  snapshotSession(session);
+  const state = ensureRewindState(session);
+  assert.equal(state.budget_remaining, 3);
+  rewindSession(session);
+  assert.equal(state.budget_remaining, 2);
+  rewindSession(session);
+  assert.equal(state.budget_remaining, 1);
+});
+
+test('resetRewind clears buffer + restores default budget', () => {
+  const session = buildSession();
+  snapshotSession(session);
+  rewindSession(session);
+  resetRewind(session);
+  const summary = rewindStateSummary(session);
+  assert.equal(summary.budget_remaining, 3);
+  assert.equal(summary.snapshots_count, 0);
+});
+
+test('pickSnapshotState + applySnapshot round trip integrity', () => {
+  const session = buildSession({ turn: 7, sistema_pressure: 12 });
+  const snap = pickSnapshotState(session);
+  // Mutate then re-apply.
+  session.turn = 99;
+  session.sistema_pressure = 0;
+  session.units = [];
+  const applied = applySnapshot(session, snap);
+  assert.equal(applied, true);
+  assert.equal(session.turn, 7);
+  assert.equal(session.sistema_pressure, 12);
+  assert.equal(session.units.length, 2);
+});
+
+test('rewindStateSummary returns defaults when no state attached', () => {
+  const session = { session_id: 's2' };
+  const summary = rewindStateSummary(session);
+  assert.equal(summary.budget_remaining, 3);
+  assert.equal(summary.budget_max, 3);
+  assert.equal(summary.snapshots_count, 0);
+  assert.equal(summary.buffer_size, 3);
+});

--- a/tests/api/sessionRewind.test.js
+++ b/tests/api/sessionRewind.test.js
@@ -1,0 +1,63 @@
+// =============================================================================
+// TKT-P6 — Rewind safety valve API integration tests.
+//
+// Verifica end-to-end: POST /api/session/:id/rewind restores pre-action state,
+// decrements budget, returns 409 when buffer empty, /state surface budget.
+// =============================================================================
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+async function startSession(app) {
+  const res = await request(app)
+    .post('/api/session/start')
+    .send({ scenario_id: 'tutorial_01' })
+    .expect(200);
+  return res.body;
+}
+
+test('GET /state exposes rewind summary with defaults on fresh session', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const { session_id } = await startSession(app);
+    const stateRes = await request(app)
+      .get(`/api/session/state?session_id=${session_id}`)
+      .expect(200);
+    assert.ok(stateRes.body.rewind, 'rewind summary present');
+    assert.equal(stateRes.body.rewind.budget_remaining, 3);
+    assert.equal(stateRes.body.rewind.budget_max, 3);
+    assert.equal(stateRes.body.rewind.snapshots_count, 0);
+    assert.equal(stateRes.body.rewind.buffer_size, 3);
+  } finally {
+    if (typeof close === 'function') await close();
+  }
+});
+
+test('POST /:id/rewind returns 409 buffer_empty when no actions taken', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const { session_id } = await startSession(app);
+    const res = await request(app).post(`/api/session/${session_id}/rewind`).expect(409);
+    assert.equal(res.body.error, 'rewind_unavailable');
+    assert.equal(res.body.reason, 'buffer_empty');
+    assert.equal(res.body.budget_remaining, 3);
+  } finally {
+    if (typeof close === 'function') await close();
+  }
+});
+
+test('POST /:id/rewind returns 404 for unknown session', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app).post(`/api/session/nonexistent-id/rewind`).expect(404);
+    assert.ok(res.body.error);
+  } finally {
+    if (typeof close === 'function') await close();
+  }
+});


### PR DESCRIPTION
## Scope — TKT-P6 (scope ticket §4, ACCEPT 2026-05-11)

Anti-frustration ammortizer per OD-014. Undo button N times per battle. Snapshot state pre-action, rewind on player request.

## Endpoint shape

- **POST /api/session/:id/rewind**
  - 200 OK: `{ session_id, rewind: { rewound: true, budget_remaining, snapshots_remaining }, state }`
  - 409 Conflict: `{ error: 'rewind_unavailable', reason: 'buffer_empty' | 'budget_exhausted', budget_remaining, rewind }`
  - 404 Not Found: unknown session

- **GET /api/session/state** (esistente, esteso)
  - Body field `rewind: { budget_remaining, budget_max, snapshots_count, buffer_size }`

## Files

| File | LOC delta | Purpose |
|---|---|---|
| `apps/backend/services/combat/rewindBuffer.js` | +202 (new) | Ring buffer + budget + snapshot/apply |
| `apps/backend/routes/session.js` | +60 | Snapshot pre-action + /:id/rewind endpoint + resetRewind on /end |
| `apps/backend/routes/sessionHelpers.js` | +11 | publicSessionView rewind surface |
| `tests/ai/rewindBuffer.test.js` | +148 (new) | 10 unit tests |
| `tests/api/sessionRewind.test.js` | +63 (new) | 3 API integration tests |

## Config

- `REWIND_BUFFER_SIZE` env (default 3, range 1..10) — snapshot ring buffer depth
- `REWIND_BUDGET_PER_BATTLE` env (default 3, range 0..10) — undo count per encounter
- Budget resets on `/end` (next encounter starts fresh)
- Sistema-controlled actor actions skip snapshot (deterministic given seed)
- Skipped when `session._rewind_disabled` (PvP / replay mode flag)

## Test baseline

- `tests/ai/*.test.js`: 395 → **405 (+10)** green
- `tests/api/*.test.js`: 988 → **991 (+3)** green
- Prettier: green

## Forbidden paths

Zero touch: `.github/workflows/`, `migrations/`, `packages/contracts/`, `services/generation/`, `services/rules/`.

## Frontend hint

CSS-only HUD button deferred to follow-up — backend surface ready (`state.rewind`).

## Rollback

Revert commit. Safe: opt-in surface, sistema actions unaffected, snapshot on player action only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)