### PR TITLE
feat(coop): mating vote layer (S22-B backend, Tasks 1-3)

### DIFF
--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -78,6 +78,10 @@ function createCoopRouter({ lobby, coopStore } = {}) {
           ready_list: orch.debriefReadyList(allPlayerIds(room)),
         },
       });
+      room.broadcast({
+        type: 'mating_tally',
+        payload: orch.matingTally(allPlayerIds(room), connectedPlayerIds(room)),
+      });
       // 2026-05-15 Bundle C follow-up — surface per-actor 4-layer psicologico
       // payload to phone clients when host attached it via /coop/combat/end
       // (PR #2269 wire). Each phone composer extracts its local player slice
@@ -198,6 +202,30 @@ function createCoopRouter({ lobby, coopStore } = {}) {
       return res.json({ phase: orch.phase, tally });
     } catch (err) {
       return res.status(400).json({ error: err.message || 'world_vote_failed' });
+    }
+  });
+
+  router.post('/coop/mating/vote', (req, res) => {
+    const {
+      code,
+      player_id: playerId,
+      player_token: playerToken,
+      pair_id: pairId,
+    } = req.body || {};
+    const auth = authPlayer(code, playerId, playerToken);
+    if (!auth) return res.status(403).json({ error: 'player_auth_failed' });
+    const { room } = auth;
+    const orch = coopStore.get(code);
+    if (!orch) return res.status(409).json({ error: 'run_not_started' });
+    try {
+      const tally = orch.voteMating(playerId, pairId, {
+        allPlayerIds: allPlayerIds(room),
+        connectedPlayerIds: connectedPlayerIds(room),
+      });
+      broadcastCoopState(room, orch);
+      return res.json({ phase: orch.phase, tally });
+    } catch (err) {
+      return res.status(400).json({ error: err.message || 'mating_vote_failed' });
     }
   });
 

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -84,6 +84,8 @@ class CoopOrchestrator {
     this.run = null; // populated by startRun()
     this.characters = new Map(); // player_id → character spec
     this.worldVotes = new Map(); // player_id → scenario_id|null
+    // S22-B -- per-player mating pair vote { player_id -> { pair_id, ts } }.
+    this.matingVotes = new Map();
     this.debriefChoices = new Map();
     // 2026-05-06 narrative onboarding port — host single-choice identity
     // for entire branco. Pre-assigned trait propagated to all party
@@ -597,6 +599,54 @@ class CoopOrchestrator {
       // (caller should not auto-advance with zero participants).
       tally.all_connected_accepted =
         connectedTotal > 0 && connectedAccept === connectedTotal && connectedReject === 0;
+    }
+    return tally;
+  }
+
+  /**
+   * S22-B -- player votes for an eligible mating pair (pair_id =
+   * `${parent_a_id}__${parent_b_id}`). Debrief-phase only. Idempotent
+   * re-vote (replaces). Mirror of voteWorld.
+   */
+  voteMating(playerId, pairId, { allPlayerIds = [], connectedPlayerIds } = {}) {
+    if (this.phase !== 'debrief') throw new Error('not_in_debrief');
+    if (!playerId) throw new Error('player_id_required');
+    if (!pairId) throw new Error('pair_id_required');
+    this.matingVotes.set(playerId, { pair_id: pairId, ts: this.now() });
+    this._emit('mating_vote', { player_id: playerId, pair_id: pairId });
+    return this.matingTally(allPlayerIds, connectedPlayerIds);
+  }
+
+  /**
+   * S22-B -- tally mating votes. Returns per-pair counts, the leading
+   * pair (deterministic tie-break: lowest pair_id lexicographic), and
+   * quorum vs allPlayerIds. Mirror of worldTally shape.
+   */
+  matingTally(allPlayerIds = [], connectedPlayerIds) {
+    const counts = new Map();
+    const perPlayer = {};
+    for (const [pid, vote] of this.matingVotes.entries()) {
+      perPlayer[pid] = vote;
+      counts.set(vote.pair_id, (counts.get(vote.pair_id) || 0) + 1);
+    }
+    const tallies = Array.from(counts.entries())
+      .map(([pair_id, votes]) => ({ pair_id, votes }))
+      .sort((x, y) => y.votes - x.votes || x.pair_id.localeCompare(y.pair_id));
+    const voted = this.matingVotes.size;
+    const tally = {
+      tallies,
+      leading_pair_id: tallies.length ? tallies[0].pair_id : null,
+      total: allPlayerIds.length || voted,
+      pending: Math.max((allPlayerIds.length || voted) - voted, 0),
+      per_player: perPlayer,
+    };
+    if (Array.isArray(connectedPlayerIds)) {
+      const connected = connectedPlayerIds.filter(Boolean);
+      const connectedVoted = connected.filter((pid) => this.matingVotes.has(pid)).length;
+      tally.connected_total = connected.length;
+      tally.connected_voted = connectedVoted;
+      tally.connected_pending = Math.max(connected.length - connectedVoted, 0);
+      tally.all_connected_voted = connected.length > 0 && connectedVoted === connected.length;
     }
     return tally;
   }

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -208,6 +208,7 @@ class CoopOrchestrator {
     this.characters.clear();
     this.worldVotes.clear();
     this.sessionId = null;
+    this.matingVotes.clear();
     this.debriefChoices.clear();
     this.revealAcks.clear();
     this.formPulses.clear();
@@ -243,6 +244,7 @@ class CoopOrchestrator {
     this.characters.clear();
     this.worldVotes.clear();
     this.sessionId = null;
+    this.matingVotes.clear();
     this.debriefChoices.clear();
     this.revealAcks.clear();
     this.formPulses.clear();
@@ -834,6 +836,7 @@ class CoopOrchestrator {
     this.debriefChoices.clear();
     this.worldVotes.clear();
     this.sessionId = null;
+    this.matingVotes.clear();
     this.formPulses.clear();
     this.revealAcks.clear();
     this._setPhase('world_setup');

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -1564,6 +1564,44 @@ function createWsServer({
             }
             return;
           }
+          // S22-B -- drain mating_vote intents server-side via
+          // coopOrchestrator.voteMating (mirror world_vote). Phone sends
+          // { action: 'mating_vote', pair_id } during debrief.
+          if (action === 'mating_vote' && coopStore) {
+            try {
+              const orch = coopStore.get(room.code);
+              if (!orch) {
+                socket.send(
+                  JSON.stringify({ type: 'error', payload: { code: 'run_not_started' } }),
+                );
+                return;
+              }
+              const allPids = Array.from(room.players.values()).map((p) => p.id);
+              const connectedPids = Array.from(room.players.values())
+                .filter((p) => p.connected && p.id !== room.hostId && p.role !== 'host')
+                .map((p) => p.id);
+              const tally = orch.voteMating(playerId, msg.payload?.pair_id, {
+                allPlayerIds: allPids,
+                connectedPlayerIds: connectedPids,
+              });
+              logLobbyEvent('mating_vote', {
+                code: room.code,
+                player_id: playerId,
+                pair_id: msg.payload?.pair_id || null,
+                leading_pair_id: tally.leading_pair_id,
+              });
+              room.broadcast({ type: 'mating_tally', payload: tally });
+              socket.send(JSON.stringify({ type: 'mating_vote_accepted', payload: { tally } }));
+            } catch (err) {
+              socket.send(
+                JSON.stringify({
+                  type: 'error',
+                  payload: { code: err.message || 'mating_vote_failed' },
+                }),
+              );
+            }
+            return;
+          }
           // 2026-05-06 phone smoke W6 fix — drain lineage_choice (debrief
           // phase) server-side via coopOrchestrator.submitDebriefChoice.
           // Pre-fix the intent was relayed to host Godot → silent drop,

--- a/tests/api/coopMatingRoute.test.js
+++ b/tests/api/coopMatingRoute.test.js
@@ -41,3 +41,14 @@ test('POST /coop/mating/vote rejects bad auth', async (t) => {
   });
   assert.equal(res.status, 403);
 });
+
+test('voteMating emits mating_vote identity-signal event (pair_id + player_id)', () => {
+  const { CoopOrchestrator } = require('../../apps/backend/services/coop/coopOrchestrator');
+  const o = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'h1' });
+  o.startRun({ scenarioStack: ['enc_a'] });
+  o.phase = 'debrief';
+  o.voteMating('p1', 'a__b', { allPlayerIds: ['p1'] });
+  const evt = o.log.filter((e) => e.kind === 'mating_vote').pop();
+  assert.equal(evt.payload.pair_id, 'a__b');
+  assert.equal(evt.payload.player_id, 'p1');
+});

