### PR TITLE
feat(combat): ennea-effects readonly diagnostic (A6 wave 6 #1)

### DIFF
--- a/apps/backend/routes/combat.js
+++ b/apps/backend/routes/combat.js
@@ -1,9 +1,10 @@
 // 2026-05-20 — Combat readonly diagnostic routes (A6 pattern, gap-fill
-// Explore quick-wins wave 3 #2 + #4).
+// Explore quick-wins wave 3 #2 + #4 + wave 6 #1).
 //
 // Endpoints:
 //   GET /api/combat/status-penalties — wounded_perma + bleeding/fracture tiers
 //   GET /api/combat/biome-modifiers  — runtime diff_base + hp_mult + pressure formula per biome
+//   GET /api/combat/ennea-effects    — 9/9 ennea archetype buff catalog (label + buffs + desc)
 //
 // Frontend combat UI può preload questi reference table evitando
 // client-side duplication / null-fallback.
@@ -13,6 +14,7 @@
 const { Router } = require('express');
 const { listStatusPenalties } = require('../services/combat/statusModifiers');
 const { listBiomeModifiers } = require('../services/combat/biomeModifiers');
+const { listEnneaEffects } = require('../services/enneaEffects');
 
 function createCombatRouter() {
   const router = Router();
@@ -27,6 +29,11 @@ function createCombatRouter() {
 
   router.get('/biome-modifiers', (_req, res) => {
     const items = listBiomeModifiers();
+    res.json({ count: items.length, items });
+  });
+
+  router.get('/ennea-effects', (_req, res) => {
+    const items = listEnneaEffects();
     res.json({ count: items.length, items });
   });
 

--- a/apps/backend/services/enneaEffects.js
+++ b/apps/backend/services/enneaEffects.js
@@ -269,10 +269,30 @@ function applyEnneaToStatus(actor, effects) {
   return { applied, skipped };
 }
 
+/**
+ * 2026-05-20 — list ENNEA_EFFECTS canonical catalog (A6 pattern, gap-fill
+ * Explore quick-wins wave 6 #1). Espone 9/9 ennea archetype buff catalog
+ * per frontend per preload buff tier reference (avoids client-side
+ * duplication / drift vs canonical YAML).
+ *
+ * @returns {Array<{archetype, label, buffs, description}>} sorted by archetype name
+ */
+function listEnneaEffects() {
+  return Object.entries(ENNEA_EFFECTS)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([archetype, def]) => ({
+      archetype,
+      label: def.label,
+      buffs: Array.isArray(def.buffs) ? def.buffs.map((b) => ({ ...b })) : [],
+      description: def.description,
+    }));
+}
+
 module.exports = {
   ENNEA_EFFECTS,
   STAT_RUNTIME_KIND,
   resolveEnneaEffects,
   applyEnneaBuffs,
   applyEnneaToStatus,
+  listEnneaEffects,
 };

--- a/tests/api/combatEnneaEffectsReadonly.test.js
+++ b/tests/api/combatEnneaEffectsReadonly.test.js
@@ -1,0 +1,94 @@
+// 2026-05-20 — Combat ennea-effects readonly diagnostic (A6 pattern,
+// Explore quick-wins wave 6 #1).
+// Mirror pattern combatReadonly.test.js (status-penalties + biome-modifiers).
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+const { createCombatRouter } = require('../../apps/backend/routes/combat');
+const { listEnneaEffects, ENNEA_EFFECTS } = require('../../apps/backend/services/enneaEffects');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/combat', createCombatRouter());
+  return app;
+}
+
+test('GET /api/combat/ennea-effects: returns count + items array', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/combat/ennea-effects');
+  assert.equal(res.status, 200);
+  assert.equal(typeof res.body.count, 'number');
+  assert.ok(Array.isArray(res.body.items));
+  assert.equal(res.body.items.length, res.body.count);
+});
+
+test('GET /api/combat/ennea-effects: count matches ENNEA_EFFECTS keys (9/9 coverage)', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/combat/ennea-effects');
+  assert.equal(res.body.count, Object.keys(ENNEA_EFFECTS).length);
+  assert.equal(res.body.count, 9, '9/9 ennea archetype canonical coverage');
+});
+
+test('GET /api/combat/ennea-effects: each item exposes archetype + label + buffs + description', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/combat/ennea-effects');
+  for (const item of res.body.items) {
+    assert.equal(typeof item.archetype, 'string');
+    assert.ok(item.archetype.length > 0);
+    assert.equal(typeof item.label, 'string');
+    assert.ok(Array.isArray(item.buffs));
+    assert.equal(typeof item.description, 'string');
+  }
+});
+
+test('GET /api/combat/ennea-effects: items sorted alphabetically by archetype', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/combat/ennea-effects');
+  const archetypes = res.body.items.map((x) => x.archetype);
+  const sorted = [...archetypes].sort((a, b) => a.localeCompare(b));
+  assert.deepEqual(archetypes, sorted);
+});
+
+test('GET /api/combat/ennea-effects: spot-check Coordinatore(2) defense buff', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/combat/ennea-effects');
+  const coord = res.body.items.find((x) => x.archetype === 'Coordinatore(2)');
+  assert.ok(coord, 'Coordinatore(2) must be present');
+  assert.equal(coord.label, 'Sinergia di Squadra');
+  assert.equal(coord.buffs.length, 1);
+  assert.equal(coord.buffs[0].stat, 'defense_mod');
+  assert.equal(coord.buffs[0].amount, 1);
+});
+
+test('GET /api/combat/ennea-effects: no-auth (readonly diagnostic)', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/combat/ennea-effects');
+  assert.equal(res.status, 200);
+});
+
+test('listEnneaEffects: defensive copy (mutation does not leak to ENNEA_EFFECTS)', () => {
+  const items = listEnneaEffects();
+  const coordItem = items.find((x) => x.archetype === 'Coordinatore(2)');
+  const originalAmount = ENNEA_EFFECTS['Coordinatore(2)'].buffs[0].amount;
+  coordItem.buffs[0].amount = 999;
+  assert.equal(ENNEA_EFFECTS['Coordinatore(2)'].buffs[0].amount, originalAmount);
+});
+
+test('listEnneaEffects: all 9 canonical archetypes present', () => {
+  const items = listEnneaEffects();
+  const archetypes = items.map((x) => x.archetype);
+  for (const arch of [
+    'Conquistatore(3)',
+    'Coordinatore(2)',
+    'Esploratore(7)',
+    'Architetto(5)',
+    'Stoico(9)',
+    'Cacciatore(8)',
+  ]) {
+    assert.ok(archetypes.includes(arch), `${arch} missing`);
+  }
+});


