### PR TITLE
feat(worldgen): D4 apply tool — approved biome_affinity merge (dry-run default)

### DIFF
--- a/tests/test_apply_biome_affinity.py
+++ b/tests/test_apply_biome_affinity.py
@@ -1,0 +1,102 @@
+import sys, os, json
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools", "py"))
+
+import apply_biome_affinity as apply_ba
+
+VALID = {"savana", "palude", "caverna"}
+
+
+def test_select_approved_filters_and_validates():
+    draft = [
+        {"species_id": "a", "suggested_biome": "savana", "approved": True},
+        {"species_id": "b", "suggested_biome": "palude"},  # not approved
+        {"species_id": "c", "suggested_biome": "savana", "approved_biome": "caverna", "approved": True},
+        {"species_id": "d", "suggested_biome": "nonbiome", "approved": True},  # invalid biome
+        {"species_id": "e", "approved": True},  # no biome
+    ]
+    approved, problems = apply_ba.select_approved(draft, VALID)
+    chosen = {c["species_id"]: c["biome"] for c in approved}
+    assert chosen == {"a": "savana", "c": "caverna"}  # c override honored
+    prob_ids = {p[0] for p in problems}
+    assert "d" in prob_ids and "e" in prob_ids
+    assert "b" not in chosen and "b" not in prob_ids  # silently skipped (not approved)
+
+
+def test_plan_changes_skips_existing_and_missing():
+    catalog = [
+        {"species_id": "a"},  # missing biome -> apply
+        {"species_id": "x", "biome_affinity": "savana"},  # already has -> never overwrite
+    ]
+    approved = [
+        {"species_id": "a", "biome": "palude"},
+        {"species_id": "x", "biome": "caverna"},  # skip (existing)
+        {"species_id": "zzz", "biome": "savana"},  # skip (not in catalog)
+    ]
+    to_apply, skipped = apply_ba.plan_changes(catalog, approved)
+    assert [(sp["species_id"], b) for sp, b in to_apply] == [("a", "palude")]
+    assert {s[0] for s in skipped} == {"x", "zzz"}
+
+
+def test_apply_changes_sets_field_and_provenance():
+    sp = {"species_id": "a"}
+    apply_ba.apply_changes([(sp, "savana")])
+    assert sp["biome_affinity"] == "savana"
+    assert sp["_provenance"]["biome_affinity"] == apply_ba.PROV_TAG
+
+
+def test_apply_changes_preserves_existing_provenance():
+    sp = {"species_id": "a", "_provenance": {"visual_description": "claude-polish"}}
+    apply_ba.apply_changes([(sp, "savana")])
+    assert sp["_provenance"]["visual_description"] == "claude-polish"  # untouched
+    assert sp["_provenance"]["biome_affinity"] == apply_ba.PROV_TAG
+
+
+def test_main_dry_run_does_not_write(tmp_path):
+    cat_path = tmp_path / "cat.json"
+    cat_path.write_text(json.dumps({"catalog": [{"species_id": "a"}]}), encoding="utf-8")
+    draft_path = tmp_path / "draft.json"
+    draft_path.write_text(
+        json.dumps({"draft": [{"species_id": "a", "suggested_biome": "savana", "approved": True}]}),
+        encoding="utf-8",
+    )
+    rc = apply_ba.main(["--catalog", str(cat_path), "--draft", str(draft_path)])
+    assert rc == 0
+    after = json.loads(cat_path.read_text(encoding="utf-8"))
+    assert "biome_affinity" not in after["catalog"][0]  # dry-run = no write
+
+
+def test_main_apply_writes_only_approved_missing(tmp_path):
+    cat_path = tmp_path / "cat.json"
+    cat_path.write_text(
+        json.dumps({"catalog": [{"species_id": "a"}, {"species_id": "x", "biome_affinity": "savana"}]}),
+        encoding="utf-8",
+    )
+    draft_path = tmp_path / "draft.json"
+    draft_path.write_text(
+        json.dumps({"draft": [
+            {"species_id": "a", "suggested_biome": "savana", "approved": True},
+            {"species_id": "x", "suggested_biome": "palude", "approved": True},  # existing -> skip
+        ]}),
+        encoding="utf-8",
+    )
+    rc = apply_ba.main(["--catalog", str(cat_path), "--draft", str(draft_path), "--apply"])
+    assert rc == 0
+    after = json.loads(cat_path.read_text(encoding="utf-8"))
+    assert after["catalog"][0]["biome_affinity"] == "savana"
+    assert after["catalog"][0]["_provenance"]["biome_affinity"] == apply_ba.PROV_TAG
+    assert after["catalog"][1]["biome_affinity"] == "savana"  # NOT overwritten to palude
+
+
+def test_main_apply_rejects_invalid_biome_no_write(tmp_path):
+    cat_path = tmp_path / "cat.json"
+    cat_path.write_text(json.dumps({"catalog": [{"species_id": "a"}]}), encoding="utf-8")
+    draft_path = tmp_path / "draft.json"
+    draft_path.write_text(
+        json.dumps({"draft": [{"species_id": "a", "suggested_biome": "not_a_biome", "approved": True}]}),
+        encoding="utf-8",
+    )
+    rc = apply_ba.main(["--catalog", str(cat_path), "--draft", str(draft_path), "--apply"])
+    assert rc == 0
+    after = json.loads(cat_path.read_text(encoding="utf-8"))
+    assert "biome_affinity" not in after["catalog"][0]  # invalid -> nothing applied

