### PR TITLE
feat(combat): Overcharge verb — spend SG for +1 AP [TKT-P6-AP3]

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -189,6 +189,7 @@ const {
 } = require('./sessionHelpers');
 // Skiv ticket #5 (Sprint B): Defy verb — player counter-pressure agency.
 const { applyDefy: applyDefyAction, DEFY_SG_COST } = require('../services/combat/defyEngine');
+const { applyOvercharge: applyOverchargeAction } = require('../services/combat/overchargeEngine');
 const { createRoundBridge } = require('./sessionRoundBridge');
 // M13 P3 Phase B — progression perks apply + runtime passive damage bonus.
 const {
@@ -2761,6 +2762,50 @@ function createSessionRouter(options = {}) {
         relief: outcome.relief,
         sg_cost: outcome.cost.sg,
         ap_penalty_next_turn: outcome.cost.ap_next_turn,
+      };
+      if (Array.isArray(session.events)) session.events.push(event);
+      res.json({
+        session_id: session.session_id,
+        actor_id: actor.id,
+        ...outcome,
+        state: publicSessionView(session),
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // TKT-P6-AP3 — Overcharge verb (FFT "charge a big move" / Pillar 6).
+  // Body: { session_id, actor_id }. Validates actor is player-controlled +
+  // alive + not already overcharged this turn + SG >= OVERCHARGE_SG_COST (3);
+  // on success spends a full SG gauge and grants +1 ap_remaining THIS turn so a
+  // cost_ap:3 ability fits the 2-AP budget. The actor.status.overcharged guard
+  // is cleared by the end-of-round status decrement (once per turn). Symmetric
+  // twin of /defy (which trades SG for pressure relief at -1 AP next turn).
+  router.post('/overcharge', async (req, res, next) => {
+    try {
+      const body = req.body || {};
+      const { error, session } = resolveSession(body.session_id);
+      if (error) return res.status(error.status).json(error.body);
+      const actor = session.units.find((u) => u.id === body.actor_id);
+      if (!actor) {
+        return res.status(400).json({ error: 'actor_not_found', actor_id: body.actor_id || null });
+      }
+      const outcome = applyOverchargeAction(actor);
+      if (!outcome.ok) {
+        return res
+          .status(409)
+          .json({ error: outcome.error, detail: outcome.detail || null, actor_id: actor.id });
+      }
+      const event = {
+        event_type: 'overcharge',
+        actor_id: actor.id,
+        turn: Number(session.turn || 0),
+        sg_before: outcome.before.sg,
+        sg_after: outcome.after.sg,
+        ap_before: outcome.before.ap_remaining,
+        ap_after: outcome.after.ap_remaining,
+        sg_cost: outcome.cost.sg,
       };
       if (Array.isArray(session.events)) session.events.push(event);
       res.json({

--- a/apps/backend/services/combat/overchargeEngine.js
+++ b/apps/backend/services/combat/overchargeEngine.js
@@ -1,0 +1,85 @@
+// =============================================================================
+// Overcharge Action — TKT-P6-AP3 (Pillar 6 fairness / FFT "charge a big move").
+//
+// Five abilities cost cost_ap: 3 (frozen_stasis / meteoric_shield / power_strike
+// / sonic_blast / armatura guard) but the per-turn budget is 2 AP, so they were
+// unplayable. Rather than flatten them to 2 AP, Overcharge lets the player spend
+// a FULL SG gauge to gain +1 AP this turn — a telegraphed, once-per-turn
+// "all-in" that turns the 3-AP ability into a deliberate moment, not spam.
+//
+// Symmetric twin of defyEngine:
+//   defy:       spend 2 SG  -> pressure relief, -1 AP NEXT turn   (give up tempo)
+//   overcharge: spend 3 SG  -> +1 AP THIS turn                    (borrow tempo)
+//
+// Cost = 3 SG. sgTracker POOL_MAX = 3, so an overcharge empties the gauge — by
+// design it is rare and cannot chain. Effect: actor.ap_remaining += 1, gated to
+// once per turn via actor.status.overcharged (the end-of-round decrement loop
+// clears it like any other status counter).
+//
+// Pure: validate + apply mutations on `actor`. The route wraps with side-effects
+// (append event, public view). Mirrors defyEngine / thoughtCabinet pattern.
+// =============================================================================
+
+'use strict';
+
+const OVERCHARGE_SG_COST = 3;
+const OVERCHARGE_AP_GAIN = 1;
+
+const ERR_NOT_FOUND = 'actor_not_found';
+const ERR_NOT_PLAYER = 'not_player_controlled';
+const ERR_KO = 'actor_ko';
+const ERR_INSUFFICIENT_SG = 'insufficient_sg';
+const ERR_ALREADY_OVERCHARGED = 'already_overcharged';
+
+/**
+ * Validate that an actor can Overcharge. Pure — no mutation.
+ * @returns {{ ok: true } | { ok: false, error: string, detail?: object }}
+ */
+function canOvercharge(actor) {
+  if (!actor) return { ok: false, error: ERR_NOT_FOUND };
+  if (actor.controlled_by !== 'player') return { ok: false, error: ERR_NOT_PLAYER };
+  if (Number(actor.hp || 0) <= 0) return { ok: false, error: ERR_KO };
+  if (actor.status && Number(actor.status.overcharged) > 0) {
+    return { ok: false, error: ERR_ALREADY_OVERCHARGED };
+  }
+  const sg = Number(actor.sg || 0);
+  if (sg < OVERCHARGE_SG_COST) {
+    return { ok: false, error: ERR_INSUFFICIENT_SG, detail: { sg, required: OVERCHARGE_SG_COST } };
+  }
+  return { ok: true };
+}
+
+/**
+ * Apply Overcharge: deduct SG, grant +1 ap_remaining this turn, mark the
+ * once-per-turn guard. Mutates `actor` in place.
+ * Returns { ok, before, after, cost } for telemetry/event log.
+ */
+function applyOvercharge(actor) {
+  const guard = canOvercharge(actor);
+  if (!guard.ok) return { ok: false, error: guard.error, detail: guard.detail || null };
+  const sgBefore = Number(actor.sg || 0);
+  const apBefore = Number(actor.ap_remaining ?? actor.ap ?? 0);
+  actor.sg = Math.max(0, sgBefore - OVERCHARGE_SG_COST);
+  actor.ap_remaining = apBefore + OVERCHARGE_AP_GAIN;
+  if (!actor.status || typeof actor.status !== 'object') actor.status = {};
+  // Once-per-turn guard; cleared by the end-of-round status decrement loop.
+  actor.status.overcharged = 1;
+  return {
+    ok: true,
+    before: { sg: sgBefore, ap_remaining: apBefore },
+    after: { sg: actor.sg, ap_remaining: actor.ap_remaining, overcharged: 1 },
+    cost: { sg: OVERCHARGE_SG_COST },
+  };
+}
+
+module.exports = {
+  OVERCHARGE_SG_COST,
+  OVERCHARGE_AP_GAIN,
+  ERR_NOT_FOUND,
+  ERR_NOT_PLAYER,
+  ERR_KO,
+  ERR_INSUFFICIENT_SG,
+  ERR_ALREADY_OVERCHARGED,
+  canOvercharge,
+  applyOvercharge,
+};

--- a/tests/api/overchargeRoute.test.js
+++ b/tests/api/overchargeRoute.test.js
@@ -1,0 +1,185 @@
+// Overcharge route integration — TKT-P6-AP3 (Pillar 6 / FFT charge beat).
+// Verifies POST /api/session/overcharge: spend full SG gauge → +1 ap_remaining
+// this turn, so a cost_ap:3 ability fits the 2-AP budget. Symmetric twin of
+// /defy. Mirrors defyRoute.test.js (initial_sg seeding; start zeros SG).
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+function basePlayer(overrides = {}) {
+  return {
+    id: 'p1',
+    species: 'velox',
+    job: 'skirmisher',
+    hp: 12,
+    max_hp: 12,
+    ap: 2,
+    sg: 3,
+    attack_range: 3,
+    initiative: 14,
+    position: { x: 1, y: 1 },
+    controlled_by: 'player',
+    status: {},
+    ...overrides,
+  };
+}
+
+function baseSistema(overrides = {}) {
+  return {
+    id: 'sis',
+    species: 'carapax',
+    job: 'vanguard',
+    hp: 30,
+    max_hp: 30,
+    ap: 2,
+    attack_range: 1,
+    initiative: 5,
+    position: { x: 5, y: 5 },
+    controlled_by: 'sistema',
+    status: {},
+    ...overrides,
+  };
+}
+
+async function startSession(app, units, sistema_pressure = 60) {
+  const initial_sg = {};
+  for (const u of units) {
+    if (Number.isFinite(Number(u.sg)) && Number(u.sg) > 0) initial_sg[u.id] = u.sg;
+  }
+  const res = await request(app)
+    .post('/api/session/start')
+    .send({ units, sistema_pressure_start: sistema_pressure, initial_sg })
+    .expect(200);
+  return res.body.session_id;
+}
+
+test('POST /overcharge happy path — spends 3 SG, +1 ap_remaining, marks guard', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, [basePlayer({ sg: 3 }), baseSistema()]);
+  const r = await request(app)
+    .post('/api/session/overcharge')
+    .send({ session_id: sid, actor_id: 'p1' });
+  assert.equal(r.status, 200);
+  assert.equal(r.body.ok, true);
+  assert.equal(r.body.before.sg, 3);
+  assert.equal(r.body.after.sg, 0, 'full gauge spent');
+  assert.equal(r.body.before.ap_remaining, 2);
+  assert.equal(r.body.after.ap_remaining, 3, 'ap_remaining 2 -> 3');
+  assert.deepEqual(r.body.cost, { sg: 3 });
+  const player = r.body.state.units.find((u) => u.id === 'p1');
+  assert.equal(Number(player.ap_remaining), 3, 'state mirrors +1 AP');
+  assert.equal(Number(player.sg), 0, 'state mirrors spent gauge');
+});
+
+test('POST /overcharge: 409 insufficient_sg below full gauge', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, [basePlayer({ sg: 2 }), baseSistema()]);
+  const r = await request(app)
+    .post('/api/session/overcharge')
+    .send({ session_id: sid, actor_id: 'p1' });
+  assert.equal(r.status, 409);
+  assert.equal(r.body.error, 'insufficient_sg');
+  assert.equal(r.body.detail.sg, 2);
+  assert.equal(r.body.detail.required, 3);
+});
+
+test('POST /overcharge: 409 already_overcharged on second call same turn', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  // sg 3 → first overcharge spends all 3; second must fail on the guard, not SG.
+  // Use sg 6-capable? POOL_MAX=3 caps it, so seed exactly 3 and assert the guard
+  // error wins even though SG is now 0 (guard checked before SG).
+  const sid = await startSession(app, [basePlayer({ sg: 3 }), baseSistema()]);
+  const first = await request(app)
+    .post('/api/session/overcharge')
+    .send({ session_id: sid, actor_id: 'p1' });
+  assert.equal(first.status, 200);
+  const second = await request(app)
+    .post('/api/session/overcharge')
+    .send({ session_id: sid, actor_id: 'p1' });
+  assert.equal(second.status, 409);
+  assert.equal(second.body.error, 'already_overcharged');
+});
+
+test('POST /overcharge: 409 not_player_controlled for sistema', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, [basePlayer(), baseSistema({ sg: 3 })]);
+  const r = await request(app)
+    .post('/api/session/overcharge')
+    .send({ session_id: sid, actor_id: 'sis' });
+  assert.equal(r.status, 409);
+  assert.equal(r.body.error, 'not_player_controlled');
+});
+
+test('POST /overcharge: 400 actor_not_found', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, [basePlayer({ sg: 3 }), baseSistema()]);
+  const r = await request(app)
+    .post('/api/session/overcharge')
+    .send({ session_id: sid, actor_id: 'ghost' });
+  assert.equal(r.status, 400);
+  assert.equal(r.body.error, 'actor_not_found');
+});
+
+test('POST /overcharge: event appended to session.events', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, [basePlayer({ sg: 3 }), baseSistema()]);
+  const r = await request(app)
+    .post('/api/session/overcharge')
+    .send({ session_id: sid, actor_id: 'p1' });
+  assert.equal(r.status, 200);
+  const events = (r.body.state && r.body.state.events) || [];
+  const ev = events.find((e) => e.event_type === 'overcharge');
+  assert.ok(ev, 'expected overcharge event in session.events');
+  assert.equal(ev.actor_id, 'p1');
+  assert.equal(ev.sg_cost, 3);
+  assert.equal(ev.ap_before, 2);
+  assert.equal(ev.ap_after, 3);
+});
+
+test('POST /overcharge: the guard clears after a round so it can be reused later', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, [basePlayer({ sg: 3 }), baseSistema()]);
+  const first = await request(app)
+    .post('/api/session/overcharge')
+    .send({ session_id: sid, actor_id: 'p1' });
+  assert.equal(first.status, 200);
+  // End rounds: the generic status-decrement loop drops overcharged 1 -> 0.
+  let clearedObserved = false;
+  for (let i = 0; i < 4; i += 1) {
+    const turn = await request(app).post('/api/session/turn/end').send({ session_id: sid });
+    assert.equal(turn.status, 200);
+    const player = turn.body.state.units.find((u) => u.id === 'p1');
+    if (player && !Number(player.status?.overcharged)) {
+      clearedObserved = true;
+      break;
+    }
+  }
+  assert.ok(clearedObserved, 'overcharged guard cleared by end-of-round decrement');
+});

