### PR TITLE
feat(playtest2): Envelope A — sim→analyzer telemetry bridge

### DIFF
--- a/.github/workflows/ai-sim-nightly.yml
+++ b/.github/workflows/ai-sim-nightly.yml
@@ -145,6 +145,38 @@ jobs:
           fi
         continue-on-error: true
 
+      # Envelope A A5 — playtest #2 telemetry bridge + analyzer.
+      # Runs AFTER batch + threshold eval, BEFORE artifact upload, so the
+      # analyzer report + machine JSON ride along in the same artifact.
+      # No workflow_dispatch of other workflows; rides this existing cron.
+      # Synthetic sim runs count toward the analyzer --min-sample 30 gate
+      # (no userland required). First ~5 nightly runs are baseline-bootstrap
+      # — this step does NOT add regression gating (no `exit 1` here);
+      # the existing check-thresholds.js remains the only WR drift gate.
+      - name: Playtest #2 telemetry bridge + analyzer
+        if: always()
+        continue-on-error: true
+        run: |
+          set +e
+          BATCH_DIR=/tmp/ai-sim-nightly/batch-current
+          if [ ! -d "$BATCH_DIR/runs" ]; then
+            echo "No batch runs dir ($BATCH_DIR/runs) — skipping playtest #2 analysis"
+            exit 0
+          fi
+          node tools/sim/telemetry-bridge.js --in "$BATCH_DIR"
+          DATE=$(date -u +%Y-%m-%d)
+          REPORT="/tmp/ai-sim-nightly/playtest-2-report-${DATE}.md"
+          METRICS="/tmp/ai-sim-nightly/playtest-2-metrics-${DATE}.json"
+          python tools/py/playtest_2_analyzer.py \
+            --telemetry "$BATCH_DIR/playtest-2-telemetry.jsonl" \
+            --output "$REPORT" \
+            --json-out "$METRICS" \
+            --min-sample 30
+          echo "## Playtest #2 analyzer" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          sed -n '1,24p' "$REPORT" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -153,6 +185,8 @@ jobs:
           path: |
             /tmp/ai-sim-nightly/batch-current/
             /tmp/ai-sim-nightly/threshold-report.md
+            /tmp/ai-sim-nightly/playtest-2-report-*.md
+            /tmp/ai-sim-nightly/playtest-2-metrics-*.json
             /tmp/ai-sim-nightly/backend.log
           retention-days: 14
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,42 @@ jobs:
         working-directory: tools/py
         run: python roll_pack.py ENTP invoker ../../data/packs.yaml
 
+      # Envelope A A6 — playtest #2 analyzer regression guard.
+      # 1. Analyzer must still parse the canonical synthetic fixture + exit 0
+      #    (locks the schema contract the telemetry-bridge targets).
+      # 2. telemetry-bridge round-trips a hand-made batch into a telemetry
+      #    JSONL the analyzer accepts + emits a report with all sections.
+      - name: Playtest #2 analyzer regression guard
+        run: |
+          set -euo pipefail
+          # (1) synthetic fixture still parses, markdown + json-out, exit 0
+          python tools/py/playtest_2_analyzer.py \
+            --telemetry tests/fixtures/playtest-2-synthetic-telemetry.jsonl \
+            --output /tmp/pt2-fixture-report.md \
+            --json-out /tmp/pt2-fixture-metrics.json \
+            --min-sample 30
+          grep -q '## 1. Executive summary' /tmp/pt2-fixture-report.md
+          grep -q '## 8. Verdict + next action' /tmp/pt2-fixture-report.md
+          python -c "import json; json.load(open('/tmp/pt2-fixture-metrics.json'))"
+          # (2) telemetry-bridge round-trip on a hand-made batch dir
+          mkdir -p /tmp/pt2-batch/runs
+          cat > /tmp/pt2-batch/runs/run-1-guard.jsonl <<'JSONL'
+          {"ts":1,"kind":"config","run_label":"ci_guard_1","run_seed":42}
+          {"ts":2,"kind":"player_action","round":1,"actor":"pg1","action":"attack","status":200,"command_latency_ms":50}
+          {"ts":3,"kind":"vc_capture","ok":true,"per_actor":{"pg1":{"mbti_type":"ENTJ","ennea_archetypes":[{"id":"Conquistatore(3)","triggered":true}],"conviction_axis":{"utility":60,"liberty":50,"morality":50},"sentience":{"tier":"T2"}}}}
+          {"ts":4,"kind":"combat_outcome","outcome":"victory","rounds":3}
+          {"ts":5,"kind":"final_phase","phase":"ended"}
+          not-json-malformed-line
+          JSONL
+          node tools/sim/telemetry-bridge.js --in /tmp/pt2-batch
+          test -s /tmp/pt2-batch/playtest-2-telemetry.jsonl
+          python tools/py/playtest_2_analyzer.py \
+            --telemetry /tmp/pt2-batch/playtest-2-telemetry.jsonl \
+            --output /tmp/pt2-bridge-report.md \
+            --min-sample 30
+          grep -q '## 3. P4 Temperamenti' /tmp/pt2-bridge-report.md
+          echo "Playtest #2 analyzer regression guard: PASS"
+
   dataset-checks:
     runs-on: ubuntu-latest
     needs:

