### PR TITLE
fix(traits): remap 50 dangling TR-#### codes -> glossary slugs + catalog guard (Wave3)

### DIFF
--- a/data/core/species/species_catalog.json
+++ b/data/core/species/species_catalog.json
@@ -85,11 +85,11 @@
         "lagune"
       ],
       "trait_refs": [
-        "TR-1801",
-        "TR-1802",
-        "TR-1803",
-        "TR-1804",
-        "TR-1805"
+        "integumento_bipolare",
+        "elettromagnete_biologico",
+        "scivolamento_magnetico",
+        "filtro_metallofago",
+        "bozzolo_magnetico"
       ],
       "lifecycle_yaml": "data/core/species/anguis_magnetica_lifecycle.yaml",
       "clade_tag": "Bridge",
@@ -155,11 +155,11 @@
         "radure umide"
       ],
       "trait_refs": [
-        "TR-1501",
-        "TR-1502",
-        "TR-1503",
-        "TR-1504",
-        "TR-1505"
+        "zanne_idracida",
+        "seta_conduttiva_elettrica",
+        "articolazioni_a_leva_idraulica",
+        "filtrazione_osmotica",
+        "occhi_analizzatori_di_tensione"
       ],
       "lifecycle_yaml": "data/core/species/chemnotela_toxica_lifecycle.yaml",
       "clade_tag": "Threat",
@@ -315,11 +315,11 @@
         "letto fluviale stagionale"
       ],
       "trait_refs": [
-        "TR-1101",
-        "TR-1102",
-        "TR-1103",
-        "TR-1104",
-        "TR-1105"
+        "rostro_emostatico_litico",
+        "scheletro_idraulico_a_pistoni",
+        "ipertrofia_muscolare_massiva",
+        "ectotermia_dinamica",
+        "organi_sismici_cutanei"
       ],
       "lifecycle_yaml": "data/core/species/elastovaranus_hydrus_lifecycle.yaml",
       "clade_tag": "Playable",
@@ -387,11 +387,11 @@
         "forre umide"
       ],
       "trait_refs": [
-        "TR-1201",
-        "TR-1202",
-        "TR-1203",
-        "TR-1204",
-        "TR-1205"
+        "pelage_idrorepellente_avanzato",
+        "scudo_gluteale_cheratinizzato",
+        "articolazioni_multiassiali",
+        "coda_prensile_muscolare",
+        "rostro_linguale_prensile"
       ],
       "lifecycle_yaml": "data/core/species/gulogluteus_scutiger_lifecycle.yaml",
       "clade_tag": "Playable",
@@ -521,11 +521,11 @@
         "radure notturne"
       ],
       "trait_refs": [
-        "TR-1301",
-        "TR-1302",
-        "TR-1303",
-        "TR-1304",
-        "TR-1305"
+        "ermafroditismo_cronologico",
+        "locomozione_miriapode_ibrida",
+        "estroflessione_gastrica_acida",
+        "artiglio_cinetico_a_urto",
+        "sistemi_chimio_sonici"
       ],
       "lifecycle_yaml": "data/core/species/perfusuas_pedes_lifecycle.yaml",
       "clade_tag": "Bridge",
@@ -652,11 +652,11 @@
         "paludi"
       ],
       "trait_refs": [
-        "TR-1601",
-        "TR-1602",
-        "TR-1603",
-        "TR-1604",
-        "TR-1605"
+        "membrana_plastica_continua",
+        "flusso_ameboide_controllato",
+        "fagocitosi_assorbente",
+        "moltiplicazione_per_fusione",
+        "cisti_di_ibernazione_minerale"
       ],
       "lifecycle_yaml": "data/core/species/proteus_plasma_lifecycle.yaml",
       "clade_tag": "Playable",
@@ -719,11 +719,11 @@
         "prati alpini"
       ],
       "trait_refs": [
-        "TR-2001",
-        "TR-2002",
-        "TR-2003",
-        "TR-2004",
-        "TR-2005"
+        "corna_psico_conduttive",
+        "coscienza_d_alveare_diffusa",
+        "aura_di_dispersione_mentale",
+        "metabolismo_di_condivisione_energetica",
+        "unghie_a_micro_adesione"
       ],
       "lifecycle_yaml": "data/core/species/rupicapra_sensoria_lifecycle.yaml",
       "clade_tag": "Keystone",
