### PR TITLE
feat(campaign): N2 roster persist + GET /api/campaign/roster (PR-A)

### DIFF
--- a/apps/backend/prisma/migrations/0016_loosen_party_rosters_fk/migration.sql
+++ b/apps/backend/prisma/migrations/0016_loosen_party_rosters_fk/migration.sql
@@ -1,0 +1,8 @@
+-- N2 roster-display: loosen party_rosters -> run.id is an ephemeral co-op key,
+-- not a Campaign row. Table is EMPTY (no data migration). Mirrors the
+-- SistemaState / CreatureEpigenome loose-campaignId (no-FK) pattern.
+ALTER TABLE "party_rosters" DROP CONSTRAINT "party_rosters_campaign_id_fkey";
+
+-- Compound unique enables (campaignId, unitId) upsert (idempotent resubmit),
+-- the same key shape creatureEpigenomeStore uses.
+CREATE UNIQUE INDEX "party_rosters_campaign_id_unit_id_key" ON "party_rosters"("campaign_id", "unit_id");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -101,7 +101,6 @@ model Campaign {
   createdAt      DateTime       @default(now()) @map("created_at")
   updatedAt      DateTime       @updatedAt @map("updated_at")
   chapters       Chapter[]
-  partyRoster    PartyRoster[]
   saves          SaveSnapshot[]
 
   @@index([playerId])
@@ -128,7 +127,6 @@ model Chapter {
 model PartyRoster {
   id             String   @id @default(uuid())
   campaignId     String   @map("campaign_id")
-  campaign       Campaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
   unitId         String   @map("unit_id") // PG identifier in-encounter
   species        String
   job            String
@@ -141,6 +139,7 @@ model PartyRoster {
   createdAt      DateTime @default(now()) @map("created_at")
   updatedAt      DateTime @updatedAt @map("updated_at")
 
+  @@unique([campaignId, unitId])
   @@index([campaignId])
   @@map("party_rosters")
 }

--- a/apps/backend/routes/campaign.js
+++ b/apps/backend/routes/campaign.js
@@ -736,6 +736,26 @@ function createCampaignRouter(options = {}) {
     }
   });
 
+  // N2 roster-display -- read-only party roster mirror for the Godot v2 Nido
+  // hub. GET /api/campaign/roster?campaign_id=<run.id> -> { roster: [rows] }.
+  // Empty-safe ([] when no rows / stub / no DB); persistence failure is
+  // non-fatal. Reuses the db/prisma singleton already required above.
+  const { createRosterStore } = require('../services/campaign/rosterStore');
+
+  router.get('/campaign/roster', async (req, res) => {
+    try {
+      const campaignId = String(req.query.campaign_id || '').trim();
+      if (!campaignId) {
+        return res.status(400).json({ error: 'campaign_id query param richiesto' });
+      }
+      const store = createRosterStore(_sistemaPrisma);
+      const roster = await store.get(campaignId);
+      return res.json({ roster });
+    } catch (err) {
+      return res.status(500).json({ error: 'persist_read_failed', detail: String(err.message) });
+    }
+  });
+
   return router;
 }
 

