### PR TITLE
fix(coop): sync orch.hostId on host transfer (P1 stale gate)

### DIFF
--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -119,6 +119,27 @@ class CoopOrchestrator {
   }
 
   /**
+   * 2026-05-20 — sync orchestrator hostId with current Room host post
+   * transfer (coop-phase-validator audit Finding 1 fix). Without this,
+   * `orch.hostId` stays frozen at construction time and any caller relying
+   * on it for host-only gates (`submitOnboardingChoice`, `submitNextMacro`)
+   * would silently pass for the wrong player after host transfer.
+   *
+   * Idempotent: no-op when newHostId matches current. Emits
+   * `host_id_synced` event with previous + new id for telemetry.
+   *
+   * @param {string|null} newHostId
+   * @returns {boolean} true if hostId changed, false if no-op
+   */
+  setHostId(newHostId) {
+    if (newHostId === this.hostId) return false;
+    const previousHostId = this.hostId;
+    this.hostId = newHostId || null;
+    this._emit('host_id_synced', { previous: previousHostId, current: this.hostId });
+    return true;
+  }
+
+  /**
    * Start a new run. Moves phase lobby → character_creation.
    */
   startRun({ scenarioStack = ['enc_tutorial_01'] } = {}) {

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -1014,6 +1014,12 @@ function sendCoopSnapshotToPlayer(room, orch, playerId) {
  */
 function rebroadcastCoopState(room, orch) {
   if (!room || typeof room.broadcast !== 'function' || !orch) return;
+  // 2026-05-20 — sync orchestrator.hostId with Room.hostId post host transfer
+  // (coop-phase-validator audit Finding 1). Prevents stale hostId footgun
+  // for any future caller relying on orch.hostId for host-only gates.
+  if (typeof orch.setHostId === 'function' && orch.hostId !== room.hostId) {
+    orch.setHostId(room.hostId);
+  }
   const allIds = Array.from(room.players.values())
     .filter((p) => p.id !== room.hostId && p.role !== 'host')
     .map((p) => p.id);

--- a/tests/api/coopOrchestrator.test.js
+++ b/tests/api/coopOrchestrator.test.js
@@ -646,6 +646,74 @@ test('log captures phase_change + run_started events', () => {
 });
 
 // ===========================================================================
+// setHostId — sync hostId post host transfer (coop-phase-validator
+// audit 2026-05-20 Finding 1 P1 fix).
+// ===========================================================================
+
+test('setHostId: updates hostId from initial value to new host', () => {
+  const co = new CoopOrchestrator({ roomCode: 'HSYN', hostId: 'p_old' });
+  assert.equal(co.hostId, 'p_old');
+  const changed = co.setHostId('p_new');
+  assert.equal(changed, true);
+  assert.equal(co.hostId, 'p_new');
+});
+
+test('setHostId: no-op idempotent when same id', () => {
+  const co = new CoopOrchestrator({ roomCode: 'HSYN', hostId: 'p_same' });
+  const events = [];
+  co.on((evt) => {
+    if (evt.kind === 'host_id_synced') events.push(evt.payload);
+  });
+  const changed = co.setHostId('p_same');
+  assert.equal(changed, false);
+  assert.equal(events.length, 0);
+});
+
+test('setHostId: emits host_id_synced event with previous + current', () => {
+  const co = new CoopOrchestrator({ roomCode: 'HSYN', hostId: 'p_a' });
+  const events = [];
+  co.on((evt) => {
+    if (evt.kind === 'host_id_synced') events.push(evt.payload);
+  });
+  co.setHostId('p_b');
+  assert.equal(events.length, 1);
+  assert.equal(events[0].previous, 'p_a');
+  assert.equal(events[0].current, 'p_b');
+});
+
+test('setHostId: accepts null to clear hostId', () => {
+  const co = new CoopOrchestrator({ roomCode: 'HSYN', hostId: 'p_a' });
+  const changed = co.setHostId(null);
+  assert.equal(changed, true);
+  assert.equal(co.hostId, null);
+});
+
+test('setHostId: host-only gates respect new hostId post transfer', () => {
+  const co = new CoopOrchestrator({ roomCode: 'HSYN', hostId: 'p_old' });
+  co.startOnboarding({ scenarioStack: ['enc_demo'] });
+  // Transfer host
+  co.setHostId('p_new');
+  // Old host can no longer submit onboarding choice
+  assert.throws(
+    () =>
+      co.submitOnboardingChoice(
+        'p_old',
+        { option_key: 'a', trait_id: 't', label: 'L', narrative: 'N' },
+        { hostId: co.hostId },
+      ),
+    /host_only/,
+  );
+  // New host succeeds
+  assert.doesNotThrow(() =>
+    co.submitOnboardingChoice(
+      'p_new',
+      { option_key: 'a', trait_id: 't', label: 'L', narrative: 'N' },
+      { hostId: co.hostId },
+    ),
+  );
+});
+
+// ===========================================================================
 // Phase-skip negative tests (BACKLOG coverage gap)
 // ===========================================================================
 


### PR DESCRIPTION
## Summary

Coop-phase-validator audit 2026-05-20 **Finding 1 P1**: `CoopOrchestrator.hostId` viene assegnato una sola volta a costruzione e non aggiornato quando il Room esegue `transferHostTo()`. Latent footgun — route correnti passano sempre `room.hostId`, ma qualsiasi futuro caller che usi `orch.hostId` per gate host-only (`submitOnboardingChoice` / `submitNextMacro`) aprirebbe silenziosamente per il vecchio host già rimosso.

## Changes

### `apps/backend/services/coop/coopOrchestrator.js`

Nuovo metodo `setHostId(newHostId)`:
- Idempotent: no-op quando `newHostId === this.hostId`
- Emette evento `host_id_synced` con `{ previous, current }` per telemetry
- Ritorna boolean `changed`

### `apps/backend/services/network/wsSession.js`

`rebroadcastCoopState(room, orch)` ora chiama `orch.setHostId(room.hostId)` PRIMA del rebroadcast quando `orch.hostId !== room.hostId`. Path già attivato post `host_transferred` event (line 1933) — coverage zero-new-code-path.

### `tests/api/coopOrchestrator.test.js` (+60 LOC)

5 nuovi test:
- setHostId update basic
- setHostId idempotent no-op + no event
- setHostId emette `host_id_synced` con previous + current
- setHostId(null) accettato (clear)
- host-only gate rispetta nuovo hostId post transfer (old host throws `host_only`, new host succeeds)

## Test plan

- [x] node --test tests/api/coopOrchestrator.test.js → 53/53 verde (+5 nuovi)
- [x] node --test tests/services/network/wsSession-*.test.js tests/api/coopWsRebroadcast.test.js → 55/55 verde (zero regression)
- [x] Prettier verde (--check)
- [x] Zero breaking change: setter additivo, hostId field semantica preservata

## Rollback plan

Revert single commit `b37146ed`. Setter additivo + 1 chiamata in `rebroadcastCoopState`.

## Authority

Parallel session Lenovo branch `claude/parallel-hostid-stale-fix-2026-05-20`. Generated da coop-phase-validator agent dispatch (synth post merge #2334 + #2335 + #2336). Closes partial **BACKLOG row 'Host-transfer + coop-state sync e2e'** (foundation; E2E full test richiede WS infra extension, deferred sessione futura).