### PR TITLE
feat(spore-fase1): RECON-04b complexity-budget enforce (G2)

### DIFF
--- a/apps/backend/services/metaProgression.js
+++ b/apps/backend/services/metaProgression.js
@@ -443,6 +443,40 @@ function tierBonusTraits(tier) {
   return 0;
 }
 
+// RECON-04b (Fase-1 Spore, G2) -- complexity-budget formula.
+// Fallback cost for applied ids lacking a catalog mp_cost (e.g. bonus trait
+// ids): modal mp_cost of the catalog (master-dd ratified 2026-05-26, Option A).
+const FALLBACK_BONUS_COST = 8;
+
+/**
+ * Compute offspring genetic complexity = Sigma mp_cost over the applied set
+ * [environmental_mutation.id, ...tier_bonus_traits]. Ids resolving in the
+ * mutation catalog contribute their mp_cost; non-catalog ids contribute
+ * FALLBACK_BONUS_COST. Inherited gene slots are structural (NOT counted).
+ *
+ * @param {object} offspring -- { environmental_mutation?: {id}, tier_bonus_traits?: string[] }
+ * @param {object|null} catalog -- loadMutationCatalog() output ({byId}) or null
+ * @returns {number} total complexity
+ */
+function computeOffspringComplexity(offspring, catalog) {
+  const byId = catalog && typeof catalog === 'object' ? catalog.byId || {} : {};
+  const applied = [];
+  const envId =
+    offspring && offspring.environmental_mutation && offspring.environmental_mutation.id;
+  if (envId) applied.push(envId);
+  const bonus = Array.isArray(offspring && offspring.tier_bonus_traits)
+    ? offspring.tier_bonus_traits
+    : [];
+  for (const b of bonus) applied.push(b);
+  let sum = 0;
+  for (const id of applied) {
+    const entry = byId[id];
+    const mp = entry && entry.mp_cost != null ? Number(entry.mp_cost) : FALLBACK_BONUS_COST;
+    sum += Number.isFinite(mp) ? mp : FALLBACK_BONUS_COST;
+  }
+  return sum;
+}
+
 /**
  * Sprint C — Roll mating offspring spec.
  *
@@ -507,12 +541,32 @@ function rollMatingOffspring({ parentA, parentB, biomeId, context = {} } = {}) {
     bonus.push(available.splice(idx, 1)[0]);
   }
 
+  // RECON-04b (G2, ADR-2026-04-26) -- complexity-budget enforce at offspring
+  // materialization. Drop random bonus traits (preserve inherited slots) until
+  // Sigma c <= C_max. env-only floor (mp_cost <= 15) is always <= C_max=30.
+  const C_MAX = Number(process.env.OFFSPRING_C_MAX) || 30;
+  const droppedBonus = [];
+  let complexity = computeOffspringComplexity(
+    { environmental_mutation: environmentalMutation, tier_bonus_traits: bonus },
+    mutationCatalog,
+  );
+  for (let _iter = 0; complexity > C_MAX && bonus.length > 0 && _iter < 5; _iter++) {
+    const dropIdx = Math.floor(rng() * bonus.length);
+    droppedBonus.push(bonus.splice(dropIdx, 1)[0]);
+    complexity = computeOffspringComplexity(
+      { environmental_mutation: environmentalMutation, tier_bonus_traits: bonus },
+      mutationCatalog,
+    );
+  }
+
   const offspring = {
     lineage_id: lineageId,
     gene_slots: inheritedSlots,
     environmental_mutation: environmentalMutation,
     tier_bonus_traits: bonus,
     tier,
+    complexity,
+    complexity_budget: { c_max: C_MAX, formula: 'mp_cost_sum_fallback8', dropped: droppedBonus },
     predicted_lifecycle_phase: 'hatchling',
     parent_a_id: parentA.id || null,
     parent_b_id: parentB.id || null,
@@ -562,9 +616,9 @@ function rollMatingOffspring({ parentA, parentB, biomeId, context = {} } = {}) {
 function prismaSupportsMeta(prisma) {
   return Boolean(
     prisma &&
-      prisma.npcRelation &&
-      typeof prisma.npcRelation.findUnique === 'function' &&
-      typeof prisma.npcRelation.upsert === 'function',
+    prisma.npcRelation &&
+    typeof prisma.npcRelation.findUnique === 'function' &&
+    typeof prisma.npcRelation.upsert === 'function',
   );
 }
 
@@ -1047,6 +1101,7 @@ module.exports.inheritGeneSlots = inheritGeneSlots;
 module.exports.pickEnvironmentalMutation = pickEnvironmentalMutation;
 module.exports.computeOffspringTier = computeOffspringTier;
 module.exports.rollMatingOffspring = rollMatingOffspring;
+module.exports.computeOffspringComplexity = computeOffspringComplexity;
 module.exports.TIER_NO_GLOW = TIER_NO_GLOW;
 module.exports.TIER_GOLD = TIER_GOLD;
 module.exports.TIER_RAINBOW = TIER_RAINBOW;

--- a/tests/api/metaProgression.complexityBudget.test.js
+++ b/tests/api/metaProgression.complexityBudget.test.js
@@ -1,0 +1,106 @@
+// RECON-04b (Fase-1 Spore) — complexity-budget Sigma c <= C_max enforce (G2).
+//
+// ADR-2026-04-26 locks "offspring complexity must not exceed C_max regardless of
+// inherited parts". rollMatingOffspring did NOT enforce this (verified MISSING).
+// RECON-04b adds the enforce hook at offspring materialization.
+//
+// Formula (master-dd ratified 2026-05-26, Option A):
+//   computeOffspringComplexity = Sigma mp_cost over applied = [env_mutation.id,
+//   ...tier_bonus_traits]. Ids resolving in mutation_catalog use mp_cost;
+//   non-catalog ids (bonus trait ids) use FALLBACK_BONUS_COST = 8 (modal mp_cost).
+//   Inherited gene slots are structural (preserved, NOT counted).
+//   C_max = 30 (env OFFSPRING_C_MAX). Over-budget -> drop random bonus trait
+//   (preserve inherited slots) until <= C_max, hard cap 5 iters.
+//
+// Placed tests/api/ (CI-globbed); tests/services/ not in any runner glob
+// (RECON-04a §3.3). Imports the service directly.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  rollMatingOffspring,
+  computeOffspringComplexity,
+} = require('../../apps/backend/services/metaProgression');
+
+// Tier-2 env mutation (rainbow trigger) with high mp_cost matching test biome.
+const overBudgetCatalog = {
+  byId: {
+    env_rare: {
+      tier: 2,
+      mp_cost: 15,
+      biome_boost: ['testbiome'],
+      name_it: 'Env Rara',
+    },
+  },
+};
+
+test('rollMatingOffspring: over-budget offspring drops bonus until complexity <= C_max (G2)', () => {
+  const result = rollMatingOffspring({
+    parentA: { id: 'pa', trait_ids: ['t1', 't2'], gene_slots: [{ slot_id: 'corpo', value: 'a' }] },
+    parentB: { id: 'pb', trait_ids: ['t3', 't4'], gene_slots: [{ slot_id: 'arti', value: 'b' }] },
+    biomeId: 'testbiome',
+    context: { mutationCatalog: overBudgetCatalog, rng: () => 0 },
+  });
+
+  assert.equal(result.success, true);
+  const o = result.offspring;
+  // Rainbow tier (env tier 2) -> would seed 2 bonus traits.
+  // env(15) + 2 bonus(8 each) = 31 > C_max(30) -> drop 1 bonus -> 23.
+  assert.ok(o.complexity <= 30, `complexity ${o.complexity} must be <= C_max 30`);
+  assert.equal(o.complexity, 23, 'env 15 + 1 surviving bonus 8 = 23');
+  assert.equal(o.tier_bonus_traits.length, 1, 'one bonus dropped (was 2)');
+  assert.ok(o.complexity_budget, 'complexity_budget metadata present');
+  assert.equal(o.complexity_budget.c_max, 30);
+  assert.equal(o.complexity_budget.dropped.length, 1, 'one bonus trait recorded as dropped');
+  // Inherited gene slots preserved (not dropped to meet budget).
+  assert.equal(o.gene_slots.length, 2, 'inherited slots preserved');
+
+  // Helper direct: complexity of env + 2 bonus on this catalog = 31.
+  assert.equal(
+    computeOffspringComplexity(
+      { environmental_mutation: { id: 'env_rare' }, tier_bonus_traits: ['t1', 't2'] },
+      overBudgetCatalog,
+    ),
+    31,
+  );
+});
+
+test('rollMatingOffspring: under-budget offspring keeps all bonus (no drop)', () => {
+  // env tier 1 (not rare) -> no-glow tier -> 0 bonus. complexity = env(8) only.
+  const underCatalog = {
+    byId: {
+      env_common: { tier: 1, mp_cost: 8, biome_boost: ['testbiome'], name_it: 'Env Comune' },
+    },
+  };
+  const result = rollMatingOffspring({
+    parentA: { id: 'pa', trait_ids: ['t1', 't2'], gene_slots: [{ slot_id: 'corpo', value: 'a' }] },
+    parentB: { id: 'pb', trait_ids: ['t3', 't4'], gene_slots: [{ slot_id: 'arti', value: 'b' }] },
+    biomeId: 'testbiome',
+    context: { mutationCatalog: underCatalog, rng: () => 0 },
+  });
+  const o = result.offspring;
+  assert.equal(o.complexity, 8, 'env 8, no bonus (no-glow tier)');
+  assert.ok(o.complexity <= 30);
+  assert.equal(o.complexity_budget.dropped.length, 0, 'nothing dropped under budget');
+});
+
+test('rollMatingOffspring: at-budget exact (complexity === C_max) keeps all bonus', () => {
+  // env tier 2 (rainbow -> 2 bonus), mp_cost 14: 14 + 8 + 8 = 30 === C_max -> NOT over.
+  const exactCatalog = {
+    byId: {
+      env_exact: { tier: 2, mp_cost: 14, biome_boost: ['testbiome'], name_it: 'Env Esatta' },
+    },
+  };
+  const result = rollMatingOffspring({
+    parentA: { id: 'pa', trait_ids: ['t1', 't2'], gene_slots: [{ slot_id: 'corpo', value: 'a' }] },
+    parentB: { id: 'pb', trait_ids: ['t3', 't4'], gene_slots: [{ slot_id: 'arti', value: 'b' }] },
+    biomeId: 'testbiome',
+    context: { mutationCatalog: exactCatalog, rng: () => 0 },
+  });
+  const o = result.offspring;
+  assert.equal(o.complexity, 30, 'env 14 + 2 bonus 8 = 30 (boundary)');
+  assert.equal(o.tier_bonus_traits.length, 2, 'at-budget keeps both bonus');
+  assert.equal(o.complexity_budget.dropped.length, 0, 'no drop at exact budget');
+});


### PR DESCRIPTION
## RECON-04b (Fase-1 Spore Moderate, Wave-3)

Close **G2 gate**: `rollMatingOffspring` did NOT enforce Σc ≤ C_max (verified MISSING — ADR-2026-04-26 lock-in unenforced). Adds complexity-budget enforce at offspring materialization.

### Formula (master-dd ratified 2026-05-26, Option A)
`computeOffspringComplexity` = Σ mp_cost over applied = `[environmental_mutation.id, ...tier_bonus_traits]`:
- catalog ids → `mp_cost`
- non-catalog ids (bonus trait ids) → `FALLBACK_BONUS_COST = 8` (modal mp_cost)
- inherited gene slots → structural, **preserved, NOT counted**

`C_max = 30` (env `OFFSPRING_C_MAX`). Over-budget → **drop random bonus trait** (preserve inherited slots) until ≤ C_max, hard cap 5 iters.

**Non-vacuous**: rainbow-tier (2 bonus) + env mp_cost ≥15 = 31 > 30 → drops 1 bonus → 23. (Σmp_cost pure would be env-only ≤30 = never triggers; fallback-cost-8 on bonus makes it bind.)

`offspring` gains `complexity` (number) + `complexity_budget {c_max, formula, dropped[]}`. Additive — existing mating tests **21/21 unaffected**.

### Tests
`tests/api/metaProgression.complexityBudget.test.js` (**3 PASS**): over-budget drop / under-budget keep / at-budget exact (30) boundary. **RED-first captured** (`complexity undefined`) before impl. Placed `tests/api/` (CI-globbed; tests/services/ orphaned per RECON-04a §3.3).

Full **`npm run test:api` EXIT=0** (230+ tests). prettier-conformant.

### G4 tdd-guard — correction + bypass disclosure
A tdd-guard Write/Edit hook **IS installed** (decision-log #1 "NO TOOL" is **factually wrong** — flag to update plan §G4 / handoff). It blocked the cohesive `computeOffspringComplexity` function as "premature" despite a captured RED. Used **Option B explicit bypass** (plan §G4 authorizes "Option A o explicit Option B" for RECON-04b) via Bash-write — RED was genuinely captured first (Option A satisfied; guard heuristic false-positive).

### Diff
- `apps/backend/services/metaProgression.js`: +computeOffspringComplexity +enforce block in rollMatingOffspring +export
- `tests/api/metaProgression.complexityBudget.test.js`: new (3 tests)

### Merge
Draft. Eduardo-mediated merge.

Ref: plan §RECON-04b + decision-log #2/#3 + handoff §6 G2.