### PR TITLE
fix(balance): Wave 5-7 6-trait cluster nerf cost_ap 1→2 (P1 auditor)

### DIFF
--- a/packs/evo_tactics_pack/data/balance/trait_mechanics.yaml
+++ b/packs/evo_tactics_pack/data/balance/trait_mechanics.yaml
@@ -901,7 +901,8 @@ traits:
     attack_mod: 0
     defense_mod: 2
     damage_step: 0
-    cost_ap: 1
+    # 2026-05-20 balance-auditor P1 fix — Wave 5-7 cluster nerf (cost_ap 1→2 vs 6-trait batch-fill artifact mismatching AP:3 mantle baseline).
+    cost_ap: 2
     resistances: []
     active_effects:
       - ability_id: branchie_osmotiche_salmastra_guard
@@ -976,7 +977,8 @@ traits:
     attack_mod: 0
     defense_mod: 2
     damage_step: 0
-    cost_ap: 1
+    # 2026-05-20 balance-auditor P1 fix — Wave 5-7 cluster nerf (cost_ap 1→2 vs 6-trait batch-fill artifact mismatching AP:3 mantle baseline).
+    cost_ap: 2
     resistances: []
     active_effects:
       - ability_id: carapace_segmenti_logici_guard
@@ -991,7 +993,8 @@ traits:
     attack_mod: 0
     defense_mod: 2
     damage_step: 0
-    cost_ap: 1
+    # 2026-05-20 balance-auditor P1 fix — Wave 5-7 cluster nerf (cost_ap 1→2 vs 6-trait batch-fill artifact mismatching AP:3 mantle baseline).
+    cost_ap: 2
     resistances: []
     active_effects:
       - ability_id: carapaci_ferruginosi_guard
@@ -1006,7 +1009,8 @@ traits:
     attack_mod: 0
     defense_mod: 2
     damage_step: 0
-    cost_ap: 1
+    # 2026-05-20 balance-auditor P1 fix — Wave 5-7 cluster nerf (cost_ap 1→2 vs 6-trait batch-fill artifact mismatching AP:3 mantle baseline).
+    cost_ap: 2
     resistances: []
     active_effects:
       - ability_id: cartilagini_pseudometalliche_guard
@@ -1245,7 +1249,8 @@ traits:
     attack_mod: 0
     defense_mod: 2
     damage_step: 0
-    cost_ap: 1
+    # 2026-05-20 balance-auditor P1 fix — Wave 5-7 cluster nerf (cost_ap 1→2 vs 6-trait batch-fill artifact mismatching AP:3 mantle baseline).
+    cost_ap: 2
     resistances: []
     active_effects:
       - ability_id: ghiandole_grafene_guard
@@ -1474,7 +1479,8 @@ traits:
     attack_mod: 0
     defense_mod: 2
     damage_step: 0
-    cost_ap: 1
+    # 2026-05-20 balance-auditor P1 fix — Wave 5-7 cluster nerf (cost_ap 1→2 vs 6-trait batch-fill artifact mismatching AP:3 mantle baseline).
+    cost_ap: 2
     resistances: []
     active_effects:
       - ability_id: pelli_fitte_guard


### PR DESCRIPTION
## Summary

Balance-auditor wave 3 dispatch 2026-05-20 ha flagged **P1 cluster outlier**: 6 traits in `packs/evo_tactics_pack/data/balance/trait_mechanics.yaml` con profile identico `defense_mod:2, cost_ap:1, buff_amount:3, buff_duration:3`. File header L630-631 conferma "Tier-default balance values applied (no new design — match T1/T2/T3 baseline)" → batch-fill artifact senza per-trait tuning.

Problema: passive `defense_mod:2` al `cost_ap:1` SUPERA value di trait AP:3 (`mantello_meteoritico`, buff:4) quando 2 stacked → effective defense +4 permanente a soli AP:2 totali (vs AP:3 + temporaneo).

## Changes

6 traits modified — `cost_ap: 1 → 2` con inline P1 audit comment:

1. `branchie_osmotiche_salmastra` (L900)
2. `carapace_segmenti_logici` (L975)
3. `carapaci_ferruginosi` (L990)
4. `cartilagini_pseudometalliche` (L1005)
5. `ghiandole_grafene` (L1244)
6. `pelli_fitte` (L1473)

## Test plan

- [x] `tests/ai/*.test.js` → **417/417 verde** (931ms, AI baseline preserved zero regression)
- [x] `tests/api/predict-combat-8p.test.js` → **11/11 verde** (75ms, balance predict sane)
- [x] Prettier verde (husky lint-staged auto)
- [x] Single file edit (`trait_mechanics.yaml`)

## Rollback plan

Revert single commit `bae0bc23`. Restore `cost_ap: 1` per le 6 traits.

## Authority

Multi-agent dispatch wave 4 (post wave 3 balance-auditor findings). Branch `claude/parallel-balance-wave57-cluster-nerf-2026-05-20`. Scope ortogonale aliena/offspring agents wave 4.