### PR TITLE
feat(traits): TRAIT-RECONCILE audit + badlands Strato-2 trait_refs (Wave3)

### DIFF
--- a/data/core/species/species_catalog.json
+++ b/data/core/species/species_catalog.json
@@ -3490,7 +3490,13 @@
       "constraints": [],
       "sentience_index": "T1",
       "ecotypes": [],
-      "trait_refs": [],
+      "trait_refs": [
+        "eco_interno_riflesso",
+        "occhi_infrarosso_composti",
+        "sonno_emisferico_alternato",
+        "sacche_galleggianti_ascensoriali",
+        "lingua_tattile_trama"
+      ],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
       "legacy_slug": "echo_wing",
@@ -3512,7 +3518,6 @@
         "visual_description",
         "interactions",
         "constraints",
-        "trait_refs",
         "lifecycle_yaml"
       ]
     },
@@ -3539,7 +3544,13 @@
       "constraints": [],
       "sentience_index": "T3",
       "ecotypes": [],
-      "trait_refs": [],
+      "trait_refs": [
+        "mimetismo_cromatico_passivo",
+        "sangue_piroforico",
+        "secrezione_rallentante_palmi",
+        "lingua_tattile_trama",
+        "ventriglio_gastroliti"
+      ],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
       "legacy_slug": "ferrocolonia_magnetotattica",
@@ -3561,7 +3572,6 @@
         "visual_description",
         "interactions",
         "constraints",
-        "trait_refs",
         "lifecycle_yaml"
       ]
     },
@@ -3637,7 +3647,13 @@
       "constraints": [],
       "sentience_index": "T1",
       "ecotypes": [],
-      "trait_refs": [],
+      "trait_refs": [
+        "filamenti_digestivi_compattanti",
+        "spore_psichiche_silenziate",
+        "scheletro_idro_regolante",
+        "carapace_fase_variabile",
+        "sangue_piroforico"
+      ],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
       "legacy_slug": "nano_rust_bloom",
@@ -3659,7 +3675,6 @@
         "visual_description",
         "interactions",
         "constraints",
-        "trait_refs",
         "lifecycle_yaml"
       ]
     },
@@ -3686,7 +3701,13 @@
       "constraints": [],
       "sentience_index": "T1",
       "ecotypes": [],
-      "trait_refs": [],
+      "trait_refs": [
+        "ventriglio_gastroliti",
+        "respiro_a_scoppio",
+        "filamenti_digestivi_compattanti",
+        "nucleo_ovomotore_rotante",
+        "scheletro_idro_regolante"
+      ],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
       "legacy_slug": "rust_scavenger",
@@ -3708,7 +3729,6 @@
         "visual_description",
         "interactions",
         "constraints",
-        "trait_refs",
         "lifecycle_yaml"
       ]
     },
@@ -3735,7 +3755,13 @@
       "constraints": [],
       "sentience_index": "T1",
       "ecotypes": [],
-      "trait_refs": [],
+      "trait_refs": [
+        "nucleo_ovomotore_rotante",
+        "sacche_galleggianti_ascensoriali",
+        "scheletro_idro_regolante",
+        "carapace_fase_variabile",
+        "zampe_a_molla"
+      ],
       "lifecycle_yaml": null,
       "source": "gameplay-promote",
       "legacy_slug": "sand_burrower",
@@ -3757,7 +3783,6 @@
         "visual_description",
         "interactions",
         "constraints",
-        "trait_refs",
         "lifecycle_yaml"
       ]
     },