@@ -914,11 +914,11 @@
         "praterie arbustive"
       ],
       "trait_refs": [
-        "TR-1701",
-        "TR-1702",
-        "TR-1703",
-        "TR-1704",
-        "TR-1705"
+        "ali_fono_risonanti",
+        "cannone_sonico_a_raggio",
+        "campo_di_interferenza_acustica",
+        "cervello_a_bassa_latenza",
+        "occhi_cinetici"
       ],
       "lifecycle_yaml": "data/core/species/soniptera_resonans_lifecycle.yaml",
       "clade_tag": "Threat",
@@ -981,11 +981,11 @@
         "pianure ventose"
       ],
       "trait_refs": [
-        "TR-1401",
-        "TR-1402",
-        "TR-1403",
-        "TR-1404",
-        "TR-1405"
+        "scheletro_pneumatico_a_maglie",
+        "cinghia_iper_ciliare",
+        "rete_filtro_polmonare",
+        "canto_infrasonico_tattico",
+        "siero_anti_gelo_naturale"
       ],
       "lifecycle_yaml": "data/core/species/terracetus_ambulator_lifecycle.yaml",
       "clade_tag": "Keystone",
@@ -1050,11 +1050,11 @@
         "gole d’ombra"
       ],
       "trait_refs": [
-        "TR-1901",
-        "TR-1902",
-        "TR-1903",
-        "TR-1904",
-        "TR-1905"
+        "vello_di_assorbimento_totale",
+        "visione_multi_spettrale_amplificata",
+        "motore_biologico_silenzioso",
+        "artigli_ipo_termici",
+        "comunicazione_fotonica_coda_coda"
       ],
       "lifecycle_yaml": "data/core/species/umbra_alaris_lifecycle.yaml",
       "clade_tag": "Playable",

--- a/docs/planning/2026-05-31-trait-reconcile-audit.md
+++ b/docs/planning/2026-05-31-trait-reconcile-audit.md
@@ -69,12 +69,12 @@ suggested_traits -> restano `[]`. Effetto: i tratti ora si attivano in combat (t
 
 ## Follow-up (nuovi ticket)
 
-| Ticket                 | Cosa                                                                                           | Effort  | Gate / nota                                                          |
-| ---------------------- | ---------------------------------------------------------------------------------------------- | ------- | -------------------------------------------------------------------- |
-| TKT-TRAIT-TRCODE-REMAP | rimappare i 50 `TR-####` -> slug glossary su 10 specie canon (o definirli)                     | audit+  | **headline**; serve la tabella TR-code originale o verdict master-dd |
-| TKT-TRAIT-ORPHAN-MECH  | aggiungere i 4 orphan-mechanic alla glossary via `index.json` source + `sync_missing_index.py` | piccolo | NON hand-edit glossary; passa dal source synced                      |
-| TKT-TRAIT-FLAVOR-MECH  | 106 flavor-only senza meccanica = backlog design (quali meritano un effetto)                   | design  | YAGNI: solo i tratti citati dalle specie gameplay-touched            |
-| TKT-CATALOG-REF-GUARD  | estendere lo guard CI per validare anche `species_catalog.json` trait_refs (oggi latente)      | piccolo | chiuderebbe sia i 50 TR-code sia regressioni future                  |
+| Ticket                 | Cosa                                                                                           | Effort  | Stato / nota                                                                                                                                           |
+| ---------------------- | ---------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| TKT-TRAIT-TRCODE-REMAP | rimappare i 50 `TR-####` -> slug glossary su 10 specie canon                                   | audit+  | ✅ **RESOLVED**: la mappa esisteva in-repo (`data/external/evo/traits/TR-####.json` campo `id`); 50/50 -> slug, tutti ∈ glossary; remappati in catalog |
+| TKT-CATALOG-REF-GUARD  | estendere il guard CI per validare anche `species_catalog.json` trait_refs (era latente)       | piccolo | ✅ **RESOLVED**: nuovo test in `envelope-b-data-integrity.test.js` (0 TR-code, 0 dangling); previene regressioni                                       |
+| TKT-TRAIT-ORPHAN-MECH  | aggiungere i 4 orphan-mechanic alla glossary via `index.json` source + `sync_missing_index.py` | piccolo | aperto -- NON hand-edit glossary; passa dal source synced                                                                                              |
+| TKT-TRAIT-FLAVOR-MECH  | 106 flavor-only senza meccanica = backlog design (quali meritano un effetto)                   | design  | aperto -- YAGNI: solo i tratti citati dalle specie gameplay-touched                                                                                    |
 
 ## Controlli
 

--- a/tests/api/envelope-b-data-integrity.test.js
+++ b/tests/api/envelope-b-data-integrity.test.js
@@ -197,6 +197,26 @@ describe('OD-027 + OD-031 — species_catalog.json Pack v2 merge', () => {
     }
   });
 
