### PR TITLE
feat(authorial): §21 ALIENA-C initial wave baseline telemetry

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -1626,6 +1626,13 @@ function createSessionRouter(options = {}) {
         campaign_id: req.body?.campaign_id || null,
         sistema_state: { units_observed: {} },
       };
+      // §21 ALIENA-C: opt-in baseline coherence snapshot (round=0). Pairs with
+      // ALIENA-B per-tick emit at reinforcementSpawner. Best-effort.
+      try {
+        require('../services/combat/initialAlienaTelemetry').emitInitial(session, encounterPayload);
+      } catch (err) {
+        console.warn('[aliena-initial] emit failed:', err.message);
+      }
       // V5 SG lifecycle: encounter start reset (ADR-2026-04-26).
       // Optional restore: `req.body.initial_sg = { unit_id: pool }` lets
       // save-load + integration tests seed SG after the encounter zero-pass.

--- a/apps/backend/services/combat/initialAlienaTelemetry.js
+++ b/apps/backend/services/combat/initialAlienaTelemetry.js
@@ -1,0 +1,50 @@
+// §21 ALIENA-C -- initial wave baseline telemetry helper. Emits a one-shot
+// round=0 coherence snapshot for encounter.reinforcement_pool vs biome at
+// session start. Pairs with ALIENA-B (reinforcementSpawner per-tick) to give
+// a full temporal series anchored at the initial pool-vs-biome fit.
+//
+// Opt-in via encounter.reinforcement_policy.aliena_coherence_telemetry === true
+// (same flag as ALIENA-B). Best-effort: never throws, never blocks session start.
+
+'use strict';
+
+const ALIENA_TELEMETRY_MAX = 500;
+
+function ensureBuffer(session) {
+  if (!Array.isArray(session.aliena_coherence_telemetry)) {
+    session.aliena_coherence_telemetry = [];
+  }
+  return session.aliena_coherence_telemetry;
+}
+
+function emitInitial(session, encounter) {
+  if (!session || !encounter) return;
+  const policy = encounter.reinforcement_policy;
+  if (!policy || policy.aliena_coherence_telemetry !== true) return;
+  const pool = encounter.reinforcement_pool;
+  if (!Array.isArray(pool) || pool.length === 0) return;
+  let biomeConfig = encounter.biome || null;
+  if (!biomeConfig && encounter.biome_id) {
+    biomeConfig = {
+      biome_id: encounter.biome_id,
+      affixes: Array.isArray(encounter.affixes) ? encounter.affixes : [],
+      npc_archetypes: encounter.npc_archetypes || null,
+    };
+  }
+  if (!biomeConfig) return;
+  const buffer = ensureBuffer(session);
+  try {
+    const { applyBiomeBias } = require('./biomeSpawnBias');
+    applyBiomeBias(pool, biomeConfig, {
+      canonicalPool: pool,
+      emitAlienaCoherence: (sample) => {
+        buffer.push({ ...sample, round: 0 });
+        if (buffer.length > ALIENA_TELEMETRY_MAX) buffer.shift();
+      },
+    });
+  } catch {
+    /* best-effort; never blocks session start */
+  }
+}
+
+module.exports = { emitInitial, ALIENA_TELEMETRY_MAX };

--- a/tests/services/initialAlienaTelemetry.test.js
+++ b/tests/services/initialAlienaTelemetry.test.js
@@ -1,0 +1,40 @@
+// §21 ALIENA-C — initial wave baseline telemetry helper tests.
+'use strict';
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { emitInitial } = require('../../apps/backend/services/combat/initialAlienaTelemetry');
+
+test('emitInitial: default (flag absent) does NOT attach buffer', () => {
+  const session = {};
+  const encounter = {
+    biome_id: 'dune',
+    affixes: ['sabbia'],
+    reinforcement_pool: [{ unit_id: 'x', weight: 1, tags: ['sand'], role: 'apex' }],
+  };
+  emitInitial(session, encounter);
+  assert.equal(session.aliena_coherence_telemetry, undefined);
+});
+
+test('emitInitial: opt-in flag emits baseline round=0 snapshot for reinforcement_pool', () => {
+  const session = {};
+  const encounter = {
+    biome_id: 'dune',
+    affixes: ['sabbia'],
+    reinforcement_pool: [
+      { unit_id: 'dune_stalker', weight: 1, tags: ['sand'], role: 'apex' },
+      { unit_id: 'mire_husk', weight: 1, tags: ['wet'], role: 'support' },
+    ],
+    reinforcement_policy: { aliena_coherence_telemetry: true },
+  };
+  emitInitial(session, encounter);
+  assert.ok(Array.isArray(session.aliena_coherence_telemetry));
+  assert.equal(session.aliena_coherence_telemetry.length, 2);
+  for (const s of session.aliena_coherence_telemetry) {
+    assert.equal(s.round, 0);
+    assert.equal(s.biome_id, 'dune');
+    assert.ok(Number.isFinite(s.aggregate));
+  }
+});


### PR DESCRIPTION
## Context
Pairs with PR #2417 (ALIENA-B per-tick reinforcement emit). ALIENA-B gives the temporal coherence series from round 1+ inside combat; ALIENA-C anchors that series with a **round=0 baseline snapshot** of the same `reinforcement_pool` vs declared biome, computed once at session start.

## Architecture
- **New pure helper** `apps/backend/services/combat/initialAlienaTelemetry.js` with `emitInitial(session, encounter)`.
  - Opt-in via the same flag (`encounter.reinforcement_policy.aliena_coherence_telemetry === true`).
  - Same try/catch + tail-cap MAX=500 semantics as ALIENA-B.
  - Derives `biomeConfig` from `encounter.biome` OR `encounter.biome_id` + `affixes` + `npc_archetypes`.
- **Wire** `apps/backend/routes/session.js` right after session creation, before SG lifecycle reset. Best-effort try/catch; never blocks session start.

## Tests (2 new)
- `emitInitial: default (flag absent) does NOT attach buffer`
- `emitInitial: opt-in flag emits baseline round=0 snapshot for reinforcement_pool`

Local: **42/42 PASS** (initialAlienaTelemetry + reinforcementSpawner + alienaCoherence + biomeSpawnBias regression all green).

## §21 ALIENA pipeline status

| Stage | PR | Status |
|---|---|---|
| ALIENA-A scorer + biomeSpawnBias hook | #2415 | merged |
| ALIENA-B per-tick reinforcement emit | #2417 | merged |
| ALIENA-C initial wave baseline | this PR | open |

After this lands, telemetry buffer is populated at round=0 (baseline) + each spawn-eligible tick (delta), giving consumers a complete temporal coherence series.

## Refs
- vault SoT §21 ALIENA framework
- PR #2415 (ALIENA-A scaffolding)
- PR #2417 (ALIENA-B caller wire)

## Deferred
- Consumer endpoint exposing buffer (no client yet — diagnostic-only)
- Wire for non-reinforcement initial waves (encounter.groups schema, different code path)