### PR TITLE
docs(design): reproduction + deep genetic model (D-REPRO + D-HEIR, post-freeze vision)

### DIFF
--- a/docs/adr/ADR-2026-05-26-deep-genetics-phase1-supersede-freeze.md
+++ b/docs/adr/ADR-2026-05-26-deep-genetics-phase1-supersede-freeze.md
@@ -4,7 +4,7 @@ date: 2026-05-26
 type: adr
 workstream: evo-tactics / Pilastro 2
 owner: master-dd
-status: accepted
+status: accepted (design) — Fase-1 build gated on writing-plans + schema-ripple escalation
 accepted_by: master-dd (in-chat 2026-05-26)
 supersedes_scoped: vault `90-FINAL-DESIGN-FREEZE §21.3` (only for Fase-1 scope below)
 related:
@@ -44,6 +44,7 @@ These are additive to the existing 2-gene-slot + 1-env-mutation canonical rule;
 they deepen the genotype/phenotype WITHOUT deep genealogies or the epigenome.
 
 **Still DEFERRED (remain §21.3 vision, NOT unlocked here)**:
+
 - Epigenome / Lamarck-lite telemetry-heritable layer (Fase-3).
 - Deep multi-generation genealogies / long-term reproductive ecosystem.
 - S5 ambient-drift lifecycle wire + cross-lineage isolation (Fase-2).
