### PR TITLE
feat(api): TKT-M14-B Phase C — conviction decide + eligible endpoints — close AC3

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -2738,6 +2738,122 @@ function createSessionRouter(options = {}) {
     }
   });
 
+  // TKT-M14-B Phase C — Conviction system endpoints (eligibility + decide).
+  // Phase A engine in services/convictionEngine.js; Phase B dialogue YAML
+  // + loader in services/dialogueLoader.js; Phase C exposes API surface.
+  //
+  // State storage: session.convictionState[actorId] = { utility, liberty,
+  // morality, events_classified }. Persists across calls within session
+  // lifetime. Default actor = first unit with controlled_by='player'.
+  // vcSnapshot.per_actor[uid].conviction_axis (Phase A) resta event-derived
+  // separato — endpoint state additive sopra (test 8 regression preserved).
+  router.get('/:id/conviction/eligible', (req, res, next) => {
+    try {
+      const { error, session } = resolveSession(req.params.id);
+      if (error) return res.status(error.status).json(error.body);
+
+      const { findEligible } = require('../services/dialogueLoader');
+      const playerUnit = (session.units || []).find((u) => u && u.controlled_by === 'player');
+      const actorId = String(req.query.actor || '').trim() || (playerUnit ? playerUnit.id : null);
+      if (!actorId) {
+        return res.status(404).json({ error: 'no_player_actor' });
+      }
+
+      if (!session.convictionState) session.convictionState = {};
+      if (!session.convictionState[actorId]) {
+        session.convictionState[actorId] = {
+          utility: 50,
+          liberty: 50,
+          morality: 50,
+          events_classified: 0,
+        };
+      }
+      const state = session.convictionState[actorId];
+
+      const branches = findEligible(state, {
+        encounter_id: session.encounter_id || null,
+      });
+
+      res.json({
+        actor_id: actorId,
+        conviction_axis: state,
+        branches: branches.map((b) => ({
+          id: b.id,
+          title: b.title,
+          description_it: b.description_it,
+          description_en: b.description_en,
+        })),
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.post('/:id/conviction/decide', (req, res, next) => {
+    try {
+      const { error, session } = resolveSession(req.params.id);
+      if (error) return res.status(error.status).json(error.body);
+
+      const body = req.body || {};
+      const branchId = body.branch_id;
+      const choiceId = body.choice_id;
+      if (!branchId || !choiceId) {
+        return res.status(400).json({
+          error: 'missing_body_fields',
+          required: ['branch_id', 'choice_id'],
+        });
+      }
+
+      const { getBranch, getChoice } = require('../services/dialogueLoader');
+      const branch = getBranch(branchId);
+      if (!branch) {
+        return res.status(404).json({ error: 'branch_not_found', branch_id: branchId });
+      }
+      const choice = getChoice(branchId, choiceId);
+      if (!choice) {
+        return res.status(404).json({
+          error: 'choice_not_found',
+          branch_id: branchId,
+          choice_id: choiceId,
+        });
+      }
+
+      const playerUnit = (session.units || []).find((u) => u && u.controlled_by === 'player');
+      const actorId = String(body.actor || '').trim() || (playerUnit ? playerUnit.id : null);
+      if (!actorId) {
+        return res.status(404).json({ error: 'no_player_actor' });
+      }
+
+      const { applyDelta } = require('../services/convictionEngine');
+      if (!session.convictionState) session.convictionState = {};
+      if (!session.convictionState[actorId]) {
+        session.convictionState[actorId] = {
+          utility: 50,
+          liberty: 50,
+          morality: 50,
+          events_classified: 0,
+        };
+      }
+      const prev = session.convictionState[actorId];
+      const next = applyDelta(prev, choice.delta);
+      session.convictionState[actorId] = {
+        ...next,
+        events_classified: (prev.events_classified || 0) + 1,
+      };
+
+      res.json({
+        actor_id: actorId,
+        branch_id: branchId,
+        choice_id: choiceId,
+        delta_applied: choice.delta,
+        conviction_axis: session.convictionState[actorId],
+        consequence: choice.consequence,
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
   router.post('/end', async (req, res, next) => {
     try {
       const body = req.body || {};

--- a/tests/api/sessionConviction.test.js
+++ b/tests/api/sessionConviction.test.js
@@ -1,0 +1,199 @@
+// TKT-M14-B Phase C — Session conviction endpoints integration tests.
+//
+// Covers:
+//   - GET /:id/conviction/eligible (filter by axis_threshold + encounter scope)
+//   - POST /:id/conviction/decide (apply delta + return updated axis + consequence)
+//   - vcSnapshot per_actor[uid].conviction_axis surface preserved (Phase A regression)
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+
+async function startSession(app) {
+  const res = await request(app)
+    .post('/api/session/start')
+    .send({
+      units: [
+        {
+          id: 'p1',
+          species: 'velox',
+          job: 'skirmisher',
+          hp: 10,
+          ap: 2,
+          attack_range: 2,
+          initiative: 14,
+          position: { x: 2, y: 2 },
+          controlled_by: 'player',
+        },
+        {
+          id: 'sis',
+          species: 'carapax',
+          job: 'vanguard',
+          hp: 10,
+          ap: 2,
+          attack_range: 1,
+          initiative: 10,
+          position: { x: 3, y: 2 },
+          controlled_by: 'sistema',
+        },
+      ],
+    })
+    .expect(200);
+  return res.body.session_id;
+}
+
+test('GET /:id/conviction/eligible returns branches for default player actor (neutral 50/50/50)', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const sessionId = await startSession(app);
+    const res = await request(app).get(`/api/session/${sessionId}/conviction/eligible`).expect(200);
+    assert.equal(res.body.actor_id, 'p1');
+    assert.ok(res.body.conviction_axis);
+    assert.equal(res.body.conviction_axis.utility, 50);
+    assert.ok(Array.isArray(res.body.branches));
+    // Neutral 50/50/50: prisoner_choice + resource_split + skiv_drift_choice eligible (3 unconditional).
+    const ids = res.body.branches.map((b) => b.id);
+    assert.ok(ids.includes('conv_branch_prisoner_choice'));
+    assert.ok(!ids.includes('conv_branch_betrayal_offer'), 'utility threshold not met');
+    assert.ok(!ids.includes('conv_branch_pack_unity'), 'morality threshold not met');
+  } finally {
+    if (typeof close === 'function') await close().catch(() => {});
+  }
+});
+
+test('GET /:id/conviction/eligible 404 for unknown session', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app).get('/api/session/nonexistent_id/conviction/eligible').expect(404);
+  } finally {
+    if (typeof close === 'function') await close().catch(() => {});
+  }
+});
+
+test('POST /:id/conviction/decide applies delta + returns updated axis + consequence', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const sessionId = await startSession(app);
+    const res = await request(app)
+      .post(`/api/session/${sessionId}/conviction/decide`)
+      .send({ branch_id: 'conv_branch_prisoner_choice', choice_id: 'liberate' })
+      .expect(200);
+    assert.equal(res.body.actor_id, 'p1');
+    assert.equal(res.body.branch_id, 'conv_branch_prisoner_choice');
+    assert.equal(res.body.choice_id, 'liberate');
+    assert.equal(res.body.delta_applied.liberty, 12);
+    // 50 + 12 = 62
+    assert.equal(res.body.conviction_axis.liberty, 62);
+    // 50 - 5 = 45 (utility)
+    assert.equal(res.body.conviction_axis.utility, 45);
+    // 50 + 5 = 55 (morality)
+    assert.equal(res.body.conviction_axis.morality, 55);
+    assert.ok(res.body.consequence);
+    assert.ok(res.body.consequence.includes('sabbia') || res.body.consequence.length > 0);
+  } finally {
+    if (typeof close === 'function') await close().catch(() => {});
+  }
+});
+
+test('POST /:id/conviction/decide round-trip: state persists between decisions', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const sessionId = await startSession(app);
+    // Decision 1: liberate (lib +12, util -5, mor +5) → 45/62/55
+    await request(app)
+      .post(`/api/session/${sessionId}/conviction/decide`)
+      .send({ branch_id: 'conv_branch_prisoner_choice', choice_id: 'liberate' })
+      .expect(200);
+    // Decision 2: split_half (lib +5, util -3, mor +6) → 42/67/61
+    const res2 = await request(app)
+      .post(`/api/session/${sessionId}/conviction/decide`)
+      .send({ branch_id: 'conv_branch_resource_split', choice_id: 'split_half' })
+      .expect(200);
+    assert.equal(res2.body.conviction_axis.utility, 42);
+    assert.equal(res2.body.conviction_axis.liberty, 67);
+    assert.equal(res2.body.conviction_axis.morality, 61);
+    assert.equal(res2.body.conviction_axis.events_classified, 2);
+  } finally {
+    if (typeof close === 'function') await close().catch(() => {});
+  }
+});
+
+test('POST /:id/conviction/decide 404 for invalid branch_id', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const sessionId = await startSession(app);
+    await request(app)
+      .post(`/api/session/${sessionId}/conviction/decide`)
+      .send({ branch_id: 'nonexistent_branch', choice_id: 'foo' })
+      .expect(404);
+  } finally {
+    if (typeof close === 'function') await close().catch(() => {});
+  }
+});
+
+test('POST /:id/conviction/decide 404 for invalid choice_id', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const sessionId = await startSession(app);
+    await request(app)
+      .post(`/api/session/${sessionId}/conviction/decide`)
+      .send({ branch_id: 'conv_branch_prisoner_choice', choice_id: 'invalid_choice' })
+      .expect(404);
+  } finally {
+    if (typeof close === 'function') await close().catch(() => {});
+  }
+});
+
+test('POST /:id/conviction/decide 400 for missing body fields', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const sessionId = await startSession(app);
+    await request(app).post(`/api/session/${sessionId}/conviction/decide`).send({}).expect(400);
+  } finally {
+    if (typeof close === 'function') await close().catch(() => {});
+  }
+});
+
+test('GET /:id/vc still includes conviction_axis (Phase A regression preserved)', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const sessionId = await startSession(app);
+    const res = await request(app).get(`/api/session/${sessionId}/vc`).expect(200);
+    assert.ok(res.body.per_actor);
+    assert.ok(res.body.per_actor.p1);
+    assert.ok(res.body.per_actor.p1.conviction_axis, 'conviction_axis missing in vcSnapshot');
+    assert.equal(res.body.per_actor.p1.conviction_axis.utility, 50);
+    assert.equal(res.body.per_actor.p1.conviction_axis.liberty, 50);
+    assert.equal(res.body.per_actor.p1.conviction_axis.morality, 50);
+  } finally {
+    if (typeof close === 'function') await close().catch(() => {});
+  }
+});
+
+test('Decision flow surfaces post-decide via eligibility threshold cross-over', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const sessionId = await startSession(app);
+    // baseline 50/50/50 — betrayal_offer NOT eligible (needs util>=60 + lib>=40)
+    let res = await request(app).get(`/api/session/${sessionId}/conviction/eligible`).expect(200);
+    assert.ok(!res.body.branches.map((b) => b.id).includes('conv_branch_betrayal_offer'));
+    // Apply interrogate (util +10, lib -3, mor -2) → 60/47/48
+    await request(app)
+      .post(`/api/session/${sessionId}/conviction/decide`)
+      .send({ branch_id: 'conv_branch_prisoner_choice', choice_id: 'interrogate' })
+      .expect(200);
+    // Now util=60, lib=47 → betrayal_offer eligible (util>=60 + lib>=40)
+    res = await request(app).get(`/api/session/${sessionId}/conviction/eligible`).expect(200);
+    const ids = res.body.branches.map((b) => b.id);
+    assert.ok(
+      ids.includes('conv_branch_betrayal_offer'),
+      `betrayal_offer should be eligible post util=60 lib=47, got ${JSON.stringify(ids)}`,
+    );
+  } finally {
+    if (typeof close === 'function') await close().catch(() => {});
+  }
+});


### PR DESCRIPTION
## Summary

Closes TKT-M14-B Conviction system Phase C (route extend) — additive su Phase A engine (#2248) + Phase B content (#2249).

## Deliverables

- `GET /api/session/:id/conviction/eligible` — actor axis + eligible branches
- `POST /api/session/:id/conviction/decide` — apply delta + return axis + consequence
- 9 tests `tests/api/sessionConviction.test.js`
- Session state: `session.convictionState[actorId]` persists across calls

## Tests

- 9/9 Phase C tests verde
- 1038/1038 full tests/api baseline verde
- Phase A regression preserved (test 8 vcSnapshot conviction_axis)

## Pillar P4

🟡++ → 🟢 candidato (engine + content + API + surface all LIVE)

## Forbidden paths

NONE touched. Only `apps/backend/routes/session.js` + `tests/api/sessionConviction.test.js`.

## Rollback

Single-file revert su `apps/backend/routes/session.js` (124 LOC additive) + test removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)