### PR TITLE
feat(coop): listBiomeRoleDemands + readonly diagnostic route (A6 pattern)

### DIFF
--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -11,6 +11,7 @@
 'use strict';
 
 const express = require('express');
+const { listBiomeRoleDemands } = require('../services/coop/ermesExporter');
 
 function createCoopRouter({ lobby, coopStore } = {}) {
   if (!lobby) throw new Error('createCoopRouter: lobby required');
@@ -93,6 +94,14 @@ function createCoopRouter({ lobby, coopStore } = {}) {
       }
     }
   }
+
+  // 2026-05-20 — readonly diagnostic per onboarding hint (A6 pattern
+  // `listStarterBiomas` replicato; gap-fill Explore quick-win discovery).
+  // Frontend onboarding HUD può preload role expectation per biome scelto.
+  router.get('/coop/role-demands', (_req, res) => {
+    const items = listBiomeRoleDemands();
+    res.json({ count: items.length, items });
+  });
 
   router.post('/coop/run/start', (req, res) => {
     const { code, host_token: hostToken, scenario_stack: scenarioStack } = req.body || {};

--- a/apps/backend/services/coop/ermesExporter.js
+++ b/apps/backend/services/coop/ermesExporter.js
@@ -209,9 +209,25 @@ function _countPartyRoles(partyJobs) {
   return out;
 }
 
+/**
+ * 2026-05-20 — list all 13 biome → role demand mappings (mirror A6
+ * `listStarterBiomas` pattern, gap-fill da Explore quick-win discovery).
+ * Used by readonly diagnostic route + frontend onboarding hint surface.
+ *
+ * @returns {Array<{biome_id: string, roles_demanded: object, total_slots: number}>}
+ */
+function listBiomeRoleDemands() {
+  return Object.entries(BIOME_ROLE_DEMANDS).map(([biome_id, roles_demanded]) => ({
+    biome_id,
+    roles_demanded: { ...roles_demanded },
+    total_slots: Object.values(roles_demanded).reduce((sum, n) => sum + (Number(n) || 0), 0),
+  }));
+}
+
 module.exports = {
   getErmesForBiome,
   computeRoleGap,
+  listBiomeRoleDemands,
   BIOME_ROLE_DEMANDS,
   STATIC_FALLBACKS,
   NEUTRAL_FALLBACK,

--- a/tests/api/coopRoleDemands.test.js
+++ b/tests/api/coopRoleDemands.test.js
@@ -1,0 +1,85 @@
+// 2026-05-20 — GET /api/coop/role-demands readonly diagnostic route.
+// Mirror pattern A6 listStarterBiomas (gap-fill Explore quick-win discovery).
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+const { createLobbyRouter } = require('../../apps/backend/routes/lobby');
+const { createCoopRouter } = require('../../apps/backend/routes/coop');
+const { createCoopStore } = require('../../apps/backend/services/coop/coopStore');
+const { LobbyService } = require('../../apps/backend/services/network/wsSession');
+const {
+  listBiomeRoleDemands,
+  BIOME_ROLE_DEMANDS,
+} = require('../../apps/backend/services/coop/ermesExporter');
+
+function buildApp() {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createLobbyRouter({ lobby }));
+  app.use('/api', createCoopRouter({ lobby, coopStore }));
+  return app;
+}
+
+test('GET /api/coop/role-demands: returns count + items array', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/coop/role-demands');
+  assert.equal(res.status, 200);
+  assert.equal(typeof res.body.count, 'number');
+  assert.ok(Array.isArray(res.body.items));
+  assert.equal(res.body.items.length, res.body.count);
+});
+
+test('GET /api/coop/role-demands: count matches BIOME_ROLE_DEMANDS keys', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/coop/role-demands');
+  assert.equal(res.body.count, Object.keys(BIOME_ROLE_DEMANDS).length);
+});
+
+test('GET /api/coop/role-demands: each item exposes biome_id + roles_demanded + total_slots', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/coop/role-demands');
+  for (const item of res.body.items) {
+    assert.equal(typeof item.biome_id, 'string');
+    assert.ok(item.biome_id.length > 0);
+    assert.equal(typeof item.roles_demanded, 'object');
+    assert.equal(typeof item.total_slots, 'number');
+    assert.ok(item.total_slots >= 1, `${item.biome_id} total_slots must be ≥1`);
+  }
+});
+
+test('GET /api/coop/role-demands: savana entry exposes esploratore + guerriero (parity Godot)', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/coop/role-demands');
+  const savana = res.body.items.find((x) => x.biome_id === 'savana');
+  assert.ok(savana, 'savana entry must be present');
+  assert.equal(savana.roles_demanded.esploratore, 1);
+  assert.equal(savana.roles_demanded.guerriero, 1);
+  assert.equal(savana.total_slots, 2);
+});
+
+test('GET /api/coop/role-demands: requires no auth (readonly diagnostic)', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/coop/role-demands');
+  assert.equal(res.status, 200);
+});
+
+test('listBiomeRoleDemands: returned roles_demanded is a defensive copy (mutation does not leak to BIOME_ROLE_DEMANDS)', () => {
+  const items = listBiomeRoleDemands();
+  const savanaItem = items.find((x) => x.biome_id === 'savana');
+  const originalEsploratore = BIOME_ROLE_DEMANDS.savana.esploratore;
+  savanaItem.roles_demanded.esploratore = 99;
+  assert.equal(BIOME_ROLE_DEMANDS.savana.esploratore, originalEsploratore);
+});
+
+test('listBiomeRoleDemands: total_slots correctly sums multi-role biomes (foresta_miceliale=2)', () => {
+  const items = listBiomeRoleDemands();
+  const foresta = items.find((x) => x.biome_id === 'foresta_miceliale');
+  assert.ok(foresta);
+  assert.equal(foresta.total_slots, 2); // tessitore: 2
+  assert.equal(foresta.roles_demanded.tessitore, 2);
+});


