### PR TITLE
fix(balance): revise hc06 hardcore band to engine reality + wire enemy_damage knob (OD-032 A+C)

### DIFF
--- a/OPEN_DECISIONS.md
+++ b/OPEN_DECISIONS.md
@@ -9,24 +9,55 @@
 
 ## Aperte
 
+### [OD-032] hardcore_06 secondary band — blocker strutturale + design fork ✅ RISOLTA A+C 2026-05-21
+
+> **Verdict master-dd 2026-05-21: A+C.** A = banda canonica rivista alla realtà engine (N=40 evidence). C = enemy_damage knob wired per hc06 (capability per futuro timer-off path). Shipped:
+>
+> - **A**: `damage_curves.yaml` hardcore `target_bands` → defeat `[0.40,0.55]→[0.75,0.85]`, timeout `[0.15,0.25]→[0.00,0.05]`, WR `[0.15,0.25]` invariata. Evidence: prod config (boss_hp 0.65, timer 25) N=40 = WR 25% / defeat 75% / timeout 0% (pooled N=72 ~ WR 21% / def 78% / to 0%). Banda originale era DESIGN-TARGET incompatibile col proprio `turn_limit_defeat=25` (M7 elimina stalemate → timeout~0). Optuna 3-knob run confermò timeout irraggiungibile (no stalemate corner nei 5 trial; combat hc06 risolve win/wipe entro 40 round).
+> - **C**: `enemy_damage_multiplier_override` knob wired hc06 (batch encounter.id + Optuna knob_space + multi-band objective). Validato: shift WR/defeat pulito. NON cambia config production (capability per timer-off path se master-dd lo vuole).
+> - **Bug collaterale fixato**: batch CLIENT ignorava `DAMAGE_CURVES_PATH` env (no-op silenzioso scenario_overrides in calibrazione). Ora env-aware + passato al subprocess batch in optuna/parallel.
+> - **ALT non-shippato (master-dd authority)**: restaurare timeout-middle band = revert M7 (raise/disable turn_limit) + tune stalemate corner. Fragile (iter7 = 67% timeout uncontrolled). enemy_damage knob pronto se si persegue.
+> - **Side-finding**: backend hang dopo ~7 sessioni/processo durante batch (3 run stallati a 7/shard). Workaround: 8 shard × 5. Investigazione separata raccomandata.
+
+**Contesto**: task "converge secondary band hc06 (defeat 85% → 40-55%, timeout 0% → 15-25%, WR resta in-band [15-25%])" via Optuna multi-knob `boss_hp_multiplier` + `turn_limit_defeat_override`. Investigazione pre-run ha trovato che il band è **strutturalmente irraggiungibile** con i knob attuali. Niente run lanciato (gated master-dd).
+
+**3 problemi trovati**:
+
+1. **turn_limit è binario, non controlla lo split.** `MAX_ROUNDS=40` (`batch_calibrate_hardcore06.py:19`) + `detect_outcome` forza `defeat` quando `turn >= turn_limit_defeat` (`:431`). Qualsiasi limit ≤40 cattura TUTTE le partite irrisolte prima che il loop a 40 round produca un `timeout` → **timeout = 0% per ogni valore in [25,40]**. Timeout si sblocca solo a limit ≥41 (= disabilitato, mai triggera nel loop a 40). Non c'è conversione parziale: lo split defeat↔timeout è una step-function, turn_limit NON può colpire finemente timeout 15-25%.
+2. **Disabilitare il timer fa schizzare la WR.** Probe N=12 con `turn_limit=41` + boss_hp 0.65: 5/6 **victory a turn 23-38**. La WR appariva 15% solo perché il force-defeat a turn 25 tagliava partite che il party avrebbe vinto. Con timer off, per tenere WR in [15,25] serve boss_hp ben sopra il range [0.50,1.00] configurato. Con 1 knob continuo effettivo (boss_hp) vs 3 vincoli di banda → probabilmente infeasible.
+3. **Bug tooling (no-op silenzioso)**: il _client_ batch ignora l'env `DAMAGE_CURVES_PATH` — `DAMAGE_CURVES_PATH` è hardcoded a produzione (`batch_calibrate_hardcore06.py:21`), e `load_turn_limit_defeat` / override-parser leggono da lì (`:180`,`:110`). Nei run Optuna parallel il knob `turn_limit_defeat_override` scritto in staging era letto solo dal backend, **mai dal client** → il client usava sempre prod=25. Quindi nei run multi-knob passati il knob turn_limit era un no-op (variava solo boss_hp).
+
+   ⚠️ _Claude autonomous finding — pending master-dd review_. Anche l'oggetto Optuna ottimizzava solo distanza-WR (ignorava defeat/timeout band).
+
+**Design fork (verdict master-dd richiesto)**:
+
+- **A — Rivedere la banda canonica hc06.** defeat 40-55 + timeout 15-25 contraddice `turn_limit_defeat=25` (M7 Option A+D decision-pressure, `damage_curves.yaml:70`). Forse la banda è aspirazionale e va riallineata alla realtà engine (es. defeat 70-85, timeout 0-10 con timer ON).
+- **B — Alzare MAX_ROUNDS / cambiare modello outcome** per dare conversione parziale (controllo fine dello split). Tocca semantica game-length della calibrazione.
+- **C — Aggiungere un knob di split indipendente** (es. `enemy_damage_multiplier_override` come in hc07): più danno nemico → wipe più rapidi (defeat) vs sopravvivere-a-timeout. Dà la 2ª dimensione continua mancante. Richiede wiring hc06 + ri-tune congiunto.
+
+**Default proposto**: A o C. A se la banda era ottimistica (riallinea SoT alla realtà); C se si vuole davvero la banda e serve il 2° knob. **Prerequisito comune a B/C**: fixare il bug no-op (client env-aware `DAMAGE_CURVES_PATH` + passare l'env al subprocess batch in `calibrate_optuna.py`/`calibrate_parallel.py`) + oggetto Optuna multi-banda. Senza quel fix nessun run hc06 secondary è valido.
+
+**WR primary resta in-band** (boss_hp 0.65 = WR 15%, N=40 ratificato) — questo OD riguarda SOLO la banda secondaria. Nessuna regressione P6 primary.
+
 ### [OD-024..031] ai-station ecosystem audit verdicts — ✅ 8/8 SHIPPED cross-stack 2026-05-14
 
 8 OD originati da PR #2260 ecosystem audit + ai-station re-analisi vault PR #5. Master-dd direction "finish work, not conservative". Tutti shipped via Envelope A+B+C cascade ~26h cross-stack.
 
-| OD  | Topic                                       | Verdict ai-station                                  | Channel shipped                                       |
-| :-: | ------------------------------------------- | --------------------------------------------------- | ----------------------------------------------------- |
-| 024 | Sentience tier backfill                     | ✅ Full RFC T1-T6 + 4 traits 15/15 lifecycle        | Game/ #2262 (residue 30 species pending)              |
-| 025 | Promotions demolish vs implement            | ❌ REJECT framing (engine LIVE) + smoke + B2 catalog| Game/ #2261 + #2262                                   |
-| 026 | Atlas mini-map decisione D5                 | ✅ Diegetic TV + Phone overlay (FDF §16)            | Godot v2 #260 scaffold (asset commission pending)     |
-| 027 | Bridge species type                         | ✅ Full Species type + ecotypes                     | Game/ #2262 species_catalog.json v0.2.0               |
-| 028 | Audio pipeline                              | ✅ Howler.js middleware (CDN opt-in, zero npm dep)  | Game/ #2261 audio.js facade                           |
-| 029 | Ancestors Path B biome_pool                 | ✅ Proceed mapping 13→51 entries (4 branch)         | Game/ #2262 neurons_bridge.csv                        |
-| 030 | Game-Database HTTP runtime flag             | ✅ flag-ON default (D2-C cross-stack pipeline LIVE) | Game/ #2261 default flip                              |
-| 031 | Pack drift policy                           | ✅ Core autoritativo additive (species + mating)    | Game/ #2262 species_catalog + branch mating gene_slots|
+| OD  | Topic                            | Verdict ai-station                                   | Channel shipped                                        |
+| :-: | -------------------------------- | ---------------------------------------------------- | ------------------------------------------------------ |
+| 024 | Sentience tier backfill          | ✅ Full RFC T1-T6 + 4 traits 15/15 lifecycle         | Game/ #2262 (residue 30 species pending)               |
+| 025 | Promotions demolish vs implement | ❌ REJECT framing (engine LIVE) + smoke + B2 catalog | Game/ #2261 + #2262                                    |
+| 026 | Atlas mini-map decisione D5      | ✅ Diegetic TV + Phone overlay (FDF §16)             | Godot v2 #260 scaffold (asset commission pending)      |
+| 027 | Bridge species type              | ✅ Full Species type + ecotypes                      | Game/ #2262 species_catalog.json v0.2.0                |
+| 028 | Audio pipeline                   | ✅ Howler.js middleware (CDN opt-in, zero npm dep)   | Game/ #2261 audio.js facade                            |
+| 029 | Ancestors Path B biome_pool      | ✅ Proceed mapping 13→51 entries (4 branch)          | Game/ #2262 neurons_bridge.csv                         |
+| 030 | Game-Database HTTP runtime flag  | ✅ flag-ON default (D2-C cross-stack pipeline LIVE)  | Game/ #2261 default flip                               |
+| 031 | Pack drift policy                | ✅ Core autoritativo additive (species + mating)     | Game/ #2262 species_catalog + branch mating gene_slots |
 
 **Status**: ✅ 8/8 SHIPPED. 3 governance Q residue (Q1 schema fork + Q2 mating drift autonomous + Q3 engine B3) tutti chiusi questa sessione (Q1 awaits master-dd ADR scelta canonical-migration vs coexistence; Q2+Q3 ✅ shipped).
 
 **Cross-link**:
+
 - Audit source: [PR #2260](https://github.com/MasterDD-L34D/Game/pull/2260) ecosystem 7-strati
 - Plan canonical: [`docs/planning/2026-05-13-ecosystem-research-solution-plan.md`](docs/planning/2026-05-13-ecosystem-research-solution-plan.md) §6
 - Governance record: [`docs/governance/open-decisions/OD-024-031-verdict-record.md`](docs/governance/open-decisions/OD-024-031-verdict-record.md)

--- a/data/core/balance/damage_curves.yaml
+++ b/data/core/balance/damage_curves.yaml
@@ -55,10 +55,27 @@ encounter_classes:
 
   hardcore:
     description: 'High-difficulty 8p co-op. Team tactical peak required.'
+    # 2026-05-21 (OD-032) band revised to engine reality via N=40 evidence.
+    # Original DESIGN-TARGET was defeat [0.40,0.55] + timeout [0.15,0.25] (a
+    # "hard but ran-out-of-time" middle outcome). That target is structurally
+    # INCOMPATIBLE with turn_limit_defeat=25 below: M7 added the timer
+    # specifically to "elimina stalemate pattern (iter7 timeout 67%)" -> it
+    # converts every unresolved game to defeat at turn 25, so timeout ~0 always.
+    # Optuna 3-knob run (boss_hp + enemy_damage + turn_limit) confirmed: with
+    # timer ON timeout=0 (no reachable stalemate band); even timer-OFF the 5
+    # trials never produced timeout (hc06 combat resolves win/wipe within 40
+    # rounds). Production config (boss_hp 0.65, timer 25) N=40: WR 25% / defeat
+    # 75% / timeout 0% (pooled N=72 ~ WR 21% / defeat 78% / to 0%). Band now
+    # matches that. WR [0.15,0.25] kept (primary pillar, in-band).
+    # ALT (master-dd, OD-032): to restore the timeout-middle band, revert M7
+    # (raise/disable turn_limit) + tune the stalemate corner (high boss_hp +
+    # low enemy_damage) -- fragile (iter7 hit 67% uncontrolled) and re-opens the
+    # stalemate M7 closed. enemy_damage_multiplier_override knob now wired for
+    # hc06 (OD-032 C) if that path is pursued.
     target_bands:
       win_rate: [0.15, 0.25]
-      defeat_rate: [0.40, 0.55]
-      timeout_rate: [0.15, 0.25]
+      defeat_rate: [0.75, 0.85]
+      timeout_rate: [0.00, 0.05]
     # M7-#2 Phase E iter7 (post iter6 RED wr 63.3%): 1.4 → 1.8 (+0.4).
     # Vedi docs/playtest/2026-04-20-m7-iter6-hardcore-verdict.md § Option A+D.
     enemy_damage_multiplier: 1.8

--- a/docs/planning/2026-05-21-session-handoff-v44.5-FINAL.md
+++ b/docs/planning/2026-05-21-session-handoff-v44.5-FINAL.md
@@ -1,0 +1,121 @@
+---
+title: Session handoff v44.5 FINAL — Calibration toolkit complete + both hardcore in-band
+date: 2026-05-21
+type: session-handoff
+sprint: v44.4 -> v44.5
+pillar: [P6]
+status: complete
+supersedes: docs/planning/2026-05-21-session-handoff.md
+last_verified: 2026-05-21
+---
+
+# Session handoff v44.5 FINAL — Calibration methodology complete
+
+## TL;DR (30s)
+
+**7 PRs merged main** (2026-05-20/21). Both P6 hardcore scenarios primary metric
+in-band. Full calibration methodology toolkit shipped (6 tools). 5-lesson
+anti-pattern cluster codified (L-069/070/071/072/073, catalog #14-18). Issue
+#2356 (production clobber) structurally resolved via staging-writer. Optuna
+Bayesian opt now affordable at ratify-grade N=40 via per-trial 4x parallel-internal.
+
+## PRs merged (7)
+
+| PR    | Topic                                                         | Key result                                      |
+| ----- | ------------------------------------------------------------- | ----------------------------------------------- |
+| #2354 | scenario_overrides infra + α P0 trio (C+B+F) + Optuna + L-073 | per-scenario knob layer + 3 calibration methods |
+| #2355 | Codex audit cross-PR sweep                                    | ionico mirror + XSS + doc fixes                 |
+| #2357 | MAP-Elites Method D real evaluator                            | QD explorer (real backend)                      |
+| #2358 | staging-writer fix (issue #2356)                              | production never clobbered                      |
+| #2359 | hardcore_07 edm 2.1                                           | WR 60% -> 45% IN-BAND                           |
+| #2360 | L-072 auto-enforce (drift_verify)                             | prior-baseline inversion guard                  |
+| #2361 | Optuna parallel-internal                                      | per-trial 4x (24min -> 6min)                    |
+
+## Pillar P6 final state (main HEAD 315c463a)
+
+| Scenario    | Knob                                 | WR (N=40 ratified) | Status                                                |
+| ----------- | ------------------------------------ | ------------------ | ----------------------------------------------------- |
+| hardcore_06 | boss_hp_multiplier 0.65              | 15%                | 🟢 primary in-band [15-25%], secondary defeat 85% RED |
+| hardcore_07 | enemy_damage_multiplier_override 2.1 | 45%                | 🟢 IN-BAND [30-50%]                                   |
+
+hardcore_07 secondary (defeat 0% / timeout 55%) scenario-appropriate (pod-rush timer).
+
+## Calibration toolkit (all tools/py/, on main)
+
+| Tool                                | Method                     | Status                                                |
+| ----------------------------------- | -------------------------- | ----------------------------------------------------- |
+| `calibrate_parallel.py`             | C — 4-shard parallel       | 4x verified; `start_shard(curves_path)` staging-aware |
+| `calibrate_sprt.py`                 | B — Wilson CI95 early-stop | conservative-correct                                  |
+| `calibrate_optuna.py`               | A — Bayesian TPE           | `--parallel` 4x + `--n-per-trial 40` + staging-writer |
+| `calibrate_map_elites.py`           | D — QD real evaluator      | stub + real (N=40 default)                            |
+| `calibrate_drift_verify.py`         | N=10->N=40 escalation      | `--prior-baseline` L-072 inversion guard              |
+| `check_trait_mirror_consistency.py` | trait mirror validator     | pre-commit + CI integrated                            |
+
+## scenario_overrides knobs (damage_curves.yaml + damageCurves.js)
+
+| Knob                             | Apply site                             | Note                                        |
+| -------------------------------- | -------------------------------------- | ------------------------------------------- |
+| boss_hp_multiplier               | build (hardcoreScenario.js)            | 0.65 hc06 shipped                           |
+| turn_limit_defeat_override       | sessionRoundBridge.js                  | scenario-aware                              |
+| enemy_count_modifier             | build                                  | infra (hc07 iter1 rejected, kept available) |
+| enemy_damage_multiplier_override | session.js /start (needs encounter.id) | 2.1 hc07 shipped, REPLACES class            |
+
+Backend `DAMAGE_CURVES_PATH` env -> staging-writer (production untouched pre-ratify).
+
+## Anti-pattern catalog (user-global CLAUDE.md #14-18)
+
+- #14 L-069 N=10 lucky-sample false in-band (N=40 ratify gate)
+- #15 L-070 Multi-knob sequential overshoot (single-knob bisection)
+- #16 L-071 LOBBY_WS_PORT collision (LOBBY_WS_ENABLED=false per shard)
+- #17 L-073 Optimizer-on-noise (objective N >= ratify threshold)
+- #18 L-072 Direction-test N=10 probe pre-N=40 (auto-enforced drift_verify)
+
+## Method discipline proven (hc07 iter2 clean run)
+
+L-072 direction probe (N=10 WR 60->30 toward) -> L-070 single-knob bisection
+(edm 2.2 overshoot 27.5% -> 2.1 in-band 45%) -> L-069 N=40 ratify gate -> Method C
+parallel 4x. Zero wasted runs (vs iter1 which ran N=40 direct on inverted knob).
+
+## Cross-repo status
+
+- codemasterdd-ai-station: clean (no open PR)
+- Game-Godot-v2: clean (no open PR)
+- Game-Database: #151 OPEN (pg_trgm fuzzy search Fase 2) — OTHER session/domain,
+  NOT calibration-related, not blocking.
+
+## Memory saved (PC-local)
+
+- `feedback_n_sample_authority.md` (L-069)
+- `feedback_calibration_toolkit_2026_05_21.md` (toolkit + L-070/071/072/073 + state)
+- `MEMORY.md` index updated (2 entries)
+
+## Outstanding next session (1 item, ALL tooling ready)
+
+**hardcore_06 secondary band convergence** (defeat 85% -> target 40-55%):
+
+- Primary metric (WR 15%) already in-band; only defeat/timeout split RED.
+- Multi-knob joint needed (boss_hp + turn_limit) — single-knob iters overshot.
+- NOW affordable: `calibrate_optuna.py --scenario hardcore_06 --parallel
+--n-per-trial 40 --n-trials 8` (~48min, staging-safe, N=40-objective per L-073).
+- Alternative: MAP-Elites real run (full knob surface, ~17h, Sprint M14+).
+
+No tooling gaps. Next session = pure calibration run.
+
+## Cleanup notes
+
+- main locked by worktree clever-brattain-ce2046 (gh merge git-switch errors
+  cosmetic; remote merges succeeded all 7 PRs).
+- Stale merged branches local (claude/optuna-parallel-internal etc) — prunable.
+
+## RESUME PASTE (next session)
+
+```
+hardcore_06 secondary band convergence: lancia
+calibrate_optuna.py --scenario hardcore_06 --parallel --n-per-trial 40
+--n-trials 8 (multi-knob boss_hp_multiplier + turn_limit_defeat_override joint,
+~48min staging-safe). Target: defeat 85% -> 40-55%, timeout 0% -> 15-25%,
+mantieni WR primary in-band [15-25%]. Best params N=40 ratify pre-ship (L-069).
+Se Optuna converge -> ship PR scenario_overrides update. Leggi memory
+feedback_calibration_toolkit_2026_05_21.md per toolkit + L-069/070/071/072/073.
+main HEAD 315c463a, 7 PR merged, entrambi hardcore primary in-band.
+```

--- a/tests/ai/damageCurves.test.js
+++ b/tests/ai/damageCurves.test.js
@@ -107,8 +107,8 @@ test('getTargetBands: returns 3 rate ranges for class', () => {
   const bands = getTargetBands('hardcore');
   assert.ok(bands);
   assert.deepEqual(bands.win_rate, [0.15, 0.25]);
-  assert.deepEqual(bands.defeat_rate, [0.4, 0.55]);
-  assert.deepEqual(bands.timeout_rate, [0.15, 0.25]);
+  assert.deepEqual(bands.defeat_rate, [0.75, 0.85]);
+  assert.deepEqual(bands.timeout_rate, [0.0, 0.05]);
 });
 
 test('getTargetBands: null on unknown class', () => {

--- a/tests/scripts/test_calibrate_target_bands.py
+++ b/tests/scripts/test_calibrate_target_bands.py
@@ -40,11 +40,13 @@ def test_load_missing_class_returns_none():
 
 
 def test_hardcore_bands_match_adr():
-    """ADR-2026-04-20 §class table: hardcore win 15-25%, defeat 40-55%, timeout 15-25%."""
+    """OD-032 (2026-05-21) band revised to engine reality: hardcore win 15-25%,
+    defeat 75-85%, timeout 0-5%. turn_limit_defeat=25 converts unresolved games
+    to defeat at turn 25 (M7 anti-stalemate timer) → timeout ~0 structurally."""
     b = load_target_bands("hardcore")
     assert b["win_rate"] == [0.15, 0.25]
-    assert b["defeat_rate"] == [0.40, 0.55]
-    assert b["timeout_rate"] == [0.15, 0.25]
+    assert b["defeat_rate"] == [0.75, 0.85]
+    assert b["timeout_rate"] == [0.00, 0.05]
 
 
 def test_boss_bands_match_adr():
@@ -56,15 +58,16 @@ def test_boss_bands_match_adr():
 
 def test_verdict_green_when_in_band():
     b = load_target_bands("hardcore")
-    v, _ = verdict_for(0.20, 0.50, 0.20, b)
+    # win 0.20 in [0.15,0.25], defeat 0.80 in [0.75,0.85], timeout 0.02 in [0.00,0.05]
+    v, _ = verdict_for(0.20, 0.80, 0.02, b)
     assert v == "GREEN"
 
 
 def test_verdict_amber_within_5pp():
     """±5pp tolerance da band edge."""
     b = load_target_bands("hardcore")
-    # win_rate 0.28 is 3pp sopra hi (0.25) → AMBER
-    v, reasons = verdict_for(0.28, 0.50, 0.20, b)
+    # win_rate 0.28 is 3pp sopra hi (0.25) → AMBER; defeat+timeout in-band
+    v, reasons = verdict_for(0.28, 0.80, 0.02, b)
     assert v == "AMBER"
     assert any("win_rate" in r for r in reasons)
 

--- a/tools/py/batch_calibrate_hardcore06.py
+++ b/tools/py/batch_calibrate_hardcore06.py
@@ -3,6 +3,12 @@
 
 Greedy player policy (atk-closest), AI auto. N=30 default.
 Target: win_rate 15-25%, turns 14-18, K/D 0.6-0.9.
+
+PERF / HANG NOTE (2026-05-21): default --host uses 127.0.0.1, NOT "localhost".
+The backend binds IPv4 (0.0.0.0); on Windows "localhost" resolves IPv6 ::1 first
+and Python urllib (no Happy-Eyeballs) stalls ~2s per request before IPv4 fallback
+(~28 calls/run x 2s = ~56s/run vs ~0.7s/run). That per-call stall is what made a
+shard look like it "hangs" after ~7 sessions. Always pass an IP host, not a name.
 """
 
 import argparse
@@ -17,7 +23,7 @@ import urllib.request
 
 SCENARIO_ID = "enc_tutorial_06_hardcore"
 MAX_ROUNDS = 40
-DEFAULT_HOST = "http://localhost:3340"
+DEFAULT_HOST = "http://127.0.0.1:3340"  # IP not "localhost" (Windows IPv6 stall, see module docstring)
 # 2026-05-21 no-op-bug fix (OD-032): honor DAMAGE_CURVES_PATH env so the batch
 # CLIENT reads the SAME staging file the backend reads. Without this the client's
 # load_turn_limit_defeat / scenario-override parser always read production, making

--- a/tools/py/batch_calibrate_hardcore06.py
+++ b/tools/py/batch_calibrate_hardcore06.py
@@ -18,7 +18,12 @@ import urllib.request
 SCENARIO_ID = "enc_tutorial_06_hardcore"
 MAX_ROUNDS = 40
 DEFAULT_HOST = "http://localhost:3340"
-DAMAGE_CURVES_PATH = os.path.join(
+# 2026-05-21 no-op-bug fix (OD-032): honor DAMAGE_CURVES_PATH env so the batch
+# CLIENT reads the SAME staging file the backend reads. Without this the client's
+# load_turn_limit_defeat / scenario-override parser always read production, making
+# staging-writer scenario_overrides (turn_limit_defeat_override, enemy_damage...)
+# a SILENT NO-OP on the client side during Optuna/MAP-Elites calibration.
+DAMAGE_CURVES_PATH = os.environ.get("DAMAGE_CURVES_PATH") or os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "..", "..", "data", "core", "balance", "damage_curves.yaml"
 )
 
@@ -589,6 +594,9 @@ def run_one(host, run_idx, turn_limit_defeat=None):
         "modulation": "full",
         "sistema_pressure_start": pstart,
         "hazard_tiles": hazard,
+        # 2026-05-21 (OD-032 C): id enables scenario_overrides resolution at /start
+        # (boss_hp + enemy_damage_multiplier_override per session.js scenarioIdForEdm).
+        "encounter": {"id": SCENARIO_ID},
     })
     if status != 200:
         return {"error": f"session/start failed: {start}"}

--- a/tools/py/batch_calibrate_hardcore07.py
+++ b/tools/py/batch_calibrate_hardcore07.py
@@ -19,7 +19,7 @@ import urllib.request
 
 SCENARIO_ID = "enc_tutorial_07_hardcore_pod_rush"
 MAX_ROUNDS = 15
-DEFAULT_HOST = "http://localhost:3334"
+DEFAULT_HOST = "http://127.0.0.1:3334"  # IP not "localhost" (Windows IPv6 ~2s/call stall)
 
 
 def _retry(fn, retries=5, backoff_base=0.5):

--- a/tools/py/calibrate_drift_verify.py
+++ b/tools/py/calibrate_drift_verify.py
@@ -169,7 +169,7 @@ def assess_vs_prior(probe_wr, prior_wr, target_band):
 def main():
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--scenario", choices=list(SCENARIO_MAP.keys()), required=True)
-    p.add_argument("--host", default="http://localhost:3334")
+    p.add_argument("--host", default="http://127.0.0.1:3334")  # IP not "localhost" (Windows IPv6 ~2s/call stall)
     p.add_argument("--out-dir", default="docs/playtest")
     p.add_argument("--probe-n", type=int, default=10, help="N=10 default")
     p.add_argument("--ratify-n", type=int, default=40, help="N=40 default")

--- a/tools/py/calibrate_map_elites.py
+++ b/tools/py/calibrate_map_elites.py
@@ -287,7 +287,7 @@ def main():
                    help="(real eval only) batch N per cell eval. Default 40 per "
                         "L-073 (N<40 = noise-placed cells). Compute heavy: "
                         "iterations × N × ~30s. Use --stub-eval for fast algo test.")
-    p.add_argument("--host", default="http://localhost:3340")
+    p.add_argument("--host", default="http://127.0.0.1:3340")  # IP not "localhost" (Windows IPv6 ~2s/call stall)
     args = p.parse_args()
 
     rng = random.Random(args.seed)

--- a/tools/py/calibrate_optuna.py
+++ b/tools/py/calibrate_optuna.py
@@ -73,11 +73,28 @@ SCENARIO_CFG = {
         "target_band": (0.15, 0.25),
         "target_center": 0.20,
         "batch_script": "batch_calibrate_hardcore06.py",
+        # OD-032 C: 2 continuous levers + pinned timer. enemy_damage = defeat<->timeout
+        # SPLIT lever (high dmg -> party wiped fast = defeat; low dmg -> survive to
+        # round 40 = timeout). boss_hp = difficulty/WR (upper widened: timer-off the
+        # party wins easily, needs harder). turn_limit PINNED 41 (>= MAX_ROUNDS 40 =
+        # disabled, validated probe v2): required for timeout>0 since any limit <=40
+        # force-defeats unresolved games before the loop yields a timeout. Searching
+        # turn_limit wastes ~76% of trials in the dead zone (only 41-45 unlock), so
+        # it's a fixed_override not a knob. NOTE: disables M7 decision-pressure for
+        # hc06 — part of the A+C decision to make the secondary band reachable.
         "knob_space": {
-            "boss_hp_multiplier": ("float", 0.50, 1.00),
-            "turn_limit_defeat_override": ("int", 25, 35),
+            "boss_hp_multiplier": ("float", 0.50, 1.30),
+            "enemy_damage_multiplier_override": ("float", 1.0, 2.5),
         },
+        "fixed_overrides": {"turn_limit_defeat_override": 41},
         "extra_batch_args": ["--encounter-class", "hardcore"],
+        # Multi-band objective (canonical hardcore bands, damage_curves.yaml:59-61).
+        # WR primary-weighted (hard constraint). See parse_objective_multiband.
+        "secondary_bands": {
+            "win_rate": (0.15, 0.25),
+            "defeat_rate": (0.40, 0.55),
+            "timeout_rate": (0.15, 0.25),
+        },
     },
     "hardcore_07": {
         "scenario_id": "enc_tutorial_07_hardcore_pod_rush",
@@ -238,8 +255,12 @@ def stop_backend(proc):
         pass
 
 
-def run_batch(scenario, host, n, label, log_dir):
-    """Run batch_calibrate_*.py + return parsed result."""
+def run_batch(scenario, host, n, label, log_dir, curves_path=None):
+    """Run batch_calibrate_*.py + return parsed result.
+
+    curves_path (OD-032 no-op-bug fix): pass DAMAGE_CURVES_PATH to the batch CLIENT
+    so its scenario-override parser reads the staging candidate (not production).
+    """
     cfg = SCENARIO_CFG[scenario]
     script = TOOLS_PY / cfg["batch_script"]
     out_path = log_dir / f"{label}.json"
@@ -253,8 +274,11 @@ def run_batch(scenario, host, n, label, log_dir):
         "--jsonl", str(jsonl_path),
         "--skip-health",
     ] + cfg["extra_batch_args"]
+    env = dict(os.environ)
+    if curves_path is not None:
+        env["DAMAGE_CURVES_PATH"] = str(curves_path)
     with open(log_path, "w", encoding="utf-8") as fh:
-        rc = subprocess.run(cmd, stdout=fh, stderr=subprocess.STDOUT, cwd=str(REPO_ROOT)).returncode
+        rc = subprocess.run(cmd, stdout=fh, stderr=subprocess.STDOUT, cwd=str(REPO_ROOT), env=env).returncode
     if rc != 0:
         return None
     try:
@@ -276,6 +300,66 @@ def parse_objective(result, target_center):
     if wr > 1.0:
         wr = wr / 100.0
     return abs(wr - target_center)
+
+
+def _norm_rate(v):
+    if v is None:
+        return None
+    v = float(v)
+    return v / 100.0 if v > 1.0 else v
+
+
+def _band_distance(val, lo, hi):
+    """Out-of-band distance (0 inside band, else distance to nearest edge)."""
+    if val < lo:
+        return lo - val
+    if val > hi:
+        return val - hi
+    return 0.0
+
+
+def parse_objective_multiband(agg, bands, primary_key="win_rate", primary_weight=2.0):
+    """Composite multi-band penalty. Optuna minimizes.
+
+    Sum of weighted out-of-band distances across WR + defeat + timeout. WR is
+    primary-weighted (hard constraint per L-069 — must stay in-band). A tiny
+    center-pull tie-break (0.01x) gives gradient toward band centers even when
+    all rates are already in-band. Returns inf if any required rate is missing.
+    """
+    if not agg:
+        return float("inf")
+    rates = {}
+    for key in bands:
+        v = _norm_rate(agg.get(key))
+        if v is None:
+            return float("inf")
+        rates[key] = v
+    penalty = 0.0
+    tiebreak = 0.0
+    for key, (lo, hi) in bands.items():
+        w = primary_weight if key == primary_key else 1.0
+        penalty += w * _band_distance(rates[key], lo, hi)
+        tiebreak += abs(rates[key] - (lo + hi) / 2.0)
+    return penalty + 0.01 * tiebreak
+
+
+def _store_rates(trial, agg, n):
+    """Persist observed rates as Optuna user_attrs so the report is self-contained."""
+    try:
+        trial.set_user_attr("win_rate", _norm_rate((agg or {}).get("win_rate")))
+        trial.set_user_attr("defeat_rate", _norm_rate((agg or {}).get("defeat_rate")))
+        trial.set_user_attr("timeout_rate", _norm_rate((agg or {}).get("timeout_rate")))
+        trial.set_user_attr("n", n)
+    except Exception:
+        pass
+
+
+def _fmt_rates(agg):
+    """Compact WR/defeat/timeout log string from an aggregate dict."""
+    def pct(key):
+        v = _norm_rate((agg or {}).get(key))
+        return "?" if v is None else f"{v * 100:.1f}%"
+    return f"WR={pct('win_rate')} def={pct('defeat_rate')} to={pct('timeout_rate')}"
 
 
 def make_objective_parallel(scenario, n_per_trial, shards, base_port, log_dir):
@@ -301,6 +385,7 @@ def make_objective_parallel(scenario, n_per_trial, shards, base_port, log_dir):
             else:
                 raise ValueError(f"Unknown knob kind: {kind}")
 
+        knob_values.update(cfg.get("fixed_overrides") or {})  # pinned non-search overrides
         trial_label = f"trial-{trial.number:03d}"
         print(f"\n[optuna-parallel] {trial_label} knobs: {knob_values}", flush=True)
 
@@ -335,7 +420,9 @@ def make_objective_parallel(scenario, n_per_trial, shards, base_port, log_dir):
                 jsonl_p = log_dir / f"{trial_label}-shard{i}.jsonl"
                 log_p = log_dir / f"{trial_label}-shard{i}.log"
                 jsonl_paths.append(jsonl_p)
-                proc, fh = cp.run_shard_batch(host, cp_cfg, n, out_p, jsonl_p, log_p)
+                # OD-032 no-op-bug fix: batch CLIENT also reads staging candidate.
+                proc, fh = cp.run_shard_batch(host, cp_cfg, n, out_p, jsonl_p, log_p,
+                                              curves_path=staging_path)
                 batch_procs.append((proc, fh))
             for proc, fh in batch_procs:
                 proc.wait()
@@ -345,11 +432,14 @@ def make_objective_parallel(scenario, n_per_trial, shards, base_port, log_dir):
                     pass
             runs = cp.merge_jsonl(jsonl_paths)
             agg = cp.aggregate_merged(runs, scenario)
-            distance = parse_objective({"aggregate": agg}, cfg["target_center"])
-            wr = float((agg or {}).get("win_rate", 0))
-            if wr > 1: wr /= 100
-            print(f"[optuna-parallel] {trial_label} WR={wr*100:.1f}% N={len(runs)} distance={distance:.3f}",
-                  flush=True)
+            bands = cfg.get("secondary_bands")
+            if bands:
+                distance = parse_objective_multiband(agg, bands)
+            else:
+                distance = parse_objective({"aggregate": agg}, cfg["target_center"])
+            _store_rates(trial, agg, len(runs))
+            print(f"[optuna-parallel] {trial_label} {_fmt_rates(agg)} "
+                  f"N={len(runs)} distance={distance:.3f}", flush=True)
             return distance
         finally:
             ports2 = [base_port + i for i in range(shards)]
@@ -376,6 +466,7 @@ def make_objective(scenario, host, n_per_trial, log_dir, backend_proc_ref):
             else:
                 raise ValueError(f"Unknown knob kind: {kind}")
 
+        knob_values.update(cfg.get("fixed_overrides") or {})  # pinned non-search overrides
         trial_label = f"trial-{trial.number:03d}"
         print(f"\n[optuna] {trial_label} knobs: {knob_values}", flush=True)
 
@@ -393,13 +484,20 @@ def make_objective(scenario, host, n_per_trial, log_dir, backend_proc_ref):
                 return float("inf")
             backend_proc_ref["proc"] = proc
 
-            result = run_batch(scenario, host_url, n_per_trial, trial_label, log_dir)
-            distance = parse_objective(result, cfg["target_center"])
+            # OD-032 no-op-bug fix: batch CLIENT also reads staging candidate.
+            result = run_batch(scenario, host_url, n_per_trial, trial_label, log_dir,
+                               curves_path=staging_path)
+            bands = cfg.get("secondary_bands")
             if result:
-                wr = float((result.get("aggregate") or {}).get("win_rate", 0))
-                if wr > 1: wr /= 100
-                print(f"[optuna] {trial_label} WR={wr*100:.1f}% distance={distance:.3f}", flush=True)
+                agg = result.get("aggregate") or result.get("summary") or {}
+                if bands:
+                    distance = parse_objective_multiband(agg, bands)
+                else:
+                    distance = parse_objective(result, cfg["target_center"])
+                _store_rates(trial, agg, agg.get("n") or n_per_trial)
+                print(f"[optuna] {trial_label} {_fmt_rates(agg)} distance={distance:.3f}", flush=True)
             else:
+                distance = float("inf")
                 print(f"[optuna] {trial_label} batch failed", file=sys.stderr, flush=True)
             return distance
         finally:
@@ -445,7 +543,11 @@ def main():
     log_dir = REPO_ROOT / args.out_dir / f"optuna-{args.scenario}-{label}"
     log_dir.mkdir(parents=True, exist_ok=True)
 
-    sampler = optuna.samplers.TPESampler(seed=args.seed)
+    # n_startup_trials default 10 = pure random until then. With small trial budgets
+    # (8-12) over 2-3 knobs that means no Bayesian guidance at all. Lower to 5 so TPE
+    # exploits the posterior for the back half of the run.
+    n_startup = min(5, max(2, args.n_trials // 2))
+    sampler = optuna.samplers.TPESampler(seed=args.seed, n_startup_trials=n_startup)
     study = optuna.create_study(direction="minimize", sampler=sampler,
                                  study_name=f"calibrate-{args.scenario}-{label}")
 
@@ -491,11 +593,14 @@ def main():
         "best_trial_number": best.number,
         "best_value_distance": best.value,
         "best_params": best.params,
+        "best_rates": dict(best.user_attrs),
+        "secondary_bands": {k: list(v) for k, v in (cfg.get("secondary_bands") or {}).items()},
         "all_trials": [
             {
                 "number": t.number,
                 "value": t.value,
                 "params": t.params,
+                "rates": dict(t.user_attrs),
                 "state": str(t.state),
             }
             for t in study.trials
@@ -512,7 +617,11 @@ def main():
     print(f"\n[optuna] DONE elapsed={elapsed/60:.1f}min", flush=True)
     print(f"[optuna] best trial #{best.number}: distance={best.value:.3f} params={best.params}",
           flush=True)
+    if best.user_attrs:
+        print(f"[optuna] best rates: {_fmt_rates(best.user_attrs)} "
+              f"(N={best.user_attrs.get('n')})", flush=True)
     print(f"[optuna] report: {report_path}", flush=True)
+    print(f"[optuna] NEXT: N=40 ratify best_params before ship (L-069).", flush=True)
     return 0
 
 

--- a/tools/py/calibrate_optuna.py
+++ b/tools/py/calibrate_optuna.py
@@ -73,27 +73,28 @@ SCENARIO_CFG = {
         "target_band": (0.15, 0.25),
         "target_center": 0.20,
         "batch_script": "batch_calibrate_hardcore06.py",
-        # OD-032 C: 2 continuous levers + pinned timer. enemy_damage = defeat<->timeout
-        # SPLIT lever (high dmg -> party wiped fast = defeat; low dmg -> survive to
-        # round 40 = timeout). boss_hp = difficulty/WR (upper widened: timer-off the
-        # party wins easily, needs harder). turn_limit PINNED 41 (>= MAX_ROUNDS 40 =
-        # disabled, validated probe v2): required for timeout>0 since any limit <=40
-        # force-defeats unresolved games before the loop yields a timeout. Searching
-        # turn_limit wastes ~76% of trials in the dead zone (only 41-45 unlock), so
-        # it's a fixed_override not a knob. NOTE: disables M7 decision-pressure for
-        # hc06 — part of the A+C decision to make the secondary band reachable.
+        # OD-032 A+C: boss_hp = difficulty/WR lever; enemy_damage = lethality lever
+        # (high dmg -> faster wipes). turn_limit PINNED 41 (>= MAX_ROUNDS 40 =
+        # disabled) — carried from the OD-032 C ALT probe that tried to open a
+        # timeout-middle band. That band proved UNREACHABLE: hc06 combat resolves
+        # win/wipe within 40 rounds, so timeout ~0 even timer-off (see the hardcore
+        # comment in damage_curves.yaml + OD-032 A). Objective therefore targets the
+        # CANONICAL defeat-heavy band below, not the old middle band. Searching
+        # turn_limit wastes ~76% of trials in a dead zone, so it stays a
+        # fixed_override not a knob.
         "knob_space": {
             "boss_hp_multiplier": ("float", 0.50, 1.30),
             "enemy_damage_multiplier_override": ("float", 1.0, 2.5),
         },
         "fixed_overrides": {"turn_limit_defeat_override": 41},
         "extra_batch_args": ["--encounter-class", "hardcore"],
-        # Multi-band objective (canonical hardcore bands, damage_curves.yaml:59-61).
-        # WR primary-weighted (hard constraint). See parse_objective_multiband.
+        # Multi-band objective = CANONICAL hardcore target_bands (damage_curves.yaml
+        # hardcore: win 15-25%, defeat 75-85%, timeout 0-5%, revised OD-032
+        # 2026-05-21). WR primary-weighted (hard constraint). See parse_objective_multiband.
         "secondary_bands": {
             "win_rate": (0.15, 0.25),
-            "defeat_rate": (0.40, 0.55),
-            "timeout_rate": (0.15, 0.25),
+            "defeat_rate": (0.75, 0.85),
+            "timeout_rate": (0.00, 0.05),
         },
     },
     "hardcore_07": {
@@ -232,11 +233,11 @@ def start_backend(port=3340, curves_path=None):
         env=env,
         cwd=str(REPO_ROOT),
     )
-    wait = wait_healthy(f"http://localhost:{port}", max_wait=90)
+    wait = wait_healthy(f"http://127.0.0.1:{port}", max_wait=90)
     if wait is None:
         proc.kill()
         return None, None
-    return proc, f"http://localhost:{port}"
+    return proc, f"http://127.0.0.1:{port}"
 
 
 def stop_backend(proc):
@@ -391,7 +392,8 @@ def make_objective_parallel(scenario, n_per_trial, shards, base_port, log_dir):
 
         staging_path = write_scenario_override(cfg["scenario_id"], knob_values)
         ports = [base_port + i for i in range(shards)]
-        hosts = [f"http://localhost:{p}" for p in ports]
+        # 127.0.0.1 not "localhost": Windows IPv6 ::1 stall ~2s/call (see calibrate_parallel.py).
+        hosts = [f"http://127.0.0.1:{p}" for p in ports]
         shard_procs, shard_fhs = [], []
         try:
             # Pre-check ports free.
@@ -515,7 +517,7 @@ def main():
                         "N<40 = optimizer converges to NOISE (smoke 2026-05-21: "
                         "N=20 trial WR 15% -> N=40 ratify WR 30%). Use parallel C "
                         "internal to make N=40/trial affordable (~3min/trial).")
-    p.add_argument("--host", default="http://localhost:3340",
+    p.add_argument("--host", default="http://127.0.0.1:3340",
                    help="Backend URL (auto-managed if backend not running)")
     p.add_argument("--parallel", action="store_true",
                    help="Parallel-internal: each trial uses N shards (4x speedup). "
@@ -582,6 +584,11 @@ def main():
     elapsed = time.time() - t0
     best = study.best_trial
 
+    # best.params holds only the SAMPLED knobs; Optuna omits pinned fixed_overrides.
+    # ratify_params is the full effective config a ratify run must reproduce (P2).
+    fixed_overrides_eff = cfg.get("fixed_overrides") or {}
+    ratify_params = {**best.params, **fixed_overrides_eff}
+
     report = {
         "scenario": args.scenario,
         "scenario_id": cfg["scenario_id"],
@@ -593,6 +600,8 @@ def main():
         "best_trial_number": best.number,
         "best_value_distance": best.value,
         "best_params": best.params,
+        "fixed_overrides": fixed_overrides_eff,
+        "ratify_params": ratify_params,
         "best_rates": dict(best.user_attrs),
         "secondary_bands": {k: list(v) for k, v in (cfg.get("secondary_bands") or {}).items()},
         "all_trials": [
@@ -621,7 +630,13 @@ def main():
         print(f"[optuna] best rates: {_fmt_rates(best.user_attrs)} "
               f"(N={best.user_attrs.get('n')})", flush=True)
     print(f"[optuna] report: {report_path}", flush=True)
-    print(f"[optuna] NEXT: N=40 ratify best_params before ship (L-069).", flush=True)
+    if fixed_overrides_eff:
+        print(f"[optuna] NEXT: N=40 ratify FULL params {ratify_params} before ship "
+              f"(L-069). best_params omits pinned {fixed_overrides_eff} — include them.",
+              flush=True)
+    else:
+        print(f"[optuna] NEXT: N=40 ratify best_params {best.params} before ship (L-069).",
+              flush=True)
     return 0
 
 

--- a/tools/py/calibrate_parallel.py
+++ b/tools/py/calibrate_parallel.py
@@ -234,7 +234,14 @@ def main():
     else:
         owned_shards = True
         ports = [args.base_port + i for i in range(args.shards)]
-        hosts = [f"http://localhost:{port}" for port in ports]
+        # Use 127.0.0.1, not "localhost". Backend binds IPv4 (0.0.0.0); on Windows
+        # "localhost" resolves ::1 (IPv6) first and Python urllib (no Happy-Eyeballs)
+        # stalls ~2s per request before falling back to IPv4 — ~28 calls/run x 2s
+        # = ~56s/run vs ~0.7s/run, which looks like a per-shard "hang" after a few
+        # sessions. Empirically verified 2026-05-21: localhost 2.04s/call vs
+        # 127.0.0.1 0.001s/call (N=10 batch: ~560s -> 7s). See SCENARIO_MAP/--hosts
+        # for remote overrides.
+        hosts = [f"http://127.0.0.1:{port}" for port in ports]
 
         # Sanity: ensure ports not already taken.
         for h in hosts:

--- a/tools/py/calibrate_parallel.py
+++ b/tools/py/calibrate_parallel.py
@@ -133,8 +133,14 @@ def stop_shard(proc, fh, port):
             pass
 
 
-def run_shard_batch(host, scenario_cfg, n, out_path, jsonl_path, log_path):
-    """Subprocess wrapper -- launch batch_calibrate_*.py against one shard."""
+def run_shard_batch(host, scenario_cfg, n, out_path, jsonl_path, log_path, curves_path=None):
+    """Subprocess wrapper -- launch batch_calibrate_*.py against one shard.
+
+    curves_path (OD-032 no-op-bug fix): if set, the batch CLIENT subprocess gets
+    DAMAGE_CURVES_PATH=curves_path so its scenario-override parser reads the SAME
+    staging file the backend shard reads. Without this the client silently used
+    production overrides (turn_limit/enemy_damage knobs = no-op during calibration).
+    """
     script_path = TOOLS_PY / scenario_cfg["script"]
     cmd = [
         sys.executable, "-u", str(script_path),
@@ -146,7 +152,10 @@ def run_shard_batch(host, scenario_cfg, n, out_path, jsonl_path, log_path):
     ] + scenario_cfg["extra_args"]
     print(f"[parallel] launch shard host={host} N={n}", flush=True)
     f = open(log_path, "w", encoding="utf-8")
-    proc = subprocess.Popen(cmd, stdout=f, stderr=subprocess.STDOUT, cwd=str(REPO_ROOT))
+    env = dict(os.environ)
+    if curves_path is not None:
+        env["DAMAGE_CURVES_PATH"] = str(curves_path)
+    proc = subprocess.Popen(cmd, stdout=f, stderr=subprocess.STDOUT, cwd=str(REPO_ROOT), env=env)
     return proc, f
 
 

--- a/tools/py/calibrate_sprt.py
+++ b/tools/py/calibrate_sprt.py
@@ -128,7 +128,7 @@ def health_check(host, timeout=2):
 def main():
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--scenario", choices=list(SCENARIO_MAP.keys()), required=True)
-    p.add_argument("--host", default="http://localhost:3334")
+    p.add_argument("--host", default="http://127.0.0.1:3334")  # IP not "localhost" (Windows IPv6 ~2s/call stall)
     p.add_argument("--max-n", type=int, default=80, help="Hard ceiling N")
     p.add_argument("--min-n", type=int, default=10,
                    help="Minimum N before considering early-stop (default 10)")


### PR DESCRIPTION
## Summary

Resolves **OPEN_DECISIONS OD-032** (master-dd verdict **A+C**). The hardcore_06 secondary band (`defeat 40-55%`, `timeout 15-25%`) was found **structurally unreachable**; this revises the canonical band to engine reality and wires the enemy_damage split-knob for hc06.

### A — band revised (`data/core/balance/damage_curves.yaml`, hardcore class)
- `defeat_rate [0.40,0.55] -> [0.75,0.85]`
- `timeout_rate [0.15,0.25] -> [0.00,0.05]`
- `win_rate [0.15,0.25]` **kept** (primary pillar, in-band)

The original band was a *design-target* incompatible with its own `turn_limit_defeat=25`: M7 added that timer to "elimina stalemate pattern (iter7 timeout 67%)", converting every unresolved game to defeat at turn 25 -> **timeout ~0 always**.

**Evidence** (production config boss_hp 0.65, timer 25):
| run | N | WR | defeat | timeout |
|---|---|---|---|---|
| ratify 8x5 | 40 | 25.0% | 75.0% | 0.0% |
| partial | 32 | 18.8% | 81.2% | 0.0% |
| **pooled** | **72** | **~21%** | **~78%** | **0%** |

Optuna 3-knob run (boss_hp + enemy_damage + turn_limit) confirmed no reachable timeout band — hc06 combat resolves win/wipe within 40 rounds; no stalemate corner in the sampled trials.

### C — enemy_damage knob wired for hc06
- batch `/start` sends `encounter.id` -> backend `applyEnemyDamageMultiplier` resolves the scenario override (session.js:1490, generic path, no backend change)
- `calibrate_optuna.py` hc06 knob_space + multi-band objective (WR primary-weighted + defeat + timeout)
- Capability only; **no production knob change** (boss_hp 0.65 + M7 timer preserved). Enables the OD-032 ALT timer-off path if master-dd pursues the timeout-middle band.

### Bug fixed (silent no-op)
The batch **client** ignored `DAMAGE_CURVES_PATH` env (hardcoded prod) — staging `scenario_overrides` (turn_limit/enemy_damage knobs) never reached the client during Optuna/parallel calibration (only boss_hp varied via the backend). Now env-aware + passed to the batch subprocess in `calibrate_optuna.py` and `calibrate_parallel.py`.

### Out of scope / follow-up
- **ALT (master-dd authority)**: restore timeout-middle band = revert M7 (raise/disable turn_limit) + tune stalemate corner. Fragile (iter7 = 67% timeout uncontrolled). Knob is ready if pursued.
- **Side-finding**: backend hangs after ~7 sessions/process during batch (3 runs stalled at 7/shard). Workaround used: 8 shards x 5. Separate investigation recommended.

## Test plan
- [x] `node --test tests/scripts/damageCurvesIntegrity.test.js` -> 10/10 pass (band shape + monotonic multiplier)
- [x] `python -m py_compile` on all 3 calibration tools
- [x] No forbidden paths touched (data/core/balance allowed)
- [ ] CI green