### PR TITLE
feat(combat): wire morale check on ally death (TKT-ORPHAN-MORALE)

### DIFF
--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -1413,6 +1413,46 @@ function createRoundBridge(deps) {
           );
         }
       }
+      // TKT-ORPHAN-MORALE (wire 2026-05-26): Battle-Brothers morale check on ally
+      // death. When a unit is killed, its LIVING adjacent allies make a morale
+      // check -> panic (or rarely rage on a natural 1). morale.js was orphan
+      // (test-only, never wired). checkMorale applies the status internally.
+      // Best-effort; never blocks the kill flow.
+      try {
+        const { checkMorale } = require('../services/combat/morale');
+        const deadTeam = target.controlled_by || target.team;
+        const dp = target.position;
+        if (dp && Number.isFinite(Number(dp.x)) && Number.isFinite(Number(dp.y))) {
+          for (const ally of session.units) {
+            if (!ally || ally.id === target.id || Number(ally.hp || 0) <= 0) continue;
+            if ((ally.controlled_by || ally.team) !== deadTeam) continue;
+            const apos = ally.position;
+            if (!apos || !Number.isFinite(Number(apos.x))) continue;
+            const dist =
+              Math.abs(Number(apos.x) - Number(dp.x)) + Math.abs(Number(apos.y) - Number(dp.y));
+            if (dist > 1) continue;
+            const res = checkMorale(ally, 'ally_killed_adjacent', {});
+            if (res && res.triggered && res.status) {
+              await appendEvent(session, {
+                ts: new Date().toISOString(),
+                session_id: session.session_id,
+                action_type: 'morale',
+                actor_id: ally.id,
+                target_id: ally.id,
+                turn: session.turn,
+                result: res.status,
+                morale_event: 'ally_killed_adjacent',
+                morale_score: res.score,
+                morale_threshold: res.threshold,
+                duration: res.duration,
+              });
+            }
+          }
+        }
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn('[morale] failed:', err && err.message ? err.message : err);
+      }
     }
   }
 

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -1413,41 +1413,19 @@ function createRoundBridge(deps) {
           );
         }
       }
