### PR TITLE
feat(forms): A6 starter_bioma frontend label surface (Engine LIVE killer)

### DIFF
--- a/apps/backend/services/forms/formPackRecommender.js
+++ b/apps/backend/services/forms/formPackRecommender.js
@@ -23,27 +23,109 @@ const yaml = require('js-yaml');
 const BIAS_FILE = path.join(process.cwd(), 'data', 'core', 'forms', 'form_pack_bias.yaml');
 let _cache = null;
 
-// QW2 / M-017: Form -> starter bioma mapping (slot `starter_bioma` resolution).
+// QW2 / M-017 / A6: Form -> starter bioma mapping (slot `starter_bioma`).
 // Each Form has a thematic biome + dedicated trait `starter_bioma_<form_id>`
 // defined in data/core/traits/active_effects.yaml + glossary.json.
-// Wire UI onboarding panel = follow-up PR.
+// biome_label_it / trait_label_it sourced from biomes.yaml display_name_it +
+// glossary.json label_it (frontend surface label, A6 Engine LIVE Surface DEAD
+// killer). If those source files drift, regen via `npm run lint:starter-bioma`.
 const STARTER_BIOMA_MAP = Object.freeze({
-  ISTJ: { biome_id: 'steppe_algoritmiche', trait_id: 'starter_bioma_istj' },
-  ISFJ: { biome_id: 'foresta_temperata', trait_id: 'starter_bioma_isfj' },
-  INFJ: { biome_id: 'foresta_miceliale', trait_id: 'starter_bioma_infj' },
-  INTJ: { biome_id: 'rovine_planari', trait_id: 'starter_bioma_intj' },
-  ISTP: { biome_id: 'caverna', trait_id: 'starter_bioma_istp' },
-  ISFP: { biome_id: 'reef_luminescente', trait_id: 'starter_bioma_isfp' },
-  INFP: { biome_id: 'foresta_acida', trait_id: 'starter_bioma_infp' },
-  INTP: { biome_id: 'canyons_risonanti', trait_id: 'starter_bioma_intp' },
-  ESTP: { biome_id: 'savana', trait_id: 'starter_bioma_estp' },
-  ESFP: { biome_id: 'dorsale_termale_tropicale', trait_id: 'starter_bioma_esfp' },
-  ENFP: { biome_id: 'canopia_ionica', trait_id: 'starter_bioma_enfp' },
-  ENTP: { biome_id: 'atollo_obsidiana', trait_id: 'starter_bioma_entp' },
-  ESTJ: { biome_id: 'badlands', trait_id: 'starter_bioma_estj' },
-  ESFJ: { biome_id: 'pianura_salina_iperarida', trait_id: 'starter_bioma_esfj' },
-  ENFJ: { biome_id: 'palude', trait_id: 'starter_bioma_enfj' },
-  ENTJ: { biome_id: 'abisso_vulcanico', trait_id: 'starter_bioma_entj' },
+  ISTJ: {
+    biome_id: 'steppe_algoritmiche',
+    biome_label_it: 'Steppe Algoritmiche',
+    trait_id: 'starter_bioma_istj',
+    trait_label_it: 'Adattamento Steppe (ISTJ)',
+  },
+  ISFJ: {
+    biome_id: 'foresta_temperata',
+    biome_label_it: 'Foresta Temperata Umida',
+    trait_id: 'starter_bioma_isfj',
+    trait_label_it: 'Adattamento Foresta Temperata (ISFJ)',
+  },
+  INFJ: {
+    biome_id: 'foresta_miceliale',
+    biome_label_it: 'Foresta Miceliale',
+    trait_id: 'starter_bioma_infj',
+    trait_label_it: 'Adattamento Foresta Miceliale (INFJ)',
+  },
+  INTJ: {
+    biome_id: 'rovine_planari',
+    biome_label_it: 'Rovine Planari Fratturate',
+    trait_id: 'starter_bioma_intj',
+    trait_label_it: 'Adattamento Rovine Planari (INTJ)',
+  },
+  ISTP: {
+    biome_id: 'caverna',
+    biome_label_it: 'Caverna Risonante',
+    trait_id: 'starter_bioma_istp',
+    trait_label_it: 'Adattamento Caverna (ISTP)',
+  },
+  ISFP: {
+    biome_id: 'reef_luminescente',
+    biome_label_it: 'Scogliera Luminescente',
+    trait_id: 'starter_bioma_isfp',
+    trait_label_it: 'Adattamento Reef Luminescente (ISFP)',
+  },
+  INFP: {
+    biome_id: 'foresta_acida',
+    biome_label_it: 'Foresta Acida',
+    trait_id: 'starter_bioma_infp',
+    trait_label_it: 'Adattamento Foresta Acida (INFP)',
+  },
+  INTP: {
+    biome_id: 'canyons_risonanti',
+    biome_label_it: 'Canyon Risonanti',
+    trait_id: 'starter_bioma_intp',
+    trait_label_it: 'Adattamento Canyons Risonanti (INTP)',
+  },
+  ESTP: {
+    biome_id: 'savana',
+    biome_label_it: 'Savana Ionizzata',
+    trait_id: 'starter_bioma_estp',
+    trait_label_it: 'Adattamento Savana (ESTP)',
+  },
+  ESFP: {
+    biome_id: 'dorsale_termale_tropicale',
+    biome_label_it: 'Dorsale Termale Tropicale',
+    trait_id: 'starter_bioma_esfp',
+    trait_label_it: 'Adattamento Dorsale Tropicale (ESFP)',
+  },
+  ENFP: {
+    biome_id: 'canopia_ionica',
+    biome_label_it: 'Canopia Ionica',
+    trait_id: 'starter_bioma_enfp',
+    trait_label_it: 'Adattamento Canopia Ionica (ENFP)',
+  },
+  ENTP: {
+    biome_id: 'atollo_obsidiana',
+    biome_label_it: 'Atollo di Ossidiana',
+    trait_id: 'starter_bioma_entp',
+    trait_label_it: 'Adattamento Atollo Obsidiana (ENTP)',
+  },
+  ESTJ: {
+    biome_id: 'badlands',
+    biome_label_it: 'Calanchi Ferromagnetici',
+    trait_id: 'starter_bioma_estj',
+    trait_label_it: 'Adattamento Badlands (ESTJ)',
+  },
+  ESFJ: {
+    biome_id: 'pianura_salina_iperarida',
+    biome_label_it: 'Pianura Salina Iperarida',
+    trait_id: 'starter_bioma_esfj',
+    trait_label_it: 'Adattamento Pianura Salina (ESFJ)',
+  },
+  ENFJ: {
+    biome_id: 'palude',
+    biome_label_it: 'Palude Tossica',
+    trait_id: 'starter_bioma_enfj',
+    trait_label_it: 'Adattamento Palude (ENFJ)',
+  },
+  ENTJ: {
+    biome_id: 'abisso_vulcanico',
+    biome_label_it: 'Abisso Vulcanico',
+    trait_id: 'starter_bioma_entj',
+    trait_label_it: 'Adattamento Abisso Vulcanico (ENTJ)',
+  },
 });
 
 function loadBias() {
@@ -109,7 +191,9 @@ function listStarterBiomas() {
   return Object.entries(STARTER_BIOMA_MAP).map(([form_id, v]) => ({
     form_id,
     biome_id: v.biome_id,
+    biome_label_it: v.biome_label_it,
     trait_id: v.trait_id,
+    trait_label_it: v.trait_label_it,
   }));
 }
 

--- a/apps/play/src/characterCreation.js
+++ b/apps/play/src/characterCreation.js
@@ -225,11 +225,14 @@ export function wireCharacterCreation(overlay, bridge) {
         starterBiomaEl.textContent = '';
         return;
       }
-      const biomeLabel = data.biome_id.replace(/_/g, ' ');
+      // A6 — prefer human label (biome_label_it / trait_label_it) over raw id.
+      // Fallback retro-compat: biome_id underscore-replace, trait_id raw.
+      const biomeLabel = data.biome_label_it || data.biome_id.replace(/_/g, ' ');
+      const traitLabel = data.trait_label_it || data.trait_id;
       starterBiomaEl.innerHTML =
         `<div class="cc-preview-starter-bioma-title">Bioma origine</div>` +
         `<span class="cc-preview-starter-bioma-biome">🌍 ${biomeLabel}</span>` +
-        ` → <span class="cc-preview-starter-bioma-trait">${data.trait_id}</span>`;
+        ` → <span class="cc-preview-starter-bioma-trait">${traitLabel}</span>`;
     } catch {
       starterBiomaEl.textContent = '';
     }

