### PR TITLE
fix(coop): collision-resistant run.id (crypto.randomUUID) — SistemaState key safety

### DIFF
--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -4,8 +4,18 @@
 
 'use strict';
 
+const crypto = require('crypto');
 const { foldObservations } = require('../ai/sistemaStateAccumulator');
 const { createSistemaStateStore } = require('../ai/sistemaStateStore');
+
+// CAMP-1/CAMP-2 - run.id is the SistemaState persistence key (server writes
+// SistemaState under run.id; Godot client keys CampaignState.campaign_id on
+// it). The legacy `run_${Date.now().toString(36)}` collided when two runs
+// were created in the same millisecond, causing cross-run learning bleed.
+// crypto.randomUUID() is collision-resistant; the `run_` prefix is preserved.
+function newRunId() {
+  return `run_${crypto.randomUUID()}`;
+}
 
 // 2026-05-06 narrative onboarding port — `onboarding` phase added per
 // canonical `docs/core/51-ONBOARDING-60S.md` Phase B. Sequence:
@@ -168,7 +178,7 @@ class CoopOrchestrator {
       throw new Error(`cannot_start_from_phase:${this.phase}`);
     }
     this.run = {
-      id: `run_${Date.now().toString(36)}`,
+      id: newRunId(),
       scenarioStack: Array.isArray(scenarioStack) ? scenarioStack : ['enc_tutorial_01'],
       currentIndex: 0,
       partyXp: 0,
@@ -202,7 +212,7 @@ class CoopOrchestrator {
       throw new Error(`cannot_start_from_phase:${this.phase}`);
     }
     this.run = {
-      id: `run_${Date.now().toString(36)}`,
+      id: newRunId(),
       scenarioStack: Array.isArray(scenarioStack) ? scenarioStack : ['enc_tutorial_01'],
       currentIndex: 0,
       partyXp: 0,

--- a/tests/api/coopOrchestrator.test.js
+++ b/tests/api/coopOrchestrator.test.js
@@ -228,6 +228,44 @@ test('startRun transitions lobby → character_creation', () => {
   assert.deepEqual(run.scenarioStack, ['enc_tutorial_01']);
 });
 
+// CAMP-1/CAMP-2 - run.id is the SistemaState persistence key. Two runs
+// created in the SAME millisecond must NOT collide (cross-run learning
+// bleed). The old `run_${Date.now().toString(36)}` impl fails this: pin
+// Date.now to a constant so both orchestrators see the identical tick and
+// the time-only id would be byte-identical.
+test('two runs in the same now() tick get distinct ids', () => {
+  const realNow = Date.now;
+  Date.now = () => 1000;
+  try {
+    const o1 = new CoopOrchestrator({ roomCode: 'R1', hostId: 'h1' });
+    const o2 = new CoopOrchestrator({ roomCode: 'R2', hostId: 'h2' });
+    const r1 = o1.startRun();
+    const r2 = o2.startRun();
+    assert.notEqual(r1.id, r2.id, 'same-tick runs must have distinct ids');
+    assert.match(r1.id, /^run_/);
+    assert.match(r2.id, /^run_/);
+  } finally {
+    Date.now = realNow;
+  }
+});
+
+// startOnboarding shares the run.id shape with startRun - same collision
+// surface, same SistemaState key path. Guard both call sites.
+test('two onboarding runs in the same now() tick get distinct ids', () => {
+  const realNow = Date.now;
+  Date.now = () => 2000;
+  try {
+    const o1 = new CoopOrchestrator({ roomCode: 'R3', hostId: 'h3' });
+    const o2 = new CoopOrchestrator({ roomCode: 'R4', hostId: 'h4' });
+    const r1 = o1.startOnboarding();
+    const r2 = o2.startOnboarding();
+    assert.notEqual(r1.id, r2.id, 'same-tick onboarding runs must have distinct ids');
+    assert.match(r1.id, /^run_/);
+  } finally {
+    Date.now = realNow;
+  }
+});
+
 test('submitCharacter stores spec + advances when all players ready', () => {
   const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
   co.startRun();


### PR DESCRIPTION
## Summary
`run.id` became the SistemaState persistence key with CAMP-1/CAMP-2 (server writes SistemaState under run.id; Godot keys CampaignState.campaign_id on it). The old `run_${Date.now().toString(36)}` collides for two runs created in the same millisecond → cross-run SistemaState bleed (one run reads/overwrites another's persisted learning).

- `newRunId()` helper → `run_${crypto.randomUUID()}`, used at both `startRun` + `startOnboarding`. `run_` prefix preserved.

## Verification
- grep `run_` across `apps/backend`: nothing parses/substring the id — opaque string everywhere. `app.js` tmpPath is independent.
- Prisma `SistemaState.campaignId` (0011) + `GodotV2CampaignState.campaignId` (0010): both plain `String` (unbounded `text`, no VarChar) → 40-char id fits.

## Test plan
- [x] 2 new tests (`tests/api/coopOrchestrator.test.js`): two startRun/startOnboarding in the same pinned `Date.now()` tick → distinct ids. Old impl fails (byte-identical `run_rs`); fix passes.
- [x] `node --test tests/api/*.test.js` → 1279/1279
- [x] prettier --check clean