### PR TITLE
feat(authorial): wire aliena coherence telemetry at reinforcement tick

### DIFF
--- a/apps/backend/services/combat/biomeSpawnBias.js
+++ b/apps/backend/services/combat/biomeSpawnBias.js
@@ -264,8 +264,8 @@ function applyBiomeBias(pool, biomeConfig, opts = {}) {
             canonicalPool: opts.canonicalPool || [],
           });
           opts.emitAlienaCoherence({
-            entry_id: entry.id,
-            biome_id: biomeConfig && biomeConfig.id,
+            entry_id: entry.id || entry.unit_id,
+            biome_id: biomeConfig && (biomeConfig.id || biomeConfig.biome_id),
             aggregate: score.aggregate,
             sub_scores: score.sub_scores,
           });

--- a/apps/backend/services/combat/reinforcementSpawner.js
+++ b/apps/backend/services/combat/reinforcementSpawner.js
@@ -119,6 +119,9 @@ function ensureAlienaTelemetry(session) {
   return session.aliena_coherence_telemetry;
 }
 
+// `applyBiomeBias` return value is intentionally discarded: this pre-pass is
+// invoked for the per-entry `emitAlienaCoherence` callback side-effect only;
+// the bias-applied weights are not consumed at this site.
 function emitAlienaPoolSnapshot(session, pool, biomeConfig, round) {
   if (!Array.isArray(pool) || pool.length === 0 || !biomeConfig) return;
   const buffer = ensureAlienaTelemetry(session);
@@ -128,8 +131,10 @@ function emitAlienaPoolSnapshot(session, pool, biomeConfig, round) {
       canonicalPool: pool,
       emitAlienaCoherence: (sample) => {
         buffer.push({ ...sample, round });
+        // Tail-truncate per push so a burst pool >MAX never transiently
+        // allocates beyond the cap (harsh-review PR #2417 follow-up).
         if (buffer.length > ALIENA_TELEMETRY_MAX) {
-          buffer.splice(0, buffer.length - ALIENA_TELEMETRY_MAX);
+          buffer.shift();
         }
       },
     });

--- a/apps/backend/services/combat/reinforcementSpawner.js
+++ b/apps/backend/services/combat/reinforcementSpawner.js
@@ -108,6 +108,36 @@ function ensureReinforcementState(session) {
   return session.reinforcement_state;
 }
 
+// §21 ALIENA diagnostic buffer (ALIENA-B). Opt-in via
+// encounter.reinforcement_policy.aliena_coherence_telemetry === true.
+// Tail-truncated to bound memory on long sessions.
+const ALIENA_TELEMETRY_MAX = 500;
+function ensureAlienaTelemetry(session) {
+  if (!Array.isArray(session.aliena_coherence_telemetry)) {
+    session.aliena_coherence_telemetry = [];
+  }
+  return session.aliena_coherence_telemetry;
+}
+
+function emitAlienaPoolSnapshot(session, pool, biomeConfig, round) {
+  if (!Array.isArray(pool) || pool.length === 0 || !biomeConfig) return;
+  const buffer = ensureAlienaTelemetry(session);
+  try {
+    const { applyBiomeBias } = require('./biomeSpawnBias');
+    applyBiomeBias(pool, biomeConfig, {
+      canonicalPool: pool,
+      emitAlienaCoherence: (sample) => {
+        buffer.push({ ...sample, round });
+        if (buffer.length > ALIENA_TELEMETRY_MAX) {
+          buffer.splice(0, buffer.length - ALIENA_TELEMETRY_MAX);
+        }
+      },
+    });
+  } catch {
+    /* best-effort; never blocks spawn */
+  }
+}
+
 function tick(session, encounter, opts = {}) {
   const rng = typeof opts.rng === 'function' ? opts.rng : Math.random;
   const policy = encounter?.reinforcement_policy;
@@ -166,6 +196,11 @@ function tick(session, encounter, opts = {}) {
       affixes: Array.isArray(encounter.affixes) ? encounter.affixes : [],
       npc_archetypes: encounter.npc_archetypes || null,
     };
+  }
+
+  // §21 ALIENA diagnostic pre-pass (ALIENA-B). One-shot per tick, full pool.
+  if (policy.aliena_coherence_telemetry === true) {
+    emitAlienaPoolSnapshot(session, pool, biomeConfig, round);
   }
 
   for (let i = 0; i < budget; i += 1) {

--- a/tests/services/reinforcementSpawner.test.js
+++ b/tests/services/reinforcementSpawner.test.js
@@ -240,6 +240,70 @@ test('Sprint 2 §II — biomeConfig fallback null when no biome_id + no biome', 
   assert.ok(res.spawned.every((s) => s.unit_id === 'm'));
 });
 
