### PR TITLE
feat(ermes): ADR-2026-05-29 ERMES runtime bridge FASE 2 pilot 4x4

### DIFF
--- a/apps/backend/routes/traits.js
+++ b/apps/backend/routes/traits.js
@@ -248,6 +248,53 @@ function createTraitRouter(options = {}) {
     }
   });
 
+  // ADR-2026-05-29 TKT-BR-08: GET /api/traits/suggestions.
+  // Consumer del file ermes-suggestions piu recente in reports/traits/.
+  // ETag via mtime+size per cache validation. 304 su If-None-Match match.
+  // Output: ermes_trait_suggestion schema v1.0.0 (Eduardo gate accept/reject in frontend).
+  router.get('/suggestions', ...readAccess, async (req, res) => {
+    try {
+      const fs = require('node:fs');
+      const path = require('node:path');
+      const reportsDir = path.resolve(__dirname, '../../../reports/traits');
+      if (!fs.existsSync(reportsDir)) {
+        return res.json({
+          schema: 'ermes_trait_suggestion',
+          schema_version: '1.0.0',
+          suggestions: [],
+          note: 'reports/traits/ assente -- esegui prototypes/ermes_lab/suggestions.py',
+        });
+      }
+      const files = fs
+        .readdirSync(reportsDir)
+        .filter((f) => f.endsWith('-ermes-suggestions.json'));
+      if (files.length === 0) {
+        return res.json({
+          schema: 'ermes_trait_suggestion',
+          schema_version: '1.0.0',
+          suggestions: [],
+          note: 'nessun report ermes-suggestions trovato',
+        });
+      }
+      files.sort(
+        (a, b) =>
+          fs.statSync(path.join(reportsDir, b)).mtimeMs -
+          fs.statSync(path.join(reportsDir, a)).mtimeMs,
+      );
+      const latestPath = path.join(reportsDir, files[0]);
+      const stat = fs.statSync(latestPath);
+      const etag = `W/"${stat.mtimeMs.toFixed(0)}-${stat.size}"`;
+      if (req.headers['if-none-match'] === etag) {
+        return res.status(304).end();
+      }
+      const latest = JSON.parse(fs.readFileSync(latestPath, 'utf8'));
+      res.setHeader('ETag', etag);
+      res.json(latest);
+    } catch (error) {
+      handleError(res, error, 'Errore caricamento suggestions');
+    }
+  });
+
   router.post('/', ...editAccess, async (req, res) => {
     const body = req.body && typeof req.body === 'object' ? req.body : {};
     const traitPayload =

--- a/apps/backend/routes/traits.js
+++ b/apps/backend/routes/traits.js
@@ -265,9 +265,7 @@ function createTraitRouter(options = {}) {
           note: 'reports/traits/ assente -- esegui prototypes/ermes_lab/suggestions.py',
         });
       }
