### PR TITLE
docs(reuse): fix dead external-repos backlink + encounter-CLI ticket

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -43,6 +43,14 @@ Note: orphan-agent over-claimed "woundedPerma superseded" — trust-but-verify c
 
 **Tooling:** `tools/py/ancestors_style_guide_proposal.py` v1 — completed migration tooling (ancestors/neurons taxonomy, museum-covered domain). NOT a dead dup to delete — repo-archaeologist museum-card candidate (reuse provenance). KEEP.
 
+### 🔵 REUSE-REVIVAL — encounter-authoring CLI (da Fallout Tactics postmortem, archivio Ryzen 2026-05-28)
+
+Source: reuse-queue triage codemasterdd `KNOWLEDGE_MAP.md` §7 (archivio `ryzen-memory-archive/Game-Desktop-old/reference_tactical_postmortems.md`). Unico pattern tattico genuinamente NON costruito tra gli 11 reference archiviati (prova-di-eliminazione: gli altri = backup già assorbito in SoT/code).
+
+| Ticket | Cosa | Razionale | Stato |
+| ------ | ---- | --------- | ----- |
+| TKT-ENCOUNTER-CLI | `game_cli.py author-encounter` — CLI authoring encounter (numeric spec + vertical-slice playtest loop, pattern Fallout Tactics / Micro Forte 2001) | Sblocca volume content-slice M3 (encounter authoring oggi manuale) | OPEN — master-dd verdict (scope M3 vs defer) |
+
 ### ✅ Ecosystem audit + ai-station Envelope A+B+C cascade — sessione 2026-05-13/14/15 — 14 PR cross-stack shipped
 
 User trigger 2026-05-13: "analizza col metodo tutta l'infrastruttura Ecosistema > ... > evoluzioni" → ecosystem 7-strati audit (495 LOC) + plan 22 ticket TKT-ECO-XX (730 LOC) → 8 OD raised → vault PR #5 ai-station re-analisi → master-dd direction "finish work, not conservative" → cascade 13 PR shipped cross-stack ~26h delivery.

--- a/docs/guide/games-source-index.md
+++ b/docs/guide/games-source-index.md
@@ -245,7 +245,7 @@ review_cycle_days: 90
 
 ## Repo open-source extraction map
 
-> Source: [`reference_external_repos.md`](../../C--Users-VGit-Desktop-Game/memory/reference_external_repos.md) (memory) + [Tier 0 Deep Dive](../../C--Users-VGit-Desktop-Game/memory/reference_tier0_deep_dive.md). 37 repo curati, 4 tier per impatto architetturale.
+> Source: `reference_external_repos.md` + `reference_tier0_deep_dive.md` (Claude memory, archiviati 2026-05-27 in codemasterdd `docs/ryzen-memory-archive/Game-Desktop-old/` -- erano path Ryzen-locale morto, ora preservati in git). 37 repo curati, 4 tier per impatto architetturale.
 
 ### Tier 0 — Analisi immediata
 


### PR DESCRIPTION
## Reuse-queue items B + C (from Ryzen archive triage)

Two docs-only fixes surfaced by a cross-repo knowledge audit (codemasterdd `KNOWLEDGE_MAP.md` §7 reuse-queue).

**B — fix dead backlink** (`docs/guide/games-source-index.md:248`): the "Repo open-source extraction map" Source line pointed to a dead Ryzen-local path (`../../C--Users-VGit-Desktop-Game/memory/...`), unresolvable from any clone. Repointed to the now git-preserved archive in codemasterdd (`docs/ryzen-memory-archive/Game-Desktop-old/`, captured 2026-05-27). The 37-repo table itself is unchanged (already inline 246-324).

**C — TKT-ENCOUNTER-CLI revival ticket** (BACKLOG): `game_cli.py author-encounter` — the one genuinely-unbuilt tactical pattern (Fallout Tactics postmortem) from the 11 archived `reference_*` (the rest = backup already absorbed in SoT/code, per prova-di-eliminazione). Unblocks M3 content-slice volume. **OPEN — master-dd verdict** (scope M3 vs defer), no autonomous build.

Docs-only, no behavior change. Merge per Game governance.

🤖 Generated with Claude Code