### PR TITLE
feat(api): sistema-state read-only mirror route (M1 sub-proj 2)

### DIFF
--- a/apps/backend/routes/campaign.js
+++ b/apps/backend/routes/campaign.js
@@ -714,6 +714,28 @@ function createCampaignRouter(options = {}) {
     }
   });
 
+  // M1 sub-proj 2 — read-only Sistema-memory mirror for the Godot v2 client.
+  //   GET /api/campaign/sistema-state?campaign_id=<id>
+  //     → 200 { state: { units_observed } }  (empty-safe {} when no row / stub)
+  //     → 400 missing campaign_id
+  // Thin read over the sub-proj 1 store; persistence failure is non-fatal.
+  const { createSistemaStateStore } = require('../services/ai/sistemaStateStore');
+  const { prisma: _sistemaPrisma } = require('../db/prisma');
+
+  router.get('/campaign/sistema-state', async (req, res) => {
+    try {
+      const campaignId = String(req.query.campaign_id || '').trim();
+      if (!campaignId) {
+        return res.status(400).json({ error: 'campaign_id query param richiesto' });
+      }
+      const store = createSistemaStateStore(_sistemaPrisma);
+      const state = await store.get(campaignId); // { units_observed }
+      return res.json({ state });
+    } catch (err) {
+      return res.status(500).json({ error: 'persist_read_failed', detail: String(err.message) });
+    }
+  });
+
   return router;
 }
 

--- a/tests/api/sistemaStateRoute.test.js
+++ b/tests/api/sistemaStateRoute.test.js
@@ -1,0 +1,30 @@
+// M1 sub-proj 2 — read-only Sistema-memory route. Store is a stub no-op
+// in tests (no DATABASE_URL) → units_observed is always {} here; assertions
+// target route shape (200 envelope, empty-safe, 400 guard).
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+
+test('GET /api/campaign/sistema-state returns 200 with empty-safe state', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => { if (typeof close === 'function') await close().catch(() => {}); });
+
+  const res = await request(app)
+    .get('/api/campaign/sistema-state')
+    .query({ campaign_id: 'camp_mirror_test' });
+  assert.equal(res.status, 200, 'returns 200');
+  assert.ok(res.body.state, 'state present');
+  assert.deepEqual(res.body.state.units_observed, {}, 'units_observed empty (stub no-op)');
+});
+
+test('GET /api/campaign/sistema-state 400 when campaign_id missing', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => { if (typeof close === 'function') await close().catch(() => {}); });
+
+  const res = await request(app).get('/api/campaign/sistema-state');
+  assert.equal(res.status, 400, 'missing campaign_id → 400');
+});

--- a/tests/api/sistemaStateRoute.test.js
+++ b/tests/api/sistemaStateRoute.test.js
@@ -11,7 +11,9 @@ const { createApp } = require('../../apps/backend/app');
 
 test('GET /api/campaign/sistema-state returns 200 with empty-safe state', async (t) => {
   const { app, close } = createApp({ databasePath: null });
-  t.after(async () => { if (typeof close === 'function') await close().catch(() => {}); });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
 
   const res = await request(app)
     .get('/api/campaign/sistema-state')
@@ -23,7 +25,9 @@ test('GET /api/campaign/sistema-state returns 200 with empty-safe state', async 
 
 test('GET /api/campaign/sistema-state 400 when campaign_id missing', async (t) => {
   const { app, close } = createApp({ databasePath: null });
-  t.after(async () => { if (typeof close === 'function') await close().catch(() => {}); });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
 
   const res = await request(app).get('/api/campaign/sistema-state');
   assert.equal(res.status, 400, 'missing campaign_id → 400');


### PR DESCRIPTION
## Summary
- New `GET /api/campaign/sistema-state?campaign_id=<id>` route exposing M1 `units_observed` to the Godot v2 client (read-only mirror).
- Thin read over the existing `sistemaStateStore` (sub-proj 1 #2363) — empty-safe (`{units_observed:{}}` when no row/stub), `400` on missing campaign_id, `500` in catch. Mirrors the `godot-v2/state` GET route style.
- No new service file, no write endpoint, no change to store/accumulator/session.js.

This is **PR-A** of M1 sub-project 2 (Godot Sistema-memory mirror). Godot client + surfaces ship in GGv2 PR (linked separately).

## Test Plan
- [x] `node --test tests/api/sistemaStateRoute.test.js` — 2/2 (200 empty-safe + 400 guard)
- [x] `node --test tests/api/*.test.js` regression — 1272/1272
- [x] Live telegraph/echo only render once migration `0011_sistema_state` applied at deploy (until then store stub → empty → client surfaces hidden, correct back-compat)

Spec/plan: GGv2 `docs/superpowers/specs|plans/2026-05-21-m1-godot-mirror*`.