### PR TITLE
feat(api): TKT-P2 Brigandine Phase C — 6 seasonal campaign endpoints + 10 tests

### DIFF
--- a/apps/backend/routes/campaign.js
+++ b/apps/backend/routes/campaign.js
@@ -46,6 +46,26 @@ const {
 const { grantXpToSurvivors } = require('../services/progression/progressionApply');
 const { loadXpCurve } = require('../services/progression/progressionLoader');
 
+// TKT-P2 Brigandine seasonal — Phase C routes (engine Phase A #2251 + content Phase B #2252).
+const seasonalEngine = require('../services/campaign/seasonalEngine');
+const seasonalContentLoader = require('../services/campaign/seasonalContentLoader');
+
+// In-memory seasonal state Map<campaign_id, state>. Per POC. Resettable via
+// _resetSeasonalState() per test isolation. Future iteration: integrate con
+// campaignStore o Prisma write-through (pattern progressionStore).
+const campaignSeasonalState = new Map();
+
+function _resetSeasonalState() {
+  campaignSeasonalState.clear();
+}
+
+function _getOrInitSeasonalState(campaignId) {
+  if (!campaignSeasonalState.has(campaignId)) {
+    campaignSeasonalState.set(campaignId, seasonalEngine.initialState());
+  }
+  return campaignSeasonalState.get(campaignId);
+}
+
 // M12 Phase D — evolve opportunity trigger threshold (ADR-2026-04-23 addendum).
 // Victory + pe_earned >= PE_EVOLVE_TRIGGER_THRESHOLD → response.evolve_opportunity=true.
 // Consumed frontend-side (formsPanel auto-open) + lobby campaign mirror.
@@ -529,6 +549,120 @@ function createCampaignRouter(options = {}) {
     return res.json(result);
   });
 
