### PR TITLE
fix(governance): remove dead ADR-XXX-refactor-cli placeholder unblocking merge queue

### DIFF
--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -591,19 +591,6 @@
       "track": "active"
     },
     {
-      "path": "docs/adr/ADR-XXX-refactor-cli.md",
-      "title": "ADR-XXX: Motivazioni refactor CLI e allineamento toolchain",
-      "doc_status": "active",
-      "doc_owner": "platform-docs",
-      "workstream": "cross-cutting",
-      "last_verified": "2026-05-06",
-      "source_of_truth": false,
-      "language": "it-en",
-      "review_cycle_days": 14,
-      "primary": false,
-      "track": "migrated"
-    },
-    {
       "path": "docs/appendici/A-CANVAS_ORIGINALE.md",
       "title": "Canvas A — Originale (A.L.I.E.N.A.)",
       "doc_status": "active",


### PR DESCRIPTION
## Problema
Il check CI **`governance`** (`tools/check_docs_governance.py --registry docs/governance/docs_registry.json --strict`) fallisce con **`errors=1`** (`path_missing`) su ogni branch PR -> required gate -> **blocca l'intera coda merge repo-wide** (motivo reale dello "0 mergeable" su tutti i PR Jules, NON il codice Jules).

## Causa
`docs_registry.json` conteneva un **entry duplicato placeholder**:
`docs/adr/ADR-XXX-refactor-cli.md` (XXX letterale, file inesistente),
introdotto dal commit migrator-registry. L'ADR reale e' gia' registrato
correttamente come `ADR-2025-11-refactor-cli.md`.

## Fix
Rimosso il solo blocco placeholder morto (-13 righe, 1 entry). Zero impatto sull'ADR reale.

## Verifica
`check_docs_governance.py --strict` post-fix: **`errors=0 warnings=52`** (i 52 warning = doc stale, non-bloccanti, pre-esistenti e fuori scope di questo fix).

Diagnosi: artifact CI `docs-governance-report-25993429426` + `git show origin/main`. Branch+PR per review/merge Eduardo (no self-merge).