### PR TITLE
docs: integrate games list into SoT + method-docs reflect AI-playtest

### DIFF
--- a/.claude/agents/balance-illuminator.md
+++ b/.claude/agents/balance-illuminator.md
@@ -264,7 +264,7 @@ Prima di ogni analisi, leggi in questo ordine:
 3. **Scenario spec**: `apps/backend/services/{hardcoreScenario,tutorialScenario}.js`
 4. **Damage curves + bands**: `data/core/balance/damage_curves.yaml` (target bands per encounter_class)
 5. **Historical playtest docs**: `docs/playtest/*.md`
-6. **ADR history**: `ADR-2026-04-20-damage-scaling-curves.md`, `ADR-2026-04-26-calibration-harness-policy.md`
+6. **ADR history**: `ADR-2026-04-20-damage-scaling-curves.md`, `ADR-2026-04-26-calibration-harness-policy.md` (SUPERSEDED 2026-05-29 -> `docs/process/CANONICAL-AI-PLAYTEST.md`: gate-policy flippata, harness AI-driven multi-policy = gate/oracolo, playtest umano = opzionale)
 7. **CLAUDE.md claims**: solo sanity cross-check, mai autoritativo
 
 ## Execution flow

--- a/docs/adr/ADR-2026-05-18-df-levels-integration-direction.md
+++ b/docs/adr/ADR-2026-05-18-df-levels-integration-direction.md
@@ -96,7 +96,9 @@ ADR dichiara di combattere).
 Verdetto: **SHIPPED** (fatto, drop) | **GATED** (open ma bloccato da decisione) |
 **GREENFIELD** (non-costruito, feature ordinaria se voluta) | **REF**
 (reference/validatore, no feature) | **ANTI** (rifiuto esplicito).
