### PR TITLE
docs(governance): correct reconcile -- creature P0 was already shipped

### DIFF
--- a/docs/reports/2026-04-26-creature-emergence-audit.md
+++ b/docs/reports/2026-04-26-creature-emergence-audit.md
@@ -6,7 +6,7 @@ created: 2026-04-26
 author: creature-aspect-illuminator (audit mode)
 tags: [species, lifecycle, emergence, spawn, visual-morphology]
 last_verified: "2026-05-29"
-reconcile_note: "Partial: P0 drawLifecycleRing/drawMutationDots NOT shipped (apps/play/src); biome_affinity spawn-filter still open. Visual-emergence gap carded in museum evolution_genetics-voidling-bound. See docs/reports/2026-05-29-design-docs-currency-reconcile.md"
+reconcile_note: "Partial: P0 visual-emergence SHIPPED (render.js resolveUnitVisualStyle + getAspectTokenOverlay + drawLifecycleBadge, 10-stadi spec 2026-04-27); biomeAffinity stat-mod wired (session.js); only foodweb spawn-filter still open (= worldgen GAP-A). Earlier 'NOT shipped' was a name-based false-negative. See docs/reports/2026-05-29-design-docs-currency-reconcile.md"
 ---
 
 # Creature Emergence Audit

--- a/docs/reports/2026-04-26-lore-alien-event-swarm-redig.md
+++ b/docs/reports/2026-04-26-lore-alien-event-swarm-redig.md
@@ -7,7 +7,7 @@ last_verified: "2026-05-29"
 source_of_truth: false
 language: it
 review_cycle_days: 30
-reconcile_note: "Verdict CONFIRMED_ZERO (no alien-event) still valid. Candidates eco_lucido/strappo_planare now partly wired in data/core/events/mutagen_events.yaml; Leviatano/Frattura canonical (vault Atlas frattura-abissale MOC). See docs/reports/2026-05-29-design-docs-currency-reconcile.md"
+reconcile_note: "Verdict CONFIRMED_ZERO (no alien-event) still valid. Candidates eco_lucido/strappo_planare now present in data/core/events/mutagen_events.yaml but DATA-ONLY (no backend consumer yet), not in active_effects/glossary. Leviatano/Frattura canonical (vault Atlas frattura-abissale MOC). See docs/reports/2026-05-29-design-docs-currency-reconcile.md"
 ---
 
 # Lore alien-event — Swarm Re-dig

--- a/docs/reports/2026-05-29-design-docs-currency-reconcile.md
+++ b/docs/reports/2026-05-29-design-docs-currency-reconcile.md
@@ -25,8 +25,9 @@ work) + Currency Gate.
 - **2 doc = storico/eseguito**: nido (Path A shipped) + mutation-system-design
   (engine shipped + ADR-2026-05-10). Marcati di conseguenza.
 - **3 doc = ancora usabili come gap-roadmap o reference**: worldgen (GAP-A/B/C
-  aperti), creature-emergence (P0 visual-emergence aperto), lore-redig (verdetto
-  valido, candidati parz. wired).
+  aperti), creature-emergence (P0 visual-emergence **SHIPPED** -- resta solo
+  spawn-filter; vedi correzione ground-truth sotto), lore-redig (verdetto valido,
+  candidati data-only non ancora runtime).
 - **1 doc = destinazione, non sorgente**: `MUSEUM.md` e la knowledgebase stessa
   (curata solo da `repo-archaeologist`).
 
@@ -38,8 +39,10 @@ work) + Currency Gate.
 | Mutation auto-trigger | `apps/backend/services/combat/mutationTriggerEvaluator.js` + `docs/adr/ADR-2026-05-10-mutation-auto-trigger-evaluator.md` (accepted) | ESISTE |
 | Nido frontend shipped | `apps/play/src/nestHub.js` | ESISTE |
 | Worldgen runtime | `biomeResonance.js` + `biomeSpawnBias.js` + `biomePoolLoader.js` live; nessun `foodwebFilter`/`crossEventEngine`/`ecosystemLoader` | PARZIALE |
