### PR TITLE
feat(campaign): TKT-P2 Brigandine seasonal Phase A engine — organization+battle phases + 4-season cycle

### DIFF
--- a/apps/backend/services/campaign/seasonalEngine.js
+++ b/apps/backend/services/campaign/seasonalEngine.js
@@ -1,0 +1,222 @@
+// TKT-P2 Brigandine seasonal — Phase A engine.
+//
+// Reference: docs/planning/2026-05-11-big-items-scope-tickets-bundle.md §5
+// (TKT-P2-BRIGANDINE-SEASONAL). Master-dd verdict A4 PROMUOVI priorità M14
+// (override OD-015 deferred verdict).
+//
+// Museum cards consulted (museum-first protocol):
+//   - M-2026-04-26-012 Worldgen Stack 4-livelli (bioma→ecosistema→foodweb→network)
+//     — seasonal modifiers compatible con biome layer (resource_yield / hazard).
+//   - M-2026-04-26-014 Cross-bioma event propagation (validator-time logic,
+//     zero runtime) — seasonal events_log additive primitive.
+//   - M-2026-04-25-005 Magnetic Rift Resonance (swarm trait T2, biome resonance)
+//     — recruit_pool modifier suggerito per season-biome interactions (Phase B).
+//
+// Pattern reference: Brigandine seasonal macro-loop (Organization Phase ↔ Battle
+// Phase, 4-season cycle = 1 year, multi-year campaign). Pivot rispetto a
+// `campaignEngine.js` (chapter-based linear/branching): seasonalEngine modella
+// macro-loop ciclico time-based, complementare e non in conflict.
+//
+// Phase A scope (THIS PR):
+//   - State shape + pure functions (initialState/advancePhase/advanceSeason)
+//   - Phase metadata (organization vs battle restrictions + actions)
+//   - Season modifiers POC (resource_yield, encounter_rate, hazard, recruit_pool)
+//   - events_log primitive (append-only)
+//   - Zero I/O, zero side-effect su esterni
+//
+// Phase B (defer): sample seasons YAML content data/core/campaign/seasons/*.yaml
+// Phase C (defer): apps/backend/routes/campaign.js seasonal endpoints
+// Phase D (defer): UI surface frontend HUD season indicator + organization actions
+//
+// === State shape ===
+//
+//   {
+//     current_phase: 'organization' | 'battle',
+//     current_season: 'spring' | 'summer' | 'autumn' | 'winter',
+//     current_year: number (1..N, monotone increment),
+//     phase_turn: number (0..M, reset on phase change),
+//     season_index: number (0..3, 0=spring 1=summer 2=autumn 3=winter),
+//     events_log: Array<{ year, season, phase, type, payload, t }>
+//   }
+//
+// === Transition rules ===
+//
+//   organization → battle: stesso season, phase_turn reset 0
+//   battle → organization: avanza season (potenzialmente year+1), phase_turn reset
+//
+// Quindi 1 anno = 4 stagioni × 2 fasi = 8 transizioni totali per ciclo annuo.
+
+'use strict';
+
+const SEASONS = ['spring', 'summer', 'autumn', 'winter'];
+const PHASES = ['organization', 'battle'];
+
+// Phase metadata — label, available actions, restrictions.
+const PHASE_SPECS = {
+  organization: {
+    label: 'Organization Phase',
+    description: 'Recruit, train, equip, deploy. No combat.',
+    actions: ['recruit', 'train', 'equip', 'deploy'],
+    combat_enabled: false,
+  },
+  battle: {
+    label: 'Battle Phase',
+    description: 'Tactical encounters. Recruitment locked.',
+    actions: ['engage', 'retreat', 'reinforce'],
+    combat_enabled: true,
+  },
+};
+
+// Season modifiers (POC values per Phase A spec).
+// Phase B will load these da data/core/campaign/seasons/*.yaml.
+const SEASON_MODIFIERS = {
+  spring: {
+    resource_yield: 1.2,
+    encounter_rate: 0.9,
+    hazard: 'flood',
+    recruit_pool: +1,
+  },
+  summer: {
+    resource_yield: 1.0,
+    encounter_rate: 1.1,
+    hazard: 'drought',
+    recruit_pool: 0,
+  },
+  autumn: {
+    resource_yield: 1.1,
+    encounter_rate: 1.0,
+    hazard: 'storm',
+    recruit_pool: 0,
+  },
+  winter: {
+    resource_yield: 0.7,
+    encounter_rate: 1.3,
+    hazard: 'frost',
+    recruit_pool: -1,
+  },
+};
+
+/**
+ * Baseline state: year 1, spring, organization phase, no events.
+ */
+function initialState() {
+  return {
+    current_phase: 'organization',
+    current_season: 'spring',
+    current_year: 1,
+    phase_turn: 0,
+    season_index: 0,
+    events_log: [],
+  };
+}
+
+/**
+ * Advance phase organization → battle (same season) OR battle → organization
+ * + next season. Pure: returns new state, does not mutate input.
+ */
+function advancePhase(state) {
+  if (!state || !PHASES.includes(state.current_phase)) {
+    throw new Error('advancePhase: invalid state.current_phase');
+  }
+  if (state.current_phase === 'organization') {
+    return {
+      ...state,
+      current_phase: 'battle',
+      phase_turn: 0,
+      events_log: [...(state.events_log || [])],
+    };
+  }
+  // battle → organization + next season
+  return advanceSeasonInternal({
+    ...state,
+    current_phase: 'organization',
+    phase_turn: 0,
+    events_log: [...(state.events_log || [])],
+  });
+}
+
+/**
+ * Internal helper — advance season index, wrap to next year when crossing winter.
+ */
+function advanceSeasonInternal(state) {
+  const nextIndex = (state.season_index + 1) % SEASONS.length;
+  const wrappedYear = nextIndex === 0 ? state.current_year + 1 : state.current_year;
+  return {
+    ...state,
+    season_index: nextIndex,
+    current_season: SEASONS[nextIndex],
+    current_year: wrappedYear,
+  };
+}
+
+/**
+ * Public: advance season directly (bypass phase). Returns new state.
+ * Used per test + future scenarios (es. skip season via narrative event).
+ */
+function advanceSeason(state) {
+  if (!state) {
+    throw new Error('advanceSeason: invalid state');
+  }
+  return advanceSeasonInternal({
+    ...state,
+    events_log: [...(state.events_log || [])],
+  });
+}
+
+/**
+ * Get phase metadata for current state.
+ */
+function getCurrentPhaseSpec(state) {
+  if (!state || !PHASE_SPECS[state.current_phase]) {
+    return null;
+  }
+  return { ...PHASE_SPECS[state.current_phase] };
+}
+
+/**
+ * Get season modifiers for a season key. Returns frozen copy.
+ */
+function getSeasonModifiers(season) {
+  if (!SEASON_MODIFIERS[season]) {
+    return null;
+  }
+  return { ...SEASON_MODIFIERS[season] };
+}
+
+/**
+ * Append event to log. Pure: returns new state with extended log.
+ * Event shape: { type, payload? }. Engine adds year/season/phase/t context.
+ */
+function appendEvent(state, event) {
+  if (!state) {
+    throw new Error('appendEvent: invalid state');
+  }
+  if (!event || typeof event !== 'object' || !event.type) {
+    throw new Error('appendEvent: event must have a type');
+  }
+  const enriched = {
+    year: state.current_year,
+    season: state.current_season,
+    phase: state.current_phase,
+    type: event.type,
+    payload: event.payload ?? null,
+    t: (state.events_log || []).length,
+  };
+  return {
+    ...state,
+    events_log: [...(state.events_log || []), enriched],
+  };
+}
+
+module.exports = {
+  SEASONS,
+  PHASES,
+  PHASE_SPECS,
+  SEASON_MODIFIERS,
+  initialState,
+  advancePhase,
+  advanceSeason,
+  getCurrentPhaseSpec,
+  getSeasonModifiers,
+  appendEvent,
+};

