### PR TITLE
feat(worldgen): promote 13 D4 NEW ecosystems to packs (staging)

### DIFF
--- a/packs/evo_tactics_pack/data/ecosystems/abisso_vulcanico.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/abisso_vulcanico.ecosystem.yaml
@@ -1,0 +1,22 @@
+schema_version: 1.0
+ecosistema:
+  id: ABISSO_VULCANICO
+  label: Abisso Vulcanico
+  biome_id: abisso_vulcanico
+  trofico:
+    produttori:
+    - batteri_chemiosintetici
+    - alghe_termofile
+    consumatori:
+      primari:
+      - fumarisorba-sulfurea
+      secondari: []
+      terziari:
+      - pyrosaltus-celeris
+      - cinerastra-nodosa
+      - magmocardium-furens
+    decompositori:
+    - basaltocara-scutata
+_provenance:
+  trofico: d4-ecoyaml-gen-heuristic-DRAFT
+  produttori: d4-producer-selection-claude-reuse-first-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/atollo_obsidiana.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/atollo_obsidiana.ecosystem.yaml
@@ -1,0 +1,20 @@
+schema_version: 1.0
+ecosistema:
+  id: ATOLLO_OBSIDIANA
+  label: Atollo Obsidiana
+  biome_id: atollo_obsidiana
+  trofico:
+    produttori:
+    - alghe
+    - cianobatteri
+    consumatori:
+      primari: []
+      secondari:
+      - anguis-magnetica
+      terziari:
+      - vitricyba-punctata
+    decompositori:
+    - magnetocola-pastoris
+_provenance:
+  trofico: d4-ecoyaml-gen-heuristic-DRAFT
+  produttori: d4-producer-selection-claude-reuse-first-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/caldera_glaciale.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/caldera_glaciale.ecosystem.yaml
@@ -1,0 +1,20 @@
+schema_version: 1.0
+ecosistema:
+  id: CALDERA_GLACIALE
+  label: Caldera Glaciale
+  biome_id: caldera_glaciale
+  trofico:
+    produttori:
+    - alghe_cryofile
+    - muschi_permafrost
+    consumatori:
+      primari:
+      - rupicapra-sensoria
+      secondari:
+      - psionerva-montis
+      - glaciolabis-nitida
+      terziari: []
+    decompositori: []
+_provenance:
+  trofico: d4-ecoyaml-gen-heuristic-DRAFT
+  produttori: d4-producer-selection-claude-reuse-first-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/canopia_ionica.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/canopia_ionica.ecosystem.yaml
@@ -1,0 +1,19 @@
+schema_version: 1.0
+ecosistema:
+  id: CANOPIA_IONICA
+  label: Canopia Ionica
+  biome_id: canopia_ionica
+  trofico:
+    produttori:
+    - piante_superiori
+    - alghe
+    consumatori:
+      primari: []
+      secondari: []
+      terziari:
+      - soniptera-resonans
+      - sonaraptor-dissonans
+    decompositori: []
+_provenance:
+  trofico: d4-ecoyaml-gen-heuristic-DRAFT
+  produttori: d4-producer-selection-claude-reuse-first-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/canyons_risonanti.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/canyons_risonanti.ecosystem.yaml
@@ -1,0 +1,20 @@
+schema_version: 1.0
+ecosistema:
+  id: CANYONS_RISONANTI
+  label: Canyons Risonanti
+  biome_id: canyons_risonanti
+  trofico:
+    produttori:
+    - licheni_termocromici
+    - arbusti_xerofili
+    consumatori:
+      primari: []
+      secondari:
+      - gulogluteus-scutiger
+      - ventornis-longiala
+      terziari:
+      - lithoraptor-acutornis
+    decompositori: []
+_provenance:
+  trofico: d4-ecoyaml-gen-heuristic-DRAFT
+  produttori: d4-producer-selection-claude-reuse-first-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/caverna.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/caverna.ecosystem.yaml
@@ -1,0 +1,20 @@
+schema_version: 1.0
+ecosistema:
+  id: CAVERNA
+  label: Caverna
+  biome_id: caverna
+  trofico:
+    produttori:
+    - lichene_emette
+    - funghi_chemiosintetici
+    consumatori:
+      primari:
+      - cryptolorca-medicata
+      secondari:
+      - perfusuas-pedes
+      - cavatympa-sonans
+      terziari: []
+    decompositori: []
+_provenance:
+  trofico: d4-ecoyaml-gen-heuristic-DRAFT
+  produttori: d4-producer-selection-claude-reuse-first-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/dorsale_termale_tropicale.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/dorsale_termale_tropicale.ecosystem.yaml
@@ -1,0 +1,19 @@
+schema_version: 1.0
+ecosistema:
+  id: DORSALE_TERMALE_TROPICALE
+  label: Dorsale Termale Tropicale
+  biome_id: dorsale_termale_tropicale
+  trofico:
+    produttori:
+    - cianobatteri
+    - alghe_termali
+    consumatori:
+      primari:
+      - symbiotica-thermalis
+      secondari:
+      - umbra-alaris
+      terziari: []
+    decompositori: []
+_provenance:
+  trofico: d4-ecoyaml-gen-heuristic-DRAFT
+  produttori: d4-producer-selection-claude-reuse-first-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/foresta_acida.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/foresta_acida.ecosystem.yaml
@@ -1,0 +1,18 @@
+schema_version: 1.0
+ecosistema:
+  id: FORESTA_ACIDA
+  label: Foresta Acida
+  biome_id: foresta_acida
+  trofico:
+    produttori:
+    - ifa_psichedelica
+    - funghi_acidofili
+    consumatori:
+      primari: []
+      secondari: []
+      terziari:
+      - chemnotela-toxica
+    decompositori: []
+_provenance:
+  trofico: d4-ecoyaml-gen-heuristic-DRAFT
+  produttori: d4-producer-selection-claude-reuse-first-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/frattura_abissale_sinaptica.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/frattura_abissale_sinaptica.ecosystem.yaml
@@ -1,0 +1,25 @@
+schema_version: 1.0
+ecosistema:
+  id: FRATTURA_ABISSALE_SINAPTICA
+  label: Frattura Abissale Sinaptica
+  biome_id: frattura_abissale_sinaptica
+  trofico:
+    produttori:
+    - batteri_chemiosintetici
+    - alghe_bioluminescenti
+    consumatori:
+      primari:
+      - polpo-araldo-sinaptico
+      secondari:
+      - sonapteryx-resonans
+      terziari:
+      - leviatano-risonante
+      - sciame-larve-neurali
+      - electromanta-abyssalis
+      - tempestarius-psionicus
+    decompositori:
+    - simbionte-corallino-riflesso
+    - radiluma-pendula
+_provenance:
+  trofico: d4-ecoyaml-gen-heuristic-DRAFT
+  produttori: d4-producer-selection-claude-reuse-first-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/palude.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/palude.ecosystem.yaml
@@ -1,0 +1,23 @@
+schema_version: 1.0
+ecosistema:
+  id: PALUDE
+  label: Palude
+  biome_id: palude
+  trofico:
+    produttori:
+    - canneti_palustri
+    - alghe
+    consumatori:
+      primari:
+      - paludogromus-magnus
+      secondari:
+      - proteus-plasma
+      - fusomorpha-palustris
+      - calamipes-gracilis
+      terziari:
+      - limnofalcis-serrata
+      - siltovena-bifida
+    decompositori: []
+_provenance:
+  trofico: d4-ecoyaml-gen-heuristic-DRAFT
+  produttori: d4-producer-selection-claude-reuse-first-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/pianura_salina_iperarida.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/pianura_salina_iperarida.ecosystem.yaml
@@ -1,0 +1,20 @@
+schema_version: 1.0
+ecosistema:
+  id: PIANURA_SALINA_IPERARIDA
+  label: Pianura Salina Iperarida
+  biome_id: pianura_salina_iperarida
+  trofico:
+    produttori:
+    - crostoni_criptofite
+    - cianobatteri
+    consumatori:
+      primari:
+      - salifossa-tenebris
+      - salisucta-alveata
+      secondari:
+      - elastovaranus-hydrus
+      terziari: []
+    decompositori: []
+_provenance:
+  trofico: d4-ecoyaml-gen-heuristic-DRAFT
+  produttori: d4-producer-selection-claude-reuse-first-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/reef_luminescente.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/reef_luminescente.ecosystem.yaml
@@ -1,0 +1,18 @@
+schema_version: 1.0
+ecosistema:
+  id: REEF_LUMINESCENTE
+  label: Reef Luminescente
+  biome_id: reef_luminescente
+  trofico:
+    produttori:
+    - alghe
+    - coralli_simbiotici
+    consumatori:
+      primari: []
+      secondari:
+      - lucinerva-filata
+      terziari: []
+    decompositori: []
+_provenance:
+  trofico: d4-ecoyaml-gen-heuristic-DRAFT
+  produttori: d4-producer-selection-claude-reuse-first-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/savana.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/savana.ecosystem.yaml
@@ -1,0 +1,21 @@
+schema_version: 1.0
+ecosistema:
+  id: SAVANA
+  label: Savana
+  biome_id: savana
+  trofico:
+    produttori:
+    - arbusti_xerofili
+    - cianobatteri
+    consumatori:
+      primari:
+      - arenaceros-placidus
+      secondari: []
+      terziari:
+      - dune-stalker
+      - arenavolux-sagittalis
+      - pulverator-gregarius
+    decompositori: []
+_provenance:
+  trofico: d4-ecoyaml-gen-heuristic-DRAFT
+  produttori: d4-producer-selection-claude-reuse-first-DRAFT


