### PR TITLE
ermes FASE 3 P1: wire bridge into live combat (unified +/-2 cap)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -123,7 +123,9 @@ const {
 // Applica penalty/bonus biome-specific a unit basato su trait set × biome_id.
 // Pilot 4×3: thermal_armor, zampe_a_molla, pelle_elastomera, denti_seghettati
 // × savana, caverna_risonante, rovine_planari.
-const { loadTraitEnvironmentalCosts, applyBiomeTraitCosts } = require('../services/traitEffects');
+// ADR-2026-05-29 FASE 3: applyBiomeEcoEffects replaces inline ADR-21c block.
+// Runs ADR-21c + ERMES + unified +/-2 cap. applyBiomeTraitCosts no longer used directly.
+const { loadTraitEnvironmentalCosts, applyBiomeEcoEffects } = require('../services/traitEffects');
 // QW1 (M-018 worldgen card): biome diff_base + stress_modifiers → runtime
 // pressure / enemy HP. Same encounter on savana vs abisso_vulcanico now
 // produces different numbers, not just different texture.
@@ -1401,28 +1403,26 @@ function createSessionRouter(options = {}) {
         // best-effort: se config non carica, skip profile scaling
       }
 
-      // M11 pilot (ADR-2026-04-21c, issue #1674): apply biome environmental
-      // trait costs. Legge biome_id da req.body (top-level) con fallback
-      // req.body.encounter?.biome_id. Pilot scope 4 trait × 3 biomi = 12 cell.
-      // Session-scoped compute (no Prisma persistence).
+      // M11 pilot (ADR-2026-04-21c, issue #1674) + ADR-2026-05-29 FASE 3:
+      // apply biome environmental eco effects (ADR-21c + ERMES + +/-2 unified cap).
+      // Legge biome_id da req.body (top-level) con fallback req.body.encounter?.biome_id.
+      // Session-scoped compute (no Prisma persistence). Log surfaced in response.
       const biomeIdRaw = req.body?.biome_id || req.body?.encounter?.biome_id || null;
       let biomeCostsLog = [];
       if (biomeIdRaw) {
         try {
           const biomeCostsRegistry = loadTraitEnvironmentalCosts();
-          if (biomeCostsRegistry && biomeCostsRegistry.trait_costs) {
-            units = units.map((u) => {
-              if (!u) return u;
-              const clone = { ...u };
-              const applied = applyBiomeTraitCosts(clone, biomeIdRaw, biomeCostsRegistry);
-              if (applied && applied.length) {
-                biomeCostsLog.push({ unit_id: clone.id, applied });
-              }
-              return clone;
-            });
-          }
+          units = units.map((u) => {
+            if (!u) return u;
+            const clone = { ...u };
+            const log = applyBiomeEcoEffects(clone, biomeIdRaw, { biomeCostsRegistry });
+            if (log && (log.adr21c.length || log.ermes.length)) {
+              biomeCostsLog.push({ unit_id: clone.id, ...log });
+            }
+            return clone;
+          });
         } catch (err) {
-          console.warn('[trait-env-costs] apply failed:', err.message);
+          console.warn('[biome-eco-effects] apply failed:', err.message);
         }
       }
 
@@ -1755,6 +1755,9 @@ function createSessionRouter(options = {}) {
         // Array per-unit con mutation_ids ereditati da pool propagato.
         // Empty se nessuna lineage propagation precedente o no match.
         lineage_inherited: lineageInherited,
+        // ADR-2026-05-29 FASE 3: biome eco effects log per-unit (ADR-21c + ERMES + cap).
+        // Each entry: { unit_id, adr21c, ermes, combined_delta, capped, biome_id, band }.
+        biomeCostsLog,
       });
     } catch (err) {
       next(err);

--- a/apps/backend/services/coop/ermesExporter.js
+++ b/apps/backend/services/coop/ermesExporter.js
@@ -65,6 +65,20 @@ const STATIC_FALLBACKS = Object.freeze({
       ruin_collapse: 0.5,
     },
   },
+  rovine_planari: {
+    eco_pressure_score: 0.16,
+    bias: {
+      ruin_collapse: 0.4,
+      magnetic_pull: 0.35,
+    },
+  },
+  cryosteppe_convergence: {
+    eco_pressure_score: 0.87,
+    bias: {
+      cold_shock: 0.7,
+      whiteout_disorient: 0.55,
+    },
+  },
 });
 
 const NEUTRAL_FALLBACK = Object.freeze({

--- a/apps/backend/services/traitEffects.js
+++ b/apps/backend/services/traitEffects.js
@@ -752,6 +752,71 @@ function _resetErmesCostMarker(unit) {
   delete unit._ermes_biome_costs_log;
 }
 
+// ADR-2026-05-29 FASE 3 (section 3): unified biome-eco orchestrator.
+// Runs ADR-21c applyBiomeTraitCosts + ERMES applyErmesBiomeTraitCosts, then clamps
+// the COMBINED biome-origin delta per stat to +/-2 (mirror ADR-21c strict range).
+// Snapshot/diff so non-biome bonuses already on the field are preserved. Idempotent
+// via the sub-functions' own markers. NEVER writes creature_epigenome (R6 gate).
+const BIOME_ECO_FIELDS = ['attack_mod_bonus', 'defense_mod_bonus', 'mobility', 'rest_recovery'];
+const BIOME_ECO_COMBINED_CAP = 2;
+
+function applyBiomeEcoEffects(unit, biomeId, opts = {}) {
+  const emptyLog = {
+    adr21c: [],
+    ermes: [],
+    combined_delta: {},
+    capped: false,
+    biome_id: biomeId || null,
+    band: null,
+  };
+  if (!unit || !biomeId) return emptyLog;
+
+  const base = {};
+  for (const f of BIOME_ECO_FIELDS) base[f] = Number(unit[f] || 0);
+
+  let adr21c = [];
+  if (opts.biomeCostsRegistry && opts.biomeCostsRegistry.trait_costs) {
+    try {
+      adr21c = applyBiomeTraitCosts(unit, biomeId, opts.biomeCostsRegistry) || [];
+    } catch (_) {
+      adr21c = [];
+    }
+  }
+
+  let ermes = [];
+  try {
+    ermes =
+      applyErmesBiomeTraitCosts(unit, biomeId, {
+        ermesExporter: opts.ermesExporter,
+        bucketed: opts.bucketed,
+      }) || [];
+  } catch (_) {
+    ermes = [];
+  }
+
+  const combined_delta = {};
+  let capped = false;
+  for (const f of BIOME_ECO_FIELDS) {
+    const raw = Number(unit[f] || 0) - base[f];
+    const clamped = Math.max(-BIOME_ECO_COMBINED_CAP, Math.min(BIOME_ECO_COMBINED_CAP, raw));
+    if (clamped !== raw) capped = true;
+    unit[f] = base[f] + clamped;
+    if (clamped !== 0) combined_delta[f] = clamped;
+  }
+
+  const ecoItem = Array.isArray(ermes)
+    ? ermes.find((a) => a && a.bucket === 'eco_pressure_score')
+    : null;
+  return {
+    adr21c,
+    ermes,
+    combined_delta,
+    capped,
+    biome_id: biomeId,
+    band: ecoItem ? ecoItem.band : null,
+  };
+}
+
 /**
  * Evaluate movement-triggered buff_stat traits for a unit.
  *
@@ -801,6 +866,9 @@ module.exports = {
   applyBiomeTraitCosts,
   BIOME_COST_DEFAULT_PATH,
   _resetBiomeCostCache,
+  // ADR-2026-05-29 FASE 3: unified biome-eco orchestrator
+  applyBiomeEcoEffects,
+  BIOME_ECO_COMBINED_CAP,
   // ADR-2026-05-29 TKT-BR-06 ERMES bucketed deltas
   applyErmesBiomeTraitCosts,
   _resetErmesCostMarker,

--- a/docs/playtest/2026-05-30-ermes-fase3-p2-calibration.md
+++ b/docs/playtest/2026-05-30-ermes-fase3-p2-calibration.md
@@ -1,0 +1,42 @@
+# FASE 3 P2 -- ERMES combat-wiring calibration (N=40 balance gate)
+
+Date: 2026-05-30
+Spec: vault `Spaces/Dev/Evo-Tactics/plans/2026-05-30-ermes-fase3-combat-wiring-design.md` section 8
+Branch: chore/2026-05-30-ermes-fase3-p1 (PR #2437)
+
+## Gate
+
+ADR-2026-05-29 section 9: ERMES live combat wiring must not shift win-rate > 5pp (N=40 ratify).
+
+## Method
+
+hardcore_06 scenario, `tools/py/batch_calibrate_hardcore06.py` (`--biome-id` seam added in P2).
+
+- baseline: no biome_id (ERMES no-op).
+- cryosteppe_convergence: HIGH band (eco ~0.87 static fallback) -> symmetric +1 atk / +1 def
+  on both unit pools, combined cap +/-2 (applyBiomeEcoEffects).
+- N=40 per L-069 / L-073 (N=10 = direction only, not ratify).
+
+## Result
+
+| condition       | WR        | wins/N          |
+| --------------- | --------- | --------------- |
+| baseline        | 15.0%     | 6/40            |
+| cryosteppe HIGH | 15.0%     | 6/40            |
+| **delta**       | **0.0pp** | **PASS (<5pp)** |
+
+Wilson CI95 ~[7%, 29%] each; delta point 0pp clearly within the 5pp gate.
+
+## Findings
+
+- Symmetric +/-2 combined delta = **WR-neutral** (0pp). The design's symmetric-neutral
+  assumption is ratified at N=40.
+- The earlier N=10 probe showed cryosteppe -10pp -> **pure noise** (L-069): the baseline
+  alone swung 30% at N=10 to 15% at N=40. Confirms N=10 = direction-only, N=40 = ratify.
+- Caveat: rovine LOW (-1/-1, symmetric mirror) not separately N=40'd; low risk (same
+  magnitude opposite sign, symmetric mechanism proven neutral on the HIGH band).
+
+## Verdict
+
+P2 gate **PASS**. P1 (PR #2437) is balance-safe to merge. Telegraph (P4) + Godot parity (P5)
+unblocked. Combat-WR re-check recommended only if `ermes_bucket_thresholds.yaml` deltas change.

--- a/tests/api/sessionBiomeEcoEffects.test.js
+++ b/tests/api/sessionBiomeEcoEffects.test.js
@@ -1,0 +1,62 @@
+'use strict';
+// ERMES FASE 3 P1 — wire test: applyBiomeEcoEffects surfaces in /api/session/start response.
+// ADR-2026-05-29: biomeCostsLog now carries { unit_id, adr21c, ermes, combined_delta, capped, biome_id, band }
+// per-unit log. Tests: HIGH band present for cryosteppe_convergence; no log when biome_id absent.
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+async function getTutorialUnits(app) {
+  const res = await request(app).get('/api/tutorial/enc_tutorial_01');
+  assert.equal(res.status, 200, `tutorial load failed: ${res.status}`);
+  return res.body.units;
+}
+
+test('session/start surfaces ERMES band in biomeCostsLog (cryosteppe HIGH)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const units = await getTutorialUnits(app);
+
+  const res = await request(app)
+    .post('/api/session/start')
+    .send({
+      units,
+      biome_id: 'cryosteppe_convergence',
+    })
+    .expect(200);
+
+  assert.ok(
+    Array.isArray(res.body.biomeCostsLog),
+    `biomeCostsLog must be an array in response, got: ${JSON.stringify(res.body.biomeCostsLog)}`,
+  );
+
+  const high = res.body.biomeCostsLog.find((e) => e.band === 'high');
+  assert.ok(
+    high,
+    `expected at least one log entry with band=high for cryosteppe_convergence; log=${JSON.stringify(res.body.biomeCostsLog)}`,
+  );
+});
+
+test('session/start without biome_id -> no biome eco log', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const units = await getTutorialUnits(app);
+
+  const res = await request(app).post('/api/session/start').send({ units }).expect(200);
+
+  const log = res.body.biomeCostsLog;
+  assert.ok(
+    !log || (Array.isArray(log) && log.length === 0),
+    `expected biomeCostsLog absent or empty when no biome_id; got: ${JSON.stringify(log)}`,
+  );
+});

--- a/tests/services/applyBiomeEcoEffects.test.js
+++ b/tests/services/applyBiomeEcoEffects.test.js
@@ -1,0 +1,67 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  applyBiomeEcoEffects,
+  _resetBiomeCostCache,
+} = require('../../apps/backend/services/traitEffects');
+
+const REG = { trait_costs: { t_neg: { b: { attack_mod: -2 } } } };
+const ERMES_LOW = {
+  buckets: { eco_pressure_score: { band: 'low', def: { delta_mod: -1 } } },
+  caps: { max_delta_any_stat: 2, max_buckets_active_per_unit: 3 },
+};
+const ERMES_HIGH = {
+  buckets: { eco_pressure_score: { band: 'high', def: { delta_mod: 1 } } },
+  caps: { max_delta_any_stat: 2, max_buckets_active_per_unit: 3 },
+};
+function unit(extra = {}) {
+  return { id: 'u1', traits: ['t_neg'], attack_mod_bonus: 0, defense_mod_bonus: 0, ...extra };
+}
+
+test('unified cap: 21c -2 + ermes -1 on attack clamps to -2 (not -3)', () => {
+  _resetBiomeCostCache();
+  const u = unit();
+  const log = applyBiomeEcoEffects(u, 'b', { biomeCostsRegistry: REG, bucketed: ERMES_LOW });
+  assert.equal(u.attack_mod_bonus, -2, 'attack combined clamped to -2');
+  assert.equal(u.defense_mod_bonus, -1, 'defense only ermes -1 (no 21c defense)');
+  assert.equal(log.capped, true);
+  assert.equal(log.combined_delta.attack_mod_bonus, -2);
+  assert.equal(log.band, 'low');
+});
+
+test('base-snapshot non-clobber: pre-existing bonus preserved', () => {
+  _resetBiomeCostCache();
+  const u = unit({ attack_mod_bonus: 5 });
+  applyBiomeEcoEffects(u, 'b', { biomeCostsRegistry: REG, bucketed: ERMES_LOW });
+  assert.equal(u.attack_mod_bonus, 3); // base 5 + clamped -2
+});
+
+test('idempotent: re-apply does not double-charge', () => {
+  _resetBiomeCostCache();
+  const u = unit();
+  applyBiomeEcoEffects(u, 'b', { biomeCostsRegistry: REG, bucketed: ERMES_LOW });
+  const after1 = u.attack_mod_bonus;
+  applyBiomeEcoEffects(u, 'b', { biomeCostsRegistry: REG, bucketed: ERMES_LOW });
+  assert.equal(u.attack_mod_bonus, after1);
+});
+
+test('soft-fail: no unit or no biomeId -> empty log, no throw', () => {
+  assert.deepEqual(applyBiomeEcoEffects(null, 'b', {}).combined_delta, {});
+  assert.deepEqual(applyBiomeEcoEffects(unit(), null, {}).combined_delta, {});
+});
+
+test('symmetric: positive band applies to a plain unit (both pools)', () => {
+  _resetBiomeCostCache();
+  const enemy = { id: 'e1', traits: [], attack_mod_bonus: 0, defense_mod_bonus: 0 };
+  applyBiomeEcoEffects(enemy, 'b', { biomeCostsRegistry: REG, bucketed: ERMES_HIGH });
+  assert.equal(enemy.attack_mod_bonus, 1);
+  assert.equal(enemy.defense_mod_bonus, 1);
+});
+
+test('R6 gate: never writes creature_epigenome.bias', () => {
+  _resetBiomeCostCache();
+  const u = unit();
+  applyBiomeEcoEffects(u, 'b', { biomeCostsRegistry: REG, bucketed: ERMES_LOW });
+  assert.equal(u.creature_epigenome, undefined);
+});

--- a/tests/services/coop/ermesExporter.test.js
+++ b/tests/services/coop/ermesExporter.test.js
@@ -307,6 +307,28 @@ test('getErmesBucketed: missing buckets yaml -> empty buckets, null caps/guards'
 });
 
 // ===========================================================================
+// FASE 3 P1 -- pilot biome static fallback banding (rovine_planari / cryosteppe_convergence).
+// ===========================================================================
+
+test('STATIC_FALLBACKS: rovine_planari pilot present + LOW band', () => {
+  bucketsReset();
+  const e = getErmesForBiome('rovine_planari', { reportPath: '/tmp/no_such_report.json' });
+  assert.ok(e.eco_pressure_score < 0.33, `rovine should be LOW, got ${e.eco_pressure_score}`);
+  const out = getErmesBucketed('rovine_planari', { reportPath: '/tmp/no_such_report.json' });
+  assert.equal(out.buckets.eco_pressure_score.band, 'low');
+});
+
+test('STATIC_FALLBACKS: cryosteppe_convergence pilot present + HIGH band', () => {
+  bucketsReset();
+  const e = getErmesForBiome('cryosteppe_convergence', { reportPath: '/tmp/no_such_report.json' });
+  assert.ok(e.eco_pressure_score >= 0.66, `cryosteppe should be HIGH, got ${e.eco_pressure_score}`);
+  const out = getErmesBucketed('cryosteppe_convergence', {
+    reportPath: '/tmp/no_such_report.json',
+  });
+  assert.equal(out.buckets.eco_pressure_score.band, 'high');
+});
+
+// ===========================================================================
 // ADR-2026-05-29 TKT-BR-11 -- cross-repo parity guard vs Godot v2.
 // ===========================================================================
 

--- a/tools/py/batch_calibrate_hardcore06.py
+++ b/tools/py/batch_calibrate_hardcore06.py
@@ -586,7 +586,7 @@ def _extract_trait_ids(action_result):
     return out
 
 
-def run_one(host, run_idx, turn_limit_defeat=None):
+def run_one(host, run_idx, turn_limit_defeat=None, biome_id=None):
     # Fetch scenario.
     status, sc = get(f"{host}/api/tutorial/{SCENARIO_ID}")
     if status != 200:
@@ -604,6 +604,8 @@ def run_one(host, run_idx, turn_limit_defeat=None):
         # 2026-05-21 (OD-032 C): id enables scenario_overrides resolution at /start
         # (boss_hp + enemy_damage_multiplier_override per session.js scenarioIdForEdm).
         "encounter": {"id": SCENARIO_ID},
+        # ERMES FASE 3 P2: set biome_id to exercise applyBiomeEcoEffects in calibration.
+        **({"biome_id": biome_id} if biome_id else {}),
     })
     if status != 200:
         return {"error": f"session/start failed: {start}"}
@@ -816,6 +818,10 @@ def main():
                     help="M7-#2 Phase D: class key da damage_curves.yaml. "
                          "Default 'hardcore' (coerente con enc_tutorial_06_hardcore). "
                          "Valori: tutorial|tutorial_advanced|standard|hardcore|boss")
+    ap.add_argument("--biome-id", default=None,
+                    help="ERMES FASE 3 P2: set req.body.biome_id to exercise biome eco "
+                         "deltas (applyBiomeEcoEffects) during calibration. e.g. "
+                         "cryosteppe_convergence (HIGH) | rovine_planari (LOW).")
     args = ap.parse_args()
 
     # Health probe (TKT-08): fail fast se backend non risponde.
@@ -844,7 +850,7 @@ def main():
     failures = 0
     try:
         for i in range(args.n):
-            r = run_one(args.host, i, turn_limit_defeat=turn_limit_defeat)
+            r = run_one(args.host, i, turn_limit_defeat=turn_limit_defeat, biome_id=args.biome_id)
             runs.append(r)
             if "error" in r:
                 failures += 1


### PR DESCRIPTION
## Summary

P1 of FASE 3 (spec: vault `plans/2026-05-30-ermes-fase3-combat-wiring-design.md`, Envelope C approved). Wires the ERMES bridge into the live combat path — it was plumbing-only (zero callers) since FASE 2.

- **`applyBiomeEcoEffects`** orchestrator (traitEffects.js): runs ADR-21c `applyBiomeTraitCosts` + ERMES `applyErmesBiomeTraitCosts`, snapshots base, clamps the **combined** biome-origin delta per stat to **±2** (base-snapshot preserves non-biome bonuses). Idempotent, R6 gate (no `creature_epigenome` write).
- **session.js** `/api/session/start`: inline ADR-21c block replaced with one `applyBiomeEcoEffects` call per unit (both pools — symmetric); merged log surfaced in `biomeCostsLog` response.
- **STATIC_FALLBACKS**: pilot biomes `rovine_planari` (LOW) + `cryosteppe_convergence` (HIGH) added → non-neutral without a generated report.

## Tests
- `applyBiomeEcoEffects` 6 (unified cap −2-not−4, base non-clobber, idempotent, soft-fail, symmetric, R6 gate)
- `ermesExporter` +2 (pilot band low/high)
- `sessionBiomeEcoEffects` 2 (api: cryosteppe HIGH band in `biomeCostsLog`; no-op without biome_id)
- services+ai **1752 pass / 0 fail**, api **1369 / 0 fail**, prettier clean. Independent review per task (approved).

## ⚠️ Balance note
P1 makes ERMES **live in combat** (deltas applied) — symmetric (both pools) + capped ±2 (low risk by design), but **N=40 WR calibration is P2 (not yet run)**. Per the spec, P2 ratifies WR shift <5pp; P4/P5 (player-facing telegraph/Godot) are gated on P2. Recommend running P2 calibration before/with merge if you want main fully balance-ratified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)