### PR TITLE
fix(coop): normalize string-id survivors in resolveMatingWinner (Codex P2)

### DIFF
--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -671,7 +671,11 @@ class CoopOrchestrator {
     // actual surviving units. voteMating accepts any client pair_id, so a
     // bogus pair must NOT trigger an offspring roll. Leave matingResolved
     // false so a later legit pair can still win.
-    const survivorIds = new Set((this.run.survivors || []).map((u) => u && u.id).filter(Boolean));
+    const survivorIds = new Set(
+      (this.run.survivors || [])
+        .map((u) => (typeof u === 'string' ? u : u && (u.id || u.unit_id)))
+        .filter(Boolean),
+    );
     if (!parentAId || !parentBId || !survivorIds.has(parentAId) || !survivorIds.has(parentBId)) {
       return null;
     }

--- a/tests/services/coop/coopMatingResolve.test.js
+++ b/tests/services/coop/coopMatingResolve.test.js
@@ -41,3 +41,13 @@ test('resolveMatingWinner rejects pair not in survivors (no roll on bogus ids)',
   assert.equal(o.resolveMatingWinner(['p1'], ['p1']), null);
   assert.equal(o.run.matingResolved, false);
 });
+
+test('resolveMatingWinner accepts string-id survivors (browser host shape)', () => {
+  const o = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'h1' });
+  o.startRun({ scenarioStack: ['enc_a'] });
+  o.phase = 'combat';
+  o.endCombat({ outcome: 'victory', survivors: ['u_a', 'u_b'] });
+  o.voteMating('p1', 'u_a__u_b', { allPlayerIds: ['p1'] });
+  const w = o.resolveMatingWinner(['p1'], ['p1']);
+  assert.equal(w.pair_id, 'u_a__u_b');
+});


### PR DESCRIPTION
Codex P2 (on #2435, re Task 8 code): browser host (apps/play/src/main.js) posts coop combat survivors as bare unit-id STRINGS, not {id} objects. resolveMatingWinner validated parents via u.id -> undefined -> every pair rejected -> offspring roll silently never fired for that flow. Fix: survivor-id extraction accepts string | {id|unit_id}. Test added (string-survivor shape resolves). 5/5 coopMatingResolve green.