### PR TITLE
feat(od026): wire real Skiv echolocation pulse telemetry (schema 6→6.5/7)

### DIFF
--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -126,6 +126,15 @@ function normaliseUnit(raw, fallbackIndex) {
     // useUtilityAi global (default false) → Utility AI mai attivo per /start sessions.
     // Bot-flagged 2026-04-29 PR #1495 review.
     ai_profile: input.ai_profile ? String(input.ai_profile) : null,
+    // OD-026 — preserve default_parts sensory bag (e.g.
+    // { senses: ['echolocation'] }). senseReveal._hasEcholocationSense
+    // reads actor.default_parts.senses; without carrying it here the
+    // echolocation pulse mechanic could never fire for a /start unit
+    // (it was already silently dropped — "Engine LIVE Surface DEAD").
+    // Additive + back-compat: only set when input declares an object.
+    ...(input.default_parts && typeof input.default_parts === 'object'
+      ? { default_parts: input.default_parts }
+      : {}),
   };
   // 2026-05-06 TKT-P3-FORM-STAT-APPLIER — apply form stat_seed delta to
   // baseline. Pre-fix: form_id was cosmetic only — NO mech link to combat.

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -53,6 +53,21 @@ const {
   applyHazardImmunity: applyArchetypeHazardImmunity,
   computeAlphaAffinityGrant: computeArchetypeAlphaGrant,
 } = require('../services/combat/archetypePassives');
+// OD-026 — Skiv echolocation pulse telemetry seam. The senseReveal helper
+// (apps/backend/services/combat/senseReveal.js) derives revealed-tile coords
+// for an actor with a `default_parts.senses: [echolocation]` entry. Wired
+// here at the post-attack seam so a REAL attack by an echolocating actor
+// emits a `skiv_pulse_fired` event into session.events (analyzer OD-026
+// atlas). Lazy require with graceful fallback — a missing/broken module
+// must never block combat resolution.
+let _senseReveal = null;
+try {
+  // eslint-disable-next-line global-require
+  _senseReveal = require('../services/combat/senseReveal');
+} catch (_err) {
+  _senseReveal = null;
+}
+
 // Telepatic-link reveal pipe (2026-04-25 audit follow-up). Lazy-loaded with
 // graceful fallback so missing module never blocks /round/begin-planning.
 let computeTelepathicReveal = null;
@@ -559,6 +574,57 @@ function createRoundBridge(deps) {
         consumeCapPt(session, requestedCapPt);
       }
       await appendEvent(session, event);
