### PR TITLE
feat(species): unify 22 gameplay creatures into canon SoT (Wave3 CANON-RECONCILE)

### DIFF
--- a/data/core/species/species_catalog.json
+++ b/data/core/species/species_catalog.json
@@ -1,11 +1,12 @@
 {
-  "version": "0.4.1",
+  "version": "0.4.2",
   "merged_at": "2026-05-15",
   "source_provenance": {
     "pack_v2_full_plus": "/tmp/species_catalog_v0.2.0_backup.json",
     "game_canonical_lifecycle": "data/core/species",
     "legacy_yaml_species": "/tmp/species_etl_source.yaml",
-    "legacy_yaml_expansion": "/tmp/species_expansion_etl_source.yaml"
+    "legacy_yaml_expansion": "/tmp/species_expansion_etl_source.yaml",
+    "gameplay_promote": "packs/evo_tactics_pack/data/species"
   },
   "sentience_assignment_method": {
     "pack_v2_plus_source": "sentience_index field verbatim",
@@ -14,17 +15,18 @@
     "phase_3_heuristic": "ADR-2026-05-15 Phase 3 Path Quick: functional_signature + risk_profile + interactions filled from clade_tag + trait_plan + foodweb cross-lookup. visual_description + symbiosis + constraints pending master-dd review."
   },
   "stats": {
-    "total_species": 53,
+    "total_species": 75,
     "by_source": {
       "pack-v2-full-plus": 10,
       "game-canonical-stub": 5,
-      "legacy-yaml-merge": 38
+      "legacy-yaml-merge": 38,
+      "gameplay-promote": 22
     },
     "by_sentience_tier": {
-      "T1": 22,
+      "T1": 42,
       "T2": 16,
       "T5": 3,
-      "T3": 6,
+      "T3": 8,
       "T0": 1,
       "T4": 5
     },
@@ -3464,6 +3466,1128 @@
         "constraints": "heuristic-pattern-C-mechanical",
         "biome_affinity": "d4-heuristic-suggest+master-dd-approve"
       }
+    },
+    {
+      "species_id": "echo_wing",
+      "scientific_name": "",
+      "common_names": [
+        "Echo Wing"
+      ],
+      "classification": {
+        "macro_class": "volatore_planatore",
+        "habitat": "badlands"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 1,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T1",
+      "ecotypes": [
+        "badlands"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "echo_wing",
+      "biome_affinity": "badlands",
+      "role_tags": [
+        "dispersore_ponte"
+      ],
+      "clade_tag": null,
+      "morphotype": "volatore_planatore",
+      "threat_tier": "T1",
+      "encounter_role": "ambient",
+      "pack_path": "packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
+    },
+    {
+      "species_id": "ferrocolonia_magnetotattica",
+      "scientific_name": "",
+      "common_names": [
+        "Ferrocolonia Magnetotattica"
+      ],
+      "classification": {
+        "macro_class": "ingegnere_radicante",
+        "habitat": "badlands"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 2,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T3",
+      "ecotypes": [
+        "badlands"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "ferrocolonia_magnetotattica",
+      "biome_affinity": "badlands",
+      "role_tags": [
+        "predatore_regolatore_simbionte"
+      ],
+      "clade_tag": null,
+      "morphotype": "ingegnere_radicante",
+      "threat_tier": "T2",
+      "encounter_role": "elite",
+      "pack_path": "packs/evo_tactics_pack/data/species/badlands/ferrocolonia-magnetotattica.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
+    },
+    {
+      "species_id": "magneto_ridge_hunter",
+      "scientific_name": "",
+      "common_names": [
+        "Magneto Ridge Hunter"
+      ],
+      "classification": {
+        "macro_class": "unknown",
+        "habitat": "badlands"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 1,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T1",
+      "ecotypes": [
+        "badlands"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "magneto_ridge_hunter",
+      "biome_affinity": "badlands",
+      "role_tags": [
+        "evento_ecologico"
+      ],
+      "clade_tag": null,
+      "morphotype": null,
+      "threat_tier": null,
+      "encounter_role": "minion",
+      "pack_path": "packs/evo_tactics_pack/data/species/badlands/magneto-ridge-hunter.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
+    },
+    {
+      "species_id": "nano_rust_bloom",
+      "scientific_name": "",
+      "common_names": [
+        "Nano Rust Bloom"
+      ],
+      "classification": {
+        "macro_class": "scavenger_corazzato",
+        "habitat": "badlands"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 3,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T1",
+      "ecotypes": [
+        "badlands"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "nano_rust_bloom",
+      "biome_affinity": "badlands",
+      "role_tags": [
+        "minaccia_microbica"
+      ],
+      "clade_tag": null,
+      "morphotype": "scavenger_corazzato",
+      "threat_tier": "T3",
+      "encounter_role": "boss",
+      "pack_path": "packs/evo_tactics_pack/data/species/badlands/nano-rust-bloom.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
+    },
+    {
+      "species_id": "rust_scavenger",
+      "scientific_name": "",
+      "common_names": [
+        "Rust Scavenger"
+      ],
+      "classification": {
+        "macro_class": "scavenger_corazzato",
+        "habitat": "badlands"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 1,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T1",
+      "ecotypes": [
+        "badlands"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "rust_scavenger",
+      "biome_affinity": "badlands",
+      "role_tags": [
+        "ingegneri_ecosistema"
+      ],
+      "clade_tag": null,
+      "morphotype": "scavenger_corazzato",
+      "threat_tier": "T1",
+      "encounter_role": "ambient",
+      "pack_path": "packs/evo_tactics_pack/data/species/badlands/rust-scavenger.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
+    },
+    {
+      "species_id": "sand_burrower",
+      "scientific_name": "",
+      "common_names": [
+        "Sand Burrower"
+      ],
+      "classification": {
+        "macro_class": "cursoriale_quadrupede",
+        "habitat": "badlands"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 1,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T1",
+      "ecotypes": [
+        "badlands"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "sand_burrower",
+      "biome_affinity": "badlands",
+      "role_tags": [
+        "erbivoro_primario"
+      ],
+      "clade_tag": null,
+      "morphotype": "cursoriale_quadrupede",
+      "threat_tier": "T1",
+      "encounter_role": "minion",
+      "pack_path": "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
+    },
+    {
+      "species_id": "slag_veil_ambusher",
+      "scientific_name": "",
+      "common_names": [
+        "Slag Veil Ambusher"
+      ],
+      "classification": {
+        "macro_class": "unknown",
+        "habitat": "badlands"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 1,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T1",
+      "ecotypes": [
+        "badlands"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "slag_veil_ambusher",
+      "biome_affinity": "badlands",
+      "role_tags": [
+        "evento_ecologico"
+      ],
+      "clade_tag": null,
+      "morphotype": null,
+      "threat_tier": null,
+      "encounter_role": "minion",
+      "pack_path": "packs/evo_tactics_pack/data/species/badlands/slag-veil-ambusher.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
+    },
+    {
+      "species_id": "aurora_bridge_runner",
+      "scientific_name": "",
+      "common_names": [
+        "Aurora Bridge Runner"
+      ],
+      "classification": {
+        "macro_class": "unknown",
+        "habitat": "cryosteppe"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 1,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T1",
+      "ecotypes": [
+        "cryosteppe"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "aurora_bridge_runner",
+      "biome_affinity": "cryosteppe",
+      "role_tags": [
+        "evento_ecologico"
+      ],
+      "clade_tag": null,
+      "morphotype": null,
+      "threat_tier": null,
+      "encounter_role": "minion",
+      "pack_path": "packs/evo_tactics_pack/data/species/cryosteppe/aurora-bridge-runner.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
+    },
+    {
+      "species_id": "aurora_gull",
+      "scientific_name": "",
+      "common_names": [
+        "Gabbiano d’Aurora"
+      ],
+      "classification": {
+        "macro_class": "volatore_planatore",
+        "habitat": "cryosteppe"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 1,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T1",
+      "ecotypes": [
+        "cryosteppe"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "aurora_gull",
+      "biome_affinity": "cryosteppe",
+      "role_tags": [
+        "dispersore_ponte"
+      ],
+      "clade_tag": null,
+      "morphotype": "volatore_planatore",
+      "threat_tier": "T1",
+      "encounter_role": "ambient",
+      "pack_path": "packs/evo_tactics_pack/data/species/cryosteppe/aurora-gull.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
+    },
+    {
+      "species_id": "cryo_lynx",
+      "scientific_name": "",
+      "common_names": [
+        "Cryo Lynx"
+      ],
+      "classification": {
+        "macro_class": "cursoriale_quadrupede",
+        "habitat": "cryosteppe"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 3,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T1",
+      "ecotypes": [
+        "cryosteppe"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "cryo_lynx",
+      "biome_affinity": "cryosteppe",
+      "role_tags": [
+        "predatore_terziario_apex"
+      ],
+      "clade_tag": null,
+      "morphotype": "cursoriale_quadrupede",
+      "threat_tier": "T3",
+      "encounter_role": "elite",
+      "pack_path": "packs/evo_tactics_pack/data/species/cryosteppe/cryo-lynx.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
+    },
+    {
+      "species_id": "steppe_bison_mini",
+      "scientific_name": "",
+      "common_names": [
+        "Bisonte Nano della Steppa"
+      ],
+      "classification": {
+        "macro_class": "cursoriale_quadrupede",
+        "habitat": "cryosteppe"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 1,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T1",
+      "ecotypes": [
+        "cryosteppe"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "steppe_bison_mini",
+      "biome_affinity": "cryosteppe",
+      "role_tags": [
+        "ingegneri_ecosistema"
+      ],
+      "clade_tag": null,
+      "morphotype": "cursoriale_quadrupede",
+      "threat_tier": "T1",
+      "encounter_role": "ambient",
+      "pack_path": "packs/evo_tactics_pack/data/species/cryosteppe/steppe-bison-mini.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
+    },
+    {
+      "species_id": "thaw_rot",
+      "scientific_name": "",
+      "common_names": [
+        "Thaw Rot"
+      ],
+      "classification": {
+        "macro_class": "scavenger_corazzato",
+        "habitat": "cryosteppe"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 3,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T1",
+      "ecotypes": [
+        "cryosteppe"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "thaw_rot",
+      "biome_affinity": "cryosteppe",
+      "role_tags": [
+        "minaccia_microbica"
+      ],
+      "clade_tag": null,
+      "morphotype": "scavenger_corazzato",
+      "threat_tier": "T3",
+      "encounter_role": "boss",
+      "pack_path": "packs/evo_tactics_pack/data/species/cryosteppe/thaw-rot.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
+    },
+    {
+      "species_id": "zephyr_spore_courier",
+      "scientific_name": "",
+      "common_names": [
+        "Zephyr Spore Courier"
+      ],
+      "classification": {
+        "macro_class": "unknown",
+        "habitat": "cryosteppe"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 1,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T1",
+      "ecotypes": [
+        "cryosteppe"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "zephyr_spore_courier",
+      "biome_affinity": "cryosteppe",
+      "role_tags": [
+        "evento_ecologico"
+      ],
+      "clade_tag": null,
+      "morphotype": null,
+      "threat_tier": null,
+      "encounter_role": "minion",
+      "pack_path": "packs/evo_tactics_pack/data/species/cryosteppe/zephyr-spore-courier.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
+    },
+    {
+      "species_id": "cactus_weaver",
+      "scientific_name": "",
+      "common_names": [
+        "Cactus Weaver"
+      ],
+      "classification": {
+        "macro_class": "ingegnere_radicante",
+        "habitat": "deserto_caldo"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 1,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T1",
+      "ecotypes": [
+        "deserto_caldo"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "cactus_weaver",
+      "biome_affinity": "deserto_caldo",
+      "role_tags": [
+        "ingegneri_ecosistema"
+      ],
+      "clade_tag": null,
+      "morphotype": "ingegnere_radicante",
+      "threat_tier": "T1",
+      "encounter_role": "ambient",
+      "pack_path": "packs/evo_tactics_pack/data/species/deserto_caldo/cactus-weaver.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
+    },
+    {
+      "species_id": "noctule_termico",
+      "scientific_name": "",
+      "common_names": [
+        "Noctule Termico"
+      ],
+      "classification": {
+        "macro_class": "volatore_planatore",
+        "habitat": "deserto_caldo"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 1,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T1",
+      "ecotypes": [
+        "deserto_caldo"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "noctule_termico",
+      "biome_affinity": "deserto_caldo",
+      "role_tags": [
+        "dispersore_ponte"
+      ],
+      "clade_tag": null,
+      "morphotype": "volatore_planatore",
+      "threat_tier": "T1",
+      "encounter_role": "ambient",
+      "pack_path": "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
+    },
+    {
+      "species_id": "silica_bloom",
+      "scientific_name": "",
+      "common_names": [
+        "Silica Bloom"
+      ],
+      "classification": {
+        "macro_class": "scavenger_corazzato",
+        "habitat": "deserto_caldo"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 3,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T1",
+      "ecotypes": [
+        "deserto_caldo"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "silica_bloom",
+      "biome_affinity": "deserto_caldo",
+      "role_tags": [
+        "minaccia_microbica"
+      ],
+      "clade_tag": null,
+      "morphotype": "scavenger_corazzato",
+      "threat_tier": "T3",
+      "encounter_role": "boss",
+      "pack_path": "packs/evo_tactics_pack/data/species/deserto_caldo/silica-bloom.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
+    },
+    {
+      "species_id": "thermo_raptor",
+      "scientific_name": "",
+      "common_names": [
+        "Thermo Raptor"
+      ],
+      "classification": {
+        "macro_class": "cursoriale_quadrupede",
+        "habitat": "deserto_caldo"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 3,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T1",
+      "ecotypes": [
+        "deserto_caldo"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "thermo_raptor",
+      "biome_affinity": "deserto_caldo",
+      "role_tags": [
+        "predatore_terziario_apex"
+      ],
+      "clade_tag": null,
+      "morphotype": "cursoriale_quadrupede",
+      "threat_tier": "T3",
+      "encounter_role": "elite",
+      "pack_path": "packs/evo_tactics_pack/data/species/deserto_caldo/thermo-raptor.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
+    },
+    {
+      "species_id": "blight_micotico",
+      "scientific_name": "",
+      "common_names": [
+        "Blight Micotico"
+      ],
+      "classification": {
+        "macro_class": "unknown",
+        "habitat": "foresta_temperata"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 3,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T1",
+      "ecotypes": [
+        "foresta_temperata"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "blight_micotico",
+      "biome_affinity": "foresta_temperata",
+      "role_tags": [
+        "minaccia_microbica"
+      ],
+      "clade_tag": null,
+      "morphotype": null,
+      "threat_tier": "T3",
+      "encounter_role": "boss",
+      "pack_path": "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
+    },
+    {
+      "species_id": "glowcap_weaver",
+      "scientific_name": "",
+      "common_names": [
+        "Glowcap Weaver"
+      ],
+      "classification": {
+        "macro_class": "unknown",
+        "habitat": "foresta_temperata"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 1,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T1",
+      "ecotypes": [
+        "foresta_temperata"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "glowcap_weaver",
+      "biome_affinity": "foresta_temperata",
+      "role_tags": [
+        "evento_ecologico"
+      ],
+      "clade_tag": null,
+      "morphotype": null,
+      "threat_tier": null,
+      "encounter_role": "minion",
+      "pack_path": "packs/evo_tactics_pack/data/species/foresta_temperata/glowcap-weaver.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
+    },
+    {
+      "species_id": "lupus_temperatus",
+      "scientific_name": "",
+      "common_names": [
+        "Lupo della Foresta"
+      ],
+      "classification": {
+        "macro_class": "unknown",
+        "habitat": "foresta_temperata"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 2,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T1",
+      "ecotypes": [
+        "foresta_temperata"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "lupus_temperatus",
+      "biome_affinity": "foresta_temperata",
+      "role_tags": [
+        "predatore_terziario_apex"
+      ],
+      "clade_tag": null,
+      "morphotype": null,
+      "threat_tier": "T2",
+      "encounter_role": "elite",
+      "pack_path": "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
+    },
+    {
+      "species_id": "myco_spire_warden",
+      "scientific_name": "",
+      "common_names": [
+        "Myco Spire Warden"
+      ],
+      "classification": {
+        "macro_class": "unknown",
+        "habitat": "foresta_temperata"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 1,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T1",
+      "ecotypes": [
+        "foresta_temperata"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "myco_spire_warden",
+      "biome_affinity": "foresta_temperata",
+      "role_tags": [
+        "evento_ecologico"
+      ],
+      "clade_tag": null,
+      "morphotype": null,
+      "threat_tier": null,
+      "encounter_role": "minion",
+      "pack_path": "packs/evo_tactics_pack/data/species/foresta_temperata/myco-spire-warden.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
+    },
+    {
+      "species_id": "sentinella_radice",
+      "scientific_name": "",
+      "common_names": [
+        "Sentinella Radice"
+      ],
+      "classification": {
+        "macro_class": "unknown",
+        "habitat": "foresta_temperata"
+      },
+      "functional_signature": "",
+      "visual_description": "",
+      "risk_profile": {
+        "danger_level": 1,
+        "vectors": []
+      },
+      "interactions": {
+        "predates_on": [],
+        "predated_by": []
+      },
+      "constraints": [],
+      "sentience_index": "T3",
+      "ecotypes": [
+        "foresta_temperata"
+      ],
+      "trait_refs": [],
+      "lifecycle_yaml": null,
+      "source": "gameplay-promote",
+      "legacy_slug": "sentinella_radice",
+      "biome_affinity": "foresta_temperata",
+      "role_tags": [
+        "ingegneri_ecosistema"
+      ],
+      "clade_tag": null,
+      "morphotype": null,
+      "threat_tier": "T1",
+      "encounter_role": "ambient",
+      "pack_path": "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml",
+      "merged_at": "2026-05-31",
+      "_promote_stub": true,
+      "_todo_fields": [
+        "scientific_name",
+        "classification",
+        "functional_signature",
+        "visual_description",
+        "interactions",
+        "constraints",
+        "trait_refs",
+        "lifecycle_yaml"
+      ]
     }
   ]
 }

--- a/docs/planning/2026-05-30-canon-reconcile-audit.md
+++ b/docs/planning/2026-05-30-canon-reconcile-audit.md
@@ -1,0 +1,99 @@
+---
+title: 'CANON-RECONCILE audit + Wave3 bestiary unify (Option 1)'
+workstream: worldgen
+category: planning
+doc_status: active
+doc_owner: claude-code
+last_verified: '2026-05-30'
+source_of_truth: false
+language: it
+review_cycle_days: 30
+tags: [planning, wave3, canon-reconcile, species, catalog, bestiary]
+---
+
+# CANON-RECONCILE audit + bestiary unify (Wave 3, 2026-05-30)
+
+Ticket: **TKT-SPECIE-CANON-RECONCILE** (Wave 3 del gap-resolution plan).
+Decisione master-dd (Eduardo): **Option 1 -- UNIRE** i due bestiari in un unico canon.
+
+## Audit -- il vero quadro (ground-truth, non plan-table)
+
+Il piano diceva "85 schede specie vs 53 SoT". Falso framing: le 85 file in
+`packs/evo_tactics_pack/data/species/<biome>/` NON sono 85 specie.
+
+| categoria        | n   | cos'e'                                     |
+| ---------------- | --- | ------------------------------------------ |
+| `*-trait-keeper` | 38  | contenitori tratti per-bioma -- NON specie |
+| `evento-*`       | 4   | eventi ecologici -- NON specie             |
+| creature reali   | 43  | le creature che gli scenari usano davvero  |
+
+Confronto vero: **43 creature gameplay vs 53 canon** -- due mondi di naming quasi
+disgiunti (**1 sola** sovrapposizione: `dune_stalker`).
+
+- **Canon (53)** = `data/core/species/species_catalog.json`. Bestiario di design ricco
+  (nome scientifico, classificazione, descrizioni, interazioni). `biome_affinity` 53/53,
+  lifecycle 15/53, trait_refs 37/53. MA 52/53 senza scheda combat-usabile.
+- **Gameplay (43)** = pack YAML per-bioma. 23/43 adapter-ready (hanno threat_tier +
+  role_trofico); le altre incomplete.
+- Correzione anti-stale: il piano diceva "32 specie senza biome_affinity" -> **falso
+  oggi** (53/53 ce l'hanno). TKT-SPECIE-BIOME quasi chiuso.
+
+## Pipeline reality (load-bearing)
+
+`species_catalog.json` e' un **artefatto di merge** le cui sorgenti originali stanno in
+`/tmp/...` (effimere, perse). Il regen-from-scratch e' morto; il file e' editato in-place
+da tool di polish (`apply_biome_affinity.py`, `apply_phase3_polish_d5_d6.py`). Quindi la
+promozione = append in-place via script, NON rigenerazione.
+
+Contratto entry (enforced da `tests/api/envelope-b-data-integrity.test.js`): 14 chiavi
+richieste presenti + `sentience_index` in `/^T[0-6]$/` + count per-`source` + guardia
+hard `total_species`.
+
+## Esecuzione -- unify a 2 strati
+
+**Strato 1 (questo PR) -- STRUTTURA.** Script `tools/etl/promote_gameplay_to_canon.py`:
+promuove le creature gameplay nel canon come entry STRUTTURALI (id/bioma/ruolo/threat/
+morfotipo mappati) con i campi design ricchi lasciati come STUB flaggati
+(`_promote_stub: true`, `_todo_fields: [...]`, `source: gameplay-promote`).
+
+Scope promosso (**22 creature**), i biomi gameplay multi-specie:
+
+| bioma             | n   |
+| ----------------- | --- |
+| badlands          | 7   |
+| cryosteppe        | 6   |
+| deserto_caldo     | 4   |
+| foresta_temperata | 5   |
+
+Catalogo **53 -> 75**. La base canon 53 e' **invariata** (test lo verifica).
+
+**Esclusi di proposito** (decisione, non dimenticanza):
+
+- `rovine_planari` (10) -- **D6 LOCKED** = nuovo contenuto, gate separato (richiede
+  authoring D&D-style + threat_tier/role assenti).
+- `tutorial` generici (apex-predatore / guardiano-_ / predone-_) -- placeholder di ruolo
+  per scenari, NON specie disegnate. Restano scenario-local.
+- biomi a 1-creatura (thin) -- YAGNI: promuovere quando quel bioma entra nel gameplay.
+
+**Strato 2 (incrementale, NON questo PR) -- CONTENUTO.** Authoring dei campi design
+(scientific_name, classification, functional_signature, visual_description, interactions,
+constraints, trait_refs, lifecycle) per le 22 entry, bioma per bioma. Trovabili via
+`source == 'gameplay-promote'` o `_promote_stub == true`. Delegabile a writer/swarm.
+
+## Controlli (tutti verdi)
+
+- `tests/api/envelope-b-data-integrity.test.js` aggiornato (75; base-53 invariata;
+  batch 22 tutte `_promote_stub`; allow `gameplay-promote` lifecycle null).
+- Sweep consumer catalogo: **JS 112/112**, **python 64/64**.
+- Regression D4 risolta: `suggest_biome_affinity.load_catalog` ora esclude
+  `gameplay-promote` (stub non sono ground-truth per l'euristica biome -- stesso spirito
+  anti-self-poisoning del filtro D4-provenance). suggest 20/20, apply 26/26.
+
+## Follow-up aperti
+
+- **Strato 2 authoring** delle 22 stub (incrementale, YAGNI per bioma gameplay-touched).
+- **D6** rovine_planari (10) -- gate separato.
+- **Pulizia** dei 38 `*-trait-keeper` + 4 `evento-*` fuori da `species/` (non-specie
+  nella cartella sbagliata) -- cleanup separato.
+- 6 creature non-promosse con solo `threat_tier` mancante = fix veloce se servono in
+  combat (vedi audit).

--- a/tests/api/envelope-b-data-integrity.test.js
+++ b/tests/api/envelope-b-data-integrity.test.js
@@ -121,9 +121,27 @@ describe('OD-027 + OD-031 — species_catalog.json Pack v2 merge', () => {
     assert.equal(typeof catalog.stats.total_species, 'number');
   });
 
-  test('53 species merged (15 lifecycle + 38 legacy residue) — ADR-2026-05-15 Phase 1', () => {
-    assert.equal(catalog.stats.total_species, 53);
-    assert.equal(catalog.catalog.length, 53);
+  test('75 species (53 canon + 22 gameplay-promote) -- Wave3 CANON-RECONCILE', () => {
+    // Wave 3 unify (Option 1): gameplay creatures from the multi-species gameplay
+    // biomes (badlands 7 + cryosteppe 6 + deserto_caldo 4 + foresta_temperata 5)
+    // promoted into the canon SoT as structural stubs (source=gameplay-promote).
+    // Excludes rovine_planari (D6) + tutorial generics + thin biomes. See
+    // docs/planning/2026-05-30-canon-reconcile-audit.md + promote_gameplay_to_canon.py.
+    assert.equal(catalog.stats.total_species, 75);
+    assert.equal(catalog.catalog.length, 75);
+  });
+
+  test('canon base unchanged: 53 = 10 pack + 5 stub + 38 legacy', () => {
+    const base = catalog.catalog.filter((e) => e.source !== 'gameplay-promote');
+    assert.equal(base.length, 53, 'the original 53-species canon must be untouched');
+  });
+
+  test('gameplay-promote batch (22 species, all flagged _promote_stub)', () => {
+    const promo = catalog.catalog.filter((e) => e.source === 'gameplay-promote');
+    assert.equal(promo.length, 22, 'expected 22 gameplay creatures promoted');
+    for (const e of promo) {
+      assert.equal(e._promote_stub, true, `${e.species_id} must be flagged _promote_stub`);
+    }
   });
 
   test('Pack v2-full-plus metadata merged (10 species)', () => {
@@ -185,11 +203,11 @@ describe('OD-027 + OD-031 — species_catalog.json Pack v2 merge', () => {
     // Only 15 species (pack-v2-full-plus + game-canonical-stub) require lifecycle.
     for (const entry of catalog.catalog) {
       if (entry.lifecycle_yaml === null) {
-        // legacy-yaml-merge: lifecycle missing by design (Phase 3 master-dd review may add)
-        assert.equal(
-          entry.source,
-          'legacy-yaml-merge',
-          `${entry.species_id} null lifecycle requires legacy source`,
+        // legacy-yaml-merge: lifecycle missing by design (Phase 3 master-dd review may add).
+        // gameplay-promote: Wave3 structural stubs, lifecycle authored in Strato 2.
+        assert.ok(
+          entry.source === 'legacy-yaml-merge' || entry.source === 'gameplay-promote',
+          `${entry.species_id} null lifecycle requires legacy or gameplay-promote source`,
         );
         continue;
       }

--- a/tools/etl/promote_gameplay_to_canon.py
+++ b/tools/etl/promote_gameplay_to_canon.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Promote gameplay pack-species YAML into the canonical species_catalog.json.
+
+Wave 3 / CANON-RECONCILE (Option 1 "unify"): the canon SoT
+(data/core/species/species_catalog.json, 53 species) and the gameplay creatures
+(packs/evo_tactics_pack/data/species/<biome>/<id>.yaml) were near-disjoint naming
+worlds. This promotes a gameplay creature into the canon catalog as a STRUCTURAL
+entry (id/biome/role/threat/morphotype mapped) with the design-rich fields
+(scientific_name, classification, functional_signature, visual_description,
+interactions, constraints, trait_refs, lifecycle_yaml) left as flagged STUBS
+(`_promote_stub: true`) for incremental authoring (Strato 2).
+
+Contract enforced by tests/api/envelope-b-data-integrity.test.js:
+  - 14 required keys present per entry
+  - sentience_index in /^T[0-6]$/
+  - source-count asserts (new source 'gameplay-promote')
+  - lifecycle_yaml=null only allowed for whitelisted sources
+
+Idempotent: skips species_id already in catalog. Not a creature: *-trait-keeper /
+evento-* are excluded (they are not species).
+
+Usage:
+  python tools/etl/promote_gameplay_to_canon.py --biome badlands [--biome cryosteppe ...]
+  python tools/etl/promote_gameplay_to_canon.py --all-gameplay   # the 6 gameplay-touched biomes
+  python tools/etl/promote_gameplay_to_canon.py --biome badlands --dry-run
+"""
+
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+from datetime import date
+
+import yaml
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+CATALOG_PATH = os.path.join(REPO_ROOT, "data", "core", "species", "species_catalog.json")
+SPECIES_DIR = os.path.join(REPO_ROOT, "packs", "evo_tactics_pack", "data", "species")
+NEW_SOURCE = "gameplay-promote"
+
+# Design-rich fields left as stubs for Strato-2 incremental authoring.
+TODO_FIELDS = [
+    "scientific_name", "classification", "functional_signature",
+    "visual_description", "interactions", "constraints", "trait_refs", "lifecycle_yaml",
+]
+
+# threat_tier -> risk_profile.danger_level (clamped 1..5)
+TIER_DANGER = {"T0": 1, "T1": 1, "T2": 2, "T3": 3, "T4": 4, "T5": 5}
+
+
+def norm(s):
+    return re.sub(r"[^a-z0-9]+", "_", str(s).lower()).strip("_")
+
+
+def is_creature(fid):
+    return not (fid.endswith("-trait-keeper") or fid.endswith("_trait_keeper")
+                or fid.startswith("evento-") or fid.startswith("evento_"))
+
+
+def load_yaml(p):
+    with open(p, encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def derive_entry(pack, biome, fid):
+    bal = pack.get("balance") if isinstance(pack.get("balance"), dict) else {}
+    tier = bal.get("threat_tier") or pack.get("threat_tier")
+    tier = str(tier).upper() if tier else None
+    role = pack.get("role_trofico")
+    flags = pack.get("flags") if isinstance(pack.get("flags"), dict) else {}
+    sentient = bool(flags.get("sentient"))
+    display = pack.get("display_name") or fid.replace("-", " ").title()
+    morph = pack.get("morphotype")
+
+    danger = TIER_DANGER.get(tier, 1)
+    sentience = "T3" if sentient else "T1"  # RFC heuristic: sentient->T3, animal->T1
+
+    return {
+        "species_id": norm(fid),
+        # --- STUB design fields (presence required by integrity test) ---
+        "scientific_name": "",              # TODO author Latin binomial
+        "common_names": [display],
+        "classification": {"macro_class": morph or "unknown", "habitat": biome},
+        "functional_signature": "",         # TODO author
+        "visual_description": "",           # TODO author
+        "risk_profile": {"danger_level": danger, "vectors": []},
+        "interactions": {"predates_on": [], "predated_by": []},
+        "constraints": [],
+        "sentience_index": sentience,
+        "ecotypes": [biome],
+        "trait_refs": [],                   # TODO map functional_tags -> TR-#### ids
+        "lifecycle_yaml": None,             # TODO seed lifecycle stub
+        # --- structural / provenance ---
+        "source": NEW_SOURCE,
+        "legacy_slug": norm(fid),
+        "biome_affinity": biome,
+        "role_tags": [role] if role else [],
+        "clade_tag": None,
+        "morphotype": morph,
+        "threat_tier": tier,
+        "encounter_role": bal.get("encounter_role"),
+        "pack_path": os.path.relpath(
+            os.path.join(SPECIES_DIR, biome, f"{fid}.yaml"), REPO_ROOT
+        ).replace(os.sep, "/"),
+        "merged_at": date.today().isoformat(),
+        "_promote_stub": True,
+        "_todo_fields": list(TODO_FIELDS),
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--biome", action="append", default=[], help="biome dir to promote (repeatable)")
+    ap.add_argument("--all-gameplay", action="store_true",
+                    help="promote the 6 gameplay-touched biomes (excludes rovine_planari = D6)")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    # Multi-species gameplay biomes. EXCLUDES:
+    #  - rovine_planari (D6 LOCKED = new content, separate decision)
+    #  - tutorial (generic scenario role-placeholders, not designed species)
+    #  - thin single-creature biomes (YAGNI: promote when that biome enters gameplay)
+    GAMEPLAY_BIOMES = ["badlands", "cryosteppe", "deserto_caldo", "foresta_temperata"]
+    biomes = args.biome or (GAMEPLAY_BIOMES if args.all_gameplay else [])
+    if not biomes:
+        print("ERROR: pass --biome <name> or --all-gameplay", file=sys.stderr)
+        return 2
+
+    catalog = json.load(open(CATALOG_PATH, encoding="utf-8"))
+    existing = {e["species_id"] for e in catalog["catalog"]}
+
+    added, skipped = [], []
+    for biome in biomes:
+        for p in sorted(glob.glob(os.path.join(SPECIES_DIR, biome, "*.yaml"))):
+            fid = os.path.splitext(os.path.basename(p))[0]
+            if not is_creature(fid):
+                continue
+            sid = norm(fid)
+            if sid in existing:
+                skipped.append(sid)
+                continue
+            entry = derive_entry(load_yaml(p), biome, fid)
+            catalog["catalog"].append(entry)
+            existing.add(sid)
+            added.append(sid)
+
+    # Recompute stats.
+    cat = catalog["catalog"]
+    by_source, by_sent = {}, {}
+    for e in cat:
+        by_source[e["source"]] = by_source.get(e["source"], 0) + 1
+        by_sent[e["sentience_index"]] = by_sent.get(e["sentience_index"], 0) + 1
+    catalog.setdefault("stats", {})
+    catalog["stats"]["total_species"] = len(cat)
+    catalog["stats"]["by_source"] = by_source
+    catalog["stats"]["by_sentience_tier"] = by_sent
+    catalog["version"] = "0.4.2"
+    if isinstance(catalog.get("source_provenance"), dict):
+        catalog["source_provenance"]["gameplay_promote"] = "packs/evo_tactics_pack/data/species"
+
+    print(f"added {len(added)}: {added}")
+    print(f"skipped (already canon) {len(skipped)}: {skipped}")
+    print(f"catalog now {len(cat)} species; by_source={by_source}")
+
+    if args.dry_run:
+        print("[dry-run] not written")
+        return 0
+    with open(CATALOG_PATH, "w", encoding="utf-8") as f:
+        json.dump(catalog, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    print(f"written {CATALOG_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/py/suggest_biome_affinity.py
+++ b/tools/py/suggest_biome_affinity.py
@@ -21,7 +21,12 @@ CANONICAL_DATA_DIR = REPO_ROOT / "data/core"
 def load_catalog(path: Path = CATALOG_PATH) -> list:
     with open(path, encoding="utf-8") as f:
         data = json.load(f)
-    return data["catalog"]
+    # Wave3 CANON-RECONCILE: gameplay-promote entries are design-incomplete structural
+    # stubs whose biome_affinity is the native pack-dir biome (not editorial ground
+    # truth). Exclude them from this heuristic's scope (it suggests affinity for the
+    # original canon's unassigned species) -- same anti-self-poisoning spirit as the
+    # D4-provenance filter in train_trait_biome.
+    return [s for s in data["catalog"] if s.get("source") != "gameplay-promote"]
 
 
 def split_by_biome_affinity(species: list):


### PR DESCRIPTION
## Wave 3 -- CANON-RECONCILE: unify gameplay creatures into the canon bestiary (Option 1)

Resolves **TKT-SPECIE-CANON-RECONCILE** (Wave 3). Master-dd decision: **Option 1 -- unify**
the two near-disjoint bestiaries into a single canon.

### Audit finding (ground-truth, corrected the plan)
The plan's "85 species vs 53 SoT" was a false framing. The 85 pack files are:
**38 `*-trait-keeper`** (not species) + **4 `evento-*`** (events) + **43 real creatures**.
Real comparison = **43 gameplay creatures vs 53 canon** -- naming worlds nearly disjoint
(only `dune_stalker` overlapped). Also corrected: "32 species missing biome_affinity" is
**stale** -- 53/53 already have it.

### What this PR does (Strato 1 -- structure)
`tools/etl/promote_gameplay_to_canon.py` promotes the multi-species gameplay biomes'
creatures into `species_catalog.json` as **structural stubs** (`source=gameplay-promote`,
`_promote_stub` flagged), design-rich fields left as flagged TODO.

| biome | promoted |
|-------|----------|
| badlands | 7 |
| cryosteppe | 6 |
| deserto_caldo | 4 |
| foresta_temperata | 5 |
| **total** | **22** |

Catalog **53 -> 75**. The original 53-species canon is **untouched** (test-enforced).

**Excluded by design**: `rovine_planari` (10, D6 new-content gate), `tutorial` generics
(scenario role-placeholders, not species), thin single-creature biomes (YAGNI).

**Strato 2 (NOT this PR)**: incremental authoring of the design prose
(scientific_name, descriptions, interactions, lifecycle) per biome. Findable via
`source == 'gameplay-promote'`. Delegatable to writer/swarm.

### Checks (all green)
- `envelope-b-data-integrity.test.js` updated (75; base-53 invariant; 22 `_promote_stub`;
  allow `gameplay-promote` null lifecycle).
- Catalog-consumer sweep: **JS 112/112** + **python 64/64**.
- D4 regression fixed: `suggest_biome_affinity.load_catalog` excludes `gameplay-promote`
  (stubs aren't editorial ground truth -- anti-self-poisoning). suggest 20/20, apply 26/26.

Full audit + decision rationale: `docs/planning/2026-05-30-canon-reconcile-audit.md`.

Coding-Agent: claude-opus-4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
