### PR TITLE
feat(ermes): FASE 3 P3 boot-generate eco_pressure report

### DIFF
--- a/apps/backend/index.js
+++ b/apps/backend/index.js
@@ -119,6 +119,21 @@ server.listen(port, host, () => {
   } else {
     console.log('[game-database] HTTP integration disabled — using local files only');
   }
+
+  // FASE 3 P3: best-effort boot generation of the ERMES eco_pressure report so
+  // pilot biomes are dynamically non-neutral (static fallbacks cover absence).
+  // Non-blocking + idempotent (freshness check). Failure logged, never fatal.
+  try {
+    const { createErmesRunner } = require('./services/ermes/ermesRunner');
+    createErmesRunner()
+      .generateBootReport()
+      .then((r) =>
+        console.log(`[ermes] boot report: ${r.generated ? 'generated' : r.reason || 'skipped'}`),
+      )
+      .catch((e) => console.warn('[ermes] boot report failed:', e?.message || e));
+  } catch (e) {
+    console.warn('[ermes] boot report init failed:', e?.message || e);
+  }
 });
 
 async function shutdown(signal) {

--- a/apps/backend/services/ermes/ermesRunner.js
+++ b/apps/backend/services/ermes/ermesRunner.js
@@ -143,6 +143,40 @@ function createErmesRunner(opts = {}) {
     }
   }
 
+  // FASE 3 P3: one-shot boot report generation. Idempotent via freshness check
+  // (skip if report exists + younger than ttlMs) -> the report file IS the
+  // checkpoint (anti-pattern #5). Non-blocking: the caller (backend boot) does
+  // NOT await -- best-effort at startup; static fallbacks cover absence.
+  async function generateBootReport({ force = false, ttlMs = 24 * 60 * 60 * 1000 } = {}) {
+    if (!force && fs.existsSync(outputPath)) {
+      try {
+        const age = Date.now() - fs.statSync(outputPath).mtimeMs;
+        if (age < ttlMs) return { skipped: true, reason: 'fresh', output: outputPath, age_ms: age };
+      } catch (_) {
+        /* stat failed -> fall through to regen */
+      }
+    }
+    if (labScriptPath === '/skip') {
+      return { skipped_lab: true, output: outputPath };
+    }
+    return new Promise((resolve, reject) => {
+      const proc = spawn(
+        python,
+        [labScriptPath, '--multi-biome', '--config', labConfig, '--output', outputPath],
+        { stdio: 'pipe' },
+      );
+      let stderr = '';
+      proc.stderr.on('data', (d) => {
+        stderr += d.toString();
+      });
+      proc.on('error', (err) => reject(err));
+      proc.on('exit', (code) => {
+        if (code === 0) resolve({ generated: true, output: outputPath });
+        else reject(new Error(`ermes_sim boot exited ${code}: ${stderr.slice(0, 400)}`));
+      });
+    });
+  }
+
   return {
     getTraitToPoolsMap,
     poolsForTrait,
@@ -151,6 +185,7 @@ function createErmesRunner(opts = {}) {
     isRunning,
     onRerunComplete,
     runQueuedRerun,
+    generateBootReport,
     DEFAULT_BIOME_POOLS,
     DEFAULT_LAB_SCRIPT,
     DEFAULT_LAB_CONFIG,

--- a/tests/services/ermes/ermesRunner.test.js
+++ b/tests/services/ermes/ermesRunner.test.js
@@ -108,3 +108,57 @@ test('missing biome_pools file -> empty index, no throw', () => {
   assert.deepEqual(r.poolsForTrait('t_shared'), []);
   assert.equal(r.getTraitToPoolsMap().size, 0);
 });
+
+// ---------------------------------------------------------------------------
+// FASE 3 P3 -- generateBootReport (idempotent boot-time report generation).
+// ---------------------------------------------------------------------------
+
+test('generateBootReport: /skip lab + no report -> skipped_lab', async () => {
+  const r = createErmesRunner({
+    labScriptPath: '/skip',
+    outputPath: path.join(os.tmpdir(), `no_report_${Date.now()}.json`),
+  });
+  const res = await r.generateBootReport();
+  assert.equal(res.skipped_lab, true);
+});
+
+test('generateBootReport: fresh report -> skipped (idempotent, no regen)', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ermes-boot-'));
+  const out = path.join(dir, 'latest.json');
+  fs.writeFileSync(out, '{"biomes":{}}');
+  try {
+    const r = createErmesRunner({ labScriptPath: '/skip', outputPath: out });
+    const res = await r.generateBootReport();
+    assert.equal(res.skipped, true);
+    assert.equal(res.reason, 'fresh');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('generateBootReport: stale report past ttl -> regen path (skipped_lab)', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ermes-boot-'));
+  const out = path.join(dir, 'latest.json');
+  fs.writeFileSync(out, '{"biomes":{}}');
+  fs.utimesSync(out, 1000000, 1000000); // ancient mtime
+  try {
+    const r = createErmesRunner({ labScriptPath: '/skip', outputPath: out });
+    const res = await r.generateBootReport({ ttlMs: 1000 });
+    assert.equal(res.skipped_lab, true);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('generateBootReport: force bypasses freshness', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ermes-boot-'));
+  const out = path.join(dir, 'latest.json');
+  fs.writeFileSync(out, '{"biomes":{}}'); // fresh
+  try {
+    const r = createErmesRunner({ labScriptPath: '/skip', outputPath: out });
+    const res = await r.generateBootReport({ force: true });
+    assert.equal(res.skipped_lab, true);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
FASE 3 **P3** (report pipeline). Follow-up to #2437 (P1+P2 merged).

`ermesRunner.generateBootReport()` runs `ermes_sim --multi-biome` once at backend boot:
- async, non-blocking, **best-effort** (logged, never fatal; static fallbacks cover absence)
- **idempotent**: freshness check (skip if report younger than ttl) -> the report file IS the checkpoint (anti-pattern #5)
- wired into `index.js` `server.listen` callback

Effect: pilot biomes are **dynamic from the report** (rovine LOW / cryosteppe HIGH), not static-fallback only.

## Verification
- boot -> `[ermes] boot report: generated` -> report written.
- `getErmesBucketed`: rovine_planari 0.164 **low**, cryosteppe 0.876 **high**, savana/caverna med.
- 4 unit tests (skipped_lab, fresh-idempotent, stale-regen, force-bypass) under `tests/services/ermes/` (CI-wired).

## Test plan
- [x] ermesRunner.test.js 11/11 (7 BR-03 + 4 generateBootReport)
- [x] boot integration verified (report generated + pilots dynamic)
- [ ] CI stack-quality (validated on push)

ref: vault `plans/2026-05-30-ermes-fase3-combat-wiring-design.md` section 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)