### PR TITLE
feat(calibration): L-072 auto-enforce — drift_verify prior-baseline direction-test

### DIFF
--- a/tools/py/calibrate_drift_verify.py
+++ b/tools/py/calibrate_drift_verify.py
@@ -126,6 +126,46 @@ def should_escalate(direction):
     return direction in ("IN_BAND", "OOB_HIGH_MARGINAL", "OOB_LOW_MARGINAL")
 
 
+def assess_vs_prior(probe_wr, prior_wr, target_band):
+    """L-072 direction-test: did the knob move WR TOWARD or AWAY from target
+    band relative to the PRIOR baseline?
+
+    Catches knob INVERSION (es. 3A iter1 hardcore_07 enemy_count -1: prior 60%
+    OOB-high, probe 70% = MORE OOB-high = AWAY = wrong direction, reverse delta).
+    Plain band-classification (assess_direction) sees "OOB-high" both times and
+    misses that the knob made it WORSE.
+
+    Args:
+        probe_wr: float [0,1] N=10 probe win rate
+        prior_wr: float [0,1] prior-knob baseline win rate
+        target_band: (floor, ceiling)
+
+    Returns:
+        (verdict, reason) where verdict in {TOWARD, AWAY, NEUTRAL, IN_BAND_HOLD}
+    """
+    floor, ceiling = target_band
+    center = (floor + ceiling) / 2
+    # If probe already in band, knob landed regardless of prior direction.
+    if floor <= probe_wr <= ceiling:
+        return ("IN_BAND_HOLD",
+                f"probe WR {probe_wr*100:.1f}% in band [{floor*100:.0f}-{ceiling*100:.0f}] "
+                f"(prior {prior_wr*100:.1f}%)")
+    prior_dist = abs(prior_wr - center)
+    probe_dist = abs(probe_wr - center)
+    delta_dist = (prior_dist - probe_dist) * 100  # positive = closer to center
+    if abs(delta_dist) < 2.5:  # within noise floor of N=10
+        return ("NEUTRAL",
+                f"probe WR {probe_wr*100:.1f}% ~ prior {prior_wr*100:.1f}% "
+                f"(dist-to-center delta {delta_dist:+.1f}pp < noise)")
+    if delta_dist > 0:
+        return ("TOWARD",
+                f"probe WR {probe_wr*100:.1f}% moved TOWARD band vs prior "
+                f"{prior_wr*100:.1f}% (closer to center by {delta_dist:.1f}pp)")
+    return ("AWAY",
+            f"probe WR {probe_wr*100:.1f}% moved AWAY from band vs prior "
+            f"{prior_wr*100:.1f}% (farther by {-delta_dist:.1f}pp) -- REVERSE knob delta")
+
+
 def main():
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--scenario", choices=list(SCENARIO_MAP.keys()), required=True)
@@ -135,6 +175,10 @@ def main():
     p.add_argument("--ratify-n", type=int, default=40, help="N=40 default")
     p.add_argument("--target-band", help="Override target band as 'floor-ceiling' percent, e.g. '30-50'")
     p.add_argument("--no-escalate", action="store_true", help="Probe only, never ratify")
+    p.add_argument("--prior-baseline", type=float, default=None,
+                   help="L-072: prior-knob WR percent (es. 60 for hardcore_07 pre-change). "
+                        "If probe moves AWAY from target vs prior, ABORT escalate + "
+                        "suggest reverse delta (catches knob inversion like 3A iter1).")
     p.add_argument("--label", help="Suffix per output filenames (default: timestamp)")
     args = p.parse_args()
 
@@ -174,7 +218,42 @@ def main():
         return 3
     probe_result = parse_batch_result(probe_json)
     direction, reason = assess_direction(probe_result, target)
