### PR TITLE
feat(ermes): FASE 3 P4 biome eco band telegraph (chip)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -1409,6 +1409,7 @@ function createSessionRouter(options = {}) {
       // Session-scoped compute (no Prisma persistence). Log surfaced in response.
       const biomeIdRaw = req.body?.biome_id || req.body?.encounter?.biome_id || null;
       let biomeCostsLog = [];
+      let ermesBand = null;
       if (biomeIdRaw) {
         try {
           const biomeCostsRegistry = loadTraitEnvironmentalCosts();
@@ -1416,6 +1417,9 @@ function createSessionRouter(options = {}) {
             if (!u) return u;
             const clone = { ...u };
             const log = applyBiomeEcoEffects(clone, biomeIdRaw, { biomeCostsRegistry });
+            // FASE 3 P4: capture biome-level eco band (uniform across units, set
+            // even for med where no delta is applied) for the diegetic chip.
+            if (log && log.band) ermesBand = log.band;
             if (log && (log.adr21c.length || log.ermes.length)) {
               biomeCostsLog.push({ unit_id: clone.id, ...log });
             }
@@ -1619,6 +1623,9 @@ function createSessionRouter(options = {}) {
         // M11 pilot (ADR-2026-04-21c): biome_id + log trait env deltas applicati.
         biome_id: biomeIdRaw,
         biome_costs_log: biomeCostsLog,
+        // FASE 3 P4: biome-level eco band (low/med/high) for the diegetic biome
+        // chip descriptor ("Bioma calmo/in equilibrio/in tensione").
+        ermes_band: ermesBand,
         // QW1 (M-018): runtime knobs derivati da biomes.yaml diff_base +
         // hazard.stress_modifiers. Esposto via /api/session/state per debug
         // + future UI hint. Consumed da round bridge (pressure_mult tick) e

--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -457,6 +457,9 @@ function publicSessionView(session) {
     // encounter ma biome_id raw non passato (e.g. tutorial UI flow).
     // Null se nessun biome dichiarato (legacy tutorial / scenario JS senza biome).
     biome_id: session.biome_id || session.encounter?.biome_id || null,
+    // FASE 3 P4 -- biome eco band (low/med/high) for the diegetic biome chip
+    // descriptor ("Bioma calmo/in equilibrio/in tensione"). Null if no biome.
+    ermes_band: session.ermes_band || null,
     // M1 ADR-2026-05-18 -- campaign scope + Sistema learning state (read-only surface).
     campaign_id: session.campaign_id || null,
     sistema_state: session.sistema_state || { units_observed: {} },

--- a/apps/play/src/biomeChip.js
+++ b/apps/play/src/biomeChip.js
@@ -79,9 +79,26 @@ export function pressureTier(biomeModifiers) {
   return null;
 }
 
+// Pure: ERMES eco_pressure band → diegetic IT descriptor (FASE 3 P4).
+// ADR "Per il giocatore" doctrine: il nome "ERMES" non appare MAI al player.
+// low = calmo, med = in equilibrio, high = in tensione. Unknown → ''.
+export function ecoBandLabel(band) {
+  switch (band) {
+    case 'low':
+      return 'Bioma calmo';
+    case 'med':
+      return 'Bioma in equilibrio';
+    case 'high':
+      return 'Bioma in tensione';
+    default:
+      return '';
+  }
+}
+
 // Pure: payload → HTML chip. Returns empty string se biome_id mancante.
 // Optional biomeModifiers param adds pressure indicator (TKT-ECO-A5).
-export function formatBiomeChip(biomeId, biomeModifiers = null) {
+// Optional ermesBand (low/med/high) adds eco descriptor (FASE 3 P4).
+export function formatBiomeChip(biomeId, biomeModifiers = null, ermesBand = null) {
   if (!biomeId) return '';
   const icon = iconForBiome(biomeId);
   const label = labelForBiome(biomeId);
@@ -90,10 +107,15 @@ export function formatBiomeChip(biomeId, biomeModifiers = null) {
   const pressureHtml = tier
     ? `<span class="biome-pressure biome-pressure-${tier}" data-tier="${tier}">${tier === 'severe' ? '⚠⚠' : '⚠'}</span>`
     : '';
+  const ecoLabel = ecoBandLabel(ermesBand);
+  const ecoHtml = ecoLabel
+    ? `<span class="biome-eco biome-eco-${ermesBand}" data-band="${ermesBand}">${escapeHtml(ecoLabel)}</span>`
+    : '';
   return (
     `<span class="biome-icon">${icon}</span>` +
     `<span class="biome-label">${escapeHtml(label)}</span>` +
-    pressureHtml
+    pressureHtml +
+    ecoHtml
   );
 }
 
@@ -114,9 +136,9 @@ function escapeHtml(s) {
 // Side effect: render biome chip into HUD container element.
 // Idempotent — sostituisce innerHTML. Hide via .biome-hidden class quando biome_id null.
 // TKT-ECO-A5 — optional biomeModifiers param surface pressure tier indicator.
-export function renderBiomeChip(containerEl, biomeId, biomeModifiers = null) {
+export function renderBiomeChip(containerEl, biomeId, biomeModifiers = null, ermesBand = null) {
   if (!containerEl || typeof containerEl.innerHTML !== 'string') return;
-  const html = formatBiomeChip(biomeId, biomeModifiers);
+  const html = formatBiomeChip(biomeId, biomeModifiers, ermesBand);
   if (!html) {
     containerEl.innerHTML = '';
     containerEl.classList.add('biome-hidden');
@@ -136,6 +158,11 @@ export function renderBiomeChip(containerEl, biomeId, biomeModifiers = null) {
   } else if (tier === 'elevated') {
     const hp = Math.round((Number(biomeModifiers?.hp_mult || 1) - 1) * 100);
     tooltip = `Bioma stress elevato: HP nemici +${hp}%. Vedi Codex per dettagli.`;
+  }
+  // FASE 3 P4: eco descriptor in tooltip (diegetic, no ERMES name).
+  const ecoLabel = ecoBandLabel(ermesBand);
+  if (ecoLabel) {
+    tooltip += ` · ${ecoLabel} (reazione del bioma ai tratti in gioco).`;
   }
   containerEl.setAttribute('title', tooltip);
 }

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -1157,7 +1157,9 @@ function refreshBiomeChip() {
   const biomeId = state.world?.biome_id || null;
   // TKT-ECO-A5 — pass biome_modifiers per pressure tier indicator.
   const biomeModifiers = state.world?.biome_modifiers || null;
-  renderBiomeChip(containerEl, biomeId, biomeModifiers);
+  // FASE 3 P4 — eco band (low/med/high) diegetic descriptor on the chip.
+  const ermesBand = state.world?.ermes_band || null;
+  renderBiomeChip(containerEl, biomeId, biomeModifiers, ermesBand);
 }
 
 // Action 7 (ADR-2026-04-28 §Action 7) — refresh CT bar HUD lookahead 3 turni.

--- a/tests/api/sessionBiomeEcoEffects.test.js
+++ b/tests/api/sessionBiomeEcoEffects.test.js
@@ -42,6 +42,13 @@ test('session/start surfaces ERMES band in biomeCostsLog (cryosteppe HIGH)', asy
     high,
     `expected at least one log entry with band=high for cryosteppe_convergence; log=${JSON.stringify(res.body.biomeCostsLog)}`,
   );
+
+  // FASE 3 P4: biome-level eco band surfaced in state (consumed by the biome chip).
+  assert.equal(
+    res.body.state?.ermes_band,
+    'high',
+    `expected state.ermes_band='high' for cryosteppe_convergence; state.ermes_band=${res.body.state?.ermes_band}`,
+  );
 });
 
 test('session/start without biome_id -> no biome eco log', async (t) => {

--- a/tests/play/biomeChip.test.js
+++ b/tests/play/biomeChip.test.js
@@ -241,3 +241,68 @@ describe('renderBiomeChip — DOM side effect', () => {
     assert.ok(!c._attrs.title.includes('OSTILE'));
   });
 });
+
+// FASE 3 P4 — ERMES eco band diegetic descriptor.
+describe('ecoBandLabel + eco descriptor (FASE 3 P4)', () => {
+  function fakeContainer() {
+    const classList = new Set();
+    const attrs = {};
+    return {
+      innerHTML: '',
+      classList: {
+        add: (...c) => c.forEach((x) => classList.add(x)),
+        remove: (...c) => c.forEach((x) => classList.delete(x)),
+        contains: (x) => classList.has(x),
+      },
+      setAttribute: (k, v) => {
+        attrs[k] = v;
+      },
+      removeAttribute: (k) => {
+        delete attrs[k];
+      },
+      _attrs: attrs,
+    };
+  }
+
+  test('ecoBandLabel maps bands to diegetic IT (never the ERMES name)', async () => {
+    const { ecoBandLabel } = await loadModule();
+    assert.equal(ecoBandLabel('low'), 'Bioma calmo');
+    assert.equal(ecoBandLabel('med'), 'Bioma in equilibrio');
+    assert.equal(ecoBandLabel('high'), 'Bioma in tensione');
+    assert.equal(ecoBandLabel(null), '');
+    assert.equal(ecoBandLabel('xyz'), '');
+    for (const b of ['low', 'med', 'high']) {
+      assert.ok(!ecoBandLabel(b).toUpperCase().includes('ERMES'));
+    }
+  });
+
+  test('formatBiomeChip appends eco descriptor when band present', async () => {
+    const { formatBiomeChip } = await loadModule();
+    const html = formatBiomeChip('cryosteppe_convergence', null, 'high');
+    assert.ok(html.includes('biome-eco-high'));
+    assert.ok(html.includes('Bioma in tensione'));
+    assert.ok(html.includes('data-band="high"'));
+  });
+
+  test('formatBiomeChip — no eco span when band null/unknown', async () => {
+    const { formatBiomeChip } = await loadModule();
+    assert.ok(!formatBiomeChip('savana', null, null).includes('biome-eco'));
+    assert.ok(!formatBiomeChip('savana', null, 'bogus').includes('biome-eco'));
+  });
+
+  test('formatBiomeChip — eco + pressure tier coexist', async () => {
+    const { formatBiomeChip } = await loadModule();
+    const html = formatBiomeChip('abisso_vulcanico', { hp_mult: 1.05 }, 'low');
+    assert.ok(html.includes('biome-pressure-elevated'));
+    assert.ok(html.includes('biome-eco-low'));
+    assert.ok(html.includes('Bioma calmo'));
+  });
+
+  test('renderBiomeChip — eco descriptor in body + tooltip', async () => {
+    const { renderBiomeChip } = await loadModule();
+    const c = fakeContainer();
+    renderBiomeChip(c, 'rovine_planari', null, 'low');
+    assert.ok(c.innerHTML.includes('Bioma calmo'));
+    assert.ok(c._attrs.title.includes('Bioma calmo'));
+  });
+});


### PR DESCRIPTION
## Summary
FASE 3 **P4** (telegraph UI -- player-perceivable). Follow-up to #2437 (P1+P2), #2438 (P3).

Surfaces the ERMES eco band **diegetically** (ADR "Per il giocatore" -- the name "ERMES" never shown):
- `biomeChip.ecoBandLabel`: low=`Bioma calmo` / med=`Bioma in equilibrio` / high=`Bioma in tensione`.
- chip eco span + tooltip line ("reazione del bioma ai tratti in gioco").
- backend: session captures biome band -> `session.ermes_band` -> `publicSessionView` -> `state.world.ermes_band` -> `main.js renderBiomeChip`.
- **reuses the existing biome chip surface** (spec: reuse infra, not a new component).

## Verification
- `biomeChip` 29/29 (+5 P4: ecoBandLabel, chip eco span, eco+pressure coexist, tooltip, no-span-when-null).
- `sessionBiomeEcoEffects` integration: cryosteppe -> `state.ermes_band='high'` (2/2).

## Test plan
- [x] biomeChip.test.js 29/29
- [x] sessionBiomeEcoEffects.test.js 2/2 (state.ermes_band wiring)
- [ ] CI stack-quality (validated on push)

ref: vault `plans/2026-05-30-ermes-fase3-combat-wiring-design.md` section 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)