### PR TITLE
fix(species): Codex P2 #2490+#2491 (schema source enum + ecotypes + Wave4 gate)

### DIFF
--- a/data/core/species/species_catalog.json
+++ b/data/core/species/species_catalog.json
@@ -3489,9 +3489,7 @@
       },
       "constraints": [],
       "sentience_index": "T1",
-      "ecotypes": [
-        "badlands"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
@@ -3540,9 +3538,7 @@
       },
       "constraints": [],
       "sentience_index": "T3",
-      "ecotypes": [
-        "badlands"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
@@ -3591,9 +3587,7 @@
       },
       "constraints": [],
       "sentience_index": "T1",
-      "ecotypes": [
-        "badlands"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
@@ -3642,9 +3636,7 @@
       },
       "constraints": [],
       "sentience_index": "T1",
-      "ecotypes": [
-        "badlands"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
@@ -3693,9 +3685,7 @@
       },
       "constraints": [],
       "sentience_index": "T1",
-      "ecotypes": [
-        "badlands"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
@@ -3744,9 +3734,7 @@
       },
       "constraints": [],
       "sentience_index": "T1",
-      "ecotypes": [
-        "badlands"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
@@ -3795,9 +3783,7 @@
       },
       "constraints": [],
       "sentience_index": "T1",
-      "ecotypes": [
-        "badlands"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
@@ -3846,9 +3832,7 @@
       },
       "constraints": [],
       "sentience_index": "T1",
-      "ecotypes": [
-        "cryosteppe"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
@@ -3897,9 +3881,7 @@
       },
       "constraints": [],
       "sentience_index": "T1",
-      "ecotypes": [
-        "cryosteppe"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
@@ -3948,9 +3930,7 @@
       },
       "constraints": [],
       "sentience_index": "T1",
-      "ecotypes": [
-        "cryosteppe"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
@@ -3999,9 +3979,7 @@
       },
       "constraints": [],
       "sentience_index": "T1",
-      "ecotypes": [
-        "cryosteppe"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
@@ -4050,9 +4028,7 @@
       },
       "constraints": [],
       "sentience_index": "T1",
-      "ecotypes": [
-        "cryosteppe"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
@@ -4101,9 +4077,7 @@
       },
       "constraints": [],
       "sentience_index": "T1",
-      "ecotypes": [
-        "cryosteppe"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
@@ -4152,9 +4126,7 @@
       },
       "constraints": [],
       "sentience_index": "T1",
-      "ecotypes": [
-        "deserto_caldo"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
@@ -4203,9 +4175,7 @@
       },
       "constraints": [],
       "sentience_index": "T1",
-      "ecotypes": [
-        "deserto_caldo"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
@@ -4254,9 +4224,7 @@
       },
       "constraints": [],
       "sentience_index": "T1",
-      "ecotypes": [
-        "deserto_caldo"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
@@ -4305,9 +4273,7 @@
       },
       "constraints": [],
       "sentience_index": "T1",
-      "ecotypes": [
-        "deserto_caldo"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
@@ -4356,9 +4322,7 @@
       },
       "constraints": [],
       "sentience_index": "T1",
-      "ecotypes": [
-        "foresta_temperata"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
@@ -4407,9 +4371,7 @@
       },
       "constraints": [],
       "sentience_index": "T1",
-      "ecotypes": [
-        "foresta_temperata"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
@@ -4458,9 +4420,7 @@
       },
       "constraints": [],
       "sentience_index": "T1",
-      "ecotypes": [
-        "foresta_temperata"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
@@ -4509,9 +4469,7 @@
       },
       "constraints": [],
       "sentience_index": "T1",
-      "ecotypes": [
-        "foresta_temperata"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
@@ -4560,9 +4518,7 @@
       },
       "constraints": [],
       "sentience_index": "T3",
-      "ecotypes": [
-        "foresta_temperata"
-      ],
+      "ecotypes": [],
       "trait_refs": [],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",

--- a/docs/planning/2026-05-30-design-data-gap-resolution-plan.md
+++ b/docs/planning/2026-05-30-design-data-gap-resolution-plan.md
@@ -94,8 +94,8 @@ Outcome: l'adapter sblocca la combat-usabilita del materiale esistente (pilota b
   `docs/playtest/2026-05-30-badlands-pilot-calibration.md`.
 - **TKT-SPECIE-CANON-RECONCILE** -- ✅ **DONE (Strato 1)** via D7/#2490 (vedi sopra). Audit
   completo + decisione unify + 22 promosse (53->75). Strato 2 = follow-up sotto.
