### PR TITLE
feat(p3): Phase B4 — promotionEngine.js job_threshold_override engine consume

### DIFF
--- a/apps/backend/services/progression/promotionEngine.js
+++ b/apps/backend/services/progression/promotionEngine.js
@@ -85,6 +85,14 @@ const FALLBACK_CONFIG = {
       ability_unlock_tier: 'r5',
     },
   },
+  // 2026-05-14 Phase B4 — custode tank alt-path (assists_min unreachable for
+  // tank playstyle; replace with damage_taken_min proxy). Mirror promotions.yaml.
+  job_threshold_override: {
+    custode: {
+      elite: { assists_min: null, damage_taken_min: 30 },
+      master: { assists_min: null, damage_taken_min: 75 },
+    },
+  },
 };
 
 /**
@@ -144,12 +152,15 @@ function resetCache() {
  */
 function computeUnitMetrics(unit, eventLog = []) {
   if (!unit || !unit.id) {
-    return { kills: 0, assists: 0, objectives: 0 };
+    return { kills: 0, assists: 0, objectives: 0, damage_taken: 0 };
   }
   const events = Array.isArray(eventLog) ? eventLog : [];
   let kills = 0;
   let assists = 0;
   let objectives = 0;
+  // Phase B4 — damage_taken metric for custode tank alt-path threshold.
+  // Sums damage_dealt received as target. Proxy for "tank shielded N PT".
+  let damage_taken = 0;
 
   // Walk events; track lethal blows + own contributions.
   const damagedByUnit = new Map(); // target_id → turn last damaged by unit
@@ -177,6 +188,17 @@ function computeUnitMetrics(unit, eventLog = []) {
         if (isKill) assists += 1;
       }
     }
+    // Phase B4 — damage_taken accumulator: any attack targeting our unit.
+    // Counted unconditionally (separate branch from assist tracking, which
+    // requires actorId !== unit.id). Handles edge: foe attacking us directly.
+    if (
+      action === 'attack' &&
+      targetId === unit.id &&
+      actorId !== unit.id &&
+      Number.isFinite(Number(ev.damage_dealt))
+    ) {
+      damage_taken += Number(ev.damage_dealt);
+    }
     if (
       (action === 'objective_complete' || action === 'mission_objective') &&
       (!actorId ||
@@ -186,7 +208,7 @@ function computeUnitMetrics(unit, eventLog = []) {
       if (ev.result === 'ok' || ev.result === 'completed') objectives += 1;
     }
   }
-  return { kills, assists, objectives };
+  return { kills, assists, objectives, damage_taken };
 }
 
 function currentTier(unit) {
@@ -222,7 +244,12 @@ function evaluatePromotion(unit, eventLog = [], config = null) {
       reward: null,
     };
   }
-  const threshold = cfg.thresholds?.[next] || null;
+  const baseThreshold = cfg.thresholds?.[next] || null;
+  // 2026-05-14 Phase B4 — merge job_threshold_override onto base threshold.
+  // Per-Job gate override (closes economy-design GAP custode tank assists_min
+  // mismatch). Override fields win per-key (null removes gate; new metric
+  // adds new gate). Shallow merge pattern parallel _mergeJobBias rewards.
+  const threshold = baseThreshold ? _mergeJobThreshold(baseThreshold, cfg, unit, next) : null;
   const baseReward = cfg.rewards?.[next] || null;
   // 2026-05-14 Phase B3 — surface Job-biased reward in eligibility preview
   // so UI (PromotionPanel) can render per-Job override stats (e.g.
