### PR TITLE
feat(play): surface-wire P4 personality voices + conviction badges in debrief

### DIFF
--- a/apps/backend/services/rewardEconomy.js
+++ b/apps/backend/services/rewardEconomy.js
@@ -148,6 +148,40 @@ function buildBiomePressureRating(session) {
   };
 }
 
+// TKT-P4 (2026-05-30) — personality voice color + surface helpers.
+const _MBTI_PAIRS = ['E_I', 'S_N', 'T_F', 'J_P'];
+// IT headline per pole letter for the inner-voice card (derived from pole only).
+const _POLE_NAME_IT = {
+  E: 'Voce estroversa',
+  I: 'Voce introversa',
+  S: 'Voce sensoriale',
+  N: 'Voce intuitiva',
+  T: 'Voce razionale',
+  F: 'Voce empatica',
+  J: 'Voce strutturata',
+  P: 'Voce fluida',
+};
+const _TIER_RANK = { 3: 3, 2: 2, 1: 1, shout: 3, voice: 2, whisper: 1 };
+
+// Most decisive (out-of-deadband) MBTI axis → its pole letter. null when every
+// axis sits in the 0.4..0.6 deadband. Used to tint an actor's ennea voice quote.
+function dominantPoleLetter(mbtiAxes) {
+  if (!mbtiAxes || typeof mbtiAxes !== 'object') return null;
+  let bestLetter = null;
+  let bestMag = 0.1; // require |value-0.5| > 0.1 (out of deadband)
+  for (const axis of _MBTI_PAIRS) {
+    const entry = mbtiAxes[axis];
+    const v = entry && Number.isFinite(Number(entry.value)) ? Number(entry.value) : null;
+    if (v === null) continue;
+    const mag = Math.abs(v - 0.5);
+    if (mag <= bestMag) continue;
+    bestMag = mag;
+    const [lo, hi] = axis.split('_');
+    bestLetter = v < 0.5 ? lo : hi;
+  }
+  return bestLetter;
+}
+
 function buildDebriefSummary(session, vcSnapshot, peResult, pfSession = {}) {
   // 2026-04-26 (Q19 resolved Opzione A): PE→PI conversion gated su outcome=victory
   // (StS gold analogy). Defeat/timeout = PE earned ma non convertito; resta in pool campaign-wide.
@@ -205,6 +239,7 @@ function buildDebriefSummary(session, vcSnapshot, peResult, pfSession = {}) {
   let enneaVoices = [];
   try {
     const { selectEnneaVoice } = require('../../../services/narrative/narrativeEngine');
+    const { mbtiTaggedLine } = require('./mbtiPalette');
     const beatId = isVictory ? 'victory_solo' : 'defeat_critical';
     // Deterministic seed per session_id per reproducibility (test).
     const seedSrc = String(session?.session_id || 'debrief');
@@ -224,18 +259,69 @@ function buildDebriefSummary(session, vcSnapshot, peResult, pfSession = {}) {
       if (!Array.isArray(vc.ennea_archetypes) || vc.ennea_archetypes.length === 0) continue;
       const selection = selectEnneaVoice(vc.ennea_archetypes, beatId, { rand });
       if (selection) {
+        const pole = dominantPoleLetter(vc.mbti_axes);
         enneaVoices.push({
           actor_id: actorId,
           archetype_id: selection.archetype_id,
           ennea_type: selection.ennea_type,
           beat_id: selection.beat_id,
           line_id: selection.line_id,
-          text: selection.text,
+          mbti_pole: pole || null,
+          // TKT-P4-DIALOGUE-COLORS: tint the archetype quote with the actor's
+          // dominant MBTI pole (frontend renders the <mbti> tag in WCAG color).
+          text: pole ? mbtiTaggedLine(selection.text, [pole]) : selection.text,
         });
       }
     }
   } catch {
     // narrativeEngine / enneaVoice module optional — non blocca debrief
+  }
+
+  // 2026-05-30 TKT-P4-DIALOGUE-COLORS — wire inner voices (Disco Elysium diegetic
+  // monologue) into the debrief. Engine LIVE (innerVoice.evaluateVoiceTriggers +
+  // 24-line inner_voices.yaml) but had ZERO debrief surface. Emit up to 2 of the
+  // most intense triggered voices per actor, MBTI-tinted via mbtiTaggedLine.
+  let innerVoices = [];
+  try {
+    const { evaluateVoiceTriggers, describeVoice } = require('./narrative/innerVoice');
+    const { mbtiTaggedLine } = require('./mbtiPalette');
+    for (const [actorId, vc] of Object.entries(vcSnapshot.per_actor || {})) {
+      const axes = vc && vc.mbti_axes ? vc.mbti_axes : null;
+      if (!axes) continue;
+      const { heard } = evaluateVoiceTriggers(axes, []);
+      if (!Array.isArray(heard) || heard.length === 0) continue;
+      const described = heard.map((id) => describeVoice(id)).filter(Boolean);
+      described.sort((a, b) => (_TIER_RANK[b.tier] || 0) - (_TIER_RANK[a.tier] || 0));
+      for (const v of described.slice(0, 2)) {
+        const pole = typeof v.pole_letter === 'string' ? v.pole_letter : null;
+        const raw = v.voice_it || v.flavor_it || '';
+        if (!raw) continue;
+        innerVoices.push({
+          actor_id: actorId,
+          voice_id: v.id,
+          axis: v.axis || null,
+          direction: v.direction || null,
+          tier: v.tier ?? null,
+          label: pole ? _POLE_NAME_IT[pole] || null : null,
+          mbti_pole: pole,
+          text: pole ? mbtiTaggedLine(raw, [pole]) : raw,
+        });
+      }
+    }
+  } catch {
+    // innerVoice module optional — non blocca debrief
+  }
+
+  // 2026-05-30 TKT-P4-CONVICTION-BADGES — wire conviction badges (Triangle
+  // Strategy pattern) into the debrief. Engine LIVE (mbtiSurface) but the only
+  // renderer was a transient in-combat flash; surface the per-actor badges in
+  // the debrief payload (first-reveal mode — no previous snapshot needed).
+  let mbtiSurface = { conviction_badges: {} };
+  try {
+    const { buildConvictionBadgesMap } = require('./mbtiSurface');
+    mbtiSurface = { conviction_badges: buildConvictionBadgesMap(vcSnapshot) || {} };
+  } catch {
+    // mbtiSurface module optional — non blocca debrief
   }
 
   // Sprint 12 (Surface-DEAD #4) — Mating lifecycle wire.
@@ -292,6 +378,12 @@ function buildDebriefSummary(session, vcSnapshot, peResult, pfSession = {}) {
     // 1 line per actor con triggered ennea archetypes. Beat selected by outcome
     // (victory_solo | defeat_critical). Empty quando no archetypes triggered.
     ennea_voices: enneaVoices,
+    // 2026-05-30 TKT-P4-DIALOGUE-COLORS — inner voice diegetic monologue (MBTI-
+    // tinted), up to 2 per actor. Empty when no axis crosses a voice threshold.
+    inner_voices: innerVoices,
+    // 2026-05-30 TKT-P4-CONVICTION-BADGES — conviction badges per actor (map
+    // uid → [badge]). Empty map when no decisive axis (first-reveal mode).
+    mbti_surface: mbtiSurface,
     // Personality projection
     pf_session: pfSession,
     // Combat stats

--- a/apps/play/src/convictionBadgeRender.js
+++ b/apps/play/src/convictionBadgeRender.js
@@ -1,0 +1,107 @@
+// 2026-05-30 TKT-P4-CONVICTION-BADGES — conviction badge debrief render.
+//
+// Engine LIVE: apps/backend/services/mbtiSurface.js buildConvictionBadges /
+// buildConvictionBadgesMap (Triangle Strategy "Conviction" pattern — a decisive
+// MBTI axis manifests as a color-coded badge). Wired into
+// rewardEconomy.buildDebriefSummary → debrief.mbti_surface.conviction_badges.
+//
+// Surface DEAD pre-2026-05-30: the only renderer was a transient in-combat
+// flash overlay (characterPanel.flashConvictionBadge). The debrief panel — where
+// the player reflects post-combat — never showed convictions. This adds a
+// persistent debrief section.
+//
+// Badge shape: { axis, letter, label, axis_label, color, color_name,
+//                confidence, value, delta }.
+
+'use strict';
+
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+
+// Pure: conviction badge → HTML chip. Empty string if invalid.
+export function formatConvictionBadge(badge) {
+  if (!badge || typeof badge !== 'object') return '';
+  const letter = String(badge.letter || '').trim();
+  const axisLabel = String(badge.axis_label || '').trim();
+  if (!letter && !axisLabel) return '';
+  const poleLabel = String(badge.label || badge.pole_label || '').trim();
+  const axis = String(badge.axis || '').trim();
+  // Color is only trusted when it matches a strict 6-digit hex (anti-injection).
+  const color = HEX_COLOR_RE.test(String(badge.color || '')) ? String(badge.color) : null;
+  const colorStyle = color ? ` style="color:${color}"` : '';
+  const borderStyle = color ? ` style="border-color:${color}"` : '';
+  const axisAttr = axis ? ` data-axis="${escapeHtml(axis)}"` : '';
+  const delta = formatDelta(badge.delta);
+  const deltaHtml = delta ? `<span class="cv-delta">${escapeHtml(delta)}</span>` : '';
+  const letterHtml = letter
+    ? `<span class="cv-letter"${colorStyle}>${escapeHtml(letter)}</span>`
+    : '';
+  const axisHtml = axisLabel ? `<span class="cv-axis-label">${escapeHtml(axisLabel)}</span>` : '';
+  const poleHtml = poleLabel ? `<span class="cv-pole-label">${escapeHtml(poleLabel)}</span>` : '';
+  return `<div class="db-conviction-badge"${axisAttr}${borderStyle}>
+    ${letterHtml}
+    ${axisHtml}
+    ${poleHtml}
+    ${deltaHtml}
+  </div>`;
+}
+
+// Pure: per-actor map { uid: [badges] } OR flat array → HTML list.
+export function formatConvictionBadgeList(payload) {
+  const flat = flattenBadges(payload);
+  if (flat.length === 0) return '';
+  return flat.map(formatConvictionBadge).filter(Boolean).join('');
+}
+
+function flattenBadges(payload) {
+  if (!payload) return [];
+  if (Array.isArray(payload)) return payload;
+  if (typeof payload === 'object') {
+    const out = [];
+    for (const v of Object.values(payload)) {
+      if (Array.isArray(v)) out.push(...v);
+    }
+    return out;
+  }
+  return [];
+}
+
+// Scale delta (0..1 fraction) to a signed integer (×100), matching the
+// in-combat characterPanel badge. null/invalid → ''.
+function formatDelta(delta) {
+  if (delta === null || delta === undefined) return '';
+  const n = Number(delta);
+  if (!Number.isFinite(n) || n === 0) return '';
+  const sign = n > 0 ? '+' : '';
+  return `${sign}${Math.round(n * 100)}`;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(
+    /[&<>"']/g,
+    (c) =>
+      ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+      })[c],
+  );
+}
+
+// Side effect: render badges into list container + show/hide section parent.
+// Idempotent — replaces innerHTML.
+//   sectionEl = #db-conviction-section
+//   listEl    = #db-conviction-list
+//   payload   = conviction_badges map | flat array | null
+export function renderConvictionBadges(sectionEl, listEl, payload) {
+  if (!sectionEl || !listEl) return;
+  const html = formatConvictionBadgeList(payload);
+  if (!html) {
+    sectionEl.style.display = 'none';
+    listEl.innerHTML = '';
+    return;
+  }
+  sectionEl.style.display = '';
+  listEl.innerHTML = html;
+}

--- a/apps/play/src/debriefPanel.css
+++ b/apps/play/src/debriefPanel.css
@@ -717,12 +717,15 @@
   gap: 10px;
 }
 .db-ennea-voice {
-  background: linear-gradient(180deg, #1a1828 0%, #0e0c18 100%);
-  border: 1px solid #2a2438;
+  /* TKT-P4-DIALOGUE-COLORS: light card so the dark-on-light MBTI palette
+     (.mbti-axis-X) stays WCAG AA. Disco-Elysium thought-card look. */
+  background: #ffffff;
+  border: 1px solid #d8d2e6;
   border-left: 3px solid #6a5a9a;
   border-radius: 8px;
   padding: 10px 14px;
   font-family: Georgia, 'Times New Roman', serif;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
 }
 .db-ennea-voice-header {
   display: flex;
@@ -732,7 +735,7 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: #b0a8c8;
+  color: #5a5470;
   margin-bottom: 6px;
 }
 .db-ennea-voice-icon {
@@ -751,9 +754,93 @@
 .db-ennea-voice-text {
   font-style: italic;
   font-size: 0.95rem;
-  color: #e6e2f0;
+  color: #2a2f3d;
   line-height: 1.4;
   margin: 0;
+}
+
+/* TKT-P4-DIALOGUE-COLORS: inner voice (Disco Elysium internal monologue). */
+.db-inner-voices-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.db-inner-voice {
+  background: #ffffff;
+  border: 1px solid #d6d2e8;
+  border-left: 3px solid #8a7ad9;
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-family: Georgia, 'Times New Roman', serif;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+}
+.db-inner-voice-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.db-inner-voice-pole {
+  font-weight: 800;
+  font-size: 13px;
+  width: 20px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #ece8fb;
+  color: #4a3aa0;
+}
+.db-inner-voice-label {
+  font-weight: 700;
+  color: #4a3aa0;
+}
+.db-inner-voice-tier {
+  font-size: 11px;
+  color: #5a6b85;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.db-inner-voice-text {
+  font-style: italic;
+  color: #2a2f3d;
+}
+
+/* TKT-P4-CONVICTION-BADGES: Triangle Strategy conviction chips (inline color). */
+.db-conviction-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.db-conviction-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(20, 26, 38, 0.7);
+  border: 1px solid #2c3650;
+  border-left-width: 4px;
+  border-radius: 8px;
+  padding: 6px 10px;
+}
+.db-conviction-badge .cv-letter {
+  font-weight: 800;
+  font-size: 16px;
+}
+.db-conviction-badge .cv-axis-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #9fb0cc;
+}
+.db-conviction-badge .cv-pole-label {
+  font-weight: 600;
+  color: #e8ecf5;
+}
+.db-conviction-badge .cv-delta {
+  font-size: 11px;
+  font-weight: 700;
+  color: #7ee0a0;
 }
 /* 9 archetype color accent (border-left). */
 .db-ennea-voice.archetype-1 {

--- a/apps/play/src/debriefPanel.js
+++ b/apps/play/src/debriefPanel.js
@@ -19,6 +19,10 @@ import { setupOffspringRitual } from './offspringRitualPanel.js';
 // 2026-05-06 TKT-P4-ENNEA-VOICE-FRONTEND: 9/9 ennea voice palette wire.
 // Engine LIVE Surface DEAD #1 P4 fix — ~189 line authorate visibili in debrief.
 import { renderEnneaVoices } from './enneaVoiceRender.js';
+// 2026-05-30 TKT-P4-DIALOGUE-COLORS: inner voice (Disco Elysium monologue) +
+// TKT-P4-CONVICTION-BADGES: Triangle Strategy conviction badges, debrief surface.
+import { renderInnerVoices } from './innerVoiceRender.js';
+import { renderConvictionBadges } from './convictionBadgeRender.js';
 
 // Sprint Surface-DEAD ennea archetypes — 9 archetypes player surface in debrief.
 // Mirror ENNEA_META da characterPanel.js (kept self-contained per debrief scope).
@@ -192,6 +196,18 @@ export function renderDebriefPanel() {
         <div class="db-ennea-voices-list" id="db-ennea-voices-list"></div>
       </div>
 
+      <!-- 2026-05-30 TKT-P4-DIALOGUE-COLORS: inner voice diegetic monologue (MBTI-tinted). -->
+      <div class="db-section" id="db-inner-voices-section" style="display:none">
+        <div class="db-section-title">💭 Voce interiore</div>
+        <div class="db-inner-voices-list" id="db-inner-voices-list"></div>
+      </div>
+
+      <!-- 2026-05-30 TKT-P4-CONVICTION-BADGES: Triangle Strategy conviction badges. -->
+      <div class="db-section" id="db-conviction-section" style="display:none">
+        <div class="db-section-title">⚜️ Convinzioni manifestate</div>
+        <div class="db-conviction-list" id="db-conviction-list"></div>
+      </div>
+
       <!-- Sprint 10 (Surface-DEAD #7): QBN narrative event diegetic. -->
       <div class="db-section db-qbn-section" id="db-qbn-section" style="display:none">
         <div class="db-section-title">📖 Cronaca diegetica</div>
@@ -296,6 +312,11 @@ export function wireDebriefPanel(overlay, bridge) {
     // Shape: [{actor_id, archetype_id, ennea_type, beat_id, line_id, text}].
     // Empty array hides section.
     enneaVoices: [],
+    // 2026-05-30 TKT-P4-DIALOGUE-COLORS: inner voice palette per actor.
+    // Shape: [{actor_id, voice_id, axis, direction, mbti_pole, tier, label, text}].
+    innerVoices: [],
+    // 2026-05-30 TKT-P4-CONVICTION-BADGES: conviction badges (map uid→[badge] or flat).
+    convictionBadges: null,
     // OD-001 Path A Sprint B (2026-04-26): debrief recruit wire.
     recruitedNpcIds: new Set(),
     recruitInFlight: new Set(),
@@ -481,6 +502,24 @@ export function wireDebriefPanel(overlay, bridge) {
     renderEnneaVoices(section, list, state.enneaVoices);
   };
 
+  // 2026-05-30 TKT-P4-DIALOGUE-COLORS — render inner voice diegetic monologue.
+  // Section hidden by default; revealed when innerVoices payload non-empty.
+  const renderInnerVoicesSection = () => {
+    const section = overlay.querySelector('#db-inner-voices-section');
+    const list = overlay.querySelector('#db-inner-voices-list');
+    if (!section || !list) return;
+    renderInnerVoices(section, list, state.innerVoices);
+  };
+
+  // 2026-05-30 TKT-P4-CONVICTION-BADGES — render conviction badges.
+  // Section hidden by default; revealed when a decisive axis produced a badge.
+  const renderConvictionSection = () => {
+    const section = overlay.querySelector('#db-conviction-section');
+    const list = overlay.querySelector('#db-conviction-list');
+    if (!section || !list) return;
+    renderConvictionBadges(section, list, state.convictionBadges);
+  };
+
   // Sprint 12 (Surface-DEAD #4) — render lineage eligibles (pair-bond cards).
   // Sezione hidden by default, rivela quando matingEligibles non vuota.
   // Solo su victory (defeat = niente lineage); il backend già filtra ma
@@ -660,6 +699,8 @@ export function wireDebriefPanel(overlay, bridge) {
     renderQbn();
     renderLineage();
     renderEnneaVoicesSection();
+    renderInnerVoicesSection();
+    renderConvictionSection();
     renderRecruit();
     // Fire-and-forget: Skiv card refresh ad ogni render debrief.
     renderSkivMonitorCard();
@@ -874,6 +915,19 @@ export function wireDebriefPanel(overlay, bridge) {
     setEnneaVoices(payload) {
       state.enneaVoices = Array.isArray(payload) ? payload : [];
       renderEnneaVoicesSection();
+    },
+    // 2026-05-30 TKT-P4-DIALOGUE-COLORS — set inner voice palette per actor.
+    // Accepts [{actor_id, voice_id, mbti_pole, tier, label, text}]. Empty → hide.
+    setInnerVoices(payload) {
+      state.innerVoices = Array.isArray(payload) ? payload : [];
+      renderInnerVoicesSection();
+    },
+    // 2026-05-30 TKT-P4-CONVICTION-BADGES — set conviction badges.
+    // Accepts map { uid: [badge] } OR flat [badge] OR null. Empty → hide.
+    setConvictionBadges(payload) {
+      state.convictionBadges =
+        payload && (Array.isArray(payload) || typeof payload === 'object') ? payload : null;
+      renderConvictionSection();
     },
     show() {
       overlay.classList.remove('db-hidden');

--- a/apps/play/src/dialogueRender.js
+++ b/apps/play/src/dialogueRender.js
@@ -94,11 +94,16 @@ function tagsAreBalanced(text) {
  *
  * @param {string} text — può contenere `<mbti axis="X">...</mbti>`
  * @param {{revealed?: Array}} [mbtiRevealed] — Path A payload
+ * @param {{forceReveal?: boolean}} [opts] — TKT-P4-DIALOGUE-COLORS: se
+ *   `forceReveal` colora OGNI asse taggato a prescindere dal Path-A gating.
+ *   Usato dalle voci personalità del debrief (ennea + inner voice): la voce
+ *   È il momento di reveal, quindi il colore non va gated.
  * @returns {string} HTML safe
  */
-function renderMbtiTaggedHtml(text, mbtiRevealed = null) {
+function renderMbtiTaggedHtml(text, mbtiRevealed = null, opts = {}) {
   if (typeof text !== 'string') return '';
   if (text.length === 0) return '';
+  const forceReveal = Boolean(opts && opts.forceReveal);
   // Fallback graceful per tag non bilanciati: escape + plain.
   if (!tagsAreBalanced(text)) {
     return escapeHtml(text);
@@ -112,7 +117,7 @@ function renderMbtiTaggedHtml(text, mbtiRevealed = null) {
     const openMatch = part.match(/^<mbti\s+axis="([EISNTFJP])"\s*>$/);
     if (openMatch) {
       const letter = openMatch[1];
-      const revealed = isAxisRevealed(letter, mbtiRevealed);
+      const revealed = forceReveal || isAxisRevealed(letter, mbtiRevealed);
       stack.push({ letter, revealed });
       if (revealed) {
         out += `<span class="mbti-axis-${letter}" data-mbti-axis="${letter}">`;

--- a/apps/play/src/enneaVoiceRender.js
+++ b/apps/play/src/enneaVoiceRender.js
@@ -17,6 +17,12 @@
 
 'use strict';
 
+// TKT-P4-DIALOGUE-COLORS (2026-05-30): voce archetipo color-coded per asse MBTI.
+// Il backend (rewardEconomy.buildDebriefSummary) avvolge il testo in
+// `<mbti axis="X">...</mbti>` via mbtiTaggedLine usando il polo dominante
+// dell'attore; qui lo renderizziamo a colori (forceReveal — la voce È il reveal).
+import { renderMbtiTaggedHtml } from './dialogueRender.js';
+
 // Mapping archetype_id → metadata UI (icon + label + color).
 // Color = Disco-Elysium thought cabinet aesthetic (subtle gradient bg).
 const ARCHETYPE_META = {
@@ -62,7 +68,7 @@ export function formatVoiceLine(voice) {
       <span class="db-ennea-voice-label">${escapeHtml(meta.label)}</span>
       ${beatHtml}
     </div>
-    <div class="db-ennea-voice-text">"${escapeHtml(text)}"</div>
+    <div class="db-ennea-voice-text">"${renderMbtiTaggedHtml(text, null, { forceReveal: true })}"</div>
   </div>`;
 }
 

--- a/apps/play/src/innerVoiceRender.js
+++ b/apps/play/src/innerVoiceRender.js
@@ -1,0 +1,96 @@
+// 2026-05-30 TKT-P4-DIALOGUE-COLORS — Inner voice debrief render.
+//
+// Engine LIVE: apps/backend/services/narrative/innerVoice.js
+// (evaluateVoiceTriggers + describeVoice) + data/core/thoughts/inner_voices.yaml
+// (24 voices = 4 MBTI axes × 2 directions × 3 tiers). Wired into
+// rewardEconomy.buildDebriefSummary → debrief.inner_voices = [{ actor_id,
+// voice_id, axis, direction, mbti_pole, tier, label, text }, ...].
+//
+// Surface DEAD pre-2026-05-30: the debrief panel never rendered inner voices —
+// the Disco-Elysium internal monologue was invisible (Engine LIVE Surface DEAD).
+//
+// Surface NEW: debrief panel shows the actor's MBTI-tinted inner monologue,
+// color-coded per axis (WCAG AA palette via renderMbtiTaggedHtml forceReveal).
+
+'use strict';
+
+// Color-coding: backend wraps `voice_it` in `<mbti axis="X">...</mbti>` via
+// mbtiTaggedLine; here we colorize it (forceReveal — the voice IS the reveal).
+import { renderMbtiTaggedHtml } from './dialogueRender.js';
+
+// Tier label IT for the intensity badge (whisper → shout).
+const TIER_LABEL_IT = {
+  whisper: 'sussurro',
+  voice: 'voce',
+  shout: 'grido',
+};
+
+// Pure: inner voice payload → HTML card. Empty string if payload invalid.
+export function formatInnerVoiceLine(voice) {
+  if (!voice || typeof voice !== 'object') return '';
+  const text = String(voice.text || '').trim();
+  if (!text) return '';
+  const pole = String(voice.mbti_pole || '').trim();
+  const poleCls = /^[EISNTFJP]$/.test(pole) ? ` mbti-pole-${pole}` : '';
+  const poleAttr = pole ? ` data-mbti-pole="${escapeHtml(pole)}"` : '';
+  const actorId = String(voice.actor_id || '').trim();
+  const actorAttr = actorId ? ` data-actor-id="${escapeHtml(actorId)}"` : '';
+  const axis = String(voice.axis || '').trim();
+  const axisAttr = axis ? ` data-axis="${escapeHtml(axis)}"` : '';
+  const label = String(voice.label || '').trim();
+  const tier = String(voice.tier || '').trim();
+  const tierLabel = TIER_LABEL_IT[tier] || tier;
+  const labelHtml = label ? `<span class="db-inner-voice-label">${escapeHtml(label)}</span>` : '';
+  const tierHtml = tierLabel
+    ? `<span class="db-inner-voice-tier">${escapeHtml(tierLabel)}</span>`
+    : '';
+  const poleIcon = pole ? `<span class="db-inner-voice-pole">${escapeHtml(pole)}</span>` : '';
+  return `<div class="db-inner-voice${poleCls}"${actorAttr}${poleAttr}${axisAttr}>
+    <div class="db-inner-voice-header">
+      ${poleIcon}
+      ${labelHtml}
+      ${tierHtml}
+    </div>
+    <div class="db-inner-voice-text">"${renderMbtiTaggedHtml(text, null, { forceReveal: true })}"</div>
+  </div>`;
+}
+
+// Pure: array of inner voice payloads → HTML list. Filters invalid.
+export function formatInnerVoiceList(voices) {
+  if (!Array.isArray(voices) || voices.length === 0) return '';
+  return voices.map(formatInnerVoiceLine).filter(Boolean).join('');
+}
+
+function escapeHtml(s) {
+  return String(s).replace(
+    /[&<>"']/g,
+    (c) =>
+      ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+      })[c],
+  );
+}
+
+// Side effect: render inner voice list into list container + show/hide section
+// parent. Idempotent — replaces innerHTML.
+//   sectionEl = #db-inner-voices-section
+//   listEl    = #db-inner-voices-list
+//   payload   = inner_voices array | null
+export function renderInnerVoices(sectionEl, listEl, payload) {
+  if (!sectionEl || !listEl) return;
+  const html = formatInnerVoiceList(payload);
+  if (!html) {
+    sectionEl.style.display = 'none';
+    listEl.innerHTML = '';
+    return;
+  }
+  sectionEl.style.display = '';
+  listEl.innerHTML = html;
+}
+
+// Test hook: expose TIER_LABEL_IT for parity tests.
+export const _internals = { TIER_LABEL_IT };

--- a/apps/play/src/phaseCoordinator.js
+++ b/apps/play/src/phaseCoordinator.js
@@ -123,8 +123,18 @@ export function createPhaseCoordinator(bridge) {
             ? debriefPayload.ennea_voices
             : [];
           if (dbApi.setEnneaVoices) dbApi.setEnneaVoices(enneaVoices);
+          // 2026-05-30 TKT-P4-DIALOGUE-COLORS: pipe inner voice monologue
+          // dal debriefPayload.inner_voices (rewardEconomy.buildDebriefSummary).
+          const innerVoices = Array.isArray(debriefPayload?.inner_voices)
+            ? debriefPayload.inner_voices
+            : [];
+          if (dbApi.setInnerVoices) dbApi.setInnerVoices(innerVoices);
+          // 2026-05-30 TKT-P4-CONVICTION-BADGES: pipe conviction badges map
+          // dal debriefPayload.mbti_surface.conviction_badges (Triangle Strategy).
+          const convictionBadges = debriefPayload?.mbti_surface?.conviction_badges || null;
+          if (dbApi.setConvictionBadges) dbApi.setConvictionBadges(convictionBadges);
         } catch {
-          /* narrative event + lineage + ennea + voices optional */
+          /* narrative event + lineage + ennea + voices + conviction optional */
         }
         break;
       }

--- a/tests/play/convictionBadgeRender.test.js
+++ b/tests/play/convictionBadgeRender.test.js
@@ -1,0 +1,124 @@
+// TKT-P4-CONVICTION-BADGES — conviction badge debrief render tests.
+//
+// Engine LIVE: mbtiSurface.buildConvictionBadges / buildConvictionBadgesMap
+// (Triangle Strategy pattern). Wired into rewardEconomy.buildDebriefSummary →
+// debrief.mbti_surface.conviction_badges = { uid: [{ axis, letter, label,
+// axis_label, color, color_name, confidence, value, delta }, ...], ... }.
+//
+// Surface DEAD pre-2026-05-30: the only renderer was an in-combat transient
+// flash (characterPanel); the debrief panel never showed convictions. This adds
+// a persistent debrief section.
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+async function loadModule() {
+  return import('../../apps/play/src/convictionBadgeRender.js');
+}
+
+const SAMPLE = {
+  axis: 'T_F',
+  letter: 'T',
+  label: 'Pensiero',
+  axis_label: 'Decisione',
+  color: '#0e7490',
+  color_name: 'teal',
+  confidence: 0.85,
+  value: 0.9,
+  delta: null,
+};
+
+describe('formatConvictionBadge — pure HTML chip', () => {
+  test('null/non-object → empty string', async () => {
+    const { formatConvictionBadge } = await loadModule();
+    assert.equal(formatConvictionBadge(null), '');
+    assert.equal(formatConvictionBadge('x'), '');
+    assert.equal(formatConvictionBadge(3), '');
+  });
+
+  test('missing letter AND axis_label → empty string', async () => {
+    const { formatConvictionBadge } = await loadModule();
+    assert.equal(formatConvictionBadge({ color: '#0e7490' }), '');
+  });
+
+  test('full badge → letter + axis_label + pole label + color', async () => {
+    const { formatConvictionBadge } = await loadModule();
+    const html = formatConvictionBadge(SAMPLE);
+    assert.ok(html.includes('Decisione'), 'axis label');
+    assert.ok(html.includes('Pensiero'), 'pole label');
+    assert.ok(html.includes('>T<'), 'letter');
+    assert.ok(html.includes('#0e7490'), 'color applied');
+    assert.ok(html.includes('data-axis="T_F"'));
+  });
+
+  test('positive delta shown as scaled signed integer', async () => {
+    const { formatConvictionBadge } = await loadModule();
+    const html = formatConvictionBadge({ ...SAMPLE, delta: 0.12 });
+    assert.ok(html.includes('+12'), 'delta scaled ×100 with sign');
+  });
+
+  test('invalid color is not injected as inline style (sanitized)', async () => {
+    const { formatConvictionBadge } = await loadModule();
+    const html = formatConvictionBadge({ ...SAMPLE, color: 'red;}</style><script>x' });
+    assert.ok(!html.includes('<script>'), 'no script injection');
+    assert.ok(!html.includes('color:red;}'), 'malformed color not used inline');
+  });
+});
+
+describe('formatConvictionBadgeList — accepts map or flat array', () => {
+  test('null/empty → empty string', async () => {
+    const { formatConvictionBadgeList } = await loadModule();
+    assert.equal(formatConvictionBadgeList(null), '');
+    assert.equal(formatConvictionBadgeList([]), '');
+    assert.equal(formatConvictionBadgeList({}), '');
+  });
+
+  test('per-actor map {uid:[badges]} → flattened render', async () => {
+    const { formatConvictionBadgeList } = await loadModule();
+    const html = formatConvictionBadgeList({
+      p_a: [SAMPLE],
+      p_b: [{ ...SAMPLE, axis: 'E_I', letter: 'E', axis_label: 'Energia sociale' }],
+    });
+    assert.ok(html.includes('Decisione'));
+    assert.ok(html.includes('Energia sociale'));
+  });
+
+  test('flat array also accepted', async () => {
+    const { formatConvictionBadgeList } = await loadModule();
+    const html = formatConvictionBadgeList([SAMPLE]);
+    assert.ok(html.includes('Decisione'));
+  });
+});
+
+describe('renderConvictionBadges — DOM side effect (fake nodes)', () => {
+  function makeFake() {
+    return { style: { display: 'block' }, innerHTML: '' };
+  }
+
+  test('empty payload → section hidden + cleared', async () => {
+    const { renderConvictionBadges } = await loadModule();
+    const section = makeFake();
+    const list = makeFake();
+    list.innerHTML = 'stale';
+    renderConvictionBadges(section, list, {});
+    assert.equal(section.style.display, 'none');
+    assert.equal(list.innerHTML, '');
+  });
+
+  test('valid payload → section visible + populated', async () => {
+    const { renderConvictionBadges } = await loadModule();
+    const section = makeFake();
+    const list = makeFake();
+    section.style.display = 'none';
+    renderConvictionBadges(section, list, { p_a: [SAMPLE] });
+    assert.equal(section.style.display, '');
+    assert.ok(list.innerHTML.includes('Decisione'));
+  });
+
+  test('null refs → no throw', async () => {
+    const { renderConvictionBadges } = await loadModule();
+    assert.doesNotThrow(() => renderConvictionBadges(null, null, {}));
+  });
+});

--- a/tests/play/dialogueColorsWcag.test.js
+++ b/tests/play/dialogueColorsWcag.test.js
@@ -1,0 +1,68 @@
+// TKT-P4-DIALOGUE-COLORS — frontend WCAG AA gate (mirror tests/services/mbtiPalette.test.js).
+//
+// The debrief personality voices (ennea + inner) render their MBTI color via the
+// .mbti-axis-X CSS classes in dialogueRender.css. Those classes MUST stay WCAG
+// AA (>=4.5:1) against the light voice-card background, and MUST stay in sync
+// with the canonical palette (data/core/personality/mbti_axis_palette.yaml,
+// proven WCAG-on-white by the backend test) to avoid drift.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  loadMbtiPalette,
+  wcagContrastRatio,
+  _resetPaletteCache,
+} = require('../../apps/backend/services/mbtiPalette');
+
+const CSS = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'apps', 'play', 'src', 'dialogueRender.css'),
+  'utf8',
+);
+
+const LETTERS = ['E', 'I', 'S', 'N', 'T', 'F', 'J', 'P'];
+
+// Voice cards render on a light background (#ffffff) — the palette is built
+// WCAG-AA dark-on-light (see mbti_axis_palette.yaml header). debriefPanel.css
+// gives .db-ennea-voice / .db-inner-voice a white card to honor this.
+const CARD_BG = '#ffffff';
+
+function cssColor(letter) {
+  const re = new RegExp(`\\.mbti-axis-${letter}\\s*\\{[^}]*color:\\s*(#[0-9a-fA-F]{6})`, 'i');
+  const m = CSS.match(re);
+  return m ? m[1].toLowerCase() : null;
+}
+
+test('dialogueRender.css defines all 8 axis color classes', () => {
+  for (const letter of LETTERS) {
+    assert.ok(cssColor(letter), `.mbti-axis-${letter} color missing`);
+  }
+});
+
+test('every axis color is WCAG AA (>=4.5:1) on the light voice card', () => {
+  for (const letter of LETTERS) {
+    const color = cssColor(letter);
+    const ratio = wcagContrastRatio(color, CARD_BG);
+    assert.ok(
+      ratio >= 4.5,
+      `${letter} (${color}) contrast ${ratio.toFixed(2)} < AA 4.5 on ${CARD_BG}`,
+    );
+  }
+});
+
+test('CSS axis colors stay in sync with canonical mbti_axis_palette.yaml (no drift)', () => {
+  _resetPaletteCache();
+  const palette = loadMbtiPalette();
+  for (const letter of LETTERS) {
+    assert.equal(
+      cssColor(letter),
+      palette[letter].color.toLowerCase(),
+      `${letter} CSS color drifted from canonical palette`,
+    );
+  }
+  _resetPaletteCache();
+});

--- a/tests/play/dialogueRender.test.js
+++ b/tests/play/dialogueRender.test.js
@@ -1,0 +1,54 @@
+// TKT-P4-DIALOGUE-COLORS — renderMbtiTaggedHtml forceReveal option tests.
+//
+// Pre-P4: <mbti> color spans only rendered when the axis is in
+// mbtiRevealed.revealed[] (Path A gating). Debrief personality voices (ennea +
+// inner) ARE the reveal moment, so they must color-code unconditionally via the
+// additive { forceReveal: true } option. WCAG AA preserved (palette mirror).
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+async function loadModule() {
+  return import('../../apps/play/src/dialogueRender.js');
+}
+
+describe('renderMbtiTaggedHtml — forceReveal option (TKT-P4-DIALOGUE-COLORS)', () => {
+  test('without forceReveal, unrevealed axis stays plain (no color leak)', async () => {
+    const { renderMbtiTaggedHtml } = await loadModule();
+    const html = renderMbtiTaggedHtml('<mbti axis="T">La logica guida.</mbti>', null);
+    assert.ok(html.includes('La logica guida.'));
+    assert.ok(!html.includes('mbti-axis-T'), 'no color span when not revealed');
+    assert.ok(!html.includes('style="color:'), 'no inline color when not revealed');
+  });
+
+  test('forceReveal colorizes every tagged axis regardless of reveal state', async () => {
+    const { renderMbtiTaggedHtml } = await loadModule();
+    const html = renderMbtiTaggedHtml('<mbti axis="T">La logica guida.</mbti>', null, {
+      forceReveal: true,
+    });
+    assert.ok(html.includes('mbti-axis-T'), 'color class applied (WCAG AA via CSS)');
+    assert.ok(html.includes('data-mbti-axis="T"'), 'axis data attr present');
+    assert.ok(html.includes('La logica guida.'));
+  });
+
+  test('forceReveal still escapes inner HTML (XSS safety)', async () => {
+    const { renderMbtiTaggedHtml } = await loadModule();
+    const html = renderMbtiTaggedHtml('<mbti axis="F"><script>alert(1)</script></mbti>', null, {
+      forceReveal: true,
+    });
+    assert.ok(!html.includes('<script>'), 'no live script tag');
+    assert.ok(html.includes('&lt;script&gt;'), 'inner escaped');
+    assert.ok(html.includes('mbti-axis-F'), 'still colorized');
+  });
+
+  test('forceReveal escapes plain text outside tags', async () => {
+    const { renderMbtiTaggedHtml } = await loadModule();
+    const html = renderMbtiTaggedHtml('prima <mbti axis="N">visione</mbti> <b>dopo</b>', null, {
+      forceReveal: true,
+    });
+    assert.ok(html.includes('&lt;b&gt;dopo&lt;/b&gt;'), 'outside-tag HTML escaped');
+    assert.ok(html.includes('mbti-axis-N'));
+  });
+});

--- a/tests/play/enneaVoiceRender.test.js
+++ b/tests/play/enneaVoiceRender.test.js
@@ -169,3 +169,37 @@ describe('renderEnneaVoices — DOM side effect (fake nodes)', () => {
     assert.doesNotThrow(() => renderEnneaVoices(null, { innerHTML: '' }, []));
   });
 });
+
+describe('formatVoiceLine — MBTI color-coding (TKT-P4-DIALOGUE-COLORS)', () => {
+  test('mbti-tagged text → quote rendered with WCAG color span', async () => {
+    const { formatVoiceLine } = await loadModule();
+    const html = formatVoiceLine({
+      actor_id: 'p_a',
+      archetype_id: 'Architetto(5)',
+      beat_id: 'victory_solo',
+      text: '<mbti axis="N">Visione astratta confermata.</mbti>',
+    });
+    assert.ok(html.includes('mbti-axis-N'), 'color class applied (WCAG AA via CSS)');
+    assert.ok(html.includes('Visione astratta confermata.'), 'inner text preserved');
+  });
+
+  test('plain (untagged) text still renders escaped, no color span', async () => {
+    const { formatVoiceLine } = await loadModule();
+    const html = formatVoiceLine({
+      archetype_id: 'Stoico(9)',
+      text: 'Resisto. Sempre.',
+    });
+    assert.ok(html.includes('Resisto. Sempre.'));
+    assert.ok(!html.includes('mbti-axis-'), 'no color span for plain text');
+  });
+
+  test('mbti-tagged text with XSS inner stays escaped (color + safety)', async () => {
+    const { formatVoiceLine } = await loadModule();
+    const html = formatVoiceLine({
+      archetype_id: 'Cacciatore(8)',
+      text: '<mbti axis="F"><img src=x onerror=alert(1)></mbti>',
+    });
+    assert.ok(!html.includes('<img src'), 'no live img tag');
+    assert.ok(html.includes('mbti-axis-F'), 'still colorized');
+  });
+});

--- a/tests/play/innerVoiceRender.test.js
+++ b/tests/play/innerVoiceRender.test.js
@@ -1,0 +1,120 @@
+// TKT-P4-DIALOGUE-COLORS — inner voice debrief render tests.
+//
+// Inner voices (Disco Elysium diegetic, 24 lines = 4 MBTI axes × 2 dir × 3
+// tiers) are engine-LIVE (innerVoice.evaluateVoiceTriggers + inner_voices.yaml)
+// but had ZERO debrief surface. This renders them color-coded per MBTI axis,
+// mirroring enneaVoiceRender. Payload shape per voice:
+//   { actor_id, voice_id, axis, direction, mbti_pole, tier, label, text }
+// text is pre-wrapped backend-side: '<mbti axis="X">voice_it</mbti>'.
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+async function loadModule() {
+  return import('../../apps/play/src/innerVoiceRender.js');
+}
+
+describe('formatInnerVoiceLine — pure HTML formatter', () => {
+  test('null/non-object payload → empty string', async () => {
+    const { formatInnerVoiceLine } = await loadModule();
+    assert.equal(formatInnerVoiceLine(null), '');
+    assert.equal(formatInnerVoiceLine(undefined), '');
+    assert.equal(formatInnerVoiceLine('garbage'), '');
+    assert.equal(formatInnerVoiceLine(7), '');
+  });
+
+  test('missing text → empty string', async () => {
+    const { formatInnerVoiceLine } = await loadModule();
+    assert.equal(formatInnerVoiceLine({ mbti_pole: 'E', label: 'x' }), '');
+    assert.equal(formatInnerVoiceLine({ text: '' }), '');
+  });
+
+  test('full payload → label + tier + color-coded quote', async () => {
+    const { formatInnerVoiceLine } = await loadModule();
+    const html = formatInnerVoiceLine({
+      actor_id: 'p_a',
+      voice_id: 'e_i_low_voice',
+      axis: 'E_I',
+      direction: 'low',
+      mbti_pole: 'E',
+      tier: 'voice',
+      label: 'Voce estroversa',
+      text: '<mbti axis="E">Insieme siamo più forti.</mbti>',
+    });
+    assert.ok(html.includes('data-actor-id="p_a"'));
+    assert.ok(html.includes('Voce estroversa'), 'label rendered');
+    assert.ok(html.includes('Insieme siamo più forti.'), 'quote text rendered');
+    assert.ok(html.includes('mbti-axis-E'), 'color class applied (WCAG AA via CSS)');
+  });
+
+  test('escapes label + XSS-safe quote', async () => {
+    const { formatInnerVoiceLine } = await loadModule();
+    const html = formatInnerVoiceLine({
+      mbti_pole: 'T',
+      label: '<b>boom</b>',
+      text: '<mbti axis="T"><script>alert(1)</script></mbti>',
+    });
+    assert.ok(!html.includes('<script>'), 'no live script');
+    assert.ok(!html.includes('<b>boom</b>'), 'label escaped');
+    assert.ok(html.includes('mbti-axis-T'), 'still colorized');
+  });
+});
+
+describe('formatInnerVoiceList — pure HTML list', () => {
+  test('null/empty array → empty string', async () => {
+    const { formatInnerVoiceList } = await loadModule();
+    assert.equal(formatInnerVoiceList(null), '');
+    assert.equal(formatInnerVoiceList([]), '');
+    assert.equal(formatInnerVoiceList('garbage'), '');
+  });
+
+  test('mixed valid + invalid filters silently', async () => {
+    const { formatInnerVoiceList } = await loadModule();
+    const html = formatInnerVoiceList([
+      { mbti_pole: 'F', label: 'A', text: '<mbti axis="F">alpha</mbti>' },
+      null,
+      { label: 'B' }, // no text → filtered
+      { mbti_pole: 'J', label: 'C', text: 'gamma' },
+    ]);
+    assert.ok(html.includes('alpha'));
+    assert.ok(!html.includes('>B<'));
+    assert.ok(html.includes('gamma'));
+  });
+});
+
+describe('renderInnerVoices — DOM side effect (fake nodes)', () => {
+  function makeFake() {
+    return { style: { display: 'block' }, innerHTML: '' };
+  }
+
+  test('null payload → section hidden + listEl cleared', async () => {
+    const { renderInnerVoices } = await loadModule();
+    const section = makeFake();
+    const list = makeFake();
+    list.innerHTML = 'stale';
+    renderInnerVoices(section, list, null);
+    assert.equal(section.style.display, 'none');
+    assert.equal(list.innerHTML, '');
+  });
+
+  test('valid payload → section visible + populated', async () => {
+    const { renderInnerVoices } = await loadModule();
+    const section = makeFake();
+    const list = makeFake();
+    section.style.display = 'none';
+    renderInnerVoices(section, list, [
+      { mbti_pole: 'N', label: 'Voce intuitiva', text: '<mbti axis="N">Vedo oltre.</mbti>' },
+    ]);
+    assert.equal(section.style.display, '');
+    assert.ok(list.innerHTML.includes('Vedo oltre.'));
+    assert.ok(list.innerHTML.includes('mbti-axis-N'));
+  });
+
+  test('null refs → no throw', async () => {
+    const { renderInnerVoices } = await loadModule();
+    assert.doesNotThrow(() => renderInnerVoices(null, null, []));
+    assert.doesNotThrow(() => renderInnerVoices(null, { innerHTML: '' }, []));
+  });
+});

--- a/tests/services/debriefPersonality.test.js
+++ b/tests/services/debriefPersonality.test.js
@@ -1,0 +1,104 @@
+// TKT-P4 (ENNEAVOICE-FE + DIALOGUE-COLORS + CONVICTION-BADGES) — backend wire.
+//
+// buildDebriefSummary already attached ennea_voices (engine LIVE). This sprint
+// also attaches:
+//   - inner_voices (innerVoice.evaluateVoiceTriggers, MBTI-tinted)
+//   - mbti_surface.conviction_badges (mbtiSurface.buildConvictionBadgesMap)
+//   - MBTI color tags on BOTH ennea + inner voice text (mbtiPalette.mbtiTaggedLine)
+// so the debrief payload carries everything the panel renders.
+//
+// No new engine — pure composition of existing pure selectors + real YAML data.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildDebriefSummary } = require('../../apps/backend/services/rewardEconomy');
+
+function makeVcSnapshot() {
+  return {
+    turns_played: 6,
+    per_actor: {
+      p_a: {
+        aggregate_indices: { aggression: 0.7 },
+        mbti_type: 'INTJ',
+        mbti_axes: {
+          E_I: { value: 0.5, coverage: 'full' }, // deadband → no badge/pole
+          S_N: { value: 0.92, coverage: 'full' }, // decisive
+          T_F: { value: 0.08, coverage: 'full' }, // decisive
+          J_P: { value: 0.5, coverage: 'full' },
+        },
+        ennea_archetypes: [{ id: 'Architetto(5)', triggered: true }],
+      },
+    },
+  };
+}
+
+const VICTORY_SESSION = {
+  session_id: 's-test-1',
+  outcome: 'victory',
+  events: [],
+  damage_taken: {},
+};
+const PE_RESULT = { per_actor: { p_a: { pe_total: 7 } }, session_total: 7 };
+
+test('ennea_voices text is MBTI color-tagged (TKT-P4-DIALOGUE-COLORS)', () => {
+  const debrief = buildDebriefSummary(VICTORY_SESSION, makeVcSnapshot(), PE_RESULT);
+  assert.ok(Array.isArray(debrief.ennea_voices), 'ennea_voices array');
+  assert.ok(debrief.ennea_voices.length >= 1, 'at least one ennea voice');
+  const v = debrief.ennea_voices[0];
+  assert.ok(v.mbti_pole, 'ennea voice carries a dominant mbti_pole');
+  assert.match(v.text, /<mbti axis="[EISNTFJP]">/, 'ennea text wrapped via mbtiTaggedLine');
+});
+
+test('inner_voices attached + color-tagged (TKT-P4-DIALOGUE-COLORS)', () => {
+  const debrief = buildDebriefSummary(VICTORY_SESSION, makeVcSnapshot(), PE_RESULT);
+  assert.ok(Array.isArray(debrief.inner_voices), 'inner_voices array');
+  assert.ok(debrief.inner_voices.length >= 1, 'at least one inner voice');
+  for (const v of debrief.inner_voices) {
+    assert.equal(v.actor_id, 'p_a');
+    assert.match(v.mbti_pole, /^[EISNTFJP]$/, 'inner voice carries pole letter');
+    assert.match(v.text, /<mbti axis="[EISNTFJP]">/, 'inner text wrapped via mbtiTaggedLine');
+    assert.ok(v.voice_id, 'voice_id present');
+  }
+});
+
+test('mbti_surface.conviction_badges attached (TKT-P4-CONVICTION-BADGES)', () => {
+  const debrief = buildDebriefSummary(VICTORY_SESSION, makeVcSnapshot(), PE_RESULT);
+  assert.ok(
+    debrief.mbti_surface && typeof debrief.mbti_surface === 'object',
+    'mbti_surface object',
+  );
+  const badges = debrief.mbti_surface.conviction_badges;
+  assert.ok(badges && typeof badges === 'object', 'conviction_badges map');
+  assert.ok(Array.isArray(badges.p_a), 'badges for decisive actor p_a');
+  assert.ok(badges.p_a.length >= 1, 'at least one badge for decisive axes');
+  const b = badges.p_a[0];
+  assert.match(b.letter, /^[EISNTFJP]$/, 'badge has letter');
+  assert.match(b.color, /^#[0-9a-fA-F]{6}$/, 'badge has hex color');
+});
+
+test('graceful: empty per_actor → empty voices + empty conviction map', () => {
+  const debrief = buildDebriefSummary(
+    VICTORY_SESSION,
+    { turns_played: 0, per_actor: {} },
+    {
+      per_actor: {},
+      session_total: 0,
+    },
+  );
+  assert.deepEqual(debrief.ennea_voices, []);
+  assert.deepEqual(debrief.inner_voices, []);
+  assert.deepEqual(debrief.mbti_surface.conviction_badges, {});
+});
+
+test('defeat outcome still attaches inner_voices + conviction (beat = defeat)', () => {
+  const debrief = buildDebriefSummary(
+    { ...VICTORY_SESSION, outcome: 'defeat' },
+    makeVcSnapshot(),
+    PE_RESULT,
+  );
+  assert.ok(Array.isArray(debrief.inner_voices));
+  assert.ok(debrief.mbti_surface.conviction_badges.p_a.length >= 1);
+});


### PR DESCRIPTION
## What

Wave 1 of the design-data gap-resolution plan — **surface-wire** the engine-LIVE / player-surface-DEAD **P4 (MBTI/Ennea)** systems into the debrief panel. Goal: P4 surface 60% → 90% (🟡++ → 🟢). **No new engine** — pure composition of existing pure selectors + real YAML data. No combat-band impact.

- **TKT-P4-ENNEAVOICE-FE** — ennea voice quotes now render MBTI **color-coded** (actor's dominant pole).
- **TKT-P4-DIALOGUE-COLORS** — ennea **and** inner voice text auto-wrapped via `mbtiTaggedLine`; **inner voice** (Disco Elysium monologue) surfaced for the first time, color-coded.
- **TKT-P4-CONVICTION-BADGES** — Triangle Strategy conviction badges rendered in the debrief (was in-combat flash only).

## Backend (`rewardEconomy.buildDebriefSummary`)
- attach `inner_voices` (`innerVoice.evaluateVoiceTriggers` + `inner_voices.yaml`, ≤2 most-intense per actor, MBTI-tinted).
- attach `mbti_surface.conviction_badges` (`mbtiSurface.buildConvictionBadgesMap`, first-reveal mode — no new state).
- tag ennea + inner text via `mbtiPalette.mbtiTaggedLine` (dominant pole for ennea, `pole_letter` for inner).

## Frontend (`apps/play`)
- new pure renderers `innerVoiceRender.js` + `convictionBadgeRender.js` (DOM-side-effect, XSS-safe).
- `enneaVoiceRender` quote colorized; `dialogueRender.renderMbtiTaggedHtml` gains additive `{ forceReveal }` (the voice **is** the reveal → color not Path-A-gated).
- `debriefPanel` + `phaseCoordinator` render/pipe the two new sections.
- **WCAG AA preserved**: voice cards use a light bg so the dark-on-light MBTI palette (`mbti_axis_palette.yaml`) keeps ≥4.5:1 — enforced by a new test parsing `dialogueRender.css` for contrast + palette sync.

## Tests (TDD)
+46 (41 frontend renderer/WCAG + 5 backend). All green (`node --test` over the touched files); Prettier clean.

## Notes
- Branch supersedes the earlier empty `claude/p4-ennea-voice-surface`.
- `apps/play` has no in-repo bundler (built by an external pipeline; not in CI) → FE verification = renderer unit tests + Prettier + no-regression suites.
- Referenced design docs (`docs/planning/2026-05-30-design-data-gap-resolution-plan.md`, `DESIGN-DATA-ATLAS.md`, `2026-05-06-mbti-ennea-audit.md`) were not all present in-tree; design intent taken from code/data + museum P4 cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