--- a/tests/api/coopMatingRoute.test.js
+++ b/tests/api/coopMatingRoute.test.js
@@ -1,0 +1,43 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+test('POST /coop/mating/vote records + returns mating_tally', async (t) => {
+  const { app, lobby, coopStore, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (close) await close().catch(() => {});
+  });
+  const room = lobby.createRoom({ hostName: 'TV' });
+  const p1 = lobby.joinRoom({ code: room.code, playerName: 'Bob' });
+  const orch = coopStore.getOrCreate(room.code);
+  orch.startRun({ scenarioStack: ['enc_a'] });
+  orch.phase = 'debrief';
+  const res = await request(app).post('/api/coop/mating/vote').send({
+    code: room.code,
+    player_id: p1.player_id,
+    player_token: p1.player_token,
+    pair_id: 'a__b',
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.tally.leading_pair_id, 'a__b');
+});
+
+test('POST /coop/mating/vote rejects bad auth', async (t) => {
+  const { app, lobby, coopStore, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (close) await close().catch(() => {});
+  });
+  const room = lobby.createRoom({ hostName: 'TV' });
+  const orch = coopStore.getOrCreate(room.code);
+  orch.startRun({ scenarioStack: ['enc_a'] });
+  orch.phase = 'debrief';
+  const res = await request(app).post('/api/coop/mating/vote').send({
+    code: room.code,
+    player_id: 'ghost',
+    player_token: 'bad',
+    pair_id: 'a__b',
+  });
+  assert.equal(res.status, 403);
+});