--- a/tests/smoke/ai-driven-sim.js
+++ b/tests/smoke/ai-driven-sim.js
@@ -551,13 +551,24 @@ function logSistemaDecisions(round, body) {
       actor_id: activeUnit.id,
       ...action,
     };
+    const actT0 = Date.now();
     const actRes = await postJson('/api/session/action', actBody);
-    log('player_action', {
+    // Envelope A A2 — map the action REST round-trip duration onto a
+    // command_latency_ms field for attack-type actions so the playtest #2
+    // analyzer Performance section (M.7 p95 gate) draws from real sim
+    // latency. Non-attack actions still log without latency (analyzer only
+    // reads command_latency_ms where > 0). Backward-compatible: existing
+    // balance summary counts `player_action` kind regardless of new field.
+    const playerActionEntry = {
       round: rounds,
       actor: activeUnit.id,
       action: action.action_type,
       status: actRes.status,
-    });
+    };
+    if (action.action_type === 'attack') {
+      playerActionEntry.command_latency_ms = Date.now() - actT0;
+    }
+    log('player_action', playerActionEntry);
 
     // End turn after single action (player AP=2 default; second action
     // optional — keep simple, end turn).
@@ -574,11 +585,43 @@ function logSistemaDecisions(round, body) {
   // T1.2 telemetry — pull VC scoring + objective state pre-close so the
   // JSONL holds full balance metrics for downstream analyzers.
   const vcRes = await getJson(`/api/session/${sessionId}/vc`);
-  const vcMbti = vcRes.body?.mbti || vcRes.body?.scoring?.mbti || null;
-  const vcEnnea = vcRes.body?.ennea || vcRes.body?.scoring?.ennea || null;
-  log('vc_capture', { ok: vcRes.status === 200, mbti: vcMbti, ennea: vcEnnea });
-  if (vcMbti) console.log('VC MBTI:', JSON.stringify(vcMbti));
-  if (vcEnnea) console.log('VC Ennea:', JSON.stringify(vcEnnea));
+  // Envelope A A2 — capture the FULL 4-layer per_actor profile from the
+  // GET /:id/vc snapshot (apps/backend/services/vcScoring.js buildVcSnapshot
+  // shape: { session_id, per_actor: { <uid>: { mbti_type, mbti_axes,
+  // ennea_archetypes:[{id,triggered}], conviction_axis:{utility,liberty,
+  // morality}, sentience:{tier} } }, meta }). The telemetry-bridge maps
+  // this directly to the analyzer `vc_snapshot` event (P4 Temperamenti:
+  // MBTI / Ennea / Conviction / Sentience layers). Field names mirror the
+  // real response — no fabrication; absent layers stay absent.
+  const vcSnapshot = vcRes.body || {};
+  const vcPerActor = vcSnapshot.per_actor || {};
+  // Legacy top-level mbti/ennea kept for backward compat with any older
+  // batch aggregator that read vc_capture.mbti / .ennea directly.
+  const legacyMbti = vcSnapshot.mbti || vcSnapshot.scoring?.mbti || null;
+  const legacyEnnea = vcSnapshot.ennea || vcSnapshot.scoring?.ennea || null;
+  log('vc_capture', {
+    ok: vcRes.status === 200,
+    mbti: legacyMbti,
+    ennea: legacyEnnea,
+    per_actor: vcPerActor,
+  });
+  const actorCount = Object.keys(vcPerActor).length;
+  console.log(`VC per_actor captured: ${actorCount} actor(s)`);
+  if (actorCount > 0) {
+    const first = Object.values(vcPerActor)[0];
+    console.log(
+      `VC sample actor: mbti=${first?.mbti_type} sentience=${first?.sentience?.tier} ` +
+        `conviction=${JSON.stringify(first?.conviction_axis)}`,
+    );
+  }
+  // TODO(Envelope A — A2 promotion): the headless smoke flow closes the
+  // session before debrief and does not currently drive a job promotion
+  // (promotionEngine.js is invoked via the coop debrief path, host-only,
+  // not reachable from this single-worker harness without a larger
+  // refactor of the debrief/lineage choreography). Promotion telemetry
+  // (P3 Identità) is therefore NOT emitted yet — analyzer P3 stays 🔴 on
+  // synthetic-only data until a future envelope wires the debrief
+  // promotion capture. Intentionally NOT faking promotion events.
   await postJson('/api/session/end', { session_id: sessionId });
   // Coop endCombat is host-only; emulate via coopOrchestrator state poll.
   // For sim purposes we rely on session.events VICTORY/DEFEAT to drive

--- a/tools/py/playtest_2_analyzer.py
+++ b/tools/py/playtest_2_analyzer.py
@@ -76,6 +76,11 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--telemetry", required=True, help="Path to telemetry JSONL")
     p.add_argument("--output", help="Output markdown path (default stdout)")
     p.add_argument(
+        "--json-out",
+        help="Optional path to dump aggregated metric dicts as JSON "
+        "(machine-readable; non-breaking, markdown output unchanged)",
+    )
+    p.add_argument(
         "--min-sample",
         type=int,
         default=MIN_SAMPLE_GREEN_HARD,
@@ -452,6 +457,40 @@ def main() -> int:
     perf = analyze_performance(events)
 
     report = build_report(summary, p3, p4, p6, od024, od026, perf, args.min_sample)
+
+    # Envelope A A4 — optional machine-readable JSON dump of the aggregated
+    # metric dicts. Non-breaking: markdown output path is unchanged. The
+    # nightly workflow uploads this alongside the report so downstream
+    # tooling (drift dashboards) does not have to re-parse markdown.
+    if args.json_out:
+        json_path = Path(args.json_out)
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+        # job_tier_breakdown uses (job, tier) tuple keys → JSON-unsafe.
+        # Re-key to "job::tier" strings for the machine dump only (the
+        # markdown report keeps the original tuple-keyed dict untouched).
+        p3_json = dict(p3)
+        p3_json["job_tier_breakdown"] = {
+            f"{job}::{tier}": count
+            for (job, tier), count in p3["job_tier_breakdown"].items()
+        }
+        machine = {
+            "summary": {
+                "total_sessions": summary["total_sessions"],
+                "total_events": summary["total_events"],
+            },
+            "min_sample": args.min_sample,
+            "p3_promotions": p3_json,
+            "p4_psicologico": p4,
+            "p6_fairness": p6,
+            "od024_interoception": od024,
+            "od026_atlas": od026,
+            "performance": perf,
+        }
+        json_path.write_text(
+            json.dumps(machine, indent=2, default=str), encoding="utf-8"
+        )
+        print(f"[playtest-2-analyzer] JSON metrics written: {json_path}")
+
     if args.output:
         out_path = Path(args.output)
         out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tools/sim/telemetry-bridge.js
+++ b/tools/sim/telemetry-bridge.js
@@ -1,0 +1,298 @@
+// Envelope A — A1: playtest #2 telemetry bridge.
+//
+// Transforms the deterministic AI-vs-AI sim batch JSONL (kind-keyed,
+// emitted by tests/smoke/ai-driven-sim.js + tools/sim/batch-ai-runner.js)
+// into the analyzer schema consumed by tools/py/playtest_2_analyzer.py
+// (one event/line, grouped by session_id).
+//
+// Input  : a batch dir (default: newest /tmp/ai-sim-runs/batch-*) OR
+//          explicit --in <dir>. Reads every <batchdir>/runs/run-*.jsonl.
+// Output : <batchdir>/playtest-2-telemetry.jsonl (override via --out).
+//
+// Mapping (source `kind` → analyzer event):
+//   config                → derives session_id (run_label || seed || file)
+//   vc_capture (rich)      → {event_type:"vc_snapshot", per_actor:{...}}
+//                            uses per_actor mbti_type / ennea_archetypes /
+//                            conviction_axis / sentience.tier as actually
+//                            present in the run JSONL (A2 enriches these).
+//   player_action (attack) → {action_type:"attack", actor_id,
+//                             command_latency_ms} when a REST/rest dur is
+//                             attributable to that action.
+//   rest                   → command_latency_ms carrier for the next attack.
+//   promotion (passthru)   → {action_type:"promotion", ...} if harness emits.
+//   trait_effects/pressure → passed through when present on player_action.
+//   skiv_pulse_fired       → {event_type:"skiv_pulse_fired", ...} passthru.
+//   rewind                 → {action_type:"rewind", ...} passthru.
+//
+// Defensive contract:
+//   - malformed JSONL line → skipped (counted, not fatal)
+//   - NO fabrication: a field is emitted only if it is really present in
+//     the source run. Missing 4-layer fields simply yield a sparser
+//     vc_snapshot (analyzer degrades gracefully — that is by design).
+//
+// Cross-ref:
+//   tests/smoke/ai-driven-sim.js     (source log() shapes)
+//   tools/sim/batch-ai-runner.js     (batch dir layout)
+//   tools/py/playtest_2_analyzer.py  (target schema)
+//
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+function parseArgs(argv) {
+  const args = { in: null, out: null };
+  for (let i = 2; i < argv.length; i += 1) {
+    const tok = argv[i];
+    if (tok === '--in') args.in = argv[++i];
+    else if (tok === '--out') args.out = argv[++i];
+    else console.warn(`unknown arg: ${tok}`);
+  }
+  return args;
+}
+
+// Resolve batch dir: explicit --in, else newest /tmp/ai-sim-runs/batch-*.
+function resolveBatchDir(explicit) {
+  if (explicit) return explicit;
+  const root = '/tmp/ai-sim-runs';
+  if (!fs.existsSync(root)) {
+    console.error(`FATAL: no --in and ${root} does not exist`);
+    process.exit(2);
+  }
+  const batches = fs
+    .readdirSync(root)
+    .filter((d) => d.startsWith('batch-'))
+    .map((d) => path.join(root, d))
+    .filter((p) => fs.statSync(p).isDirectory())
+    .sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs);
+  if (batches.length === 0) {
+    console.error(`FATAL: no batch-* dirs under ${root} (pass --in <dir>)`);
+    process.exit(2);
+  }
+  return batches[0];
+}
+
+// Defensive JSONL reader — skips malformed lines, returns {events, skipped}.
+function readJsonl(file) {
+  const events = [];
+  let skipped = 0;
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch (err) {
+    console.warn(`WARN: cannot read ${file}: ${err.message}`);
+    return { events, skipped };
+  }
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      events.push(JSON.parse(trimmed));
+    } catch {
+      skipped += 1;
+    }
+  }
+  return { events, skipped };
+}
+
+// Derive a stable session_id for a run from its config event or filename.
+function deriveSessionId(events, file) {
+  const cfg = events.find((e) => e && e.kind === 'config');
+  if (cfg) {
+    if (cfg.run_label) return String(cfg.run_label);
+    if (cfg.run_seed != null) return `seed-${cfg.run_seed}`;
+  }
+  // Fallback: filename stem (run-<id>-<label>.jsonl).
+  return path.basename(file).replace(/\.jsonl$/, '');
+}
+
+// Normalize ennea_archetypes into the analyzer-expected dict {<arch>: bool}.
+// vcScoring.computeEnneaArchetypes returns an ARRAY of {id, triggered};
+// the synthetic fixture uses a dict. Accept both, emit dict. No invention:
+// only entries actually present are kept.
+function normalizeEnnea(ennea) {
+  if (!ennea) return undefined;
+  if (Array.isArray(ennea)) {
+    const out = {};
+    for (const item of ennea) {
+      if (item && item.id != null) out[String(item.id)] = Boolean(item.triggered);
+    }
+    return Object.keys(out).length ? out : undefined;
+  }
+  if (typeof ennea === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(ennea)) {
+      // value may be bool or {triggered}
+      if (v && typeof v === 'object' && 'triggered' in v) out[k] = Boolean(v.triggered);
+      else out[k] = Boolean(v);
+    }
+    return Object.keys(out).length ? out : undefined;
+  }
+  return undefined;
+}
+
+// Build a vc_snapshot per_actor map from a rich vc_capture event. Emits
+// ONLY the sub-fields that are really present (no fabrication).
+function buildVcSnapshotPerActor(vcEv) {
+  const per = vcEv.per_actor || vcEv.vc_per_actor || null;
+  if (!per || typeof per !== 'object') return null;
+  const out = {};
+  for (const [uid, actor] of Object.entries(per)) {
+    if (!actor || typeof actor !== 'object') continue;
+    const entry = {};
+    if (actor.mbti_type) entry.mbti_type = actor.mbti_type;
+    const ennea = normalizeEnnea(actor.ennea_archetypes);
+    if (ennea) entry.ennea_archetypes = ennea;
+    if (actor.conviction_axis && typeof actor.conviction_axis === 'object') {
+      const ca = actor.conviction_axis;
+      const conv = {};
+      for (const axis of ['utility', 'liberty', 'morality']) {
+        if (typeof ca[axis] === 'number') conv[axis] = ca[axis];
+      }
+      if (Object.keys(conv).length) entry.conviction_axis = conv;
+    }
+    // sentience may be {tier} object or a bare tier string.
+    if (actor.sentience && typeof actor.sentience === 'object') {
+      if (actor.sentience.tier) entry.sentience = { tier: actor.sentience.tier };
+    } else if (typeof actor.sentience_tier === 'string') {
+      entry.sentience = { tier: actor.sentience_tier };
+    }
+    if (Object.keys(entry).length) out[uid] = entry;
+  }
+  return Object.keys(out).length ? out : null;
+}
+
+function transformRun(events, sessionId) {
+  const out = [];
+  // Pending latency from the most recent rest/REST action-call, attributed
+  // to the next attack-type player_action (A2 maps REST dur → latency).
+  let pendingLatencyMs = null;
+
+  for (const ev of events) {
+    if (!ev || typeof ev !== 'object') continue;
+    const kind = ev.kind;
+
+    if (kind === 'rest' && typeof ev.dur_ms === 'number') {
+      pendingLatencyMs = ev.dur_ms;
+      continue;
+    }
+
+    if (kind === 'player_action') {
+      const isAttack = ev.action === 'attack' || ev.action_type === 'attack';
+      const obj = {
+        session_id: sessionId,
+        action_type: isAttack ? 'attack' : ev.action || ev.action_type || 'action',
+        actor_id: ev.actor || ev.actor_id || null,
+      };
+      // command_latency_ms: prefer explicit field, else the action's own
+      // round-trip dur, else a pending rest dur. Emit only if real.
+      const lat =
+        typeof ev.command_latency_ms === 'number'
+          ? ev.command_latency_ms
+          : typeof ev.dur_ms === 'number'
+            ? ev.dur_ms
+            : pendingLatencyMs;
+      if (typeof lat === 'number' && lat > 0) obj.command_latency_ms = lat;
+      pendingLatencyMs = null;
+      // Passthrough OD-024 / P6 fields when the harness emits them.
+      if (Array.isArray(ev.trait_effects)) obj.trait_effects = ev.trait_effects;
+      if (ev.pressure_tier != null) obj.pressure_tier = ev.pressure_tier;
+      out.push(obj);
+      continue;
+    }
+
+    if (kind === 'vc_capture') {
+      const perActor = buildVcSnapshotPerActor(ev);
+      if (perActor) {
+        out.push({
+          session_id: sessionId,
+          event_type: 'vc_snapshot',
+          per_actor: perActor,
+        });
+      }
+      continue;
+    }
+
+    if (kind === 'promotion') {
+      const obj = {
+        session_id: sessionId,
+        action_type: 'promotion',
+        actor_id: ev.actor_id || ev.actor || null,
+      };
+      if (ev.job_id != null) obj.job_id = ev.job_id;
+      if (ev.applied_tier != null) obj.applied_tier = ev.applied_tier;
+      else if (ev.target_tier != null) obj.applied_tier = ev.target_tier;
+      out.push(obj);
+      continue;
+    }
+
+    if (kind === 'rewind') {
+      const obj = { session_id: sessionId, action_type: 'rewind', actor_id: ev.actor_id || null };
+      if (typeof ev.command_latency_ms === 'number') {
+        obj.command_latency_ms = ev.command_latency_ms;
+      }
+      out.push(obj);
+      continue;
+    }
+
+    if (kind === 'skiv_pulse_fired') {
+      out.push({
+        session_id: sessionId,
+        event_type: 'skiv_pulse_fired',
+        actor_id: ev.actor_id || null,
+        target_biome_id: ev.target_biome_id || '',
+      });
+      continue;
+    }
+  }
+  return out;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const batchDir = resolveBatchDir(args.in);
+  const runsDir = path.join(batchDir, 'runs');
+  if (!fs.existsSync(runsDir)) {
+    console.error(`FATAL: ${runsDir} not found (expected batch-*/runs/run-*.jsonl)`);
+    process.exit(2);
+  }
+  const runFiles = fs
+    .readdirSync(runsDir)
+    .filter((f) => f.startsWith('run-') && f.endsWith('.jsonl'))
+    .map((f) => path.join(runsDir, f));
+  if (runFiles.length === 0) {
+    console.error(`FATAL: no run-*.jsonl in ${runsDir}`);
+    process.exit(2);
+  }
+
+  const outPath = args.out || path.join(batchDir, 'playtest-2-telemetry.jsonl');
+  const outLines = [];
+  let totalSkipped = 0;
+  const sessionIds = new Set();
+
+  for (const file of runFiles) {
+    const { events, skipped } = readJsonl(file);
+    totalSkipped += skipped;
+    if (events.length === 0) continue;
+    const sessionId = deriveSessionId(events, file);
+    sessionIds.add(sessionId);
+    for (const transformed of transformRun(events, sessionId)) {
+      outLines.push(JSON.stringify(transformed));
+    }
+  }
+
+  fs.writeFileSync(outPath, outLines.join('\n') + (outLines.length ? '\n' : ''));
+  console.log(`[telemetry-bridge] batch dir : ${batchDir}`);
+  console.log(`[telemetry-bridge] run files : ${runFiles.length}`);
+  console.log(`[telemetry-bridge] sessions  : ${sessionIds.size}`);
+  console.log(`[telemetry-bridge] events    : ${outLines.length}`);
+  console.log(`[telemetry-bridge] skipped   : ${totalSkipped} malformed line(s)`);
+  console.log(`[telemetry-bridge] output    : ${outPath}`);
+  return 0;
+}
+
+if (require.main === module) {
+  process.exit(main());
+}
+
+module.exports = { transformRun, normalizeEnnea, buildVcSnapshotPerActor, deriveSessionId };


