### PR TITLE
feat(playtest): canonical AI-driven playtest harness (seed + triangulation + suite)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -23,20 +23,22 @@
 
 Source: design-docs currency reconcile (`docs/reports/2026-05-29-design-docs-currency-reconcile.md`) + worldgen-pcg-audit (2026-04-26), ground-truth-verificato 2026-05-29. Museum cards M-013/M-014/M-016 + gallery worldgen. Engine-LIVE-Surface-DEAD: i 4 livelli worldgen (bioma/ecosistema/foodweb/network) hanno il dato ma 3 livelli restano senza consumer runtime. NO autonomous wire (revive culture: decision master-dd).
 
-| Ticket             | Gap                              | Verified state 2026-05-29                                                                                                              | Effort (post-blast-radius) | Decision                                                            |
-| ------------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------- |
-| TKT-WORLDGEN-GAPA  | foodweb -> spawn composition     | `biomeAffinity.js` = stat-modifier (Subnautica, wired session.js:506), NON spawn-filter; `reinforcementSpawner.js` non filtra per trophic-tier/biome_affinity | ~8-10h (×1.0-1.2)          | wire `ecosystemLoader` + foodweb whitelist in reinforcementSpawner OR remove |
-| TKT-WORLDGEN-GAPB  | cross-events -> pressure modifier | `cross_events.yaml` (3 eventi) zero consumer runtime; `seasonalEngine.js` Phase-A scaffold (wired campaign.js:50) ma NON consuma cross_events | ~12h (×1.3 session hook)   | wire crossEventEngine (pressure/hazard delta su session) OR remove  |
-| TKT-WORLDGEN-GAPC  | meta-network -> campaign routing | `meta_network_alpha.yaml` (5 nodi/11 archi) zero consumer; `campaignEngine.js` usa encounter_id statici                              | ~30-40h (POST-MVP)         | Dormans mission/space grammar su meta-network — POST-MVP, gate normale, NON priorità automatica |
+| Ticket            | Gap                               | Verified state 2026-05-29                                                                                                                                     | Effort (post-blast-radius) | Decision                                                                                        |
+| ----------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------- |
+| TKT-WORLDGEN-GAPA | foodweb -> spawn composition      | `biomeAffinity.js` = stat-modifier (Subnautica, wired session.js:506), NON spawn-filter; `reinforcementSpawner.js` non filtra per trophic-tier/biome_affinity | ~8-10h (×1.0-1.2)          | wire `ecosystemLoader` + foodweb whitelist in reinforcementSpawner OR remove                    |
+| TKT-WORLDGEN-GAPB | cross-events -> pressure modifier | `cross_events.yaml` (3 eventi) zero consumer runtime; `seasonalEngine.js` Phase-A scaffold (wired campaign.js:50) ma NON consuma cross_events                 | ~12h (×1.3 session hook)   | wire crossEventEngine (pressure/hazard delta su session) OR remove                              |
+| TKT-WORLDGEN-GAPC | meta-network -> campaign routing  | `meta_network_alpha.yaml` (5 nodi/11 archi) zero consumer; `campaignEngine.js` usa encounter_id statici                                                       | ~30-40h (POST-MVP)         | Dormans mission/space grammar su meta-network — POST-MVP, gate normale, NON priorità automatica |
 
-### 🟡 OPEN — Canonical AI-driven playtest (paradigma flip 2026-05-29)
+### ✅ SHIPPED — Canonical AI-driven playtest (paradigma flip 2026-05-29)
 
 SoT: `docs/process/CANONICAL-AI-PLAYTEST.md` + `docs/playtest/canonical-suite.yaml`. Flip: AI-driven multi-policy (N=40) = gate/oracolo riproducibile; playtest umano = conferma opzionale, mai bloccante. Tooling esistente `tools/py/calibrate_*.py` + `batch_calibrate_*.py`.
 
-| Ticket                   | Scope                                                                                           | Effort | Note                                                          |
-| ------------------------ | ----------------------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------ |
-| TKT-PLAYTEST-SEED        | `--seed` pin RNG nei `batch_calibrate_*.py` per riproducibilita' bit-identica                   | ~2-3h  | gap "ogni volta" (oggi solo statistica N=40, non bit-identica) |
-| TKT-PLAYTEST-TRIANGULATE | wire multi-policy `--policy {random,greedy,lookahead2,utility}` (Restricted-Play, Jaffe 2012)   | ~4h    | stub gia' nel policy doc superseded; output = banda WR non single verdict |
+**SHIPPED 2026-05-30** (branch `claude/canonical-ai-playtest-harness`): TKT-PLAYTEST-SEED `fd5c050c` + TKT-PLAYTEST-TRIANGULATE `b3ed0430` + TKT-PLAYTEST-SUITE `26387f52`. New: `tools/py/calibrate_policies.py` + `tools/py/playtest_canonical.py`; backend seedable RNG `apps/backend/services/combat/pseudoRng.js`. Smoke verde (backend up): seed bit-identico, banda WR random<greedy~lookahead2<utility, suite --dry-run + live N=10. PR pendente.
+
+| Ticket                   | Scope                                                                                             | Effort | Note                                                                         |
+| ------------------------ | ------------------------------------------------------------------------------------------------- | ------ | ---------------------------------------------------------------------------- |
+| TKT-PLAYTEST-SEED        | `--seed` pin RNG nei `batch_calibrate_*.py` per riproducibilita' bit-identica                     | ~2-3h  | gap "ogni volta" (oggi solo statistica N=40, non bit-identica)               |
+| TKT-PLAYTEST-TRIANGULATE | wire multi-policy `--policy {random,greedy,lookahead2,utility}` (Restricted-Play, Jaffe 2012)     | ~4h    | stub gia' nel policy doc superseded; output = banda WR non single verdict    |
 | TKT-PLAYTEST-SUITE       | `tools/py/playtest_canonical.py` orchestratore summa (manifest -> N=40 parallel -> report datato) | ~4-6h  | smoke-gated (backend up + ~10min). Anti-pattern #9: non shippare non-testato |
 
 ### 🟡 OPEN — intensive fix/tuning audit 2026-05-22 (orphan inventory + balance ratify)
@@ -67,8 +69,8 @@ Note: orphan-agent over-claimed "woundedPerma superseded" — trust-but-verify c
 
 Source: reuse-queue triage codemasterdd `KNOWLEDGE_MAP.md` §7 (archivio `ryzen-memory-archive/Game-Desktop-old/reference_tactical_postmortems.md`). Unico pattern tattico genuinamente NON costruito tra gli 11 reference archiviati (prova-di-eliminazione: gli altri = backup già assorbito in SoT/code).
 