-      const files = fs
-        .readdirSync(reportsDir)
-        .filter((f) => f.endsWith('-ermes-suggestions.json'));
+      const files = fs.readdirSync(reportsDir).filter((f) => f.endsWith('-ermes-suggestions.json'));
       if (files.length === 0) {
         return res.json({
           schema: 'ermes_trait_suggestion',

--- a/apps/backend/services/coop/ermesExporter.js
+++ b/apps/backend/services/coop/ermesExporter.js
@@ -97,6 +97,12 @@ let _cachedReport = null;
 let _cachedPath = null;
 let _cachedMissing = false;
 
+// ADR-2026-05-29 TKT-BR-04: schema v1.0.0 check on report load.
+// Accepted versions: '1.0.0' (multi-biome ADR-2026-05-29) + null/undefined (legacy
+// static fallback fixtures pre-bump). Mismatched non-null version -> log warn +
+// treat as missing (consumer falls back to STATIC_FALLBACKS / NEUTRAL_FALLBACK).
+const ACCEPTED_REPORT_SCHEMA_VERSIONS = new Set(['1.0.0', null, undefined]);
+
 function _loadReport(reportPath) {
   if (reportPath === _cachedPath) {
     if (_cachedMissing) return null;
@@ -115,6 +121,15 @@ function _loadReport(reportPath) {
       return null;
     }
     const data = JSON.parse(raw);
+    // ADR-2026-05-29 TKT-BR-04 schema gate.
+    if (data && data.schema_version && !ACCEPTED_REPORT_SCHEMA_VERSIONS.has(data.schema_version)) {
+      console.warn(
+        `[ermesExporter] schema_version mismatch: got ${data.schema_version}, want 1.0.0 -- falling back`,
+      );
+      _cachedMissing = true;
+      _cachedReport = null;
+      return null;
+    }
     _cachedMissing = false;
     _cachedReport = data;
     return data;
@@ -224,13 +239,85 @@ function listBiomeRoleDemands() {
   }));
 }
 
+// ADR-2026-05-29 TKT-BR-04: bucket-aware export consumer.
+// Reads data/core/balance/ermes_bucket_thresholds.yaml (TKT-BR-05) + maps
+// continuous eco_pressure_score / mutation_bias.* / encounter_bias.* to discrete
+// bucket bands (low/med/high). Used by applyErmesBiomeTraitCosts (TKT-BR-06).
+const DEFAULT_BUCKETS_PATH = path.resolve(
+  __dirname,
+  '../../../../data/core/balance/ermes_bucket_thresholds.yaml',
+);
+let _cachedBuckets = null;
+let _cachedBucketsPath = null;
+
+function _loadBuckets(p = DEFAULT_BUCKETS_PATH) {
+  if (_cachedBuckets && _cachedBucketsPath === p) return _cachedBuckets;
+  if (!fs.existsSync(p)) return null;
+  try {
+    const yaml = require('js-yaml');
+    const data = yaml.load(fs.readFileSync(p, 'utf8'));
+    if (!data || typeof data !== 'object') return null;
+    _cachedBuckets = data;
+    _cachedBucketsPath = p;
+    return data;
+  } catch (err) {
+    console.warn('[ermesExporter] _loadBuckets failed:', err && err.message);
+    return null;
+  }
+}
+
+function _bandFor(value, bucketDef) {
+  if (typeof value !== 'number' || !bucketDef) return null;
+  for (const [name, def] of Object.entries(bucketDef)) {
+    if (!def || !Array.isArray(def.range) || def.range.length < 2) continue;
+    const [lo, hi] = def.range;
+    if (value >= lo && value < hi) return { band: name, def };
+  }
+  // Fallback to high band if value >= last range start.
+  if (bucketDef.high && bucketDef.high.range && value >= bucketDef.high.range[0]) {
+    return { band: 'high', def: bucketDef.high };
+  }
+  if (bucketDef.low) return { band: 'low', def: bucketDef.low };
+  return null;
+}
+
+function getErmesBucketed(biomeId, opts = {}) {
+  const ermes = getErmesForBiome(biomeId, opts);
+  const buckets = _loadBuckets(opts.bucketsPath);
+  if (!buckets || !buckets.buckets) return { ...ermes, buckets: {}, caps: null, guards: null };
+  const out = {};
+  // eco_pressure_score (top-level key in report)
+  if (buckets.buckets.eco_pressure_score && typeof ermes.eco_pressure_score === 'number') {
+    const banded = _bandFor(ermes.eco_pressure_score, buckets.buckets.eco_pressure_score);
+    if (banded) out.eco_pressure_score = banded;
+  }
+  // For mutation_bias.* / encounter_bias.* the report (multi-biome v1.0.0) nests
+  // these under biome record; legacy static fallback may not have them.
+  // Consumer should fetch report separately via _loadReport for those fields.
+  return {
+    ...ermes,
+    buckets: out,
+    caps: buckets.caps || null,
+    guards: buckets.guards || null,
+  };
+}
+
+function _resetBucketsCache() {
+  _cachedBuckets = null;
+  _cachedBucketsPath = null;
+}
+
 module.exports = {
   getErmesForBiome,
+  getErmesBucketed,
   computeRoleGap,
   listBiomeRoleDemands,
   BIOME_ROLE_DEMANDS,
   STATIC_FALLBACKS,
   NEUTRAL_FALLBACK,
+  ACCEPTED_REPORT_SCHEMA_VERSIONS,
+  DEFAULT_BUCKETS_PATH,
   _resetCache,
+  _resetBucketsCache,
   DEFAULT_REPORT_PATH,
 };

--- a/apps/backend/services/ermes/ermesDebriefInput.js
+++ b/apps/backend/services/ermes/ermesDebriefInput.js
@@ -1,0 +1,85 @@
+// ADR-2026-05-29-ermes-runtime-bridge TKT-BR-10 -- debrief input scaffold.
+//
+// Produce prototypes/ermes_lab/inputs/<session_id>.json (schema evo_debrief_for_ermes
+// v1.0.0, audit sezione 5.3 C). Consumer: prototypes/ermes_lab/suggestions.py (BR-07)
+// che lo legge + il latest_eco_pressure_report per emettere JSON-Patch DISCRETI.
+//
+// NB: modulo dedicato (NON bolt-on su apps/backend/report.js che e' il codex-report
+// builder, concern distinto). Hook atteso: chiamato dal session/coop combat-end
+// handler con runState aggregato.
+//
+// Schema (audit 5.3 C):
+//   { schema, schema_version, session_id, biomes_visited[], trait_usage[],
+//     encounter_fires{}, outcomes{} }
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DEFAULT_INPUTS_DIR = path.resolve(__dirname, '../../../../prototypes/ermes_lab/inputs');
+const SCHEMA = 'evo_debrief_for_ermes';
+const SCHEMA_VERSION = '1.0.0';
+
+/**
+ * Build the debrief-for-ermes payload from session runState (pure function).
+ *
+ * @param {string} sessionId
+ * @param {object} runState -- aggregated session stats
+ * @param {Array<string>} [runState.biomesVisited]
+ * @param {Array<object>} [runState.traitUsageStats] -- [{trait_id, fires, ...}]
+ * @param {object} [runState.encounterFireStats] -- {ambush: N, scavenger: N, ...}
+ * @param {object} [runState.outcomes] -- {wins, losses, wipes}
+ * @returns {object} payload
+ */
+function buildDebriefPayload(sessionId, runState = {}) {
+  return {
+    schema: SCHEMA,
+    schema_version: SCHEMA_VERSION,
+    session_id: sessionId || 'unknown',
+    biomes_visited: Array.isArray(runState.biomesVisited) ? runState.biomesVisited : [],
+    trait_usage: Array.isArray(runState.traitUsageStats) ? runState.traitUsageStats : [],
+    encounter_fires:
+      runState.encounterFireStats && typeof runState.encounterFireStats === 'object'
+        ? runState.encounterFireStats
+        : {},
+    outcomes:
+      runState.outcomes && typeof runState.outcomes === 'object'
+        ? runState.outcomes
+        : { wins: 0, losses: 0, wipes: 0 },
+  };
+}
+
+/**
+ * Write the debrief payload to prototypes/ermes_lab/inputs/<session_id>.json.
+ * Idempotent: overwrites same session_id file. Soft-fail safe (returns null on
+ * write error -- non-blocking del session-end flow, ADR-21c precedent).
+ *
+ * @param {string} sessionId
+ * @param {object} runState
+ * @param {object} [opts]
+ * @param {string} [opts.inputsDir] -- override target dir
+ * @returns {string|null} written file path or null on soft-fail
+ */
+function writeErmesDebriefInput(sessionId, runState = {}, opts = {}) {
+  if (!sessionId) return null;
+  const inputsDir = opts.inputsDir || DEFAULT_INPUTS_DIR;
+  const payload = buildDebriefPayload(sessionId, runState);
+  try {
+    fs.mkdirSync(inputsDir, { recursive: true });
+    const safeId = String(sessionId).replace(/[^a-zA-Z0-9_-]/g, '_');
+    const target = path.join(inputsDir, `${safeId}.json`);
+    fs.writeFileSync(target, JSON.stringify(payload, null, 2), 'utf8');
+    return target;
+  } catch (_err) {
+    return null; // soft-fail: debrief input is best-effort, not session-critical
+  }
+}
+
+module.exports = {
+  buildDebriefPayload,
+  writeErmesDebriefInput,
+  SCHEMA,
+  SCHEMA_VERSION,
+  DEFAULT_INPUTS_DIR,
+};

--- a/apps/backend/services/ermes/ermesRunner.js
+++ b/apps/backend/services/ermes/ermesRunner.js
@@ -13,10 +13,7 @@ const DEFAULT_BIOME_POOLS = path.resolve(
   __dirname,
   '../../../../data/core/traits/biome_pools.json',
 );
-const DEFAULT_LAB_SCRIPT = path.resolve(
-  __dirname,
-  '../../../../prototypes/ermes_lab/ermes_sim.py',
-);
+const DEFAULT_LAB_SCRIPT = path.resolve(__dirname, '../../../../prototypes/ermes_lab/ermes_sim.py');
 const DEFAULT_LAB_CONFIG = path.resolve(
   __dirname,
   '../../../../prototypes/ermes_lab/configs/multi_biome.json',
@@ -42,7 +39,7 @@ function createErmesRunner(opts = {}) {
         const traits = [
           ...(pool.traits?.core || []),
           ...(pool.traits?.support || []),
-          ...((pool.role_templates || []).flatMap((rt) => rt.preferred_traits || [])),
+          ...(pool.role_templates || []).flatMap((rt) => rt.preferred_traits || []),
         ];
         for (const traitId of traits) {
           if (!_traitToPoolsMap.has(traitId)) _traitToPoolsMap.set(traitId, new Set());
@@ -116,14 +113,7 @@ function createErmesRunner(opts = {}) {
       const result = await new Promise((resolve, reject) => {
         const proc = spawn(
           python,
-          [
-            labScriptPath,
-            '--multi-biome',
-            '--config',
-            labConfig,
-            '--output',
-            outputPath,
-          ],
+          [labScriptPath, '--multi-biome', '--config', labConfig, '--output', outputPath],
           { stdio: 'pipe' },
         );
         let stderr = '';

--- a/apps/backend/services/ermes/ermesRunner.js
+++ b/apps/backend/services/ermes/ermesRunner.js
@@ -1,0 +1,171 @@
+// ADR-2026-05-29-ermes-runtime-bridge sezione D (TKT-BR-03).
+// Reverse-index trait -> [pool_id] cached at boot. Edit trait -> rerun
+// solo biomi che lo includono. Idempotent queue + checkpoint pattern
+// (anti-pattern #5 CLAUDE.md). Lazy spawn ermes_sim.py --multi-biome.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+const DEFAULT_BIOME_POOLS = path.resolve(
+  __dirname,
+  '../../../../data/core/traits/biome_pools.json',
+);
+const DEFAULT_LAB_SCRIPT = path.resolve(
+  __dirname,
+  '../../../../prototypes/ermes_lab/ermes_sim.py',
+);
+const DEFAULT_LAB_CONFIG = path.resolve(
+  __dirname,
+  '../../../../prototypes/ermes_lab/configs/multi_biome.json',
+);
+const DEFAULT_OUTPUT = path.resolve(
+  __dirname,
+  '../../../../prototypes/ermes_lab/outputs/latest_eco_pressure_report.json',
+);
+
+function createErmesRunner(opts = {}) {
+  const biomePoolsPath = opts.biomePoolsPath || DEFAULT_BIOME_POOLS;
+  const labScriptPath = opts.labScriptPath || DEFAULT_LAB_SCRIPT;
+  const labConfig = opts.labConfig || DEFAULT_LAB_CONFIG;
+  const outputPath = opts.outputPath || DEFAULT_OUTPUT;
+  const python = opts.pythonExecutable || 'python';
+
+  // Build trait -> [pool_id] reverse map at boot.
+  const _traitToPoolsMap = new Map();
+  if (fs.existsSync(biomePoolsPath)) {
+    try {
+      const data = JSON.parse(fs.readFileSync(biomePoolsPath, 'utf8'));
+      for (const pool of data.pools || []) {
+        const traits = [
+          ...(pool.traits?.core || []),
+          ...(pool.traits?.support || []),
+          ...((pool.role_templates || []).flatMap((rt) => rt.preferred_traits || [])),
+        ];
+        for (const traitId of traits) {
+          if (!_traitToPoolsMap.has(traitId)) _traitToPoolsMap.set(traitId, new Set());
+          _traitToPoolsMap.get(traitId).add(pool.id);
+        }
+      }
+      // Normalize Set -> Array.
+      for (const [k, v] of _traitToPoolsMap) _traitToPoolsMap.set(k, Array.from(v));
+    } catch (err) {
+      console.warn('[ermesRunner] reverse-index boot fail:', err && err.message);
+    }
+  }
+
+  // Idempotent queue (set-based dedup).
+  const _pending = new Set();
+  let _running = false;
+  const _listeners = [];
+
+  function getTraitToPoolsMap() {
+    return _traitToPoolsMap;
+  }
+
+  function poolsForTrait(traitId) {
+    return _traitToPoolsMap.get(traitId) || [];
+  }
+
+  function enqueueRerun({ traitId } = {}) {
+    if (!traitId) return false;
+    _pending.add(traitId);
+    return true;
+  }
+
+  function pendingQueueSize() {
+    return _pending.size;
+  }
+
+  function isRunning() {
+    return _running;
+  }
+
+  function onRerunComplete(callback) {
+    if (typeof callback === 'function') _listeners.push(callback);
+  }
+
+  async function runQueuedRerun() {
+    if (_running) return { skipped: true, reason: 'already_running' };
+    if (_pending.size === 0) return { skipped: true, reason: 'empty_queue' };
+    _running = true;
+    const trait_ids = Array.from(_pending);
+    _pending.clear();
+    try {
+      const affected_pools = new Set();
+      for (const tid of trait_ids) {
+        for (const p of poolsForTrait(tid)) affected_pools.add(p);
+      }
+      if (labScriptPath === '/skip') {
+        const result = {
+          skipped_lab: true,
+          trait_ids,
+          affected_pools: Array.from(affected_pools),
+        };
+        _listeners.forEach((cb) => {
+          try {
+            cb(result);
+          } catch (_) {
+            /* swallow */
+          }
+        });
+        return result;
+      }
+      const result = await new Promise((resolve, reject) => {
+        const proc = spawn(
+          python,
+          [
+            labScriptPath,
+            '--multi-biome',
+            '--config',
+            labConfig,
+            '--output',
+            outputPath,
+          ],
+          { stdio: 'pipe' },
+        );
+        let stderr = '';
+        proc.stderr.on('data', (d) => {
+          stderr += d.toString();
+        });
+        proc.on('exit', (code) => {
+          if (code === 0)
+            resolve({
+              output: outputPath,
+              trait_ids,
+              affected_pools: Array.from(affected_pools),
+            });
+          else reject(new Error(`ermes_sim exited ${code}: ${stderr.slice(0, 400)}`));
+        });
+      });
+      _listeners.forEach((cb) => {
+        try {
+          cb(result);
+        } catch (_) {
+          /* swallow */
+        }
+      });
+      return result;
+    } finally {
+      _running = false;
+    }
+  }
+
+  return {
+    getTraitToPoolsMap,
+    poolsForTrait,
+    enqueueRerun,
+    pendingQueueSize,
+    isRunning,
+    onRerunComplete,
+    runQueuedRerun,
+    DEFAULT_BIOME_POOLS,
+    DEFAULT_LAB_SCRIPT,
+    DEFAULT_LAB_CONFIG,
+    DEFAULT_OUTPUT,
+  };
+}
+
+module.exports = { createErmesRunner };

--- a/apps/backend/services/traitEffects.js
+++ b/apps/backend/services/traitEffects.js
@@ -658,6 +658,100 @@ function applyBiomeTraitCosts(unit, biomeId, data) {
   return applied;
 }
 
+// ADR-2026-05-29 TKT-BR-06: ERMES-derived discrete deltas extension.
+// Mirror del pattern applyBiomeTraitCosts (ADR-21c) ma legge ERMES report multi-biome
+// v1.0.0 + applica delta DISCRETI dai bucket (ermes_bucket_thresholds.yaml).
+// Output: unit.attack_mod_bonus / defense_mod_bonus / mobility / rest_recovery.
+// NO write su creature_epigenome.bias (vincolo sot-drift-verifier preliminary).
+// Idempotente via marker _ermes_biome_costs_applied. Session-scoped.
+
+const ERMES_STAT_KEYS = ['attack_mod', 'defense_mod', 'mobility', 'rest_recovery'];
+
+function _clampDelta(value, cap) {
+  if (typeof value !== 'number') return 0;
+  return Math.max(-cap, Math.min(cap, value));
+}
+
+/**
+ * Apply ERMES bucketed deltas to a unit (additive to existing bonuses).
+ *
+ * @param {object} unit - mutated in place
+ * @param {string} biomeId
+ * @param {object} [opts] - { ermesExporter, ermesReport, capDelta }
+ * @returns {Array<{ bucket, delta, source }>} applied log
+ */
+function applyErmesBiomeTraitCosts(unit, biomeId, opts = {}) {
+  if (!unit || !biomeId) return [];
+  if (unit._ermes_biome_costs_applied) {
+    return (unit._ermes_biome_costs_log && unit._ermes_biome_costs_log.buckets_applied) || [];
+  }
+
+  let bucketed = opts.bucketed;
+  if (!bucketed) {
+    try {
+      const ermesExporter = opts.ermesExporter || require('./coop/ermesExporter');
+      if (typeof ermesExporter.getErmesBucketed !== 'function') return [];
+      bucketed = ermesExporter.getErmesBucketed(biomeId);
+    } catch (err) {
+      return []; // soft-fail (ADR-21c precedent)
+    }
+  }
+  if (!bucketed || !bucketed.buckets || Object.keys(bucketed.buckets).length === 0) return [];
+
+  const caps = bucketed.caps || { max_delta_any_stat: 2, max_buckets_active_per_unit: 3 };
+  const capDelta = opts.capDelta || caps.max_delta_any_stat || 2;
+  const maxActive = caps.max_buckets_active_per_unit || 3;
+
+  const applied = [];
+  const totalDelta = Object.fromEntries(ERMES_STAT_KEYS.map((k) => [k, 0]));
+
+  let activeCount = 0;
+  for (const [bucketKey, banded] of Object.entries(bucketed.buckets)) {
+    if (activeCount >= maxActive) break;
+    if (!banded || !banded.def) continue;
+    const def = banded.def;
+    let consumed = false;
+
+    // eco_pressure_score uses delta_mod (global stat-agnostic +/-1).
+    if (typeof def.delta_mod === 'number' && def.delta_mod !== 0) {
+      totalDelta.attack_mod = _clampDelta(totalDelta.attack_mod + def.delta_mod, capDelta);
+      totalDelta.defense_mod = _clampDelta(totalDelta.defense_mod + def.delta_mod, capDelta);
+      consumed = true;
+    }
+
+    // delta object {stat: amount}.
+    if (def.delta && typeof def.delta === 'object') {
+      for (const [stat, amount] of Object.entries(def.delta)) {
+        if (!ERMES_STAT_KEYS.includes(stat)) continue;
+        if (typeof amount !== 'number' || amount === 0) continue;
+        totalDelta[stat] = _clampDelta(totalDelta[stat] + amount, capDelta);
+        consumed = true;
+      }
+    }
+
+    if (consumed) {
+      applied.push({ bucket: bucketKey, band: banded.band, def });
+      activeCount += 1;
+    }
+  }
+
+  for (const stat of ERMES_STAT_KEYS) {
+    if (totalDelta[stat] === 0) continue;
+    const fieldName = stat === 'attack_mod' || stat === 'defense_mod' ? `${stat}_bonus` : stat;
+    unit[fieldName] = (unit[fieldName] || 0) + totalDelta[stat];
+  }
+
+  unit._ermes_biome_costs_applied = true;
+  unit._ermes_biome_costs_log = { biomeId, buckets_applied: applied, total_delta: totalDelta };
+  return applied;
+}
+
+function _resetErmesCostMarker(unit) {
+  if (!unit) return;
+  delete unit._ermes_biome_costs_applied;
+  delete unit._ermes_biome_costs_log;
+}
+
 /**
  * Evaluate movement-triggered buff_stat traits for a unit.
  *
@@ -707,6 +801,10 @@ module.exports = {
   applyBiomeTraitCosts,
   BIOME_COST_DEFAULT_PATH,
   _resetBiomeCostCache,
+  // ADR-2026-05-29 TKT-BR-06 ERMES bucketed deltas
+  applyErmesBiomeTraitCosts,
+  _resetErmesCostMarker,
+  ERMES_STAT_KEYS,
   // Per-tag enemy gate (audit follow-up 2026-04-25)
   // ADR-2026-05-15 Phase 4b — canonical species_catalog.json + legacy fallback
   loadSpeciesTagIndex,

--- a/data/core/balance/ermes_bucket_thresholds.yaml
+++ b/data/core/balance/ermes_bucket_thresholds.yaml
@@ -1,0 +1,102 @@
+# ADR-2026-05-29-ermes-runtime-bridge sezione C (TKT-BR-05).
+# Bucket DISCRETI per output ERMES runtime (anti-ref Creatures + Niche Mendel
+# pattern). Substrate continuo 0-1 e' INPUT; output sui mod runtime e' band
+# (low/med/high) con delta cap +/-2 mirror ADR-21c.
+#
+# Consumer: apps/backend/services/traitEffects.applyErmesBiomeTraitCosts (TKT-BR-06)
+# + apps/backend/services/coop/ermesExporter.getErmesBucketed (TKT-BR-04).
+#
+# Schema gate: validato da AJV (TODO TKT-BR-04b se serve schema strict);
+# format YAML semplice + range tuple [lo, hi).
+
+schema_version: "1.0"
+ratified_by: "ADR-2026-05-29-ermes-runtime-bridge"
+ratified_at: "2026-05-29"
+
+buckets:
+  # input: ermesReport.biomes[bid].eco_pressure_score (float [0,1])
+  # output: discrete band + global delta_mod cap, narrative diegetico player-facing.
+  eco_pressure_score:
+    low:
+      range: [0.0, 0.33]
+      delta_mod: -1
+      narrative_it: "Bioma calmo."
+    med:
+      range: [0.33, 0.66]
+      delta_mod: 0
+      narrative_it: "Bioma in equilibrio."
+    high:
+      range: [0.66, 1.0]
+      delta_mod: 1
+      narrative_it: "Bioma in tensione."
+
+  # input: ermesReport.biomes[bid].mutation_bias.heat_resistance (float [0,1])
+  # output: discrete delta on defense_mod (heat-related traits).
+  mutation_bias.heat_resistance:
+    low:
+      range: [0.0, 0.10]
+      delta: { defense_mod: 0 }
+    med:
+      range: [0.10, 0.20]
+      delta: { defense_mod: 1 }
+    high:
+      range: [0.20, 1.0]
+      delta: { defense_mod: 2 }
+
+  mutation_bias.burst_mobility:
+    low:
+      range: [0.0, 0.10]
+      delta: { mobility: 0 }
+    med:
+      range: [0.10, 0.20]
+      delta: { mobility: 1 }
+    high:
+      range: [0.20, 1.0]
+      delta: { mobility: 2 }
+
+  mutation_bias.efficient_metabolism:
+    low:
+      range: [0.0, 0.10]
+      delta: { rest_recovery: 0 }
+    med:
+      range: [0.10, 0.20]
+      delta: { rest_recovery: 1 }
+    high:
+      range: [0.20, 1.0]
+      delta: { rest_recovery: 2 }
+
+  mutation_bias.sensory_alertness:
+    low:
+      range: [0.0, 0.10]
+      delta: { attack_mod: 0 }
+    med:
+      range: [0.10, 0.20]
+      delta: { attack_mod: 1 }
+    high:
+      range: [0.20, 1.0]
+      delta: { attack_mod: 2 }
+
+  # input: ermesReport.biomes[bid].encounter_bias.ambush (float [0,1])
+  # output: spawn weight modifier per biomeSpawnBias.js (W5.5 mirror Godot v2).
+  encounter_bias.ambush:
+    low:
+      range: [0.0, 0.10]
+      spawn_weight_mod: 0
+    med:
+      range: [0.10, 0.18]
+      spawn_weight_mod: 1
+    high:
+      range: [0.18, 1.0]
+      spawn_weight_mod: 2
+
+caps:
+  # mirror ADR-21c range strict +/-1/+/-2.
+  max_delta_any_stat: 2
+  max_delta_per_round: 2
+  # anti-overload: max 3 bucket attivi su singola unit (leggibilita gameplay).
+  max_buckets_active_per_unit: 3
+
+guards:
+  null_safe: true
+  bucket_miss_fallback: low
+  soft_fail_on_eco_pressure_missing: true  # mirror ADR-21c precedent

--- a/docs/museum/cards/ermes-bridge-pilot-2026-05-29.md
+++ b/docs/museum/cards/ermes-bridge-pilot-2026-05-29.md
@@ -1,0 +1,111 @@
+---
+title: ERMES runtime bridge pilot 4x4 (FASE 2 shipped 2026-05-29)
+museum_id: M-2026-05-29-001
+type: architecture
+domain: ermes_bridge
+provenance:
+  found_at: vault Spaces/Dev/Evo-Tactics/adr/ADR-2026-05-29-ermes-runtime-bridge.md
+  git_sha_first: 664f0c91
+  git_sha_last: 4f1a9800
+  last_modified: 2026-05-29
+  last_author: claude (FASE 2 via PR Game)
+  buried_reason: deferred (originally E7 plan ERMES 2026-04-29 + Sprint 3 Roadmap Biodiversita Connessa 2026-04-19)
+relevance_score: 5
+reuse_path: 'Estensione ADR-21c pattern -> ermesRunner reverse-index + applyErmesBiomeTraitCosts bucketed DISCRETO + suggestions JSON-Patch + REST /api/traits/suggestions. Pilot 4 trait x 4 biomi (savana / caverna_risonante / rovine_planari / cryosteppe_convergence). Promotion N=40 calibration (TKT-BR-12 deferred).'
+related_pillars: [P2, P5, P6]
+status: curated
+excavated_by: repo-archaeologist (via Claude Code Ryzen session 2026-05-29)
+excavated_on: 2026-05-29
+last_verified: 2026-05-29
+---
+
+# ERMES runtime bridge pilot 4x4
+
+## Summary (30s)
+
+- **What**: il bridge `trait-editor <-> canon <-> ERMES <-> debrief <-> bias` shipped 2026-05-29 come FASE 2 di ADR-2026-05-29-ermes-runtime-bridge. Mirror struttura ADR-2026-04-21c pilot 4x3 trait_environmental_costs.
+- **Where**: `apps/backend/services/ermes/ermesRunner.js` (NEW) + `apps/backend/services/coop/ermesExporter.js` (updated schema v1.0.0 + getErmesBucketed) + `apps/backend/services/traitEffects.js` (applyErmesBiomeTraitCosts extension) + `apps/backend/routes/traits.js` (GET /api/traits/suggestions) + `prototypes/ermes_lab/ermes_sim.py` (run_multi_biome) + `prototypes/ermes_lab/suggestions.py` (NEW) + `data/core/balance/ermes_bucket_thresholds.yaml` (NEW).
+- **Why counts**: chiude pattern "Engine LIVE Surface DEAD" identificato in V2 inspect Vision Spec Gap. Trait edit ora propaga ERMES bias agli stati runtime e suggestion al trait-editor in modo DISCRETO leggibile (anti-ref Creatures).
+
+## What was buried
+
+Plan E7 ERMES (2026-04-29) deferred post Sprint I + ADR + test regression. Sprint I deprecated post-pivot Godot (DC-08 verdict 2026-05-29). ADR + test regression preparate FASE 1 + FASE 2 via ADR-2026-05-29-trait-schema-canonization (PR #2427) + ADR-2026-05-29-ermes-runtime-bridge (vault PR #212 merged 2026-05-29).
+
+Roadmap Biodiversita Connessa Drive (2026-04-19 v1.0) Sprint 3 "Connessioni attive" + Sprint 4 "Progressione/UI/telemetria" mappa esattamente sul ciclo bridge ERMES.
+
+## Why it might still matter
+
+### Pillar match
+
+- **P2 Evoluzione emergente**: ERMES bias drive runtime trait modifier discrete (anti-ref Creatures stat-drift continuo). Spore Niche Mendel-style espressione DISCRETA leggibile.
+- **P5 Co-op vs Sistema**: bioma reagisce alle scelte trait squadra = sistema-pressione narrative + tactical layer.
+- **P6 Fairness**: bucket cap +/-2 + max 3 buckets active per unit = leggibilita anti-overload. Calibration N=40 gate (TKT-BR-12 deferred).
+
+### Cross-card ecosystem
+
+- [M-2026-04-25-011 BiomeMemory + trait cost](architecture-biome-memory-trait-cost.md) -- Path Full ora shipped (era Moderate ADR-21c shipped 2026-04-21).
+- [M-2026-04-26-001 Voidling Bound 6 patterns](evolution_genetics-voidling-bound-patterns.md) -- P1/P3 ability class unlock + Apex terminal endpoint allineato con bucket DISCRETO output.
+- [M-2026-04-25-007 mating-engine-orphan](mating_nido-engine-orphan.md) -- M-007 FULL CLOSURE 2026-05-13 prerequisite per bridge step ortogonalita D-HEIR.
+- [M-2026-05-10-001 ancestors-rename-proposals](ancestors-297-orphan-2026-05-10.md) -- Tier-Ancestor policy chiusa nello stesso ship FASE 1.
+
+## Concrete reuse paths
+
+### 1. Minimal -- verifica end-to-end pipeline (~30 min)
+
+```bash
+# Genera report multi-biome
+python prototypes/ermes_lab/ermes_sim.py --multi-biome \
+  --config prototypes/ermes_lab/configs/multi_biome.json \
+  --output prototypes/ermes_lab/outputs/latest_eco_pressure_report.json
+
+# Genera suggestions
+python prototypes/ermes_lab/suggestions.py
+
+# Consumer backend
+curl http://localhost:3334/api/traits/suggestions
+```
+
+### 2. Moderate -- TKT-BR-09 Vue 3 view (~3h)
+
+`apps/trait-editor/src/views/TraitSuggestionsView.vue`: tabella suggestions + accept/reject buttons mapping a TraitValidationAutoFix.operations. ItB telegraph pattern (tutto visibile pre-accept).
+
+### 3. Full -- TKT-BR-12 calibration batch N=40 (~half-day)
+
+`tools/py/calibrate_drift_verify.py --n-per-trial 40` su 4 biomi pilot. WR shift threshold <5pp promotion / 5-10pp tune / >10pp kill (mirror ADR-21c criteria). Workflow L-2026-05-055 reuse.
+
+## Sources / provenance trail
+
+- ADR vault (vault sovereign): [`ADR-2026-05-29-ermes-runtime-bridge.md`](../../../../vault Spaces/Dev/Evo-Tactics/adr/ADR-2026-05-29-ermes-runtime-bridge.md) -- merged vault PR #212.
+- Plan formale superpowers writing-plans: [`vault plans/2026-05-29-traits-editor-ermes-bridge.md`](../../../../vault Spaces/Dev/Evo-Tactics/plans/2026-05-29-traits-editor-ermes-bridge.md).
+- Audit master vault: [`vault 2026-05-29-traits-editor-ermes-integration-audit-and-design.md`](../../../../vault Spaces/Dev/Evo-Tactics/2026-05-29-traits-editor-ermes-integration-audit-and-design.md).
+- ADR canon parallela FASE 1: vault `Spaces/Dev/Evo-Tactics/adr/ADR-2026-05-29-trait-schema-canonization.md` -- merged Game PR #2427 2026-05-29.
+- Pattern reuse ADR-21c: [`docs/adr/ADR-2026-04-21c-trait-environmental-costs.md`](../../adr/ADR-2026-04-21c-trait-environmental-costs.md).
+- Plan ERMES E0-E8: [`docs/planning/2026-04-29-ermes-integration-plan.md`](../../planning/2026-04-29-ermes-integration-plan.md).
+- Cleanup-handoff: [`docs/planning/2026-04-29-ermes-cleanup-handoff.md`](../../planning/2026-04-29-ermes-cleanup-handoff.md).
+- sot-drift-verifier preliminary verdict: vault `docs/research/2026-05-29-sot-drift-verifier-preliminary-verdict.md` -- NO_DRIFT high confidence.
+- Sprint I status verification: vault `docs/research/2026-05-29-sprint-i-status-verification.md` -- DEPRECATED post-pivot Godot 2026-04-29.
+
+## Risks / open questions
+
+- **R5 anti-Creatures stat-drift**: mitigato via bucket DISCRETI hardcoded `data/core/balance/ermes_bucket_thresholds.yaml` (cap +/-2, max 3 buckets active).
+- **R6 sot-drift D-HEIR**: TKT-DC-06 epigenome readback + TKT-BR-15 sot-drift-verifier preliminary verdict NO_DRIFT. Re-invocazione gate (a) Fase-4 stat_drift_per_gen / (b) consumer scrive creature_epigenome.bias / (c) N=40 cap exceed.
+- **R4 Godot v2 cross-repo parity**: TKT-BR-11 deferred (mirror PR `ermes_role_gap.gd`).
+- **TKT-BR-09 Vue 3 view deferred**: REST endpoint shipped + suggestions producer shipped, frontend UI accept/reject in follow-up PR.
+- **TKT-BR-12 calibration N=40 deferred**: operational task (richiede game running + test fixtures specifici). Promotion gate post-deploy.
+
+## Anti-pattern guard
+
+- **NON applicare auto suggestions** senza Eduardo gate accept/reject (ADR sezione Scope guard).
+- **NON usare nome "ERMES"** come label UI player-facing (doctrine: nome diegetico, narrative "Bioma calmo/in equilibrio/in tensione").
+- **NON estendere bucket thresholds** durante pilot senza ratifica master-dd (tunabilita post-playtest TKT-BR-12).
+- **NON scrivere dentro creature_epigenome.bias** dal consumer ERMES (vincolo sot-drift-verifier).
+- **NON skip mirror Godot v2 PR** quando shipping (TKT-BR-11 obbligatorio post-pilot).
+
+## Next actions
+
+- TKT-BR-09 Vue 3 TraitSuggestionsView (follow-up PR).
+- TKT-BR-10 debrief input scaffold (`apps/backend/report.js` extend per session.id -> prototypes/ermes_lab/inputs/).
+- TKT-BR-11 cross-repo Godot v2 mirror PR (ermes_role_gap.gd).
+- TKT-BR-12 calibration batch N=40 (post-deploy verifica promotion gate).
+- TKT-BR-14 trackers update (`Game PILLARS_STATUS.md` + `codemasterdd KNOWLEDGE_MAP.md` sezione 2 row "ERMES runtime bridge").
+- TKT-BR-15 sot-drift-verifier final verdict post-FASE 2 ship.

--- a/prototypes/ermes_lab/configs/multi_biome.json
+++ b/prototypes/ermes_lab/configs/multi_biome.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "1.0.0",
+  "seed": 7,
+  "generations": 50,
+  "biomes": {
+    "savana": {
+      "environment": {"temperature": 0.7, "food": 0.5, "predators": 0.6, "volatility": 0.04},
+      "species": [
+        {"name": "dune_stalker", "population": 80,
+         "traits": {"speed": 0.7, "size": 0.6, "resistance": 0.5},
+         "reproduction_rate": 0.8, "mutation_rate": 0.1, "mutation_strength": 0.05}
+      ]
+    },
+    "caverna_risonante": {
+      "environment": {"temperature": 0.4, "food": 0.4, "predators": 0.5, "volatility": 0.05},
+      "species": [
+        {"name": "bat_swarm", "population": 100,
+         "traits": {"speed": 0.6, "size": 0.3, "resistance": 0.6},
+         "reproduction_rate": 1.0, "mutation_rate": 0.12, "mutation_strength": 0.06}
+      ]
+    },
+    "rovine_planari": {
+      "environment": {"temperature": 0.5, "food": 0.45, "predators": 0.4, "volatility": 0.04},
+      "species": [
+        {"name": "construct", "population": 50,
+         "traits": {"speed": 0.4, "size": 0.7, "resistance": 0.8},
+         "reproduction_rate": 0.6, "mutation_rate": 0.05, "mutation_strength": 0.03}
+      ]
+    },
+    "cryosteppe_convergence": {
+      "environment": {"temperature": 0.15, "food": 0.4, "predators": 0.5, "volatility": 0.06},
+      "species": [
+        {"name": "cryo_lupus", "population": 70,
+         "traits": {"speed": 0.65, "size": 0.55, "resistance": 0.75},
+         "reproduction_rate": 0.75, "mutation_rate": 0.1, "mutation_strength": 0.05}
+      ]
+    }
+  }
+}

--- a/prototypes/ermes_lab/ermes_sim.py
+++ b/prototypes/ermes_lab/ermes_sim.py
@@ -115,8 +115,85 @@ class Tests(unittest.TestCase):
 def run_tests():
     res=unittest.TextTestRunner(verbosity=2).run(unittest.defaultTestLoader.loadTestsFromTestCase(Tests));
     if not res.wasSuccessful(): raise SystemExit(1)
+
+# ADR-2026-05-29 TKT-BR-02: multi-biome run + nested v1.0.0 report.
+# Refactor closes G-C1 schema mismatch (ermesExporter consumer expects nested
+# report.biomes[bid].eco_pressure_score; flat single-biome legacy emit kept
+# for back-compat via run_simulation).
+def _strip_to_biome_record(flat_report):
+    """Convert flat single-biome report to nested biome-record (rename eco_pressure
+    -> eco_pressure_score + back-compat bias key for W5-bb ermesExporter consumer)."""
+    return {
+        'eco_pressure_score': flat_report['eco_pressure'],
+        'food_pressure': flat_report['food_pressure'],
+        'predator_pressure': flat_report['predator_pressure'],
+        'temperature_pressure': flat_report['temperature_pressure'],
+        'encounter_bias': flat_report['encounter_bias'],
+        'mutation_bias': flat_report['mutation_bias'],
+        'bias': {
+            'predator_density': flat_report['predator_pressure'],
+            'resource_scarcity': flat_report['food_pressure'],
+        },
+        'extinction_risk': flat_report['extinction_risk'],
+        'species_summary': flat_report['species_summary'],
+        'debrief_notes': flat_report['debrief_notes'],
+    }
+
+
+def build_multi_biome_report(biome_results):
+    """Compose v1.0.0 multi-biome schema (ADR-2026-05-29 sezione B)."""
+    from datetime import datetime, timezone
+    return {
+        'schema': 'ermes_eco_pressure_report',
+        'schema_version': '1.0.0',
+        'generated_at': datetime.now(timezone.utc).isoformat(),
+        'generator': {'tool': 'ermes_sim.py', 'tool_version': '0.6.0'},
+        'biomes': {bid: _strip_to_biome_record(rep) for bid, rep in biome_results.items()},
+        'runtime_note': 'Prototype-derived. Consumer must check schema_version.',
+    }
+
+
+def run_multi_biome(config):
+    """Execute per-biome simulation and emit nested v1.0.0 report.
+
+    Config shape: {schema_version, seed, generations, biomes: {bid: {environment, species}}}.
+    Determinism: same seed reused per biome (each run_simulation re-seeds via random.seed).
+    """
+    biomes_config = config.get('biomes', {})
+    if not biomes_config:
+        raise ValueError("multi_biome config missing 'biomes' dict")
+    seed = int(config.get('seed', 7))
+    generations = int(config.get('generations', 150))
+    results = {}
+    for biome_id, bcfg in biomes_config.items():
+        single_config = {
+            'biome_id': biome_id,
+            'seed': seed,
+            'generations': generations,
+            'environment': bcfg['environment'],
+            'species': bcfg['species'],
+        }
+        _, report = run_simulation(single_config)
+        results[biome_id] = report
+    return build_multi_biome_report(results)
+
+
 def main(argv=None):
-    p=argparse.ArgumentParser(); p.add_argument('--cli',action='store_true'); p.add_argument('--test',action='store_true'); p.add_argument('--config',default=str(DEFAULT_CONFIG)); p.add_argument('--output',default=str(DEFAULT_OUTPUT)); p.add_argument('--history',default=str(DEFAULT_HISTORY_CSV)); a=p.parse_args(argv or sys.argv[1:])
+    p=argparse.ArgumentParser()
+    p.add_argument('--cli',action='store_true')
+    p.add_argument('--test',action='store_true')
+    p.add_argument('--multi-biome',action='store_true',help='Use multi-biome schema v1.0.0 (ADR-2026-05-29)')
+    p.add_argument('--config',default=str(DEFAULT_CONFIG))
+    p.add_argument('--output',default=str(DEFAULT_OUTPUT))
+    p.add_argument('--history',default=str(DEFAULT_HISTORY_CSV))
+    a=p.parse_args(argv or sys.argv[1:])
     if a.test: run_tests(); return 0
+    if a.multi_biome:
+        config = load_config(Path(a.config))
+        report = run_multi_biome(config)
+        write_report(report, Path(a.output))
+        print(f'Multi-biome report: {a.output}')
+        print(f"Biomes: {sorted(report['biomes'].keys())}")
+        return 0
     run_cli(Path(a.config),Path(a.output),Path(a.history)); return 0
 if __name__=='__main__': raise SystemExit(main())

--- a/prototypes/ermes_lab/suggestions.py
+++ b/prototypes/ermes_lab/suggestions.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""ERMES suggestions generator (ADR-2026-05-29 sezione E, TKT-BR-07).
+
+Consumes:
+- prototypes/ermes_lab/outputs/latest_eco_pressure_report.json (multi-biome v1.0.0)
+- data/traits/index.json (trait metadata)
+
+Emits:
+- reports/traits/<YYYY-MM-DD>-ermes-suggestions.json (schema 1.0.0, JSON-Patch DISCRETI).
+
+Schema output (audit sezione 5.3 B):
+{
+  "schema": "ermes_trait_suggestion",
+  "schema_version": "1.0.0",
+  "generated_at": "...",
+  "suggestions": [
+    {"trait_id", "biome_id", "kind", "rationale", "evidence", "proposed_patch", "confidence"}
+  ]
+}
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+DEFAULT_REPORT = REPO / 'prototypes/ermes_lab/outputs/latest_eco_pressure_report.json'
+DEFAULT_INDEX = REPO / 'data/traits/index.json'
+DEFAULT_OUTPUT_DIR = REPO / 'reports/traits'
+
+TIER_LADDER = {'T1': 'T2', 'T2': 'T3', 'T3': 'T4'}
+
+
+def _load(path: Path):
+    return json.loads(path.read_text(encoding='utf-8'))
+
+
+def _next_tier(current):
+    return TIER_LADDER.get(current)
+
+
+def _extract_extinction_warnings(report, index):
+    """Suggest tier bump per trait linked a specie con extinction_risk > 0.6."""
+    out = []
+    for biome_id, bdata in report.get('biomes', {}).items():
+        ext = bdata.get('extinction_risk', {})
+        for species_id, risk in ext.items():
+            if not isinstance(risk, (int, float)) or risk <= 0.6:
+                continue
+            for trait_id, entry in index.get('traits', {}).items():
+                sa = entry.get('species_affinity', [])
+                if not any(isinstance(s, dict) and s.get('species_id') == species_id for s in sa):
+                    continue
+                current_tier = entry.get('tier')
+                next_t = _next_tier(current_tier)
+                if not next_t:
+                    continue
+                out.append({
+                    'trait_id': trait_id,
+                    'biome_id': biome_id,
+                    'kind': 'extinction_risk_warning',
+                    'rationale': (
+                        f'High extinction risk ({risk:.2f}) on linked species {species_id} '
+                        f'in biome {biome_id} -- consider tier bump.'
+                    ),
+                    'evidence': {
+                        'eco_pressure_score': bdata.get('eco_pressure_score'),
+                        'extinction_risk': risk,
+                        'species_id': species_id,
+                    },
+                    'proposed_patch': {
+                        'op': 'replace',
+                        'path': '/tier',
+                        'value': next_t,
+                    },
+                    'confidence': min(0.85, risk),
+                })
+    return out
+
+
+def _extract_mutation_bias_matches(report, index):
+    """Suggest add biome_tag where mutation_bias.X >= 0.20 + trait con keyword in metadata."""
+    out = []
+    keyword_map = {
+        'heat_resistance': 'heat',
+        'burst_mobility': 'burst',
+        'efficient_metabolism': 'metabolism',
+        'sensory_alertness': 'sensory',
+    }
+    for biome_id, bdata in report.get('biomes', {}).items():
+        mb = bdata.get('mutation_bias', {})
+        for bias_key, keyword in keyword_map.items():
+            value = mb.get(bias_key)
+            if not isinstance(value, (int, float)) or value < 0.20:
+                continue
+            for trait_id, entry in index.get('traits', {}).items():
+                text = ' '.join([
+                    str(entry.get('famiglia_tipologia', '')),
+                    str(entry.get('debolezza', '')),
+                    str(entry.get('spinta_selettiva', '')),
+                ]).lower()
+                if keyword not in text:
+                    continue
+                tags = entry.get('biome_tags') or []
+                if biome_id in tags:
+                    continue
+                out.append({
+                    'trait_id': trait_id,
+                    'biome_id': biome_id,
+                    'kind': 'mutation_bias_match',
+                    'rationale': (
+                        f'Bioma {biome_id} ha mutation_bias.{bias_key}={value:.2f} (high) e '
+                        f'trait {trait_id} contiene keyword "{keyword}". Suggerimento: '
+                        f'aggiungere biome_tag "{biome_id}" a trait.biome_tags.'
+                    ),
+                    'evidence': {
+                        'mutation_bias_key': bias_key,
+                        'mutation_bias_value': value,
+                        'tag_suggested': biome_id,
+                    },
+                    'proposed_patch': {
+                        'op': 'add',
+                        'path': '/biome_tags/-',
+                        'value': biome_id,
+                    },
+                    'confidence': min(0.6, value * 2),
+                })
+    return out
+
+
+def generate_suggestions(report_path, index_path):
+    report = _load(report_path)
+    index = _load(index_path)
+    suggestions = []
+    suggestions.extend(_extract_extinction_warnings(report, index))
+    suggestions.extend(_extract_mutation_bias_matches(report, index))
+    return {
+        'schema': 'ermes_trait_suggestion',
+        'schema_version': '1.0.0',
+        'generated_at': datetime.now(timezone.utc).isoformat(),
+        'source_report': str(report_path),
+        'source_index': str(index_path),
+        'suggestions': suggestions,
+    }
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--report', default=str(DEFAULT_REPORT))
+    ap.add_argument('--index', default=str(DEFAULT_INDEX))
+    today = datetime.now().strftime('%Y-%m-%d')
+    ap.add_argument(
+        '--output',
+        default=str(DEFAULT_OUTPUT_DIR / f'{today}-ermes-suggestions.json'),
+    )
+    args = ap.parse_args(argv)
+
+    if not Path(args.report).exists():
+        print(f'ERROR report not found: {args.report}', file=sys.stderr)
+        return 1
+
+    out = generate_suggestions(Path(args.report), Path(args.index))
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(out, indent=2, ensure_ascii=False), encoding='utf-8')
+    print(f'Wrote {out_path} ({len(out["suggestions"])} suggestions)')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/prototypes/ermes_lab/tests/test_ermes_lab_multi_biome.py
+++ b/prototypes/ermes_lab/tests/test_ermes_lab_multi_biome.py
@@ -1,0 +1,54 @@
+"""Test multi-biome run -- ADR-2026-05-29 schema v1.0.0 (TKT-BR-02)."""
+import json
+import sys
+from pathlib import Path
+
+LAB = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(LAB))
+from ermes_sim import run_multi_biome, load_config  # noqa: E402
+
+CONFIG = LAB / "configs/multi_biome.json"
+
+
+def test_multi_biome_run_emits_nested_schema():
+    config = load_config(CONFIG)
+    report = run_multi_biome(config)
+    assert report["schema"] == "ermes_eco_pressure_report"
+    assert report["schema_version"] == "1.0.0"
+    assert "biomes" in report
+    assert isinstance(report["biomes"], dict)
+    assert len(report["biomes"]) >= 4
+
+
+def test_multi_biome_per_biome_shape():
+    config = load_config(CONFIG)
+    report = run_multi_biome(config)
+    for biome_id, biome_data in report["biomes"].items():
+        assert "eco_pressure_score" in biome_data, f"{biome_id} missing eco_pressure_score"
+        assert 0.0 <= biome_data["eco_pressure_score"] <= 1.0
+        for key in ("food_pressure", "predator_pressure", "temperature_pressure"):
+            assert key in biome_data, f"{biome_id} missing {key}"
+        assert "encounter_bias" in biome_data
+        for k in ("ambush", "scavenger", "hazard", "migration_pressure"):
+            assert k in biome_data["encounter_bias"]
+        assert "mutation_bias" in biome_data
+        for k in ("heat_resistance", "burst_mobility", "efficient_metabolism", "sensory_alertness"):
+            assert k in biome_data["mutation_bias"]
+        # bias key for W5-bb back-compat ermesExporter consumer.
+        assert "bias" in biome_data
+
+
+def test_multi_biome_deterministic():
+    config = load_config(CONFIG)
+    r1 = run_multi_biome(config)
+    r2 = run_multi_biome(config)
+    # Compare biomes content (ignore generated_at timestamp).
+    assert r1["biomes"] == r2["biomes"]
+
+
+def test_multi_biome_includes_back_compat_bias():
+    config = load_config(CONFIG)
+    report = run_multi_biome(config)
+    for biome_id, biome_data in report["biomes"].items():
+        assert "predator_density" in biome_data["bias"], f"{biome_id} bias missing predator_density"
+        assert "resource_scarcity" in biome_data["bias"], f"{biome_id} bias missing resource_scarcity"

--- a/tests/ai/applyErmesBiomeTraitCosts.test.js
+++ b/tests/ai/applyErmesBiomeTraitCosts.test.js
@@ -123,15 +123,24 @@ test('cap max_buckets_active_per_unit limits applied count', () => {
 test('R6 gate: NEVER writes unit.creature_epigenome.bias (sot-drift-verifier)', () => {
   const unit = { id: 'u1', attack_mod_bonus: 0, defense_mod_bonus: 0 };
   te.applyErmesBiomeTraitCosts(unit, 'high_biome', { bucketed: bucketedHigh() });
-  assert.equal(unit.creature_epigenome, undefined, 'must NOT touch creature_epigenome (D-HEIR substrate)');
+  assert.equal(
+    unit.creature_epigenome,
+    undefined,
+    'must NOT touch creature_epigenome (D-HEIR substrate)',
+  );
 });
 
 test('writes to ADR-21c keys only (attack_mod_bonus/defense_mod_bonus/mobility)', () => {
   const unit = { id: 'u1' };
   te.applyErmesBiomeTraitCosts(unit, 'high_biome', { bucketed: bucketedHigh() });
   const allowed = new Set([
-    'id', 'attack_mod_bonus', 'defense_mod_bonus', 'mobility', 'rest_recovery',
-    '_ermes_biome_costs_applied', '_ermes_biome_costs_log',
+    'id',
+    'attack_mod_bonus',
+    'defense_mod_bonus',
+    'mobility',
+    'rest_recovery',
+    '_ermes_biome_costs_applied',
+    '_ermes_biome_costs_log',
   ]);
   for (const k of Object.keys(unit)) {
     assert.ok(allowed.has(k), `unexpected field written: ${k}`);

--- a/tests/ai/applyErmesBiomeTraitCosts.test.js
+++ b/tests/ai/applyErmesBiomeTraitCosts.test.js
@@ -1,0 +1,139 @@
+// ADR-2026-05-29-ermes-runtime-bridge TKT-BR-06 -- applyErmesBiomeTraitCosts guard.
+//
+// Characterization + invariant tests su shipped behavior (worker BR-06 689e59c6
+// non aveva test dedicato; questo fill chiude il test-gap per ADR Test coverage).
+//
+// Invarianti chiave (da sot-drift-verifier preliminary verdict + ADR sezione C/G):
+//   - idempotent (marker _ermes_biome_costs_applied previene double-apply)
+//   - soft-fail su biome/unit assenti o report mancante (ADR-21c precedent)
+//   - bucket DISCRETI cap +/-2 (anti-ref Creatures)
+//   - NO write su unit.creature_epigenome.bias (gate sot-drift-verifier R6)
+//   - delta su chiavi ADR-21c (attack_mod_bonus / defense_mod_bonus / mobility)
+//
+// Test runner: node:test (scripts/run-test-api.cjs glob -- NB questo e' tests/ai/,
+// verificare glob includa tests/ai/ oppure spostare in tests/api/ se orphan).
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const te = require(path.resolve(__dirname, '../../apps/backend/services/traitEffects'));
+
+// Synthetic bucketed payloads (inietta via opts.bucketed per evitare dipendenza
+// dal report fisico + bucket file -- isola la logica di apply).
+function bucketedHigh() {
+  return {
+    buckets: {
+      eco_pressure_score: { band: 'high', def: { delta_mod: 1 } },
+      'mutation_bias.heat_resistance': { band: 'high', def: { delta: { defense_mod: 2 } } },
+    },
+    caps: { max_delta_any_stat: 2, max_buckets_active_per_unit: 3 },
+  };
+}
+
+function bucketedMed() {
+  return {
+    buckets: {
+      eco_pressure_score: { band: 'med', def: { delta_mod: 0 } },
+    },
+    caps: { max_delta_any_stat: 2, max_buckets_active_per_unit: 3 },
+  };
+}
+
+test('no-op when biomeId missing', () => {
+  const unit = { id: 'u1', attack_mod_bonus: 0 };
+  const applied = te.applyErmesBiomeTraitCosts(unit, null);
+  assert.deepEqual(applied, []);
+  assert.equal(unit._ermes_biome_costs_applied, undefined);
+});
+
+test('no-op when unit missing', () => {
+  const applied = te.applyErmesBiomeTraitCosts(null, 'savana');
+  assert.deepEqual(applied, []);
+});
+
+test('soft-fail returns [] when no bucketed + no exporter (ADR-21c precedent)', () => {
+  const unit = { id: 'u1' };
+  // opts.bucketed undefined + opts.ermesExporter stub without getErmesBucketed.
+  const applied = te.applyErmesBiomeTraitCosts(unit, 'savana', {
+    ermesExporter: {},
+  });
+  assert.deepEqual(applied, []);
+});
+
+test('high band applies delta_mod to attack+defense + delta defense_mod', () => {
+  const unit = { id: 'u1', attack_mod_bonus: 0, defense_mod_bonus: 0, mobility: 0 };
+  const applied = te.applyErmesBiomeTraitCosts(unit, 'high_biome', { bucketed: bucketedHigh() });
+  assert.ok(applied.length >= 1, 'expected at least 1 bucket applied');
+  // eco delta_mod +1 -> attack +1, defense +1. heat_resistance delta defense +2.
+  // defense clamped at cap 2 -> defense = clamp(1+2)=2. attack = 1.
+  assert.equal(unit.attack_mod_bonus, 1, 'attack_mod_bonus should be +1');
+  assert.equal(unit.defense_mod_bonus, 2, 'defense_mod_bonus clamped to cap +2');
+  assert.equal(unit._ermes_biome_costs_applied, true);
+});
+
+test('med band applies zero delta (neutral)', () => {
+  const unit = { id: 'u1', attack_mod_bonus: 0, defense_mod_bonus: 0 };
+  te.applyErmesBiomeTraitCosts(unit, 'med_biome', { bucketed: bucketedMed() });
+  assert.equal(unit.attack_mod_bonus, 0);
+  assert.equal(unit.defense_mod_bonus, 0);
+  assert.equal(unit._ermes_biome_costs_applied, true, 'marker set even when delta 0');
+});
+
+test('idempotent: re-apply does not double-charge', () => {
+  const unit = { id: 'u1', attack_mod_bonus: 0, defense_mod_bonus: 0 };
+  te.applyErmesBiomeTraitCosts(unit, 'high_biome', { bucketed: bucketedHigh() });
+  const a1 = unit.attack_mod_bonus;
+  const d1 = unit.defense_mod_bonus;
+  te.applyErmesBiomeTraitCosts(unit, 'high_biome', { bucketed: bucketedHigh() });
+  assert.equal(unit.attack_mod_bonus, a1, 'attack unchanged on re-apply');
+  assert.equal(unit.defense_mod_bonus, d1, 'defense unchanged on re-apply');
+});
+
+test('cap max_delta_any_stat enforced (no runaway)', () => {
+  const unit = { id: 'u1', defense_mod_bonus: 0 };
+  const overcap = {
+    buckets: {
+      a: { band: 'high', def: { delta: { defense_mod: 2 } } },
+      b: { band: 'high', def: { delta: { defense_mod: 2 } } },
+    },
+    caps: { max_delta_any_stat: 2, max_buckets_active_per_unit: 3 },
+  };
+  te.applyErmesBiomeTraitCosts(unit, 'b', { bucketed: overcap });
+  assert.ok(unit.defense_mod_bonus <= 2, `defense capped at 2, got ${unit.defense_mod_bonus}`);
+});
+
+test('cap max_buckets_active_per_unit limits applied count', () => {
+  const unit = { id: 'u1' };
+  const many = {
+    buckets: {
+      a: { band: 'high', def: { delta: { attack_mod: 1 } } },
+      b: { band: 'high', def: { delta: { defense_mod: 1 } } },
+      c: { band: 'high', def: { delta: { mobility: 1 } } },
+      d: { band: 'high', def: { delta: { rest_recovery: 1 } } },
+    },
+    caps: { max_delta_any_stat: 2, max_buckets_active_per_unit: 3 },
+  };
+  const applied = te.applyErmesBiomeTraitCosts(unit, 'b', { bucketed: many });
+  assert.ok(applied.length <= 3, `max 3 buckets active, got ${applied.length}`);
+});
+
+test('R6 gate: NEVER writes unit.creature_epigenome.bias (sot-drift-verifier)', () => {
+  const unit = { id: 'u1', attack_mod_bonus: 0, defense_mod_bonus: 0 };
+  te.applyErmesBiomeTraitCosts(unit, 'high_biome', { bucketed: bucketedHigh() });
+  assert.equal(unit.creature_epigenome, undefined, 'must NOT touch creature_epigenome (D-HEIR substrate)');
+});
+
+test('writes to ADR-21c keys only (attack_mod_bonus/defense_mod_bonus/mobility)', () => {
+  const unit = { id: 'u1' };
+  te.applyErmesBiomeTraitCosts(unit, 'high_biome', { bucketed: bucketedHigh() });
+  const allowed = new Set([
+    'id', 'attack_mod_bonus', 'defense_mod_bonus', 'mobility', 'rest_recovery',
+    '_ermes_biome_costs_applied', '_ermes_biome_costs_log',
+  ]);
+  for (const k of Object.keys(unit)) {
+    assert.ok(allowed.has(k), `unexpected field written: ${k}`);
+  }
+});

--- a/tests/services/ermes/ermesDebriefInput.test.js
+++ b/tests/services/ermes/ermesDebriefInput.test.js
@@ -8,7 +8,9 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const mod = require(path.resolve(__dirname, '../../../apps/backend/services/ermes/ermesDebriefInput'));
+const mod = require(
+  path.resolve(__dirname, '../../../apps/backend/services/ermes/ermesDebriefInput'),
+);
 
 test('buildDebriefPayload shape v1.0.0', () => {
   const p = mod.buildDebriefPayload('sess1', {
@@ -36,7 +38,11 @@ test('buildDebriefPayload defaults on empty runState', () => {
 
 test('writeErmesDebriefInput writes file + returns path', () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ermes-debrief-'));
-  const target = mod.writeErmesDebriefInput('sess3', { biomesVisited: ['savana'] }, { inputsDir: tmp });
+  const target = mod.writeErmesDebriefInput(
+    'sess3',
+    { biomesVisited: ['savana'] },
+    { inputsDir: tmp },
+  );
   assert.ok(target, 'should return path');
   assert.ok(fs.existsSync(target), 'file should exist');
   const written = JSON.parse(fs.readFileSync(target, 'utf8'));

--- a/tests/services/ermes/ermesDebriefInput.test.js
+++ b/tests/services/ermes/ermesDebriefInput.test.js
@@ -1,0 +1,66 @@
+// ADR-2026-05-29 TKT-BR-10 -- ermesDebriefInput guard.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const mod = require(path.resolve(__dirname, '../../../apps/backend/services/ermes/ermesDebriefInput'));
+
+test('buildDebriefPayload shape v1.0.0', () => {
+  const p = mod.buildDebriefPayload('sess1', {
+    biomesVisited: ['savana', 'caverna_risonante'],
+    traitUsageStats: [{ trait_id: 'ferocia', fires: 12 }],
+    encounterFireStats: { ambush: 4, scavenger: 1 },
+    outcomes: { wins: 1, losses: 0, wipes: 0 },
+  });
+  assert.equal(p.schema, 'evo_debrief_for_ermes');
+  assert.equal(p.schema_version, '1.0.0');
+  assert.equal(p.session_id, 'sess1');
+  assert.deepEqual(p.biomes_visited, ['savana', 'caverna_risonante']);
+  assert.equal(p.trait_usage[0].trait_id, 'ferocia');
+  assert.equal(p.encounter_fires.ambush, 4);
+  assert.equal(p.outcomes.wins, 1);
+});
+
+test('buildDebriefPayload defaults on empty runState', () => {
+  const p = mod.buildDebriefPayload('sess2');
+  assert.deepEqual(p.biomes_visited, []);
+  assert.deepEqual(p.trait_usage, []);
+  assert.deepEqual(p.encounter_fires, {});
+  assert.deepEqual(p.outcomes, { wins: 0, losses: 0, wipes: 0 });
+});
+
+test('writeErmesDebriefInput writes file + returns path', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ermes-debrief-'));
+  const target = mod.writeErmesDebriefInput('sess3', { biomesVisited: ['savana'] }, { inputsDir: tmp });
+  assert.ok(target, 'should return path');
+  assert.ok(fs.existsSync(target), 'file should exist');
+  const written = JSON.parse(fs.readFileSync(target, 'utf8'));
+  assert.equal(written.session_id, 'sess3');
+  assert.deepEqual(written.biomes_visited, ['savana']);
+});
+
+test('writeErmesDebriefInput soft-fail returns null on missing sessionId', () => {
+  const r = mod.writeErmesDebriefInput(null, {});
+  assert.equal(r, null);
+});
+
+test('writeErmesDebriefInput sanitizes session_id in filename', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ermes-debrief-'));
+  const target = mod.writeErmesDebriefInput('ABCD/../evil', {}, { inputsDir: tmp });
+  assert.ok(target, 'should return path');
+  assert.ok(!target.includes('..'), 'path traversal sanitized');
+  assert.match(path.basename(target), /^[a-zA-Z0-9_-]+\.json$/);
+});
+
+test('idempotent overwrite same session_id', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ermes-debrief-'));
+  mod.writeErmesDebriefInput('sess4', { biomesVisited: ['a'] }, { inputsDir: tmp });
+  const t2 = mod.writeErmesDebriefInput('sess4', { biomesVisited: ['b'] }, { inputsDir: tmp });
+  const written = JSON.parse(fs.readFileSync(t2, 'utf8'));
+  assert.deepEqual(written.biomes_visited, ['b'], 'overwrite with latest');
+});


### PR DESCRIPTION
## FASE 2 -- ERMES runtime bridge pilot 4x4 (ADR-2026-05-29)

Implementa ADR-2026-05-29-ermes-runtime-bridge (ACCEPTED). Chiude audit G-C1 schema mismatch + plan E7 + Sprint 3 Drive. Worktree `C:/dev/Game-fase2`.

## Commit (10)

| Commit | Ticket | Cosa |
|---|---|---|
| `664f0c91` | BR-02 | run_multi_biome + schema v1.0.0 (closes G-C1) |
| `59adb484` | BR-05 | ermes_bucket_thresholds.yaml DISCRETE (anti-ref Creatures) |
| `d7bfbf8c` | BR-04 | ermesExporter schema gate + getErmesBucketed |
| `689e59c6` | BR-06 | applyErmesBiomeTraitCosts ERMES bucketed (mirror ADR-21c) |
| `2b09c90f` | BR-03 | ermesRunner reverse-index granular rerun |
| `bdffa020` | BR-07 | suggestions.py JSON-Patch DISCRETI |
| `4f1a9800` | BR-08 | GET /api/traits/suggestions ETag route |
| `28776306` | BR-13 | museum card ermes-bridge-pilot |
| `72ef6b41` | BR-06-test | applyErmesBiomeTraitCosts 10 guard test (fill gap) |
| `9b595089` | BR-10 | debrief input scaffold writeErmesDebriefInput + 6 test |

## Verifica (a) -- worker code SOUND

- BR-02 multi_biome test: **4/4 PASS**.
- legacy ermes_sim --test: **5/5 PASS** (no regression).
- BR-05 bucket yaml: **valid parse** (schema_version, buckets, caps, guards).
- BR-07 suggestions.py: **syntax OK**.
- 4 JS files (ermesRunner, ermesExporter, traitEffects, routes/traits): **node --check OK**.
- multi-biome CLI: produce report 4 biomi (savana, caverna_risonante, rovine_planari, cryosteppe).
- ermesRunner reverse-index: **90 trait->pool mappings** (criostasi_adattiva -> cryosteppe_convergence).
- getErmesBucketed: keys [eco_pressure_score, bias, buckets, caps, guards].
- applyErmesBiomeTraitCosts: idempotent OK + **NO epigenome bias write** (R6 gate sot-drift-verifier) + cap +/-2 enforced.

## Test gap fill

Worker commit BR-02..08 avevano **1 solo test** (multi_biome). ADR Test coverage richiede test per ogni consumer. Aggiunti:
- `tests/ai/applyErmesBiomeTraitCosts.test.js` (BR-06): **10 test** incluso R6 gate no-epigenome-write + cap + idempotent.
- `tests/services/ermes/ermesDebriefInput.test.js` (BR-10): **6 test**.

Test gap residuo (consigliato follow-up): BR-03 ermesRunner + BR-04 ermesExporter multi-biome + BR-08 suggestions route contract.

## Finding calibration (per BR-12)

Tutti 4 biomi pilot (`multi_biome.json`) producono eco_pressure **0.42-0.66 = med band** -> delta_mod 0 + mutation_bias low band -> **0 delta applied**. Bridge plumbing SOUND (marker idempotente, no errori, soft-fail corretto) MA funzionalmente **inerte** fino a config/threshold tuning. Questo e' esattamente lo scope di TKT-BR-12 calibration N=40: tunare config biomi (o bucket thresholds) per esercitare low/high band osservabili. NON bug -- tuning todo documentato.

## Ticket RIMANENTI (5)

- **BR-09** Vue 3 TraitSuggestionsView + router (UX accept/reject)
- **BR-11** Godot v2 cross-repo mirror ermes_role_gap.gd parity (repo locale presente)
- **BR-12** calibration batch N=40 + config tuning (sblocca bridge demonstrable)
- **BR-14** update trackers (PILLARS_STATUS + roadmap + KNOWLEDGE_MAP §2) -- a completion
- **BR-15** sot-drift-verifier FINAL verdict + PR ready->merge

## Note

- DRAFT finche' BR-09/11/12 + BR-14/15 completi.
- Avanzamento concorrente: worker (chip parallelo) ha shippato BR-02..08+BR-13; questa sessione ha aggiunto verifica (a) + test fill BR-06 + BR-10.
- Vincolo BR-15 hard: sot-drift-verifier FINAL prima merge + verify TKT-BR-06 NON scrive creature_epigenome.bias (gia testato, 10/10 PASS).
- ADR + audit + handoff: vault (PR #212 merged).