### PR DESCRIPTION
## Summary

Wires the existing disconnected `tools/py/playtest_2_analyzer.py` to the deterministic AI-vs-AI sim. No new engine — pure bridging + telemetry enrichment.

- **A1** `tools/sim/telemetry-bridge.js` (NEW): batch dir → analyzer-schema JSONL. `vc_capture`→`vc_snapshot` per_actor, REST/attack dur→`command_latency_ms`, ennea array→`{arch:bool}` dict normalize. Defensive: malformed lines skipped/counted, **no fabrication** of absent fields.
- **A2** `tests/smoke/ai-driven-sim.js`: captures full `GET /:id/vc` `per_actor` 4-layer profile (mbti_type / ennea_archetypes / conviction_axis / sentience.tier — real `buildVcSnapshot` shape) + maps attack action REST round-trip to `command_latency_ms`. Backward-compatible (legacy `vc_capture.mbti/.ennea` kept; balance summary untouched).
- **A4** `playtest_2_analyzer.py`: non-breaking `--json-out` machine dump (markdown output unchanged; tuple `job_tier` keys re-keyed for JSON safety).
- **A5** `ai-sim-nightly.yml`: bridge + analyzer steps after the existing batch/threshold steps; report + JSON ride the existing artifact. No `workflow_dispatch` of other workflows, **no new regression gate** (first ~5 runs = baseline-bootstrap safe; `check-thresholds.js` stays the only WR drift gate).
- **A6** `ci.yml` `python-tests`: analyzer regression guard — synthetic fixture still parses (8 sections, exit 0) + bridge round-trip emits a valid report.

