### PR TITLE
docs(ops): 7+2 backend env flags in deploy-min-checklist

### DIFF
--- a/docs/ops/deploy-min-checklist.md
+++ b/docs/ops/deploy-min-checklist.md
@@ -306,3 +306,33 @@ File aggiunti/modificati Sprint C:
 | `tests/scripts/deploy-min-bundle.test.js` | new    | Sintassi + frontmatter + YAML/TOML valid                    |
 
 Zero behavior change `apps/backend/`. Zero schema change.
+
+---
+
+## Backend env flags (opt-in, default OFF unless noted)
+
+Doc 2026-05-20 — repo-archaeologist museum card `session-debug-infra-patterns-2026-05-20` P6 finding (7 env flag undocumented). Flag elencati cross-source `apps/backend/`:
+
+| Env flag                       | Default      | Path canonical                                       | Effetto                                                                                                                                                                      |
+| ------------------------------ | ------------ | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BRAVADO_ENABLED`              | `false`      | `apps/backend/routes/session.js:782`                 | Attiva morale bravado post-kill (action 5a). Test/playtest balance calibration senza code change. Set `BRAVADO_ENABLED=true` runtime.                                        |
+| `NIDO_UNLOCKED`                | `false`      | `apps/backend/routes/sessionHelpers.js:357`          | Dev/test bypass per V3 mating/nido unlock gate (skip campaign progression requirement). Set `NIDO_UNLOCKED=true` runtime.                                                    |
+| `VC_AXES_ITER`                 | `1` (auto)   | `apps/backend/services/vcScoring.js:892-903`         | Force MBTI axes iteration version. `1` = iter1 legacy (back-compat), `2` = iter2 4-axis full reveal. Auto-detect default; set `VC_AXES_ITER=2` per playtest reveal A/B test. |
+| `MBTI_REVEAL_THRESHOLD`        | `0.7`        | `apps/backend/services/mbtiSurface.js:145-165`       | Phased reveal MBTI confidence threshold (Disco Elysium pattern). Range `[0..1]`. Set `MBTI_REVEAL_THRESHOLD=0.5` per relaxed reveal A/B test (più assi early game).          |
+| `LOBBY_LOG_DISABLED`           | `0`          | `apps/backend/services/network/wsSession.js:46-49`   | Silenzia lobby-service log per smoke runs / CI noise reduction. Set `LOBBY_LOG_DISABLED=1` runtime.                                                                          |
+| `REWIND_BUFFER_SIZE`           | `3`          | `apps/backend/services/combat/rewindBuffer.js:10,27` | Ring buffer FIFO size per rewind safety valve. Set integer ≥1 per scenari mid-combat. Larger buffer = more undo history (memory cost).                                       |
+| `PRISMA_LOG_QUERIES`           | unset (warn) | `apps/backend/db/prisma.js:106`                      | Activa Prisma query logging (verbose). Set `PRISMA_LOG_QUERIES=1` per debug DB query traces. Default log level `['warn', 'error']` (no query spam).                          |
+| `LOBBY_HOST_TRANSFER_GRACE_MS` | `90000`      | `apps/backend/services/network/wsSession.js`         | Override host-transfer grace ms (phone smoke W4 post-fix 30→90s default). Set integer ms per stricter SLA test (es. `LOBBY_HOST_TRANSFER_GRACE_MS=30000` per 30s).           |
+| `ORCHESTRATOR_AUTOCLOSE_MS`    | unset        | `services/generation/` test infra                    | Python orchestrator pool auto-close timeout. Set durante `node --test` per evitare hanging tests (canonical `ORCHESTRATOR_AUTOCLOSE_MS=2000`).                               |
+
+**Combinazioni utili per playtest balance**:
+
+- Calibration A/B reveal: `MBTI_REVEAL_THRESHOLD=0.5 VC_AXES_ITER=2 BRAVADO_ENABLED=true npm run start:api`
+- Silent smoke testing: `LOBBY_LOG_DISABLED=1 ORCHESTRATOR_AUTOCLOSE_MS=2000 npm run test:api`
+- Dev playthrough unlock all: `NIDO_UNLOCKED=true REWIND_BUFFER_SIZE=5 npm run start:api`
+
+**Anti-pattern guard**: NON aggiungere nuovi env flag senza:
+
+1. Default OFF / safe (back-compat preservato)
+2. Path canonical (single read site) + descrizione effect
+3. Append a questo table appena merged (lesson L-066 parallel session drift)


### PR DESCRIPTION
## Summary

Doc 7 env flag undocumented (repo-archaeologist museum card `session-debug-infra-patterns-2026-05-20` P6 finding) + 2 canonical extra (`LOBBY_HOST_TRANSFER_GRACE_MS` + `ORCHESTRATOR_AUTOCLOSE_MS`) per coverage completo.

## Changes

`docs/ops/deploy-min-checklist.md` append section "Backend env flags (opt-in, default OFF unless noted)" — table 9 flag con default, path canonical, effetto. Plus:

- 3 combinazioni utili per playtest balance (calibration A/B reveal, silent smoke, dev playthrough unlock all)
- Anti-pattern guard: nuovi flag richiedono default OFF + path canonical + doc append (lesson L-066 parallel session drift)

## Test plan

- [x] Doc-only, zero code change
- [x] Prettier verde
- [x] All 9 flag verified via grep cross `apps/backend/`

## Authority

Multi-agent dispatch wave 3 follow-up (Agent 3 P6 ship). Branch `claude/parallel-env-flag-doc-2026-05-20`.