### PR TITLE
fix(od026): read Godot biome_focus from committed jsonl, not private-repo raw 404

### DIFF
--- a/data/derived/atlas-telemetry/biome-focus.jsonl
+++ b/data/derived/atlas-telemetry/biome-focus.jsonl
@@ -1,0 +1,6 @@
+{"session_id":"godot-atlas-biome-focus","event_type":"biome_focus_changed","actor_id":"godot-client","biome_id":"caverna","surface":"tv"}
+{"session_id":"godot-atlas-biome-focus","event_type":"biome_focus_changed","actor_id":"godot-client","biome_id":"foresta_temperata","surface":"tv"}
+{"session_id":"godot-atlas-biome-focus","event_type":"biome_focus_changed","actor_id":"godot-client","biome_id":"atollo_obsidiana","surface":"tv"}
+{"session_id":"godot-atlas-biome-focus","event_type":"biome_focus_changed","actor_id":"godot-client","biome_id":"caverna","surface":"phone"}
+{"session_id":"godot-atlas-biome-focus","event_type":"biome_focus_changed","actor_id":"godot-client","biome_id":"foresta_temperata","surface":"phone"}
+{"session_id":"godot-atlas-biome-focus","event_type":"biome_focus_changed","actor_id":"godot-client","biome_id":"atollo_obsidiana","surface":"phone"}

--- a/docs/runbook/od026-biome-focus-sync.md
+++ b/docs/runbook/od026-biome-focus-sync.md
@@ -1,0 +1,59 @@
+# OD-026 — Godot `biome_focus_changed` telemetry sync
+
+## What this is
+
+`data/derived/atlas-telemetry/biome-focus.jsonl` is the **real, deterministic**
+`biome_focus_changed` signal export captured from the Godot client
+(`Game-Godot-v2`). It is consumed by `tools/sim/telemetry-bridge.js`, which
+merges it into the playtest-2 telemetry stream so
+`tools/py/playtest_2_analyzer.py` can populate
+`od026_atlas.biome_focus_events` — the field that completes the advertised
+playtest schema-coverage **7/7**.
+
+`biome_focus_changed` is a **client-only UI signal**: the backend sim never
+emits it. Without this committed export the analyzer field stays empty.
+
+## Why it is committed (not fetched live)
+
+The original OD-026 implementation reused the OD-042-A skiv-monitor pattern:
+fetch the producer's JSONL over `raw.githubusercontent.com`. That works for
+skiv-monitor only because its producer repo is **public**.
+
+`Game-Godot-v2` is a **private** repo. `raw.githubusercontent.com` serves
+**only public repos** and ignores auth → the live fetch returned **404
+forever in production**. The bridge's graceful-skip then silently emitted
+`[]`, so the advertised "7/7" was actually **6.5/7 in production with no
+error** (dangerous silent degradation).
+
+The data is small (6 lines, 875 bytes) and **deterministic**: the Godot GUT
+test drives 3 fixed pilot biomes × 2 surfaces, so the output is fixed and
+reproducible. Committing the real captured bytes into this **public** repo
+is honest, version-controlled, and removes the private-repo network
+dependency entirely. It is **not** fabricated and **not** a stub.
+
+## How to regenerate (when atlas pilot biomes change)
+
+1. In `Game-Godot-v2`, run the GUT export test:
+   `test_biome_focus_telemetry_export.gd`
+   (it writes `data/derived/atlas-telemetry/biome-focus.jsonl`).
+2. Copy that file **byte-for-byte** into this repo at the same path:
+   `data/derived/atlas-telemetry/biome-focus.jsonl`.
+   Quick path with a PAT that has Contents read on the private repo:
+
+   ```sh
+   gh api repos/MasterDD-L34D/Game-Godot-v2/contents/data/derived/atlas-telemetry/biome-focus.jsonl \
+     --jq '.content' | base64 -d > data/derived/atlas-telemetry/biome-focus.jsonl
+   ```
+3. Commit the change. The bridge picks it up automatically (local-first
+   read, no code change needed).
+
+## Transport contract (telemetry-bridge.js)
+
+- **Default**: read the committed local file
+  `data/derived/atlas-telemetry/biome-focus.jsonl` (no network).
+- **Optional override**: set `GODOT_BIOME_FOCUS_URL` to a reachable URL to
+  fetch remotely instead. If the override is unreachable, the bridge falls
+  back to the local committed file.
+- **Graceful skip**: file missing / unreadable / all lines malformed →
+  emit `[]`, log a WARN, never fatal, never fabricate.
+- `SKIP_GODOT_BIOME_FOCUS=1` disables the merge entirely (unchanged).

--- a/tools/sim/telemetry-bridge.js
+++ b/tools/sim/telemetry-bridge.js
@@ -248,45 +248,45 @@ function transformRun(events, sessionId) {
   return out;
 }
 
