### PR TITLE
feat(coop): server-side offspring birth on mating resolve (S22-B Task 8)

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -38,6 +38,8 @@ const { createSkivRouter } = require('./routes/skiv');
 // Sprint 3 §II (2026-04-27) — AncientBeast wiki cross-link slug bridge.
 const { createSpeciesWikiRouter } = require('./routes/speciesWiki');
 const { createCoopStore } = require('./services/coop/coopStore');
+// S22-B Task 8 -- metaStore factory for server-side offspring roll on mating quorum.
+const { createMetaStore } = require('./services/metaProgression');
 const { LobbyService } = require('./services/network/wsSession');
 const { createNebulaTelemetryAggregator } = require('./services/nebulaTelemetryAggregator');
 const { createReleaseReporter } = require('./services/releaseReporter');
@@ -790,7 +792,11 @@ function createApp(options = {}) {
   // Graceful fallback when DATABASE_URL unset (dev/demo/tests).
   app.use('/api', createLobbyRouter({ lobby }));
   // M17 — Co-op run orchestrator (character creation + world setup + debrief).
-  app.use('/api', createCoopRouter({ lobby, coopStore }));
+  // S22-B Task 8 -- metaStoreFactory + prisma injected so a mating quorum can
+  // roll offspring server-side (WS handler + REST parity). Prisma-gated; the
+  // resolver degrades gracefully when prisma is absent (dev/demo/tests).
+  const metaStoreFactory = (campaignId) => createMetaStore({ prisma: repo.prisma, campaignId });
+  app.use('/api', createCoopRouter({ lobby, coopStore, metaStoreFactory, prisma: repo.prisma }));
   // 2026-05-20 — Combat readonly diagnostic (status-penalties + biome-modifiers).
   app.use('/api/combat', createCombatRouter());
   app.use('/api', createCompanionRouter());
@@ -1024,7 +1030,16 @@ function createApp(options = {}) {
     }
   }
 
-  return { app, repo, generationOrchestrator, lobby, coopStore, close };
+  return {
+    app,
+    repo,
+    generationOrchestrator,
+    lobby,
+    coopStore,
+    metaStoreFactory,
+    prisma: repo.prisma,
+    close,
+  };
 }
 
 module.exports = { createApp };

--- a/apps/backend/index.js
+++ b/apps/backend/index.js
@@ -31,7 +31,7 @@ const gameDatabaseEnabled = process.env.GAME_DATABASE_ENABLED !== 'false';
 const gameDatabaseTimeoutMs = Number.parseInt(process.env.GAME_DATABASE_TIMEOUT_MS || '', 10);
 const gameDatabaseTtlMs = Number.parseInt(process.env.GAME_DATABASE_TTL_MS || '', 10);
 
