### PR TITLE
fix(play): wire backend debrief payload into the debrief panel (P4 surface)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -3131,6 +3131,49 @@ function createSessionRouter(options = {}) {
     }
   });
 
+  // 2026-05-30 P4 debrief wire — GET /:id/debrief. Non-destructive sibling of
+  // POST /end: returns the same buildDebriefSummary payload (ennea_voices /
+  // inner_voices / conviction_badges / ennea archetypes / narrative_event /
+  // mating_eligibles) WITHOUT finalizing or deleting the session. A coop host
+  // fetches it to attach `debrief_payload` to /coop/combat/end while keeping its
+  // own session alive for the VC block + promotion accept (a destructive /end
+  // would 404 those). Registered after the static routes, same ordering guard as
+  // /:id/vc below. Outcome gate: ?outcome=victory unlocks mating/PE→PI fields.
+  router.get('/:id/debrief', (req, res, next) => {
+    try {
+      const { error, session } = resolveSession(req.params.id);
+      if (error) return res.status(error.status).json(error.body);
+      const rawOutcome = typeof req.query.outcome === 'string' ? req.query.outcome : null;
+      // Map the client outcome ('victory'/'defeat') to the session.outcome
+      // vocabulary buildDebriefSummary gates on (=== 'victory'). Mirror /end's
+      // 'win' → 'victory' normalization; fall back to the session's own outcome.
+      const normalizedOutcome =
+        rawOutcome === 'win' || rawOutcome === 'victory'
+          ? 'victory'
+          : rawOutcome || session.outcome || null;
+      let debrief = null;
+      try {
+        const vcSnapshot = buildVcSnapshot(session, telemetryConfig);
+        const { computeSessionPE, buildDebriefSummary } = require('../services/rewardEconomy');
+        const peResult = computeSessionPE(vcSnapshot, {
+          difficulty: session.encounter_class || session.difficulty || 'standard',
+        });
+        // Shallow clone with the resolved outcome so we never mutate the live
+        // session — it must stay pristine for the host's later /end + promotion.
+        debrief = buildDebriefSummary(
+          { ...session, outcome: normalizedOutcome },
+          vcSnapshot,
+          peResult,
+        );
+      } catch {
+        /* vc + debrief are best-effort — never block the read */
+      }
+      res.json({ session_id: session.session_id, outcome: normalizedOutcome, debrief });
+    } catch (err) {
+      next(err);
+    }
+  });
+
   // SPRINT_003 fase 3: VC snapshot on-demand. Registrato DOPO tutte le
   // route statiche (/start, /state, /action, /turn/end, /end) per
   // evitare che resolveSession('state') venga intercettato dal pattern

--- a/apps/play/src/api.js
+++ b/apps/play/src/api.js
@@ -126,6 +126,14 @@ export const api = {
       body: JSON.stringify({ session_id: sid, auto_resolve: autoResolve }),
     }),
   vc: (sid) => jsonFetch(`/api/session/${encodeURIComponent(sid)}/vc`),
