### PR TITLE
feat(combat): biome pressure rating chip in debrief (TKT-ECO-A5)

### DIFF
--- a/apps/backend/services/rewardEconomy.js
+++ b/apps/backend/services/rewardEconomy.js
@@ -98,6 +98,48 @@ function convertPE(peBalance) {
  * @param {object} pfSession — output di computePfSession() per actor (opzionale)
  * @returns {object} debrief payload
  */
+// TKT-ECO-A5 (Gate-5 surface) — biome pressure rating chip for the debrief.
+// The biome diff_base + hazard.stress_modifiers engine is LIVE (biomeModifiers.js
+// scales enemy HP on /start, adds pressure_initial_bonus, ticks pressure_mult per
+// round in sessionRoundBridge). But the player never SAW it — biome_modifiers lived
+// only in /state telemetry, not the debrief. This derives a human-readable chip so
+// "Cryosteppe vs Foresta" reads as a tangible difficulty difference post-combat.
+// Returns null when the session has no biome modifiers (graceful, e.g. no biome_id).
+function buildBiomePressureRating(session) {
+  const bm =
+    session && typeof session.biome_modifiers === 'object' ? session.biome_modifiers : null;
+  if (!bm) return null;
+  const diffBase = Number(bm.diff_base) || 1.0;
+  const hpMult = Number(bm.hp_mult) || 1.0;
+  const pressureInit = Number(bm.pressure_initial_bonus) || 0;
+  const pressurePerRound = Number(bm.pressure_mult) || 0;
+  let rating;
+  let labelIt;
+  if (diffBase >= 5) {
+    rating = 'EXTREME';
+    labelIt = 'Bioma estremo';
+  } else if (diffBase >= 4) {
+    rating = 'HOSTILE';
+    labelIt = 'Bioma ostile';
+  } else if (diffBase >= 3) {
+    rating = 'MODERATE';
+    labelIt = 'Bioma impegnativo';
+  } else {
+    rating = 'NEUTRAL';
+    labelIt = 'Bioma neutro';
+  }
+  return {
+    rating,
+    label_it: labelIt,
+    biome_id:
+      bm.biome_id || session.biome_id || (session.encounter && session.encounter.biome_id) || null,
+    diff_base: diffBase,
+    enemy_hp_bonus_pct: Math.round((hpMult - 1) * 100),
+    pressure_initial_bonus: pressureInit,
+    pressure_per_round: pressurePerRound,
+  };
+}
+
 function buildDebriefSummary(session, vcSnapshot, peResult, pfSession = {}) {
   // 2026-04-26 (Q19 resolved Opzione A): PE→PI conversion gated su outcome=victory
   // (StS gold analogy). Defeat/timeout = PE earned ma non convertito; resta in pool campaign-wide.
@@ -249,6 +291,9 @@ function buildDebriefSummary(session, vcSnapshot, peResult, pfSession = {}) {
       total_events: (session.events || []).length,
       kills: Object.values(session.damage_taken || {}).filter((v) => v <= 0).length,
     },
+    // TKT-ECO-A5 — biome pressure rating chip (Gate-5 surface for the live
+    // diff_base + hazard engine). null when session has no biome modifiers.
+    biome_pressure_rating: buildBiomePressureRating(session),
   };
 }
 
@@ -259,4 +304,5 @@ module.exports = {
   computeSessionPE,
   convertPE,
   buildDebriefSummary,
+  buildBiomePressureRating,
 };

