### PR TITLE
feat(spore-fase1): RECON-02 populate 12 derived_ability_id (S2)

### DIFF
--- a/data/core/mutations/mutation_catalog.yaml
+++ b/data/core/mutations/mutation_catalog.yaml
@@ -36,7 +36,7 @@ mutations:
       add: [artigli_sghiaccio_glaciale]
     pe_cost: 12
     pi_cost: 6
-    derived_ability_id: null
+    derived_ability_id: artigli_sghiaccio_glaciale
     mp_cost: 8
     biome_boost: [cryosteppe, caldera_glaciale]
     biome_penalty: [deserto_caldo, dorsale_termale_tropicale]
@@ -116,7 +116,7 @@ mutations:
       add: [denti_chelatanti]
     pe_cost: 10
     pi_cost: 5
-    derived_ability_id: null
+    derived_ability_id: denti_chelatanti
     mp_cost: 8
     biome_boost: [palude, foresta_acida]
     biome_penalty: [pianura_salina_iperarida]
@@ -233,7 +233,7 @@ mutations:
       add: [circolazione_supercritica]
     pe_cost: 25
     pi_cost: 12
-    derived_ability_id: null
+    derived_ability_id: circolazione_supercritica
     mp_cost: 15
     biome_boost: [savana, badlands, abisso_vulcanico]
     biome_penalty: [cryosteppe, caldera_glaciale]
@@ -271,7 +271,7 @@ mutations:
       add: [canto_di_richiamo]
     pe_cost: 12
     pi_cost: 8
-    derived_ability_id: null
+    derived_ability_id: canto_di_richiamo
     mp_cost: 8
     biome_boost: [foresta_temperata, foresta_miceliale, canyons_risonanti]
     biome_penalty: [deserto_caldo, pianura_salina_iperarida]
@@ -309,7 +309,7 @@ mutations:
       add: [aura_di_dispersione_mentale]
     pe_cost: 12
     pi_cost: 8
-    derived_ability_id: null
+    derived_ability_id: aura_di_dispersione_mentale
     mp_cost: 8
     biome_boost: [rovine_planari, mezzanotte_orbitale, frattura_abissale_sinaptica]
     biome_penalty: []
@@ -354,7 +354,7 @@ mutations:
       add: [occhi_cristallo_modulare]
     pe_cost: 12
     pi_cost: 6
-    derived_ability_id: null
+    derived_ability_id: occhi_cristallo_modulare
     mp_cost: 8
     biome_boost: [rovine_planari, steppe_algoritmiche, mezzanotte_orbitale]
     biome_penalty: [foresta_miceliale, foresta_acida]
@@ -392,7 +392,7 @@ mutations:
       add: [antenne_plasmatiche_tempesta]
     pe_cost: 25
     pi_cost: 15
-    derived_ability_id: null
+    derived_ability_id: antenne_plasmatiche_tempesta
     mp_cost: 15
     biome_boost: [stratosfera_tempestosa, canopia_ionica]
     biome_penalty: [caverna, abisso_vulcanico]
@@ -436,7 +436,7 @@ mutations:
       add: [ali_solari_fotoni]
     pe_cost: 12
     pi_cost: 7
-    derived_ability_id: null
+    derived_ability_id: ali_solari_fotoni
     mp_cost: 8
     biome_boost: [altipiani_solari, deserto_caldo, stratosfera_tempestosa]
     biome_penalty: [caverna, abisso_vulcanico]
@@ -560,7 +560,7 @@ mutations:
       add: [epidermide_dielettrica]
     pe_cost: 10
     pi_cost: 5
-    derived_ability_id: null
+    derived_ability_id: epidermide_dielettrica
     mp_cost: 8
     biome_boost: [stratosfera_tempestosa, canopia_ionica, mezzanotte_orbitale]
     biome_penalty: [foresta_temperata, foresta_miceliale]