--- a/tests/api/formPackRecommender.test.js
+++ b/tests/api/formPackRecommender.test.js
@@ -167,6 +167,22 @@ test('resolveStarterBioma: 16 forms map to {biome_id, trait_id}', () => {
   }
 });
 
+// A6 frontend label surface — every form must expose biome_label_it +
+// trait_label_it (Engine LIVE Surface DEAD killer).
+test('resolveStarterBioma: 16 forms expose biome_label_it + trait_label_it', () => {
+  for (const f of ALL_16_FORMS) {
+    const r = resolveStarterBioma(f);
+    assert.equal(typeof r.biome_label_it, 'string', `${f} biome_label_it`);
+    assert.ok(r.biome_label_it.length > 0, `${f} biome_label_it non-empty`);
+    assert.equal(typeof r.trait_label_it, 'string', `${f} trait_label_it`);
+    assert.ok(r.trait_label_it.length > 0, `${f} trait_label_it non-empty`);
+    assert.ok(
+      r.trait_label_it.includes(f),
+      `${f} trait_label_it should mention form id (got: ${r.trait_label_it})`,
+    );
+  }
+});
+
 test('resolveStarterBioma: unknown / NEUTRA returns null', () => {
   assert.equal(resolveStarterBioma('XXXX'), null);
   assert.equal(resolveStarterBioma('NEUTRA'), null);
@@ -175,13 +191,15 @@ test('resolveStarterBioma: unknown / NEUTRA returns null', () => {
   assert.equal(resolveStarterBioma(undefined), null);
 });
 
-test('listStarterBiomas: returns 16 items with form_id+biome_id+trait_id', () => {
+test('listStarterBiomas: returns 16 items with form_id+biome_id+trait_id+labels', () => {
   const list = listStarterBiomas();
   assert.equal(list.length, 16);
   for (const item of list) {
     assert.ok(ALL_16_FORMS.includes(item.form_id));
     assert.ok(item.biome_id.length > 0);
     assert.ok(item.trait_id.startsWith('starter_bioma_'));
+    assert.ok(item.biome_label_it && item.biome_label_it.length > 0);
+    assert.ok(item.trait_label_it && item.trait_label_it.length > 0);
   }
 });
 

--- a/tests/api/formPackRoutes.test.js
+++ b/tests/api/formPackRoutes.test.js
@@ -75,6 +75,9 @@ test('GET /api/forms/INTJ/starter-bioma: resolves single form', async (t) => {
   assert.equal(res.body.form_id, 'INTJ');
   assert.equal(res.body.trait_id, 'starter_bioma_intj');
   assert.equal(res.body.biome_id, 'rovine_planari');
+  // A6 surface labels (frontend label gap killer).
+  assert.equal(res.body.biome_label_it, 'Rovine Planari Fratturate');
+  assert.equal(res.body.trait_label_it, 'Adattamento Rovine Planari (INTJ)');
 });
 
 test('GET /api/forms/XXXX/starter-bioma: 404 for unknown form', async (t) => {


### PR DESCRIPTION
## Summary

Closes BACKLOG row **A6 starter_bioma trait** — `🟡 PARTIAL → ✅ DONE` (frontend label gap, ~30 LOC stimati). Anti-pattern killer **Engine LIVE Surface DEAD** (Gate 5).

Pre-PR state: backend chain ✅ shipped (16 STARTER_BIOMA_MAP entries + active_effects.yaml + glossary.json + route `/api/forms/:formId/starter-bioma`), ma surface frontend mostrava raw `biome_id.replace(/_/g, ' ')` + raw `trait_id` (`starter_bioma_isfj` invece di `Adattamento Foresta Temperata (ISFJ)`).

## Changes

- **`apps/backend/services/forms/formPackRecommender.js`**: STARTER_BIOMA_MAP extended con 2 nuovi field per ognuna delle 16 Form MBTI:
  - `biome_label_it` — sourced da `data/core/biomes.yaml` `display_name_it`
  - `trait_label_it` — sourced da `data/core/traits/glossary.json` `label_it`
  - `listStarterBiomas()` shape esteso retro-compat (additive, nessun breaking).
- **`apps/play/src/characterCreation.js`**: render usa `data.biome_label_it || data.biome_id.replace(...)` + `data.trait_label_it || data.trait_id` (fallback retro-compat zero-break).
- **Tests** (`tests/api/formPackRecommender.test.js` + `tests/api/formPackRoutes.test.js`):
  - 16/16 forms espongono `biome_label_it` + `trait_label_it` non-empty
  - `trait_label_it` deve menzionare l'id Form (es. `(ISFJ)`)
  - GET `/api/forms/INTJ/starter-bioma` asserisce label INTJ esatti

## Live probe

```bash
curl http://localhost:3334/api/forms/INTJ/starter-bioma
# {"form_id":"INTJ","biome_id":"rovine_planari",
#  "biome_label_it":"Rovine Planari Fratturate",
#  "trait_id":"starter_bioma_intj",
#  "trait_label_it":"Adattamento Rovine Planari (INTJ)"}
```

## Test plan

- [x] `node --test tests/api/formPackRecommender.test.js tests/api/formPackRoutes.test.js` → 36/36 verde
- [x] Prettier verde sui 4 file editati
- [x] Backend live probe `/api/forms/INTJ/starter-bioma` + `/api/forms/ENFJ/starter-bioma` + `/api/forms/starter-biomas` confermano payload shape
- [ ] Frontend visual smoke character creation overlay (post-merge userland — dev probe API è proxy del wire)

## Rollback plan

Revert single commit `b5889002`. Frontend ha fallback retro-compat sui field nuovi assenti (zero-break).

## Authority

Parallel session Lenovo branch `claude/parallel-game-a6-frontend-2026-05-20`. Coordinato vs sessione Ryzen (governance OD-050 chiusa, scope ortogonale). Stamp ownership in `codemasterdd-ai-station` `docs/sessions/2026-05-19-continuity-handoff.md` §Parallel-session log 2026-05-20.