-// OD-026 / OD-038 — fetch REAL biome_focus_changed telemetry produced by
-// the Godot client (Game-Godot-v2). biome_focus_changed is a CLIENT-only
+// OD-026 / OD-038 / OD-026-FIX — REAL biome_focus_changed telemetry produced
+// by the Godot client (Game-Godot-v2). biome_focus_changed is a CLIENT-only
 // UI signal the backend sim never emits, so the analyzer's
 // od026_atlas.biome_focus_events stays empty without this bridge.
 //
-// Mirrors the OD-042-A skiv-monitor cross-repo pattern: the producer
-// (a GUT test) commits a small deterministic analyzer-shaped JSONL to a
-// known path; we fetch it over raw.githubusercontent.com (no cross-repo
-// auth). GRACEFUL DEGRADATION: any failure (offline CI, 404, malformed)
-// → return [] and log a WARN; the analyzer simply shows biome_focus
-// empty exactly as it does today. NEVER fabricate events.
-const GODOT_BIOME_FOCUS_URL =
-  process.env.GODOT_BIOME_FOCUS_URL ||
-  'https://raw.githubusercontent.com/MasterDD-L34D/Game-Godot-v2/main/data/derived/atlas-telemetry/biome-focus.jsonl';
+// TRANSPORT (fixed): the producer is the Godot GUT test
+// `test_biome_focus_telemetry_export.gd` in Game-Godot-v2, which writes a
+// small DETERMINISTIC analyzer-shaped JSONL (3 fixed pilot biomes × 2
+// surfaces = 6 lines, 875 bytes). The original OD-026 reused the OD-042-A
+// skiv-monitor raw.githubusercontent.com pattern — but that pattern only
+// works because the skiv producer repo is PUBLIC. Game-Godot-v2 is PRIVATE,
+// so raw.githubusercontent.com returns 404 forever with no auth → the
+// graceful-skip silently emitted [] and the advertised "schema-coverage
+// 7/7" was actually 6.5/7 in production with NO error.
+//
+// FIX: commit the real captured deterministic export into THIS public repo
+// at data/derived/atlas-telemetry/biome-focus.jsonl (byte-identical copy of
+// the Game-Godot-v2 GUT export) and read it LOCALLY first — no network, no
+// private-repo dependency. The GODOT_BIOME_FOCUS_URL env override is kept
+// as an OPTIONAL remote fallback (only used if explicitly set to a
+// reachable URL). REGEN: when the atlas pilot biomes change, re-run the
+// GUT export test in Game-Godot-v2 and copy its biome-focus.jsonl here.
+// See docs/runbook/od026-biome-focus-sync.md.
+//
+// GRACEFUL DEGRADATION preserved: file missing / malformed / unreachable
+// override → return [] and log a WARN; analyzer shows biome_focus empty
+// exactly as before. NEVER fabricate events.
+const GODOT_BIOME_FOCUS_LOCAL = path.join(
+  __dirname,
+  '..',
+  '..',
+  'data',
+  'derived',
+  'atlas-telemetry',
+  'biome-focus.jsonl',
+);
+const GODOT_BIOME_FOCUS_URL = process.env.GODOT_BIOME_FOCUS_URL || '';
 