+  // TKT-P2 Brigandine seasonal — Phase C endpoints.
+  //
+  // 6 endpoints expose macro-loop state + transitions + content metadata:
+  //   GET  /api/campaign/seasonal/state           - current state for campaign_id
+  //   POST /api/campaign/seasonal/advance-phase   - organization ↔ battle
+  //   POST /api/campaign/seasonal/advance-season  - spring → summer → ... (+year wrap)
+  //   GET  /api/campaign/seasonal/modifiers       - current season modifiers
+  //   GET  /api/campaign/seasonal/phase-spec      - current phase actions + restrictions
+  //   GET  /api/campaign/seasonal/events          - season events_pool (?season=<id>)
+  //
+  // State storage: in-memory Map (POC). campaign_id query/body param required.
+
+  router.get('/campaign/seasonal/state', (req, res) => {
+    const campaignId = String(req.query?.campaign_id || '').trim();
+    if (!campaignId) {
+      return res.status(400).json({ error: 'campaign_id query param richiesto' });
+    }
+    const state = _getOrInitSeasonalState(campaignId);
+    return res.json({ campaign_id: campaignId, state });
+  });
+
+  router.post('/campaign/seasonal/advance-phase', (req, res) => {
+    const campaignId = String(req.body?.campaign_id || '').trim();
+    if (!campaignId) {
+      return res.status(400).json({ error: 'campaign_id richiesto' });
+    }
+    const prev = _getOrInitSeasonalState(campaignId);
+    try {
+      const next = seasonalEngine.advancePhase(prev);
+      campaignSeasonalState.set(campaignId, next);
+      return res.json({ campaign_id: campaignId, state: next });
+    } catch (err) {
+      return res.status(500).json({ error: 'advance_phase_failed', detail: err.message });
+    }
+  });
+
+  router.post('/campaign/seasonal/advance-season', (req, res) => {
+    const campaignId = String(req.body?.campaign_id || '').trim();
+    if (!campaignId) {
+      return res.status(400).json({ error: 'campaign_id richiesto' });
+    }
+    const prev = _getOrInitSeasonalState(campaignId);
+    try {
+      const next = seasonalEngine.advanceSeason(prev);
+      campaignSeasonalState.set(campaignId, next);
+      return res.json({ campaign_id: campaignId, state: next });
+    } catch (err) {
+      return res.status(500).json({ error: 'advance_season_failed', detail: err.message });
+    }
+  });
+
+  router.get('/campaign/seasonal/modifiers', (req, res) => {
+    const campaignId = String(req.query?.campaign_id || '').trim();
+    if (!campaignId) {
+      return res.status(400).json({ error: 'campaign_id query param richiesto' });
+    }
+    const state = _getOrInitSeasonalState(campaignId);
+    // Prefer YAML content (Phase B loader) for full hazards array; fallback engine POC.
+    const yamlSeason = seasonalContentLoader.getSeason(state.current_season);
+    if (yamlSeason) {
+      return res.json({
+        campaign_id: campaignId,
+        season: state.current_season,
+        modifiers: yamlSeason.modifiers,
+        hazards: yamlSeason.hazards || [],
+      });
+    }
+    const modifiers = seasonalEngine.getSeasonModifiers(state.current_season);
+    return res.json({
+      campaign_id: campaignId,
+      season: state.current_season,
+      modifiers,
+      hazards: modifiers ? [{ type: modifiers.hazard, intensity: 0.5, affected_biomes: [] }] : [],
+    });
+  });
+
+  router.get('/campaign/seasonal/phase-spec', (req, res) => {
+    const campaignId = String(req.query?.campaign_id || '').trim();
+    if (!campaignId) {
+      return res.status(400).json({ error: 'campaign_id query param richiesto' });
+    }
+    const state = _getOrInitSeasonalState(campaignId);
+    // Prefer YAML content (Phase B loader); fallback engine POC.
+    const yamlPhase = seasonalContentLoader.getPhase(`${state.current_phase}_phase`);
+    if (yamlPhase) {
+      return res.json({
+        campaign_id: campaignId,
+        phase: state.current_phase,
+        available_actions: yamlPhase.available_actions || [],
+        restricted_actions: yamlPhase.restricted_actions || [],
+        combat_enabled: yamlPhase.combat_enabled,
+        auto_advance: yamlPhase.auto_advance,
+      });
+    }
+    const spec = seasonalEngine.getCurrentPhaseSpec(state);
+    return res.json({
+      campaign_id: campaignId,
+      phase: state.current_phase,
+      available_actions: spec ? spec.actions : [],
+      restricted_actions: [],
+      combat_enabled: spec ? spec.combat_enabled : false,
+      auto_advance: false,
+    });
+  });
+
+  router.get('/campaign/seasonal/events', (req, res) => {
+    const season = String(req.query?.season || '').trim();
+    if (!season) {
+      return res.status(400).json({ error: 'season query param richiesto' });
+    }
+    const events = seasonalContentLoader.getSeasonEvents(season);
+    return res.json({ season, events, count: events.length });
+  });
+
   return router;
 }
 
@@ -536,4 +670,5 @@ module.exports = {
   createCampaignRouter,
   computeEvolveOpportunity,
   PE_EVOLVE_TRIGGER_THRESHOLD,
+  _resetSeasonalState,
 };

