### PR TITLE
feat(epigenome): sim paramOverrides + --weight/--alpha (tuning sweep)

### DIFF
--- a/tests/api/epigenomeLineageSim.test.js
+++ b/tests/api/epigenomeLineageSim.test.js
@@ -74,3 +74,28 @@ test('anti-snowball: strong play converges to a bounded fixed point (plateau, un
   );
   assert.equal(r.checks.anti_snowball, true);
 });
+
+test('paramOverrides: higher inheritance_weight raises gen-1 deviation (tuning sweep)', () => {
+  const base = runLineageSim({
+    profile: 'strong_utility',
+    generations: 6,
+    sessionsPerGen: 5,
+    lineages: 40,
+    seed: 7,
+  });
+  const bumped = runLineageSim({
+    profile: 'strong_utility',
+    generations: 6,
+    sessionsPerGen: 5,
+    lineages: 40,
+    seed: 7,
+    paramOverrides: { inheritance_weight: 0.6 },
+  });
+  // deviation is linear in weight: 0.6 vs ratified 0.3 -> ~2x gen-1 deviation.
+  assert.equal(bumped.params.weight, 0.6, 'override must apply to reported params');
+  assert.ok(
+    bumped.checks.gen1_deviation > base.checks.gen1_deviation * 1.8,
+    'doubling weight must ~double gen-1 deviation',
+  );
+  assert.equal(bumped.checks.all_gens_under_cap, true, 'still bounded under cap at weight 0.6');
+});

--- a/tools/sim/epigenome_lineage_sim.js
+++ b/tools/sim/epigenome_lineage_sim.js
@@ -35,8 +35,12 @@ function runLineageSim({
   sessionsPerGen = 5,
   lineages = 40,
   seed = 12345,
+  paramOverrides = {},
 } = {}) {
-  const cfg = eng.loadEpigenomeConfig();
+  // paramOverrides lets a tuning sweep probe non-ratified values (e.g.
+  // inheritance_weight, accumulation_alpha) WITHOUT editing data/core/mating.yaml.
+  // Empty default => ratified config verbatim.
+  const cfg = { ...eng.loadEpigenomeConfig(), ...paramOverrides };
   const conv = PROFILES[profile] || PROFILES.neutral;
 
   const perGen = Array.from({ length: generations }, () => ({
@@ -140,12 +144,16 @@ if (require.main === module) {
     const i = args.indexOf('--' + k);
     return i >= 0 ? args[i + 1] : d;
   };
+  const paramOverrides = {};
+  if (args.includes('--weight')) paramOverrides.inheritance_weight = Number(get('weight'));
+  if (args.includes('--alpha')) paramOverrides.accumulation_alpha = Number(get('alpha'));
   const report = runLineageSim({
     profile: get('profile', 'strong_utility'),
     generations: Number(get('generations', 6)),
     sessionsPerGen: Number(get('sessions-per-gen', 5)),
     lineages: Number(get('lineages', 40)),
     seed: Number(get('seed', 12345)),
+    paramOverrides,
   });
   process.stdout.write(JSON.stringify(report, null, 2) + '\n');
 }


### PR DESCRIPTION
## Summary
Adds optional `paramOverrides` to `runLineageSim` (merged over `loadEpigenomeConfig()`) + CLI `--weight`/`--alpha`, so the lineage sim can probe non-ratified params WITHOUT editing `mating.yaml`. Empty default = ratified config verbatim (back-compat). Enables the perceptibility weight-sweep.

## Test plan
- [x] `node --test tests/api/epigenomeLineageSim.test.js` (5) — incl. new "doubling weight ~doubles gen-1 deviation + still under cap"
- [x] back-compat: zero-arg = ratified config; malformed `--weight` → engine isFinite-guard → 0.3 fallback (graceful)

## Cognitive protocols
- Combined spec+quality review APPROVED. Coding-Agent: claude-opus-4.7