### PR TITLE
fix(play): restore W8O-2 clearAbilities token-bump + regression test (rolled back by #2327)

### DIFF
--- a/apps/play/src/abilityPanel.js
+++ b/apps/play/src/abilityPanel.js
@@ -100,6 +100,13 @@ export async function renderAbilities(unit, state, onAbility) {
 }
 
 export function clearAbilities() {
+  // W8O-2 (re-applied 2026-05-20, regressed by Jules #2327 rewrite that dropped
+  // this line; first landed PR #2321): invalidate any in-flight renderAbilities
+  // await. Without this, a render started before clear (token still latest)
+  // resurrects abilities for the gone unit when loadJobDetail resolves. Same
+  // bug class as W8/W8O ("barra si e buggata"). Regression test in
+  // tests/play/abilityPanelClearRace.test.js MUST stay green.
+  _renderToken += 1;
   const titleEl = document.getElementById('abilities-title');
   const container = document.getElementById('abilities');
   if (titleEl) titleEl.classList.add('hidden-empty');

--- a/docs/museum/MUSEUM.md
+++ b/docs/museum/MUSEUM.md
@@ -47,6 +47,7 @@
 - [Cogmind Tooltip Stratificati](cards/ui-cogmind-tooltip-stratificati-quick-win.md) — **4/5** · P2+P3 quick-win UI ~5h · unintegrated
 - [Tier E Quick Wins (DuckDB + SPRT + LLM critic)](cards/telemetry-duckdb-stockfish-llm-critic-quick-wins.md) — **4/5** · P6 ops bundle ~10-15h, Pathfinder XP shipped #1894 · unintegrated
 - [NS2 Strategist + Frozen Synapse Replay](cards/coop-ns2-frozen-synapse-replay-asymmetric.md) — **4/5** · P5 replay cinematico + 5p+ asymmetric · unintegrated
+- [Coop WS Test Infra Patterns](cards/coop-ws-test-infra-patterns-2026-05-20.md) — **5/5** · 6 pattern riusabili per disconnect-race + host-transfer e2e · unintegrated
 
 ---
 
@@ -103,6 +104,10 @@ _Pool secco. 10/10 species in `incoming/species/*.json` già canonical via commi
 
 - [BiomeMemory + Costo ambientale trait](cards/architecture-biome-memory-trait-cost.md) — score 4/5 · 3 exploration-note + Skiv biome-mover · deferred
 
+### Test infrastructure
+
+- [Coop WS Test Infra Patterns](cards/coop-ws-test-infra-patterns-2026-05-20.md) — score 5/5 · 6 pattern riusabili (spinUp/attachBuffer/ghostTimeoutMs/connectedPids/coopStore seed/terminate vs close) per disconnect-race + host-transfer e2e · unintegrated
+
 ### Pipeline failure modes
 
 - [evo-swarm run #5 discarded claims](cards/evo-swarm-run-5-discarded-claims.md) — score 4/5 · 8 hallucinated + 2 redundant, OD-022 gate reference + LLM prompt training · curated (⚠️ user-requested autonomous deviation Museum-first protocol — repo-archaeologist agent review pending)
@@ -151,11 +156,11 @@ _Restanti: 22 artifact in inventory (1 ADR formally Superseded + 4 partial super
 
 ## 📊 Stats
 
-- **Excavations run**: 12 totali (4 session-1 + 4 session-2 + 1 session-3: worldgen + 1 session-5: ancestors reentry + 1 session-6 cross-validation 2026-05-13 + 1 session-7 Phase 3 Path D methodology 2026-05-15)
-- **Artifact identificati**: ~101 totali (100 precedenti + 1 Phase 3 Path D HYBRID methodology pattern)
-- **Cards total**: 34 curate (8 score 5/5 · 13 score 4/5 · 11 score 3/5 · 2 score 2/5) — +1 score 5/5 methodology pattern
+- **Excavations run**: 13 totali (4 session-1 + 4 session-2 + 1 session-3: worldgen + 1 session-5: ancestors reentry + 1 session-6 cross-validation 2026-05-13 + 1 session-7 Phase 3 Path D methodology 2026-05-15 + 1 session-8 coop WS test infra 2026-05-20)
+- **Artifact identificati**: ~107 totali (101 precedenti + 6 pattern coop WS test infra)
+- **Cards total**: 35 curate (9 score 5/5 · 13 score 4/5 · 11 score 3/5 · 2 score 2/5) — +1 score 5/5 test infra
 - **Galleries**: 3 (enneagramma + ancestors + worldgen)
-- **Last excavate**: 2026-05-15 (session 7 Phase 3 Path D HYBRID: Pattern A+B+C industry-pattern enrichment methodology + \_provenance audit trail, M-2026-05-15-001 score 5/5)
+- **Last excavate**: 2026-05-20 (session 8 coop WS test infra: 6 pattern riusabili disconnect-race + host-transfer, M-2026-05-20-001 score 5/5)
 - **Coverage**: **100%+** (9/9 domain + indie research cluster nuovi)
 - **Skiv unblock**: 8/11 card hanno reuse path Skiv-aware (Sprint A: 2, Sprint B: 1, Sprint C: 4, biome-mover differentiation: 1)
 - **Cross-agent validation**: ✅ PASS 2026-04-25 (creature-aspect-illuminator consulted MUSEUM.md spontaneously, 6 GAP found, 10-15min saved)

--- a/docs/museum/cards/coop-ws-test-infra-patterns-2026-05-20.md
+++ b/docs/museum/cards/coop-ws-test-infra-patterns-2026-05-20.md
@@ -1,0 +1,170 @@
+---
+title: Coop WS Test Infrastructure Patterns — disconnect race + host-transfer e2e
+museum_id: M-2026-05-20-001
+type: architecture
+domain: [architecture]
+provenance:
+  found_at: tests/api/lobbyWebSocket.test.js + tests/api/coopWsRebroadcast.test.js + tests/services/network/wsSession-ghost.test.js + tests/services/network/wsSession-resume.test.js + tests/api/coopOrchestrator.test.js + tests/api/coopWorldVote.test.js
+  git_sha_first: db4325f0 # lobbyWebSocket initial M11 Phase A
+  git_sha_last: 0ce921540842f4b6327a2e4c9dfde65c3be2310b # coopOrchestrator.test.js 2026-05-20
+  last_modified: 2026-05-20
+  last_author: MasterDD-L34D
+  buried_reason: unintegrated
+relevance_score: 5
+reuse_path: tests/api/coopWorldVote.test.js + tests/services/network/wsSession-ghost.test.js + tests/api/coopWsRebroadcast.test.js — compose 2 new test files for disconnect-race + host-transfer e2e
+related_pillars: [P5]
+status: excavated
+excavated_by: repo-archaeologist
+excavated_on: 2026-05-20
+last_verified: 2026-05-20
+---
+
+# Coop WS Test Infrastructure Patterns
+
+## Summary (30s)
+
+- 6 test file con pattern WS testabili standalone via `spinUp()` + `LobbyService` in-memory. Zero server esterno richiesto.
+- Pattern `attachBuffer/waitForMessage/openWs/spinUp` duplicato in ogni file ma con piccole variazioni — riusabile as-is per i 2 test mancanti.
+- `worldTally(connectedPlayerIds)` e `ghostTimeoutMs` sono entrambi testabili direttamente senza WS overhead per unit cases.
+
+## What was buried
+
+Sei file di test coprono l'infrastruttura WS coop ma NON includono:
+
+1. **Multi-player disconnect race durante vote attivo** — il path `B-NEW-1 fix 2026-05-08` in `wsSession.js:1516` che filtra `connectedPids` è testato a livello unit in `coopOrchestrator.test.js:106` (solo `worldTally` pure-function), ma NON ha test WS end-to-end: player vota via WS intent `world_vote`, poi disconnette (`.close()`), il tally successivo deve contenere `connected_total = 1` (non 2) e `all_connected_accepted = true`.
+
+2. **Host-transfer + coop-state sync e2e con `coopStore`** — `coopWsRebroadcast.test.js` testa `phase_change + character_ready_list` (F-1) ma NON testa `world_tally` rebroadcast (riga `wsSession.js:997` + `wsSession.js:1036`) dopo host-transfer in `world_setup` phase. Il test esistente usa `hostWs.close()` (graceful, 80ms grace) — il pattern `hostWs.terminate()` (abrupt, zero grace) è usato solo in `lobbyWebSocket.test.js:429` per `round_ready` replay.
+
+### Pattern riusabili identificati
+
+**P1 — `spinUp()` factory** (`tests/api/lobbyWebSocket.test.js:80-90`, `tests/api/coopWsRebroadcast.test.js:62-71`):
+
+```js
+async function spinUp(coopStore) {
+  const lobby = new LobbyService();
+  const wsHandle = createWsServer({ lobby, coopStore, port: 0 });
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  return { lobby, port: wsHandle.wss.address().port, wsHandle };
+}
+```
+
+Differenza chiave: `coopWsRebroadcast.test.js` accetta `coopStore` opzionale (pattern F-1 backward-compat). Per i test nuovi passare sempre `createCoopStore({ lobby })`.
+
+**P2 — `attachBuffer/waitForMessage` predicate-based** (`tests/api/lobbyWebSocket.test.js:28-66`):
+Buffer accumula tutti i messaggi WS ricevuti; `waitForMessage(ws, predicate, timeoutMs)` controlla buffer esistente PRIMA di attendere nuovi. Evita race condition listener-attachment. Timeout 3000ms default, overridable.
+
+**P3 — `ghostTimeoutMs` e `hostTransferGraceMs` configurabili per test** (`tests/services/network/wsSession-ghost.test.js:185`):
+
+```js
+const meta = lobby.createRoom({ hostName: 'Alice' });
+const room = lobby.getRoom(meta.code);
+room.ghostTimeoutMs = 80; // post-create override
+```
+
+Oppure via costruttore: `lobby.createRoom({ hostName: 'Alice', hostTransferGraceMs: 50 })`. Entrambi usati in test esistenti. Tight window (50-80ms) rende test veloci senza `sleep` lungo.
+
+**P4 — `room.players.values()` filtra `.connected` per quorum** (`wsSession.js:1518-1520` — pattern già usato in produzione, da replicare nel test):
+
+```js
+const connectedPids = Array.from(room.players.values())
+  .filter((p) => p.connected && p.id !== room.hostId && p.role !== 'host')
+  .map((p) => p.id);
+```
+
+Il campo `.connected` su ogni player è `true` quando il socket WS è attivo, `false` dopo `close/terminate`. Verificabile via `room.players.get(pid).connected`.
+
+**P5 — `coopStore.getOrCreate(code)` per seedare `orch.phase` pre-test** (`coopWsRebroadcast.test.js:91-98`):
+
+```js
+const orch = coopStore.getOrCreate(room.code);
+orch.startRun({ scenarioStack: ['enc_tutorial_01'] });
+orch.submitCharacter(
+  p1.player_id,
+  { name: 'Bobby', form_id: 'istj_custode' },
+  { allPlayerIds: [p1.player_id] },
+);
+assert.equal(orch.phase, 'world_setup');
+```
+
+Permette di portare l'orchestrator in `world_setup` prima di aprire WS, così i test di vote possono iniziare direttamente dal voto senza simulare l'intero onboarding.
+
+**P6 — `hostWs.terminate()` vs `hostWs.close()`** (`lobbyWebSocket.test.js:429`):
+`terminate()` = abrupt disconnect (simula crash/network drop). `close()` = graceful (WebSocket CLOSE frame). Per test disconnect-race usare `terminate()` se vuoi simulare drop improvviso; per host-transfer graceful usare `close()` + aspettare `player_disconnected` prima di procedere.
+
+## Why it was buried
+
+Non sepolti in senso proprio: i pattern esistono e funzionano. Il gap è che i 2 test mancanti richiedono **composizione** di pattern da file diversi (`coopOrchestrator.test.js` unit + `coopWsRebroadcast.test.js` WS integration + `wsSession-ghost.test.js` timing). Nessun singolo file copre entrambi i layer (WS intent → coop orchestrator → tally connected-only).
+
+## Why it might still matter
+
+- BACKLOG ha 2 entry esplicite: "Multi-player disconnect race test" + "Host-transfer + coop-state sync e2e".
+- P5 Co-op confirmed 🟢 ma test coverage gap = regression risk su ogni refactor `wsSession.js` vote path.
+- `B-NEW-1 fix 2026-05-08` (connected-only quorum) è il bug più recente nel path — zero WS-level regression test per quel fix specifico.
+
+## Concrete reuse paths
+
+### 1. Minimal — disconnect race unit test (P0, ~1.5h)
+
+File: `tests/api/coopOrchestrator.test.js` (append).
+
+```js
+test('worldTally: player voted then disconnected counts only in connected tally', () => {
+  const co = new CoopOrchestrator({ roomCode: 'DISC', hostId: 'p_h' });
+  co.startOnboarding({ scenarioStack: ['enc_demo'] });
+  co._setPhase('world_setup');
+  const allIds = ['p_a', 'p_b'];
+  // p_a vota accept, poi p_b droppe prima di votare.
+  co.voteWorld('p_a', { accept: true, allPlayerIds: allIds, connectedPlayerIds: allIds });
+  // p_b ora disconnesso — connectedIds = solo p_a.
+  const connectedIds = ['p_a'];
+  const tally = co.worldTally(allIds, connectedIds);
+  assert.equal(tally.accept, 1);
+  assert.equal(tally.connected_total, 1);
+  assert.equal(tally.all_connected_accepted, true); // p_b offline non blocca
+  assert.equal(tally.connected_pending, 0);
+});
+```
+
+Effort: ~1h (puro unit, nessun WS, pattern da `coopOrchestrator.test.js:106` già esistente).
+
+### 2. Moderate — disconnect race WS e2e (P1, ~3h)
+
+Nuovo file: `tests/api/coopDisconnectRace.test.js`.
+
+Setup: `spinUp(coopStore)` da `coopWsRebroadcast.test.js`. Seed orchestrator in `world_setup` (P5). Connetti host + p1 + p2 WS. p1 invia `intent {action:"world_vote", accept:true}`. p2 disconnette via `p2Ws.close()`. Aspetta `player_disconnected` su host. p1 invia secondo vote (o check tally via `world_tally` broadcast). Assert `tally.connected_total === 1` + `tally.all_connected_accepted === true`.
+
+Effort: ~2.5-3h (WS setup + timing + assert `world_tally` broadcast).
+Blast radius: ×1.0 (test-only, zero produzione).
+
+### 3. Full — host-transfer + coop-state sync e2e (P1, ~3h)
+
+Nuovo file: `tests/api/coopHostTransferSync.test.js`.
+
+Estende `coopWsRebroadcast.test.js` F-1 pattern. Seed orchestrator in `world_setup` con p1 vote già registrato. Host droppe (`hostWs.terminate()`, `hostTransferGraceMs: 50`). Aspetta `host_transferred` su p1 (promosso). Assert che p1 riceva:
+
+- `phase_change { phase: 'world_setup', reason: 'host_transferred' }` (già testato F-1)
+- `character_ready_list` snapshot (già testato F-1)
+- **`world_tally` snapshot** — questo è il gap. `wsSession.js:997` invia `world_tally` in `_rebroadcastCoopState` ma F-1 non lo asserta.
+
+Effort: ~2.5-3h (extend F-1, add `world_tally` assert).
+Blast radius: ×1.0 (test-only).
+
+## Sources / provenance trail
+
+- `tests/api/lobbyWebSocket.test.js` — SHA `355f12d4`, 2026-04-25. `spinUp` + `attachBuffer` + `waitForMessage` + `openWs` canonical. Test host-transfer `round_ready` replay (linee 371-443).
+- `tests/api/coopWsRebroadcast.test.js` — SHA `b7abfe39`, 2026-04-24. `createCoopStore` integration + `phase_change` + `character_ready_list` post host-transfer. F-1 pattern.
+- `tests/services/network/wsSession-ghost.test.js` — SHA `ec383a23`, 2026-05-03. `ghostTimeoutMs` override post-create + `player_left{ghost_timeout}` broadcast.
+- `tests/services/network/wsSession-resume.test.js` — SHA `51097d9f`, 2026-05-03. `last_version` param su `openWs` + replay ordering invariant.
+- `tests/api/coopOrchestrator.test.js` — SHA `0ce92154`, 2026-05-20. `worldTally(connectedPlayerIds)` unit test linee 106-134.
+- `tests/api/coopWorldVote.test.js` — SHA `c259058c`, 2026-04-24. REST vote bootstrap pattern `bootstrapWorldSetup`.
+- `apps/backend/services/network/wsSession.js` — `B-NEW-1 fix` linee 1516-1525 (connected-only quorum), `_rebroadcastCoopState` linee 994-1000 (world_tally send post host-transfer).
+
+## Risks / open questions
+
+- `attachBuffer/waitForMessage` duplicato in 5 file distinti con piccole variazioni (es. `openWs` in `wsSession-resume.test.js` accetta `last_version` opzionale). Se usi copy-paste per il nuovo test, includi la variante con `last_version` da `wsSession-resume.test.js:67-73` solo se necessario.
+- `ghostTimeoutMs = 0` (default prod) vs override post-create nei test: non confondere con `hostTransferGraceMs`. Ghost = cleanup player non-host disconnesso. HostTransfer = promozione host disconnesso. Separati e non-interferenti.
+- Il test "disconnect race" funziona SOLO se `coopStore` è passato a `createWsServer`. Senza `coopStore` il path `world_vote` intent è no-op (riga `wsSession.js:1506`).
+- Nessun test attuale verifica il caso limite: player vota, poi si riconnette, poi il ghost timer NON spara — ma il suo voto rimane nel tally con `connected = true` di nuovo. Potenziale false-positive su `all_connected_accepted` se tally viene letto MENTRE il ghost timer è pending ma prima che spari. Non bloccante per i 2 test richiesti.

--- a/tests/api/coopOrchestrator.test.js
+++ b/tests/api/coopOrchestrator.test.js
@@ -693,3 +693,51 @@ test('startRun from ended phase succeeds (allowed restart path)', () => {
   assert.doesNotThrow(() => co.startRun({ scenarioStack: ['enc_demo_2'] }));
   assert.equal(co.phase, 'character_creation');
 });
+
+// ===========================================================================
+// Multi-player disconnect race (BACKLOG coverage gap; cf. coop-phase-validator
+// audit 2026-05-20 Finding 4 — stale accept-vote of disconnected player must
+// not satisfy all_connected_accepted quorum).
+// ===========================================================================
+
+test('worldTally: disconnected voter accept does NOT fire all_connected_accepted when other connected player pending', () => {
+  const co = new CoopOrchestrator({ roomCode: 'DISC', hostId: 'p_h' });
+  co.startRun({ scenarioStack: ['enc_demo'] });
+  co._setPhase('world_setup');
+  const allIds = ['p_a', 'p_b', 'p_c'];
+  // p_a and p_b vote accept; then p_b "disconnects" mid-tally.
+  co.voteWorld('p_a', { accept: true, allPlayerIds: allIds });
+  co.voteWorld('p_b', { accept: true, allPlayerIds: allIds });
+  const connected = ['p_a', 'p_c']; // p_b dropped; p_c never voted yet
+  const tally = co.worldTally(allIds, connected);
+  // Global accept still 2 (vote persists in Map by design).
+  assert.equal(tally.accept, 2);
+  // BUT connected quorum must NOT fire — p_c (connected) hasn't voted.
+  assert.equal(tally.all_connected_accepted, false);
+  assert.equal(tally.connected_pending, 1);
+  // Only when p_c (last connected) votes accept does quorum fire.
+  co.voteWorld('p_c', { accept: true, allPlayerIds: allIds });
+  const tally2 = co.worldTally(allIds, connected);
+  assert.equal(tally2.all_connected_accepted, true);
+  assert.equal(tally2.connected_pending, 0);
+});
+
+test('worldTally: disconnected REJECT vote excluded from connected_reject quorum', () => {
+  const co = new CoopOrchestrator({ roomCode: 'DISC', hostId: 'p_h' });
+  co.startRun({ scenarioStack: ['enc_demo'] });
+  co._setPhase('world_setup');
+  const allIds = ['p_a', 'p_b'];
+  // p_a accepts, p_b rejects, then p_b drops.
+  co.voteWorld('p_a', { accept: true, allPlayerIds: allIds });
+  co.voteWorld('p_b', { accept: false, allPlayerIds: allIds });
+  const connected = ['p_a']; // p_b dropped
+  const tally = co.worldTally(allIds, connected);
+  // Global counts still see both votes.
+  assert.equal(tally.accept, 1);
+  assert.equal(tally.reject, 1);
+  // Connected quorum sees only p_a → unanimous accept across connected.
+  assert.equal(tally.connected_total, 1);
+  assert.equal(tally.connected_accept, 1);
+  assert.equal(tally.connected_reject, 0);
+  assert.equal(tally.all_connected_accepted, true);
+});

--- a/tests/play/abilityPanelClearRace.test.js
+++ b/tests/play/abilityPanelClearRace.test.js
@@ -1,0 +1,107 @@
+// Regression: clearAbilities() must invalidate an in-flight renderAbilities()
+// await. Bug class "barra si e buggata" (W8/W8O): token guards render-vs-render
+// but NOT render-vs-clear. If unit is deselected/dies during loadJobDetail
+// fetch latency, clearAbilities() wipes the panel but the in-flight render
+// (token still latest) resurrects abilities for the gone unit.
+//
+// Fix originally landed PR #2321 (W8O-2), regressed by Jules PR #2327
+// rewrite that dropped the token-bump. This file = re-applied + test
+// restored (2026-05-20).
+//
+// No jsdom: minimal fake DOM + deferred fetch to interleave clear during await.
+
+'use strict';
+
+const { test, describe, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+function fakeEl() {
+  return {
+    _cls: new Set(),
+    innerHTML: '',
+    textContent: '',
+    dataset: {},
+    classList: {
+      add: function (c) {
+        /* bound below */
+      },
+      remove: function (c) {},
+      contains: function (c) {
+        return false;
+      },
+      toggle: function (c, on) {},
+    },
+    appendChild() {},
+    addEventListener() {},
+  };
+}
+
+function wireEl(el) {
+  el.classList.add = (c) => el._cls.add(c);
+  el.classList.remove = (c) => el._cls.delete(c);
+  el.classList.contains = (c) => el._cls.has(c);
+  el.classList.toggle = (c, on) => {
+    if (on) el._cls.add(c);
+    else el._cls.delete(c);
+  };
+  return el;
+}
+
+describe('abilityPanel clear-vs-inflight-render race (W8O-2 regression guard)', () => {
+  let titleEl, container, deferred;
+
+  beforeEach(() => {
+    titleEl = wireEl(fakeEl());
+    container = wireEl(fakeEl());
+    let appended = [];
+    container.appendChild = (row) => {
+      appended.push(row);
+      container._rows = appended;
+    };
+
+    globalThis.document = {
+      getElementById: (id) =>
+        id === 'abilities-title' ? titleEl : id === 'abilities' ? container : null,
+      createElement: () => wireEl(fakeEl()),
+    };
+
+    // fetch: /api/jobs (module preload) resolves immediately empty;
+    // /api/jobs/<id> returns a DEFERRED promise we control (the await window).
+    deferred = null;
+    globalThis.fetch = (url) => {
+      if (url === '/api/jobs') {
+        return Promise.resolve({ json: () => Promise.resolve({ jobs: [] }) });
+      }
+      return new Promise((resolve) => {
+        deferred = () =>
+          resolve({
+            json: () => Promise.resolve({ abilities: [{ ability_id: 'a1', name: 'Strike' }] }),
+          });
+      });
+    };
+  });
+
+  test('clearAbilities() during loadJobDetail await must keep panel cleared', async () => {
+    const mod = await import('../../apps/play/src/abilityPanel.js');
+    const unit = { id: 'u1', job: 'warrior', ap_remaining: 5 };
+
+    const p = mod.renderAbilities(unit, {}, () => {}); // not awaited: in-flight
+    // unit deselected/dead mid-flight -> caller takes else branch:
+    mod.clearAbilities();
+    assert.equal(container.innerHTML, '', 'clear should empty container');
+
+    deferred(); // loadJobDetail resolves AFTER the explicit clear
+    await p;
+
+    // BUG (pre-fix): in-flight render resurrects abilities for the gone unit.
+    assert.equal(
+      container._rows ? container._rows.length : 0,
+      0,
+      'in-flight render must NOT append rows after clearAbilities()',
+    );
+    assert.ok(
+      titleEl._cls.has('hidden-empty'),
+      'title must remain hidden-empty after clear (not re-shown by stale render)',
+    );
+  });
+});

--- a/tests/services/coop/ermesExporter.test.js
+++ b/tests/services/coop/ermesExporter.test.js
@@ -8,6 +8,8 @@ const os = require('node:os');
 const path = require('node:path');
 const {
   getErmesForBiome,
+  computeRoleGap,
+  BIOME_ROLE_DEMANDS,
   STATIC_FALLBACKS,
   NEUTRAL_FALLBACK,
   _resetCache,
@@ -102,5 +104,75 @@ test('malformed json report returns static fallback', () => {
     assert.equal(e.eco_pressure_score, 0.62);
   } finally {
     fs.unlinkSync(tmp);
+  }
+});
+
+// ===========================================================================
+// computeRoleGap negative + edge case tests (gap coverage 2026-05-20).
+// ===========================================================================
+
+test('computeRoleGap: empty party against demand biome → all roles negative', () => {
+  const gap = computeRoleGap([], 'savana');
+  assert.equal(gap.esploratore, -1);
+  assert.equal(gap.guerriero, -1);
+});
+
+test('computeRoleGap: null/undefined party defaults to empty', () => {
+  const gap1 = computeRoleGap(null, 'caverna');
+  const gap2 = computeRoleGap(undefined, 'caverna');
+  assert.deepEqual(gap1, { esploratore: -1, custode: -1 });
+  assert.deepEqual(gap2, { esploratore: -1, custode: -1 });
+});
+
+test('computeRoleGap: unknown biome → empty demand, party roles surface as over-rep', () => {
+  const gap = computeRoleGap(['guerriero', 'tessitore'], 'biome_inesistente');
+  assert.equal(gap.guerriero, 1);
+  assert.equal(gap.tessitore, 1);
+});
+
+test('computeRoleGap: party over-fills demand → positive delta', () => {
+  // savana demands {esploratore: 1, guerriero: 1}
+  const gap = computeRoleGap(['esploratore', 'esploratore', 'guerriero'], 'savana');
+  assert.equal(gap.esploratore, 1); // 2 present - 1 demanded
+  assert.equal(gap.guerriero, 0);
+});
+
+test('computeRoleGap: extra party roles not in demand surface separately', () => {
+  // savana demands {esploratore:1, guerriero:1}; party adds tessitore
+  const gap = computeRoleGap(['esploratore', 'guerriero', 'tessitore'], 'savana');
+  assert.equal(gap.esploratore, 0);
+  assert.equal(gap.guerriero, 0);
+  assert.equal(gap.tessitore, 1); // over-rep, not in demand
+});
+
+test('computeRoleGap: accepts player dict objects with job_id field', () => {
+  const party = [{ job_id: 'esploratore' }, { job_id: 'guerriero' }];
+  const gap = computeRoleGap(party, 'savana');
+  assert.equal(gap.esploratore, 0);
+  assert.equal(gap.guerriero, 0);
+});
+
+test('computeRoleGap: ignores entries with missing/empty job_id', () => {
+  const party = [{ job_id: 'esploratore' }, { job_id: '' }, { name: 'no_job' }, null, 'guerriero'];
+  const gap = computeRoleGap(party, 'savana');
+  assert.equal(gap.esploratore, 0);
+  assert.equal(gap.guerriero, 0);
+});
+
+test('BIOME_ROLE_DEMANDS: covers ≥13 biomes (cross-repo parity Godot v2)', () => {
+  const keys = Object.keys(BIOME_ROLE_DEMANDS);
+  assert.ok(keys.length >= 13, `expected ≥13 biomes, got ${keys.length}`);
+  // Spot check 5 known biomes (parity ermes_role_gap.gd).
+  for (const b of ['savana', 'caverna', 'atollo_obsidiana', 'foresta_temperata', 'badlands']) {
+    assert.ok(BIOME_ROLE_DEMANDS[b], `${b} missing from BIOME_ROLE_DEMANDS`);
+  }
+});
+
+test('BIOME_ROLE_DEMANDS: all role counts are positive integers', () => {
+  for (const [biome, demand] of Object.entries(BIOME_ROLE_DEMANDS)) {
+    for (const [role, count] of Object.entries(demand)) {
+      assert.ok(Number.isInteger(count), `${biome}.${role} not integer: ${count}`);
+      assert.ok(count > 0, `${biome}.${role} not positive: ${count}`);
+    }
   }
 });


### PR DESCRIPTION
## Regression diagnosis
W8O-2 race fix from PR #2321 + its regression test were silently dropped by Jules PR #2327 `rewrite ability panel condition` 8h after #2321 landed. The bug-class "barra si e buggata" (render-vs-clear race when unit deselected/dies during loadJobDetail latency) is back on origin/main.

## Fix
Re-apply identical 1-line `_renderToken += 1` in `clearAbilities()` + restore regression test `tests/play/abilityPanelClearRace.test.js`.

## TDD-verified
- Test written first → FAIL on regressed main (race resurrects abilities post-clear)
- 1-line fix applied → test PASS
- 0 regression on tests/play/* (13 files green)

## Recommendation
Add `abilityPanelClearRace.test.js` to regression-guard CI watchlist so future Jules-class auto-rewrites cannot silently drop this fix again.