### PR TITLE
feat(coop): listAlienaSummaries + readonly diagnostic route (A6 pattern)

### DIFF
--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -12,6 +12,7 @@
 
 const express = require('express');
 const { listBiomeRoleDemands } = require('../services/coop/ermesExporter');
+const { listAlienaSummaries } = require('../services/coop/alienaGenerator');
 
 function createCoopRouter({ lobby, coopStore } = {}) {
   if (!lobby) throw new Error('createCoopRouter: lobby required');
@@ -100,6 +101,15 @@ function createCoopRouter({ lobby, coopStore } = {}) {
   // Frontend onboarding HUD può preload role expectation per biome scelto.
   router.get('/coop/role-demands', (_req, res) => {
     const items = listBiomeRoleDemands();
+    res.json({ count: items.length, items });
+  });
+
+  // 2026-05-20 — readonly diagnostic per onboarding world mood preload
+  // (A6 pattern `listBiomeRoleDemands` replicato; gap-fill Explore quick-win
+  // discovery). Frontend onboarding HUD può preload aliena_summary_it per
+  // biome scelto. Doctrine: surface diegetic summary, mai label "ALIENA".
+  router.get('/coop/aliena-summaries', (_req, res) => {
+    const items = listAlienaSummaries();
     res.json({ count: items.length, items });
   });
 

--- a/apps/backend/services/coop/alienaGenerator.js
+++ b/apps/backend/services/coop/alienaGenerator.js
@@ -104,10 +104,28 @@ async function generateAlienaEnvelope(biomeId, opts = {}) {
   return { summary: templateSummary, version: ALIENA_VERSION_TEMPLATE_V1 };
 }
 
+/**
+ * 2026-05-20 — list all 13 biome → aliena_summary_it mappings + fallback flag
+ * (mirror A6 `listBiomeRoleDemands` pattern, gap-fill da Explore quick-win
+ * discovery). Used by readonly diagnostic route + frontend onboarding world
+ * mood preload. Doctrine: surface aliena_summary_it never labels ALIENA
+ * system; player vede solo il summary diegetic.
+ *
+ * @returns {Array<{biome_id: string, summary: string, has_fallback: boolean}>}
+ */
+function listAlienaSummaries() {
+  return Object.entries(STATIC_SUMMARIES).map(([biome_id, summary]) => ({
+    biome_id,
+    summary: String(summary),
+    has_fallback: summary === FALLBACK_SUMMARY,
+  }));
+}
+
 module.exports = {
   generateAlienaSummary,
   generateAlienaEnvelope,
   generateAuthoringTags,
+  listAlienaSummaries,
   STATIC_SUMMARIES,
   FALLBACK_SUMMARY,
   ALIENA_VERSION_TEMPLATE_V1,

--- a/tests/api/coopAlienaSummaries.test.js
+++ b/tests/api/coopAlienaSummaries.test.js
@@ -1,0 +1,89 @@
+// 2026-05-20 — GET /api/coop/aliena-summaries readonly diagnostic route.
+// Mirror pattern A6 listBiomeRoleDemands (gap-fill Explore quick-win discovery).
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+const { createLobbyRouter } = require('../../apps/backend/routes/lobby');
+const { createCoopRouter } = require('../../apps/backend/routes/coop');
+const { createCoopStore } = require('../../apps/backend/services/coop/coopStore');
+const { LobbyService } = require('../../apps/backend/services/network/wsSession');
+const {
+  listAlienaSummaries,
+  STATIC_SUMMARIES,
+  FALLBACK_SUMMARY,
+} = require('../../apps/backend/services/coop/alienaGenerator');
+
+function buildApp() {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createLobbyRouter({ lobby }));
+  app.use('/api', createCoopRouter({ lobby, coopStore }));
+  return app;
+}
+
+test('GET /api/coop/aliena-summaries: returns count + items array', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/coop/aliena-summaries');
+  assert.equal(res.status, 200);
+  assert.equal(typeof res.body.count, 'number');
+  assert.ok(Array.isArray(res.body.items));
+  assert.equal(res.body.items.length, res.body.count);
+});
+
+test('GET /api/coop/aliena-summaries: count matches STATIC_SUMMARIES keys', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/coop/aliena-summaries');
+  assert.equal(res.body.count, Object.keys(STATIC_SUMMARIES).length);
+});
+
+test('GET /api/coop/aliena-summaries: each item exposes biome_id + summary + has_fallback', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/coop/aliena-summaries');
+  for (const item of res.body.items) {
+    assert.equal(typeof item.biome_id, 'string');
+    assert.ok(item.biome_id.length > 0);
+    assert.equal(typeof item.summary, 'string');
+    assert.ok(item.summary.length > 0, `${item.biome_id} summary must be non-empty`);
+    assert.equal(typeof item.has_fallback, 'boolean');
+  }
+});
+
+test('GET /api/coop/aliena-summaries: savana entry surfaces expected summary text (parity Godot v2 sample JSON)', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/coop/aliena-summaries');
+  const savana = res.body.items.find((x) => x.biome_id === 'savana');
+  assert.ok(savana, 'savana entry must be present');
+  assert.ok(savana.summary.includes('Savana'));
+  assert.equal(savana.has_fallback, false);
+});
+
+test('GET /api/coop/aliena-summaries: requires no auth (readonly diagnostic)', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/coop/aliena-summaries');
+  assert.equal(res.status, 200);
+});
+
+test('listAlienaSummaries: returned items do not leak mutations to STATIC_SUMMARIES (frozen source)', () => {
+  const items = listAlienaSummaries();
+  const savanaItem = items.find((x) => x.biome_id === 'savana');
+  const originalSummary = STATIC_SUMMARIES.savana;
+  savanaItem.summary = 'MUTATED';
+  // STATIC_SUMMARIES is Object.freeze'd so mutation cannot leak; verify.
+  assert.equal(STATIC_SUMMARIES.savana, originalSummary);
+});
+
+test('listAlienaSummaries: FALLBACK_SUMMARY exported as separate constant (not part of per-biome map)', () => {
+  assert.equal(typeof FALLBACK_SUMMARY, 'string');
+  assert.ok(FALLBACK_SUMMARY.length > 0);
+  // No biome entry in STATIC_SUMMARIES is identical to FALLBACK_SUMMARY,
+  // so all has_fallback flags must be false.
+  const items = listAlienaSummaries();
+  for (const item of items) {
+    assert.equal(item.has_fallback, false, `${item.biome_id} should not equal FALLBACK_SUMMARY`);
+  }
+});


