### PR TITLE
feat(coop): vcSnapshotToDebriefPayload serializer — cross-stack parity Godot v2

### DIFF
--- a/apps/backend/services/coop/vcSnapshotToDebriefPayload.js
+++ b/apps/backend/services/coop/vcSnapshotToDebriefPayload.js
@@ -1,0 +1,87 @@
+// 2026-05-15 Bundle C cross-stack parity — vcScoring snapshot → debrief_payload
+// flatten transform. Mirror Godot v2 DebriefState.to_debrief_payload (PR #274).
+//
+// Provides Game/-side serializer for host-driven endCombat OR future
+// server-driven debrief_payload broadcast (parity with #2276 surface).
+//
+// Input shape (vcScoring.buildVcSnapshot per_actor):
+//   {
+//     raw_metrics, aggregate_indices, mbti_axes, mbti_type,
+//     ennea_archetypes: Array<{name?: string, ...}>,
+//     conviction_axis: { utility, liberty, morality, events_classified },
+//     sentience: { tier: "T0"-"T6", source: string }
+//   }
+//
+// Output shape (debrief_payload schema PINNED Godot v2 #276):
+//   {
+//     per_actor: {
+//       <uid>: {
+//         sentience_tier: "T0"-"T6",
+//         conviction_axis: { utility, liberty, morality },  // 3 keys, int
+//         ennea_archetype: "<canonical IT name>"             // single primary
+//       }
+//     }
+//   }
+//
+// Cross-stack contract: PR #276 schema parity snapshot Godot v2.
+'use strict';
+
+const CANONICAL_AXIS_KEYS = ['utility', 'liberty', 'morality'];
+
+/**
+ * Flatten vcScoring buildVcSnapshot per_actor to debrief_payload schema.
+ *
+ * @param {object} vcSnapshot — output of vcScoring.buildVcSnapshot(session, config)
+ * @returns {object} debrief_payload `{per_actor: {<uid>: {...3 layers...}}}`
+ */
+function vcSnapshotToDebriefPayload(vcSnapshot) {
+  const payload = { per_actor: {} };
+  if (!vcSnapshot || typeof vcSnapshot !== 'object') return payload;
+  const perActor = vcSnapshot.per_actor;
+  if (!perActor || typeof perActor !== 'object') return payload;
+
+  for (const [uid, actorData] of Object.entries(perActor)) {
+    if (!actorData || typeof actorData !== 'object') continue;
+    const entry = {};
+
+    // Sentience: tier flatten (skip source meta).
+    const sent = actorData.sentience;
+    if (sent && typeof sent === 'object' && typeof sent.tier === 'string') {
+      entry.sentience_tier = sent.tier;
+    }
+
+    // Conviction: keep 3 canonical keys only, coerce to int (drop events_classified).
+    const axis = actorData.conviction_axis;
+    if (axis && typeof axis === 'object') {
+      const flatAxis = {};
+      for (const key of CANONICAL_AXIS_KEYS) {
+        if (key in axis && typeof axis[key] === 'number') {
+          flatAxis[key] = Math.round(axis[key]);
+        }
+      }
+      if (Object.keys(flatAxis).length === CANONICAL_AXIS_KEYS.length) {
+        entry.conviction_axis = flatAxis;
+      }
+    }
+
+    // Ennea: primary archetype (first fired). Array of objects with .name field.
+    const ennea = actorData.ennea_archetypes;
+    if (Array.isArray(ennea) && ennea.length > 0) {
+      const primary = ennea[0];
+      if (primary && typeof primary === 'object' && typeof primary.name === 'string') {
+        entry.ennea_archetype = primary.name;
+      } else if (typeof primary === 'string') {
+        // Defensive: accept bare-string array shape too.
+        entry.ennea_archetype = primary;
+      }
+    }
+
+    // Skip unit with zero meaningful surface (preserve back-compat).
+    if (Object.keys(entry).length > 0) {
+      payload.per_actor[uid] = entry;
+    }
+  }
+  return payload;
+}
+
+module.exports = { vcSnapshotToDebriefPayload, CANONICAL_AXIS_KEYS };