@@ -597,7 +597,7 @@ mutations:
       add: [branchie_metalloidi]
     pe_cost: 12
     pi_cost: 6
-    derived_ability_id: null
+    derived_ability_id: branchie_metalloidi
     mp_cost: 8
     biome_boost: [reef_luminescente, atollo_obsidiana, abisso_vulcanico]
     biome_penalty: [pianura_salina_iperarida, deserto_caldo]
@@ -629,7 +629,7 @@ mutations:
       add: [capillari_fotovoltaici]
     pe_cost: 12
     pi_cost: 6
-    derived_ability_id: null
+    derived_ability_id: capillari_fotovoltaici
     mp_cost: 8
     biome_boost: [altipiani_solari, deserto_caldo, stratosfera_tempestosa]
     biome_penalty: [abisso_vulcanico, caverna]
@@ -804,7 +804,7 @@ mutations:
       add: [coda_frusta_cinetica]
     pe_cost: 25
     pi_cost: 12
-    derived_ability_id: null
+    derived_ability_id: coda_frusta_cinetica
     mp_cost: 15
     biome_boost: [savana, badlands, foresta_temperata]
     biome_penalty: []

--- a/tests/api/mutations.derived-ability.test.js
+++ b/tests/api/mutations.derived-ability.test.js
@@ -1,0 +1,102 @@
+// RECON-02 (Fase-1 Spore) — derived_ability_id emergence contract.
+//
+// S2 part->ability: when a mutation catalog entry has a non-null
+// `derived_ability_id`, applying it must surface that id on the response AND
+// unlock it into `unit.abilities[]` (applyMutationPure, mutationEngine.js:161-167).
+//
+// RECON-02 populated 12/36 entries (cross-category, non-symbiotic,
+// non-Manual_apply_only). The remaining 24 stay null (partial authoring debt,
+// documented). This test locks the emergence wiring.
+//
+// Placed in tests/api/ (route-level integration) because scripts/run-test-api.cjs
+// globs `tests/api/*.test.js`; tests/services/ is NOT in any CI runner glob
+// (same orphaned-glob finding as RECON-04a ripple-audit §3.3). The route path
+// exercises the full wiring (route -> applyMutationPure -> catalog).
+//
+// G4 tdd-guard: characterization of shipped wiring + new content (GREEN by
+// design). Content-only ticket bypass per plan §G4 Option B.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+test('POST /apply: populated derived_ability_id unlocks into unit.abilities (S2)', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    // denti_bleed_to_chelate -> derived_ability_id: denti_chelatanti (RECON-02).
+    const unit = {
+      id: 'u-da',
+      trait_ids: ['denti_seghettati'],
+      applied_mutations: [],
+      mp: 20,
+    };
+    const res = await request(app)
+      .post('/api/v1/mutations/apply')
+      .send({ unit, mutation_id: 'denti_bleed_to_chelate' })
+      .expect(200);
+
+    assert.equal(
+      res.body.derived_ability_id,
+      'denti_chelatanti',
+      'derived ability surfaced on response',
+    );
+    assert.ok(Array.isArray(res.body.unit.abilities), 'abilities array present on updated unit');
+    assert.ok(
+      res.body.unit.abilities.includes('denti_chelatanti'),
+      'derived ability unlocked into unit.abilities[]',
+    );
+  } finally {
+    await close();
+  }
+});
+
+test('POST /apply: derived ability not duplicated when already present (idempotent unlock)', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const unit = {
+      id: 'u-da-idem',
+      trait_ids: ['denti_seghettati'],
+      applied_mutations: [],
+      abilities: ['denti_chelatanti'],
+      mp: 20,
+    };
+    const res = await request(app)
+      .post('/api/v1/mutations/apply')
+      .send({ unit, mutation_id: 'denti_bleed_to_chelate' })
+      .expect(200);
+
+    const count = res.body.unit.abilities.filter((a) => a === 'denti_chelatanti').length;
+    assert.equal(count, 1, 'ability present exactly once (no duplicate)');
+  } finally {
+    await close();
+  }
+});
+
+test('POST /apply: un-populated mutation yields null derived_ability_id (partial-authoring back-compat)', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    // occhi_tension_to_kinetic stays derived_ability_id: null (24/36 unpopulated).
+    const unit = {
+      id: 'u-null',
+      trait_ids: ['occhi_analizzatori_di_tensione'],
+      applied_mutations: [],
+      mp: 20,
+    };
+    const res = await request(app)
+      .post('/api/v1/mutations/apply')
+      .send({ unit, mutation_id: 'occhi_tension_to_kinetic' })
+      .expect(200);
+
+    assert.equal(res.body.derived_ability_id, null, 'null derived id when not authored');
+    const abilities = res.body.unit.abilities || [];
+    assert.ok(
+      !abilities.includes('occhi_cinetici'),
+      'no synthetic ability unlocked for null entry',
+    );
+  } finally {
+    await close();
+  }
+});


