### PR TITLE
fix(coop): pick triggered ennea + use id (Codex P2 follow-up #2277)

### DIFF
--- a/apps/backend/services/coop/vcSnapshotToDebriefPayload.js
+++ b/apps/backend/services/coop/vcSnapshotToDebriefPayload.js
@@ -64,15 +64,20 @@ function vcSnapshotToDebriefPayload(vcSnapshot) {
       }
     }
 
-    // Ennea: primary archetype (first fired). Array of objects with .name field.
+    // Ennea: primary triggered archetype. Real vcScoring shape is
+    // {id, triggered, condition, reason?} (NOT {.name}). Pick first triggered
+    // entry; if none, omit ennea_archetype. Codex P2 fix on PR #2277.
     const ennea = actorData.ennea_archetypes;
     if (Array.isArray(ennea) && ennea.length > 0) {
-      const primary = ennea[0];
-      if (primary && typeof primary === 'object' && typeof primary.name === 'string') {
-        entry.ennea_archetype = primary.name;
-      } else if (typeof primary === 'string') {
-        // Defensive: accept bare-string array shape too.
-        entry.ennea_archetype = primary;
+      // Pick first triggered entry (NOT [0] which may be untriggered).
+      const primary = ennea.find((e) => e && typeof e === 'object' && e.triggered === true);
+      if (primary && typeof primary.id === 'string') {
+        entry.ennea_archetype = primary.id;
+      }
+      // Defensive bare-string fallback (legacy back-compat; real buildVcSnapshot
+      // never emits bare strings).
+      else if (typeof ennea[0] === 'string') {
+        entry.ennea_archetype = ennea[0];
       }
     }
 

--- a/tests/api/vcSnapshotToDebriefPayload.test.js
+++ b/tests/api/vcSnapshotToDebriefPayload.test.js
@@ -21,7 +21,9 @@ function _fullActor(opts = {}) {
     aggregate_indices: {},
     mbti_axes: {},
     mbti_type: 'INTJ',
-    ennea_archetypes: opts.ennea ?? [{ name: 'Conquistatore' }],
+    ennea_archetypes: opts.ennea ?? [
+      { id: 'enn_conquistatore', triggered: true, condition: { gt: ['agg', 50] } },
+    ],
     conviction_axis: opts.axis ?? {
       utility: 60,
       liberty: 50,
@@ -47,7 +49,7 @@ test('full actor serializes all 3 layers', () => {
   const entry = out.per_actor.pg_alice;
   assert.equal(entry.sentience_tier, 'T3');
   assert.deepEqual(entry.conviction_axis, { utility: 60, liberty: 50, morality: 55 });
-  assert.equal(entry.ennea_archetype, 'Conquistatore');
+  assert.equal(entry.ennea_archetype, 'enn_conquistatore');
 });
 
 test('conviction_axis drops events_classified (4 keys → 3 canonical)', () => {
@@ -81,9 +83,16 @@ test('ennea_archetypes empty array → ennea_archetype omitted', () => {
 
 test('ennea_archetypes first object .name picked', () => {
   const out = vcSnapshotToDebriefPayload(
-    _snap({ pg: _fullActor({ ennea: [{ name: 'Mediatore' }, { name: 'Stoico' }] }) }),
+    _snap({
+      pg: _fullActor({
+        ennea: [
+          { id: 'enn_mediatore', triggered: true, condition: {} },
+          { id: 'enn_stoico', triggered: true, condition: {} },
+        ],
+      }),
+    }),
   );
-  assert.equal(out.per_actor.pg.ennea_archetype, 'Mediatore');
+  assert.equal(out.per_actor.pg.ennea_archetype, 'enn_mediatore');
 });
 
 test('ennea_archetypes bare-string fallback supported', () => {
@@ -149,4 +158,27 @@ test('integration: buildVcSnapshot output → debrief_payload schema', () => {
   assert.equal(payload.per_actor.pg_skiv.sentience_tier, 'T2');
   // Conviction axis baseline.
   assert.equal(payload.per_actor.pg_skiv.conviction_axis.utility, 50);
+});
+
+test('untriggered ennea entries are filtered out (real vcScoring shape)', () => {
+  const actor = _fullActor({
+    ennea: [
+      { id: 'enn_riformatore', triggered: false, condition: {}, reason: 'missing:agg' },
+      { id: 'enn_mediatore', triggered: false, condition: {} },
+    ],
+  });
+  const out = vcSnapshotToDebriefPayload(_snap({ pg: actor }));
+  assert.equal('ennea_archetype' in out.per_actor.pg, false);
+});
+
+test('mixed triggered/untriggered picks first triggered', () => {
+  const actor = _fullActor({
+    ennea: [
+      { id: 'enn_a', triggered: false, condition: {} },
+      { id: 'enn_b', triggered: true, condition: {} },
+      { id: 'enn_c', triggered: true, condition: {} },
+    ],
+  });
+  const out = vcSnapshotToDebriefPayload(_snap({ pg: actor }));
+  assert.equal(out.per_actor.pg.ennea_archetype, 'enn_b');
 });


### PR DESCRIPTION
## Summary

Follow-up to merged PR #2277 (vcSnapshotToDebriefPayload serializer) addressing Codex P2 inline finding that was unaddressed at merge time.

## Timeline

- 14:44:06 UTC -- #2277 opened by autoresearch
- 14:45:46 UTC -- Codex auto-review filed P2 inline on `vcSnapshotToDebriefPayload.js:72`
- 14:47:31 UTC -- #2277 **merged** (P2 unresolved)
- 17:45+ UTC -- codemasterdd audit discovered the merged-with-finding state -> follow-up

## Issue

Codex inline P2 finding: serializer assumed `ennea[0].name` shape, but real `computeEnneaArchetypes` (`apps/backend/services/vcScoring.js`) returns entries shaped `{id, triggered, condition, reason?}` -- **zero `.name` field**.

**Empirical verify** via `gh api` on vcScoring.js source confirmed the finding. Without fix, host-driven `buildVcSnapshot -> vcSnapshotToDebriefPayload` silently omits `ennea_archetype` from debrief_payload even when archetypes fired -> debrief clients never receive the Ennea label.

## Fix

### `apps/backend/services/coop/vcSnapshotToDebriefPayload.js` (lines 67-78)

- Pick first entry where `e.triggered === true` (NOT blindly `[0]` which may be untriggered)
- Use `e.id` as canonical label
- Preserve defensive bare-string fallback for legacy back-compat tests

### `tests/api/vcSnapshotToDebriefPayload.test.js`

- `_fullActor` default mock: `[{name: 'Conquistatore'}]` → `[{id: 'enn_conquistatore', triggered: true, condition: {...}}]` (real vcScoring shape)
- Updated 'full actor serializes all 3 layers' assertion to use new id
- Updated 'first object picked' mock + assertion
- **NEW test**: `untriggered ennea entries are filtered out (real vcScoring shape)` -- verifica omit quando tutte `triggered:false`
- **NEW test**: `mixed triggered/untriggered picks first triggered` -- verifica skip untriggered + pick first triggered

## Verification

```
cd Game && node tests/api/vcSnapshotToDebriefPayload.test.js
ℹ tests 16
ℹ pass 16
ℹ fail 0
```

14 realigned existing tests + 2 new tests pass.

## Cognitive protocols applied

- P1 Refresh-verify: applied AFTER discovery -- this PR exists because Protocol 1 was NOT applied pre-#2277-review-action (assumed PR open from earlier audit, didn't re-verify state at time of mention). Lesson candidate L-029 documented.
- P2 Autoresearch Step 0 (per L-2026-05-025 + ADR-0026 amendment): YES -- `gh api ground truth on vcScoring.js source` confirmed Codex P2 finding pre-fix
- P3-P6: NO

## Related

- Original PR #2277 (merged with P2 unaddressed)
- Codex inline P2 review on #2277
- Lesson L-2026-05-028 (gh pr view default doesn't show inline -- which would have caught this earlier if check applied pre-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)