### Promotion TODO (deferred, not faked)
P3 Identità promotion telemetry is **not** emitted: the headless smoke flow closes the session before the host-only debrief/`promotionEngine.js` path. Documented as an in-code `TODO(Envelope A — A2 promotion)`. P3 stays 🔴 on synthetic-only until a future envelope wires the debrief promotion capture.

## Quality Gate (repo CLAUDE.md mandatory)

**Smoke** — `node tools/sim/telemetry-bridge.js --in <batch>` then `python tools/py/playtest_2_analyzer.py --telemetry <out> --json-out <m.json> --min-sample 30`.
Expected: bridge skips malformed lines + writes telemetry; analyzer exits 0 with all 8 sections + valid JSON.
Actual: ✅ bridge 5 events / 1 malformed skipped; analyzer exit 0; report sections 1–8 present; `metrics.json` valid (8 keys); P4 layer_completeness all true; perf p50=55ms p95=61ms PASS.

**Research** — ≥3 edge cases (5 covered):
1. Malformed JSONL line → skipped + counted, non-fatal ✅
2. Zero promotions → P3 🔴, no crash, exit 0 ✅
3. Timeout outcome / zero attacks → no div-by-zero, exit 0 ✅
4. Missing `per_actor` → no KeyError (no vc_snapshot emitted), exit 0 ✅
5. Empty `runs/` dir → bridge exits 2 cleanly ✅
Plus: original synthetic fixture still parses (regression) ✅

**Tuning** — metric = analyzer schema-coverage from REAL sim vs synthetic.
- Before: **0/7** dimensions from sim (analyzer fully disconnected).
- After: **5/7** real — P4 MBTI ✅, P4 Ennea ✅, P4 Conviction ✅, P4 Sentience ✅ (real `buildVcSnapshot` per_actor), Performance latency ✅ (real REST round-trip p50/p95).
- Still synthetic-only (honest): P3 promotions (debrief TODO), P6 pressure_tier, OD-024 interoception, OD-026 atlas — passthrough wiring present in the bridge but the headless harness does not yet emit these source events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)