### PR TITLE
fix(mating): stale weight 0.3 comment -> 0.45 (memoria_ambientale)

### DIFF
--- a/data/core/mating.yaml
+++ b/data/core/mating.yaml
@@ -451,7 +451,7 @@ gene_slots:
         - id: memoria_ambientale
           label_it: "Memoria ambientale"
           maps_to_part: null
-          inheritance_weight: 0.0 # gene-slot pick: mai (rigenerata bioma). Espressione epigenetica governata dal blocco `epigenome:` (Fase-3, weight 0.3)
+          inheritance_weight: 0.0 # gene-slot pick: mai (rigenerata bioma). Espressione epigenetica governata dal blocco `epigenome:` (Fase-3, weight 0.45 ratified #2409)
           mutation_chance: 0.30
 
   mutation_tiers:


### PR DESCRIPTION
1-line comment fix flagged by vault PR #206 harsh-review. Comment on `memoria_ambientale.inheritance_weight` ancora citava "weight 0.3" — bump a 0.45 ratified #2409. No code/test change.