### PR TITLE
feat(ui): TKT-M15-FE promotion accept/defer UI — frontend completion P3 Identità

### DIFF
--- a/apps/play/src/api.js
+++ b/apps/play/src/api.js
@@ -83,6 +83,16 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ session_id: sid, actor_id: actorId }),
     }),
+  // TKT-M15-FE — Promotion engine (XP tier ladder, accept/defer UI).
+  // PR #2242 backend: evaluatePromotion + applyPromotion + 2 endpoint.
+  // Eligibility = derivata da session.events log; promote applica deltas stat.
+  promotionEligibility: (sid) =>
+    jsonFetch(`/api/session/${encodeURIComponent(sid)}/promotion-eligibility`),
+  promotionAccept: (sid, unitId, targetTier) =>
+    jsonFetch(`/api/session/${encodeURIComponent(sid)}/promote`, {
+      method: 'POST',
+      body: JSON.stringify({ unit_id: unitId, target_tier: targetTier }),
+    }),
   // Bundle B.3 — Tunic decipher Codex pages.
   codexPages: (sid) => jsonFetch(`/api/v1/codex/pages?session_id=${encodeURIComponent(sid || '')}`),
   codexDecipher: (sid, pageId, triggerData = {}) =>

--- a/apps/play/src/endgame.js
+++ b/apps/play/src/endgame.js
@@ -1,6 +1,7 @@
 // End-game detection + overlay (con VC debrief integrato).
 
 import { api } from './api.js';
+import { renderPromotionPanel } from './promotionPanel.js';
 
 function renderVcBlock(vcSnapshot) {
   if (!vcSnapshot || !vcSnapshot.per_actor) return '';
@@ -84,6 +85,17 @@ export function showEndgame(result, state, handlers) {
         slot.textContent = '⚠ VC non disponibile';
       }
     });
+  }
+
+  // TKT-M15-FE — Promotion panel (victory only; defeat path doesn't grant
+  // promotion eligibility usually but engine returns reason=thresholds_not_met
+  // gracefully so rendering on defeat is a noop empty state).
+  if (result === 'victory' && state.session_id) {
+    try {
+      renderPromotionPanel(state.session_id, document.getElementById('endgame-stats'));
+    } catch (err) {
+      console.warn('[promotion] render error', err);
+    }
   }
 
   document.getElementById('endgame-next').onclick = handlers.next;

