### PR TITLE
feat(coop): endCombat accepts optional debrief_payload — Godot v2 #269 phone parity wire

### DIFF
--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -259,19 +259,24 @@ function createCoopRouter({ lobby, coopStore } = {}) {
 
   router.post('/coop/combat/end', (req, res) => {
     // Host notifies combat ended (victory/defeat). MVP: host controls.
+    // 2026-05-15 Bundle C follow-up — optional `debrief_payload` carries
+    // 4-layer profilo psicologico (per_actor sentience+conviction+ennea) for
+    // phone DebriefView parity reveal. Computed by host-side combat resolver
+    // via vcScoring.buildVcSnapshot before POST. Back-compat: omit → null.
     const {
       code,
       host_token: hostToken,
       outcome = 'victory',
       xp_earned: xpEarned = 0,
       survivors = [],
+      debrief_payload: debriefPayload = null,
     } = req.body || {};
     const room = authHost(code, hostToken);
     if (!room) return res.status(403).json({ error: 'host_auth_failed' });
     const orch = coopStore.get(code);
     if (!orch) return res.status(409).json({ error: 'run_not_started' });
     try {
-      const result = orch.endCombat({ outcome, xpEarned, survivors });
+      const result = orch.endCombat({ outcome, xpEarned, survivors, debriefPayload });
       broadcastCoopState(room, orch);
       return res.json({ phase: orch.phase, result });
     } catch (err) {

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -598,12 +598,32 @@ class CoopOrchestrator {
 
   /**
    * Mark combat outcome. Moves phase combat → debrief.
+   *
+   * 2026-05-15 Bundle C follow-up — optional `debriefPayload` carries
+   * 4-layer profilo psicologico (sentience + conviction + ennea per actor)
+   * computed by combat resolver via vcScoring.buildVcSnapshot. Attached to
+   * run.debrief for broadcastCoopState → phone DebriefView reveal parity
+   * with TV. Back-compat: default null → no payload, phone hides labels.
+   *
+   * Expected shape (all optional):
+   *   debriefPayload.per_actor[uid] = {
+   *     sentience_tier: "T0"-"T6",
+   *     conviction_axis: {utility, liberty, morality},
+   *     ennea_archetype: "<canonical name>"
+   *   }
    */
-  endCombat({ outcome = 'victory', survivors = [], xpEarned = 0 } = {}) {
+  endCombat({ outcome = 'victory', survivors = [], xpEarned = 0, debriefPayload = null } = {}) {
     if (this.phase !== 'combat') throw new Error('not_in_combat');
     this.run.outcome = outcome;
     this.run.partyXp += xpEarned;
-    this._emit('combat_ended', { outcome, survivors, xp: xpEarned });
+    if (debriefPayload && typeof debriefPayload === 'object') {
+      this.run.debrief = debriefPayload;
+    }
+    const emitPayload = { outcome, survivors, xp: xpEarned };
+    if (debriefPayload && typeof debriefPayload === 'object') {
+      emitPayload.debrief = debriefPayload;
+    }
+    this._emit('combat_ended', emitPayload);
     this._setPhase('debrief');
     return { outcome, xp: xpEarned };
   }

--- a/tests/api/coopEndCombatDebriefPayload.test.js
+++ b/tests/api/coopEndCombatDebriefPayload.test.js
@@ -1,0 +1,98 @@
+// 2026-05-15 Bundle C follow-up — coopOrchestrator.endCombat optional
+// debrief_payload extension test. Closes Phone DebriefView parity wire
+// (mirror Godot v2 #269 PhoneDebriefView psicologico labels).
+//
+// Schema:
+//   debriefPayload.per_actor[uid] = {
+//     sentience_tier: "T0"-"T6",
+//     conviction_axis: {utility, liberty, morality},
+//     ennea_archetype: "<canonical name>"
+//   }
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { CoopOrchestrator } = require('../../apps/backend/services/coop/coopOrchestrator');
+
+function _setupAtCombat() {
+  const co = new CoopOrchestrator({ roomCode: 'DPLD', hostId: 'p_h' });
+  co.startRun({ scenarioStack: ['enc_demo_01'] });
+  co.submitCharacter(
+    'p_h',
+    { name: 'Aria', form_id: 'istj', species_id: 'scagliato', job_id: 'guerriero' },
+    { allPlayerIds: ['p_h'] },
+  );
+  co.confirmWorld();
+  return co;
+}
+
+test('endCombat without debriefPayload (back-compat): run.debrief absent', () => {
+  const co = _setupAtCombat();
+  co.endCombat({ outcome: 'victory', xpEarned: 10 });
+  assert.equal(co.phase, 'debrief');
+  assert.equal(co.run.debrief, undefined, 'run.debrief NOT set on back-compat path');
+});
+
+test('endCombat with debriefPayload attaches to run.debrief', () => {
+  const co = _setupAtCombat();
+  const payload = {
+    per_actor: {
+      pg_alice: {
+        sentience_tier: 'T2',
+        conviction_axis: { utility: 58, liberty: 52, morality: 46 },
+        ennea_archetype: 'Conquistatore',
+      },
+    },
+  };
+  co.endCombat({ outcome: 'victory', debriefPayload: payload });
+  assert.deepEqual(co.run.debrief, payload);
+});
+
+test('endCombat emits combat_ended with debrief field when payload provided', () => {
+  const co = _setupAtCombat();
+  const events = [];
+  co.on((evt) => {
+    if (evt.kind === 'combat_ended') events.push(evt.payload);
+  });
+  const payload = { per_actor: { pg_a: { sentience_tier: 'T3' } } };
+  co.endCombat({ outcome: 'victory', debriefPayload: payload });
+  assert.equal(events.length, 1);
+  assert.deepEqual(events[0].debrief, payload);
+  assert.equal(events[0].outcome, 'victory');
+});
+
+test('endCombat back-compat path does NOT include debrief field in emit', () => {
+  const co = _setupAtCombat();
+  const events = [];
+  co.on((evt) => {
+    if (evt.kind === 'combat_ended') events.push(evt.payload);
+  });
+  co.endCombat({ outcome: 'victory' });
+  assert.equal(events.length, 1);
+  assert.equal('debrief' in events[0], false, 'no debrief field on back-compat emit');
+});
+
+test('endCombat rejects non-object debriefPayload silently (back-compat default)', () => {
+  const co = _setupAtCombat();
+  co.endCombat({ outcome: 'victory', debriefPayload: 'invalid_string' });
+  assert.equal(co.run.debrief, undefined, 'string payload ignored');
+});
+
+test('endCombat accepts empty Dict debriefPayload (valid, empty per_actor)', () => {
+  const co = _setupAtCombat();
+  co.endCombat({ outcome: 'victory', debriefPayload: {} });
+  assert.deepEqual(co.run.debrief, {});
+});
+
+test('endCombat phase advance unaffected by debriefPayload presence', () => {
+  const co = _setupAtCombat();
+  co.endCombat({
+    outcome: 'defeat',
+    xpEarned: 0,
+    debriefPayload: { per_actor: {} },
+  });
+  assert.equal(co.phase, 'debrief');
+  assert.equal(co.run.outcome, 'defeat');
+});


### PR DESCRIPTION
## Summary

Closes cross-stack wire for Godot v2 #269 PhoneDebriefView 4-layer psicologico reveal. Phone players now receive sentience tier + conviction axis + ennea archetype on `combat_ended` broadcast.

## Wire chain

```
Host-side combat resolver computes vcScoring.buildVcSnapshot
  → POST /api/coop/combat/end with debrief_payload body field
  → coopOrchestrator.endCombat({ ..., debriefPayload })
  → run.debrief = payload + combat_ended emit attaches debrief
  → broadcastCoopState surfaces run.debrief in state
  → Phone WS state.run.debrief → PhoneComposer.bind_state
  → PhoneDebriefView._render_psicologico (Godot v2 #269)
```

## Schema

```
debrief_payload.per_actor[uid] = {
  sentience_tier: \"T0\"-\"T6\",                     // RFC v0.1
  conviction_axis: { utility, liberty, morality }, // 50-baseline
  ennea_archetype: \"<canonical name>\"             // 9-canon
}
```

## Back-compat

- `debrief_payload` OMITTED → no behavior change (`run.debrief` absent, emit payload lacks `debrief` field)
- Non-object payload (string/null) → silently rejected
- Empty Dict `{}` → valid (no per_actor data yet)

## Tests

- +7 new GUT `tests/api/coopEndCombatDebriefPayload.test.js`
- Regression 55/55 pass (coopOrchestrator + coopRoutes + coopDebrief)

## Phase-2 follow-up

Host-side combat resolver populates `debrief_payload` from `buildVcSnapshot` at session_ended. Out of scope for this PR (additive wire only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)