### PR TITLE
fix(playtest): address Codex review on #2448 (seed passthrough + per-session RNG)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -130,13 +130,11 @@ const { loadTraitEnvironmentalCosts, applyBiomeEcoEffects } = require('../servic
 // pressure / enemy HP. Same encounter on savana vs abisso_vulcanico now
 // produces different numbers, not just different texture.
 const { getBiomeModifiers, applyEnemyHpMultiplier } = require('../services/combat/biomeModifiers');
-// TKT-PLAYTEST-SEED (2026-05-29): canonical seedable combat RNG. Unseeded =
-// Math.random (zero prod change); seeded at /start = bit-identical calibration.
-const {
-  defaultRng,
-  seedRng: seedCombatRng,
-  clearSeed: clearCombatSeed,
-} = require('../services/combat/pseudoRng');
+// TKT-PLAYTEST-SEED (2026-05-29): canonical seedable combat RNG. Unseeded
+// defaultRng === Math.random (zero prod change). The seed is recorded per
+// session (session.combatRng) and installed by sessionRoundBridge via
+// runWithSeed only while resolving that session's combat (P2 review fix).
+const { defaultRng } = require('../services/combat/pseudoRng');
 // TKT-WORLDGEN-GAPB (2026-05-29): seasonal cross-event flat pressure engine.
 const { getCrossEventPressureDelta } = require('../services/worldgen/crossEventEngine');
 // M6-#1 (ADR-2026-04-19 + spike 2026-04-19): Node native resistance engine.
