### PR TITLE
feat(campaign): TKT-P2 Brigandine Phase B — 4 season + 2 phase YAML content + loader

### DIFF
--- a/apps/backend/services/campaign/seasonalContentLoader.js
+++ b/apps/backend/services/campaign/seasonalContentLoader.js
@@ -1,0 +1,156 @@
+// TKT-P2 Brigandine seasonal — Phase B content loader.
+//
+// Reads YAML from data/core/campaign/seasons/*.yaml + data/core/campaign/phases/*.yaml.
+// Returns parsed objects with caching + reload helper for test.
+//
+// Pattern parallel to apps/backend/services/dialogueLoader.js (TKT-M14-B Phase B).
+// PURE module: cache lazy at first call; _resetCache() esposto per test.
+//
+// Engine source-of-truth alignment:
+//   - Season ids match seasonalEngine.SEASONS canonical ['spring', 'summer',
+//     'autumn', 'winter'].
+//   - Phase ids match seasonalEngine.PHASES canonical ['organization', 'battle'].
+//   - Season modifier shape (resource_yield, encounter_rate, recruit_pool_delta,
+//     hazard) extends Phase A POC values con events_pool aggiuntivo per Phase B.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const SEASONS_DIR = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  'data',
+  'core',
+  'campaign',
+  'seasons',
+);
+const PHASES_DIR = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  'data',
+  'core',
+  'campaign',
+  'phases',
+);
+
+let seasonsCache = null;
+let seasonsCacheDir = null;
+let phasesCache = null;
+let phasesCacheDir = null;
+
+function _readYamlDir(dir) {
+  if (!fs.existsSync(dir)) return [];
+  const files = fs
+    .readdirSync(dir)
+    .filter((name) => name.endsWith('.yaml') || name.endsWith('.yml'));
+  const parsed = [];
+  for (const file of files) {
+    const fullPath = path.join(dir, file);
+    try {
+      const content = fs.readFileSync(fullPath, 'utf8');
+      const obj = yaml.load(content);
+      if (obj && obj.id) {
+        parsed.push(obj);
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn(`[seasonalContentLoader] skipped malformed file ${file}`);
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(`[seasonalContentLoader] failed parse ${file}: ${err.message}`);
+    }
+  }
+  return parsed;
+}
+
+/**
+ * Load all 4 seasons (spring/summer/autumn/winter). Cached after first call.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.dir] - override directory (test/inject)
+ * @param {boolean} [opts.force] - force reload bypass cache
+ * @returns {Array<object>}
+ */
+function loadSeasons(opts = {}) {
+  const dir = opts.dir || SEASONS_DIR;
+  if (!opts.force && seasonsCache && seasonsCacheDir === dir) return seasonsCache;
+  seasonsCache = _readYamlDir(dir);
+  seasonsCacheDir = dir;
+  return seasonsCache;
+}
+
+/**
+ * Get a single season by id ('spring' | 'summer' | 'autumn' | 'winter').
+ * @returns {object|null}
+ */
+function getSeason(id, opts = {}) {
+  if (!id) return null;
+  const all = loadSeasons(opts);
+  return all.find((s) => s.id === id) || null;
+}
+
+/**
+ * Load all phases (organization_phase, battle_phase). Cached.
+ *
+ * @param {object} [opts]
+ * @returns {Array<object>}
+ */
+function loadPhases(opts = {}) {
+  const dir = opts.dir || PHASES_DIR;
+  if (!opts.force && phasesCache && phasesCacheDir === dir) return phasesCache;
+  phasesCache = _readYamlDir(dir);
+  phasesCacheDir = dir;
+  return phasesCache;
+}
+
+/**
+ * Get a single phase by id ('organization_phase' | 'battle_phase').
+ * @returns {object|null}
+ */
+function getPhase(id, opts = {}) {
+  if (!id) return null;
+  const all = loadPhases(opts);
+  return all.find((p) => p.id === id) || null;
+}
+
+/**
+ * Get events_pool for a season id. Returns [] if season missing or no events.
+ *
+ * @param {string} seasonId
+ * @returns {Array<object>}
+ */
+function getSeasonEvents(seasonId, opts = {}) {
+  const season = getSeason(seasonId, opts);
+  if (!season || !Array.isArray(season.events_pool)) return [];
+  return season.events_pool;
+}
+
+/**
+ * Reset all caches (test helper).
+ */
+function _resetCache() {
+  seasonsCache = null;
+  seasonsCacheDir = null;
+  phasesCache = null;
+  phasesCacheDir = null;
+}
+
+module.exports = {
+  SEASONS_DIR,
+  PHASES_DIR,
+  loadSeasons,
+  getSeason,
+  loadPhases,
+  getPhase,
+  getSeasonEvents,
+  _resetCache,
+};

--- a/data/core/campaign/phases/battle_phase.yaml
+++ b/data/core/campaign/phases/battle_phase.yaml
@@ -1,0 +1,27 @@
+# TKT-P2 Brigandine seasonal — Phase B content (Battle Phase).
+#
+# Schema: cfr organization_phase.yaml header.
+# Narrative beat: Tattica + survival. Reclutamento bloccato.
+
+id: battle_phase
+display_name_it: "Fase di Battaglia"
+display_name_en: "Battle Phase"
+description_it: |
+  Tattica + survival. Encounter sequenziali sul terreno. Reclutamento
+  bloccato, decisioni binarie sotto pressione. La fase chiude quando
+  obiettivo stagionale completato o branco si ritira.
+description_en: |
+  Tactics + survival. Sequential encounters on terrain. Recruitment
+  locked, binary decisions under pressure. Phase ends when seasonal
+  objective is met or pack retreats.
+duration_turns: 3
+available_actions:
+  - engage
+  - retreat
+  - reinforce
+  - scout
+restricted_actions:
+  - recruit
+  - train
+auto_advance: false
+combat_enabled: true

--- a/data/core/campaign/phases/organization_phase.yaml
+++ b/data/core/campaign/phases/organization_phase.yaml
@@ -1,0 +1,31 @@
+# TKT-P2 Brigandine seasonal — Phase B content (Organization Phase).
+#
+# Reference: docs/planning/2026-05-11-big-items-scope-tickets-bundle.md §5.
+# Schema inline (NO contracts touch). Loader: seasonalContentLoader.js.
+# Engine: seasonalEngine.js PHASE_SPECS canonical match.
+#
+# Narrative beat: Tra una battaglia e l'altra. Recluta, riposa, allena.
+
+id: organization_phase
+display_name_it: "Fase Organizzativa"
+display_name_en: "Organization Phase"
+description_it: |
+  Tra una battaglia e l'altra. Recluta nuove creature, riposa il branco,
+  allena le abilità. Niente combattimento. Le decisioni qui modellano
+  la prossima Battle Phase.
+description_en: |
+  Between battles. Recruit new creatures, rest the pack, train abilities.
+  No combat. Decisions here shape the next Battle Phase.
+duration_turns: 3
+available_actions:
+  - recruit
+  - rest
+  - train
+  - equip
+  - deploy
+  - explore
+restricted_actions:
+  - combat
+  - engage
+auto_advance: true
+combat_enabled: false

--- a/data/core/campaign/seasons/autumn.yaml
+++ b/data/core/campaign/seasons/autumn.yaml
@@ -1,0 +1,38 @@
+# TKT-P2 Brigandine seasonal — Phase B content (Autumn).
+#
+# Schema: cfr spring.yaml header.
+# Narrative beat: Vento cambia direzione. Migrazioni e tempeste.
+
+id: autumn
+display_name_it: "Autunno"
+display_name_en: "Autumn"
+description_it: |
+  Il vento cambia direzione. Migrazioni di creature dai biomi estivi
+  verso i nidi profondi. Tempeste di sabbia frequenti, encounter
+  con specie nuove (migratori).
+description_en: |
+  Wind shifts. Creatures migrate from summer biomes toward deep nests.
+  Frequent sandstorms, encounters with new species (migrants).
+duration_turns: 6
+modifiers:
+  resource_yield: 1.1
+  encounter_rate: 1.0
+  recruit_pool_delta: 0
+hazards:
+  - type: storm
+    intensity: 0.5
+    affected_biomes:
+      - dune
+      - pianura
+      - umido
+events_pool:
+  - id: autumn_migration
+    description_it: "Migrazione. +1 specie disponibile per recruit."
+    description_en: "Migration. +1 species available for recruit."
+    trigger: random
+    weight: 35
+  - id: autumn_sandstorm
+    description_it: "Tempesta di sabbia. Visibilità ridotta. Encounter difficile."
+    description_en: "Sandstorm. Reduced visibility. Hard encounter."
+    trigger: hazard_threshold
+    weight: 25

--- a/data/core/campaign/seasons/spring.yaml
+++ b/data/core/campaign/seasons/spring.yaml
@@ -1,0 +1,42 @@
+# TKT-P2 Brigandine seasonal — Phase B content (Spring).
+#
+# Reference: docs/planning/2026-05-11-big-items-scope-tickets-bundle.md §5.
+# Schema inline (NO contracts touch — Phase B keeps YAML self-contained).
+# Loader: apps/backend/services/campaign/seasonalContentLoader.js.
+# Engine: apps/backend/services/campaign/seasonalEngine.js (Phase A POC values
+# canonical match — modifiers field-by-field aligned).
+#
+# Narrative beat: Sabbie risvegliate. Risorse abbondanti, hazard alluvione.
+
+id: spring
+display_name_it: "Primavera"
+display_name_en: "Spring"
+description_it: |
+  Sabbie risvegliate. L'acqua scorre nei letti secchi, le creature
+  emergono dai nidi invernali. Risorse abbondanti ma hazard alluvione
+  nei biomi umidi.
+description_en: |
+  Awakened sands. Water flows in dry beds, creatures emerge from
+  winter nests. Abundant resources but flood hazard in wet biomes.
+duration_turns: 6
+modifiers:
+  resource_yield: 1.2
+  encounter_rate: 0.9
+  recruit_pool_delta: 1
+hazards:
+  - type: flood
+    intensity: 0.3
+    affected_biomes:
+      - umido
+      - palude
+events_pool:
+  - id: spring_bloom
+    description_it: "Fioritura tardiva. +2 morale al branco."
+    description_en: "Late bloom. +2 morale to the pack."
+    trigger: random
+    weight: 30
+  - id: spring_storm
+    description_it: "Tempesta primaverile. Cancella un encounter."
+    description_en: "Spring storm. Cancels one encounter."
+    trigger: hazard_threshold
+    weight: 20

--- a/data/core/campaign/seasons/summer.yaml
+++ b/data/core/campaign/seasons/summer.yaml
@@ -1,0 +1,37 @@
+# TKT-P2 Brigandine seasonal — Phase B content (Summer).
+#
+# Schema: cfr spring.yaml header.
+# Narrative beat: Sole alto, sabbia rovente. Encounter più frequenti.
+
+id: summer
+display_name_it: "Estate"
+display_name_en: "Summer"
+description_it: |
+  Sole alto, sabbia rovente. Le creature si spostano di notte per
+  evitare il calore. Encounter più frequenti durante le ore fresche,
+  hazard siccità nei deserti.
+description_en: |
+  High sun, scorching sand. Creatures move at night to avoid heat.
+  Encounters more frequent during cool hours, drought hazard in deserts.
+duration_turns: 6
+modifiers:
+  resource_yield: 1.0
+  encounter_rate: 1.1
+  recruit_pool_delta: 0
+hazards:
+  - type: drought
+    intensity: 0.4
+    affected_biomes:
+      - deserto
+      - dune
+events_pool:
+  - id: summer_mirage
+    description_it: "Miraggio. Scout perde 1 turno."
+    description_en: "Mirage. Scout loses 1 turn."
+    trigger: random
+    weight: 25
+  - id: summer_harvest
+    description_it: "Raccolta. +1 risorsa stagionale."
+    description_en: "Harvest. +1 seasonal resource."
+    trigger: random
+    weight: 30

--- a/data/core/campaign/seasons/winter.yaml
+++ b/data/core/campaign/seasons/winter.yaml
@@ -1,0 +1,38 @@
+# TKT-P2 Brigandine seasonal — Phase B content (Winter).
+#
+# Schema: cfr spring.yaml header.
+# Narrative beat: Gelo notturno. Risorse scarse. Reclutamento limitato.
+
+id: winter
+display_name_it: "Inverno"
+display_name_en: "Winter"
+description_it: |
+  Gelo notturno. Le creature ibernano o migrano in profondità.
+  Risorse scarse, reclutamento limitato, encounter più letali
+  per la scarsità di vie di fuga.
+description_en: |
+  Night frost. Creatures hibernate or migrate deep. Scarce resources,
+  limited recruitment, encounters more lethal due to lack of escape routes.
+duration_turns: 6
+modifiers:
+  resource_yield: 0.7
+  encounter_rate: 1.3
+  recruit_pool_delta: -1
+hazards:
+  - type: frost
+    intensity: 0.6
+    affected_biomes:
+      - alpino
+      - tundra
+      - dune
+events_pool:
+  - id: winter_freeze
+    description_it: "Gelo improvviso. -1 morale al branco."
+    description_en: "Sudden freeze. -1 morale to the pack."
+    trigger: hazard_threshold
+    weight: 30
+  - id: winter_cache
+    description_it: "Cache nascosta. +2 risorse stagionali."
+    description_en: "Hidden cache. +2 seasonal resources."
+    trigger: random
+    weight: 15

--- a/tests/api/seasonalContentLoader.test.js
+++ b/tests/api/seasonalContentLoader.test.js
@@ -1,0 +1,134 @@
+// TKT-P2 Brigandine seasonal — Phase B content loader unit tests.
+//
+// Covers loader API: loadSeasons, getSeason, loadPhases, getPhase,
+// getSeasonEvents, _resetCache. Validates modifiers + hazards shape contract
+// + alignment with seasonalEngine canonical season/phase ids.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  loadSeasons,
+  getSeason,
+  loadPhases,
+  getPhase,
+  getSeasonEvents,
+  _resetCache,
+} = require('../../apps/backend/services/campaign/seasonalContentLoader');
+
+const { SEASONS, PHASES } = require('../../apps/backend/services/campaign/seasonalEngine');
+
+test('seasonalContentLoader: loadSeasons returns 4 seasons no error', () => {
+  _resetCache();
+  const seasons = loadSeasons();
+  assert.equal(seasons.length, 4, `expected 4 seasons, got ${seasons.length}`);
+  const ids = seasons.map((s) => s.id).sort();
+  assert.deepEqual(ids, [...SEASONS].sort(), 'season ids match engine canonical');
+});
+
+test('seasonalContentLoader: getSeason by id returns parsed object', () => {
+  _resetCache();
+  const spring = getSeason('spring');
+  assert.ok(spring, 'spring exists');
+  assert.equal(spring.id, 'spring');
+  assert.equal(spring.display_name_it, 'Primavera');
+  assert.ok(spring.modifiers, 'modifiers present');
+  assert.ok(Array.isArray(spring.hazards), 'hazards array');
+  assert.equal(getSeason('nonexistent'), null);
+  assert.equal(getSeason(null), null);
+});
+
+test('seasonalContentLoader: loadPhases returns 2 phases no error', () => {
+  _resetCache();
+  const phases = loadPhases();
+  assert.equal(phases.length, 2, `expected 2 phases, got ${phases.length}`);
+  const ids = phases.map((p) => p.id).sort();
+  assert.deepEqual(ids, ['battle_phase', 'organization_phase']);
+});
+
+test('seasonalContentLoader: getPhase by id returns parsed object', () => {
+  _resetCache();
+  const org = getPhase('organization_phase');
+  assert.ok(org, 'organization_phase exists');
+  assert.equal(org.combat_enabled, false);
+  assert.ok(Array.isArray(org.available_actions));
+  assert.ok(org.available_actions.includes('recruit'));
+
+  const battle = getPhase('battle_phase');
+  assert.ok(battle, 'battle_phase exists');
+  assert.equal(battle.combat_enabled, true);
+  assert.ok(battle.available_actions.includes('engage'));
+});
+
+test('seasonalContentLoader: getSeasonEvents spring returns events_pool', () => {
+  _resetCache();
+  const events = getSeasonEvents('spring');
+  assert.ok(events.length >= 2, `expected >=2 spring events, got ${events.length}`);
+  for (const ev of events) {
+    assert.ok(ev.id, 'event has id');
+    assert.ok(ev.trigger, 'event has trigger');
+    assert.ok(typeof ev.weight === 'number', 'weight numeric');
+  }
+});
+
+test('seasonalContentLoader: modifiers shape (resource_yield + recruit_pool_delta numeric)', () => {
+  _resetCache();
+  for (const seasonId of SEASONS) {
+    const s = getSeason(seasonId);
+    assert.ok(s, `season ${seasonId} loaded`);
+    assert.ok(
+      typeof s.modifiers.resource_yield === 'number',
+      `${seasonId}.modifiers.resource_yield numeric`,
+    );
+    assert.ok(
+      typeof s.modifiers.encounter_rate === 'number',
+      `${seasonId}.modifiers.encounter_rate numeric`,
+    );
+    assert.ok(
+      typeof s.modifiers.recruit_pool_delta === 'number',
+      `${seasonId}.modifiers.recruit_pool_delta numeric`,
+    );
+  }
+});
+
+test('seasonalContentLoader: hazards shape (array with type + intensity)', () => {
+  _resetCache();
+  for (const seasonId of SEASONS) {
+    const s = getSeason(seasonId);
+    assert.ok(Array.isArray(s.hazards), `${seasonId} hazards array`);
+    assert.ok(s.hazards.length >= 1, `${seasonId} hazards >=1`);
+    for (const h of s.hazards) {
+      assert.ok(h.type, `${seasonId} hazard type present`);
+      assert.ok(typeof h.intensity === 'number', `${seasonId} hazard intensity numeric`);
+      assert.ok(Array.isArray(h.affected_biomes), `${seasonId} affected_biomes array`);
+    }
+  }
+});
+
+test('seasonalContentLoader: cache reset works (force reload bypass)', () => {
+  _resetCache();
+  const a = loadSeasons();
+  const b = loadSeasons(); // cached
+  assert.equal(a, b, 'cache returns same reference');
+  _resetCache();
+  const c = loadSeasons();
+  assert.notEqual(a, c, 'reset invalidates cache');
+});
+
+test('seasonalContentLoader: phase ids align with engine PHASES canonical', () => {
+  _resetCache();
+  const phases = loadPhases();
+  const phaseEngineIds = phases
+    .map((p) => {
+      // YAML id ends with '_phase'; engine canonical is bare 'organization'|'battle'.
+      return p.id.replace(/_phase$/, '');
+    })
+    .sort();
+  assert.deepEqual(
+    phaseEngineIds,
+    [...PHASES].sort(),
+    'phase yaml ids align with engine canonical after suffix strip',
+  );
+});


