### PR TITLE
feat(ui): TKT-P6-FE rewind HUD button — frontend completion P6 anti-frustration

### DIFF
--- a/apps/play/index.html
+++ b/apps/play/index.html
@@ -291,6 +291,14 @@
             <button id="undo-action" class="undo-btn hidden" title="Annulla ultima azione (Ctrl+Z)">
               ↶ Undo
             </button>
+            <!-- TKT-P6-FE — Rewind safety valve (3 snapshots post-action). P6 anti-frustration. -->
+            <button
+              id="rewind-action"
+              class="rewind-btn"
+              title="Annulla turno — rewind 1 azione completata (budget 3 per combat)"
+            >
+              ↶ Annulla turno <span id="rewind-budget" class="rewind-budget">3/3</span>
+            </button>
             <button id="new-session">Nuova sessione</button>
             <button id="reset-round" title="Emergency reset round state (se tutto bloccato)">
               🔄 Reset

--- a/apps/play/src/api.js
+++ b/apps/play/src/api.js
@@ -83,6 +83,14 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ session_id: sid, actor_id: actorId }),
     }),
+  // TKT-P6-FE — Rewind safety valve (3-snapshot buffer post-action).
+  // Anti-frustration: 409 quando budget esaurito o buffer vuoto. Budget reset
+  // a fine combat. Server append rewind audit event nel log.
+  rewindAction: (sid) =>
+    jsonFetch(`/api/session/${encodeURIComponent(sid)}/rewind`, {
+      method: 'POST',
+      body: JSON.stringify({}),
+    }),
   // Bundle B.3 — Tunic decipher Codex pages.
   codexPages: (sid) => jsonFetch(`/api/v1/codex/pages?session_id=${encodeURIComponent(sid || '')}`),
   codexDecipher: (sid, pageId, triggerData = {}) =>

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -250,6 +250,18 @@ function redraw() {
       state.pendingIntents.some((pi) => pi.unit_id === state.selected && !pi.reaction_trigger);
     undoBtn.classList.toggle('hidden', !hasPending);
   }