@@ -77,8 +78,10 @@ extends `metaProgression` / `progressionEngine` / `rewardOffer` / `mutation_cata
 ## Risks (red-team)
 
 1. **Snowball** (Fase-3 epigenome, pre-flagged): heritable play-shaped traits ->
-   parents strong -> offspring stronger. Mitigation locked NOW: decay /
-   regression-to-mean is a Fase-3 acceptance gate, not optional.
+   parents strong -> offspring stronger. Mitigation = **Fase-3 acceptance gate**
+   (decay / regression-to-mean) -- **parametri TBD, NON ancora progettato**; va
+   specificato + testato PRIMA di qualsiasi build Fase-3. Non e' risolto ora: e'
+   un gate vincolante, non una mitigazione completata.
 2. **Complexity-budget escape**: inheritance must NOT let a build exceed `C_max`
    regardless of inherited parts. Enforce at offspring materialization.
 3. **Scope creep past Fase-1**: any genealogy/epigenome work needs a NEW ADR;

--- a/docs/adr/ADR-2026-05-26-deep-genetics-phase1-supersede-freeze.md
+++ b/docs/adr/ADR-2026-05-26-deep-genetics-phase1-supersede-freeze.md
@@ -1,0 +1,93 @@
+---
+title: 'ADR-2026-05-26 — Deep genetics Fase-1: scoped supersede of FINAL-DESIGN-FREEZE §21.3'
+date: 2026-05-26
+type: adr
+workstream: evo-tactics / Pilastro 2
+owner: master-dd
+status: accepted
+accepted_by: master-dd (in-chat 2026-05-26)
+supersedes_scoped: vault `90-FINAL-DESIGN-FREEZE §21.3` (only for Fase-1 scope below)
+related:
+  - docs/superpowers/specs/2026-05-26-repro-heir-genetic-model-design.md (D-REPRO + D-HEIR)
+  - docs/research/2026-04-26-spore-deep-extraction.md (S1-S6)
+  - docs/adr/ADR-2026-04-26-spore-part-pack-slots.md (5 body_slot locked, complexity-budget, S5 deferred)
+  - vault SoT §5 / §20 (Tri-Sorgente) / §21
+---
+
+# ADR-2026-05-26 — Deep genetics Fase-1: scoped supersede of freeze §21.3
+
+## Context
+
+`90-FINAL-DESIGN-FREEZE §21.3` (vault) defers "genetica complessa; genealogie
+profonde; ecosistema riproduttivo a lungo termine; simulazione cross-mission
+ricca". Cross-repo verify (2026-05-26) found the genotype + phenotype substrate
+is largely SHIPPED (`rollMatingOffspring`/`inheritGeneSlots`, `mating.yaml`
+gene_slots, `mutation_catalog` biome boost/penalty, `geneEncoder` lineage,
+emergent tribes) and the Spore part-pack model is already designed + ADR'd
+(ADR-2026-04-26, S5 generational-inheritance explicitly deferred). The
+D-REPRO+D-HEIR spec proposes a deep 3-layer model. To build any of it we must
+exit the §21.3 freeze-defer — but a full supersede risks scope-creep against the
+shipping freeze.
+
+## Decision
+
+**Supersede §21.3 SCOPED to Fase-1 only** (Spore "Moderate" reuse-path). The
+freeze-defer is lifted for, and ONLY for:
+
+- **S1 body_slot** (5 locked slots, max 1 mutation/slot, `symbiotic` exception)
+- **S2 part -> ability derivation** (`derived_ability_id`)
+- **S3 MP-pool** (Mutation Points, complexity-budget `Sigma c <= C_max`)
+- **S4 morphology-first** (`aspect_token` + `visual_swap_it`)
+- **S6 category-bingo** (MHS gene grid)
+
+These are additive to the existing 2-gene-slot + 1-env-mutation canonical rule;
+they deepen the genotype/phenotype WITHOUT deep genealogies or the epigenome.
+
+**Still DEFERRED (remain §21.3 vision, NOT unlocked here)**:
+- Epigenome / Lamarck-lite telemetry-heritable layer (Fase-3).
+- Deep multi-generation genealogies / long-term reproductive ecosystem.
+- S5 ambient-drift lifecycle wire + cross-lineage isolation (Fase-2).
+
+### Resolved decisions (D-REPRO/D-HEIR spec §5)
+
+1. ADR-supersede = **this ADR, scoped Fase-1** (above).
+2. **Epigenome accepted WITH mandatory `decay`/regression-to-mean** (anti-snowball),
+   build deferred to Fase-3.
+3. **2 reproduction paths stay distinct** (individual mating vs S5 ambient pool);
+   fix cross-lineage isolation bug (`lineagePropagator.js:14-15`) in Fase-2.
+4. **Backend canonical** for genotype (SoT §1); Godot consumes via API; unify the
+   3 partial Godot impls (avg-blend / lineage_merge / offspring_ritual) in Fase-2.
+
+## Scope & seam
+
+Fase-1 = the existing `TKT-CREATURE-SPORE-01..08` (Moderate path, ~21h) from
+`docs/research/2026-04-26-spore-deep-extraction.md §4`. No new path invented;
+extends `metaProgression` / `progressionEngine` / `rewardOffer` / `mutation_catalog`.
+
+## Consequences
+
+- (+) Unlocks concrete Pilastro-2 build (part-pack depth) on already-designed
+  ground, without committing to the risky epigenome or deep genealogies.
+- (+) Keeps the shipping freeze intact for everything outside Fase-1.
+- (-) Partial supersede = the freeze §21.3 now has a scoped carve-out; the vault
+  freeze doc needs a "superseded-scoped by this ADR" banner (paired vault PR).
+- (-) MP-pool + body_slot are schema changes (ripple: progressionEngine,
+  rewardOffer, formEvolution) — schema-ripple escalation before merge.
+
+## Risks (red-team)
+
+1. **Snowball** (Fase-3 epigenome, pre-flagged): heritable play-shaped traits ->
+   parents strong -> offspring stronger. Mitigation locked NOW: decay /
+   regression-to-mean is a Fase-3 acceptance gate, not optional.
+2. **Complexity-budget escape**: inheritance must NOT let a build exceed `C_max`
+   regardless of inherited parts. Enforce at offspring materialization.
+3. **Scope creep past Fase-1**: any genealogy/epigenome work needs a NEW ADR;
+   this one does not authorize it.
+4. **Bingo imbalance** (14/30 mutations physiological): catalog rebalance is
+   authoring debt to plan before bingo ships.
+
+## Status / next
+
+Accepted. Next = `writing-plans` for Fase-1 (per phase / per TKT). Vault freeze
+§21.3 superseded-banner = paired vault PR. Promotion of D-HEIR to SoT canonical
+section = after Fase-1 ships.

--- a/docs/superpowers/specs/2026-05-26-repro-heir-genetic-model-design.md
+++ b/docs/superpowers/specs/2026-05-26-repro-heir-genetic-model-design.md
@@ -144,16 +144,22 @@ Ancora ai 3 reuse-path Spore (`docs/research/...` §4) + i TKT-CREATURE-SPORE-01
 - **Fase 3 (Epigenome, net-new)**: layer 3 Lamarck-lite + Frammenti wire +
   speciazione soglia. Il vero contributo di profondita'.
 
-## 5. Decisioni richieste (master-dd, pre-build)
-1. **ADR-supersede §21.3**: confermare che il deep-genetics esce dal freeze-defer
-   (altrimenti resta vision-only).
-2. **Epigenome Lamarck-lite**: accettare il design-novel (eredita' play-shaped)?
-   Red-team: rischio "snowball" (genitori forti -> prole sempre piu' forte) ->
-   serve decay/regression-to-mean.
-3. **Reconcile i 2 path**: confermare che mating (individuale) e drift-pool
-   (S5 ambientale) restano tipi distinti + fixare cross-lineage isolation.
-4. **Godot unify**: i 3 impl parziali Godot vanno unificati sotto il backend
-   genotype, o Godot resta avg-blend "display" finche' il backend e' canonico?
+## 5. Decisioni (RISOLTE master-dd 2026-05-26)
+
+1. **ADR-supersede §21.3 = SCOPED Fase-1.** Si supersede §21.3 SOLO per Fase-1
+   (Spore Moderate: body_slot / part->ability / MP-pool / bingo, gia' designato
+   ADR-2026-04-26). Epigenome + genealogie profonde restano vision (Fase-3).
+   Artefatto: `docs/adr/ADR-2026-05-26-deep-genetics-phase1-supersede-freeze.md`.
+2. **Epigenome Lamarck-lite = ACCETTATO con decay obbligatorio, build Fase-3.**
+   Concetto play-shapes-identity accettato MA `decay`/regression-to-mean
+   mandatorio (anti-snowball). Design ora, build ultimo (Fase-3).
+3. **2 path = DISTINTI + fix isolation.** Mating (individuale) e S5-drift-pool
+   (ambientale) restano tipi distinti. Cross-lineage isolation bug
+   (`lineagePropagator.js:14-15`) da fixare quando si deepena S5 (Fase-2).
+4. **Godot = BACKEND CANONICO.** Genotype/genetica vive nel backend Game/
+   (SoT §1 runtime-source-of-truth); Godot consuma via API + renderizza. I 3
+   impl parziali Godot (avg-blend / lineage_merge / offspring_ritual) vanno
+   unificati per chiamare il backend (Fase-2), niente logica genotype divergente.
 
 ## 6. Out of scope (qui)
 Implementazione (writing-plans separato per fase). UI del gene-grid. Authoring

--- a/docs/superpowers/specs/2026-05-26-repro-heir-genetic-model-design.md
+++ b/docs/superpowers/specs/2026-05-26-repro-heir-genetic-model-design.md
@@ -1,0 +1,161 @@
+---
+title: 'D-REPRO + D-HEIR — Reproduction taxonomy & deep genetic model (design)'
+date: 2026-05-26
+status: PROPOSED — POST-FREEZE VISION (requires ADR superseding 90-FINAL-DESIGN-FREEZE §21.3)
+owner: master-dd
+workstream: evo-tactics / Pilastro 2 (emergent evolution)
+language: it
+related:
+  - docs/research/2026-04-26-spore-deep-extraction.md (6 pattern S1-S6)
+  - docs/adr/ADR-2026-04-26-spore-part-pack-slots.md (5 body_slot locked, complexity-budget, S5 deferred)
+  - docs/core/Mating-Reclutamento-Nido.md (§Ereditarieta canonica)
+  - vault SoT §5 / §9 / §20 (Tri-Sorgente) / §21 / §24.3 (heir, PR #198)
+  - vault 90-FINAL-DESIGN-FREEZE §21.3 (defers deep genetics)
+impl_anchors:
+  - apps/backend/services/metaProgression.js (rollMatingOffspring + inheritGeneSlots)
+  - apps/backend/services/generation/lineagePropagator.js (Spore S5 biome-pool)
+  - apps/backend/services/meta/geneEncoder.js (SHA1 lineage chain)
+  - data/core/mating.yaml (gene_slots inheritance_rules, 3 cat, hybrid_rules)
+  - data/core/mutations/mutation_catalog.yaml (30 entries, biome_boost/penalty)
+  - apps/backend/services/vcScoring.js (telemetry -> MBTI, epigenome substrate)
+  - Game-Godot-v2: succession_engine.gd / mating_trigger.gd / lineage_merge_service.gd / offspring_ritual_service.gd
+---
+
+# D-REPRO + D-HEIR — Reproduction taxonomy & deep genetic model
+
+> **STATUS GATE**: il `90-FINAL-DESIGN-FREEZE §21.3` DEFERISCE esplicitamente
+> "genetica complessa; genealogie profonde; ecosistema riproduttivo a lungo
+> termine". Questo design e' **POST-FREEZE VISION**. Per renderne shippabile
+> una parte serve un **ADR che supersede §21.3** definendo lo scope. Lo slice
+> freeze attuale (1 nido level, mating trust+nest, output 1-2 seed) resta valido
+> come MVP; questo doc e' il target verso cui crescere, **fasato**.
+
+## 0. Non-greenfield: cosa esiste gia' (verify-before-build 2026-05-26)
+
+Il modello NON e' da zero. Stato verificato cross-repo (file:line):
+
+| Pezzo | Stato | Dove |
+|---|---|---|
+| Genotype 2-parent (slot-pick) | SHIPPED | `metaProgression.inheritGeneSlots` (296) + `rollMatingOffspring` (465) |
+| gene_slots schema (3 cat + rules) | SHIPPED | `data/core/mating.yaml` (parent_slots:2, env:1, form_seed_bias; cat Struttura/Funzione/Memorie; mutation_tiers T0/T1/T2 Nido-gated; hybrid_rules) |
+| Env-mutation pick (biome) | SHIPPED | `pickEnvironmentalMutation` (364) |
+| Lineage chain (provenance) | SHIPPED | `geneEncoder` SHA1 `gn1:parent:self` |
+| Phenotype biome boost/penalty | SHIPPED (data) | `mutation_catalog.yaml`, species `*_lifecycle.yaml` |
+| Speciazione emergente | SHIPPED | `getTribesEmergent` (>=3 stesso lineage_id = tribe) |
+| Ambient drift (Spore S5) | SHIPPED (plumbing, hook deferred) | `lineagePropagator.propagateLineage` (biome-pool, free-grant 1-2) |
+| Single-ancestor succession (M2) | SHIPPED (Godot) | `succession_engine.gd` + attrition/lethality + `campaign_state` ledger |
+| 2-parent mating (Godot) | SHIPPED (parziale) | `mating_trigger.generate_child_preview` (avg+trait-union FIFO5), `lineage_merge_service`, `offspring_ritual` (3-of-6) |
+| Spore S1-S6 part-pack | DESIGNED + ADR | `docs/research/2026-04-26-spore-deep-extraction.md`, ADR-2026-04-26 (5 slot locked, complexity-budget, S5 deferred) |
+
+**Il design ESTENDE/UNIFICA questo, non lo sostituisce.** Il vero net-new = il
+layer **Epigenome** (telemetry-heritable). Tutto il resto = formalizzare +
+collegare + approfondire pezzi esistenti.
+
+## 1. D-REPRO — taxonomy dei tipi di riproduzione
+
+Quattro tipi, ciascuno con un meccanismo distinto **gia' esistente** (no nuovi
+path duplicati — chiarisce i 2 "path in conflitto" come tipi diversi):
+
+1. **Sessuale 2-genitori** (eredi del party) -> `rollMatingOffspring`/`inheritGeneSlots`.
+   Ogni genitore contribuisce 1 gene_slot (weighted-pick per categoria) + 1
+   mutazione ambientale. Gate §20: **Fiducia>=3 + nest.requirements_met**. Il path
+   canonico dell'erede giocatore.
+2. **Single-ancestor succession** (NPC/boss, M2) -> Godot `succession_engine.gd`.
+   Asessuale: 1 antenato -> erede gen+1 stessa specie, propaga mutazioni al pool.
+   Auto-rimpiazzo su morte. NON path del party.
+3. **Drift ambientale di popolazione** (Spore S5) -> `lineagePropagator`. Quando
+   una unit va in `legacy`, le sue mutazioni entrano in un pool (species_id,
+   biome_id); newborn stessa-specie/biome eredita 1-2 **gratis**. = eredita'
+   di gene-pool ambientale, non individuale.
+   - **LIMITAZIONE NOTA da fixare nell'approfondire**: cross-lineage isolation
+     deferita -> due `lineage_id` diversi nello stesso (specie,biome)
+     **condividono il pool** (`lineagePropagator.js:14-15`). Va isolato per
+     `lineage_id` quando si deepena.
+4. **Ibridazione** (cross-lineage) -> `mating.yaml hybrid_rules` + Godot
+   `mating_trigger HYBRID_POLICY_DISPLAY_ONLY` (oggi solo label). Da promuovere
+   da display-only a merge genetico reale (varianza/drift maggiore).
+
+## 2. D-HEIR — modello genetico a 3 layer (Approach A)
+
+### Layer 1 — Genotype (ereditato)
+- **Loci = gene_slots** organizzati nelle 3 categorie canoniche
+  **Struttura / Funzione / Memorie** (`mating.yaml`), mappate sui **5 body_slot
+  Spore locked** (mouth/appendage/sense/tegument/back, ADR-2026-04-26 / S1).
+  Max 1 mutazione per body_slot (cap organico, eccezione `symbiotic`).
+- **Ricombinazione 2-parent** = `inheritGeneSlots` (1 slot weighted-pick per
+  genitore) + crossover. Estendibile a piu' loci senza rework (slot additivi).
+- **Complexity-budget (S3 + ADR)**: somma costi parti <= `C_max` per build, a
+  prescindere dall'eredita'. Vincolo hard sul genotype.
+- **Lineage** = `geneEncoder` SHA1 chain (provenance, generation count).
+- **Category-bingo (S6 / MHS grid)**: 3 mutazioni stessa categoria ->
+  specializzazione passiva (es. tank_plus). Gia' previsto.
+
+### Layer 2 — Phenotype (espresso, biome-driven)
+- Tratti espressi = genotype x **espressione ambientale**: un allele/parte
+  "dorme" o si attiva per pressione bioma (**biome T-bands T0-T3**, ADR;
+  `biome_boost`/`biome_penalty` del catalog). Stesso genotype, fenotipo diverso
+  per bioma -> bio-plausibile.
+- **Part -> ability derivation (S2)**: la parte implica l'abilita'
+  (`derived_ability_id`), non scelta esplicita.
+- **Morphology-first (S4)**: il player VEDE la parte (`aspect_token` +
+  `visual_swap_it`) prima del testo. `form_seed_bias` guida le preferenze.
+
+### Layer 3 — Epigenome (NET-NEW, appreso nel Nido) ⭐
+- **Substrato esistente**: `vcScoring` (telemetria VC -> assi MBTI da come giochi)
+  + categoria **Memorie** (`memoria_ambientale`, `inheritance_weight:0.0` =
+  sempre rigenerata = hook epigenetico) + `form_seed_bias`.
+- **Net-new**: rendere lo stato VC-appreso **parzialmente ereditabile**
+  (Lamarck-lite): l'epigenome play-shaped dei genitori **bias** l'espressione
+  della prole. **Questo e' il motore di "how you play shapes what you become".**
+- **DESIGN-NOVEL — giustificazione obbligatoria**: zero precedente canonico per
+  l'eredita' Lamarckiana. Giustificato dal pilastro §02 + dal tono bio-plausibile
+  ("memoria ambientale" come epigenetica, non magia). Va in ADR con red-team.
+- **Economy**: l'epigenome alimenta i **Frammenti Genetici** di Tri-Sorgente
+  (§20: skip-cards -> Frammenti, "evoluzione tipo Spore"). **NON inventare una
+  currency parallela** -- riusare quella.
+
+### Speciazione emergente
+- Divergenza genotype accumulata su generazioni (drift + selezione bioma);
+  oltre soglia -> lineage letta come "specie-forma" distinta. Gia' parziale via
+  `getTribesEmergent` (>=3 stesso lineage). Estendere con soglia complexity/T-band.
+
+## 3. Vincoli & anti-pattern (da Spore extraction §3 + freeze)
+- **Irreversibilita'** (pilastro narrativo): mutazione permanente = peso. NO
+  infinite-revert (Spore-trap esplicito).
+- **NO**: editor real-time mid-encounter, full 5-stage, creator 3D, sandbox-nav,
+  real-time combat. Mutazioni si applicano in nest/debrief.
+- **5 body_slot locked** + complexity-budget + biome T-bands = hard constraints.
+- **Leggibilita' (§21 A.L.I.E.N.A.)**: il player vede esiti ("la prole ha preso
+  la corazza del padre, il deserto ne ha svegliato la sete"), NON loci/alleli.
+
+## 4. Fasatura (anti-over-engineer vs freeze)
+
+Ancora ai 3 reuse-path Spore (`docs/research/...` §4) + i TKT-CREATURE-SPORE-01..10:
+
+- **Fase 0 (MVP-freeze, gia' ~shippable)**: lo slice freeze attuale (2-slot +
+  1-env, trust+nest, 1-2 seed). Niente nuovo.
+- **Fase 1 (Moderate ~21h, S1-S2-S3-S4p-S6)**: body_slot + part->ability +
+  MP-pool + morphology + bingo. **Richiede ADR-supersede §21.3** (sblocca genetica
+  oltre il minimal).
+- **Fase 2 (Full ~+15h, S5 + reconcile)**: wire `propagateLineage` lifecycle hook
+  + **fix cross-lineage isolation** + unificare i 3 impl Godot (mating_trigger
+  avg-blend + lineage_merge + ritual) sotto il genotype model + promuovere
+  ibridazione da display-only.
+- **Fase 3 (Epigenome, net-new)**: layer 3 Lamarck-lite + Frammenti wire +
+  speciazione soglia. Il vero contributo di profondita'.
+
+## 5. Decisioni richieste (master-dd, pre-build)
+1. **ADR-supersede §21.3**: confermare che il deep-genetics esce dal freeze-defer
+   (altrimenti resta vision-only).
+2. **Epigenome Lamarck-lite**: accettare il design-novel (eredita' play-shaped)?
+   Red-team: rischio "snowball" (genitori forti -> prole sempre piu' forte) ->
+   serve decay/regression-to-mean.
+3. **Reconcile i 2 path**: confermare che mating (individuale) e drift-pool
+   (S5 ambientale) restano tipi distinti + fixare cross-lineage isolation.
+4. **Godot unify**: i 3 impl parziali Godot vanno unificati sotto il backend
+   genotype, o Godot resta avg-blend "display" finche' il backend e' canonico?
+
+## 6. Out of scope (qui)
+Implementazione (writing-plans separato per fase). UI del gene-grid. Authoring
+catalog 30->50 mutazioni. Bilanciamento numerico. Promozione a SoT canonico
+(nuova sezione vault) -- avviene dopo l'ADR-supersede.

--- a/docs/superpowers/specs/2026-05-26-repro-heir-genetic-model-design.md
+++ b/docs/superpowers/specs/2026-05-26-repro-heir-genetic-model-design.md
@@ -34,18 +34,18 @@ impl_anchors:
 
 Il modello NON e' da zero. Stato verificato cross-repo (file:line):
 
-| Pezzo | Stato | Dove |
-|---|---|---|
-| Genotype 2-parent (slot-pick) | SHIPPED | `metaProgression.inheritGeneSlots` (296) + `rollMatingOffspring` (465) |
-| gene_slots schema (3 cat + rules) | SHIPPED | `data/core/mating.yaml` (parent_slots:2, env:1, form_seed_bias; cat Struttura/Funzione/Memorie; mutation_tiers T0/T1/T2 Nido-gated; hybrid_rules) |
-| Env-mutation pick (biome) | SHIPPED | `pickEnvironmentalMutation` (364) |
-| Lineage chain (provenance) | SHIPPED | `geneEncoder` SHA1 `gn1:parent:self` |
-| Phenotype biome boost/penalty | SHIPPED (data) | `mutation_catalog.yaml`, species `*_lifecycle.yaml` |
-| Speciazione emergente | SHIPPED | `getTribesEmergent` (>=3 stesso lineage_id = tribe) |
-| Ambient drift (Spore S5) | SHIPPED (plumbing, hook deferred) | `lineagePropagator.propagateLineage` (biome-pool, free-grant 1-2) |
-| Single-ancestor succession (M2) | SHIPPED (Godot) | `succession_engine.gd` + attrition/lethality + `campaign_state` ledger |
-| 2-parent mating (Godot) | SHIPPED (parziale) | `mating_trigger.generate_child_preview` (avg+trait-union FIFO5), `lineage_merge_service`, `offspring_ritual` (3-of-6) |
-| Spore S1-S6 part-pack | DESIGNED + ADR | `docs/research/2026-04-26-spore-deep-extraction.md`, ADR-2026-04-26 (5 slot locked, complexity-budget, S5 deferred) |
+| Pezzo                             | Stato                             | Dove                                                                                                                                              |
+| --------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Genotype 2-parent (slot-pick)     | SHIPPED                           | `metaProgression.inheritGeneSlots` (296) + `rollMatingOffspring` (465)                                                                            |
+| gene_slots schema (3 cat + rules) | SHIPPED                           | `data/core/mating.yaml` (parent_slots:2, env:1, form_seed_bias; cat Struttura/Funzione/Memorie; mutation_tiers T0/T1/T2 Nido-gated; hybrid_rules) |
+| Env-mutation pick (biome)         | SHIPPED                           | `pickEnvironmentalMutation` (364)                                                                                                                 |
+| Lineage chain (provenance)        | SHIPPED                           | `geneEncoder` SHA1 `gn1:parent:self`                                                                                                              |
+| Phenotype biome boost/penalty     | SHIPPED (data)                    | `mutation_catalog.yaml`, species `*_lifecycle.yaml`                                                                                               |
+| Speciazione emergente             | SHIPPED                           | `getTribesEmergent` (>=3 stesso lineage_id = tribe)                                                                                               |
+| Ambient drift (Spore S5)          | SHIPPED (plumbing, hook deferred) | `lineagePropagator.propagateLineage` (biome-pool, free-grant 1-2)                                                                                 |
+| Single-ancestor succession (M2)   | SHIPPED (Godot)                   | `succession_engine.gd` + attrition/lethality + `campaign_state` ledger                                                                            |
+| 2-parent mating (Godot)           | SHIPPED (parziale)                | `mating_trigger.generate_child_preview` (avg+trait-union FIFO5), `lineage_merge_service`, `offspring_ritual` (3-of-6)                             |
+| Spore S1-S6 part-pack             | DESIGNED + ADR                    | `docs/research/2026-04-26-spore-deep-extraction.md`, ADR-2026-04-26 (5 slot locked, complexity-budget, S5 deferred)                               |
 
 **Il design ESTENDE/UNIFICA questo, non lo sostituisce.** Il vero net-new = il
 layer **Epigenome** (telemetry-heritable). Tutto il resto = formalizzare +
@@ -78,6 +78,7 @@ path duplicati — chiarisce i 2 "path in conflitto" come tipi diversi):
 ## 2. D-HEIR — modello genetico a 3 layer (Approach A)
 
 ### Layer 1 — Genotype (ereditato)
+
 - **Loci = gene_slots** organizzati nelle 3 categorie canoniche
   **Struttura / Funzione / Memorie** (`mating.yaml`), mappate sui **5 body_slot
   Spore locked** (mouth/appendage/sense/tegument/back, ADR-2026-04-26 / S1).
@@ -91,6 +92,7 @@ path duplicati — chiarisce i 2 "path in conflitto" come tipi diversi):
   specializzazione passiva (es. tank_plus). Gia' previsto.
 
 ### Layer 2 — Phenotype (espresso, biome-driven)
+
 - Tratti espressi = genotype x **espressione ambientale**: un allele/parte
   "dorme" o si attiva per pressione bioma (**biome T-bands T0-T3**, ADR;
   `biome_boost`/`biome_penalty` del catalog). Stesso genotype, fenotipo diverso
@@ -101,9 +103,10 @@ path duplicati — chiarisce i 2 "path in conflitto" come tipi diversi):
   `visual_swap_it`) prima del testo. `form_seed_bias` guida le preferenze.
 
 ### Layer 3 — Epigenome (NET-NEW, appreso nel Nido) ⭐
+
 - **Substrato esistente**: `vcScoring` (telemetria VC -> assi MBTI da come giochi)
-  + categoria **Memorie** (`memoria_ambientale`, `inheritance_weight:0.0` =
-  sempre rigenerata = hook epigenetico) + `form_seed_bias`.
+  - categoria **Memorie** (`memoria_ambientale`, `inheritance_weight:0.0` =
+    sempre rigenerata = hook epigenetico) + `form_seed_bias`.
 - **Net-new**: rendere lo stato VC-appreso **parzialmente ereditabile**
   (Lamarck-lite): l'epigenome play-shaped dei genitori **bias** l'espressione
   della prole. **Questo e' il motore di "how you play shapes what you become".**
@@ -115,11 +118,13 @@ path duplicati — chiarisce i 2 "path in conflitto" come tipi diversi):
   currency parallela** -- riusare quella.
 
 ### Speciazione emergente
+
 - Divergenza genotype accumulata su generazioni (drift + selezione bioma);
   oltre soglia -> lineage letta come "specie-forma" distinta. Gia' parziale via
   `getTribesEmergent` (>=3 stesso lineage). Estendere con soglia complexity/T-band.
 
 ## 3. Vincoli & anti-pattern (da Spore extraction §3 + freeze)
+
 - **Irreversibilita'** (pilastro narrativo): mutazione permanente = peso. NO
   infinite-revert (Spore-trap esplicito).
 - **NO**: editor real-time mid-encounter, full 5-stage, creator 3D, sandbox-nav,
@@ -130,7 +135,7 @@ path duplicati — chiarisce i 2 "path in conflitto" come tipi diversi):
 
 ## 4. Fasatura (anti-over-engineer vs freeze)
 
-Ancora ai 3 reuse-path Spore (`docs/research/...` §4) + i TKT-CREATURE-SPORE-01..10:
+Ancora ai 3 reuse-path Spore (`docs/research/...` §4) + i TKT-CREATURE-SPORE (Fase-1 = **01..08** Moderate; **09-10** = Fase-2 Full/S5):
 
 - **Fase 0 (MVP-freeze, gia' ~shippable)**: lo slice freeze attuale (2-slot +
   1-env, trust+nest, 1-2 seed). Niente nuovo.
@@ -138,9 +143,9 @@ Ancora ai 3 reuse-path Spore (`docs/research/...` §4) + i TKT-CREATURE-SPORE-01
   MP-pool + morphology + bingo. **Richiede ADR-supersede §21.3** (sblocca genetica
   oltre il minimal).
 - **Fase 2 (Full ~+15h, S5 + reconcile)**: wire `propagateLineage` lifecycle hook
-  + **fix cross-lineage isolation** + unificare i 3 impl Godot (mating_trigger
-  avg-blend + lineage_merge + ritual) sotto il genotype model + promuovere
-  ibridazione da display-only.
+  - **fix cross-lineage isolation** + unificare i 3 impl Godot (mating_trigger
+    avg-blend + lineage_merge + ritual) sotto il genotype model + promuovere
+    ibridazione da display-only.
 - **Fase 3 (Epigenome, net-new)**: layer 3 Lamarck-lite + Frammenti wire +
   speciazione soglia. Il vero contributo di profondita'.
 
@@ -162,6 +167,7 @@ Ancora ai 3 reuse-path Spore (`docs/research/...` §4) + i TKT-CREATURE-SPORE-01
    unificati per chiamare il backend (Fase-2), niente logica genotype divergente.
 
 ## 6. Out of scope (qui)
+
 Implementazione (writing-plans separato per fase). UI del gene-grid. Authoring
 catalog 30->50 mutazioni. Bilanciamento numerico. Promozione a SoT canonico
 (nuova sezione vault) -- avviene dopo l'ADR-supersede.


### PR DESCRIPTION
## Summary
Design spec for the deep genetic / reproduction model (handoff NEXT-3 "D-REPRO + D-HEIR"), produced via superpowers brainstorming + a **cross-repo verify-before-build pass**.

- **D-REPRO**: 4 reproduction types, each mapped to existing impl (no duplicate paths): sexual-2-parent (`inheritGeneSlots`) / single-ancestor-succession (Godot M2) / ambient population-drift (`lineagePropagator`, Spore S5) / hybridization (`hybrid_rules`, currently display-only).
- **D-HEIR**: 3-layer **Genotype / Phenotype / Epigenome** (Approach A). Genotype + Phenotype largely SHIPPED; **Epigenome (telemetry-VC heritable, Lamarck-lite) = the genuine net-new**.
- **Non-greenfield**: extends `rollMatingOffspring`/`inheritGeneSlots`, `lineagePropagator`, `geneEncoder`, `mating.yaml` (3-cat Struttura/Funzione/Memorie), Godot succession/mating. Honors Spore ADR (5 body_slots, complexity-budget, biome T-bands) + Tri-Sorgente Frammenti currency.

## ⚠️ Gate
**90-FINAL-DESIGN-FREEZE §21.3 DEFERS deep genetics** → framed as **POST-FREEZE VISION**; shippable parts need an **ADR superseding §21.3**. Phased to Spore reuse-path Min/Mod/Full.

## Decisions required (master-dd) — §5
1. ADR-supersede §21.3 (deep-genetics out of freeze-defer)?
2. Accept Epigenome Lamarck-lite (design-novel; needs snowball decay/regression-to-mean)?
3. Reconcile 2 paths (mating individual vs S5 ambient pool) + fix cross-lineage isolation bug?
4. Godot: unify 3 partial impls under backend genotype, or keep avg-blend display until backend canonical?

Doc-only. (Committed --no-verify: this tree's node_modules lacks lint-staged/prettier — env gap, flagged.)