--- a/tests/services/overchargeEngine.test.js
+++ b/tests/services/overchargeEngine.test.js
@@ -1,0 +1,117 @@
+'use strict';
+
+// TKT-P6-AP3 — Overcharge verb (Pillar 6 fairness / FFT charge beat).
+//
+// Symmetric twin of defyEngine: the player spends a full SG gauge to gain +1 AP
+// THIS turn, so a `cost_ap: 3` ability (frozen_stasis / power_strike /
+// sonic_blast / meteoric_shield / armatura guard) becomes playable inside the
+// 2-AP/turn budget — but only as a telegraphed "all-in" move, not spam.
+//
+// Pure module (mirror defyEngine): canOvercharge(actor) validates, applyOvercharge
+// (actor) mutates actor in place. Route wraps side-effects + event.
+//
+// Cost = 3 SG (POOL_MAX = 3 → empties the gauge; defy costs 2). Effect:
+// actor.ap_remaining += 1, capped so it cannot exceed base ap + 1 (one
+// overcharge per turn). Guard actor.status.overcharged marks the turn used.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  OVERCHARGE_SG_COST,
+  OVERCHARGE_AP_GAIN,
+  canOvercharge,
+  applyOvercharge,
+  ERR_NOT_FOUND,
+  ERR_NOT_PLAYER,
+  ERR_KO,
+  ERR_INSUFFICIENT_SG,
+  ERR_ALREADY_OVERCHARGED,
+} = require('../../apps/backend/services/combat/overchargeEngine');
+
+function player(over = {}) {
+  return {
+    id: 'p1',
+    controlled_by: 'player',
+    hp: 20,
+    ap: 2,
+    ap_remaining: 2,
+    sg: 3,
+    status: {},
+    ...over,
+  };
+}
+
+test('OVERCHARGE constants: 3 SG cost, +1 AP gain', () => {
+  assert.equal(OVERCHARGE_SG_COST, 3);
+  assert.equal(OVERCHARGE_AP_GAIN, 1);
+});
+
+test('canOvercharge: ok for an alive player with a full gauge', () => {
+  assert.deepEqual(canOvercharge(player()), { ok: true });
+});
+
+test('canOvercharge: actor_not_found when null', () => {
+  assert.equal(canOvercharge(null).error, ERR_NOT_FOUND);
+});
+
+test('canOvercharge: not_player_controlled for sistema units', () => {
+  assert.equal(canOvercharge(player({ controlled_by: 'sistema' })).error, ERR_NOT_PLAYER);
+});
+
+test('canOvercharge: actor_ko at 0 hp', () => {
+  assert.equal(canOvercharge(player({ hp: 0 })).error, ERR_KO);
+});
+
+test('canOvercharge: insufficient_sg below the cost', () => {
+  const res = canOvercharge(player({ sg: 2 }));
+  assert.equal(res.error, ERR_INSUFFICIENT_SG);
+  assert.deepEqual(res.detail, { sg: 2, required: 3 });
+});
+
+test('canOvercharge: already_overcharged this turn', () => {
+  assert.equal(
+    canOvercharge(player({ status: { overcharged: 1 } })).error,
+    ERR_ALREADY_OVERCHARGED,
+  );
+});
+
+test('applyOvercharge: spends 3 SG, +1 ap_remaining, marks the turn', () => {
+  const actor = player();
+  const out = applyOvercharge(actor);
+  assert.equal(out.ok, true);
+  assert.equal(actor.sg, 0, 'full gauge spent (3 -> 0)');
+  assert.equal(actor.ap_remaining, 3, 'ap_remaining 2 -> 3');
+  assert.equal(actor.status.overcharged, 1, 'overcharged guard set');
+  assert.deepEqual(out.before, { sg: 3, ap_remaining: 2 });
+  assert.equal(out.after.sg, 0);
+  assert.equal(out.after.ap_remaining, 3);
+  assert.deepEqual(out.cost, { sg: 3 });
+});
+
+test('applyOvercharge: refuses a second overcharge in the same turn', () => {
+  const actor = player({ sg: 3 });
+  applyOvercharge(actor); // first ok (sg now 0 anyway)
+  const actor2 = player({ sg: 3, status: { overcharged: 1 } });
+  const out = applyOvercharge(actor2);
+  assert.equal(out.ok, false);
+  assert.equal(out.error, ERR_ALREADY_OVERCHARGED);
+  assert.equal(actor2.sg, 3, 'no SG spent on refusal');
+  assert.equal(actor2.ap_remaining, 2, 'no AP granted on refusal');
+});
+
+test('applyOvercharge: refuses when SG insufficient (no mutation)', () => {
+  const actor = player({ sg: 2 });
+  const out = applyOvercharge(actor);
+  assert.equal(out.ok, false);
+  assert.equal(out.error, ERR_INSUFFICIENT_SG);
+  assert.equal(actor.sg, 2, 'SG untouched');
+  assert.equal(actor.ap_remaining, 2, 'AP untouched');
+});
+
+test('applyOvercharge: ap_remaining derives from ap when undefined', () => {
+  const actor = player({ ap: 2, ap_remaining: undefined });
+  const out = applyOvercharge(actor);
+  assert.equal(out.ok, true);
+  assert.equal(actor.ap_remaining, 3, 'base ap 2 + 1');
+});


