### PR TITLE
feat(combat): readonly diagnostic routes (status-penalties + biome-modifiers)

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -27,6 +27,8 @@ const { createCodexRouter } = require('./routes/codex');
 const { createFormPackRouter } = require('./routes/formPackRoutes');
 const { createLobbyRouter } = require('./routes/lobby');
 const { createCoopRouter } = require('./routes/coop');
+// 2026-05-20 — Combat readonly diagnostic routes (status penalties + biome modifiers)
+const { createCombatRouter } = require('./routes/combat');
 // W5.5 — companion picker REST endpoint.
 const { createCompanionRouter } = require('./routes/companion');
 // Skiv ticket #7 — unit diary persistence (cross-session memoria)
@@ -786,6 +788,8 @@ function createApp(options = {}) {
   // M17 — Co-op run orchestrator (character creation + world setup + debrief).
   const coopStore = createCoopStore({ lobby });
   app.use('/api', createCoopRouter({ lobby, coopStore }));
+  // 2026-05-20 — Combat readonly diagnostic (status-penalties + biome-modifiers).
+  app.use('/api/combat', createCombatRouter());
   app.use('/api', createCompanionRouter());
 
   // Skiv ticket #7 — unit diary persistence MVP (backend-only, JSONL append).

--- a/apps/backend/routes/combat.js
+++ b/apps/backend/routes/combat.js
@@ -1,0 +1,36 @@
+// 2026-05-20 — Combat readonly diagnostic routes (A6 pattern, gap-fill
+// Explore quick-wins wave 3 #2 + #4).
+//
+// Endpoints:
+//   GET /api/combat/status-penalties — wounded_perma + bleeding/fracture tiers
+//   GET /api/combat/biome-modifiers  — runtime diff_base + hp_mult + pressure formula per biome
+//
+// Frontend combat UI può preload questi reference table evitando
+// client-side duplication / null-fallback.
+
+'use strict';
+
+const { Router } = require('express');
+const { listStatusPenalties } = require('../services/combat/statusModifiers');
+const { listBiomeModifiers } = require('../services/combat/biomeModifiers');
+
+function createCombatRouter() {
+  const router = Router();
+
+  router.get('/status-penalties', (_req, res) => {
+    const data = listStatusPenalties();
+    res.json({
+      wounded_perma_attack_penalty: data.wounded_perma_attack_penalty,
+      bleeding_fracture_slow_down_threshold: data.bleeding_fracture_slow_down_threshold,
+    });
+  });
+
+  router.get('/biome-modifiers', (_req, res) => {
+    const items = listBiomeModifiers();
+    res.json({ count: items.length, items });
+  });
+
+  return router;
+}
+
+module.exports = { createCombatRouter };

--- a/apps/backend/services/combat/biomeModifiers.js
+++ b/apps/backend/services/combat/biomeModifiers.js
@@ -161,9 +161,29 @@ function applyEnemyHpMultiplier(units, hpMult) {
   return units;
 }
 
+/**
+ * 2026-05-20 — list runtime biome modifier registry (A6 pattern, gap-fill
+ * Explore quick-win wave 3 #4). Used by readonly diagnostic route +
+ * frontend combat UI per preload diff_base/hp_mult/pressure formula per biome.
+ *
+ * @param {object} [registry] — DI override (test/dev)
+ * @returns {Array<{biome_id, diff_base, hp_mult, pressure_mult, pressure_initial_bonus}>}
+ */
+function listBiomeModifiers(registry) {
+  const biomes = registry || loadBiomesConfig();
+  if (!biomes || typeof biomes !== 'object') return [];
+  return Object.keys(biomes)
+    .sort()
+    .map((biome_id) => ({
+      biome_id,
+      ...getBiomeModifiers(biome_id, biomes),
+    }));
+}
+
 module.exports = {
   loadBiomesConfig,
   getBiomeModifiers,
+  listBiomeModifiers,
   applyEnemyHpMultiplier,
   _resetCache,
   DEFAULT_BIOMES_YAML,

--- a/apps/backend/services/combat/statusModifiers.js
+++ b/apps/backend/services/combat/statusModifiers.js
@@ -257,11 +257,33 @@ function applyTurnRegen(unit) {
   return events;
 }
 
+/**
+ * 2026-05-20 — list status penalty tiers (A6 pattern, gap-fill Explore
+ * quick-win wave 3 #2). Used by readonly diagnostic route + frontend
+ * combat UI per preload penalty tier table (avoids client-side duplication).
+ *
+ * @returns {{
+ *   wounded_perma_attack_penalty: Array<{severity, penalty}>,
+ *   bleeding_fracture_slow_down_threshold: Array<{severity, triggers_slow_down}>,
+ * }}
+ */
+function listStatusPenalties() {
+  return {
+    wounded_perma_attack_penalty: Object.entries(WOUNDED_PERMA_ATTACK_PENALTY).map(
+      ([severity, penalty]) => ({ severity, penalty }),
+    ),
+    bleeding_fracture_slow_down_threshold: Object.entries(
+      BLEEDING_FRACTURE_SLOW_DOWN_THRESHOLD,
+    ).map(([severity, triggers_slow_down]) => ({ severity, triggers_slow_down })),
+  };
+}
+
 module.exports = {
   computeStatusModifiers,
   applyTurnRegen,
   computeWoundedPermaAttackPenalty,
   computeSlowDownPenalty,
+  listStatusPenalties,
   // Exported for tests
   manhattanDistance,
   WOUNDED_PERMA_ATTACK_PENALTY,

--- a/tests/api/combatReadonly.test.js
+++ b/tests/api/combatReadonly.test.js
@@ -1,0 +1,137 @@
+// 2026-05-20 — Combat readonly diagnostic routes (A6 pattern gap-fill
+// Explore quick-wins wave 3 #2 + #4).
+// Mirror pattern coopRoleDemands.test.js + coopAlienaSummaries.test.js.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+const { createCombatRouter } = require('../../apps/backend/routes/combat');
+const {
+  listStatusPenalties,
+  WOUNDED_PERMA_ATTACK_PENALTY,
+  BLEEDING_FRACTURE_SLOW_DOWN_THRESHOLD,
+} = require('../../apps/backend/services/combat/statusModifiers');
+const { listBiomeModifiers } = require('../../apps/backend/services/combat/biomeModifiers');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/combat', createCombatRouter());
+  return app;
+}
+
+// ===========================================================================
+// status-penalties
+// ===========================================================================
+
+test('GET /api/combat/status-penalties: returns both tier tables', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/combat/status-penalties');
+  assert.equal(res.status, 200);
+  assert.ok(Array.isArray(res.body.wounded_perma_attack_penalty));
+  assert.ok(Array.isArray(res.body.bleeding_fracture_slow_down_threshold));
+});
+
+test('GET /api/combat/status-penalties: wounded_perma covers light/medium/severe', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/combat/status-penalties');
+  const severities = res.body.wounded_perma_attack_penalty.map((e) => e.severity);
+  for (const s of ['light', 'medium', 'severe']) {
+    assert.ok(severities.includes(s), `wounded_perma missing ${s}`);
+  }
+});
+
+test('GET /api/combat/status-penalties: bleeding_fracture covers minor/medium/major', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/combat/status-penalties');
+  const severities = res.body.bleeding_fracture_slow_down_threshold.map((e) => e.severity);
+  for (const s of ['minor', 'medium', 'major']) {
+    assert.ok(severities.includes(s), `bleeding_fracture missing ${s}`);
+  }
+});
+
+test('GET /api/combat/status-penalties: penalty values match source constants', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/combat/status-penalties');
+  for (const entry of res.body.wounded_perma_attack_penalty) {
+    assert.equal(entry.penalty, WOUNDED_PERMA_ATTACK_PENALTY[entry.severity]);
+  }
+  for (const entry of res.body.bleeding_fracture_slow_down_threshold) {
+    assert.equal(entry.triggers_slow_down, BLEEDING_FRACTURE_SLOW_DOWN_THRESHOLD[entry.severity]);
+  }
+});
+
+test('GET /api/combat/status-penalties: no-auth (readonly diagnostic)', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/combat/status-penalties');
+  assert.equal(res.status, 200);
+});
+
+test('listStatusPenalties: returned shape matches contract', () => {
+  const data = listStatusPenalties();
+  assert.ok(Array.isArray(data.wounded_perma_attack_penalty));
+  assert.ok(Array.isArray(data.bleeding_fracture_slow_down_threshold));
+  for (const e of data.wounded_perma_attack_penalty) {
+    assert.equal(typeof e.severity, 'string');
+    assert.equal(typeof e.penalty, 'number');
+  }
+  for (const e of data.bleeding_fracture_slow_down_threshold) {
+    assert.equal(typeof e.severity, 'string');
+    assert.equal(typeof e.triggers_slow_down, 'boolean');
+  }
+});
+
+// ===========================================================================
+// biome-modifiers
+// ===========================================================================
+
+test('GET /api/combat/biome-modifiers: returns count + items array', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/combat/biome-modifiers');
+  assert.equal(res.status, 200);
+  assert.equal(typeof res.body.count, 'number');
+  assert.ok(Array.isArray(res.body.items));
+  assert.equal(res.body.items.length, res.body.count);
+});
+
+test('GET /api/combat/biome-modifiers: each item exposes diff_base + hp_mult + pressure_*', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/combat/biome-modifiers');
+  for (const item of res.body.items) {
+    assert.equal(typeof item.biome_id, 'string');
+    assert.ok(item.biome_id.length > 0);
+    assert.equal(typeof item.diff_base, 'number');
+    assert.equal(typeof item.hp_mult, 'number');
+    assert.equal(typeof item.pressure_mult, 'number');
+    assert.equal(typeof item.pressure_initial_bonus, 'number');
+  }
+});
+
+test('GET /api/combat/biome-modifiers: no-auth (readonly diagnostic)', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/combat/biome-modifiers');
+  assert.equal(res.status, 200);
+});
+
+test('listBiomeModifiers: stable sort by biome_id', () => {
+  const items = listBiomeModifiers();
+  const ids = items.map((x) => x.biome_id);
+  const sorted = [...ids].sort();
+  assert.deepEqual(ids, sorted, 'items must be sorted by biome_id alphabetically');
+});
+
+test('listBiomeModifiers: gracefully handles empty registry', () => {
+  const items = listBiomeModifiers({});
+  assert.deepEqual(items, []);
+});
+
+test('listBiomeModifiers: SAFE_DEFAULTS for unknown biome in registry', () => {
+  // Provide registry without any matching biome_id structure
+  const items = listBiomeModifiers({ fake_biome: null });
+  assert.equal(items.length, 1);
+  // null biome cfg → returns SAFE_DEFAULTS
+  assert.equal(items[0].diff_base, 1.0);
+  assert.equal(items[0].hp_mult, 1.0);
+});


