### PR TITLE
docs(combat): clarify woundperma permanent-meta lifecycle + crit panic probability

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -288,9 +288,12 @@ function createSessionRouter(options = {}) {
 
   const sessions = new Map();
   // TKT-ORPHAN-WOUNDPERMA: cross-encounter wounded_perma scar map, keyed by
-  // campaign_id (== run.id). Persists between single-encounter sessions of the
-  // same playthrough so woundedPerma.applyWound (write) + restoreOnEncounterStart
-  // (restore) are live, not orphan. In-memory (dev/demo; lossy on restart).
+  // campaign_id (== run.id). PERMANENT roguelike meta-progression (master-dd
+  // 2026-05-30): scars persist across encounters AND across playthroughs of the
+  // same campaign_id -- deliberately never reset (no clearSession on this map).
+  // woundedPerma.applyWound (write) + restoreOnEncounterStart (restore) are live.
+  // In-memory (dev/demo; lossy on process restart) -> true cross-restart permanence
+  // needs DB backing (future follow-up); unbounded growth acceptable (few campaign ids).
   const woundedPermaByCampaign = new Map();
   let activeSessionId = null; // PR-1 §22 coop-WS surface — optional coop orchestrator store; when present,
   // /start links the new session id back by campaign_id (== run.id).
@@ -854,7 +857,9 @@ function createSessionRouter(options = {}) {
       // unconditional panic. checkMorale rolls d20+morale_mod vs threshold and
       // applies panic on target.status when it triggers, so morale.js's crit
       // event is finally live + telemetered (units with high morale_mod can now
-      // shrug off a crit). Best-effort: never blocks the hit.
+      // shrug off a crit). Probability: a default unit (morale_mod 0) panics ~65% on
+      // crit (d20 vs threshold), NOT the old guaranteed 100%; morale_mod lowers/erases it.
+      // Best-effort: never blocks the hit.
       if (result.is_critical && target.status && target.hp > 0) {
         try {
           const { checkMorale } = require('../services/combat/morale');

--- a/apps/backend/services/combat/woundedPerma.js
+++ b/apps/backend/services/combat/woundedPerma.js
@@ -9,8 +9,13 @@
 //      → applyWound(unit, sessionMap) on every KO'd player unit
 //   2. encounter starts → restoreOnEncounterStart(unit, sessionMap) re-applies
 //      HP penalty from prior session map, idempotent (skip if already applied).
-//   3. session ends → clearSession(sessionMap) wipes all entries (durata sessione,
-//      handoff §4 D-skiv-2 default).
+//   3. clearSession(sessionMap) wipes all entries -- kept for session-scoped callers.
+//      NOTE (master-dd 2026-05-30): the live caller (session.js TKT-ORPHAN-WOUNDPERMA)
+//      keys the map by campaign_id and DELIBERATELY never clears it -- scars are a
+//      PERMANENT roguelike meta-progression consequence (carry across playthroughs),
+//      so the old "durata sessione" default does NOT apply to that map. Current store
+//      is in-memory (lossy on process restart); true cross-restart permanence = future
+//      DB-backed follow-up.
 //
 // API:
 //   initSessionMap()                           → empty map object


### PR DESCRIPTION
Follow-up post harsh-review di #2463 (Wave 2). **Comment-only, zero behavior change.**

Risolve i 2 residui non-bloccanti del review + decisione master-dd:

1. **Woundperma lifecycle** (decisione master-dd: roguelike-PERMANENT meta-progression): `woundedPerma.js` header §3 rimuove lo stale "durata sessione / clearSession on session-end" che contraddice la mappa campaign-keyed shipped; documenta intento permanent (cicatrici persistono cross-encounter E cross-playthrough, mai reset) + **caveat onesto in-memory** (lossy al restart -> vera permanenza cross-restart = futura persistenza DB). `session.js:294` comment allineato (cross-playthrough permanent).
2. **Crit panic probability** (review P2): `session.js` crit-morale block nota che `morale_mod 0` -> ~65% panic su crit (vs vecchio 100% unconditional); `morale_mod` abbassa/azzera.

Watch residui (NON in questa PR, tracked): HC06 a band-floor 0.15 · HC07 OOB-high cronico pre-esistente.
