### PR TITLE
fix(authorial): aliena scorer normalize entry.id || entry.unit_id

### DIFF
--- a/apps/backend/services/authorial/alienaCoherence.js
+++ b/apps/backend/services/authorial/alienaCoherence.js
@@ -25,10 +25,16 @@ function clamp01(x) {
   return Math.max(0, Math.min(1, x));
 }
 
+function _entryId(e) {
+  if (!e) return null;
+  return e.id || e.unit_id || null;
+}
+
 function _scorePlausibilita(entry, biomeConfig, canonicalPool) {
-  if (!entry || !entry.id) return 0;
+  const eid = _entryId(entry);
+  if (!eid) return 0;
   const pool = Array.isArray(canonicalPool) ? canonicalPool : [];
-  const inPool = pool.some((p) => p && p.id === entry.id);
+  const inPool = pool.some((p) => p && _entryId(p) === eid);
   if (inPool) return 1.0;
   const roleTemplates = (biomeConfig && biomeConfig.role_templates) || [];
   try {

--- a/tests/api/alienaCoherence.test.js
+++ b/tests/api/alienaCoherence.test.js
@@ -93,3 +93,13 @@ test('hook: no emitAlienaCoherence callback -> no telemetry, no throw (back-comp
   const out = applyBiomeBias(pool, { id: 'dune', affixes: [] });
   assert.equal(out.length, 1);
 });
+
+test('aliena scorer: unit_id schema (reinforcement_pool) -> plausibilita 1.0 in-pool', () => {
+  // Codex P2 PR #2418 regression: reinforcement_pool uses `unit_id` schema,
+  // not `id`. _scorePlausibilita must normalize both entry + canonicalPool.
+  const entry = { unit_id: 'dune_stalker', tags: ['sand'], role: 'apex' };
+  const biomeConfig = { id: 'dune', affixes: ['sabbia'], role_templates: [] };
+  const canonicalPool = [{ unit_id: 'dune_stalker' }, { unit_id: 'mire_husk' }];
+  const r = scoreAlienaCoherence(entry, biomeConfig, { canonicalPool });
+  assert.equal(r.sub_scores.plausibilita, 1.0);
+});


### PR DESCRIPTION
## Context
Codex P2 review on merged PR #2418 (ALIENA-C baseline) flagged a real bug: `_scorePlausibilita` systematically returned **0** for entries from the canonical `reinforcement_pool` schema (which uses `unit_id` not `id`), so the round=0 baseline telemetry under-scored every in-pool entry to `plausibilita: 0` instead of `1.0`.

Same bug also affects ALIENA-B per-tick emit (PR #2417): the same pool entries feed the same scorer through the same `canonicalPool` opts, so per-tick telemetry was also under-scored.

## Fix
Extract `_entryId(e) = e.id || e.unit_id || null`. Use it both for the entry input null-check and the `canonicalPool[].id` comparison. No API change.

Result: `aggregate` for `unit_id`-schema pools now matches the intended specification (plausibilita 1.0 when entry is in canonicalPool, instead of 0 + cascading low aggregate).

## Tests
1 new regression test at `tests/api/alienaCoherence.test.js`:
```js
test('aliena scorer: unit_id schema (reinforcement_pool) -> plausibilita 1.0 in-pool', ...)
```

Local: **43/43 PASS** (alienaCoherence + biomeSpawnBias + reinforcementSpawner + initialAlienaTelemetry all green).

## Refs
- Codex inline comment on PR #2418 `apps/backend/services/combat/initialAlienaTelemetry.js:39`
- PR #2415 (ALIENA-A scorer authoring) - introduced the bug
- PR #2417 (ALIENA-B) + PR #2418 (ALIENA-C) - both consume the scorer

## Impact on previously merged telemetry
None observed in production -- diagnostic-only buffer with no consumer yet. Any pre-fix samples collected would have systematically low plausibilita; post-fix samples will be on the correct scale. If future consumers compare pre/post-fix samples, document the discontinuity.