--- a/tests/api/seasonalEngine.test.js
+++ b/tests/api/seasonalEngine.test.js
@@ -1,0 +1,151 @@
+// TKT-P2 Brigandine seasonal — Phase A engine unit tests.
+//
+// Cover acceptance criteria scope ticket §5 within Phase A bound:
+//   - initialState baseline (AC1 campaign start primitives)
+//   - Phase transitions organization↔battle (AC2/AC3 organization+battle phases)
+//   - Season cycle spring→summer→autumn→winter→spring+year (year monotone)
+//   - Phase metadata + season modifiers retrievable
+//   - events_log append-only primitive (AC4 outcome aggregation primitive)
+//   - Multi-year progression no state corruption (AC5 cumulative state hygiene)
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  SEASONS,
+  initialState,
+  advancePhase,
+  advanceSeason,
+  getCurrentPhaseSpec,
+  getSeasonModifiers,
+  appendEvent,
+} = require('../../apps/backend/services/campaign/seasonalEngine');
+
+test('seasonalEngine: initialState returns year 1 spring organization', () => {
+  const state = initialState();
+  assert.equal(state.current_year, 1);
+  assert.equal(state.current_season, 'spring');
+  assert.equal(state.current_phase, 'organization');
+  assert.equal(state.season_index, 0);
+  assert.equal(state.phase_turn, 0);
+  assert.deepEqual(state.events_log, []);
+});
+
+test('seasonalEngine: advancePhase organization → battle (same season)', () => {
+  const s0 = initialState();
+  const s1 = advancePhase(s0);
+  assert.equal(s1.current_phase, 'battle');
+  assert.equal(s1.current_season, 'spring');
+  assert.equal(s1.current_year, 1);
+  assert.equal(s1.season_index, 0);
+  assert.equal(s1.phase_turn, 0);
+});
+
+test('seasonalEngine: advancePhase battle → organization + next season', () => {
+  const s0 = initialState();
+  const s1 = advancePhase(s0); // battle, spring
+  const s2 = advancePhase(s1); // organization, summer
+  assert.equal(s2.current_phase, 'organization');
+  assert.equal(s2.current_season, 'summer');
+  assert.equal(s2.season_index, 1);
+  assert.equal(s2.current_year, 1);
+});
+
+test('seasonalEngine: advanceSeason spring → summer', () => {
+  const s0 = initialState();
+  const s1 = advanceSeason(s0);
+  assert.equal(s1.current_season, 'summer');
+  assert.equal(s1.season_index, 1);
+  assert.equal(s1.current_year, 1);
+});
+
+test('seasonalEngine: advanceSeason winter → spring + year++ (wrap)', () => {
+  let s = { ...initialState(), current_season: 'winter', season_index: 3 };
+  s = advanceSeason(s);
+  assert.equal(s.current_season, 'spring');
+  assert.equal(s.season_index, 0);
+  assert.equal(s.current_year, 2);
+});
+
+test('seasonalEngine: full year cycle 4 seasons → year++', () => {
+  let s = initialState();
+  for (let i = 0; i < SEASONS.length; i += 1) {
+    s = advanceSeason(s);
+  }
+  // After 4 advances starting from spring: spring again, year 2.
+  assert.equal(s.current_season, 'spring');
+  assert.equal(s.current_year, 2);
+  assert.equal(s.season_index, 0);
+});
+
+test('seasonalEngine: getSeasonModifiers spring returns expected shape', () => {
+  const mod = getSeasonModifiers('spring');
+  assert.ok(mod, 'spring modifiers exist');
+  assert.equal(mod.resource_yield, 1.2);
+  assert.equal(mod.encounter_rate, 0.9);
+  assert.equal(mod.hazard, 'flood');
+  assert.equal(mod.recruit_pool, 1);
+});
+
+test('seasonalEngine: getSeasonModifiers winter has reduced yield + recruit penalty', () => {
+  const mod = getSeasonModifiers('winter');
+  assert.ok(mod, 'winter modifiers exist');
+  assert.ok(mod.resource_yield < 1.0, 'winter yield reduced');
+  assert.ok(mod.encounter_rate > 1.0, 'winter encounter rate elevated');
+  assert.equal(mod.recruit_pool, -1);
+  assert.equal(mod.hazard, 'frost');
+});
+
+test('seasonalEngine: getCurrentPhaseSpec returns metadata matching current_phase', () => {
+  const s0 = initialState();
+  const spec0 = getCurrentPhaseSpec(s0);
+  assert.equal(spec0.label, 'Organization Phase');
+  assert.equal(spec0.combat_enabled, false);
+  assert.ok(spec0.actions.includes('recruit'));
+
+  const s1 = advancePhase(s0);
+  const spec1 = getCurrentPhaseSpec(s1);
+  assert.equal(spec1.label, 'Battle Phase');
+  assert.equal(spec1.combat_enabled, true);
+  assert.ok(spec1.actions.includes('engage'));
+});
+
+test('seasonalEngine: appendEvent stores in events_log with context enrichment', () => {
+  const s0 = initialState();
+  const s1 = appendEvent(s0, { type: 'recruit', payload: { unit_id: 'wolf_a' } });
+  assert.equal(s1.events_log.length, 1);
+  const ev = s1.events_log[0];
+  assert.equal(ev.type, 'recruit');
+  assert.equal(ev.year, 1);
+  assert.equal(ev.season, 'spring');
+  assert.equal(ev.phase, 'organization');
+  assert.equal(ev.t, 0);
+  assert.deepEqual(ev.payload, { unit_id: 'wolf_a' });
+  // Pure: input not mutated.
+  assert.equal(s0.events_log.length, 0);
+});
+
+test('seasonalEngine: multiple cycles 5 years no state corruption', () => {
+  let s = initialState();
+  // Cycle: each year = 4 advancePhase(battle→organization) + 4 advancePhase(organization→battle)
+  // Simpler: 8 advancePhase calls per year (8 transitions total per year cycle).
+  // Year 1 start: organization/spring. After 8 phase advances we should be back to
+  // organization/spring of year 2.
+  const TARGET_YEARS = 5;
+  for (let y = 0; y < TARGET_YEARS; y += 1) {
+    for (let i = 0; i < 8; i += 1) {
+      s = advancePhase(s);
+    }
+  }
+  assert.equal(s.current_year, 1 + TARGET_YEARS);
+  assert.equal(s.current_season, 'spring');
+  assert.equal(s.current_phase, 'organization');
+  assert.equal(s.season_index, 0);
+
+  // Append events along the way still safe.
+  s = appendEvent(s, { type: 'year_recap', payload: { years_elapsed: TARGET_YEARS } });
+  assert.equal(s.events_log.length, 1);
+  assert.equal(s.events_log[0].year, 1 + TARGET_YEARS);
+});


