### PR TITLE
fix(ai): M1 persistent_high_threat reaches Utility AI path (TKT-P6-M1-UTILITY-AI-PASSTHROUGH)

### DIFF
--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -323,7 +323,14 @@ function createDeclareSistemaIntents(deps) {
             }
           }
         }
-        policy = selectAiPolicyUtility(actor, target, {}, stickyDifficulty);
+        // M1 ADR-2026-05-18 Option B -- surface persistent high-threat to the
+        // Utility AI path too (was dropped here; legacy path at selectAiPolicy
+        // below already reads threatCtx). Without this, M1's defensive overlay
+        // went inert for any Sistema unit running a use_utility_brain profile.
+        const utilityState = {
+          persistent_high_threat: !!(threatCtx && threatCtx.persistent_high_threat),
+        };
+        policy = selectAiPolicyUtility(actor, target, utilityState, stickyDifficulty);
       } else {
         policy = selectAiPolicy(actor, target, null, threatCtx);
       }

--- a/apps/backend/services/ai/utilityBrain.js
+++ b/apps/backend/services/ai/utilityBrain.js
@@ -177,6 +177,14 @@ function manhattanFallback(a, b) {
 const DEFAULT_STICKINESS_WEIGHT = 0.15;
 const DEFAULT_STICKINESS_DIRECTION_WEIGHT = 0.075;
 
+// M1 ADR-2026-05-18 Option B -- persistent high-threat defensive overlay.
+// Utility-AI mirror of selectAiPolicy's +20% retreat-threshold bias (policy.js
+// REGOLA_002): when a proven killer (persistent high-threat PG) is on the field,
+// retreat actions receive a flat additive bonus so the unit leans cautious near
+// retreat-worthy HP. Deterministic (no RNG). Inactive when state.persistent_high_threat
+// is falsy -> zero contribution -> baseline behavior preserved.
+const PERSISTENT_THREAT_RETREAT_BONUS = 0.2;
+
 function _moveDirection(fromPos, toPos) {
   if (!fromPos || !toPos) return null;
   const dx = (toPos.x ?? 0) - (fromPos.x ?? 0);
@@ -231,6 +239,19 @@ function scoreAction(
       totalScore += stickDirWeight;
       breakdown.push({ name: 'StickyDirection', raw: 1, curved: 1, weighted: stickDirWeight });
     }
+  }
+
+  // M1 persistent high-threat defensive overlay (see PERSISTENT_THREAT_RETREAT_BONUS).
+  // Boosts retreat utility when a high-threat PG is on the field; non-retreat actions
+  // are untouched (mirrors legacy "widen cautious path" rather than penalize aggression).
+  if (state && state.persistent_high_threat && action.type === 'retreat') {
+    totalScore += PERSISTENT_THREAT_RETREAT_BONUS;
+    breakdown.push({
+      name: 'PersistentThreat',
+      raw: 1,
+      curved: 1,
+      weighted: PERSISTENT_THREAT_RETREAT_BONUS,
+    });
   }
 
   return { score: totalScore, breakdown };

--- a/tests/ai/utilityPersistentThreat.test.js
+++ b/tests/ai/utilityPersistentThreat.test.js
@@ -1,0 +1,94 @@
+// tests/ai/utilityPersistentThreat.test.js
+// M1 ADR-2026-05-18 Option B -- Utility AI path consumes persistent_high_threat.
+// Parity with the legacy selectAiPolicy +20% retreat-threshold bias
+// (see sistemaDefendBias.test.js): a Utility-AI Sistema unit with a high-threat
+// PG on the field leans more defensive (retreat) than without. Deterministic.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  scoreAction,
+  selectAiPolicyUtility,
+} = require('../../apps/backend/services/ai/utilityBrain');
+
+function sisActor(hp, maxHp) {
+  return {
+    id: 'sis_1',
+    team: 'sistema',
+    hp,
+    max_hp: maxHp,
+    position: { x: 0, y: 0 },
+    attack_range: 2,
+  };
+}
+
+function pg(hp, maxHp) {
+  return { id: 'p1', team: 'player', hp, max_hp: maxHp, position: { x: 1, y: 0 } };
+}
+
+// ── scoreAction granularity: guaranteed delta + non-retreat untouched ──
+
+test('scoreAction: persistent_high_threat boosts retreat by exactly the bonus', () => {
+  const actor = sisActor(6, 10);
+  const baseState = { units: { sis_1: actor, p1: pg(10, 10) } };
+  const threatState = { ...baseState, persistent_high_threat: true };
+
+  const without = scoreAction({ type: 'retreat' }, actor, baseState);
+  const withThreat = scoreAction({ type: 'retreat' }, actor, threatState);
+
+  assert.ok(
+    withThreat.score > without.score,
+    'retreat should score higher under persistent_high_threat',
+  );
+  assert.ok(
+    Math.abs(withThreat.score - without.score - 0.2) < 1e-9,
+    'delta should equal the flat retreat bonus (0.2)',
+  );
+});
+
+test('scoreAction: persistent_high_threat does NOT change non-retreat actions', () => {
+  const actor = sisActor(6, 10);
+  const baseState = { units: { sis_1: actor, p1: pg(10, 10) } };
+  const threatState = { ...baseState, persistent_high_threat: true };
+
+  const attackBase = scoreAction({ type: 'attack', target: 'p1' }, actor, baseState);
+  const attackThreat = scoreAction({ type: 'attack', target: 'p1' }, actor, threatState);
+  assert.equal(attackThreat.score, attackBase.score);
+
+  const approachBase = scoreAction({ type: 'approach', target: 'p1' }, actor, baseState);
+  const approachThreat = scoreAction({ type: 'approach', target: 'p1' }, actor, threatState);
+  assert.equal(approachThreat.score, approachBase.score);
+});
+
+// ── selectAiPolicyUtility integration: the flip (leans more defensive) ──
+
+test('selectAiPolicyUtility: borderline actor flips attack -> retreat under threat', () => {
+  // hp 6/10 chosen so retreat is just-below the attack score without threat;
+  // the +0.2 bonus tips the argmax to retreat (mirrors legacy widened band).
+  const actor = sisActor(6, 10);
+  const target = pg(10, 10);
+
+  const noThreat = selectAiPolicyUtility(actor, target, {});
+  assert.equal(noThreat.intent, 'attack', 'baseline (no threat) is aggressive');
+
+  const threat = selectAiPolicyUtility(actor, target, { persistent_high_threat: true });
+  assert.equal(threat.intent, 'retreat', 'high-threat PG present -> defensive');
+});
+
+test('selectAiPolicyUtility: absent flag preserves baseline (back-compat)', () => {
+  const actor = sisActor(6, 10);
+  const target = pg(10, 10);
+  const a = selectAiPolicyUtility(actor, target, {});
+  const b = selectAiPolicyUtility(actor, target, { persistent_high_threat: false });
+  assert.equal(a.intent, b.intent);
+  assert.equal(a.intent, 'attack');
+});
+
+test('selectAiPolicyUtility: deterministic under threat (no RNG)', () => {
+  const actor = sisActor(6, 10);
+  const target = pg(10, 10);
+  const a = selectAiPolicyUtility(actor, target, { persistent_high_threat: true });
+  const b = selectAiPolicyUtility(actor, target, { persistent_high_threat: true });
+  assert.equal(a.intent, b.intent);
+  assert.equal(a.score, b.score);
+});