@@ -249,6 +276,16 @@ function evaluatePromotion(unit, eventLog = [], config = null) {
   }
   if (Number.isFinite(threshold.objectives_min) && metrics.objectives < threshold.objectives_min) {
     reasons.push(`objectives ${metrics.objectives} < ${threshold.objectives_min}`);
+  }
+  // Phase B4 — new metric path: damage_taken_min (custode tank alt-path).
+  // Allows job_threshold_override to introduce new gate metrics without
+  // breaking base schema. Gracefully skipped when metric absent.
+  if (
+    Number.isFinite(threshold.damage_taken_min) &&
+    Number.isFinite(metrics.damage_taken) &&
+    metrics.damage_taken < threshold.damage_taken_min
+  ) {
+    reasons.push(`damage_taken ${metrics.damage_taken} < ${threshold.damage_taken_min}`);
   }
   const eligible = reasons.length === 0;
   return {
@@ -353,6 +390,43 @@ function applyPromotion(unit, targetTier, config = null) {
 //     per Job — only elite/master in current schema)
 //
 // Mirror Godot v2 scripts/progression/promotion_engine.gd _merge_job_bias.
+// 2026-05-14 Phase B4 ai-station — job_threshold_override merge helper.
+// Reads cfg.job_threshold_override[unit.job_id][targetTier] and shallow-merges
+// onto base threshold. Override semantics:
+//   - field: <number> → set new threshold (overrides base or adds new metric)
+//   - field: null     → REMOVE gate (skip threshold check)
+//
+// Closes economy-design GAP: custode tank assists_min:6/12 unreachable for
+// tank playstyle. Override replaces with damage_taken_min proxy.
+//
+// Mirror Godot v2 scripts/progression/promotion_engine.gd _merge_job_threshold.
+function _mergeJobThreshold(baseThreshold, cfg, unit, targetTier) {
+  if (
+    !cfg ||
+    typeof cfg.job_threshold_override !== 'object' ||
+    cfg.job_threshold_override === null
+  ) {
+    return baseThreshold;
+  }
+  const jobId = unit && typeof unit.job_id === 'string' ? unit.job_id : '';
+  if (!jobId) return baseThreshold;
+  const jobBlock = cfg.job_threshold_override[jobId];
+  if (!jobBlock || typeof jobBlock !== 'object') return baseThreshold;
+  const tierOverride = jobBlock[targetTier];
+  if (!tierOverride || typeof tierOverride !== 'object') return baseThreshold;
+  // Shallow merge: override fields win. null values DELETE base fields (remove
+  // gate entirely so threshold check skips them).
+  const merged = { ...baseThreshold };
+  for (const key of Object.keys(tierOverride)) {
+    if (tierOverride[key] === null) {
+      delete merged[key];
+    } else {
+      merged[key] = tierOverride[key];
+    }
+  }
+  return merged;
+}
+
 function _mergeJobBias(baseReward, cfg, unit, targetTier) {
   if (!cfg || typeof cfg.job_archetype_bias !== 'object' || cfg.job_archetype_bias === null) {
     return baseReward;
@@ -381,4 +455,6 @@ module.exports = {
   FALLBACK_CONFIG,
   // Phase B3 helper exported for cross-stack parity tests + Godot v2 mirror.
   _mergeJobBias,
+  // Phase B4 — job_threshold_override helper exported for tests.
+  _mergeJobThreshold,
 };

--- a/tests/api/phase-b4-job-threshold-override.test.js
+++ b/tests/api/phase-b4-job-threshold-override.test.js
@@ -1,0 +1,210 @@
+// OD-025 Phase B4 ai-station 2026-05-14 — job_threshold_override engine consumption.
+//
+// Closes economy-design GSD audit GAP: custode tank assists_min:6/12
+// unreachable for tank playstyle (kills+damage_taken, not assists).
+// Override replaces base threshold with damage_taken_min proxy.
+//
+// Schema:
+//   cfg.job_threshold_override[job_id][tier] = { <field>: number|null }
+//   - <number> sets new threshold (replaces base or adds new metric)
+//   - null DELETES gate (skip threshold check)
+//
+// Tests:
+//   - _mergeJobThreshold helper (graceful fallbacks + override semantics)
+//   - computeUnitMetrics damage_taken accumulator
+//   - evaluatePromotion custode alt-path eligibility (assists null + damage_taken_min)
+//   - applyPromotion respects override-defined eligibility gate
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  evaluatePromotion,
+  computeUnitMetrics,
+  _mergeJobThreshold,
+  FALLBACK_CONFIG,
+} = require('../../apps/backend/services/progression/promotionEngine');
+
+function _unit(jobId, tier = 'captain') {
+  return {
+    id: `pg-${jobId}`,
+    job_id: jobId,
+    promotion_tier: tier,
+    hp: 30,
+    max_hp: 30,
+    attack_mod: 0,
+    defense_mod: 0,
+    initiative: 0,
+  };
+}
+
+function _attack(actor, target, turn, killed = false, damage = 0) {
+  return {
+    action_type: 'attack',
+    actor_id: actor,
+    target_id: target,
+    turn,
+    killed,
+    damage_dealt: damage,
+    result: killed ? 'kill' : 'hit',
+  };
+}
+
+describe('Phase B4 — _mergeJobThreshold helper', () => {
+  const CFG_OVERRIDE = {
+    job_threshold_override: {
+      custode: {
+        elite: { assists_min: null, damage_taken_min: 30 },
+        master: { assists_min: null, damage_taken_min: 75 },
+      },
+    },
+  };
+
+  test('returns base when no job_threshold_override in cfg', () => {
+    const base = { kills_min: 18, assists_min: 6 };
+    assert.deepEqual(_mergeJobThreshold(base, {}, { job_id: 'custode' }, 'elite'), base);
+  });
+
+  test('returns base when unit has no job_id', () => {
+    const base = { kills_min: 18 };
+    assert.deepEqual(_mergeJobThreshold(base, CFG_OVERRIDE, {}, 'elite'), base);
+  });
+
+  test('returns base when job_id unrecognized', () => {
+    const base = { kills_min: 18, assists_min: 6 };
+    assert.deepEqual(
+      _mergeJobThreshold(base, CFG_OVERRIDE, { job_id: 'guerriero' }, 'elite'),
+      base,
+    );
+  });
+
+  test('returns base when tier override absent (e.g. veteran/captain)', () => {
+    const base = { kills_min: 3 };
+    assert.deepEqual(
+      _mergeJobThreshold(base, CFG_OVERRIDE, { job_id: 'custode' }, 'veteran'),
+      base,
+    );
+  });
+
+  test('null value DELETES base gate', () => {
+    const base = { kills_min: 18, assists_min: 6, objectives_min: 6 };
+    const merged = _mergeJobThreshold(base, CFG_OVERRIDE, { job_id: 'custode' }, 'elite');
+    assert.ok(!('assists_min' in merged), 'assists_min removed by null override');
+    assert.equal(merged.kills_min, 18, 'base kills_min preserved');
+    assert.equal(merged.objectives_min, 6, 'base objectives_min preserved');
+  });
+
+  test('numeric override ADDS new gate metric (damage_taken_min)', () => {
+    const base = { kills_min: 18, assists_min: 6 };
+    const merged = _mergeJobThreshold(base, CFG_OVERRIDE, { job_id: 'custode' }, 'elite');
+    assert.equal(merged.damage_taken_min, 30, 'NEW damage_taken_min gate added');
+  });
+});
+
+describe('Phase B4 — computeUnitMetrics damage_taken accumulator', () => {
+  test('damage_taken aggregates from attack events targeting unit', () => {
+    const unit = { id: 'pg', promotion_tier: 'base' };
+    const events = [
+      _attack('enemy1', 'pg', 1, false, 5),
+      _attack('enemy2', 'pg', 2, false, 7),
+      _attack('enemy1', 'pg', 3, false, 3),
+    ];
+    const m = computeUnitMetrics(unit, events);
+    assert.equal(m.damage_taken, 15);
+  });
+
+  test('damage_taken does NOT include self-attack (defensive)', () => {
+    const unit = { id: 'pg', promotion_tier: 'base' };
+    const events = [
+      _attack('pg', 'pg', 1, false, 10), // self-target — ignored
+    ];
+    const m = computeUnitMetrics(unit, events);
+    assert.equal(m.damage_taken, 0);
+  });
+
+  test('damage_taken zero when no incoming attacks', () => {
+    const unit = { id: 'pg', promotion_tier: 'base' };
+    const events = [_attack('pg', 'enemy1', 1, false, 5)];
+    const m = computeUnitMetrics(unit, events);
+    assert.equal(m.damage_taken, 0);
+  });
+});
+
+describe('Phase B4 — evaluatePromotion custode alt-path', () => {
+  test('custode elite eligible via damage_taken_min (no assists needed)', () => {
+    const custode = _unit('custode', 'captain');
+    // Need 18 kills + 6 objectives + (NEW) damage_taken ≥ 30.
+    // Original assists_min:6 OVERRIDDEN to null (removed gate).
+    const events = [];
+    for (let i = 0; i < 18; i++) {
+      events.push(_attack('pg-custode', `e${i}`, i, true, 3));
+    }
+    // 6 objectives.
+    for (let i = 0; i < 6; i++) {
+      events.push({
+        action_type: 'objective_complete',
+        turn: 100 + i,
+        actor_id: 'pg-custode',
+        result: 'ok',
+      });
+    }
+    // Receive 35 damage (above damage_taken_min=30 threshold).
+    for (let i = 0; i < 7; i++) {
+      events.push(_attack('foe', 'pg-custode', 200 + i, false, 5));
+    }
+    const r = evaluatePromotion(custode, events, FALLBACK_CONFIG);
+    assert.equal(r.next_tier, 'elite');
+    assert.equal(r.eligible, true, `expected eligible: ${r.reason}`);
+  });
+
+  test('custode elite BLOCKED when damage_taken below threshold', () => {
+    const custode = _unit('custode', 'captain');
+    const events = [];
+    for (let i = 0; i < 18; i++) {
+      events.push(_attack('pg-custode', `e${i}`, i, true, 3));
+    }
+    for (let i = 0; i < 6; i++) {
+      events.push({
+        action_type: 'objective_complete',
+        turn: 100 + i,
+        actor_id: 'pg-custode',
+        result: 'ok',
+      });
+    }
+    // Only 10 damage taken (below 30 threshold).
+    for (let i = 0; i < 2; i++) {
+      events.push(_attack('foe', 'pg-custode', 200 + i, false, 5));
+    }
+    const r = evaluatePromotion(custode, events, FALLBACK_CONFIG);
+    assert.equal(r.eligible, false);
+    assert.ok(r.reason.includes('damage_taken'), `reason should mention damage_taken: ${r.reason}`);
+  });
+
+  test('custode threshold preview excludes assists_min (deleted by override)', () => {
+    const custode = _unit('custode', 'captain');
+    const r = evaluatePromotion(custode, [], FALLBACK_CONFIG);
+    assert.equal(r.next_tier, 'elite');
+    assert.ok(!('assists_min' in r.threshold), 'assists_min removed for custode elite');
+    assert.equal(r.threshold.damage_taken_min, 30);
+    assert.equal(r.threshold.kills_min, 18, 'base kills_min preserved');
+  });
+
+  test('guerriero unaffected by custode override (different job)', () => {
+    const guerriero = _unit('guerriero', 'captain');
+    const r = evaluatePromotion(guerriero, [], FALLBACK_CONFIG);
+    assert.equal(r.threshold.assists_min, 6, 'guerriero retains base assists_min');
+    assert.ok(!('damage_taken_min' in r.threshold), 'guerriero has no damage_taken gate');
+  });
+});
+
+describe('Phase B4 — custode master alt-path', () => {
+  test('custode master requires damage_taken ≥ 75', () => {
+    const custode = _unit('custode', 'elite');
+    const r = evaluatePromotion(custode, [], FALLBACK_CONFIG);
+    assert.equal(r.next_tier, 'master');
+    assert.equal(r.threshold.damage_taken_min, 75);
+    assert.ok(!('assists_min' in r.threshold));
+  });
+});

--- a/tests/fixtures/godot-v2-promotions-v0.2.0.json
+++ b/tests/fixtures/godot-v2-promotions-v0.2.0.json
@@ -57,8 +57,8 @@
       "master": { "hp_bonus": 30, "attack_mod_bonus": 5 }
     },
     "esploratore": {
-      "elite": { "initiative_bonus": 5, "defense_mod_bonus": 1 },
-      "master": { "initiative_bonus": 6, "crit_chance_bonus": 8 }
+      "elite": { "initiative_bonus": 4, "defense_mod_bonus": 1 },
+      "master": { "initiative_bonus": 5, "crit_chance_bonus": 8 }
     },
     "tessitore": {
       "elite": { "ability_unlock_tier": "r4", "ability_id_override": "weave_mastery" },
@@ -67,6 +67,12 @@
     "custode": {
       "elite": { "hp_bonus": 20, "defense_mod_bonus": 4 },
       "master": { "hp_bonus": 35, "defense_mod_bonus": 5 }
+    }
+  },
+  "job_threshold_override": {
+    "custode": {
+      "elite": { "assists_min": null, "damage_taken_min": 30 },
+      "master": { "assists_min": null, "damage_taken_min": 75 }
     }
   }
 }


### PR DESCRIPTION
## Context

Closes GSD audit economy-design GAP-003 — custode tank \`assists_min:6/12\` gate unreachable for tank playstyle. Phase B3 (PR #2267) shipped schema anchor in promotions.yaml; Phase B4 engine consumes it.

## Engine changes

\`promotionEngine.js\`:
- NEW \`_mergeJobThreshold(baseThreshold, cfg, unit, targetTier)\` (mirror _mergeJobBias pattern)
  - Numeric override sets new threshold
  - \`null\` DELETES gate (skip threshold check)
- \`evaluatePromotion\`: base_threshold → _mergeJobThreshold → eligibility
- \`_threshold_reasons\`: \`damage_taken_min\` gate added
- \`computeUnitMetrics\`: NEW \`damage_taken\` accumulator (sums damage_dealt when target=our unit, attacker=foe)
- \`FALLBACK_CONFIG\` embeds custode override (\`assists_min: null\` + \`damage_taken_min: 30/75\`)

## Tests

\`tests/api/phase-b4-job-threshold-override.test.js\` — **14 tests**:
- _mergeJobThreshold helper (6 cases)
- damage_taken accumulator (3 cases)
- custode alt-path eligibility (4 cases)
- custode master (1 case)

\`tests/fixtures/godot-v2-promotions-v0.2.0.json\` — synced Godot v2 mainline mirror (cross-stack parity test).

## Cross-link

- ai-station re-analisi: vault PR #5
- Phase B3 schema: PR #2264
- GSD audit Bundle B: PR #2267 (yaml schema added)
- Phase B4 Godot v2 mirror: forthcoming