### PR TITLE
feat(coop): gated 'nido' hub phase for Godot return-to-Nido loop (N1 PR-G)

### DIFF
--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -29,6 +29,7 @@ const PHASES = [
   'world_setup',
   'combat',
   'debrief',
+  'nido', // N1 Nido-hub phase (return-to-hub loop step, after debrief)
   'ended',
 ];
 

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -7,6 +7,7 @@
 const crypto = require('crypto');
 const { foldObservations } = require('../ai/sistemaStateAccumulator');
 const { createSistemaStateStore } = require('../ai/sistemaStateStore');
+const { checkNidoUnlock } = require('../../routes/sessionHelpers');
 
 // CAMP-1/CAMP-2 - run.id is the SistemaState persistence key (server writes
 // SistemaState under run.id; Godot client keys CampaignState.campaign_id on
@@ -71,11 +72,17 @@ class CoopOrchestrator {
     now = Date.now,
     worldEnricher = null,
     sistemaStateStore = null,
+    nidoUnlocked = false,
   } = {}) {
     if (!roomCode) throw new Error('room_code_required');
     this.roomCode = roomCode;
     this.hostId = hostId || null;
     this.now = now;
+    // N1 Nido-hub — pre-seeded unlock flag (DI seam for tests + server-side
+    // room construction). When true, debrief advance routes to 'nido' instead
+    // of directly to world_setup. env NIDO_UNLOCKED=true also activates the
+    // gate (checked at call-time via checkNidoUnlock).
+    this._nidoUnlocked = Boolean(nidoUnlocked);
     // CAMP-2 — SistemaState accumulation store (DI seam, same style as
     // worldEnricher). Default lazily wires the canonical Prisma-backed store
     // on first use so module-load order / stub-mode (no DATABASE_URL) stays
@@ -745,11 +752,34 @@ class CoopOrchestrator {
         advance = { action: 'already_ended' };
       }
     } else if (this.phase === 'debrief') {
-      advance = this.advanceScenarioOrEnd();
+      // N1 Nido-hub gate: if unlocked, route to nido hub before advancing.
+      // checkNidoUnlock checks env NIDO_UNLOCKED=true OR meta.nido_unlocked.
+      if (checkNidoUnlock({ meta: { nido_unlocked: this._nidoUnlocked } })) {
+        this._setPhase('nido');
+        advance = { action: 'nido' };
+      } else {
+        advance = this.advanceScenarioOrEnd();
+      }
     } else {
       advance = { action: 'noop_post_advance' };
     }
     return { choice, phase: this.phase, run_state: this.run, advance };
