### PR TITLE
fix(p3): D.5+D.6 v2 fine-grained Italian grammar pass — 7 typo/conjugation fixes

### DIFF
--- a/data/core/species/species_catalog.json
+++ b/data/core/species/species_catalog.json
@@ -1185,7 +1185,7 @@
       "interactions": {
         "predates_on": [],
         "predated_by": [],
-        "symbiosis": "Il pulso termico che irradia stabilizza le colonie batteriche chemiosintetiche della dorsale: senza la sua regolazione, la temperatura fluttua oltre la soglia di tolleranza e tre livelli trofici collassano in una stagione."
+        "symbiosis": "Il polso termico che irradia stabilizza le colonie batteriche chemiosintetiche della dorsale: senza la sua regolazione, la temperatura fluttua oltre la soglia di tolleranza e tre livelli trofici collassano in una stagione."
       },
       "constraints": [
         "Mantenere vivo: rimozione collassa intera rete trofica del bioma"
@@ -1328,7 +1328,7 @@
         "habitat": "unknown"
       },
       "functional_signature": "Specie bridge con corna_psico_conduttive + focus_frazionato.",
-      "visual_description": "Arrampica la caldera glaciale con l'attenzione di chi legge il paesaggio come testo: le corna psico-conduttive captano le correnti ferromagnetiche che altri esseri ignorano, traducendo il silenzio del ghiaccio in informazione navigabile. Abita la soglia tra il freddo e il psionico, curiosa di entrambi.",
+      "visual_description": "Arrampica la caldera glaciale con l'attenzione di chi legge il paesaggio come testo: le corna psico-conduttive captano le correnti ferromagnetiche che altri esseri ignorano, traducendo il silenzio del ghiaccio in informazione navigabile. Abita la soglia tra il freddo e lo psionico, curiosa di entrambi.",
       "risk_profile": {
         "danger_level": 4,
         "vectors": [
@@ -1553,7 +1553,7 @@
         "habitat": "ferrous-badlands"
       },
       "functional_signature": "Specie keystone con adattamenti non specificati.",
-      "visual_description": "Scava nella materia morta con la pazienza di chi sa che il ciclo non ha fretta. Il suo corpo è il confine tra ciò che è stato e ciò che tornerà utile: ogni boccone di detrito che inghiotte è cibo restituito sotto altra forma a tre specie diverse. Toglietelo e la rete trofica inizia a digiunare.",
+      "visual_description": "Scava nella materia morta con la pazienza di chi sa che il ciclo non ha fretta. Il suo corpo è il confine tra ciò che è stato e ciò che tornerà utile: ogni boccone di detrito che inghiotte è cibo restituito sotto altra forma a tre specie diverse. Toglietela e la rete trofica inizia a digiunare.",
       "risk_profile": {
         "danger_level": 1,
         "vectors": []
@@ -2029,7 +2029,7 @@
       "interactions": {
         "predates_on": [],
         "predated_by": [],
-        "symbiosis": "Le membrane eliofiltranti convertono la luce solare in exsudate che fertilizzano il suolo attorno ai percorsi di pascolo: i micro-organismi del suolo prosperano sui suoi sentieri e le specie detritivore seguono la sua rotta stagionale."
+        "symbiosis": "Le membrane eliofiltranti convertono la luce solare in essudati che fertilizzano il suolo attorno ai percorsi di pascolo: i micro-organismi del suolo prosperano sui suoi sentieri e le specie detritivore seguono la sua rotta stagionale."
       },
       "constraints": [
         "Risponde a stimoli immediati senza tattiche multi-step",
@@ -2260,7 +2260,7 @@
       "interactions": {
         "predates_on": [],
         "predated_by": [],
-        "symbiosis": "Le antenne a microonde cavernose mappano cavità invisibili dove le specie troglofile si ricovrano nelle stagioni avverse: i suoi richiami aprono rifugi che altrimenti resterebbero introvabili — è la chiave acustica della sopravvivenza ipogea."
+        "symbiosis": "Le antenne a microonde cavernose mappano cavità invisibili dove le specie troglofile si ricoverano nelle stagioni avverse: i suoi richiami aprono rifugi che altrimenti resterebbero introvabili — è la chiave acustica della sopravvivenza ipogea."
       },
       "constraints": [
         "Specie ponte cross-bioma: migrazione stagionale prevedibile, vulnerabile in transito"
@@ -2421,7 +2421,7 @@
         "habitat": "cold-mirror-fen"
       },
       "functional_signature": "Specie support con adattamenti non specificati.",
-      "visual_description": "Si muove tra le specie brucatrici con una discrezione che la rende quasi invisibile al comportamento collettivo del gregge. Ripara, redistribuisce, occcupa i vuoti che gli altri lasciano senza accorgersene. Il suo contributo si nota solo quando manca.",
+      "visual_description": "Si muove tra le specie brucatrici con una discrezione che la rende quasi invisibile al comportamento collettivo del gregge. Ripara, redistribuisce, occupa i vuoti che gli altri lasciano senza accorgersene. Il suo contributo si nota solo quando manca.",
       "risk_profile": {
         "danger_level": 1,
         "vectors": []
@@ -2755,7 +2755,7 @@
         "habitat": "ashen-sink"
       },
       "functional_signature": "Specie threat con adattamenti non specificati.",
-      "visual_description": "La colorazione cinerea lo rende indistinguibile dai substrati vulcanici su cui riposa per ore. Cacciatore in agguato puro: ogni nodul sporgente del corpo è un punto di ancoraggio che riduce il profilo termico finché la preda non è abbastanza vicina da non avere scelta.",
+      "visual_description": "La colorazione cinerea lo rende indistinguibile dai substrati vulcanici su cui riposa per ore. Cacciatore in agguato puro: ogni nodulo sporgente del corpo è un punto di ancoraggio che riduce il profilo termico finché la preda non è abbastanza vicina da non avere scelta.",
       "risk_profile": {
         "danger_level": 1,
         "vectors": []

--- a/docs/playtest/2026-05-15-d5-d6-fine-grained-review-v2.md
+++ b/docs/playtest/2026-05-15-d5-d6-fine-grained-review-v2.md
@@ -1,0 +1,102 @@
+---
+title: 'D.5 + D.6 Fine-Grained Narrative Review — v2 Italian Grammar Pass'
+date: 2026-05-15
+author: claude-autonomous collaborative master-dd authority
+status: applied
+workstream: dataset-pack
+tags: [species, catalog, polish, fine-grained-review, italian-grammar, v2]
+---
+
+# D.5 + D.6 Fine-Grained Narrative Review — v2 Italian Grammar Pass
+
+## Contesto
+
+Post-merge PR #2272 (squash `a18a86f`) — 36 visual_description + 18 symbiosis polished con per-clade voice register + Skiv-canonical override.
+
+Master-dd authority request: **fine-grained narrative review batch via `review_phase3.py --field visual_description --filter claude-polish`**.
+
+Tool extension: `tools/py/review_phase3.py` esteso con `--filter claude-polish` (substring match su `claude-polish-*` provenance), commit incluso in questa iterazione.
+
+## Review pass metodologia
+
+Per ogni 54 entry polished, critical check su:
+
+1. **Voice register consistency** — clade-appropriate (Apex epico / Keystone solenne / Threat tensa / Bridge curiosa / Support discreta / Playable empatica / Skiv-adjacent desertic)
+2. **Tag coherence** — fatti anatomici grounded su `default_parts` + `functional_signature` + `ecotypes`
+3. **Concrete vs vague** — "tre specie" / "due livelli trofici" / "nicchie" preferiti rispetto a "ecosistema" generic
+4. **Closing punch** — Apex/Threat strong closure, Keystone consequence beat, Bridge soglia/margine, Support understatement
+5. **Italian grammar** — articoli + concordanze + coniugazioni + apocope corrette
+6. **Repetition** across entries (metafore reused)
+
+## Findings — overall quality
+
+**Voice quality**: ALTA. 36 visual + 18 symbiosis tutti rispettano il per-clade register. Zero clade-mismatch. 3 sample exemplary:
+
+- Apex `sp_paludogromus_magnus` Keystone closure: _"Togli il magnus e la palude smette di essere palude — diventa un deserto sommerso."_ — strong consequence + image
+- Support `sp_nebulocornis_mollis` closure: _"Il suo contributo si nota solo quando manca."_ — perfect understatement
+- Bridge `sp_zephyrovum_fidelis` symbiosis: _"Trasporta il futuro genetico altrui come bagaglio inconsapevole."_ — beautiful Skiv-style
+
+**Repetition** (minor, not requiring fix):
+
+- "Si muove" opens 3 entries across different clades (acceptable variation)
+- "Senza..." consequence used 8× Keystone (canonical Solenne register, not over-used by design)
+
+## Findings — 7 issues fixed
+
+Italian grammar/typo issues caught:
+
+| #   | Species                  | Field                  | Issue                                 | Fix                |
+| --- | ------------------------ | ---------------------- | ------------------------------------- | ------------------ |
+| 1   | `sp_nebulocornis_mollis` | visual_description     | "occcupa" (typo c×3)                  | "occupa"           |
+| 2   | `sp_cinerastra_nodosa`   | visual_description     | "nodul sporgente" (apocope errata)    | "nodulo sporgente" |
+| 3   | `sp_cavatympa_sonans`    | interactions.symbiosis | "si ricovrano" (coniug. errata)       | "si ricoverano"    |
+| 4   | `sp_ferriscroba_detrita` | visual_description     | "Toglietelo" (specie = femm.)         | "Toglietela"       |
+| 5   | `psionerva_montis`       | visual_description     | "il psionico" (art. ps impura → lo)   | "lo psionico"      |
+| 6   | `symbiotica_thermalis`   | interactions.symbiosis | "Il pulso termico" (preferisci polso) | "Il polso termico" |
+| 7   | `sp_arenaceros_placidus` | interactions.symbiosis | "exsudate" (loanword)                 | "essudati" (it.)   |
+
+Total: 14 char delta (7 ins + 7 del). Zero schema change. Zero `_provenance` change (fixes preservano la provenance tag claude-polish-\*).
+
+## Apply script
+
+`tools/py/apply_phase3_polish_d5_d6_v2_fixes.py` — surgical substring replace via Python:
+
+```python
+FIXES = [
+    ("sp_nebulocornis_mollis typo c×3", "occcupa", "occupa"),
+    ("sp_cinerastra_nodosa apocope", "nodul sporgente", "nodulo sporgente"),
+    # ... 7 total
+]
+```
+
+Safety:
+
+- Verifica unicità pre-apply (count == 1 per ogni substring)
+- Parse JSON post-replace per validare struttura
+- Re-write con `ensure_ascii=False, indent=2` (UTF-8 explicit per CLAUDE.md §Encoding Discipline)
+
+## Verify gates
+
+- ✅ `python3 tools/py/apply_phase3_polish_d5_d6_v2_fixes.py` — 7/7 fix applicati
+- ✅ `python3 tools/py/game_cli.py validate-datasets` — 14 controlli 0 avvisi
+- ✅ `PYTHONPATH=tools/py pytest tests/test_phase3_path_d_tools.py` — 17/17 verde
+- ✅ `node --test tests/services/beastBondCatalogIntegrity.test.js` — 5/5 verde
+- ✅ `node --test tests/api/envelope-b-data-integrity.test.js` — 25/25 verde
+- ✅ Diff stat: 14 char delta, zero schema change
+
+## Outstanding (post v2)
+
+- **Master-dd narrative review pass** opzionale ulteriore — la voice quality è ALTA, ulteriori fini-tune sono optional polish
+- **Phase 4d Scope B** Game-Database cross-stack execution (MCP out-of-scope, manual cherry-pick — PR template ready)
+
+## Cross-link
+
+- Previous PR: #2272 merged squash `a18a86f` (D.5+D.6 batch polish)
+- Closure PR: #2271 merged squash `66be60b` (Q1 Option A canonical migration)
+- ADR: `docs/adr/ADR-2026-05-15-species-catalog-schema-fork-resolution.md`
+- Museum methodology: `docs/museum/cards/phase-3-path-d-hybrid-pattern-abc.md` (M-2026-05-15-001 score 5/5)
+- Polish batch report: `docs/playtest/2026-05-15-d5-d6-polish-collaborative-batch.md`
+- Voice canonical Skiv: `docs/skiv/CANONICAL.md`
+- Polish script: `tools/py/apply_phase3_polish_d5_d6.py` (initial polish)
+- Fixes script: `tools/py/apply_phase3_polish_d5_d6_v2_fixes.py` (this iteration)
+- Review tool: `tools/py/review_phase3.py` (`--filter claude-polish` extension this iteration)

--- a/tools/py/apply_phase3_polish_d5_d6_v2_fixes.py
+++ b/tools/py/apply_phase3_polish_d5_d6_v2_fixes.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+apply_phase3_polish_d5_d6_v2_fixes.py
+Fine-grained Italian grammar/typo fixes post-D.5+D.6 polish batch (PR #2272 merged).
+
+Issues found in fine-grained narrative review pass:
+1. sp_nebulocornis_mollis visual: "occcupa" (typo c×3) → "occupa"
+2. sp_cinerastra_nodosa visual: "nodul sporgente" (apocope errata) → "nodulo sporgente"
+3. sp_cavatympa_sonans symbiosis: "si ricovrano" (coniug. errata) → "si ricoverano"
+4. sp_ferriscroba_detrita visual: "Toglietelo" → "Toglietela" (specie femm.)
+5. psionerva_montis visual: "il psionico" → "lo psionico" (art. ps impura)
+6. symbiotica_thermalis symbiosis: "Il pulso termico" → "Il polso termico"
+7. sp_arenaceros_placidus symbiosis: "exsudate" → "essudati" (italianizzazione)
+
+All fixes are unique substring replacements verified pre-apply.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+CATALOG_PATH = Path(__file__).parent.parent.parent / "data/core/species/species_catalog.json"
+
+FIXES = [
+    # (description, old_substring, new_substring)
+    ("sp_nebulocornis_mollis typo c×3", "occcupa", "occupa"),
+    ("sp_cinerastra_nodosa apocope", "nodul sporgente", "nodulo sporgente"),
+    ("sp_cavatympa_sonans coniug.", "si ricovrano", "si ricoverano"),
+    ("sp_ferriscroba_detrita specie femm.", "Toglietelo e la rete trofica", "Toglietela e la rete trofica"),
+    ("psionerva_montis art. ps impura", "il freddo e il psionico", "il freddo e lo psionico"),
+    ("symbiotica_thermalis pulso→polso", "Il pulso termico che irradia", "Il polso termico che irradia"),
+    ("sp_arenaceros_placidus italianizz.", "luce solare in exsudate", "luce solare in essudati"),
+]
+
+
+def apply_fixes(catalog_path: Path) -> int:
+    with open(catalog_path, encoding="utf-8") as f:
+        text = f.read()
+
+    applied = 0
+    skipped = []
+    for desc, old, new in FIXES:
+        count = text.count(old)
+        if count == 0:
+            skipped.append((desc, old, "not-found"))
+            continue
+        if count > 1:
+            skipped.append((desc, old, f"multiple-{count}"))
+            continue
+        text = text.replace(old, new)
+        applied += 1
+        print(f"  OK: {desc:40} '{old}' → '{new}'")
+
+    if skipped:
+        print("\nSkipped:")
+        for desc, old, reason in skipped:
+            print(f"  SKIP: {desc:40} '{old}' ({reason})")
+
+    # Parse + write back (preserves JSON structure + reformats consistently)
+    data = json.loads(text)
+    with open(catalog_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+    print(f"\nApplied {applied}/{len(FIXES)} fixes. Catalog rewritten UTF-8.")
+    return applied
+
+
+if __name__ == "__main__":
+    path = Path(sys.argv[1]) if len(sys.argv) > 1 else CATALOG_PATH
+    if not path.exists():
+        print(f"ERROR: {path} not found", file=sys.stderr)
+        sys.exit(1)
+    n = apply_fixes(path)
+    sys.exit(0 if n == len(FIXES) else 1)

--- a/tools/py/review_phase3.py
+++ b/tools/py/review_phase3.py
@@ -98,6 +98,8 @@ def main():
                 match = field_prov == "needs-master-dd"
             elif args.filter == "default":
                 match = "default" in field_prov
+            elif args.filter == "claude-polish":
+                match = "claude-polish" in field_prov
             else:
                 match = field_prov == args.filter
             if match:


### PR DESCRIPTION
## Summary

Fine-grained narrative review post-PR-#2272 via `tools/py/review_phase3.py --field visual_description --filter claude-polish` (54 entries reviewed critically).

**Voice quality overall ALTA**: zero clade-mismatch, register consistency 100%. 7 Italian grammar/typo issues caught and fixed surgically.

## Issues fixed (7)

| # | Species | Field | Issue | Fix |
|---|---------|-------|-------|-----|
| 1 | `sp_nebulocornis_mollis` | visual_description | "occcupa" (typo c×3) | "occupa" |
| 2 | `sp_cinerastra_nodosa` | visual_description | "nodul sporgente" (apocope errata) | "nodulo sporgente" |
| 3 | `sp_cavatympa_sonans` | interactions.symbiosis | "si ricovrano" (coniug. errata) | "si ricoverano" |
| 4 | `sp_ferriscroba_detrita` | visual_description | "Toglietelo" (specie = femm.) | "Toglietela" |
| 5 | `psionerva_montis` | visual_description | "il psionico" (art. ps impura → lo) | "lo psionico" |
| 6 | `symbiotica_thermalis` | interactions.symbiosis | "Il pulso termico" (preferisci polso) | "Il polso termico" |
| 7 | `sp_arenaceros_placidus` | interactions.symbiosis | "exsudate" (loanword) | "essudati" (it.) |

**Delta**: 14 char (7 ins + 7 del). Zero schema change. `_provenance` preserved.

## Tool extension

`tools/py/review_phase3.py` esteso con `--filter claude-polish` (substring match su `claude-polish-*` provenance). Enables future master-dd batch review queue su entries post-polish.

## Voice quality findings (no fix needed)

**3 sample exemplary** (confirmano qualità register):

- Apex `sp_paludogromus_magnus` Keystone closure: _"Togli il magnus e la palude smette di essere palude — diventa un deserto sommerso."_ — strong consequence + image
- Support `sp_nebulocornis_mollis` closure: _"Il suo contributo si nota solo quando manca."_ — perfect understatement
- Bridge `sp_zephyrovum_fidelis` symbiosis: _"Trasporta il futuro genetico altrui come bagaglio inconsapevole."_ — beautiful Skiv-style

**Repetition** (minor, NOT requiring fix):
- "Si muove" opens 3 entries across different clades (acceptable variation)
- "Senza..." consequence used 8× Keystone (canonical SOLENNE register, not over-used by design)

## Verify gates

- ✅ `python3 tools/py/apply_phase3_polish_d5_d6_v2_fixes.py` — 7/7 fix applicati
- ✅ `python3 tools/py/game_cli.py validate-datasets` — 14 controlli 0 avvisi
- ✅ `PYTHONPATH=tools/py pytest tests/test_phase3_path_d_tools.py` — 17/17 verde
- ✅ `node --test tests/services/beastBondCatalogIntegrity.test.js` — 5/5 verde
- ✅ `node --test tests/api/envelope-b-data-integrity.test.js` — 25/25 verde

## Files

- `data/core/species/species_catalog.json` — 14 char delta (7 surgical fixes)
- `tools/py/apply_phase3_polish_d5_d6_v2_fixes.py` — fix script (substring uniqueness check + JSON re-write UTF-8)
- `tools/py/review_phase3.py` — extended with `--filter claude-polish`
- `docs/playtest/2026-05-15-d5-d6-fine-grained-review-v2.md` — review methodology + findings report

## Outstanding

- **Master-dd narrative review pass** ulteriore — opzionale, voice quality è ALTA
- **Phase 4d Scope B** Game-Database cross-stack execution (MCP out-of-scope, manual cherry-pick — PR template ready)

## Cross-link

- Previous PR: #2272 merged squash `a18a86f` (D.5+D.6 batch polish)
- Closure PR: #2271 merged squash `66be60b` (Q1 Option A canonical migration)
- ADR: `docs/adr/ADR-2026-05-15-species-catalog-schema-fork-resolution.md`
- Museum methodology: `docs/museum/cards/phase-3-path-d-hybrid-pattern-abc.md` (M-2026-05-15-001 score 5/5)
- Voice canonical Skiv: `docs/skiv/CANONICAL.md`

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6srUa68gNCio67sLwyqY7)_