--- a/tests/services/coop/coopMatingVote.test.js
+++ b/tests/services/coop/coopMatingVote.test.js
@@ -31,3 +31,13 @@ test('voteMating re-vote replaces, not stacks; debrief gate enforced', () => {
   const lobby = new CoopOrchestrator({ roomCode: 'ZZ', hostId: 'h' });
   assert.throws(() => lobby.voteMating('p1', 'a__b'), /not_in_debrief/);
 });
+
+test('matingVotes cleared on scenario advance (new debrief round)', () => {
+  const o = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'h1' });
+  o.startRun({ scenarioStack: ['e1', 'e2'] });
+  o.phase = 'debrief';
+  o.voteMating('p1', 'a__b', { allPlayerIds: ['p1'] });
+  assert.equal(o.matingVotes.size, 1);
+  o.advanceScenarioOrEnd();
+  assert.equal(o.matingVotes.size, 0);
+});

--- a/tests/services/coop/coopMatingVote.test.js
+++ b/tests/services/coop/coopMatingVote.test.js
@@ -1,0 +1,33 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { CoopOrchestrator } = require('../../../apps/backend/services/coop/coopOrchestrator');
+
+function debriefOrch() {
+  const o = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'h1' });
+  o.startRun({ scenarioStack: ['enc_a'] });
+  o.phase = 'debrief';
+  return o;
+}
+
+test('voteMating records a vote and matingTally reports leading pair', () => {
+  const o = debriefOrch();
+  o.voteMating('p1', 'a__b', { allPlayerIds: ['p1', 'p2'] });
+  o.voteMating('p2', 'a__b', { allPlayerIds: ['p1', 'p2'] });
+  const tally = o.matingTally(['p1', 'p2']);
+  assert.equal(tally.leading_pair_id, 'a__b');
+  assert.equal(tally.tallies.find((t) => t.pair_id === 'a__b').votes, 2);
+  assert.equal(tally.total, 2);
+  assert.equal(tally.pending, 0);
+});
+
+test('voteMating re-vote replaces, not stacks; debrief gate enforced', () => {
+  const o = debriefOrch();
+  o.voteMating('p1', 'a__b', { allPlayerIds: ['p1'] });
+  o.voteMating('p1', 'c__d', { allPlayerIds: ['p1'] });
+  const tally = o.matingTally(['p1']);
+  assert.equal(tally.leading_pair_id, 'c__d');
+  assert.equal(tally.tallies.length, 1);
+  const lobby = new CoopOrchestrator({ roomCode: 'ZZ', hostId: 'h' });
+  assert.throws(() => lobby.voteMating('p1', 'a__b'), /not_in_debrief/);
+});

