### PR TITLE
docs(backlog): close stale TKT-ECO A4-residue/A5/A6 (all shipped)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -25,19 +25,19 @@ User trigger 2026-05-13: "analizza col metodo tutta l'infrastruttura Ecosistema 
 
 **Ticket TKT-ECO-XX status post-cascade** (Phase A residue ai-station codemasterdd protocol):
 
-| Ticket                                     | Effort |   Status   | Channel                                                 |
-| ------------------------------------------ | :----: | :--------: | ------------------------------------------------------- |
-| A1 smoke mutations UI                      |  0.5h  |  ✅ DONE   | audit verify (PARTIAL-WIRED finding)                    |
-| A2 verify-only smoke promote               |  0.5h  | ✅ SHIPPED | Game/ #2261                                             |
-| A3 museum card M-007 post-script           |  0.5h  |  ✅ DONE   | additive update mating_nido card                        |
-| A4 sentience tier backfill 15/15 lifecycle |  5-6h  | ✅ SHIPPED | Game/ #2262                                             |
-| A4-residue 30 species heuristic            |  3-4h  | ⏳ PENDING | gated master-dd verdict                                 |
-| A5 bioma diff_base + hazard pressure       |   3h   | ⏳ PENDING | gated master-dd verdict (sessionHelpers backend)        |
-| A6 starter_bioma trait                     |   3h   | 🟡 PARTIAL | backend chain ✅, frontend label gap (~30 LOC)          |
-| A7 mating.yaml pack drift                  |   2h   |  ✅ DONE   | gene_slots core → pack sync this session                |
-| A8 promotions engine Phase B3              |  3-4h  | ✅ SHIPPED | Game/ #2264                                             |
-| B1-B6 various Envelope B                   |  ~17h  | ✅ SHIPPED | Game/ #2262 + #2263 + #2267 + #2268                     |
-| C1-C7 various Envelope C                   |  ~99h  | 🟡 PARTIAL | Atlas scaffold ✅ Godot v2 #260, runtime gated playtest |
+| Ticket                                     | Effort |   Status   | Channel                                                                         |
+| ------------------------------------------ | :----: | :--------: | ------------------------------------------------------------------------------- |
+| A1 smoke mutations UI                      |  0.5h  |  ✅ DONE   | audit verify (PARTIAL-WIRED finding)                                            |
+| A2 verify-only smoke promote               |  0.5h  | ✅ SHIPPED | Game/ #2261                                                                     |
+| A3 museum card M-007 post-script           |  0.5h  |  ✅ DONE   | additive update mating_nido card                                                |
+| A4 sentience tier backfill 15/15 lifecycle |  5-6h  | ✅ SHIPPED | Game/ #2262                                                                     |
+| A4-residue 30 species heuristic            |  3-4h  | ✅ SHIPPED | Game/ #2271 (legacy_yaml_residue → sentience_tier mirror; catalog 53/53 tiered) |
+| A5 bioma diff_base + hazard pressure       |   3h   | ✅ SHIPPED | engine #1864 (HP+pressure live) + chip #2366 (debrief Gate-5 surface)           |
+| A6 starter_bioma trait                     |   3h   | ✅ SHIPPED | backend recommender + #2334 frontend label (characterCreation biome_label_it)   |
+| A7 mating.yaml pack drift                  |   2h   |  ✅ DONE   | gene_slots core → pack sync this session                                        |
+| A8 promotions engine Phase B3              |  3-4h  | ✅ SHIPPED | Game/ #2264                                                                     |
+| B1-B6 various Envelope B                   |  ~17h  | ✅ SHIPPED | Game/ #2262 + #2263 + #2267 + #2268                                             |
+| C1-C7 various Envelope C                   |  ~99h  | 🟡 PARTIAL | Atlas scaffold ✅ Godot v2 #260, runtime gated playtest                         |
 
 **Pillar deltas v40 → v41**:
 


### PR DESCRIPTION
## Summary

Verified A4-residue, A5, A6 were **already shipped** — BACKLOG statuses were stale (recurring rot: engine live, BACKLOG not updated). Marked all three ✅ SHIPPED with PR refs.

| Ticket | Was | Now | Evidence |
|---|---|---|---|
| A4-residue (30 species sentience) | ⏳ PENDING | ✅ SHIPPED | #2271 — `legacy_yaml_residue → sentience_tier mirror`; catalog 53/53 tiered (stats by_sentience_tier sums to 53) |
| A5 (bioma diff_base + hazard) | ⏳ PENDING | ✅ SHIPPED | engine #1864 (enemy HP + pressure_initial + pressure_per_round live) + chip #2366 (debrief Gate-5 surface) |
| A6 (starter_bioma) | 🟡 PARTIAL | ✅ SHIPPED | recommender resolveStarterBioma + #2334 frontend label (characterCreation.js biome_label_it/trait_label_it) |

No code change — doc hygiene only.

## Test plan
- [x] N/A (BACKLOG.md only); prettier clean