### PR TITLE
docs(governance): currency-reconcile 6 design docs vs shipped state

### DIFF
--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -5023,10 +5023,10 @@
     {
       "path": "docs/planning/2026-04-25-mutation-system-design.md",
       "title": "Mutation System Design — M14+ runtime intent + 30 mutation catalog (T2 24, T3 6) + 5 categorie + integration M12/M13/M11",
-      "doc_status": "draft",
+      "doc_status": "superseded",
       "doc_owner": "catalog-curator",
       "workstream": "dataset-pack",
-      "last_verified": "2026-04-25",
+      "last_verified": "2026-05-29",
       "source_of_truth": false,
       "language": "it",
       "review_cycle_days": 30

--- a/docs/planning/2026-04-25-mutation-system-design.md
+++ b/docs/planning/2026-04-25-mutation-system-design.md
@@ -1,11 +1,13 @@
 ---
-doc_status: draft
+doc_status: superseded
 doc_owner: catalog-curator
 workstream: dataset-pack
-last_verified: 2026-04-25
+last_verified: 2026-05-29
 source_of_truth: false
 language: it
 review_cycle_days: 30
+superseded_by: docs/adr/ADR-2026-05-10-mutation-auto-trigger-evaluator.md
+reconcile_note: "SHIPPED -- mutationEngine.js + mutationCatalogLoader.js + combat/mutationTriggerEvaluator.js live; auto-trigger formalized in ADR-2026-05-10. Design realized. See docs/reports/2026-05-29-design-docs-currency-reconcile.md"
 ---
 
 # Mutation System Design — Evo-Tactics

--- a/docs/reports/2026-04-26-creature-emergence-audit.md
+++ b/docs/reports/2026-04-26-creature-emergence-audit.md
@@ -5,6 +5,8 @@ status: draft
 created: 2026-04-26
 author: creature-aspect-illuminator (audit mode)
 tags: [species, lifecycle, emergence, spawn, visual-morphology]
+last_verified: "2026-05-29"
+reconcile_note: "Partial: P0 drawLifecycleRing/drawMutationDots NOT shipped (apps/play/src); biome_affinity spawn-filter still open. Visual-emergence gap carded in museum evolution_genetics-voidling-bound. See docs/reports/2026-05-29-design-docs-currency-reconcile.md"
 ---
 
 # Creature Emergence Audit

--- a/docs/reports/2026-04-26-lore-alien-event-swarm-redig.md
+++ b/docs/reports/2026-04-26-lore-alien-event-swarm-redig.md
@@ -3,10 +3,11 @@ title: "Lore alien-event: swarm re-dig — fonti esterne non esplorate"
 doc_status: draft
 doc_owner: repo-archaeologist
 workstream: cross-cutting
-last_verified: "2026-04-26"
+last_verified: "2026-05-29"
 source_of_truth: false
 language: it
 review_cycle_days: 30
+reconcile_note: "Verdict CONFIRMED_ZERO (no alien-event) still valid. Candidates eco_lucido/strappo_planare now partly wired in data/core/events/mutagen_events.yaml; Leviatano/Frattura canonical (vault Atlas frattura-abissale MOC). See docs/reports/2026-05-29-design-docs-currency-reconcile.md"
 ---
 
 # Lore alien-event — Swarm Re-dig

--- a/docs/reports/2026-04-26-nido-pokopia-housing-pattern.md
+++ b/docs/reports/2026-04-26-nido-pokopia-housing-pattern.md
@@ -6,6 +6,8 @@ created: 2026-04-26
 author: creature-aspect-illuminator
 related_od: OD-001
 related_cards: [M-2026-04-25-007, M-2026-04-25-008]
+last_verified: "2026-05-29"
+reconcile_note: "EXECUTED -- OD-001 Path A shipped (apps/play/src/nestHub.js, PR #1876/#1879/#1911); museum M-007 revived. Historical reference. See docs/reports/2026-05-29-design-docs-currency-reconcile.md"
 ---
 
 # Nido — housing+mutation pattern, repo audit + Pokopia reference

--- a/docs/reports/2026-04-26-worldgen-pcg-audit.md
+++ b/docs/reports/2026-04-26-worldgen-pcg-audit.md
@@ -5,6 +5,8 @@ category: report
 doc_status: draft
 doc_owner: claude-code
 tags: [pcg, worldgen, ecosystem, biome, audit]
+last_verified: "2026-05-29"
+reconcile_note: "Curated to museum cards M-012..M-018 + gallery worldgen. Runtime: biomeResonance + biomeSpawnBias live; GAP-A/B/C (foodweb-filter, cross-event-engine, campaign-routing) still open. See docs/reports/2026-05-29-design-docs-currency-reconcile.md"
 ---
 
 # PCG Audit: Worldgen Runtime vs Dato

--- a/docs/reports/2026-05-29-design-docs-currency-reconcile.md
+++ b/docs/reports/2026-05-29-design-docs-currency-reconcile.md
@@ -1,0 +1,97 @@
+---
+title: "Design docs currency reconcile -- 6 doc apr-2026 vs shipped state (2026-05-29)"
+workstream: cross-cutting
+category: report
+doc_status: active
+doc_owner: claude-code
+last_verified: "2026-05-29"
+source_of_truth: false
+language: it
+tags: [currency, reconcile, audit, governance, worldgen, mutation, nido, lore]
+---
+
+# Design docs currency reconcile (2026-05-29)
+
+Audit di currency su 6 doc di design/audit Evo-Tactics prodotti il 25-26 apr 2026
+(PR #1776 + #1866). Domanda: **sono ancora usati e usabili?** Metodo: ground-truth
+contro lo stato shipped (codice runtime + ADR + museum + registry), non contro la
+narrativa del doc. Riferimento metodo: anti-pattern #19 (stale tracker lag shipped
+work) + Currency Gate.
+
+## TL;DR
+
+- **~80% gia processato**: i 6 doc sono in larga parte gia curati nel museum
+  (`docs/museum/`) o gia shipped a runtime. Non sono materiale "perso da recuperare".
+- **2 doc = storico/eseguito**: nido (Path A shipped) + mutation-system-design
+  (engine shipped + ADR-2026-05-10). Marcati di conseguenza.
+- **3 doc = ancora usabili come gap-roadmap o reference**: worldgen (GAP-A/B/C
+  aperti), creature-emergence (P0 visual-emergence aperto), lore-redig (verdetto
+  valido, candidati parz. wired).
+- **1 doc = destinazione, non sorgente**: `MUSEUM.md` e la knowledgebase stessa
+  (curata solo da `repo-archaeologist`).
+
+## Metodo -- segnali ground-truth verificati
+
+| Segnale | Comando/path | Esito |
+|---|---|---|
+| Mutation engine shipped | `apps/backend/services/mutations/{mutationEngine,mutationCatalogLoader,mpTracker}.js` | ESISTE |
+| Mutation auto-trigger | `apps/backend/services/combat/mutationTriggerEvaluator.js` + `docs/adr/ADR-2026-05-10-mutation-auto-trigger-evaluator.md` (accepted) | ESISTE |
+| Nido frontend shipped | `apps/play/src/nestHub.js` | ESISTE |
+| Worldgen runtime | `biomeResonance.js` + `biomeSpawnBias.js` + `biomePoolLoader.js` live; nessun `foodwebFilter`/`crossEventEngine`/`ecosystemLoader` | PARZIALE |
+| Creature visual-emergence P0 | grep `drawLifecycleRing`/`drawMutationDots` in `apps/play/src` | ASSENTE (gap aperto) |
+| Lore candidati | `eco_lucido`/`strappo_planare` in `data/core/events/mutagen_events.yaml` | PARZIALE (wired qui, non in active_effects) |
+| Curazione museum | `MUSEUM.md` cards M-007/M-008/M-012..M-018 + gallery worldgen | GIA CURATO |
+
+## Verdetto per doc
+
+| Doc | Stato | Verdetto | Azione |
+|---|---|---|---|
+| `reports/2026-04-26-worldgen-pcg-audit` | content in museum M-012..M-018 + gallery; GAP-A/B/C non shipped | **USABILE** (gap-roadmap) | annotato `reconcile_note` + `last_verified` |
+| `reports/2026-04-26-creature-emergence-audit` | P0 drawLifecycleRing/drawMutationDots non shipped; biome_affinity spawn-filter aperto | **USABILE** (gap P0) | annotato |
+| `reports/2026-04-26-lore-alien-event-swarm-redig` | verdetto "no alien-event" valido; eco_lucido/strappo_planare parz. wired; Leviatano canonical | **REFERENCE valida** | annotato |
+| `reports/2026-04-26-nido-pokopia-housing-pattern` | nestHub.js shipped + M-007 revived (OD-001 Path A, PR #1876/#1879/#1911) | **STORICO/eseguito** | annotato (historical) |
+| `planning/2026-04-25-mutation-system-design` | mutationEngine + catalogLoader + triggerEvaluator shipped + ADR-2026-05-10 | **SUPERSEDED** | `doc_status: superseded` + `superseded_by` + registry sync |
+| `museum/MUSEUM.md` | index KB attivo (last verified 2026-05-20) | **non target recovery** -- e la destinazione | nessuna modifica (curator-gated a repo-archaeologist) |
+
+## Residuo ancora aperto (usabile = vivo)
+
+1. **Worldgen GAP-A** foodweb -> spawn composition (~8-10h). Card museum gia
+   presente: `worldgen-species-emergence-from-ecosystem` (M-013) +
+   `worldgen-trophic-roles-validator-not-runtime` (M-016).
+2. **Worldgen GAP-B** cross-events -> pressure modifier (~12h). Card:
+   `worldgen-cross-bioma-events-propagation` (M-014).
+3. **Worldgen GAP-C** meta-network -> campaign routing (~30-40h, post-MVP).
+4. **Creature-emergence P0** `drawLifecycleRing`/`drawMutationDots` in `render.js`
+   (~5h). Gap confermato in card `evolution_genetics-voidling-bound-patterns`
+   (visual_swap_it P0). **NON ha card dedicata** -> candidato museum (handoff sotto).
+5. **Lore** trait `eco_lucido`/`strappo_planare`: parz. in `mutagen_events.yaml`,
+   non ancora in `active_effects.yaml`/`glossary.json` come da Candidate 1 del doc.
+
+## Handoff museum (per sessione Game, curatore = repo-archaeologist)
+
+`docs/museum/` e scrivibile SOLO da `repo-archaeologist` (convenzione MUSEUM.md).
+Da questa sessione codemasterdd quell'agent non e nel registry, quindi NON tocco il
+museum. Follow-up da eseguire in una sessione Claude Code dentro `C:/dev/Game`:
+
+- [ ] Valutare card dedicata per **creature-emergence visual-emergence P0**
+  (`drawLifecycleRing` + `drawMutationDots`), oggi solo coperto di sponda da
+  `evolution_genetics-voidling-bound-patterns`.
+- [ ] Bump `MUSEUM.md` "Last verified" con nota: worldgen GAP-A/B/C ancora open al
+  2026-05-29; nido M-007 confermato revived/shipped.
+
+## Mirror sovereign (vault)
+
+Sintesi di questo reconcile mirrorata in `C:/dev/vault`
+(`Spaces/Dev/Evo-Tactics/`) come reference-by-source (OD-055): 1 nota digest che
+linka i 6 doc + i loro card museum + le MOC Atlas esistenti
+(`evo-tactics-frattura-abissale-moc`). Branch+PR, merge Eduardo-only.
+
+## Sources
+
+- Game runtime: `apps/backend/services/mutations/*`, `apps/backend/services/combat/*`,
+  `apps/play/src/nestHub.js`
+- ADR: `docs/adr/ADR-2026-05-10-mutation-auto-trigger-evaluator.md`
+- Museum: `docs/museum/MUSEUM.md` (cards M-007/M-008/M-012..M-018)
+- Governance: `docs/governance/docs_registry.json` + `tools/check_docs_governance.py`
+  + `tools/docs_status_promotion.py`
+- I 6 doc auditati (front-matter annotati con `reconcile_note` salvo MUSEUM.md)


### PR DESCRIPTION
## Cosa
Currency reconcile di 6 doc design/audit Evo-Tactics (apr-2026, PR #1776/#1866) vs stato shipped. Docs-only, zero codice.

## Verdetti
- `planning/2026-04-25-mutation-system-design` -> **superseded** (mutationEngine + mutationCatalogLoader + combat/mutationTriggerEvaluator shipped; auto-trigger in ADR-2026-05-10). doc_status + registry sync.
- `reports/...nido-pokopia` -> **EXECUTED** (nestHub.js shipped PR #1876/#1879/#1911; museum M-007 revived). reconcile_note + last_verified.
- `reports/...worldgen-pcg-audit` -> **usabile** gap-roadmap (GAP-A/B/C aperti; content gia in museum M-012..M-018).
- `reports/...creature-emergence-audit` -> **usabile** (P0 drawLifecycleRing/drawMutationDots non shipped).
- `reports/...lore-alien-event-swarm-redig` -> **reference valida** (verdetto no-alien-event; eco_lucido/strappo_planare parz. wired in mutagen_events.yaml).

## Nuovo
`docs/reports/2026-05-29-design-docs-currency-reconcile.md` -- verdetto per-doc + residuo aperto + handoff museum (per sessione Game con repo-archaeologist; museum curator-gated, non toccato qui).

## Verifica
`python tools/check_docs_governance.py --strict` -> errors=0 (323 warnings pre-esistenti, non introdotte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)