--- a/tests/services/network/wsSession-matingVote.test.js
+++ b/tests/services/network/wsSession-matingVote.test.js
@@ -1,0 +1,112 @@
+// S22-B 2026-05-29 -- phone mating_vote WS intent drains server-side via
+// coopOrchestrator.voteMating + broadcasts mating_tally + acks
+// mating_vote_accepted. Mirror of world_vote intent handler.
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const WebSocket = require('ws');
+const {
+  LobbyService,
+  createWsServer,
+} = require('../../../apps/backend/services/network/wsSession');
+const { createCoopStore } = require('../../../apps/backend/services/coop/coopStore');
+
+function attachBuffer(ws) {
+  ws.__buf = [];
+  ws.__waiters = [];
+  ws.on('message', (raw) => {
+    let msg;
+    try {
+      msg = JSON.parse(raw.toString());
+    } catch {
+      return;
+    }
+    ws.__buf.push(msg);
+    for (const w of ws.__waiters.slice()) {
+      if (w.predicate(msg)) {
+        ws.__waiters = ws.__waiters.filter((x) => x !== w);
+        w.resolve(msg);
+      }
+    }
+  });
+  return ws;
+}
+
+function waitForMessage(ws, predicate, timeoutMs = 3000) {
+  for (const msg of ws.__buf) {
+    if (predicate(msg)) return Promise.resolve(msg);
+  }
+  return new Promise((resolve, reject) => {
+    const waiter = { predicate, resolve, reject };
+    const timer = setTimeout(() => {
+      ws.__waiters = ws.__waiters.filter((x) => x !== waiter);
+      reject(new Error('timeout waiting for ws message'));
+    }, timeoutMs);
+    waiter.resolve = (msg) => {
+      clearTimeout(timer);
+      resolve(msg);
+    };
+    ws.__waiters.push(waiter);
+  });
+}
+
+function openWs(port, { code, player_id, token }) {
+  const url = `ws://127.0.0.1:${port}/ws?code=${encodeURIComponent(code)}&player_id=${encodeURIComponent(player_id)}&token=${encodeURIComponent(token)}`;
+  return attachBuffer(new WebSocket(url));
+}
+
+async function waitOpen(ws) {
+  return new Promise((resolve, reject) => {
+    ws.once('open', () => resolve());
+    ws.once('error', reject);
+  });
+}
+
+test('S22-B: phone mating_vote WS intent broadcasts mating_tally + acks accepted', async () => {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const wsHandle = createWsServer({ lobby, coopStore, port: 0 });
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  const port = wsHandle.wss.address().port;
+
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Bob' });
+
+    const orch = coopStore.getOrCreate(room.code);
+    orch.startRun({ scenarioStack: ['enc_tutorial_01'] });
+    // Force debrief phase so voteMating is accepted.
+    orch.phase = 'debrief';
+
+    const p1Ws = openWs(port, {
+      code: room.code,
+      player_id: p1.player_id,
+      token: p1.player_token,
+    });
+    await waitOpen(p1Ws);
+    await waitForMessage(p1Ws, (m) => m.type === 'hello');
+
+    p1Ws.send(
+      JSON.stringify({ type: 'intent', payload: { action: 'mating_vote', pair_id: 'a__b' } }),
+    );
+
+    const tallyMsg = await waitForMessage(
+      p1Ws,
+      (m) => m.type === 'mating_tally' && m.payload?.leading_pair_id === 'a__b',
+      2000,
+    );
+    assert.equal(tallyMsg.payload.leading_pair_id, 'a__b');
+
+    const ack = await waitForMessage(p1Ws, (m) => m.type === 'mating_vote_accepted', 2000);
+    assert.ok(ack.payload?.tally);
+    assert.equal(ack.payload.tally.leading_pair_id, 'a__b');
+
+    p1Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});


### PR DESCRIPTION
## S22-B backend -- coop mating vote layer (Tasks 1-3)

Backend half of the S22-B mating roll initiator (plan: Game-Godot-v2 #367). Mirrors the shipped world-vote infra.

- **Task 1** `orch.voteMating` + `matingTally` -- debrief-phase pair voting, idempotent re-vote, deterministic tie-break (lowest `pair_id`), `pair_id = parent_a_id__parent_b_id`. Emits `mating_vote` event (per-player identity signal).
- **Task 2** `POST /api/coop/mating/vote` (mirror `/coop/world/vote`) + `mating_tally` broadcast in the debrief arm of `broadcastCoopState`.
- **Task 3** identity-signal contract test (vote -> MBTI/conviction formula DEFERRED, data-driven per spec).

### Tests
- `coopMatingVote.test.js` (vote/tally/re-vote/gate), `coopMatingRoute.test.js` (route happy + auth-fail + identity event). 115/115 coop regression green.

Godot consumer (MatingApi + PhoneMatingView + loader + composer) = sibling PR on Game-Godot-v2. Resolve->roll (Task 8) reuses existing `meta.js` rollOffspring endpoint, host-mediated.