+  }
+
+  /**
+   * N1 Nido-hub — host leaves the hub and starts the next mission.
+   * Requires phase === 'nido'. Host-only. Delegates to advanceScenarioOrEnd()
+   * which moves phase to world_setup (or ended if stack exhausted).
+   *
+   * @param playerId — submitting player (must equal hostId)
+   * @param hostId — current host player id (host-only gate)
+   * @returns { phase, advance, run_state }
+   */
+  startMissionFromNido(playerId, { hostId } = {}) {
+    if (hostId && playerId !== hostId) throw new Error('host_only');
+    if (this.phase !== 'nido') throw new Error('not_in_nido');
+    const advance = this.advanceScenarioOrEnd();
+    return { phase: this.phase, advance, run_state: this.run };
   }
 
   /**

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -89,6 +89,7 @@ const KNOWN_PHASES = new Set([
   'world_seed_reveal', // UI-only transient between world_setup → combat
   'combat',
   'debrief',
+  'nido', // N1 Nido-hub phase
   'ended',
   // Combat lifecycle hints (not orch phases, but used by round model).
   'planning',

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -1828,6 +1828,43 @@ function createWsServer({
             }
             return;
           }
+          // N1 Nido-hub — host leaves nido and starts the next mission.
+          // Mirror of next_macro handler shape.
+          if (action === 'nido_start_mission' && coopStore) {
+            if (player.role !== 'host') {
+              socket.send(JSON.stringify({ type: 'error', payload: { code: 'not_host' } }));
+              return;
+            }
+            try {
+              const orch = coopStore.get(room.code);
+              if (!orch) {
+                socket.send(
+                  JSON.stringify({ type: 'error', payload: { code: 'run_not_started' } }),
+                );
+                return;
+              }
+              const result = orch.startMissionFromNido(playerId, { hostId: room.hostId });
+              if (result.phase === 'world_setup') {
+                room.publishPhaseChange('world_setup');
+              } else if (result.phase === 'ended') {
+                room.publishPhaseChange('ended');
+              }
+              socket.send(
+                JSON.stringify({
+                  type: 'nido_start_mission_accepted',
+                  payload: { phase: result.phase },
+                }),
+              );
+            } catch (err) {
+              socket.send(
+                JSON.stringify({
+                  type: 'error',
+                  payload: { code: err.message || 'nido_start_mission_failed' },
+                }),
+              );
+            }
+            return;
+          }
           // No more lifecycle drain branches — all 5 server-side now.
           // Defensive fallback: relay to host (legacy web v1 path) for
           // any unrecognized lifecycle intent.

--- a/tests/api/coopOrchestrator.test.js
+++ b/tests/api/coopOrchestrator.test.js
@@ -154,9 +154,10 @@ test('worldTally back-compat omits connected_* fields when arg missing', () => {
   assert.equal(tally.all_connected_accepted, undefined);
 });
 
-test('PHASES covers lobby→onboarding→character_creation→world_setup→combat→debrief→ended', () => {
+test('PHASES covers lobby→onboarding→character_creation→world_setup→combat→debrief→nido→ended', () => {
   // 2026-05-06 narrative onboarding port — `onboarding` inserted between
   // lobby and character_creation per canonical 51-ONBOARDING-60S.md.
+  // N1 Nido-hub — `nido` inserted after `debrief` (return-to-hub loop step).
   assert.deepEqual(PHASES, [
     'lobby',
     'onboarding',
@@ -164,6 +165,7 @@ test('PHASES covers lobby→onboarding→character_creation→world_setup→comb
     'world_setup',
     'combat',
     'debrief',
+    'nido',
     'ended',
   ]);
 });

--- a/tests/services/coop/coopOrchestrator-nido.test.js
+++ b/tests/services/coop/coopOrchestrator-nido.test.js
@@ -1,0 +1,20 @@
+// G1 — N1 Nido-hub: verify 'nido' is a valid phase in coopOrchestrator.
+// Task: register 'nido' in PHASES so _setPhase('nido') does not throw.
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { CoopOrchestrator } = require('../../../apps/backend/services/coop/coopOrchestrator');
+
+function freshAtDebrief() {
+  const o = new CoopOrchestrator({ roomCode: 'TEST', hostId: 'h1', now: () => 1 });
+  o.run = { id: 'run_test', outcome: null };
+  o.phase = 'debrief';
+  return o;
+}
+
+test("_setPhase('nido') is a valid phase", () => {
+  const o = freshAtDebrief();
+  assert.doesNotThrow(() => o._setPhase('nido'));
+  assert.equal(o.phase, 'nido');
+});

--- a/tests/services/coop/coopOrchestrator-nido.test.js
+++ b/tests/services/coop/coopOrchestrator-nido.test.js
@@ -1,20 +1,97 @@
 // G1 — N1 Nido-hub: verify 'nido' is a valid phase in coopOrchestrator.
-// Task: register 'nido' in PHASES so _setPhase('nido') does not throw.
+// G2 — N1 Nido-hub: gate debrief-advance into nido + startMissionFromNido.
 'use strict';
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const { CoopOrchestrator } = require('../../../apps/backend/services/coop/coopOrchestrator');
 
-function freshAtDebrief() {
-  const o = new CoopOrchestrator({ roomCode: 'TEST', hostId: 'h1', now: () => 1 });
-  o.run = { id: 'run_test', outcome: null };
+// freshAtDebrief: minimal orchestrator at debrief phase with a 2-scenario run
+// (so advanceScenarioOrEnd goes to world_setup, not ended).
+function freshAtDebrief({ nidoUnlocked = false } = {}) {
+  const o = new CoopOrchestrator({ roomCode: 'TEST', hostId: 'h1', now: () => 1, nidoUnlocked });
+  o.run = {
+    id: 'run_test',
+    outcome: null,
+    matingResolved: false,
+    survivors: [],
+    partyXp: 0,
+    partyPi: 0,
+    scenarioStack: ['enc_tutorial_01', 'enc_tutorial_02'],
+    currentIndex: 0,
+    lastMacro: null,
+  };
   o.phase = 'debrief';
   return o;
 }
+
+// --- G1 test (unchanged) ---
 
 test("_setPhase('nido') is a valid phase", () => {
   const o = freshAtDebrief();
   assert.doesNotThrow(() => o._setPhase('nido'));
   assert.equal(o.phase, 'nido');
+});
+
+// --- G2 tests ---
+
+// (a) debrief + advance enters 'nido' when unlocked (constructor flag)
+test('submitNextMacro advance from debrief enters nido when nidoUnlocked=true', () => {
+  const o = freshAtDebrief({ nidoUnlocked: true });
+  const result = o.submitNextMacro('h1', { choice: 'advance' }, { hostId: 'h1' });
+  assert.equal(o.phase, 'nido');
+  assert.equal(result.phase, 'nido');
+  assert.deepEqual(result.advance, { action: 'nido' });
+});
+
+// (a2) env override also unlocks
+test('submitNextMacro advance from debrief enters nido when NIDO_UNLOCKED env=true', () => {
+  const o = freshAtDebrief({ nidoUnlocked: false });
+  process.env.NIDO_UNLOCKED = 'true';
+  try {
+    const result = o.submitNextMacro('h1', { choice: 'advance' }, { hostId: 'h1' });
+    assert.equal(o.phase, 'nido');
+    assert.equal(result.phase, 'nido');
+    assert.deepEqual(result.advance, { action: 'nido' });
+  } finally {
+    delete process.env.NIDO_UNLOCKED;
+  }
+});
+
+// (b) debrief + advance does NOT enter nido when locked (goes to world_setup)
+test('submitNextMacro advance from debrief goes to world_setup when nido locked', () => {
+  const o = freshAtDebrief({ nidoUnlocked: false });
+  delete process.env.NIDO_UNLOCKED; // ensure env is clean
+  const result = o.submitNextMacro('h1', { choice: 'advance' }, { hostId: 'h1' });
+  assert.notEqual(o.phase, 'nido');
+  assert.notEqual(result.phase, 'nido');
+  // advanceScenarioOrEnd with 2 scenarios -> world_setup
+  assert.equal(o.phase, 'world_setup');
+});
+
+// (c) startMissionFromNido from nido advances to world_setup
+test('startMissionFromNido from nido phase returns world_setup', () => {
+  const o = freshAtDebrief({ nidoUnlocked: true });
+  o._setPhase('nido'); // manually enter nido
+  const result = o.startMissionFromNido('h1', { hostId: 'h1' });
+  assert.equal(o.phase, 'world_setup');
+  assert.equal(result.phase, 'world_setup');
+  assert.equal(result.advance.action, 'next_scenario');
+  assert.ok(result.run_state, 'run_state present');
+});
+
+// (d) startMissionFromNido is host-only
+test('startMissionFromNido throws host_only for non-host', () => {
+  const o = freshAtDebrief({ nidoUnlocked: true });
+  o._setPhase('nido');
+  assert.throws(() => o.startMissionFromNido('player2', { hostId: 'h1' }), {
+    message: 'host_only',
+  });
+});
+
+// (d2) startMissionFromNido throws not_in_nido when phase != nido
+test('startMissionFromNido throws not_in_nido when not in nido phase', () => {
+  const o = freshAtDebrief();
+  // phase is 'debrief', not 'nido'
+  assert.throws(() => o.startMissionFromNido('h1', { hostId: 'h1' }), { message: 'not_in_nido' });
 });

--- a/tests/services/network/wsSession-nido.test.js
+++ b/tests/services/network/wsSession-nido.test.js
@@ -1,0 +1,201 @@
+// N1 Nido-hub — nido_start_mission WS intent routes to
+// orchestrator.startMissionFromNido (host-only) and broadcasts
+// phase_change -> world_setup. Mirror of next_macro handler shape.
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const WebSocket = require('ws');
+const {
+  LobbyService,
+  createWsServer,
+} = require('../../../apps/backend/services/network/wsSession');
+const { createCoopStore } = require('../../../apps/backend/services/coop/coopStore');
+
+process.env.AUTH_SECRET = 'test-secret-must-be-at-least-16-chars-long';
+
+function attachBuffer(ws) {
+  ws.__buf = [];
+  ws.__waiters = [];
+  ws.on('message', (raw) => {
+    let msg;
+    try {
+      msg = JSON.parse(raw.toString());
+    } catch {
+      return;
+    }
+    ws.__buf.push(msg);
+    for (const w of ws.__waiters.slice()) {
+      if (w.predicate(msg)) {
+        ws.__waiters = ws.__waiters.filter((x) => x !== w);
+        w.resolve(msg);
+      }
+    }
+  });
+  return ws;
+}
+
+function waitForMessage(ws, predicate, timeoutMs = 3000) {
+  for (const msg of ws.__buf) {
+    if (predicate(msg)) return Promise.resolve(msg);
+  }
+  return new Promise((resolve, reject) => {
+    const waiter = { predicate, resolve, reject };
+    const timer = setTimeout(() => {
+      ws.__waiters = ws.__waiters.filter((x) => x !== waiter);
+      reject(new Error('timeout waiting for ws message'));
+    }, timeoutMs);
+    waiter.resolve = (msg) => {
+      clearTimeout(timer);
+      resolve(msg);
+    };
+    ws.__waiters.push(waiter);
+  });
+}
+
+function openWs(port, { code, player_id, token }) {
+  const url = `ws://127.0.0.1:${port}/ws?code=${encodeURIComponent(code)}&player_id=${encodeURIComponent(player_id)}&token=${encodeURIComponent(token)}`;
+  return attachBuffer(new WebSocket(url));
+}
+
+async function waitOpen(ws) {
+  return new Promise((resolve, reject) => {
+    ws.once('open', () => resolve());
+    ws.once('error', reject);
+  });
+}
+
+test('N1: nido_start_mission intent -> startMissionFromNido -> phase_change world_setup broadcast', async () => {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const wsHandle = createWsServer({ lobby, coopStore, port: 0 });
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  const port = wsHandle.wss.address().port;
+
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Bob' });
+
+    const orch = coopStore.getOrCreate(room.code);
+    // Two scenarios so advanceScenarioOrEnd lands on world_setup not ended.
+    orch.startRun({ scenarioStack: ['enc_tutorial_01', 'enc_tutorial_02'] });
+    // Force orchestrator to nido phase so startMissionFromNido is accepted.
+    orch.phase = 'nido';
+
+    const hostWs = openWs(port, {
+      code: room.code,
+      player_id: room.host_id,
+      token: room.host_token,
+    });
+    const p1Ws = openWs(port, {
+      code: room.code,
+      player_id: p1.player_id,
+      token: p1.player_token,
+    });
+
+    await Promise.all([waitOpen(hostWs), waitOpen(p1Ws)]);
+    await Promise.all([
+      waitForMessage(hostWs, (m) => m.type === 'hello'),
+      waitForMessage(p1Ws, (m) => m.type === 'hello'),
+    ]);
+
+    hostWs.send(JSON.stringify({ type: 'intent', payload: { action: 'nido_start_mission' } }));
+
+    // Host receives nido_start_mission_accepted ack.
+    const ack = await waitForMessage(hostWs, (m) => m.type === 'nido_start_mission_accepted', 2000);
+    assert.equal(ack.payload.phase, 'world_setup');
+
+    // All connected clients receive phase_change -> world_setup.
+    const [hostPc, p1Pc] = await Promise.all([
+      waitForMessage(
+        hostWs,
+        (m) => m.type === 'phase_change' && m.payload?.phase === 'world_setup',
+        2000,
+      ),
+      waitForMessage(
+        p1Ws,
+        (m) => m.type === 'phase_change' && m.payload?.phase === 'world_setup',
+        2000,
+      ),
+    ]);
+    assert.equal(hostPc.payload.phase, 'world_setup');
+    assert.equal(p1Pc.payload.phase, 'world_setup');
+
+    hostWs.close();
+    p1Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('N1: nido_start_mission by non-host returns error not_host', async () => {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const wsHandle = createWsServer({ lobby, coopStore, port: 0 });
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  const port = wsHandle.wss.address().port;
+
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Bob' });
+
+    const orch = coopStore.getOrCreate(room.code);
+    orch.startRun({ scenarioStack: ['enc_tutorial_01'] });
+    orch.phase = 'nido';
+
+    const p1Ws = openWs(port, {
+      code: room.code,
+      player_id: p1.player_id,
+      token: p1.player_token,
+    });
+    await waitOpen(p1Ws);
+    await waitForMessage(p1Ws, (m) => m.type === 'hello');
+
+    p1Ws.send(JSON.stringify({ type: 'intent', payload: { action: 'nido_start_mission' } }));
+
+    const errMsg = await waitForMessage(p1Ws, (m) => m.type === 'error', 2000);
+    assert.ok(errMsg.payload.code, 'error code present');
+
+    p1Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('N1: nido_start_mission when no orchestrator returns run_not_started error', async () => {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const wsHandle = createWsServer({ lobby, coopStore, port: 0 });
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  const port = wsHandle.wss.address().port;
+
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+
+    const hostWs = openWs(port, {
+      code: room.code,
+      player_id: room.host_id,
+      token: room.host_token,
+    });
+    await waitOpen(hostWs);
+    await waitForMessage(hostWs, (m) => m.type === 'hello');
+
+    hostWs.send(JSON.stringify({ type: 'intent', payload: { action: 'nido_start_mission' } }));
+
+    const errMsg = await waitForMessage(hostWs, (m) => m.type === 'error', 2000);
+    assert.equal(errMsg.payload.code, 'run_not_started');
+
+    hostWs.close();
+  } finally {
+    await wsHandle.close();
+  }
+});


### PR DESCRIPTION
## N1 Nido-hub — Game/ side (PR-G of two-repo)

Adds a gated co-op `nido` phase so the Godot client can insert a "return to Nido hub" step between debrief and the next mission. Godot client = separate PR (PR-N). Server phase enum was gated (`coopOrchestrator.PHASES` + `wsSession.KNOWN_PHASES`), so this Game/ change is required for the phone mirror.

### Changes (TDD, `node --test`)
- **G1** — register `'nido'` in `coopOrchestrator.PHASES` + `wsSession.KNOWN_PHASES`.
- **G2** — `submitNextMacro` debrief-advance routes to `nido` when unlocked (via existing `checkNidoUnlock` — env `NIDO_UNLOCKED=true` OR a new `nidoUnlocked` constructor DI flag, default **locked = today's behavior**); new `startMissionFromNido(playerId,{hostId})` (host-only, requires phase `nido`, delegates to `advanceScenarioOrEnd` -> `world_setup`).
- **G3** — `wsSession` `nido_start_mission` host intent -> `startMissionFromNido` + `publishPhaseChange` (mirrors `next_macro` handler).

### Tests
coop **108/108**, network **79/79** (no regression; +10 new nido tests). Gate defaults locked → zero behavior change until `NIDO_UNLOCKED` / constructor flag set.

### Scope
Read-only Nido-hub display + next-mission only (N1). N2-N5 (party/mate/recruit/Descent) + rich Nido modules/resources out of scope. Real narrative `nido_unlocked` authoring = follow-up. Spec/plan: Godot-v2 `docs/superpowers/{specs,plans}/2026-05-30-nido-hub-n1*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)