### PR TITLE
feat(ai-station): Phase B3 — PromotionEngine job_archetype_bias + vc_scoring sentience fold

### DIFF
--- a/apps/backend/services/progression/promotionEngine.js
+++ b/apps/backend/services/progression/promotionEngine.js
@@ -223,7 +223,12 @@ function evaluatePromotion(unit, eventLog = [], config = null) {
     };
   }
   const threshold = cfg.thresholds?.[next] || null;
-  const reward = cfg.rewards?.[next] || null;
+  const baseReward = cfg.rewards?.[next] || null;
+  // 2026-05-14 Phase B3 — surface Job-biased reward in eligibility preview
+  // so UI (PromotionPanel) can render per-Job override stats (e.g.
+  // guerriero elite → hp:18 not hp:15 base). Base preserved when no
+  // override (graceful).
+  const reward = baseReward ? _mergeJobBias(baseReward, cfg, unit, next) : null;
   if (!threshold) {
     return {
       current_tier: cur,
@@ -281,10 +286,16 @@ function applyPromotion(unit, targetTier, config = null) {
       target_tier: targetTier,
     };
   }
-  const reward = cfg.rewards?.[targetTier];
-  if (!reward) {
+  const baseReward = cfg.rewards?.[targetTier];
+  if (!baseReward) {
     return { ok: false, error: 'no_reward_defined', target_tier: targetTier };
   }
+  // 2026-05-14 OD-025-B2 Phase B3 ai-station — job_archetype_bias engine
+  // consumption. promotions.yaml v0.2.0 schema anchor surfaces per-Job
+  // override blocks (guerriero/esploratore/tessitore/custode). Merge: base
+  // reward fields + Job override (override wins per-key). Unrecognized job_id
+  // → no override (graceful no-op = base reward applied).
+  const reward = _mergeJobBias(baseReward, cfg, unit, targetTier);
   const deltas = {};
   if (Number.isFinite(reward.hp_bonus)) {
     const before = Number(unit.hp || 0);
@@ -315,6 +326,14 @@ function applyPromotion(unit, targetTier, config = null) {
     unit.ability_tier_unlocked = reward.ability_unlock_tier;
     deltas.ability_unlock_tier = reward.ability_unlock_tier;
   }
+  // 2026-05-14 Phase B3 — ability_id_override (tessitore Job specialization).
+  // job_archetype_bias schema: tessitore elite → ability_id_override:
+  // weave_mastery / master → weave_apex. Engine reads optional field; non-
+  // tessitore units pass through gracefully (no override field present).
+  if (typeof reward.ability_id_override === 'string' && reward.ability_id_override) {
+    unit.ability_id_unlocked = reward.ability_id_override;
+    deltas.ability_id_override = reward.ability_id_override;
+  }
   unit.promotion_tier = targetTier;
   return {
     ok: true,
@@ -322,6 +341,33 @@ function applyPromotion(unit, targetTier, config = null) {
     previous_tier: cur,
     deltas,
   };
+}
+
+// 2026-05-14 OD-025-B2 Phase B3 ai-station — job_archetype_bias merge helper.
+// Reads cfg.job_archetype_bias[unit.job_id][targetTier] and shallow-merges
+// onto the base reward Dict. Override fields win per-key. Returns base
+// untouched when:
+//   - cfg.job_archetype_bias absent
+//   - unit.job_id absent / unrecognized
+//   - target_tier override block absent (e.g. veteran/captain not specified
+//     per Job — only elite/master in current schema)
+//
+// Mirror Godot v2 scripts/progression/promotion_engine.gd _merge_job_bias.
+function _mergeJobBias(baseReward, cfg, unit, targetTier) {
+  if (!cfg || typeof cfg.job_archetype_bias !== 'object' || cfg.job_archetype_bias === null) {
+    return baseReward;
+  }
+  const jobId = unit && typeof unit.job_id === 'string' ? unit.job_id : '';
+  if (!jobId) return baseReward;
+  const jobBlock = cfg.job_archetype_bias[jobId];
+  if (!jobBlock || typeof jobBlock !== 'object') return baseReward;
+  const tierOverride = jobBlock[targetTier];
+  if (!tierOverride || typeof tierOverride !== 'object') return baseReward;
+  // Shallow-merge: override fields win per-key. Preserves base fields not
+  // mentioned in override (e.g. esploratore elite override has only
+  // initiative_bonus + defense_mod_bonus; base hp_bonus/attack_mod_bonus/
+  // ability_unlock_tier propagate).
+  return { ...baseReward, ...tierOverride };
 }
 
 module.exports = {
@@ -333,4 +379,6 @@ module.exports = {
   currentTier,
   nextTier,
   FALLBACK_CONFIG,
+  // Phase B3 helper exported for cross-stack parity tests + Godot v2 mirror.
+  _mergeJobBias,
 };

--- a/apps/backend/services/vcScoring.js
+++ b/apps/backend/services/vcScoring.js
@@ -916,6 +916,12 @@ function buildVcSnapshot(session, config) {
   // TKT-M14-B Phase A: conviction axis aggregato additivo, vedi
   // services/convictionEngine.js. Range 0..100 per axis, baseline 50.
   const convictionByActor = evaluateConviction(events, units);
+  // 2026-05-14 OD-024 Phase B3 ai-station — sentience tier fold.
+  // Reads species_catalog.json (Game/ canonical post #2262) and resolves
+  // per-actor sentience_index (T0-T6). Adds 4th layer to 3-layer psicologico
+  // (MBTI 4-axis + Ennea 9-arch + Conviction 3-axis + Sentience tier).
+  // Cross-link: docs/governance/open-decisions/OD-024-031-verdict-record.md
+  const sentienceByActor = _resolveSentienceTiers(units, session);
   for (const [unitId, rawMetrics] of Object.entries(raw)) {
     const aggregate = computeAggregateIndices(rawMetrics, config);
     const mbti = axesFn(rawMetrics);
@@ -932,6 +938,11 @@ function buildVcSnapshot(session, config) {
         liberty: 50,
         morality: 50,
         events_classified: 0,
+      },
+      // 2026-05-14 OD-024 Phase B3 — sentience tier (4th psicologico layer).
+      sentience: sentienceByActor[unitId] || {
+        tier: 'T1',
+        source: 'default-fallback',
       },
     };
   }
@@ -974,6 +985,84 @@ function buildVcSnapshot(session, config) {
   };
 }
 
+// 2026-05-14 OD-024 Phase B3 ai-station — sentience tier resolver.
+// Reads species_catalog.json (Game/ data/core/species/) and maps each unit
+// to its sentience_index via species_id lookup. Cache catalog per call site
+// to avoid repeat disk reads.
+//
+// Resolution priority:
+//   1. session.species_catalog (in-memory caller injection) — preferred
+//   2. Load from data/core/species/species_catalog.json (canonical)
+//   3. Fallback: empty index → all units default to "T1" (RFC v0.1 baseline)
+//
+// Returns { <unit_id>: { tier: "T0"|...|"T6", source: <provenance> } }
+//
+// Mirror Godot v2 scripts/scoring/vc_scoring.gd _resolve_sentience_tiers.
+let _cachedSpeciesCatalog = null;
+let _cachedCatalogPath = null;
+const _DEFAULT_SPECIES_CATALOG_PATH = require('path').resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'data',
+  'core',
+  'species',
+  'species_catalog.json',
+);
+
+function _loadSpeciesCatalog(filePath = _DEFAULT_SPECIES_CATALOG_PATH) {
+  if (_cachedSpeciesCatalog !== null && _cachedCatalogPath === filePath) {
+    return _cachedSpeciesCatalog;
+  }
+  try {
+    const raw = require('fs').readFileSync(filePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    const index = {};
+    if (Array.isArray(parsed?.catalog)) {
+      for (const entry of parsed.catalog) {
+        if (entry?.species_id) {
+          index[entry.species_id] = entry;
+        }
+      }
+    }
+    _cachedSpeciesCatalog = index;
+    _cachedCatalogPath = filePath;
+    return index;
+  } catch {
+    _cachedSpeciesCatalog = {};
+    _cachedCatalogPath = filePath;
+    return {};
+  }
+}
+
+function _resetSpeciesCatalogCache() {
+  _cachedSpeciesCatalog = null;
+  _cachedCatalogPath = null;
+}
+
+function _resolveSentienceTiers(units, session) {
+  const out = {};
+  if (!Array.isArray(units) || units.length === 0) return out;
+  // Caller-injected catalog (e.g. tests) takes precedence over disk load.
+  const sessionCatalog =
+    session && session.species_catalog && typeof session.species_catalog === 'object'
+      ? session.species_catalog
+      : null;
+  const catalog = sessionCatalog || _loadSpeciesCatalog();
+  for (const u of units) {
+    if (!u || !u.id) continue;
+    const speciesId = u.species_id || u.species || '';
+    const entry = catalog[speciesId];
+    if (entry && typeof entry.sentience_index === 'string') {
+      out[u.id] = { tier: entry.sentience_index, source: 'species_catalog' };
+    } else {
+      out[u.id] = { tier: 'T1', source: 'default-fallback' };
+    }
+  }
+  return out;
+}
+
 module.exports = {
   loadTelemetryConfig,
   computeRawMetrics,
@@ -986,5 +1075,9 @@ module.exports = {
   tokenizeCondition,
   evaluateCondition,
   SCORING_VERSION,
+  // 2026-05-14 Phase B3 — sentience tier resolver exports for tests + tools.
+  _loadSpeciesCatalog,
+  _resetSpeciesCatalogCache,
+  _resolveSentienceTiers,
   DEFAULT_TELEMETRY_PATH,
 };

--- a/tests/api/phase-b3-promotion-job-bias.test.js
+++ b/tests/api/phase-b3-promotion-job-bias.test.js
@@ -1,0 +1,181 @@
+// OD-025-B2 Phase B3 ai-station 2026-05-14 — job_archetype_bias engine consumption.
+//
+// promotions.yaml v0.2.0 surface job_archetype_bias schema anchor for
+// per-Job tier overrides (guerriero/esploratore/tessitore/custode).
+// Phase B3: engine reads + merges override onto base reward (override wins).
+//
+// Closes Pillar P3 Identità Specie × Job depth — different Jobs now get
+// distinct rewards at elite/master tier.
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  applyPromotion,
+  evaluatePromotion,
+  _mergeJobBias,
+  FALLBACK_CONFIG,
+} = require('../../apps/backend/services/progression/promotionEngine');
+
+// Synthetic config matching promotions.yaml v0.2.0 job_archetype_bias schema.
+const CFG_WITH_BIAS = {
+  ...FALLBACK_CONFIG,
+  job_archetype_bias: {
+    guerriero: {
+      elite: { hp_bonus: 18, attack_mod_bonus: 4 },
+      master: { hp_bonus: 30, attack_mod_bonus: 5 },
+    },
+    esploratore: {
+      elite: { initiative_bonus: 5, defense_mod_bonus: 1 },
+      master: { initiative_bonus: 6, crit_chance_bonus: 8 },
+    },
+    tessitore: {
+      elite: { ability_unlock_tier: 'r4', ability_id_override: 'weave_mastery' },
+      master: { ability_unlock_tier: 'r5', ability_id_override: 'weave_apex' },
+    },
+    custode: {
+      elite: { hp_bonus: 20, defense_mod_bonus: 4 },
+      master: { hp_bonus: 35, defense_mod_bonus: 5 },
+    },
+  },
+};
+
+function _unit(jobId, promotion_tier = 'captain') {
+  return {
+    id: `pg-${jobId}`,
+    job_id: jobId,
+    promotion_tier,
+    hp: 20,
+    max_hp: 20,
+    attack_mod: 0,
+    defense_mod: 0,
+    initiative: 0,
+    crit_chance: 0,
+  };
+}
+
+describe('Phase B3 — _mergeJobBias helper', () => {
+  test('returns base reward when cfg has no job_archetype_bias', () => {
+    const base = { hp_bonus: 15, attack_mod_bonus: 3 };
+    const cfg = { rewards: {} };
+    assert.deepEqual(_mergeJobBias(base, cfg, { job_id: 'guerriero' }, 'elite'), base);
+  });
+
+  test('returns base when unit has no job_id', () => {
+    const base = { hp_bonus: 15 };
+    assert.deepEqual(_mergeJobBias(base, CFG_WITH_BIAS, {}, 'elite'), base);
+  });
+
+  test('returns base when job_id unrecognized', () => {
+    const base = { hp_bonus: 15 };
+    assert.deepEqual(_mergeJobBias(base, CFG_WITH_BIAS, { job_id: 'demigod' }, 'elite'), base);
+  });
+
+  test('merges override on top of base (override wins per-key)', () => {
+    const base = {
+      hp_bonus: 15,
+      attack_mod_bonus: 3,
+      defense_mod_bonus: 2,
+      ability_unlock_tier: 'r4',
+    };
+    const merged = _mergeJobBias(base, CFG_WITH_BIAS, { job_id: 'guerriero' }, 'elite');
+    assert.equal(merged.hp_bonus, 18, 'guerriero hp override +3');
+    assert.equal(merged.attack_mod_bonus, 4, 'guerriero atk override +1');
+    assert.equal(merged.defense_mod_bonus, 2, 'base preserved when not overridden');
+    assert.equal(merged.ability_unlock_tier, 'r4', 'base preserved when not overridden');
+  });
+
+  test('tier without override returns base (e.g. veteran/captain not in bias)', () => {
+    const base = { hp_bonus: 10 };
+    assert.deepEqual(_mergeJobBias(base, CFG_WITH_BIAS, { job_id: 'guerriero' }, 'captain'), base);
+  });
+});
+
+describe('Phase B3 — applyPromotion consumes job_archetype_bias', () => {
+  test('guerriero elite: hp_bonus=18 (override), atk=4', () => {
+    const u = _unit('guerriero');
+    const r = applyPromotion(u, 'elite', CFG_WITH_BIAS);
+    assert.equal(r.ok, true);
+    assert.equal(u.max_hp, 20 + 18, 'guerriero hp:18 override applied');
+    assert.equal(u.attack_mod, 4, 'guerriero atk:4 override');
+    assert.equal(u.defense_mod, 2, 'base defense_mod_bonus preserved');
+  });
+
+  test('esploratore elite: initiative=5 (override) + defense=1 (override)', () => {
+    const u = _unit('esploratore');
+    const r = applyPromotion(u, 'elite', CFG_WITH_BIAS);
+    assert.equal(r.ok, true);
+    assert.equal(u.initiative, 5, 'esploratore init:5 override');
+    assert.equal(u.defense_mod, 1, 'esploratore def:1 override (-1 from base)');
+    assert.equal(u.max_hp, 20 + 15, 'base hp_bonus preserved');
+  });
+
+  test('tessitore elite: ability_id_override applied', () => {
+    const u = _unit('tessitore');
+    const r = applyPromotion(u, 'elite', CFG_WITH_BIAS);
+    assert.equal(r.ok, true);
+    assert.equal(u.ability_id_unlocked, 'weave_mastery', 'ability_id_override propagated');
+    assert.equal(u.ability_tier_unlocked, 'r4');
+    assert.equal(r.deltas.ability_id_override, 'weave_mastery');
+  });
+
+  test('custode elite: hp:20 + def:4 (override stack)', () => {
+    const u = _unit('custode');
+    const r = applyPromotion(u, 'elite', CFG_WITH_BIAS);
+    assert.equal(r.ok, true);
+    assert.equal(u.max_hp, 20 + 20);
+    assert.equal(u.defense_mod, 4);
+  });
+
+  test('guerriero master: hp:30 + atk:5 (override) + crit:5 (base preserved)', () => {
+    const u = _unit('guerriero', 'elite');
+    const r = applyPromotion(u, 'master', CFG_WITH_BIAS);
+    assert.equal(r.ok, true);
+    assert.equal(u.max_hp, 20 + 30);
+    assert.equal(u.attack_mod, 5);
+    assert.equal(u.crit_chance, 5, 'base crit_chance_bonus preserved');
+  });
+
+  test('esploratore master: crit:8 override', () => {
+    const u = _unit('esploratore', 'elite');
+    const r = applyPromotion(u, 'master', CFG_WITH_BIAS);
+    assert.equal(r.ok, true);
+    assert.equal(u.crit_chance, 8, 'esploratore crit:8 override (+3 over base)');
+    assert.equal(u.initiative, 6, 'esploratore init:6 override');
+  });
+
+  test('unknown job_id (mascalzone) gets base reward (graceful)', () => {
+    const u = _unit('mascalzone');
+    const r = applyPromotion(u, 'elite', CFG_WITH_BIAS);
+    assert.equal(r.ok, true);
+    assert.equal(u.max_hp, 20 + 15, 'base hp_bonus (no override)');
+    assert.equal(u.attack_mod, 3, 'base atk_bonus');
+  });
+});
+
+describe('Phase B3 — evaluatePromotion surfaces Job-biased reward preview', () => {
+  test('guerriero next_tier=elite preview shows override reward', () => {
+    const u = _unit('guerriero');
+    const events = [];
+    // No metrics → not eligible, but reward preview still surfaced.
+    const r = evaluatePromotion(u, events, CFG_WITH_BIAS);
+    assert.equal(r.next_tier, 'elite');
+    assert.equal(r.reward.hp_bonus, 18, 'guerriero override surfaced in preview');
+    assert.equal(r.reward.attack_mod_bonus, 4);
+  });
+
+  test('unknown job preview shows base reward', () => {
+    const u = _unit('mascalzone');
+    const r = evaluatePromotion(u, [], CFG_WITH_BIAS);
+    assert.equal(r.reward.hp_bonus, 15, 'base hp_bonus');
+  });
+
+  test('null reward when no rewards block defined', () => {
+    const cfg = { tier_ladder: ['base', 'veteran'], thresholds: { veteran: {} }, rewards: {} };
+    const u = _unit('guerriero', 'base');
+    const r = evaluatePromotion(u, [], cfg);
+    assert.equal(r.reward, null);
+  });
+});

--- a/tests/api/phase-b3-sentience-fold.test.js
+++ b/tests/api/phase-b3-sentience-fold.test.js
@@ -1,0 +1,158 @@
+// OD-024 Phase B3 ai-station 2026-05-14 — sentience tier fold in vc_scoring.
+//
+// vc_scoring.buildVcSnapshot per_actor[uid] now includes sentience.tier
+// (T0-T6) resolved via SpeciesCatalog (Game/ data/core/species/species_catalog.json).
+// 4-layer psicologico completo: MBTI + Ennea + Conviction + Sentience.
+//
+// Closes Pillar P4 Temperamenti depth — sentience surface fully wired.
+
+'use strict';
+
+const { test, describe, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildVcSnapshot,
+  _resolveSentienceTiers,
+  _resetSpeciesCatalogCache,
+} = require('../../apps/backend/services/vcScoring');
+
+const SAMPLE_CATALOG = {
+  elastovaranus_hydrus: {
+    species_id: 'elastovaranus_hydrus',
+    sentience_index: 'T1',
+    source: 'pack-v2-full-plus',
+  },
+  perfusuas_pedes: {
+    species_id: 'perfusuas_pedes',
+    sentience_index: 'T3',
+    source: 'pack-v2-full-plus',
+  },
+  proteus_plasma: {
+    species_id: 'proteus_plasma',
+    sentience_index: 'T0',
+    source: 'pack-v2-full-plus',
+  },
+};
+
+beforeEach(() => {
+  _resetSpeciesCatalogCache();
+});
+
+describe('Phase B3 — _resolveSentienceTiers helper', () => {
+  test('maps species_id → sentience_index from injected session catalog', () => {
+    const units = [
+      { id: 'u1', species_id: 'elastovaranus_hydrus' },
+      { id: 'u2', species_id: 'perfusuas_pedes' },
+      { id: 'u3', species_id: 'proteus_plasma' },
+    ];
+    const result = _resolveSentienceTiers(units, { species_catalog: SAMPLE_CATALOG });
+    assert.equal(result.u1.tier, 'T1');
+    assert.equal(result.u1.source, 'species_catalog');
+    assert.equal(result.u2.tier, 'T3');
+    assert.equal(result.u3.tier, 'T0');
+  });
+
+  test('unit with unknown species → T1 default fallback', () => {
+    const units = [{ id: 'u1', species_id: 'unknown_creature' }];
+    const result = _resolveSentienceTiers(units, { species_catalog: SAMPLE_CATALOG });
+    assert.equal(result.u1.tier, 'T1');
+    assert.equal(result.u1.source, 'default-fallback');
+  });
+
+  test('unit without species_id → T1 default fallback', () => {
+    const units = [{ id: 'u1' }];
+    const result = _resolveSentienceTiers(units, { species_catalog: SAMPLE_CATALOG });
+    assert.equal(result.u1.tier, 'T1');
+    assert.equal(result.u1.source, 'default-fallback');
+  });
+
+  test('unit.species (legacy field) also accepted', () => {
+    const units = [{ id: 'u1', species: 'perfusuas_pedes' }];
+    const result = _resolveSentienceTiers(units, { species_catalog: SAMPLE_CATALOG });
+    assert.equal(result.u1.tier, 'T3', 'legacy "species" field supported');
+  });
+
+  test('empty units array → empty result', () => {
+    assert.deepEqual(_resolveSentienceTiers([], { species_catalog: SAMPLE_CATALOG }), {});
+  });
+
+  test('null units → empty result', () => {
+    assert.deepEqual(_resolveSentienceTiers(null, {}), {});
+  });
+
+  test('falls back to disk-loaded catalog when no session injection', () => {
+    // Without species_catalog in session, loads from data/core/species/.
+    const units = [{ id: 'u1', species_id: 'elastovaranus_hydrus' }];
+    const result = _resolveSentienceTiers(units, {});
+    // Canonical Game/ catalog has elastovaranus_hydrus → T1 per merged JSON.
+    assert.equal(result.u1.tier, 'T1');
+    assert.equal(result.u1.source, 'species_catalog');
+  });
+});
+
+describe('Phase B3 — buildVcSnapshot surfaces sentience per actor', () => {
+  test('per_actor[uid].sentience populated for all units', () => {
+    const session = {
+      events: [],
+      units: [
+        { id: 'u1', species_id: 'elastovaranus_hydrus' },
+        { id: 'u2', species_id: 'perfusuas_pedes' },
+      ],
+      grid: { width: 6 },
+      species_catalog: SAMPLE_CATALOG,
+    };
+    const snap = buildVcSnapshot(session, {
+      indices: {},
+      mbti_axes: {},
+      ennea_themes: [],
+      normalization: {},
+    });
+    assert.ok(snap.per_actor.u1);
+    assert.ok(snap.per_actor.u1.sentience, 'sentience field present');
+    assert.equal(snap.per_actor.u1.sentience.tier, 'T1');
+    assert.equal(snap.per_actor.u2.sentience.tier, 'T3');
+  });
+
+  test('per_actor preserves all 4 psicologico layers', () => {
+    const session = {
+      events: [],
+      units: [{ id: 'u1', species_id: 'elastovaranus_hydrus' }],
+      grid: { width: 6 },
+      species_catalog: SAMPLE_CATALOG,
+    };
+    const snap = buildVcSnapshot(session, {
+      indices: {},
+      mbti_axes: {},
+      ennea_themes: [],
+      normalization: {},
+    });
+    const actor = snap.per_actor.u1;
+    // 4 layers psicologico
+    assert.ok(actor.mbti_axes, 'MBTI layer');
+    assert.ok(actor.ennea_archetypes, 'Ennea layer');
+    assert.ok(actor.conviction_axis, 'Conviction layer (D2-A)');
+    assert.ok(actor.sentience, 'Sentience layer (Phase B3 NEW)');
+  });
+
+  test('sentience layer additive — backward-compat existing consumers', () => {
+    // Snapshot still contains all old surface; sentience is purely additive.
+    const session = {
+      events: [],
+      units: [{ id: 'u1', species_id: 'elastovaranus_hydrus' }],
+      grid: { width: 6 },
+      species_catalog: SAMPLE_CATALOG,
+    };
+    const snap = buildVcSnapshot(session, {
+      indices: {},
+      mbti_axes: {},
+      ennea_themes: [],
+      normalization: {},
+    });
+    const actor = snap.per_actor.u1;
+    assert.ok(actor.raw_metrics);
+    assert.ok(actor.aggregate_indices);
+    assert.ok(actor.mbti_type);
+    assert.equal(actor.conviction_axis.utility, 50, 'conviction baseline preserved');
+  });
+});


### PR DESCRIPTION
## Context

ai-station Phase B3 priorità 4 (Phase B engine extensions). Closes 2 schema anchors landed Envelope B (PR #2262) but not yet consumed:

1. **OD-025-B2** — `promotions.yaml` job_archetype_bias schema (guerriero/esploratore/tessitore/custode × elite/master) ship without engine wire
2. **OD-024** — sentience_index field on species_catalog.json but vc_scoring not folding into psicologico snapshot

## Changes

### OD-025-B2 — PromotionEngine job_archetype_bias engine consumption

- `_mergeJobBias(baseReward, cfg, unit, targetTier)` helper (exported)
- `applyPromotion`: cfg.rewards[tier] → _mergeJobBias → _apply_reward (override wins per-key)
- `evaluatePromotion`: surface job-biased reward in eligibility preview (UI per-Job stats)
- `ability_id_override` propagation (tessitore weave_mastery / weave_apex)
- Graceful fallback: missing job_id / unrecognized / no override block → base

Example: guerriero elite → hp:18 (NOT base 15), atk:4 (NOT base 3), defense:2 base preserved.

### OD-024 — vc_scoring sentience tier fold (4-layer psicologico)

- `_resolveSentienceTiers(units, session)` helper (exported)
- `_loadSpeciesCatalog()` with cache + reset for tests
- `buildVcSnapshot`: per_actor.sentience = {tier, source}
  - source = "species_catalog" (resolved via lookup)
  - source = "default-fallback" (unit without species_id OR unknown)
- Resolution priority: session.species_catalog injection > on-disk JSON > default fallback

**4-layer profilo psicologico LIVE**: MBTI + Ennea + Conviction (D2-A) + Sentience (NEW).

## Tests

- `tests/api/phase-b3-promotion-job-bias.test.js` — 15 tests (helper unit + per-Job override + preview)
- `tests/api/phase-b3-sentience-fold.test.js` — 10 tests (resolver + snapshot integration + 4-layer verify)

**Aggregate Phase B3 + regression: 115/119 pass** (4 skip cross-stack diff sibling absent). Existing tests/ai/promotionEngine + tests/services/vcScoring: 0 break.

## Pillar status delta

| # | Pre | Post | Note |
|---|:--:|:--:|---|
| P3 Identità | 🟢-cand | 🟢-cand | job_archetype_bias LIVE → distinct Job depth |
| P4 Temperamenti | 🟢-cand | 🟢-cand | 4-layer psicologico LIVE end-to-end |

## Cross-stack TODO

Godot v2 mirror PR forthcoming (`scripts/progression/promotion_engine.gd` `_merge_job_bias` + `scripts/ai/vc_scoring.gd` `_resolve_sentience_tiers`).

## Cross-link

- Envelope B: PR #2262 (schema anchor shipped)
- Drift fix: PR #2263 (FALLBACK_CONFIG cross-stack parity)
- Vault ai-station re-analisi: #5
- PR #2260 audit source: comment-4451712640