--- a/apps/play/src/promotionPanel.js
+++ b/apps/play/src/promotionPanel.js
@@ -1,0 +1,138 @@
+// TKT-M15-FE — Promotion UI accept/defer button (P3 Identità Specie x Job).
+//
+// Wires backend promotion engine (PR #2242) to the endgame overlay. On victory,
+// fetch /api/session/:id/promotion-eligibility, render one card per eligible
+// unit with accept/defer buttons. Defer is implicit (close debrief without
+// accepting). Accept calls POST /api/session/:id/promote.
+//
+// Acceptance §3 closure from TKT-M15 scope ticket: frontend accept/defer button.
+
+import { api } from './api.js';
+
+function statKey(k) {
+  const map = {
+    hp: 'HP',
+    attack_mod: 'Attacco',
+    initiative: 'Iniziativa',
+    ability_unlock_tier: 'Sblocca abilità tier',
+  };
+  return map[k] || k;
+}
+
+function renderDeltas(deltas) {
+  if (!deltas || typeof deltas !== 'object') return '';
+  const entries = Object.entries(deltas);
+  if (entries.length === 0) return '<em class="promo-no-reward">Nessun bonus stat</em>';
+  return entries
+    .map(([k, v]) => {
+      const sign = typeof v === 'number' && v > 0 ? '+' : '';
+      return `<span class="promo-stat-chip">${statKey(k)} ${sign}${v}</span>`;
+    })
+    .join('');
+}
+
+function renderCard(unitId, eligibility) {
+  const tierLabel = eligibility.next_tier || '—';
+  const reward = eligibility.reward || {};
+  const previewDeltas = {};
+  if (reward.hp_bonus) previewDeltas.hp = reward.hp_bonus;
+  if (reward.attack_mod_bonus) previewDeltas.attack_mod = reward.attack_mod_bonus;
+  if (reward.initiative_bonus) previewDeltas.initiative = reward.initiative_bonus;
+  if (reward.ability_unlock_tier) previewDeltas.ability_unlock_tier = reward.ability_unlock_tier;
+
+  return `
+    <div class="promo-card" data-unit="${unitId}" data-target-tier="${tierLabel}">
+      <div class="promo-header">
+        <strong class="promo-unit">${unitId}</strong>
+        <span class="promo-tier-arrow">${eligibility.current_tier || '—'} → ${tierLabel}</span>
+      </div>
+      <div class="promo-rewards">${renderDeltas(previewDeltas)}</div>
+      <div class="promo-actions">
+        <button class="promo-accept" data-unit="${unitId}" data-target-tier="${tierLabel}">
+          ✓ Accetta promozione
+        </button>
+        <button class="promo-defer" data-unit="${unitId}">⏭ Differisci</button>
+      </div>
+      <div class="promo-status" id="promo-status-${unitId}"></div>
+    </div>
+  `;
+}
+
+/**
+ * Fetch promotion eligibility for the session and render cards for each
+ * eligible unit. Attaches click handlers for accept/defer in-place.
+ *
+ * @param {string} sessionId
+ * @param {HTMLElement} container — DOM element to append the panel into.
+ *   Typically the endgame stats slot.
+ */
+export async function renderPromotionPanel(sessionId, container) {
+  if (!sessionId || !container) return;
+  const slot = document.createElement('div');
+  slot.id = 'promotion-panel-slot';
+  slot.className = 'promo-panel loading';
+  slot.innerHTML = '<em>⏳ Promozioni…</em>';
+  container.appendChild(slot);
+
+  const r = await api.promotionEligibility(sessionId);
+  if (!r.ok || !r.data) {
+    slot.className = 'promo-panel error';
+    slot.innerHTML = '<em>⚠ Promozioni non disponibili</em>';
+    return;
+  }
+  const eligibleList = (r.data.eligibility || []).filter((e) => e && e.eligible);
+  if (eligibleList.length === 0) {
+    slot.className = 'promo-panel empty';
+    slot.innerHTML = '<em>Nessuna promozione disponibile dopo questo combat.</em>';
+    return;
+  }
+  slot.className = 'promo-panel';
+  slot.innerHTML = `
+    <h3>🎖 Promozioni disponibili</h3>
+    <div class="promo-list">${eligibleList.map((e) => renderCard(e.unit_id, e)).join('')}</div>
+  `;
+
+  // Wire accept handlers.
+  slot.querySelectorAll('.promo-accept').forEach((btn) => {
+    btn.addEventListener('click', async (ev) => {
+      const el = ev.currentTarget;
+      const unitId = el.dataset.unit;
+      const targetTier = el.dataset.targetTier;
+      const statusEl = slot.querySelector(`#promo-status-${unitId}`);
+      el.disabled = true;
+      const deferBtn = slot.querySelector(`.promo-defer[data-unit="${unitId}"]`);
+      if (deferBtn) deferBtn.disabled = true;
+      if (statusEl) statusEl.innerHTML = '<em>⏳ Applico promozione…</em>';
+      const resp = await api.promotionAccept(sessionId, unitId, targetTier);
+      if (!resp.ok) {
+        if (statusEl) {
+          const reason = resp.data?.error || `HTTP ${resp.status}`;
+          statusEl.className = 'promo-status error';
+          statusEl.textContent = `✖ ${reason}`;
+        }
+        el.disabled = false;
+        if (deferBtn) deferBtn.disabled = false;
+        return;
+      }
+      const card = el.closest('.promo-card');
+      if (card) card.classList.add('promo-accepted');
+      if (statusEl) {
+        statusEl.className = 'promo-status ok';
+        statusEl.innerHTML = `✓ Promosso a <strong>${resp.data?.applied_tier || targetTier}</strong>`;
+      }
+    });
+  });
+
+  // Defer: visual-only collapse, no API call (eligibility persists in session).
+  slot.querySelectorAll('.promo-defer').forEach((btn) => {
+    btn.addEventListener('click', (ev) => {
+      const card = ev.currentTarget.closest('.promo-card');
+      if (card) card.classList.add('promo-deferred');
+      const statusEl = slot.querySelector(`#promo-status-${ev.currentTarget.dataset.unit}`);
+      if (statusEl) {
+        statusEl.className = 'promo-status deferred';
+        statusEl.textContent = '⏭ Differita (riproponibile prossimo debrief)';
+      }
+    });
+  });
+}

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -3820,3 +3820,122 @@ canvas#grid.bg3lite-smooth-movement {
     min-height: 28px;
   }
 }