--- a/apps/backend/services/campaign/rosterStore.js
+++ b/apps/backend/services/campaign/rosterStore.js
@@ -1,0 +1,89 @@
+// N2 roster-display -- per-run party-roster persistence (campaignId == run.id)
+// -> party_rosters rows. Mirror of creatureEpigenomeStore: DI factory,
+// Prisma-gated, best-effort. When the partyRoster model is absent (in-memory
+// stub / no DATABASE_URL) or a query throws, reads return [] and upsert is a
+// no-op. Persistence failure must NEVER block character submit.
+
+'use strict';
+
+function _parseJsonArray(s) {
+  if (Array.isArray(s)) return s;
+  try {
+    const v = JSON.parse(s == null ? '[]' : String(s));
+    return Array.isArray(v) ? v : [];
+  } catch {
+    return [];
+  }
+}
+
+// charSpec = coopOrchestrator normalized spec (player_id, species_id, job_id,
+// traits, ...). party_rosters has no name column; unit_id is the handle.
+function _specToRow(charSpec) {
+  const s = charSpec || {};
+  return {
+    unitId: s.unit_id || `pg_${s.player_id}`,
+    species: s.species_id || 'unknown',
+    job: s.job_id || 'guerriero',
+    tier: 'base',
+    hpBase: s.hp || s.hp_max || 22,
+    traits: JSON.stringify(Array.isArray(s.traits) ? s.traits : []),
+    acquiredTraits: '[]',
+    xpTotal: 0,
+    level: 1,
+  };
+}
+
+function _toClean(r) {
+  return {
+    unit_id: r.unitId,
+    species: r.species,
+    job: r.job,
+    tier: r.tier,
+    hp_base: r.hpBase,
+    traits: _parseJsonArray(r.traits),
+    acquired_traits: _parseJsonArray(r.acquiredTraits),
+    xp_total: r.xpTotal,
+    level: r.level,
+  };
+}
+
+function createRosterStore(prisma) {
+  const model = prisma && prisma.partyRoster ? prisma.partyRoster : null;
+
+  async function get(campaignId) {
+    if (!model || !campaignId) return [];
+    try {
+      const rows = await model.findMany({ where: { campaignId } });
+      return (rows || []).map(_toClean);
+    } catch {
+      return [];
+    }
+  }
+
+  async function upsert(campaignId, charSpec) {
+    if (!model || !campaignId) return;
+    const row = _specToRow(charSpec);
+    try {
+      await model.upsert({
+        where: { campaignId_unitId: { campaignId, unitId: row.unitId } },
+        update: {
+          species: row.species,
+          job: row.job,
+          tier: row.tier,
+          hpBase: row.hpBase,
+          traits: row.traits,
+          acquiredTraits: row.acquiredTraits,
+          xpTotal: row.xpTotal,
+          level: row.level,
+        },
+        create: { campaignId, ...row },
+      });
+    } catch (err) {
+      console.warn('[rosterStore] upsert failed (best-effort):', err.message);
+    }
+  }
+
+  return { get, upsert };
+}
+
+module.exports = { createRosterStore };

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -7,6 +7,7 @@
 const crypto = require('crypto');
 const { foldObservations } = require('../ai/sistemaStateAccumulator');
 const { createSistemaStateStore } = require('../ai/sistemaStateStore');
+const { createRosterStore } = require('../campaign/rosterStore');
 const { checkNidoUnlock } = require('../../routes/sessionHelpers');
 
 // CAMP-1/CAMP-2 - run.id is the SistemaState persistence key (server writes