### PR DESCRIPTION
## RECON-02 (Fase-1 Spore Moderate, Wave-2 serial)

Close S2 emergent-ability content gap: **12/36** catalog entries populated (was 0/36 null).

### Design decision (Option A, documented)
`derived_ability_id` = `trait_swap.add` trait id — the new trait carries the active combat `effect` = the emergent ability. **All 12 verified to exist as keys in `data/core/traits/active_effects.yaml`** (zero dangling refs).

Option B ("invent new ability tokens" e.g. `bite_chelate`) **rejected**: would require an abilities registry that does not exist → the exact escalation the plan risk-row flagged. `active_effects.yaml` is `traits:`-keyed with no separate ability namespace; runtime (`applyMutationPure` mutationEngine.js:161-167) appends the id to `unit.abilities[]` with no apply-time registry validation.

### Selection (balanced cross-category 3/3/3/3)
tier 2-3, skip symbiotic (`body_slot: null`), skip Manual_apply_only (`trigger_conditions: []`):

| category | mutations |
|---|---|
| physiological | denti_bleed_to_chelate, artigli_freeze_to_glacier, coda_kinetic_chain |
| behavioral | rage_simple_to_super, voice_panic_to_summon, intimidator_to_dispersal |
| sensorial | eyes_kinetic_to_crystal, antenne_track_to_storm, wings_ion_to_solar |
| environmental | pelle_burn_to_dielectric, branchie_metalloid_upgrade, capillari_to_photovoltaic |

Remaining **24/36 stay null** (partial authoring debt, documented — NOT Fase-1 blocker; RECON-03b territory).

### Tests + gates
- `tests/api/mutations.derived-ability.test.js` (3 PASS): populated→`unit.abilities[]` unlock, idempotent no-dup, null back-compat.
- Placed `tests/api/` (CI-globbed). `tests/services/` is NOT in any runner glob (RECON-04a §3.3 finding) — route-level integration exercises full wiring.
- Linter Pattern-6: **36/36 PASS**. Full mutation suite: **50/50 PASS**.
- **G1 schema-ripple SAFE**: RECON-04a confirmed zero downstream coupling; populating a nullable field leaves consumer null-branch unchanged.
- **G4 tdd-guard**: content + characterization; one-test-at-a-time honored (Write-hook active despite plan "no tool").

### Diff
- `data/core/mutations/mutation_catalog.yaml`: 12 `derived_ability_id` field changes (surgical, prettier-conformant, no description edits — DoD doesn't require, keeps review clean).
- `tests/api/mutations.derived-ability.test.js`: new (3 tests).

### Merge
Draft. Eduardo-mediated merge (oversight gate).

Ref: plan `docs/superpowers/plans/2026-05-26-fase1-spore-moderate-reconciliation-plan.md` §RECON-02 + handoff §15.