-- **TKT-SPECIE-BIOME** -- ✅ **quasi-chiuso**: il claim "32/53 senza biome_affinity" e'
-  **STALE** -- ground-truth 2026-05-30 = **53/53 ce l'hanno**. Tool D4 (`suggest/apply_
+- **TKT-SPECIE-BIOME** -- ✅ **quasi-chiuso**: il claim "32/53 senza biome*affinity" e'
+  **STALE** -- ground-truth 2026-05-30 = **53/53 ce l'hanno**. Tool D4 (`suggest/apply*
   biome_affinity`) shipped (#2466/#2473/#2476). Resta solo per-bioma se si estende un
   ecosystem.yaml nuovo.
 - **TKT-ECO-YAML-GEN** -- 🟡 tool shipped (#2476); 5/20 biomi hanno ecosystem.yaml.
@@ -106,16 +106,19 @@ Outcome: l'adapter sblocca la combat-usabilita del materiale esistente (pilota b
 
 #### Follow-up aperti da CANON-RECONCILE/D7 (nuovi ticket)
 
-| Ticket                       | Cosa                                                                                                   | Mode             | Gate / nota                                   |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------ | ---------------- | --------------------------------------------- |
-| TKT-SPECIE-STRATO2-AUTHOR    | authoring campi design delle 22 stub `_promote_stub` (scientific_name, descrizioni, interactions, lifecycle), bioma-per-bioma | writer / swarm   | incrementale YAGNI; trovabili via `source==gameplay-promote` |
-| TKT-SPECIE-TRAITKEEPER-RELOC | spostare 38 `*-trait-keeper` + 4 `evento-*` fuori da `packs/.../species/` (non-specie in cartella errata) | data hygiene     | **gated**: serve consumer-trace completo (pack-catalog gen + biome trait loader) prima di muovere |
-| TKT-SPECIE-TIER-FIX          | 6 creature gameplay con solo `threat_tier` mancante (magneto-ridge/slag-veil/aurora-bridge/zephyr/glowcap/myco-spire) | balance          | assegnare tier = giudizio balance, fare se servono in combat |
-| TKT-D6-ROVINE-CONTENT        | 10 creature rovine_planari = nuovo contenuto D&D-style (threat_tier+role+design)                       | writer/designer  | **D6 LOCKED gate**; escluse dall'unify        |
+| Ticket                       | Cosa                                                                                                                          | Mode            | Gate / nota                                                                                       |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------- |
+| TKT-SPECIE-STRATO2-AUTHOR    | authoring campi design delle 22 stub `_promote_stub` (scientific_name, descrizioni, interactions, lifecycle), bioma-per-bioma | writer / swarm  | incrementale YAGNI; trovabili via `source==gameplay-promote`                                      |
+| TKT-SPECIE-TRAITKEEPER-RELOC | spostare 38 `*-trait-keeper` + 4 `evento-*` fuori da `packs/.../species/` (non-specie in cartella errata)                     | data hygiene    | **gated**: serve consumer-trace completo (pack-catalog gen + biome trait loader) prima di muovere |
+| TKT-SPECIE-TIER-FIX          | 6 creature gameplay con solo `threat_tier` mancante (magneto-ridge/slag-veil/aurora-bridge/zephyr/glowcap/myco-spire)         | balance         | assegnare tier = giudizio balance, fare se servono in combat                                      |
+| TKT-D6-ROVINE-CONTENT        | 10 creature rovine_planari = nuovo contenuto D&D-style (threat_tier+role+design)                                              | writer/designer | **D6 LOCKED gate**; escluse dall'unify                                                            |
 
 Stato gate post-2026-05-30: il **critical-path Wave 3 (adapter) e CHIUSO**; CANON-RECONCILE
 Strato 1 chiuso. Resta backfill incrementale YAGNI (lifecycle/eco-yaml/strato2) + audit
-TRAIT-RECONCILE + i 4 follow-up sopra. Wave 4 (Pathfinder-seed) ora sbloccabile (adapter ✅).
+TRAIT-RECONCILE + i 4 follow-up sopra. Wave 4 (Pathfinder-seed): **solo il gate adapter e'
+sgombro** (✅). Il secondo gate -- `ecosystem.yaml` per bioma -- resta APERTO (5/20 biomi),
+e TKT-PATHFINDER-SEED dipende da ENTRAMBI (adapter + ecosystem.yaml): NON avviare il seed
+30-50h prima che gli ecosystem.yaml dei biomi target esistano (Codex #2491 P2).
 
 ## Wave 4 — content + Pathfinder seed (writer/designer; D2 DECISO; L2-L5 gated)
 

--- a/schemas/evo/species_catalog.schema.json
+++ b/schemas/evo/species_catalog.schema.json
@@ -53,7 +53,7 @@
     },
     "catalog": {
       "type": "array",
-      "description": "53 species entries (10 pack-v2-full-plus + 5 game-canonical-stub + 38 legacy-yaml-merge)",
+      "description": "75 species entries (53 canon [10 pack-v2-full-plus + 5 game-canonical-stub + 38 legacy-yaml-merge] + 22 gameplay-promote, Wave3 CANON-RECONCILE #2490)",
       "items": {
         "type": "object",
         "required": ["species_id", "source"],
@@ -175,7 +175,12 @@
           "epithet": { "type": ["string", "null"] },
           "source": {
             "type": "string",
-            "enum": ["pack-v2-full-plus", "game-canonical-stub", "legacy-yaml-merge"]
+            "enum": [
+              "pack-v2-full-plus",
+              "game-canonical-stub",
+              "legacy-yaml-merge",
+              "gameplay-promote"
+            ]
           },
           "merged_at": { "type": "string" },
           "_provenance": {

--- a/tools/etl/promote_gameplay_to_canon.py
+++ b/tools/etl/promote_gameplay_to_canon.py
@@ -89,7 +89,9 @@ def derive_entry(pack, biome, fid):
         "interactions": {"predates_on": [], "predated_by": []},
         "constraints": [],
         "sentience_index": sentience,
-        "ecotypes": [biome],
+        # ecotypes is a constrained vocab (enums.json ecotype_cluster), NOT a free biome
+        # name -> empty for stubs; Strato 2 assigns valid ecotype clusters.
+        "ecotypes": [],
         "trait_refs": [],                   # TODO map functional_tags -> TR-#### ids
         "lifecycle_yaml": None,             # TODO seed lifecycle stub
         # --- structural / provenance ---


### PR DESCRIPTION
## Fix Codex P2 from #2490 + #2491

Addresses the two unread Codex P2 comments on my merged Wave-3 PRs (per the new
merge-gate: read Codex, not only CI).

### #2490 P2 -- catalog schema invalid for `gameplay-promote`
`schemas/evo/species_catalog.schema.json` enum'd `source` to 3 values, so the 22
promoted rows failed `node scripts/validate-dataset.cjs`. My rows also set
`ecotypes=[biome]`, violating the `ecotype_cluster` enum.
- schema: add `gameplay-promote` to the `source` enum + count description 53 -> 75.
- `species_catalog.json`: 22 gameplay-promote entries `ecotypes` -> `[]` (Strato-2
  TODO field; ecotype_cluster is a constrained vocab, not a biome name).
- `promote_gameplay_to_canon.py`: same fix for future runs.

**Result**: all 22 promoted rows pass the validator (0 failures at index >= 53).

### #2491 P2 -- Wave 4 gate phrasing
Reworded: only the **adapter** gate is cleared; the `ecosystem.yaml` gate (5/20
biomes) stays open, and TKT-PATHFINDER-SEED depends on both -- don't start the
30-50h seed before the target biomes' ecosystem.yaml exist.

### Out of scope (flagged separately)
The validator also fails on **43 pre-existing base-canon entries** (idx 0-52, e.g.
`sp_magmocardium_furens` ecotypes `['apex','predator',...]`) -- a latent bug not
introduced here and not gated by CI's `game_cli.py validate-datasets`. Spawned a
follow-up to map those to valid `ecotype_cluster` values.

Checks: validate-dataset.cjs (my rows clean) + envelope-b integrity 27/27 + docs
governance errors=0 + DECISIONS_LOG no-drift.

Coding-Agent: claude-opus-4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