### PR DESCRIPTION
## Summary

Replica PR #2334 + #2338 A6 pattern (`listBiomeRoleDemands`) per il dataset `aliena_summary_it`. Espone 13 biome narrative summaries via GET endpoint readonly per frontend onboarding world-mood preload.

Doctrine preserved: surface diegetic summary, never label ALIENA system to player.

Generated via `superpowers:dispatching-parallel-agents` wave 4 (Agent 2/3, post Explore quick-wins wave 3 #1).

## Changes

- **`apps/backend/services/coop/alienaGenerator.js`**: `listAlienaSummaries()` export con `{biome_id, summary, has_fallback}` shape + `FALLBACK_SUMMARY` discriminator.
- **`apps/backend/routes/coop.js`**: `GET /coop/aliena-summaries` (no-auth, mirrors `/coop/role-demands` at line 99).
- **`tests/api/coopAlienaSummaries.test.js`** (NEW): 7 test:
  - count + items array shape
  - count matches `STATIC_SUMMARIES` keys (13)
  - per-item fields shape (biome_id + summary + has_fallback boolean)
  - savana spot-check (`"Savana"` substring + `has_fallback=false`)
  - no-auth gate
  - frozen-source mutation guard
  - `FALLBACK_SUMMARY` constant exposed correctly

## Rebuild note

Branch precedente `claude/parallel-aliena-summaries-readonly-2026-05-20` contaminato da Agent 1 wave 4 (`trait_mechanics.yaml` hunk leaked durante parallel cwd HEAD switching, lesson L-066). Branch corrente cherry-pick 3 file legit (routes + service + test) su `origin/main` fresh.

## Test plan

- [x] `node --test tests/api/coopAlienaSummaries.test.js` → 7/7 verde (268ms)
- [x] Prettier verde
- [x] Zero breaking change

## Authority

Branch `claude/parallel-aliena-summaries-clean-2026-05-20`. Scope ortogonale wave 4 (balance + offspring agents).