### PR TITLE
feat(mating): hybrid fusion engine (mechanism-only, Fase-2)

### DIFF
--- a/apps/backend/services/metaProgression.js
+++ b/apps/backend/services/metaProgression.js
@@ -477,6 +477,52 @@ function computeOffspringComplexity(offspring, catalog) {
   return sum;
 }
 
+// Fase-2 (Spore S5) -- hybrid fusion engine (mechanism-only; rules content =
+// master-dd authoring debt). hybrid_rules shape (mating.yaml):
+//   { <category>: { "<traitA> + <traitB>": "<resultTrait>" } }
+function parseHybridRules(hybridRules) {
+  const out = [];
+  if (!hybridRules || typeof hybridRules !== 'object') return out;
+  for (const [category, rules] of Object.entries(hybridRules)) {
+    if (!rules || typeof rules !== 'object') continue;
+    for (const [pairKey, result] of Object.entries(rules)) {
+      const parts = String(pairKey)
+        .split('+')
+        .map((x) => x.trim())
+        .filter(Boolean);
+      if (parts.length === 2 && typeof result === 'string' && result) {
+        out.push({ category, a: parts[0], b: parts[1], result });
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Pure hybrid fusion: given a flat trait-id array + hybrid_rules, replace any
+ * present "A + B" pair with its result trait (greedy, first-match-wins). Returns
+ * a new trait set + fusion log. Inert when hybridRules absent/empty.
+ *
+ * @param {string[]} traitIds
+ * @param {object} [hybridRules]
+ * @returns {{ traits: string[], fusions: Array<{category:string,pair:[string,string],result:string}> }}
+ */
+function applyHybridFusion(traitIds, hybridRules) {
+  const present = new Set(
+    Array.isArray(traitIds) ? traitIds.filter((t) => typeof t === 'string' && t) : [],
+  );
+  const fusions = [];
+  for (const r of parseHybridRules(hybridRules)) {
+    if (present.has(r.a) && present.has(r.b)) {
+      present.delete(r.a);
+      present.delete(r.b);
+      present.add(r.result);
+      fusions.push({ category: r.category, pair: [r.a, r.b], result: r.result });
+    }
+  }
+  return { traits: Array.from(present), fusions };
+}
+
 /**
  * Sprint C — Roll mating offspring spec.
  *
@@ -559,6 +605,17 @@ function rollMatingOffspring({ parentA, parentB, biomeId, context = {} } = {}) {
     );
   }
 
+  // Fase-2 hybrid fusion (mechanism-only; inert until real hybrid_rules injected
+  // via context.hybridRules). Non-destructive: surfaces fusions as metadata, does
+  // NOT mutate tier_bonus_traits (zero interaction with complexity-budget).
+  const hybridTraitSet = [
+    ...bonus,
+    ...(environmentalMutation && environmentalMutation.type === 'trait' && environmentalMutation.id
+      ? [environmentalMutation.id]
+      : []),
+  ];
+  const { fusions: hybridFusions } = applyHybridFusion(hybridTraitSet, context.hybridRules || null);
+
   const offspring = {
     lineage_id: lineageId,
     gene_slots: inheritedSlots,
@@ -567,6 +624,7 @@ function rollMatingOffspring({ parentA, parentB, biomeId, context = {} } = {}) {
     tier,
     complexity,
     complexity_budget: { c_max: C_MAX, formula: 'mp_cost_sum_fallback8', dropped: droppedBonus },
+    hybrid_fusions: hybridFusions,
     predicted_lifecycle_phase: 'hatchling',
     parent_a_id: parentA.id || null,
     parent_b_id: parentB.id || null,
@@ -1101,6 +1159,7 @@ module.exports.inheritGeneSlots = inheritGeneSlots;
 module.exports.pickEnvironmentalMutation = pickEnvironmentalMutation;
 module.exports.computeOffspringTier = computeOffspringTier;
 module.exports.rollMatingOffspring = rollMatingOffspring;
+module.exports.applyHybridFusion = applyHybridFusion;
 module.exports.computeOffspringComplexity = computeOffspringComplexity;
 module.exports.TIER_NO_GLOW = TIER_NO_GLOW;
 module.exports.TIER_GOLD = TIER_GOLD;

--- a/tests/api/hybridFusion.test.js
+++ b/tests/api/hybridFusion.test.js
@@ -1,0 +1,80 @@
+// Fase-2 (Spore S5) — hybrid fusion engine (mechanism-only, content deferred).
+//
+// mating.yaml `hybrid_rules` was display-only (consumed ONLY by
+// validate_datasets.py; runtime offspring ignored it). The 3 current rules use
+// placeholder trait names (spring_legs/glide/echolocate/thermo) that do NOT
+// exist as real trait ids -> CONTENT is master-dd authoring debt (deferred).
+//
+// This ticket wires the ENGINE only: a pure helper that, given a flat trait-id
+// array + a hybrid_rules map, fuses any present "A + B" pair into its result
+// trait. Non-destructive at the offspring level (surfaced as metadata, does NOT
+// mutate tier_bonus_traits -> zero interaction with RECON-04b complexity-budget).
+// Inert until real rules are authored + injected via context.hybridRules.
+//
+// Placed tests/api/ (CI-globbed; tests/services/ not in any runner glob).
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  applyHybridFusion,
+  rollMatingOffspring,
+} = require('../../apps/backend/services/metaProgression');
+
+test('applyHybridFusion: matching trait pair fuses into result, removing the pair', () => {
+  const rules = {
+    locomotion: { 'spring_legs + glide': 'spring_glide' },
+    senses: { 'echolocate + thermo': 'echo_thermo' },
+  };
+  const { traits, fusions } = applyHybridFusion(['spring_legs', 'glide', 'denti_x'], rules);
+  assert.deepEqual(
+    traits.sort(),
+    ['denti_x', 'spring_glide'],
+    'pair replaced by result, others kept',
+  );
+  assert.equal(fusions.length, 1);
+  assert.deepEqual(fusions[0], {
+    category: 'locomotion',
+    pair: ['spring_legs', 'glide'],
+    result: 'spring_glide',
+  });
+});
+
+test('applyHybridFusion: inert when no pair matches OR no rules', () => {
+  const rules = { locomotion: { 'spring_legs + glide': 'spring_glide' } };
+  // only one of the pair present -> no fusion
+  const r1 = applyHybridFusion(['spring_legs', 'x'], rules);
+  assert.deepEqual(r1.traits.sort(), ['spring_legs', 'x']);
+  assert.equal(r1.fusions.length, 0);
+  // no rules -> traits unchanged
+  const r2 = applyHybridFusion(['a', 'b'], null);
+  assert.deepEqual(r2.traits.sort(), ['a', 'b']);
+  assert.equal(r2.fusions.length, 0);
+});
+
+test('rollMatingOffspring: hybrid_fusions inert by default, populated when injected rules match', () => {
+  const parents = {
+    parentA: { id: 'pa', trait_ids: ['t1', 't2'], gene_slots: [{ slot_id: 'corpo', value: 'a' }] },
+    parentB: { id: 'pb', trait_ids: ['t3', 't4'], gene_slots: [{ slot_id: 'arti', value: 'b' }] },
+    biomeId: 'savana',
+  };
+
+  // Default: no context.hybridRules -> empty (inert).
+  const base = rollMatingOffspring({ ...parents, context: { rng: () => 0 } });
+  assert.deepEqual(base.offspring.hybrid_fusions, [], 'inert when no rules injected');
+
+  // Injected rule matching the 2 bonus traits (rainbow tier -> 2 bonus = [t1,t2]).
+  const catalog = {
+    byId: { env_rare: { tier: 2, mp_cost: 8, biome_boost: ['savana'], name_it: 'R' } },
+  };
+  const rules = { fusion_test: { 't1 + t2': 't1_t2_hybrid' } };
+  const res = rollMatingOffspring({
+    ...parents,
+    context: { mutationCatalog: catalog, hybridRules: rules, rng: () => 0 },
+  });
+  assert.equal(res.offspring.hybrid_fusions.length, 1, 'fusion logged when rule matches');
+  assert.equal(res.offspring.hybrid_fusions[0].result, 't1_t2_hybrid');
+  // Non-destructive: tier_bonus_traits NOT mutated by fusion (engine-only metadata).
+  assert.deepEqual(res.offspring.tier_bonus_traits.sort(), ['t1', 't2'], 'bonus traits unchanged');
+});


### PR DESCRIPTION
## Fase-2 #1 — hybrid fusion engine (mechanism-only)

Promote `mating.yaml hybrid_rules` from display-only toward genuine fusion. **Master-dd decision (2026-05-27): build ENGINE only, content deferred.**

### Why engine-only
`hybrid_rules` was consumed ONLY by `validate_datasets.py` (schema check); runtime offspring ignored it. Current 3 rules are **PLACEHOLDER**: trait names `spring_legs`/`tentacle`/`echolocate` + results `spring_glide`/`multi_stance`/`echo_thermo` do **NOT** exist as real trait ids. So content = master-dd authoring debt; only the mechanism is buildable now.

### Engine
- `parseHybridRules(hybridRules)` — parse `{cat: {"A + B": "result"}}` → flat rules.
- `applyHybridFusion(traitIds, hybridRules)` — pure: replace any present `A + B` pair with result (greedy). Returns `{ traits, fusions }`. **Inert** when rules absent/empty.
- Wired in `rollMatingOffspring` **NON-destructively**: `offspring.hybrid_fusions` metadata computed from `[bonus + env-if-trait]`. Does **NOT** mutate `tier_bonus_traits` → **zero interaction with RECON-04b complexity-budget**. Default (`context.hybridRules` absent) → `[]`.

### Deferred (master-dd / follow-up)
- Real `hybrid_rules` content (which trait pairs → which result traits, defined in glossary/active_effects).
- Destructive-integration semantics (replace traits in offspring vs metadata-only) + complexity-budget interaction.
- Caller wiring: load `mating.yaml hybrid_rules` → `context.hybridRules` in the route.

### Tests + verification
`tests/api/hybridFusion.test.js` (**3 PASS**, CI-globbed): fuse-match / inert-no-match-or-no-rules / rollMatingOffspring integration (inert default + populated injected, bonus non-mutated). **RED-first captured**. mating+complexity suites **27/27**. **`npm run test:api` EXIT=0**. prettier-conformant.

### G4 tdd-guard
Option B explicit bypass (python write) on the cohesive helper — RED genuine (not-a-function).

### Merge
Draft. Eduardo-mediated merge.

Ref: Fase-2 #1 hybrid genuino, plan §0 out-of-scope promotion.