### PR TITLE
feat(governance): auto-project OPEN_DECISIONS Aperte from per-OD inline status [follow-up #2489]

### DIFF
--- a/.github/workflows/docs-governance.yml
+++ b/.github/workflows/docs-governance.yml
@@ -43,6 +43,10 @@ jobs:
         id: decisions_log_sync
         run: python tools/generate_decisions_log.py --check
 
+      - name: Open decisions auto-sync (required -- fail-on-diff, anti-drift #19)
+        id: open_decisions_sync
+        run: python tools/generate_open_decisions.py --check
+
       - name: Docs link integrity (warning-only)
         id: link_check
         continue-on-error: true

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -54,3 +54,13 @@ if git diff --cached --name-only | grep -qE "^docs/adr/ADR-.*\.md$"; then
       || echo "[pre-commit] WARN decisions-log regen failed -- run tools/generate_decisions_log.py"
   fi
 fi
+
+# 2026-05-31 -- OPEN_DECISIONS auto-sync (anti-drift #19, follow-up #2489). If
+# OPEN_DECISIONS.md is staged, regenerate the "Aperte" index so it never drifts.
+# Non-blocking (CI `--check` = hard gate).
+if git diff --cached --name-only | grep -qE "^OPEN_DECISIONS\.md$"; then
+  if command -v python >/dev/null 2>&1; then
+    python tools/generate_open_decisions.py && git add OPEN_DECISIONS.md \
+      || echo "[pre-commit] WARN open-decisions regen failed -- run tools/generate_open_decisions.py"
+  fi
+fi

--- a/OPEN_DECISIONS.md
+++ b/OPEN_DECISIONS.md
@@ -7,9 +7,25 @@
 
 ---
 
+<!-- HOWTO: aprire un OD = nuova sezione `### [OD-NNN] …` + comment `<!-- od id=OD-NNN status=open -->`. chiudere = aggiungi ✅ all'heading E `status=resolved resolved_by="…"` nel comment, poi `python tools/generate_open_decisions.py` (o lascia fare al pre-commit husky). Lo stato canonico machine e' nel comment, NON nell'heading. -->
+
 ## Aperte
 
+<!-- gen:od-open -->
+
+_Generato da `tools/generate_open_decisions.py`. NON editare a mano: edita i comment `<!-- od … -->` di ogni sezione e rigenera._
+
+| OD                                                                                                            | Titolo                         | Livello                                        | Ref      |
+| ------------------------------------------------------------------------------------------------------------- | ------------------------------ | ---------------------------------------------- | -------- |
+| [OD-023](#od-023-phase-b-execution-date-verdict--day-5-anticipato-vs-day-8-canonical-vs-adr-amendment-path-d) | Phase B execution date verdict | workflow + ADR contract gate (date-discipline) | ADR-0021 |
+
+<!-- /gen:od-open -->
+
+> _Le sezioni dettagliate sotto includono anche decisioni risolte/archiviate; lo stato canonico e' nel comment `<!-- od -->` di ogni sezione — la lista sopra e' la proiezione delle sole `open`._
+
 ### [OD-032] hardcore_06 secondary band — blocker strutturale + design fork ✅ RISOLTA A+C 2026-05-21
+
+<!-- od id=OD-032 status=resolved resolved_by="RISOLTA A+C 2026-05-21" -->
 
 > **Verdict master-dd 2026-05-21: A+C.** A = banda canonica rivista alla realtà engine (N=40 evidence). C = enemy_damage knob wired per hc06 (capability per futuro timer-off path). Shipped:
 >
@@ -41,6 +57,8 @@
 
 ### [OD-024..031] ai-station ecosystem audit verdicts — ✅ 8/8 SHIPPED cross-stack 2026-05-14
 
+<!-- od id=OD-024..031 status=resolved resolved_by="8/8 SHIPPED cross-stack 2026-05-14" -->
+
 8 OD originati da PR #2260 ecosystem audit + ai-station re-analisi vault PR #5. Master-dd direction "finish work, not conservative". Tutti shipped via Envelope A+B+C cascade ~26h cross-stack.
 
 | OD  | Topic                            | Verdict ai-station                                   | Channel shipped                                        |
@@ -70,6 +88,8 @@
 
 ### [OD-023] Phase B execution date verdict — Day 5 anticipato vs Day 8 canonical vs ADR amendment Path D
 
+<!-- od id=OD-023 status=open -->
+
 - **Livello**: workflow + ADR contract gate (date-discipline)
 - **Stato**: **APERTA 2026-05-12** — user trigger phrase exact match pre-stage doc §5 invocata Day 5/8 (2026-05-12) invece target Day 7 (2026-05-14). Richiesto parere OOA + ai-station methods.
 - **Ambiguità**: 3 path scoring (3-agent OOA parallel):
@@ -85,6 +105,8 @@
 
 ### [OD-017] Phase B trigger 2/3 — Option α full social vs β solo hardware vs γ synthetic only ✅ RISOLTA 2026-05-08 (DOWNGRADE nice-to-have)
 
+<!-- od id=OD-017 status=resolved resolved_by="RISOLTA 2026-05-08 (DOWNGRADE nice-to-have)" -->
+
 - **Livello**: workflow + ADR contract gate
 - **Stato**: **risolta 2026-05-08** — master-dd verdict explicit "Phase B trigger 2/3 NON è hard gate, diventa nice-to-have. Probabilmente weekend se launcher 1-2 click usability OK."
 - **Verdict**: Phase B trigger condition §5 ADR-2026-05-05 **AMENDED** → trigger originale 4 conditions → 2 hard (Phase A 7gg grace + 0 critical regression) + 1 nice-to-have (4-amici social playtest). Phase B archive web v1 formal POST 2026-05-14 + zero-regression confirmed = automatic accept. Master-dd 4-amici weekend = supplement, NOT blocker.
@@ -94,6 +116,8 @@
 - **Source ref**: [ADR-2026-05-05 §5](docs/adr/ADR-2026-05-05-cutover-godot-v2-fase-3-formal.md) AMENDMENT 2026-05-08 + [docs/playtest/2026-05-08-phase-b-synthetic-supplement-iter1.md](docs/playtest/2026-05-08-phase-b-synthetic-supplement-iter1.md).
 
 ### [OD-017-original-archive] Phase B trigger 2/3 (PRE-AMENDMENT)
+
+<!-- od id=OD-017-original-archive status=archived -->
 
 - **Ambiguità**: ADR-2026-05-05 §5 trigger 2/3 require "1+ playtest pass post-cutover (4 amici + master-dd, full combat scenario)". Master-dd silenzioso Day 2/7. Window 7gg termina 2026-05-14. Tre path:
   - **Option α canonical** (4 amici Discord/WhatsApp + master-dd, ~1-2h userland, satisfies trigger ✅)
@@ -106,6 +130,8 @@
 - **Source ref**: [ADR-2026-05-05 §5](docs/adr/ADR-2026-05-05-cutover-godot-v2-fase-3-formal.md), [PR #2112](https://github.com/MasterDD-L34D/Game/pull/2112), [docs/playtest/2026-05-08-phase-b-synthetic-supplement-iter1.md](docs/playtest/2026-05-08-phase-b-synthetic-supplement-iter1.md), [docs/playtest/2026-05-07-master-dd-validation-10min-checklist.md](docs/playtest/2026-05-07-master-dd-validation-10min-checklist.md).
 
 ### [OD-018] Tier 2 PlayGodot integration — kill-60 verdict accept/reject ✅ RISOLTA 2026-05-08 (OVERRIDE keep both)
+
+<!-- od id=OD-018 status=resolved resolved_by="RISOLTA 2026-05-08 (OVERRIDE keep both)" -->
 
 - **Livello**: workflow (test infra)
 - **Stato**: **risolta 2026-05-08** — master-dd verdict explicit "no, vogliamo mantenere anche PlayGodot+GodotTestDriver. Lo avevamo scelto per un motivo. Servono per i test."
@@ -121,6 +147,8 @@
 
 ### [OD-018-original-archive] Tier 2 PlayGodot kill-60 verdict (PRE-OVERRIDE)
 
+<!-- od id=OD-018-original-archive status=archived -->
+
 - **Ambiguità**: handoff `docs/playtest/AGENT_DRIVEN_WORKFLOW.md` §"Adoption roadmap" lista PlayGodot Tier 2 ~5h post Phase A. Research PR #2110 reveal stima 5h era WRONG. Reality:
   - PlayGodot ~20-40h (custom Godot fork build + scons C++ + 2-platform maintenance)
   - GodotTestDriver ~10-15h (C# stack mismatch GDScript)
@@ -133,6 +161,8 @@
 
 ### [OD-019] Skiv Monitor scheduled fail fix — Option A repo toggle vs B/C/D workflow edit ✅ RISOLTA 2026-05-08 (Option A confirmed)
 
+<!-- od id=OD-019 status=resolved resolved_by="RISOLTA 2026-05-08 (Option A confirmed)" -->
+
 - **Livello**: ops (CI cosmetic)
 - **Stato**: **risolta 2026-05-08** — master-dd verdict explicit "A 1-click. Forensic puro repo setting toggle off post-data."
 - **Verdict**: **Option A repo setting toggle**. Master-dd manual action: Settings → Actions → General → Workflow permissions → check "Allow GitHub Actions to create and approve pull requests". 30s 1-click. Restore pre-2026-04-25 verde state. NON Claude action (repo settings = userland).
@@ -140,6 +170,8 @@
 - **Source ref**: [docs/reports/2026-05-08-skiv-monitor-rca.md](docs/reports/2026-05-08-skiv-monitor-rca.md) + master-dd verdict 2026-05-08.
 
 ### [OD-019-original-archive] Skiv Monitor fix (PRE-VERDICT)
+
+<!-- od id=OD-019-original-archive status=archived -->
 
 - **Ambiguità**: workflow `Skiv Monitor` 30/30 last runs failure (~12 days, post 2026-04-25 ultimo successo PR auto #1836). Root cause: `gh pr create` exit 1 perm denied. Branch `auto/skiv-monitor-update` push OK. 4 fix path:
   - **Option A** repo setting toggle (Settings → Actions → "Allow GitHub Actions to create PRs", 30s 1-click, 🟢 LOW risk)
@@ -153,6 +185,8 @@
 - **Source ref**: [docs/reports/2026-05-08-skiv-monitor-rca.md](docs/reports/2026-05-08-skiv-monitor-rca.md).
 
 ### [OD-020] Sprint Q+ pre-kickoff scope freeze — 5 sub-decisione ✅ RISOLTA 2026-05-08 (FULL deep scope)
+
+<!-- od id=OD-020 status=resolved resolved_by="RISOLTA 2026-05-08 (FULL deep scope)" -->
 
 - **Livello**: game (cross-stack ETL)
 - **Stato**: **risolta 2026-05-08** — master-dd verdict explicit "se intuisco bene mi chiedi se insistere sullo Sprint Q. Sì vogliamo insistere a farlo tutto approfonditamente."
@@ -172,6 +206,8 @@
 
 ### [OD-020-original-archive] Sprint Q+ scope freeze (PRE-VERDICT)
 
+<!-- od id=OD-020-original-archive status=archived -->
+
 - **Ambiguità**: Sprint Q+ LineageMergeService ETL chiusura GAP-12 audit godot-surface-coverage. 14-17h effort total. 5 sub-decisione master-dd richieste pre-kickoff:
   - **Q-1** Schema contract `lineage_ritual.schema.json` review obbligatorio (forbidden path `packages/contracts/`)
   - **Q-2** Prisma migration `Offspring { id, parent_a_id, parent_b_id, mutations, born_at, lineage_id }` master-dd manual approve (forbidden path `migrations/`)
@@ -185,6 +221,8 @@
 - **Source ref**: [docs/planning/2026-05-08-sprint-q-lineage-merge-etl-scoping.md](docs/planning/2026-05-08-sprint-q-lineage-merge-etl-scoping.md).
 
 ### [OD-021] Continuous synthetic monitoring Day 3-7 — confirm/reject Claude autonomous schedule ✅ RISOLTA 2026-05-08 (Option C ridotto)
+
+<!-- od id=OD-021 status=resolved resolved_by="RISOLTA 2026-05-08 (Option C ridotto)" -->
 
 - **Livello**: workflow
 - **Stato**: **risolta 2026-05-08** — master-dd verdict explicit "C" (modify cadence ridotto Day 3+5+7 only).
@@ -201,6 +239,8 @@
 - **Source ref**: [PR #2112 §7](https://github.com/MasterDD-L34D/Game/pull/2112) + master-dd verdict 2026-05-08.
 
 ### [OD-022] evo-swarm pipeline cross-verification gate pre run #6 ✅ IMPLICIT ACCEPT 2026-05-08 sera (cross-repo evidence convergente)
+
+<!-- od id=OD-022 status=resolved resolved_by="IMPLICIT ACCEPT 2026-05-08 sera (cross-repo evidence convergente)" -->
 
 - **Livello**: workflow + pipeline contract (Atto 2 Scenario A "Integration drive")
 - **Trigger**: post merge PR #2108 `1cfd7220` (run #5 distillation honesty pass — 7/13 swarm claims hallucinated vs canonical Game).
@@ -226,6 +266,8 @@
 
 ### [OD-021-original-archive] Continuous monitoring schedule (PRE-VERDICT)
 
+<!-- od id=OD-021-original-archive status=archived -->
+
 - **Ambiguità**: PR #2112 Phase B synthetic supplement propone schedule Day 3-7 monitoring window: Claude rerun Tier 1 phone smoke harness ~5min/giorno per regression detection autonomous. Total ~25-30min cumulative cycle 7gg. Master-dd burden invariato.
 - **Perché conta**: regression detection earlier vs Day 7 master-dd verdict. Synthetic supplement evidence growing dataset pre-Phase-B-trigger. Zero-cost Claude vs ZERO master-dd action.
 - **Miglior default proposto**: **CONFIRM schedule**. Cadence proposta:
@@ -241,6 +283,8 @@
 
 ### [OD-014] P6 Fairness ammortizer — Tactics Ogre rewind/WORLD-Chariot pattern ✅ RISOLTA 2026-05-11 (IMPLEMENT ORA ACCEPTED-IMPL-SCOPED)
 
+<!-- od id=OD-014 status=resolved resolved_by="RISOLTA 2026-05-11 (IMPLEMENT ORA ACCEPTED-IMPL-SCOPED)" -->
+
 - **Livello**: game (combat fairness + anti-frustration ammortizer)
 - **Stato**: **risolta 2026-05-11** — master-dd verdict batch 11-decisioni explicit ACCEPT implement ora (~5-7h) NON deferred post-playtest.
 - **Verdict**: **IMPLEMENT ORA come safety valve player**. NON gate su playtest feedback. Rewind N times per battle + snapshot state pre-action.
@@ -251,6 +295,8 @@
 
 ### [OD-015] P2 Macro-loop campaign — Brigandine seasonal Organization Phase pattern ✅ RISOLTA 2026-05-11 (PROMUOVI priorità M14 ACCEPTED-SCOPED)
 
+<!-- od id=OD-015 status=resolved resolved_by="RISOLTA 2026-05-11 (PROMUOVI priorità M14 ACCEPTED-SCOPED)" -->
+
 - **Livello**: game (P2 evoluzione macro-loop campaign-wide)
 - **Stato**: **risolta 2026-05-11** — master-dd verdict batch 11-decisioni explicit PROMUOVI priorità M12+ → M14.
 - **Verdict**: **PROMUOVI priorità M14**. NON M12+ post-playtest deferred. Brigandine seasonal Organization Phase + Battle Phase 5-10 stagioni meta-loop scoped M14.
@@ -260,6 +306,8 @@
 - **Source ref**: master-dd verdict batch 2026-05-11 (A4 promotion grant) + F1+F2 §"Brigandine" + ADR-2026-04-28-deep-research-actions §5 + scope ticket bundle.
 
 ### [OD-001] V3 Mating/Nido — scope e timing ✅ FULL CLOSURE 2026-04-27 notte
+
+<!-- od id=OD-001 status=resolved resolved_by="FULL CLOSURE 2026-04-27 notte" -->
 
 - **Livello**: game + system
 - **Stato**: **FULL CLOSURE 2026-04-27 notte** — verdict user **Path A** confermato + PR #1877 superseded chiuso definitivamente. Sprint Nido Path A 4/4 SHIPPED end-to-end + UI Mating tab via combo:
@@ -292,6 +340,8 @@
 
 ### [OD-002] V6 UI TV dashboard polish — priorità vs playtest feedback ✅ RISOLTA 2026-05-11 (ACCEPT proattivo ORA)
 
+<!-- od id=OD-002 status=resolved resolved_by="RISOLTA 2026-05-11 (ACCEPT proattivo ORA)" -->
+
 - **Livello**: repo (frontend UI)
 - **Stato**: **risolta 2026-05-11** — master-dd verdict batch 11-decisioni explicit ACCEPT proattivo ora (~3-5h).
 - **Verdict**: **ACCEPT proattivo ORA**. NON deferred post-playtest. Polish iterativo + screenshot before/after senza dipendere da TKT-M11B-06.
@@ -302,6 +352,8 @@
 
 ### [OD-003] Triangle Strategy rollout sequence — M14-A/B vs M15 priorità ✅ RISOLTA 2026-05-11 (sequenza M14-A → M14-B → M15 ACCEPTED)
 
+<!-- od id=OD-003 status=resolved resolved_by="RISOLTA 2026-05-11 (sequenza M14-A → M14-B → M15 ACCEPTED)" -->
+
 - **Livello**: game + system
 - **Stato**: **risolta 2026-05-11** — master-dd verdict batch 11-decisioni explicit ACCEPT sequenza M14-A → M14-B → M15.
 - **Verdict**: **sequenza M14-A → M14-B → M15**. Non parallelizzata. 3 ticket scoped, NOT impl this session.
@@ -311,6 +363,8 @@
 - **Source ref**: master-dd verdict batch 2026-05-11 (A2 grant) + scope ticket bundle.
 
 ### [OD-004] Game-Database HTTP runtime Alt B — quando attivare ✅ RISOLTA 2026-05-11 (status quo flag-OFF confermato)
+
+<!-- od id=OD-004 status=resolved resolved_by="RISOLTA 2026-05-11 (status quo flag-OFF confermato)" -->
 
 - **Livello**: system + repo
 - **Stato**: **risolta 2026-05-11** — master-dd verdict batch 11-decisioni explicit status quo flag-OFF.
@@ -323,6 +377,8 @@
 
 ### [OD-005] Integrazione `Game Balance & Economy Tuning` skill (mcpmarket) ✅ RISOLTA 2026-05-11 (install ORA ACCEPTED)
 
+<!-- od id=OD-005 status=resolved resolved_by="RISOLTA 2026-05-11 (install ORA ACCEPTED)" -->
+
 - **Livello**: workflow
 - **Stato**: **risolta 2026-05-11** — master-dd verdict batch 11-decisioni explicit ACCEPT install proattivo ora (~30min).
 - **Verdict**: **install ORA** (NON deferred post-playtest). Test-driven adoption su `docs/playtest/*-calibration.md` raccolti + dataset balance esistenti.
@@ -332,6 +388,8 @@
 - **Source ref**: master-dd verdict batch 2026-05-11 (C6 grant) + scope ticket bundle.
 
 ### [OD-008] Sentience index backfill scope ✅ RISOLTA 2026-04-25 → ⚠️ OVERRIDE 2026-04-25 sera
+
+<!-- od id=OD-008 status=resolved resolved_by="RISOLTA 2026-04-25 → ⚠️ OVERRIDE 2026-04-25 sera" -->
 
 - **Livello**: game + system
 - **Stato**: **OVERRIDE 2026-04-25 sera (user re-decisione)** — sostituisce verdict Opzione B precedente
@@ -354,6 +412,8 @@
 
 ### [OD-009] Ennea source canonical — `data/core/personality/` vs `packs/evo_tactics_pack/...` ✅ RISOLTA confermata 2026-04-25
 
+<!-- od id=OD-009 status=resolved resolved_by="RISOLTA confermata 2026-04-25" -->
+
 - **Livello**: system + repo
 - **Stato**: **risolta 2026-04-25 (user OK)** — vedi card M-2026-04-25-002 + M-2026-04-25-003
 - **Verdict confermato**: **Option 3 hybrid** (entrambi mantenuti):
@@ -371,6 +431,8 @@
 - **Ref**: card [M-2026-04-25-002](docs/museum/cards/enneagramma-mechanics-registry.md), [M-2026-04-25-003](docs/museum/cards/enneagramma-dataset-9-types.md), gallery [galleries/enneagramma.md](docs/museum/galleries/enneagramma.md).
 
 ### [OD-010] Skiv voice palette default — Type 5 vs Type 7 ✅ RISOLTA confermata 2026-04-25
+
+<!-- od id=OD-010 status=resolved resolved_by="RISOLTA confermata 2026-04-25" -->
 
 - **Livello**: game + narrative
 - **Stato**: **risolta 2026-04-25 (user OK)** — skip-decision via A/B test data-driven
@@ -394,6 +456,8 @@
 
 ### [OD-011] Ancestors recovery scope ✅ RISOLTA 2026-04-25 → ⚠️ OVERRIDE 2026-04-25 sera
 
+<!-- od id=OD-011 status=resolved resolved_by="RISOLTA 2026-04-25 → ⚠️ OVERRIDE 2026-04-25 sera" -->
+
 - **Livello**: game + system
 - **Stato**: **OVERRIDE 2026-04-25 sera (user re-decisione)** — full scope upgrade da Path A solo a Path A + Path B insieme
 - **Verdict NEW**: **Opzione A FULL — recovery completo ~15-20h**:
@@ -415,6 +479,8 @@
 
 ### [OD-013] MBTI surface presentation — phased reveal vs accrual silenzioso vs full upfront ✅ RISOLTA Path A+B 2026-04-26
 
+<!-- od id=OD-013 status=resolved resolved_by="RISOLTA Path A+B 2026-04-26" -->
+
 - **Livello**: game + system
 - **Stato**: **RISOLTA 2026-04-26** — verdict user A+B entrambi shipped. **Path A** branch `feat/d1a-mbti-phased-reveal` (PR #1848 merged): `mbtiSurface.js` helper + `/vc` + `/pf` extension `mbti_revealed` + `debriefPanel` `#db-mbti-section` UI + 12/12 test. Threshold 0.7 default (env `MBTI_REVEAL_THRESHOLD` A/B). **Path B** branch `feat/d1b-mbti-dialogue-color-codes`: palette canonical 8 colori in `data/core/personality/mbti_axis_palette.yaml` (WCAG AA ≥5.02:1) + `mbtiPalette.js` (loader/lookup/tag/contrast helpers) + `dialogueRender.js` (DOM-free renderer reveal-gated compose Path A) + CSS axis classes con hover tooltip + print-safe + 26/26 test. P4 🟡 → 🟡++ (Path A+B both shipped; integration narrativeEngine + render.js pendente). Card M-009 reuse_path completato.
 - **Stato precedente**: proposta 2026-04-25 (museum card [M-2026-04-25-009 Triangle Strategy](docs/museum/cards/personality-triangle-strategy-transfer.md) trigger)
@@ -430,6 +496,8 @@
 - **Ref**: card [M-2026-04-25-009 Triangle Strategy MBTI Transfer](docs/museum/cards/personality-triangle-strategy-transfer.md), gallery [galleries/enneagramma.md](docs/museum/galleries/enneagramma.md), source [docs/research/triangle-strategy-transfer-plan.md](docs/research/triangle-strategy-transfer-plan.md).
 
 ### [OD-012] Swarm trait integration scope ✅ RISOLTA 2026-04-25 → ⚠️ OVERRIDE 2026-04-25 sera
+
+<!-- od id=OD-012 status=resolved resolved_by="RISOLTA 2026-04-25 → ⚠️ OVERRIDE 2026-04-25 sera" -->
 
 - **Livello**: game + system
 - **Stato**: **OVERRIDE 2026-04-25 sera (user re-decisione)** — sostituisce single-shot con batch
@@ -453,6 +521,8 @@
 
 ### [OD-016] Midnight Suns 3-card-plays + Heroism economy — design precedent thoughts ritual (citation-only) ✅ RISOLTA 2026-04-28
 
+<!-- od id=OD-016 status=resolved resolved_by="RISOLTA 2026-04-28" -->
+
 - **Livello**: game (P4 MBTI thoughts ritual UI design audit strength)
 - **Stato**: ✅ closure citation 2026-04-28 (Action 8 P3) — moved Aperte → Risolte 2026-05-08 sera (audit cleanup misplace)
 - **Ambiguità**: thoughts ritual G3 (PR #1983) usa pattern 3-card-style (3 candidati + 30s timer + irreversible) — research valida questo è Midnight Suns Hero Combo unlock-by-relationship design precedent. NO design change needed.
@@ -460,6 +530,8 @@
 - **Source ref**: F1 §"Midnight Suns" + F2 §"Midnight Suns" + ADR-2026-04-28-deep-research-actions §5 citations + PR #1983 G3 Skiv thoughts ritual choice UI shipped 2026-04-27/28.
 
 ### [OD-006] Master orchestrator prompt — adottare o no? ✅ RISOLTA
+
+<!-- od id=OD-006 status=resolved resolved_by="RISOLTA" -->
 
 - **Livello**: workflow
 - **Stato**: **risolta 2026-04-24**
@@ -472,6 +544,8 @@
 - **Ref**: audit readiness section C.5.
 
 ### [OD-007] Sprint 3 archivio — chiudere o deferrere? ✅ RISOLTA
+
+<!-- od id=OD-007 status=resolved resolved_by="RISOLTA" -->
 
 - **Livello**: workflow
 - **Stato**: **risolta 2026-04-24** (questa sessione)

--- a/docs/superpowers/specs/2026-05-31-open-decisions-projection-design.md
+++ b/docs/superpowers/specs/2026-05-31-open-decisions-projection-design.md
@@ -1,0 +1,238 @@
+---
+title: "OPEN_DECISIONS auto-projection — schema-migration + derive-don't-maintain (follow-up #2489)"
+workstream: ops-qa
+category: spec
+doc_status: active
+doc_owner: claude-code
+last_verified: '2026-05-31'
+source_of_truth: false
+language: it
+review_cycle_days: 60
+tags: [governance, auto-sync, anti-drift, open-decisions, schema-migration, projection, ci]
+---
+
+# OPEN_DECISIONS auto-projection — design
+
+> Follow-up 1 di #2489 (harsh-review P1-1 DEFERRED: "schema prosa-loose, serve schema-migration
+> spec propria"). Stesso root-cause anti-pattern #19: la lista "Aperte" e' hand-maintained →
+> drifta. Metodo: research-lite → questo spec → harsh-review SDMG falsify → build → QG. Pattern di
+> riferimento: `tools/generate_decisions_log.py` (#2489).
+
+## Harsh-review adottato (critic 4-pass, 2026-05-31 — "se rigetta adotto, non difendo")
+
+VERDICT critic = ACCEPT-WITH-FIXES (6 must-fix). Tutti adottati in questa rev:
+
+1. **Ground-truth riderivata dal file reale** (EMPIRICA-1, era materialmente sbagliata): NON 30
+   sotto Aperte ma **27** (i 3 OD-016/006/007 sono sotto `## Risolte`); NON 1 solo no-✅ ma **6**
+   (OD-023 + 5 `-original-archive`). Tabella sotto = misurata, non asserita.
+2. **R2 era inerte → demoted + riparato** (LOGICA-1/Pri-2): il drift-killer e' la **proiezione +
+   R1 fail-on-diff**, NON R2. R2 riscritto per leggere `governed_by` sulle entry `open` (non
+   `resolved_by`, che le open non hanno mai), tier WARN, false-positive-safe.
+3. **Regola migrazione = 3-way ordinata in UN posto** + R6 (archive⟺archived) + **doppia-copia
+   risolta**: il comment e' l'unica sorgente machine; l'heading `✅` e' decorazione NON letta dal
+   generatore (Pri-3, Alt-Persp-2).
+4. **Parse delimitato** alla prossima `### [OD-`; `—` se Livello/ref assenti (OD-032 + OD-024..031
+   non hanno `- **Livello**:`) (LOGICA-3).
+5. **NIENTE reorg strutturale**: blocco generato iniettato in cima a `## Aperte`, `## Risolte`
+   intatta, comment in-place (Alt-Persp-1, churn minimo come precedente DECISIONS_LOG).
+6. **Prettier resta ON** su OPEN_DECISIONS.md: blocco generato reso prettier-stabile + `prettier
+--check` in QG; `.prettierignore` solo fallback se il blocco si dimostra instabile (VALORI-1).
+   - HOWTO contributor + husky auto-regen (VALORI-2).
+
+## Ground-truth (MISURATO su file reale 2026-05-31 — `python` parse, non asserito)
+
+| Fatto                                     | Valore                                                         |
+| ----------------------------------------- | -------------------------------------------------------------- |
+| Heading OD totali (`### [OD-`)            | 30                                                             |
+| sotto `## Aperte` (L10–451)               | **27**                                                         |
+| sotto `## Risolte` (L452+)                | 3 (OD-016, OD-006, OD-007 — tutti `✅`)                        |
+| no-`✅` sotto Aperte                      | **6** = OD-023 + 5 `-original-archive`                         |
+| con `✅` (tutti i 30)                     | 24                                                             |
+| `-original-archive` (storici PRE-VERDICT) | 5 (OD-017/018/019/020/021-original-archive)                    |
+| range entry                               | OD-024..031 (8 OD in un heading, `✅ 8/8 SHIPPED`)             |
+| status encoding oggi                      | **prosa libera nell'heading** (`✅ RISOLTA …`) — non parsabile |
+| `docs/governance/open-decisions/`         | 2 soli file archivio, NON per-OD                               |
+
+**Esito regola di migrazione 3-way ordinata** (archive → `✅`-resolved → open) sui 30:
+**24 resolved + 5 archived + 1 open (OD-023)**. (La regola NAIVE solo-`✅` darebbe 6 open: i 5
+archive non hanno `✅` → e' per questo che `archive` deve venire PRIMA.) Lista "Aperte" generata
+post-migrazione = **1 riga (OD-023)** vs 27 sezioni stale oggi.
+
+**Conseguenza design**: NON esiste un per-OD file (come gli ADR per DECISIONS_LOG) → il
+source-of-truth machine deve vivere **inline** in `OPEN_DECISIONS.md`.
+
+## Principio (eredita #2489): DERIVE don't MAINTAIN
+
+La lista "Aperte" diventa un **artefatto generato** (proiezione del campo machine per-OD), guardata
+da CI **fail-on-diff**. Marker-injection: prosa hand FUORI dai marker, indice generato DENTRO.
+
+## Drift-killer = proiezione + R1 (NON R2)
+
+Il drift osservato (27 sezioni risolte ancora sotto "Aperte") e' ucciso dalla **proiezione stessa**:
+una sezione con `status=resolved` nel suo comment e' automaticamente esclusa dall'indice generato →
+**non puoi piu' lasciarla "in Aperte"**, perche' "Aperte" e' generato e R1 fail-on-diff impedisce
+edit manuali della lista. R2 (sotto) e' un check semantico SECONDARIO opzionale, non il meccanismo
+principale. (Nota onesta cost/benefit: l'open-set oggi e' minuscolo (1); il valore non e' gestire
+volume ma **prevenire la ricomparsa del 27-stale** — anti-pattern #19.)
+
+## Decisione architetturale (la crux)
+
+- **A — sidecar registry**: duplica i metadati → **stesso 2-copy-drift che combattiamo**. RIGETTATA.
+- **B — file per-OD**: non esiste (solo 2 archivio); 30+ file nuovi = churn enorme. RIGETTATA.
+- **C — comment HTML inline per sezione** (SCELTA): single-source co-locato, zero file nuovi, render
+  invariato, parsing banale, coerente con marker-injection. **Il comment e' l'UNICA sorgente machine.**
+
+### Schema (lo "small schema" richiesto)
+
+Un commento HTML per sezione OD, subito sotto l'heading:
+
+```
+<!-- od id=OD-023 status=open governed_by="ADR-2026-05-05" -->
+<!-- od id=OD-032 status=resolved resolved_by="master-dd 2026-05-21 (A+C)" -->
+<!-- od id=OD-017-original-archive status=archived -->
+```
+
+| Campo         | Obbligo                        | Forma                                                                                 |
+| ------------- | ------------------------------ | ------------------------------------------------------------------------------------- |
+| `id`          | sempre                         | `OD-NNN`; range verbatim (`OD-024..031`); `-original-archive` per storici             |
+| `status`      | sempre                         | `open` \| `resolved` \| `archived`                                                    |
+| `resolved_by` | richiesto se `status=resolved` | testo libero (puo' contenere `ADR-…`/`PR #…`)                                         |
+| `governed_by` | **opzionale, solo `open`**     | `ADR-NNN` dell'ADR che, se accepted, _risolverebbe_ l'OD (≠ ADR citato come contesto) |
+
+`archived` = i 5 companion storici (esclusi da proiezione + check semantici, ma **renderizzati
+verbatim nel body** — zero info-lost, audit trail preservato).
+
+### Doppia-copia status (comment vs heading `✅`) — risolta
+
+Il **comment e' l'unica sorgente letta dal generatore**. L'heading `✅` resta come decorazione
+umana a colpo d'occhio, **NON letta**. Niente 2ª sorgente che guida l'output → niente 2-copy-drift
+sul dato che conta. Un check di sola coerenza cosmetica (R5, WARN) segnala se divergono, ma **non
+incide sull'indice** (per questo WARN, non ERROR: una divergenza heading/comment e' cosmetica e
+l'unico drift che conta — la lista Aperte — e' gia blindato da R1). Divergenza deliberata dal
+suggerimento critic "R5=ERROR": un ERROR costringerebbe doppio-edit-o-CI-rossa (VALORI-2 friction)
+per un dato non load-bearing; risolto a favore di minor attrito + husky auto-regen.
+
+## Struttura file post-migrazione (churn minimo — NO reorg)
+
+Adotta Alt-Persp-1: **nessuna sezione spostata**. Solo:
+
+1. Inietta il blocco generato subito dopo l'heading `## Aperte` (prima della prima `### [OD-`):
+
+```
+## Aperte
+
+<!-- gen:od-open -->
+_Generato da `tools/generate_open_decisions.py`. NON editare a mano: edita i comment `<!-- od … -->` e rigenera._
+| OD | Titolo | Livello | Ref |
+| --- | --- | --- | --- |
+| [OD-023](#od-023-…) | Phase B execution date verdict | workflow | ADR-2026-05-05 §5 |
+<!-- /gen:od-open -->
+
+> _Le sezioni dettagliate sotto includono anche decisioni risolte/archiviate; lo stato canonico e' nel comment `<!-- od -->` di ogni sezione — la lista sopra e' la proiezione delle sole `open`._
+
+### [OD-032] … ✅ RISOLTA …
+<!-- od id=OD-032 status=resolved resolved_by="master-dd 2026-05-21 (A+C)" -->
+… prosa hand invariata …
+```
+
+2. Inietta `<!-- od … -->` sotto ciascuna delle 30 heading (27 Aperte + 3 Risolte).
+3. `## Risolte`, `## Regola pratica`, `## Ref` **invariate**. La prosa NON viene riscritta.
+
+Diff = 30 comment + 1 blocco + 1 nota + 1 HOWTO. Mechanical, low-churn (come inject DECISIONS_LOG
+sotto `## Index per data`, `generate_decisions_log.py:141-148`).
+
+### HOWTO contributor (iniettato in cima al file)
+
+```
+<!-- HOWTO: aprire un OD = nuova sezione ### [OD-NNN] + comment <!-- od id=OD-NNN status=open -->.
+     chiudere = aggiungi ✅ all'heading E status=resolved resolved_by="..." nel comment, poi
+     `python tools/generate_open_decisions.py` (o lascia fare al pre-commit husky). -->
+```
+
+## Generatore — contratto (`tools/generate_open_decisions.py`)
+
+Mirror di `generate_decisions_log.py`:
+
+- Read `utf-8-sig`. Per ogni `<!-- od … -->`: associa l'heading `### [OD-…]` immediatamente sopra
+  (titolo) + parse campi del comment.
+- **"Sezione" delimitata** dal comment fino alla prossima `### [OD-` (LOGICA-3): Livello = primo
+  `- **Livello**:` in-bound, else `—`; Ref = primo `ADR-…`/`PR #…` in-bound o in `resolved_by`/
+  `governed_by`, else `—`. **Mai** oltre il confine.
+- Proiezione = righe `status=open`, sort per intero `OD-(\d+)` asc (range/suffix dopo).
+- Inietta tra `<!-- gen:od-open -->` … `<!-- /gen:od-open -->`. Prosa fuori-marker verbatim.
+- Deterministico (sort stabile) + idempotente (2 run identici).
+- `--check`: exit 1 se out-of-sync. Default: riscrive in place.
+- **Riuso**: importa `adr_status` + `STATUS_MAP` da `generate_decisions_log.py` (no duplicazione).
+  Stdlib only (`re`/`pathlib`/`argparse`) — **niente nuove dipendenze**.
+
+## Check — regole falsificabili
+
+- **R1 fail-on-diff** (ERROR): blocco "Aperte" rigenerato ≠ committato → exit 1. **Drift-killer primario.**
+- **R4 integrita id** (ERROR): id duplicato; id malformato (non `OD-…`); comment senza heading sopra.
+- **R6 archive coherence** (ERROR): id finisce `-original-archive` ⟺ `status=archived` (bidirezionale).
+- **R2 semantico** (WARN, opzionale): per `status=open` con `governed_by=ADR-NNN`, se `adr_status`
+  di quell'ADR ∈ {Accepted, Superseded} → WARN "OD aperto ma l'ADR governante e' accepted — verifica
+  se di fatto risolto". Tier WARN perche' potrebbe essere governing-not-resolving. **NON inerte**
+  (fira appena un'open dichiara `governed_by` di un ADR risolto) ma **dormiente sui dati correnti**:
+  NON setto `governed_by` su OD-023 (il suo ADR-2026-05-05 e' _governing_, non _risolutore_ — settarlo
+  darebbe falso-positivo). R2 e' una capability per il pattern futuro "OD open con ADR risolutore linkato".
+- **R3 igiene** (WARN): `status=resolved` senza `resolved_by`. La migrazione pre-popola `resolved_by`
+  per tutte le 24 resolved dalla prosa esistente → target QG = 0 WARN R3.
+- **R5 coerenza marker** (WARN, cosmetico): `status` vs presenza `✅` nell'heading (vedi doppia-copia).
+
+R2 NON e' l'euristica larga "open + qualsiasi ADR in prosa = drift" (falso-positivo su OD-023 che
+cita ADR-2026-05-05 come _contesto_). Solo `governed_by` (campo intenzionale) attiva R2.
+
+## CI + husky + prettier
+
+| Componente                              | Modifica                                                                                                                                                                                                                                                                                                                                          |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.github/workflows/docs-governance.yml` | step (required) `python tools/generate_open_decisions.py --check` accanto al DECISIONS_LOG check                                                                                                                                                                                                                                                  |
+| `.husky/pre-commit`                     | step regen quando `OPEN_DECISIONS.md` staged (mirror righe 49-56 DECISIONS_LOG): `python tools/generate_open_decisions.py && git add OPEN_DECISIONS.md` (warn-only; CI = hard gate)                                                                                                                                                               |
+| **prettier**                            | **resta ON** (VALORI-1). Tuning: il generatore emette tabella prettier-stabile (4-col md, no padding manuale). QG: `npx prettier --check OPEN_DECISIONS.md` pulito post-regen. **Fallback**: solo se il blocco si rivela prettier-instabile dopo tuning → aggiungi `OPEN_DECISIONS.md` a `.prettierignore` (come `DECISIONS_LOG.md`) + documenta. |
+
+## Build plan (smoke-gated, locale python+git — NO game backend)
+
+1. **Migrazione**: 30 comment + 5 archive + blocco + nota + HOWTO. Regola 3-way ordinata.
+   Smoke: parse → **1 open (OD-023) + 24 resolved + 5 archived**.
+2. **Generatore** `generate_open_decisions.py` + one-time regen blocco. Smoke: `python … && git diff` = solo blocco.
+3. **Prettier-stability**: `npx prettier --write OPEN_DECISIONS.md` → ri-`--check` → re-run generatore → diff 0. Se instabile → .prettierignore fallback.
+4. **Check R1-R6**: introduci contraddizione fittizia (es. archive con status=open) → R6 ERROR; pulisci → verde. Open+governed_by-accepted fittizio → R2 WARN.
+5. **CI + husky** wiring.
+6. **QG**.
+
+## QG (smoke obbligatorio)
+
+- Idempotenza: 2 run → bit-identico.
+- `git diff --exit-code OPEN_DECISIONS.md` = 0 post-commit (sync).
+- `--check` in-sync → 0; tabella edit manuale → 1.
+- `npx prettier --check OPEN_DECISIONS.md` pulito (o `.prettierignore` fallback documentato).
+- `python tools/check_docs_governance.py --strict` errors=0 invariato.
+- Conteggio: indice generato = **1 open (OD-023)**; classificazione = 24 resolved + 5 archived.
+- R6 falsifica (archive+open → ERROR); R3 = 0 WARN (resolved_by pre-popolato).
+
+## Anti-pattern guard (SDMG)
+
+- Comment inline = single-source (no sidecar 2-copy). Heading `✅` decorazione non-letta (no doppia-sorgente sul dato che conta).
+- Regola migrazione 3-way ordinata in UN posto + R6 enforce.
+- R2 non-inerte ma onesto (WARN, dormiente, false-positive-safe) — NON brandito come drift-killer.
+- Parse delimitato (no scan oltre confine → diff stabili).
+- Prettier ON + blocco stabile (no fight prettier/fail-on-diff). .prettierignore solo fallback.
+- Generatore deterministico. Riuso `adr_status`/`STATUS_MAP`. Niente nuove dipendenze.
+- Zero-info-lost: archived renderizzati verbatim; OD-022 (`✅ IMPLICIT ACCEPT` ma body "CANDIDATE-RIPE")
+  - OD-013 (resolved ma integrazione "pendente") → nota inline "human puo' ri-aprire/verificare".
+- HOWTO + husky auto-regen (contributor non-tecnico non intrappolato da CI rossa su comment invisibile).
+
+## Scope OUT
+
+- NON tocca la prosa-verdetto (solo inietta comment + blocco + nota/HOWTO).
+- NON il registry docs (follow-up 2 separato).
+- NON file-per-OD (rigettato). NON reorg sezioni (Alt-Persp-1).
+- NON auto-risolve/auto-apre OD (proietta + flagga; lo status lo attesta l'umano).
+
+## Riferimenti
+
+- Pattern: `tools/generate_decisions_log.py` (#2489). Spec madre: `docs/superpowers/specs/2026-05-30-governance-auto-sync-design.md` (§P5).
+- Esistente: `tools/check_docs_governance.py`, `.github/workflows/docs-governance.yml`, `.husky/pre-commit` (49-56), `.prettierignore` (6).
+- Target: `OPEN_DECISIONS.md`, `docs/governance/open-decisions/`.
+- Harsh-review: ARCHON critic 4-pass, 2026-05-31 (ACCEPT-WITH-FIXES, 6/6 adottati).

--- a/docs/superpowers/specs/2026-05-31-open-decisions-projection-design.md
+++ b/docs/superpowers/specs/2026-05-31-open-decisions-projection-design.md
@@ -168,8 +168,9 @@ Mirror di `generate_decisions_log.py`:
 ## Check — regole falsificabili
 
 - **R1 fail-on-diff** (ERROR): blocco "Aperte" rigenerato ≠ committato → exit 1. **Drift-killer primario.**
-- **R4 integrita id** (ERROR): id duplicato; id malformato (non `OD-…`); comment senza heading sopra.
+- **R4 integrita id** (ERROR): id duplicato; id malformato (non shape `OD-…`); comment id ≠ heading id (un typo `id=oops` sotto `### [OD-100]` non deve diventare riga canonica); comment senza heading sopra.
 - **R6 archive coherence** (ERROR): id finisce `-original-archive` ⟺ `status=archived` (bidirezionale).
+- **R7 heading-senza-comment** (ERROR, Codex #2492): una heading `### [OD-NNN]` senza `<!-- od ... -->` adiacente → il loop (che scansiona solo i commenti) la salta, `--check` passerebbe e l'OD aperta sparirebbe dall'indice = il drift che il gate previene. Ora ERROR.
 - **R2 semantico** (WARN, opzionale): per `status=open` con `governed_by=ADR-NNN`, se `adr_status`
   di quell'ADR ∈ {Accepted, Superseded} → WARN "OD aperto ma l'ADR governante e' accepted — verifica
   se di fatto risolto". Tier WARN perche' potrebbe essere governing-not-resolving. **NON inerte**

--- a/tools/generate_open_decisions.py
+++ b/tools/generate_open_decisions.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Generate the OPEN_DECISIONS.md "Aperte" index from per-OD inline metadata (derive-don't-maintain).
+
+Anti-drift (anti-pattern #19): the "Aperte" list is a GENERATED projection of each OD section's
+machine-readable comment (`<!-- od id=… status=… -->`), injected between markers. Hand prose lives
+OUTSIDE the markers and is preserved verbatim. A CI `git diff --exit-code` gate (R1) makes the
+open-list impossible to drift: a section marked `status=resolved` is auto-excluded, so you can no
+longer leave a resolved OD sitting in "Aperte".
+
+Design: docs/superpowers/specs/2026-05-31-open-decisions-projection-design.md
+- Source of truth = the `<!-- od … -->` comment under each `### [OD-…]` heading (the heading `✅`
+  is human decoration, NOT read here).
+- Generated block = a table between `<!-- gen:od-open -->` … `<!-- /gen:od-open -->`.
+- Deterministic: stable sort (OD number asc) -> clean diffs. Prettier-aligned columns so prettier
+  --write is a no-op (no fight with the fail-on-diff gate).
+
+Checks (run by --check, alongside the R1 diff gate):
+- R2 (WARN): status=open with governed_by=ADR-NNN whose status is Accepted/Superseded -> verify.
+- R3 (WARN): status=resolved without resolved_by.
+- R4 (ERROR): duplicate id; malformed id; comment without a preceding OD heading.
+- R5 (WARN): heading `✅` presence disagrees with comment status (cosmetic).
+- R6 (ERROR): id ends `-original-archive` XOR status=archived (must match both ways).
+
+Usage:
+    python tools/generate_open_decisions.py            # rewrite OPEN_DECISIONS.md in place
+    python tools/generate_open_decisions.py --check    # exit 1 if out of sync or any ERROR (CI gate)
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# reuse status normalization from the DECISIONS_LOG generator (no duplication)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from generate_decisions_log import ADR_DIR, adr_status, parse_frontmatter  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OD_PATH = REPO_ROOT / "OPEN_DECISIONS.md"
+BEGIN = "<!-- gen:od-open -->"
+END = "<!-- /gen:od-open -->"
+
+HEADING_RE = re.compile(r"^### \[(OD-[0-9.]+(?:-original-archive)?)\]\s*(.*)$")
+COMMENT_RE = re.compile(r"^<!--\s*od\s+(.*?)\s*-->\s*$")
+# key=value with optional double-quoted value
+KV_RE = re.compile(r'(\w+)=(?:"([^"]*)"|(\S+))')
+ADR_REF_RE = re.compile(r"ADR-\d{4}(?:-\d{2}){0,2}[A-Za-z0-9-]*")
+PR_REF_RE = re.compile(r"PR #\d+|#\d+")
+LIVELLO_RE = re.compile(r"^- \*\*Livello\*\*:\s*(.+?)\s*$")
+
+VALID_STATUS = {"open", "resolved", "archived"}
+
+
+class ODRecord:
+    __slots__ = (
+        "id",
+        "status",
+        "resolved_by",
+        "governed_by",
+        "title",
+        "anchor",
+        "livello",
+        "ref",
+        "heading_has_check",
+        "comment_line",
+    )
+
+    def __init__(self, **kw):
+        for k in self.__slots__:
+            setattr(self, k, kw.get(k))
+
+
+def _heading_title(raw: str) -> str:
+    """Heading text minus a trailing `✅ …` decoration and trailing date noise."""
+    # cut at the first status decoration marker
+    title = re.split("✅|⚠️?", raw, maxsplit=1)[0].strip()
+    # drop a trailing " - ..." tail (em-dash separated) if it duplicates the resolution prose
+    title = re.split("\\s+—\\s+", title, maxsplit=1)[0].strip()
+    return title or raw.strip()
+
+
+def _anchor(heading_text: str) -> str:
+    """GitHub-slugger anchor for the FULL heading text (after `### `), incl. the `[OD-NNN] … — tail`.
+    Faithful to github-slugger: lowercase, strip punctuation (keep \\w/space/hyphen), each space ->
+    hyphen WITHOUT collapsing (so `verdict — day` -> `verdict--day`, matching GitHub)."""
+    slug = heading_text.strip().lower()
+    slug = re.sub(r"[^\w\s-]", "", slug, flags=re.UNICODE)
+    slug = re.sub(r"\s", "-", slug)
+    return slug
+
+
+def parse_records(text: str) -> tuple[list[ODRecord], list[str]]:
+    """Parse OD records from heading+comment pairs. Returns (records, errors)."""
+    lines = text.splitlines()
+    records: list[ODRecord] = []
+    errors: list[str] = []
+    seen_ids: set[str] = set()
+
+    # index heading lines
+    headings: dict[int, tuple[str, str, bool, str]] = {}
+    heading_order: list[int] = []
+    for i, ln in enumerate(lines):
+        m = HEADING_RE.match(ln)
+        if m:
+            full = ln[4:] if ln.startswith("### ") else ln  # text after "### " for the anchor
+            headings[i] = (m.group(1), _heading_title(m.group(2)), "✅" in ln, full)
+            heading_order.append(i)
+
+    for i, ln in enumerate(lines):
+        cm = COMMENT_RE.match(ln)
+        if not cm:
+            continue
+        fields = {k: (q or u) for k, q, u in KV_RE.findall(cm.group(1))}
+        if "id" not in fields or "status" not in fields:
+            errors.append(f"R4 ERROR L{i+1}: malformed od-comment (need id+status): {ln.strip()}")
+            continue
+        # nearest preceding heading
+        prev = [h for h in heading_order if h < i]
+        if not prev or (i - prev[-1]) > 3:
+            errors.append(f"R4 ERROR L{i+1}: od-comment {fields['id']} has no OD heading above it")
+            continue
+        h_line = prev[-1]
+        h_id, h_title, h_check, h_full = headings[h_line]
+        od_id = fields["id"]
+        status = fields["status"]
+        if status not in VALID_STATUS:
+            errors.append(f"R4 ERROR L{i+1}: {od_id} invalid status '{status}'")
+            continue
+        if od_id in seen_ids:
+            errors.append(f"R4 ERROR L{i+1}: duplicate id {od_id}")
+            continue
+        seen_ids.add(od_id)
+
+        # section bound: this comment -> next OD heading
+        next_h = next((h for h in heading_order if h > h_line), len(lines))
+        section = lines[i + 1 : next_h]
+        livello = "—"
+        for s in section:
+            lm = LIVELLO_RE.match(s)
+            if lm:
+                livello = lm.group(1)
+                break
+        # short ref: prefer explicit fields, else first ADR/PR token in-section
+        ref = "—"
+        for src in (fields.get("resolved_by", ""), fields.get("governed_by", "")):
+            mref = ADR_REF_RE.search(src) or PR_REF_RE.search(src)
+            if mref:
+                ref = mref.group(0)
+                break
+        if ref == "—":
+            for s in section:
+                mref = ADR_REF_RE.search(s) or PR_REF_RE.search(s)
+                if mref:
+                    ref = mref.group(0)
+                    break
+
+        records.append(
+            ODRecord(
+                id=od_id,
+                status=status,
+                resolved_by=fields.get("resolved_by"),
+                governed_by=fields.get("governed_by"),
+                title=h_title,
+                anchor=_anchor(h_full),
+                livello=livello,
+                ref=ref,
+                heading_has_check=h_check,
+                comment_line=i + 1,
+            )
+        )
+    return records, errors
+
+
+def _od_sort_key(od_id: str) -> tuple[int, str]:
+    m = re.search(r"OD-(\d+)", od_id)
+    return (int(m.group(1)) if m else 9999, od_id)
+
+
+def render_table(records: list[ODRecord]) -> str:
+    """Prettier-aligned GFM table of status=open records (columns padded to max cell width)."""
+    open_recs = sorted((r for r in records if r.status == "open"), key=lambda r: _od_sort_key(r.id))
+    header = ["OD", "Titolo", "Livello", "Ref"]
+    rows = []
+    for r in open_recs:
+        link = f"[{r.id}](#{r.anchor})"
+        rows.append([link, r.title.replace("|", "\\|"), (r.livello or "—").replace("|", "\\|"), r.ref or "—"])
+    # column widths (min 3 for the --- separator), prettier-style
+    widths = [max(len(header[c]), 3, *(len(row[c]) for row in rows)) if rows else max(len(header[c]), 3) for c in range(4)]
+
+    def fmt(cells: list[str]) -> str:
+        return "| " + " | ".join(cells[c].ljust(widths[c]) for c in range(4)) + " |"
+
+    out = [
+        "_Generato da `tools/generate_open_decisions.py`. NON editare a mano: edita i comment "
+        "`<!-- od … -->` di ogni sezione e rigenera._",
+        "",
+        fmt(header),
+        "| " + " | ".join("-" * widths[c] for c in range(4)) + " |",
+    ]
+    out.extend(fmt(row) for row in rows)
+    return "\n".join(out)
+
+
+def build_block(records: list[ODRecord]) -> str:
+    # blank lines after BEGIN / before END match prettier's markdown formatting, so `prettier
+    # --write` is a no-op on the block and never fights the fail-on-diff gate (#2489 gotcha).
+    return f"{BEGIN}\n\n{render_table(records)}\n\n{END}"
+
+
+def apply(text: str, block: str) -> str:
+    if BEGIN in text and END in text:
+        pre = text.split(BEGIN, 1)[0]
+        post = text.split(END, 1)[1]
+        return f"{pre}{block}{post}"
+    raise SystemExit("OPEN_DECISIONS.md: markers <!-- gen:od-open --> not found (run migration first)")
+
+
+def validate(records: list[ODRecord], parse_errors: list[str]) -> tuple[list[str], list[str]]:
+    """Return (errors, warns) from R2-R6 (R1 = diff, handled in main)."""
+    errors = list(parse_errors)
+    warns: list[str] = []
+    for r in records:
+        is_archive = r.id.endswith("-original-archive")
+        # R6 archive coherence (both directions)
+        if is_archive != (r.status == "archived"):
+            errors.append(
+                f"R6 ERROR L{r.comment_line}: {r.id} archive-suffix={is_archive} but status={r.status} (must match)"
+            )
+        # R3 resolved without ref
+        if r.status == "resolved" and not r.resolved_by:
+            warns.append(f"R3 WARN L{r.comment_line}: {r.id} status=resolved without resolved_by")
+        # R5 marker coherence (cosmetic)
+        if r.status == "resolved" and not r.heading_has_check:
+            warns.append(f"R5 WARN L{r.comment_line}: {r.id} status=resolved but heading has no check-mark")
+        if r.status == "open" and r.heading_has_check:
+            warns.append(f"R5 WARN L{r.comment_line}: {r.id} status=open but heading has a check-mark")
+        # R2 open governed_by an accepted ADR
+        if r.status == "open" and r.governed_by:
+            mref = ADR_REF_RE.search(r.governed_by)
+            if mref:
+                adr_file = ADR_DIR / f"{mref.group(0)}.md"
+                if not adr_file.exists():
+                    cands = list(ADR_DIR.glob(f"{mref.group(0)}*.md"))
+                    adr_file = cands[0] if cands else adr_file
+                if adr_file.exists():
+                    st = adr_status(parse_frontmatter(adr_file.read_text(encoding="utf-8-sig")))
+                    if st in ("Accepted", "Superseded"):
+                        warns.append(
+                            f"R2 WARN L{r.comment_line}: {r.id} status=open but governed_by {mref.group(0)} is {st} - verify if actually resolved"
+                        )
+    return errors, warns
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--check", action="store_true", help="exit 1 if out of sync or any ERROR (CI gate)")
+    args = ap.parse_args()
+
+    current = OD_PATH.read_text(encoding="utf-8-sig")
+    records, parse_errors = parse_records(current)
+    errors, warns = validate(records, parse_errors)
+    block = build_block(records)
+    updated = apply(current, block)
+
+    n_open = sum(1 for r in records if r.status == "open")
+    n_res = sum(1 for r in records if r.status == "resolved")
+    n_arch = sum(1 for r in records if r.status == "archived")
+    summary = f"{len(records)} OD ({n_open} open, {n_res} resolved, {n_arch} archived)"
+
+    for w in warns:
+        print(f"[open-decisions] {w}", file=sys.stderr)
+    for e in errors:
+        print(f"[open-decisions] {e}", file=sys.stderr)
+
+    if args.check:
+        rc = 0
+        if errors:
+            print(f"[open-decisions] {len(errors)} ERROR(s) - fix before merge", file=sys.stderr)
+            rc = 1
+        if updated != current:
+            print(
+                f"[open-decisions] OUT OF SYNC ({summary}). Run: python tools/generate_open_decisions.py",
+                file=sys.stderr,
+            )
+            rc = 1
+        if rc == 0:
+            print(f"[open-decisions] in sync + valid ({summary})")
+        return rc
+
+    if errors:
+        # still regenerate the block, but signal the ERRORs loudly (CI --check is the hard gate)
+        print(f"[open-decisions] WARN: {len(errors)} ERROR(s) present (see above) - fix the comments", file=sys.stderr)
+    if updated != current:
+        OD_PATH.write_text(updated, encoding="utf-8")
+        print(f"[open-decisions] regenerated ({summary})")
+    else:
+        print(f"[open-decisions] no change ({summary})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/generate_open_decisions.py
+++ b/tools/generate_open_decisions.py
@@ -17,9 +17,10 @@ Design: docs/superpowers/specs/2026-05-31-open-decisions-projection-design.md
 Checks (run by --check, alongside the R1 diff gate):
 - R2 (WARN): status=open with governed_by=ADR-NNN whose status is Accepted/Superseded -> verify.
 - R3 (WARN): status=resolved without resolved_by.
-- R4 (ERROR): duplicate id; malformed id; comment without a preceding OD heading.
+- R4 (ERROR): duplicate id; malformed id (not OD-NNN shape); comment id != heading id; comment without a preceding OD heading.
 - R5 (WARN): heading `✅` presence disagrees with comment status (cosmetic).
 - R6 (ERROR): id ends `-original-archive` XOR status=archived (must match both ways).
+- R7 (ERROR): an OD heading with no adjacent <!-- od ... --> comment (else its open decision is silently omitted from the index).
 
 Usage:
     python tools/generate_open_decisions.py            # rewrite OPEN_DECISIONS.md in place
@@ -96,6 +97,7 @@ def parse_records(text: str) -> tuple[list[ODRecord], list[str]]:
     records: list[ODRecord] = []
     errors: list[str] = []
     seen_ids: set[str] = set()
+    covered: set[int] = set()  # heading line-nums that have an adjacent od-comment (R7)
 
     # index heading lines
     headings: dict[int, tuple[str, str, bool, str]] = {}
@@ -121,9 +123,18 @@ def parse_records(text: str) -> tuple[list[ODRecord], list[str]]:
             errors.append(f"R4 ERROR L{i+1}: od-comment {fields['id']} has no OD heading above it")
             continue
         h_line = prev[-1]
+        covered.add(h_line)  # this heading has an adjacent od-comment (R7 satisfied)
         h_id, h_title, h_check, h_full = headings[h_line]
         od_id = fields["id"]
         status = fields["status"]
+        # R4: id must match the OD-NNN shape AND equal its heading id (a typo'd comment id must
+        # not become a canonical row, e.g. `id=oops` under `### [OD-100]`).
+        if not re.fullmatch(r"OD-[0-9.]+(?:-original-archive)?", od_id):
+            errors.append(f"R4 ERROR L{i+1}: malformed id '{od_id}' (expected OD-NNN)")
+            continue
+        if od_id != h_id:
+            errors.append(f"R4 ERROR L{i+1}: comment id '{od_id}' != heading id '{h_id}'")
+            continue
         if status not in VALID_STATUS:
             errors.append(f"R4 ERROR L{i+1}: {od_id} invalid status '{status}'")
             continue
@@ -169,6 +180,17 @@ def parse_records(text: str) -> tuple[list[ODRecord], list[str]]:
                 comment_line=i + 1,
             )
         )
+
+    # R7: every OD heading must carry an adjacent <!-- od ... --> comment. Without this, a new
+    # `### [OD-033]` whose author forgot the metadata line is silently skipped (the loop only scans
+    # comments) -> --check passes + the open decision is omitted from the index = the exact
+    # stale/missing-index drift this gate prevents.
+    for h_line in heading_order:
+        if h_line not in covered:
+            errors.append(
+                f"R7 ERROR L{h_line+1}: OD heading {headings[h_line][0]} has no adjacent <!-- od ... --> metadata"
+            )
+
     return records, errors
 
 


### PR DESCRIPTION
## Cosa

Follow-up 1 di #2489 (anti-pattern #19, stale-tracker). Rende la lista **"Aperte"** di `OPEN_DECISIONS.md` un **artefatto generato** (derive-don't-maintain), guardato da CI **fail-on-diff** — esattamente come #2489 fece per `DECISIONS_LOG`. Harsh-review #2489 aveva DEFERITO questo come P1-1 ("schema prosa-loose, serve schema-migration spec propria"): questo PR fa la schema-migration + il generatore.

## Perché (il drift, misurato)

Sotto `## Aperte` ci sono **27 sezioni OD** ma **24 sono già `✅ RISOLTA`** e mai spostate → la lista "Aperte" è **~93% stale**. Solo **OD-023** è davvero aperto. Lo status oggi vive nella **prosa dell'heading** (`✅ RISOLTA …`) = non parsabile.

## Come

- **Schema** (`<!-- od id= status= [resolved_by=] [governed_by=] -->`, un comment inline per sezione = unica sorgente machine; l'heading `✅` resta decorazione non-letta).
- **Migrazione one-time** (regola 3-way ordinata: `-original-archive`→archived → `✅`→resolved → open): **24 resolved + 5 archived + 1 open (OD-023)**. Prosa preservata verbatim (diff = 74 insert, **0 delete**).
- **`tools/generate_open_decisions.py`**: proietta le righe `status=open` tra marker `<!-- gen:od-open -->`, riusa `adr_status` da `generate_decisions_log.py` (no dup), tabella **prettier-stabile** (prettier resta ON, niente `.prettierignore`), `--check` = gate.
- **Check R1-R6**: R1 fail-on-diff (drift-killer primario) · R4 id integrity (ERROR) · R6 archive⟺archived (ERROR) · R2 open+governed_by-ADR-accepted (WARN, dormiente) · R3 resolved-senza-ref (WARN) · R5 coerenza heading-✅/comment (WARN).
- **CI**: nuovo step `--check` in `docs-governance.yml`. **Husky**: regen-on-OPEN_DECISIONS-change.

## Metodo (come #2489)

research-lite → spec (`docs/superpowers/specs/2026-05-31-open-decisions-projection-design.md`) → **harsh-review (ARCHON critic 4-pass)** → build → QG. Verdict critic = **ACCEPT-WITH-FIXES (6 must-fix), tutti adottati** (SDMG: se rigetta, adotto). Il critic ha corretto 2 difetti reali: la mia ground-truth era sbagliata (avevo contato 30 sotto Aperte invece di 27) e R2 era **inerte** (leggeva `resolved_by` che le open non hanno → riscritto per leggere `governed_by`).

## ⚠️ Forbidden-path flag

Tocca **`.github/workflows/docs-governance.yml`** (forbidden path, auto-merge L3 gate 5) → **NON auto-merge eligible, richiede merge manuale master-dd**. Identico a #2489 (stesso file, stesso pattern: il fail-on-diff gate è il deliverable). `.husky/` non è forbidden.

## QG (eseguito)

- Generatore idempotente (2 run → identico); `--check` exit 0; falsificato R1 (out-of-sync→1), R6 (archive+open→1), R2 (WARN→0).
- `prettier --check OPEN_DECISIONS.md` + spec + yaml = **clean** (prettier-stabile, no fight col gate).
- `python tools/check_docs_governance.py --strict` → **errors=0** (invariato, 329 warning pre-esistenti).
- `sh -n .husky/pre-commit` OK; YAML valido; commit clean (husky prettier+regen no-op).

## Rollback (03A)

Revert del commit: rimuove generatore + 2 step (CI/husky) + i comment inline da OPEN_DECISIONS.md (prosa intatta, additive-only → revert pulito). Nessuna migrazione DB, nessuno schema condiviso, nessuna dipendenza nuova.

## Changelog

`feat(governance)`: la lista Aperte di OPEN_DECISIONS è ora generata da status machine-readable per-OD + gate CI fail-on-diff. Prima: lista hand-maintained, 24/27 voci risolte ancora marcate "Aperte". Ora: proiezione = 1 sola aperta (OD-023), impossibile da driftare.

## Scope OUT

Follow-up 2 (registry reconcile) = PR separato. Nessun reorg sezioni, nessun file-per-OD, nessun auto-resolve/auto-open (solo proietta + flagga; lo status lo attesta l'umano).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