-| Ticket | Cosa | Razionale | Stato |
-| ------ | ---- | --------- | ----- |
+| Ticket            | Cosa                                                                                                                                               | Razionale                                                          | Stato                                        |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------- |
 | TKT-ENCOUNTER-CLI | `game_cli.py author-encounter` — CLI authoring encounter (numeric spec + vertical-slice playtest loop, pattern Fallout Tactics / Micro Forte 2001) | Sblocca volume content-slice M3 (encounter authoring oggi manuale) | OPEN — master-dd verdict (scope M3 vs defer) |
 
 ### ✅ Ecosystem audit + ai-station Envelope A+B+C cascade — sessione 2026-05-13/14/15 — 14 PR cross-stack shipped

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -130,6 +130,13 @@ const { loadTraitEnvironmentalCosts, applyBiomeEcoEffects } = require('../servic
 // pressure / enemy HP. Same encounter on savana vs abisso_vulcanico now
 // produces different numbers, not just different texture.
 const { getBiomeModifiers, applyEnemyHpMultiplier } = require('../services/combat/biomeModifiers');
+// TKT-PLAYTEST-SEED (2026-05-29): canonical seedable combat RNG. Unseeded =
+// Math.random (zero prod change); seeded at /start = bit-identical calibration.
+const {
+  defaultRng,
+  seedRng: seedCombatRng,
+  clearSeed: clearCombatSeed,
+} = require('../services/combat/pseudoRng');
 // M6-#1 (ADR-2026-04-19 + spike 2026-04-19): Node native resistance engine.
 // Applica channel-specific resist/vuln su damage pre-hp. Evidence spike:
 // 84.6% → 20% win rate hardcore-06 con flat 50% resist (leva confermata).
@@ -253,7 +260,10 @@ function createSessionRouter(options = {}) {
   const router = Router();
   const repoRoot = path.resolve(__dirname, '..', '..', '..');
   const logsDir = options.logsDir || path.join(repoRoot, 'logs');
-  const rng = typeof options.rng === 'function' ? options.rng : Math.random;
+  // TKT-PLAYTEST-SEED: default to the canonical seedable provider so a seed
+  // pinned at /start propagates to every combat draw. defaultRng === Math.random
+  // behavior until seeded, so production is unchanged.
+  const rng = typeof options.rng === 'function' ? options.rng : defaultRng;
   const traitRegistry = options.traitRegistry || loadActiveTraitRegistry();
   const fairnessConfig = options.fairnessConfig || loadFairnessConfig();
   const telemetryConfig = options.telemetryConfig || loadTelemetryConfig();
@@ -1344,6 +1354,15 @@ function createSessionRouter(options = {}) {
 
   router.post('/start', async (req, res, next) => {
     try {
+      // TKT-PLAYTEST-SEED: pin the combat RNG for bit-identical calibration.
+      // Must run before any session-setup roll. Production omits `seed` ->
+      // clearCombatSeed() -> Math.random passthrough (no behavior change).
+      const seedRaw = req.body?.seed;
+      if (seedRaw !== undefined && seedRaw !== null && seedRaw !== '') {
+        seedCombatRng(seedRaw);
+      } else {
+        clearCombatSeed();
+      }
       const sessionId = newSessionId();
       const now = new Date();
       const logFilePath = path.join(logsDir, `session_${timestampStamp(now)}.json`);

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -33,6 +33,7 @@
 'use strict';
 
 const { loadJobs, extractAbilities } = require('./jobsLoader');
+const { defaultRng } = require('./combat/pseudoRng');
 
 let abilityIndex = null;
 
@@ -125,7 +126,7 @@ function createAbilityExecutor(deps) {
     appendEvent,
     manhattanDistance,
     gridSize = 6,
-    rng = Math.random,
+    rng = defaultRng,
   } = deps;
 
   // V5 SG earn (ADR-2026-04-26 Opzione C mixed): accumulate dealt+taken

--- a/apps/backend/services/ai/utilityBrain.js
+++ b/apps/backend/services/ai/utilityBrain.js
@@ -14,6 +14,10 @@
 
 'use strict';
 
+// TKT-PLAYTEST-SEED: draw from the canonical seedable RNG so the utility
+// policy is deterministic under a pinned seed (unseeded === Math.random).
+const { defaultRng } = require('../combat/pseudoRng');
+
 // ─────────────────────────────────────────────────────────────────
 // Consideration curves
 // ─────────────────────────────────────────────────────────────────
@@ -288,7 +292,7 @@ function selectAction(
       stickinessDirectionWeight,
     });
     // Add noise
-    const noisyScore = result.score + (Math.random() - 0.5) * 2 * noise * result.score;
+    const noisyScore = result.score + (defaultRng() - 0.5) * 2 * noise * result.score;
     return { action, score: Math.max(0, noisyScore), breakdown: result.breakdown };
   });
 
@@ -298,7 +302,7 @@ function selectAction(
   let chosen;
   switch (selection) {
     case 'random':
-      chosen = scored[Math.floor(Math.random() * scored.length)];
+      chosen = scored[Math.floor(defaultRng() * scored.length)];
       break;
     case 'weighted_top3': {
       const top = scored.slice(0, 3);
@@ -306,7 +310,7 @@ function selectAction(
       if (totalWeight === 0) {
         chosen = top[0];
       } else {
-        let roll = Math.random() * totalWeight;
+        let roll = defaultRng() * totalWeight;
         chosen = top[0];
         for (const s of top) {
           roll -= s.score;

--- a/apps/backend/services/combat/morale.js
+++ b/apps/backend/services/combat/morale.js
@@ -27,6 +27,8 @@
 
 'use strict';
 
+const { defaultRng } = require('./pseudoRng');
+
 const PANIC_DURATION_DEFAULT = 2;
 const RAGE_DURATION_DEFAULT = 1;
 
@@ -84,7 +86,7 @@ function checkMorale(unit, eventType, ctx = {}) {
   const profile = EVENT_OUTCOME_PROFILE[eventType] || { primary: 'panic', rage_inversion: false };
 
   // Roll d20.
-  const rng = typeof ctx.rng === 'function' ? ctx.rng : Math.random;
+  const rng = typeof ctx.rng === 'function' ? ctx.rng : defaultRng;
   const die = Math.floor(rng() * 20) + 1; // 1..20
   const moraleMod = Number(unit.morale_mod || 0);
   const score = die + moraleMod;

--- a/apps/backend/services/combat/pseudoRng.js
+++ b/apps/backend/services/combat/pseudoRng.js
@@ -80,6 +80,78 @@ function resetStreaks(unit) {
   return unit;
 }
 
+// ─────────────────────────────────────────────────────────────────
+// Seedable global RNG (TKT-PLAYTEST-SEED, 2026-05-29).
+//
+// Canonical RNG provider for combat. `defaultRng` is a drop-in for
+// Math.random: when UNSEEDED it delegates to Math.random (bit-for-bit
+// production behavior, zero regression). When SEEDED (via seedRng, called
+// from POST /api/session/start when the body carries a `seed`) it draws
+// from a deterministic mulberry32 stream so a calibration run is
+// reproducible bit-identical given the same seed.
+//
+// Module-global by design: one backend process runs one calibration
+// session at a time per shard (LOBBY_WS_ENABLED=false, L-071), and each
+// /start reseeds. Production never sends a seed -> unseeded -> Math.random.
+//
+// API:
+//   seedRng(seed)  -> bool   set the stream to a finite numeric seed
+//   clearSeed()              revert to Math.random passthrough
+//   isSeeded()     -> bool   true when a deterministic stream is active
+//   defaultRng()   -> [0,1)  next float (seeded stream or Math.random)
+// ─────────────────────────────────────────────────────────────────
+
+// Active deterministic generator, or null when unseeded (Math.random).
+let _rngState = null;
+
+/**
+ * mulberry32 — compact, well-distributed 32-bit PRNG. Returns a function
+ * producing floats in [0,1). Same well-known constants as the reference
+ * implementation so the stream is portable/inspectable.
+ */
+function _mulberry32(seed) {
+  let a = seed >>> 0;
+  return function next() {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Pin the global RNG stream to a seed. Coerces numeric strings. Non-finite
+ * input is rejected (returns false) and leaves the stream unseeded.
+ * @returns {boolean} true if a deterministic stream is now active.
+ */
+function seedRng(seed) {
+  const n = Number(seed);
+  if (!Number.isFinite(n)) {
+    _rngState = null;
+    return false;
+  }
+  _rngState = _mulberry32(n >>> 0);
+  return true;
+}
+
+/** Revert to Math.random passthrough (no determinism). */
+function clearSeed() {
+  _rngState = null;
+}
+
+/** @returns {boolean} true when a deterministic seeded stream is active. */
+function isSeeded() {
+  return _rngState !== null;
+}
+
+/**
+ * Canonical combat RNG. Float in [0,1). Seeded stream when active, else
+ * Math.random. Stable reference — safe for callers to capture once.
+ */
+function defaultRng() {
+  return _rngState !== null ? _rngState() : Math.random();
+}
+
 module.exports = {
   initUnit,
   recordRoll,
@@ -87,4 +159,9 @@ module.exports = {
   resetStreaks,
   MISS_STREAK_THRESHOLD,
   STREAK_BONUS,
+  // Seedable global RNG (TKT-PLAYTEST-SEED).
+  seedRng,
+  clearSeed,
+  isSeeded,
+  defaultRng,
 };

--- a/apps/backend/services/combat/reinforcementSpawner.js
+++ b/apps/backend/services/combat/reinforcementSpawner.js
@@ -27,6 +27,7 @@
 'use strict';
 
 const { computeSistemaTier } = require('../../routes/sessionHelpers');
+const { defaultRng } = require('./pseudoRng');
 
 const DEFAULT_MIN_DISTANCE_FROM_PG = 3; // Manhattan
 const TIER_LABEL_ORDER = ['Calm', 'Alert', 'Escalated', 'Critical', 'Apex'];
@@ -147,7 +148,7 @@ function emitAlienaPoolSnapshot(session, pool, biomeConfig, round) {
 }
 
 function tick(session, encounter, opts = {}) {
-  const rng = typeof opts.rng === 'function' ? opts.rng : Math.random;
+  const rng = typeof opts.rng === 'function' ? opts.rng : defaultRng;
   const policy = encounter?.reinforcement_policy;
   if (!policy || policy.enabled !== true) {
     return { spawned: [], budget_used: 0, skipped: true, reason: 'policy_disabled' };

--- a/apps/backend/services/traitEffects.js
+++ b/apps/backend/services/traitEffects.js
@@ -27,6 +27,7 @@ const yaml = require('js-yaml');
 // mutati. Cache key per attack-result hash. Soft-fail safe (always recompute
 // se cache miss o invalid input).
 const dirtyFlagTracker = require('./perf/dirtyFlagTracker');
+const { defaultRng } = require('./combat/pseudoRng');
 
 const DEFAULT_REGISTRY_PATH = path.resolve(
   __dirname,
@@ -423,7 +424,7 @@ function evaluateSingleTrait({ traitId, definition, actor, target, attackResult,
         const bonus = Number(match[3] || 0);
         let roll = 0;
         for (let i = 0; i < numDice; i += 1) {
-          roll += Math.floor((ctx?.rng ? ctx.rng() : Math.random()) * sides) + 1;
+          roll += Math.floor((ctx?.rng ? ctx.rng() : defaultRng()) * sides) + 1;
         }
         healAmount = roll + bonus;
       }

--- a/docs/playtest/canonical-suite.yaml
+++ b/docs/playtest/canonical-suite.yaml
@@ -3,7 +3,7 @@
 # Machine-readable list of canonical scenarios + ratified bands + run config.
 # Paradigm (2026-05-29): AI-driven multi-policy = gate/oracle; human = optional.
 version: 1
-last_verified: "2026-05-29"
+last_verified: '2026-05-29'
 
 # N-ladder (L-069/L-073): 10 probe (+-30pp) / 40 ratify (+-15pp) / 100 forensic (+-10pp)
 n_ladder:
@@ -13,47 +13,47 @@ n_ladder:
 
 # Multi-policy triangulation (Jaffe 2012). Human WR ~= band [random, strong].
 policies: [random, greedy, lookahead2, utility]
-human_wr_formula: "greedy_WR*0.55 + lookahead_WR*0.45"  # tunable if optional human data arrives
+human_wr_formula: 'greedy_WR*0.55 + lookahead_WR*0.45' # tunable if optional human data arrives
 
 # Reproducibility contract (see CANONICAL-AI-PLAYTEST.md sec 3)
 repro:
-  host: "http://127.0.0.1"      # NOT localhost (IPv6 ::1 stall on Windows)
-  lobby_ws_enabled: false       # per-shard, port collision (L-071)
-  damage_curves_path_required: true   # client must read backend staging file (L-069/OD-032)
-  seed_pinned: false            # GAP -> TKT-PLAYTEST-SEED (bit-identical repro pending)
+  host: 'http://127.0.0.1' # NOT localhost (IPv6 ::1 stall on Windows)
+  lobby_ws_enabled: false # per-shard, port collision (L-071)
+  damage_curves_path_required: true # client must read backend staging file (L-069/OD-032)
+  seed_pinned: true # WIRED via TKT-PLAYTEST-SEED (batch --seed -> pseudoRng.js defaultRng at /start)
   config_source: data/core/balance/damage_curves.yaml
   scenario_spawn_source: apps/backend/services/hardcoreScenario.js
 
 # Composite metric (anti false-balanced)
-composite_metric: "0.50*win_rate + 0.25*kd_ratio + 0.25*pe_ratio"
+composite_metric: '0.50*win_rate + 0.25*kd_ratio + 0.25*pe_ratio'
 
 scenarios:
   - id: enc_tutorial_06_hardcore
     role: balance_oracle
     target_band: [0.15, 0.25]
     ratified_knob: { boss_hp_multiplier: 0.65 }
-    last_wr_n40: "0.15-0.25"
+    last_wr_n40: '0.15-0.25'
     status: ratified
     tool: tools/py/batch_calibrate_hardcore06.py
     port: 3340
-    note: "iter3 turn_limit_defeat null = overshoot WR 0.85 REJECTED. Source #2381 ratify."
+    note: 'iter3 turn_limit_defeat null = overshoot WR 0.85 REJECTED. Source #2381 ratify.'
 
   - id: enc_tutorial_07_hardcore_pod_rush
     role: balance_oracle
     target_band: [0.30, 0.50]
-    ratified_knob: { enemy_damage_multiplier_override: 2.1 }   # REPLACES class 1.8, not stack
-    last_wr_n40: "0.30-0.40"
+    ratified_knob: { enemy_damage_multiplier_override: 2.1 } # REPLACES class 1.8, not stack
+    last_wr_n40: '0.30-0.40'
     status: in_band
     tool: tools/py/batch_calibrate_hardcore07.py
     port: 3334
-    note: "post wave 5-7 nerf (6 traits cost_ap 1->2) = -40-60pp WR. Timer-driven scenario."
+    note: 'post wave 5-7 nerf (6 traits cost_ap 1->2) = -40-60pp WR. Timer-driven scenario.'
 
   - id: enc_tutorial_01_05
     role: designed_winnable_ladder
     target_band: null
     status: not_balance_oracle
     tool: tools/py/batch_calibrate_*.py
-    note: "Tutorial = learning ladder, designed-winnable (greedy ~100% WR). NOT a difficulty target."
+    note: 'Tutorial = learning ladder, designed-winnable (greedy ~100% WR). NOT a difficulty target.'
 
 # Canonical run (parallel, ~10min N=40). Suite-runner = TKT-PLAYTEST-SUITE (pending smoke).
 run_canonical: |
@@ -61,5 +61,5 @@ run_canonical: |
   python tools/py/calibrate_parallel.py --scenario hardcore_07 --n 40 --shards 4 --base-port 3341
 
 gate:
-  merge: "AI regression tests/ai/*.test.js green AND touched-scenario WR in-band @ N=40 AND no crash/contract-ripple"
-  human_playtest: "OPTIONAL confirmation, never blocking"
+  merge: 'AI regression tests/ai/*.test.js green AND touched-scenario WR in-band @ N=40 AND no crash/contract-ripple'
+  human_playtest: 'OPTIONAL confirmation, never blocking'

--- a/docs/playtest/canonical-suite.yaml
+++ b/docs/playtest/canonical-suite.yaml
@@ -55,7 +55,7 @@ scenarios:
     tool: tools/py/batch_calibrate_*.py
     note: 'Tutorial = learning ladder, designed-winnable (greedy ~100% WR). NOT a difficulty target.'
 
-# Canonical run (parallel, ~10min N=40). Suite-runner = TKT-PLAYTEST-SUITE (pending smoke).
+# Canonical run (parallel, ~10min N=40). One-command suite = tools/py/playtest_canonical.py (TKT-PLAYTEST-SUITE, SHIPPED 2026-05-30).
 run_canonical: |
   python tools/py/calibrate_parallel.py --scenario hardcore_06 --n 40 --shards 4 --base-port 3341
   python tools/py/calibrate_parallel.py --scenario hardcore_07 --n 40 --shards 4 --base-port 3341

--- a/docs/process/CANONICAL-AI-PLAYTEST.md
+++ b/docs/process/CANONICAL-AI-PLAYTEST.md
@@ -1,10 +1,10 @@
 ---
-title: "Canonical AI-driven playtest — single reproducible best-test (SoT)"
+title: 'Canonical AI-driven playtest — single reproducible best-test (SoT)'
 workstream: ops-qa
 category: process
 doc_status: active
 doc_owner: claude-code
-last_verified: "2026-05-29"
+last_verified: '2026-05-29'
 source_of_truth: true
 language: it
 review_cycle_days: 90
@@ -24,11 +24,11 @@ supersedes:
 
 ## 0. Paradigma (flip 2026-05-29)
 
-| Prima (superseded) | Ora (canonical) |
-|---|---|
-| Harness AI = diagnostic, NON merge gate | **Harness AI = gate**: WR in-band a N=40 + test verdi = merge OK |
+| Prima (superseded)                                    | Ora (canonical)                                                                 |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Harness AI = diagnostic, NON merge gate               | **Harness AI = gate**: WR in-band a N=40 + test verdi = merge OK                |
 | Oracolo vero = playtest live umano (4 amici TV+phone) | **Oracolo = AI-driven multi-policy**; human = conferma opzionale, mai bloccante |
-| Sim = scaffold, humans = ground truth | Sim multi-policy + telemetria = ground truth riproducibile |
+| Sim = scaffold, humans = ground truth                 | Sim multi-policy + telemetria = ground truth riproducibile                      |
 
 Razionale: il playtest umano 4-amici e' raro, non-riproducibile, e ha bloccato sprint
 per settimane (TKT-M11B-06). L'AI-driven e' riproducibile **ogni volta**, scala, ed e'
@@ -41,12 +41,12 @@ gia' il metodo de-facto (tutti i dati ratify sotto vengono da li').
 NON usare single greedy come proxy-umano (anti-pattern, rejected da Jaffe 2012 +
 Politowski 2023). Il best-test gira **>=3 policy** e produce una **banda** WR:
 
-| Policy | Ruolo | Sorgente |
-|---|---|---|
-| `random` | noise floor (WR minimo) | baseline |
-| `greedy` | ceiling locale (atk-closest, focus-fire) | attuale default batch |
-| `lookahead2` | tactical awareness | da wire |
-| `utility` | smart brain | `apps/backend/services/ai/utilityBrain.js` (opt-in `ai_profile: aggressive`) |
+| Policy       | Ruolo                                    | Sorgente                                                                     |
+| ------------ | ---------------------------------------- | ---------------------------------------------------------------------------- |
+| `random`     | noise floor (WR minimo)                  | baseline                                                                     |
+| `greedy`     | ceiling locale (atk-closest, focus-fire) | attuale default batch                                                        |
+| `lookahead2` | tactical awareness                       | da wire                                                                      |
+| `utility`    | smart brain                              | `apps/backend/services/ai/utilityBrain.js` (opt-in `ai_profile: aggressive`) |
 
 Human WR stimato ~= banda `[random_WR, strong_WR]`. Banda larga = skill-dominated
 (posizionamento conta); stretta = luck-dominated (tune variance). Formula iniziale
@@ -54,11 +54,11 @@ Human WR stimato ~= banda `[random_WR, strong_WR]`. Banda larga = skill-dominate
 
 ### 1.2 N-ladder (autorita' L-069/L-070/L-072/L-073)
 
-| Fase | N | CI95 WR | Quando |
-|---|---|---|---|
-| **Probe** | 10 | ±30pp | direzione del delta (NON band-placement). Mai claim upgrade da N=10 |
-| **Ratify** | 40 | ±15pp | **gate decisionale** band-placement |
-| **Forensic** | 100 | ±10pp | cross-scenario fairness / metagame lock |
+| Fase         | N   | CI95 WR | Quando                                                              |
+| ------------ | --- | ------- | ------------------------------------------------------------------- |
+| **Probe**    | 10  | ±30pp   | direzione del delta (NON band-placement). Mai claim upgrade da N=10 |
+| **Ratify**   | 40  | ±15pp   | **gate decisionale** band-placement                                 |
+| **Forensic** | 100 | ±10pp   | cross-scenario fairness / metagame lock                             |
 
 Regole dure: N=10 = solo direzione (segno robusto, magnitudo rumorosa). MAI catene
 iter1/iter2/iter3 di N=10 (rumore compounding). Un N=40 > tre N=10. Optimizer
@@ -69,12 +69,12 @@ altrimenti converge a rumore (L-073).
 
 `win_rate` dice SE sei fuori band, non PERCHE'. Diagnosi prima:
 
-| Sintomo | Causa | Knob |
-|---|---|---|
-| WR alto + boss residual >50% | survivability | enemy DPR / HP party |
+| Sintomo                      | Causa                    | Knob                    |
+| ---------------------------- | ------------------------ | ----------------------- |
+| WR alto + boss residual >50% | survivability            | enemy DPR / HP party    |
 | WR alto + boss residual <10% | DPR insufficiente nemico | enemy_damage_multiplier |
-| Timeout 100% + turns=max | timer | turn_limit_defeat |
-| WR ~target ma KD estremo | swingy | variance |
+| Timeout 100% + turns=max     | timer                    | turn_limit_defeat       |
+| WR ~target ma KD estremo     | swingy                   | variance                |
 
 Composite metric (anti falso-"balanced"): `0.50*WR + 0.25*KD_ratio + 0.25*PE_ratio`.
 Metriche gia' emesse: `boss_hp_remaining_avg_on_loss`, `kd_avg`, `dmg_dealt_avg`.
@@ -94,16 +94,16 @@ Prima di ogni batch (costoso): `predictCombat(actor, target, n=1000)` in
 
 ## 2. Tooling (esistente, riusabile)
 
-| Tool | Cosa | Invocazione |
-|---|---|---|
-| `tools/py/batch_calibrate_hardcore06.py` | WR runner HC06 | `--host http://127.0.0.1:3340 --encounter-class hardcore --n 40 --out <json>` |
-| `tools/py/batch_calibrate_hardcore07.py` | WR runner HC07 (timer) | `--host http://127.0.0.1:3334 --n 40 --out <json>` |
-| `tools/py/batch_calibrate_non_elim.py` / `_skiv_solo_pack.py` | altri scenari | analogo |
-| `tools/py/calibrate_parallel.py` | 4-shard parallel | `--scenario hardcore_06 --n 40 --shards 4 --base-port 3341` (~10min vs ~36min serial) |
-| `tools/py/calibrate_drift_verify.py` | N=10 probe -> auto-escalate N=40 | `--scenario hardcore_06 --target-band 15-25` |
-| `tools/py/sprt_calibrate.py` | Stockfish SPRT early-stop | `--scenario <s> --target-low 0.30 --target-high 0.50 --n-max 80` |
-| `tools/py/playtest_2_analyzer.py` | aggregatore JSONL telemetry | post-run |
-| `.claude/agents/balance-illuminator.md` | agent: encoda tutto (calibration + research mode) | invoke |
+| Tool                                                          | Cosa                                              | Invocazione                                                                           |
+| ------------------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `tools/py/batch_calibrate_hardcore06.py`                      | WR runner HC06                                    | `--host http://127.0.0.1:3340 --encounter-class hardcore --n 40 --out <json>`         |
+| `tools/py/batch_calibrate_hardcore07.py`                      | WR runner HC07 (timer)                            | `--host http://127.0.0.1:3334 --n 40 --out <json>`                                    |
+| `tools/py/batch_calibrate_non_elim.py` / `_skiv_solo_pack.py` | altri scenari                                     | analogo                                                                               |
+| `tools/py/calibrate_parallel.py`                              | 4-shard parallel                                  | `--scenario hardcore_06 --n 40 --shards 4 --base-port 3341` (~10min vs ~36min serial) |
+| `tools/py/calibrate_drift_verify.py`                          | N=10 probe -> auto-escalate N=40                  | `--scenario hardcore_06 --target-band 15-25`                                          |
+| `tools/py/sprt_calibrate.py`                                  | Stockfish SPRT early-stop                         | `--scenario <s> --target-low 0.30 --target-high 0.50 --n-max 80`                      |
+| `tools/py/playtest_2_analyzer.py`                             | aggregatore JSONL telemetry                       | post-run                                                                              |
+| `.claude/agents/balance-illuminator.md`                       | agent: encoda tutto (calibration + research mode) | invoke                                                                                |
 
 Optimizer/search (research-tier, primary-sourced in `balance-illuminator.md`): SPRT,
 MCTS smart playout, MAP-Elites QD, Bayesian (Optuna/Ax, N>=40/trial), LLM-as-critic
@@ -117,7 +117,7 @@ Per risultati ri-ottenibili:
 2. **`DAMAGE_CURVES_PATH` set**: il client DEVE leggere lo stesso staging file del backend, altrimenti gli override sono SILENT NO-OP client-side (bug L-069/OD-032).
 3. **`LOBBY_WS_ENABLED=false`** per ogni shard parallel (collisione porta WS, L-071). Porte shard deterministiche (base 3341 + offset).
 4. **Host `127.0.0.1` NON "localhost"** (Windows risolve IPv6 ::1 prima -> stall ~2s/call).
-5. **SEED RNG pinnato** — **GAP APERTO**: i batch attuali NON pinnano il seed (run non bit-identici). Per "ogni volta" bit-identico serve `--seed` (vedi `TKT-PLAYTEST-SEED`). Finche' non wired, riproducibilita' = statistica (stessa banda a N=40), non bit-identica.
+5. **SEED RNG pinnato** — **WIRED** (TKT-PLAYTEST-SEED, 2026-05-30): `batch_calibrate_hardcore0{6,7}.py --seed` propaga il seed a `/api/session/start`, che pinna la RNG combat seedabile (`apps/backend/services/combat/pseudoRng.js` `defaultRng`/`seedRng`). 2 run stesso seed = JSON bit-identici (smoke verde). Unseeded = `Math.random` (zero regressione prod). Run i usa `seed+i` (intero batch riproducibile).
 6. **Policy fissate**: il set multi-policy (1.1) e' parte del contratto, non ad-hoc.
 7. **Output archiviato**: `docs/playtest/YYYY-MM-DD-<scenario>-<phase>.json` + report `docs/playtest/YYYY-MM-DD-<scenario>-illuminator.md`.
 
@@ -125,24 +125,26 @@ Per risultati ri-ottenibili:
 
 Manifest macchina-leggibile: [`docs/playtest/canonical-suite.yaml`](../playtest/canonical-suite.yaml).
 
-| Scenario | Band target | Knob ratificato | WR (N=40) | Stato |
-|---|---|---|---|---|
-| `enc_tutorial_06_hardcore` | 15-25% | `boss_hp_multiplier: 0.65` | 15-25% (iter2 + #2381) | RATIFIED. iter3 `turn_limit null` = overshoot 85% REJECTED |
-| `enc_tutorial_07_hardcore_pod_rush` | 30-50% | `enemy_damage_multiplier_override: 2.1` (REPLACE class 1.8) | 30-40% (post-wave 5-7 nerf) | IN-BAND |
-| `enc_tutorial_01..05` | designed-winnable | n/a | ~100% greedy | NON balance-oracle (ladder di apprendimento) |
+| Scenario                            | Band target       | Knob ratificato                                             | WR (N=40)                   | Stato                                                      |
+| ----------------------------------- | ----------------- | ----------------------------------------------------------- | --------------------------- | ---------------------------------------------------------- |
+| `enc_tutorial_06_hardcore`          | 15-25%            | `boss_hp_multiplier: 0.65`                                  | 15-25% (iter2 + #2381)      | RATIFIED. iter3 `turn_limit null` = overshoot 85% REJECTED |
+| `enc_tutorial_07_hardcore_pod_rush` | 30-50%            | `enemy_damage_multiplier_override: 2.1` (REPLACE class 1.8) | 30-40% (post-wave 5-7 nerf) | IN-BAND                                                    |
+| `enc_tutorial_01..05`               | designed-winnable | n/a                                                         | ~100% greedy                | NON balance-oracle (ladder di apprendimento)               |
 
 Fonte knob: `data/core/balance/damage_curves.yaml`. Fonte dati: `docs/playtest/2026-05-20-*`, `2026-05-21-*`, `2026-05-26-ratify-2381-balance.md`.
 
 ## 5. Gate policy (canonical)
 
 **Merge gate** (sostituisce "harness != gate"):
+
 - AI regression `tests/ai/*.test.js` verde (obbligatorio).
 - Scenario toccato: WR **in-band a N=40** (multi-policy) — ratify gate.
 - No crash / no contract-ripple.
 
 **Human playtest = conferma OPZIONALE**, mai bloccante. Se gira (G7 RC o quando capita)
 = un singolo re-tune iter, non un blocco. Telemetria JSONL via `POST /api/session/telemetry`
-+ `playtest-analyzer` se ci sono dati human, ma la loro assenza NON blocca nulla.
+
+- `playtest-analyzer` se ci sono dati human, ma la loro assenza NON blocca nulla.
 
 ## 6. Comando canonico (finche' il suite-runner non e' wired)
 
@@ -156,18 +158,19 @@ python tools/py/calibrate_parallel.py --scenario hardcore_07 --n 40 --shards 4 -
 ```
 
 Suite-runner unico (`tools/py/playtest_canonical.py`, gira tutto il manifest a N=40 +
-report datato + seed-pin) = **TKT-PLAYTEST-SUITE** (da scaffoldare + smoke, anti-pattern
-#9: non shippato non-testato).
+report datato + `--dry-run` backend-free) = **TKT-PLAYTEST-SUITE** -- **SHIPPED** 2026-05-30
+(smoke verde: --dry-run + live hardcore_06 N=10). Comando: `python tools/py/playtest_canonical.py --n 40`.
 
-## 7. Backlog (gap -> ticket)
+## 7. Backlog (gap -> ticket) -- ALL SHIPPED 2026-05-30 (branch claude/canonical-ai-playtest-harness)
 
-- **TKT-PLAYTEST-SEED**: `--seed` pin RNG nei batch_calibrate_* per riproducibilita' bit-identica.
-- **TKT-PLAYTEST-TRIANGULATE**: wire multi-policy `--policy {random,greedy,lookahead2,utility}` (~4h, stub gia' in policy doc superseded).
-- **TKT-PLAYTEST-SUITE**: `playtest_canonical.py` orchestratore summa (manifest -> N=40 parallel -> report datato). Smoke-gated.
+- **TKT-PLAYTEST-SEED** [SHIPPED]: `--seed` nei batch*calibrate*\* -> bit-identico via `pseudoRng.js` `defaultRng` + `/start` seed.
+- **TKT-PLAYTEST-TRIANGULATE** [SHIPPED]: `--policy {random,greedy,lookahead2,utility,all}` (`calibrate_policies.py`) -> banda WR + stima human.
+- **TKT-PLAYTEST-SUITE** [SHIPPED]: `playtest_canonical.py` (manifest -> N=40 parallel -> report datato; `--dry-run` backend-free).
 
 ## 8. Supersedes / flag (paradigma human-oracle declassato)
 
 Questi riferimenti al playtest umano come gate/oracolo sono **declassati a opzionale**:
+
 - `docs/process/2026-04-26-calibration-harness-policy.md` (`status: superseded`, gate-stance invertita)
 - `docs/adr/ADR-2026-05-18-df-levels-integration-direction.md` gate (a) — ora AI-driven
 - `docs/adr/ADR-2026-05-18-sistema-persistent-state-learning.md` gate ratify — ora AI-driven

--- a/tests/services/sprint-alpha/pseudoRng.test.js
+++ b/tests/services/sprint-alpha/pseudoRng.test.js
@@ -14,6 +14,10 @@ const {
   resetStreaks,
   MISS_STREAK_THRESHOLD,
   STREAK_BONUS,
+  seedRng,
+  clearSeed,
+  isSeeded,
+  defaultRng,
 } = require('../../../apps/backend/services/combat/pseudoRng');
 
 test('pseudoRng: 3 miss consecutivi → +5 to_hit bonus', () => {
@@ -59,4 +63,62 @@ test('pseudoRng: back-compat zero-bonus su unit senza fields + null safety', () 
   resetStreaks(unit);
   assert.equal(unit.miss_streak, 0);
   assert.equal(unit.hit_streak, 0);
+});
+
+// ─────────────────────────────────────────────────────────────────
+// TKT-PLAYTEST-SEED — seedable global RNG (bit-identical calibration).
+// defaultRng() is the canonical combat RNG provider: Math.random when
+// unseeded (zero prod change), deterministic mulberry32 stream when seeded.
+// ─────────────────────────────────────────────────────────────────
+
+test('pseudoRng: defaultRng unseeded yields floats in [0,1)', () => {
+  clearSeed();
+  assert.equal(isSeeded(), false, 'starts unseeded');
+  for (let i = 0; i < 50; i += 1) {
+    const v = defaultRng();
+    assert.ok(v >= 0 && v < 1, `value ${v} in [0,1)`);
+  }
+  assert.equal(isSeeded(), false, 'unseeded after draws (Math.random passthrough)');
+});
+
+test('pseudoRng: same seed → bit-identical sequence', () => {
+  seedRng(12345);
+  assert.equal(isSeeded(), true);
+  const a = Array.from({ length: 20 }, () => defaultRng());
+  seedRng(12345);
+  const b = Array.from({ length: 20 }, () => defaultRng());
+  assert.deepEqual(a, b, 'identical seed reproduces identical stream');
+  // values are real floats in range, not constant
+  assert.ok(new Set(a).size > 1, 'stream is not a constant');
+  clearSeed();
+});
+
+test('pseudoRng: different seeds → different sequences', () => {
+  seedRng(1);
+  const a = Array.from({ length: 10 }, () => defaultRng());
+  seedRng(2);
+  const b = Array.from({ length: 10 }, () => defaultRng());
+  assert.notDeepEqual(a, b, 'distinct seeds diverge');
+  clearSeed();
+});
+
+test('pseudoRng: clearSeed reverts to Math.random passthrough', () => {
+  seedRng(7);
+  assert.equal(isSeeded(), true);
+  clearSeed();
+  assert.equal(isSeeded(), false);
+  const v = defaultRng();
+  assert.ok(v >= 0 && v < 1);
+});
+
+test('pseudoRng: seedRng rejects non-finite, stays unseeded', () => {
+  clearSeed();
+  assert.equal(seedRng('not-a-number'), false);
+  assert.equal(isSeeded(), false);
+  assert.equal(seedRng(undefined), false);
+  assert.equal(isSeeded(), false);
+  // numeric string is coerced and accepted
+  assert.equal(seedRng('42'), true);
+  assert.equal(isSeeded(), true);
+  clearSeed();
 });

--- a/tests/test_calibrate_policies.py
+++ b/tests/test_calibrate_policies.py
@@ -1,0 +1,146 @@
+"""Unit tests for tools/py/calibrate_policies.py -- Restricted-Play policies.
+
+Backend-free. Validates the multi-policy player intent generators used by the
+triangulation harness (TKT-PLAYTEST-TRIANGULATE, Jaffe 2012 AIIDE):
+  - intent legality (player actor, valid action type, in-bounds move)
+  - random policy reproducibility under a seeded RNG
+  - lookahead2 secures an adjacent killable target
+  - utility prefers the lowest-HP target over a full-HP one
+  - band math (WR band + human estimate)
+"""
+
+from __future__ import annotations
+
+import random
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools" / "py"))
+
+from calibrate_policies import (  # noqa: E402
+    POLICIES,
+    compute_band,
+    pick_intents,
+)
+
+
+def _state():
+    """p1 adjacent to a low-HP enemy (e1), p2 near; e2 far + full HP."""
+    return {
+        "grid": {"width": 6, "height": 6},
+        "units": [
+            {"id": "p1", "controlled_by": "player", "hp": 10, "max_hp": 10,
+             "position": {"x": 0, "y": 0}, "ap_remaining": 2, "attack_range": 1},
+            {"id": "p2", "controlled_by": "player", "hp": 10, "max_hp": 10,
+             "position": {"x": 2, "y": 0}, "ap_remaining": 2, "attack_range": 1},
+            {"id": "e1", "controlled_by": "sistema", "hp": 2, "max_hp": 10,
+             "position": {"x": 0, "y": 1}},
+            {"id": "e2", "controlled_by": "sistema", "hp": 10, "max_hp": 10,
+             "position": {"x": 5, "y": 5}},
+        ],
+    }
+
+
+def _ctx():
+    return {
+        "channel_for": lambda tid: "psionico" if tid == "e1" else "fisico",
+        "enemy_priority": lambda e: 0,
+        "attack_range_default": 1,
+    }
+
+
+def _assert_legal(intents, state):
+    players = {u["id"] for u in state["units"] if u["controlled_by"] == "player"}
+    gw = state["grid"]["width"]
+    gh = state["grid"]["height"]
+    for it in intents:
+        assert it["actor_id"] in players, "intent actor must be a player unit"
+        act = it["action"]
+        assert act["type"] in ("attack", "move", "skip"), act["type"]
+        if act["type"] == "move":
+            p = act["position"]
+            assert 0 <= p["x"] < gw and 0 <= p["y"] < gh, "move in bounds"
+        if act["type"] == "attack":
+            assert "target_id" in act and "channel" in act
+
+
+def test_policies_constant_has_four():
+    assert set(POLICIES) == {"random", "greedy", "lookahead2", "utility"}
+
+
+def test_pick_intents_rejects_unknown_policy():
+    with pytest.raises(ValueError):
+        pick_intents("nonsense", _state(), _ctx(), random.Random(0))
+
+
+def test_pick_intents_greedy_not_handled_here():
+    # greedy stays in each script (back-compat); the shared module refuses it.
+    with pytest.raises(ValueError):
+        pick_intents("greedy", _state(), _ctx(), random.Random(0))
+
+
+def test_random_policy_is_legal_and_reproducible():
+    a = pick_intents("random", _state(), _ctx(), random.Random(123))
+    b = pick_intents("random", _state(), _ctx(), random.Random(123))
+    assert a == b, "same seed -> identical random intents"
+    _assert_legal(a, _state())
+
+
+def test_random_policy_diverges_on_different_seed():
+    a = pick_intents("random", _state(), _ctx(), random.Random(1))
+    b = pick_intents("random", _state(), _ctx(), random.Random(999))
+    # Not a hard guarantee per-call, but across the 2-unit action space these
+    # seeds differ; this guards against a constant (non-random) generator.
+    assert a != b
+
+
+def test_lookahead2_secures_adjacent_kill():
+    intents = pick_intents("lookahead2", _state(), _ctx(), None)
+    p1 = [it for it in intents if it["actor_id"] == "p1"]
+    assert p1, "p1 should act"
+    atk = [it for it in p1 if it["action"]["type"] == "attack"]
+    assert atk, "p1 adjacent to killable e1 must attack"
+    assert atk[0]["action"]["target_id"] == "e1"
+    assert atk[0]["action"]["channel"] == "psionico", "uses ctx channel_for"
+
+
+def test_utility_prefers_low_hp_target():
+    intents = pick_intents("utility", _state(), _ctx(), None)
+    p1_atk = [
+        it for it in intents
+        if it["actor_id"] == "p1" and it["action"]["type"] == "attack"
+    ]
+    assert p1_atk, "p1 in range of e1 should attack"
+    assert p1_atk[0]["action"]["target_id"] == "e1", "lowest-HP target preferred"
+
+
+def test_utility_is_deterministic():
+    assert pick_intents("utility", _state(), _ctx(), None) == pick_intents(
+        "utility", _state(), _ctx(), None
+    )
+
+
+def test_compute_band():
+    per_policy_runs = {
+        "random": [{"outcome": "defeat"}, {"outcome": "defeat"}, {"outcome": "victory"}, {"outcome": "defeat"}],
+        "greedy": [{"outcome": "victory"}, {"outcome": "victory"}, {"outcome": "defeat"}, {"outcome": "defeat"}],
+        "lookahead2": [{"outcome": "victory"}, {"outcome": "victory"}, {"outcome": "victory"}, {"outcome": "defeat"}],
+        "utility": [{"outcome": "victory"}, {"outcome": "victory"}, {"outcome": "victory"}, {"outcome": "victory"}],
+    }
+    band = compute_band(per_policy_runs)
+    assert band["policy_win_rate"]["random"] == pytest.approx(0.25)
+    assert band["policy_win_rate"]["greedy"] == pytest.approx(0.50)
+    assert band["policy_win_rate"]["lookahead2"] == pytest.approx(0.75)
+    assert band["policy_win_rate"]["utility"] == pytest.approx(1.0)
+    assert band["band"] == [pytest.approx(0.25), pytest.approx(1.0)]
+    # human estimate = greedy*0.55 + lookahead2*0.45 = 0.275 + 0.3375 = 0.6125
+    assert band["human_wr_est"] == pytest.approx(0.6125)
+
+
+def test_compute_band_handles_missing_policy():
+    band = compute_band({"random": [{"outcome": "defeat"}], "greedy": [{"outcome": "victory"}]})
+    assert band["band"] == [pytest.approx(0.0), pytest.approx(1.0)]
+    # human est None when lookahead2 absent
+    assert band["human_wr_est"] is None

--- a/tests/test_playtest_canonical.py
+++ b/tests/test_playtest_canonical.py
@@ -1,0 +1,93 @@
+"""Unit tests for tools/py/playtest_canonical.py -- canonical suite orchestrator.
+
+Backend-free. Covers the pure manifest/plan helpers + the --dry-run CLI path
+(TKT-PLAYTEST-SUITE). The live run (calibrate_parallel subprocess) is smoke-
+tested separately with a backend up (anti-pattern #9: dry-run != live smoke).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools" / "py"))
+
+import playtest_canonical as pc  # noqa: E402
+
+MANIFEST = ROOT / "docs" / "playtest" / "canonical-suite.yaml"
+
+
+def test_load_manifest_real_file():
+    m = pc.load_manifest(str(MANIFEST))
+    assert m["version"] == 1
+    assert isinstance(m["scenarios"], list) and len(m["scenarios"]) >= 2
+
+
+def test_oracle_scenarios_excludes_tutorial_ladder():
+    m = pc.load_manifest(str(MANIFEST))
+    oracles = pc.oracle_scenarios(m)
+    ids = {s["id"] for s in oracles}
+    assert "enc_tutorial_06_hardcore" in ids
+    assert "enc_tutorial_07_hardcore_pod_rush" in ids
+    # the designed-winnable tutorial ladder is NOT a balance oracle
+    assert "enc_tutorial_01_05" not in ids
+
+
+def test_resolve_parallel_key():
+    assert pc.resolve_parallel_key("enc_tutorial_06_hardcore") == "hardcore_06"
+    assert pc.resolve_parallel_key("enc_tutorial_07_hardcore_pod_rush") == "hardcore_07"
+    assert pc.resolve_parallel_key("nope") is None
+
+
+def test_wr_from_runs():
+    runs = [{"outcome": "victory"}, {"outcome": "defeat"}, {"outcome": "timeout"}, {"outcome": "victory"}]
+    assert pc.wr_from_runs(runs) == pytest.approx(0.5)
+    assert pc.wr_from_runs([]) is None
+    # non-dict / missing outcome are ignored
+    assert pc.wr_from_runs([{"outcome": "victory"}, {"error": "x"}]) == pytest.approx(1.0)
+
+
+def test_in_band():
+    assert pc.in_band(0.20, [0.15, 0.25]) is True
+    assert pc.in_band(0.15, [0.15, 0.25]) is True
+    assert pc.in_band(0.30, [0.15, 0.25]) is False
+    assert pc.in_band(None, [0.15, 0.25]) is False
+
+
+def test_build_plan_has_oracle_scenarios_with_keys():
+    m = pc.load_manifest(str(MANIFEST))
+    plan = pc.build_plan(m, n=40, shards=4, base_port=3341)
+    assert plan["n"] == 40
+    assert plan["shards"] == 4
+    keys = {s["parallel_key"] for s in plan["scenarios"]}
+    assert keys == {"hardcore_06", "hardcore_07"}
+    # repro contract surfaced in the plan
+    assert plan["repro"]["host"].startswith("http://127.0.0.1")
+    assert plan["repro"]["lobby_ws_enabled"] is False
+
+
+def test_build_plan_scenario_filter():
+    m = pc.load_manifest(str(MANIFEST))
+    plan = pc.build_plan(m, n=10, shards=2, base_port=3341, only="hardcore_06")
+    assert [s["parallel_key"] for s in plan["scenarios"]] == ["hardcore_06"]
+
+
+def test_dry_run_cli_no_backend(tmp_path):
+    """--dry-run parses the manifest + prints the plan and exits 0 without any
+    backend (this is the backend-free smoke gate)."""
+    env = dict(os.environ)
+    proc = subprocess.run(
+        [sys.executable, str(ROOT / "tools" / "py" / "playtest_canonical.py"),
+         "--dry-run", "--n", "40", "--manifest", str(MANIFEST)],
+        capture_output=True, text=True, env=env, cwd=str(ROOT), timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr
+    out = proc.stdout
+    assert "DRY-RUN" in out
+    assert "hardcore_06" in out and "hardcore_07" in out
+    assert "127.0.0.1" in out

--- a/tools/py/batch_calibrate_hardcore06.py
+++ b/tools/py/batch_calibrate_hardcore06.py
@@ -586,7 +586,7 @@ def _extract_trait_ids(action_result):
     return out
 
 
-def run_one(host, run_idx, turn_limit_defeat=None, biome_id=None):
+def run_one(host, run_idx, turn_limit_defeat=None, biome_id=None, seed=None):
     # Fetch scenario.
     status, sc = get(f"{host}/api/tutorial/{SCENARIO_ID}")
     if status != 200:
@@ -598,6 +598,9 @@ def run_one(host, run_idx, turn_limit_defeat=None, biome_id=None):
     # Start.
     status, start = post(f"{host}/api/session/start", {
         "units": units,
+        # TKT-PLAYTEST-SEED: pin backend combat RNG for bit-identical replay.
+        # None -> key omitted -> backend stays on Math.random (no behavior change).
+        **({"seed": seed} if seed is not None else {}),
         "modulation": "full",
         "sistema_pressure_start": pstart,
         "hazard_tiles": hazard,
@@ -694,6 +697,7 @@ def run_one(host, run_idx, turn_limit_defeat=None, biome_id=None):
 
     return {
         "run": run_idx,
+        "seed": seed,
         "outcome": outcome,
         "rounds": state.get("turn", 0),
         "players_alive": players_alive,
@@ -822,6 +826,10 @@ def main():
                     help="ERMES FASE 3 P2: set req.body.biome_id to exercise biome eco "
                          "deltas (applyBiomeEcoEffects) during calibration. e.g. "
                          "cryosteppe_convergence (HIGH) | rovine_planari (LOW).")
+    ap.add_argument("--seed", type=int, default=None,
+                    help="TKT-PLAYTEST-SEED: base seed for bit-identical runs. Run i uses "
+                         "seed+i (so the whole batch is reproducible). Omit = legacy "
+                         "Math.random (statistical reproducibility only).")
     args = ap.parse_args()
 
     # Health probe (TKT-08): fail fast se backend non risponde.
@@ -850,7 +858,9 @@ def main():
     failures = 0
     try:
         for i in range(args.n):
-            r = run_one(args.host, i, turn_limit_defeat=turn_limit_defeat, biome_id=args.biome_id)
+            run_seed = args.seed + i if args.seed is not None else None
+            r = run_one(args.host, i, turn_limit_defeat=turn_limit_defeat,
+                        biome_id=args.biome_id, seed=run_seed)
             runs.append(r)
             if "error" in r:
                 failures += 1

--- a/tools/py/batch_calibrate_hardcore06.py
+++ b/tools/py/batch_calibrate_hardcore06.py
@@ -14,12 +14,15 @@ shard look like it "hangs" after ~7 sessions. Always pass an IP host, not a name
 import argparse
 import json
 import os
+import random
 import re
 import statistics
 import sys
 import time
 import urllib.error
 import urllib.request
+
+import calibrate_policies
 
 SCENARIO_ID = "enc_tutorial_06_hardcore"
 MAX_ROUNDS = 40
@@ -371,6 +374,31 @@ def _pick_channel_for(target_id):
     return CHANNEL_EXPLOIT_MAP.get(target_id, "fisico")
 
 
+# TKT-PLAYTEST-TRIANGULATE: hc06 ctx -- channel exploit map + boss-last priority
+# (focus minions first, mirrors plan_player_intents enemy_priority).
+def _enemy_priority_hc06(e):
+    eid = e.get("id", "")
+    if eid == "e_apex_boss":
+        return 2
+    if "elite" in eid:
+        return 1
+    return 0
+
+
+POLICY_CTX = {
+    "channel_for": _pick_channel_for,
+    "enemy_priority": _enemy_priority_hc06,
+    "attack_range_default": 1,
+}
+
+
+def _policy_rng(policy, run_seed):
+    """random.Random for the 'random' policy (seeded -> reproducible); None else."""
+    if policy != "random":
+        return None
+    return random.Random(run_seed) if run_seed is not None else random.Random()
+
+
 def plan_player_intents(state, occupied):
     units = state.get("units", [])
     grid = state.get("grid", {})
@@ -586,7 +614,8 @@ def _extract_trait_ids(action_result):
     return out
 
 
-def run_one(host, run_idx, turn_limit_defeat=None, biome_id=None, seed=None):
+def run_one(host, run_idx, turn_limit_defeat=None, biome_id=None, seed=None,
+            policy="greedy", rng=None):
     # Fetch scenario.
     status, sc = get(f"{host}/api/tutorial/{SCENARIO_ID}")
     if status != 200:
@@ -630,7 +659,10 @@ def run_one(host, run_idx, turn_limit_defeat=None, biome_id=None, seed=None):
         outcome = detect_outcome(state, turn_limit_defeat)
         if outcome:
             break
-        intents = plan_player_intents(state, None)
+        if policy == "greedy":
+            intents = plan_player_intents(state, None)
+        else:
+            intents = calibrate_policies.pick_intents(policy, state, POLICY_CTX, rng)
         status, resp = post(f"{host}/api/session/round/execute", {
             "session_id": sid,
             "player_intents": intents,
@@ -698,6 +730,7 @@ def run_one(host, run_idx, turn_limit_defeat=None, biome_id=None, seed=None):
     return {
         "run": run_idx,
         "seed": seed,
+        "policy": policy,
         "outcome": outcome,
         "rounds": state.get("turn", 0),
         "players_alive": players_alive,
@@ -807,6 +840,69 @@ def _hist(values, bins):
     return out
 
 
+def run_triangulation(args):
+    """TKT-PLAYTEST-TRIANGULATE: run every policy at N and report a WR band.
+    Additive output (mode=triangulation); single-policy callers unaffected."""
+    from calibrate_policies import POLICIES, compute_band
+
+    turn_limit_defeat = load_turn_limit_defeat(args.encounter_class, scenario_id=SCENARIO_ID)
+    print(
+        f"Hardcore 06 TRIANGULATION: policies={list(POLICIES)} N={args.n}/policy "
+        f"host={args.host} seed={'None' if args.seed is None else args.seed} "
+        f"turn_limit_defeat={turn_limit_defeat}",
+        flush=True,
+    )
+    t0 = time.time()
+    per_policy = {}
+    policy_aggs = {}
+    for pol in POLICIES:
+        runs = []
+        for i in range(args.n):
+            run_seed = args.seed + i if args.seed is not None else None
+            r = run_one(args.host, i, turn_limit_defeat=turn_limit_defeat,
+                        biome_id=args.biome_id, seed=run_seed, policy=pol,
+                        rng=_policy_rng(pol, run_seed))
+            runs.append(r)
+            mark = ("V" if r.get("outcome") == "victory" else "L" if r.get("outcome") == "defeat"
+                    else "T" if r.get("outcome") == "timeout" else "E")
+            print(f"  [{pol}] [{i+1}/{args.n}] {mark} rounds={r.get('rounds','?')} "
+                  f"boss_hp={r.get('boss_hp_remaining','?')}", flush=True)
+            if args.cooldown > 0 and i + 1 < args.n:
+                time.sleep(args.cooldown)
+        per_policy[pol] = runs
+        policy_aggs[pol] = aggregate(runs, encounter_class=args.encounter_class)
+
+    band = compute_band(per_policy)
+    elapsed = round(time.time() - t0, 1)
+    pwr = band["policy_win_rate"]
+    print("\n=== TRIANGULATION BAND ===", flush=True)
+    for pol in POLICIES:
+        wr = pwr.get(pol)
+        print(f"  {pol:11s} WR={'n/a' if wr is None else f'{wr * 100:.1f}%'}", flush=True)
+    lo, hi = band["band"]
+    human = band["human_wr_est"]
+    lo_s = "n/a" if lo is None else f"{lo * 100:.1f}%"
+    hi_s = "n/a" if hi is None else f"{hi * 100:.1f}%"
+    human_s = "n/a" if human is None else f"{human * 100:.1f}%"
+    print(f"  band=[{lo_s}, {hi_s}]  human_est={human_s} ({band['human_wr_formula']})", flush=True)
+
+    out = {
+        "scenario_id": SCENARIO_ID,
+        "mode": "triangulation",
+        "n_per_policy": args.n,
+        "seed": args.seed,
+        "encounter_class": args.encounter_class,
+        "elapsed_sec": elapsed,
+        "band": band,
+        "policies": {pol: {"aggregate": policy_aggs[pol], "runs": per_policy[pol]} for pol in POLICIES},
+    }
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as f:
+            json.dump(out, f, indent=2)
+        print(f"\nWrote {args.out}")
+    return 0
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--host", default=DEFAULT_HOST)
@@ -830,6 +926,11 @@ def main():
                     help="TKT-PLAYTEST-SEED: base seed for bit-identical runs. Run i uses "
                          "seed+i (so the whole batch is reproducible). Omit = legacy "
                          "Math.random (statistical reproducibility only).")
+    ap.add_argument("--policy", default="greedy",
+                    choices=["random", "greedy", "lookahead2", "utility", "all"],
+                    help="TKT-PLAYTEST-TRIANGULATE: player policy proxy. 'all' runs every "
+                         "policy and reports a WR band (Jaffe 2012 Restricted Play). "
+                         "Default greedy (back-compat single-policy output).")
     args = ap.parse_args()
 
     # Health probe (TKT-08): fail fast se backend non risponde.
@@ -843,6 +944,10 @@ def main():
     if args.probe:
         probe_one(args.host)
         return 0
+
+    # TKT-PLAYTEST-TRIANGULATE: multi-policy band mode short-circuits single flow.
+    if args.policy == "all":
+        return run_triangulation(args)
 
     # M9 P6: load turn_limit_defeat per class (force decision pressure).
     # 2026-05-20 L-069 iter3: pass SCENARIO_ID for scenario_overrides resolution.
@@ -860,7 +965,8 @@ def main():
         for i in range(args.n):
             run_seed = args.seed + i if args.seed is not None else None
             r = run_one(args.host, i, turn_limit_defeat=turn_limit_defeat,
-                        biome_id=args.biome_id, seed=run_seed)
+                        biome_id=args.biome_id, seed=run_seed, policy=args.policy,
+                        rng=_policy_rng(args.policy, run_seed))
             runs.append(r)
             if "error" in r:
                 failures += 1

--- a/tools/py/batch_calibrate_hardcore07.py
+++ b/tools/py/batch_calibrate_hardcore07.py
@@ -145,13 +145,16 @@ def detect_outcome(state, timer_expired):
     return None
 
 
-def run_one(host, run_idx):
+def run_one(host, run_idx, seed=None):
     status, sc = get(f"{host}/api/tutorial/{SCENARIO_ID}")
     if status != 200:
         return {"run": run_idx, "error": f"scenario fetch {status}"}
 
     status, start = post(f"{host}/api/session/start", {
         "units": sc["units"],
+        # TKT-PLAYTEST-SEED: pin backend combat RNG for bit-identical replay.
+        # None -> key omitted -> backend stays on Math.random (no behavior change).
+        **({"seed": seed} if seed is not None else {}),
         "modulation": sc.get("recommended_modulation", "quartet"),
         "sistema_pressure_start": sc.get("sistema_pressure_start", 60),
         "hazard_tiles": sc.get("hazard_tiles", []),
@@ -237,6 +240,7 @@ def run_one(host, run_idx):
     losses = player_initial - players_alive
     return {
         "run": run_idx,
+        "seed": seed,
         "outcome": outcome,
         "rounds": rounds,
         "timer_expired": timer_expired,
@@ -342,6 +346,10 @@ def main():
     p.add_argument("--jsonl", default=None, help="JSONL incremental output (resume)")
     p.add_argument("--cooldown", type=float, default=0.5, help="Sec between runs")
     p.add_argument("--skip-health", action="store_true", help="Skip /api/health probe")
+    p.add_argument("--seed", type=int, default=None,
+                   help="TKT-PLAYTEST-SEED: base seed for bit-identical runs. Run i uses "
+                        "seed+i (so the whole batch is reproducible). Omit = legacy "
+                        "Math.random (statistical reproducibility only).")
     args = p.parse_args()
 
     # TKT-08: health probe fail-fast prima di batch.
@@ -351,14 +359,16 @@ def main():
             return 1
         print(f"OK: backend healthy at {args.host}", flush=True)
 
-    print(f"Hardcore 07 calibration: N={args.n} host={args.host}", flush=True)
+    seed_note = f"seed={args.seed} (bit-identical)" if args.seed is not None else "seed=None (statistical)"
+    print(f"Hardcore 07 calibration: N={args.n} host={args.host} {seed_note}", flush=True)
     t0 = time.time()
     runs = []
     failures = 0
     jsonl_fh = open(args.jsonl, "a", encoding="utf-8") if args.jsonl else None
     try:
         for i in range(args.n):
-            r = run_one(args.host, i + 1)
+            run_seed = args.seed + i if args.seed is not None else None
+            r = run_one(args.host, i + 1, seed=run_seed)
             runs.append(r)
             if "error" in r:
                 failures += 1

--- a/tools/py/batch_calibrate_hardcore07.py
+++ b/tools/py/batch_calibrate_hardcore07.py
@@ -17,9 +17,26 @@ import time
 import urllib.error
 import urllib.request
 
+import calibrate_policies
+
 SCENARIO_ID = "enc_tutorial_07_hardcore_pod_rush"
 MAX_ROUNDS = 15
 DEFAULT_HOST = "http://127.0.0.1:3334"  # IP not "localhost" (Windows IPv6 ~2s/call stall)
+
+# TKT-PLAYTEST-TRIANGULATE: hc07 is a timer scenario with no archetype channel
+# exploit -> fisico focus, equal enemy priority.
+POLICY_CTX = {
+    "channel_for": lambda _tid: "fisico",
+    "enemy_priority": lambda _e: 0,
+    "attack_range_default": 1,
+}
+
+
+def _policy_rng(policy, run_seed):
+    """random.Random for the 'random' policy (seeded -> reproducible); None else."""
+    if policy != "random":
+        return None
+    return random.Random(run_seed) if run_seed is not None else random.Random()
 
 
 def _retry(fn, retries=5, backoff_base=0.5):
@@ -145,7 +162,7 @@ def detect_outcome(state, timer_expired):
     return None
 
 
-def run_one(host, run_idx, seed=None):
+def run_one(host, run_idx, seed=None, policy="greedy", rng=None):
     status, sc = get(f"{host}/api/tutorial/{SCENARIO_ID}")
     if status != 200:
         return {"run": run_idx, "error": f"scenario fetch {status}"}
@@ -187,7 +204,10 @@ def run_one(host, run_idx, seed=None):
 
     for r in range(1, MAX_ROUNDS + 1):
         rounds = r
-        intents = plan_intents(state)
+        if policy == "greedy":
+            intents = plan_intents(state)
+        else:
+            intents = calibrate_policies.pick_intents(policy, state, POLICY_CTX, rng)
         status, resp = post(f"{host}/api/session/round/execute", {
             "session_id": sid,
             "player_intents": intents,
@@ -241,6 +261,7 @@ def run_one(host, run_idx, seed=None):
     return {
         "run": run_idx,
         "seed": seed,
+        "policy": policy,
         "outcome": outcome,
         "rounds": rounds,
         "timer_expired": timer_expired,
@@ -338,6 +359,64 @@ def summarise(runs):
     }
 
 
+def run_triangulation(args):
+    """TKT-PLAYTEST-TRIANGULATE: run every policy at N and report a WR band.
+    Output shape is additive (mode=triangulation) so single-policy callers
+    (calibrate_parallel.py) are unaffected."""
+    from calibrate_policies import POLICIES, compute_band
+
+    print(
+        f"Hardcore 07 TRIANGULATION: policies={list(POLICIES)} N={args.n}/policy "
+        f"host={args.host} seed={'None' if args.seed is None else args.seed}",
+        flush=True,
+    )
+    t0 = time.time()
+    per_policy = {}
+    policy_summaries = {}
+    for pol in POLICIES:
+        runs = []
+        for i in range(args.n):
+            run_seed = args.seed + i if args.seed is not None else None
+            r = run_one(args.host, i + 1, seed=run_seed, policy=pol,
+                        rng=_policy_rng(pol, run_seed))
+            runs.append(r)
+            print(f"  [{pol}] run {i+1}: {r.get('outcome', 'error')} "
+                  f"rounds={r.get('rounds', '?')}", flush=True)
+            if args.cooldown > 0 and i + 1 < args.n:
+                time.sleep(args.cooldown)
+        per_policy[pol] = runs
+        policy_summaries[pol] = summarise(runs)
+
+    band = compute_band(per_policy)
+    elapsed = round(time.time() - t0, 1)
+    pwr = band["policy_win_rate"]
+    print("\n=== TRIANGULATION BAND ===", flush=True)
+    for pol in POLICIES:
+        wr = pwr.get(pol)
+        print(f"  {pol:11s} WR={'n/a' if wr is None else f'{wr * 100:.1f}%'}", flush=True)
+    lo, hi = band["band"]
+    human = band["human_wr_est"]
+    lo_s = "n/a" if lo is None else f"{lo * 100:.1f}%"
+    hi_s = "n/a" if hi is None else f"{hi * 100:.1f}%"
+    human_s = "n/a" if human is None else f"{human * 100:.1f}%"
+    print(f"  band=[{lo_s}, {hi_s}]  human_est={human_s} ({band['human_wr_formula']})", flush=True)
+
+    out = {
+        "scenario": SCENARIO_ID,
+        "mode": "triangulation",
+        "n_per_policy": args.n,
+        "seed": args.seed,
+        "elapsed_s": elapsed,
+        "band": band,
+        "policies": {pol: {"summary": policy_summaries[pol], "runs": per_policy[pol]} for pol in POLICIES},
+    }
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as f:
+            json.dump(out, f, indent=2)
+        print(f"Saved: {args.out}", flush=True)
+    return 0
+
+
 def main():
     p = argparse.ArgumentParser()
     p.add_argument("--n", type=int, default=10)
@@ -350,6 +429,11 @@ def main():
                    help="TKT-PLAYTEST-SEED: base seed for bit-identical runs. Run i uses "
                         "seed+i (so the whole batch is reproducible). Omit = legacy "
                         "Math.random (statistical reproducibility only).")
+    p.add_argument("--policy", default="greedy",
+                   choices=["random", "greedy", "lookahead2", "utility", "all"],
+                   help="TKT-PLAYTEST-TRIANGULATE: player policy proxy. 'all' runs every "
+                        "policy and reports a WR band (Jaffe 2012 Restricted Play). "
+                        "Default greedy (back-compat single-policy output).")
     args = p.parse_args()
 
     # TKT-08: health probe fail-fast prima di batch.
@@ -358,6 +442,10 @@ def main():
             print(f"ERROR: backend health check failed at {args.host}/api/health", flush=True)
             return 1
         print(f"OK: backend healthy at {args.host}", flush=True)
+
+    # TKT-PLAYTEST-TRIANGULATE: multi-policy band mode short-circuits single flow.
+    if args.policy == "all":
+        return run_triangulation(args)
 
     seed_note = f"seed={args.seed} (bit-identical)" if args.seed is not None else "seed=None (statistical)"
     print(f"Hardcore 07 calibration: N={args.n} host={args.host} {seed_note}", flush=True)
@@ -368,7 +456,8 @@ def main():
     try:
         for i in range(args.n):
             run_seed = args.seed + i if args.seed is not None else None
-            r = run_one(args.host, i + 1, seed=run_seed)
+            r = run_one(args.host, i + 1, seed=run_seed, policy=args.policy,
+                        rng=_policy_rng(args.policy, run_seed))
             runs.append(r)
             if "error" in r:
                 failures += 1

--- a/tools/py/calibrate_policies.py
+++ b/tools/py/calibrate_policies.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Multi-policy player intent generators -- Restricted-Play triangulation.
+
+TKT-PLAYTEST-TRIANGULATE (2026-05-29). Shared by batch_calibrate_hardcore0{6,7}.py
+to drive the player party with policies of varying strength so a single greedy
+proxy is NOT mistaken for the human (anti-pattern rejected by Jaffe 2012 AIIDE +
+Politowski 2023). The harness reports a WR *band*, not one verdict.
+
+Policies (weak -> strong player proxy):
+  random      noise floor -- uniform random legal action (seeded -> reproducible)
+  greedy      each script's existing nearest-enemy focus -- kept IN-SCRIPT for
+              exact back-compat (this module refuses it on purpose)
+  lookahead2  tactical: focus-fire the most-killable target, move into range
+  utility     smart: weighted considerations argmax, mirrors
+              apps/backend/services/ai/utilityBrain.js (TargetHealth +
+              Distance considerations)
+
+Human WR ~= band [random_WR, strong_WR]; initial point estimate
+greedy_WR*0.55 + lookahead2_WR*0.45 (CANONICAL-AI-PLAYTEST.md sec 1.1).
+
+Pure module: no HTTP, no backend. Intent shape matches POST
+/api/session/round/execute `player_intents`:
+  attack: {actor_id, action:{type:'attack', target_id, channel}}
+  move:   {actor_id, action:{type:'move', position:{x,y}}}
+  skip:   {actor_id, action:{type:'skip'}}
+"""
+
+from __future__ import annotations
+
+POLICIES = ("random", "greedy", "lookahead2", "utility")
+
+# utility consideration weights (mirror utilityBrain.js DEFAULT_CONSIDERATIONS).
+_W_TARGET_HEALTH = 1.0   # prefer low-HP targets (secure kills)
+_W_DISTANCE = 0.8        # prefer close targets
+_MAX_RANGE = 10          # distance normaliser (utilityBrain Distance.maxRange)
+_ATTACK_BONUS = 0.5      # attacking beats repositioning when both available
+
+
+def manhattan(a, b):
+    return abs(a["x"] - b["x"]) + abs(a["y"] - b["y"])
+
+
+def _living(units, faction):
+    return [u for u in units if u.get("controlled_by") == faction and u.get("hp", 0) > 0]
+
+
+def _ap(unit):
+    return unit.get("ap_remaining", unit.get("ap", 2))
+
+
+def _range(unit, ctx):
+    return unit.get("attack_range", ctx.get("attack_range_default", 1))
+
+
+def _channel_for(ctx):
+    fn = ctx.get("channel_for")
+    return fn if callable(fn) else (lambda _tid: "fisico")
+
+
+def _priority_of(ctx):
+    fn = ctx.get("enemy_priority")
+    return fn if callable(fn) else (lambda _e: 0)
+
+
+def _legal_moves(pos, gw, gh, reserved):
+    """4-neighbour steps in-bounds and not currently occupied (deterministic order)."""
+    out = []
+    for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+        nx, ny = pos["x"] + dx, pos["y"] + dy
+        if 0 <= nx < gw and 0 <= ny < gh and (nx, ny) not in reserved:
+            out.append({"x": nx, "y": ny})
+    return out
+
+
+def _step_toward(src, dst, gw, gh, reserved):
+    """One greedy orthogonal step toward dst, avoiding reserved tiles."""
+    dx = dst["x"] - src["x"]
+    dy = dst["y"] - src["y"]
+    cands = []
+    if abs(dx) >= abs(dy) and dx != 0:
+        cands.append({"x": src["x"] + (1 if dx > 0 else -1), "y": src["y"]})
+    if dy != 0:
+        cands.append({"x": src["x"], "y": src["y"] + (1 if dy > 0 else -1)})
+    if dx != 0:
+        cands.append({"x": src["x"] + (1 if dx > 0 else -1), "y": src["y"]})
+    for c in cands:
+        if 0 <= c["x"] < gw and 0 <= c["y"] < gh and (c["x"], c["y"]) not in reserved:
+            return c
+    return None
+
+
+def _grid(state):
+    g = state.get("grid", {}) or {}
+    return int(g.get("width", 10)), int(g.get("height", 10))
+
+
+def _attack_intent(pl, target, ctx):
+    return {
+        "actor_id": pl["id"],
+        "action": {
+            "type": "attack",
+            "target_id": target["id"],
+            "channel": _channel_for(ctx)(target["id"]),
+        },
+    }
+
+
+def plan_random(state, ctx, rng):
+    """Uniform random legal action per player. Noise floor. Needs a seeded
+    random.Random for reproducibility."""
+    if rng is None:
+        raise ValueError("plan_random requires a random.Random instance")
+    units = state.get("units", [])
+    gw, gh = _grid(state)
+    players = _living(units, "player")
+    enemies = _living(units, "sistema")
+    if not enemies:
+        return []
+    reserved = {(u["position"]["x"], u["position"]["y"]) for u in units if u.get("hp", 0) > 0}
+    intents = []
+    for pl in players:
+        ap = _ap(pl)
+        if ap <= 0:
+            continue
+        rng_ = _range(pl, ctx)
+        candidates = []
+        if ap >= 1:
+            for e in enemies:
+                if manhattan(pl["position"], e["position"]) <= rng_:
+                    candidates.append(("attack", e))
+        if ap >= 2:
+            for mv in _legal_moves(pl["position"], gw, gh, reserved):
+                candidates.append(("move", mv))
+        candidates.append(("skip", None))
+        kind, payload = candidates[rng.randrange(len(candidates))]
+        if kind == "attack":
+            intents.append(_attack_intent(pl, payload, ctx))
+        elif kind == "move":
+            intents.append({"actor_id": pl["id"], "action": {"type": "move", "position": payload}})
+            reserved.discard((pl["position"]["x"], pl["position"]["y"]))
+            reserved.add((payload["x"], payload["y"]))
+        else:
+            intents.append({"actor_id": pl["id"], "action": {"type": "skip"}})
+    return intents
+
+
+def lookahead2(state, ctx):
+    """Tactical: focus-fire the most-killable in-range target; otherwise close
+    the distance to the best target so the kill lands next turn."""
+    units = state.get("units", [])
+    gw, gh = _grid(state)
+    players = _living(units, "player")
+    enemies = _living(units, "sistema")
+    if not enemies:
+        return []
+    prio = _priority_of(ctx)
+    reserved = {(u["position"]["x"], u["position"]["y"]) for u in units if u.get("hp", 0) > 0}
+    intents = []
+    for pl in players:
+        ap = _ap(pl)
+        if ap <= 0:
+            continue
+        rng_ = _range(pl, ctx)
+        in_range = [e for e in enemies if manhattan(pl["position"], e["position"]) <= rng_]
+        if in_range and ap >= 1:
+            # secure the kill: lowest HP first, then priority, then nearest.
+            target = min(in_range, key=lambda e: (e.get("hp", 0), prio(e), manhattan(pl["position"], e["position"])))
+            intents.append(_attack_intent(pl, target, ctx))
+            continue
+        # approach the most-killable target (lowest HP, then priority, then nearest).
+        target = min(enemies, key=lambda e: (e.get("hp", 0), prio(e), manhattan(pl["position"], e["position"])))
+        if ap >= 2:
+            nxt = _step_toward(pl["position"], target["position"], gw, gh, reserved)
+            if nxt is not None:
+                intents.append({"actor_id": pl["id"], "action": {"type": "move", "position": nxt}})
+                reserved.discard((pl["position"]["x"], pl["position"]["y"]))
+                reserved.add((nxt["x"], nxt["y"]))
+                if manhattan(nxt, target["position"]) <= rng_:
+                    intents.append(_attack_intent(pl, target, ctx))
+            else:
+                intents.append({"actor_id": pl["id"], "action": {"type": "skip"}})
+        else:
+            intents.append({"actor_id": pl["id"], "action": {"type": "skip"}})
+    return intents
+
+
+def _utility_target_health(target):
+    mh = target.get("max_hp") or 0
+    if mh <= 0:
+        return 0.5
+    return 1.0 - (target.get("hp", 0) / mh)  # linear_inverse: low HP -> high score
+
+
+def utility(state, ctx):
+    """Smart policy: weighted-consideration argmax per player. Mirrors
+    utilityBrain.js (TargetHealth linear_inverse + Distance quadratic_inverse)."""
+    units = state.get("units", [])
+    gw, gh = _grid(state)
+    players = _living(units, "player")
+    enemies = _living(units, "sistema")
+    if not enemies:
+        return []
+    prio = _priority_of(ctx)
+    reserved = {(u["position"]["x"], u["position"]["y"]) for u in units if u.get("hp", 0) > 0}
+    intents = []
+    for pl in players:
+        ap = _ap(pl)
+        if ap <= 0:
+            continue
+        rng_ = _range(pl, ctx)
+        scored = []  # (score, kind, payload, priority_tiebreak)
+        # attack candidates (in range, ap>=1)
+        if ap >= 1:
+            for e in enemies:
+                dist = manhattan(pl["position"], e["position"])
+                if dist <= rng_:
+                    th = _utility_target_health(e)
+                    ds = 1.0 - min(dist / _MAX_RANGE, 1.0)
+                    score = _W_TARGET_HEALTH * th + _W_DISTANCE * (ds * ds) + _ATTACK_BONUS
+                    scored.append((score, "attack", e, prio(e)))
+        # move candidates toward each enemy (ap>=2)
+        if ap >= 2:
+            best_target = min(enemies, key=lambda e: (prio(e), e.get("hp", 0), manhattan(pl["position"], e["position"])))
+            nxt = _step_toward(pl["position"], best_target["position"], gw, gh, reserved)
+            if nxt is not None:
+                th = _utility_target_health(best_target)
+                newdist = manhattan(nxt, best_target["position"])
+                ds = 1.0 - min(newdist / _MAX_RANGE, 1.0)
+                score = _W_TARGET_HEALTH * th + _W_DISTANCE * (ds * ds)
+                scored.append((score, "move", nxt, prio(best_target)))
+        if not scored:
+            intents.append({"actor_id": pl["id"], "action": {"type": "skip"}})
+            continue
+        # argmax; deterministic tie-break: higher score, then lower priority value.
+        scored.sort(key=lambda s: (-s[0], s[3]))
+        _score, kind, payload, _p = scored[0]
+        if kind == "attack":
+            intents.append(_attack_intent(pl, payload, ctx))
+        else:
+            intents.append({"actor_id": pl["id"], "action": {"type": "move", "position": payload}})
+            reserved.discard((pl["position"]["x"], pl["position"]["y"]))
+            reserved.add((payload["x"], payload["y"]))
+    return intents
+
+
+def pick_intents(policy, state, ctx, rng=None):
+    """Dispatch to a non-greedy policy. `greedy` is intentionally NOT handled
+    here -- each batch script keeps its own ratified greedy planner."""
+    if policy == "random":
+        return plan_random(state, ctx, rng)
+    if policy == "lookahead2":
+        return lookahead2(state, ctx)
+    if policy == "utility":
+        return utility(state, ctx)
+    raise ValueError(
+        f"pick_intents: policy {policy!r} not handled here "
+        f"(greedy stays in-script; valid shared policies: random/lookahead2/utility)"
+    )
+
+
+def compute_band(per_policy_runs):
+    """Given {policy: [run,...]} compute per-policy WR (fraction), the WR band
+    [min,max], and the initial human estimate greedy*0.55 + lookahead2*0.45."""
+    wr = {}
+    for pol, runs in per_policy_runs.items():
+        ok = [r for r in runs if isinstance(r, dict) and "outcome" in r]
+        n = len(ok)
+        if n == 0:
+            continue
+        wins = sum(1 for r in ok if r.get("outcome") == "victory")
+        wr[pol] = wins / n
+    band = [min(wr.values()), max(wr.values())] if wr else [None, None]
+    human = None
+    if "greedy" in wr and "lookahead2" in wr:
+        human = wr["greedy"] * 0.55 + wr["lookahead2"] * 0.45
+    return {
+        "policy_win_rate": wr,
+        "band": band,
+        "human_wr_est": human,
+        "human_wr_formula": "greedy*0.55 + lookahead2*0.45",
+    }

--- a/tools/py/playtest_canonical.py
+++ b/tools/py/playtest_canonical.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Canonical AI-driven playtest suite runner (TKT-PLAYTEST-SUITE, 2026-05-29).
+
+Single-command orchestrator that reproduces the ratified balance state "every
+time": reads the machine-readable manifest (docs/playtest/canonical-suite.yaml),
+runs each canonical balance-oracle scenario at N=40 (ratify gate, L-069) via
+tools/py/calibrate_parallel.py, checks each WR against its ratified target band,
+and writes a dated combined report under docs/playtest/.
+
+Method SoT: docs/process/CANONICAL-AI-PLAYTEST.md (sec 6 "comando canonico").
+
+Reproducibility contract (CANONICAL-AI-PLAYTEST.md sec 3), enforced here +
+inside calibrate_parallel.start_shard:
+  - host 127.0.0.1 (NOT localhost: Windows IPv6 ::1 stall ~2s/call)
+  - LOBBY_WS_ENABLED=false per shard (port collision, L-071)
+  - DAMAGE_CURVES_PATH set so client + backend read the same staging file
+    (else scenario_overrides are a silent client-side no-op, L-069/OD-032)
+
+--dry-run parses the manifest and prints the execution plan with NO backend
+(backend-free smoke gate; anti-pattern #9: dry-run != live smoke -> always
+follow with a live N>=10 run before trusting it).
+
+Usage:
+  python tools/py/playtest_canonical.py --dry-run
+  python tools/py/playtest_canonical.py --n 40                 # full suite
+  python tools/py/playtest_canonical.py --scenario hardcore_06 --n 10  # one
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOLS_PY = REPO_ROOT / "tools" / "py"
+CALIBRATE_PARALLEL = TOOLS_PY / "calibrate_parallel.py"
+DEFAULT_MANIFEST = REPO_ROOT / "docs" / "playtest" / "canonical-suite.yaml"
+
+sys.path.insert(0, str(TOOLS_PY))
+import calibrate_parallel  # noqa: E402  (SoT for scenario_id -> parallel key)
+
+# scenario_id (manifest) -> calibrate_parallel scenario key. Inverted from the
+# parallel runner's own SCENARIO_MAP so the mapping has one source of truth.
+_ID_TO_KEY = {cfg["scenario_id"]: key for key, cfg in calibrate_parallel.SCENARIO_MAP.items()}
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (unit-tested, backend-free)
+# ---------------------------------------------------------------------------
+
+def load_manifest(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def oracle_scenarios(manifest):
+    """Balance-oracle scenarios only (the designed-winnable tutorial ladder is
+    NOT a difficulty target -- excluded)."""
+    return [s for s in manifest.get("scenarios", []) if s.get("role") == "balance_oracle"]
+
+
+def resolve_parallel_key(scenario_id):
+    """Manifest scenario id -> calibrate_parallel --scenario key, or None."""
+    return _ID_TO_KEY.get(scenario_id)
+
+
+def wr_from_runs(runs):
+    """Win rate (fraction) computed directly from runs -- unit-consistent across
+    the hc06 (fraction) / hc07 (percent) aggregate quirk. None if no runs."""
+    ok = [r for r in runs if isinstance(r, dict) and "outcome" in r]
+    if not ok:
+        return None
+    return sum(1 for r in ok if r.get("outcome") == "victory") / len(ok)
+
+
+def in_band(wr, band):
+    if wr is None or not band or len(band) != 2:
+        return False
+    return band[0] <= wr <= band[1]
+
+
+def build_plan(manifest, n, shards, base_port, only=None):
+    """Backend-free execution plan (used by --dry-run + the live runner)."""
+    scenarios = []
+    for s in oracle_scenarios(manifest):
+        key = resolve_parallel_key(s["id"])
+        if key is None:
+            continue
+        if only and key != only:
+            continue
+        scenarios.append({
+            "id": s["id"],
+            "parallel_key": key,
+            "target_band": s.get("target_band"),
+            "ratified_knob": s.get("ratified_knob"),
+            "n": n,
+            "ports": [base_port + i for i in range(shards)],
+        })
+    repro = dict(manifest.get("repro", {}))
+    return {
+        "n": n,
+        "shards": shards,
+        "base_port": base_port,
+        "ladder_role": "ratify" if n >= 40 else ("probe" if n <= 10 else "interim"),
+        "scenarios": scenarios,
+        "repro": repro,
+        "composite_metric": manifest.get("composite_metric"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Live execution (calibrate_parallel subprocess) + report
+# ---------------------------------------------------------------------------
+
+def _resolve_curves_path(manifest):
+    cfg = manifest.get("repro", {}).get("config_source") or "data/core/balance/damage_curves.yaml"
+    p = REPO_ROOT / cfg
+    return str(p)
+
+
+def run_scenario(parallel_key, n, shards, base_port, work_dir, label, curves_path):
+    """Run one scenario via calibrate_parallel.py, read the merged JSON, return
+    a result row. Honors the repro contract via DAMAGE_CURVES_PATH env."""
+    work_dir = Path(work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        sys.executable, "-u", str(CALIBRATE_PARALLEL),
+        "--scenario", parallel_key, "--n", str(n),
+        "--shards", str(shards), "--base-port", str(base_port),
+        "--out-dir", str(work_dir), "--label", label,
+    ]
+    env = dict(os.environ)
+    if curves_path:
+        env["DAMAGE_CURVES_PATH"] = curves_path
+    print(f"\n[suite] >>> {parallel_key} N={n} shards={shards} base_port={base_port}", flush=True)
+    proc = subprocess.run(cmd, env=env, cwd=str(REPO_ROOT))
+    merged = work_dir / f"parallel-{parallel_key}-{label}-merged.json"
+    if proc.returncode != 0 or not merged.exists():
+        return {
+            "parallel_key": parallel_key, "status": "failed",
+            "returncode": proc.returncode, "merged_path": str(merged),
+        }
+    data = json.loads(merged.read_text(encoding="utf-8"))
+    runs = data.get("runs", [])
+    return {
+        "parallel_key": parallel_key,
+        "status": "ok",
+        "n_runs": len(runs),
+        "win_rate": wr_from_runs(runs),
+        "merged_path": str(merged),
+        "elapsed_sec": data.get("parallel_elapsed_sec"),
+    }
+
+
+def build_report(plan, results, label, manifest_path):
+    rows = []
+    all_in_band = True
+    by_key = {r["parallel_key"]: r for r in results}
+    for sc in plan["scenarios"]:
+        r = by_key.get(sc["parallel_key"], {})
+        wr = r.get("win_rate")
+        band = sc["target_band"]
+        ib = in_band(wr, band) if r.get("status") == "ok" else None
+        if ib is not True:
+            all_in_band = False
+        rows.append({
+            "id": sc["id"],
+            "parallel_key": sc["parallel_key"],
+            "target_band": band,
+            "ratified_knob": sc["ratified_knob"],
+            "status": r.get("status", "missing"),
+            "n_runs": r.get("n_runs"),
+            "win_rate": wr,
+            "in_band": ib,
+            "elapsed_sec": r.get("elapsed_sec"),
+            "merged_path": r.get("merged_path"),
+        })
+    return {
+        "suite": "canonical-ai-playtest",
+        "label": label,
+        "manifest": str(manifest_path),
+        "n": plan["n"],
+        "ladder_role": plan["ladder_role"],
+        "all_in_band": all_in_band,
+        "repro": plan["repro"],
+        "scenarios": rows,
+    }
+
+
+def _fmt_pct(x):
+    return "n/a" if x is None else f"{x * 100:.1f}%"
+
+
+def _fmt_band(b):
+    return "n/a" if not b else f"[{b[0] * 100:.0f}%, {b[1] * 100:.0f}%]"
+
+
+def write_report(report, out_dir, label):
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / f"{label}-canonical-suite.json"
+    md_path = out_dir / f"{label}-canonical-suite.md"
+    json_path.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    lines = [
+        f"# Canonical AI-driven playtest suite -- {label}",
+        "",
+        f"Manifest: `{report['manifest']}`  |  N={report['n']} ({report['ladder_role']})  "
+        f"|  all_in_band: **{report['all_in_band']}**",
+        "",
+        "| scenario | key | band | WR (N) | in-band | knob |",
+        "|---|---|---|---|---|---|",
+    ]
+    for s in report["scenarios"]:
+        ib = {True: "YES", False: "NO", None: "?"}[s["in_band"]]
+        knob = json.dumps(s["ratified_knob"]) if s["ratified_knob"] else "-"
+        lines.append(
+            f"| {s['id']} | {s['parallel_key']} | {_fmt_band(s['target_band'])} | "
+            f"{_fmt_pct(s['win_rate'])} ({s['n_runs']}) | {ib} | `{knob}` |"
+        )
+    lines += [
+        "",
+        "Method SoT: `docs/process/CANONICAL-AI-PLAYTEST.md`. "
+        "Repro: host 127.0.0.1, LOBBY_WS_ENABLED=false, DAMAGE_CURVES_PATH pinned.",
+        "",
+    ]
+    md_path.write_text("\n".join(lines), encoding="utf-8")
+    return {"json": str(json_path), "md": str(md_path)}
+
+
+def print_plan(plan, manifest_path):
+    print("=== DRY-RUN: canonical AI-driven playtest suite plan ===", flush=True)
+    print(f"manifest: {manifest_path}", flush=True)
+    print(f"N per scenario: {plan['n']} (ladder role: {plan['ladder_role']})  "
+          f"shards: {plan['shards']}  base_port: {plan['base_port']}", flush=True)
+    repro = plan["repro"]
+    print("repro contract:", flush=True)
+    print(f"  host={repro.get('host')}  lobby_ws_enabled={repro.get('lobby_ws_enabled')}  "
+          f"damage_curves_path_required={repro.get('damage_curves_path_required')}", flush=True)
+    print(f"  config_source={repro.get('config_source')}", flush=True)
+    print(f"scenarios ({len(plan['scenarios'])}):", flush=True)
+    for s in plan["scenarios"]:
+        band = _fmt_band(s["target_band"])
+        print(f"  - {s['id']} -> --scenario {s['parallel_key']} N={s['n']} "
+              f"band={band} ports={s['ports']} knob={json.dumps(s['ratified_knob'])}", flush=True)
+    if not plan["scenarios"]:
+        print("  (none -- check manifest roles / scenario filter)", flush=True)
+    print("=== no backend touched (dry run) ===", flush=True)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--manifest", default=str(DEFAULT_MANIFEST))
+    p.add_argument("--n", type=int, default=40, help="Runs per scenario (default 40 = ratify gate).")
+    p.add_argument("--shards", type=int, default=4)
+    p.add_argument("--base-port", type=int, default=3341)
+    p.add_argument("--scenario", default=None,
+                   help="Run only this calibrate_parallel key (e.g. hardcore_06).")
+    p.add_argument("--out-dir", default="docs/playtest", help="Where the combined report is written.")
+    p.add_argument("--label", default=None, help="Report label (default today's date).")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Parse manifest + print plan, NO backend (backend-free smoke).")
+    args = p.parse_args()
+
+    manifest = load_manifest(args.manifest)
+    plan = build_plan(manifest, args.n, args.shards, args.base_port, only=args.scenario)
+
+    if args.dry_run:
+        print_plan(plan, args.manifest)
+        return 0
+
+    if not plan["scenarios"]:
+        print("[suite] no scenarios resolved (check manifest / --scenario filter)", file=sys.stderr, flush=True)
+        return 2
+
+    label = args.label or time.strftime("%Y-%m-%d")
+    curves_path = _resolve_curves_path(manifest)
+    work_dir = Path(REPO_ROOT) / args.out_dir / f"_canonical-work-{label}"
+
+    print(f"[suite] canonical run: {len(plan['scenarios'])} scenario(s) N={args.n} "
+          f"label={label} curves={curves_path}", flush=True)
+    results = []
+    for sc in plan["scenarios"]:
+        results.append(run_scenario(
+            sc["parallel_key"], args.n, args.shards, args.base_port,
+            work_dir, label, curves_path,
+        ))
+
+    report = build_report(plan, results, label, args.manifest)
+    paths = write_report(report, Path(REPO_ROOT) / args.out_dir, label)
+
+    print("\n=== CANONICAL SUITE REPORT ===", flush=True)
+    for s in report["scenarios"]:
+        print(f"  {s['parallel_key']:12s} WR={_fmt_pct(s['win_rate'])} "
+              f"band={_fmt_band(s['target_band'])} in_band={s['in_band']} status={s['status']}", flush=True)
+    print(f"  all_in_band={report['all_in_band']}", flush=True)
+    print(f"report: {paths['md']}", flush=True)
+    # Non-zero exit when a touched scenario regressed out of band (CI gate-able).
+    return 0 if report["all_in_band"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Canonical AI-driven playtest harness — 3 tickets

Implements the 3 enhancements from `docs/process/CANONICAL-AI-PLAYTEST.md` §7 / `BACKLOG.md`, making the AI-driven playtest paradigm (PRs #2445/#2446) reproducible **every time** + one-command. Done in order, each smoke-tested with a backend up **before** the next (anti-pattern #9: dry-run ≠ live smoke).

### TKT-PLAYTEST-SEED (`fd5c050c`)
- `--seed` on `batch_calibrate_hardcore0{6,7}.py` → new seedable global RNG in `apps/backend/services/combat/pseudoRng.js` (mulberry32), pinned at `POST /api/session/start`.
- Every combat-path `Math.random` fallback (session rng `session.js:256`, morale, reinforcement, traitEffects, abilityExecutor, utilityBrain) now draws from `defaultRng`: **identical to `Math.random` when unseeded → zero production change**; deterministic stream when seeded. Run *i* uses `seed+i` (whole batch reproducible).
- **Smoke** (backend up `127.0.0.1:3334`): 2× N=2 `--seed 42` → bit-identical `runs[]`; unseeded 2× N=3 → differ (proves the seed drives determinism).

### TKT-PLAYTEST-TRIANGULATE (`b3ed0430`)
- `--policy {random,greedy,lookahead2,utility,all}` via shared `tools/py/calibrate_policies.py` (Restricted Play, Jaffe 2012 AIIDE). `all` → WR **band** `[random_WR, strong_WR]` + human estimate `greedy*0.55 + lookahead2*0.45`, not a single verdict.
- `greedy` stays in-script (exact back-compat); default single-policy output shape unchanged → `calibrate_parallel.py` + ratified bands safe.
- **Smoke**: hc06 `--policy all` N=2 → band random 0% < greedy 50% ~ lookahead2 50% < utility 100% (correct weak→strong ordering); hc07 likewise.

### TKT-PLAYTEST-SUITE (`26387f52`)
- `tools/py/playtest_canonical.py`: reads `docs/playtest/canonical-suite.yaml` → runs each balance-oracle scenario at N=40 via `calibrate_parallel.py` → dated combined report (json+md) under `docs/playtest/`. `--dry-run` parses the manifest + prints the plan with **no backend** (backend-free smoke gate).
- Enforces the repro contract: host `127.0.0.1`, `LOBBY_WS_ENABLED=false` per shard, `DAMAGE_CURVES_PATH` pinned. Exits 1 when a scenario regresses out of band (CI-gateable).
- **Smoke**: `--dry-run` lists hc06 `[15-25%]` + hc07 `[30-50%]`; live `hardcore_06` N=10 → 4 shards → merged 10 runs → report written.

### Tests / gates
- New tests: `tests/services/sprint-alpha/pseudoRng.test.js` (+5 seedable-RNG), `tests/test_calibrate_policies.py` (10), `tests/test_playtest_canonical.py` (8).
- AI regression `tests/ai/*.test.js` **462/462**; affected combat modules **82/82**; docs governance `--strict` **errors=0**.
- Ratified bands **NOT touched**: hc06 `[15-25%]` (`boss_hp_multiplier 0.65`), hc07 `[30-50%]` (`enemy_damage_multiplier_override 2.1`).

### Notes
- The N=2 / N=10 smokes above are **probes** (L-069 noise floor), not band-placement claims — the suite's default **N=40** is the ratify gate.
- Trackers updated same-PR (anti-pattern #19): SoT §3/§6/§7 + manifest `seed_pinned: true` + BACKLOG section → SHIPPED.
- Per task: **do not merge until governance + ci-gate green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