-    print(f"[drift-verify] PROBE direction={direction} — {reason}")
+    print(f"[drift-verify] PROBE direction={direction} -- {reason}")
+
+    # L-072 prior-baseline direction-test: catch knob inversion before N=40.
+    prior_verdict = None
+    prior_reason = None
+    if args.prior_baseline is not None and probe_result is not None:
+        prior_wr = args.prior_baseline / 100.0
+        prior_verdict, prior_reason = assess_vs_prior(probe_result["win_rate"], prior_wr, target)
+        print(f"[drift-verify] PRIOR-TEST (L-072) {prior_verdict} -- {prior_reason}")
+        if prior_verdict == "AWAY":
+            print(f"[drift-verify] ABORT escalate: knob moved AWAY from target. "
+                  f"Reverse delta sign + re-probe. (N=40 ratify would waste budget.)",
+                  file=sys.stderr)
+            # Write probe-only report with abort verdict.
+            abort_report = {
+                "scenario": args.scenario,
+                "scenario_id": cfg["scenario_id"],
+                "target_band": list(target),
+                "probe": probe_result,
+                "probe_direction": direction,
+                "probe_reason": reason,
+                "prior_baseline_wr": prior_wr,
+                "prior_test_verdict": prior_verdict,
+                "prior_test_reason": prior_reason,
+                "escalated": False,
+                "abort_reason": "L-072 knob moved AWAY from target vs prior baseline",
+                "probe_elapsed_sec": probe_elapsed,
+                "host": args.host,
+                "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "lesson_ref": "CLAUDE.md anti-pattern #18 (L-072 direction-test)",
+            }
+            abort_path = Path(f"{base}-ABORT-l072.json")
+            with open(abort_path, "w", encoding="utf-8") as f:
+                json.dump(abort_report, f, indent=2, ensure_ascii=False)
+            print(f"[drift-verify] abort report: {abort_path}")
+            return 7  # distinct exit: L-072 inversion abort
 
     if args.no_escalate or not should_escalate(direction):
         if not should_escalate(direction):
@@ -206,6 +285,9 @@ def main():
         "probe": probe_result,
         "probe_direction": direction,
         "probe_reason": reason,
+        "prior_baseline_wr": (args.prior_baseline / 100.0) if args.prior_baseline is not None else None,
+        "prior_test_verdict": prior_verdict,
+        "prior_test_reason": prior_reason,
         "probe_elapsed_sec": probe_elapsed,
         "ratify": ratify_result,
         "ratify_elapsed_sec": ratify_elapsed,


### PR DESCRIPTION
## Summary

Makes anti-pattern #18 (L-072) ENFORCEABLE in `calibrate_drift_verify.py`, not
just documented. Catches knob INVERSION before wasting N=40 ratify.

## Problem

Plain `assess_direction` (vs target band) sees "OOB-high" both pre/post knob
change — misses that the knob made WR WORSE. 3A iter1 hardcore_07
`enemy_count -1`: prior 60% OOB-high, probe 70% = MORE OOB-high. Old logic
classified OOB_HIGH_FAR (no escalate) but no explicit inversion flag.

## Fix

`assess_vs_prior(probe_wr, prior_wr, target_band)`:
- **IN_BAND_HOLD** — probe in band (escalate to confirm)
- **TOWARD** — probe OOB but closer to center than prior (escalate)
- **AWAY** — probe farther than prior (ABORT + reverse-delta + exit 7)
- **NEUTRAL** — move < 2.5pp (N=10 noise floor)

Flow: `--prior-baseline 60` → N=10 probe → if AWAY → abort report + exit 7
(no N=40 wasted). Else normal escalate.

## Unit-validated

| Case | Verdict |
|---|---|
| iter1 inversion (prior 60, probe 70) | **AWAY** ✅ (the case it prevents) |
| iter2 toward (prior 60, probe 30) | IN_BAND_HOLD |
| oob-low toward (prior 10, probe 25) | TOWARD |
| neutral (prior 60, probe 59) | NEUTRAL |

## Test plan

- [x] py_compile SYNTAX OK
- [x] assess_vs_prior unit-validated (4 cases)
- [x] Backward-compat: `--prior-baseline` optional (default None = old behavior)
- [x] --help shows new arg
- [ ] Master-dd review

Refs: CLAUDE.md anti-pattern #18 (L-072), hc07 3A iter1 waste evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)