@@ -72,6 +73,7 @@ class CoopOrchestrator {
     now = Date.now,
     worldEnricher = null,
     sistemaStateStore = null,
+    rosterStore = null,
     nidoUnlocked = false,
   } = {}) {
     if (!roomCode) throw new Error('room_code_required');
@@ -88,6 +90,10 @@ class CoopOrchestrator {
     // on first use so module-load order / stub-mode (no DATABASE_URL) stays
     // safe. Tests inject a stub recording get/upsert.
     this._sistemaStore = sistemaStateStore;
+    // N2 roster-display -- run-keyed party_rosters persistence (DI seam, same
+    // style as sistemaStateStore). Lazily wires the canonical Prisma store on
+    // first use so module-load order / stub-mode stays safe.
+    this._rosterStore = rosterStore;
     this.phase = 'lobby';
     this.run = null; // populated by startRun()
     this.characters = new Map(); // player_id → character spec
@@ -132,6 +138,13 @@ class CoopOrchestrator {
     // eslint-disable-next-line global-require
     this._sistemaStore = createSistemaStateStore(require('../../db/prisma').prisma);
     return this._sistemaStore;
+  }
+
+  _getRosterStore() {
+    if (this._rosterStore) return this._rosterStore;
+    // eslint-disable-next-line global-require
+    this._rosterStore = createRosterStore(require('../../db/prisma').prisma);
+    return this._rosterStore;
   }
 
   _emit(kind, payload = {}) {
@@ -374,6 +387,15 @@ class CoopOrchestrator {
       submitted_at: this.now(),
     };
     this.characters.set(playerId, normalized);
+    // N2 -- persist the created PG to party_rosters (run.id-keyed), best-effort
+    // and fire-and-forget. Never block / throw into the submit path.
+    if (this.run && this.run.id) {
+      try {
+        this._getRosterStore().upsert(this.run.id, normalized);
+      } catch (_err) {
+        /* best-effort */
+      }
+    }
     this._emit('character_ready', normalized);
 
     const expected = new Set(allPlayerIds.filter(Boolean));

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -388,10 +388,15 @@ class CoopOrchestrator {
     };
     this.characters.set(playerId, normalized);
     // N2 -- persist the created PG to party_rosters (run.id-keyed), best-effort
-    // and fire-and-forget. Never block / throw into the submit path.
+    // and fire-and-forget. Never block / throw into the submit path: the sync
+    // try/catch covers a wiring throw (store construct), and the .catch covers
+    // an async-rejecting upsert (the canonical store swallows internally).
     if (this.run && this.run.id) {
       try {
-        this._getRosterStore().upsert(this.run.id, normalized);
+        const persisting = this._getRosterStore().upsert(this.run.id, normalized);
+        if (persisting && typeof persisting.catch === 'function') {
+          persisting.catch(() => {});
+        }
       } catch (_err) {
         /* best-effort */
       }

--- a/tests/api/campaignRoster.test.js
+++ b/tests/api/campaignRoster.test.js
@@ -1,0 +1,48 @@
+// N2 roster-display -- GET /api/campaign/roster read route. Empty-safe (no DB
+// in CI -> rosterStore returns []); 400 on missing campaign_id.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const http = require('node:http');
+
+const { createCampaignRouter } = require('../../apps/backend/routes/campaign');
+
+function startServer(t) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createCampaignRouter());
+  const server = app.listen(0);
+  t.after(() => server.close());
+  return `http://127.0.0.1:${server.address().port}`;
+}
+
+function get(url) {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url);
+    const req = http.request(
+      { hostname: u.hostname, port: u.port, path: u.pathname + u.search, method: 'GET' },
+      (res) => {
+        let d = '';
+        res.on('data', (c) => (d += c));
+        res.on('end', () => resolve({ status: res.statusCode, body: d ? JSON.parse(d) : null }));
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+test('GET roster returns { roster: [] } for an unknown/fresh campaign', async (t) => {
+  const base = startServer(t);
+  const res = await get(`${base}/api/campaign/roster?campaign_id=run_fresh`);
+  assert.equal(res.status, 200);
+  assert.deepEqual(res.body, { roster: [] });
+});
+
+test('GET roster 400 without campaign_id', async (t) => {
+  const base = startServer(t);
+  const res = await get(`${base}/api/campaign/roster`);
+  assert.equal(res.status, 400);
+});

--- a/tests/api/coopRosterPersist.test.js
+++ b/tests/api/coopRosterPersist.test.js
@@ -1,0 +1,73 @@
+// N2 roster-display -- submitCharacter persists each created PG to the roster
+// store (run.id-keyed), best-effort, via constructor DI.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { CoopOrchestrator } = require('../../apps/backend/services/coop/coopOrchestrator');
+
+function stubStore() {
+  const calls = [];
+  return {
+    calls,
+    async get() {
+      return [];
+    },
+    upsert(campaignId, spec) {
+      calls.push({ campaignId, spec });
+    },
+  };
+}
+
+function freshAtCharCreation(store) {
+  const co = new CoopOrchestrator({ roomCode: 'RSTR', hostId: 'p_h', rosterStore: store });
+  co.startOnboarding({ scenarioStack: ['enc_demo'] });
+  co._setPhase('character_creation');
+  return co;
+}
+
+test('submitCharacter upserts the roster row keyed on run.id', () => {
+  const store = stubStore();
+  const co = freshAtCharCreation(store);
+  co.submitCharacter(
+    'p_h',
+    { name: 'Liev', form_id: 'form_x', species_id: 'umbra', job_id: 'custode' },
+    { allPlayerIds: ['p_h', 'p_a'] }, // 2 players -> stays in character_creation
+  );
+  assert.equal(store.calls.length, 1);
+  assert.equal(store.calls[0].campaignId, co.run.id);
+  assert.equal(store.calls[0].spec.species_id, 'umbra');
+  assert.equal(store.calls[0].spec.player_id, 'p_h');
+});
+
+test('identical resubmit (dedup) does NOT re-persist', () => {
+  const store = stubStore();
+  const co = freshAtCharCreation(store);
+  const spec = { name: 'Liev', form_id: 'form_x', species_id: 'umbra', job_id: 'custode' };
+  co.submitCharacter('p_h', spec, { allPlayerIds: ['p_h', 'p_a'] });
+  co.submitCharacter('p_h', spec, { allPlayerIds: ['p_h', 'p_a'] });
+  assert.equal(store.calls.length, 1); // 2nd is deduped before the hook
+});
+
+test('persist never throws into submit when store.upsert throws', () => {
+  const co = new CoopOrchestrator({
+    roomCode: 'RSTR',
+    hostId: 'p_h',
+    rosterStore: {
+      get: async () => [],
+      upsert() {
+        throw new Error('db down');
+      },
+    },
+  });
+  co.startOnboarding({ scenarioStack: ['enc_demo'] });
+  co._setPhase('character_creation');
+  assert.doesNotThrow(() =>
+    co.submitCharacter(
+      'p_h',
+      { name: 'Liev', form_id: 'form_x', species_id: 'umbra', job_id: 'custode' },
+      { allPlayerIds: ['p_h', 'p_a'] },
+    ),
+  );
+});

--- a/tests/api/coopRosterPersist.test.js
+++ b/tests/api/coopRosterPersist.test.js
@@ -71,3 +71,28 @@ test('persist never throws into submit when store.upsert throws', () => {
     ),
   );
 });
+
+test('persist swallows an async-rejecting store upsert (no unhandled rejection)', async () => {
+  const co = new CoopOrchestrator({
+    roomCode: 'RSTR',
+    hostId: 'p_h',
+    rosterStore: {
+      get: async () => [],
+      async upsert() {
+        throw new Error('async db down');
+      },
+    },
+  });
+  co.startOnboarding({ scenarioStack: ['enc_demo'] });
+  co._setPhase('character_creation');
+  assert.doesNotThrow(() =>
+    co.submitCharacter(
+      'p_h',
+      { name: 'Liev', form_id: 'form_x', species_id: 'umbra', job_id: 'custode' },
+      { allPlayerIds: ['p_h', 'p_a'] },
+    ),
+  );
+  // Let the deferred upsert rejection settle; the hook's .catch must swallow it
+  // (an unguarded rejection would surface as an unhandled rejection here).
+  await new Promise((resolve) => setImmediate(resolve));
+});

--- a/tests/services/rosterStore.test.js
+++ b/tests/services/rosterStore.test.js
@@ -1,0 +1,82 @@
+// N2 roster-display — rosterStore (mirror creatureEpigenomeStore): DI,
+// prisma-gated, best-effort. Run-keyed party_rosters persistence.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createRosterStore } = require('../../apps/backend/services/campaign/rosterStore');
+
+// In-memory fake of the prisma partyRoster delegate (compound-key upsert).
+function fakePrisma() {
+  const rows = [];
+  return {
+    _rows: rows,
+    partyRoster: {
+      async findMany({ where }) {
+        return rows.filter((r) => r.campaignId === where.campaignId);
+      },
+      async upsert({ where, update, create }) {
+        const k = where.campaignId_unitId;
+        const hit = rows.find((r) => r.campaignId === k.campaignId && r.unitId === k.unitId);
+        if (hit) {
+          Object.assign(hit, update);
+          return hit;
+        }
+        const row = { ...create };
+        rows.push(row);
+        return row;
+      },
+    },
+  };
+}
+
+test('upsert then get round-trips a clean snake_case row', async () => {
+  const store = createRosterStore(fakePrisma());
+  await store.upsert('run_1', {
+    player_id: 'p1',
+    species_id: 'umbra_alaris',
+    job_id: 'custode',
+    traits: ['t_a', 't_b'],
+  });
+  const rows = await store.get('run_1');
+  assert.equal(rows.length, 1);
+  assert.deepEqual(rows[0], {
+    unit_id: 'pg_p1',
+    species: 'umbra_alaris',
+    job: 'custode',
+    tier: 'base',
+    hp_base: 22,
+    traits: ['t_a', 't_b'],
+    acquired_traits: [],
+    xp_total: 0,
+    level: 1,
+  });
+});
+
+test('upsert is idempotent on (campaignId, unitId) — updates, no duplicate', async () => {
+  const fp = fakePrisma();
+  const store = createRosterStore(fp);
+  await store.upsert('run_1', { player_id: 'p1', species_id: 'a', job_id: 'guerriero' });
+  await store.upsert('run_1', { player_id: 'p1', species_id: 'b', job_id: 'tessitore' });
+  const rows = await store.get('run_1');
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].species, 'b');
+  assert.equal(rows[0].job, 'tessitore');
+});
+
+test('get is empty-safe: unknown campaign -> []', async () => {
+  const store = createRosterStore(fakePrisma());
+  assert.deepEqual(await store.get('run_none'), []);
+});
+
+test('no-prisma store: get -> [], upsert -> no throw (no-op)', async () => {
+  const store = createRosterStore(null);
+  assert.deepEqual(await store.get('run_1'), []);
+  await store.upsert('run_1', { player_id: 'p1' }); // must not throw
+});
+
+test('get with empty campaignId -> []', async () => {
+  const store = createRosterStore(fakePrisma());
+  assert.deepEqual(await store.get(''), []);
+});