-Catalogo completo "cosa prendi/cosa NO" prosa = DESIGN_DIGEST §11. Qui = decisione.
+Catalogo studiato (studio+feature+pilastro+depth) = SoT registrato `docs/guide/games-source-index.md`.
+Catalogo "cosa prendi/cosa NO" prosa = DESIGN_DIGEST §11. Qui = **DF-level + verdetto** governato
+(de-dup: NON ripetere il catalogo — feature/pilastro in games-source-index, verdetto-di-build qui).
 
 ### A — Pillar tier
 

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -3681,6 +3681,19 @@
       "track": "migrated"
     },
     {
+      "path": "docs/guide/games-source-index.md",
+      "title": "Games Source Index — catalogo giochi-fonte + ricerche (SoT)",
+      "doc_status": "active",
+      "doc_owner": "platform-docs",
+      "workstream": "cross-cutting",
+      "last_verified": "2026-05-29",
+      "source_of_truth": true,
+      "language": "it-en",
+      "review_cycle_days": 90,
+      "primary": false,
+      "track": "migrated"
+    },
+    {
       "path": "docs/guide/external-references.md",
       "title": "Risorse esterne curate — Game Design Reference",
       "doc_status": "active",

--- a/docs/guide/games-source-index.md
+++ b/docs/guide/games-source-index.md
@@ -4,7 +4,7 @@ doc_status: active
 doc_owner: platform-docs
 workstream: cross-cutting
 last_verified: '2026-05-29'
-source_of_truth: false
+source_of_truth: true
 language: it-en
 review_cycle_days: 90
 ---
@@ -412,6 +412,23 @@ Index canonico museum: [docs/museum/MUSEUM.md](../museum/MUSEUM.md).
 - Trigger review: nuovo pilastro stato change (🔴→🟡→🟢) → re-check top-3 source per pillar relevance
 
 ---
+
+## Relazione con SoT governato
+
+Questo catalogo e' **source-of-truth governato** (registrato in
+`docs/governance/docs_registry.json`, `source_of_truth: true`, review-cycle 90gg): la
+lista giochi-fonte non e' piu' un doc laterale che va stale (drift 2026-05-29: Pokopia
++ Dwarf Fortress mancanti = root-cause maintenance-protocol non seguito). Relazioni:
+
+- **DF-Levels matrix** ([ADR-2026-05-18-df-levels](../adr/ADR-2026-05-18-df-levels-integration-direction.md)):
+  aggiunge la dimensione **L0-L5 + verdetto governato** (SHIPPED/GATED/GREENFIELD/REF/ANTI).
+  De-dup: studio+feature+pilastro+depth = QUI (catalogo SoT); DF-level + verdetto-di-build = li'.
+- **Metodo playtest**: validazione dei pattern adottati = [playtest AI-driven canonico](../process/CANONICAL-AI-PLAYTEST.md)
+  (gate riproducibile multi-policy N=40), NON playtest umano.
+- **Mirror sovereign**: vault `Atlas/evo-tactics-*-moc.md` + `Cards/deep-research-evo-tactics/` = copia sovereign design-notes.
+
+Maintenance: nuovo gioco -> riga qui (protocollo sotto) E, se tocca direzione DF, riga
+nella matrix ADR. Currency check nel review-cycle 90gg (registry-tracked = niente piu' drift silenzioso).
 
 ## Riferimenti incrociati
 

--- a/docs/hubs/ops-qa.md
+++ b/docs/hubs/ops-qa.md
@@ -24,9 +24,11 @@ review_cycle_days: 14
 - [CI pipeline](../ci-pipeline.md)
 - [CI details](../ci.md)
 - [Observability](../observability.md)
+- [Canonical AI-driven playtest — SoT metodo](../process/CANONICAL-AI-PLAYTEST.md) + [suite manifest](../playtest/canonical-suite.yaml)
 
 ## Gate principali
 
 - quality checks definiti in `ci.yml`
 - `python tools/check_site_links.py docs`
 - `python tools/check_docs_governance.py`
+- **Playtest AI-driven canonico** (multi-policy, WR in-band a N=40) = balance gate riproducibile; playtest umano = conferma opzionale. SoT: `docs/process/CANONICAL-AI-PLAYTEST.md`


### PR DESCRIPTION
Completa il flip playtest (#2445) + **integra la lista giochi nel SoT governato** + aggiorna i method-doc.

## Lista giochi -> SoT
- `docs/guide/games-source-index.md`: `source_of_truth: false -> true` + **registrato in `docs/governance/docs_registry.json`** (review-cycle 90gg) -> ora e' un SoT tracciato, niente piu' drift silenzioso (root-cause: Pokopia + Dwarf Fortress mancanti, 2026-05-29).
- Nuova sezione "Relazione con SoT governato": de-dup esplicito vs **DF-levels matrix** (catalogo studio+feature+pilastro = qui; DF-level + verdetto = ADR), vault MOC (mirror sovereign), canonical-playtest (metodo).
- `ADR-2026-05-18-df-levels` matrix: cross-link de-dup -> games-source-index come catalogo SoT.

## Method-doc aggiornati ai nuovi metodi
- `docs/hubs/ops-qa.md` (hub SoT): aggiunto canonical AI-playtest doc + manifest + **gate AI-driven** nei Gate principali.
- `.claude/agents/balance-illuminator.md`: ref `calibration-harness-policy` marcata SUPERSEDED -> `CANONICAL-AI-PLAYTEST.md` (gate-policy flippata).

## Gap codice (NON in questo PR — backend-session)
Restano ticket sharp (no smoke possibile qui): `TKT-PLAYTEST-SEED` / `-TRIANGULATE` / `-SUITE` + worldgen `GAPA/B/C`. Tutti backend-dependent / behavior-critical -> Game-session con backend (anti-pattern #9/#11: no codice non-smoke-testato).

Verifica: `check_docs_governance --strict` errors=0 (games-index SoT registration: frontmatter==registry match, zero mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
