### PR TITLE
feat(authorial): §21 ALIENA-E groups initial-wave baseline

### DIFF
--- a/apps/backend/services/combat/initialAlienaTelemetry.js
+++ b/apps/backend/services/combat/initialAlienaTelemetry.js
@@ -17,33 +17,59 @@ function ensureBuffer(session) {
   return session.aliena_coherence_telemetry;
 }
 
-function emitInitial(session, encounter) {
-  if (!session || !encounter) return;
-  const policy = encounter.reinforcement_policy;
-  if (!policy || policy.aliena_coherence_telemetry !== true) return;
-  const pool = encounter.reinforcement_pool;
-  if (!Array.isArray(pool) || pool.length === 0) return;
-  let biomeConfig = encounter.biome || null;
-  if (!biomeConfig && encounter.biome_id) {
-    biomeConfig = {
-      biome_id: encounter.biome_id,
-      affixes: Array.isArray(encounter.affixes) ? encounter.affixes : [],
-      npc_archetypes: encounter.npc_archetypes || null,
-    };
-  }
-  if (!biomeConfig) return;
+function _deriveBiomeConfig(encounter) {
+  if (!encounter) return null;
+  if (encounter.biome) return encounter.biome;
+  if (!encounter.biome_id) return null;
+  return {
+    biome_id: encounter.biome_id,
+    affixes: Array.isArray(encounter.affixes) ? encounter.affixes : [],
+    npc_archetypes: encounter.npc_archetypes || null,
+  };
+}
+
+function _emitPool(session, pool, biomeConfig, source) {
   const buffer = ensureBuffer(session);
   try {
     const { applyBiomeBias } = require('./biomeSpawnBias');
     applyBiomeBias(pool, biomeConfig, {
       canonicalPool: pool,
       emitAlienaCoherence: (sample) => {
-        buffer.push({ ...sample, round: 0 });
+        buffer.push({ ...sample, round: 0, source });
         if (buffer.length > ALIENA_TELEMETRY_MAX) buffer.shift();
       },
     });
   } catch {
     /* best-effort; never blocks session start */
+  }
+}
+
+function _mapGroupsToPool(groups) {
+  if (!Array.isArray(groups)) return [];
+  return groups
+    .filter((g) => g && g.species_hint)
+    .map((g) => ({
+      id: g.species_hint,
+      role: g.role || null,
+      tags: Array.isArray(g.trait_ids) ? g.trait_ids : [],
+    }));
+}
+
+function emitInitial(session, encounter) {
+  if (!session || !encounter) return;
+  const policy = encounter.reinforcement_policy;
+  if (!policy || policy.aliena_coherence_telemetry !== true) return;
+  const biomeConfig = _deriveBiomeConfig(encounter);
+  if (!biomeConfig) return;
+  // ALIENA-C reinforcement_pool branch (round=0 baseline).
+  const rPool = encounter.reinforcement_pool;
+  if (Array.isArray(rPool) && rPool.length > 0) {
+    _emitPool(session, rPool, biomeConfig, 'reinforcement_pool');
+  }
+  // ALIENA-E groups branch (initial-wave NPCs, parallel schema).
+  const gPool = _mapGroupsToPool(encounter.groups);
+  if (gPool.length > 0) {
+    _emitPool(session, gPool, biomeConfig, 'groups');
   }
 }
 

--- a/tests/services/initialAlienaTelemetry.test.js
+++ b/tests/services/initialAlienaTelemetry.test.js
@@ -18,6 +18,43 @@ test('emitInitial: default (flag absent) does NOT attach buffer', () => {
   assert.equal(session.aliena_coherence_telemetry, undefined);
 });
 
+test('emitInitial: opt-in flag emits baseline for encounter.groups (ALIENA-E)', () => {
+  // ALIENA-E: groups schema parallel to reinforcement_pool. Same flag.
+  // groups[i] = { role, power, count, species_hint, trait_ids } -> mapped to
+  // entry { id: species_hint, role, tags: trait_ids } for scoring.
+  const session = {};
+  const encounter = {
+    biome_id: 'abisso_vulcanico',
+    affixes: ['lava'],
+    groups: [
+      {
+        role: 'apex',
+        power: 14,
+        count: 1,
+        species_hint: 'leviatano_risonante',
+        trait_ids: ['mantello_meteoritico'],
+      },
+      {
+        role: 'support',
+        power: 8,
+        count: 2,
+        species_hint: 'fiamma_minore',
+        trait_ids: ['piroforico'],
+      },
+    ],
+    reinforcement_policy: { aliena_coherence_telemetry: true },
+  };
+  emitInitial(session, encounter);
+  assert.ok(Array.isArray(session.aliena_coherence_telemetry));
+  assert.equal(session.aliena_coherence_telemetry.length, 2);
+  for (const s of session.aliena_coherence_telemetry) {
+    assert.equal(s.round, 0);
+    assert.equal(s.source, 'groups');
+    assert.equal(s.biome_id, 'abisso_vulcanico');
+    assert.ok(Number.isFinite(s.aggregate));
+  }
+});
+
 test('emitInitial: opt-in flag emits baseline round=0 snapshot for reinforcement_pool', () => {
   const session = {};
   const encounter = {


### PR DESCRIPTION
## Context
T1 of auto-execution plan. Extends ALIENA-C (PR #2418) to cover the parallel `encounter.groups` schema. Most existing encounter YAMLs use `groups` (initial-wave NPC declarations) — without this extension, ALIENA telemetry baseline is silent on the majority of real encounter data.

## Schema mapping
```
groups[i] = { role, power, count, species_hint, trait_ids }
  -> entry { id: species_hint, role, tags: trait_ids }
```

Sample carries `source: 'groups'` (vs `'reinforcement_pool'`) so consumers can split timeline by emit origin.

## Refactor
Extracted `_deriveBiomeConfig()` + `_emitPool(session, pool, biome, source)` helpers. DRY both branches. Each branch emits conditionally if pool non-empty (no false-empty emissions).

## Tests
1 new (groups schema emits + `source='groups'` + `biome_id` correct). Existing reinforcement_pool tests preserved (back-compat).

Local: **47/47 PASS** (initialAlienaTelemetry + alienaTelemetryEndpoint + alienaCoherence + biomeSpawnBias + reinforcementSpawner).

## Pipeline status
| Stage | PR | Status |
|---|---|---|
| ALIENA-A scorer + hook | #2415 | merged |
| ALIENA-B per-tick reinforcement | #2417 | merged |
| ALIENA-C baseline round=0 (reinforcement_pool) | #2418 | merged |
| ALIENA-fix unit_id schema | #2419 | merged |
| ALIENA-D consumer endpoint | #2420 | merged |
| **ALIENA-E baseline round=0 (groups)** | **this PR** | **open** |

After merge: baseline covers both `groups` (initial NPCs) + `reinforcement_pool` (waves) on opt-in encounters.

## Refs
- PR #2418 (ALIENA-C baseline reinforcement_pool)
- vault SoT v7.1 §21 (last reconcile PR #210)