@@ -1356,14 +1354,16 @@ function createSessionRouter(options = {}) {
 
   router.post('/start', async (req, res, next) => {
     try {
-      // TKT-PLAYTEST-SEED: pin the combat RNG for bit-identical calibration.
-      // Must run before any session-setup roll. Production omits `seed` ->
-      // clearCombatSeed() -> Math.random passthrough (no behavior change).
+      // TKT-PLAYTEST-SEED (P2 per-session): record the combat seed on the
+      // session (combatRng holder), NOT a process-global stream. The round
+      // bridge installs it via runWithSeed only while resolving THIS session's
+      // combat, so concurrent sessions never share RNG state. Production omits
+      // `seed` -> null -> Math.random passthrough (no behavior change).
       const seedRaw = req.body?.seed;
+      let combatSeedState = null;
       if (seedRaw !== undefined && seedRaw !== null && seedRaw !== '') {
-        seedCombatRng(seedRaw);
-      } else {
-        clearCombatSeed();
+        const seedNum = Number(seedRaw);
+        if (Number.isFinite(seedNum)) combatSeedState = seedNum >>> 0;
       }
       const sessionId = newSessionId();
       const now = new Date();
@@ -1594,6 +1594,10 @@ function createSessionRouter(options = {}) {
       const session = {
         session_id: sessionId,
         scenario_id: scenarioId,
+        // TKT-PLAYTEST-SEED (P2): per-session RNG cursor. { state: int } when a
+        // seed was provided (deterministic), { state: null } otherwise
+        // (Math.random). Installed by sessionRoundBridge via runWithSeed.
+        combatRng: { state: combatSeedState },
         // M7-#2 Phase B: persist encounter class per enrage check runtime
         encounter_class: encounterClassUsed || 'standard',
         pressure_start: pressureStart,

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -39,6 +39,10 @@ const {
   resetRoundSynergyTracker,
 } = require('../services/combat/synergyDetector');
 const { tick: reinforcementTick } = require('../services/combat/reinforcementSpawner');
+// TKT-PLAYTEST-SEED (P2): per-session RNG scoping for combat round resolution.
+// Installs session.combatRng around each (synchronous) resolveRoundPure so a
+// seeded calibration session's stream is isolated from concurrent sessions.
+const { runWithSeed } = require('../services/combat/pseudoRng');
 const { evaluateObjective } = require('../services/combat/objectiveEvaluator');
 const { tick: missionTimerTick } = require('../services/combat/missionTimer');
 // 2026-04-26: wire isTurnLimitExceeded (damage_curves.yaml soft cap per encounter_class).
@@ -505,7 +509,9 @@ function createRoundBridge(deps) {
     }
     cur = roundOrchestrator.declareIntent(cur, actor.id, roundAction).nextState;
     cur = roundOrchestrator.commitRound(cur).nextState;
-    const result = resolveRoundPure(cur, null, rng, realResolveAction);
+    const result = runWithSeed(session.combatRng, () =>
+      resolveRoundPure(cur, null, rng, realResolveAction),
+    );
     session.roundState = result.nextState;
     syncStatusesFromRoundState(session);
 
@@ -1652,7 +1658,9 @@ function createRoundBridge(deps) {
       return { nextState: next, turnLogEntry };
     };
 
-    const result = resolveRoundPure(session.roundState, null, rng, realResolveAction);
+    const result = runWithSeed(session.combatRng, () =>
+      resolveRoundPure(session.roundState, null, rng, realResolveAction),
+    );
     session.roundState = result.nextState;
     syncStatusesFromRoundState(session);
 
@@ -1806,7 +1814,9 @@ function createRoundBridge(deps) {
       if (session.roundState && session.roundState.round_phase === PHASE_PLANNING) {
         try {
           session.roundState = roundOrchestrator.commitRound(session.roundState).nextState;
-          const result = resolveRoundPure(session.roundState, null, rng, placeholderResolveAction);
+          const result = runWithSeed(session.combatRng, () =>
+            resolveRoundPure(session.roundState, null, rng, placeholderResolveAction),
+          );
           session.roundState = result.nextState;
           syncStatusesFromRoundState(session);
         } catch (_e) {
@@ -2057,7 +2067,9 @@ function createRoundBridge(deps) {
 
         // auto_resolve=true: risolve round in simultanea usando unified resolver
         const { resolveFn, iaActions, playerActions, kills } = buildUnifiedRoundResolver(session);
-        const result = resolveRoundPure(session.roundState, null, rng, resolveFn);
+        const result = runWithSeed(session.combatRng, () =>
+          resolveRoundPure(session.roundState, null, rng, resolveFn),
+        );
         session.roundState = result.nextState;
         syncStatusesFromRoundState(session);
 
@@ -2169,7 +2181,9 @@ function createRoundBridge(deps) {
             .status(400)
             .json({ error: 'roundState non inizializzato (chiama prima /declare-intent)' });
         }
-        const result = resolveRoundPure(session.roundState, null, rng, placeholderResolveAction);
+        const result = runWithSeed(session.combatRng, () =>
+          resolveRoundPure(session.roundState, null, rng, placeholderResolveAction),
+        );
         session.roundState = result.nextState;
         syncStatusesFromRoundState(session);
         res.json({

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -42,7 +42,7 @@ const { tick: reinforcementTick } = require('../services/combat/reinforcementSpa
 // TKT-PLAYTEST-SEED (P2): per-session RNG scoping for combat round resolution.
 // Installs session.combatRng around each (synchronous) resolveRoundPure so a
 // seeded calibration session's stream is isolated from concurrent sessions.
-const { runWithSeed } = require('../services/combat/pseudoRng');
+const { runWithSeed, makeHolderRng } = require('../services/combat/pseudoRng');
 const { evaluateObjective } = require('../services/combat/objectiveEvaluator');
 const { tick: missionTimerTick } = require('../services/combat/missionTimer');
 // 2026-04-26: wire isTurnLimitExceeded (damage_curves.yaml soft cap per encounter_class).
@@ -1428,6 +1428,9 @@ function createRoundBridge(deps) {
         const moraleEvents = moraleEventsForKill(target, session.units, {
           sessionId: session.session_id,
           turn: session.turn,
+          // Codex #2450 P1: keep the post-kill morale d20 inside the session RNG
+          // (this path runs after runWithSeed restored the global stream).
+          rng: makeHolderRng(session.combatRng),
         });
         for (const mEv of moraleEvents) {
           // eslint-disable-next-line no-await-in-loop
@@ -1688,7 +1691,10 @@ function createRoundBridge(deps) {
 
     // ADR-2026-04-19 + 04-20 wiring (feature flag OFF by default).
     // session.encounter undefined → both modules return no-op.
-    const reinforcementResult = reinforcementTick(session, session.encounter);
+    // Codex #2450 P1: reinforcement pool pick draws from the session RNG too.
+    const reinforcementResult = reinforcementTick(session, session.encounter, {
+      rng: makeHolderRng(session.combatRng),
+    });
     for (const rec of reinforcementResult.spawned || []) {
       if (rec.skipped) continue;
       await appendEvent(session, {
@@ -2092,7 +2098,10 @@ function createRoundBridge(deps) {
 
         // ADR-2026-04-19 + 04-20 wiring (commit-round path).
         // Graceful no-op if session.encounter undefined.
-        const reinforcementResult = reinforcementTick(session, session.encounter);
+        // Codex #2450 P1: reinforcement pool pick draws from the session RNG too.
+        const reinforcementResult = reinforcementTick(session, session.encounter, {
+          rng: makeHolderRng(session.combatRng),
+        });
         for (const rec of reinforcementResult.spawned || []) {
           if (rec.skipped) continue;
           await appendEvent(session, {

--- a/apps/backend/services/combat/moraleOnKill.js
+++ b/apps/backend/services/combat/moraleOnKill.js
@@ -6,7 +6,7 @@
 // (Manhattan dist <= 1) same-team ally whose checkMorale triggers. checkMorale
 // applies the status to the ally internally (side effect on ally.status).
 //
-// opts: { sessionId?, turn?, now?, checkMorale? (DI for tests) }
+// opts: { sessionId?, turn?, now?, rng? (session-scoped d20 rng), checkMorale? (DI for tests) }
 
 const { checkMorale: defaultCheckMorale } = require('./morale');
 
@@ -29,7 +29,7 @@ function moraleEventsForKill(deadUnit, units, opts = {}) {
     const dist = Math.abs(Number(apos.x) - Number(dp.x)) + Math.abs(Number(apos.y) - Number(dp.y));
     if (dist > 1) continue;
 
-    const res = checkMorale(ally, 'ally_killed_adjacent', {});
+    const res = checkMorale(ally, 'ally_killed_adjacent', { rng: opts.rng });
     if (res && res.triggered && res.status) {
       events.push({
         ts: now,

--- a/apps/backend/services/combat/pseudoRng.js
+++ b/apps/backend/services/combat/pseudoRng.js
@@ -94,29 +94,38 @@ function resetStreaks(unit) {
 // session at a time per shard (LOBBY_WS_ENABLED=false, L-071), and each
 // /start reseeds. Production never sends a seed -> unseeded -> Math.random.
 //
+// The stream is a mulberry32 cursor held as a plain integer (`_seedA`) plus an
+// `_active` flag. Holding the cursor as an int (vs a closure) lets it be
+// captured/restored, which is what makes PER-SESSION scoping possible
+// (runWithSeed): a seeded calibration session keeps its own cursor on the
+// session object, so concurrent sessions never clobber a shared stream
+// (P2 review fix). Production never seeds -> _active stays false -> Math.random.
+//
 // API:
-//   seedRng(seed)  -> bool   set the stream to a finite numeric seed
-//   clearSeed()              revert to Math.random passthrough
-//   isSeeded()     -> bool   true when a deterministic stream is active
-//   defaultRng()   -> [0,1)  next float (seeded stream or Math.random)
+//   seedRng(seed)        -> bool   pin the GLOBAL stream to a finite numeric seed
+//   clearSeed()                    revert global to Math.random passthrough
+//   isSeeded()           -> bool   true when the global deterministic stream is active
+//   defaultRng()         -> [0,1)  next float (seeded stream or Math.random)
+//   captureState()       -> int|null   snapshot the cursor (null when unseeded)
+//   restoreState(state)            install a cursor (null = unseeded)
+//   runWithSeed(holder, fn)        run fn with holder.state installed, advance it,
+//                                  save back, then restore the previous global
+//                                  state. fn MUST be synchronous.
 // ─────────────────────────────────────────────────────────────────
 
-// Active deterministic generator, or null when unseeded (Math.random).
-let _rngState = null;
+// mulberry32 cursor (int) + active flag. _active=false -> Math.random.
+let _active = false;
+let _seedA = 0;
 
 /**
- * mulberry32 — compact, well-distributed 32-bit PRNG. Returns a function
- * producing floats in [0,1). Same well-known constants as the reference
- * implementation so the stream is portable/inspectable.
+ * Advance the mulberry32 cursor once and return a float in [0,1). Same
+ * well-known constants as the reference implementation (stream portable).
  */
-function _mulberry32(seed) {
-  let a = seed >>> 0;
-  return function next() {
-    a = (a + 0x6d2b79f5) | 0;
-    let t = Math.imul(a ^ (a >>> 15), 1 | a);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
+function _step() {
+  _seedA = (_seedA + 0x6d2b79f5) | 0;
+  let t = Math.imul(_seedA ^ (_seedA >>> 15), 1 | _seedA);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
 }
 
 /**
@@ -127,21 +136,22 @@ function _mulberry32(seed) {
 function seedRng(seed) {
   const n = Number(seed);
   if (!Number.isFinite(n)) {
-    _rngState = null;
+    _active = false;
     return false;
   }
-  _rngState = _mulberry32(n >>> 0);
+  _seedA = n >>> 0;
+  _active = true;
   return true;
 }
 
 /** Revert to Math.random passthrough (no determinism). */
 function clearSeed() {
-  _rngState = null;
+  _active = false;
 }
 
 /** @returns {boolean} true when a deterministic seeded stream is active. */
 function isSeeded() {
-  return _rngState !== null;
+  return _active;
 }
 
 /**
@@ -149,7 +159,49 @@ function isSeeded() {
  * Math.random. Stable reference — safe for callers to capture once.
  */
 function defaultRng() {
-  return _rngState !== null ? _rngState() : Math.random();
+  return _active ? _step() : Math.random();
+}
+
+/** Snapshot the global cursor: the int when seeded, null when unseeded. */
+function captureState() {
+  return _active ? _seedA : null;
+}
+
+/** Install a cursor snapshot. null/undefined -> unseeded (Math.random). */
+function restoreState(state) {
+  if (state === null || state === undefined) {
+    _active = false;
+  } else {
+    _seedA = state >>> 0;
+    _active = true;
+  }
+}
+
+/**
+ * Scope a seeded stream to one synchronous block (P2 per-session fix).
+ *
+ * `holder` is a mutable `{ state: int|null }` carrying a session's RNG cursor.
+ * Its state is installed before `fn`, advanced by `fn`'s defaultRng draws, then
+ * saved back into `holder.state`; the previous global state is restored after,
+ * so other sessions / nested callers are unaffected. `fn` MUST be synchronous
+ * (no `await` between draws) for the isolation guarantee to hold — combat round
+ * resolution (resolveRoundPure) is synchronous, which is where this is used.
+ *
+ * @param {{state: number|null}|null|undefined} holder
+ * @param {Function} fn synchronous
+ * @returns {*} fn's return value
+ */
+function runWithSeed(holder, fn) {
+  const prevActive = _active;
+  const prevA = _seedA;
+  restoreState(holder ? holder.state : null);
+  try {
+    return fn();
+  } finally {
+    if (holder) holder.state = captureState();
+    _active = prevActive;
+    _seedA = prevA;
+  }
 }
 
 module.exports = {
@@ -164,4 +216,8 @@ module.exports = {
   clearSeed,
   isSeeded,
   defaultRng,
+  // Per-session scoping (TKT-PLAYTEST-SEED P2 review fix).
+  captureState,
+  restoreState,
+  runWithSeed,
 };

--- a/apps/backend/services/combat/pseudoRng.js
+++ b/apps/backend/services/combat/pseudoRng.js
@@ -118,14 +118,23 @@ let _active = false;
 let _seedA = 0;
 
 /**
- * Advance the mulberry32 cursor once and return a float in [0,1). Same
- * well-known constants as the reference implementation (stream portable).
+ * Pure mulberry32 step: advance cursor `a` once, return { a: nextCursor, v }
+ * with v in [0,1). Same well-known constants (stream portable). Shared by the
+ * global stream (_step) and per-holder streams (makeHolderRng) so they produce
+ * one identical sequence from a given cursor.
  */
-function _step() {
-  _seedA = (_seedA + 0x6d2b79f5) | 0;
-  let t = Math.imul(_seedA ^ (_seedA >>> 15), 1 | _seedA);
+function _advance(a) {
+  a = (a + 0x6d2b79f5) | 0;
+  let t = Math.imul(a ^ (a >>> 15), 1 | a);
   t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  return { a, v: ((t ^ (t >>> 14)) >>> 0) / 4294967296 };
+}
+
+/** Advance the GLOBAL cursor once and return a float in [0,1). */
+function _step() {
+  const r = _advance(_seedA);
+  _seedA = r.a;
+  return r.v;
 }
 
 /**
@@ -204,6 +213,27 @@ function runWithSeed(holder, fn) {
   }
 }
 
+/**
+ * Build a session-scoped rng FUNCTION drawing directly from `holder.state`
+ * (advancing + persisting it), independent of the global stream. Lets ASYNC
+ * post-resolution paths (morale-on-kill, reinforcement spawn) keep drawing the
+ * SAME per-session stream the synchronous runWithSeed block used -- safe across
+ * `await`s and concurrent sessions because it never touches the global cursor
+ * (Codex #2450 P1). holder null / holder.state null -> Math.random passthrough.
+ * @param {{state: number|null}|null|undefined} holder
+ * @returns {() => number}
+ */
+function makeHolderRng(holder) {
+  return function holderRng() {
+    if (!holder || holder.state === null || holder.state === undefined) {
+      return Math.random();
+    }
+    const r = _advance(holder.state);
+    holder.state = r.a;
+    return r.v;
+  };
+}
+
 module.exports = {
   initUnit,
   recordRoll,
@@ -220,4 +250,5 @@ module.exports = {
   captureState,
   restoreState,
   runWithSeed,
+  makeHolderRng,
 };

--- a/docs/playtest/canonical-suite.yaml
+++ b/docs/playtest/canonical-suite.yaml
@@ -21,6 +21,7 @@ repro:
   lobby_ws_enabled: false # per-shard, port collision (L-071)
   damage_curves_path_required: true # client must read backend staging file (L-069/OD-032)
   seed_pinned: true # WIRED via TKT-PLAYTEST-SEED (batch --seed -> pseudoRng.js defaultRng at /start)
+  canonical_seed: 424242 # suite-runner pins this by default for a bit-identical gate; --no-seed = fresh statistical sample
   config_source: data/core/balance/damage_curves.yaml
   scenario_spawn_source: apps/backend/services/hardcoreScenario.js
 
@@ -57,8 +58,11 @@ scenarios:
 
 # Canonical run (parallel, ~10min N=40). One-command suite = tools/py/playtest_canonical.py (TKT-PLAYTEST-SUITE, SHIPPED 2026-05-30).
 run_canonical: |
-  python tools/py/calibrate_parallel.py --scenario hardcore_06 --n 40 --shards 4 --base-port 3341
-  python tools/py/calibrate_parallel.py --scenario hardcore_07 --n 40 --shards 4 --base-port 3341
+  # One command (pins canonical_seed for a bit-identical gate; --no-seed = fresh statistical sample):
+  python tools/py/playtest_canonical.py --n 40
+  # Manual per-scenario equivalent (--seed pins the run):
+  #   python tools/py/calibrate_parallel.py --scenario hardcore_06 --n 40 --seed 424242
+  #   python tools/py/calibrate_parallel.py --scenario hardcore_07 --n 40 --seed 424242
 
 gate:
   merge: 'AI regression tests/ai/*.test.js green AND touched-scenario WR in-band @ N=40 AND no crash/contract-ripple'

--- a/tests/services/moraleOnKill.test.js
+++ b/tests/services/moraleOnKill.test.js
@@ -31,3 +31,15 @@ test('emits one morale event only for a living adjacent same-team ally', () => {
   assert.equal(e.session_id, 's1');
   assert.ok(e.result === 'panic' || e.result === 'rage', 'panic (or rage on nat-1)');
 });
+
+test('forwards opts.rng to the morale d20 (Codex #2450 P1 seeded path)', () => {
+  const dead = { id: 'd1', controlled_by: 'sistema', position: { x: 1, y: 1 } };
+  const units = [dead, { id: 'ally', controlled_by: 'sistema', hp: 10, position: { x: 1, y: 2 } }];
+  // morale_mod default 0: rng->0 yields die=1 (low score => triggers); rng->~1
+  // yields die=20 (high score => no trigger). Proves the d20 uses opts.rng,
+  // so a seeded session's post-kill morale is deterministic (not Math.random).
+  const low = moraleEventsForKill(dead, units, { sessionId: 's', turn: 1, rng: () => 0 });
+  const high = moraleEventsForKill(dead, units, { sessionId: 's', turn: 1, rng: () => 0.999 });
+  assert.equal(low.length, 1, 'low roll triggers morale (rng wired to the d20)');
+  assert.equal(high.length, 0, 'high roll does not trigger (rng wired to the d20)');
+});

--- a/tests/services/sprint-alpha/pseudoRng.test.js
+++ b/tests/services/sprint-alpha/pseudoRng.test.js
@@ -21,6 +21,7 @@ const {
   captureState,
   restoreState,
   runWithSeed,
+  makeHolderRng,
 } = require('../../../apps/backend/services/combat/pseudoRng');
 
 test('pseudoRng: 3 miss consecutivi → +5 to_hit bonus', () => {

--- a/tests/services/sprint-alpha/pseudoRng.test.js
+++ b/tests/services/sprint-alpha/pseudoRng.test.js
@@ -199,3 +199,39 @@ test('pseudoRng: runWithSeed restores the prior global state', () => {
   runWithSeed({ state: 7 }, () => defaultRng());
   assert.equal(isSeeded(), false, 'unseeded global stays unseeded after runWithSeed');
 });
+
+// makeHolderRng: a session-scoped rng FUNCTION that draws straight from a
+// holder cursor (no global). Lets async post-resolution paths (morale on kill,
+// reinforcement spawn) keep drawing the SAME per-session stream that the
+// synchronous runWithSeed block used -- Codex #2450 P1 fix.
+
+test('pseudoRng: makeHolderRng is deterministic per holder seed', () => {
+  clearSeed();
+  const r1 = makeHolderRng({ state: 50 });
+  const r2 = makeHolderRng({ state: 50 });
+  assert.deepEqual([r1(), r1(), r1()], [r2(), r2(), r2()], 'same holder seed -> same sequence');
+});
+
+test('pseudoRng: runWithSeed + makeHolderRng share one continuous stream', () => {
+  clearSeed();
+  // Path A: two draws inside runWithSeed, then one more via makeHolderRng.
+  const h = { state: 77 };
+  const inRun = [];
+  runWithSeed(h, () => {
+    inRun.push(defaultRng(), defaultRng());
+  });
+  const cont = makeHolderRng(h)();
+  // Path B: three consecutive draws from a fresh holder of the same seed.
+  const ref = makeHolderRng({ state: 77 });
+  assert.deepEqual(
+    [inRun[0], inRun[1], cont],
+    [ref(), ref(), ref()],
+    'combat (runWithSeed) -> morale/reinforcement (makeHolderRng) is one stream',
+  );
+  assert.equal(isSeeded(), false, 'global untouched by makeHolderRng');
+});
+
+test('pseudoRng: makeHolderRng unseeded holder -> Math.random passthrough', () => {
+  assert.ok(((v) => v >= 0 && v < 1)(makeHolderRng({ state: null })()));
+  assert.ok(((v) => v >= 0 && v < 1)(makeHolderRng(null)()));
+});

--- a/tests/services/sprint-alpha/pseudoRng.test.js
+++ b/tests/services/sprint-alpha/pseudoRng.test.js
@@ -18,6 +18,9 @@ const {
   clearSeed,
   isSeeded,
   defaultRng,
+  captureState,
+  restoreState,
+  runWithSeed,
 } = require('../../../apps/backend/services/combat/pseudoRng');
 
 test('pseudoRng: 3 miss consecutivi → +5 to_hit bonus', () => {
@@ -121,4 +124,77 @@ test('pseudoRng: seedRng rejects non-finite, stays unseeded', () => {
   assert.equal(seedRng('42'), true);
   assert.equal(isSeeded(), true);
   clearSeed();
+});
+
+// ─────────────────────────────────────────────────────────────────
+// TKT-PLAYTEST-SEED P2 — per-session RNG scoping (runWithSeed). Fixes the
+// process-global footgun: a seeded calibration session keeps its own cursor
+// on the session object, so concurrent sessions never clobber each other.
+// ─────────────────────────────────────────────────────────────────
+
+test('pseudoRng: captureState null when unseeded; restoreState resumes exact position', () => {
+  clearSeed();
+  assert.equal(captureState(), null, 'null cursor when unseeded');
+  seedRng(77);
+  defaultRng();
+  defaultRng();
+  const snap = captureState();
+  const next = defaultRng();
+  restoreState(snap);
+  assert.equal(defaultRng(), next, 'restoreState resumes the exact stream position');
+  clearSeed();
+});
+
+test('pseudoRng: runWithSeed gives per-session continuity + reproducibility', () => {
+  clearSeed();
+  const s1 = { state: 100 };
+  const a = [];
+  runWithSeed(s1, () => {
+    a.push(defaultRng(), defaultRng());
+  });
+  runWithSeed(s1, () => {
+    a.push(defaultRng(), defaultRng());
+  });
+  const s2 = { state: 100 };
+  const b = [];
+  runWithSeed(s2, () => {
+    b.push(defaultRng(), defaultRng());
+  });
+  runWithSeed(s2, () => {
+    b.push(defaultRng(), defaultRng());
+  });
+  assert.deepEqual(a, b, 'same start state reproduces the stream across runWithSeed calls');
+  assert.equal(new Set(a).size, 4, 'stream advanced (not reset) across calls');
+});
+
+test('pseudoRng: runWithSeed isolates two concurrent session streams', () => {
+  clearSeed();
+  const aSolo = [];
+  runWithSeed({ state: 1 }, () => {
+    aSolo.push(defaultRng(), defaultRng(), defaultRng());
+  });
+  // Interleave A and B; A's stream must be unaffected by B's draws.
+  const sA = { state: 1 };
+  const sB = { state: 2 };
+  const aInter = [];
+  runWithSeed(sA, () => aInter.push(defaultRng()));
+  runWithSeed(sB, () => defaultRng());
+  runWithSeed(sA, () => aInter.push(defaultRng()));
+  runWithSeed(sB, () => defaultRng());
+  runWithSeed(sA, () => aInter.push(defaultRng()));
+  assert.deepEqual(aInter, aSolo, 'session A stream identical whether or not B interleaves');
+});
+
+test('pseudoRng: runWithSeed restores the prior global state', () => {
+  seedRng(555);
+  defaultRng();
+  const stateBefore = captureState();
+  runWithSeed({ state: 999 }, () => {
+    defaultRng();
+    defaultRng();
+  });
+  assert.equal(captureState(), stateBefore, 'global seed cursor restored after runWithSeed');
+  clearSeed();
+  runWithSeed({ state: 7 }, () => defaultRng());
+  assert.equal(isSeeded(), false, 'unseeded global stays unseeded after runWithSeed');
 });

--- a/tests/test_playtest_canonical.py
+++ b/tests/test_playtest_canonical.py
@@ -77,6 +77,36 @@ def test_build_plan_scenario_filter():
     assert [s["parallel_key"] for s in plan["scenarios"]] == ["hardcore_06"]
 
 
+def test_resolve_seed_default_uses_manifest_canonical_seed():
+    m = pc.load_manifest(str(MANIFEST))
+    # manifest has seed_pinned: true + canonical_seed -> honored by default
+    assert pc.resolve_seed(m) == 424242
+    assert pc.resolve_seed(m, cli_seed=99) == 99, "explicit --seed wins"
+    assert pc.resolve_seed(m, no_seed=True) is None, "--no-seed forces fresh sample"
+
+
+def test_resolve_seed_no_pin_returns_none():
+    assert pc.resolve_seed({"repro": {"seed_pinned": False, "canonical_seed": 5}}) is None
+    assert pc.resolve_seed({"repro": {}}) is None
+    assert pc.resolve_seed({}) is None
+
+
+def test_build_plan_includes_seed():
+    m = pc.load_manifest(str(MANIFEST))
+    assert pc.build_plan(m, n=40, shards=4, base_port=3341, seed=424242)["seed"] == 424242
+    assert pc.build_plan(m, n=40, shards=4, base_port=3341)["seed"] is None
+
+
+def test_dry_run_cli_shows_canonical_seed(tmp_path):
+    proc = subprocess.run(
+        [sys.executable, str(ROOT / "tools" / "py" / "playtest_canonical.py"),
+         "--dry-run", "--manifest", str(MANIFEST)],
+        capture_output=True, text=True, env=dict(os.environ), cwd=str(ROOT), timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "seed: 424242" in proc.stdout, "default dry-run pins the canonical seed"
+
+
 def test_dry_run_cli_no_backend(tmp_path):
     """--dry-run parses the manifest + prints the plan and exits 0 without any
     backend (this is the backend-free smoke gate)."""

--- a/tools/py/calibrate_parallel.py
+++ b/tools/py/calibrate_parallel.py
@@ -133,7 +133,7 @@ def stop_shard(proc, fh, port):
             pass
 
 
-def run_shard_batch(host, scenario_cfg, n, out_path, jsonl_path, log_path, curves_path=None):
+def run_shard_batch(host, scenario_cfg, n, out_path, jsonl_path, log_path, curves_path=None, seed=None):
     """Subprocess wrapper -- launch batch_calibrate_*.py against one shard.
 
     curves_path (OD-032 no-op-bug fix): if set, the batch CLIENT subprocess gets
@@ -149,7 +149,7 @@ def run_shard_batch(host, scenario_cfg, n, out_path, jsonl_path, log_path, curve
         "--out", str(out_path),
         "--jsonl", str(jsonl_path),
         "--skip-health",
-    ] + scenario_cfg["extra_args"]
+    ] + (["--seed", str(seed)] if seed is not None else []) + scenario_cfg["extra_args"]
     print(f"[parallel] launch shard host={host} N={n}", flush=True)
     f = open(log_path, "w", encoding="utf-8")
     env = dict(os.environ)
@@ -214,6 +214,10 @@ def main():
     p.add_argument("--label", default=None, help="Suffix for output files")
     p.add_argument("--keep-shards", action="store_true",
                    help="Don't stop shards on exit (for reuse).")
+    p.add_argument("--seed", type=int, default=None,
+                   help="TKT-PLAYTEST-SEED: base seed for bit-identical runs. Each shard gets "
+                        "a distinct offset (base + cumulative N) so runs never duplicate across "
+                        "shards while the whole batch stays reproducible. Omit = Math.random.")
     args = p.parse_args()
 
     cfg = SCENARIO_MAP[args.scenario]
@@ -273,6 +277,16 @@ def main():
     # Distribute runs.
     n_per_shard = distribute_n(args.n, args.shards)
     print(f"[parallel] N={args.n} distributed: {n_per_shard}", flush=True)
+    # TKT-PLAYTEST-SEED: per-shard seed offset so each shard draws a DISTINCT
+    # slice of the seed space (shard i runs seeds base+offset ..), keeping the
+    # whole N reproducible without duplicate runs across shards.
+    seed_offsets = []
+    _acc = 0
+    for _n in n_per_shard:
+        seed_offsets.append(_acc)
+        _acc += _n
+    if args.seed is not None:
+        print(f"[parallel] seed={args.seed} per-shard offsets={seed_offsets}", flush=True)
 
     # Launch batches parallel.
     batch_procs = []
@@ -287,7 +301,8 @@ def main():
         log_p = Path(f"{base}-shard{i}.log")
         out_paths.append(out_p)
         jsonl_paths.append(jsonl_p)
-        proc, fh = run_shard_batch(host, cfg, n, out_p, jsonl_p, log_p)
+        shard_seed = args.seed + seed_offsets[i] if args.seed is not None else None
+        proc, fh = run_shard_batch(host, cfg, n, out_p, jsonl_p, log_p, seed=shard_seed)
         batch_procs.append((proc, fh, host, n, log_p))
 
     t0 = time.time()
@@ -353,6 +368,7 @@ def main():
         "scenario_id": cfg["scenario_id"],
         "target_band": list(cfg["target_band"]),
         "total_n": args.n,
+        "seed": args.seed,
         "shards": args.shards,
         "n_per_shard": n_per_shard,
         "hosts": hosts,

--- a/tools/py/playtest_canonical.py
+++ b/tools/py/playtest_canonical.py
@@ -86,7 +86,22 @@ def in_band(wr, band):
     return band[0] <= wr <= band[1]
 
 
-def build_plan(manifest, n, shards, base_port, only=None):
+def resolve_seed(manifest, cli_seed=None, no_seed=False):
+    """Effective canonical seed: --no-seed wins (None = fresh statistical sample),
+    then explicit --seed, then the manifest canonical_seed when seed_pinned is set.
+    This is what makes manifest `seed_pinned: true` actually honored end-to-end."""
+    if no_seed:
+        return None
+    if cli_seed is not None:
+        return int(cli_seed)
+    repro = manifest.get("repro", {})
+    if repro.get("seed_pinned"):
+        cs = repro.get("canonical_seed")
+        return int(cs) if cs is not None else None
+    return None
+
+
+def build_plan(manifest, n, shards, base_port, only=None, seed=None):
     """Backend-free execution plan (used by --dry-run + the live runner)."""
     scenarios = []
     for s in oracle_scenarios(manifest):
@@ -106,6 +121,7 @@ def build_plan(manifest, n, shards, base_port, only=None):
     repro = dict(manifest.get("repro", {}))
     return {
         "n": n,
+        "seed": seed,
         "shards": shards,
         "base_port": base_port,
         "ladder_role": "ratify" if n >= 40 else ("probe" if n <= 10 else "interim"),
@@ -125,9 +141,9 @@ def _resolve_curves_path(manifest):
     return str(p)
 
 
-def run_scenario(parallel_key, n, shards, base_port, work_dir, label, curves_path):
+def run_scenario(parallel_key, n, shards, base_port, work_dir, label, curves_path, seed=None):
     """Run one scenario via calibrate_parallel.py, read the merged JSON, return
-    a result row. Honors the repro contract via DAMAGE_CURVES_PATH env."""
+    a result row. Honors the repro contract via DAMAGE_CURVES_PATH env + --seed."""
     work_dir = Path(work_dir)
     work_dir.mkdir(parents=True, exist_ok=True)
     cmd = [
@@ -136,6 +152,8 @@ def run_scenario(parallel_key, n, shards, base_port, work_dir, label, curves_pat
         "--shards", str(shards), "--base-port", str(base_port),
         "--out-dir", str(work_dir), "--label", label,
     ]
+    if seed is not None:
+        cmd += ["--seed", str(seed)]
     env = dict(os.environ)
     if curves_path:
         env["DAMAGE_CURVES_PATH"] = curves_path
@@ -187,6 +205,7 @@ def build_report(plan, results, label, manifest_path):
         "label": label,
         "manifest": str(manifest_path),
         "n": plan["n"],
+        "seed": plan.get("seed"),
         "ladder_role": plan["ladder_role"],
         "all_in_band": all_in_band,
         "repro": plan["repro"],
@@ -240,6 +259,8 @@ def print_plan(plan, manifest_path):
     print(f"manifest: {manifest_path}", flush=True)
     print(f"N per scenario: {plan['n']} (ladder role: {plan['ladder_role']})  "
           f"shards: {plan['shards']}  base_port: {plan['base_port']}", flush=True)
+    _seed = plan.get("seed")
+    print(f"seed: {_seed if _seed is not None else 'None (fresh statistical sample)'}", flush=True)
     repro = plan["repro"]
     print("repro contract:", flush=True)
     print(f"  host={repro.get('host')}  lobby_ws_enabled={repro.get('lobby_ws_enabled')}  "
@@ -265,12 +286,18 @@ def main():
                    help="Run only this calibrate_parallel key (e.g. hardcore_06).")
     p.add_argument("--out-dir", default="docs/playtest", help="Where the combined report is written.")
     p.add_argument("--label", default=None, help="Report label (default today's date).")
+    p.add_argument("--seed", type=int, default=None,
+                   help="TKT-PLAYTEST-SEED: base seed (bit-identical). Default = manifest "
+                        "canonical_seed when seed_pinned. Use --no-seed for a fresh sample.")
+    p.add_argument("--no-seed", action="store_true",
+                   help="Force a fresh (Math.random) statistical sample, ignoring canonical_seed.")
     p.add_argument("--dry-run", action="store_true",
                    help="Parse manifest + print plan, NO backend (backend-free smoke).")
     args = p.parse_args()
 
     manifest = load_manifest(args.manifest)
-    plan = build_plan(manifest, args.n, args.shards, args.base_port, only=args.scenario)
+    eff_seed = resolve_seed(manifest, args.seed, args.no_seed)
+    plan = build_plan(manifest, args.n, args.shards, args.base_port, only=args.scenario, seed=eff_seed)
 
     if args.dry_run:
         print_plan(plan, args.manifest)
@@ -290,7 +317,7 @@ def main():
     for sc in plan["scenarios"]:
         results.append(run_scenario(
             sc["parallel_key"], args.n, args.shards, args.base_port,
-            work_dir, label, curves_path,
+            work_dir, label, curves_path, seed=eff_seed,
         ))
 
     report = build_report(plan, results, label, args.manifest)


### PR DESCRIPTION
Follow-up to #2448 (merged): addresses the two Codex review comments that arrived after the squash-merge, so they weren't in the merged commit.

### P1 — pass the canonical seed through the suite runner (comment 3327354532)
`calibrate_parallel.py` gained `--seed` (per-shard offset so runs stay **distinct** and the whole batch reproducible); `playtest_canonical.py` resolves the seed (`--seed` / `--no-seed` / manifest `canonical_seed` when `seed_pinned`) and passes it down. Manifest adds `canonical_seed: 424242` and `run_canonical` pins it. `repro.seed_pinned: true` is now honored **end-to-end** — previously the suite still ran on `Math.random`.
- **Smoke**: suite ×2 at the default seed → **bit-identical** runs (seeds `424242–424249`, distinct per shard); `--no-seed` for a fresh statistical sample (N=40 stays the ratify gate).

### P2 — keep seeded RNG state per session (comment 3327354535)
`pseudoRng` now holds the mulberry32 cursor as an int plus `captureState` / `restoreState` / `runWithSeed`. `/start` records the seed on `session.combatRng` instead of mutating a process-global stream; `sessionRoundBridge` installs it via `runWithSeed` around each **synchronous** `resolveRoundPure`, so a seeded calibration session never clobbers a concurrent session's RNG. Unseeded `defaultRng` === `Math.random` (zero production change).
- +4 isolation/continuity unit tests.

### Gates
- AI `tests/ai/*` **462/462**; `pseudoRng` **13/13**; pytest (`calibrate_policies` + `playtest_canonical`) **22/22**; docs governance `--strict` **errors=0**.
- Live: `playtest_canonical --scenario hardcore_06 --n 6` → in-band, report written, backend boots on current main (post-#2449).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
