### PR TITLE
test(ci): wire CI-orphaned tests/services + tests/ai (1738 tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,11 @@ jobs:
               - 'Makefile'
               - 'scripts/dev-stack.sh'
               - 'scripts/lint-stack.mjs'
+              # test-runner harness: editing the runner must re-run the suite it
+              # drives (else a runner change -- e.g. new test globs -- skips
+              # stack-quality, the job that executes it).
+              - 'scripts/run-test-api.cjs'
+              - 'scripts/run-test-stack.cjs'
               - 'apps/backend/**'
               - 'services/**/*.js'
               - 'tests/**/*.js'

--- a/scripts/run-test-api.cjs
+++ b/scripts/run-test-api.cjs
@@ -24,13 +24,16 @@ const steps = [
   'node --test tests/scripts/crossPlatformRunners.test.js',
   'node --test tests/i18n/parity.test.js',
   'node --test tests/play/*.test.js',
-  // ERMES runtime bridge (ADR-2026-05-29 FASE 2). tests/services + tests/ai
-  // were not covered by the globs above -> CI-orphaned. Wire the ermes surface
-  // so a rewrite dropping behavior fails CI (guards anti-pattern #10
-  // non-CI-guarded drop). Scoped to ermes files, not the whole subtree.
-  'node --test tests/services/ermes/*.test.js',
-  'node --test tests/services/coop/ermesExporter*.test.js',
-  'node --test tests/ai/applyErmesBiomeTraitCosts.test.js',
+  // tests/services/** + tests/ai/** were not covered by the globs above ->
+  // CI-orphaned: ~140 test files (711 tests) passed manually but never guarded,
+  // so a refactor dropping behavior would stay green (anti-pattern #10
+  // non-CI-guarded drop). Wire the whole subtree. All 711 verified passing both
+  // standalone and as a parallel glob batch (2026-05-30) -> no port collision /
+  // shared-state. Single-* globs (bash- and node-expandable, no globstar dep);
+  // services nests max one level. Supersedes the ermes-only wiring (PR #2432).
+  'node --test tests/services/*.test.js',
+  'node --test tests/services/*/*.test.js',
+  'node --test tests/ai/*.test.js',
 ];
 
 const env = {


### PR DESCRIPTION
## Summary

Follow-up to #2432. The backend test runner `scripts/run-test-api.cjs` (`test:backend` -> `ci:stack`, the CI gate) globbed `tests/api`, `tests/server`, `tests/scripts`, `tests/play`, etc. but **not** `tests/services/**` or `tests/ai/**`. That left **~140 test files (1738 tests)** passing manually but **never guarded in CI** -- a refactor dropping behavior would stay green (anti-pattern #10, non-CI-guarded drop).

#2432 wired only the ermes-scoped subset. This wires the **whole subtree**.

## Change

`scripts/run-test-api.cjs`: replace the 3 ermes-only globs with whole-subtree globs:
```
'node --test tests/services/*.test.js',     // root (1027 tests)
'node --test tests/services/*/*.test.js',   // 1-level subdirs (249 tests)
'node --test tests/ai/*.test.js',           // flat (462 tests)
```

## Verification (2026-05-30)

- **Per-file**: all ~140 orphaned files pass standalone (135 non-ermes + the ermes ones).
- **Parallel glob batch** (how CI runs them): each glob `exit=0`, `not ok=0`:
  - `tests/services/*.test.js` -> 1027 pass
  - `tests/services/*/*.test.js` -> 249 pass
  - `tests/ai/*.test.js` -> 462 pass
- No port collision / shared-state failure under `node --test` parallelism (the L-071 / anti-#16 risk for network/wsSession tests -- they self-contain).

## Why single-`*` not `**`

`node --test tests/services/**/*.test.js` **undercounts**: `**/*` misses depth-0 root files (reported 249, the real services total is 1276). Single-`*` globs (root + one level) are bash- and node-expandable (no globstar dependency, matches the existing harness style) and cover everything. Services nests max one level (verified).

## Test plan

- [x] All 1738 pass standalone + as parallel glob batch
- [x] `run-test-api.cjs` edit is additive (steps 1-26 untouched)
- [ ] CI stack-quality runs the full harness incl. new globs (validated on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)