-const { app, lobby, coopStore } = createApp({
+const { app, lobby, coopStore, metaStoreFactory, prisma } = createApp({
   dataRoot,
   gameDatabase: {
     enabled: gameDatabaseEnabled,
@@ -72,10 +72,10 @@ const server = http.createServer(app);
 // WS server: shared mode (single port for demo/ngrok) or dedicated port.
 if (wsEnabled && lobby) {
   if (wsShared) {
-    lobbyWs = createWsServer({ lobby, coopStore, server });
+    lobbyWs = createWsServer({ lobby, coopStore, metaStoreFactory, prisma, server });
     console.log(`[lobby-ws] WebSocket server attached to HTTP server on /ws (shared mode)`);
   } else {
-    lobbyWs = createWsServer({ lobby, coopStore, port: wsPort });
+    lobbyWs = createWsServer({ lobby, coopStore, metaStoreFactory, prisma, port: wsPort });
     console.log(`[lobby-ws] WebSocket server online on ws://${wsHost}:${wsPort}/ws`);
   }
   // Opzione C: hydrate rooms from Prisma if persistence wired.

--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -15,7 +15,7 @@ const { listBiomeRoleDemands } = require('../services/coop/ermesExporter');
 const { listAlienaSummaries } = require('../services/coop/alienaGenerator');
 const { buildPhaseChangePayload } = require('../services/coop/phaseChangePayload');
 
-function createCoopRouter({ lobby, coopStore } = {}) {
+function createCoopRouter({ lobby, coopStore, metaStoreFactory = null, prisma = null } = {}) {
   if (!lobby) throw new Error('createCoopRouter: lobby required');
   if (!coopStore) throw new Error('createCoopRouter: coopStore required');
   const router = express.Router();
@@ -218,11 +218,42 @@ function createCoopRouter({ lobby, coopStore } = {}) {
     const orch = coopStore.get(code);
     if (!orch) return res.status(409).json({ error: 'run_not_started' });
     try {
+      const allPids = allPlayerIds(room);
+      const connectedPids = connectedPlayerIds(room);
       const tally = orch.voteMating(playerId, pairId, {
-        allPlayerIds: allPlayerIds(room),
-        connectedPlayerIds: connectedPlayerIds(room),
+        allPlayerIds: allPids,
+        connectedPlayerIds: connectedPids,
       });
       broadcastCoopState(room, orch);
+      // S22-B Task 8 -- WS parity: roll offspring + broadcast mating_resolved
+      // when this vote meets connected-only quorum. Best-effort, additive.
+      const winner = orch.resolveMatingWinner(allPids, connectedPids);
+      if (winner && metaStoreFactory) {
+        const store = metaStoreFactory(winner.campaign_id);
+        if (store) {
+          // eslint-disable-next-line global-require
+          const { resolveCoopMatingOffspring } = require('../services/mating/coopMatingResolver');
+          resolveCoopMatingOffspring({
+            store,
+            prisma,
+            campaignId: winner.campaign_id,
+            parentAId: winner.parent_a_id,
+            parentBId: winner.parent_b_id,
+            biomeId: winner.biome_id,
+          })
+            .then((resolveRes) => {
+              room.broadcast({
+                type: 'mating_resolved',
+                payload: {
+                  pair_id: winner.pair_id,
+                  offspring: resolveRes.offspring || null,
+                  ok: resolveRes.success,
+                },
+              });
+            })
+            .catch(() => {});
+        }
+      }
       return res.json({ phase: orch.phase, tally });
     } catch (err) {
       return res.status(400).json({ error: err.message || 'mating_vote_failed' });

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -204,6 +204,8 @@ class CoopOrchestrator {
       partyXp: 0,
       partyPi: 0,
       outcome: null,
+      matingResolved: false,
+      survivors: [],
     };
     this.characters.clear();
     this.worldVotes.clear();
@@ -240,6 +242,8 @@ class CoopOrchestrator {
       partyXp: 0,
       partyPi: 0,
       outcome: null,
+      matingResolved: false,
+      survivors: [],
     };
     this.characters.clear();
     this.worldVotes.clear();
@@ -654,6 +658,26 @@ class CoopOrchestrator {
   }
 
   /**
+   * S22-B Task 8 -- if mating quorum is met and not yet resolved, mark
+   * resolved and return the winning pair (parsed ids). Idempotent: null on
+   * subsequent calls or before quorum. Connected-only quorum (mirror world).
+   */
+  resolveMatingWinner(allPlayerIds = [], connectedPlayerIds = []) {
+    if (!this.run || this.run.matingResolved) return null;
+    const tally = this.matingTally(allPlayerIds, connectedPlayerIds);
+    if (!tally.all_connected_voted || !tally.leading_pair_id) return null;
+    this.run.matingResolved = true;
+    const [parentAId, parentBId] = String(tally.leading_pair_id).split('__');
+    return {
+      pair_id: tally.leading_pair_id,
+      parent_a_id: parentAId,
+      parent_b_id: parentBId,
+      biome_id: this.run.scenarioStack?.[this.run.currentIndex] || null,
+      campaign_id: this.run.id,
+    };
+  }
+
+  /**
    * 2026-05-06 phone smoke W7 — submit post-debrief macro navigation choice.
    * Host-only (mirror submitOnboardingChoice pattern). Choice ∈
    * {advance, branch, retreat}. Phase must be `debrief` or `ended` (post
@@ -753,6 +777,7 @@ class CoopOrchestrator {
   } = {}) {
     if (this.phase !== 'combat') throw new Error('not_in_combat');
     this.run.outcome = outcome;
+    this.run.survivors = Array.isArray(survivors) ? survivors : [];
     this.run.partyXp += xpEarned;
     if (debriefPayload && typeof debriefPayload === 'object') {
       this.run.debrief = debriefPayload;

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -666,8 +666,16 @@ class CoopOrchestrator {
     if (!this.run || this.run.matingResolved) return null;
     const tally = this.matingTally(allPlayerIds, connectedPlayerIds);
     if (!tally.all_connected_voted || !tally.leading_pair_id) return null;
-    this.run.matingResolved = true;
     const [parentAId, parentBId] = String(tally.leading_pair_id).split('__');
+    // S22-B Task 8 (Codex P1) -- only resolve a pair whose BOTH parents are
+    // actual surviving units. voteMating accepts any client pair_id, so a
+    // bogus pair must NOT trigger an offspring roll. Leave matingResolved
+    // false so a later legit pair can still win.
+    const survivorIds = new Set((this.run.survivors || []).map((u) => u && u.id).filter(Boolean));
+    if (!parentAId || !parentBId || !survivorIds.has(parentAId) || !survivorIds.has(parentBId)) {
+      return null;
+    }
+    this.run.matingResolved = true;
     return {
       pair_id: tally.leading_pair_id,
       parent_a_id: parentAId,

--- a/apps/backend/services/mating/coopMatingResolver.js
+++ b/apps/backend/services/mating/coopMatingResolver.js
@@ -1,0 +1,51 @@
+'use strict';
+// S22-B Task 8 -- server-side offspring roll for a resolved coop mating vote.
+// Additive: reuses metaStore.rollOffspring + best-effort epigenome hydration
+// (creatureEpigenomeStore), mirroring routes/meta.js /mating/roll WITHOUT
+// touching that endpoint. Prisma-gated: degrades to a bare roll on failure.
+// All extra context is OPTIONAL -- the roll must work with an empty context.
+
+async function resolveCoopMatingOffspring({
+  store,
+  parentAId,
+  parentBId,
+  biomeId,
+  campaignId,
+  prisma,
+} = {}) {
+  if (!store || typeof store.rollOffspring !== 'function')
+    return { success: false, error: 'store_required' };
+  if (!parentAId || !parentBId) return { success: false, error: 'parent_ids_required' };
+  const parentA = { id: parentAId };
+  const parentB = { id: parentBId };
+  const context = {};
+  // Best-effort epigenome hydration (Fase-3), prisma-gated; any failure is swallowed.
+  try {
+    if (campaignId && prisma) {
+      // eslint-disable-next-line global-require
+      const { createCreatureEpigenomeStore } = require('../genetics/creatureEpigenomeStore');
+      const epiStore = createCreatureEpigenomeStore(prisma);
+      const ea = await epiStore.get(campaignId, parentAId);
+      if (ea) parentA.epigenome = ea;
+      const eb = await epiStore.get(campaignId, parentBId);
+      if (eb) parentB.epigenome = eb;
+    }
+  } catch {
+    /* best-effort hydration */
+  }
+  try {
+    const result = await store.rollOffspring({
+      parentA,
+      parentB,
+      biomeId: biomeId || null,
+      context,
+    });
+    return result && result.success
+      ? { success: true, offspring: result.offspring }
+      : { success: false, error: (result && result.reason) || 'roll_failed' };
+  } catch (err) {
+    return { success: false, error: err.message || 'roll_threw' };
+  }
+}
+
+module.exports = { resolveCoopMatingOffspring };

--- a/apps/backend/services/mating/coopMatingResolver.js
+++ b/apps/backend/services/mating/coopMatingResolver.js
@@ -29,6 +29,16 @@ async function resolveCoopMatingOffspring({
       if (ea) parentA.epigenome = ea;
       const eb = await epiStore.get(campaignId, parentBId);
       if (eb) parentB.epigenome = eb;
+      // Codex P2 -- supply epigenome config + species mean so rollOffspring
+      // actually applies epigenetic inheritance (mirror /mating/roll). Without
+      // context.epigenomeConfig, hydrated epigenomes are ignored by the roll.
+      // eslint-disable-next-line global-require
+      const { loadEpigenomeConfig, computeSpeciesMean } = require('../genetics/epigenome');
+      context.epigenomeConfig = loadEpigenomeConfig();
+      const pop = Object.values(await epiStore.getMany(campaignId)).map((epi) => ({
+        epigenome: epi,
+      }));
+      if (pop.length > 0) context.speciesMean = computeSpeciesMean(pop);
     }
   } catch {
     /* best-effort hydration */

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -1090,6 +1090,12 @@ function createWsServer({
   port = null,
   path = '/ws',
   coopStore = null,
+  // S22-B Task 8 -- optional DI for server-side offspring roll on mating
+  // quorum. metaStoreFactory: (campaignId) => metaStore. prisma forwarded to
+  // the resolver for best-effort epigenome hydration. Both absent -> resolve
+  // is a no-op (mating_tally + ack still fire).
+  metaStoreFactory = null,
+  prisma = null,
 } = {}) {
   if (!lobby) throw new Error('lobby_required');
   if (!server && (port === null || port === undefined)) {
@@ -1592,6 +1598,36 @@ function createWsServer({
               });
               room.broadcast({ type: 'mating_tally', payload: tally });
               socket.send(JSON.stringify({ type: 'mating_vote_accepted', payload: { tally } }));
+              // S22-B Task 8 -- if the vote met connected-only quorum, roll the
+              // offspring server-side + broadcast mating_resolved. Best-effort:
+              // any failure leaves tally/ack intact (resolve is additive).
+              const winner = orch.resolveMatingWinner(allPids, connectedPids);
+              if (winner && metaStoreFactory) {
+                const store = metaStoreFactory(winner.campaign_id);
+                if (store) {
+                  // eslint-disable-next-line global-require
+                  const { resolveCoopMatingOffspring } = require('../mating/coopMatingResolver');
+                  resolveCoopMatingOffspring({
+                    store,
+                    prisma,
+                    campaignId: winner.campaign_id,
+                    parentAId: winner.parent_a_id,
+                    parentBId: winner.parent_b_id,
+                    biomeId: winner.biome_id,
+                  })
+                    .then((resolveRes) => {
+                      room.broadcast({
+                        type: 'mating_resolved',
+                        payload: {
+                          pair_id: winner.pair_id,
+                          offspring: resolveRes.offspring || null,
+                          ok: resolveRes.success,
+                        },
+                      });
+                    })
+                    .catch(() => {});
+                }
+              }
             } catch (err) {
               socket.send(
                 JSON.stringify({

--- a/tests/services/coop/coopMatingResolve.test.js
+++ b/tests/services/coop/coopMatingResolve.test.js
@@ -34,3 +34,10 @@ test('resolveMatingWinner null before quorum', () => {
   const o = debriefWithSurvivors();
   assert.equal(o.resolveMatingWinner(['p1', 'p2'], ['p1', 'p2']), null);
 });
+
+test('resolveMatingWinner rejects pair not in survivors (no roll on bogus ids)', () => {
+  const o = debriefWithSurvivors();
+  o.voteMating('p1', 'foo__bar', { allPlayerIds: ['p1'] });
+  assert.equal(o.resolveMatingWinner(['p1'], ['p1']), null);
+  assert.equal(o.run.matingResolved, false);
+});

--- a/tests/services/coop/coopMatingResolve.test.js
+++ b/tests/services/coop/coopMatingResolve.test.js
@@ -1,0 +1,36 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { CoopOrchestrator } = require('../../../apps/backend/services/coop/coopOrchestrator');
+
+function debriefWithSurvivors() {
+  const o = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'h1' });
+  o.startRun({ scenarioStack: ['enc_a'] });
+  o.phase = 'combat';
+  o.endCombat({ outcome: 'victory', survivors: [{ id: 'u_a' }, { id: 'u_b' }] });
+  return o;
+}
+
+test('endCombat persists survivors on run', () => {
+  const o = debriefWithSurvivors();
+  assert.deepEqual(
+    o.run.survivors.map((u) => u.id),
+    ['u_a', 'u_b'],
+  );
+});
+
+test('resolveMatingWinner returns winner once quorum met, then null (idempotent)', () => {
+  const o = debriefWithSurvivors();
+  o.voteMating('p1', 'u_a__u_b', { allPlayerIds: ['p1'] });
+  const w = o.resolveMatingWinner(['p1'], ['p1']);
+  assert.equal(w.pair_id, 'u_a__u_b');
+  assert.equal(w.parent_a_id, 'u_a');
+  assert.equal(w.parent_b_id, 'u_b');
+  assert.equal(w.campaign_id, o.run.id);
+  assert.equal(o.resolveMatingWinner(['p1'], ['p1']), null);
+});
+
+test('resolveMatingWinner null before quorum', () => {
+  const o = debriefWithSurvivors();
+  assert.equal(o.resolveMatingWinner(['p1', 'p2'], ['p1', 'p2']), null);
+});

--- a/tests/services/mating/coopMatingResolver.test.js
+++ b/tests/services/mating/coopMatingResolver.test.js
@@ -1,0 +1,41 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  resolveCoopMatingOffspring,
+} = require('../../../apps/backend/services/mating/coopMatingResolver');
+
+test('rolls via injected store (no prisma -> bare parents)', async () => {
+  const calls = [];
+  const stubStore = {
+    rollOffspring: async (args) => {
+      calls.push(args);
+      return { success: true, offspring: { lineage_id: 'L1' } };
+    },
+  };
+  const res = await resolveCoopMatingOffspring({
+    store: stubStore,
+    parentAId: 'u_a',
+    parentBId: 'u_b',
+    biomeId: 'enc_a',
+    campaignId: null,
+    prisma: null,
+  });
+  assert.equal(res.success, true);
+  assert.equal(res.offspring.lineage_id, 'L1');
+  assert.equal(calls[0].parentA.id, 'u_a');
+  assert.equal(calls[0].parentB.id, 'u_b');
+  assert.equal(calls[0].biomeId, 'enc_a');
+});
+
+test('guards: missing store or ids', async () => {
+  assert.equal(
+    (await resolveCoopMatingOffspring({ store: null, parentAId: 'a', parentBId: 'b' })).error,
+    'store_required',
+  );
+  const stub = { rollOffspring: async () => ({ success: true, offspring: {} }) };
+  assert.equal(
+    (await resolveCoopMatingOffspring({ store: stub, parentAId: '', parentBId: 'b' })).error,
+    'parent_ids_required',
+  );
+});

--- a/tests/services/network/wsSession-matingResolve.test.js
+++ b/tests/services/network/wsSession-matingResolve.test.js
@@ -1,0 +1,112 @@
+// S22-B Task 8 -- when a phone mating_vote reaches quorum, the WS handler
+// rolls the offspring server-side via coopMatingResolver (metaStore.rollOffspring)
+// and broadcasts { type: 'mating_resolved', payload: { pair_id, offspring, ok } }
+// to the room. Mirror harness of wsSession-matingVote.test.js.
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const WebSocket = require('ws');
+const {
+  LobbyService,
+  createWsServer,
+} = require('../../../apps/backend/services/network/wsSession');
+const { createCoopStore } = require('../../../apps/backend/services/coop/coopStore');
+
+function attachBuffer(ws) {
+  ws.__buf = [];
+  ws.__waiters = [];
+  ws.on('message', (raw) => {
+    let msg;
+    try {
+      msg = JSON.parse(raw.toString());
+    } catch {
+      return;
+    }
+    ws.__buf.push(msg);
+    for (const w of ws.__waiters.slice()) {
+      if (w.predicate(msg)) {
+        ws.__waiters = ws.__waiters.filter((x) => x !== w);
+        w.resolve(msg);
+      }
+    }
+  });
+  return ws;
+}
+
+function waitForMessage(ws, predicate, timeoutMs = 3000) {
+  for (const msg of ws.__buf) {
+    if (predicate(msg)) return Promise.resolve(msg);
+  }
+  return new Promise((resolve, reject) => {
+    const waiter = { predicate, resolve, reject };
+    const timer = setTimeout(() => {
+      ws.__waiters = ws.__waiters.filter((x) => x !== waiter);
+      reject(new Error('timeout waiting for ws message'));
+    }, timeoutMs);
+    waiter.resolve = (msg) => {
+      clearTimeout(timer);
+      resolve(msg);
+    };
+    ws.__waiters.push(waiter);
+  });
+}
+
+function openWs(port, { code, player_id, token }) {
+  const url = `ws://127.0.0.1:${port}/ws?code=${encodeURIComponent(code)}&player_id=${encodeURIComponent(player_id)}&token=${encodeURIComponent(token)}`;
+  return attachBuffer(new WebSocket(url));
+}
+
+async function waitOpen(ws) {
+  return new Promise((resolve, reject) => {
+    ws.once('open', () => resolve());
+    ws.once('error', reject);
+  });
+}
+
+test('S22-B: phone mating_vote quorum rolls offspring + broadcasts mating_resolved', async () => {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const metaStoreFactory = () => ({
+    rollOffspring: async () => ({ success: true, offspring: { lineage_id: 'L1' } }),
+  });
+  const wsHandle = createWsServer({ lobby, coopStore, metaStoreFactory, port: 0 });
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  const port = wsHandle.wss.address().port;
+
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Bob' });
+
+    const orch = coopStore.getOrCreate(room.code);
+    orch.startRun({ scenarioStack: ['enc_tutorial_01'] });
+    // Drive to debrief WITH survivors so the winning pair maps to units.
+    orch.phase = 'combat';
+    orch.endCombat({ outcome: 'victory', survivors: [{ id: 'u_a' }, { id: 'u_b' }] });
+
+    const p1Ws = openWs(port, {
+      code: room.code,
+      player_id: p1.player_id,
+      token: p1.player_token,
+    });
+    await waitOpen(p1Ws);
+    await waitForMessage(p1Ws, (m) => m.type === 'hello');
+
+    // Single connected non-host player votes -> connected-only quorum met.
+    p1Ws.send(
+      JSON.stringify({ type: 'intent', payload: { action: 'mating_vote', pair_id: 'u_a__u_b' } }),
+    );
+
+    const resolved = await waitForMessage(p1Ws, (m) => m.type === 'mating_resolved', 2500);
+    assert.equal(resolved.payload.pair_id, 'u_a__u_b');
+    assert.equal(resolved.payload.ok, true);
+    assert.equal(resolved.payload.offspring.lineage_id, 'L1');
+
+    p1Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});


### PR DESCRIPTION
## S22-B Task 8 -- server-side offspring birth on mating resolve

Completes S22-B: when the coop mating vote reaches quorum, the winning pair produces an offspring server-side + broadcasts `mating_resolved`. Plan: #369.

**Backend-only (no Godot port).** `metaStore.rollOffspring` already hydrates parent genes from `creatureEpigenomeStore` by `(campaignId, unitId)` -- the roll needs only the voted pair's parent IDs + `run.id`.

- **orch**: persist `run.survivors` on `endCombat`; idempotent `resolveMatingWinner` (quorum -> winning pair, `run.matingResolved` guard).
- **coopMatingResolver** (additive, `meta.js` untouched): epigenome-hydrated (best-effort, prisma-gated) `rollOffspring`; degrades to bare roll without prisma.
- **wire**: WS `mating_vote` handler (phone path) + REST `/coop/mating/vote` parity -> on quorum, roll via injected `metaStoreFactory` + broadcast `mating_resolved {pair_id, offspring, ok}`. `metaStoreFactory`+`prisma` DI through `app.js`/`index.js`.

### Tests (TDD)
- `coopMatingResolve` (survivors persist + resolveMatingWinner idempotent/quorum)
- `coopMatingResolver` (roll via store + guards)
- `wsSession-matingResolve` (WS quorum -> mating_resolved broadcast with offspring)
- Full regression: 284/284 (network + coop API + coop/mating services).

### Deferred
Godot `mating_resolved` consumer (offspring reveal UI) -- phone functional with vote+tally; follow-up.