### PR TITLE
chore(ai): remove orphan debrief_payload.sistema_memory field

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -11,8 +11,8 @@
 
 > Canonical per-repo goals. Hub mirror: `codemasterdd/GOALS.md`. Horizons: Short=weeks / Mid=1-2mo / Long=3-6mo.
 
-- **Short**: close M1 Sistema persistent cross-session learning (route #2364 + pilot #2363 + utility-AI passthrough #2376 + **Gate-5 backend debrief surface #2377**). Gate-5 NOT fully closed until Godot v2 phone debrief renders `sistema_memory` (cross-repo follow-up, master-dd wording verdict gated). Hardcore band revision DONE (#2365 OD-032).
-- **Mid**: M1 Sistema full wired Game<->Godot (incl. Gate-5 Godot render of `sistema_memory`); trait system completeness (post-A4 ionico/termico).
+- **Short**: M1 Sistema persistent cross-session learning **CLOSED** — pilot #2363 + read route #2364 + utility-AI passthrough #2376 + **Gate-5 surface live via Godot #342** (brief "Il Sistema ricorda" + debrief Cronaca echo, rendered from `units_observed` HTTP read route). Backend `debrief_payload.sistema_memory` (#2377) **removed as orphan** — Godot renders from the canonical read-route path, single-source. Hardcore band revision DONE (#2365 OD-032).
+- **Mid**: M1 Sistema full wired Game<->Godot — validate/playtest the live loop; trait system completeness (post-A4 ionico/termico).
 - **Long**: shippable co-op tactical loop -- 4-8 friends, TV + phones (Jackbox model), ~60min runs, "how you play shapes what you become".
 
 ---

--- a/apps/backend/services/rewardEconomy.js
+++ b/apps/backend/services/rewardEconomy.js
@@ -148,43 +148,6 @@ function buildBiomePressureRating(session) {
   };
 }
 
-// M1 ADR-2026-05-18 (DRAFT) — Sistema persistent-learning Gate-5 surface.
-// The engine (sistemaStateAccumulator -> store -> policy.js REGOLA_002 retreat
-// +20% vs proven killers) is LIVE but had NO player surface: the Sistema flees
-// sooner from a high-threat PG with an INVISIBLE cause. This exposes the prior
-// units_observed (the state that DROVE this battle's REGOLA_002 behavior) so the
-// debrief can show "the Sistema remembers you". Mirrors buildBiomePressureRating
-// (TKT-ECO-A5 #2366). null when nobody is marked high-threat.
-// label_it/detail_it wording approved by master-dd 2026-05-22 (PR #2377 review).
-function buildSistemaMemory(session) {
-  const observed =
-    session && session.sistema_state && typeof session.sistema_state.units_observed === 'object'
-      ? session.sistema_state.units_observed
-      : null;
-  if (!observed) return null;
-  const marked = [];
-  for (const unitId of Object.keys(observed)) {
-    const rec = observed[unitId] || {};
-    if (rec.threat_level === 'high') {
-      marked.push({
-        unit_id: unitId,
-        kills_vs_sistema: Number(rec.kills_vs_sistema) || 0,
-        threat_level: 'high',
-      });
-    }
-  }
-  if (marked.length === 0) return null;
-  // Deterministic ordering (most kills first) for stable UI + tests.
-  marked.sort(
-    (a, b) => b.kills_vs_sistema - a.kills_vs_sistema || (a.unit_id < b.unit_id ? -1 : 1),
-  );
-  return {
-    marked,
-    label_it: 'Il Sistema ti ricorda',
-    detail_it: 'Riconosce i predatori provati e fugge prima da loro.',
-  };
-}
-
 function buildDebriefSummary(session, vcSnapshot, peResult, pfSession = {}) {
   // 2026-04-26 (Q19 resolved Opzione A): PE→PI conversion gated su outcome=victory
   // (StS gold analogy). Defeat/timeout = PE earned ma non convertito; resta in pool campaign-wide.
@@ -339,9 +302,6 @@ function buildDebriefSummary(session, vcSnapshot, peResult, pfSession = {}) {
     // TKT-ECO-A5 — biome pressure rating chip (Gate-5 surface for the live
     // diff_base + hazard engine). null when session has no biome modifiers.
     biome_pressure_rating: buildBiomePressureRating(session),
-    // M1 ADR-2026-05-18 — Sistema persistent-memory chip (Gate-5 surface for the
-    // live cross-session learning + REGOLA_002 retreat). null when nobody marked.
-    sistema_memory: buildSistemaMemory(session),
   };
 }
 
@@ -353,5 +313,4 @@ module.exports = {
   convertPE,
   buildDebriefSummary,
   buildBiomePressureRating,
-  buildSistemaMemory,
 };