--- a/tests/api/vcSnapshotToDebriefPayload.test.js
+++ b/tests/api/vcSnapshotToDebriefPayload.test.js
@@ -1,0 +1,152 @@
+// 2026-05-15 Bundle C cross-stack parity — Game/-side debrief_payload serializer.
+// Mirrors Godot v2 DebriefState.to_debrief_payload + #276 schema parity snapshot.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  vcSnapshotToDebriefPayload,
+  CANONICAL_AXIS_KEYS,
+} = require('../../apps/backend/services/coop/vcSnapshotToDebriefPayload');
+
+function _snap(perActor) {
+  return { session_id: 'test', per_actor: perActor, meta: {} };
+}
+
+function _fullActor(opts = {}) {
+  return {
+    raw_metrics: {},
+    aggregate_indices: {},
+    mbti_axes: {},
+    mbti_type: 'INTJ',
+    ennea_archetypes: opts.ennea ?? [{ name: 'Conquistatore' }],
+    conviction_axis: opts.axis ?? {
+      utility: 60,
+      liberty: 50,
+      morality: 55,
+      events_classified: 4,
+    },
+    sentience: opts.sent ?? { tier: 'T3', source: 'species_catalog' },
+  };
+}
+
+test('null/non-object input returns empty per_actor', () => {
+  assert.deepEqual(vcSnapshotToDebriefPayload(null), { per_actor: {} });
+  assert.deepEqual(vcSnapshotToDebriefPayload(undefined), { per_actor: {} });
+  assert.deepEqual(vcSnapshotToDebriefPayload(42), { per_actor: {} });
+});
+
+test('snapshot without per_actor returns empty', () => {
+  assert.deepEqual(vcSnapshotToDebriefPayload({}), { per_actor: {} });
+});
+
+test('full actor serializes all 3 layers', () => {
+  const out = vcSnapshotToDebriefPayload(_snap({ pg_alice: _fullActor() }));
+  const entry = out.per_actor.pg_alice;
+  assert.equal(entry.sentience_tier, 'T3');
+  assert.deepEqual(entry.conviction_axis, { utility: 60, liberty: 50, morality: 55 });
+  assert.equal(entry.ennea_archetype, 'Conquistatore');
+});
+
+test('conviction_axis drops events_classified (4 keys → 3 canonical)', () => {
+  const out = vcSnapshotToDebriefPayload(_snap({ pg: _fullActor() }));
+  const axis = out.per_actor.pg.conviction_axis;
+  assert.deepEqual(Object.keys(axis).sort(), CANONICAL_AXIS_KEYS.slice().sort());
+  assert.equal('events_classified' in axis, false);
+});
+
+test('conviction_axis missing canonical key → axis omitted (back-compat)', () => {
+  const actor = _fullActor({ axis: { utility: 60, liberty: 50 } }); // morality missing
+  const out = vcSnapshotToDebriefPayload(_snap({ pg: actor }));
+  assert.equal('conviction_axis' in out.per_actor.pg, false);
+});
+
+test('conviction_axis float values rounded to int', () => {
+  const actor = _fullActor({
+    axis: { utility: 60.7, liberty: 50.2, morality: 55.5, events_classified: 0 },
+  });
+  const out = vcSnapshotToDebriefPayload(_snap({ pg: actor }));
+  const axis = out.per_actor.pg.conviction_axis;
+  assert.equal(axis.utility, 61);
+  assert.equal(axis.liberty, 50);
+  assert.equal(axis.morality, 56);
+});
+
+test('ennea_archetypes empty array → ennea_archetype omitted', () => {
+  const out = vcSnapshotToDebriefPayload(_snap({ pg: _fullActor({ ennea: [] }) }));
+  assert.equal('ennea_archetype' in out.per_actor.pg, false);
+});
+
+test('ennea_archetypes first object .name picked', () => {
+  const out = vcSnapshotToDebriefPayload(
+    _snap({ pg: _fullActor({ ennea: [{ name: 'Mediatore' }, { name: 'Stoico' }] }) }),
+  );
+  assert.equal(out.per_actor.pg.ennea_archetype, 'Mediatore');
+});
+
+test('ennea_archetypes bare-string fallback supported', () => {
+  const out = vcSnapshotToDebriefPayload(_snap({ pg: _fullActor({ ennea: ['Riformatore'] }) }));
+  assert.equal(out.per_actor.pg.ennea_archetype, 'Riformatore');
+});
+
+test('sentience without tier → sentience_tier omitted', () => {
+  const out = vcSnapshotToDebriefPayload(
+    _snap({ pg: _fullActor({ sent: { source: 'default-fallback' } }) }),
+  );
+  assert.equal('sentience_tier' in out.per_actor.pg, false);
+});
+
+test('actor with zero meaningful surface omitted entirely', () => {
+  const empty = {
+    raw_metrics: {},
+    aggregate_indices: {},
+    mbti_axes: {},
+    mbti_type: 'INTJ',
+    ennea_archetypes: [],
+    conviction_axis: { utility: 50 }, // missing 2 canonical keys → axis dropped
+    sentience: { source: 'default-fallback' }, // tier missing
+  };
+  const out = vcSnapshotToDebriefPayload(_snap({ pg_empty: empty }));
+  assert.equal('pg_empty' in out.per_actor, false);
+});
+
+test('multi-actor preserves all units with meaningful data', () => {
+  const out = vcSnapshotToDebriefPayload(
+    _snap({
+      pg_a: _fullActor({ sent: { tier: 'T2', source: 'species_catalog' } }),
+      pg_b: _fullActor({ sent: { tier: 'T5', source: 'species_catalog' } }),
+    }),
+  );
+  assert.equal(Object.keys(out.per_actor).length, 2);
+  assert.equal(out.per_actor.pg_a.sentience_tier, 'T2');
+  assert.equal(out.per_actor.pg_b.sentience_tier, 'T5');
+});
+
+test('JSON roundtrip preserves schema (HTTP POST contract)', () => {
+  const out = vcSnapshotToDebriefPayload(_snap({ pg: _fullActor() }));
+  const roundtrip = JSON.parse(JSON.stringify(out));
+  assert.deepEqual(roundtrip, out);
+});
+
+test('integration: buildVcSnapshot output → debrief_payload schema', () => {
+  // Real-world integration: feed actual vcScoring output through serializer.
+  const { buildVcSnapshot } = require('../../apps/backend/services/vcScoring');
+  const session = {
+    units: [{ id: 'pg_skiv', species_id: 'dune_stalker', applied_traits: [] }],
+    events: Array.from({ length: 6 }, (_, i) => ({
+      action_type: 'attack',
+      actor_id: 'pg_skiv',
+      target_id: 'enemy',
+      turn: i + 1,
+      damage_dealt: 5,
+    })),
+  };
+  const snap = buildVcSnapshot(session, {});
+  const payload = vcSnapshotToDebriefPayload(snap);
+  // dune_stalker has sentience tier T2 in species_catalog.
+  assert.equal(payload.per_actor.pg_skiv.sentience_tier, 'T2');
+  // Conviction axis baseline.
+  assert.equal(payload.per_actor.pg_skiv.conviction_axis.utility, 50);
+});