+      // OD-026 — Skiv echolocation pulse. If the attacking actor carries an
+      // echolocation sense (default_parts.senses) and is not on cooldown,
+      // the REAL senseReveal mechanic derives revealed tiles around the
+      // attacked target. When ≥1 tile is revealed we emit a
+      // `skiv_pulse_fired` event into session.events (analyzer OD-026
+      // atlas) + mark the 2-round cooldown. target_biome_id is sourced from
+      // REAL session biome state (session.biome_id || encounter biome) — no
+      // hardcoded constant. No fabrication: emitted ONLY when getRevealedTiles
+      // actually returns tiles for a real attack. Defensive: any failure is
+      // swallowed so the pulse seam can never break combat.
+      if (_senseReveal && typeof _senseReveal.getRevealedTiles === 'function') {
+        try {
+          const currentRound = Number(
+            (session.roundState && session.roundState.round) || session.turn || 0,
+          );
+          // Real grid bounds (mirror session.js _gw/_gh pattern). Falls back
+          // to the scalar gridSize dep, else undefined → getRevealedTiles
+          // treats bounds as Infinity (no clamp) which is safe.
+          const gw =
+            (session.grid && Number(session.grid.width)) ||
+            (typeof gridSize === 'number' ? gridSize : undefined);
+          const gh =
+            (session.grid && Number(session.grid.height)) ||
+            (typeof gridSize === 'number' ? gridSize : undefined);
+          const world = {
+            currentRound,
+            width: Number.isFinite(gw) ? gw : undefined,
+            height: Number.isFinite(gh) ? gh : undefined,
+          };
+          const revealed = _senseReveal.getRevealedTiles(actor, target, world);
+          if (Array.isArray(revealed) && revealed.length > 0) {
+            const biomeId =
+              session.biome_id || (session.encounter && session.encounter.biome_id) || '';
+            await appendEvent(session, {
+              ts: new Date().toISOString(),
+              session_id: session.session_id,
+              action_type: 'skiv_pulse_fired',
+              actor_id: actor.id,
+              target_biome_id: biomeId,
+              revealed_tiles: revealed.length,
+              turn: session.turn,
+              trait_effects: [],
+            });
+            _senseReveal.markCooldown(actor, currentRound);
+          }
+        } catch (err) {
+          // Non-blocking: pulse telemetry must never break combat.
+          // eslint-disable-next-line no-console
+          console.warn('[od026 skiv-pulse] skipped:', err && err.message ? err.message : err);
+        }
+      }
       // iter4: emit reaction_trigger event quando intercept fires.
       if (capturedResults.intercept) {
         const reactionEvent = {

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -39,6 +39,14 @@ function characterToUnit(character, { index = 0 } = {}) {
     ap: character.ap_max || 2,
     traits: Array.isArray(character.traits) ? character.traits : [],
     position: character.position || { x: index, y: 0 },
+    // OD-026 — preserve default_parts (sensory bag, e.g.
+    // { senses: ['echolocation'] }) so the senseReveal echolocation pulse
+    // mechanic can fire for an actor that declares the sense. Additive:
+    // only carried through when the character actually declares it; absent
+    // default_parts stays absent (back-compat, no behaviour change).
+    ...(character.default_parts && typeof character.default_parts === 'object'
+      ? { default_parts: character.default_parts }
+      : {}),
   };
 }
 

--- a/tests/smoke/ai-driven-sim.js
+++ b/tests/smoke/ai-driven-sim.js
@@ -498,11 +498,47 @@ function logSistemaDecisions(round, body) {
   // engine then REALLY evaluates these per attack and appends
   // {trait,triggered,effect:proprioception_balance|nociception_reactive}
   // to the attack event — genuine engine output, not fabricated.
-  const characters = rawCharacters.map((ch) => ({
+  //
+  // Envelope C (OD-026 atlas) — equip the host character with an
+  // echolocation sense so the REAL senseReveal mechanic fires. The OD-026
+  // seam (apps/backend/routes/sessionRoundBridge.js, post-attack) calls
+  // senseReveal.getRevealedTiles(actor, target, world); it returns tiles
+  // ONLY when actor.default_parts.senses contains 'echolocation' and the
+  // actor is not on its 2-round cooldown. characterToUnit
+  // (coopOrchestrator.js) + normaliseUnit (sessionHelpers.js) preserve
+  // character.default_parts onto the spawned unit. We also add the
+  // `sensori_geomagnetici` trait (senseReveal BONUS_TRAIT_ID → +1 reveal
+  // radius) so the pulse reveals tiles even on a small grid. This only
+  // EQUIPS the sense — the backend then evaluates the real mechanic on a
+  // real attack; the skiv_pulse_fired event is genuine engine output, not
+  // fabricated (emitted only when getRevealedTiles really returns tiles).
+  const ECHO_TRAIT = 'sensori_geomagnetici';
+  const characters = rawCharacters.map((ch, idx) => ({
     ...ch,
     traits: Array.from(
-      new Set([...(Array.isArray(ch.traits) ? ch.traits : []), ...INTEROCEPTION_ACTOR_TRAITS]),
+      new Set([
+        ...(Array.isArray(ch.traits) ? ch.traits : []),
+        ...INTEROCEPTION_ACTOR_TRAITS,
+        // Only the host (idx 0 = Skiv custode) carries echolocation so the
+        // OD-026 path mirrors the diegetic design (Skiv personal sprint).
+        ...(idx === 0 ? [ECHO_TRAIT] : []),
+      ]),
     ),
+    ...(idx === 0
+      ? {
+          default_parts: {
+            ...(ch.default_parts && typeof ch.default_parts === 'object' ? ch.default_parts : {}),
+            senses: Array.from(
+              new Set([
+                ...(ch.default_parts && Array.isArray(ch.default_parts.senses)
+                  ? ch.default_parts.senses
+                  : []),
+                'echolocation',
+              ]),
+            ),
+          },
+        }
+      : {}),
     status: { ...(ch.status && typeof ch.status === 'object' ? ch.status : {}), ferito: 1 },
   }));
 
@@ -524,10 +560,34 @@ function logSistemaDecisions(round, body) {
     enemies = buildScenarioEnemies();
     yamlMeta = null;
   }
+  // OD-026 — resolve the REAL scenario biome from the encounter YAML
+  // (docs/planning/encounters/<scenario>.yaml `biome_id:`). This is genuine
+  // scenario state, not a hardcoded constant: the backend stamps it onto
+  // session.biome_id, and the OD-026 seam sources skiv_pulse_fired
+  // target_biome_id from session.biome_id. If the scenario YAML is missing
+  // or declares no biome we omit biome_id (the seam then emits "" which the
+  // analyzer counts as a pulse without a revealed biome — still real).
+  let scenarioBiomeId = null;
+  try {
+    const encYamlPath = path.join(ENCOUNTER_DIR, `${SCENARIO_ID}.yaml`);
+    if (fs.existsSync(encYamlPath)) {
+      const encParsed = yaml.load(fs.readFileSync(encYamlPath, 'utf-8'));
+      if (encParsed && typeof encParsed.biome_id === 'string' && encParsed.biome_id) {
+        scenarioBiomeId = encParsed.biome_id;
+      }
+    }
+  } catch (err) {
+    log('biome_resolve_fail', { scenario: SCENARIO_ID, error: err.message });
+  }
+  console.log(`Scenario biome: ${scenarioBiomeId || '(none declared)'}`);
+
   const startBody = {
     characters,
     units: enemies,
     scenario_id: SCENARIO_ID,
+    // OD-026 — pass the real scenario biome so session.biome_id is genuine
+    // combat state the skiv_pulse_fired event can reference.
+    ...(scenarioBiomeId ? { biome_id: scenarioBiomeId } : {}),
     // 2026-05-10 — pass encounter_id when YAML mode so backend
     // encounterLoader populates objective + biomeSpawnBias + conditions
     // (see apps/backend/routes/session.js:1473). Without this, non-elim
@@ -551,6 +611,8 @@ function logSistemaDecisions(round, body) {
   logSection('combat round loop');
   let rounds = 0;
   let outcome = null;
+  // OD-026 — dedupe skiv_pulse_fired across repeated state.events tails.
+  const seenPulseKeys = new Set();
   while (rounds < MAX_ROUNDS) {
     rounds += 1;
     const stRes = await getJson(`/api/session/state?session_id=${sessionId}`);
@@ -585,6 +647,26 @@ function logSistemaDecisions(round, body) {
             damage_dealt: ev.damage_dealt || null,
             event_ts: ev.ts || null,
           });
+        }
+        // OD-026 — surface the REAL skiv_pulse_fired events the backend
+        // senseReveal seam appended to session.events. publicSessionView
+        // only exposes session.events.slice(-30), and the same tail repeats
+        // across round-state polls, so dedupe by the monotone action_index
+        // appendEvent stamps on every event. telemetry-bridge.js maps the
+        // `kind: 'skiv_pulse_fired'` JSONL line → analyzer OD-026 atlas.
+        if (ev?.action_type === 'skiv_pulse_fired') {
+          const dedupeKey =
+            ev.action_index != null ? `pulse_${ev.action_index}` : `pulse_ts_${ev.ts}`;
+          if (!seenPulseKeys.has(dedupeKey)) {
+            seenPulseKeys.add(dedupeKey);
+            log('skiv_pulse_fired', {
+              round: rounds,
+              actor_id: ev.actor_id || null,
+              target_biome_id: ev.target_biome_id || '',
+              revealed_tiles: ev.revealed_tiles ?? null,
+              event_ts: ev.ts || null,
+            });
+          }
         }
       }
     }
@@ -800,16 +882,20 @@ function logSistemaDecisions(round, body) {
     }
   }
 
-  // TODO(Envelope C — OD-026 atlas): the diegetic atlas / Skiv-pulse
-  // reveal_neighbor system is NOT YET IMPLEMENTED in the backend. There
-  // is no skiv_pulse_fired / biome_focus_changed event anywhere in
-  // apps/backend (the only Skiv route is the devops GitHub-companion in
-  // routes/skiv.js, unrelated to in-game atlas). Per OD-024-031 verdict
-  // record §"Envelope C (OD-026 Diegetic)" this is an explicitly-deferred
-  // ~6h dedicated sprint pending a master-dd design call (custom shader
-  // vs Skiv pulse reuse). OD-026 atlas telemetry therefore CANNOT be
-  // emitted headless without that sprint — analyzer OD-026 stays empty
-  // on real data by design. Intentionally NOT faking skiv_pulse events.
+  // OD-026 atlas (wired 2026-05-17): the Skiv echolocation pulse is now a
+  // REAL backend mechanic. The host character is equipped with
+  // default_parts.senses:['echolocation'] (+ sensori_geomagnetici radius
+  // bonus); the post-attack seam in apps/backend/routes/sessionRoundBridge.js
+  // calls senseReveal.getRevealedTiles(actor, target, world) and, when it
+  // returns ≥1 tile, appends a {action_type:'skiv_pulse_fired',
+  // target_biome_id:<real session biome>} event to session.events. The
+  // round loop above surfaces it (kind:'skiv_pulse_fired') for
+  // telemetry-bridge.js → analyzer OD-026 atlas. Genuine engine output —
+  // emitted only when the real mechanic reveals tiles, never fabricated.
+  // biome_focus_changed remains a Godot-client-only UI interaction (camera
+  // biome focus) with no backend equivalent — intentionally NOT synthesized
+  // headless (analyzer biome_focus_events stays {} by design until the
+  // Godot client emits it).
   await postJson('/api/session/end', { session_id: sessionId });
   // Coop endCombat is host-only; emulate via coopOrchestrator state poll.
   // For sim purposes we rely on session.events VICTORY/DEFEAT to drive


### PR DESCRIPTION
## Summary

Closes the OD-026 telemetry gap: the playtest#2 analyzer now consumes **REAL** `skiv_pulse_fired` events from the genuine `senseReveal` echolocation mechanic, instead of OD-026 staying empty by design.

- **Seam** (`apps/backend/routes/sessionRoundBridge.js`): post-attack, if the attacking actor has `default_parts.senses:[echolocation]` and is off cooldown, the real `senseReveal.getRevealedTiles()` runs; when it reveals ≥1 tile we append `{action_type:'skiv_pulse_fired', actor_id, target_biome_id:<real session biome>}` to `session.events` + `markCooldown`. **No fabrication** — emitted only when the real mechanic reveals tiles.
- **Field preservation bug fixed**: `normaliseUnit` (`sessionHelpers.js`) + `characterToUnit` (`coopOrchestrator.js`) silently dropped `default_parts` ("Engine LIVE Surface DEAD"). Now preserved (additive, back-compat) — without this the sense could never reach a `/start` unit.
- **Harness** (`tests/smoke/ai-driven-sim.js`): equips the host with `echolocation` + `sensori_geomagnetici` (radius bonus, mirrors Envelope C trait equipping), resolves the **real scenario biome** from the encounter YAML (`enc_tutorial_01` → `savana`), and surfaces `session.events` pulse events into the run JSONL (deduped by `action_index`) for `telemetry-bridge.js` → analyzer.

`biome_focus_changed` is a Godot-client-only UI interaction (camera biome focus) with no backend equivalent — **honestly deferred**, not synthesized. Analyzer `biome_focus_events` stays `{}` by design. **Schema coverage 6/7 → 6.5/7.**

## Quality Gate (Global CLAUDE.md, 3 steps)

**Smoke** — real backend (`PORT=3334 LOBBY_WS_PORT=3341`), 3-seed batch (`enc_tutorial_01`, aggressive, 20r): **7 real `skiv_pulse_fired`** captured (`target_biome_id:"savana"`, `revealed_tiles:7-8`). telemetry-bridge passed all 7 through. Analyzer §6 OD-026 = "Pulse events: **7** / Revealed biomes: savana: 7"; `metrics.json` `od026_atlas = {skiv_pulse_events:7, revealed_biomes:{savana:7}, biome_focus_events:{}}` — non-empty from real data. Analyzer exit 0 on the regression fixture (the `--min-sample 30` exit 1 is the RED sample-size verdict on 3 sessions, by design, not a crash).

**Research** — 3 edge cases:
1. *No echolocation actor → 0 pulses, no crash*: `_hasEcholocationSense` false → `getRevealedTiles` `[]` → seam `if (revealed.length>0)` skips. Covered by existing unit test + extra-player chars deliberately senseless; no crashes across 3 runs.
2. *Cooldown blocks repeat → still valid*: real data shows pulses at rounds 15/17/19 — gaps of exactly 2 (`COOLDOWN_ROUNDS`). Events remain valid.
3. *Malformed passthrough skipped*: bridge `readJsonl` skips malformed (counted, non-fatal); synthetic-fixture analyzer stable exit 0 (regression guard intact).

**Tuning** — `skiv_pulse_fired` real (6→7); `biome_focus_changed` honestly deferred (no backend equivalent) → **6.5/7**. Backend suite: **all green (0 fail)**. senseReveal unit test: 6/6 pass (module unchanged). Touched JS Prettier-formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)