### PR DESCRIPTION
## Summary

A6 pattern replicato (5th readonly diagnostic endpoint cumulativo). Gap-fill Explore quick-wins wave 6 #1 — espone 9/9 ennea archetype buff catalog per frontend combat UI preload.

## A6 pattern coverage (cumulative)

| # | PR | Endpoint |
|---|---|---|
| 1 | #2334 | `GET /api/forms/:formId/starter-bioma` |
| 2 | #2338 | `GET /api/coop/role-demands` |
| 3 | #2345 | `GET /api/coop/aliena-summaries` |
| 4 | #2347 | `GET /api/combat/status-penalties` + `GET /api/combat/biome-modifiers` |
| 5 | **this PR** | **`GET /api/combat/ennea-effects`** |

## Changes

- **`apps/backend/services/enneaEffects.js`**: `listEnneaEffects()` export returns `Array<{archetype, label, buffs, description}>` sorted alphabetically. Buffs defensive copy (shallow) per mutation guard.
- **`apps/backend/routes/combat.js`**: `GET /api/combat/ennea-effects` (no-auth) appended a existing combat router.
- **`tests/api/combatEnneaEffectsReadonly.test.js`** (NEW, 8 test):
  - count + items array shape
  - count matches `ENNEA_EFFECTS` keys (9/9 archetype canonical coverage)
  - per-item field shape (archetype + label + buffs[] + description)
  - items sorted alphabetically
  - Coordinatore(2) spot-check (defense_mod +1)
  - no-auth gate
  - defensive copy (mutation does not leak)
  - 6 canonical archetype names verification

## Test plan

- [x] node --test → 20/20 verde (8 nuovi ennea + 12 regression combat readonly)
- [x] Prettier verde (husky lint-staged)
- [x] Zero breaking change (all additive)

## Authority

Multi-agent dispatch wave 6 (Explore quick-wins #1 ship). Branch `claude/parallel-ennea-effects-readonly-2026-05-20`.