### PR TITLE
feat(playtest): --seed on all batch runners + --policy on quartet (close *.py glob)

### DIFF
--- a/tools/py/batch_calibrate_hardcore06_quartet.py
+++ b/tools/py/batch_calibrate_hardcore06_quartet.py
@@ -9,6 +9,7 @@ Reuse engine da tools/py/batch_calibrate_hardcore06.py (import).
 
 import argparse
 import json
+import random
 import statistics
 import sys
 import time
@@ -16,16 +17,17 @@ import urllib.error
 import urllib.request
 
 sys.path.insert(0, "tools/py")
+import calibrate_policies  # noqa: E402
 from batch_calibrate_hardcore06 import (  # noqa: E402
     post, get, pressure_tier, plan_player_intents, detect_outcome,
-    MAX_ROUNDS, aggregate,
+    MAX_ROUNDS, aggregate, POLICY_CTX, _policy_rng,
 )
 
 SCENARIO_ID = "enc_tutorial_06_hardcore"
 DEFAULT_HOST = "http://localhost:3340"
 
 
-def run_one_quartet(host, run_idx):
+def run_one_quartet(host, run_idx, seed=None, policy="greedy", rng=None):
     status, sc = get(f"{host}/api/tutorial/{SCENARIO_ID}")
     if status != 200:
         return {"error": f"fetch scenario failed: {sc}"}
