### PR TITLE
feat(coop): broadcast debrief_payload type — Phase-3 cross-stack wire closure

### DIFF
--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -79,6 +79,18 @@ function createCoopRouter({ lobby, coopStore } = {}) {
           ready_list: orch.debriefReadyList(allPlayerIds(room)),
         },
       });
+      // 2026-05-15 Bundle C follow-up — surface per-actor 4-layer psicologico
+      // payload to phone clients when host attached it via /coop/combat/end
+      // (PR #2269 wire). Each phone composer extracts its local player slice
+      // and renders PhoneDebriefView labels (Godot v2 #269+#270).
+      // Schema: orch.run.debrief.per_actor[uid] = { sentience_tier,
+      // conviction_axis, ennea_archetype }.
+      if (orch.run?.debrief && typeof orch.run.debrief === 'object') {
+        room.broadcast({
+          type: 'debrief_payload',
+          payload: orch.run.debrief,
+        });
+      }
     }
   }
 

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -1043,6 +1043,14 @@ function rebroadcastCoopState(room, orch) {
         ready_list: orch.debriefReadyList(allIds),
       },
     });
+    // 2026-05-15 Bundle C follow-up — surface 4-layer psicologico payload
+    // post host-transfer (parity with routes/coop.js:broadcastCoopState).
+    if (orch.run?.debrief && typeof orch.run.debrief === 'object') {
+      room.broadcast({
+        type: 'debrief_payload',
+        payload: orch.run.debrief,
+      });
+    }
   }
 }
 

--- a/tests/api/coopBroadcastDebriefPayload.test.js
+++ b/tests/api/coopBroadcastDebriefPayload.test.js
@@ -1,0 +1,135 @@
+// 2026-05-15 Bundle C follow-up — broadcastCoopState emits debrief_payload
+// type when orch.run.debrief present (#2269 wire). Closes phase-3 cross-stack
+// surface for Godot v2 #269 + #270 phone DebriefView reveal.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+
+const { createLobbyRouter } = require('../../apps/backend/routes/lobby');
+const { createCoopRouter } = require('../../apps/backend/routes/coop');
+const { createCoopStore } = require('../../apps/backend/services/coop/coopStore');
+const { LobbyService } = require('../../apps/backend/services/network/wsSession');
+
+function buildApp() {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  // Capture all broadcasts emitted to rooms via LobbyService.
+  const broadcasts = [];
+  const origGetRoom = lobby.getRoom.bind(lobby);
+  lobby.getRoom = function (code) {
+    const room = origGetRoom(code);
+    if (room && !room.__broadcastWrapped) {
+      const origBroadcast = room.broadcast.bind(room);
+      room.broadcast = function (msg) {
+        broadcasts.push({ code, msg });
+        return origBroadcast(msg);
+      };
+      room.__broadcastWrapped = true;
+    }
+    return room;
+  };
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createLobbyRouter({ lobby }));
+  app.use('/api', createCoopRouter({ lobby, coopStore }));
+  return { app, lobby, coopStore, broadcasts };
+}
+
+async function _setupAtCombat(app, broadcasts) {
+  let r = await request(app).post('/api/lobby/create').send({ host_name: 'Host', max_players: 4 });
+  const code = r.body.code;
+  const hostToken = r.body.host_token;
+  r = await request(app).post('/api/lobby/join').send({ code, player_name: 'A' });
+  const playerId = r.body.player_id;
+  const playerToken = r.body.player_token;
+  await request(app)
+    .post('/api/coop/run/start')
+    .send({ code, host_token: hostToken, scenario_stack: ['enc_demo_01'] });
+  await request(app).post('/api/coop/character/create').send({
+    code,
+    player_id: playerId,
+    player_token: playerToken,
+    name: 'A',
+    form_id: 'istj',
+    species_id: 'x',
+    job_id: 'guerriero',
+  });
+  await request(app)
+    .post('/api/coop/world/confirm')
+    .send({ code, host_token: hostToken, scenario_id: 'enc_demo_01' });
+  // Reset broadcast log to only capture debrief-phase emissions.
+  broadcasts.length = 0;
+  return { code, hostToken };
+}
+
+test('broadcastCoopState emits debrief_payload when run.debrief present', async () => {
+  const { app, broadcasts } = buildApp();
+  const { code, hostToken } = await _setupAtCombat(app, broadcasts);
+  const payload = {
+    per_actor: {
+      p_h: {
+        sentience_tier: 'T3',
+        conviction_axis: { utility: 60, liberty: 50, morality: 55 },
+        ennea_archetype: 'Mediatore',
+      },
+    },
+  };
+  const res = await request(app)
+    .post('/api/coop/combat/end')
+    .send({ code, host_token: hostToken, outcome: 'victory', debrief_payload: payload });
+  assert.equal(res.status, 200);
+  const types = broadcasts.map((b) => b.msg.type);
+  assert.ok(types.includes('debrief_payload'), `expected debrief_payload broadcast: ${types}`);
+  const dpMsg = broadcasts.find((b) => b.msg.type === 'debrief_payload');
+  assert.deepEqual(dpMsg.msg.payload, payload);
+});
+
+test('broadcastCoopState skips debrief_payload when payload absent (back-compat)', async () => {
+  const { app, broadcasts } = buildApp();
+  const { code, hostToken } = await _setupAtCombat(app, broadcasts);
+  const res = await request(app)
+    .post('/api/coop/combat/end')
+    .send({ code, host_token: hostToken, outcome: 'victory' });
+  assert.equal(res.status, 200);
+  const types = broadcasts.map((b) => b.msg.type);
+  assert.equal(
+    types.includes('debrief_payload'),
+    false,
+    `no debrief_payload broadcast expected; got: ${types}`,
+  );
+});
+
+test('debrief_payload broadcast ordered after debrief_ready_list', async () => {
+  const { app, broadcasts } = buildApp();
+  const { code, hostToken } = await _setupAtCombat(app, broadcasts);
+  await request(app)
+    .post('/api/coop/combat/end')
+    .send({
+      code,
+      host_token: hostToken,
+      outcome: 'victory',
+      debrief_payload: { per_actor: { p_h: { sentience_tier: 'T4' } } },
+    });
+  const types = broadcasts.map((b) => b.msg.type);
+  const dpIdx = types.indexOf('debrief_payload');
+  const rdyIdx = types.indexOf('debrief_ready_list');
+  assert.ok(dpIdx > rdyIdx, `expected debrief_payload AFTER debrief_ready_list: ${types}`);
+});
+
+test('debrief_payload broadcast NOT emitted in non-debrief phase', async () => {
+  const { app, broadcasts } = buildApp();
+  let r = await request(app).post('/api/lobby/create').send({ host_name: 'Host', max_players: 4 });
+  const code = r.body.code;
+  const hostToken = r.body.host_token;
+  await request(app).post('/api/lobby/join').send({ code, player_name: 'A' });
+  await request(app)
+    .post('/api/coop/run/start')
+    .send({ code, host_token: hostToken, scenario_stack: ['enc_demo_01'] });
+  // No combat → no debrief phase → no debrief_payload broadcast.
+  const types = broadcasts.map((b) => b.msg.type);
+  assert.equal(types.includes('debrief_payload'), false);
+});


