### PR TITLE
feat(worldgen): GAP-A foodweb filter + GAP-B cross-event pressure

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -130,6 +130,8 @@ const { loadTraitEnvironmentalCosts, applyBiomeEcoEffects } = require('../servic
 // pressure / enemy HP. Same encounter on savana vs abisso_vulcanico now
 // produces different numbers, not just different texture.
 const { getBiomeModifiers, applyEnemyHpMultiplier } = require('../services/combat/biomeModifiers');
+// TKT-WORLDGEN-GAPB (2026-05-29): seasonal cross-event flat pressure engine.
+const { getCrossEventPressureDelta } = require('../services/worldgen/crossEventEngine');
 // M6-#1 (ADR-2026-04-19 + spike 2026-04-19): Node native resistance engine.
 // Applica channel-specific resist/vuln su damage pre-hp. Evidence spike:
 // 84.6% → 20% win rate hardcore-06 con flat 50% resist (leva confermata).
@@ -1435,6 +1437,10 @@ function createSessionRouter(options = {}) {
       // (no-op multipliers, zero pressure bonus). Enemy HP scaled here so
       // downstream pipeline (objectives, balance) reads the modulated values.
       const biomeModifiers = getBiomeModifiers(biomeIdRaw);
+      // TKT-WORLDGEN-GAPB: seasonal cross-event flat pressure offset. No season in
+      // payload (e.g. hardcore scenarios) -> pressure_delta 0 -> WR bands unchanged.
+      const seasonRaw = req.body?.season || req.body?.encounter?.season || null;
+      const crossEvent = getCrossEventPressureDelta(biomeIdRaw, seasonRaw);
       if (biomeModifiers.hp_mult !== 1.0) {
         applyEnemyHpMultiplier(units, biomeModifiers.hp_mult);
       }
@@ -1601,7 +1607,8 @@ function createSessionRouter(options = {}) {
           Math.min(
             100,
             (Number(req.body?.sistema_pressure_start) || 0) +
-              Number(biomeModifiers.pressure_initial_bonus || 0),
+              Number(biomeModifiers.pressure_initial_bonus || 0) +
+              Number(crossEvent.pressure_delta || 0),
           ),
         ),
         // Hazard tiles dal scenario (es. enc_tutorial_03 fumarole).
@@ -1631,6 +1638,9 @@ function createSessionRouter(options = {}) {
         // + future UI hint. Consumed da round bridge (pressure_mult tick) e
         // applicato in applyEnemyHpMultiplier sopra (hp_mult).
         biome_modifiers: biomeModifiers,
+        // TKT-WORLDGEN-GAPB: seasonal cross-event surface (replay/HUD).
+        cross_events: crossEvent.events,
+        cross_event_hazards: crossEvent.hazards,
         // M1 ADR-2026-05-18 -- campaign scope for SistemaState persistence.
         campaign_id: req.body?.campaign_id || null,
         sistema_state: { units_observed: {} },

--- a/apps/backend/services/combat/reinforcementSpawner.js
+++ b/apps/backend/services/combat/reinforcementSpawner.js
@@ -27,6 +27,8 @@
 'use strict';
 
 const { computeSistemaTier } = require('../../routes/sessionHelpers');
+// TKT-WORLDGEN-GAPA (2026-05-29): foodweb whitelist filter for the spawn pool.
+const { filterReinforcementPool } = require('../worldgen/foodwebFilter');
 
 const DEFAULT_MIN_DISTANCE_FROM_PG = 3; // Manhattan
 const TIER_LABEL_ORDER = ['Calm', 'Alert', 'Escalated', 'Critical', 'Apex'];
@@ -152,7 +154,34 @@ function tick(session, encounter, opts = {}) {
   if (!policy || policy.enabled !== true) {
     return { spawned: [], budget_used: 0, skipped: true, reason: 'policy_disabled' };
   }
-  const pool = encounter?.reinforcement_pool;
+  // TKT-WORLDGEN-GAPA: filter the spawn pool to the encounter biome's foodweb
+  // (Caves of Qud whitelist). `pool` is bound to the filtered result, so both
+  // the ALIENA snapshot and the spawn loop below consume it. Kill switch:
+  // policy.foodweb_filter === false. Filter never empties the pool (fallback),
+  // so off-foodweb scenario pools (e.g. synthetic hardcore units) pass through
+  // unchanged -> WR bands unaffected.
+  const rawPool = encounter?.reinforcement_pool;
+  const foodwebBiomeId = encounter?.biome_id || encounter?.biome || session?.biome_id || null;
+  let foodwebMeta;
+  let pool;
+  if (policy.foodweb_filter === false) {
+    foodwebMeta = { applied: false, biome_id: foodwebBiomeId, excluded: [], reason: 'disabled' };
+    pool = rawPool;
+  } else {
+    foodwebMeta = filterReinforcementPool(rawPool, foodwebBiomeId);
+    pool = foodwebMeta.pool;
+  }
+  if (foodwebMeta.reason === 'filtered' || foodwebMeta.reason === 'all_excluded_fallback') {
+    // Gate-5 surface: developer/replay-visible record of foodweb pool shaping.
+    console.log(
+      JSON.stringify({
+        component: 'reinforcement-foodweb-filter',
+        biome_id: foodwebBiomeId,
+        reason: foodwebMeta.reason,
+        excluded: foodwebMeta.excluded,
+      }),
+    );
+  }
   const entryTiles = encounter?.reinforcement_entry_tiles;
   if (!Array.isArray(pool) || pool.length === 0) {
     return { spawned: [], budget_used: 0, skipped: true, reason: 'no_pool' };
@@ -269,6 +298,12 @@ function tick(session, encounter, opts = {}) {
     skipped: effective.length === 0,
     reason: effective.length === 0 ? 'no_tile_or_pool' : 'spawned',
     tier_at_tick: tier.label,
+    foodweb_filter: {
+      applied: foodwebMeta.applied,
+      biome_id: foodwebMeta.biome_id,
+      excluded: foodwebMeta.excluded,
+      reason: foodwebMeta.reason,
+    },
   };
 }
 

--- a/apps/backend/services/worldgen/crossEventEngine.js
+++ b/apps/backend/services/worldgen/crossEventEngine.js
@@ -1,0 +1,115 @@
+// Cross-event seasonal pressure engine — TKT-WORLDGEN-GAPB (2026-05-29).
+//
+// Consumes packs/evo_tactics_pack/data/ecosystems/network/cross_events.yaml
+// (seasonal cross-biome events) and computes a FLAT pressure offset for a
+// session's biome + season. Closes the Engine-LIVE / Surface-DEAD gap:
+// cross_events.yaml had ZERO runtime consumer before this.
+//
+// Pattern: Rimworld temperature-offset — a flat, bounded modifier, NOT an
+// ecological simulation (avoids the Ultima Online runtime-foodweb trap; see
+// docs/reports/2026-04-26-worldgen-pcg-audit.md).
+//
+// An event applies to a session when:
+//   - the session biome_id is in the event's `to_nodes` (affected biomes), AND
+//   - the event's `season` matches the session season.
+// Matching is case-insensitive (to_nodes are uppercase node ids, biome_id is
+// the lowercase slug). pressure_delta values sum across active events.
+//
+// API:
+//   getActiveCrossEvents(biomeId, season, opts?) -> [event]
+//   getCrossEventPressureDelta(biomeId, season, opts?) ->
+//     { pressure_delta, hazards: [string], events: [event_id] }
+//   _resetCache() — test seam.
+//
+// opts.events — injected event array (pure unit testing, skips file load).
+// opts.path   — override yaml path.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const CROSS_EVENTS_PATH = path.resolve(
+  __dirname,
+  '../../../../packs/evo_tactics_pack/data/ecosystems/network/cross_events.yaml',
+);
+
+let _cache = null;
+
+function _norm(value) {
+  return String(value == null ? '' : value)
+    .trim()
+    .toLowerCase();
+}
+
+function loadCrossEvents(opts = {}) {
+  if (_cache && !opts.force && !opts.path && !opts.events) return _cache;
+  const filePath = opts.path || CROSS_EVENTS_PATH;
+  let events = [];
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const parsed = yaml.load(raw);
+    events = Array.isArray(parsed && parsed.events) ? parsed.events : [];
+  } catch (err) {
+    console.warn('[crossEventEngine] load failed:', filePath, err.message);
+    events = [];
+  }
+  if (!opts.path && !opts.events) _cache = events;
+  return events;
+}
+
+function getActiveCrossEvents(biomeId, season, opts = {}) {
+  if (!biomeId || !season) return [];
+  const b = _norm(biomeId);
+  const s = _norm(season);
+  const events = Array.isArray(opts.events) ? opts.events : loadCrossEvents(opts);
+  return events.filter((e) => {
+    if (!e || _norm(e.season) !== s) return false;
+    const targets = Array.isArray(e.to_nodes) ? e.to_nodes.map(_norm) : [];
+    return targets.includes(b);
+  });
+}
+
+function getCrossEventPressureDelta(biomeId, season, opts = {}) {
+  const active = getActiveCrossEvents(biomeId, season, opts);
+  let pressureDelta = 0;
+  const hazards = [];
+  const ids = [];
+  for (const e of active) {
+    const d = Number(e.pressure_delta);
+    if (Number.isFinite(d)) pressureDelta += d;
+    if (e.hazard_modifier) hazards.push(e.hazard_modifier);
+    ids.push(e.species_id || e.id || 'unknown');
+  }
+  if (active.length > 0) {
+    // Gate-5 surface: developer/replay-visible record of seasonal cross-events.
+    try {
+      console.log(
+        JSON.stringify({
+          component: 'cross-event-engine',
+          biome_id: biomeId,
+          season,
+          events: ids,
+          pressure_delta: pressureDelta,
+          hazards,
+        }),
+      );
+    } catch {
+      /* logging best-effort */
+    }
+  }
+  return { pressure_delta: pressureDelta, hazards, events: ids };
+}
+
+function _resetCache() {
+  _cache = null;
+}
+
+module.exports = {
+  loadCrossEvents,
+  getActiveCrossEvents,
+  getCrossEventPressureDelta,
+  _resetCache,
+  CROSS_EVENTS_PATH,
+};

--- a/apps/backend/services/worldgen/ecosystemResolver.js
+++ b/apps/backend/services/worldgen/ecosystemResolver.js
@@ -1,0 +1,96 @@
+// Ecosystem trophic resolver — TKT-WORLDGEN-GAPA (2026-05-29).
+//
+// Read-only loader: maps a biome_id to the set of species in that biome's
+// trophic web, parsed from packs/evo_tactics_pack/data/ecosystems/*.ecosystem.yaml.
+// Consumed by foodwebFilter (spawn-pool whitelist). No writes, no generation.
+//
+// YAML shape (per file):
+//   ecosistema:
+//     id: BADLANDS
+//     biome_id: badlands
+//     trofico:
+//       produttori: [..]
+//       consumatori: { primari: [..], secondari: [..], terziari: [..] }
+//       decompositori: [..]
+//
+// `species_all` = flat union of every species across all trophic tiers. A
+// species present anywhere in a biome's foodweb is "of" that biome for the
+// whitelist. Producers (plants) are harmless to include — they never appear in
+// reinforcement pools.
+//
+// API:
+//   getEcosystem(biomeId) -> { biome_id, id, species_all: [string] } | null
+//   _resetCache()         — test seam (re-read from disk on next call)
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const ECOSYSTEMS_DIR = path.resolve(
+  __dirname,
+  '../../../../packs/evo_tactics_pack/data/ecosystems',
+);
+
+let _cache = null;
+
+function _pushAll(target, arr) {
+  if (!Array.isArray(arr)) return;
+  for (const s of arr) {
+    if (s) target.push(String(s).trim());
+  }
+}
+
+function _collectSpecies(trofico) {
+  if (!trofico || typeof trofico !== 'object') return [];
+  const out = [];
+  _pushAll(out, trofico.produttori);
+  const consumatori = trofico.consumatori;
+  if (consumatori && typeof consumatori === 'object') {
+    _pushAll(out, consumatori.primari);
+    _pushAll(out, consumatori.secondari);
+    _pushAll(out, consumatori.terziari);
+  }
+  _pushAll(out, trofico.decompositori);
+  return out;
+}
+
+function _load() {
+  if (_cache) return _cache;
+  const map = new Map();
+  let files = [];
+  try {
+    files = fs.readdirSync(ECOSYSTEMS_DIR).filter((f) => f.endsWith('.ecosystem.yaml'));
+  } catch (err) {
+    console.warn('[ecosystemResolver] dir read failed:', ECOSYSTEMS_DIR, err.message);
+  }
+  for (const f of files) {
+    try {
+      const raw = fs.readFileSync(path.join(ECOSYSTEMS_DIR, f), 'utf-8');
+      const parsed = yaml.load(raw);
+      const eco = parsed && parsed.ecosistema;
+      if (!eco || !eco.biome_id) continue;
+      map.set(String(eco.biome_id).trim().toLowerCase(), {
+        biome_id: eco.biome_id,
+        id: eco.id || null,
+        species_all: _collectSpecies(eco.trofico),
+      });
+    } catch (err) {
+      console.warn('[ecosystemResolver] parse failed:', f, err.message);
+    }
+  }
+  _cache = map;
+  return map;
+}
+
+function getEcosystem(biomeId) {
+  if (!biomeId) return null;
+  return _load().get(String(biomeId).trim().toLowerCase()) || null;
+}
+
+function _resetCache() {
+  _cache = null;
+}
+
+module.exports = { getEcosystem, _resetCache, ECOSYSTEMS_DIR };

--- a/apps/backend/services/worldgen/foodwebFilter.js
+++ b/apps/backend/services/worldgen/foodwebFilter.js
@@ -1,0 +1,77 @@
+// Foodweb spawn-pool filter — TKT-WORLDGEN-GAPA (2026-05-29).
+//
+// Wires the read-only `ecosystemResolver` (trophic data per biome) into a
+// reinforcement spawn-pool WHITELIST filter. Closes the Engine-LIVE /
+// Surface-DEAD gap: ecosystem.yaml trophic tiers existed but no runtime
+// consumed them.
+//
+// Pattern: Caves of Qud spawn whitelist (docs/reports/2026-04-26-worldgen-pcg-
+// audit.md). FILTER only -- never generates units. Excludes pool entries whose
+// species is NOT part of the encounter biome's foodweb (e.g. a cryosteppe
+// creature reinforcing a badlands battle).
+//
+// Band-safety guarantees (see TKT-WORLDGEN-GAPA + CANONICAL-AI-PLAYTEST):
+//   - No biome / no ecosystem data -> passthrough (unchanged behavior).
+//   - Filtering that would empty the pool -> fallback to the unfiltered pool
+//     (spawning is NEVER blocked by this filter).
+//   The canonical hardcore reinforcement pools are trophic-clean, so this
+//   filter removes nothing there -> WR bands unchanged.
+//
+// API:
+//   filterReinforcementPool(pool, biomeId, opts?) -> {
+//     pool,        // filtered array (or original on passthrough/fallback)
+//     applied,     // boolean: did the filter actually remove any entry?
+//     biome_id,
+//     excluded,    // [unit_id] removed (or would-be removed on fallback)
+//     reason,      // 'no_biome' | 'empty_pool' | 'no_ecosystem' |
+//                  // 'all_in_foodweb' | 'filtered' | 'all_excluded_fallback'
+//   }
+//
+// opts.getEcosystem -- injectable resolver (default ecosystemResolver.getEcosystem)
+//   for pure unit testing.
+
+'use strict';
+
+const ecosystemResolver = require('./ecosystemResolver');
+
+function _norm(value) {
+  return String(value == null ? '' : value).trim();
+}
+
+function filterReinforcementPool(pool, biomeId, opts = {}) {
+  if (!Array.isArray(pool) || pool.length === 0) {
+    return { pool, applied: false, biome_id: biomeId || null, excluded: [], reason: 'empty_pool' };
+  }
+  if (!biomeId) {
+    return { pool, applied: false, biome_id: null, excluded: [], reason: 'no_biome' };
+  }
+
+  const getEcosystem =
+    typeof opts.getEcosystem === 'function' ? opts.getEcosystem : ecosystemResolver.getEcosystem;
+  const eco = getEcosystem(biomeId);
+  if (!eco || !Array.isArray(eco.species_all) || eco.species_all.length === 0) {
+    return { pool, applied: false, biome_id: biomeId, excluded: [], reason: 'no_ecosystem' };
+  }
+
+  const whitelist = new Set(eco.species_all.map(_norm));
+  const kept = [];
+  const excluded = [];
+  for (const entry of pool) {
+    const id = _norm(entry && entry.unit_id);
+    if (whitelist.has(id)) kept.push(entry);
+    else excluded.push(id);
+  }
+
+  if (kept.length === 0) {
+    // Band-safety: a whitelist that excludes everything would block spawning
+    // entirely and silently change combat difficulty. Fall back to the
+    // unfiltered pool instead (the caller surfaces this via telemetry/log).
+    return { pool, applied: false, biome_id: biomeId, excluded, reason: 'all_excluded_fallback' };
+  }
+  if (excluded.length === 0) {
+    return { pool, applied: false, biome_id: biomeId, excluded: [], reason: 'all_in_foodweb' };
+  }
+  return { pool: kept, applied: true, biome_id: biomeId, excluded, reason: 'filtered' };
+}
+
+module.exports = { filterReinforcementPool };

--- a/packs/evo_tactics_pack/data/ecosystems/network/cross_events.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/network/cross_events.yaml
@@ -1,3 +1,7 @@
+# encoding-non-ascii-ok: pre-existing Italian effect descriptions (accented prose)
+# TKT-WORLDGEN-GAPB (2026-05-29): added season + pressure_delta + hazard_modifier
+# so crossEventEngine applies a flat seasonal pressure offset to each affected
+# biome (to_nodes). FLAT modifier (Rimworld temperature-offset), not a sim.
 schema_version: 1.0
 events:
   - species_id: evento-tempesta-ferrosa
@@ -9,8 +13,10 @@ events:
     to_nodes:
       - FORESTA_TEMPERATA
       - DESERTO_CALDO
-    effect: polveri ferrose e carica magnetica, penalità visibilità/gear 
-      metallico
+    effect: polveri ferrose e carica magnetica, penalità visibilità/gear metallico
+    season: autumn
+    pressure_delta: 2
+    hazard_modifier: metal_gear_visibility
   - species_id: evento-ondata-termica
     from_nodes:
       - DESERTO_CALDO
@@ -19,6 +25,9 @@ events:
     to_nodes:
       - BADLANDS
     effect: ondata di calore e ionizzazione, stress termico esteso
+    season: summer
+    pressure_delta: 2
+    hazard_modifier: thermal_stress
   - species_id: evento-brinastorm
     from_nodes:
       - CRYOSTEPPE
@@ -29,3 +38,6 @@ events:
       - FORESTA_TEMPERATA
       - BADLANDS
     effect: ghiaccio fine in sospensione, visibilità ridotta e attrito aumentato
+    season: winter
+    pressure_delta: 1
+    hazard_modifier: ice_friction

--- a/tests/services/reinforcementSpawner.test.js
+++ b/tests/services/reinforcementSpawner.test.js
@@ -6,6 +6,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 const { tick, _internals } = require('../../apps/backend/services/combat/reinforcementSpawner');
+const ecosystemResolver = require('../../apps/backend/services/worldgen/ecosystemResolver');
 
 function mockSession(overrides = {}) {
   return {
@@ -314,4 +315,98 @@ test('_internals: tierMeetsMin', () => {
   assert.equal(_internals.tierMeetsMin('Calm', 'Alert'), false);
   assert.equal(_internals.tierMeetsMin('Apex', 'Escalated'), true);
   assert.equal(_internals.tierMeetsMin('Unknown', 'Alert'), true); // permissive fallback
+});
+
+// --- TKT-WORLDGEN-GAPA: foodweb spawn-pool whitelist filter ---
+
+const gapaFarEntryTiles = [
+  [9, 9],
+  [8, 9],
+  [9, 8],
+  [8, 8],
+];
+
+test('GAP-A: band-neutral on trophic-clean badlands pool (excluded empty)', () => {
+  ecosystemResolver._resetCache();
+  const session = mockSession({ pressure: 30 }); // Alert -> budget 1
+  const enc = mockEncounter({
+    biome_id: 'badlands',
+    reinforcement_pool: [
+      { unit_id: 'rust-scavenger', weight: 2, max_spawns: 5, hp: 8 },
+      { unit_id: 'sand-burrower', weight: 2, max_spawns: 5, hp: 7 },
+      { unit_id: 'echo-wing', weight: 1, max_spawns: 5, hp: 6 },
+    ],
+    reinforcement_entry_tiles: gapaFarEntryTiles,
+  });
+  const res = tick(session, enc, { rng: () => 0.1 });
+  assert.ok(res.foodweb_filter);
+  assert.deepEqual(res.foodweb_filter.excluded, []); // nothing removed -> WR bands unchanged
+  assert.equal(res.foodweb_filter.applied, false);
+  assert.ok(res.spawned.length > 0);
+});
+
+test('GAP-A: excludes off-biome species from spawn pool', () => {
+  ecosystemResolver._resetCache();
+  const session = mockSession({ pressure: 30 });
+  const enc = mockEncounter({
+    biome_id: 'badlands',
+    reinforcement_pool: [
+      { unit_id: 'rust-scavenger', weight: 5, max_spawns: 5, hp: 8 }, // badlands consumer
+      { unit_id: 'cryo-lynx', weight: 5, max_spawns: 5, hp: 8 }, // cryosteppe -- filtered out
+    ],
+    reinforcement_entry_tiles: gapaFarEntryTiles,
+  });
+  // rng biased to the LAST entry: a broken filter would spawn cryo-lynx.
+  const res = tick(session, enc, { rng: () => 0.99 });
+  assert.equal(res.foodweb_filter.applied, true);
+  assert.ok(res.foodweb_filter.excluded.includes('cryo-lynx'));
+  assert.ok(res.spawned.length > 0);
+  assert.ok(res.spawned.every((s) => s.unit_id === 'rust-scavenger'));
+});
+
+test('GAP-A: hardcore_07 off-foodweb pool -> all_excluded_fallback (pool preserved, band-safe)', () => {
+  ecosystemResolver._resetCache();
+  const session = mockSession({ pressure: 30 });
+  // rovine_planari foodweb does NOT contain these synthetic combat units, so
+  // the filter would empty the pool -> fallback preserves it unchanged.
+  const enc = mockEncounter({
+    biome_id: 'rovine_planari',
+    reinforcement_pool: [
+      { unit_id: 'cacciatore_corazzato', weight: 2, max_spawns: 3, hp: 8 },
+      { unit_id: 'predone_agile', weight: 3, max_spawns: 3, hp: 6 },
+    ],
+    reinforcement_entry_tiles: gapaFarEntryTiles,
+  });
+  const res = tick(session, enc, { rng: () => 0.5 });
+  assert.equal(res.foodweb_filter.reason, 'all_excluded_fallback');
+  assert.equal(res.foodweb_filter.applied, false);
+  assert.ok(res.spawned.length > 0); // pool preserved -> still spawns -> bands unchanged
+});
+
+test('GAP-A: kill switch (foodweb_filter:false) disables filter', () => {
+  ecosystemResolver._resetCache();
+  const session = mockSession({ pressure: 30 });
+  const enc = mockEncounter({
+    biome_id: 'badlands',
+    reinforcement_pool: [{ unit_id: 'cryo-lynx', weight: 1, max_spawns: 5, hp: 8 }], // off-biome, allowed
+    reinforcement_entry_tiles: gapaFarEntryTiles,
+    reinforcement_policy: {
+      enabled: true,
+      min_tier: 'Alert',
+      cooldown_rounds: 0,
+      max_total_spawns: 10,
+      foodweb_filter: false,
+    },
+  });
+  const res = tick(session, enc, { rng: () => 0 });
+  assert.equal(res.foodweb_filter.reason, 'disabled');
+  assert.ok(res.spawned.length > 0);
+});
+
+test('GAP-A: no biome_id -> filter passthrough (no_biome)', () => {
+  const session = mockSession({ pressure: 30 });
+  const enc = mockEncounter({ reinforcement_entry_tiles: gapaFarEntryTiles });
+  const res = tick(session, enc, { rng: () => 0.5 });
+  assert.equal(res.foodweb_filter.reason, 'no_biome');
+  assert.ok(res.spawned.length > 0);
 });

--- a/tests/worldgen/crossEventEngine.test.js
+++ b/tests/worldgen/crossEventEngine.test.js
@@ -1,0 +1,102 @@
+// Tests for crossEventEngine — TKT-WORLDGEN-GAPB (2026-05-29).
+//
+// Consumes cross_events.yaml (seasonal cross-biome events) and computes a FLAT
+// pressure offset for a session's biome + season (Rimworld temperature-offset
+// pattern, not an ecological sim). Real-data cases mirror cross_events.yaml:
+//   ondata-termica  -> to BADLANDS,                  season summer, pressure 2
+//   brinastorm      -> to FORESTA_TEMPERATA+BADLANDS, season winter, pressure 1
+//   tempesta-ferrosa-> to FORESTA_TEMPERATA+DESERTO_CALDO, season autumn, pressure 2
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const {
+  getActiveCrossEvents,
+  getCrossEventPressureDelta,
+  _resetCache,
+} = require('../../apps/backend/services/worldgen/crossEventEngine');
+
+test('crossEventEngine: no biome or season -> no events', () => {
+  assert.deepEqual(getActiveCrossEvents(null, 'summer'), []);
+  assert.deepEqual(getActiveCrossEvents('badlands', null), []);
+  assert.equal(getCrossEventPressureDelta(null, null).pressure_delta, 0);
+});
+
+test('crossEventEngine: real data badlands + summer -> ondata-termica (delta 2)', () => {
+  _resetCache();
+  const r = getCrossEventPressureDelta('badlands', 'summer');
+  assert.equal(r.pressure_delta, 2);
+  assert.ok(r.events.includes('evento-ondata-termica'));
+  assert.ok(r.hazards.includes('thermal_stress'));
+});
+
+test('crossEventEngine: real data badlands + winter -> brinastorm (delta 1)', () => {
+  _resetCache();
+  const r = getCrossEventPressureDelta('badlands', 'winter');
+  assert.equal(r.pressure_delta, 1);
+  assert.ok(r.events.includes('evento-brinastorm'));
+});
+
+test('crossEventEngine: real data badlands + autumn -> no matching event (delta 0)', () => {
+  _resetCache();
+  // tempesta-ferrosa (autumn) targets FORESTA_TEMPERATA + DESERTO_CALDO, not BADLANDS.
+  const r = getCrossEventPressureDelta('badlands', 'autumn');
+  assert.equal(r.pressure_delta, 0);
+  assert.deepEqual(r.events, []);
+});
+
+test('crossEventEngine: real data foresta_temperata + autumn -> tempesta-ferrosa (delta 2)', () => {
+  _resetCache();
+  const r = getCrossEventPressureDelta('foresta_temperata', 'autumn');
+  assert.equal(r.pressure_delta, 2);
+  assert.ok(r.events.includes('evento-tempesta-ferrosa'));
+});
+
+test('crossEventEngine: real data badlands + spring -> nothing (delta 0)', () => {
+  _resetCache();
+  const r = getCrossEventPressureDelta('badlands', 'spring');
+  assert.equal(r.pressure_delta, 0);
+});
+
+test('crossEventEngine: case-insensitive biome + season match', () => {
+  _resetCache();
+  const r = getCrossEventPressureDelta('BADLANDS', 'Summer');
+  assert.equal(r.pressure_delta, 2);
+});
+
+test('crossEventEngine: injected events (pure, no I/O)', () => {
+  const events = [
+    {
+      species_id: 'ev-a',
+      season: 'summer',
+      to_nodes: ['BADLANDS'],
+      pressure_delta: 3,
+      hazard_modifier: 'h1',
+    },
+    {
+      species_id: 'ev-b',
+      season: 'summer',
+      to_nodes: ['CRYOSTEPPE'],
+      pressure_delta: 5,
+    },
+  ];
+  const active = getActiveCrossEvents('badlands', 'summer', { events });
+  assert.equal(active.length, 1);
+  assert.equal(active[0].species_id, 'ev-a');
+  const r = getCrossEventPressureDelta('badlands', 'summer', { events });
+  assert.equal(r.pressure_delta, 3);
+  assert.deepEqual(r.hazards, ['h1']);
+});
+
+test('crossEventEngine: multiple active events sum pressure_delta', () => {
+  const events = [
+    { species_id: 'ev-a', season: 'summer', to_nodes: ['BADLANDS'], pressure_delta: 2 },
+    { species_id: 'ev-b', season: 'summer', to_nodes: ['BADLANDS'], pressure_delta: 3 },
+  ];
+  const r = getCrossEventPressureDelta('badlands', 'summer', { events });
+  assert.equal(r.pressure_delta, 5);
+  assert.equal(r.events.length, 2);
+});
+
+module.exports = {};

--- a/tests/worldgen/foodwebFilter.test.js
+++ b/tests/worldgen/foodwebFilter.test.js
@@ -1,0 +1,111 @@
+// Tests for foodwebFilter — TKT-WORLDGEN-GAPA (2026-05-29).
+//
+// Wires ecosystemResolver trophic data into a reinforcement spawn-pool
+// whitelist filter (Caves of Qud spawn-whitelist pattern). FILTER only,
+// never generation. Species names below are real catalog entries:
+//   badlands consumers: rust-scavenger, sand-burrower, echo-wing,
+//                        ferrocolonia-magnetotattica (badlands.ecosystem.yaml)
+//   off-biome (cryosteppe): cryo-lynx, steppe-bison-mini (cryosteppe.ecosystem.yaml)
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { filterReinforcementPool } = require('../../apps/backend/services/worldgen/foodwebFilter');
+const ecosystemResolver = require('../../apps/backend/services/worldgen/ecosystemResolver');
+
+test('foodwebFilter: no biome_id -> passthrough (applied false)', () => {
+  const pool = [{ unit_id: 'grunt', weight: 1 }];
+  const r = filterReinforcementPool(pool, null);
+  assert.equal(r.applied, false);
+  assert.equal(r.reason, 'no_biome');
+  assert.equal(r.pool, pool);
+});
+
+test('foodwebFilter: empty pool -> passthrough', () => {
+  const r = filterReinforcementPool([], 'badlands');
+  assert.equal(r.applied, false);
+  assert.equal(r.reason, 'empty_pool');
+});
+
+test('foodwebFilter: unknown biome (no ecosystem) -> passthrough', () => {
+  const pool = [{ unit_id: 'grunt', weight: 1 }];
+  const r = filterReinforcementPool(pool, 'no-such-biome', {
+    getEcosystem: () => null,
+  });
+  assert.equal(r.applied, false);
+  assert.equal(r.reason, 'no_ecosystem');
+  assert.equal(r.pool, pool);
+});
+
+test('foodwebFilter: real badlands trophic-clean pool -> no exclusions (BAND-NEUTRAL)', () => {
+  ecosystemResolver._resetCache();
+  const pool = [
+    { unit_id: 'rust-scavenger', weight: 2 },
+    { unit_id: 'sand-burrower', weight: 2 },
+    { unit_id: 'echo-wing', weight: 1 },
+    { unit_id: 'ferrocolonia-magnetotattica', weight: 1 },
+  ];
+  const r = filterReinforcementPool(pool, 'badlands');
+  assert.deepEqual(r.excluded, []);
+  assert.equal(r.pool.length, pool.length); // nothing removed -> bands unchanged
+  assert.equal(r.reason, 'all_in_foodweb');
+});
+
+test('foodwebFilter: off-biome species excluded, biome species kept', () => {
+  ecosystemResolver._resetCache();
+  const pool = [
+    { unit_id: 'rust-scavenger', weight: 2 }, // badlands consumer
+    { unit_id: 'cryo-lynx', weight: 2 }, // cryosteppe -- off-biome
+  ];
+  const r = filterReinforcementPool(pool, 'badlands');
+  assert.equal(r.applied, true);
+  assert.equal(r.reason, 'filtered');
+  assert.deepEqual(
+    r.pool.map((e) => e.unit_id),
+    ['rust-scavenger'],
+  );
+  assert.deepEqual(r.excluded, ['cryo-lynx']);
+});
+
+test('foodwebFilter: ALL off-biome -> fallback to unfiltered (never empties pool)', () => {
+  ecosystemResolver._resetCache();
+  const pool = [
+    { unit_id: 'cryo-lynx', weight: 1 }, // cryosteppe
+    { unit_id: 'steppe-bison-mini', weight: 1 }, // cryosteppe
+  ];
+  const r = filterReinforcementPool(pool, 'badlands');
+  assert.equal(r.applied, false);
+  assert.equal(r.reason, 'all_excluded_fallback');
+  assert.equal(r.pool, pool); // pool preserved -- spawning never blocked
+  assert.equal(r.excluded.length, 2);
+});
+
+test('foodwebFilter: injected resolver (pure, no I/O)', () => {
+  const pool = [
+    { unit_id: 'wolf', weight: 1 },
+    { unit_id: 'shark', weight: 1 },
+  ];
+  const fakeEco = { biome_id: 'forest', species_all: ['wolf', 'deer'] };
+  const r = filterReinforcementPool(pool, 'forest', {
+    getEcosystem: () => fakeEco,
+  });
+  assert.equal(r.applied, true);
+  assert.deepEqual(
+    r.pool.map((e) => e.unit_id),
+    ['wolf'],
+  );
+  assert.deepEqual(r.excluded, ['shark']);
+});
+
+test('foodwebFilter: normalizes whitespace in unit_id match', () => {
+  const pool = [{ unit_id: ' wolf ', weight: 1 }];
+  const fakeEco = { biome_id: 'forest', species_all: ['wolf'] };
+  const r = filterReinforcementPool(pool, 'forest', {
+    getEcosystem: () => fakeEco,
+  });
+  assert.equal(r.reason, 'all_in_foodweb');
+  assert.deepEqual(r.excluded, []);
+});
+
+module.exports = {};


### PR DESCRIPTION
Completa il chip worldgen runtime-wire (GAP-A + GAP-B). Chiude Engine-LIVE/Surface-DEAD: i dati ecosystem esistevano ma nessun runtime li consumava.

**Provenance**: avviato dal chip `worldgen-gapa-foodweb`, che ha beccato l'outage Anthropic `claude-opus-4-8` (tool-channel corrotto -> non ha potuto committare, ha scritto un handoff). Finito + ground-truth-verificato da sessione stabile. Le claim dell'handoff "reinforcementSpawner unmodified" + "PR #2447/#2448 aperti" erano **phantom-corrotte** (verificato reale via git/test).

## GAP-A — foodweb spawn-pool filter (TKT-WORLDGEN-GAPA)
- `ecosystemResolver.js`: biome_id -> species_all da `*.ecosystem.yaml` (cached, _resetCache seam)
- `foodwebFilter.js`: whitelist Caves-of-Qud, band-safe (`all_excluded_fallback` non svuota mai il pool; no biome/eco -> passthrough)
- `reinforcementSpawner.js` wired + Gate-5 log + kill-switch `policy.foodweb_filter=false`
- 8 unit + 4 integration test

## GAP-B — cross-event seasonal pressure (TKT-WORLDGEN-GAPB)
- `cross_events.yaml`: +season/pressure_delta/hazard_modifier (3 eventi)
- `crossEventEngine.js`: flat-offset Rimworld (NON sim -> evita trap UO), match to_nodes+season
- `session.js` /start: fold `pressure_delta` in `sistema_pressure` + surface `cross_events`/hazards
- 9 unit test

## Validation (questa sessione, ground-truthed)
- `node --test`: **40 worldgen+spawner GREEN**, **462 AI regression GREEN**, sessionEncounterWiring /start GREEN (wire regression-clean)
- `prettier --check` clean

## Band-safety
hardcore_06/07 reinforcement pool = unit SIS sintetiche NON in alcun foodweb -> `all_excluded_fallback` -> pool invariato -> bande invariate. hardcore /start passa NO season -> cross-event delta 0 -> `sistema_pressure` invariato.

## Residual gates (NON fatti qui -- serve backend)
- [ ] **Band re-verify empirico** HC06 [15-25%] / HC07 [30-50%] via canonical AI playtest (`calibrate_parallel.py`) -- backend up ~10min
- [ ] (opzionale) GAP-B route-level integration test (engine gia' 9-unit-tested + wire boota clean)

Gate master-dd: WIRE approvato (filter-only A + flat-modifier B). GAP-C (meta-network) = POST-MVP, non fatto.

**NON MERGARE** finche' band re-verify (backend) non passa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