### PR DESCRIPTION
## N2 PR-A — roster persistence + read route (Game/ side)

Foundation for the Godot v2 Nido **party roster display** (N2). Persists each created PG to the (previously empty + unwritten) `party_rosters` table keyed on `run.id`, and exposes a thin read route. **Display-only foundation — no combat / balance change.** The Godot client (PR-B, separate) reads `GET /api/campaign/roster`.

Mirrors the M1 (`#2364`) / N1 (`#2449`) two-repo split. Build + merge this first; the Godot PR consumes the route.

### Changes
- **Migration `0016_loosen_party_rosters_fk`** — drops the Campaign FK (`party_rosters_campaign_id_fkey`) and adds a `(campaign_id, unit_id)` UNIQUE index. `run.id` is an ephemeral co-op key, not a Campaign row. Table is **EMPTY → no data migration**. Mirrors the `SistemaState` / `CreatureEpigenome` loose-`campaignId` (no-FK) precedent.
- **`services/campaign/rosterStore.js`** — clone of `creatureEpigenomeStore` (DI factory, Prisma-gated, best-effort). `get(campaignId)` → snake_case rows; `upsert(campaignId, charSpec)` on the compound `(campaignId, unitId)` key. No-prisma / query-throw → reads `[]`, upsert no-op (never throws).
- **`coopOrchestrator.submitCharacter`** — best-effort, fire-and-forget persist hook (constructor DI like `sistemaStateStore`), keyed on `this.run.id`. Runs after the dedup gate (identical resubmit does not re-persist); a sync wiring throw or an async upsert rejection cannot propagate into submit.
- **`GET /api/campaign/roster?campaign_id=<run.id>`** → `{ roster: [rows] }` — mirrors the sistema-state read route (400 missing / 200 / 500), empty-safe, reuses the `db/prisma` singleton.