-| Creature visual-emergence P0 | grep `drawLifecycleRing`/`drawMutationDots` in `apps/play/src` | ASSENTE (gap aperto) |
-| Lore candidati | `eco_lucido`/`strappo_planare` in `data/core/events/mutagen_events.yaml` | PARZIALE (wired qui, non in active_effects) |
+| Creature visual-emergence P0 | `render.js` `resolveUnitVisualStyle` + `getAspectTokenOverlay` + `drawLifecycleBadge` (drawUnit L982/L1249); 10-stadi spec 2026-04-27 | SHIPPED (grep name-based `drawLifecycleRing` = falso-negativo, impl con nomi diversi) |
+| Creature biome stat | `apps/backend/services/species/biomeAffinity.js` wired (session.js:506) | SHIPPED (stat-mod Subnautica; non spawn-filter) |
+| Lore candidati | `eco_lucido`/`strappo_planare` in `data/core/events/mutagen_events.yaml`; nessun consumer backend | DATA-ONLY (non runtime) |
+| Seasonal/cross-event | `services/campaign/seasonalEngine.js` Phase-A wired (campaign.js:50); `cross_events.yaml` nessun consumer | PARZIALE (scaffold, GAP-B aperto) |
 | Curazione museum | `MUSEUM.md` cards M-007/M-008/M-012..M-018 + gallery worldgen | GIA CURATO |
 
 ## Verdetto per doc
@@ -47,7 +50,7 @@ work) + Currency Gate.
 | Doc | Stato | Verdetto | Azione |
 |---|---|---|---|
 | `reports/2026-04-26-worldgen-pcg-audit` | content in museum M-012..M-018 + gallery; GAP-A/B/C non shipped | **USABILE** (gap-roadmap) | annotato `reconcile_note` + `last_verified` |
-| `reports/2026-04-26-creature-emergence-audit` | P0 drawLifecycleRing/drawMutationDots non shipped; biome_affinity spawn-filter aperto | **USABILE** (gap P0) | annotato |
+| `reports/2026-04-26-creature-emergence-audit` | P0 visual-emergence **SHIPPED** (render.js resolveUnitVisualStyle + getAspectTokenOverlay + drawLifecycleBadge); biomeAffinity stat-mod wired; resta solo foodweb spawn-filter (= GAP-A) | **PARZIALE** (gran parte shipped) | annotato + correzione |
 | `reports/2026-04-26-lore-alien-event-swarm-redig` | verdetto "no alien-event" valido; eco_lucido/strappo_planare parz. wired; Leviatano canonical | **REFERENCE valida** | annotato |
 | `reports/2026-04-26-nido-pokopia-housing-pattern` | nestHub.js shipped + M-007 revived (OD-001 Path A, PR #1876/#1879/#1911) | **STORICO/eseguito** | annotato (historical) |
 | `planning/2026-04-25-mutation-system-design` | mutationEngine + catalogLoader + triggerEvaluator shipped + ADR-2026-05-10 | **SUPERSEDED** | `doc_status: superseded` + `superseded_by` + registry sync |
@@ -55,29 +58,47 @@ work) + Currency Gate.
 
 ## Residuo ancora aperto (usabile = vivo)
 
-1. **Worldgen GAP-A** foodweb -> spawn composition (~8-10h). Card museum gia
-   presente: `worldgen-species-emergence-from-ecosystem` (M-013) +
+1. **Worldgen GAP-A** foodweb -> spawn composition (~8-10h). NON chiuso:
+   `biomeAffinity.js` e stat-modifier (Subnautica), non spawn-pool filter;
+   `reinforcementSpawner.js` non filtra per foodweb/biome_affinity. Card museum:
+   `worldgen-species-emergence-from-ecosystem` (M-013) +
    `worldgen-trophic-roles-validator-not-runtime` (M-016).
-2. **Worldgen GAP-B** cross-events -> pressure modifier (~12h). Card:
+2. **Worldgen GAP-B** cross-events -> pressure modifier (~12h). Parziale:
+   `seasonalEngine.js` Phase-A (scaffold ciclico, wired campaign.js:50) esiste, ma
+   `cross_events.yaml` resta senza consumer runtime. Card:
    `worldgen-cross-bioma-events-propagation` (M-014).
 3. **Worldgen GAP-C** meta-network -> campaign routing (~30-40h, post-MVP).