--- a/apps/backend/services/rewardEconomy.js
+++ b/apps/backend/services/rewardEconomy.js
@@ -113,6 +113,15 @@ function buildBiomePressureRating(session) {
   const hpMult = Number(bm.hp_mult) || 1.0;
   const pressureInit = Number(bm.pressure_initial_bonus) || 0;
   const pressurePerRound = Number(bm.pressure_mult) || 0;
+  const biomeId =
+    bm.biome_id || session.biome_id || (session.encounter && session.encounter.biome_id) || null;
+  // Codex P2: /api/session/start persists biome_modifiers even with no biome
+  // (getBiomeModifiers -> SAFE_DEFAULTS). Suppress the chip when there's no real
+  // biome AND modifiers are all defaults, so consumers distinguish "no biome
+  // configured" (null) from a true neutral biome (NEUTRAL chip with biome_id).
+  const isDefault =
+    diffBase <= 1.0 && hpMult === 1.0 && pressureInit === 0 && pressurePerRound === 0;
+  if (!biomeId && isDefault) return null;
   let rating;
   let labelIt;
   if (diffBase >= 5) {
@@ -131,8 +140,7 @@ function buildBiomePressureRating(session) {
   return {
     rating,
     label_it: labelIt,
-    biome_id:
-      bm.biome_id || session.biome_id || (session.encounter && session.encounter.biome_id) || null,
+    biome_id: biomeId,
     diff_base: diffBase,
     enemy_hp_bonus_pct: Math.round((hpMult - 1) * 100),
     pressure_initial_bonus: pressureInit,

--- a/tests/services/rewardEconomy.test.js
+++ b/tests/services/rewardEconomy.test.js
@@ -14,6 +14,7 @@ const {
   computeSessionPE,
   convertPE,
   buildDebriefSummary,
+  buildBiomePressureRating,
 } = require('../../apps/backend/services/rewardEconomy');
 
 // ─────────────────────────────────────────────────────────────────
@@ -189,4 +190,57 @@ test('exports surface canonical constants', () => {
   assert.equal(PE_BASE_BY_DIFFICULTY.standard, 5);
   assert.equal(PE_BASE_BY_DIFFICULTY.elite, 8);
   assert.equal(PE_BASE_BY_DIFFICULTY.boss, 12);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// TKT-ECO-A5 — biome pressure rating chip (Gate-5 surface)
+// ─────────────────────────────────────────────────────────────────
+
+test('buildBiomePressureRating: null when no biome_modifiers', () => {
+  assert.equal(buildBiomePressureRating({ session_id: 's' }), null);
+  assert.equal(buildBiomePressureRating({ biome_modifiers: 'nope' }), null);
+});
+
+test('buildBiomePressureRating: neutral biome (diff_base<=2)', () => {
+  const r = buildBiomePressureRating({
+    biome_modifiers: { diff_base: 2, hp_mult: 1.0, pressure_initial_bonus: 0, pressure_mult: 0 },
+  });
+  assert.equal(r.rating, 'NEUTRAL');
+  assert.equal(r.enemy_hp_bonus_pct, 0);
+  assert.equal(r.pressure_initial_bonus, 0);
+});
+
+test('buildBiomePressureRating: hostile/extreme scale + derived bonuses', () => {
+  const hostile = buildBiomePressureRating({
+    biome_id: 'abisso_vulcanico',
+    biome_modifiers: { diff_base: 4, hp_mult: 1.1, pressure_initial_bonus: 10, pressure_mult: 2 },
+  });
+  assert.equal(hostile.rating, 'HOSTILE');
+  assert.equal(hostile.enemy_hp_bonus_pct, 10); // (1.1-1)*100
+  assert.equal(hostile.pressure_per_round, 2);
+  assert.equal(hostile.biome_id, 'abisso_vulcanico');
+
+  const extreme = buildBiomePressureRating({
+    biome_modifiers: { diff_base: 5, hp_mult: 1.15, pressure_initial_bonus: 15, pressure_mult: 3 },
+  });
+  assert.equal(extreme.rating, 'EXTREME');
+  assert.equal(extreme.enemy_hp_bonus_pct, 15);
+});
+
+test('buildDebriefSummary includes biome_pressure_rating chip', () => {
+  const session = {
+    session_id: 'sess_biome',
+    biome_modifiers: { diff_base: 3, hp_mult: 1.05, pressure_initial_bonus: 5, pressure_mult: 1 },
+  };
+  const snap = makeVcSnapshot({}, 3);
+  const debrief = buildDebriefSummary(session, snap, computeSessionPE(snap, {}));
+  assert.ok(debrief.biome_pressure_rating);
+  assert.equal(debrief.biome_pressure_rating.rating, 'MODERATE');
+  assert.equal(debrief.biome_pressure_rating.enemy_hp_bonus_pct, 5);
+});
+
+test('buildDebriefSummary biome_pressure_rating null without modifiers', () => {
+  const snap = makeVcSnapshot({}, 0);
+  const debrief = buildDebriefSummary({ session_id: 's' }, snap, computeSessionPE(snap, {}));
+  assert.equal(debrief.biome_pressure_rating, null);
 });

--- a/tests/services/rewardEconomy.test.js
+++ b/tests/services/rewardEconomy.test.js
@@ -201,6 +201,28 @@ test('buildBiomePressureRating: null when no biome_modifiers', () => {
   assert.equal(buildBiomePressureRating({ biome_modifiers: 'nope' }), null);
 });
 
+test('buildBiomePressureRating: null on SAFE_DEFAULTS with no biome (Codex P2)', () => {
+  // /api/session/start persists biome_modifiers=SAFE_DEFAULTS even with no biome.
+  assert.equal(
+    buildBiomePressureRating({
+      biome_modifiers: {
+        diff_base: 1.0,
+        hp_mult: 1.0,
+        pressure_initial_bonus: 0,
+        pressure_mult: 0,
+      },
+    }),
+    null,
+  );
+  // But a real biome_id keeps the chip even at defaults.
+  const withId = buildBiomePressureRating({
+    biome_id: 'foresta',
+    biome_modifiers: { diff_base: 1.0, hp_mult: 1.0, pressure_initial_bonus: 0, pressure_mult: 0 },
+  });
+  assert.equal(withId.rating, 'NEUTRAL');
+  assert.equal(withId.biome_id, 'foresta');
+});
+
 test('buildBiomePressureRating: neutral biome (diff_base<=2)', () => {
   const r = buildBiomePressureRating({
     biome_modifiers: { diff_base: 2, hp_mult: 1.0, pressure_initial_bonus: 0, pressure_mult: 0 },


### PR DESCRIPTION
## Summary

Closes **TKT-ECO-A5** (bioma diff_base + hazard pressure modifier). Investigation found the **engine is already LIVE** (PR #1864 / M-018): `biomeModifiers.js` scales enemy HP on `/start`, adds `pressure_initial_bonus`, and ticks `pressure_mult` per round (`sessionRoundBridge`). The only residual was **action 3 — the Gate-5 debrief surface**: `biome_modifiers` lived only in `/state` telemetry, so the player never saw the biome difficulty at debrief.

- `buildBiomePressureRating(session)` derives a human chip from `session.biome_modifiers`: `rating` (NEUTRAL/MODERATE/HOSTILE/EXTREME by `diff_base`), `enemy_hp_bonus_pct`, `pressure_initial_bonus`, `pressure_per_round`, `biome_id`, `label_it`.
- `buildDebriefSummary` now emits `biome_pressure_rating`. Null when no biome modifiers (graceful).
- Pure read-only derived field — **no combat behavior change** (engine untouched), so the A5 sweep is N/A here.
- 6 unit tests (helper + debrief integration).

So "Cryosteppe vs Foresta" now reads as a tangible post-combat difficulty chip (the engine difference was already applied; this surfaces it).

### Related (this session)
- **hc07 secondary band**: analyzed — healthy as-is (mission-timer scenario, timeout-by-design, WR in-band). Verdict C, no change. Recorded in memory.

## Test plan
- [x] `node --test tests/services/rewardEconomy.test.js` -> 17/17
- [x] `node --test tests/api/debriefPanelRecruit.test.js` (consumer) -> 10/10
- [x] prettier clean
- [x] apps/backend scope only, no forbidden paths
- [ ] CI green