+
+/* TKT-M15-FE — Promotion panel (endgame overlay, victory). */
+.promo-panel {
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+  text-align: left;
+}
+.promo-panel.loading,
+.promo-panel.error,
+.promo-panel.empty {
+  opacity: 0.75;
+  font-size: 0.95em;
+}
+.promo-panel h3 {
+  color: var(--accent);
+  margin: 0 0 12px;
+  font-size: 1.05em;
+}
+.promo-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.promo-card {
+  background: var(--cell);
+  border: 1px solid var(--border);
+  padding: 12px;
+  border-radius: 4px;
+  transition: opacity 0.2s ease;
+}
+.promo-card.promo-accepted {
+  border-color: #6fb085;
+  background: #2a3a30;
+}
+.promo-card.promo-deferred {
+  opacity: 0.55;
+}
+.promo-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 8px;
+}
+.promo-unit {
+  color: var(--accent);
+  font-size: 1.05em;
+}
+.promo-tier-arrow {
+  font-family: 'VT323', monospace;
+  font-size: 1.1em;
+  letter-spacing: 1px;
+}
+.promo-rewards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+.promo-stat-chip {
+  background: rgba(139, 111, 176, 0.2);
+  border: 1px solid #8b6fb0;
+  color: #d4b8e8;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 0.85em;
+}
+.promo-no-reward {
+  opacity: 0.7;
+  font-size: 0.9em;
+}
+.promo-actions {
+  display: flex;
+  gap: 8px;
+}
+.promo-accept,
+.promo-defer {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.9em;
+}
+.promo-accept {
+  background: #2a4a3a;
+  border-color: #6fb085;
+  color: #b8e8c8;
+}
+.promo-accept:hover:not(:disabled) {
+  background: #4f876b;
+  color: #fff;
+}
+.promo-defer:hover:not(:disabled) {
+  background: var(--accent);
+  color: var(--bg);
+}
+.promo-accept:disabled,
+.promo-defer:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.promo-status {
+  margin-top: 8px;
+  font-size: 0.9em;
+  min-height: 1.2em;
+}
+.promo-status.ok {
+  color: #6fb085;
+}
+.promo-status.error {
+  color: #d96f6f;
+}
+.promo-status.deferred {
+  opacity: 0.7;
+  font-style: italic;
+}


### PR DESCRIPTION
## Summary

Frontend completion follow-up from [PR #2242](https://github.com/MasterDD-L34D/Game/pull/2242) (TKT-M15 backend: `evaluatePromotion` + `applyPromotion` + 2 endpoint + 17 test). Wires the accept/defer UI so XP tier ladder is actually visible to the player post-victory.

## Changes

- `apps/play/src/api.js` — `promotionEligibility(sid)` + `promotionAccept(sid, unitId, targetTier)`
- `apps/play/src/promotionPanel.js` **NEW** (~130 LOC) — `renderPromotionPanel(sid, container)` async fetch + per-unit card render + accept/defer handlers
- `apps/play/src/endgame.js` — hook into `showEndgame()` victory path
- `apps/play/src/style.css` — `.promo-panel` + `.promo-card` + chip + accepted/deferred visual states

## Endpoint shape (note vs scope ticket)

Scope ticket prompt said `/api/promotion/offer/:unitId` + `/api/promotion/decide/:unitId`. **Actual backend ships as session-scoped:**
- `GET /api/session/:id/promotion-eligibility` → `{ eligibility: [{ unit_id, current_tier, next_tier, eligible, reason, reward, metrics }] }`
- `POST /api/session/:id/promote` with body `{ unit_id, target_tier }` → `{ applied_tier, previous_tier, deltas, state }`

Frontend adapted to actual shape (no schema changes).

## UX

- Victory overlay shows new "🎖 Promozioni disponibili" panel after VC block
- Each eligible unit: card with `current → next` tier arrow + reward chips (HP/Attacco/Iniziativa/Abilità unlock)
- "✓ Accetta" → POST + visual confirm "Promosso a TX" + card highlighted green
- "⏭ Differisci" → visual-only collapse (eligibility persists session-side, re-proposed next combat)

## Test plan

- [x] `node --test tests/api/promotion.test.js` — 17/17 green (no regression backend)
- [x] `node --test tests/ai/*.test.js` — 417/417 baseline preserved
- [x] Prettier clean on 4 files (1 new)
- [ ] Manual: complete winning encounter with kill threshold → panel appears → accept → card highlights
- [ ] Manual: defer → card greys out + status "Differita"

## Pillar impact

P3 Identità Specie x Job: 🟢++ (XCOM-style perk pick now player-facing).

## Acceptance §3 closure

TKT-M15 scope ticket §3 frontend: accept/defer UI shipped. i18n hardcoded IT ("Accetta promozione" / "Differisci") per single-locale codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)