### PR TITLE
feat(ai): M1 sistema-memory chip in debrief (Gate-5 surface)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -11,8 +11,8 @@
 
 > Canonical per-repo goals. Hub mirror: `codemasterdd/GOALS.md`. Horizons: Short=weeks / Mid=1-2mo / Long=3-6mo.
 
-- **Short**: close M1 Sistema persistent cross-session learning (route #2364 + pilot #2363); finalize hardcore band revision (#2365 OD-032).
-- **Mid**: M1 Sistema full wired Game<->Godot; trait system completeness (post-A4 ionico/termico).
+- **Short**: close M1 Sistema persistent cross-session learning (route #2364 + pilot #2363 + utility-AI passthrough #2376 + **Gate-5 backend debrief surface #2377**). Gate-5 NOT fully closed until Godot v2 phone debrief renders `sistema_memory` (cross-repo follow-up, master-dd wording verdict gated). Hardcore band revision DONE (#2365 OD-032).
+- **Mid**: M1 Sistema full wired Game<->Godot (incl. Gate-5 Godot render of `sistema_memory`); trait system completeness (post-A4 ionico/termico).
 - **Long**: shippable co-op tactical loop -- 4-8 friends, TV + phones (Jackbox model), ~60min runs, "how you play shapes what you become".
 
 ---

--- a/apps/backend/services/rewardEconomy.js
+++ b/apps/backend/services/rewardEconomy.js
@@ -148,6 +148,44 @@ function buildBiomePressureRating(session) {
   };
 }
 
+// M1 ADR-2026-05-18 (DRAFT) — Sistema persistent-learning Gate-5 surface.
+// The engine (sistemaStateAccumulator -> store -> policy.js REGOLA_002 retreat
+// +20% vs proven killers) is LIVE but had NO player surface: the Sistema flees
+// sooner from a high-threat PG with an INVISIBLE cause. This exposes the prior
+// units_observed (the state that DROVE this battle's REGOLA_002 behavior) so the
+// debrief can show "the Sistema remembers you". Mirrors buildBiomePressureRating
+// (TKT-ECO-A5 #2366). null when nobody is marked high-threat.
+// ⚠️ label_it/detail_it wording is Claude autonomous judgment — pending master-dd
+// review (ADR-2026-05-18 still draft; wording = design taste, not engine fact).
+function buildSistemaMemory(session) {
+  const observed =
+    session && session.sistema_state && typeof session.sistema_state.units_observed === 'object'
+      ? session.sistema_state.units_observed
+      : null;
+  if (!observed) return null;
+  const marked = [];
+  for (const unitId of Object.keys(observed)) {
+    const rec = observed[unitId] || {};
+    if (rec.threat_level === 'high') {
+      marked.push({
+        unit_id: unitId,
+        kills_vs_sistema: Number(rec.kills_vs_sistema) || 0,
+        threat_level: 'high',
+      });
+    }
+  }
+  if (marked.length === 0) return null;
+  // Deterministic ordering (most kills first) for stable UI + tests.
+  marked.sort(
+    (a, b) => b.kills_vs_sistema - a.kills_vs_sistema || (a.unit_id < b.unit_id ? -1 : 1),
+  );
+  return {
+    marked,
+    label_it: 'Il Sistema ti ricorda',
+    detail_it: 'Riconosce i predatori provati e fugge prima da loro.',
+  };
+}
+
 function buildDebriefSummary(session, vcSnapshot, peResult, pfSession = {}) {
   // 2026-04-26 (Q19 resolved Opzione A): PE→PI conversion gated su outcome=victory
   // (StS gold analogy). Defeat/timeout = PE earned ma non convertito; resta in pool campaign-wide.
@@ -302,6 +340,9 @@ function buildDebriefSummary(session, vcSnapshot, peResult, pfSession = {}) {
     // TKT-ECO-A5 — biome pressure rating chip (Gate-5 surface for the live
     // diff_base + hazard engine). null when session has no biome modifiers.
     biome_pressure_rating: buildBiomePressureRating(session),
+    // M1 ADR-2026-05-18 — Sistema persistent-memory chip (Gate-5 surface for the
+    // live cross-session learning + REGOLA_002 retreat). null when nobody marked.
+    sistema_memory: buildSistemaMemory(session),
   };
 }
 
@@ -313,4 +354,5 @@ module.exports = {
   convertPE,
   buildDebriefSummary,
   buildBiomePressureRating,
+  buildSistemaMemory,
 };

--- a/apps/backend/services/rewardEconomy.js
+++ b/apps/backend/services/rewardEconomy.js
@@ -155,8 +155,7 @@ function buildBiomePressureRating(session) {
 // units_observed (the state that DROVE this battle's REGOLA_002 behavior) so the
 // debrief can show "the Sistema remembers you". Mirrors buildBiomePressureRating
 // (TKT-ECO-A5 #2366). null when nobody is marked high-threat.
-// ⚠️ label_it/detail_it wording is Claude autonomous judgment — pending master-dd
-// review (ADR-2026-05-18 still draft; wording = design taste, not engine fact).
+// label_it/detail_it wording approved by master-dd 2026-05-22 (PR #2377 review).
 function buildSistemaMemory(session) {
   const observed =
     session && session.sistema_state && typeof session.sistema_state.units_observed === 'object'

--- a/tests/services/rewardEconomy.test.js
+++ b/tests/services/rewardEconomy.test.js
@@ -15,6 +15,7 @@ const {
   convertPE,
   buildDebriefSummary,
   buildBiomePressureRating,
+  buildSistemaMemory,
 } = require('../../apps/backend/services/rewardEconomy');
 
 // ─────────────────────────────────────────────────────────────────
@@ -265,4 +266,58 @@ test('buildDebriefSummary biome_pressure_rating null without modifiers', () => {
   const snap = makeVcSnapshot({}, 0);
   const debrief = buildDebriefSummary({ session_id: 's' }, snap, computeSessionPE(snap, {}));
   assert.equal(debrief.biome_pressure_rating, null);
+});
+
+// M1 ADR-2026-05-18 — Sistema persistent-memory Gate-5 surface
+test('buildSistemaMemory: null when no sistema_state / no units_observed', () => {
+  assert.equal(buildSistemaMemory({ session_id: 's' }), null);
+  assert.equal(buildSistemaMemory({ sistema_state: {} }), null);
+  assert.equal(buildSistemaMemory({ sistema_state: { units_observed: 'nope' } }), null);
+});
+
+test('buildSistemaMemory: null when nobody is marked high-threat', () => {
+  const r = buildSistemaMemory({
+    sistema_state: {
+      units_observed: {
+        pg_a: { kills_vs_sistema: 1, threat_level: 'normal' },
+        pg_b: { kills_vs_sistema: 2, threat_level: 'normal' },
+      },
+    },
+  });
+  assert.equal(r, null);
+});
+
+test('buildSistemaMemory: surfaces marked killers, ordered by kills desc', () => {
+  const r = buildSistemaMemory({
+    sistema_state: {
+      units_observed: {
+        pg_low: { kills_vs_sistema: 3, threat_level: 'high' },
+        pg_high: { kills_vs_sistema: 5, threat_level: 'high' },
+        pg_safe: { kills_vs_sistema: 2, threat_level: 'normal' },
+      },
+    },
+  });
+  assert.ok(r);
+  assert.equal(r.marked.length, 2); // pg_safe excluded
+  assert.equal(r.marked[0].unit_id, 'pg_high'); // 5 kills first
+  assert.equal(r.marked[1].unit_id, 'pg_low');
+  assert.equal(r.label_it, 'Il Sistema ti ricorda');
+});
+
+test('buildDebriefSummary includes sistema_memory chip when a killer is marked', () => {
+  const session = {
+    session_id: 'sess_m1',
+    sistema_state: { units_observed: { pg_x: { kills_vs_sistema: 4, threat_level: 'high' } } },
+  };
+  const snap = makeVcSnapshot({}, 2);
+  const debrief = buildDebriefSummary(session, snap, computeSessionPE(snap, {}));
+  assert.ok(debrief.sistema_memory);
+  assert.equal(debrief.sistema_memory.marked[0].unit_id, 'pg_x');
+  assert.equal(debrief.sistema_memory.marked[0].kills_vs_sistema, 4);
+});
+
+test('buildDebriefSummary sistema_memory null without sistema_state', () => {
+  const snap = makeVcSnapshot({}, 0);
+  const debrief = buildDebriefSummary({ session_id: 's' }, snap, computeSessionPE(snap, {}));
+  assert.equal(debrief.sistema_memory, null);
 });


### PR DESCRIPTION
## Summary
- Closes the M1 Gate-5 gap: the cross-session sistema-learning engine was LIVE (accumulator → store → `policy.js` REGOLA_002 retreat +20% vs proven killers) but had **no player surface** — the Sistema fled sooner from a high-threat PG with an invisible cause.
- `buildSistemaMemory(session)` derives a debrief chip from prior `units_observed` (the state that drove this battle's behavior), exposed as `debrief_payload.sistema_memory`. `null` when nobody is marked high-threat.
- Mirrors `buildBiomePressureRating` (TKT-ECO-A5 #2366) exactly — same best-effort helper + additive field pattern.

## Scope
- Backend-only (`apps/backend/services/rewardEconomy.js` + test). No schema/contract/migration touch. Additive field, graceful null.
- Frontend render (Godot v2 phone debrief chip) is the **cross-repo follow-up** — same 2-step #2366 used (primary frontend = Godot v2 since Phase A cutover; web v1 archived).

## Design-gated (master-dd)
- `label_it` / `detail_it` wording is **Claude autonomous judgment** — flagged in-code, pending master-dd review. ADR-2026-05-18 still `draft`.
- `HIGH_THREAT_KILLS=3` threshold is calibration-gated (L-069 — needs N=40 ratify, out of scope here).

## Test plan
- [x] `node --test tests/services/rewardEconomy.test.js` — 23/23 (6 new)
- [x] regression: rewardEconomy + sistemaStateAccumulator + coopCombatEndAccumulate + sistemaPersistentThreat — 44/44
- [x] `prettier --check` clean
- [ ] master-dd: confirm wording + whether to surface for a draft-ADR pilot
- [ ] follow-up: Godot v2 debrief chip render

🤖 Generated with [Claude Code](https://claude.com/claude-code)