@@ -48,6 +50,8 @@ def run_one_quartet(host, run_idx):
 
     status, start = post(f"{host}/api/session/start", {
         "units": quartet_units,
+        # TKT-PLAYTEST-SEED: pin backend combat RNG for bit-identical replay.
+        **({"seed": seed} if seed is not None else {}),
         "modulation": "quartet",
         "sistema_pressure_start": pstart,
         "hazard_tiles": hazard,
@@ -65,7 +69,10 @@ def run_one_quartet(host, run_idx):
         outcome = detect_outcome(state)
         if outcome:
             break
-        intents = plan_player_intents(state, None)
+        if policy == "greedy":
+            intents = plan_player_intents(state, None)
+        else:
+            intents = calibrate_policies.pick_intents(policy, state, POLICY_CTX, rng)
         status, resp = post(f"{host}/api/session/round/execute", {
             "session_id": sid,
             "player_intents": intents,
@@ -110,6 +117,8 @@ def run_one_quartet(host, run_idx):
 
     return {
         "run": run_idx,
+        "seed": seed,
+        "policy": policy,
         "outcome": outcome,
         "rounds": state.get("turn", 0),
         "players_alive": players_alive,
@@ -129,12 +138,20 @@ def main():
     ap.add_argument("--host", default=DEFAULT_HOST)
     ap.add_argument("--n", type=int, default=10)
     ap.add_argument("--out", default=None)
+    ap.add_argument("--seed", type=int, default=None,
+                    help="TKT-PLAYTEST-SEED: base seed; run i uses seed+i for bit-identical replay.")
+    ap.add_argument("--policy", default="greedy",
+                    choices=["random", "greedy", "lookahead2", "utility"],
+                    help="TKT-PLAYTEST-TRIANGULATE: player policy proxy (single). Band/'all' mode "
+                         "lives in the canonical suite (playtest_canonical.py) for hc06/hc07.")
     args = ap.parse_args()
 
     runs = []
     t0 = time.time()
     for i in range(args.n):
-        r = run_one_quartet(args.host, i)
+        run_seed = args.seed + i if args.seed is not None else None
+        r = run_one_quartet(args.host, i, seed=run_seed, policy=args.policy,
+                            rng=_policy_rng(args.policy, run_seed))
         runs.append(r)
         mark = "V" if r.get("outcome") == "victory" else "L" if r.get("outcome") == "defeat" else "T" if r.get("outcome") == "timeout" else "E"
         print(f"[{i+1}/{args.n}] {mark} rounds={r.get('rounds','?')} boss={r.get('boss_hp_remaining','?')} pa={r.get('players_alive','?')}/4", flush=True)

--- a/tools/py/batch_calibrate_non_elim.py
+++ b/tools/py/batch_calibrate_non_elim.py
@@ -149,13 +149,16 @@ def encounter_to_units(encounter):
     return units
 
 
-def run_one(host, encounter, run_idx):
+def run_one(host, encounter, run_idx, seed=None):
     units = encounter_to_units(encounter)
 
     encounter_payload = dict(encounter)
 
     status, start = post(f"{host}/api/session/start", {
         "units": units,
+        # TKT-PLAYTEST-SEED: pin backend combat RNG for bit-identical replay
+        # (this escort scenario has no player policy -> only --seed applies).
+        **({"seed": seed} if seed is not None else {}),
         "encounter": encounter_payload,
     })
     if status != 200:
@@ -179,6 +182,7 @@ def run_one(host, encounter, run_idx):
 
     return {
         "run": run_idx,
+        "seed": seed,
         "outcome": end_res.get("outcome"),
         "objective_state": end_res.get("objective_state"),
         "final_objective": objective_state_seen,
@@ -231,6 +235,9 @@ def main():
     ap.add_argument("--out", default=None, help="JSON output path")
     ap.add_argument("--probe", action="store_true", help="N=1 verbose probe")
     ap.add_argument("--skip-health", action="store_true")
+    ap.add_argument("--seed", type=int, default=None,
+                    help="TKT-PLAYTEST-SEED: base seed; run i uses seed+i for bit-identical "
+                         "replay. Omit = Math.random. (No --policy: escort scenario, no player ladder.)")
     args = ap.parse_args()
 
     # Resolve scenario path.
@@ -257,7 +264,7 @@ def main():
     runs = []
     t0 = time.time()
     for i in range(args.n):
-        r = run_one(args.host, encounter, i)
+        r = run_one(args.host, encounter, i, seed=(args.seed + i if args.seed is not None else None))
         runs.append(r)
         mark = "V" if r.get("outcome") == "win" else "L" if r.get("outcome") in ("wipe", "objective_failed") else "T" if r.get("outcome") == "timeout" else "E"
         print(f"[{i+1}/{args.n}] {mark} outcome={r.get('outcome', 'err')}", flush=True)

--- a/tools/py/batch_calibrate_skiv_solo_pack.py
+++ b/tools/py/batch_calibrate_skiv_solo_pack.py
@@ -246,10 +246,13 @@ def detect_outcome(state, rounds):
     return None
 
 
-def run_one(host, run_idx):
+def run_one(host, run_idx, seed=None):
     units = build_skiv_units()
     status, start = post(f"{host}/api/session/start", {
         "units": units,
+        # TKT-PLAYTEST-SEED: pin backend combat RNG for bit-identical replay
+        # (single-unit survival scenario -> only --seed; no player-ladder policy).
+        **({"seed": seed} if seed is not None else {}),
         "encounter_id": ENCOUNTER_ID,
         "biome_id": "savana",
     })
@@ -298,6 +301,7 @@ def run_one(host, run_idx):
     )
     return {
         "run": run_idx,
+        "seed": seed,
         "outcome": outcome,
         "rounds": rounds,
         "skiv_hp_final": skiv_hp,
@@ -424,6 +428,9 @@ def main():
     parser.add_argument("--target-high", type=int, default=45)
     parser.add_argument("--no-report", action="store_true", help="skip md report write")
     parser.add_argument("--json-out", help="optional path to dump raw runs JSON")
+    parser.add_argument("--seed", type=int, default=None,
+                        help="TKT-PLAYTEST-SEED: base seed; run i uses seed+i for bit-identical "
+                             "replay. Omit = Math.random. (No --policy: solo-survival, no player ladder.)")
     args = parser.parse_args()
 
     host = args.host.rstrip("/")
@@ -434,7 +441,7 @@ def main():
 
     runs = []
     for i in range(1, args.n + 1):
-        result = run_one(host, i)
+        result = run_one(host, i, seed=(args.seed + i if args.seed is not None else None))
         runs.append(result)
         outcome = result.get("outcome", "ERROR")
         marker = " ✓mark" if result.get("alpha_marked") else ""


### PR DESCRIPTION
Closes the `batch_calibrate_*.py` glob (follow-up to #2448/#2450). All 5 batch runners now accept `--seed`; the only multi-unit-party elimination runner also gets `--policy`.

| runner | --seed | --policy | why |
|---|---|---|---|
| hardcore06 / hardcore07 | ✅ (in #2448/#2450) | ✅ | canonical balance oracles |
| **hardcore06_quartet** | ✅ | ✅ {random,greedy,lookahead2,utility} | 4p elimination (reuses hc06 `POLICY_CTX`/`_policy_rng`) |
| **non_elim** | ✅ | — | escort, no player-driven intents (`/turn/end` loop) |
| **skiv_solo_pack** | ✅ | — | single-unit survival; weak→strong ladder doesn't fit |

`--seed`: run *i* uses `seed+i`, bit-identical replay via the merged backend `pseudoRng` (universal — any script sending `seed` to `/start`). Band/`all` mode stays in the canonical suite (`playtest_canonical.py`) for hc06/hc07.

**Smoke** (backend up `127.0.0.1:3334`): each runner seeded ×2 → **bit-identical** (skiv, quartet, non_elim); `quartet --policy utility` runs. Regression: `non_elim` test + `calibrate_policies` 18/18. No forbidden paths, no deps, tools-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
