### PR TITLE
fix(backend): drop unit_progressions.updated_at SQL default to match schema

### DIFF
--- a/apps/backend/prisma/migrations/0013_fix_unit_progressions_updated_at/migration.sql
+++ b/apps/backend/prisma/migrations/0013_fix_unit_progressions_updated_at/migration.sql
@@ -1,0 +1,17 @@
+-- 2026-05-22 Fix schema drift: unit_progressions.updated_at default.
+-- The UnitProgression model in schema.prisma declares
+--   updatedAt DateTime @updatedAt @map("updated_at")
+-- which Prisma manages at the application layer and therefore expects NO SQL
+-- column default. However migration 0004_unit_progression created the column as
+--   "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+-- so the migration history (and any DB built from it) carries a DEFAULT now()
+-- that the canonical schema does not. `prisma migrate diff
+--   --from-migrations prisma/migrations --to-schema-datamodel prisma/schema.prisma`
+-- (and migrate-status against a fresh DB) reported:
+--   [*] Altered column `updated_at` (default changed from Some(Now) to None)
+-- The schema is the source of truth, so this corrective migration drops the
+-- column default to align the DB with the schema. Additive only — existing
+-- migration files (immutable history) are untouched.
+
+-- AlterTable
+ALTER TABLE "unit_progressions" ALTER COLUMN "updated_at" DROP DEFAULT;


### PR DESCRIPTION
## Drift

`prisma migrate diff --from-migrations apps/backend/prisma/migrations --to-schema-datamodel apps/backend/prisma/schema.prisma` (surfaced 2026-05-22 during the CAMP-3c deploy) reported:

```
[*] Changed the `unit_progressions` table
  [*] Altered column `updated_at` (default changed from Some(Now) to None)
```

**Direction (ground-truthed):**
- `schema.prisma` (canonical, source of truth) declares `updatedAt DateTime @updatedAt @map("updated_at")` — Prisma manages this at the app layer, **no SQL default**.
- Migration `0004_unit_progression` created the column as `"updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP`, so the migration history (and any DB built from it) carries a `DEFAULT now()` the schema does not.

So the fix is to **drop the column default**, aligning the DB with the schema.

## Fix

New migration `0013_fix_unit_progressions_updated_at` (additive only — no existing migration files altered):

```sql
ALTER TABLE "unit_progressions" ALTER COLUMN "updated_at" DROP DEFAULT;
```

The SQL was generated by Prisma itself (`migrate diff ... --script`) — byte-identical to the corrective op.

## Verification

Ran `prisma migrate diff --from-migrations prisma/migrations --to-schema-datamodel prisma/schema.prisma` against a throwaway Postgres 16 shadow DB:
- **Without** 0013: diff contains `ALTER TABLE "unit_progressions" ALTER COLUMN "updated_at" DROP DEFAULT;`
- **With** 0013: `unit_progressions` is **no longer in the diff** — drift resolved.

`prisma validate` passes (schema valid).

## Heads-up — separate pre-existing drift (out of scope)

The same shadow-DB diff revealed the migration history is broadly out of sync with `schema.prisma` beyond `unit_progressions`. This PR intentionally fixes ONLY the `unit_progressions.updated_at` drift requested. The remaining drift (not addressed here) includes:

- Same `updated_at` `Some(Now)` -> `None` default drift on: `ideas`, `form_session_states`, `lobby_sessions`, `nest_states`, `npc_relations`, `skiv_companion_states`
- Missing tables in migration history vs schema: `campaigns`, `chapters`, `party_rosters`, `save_snapshots` (plus their indexes/FKs)
- FK redefinitions on `affinity_logs`, `idea_feedback`, `mating_events`, `trust_logs` (relation_id); index additions

Recommend a follow-up ticket for a comprehensive history-vs-schema reconciliation migration.