### PR DESCRIPTION
## Summary

Game/-side serializer for `vcScoring.buildVcSnapshot per_actor` → `debrief_payload` canonical schema. Mirrors Godot v2 `DebriefState.to_debrief_payload` (PR #274). Canonical schema pinned by Godot v2 #276 cross-stack parity snapshot.

## Use cases

- **Host-driven flow (current)**: host computes vcScoring + manually flattens before POST `/coop/combat/end`. This helper standardizes shape.
- **Server-driven flow (future)**: if backend computes vcScoring server-side, this serializer ready for direct broadcast wire.

## Transform

```
Input (vcScoring per_actor):
  ennea_archetypes: Array<{name?: string}>
  conviction_axis: {utility, liberty, morality, events_classified}
  sentience: {tier, source}

Output (debrief_payload canonical):
  per_actor: {
    <uid>: {
      sentience_tier: \"T0\"-\"T6\",                   // tier flatten
      conviction_axis: {utility, liberty, morality}, // 3 keys int-rounded
      ennea_archetype: \"<canonical IT name>\"        // primary [0]
    }
  }
```

## Tests (14 GUT)

null/undefined / no per_actor / full 3-layer / drop events_classified / missing canonical key / float-to-int rounding / ennea empty / ennea object pick / ennea bare-string / sentience no-tier / zero-surface omit / multi-actor / JSON roundtrip / **integration: real buildVcSnapshot → serializer end-to-end**

## Bundle C cross-stack closure tally

- Godot v2 #265-#277 (12 PR)
- Game/ #2268+#2269+#2276 + **THIS** (4 PR)
- 16 PR cumulative cross-stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)