### PR DESCRIPTION
## Summary

Closes Phase-3 cross-stack wire (Bundle C wave). Backend publishes 4-layer psicologico payload to all phone clients via WS broadcast type `debrief_payload`. Phone composer (#270) already extracts `per_actor[local_player_id]`.

## Wire chain LIVE end-to-end (cumulative)

```
Host vcScoring.buildVcSnapshot
  → POST /api/coop/combat/end debrief_payload (#2269)
  → orch.run.debrief stored
  → broadcastCoopState emits type=debrief_payload (THIS PR)
  → rebroadcastCoopState emits same after host-transfer (THIS PR)
  → CoopWsPeer state_received Godot v2
  → PhoneComposer._on_state extracts per_actor[local_player_id] (#270)
  → PhoneDebriefView labels VISIBLE (#269)
```

## Broadcast ordering invariant

`phase_change` → `character_ready_list` → `debrief_ready_list` → `debrief_payload`

Phone composer has phase context BEFORE psicologico data arrives.

## Back-compat

- `run.debrief` absent → no debrief_payload broadcast
- Non-object debrief → silently ignored
- Non-debrief phase → debrief_payload NEVER emitted

## Tests

- +4 new GUT `tests/api/coopBroadcastDebriefPayload.test.js`
- Regression 20/20 (coopRoutes + coopEndCombatDebriefPayload + new)

## Bundle C wave 2026-05-14/15 closure (8 PR cumulative)

| PR | Repo | Topic |
|---|---|---|
| #265 | Godot v2 | DebriefView Sentience UI |
| #266 | Godot v2 | VcScoring wire + Conviction UI |
| #267 | Godot v2 | SpeciesCatalog runtime + canonical species_id |
| #268 | Godot v2 | Synthetic Playtest #2 30/30 prod verdict |
| #269 | Godot v2 | PhoneDebriefView phone parity labels |
| #270 | Godot v2 | PhoneComposer extract debrief.per_actor |
| #2268 | Game/ | Phase B4 job_threshold_override engine |
| #2269 | Game/ | endCombat debrief_payload backend wire |
| **#2270** | Game/ | **broadcast surface (THIS)** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)