+  test('every catalog trait_ref resolves to glossary (no TR-#### codes, no dangling) -- TKT-CATALOG-REF-GUARD', () => {
+    // Wave3 TRAIT-RECONCILE: the species_catalog trait_refs were previously NOT
+    // CI-guarded (the pack-yaml guard in speciesTraitReferences.test.js covers a
+    // different surface), so 50 legacy TR-#### codes sat dangling. After the remap
+    // (TR-####.json id -> slug) every catalog trait_ref must resolve to glossary.json.
+    const glossPath = path.join(REPO_ROOT, 'data', 'core', 'traits', 'glossary.json');
+    const gloss = JSON.parse(fs.readFileSync(glossPath, 'utf8')).traits;
+    const dangling = [];
+    for (const entry of catalog.catalog) {
+      for (const ref of entry.trait_refs || []) {
+        if (/^TR-\d+$/.test(ref)) {
+          dangling.push(`${entry.species_id}:${ref} (un-remapped TR-code)`);
+        } else if (!(ref in gloss)) {
+          dangling.push(`${entry.species_id}:${ref} (not in glossary)`);
+        }
+      }
+    }
+    assert.equal(dangling.length, 0, `dangling trait_refs:\n  ${dangling.join('\n  ')}`);
+  });
+
   test('lifecycle_yaml path points to existing YAML (when present)', () => {
     // ADR-2026-05-15 Phase 1: legacy-yaml-merge entries (38 species) have
     // lifecycle_yaml=null since no per-species lifecycle file exists.


### PR DESCRIPTION
## Wave 3 -- close the TRAIT-RECONCILE headline: remap 50 dangling TR-#### codes

The audit (#2501) flagged 50 `TR-####` legacy codes on 10 canon species as dangling
(in neither glossary nor active_effects). Turns out **the mapping existed in-repo all
along**: `data/external/evo/traits/TR-####.json` each carry an `id` slug field.

- **50/50** TR-codes -> slug, **all already in glossary.json** -> remapped in
  `species_catalog.json`. Result: **0 TR-codes, 0 non-glossary refs** in the catalog.
- Species touched (5 refs each): anguis_magnetica, chemnotela_toxica, elastovaranus_hydrus,
  gulogluteus_scutiger, perfusuas_pedes, proteus_plasma, rupicapra_sensoria,
  soniptera_resonans, terracetus_ambulator, umbra_alaris.

**Also closes TKT-CATALOG-REF-GUARD**: new test in `envelope-b-data-integrity.test.js`
asserts every catalog `trait_ref` resolves to glossary (no TR-codes, no dangling) ->
prevents regression (the existing `speciesTraitReferences` guard covers pack-yaml, a
different surface). This is exactly the latency that let the 50 codes sit unnoticed.

Audit doc updated: **2 of 4 follow-ups now RESOLVED** (TRCODE-REMAP + CATALOG-REF-GUARD).
Remaining open: orphan-mech glossary sync (4), flavor-only design backlog (106).

### Checks
envelope-b 28/28 (incl. new guard) + validate-dataset.cjs (rows clean) + pack guard 3/3
+ docs governance errors=0.

Coding-Agent: claude-opus-4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
