### PR TITLE
feat(ai-station): Playtest #2 analyzer + cross-stack snapshot fixture (test infra)

### DIFF
--- a/docs/playtest/2026-05-14-playtest-2-plan.md
+++ b/docs/playtest/2026-05-14-playtest-2-plan.md
@@ -1,0 +1,118 @@
+---
+title: Playtest #2 execution plan — ai-station verdict validation
+doc_status: draft
+doc_owner: master-dd
+workstream: ai-station-playtest
+last_verified: 2026-05-14
+language: it
+---
+
+# Playtest #2 plan — ai-station verdict validation
+
+Userland validation gate per 🟢-cand → 🟢 hard promotion P3+P4+P6.
+Telemetry analyzer infrastructure ready ahead-of-time:
+`tools/py/playtest_2_analyzer.py` + report template auto-generato.
+
+## Obiettivi
+
+1. **P3 Identità** — verifica job_archetype_bias preferences emergono
+   in player behavior (guerriero/esploratore/tessitore/custode pick
+   distinctly at elite/master tier).
+2. **P4 Temperamenti** — verifica 4-layer psicologico (MBTI + Ennea +
+   Conviction + Sentience) clusterizza in modo non-uniforme (player
+   identity emergent).
+3. **P6 Fairness** — rewind frequency + pressure tier balance OK
+   (no abuse + sufficient challenge).
+4. **OD-024 interoception traits** — firing rate ≥10% of attacks (proof
+   sensoriale tier T1 surface visible in combat).
+5. **OD-026 Skiv pulse atlas** — usage frequency ≥1× per session avg.
+6. **Performance M.7** — command latency p95 < 100ms PASS gate.
+
+## Sample size target
+
+- **🟢 hard verdict**: **30 sessions** minimum
+- **🟡 partial**: 5-29 sessions (ship pillars qualifying, repeat for gap)
+- **🔴 insufficient**: <5 (defer promotion, replan)
+
+## Setup
+
+### Pre-playtest checklist
+
+- [ ] Cloudflare prod deploy LIVE (Prisma migration 0010 auto-runs)
+- [ ] Telemetry capture wire LIVE (verify command_latency_ms + vc_snapshot + trait_effects + skiv_pulse_fired events flowing to JSONL)
+- [ ] Telemetry endpoint reachable: `/api/telemetry/log` (or local JSONL)
+- [ ] Playwright agent ready (PR #246 C1 scaffold) for automated paths
+- [ ] Test recruiter list ≥30 (mix MBTI + experience levels)
+
+### Test session structure
+
+Per session (~20-30 min):
+
+1. Form pulse (5 axes character creation)
+2. World setup + Custode reveal
+3. Combat encounter (8x6 grid, 3-5 rounds)
+4. Debrief (4-layer psicologico reveal)
+5. Promotion decision (elite/master if eligible)
+6. Optional: Atlas pulse exploration
+
+### Telemetry events captured
+
+| Event type                         | Captures                           |
+| ---------------------------------- | ---------------------------------- |
+| `attack`                           | command_latency_ms + trait_effects |
+| `promotion` / `promotion_accepted` | job_id + applied_tier              |
+| `vc_snapshot`                      | per_actor 4-layer psicologico      |
+| `rewind`                           | rewind usage                       |
+| `skiv_pulse_fired`                 | OD-026 atlas reveal events         |
+| `biome_focus_changed`              | atlas neighbor click events        |
+
+## Execution
+
+```bash
+# 1. Stream telemetry to JSONL (per session)
+node apps/backend/scripts/telemetry-capture.js > playtest-2-session-N.jsonl
+
+# 2. Aggregate all sessions
+cat playtest-2-session-*.jsonl > playtest-2-all-sessions.jsonl
+
+# 3. Run analyzer
+python tools/py/playtest_2_analyzer.py \
+    --telemetry playtest-2-all-sessions.jsonl \
+    --output docs/playtest/$(date +%Y-%m-%d)-playtest-2-report.md \
+    --min-sample 30
+
+# 4. Review markdown report → master-dd verdict
+```
+
+## Report sections
+
+Auto-generato analyzer:
+
+1. **Executive summary** — sample size + 🟢/🟡/🔴 per pillar
+2. **P3 promotion uptake** — tier distribution + Job × Tier breakdown
+3. **P4 4-layer psicologico** — MBTI + Ennea + Conviction + Sentience
+4. **P6 fairness** — pressure tier + rewind frequency
+5. **OD-024 interoception** — 4 trait firing rates
+6. **OD-026 atlas** — pulse events + biome reveals
+7. **Performance** — p50/p95 latency vs M.7 gate
+8. **Verdict + next action** — 3/3 / 2/3 / 1/3 / 0/3 pillars hard verified
+
+## Decision matrix
+
+| Verdict               | Action                                                         |
+| --------------------- | -------------------------------------------------------------- |
+| 🟢 3/3 hard           | Promote P3+P4+P6 🟢-cand → 🟢 hard. Update pillar-status.md.   |
+| 🟡 2/3 partial        | Promote qualifying pillars. Repeat playtest #3 for gap pillar. |
+| 🟡 1/3 partial        | Single pillar promotion + cause analysis for non-qualifying.   |
+| 🔴 0/3 / undersampled | Broader recruitment + Playtest #2bis.                          |
+
+## Cross-link
+
+- Analyzer: `tools/py/playtest_2_analyzer.py`
+- Tests: `tools/py/test_playtest_2_analyzer.py` (19 unit tests)
+- Synthetic fixture: `tests/fixtures/playtest-2-synthetic-telemetry.jsonl`
+- ai-station re-analisi: `vault docs/decisions/OD-024-031-aistation-reanalysis-2026-05-14.md`
+- Phase B3: PR #2264 (Game/) + #261 (Godot v2)
+- Envelope A+B+C: PRs #2261/#2262/#259/#260
+- Skiv pulse wire: PR #262
+- D2-C Prisma: PR #2259 (Cloudflare prod deploy auto-deploys migration 0010)

--- a/tests/api/promotion-fallback-cross-stack-parity.test.js
+++ b/tests/api/promotion-fallback-cross-stack-parity.test.js
@@ -26,10 +26,34 @@ const path = require('node:path');
 const { FALLBACK_CONFIG } = require('../../apps/backend/services/progression/promotionEngine');
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
-// Sibling Godot v2 repo — mirror bundled JSON (matches PR #259 v0.2.0).
-// Tries multiple paths (direct sibling + Desktop layout) to handle both
-// canonical clone layout AND worktree-checkout layout.
+// 2026-05-14 ai-station drift-fix follow-up — Godot v2 promotions.json
+// snapshot fixture lives inside Game/ tests/fixtures/. Eliminates the
+// previous skip-when-sibling-absent pattern (4 skipped tests in CI single-
+// repo clone) and makes cross-stack parity a hard CI gate.
+//
+// Fixture update flow:
+//   When Godot v2 ships a promotions.json bump, copy the canonical mirror
+//   from sibling repo:
+//     cp <godot-v2>/data/progression/promotions.json \
+//        tests/fixtures/godot-v2-promotions-v<version>.json
+//   Then update GODOT_V2_FIXTURE_PATH below and bump the assertion expecting
+//   the new version. CI fires test on any drift.
+//
+// Resolution priority:
+//   1. GODOT_V2_REPO env var (CI matrix builds with sibling checkout)
+//   2. Sibling Game-Godot-v2 repo on local Desktop layout
+//   3. Bundled fixture (canonical, always present)
+const GODOT_V2_FIXTURE_PATH = path.resolve(
+  __dirname,
+  '..',
+  'fixtures',
+  'godot-v2-promotions-v0.2.0.json',
+);
 const GODOT_V2_PATH_CANDIDATES = [
+  // Env override (CI matrix with sibling checkout) — wins so live drift
+  // surfaces immediately during dev rather than masked by stale fixture.
+  process.env.GODOT_V2_REPO &&
+    path.resolve(process.env.GODOT_V2_REPO, 'data', 'progression', 'promotions.json'),
   path.resolve(REPO_ROOT, '..', 'Game-Godot-v2', 'data', 'progression', 'promotions.json'),
   // Worktree layout: /Game/.claude/worktrees/<name> → ../../../Game-Godot-v2/
   path.resolve(
@@ -43,9 +67,8 @@ const GODOT_V2_PATH_CANDIDATES = [
     'progression',
     'promotions.json',
   ),
-  // Env override for CI matrix builds with custom repo layout.
-  process.env.GODOT_V2_REPO &&
-    path.resolve(process.env.GODOT_V2_REPO, 'data', 'progression', 'promotions.json'),
+  // Final fallback: bundled fixture. ALWAYS present → tests never skip.
+  GODOT_V2_FIXTURE_PATH,
 ].filter(Boolean);
 
 function findGodotV2Json() {

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,62 @@
+---
+title: Cross-stack test fixtures
+doc_status: draft
+doc_owner: claude-code
+workstream: ai-station-test-infra
+last_verified: 2026-05-14
+language: it
+---
+
+# Cross-stack test fixtures
+
+Snapshot di file Godot v2 canonici embedded in Game/ tests/ per evitare
+skip-when-sibling-absent in CI single-repo clones.
+
+## Inventory
+
+| Fixture                           | Mirror of                                        | Last sync  |
+| --------------------------------- | ------------------------------------------------ | ---------- |
+| `godot-v2-promotions-v0.2.0.json` | `Game-Godot-v2:data/progression/promotions.json` | 2026-05-14 |
+
+## Update flow (drift detection)
+
+Quando Godot v2 ships a bump (es. v0.2.0 → v0.3.0):
+
+```bash
+# 1. Pull Godot v2 main
+cd ../Game-Godot-v2 && git pull origin main
+
+# 2. Copy canonical mirror
+cp data/progression/promotions.json \
+   ../Game/tests/fixtures/godot-v2-promotions-v<version>.json
+
+# 3. Update GODOT_V2_FIXTURE_PATH in test file
+# tests/api/promotion-fallback-cross-stack-parity.test.js → bump filename
+
+# 4. Bump version assertion + run tests
+node --test tests/api/promotion-fallback-cross-stack-parity.test.js
+```
+
+## Resolution priority
+
+Cross-stack tests resolve Godot v2 JSON via candidates ordered:
+
+1. **`GODOT_V2_REPO` env var** — CI matrix builds con sibling checkout (live drift surface)
+2. **Sibling repo on Desktop layout** — local dev with both repos checked out
+3. **Bundled fixture** — final fallback, ALWAYS present → tests never skip
+
+## Why bundled fixture wins
+
+Pre-fixture (2026-05-14): single-repo CI clone skipped 4 cross-stack tests
+(no sibling Game-Godot-v2/ → tests gracefully skip). Drift could land
+unnoticed when local dev had sibling out-of-date.
+
+Post-fixture: fixture = canonical snapshot Godot v2 mainline. CI matches
+Game/ FALLBACK_CONFIG against this snapshot byte-shape. Any drift either
+side fires test. Update flow manual but auditable.
+
+## Cross-link
+
+- `tests/api/promotion-fallback-cross-stack-parity.test.js`
+- ai-station re-analisi: `vault docs/decisions/OD-024-031-aistation-reanalysis-2026-05-14.md`
+- Cross-stack drift original fix: PR #2263

--- a/tests/fixtures/godot-v2-promotions-v0.2.0.json
+++ b/tests/fixtures/godot-v2-promotions-v0.2.0.json
@@ -1,0 +1,72 @@
+{
+  "version": "0.2.0",
+  "_source_yaml": "Game/data/core/promotions/promotions.yaml (TKT-M15 + OD-025-B2 ai-station 2026-05-14)",
+  "tier_ladder": ["base", "veteran", "captain", "elite", "master"],
+  "thresholds": {
+    "veteran": {
+      "kills_min": 3,
+      "objectives_min": 1
+    },
+    "captain": {
+      "kills_min": 8,
+      "objectives_min": 3,
+      "assists_min": 2
+    },
+    "elite": {
+      "kills_min": 18,
+      "objectives_min": 6,
+      "assists_min": 6
+    },
+    "master": {
+      "kills_min": 35,
+      "objectives_min": 12,
+      "assists_min": 12
+    }
+  },
+  "rewards": {
+    "veteran": {
+      "hp_bonus": 5,
+      "attack_mod_bonus": 1,
+      "ability_unlock_tier": "r2"
+    },
+    "captain": {
+      "hp_bonus": 10,
+      "attack_mod_bonus": 2,
+      "initiative_bonus": 2,
+      "ability_unlock_tier": "r3"
+    },
+    "elite": {
+      "hp_bonus": 15,
+      "attack_mod_bonus": 3,
+      "defense_mod_bonus": 2,
+      "initiative_bonus": 3,
+      "ability_unlock_tier": "r4"
+    },
+    "master": {
+      "hp_bonus": 25,
+      "attack_mod_bonus": 4,
+      "defense_mod_bonus": 3,
+      "initiative_bonus": 4,
+      "crit_chance_bonus": 5,
+      "ability_unlock_tier": "r5"
+    }
+  },
+  "job_archetype_bias": {
+    "guerriero": {
+      "elite": { "hp_bonus": 18, "attack_mod_bonus": 4 },
+      "master": { "hp_bonus": 30, "attack_mod_bonus": 5 }
+    },
+    "esploratore": {
+      "elite": { "initiative_bonus": 5, "defense_mod_bonus": 1 },
+      "master": { "initiative_bonus": 6, "crit_chance_bonus": 8 }
+    },
+    "tessitore": {
+      "elite": { "ability_unlock_tier": "r4", "ability_id_override": "weave_mastery" },
+      "master": { "ability_unlock_tier": "r5", "ability_id_override": "weave_apex" }
+    },
+    "custode": {
+      "elite": { "hp_bonus": 20, "defense_mod_bonus": 4 },
+      "master": { "hp_bonus": 35, "defense_mod_bonus": 5 }
+    }
+  }
+}

--- a/tests/fixtures/playtest-2-synthetic-telemetry.jsonl
+++ b/tests/fixtures/playtest-2-synthetic-telemetry.jsonl
@@ -1,0 +1,35 @@
+# Synthetic playtest #2 telemetry fixture for tools/py/playtest_2_analyzer.py.
+# 6 sessions × ~10 events each = covers ai-station verdict surfaces:
+#   - P3 Identità (promotions tier/job mix)
+#   - P4 Temperamenti (4-layer psicologico per_actor snapshot)
+#   - P6 Fairness (pressure tier + rewind)
+#   - OD-024 (interoception trait firings)
+#   - OD-026 (Skiv pulse + biome_focus events)
+#   - Performance (command_latency_ms)
+# Lines starting with `#` are comments (analyzer skips).
+{"session_id": "s1", "action_type": "attack", "actor_id": "pg1", "command_latency_ms": 45, "trait_effects": [{"trait": "propriocezione", "triggered": true, "effect": "proprioception_balance"}], "pressure_tier": 2}
+{"session_id": "s1", "action_type": "attack", "actor_id": "pg1", "command_latency_ms": 52, "trait_effects": [{"trait": "nocicezione", "triggered": true, "effect": "nociception_reactive"}], "pressure_tier": 2}
+{"session_id": "s1", "action_type": "promotion", "actor_id": "pg1", "job_id": "guerriero", "applied_tier": "elite", "command_latency_ms": 38}
+{"session_id": "s1", "event_type": "vc_snapshot", "per_actor": {"pg1": {"mbti_type": "ENTJ", "ennea_archetypes": {"Conquistatore(3)": true}, "conviction_axis": {"utility": 65, "liberty": 50, "morality": 45}, "sentience": {"tier": "T2", "source": "species_catalog"}}}}
+{"session_id": "s1", "event_type": "skiv_pulse_fired", "actor_id": "pg1", "target_biome_id": "caverna"}
+{"session_id": "s1", "event_type": "biome_focus_changed", "biome_id": "caverna"}
+{"session_id": "s2", "action_type": "attack", "actor_id": "pg2", "command_latency_ms": 67, "trait_effects": [{"trait": "termocezione", "triggered": true, "effect": "thermoception_resist"}], "pressure_tier": 3}
+{"session_id": "s2", "action_type": "rewind", "actor_id": "pg2", "command_latency_ms": 120}
+{"session_id": "s2", "action_type": "promotion", "actor_id": "pg2", "job_id": "custode", "applied_tier": "captain", "command_latency_ms": 41}
+{"session_id": "s2", "event_type": "vc_snapshot", "per_actor": {"pg2": {"mbti_type": "ISFJ", "ennea_archetypes": {"Lealista(6)": true}, "conviction_axis": {"utility": 50, "liberty": 60, "morality": 70}, "sentience": {"tier": "T1", "source": "species_catalog"}}}}
+{"session_id": "s3", "action_type": "attack", "actor_id": "pg3", "command_latency_ms": 89, "trait_effects": [{"trait": "equilibrio_vestibolare", "triggered": true, "effect": "vestibular_advantage"}], "pressure_tier": 2}
+{"session_id": "s3", "action_type": "promotion", "actor_id": "pg3", "job_id": "esploratore", "applied_tier": "elite", "command_latency_ms": 55}
+{"session_id": "s3", "event_type": "vc_snapshot", "per_actor": {"pg3": {"mbti_type": "ENFP", "ennea_archetypes": {"Esploratore(7)": true}, "conviction_axis": {"utility": 45, "liberty": 75, "morality": 50}, "sentience": {"tier": "T3", "source": "species_catalog"}}}}
+{"session_id": "s3", "event_type": "skiv_pulse_fired", "actor_id": "pg3", "target_biome_id": "foresta_temperata"}
+{"session_id": "s4", "action_type": "attack", "actor_id": "pg4", "command_latency_ms": 78, "trait_effects": [{"trait": "propriocezione", "triggered": true, "effect": "proprioception_balance"}], "pressure_tier": 4}
+{"session_id": "s4", "action_type": "attack", "actor_id": "pg4", "command_latency_ms": 95, "trait_effects": [{"trait": "termocezione", "triggered": true, "effect": "thermoception_resist"}], "pressure_tier": 4}
+{"session_id": "s4", "action_type": "promotion", "actor_id": "pg4", "job_id": "tessitore", "applied_tier": "master", "command_latency_ms": 62}
+{"session_id": "s4", "event_type": "vc_snapshot", "per_actor": {"pg4": {"mbti_type": "INTJ", "ennea_archetypes": {"Architetto(5)": true}, "conviction_axis": {"utility": 70, "liberty": 40, "morality": 55}, "sentience": {"tier": "T2", "source": "species_catalog"}}}}
+{"session_id": "s5", "action_type": "attack", "actor_id": "pg5", "command_latency_ms": 33, "pressure_tier": 1}
+{"session_id": "s5", "action_type": "promotion", "actor_id": "pg5", "job_id": "guerriero", "applied_tier": "veteran", "command_latency_ms": 27}
+{"session_id": "s5", "event_type": "vc_snapshot", "per_actor": {"pg5": {"mbti_type": "ESTP", "ennea_archetypes": {"Cacciatore(8)": true}, "conviction_axis": {"utility": 60, "liberty": 55, "morality": 40}, "sentience": {"tier": "T1", "source": "species_catalog"}}}}
+{"session_id": "s6", "action_type": "rewind", "actor_id": "pg6", "command_latency_ms": 110}
+{"session_id": "s6", "action_type": "promotion", "actor_id": "pg6", "job_id": "custode", "applied_tier": "elite", "command_latency_ms": 48}
+{"session_id": "s6", "event_type": "vc_snapshot", "per_actor": {"pg6": {"mbti_type": "ISFJ", "ennea_archetypes": {"Lealista(6)": true}, "conviction_axis": {"utility": 55, "liberty": 50, "morality": 65}, "sentience": {"tier": "T3", "source": "species_catalog"}}}}
+{"session_id": "s6", "event_type": "skiv_pulse_fired", "actor_id": "pg6", "target_biome_id": "atollo_obsidiana"}
+{"session_id": "s6", "event_type": "biome_focus_changed", "biome_id": "atollo_obsidiana"}

--- a/tools/py/playtest_2_analyzer.py
+++ b/tools/py/playtest_2_analyzer.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""Playtest #2 telemetry analyzer — ai-station verdict validation.
+
+Specialized analyzer focused on validating ai-station 8 OD verdicts via
+playtest #2 userland telemetry. Builds on tools/py/analyze_telemetry.py
+DuckDB infrastructure but adds verdict-specific aggregations + report
+generator producing markdown verdict (🟢-cand → 🟢 hard promotion gate).
+
+Focus areas (ai-station Phase B+C verdicts):
+  - P3 Identità — promotion uptake (Jobs reaching elite/master tier,
+    job_archetype_bias preferences via Phase B3 #2264)
+  - P4 Temperamenti — 4-layer psicologico distribution (MBTI/Ennea/
+    Conviction/Sentience clustering)
+  - P6 Fairness — pressure tier balance + rewind usage frequency
+  - OD-024 — interoception traits firing rates
+    (propriocezione/nocicezione/equilibrio_vestibolare/termocezione)
+  - OD-026 — Skiv pulse atlas reveal_neighbor events
+  - Performance — command latency p95 (M.7), session length, drop-off
+
+Usage:
+  python tools/py/playtest_2_analyzer.py \\
+      --telemetry tests/fixtures/playtest-2-synthetic-telemetry.jsonl \\
+      --output docs/playtest/2026-05-XX-playtest-2-report.md
+
+Output:
+  Markdown report with sections:
+    1. Executive summary (sample size + 🟢/🟡/🔴 verdict per pillar)
+    2. P3 promotion uptake breakdown
+    3. P4 4-layer psicologico distribution
+    4. P6 fairness signals
+    5. OD-024 interoception trait firing
+    6. OD-026 atlas pulse usage
+    7. Performance metrics
+    8. Verdict + next-action recommendation
+
+Graceful: missing duckdb dep → fallback pure-stdlib JSONL iteration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from collections import Counter, defaultdict
+from datetime import date
+from pathlib import Path
+
+# Windows cp1252 stdout chokes on emoji. Force UTF-8 if reconfigure supported.
+if hasattr(sys.stdout, "reconfigure"):
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+    except (TypeError, ValueError):
+        pass
+
+# Optional DuckDB acceleration (Tier E donor — analyze_telemetry.py pattern).
+try:
+    import duckdb  # type: ignore
+
+    HAS_DUCKDB = True
+except ImportError:
+    HAS_DUCKDB = False
+
+
+# Minimum sample for 🟢 hard verdict (vs 🟢-cand). Below = 🟡 partial.
+MIN_SAMPLE_GREEN_HARD = 30  # ~30 sessions ≈ pillar promotion threshold
+MIN_SAMPLE_PARTIAL = 5  # below = 🔴 insufficient signal
+
+# Performance gates per M.7 telemetry contract.
+LATENCY_P95_PASS_MS = 100
+LATENCY_P95_COND_MS = 200
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Playtest #2 telemetry analyzer (ai-station)")
+    p.add_argument("--telemetry", required=True, help="Path to telemetry JSONL")
+    p.add_argument("--output", help="Output markdown path (default stdout)")
+    p.add_argument(
+        "--min-sample",
+        type=int,
+        default=MIN_SAMPLE_GREEN_HARD,
+        help="Min sample for 🟢 hard (default 30)",
+    )
+    return p.parse_args()
+
+
+def load_events(path: Path) -> list[dict]:
+    """Load JSONL telemetry — one event per line. Graceful malformed-line skip."""
+    if not path.exists():
+        print(f"ERROR: telemetry file not found: {path}", file=sys.stderr)
+        sys.exit(2)
+    events: list[dict] = []
+    with path.open(encoding="utf-8") as f:
+        for i, line in enumerate(f, 1):
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError as err:
+                print(f"WARN: line {i} malformed JSON, skipped: {err}", file=sys.stderr)
+    return events
+
+
+def aggregate_session_summary(events: list[dict]) -> dict:
+    """Aggregate per-session summary. Group by session_id."""
+    by_session: dict[str, list[dict]] = defaultdict(list)
+    for ev in events:
+        sid = ev.get("session_id", "_unknown_")
+        by_session[sid].append(ev)
+    return {
+        "total_sessions": len(by_session),
+        "total_events": len(events),
+        "sessions": by_session,
+    }
+
+
+def analyze_p3_promotions(by_session: dict[str, list[dict]]) -> dict:
+    """P3 Identità — promotion uptake + job_archetype_bias preferences."""
+    promotion_events = []
+    for evs in by_session.values():
+        for ev in evs:
+            if ev.get("action_type") in ("promotion", "promotion_accepted"):
+                promotion_events.append(ev)
+    tier_distribution: Counter = Counter()
+    job_tier: Counter = Counter()
+    for ev in promotion_events:
+        tier = ev.get("applied_tier", ev.get("target_tier", "unknown"))
+        job = ev.get("job_id", "unknown")
+        tier_distribution[tier] += 1
+        job_tier[(job, tier)] += 1
+    elite_count = tier_distribution.get("elite", 0)
+    master_count = tier_distribution.get("master", 0)
+    return {
+        "total_promotions": len(promotion_events),
+        "tier_distribution": dict(tier_distribution),
+        "elite_count": elite_count,
+        "master_count": master_count,
+        "phase_b3_reached": elite_count + master_count,
+        "job_tier_breakdown": dict(job_tier),
+    }
+
+
+def analyze_p4_psicologico(by_session: dict[str, list[dict]]) -> dict:
+    """P4 Temperamenti — 4-layer profilo psicologico distribution."""
+    mbti_types: Counter = Counter()
+    ennea_archs: Counter = Counter()
+    conviction_axes: list[dict] = []
+    sentience_tiers: Counter = Counter()
+    for evs in by_session.values():
+        for ev in evs:
+            if ev.get("event_type") == "vc_snapshot":
+                per_actor = ev.get("per_actor", {})
+                for uid, actor in per_actor.items():
+                    mbti_t = actor.get("mbti_type", "")
+                    if mbti_t:
+                        mbti_types[mbti_t] += 1
+                    for arch, fired in (actor.get("ennea_archetypes") or {}).items():
+                        if fired:
+                            ennea_archs[arch] += 1
+                    if "conviction_axis" in actor:
+                        conviction_axes.append(actor["conviction_axis"])
+                    sent = (actor.get("sentience") or {}).get("tier", "")
+                    if sent:
+                        sentience_tiers[sent] += 1
+    conviction_summary = {}
+    if conviction_axes:
+        for axis in ("utility", "liberty", "morality"):
+            values = [float(c.get(axis, 50)) for c in conviction_axes]
+            conviction_summary[axis] = {
+                "mean": statistics.mean(values) if values else None,
+                "stdev": statistics.stdev(values) if len(values) > 1 else 0.0,
+            }
+    return {
+        "mbti_distribution": dict(mbti_types),
+        "ennea_distribution": dict(ennea_archs),
+        "conviction_distribution": conviction_summary,
+        "sentience_distribution": dict(sentience_tiers),
+        "layer_completeness": {
+            "mbti": len(mbti_types) > 0,
+            "ennea": len(ennea_archs) > 0,
+            "conviction": bool(conviction_axes),
+            "sentience": len(sentience_tiers) > 0,
+        },
+    }
+
+
+def analyze_p6_fairness(by_session: dict[str, list[dict]]) -> dict:
+    """P6 Fairness — pressure tier balance + rewind usage."""
+    pressure_tiers: Counter = Counter()
+    rewind_events = 0
+    for evs in by_session.values():
+        for ev in evs:
+            tier = ev.get("pressure_tier")
+            if tier is not None:
+                pressure_tiers[str(tier)] += 1
+            if ev.get("action_type") == "rewind":
+                rewind_events += 1
+    return {
+        "pressure_distribution": dict(pressure_tiers),
+        "rewind_events": rewind_events,
+        "rewind_sessions_pct": (
+            100 * rewind_events / max(1, len(by_session)) if by_session else 0.0
+        ),
+    }
+
+
+def analyze_od024_interoception(events: list[dict]) -> dict:
+    """OD-024 — 4 interoception traits firing rates."""
+    interoception_log_tags = {
+        "proprioception_balance",
+        "vestibular_advantage",
+        "nociception_reactive",
+        "thermoception_resist",
+    }
+    firings: Counter = Counter()
+    total_attacks = 0
+    for ev in events:
+        if ev.get("action_type") == "attack":
+            total_attacks += 1
+        for fx in ev.get("trait_effects", []) or []:
+            tag = fx.get("effect")
+            if tag in interoception_log_tags and fx.get("triggered"):
+                firings[tag] += 1
+    return {
+        "firings_by_trait": dict(firings),
+        "total_firings": sum(firings.values()),
+        "total_attacks": total_attacks,
+        "firing_rate_pct": (
+            100 * sum(firings.values()) / total_attacks if total_attacks else 0.0
+        ),
+    }
+
+
+def analyze_od026_atlas(events: list[dict]) -> dict:
+    """OD-026 — Skiv pulse atlas reveal_neighbor + biome_focus events."""
+    pulse_events = 0
+    biome_focus: Counter = Counter()
+    revealed_biomes: Counter = Counter()
+    for ev in events:
+        if ev.get("event_type") == "skiv_pulse_fired":
+            pulse_events += 1
+            biome_id = ev.get("target_biome_id", "")
+            if biome_id:
+                revealed_biomes[biome_id] += 1
+        if ev.get("event_type") == "biome_focus_changed":
+            biome_focus[ev.get("biome_id", "_unknown_")] += 1
+    return {
+        "skiv_pulse_events": pulse_events,
+        "revealed_biomes": dict(revealed_biomes),
+        "biome_focus_events": dict(biome_focus),
+    }
+
+
+def analyze_performance(events: list[dict]) -> dict:
+    """Performance — command latency p95 + session length distribution."""
+    latencies_ms: list[float] = []
+    for ev in events:
+        lat = ev.get("command_latency_ms")
+        if isinstance(lat, (int, float)) and lat > 0:
+            latencies_ms.append(float(lat))
+    p95 = None
+    p50 = None
+    if latencies_ms:
+        latencies_sorted = sorted(latencies_ms)
+        p50 = latencies_sorted[int(0.5 * len(latencies_sorted))]
+        p95 = latencies_sorted[int(0.95 * len(latencies_sorted))]
+    verdict_gate = "n/a"
+    if p95 is not None:
+        if p95 < LATENCY_P95_PASS_MS:
+            verdict_gate = "PASS"
+        elif p95 < LATENCY_P95_COND_MS:
+            verdict_gate = "CONDITIONAL"
+        else:
+            verdict_gate = "ABORT"
+    return {
+        "command_latency_p50_ms": p50,
+        "command_latency_p95_ms": p95,
+        "command_latency_verdict": verdict_gate,
+        "samples": len(latencies_ms),
+    }
+
+
+def _verdict_emoji(metric_count: int, min_sample: int) -> str:
+    if metric_count >= min_sample:
+        return "🟢"
+    if metric_count >= MIN_SAMPLE_PARTIAL:
+        return "🟡"
+    return "🔴"
+
+
+def build_report(  # noqa: PLR0913
+    summary: dict,
+    p3: dict,
+    p4: dict,
+    p6: dict,
+    od024: dict,
+    od026: dict,
+    perf: dict,
+    min_sample: int,
+) -> str:
+    """Build markdown report from aggregated metrics."""
+    today = date.today().isoformat()
+    total_sessions = summary["total_sessions"]
+    total_events = summary["total_events"]
+    overall_verdict = _verdict_emoji(total_sessions, min_sample)
+    lines: list[str] = []
+    lines.append(f"# Playtest #2 telemetry report — {today}")
+    lines.append("")
+    lines.append("ai-station verdict validation report. Auto-generated by")
+    lines.append("`tools/py/playtest_2_analyzer.py`. Sample-driven verdicts:")
+    lines.append("🟢 = ≥30 sessions sample / 🟡 = 5-29 / 🔴 = <5.")
+    lines.append("")
+    lines.append("## 1. Executive summary")
+    lines.append("")
+    lines.append(f"- **Sessions analyzed**: {total_sessions}")
+    lines.append(f"- **Total events**: {total_events}")
+    lines.append(f"- **Overall sample verdict**: {overall_verdict}")
+    lines.append("")
+    lines.append("| Pillar | Verdict | Note |")
+    lines.append("|---|:--:|---|")
+    p3_v = _verdict_emoji(p3["total_promotions"], min_sample)
+    p4_v = "🟢" if all(p4["layer_completeness"].values()) else "🟡"
+    p6_v = _verdict_emoji(
+        sum(p6["pressure_distribution"].values()) or 0, min_sample
+    )
+    lines.append(f"| P3 Identità | {p3_v} | {p3['total_promotions']} promotions, "
+                 f"{p3['phase_b3_reached']} reached elite/master |")
+    lines.append(f"| P4 Temperamenti | {p4_v} | 4-layer completeness: "
+                 f"{p4['layer_completeness']} |")
+    lines.append(f"| P6 Fairness | {p6_v} | {p6['rewind_events']} rewinds, "
+                 f"{p6['rewind_sessions_pct']:.1f}% of sessions |")
+    lines.append("")
+    # P3 Promotions
+    lines.append("## 2. P3 Identità — promotion uptake")
+    lines.append("")
+    lines.append(f"Tier distribution: `{p3['tier_distribution']}`")
+    lines.append("")
+    if p3["job_tier_breakdown"]:
+        lines.append("**Job × Tier breakdown** (Phase B3 job_archetype_bias signal):")
+        for (job, tier), count in sorted(p3["job_tier_breakdown"].items()):
+            lines.append(f"- `{job}` → `{tier}`: {count}")
+    else:
+        lines.append("_No Job × Tier data captured._")
+    lines.append("")
+    # P4 4-layer psicologico
+    lines.append("## 3. P4 Temperamenti — 4-layer profilo psicologico")
+    lines.append("")
+    lines.append("### MBTI distribution")
+    for typ, count in sorted(p4["mbti_distribution"].items()):
+        lines.append(f"- {typ}: {count}")
+    lines.append("")
+    lines.append("### Ennea archetype firings")
+    for arch, count in sorted(p4["ennea_distribution"].items()):
+        lines.append(f"- {arch}: {count}")
+    lines.append("")
+    lines.append("### Conviction axes (D2-A)")
+    for axis, stats in p4["conviction_distribution"].items():
+        mean = stats.get("mean")
+        stdev = stats.get("stdev", 0)
+        if mean is not None:
+            lines.append(f"- **{axis}**: mean={mean:.1f} σ={stdev:.1f}")
+    lines.append("")
+    lines.append("### Sentience tier distribution (Phase B3 OD-024)")
+    for tier, count in sorted(p4["sentience_distribution"].items()):
+        lines.append(f"- {tier}: {count}")
+    lines.append("")
+    # P6 Fairness
+    lines.append("## 4. P6 Fairness — pressure tier + rewind")
+    lines.append("")
+    lines.append(f"Pressure tier distribution: `{p6['pressure_distribution']}`")
+    lines.append(
+        f"Rewind events: **{p6['rewind_events']}** "
+        f"({p6['rewind_sessions_pct']:.1f}% of sessions)"
+    )
+    lines.append("")
+    # OD-024 interoception
+    lines.append("## 5. OD-024 — interoception traits firing")
+    lines.append("")
+    lines.append(f"Total attacks: {od024['total_attacks']}")
+    lines.append(
+        f"Total interoception firings: **{od024['total_firings']}** "
+        f"({od024['firing_rate_pct']:.1f}% of attacks)"
+    )
+    for trait, count in sorted(od024["firings_by_trait"].items()):
+        lines.append(f"- `{trait}`: {count}")
+    lines.append("")
+    # OD-026 atlas
+    lines.append("## 6. OD-026 — Skiv pulse atlas usage")
+    lines.append("")
+    lines.append(f"Pulse events: **{od026['skiv_pulse_events']}**")
+    if od026["revealed_biomes"]:
+        lines.append("Revealed biomes:")
+        for biome, count in sorted(od026["revealed_biomes"].items()):
+            lines.append(f"- `{biome}`: {count}")
+    if od026["biome_focus_events"]:
+        lines.append("Biome focus clicks:")
+        for biome, count in sorted(od026["biome_focus_events"].items()):
+            lines.append(f"- `{biome}`: {count}")
+    lines.append("")
+    # Performance
+    lines.append("## 7. Performance — command latency (M.7 contract)")
+    lines.append("")
+    lines.append(
+        f"- p50: **{perf['command_latency_p50_ms']}** ms / p95: "
+        f"**{perf['command_latency_p95_ms']}** ms ({perf['samples']} samples)"
+    )
+    lines.append(f"- Verdict gate (M.7): **{perf['command_latency_verdict']}**")
+    lines.append(
+        f"  - PASS < {LATENCY_P95_PASS_MS}ms / CONDITIONAL "
+        f"< {LATENCY_P95_COND_MS}ms / ABORT ≥ {LATENCY_P95_COND_MS}ms"
+    )
+    lines.append("")
+    # Final verdict
+    lines.append("## 8. Verdict + next action")
+    lines.append("")
+    pillars_green = sum(1 for v in (p3_v, p4_v, p6_v) if v == "🟢")
+    if pillars_green == 3:
+        lines.append("🟢 **3/3 pillars hard verified** — proceed 🟢-cand → 🟢 hard "
+                     "promotion for P3+P4+P6.")
+    elif pillars_green >= 1:
+        lines.append(f"🟡 **{pillars_green}/3 pillars hard verified** — partial "
+                     "promotion: shipping pillars qualifying threshold, repeat "
+                     "playtest #3 for residual gap.")
+    else:
+        lines.append(
+            "🔴 **0/3 pillars hard verified** — insufficient sample. Repeat "
+            "playtest #2 with broader recruitment OR adjust sample size target."
+        )
+    lines.append("")
+    lines.append("## Cross-link")
+    lines.append("")
+    lines.append("- ai-station re-analisi: `vault docs/decisions/"
+                 "OD-024-031-aistation-reanalysis-2026-05-14.md`")
+    lines.append("- Phase B3 cross-stack: Game/ PR #2264 + Godot v2 PR #261")
+    lines.append("- Envelope A+B+C: PR #2261 + #2262 + #259 + #260")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    telemetry_path = Path(args.telemetry)
+    events = load_events(telemetry_path)
+    summary = aggregate_session_summary(events)
+    by_session = summary["sessions"]
+
+    p3 = analyze_p3_promotions(by_session)
+    p4 = analyze_p4_psicologico(by_session)
+    p6 = analyze_p6_fairness(by_session)
+    od024 = analyze_od024_interoception(events)
+    od026 = analyze_od026_atlas(events)
+    perf = analyze_performance(events)
+
+    report = build_report(summary, p3, p4, p6, od024, od026, perf, args.min_sample)
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(report, encoding="utf-8")
+        print(f"[playtest-2-analyzer] Report written: {out_path}")
+    else:
+        print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/py/test_playtest_2_analyzer.py
+++ b/tools/py/test_playtest_2_analyzer.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/py/playtest_2_analyzer.py.
+
+Validates per-pillar aggregation functions + report build end-to-end on
+synthetic telemetry fixture.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from collections import defaultdict
+from pathlib import Path
+
+# Ensure tool path importable.
+sys.path.insert(0, str(Path(__file__).parent))
+
+from playtest_2_analyzer import (  # noqa: E402
+    aggregate_session_summary,
+    analyze_od024_interoception,
+    analyze_od026_atlas,
+    analyze_p3_promotions,
+    analyze_p4_psicologico,
+    analyze_p6_fairness,
+    analyze_performance,
+    build_report,
+    load_events,
+)
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "tests"
+    / "fixtures"
+    / "playtest-2-synthetic-telemetry.jsonl"
+)
+
+
+class LoadEventsTests(unittest.TestCase):
+    def test_skips_comments_and_blanks(self) -> None:
+        events = load_events(FIXTURE_PATH)
+        # Fixture has 26 data lines (no blanks/comments counted).
+        self.assertGreater(len(events), 20)
+        self.assertTrue(all(isinstance(e, dict) for e in events))
+
+
+class SessionSummaryTests(unittest.TestCase):
+    def test_groups_by_session_id(self) -> None:
+        events = load_events(FIXTURE_PATH)
+        summary = aggregate_session_summary(events)
+        self.assertEqual(summary["total_sessions"], 6)
+        self.assertEqual(summary["total_events"], len(events))
+
+
+class P3PromotionsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        events = load_events(FIXTURE_PATH)
+        self.summary = aggregate_session_summary(events)
+
+    def test_aggregates_promotion_tier(self) -> None:
+        result = analyze_p3_promotions(self.summary["sessions"])
+        self.assertEqual(result["total_promotions"], 6)
+        # Fixture has 1 elite (guerriero) + 1 captain (custode) + 1 elite (espl)
+        # + 1 master (tess) + 1 veteran (guerr) + 1 elite (cust) = 3 elite, 1 master
+        self.assertEqual(result["elite_count"], 3)
+        self.assertEqual(result["master_count"], 1)
+        self.assertEqual(result["phase_b3_reached"], 4)
+
+    def test_job_tier_breakdown(self) -> None:
+        result = analyze_p3_promotions(self.summary["sessions"])
+        # Verify Phase B3 job_archetype_bias signal: distinct Jobs at elite/master.
+        breakdown = result["job_tier_breakdown"]
+        # guerriero appears at both veteran + elite tier
+        self.assertIn(("guerriero", "elite"), breakdown)
+        self.assertIn(("guerriero", "veteran"), breakdown)
+        self.assertIn(("tessitore", "master"), breakdown)
+        self.assertIn(("custode", "elite"), breakdown)
+
+
+class P4PsicologicoTests(unittest.TestCase):
+    def setUp(self) -> None:
+        events = load_events(FIXTURE_PATH)
+        self.summary = aggregate_session_summary(events)
+
+    def test_4_layer_completeness(self) -> None:
+        result = analyze_p4_psicologico(self.summary["sessions"])
+        completeness = result["layer_completeness"]
+        self.assertTrue(completeness["mbti"], "MBTI layer must be present")
+        self.assertTrue(completeness["ennea"], "Ennea layer must be present")
+        self.assertTrue(completeness["conviction"], "Conviction layer (D2-A)")
+        self.assertTrue(
+            completeness["sentience"], "Sentience layer (Phase B3 OD-024)"
+        )
+
+    def test_mbti_distribution_unique_types(self) -> None:
+        result = analyze_p4_psicologico(self.summary["sessions"])
+        # Fixture has 6 unique MBTI types: ENTJ/ISFJ/ENFP/INTJ/ESTP/ISFJ
+        self.assertGreaterEqual(len(result["mbti_distribution"]), 5)
+
+    def test_sentience_distribution_t0_t6_subset(self) -> None:
+        result = analyze_p4_psicologico(self.summary["sessions"])
+        tiers = set(result["sentience_distribution"].keys())
+        valid_tiers = {f"T{i}" for i in range(7)}
+        self.assertTrue(tiers.issubset(valid_tiers), f"Got invalid tiers: {tiers}")
+
+    def test_conviction_aggregates_mean_stdev(self) -> None:
+        result = analyze_p4_psicologico(self.summary["sessions"])
+        for axis in ("utility", "liberty", "morality"):
+            self.assertIn(axis, result["conviction_distribution"])
+            stats = result["conviction_distribution"][axis]
+            self.assertIsNotNone(stats.get("mean"))
+            # Mean should be in plausible 0..100 range
+            self.assertGreaterEqual(stats["mean"], 0)
+            self.assertLessEqual(stats["mean"], 100)
+
+
+class P6FairnessTests(unittest.TestCase):
+    def setUp(self) -> None:
+        events = load_events(FIXTURE_PATH)
+        self.summary = aggregate_session_summary(events)
+
+    def test_pressure_tier_counts(self) -> None:
+        result = analyze_p6_fairness(self.summary["sessions"])
+        # Fixture has tiers 1,2,3,4 represented
+        tiers = result["pressure_distribution"]
+        self.assertTrue(set(tiers.keys()).issubset({"1", "2", "3", "4"}))
+
+    def test_rewind_event_count(self) -> None:
+        result = analyze_p6_fairness(self.summary["sessions"])
+        self.assertEqual(result["rewind_events"], 2)
+        # 2 rewinds across 6 sessions = 33.3%
+        self.assertAlmostEqual(result["rewind_sessions_pct"], 33.33, places=1)
+
+
+class OD024InteroceptionTests(unittest.TestCase):
+    def test_all_4_traits_fire(self) -> None:
+        events = load_events(FIXTURE_PATH)
+        result = analyze_od024_interoception(events)
+        firings = result["firings_by_trait"]
+        self.assertIn("proprioception_balance", firings)
+        self.assertIn("vestibular_advantage", firings)
+        self.assertIn("nociception_reactive", firings)
+        self.assertIn("thermoception_resist", firings)
+
+    def test_firing_rate_computed(self) -> None:
+        events = load_events(FIXTURE_PATH)
+        result = analyze_od024_interoception(events)
+        self.assertGreater(result["firing_rate_pct"], 0)
+        self.assertLessEqual(result["firing_rate_pct"], 100)
+
+
+class OD026AtlasTests(unittest.TestCase):
+    def test_pulse_event_count(self) -> None:
+        events = load_events(FIXTURE_PATH)
+        result = analyze_od026_atlas(events)
+        self.assertEqual(result["skiv_pulse_events"], 3)
+
+    def test_revealed_biomes_captured(self) -> None:
+        events = load_events(FIXTURE_PATH)
+        result = analyze_od026_atlas(events)
+        self.assertIn("caverna", result["revealed_biomes"])
+        self.assertIn("foresta_temperata", result["revealed_biomes"])
+        self.assertIn("atollo_obsidiana", result["revealed_biomes"])
+
+
+class PerformanceTests(unittest.TestCase):
+    def test_p95_computed_with_verdict_gate(self) -> None:
+        events = load_events(FIXTURE_PATH)
+        result = analyze_performance(events)
+        self.assertGreater(result["samples"], 0)
+        self.assertIsNotNone(result["command_latency_p50_ms"])
+        self.assertIsNotNone(result["command_latency_p95_ms"])
+        self.assertIn(result["command_latency_verdict"], ("PASS", "CONDITIONAL", "ABORT"))
+
+    def test_no_latency_data_returns_na(self) -> None:
+        result = analyze_performance([])
+        self.assertEqual(result["command_latency_verdict"], "n/a")
+
+
+class ReportBuildTests(unittest.TestCase):
+    def test_report_contains_all_8_sections(self) -> None:
+        events = load_events(FIXTURE_PATH)
+        summary = aggregate_session_summary(events)
+        by_session = summary["sessions"]
+        report = build_report(
+            summary,
+            analyze_p3_promotions(by_session),
+            analyze_p4_psicologico(by_session),
+            analyze_p6_fairness(by_session),
+            analyze_od024_interoception(events),
+            analyze_od026_atlas(events),
+            analyze_performance(events),
+            min_sample=30,
+        )
+        # 8 numbered sections required
+        for n in range(1, 9):
+            self.assertIn(f"## {n}.", report)
+        self.assertIn("ai-station", report.lower())
+
+    def test_report_partial_verdict_when_undersampled(self) -> None:
+        # Synthetic fixture has 6 sessions < 30 → at most 🟡 1/3 verdict.
+        events = load_events(FIXTURE_PATH)
+        summary = aggregate_session_summary(events)
+        by_session = summary["sessions"]
+        report = build_report(
+            summary,
+            analyze_p3_promotions(by_session),
+            analyze_p4_psicologico(by_session),
+            analyze_p6_fairness(by_session),
+            analyze_od024_interoception(events),
+            analyze_od026_atlas(events),
+            analyze_performance(events),
+            min_sample=30,
+        )
+        # Should NOT claim 3/3 hard verified at 6 sessions
+        self.assertNotIn("3/3 pillars hard verified", report)
+
+
+class GracefulDegradationTests(unittest.TestCase):
+    def test_empty_telemetry_no_crash(self) -> None:
+        # Simulate empty event list — all aggregators must return Dict shape.
+        empty: dict = defaultdict(list)
+        p3 = analyze_p3_promotions(empty)
+        self.assertEqual(p3["total_promotions"], 0)
+        p4 = analyze_p4_psicologico(empty)
+        self.assertEqual(p4["mbti_distribution"], {})
+        p6 = analyze_p6_fairness(empty)
+        self.assertEqual(p6["rewind_events"], 0)
+        od024 = analyze_od024_interoception([])
+        self.assertEqual(od024["total_firings"], 0)
+        od026 = analyze_od026_atlas([])
+        self.assertEqual(od026["skiv_pulse_events"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Context

2 infra improvements per master-dd queue priority 4 close-out. Pure-code, no userland data required. Sblocca:
1. Cross-stack drift detection senza sibling repo checkout
2. Playtest #2 analysis pipeline ready ahead-of-time

## Changes

### 1. Cross-stack snapshot fixture (eliminates 4 skip tests)

- \`tests/fixtures/godot-v2-promotions-v0.2.0.json\` (NEW, 72 lines) = byte-identical mirror Godot v2 mainline
- \`tests/fixtures/README.md\` — update flow doc (manual sync on Godot v2 bump)
- \`tests/api/promotion-fallback-cross-stack-parity.test.js\` — candidates order: env override → sibling layouts → bundled fixture (always present → tests never skip)

Test result: **12/12 pass** (was 8 pass + 4 skip).

### 2. Playtest #2 telemetry analyzer + report template

- \`tools/py/playtest_2_analyzer.py\` (~470 LOC stdlib only)
  - 6 per-pillar analyzers: P3 promotions / P4 4-layer psicologico / P6 fairness / OD-024 / OD-026 / Performance
  - 8-section markdown auto-report (exec summary + per-pillar + verdict)
  - Verdict gates: 🟢 (≥30) / 🟡 (5-29) / 🔴 (<5) sample
- \`tools/py/test_playtest_2_analyzer.py\` — **19 unit tests**
- \`tests/fixtures/playtest-2-synthetic-telemetry.jsonl\` — 6 sessions × 26 events covering all surfaces
- \`docs/playtest/2026-05-14-playtest-2-plan.md\` — execution plan + telemetry events + decision matrix

Test result: **19/19 pass** (Python unittest stdlib).

## Verdict mechanism

Analyzer aggregates by pillar per ai-station verdict surfaces:

| Pillar | Signal source | Phase B3 link |
|---|---|---|
| P3 Identità | promotion tier distribution + Job × Tier | job_archetype_bias (#2264) |
| P4 Temperamenti | 4-layer completeness (MBTI+Ennea+Conviction+Sentience) | sentience fold (#2264) |
| P6 Fairness | pressure_tier balance + rewind frequency | pressure-tier-encounter (#221) |
| OD-024 | 4 interoception traits firing rate | interoception runtime (#2262) |
| OD-026 | Skiv pulse + biome_focus events | atlas + pulse wire (#260/#262) |
| Performance | command_latency_p95 vs M.7 contract | TelemetryCollector (#166) |

## Usage when playtest fires

\`\`\`bash
# After playtest #2 captures telemetry:
python tools/py/playtest_2_analyzer.py \
    --telemetry playtest-2-all-sessions.jsonl \
    --output docs/playtest/\$(date +%Y-%m-%d)-playtest-2-report.md \
    --min-sample 30
\`\`\`

Output: markdown report con verdict per pillar → master-dd decide promotion 🟢-cand → 🟢 hard.

## Cross-link

- ai-station re-analisi: vault PR #5
- Phase B3: #2264 (Game/) + #261 (Godot v2)
- Envelope A+B+C: #2261/#2262/#259/#260
- Drift fix: #2263
- Skiv pulse wire: #262