--- a/tests/api/campaignSeasonal.test.js
+++ b/tests/api/campaignSeasonal.test.js
@@ -1,0 +1,179 @@
+// TKT-P2 Brigandine seasonal — Phase C routes integration tests.
+//
+// Cover 6 endpoints: state, advance-phase, advance-season, modifiers,
+// phase-spec, events. State storage in-memory Map (POC).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const http = require('node:http');
+
+const { createCampaignRouter, _resetSeasonalState } = require('../../apps/backend/routes/campaign');
+const { _resetCache } = require('../../apps/backend/services/campaign/seasonalContentLoader');
+
+function startTestServer(t) {
+  _resetSeasonalState();
+  _resetCache();
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createCampaignRouter());
+  const server = app.listen(0);
+  const port = server.address().port;
+  t.after(() => server.close());
+  return { url: `http://127.0.0.1:${port}` };
+}
+
+function request(method, url, body = null) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const opts = {
+      hostname: parsed.hostname,
+      port: parsed.port,
+      path: parsed.pathname + parsed.search,
+      method,
+      headers: { 'content-type': 'application/json' },
+    };
+    const req = http.request(opts, (res) => {
+      let data = '';
+      res.on('data', (c) => (data += c));
+      res.on('end', () => {
+        let parsedBody = null;
+        try {
+          parsedBody = data ? JSON.parse(data) : null;
+        } catch (e) {
+          parsedBody = data;
+        }
+        resolve({ status: res.statusCode, body: parsedBody });
+      });
+    });
+    req.on('error', reject);
+    if (body) req.write(JSON.stringify(body));
+    req.end();
+  });
+}
+
+test('GET /api/campaign/seasonal/state: returns initial year 1 spring organization', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('GET', `${url}/api/campaign/seasonal/state?campaign_id=c1`);
+  assert.equal(res.status, 200);
+  assert.equal(res.body.campaign_id, 'c1');
+  assert.equal(res.body.state.current_year, 1);
+  assert.equal(res.body.state.current_season, 'spring');
+  assert.equal(res.body.state.current_phase, 'organization');
+  assert.equal(res.body.state.season_index, 0);
+});
+
+test('GET /api/campaign/seasonal/state: missing campaign_id = 400', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('GET', `${url}/api/campaign/seasonal/state`);
+  assert.equal(res.status, 400);
+});
+
+test('POST /api/campaign/seasonal/advance-phase: organization → battle (same season)', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('POST', `${url}/api/campaign/seasonal/advance-phase`, {
+    campaign_id: 'c1',
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.state.current_phase, 'battle');
+  assert.equal(res.body.state.current_season, 'spring');
+  assert.equal(res.body.state.current_year, 1);
+});
+
+test('POST /api/campaign/seasonal/advance-phase: battle → organization + next season', async (t) => {
+  const { url } = startTestServer(t);
+  await request('POST', `${url}/api/campaign/seasonal/advance-phase`, { campaign_id: 'c1' });
+  const res = await request('POST', `${url}/api/campaign/seasonal/advance-phase`, {
+    campaign_id: 'c1',
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.state.current_phase, 'organization');
+  assert.equal(res.body.state.current_season, 'summer');
+  assert.equal(res.body.state.current_year, 1);
+});
+
+test('POST /api/campaign/seasonal/advance-season: spring → summer', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('POST', `${url}/api/campaign/seasonal/advance-season`, {
+    campaign_id: 'c1',
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.state.current_season, 'summer');
+  assert.equal(res.body.state.season_index, 1);
+  assert.equal(res.body.state.current_year, 1);
+});
+
+test('POST /api/campaign/seasonal/advance-season: winter → spring + year++', async (t) => {
+  const { url } = startTestServer(t);
+  // Advance 4 seasons to wrap.
+  for (let i = 0; i < 4; i += 1) {
+    await request('POST', `${url}/api/campaign/seasonal/advance-season`, { campaign_id: 'c1' });
+  }
+  const res = await request('GET', `${url}/api/campaign/seasonal/state?campaign_id=c1`);
+  assert.equal(res.status, 200);
+  assert.equal(res.body.state.current_season, 'spring');
+  assert.equal(res.body.state.current_year, 2);
+});
+
+test('GET /api/campaign/seasonal/modifiers: spring resource_yield 1.2', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('GET', `${url}/api/campaign/seasonal/modifiers?campaign_id=c1`);
+  assert.equal(res.status, 200);
+  assert.equal(res.body.season, 'spring');
+  assert.equal(res.body.modifiers.resource_yield, 1.2);
+  assert.ok(Array.isArray(res.body.hazards));
+  assert.ok(res.body.hazards.length >= 1);
+  assert.equal(res.body.hazards[0].type, 'flood');
+});
+
+test('GET /api/campaign/seasonal/modifiers: winter recruit_pool_delta -1', async (t) => {
+  const { url } = startTestServer(t);
+  // Advance to winter: spring→summer→autumn→winter (3 season advances).
+  for (let i = 0; i < 3; i += 1) {
+    await request('POST', `${url}/api/campaign/seasonal/advance-season`, { campaign_id: 'c1' });
+  }
+  const res = await request('GET', `${url}/api/campaign/seasonal/modifiers?campaign_id=c1`);
+  assert.equal(res.status, 200);
+  assert.equal(res.body.season, 'winter');
+  assert.equal(res.body.modifiers.recruit_pool_delta, -1);
+});
+
+test('GET /api/campaign/seasonal/phase-spec: organization actions includes recruit', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('GET', `${url}/api/campaign/seasonal/phase-spec?campaign_id=c1`);
+  assert.equal(res.status, 200);
+  assert.equal(res.body.phase, 'organization');
+  assert.equal(res.body.combat_enabled, false);
+  assert.ok(res.body.available_actions.includes('recruit'));
+});
+
+test('GET /api/campaign/seasonal/events?season=spring returns events_pool', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('GET', `${url}/api/campaign/seasonal/events?season=spring`);
+  assert.equal(res.status, 200);
+  assert.equal(res.body.season, 'spring');
+  assert.ok(res.body.count >= 2);
+  assert.ok(Array.isArray(res.body.events));
+  for (const ev of res.body.events) {
+    assert.ok(ev.id);
+    assert.ok(ev.trigger);
+  }
+});
+
+test('Multi-call round-trip: 5 years of advance-phase cycles preserve state integrity', async (t) => {
+  const { url } = startTestServer(t);
+  // Each year = 8 advance-phase calls (4 seasons × 2 phases each).
+  const YEARS = 5;
+  for (let y = 0; y < YEARS; y += 1) {
+    for (let i = 0; i < 8; i += 1) {
+      await request('POST', `${url}/api/campaign/seasonal/advance-phase`, { campaign_id: 'c1' });
+    }
+  }
+  const res = await request('GET', `${url}/api/campaign/seasonal/state?campaign_id=c1`);
+  assert.equal(res.status, 200);
+  assert.equal(res.body.state.current_year, 1 + YEARS);
+  assert.equal(res.body.state.current_season, 'spring');
+  assert.equal(res.body.state.current_phase, 'organization');
+});