### Boundary (intentional, documented in the design spec)
- **Run-keyed** = persists across MISSIONS within a run/session, NOT across separate sessions (ephemeral `run.id`; cross-session needs a stable save identity the co-op flow lacks).
- **Empty in solo** — the Godot solo/TV path fields `TUTORIAL_01_UNITS` and never calls `submitCharacter`; the roster is populated only by a co-op run. Empty-safe is the primary path.
- **Out of scope:** fielding selected members in combat (balance-adjacent, crosses the #371 threshold), cross-session persistence, recruit/offspring sources (N3/N4).

### Tests (`node --test`)
- `tests/services/rosterStore.test.js` (5) — round-trip snake_case, idempotent compound upsert, empty-safe, no-prisma no-op.
- `tests/api/coopRosterPersist.test.js` (4) — persists keyed on run.id, dedup no-repersist, sync-throw + async-reject swallowed.
- `tests/api/campaignRoster.test.js` (2) — 200 `{roster:[]}` + 400 missing.
- Full `npm run test:api` + `npm run lint:stack` green. Fresh-eyes final review: APPROVE_WITH_NITS (the one nit — async-reject guard — fixed in this branch).

Design: `Game-Godot-v2/docs/superpowers/specs/2026-05-30-n2-roster-display-design.md` + plan `…/plans/2026-05-30-n2-roster-display.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
