### PR TITLE
docs(playtest): canonical AI-driven playtest SoT + human-gate flip

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -29,6 +29,16 @@ Source: design-docs currency reconcile (`docs/reports/2026-05-29-design-docs-cur
 | TKT-WORLDGEN-GAPB  | cross-events -> pressure modifier | `cross_events.yaml` (3 eventi) zero consumer runtime; `seasonalEngine.js` Phase-A scaffold (wired campaign.js:50) ma NON consuma cross_events | ~12h (×1.3 session hook)   | wire crossEventEngine (pressure/hazard delta su session) OR remove  |
 | TKT-WORLDGEN-GAPC  | meta-network -> campaign routing | `meta_network_alpha.yaml` (5 nodi/11 archi) zero consumer; `campaignEngine.js` usa encounter_id statici                              | ~30-40h (POST-MVP)         | Dormans mission/space grammar su meta-network — POST-MVP, gate normale, NON priorità automatica |
 
+### 🟡 OPEN — Canonical AI-driven playtest (paradigma flip 2026-05-29)
+
+SoT: `docs/process/CANONICAL-AI-PLAYTEST.md` + `docs/playtest/canonical-suite.yaml`. Flip: AI-driven multi-policy (N=40) = gate/oracolo riproducibile; playtest umano = conferma opzionale, mai bloccante. Tooling esistente `tools/py/calibrate_*.py` + `batch_calibrate_*.py`.
+
+| Ticket                   | Scope                                                                                           | Effort | Note                                                          |
+| ------------------------ | ----------------------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------ |
+| TKT-PLAYTEST-SEED        | `--seed` pin RNG nei `batch_calibrate_*.py` per riproducibilita' bit-identica                   | ~2-3h  | gap "ogni volta" (oggi solo statistica N=40, non bit-identica) |
+| TKT-PLAYTEST-TRIANGULATE | wire multi-policy `--policy {random,greedy,lookahead2,utility}` (Restricted-Play, Jaffe 2012)   | ~4h    | stub gia' nel policy doc superseded; output = banda WR non single verdict |
+| TKT-PLAYTEST-SUITE       | `tools/py/playtest_canonical.py` orchestratore summa (manifest -> N=40 parallel -> report datato) | ~4-6h  | smoke-gated (backend up + ~10min). Anti-pattern #9: non shippare non-testato |
+
 ### 🟡 OPEN — intensive fix/tuning audit 2026-05-22 (orphan inventory + balance ratify)
 
 Source: `general-purpose` orphan hunt + `balance-auditor` sweep (2026-05-22). Verified findings; dispositions are master-dd-gated (wire-vs-remove / N=40 ratify).
@@ -87,7 +97,7 @@ User trigger 2026-05-13: "analizza col metodo tutta l'infrastruttura Ecosistema 
 - P4 Temperamenti: 🟢-cand → 🟢 candidato HARD (sentience 15/15 + 51 neurons + vc_scoring fold)
 - P6 Fairness: 🟢 candidato confermato (conviction tactical flags inline)
 
-🟢 hard final ancora gated **Playtest #2 userland** (master-dd manual, 4 amici). Synthetic baseline shipped #2266 (P3 🟡 + P4 🟢 + P6 🟢 con 30 sessions).
+🟢 hard final: gate = **playtest AI-driven canonico** (multi-policy N=40 in-band, `docs/process/CANONICAL-AI-PLAYTEST.md`). Playtest umano "#2 userland 4 amici" = conferma OPZIONALE, NON bloccante (flip 2026-05-29). Synthetic baseline shipped #2266 (P3 🟡 + P4 🟢 + P6 🟢 con 30 sessions).
 
 **Anti-pattern killer milestone**: cross-validation L7c Promotions ORPHAN claim FALSE NEGATIVE → museum discard card [M-2026-05-13-001](docs/museum/cards/promotions-orphan-claim-discarded.md) + lessons codify per Explore agent inventory.
 
@@ -806,7 +816,7 @@ Da `docs/research/triangle-strategy-transfer-plan.md` — 10 meccaniche identifi
 ## 🚫 Bloccato da
 
 - **TKT-07** ← TKT-06 (predict_combat fix prima di sweep #2)
-- **V6 UI polish** ← TKT-M11B-06 playtest (serve feedback real per priorità UI)
+- **V6 UI polish** ← playtest canonico AI-driven (`docs/process/CANONICAL-AI-PLAYTEST.md`) OR feedback human opzionale (TKT-M11B-06 declassato, non bloccante)
 - **M15 Triangle Strategy** ← M14-A + M14-B completati (sequenza rollout)
 - **Alt B HTTP runtime** ← Game-Database sibling repo availability + deployment pubblico
 

--- a/COMPACT_CONTEXT.md
+++ b/COMPACT_CONTEXT.md
@@ -64,7 +64,7 @@
 - P5 Co-op: 🟢 confirmed + Phase-3 debrief_payload cross-stack closure (#2270 in flight)
 - P6 Fairness: 🟢 candidato confermato (conviction tactical flags inline)
 
-🟢 hard final ancora gated **Playtest #2 userland** (master-dd manual, 4 amici).
+🟢 hard final: gate = **playtest AI-driven canonico** (multi-policy N=40, `docs/process/CANONICAL-AI-PLAYTEST.md`); playtest umano 4-amici = conferma OPZIONALE (flip 2026-05-29).
 
 **Phase A residue mio plan TKT-ECO-XX (~9-10h)**:
 
@@ -1100,7 +1100,7 @@ Total Fase 1 effort: ~5-5.5 settimane.
 
 1. **Read handoff doc** (`docs/planning/2026-04-25-illuminator-orchestra-handoff.md`) — 90s onboarding alla orchestra agent + workflow validato 6×.
 2. **Pick P0 residual or new domain** — usa illuminator agent invocation in `--mode audit` per scope, poi runtime apply separato.
-3. **TKT-M11B-06 playtest live** (userland, 2-4h con 2-4 amici) — unico bloccante P5 🟢 definitivo. Post-playtest: invoke `playtest-analyzer` agent per crunchare dati JSONL + visualizza in `apps/analytics/index.html`.
+3. **Playtest AI-driven canonico** P5 (multi-policy N=40, `docs/process/CANONICAL-AI-PLAYTEST.md`) — gate riproducibile, NON bloccante umano. TKT-M11B-06 playtest live 4-amici = conferma OPZIONALE (declassato 2026-05-29, flip). `playtest-analyzer` agent processa JSONL se/quando ci sono dati human.
 
 **Deferred**: M13 P3 Phase B balance pass, M13 P6 Phase B calibration hardcore 07, M14-D pincer queue (ADR ready), V3 Mating/Nido (~20h post-MVP, pattern già researched).
 

--- a/docs/adr/ADR-2026-05-18-df-levels-integration-direction.md
+++ b/docs/adr/ADR-2026-05-18-df-levels-integration-direction.md
@@ -213,10 +213,11 @@ L0-L5 declassato a lente**.
 4. **Build**: L0-L1 ora (vicini al core). **L2-L5 = feature ordinarie M2+**, NON
    priorita' automatica, gated da DUE precondizioni HARD (fix P1.1/P1.2/P1.3
    harsh-review — non hand-wavy):
-   - **(a) gate playtest falsificabile**: nessun merge L2-L5 finche' il core co-op
-     loop non e' validato end-to-end in un playtest filato (>=1 sessione 4-umani
-     TV+phone, run completa, findings in `docs/playtest/`, sign-off master-dd).
-     Artefatto-gate = BACKLOG `Short` goal M1.
+   - **(a) gate AI-driven canonical playtest** (paradigma 2026-05-29,
+     `docs/process/CANONICAL-AI-PLAYTEST.md`): nessun merge L2-L5 finche' il core co-op
+     loop non passa il **playtest AI-driven canonico** (multi-policy, WR in-band a N=40,
+     test verdi), riproducibile via `calibrate_parallel.py`. Playtest umano = conferma
+     opzionale, NON bloccante. Artefatto-gate = `canonical-suite.yaml` + BACKLOG `Short` M1.
    - **(b) regola same-increment-surface**: ogni sprint L2-L5 shippa engine + payoff
      player-visibile + debrief NELLO STESSO incremento, o non shippa (roadmap
      `evo-state-roadmap` §82-83). Cross-run NON de-rischia: e' un *moltiplicatore* di

--- a/docs/adr/ADR-2026-05-18-sistema-persistent-state-learning.md
+++ b/docs/adr/ADR-2026-05-18-sistema-persistent-state-learning.md
@@ -164,11 +164,11 @@ harsh-review stress-test:
 1. **Option B = RATIFIED** (gia' shipped + e2e PASS 2026-05-25). NON era una scelta
    "pilot" forward (correzione P0.2 harsh-review: era stale framing). Resta in main
    come shipped subset (units_observed + threat).
-2. **Gate = ratify-OR-revert sul playtest core co-op**: Option B resta, ma il lock
-   definitivo (no-revert) e' subordinato al gate playtest filato del core loop
-   (>=1 sessione 4-umani TV+phone, findings `docs/playtest/`, sign-off master-dd) —
-   stesso gate di L2-L5 nel parent ADR. Se il playtest mostra "AI troppo aggressiva"
-   (Risks #5) -> tuning o revert del subset.
+2. **Gate = ratify-OR-revert sul playtest AI-driven canonical**: Option B resta, ma il
+   lock definitivo (no-revert) e' subordinato al **playtest AI-driven canonico** del core
+   loop (multi-policy, WR in-band a N=40, `docs/process/CANONICAL-AI-PLAYTEST.md`) —
+   stesso gate di L2-L5 nel parent ADR. Playtest umano = conferma opzionale. Se la sim
+   mostra "AI troppo aggressiva" (Risks #5) -> tuning o revert del subset.
 3. **Estensione Option A** (tactics_observed / factions / strategic_phase) = feature
    M2+ ordinaria, NON priorita' automatica, stesso doppio-gate (playtest +
    same-increment-surface) del parent. NON costruire ora.

--- a/docs/playtest/canonical-suite.yaml
+++ b/docs/playtest/canonical-suite.yaml
@@ -1,0 +1,65 @@
+# Canonical AI-driven playtest suite manifest
+# SoT method: docs/process/CANONICAL-AI-PLAYTEST.md
+# Machine-readable list of canonical scenarios + ratified bands + run config.
+# Paradigm (2026-05-29): AI-driven multi-policy = gate/oracle; human = optional.
+version: 1
+last_verified: "2026-05-29"
+
+# N-ladder (L-069/L-073): 10 probe (+-30pp) / 40 ratify (+-15pp) / 100 forensic (+-10pp)
+n_ladder:
+  probe: 10
+  ratify: 40
+  forensic: 100
+
+# Multi-policy triangulation (Jaffe 2012). Human WR ~= band [random, strong].
+policies: [random, greedy, lookahead2, utility]
+human_wr_formula: "greedy_WR*0.55 + lookahead_WR*0.45"  # tunable if optional human data arrives
+
+# Reproducibility contract (see CANONICAL-AI-PLAYTEST.md sec 3)
+repro:
+  host: "http://127.0.0.1"      # NOT localhost (IPv6 ::1 stall on Windows)
+  lobby_ws_enabled: false       # per-shard, port collision (L-071)
+  damage_curves_path_required: true   # client must read backend staging file (L-069/OD-032)
+  seed_pinned: false            # GAP -> TKT-PLAYTEST-SEED (bit-identical repro pending)
+  config_source: data/core/balance/damage_curves.yaml
+  scenario_spawn_source: apps/backend/services/hardcoreScenario.js
+
+# Composite metric (anti false-balanced)
+composite_metric: "0.50*win_rate + 0.25*kd_ratio + 0.25*pe_ratio"
+
+scenarios:
+  - id: enc_tutorial_06_hardcore
+    role: balance_oracle
+    target_band: [0.15, 0.25]
+    ratified_knob: { boss_hp_multiplier: 0.65 }
+    last_wr_n40: "0.15-0.25"
+    status: ratified
+    tool: tools/py/batch_calibrate_hardcore06.py
+    port: 3340
+    note: "iter3 turn_limit_defeat null = overshoot WR 0.85 REJECTED. Source #2381 ratify."
+
+  - id: enc_tutorial_07_hardcore_pod_rush
+    role: balance_oracle
+    target_band: [0.30, 0.50]
+    ratified_knob: { enemy_damage_multiplier_override: 2.1 }   # REPLACES class 1.8, not stack
+    last_wr_n40: "0.30-0.40"
+    status: in_band
+    tool: tools/py/batch_calibrate_hardcore07.py
+    port: 3334
+    note: "post wave 5-7 nerf (6 traits cost_ap 1->2) = -40-60pp WR. Timer-driven scenario."
+
+  - id: enc_tutorial_01_05
+    role: designed_winnable_ladder
+    target_band: null
+    status: not_balance_oracle
+    tool: tools/py/batch_calibrate_*.py
+    note: "Tutorial = learning ladder, designed-winnable (greedy ~100% WR). NOT a difficulty target."
+
+# Canonical run (parallel, ~10min N=40). Suite-runner = TKT-PLAYTEST-SUITE (pending smoke).
+run_canonical: |
+  python tools/py/calibrate_parallel.py --scenario hardcore_06 --n 40 --shards 4 --base-port 3341
+  python tools/py/calibrate_parallel.py --scenario hardcore_07 --n 40 --shards 4 --base-port 3341
+
+gate:
+  merge: "AI regression tests/ai/*.test.js green AND touched-scenario WR in-band @ N=40 AND no crash/contract-ripple"
+  human_playtest: "OPTIONAL confirmation, never blocking"

--- a/docs/process/2026-04-26-calibration-harness-policy.md
+++ b/docs/process/2026-04-26-calibration-harness-policy.md
@@ -2,9 +2,10 @@
 title: Calibration harness policy — diagnostic, not merge gate
 workstream: ops-qa
 category: process
-doc_status: draft
+doc_status: superseded
 doc_owner: claude-code
-last_verified: '2026-04-26'
+last_verified: '2026-05-29'
+superseded_by: docs/process/CANONICAL-AI-PLAYTEST.md
 source_of_truth: false
 language: it
 review_cycle_days: 90
@@ -21,6 +22,13 @@ related:
 ---
 
 # Calibration Harness Policy — Diagnostic, Not Merge Gate
+
+> **SUPERSEDED 2026-05-29** da [`CANONICAL-AI-PLAYTEST.md`](CANONICAL-AI-PLAYTEST.md).
+> Il **gate-stance e' INVERTITO**: l'harness AI-driven (multi-policy, N=40) ORA E' il
+> merge gate/oracolo; il playtest umano e' conferma opzionale, NON il gate. Le sezioni
+> "Harness != merge gate" e "Oracolo vero = playtest live umano" qui sotto sono
+> **storiche/declassate**. La **metodologia** (Restricted-Play triangulation, predictCombat,
+> composite metric, smart policy) resta valida ed e' assorbita nel doc canonical.
 
 **Stato**: 🟡 DRAFT (M14-C follow-up, pending master-dd approval)  
 **Trigger**: sessione 2026-04-26 iter3-iter5 hardcore_06 post-elevation = 30+ min di loop edit→backend→harness senza convergenza. User feedback: "stiamo perdendo un sacco di tempo".

--- a/docs/process/CANONICAL-AI-PLAYTEST.md
+++ b/docs/process/CANONICAL-AI-PLAYTEST.md
@@ -1,0 +1,183 @@
+---
+title: "Canonical AI-driven playtest — single reproducible best-test (SoT)"
+workstream: ops-qa
+category: process
+doc_status: active
+doc_owner: claude-code
+last_verified: "2026-05-29"
+source_of_truth: true
+language: it
+review_cycle_days: 90
+tags: [playtest, calibration, ai-driven, balance, reproducible, sot]
+supersedes:
+  - docs/process/2026-04-26-calibration-harness-policy.md (gate-stance flipped; methodology absorbed)
+---
+
+# Canonical AI-driven Playtest — single reproducible best-test
+
+> **SoT del metodo di playtest.** Decisione master-dd 2026-05-29: i playtest sono
+> **AI-driven** (batch-sim win-rate su N), come fatto finora. Il playtest umano NON
+> e' piu' il gate/oracolo: e' **conferma opzionale**, mai bloccante. Questo doc
+> **inverte** la policy `2026-04-26-calibration-harness-policy.md` ("oracolo vero =
+> playtest live umano") e ne **assorbe la metodologia** (Restricted-Play, predictCombat,
+> composite metric). E' la summa dei playtest fatti + i migliori metodi dalle ricerche.
+
+## 0. Paradigma (flip 2026-05-29)
+
+| Prima (superseded) | Ora (canonical) |
+|---|---|
+| Harness AI = diagnostic, NON merge gate | **Harness AI = gate**: WR in-band a N=40 + test verdi = merge OK |
+| Oracolo vero = playtest live umano (4 amici TV+phone) | **Oracolo = AI-driven multi-policy**; human = conferma opzionale, mai bloccante |
+| Sim = scaffold, humans = ground truth | Sim multi-policy + telemetria = ground truth riproducibile |
+
+Razionale: il playtest umano 4-amici e' raro, non-riproducibile, e ha bloccato sprint
+per settimane (TKT-M11B-06). L'AI-driven e' riproducibile **ogni volta**, scala, ed e'
+gia' il metodo de-facto (tutti i dati ratify sotto vengono da li').
+
+## 1. Il metodo (summa)
+
+### 1.1 Multi-policy triangulation (Jaffe 2012) — l'upgrade chiave
+
+NON usare single greedy come proxy-umano (anti-pattern, rejected da Jaffe 2012 +
+Politowski 2023). Il best-test gira **>=3 policy** e produce una **banda** WR:
+
+| Policy | Ruolo | Sorgente |
+|---|---|---|
+| `random` | noise floor (WR minimo) | baseline |
+| `greedy` | ceiling locale (atk-closest, focus-fire) | attuale default batch |
+| `lookahead2` | tactical awareness | da wire |
+| `utility` | smart brain | `apps/backend/services/ai/utilityBrain.js` (opt-in `ai_profile: aggressive`) |
+
+Human WR stimato ~= banda `[random_WR, strong_WR]`. Banda larga = skill-dominated
+(posizionamento conta); stretta = luck-dominated (tune variance). Formula iniziale
+`greedy_WR*0.55 + lookahead_WR*0.45` (tunabile se/quando arrivano dati human opzionali).
+
+### 1.2 N-ladder (autorita' L-069/L-070/L-072/L-073)
+
+| Fase | N | CI95 WR | Quando |
+|---|---|---|---|
+| **Probe** | 10 | ±30pp | direzione del delta (NON band-placement). Mai claim upgrade da N=10 |
+| **Ratify** | 40 | ±15pp | **gate decisionale** band-placement |
+| **Forensic** | 100 | ±10pp | cross-scenario fairness / metagame lock |
+
+Regole dure: N=10 = solo direzione (segno robusto, magnitudo rumorosa). MAI catene
+iter1/iter2/iter3 di N=10 (rumore compounding). Un N=40 > tre N=10. Optimizer
+(Optuna/Bayesian/MAP-Elites) objective N **deve** essere >= ratify threshold (40),
+altrimenti converge a rumore (L-073).
+
+### 1.3 Diagnosis metric-first (prima di toccare knob)
+
+`win_rate` dice SE sei fuori band, non PERCHE'. Diagnosi prima:
+
+| Sintomo | Causa | Knob |
+|---|---|---|
+| WR alto + boss residual >50% | survivability | enemy DPR / HP party |
+| WR alto + boss residual <10% | DPR insufficiente nemico | enemy_damage_multiplier |
+| Timeout 100% + turns=max | timer | turn_limit_defeat |
+| WR ~target ma KD estremo | swingy | variance |
+
+Composite metric (anti falso-"balanced"): `0.50*WR + 0.25*KD_ratio + 0.25*PE_ratio`.
+Metriche gia' emesse: `boss_hp_remaining_avg_on_loss`, `kd_avg`, `dmg_dealt_avg`.
+
+### 1.4 Multi-knob discipline (L-070/L-072)
+
+Cambiare knob A per fix M2 quando knob B ha gia' ottimizzato M1, senza simulare joint
+effect = overshoot. Evidenza: hardcore_06 iter3 (`turn_limit null` sopra boss_hp 0.65)
+= WR 85% catastrofico. Regola: N=10 probe TRA i cambi knob; predici interazione
+qualitativa prima di applicare due knob insieme.
+
+### 1.5 predictCombat O(1) pre-check
+
+Prima di ogni batch (costoso): `predictCombat(actor, target, n=1000)` in
+`apps/backend/routes/sessionHelpers.js:171` (enumera 20 facce d20, no HTTP, deterministico)
+-> se `avg_dmg * rounds_avg > player_hp_pool` la config e' rotta, skip il batch.
+
+## 2. Tooling (esistente, riusabile)
+
+| Tool | Cosa | Invocazione |
+|---|---|---|
+| `tools/py/batch_calibrate_hardcore06.py` | WR runner HC06 | `--host http://127.0.0.1:3340 --encounter-class hardcore --n 40 --out <json>` |
+| `tools/py/batch_calibrate_hardcore07.py` | WR runner HC07 (timer) | `--host http://127.0.0.1:3334 --n 40 --out <json>` |
+| `tools/py/batch_calibrate_non_elim.py` / `_skiv_solo_pack.py` | altri scenari | analogo |
+| `tools/py/calibrate_parallel.py` | 4-shard parallel | `--scenario hardcore_06 --n 40 --shards 4 --base-port 3341` (~10min vs ~36min serial) |
+| `tools/py/calibrate_drift_verify.py` | N=10 probe -> auto-escalate N=40 | `--scenario hardcore_06 --target-band 15-25` |
+| `tools/py/sprt_calibrate.py` | Stockfish SPRT early-stop | `--scenario <s> --target-low 0.30 --target-high 0.50 --n-max 80` |
+| `tools/py/playtest_2_analyzer.py` | aggregatore JSONL telemetry | post-run |
+| `.claude/agents/balance-illuminator.md` | agent: encoda tutto (calibration + research mode) | invoke |
+
+Optimizer/search (research-tier, primary-sourced in `balance-illuminator.md`): SPRT,
+MCTS smart playout, MAP-Elites QD, Bayesian (Optuna/Ax, N>=40/trial), LLM-as-critic
+(TITAN 2025). Vedi anche `docs/research/2026-05-20-calibration-knob-patterns-industry.md`.
+
+## 3. Contratto di riproducibilita' ("ogni volta")
+
+Per risultati ri-ottenibili:
+
+1. **Config pinned**: `data/core/balance/damage_curves.yaml` (`scenario_overrides` + `target_bands`) e `apps/backend/services/hardcoreScenario.js`. Knob change = restart shard.
+2. **`DAMAGE_CURVES_PATH` set**: il client DEVE leggere lo stesso staging file del backend, altrimenti gli override sono SILENT NO-OP client-side (bug L-069/OD-032).
+3. **`LOBBY_WS_ENABLED=false`** per ogni shard parallel (collisione porta WS, L-071). Porte shard deterministiche (base 3341 + offset).
+4. **Host `127.0.0.1` NON "localhost"** (Windows risolve IPv6 ::1 prima -> stall ~2s/call).
+5. **SEED RNG pinnato** — **GAP APERTO**: i batch attuali NON pinnano il seed (run non bit-identici). Per "ogni volta" bit-identico serve `--seed` (vedi `TKT-PLAYTEST-SEED`). Finche' non wired, riproducibilita' = statistica (stessa banda a N=40), non bit-identica.
+6. **Policy fissate**: il set multi-policy (1.1) e' parte del contratto, non ad-hoc.
+7. **Output archiviato**: `docs/playtest/YYYY-MM-DD-<scenario>-<phase>.json` + report `docs/playtest/YYYY-MM-DD-<scenario>-illuminator.md`.
+
+## 4. Scenari canonici + bande ratificate (stato 2026-05-29)
+
+Manifest macchina-leggibile: [`docs/playtest/canonical-suite.yaml`](../playtest/canonical-suite.yaml).
+
+| Scenario | Band target | Knob ratificato | WR (N=40) | Stato |
+|---|---|---|---|---|
+| `enc_tutorial_06_hardcore` | 15-25% | `boss_hp_multiplier: 0.65` | 15-25% (iter2 + #2381) | RATIFIED. iter3 `turn_limit null` = overshoot 85% REJECTED |
+| `enc_tutorial_07_hardcore_pod_rush` | 30-50% | `enemy_damage_multiplier_override: 2.1` (REPLACE class 1.8) | 30-40% (post-wave 5-7 nerf) | IN-BAND |
+| `enc_tutorial_01..05` | designed-winnable | n/a | ~100% greedy | NON balance-oracle (ladder di apprendimento) |
+
+Fonte knob: `data/core/balance/damage_curves.yaml`. Fonte dati: `docs/playtest/2026-05-20-*`, `2026-05-21-*`, `2026-05-26-ratify-2381-balance.md`.
+
+## 5. Gate policy (canonical)
+
+**Merge gate** (sostituisce "harness != gate"):
+- AI regression `tests/ai/*.test.js` verde (obbligatorio).
+- Scenario toccato: WR **in-band a N=40** (multi-policy) — ratify gate.
+- No crash / no contract-ripple.
+
+**Human playtest = conferma OPZIONALE**, mai bloccante. Se gira (G7 RC o quando capita)
+= un singolo re-tune iter, non un blocco. Telemetria JSONL via `POST /api/session/telemetry`
++ `playtest-analyzer` se ci sono dati human, ma la loro assenza NON blocca nulla.
+
+## 6. Comando canonico (finche' il suite-runner non e' wired)
+
+Riproduce lo stato ratificato (N=40 parallel, ~10min):
+
+```bash
+# prereq: backend buildabile; staging damage_curves pinned
+python tools/py/calibrate_parallel.py --scenario hardcore_06 --n 40 --shards 4 --base-port 3341
+python tools/py/calibrate_parallel.py --scenario hardcore_07 --n 40 --shards 4 --base-port 3341
+# verifica: WR HC06 in [0.15,0.25], HC07 in [0.30,0.50]
+```
+
+Suite-runner unico (`tools/py/playtest_canonical.py`, gira tutto il manifest a N=40 +
+report datato + seed-pin) = **TKT-PLAYTEST-SUITE** (da scaffoldare + smoke, anti-pattern
+#9: non shippato non-testato).
+
+## 7. Backlog (gap -> ticket)
+
+- **TKT-PLAYTEST-SEED**: `--seed` pin RNG nei batch_calibrate_* per riproducibilita' bit-identica.
+- **TKT-PLAYTEST-TRIANGULATE**: wire multi-policy `--policy {random,greedy,lookahead2,utility}` (~4h, stub gia' in policy doc superseded).
+- **TKT-PLAYTEST-SUITE**: `playtest_canonical.py` orchestratore summa (manifest -> N=40 parallel -> report datato). Smoke-gated.
+
+## 8. Supersedes / flag (paradigma human-oracle declassato)
+
+Questi riferimenti al playtest umano come gate/oracolo sono **declassati a opzionale**:
+- `docs/process/2026-04-26-calibration-harness-policy.md` (`status: superseded`, gate-stance invertita)
+- `docs/adr/ADR-2026-05-18-df-levels-integration-direction.md` gate (a) — ora AI-driven
+- `docs/adr/ADR-2026-05-18-sistema-persistent-state-learning.md` gate ratify — ora AI-driven
+- `BACKLOG.md` TKT-M11B-06 / "Playtest #2 userland 4 amici" — declassato
+- `CLAUDE.md` / `COMPACT_CONTEXT.md` (Game) sprint-context "4 amici" gate — flag: vedi questo doc
+- `docs/planning/EVO_FINAL_DESIGN_MILESTONES_AND_GATES.md` G7 RC sign-off — resta milestone RC, NON gate-dev
+
+## Riferimenti
+
+- Metodologia: `.claude/agents/balance-illuminator.md` (calibration + research) + `docs/research/2026-05-20-calibration-knob-patterns-industry.md`
+- Lezioni: L-069 (N=10 noise) / L-070 (multi-knob overshoot) / L-072 (direction-probe bisection) / L-073 (optimizer-on-noise) — `~/aa01/learnings/`
+- Papers: Jaffe AIIDE 2012 (Restricted Play), Politowski IEEE CoG 2023, Fontaine 2019 (MAP-Elites Hearthstone), Stockfish SPRT/Fishtest
+- Tooling: `tools/py/calibrate_*.py` + `batch_calibrate_*.py`


### PR DESCRIPTION
Paradigma **flip** (master-dd 2026-05-29): i playtest sono **AI-driven** (batch-sim WR multi-policy), come fatto finora. Human playtest = conferma **opzionale**, mai bloccante.

## Nuovo (la "summa")
- `docs/process/CANONICAL-AI-PLAYTEST.md` (SoT) — metodo canonico riproducibile: N-ladder (10 probe / 40 ratify / 100 forensic, L-069/L-073), **multi-policy triangulation** (Restricted-Play, Jaffe 2012 — l'upgrade vs single-greedy), diagnosis-metric-first, composite metric, predictCombat O(1) pre-check, contratto riproducibilita' (config-pin + seed-pin gap + env), gate-policy, dati ratificati.
- `docs/playtest/canonical-suite.yaml` — manifest macchina-leggibile (scenario -> band -> knob -> comando).

## Flip dei blocchi human-playtest
- `docs/process/2026-04-26-calibration-harness-policy.md` -> **superseded** (gate-stance invertita: "harness != gate" + "oracolo = human" declassati; metodologia assorbita).
- ADR `DF-levels` gate (a) + `Sistema S7` gate -> playtest **AI-driven canonico** (era "4-umani TV+phone, sign-off" che avevo scritto io = il blocco da correggere).
- `BACKLOG.md`: "Playtest #2 userland 4 amici" + "V6 <- TKT-M11B-06" declassati a opzionale. + 3 ticket: `TKT-PLAYTEST-SEED` (repro bit-identica), `TKT-PLAYTEST-TRIANGULATE` (multi-policy), `TKT-PLAYTEST-SUITE` (runner unico, smoke-gated).
- `COMPACT_CONTEXT.md`: "unico bloccante P5" + "hard final gated" -> AI-driven canonical.

## Dati recuperati (ratificati, fonte dei band)
- `enc_tutorial_06_hardcore` [15-25%]: `boss_hp_multiplier 0.65` (iter2 + #2381). iter3 turn_limit null = overshoot 85% REJECTED.
- `enc_tutorial_07_hardcore_pod_rush` [30-50%]: `enemy_damage_multiplier_override 2.1` (post wave 5-7 nerf).
- tutorial 1-5: designed-winnable (non balance-oracle).

## Non shippato (anti-pattern #9)
Lo script orchestratore `playtest_canonical.py` NON e' shippato (serve smoke con backend up ~10min) -> ticket `TKT-PLAYTEST-SUITE`. Finche' non wired, run via `calibrate_parallel.py` (comando nel doc).

## Note scope
Game `CLAUDE.md` ha solo refs soft-narrative ("prossima frontiera P5 playtest live"), nessun hard-gate -> declassato via la sezione Supersedes del doc canonical (non inline-edit del file enorme self-gov). `seed-pin` = gap riproducibilita' "ogni volta" bit-identica (oggi: statistica a N=40).

Verifica: `check_docs_governance --strict` errors=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
