### PR TITLE
feat(coop): CAMP-2 accumulation bridge — /coop/combat/end folds SistemaState (M1 live)

### DIFF
--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -301,13 +301,20 @@ function createCoopRouter({ lobby, coopStore } = {}) {
       xp_earned: xpEarned = 0,
       survivors = [],
       debrief_payload: debriefPayload = null,
+      sistema_observations: sistemaObservations = null,
     } = req.body || {};
     const room = authHost(code, hostToken);
     if (!room) return res.status(403).json({ error: 'host_auth_failed' });
     const orch = coopStore.get(code);
     if (!orch) return res.status(409).json({ error: 'run_not_started' });
     try {
-      const result = orch.endCombat({ outcome, xpEarned, survivors, debriefPayload });
+      const result = orch.endCombat({
+        outcome,
+        xpEarned,
+        survivors,
+        debriefPayload,
+        sistemaObservations,
+      });
       broadcastCoopState(room, orch);
       return res.json({ phase: orch.phase, result });
     } catch (err) {

--- a/apps/backend/services/ai/sistemaStateAccumulator.js
+++ b/apps/backend/services/ai/sistemaStateAccumulator.js
@@ -64,4 +64,37 @@ function accumulate(priorUnitsObserved, session) {
   return out;
 }
 
-module.exports = { accumulate, HIGH_THREAT_KILLS };
+// CAMP-2 — slim-delta fold: accumulate a per-encounter observation
+// { roster:[pg_id], kills:{pg_id:int} } into prior units_observed.
+// Server owns the threat threshold (HIGH_THREAT_KILLS). Pure, no I/O.
+function foldObservations(priorUnitsObserved, observations) {
+  const out = {};
+  const prior =
+    priorUnitsObserved && typeof priorUnitsObserved === 'object' ? priorUnitsObserved : {};
+  for (const id of Object.keys(prior)) {
+    const r = prior[id] || {};
+    out[id] = {
+      kills_vs_sistema: Number(r.kills_vs_sistema) || 0,
+      sightings: Number(r.sightings) || 0,
+      threat_level: r.threat_level === 'high' ? 'high' : 'normal',
+    };
+  }
+  const obs = observations && typeof observations === 'object' ? observations : {};
+  const roster = Array.isArray(obs.roster) ? obs.roster : [];
+  const kills = obs.kills && typeof obs.kills === 'object' ? obs.kills : {};
+  const ensure = (id) =>
+    (out[id] = out[id] || { kills_vs_sistema: 0, sightings: 0, threat_level: 'normal' });
+  for (const id of roster) {
+    if (id == null) continue;
+    ensure(String(id)).sightings += 1;
+  }
+  for (const id of Object.keys(kills)) {
+    ensure(String(id)).kills_vs_sistema += Number(kills[id]) || 0;
+  }
+  for (const id of Object.keys(out)) {
+    out[id].threat_level = out[id].kills_vs_sistema >= HIGH_THREAT_KILLS ? 'high' : 'normal';
+  }
+  return out;
+}
+
+module.exports = { accumulate, foldObservations, HIGH_THREAT_KILLS };

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -4,6 +4,9 @@
 
 'use strict';
 
+const { foldObservations } = require('../ai/sistemaStateAccumulator');
+const { createSistemaStateStore } = require('../ai/sistemaStateStore');
+
 // 2026-05-06 narrative onboarding port — `onboarding` phase added per
 // canonical `docs/core/51-ONBOARDING-60S.md` Phase B. Sequence:
 // lobby → onboarding → character_creation → world_setup → combat → debrief.
@@ -51,11 +54,22 @@ function characterToUnit(character, { index = 0 } = {}) {
 }
 
 class CoopOrchestrator {
-  constructor({ roomCode, hostId, now = Date.now, worldEnricher = null } = {}) {
+  constructor({
+    roomCode,
+    hostId,
+    now = Date.now,
+    worldEnricher = null,
+    sistemaStateStore = null,
+  } = {}) {
     if (!roomCode) throw new Error('room_code_required');
     this.roomCode = roomCode;
     this.hostId = hostId || null;
     this.now = now;
+    // CAMP-2 — SistemaState accumulation store (DI seam, same style as
+    // worldEnricher). Default lazily wires the canonical Prisma-backed store
+    // on first use so module-load order / stub-mode (no DATABASE_URL) stays
+    // safe. Tests inject a stub recording get/upsert.
+    this._sistemaStore = sistemaStateStore;
     this.phase = 'lobby';
     this.run = null; // populated by startRun()
     this.characters = new Map(); // player_id → character spec
@@ -88,6 +102,13 @@ class CoopOrchestrator {
     // eslint-disable-next-line global-require
     this._worldEnricher = require('./worldEnricher');
     return this._worldEnricher;
+  }
+
+  _getSistemaStore() {
+    if (this._sistemaStore) return this._sistemaStore;
+    // eslint-disable-next-line global-require
+    this._sistemaStore = createSistemaStateStore(require('../../db/prisma').prisma);
+    return this._sistemaStore;
   }
 
   _emit(kind, payload = {}) {
@@ -641,7 +662,13 @@ class CoopOrchestrator {
    *     ennea_archetype: "<canonical name>"
    *   }
    */
-  endCombat({ outcome = 'victory', survivors = [], xpEarned = 0, debriefPayload = null } = {}) {
+  endCombat({
+    outcome = 'victory',
+    survivors = [],
+    xpEarned = 0,
+    debriefPayload = null,
+    sistemaObservations = null,
+  } = {}) {
     if (this.phase !== 'combat') throw new Error('not_in_combat');
     this.run.outcome = outcome;
     this.run.partyXp += xpEarned;
@@ -654,6 +681,23 @@ class CoopOrchestrator {
     }
     this._emit('combat_ended', emitPayload);
     this._setPhase('debrief');
+    // CAMP-2 best-effort SistemaState accumulation. Folds the per-encounter
+    // slim-delta { roster, kills } into units_observed keyed by run.id. Runs
+    // detached (Promise.resolve().then) + .catch so a store failure NEVER
+    // blocks or throws into the combat-end path. No observations → no-op.
+    if (sistemaObservations && this.run && this.run.id) {
+      const store = this._getSistemaStore();
+      const runId = this.run.id;
+      Promise.resolve()
+        .then(async () => {
+          const prior = await store.get(runId);
+          const next = foldObservations((prior && prior.units_observed) || {}, sistemaObservations);
+          await store.upsert(runId, next);
+        })
+        .catch((err) =>
+          console.warn('[coop] sistema accumulate failed (best-effort):', err.message),
+        );
+    }
     return { outcome, xp: xpEarned };
   }
 

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -684,7 +684,7 @@ class CoopOrchestrator {
     // CAMP-2 best-effort SistemaState accumulation. Folds the per-encounter
     // slim-delta { roster, kills } into units_observed keyed by run.id. Runs
     // detached (Promise.resolve().then) + .catch so a store failure NEVER
-    // blocks or throws into the combat-end path. No observations → no-op.
+    // blocks or throws into the combat-end path. No observations -> no-op.
     if (sistemaObservations && this.run && this.run.id) {
       const store = this._getSistemaStore();
       const runId = this.run.id;

--- a/tests/ai/sistemaStateFoldObservations.test.js
+++ b/tests/ai/sistemaStateFoldObservations.test.js
@@ -1,0 +1,29 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { foldObservations } = require('../../apps/backend/services/ai/sistemaStateAccumulator');
+
+test('sightings +1 per roster PG, kills accumulate, threat flips at 3', () => {
+  let uo = foldObservations({}, { roster: ['skiv_7', 'skiv_3'], kills: { skiv_7: 2 } });
+  assert.equal(uo.skiv_7.sightings, 1);
+  assert.equal(uo.skiv_7.kills_vs_sistema, 2);
+  assert.equal(uo.skiv_7.threat_level, 'normal');
+  assert.equal(uo.skiv_3.sightings, 1);
+  assert.equal(uo.skiv_3.kills_vs_sistema, 0);
+  uo = foldObservations(uo, { roster: ['skiv_7', 'skiv_3'], kills: { skiv_7: 1 } });
+  assert.equal(uo.skiv_7.sightings, 2);
+  assert.equal(uo.skiv_7.kills_vs_sistema, 3);
+  assert.equal(uo.skiv_7.threat_level, 'high');
+});
+
+test('empty observations is a no-op clone of prior', () => {
+  const prior = { skiv_7: { kills_vs_sistema: 3, sightings: 2, threat_level: 'high' } };
+  const uo = foldObservations(prior, { roster: [], kills: {} });
+  assert.deepEqual(uo, prior);
+  assert.notEqual(uo, prior, 'returns a copy, does not mutate');
+});
+
+test('malformed input safe', () => {
+  assert.deepEqual(foldObservations(null, null), {});
+  assert.deepEqual(foldObservations(undefined, { roster: 'x', kills: 5 }), {});
+});

--- a/tests/api/coopCombatEndAccumulate.test.js
+++ b/tests/api/coopCombatEndAccumulate.test.js
@@ -57,13 +57,13 @@ test('endCombat folds sistemaObservations into store.upsert(run.id, ...)', async
   assert.equal(store.upserts.length, 1, 'exactly one upsert fired');
   const { campaignId, unitsObserved } = store.upserts[0];
   assert.equal(campaignId, runId, 'upsert keyed by run.id');
-  // pg_a: 3 kills >= HIGH_THREAT_KILLS(3) → threat high.
+  // pg_a: 3 kills >= HIGH_THREAT_KILLS(3) -> threat high.
   assert.deepEqual(unitsObserved.pg_a, {
     kills_vs_sistema: 3,
     sightings: 1,
     threat_level: 'high',
   });
-  // pg_b: 1 kill < threshold → threat normal.
+  // pg_b: 1 kill < threshold -> threat normal.
   assert.deepEqual(unitsObserved.pg_b, {
     kills_vs_sistema: 1,
     sightings: 1,
@@ -82,7 +82,7 @@ test('endCombat folds onto prior units_observed from store.get', async () => {
   });
   await tick();
   assert.equal(store.upserts.length, 1);
-  // prior 2 kills + 1 this encounter = 3 >= threshold → high; sightings 5 + 1.
+  // prior 2 kills + 1 this encounter = 3 >= threshold -> high; sightings 5 + 1.
   assert.deepEqual(store.upserts[0].unitsObserved.pg_a, {
     kills_vs_sistema: 3,
     sightings: 6,
@@ -95,7 +95,7 @@ test('endCombat WITHOUT sistemaObservations does NOT upsert (back-compat)', asyn
   const co = _setupAtCombat(store);
   co.endCombat({ outcome: 'victory', xpEarned: 10 });
   await tick();
-  assert.equal(store.upserts.length, 0, 'no observations → no accumulation');
+  assert.equal(store.upserts.length, 0, 'no observations -> no accumulation');
   assert.equal(co.phase, 'debrief', 'phase still advances normally');
 });
 
@@ -115,7 +115,7 @@ test('endCombat phase + outcome unaffected by sistemaObservations', async () => 
 test('default store (no injection) does not break endCombat', async () => {
   // Back-compat: omitting sistemaStateStore must still construct + drive to
   // debrief without throwing, even when sistemaObservations supplied (default
-  // store is stub-safe with no DATABASE_URL → upsert no-op).
+  // store is stub-safe with no DATABASE_URL -> upsert no-op).
   const co = new CoopOrchestrator({ roomCode: 'DFLT', hostId: 'p_h' });
   co.startRun({ scenarioStack: ['enc_demo_01'] });
   co.submitCharacter('p_h', { name: 'Aria', form_id: 'istj' }, { allPlayerIds: ['p_h'] });

--- a/tests/coop/coopCombatEndAccumulate.test.js
+++ b/tests/coop/coopCombatEndAccumulate.test.js
@@ -1,0 +1,128 @@
+// CAMP-2 (PR-A2) — coopOrchestrator.endCombat folds an optional
+// `sistemaObservations` slim-delta { roster:[pg_id], kills:{pg_id:int} } into
+// the injected sistema-state store keyed by run.id. Best-effort/async: the
+// fold runs in a detached Promise so it NEVER blocks the combat-end path.
+//
+// Store-injection seam: the orchestrator constructor opts object gains a
+// `sistemaStateStore` dep (same DI style as `worldEnricher`). Default wires the
+// canonical store; tests inject a STUB recording get/upsert calls.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { CoopOrchestrator } = require('../../apps/backend/services/coop/coopOrchestrator');
+
+// Stub sistema-state store: empty-safe get(), records every upsert(campaignId, uo).
+function makeStubStore(initial = {}) {
+  const upserts = [];
+  return {
+    upserts,
+    async get() {
+      return { units_observed: initial };
+    },
+    async upsert(campaignId, unitsObserved) {
+      upserts.push({ campaignId, unitsObserved });
+    },
+  };
+}
+
+function _setupAtCombat(store) {
+  const co = new CoopOrchestrator({ roomCode: 'CAMP', hostId: 'p_h', sistemaStateStore: store });
+  co.startRun({ scenarioStack: ['enc_demo_01'] });
+  co.submitCharacter(
+    'p_h',
+    { name: 'Aria', form_id: 'istj', species_id: 'scagliato', job_id: 'guerriero' },
+    { allPlayerIds: ['p_h'] },
+  );
+  co.confirmWorld();
+  return co;
+}
+
+// Best-effort accumulation is detached via Promise.resolve().then(...). Yield a
+// macrotask so the chained async fold + upsert settle before asserting.
+const tick = () => new Promise((r) => setImmediate(r));
+
+test('endCombat folds sistemaObservations into store.upsert(run.id, ...)', async () => {
+  const store = makeStubStore();
+  const co = _setupAtCombat(store);
+  const runId = co.run.id;
+  co.endCombat({
+    outcome: 'victory',
+    xpEarned: 10,
+    sistemaObservations: { roster: ['pg_a', 'pg_b'], kills: { pg_a: 3, pg_b: 1 } },
+  });
+  await tick();
+  assert.equal(store.upserts.length, 1, 'exactly one upsert fired');
+  const { campaignId, unitsObserved } = store.upserts[0];
+  assert.equal(campaignId, runId, 'upsert keyed by run.id');
+  // pg_a: 3 kills >= HIGH_THREAT_KILLS(3) → threat high.
+  assert.deepEqual(unitsObserved.pg_a, {
+    kills_vs_sistema: 3,
+    sightings: 1,
+    threat_level: 'high',
+  });
+  // pg_b: 1 kill < threshold → threat normal.
+  assert.deepEqual(unitsObserved.pg_b, {
+    kills_vs_sistema: 1,
+    sightings: 1,
+    threat_level: 'normal',
+  });
+});
+
+test('endCombat folds onto prior units_observed from store.get', async () => {
+  const store = makeStubStore({
+    pg_a: { kills_vs_sistema: 2, sightings: 5, threat_level: 'normal' },
+  });
+  const co = _setupAtCombat(store);
+  co.endCombat({
+    outcome: 'victory',
+    sistemaObservations: { roster: ['pg_a'], kills: { pg_a: 1 } },
+  });
+  await tick();
+  assert.equal(store.upserts.length, 1);
+  // prior 2 kills + 1 this encounter = 3 >= threshold → high; sightings 5 + 1.
+  assert.deepEqual(store.upserts[0].unitsObserved.pg_a, {
+    kills_vs_sistema: 3,
+    sightings: 6,
+    threat_level: 'high',
+  });
+});
+
+test('endCombat WITHOUT sistemaObservations does NOT upsert (back-compat)', async () => {
+  const store = makeStubStore();
+  const co = _setupAtCombat(store);
+  co.endCombat({ outcome: 'victory', xpEarned: 10 });
+  await tick();
+  assert.equal(store.upserts.length, 0, 'no observations → no accumulation');
+  assert.equal(co.phase, 'debrief', 'phase still advances normally');
+});
+
+test('endCombat phase + outcome unaffected by sistemaObservations', async () => {
+  const store = makeStubStore();
+  const co = _setupAtCombat(store);
+  const ret = co.endCombat({
+    outcome: 'defeat',
+    sistemaObservations: { roster: ['pg_a'], kills: {} },
+  });
+  await tick();
+  assert.equal(co.phase, 'debrief');
+  assert.equal(co.run.outcome, 'defeat');
+  assert.equal(ret.outcome, 'defeat');
+});
+
+test('default store (no injection) does not break endCombat', async () => {
+  // Back-compat: omitting sistemaStateStore must still construct + drive to
+  // debrief without throwing, even when sistemaObservations supplied (default
+  // store is stub-safe with no DATABASE_URL → upsert no-op).
+  const co = new CoopOrchestrator({ roomCode: 'DFLT', hostId: 'p_h' });
+  co.startRun({ scenarioStack: ['enc_demo_01'] });
+  co.submitCharacter('p_h', { name: 'Aria', form_id: 'istj' }, { allPlayerIds: ['p_h'] });
+  co.confirmWorld();
+  assert.doesNotThrow(() =>
+    co.endCombat({ outcome: 'victory', sistemaObservations: { roster: ['pg_a'], kills: {} } }),
+  );
+  await tick();
+  assert.equal(co.phase, 'debrief');
+});


### PR DESCRIPTION
## Summary
CAMP-2 server half: makes the M1 Sistema accumulator reachable from the live (client-side) co-op flow. Previously the accumulator only had the legacy `session.js /end` writer, which the Godot port never calls — so `SistemaState.units_observed` was never written (see GGv2 doc PR #343 architecture map).

- `sistemaStateAccumulator.foldObservations(prior, {roster, kills})` — pure slim-delta fold (sightings+1 per roster PG, kills accumulate, threat recompute vs `HIGH_THREAT_KILLS`; server owns threshold).
- `coopOrchestrator.endCombat({...sistemaObservations})` + `/coop/combat/end` parse — best-effort detached fold → `sistemaStateStore.upsert(run.id, ...)`. Never blocks/throws into combat-end. Back-compat: no `sistema_observations` → no-op.
- Store injected via the existing `worldEnricher` lazy-getter DI pattern (default real store, stub-safe).

## Honest scope
This is the **write path**. Pairs with GGv2 [#344](https://github.com/MasterDD-L34D/Game-Godot-v2/pull/344) (kill-signal + slim-delta producer + campaign_id). Telegraph **read-back** is gated on: (a) run_id plumbing into WorldSetupState (follow-up — live `start_run` response run_id is currently discarded, so campaign_id stays "default"), (b) CAMP-3 loop closure + TV DebriefView mount. Migration `0011_sistema_state` applies at deploy.

## Test plan
- [x] `node --test tests/ai/*.test.js` (foldObservations 3 + 447 regression)
- [x] `node --test tests/api/*.test.js` — coopCombatEndAccumulate 5 + full 1277/1277 (CI runner glob)
- [x] prettier --check clean (CI Lint stack gate)