### PR DESCRIPTION
## Summary

Mirror del pattern A6 STARTER_BIOMA_MAP (#2334) replicato su `BIOME_ROLE_DEMANDS` esistente. Gap-fill da `Explore` quick-win discovery 2026-05-20 (Candidato #2).

Engine LIVE Surface DEAD killer (Gate 5): role expectations per biome erano disponibili solo internamente a `computeRoleGap()` post-vote. Ora frontend onboarding HUD può preload `roles_demanded` per biome appena scelto.

## Changes

### `apps/backend/services/coop/ermesExporter.js`

Nuovo export `listBiomeRoleDemands()`:

```js
[
  { biome_id: "savana", roles_demanded: { esploratore: 1, guerriero: 1 }, total_slots: 2 },
  { biome_id: "caverna", roles_demanded: { esploratore: 1, custode: 1 }, total_slots: 2 },
  ...13 entries
]
```

Defensive copy su `roles_demanded` (mutation caller non leak su `Object.freeze(BIOME_ROLE_DEMANDS)`).

### `apps/backend/routes/coop.js`

`GET /api/coop/role-demands` readonly diagnostic, no-auth. Risposta:

```json
{ "count": 13, "items": [...] }
```

### `tests/api/coopRoleDemands.test.js` (NEW, 7 tests)

- count + items shape
- count matches `BIOME_ROLE_DEMANDS` keys (parity Godot v2 `scripts/session/ermes_role_gap.gd`)
- savana spot check (esploratore + guerriero)
- no-auth gate (readonly diagnostic)
- defensive copy mutation isolation
- total_slots multi-role sum (foresta_miceliale `tessitore: 2` → total 2)
- each item biome_id non-empty + total_slots ≥1

## Live probe (backend port 3334)

```
GET /api/coop/role-demands → 200 OK
{ "count": 13, "items": [...] }
```

## Test plan

- [x] node --test tests/api/coopRoleDemands.test.js tests/services/coop/ermesExporter.test.js → 25/25 verde (+7 nuovi)
- [x] Prettier verde
- [x] Live probe API confermato
- [x] Zero breaking change: tutti additivi (nuovo export + nuova route)

## Rollback plan

Revert single commit `923e55f0`. Tutti additivi.

## Authority

Parallel session Lenovo branch `claude/parallel-list-bioma-role-demands-2026-05-20`. Generated da `Explore` agent dispatch Candidato #2 (post merge #2334 + #2335 + #2336 cascade). Scope ortogonale vs sessione Ryzen-Bash (governance OD-050 chiusa).