-async function fetchGodotBiomeFocus(url) {
-  if (typeof fetch !== 'function') {
-    console.warn('[telemetry-bridge] WARN: global fetch unavailable — skipping Godot biome_focus');
-    return [];
-  }
-  let text;
-  try {
-    const ctl = new AbortController();
-    const timer = setTimeout(() => ctl.abort(), 15000);
-    const res = await fetch(url, { signal: ctl.signal });
-    clearTimeout(timer);
-    if (!res.ok) {
-      console.warn(
-        `[telemetry-bridge] WARN: Godot biome_focus fetch ${res.status} — skipping (non-fatal)`,
-      );
-      return [];
-    }
-    text = await res.text();
-  } catch (err) {
-    console.warn(
-      `[telemetry-bridge] WARN: Godot biome_focus fetch failed (${err.message}) — skipping`,
-    );
-    return [];
-  }
+function parseBiomeFocusText(text) {
   const out = [];
   let skipped = 0;
   for (const line of text.split('\n')) {
@@ -320,6 +320,65 @@ async function fetchGodotBiomeFocus(url) {
     console.warn(`[telemetry-bridge] Godot biome_focus: ${skipped} malformed/irrelevant line(s)`);
   }
   return out;
+}
+
+async function fetchRemoteBiomeFocus(url) {
+  if (typeof fetch !== 'function') {
+    console.warn(
+      '[telemetry-bridge] WARN: global fetch unavailable — skipping Godot biome_focus override',
+    );
+    return null;
+  }
+  try {
+    const ctl = new AbortController();
+    const timer = setTimeout(() => ctl.abort(), 15000);
+    const res = await fetch(url, { signal: ctl.signal });
+    clearTimeout(timer);
+    if (!res.ok) {
+      console.warn(
+        `[telemetry-bridge] WARN: Godot biome_focus override fetch ${res.status} — skipping (non-fatal)`,
+      );
+      return null;
+    }
+    return await res.text();
+  } catch (err) {
+    console.warn(
+      `[telemetry-bridge] WARN: Godot biome_focus override fetch failed (${err.message}) — skipping`,
+    );
+    return null;
+  }
+}
+
+// Local-first: read the committed deterministic Godot export from THIS
+// public repo. Optional GODOT_BIOME_FOCUS_URL override fetches remotely
+// instead (only if explicitly set + reachable). Any total absence →
+// [] (graceful skip), never fatal, never fabricated.
+async function fetchGodotBiomeFocus(localPath, overrideUrl) {
+  if (overrideUrl) {
+    const text = await fetchRemoteBiomeFocus(overrideUrl);
+    if (text !== null) {
+      return parseBiomeFocusText(text);
+    }
+    console.warn(
+      '[telemetry-bridge] WARN: override URL unusable — falling back to local committed jsonl',
+    );
+  }
+  if (!fs.existsSync(localPath)) {
+    console.warn(
+      `[telemetry-bridge] WARN: local Godot biome_focus jsonl missing (${localPath}) — skipping (non-fatal)`,
+    );
+    return [];
+  }
+  let text;
+  try {
+    text = fs.readFileSync(localPath, 'utf8');
+  } catch (err) {
+    console.warn(
+      `[telemetry-bridge] WARN: local Godot biome_focus read failed (${err.message}) — skipping`,
+    );
+    return [];
+  }
+  return parseBiomeFocusText(text);
 }
 
 async function main() {
@@ -359,7 +418,7 @@ async function main() {
   // any failure — analyzer degrades to empty biome_focus exactly as today).
   let biomeFocus = [];
   if (process.env.SKIP_GODOT_BIOME_FOCUS !== '1') {
-    biomeFocus = await fetchGodotBiomeFocus(GODOT_BIOME_FOCUS_URL);
+    biomeFocus = await fetchGodotBiomeFocus(GODOT_BIOME_FOCUS_LOCAL, GODOT_BIOME_FOCUS_URL);
     for (const ev of biomeFocus) {
       sessionIds.add(ev.session_id);
       outLines.push(JSON.stringify(ev));


### PR DESCRIPTION
## Bug (silent production degradation, shipped by #2290)

`tools/sim/telemetry-bridge.js` fetched `biome_focus_changed` telemetry from
**Game-Godot-v2** over `raw.githubusercontent.com`. Game-Godot-v2 is a
**PRIVATE** repo; `raw.githubusercontent.com` serves only public repos →
the fetch **404'd forever in production**. The graceful-skip then silently
emitted `[]`, so `od026_atlas.biome_focus_events` stayed empty and the
advertised playtest **schema-coverage "7/7" was actually 6.5/7 in
production with NO error**. The OD-042-A skiv-monitor raw pattern was wrongly
reused (skiv works only because its producer repo is public).

## Fix (minimal, correct, robust)

- Commit the **real, deterministic** Godot GUT export (byte-identical copy
  fetched from Game-Godot-v2 via Contents API — 6 lines / 875 bytes, 3 fixed
  pilot biomes × 2 surfaces) into this **PUBLIC** repo at
  `data/derived/atlas-telemetry/biome-focus.jsonl`.
- `telemetry-bridge.js` reads this **local committed file first** (no
  network, no private-repo dependency). `GODOT_BIOME_FOCUS_URL` kept as an
  **optional** remote override with graceful fallback to the local file.
- All skip paths preserved (missing/malformed/`SKIP_GODOT_BIOME_FOCUS=1`).
- Added `docs/runbook/od026-biome-focus-sync.md` (regen procedure).
  Not fabricated, not a stub: deterministic real signal output,
  version-controlled, documented regeneration.

## Quality Gate

**Smoke** — bridge reads local jsonl, no network → 6 real events →
`playtest_2_analyzer.py` yields
`od026_atlas.biome_focus_events = {caverna:2, foresta_temperata:2, atollo_obsidiana:2}`
(non-empty, real biomes), exit 0.

**Research** (3 edge cases, all pass):
1. Local file missing → `WARN ... missing — skipping (non-fatal)`, `biomefocus: 0`, exit 0, no crash.
2. Malformed/empty-biome lines → skipped (counted), 6 real events still emitted.
3. `GODOT_BIOME_FOCUS_URL` set + reachable → override used (1 real event), malformed override line skipped, local bypassed; unreachable override → graceful fallback to local file.

**Tuning** — before: prod = **6.5/7 silently broken** (private-repo raw 404,
silent `[]`). after: prod = **7/7 real** via committed deterministic Godot
output, version-controlled and documented. Silent degradation eliminated;
transport no longer depends on a private repo over an auth-less endpoint.

## CI

`tools/sim/**` + `data/**` changes correctly trigger `python-tests`
(analyzer regression guard) and `stack-quality` (Prettier) via paths-filter.
The existing CI guard part (3) sets a reachable `GODOT_BIOME_FOCUS_URL` →
exercises the override path unchanged; part (2) uses
`SKIP_GODOT_BIOME_FOCUS=1` unchanged. Prettier: file already formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)