### PR TITLE
feat(worldgen): badlands pilot scenario, adapter-driven enemies (phase 2a)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -322,8 +322,10 @@ function createSessionRouter(options = {}) {
     }
   }
 
-  // Pattern matcher per tutorial scenario IDs (funnel analysis input).
-  const TUTORIAL_SCENARIO_RE = /^enc_tutorial_\d+/;
+  // Pattern matcher per tutorial + badlands-pilot scenario IDs (SG-init + funnel
+  // telemetry). enc_badlands_pilot_01 (adapter pilot) gets the same SG=1 onboard
+  // treatment as the hardcore scenarios so its calibration is comparable.
+  const TUTORIAL_SCENARIO_RE = /^enc_(tutorial|badlands_pilot)_\d+/;
   function isTutorialScenario(scenarioId) {
     return typeof scenarioId === 'string' && TUTORIAL_SCENARIO_RE.test(scenarioId);
   }

--- a/apps/backend/routes/tutorial.js
+++ b/apps/backend/routes/tutorial.js
@@ -31,6 +31,10 @@ const {
   buildHardcoreUnits07,
 } = require('../services/hardcoreScenario');
 const { selectBriefing } = require('../services/narrative/briefingVariations');
+const {
+  BADLANDS_SCENARIO_01,
+  buildBadlandsUnits01,
+} = require('../services/worldgen/badlandsPilotScenario');
 
 // Optional briefing variation: when ?variant_seed=N is passed, swap the
 // hardcoded briefing_pre/post with a YAML-pack variant (tutorial_briefings.yaml).
@@ -146,6 +150,15 @@ function createTutorialRouter() {
     });
   });
 