-      // TKT-ORPHAN-MORALE (wire 2026-05-26): Battle-Brothers morale check on ally
-      // death. When a unit is killed, its LIVING adjacent allies make a morale
-      // check -> panic (or rarely rage on a natural 1). morale.js was orphan
-      // (test-only, never wired). checkMorale applies the status internally.
-      // Best-effort; never blocks the kill flow.
+      // TKT-ORPHAN-MORALE (wire): morale check on ally death. Logic extracted
+      // to services/combat/moraleOnKill (pure, unit-tested). When a unit is
+      // killed, its LIVING adjacent same-team allies make a morale check ->
+      // panic (or rarely rage). Best-effort; never blocks the kill flow.
       try {
-        const { checkMorale } = require('../services/combat/morale');
-        const deadTeam = target.controlled_by || target.team;
-        const dp = target.position;
-        if (dp && Number.isFinite(Number(dp.x)) && Number.isFinite(Number(dp.y))) {
-          for (const ally of session.units) {
-            if (!ally || ally.id === target.id || Number(ally.hp || 0) <= 0) continue;
-            if ((ally.controlled_by || ally.team) !== deadTeam) continue;
-            const apos = ally.position;
-            if (!apos || !Number.isFinite(Number(apos.x))) continue;
-            const dist =
-              Math.abs(Number(apos.x) - Number(dp.x)) + Math.abs(Number(apos.y) - Number(dp.y));
-            if (dist > 1) continue;
-            const res = checkMorale(ally, 'ally_killed_adjacent', {});
-            if (res && res.triggered && res.status) {
-              await appendEvent(session, {
-                ts: new Date().toISOString(),
-                session_id: session.session_id,
-                action_type: 'morale',
-                actor_id: ally.id,
-                target_id: ally.id,
-                turn: session.turn,
-                result: res.status,
-                morale_event: 'ally_killed_adjacent',
-                morale_score: res.score,
-                morale_threshold: res.threshold,
-                duration: res.duration,
-              });
-            }
-          }
+        const { moraleEventsForKill } = require('../services/combat/moraleOnKill');
+        const moraleEvents = moraleEventsForKill(target, session.units, {
+          sessionId: session.session_id,
+          turn: session.turn,
+        });
+        for (const mEv of moraleEvents) {
+          // eslint-disable-next-line no-await-in-loop
+          await appendEvent(session, mEv);
         }
       } catch (err) {
         // eslint-disable-next-line no-console

--- a/apps/backend/services/combat/moraleOnKill.js
+++ b/apps/backend/services/combat/moraleOnKill.js
@@ -16,7 +16,8 @@ function moraleEventsForKill(deadUnit, units, opts = {}) {
   const dp = deadUnit.position;
   if (!dp || !Number.isFinite(Number(dp.x)) || !Number.isFinite(Number(dp.y))) return events;
 
-  const checkMorale = typeof opts.checkMorale === 'function' ? opts.checkMorale : defaultCheckMorale;
+  const checkMorale =
+    typeof opts.checkMorale === 'function' ? opts.checkMorale : defaultCheckMorale;
   const deadTeam = deadUnit.controlled_by || deadUnit.team;
   const now = opts.now || new Date().toISOString();
 

--- a/apps/backend/services/combat/moraleOnKill.js
+++ b/apps/backend/services/combat/moraleOnKill.js
@@ -1,0 +1,51 @@
+'use strict';
+
+// TKT-ORPHAN-MORALE — Battle-Brothers morale check on ally death, extracted from
+// sessionRoundBridge.postResolveKills for testability. Pure: given the killed
+// unit + the unit list, returns morale event objects for each LIVING adjacent
+// (Manhattan dist <= 1) same-team ally whose checkMorale triggers. checkMorale
+// applies the status to the ally internally (side effect on ally.status).
+//
+// opts: { sessionId?, turn?, now?, checkMorale? (DI for tests) }
+
+const { checkMorale: defaultCheckMorale } = require('./morale');
+
+function moraleEventsForKill(deadUnit, units, opts = {}) {
+  const events = [];
+  if (!deadUnit || !Array.isArray(units)) return events;
+  const dp = deadUnit.position;
+  if (!dp || !Number.isFinite(Number(dp.x)) || !Number.isFinite(Number(dp.y))) return events;
+
+  const checkMorale = typeof opts.checkMorale === 'function' ? opts.checkMorale : defaultCheckMorale;
+  const deadTeam = deadUnit.controlled_by || deadUnit.team;
+  const now = opts.now || new Date().toISOString();
+
+  for (const ally of units) {
+    if (!ally || ally.id === deadUnit.id || Number(ally.hp || 0) <= 0) continue;
+    if ((ally.controlled_by || ally.team) !== deadTeam) continue;
+    const apos = ally.position;
+    if (!apos || !Number.isFinite(Number(apos.x))) continue;
+    const dist = Math.abs(Number(apos.x) - Number(dp.x)) + Math.abs(Number(apos.y) - Number(dp.y));
+    if (dist > 1) continue;
+
+    const res = checkMorale(ally, 'ally_killed_adjacent', {});
+    if (res && res.triggered && res.status) {
+      events.push({
+        ts: now,
+        session_id: opts.sessionId,
+        action_type: 'morale',
+        actor_id: ally.id,
+        target_id: ally.id,
+        turn: opts.turn,
+        result: res.status,
+        morale_event: 'ally_killed_adjacent',
+        morale_score: res.score,
+        morale_threshold: res.threshold,
+        duration: res.duration,
+      });
+    }
+  }
+  return events;
+}
+
+module.exports = { moraleEventsForKill };

--- a/tests/services/moraleOnKill.test.js
+++ b/tests/services/moraleOnKill.test.js
@@ -1,0 +1,33 @@
+// TKT-ORPHAN-MORALE wire test — pure helper extracted from
+// sessionRoundBridge.postResolveKills. Deterministic via real checkMorale
+// forced with morale_mod (no HTTP/DB/RNG-flakiness). One test exercises all
+// filters (adjacency / team / living / self) + trigger + event shape.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { moraleEventsForKill } = require('../../apps/backend/services/combat/moraleOnKill');
+
+test('emits one morale event only for a living adjacent same-team ally', () => {
+  const dead = { id: 'd1', controlled_by: 'sistema', position: { x: 1, y: 1 } };
+  const units = [
+    dead,
+    { id: 'ally', controlled_by: 'sistema', hp: 10, morale_mod: -20, position: { x: 1, y: 2 } },
+    { id: 'dead_ally', controlled_by: 'sistema', hp: 0, morale_mod: -20, position: { x: 2, y: 1 } },
+    { id: 'far', controlled_by: 'sistema', hp: 10, morale_mod: -20, position: { x: 3, y: 3 } },
+    { id: 'enemy', controlled_by: 'player', hp: 10, morale_mod: -20, position: { x: 0, y: 1 } },
+  ];
+
+  const evs = moraleEventsForKill(dead, units, { sessionId: 's1', turn: 4 });
+
+  assert.equal(evs.length, 1, 'only the living adjacent same-team ally reacts');
+  const e = evs[0];
+  assert.equal(e.actor_id, 'ally');
+  assert.equal(e.target_id, 'ally');
+  assert.equal(e.action_type, 'morale');
+  assert.equal(e.morale_event, 'ally_killed_adjacent');
+  assert.equal(e.turn, 4);
+  assert.equal(e.session_id, 's1');
+  assert.ok(e.result === 'panic' || e.result === 'rage', 'panic (or rage on nat-1)');
+});


### PR DESCRIPTION
## Summary
Orphan #3 of the 2026-05-22 Gate-5 audit — verdict 3A (full wire).

`morale.js` (Battle-Brothers-style morale → panic/rage, shipped Sprint α #1959) was **orphan** (test-only, never wired). `postResolveKills` now runs `checkMorale('ally_killed_adjacent')` for each **living adjacent ally** of a killed unit → panic (or rage on a natural 1). The engine applies the status internally; a `morale` event is logged.

- Single clean hook (reuses the existing `kills` list — `{actor, target, event}`).
- Best-effort try/catch, never blocks the kill flow.
- **Surface**: `panic`/`rage` (already canonical statuses, freeze §7.4) now actually trigger from ally deaths → player sees morale breaks.

## Scope note
Per OD-058 Gate 3, the 4 orphan engines are accepted into canonical design (3A). This wires morale; the other event types in morale.js (`enemy_critical_hit`, `status_panic_high`) are future hooks. SoT/00D entry for the morale system tracked in OD-058 D5.

## Test plan
- [x] morale engine tests 5/5
- [x] sessionRoundBridge.js syntax + prettier clean
- [ ] CI round-flow integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)