### PR DESCRIPTION
## Summary

A6 pattern replicato (PR #2334 + #2338 + #2345) per il combat domain. Gap-fill Explore quick-wins wave 3 #2 + #4.

Espone 2 nuovi endpoint readonly diagnostic per frontend combat UI preload (penalty tier table + biome modifier formula) evitando client-side duplication / null fallback.

## Changes

- **`apps/backend/services/combat/statusModifiers.js`**: `listStatusPenalties()` export shape `{wounded_perma_attack_penalty: [{severity, penalty}], bleeding_fracture_slow_down_threshold: [{severity, triggers_slow_down}]}`.
- **`apps/backend/services/combat/biomeModifiers.js`**: `listBiomeModifiers(registry?)` export shape `Array<{biome_id, diff_base, hp_mult, pressure_mult, pressure_initial_bonus}>` sorted by biome_id.
- **`apps/backend/routes/combat.js` (NEW)**: `createCombatRouter()` + 2 endpoint:
  - `GET /api/combat/status-penalties` (no-auth)
  - `GET /api/combat/biome-modifiers` (no-auth)
- **`apps/backend/app.js`**: register router at `/api/combat`.
- **`tests/api/combatReadonly.test.js` (NEW, 12 test)**: count + items shape + severity coverage (light/medium/severe + minor/medium/major) + parity vs source constants + sort stable + empty registry handling + SAFE_DEFAULTS fallback + no-auth gate.

## Test plan

- [x] node --test tests/api/combatReadonly.test.js → 12/12 verde (296ms)
- [x] Prettier verde
- [x] Zero breaking change (all additive)

## Authority

Multi-agent dispatch wave 3 follow-up (Explore quick-wins #2 + #4 ship). Branch `claude/parallel-status-biome-modifiers-readonly-2026-05-20`.