### PR TITLE
feat(od026): merge real Godot biome_focus_changed into playtest#2 analyzer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,11 @@ jobs:
               - 'services/**/*.py'
               - 'tests/**/*.py'
               - 'tools/py/**'
+              # OD-038 — the playtest#2 analyzer regression guard
+              # (python-tests job) exercises tools/sim/telemetry-bridge.js
+              # round-trip. Bridge edits MUST re-run that guard, otherwise
+              # the biome_focus / schema-contract assertions are skipped.
+              - 'tools/sim/**'
             data:
               - 'data/**'
               - 'packs/**'
@@ -87,6 +92,8 @@ jobs:
               - 'data/core/**/*.yaml'
               - 'packs/**/*.yaml'
               - 'packages/contracts/schemas/**'
+              # OD-038 — sim bridge JS must hit stack-quality (Prettier).
+              - 'tools/sim/**'
             site_audit:
               - 'ops/site-audit/**'
               - 'Makefile'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,13 +361,43 @@ jobs:
           {"ts":5,"kind":"final_phase","phase":"ended"}
           not-json-malformed-line
           JSONL
-          node tools/sim/telemetry-bridge.js --in /tmp/pt2-batch
+          # SKIP_GODOT_BIOME_FOCUS=1 keeps this round-trip hermetic (no
+          # cross-repo network dependency on the Godot artifact, which may
+          # not yet exist on Game-Godot-v2 main when this PR's CI runs).
+          SKIP_GODOT_BIOME_FOCUS=1 node tools/sim/telemetry-bridge.js --in /tmp/pt2-batch
           test -s /tmp/pt2-batch/playtest-2-telemetry.jsonl
           python tools/py/playtest_2_analyzer.py \
             --telemetry /tmp/pt2-batch/playtest-2-telemetry.jsonl \
             --output /tmp/pt2-bridge-report.md \
             --min-sample 30
           grep -q '## 3. P4 Temperamenti' /tmp/pt2-bridge-report.md
+          # (3) OD-026/OD-038 — Godot biome_focus_changed merge path. Serve
+          # a local fixture over http (fetch has no file:// support) and
+          # assert od026_atlas.biome_focus_events becomes NON-EMPTY with
+          # REAL biome ids + malformed lines skipped. Locks 7-of-7 close.
+          FIX=/tmp/biome-focus.jsonl
+          cat > "$FIX" <<'JSONL'
+          {"session_id":"godot-atlas-biome-focus","event_type":"biome_focus_changed","actor_id":"godot-client","biome_id":"caverna","surface":"tv"}
+          {"session_id":"godot-atlas-biome-focus","event_type":"biome_focus_changed","actor_id":"godot-client","biome_id":"foresta_temperata","surface":"phone"}
+          bad-line-must-be-skipped
+          JSONL
+          ( cd /tmp && python3 -m http.server 8765 >/tmp/httpd.log 2>&1 & echo $! > /tmp/httpd.pid )
+          for i in $(seq 1 20); do curl -fsS http://127.0.0.1:8765/biome-focus.jsonl >/dev/null 2>&1 && break; sleep 0.5; done
+          GODOT_BIOME_FOCUS_URL=http://127.0.0.1:8765/biome-focus.jsonl \
+            node tools/sim/telemetry-bridge.js --in /tmp/pt2-batch --out /tmp/pt2-bf.jsonl
+          kill "$(cat /tmp/httpd.pid)" 2>/dev/null || true
+          python tools/py/playtest_2_analyzer.py \
+            --telemetry /tmp/pt2-bf.jsonl \
+            --output /tmp/pt2-bf-report.md \
+            --json-out /tmp/pt2-bf-metrics.json \
+            --min-sample 30
+          python3 - <<'PY'
+          import json
+          m = json.load(open('/tmp/pt2-bf-metrics.json'))
+          bf = m['od026_atlas']['biome_focus_events']
+          assert bf.get('caverna') == 1 and bf.get('foresta_temperata') == 1, bf
+          print('OD-026 biome_focus_events real & non-empty:', bf)
+          PY
           echo "Playtest #2 analyzer regression guard: PASS"
 
   dataset-checks:

--- a/tools/sim/telemetry-bridge.js
+++ b/tools/sim/telemetry-bridge.js
@@ -248,7 +248,81 @@ function transformRun(events, sessionId) {
   return out;
 }
 