-4. **Creature-emergence P0** `drawLifecycleRing`/`drawMutationDots` in `render.js`
-   (~5h). Gap confermato in card `evolution_genetics-voidling-bound-patterns`
-   (visual_swap_it P0). **NON ha card dedicata** -> candidato museum (handoff sotto).
-5. **Lore** trait `eco_lucido`/`strappo_planare`: parz. in `mutagen_events.yaml`,
-   non ancora in `active_effects.yaml`/`glossary.json` come da Candidate 1 del doc.
+4. **Lore** trait `eco_lucido`/`strappo_planare`: presenti in
+   `data/core/events/mutagen_events.yaml` ma DATA-ONLY (nessun consumer backend),
+   non ancora in `active_effects.yaml`/`glossary.json`.
+
+> **CHIUSO** (era erroneamente listato aperto): creature-emergence P0
+> visual-emergence -- shipped in `render.js`. Vedi correzione ground-truth sotto.
 
 ## Handoff museum (per sessione Game, curatore = repo-archaeologist)
 
 `docs/museum/` e scrivibile SOLO da `repo-archaeologist` (convenzione MUSEUM.md).
 Da questa sessione codemasterdd quell'agent non e nel registry, quindi NON tocco il
-museum. Follow-up da eseguire in una sessione Claude Code dentro `C:/dev/Game`:
+museum. Follow-up opzionale in una sessione Claude Code dentro `C:/dev/Game`:
 
-- [ ] Valutare card dedicata per **creature-emergence visual-emergence P0**
-  (`drawLifecycleRing` + `drawMutationDots`), oggi solo coperto di sponda da
-  `evolution_genetics-voidling-bound-patterns`.
-- [ ] Bump `MUSEUM.md` "Last verified" con nota: worldgen GAP-A/B/C ancora open al
-  2026-05-29; nido M-007 confermato revived/shipped.
+- [x] ~~Card creature-emergence visual P0~~ -- **non serve**: gap gia shipped
+  (render.js). Una card sarebbe false-positive (curare canonical attivo, vietato
+  da repo-archaeologist DO-NOT).
+- [ ] (Opzionale) Bump `MUSEUM.md` "Last verified" con nota: worldgen GAP-A/B/C
+  ancora open al 2026-05-29; nido M-007 + creature visual-emergence shipped.
+
+## Correzione ground-truth (2026-05-29, post #2440)
+
+Verifica approfondita post-merge: la riga creature-emergence "P0 non shipped" era
+**falso-negativo name-based** (L-038 family). Il grep cercava i nomi letterali
+`drawLifecycleRing`/`drawMutationDots`, assenti -- ma la funzionalita E shipped
+sotto altri nomi: `render.js` `drawUnit` usa `resolveUnitVisualStyle` (stadio 1-10
++ lifecycle_phase fallback), `drawLifecycleBadge`, e
+`getAspectTokenOverlay(unit.aspect_token)` (mutation_catalog.yaml 36 aspect_token).
+La 10-stadi naming spec (2026-04-27) ha superseduto il modello 5-fasi.
+
+Lezione: verificare per COMPORTAMENTO/simbolo equivalente, non per nome-funzione
+atteso. Ground-truth > euristica-di-grep.
 
 ## Mirror sovereign (vault)
 


### PR DESCRIPTION
Follow-up correzione di #2440 dopo ground-truth re-verify approfondito.

## Fix
- **creature-emergence P0 visual-emergence**: era listato 'NOT shipped' = **falso-negativo name-based** (L-038). Realta: shipped in `render.js` (`resolveUnitVisualStyle` + `getAspectTokenOverlay` + `drawLifecycleBadge`, 10-stadi spec 2026-04-27). Corretto report + front-matter.
- **biomeAffinity.js** (stat-mod, session.js:506) + **seasonalEngine.js** Phase-A (campaign.js:50) ora annotati come wired (partial).
- **lore candidates** eco_lucido/strappo_planare = **data-only** in mutagen_events.yaml (nessun consumer backend), non 'wired'.
- **museum card creature P0** = non serve (sarebbe false-positive curation, vietato repo-archaeologist DO-NOT).

Worldgen GAP-A/B/C restano open (ground-truth confermato: biomeAffinity != spawn-filter; cross_events.yaml senza consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)