--- a/docs/planning/2026-05-31-trait-reconcile-audit.md
+++ b/docs/planning/2026-05-31-trait-reconcile-audit.md
@@ -1,0 +1,85 @@
+---
+title: 'TRAIT-RECONCILE audit (Wave 3) + badlands Strato-2 trait_refs'
+workstream: worldgen
+category: planning
+doc_status: active
+doc_owner: claude-code
+last_verified: '2026-05-31'
+source_of_truth: false
+language: it
+review_cycle_days: 30
+tags: [planning, wave3, trait-reconcile, traits, glossary, species]
+---
+
+# TRAIT-RECONCILE audit (Wave 3, 2026-05-31)
+
+Ticket **TKT-TRAIT-RECONCILE** (ultimo audit aperto di Wave 3). Read-only; corregge i
+numeri stale del piano ("104 senza meccanica + tassonomia 57->106").
+
+## Il vero quadro (ground-truth main 2e9ca343)
+
+Due artefatti separati:
+
+- **`data/core/traits/glossary.json`** = **604** tratti, SOLO flavor (label_it/en +
+  description_it/en, nessun campo meccanica). **Synced** da `data/traits/index.json` via
+  `tools/traits/sync_missing_index.py` (workflow `traits-sync.yml`) -> **NON hand-edit**.
+- **`data/core/traits/active_effects.yaml`** = **502** tratti CON meccanica (trigger +
+  effect; consumati da `traitEffects.js`).
+
+| relazione                                    | n       |
+| -------------------------------------------- | ------- |
+| glossary (flavor)                            | 604     |
+| active_effects (meccanica)                   | 502     |
+| meccanica ∩ glossary                         | 498     |
+| **meccanica SENZA flavor (orphan-mechanic)** | **4**   |
+| **glossary SENZA meccanica (flavor-only)**   | **106** |
+
+I 4 orphan-mechanic: `equilibrio_vestibolare`, `nocicezione`, `propriocezione`,
+`termocezione` (hanno effetto ma manca la entry glossary).
+
+## Species trait_refs -- il bug headline
+
+`species_catalog.json` referenzia **177** trait_id distinti:
+
+| categoria                                     | n      | stato                                                |
+| --------------------------------------------- | ------ | ---------------------------------------------------- |
+| slug name-id (es. `scheletro_idro_regolante`) | 127    | ✅ **127/127 risolvono** in glossary                 |
+| **codici `TR-####`** (TR-1101..TR-2005)       | **50** | 🔴 **TUTTI dangling** (in NESSUNO dei due artefatti) |
+
+I 50 `TR-####` sono un **secondo namespace legacy** mai mappato agli slug, su ~10 specie
+canon (`elastovaranus_hydrus`, `gulogluteus_scutiger`, `perfusuas_pedes`,
+`terracetus_ambulator`, `chemnotela_toxica`, `proteus_plasma`, `soniptera_resonans`,
+`anguis_magnetica`, `umbra_alaris`, `rupicapra_sensoria` -- 5 TR-code ciascuna).
+
+**Perche' main e' verde nonostante i 50 dangling**: `tests/scripts/speciesTraitReferences.test.js`
+valida i trait-list dei **pack YAML** (`suggested_traits`/`optional_traits`/`core`...), NON
+i `trait_refs` di `species_catalog.json` -> i TR-code sono latenti (come gli ecotypes
+del CANON-RECONCILE).
+
+## Fix applicato in questo PR (Strato-2 badlands, opzione B)
+
+Le 22 creature `gameplay-promote` (CANON-RECONCILE #2490) avevano `trait_refs: []`. Riempiti
+i `trait_refs` delle **5 creature badlands** con `suggested_traits` (tutti glossary-valid):
+`echo_wing` / `ferrocolonia_magnetotattica` / `nano_rust_bloom` / `rust_scavenger` /
+`sand_burrower` (5 trait ciascuna). `magneto_ridge_hunter` + `slag_veil_ambusher` non hanno
+suggested_traits -> restano `[]`. Effetto: i tratti ora si attivano in combat (traitEffects
+
+- adapter). Campi prosa (scientific_name, visual_description, functional_signature) restano
+  TODO writer-gated -- NON fabbricati (lore = master-dd/writer).
+
+## Follow-up (nuovi ticket)
+
+| Ticket                 | Cosa                                                                                           | Effort  | Gate / nota                                                          |
+| ---------------------- | ---------------------------------------------------------------------------------------------- | ------- | -------------------------------------------------------------------- |
+| TKT-TRAIT-TRCODE-REMAP | rimappare i 50 `TR-####` -> slug glossary su 10 specie canon (o definirli)                     | audit+  | **headline**; serve la tabella TR-code originale o verdict master-dd |
+| TKT-TRAIT-ORPHAN-MECH  | aggiungere i 4 orphan-mechanic alla glossary via `index.json` source + `sync_missing_index.py` | piccolo | NON hand-edit glossary; passa dal source synced                      |
+| TKT-TRAIT-FLAVOR-MECH  | 106 flavor-only senza meccanica = backlog design (quali meritano un effetto)                   | design  | YAGNI: solo i tratti citati dalle specie gameplay-touched            |
+| TKT-CATALOG-REF-GUARD  | estendere lo guard CI per validare anche `species_catalog.json` trait_refs (oggi latente)      | piccolo | chiuderebbe sia i 50 TR-code sia regressioni future                  |
+
+## Controlli
+
+- `speciesTraitReferences.test.js` (pack yaml refs) verde (badlands suggested_traits gia' ∈
+  glossary).
+- `envelope-b-data-integrity.test.js` verde (catalog 75, base-53 invariata).
+- `validate-dataset.cjs`: le righe gameplay-promote restano valide (trait_refs slug ∈
+  glossary; nessun nuovo TR-code introdotto).


### PR DESCRIPTION
## Wave 3 -- TRAIT-RECONCILE audit + badlands Strato-2 trait_refs

### A -- audit (TKT-TRAIT-RECONCILE, last open Wave-3 audit)
Read-only map, corrects the plan's stale "104 / 57->106":
- `glossary.json` = **604** flavor-only traits (synced from `data/traits/index.json` -> not hand-editable).
- `active_effects.yaml` = **502** with mechanics (498 overlap, **4 orphan-mechanic**, **106 flavor-only**).
- `species_catalog.json` references **177** distinct trait_ids: **127 slugs (all resolve)** +
  **50 `TR-####` legacy codes = ALL dangling** (a 2nd namespace never mapped, on ~10 canon species).
- **Why main is green despite 50 dangling**: the CI guard (`speciesTraitReferences.test.js`)
  validates pack-yaml refs, NOT `species_catalog.json` trait_refs -> latent (like the ecotypes
  bug from CANON-RECONCILE).

Doc: `docs/planning/2026-05-31-trait-reconcile-audit.md` + 4 follow-up tickets
(TR-code remap [headline], orphan-mech glossary sync, flavor-only design backlog, extend CI guard).

### B -- Strato-2 (badlands)
The 22 `gameplay-promote` creatures (CANON-RECONCILE #2490) had `trait_refs: []`. Filled the
**5 badlands** creatures' trait_refs from their glossary-valid `suggested_traits` (echo_wing /
ferrocolonia_magnetotattica / nano_rust_bloom / rust_scavenger / sand_burrower, 5 each).
magneto_ridge_hunter + slag_veil_ambusher have none -> stay []. **Their traits now fire in
combat** (traitEffects + adapter). Prose fields (scientific_name, visual_description,
functional_signature) stay writer-gated TODO -- not fabricated.

### Checks
`speciesTraitReferences` 3/3 + `envelope-b-data-integrity` 27/27 + `validate-dataset.cjs`
(gameplay-promote rows clean, no new TR-codes) + docs governance errors=0.

Coding-Agent: claude-opus-4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