+// §21 ALIENA telemetry wire (ALIENA-B)
+test('aliena telemetry: opt-in policy populates session buffer with pool snapshot', () => {
+  const session = mockSession({ pressure: 30 });
+  const enc = mockEncounter({
+    biome_id: 'dune',
+    affixes: ['sabbia'],
+    reinforcement_pool: [
+      { unit_id: 'dune_stalker', weight: 1, tags: ['desert', 'sand'], role: 'apex' },
+      { unit_id: 'mire_husk', weight: 1, tags: ['wet'], role: 'support' },
+    ],
+    reinforcement_policy: {
+      enabled: true,
+      min_tier: 'Alert',
+      cooldown_rounds: 0,
+      max_total_spawns: 10,
+      aliena_coherence_telemetry: true,
+    },
+  });
+  tick(session, enc, { rng: () => 0.5 });
+  assert.ok(Array.isArray(session.aliena_coherence_telemetry));
+  assert.equal(session.aliena_coherence_telemetry.length, 2);
+  const sample = session.aliena_coherence_telemetry[0];
+  assert.equal(sample.biome_id, 'dune');
+  assert.ok(typeof sample.entry_id === 'string');
+  assert.ok(Number.isFinite(sample.aggregate));
+  assert.ok(sample.sub_scores && typeof sample.sub_scores === 'object');
+  assert.equal(typeof sample.round, 'number');
+});
+
+test('aliena telemetry: default (flag absent) does NOT attach buffer', () => {
+  const session = mockSession({ pressure: 30 });
+  const enc = mockEncounter({
+    biome_id: 'dune',
+    affixes: ['sabbia'],
+  });
+  tick(session, enc, { rng: () => 0.5 });
+  assert.equal(session.aliena_coherence_telemetry, undefined);
+});
+
+test('aliena telemetry: multi-tick accumulates with round metadata', () => {
+  const session = mockSession({ pressure: 30, round: 5 });
+  const enc = mockEncounter({
+    biome_id: 'dune',
+    affixes: ['sabbia'],
+    reinforcement_pool: [
+      { unit_id: 'a', weight: 1, tags: ['sand'], role: 'apex' },
+      { unit_id: 'b', weight: 1, tags: ['wet'], role: 'support' },
+    ],
+    reinforcement_policy: {
+      enabled: true,
+      min_tier: 'Alert',
+      cooldown_rounds: 0,
+      max_total_spawns: 99,
+      aliena_coherence_telemetry: true,
+    },
+  });
+  tick(session, enc, { rng: () => 0.5 });
+  session.round = 7;
+  tick(session, enc, { rng: () => 0.5 });
+  assert.equal(session.aliena_coherence_telemetry.length, 4);
+  assert.equal(session.aliena_coherence_telemetry[0].round, 5);
+  assert.equal(session.aliena_coherence_telemetry[3].round, 7);
+});
+
 test('_internals: manhattanDistance', () => {
   assert.equal(_internals.manhattanDistance([0, 0], [3, 4]), 7);
   assert.equal(_internals.manhattanDistance([5, 5], [5, 5]), 0);


### PR DESCRIPTION
## Context
Follow-up to PR #2415 (§21 ALIENA diagnostic scaffolding). PR #2415 landed the pure scorer + opt-in callback hook in `biomeSpawnBias`, but no caller wired it. This PR wires the first caller.

## Change
**`reinforcementSpawner.tick`**: when `policy.aliena_coherence_telemetry === true`, emit one full pool-vs-biome ALIENA coherence snapshot per tick into `session.aliena_coherence_telemetry` buffer.

- Opt-in (default OFF, zero impact)
- Best-effort try/catch (never blocks spawn)
- Tail-capped at 500 samples (bounded memory long sessions)
- Sample shape: `{ entry_id, biome_id, aggregate, sub_scores, round }`

**`biomeSpawnBias` emit normalization** (small bug-fix surfaced by wiring):
- `entry_id`: `entry.id || entry.unit_id` (encounters use `unit_id`)
- `biome_id`: `biomeConfig.id || biomeConfig.biome_id` (dual convention runtime vs schema)

## Tests
3 new at `tests/services/reinforcementSpawner.test.js`:
1. opt-in policy populates session buffer with pool snapshot
2. default (flag absent) does NOT attach buffer
3. multi-tick accumulates with round metadata

Run:
- `node --test tests/services/reinforcementSpawner.test.js` → 18/18 PASS
- `node --test tests/api/alienaCoherence.test.js tests/api/biomeSpawnBias.test.js` → 22/22 PASS (regression clean)

## Refs
- PR #2415 (ALIENA-A scaffolding)
- vault SoT §21 ALIENA framework
- Plan `docs/superpowers/plans/2026-05-28-aliena-coherence-diagnostic-plan.md`

## Deferred
- Caller wire at `encounterLoader` / initial wave (different code path; can land as ALIENA-C)
- Consumer endpoint exposing buffer (no consumer yet — diagnostic-only telemetry)