### PR TITLE
feat(playtest2): Envelope B robustness — pillar baselines + cross-tab + auto-flow

### DIFF
--- a/.github/workflows/ai-sim-nightly.yml
+++ b/.github/workflows/ai-sim-nightly.yml
@@ -176,6 +176,120 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
           sed -n '1,24p' "$REPORT" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "$METRICS" > /tmp/ai-sim-nightly/.metrics-path
+
+      # Envelope B / B1+B3 — pillar-metric regression baselines + bootstrap
+      # guard. Reads the analyzer metrics.json, compares vs the committed
+      # rolling baseline (tools/sim/pillar-baseline.json), folds this run in
+      # with --update. PT2-D: the first BOOTSTRAP_MIN runs only accumulate
+      # (script suppresses alerts itself; exit 0). Not a hard gate here —
+      # surfaces via issue (B3) / board delta (B4).
+      - name: Pillar regression baselines
+        id: pillar
+        if: always()
+        continue-on-error: true
+        run: |
+          set +e
+          METRICS=$(cat /tmp/ai-sim-nightly/.metrics-path 2>/dev/null || true)
+          if [ -z "$METRICS" ] || [ ! -f "$METRICS" ]; then
+            echo "No analyzer metrics.json — skipping pillar baselines"
+            echo "pillar_alert=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          DATE=$(date -u +%Y-%m-%d)
+          PREV_VERDICT=$(node -e "try{console.log(require('./tools/sim/pillar-baseline.json').verdict||'')}catch{console.log('')}")
+          node tools/sim/check-pillar-baselines.js \
+            --metrics "$METRICS" \
+            --baseline tools/sim/pillar-baseline.json \
+            --out /tmp/ai-sim-nightly/pillar-report-${DATE}.md \
+            --status-out /tmp/ai-sim-nightly/pillar-status.json \
+            --update \
+            >> $GITHUB_STEP_SUMMARY
+          STATUS=$?
+          ALERT=$(node -e "try{console.log(require('/tmp/ai-sim-nightly/pillar-status.json').alert?'true':'false')}catch{console.log('false')}")
+          NEW_VERDICT=$(node -e "try{console.log(require('/tmp/ai-sim-nightly/pillar-status.json').verdict||'')}catch{console.log('')}")
+          VCHG=$(node -e "try{console.log(require('/tmp/ai-sim-nightly/pillar-status.json').verdict_changed?'true':'false')}catch{console.log('false')}")
+          echo "pillar_alert=$ALERT" >> $GITHUB_OUTPUT
+          echo "verdict_changed=$VCHG" >> $GITHUB_OUTPUT
+          echo "prev_verdict=$PREV_VERDICT" >> $GITHUB_OUTPUT
+          echo "new_verdict=$NEW_VERDICT" >> $GITHUB_OUTPUT
+          # B4 — cross-repo board delta. The workflow GITHUB_TOKEN is
+          # repo-scoped to Game and CANNOT open a PR to codemasterdd, so we
+          # do NOT fake an automated cross-repo PR. Instead, on a verdict
+          # change, write a board-delta handoff doc into the artifact; the
+          # codemasterdd EXECUTION-BOARD.md row (OD-044) is synced via a
+          # manual/cron PR using that delta as the source of truth.
+          if [ "$VCHG" = "true" ]; then
+            DELTA=/tmp/ai-sim-nightly/playtest-2-board-delta-${DATE}.md
+            {
+              echo "# playtest#2 board delta — ${DATE}"
+              echo ""
+              echo "**OD-044 pillar verdict change**: \`${PREV_VERDICT:-<bootstrap>}\` → \`${NEW_VERDICT}\`"
+              echo ""
+              echo "Sync target: \`MasterDD-L34D/codemasterdd-ai-station\` →"
+              echo "\`docs/cross-repo/EXECUTION-BOARD.md\` row **playtest#2 automation (OD-044)**."
+              echo ""
+              echo "This is a MANUAL-HANDOFF step: the Game workflow token is"
+              echo "repo-scoped and cannot PR cross-repo. Open the codemasterdd"
+              echo "PR from this delta (or via the periodic board-sync cron)."
+              echo ""
+              echo '## Pillar status snapshot'
+              echo '```json'
+              cat /tmp/ai-sim-nightly/pillar-status.json
+              echo '```'
+            } > "$DELTA"
+            echo "board_delta=$DELTA" >> $GITHUB_OUTPUT
+          fi
+
+      # B3 — commit the updated rolling baseline + generated report via PR,
+      # NOT auto-commit to main (PT2-C). Token is contents+PR scoped.
+      - name: Open baseline-update PR
+        if: github.event_name == 'schedule' && steps.pillar.outputs.pillar_alert != ''
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          DATE=$(date -u +%Y-%m-%d)
+          if git diff --quiet -- tools/sim/pillar-baseline.json; then
+            echo "Baseline unchanged — no PR needed"
+            exit 0
+          fi
+          BRANCH="auto/playtest2-baseline-${DATE}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          mkdir -p docs/playtest
+          cp "/tmp/ai-sim-nightly/playtest-2-report-${DATE}.md" "docs/playtest/playtest-2-${DATE}.md" 2>/dev/null || true
+          git add tools/sim/pillar-baseline.json docs/playtest/playtest-2-${DATE}.md 2>/dev/null || git add tools/sim/pillar-baseline.json
+          git commit -m "chore(playtest2): nightly pillar baseline + report ${DATE}"
+          git push origin "$BRANCH" --force
+          gh pr create \
+            --title "playtest#2 nightly baseline ${DATE}" \
+            --body "Automated rolling pillar baseline update + analyzer report. Generated by ai-sim-nightly (PT2-C: PR delivery, never auto-commit to main)." \
+            --label "playtest-2,automated" \
+            --base main --head "$BRANCH" \
+            --repo "${{ github.repository }}" || echo "PR may already exist for $BRANCH"
+
+      - name: Open pillar regression issue
+        if: steps.pillar.outputs.pillar_alert == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          BODY=$(cat /tmp/ai-sim-nightly/pillar-report-${DATE}.md)
+          TITLE="playtest#2 pillar regression — $DATE"
+          # Reuse existing issues:write token (no new perms). Update an open
+          # issue with the same label set if present, else create one.
+          EXISTING=$(gh issue list --repo "${{ github.repository }}" \
+            --label "playtest-2,automated" --state open \
+            --search "pillar regression" --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "${{ github.repository }}" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY" \
+              --label "playtest-2,automated" --repo "${{ github.repository }}"
+          fi
 
       - name: Upload artifacts
         if: always()
@@ -187,6 +301,9 @@ jobs:
             /tmp/ai-sim-nightly/threshold-report.md
             /tmp/ai-sim-nightly/playtest-2-report-*.md
             /tmp/ai-sim-nightly/playtest-2-metrics-*.json
+            /tmp/ai-sim-nightly/pillar-report-*.md
+            /tmp/ai-sim-nightly/pillar-status.json
+            /tmp/ai-sim-nightly/playtest-2-board-delta-*.md
             /tmp/ai-sim-nightly/backend.log
           retention-days: 14
 

--- a/tools/sim/batch-ai-runner.js
+++ b/tools/sim/batch-ai-runner.js
@@ -281,6 +281,34 @@ function buildSummary(results, args) {
       p.avg_wall_ms = Math.round(p.avg_wall_ms / p.runs);
     }
   }