-function main() {
+// OD-026 / OD-038 — fetch REAL biome_focus_changed telemetry produced by
+// the Godot client (Game-Godot-v2). biome_focus_changed is a CLIENT-only
+// UI signal the backend sim never emits, so the analyzer's
+// od026_atlas.biome_focus_events stays empty without this bridge.
+//
+// Mirrors the OD-042-A skiv-monitor cross-repo pattern: the producer
+// (a GUT test) commits a small deterministic analyzer-shaped JSONL to a
+// known path; we fetch it over raw.githubusercontent.com (no cross-repo
+// auth). GRACEFUL DEGRADATION: any failure (offline CI, 404, malformed)
+// → return [] and log a WARN; the analyzer simply shows biome_focus
+// empty exactly as it does today. NEVER fabricate events.
+const GODOT_BIOME_FOCUS_URL =
+  process.env.GODOT_BIOME_FOCUS_URL ||
+  'https://raw.githubusercontent.com/MasterDD-L34D/Game-Godot-v2/main/data/derived/atlas-telemetry/biome-focus.jsonl';
+
+async function fetchGodotBiomeFocus(url) {
+  if (typeof fetch !== 'function') {
+    console.warn('[telemetry-bridge] WARN: global fetch unavailable — skipping Godot biome_focus');
+    return [];
+  }
+  let text;
+  try {
+    const ctl = new AbortController();
+    const timer = setTimeout(() => ctl.abort(), 15000);
+    const res = await fetch(url, { signal: ctl.signal });
+    clearTimeout(timer);
+    if (!res.ok) {
+      console.warn(
+        `[telemetry-bridge] WARN: Godot biome_focus fetch ${res.status} — skipping (non-fatal)`,
+      );
+      return [];
+    }
+    text = await res.text();
+  } catch (err) {
+    console.warn(
+      `[telemetry-bridge] WARN: Godot biome_focus fetch failed (${err.message}) — skipping`,
+    );
+    return [];
+  }
+  const out = [];
+  let skipped = 0;
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let ev;
+    try {
+      ev = JSON.parse(trimmed);
+    } catch {
+      skipped += 1;
+      continue;
+    }
+    // Only accept REAL, well-formed biome_focus_changed events. No invention.
+    if (
+      !ev ||
+      ev.event_type !== 'biome_focus_changed' ||
+      typeof ev.biome_id !== 'string' ||
+      ev.biome_id === ''
+    ) {
+      skipped += 1;
+      continue;
+    }
+    out.push({
+      session_id: String(ev.session_id || 'godot-atlas-biome-focus'),
+      event_type: 'biome_focus_changed',
+      actor_id: ev.actor_id || 'godot-client',
+      biome_id: ev.biome_id,
+    });
+  }
+  if (skipped) {
+    console.warn(`[telemetry-bridge] Godot biome_focus: ${skipped} malformed/irrelevant line(s)`);
+  }
+  return out;
+}
+
+async function main() {
   const args = parseArgs(process.argv);
   const batchDir = resolveBatchDir(args.in);
   const runsDir = path.join(batchDir, 'runs');
@@ -281,18 +355,42 @@ function main() {
     }
   }
 
+  // Merge REAL Godot client biome_focus_changed events (graceful skip on
+  // any failure — analyzer degrades to empty biome_focus exactly as today).
+  let biomeFocus = [];
+  if (process.env.SKIP_GODOT_BIOME_FOCUS !== '1') {
+    biomeFocus = await fetchGodotBiomeFocus(GODOT_BIOME_FOCUS_URL);
+    for (const ev of biomeFocus) {
+      sessionIds.add(ev.session_id);
+      outLines.push(JSON.stringify(ev));
+    }
+  }
+
   fs.writeFileSync(outPath, outLines.join('\n') + (outLines.length ? '\n' : ''));
   console.log(`[telemetry-bridge] batch dir : ${batchDir}`);
   console.log(`[telemetry-bridge] run files : ${runFiles.length}`);
   console.log(`[telemetry-bridge] sessions  : ${sessionIds.size}`);
   console.log(`[telemetry-bridge] events    : ${outLines.length}`);
+  console.log(`[telemetry-bridge] biomefocus: ${biomeFocus.length} real Godot event(s)`);
   console.log(`[telemetry-bridge] skipped   : ${totalSkipped} malformed line(s)`);
   console.log(`[telemetry-bridge] output    : ${outPath}`);
   return 0;
 }
 
 if (require.main === module) {
-  process.exit(main());
+  main().then(
+    (code) => process.exit(code),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    },
+  );
 }
 
-module.exports = { transformRun, normalizeEnnea, buildVcSnapshotPerActor, deriveSessionId };
+module.exports = {
+  transformRun,
+  normalizeEnnea,
+  buildVcSnapshotPerActor,
+  deriveSessionId,
+  fetchGodotBiomeFocus,
+};


### PR DESCRIPTION
## OD-038 — close the LAST playtest#2 schema-coverage gap (6.5/7 → 7/7)

**Consumer half.** Pairs with `MasterDD-L34D/Game-Godot-v2#283` (the producer).

`biome_focus_changed` is a Godot **client-only** UI signal the backend sim never emits, so `od026_atlas.biome_focus_events` was permanently empty. `telemetry-bridge.js` now fetches the real Godot-produced analyzer-shaped JSONL via `raw.githubusercontent.com` (mirrors the proven OD-042-A skiv-monitor cross-repo pattern — no cross-repo auth) and merges it into the bridged telemetry before the analyzer runs.

### Changes
- `tools/sim/telemetry-bridge.js` — `fetchGodotBiomeFocus()` (Node 22 global `fetch`, 15s timeout). Accepts only well-formed `biome_focus_changed` events with non-empty `biome_id`. `main()` is now async; merged events tagged with the synthetic `session_id` so the analyzer groups them. `GODOT_BIOME_FOCUS_URL` / `SKIP_GODOT_BIOME_FOCUS` env overrides.
- `.github/workflows/ci.yml` — extends the playtest#2 regression guard: round-trip stays hermetic (`SKIP_GODOT_BIOME_FOCUS=1`); a new step serves a local fixture over http and asserts `od026_atlas.biome_focus_events` becomes **non-empty with real biome ids** + malformed lines skipped.

### Graceful degradation (non-fatal by design)
Any fetch failure — offline CI, 404 (Godot artifact not yet on main), unreachable host, malformed line — → `WARN` + skip, **exit 0**, analyzer `biome_focus` empty exactly as today. **No fabricated events, ever.**

### Quality Gate
- **Smoke**: real Godot JSONL → fetch+merge → analyzer `biome_focus_events: {caverna:1, foresta_temperata:1}`, exit 0. Synthetic fixture still parses (regression guard intact). Prettier clean.
- **Research (≥3 edge, all validated locally)**: (1) artifact 404 → graceful skip exit 0; (2) unreachable host → graceful skip exit 0; (3) malformed line → skipped, real events still merged; (4) synthetic fixture unchanged.
- **Tuning**: schema-coverage 6.5/7 → **7/7** once both PRs merge (`biome_focus` now sourced from the real Godot signal, not fabricated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)