### PR TITLE
feat(epigenome): ratify inheritance_weight 0.3 -> 0.45 (sim perceptibility curve)

### DIFF
--- a/apps/backend/services/genetics/epigenome.js
+++ b/apps/backend/services/genetics/epigenome.js
@@ -175,7 +175,7 @@ const DEFAULT_MATING_PATH = path.resolve(
 
 const EPIGENOME_DEFAULTS = {
   axes: [...AXES],
-  inheritance_weight: 0.3,
+  inheritance_weight: 0.45,
   decay_per_gen: 0.6,
   regression_to_mean: 0.3,
   bias_cap: 0.2,

--- a/data/core/mating.yaml
+++ b/data/core/mating.yaml
@@ -481,7 +481,7 @@ epigenome:
   # playtest N>=40 al build (L-069). Substrato = vcScoring conviction_axis
   # (utility/liberty/morality, 0-100 -> /100; baseline 50 -> species_mean 0.5).
   axes: [utility, liberty, morality]
-  inheritance_weight: 0.3 # bias non copia (< gene-slot 0.4-0.8)
+  inheritance_weight: 0.45 # bias (low end gene-slot 0.4-0.8); 0.3->0.45 ratified 2026-05-28 via sim perceptibility curve (gen-1 felt-shift ~5%->~8%, anti-snowball still holds)
   decay_per_gen: 0.6 # bio transient ~3 gen (0.6^3 ~= 0.22)
   regression_to_mean: 0.3 # tira 30% verso media-specie
   bias_cap: 0.2 # hard-bound DEVIAZIONE da species_mean (anti-runaway)

--- a/docs/research/2026-05-27-epigenome-params-research.md
+++ b/docs/research/2026-05-27-epigenome-params-research.md
@@ -14,6 +14,8 @@ related:
 
 # Epigenome Lamarck-lite params -- research + decision
 
+> **SUPERSEDED 2026-05-28**: `inheritance_weight` 0.3 -> 0.45 (ratified via lineage-sim perceptibility curve; gen-1 felt-shift doubled, anti-snowball unchanged). 0.3 values below are the original ratification record.
+
 ## 0. Scopo (chiude il GATE Decision #2)
 
 Spec Decision #2: "Epigenome Lamarck-lite = ACCETTATO con decay obbligatorio

--- a/docs/superpowers/specs/2026-05-26-repro-heir-genetic-model-design.md
+++ b/docs/superpowers/specs/2026-05-26-repro-heir-genetic-model-design.md
@@ -123,12 +123,12 @@ Decay/regression obbligatori (anti-snowball). **Start-values** (lock finale =
 playtest N>=40 al build Fase-3, L-069). Dettaglio + proof + fonti:
 `docs/research/2026-05-27-epigenome-params-research.md`.
 
-| param                          | start            | nota                                                                 |
-| ------------------------------ | ---------------- | -------------------------------------------------------------------- |
-| `epigenome_inheritance_weight` | 0.3              | bias non copia; < gene-slot 0.4-0.8. `memoria_ambientale` 0.0 -> 0.3 |
-| `epigenome_decay_per_gen`      | 0.6 retention    | bio transient ~3 gen (0.6^3 ~= 0.22)                                 |
-| `epigenome_regression_to_mean` | 0.3              | tira 30% verso media-specie asse VC                                  |
-| `epigenome_bias_cap`           | +/-0.2 / asse VC | hard-bound anti-runaway                                              |
+| param                          | start            | nota                                                                                                                              |
+| ------------------------------ | ---------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `epigenome_inheritance_weight` | 0.45             | bias non copia; < gene-slot 0.4-0.8. `memoria_ambientale` 0.0 -> 0.3 (0.3->0.45 ratified 2026-05-28 via sim perceptibility curve) |
+| `epigenome_decay_per_gen`      | 0.6 retention    | bio transient ~3 gen (0.6^3 ~= 0.22)                                                                                              |
+| `epigenome_regression_to_mean` | 0.3              | tira 30% verso media-specie asse VC                                                                                               |
+| `epigenome_bias_cap`           | +/-0.2 / asse VC | hard-bound anti-runaway                                                                                                           |
 
 Formula (per asse VC, a offspring-materialization):
 

--- a/tests/api/epigenome.test.js
+++ b/tests/api/epigenome.test.js
@@ -187,7 +187,7 @@ const { loadEpigenomeConfig } = require('../../apps/backend/services/genetics/ep
 
 test('loadEpigenomeConfig: reads ratified params + memory map from mating.yaml', () => {
   const cfg = loadEpigenomeConfig();
-  assert.equal(cfg.inheritance_weight, 0.3);
+  assert.equal(cfg.inheritance_weight, 0.45);
   assert.equal(cfg.decay_per_gen, 0.6);
   assert.equal(cfg.regression_to_mean, 0.3);
   assert.equal(cfg.bias_cap, 0.2);

--- a/tests/api/epigenomeLineageSim.test.js
+++ b/tests/api/epigenomeLineageSim.test.js
@@ -82,6 +82,7 @@ test('paramOverrides: higher inheritance_weight raises gen-1 deviation (tuning s
     sessionsPerGen: 5,
     lineages: 40,
     seed: 7,
+    paramOverrides: { inheritance_weight: 0.3 },
   });
   const bumped = runLineageSim({
     profile: 'strong_utility',

--- a/tests/api/epigenomeMatingWire.test.js
+++ b/tests/api/epigenomeMatingWire.test.js
@@ -26,7 +26,7 @@ test('rollMatingOffspring: with config + parent epigenomes -> offspring epigenom
     context: { epigenomeConfig: cfg, speciesMean: { utility: 0.5, liberty: 0.5, morality: 0.5 } },
   });
   assert.equal(r.success, true);
-  assert.ok(Math.abs(r.offspring.epigenome.utility - 0.563) < 1e-9);
+  assert.ok(Math.abs(r.offspring.epigenome.utility - 0.5945) < 1e-9);
   assert.equal(r.offspring.epigenetic_memory.memory_id, 'memoria_efficienza');
   assert.equal(r.offspring.memoria_ambientale.source, 'epigenome');
   // parent bias strength = 0.5 >= grant_threshold 0.1 -> grant 1


### PR DESCRIPTION
## Summary
Master-dd ratified `epigenome_inheritance_weight` **0.3 → 0.45** via the lineage-sim weight-sweep (PR #2408 tool). Rationale: gen-1 felt-shift was ~5% at 0.3 (thin); 0.45 doubles it to ~8% while staying at the low end of the gene-slot band (0.4-0.8) and keeping anti-snowball intact (plateau 0.080 ≪ cap 0.2). Start-value; live human playtest remains the final lock (L-069).

## Changes
- `data/core/mating.yaml` + `epigenome.js` EPIGENOME_DEFAULTS: weight 0.3 → 0.45.
- Test ripple: `loadEpigenomeConfig` assert 0.45; mating-wire offspring.utility 0.563 → **0.5945** (= 0.5 + 0.5·0.7·0.45·0.6); lineage-sim paramOverrides `base` pinned to explicit 0.3 (default-independent). Formula unit test stays at explicit 0.3 (tests the math, not the live value).
- Docs: spec §Layer-3 table → 0.45 + note; research doc → dated SUPERSEDED notice (body kept as original record).

## Sim verification (N=40 @ 0.45)
gen1_deviation 0.0784 · plateau 0.0796 · expression_rate 1.0 · anti_snowball true.

## Test plan
- [x] epigenome (14) + mating-wire (3) + lineage-sim (5) pass
- [x] full `node --test tests/api/*.test.js` = 1329 / 0 fail

## Deferred
- vault SoT §24 may pin weight 0.3 — Eduardo updates sovereign (out of this repo).
- Coding-Agent: claude-opus-4.7