### PR TITLE
feat(coop): session_id/campaign_id on versioned phase_change (re #2423)

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -763,7 +763,16 @@ function createApp(options = {}) {
   // Sprint SPRINT_001 fase 3 — engine minimo giocabile.
   // Espone POST /api/session/{start,action,end} + GET /api/session/state.
   // Stato in memoria, log eventi su disco in logs/session_*.json.
-  app.use('/api/session', createSessionRouter(options.session || {}));
+  // PR-1 §22 coop-WS surface — lobby + coopStore created here (ahead of the
+  // session router) so /api/session/start can link the new combat session id
+  // back into the coop orchestrator (campaign_id == run.id).
+  const lobbyOptions = { ...(options.lobby || {}) };
+  if (!lobbyOptions.service && lobbyOptions.prisma === undefined && repo.prisma) {
+    lobbyOptions.prisma = repo.prisma;
+  }
+  const lobby = lobbyOptions.service || new LobbyService(lobbyOptions);
+  const coopStore = createCoopStore({ lobby });
+  app.use('/api/session', createSessionRouter({ ...(options.session || {}), coopStore }));
   app.use('/api/party', createPartyRouter());
   // M7 demo playtest: feedback collection (/api/feedback, /api/feedback/summary)
   app.use('/api', createFeedbackRouter(options.feedback || {}));
@@ -779,14 +788,8 @@ function createApp(options = {}) {
   // REST only; WebSocket server bootstraps in index.js on port 3341.
   // Opzione C (2026-04-26): optional Prisma write-through persistence.
   // Graceful fallback when DATABASE_URL unset (dev/demo/tests).
-  const lobbyOptions = { ...(options.lobby || {}) };
-  if (!lobbyOptions.service && lobbyOptions.prisma === undefined && repo.prisma) {
-    lobbyOptions.prisma = repo.prisma;
-  }
-  const lobby = lobbyOptions.service || new LobbyService(lobbyOptions);
   app.use('/api', createLobbyRouter({ lobby }));
   // M17 — Co-op run orchestrator (character creation + world setup + debrief).
-  const coopStore = createCoopStore({ lobby });
   app.use('/api', createCoopRouter({ lobby, coopStore }));
   // 2026-05-20 — Combat readonly diagnostic (status-penalties + biome-modifiers).
   app.use('/api/combat', createCombatRouter());

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -272,7 +272,9 @@ function createSessionRouter(options = {}) {
   }
 
   const sessions = new Map();
-  let activeSessionId = null;
+  let activeSessionId = null; // PR-1 §22 coop-WS surface — optional coop orchestrator store; when present,
+  // /start links the new session id back by campaign_id (== run.id).
+  const coopStore = options.coopStore || null;
 
   // Telemetry helper — append JSONL entry to logs/telemetry_YYYYMMDD.jsonl.
   // Same schema as POST /telemetry (ts, session_id, player_id, type, payload)
@@ -1662,6 +1664,16 @@ function createSessionRouter(options = {}) {
       }
       sessions.set(sessionId, session);
       activeSessionId = sessionId;
+      // PR-1 §22 coop-WS surface — link this combat session back into the coop
+      // orchestrator (campaign_id == run.id) so the next phase_change broadcast
+      // surfaces session_id to phone clients for ALIENA telemetry on debrief.
+      if (coopStore && session.campaign_id) {
+        try {
+          coopStore.linkSession(session.campaign_id, sessionId);
+        } catch {
+          /* best-effort -- coop link must never block session start */
+        }
+      }
       // M1 -- hydrate persistent Sistema learning state (best-effort, never blocks).
       try {
         if (session.campaign_id) {

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -205,6 +205,7 @@ class CoopOrchestrator {
     };
     this.characters.clear();
     this.worldVotes.clear();
+    this.sessionId = null;
     this.debriefChoices.clear();
     this.revealAcks.clear();
     this.formPulses.clear();
@@ -239,6 +240,7 @@ class CoopOrchestrator {
     };
     this.characters.clear();
     this.worldVotes.clear();
+    this.sessionId = null;
     this.debriefChoices.clear();
     this.revealAcks.clear();
     this.formPulses.clear();
@@ -781,6 +783,7 @@ class CoopOrchestrator {
     });
     this.debriefChoices.clear();
     this.worldVotes.clear();
+    this.sessionId = null;
     this.formPulses.clear();
     this.revealAcks.clear();
     this._setPhase('world_setup');

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -105,6 +105,9 @@ class CoopOrchestrator {
     // Default lazy-loads the canonical service module on first use.
     this._worldEnricher = worldEnricher;
     this.enrichedWorld = null; // populated by confirmWorld() with rich schema
+    // PR-1 §22 coop-WS surface — combat session id (POST /api/session/start)
+    // linked back via coopStore.linkSession so phase_change can surface it.
+    this.sessionId = null;
   }
 
   _getWorldEnricher() {
@@ -167,6 +170,21 @@ class CoopOrchestrator {
     const previousHostId = this.hostId;
     this.hostId = newHostId || null;
     this._emit('host_id_synced', { previous: previousHostId, current: this.hostId });
+    return true;
+  }
+  /**
+   * PR-1 §22 coop-WS surface — link the combat session id (created by
+   * POST /api/session/start, keyed in coop flow on run.id == campaign_id)
+   * so broadcastCoopState/phaseChangePayload can surface it to phone clients
+   * for ALIENA telemetry fetch on debrief. Idempotent: no-op when unchanged.
+   *
+   * @param {string|null} sessionId
+   * @returns {boolean} true if sessionId changed, false if no-op
+   */
+  setSessionId(sessionId) {
+    const next = sessionId || null;
+    if (next === this.sessionId) return false;
+    this.sessionId = next;
     return true;
   }
 

--- a/apps/backend/services/coop/coopStore.js
+++ b/apps/backend/services/coop/coopStore.js
@@ -42,7 +42,22 @@ function createCoopStore({ lobby } = {}) {
     orchestrators.clear();
   }
 
-  return { getOrCreate, get, remove, list, clear };
+  // PR-1 §22 coop-WS surface — link a combat session id (POST
+  // /api/session/start) to the orchestrator whose run.id equals the
+  // campaign_id the host passed (run.id == campaign_id in the coop flow).
+  // Returns true if a matching orch was found and updated.
+  function linkSession(campaignId, sessionId) {
+    if (!campaignId || !sessionId) return false;
+    for (const orch of orchestrators.values()) {
+      if (orch?.run?.id === campaignId) {
+        orch.setSessionId(sessionId);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  return { getOrCreate, get, remove, list, clear, linkSession };
 }
 
 module.exports = { createCoopStore };

--- a/apps/backend/services/coop/coopStore.js
+++ b/apps/backend/services/coop/coopStore.js
@@ -51,6 +51,10 @@ function createCoopStore({ lobby } = {}) {
     for (const orch of orchestrators.values()) {
       if (orch?.run?.id === campaignId) {
         orch.setSessionId(sessionId);
+        // Mirror onto the lobby room so the VERSIONED publishPhaseChange
+        // (the channel the phone composer consumes) carries session_id.
+        const room = lobby?.getRoom?.(orch.roomCode);
+        if (room) room.sessionId = sessionId;
         return true;
       }
     }

--- a/apps/backend/services/coop/phaseChangePayload.js
+++ b/apps/backend/services/coop/phaseChangePayload.js
@@ -1,4 +1,4 @@
-﻿// PR-0 §22 coop-WS surface — single source for the coop `phase_change`
+// PR-0 §22 coop-WS surface — single source for the coop `phase_change`
 // broadcast payload. Previously this { phase, round, scenario } shape was
 // duplicated inline at routes/coop.js (broadcastCoopState) and
 // services/network/wsSession.js (reconnect snapshot + host-transfer
@@ -20,6 +20,10 @@ function buildPhaseChangePayload(orch, extra = {}) {
     phase: orch?.phase,
     round: currentIndex,
     scenario: run?.scenarioStack?.[currentIndex] || null,
+    // PR-1 §22 coop-WS surface — ids for phone-side ALIENA telemetry +
+    // tribes fetch. campaign_id == run.id (Godot keys CampaignState on it).
+    session_id: orch?.sessionId ?? null,
+    campaign_id: run?.id ?? null,
     ...extra,
   };
 }

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -146,6 +146,9 @@ class Room {
     this.hostId = hostId;
     this.maxPlayers = maxPlayers;
     this.campaignId = campaignId;
+    // PR-1 §22 coop-WS surface — combat session id linked post /api/session/start
+    // (coopStore.linkSession). Surfaced in publishPhaseChange for phone clients.
+    this.sessionId = null;
     this.createdAt = hydrateFromSeed?.createdAt || Date.now();
     this.closed = Boolean(hydrateFromSeed?.closed);
     this.hostTransferGraceMs = hostTransferGraceMs;
@@ -562,7 +565,11 @@ class Room {
       throw new Error(`phase_not_whitelisted:${phase}`);
     }
     this.phase = phase;
-    return this.publishEvent('phase_change', { phase });
+    return this.publishEvent('phase_change', {
+      phase,
+      session_id: this.sessionId ?? null,
+      campaign_id: this.campaignId ?? null,
+    });
   }
 
   /**

--- a/tests/api/sessionCoopLink.test.js
+++ b/tests/api/sessionCoopLink.test.js
@@ -1,0 +1,30 @@
+// PR-1 §22 coop-WS surface — POST /api/session/start links the new combat
+// session id back into the coop orchestrator (by campaign_id == run.id) so
+// the next phase_change broadcast surfaces session_id to phone clients.
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+
+test('/session/start links session_id into coop orch matching campaign_id', async (t) => {
+  const { app, coopStore, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const orch = coopStore.getOrCreate('TEST');
+  const run = orch.startRun({ scenarioStack: ['enc_tutorial_01'] });
+  assert.equal(orch.sessionId, null);
+
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units, campaign_id: run.id });
+  assert.equal(startRes.status, 200);
+
+  assert.equal(orch.sessionId, startRes.body.session_id);
+});

--- a/tests/services/coop/coopOrchestratorSessionId.test.js
+++ b/tests/services/coop/coopOrchestratorSessionId.test.js
@@ -23,3 +23,12 @@ test('setSessionId is idempotent — returns false when unchanged', () => {
   assert.equal(orch.setSessionId(''), true); // clears to null
   assert.equal(orch.sessionId, null);
 });
+
+test('sessionId cleared on scenario advance (new combat session)', () => {
+  const o = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'h1' });
+  o.startRun({ scenarioStack: ['e1', 'e2'] });
+  o.setSessionId('sess_1');
+  assert.equal(o.sessionId, 'sess_1');
+  o.advanceScenarioOrEnd();
+  assert.equal(o.sessionId, null);
+});

--- a/tests/services/coop/coopOrchestratorSessionId.test.js
+++ b/tests/services/coop/coopOrchestratorSessionId.test.js
@@ -1,0 +1,25 @@
+// PR-1 §22 coop-WS surface — orch.setSessionId links the combat session id
+// (created by POST /api/session/start) back to the coop orchestrator so the
+// `phase_change` broadcast can surface it to phone clients for ALIENA
+// telemetry fetch on debrief.
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { CoopOrchestrator } = require('../../../apps/backend/services/coop/coopOrchestrator');
+
+test('setSessionId stores the id and returns true on change', () => {
+  const orch = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'h1' });
+  assert.equal(orch.sessionId, null);
+  const changed = orch.setSessionId('sess_123');
+  assert.equal(changed, true);
+  assert.equal(orch.sessionId, 'sess_123');
+});
+
+test('setSessionId is idempotent — returns false when unchanged', () => {
+  const orch = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'h1' });
+  orch.setSessionId('sess_123');
+  assert.equal(orch.setSessionId('sess_123'), false);
+  assert.equal(orch.setSessionId(''), true); // clears to null
+  assert.equal(orch.sessionId, null);
+});

--- a/tests/services/coop/coopStoreLinkSession.test.js
+++ b/tests/services/coop/coopStoreLinkSession.test.js
@@ -25,3 +25,14 @@ test('linkSession returns false on no match or missing args', () => {
   assert.equal(store.linkSession(orch.run.id, ''), false);
   assert.equal(orch.sessionId, null);
 });
+
+test('linkSession also mirrors sessionId onto the lobby room', () => {
+  const room = { sessionId: null };
+  const lobby = { getRoom: (code) => (code === 'ABCD' ? room : null) };
+  const store = createCoopStore({ lobby });
+  const orch = store.getOrCreate('ABCD');
+  const run = orch.startRun({ scenarioStack: ['enc_a'] });
+  assert.equal(store.linkSession(run.id, 'sess_q'), true);
+  assert.equal(orch.sessionId, 'sess_q');
+  assert.equal(room.sessionId, 'sess_q');
+});

--- a/tests/services/coop/coopStoreLinkSession.test.js
+++ b/tests/services/coop/coopStoreLinkSession.test.js
@@ -1,0 +1,27 @@
+// PR-1 §22 coop-WS surface — coopStore.linkSession maps a combat session id
+// to the coop orchestrator whose run.id matches the campaign_id passed to
+// POST /api/session/start (run.id == campaign_id in the coop flow).
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { createCoopStore } = require('../../../apps/backend/services/coop/coopStore');
+
+test('linkSession sets sessionId on the orch whose run.id matches campaignId', () => {
+  const store = createCoopStore({});
+  const orch = store.getOrCreate('ABCD');
+  const run = orch.startRun({ scenarioStack: ['enc_a'] });
+  const linked = store.linkSession(run.id, 'sess_xyz');
+  assert.equal(linked, true);
+  assert.equal(orch.sessionId, 'sess_xyz');
+});
+
+test('linkSession returns false on no match or missing args', () => {
+  const store = createCoopStore({});
+  const orch = store.getOrCreate('ABCD');
+  orch.startRun({ scenarioStack: ['enc_a'] });
+  assert.equal(store.linkSession('nope_run', 'sess_1'), false);
+  assert.equal(store.linkSession('', 'sess_1'), false);
+  assert.equal(store.linkSession(orch.run.id, ''), false);
+  assert.equal(orch.sessionId, null);
+});

--- a/tests/services/coop/phaseChangePayload.test.js
+++ b/tests/services/coop/phaseChangePayload.test.js
@@ -10,9 +10,20 @@ const {
   buildPhaseChangePayload,
 } = require('../../../apps/backend/services/coop/phaseChangePayload');
 
-function orchWith({ phase = 'combat', run = null } = {}) {
-  return { phase, run };
+function orchWith({ phase = 'combat', run = null, sessionId = null } = {}) {
+  return { phase, run, sessionId };
 }
+
+test('buildPhaseChangePayload: surfaces session_id and campaign_id (run.id)', () => {
+  const orch = orchWith({
+    phase: 'debrief',
+    run: { id: 'run_42', currentIndex: 0, scenarioStack: ['enc_a'] },
+    sessionId: 'sess_99',
+  });
+  const p = buildPhaseChangePayload(orch);
+  assert.equal(p.session_id, 'sess_99');
+  assert.equal(p.campaign_id, 'run_42');
+});
 
 test('buildPhaseChangePayload: active run surfaces phase/round/scenario', () => {
   const orch = orchWith({
@@ -20,13 +31,25 @@ test('buildPhaseChangePayload: active run surfaces phase/round/scenario', () => 
     run: { currentIndex: 1, scenarioStack: ['enc_a', 'enc_b'] },
   });
   const p = buildPhaseChangePayload(orch);
-  assert.deepEqual(p, { phase: 'combat', round: 1, scenario: 'enc_b' });
+  assert.deepEqual(p, {
+    phase: 'combat',
+    round: 1,
+    scenario: 'enc_b',
+    session_id: null,
+    campaign_id: null,
+  });
 });
 
 test('buildPhaseChangePayload: null run defaults round=0 scenario=null', () => {
   const orch = orchWith({ phase: 'lobby', run: null });
   const p = buildPhaseChangePayload(orch);
-  assert.deepEqual(p, { phase: 'lobby', round: 0, scenario: null });
+  assert.deepEqual(p, {
+    phase: 'lobby',
+    round: 0,
+    scenario: null,
+    session_id: null,
+    campaign_id: null,
+  });
 });
 
 test('buildPhaseChangePayload: extra fields merge over base (e.g. reason)', () => {
@@ -39,6 +62,8 @@ test('buildPhaseChangePayload: extra fields merge over base (e.g. reason)', () =
     phase: 'world_setup',
     round: 0,
     scenario: 'enc_a',
+    session_id: null,
+    campaign_id: null,
     reason: 'host_transferred',
   });
 });

--- a/tests/services/network/wsSession-events.test.js
+++ b/tests/services/network/wsSession-events.test.js
@@ -121,7 +121,7 @@ test('Room.publishPhaseChange: sets phase + ledger-records as phase_change', () 
   assert.equal(room.phase, 'combat');
   const entries = room.ledgerSince(0);
   assert.equal(entries[0].type, 'phase_change');
-  assert.deepEqual(entries[0].payload, { phase: 'combat' });
+  assert.deepEqual(entries[0].payload, { phase: 'combat', session_id: null, campaign_id: null });
 });
 
 test('Room.publishPhaseChange: rejects empty phase', () => {
@@ -166,8 +166,8 @@ test('WS-event: phase_change broadcast carries version + payload', async () => {
       waitForMessage(p1Ws, (m) => m.type === 'phase_change'),
     ]);
     assert.equal(hostMsg.version, 1);
-    assert.deepEqual(hostMsg.payload, { phase: 'combat' });
-    assert.deepEqual(p1Msg.payload, { phase: 'combat' });
+    assert.deepEqual(hostMsg.payload, { phase: 'combat', session_id: null, campaign_id: null });
+    assert.deepEqual(p1Msg.payload, { phase: 'combat', session_id: null, campaign_id: null });
 
     hostWs.close();
     p1Ws.close();

--- a/tests/services/network/wsSession-phaseChangeIds.test.js
+++ b/tests/services/network/wsSession-phaseChangeIds.test.js
@@ -1,0 +1,29 @@
+// PR-1 §22 coop-WS surface — Room.publishPhaseChange surfaces session_id +
+// campaign_id in the VERSIONED phase_change event. This is the channel the
+// Godot phone composer actually consumes (coop_ws_peer routes versioned
+// events to `event_received`; plain version-less phase_change is dropped as
+// unknown_type). Phone reads these ids on the debrief swap to fetch ALIENA
+// telemetry + emergent tribes.
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { LobbyService } = require('../../../apps/backend/services/network/wsSession');
+
+test('publishPhaseChange surfaces session_id + campaign_id in payload', () => {
+  const lobby = new LobbyService();
+  const created = lobby.createRoom({ hostName: 'TV', campaignId: 'camp_1' });
+  const room = lobby.getRoom(created.code);
+  room.sessionId = 'sess_7';
+
+  const captured = [];
+  room.broadcast = (msg) => captured.push(msg);
+
+  room.publishPhaseChange('debrief');
+
+  const evt = captured.find((m) => m.type === 'phase_change');
+  assert.ok(evt, 'phase_change event broadcast');
+  assert.equal(evt.payload.phase, 'debrief');
+  assert.equal(evt.payload.session_id, 'sess_7');
+  assert.equal(evt.payload.campaign_id, 'camp_1');
+});


### PR DESCRIPTION
## PR-1 (re-opened) -- session_id/campaign_id on versioned phase_change

Supersedes #2423 (auto-closed when its stacked base branch was deleted on #2422 merge). Same content, rebased onto main (PR-0 builder already merged via #2422).

- Room.publishPhaseChange surfaces session_id + campaign_id (versioned channel the phone consumes).
- coopStore.linkSession links combat session_id by run.id; /session/start wires it.
- **Codex P2 fix**: sessionId cleared on startRun/startOnboarding/advanceScenarioOrEnd (no stale session leak).

Tests: phaseChangePayload + coopOrchestratorSessionId + coopStoreLinkSession + wsSession-phaseChangeIds (11 green) + full coop/net regression.