### PR DESCRIPTION
## Summary

Phase C aggiunge API surface al TKT-P2 Brigandine seasonal macro-loop. Engine Phase A merged #2251 (\`bdab6703\`), content Phase B merged #2252 (\`a4d3650a\`).

- 6 endpoints \`/api/campaign/seasonal/*\` (state + 2 transition + modifiers + phase-spec + events)
- State in-memory \`Map<campaign_id, state>\` (POC; future: Prisma write-through pattern)
- 11 integration tests (10 endpoint cover + 1 multi-year round-trip)

## Endpoints

| Method | Path | Purpose |
| --- | --- | --- |
| GET  | \`/api/campaign/seasonal/state\` | campaign state snapshot |
| POST | \`/api/campaign/seasonal/advance-phase\` | organization ↔ battle |
| POST | \`/api/campaign/seasonal/advance-season\` | spring → summer → ... (+year wrap) |
| GET  | \`/api/campaign/seasonal/modifiers\` | current season modifiers + hazards |
| GET  | \`/api/campaign/seasonal/phase-spec\` | current phase actions + restrictions |
| GET  | \`/api/campaign/seasonal/events\` | season events_pool (\`?season=<id>\`) |

## Implementation

Prefer YAML content (Phase B loader) per modifiers/hazards/phase-spec; fallback engine POC values via \`seasonalEngine\`. Multi-call round-trip 5 anni × 8 phase transitions verificato (state spring/organization year 6).

\`_resetSeasonalState()\` esposto via module.exports per test isolation.

## Test plan

- [x] \`node --test tests/api/campaignSeasonal.test.js\` → 11/11 PASS
- [x] \`node --test tests/api/*.test.js\` → 1069/1069 PASS (+11 vs prior 1058, zero regression)
- [x] \`node --test tests/ai/*.test.js\` → 417/417 PASS (preserved)
- [x] Prettier green

## Pillar P2 Evoluzione

🟢ⁿ → 🟢ⁿ+ (canonical surface API LIVE per macro-loop Brigandine). Engine + content + API stack completo. Phase D UI (Godot v2 phone composer surface) deferred ~3h.

## Rollback plan (03A)

PR self-contained: 1 router edit + 1 test new. Revert merge commit ripristina stato post-#2252. Engine + loader rimangono intatti (zero cross-dependency runtime fuori del router).

🤖 Generated with [Claude Code](https://claude.com/claude-code)