--- a/tests/services/rewardEconomy.test.js
+++ b/tests/services/rewardEconomy.test.js
@@ -15,7 +15,6 @@ const {
   convertPE,
   buildDebriefSummary,
   buildBiomePressureRating,
-  buildSistemaMemory,
 } = require('../../apps/backend/services/rewardEconomy');
 
 // ─────────────────────────────────────────────────────────────────
@@ -266,58 +265,4 @@ test('buildDebriefSummary biome_pressure_rating null without modifiers', () => {
   const snap = makeVcSnapshot({}, 0);
   const debrief = buildDebriefSummary({ session_id: 's' }, snap, computeSessionPE(snap, {}));
   assert.equal(debrief.biome_pressure_rating, null);
-});
-
-// M1 ADR-2026-05-18 — Sistema persistent-memory Gate-5 surface
-test('buildSistemaMemory: null when no sistema_state / no units_observed', () => {
-  assert.equal(buildSistemaMemory({ session_id: 's' }), null);
-  assert.equal(buildSistemaMemory({ sistema_state: {} }), null);
-  assert.equal(buildSistemaMemory({ sistema_state: { units_observed: 'nope' } }), null);
-});
-
-test('buildSistemaMemory: null when nobody is marked high-threat', () => {
-  const r = buildSistemaMemory({
-    sistema_state: {
-      units_observed: {
-        pg_a: { kills_vs_sistema: 1, threat_level: 'normal' },
-        pg_b: { kills_vs_sistema: 2, threat_level: 'normal' },
-      },
-    },
-  });
-  assert.equal(r, null);
-});
-
-test('buildSistemaMemory: surfaces marked killers, ordered by kills desc', () => {
-  const r = buildSistemaMemory({
-    sistema_state: {
-      units_observed: {
-        pg_low: { kills_vs_sistema: 3, threat_level: 'high' },
-        pg_high: { kills_vs_sistema: 5, threat_level: 'high' },
-        pg_safe: { kills_vs_sistema: 2, threat_level: 'normal' },
-      },
-    },
-  });
-  assert.ok(r);
-  assert.equal(r.marked.length, 2); // pg_safe excluded
-  assert.equal(r.marked[0].unit_id, 'pg_high'); // 5 kills first
-  assert.equal(r.marked[1].unit_id, 'pg_low');
-  assert.equal(r.label_it, 'Il Sistema ti ricorda');
-});
-
-test('buildDebriefSummary includes sistema_memory chip when a killer is marked', () => {
-  const session = {
-    session_id: 'sess_m1',
-    sistema_state: { units_observed: { pg_x: { kills_vs_sistema: 4, threat_level: 'high' } } },
-  };
-  const snap = makeVcSnapshot({}, 2);
-  const debrief = buildDebriefSummary(session, snap, computeSessionPE(snap, {}));
-  assert.ok(debrief.sistema_memory);
-  assert.equal(debrief.sistema_memory.marked[0].unit_id, 'pg_x');
-  assert.equal(debrief.sistema_memory.marked[0].kills_vs_sistema, 4);
-});
-
-test('buildDebriefSummary sistema_memory null without sistema_state', () => {
-  const snap = makeVcSnapshot({}, 0);
-  const debrief = buildDebriefSummary({ session_id: 's' }, snap, computeSessionPE(snap, {}));
-  assert.equal(debrief.sistema_memory, null);
 });


### PR DESCRIPTION
## Summary
- `debrief_payload.sistema_memory` (shipped #2377) is an **orphan** — zero consumers (grep-confirmed in `apps/`, `packages/`, `docs/mission-console`).
- Gate-5 for M1 sistema-memory is **already closed** by Godot v2 #342, which renders from the canonical `units_observed` HTTP read route (#2364): scenario brief ("Il Sistema ricorda") + debrief Cronaca echo (`append_sistema_remembers`).
- Web v1 (`apps/play`) was never wired and is archived.
- Removing the duplicate field keeps single-source-of-truth and clears an Engine-LIVE-Surface-DEAD orphan.

## Changes
- Revert `buildSistemaMemory` helper + `debrief_payload.sistema_memory` field + export (`rewardEconomy.js`).
- Remove the 6 associated tests → `rewardEconomy.test.js` back to 18/18.
- BACKLOG: mark M1 Short goal **CLOSED** (Gate-5 live via Godot #342), note field removal.

## Lesson
Don't ship the backend half of a cross-repo surface before the contract (debrief field vs read-route path) converges. The parallel session closed Gate-5 via a different path (#342 read-route), orphaning the prematurely-shipped #2377 half.

## Test plan
- [x] `node --test tests/services/rewardEconomy.test.js` — 18/18
- [x] grep: no dangling `sistema_memory` / `buildSistemaMemory` refs
- [x] `prettier --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)