+  // TKT-P6-FE — Rewind button state (budget + disabled when exhausted or empty).
+  const rewindBtn = document.getElementById('rewind-action');
+  const rewindBudgetEl = document.getElementById('rewind-budget');
+  if (rewindBtn && rewindBudgetEl) {
+    const rw = state.world?.rewind || { budget_remaining: 3, budget_max: 3, snapshots_count: 0 };
+    const budgetRemaining = Number(rw.budget_remaining) || 0;
+    const budgetMax = Number(rw.budget_max) || 3;
+    const snapshotsCount = Number(rw.snapshots_count) || 0;
+    rewindBudgetEl.textContent = `${budgetRemaining}/${budgetMax}`;
+    const canRewind = budgetRemaining > 0 && snapshotsCount > 0;
+    rewindBtn.disabled = !canRewind;
+  }
   // ability panel
   const selUnit = (state.world.units || []).find((u) => u.id === state.selected);
   if (selUnit && selUnit.controlled_by === 'player' && selUnit.hp > 0) {
@@ -459,6 +471,28 @@ document.addEventListener('keydown', (ev) => {
   ev.preventDefault();
   handleUndoAction();
 });
+
+// TKT-P6-FE — Rewind safety valve handler.
+// POST /api/session/:id/rewind restituisce nuovo state (publicSessionView).
+// Su 409 budget esaurito o buffer vuoto: log warn + UI rimane invariata.
+async function handleRewindAction() {
+  if (!state.sid) return;
+  const r = await api.rewindAction(state.sid);
+  if (!r.ok) {
+    const reason = r.data?.reason || r.data?.error || `HTTP ${r.status}`;
+    appendLog(logEl, `✖ rewind: ${reason}`, 'warn');
+    return;
+  }
+  state.world = r.data?.state || state.world;
+  state.pendingIntents = [];
+  const rw = r.data?.rewind || {};
+  appendLog(
+    logEl,
+    `↶ Turno annullato (budget ${rw.budget_remaining ?? '?'}/${state.world?.rewind?.budget_max ?? 3})`,
+  );
+  updateHint('Ultimo turno annullato. Rigioca la stessa scelta o cambia tattica.');
+  redraw();
+}
 
 function handleUnitClick(unit) {
   if (!state.world) return;
@@ -1474,11 +1508,7 @@ async function startNewSession() {
           `🗺 Campagna ${summary?.id || lobbyBridge.session.campaign_id} avviata (live-mirror ON)`,
         );
       } else {
-        appendLog(
-          logEl,
-          `✖ campagna bootstrap: ${campRes.data?.error || campRes.status}`,
-          'error',
-        );
+        appendLog(logEl, `✖ campagna bootstrap: ${campRes.data?.error || campRes.status}`, 'error');
       }
     } catch (err) {
       appendLog(logEl, `✖ campagna bootstrap: ${err?.message || err}`, 'error');
@@ -1530,6 +1560,8 @@ document.getElementById('reset-round')?.addEventListener('click', async () => {
 });
 // Bundle B.2 — Undo last action button (planning phase only, Ctrl+Z mirror).
 document.getElementById('undo-action')?.addEventListener('click', () => handleUndoAction());
+// TKT-P6-FE — Rewind safety valve button (3-snapshot buffer, post-action).
+document.getElementById('rewind-action')?.addEventListener('click', () => handleRewindAction());
 // W8L — Codex btn header (in-game wiki: Tips re-read + Glossario + Abilità + Status).
 document.getElementById('codex-open')?.addEventListener('click', () => {
   toggleCodex();

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -1512,6 +1512,27 @@ canvas#grid:hover {
   display: none;
 }
 
+/* TKT-P6-FE — Rewind button (3-snapshot safety valve, post-action). */
+.rewind-btn {
+  background: #3a4a5a !important;
+  border-color: #6f8bb0 !important;
+  color: #b8d4e8 !important;
+}
+.rewind-btn:hover:not(:disabled) {
+  background: #4f6b87 !important;
+  color: #fff !important;
+}
+.rewind-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.rewind-budget {
+  margin-left: 4px;
+  font-size: 0.85em;
+  opacity: 0.85;
+  font-variant-numeric: tabular-nums;
+}
+
 .sidebar {
   background: var(--panel);
   padding: 12px;


### PR DESCRIPTION
## Summary

Frontend completion follow-up from [PR #2241](https://github.com/MasterDD-L34D/Game/pull/2241) (TKT-P6 backend: rewind buffer + endpoint + 13 test). Wires the HUD button so players can actually see/use the safety valve in-game.

## Changes

- `apps/play/src/api.js` — `rewindAction(sid)` wrapper → POST `/api/session/:id/rewind`
- `apps/play/index.html` — `#rewind-action` button next to existing Undo, inline counter `N/N`
- `apps/play/src/style.css` — `.rewind-btn` blue tactical theme + `:disabled` state
- `apps/play/src/main.js`:
  - `handleRewindAction()` — POST + refresh `state.world` + clear `pendingIntents` + log
  - Render loop: counter `N/N` + disabled when `budget=0` or `snapshots=0`
  - Click handler wired

State source: `state.world.rewind` from `publicSessionView` (already exposed via `sessionHelpers.js:436` — no backend change).

## Test plan

- [x] `node --test tests/api/sessionRewind.test.js` — 13/13 green (no regression backend)
- [x] `node --test tests/ai/*.test.js` — baseline preserved
- [x] Prettier clean on 4 edited files
- [ ] Manual: open `/play`, complete action → button shows `2/3`, click → state reverts + log `↶ Turno annullato`
- [ ] Manual: exhaust budget (3 rewinds) → button `:disabled` + `0/3`

## Pillar impact

P6 Fairness / anti-frustration: 🟢 candidato (engine wired, surface live).

## Acceptance §3 closure

TKT-P6 scope ticket §3 frontend: button + counter + disabled state shipped. i18n hardcoded IT ("Annulla turno") per single-locale codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)