### PR DESCRIPTION
## Summary

Phase A engine pure functions per macro-loop seasonal Brigandine-style. Scope ticket §5 (`docs/planning/2026-05-11-big-items-scope-tickets-bundle.md`). Master-dd verdict A4 PROMUOVI priorità M14 (override OD-015 deferred verdict).

Bounded scope: engine + state shape + transitions + season modifiers + events_log primitive. ~5h vs ~20h full ticket budget — Phase B/C/D deferred.

## Museum cards consulted (museum-first protocol)

- M-2026-04-26-012 [Worldgen Stack 4-livelli](docs/museum/cards/worldgen-bioma-ecosistema-foodweb-network-stack.md) — seasonal modifiers compatible con biome layer (resource_yield/hazard composition future Phase B target).
- M-2026-04-26-014 [Cross-bioma event propagation](docs/museum/cards/worldgen-cross-bioma-events-propagation.md) — events_log additive primitive precedent.
- M-2026-04-25-005 [Magnetic Rift Resonance](docs/museum/cards/old_mechanics-magnetic-rift-resonance.md) — biome resonance per season-biome recruit_pool interaction (Phase B integration target).

## Audit findings

- Campaign infrastructure exists chapter-based (`campaignEngine.js` + Store + Loader + ambitionService, 895 LOC totale). Linear/branching encounter flow.
- ZERO existing seasonal/brigandine logic in `apps/backend/` — greenfield Phase A.
- Test pattern uniforme con `tests/api/convictionAxis.test.js` (TKT-M14-B Phase A) — pure engine require + node:test + assert/strict.
- ADR-2026-04-28-deep-research-actions §5 cita Brigandine reference per P2 macro-loop deferred M12+. Verdict batch 2026-05-11 promosso a M14.
- Pivot rispetto a `campaignEngine.js`: seasonalEngine modella macro-loop ciclico time-based (4 stagioni × N anni), complementare e non in conflict con chapter-based flow esistente.