--- a/tests/ai/utilityPersistentThreat.test.js
+++ b/tests/ai/utilityPersistentThreat.test.js
@@ -26,7 +26,7 @@ function pg(hp, maxHp) {
   return { id: 'p1', team: 'player', hp, max_hp: maxHp, position: { x: 1, y: 0 } };
 }
 
-// ── scoreAction granularity: guaranteed delta + non-retreat untouched ──
+// -- scoreAction granularity: guaranteed delta + non-retreat untouched --
 
 test('scoreAction: persistent_high_threat boosts retreat by exactly the bonus', () => {
   const actor = sisActor(6, 10);
@@ -60,7 +60,7 @@ test('scoreAction: persistent_high_threat does NOT change non-retreat actions', 
   assert.equal(approachThreat.score, approachBase.score);
 });
 
-// ── selectAiPolicyUtility integration: the flip (leans more defensive) ──
+// -- selectAiPolicyUtility integration: the flip (leans more defensive) --
 
 test('selectAiPolicyUtility: borderline actor flips attack -> retreat under threat', () => {
   // hp 6/10 chosen so retreat is just-below the attack score without threat;


### PR DESCRIPTION
## Summary
The M1 Sistema defensive overlay (`persistent_high_threat` → retreat bias when a proven-killer PG is on field) was inert for Utility-AI Sistema units. `declareSistemaIntents` dropped `threatCtx` when routing to `selectAiPolicyUtility` (`:326`); only the legacy `selectAiPolicy` path applied it.

**Real, not moot**: the production `aggressive` profile sets `use_utility_brain: true` (`packs/evo_tactics_pack/data/balance/ai_profiles.yaml:48`) → aggressive Sistema units take the utility path → overlay silently skipped for them. (PR #2146's `false` was a temporary K3 isolation, superseded by K4.)

- `declareSistemaIntents`: pass `{ persistent_high_threat }` into `selectAiPolicyUtility` state.
- `utilityBrain.scoreAction`: deterministic flat retreat bonus `0.2` (`PERSISTENT_THREAT_RETREAT_BONUS`) when `state.persistent_high_threat` — mirrors the legacy "widen cautious band". Non-retreat actions untouched; flag absent → zero contribution → baseline byte-identical; no RNG.

## Provenance
Implemented by a spawned chip (TKT-P6-M1-UTILITY-AI-PASSTHROUGH) surfaced by the 2026-05-21 balance audit; independently reviewed (correctness + determinism + back-compat + magnitude sanity = mergeable). ASCII comment-separator cleanup (ADR-0021) added.

## Test plan
- [x] `tests/ai/utilityPersistentThreat.test.js` 5/5 (delta + non-retreat-untouched + attack→retreat flip + back-compat flag-off + determinism)
- [x] `node --test tests/ai/*.test.js` 452/452 (zero regression)
- [x] prettier-clean; magnitude `0.2` = soft nudge (not degenerate); tuning playtest-gated (#14/#15)