### PR TITLE
test(ci): wire tests/services/** + tests/ai/** into run-test-api.cjs

### DIFF
--- a/scripts/run-test-api.cjs
+++ b/scripts/run-test-api.cjs
@@ -24,13 +24,20 @@ const steps = [
   'node --test tests/scripts/crossPlatformRunners.test.js',
   'node --test tests/i18n/parity.test.js',
   'node --test tests/play/*.test.js',
-  // ERMES runtime bridge (ADR-2026-05-29 FASE 2). tests/services + tests/ai
-  // were not covered by the globs above -> CI-orphaned. Wire the ermes surface
-  // so a rewrite dropping behavior fails CI (guards anti-pattern #10
-  // non-CI-guarded drop). Scoped to ermes files, not the whole subtree.
-  'node --test tests/services/ermes/*.test.js',
-  'node --test tests/services/coop/ermesExporter*.test.js',
-  'node --test tests/ai/applyErmesBiomeTraitCosts.test.js',
+  // tests/services/** + tests/ai/** were not covered by the globs above ->
+  // CI-orphaned: they pass when run manually but never ran in CI, so a refactor
+  // could silently drop behavior while CI stays green (anti-pattern #10
+  // non-CI-guarded drop). All 140 files (1738 tests) verified passing in
+  // parallel 2026-05-29; these broad subtree globs supersede the prior
+  // ermes-scoped wiring (PR #2432).
+  //
+  // Globs are DOUBLE-QUOTED on purpose: spawnSync runs with shell:true, so a
+  // bare tests/services/**/*.test.js would be expanded by the shell, not node.
+  // POSIX sh (Linux CI) has no globstar -> collapses ** to a single level and
+  // silently drops the 71 top-level files (1276 -> 249 tests). Quoting forces
+  // node's own recursive glob, identical on cmd.exe (Windows) and sh (Linux).
+  'node --test "tests/services/**/*.test.js"',
+  'node --test "tests/ai/**/*.test.js"',
 ];
 
 const env = {


### PR DESCRIPTION
## Summary

`scripts/run-test-api.cjs` (the CI gate: `npm run test:api` -> `test:backend` -> `ci:stack`) only globbed `tests/api`, `tests/generation`, `tests/server`, `tests/scripts`, `tests/events`, `tests/tools`, `tests/i18n`, `tests/play`. The whole `tests/services/**` and `tests/ai/**` subtrees were **CI-orphaned**: they pass when run manually but never ran in CI, so a future refactor could drop behavior and CI would stay green (**anti-pattern #10**, non-CI-guarded drop).

This is the broader sibling of the ermes-scoped wiring merged in #2432. The 3 narrow ermes-only lines are **superseded** by two subtree globs (the ermes files are a subset).

## What changed

- `scripts/run-test-api.cjs`: replace the 3 ermes-scoped steps with
  - `node --test "tests/services/**/*.test.js"`
  - `node --test "tests/ai/**/*.test.js"`

## Evidence (all verified locally, 2026-05-29)

- **140 files** total (108 `tests/services/**` + 32 `tests/ai/**`); 135 were orphaned (5 ermes already wired).
- Ran every orphaned file individually: **135/135 PASS**, 0 fail, 0 timeout.
- Ran each subtree as a single parallel `node --test` invocation (how CI runs it): **services 1276 tests / ai 462 tests = 1738, all green**. The `wsSession-*` network tests use ephemeral ports -> no parallel collision (anti-pattern #16 clear).
- Full `run-test-api.cjs` re-run end-to-end: **exit 0**, both new steps green.

## Failing / flaky held back

**None.** Every file in both subtrees passes (sequentially and in parallel), so the whole subtree is wired. Nothing needed to be excluded.

## Cross-platform note (why the globs are double-quoted)

The runner uses `spawnSync(..., { shell: true })`. A bare `tests/services/**/*.test.js` is expanded by the **shell**, not node. POSIX `sh` (Linux CI) has no `globstar` -> collapses `**` to a single level and **silently drops the 71 top-level files** (1276 -> 249 tests). Double-quoting forces node's own recursive glob, which is identical on `cmd.exe` (Windows) and `sh` (Linux). Verified both: `sh -c '... "tests/services/**/*.test.js"'` = 1276, unquoted = 249.

## Scope / safety

- Only `scripts/run-test-api.cjs` touched. Not in any forbidden path; no new deps; no runtime/schema change.

## Test plan

- [x] Each orphaned file passes individually (135/135)
- [x] Each subtree passes as one parallel invocation (services 1276, ai 462)
- [x] Full `node scripts/run-test-api.cjs` exits 0 with both new steps green
- [x] Glob expansion verified on `sh` (Linux CI path) and `cmd` (Windows) -> 108/32

Coding-Agent: claude-opus-4.7
Trace-Id: 019e7291-866f-7925-9074-7a2df6ca9656