+  router.get('/enc_badlands_pilot_01', (_req, res) => {
+    res.json({
+      ...BADLANDS_SCENARIO_01,
+      units: buildBadlandsUnits01(),
+      usage:
+        'POST units + modulation="quartet". Pilota adapter ecologia->combat (enemies = deriveCombatStats da specie badlands reali). Band calibration phase 2b.',
+    });
+  });
+
   router.get('/', (_req, res) => {
     res.json({
       scenarios: [
@@ -190,6 +203,12 @@ function createTutorialRouter() {
           name: HARDCORE_SCENARIO_06_QUARTET.name,
           difficulty: HARDCORE_SCENARIO_06_QUARTET.difficulty_rating,
           href: `/api/tutorial/${HARDCORE_SCENARIO_06_QUARTET.id}`,
+        },
+        {
+          id: BADLANDS_SCENARIO_01.id,
+          name: BADLANDS_SCENARIO_01.name,
+          difficulty: BADLANDS_SCENARIO_01.difficulty_rating,
+          href: `/api/tutorial/${BADLANDS_SCENARIO_01.id}`,
         },
       ],
     });

--- a/apps/backend/services/worldgen/badlandsPilotScenario.js
+++ b/apps/backend/services/worldgen/badlandsPilotScenario.js
@@ -1,0 +1,206 @@
+// TKT-ADAPTER-ECO-COMBAT phase 2a (spec #2457) -- badlands pilot scenario.
+//
+// enc_badlands_pilot_01: a NEW badlands encounter whose ENEMIES are populated by
+// ecologyCombatAdapter.deriveCombatStats() from REAL badlands species YAML. This is
+// the vertical-slice proof that the adapter turns ecology data into battle-ready
+// combat units. Players are authored (a fixed quartet) -- only enemies are derived.
+//
+// NOT hardcore_06/07: this is a fresh scenario with its OWN (provisional) band, so it
+// never touches the ratified hardcore bands (census anti-pattern 5).
+//
+// Band calibration = phase 2b: encounter_class is 'standard' (provisional) until the
+// N=40 calibrate_parallel pass tunes the adapter knobs + sets the real class/band.
+// The enemy stats here are the UNTUNED adapter baseline (deliberately weak); 2b raises
+// the knobs to hit a target band. `calibration_status: 'pending'` flags this.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const { deriveCombatStats } = require('./ecologyCombatAdapter');
+
+const SPECIES_DIR = path.join(
+  process.cwd(),
+  'packs',
+  'evo_tactics_pack',
+  'data',
+  'species',
+  'badlands',
+);
+
+// The pilot enemy roster -- all 5 are in data/ecosystems/badlands.ecosystem.yaml
+// (GAP-A: the foodweb accepts them, no all_excluded_fallback). Diverse role_class:
+// APEX / HAZARD / PREDATOR / PREY / SUPPORT.
+const BADLANDS_ENEMY_IDS = [
+  'dune-stalker', // T3 predatore_terziario_apex -> APEX
+  'nano-rust-bloom', // T3 minaccia_microbica -> HAZARD
+  'ferrocolonia-magnetotattica', // T2 predatore_regolatore_simbionte -> PREDATOR
+  'sand-burrower', // T1 erbivoro_primario -> PREY
+  'rust-scavenger', // T1 ingegneri_ecosistema -> SUPPORT
+];
+
+const _speciesCache = Object.create(null);
+
+/**
+ * Load a badlands species YAML and NORMALIZE it to the adapter's input contract.
+ * The YAML nests threat_tier under `balance:` (not top-level), so we lift it.
+ * @param {string} id species id (== filename without .yaml)
+ * @returns {{id, threat_tier, role_trofico, genetic_traits, jobs_bias, morphotype}}
+ */
+function loadBadlandsSpecies(id) {
+  if (_speciesCache[id]) return _speciesCache[id];
+  const fpath = path.join(SPECIES_DIR, `${id}.yaml`);
+  const parsed = yaml.load(fs.readFileSync(fpath, 'utf8')) || {};
+  const norm = {
+    id: parsed.id || id,
+    threat_tier: (parsed.balance && parsed.balance.threat_tier) || parsed.threat_tier || null,
+    role_trofico: parsed.role_trofico || null,
+    genetic_traits:
+      parsed.genetic_traits && Array.isArray(parsed.genetic_traits.core)
+        ? parsed.genetic_traits
+        : { core: [] },
+    jobs_bias: Array.isArray(parsed.jobs_bias) ? parsed.jobs_bias : [],
+    morphotype: parsed.morphotype || null,
+  };
+  _speciesCache[id] = norm;
+  return norm;
+}
+
+/** Reset species cache (per test / reload). */
+function _resetCache() {
+  for (const k of Object.keys(_speciesCache)) delete _speciesCache[k];
+}
+
+const BADLANDS_SCENARIO_01 = {
+  id: 'enc_badlands_pilot_01',
+  name: 'Brulle Ferrose -- Pilota Adapter',
+  biome_id: 'badlands',
+  encounter_class: 'standard', // provisional; phase 2b calibration sets tuned class/band
+  difficulty_rating: 5,
+  estimated_turns: 14,
+  grid_size: 10,
+  objective: { type: 'elimination' },
+  objective_text: 'Elimina la fauna ostile delle Brulle Ferrose.',
+  sistema_pressure_start: 70,
+  recommended_modulation: 'quartet',
+  calibration_status: 'pending', // phase 2b N=40 (calibrate_parallel)
+};
+
+function _player(id, job, position, stats) {
+  return {
+    id,
+    species: 'player',
+    job,
+    controlled_by: 'player',
+    ai_profile: 'player',
+    hp: stats.hp,
+    max_hp: stats.hp,
+    ap: stats.ap,
+    mod: stats.mod,
+    dc: stats.dc,
+    guardia: stats.guardia,
+    attack_range: stats.attack_range,
+    position,
+    facing: 'E',
+    elevation: 0,
+    traits: [],
+  };
+}
+
+const ENEMY_POSITIONS = [
+  { x: 8, y: 8 },
+  { x: 8, y: 5 },
+  { x: 8, y: 2 },
+  { x: 6, y: 6 },
+  { x: 6, y: 3 },
+];
+
+/**
+ * Build the full roster: authored quartet players + adapter-derived badlands enemies.
+ * @returns {Array<object>} battle-ready units (players first, then enemies)
+ */
+function buildBadlandsUnits01() {
+  const players = [
+    _player(
+      'p_skirmisher',
+      'skirmisher',
+      { x: 1, y: 8 },
+      {
+        hp: 10,
+        ap: 2,
+        mod: 3,
+        dc: 12,
+        guardia: 0,
+        attack_range: 1,
+      },
+    ),
+    _player(
+      'p_ranger',
+      'ranger',
+      { x: 1, y: 6 },
+      {
+        hp: 10,
+        ap: 2,
+        mod: 3,
+        dc: 12,
+        guardia: 0,
+        attack_range: 2,
+      },
+    ),
+    _player(
+      'p_vanguard',
+      'vanguard',
+      { x: 1, y: 4 },
+      {
+        hp: 14,
+        ap: 2,
+        mod: 2,
+        dc: 14,
+        guardia: 1,
+        attack_range: 1,
+      },
+    ),
+    _player(
+      'p_warden',
+      'warden',
+      { x: 1, y: 2 },
+      {
+        hp: 11,
+        ap: 2,
+        mod: 2,
+        dc: 13,
+        guardia: 1,
+        attack_range: 2,
+      },
+    ),
+  ];
+
+  const enemies = BADLANDS_ENEMY_IDS.map((id, i) => {
+    const stats = deriveCombatStats(loadBadlandsSpecies(id));
+    return {
+      ...stats, // hp, ap, mod, dc, guardia, attack_range, traits, job, _adapter
+      id: `e_${id.replace(/-/g, '_')}`,
+      species: id,
+      max_hp: stats.hp,
+      position: ENEMY_POSITIONS[i] || { x: 7, y: 7 },
+      facing: 'W',
+      controlled_by: 'sistema',
+      ai_profile: 'aggressive',
+      elevation: 0,
+      // enemy needs a job for AI bias; fall back when jobs_bias is empty (e.g. rust-scavenger)
+      job: stats.job || 'vanguard',
+    };
+  });
+
+  return [...players, ...enemies];
+}
+
+module.exports = {
+  BADLANDS_SCENARIO_01,
+  BADLANDS_ENEMY_IDS,
+  buildBadlandsUnits01,
+  loadBadlandsSpecies,
+  _resetCache,
+};

--- a/tests/ai/badlandsPilotScenario.test.js
+++ b/tests/ai/badlandsPilotScenario.test.js
@@ -1,0 +1,98 @@
+// TKT-ADAPTER-ECO-COMBAT phase 2a (spec #2457) -- badlands pilot scenario.
+//
+// enc_badlands_pilot_01: NEW badlands encounter whose ENEMIES are populated by
+// ecologyCombatAdapter.deriveCombatStats from REAL loaded badlands species YAML.
+// Proves the adapter end-to-end on real ecology data. Band calibration = phase 2b.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  BADLANDS_SCENARIO_01,
+  buildBadlandsUnits01,
+  loadBadlandsSpecies,
+  BADLANDS_ENEMY_IDS,
+} = require('../../apps/backend/services/worldgen/badlandsPilotScenario');
+const { deriveCombatStats } = require('../../apps/backend/services/worldgen/ecologyCombatAdapter');
+
+test('BADLANDS_SCENARIO_01: id + biome + grid metadata', () => {
+  assert.equal(BADLANDS_SCENARIO_01.id, 'enc_badlands_pilot_01');
+  assert.equal(BADLANDS_SCENARIO_01.biome_id, 'badlands');
+  assert.ok(BADLANDS_SCENARIO_01.encounter_class, 'has encounter_class');
+  assert.ok(Number.isInteger(BADLANDS_SCENARIO_01.grid_size));
+});
+
+test('loadBadlandsSpecies: reads real YAML with adapter input fields', () => {
+  const s = loadBadlandsSpecies('dune-stalker');
+  assert.equal(s.threat_tier, 'T3');
+  assert.equal(s.role_trofico, 'predatore_terziario_apex');
+  assert.ok(Array.isArray(s.genetic_traits.core) && s.genetic_traits.core.length > 0);
+  assert.equal(s.morphotype, 'cursoriale_quadrupede');
+});
+
+test('buildBadlandsUnits01: returns players + enemies', () => {
+  const units = buildBadlandsUnits01();
+  const players = units.filter((u) => u.controlled_by === 'player');
+  const enemies = units.filter((u) => u.controlled_by === 'sistema');
+  assert.ok(players.length >= 4, `>=4 players, got ${players.length}`);
+  assert.ok(enemies.length >= 4, `>=4 enemies, got ${enemies.length}`);
+});
+
+test('buildBadlandsUnits01: enemy stats are ADAPTER-DERIVED from real species', () => {
+  const units = buildBadlandsUnits01();
+  // For every enemy, its core stats must equal deriveCombatStats(loaded species).
+  for (const id of BADLANDS_ENEMY_IDS) {
+    const expected = deriveCombatStats(loadBadlandsSpecies(id));
+    const enemy = units.find((u) => u.controlled_by === 'sistema' && u.species === id);
+    assert.ok(enemy, `enemy for ${id} present`);
+    assert.equal(enemy.hp, expected.hp, `${id} hp`);
+    assert.equal(enemy.mod, expected.mod, `${id} mod`);
+    assert.equal(enemy.dc, expected.dc, `${id} dc`);
+    assert.equal(enemy.guardia, expected.guardia, `${id} guardia`);
+    assert.equal(enemy.attack_range, expected.attack_range, `${id} attack_range`);
+    assert.deepEqual(enemy.traits, expected.traits, `${id} traits passthrough`);
+  }
+});
+
+test('buildBadlandsUnits01: enemies satisfy full battle-ready unit contract', () => {
+  const enemies = buildBadlandsUnits01().filter((u) => u.controlled_by === 'sistema');
+  for (const e of enemies) {
+    for (const f of ['hp', 'max_hp', 'ap', 'mod', 'dc', 'guardia', 'attack_range']) {
+      assert.ok(Number.isInteger(e[f]) && e[f] >= 0, `${e.id}.${f} int>=0 (got ${e[f]})`);
+    }
+    assert.equal(e.max_hp, e.hp, `${e.id} max_hp == hp on spawn`);
+    assert.ok(e.id && e.species, `${e.id} has id + species`);
+    assert.ok(e.position && Number.isInteger(e.position.x) && Number.isInteger(e.position.y));
+    assert.equal(e.controlled_by, 'sistema');
+    assert.ok(e.ai_profile, `${e.id} has ai_profile`);
+    assert.ok(Array.isArray(e.traits));
+  }
+});
+
+test('GAP-A: all enemy species are in the badlands foodweb (no exclusion)', () => {
+  // The 6 full badlands species are all in data/ecosystems/badlands.ecosystem.yaml.
+  const FOODWEB = new Set([
+    'sand-burrower',
+    'rust-scavenger',
+    'ferrocolonia-magnetotattica',
+    'echo-wing',
+    'dune-stalker',
+    'nano-rust-bloom',
+  ]);
+  for (const id of BADLANDS_ENEMY_IDS) {
+    assert.ok(FOODWEB.has(id), `${id} in badlands foodweb (GAP-A)`);
+  }
+});
+
+test('buildBadlandsUnits01: deterministic (no RNG in build)', () => {
+  const a = buildBadlandsUnits01();
+  const b = buildBadlandsUnits01();
+  assert.deepEqual(a, b);
+});
+
+test('BADLANDS_ENEMY_IDS: 4-6 badlands enemies for the pilot', () => {
+  assert.ok(Array.isArray(BADLANDS_ENEMY_IDS));
+  assert.ok(BADLANDS_ENEMY_IDS.length >= 4 && BADLANDS_ENEMY_IDS.length <= 6);
+});


### PR DESCRIPTION
## Cosa

**Phase 2a** della keystone adapter (`TKT-ADAPTER-ECO-COMBAT`, spec #2457): il pilota badlands che usa l'adapter (merged #2460) su specie reali. Prova verticale end-to-end: ecologia -> stat combat.

## Implementazione (TDD red->green, 8 test)

**Nuovo modulo** `apps/backend/services/worldgen/badlandsPilotScenario.js`:
- `enc_badlands_pilot_01` -- NUOVO encounter badlands. Gli **enemies sono adapter-derived**: `deriveCombatStats(loadBadlandsSpecies(id))` per 5 specie reali (dune-stalker T3 APEX, nano-rust-bloom T3 HAZARD, ferrocolonia T2 PREDATOR, sand-burrower T1 PREY, rust-scavenger T1 SUPPORT). Players = quartet autorale.
- `loadBadlandsSpecies` **normalizza** lo YAML reale al contratto adapter (scoperta: `threat_tier` e nested sotto `balance:`, non top-level -> il loader lo lifta).
- **GAP-A verificato**: tutte e 5 le specie sono in `data/ecosystems/badlands.ecosystem.yaml` (foodweb le accetta, no `all_excluded_fallback`).
- **NON hardcore_06/07**: scenario fresco con banda propria -> non tocca le bande ratificate (census anti-pattern 5).

**Wiring**: `tutorial.js` route `GET /enc_badlands_pilot_01` + list entry; `session.js` regex superset `/^enc_(tutorial|badlands_pilot)_\d+/` (badlands ottiene SG-init parity con gli hardcore -> calibrazione comparabile). Regex e superset esatto: tutti gli `enc_tutorial_*` esistenti matchano identico (zero regression).

## QG

- 8 unit test `node:test`: scenario metadata, loader-su-YAML-reale, **enemy stats == deriveCombatStats** (prova integrazione), contratto unit battle-ready, GAP-A, determinismo. **8/8 green.**
- Syntax-check + ASCII-clean (added lines) + regex-superset = zero regression.

## Banda

`encounter_class: 'standard'` **provvisorio**, `calibration_status: 'pending'`. Gli enemy stats sono il **baseline adapter UNTUNED** (volutamente deboli). **Phase 2b** = N=40 `calibrate_parallel` che tuna i knob dell'adapter (HP_BASE/role-mult/...) + setta la classe/banda reale. Questa PR NON claima una banda.

## Phase 2b (follow-up)

damage_curves band entry + `calibrate_parallel.py` SCENARIO_MAP + `batch_calibrate_badlands_pilot_01.py` + run N=40 -> tune knob -> ratify banda.
