### PR TITLE
ci: ci-gate aggregator to unblock path-filtered required checks (#2410)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -784,6 +784,8 @@ jobs:
     # and passes when every needed job is success-or-skipped, failing only on a
     # real failure/cancellation -- removing the need to admin-merge.
     # Scope = the jobs currently required on main (no new enforcement added).
+    # MAINTENANCE: if you make another job required on main, add it to needs: below
+    # (and vice-versa) -- this list must mirror the branch-protection required set.
     name: ci-gate
     if: always()
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -774,3 +774,35 @@ jobs:
           DEPLOY_CHROMIUM_BUNDLE_ARCHIVE: ${{ runner.temp }}/playwright-bundle/chromium-bundle.tar.gz
           DEPLOY_CHROMIUM_BUNDLE_SHA256: ${{ needs.playwright-bundle.outputs.sha256 }}
         run: scripts/run_deploy_checks.sh
+
+  ci-gate:
+    # Aggregator gate (issue #2410): meant to be the single ci.yml required check
+    # on main. The path-filtered jobs (stack-quality / cli-checks / python-tests /
+    # dataset-checks) report "skipped" when their area is not touched; a skipped
+    # REQUIRED check stays Pending and blocks the merge by design, so a tooling /
+    # CI-only PR can only land via admin override. This gate runs with always()
+    # and passes when every needed job is success-or-skipped, failing only on a
+    # real failure/cancellation -- removing the need to admin-merge.
+    # Scope = the jobs currently required on main (no new enforcement added).
+    name: ci-gate
+    if: always()
+    needs:
+      - paths-filter
+      - stack-quality
+      - cli-checks
+      - python-tests
+      - dataset-checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify no needed job failed (skipped is OK)
+        run: |
+          results="${{ join(needs.*.result, ' ') }}"
+          echo "needs results: $results"
+          for r in $results; do
+            case "$r" in
+              failure|cancelled)
+                echo "::error::a needed job concluded '$r' -> ci-gate fails"
+                exit 1 ;;
+            esac
+          done
+          echo "ci-gate pass (all needed jobs success or skipped)"


### PR DESCRIPTION
Closes #2410.

## Problem
`stack-quality` / `cli-checks` / `python-tests` / `dataset-checks` in `ci.yml` are path-filtered (`if: needs.paths-filter.outputs.X`) AND required on `main`. When a PR does not touch their area they report **skipped** -> the required check stays **Pending** -> `mergeStateStatus: BLOCKED`. Tooling/CI-only PRs can then only land via `gh pr merge --admin` (which bypasses all protections). `governance` already dodges this by running always (docs-governance.yml).

## Change
Adds one job `ci-gate` (`if: always()`, `needs:` the five currently-required ci.yml jobs). It passes when every needed job is **success or skipped**, fails only on **failure/cancelled**. Scope == jobs already required on main (no new enforcement, heavy jobs stay path-gated -> no extra runner cost).

## Follow-up (separate, owner action)
After merge, branch protection on `main` should require **`ci-gate`** (+ keep `governance`) and drop the four individual path-filtered jobs + `paths-filter`. Until that swap, `ci-gate` runs as a non-required informational check.

## Notes
- This PR itself touches only `.github/workflows/ci.yml` -> it will hit the same footgun (the 4 jobs skip) and needs one last admin-merge.
- ASCII added block; full file `yaml.safe_load` parses (14 jobs); gate `needs` verified.