## Phase A scope shipped

**`apps/backend/services/campaign/seasonalEngine.js`** (~200 LOC):

- State shape: `current_phase`, `current_season`, `current_year`, `phase_turn`, `season_index`, `events_log`.
- Pure functions: `initialState`, `advancePhase`, `advanceSeason`, `getCurrentPhaseSpec`, `getSeasonModifiers`, `appendEvent`.
- Phase metadata: organization (recruit/train/equip/deploy, combat OFF) vs battle (engage/retreat/reinforce, combat ON).
- Season modifiers POC: spring (yield 1.2, flood, +1 recruit), summer (1.0, drought, 0), autumn (1.1, storm, 0), winter (0.7, frost, -1).
- Transition rules: organization → battle (same season), battle → organization + next season (4-season cycle = 1 year, multi-year monotone).
- Append-only events_log con context enrichment year/season/phase/t.

**`tests/api/seasonalEngine.test.js`** (~140 LOC, 11 tests, 50ms):

1. initialState returns year 1 spring organization
2. advancePhase organization → battle (same season)
3. advancePhase battle → organization + next season
4. advanceSeason spring → summer
5. advanceSeason winter → spring + year++ (wrap)
6. Full year cycle 4 seasons → year++
7. getSeasonModifiers spring returns expected shape
8. getSeasonModifiers winter reduced yield + recruit penalty
9. getCurrentPhaseSpec metadata switch organization/battle
10. appendEvent context enrichment + input immutability
11. Multi-year 5-year cycle no state corruption