+  // 2026-05-30 P4 debrief wire — non-destructive debrief fetch (full
+  // buildDebriefSummary: ennea/inner voices + conviction badges + archetypes).
+  // Host uses it to attach debrief_payload to /coop/combat/end without ending
+  // the session (keeps VC + promotion accept alive). ?outcome gates mating/PE.
+  sessionDebrief: (sid, outcome = null) => {
+    const qs = outcome ? `?outcome=${encodeURIComponent(outcome)}` : '';
+    return jsonFetch(`/api/session/${encodeURIComponent(sid)}/debrief${qs}`);
+  },
   // Sprint 8 (Surface-DEAD #1): predict_combat hover preview.
   predict: (sid, actorId, targetId) =>
     jsonFetch('/api/session/predict', {

--- a/apps/play/src/debriefPipe.js
+++ b/apps/play/src/debriefPipe.js
@@ -34,9 +34,13 @@ export function pipeDebriefToPanel(dbApi, debriefPayload, playerId) {
   if (dbApi.setLineageEligibles) dbApi.setLineageEligibles(matingEligibles);
 
   // Ennea archetypes manifested for the current player (per-actor → needs id).
-  const enneaArchetypes = playerId
-    ? p?.vc_summary?.per_actor?.[playerId]?.ennea_archetypes || null
-    : null;
+  // vc_summary.per_actor is keyed by the UNIT id, which in coop is
+  // `pg_${player_id}` (characterToUnit). The phone bridge only knows the raw
+  // player_id, so try the exact id first then the pg_ unit-id form — otherwise
+  // real phone clients silently lose the archetype surface.
+  const perActor = p?.vc_summary?.per_actor || null;
+  const actorVc = playerId ? perActor?.[playerId] || perActor?.[`pg_${playerId}`] : null;
+  const enneaArchetypes = actorVc?.ennea_archetypes || null;
   if (dbApi.setEnneaArchetypes) dbApi.setEnneaArchetypes(enneaArchetypes);
 
   // TKT-P4-ENNEA-VOICE-FRONTEND — 1 diegetic quote per actor.

--- a/apps/play/src/debriefPipe.js
+++ b/apps/play/src/debriefPipe.js
@@ -1,0 +1,70 @@
+// 2026-05-30 P4 debrief wire — Engine LIVE / Surface DEAD fix.
+//
+// phaseCoordinator.js reads `bridge.lastDebrief` and routes it to the debrief
+// panel P4 setters, but nothing in apps/play ever WROTE `bridge.lastDebrief`,
+// so the backend debrief (ennea_voices / inner_voices / conviction_badges /
+// ennea archetypes / narrative_event / mating_eligibles) stayed hidden in real
+// play. This module owns the two pure halves of the wire so they stay unit
+// testable — phaseCoordinator.js imports CSS and cannot load under node:test.
+//
+//   - pipeDebriefToPanel: route a debrief payload to the panel setters
+//   - cacheDebriefOnBridge: write bridge.lastDebrief from a WS / response payload
+//
+// Payload shape = rewardEconomy.buildDebriefSummary() (the /api/session/end
+// response.debrief, rebroadcast verbatim as the coop `debrief_payload` WS msg).
+
+/**
+ * Route a debrief payload onto the debrief panel API. Idempotent + fail-safe:
+ * empty / null fields produce empty-state setter calls so the panel hides the
+ * corresponding section instead of showing stale data.
+ *
+ * @param {object} dbApi   debrief panel api (from wireDebriefPanel)
+ * @param {object|null} debriefPayload  buildDebriefSummary output (or null)
+ * @param {string|null} playerId  current actor id (gates per-actor ennea archetypes)
+ */
+export function pipeDebriefToPanel(dbApi, debriefPayload, playerId) {
+  if (!dbApi) return;
+  const p = debriefPayload && typeof debriefPayload === 'object' ? debriefPayload : null;
+
+  // Surface-DEAD #7 — QBN narrative event (null hides the journal card).
+  if (dbApi.setNarrativeEvent) dbApi.setNarrativeEvent(p?.narrative_event || null);
+
+  // Surface-DEAD #4 — mating/lineage eligibles (post-victory pair-bond cards).
+  const matingEligibles = Array.isArray(p?.mating_eligibles) ? p.mating_eligibles : [];
+  if (dbApi.setLineageEligibles) dbApi.setLineageEligibles(matingEligibles);
+
+  // Ennea archetypes manifested for the current player (per-actor → needs id).
+  const enneaArchetypes = playerId
+    ? p?.vc_summary?.per_actor?.[playerId]?.ennea_archetypes || null
+    : null;
+  if (dbApi.setEnneaArchetypes) dbApi.setEnneaArchetypes(enneaArchetypes);
+
+  // TKT-P4-ENNEA-VOICE-FRONTEND — 1 diegetic quote per actor.
+  const enneaVoices = Array.isArray(p?.ennea_voices) ? p.ennea_voices : [];
+  if (dbApi.setEnneaVoices) dbApi.setEnneaVoices(enneaVoices);
+
+  // TKT-P4-DIALOGUE-COLORS — MBTI-tinted inner monologue per actor.
+  const innerVoices = Array.isArray(p?.inner_voices) ? p.inner_voices : [];
+  if (dbApi.setInnerVoices) dbApi.setInnerVoices(innerVoices);
+
+  // TKT-P4-CONVICTION-BADGES — Triangle Strategy conviction badges (null hides).
+  const convictionBadges = p?.mbti_surface?.conviction_badges || null;
+  if (dbApi.setConvictionBadges) dbApi.setConvictionBadges(convictionBadges);
+}
+
+/**
+ * Cache a debrief payload onto the lobby bridge so the phase coordinator can
+ * read it when it switches to the debrief phase. Only writes for real object
+ * payloads — a null/garbage payload never clobbers a previously cached debrief.
+ *
+ * @param {object} bridge  lobby bridge
+ * @param {object|null} debriefPayload
+ * @returns {object|null} the currently cached debrief (after the write)
+ */
+export function cacheDebriefOnBridge(bridge, debriefPayload) {
+  if (!bridge) return null;
+  if (debriefPayload && typeof debriefPayload === 'object') {
+    bridge.lastDebrief = debriefPayload;
+  }
+  return bridge.lastDebrief || null;
+}

--- a/apps/play/src/lobbyBridge.js
+++ b/apps/play/src/lobbyBridge.js
@@ -700,6 +700,12 @@ export function initLobbyBridgeIfPresent({ wsImpl = null } = {}) {
     client.on('debrief_ready_list', (payload) => {
       coordinator.onDebriefReadyList(payload);
     });
+    // 2026-05-30 P4 debrief wire — server rebroadcasts orch.run.debrief as a
+    // `debrief_payload` message. Cache it on the bridge so the debrief panel
+    // populates its P4 surfaces (ennea/inner voices + conviction badges).
+    client.on('debrief_payload', (payload) => {
+      if (coordinator?.onDebriefPayload) coordinator.onDebriefPayload(payload);
+    });
     // M19 — forward world state to coordinator for debrief panel narrative.
     client.on('state', ({ payload }) => {
       if (coordinator?.onWorldState) coordinator.onWorldState(payload);

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -282,13 +282,31 @@ function redraw() {
           .filter((u) => u && u.controlled_by === 'player' && u.hp > 0)
           .map((u) => u.id);
         const xpEarned = outcome === 'victory' ? 10 : 2;
-        api
-          .coopCombatEnd(lobbyBridge.session.code, lobbyBridge.session.token, {
-            outcome,
-            xp_earned: xpEarned,
-            survivors,
-          })
-          .catch((err) => console.warn('[coop] combatEnd', err));
+        // 2026-05-30 P4 debrief wire — fetch the full debrief (ennea/inner
+        // voices + conviction badges + archetypes) NON-destructively (GET keeps
+        // this session alive for the VC block + promotion accept below), then
+        // attach it as debrief_payload so the server rebroadcasts it to every
+        // phone → their debrief panel P4 surfaces finally populate in real play.
+        (async () => {
+          let debriefPayload = null;
+          try {
+            const r = await api.sessionDebrief(state.sid, outcome);
+            if (r?.ok && r.data) debriefPayload = r.data.debrief || null;
+          } catch (err) {
+            console.warn('[coop] debrief fetch', err);
+          }
+          if (debriefPayload) lobbyBridge.lastDebrief = debriefPayload;
+          try {
+            await api.coopCombatEnd(lobbyBridge.session.code, lobbyBridge.session.token, {
+              outcome,
+              xp_earned: xpEarned,
+              survivors,
+              debrief_payload: debriefPayload,
+            });
+          } catch (err) {
+            console.warn('[coop] combatEnd', err);
+          }
+        })();
       }
       showEndgame(
         outcome,

--- a/apps/play/src/network.js
+++ b/apps/play/src/network.js
@@ -50,6 +50,10 @@ const EVENT_TYPES = [
   'world_tally',
   // M19 additions
   'debrief_ready_list',
+  // 2026-05-30 P4 debrief wire — server rebroadcasts orch.run.debrief so phones
+  // can populate the debrief panel P4 surfaces (ennea voices / inner voices /
+  // conviction badges / ennea archetypes). Previously unregistered → dropped.
+  'debrief_payload',
 ];
 
 function resolveDefaultWsImpl() {
@@ -266,6 +270,9 @@ export class LobbyClient {
         return;
       case 'debrief_ready_list':
         this._emit('debrief_ready_list', msg.payload || {});
+        return;
+      case 'debrief_payload':
+        this._emit('debrief_payload', msg.payload || {});
         return;
       case 'room_closed':
         this._emit('room_closed', msg.payload || {});

--- a/apps/play/src/phaseCoordinator.js
+++ b/apps/play/src/phaseCoordinator.js
@@ -10,6 +10,9 @@ import './debriefPanel.css';
 // OD-013 Path B — MBTI dialogue color palette CSS (8 axis classes + tooltip).
 // Co-located con debriefPanel: il narrative log è il primo consumer.
 import './dialogueRender.css';
+// 2026-05-30 P4 debrief wire — pure routing + bridge cache (CSS-free so they
+// stay unit testable). bridge.lastDebrief was read here but never written.
+import { pipeDebriefToPanel, cacheDebriefOnBridge } from './debriefPipe.js';
 
 export function createPhaseCoordinator(bridge) {
   if (!bridge) return null;
@@ -95,44 +98,15 @@ export function createPhaseCoordinator(bridge) {
         } catch {
           /* reward offer optional */
         }
-        // Sprint 10 (Surface-DEAD #7): pipe QBN narrative event quando debrief
-        // payload include narrative_event (rewardEconomy.buildDebriefSummary).
-        // bridge.lastDebrief è una cache del response /api/session/end o del
-        // payload coop debrief broadcast. Fail-safe: setter ignora null.
+        // 2026-05-30 P4 debrief wire — route the cached debrief payload to the
+        // panel P4 setters (narrative event + lineage + ennea archetypes +
+        // ennea voices + inner voices + conviction badges). bridge.lastDebrief
+        // is populated by onDebriefPayload (coop WS `debrief_payload` broadcast)
+        // or the host /session/end capture. Fail-safe: pipe ignores null fields.
         try {
-          const debriefPayload = bridge?.lastDebrief || bridge?.session?.lastDebrief || null;
-          const narrativeEvent = debriefPayload?.narrative_event || null;
-          if (dbApi.setNarrativeEvent) dbApi.setNarrativeEvent(narrativeEvent);
-          // Sprint 12 (Surface-DEAD #4): pipe lineage eligibles dal debrief.
-          // mating_eligibles è array di pair-bond candidates (post-victory).
-          const matingEligibles = Array.isArray(debriefPayload?.mating_eligibles)
-            ? debriefPayload.mating_eligibles
-            : [];
-          if (dbApi.setLineageEligibles) dbApi.setLineageEligibles(matingEligibles);
-          // Sprint Surface-DEAD ennea: pipe ennea_archetypes per current player
-          // dal debriefPayload.vc_summary.per_actor[playerId].
           const playerId = bridge?.session?.player_id || bridge?.session?.actor_id || null;
-          const enneaArchetypes = playerId
-            ? debriefPayload?.vc_summary?.per_actor?.[playerId]?.ennea_archetypes
-            : null;
-          if (dbApi.setEnneaArchetypes) dbApi.setEnneaArchetypes(enneaArchetypes);
-          // 2026-05-06 TKT-P4-ENNEA-VOICE-FRONTEND: pipe 9/9 voice palette
-          // dal debriefPayload.ennea_voices (rewardEconomy.buildDebriefSummary
-          // emit array of {actor_id, archetype_id, beat_id, line_id, text}).
-          const enneaVoices = Array.isArray(debriefPayload?.ennea_voices)
-            ? debriefPayload.ennea_voices
-            : [];
-          if (dbApi.setEnneaVoices) dbApi.setEnneaVoices(enneaVoices);
-          // 2026-05-30 TKT-P4-DIALOGUE-COLORS: pipe inner voice monologue
-          // dal debriefPayload.inner_voices (rewardEconomy.buildDebriefSummary).
-          const innerVoices = Array.isArray(debriefPayload?.inner_voices)
-            ? debriefPayload.inner_voices
-            : [];
-          if (dbApi.setInnerVoices) dbApi.setInnerVoices(innerVoices);
-          // 2026-05-30 TKT-P4-CONVICTION-BADGES: pipe conviction badges map
-          // dal debriefPayload.mbti_surface.conviction_badges (Triangle Strategy).
-          const convictionBadges = debriefPayload?.mbti_surface?.conviction_badges || null;
-          if (dbApi.setConvictionBadges) dbApi.setConvictionBadges(convictionBadges);
+          const debriefPayload = bridge?.lastDebrief || bridge?.session?.lastDebrief || null;
+          pipeDebriefToPanel(dbApi, debriefPayload, playerId);
         } catch {
           /* narrative event + lineage + ennea + voices + conviction optional */
         }
@@ -209,11 +183,29 @@ export function createPhaseCoordinator(bridge) {
     }
   }
 
+  // 2026-05-30 P4 debrief wire — coop `debrief_payload` WS broadcast handler.
+  // Caches the payload onto the bridge so applyPhase('debrief') can read it, and
+  // re-pipes immediately when it arrives after the phase already switched
+  // (debrief_payload and phase_change have no guaranteed ordering).
+  function onDebriefPayload(payload) {
+    cacheDebriefOnBridge(bridge, payload);
+    if (state.currentPhase === 'debrief') {
+      const playerId = bridge?.session?.player_id || bridge?.session?.actor_id || null;
+      const dbApi = ensureDebrief();
+      try {
+        pipeDebriefToPanel(dbApi, bridge?.lastDebrief || payload, playerId);
+      } catch {
+        /* debrief surfaces optional */
+      }
+    }
+  }
+
   return {
     applyPhase,
     onCharacterReadyList,
     onWorldTally,
     onDebriefReadyList,
+    onDebriefPayload,
     onPhaseChange,
     onPlayersChanged,
     onWorldState,

--- a/tests/api/sessionDebriefRoute.test.js
+++ b/tests/api/sessionDebriefRoute.test.js
@@ -1,0 +1,85 @@
+// 2026-05-30 P4 debrief wire — GET /api/session/:id/debrief.
+//
+// Non-destructive sibling of POST /api/session/end: returns the same
+// buildDebriefSummary payload (ennea_voices / inner_voices / conviction_badges
+// / ennea archetypes / narrative_event / mating_eligibles) WITHOUT deleting the
+// session. A coop host fetches it to attach `debrief_payload` to /coop/combat/end
+// while keeping its own session alive for the VC block + promotion accept.
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+
+async function startSession(app) {
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  assert.equal(scenario.status, 200);
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units });
+  assert.equal(startRes.status, 200);
+  return startRes.body.session_id;
+}
+
+test('GET /session/:id/debrief returns a debrief summary object', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const sid = await startSession(app);
+  const res = await request(app).get(`/api/session/${sid}/debrief`);
+
+  assert.equal(res.status, 200);
+  assert.ok('debrief' in res.body, 'response carries a debrief key');
+  if (res.body.debrief !== null) {
+    assert.equal(typeof res.body.debrief, 'object', 'debrief is an object (or null)');
+  }
+});
+
+test('GET /session/:id/debrief is NON-destructive — session survives', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const sid = await startSession(app);
+
+  const first = await request(app).get(`/api/session/${sid}/debrief`);
+  assert.equal(first.status, 200);
+
+  // The whole point: the session must still resolve afterward, so the host's
+  // VC block + promotion-accept buttons keep working. A destructive /end would
+  // have deleted it → these would 404.
+  const vc = await request(app).get(`/api/session/${sid}/vc`);
+  assert.equal(vc.status, 200, 'session still alive after debrief fetch (VC resolves)');
+
+  const second = await request(app).get(`/api/session/${sid}/debrief`);
+  assert.equal(second.status, 200, 'debrief fetch is idempotent');
+});
+
+test('GET /session/:id/debrief echoes the ?outcome gate', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const sid = await startSession(app);
+  const res = await request(app).get(`/api/session/${sid}/debrief?outcome=victory`);
+
+  assert.equal(res.status, 200);
+  assert.equal(res.body.outcome, 'victory');
+});
+
+test('GET /session/:id/debrief on an unknown session → 404', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const res = await request(app).get('/api/session/does-not-exist/debrief');
+  assert.equal(res.status, 404);
+});

--- a/tests/play/debriefPayloadWire.test.js
+++ b/tests/play/debriefPayloadWire.test.js
@@ -89,6 +89,34 @@ describe('pipeDebriefToPanel — routes debrief payload to the panel setters', (
     assert.deepEqual(panel.calls.setInnerVoices, FULL_PAYLOAD.inner_voices);
   });
 
+  test('per-actor key resolves the coop unit id pg_<playerId> (Codex P2)', async () => {
+    const { pipeDebriefToPanel } = await loadPipe();
+    const panel = makeSpyPanel();
+    // coop: buildDebriefSummary keys vc_summary.per_actor by the UNIT id
+    // `pg_${player_id}` (characterToUnit), but the phone bridge only knows the
+    // raw player_id — the lookup must fall back to the pg_ form or it hides.
+    const payload = {
+      vc_summary: { per_actor: { pg_p_a: { ennea_archetypes: ['Cacciatore(8)'] } } },
+    };
+    pipeDebriefToPanel(panel, payload, 'p_a');
+    assert.deepEqual(panel.calls.setEnneaArchetypes, ['Cacciatore(8)']);
+  });
+
+  test('per-actor key prefers an exact playerId match over the pg_ fallback', async () => {
+    const { pipeDebriefToPanel } = await loadPipe();
+    const panel = makeSpyPanel();
+    const payload = {
+      vc_summary: {
+        per_actor: {
+          p_a: { ennea_archetypes: ['Exact(1)'] },
+          pg_p_a: { ennea_archetypes: ['Fallback(2)'] },
+        },
+      },
+    };
+    pipeDebriefToPanel(panel, payload, 'p_a');
+    assert.deepEqual(panel.calls.setEnneaArchetypes, ['Exact(1)']);
+  });
+
   test('non-array voice fields are coerced to [] (defensive against bad shapes)', async () => {
     const { pipeDebriefToPanel } = await loadPipe();
     const panel = makeSpyPanel();

--- a/tests/play/debriefPayloadWire.test.js
+++ b/tests/play/debriefPayloadWire.test.js
@@ -1,0 +1,171 @@
+// 2026-05-30 P4 debrief wire — Engine LIVE / Surface DEAD fix.
+//
+// phaseCoordinator reads `bridge.lastDebrief` and pipes it to the debrief
+// panel P4 setters, but NOTHING ever wrote `bridge.lastDebrief` — so the
+// backend debrief (ennea_voices / inner_voices / conviction_badges / ennea
+// archetypes) stayed hidden in real play. These tests pin the receive wire:
+//   - debriefPipe.pipeDebriefToPanel routes a payload to the panel setters
+//   - debriefPipe.cacheDebriefOnBridge writes bridge.lastDebrief
+//   - network LobbyClient surfaces the `debrief_payload` WS broadcast
+//
+// All pure / fake-node — phaseCoordinator.js itself imports CSS so it cannot
+// be loaded under node:test; the routing lives in CSS-free debriefPipe.js.
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+async function loadPipe() {
+  return import('../../apps/play/src/debriefPipe.js');
+}
+async function loadNetwork() {
+  return import('../../apps/play/src/network.js');
+}
+
+function makeSpyPanel() {
+  const calls = {};
+  const rec = (name) => (arg) => {
+    calls[name] = arg;
+  };
+  return {
+    calls,
+    setNarrativeEvent: rec('setNarrativeEvent'),
+    setLineageEligibles: rec('setLineageEligibles'),
+    setEnneaArchetypes: rec('setEnneaArchetypes'),
+    setEnneaVoices: rec('setEnneaVoices'),
+    setInnerVoices: rec('setInnerVoices'),
+    setConvictionBadges: rec('setConvictionBadges'),
+  };
+}
+
+const FULL_PAYLOAD = {
+  narrative_event: { id: 'ev1', title_it: 'Eco del combattimento' },
+  mating_eligibles: [{ pair: ['p_a', 'p_b'] }],
+  ennea_voices: [{ actor_id: 'p_a', archetype_id: 'Architetto(5)', text: 'Modello validato.' }],
+  inner_voices: [{ actor_id: 'p_a', voice_id: 'v1', mbti_pole: 'N', text: 'Vedo lo schema.' }],
+  mbti_surface: { conviction_badges: { p_a: [{ id: 'utility', label: 'Utilità' }] } },
+  vc_summary: { per_actor: { p_a: { ennea_archetypes: ['Architetto(5)'] } } },
+};
+
+describe('pipeDebriefToPanel — routes debrief payload to the panel setters', () => {
+  test('full payload → every P4 setter receives its slice', async () => {
+    const { pipeDebriefToPanel } = await loadPipe();
+    const panel = makeSpyPanel();
+
+    pipeDebriefToPanel(panel, FULL_PAYLOAD, 'p_a');
+
+    assert.deepEqual(panel.calls.setNarrativeEvent, FULL_PAYLOAD.narrative_event);
+    assert.deepEqual(panel.calls.setLineageEligibles, FULL_PAYLOAD.mating_eligibles);
+    assert.deepEqual(panel.calls.setEnneaArchetypes, ['Architetto(5)']);
+    assert.deepEqual(panel.calls.setEnneaVoices, FULL_PAYLOAD.ennea_voices);
+    assert.deepEqual(panel.calls.setInnerVoices, FULL_PAYLOAD.inner_voices);
+    assert.deepEqual(panel.calls.setConvictionBadges, FULL_PAYLOAD.mbti_surface.conviction_badges);
+  });
+
+  test('null payload → setters get empty/null so the panel hides each section', async () => {
+    const { pipeDebriefToPanel } = await loadPipe();
+    const panel = makeSpyPanel();
+
+    pipeDebriefToPanel(panel, null, 'p_a');
+
+    assert.equal(panel.calls.setNarrativeEvent, null);
+    assert.deepEqual(panel.calls.setLineageEligibles, []);
+    assert.equal(panel.calls.setEnneaArchetypes, null);
+    assert.deepEqual(panel.calls.setEnneaVoices, []);
+    assert.deepEqual(panel.calls.setInnerVoices, []);
+    assert.equal(panel.calls.setConvictionBadges, null);
+  });
+
+  test('missing playerId → ennea archetypes null (cannot resolve per-actor)', async () => {
+    const { pipeDebriefToPanel } = await loadPipe();
+    const panel = makeSpyPanel();
+
+    pipeDebriefToPanel(panel, FULL_PAYLOAD, null);
+
+    assert.equal(panel.calls.setEnneaArchetypes, null);
+    // non-per-actor voices still flow regardless of playerId
+    assert.deepEqual(panel.calls.setEnneaVoices, FULL_PAYLOAD.ennea_voices);
+    assert.deepEqual(panel.calls.setInnerVoices, FULL_PAYLOAD.inner_voices);
+  });
+
+  test('non-array voice fields are coerced to [] (defensive against bad shapes)', async () => {
+    const { pipeDebriefToPanel } = await loadPipe();
+    const panel = makeSpyPanel();
+
+    pipeDebriefToPanel(panel, { ennea_voices: 'nope', inner_voices: { bad: 1 } }, 'p_a');
+
+    assert.deepEqual(panel.calls.setEnneaVoices, []);
+    assert.deepEqual(panel.calls.setInnerVoices, []);
+  });
+
+  test('panel missing setters → no throw (forward-compat with older panels)', async () => {
+    const { pipeDebriefToPanel } = await loadPipe();
+    assert.doesNotThrow(() => pipeDebriefToPanel({}, FULL_PAYLOAD, 'p_a'));
+    assert.doesNotThrow(() => pipeDebriefToPanel(null, FULL_PAYLOAD, 'p_a'));
+  });
+});
+
+describe('cacheDebriefOnBridge — writes bridge.lastDebrief (the missing wire)', () => {
+  test('object payload → cached onto bridge.lastDebrief', async () => {
+    const { cacheDebriefOnBridge } = await loadPipe();
+    const bridge = { session: { player_id: 'p_a' } };
+
+    const cached = cacheDebriefOnBridge(bridge, FULL_PAYLOAD);
+
+    assert.equal(bridge.lastDebrief, FULL_PAYLOAD);
+    assert.equal(cached, FULL_PAYLOAD);
+  });
+
+  test('null payload → does NOT clobber an existing cache', async () => {
+    const { cacheDebriefOnBridge } = await loadPipe();
+    const prior = { keep: 1 };
+    const bridge = { session: {}, lastDebrief: prior };
+
+    cacheDebriefOnBridge(bridge, null);
+
+    assert.equal(bridge.lastDebrief, prior);
+  });
+
+  test('null bridge → no throw', async () => {
+    const { cacheDebriefOnBridge } = await loadPipe();
+    assert.doesNotThrow(() => cacheDebriefOnBridge(null, FULL_PAYLOAD));
+  });
+});
+
+describe('network LobbyClient — surfaces the debrief_payload WS broadcast', () => {
+  function makeClient(LobbyClient) {
+    return new LobbyClient({ code: 'AAAA', playerId: 'p_a', token: 'tok' });
+  }
+
+  test('debrief_payload message → emits debrief_payload with its payload', async () => {
+    const { LobbyClient } = await loadNetwork();
+    const cli = makeClient(LobbyClient);
+    let got = null;
+    let errored = false;
+    cli.on('debrief_payload', (p) => {
+      got = p;
+    });
+    cli.on('error', () => {
+      errored = true;
+    });
+
+    cli._onMessage({ data: JSON.stringify({ type: 'debrief_payload', payload: FULL_PAYLOAD }) });
+
+    assert.deepEqual(got, FULL_PAYLOAD);
+    assert.equal(errored, false, 'must not fall through to unknown_inbound_type');
+  });
+
+  test('debrief_payload with no payload → emits {} (never undefined)', async () => {
+    const { LobbyClient } = await loadNetwork();
+    const cli = makeClient(LobbyClient);
+    let got = 'unset';
+    cli.on('debrief_payload', (p) => {
+      got = p;
+    });
+
+    cli._onMessage({ data: JSON.stringify({ type: 'debrief_payload' }) });
+
+    assert.deepEqual(got, {});
+  });
+});


### PR DESCRIPTION
## Problem — Engine LIVE / Surface DEAD

`apps/play/src/phaseCoordinator.js` read `bridge.lastDebrief` and routed it to the debrief panel P4 setters (`setEnneaVoices` / `setInnerVoices` / `setConvictionBadges` / `setEnneaArchetypes` / `setNarrativeEvent` / `setLineageEligibles`), but **nothing in `apps/play` ever wrote `bridge.lastDebrief`**. So every P4 personality surface — ennea archetypes (2026-05-06), inner voices + conviction badges ([#2461](https://github.com/MasterDD-L34D/Game/pull/2461)) — rendered empty in real play even though the backend computed them correctly.

The backend already broadcasts a `debrief_payload` WS message (`coop.js` / `wsSession.js`) when `orch.run.debrief` is set, but the play frontend never registered that event and the host never sent it.

## Fix (frontend + a small non-destructive backend read)

**Receive wire (phones):**
- `network.js` — register the `debrief_payload` WS event (was dropped as `unknown_inbound_type`).
- `lobbyBridge.js` — forward it to `coordinator.onDebriefPayload`.
- `phaseCoordinator.js` — new `onDebriefPayload` caches the payload onto `bridge.lastDebrief` and re-pipes if the debrief phase already opened (no ordering assumption between `phase_change` and `debrief_payload`). The routing + cache were extracted to a **CSS-free `debriefPipe.js`** so they are unit-testable (`phaseCoordinator.js` imports CSS and can't load under `node:test`).

**Host send:**
- `GET /api/session/:id/debrief` — non-destructive sibling of `POST /end`: same `buildDebriefSummary` payload, but it does **not** delete the session, so the host keeps its VC block + promotion-accept alive. Uses a shallow `{...session, outcome}` clone — the live session is never mutated.
- `api.js` — `sessionDebrief(sid, outcome)` helper.
- `main.js` — the coop host fetches the debrief non-destructively at endgame and attaches `debrief_payload` to `/coop/combat/end`; the server rebroadcasts it to every phone.

### Why a backend GET (vs the existing `POST /end`)
The only source of the full voice payload is `buildDebriefSummary`, exposed solely via `POST /end`, which **deletes the session** (`sessions.delete`). The host needs the session alive afterward for `api.vc` (VC block, P1) and `renderPromotionPanel`'s accept buttons (`api.promotionAccept`, P3). A destructive call would have regressed both. Approach chosen with the repo owner (non-destructive read endpoint).

## Tests
- `tests/play/debriefPayloadWire.test.js` — `pipeDebriefToPanel` routes every slice to the panel setters; `cacheDebriefOnBridge` writes `bridge.lastDebrief`; `LobbyClient` surfaces the `debrief_payload` WS message.
- `tests/api/sessionDebriefRoute.test.js` — route returns the debrief, is **non-destructive** (session still resolves for VC after the fetch), honors `?outcome`, 404s unknown sessions.
- `node --test` green on touched files; full `tests/play` **330/330**; coop debrief-broadcast + `sessionEndResponse` regression green. Prettier clean.

## Rollback
Revert this commit. No schema/migration/contract changes; no new deps. The new GET route is additive (back-compat); the WS event + host send are additive (omitting `debrief_payload` keeps the prior behavior — panel hidden).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
