### PR TITLE
feat(prisma): TKT-D2-C Godot v2 CampaignState cross-stack sync

### DIFF
--- a/apps/backend/prisma/migrations/0010_godot_v2_campaign_state_sync/migration.sql
+++ b/apps/backend/prisma/migrations/0010_godot_v2_campaign_state_sync/migration.sql
@@ -1,0 +1,49 @@
+-- 2026-05-13 TKT-D2-C Godot v2 CampaignState cross-stack sync.
+-- Master-dd verdict B+C 2026-05-12 (Wave 2026-05-12 #241 B-side shipped
+-- Godot v2 JSON local persistence; C-side mirror server-side persistence
+-- gated on master-dd workspace cleanup, executed 2026-05-13).
+--
+-- Mirrors Godot v2 `scripts/session/campaign_state.gd` Resource fields
+-- shipped in PR #241 (D2-B) + #226 (M15 promotion) + #227 (M14-B Conviction)
+-- + #228 (P2 Brigandine Seasonal). Provides server-side ground truth for
+-- cross-encounter persistence so multi-device + co-op sessions can hydrate
+-- consistent state across clients.
+--
+-- Schema mirror Godot Resource shape:
+--   Godot field           Postgres column          Type
+--   ----------------------------------------------------
+--   campaign_id           campaign_id              TEXT
+--   wounds_by_unit        wounds_by_unit           JSONB
+--   status_locks          status_locks             JSONB
+--   last_encounter_id     last_encounter_id        TEXT
+--   promotion_tiers       promotion_tiers          JSONB
+--   conviction_axes       conviction_axes          JSONB
+--   seasonal_state        seasonal_state           JSONB
+--
+-- JSONB columns chosen over normalized rows: write-through adapter pattern
+-- (Godot v2 saves full Resource per JSON file → backend persists snapshot
+-- atomically), low query volume (load once per encounter boot), shape
+-- evolves with Godot v2 Resource changes (additive @export fields
+-- backward-compat without schema migration churn).
+--
+-- Backward-compat: dedicated table (no ALTER on existing models). Existing
+-- Campaign / PartyRoster paths unchanged. Godot v2 client populates via
+-- new REST endpoints POST/GET /api/campaign/godot-v2/state (routes follow
+-- in this PR).
+
+CREATE TABLE "godot_v2_campaign_states" (
+    "id" TEXT NOT NULL,
+    "campaign_id" TEXT NOT NULL,
+    "wounds_by_unit" JSONB NOT NULL DEFAULT '{}',
+    "status_locks" JSONB NOT NULL DEFAULT '{}',
+    "last_encounter_id" TEXT NOT NULL DEFAULT '',
+    "promotion_tiers" JSONB NOT NULL DEFAULT '{}',
+    "conviction_axes" JSONB NOT NULL DEFAULT '{}',
+    "seasonal_state" JSONB NOT NULL DEFAULT '{}',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "godot_v2_campaign_states_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "godot_v2_campaign_states_campaign_id_key"
+    ON "godot_v2_campaign_states"("campaign_id");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -385,3 +385,25 @@ model MatingEvent {
   @@index([relationId, createdAt])
   @@map("mating_events")
 }
+
+// TKT-D2-C 2026-05-13 — Godot v2 CampaignState cross-stack sync.
+// Mirrors Godot Resource shape (scripts/session/campaign_state.gd):
+//   campaign_id + wounds_by_unit + status_locks + last_encounter_id
+//   + promotion_tiers (TKT-M15) + conviction_axes (TKT-M14-B)
+//   + seasonal_state (TKT-P2 Brigandine).
+// JSONB write-through adapter (Godot saves full Resource → backend
+// snapshot persists atomically). REST: GET/PUT /api/campaign/godot-v2/state.
+model GodotV2CampaignState {
+  id              String   @id @default(uuid())
+  campaignId      String   @unique @map("campaign_id")
+  woundsByUnit    Json     @default("{}") @map("wounds_by_unit")
+  statusLocks     Json     @default("{}") @map("status_locks")
+  lastEncounterId String   @default("") @map("last_encounter_id")
+  promotionTiers  Json     @default("{}") @map("promotion_tiers")
+  convictionAxes  Json     @default("{}") @map("conviction_axes")
+  seasonalState   Json     @default("{}") @map("seasonal_state")
+  createdAt       DateTime @default(now()) @map("created_at")
+  updatedAt       DateTime @updatedAt @map("updated_at")
+
+  @@map("godot_v2_campaign_states")
+}

--- a/apps/backend/routes/campaign.js
+++ b/apps/backend/routes/campaign.js
@@ -685,7 +685,7 @@ function createCampaignRouter(options = {}) {
   // on offline / 404. Schema mirror migration 0010.
   const godotV2State = require('../services/campaign/godotV2State');
 
-  router.get('/godot-v2/state', async (req, res) => {
+  router.get('/campaign/godot-v2/state', async (req, res) => {
     try {
       const campaignId = String(req.query.campaign_id || '').trim();
       if (!campaignId) {
@@ -701,7 +701,7 @@ function createCampaignRouter(options = {}) {
     }
   });
 
-  router.put('/godot-v2/state', async (req, res) => {
+  router.put('/campaign/godot-v2/state', async (req, res) => {
     try {
       const body = req.body || {};
       if (!String(body.campaign_id || '').trim()) {

--- a/apps/backend/routes/campaign.js
+++ b/apps/backend/routes/campaign.js
@@ -663,6 +663,57 @@ function createCampaignRouter(options = {}) {
     return res.json({ season, events, count: events.length });
   });
 
+  // TKT-D2-C 2026-05-13 — Godot v2 CampaignState cross-stack sync endpoints.
+  //
+  //   GET /api/campaign/godot-v2/state?campaign_id=<id>
+  //     → 200 { state: { campaign_id, wounds_by_unit, status_locks,
+  //              last_encounter_id, promotion_tiers, conviction_axes,
+  //              seasonal_state } }
+  //     → 404 when no row for campaign_id (caller falls back to baseline)
+  //
+  //   PUT /api/campaign/godot-v2/state
+  //     body: { campaign_id, wounds_by_unit?, status_locks?,
+  //             last_encounter_id?, promotion_tiers?, conviction_axes?,
+  //             seasonal_state? }
+  //     → 200 { state: <persisted row> } (upsert by campaign_id)
+  //     → 400 on missing campaign_id
+  //
+  // Write-through adapter: Godot v2 `scripts/session/campaign_state.gd`
+  // serializes Resource → JSON, client PUTs full snapshot, backend stores
+  // atomically. Read on encounter boot before local hydration when
+  // network reachable; falls back to user://campaigns/<id>/state.json
+  // on offline / 404. Schema mirror migration 0010.
+  const godotV2State = require('../services/campaign/godotV2State');
+
+  router.get('/godot-v2/state', async (req, res) => {
+    try {
+      const campaignId = String(req.query.campaign_id || '').trim();
+      if (!campaignId) {
+        return res.status(400).json({ error: 'campaign_id query param richiesto' });
+      }
+      const state = await godotV2State.getState(campaignId);
+      if (!state) {
+        return res.status(404).json({ error: 'not_found', campaign_id: campaignId });
+      }
+      return res.json({ state });
+    } catch (err) {
+      return res.status(500).json({ error: 'persist_read_failed', detail: String(err.message) });
+    }
+  });
+
+  router.put('/godot-v2/state', async (req, res) => {
+    try {
+      const body = req.body || {};
+      if (!String(body.campaign_id || '').trim()) {
+        return res.status(400).json({ error: 'campaign_id body field richiesto' });
+      }
+      const state = await godotV2State.upsertState(body);
+      return res.json({ state });
+    } catch (err) {
+      return res.status(500).json({ error: 'persist_write_failed', detail: String(err.message) });
+    }
+  });
+
   return router;
 }
 

--- a/apps/backend/services/campaign/godotV2State.js
+++ b/apps/backend/services/campaign/godotV2State.js
@@ -1,0 +1,83 @@
+// TKT-D2-C 2026-05-13 — Godot v2 CampaignState cross-stack service.
+//
+// Mirror Godot Resource shape (scripts/session/campaign_state.gd):
+//   campaign_id + wounds_by_unit + status_locks + last_encounter_id
+//   + promotion_tiers (TKT-M15) + conviction_axes (TKT-M14-B)
+//   + seasonal_state (TKT-P2 Brigandine).
+//
+// Write-through adapter: Godot client serializes full Resource → JSON
+// + PUTs snapshot, backend stores atomically via upsert by campaign_id.
+// Server is ground truth for multi-device + co-op sessions; client
+// falls back to user://campaigns/<id>/state.json on offline / 404.
+//
+// Injectable prisma client so tests stub without live DB.
+
+'use strict';
+
+let _defaultPrisma = null;
+
+function _resolvePrisma(injected) {
+  if (injected) return injected;
+  if (_defaultPrisma) return _defaultPrisma;
+  // Lazy require — keeps service test-injectable without forcing prisma
+  // engine boot when callers pass their own.
+  _defaultPrisma = require('../../db/prisma').prisma;
+  return _defaultPrisma;
+}
+
+// Returns null when no row exists (caller falls back to baseline).
+async function getState(campaignId, { prisma } = {}) {
+  if (!campaignId || typeof campaignId !== 'string') {
+    throw new Error('campaign_id required (non-empty string)');
+  }
+  const client = _resolvePrisma(prisma);
+  const row = await client.godotV2CampaignState.findUnique({ where: { campaignId } });
+  if (!row) return null;
+  return _rowToShape(row);
+}
+
+// Upsert by campaign_id. Returns persisted row in canonical shape.
+async function upsertState(payload, { prisma } = {}) {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('payload required (object)');
+  }
+  const campaignId = String(payload.campaign_id || '').trim();
+  if (!campaignId) {
+    throw new Error('campaign_id required (non-empty string)');
+  }
+  const data = {
+    woundsByUnit: payload.wounds_by_unit || {},
+    statusLocks: payload.status_locks || {},
+    lastEncounterId: String(payload.last_encounter_id || ''),
+    promotionTiers: payload.promotion_tiers || {},
+    convictionAxes: payload.conviction_axes || {},
+    seasonalState: payload.seasonal_state || {},
+  };
+  const client = _resolvePrisma(prisma);
+  const row = await client.godotV2CampaignState.upsert({
+    where: { campaignId },
+    update: data,
+    create: { campaignId, ...data },
+  });
+  return _rowToShape(row);
+}
+
+// Converts Prisma row → Godot Resource JSON shape (snake_case).
+function _rowToShape(row) {
+  return {
+    campaign_id: row.campaignId,
+    wounds_by_unit: row.woundsByUnit,
+    status_locks: row.statusLocks,
+    last_encounter_id: row.lastEncounterId,
+    promotion_tiers: row.promotionTiers,
+    conviction_axes: row.convictionAxes,
+    seasonal_state: row.seasonalState,
+    updated_at: row.updatedAt,
+  };
+}
+
+module.exports = {
+  getState,
+  upsertState,
+  _rowToShape, // exported for unit tests
+};

--- a/tests/api/godotV2State.test.js
+++ b/tests/api/godotV2State.test.js
@@ -39,10 +39,7 @@ test('getState returns null when no row exists', async () => {
 test('getState throws on empty campaign_id', async () => {
   const stub = makeStub();
   await assert.rejects(() => godotV2State.getState('', { prisma: stub }), /campaign_id required/);
-  await assert.rejects(
-    () => godotV2State.getState(null, { prisma: stub }),
-    /campaign_id required/,
-  );
+  await assert.rejects(() => godotV2State.getState(null, { prisma: stub }), /campaign_id required/);
 });
 
 test('upsertState stores defaults when fields absent', async () => {
@@ -101,10 +98,7 @@ test('upsertState rejects empty payload', async () => {
     () => godotV2State.upsertState({ campaign_id: '' }, { prisma: stub }),
     /campaign_id/,
   );
-  await assert.rejects(
-    () => godotV2State.upsertState(null, { prisma: stub }),
-    /payload required/,
-  );
+  await assert.rejects(() => godotV2State.upsertState(null, { prisma: stub }), /payload required/);
 });
 
 test('_rowToShape converts camelCase row to snake_case JSON', () => {

--- a/tests/api/godotV2State.test.js
+++ b/tests/api/godotV2State.test.js
@@ -1,0 +1,126 @@
+// TKT-D2-C 2026-05-13 — Godot v2 CampaignState cross-stack service tests.
+//
+// Validates getState + upsertState round-trip + canonical shape conversion +
+// validation edges (empty campaign_id rejection, default values fallback).
+// Prisma client stubbed (no live DB required).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const godotV2State = require('../../apps/backend/services/campaign/godotV2State');
+
+function makeStub(rows = new Map()) {
+  return {
+    rows,
+    godotV2CampaignState: {
+      async findUnique({ where }) {
+        return rows.get(where.campaignId) || null;
+      },
+      async upsert({ where, update, create }) {
+        const existing = rows.get(where.campaignId);
+        const merged = existing
+          ? { ...existing, ...update, updatedAt: new Date() }
+          : { id: 'uuid-stub', ...create, updatedAt: new Date(), createdAt: new Date() };
+        rows.set(where.campaignId, merged);
+        return merged;
+      },
+    },
+  };
+}
+
+test('getState returns null when no row exists', async () => {
+  const stub = makeStub();
+  const out = await godotV2State.getState('absent_campaign', { prisma: stub });
+  assert.equal(out, null);
+});
+
+test('getState throws on empty campaign_id', async () => {
+  const stub = makeStub();
+  await assert.rejects(() => godotV2State.getState('', { prisma: stub }), /campaign_id required/);
+  await assert.rejects(
+    () => godotV2State.getState(null, { prisma: stub }),
+    /campaign_id required/,
+  );
+});
+
+test('upsertState stores defaults when fields absent', async () => {
+  const stub = makeStub();
+  const out = await godotV2State.upsertState({ campaign_id: 'fresh' }, { prisma: stub });
+  assert.equal(out.campaign_id, 'fresh');
+  assert.deepEqual(out.wounds_by_unit, {});
+  assert.deepEqual(out.status_locks, {});
+  assert.equal(out.last_encounter_id, '');
+  assert.deepEqual(out.promotion_tiers, {});
+  assert.deepEqual(out.conviction_axes, {});
+  assert.deepEqual(out.seasonal_state, {});
+});
+
+test('upsertState persists full payload + round-trips via getState', async () => {
+  const stub = makeStub();
+  const payload = {
+    campaign_id: 'demo_001',
+    wounds_by_unit: { pg_skiv_alpha: [{ kind: 'arm', severity: 'minor' }] },
+    status_locks: { pg_pulverator: ['stunned'] },
+    last_encounter_id: 'enc_savana_03',
+    promotion_tiers: { pg_skiv_alpha: 'veteran' },
+    conviction_axes: { pg_skiv_alpha: { utility: 60, liberty: 55, morality: 50 } },
+    seasonal_state: { current_season: 'autumn', current_year: 2, current_phase: 'battle' },
+  };
+  const written = await godotV2State.upsertState(payload, { prisma: stub });
+  assert.equal(written.campaign_id, 'demo_001');
+  assert.equal(written.last_encounter_id, 'enc_savana_03');
+  assert.equal(written.promotion_tiers.pg_skiv_alpha, 'veteran');
+
+  const read = await godotV2State.getState('demo_001', { prisma: stub });
+  assert.ok(read);
+  assert.deepEqual(read.wounds_by_unit, payload.wounds_by_unit);
+  assert.deepEqual(read.conviction_axes, payload.conviction_axes);
+  assert.deepEqual(read.seasonal_state, payload.seasonal_state);
+});
+
+test('upsertState idempotent — second call overwrites', async () => {
+  const stub = makeStub();
+  await godotV2State.upsertState(
+    { campaign_id: 'cid', promotion_tiers: { pg_a: 'base' } },
+    { prisma: stub },
+  );
+  const out = await godotV2State.upsertState(
+    { campaign_id: 'cid', promotion_tiers: { pg_a: 'veteran' } },
+    { prisma: stub },
+  );
+  assert.equal(out.promotion_tiers.pg_a, 'veteran');
+  assert.equal(stub.rows.size, 1, 'Single row via upsert');
+});
+
+test('upsertState rejects empty payload', async () => {
+  const stub = makeStub();
+  await assert.rejects(() => godotV2State.upsertState({}, { prisma: stub }), /campaign_id/);
+  await assert.rejects(
+    () => godotV2State.upsertState({ campaign_id: '' }, { prisma: stub }),
+    /campaign_id/,
+  );
+  await assert.rejects(
+    () => godotV2State.upsertState(null, { prisma: stub }),
+    /payload required/,
+  );
+});
+
+test('_rowToShape converts camelCase row to snake_case JSON', () => {
+  const row = {
+    campaignId: 'X',
+    woundsByUnit: { u: 1 },
+    statusLocks: { u: ['s'] },
+    lastEncounterId: 'enc',
+    promotionTiers: { u: 'veteran' },
+    convictionAxes: { u: {} },
+    seasonalState: {},
+    updatedAt: new Date('2026-05-13T00:00:00Z'),
+  };
+  const shape = godotV2State._rowToShape(row);
+  assert.equal(shape.campaign_id, 'X');
+  assert.equal(shape.last_encounter_id, 'enc');
+  assert.equal(shape.promotion_tiers.u, 'veteran');
+  assert.ok(shape.updated_at instanceof Date);
+});


### PR DESCRIPTION
## Summary

Closes cross-stack D2-C gap from master-dd wave 2026-05-12 verdict B+C — Godot v2 already ships local JSON persistence (PR Godot-v2 #241), this PR adds **server-side mirror** via dedicated Postgres table + REST endpoints so multi-device + co-op sessions can hydrate a single source of truth.

### Why now (workspace gating resolved)

`Game/` workspace at session start: **detached HEAD + entire apps/backend/ deleted in working tree** (master-dd WIP investigation). This PR was authored in an **isolated worktree from `origin/main`** — master-dd's working tree untouched.

### Migration 0010 — godot_v2_campaign_states

Mirrors Godot Resource shape (`scripts/session/campaign_state.gd` lines 14-27):

| Godot field | Postgres column | Type | Source PR |
|---|---|---|---|
| `campaign_id` | `campaign_id` | TEXT UNIQUE | core |
| `wounds_by_unit` | `wounds_by_unit` | JSONB | TKT-N7 |
| `status_locks` | `status_locks` | JSONB | TKT-N7 |
| `last_encounter_id` | `last_encounter_id` | TEXT | TKT-N7 |
| `promotion_tiers` | `promotion_tiers` | JSONB | TKT-M15 (Godot #226) |
| `conviction_axes` | `conviction_axes` | JSONB | TKT-M14-B (Godot #227) |
| `seasonal_state` | `seasonal_state` | JSONB | TKT-P2 (Godot #228) |

JSONB chosen over normalized rows: write-through adapter pattern (Godot Resource → JSON → atomic PUT), low query volume (read once per encounter boot), additive `@export` field evolution backward-compat without schema churn.

### Prisma model — GodotV2CampaignState

Dedicated model + table, no ALTER on existing Campaign / PartyRoster (back-compat preserved).

### Service — `apps/backend/services/campaign/godotV2State.js`

Pure service with **injectable prisma client** (testable without live DB):
- `getState(campaign_id, { prisma? })` → snake_case Resource shape OR null
- `upsertState(payload, { prisma? })` → upsert by campaign_id, returns persisted shape
- `_rowToShape(row)` → camelCase→snake_case converter (exported for tests)

Validation: empty `campaign_id` throws; null payload throws; missing fields default to `{}` (loose schema for additive evolution).

### Routes — `apps/backend/routes/campaign.js`

| Endpoint | Status codes |
|---|---|
| `GET /api/campaign/godot-v2/state?campaign_id=<id>` | 200 `{ state }` / 404 not_found / 400 missing / 500 read_failed |
| `PUT /api/campaign/godot-v2/state` (body: full snapshot) | 200 `{ state }` / 400 missing campaign_id / 500 write_failed |

Both delegate to service for testability + reuse.

### Test plan

- [x] `node --test tests/api/godotV2State.test.js` — **7/7 pass, 56ms**
  - getState null on miss
  - getState rejects empty campaign_id
  - upsertState fills defaults for absent fields
  - upsertState full payload round-trips via getState
  - upsertState idempotent (second call overwrites, single row)
  - upsertState rejects empty payload
  - _rowToShape converts camelCase row → snake_case JSON
- [ ] CI `test:backend` green
- [ ] CI `lint:stack` green
- [ ] Prisma migration deploy clean (master-dd env)

### Cross-stack Godot v2 client follow-up (future PR)

`scripts/net/campaign_api.gd` already has scaffold; +20 LOC to `fetch_state` / `put_state` methods using same HTTPRequest pattern as `SeasonalService` (TKT-P2 Phase D shipped #248). MainCombatPanels + MainPromotion (Godot v2 #252) currently persist to `user://campaigns/default/state.json` only — adding HTTP put on save_to_json call would mirror full pipeline.

### Wave 2026-05-13 cross-stack summary

| Side | PR | Topic | State |
|---|---|---|:--:|
| Godot v2 | #250 | MainSeasonal helper LOC fix | merged |
| Godot v2 | #251 | E2 + MainPromotion + MainTelemetry helpers | merged |
| Godot v2 | #252 | E3 + E4 + F3 caller wires | open |
| Game/ | (this PR) | D2-C Prisma schema + service + routes | open |

Closes master-dd `pending_master_dd[D2-C]` checkpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)