### PR DESCRIPTION
## Cosa

Promote **staging** dei 13 draft ecosystem NEW (D4, master-dd-blessed via #2486) da `docs/planning/ecosystems-draft/` a `packs/evo_tactics_pack/data/ecosystems/`. 13 file nuovi, nient'altro toccato.

## ⚠️ Findings onesti (ground-truth — leggere prima di mergiare)

1. **Band-verify N/A**: ho tracciato i consumatori di `packs/.../ecosystems/` — solo report/export (`docs/evo-tactics-pack/reports/overview.js`, `scripts/evo_pack_pipeline.py`, `export_biodiversity_bundle.py`). Il **combat NON legge gli ecosystems** (`ecosystemResolver`/`foodwebFilter` = 0 consumatori combat; HC06/07 = roster fissi). Quindi promuovere **non puo' muovere le band** HC06/07 → band-verify non applicabile.
2. **Combat-dormant**: questi dati non fanno nulla a runtime finche' non viene costruito il wiring foodweb (`ecosystemResolver -> reinforcementSpawner`, GAP-A non ancora built). Questo e' il vero blocker a "live", non band-verify.
3. **Thin vs canonical**: i draft hanno solo `trofico`. I canonical esistenti hanno anche `clima`/`composizione_aria`/`abiotico` + companion `.biome.yaml`/`.manifest.yaml` + `data/foodwebs/<b>_foodweb.yaml`. Questi 13 sono staging-grade (tag `_provenance: *-DRAFT`); l'arricchimento (clima/abiotico = design data) + i companion restano da fare (master-dd).

## Checks (verde)

- `validate-datasets`: 14 controlli, 0 avvisi, tutti validi.
- `validate-ecosystem-pack`: RC=0 (nessuna collisione biome_id, nessun errore).
- `trace_hashes`: 205 passed. `test_biodiversity_bundle` + `validate_dashboard`: 6 passed.
- JS ecosystem-test ispezionati (no node_modules qui): nessuno globba la dir ecosystems o asserisce conteggi → i 13 nuovi non li rompono.
- `packs/` e' in `.prettierignore` (no prettier). YAML, non `.md` (no governance).

## Esclusi (per scelta)

- 3 DEFER lore-gated: `mezzanotte_orbitale`, `stratosfera_tempestosa`, `steppe_algoritmiche`.
- 2 MERGE (vanno fusi nel canonical esistente, non come file nuovi): `badlands`, `foresta_temperata`.
- `rovine_planari` off-limits (D6).

## NEXT (master-dd / gated)

- Arricchire i 13 a schema canonical (clima/abiotico + `.biome.yaml` + foodweb) — design data.
- Costruire il wiring foodweb (GAP-A) per renderli LIVE nel combat → allora band-verify diventa sensato + obbligatorio.
- Decidere i 3 DEFER (lore) + fondere i 2 MERGE.

Merge = decisione master-dd (canonical packs/ change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)