### PR TITLE
test(play): e2e proof debrief_payload reaches the phone over a real socket

### DIFF
--- a/tests/e2e/lobbyEndToEnd.test.mjs
+++ b/tests/e2e/lobbyEndToEnd.test.mjs
@@ -586,3 +586,51 @@ test('e2e: LobbyClient auth failure rejects with connect() promise reject', asyn
     await wsHandle.close();
   }
 });
+
+// ---------------------------------------------------------------------------
+// 2026-05-30 P4 debrief wire — debrief_payload broadcast reaches the phone.
+// Proves the receive half end-to-end over a REAL socket (the unit test drives
+// LobbyClient._onMessage directly): server room.broadcast → client WS frame →
+// LobbyClient dispatch → 'debrief_payload' event carrying the buildDebriefSummary
+// payload (which the phase coordinator then routes to the debrief panel setters).
+// ---------------------------------------------------------------------------
+
+test('e2e: debrief_payload broadcast reaches a connected LobbyClient with its payload', async () => {
+  const { lobby, wsHandle, wsUrl } = await spinUp();
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Phone1' });
+    const c1 = openClient({
+      wsUrl,
+      code: room.code,
+      playerId: p1.player_id,
+      token: p1.player_token,
+      role: 'player',
+    });
+    await c1.connect();
+
+    const uid = `pg_${p1.player_id}`; // coop unit id (characterToUnit) — per-actor key
+    const debrief = {
+      ennea_voices: [{ actor_id: uid, archetype_id: 'Architetto(5)', text: 'Modello validato.' }],
+      inner_voices: [{ actor_id: uid, mbti_pole: 'N', text: 'Vedo lo schema.' }],
+      mbti_surface: { conviction_badges: { [uid]: [{ id: 'utility', label: 'Utilità' }] } },
+      vc_summary: { per_actor: { [uid]: { ennea_archetypes: ['Architetto(5)'] } } },
+    };
+
+    const gotDebrief = new Promise((resolve) => c1.once('debrief_payload', resolve));
+    let errored = false;
+    c1.on('error', () => {
+      errored = true;
+    });
+
+    lobby.getRoom(room.code).broadcast({ type: 'debrief_payload', payload: debrief });
+    const received = await gotDebrief;
+
+    assert.deepEqual(received, debrief);
+    assert.equal(errored, false, 'debrief_payload must not surface as an unknown-type error');
+
+    c1.close();
+  } finally {
+    await wsHandle.close();
+  }
+});


### PR DESCRIPTION
## Follow-up to #2465 (merged)

[#2465](https://github.com/MasterDD-L34D/Game/pull/2465) wired the P4 debrief payload into the debrief panel. Its unit test drives `LobbyClient._onMessage` directly — it never exercises the actual WebSocket frame path.

This adds one e2e test (on the existing `tests/e2e/lobbyEndToEnd.test.mjs` harness: real `LobbyService` + WS server + real `LobbyClient`) that drives an **actual `debrief_payload` WS frame** — `room.broadcast({type:'debrief_payload', payload})` → client socket → `LobbyClient` dispatch → `debrief_payload` event — and asserts the full `buildDebriefSummary`-shaped payload arrives intact (and does **not** fall through to an `unknown_inbound_type` error).

Closes the Surface-DEAD gap (Gate 5) for the P4 debrief panel at the integration layer.

## Tests
- `node --test tests/e2e/lobbyEndToEnd.test.mjs` → **12/12** (new test green against current `main`).
- Test-only, additive. No runtime change, no new deps.

## Rollback
Revert this commit. Pure test addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
