### PR TITLE
feat(authorial): §21 ALIENA-D READ-only telemetry consumer endpoint

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -2703,6 +2703,28 @@ function createSessionRouter(options = {}) {
     }
   });
 
+  // §21 ALIENA-D: READ-only consumer endpoint exposing diagnostic telemetry
+  // buffer populated by ALIENA-B (per-tick reinforcement) + ALIENA-C (round=0
+  // baseline). Empty array when flag off or no spawn-eligible events yet.
+  // capped flips true when buffer hit MAX=500 tail-cap.
+  router.get('/:id/aliena-telemetry', (req, res, next) => {
+    try {
+      const { error, session } = resolveSession(req.params.id);
+      if (error) return res.status(error.status).json(error.body);
+      const buffer = Array.isArray(session.aliena_coherence_telemetry)
+        ? session.aliena_coherence_telemetry
+        : [];
+      res.json({
+        session_id: session.session_id,
+        telemetry: buffer,
+        count: buffer.length,
+        capped: buffer.length >= 500,
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
   router.post('/:id/promote', (req, res, next) => {
     try {
       const { error, session } = resolveSession(req.params.id);

--- a/tests/api/alienaTelemetryEndpoint.test.js
+++ b/tests/api/alienaTelemetryEndpoint.test.js
@@ -1,0 +1,66 @@
+// §21 ALIENA-D — consumer endpoint GET /api/session/:id/aliena-telemetry.
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+async function startSession(app, body = { scenario_id: 'tutorial_01' }) {
+  const res = await request(app).post('/api/session/start').send(body).expect(200);
+  return res.body;
+}
+
+test('GET /:id/aliena-telemetry 404 on unknown session', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app).get('/api/session/bogus_session_xyz/aliena-telemetry');
+    assert.equal(res.status, 404);
+  } finally {
+    if (close) await close();
+  }
+});
+
+test('GET /:id/aliena-telemetry returns empty buffer by default (flag off)', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const { session_id } = await startSession(app);
+    const res = await request(app).get(`/api/session/${session_id}/aliena-telemetry`).expect(200);
+    assert.equal(res.body.session_id, session_id);
+    assert.ok(Array.isArray(res.body.telemetry));
+    assert.equal(res.body.telemetry.length, 0);
+    assert.equal(res.body.count, 0);
+    assert.equal(res.body.capped, false);
+  } finally {
+    if (close) await close();
+  }
+});
+
+test('GET /:id/aliena-telemetry surfaces ALIENA-C round=0 baseline when flag on', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const { session_id } = await startSession(app, {
+      scenario_id: 'tutorial_01',
+      encounter: {
+        biome_id: 'dune',
+        affixes: ['sabbia'],
+        reinforcement_pool: [
+          { unit_id: 'dune_stalker', weight: 1, tags: ['sand'], role: 'apex' },
+          { unit_id: 'mire_husk', weight: 1, tags: ['wet'], role: 'support' },
+        ],
+        reinforcement_policy: { aliena_coherence_telemetry: true },
+      },
+    });
+    const res = await request(app).get(`/api/session/${session_id}/aliena-telemetry`).expect(200);
+    assert.equal(res.body.count, 2);
+    for (const s of res.body.telemetry) {
+      assert.equal(s.round, 0);
+      assert.equal(s.biome_id, 'dune');
+      assert.ok(Number.isFinite(s.aggregate));
+    }
+  } finally {
+    if (close) await close();
+  }
+});


### PR DESCRIPTION
## Context
Closes the §21 ALIENA diagnostic loop. ALIENA-B (PR #2417) + ALIENA-C (PR #2418) populate `session.aliena_coherence_telemetry`; this PR exposes the buffer so downstream consumers can actually read it.

## Endpoint
`GET /api/session/:id/aliena-telemetry`

| Response | Shape |
|---|---|
| 200 | `{ session_id, telemetry: Array, count: int, capped: bool }` |
| 404 | unknown session id (standard `resolveSession` pattern) |
| 200 empty | flag absent (zero overhead, back-compat — buffer never allocated) |
| `capped: true` | buffer hit `MAX=500` tail-cap |

## Tests (3 new)
- 404 on unknown session
- empty buffer by default (flag off)
- populated buffer after ALIENA-C baseline (flag on via inline encounter w/ `reinforcement_policy.aliena_coherence_telemetry: true`)

Local: **46/46 PASS** (alienaTelemetryEndpoint + alienaCoherence + biomeSpawnBias + reinforcementSpawner + initialAlienaTelemetry all green).

## §21 ALIENA pipeline status

| Stage | PR | Status |
|---|---|---|
| ALIENA-A scorer + biomeSpawnBias hook | #2415 | merged |
| ALIENA-B per-tick reinforcement emit | #2417 | merged |
| ALIENA-C initial wave baseline | #2418 | merged |
| ALIENA-fix unit_id schema normalize | #2419 | merged |
| ALIENA-D READ-only consumer endpoint | this PR | open |

Pipeline now diagnostic-complete. Enforcement layer (veto / weight modulation / conditional triggers) deliberately deferred — data-driven decision after collection via this endpoint.

## Use cases unlocked
- Phone-side coherence chart in PhoneDebriefView (future §22-C)
- Playtest data export tool (JSONL via curl)
- Analyst dashboard / regression detection
- Foundation for ALIENA enforcement-layer threshold tuning

## Refs
- PR #2415 (ALIENA-A), #2417 (ALIENA-B), #2418 (ALIENA-C), #2419 (unit_id fix)
- vault SoT §21 (v7 reconcile shipped 2026-05-28)