### PR TITLE
ermes FASE 2b: test gaps, CI wiring, band tuning, suggestions view

### DIFF
--- a/apps/backend/routes/traits.js
+++ b/apps/backend/routes/traits.js
@@ -7,6 +7,8 @@ const { createAuthHandlers } = require('../middleware/auth');
 function createTraitRouter(options = {}) {
   const router = express.Router();
   const dataRoot = options.dataRoot || path.resolve(__dirname, '..', '..', 'data');
+  const suggestionsDir =
+    options.suggestionsDir || path.resolve(__dirname, '..', '..', '..', 'reports', 'traits');
   const repository =
     options.repository ||
     new TraitRepository({
@@ -256,7 +258,7 @@ function createTraitRouter(options = {}) {
     try {
       const fs = require('node:fs');
       const path = require('node:path');
-      const reportsDir = path.resolve(__dirname, '../../../reports/traits');
+      const reportsDir = suggestionsDir;
       if (!fs.existsSync(reportsDir)) {
         return res.json({
           schema: 'ermes_trait_suggestion',

--- a/apps/trait-editor/src/App.vue
+++ b/apps/trait-editor/src/App.vue
@@ -21,6 +21,7 @@ function statusIcon(): string {
       </p>
       <nav class="app-shell__nav">
         <router-link to="/traits">Libreria</router-link>
+        <router-link to="/suggestions">Suggerimenti</router-link>
       </nav>
     </header>
     <main class="app-shell__content">

--- a/apps/trait-editor/src/router.ts
+++ b/apps/trait-editor/src/router.ts
@@ -19,6 +19,11 @@ const routes: RouteRecordRaw[] = [
     name: 'trait-editor',
     component: () => import('./views/TraitEditorView.vue'),
   },
+  {
+    path: '/suggestions',
+    name: 'trait-suggestions',
+    component: () => import('./views/TraitSuggestionsView.vue'),
+  },
   { path: '/:pathMatch(.*)*', redirect: '/traits' },
 ];
 

--- a/apps/trait-editor/src/services/trait-data.service.ts
+++ b/apps/trait-editor/src/services/trait-data.service.ts
@@ -5,6 +5,11 @@ import {
 } from '../data/traits.sample';
 import type { Trait, TraitIndexEntry } from '../types/trait';
 import type {
+  TraitSuggestion,
+  TraitSuggestionPatch,
+  TraitSuggestionsResponse,
+} from '../types/trait-suggestion';
+import type {
   TraitValidationAutoFix,
   TraitValidationAutoFixOperation,
   TraitValidationIssue,
@@ -189,6 +194,102 @@ export class TraitDataService {
 
   getLastError(): Error | null {
     return this.lastError;
+  }
+
+  // ADR-2026-05-29 TKT-BR-09: read ERMES trait suggestions (GET, read-only).
+  // Reuses fetchWithAuth (Bearer + 401 retry). Server returns the latest
+  // reports/traits/<date>-ermes-suggestions.json (ermes_trait_suggestion v1.0.0).
+  async getSuggestions(): Promise<TraitSuggestionsResponse> {
+    const endpoint = this.endpointOverride ?? TRAIT_DATA_ENDPOINT;
+    const target = this.buildSuggestionsEndpoint(endpoint);
+    if (!target) {
+      throw new Error('Endpoint suggestions non configurato.');
+    }
+    const response = await this.fetchWithAuth(target, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) {
+      throw new Error(`Caricamento suggestions fallito (stato ${response.status}).`);
+    }
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch (error) {
+      throw new Error(`Risposta suggestions non interpretabile: ${String(error)}`);
+    }
+    return this.normaliseSuggestions(payload);
+  }
+
+  private buildSuggestionsEndpoint(baseEndpoint: string): string | null {
+    const apiPath = '/api/traits/suggestions';
+    const trimmed = typeof baseEndpoint === 'string' ? baseEndpoint.trim() : '';
+    if (trimmed && this.isAbsoluteUrl(trimmed)) {
+      try {
+        const base = new URL(trimmed);
+        return new URL(apiPath, `${base.protocol}//${base.host}`).toString();
+      } catch {
+        return apiPath;
+      }
+    }
+    if (this.locationOrigin) {
+      try {
+        return new URL(apiPath, this.locationOrigin).toString();
+      } catch {
+        return apiPath;
+      }
+    }
+    return apiPath;
+  }
+
+  private normaliseSuggestions(payload: unknown): TraitSuggestionsResponse {
+    const empty: TraitSuggestionsResponse = {
+      schema: 'ermes_trait_suggestion',
+      schema_version: '1.0.0',
+      suggestions: [],
+    };
+    if (!payload || typeof payload !== 'object') {
+      return empty;
+    }
+    const record = payload as Record<string, unknown>;
+    const rawList = Array.isArray(record.suggestions) ? record.suggestions : [];
+    const suggestions = rawList
+      .map((item) => this.normaliseSuggestion(item))
+      .filter((item): item is TraitSuggestion => Boolean(item));
+    return {
+      schema: typeof record.schema === 'string' ? record.schema : empty.schema,
+      schema_version:
+        typeof record.schema_version === 'string' ? record.schema_version : empty.schema_version,
+      suggestions,
+      note: typeof record.note === 'string' ? record.note : undefined,
+    };
+  }
+
+  private normaliseSuggestion(source: unknown): TraitSuggestion | null {
+    if (!source || typeof source !== 'object') {
+      return null;
+    }
+    const r = source as Record<string, unknown>;
+    const traitId = typeof r.trait_id === 'string' ? r.trait_id : '';
+    if (!traitId) {
+      return null;
+    }
+    const patch =
+      r.proposed_patch && typeof r.proposed_patch === 'object'
+        ? (r.proposed_patch as TraitSuggestionPatch)
+        : undefined;
+    return {
+      trait_id: traitId,
+      biome_id: typeof r.biome_id === 'string' ? r.biome_id : '',
+      kind: typeof r.kind === 'string' ? r.kind : 'suggestion',
+      rationale: typeof r.rationale === 'string' ? r.rationale : '',
+      confidence: typeof r.confidence === 'number' ? r.confidence : 0,
+      evidence:
+        r.evidence && typeof r.evidence === 'object'
+          ? (r.evidence as Record<string, unknown>)
+          : undefined,
+      proposed_patch: patch,
+    };
   }
 
   validateTrait(trait: Trait): Promise<TraitValidationResult> {

--- a/apps/trait-editor/src/types/trait-suggestion.ts
+++ b/apps/trait-editor/src/types/trait-suggestion.ts
@@ -1,0 +1,28 @@
+// ADR-2026-05-29 TKT-BR-09 -- ERMES trait suggestion types.
+// Mirrors the ermes_trait_suggestion schema v1.0.0 emitted by
+// prototypes/ermes_lab/suggestions.py and served by GET /api/traits/suggestions.
+
+export interface TraitSuggestionPatch {
+  op: 'add' | 'replace' | 'remove' | string;
+  path: string;
+  value?: unknown;
+}
+
+export type TraitSuggestionDecision = 'pending' | 'accepted' | 'rejected';
+
+export interface TraitSuggestion {
+  trait_id: string;
+  biome_id: string;
+  kind: string;
+  rationale: string;
+  confidence: number;
+  evidence?: Record<string, unknown>;
+  proposed_patch?: TraitSuggestionPatch;
+}
+
+export interface TraitSuggestionsResponse {
+  schema: string;
+  schema_version: string;
+  suggestions: TraitSuggestion[];
+  note?: string;
+}

--- a/apps/trait-editor/src/views/TraitSuggestionsView.vue
+++ b/apps/trait-editor/src/views/TraitSuggestionsView.vue
@@ -1,0 +1,172 @@
+<script setup lang="ts">
+// ADR-2026-05-29 TKT-BR-09 -- ERMES trait suggestions review (accept/reject UX).
+// Read-only consumer of GET /api/traits/suggestions. Decisions are tracked
+// locally (Eduardo gate); applying a proposed_patch to a trait is a separate
+// flow (trait edit / FASE 3 wiring), not performed here.
+
+import { computed, onMounted, ref } from 'vue';
+import { getTraitDataService } from '../services/trait-data.service';
+import { useTraitState } from '../services/trait-state.service';
+import type { TraitSuggestion, TraitSuggestionDecision } from '../types/trait-suggestion';
+
+const suggestions = ref<TraitSuggestion[]>([]);
+const decisions = ref<TraitSuggestionDecision[]>([]);
+const note = ref<string | undefined>(undefined);
+const loading = ref(true);
+const error = ref<string | null>(null);
+const { setLoading, setStatus } = useTraitState();
+const dataService = getTraitDataService();
+
+const pendingCount = computed(() => decisions.value.filter((d) => d === 'pending').length);
+const acceptedCount = computed(() => decisions.value.filter((d) => d === 'accepted').length);
+const rejectedCount = computed(() => decisions.value.filter((d) => d === 'rejected').length);
+
+function accept(index: number): void {
+  if (index >= 0 && index < decisions.value.length) decisions.value[index] = 'accepted';
+}
+
+function reject(index: number): void {
+  if (index >= 0 && index < decisions.value.length) decisions.value[index] = 'rejected';
+}
+
+function decisionLabel(decision: TraitSuggestionDecision): string {
+  if (decision === 'accepted') return 'Accettato';
+  if (decision === 'rejected') return 'Rifiutato';
+  return '';
+}
+
+function confidencePct(value: number): number {
+  return Math.round(Math.max(0, Math.min(1, value)) * 100);
+}
+
+onMounted(async () => {
+  loading.value = true;
+  setLoading(true);
+  setStatus(null);
+  error.value = null;
+  try {
+    const result = await dataService.getSuggestions();
+    suggestions.value = result.suggestions;
+    decisions.value = result.suggestions.map(() => 'pending');
+    note.value = result.note;
+  } catch (err) {
+    error.value = 'Impossibile caricare i suggerimenti ERMES in questo momento.';
+    setStatus(error.value, 'error');
+    console.error('Errore caricamento suggestions ERMES:', err);
+  } finally {
+    loading.value = false;
+    setLoading(false);
+  }
+});
+</script>
+
+<template>
+  <section class="trait-suggestions" data-testid="trait-suggestions">
+    <header class="trait-suggestions__header">
+      <h1>Suggerimenti ERMES</h1>
+      <p class="trait-suggestions__summary" data-testid="summary">
+        {{ acceptedCount }} accettati, {{ rejectedCount }} rifiutati, {{ pendingCount }} in sospeso
+      </p>
+    </header>
+
+    <p v-if="loading" class="trait-suggestions__loading" data-testid="loading">Caricamento...</p>
+
+    <p v-else-if="error" class="trait-suggestions__error" data-testid="error">{{ error }}</p>
+
+    <ul v-else-if="suggestions.length > 0" class="trait-suggestions__list">
+      <li
+        v-for="(s, i) in suggestions"
+        :key="i"
+        class="trait-suggestions__item"
+        :class="`is-${decisions[i]}`"
+        data-testid="suggestion-item"
+      >
+        <div class="trait-suggestions__meta">
+          <strong class="trait-suggestions__trait">{{ s.trait_id }}</strong>
+          <span class="trait-suggestions__kind">{{ s.kind }}</span>
+          <span class="trait-suggestions__biome">{{ s.biome_id }}</span>
+          <span class="trait-suggestions__confidence">{{ confidencePct(s.confidence) }}%</span>
+        </div>
+        <p class="trait-suggestions__rationale">{{ s.rationale }}</p>
+        <code v-if="s.proposed_patch" class="trait-suggestions__patch" data-testid="patch">
+          {{ s.proposed_patch.op }} {{ s.proposed_patch.path }}<template
+            v-if="s.proposed_patch.value !== undefined"
+          >
+            = {{ s.proposed_patch.value }}</template
+          >
+        </code>
+        <div class="trait-suggestions__actions">
+          <button
+            type="button"
+            data-testid="accept-btn"
+            :disabled="decisions[i] === 'accepted'"
+            @click="accept(i)"
+          >
+            Accetta
+          </button>
+          <button
+            type="button"
+            data-testid="reject-btn"
+            :disabled="decisions[i] === 'rejected'"
+            @click="reject(i)"
+          >
+            Rifiuta
+          </button>
+          <span
+            v-if="decisions[i] !== 'pending'"
+            class="trait-suggestions__decision"
+            data-testid="decision"
+          >
+            {{ decisionLabel(decisions[i]) }}
+          </span>
+        </div>
+      </li>
+    </ul>
+
+    <p v-else class="trait-suggestions__empty" data-testid="empty">
+      {{ note || 'Nessun suggerimento ERMES disponibile.' }}
+    </p>
+  </section>
+</template>
+
+<style scoped>
+.trait-suggestions__item {
+  border: 1px solid var(--border, #ccc);
+  border-radius: 6px;
+  padding: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+.trait-suggestions__item.is-accepted {
+  border-color: #2e7d32;
+  background: rgba(46, 125, 50, 0.06);
+}
+.trait-suggestions__item.is-rejected {
+  border-color: #b71c1c;
+  background: rgba(183, 28, 28, 0.06);
+  opacity: 0.7;
+}
+.trait-suggestions__meta {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+.trait-suggestions__kind {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+.trait-suggestions__patch {
+  display: block;
+  font-family: monospace;
+  font-size: 0.85rem;
+  opacity: 0.85;
+  margin: 0.25rem 0;
+}
+.trait-suggestions__actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.4rem;
+}
+</style>

--- a/apps/trait-editor/src/views/TraitSuggestionsView.vue
+++ b/apps/trait-editor/src/views/TraitSuggestionsView.vue
@@ -89,9 +89,8 @@ onMounted(async () => {
         </div>
         <p class="trait-suggestions__rationale">{{ s.rationale }}</p>
         <code v-if="s.proposed_patch" class="trait-suggestions__patch" data-testid="patch">
-          {{ s.proposed_patch.op }} {{ s.proposed_patch.path }}<template
-            v-if="s.proposed_patch.value !== undefined"
-          >
+          {{ s.proposed_patch.op }} {{ s.proposed_patch.path
+          }}<template v-if="s.proposed_patch.value !== undefined">
             = {{ s.proposed_patch.value }}</template
           >
         </code>

--- a/apps/trait-editor/src/views/__tests__/TraitSuggestionsView.spec.ts
+++ b/apps/trait-editor/src/views/__tests__/TraitSuggestionsView.spec.ts
@@ -1,0 +1,100 @@
+// ADR-2026-05-29 TKT-BR-09 -- TraitSuggestionsView accept/reject UX.
+//
+// Mounts the view via @vue/test-utils + happy-dom, stubs global fetch (the
+// suggestions service uses TraitDataService.fetchWithAuth -> global fetch),
+// and verifies render + local accept/reject decision tracking + empty/error.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createRouter, createMemoryHistory } from 'vue-router';
+import TraitSuggestionsView from '../TraitSuggestionsView.vue';
+
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [{ path: '/', component: { template: '<div />' } }],
+});
+
+function stubFetch(payload: unknown, ok = true, status = 200): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok,
+      status,
+      json: async () => payload,
+    })),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+async function mountView() {
+  await router.push('/');
+  const wrapper = mount(TraitSuggestionsView, { global: { plugins: [router] } });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('TraitSuggestionsView (TKT-BR-09)', () => {
+  it('renders suggestions and tracks accept/reject decisions in summary', async () => {
+    stubFetch({
+      schema: 'ermes_trait_suggestion',
+      schema_version: '1.0.0',
+      suggestions: [
+        {
+          trait_id: 'heat_resistance_x',
+          biome_id: 'cryosteppe_convergence',
+          kind: 'mutation_bias_match',
+          rationale: 'High heat bias.',
+          confidence: 0.5,
+          proposed_patch: { op: 'add', path: '/biome_tags/-', value: 'cryosteppe_convergence' },
+        },
+        {
+          trait_id: 'fragile_y',
+          biome_id: 'savana',
+          kind: 'extinction_risk_warning',
+          rationale: 'High extinction risk.',
+          confidence: 0.8,
+          proposed_patch: { op: 'replace', path: '/tier', value: 'T2' },
+        },
+      ],
+    });
+    const wrapper = await mountView();
+
+    const items = wrapper.findAll('[data-testid="suggestion-item"]');
+    expect(items.length).toBe(2);
+    expect(wrapper.findAll('[data-testid="patch"]').length).toBe(2);
+
+    await items[0].find('[data-testid="accept-btn"]').trigger('click');
+    await items[1].find('[data-testid="reject-btn"]').trigger('click');
+
+    const summary = wrapper.find('[data-testid="summary"]').text();
+    expect(summary).toContain('1 accettati');
+    expect(summary).toContain('1 rifiutati');
+    expect(summary).toContain('0 in sospeso');
+  });
+
+  it('renders empty state with backend note when no suggestions', async () => {
+    stubFetch({
+      schema: 'ermes_trait_suggestion',
+      schema_version: '1.0.0',
+      suggestions: [],
+      note: 'nessun report ermes-suggestions trovato',
+    });
+    const wrapper = await mountView();
+
+    expect(wrapper.find('[data-testid="suggestion-item"]').exists()).toBe(false);
+    const empty = wrapper.find('[data-testid="empty"]');
+    expect(empty.exists()).toBe(true);
+    expect(empty.text()).toContain('nessun report');
+  });
+
+  it('renders error state when the request fails', async () => {
+    stubFetch({ error: 'boom' }, false, 500);
+    const wrapper = await mountView();
+
+    expect(wrapper.find('[data-testid="error"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="suggestion-item"]').exists()).toBe(false);
+  });
+});

--- a/docs/PILLARS_STATUS.md
+++ b/docs/PILLARS_STATUS.md
@@ -61,3 +61,23 @@ Dopo il playtest: **tutti 🟡**. Non è regressione reale: è revisione onesta 
 ---
 
 _File vivo. Aggiornare dopo ogni playtest o modifica rilevante ai pilastri._
+
+---
+
+## Aggiornamento 2026-05-29 -- ERMES runtime bridge FASE 2 (PR fase2b)
+
+Plumbing del bridge ERMES (ADR-2026-05-29) shipped + reso **dimostrabile**, ma NON
+ancora player-perceivable in combattimento. Nessun upgrade di stato pilastro.
+
+- **P2 Evoluzione emergente** (resta 🟡): il bridge legge eco_pressure per bioma e
+  applica delta DISCRETI bucketed (low -1 / med 0 / high +1) a attack/defense.
+  Config pilota tunato per esercitare low+med+high (rovine LOW, cryosteppe HIGH).
+  MA `applyErmesBiomeTraitCosts` non ha ancora caller nel loop di combattimento,
+  quindi la reazione bioma NON e' percepibile in-game. Combat wiring = FASE 3.
+- **P6 Fairness** (resta 🟡): output DISCRETO con cap +/-2 (mirror ADR-21c), max 3
+  bucket attivi per unit -> niente stat-drift continuo (anti-ref Creatures). Cap
+  testato; diventa rilevante per P6 quando il bridge sara' combat-wired.
+- Calibration WR N=40 DEFERITA a FASE 3 (oggi il bridge e' inerte nel combat loop;
+  rationale + before/after in `docs/playtest/2026-05-29-br12-ermes-band-tuning.md`).
+
+Ref: PR fase2b (BR-03/04/08/09/11/12 + wiring test ermes prima orfani in CI).

--- a/docs/playtest/2026-05-29-br12-ermes-band-tuning.md
+++ b/docs/playtest/2026-05-29-br12-ermes-band-tuning.md
@@ -1,0 +1,78 @@
+# TKT-BR-12 -- ERMES bridge band tuning + calibration scope
+
+Date: 2026-05-29
+ADR: ADR-2026-05-29-ermes-runtime-bridge
+Branch: chore/2026-05-30-ermes-bridge-fase2b
+
+## Problem (handoff finding)
+
+FASE 2 shipped the ERMES bridge plumbing (BR-02..08, BR-10, BR-13). Verification
+found it functionally INERT: all 4 pilot biomes produced `eco_pressure_score` in
+0.42-0.66, which is the MED band `[0.33, 0.66)` of
+`data/core/balance/ermes_bucket_thresholds.yaml`. MED `delta_mod` is 0, so
+`applyErmesBiomeTraitCosts` applied zero delta on every biome. Plumbing SOUND,
+output zero -> bridge not demonstrable.
+
+## Root cause
+
+`ermes_sim.build_report` derives `eco = clamp(food_p*.35 + pred_p*.4 + temp_p*.25)`
+with `food_p = 1-food`, `pred_p = predators`, `temp_p = abs(temp-.5)*2`. The four
+pilot biome environments in `prototypes/ermes_lab/configs/multi_biome.json` all
+happened to land in the mid range after the 50-generation env random walk
+(seed 7).
+
+## Fix -- config tuning (two biomes pushed to band extremes)
+
+Tuned `multi_biome.json` so the pilot set spans LOW + MED + HIGH. Pushed values
+hard so the per-generation random walk (volatility 0.04-0.06) cannot flip the band.
+
+| biome | env before (temp/food/pred) | env after | eco before | eco after | band |
+|---|---|---|---|---|---|
+| rovine_planari | 0.5 / 0.45 / 0.4 | 0.5 / 0.85 / 0.15 | 0.424 | 0.164 | LOW |
+| cryosteppe_convergence | 0.15 / 0.4 / 0.5 | 0.05 / 0.2 / 0.85 | 0.659 | 0.876 | HIGH |
+| savana | unchanged | unchanged | 0.449 | 0.449 | MED |
+| caverna_risonante | unchanged | unchanged | 0.598 | 0.598 | MED |
+
+Narrative-coherent: ancient `rovine` = calm (abundant food, few predators);
+`cryosteppe convergence` = harsh (scarce food, many predators, extreme cold).
+
+## Verification -- bridge now demonstrable
+
+Bridge run on the regenerated report (`getErmesBucketed` -> `applyErmesBiomeTraitCosts`,
+fresh unit each biome):
+
+| biome | band | attack_mod_bonus | defense_mod_bonus | buckets_applied |
+|---|---|---|---|---|
+| rovine_planari | low | -1 | -1 | 1 |
+| savana | med | 0 | 0 | 0 |
+| caverna_risonante | med | 0 | 0 | 0 |
+| cryosteppe_convergence | high | +1 | +1 | 1 |
+
+The bridge now applies -1 / 0 / +1 by band (capped +/-2 per ADR-21c). MED stays
+neutral by design. Guarded by `test_multi_biome_exercises_low_and_high_bands`
+(prototypes/ermes_lab/tests) -- a revert to an all-MED config fails CI.
+
+## Combat win-rate N=40 calibration -- DEFERRED (with reason)
+
+The handoff listed an N=40 `calibrate_drift_verify.py` run (WR shift < 5pp gate).
+Ground-truth check before running: `applyErmesBiomeTraitCosts` has NO live caller
+(grep repo-wide: only definition + export + a doc comment). `getErmesBucketed` is
+called only by it. The bridge is NOT wired into the combat / encounter loop --
+FASE 2 is plumbing by design (handoff title).
+
+`calibrate_drift_verify.py` measures combat win-rate for hardcore scenarios via a
+running server. With the bridge absent from the combat path, an N=40 run would
+exercise nothing and report ~0pp shift by construction -- ~24min of compute that
+measures a dead bridge, and a false "WR-ratified" claim (anti-pattern #8/#19,
+G2 over-claim).
+
+Decision: the WR-impact N=40 calibration is deferred to the FASE 3 ticket that
+wires `applyErmesBiomeTraitCosts` into live combat. The < 5pp gate becomes
+meaningful only once the bridge actually applies deltas in scored combat. The
+demonstrable bridge output above (capped +/-1/+/-2) is the FASE 2 deliverable.
+
+## Quality Gate
+
+- Smoke: `python ermes_sim.py --multi-biome` regenerates report, 4 biomes, bands span low/med/high.
+- Research: band edge cases + drift robustness (values pushed clear of band boundaries).
+- Tuning: before/after eco + delta documented above (inert -> -1/0/+1).

--- a/docs/playtest/2026-05-29-br12-ermes-band-tuning.md
+++ b/docs/playtest/2026-05-29-br12-ermes-band-tuning.md
@@ -26,12 +26,12 @@ happened to land in the mid range after the 50-generation env random walk
 Tuned `multi_biome.json` so the pilot set spans LOW + MED + HIGH. Pushed values
 hard so the per-generation random walk (volatility 0.04-0.06) cannot flip the band.
 
-| biome | env before (temp/food/pred) | env after | eco before | eco after | band |
-|---|---|---|---|---|---|
-| rovine_planari | 0.5 / 0.45 / 0.4 | 0.5 / 0.85 / 0.15 | 0.424 | 0.164 | LOW |
-| cryosteppe_convergence | 0.15 / 0.4 / 0.5 | 0.05 / 0.2 / 0.85 | 0.659 | 0.876 | HIGH |
-| savana | unchanged | unchanged | 0.449 | 0.449 | MED |
-| caverna_risonante | unchanged | unchanged | 0.598 | 0.598 | MED |
+| biome                  | env before (temp/food/pred) | env after         | eco before | eco after | band |
+| ---------------------- | --------------------------- | ----------------- | ---------- | --------- | ---- |
+| rovine_planari         | 0.5 / 0.45 / 0.4            | 0.5 / 0.85 / 0.15 | 0.424      | 0.164     | LOW  |
+| cryosteppe_convergence | 0.15 / 0.4 / 0.5            | 0.05 / 0.2 / 0.85 | 0.659      | 0.876     | HIGH |
+| savana                 | unchanged                   | unchanged         | 0.449      | 0.449     | MED  |
+| caverna_risonante      | unchanged                   | unchanged         | 0.598      | 0.598     | MED  |
 
 Narrative-coherent: ancient `rovine` = calm (abundant food, few predators);
 `cryosteppe convergence` = harsh (scarce food, many predators, extreme cold).
@@ -41,12 +41,12 @@ Narrative-coherent: ancient `rovine` = calm (abundant food, few predators);
 Bridge run on the regenerated report (`getErmesBucketed` -> `applyErmesBiomeTraitCosts`,
 fresh unit each biome):
 
-| biome | band | attack_mod_bonus | defense_mod_bonus | buckets_applied |
-|---|---|---|---|---|
-| rovine_planari | low | -1 | -1 | 1 |
-| savana | med | 0 | 0 | 0 |
-| caverna_risonante | med | 0 | 0 | 0 |
-| cryosteppe_convergence | high | +1 | +1 | 1 |
+| biome                  | band | attack_mod_bonus | defense_mod_bonus | buckets_applied |
+| ---------------------- | ---- | ---------------- | ----------------- | --------------- |
+| rovine_planari         | low  | -1               | -1                | 1               |
+| savana                 | med  | 0                | 0                 | 0               |
+| caverna_risonante      | med  | 0                | 0                 | 0               |
+| cryosteppe_convergence | high | +1               | +1                | 1               |
 
 The bridge now applies -1 / 0 / +1 by band (capped +/-2 per ADR-21c). MED stays
 neutral by design. Guarded by `test_multi_biome_exercises_low_and_high_bands`

--- a/prototypes/ermes_lab/configs/multi_biome.json
+++ b/prototypes/ermes_lab/configs/multi_biome.json
@@ -4,35 +4,55 @@
   "generations": 50,
   "biomes": {
     "savana": {
-      "environment": {"temperature": 0.7, "food": 0.5, "predators": 0.6, "volatility": 0.04},
+      "environment": { "temperature": 0.7, "food": 0.5, "predators": 0.6, "volatility": 0.04 },
       "species": [
-        {"name": "dune_stalker", "population": 80,
-         "traits": {"speed": 0.7, "size": 0.6, "resistance": 0.5},
-         "reproduction_rate": 0.8, "mutation_rate": 0.1, "mutation_strength": 0.05}
+        {
+          "name": "dune_stalker",
+          "population": 80,
+          "traits": { "speed": 0.7, "size": 0.6, "resistance": 0.5 },
+          "reproduction_rate": 0.8,
+          "mutation_rate": 0.1,
+          "mutation_strength": 0.05
+        }
       ]
     },
     "caverna_risonante": {
-      "environment": {"temperature": 0.4, "food": 0.4, "predators": 0.5, "volatility": 0.05},
+      "environment": { "temperature": 0.4, "food": 0.4, "predators": 0.5, "volatility": 0.05 },
       "species": [
-        {"name": "bat_swarm", "population": 100,
-         "traits": {"speed": 0.6, "size": 0.3, "resistance": 0.6},
-         "reproduction_rate": 1.0, "mutation_rate": 0.12, "mutation_strength": 0.06}
+        {
+          "name": "bat_swarm",
+          "population": 100,
+          "traits": { "speed": 0.6, "size": 0.3, "resistance": 0.6 },
+          "reproduction_rate": 1.0,
+          "mutation_rate": 0.12,
+          "mutation_strength": 0.06
+        }
       ]
     },
     "rovine_planari": {
-      "environment": {"temperature": 0.5, "food": 0.85, "predators": 0.15, "volatility": 0.04},
+      "environment": { "temperature": 0.5, "food": 0.85, "predators": 0.15, "volatility": 0.04 },
       "species": [
-        {"name": "construct", "population": 50,
-         "traits": {"speed": 0.4, "size": 0.7, "resistance": 0.8},
-         "reproduction_rate": 0.6, "mutation_rate": 0.05, "mutation_strength": 0.03}
+        {
+          "name": "construct",
+          "population": 50,
+          "traits": { "speed": 0.4, "size": 0.7, "resistance": 0.8 },
+          "reproduction_rate": 0.6,
+          "mutation_rate": 0.05,
+          "mutation_strength": 0.03
+        }
       ]
     },
     "cryosteppe_convergence": {
-      "environment": {"temperature": 0.05, "food": 0.2, "predators": 0.85, "volatility": 0.06},
+      "environment": { "temperature": 0.05, "food": 0.2, "predators": 0.85, "volatility": 0.06 },
       "species": [
-        {"name": "cryo_lupus", "population": 70,
-         "traits": {"speed": 0.65, "size": 0.55, "resistance": 0.75},
-         "reproduction_rate": 0.75, "mutation_rate": 0.1, "mutation_strength": 0.05}
+        {
+          "name": "cryo_lupus",
+          "population": 70,
+          "traits": { "speed": 0.65, "size": 0.55, "resistance": 0.75 },
+          "reproduction_rate": 0.75,
+          "mutation_rate": 0.1,
+          "mutation_strength": 0.05
+        }
       ]
     }
   }

--- a/prototypes/ermes_lab/configs/multi_biome.json
+++ b/prototypes/ermes_lab/configs/multi_biome.json
@@ -20,7 +20,7 @@
       ]
     },
     "rovine_planari": {
-      "environment": {"temperature": 0.5, "food": 0.45, "predators": 0.4, "volatility": 0.04},
+      "environment": {"temperature": 0.5, "food": 0.85, "predators": 0.15, "volatility": 0.04},
       "species": [
         {"name": "construct", "population": 50,
          "traits": {"speed": 0.4, "size": 0.7, "resistance": 0.8},
@@ -28,7 +28,7 @@
       ]
     },
     "cryosteppe_convergence": {
-      "environment": {"temperature": 0.15, "food": 0.4, "predators": 0.5, "volatility": 0.06},
+      "environment": {"temperature": 0.05, "food": 0.2, "predators": 0.85, "volatility": 0.06},
       "species": [
         {"name": "cryo_lupus", "population": 70,
          "traits": {"speed": 0.65, "size": 0.55, "resistance": 0.75},

--- a/prototypes/ermes_lab/tests/test_ermes_lab_multi_biome.py
+++ b/prototypes/ermes_lab/tests/test_ermes_lab_multi_biome.py
@@ -52,3 +52,16 @@ def test_multi_biome_includes_back_compat_bias():
     for biome_id, biome_data in report["biomes"].items():
         assert "predator_density" in biome_data["bias"], f"{biome_id} bias missing predator_density"
         assert "resource_scarcity" in biome_data["bias"], f"{biome_id} bias missing resource_scarcity"
+
+
+def test_multi_biome_exercises_low_and_high_bands():
+    # TKT-BR-12: the pilot config must produce eco_pressure spanning the LOW
+    # (<0.33) AND HIGH (>=0.66) bands so the ERMES bridge is demonstrably
+    # non-inert. When every pilot lands in MED ([0.33,0.66)) the bridge applies
+    # delta_mod 0 everywhere (the inert state found at handoff 2026-05-29).
+    # Bands mirror data/core/balance/ermes_bucket_thresholds.yaml eco_pressure_score.
+    config = load_config(CONFIG)
+    report = run_multi_biome(config)
+    scores = {b: d["eco_pressure_score"] for b, d in report["biomes"].items()}
+    assert min(scores.values()) < 0.33, f"no LOW-band biome (bridge inert): {scores}"
+    assert max(scores.values()) >= 0.66, f"no HIGH-band biome (bridge inert): {scores}"

--- a/scripts/run-test-api.cjs
+++ b/scripts/run-test-api.cjs
@@ -24,6 +24,13 @@ const steps = [
   'node --test tests/scripts/crossPlatformRunners.test.js',
   'node --test tests/i18n/parity.test.js',
   'node --test tests/play/*.test.js',
+  // ERMES runtime bridge (ADR-2026-05-29 FASE 2). tests/services + tests/ai
+  // were not covered by the globs above -> CI-orphaned. Wire the ermes surface
+  // so a rewrite dropping behavior fails CI (guards anti-pattern #10
+  // non-CI-guarded drop). Scoped to ermes files, not the whole subtree.
+  'node --test tests/services/ermes/*.test.js',
+  'node --test tests/services/coop/ermesExporter*.test.js',
+  'node --test tests/ai/applyErmesBiomeTraitCosts.test.js',
 ];
 
 const env = {

--- a/tests/api/traits.suggestions.contract.test.js
+++ b/tests/api/traits.suggestions.contract.test.js
@@ -1,0 +1,170 @@
+// ADR-2026-05-29 TKT-BR-08 -- GET /api/traits/suggestions contract guard.
+//
+// Locks the ERMES suggestions read endpoint invariants:
+//   1. reports dir absent -> 200 empty contract (schema + note, suggestions []).
+//   2. reports dir present but no *-ermes-suggestions.json -> 200 empty contract.
+//   3. latest report served (mtime descending) + ETag header W/"mtime-size".
+//   4. If-None-Match matching ETag -> 304 (no body).
+//   5. role gate: reviewer/editor/admin allowed, viewer rejected (403).
+//
+// Test runner: node:test (run-test-api.cjs glob tests/api/*.test.js).
+// suggestionsDir seam (options.suggestionsDir) keeps fixtures in os.tmpdir,
+// no pollution of repo-root reports/traits.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const express = require('express');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createTraitRouter } = require('../../apps/backend/routes/traits');
+const { signJwt } = require('../../apps/backend/utils/jwt');
+
+const AUTH_SECRET = 'test-secret';
+
+function createToken(roles) {
+  return signJwt({ sub: 'suggestions-tester', roles }, AUTH_SECRET, { expiresIn: '1h' });
+}
+
+function createApp(overrides = {}) {
+  const router = createTraitRouter({
+    repository: {},
+    auth: { secret: AUTH_SECRET },
+    ...overrides,
+  });
+  const app = express();
+  app.use(express.json());
+  app.use('/api/traits', router);
+  return app;
+}
+
+function mkReportsDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'ermes-suggestions-'));
+}
+
+function writeReport(dir, name, payload, mtimeEpochSec) {
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, JSON.stringify(payload));
+  if (typeof mtimeEpochSec === 'number') {
+    fs.utimesSync(p, mtimeEpochSec, mtimeEpochSec);
+  }
+  return p;
+}
+
+test('GET /suggestions -> 200 empty contract when reports dir absent', async () => {
+  const absent = path.join(os.tmpdir(), `ermes-absent-${Date.now()}`);
+  const app = createApp({ suggestionsDir: absent });
+  const token = createToken(['reviewer']);
+
+  const res = await request(app)
+    .get('/api/traits/suggestions')
+    .set('Authorization', `Bearer ${token}`)
+    .expect(200);
+
+  assert.equal(res.body.schema, 'ermes_trait_suggestion');
+  assert.equal(res.body.schema_version, '1.0.0');
+  assert.deepEqual(res.body.suggestions, []);
+  assert.ok(typeof res.body.note === 'string' && res.body.note.length > 0);
+});
+
+test('GET /suggestions -> 200 empty contract when dir present but no report files', async () => {
+  const dir = mkReportsDir();
+  try {
+    fs.writeFileSync(path.join(dir, 'unrelated.json'), '{}');
+    const app = createApp({ suggestionsDir: dir });
+    const token = createToken(['reviewer']);
+
+    const res = await request(app)
+      .get('/api/traits/suggestions')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    assert.equal(res.body.schema_version, '1.0.0');
+    assert.deepEqual(res.body.suggestions, []);
+    assert.match(res.body.note, /nessun report/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('GET /suggestions -> 200 latest report + ETag header', async () => {
+  const dir = mkReportsDir();
+  try {
+    writeReport(
+      dir,
+      '2026-05-28-ermes-suggestions.json',
+      { schema_version: '1.0.0', suggestions: [{ trait_id: 'old' }] },
+      1000000,
+    );
+    writeReport(
+      dir,
+      '2026-05-29-ermes-suggestions.json',
+      {
+        schema: 'ermes_trait_suggestion',
+        schema_version: '1.0.0',
+        suggestions: [{ trait_id: 'fresh', biome_id: 'savana', kind: 'extinction_risk_warning' }],
+      },
+      2000000,
+    );
+    const app = createApp({ suggestionsDir: dir });
+    const token = createToken(['editor']);
+
+    const res = await request(app)
+      .get('/api/traits/suggestions')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    assert.equal(res.body.suggestions.length, 1);
+    assert.equal(res.body.suggestions[0].trait_id, 'fresh');
+    assert.match(res.headers.etag, /^W\/"\d+-\d+"$/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('GET /suggestions -> 304 when If-None-Match matches ETag', async () => {
+  const dir = mkReportsDir();
+  try {
+    writeReport(
+      dir,
+      '2026-05-29-ermes-suggestions.json',
+      { schema_version: '1.0.0', suggestions: [] },
+      2000000,
+    );
+    const app = createApp({ suggestionsDir: dir });
+    const token = createToken(['reviewer']);
+
+    const first = await request(app)
+      .get('/api/traits/suggestions')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    const etag = first.headers.etag;
+    assert.ok(etag, 'first response must expose ETag');
+
+    await request(app)
+      .get('/api/traits/suggestions')
+      .set('Authorization', `Bearer ${token}`)
+      .set('If-None-Match', etag)
+      .expect(304);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('GET /suggestions -> 403 for viewer role', async () => {
+  const dir = mkReportsDir();
+  try {
+    const app = createApp({ suggestionsDir: dir });
+    const token = createToken(['viewer']);
+    await request(app)
+      .get('/api/traits/suggestions')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(403);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/services/coop/ermesExporter.test.js
+++ b/tests/services/coop/ermesExporter.test.js
@@ -8,11 +8,13 @@ const os = require('node:os');
 const path = require('node:path');
 const {
   getErmesForBiome,
+  getErmesBucketed,
   computeRoleGap,
   BIOME_ROLE_DEMANDS,
   STATIC_FALLBACKS,
   NEUTRAL_FALLBACK,
   _resetCache,
+  _resetBucketsCache,
 } = require('../../../apps/backend/services/coop/ermesExporter');
 
 function reset() {
@@ -174,5 +176,132 @@ test('BIOME_ROLE_DEMANDS: all role counts are positive integers', () => {
       assert.ok(Number.isInteger(count), `${biome}.${role} not integer: ${count}`);
       assert.ok(count > 0, `${biome}.${role} not positive: ${count}`);
     }
+  }
+});
+
+// ===========================================================================
+// ADR-2026-05-29 TKT-BR-04 -- schema_version gate + getErmesBucketed banding.
+// (gap-fill: pre-existing file covered getErmesForBiome/computeRoleGap only.)
+// ===========================================================================
+
+function bucketsReset() {
+  _resetCache();
+  _resetBucketsCache();
+}
+
+function writeReport(obj) {
+  const tmp = path.join(
+    os.tmpdir(),
+    `ermes_bucket_${Date.now()}_${Math.random().toString(36).slice(2)}.json`,
+  );
+  fs.writeFileSync(tmp, JSON.stringify(obj));
+  return tmp;
+}
+
+test('schema gate: v1.0.0 report loads (runtime overrides static)', () => {
+  bucketsReset();
+  const tmp = writeReport({
+    schema_version: '1.0.0',
+    biomes: { savana: { eco_pressure_score: 0.21, bias: {} } },
+  });
+  try {
+    const e = getErmesForBiome('savana', { reportPath: tmp });
+    assert.equal(e.eco_pressure_score, 0.21);
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});
+
+test('schema gate: mismatched version -> falls back to static + warn', () => {
+  bucketsReset();
+  const tmp = writeReport({
+    schema_version: '9.9.9',
+    biomes: { savana: { eco_pressure_score: 0.21 } },
+  });
+  const origWarn = console.warn;
+  let warned = '';
+  console.warn = (...a) => {
+    warned += a.join(' ');
+  };
+  try {
+    const e = getErmesForBiome('savana', { reportPath: tmp });
+    assert.equal(e.eco_pressure_score, 0.62, 'savana static fallback on schema mismatch');
+    assert.match(warned, /schema_version mismatch/);
+  } finally {
+    console.warn = origWarn;
+    fs.unlinkSync(tmp);
+  }
+});
+
+test('schema gate: null/undefined schema_version accepted (legacy fixtures)', () => {
+  bucketsReset();
+  const tmp = writeReport({ biomes: { savana: { eco_pressure_score: 0.77 } } });
+  try {
+    const e = getErmesForBiome('savana', { reportPath: tmp });
+    assert.equal(e.eco_pressure_score, 0.77);
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});
+
+test('getErmesBucketed: eco_pressure bands low/med/high (default thresholds)', () => {
+  const cases = [
+    [0.2, 'low'],
+    [0.5, 'med'],
+    [0.8, 'high'],
+  ];
+  for (const [score, expectedBand] of cases) {
+    bucketsReset();
+    const tmp = writeReport({
+      schema_version: '1.0.0',
+      biomes: { savana: { eco_pressure_score: score, bias: {} } },
+    });
+    try {
+      const out = getErmesBucketed('savana', { reportPath: tmp });
+      assert.ok(out.buckets.eco_pressure_score, `score ${score} should band`);
+      assert.equal(
+        out.buckets.eco_pressure_score.band,
+        expectedBand,
+        `score ${score} -> ${expectedBand}`,
+      );
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  }
+});
+
+test('getErmesBucketed: surfaces caps + guards from thresholds yaml', () => {
+  bucketsReset();
+  const tmp = writeReport({
+    schema_version: '1.0.0',
+    biomes: { savana: { eco_pressure_score: 0.5, bias: {} } },
+  });
+  try {
+    const out = getErmesBucketed('savana', { reportPath: tmp });
+    assert.equal(out.caps.max_delta_any_stat, 2);
+    assert.equal(out.caps.max_buckets_active_per_unit, 3);
+    assert.equal(out.guards.bucket_miss_fallback, 'low');
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});
+
+test('getErmesBucketed: missing buckets yaml -> empty buckets, null caps/guards', () => {
+  bucketsReset();
+  const tmp = writeReport({
+    schema_version: '1.0.0',
+    biomes: { savana: { eco_pressure_score: 0.5, bias: {} } },
+  });
+  try {
+    const out = getErmesBucketed('savana', {
+      reportPath: tmp,
+      bucketsPath: path.join(os.tmpdir(), 'no_such_buckets_xyz.yaml'),
+    });
+    assert.deepEqual(out.buckets, {});
+    assert.equal(out.caps, null);
+    assert.equal(out.guards, null);
+    assert.equal(out.eco_pressure_score, 0.5);
+  } finally {
+    fs.unlinkSync(tmp);
   }
 });

--- a/tests/services/coop/ermesExporter.test.js
+++ b/tests/services/coop/ermesExporter.test.js
@@ -305,3 +305,37 @@ test('getErmesBucketed: missing buckets yaml -> empty buckets, null caps/guards'
     fs.unlinkSync(tmp);
   }
 });
+
+// ===========================================================================
+// ADR-2026-05-29 TKT-BR-11 -- cross-repo parity guard vs Godot v2.
+// ===========================================================================
+
+test('BIOME_ROLE_DEMANDS: exact parity snapshot vs Godot ermes_role_gap.gd (TKT-BR-11)', () => {
+  // Cross-repo parity contract. This snapshot mirrors, verbatim, the canonical
+  // source Game-Godot-v2/scripts/session/ermes_role_gap.gd BIOME_ROLE_DEMANDS.
+  // The JS computeRoleGap is a port of that .gd compute. A unilateral edit on
+  // either side (add/remove a biome, change a demand count) without mirroring
+  // the other fails this assertion -> forces the mirror (the .gd header rule
+  // "any edit here MUST land in Godot side too"). The prior >=13 + 5-spot-check
+  // test did not catch drift in biomes 6-13.
+  const GODOT_SNAPSHOT = {
+    savana: { esploratore: 1, guerriero: 1 },
+    caverna: { esploratore: 1, custode: 1 },
+    atollo_obsidiana: { tessitore: 1, esploratore: 1 },
+    foresta_temperata: { tessitore: 1, custode: 1 },
+    badlands: { guerriero: 1, esploratore: 1 },
+    foresta_miceliale: { tessitore: 2 },
+    abisso_vulcanico: { guerriero: 1, esploratore: 1 },
+    reef_luminescente: { esploratore: 1, tessitore: 1 },
+    caldera_glaciale: { custode: 1, guerriero: 1 },
+    pianura_salina_iperarida: { esploratore: 2 },
+    mezzanotte_orbitale: { tessitore: 1, esploratore: 1 },
+    frattura_abissale_sinaptica: { tessitore: 1, custode: 1 },
+    foresta_acida: { custode: 1, tessitore: 1 },
+  };
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(BIOME_ROLE_DEMANDS)),
+    GODOT_SNAPSHOT,
+    'JS BIOME_ROLE_DEMANDS drifted from Godot ermes_role_gap.gd -- mirror both sides',
+  );
+});

--- a/tests/services/ermes/ermesRunner.test.js
+++ b/tests/services/ermes/ermesRunner.test.js
@@ -1,0 +1,110 @@
+// ADR-2026-05-29 TKT-BR-03 -- ermesRunner reverse-index + idempotent queue.
+//
+// Locks the invariants of createErmesRunner (route shipped #2428 senza test):
+//   1. reverse-index trait -> [pool_id] built at boot from biome_pools
+//      (core + support + role_templates.preferred_traits).
+//   2. enqueueRerun set-based dedup (same trait twice -> queue size 1).
+//   3. runQueuedRerun ('/skip' lab) returns affected_pools (deduped) + clears
+//      queue; empty queue -> skipped; listeners fire on completion.
+//   4. missing biome_pools file -> empty index, no throw (soft-fail boot).
+//
+// Test runner: node:test. labScriptPath '/skip' bypasses python spawn.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createErmesRunner } = require('../../../apps/backend/services/ermes/ermesRunner');
+
+// t_shared in both pools; t_a only savana; t_b only caverna (support);
+// t_rt only caverna (via role_templates.preferred_traits).
+const POOLS_FIXTURE = {
+  pools: [
+    { id: 'pool_savana', traits: { core: ['t_shared', 't_a'], support: [] }, role_templates: [] },
+    {
+      id: 'pool_caverna',
+      traits: { core: ['t_shared'], support: ['t_b'] },
+      role_templates: [{ preferred_traits: ['t_rt'] }],
+    },
+  ],
+};
+
+function makeRunner(extraOpts = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ermes-runner-'));
+  const p = path.join(dir, 'biome_pools.json');
+  fs.writeFileSync(p, JSON.stringify(POOLS_FIXTURE));
+  // Reverse-index built at construction, so the fixture file can go after.
+  const runner = createErmesRunner({ biomePoolsPath: p, labScriptPath: '/skip', ...extraOpts });
+  fs.rmSync(dir, { recursive: true, force: true });
+  return runner;
+}
+
+test('reverse-index maps trait -> pools (core + support + role_templates)', () => {
+  const r = makeRunner();
+  assert.deepEqual(r.poolsForTrait('t_shared').sort(), ['pool_caverna', 'pool_savana']);
+  assert.deepEqual(r.poolsForTrait('t_a'), ['pool_savana']);
+  assert.deepEqual(r.poolsForTrait('t_b'), ['pool_caverna']);
+  assert.deepEqual(r.poolsForTrait('t_rt'), ['pool_caverna']);
+  assert.deepEqual(r.poolsForTrait('unknown_trait'), []);
+});
+
+test('getTraitToPoolsMap returns a populated Map', () => {
+  const r = makeRunner();
+  const map = r.getTraitToPoolsMap();
+  assert.ok(map instanceof Map);
+  assert.ok(map.has('t_shared'));
+});
+
+test('enqueueRerun: valid id true, missing id false, set-based dedup', () => {
+  const r = makeRunner();
+  assert.equal(r.pendingQueueSize(), 0);
+  assert.equal(r.enqueueRerun({ traitId: 't_shared' }), true);
+  assert.equal(r.enqueueRerun({ traitId: 't_shared' }), true);
+  assert.equal(r.pendingQueueSize(), 1, 'dedup: same trait enqueued twice = size 1');
+  assert.equal(r.enqueueRerun({}), false);
+  assert.equal(r.enqueueRerun(), false);
+  assert.equal(r.pendingQueueSize(), 1);
+});
+
+test('runQueuedRerun (/skip) returns deduped affected_pools + clears queue', async () => {
+  const r = makeRunner();
+  r.enqueueRerun({ traitId: 't_shared' }); // -> both pools
+  r.enqueueRerun({ traitId: 't_a' }); // -> savana (already counted)
+  const res = await r.runQueuedRerun();
+  assert.equal(res.skipped_lab, true);
+  assert.deepEqual(res.trait_ids.sort(), ['t_a', 't_shared']);
+  assert.deepEqual(res.affected_pools.sort(), ['pool_caverna', 'pool_savana']);
+  assert.equal(r.pendingQueueSize(), 0, 'queue cleared after run');
+  assert.equal(r.isRunning(), false);
+});
+
+test('runQueuedRerun on empty queue -> skipped empty_queue', async () => {
+  const r = makeRunner();
+  const res = await r.runQueuedRerun();
+  assert.deepEqual(res, { skipped: true, reason: 'empty_queue' });
+});
+
+test('onRerunComplete listener fires with result', async () => {
+  const r = makeRunner();
+  let received = null;
+  r.onRerunComplete((result) => {
+    received = result;
+  });
+  r.enqueueRerun({ traitId: 't_b' });
+  await r.runQueuedRerun();
+  assert.ok(received, 'listener invoked');
+  assert.deepEqual(received.affected_pools, ['pool_caverna']);
+});
+
+test('missing biome_pools file -> empty index, no throw', () => {
+  const r = createErmesRunner({
+    biomePoolsPath: path.join(os.tmpdir(), 'no_such_biome_pools_xyz.json'),
+    labScriptPath: '/skip',
+  });
+  assert.deepEqual(r.poolsForTrait('t_shared'), []);
+  assert.equal(r.getTraitToPoolsMap().size, 0);
+});


### PR DESCRIPTION
## Summary

Follow-up to the merged FASE 2 ERMES plumbing (#2428, `c0fc6d5d`). Closes the 5 remaining FASE 2 tickets + 3 test-gap follow-ups from the 2026-05-29 handoff. **No new runtime behavior** -- tests, config tuning, a frontend view, a parity guard, and docs on top of the already-merged bridge.

ADR: `ADR-2026-05-29-ermes-runtime-bridge` (vault). sot-drift-verifier FINAL verdict: **NO_DRIFT, high confidence** (epigenome regression gate holds + SoT makes no over-claim).

## Tickets

- **BR-03** `test(ermes)`: ermesRunner reverse-index + idempotent-queue coverage (runner shipped #2428 without a test).
- **BR-04** `test(coop)`: extend ermesExporter test with the new `getErmesBucketed` banding + `schema_version` gate (pre-existing file covered only the old getErmesForBiome/computeRoleGap).
- **BR-08** `test(traits)`: GET /api/traits/suggestions ETag contract (empty/latest/304/role-gate) + a behaviour-preserving `suggestionsDir` test seam.
- **CI wiring** `test(ermes)`: `tests/services/**` + `tests/ai/**` were **not** covered by `run-test-api.cjs` globs -- the ermes bridge tests (BR-03/04/06/10) passed manually but were **CI-orphaned** (a rewrite dropping behaviour would stay green, anti-pattern #10). Wired the ermes-scoped paths in -- 56 ermes tests now run under `test:backend`/`ci:stack`.
- **BR-12** `feat(ermes)`: the bridge was functionally **inert** (all 4 pilot biomes landed in the MED band -> `delta_mod 0`). Tuned `multi_biome.json` so the pilot set spans LOW/MED/HIGH (rovine LOW eco 0.164, cryosteppe HIGH eco 0.876). Bridge now applies -1/0/+1 by band (capped +/-2). Guarded by a python band-spread test (all-MED revert = CI red). **Combat win-rate N=40 calibration is DEFERRED to FASE 3** with reason: `applyErmesBiomeTraitCosts` has no combat-loop caller (plumbing-only), so `calibrate_drift_verify.py` would measure a dead bridge (0pp). See `docs/playtest/2026-05-29-br12-ermes-band-tuning.md`.
- **BR-09** `feat(trait-editor)`: Vue `TraitSuggestionsView` (accept/reject UX, local decision tracking, empty/loading/error) consuming GET /api/traits/suggestions via `TraitDataService.getSuggestions` (reuses fetchWithAuth). Router `/suggestions` + nav link.
- **BR-11** `test(coop)`: cross-repo parity confirmed -- `Game-Godot-v2 scripts/session/ermes_role_gap.gd` (canonical, GUT-tested) already has all 13 biome demands + compute logic identical to the JS port (no Godot change needed; handoff marker stale, anti-#19). Added a JS-side exact 13-biome snapshot guard (prior >=13 + 5-spot test missed biomes 6-13).
- **BR-14** `docs(pillars)`: honest FASE 2 note in PILLARS_STATUS -- P2/P6 stay yellow (plumbing + demonstrable shipped, but not player-perceivable until combat wiring = FASE 3). No false green.

## Regression gate (TKT-BR-06)

`applyErmesBiomeTraitCosts` writes only `attack_mod_bonus`/`defense_mod_bonus`/`mobility`/`rest_recovery`, **never** `creature_epigenome.bias` (R6 gate test, now CI-wired). Confirmed by code + the sot-drift-verifier FINAL pass.

## Test plan

- [x] BR-03 ermesRunner test 7/7
- [x] BR-04 ermesExporter test 25/25 (incl. banding + schema gate + BR-11 snapshot)
- [x] BR-08 suggestions contract 5/5
- [x] ermes tests wired + green via `node --test` globs (56 total)
- [x] BR-12 python sim 5/5 (incl. band-spread guard) + bridge demonstration (-1/0/+1)
- [x] BR-09 trait-editor `npm run test` 26/26 + `npm run build` green
- [x] backend `tests/api/*.test.js` 1365 pass / 0 fail / 1 skip (expected TKT-CL-08)
- [x] prettier-clean on changed files (lint:stack scope)
- [x] sot-drift-verifier FINAL: NO_DRIFT high confidence
- [ ] CI: stack-quality + qa-baselines + ci-gate + trait-editor (validated on push)

## Notes / follow-ups (out of scope here)

- **Advisory (sot-drift, Eduardo discretion)**: the vault ADR "Per il giocatore" section is present-tense and could be misread as current behaviour; a "FASE 3 not-yet-wired" banner would harden it (not applied -- SoT sovereignty).
- **Broader CI-orphaning**: `tests/services/**` + `tests/ai/**` beyond ermes are still unwired from `run-test-api.cjs` -- separate follow-up (needs verifying all pass before a blanket glob).
- **Vault trackers + KNOWLEDGE_MAP**: vault PILLARS/roadmap + the codemasterdd/Lenovo KNOWLEDGE_MAP updates handled separately (sovereign / cross-PC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)