### PR TITLE
🧹 Refactor `buildTraitMetadataFromCatalog` for improved readability

### DIFF
--- a/services/generation/biomeSynthesizer.js
+++ b/services/generation/biomeSynthesizer.js
@@ -285,6 +285,50 @@ function cloneAffinity(entries) {
     .filter((entry) => entry.species_id);
 }
 
+function processTraitUsage(entry, usageTags) {
+  const traitUsage = Array.isArray(entry.usage_tags) ? entry.usage_tags.filter(Boolean) : [];
+  traitUsage.forEach((tag) => usageTags.add(tag));
+  return traitUsage;
+}
+
+function processCompletionFlags(entry, completionFlags) {
+  const flags =
+    entry.completion_flags && typeof entry.completion_flags === 'object'
+      ? entry.completion_flags
+      : {};
+  Object.entries(flags).forEach(([key, value]) => {
+    if (typeof value === 'boolean') {
+      completionFlags[key] = completionFlags[key] || value;
+    }
+  });
+  return flags;
+}
+
+function processSpeciesAffinity(entry, affinityMap) {
+  const affinityEntries = cloneAffinity(entry.species_affinity);
+  affinityEntries.forEach((affinity) => {
+    const speciesId = affinity.species_id;
+    if (!speciesId) return;
+    if (!affinityMap.has(speciesId)) {
+      affinityMap.set(speciesId, { species_id: speciesId, roles: new Set(), weight: 0 });
+    }
+    const bucket = affinityMap.get(speciesId);
+    bucket.weight += Number.isFinite(affinity.weight) ? affinity.weight : 0;
+    affinity.roles.forEach((role) => bucket.roles.add(role));
+  });
+  return affinityEntries;
+}
+
+function formatSpeciesAffinity(affinityMap) {
+  return Array.from(affinityMap.values())
+    .map((entry) => ({
+      species_id: entry.species_id,
+      roles: Array.from(entry.roles).sort(),
+      weight: Math.round(entry.weight * 1000) / 1000,
+    }))
+    .sort((a, b) => b.weight - a.weight || a.species_id.localeCompare(b.species_id));
+}
+
 function buildTraitMetadataFromCatalog(traitIds, traitCatalog) {
   if (!traitCatalog || typeof traitCatalog.get !== 'function') {
     return { usage_tags: [], species_affinity: [], completion_flags: {}, per_trait: {} };
@@ -293,48 +337,26 @@ function buildTraitMetadataFromCatalog(traitIds, traitCatalog) {
   const completionFlags = {};
   const affinityMap = new Map();
   const perTrait = {};
+
   traitIds.forEach((traitId) => {
     const entry = traitCatalog.get(traitId);
     if (!entry || typeof entry !== 'object') return;
+
     const id = entry.id || traitId;
-    const traitUsage = Array.isArray(entry.usage_tags) ? entry.usage_tags.filter(Boolean) : [];
-    traitUsage.forEach((tag) => usageTags.add(tag));
-    const flags =
-      entry.completion_flags && typeof entry.completion_flags === 'object'
-        ? entry.completion_flags
-        : {};
-    Object.entries(flags).forEach(([key, value]) => {
-      if (typeof value === 'boolean') {
-        completionFlags[key] = completionFlags[key] || value;
-      }
-    });
-    const affinityEntries = cloneAffinity(entry.species_affinity);
-    affinityEntries.forEach((affinity) => {
-      const speciesId = affinity.species_id;
-      if (!speciesId) return;
-      if (!affinityMap.has(speciesId)) {
-        affinityMap.set(speciesId, { species_id: speciesId, roles: new Set(), weight: 0 });
-      }
-      const bucket = affinityMap.get(speciesId);
-      bucket.weight += Number.isFinite(affinity.weight) ? affinity.weight : 0;
-      affinity.roles.forEach((role) => bucket.roles.add(role));
-    });
+    const traitUsage = processTraitUsage(entry, usageTags);
+    const flags = processCompletionFlags(entry, completionFlags);
+    const affinityEntries = processSpeciesAffinity(entry, affinityMap);
+
     perTrait[id] = {
       usage_tags: [...traitUsage],
       completion_flags: { ...flags },
       species_affinity: affinityEntries,
     };
   });
-  const speciesAffinity = Array.from(affinityMap.values())
-    .map((entry) => ({
-      species_id: entry.species_id,
-      roles: Array.from(entry.roles).sort(),
-      weight: Math.round(entry.weight * 1000) / 1000,
-    }))
-    .sort((a, b) => b.weight - a.weight || a.species_id.localeCompare(b.species_id));
+
   return {
     usage_tags: Array.from(usageTags).sort(),
-    species_affinity: speciesAffinity,
+    species_affinity: formatSpeciesAffinity(affinityMap),
     completion_flags: completionFlags,
     per_trait: perTrait,
   };


### PR DESCRIPTION
🎯 **What:** Extracted several helper functions (`processTraitUsage`, `processCompletionFlags`, `processSpeciesAffinity`, `formatSpeciesAffinity`) from `buildTraitMetadataFromCatalog` to reduce its overall size.
💡 **Why:** `buildTraitMetadataFromCatalog` was too long and contained mixed responsibilities. Breaking it down makes the file more readable and easier to maintain.
✅ **Verification:** Verified by checking code syntax with `node -c` and confirming pure functional refactoring. Code review also passed.
✨ **Result:** Improved modularity and readability of `services/generation/biomeSynthesizer.js`.

---
*PR created automatically by Jules for task [3572821350371046496](https://jules.google.com/task/3572821350371046496) started by @MasterDD-L34D*