### PR DESCRIPTION
## Summary

Phase B aggiunge content YAML self-contained per il TKT-P2 Brigandine seasonal macro-loop. Phase A engine merged in #2251 (`bdab6703`).

- 4 stagioni `data/core/campaign/seasons/{spring,summer,autumn,winter}.yaml`
- 2 fasi `data/core/campaign/phases/{organization,battle}_phase.yaml`
- Loader `apps/backend/services/campaign/seasonalContentLoader.js` (~140 LOC, pattern parallelo a `dialogueLoader.js`)
- 9 test `tests/api/seasonalContentLoader.test.js`

## Loader API

- `loadSeasons() / getSeason(id) / getSeasonEvents(id)`
- `loadPhases() / getPhase(id)`
- `_resetCache()` test helper

## Schema inline (NO contracts touch)

Season: `id` + display names IT/EN + `modifiers: { resource_yield, encounter_rate, recruit_pool_delta }` + `hazards: [{ type, intensity, affected_biomes }]` + `events_pool: [{ id, trigger, weight }]`.

Phase: `id` + display names + `available_actions[]` / `restricted_actions[]` + `auto_advance` + `combat_enabled`.

## Engine alignment

Season ids match `seasonalEngine.SEASONS` canonical (`['spring', 'summer', 'autumn', 'winter']`). Phase ids align con `seasonalEngine.PHASES` (suffix `_phase` strip per parity). Modifier values canonical-aligned con Phase A POC `SEASON_MODIFIERS` constant — YAML content extends Phase A senza override (Phase C router può switch engine→YAML loader).

## Test plan

- [x] `node --test tests/api/seasonalContentLoader.test.js` → 9/9 PASS
- [x] `node --test tests/api/*.test.js` → 1058/1058 PASS (baseline preserved)
- [x] `node --test tests/ai/*.test.js` → 417/417 PASS (baseline preserved)
- [x] Prettier green
- [x] YAML well-formed (`yaml.safe_load` cycle on all 8 files)

## Rollback plan (03A)

PR self-contained: 6 YAML + 1 service + 1 test. Revert merge commit ripristina stato pre-PR. Engine Phase A in `seasonalEngine.js` rimane intatto (zero cross-dependency).

## Phase C deferred (~3h)

Router `/api/campaign/seasonal/*` endpoints (state + advance-phase + advance-season + modifiers + phase-spec + events) — segue stesso branch pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)