+  // Envelope B / B2 — profile×scenario cross-tab. `by_profile` aggregates
+  // across scenarios (a known blind spot: a profile can pass overall while
+  // failing one scenario). This non-breaking sibling keys on
+  // "<profile>::<scenario>" so per-cell regressions are visible. Existing
+  // `by_profile` stays for back-compat.
+  const byProfileScenario = {};
+  for (const r of results) {
+    const cell = `${r.profile}::${r.scenario}`;
+    if (!byProfileScenario[cell]) {
+      byProfileScenario[cell] = {
+        profile: r.profile,
+        scenario: r.scenario,
+        runs: 0,
+        victory: 0,
+        defeat: 0,
+        timeout: 0,
+        avg_rounds: 0,
+      };
+    }
+    const c = byProfileScenario[cell];
+    c.runs += 1;
+    c[r.outcome] = (c[r.outcome] || 0) + 1;
+    c.avg_rounds += r.rounds || 0;
+  }
+  for (const k of Object.keys(byProfileScenario)) {
+    const c = byProfileScenario[k];
+    if (c.runs > 0) c.avg_rounds = +(c.avg_rounds / c.runs).toFixed(2);
+  }
   const avgRounds =
     total === 0 ? 0 : +(results.reduce((s, r) => s + (r.rounds || 0), 0) / total).toFixed(2);
   const avgWallMs =