--- a/tests/test_apply_biome_affinity.py
+++ b/tests/test_apply_biome_affinity.py
@@ -88,6 +88,20 @@ def test_main_apply_writes_only_approved_missing(tmp_path):
     assert after["catalog"][1]["biome_affinity"] == "savana"  # NOT overwritten to palude
 
 
+def test_load_draft_missing_returns_empty(tmp_path):
+    assert apply_ba.load_draft(tmp_path / "nope.json") == []
+
+
+def test_main_missing_draft_dry_run_safe(tmp_path):
+    cat_path = tmp_path / "cat.json"
+    cat_path.write_text(json.dumps({"catalog": [{"species_id": "a"}]}), encoding="utf-8")
+    # default draft path won't exist here; explicit missing path -> no crash, no write
+    rc = apply_ba.main(["--catalog", str(cat_path), "--draft", str(tmp_path / "nope.json")])
+    assert rc == 0
+    after = json.loads(cat_path.read_text(encoding="utf-8"))
+    assert "biome_affinity" not in after["catalog"][0]
+
+
 def test_main_apply_rejects_invalid_biome_no_write(tmp_path):
     cat_path = tmp_path / "cat.json"
     cat_path.write_text(json.dumps({"catalog": [{"species_id": "a"}]}), encoding="utf-8")