## Phase B/C/D deferred (next sessions)

- **Phase B** (~4h): sample seasons YAML content `data/core/campaign/seasons/*.yaml`
- **Phase C** (~3h): `apps/backend/routes/campaign.js` seasonal endpoints (start, advance, organization, battle, status)
- **Phase D** (~3h): UI surface frontend HUD season indicator + organization actions

Cumulative Phase A+B+C+D estimated ~15h vs ticket budget ~20h.

## Pillar P2 impact

P2 Evoluzione emergente 🟢ⁿ → engine foundation laid. Surface upgrade pillar status promotion gated on Phase B+C+D completion.

## Forbidden path verification (Gate compliance)

- NO `migrations/*` touched (Prisma Season model deferred Phase C+ con master-dd grant)
- NO `packages/contracts/*` touched
- NO `.github/workflows/*` touched
- NO `services/generation/*` touched
- NO `services/rules/*` touched (ex-Python rules engine removed 2026-05-05)

50-line rule: ~200 LOC ma all in `apps/backend/services/campaign/` (allowed scope).

## Test plan

- [x] `node --test tests/api/seasonalEngine.test.js` → 11/11 PASS (50ms)
- [x] `node --test tests/ai/*.test.js` → 417/417 baseline preserved
- [x] `npx prettier --check` → GREEN both files
- [ ] CI test:api full suite
- [ ] CI format:check
- [ ] CI paths-filter
- [ ] CI styleguide-compliance

## Rollback plan (03A)

Revert single commit — pure additive (2 new files, no edits existing). Zero blast radius su altre routes/services. Backout 1 minute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)