@@ -292,6 +320,7 @@ function buildSummary(results, args) {
     completion_rate: total === 0 ? 0 : +(completed / total).toFixed(3),
     by_outcome: byOutcome,
     by_profile: byProfile,
+    by_profile_scenario: byProfileScenario,
     avg_rounds: avgRounds,
     avg_wall_ms: avgWallMs,
     started_at: results.length > 0 ? new Date().toISOString() : null,

--- a/tools/sim/check-pillar-baselines.js
+++ b/tools/sim/check-pillar-baselines.js
@@ -1,0 +1,349 @@
+#!/usr/bin/env node
+// Envelope B / B1 — pillar-metric regression baselines for playtest #2.
+//
+// check-thresholds.js baselines ONLY win-rate per profile. This sibling adds
+// drift detection for the *pillar* metrics emitted by
+// tools/py/playtest_2_analyzer.py --json-out (metrics.json). It maintains a
+// rolling baseline file (committed) and flags drift past a per-metric
+// tolerance. It ALSO tracks the analyzer pillar verdict so the workflow can
+// react to a verdict CHANGE (not just numeric drift).
+//
+// Bootstrap window (PT2-D): until the baseline has accumulated
+// >= BOOTSTRAP_MIN samples it ONLY accumulates — it NEVER raises a regression
+// alert. This lets the first ~5 nightly runs establish a baseline silently.
+//
+// Report delivery (PT2-C): this script never commits. It writes a markdown
+// report + a machine `pillar-status.json`; the workflow decides PR vs issue.
+//
+// Usage:
+//   node tools/sim/check-pillar-baselines.js \
+//     --metrics /path/playtest-2-metrics-<date>.json \
+//     --baseline tools/sim/pillar-baseline.json \
+//     --out /tmp/pillar-report.md \
+//     --status-out /tmp/pillar-status.json \
+//     [--update]            # fold this run into the baseline (rolling mean)
+//
+// Exit:
+//   0 = clean OR bootstrap window (no gating)
+//   1 = pillar regression OR pillar verdict change (post-bootstrap only)
+//   2 = usage error
+//
+// Cross-ref:
+//   tools/py/playtest_2_analyzer.py (metrics.json producer)
+//   tools/sim/check-thresholds.js (WR-only sibling gate)
+//   .github/workflows/ai-sim-nightly.yml (consumer)
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Min samples folded into the baseline before alerts are armed (PT2-D).
+const BOOTSTRAP_MIN = 5;
+
+// Pillar dimensions tracked. `tol` = allowed absolute drift of the metric vs
+// the rolling baseline mean. `unit` is cosmetic. `extract(metrics)` returns a
+// number or null (null = key missing → graceful skip, not a failure).
+const DIMENSIONS = [
+  {
+    key: 'p3_promotion_rate',
+    label: 'P3 promotion rate (promotions / session)',
+    unit: 'per-session',
+    tol: 0.5,
+    extract(m) {
+      const p3 = m.p3_promotions;
+      const s = m.summary;
+      if (!p3 || !s || !s.total_sessions) return null;
+      return p3.total_promotions / s.total_sessions;
+    },
+  },
+  {
+    key: 'p4_conviction_stdev',
+    label: 'P4 conviction stdev (mean across axes)',
+    unit: 'stdev',
+    tol: 5,
+    extract(m) {
+      const cd = m.p4_psicologico && m.p4_psicologico.conviction_distribution;
+      if (!cd) return null;
+      const stdevs = Object.values(cd)
+        .map((a) => (a && typeof a.stdev === 'number' ? a.stdev : null))
+        .filter((v) => v !== null);
+      if (stdevs.length === 0) return null;
+      return stdevs.reduce((a, b) => a + b, 0) / stdevs.length;
+    },
+  },
+  {
+    key: 'p4_layer_completeness',
+    label: 'P4 4-layer completeness (layers populated, 0-4)',
+    unit: 'layers',
+    tol: 1,
+    extract(m) {
+      const lc = m.p4_psicologico && m.p4_psicologico.layer_completeness;
+      if (!lc) return null;
+      return Object.values(lc).filter(Boolean).length;
+    },
+  },
+  {
+    key: 'p6_pressure_spread',
+    label: 'P6 pressure-tier spread (distinct tiers observed)',
+    unit: 'tiers',
+    tol: 1,
+    extract(m) {
+      const pd = m.p6_fairness && m.p6_fairness.pressure_distribution;
+      if (!pd) return null;
+      return Object.keys(pd).length;
+    },
+  },
+  {
+    key: 'p6_rewind_pct',
+    label: 'P6 rewind sessions %',
+    unit: '%',
+    tol: 20,
+    extract(m) {
+      const f = m.p6_fairness;
+      if (!f || typeof f.rewind_sessions_pct !== 'number') return null;
+      return f.rewind_sessions_pct;
+    },
+  },
+  {
+    key: 'od024_firing_pct',
+    label: 'OD-024 interoception firing %',
+    unit: '%',
+    tol: 15,
+    extract(m) {
+      const o = m.od024_interoception;
+      if (!o || typeof o.firing_rate_pct !== 'number') return null;
+      return o.firing_rate_pct;
+    },
+  },
+  {
+    key: 'perf_latency_p95_ms',
+    label: 'Performance command latency p95 (M.7)',
+    unit: 'ms',
+    tol: 40,
+    extract(m) {
+      const p = m.performance;
+      if (!p || typeof p.command_latency_p95_ms !== 'number') return null;
+      return p.command_latency_p95_ms;
+    },
+  },
+];
+
+function parseArgs(argv) {
+  const args = {
+    metrics: null,
+    baseline: path.join('tools', 'sim', 'pillar-baseline.json'),
+    out: null,
+    statusOut: null,
+    update: false,
+  };
+  for (let i = 2; i < argv.length; i += 1) {
+    const tok = argv[i];
+    const next = () => argv[++i];
+    switch (tok) {
+      case '--metrics':
+        args.metrics = next();
+        break;
+      case '--baseline':
+        args.baseline = next();
+        break;
+      case '--out':
+        args.out = next();
+        break;
+      case '--status-out':
+        args.statusOut = next();
+        break;
+      case '--update':
+        args.update = true;
+        break;
+      default:
+        console.warn(`unknown arg: ${tok}`);
+    }
+  }
+  if (!args.metrics) {
+    console.error('FATAL: --metrics <path> required');
+    process.exit(2);
+  }
+  return args;
+}
+
+function loadBaseline(p) {
+  try {
+    const raw = JSON.parse(fs.readFileSync(p, 'utf8'));
+    return {
+      samples: Number(raw.samples) || 0,
+      verdict: raw.verdict || null,
+      dims: raw.dims || {},
+      updated_at: raw.updated_at || null,
+    };
+  } catch {
+    return { samples: 0, verdict: null, dims: {}, updated_at: null };
+  }
+}
+
+// Pillar verdict: worst of the analyzer's own performance gate + a numeric
+// regression check. Kept coarse on purpose (PASS / CONDITIONAL / REGRESSION)
+// — it is what the workflow watches for a *verdict change*.
+function computeVerdict(metrics, dimResults) {
+  const perfV = (metrics.performance && metrics.performance.command_latency_verdict) || 'n/a';
+  if (dimResults.some((d) => d.regressed)) return 'REGRESSION';
+  if (perfV === 'ABORT') return 'REGRESSION';
+  if (perfV === 'CONDITIONAL') return 'CONDITIONAL';
+  return 'PASS';
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  let metrics;
+  try {
+    metrics = JSON.parse(fs.readFileSync(args.metrics, 'utf8'));
+  } catch (e) {
+    console.error(`FATAL: cannot read metrics ${args.metrics}: ${e.message}`);
+    process.exit(2);
+  }
+
+  const baseline = loadBaseline(args.baseline);
+  const armed = baseline.samples >= BOOTSTRAP_MIN;
+
+  const dimResults = [];
+  for (const dim of DIMENSIONS) {
+    let value = null;
+    try {
+      value = dim.extract(metrics);
+    } catch {
+      value = null; // graceful: malformed sub-tree treated as missing key
+    }
+    const base = baseline.dims[dim.key];
+    const baseMean = base && typeof base.mean === 'number' ? base.mean : null;
+    const present = value !== null && Number.isFinite(value);
+    let drift = null;
+    let regressed = false;
+    if (present && baseMean !== null && armed) {
+      drift = value - baseMean;
+      regressed = Math.abs(drift) > dim.tol;
+    }
+    dimResults.push({
+      key: dim.key,
+      label: dim.label,
+      unit: dim.unit,
+      tol: dim.tol,
+      value,
+      present,
+      baseMean,
+      drift,
+      regressed,
+      missing: !present,
+    });
+  }
+
+  const verdict = computeVerdict(metrics, dimResults);
+  const verdictChanged = armed && baseline.verdict !== null && baseline.verdict !== verdict;
+  const regressed = armed && dimResults.some((d) => d.regressed);
+  const alert = armed && (regressed || verdictChanged);
+
+  // ---- Report markdown -----------------------------------------------------
+  const lines = [];
+  lines.push('## Pillar regression baselines (Envelope B / B1)');
+  lines.push('');
+  lines.push(`- Metrics: \`${path.basename(args.metrics)}\``);
+  lines.push(`- Baseline samples: ${baseline.samples} (bootstrap min ${BOOTSTRAP_MIN})`);
+  lines.push(
+    `- Mode: ${armed ? '**armed** (alerts active)' : '🟡 **bootstrap window** (alerts suppressed — establishing baseline silently)'}`,
+  );
+  lines.push(
+    `- Pillar verdict: **${verdict}**${baseline.verdict ? ` (prev: ${baseline.verdict})` : ''}`,
+  );
+  if (verdictChanged)
+    lines.push(`- ⚠️ **Pillar verdict CHANGED** ${baseline.verdict} → ${verdict}`);
+  lines.push('');
+  lines.push('| Dimension | Value | Baseline | Drift | Tol | Status |');
+  lines.push('| --------- | ----: | -------: | ----: | --: | :----: |');
+  for (const d of dimResults) {
+    const v = d.present ? Number(d.value).toFixed(2) : 'n/a (key missing)';
+    const b = d.baseMean === null ? 'n/a' : Number(d.baseMean).toFixed(2);
+    const dr = d.drift === null ? 'n/a' : `${d.drift >= 0 ? '+' : ''}${d.drift.toFixed(2)}`;
+    let status = '✅';
+    if (d.missing) status = '➖';
+    else if (d.regressed) status = '⚠️';
+    else if (!armed) status = '🟡';
+    lines.push(`| ${d.label} | ${v} | ${b} | ${dr} | ±${d.tol} | ${status} |`);
+  }
+  lines.push('');
+  if (!armed) {
+    lines.push(
+      `### Verdict: 🟡 Bootstrap — baseline at ${baseline.samples}/${BOOTSTRAP_MIN} samples, no gating`,
+    );
+  } else if (alert) {
+    lines.push('### Verdict: ⚠️ Pillar regression / verdict change');
+    lines.push('');
+    for (const d of dimResults.filter((x) => x.regressed)) {
+      lines.push(
+        `- **${d.label}**: ${Number(d.value).toFixed(2)} vs baseline ${Number(d.baseMean).toFixed(2)} (Δ ${d.drift >= 0 ? '+' : ''}${d.drift.toFixed(2)} > ±${d.tol})`,
+      );
+    }
+    if (verdictChanged) lines.push(`- **Verdict change**: ${baseline.verdict} → ${verdict}`);
+    lines.push('');
+    lines.push('### Investigation');
+    lines.push('1. Inspect artifact `ai-sim-nightly-<run_id>` (telemetry + metrics.json).');
+    lines.push('2. Compare vs prior nightly metrics; confirm not a sample-size artifact.');
+    lines.push('3. If intentional shift → run with `--update` to re-baseline.');
+  } else {
+    lines.push('### Verdict: ✅ Clean — all pillar dimensions within tolerance');
+  }
+  const report = lines.join('\n');
+  process.stdout.write(report + '\n');
+  if (args.out) fs.writeFileSync(args.out, report);
+
+  // ---- Machine status ------------------------------------------------------
+  const status = {
+    armed,
+    bootstrap: !armed,
+    baseline_samples: baseline.samples,
+    verdict,
+    prev_verdict: baseline.verdict,
+    verdict_changed: verdictChanged,
+    regressed,
+    alert,
+    dimensions: dimResults.map((d) => ({
+      key: d.key,
+      label: d.label,
+      value: d.value,
+      baseline: d.baseMean,
+      drift: d.drift,
+      tol: d.tol,
+      regressed: d.regressed,
+      missing: d.missing,
+    })),
+    generated_at: new Date().toISOString(),
+  };
+  if (args.statusOut) fs.writeFileSync(args.statusOut, JSON.stringify(status, null, 2));
+
+  // ---- Rolling baseline update (idempotent incremental mean) ---------------
+  if (args.update) {
+    const n = baseline.samples;
+    const newDims = { ...baseline.dims };
+    for (const d of dimResults) {
+      if (!d.present) continue; // never fold a missing metric
+      const prev =
+        newDims[d.key] && typeof newDims[d.key].mean === 'number' ? newDims[d.key].mean : null;
+      const prevN = newDims[d.key] && Number(newDims[d.key].n) ? Number(newDims[d.key].n) : 0;
+      const mean = prev === null ? d.value : (prev * prevN + d.value) / (prevN + 1);
+      newDims[d.key] = { mean: +mean.toFixed(6), n: prevN + 1 };
+    }
+    const next = {
+      samples: n + 1,
+      verdict,
+      dims: newDims,
+      updated_at: new Date().toISOString(),
+    };
+    fs.mkdirSync(path.dirname(args.baseline), { recursive: true });
+    fs.writeFileSync(args.baseline, JSON.stringify(next, null, 2) + '\n');
+    console.error(
+      `[pillar-baseline] folded run → samples ${next.samples}, verdict ${verdict} (${path.basename(args.baseline)})`,
+    );
+  }
+
+  if (alert) process.exit(1);
+}
+
+main();

--- a/tools/sim/pillar-baseline.json
+++ b/tools/sim/pillar-baseline.json
@@ -1,0 +1,6 @@
+{
+  "samples": 0,
+  "verdict": null,
+  "dims": {},
+  "updated_at": null
+}


### PR DESCRIPTION
## Envelope B (playtest #2 robustness) — follow-up to A+C (#2282, #2283)

### B1 — pillar-metric regression baselines
New `tools/sim/check-pillar-baselines.js`: rolling baseline over analyzer `metrics.json` for 7 pillar dimensions — P3 promotion rate, P4 conviction stdev, P4 4-layer completeness, P6 pressure-tier spread, P6 rewind %, OD-024 firing %, Performance p95 (M.7). Per-metric absolute tolerance + drift detection. Markdown report + machine `pillar-status.json`. Tracks pillar verdict (PASS/CONDITIONAL/REGRESSION) for verdict-change detection. Committed `tools/sim/pillar-baseline.json` seeded at samples=0.
**PT2-D bootstrap window**: until baseline has ≥5 samples the script ONLY accumulates — never raises an alert (establish baseline silently).

### B2 — `by_profile_scenario` cross-tab
`batch-ai-runner.js` `buildSummary` now emits `by_profile_scenario { "<profile>::<scenario>": {profile,scenario,runs,victory,defeat,timeout,avg_rounds} }`. Existing `by_profile` (cross-scenario aggregate, known blind spot) retained for back-compat. Non-breaking.

### B3 — auto-flow on regression / verdict-change
`ai-sim-nightly.yml`: pillar-baseline step after analyzer with explicit bootstrap guard. On alert → open/update issue label `playtest-2,automated` (reuses existing `issues:write` GITHUB_TOKEN — no new perms). **PT2-C**: rolling baseline + generated `docs/playtest/playtest-2-<date>.md` delivered via PR (branch `auto/playtest2-baseline-<date>`), never auto-commit to main.

### B4 — cross-repo board sync (honest manual-handoff)
Game's workflow GITHUB_TOKEN is repo-scoped and **cannot** PR to `codemasterdd-ai-station`. Not faked: on a verdict change the workflow writes `playtest-2-board-delta-<date>.md` into the artifact documenting the sync target (EXECUTION-BOARD.md OD-044 row). A one-time codemasterdd PR reflecting current state is opened separately by this agent as the example.

## Quality Gate
- **Smoke**: real backend (`PORT=3334`, HTTP :3334 health 200 + WS :3341 LISTENING, `AI_SIM_WS_URL=ws://127.0.0.1:3341/ws`) → batch → bridge → analyzer → pillar-baseline step runs; first-run bootstrap suppresses alert; exit 0; baseline accumulates.
- **Research** (4 edge cases): (1) no-baseline-file bootstrap → exit 0, alert suppressed; (2) armed + drift → exit 1, alert + REGRESSION; (3) armed + verdict unchanged + no drift → exit 0, no spurious issue; (4) metrics.json missing keys → graceful, no crash, missing dims skipped from baseline fold.
- **Tuning**: regression-detection coverage 0 (WR-only before) → **7 pillar dimensions** with baseline + drift-check.

## Constraints honored
Prettier-clean (touched JS). Analyzer CLI / synthetic fixture parsing unchanged (no edits to `playtest_2_analyzer.py` or fixture). No new workflow perms; no `workflow_dispatch` of other workflows; no branch-protection changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)