--- a/tools/py/apply_biome_affinity.py
+++ b/tools/py/apply_biome_affinity.py
@@ -1,0 +1,144 @@
+"""apply_biome_affinity.py — merge master-dd-APPROVED biome_affinity suggestions
+from the D4 draft into the canonical species catalog.
+
+Contract (spec docs/superpowers/specs/2026-05-30-d4-biome-affinity-ecoyaml-design.md §4):
+- Writes ONLY `biome_affinity` + `_provenance['biome_affinity']`. Never other fields.
+- DRY-RUN by default; `--apply` required to write the catalog.
+- Idempotent + safe: skips species that already have a `biome_affinity`
+  (never overwrites the 21 editorially-assigned golden entries).
+- Validates the biome against data/core/biomes.yaml (no invented biomes).
+- UTF-8 explicit (CLAUDE.md Encoding Discipline), ensure_ascii=False, indent=2.
+
+Approval input: master-dd reviews the draft and flips `"approved": true` on the
+entries to accept (optionally `"approved_biome": "<id>"` to override the
+suggestion). An entry is applied iff `approved` is truthy; the biome written is
+`approved_biome` if present, else `suggested_biome`.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CATALOG_PATH = REPO_ROOT / "data/core/species/species_catalog.json"
+BIOMES_PATH = REPO_ROOT / "data/core/biomes.yaml"
+DRAFT_PATH = REPO_ROOT / "docs/planning/2026-05-30-biome-affinity-draft.json"
+PROV_TAG = "d4-heuristic-suggest+master-dd-approve"
+
+
+def load_valid_biomes(path: Path = BIOMES_PATH) -> set:
+    with open(path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    return set(data["biomes"].keys())
+
+
+def load_draft(path: Path) -> list:
+    with open(path, encoding="utf-8") as f:
+        d = json.load(f)
+    if isinstance(d, dict):
+        return d.get("draft", [])
+    return d if isinstance(d, list) else []
+
+
+def select_approved(draft: list, valid_biomes: set):
+    """Return (approved_changes, problems). approved_changes = [{species_id, biome}].
+    Only entries with truthy `approved`; biome = approved_biome or suggested_biome;
+    biome must be in valid_biomes. Not-approved entries are silently skipped;
+    approved-but-broken entries (no biome / invalid biome / no id) -> problems."""
+    approved, problems = [], []
+    for e in draft:
+        if not e.get("approved"):
+            continue
+        sid = e.get("species_id")
+        biome = e.get("approved_biome") or e.get("suggested_biome")
+        if not sid:
+            problems.append(("<no species_id>", "approved entry missing species_id"))
+            continue
+        if not biome:
+            problems.append((sid, "approved but no biome (suggested_biome null)"))
+            continue
+        if biome not in valid_biomes:
+            problems.append((sid, f"biome '{biome}' not in biomes.yaml"))
+            continue
+        approved.append({"species_id": sid, "biome": biome})
+    return approved, problems
+
+
+def plan_changes(catalog: list, approved: list):
+    """Match approved changes to catalog species. Skip species already carrying a
+    biome_affinity (idempotent + never overwrite golden) and species not present.
+    Return (to_apply, skipped). to_apply = [(species_obj, biome)]."""
+    by_id = {}
+    for sp in catalog:
+        key = sp.get("species_id") or sp.get("legacy_slug")
+        if key:
+            by_id[key] = sp
+    to_apply, skipped = [], []
+    for ch in approved:
+        sp = by_id.get(ch["species_id"])
+        if sp is None:
+            skipped.append((ch["species_id"], "not in catalog"))
+            continue
+        existing = sp.get("biome_affinity")
+        if isinstance(existing, str) and existing.strip():
+            skipped.append((ch["species_id"], f"already has biome_affinity={existing}"))
+            continue
+        to_apply.append((sp, ch["biome"]))
+    return to_apply, skipped
+
+
+def apply_changes(to_apply: list) -> None:
+    for sp, biome in to_apply:
+        sp["biome_affinity"] = biome
+        prov = sp.setdefault("_provenance", {})
+        if not isinstance(prov, dict):
+            prov = {}
+            sp["_provenance"] = prov
+        prov["biome_affinity"] = PROV_TAG
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Apply approved D4 biome_affinity into the canonical catalog")
+    ap.add_argument("--draft", default=str(DRAFT_PATH))
+    ap.add_argument("--catalog", default=str(CATALOG_PATH))
+    ap.add_argument("--apply", action="store_true", help="write the catalog (default: dry-run)")
+    args = ap.parse_args(argv)
+
+    valid = load_valid_biomes()
+    draft = load_draft(Path(args.draft))
+    approved, problems = select_approved(draft, valid)
+
+    with open(args.catalog, encoding="utf-8") as f:
+        data = json.load(f)
+    catalog = data["catalog"]
+    to_apply, skipped = plan_changes(catalog, approved)
+
+    print(f"[draft] {len(draft)} entries -> {len(approved)} approved+valid, {len(problems)} rejected")
+    for sid, why in problems:
+        print(f"  reject {sid}: {why}")
+    print(f"[plan] {len(to_apply)} to apply, {len(skipped)} skipped")
+    for sid, why in skipped:
+        print(f"  skip {sid}: {why}")
+    for sp, biome in to_apply:
+        print(f"  + {sp.get('species_id')}: biome_affinity={biome}")
+
+    if not args.apply:
+        print("[DRY-RUN] no write. Re-run with --apply to write the catalog.")
+        return 0
+    if not to_apply:
+        print("[apply] nothing to apply.")
+        return 0
+
+    apply_changes(to_apply)
+    with open(args.catalog, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+    print(f"[APPLIED] wrote {len(to_apply)} biome_affinity into {args.catalog}")
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/tools/py/apply_biome_affinity.py
+++ b/tools/py/apply_biome_affinity.py
@@ -35,6 +35,11 @@ def load_valid_biomes(path: Path = BIOMES_PATH) -> set:
 
 
 def load_draft(path: Path) -> list:
+    """Return the draft entries, or [] if the file is absent. The draft is an
+    untracked artifact (docs/planning), so a clean checkout may lack it — treat
+    that as zero approved entries so the dry-run contract still holds."""
+    if not path.exists():
+        return []
     with open(path, encoding="utf-8") as f:
         d = json.load(f)
     if isinstance(d, dict):
@@ -107,7 +112,11 @@ def main(argv=None):
     args = ap.parse_args(argv)
 
     valid = load_valid_biomes()
-    draft = load_draft(Path(args.draft))
+    draft_path = Path(args.draft)
+    if not draft_path.exists():
+        print(f"[draft] not found at {draft_path} -> treating as 0 entries")
+        print("        regenerate via: python tools/py/suggest_biome_affinity.py --gate 0.45")
+    draft = load_draft(draft_path)
     approved, problems = select_approved(draft, valid)
 
     with open(args.catalog, encoding="utf-8") as f:


### PR DESCRIPTION
## D4 apply tool — merge master-dd-approved `biome_affinity` into the catalog

Item 1 of the "1+2" follow-up. Adds `tools/py/apply_biome_affinity.py` (spec §4): applies **only master-dd-approved** D4 suggestions into the canonical catalog. Item 2 (ECO-YAML-GEN) is gated — see below.

### Safety design
- **Dry-run by default.** `--apply` required to write. Against the real catalog with no approvals flagged yet, it does nothing: `[draft] 32 entries -> 0 approved+valid` → `[DRY-RUN] no write` (catalog stays git-clean).
- **Never overwrites the 21 golden.** Skips any species that already has a `biome_affinity` (idempotent).
- **Writes only `biome_affinity` + `_provenance['biome_affinity']`** (tag `d4-heuristic-suggest+master-dd-approve`). No other field touched. UTF-8 explicit, `ensure_ascii=False`.
- **Valid-biome check** against `data/core/biomes.yaml` (no invented biomes); approved-but-invalid entries are rejected, not written.

### Approval workflow (proposed UX — adjust if you prefer a separate approvals file)
1. Review the draft: `docs/planning/2026-05-30-biome-affinity-draft.json` (untracked; regenerate via `python tools/py/suggest_biome_affinity.py --gate 0.45`). Each entry has `suggested_biome` + `confidence` + `reasoning` + `alternatives`.
2. For each accepted entry, set `"approved": true` (optionally `"approved_biome": "<id>"` to override the suggestion).
3. Dry-run: `python tools/py/apply_biome_affinity.py` → review the plan.
4. Write: `python tools/py/apply_biome_affinity.py --apply` → then `git diff` the catalog + run `validate-datasets`.

### Tests
`PYTHONPATH=tools/py python -m pytest tests/test_apply_biome_affinity.py -v` → **7 passed** (select/validate, skip-existing, provenance preserve, dry-run no-write, apply-only-approved, reject-invalid). All on fixtures — never touches the real catalog.

### Item 2 — ECO-YAML-GEN is GATED (not in this PR)
Spec §5/§8 sequence it strictly **after** species carry approved `biome_affinity` (i.e. after you review the draft and `--apply` runs). It also carries a band-safety gate (N=40 re-verify if a generated `ecosystem.yaml` touches a reinforcement scenario; rovine_planari / hardcore_06-07 off-limits per D6). Building it now would be unvalidatable (no approved data) and speculative (YAGNI 1-2 gameplay-touched biomes). It unblocks the moment item 1 has run.

### Reminder
The draft's predictable accuracy is **46.7%** (below the 60% intended bar) — that's exactly why the master-dd review gate is load-bearing. This tool enforces it: nothing reaches the catalog without your `approved` flag.

### Rollback
Tool + tests only. No catalog write. Revert the commit — zero data/runtime impact.