### PR DESCRIPTION
Closes the TKT-P6-AP3 decision (master-dd verdict: option B — gating PT/SG, scoped down to a clean SG-spend after ground-truth showed cost_sg/pt/pe were unconsumed and sgTracker.spend orphan).

## Problem
5 abilities cost `cost_ap: 3` (frozen_stasis / meteoric_shield / power_strike / sonic_blast / armatura guard) but the per-turn budget is 2 AP → unplayable. Flattening to 2 AP would kill the FFT 'charge a big move' beat (Pillar 1 readable tactics + Pillar 6 fairness).

## Solution — Overcharge verb (symmetric twin of /defy)
Opt-in: spend a **full SG gauge (3 SG**, `sgTracker POOL_MAX=3`) → **+1 `ap_remaining` this turn**, once per turn. The 3-AP ability stays a deliberate, telegraphed moment.

| | trade |
|--|--|
| `/defy` (existing) | spend 2 SG → pressure relief, **−1 AP next turn** |
| `/overcharge` (new) | spend 3 SG → **+1 AP this turn** |

- `apps/backend/services/combat/overchargeEngine.js` — pure `canOvercharge`/`applyOvercharge`, mirrors `defyEngine`.
- `POST /api/session/overcharge` — validate → deduct SG → +1 AP → event, mirrors the `/defy` route wrapper.
- `actor.status.overcharged` once-per-turn guard cleared by the existing end-of-round status-decrement loop (verified runs on the priority_queue path too).

## Band-safety
Opt-in verb; nothing fires it by default → existing combat/WR bands unchanged (no scenario grants it). The 5 `cost_ap:3` abilities are left untouched.

## QG
- overchargeEngine **11/11** + overchargeRoute **7/7** (happy path, 4 error cases, event surface, guard-clears-after-round).
- Regression: defy + AI **529/529** green. prettier clean.

## Note for master-dd
SG pool max is 3, so an overcharge **empties the gauge** — intentional 'all-in', cannot chain. If you'd prefer it leave some SG (e.g. cost 2), that's a one-constant change in `overchargeEngine.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)