### PR TITLE
🧹 Refactor buildTraitMetadataFromCatalog for better code health

### DIFF
--- a/services/generation/biomeSynthesizer.js
+++ b/services/generation/biomeSynthesizer.js
@@ -285,6 +285,37 @@ function cloneAffinity(entries) {
     .filter((entry) => entry.species_id);
 }
 
+function mergeCompletionFlags(targetFlags, sourceFlags) {
+  Object.entries(sourceFlags).forEach(([key, value]) => {
+    if (typeof value === 'boolean') {
+      targetFlags[key] = targetFlags[key] || value;
+    }
+  });
+}
+
+function mergeAffinityEntries(affinityMap, affinityEntries) {
+  affinityEntries.forEach((affinity) => {
+    const speciesId = affinity.species_id;
+    if (!speciesId) return;
+    if (!affinityMap.has(speciesId)) {
+      affinityMap.set(speciesId, { species_id: speciesId, roles: new Set(), weight: 0 });
+    }
+    const bucket = affinityMap.get(speciesId);
+    bucket.weight += Number.isFinite(affinity.weight) ? affinity.weight : 0;
+    affinity.roles.forEach((role) => bucket.roles.add(role));
+  });
+}
+
+function finalizeSpeciesAffinity(affinityMap) {
+  return Array.from(affinityMap.values())
+    .map((entry) => ({
+      species_id: entry.species_id,
+      roles: Array.from(entry.roles).sort(),
+      weight: Math.round(entry.weight * 1000) / 1000,
+    }))
+    .sort((a, b) => b.weight - a.weight || a.species_id.localeCompare(b.species_id));
+}
+
 function buildTraitMetadataFromCatalog(traitIds, traitCatalog) {
   if (!traitCatalog || typeof traitCatalog.get !== 'function') {
     return { usage_tags: [], species_affinity: [], completion_flags: {}, per_trait: {} };
@@ -303,38 +334,18 @@ function buildTraitMetadataFromCatalog(traitIds, traitCatalog) {
       entry.completion_flags && typeof entry.completion_flags === 'object'
         ? entry.completion_flags
         : {};
-    Object.entries(flags).forEach(([key, value]) => {
-      if (typeof value === 'boolean') {
-        completionFlags[key] = completionFlags[key] || value;
-      }
-    });
+    mergeCompletionFlags(completionFlags, flags);
     const affinityEntries = cloneAffinity(entry.species_affinity);
-    affinityEntries.forEach((affinity) => {
-      const speciesId = affinity.species_id;
-      if (!speciesId) return;
-      if (!affinityMap.has(speciesId)) {
-        affinityMap.set(speciesId, { species_id: speciesId, roles: new Set(), weight: 0 });
-      }
-      const bucket = affinityMap.get(speciesId);
-      bucket.weight += Number.isFinite(affinity.weight) ? affinity.weight : 0;
-      affinity.roles.forEach((role) => bucket.roles.add(role));
-    });
+    mergeAffinityEntries(affinityMap, affinityEntries);
     perTrait[id] = {
       usage_tags: [...traitUsage],
       completion_flags: { ...flags },
       species_affinity: affinityEntries,
     };
   });
-  const speciesAffinity = Array.from(affinityMap.values())
-    .map((entry) => ({
-      species_id: entry.species_id,
-      roles: Array.from(entry.roles).sort(),
-      weight: Math.round(entry.weight * 1000) / 1000,
-    }))
-    .sort((a, b) => b.weight - a.weight || a.species_id.localeCompare(b.species_id));
   return {
     usage_tags: Array.from(usageTags).sort(),
-    species_affinity: speciesAffinity,
+    species_affinity: finalizeSpeciesAffinity(affinityMap),
     completion_flags: completionFlags,
     per_trait: perTrait,
   };


### PR DESCRIPTION
🎯 **What:** Extracted logical blocks from `buildTraitMetadataFromCatalog` into three helper functions: `mergeCompletionFlags`, `mergeAffinityEntries`, and `finalizeSpeciesAffinity`.
💡 **Why:** The `buildTraitMetadataFromCatalog` function was too long and complex, making it harder to maintain. By extracting the flag merging and affinity processing logic into distinct helpers, the main function is now significantly cleaner and its flow is easier to understand.
✅ **Verification:** Ran test suites encompassing biome generation, synthesizers, affinity, modifiers, resonance, and spawn bias. All suites passed. Requested code review, which passed without issues.
✨ **Result:** Improved codebase maintainability without any behavioral changes.

---
*PR created automatically by Jules for task [6156687873337617988](https://jules.google.com/task/6156687873337617988) started by @MasterDD-L34D*