### PR TITLE
feat(worldgen): GAP-C fase 2 arc-conditions Stage 1 [TKT-WORLDGEN-GAPC]

### DIFF
--- a/apps/backend/routes/campaign.js
+++ b/apps/backend/routes/campaign.js
@@ -206,7 +206,7 @@ function createCampaignRouter(options = {}) {
   // a node on the meta-network graph. Flag-gated OFF by default — when
   // META_NETWORK_ROUTING !== 'true' it returns { enabled: false } and does NOT
   // touch campaign flow (band-safe / back-compat, Gate-5 surface without wiring
-  // into /advance). Query: ?from=<NODE_ID>&cleared=A,B&allow_revisit=1&season=winter
+  // into /advance). Query: ?from=<NODE_ID>&cleared=A,B&allow_revisit=1&campaign_id=<id>&season=winter
   // Fase 2 (arc-conditions, Stage 1, ADR-2026-05-31): edges may carry a
   // `conditions:` block (season / prior_node_cleared) = Dormans lock-and-key. The
   // `season` query param feeds the evaluator (live source =
@@ -224,10 +224,19 @@ function createCampaignRouter(options = {}) {
         ? req.query.cleared.split(',').map((s) => s.trim())
         : [];
     const allowRevisit = req.query.allow_revisit === '1' || req.query.allow_revisit === 'true';
-    // Fase 2 (arc-conditions, Stage 1): the current season feeds season-gated
-    // edges. Diagnostic source = ?season= (mirrors ?cleared=); the live campaign
-    // season is campaignSeasonalState.current_season.
-    const season = typeof req.query.season === 'string' ? req.query.season : undefined;
+    // Fase 2 (arc-conditions, Stage 1): season feeds season-gated edges. Prefer the
+    // LIVE campaign season (campaignSeasonalState, advanced via the seasonal routes)
+    // when ?campaign_id= is supplied; ?season= is a diagnostic override. Read-only
+    // .get() (NOT _getOrInitSeasonalState) so this diagnostic never creates seasonal
+    // state for an arbitrary id. Absent/unknown -> undefined -> season-gated edges
+    // fail-closed (band-safe).
+    const seasonOverride = typeof req.query.season === 'string' ? req.query.season : undefined;
+    const campaignId =
+      typeof req.query.campaign_id === 'string' ? req.query.campaign_id.trim() : '';
+    const liveSeason = campaignId
+      ? campaignSeasonalState.get(campaignId)?.current_season
+      : undefined;
+    const season = seasonOverride ?? liveSeason;
     const routing = selectNextNodes(from, { graph, clearedNodes, allowRevisit, season });
     return res.json({
       enabled: true,

--- a/apps/backend/routes/campaign.js
+++ b/apps/backend/routes/campaign.js
@@ -206,8 +206,11 @@ function createCampaignRouter(options = {}) {
   // a node on the meta-network graph. Flag-gated OFF by default — when
   // META_NETWORK_ROUTING !== 'true' it returns { enabled: false } and does NOT
   // touch campaign flow (band-safe / back-compat, Gate-5 surface without wiring
-  // into /advance). Query: ?from=<NODE_ID>&cleared=A,B&allow_revisit=1
-  // Arc-conditions + node->encounter resolution are POST-MVP (spec §7).
+  // into /advance). Query: ?from=<NODE_ID>&cleared=A,B&allow_revisit=1&season=winter
+  // Fase 2 (arc-conditions, Stage 1, ADR-2026-05-31): edges may carry a
+  // `conditions:` block (season / prior_node_cleared) = Dormans lock-and-key. The
+  // `season` query param feeds the evaluator (live source =
+  // campaignSeasonalState.current_season). node->encounter resolution stays POST-MVP.
   router.get('/campaign/meta-network/next', (req, res) => {
     const enabled = process.env.META_NETWORK_ROUTING === 'true';
     if (!enabled) {
@@ -221,7 +224,11 @@ function createCampaignRouter(options = {}) {
         ? req.query.cleared.split(',').map((s) => s.trim())
         : [];
     const allowRevisit = req.query.allow_revisit === '1' || req.query.allow_revisit === 'true';
-    const routing = selectNextNodes(from, { graph, clearedNodes, allowRevisit });
+    // Fase 2 (arc-conditions, Stage 1): the current season feeds season-gated
+    // edges. Diagnostic source = ?season= (mirrors ?cleared=); the live campaign
+    // season is campaignSeasonalState.current_season.
+    const season = typeof req.query.season === 'string' ? req.query.season : undefined;
+    const routing = selectNextNodes(from, { graph, clearedNodes, allowRevisit, season });
     return res.json({
       enabled: true,
       network_id: graph ? graph.id : null,

--- a/apps/backend/services/worldgen/metaNetworkResolver.js
+++ b/apps/backend/services/worldgen/metaNetworkResolver.js
@@ -11,7 +11,8 @@
 //   network:
 //     id: ET_NET_ALPHA
 //     nodes: [{ id, biome_id, path, weight }]
-//     edges: [{ from, to, type, resistance, seasonality, notes }]
+//     edges: [{ from, to, type, resistance, seasonality, notes, conditions? }]
+//       conditions (fase 2, schema 2.1): optional arc-condition map (lock-and-key)
 //
 // API:
 //   getNetwork()              -> { id, label, nodes:[...], edges:[...] } | null
@@ -67,6 +68,11 @@ function _load() {
     resistance: Number.isFinite(Number(e.resistance)) ? Number(e.resistance) : 0,
     seasonality: e.seasonality != null ? String(e.seasonality) : null,
     notes: e.notes != null ? String(e.notes) : null,
+    // Fase 2 (arc-conditions, schema 2.1): carry the edge `conditions:` block
+    // verbatim (ADR-2026-05-31). The resolver stays "dumb" — it does NOT
+    // interpret conditions; metaNetworkRouting evaluates them. Absent -> null.
+    // Without this pass-through the mapper would silently drop conditions.
+    conditions: e.conditions != null ? e.conditions : null,
   }));
 
   const nodeIndex = new Map();

--- a/apps/backend/services/worldgen/metaNetworkRouting.js
+++ b/apps/backend/services/worldgen/metaNetworkRouting.js
@@ -1,4 +1,4 @@
-// Meta-network campaign routing — TKT-WORLDGEN-GAPC MVP fase 1 (2026-05-31).
+// Meta-network campaign routing — TKT-WORLDGEN-GAPC (MVP fase 1 + fase 2 arc-conditions).
 //
 // Pure next-node selection over the meta-network graph. Q4 verdict =
 // player-choice (Into the Breach / Slay the Spire): given the current node and
@@ -7,20 +7,39 @@
 // auto-pick. The Godot HUD renders the choice (fase 3); the backend supplies the
 // candidates + a deterministic order so tests + replays are stable.
 //
-// MVP conditions are TOPOLOGY-ONLY (no new data fields, no data mutation): a
-// candidate is eligible unless its target node is already cleared
-// (prior_node_cleared), unless ctx.allowRevisit. Richer arc-conditions
-// (requires_trait / min_pressure / season / biome_affinity) need a YAML schema
-// bump = DATA GATE, deferred to fase 2 (spec §7.3-Q2, master-dd verdict).
+// Fase 1: TOPOLOGY-ONLY filter (anti-revisit: a candidate is excluded if its
+// target node is already cleared, unless ctx.allowRevisit).
+//
+// Fase 2 (arc-conditions, ADR-2026-05-31 ACCEPTED — Stage 1): edges may carry a
+// `conditions:` block = Dormans lock-and-key (an edge is a door, the condition is
+// the key). Semantics (ADR D1):
+//   - no conditions block / empty -> always eligible (passthrough, back-compat);
+//   - AND across keys (all must pass);
+//   - OR within a list-value (e.g. season: [winter, autumn] -> any match);
+//   - fail-closed: a required state missing, or an unknown/not-yet-implemented
+//     condition key, blocks the edge (band-safe: at worst the caller falls back
+//     to the static route — a gate never silently opens).
+// Stage-1 evaluators: { season, prior_node_cleared }. min_pressure/max_pressure
+// + biome_affinity are fase-2 v1.1 (ADR) and hit the unknown-key fail-closed
+// path until implemented. NOTE: the prior_node_cleared CONDITION is a
+// PREREQUISITE ("node Y must be cleared to traverse this edge") — distinct from
+// the anti-revisit gate that excludes already-cleared TARGET nodes.
+//
+// Parallel edges: a target is eligible if AT LEAST ONE edge to it passes both
+// gates (OR across parallel edges); it is reported blocked only when NO edge to
+// it passes. Representative edge = lowest resistance; all types kept in
+// edge_types so no routing info is lost.
 //
 // Deterministic ordering: weight DESC, then node_id ASC. No RNG (keeps the MVP
-// reproducible; weighted-random is an opt-in fase-2/3 alternative, spec §7.3-Q4).
+// reproducible; weighted-random is an opt-in fase-3 alternative).
 //
 // Pure: graph + context injected; no I/O. Mirrors foodwebFilter's thin-transform
 // role. Returns:
 //   { applied, from, candidates:[{node_id, biome_id, weight, edge_type,
-//     resistance, seasonality}], excluded:[node_id], reason }
-//   reason ∈ no_graph | no_node | terminal | all_cleared | filtered | eligible
+//     resistance, seasonality, edge_types}], excluded:[node_id],
+//     blocked:[{node_id, blocked_by}], reason }
+//   reason ∈ no_graph | no_node | terminal | all_cleared | all_blocked |
+//            filtered | eligible
 
 'use strict';
 
@@ -30,6 +49,43 @@ function _norm(v) {
     .toLowerCase();
 }
 
+function _list(v) {
+  return Array.isArray(v) ? v : [v];
+}
+
+// Arc-condition evaluators (fase 2, Stage 1). Each is pure: (value, ctx) -> bool.
+// Adding a key here makes it "known"; unknown keys fail closed in _evalEdgeConditions.
+const _COND = {
+  // Current campaign season is in the allowed set (EN enum, case-insensitive).
+  // Reads ctx.season (e.g. campaignSeasonalState.current_season). Fail-closed
+  // when absent: a season-gated edge stays locked until the season is known.
+  season(value, ctx) {
+    if (ctx.season == null) return false;
+    return _list(value).map(_norm).includes(_norm(ctx.season));
+  },
+  // PREREQUISITE key: every listed node must be in ctx.clearedNodes.
+  prior_node_cleared(value, ctx) {
+    const cleared = new Set((Array.isArray(ctx.clearedNodes) ? ctx.clearedNodes : []).map(_norm));
+    return _list(value).every((id) => cleared.has(_norm(id)));
+  },
+};
+
+// Evaluate an edge's conditions against ctx. Returns { ok, blocked_by }.
+// No conditions / empty -> ok (passthrough). AND across keys; the first failing
+// or unknown key -> { ok:false, blocked_by:key }.
+function _evalEdgeConditions(conditions, ctx) {
+  if (!conditions || typeof conditions !== 'object') return { ok: true, blocked_by: null };
+  const keys = Object.keys(conditions);
+  if (keys.length === 0) return { ok: true, blocked_by: null };
+  for (const key of keys) {
+    const evaluator = _COND[key];
+    if (!evaluator || !evaluator(conditions[key], ctx)) {
+      return { ok: false, blocked_by: key };
+    }
+  }
+  return { ok: true, blocked_by: null };
+}
+
 function selectNextNodes(currentNodeId, ctx = {}) {
   const graph = ctx.graph || null;
   const empty = (applied, reason) => ({
@@ -37,6 +93,7 @@ function selectNextNodes(currentNodeId, ctx = {}) {
     from: currentNodeId || null,
     candidates: [],
     excluded: [],
+    blocked: [],
     reason,
   });
 
@@ -65,12 +122,21 @@ function selectNextNodes(currentNodeId, ctx = {}) {
   // via both corridor and trophic_spillover). Representative edge = the
   // easiest-to-traverse (lowest resistance); all parallel edge types are kept
   // in edge_types so no routing info is lost.
-  const byTarget = new Map(); // node_id key -> candidate
-  const excludedSet = new Set();
+  const byTarget = new Map(); // node_id key -> candidate (edge passed both gates)
+  const clearExcluded = new Set(); // target node already cleared (anti-revisit)
+  const condBlockedBy = new Map(); // target key -> { node_id, blocked_by } (arc-condition)
   for (const e of outgoing) {
     const toKey = _norm(e.to);
     if (!allowRevisit && cleared.has(toKey)) {
-      excludedSet.add(e.to);
+      clearExcluded.add(e.to);
+      continue;
+    }
+    const cond = _evalEdgeConditions(e.conditions, ctx);
+    if (!cond.ok) {
+      // Record once per target; a later parallel edge may still pass (OR).
+      if (!condBlockedBy.has(toKey)) {
+        condBlockedBy.set(toKey, { node_id: e.to, blocked_by: cond.blocked_by });
+      }
       continue;
     }
     const targetNode = nodeByKey.get(toKey) || null;
@@ -101,17 +167,31 @@ function selectNextNodes(currentNodeId, ctx = {}) {
 
   const candidates = [...byTarget.values()];
   for (const c of candidates) c.edge_types.sort();
+
+  // A target blocked by a condition is only "blocked" if NO edge to it passed
+  // (OR across parallel edges).
+  const blocked = [];
+  for (const [toKey, info] of condBlockedBy) {
+    if (!byTarget.has(toKey)) blocked.push(info);
+  }
+
+  const excludedSet = new Set(clearExcluded);
+  for (const b of blocked) excludedSet.add(b.node_id);
   const excluded = [...excludedSet];
 
   // Deterministic: weight DESC, then node_id ASC.
   candidates.sort((a, b) => b.weight - a.weight || a.node_id.localeCompare(b.node_id));
 
   let reason;
-  if (candidates.length === 0) reason = 'all_cleared';
-  else if (excluded.length > 0) reason = 'filtered';
-  else reason = 'eligible';
+  if (candidates.length === 0) {
+    reason = blocked.length > 0 ? 'all_blocked' : 'all_cleared';
+  } else if (excluded.length > 0) {
+    reason = 'filtered';
+  } else {
+    reason = 'eligible';
+  }
 
-  return { applied: true, from: currentNodeId, candidates, excluded, reason };
+  return { applied: true, from: currentNodeId, candidates, excluded, blocked, reason };
 }
 
 module.exports = { selectNextNodes };

--- a/packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
@@ -1,9 +1,9 @@
-schema_version: 2.0
+schema_version: 2.1
 receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: e362055b1ea59deb44a2b73bfaf8de6d4270dcfe4b1646d57fd79573742de7c2
+  trace_hash: daa14cfa4bcc63136485c46c1b99275980b5d66865477d6b72990c826afeb1e3
 links:
   ecosystems:
   - packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
@@ -66,12 +66,19 @@ network:
     resistance: 0.6
     seasonality: inverno
     notes: valichi nevosi con copertura forestale rada
+    # fase-2 arc-condition (ADR-2026-05-31, Stage 1): il valico nevoso si apre
+    # solo d'inverno (lock-and-key). `seasonality` resta flavor; il gate usa
+    # l'enum EN canonico (seasonalEngine.SEASONS).
+    conditions:
+      season: [winter]
   - from: CRYOSTEPPE
     to: FORESTA_TEMPERATA
     type: seasonal_bridge
     resistance: 0.65
     seasonality: inverno profondo
     notes: coltri di ghiaccio creano corridoi di transito sotto chioma
+    conditions:
+      season: [winter]
   - from: CRYOSTEPPE
     to: BADLANDS
     type: trophic_spillover

--- a/tests/api/metaNetworkRouteEndpoint.test.js
+++ b/tests/api/metaNetworkRouteEndpoint.test.js
@@ -164,3 +164,76 @@ test('meta-network/next: season=summer locks the winter bridge (blocked surfaced
     'CRYOSTEPPE blocked_by season surfaced',
   );
 });
+
+function postJson(url, body) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const payload = JSON.stringify(body);
+    const req = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: parsed.pathname + parsed.search,
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(payload),
+        },
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (c) => (data += c));
+        res.on('end', () =>
+          resolve({ status: res.statusCode, body: data ? JSON.parse(data) : null }),
+        );
+      },
+    );
+    req.on('error', reject);
+    req.end(payload);
+  });
+}
+
+// initialState = spring; advance-season 3x -> summer -> autumn -> winter.
+async function advanceToWinter(url, campaignId) {
+  for (let i = 0; i < 3; i++) {
+    await postJson(`${url}/api/campaign/seasonal/advance-season`, { campaign_id: campaignId });
+  }
+}
+
+// Codex P2 (#2509): the diagnostic must observe the LIVE campaign season
+// (campaignSeasonalState, advanced via the seasonal routes), not only ?season=.
+test('meta-network/next: live campaign season via campaign_id opens the winter bridge (no ?season=)', async (t) => {
+  process.env.META_NETWORK_ROUTING = 'true';
+  t.after(() => {
+    delete process.env.META_NETWORK_ROUTING;
+  });
+  const url = startTestServer(t);
+  await advanceToWinter(url, 'camp-live-winter');
+  const r = await get(
+    `${url}/api/campaign/meta-network/next?from=FORESTA_TEMPERATA&campaign_id=camp-live-winter`,
+  );
+  assert.equal(r.status, 200);
+  const targets = r.body.candidates.map((c) => c.node_id);
+  assert.ok(
+    targets.includes('CRYOSTEPPE'),
+    'live winter -> CRYOSTEPPE bridge open without ?season=',
+  );
+});
+
+test('meta-network/next: ?season= overrides the live campaign season', async (t) => {
+  process.env.META_NETWORK_ROUTING = 'true';
+  t.after(() => {
+    delete process.env.META_NETWORK_ROUTING;
+  });
+  const url = startTestServer(t);
+  await advanceToWinter(url, 'camp-override');
+  const r = await get(
+    `${url}/api/campaign/meta-network/next?from=FORESTA_TEMPERATA&campaign_id=camp-override&season=summer`,
+  );
+  assert.equal(r.status, 200);
+  const targets = r.body.candidates.map((c) => c.node_id);
+  assert.ok(
+    !targets.includes('CRYOSTEPPE'),
+    'summer override locks the bridge despite live winter',
+  );
+});

--- a/tests/api/metaNetworkRouteEndpoint.test.js
+++ b/tests/api/metaNetworkRouteEndpoint.test.js
@@ -132,3 +132,35 @@ test('meta-network/next: flag ON + unknown node -> applied:false no_node (back-c
   assert.equal(r.body.applied, false);
   assert.equal(r.body.reason, 'no_node');
 });
+
+// Fase 2 (arc-conditions, Stage 1, ADR-2026-05-31): the FORESTA_TEMPERATA ->
+// CRYOSTEPPE seasonal_bridge is gated `season: [winter]` in the real alpha graph.
+// The ?season= query param feeds the evaluator end-to-end (Gate-5 surface).
+test('meta-network/next: season=winter opens the winter seasonal_bridge', async (t) => {
+  process.env.META_NETWORK_ROUTING = 'true';
+  t.after(() => {
+    delete process.env.META_NETWORK_ROUTING;
+  });
+  const url = startTestServer(t);
+  const r = await get(`${url}/api/campaign/meta-network/next?from=FORESTA_TEMPERATA&season=winter`);
+  assert.equal(r.status, 200);
+  const targets = r.body.candidates.map((c) => c.node_id);
+  assert.ok(targets.includes('CRYOSTEPPE'), 'winter -> CRYOSTEPPE bridge eligible');
+});
+
+test('meta-network/next: season=summer locks the winter bridge (blocked surfaced)', async (t) => {
+  process.env.META_NETWORK_ROUTING = 'true';
+  t.after(() => {
+    delete process.env.META_NETWORK_ROUTING;
+  });
+  const url = startTestServer(t);
+  const r = await get(`${url}/api/campaign/meta-network/next?from=FORESTA_TEMPERATA&season=summer`);
+  assert.equal(r.status, 200);
+  const targets = r.body.candidates.map((c) => c.node_id);
+  assert.ok(!targets.includes('CRYOSTEPPE'), 'summer -> CRYOSTEPPE bridge locked');
+  assert.ok(
+    Array.isArray(r.body.blocked) &&
+      r.body.blocked.some((b) => b.node_id === 'CRYOSTEPPE' && b.blocked_by === 'season'),
+    'CRYOSTEPPE blocked_by season surfaced',
+  );
+});

--- a/tests/worldgen/metaNetworkResolver.test.js
+++ b/tests/worldgen/metaNetworkResolver.test.js
@@ -68,3 +68,25 @@ test('getOutgoingEdges: case-insensitive on source node', () => {
   assert.equal(lower.length, upper.length, 'same edge count regardless of case');
   assert.ok(upper.length >= 1);
 });
+
+// --- TKT-WORLDGEN-GAPC fase 2 (arc-conditions, Stage 1) — ADR-2026-05-31 ACCEPTED.
+// The resolver must PASS THROUGH the new edge `conditions:` block (schema 2.1).
+// The mapper previously dropped unknown fields -> conditions would be a silent
+// no-op for routing. Resolver stays "dumb": it carries conditions verbatim,
+// routing interprets them.
+test('getOutgoingEdges: every edge exposes a conditions field (null when absent)', () => {
+  _resetCache();
+  const edges = getOutgoingEdges('BADLANDS');
+  for (const e of edges) assert.ok('conditions' in e, 'edge exposes conditions key');
+  const toForesta = edges.find((e) => e.to === 'FORESTA_TEMPERATA');
+  assert.equal(toForesta.conditions, null, 'corridor edge with no gate -> conditions null');
+});
+
+test('arc-conditions data: winter seasonal_bridge edges gate on season [winter]', () => {
+  _resetCache();
+  const edges = getOutgoingEdges('FORESTA_TEMPERATA');
+  const toCryo = edges.find((e) => e.to === 'CRYOSTEPPE');
+  assert.ok(toCryo, 'FORESTA_TEMPERATA -> CRYOSTEPPE present');
+  assert.ok(toCryo.conditions && Array.isArray(toCryo.conditions.season), 'season list present');
+  assert.deepEqual(toCryo.conditions.season, ['winter']);
+});

--- a/tests/worldgen/metaNetworkRouting.test.js
+++ b/tests/worldgen/metaNetworkRouting.test.js
@@ -154,3 +154,117 @@ test('selectNextNodes: single edge still exposes edge_types as a 1-element array
   assert.equal(res.candidates[0].edge_type, 'corridor');
   assert.deepEqual(res.candidates[0].edge_types, ['corridor']);
 });
+
+// --- TKT-WORLDGEN-GAPC fase 2 (arc-conditions, Stage 1) — ADR-2026-05-31 ACCEPTED.
+// Edge `conditions:` block = Dormans lock-and-key. Semantics (ADR D1): AND across
+// keys, OR within a list-value, fail-closed on missing state / unknown key,
+// passthrough (always eligible) when no conditions block (back-compat). v1 keys =
+// { season, prior_node_cleared }. NOTE: prior_node_cleared CONDITION is a
+// PREREQUISITE ("node Y must be cleared to traverse") — distinct from the :72
+// anti-revisit gate that excludes already-cleared TARGET nodes.
+function condGraph(conditions) {
+  return {
+    nodes: [
+      { id: 'A', weight: 0 },
+      { id: 'B', biome_id: 'biome_b', weight: 0.5 },
+    ],
+    edges: [{ from: 'A', to: 'B', type: 'seasonal_bridge', resistance: 0.6, conditions }],
+  };
+}
+
+test('arc-conditions: no conditions block -> always eligible (back-compat) + blocked []', () => {
+  const res = selectNextNodes('A', {
+    graph: condGraph(undefined),
+    clearedNodes: [],
+    season: 'summer',
+  });
+  assert.equal(res.candidates.length, 1);
+  assert.equal(res.candidates[0].node_id, 'B');
+  assert.deepEqual(res.blocked, []);
+});
+
+test('arc-conditions: season match -> eligible', () => {
+  const res = selectNextNodes('A', {
+    graph: condGraph({ season: ['winter'] }),
+    clearedNodes: [],
+    season: 'winter',
+  });
+  assert.equal(res.candidates.length, 1);
+  assert.equal(res.candidates[0].node_id, 'B');
+});
+
+test('arc-conditions: season mismatch -> blocked, reason all_blocked, blocked_by season', () => {
+  const res = selectNextNodes('A', {
+    graph: condGraph({ season: ['winter'] }),
+    clearedNodes: [],
+    season: 'summer',
+  });
+  assert.equal(res.candidates.length, 0);
+  assert.equal(res.reason, 'all_blocked');
+  assert.deepEqual(res.blocked, [{ node_id: 'B', blocked_by: 'season' }]);
+  assert.deepEqual(res.excluded, ['B']);
+});
+
+test('arc-conditions: season OR within a list-value', () => {
+  const res = selectNextNodes('A', {
+    graph: condGraph({ season: ['winter', 'autumn'] }),
+    clearedNodes: [],
+    season: 'autumn',
+  });
+  assert.equal(res.candidates.length, 1);
+});
+
+test('arc-conditions: season match is case-insensitive', () => {
+  const res = selectNextNodes('A', {
+    graph: condGraph({ season: ['winter'] }),
+    clearedNodes: [],
+    season: 'Winter',
+  });
+  assert.equal(res.candidates.length, 1);
+});
+
+test('arc-conditions: season fails closed when ctx.season is absent', () => {
+  const res = selectNextNodes('A', { graph: condGraph({ season: ['winter'] }), clearedNodes: [] });
+  assert.equal(res.candidates.length, 0);
+  assert.equal(res.blocked[0].blocked_by, 'season');
+});
+
+test('arc-conditions: prior_node_cleared requires the prerequisite node be cleared', () => {
+  const ok = selectNextNodes('A', {
+    graph: condGraph({ prior_node_cleared: ['X'] }),
+    clearedNodes: ['X'],
+  });
+  assert.equal(ok.candidates.length, 1, 'prerequisite X cleared -> eligible');
+  const no = selectNextNodes('A', {
+    graph: condGraph({ prior_node_cleared: ['X'] }),
+    clearedNodes: [],
+  });
+  assert.equal(no.candidates.length, 0, 'prerequisite X not cleared -> blocked');
+  assert.equal(no.blocked[0].blocked_by, 'prior_node_cleared');
+});
+
+test('arc-conditions: AND across keys (season + prior_node_cleared)', () => {
+  const cond = { season: ['winter'], prior_node_cleared: ['X'] };
+  const both = selectNextNodes('A', {
+    graph: condGraph(cond),
+    clearedNodes: ['X'],
+    season: 'winter',
+  });
+  assert.equal(both.candidates.length, 1, 'both pass -> eligible');
+  const half = selectNextNodes('A', {
+    graph: condGraph(cond),
+    clearedNodes: ['X'],
+    season: 'summer',
+  });
+  assert.equal(half.candidates.length, 0, 'one fails -> blocked');
+});
+
+test('arc-conditions: unknown condition key fails closed (band-safe)', () => {
+  const res = selectNextNodes('A', {
+    graph: condGraph({ min_pressure: 3 }),
+    clearedNodes: [],
+    season: 'winter',
+  });
+  assert.equal(res.candidates.length, 0);
+  assert.equal(res.blocked[0].blocked_by, 'min_pressure');
+});


### PR DESCRIPTION
## What

GAP-C **fase 2 — arc-conditions, Stage 1** (Dormans lock-and-key on meta-network edges). Implements the slice authorized by **ADR-2026-05-31 (ACCEPTED)** + spec #2487. An edge is a door; a `conditions:` block is the key.

Stage 1 condition set (ADR gate order): **`season`** (plumbing-proof, live state) + **`prior_node_cleared`** (prerequisite key). `min_pressure`/`max_pressure` + the `campaignPressure` scalar and `biome_affinity` are **v1.1** (deferred per ADR).

## Changes (7 files, +290/-22)

- **`metaNetworkResolver.js`** — edge mapper now passes through the `conditions` block verbatim (was silently stripped; resolver stays "dumb", routing interprets).
- **`metaNetworkRouting.js`** — pure `_evalEdgeConditions` + evaluator registry (`season`, `prior_node_cleared`). ADR D1 semantics: AND across keys, OR within a list-value, **fail-closed** on missing state / unknown key. New `blocked: [{node_id, blocked_by}]` (additive; `excluded` kept for back-compat) + new `all_blocked` reason. Parallel-edge OR: a target is blocked only if NO edge to it passes.
- **`routes/campaign.js`** — `GET /api/campaign/meta-network/next` accepts `?season=` (mirrors `?cleared=`); feeds the evaluator (live source = `campaignSeasonalState.current_season`). Gate-5 surface — still flag-gated `META_NETWORK_ROUTING` OFF by default.
- **`meta_network_alpha.yaml`** (DATA, ADR-authorized) — `schema_version 2.0 → 2.1` + `conditions.season: [winter]` on the **2 winter** `seasonal_bridge` edges (FORESTA_TEMPERATA↔CRYOSTEPPE) + `trace_hash` recomputed. The 3rd `seasonal_bridge` ("notte" = night, not a season) is left **ungated** per the ADR ("don't gate non-season tokens"); the descriptive `seasonality` stays flavor.
- **tests** — routing +9, resolver +2, endpoint +2 (season open/lock + blocked surfaced).

## Band-safety / back-compat

- Flag OFF by default → zero campaign-flow impact (no wiring into `/advance`).
- Edge with **no** `conditions` block → always eligible → the routing is **identical** to fase-1 for every non-gated edge. Routing does not touch stat/combat → WR bands untouched.
- Fail-closed: a missing/unknown condition can only **lock** an edge (caller falls back to static) — a gate never silently opens.

## Verification

- `node --test` worldgen + endpoint: **36/36** (routing 20, resolver 8, endpoint 8).
- AI baseline: **495/495** (no regression).
- Network validators `validate_ecosistema_v2_0` + `validate_cross_foodweb_v1_0`: **exit 0** on schema 2.1.
- `trace_hash` recomputed (only this file; the ~19 pre-existing stale catalog hashes on main are untouched — the CI test only flags `to-fill`).
- `prettier --check`: clean (7 files).
- _(Full `npm run test:api` not run locally — CI covers it; the 3 affected suites + AI baseline run green.)_

## Decisions surfaced (reversible, flagged for review)

- **Unknown condition key → fail-closed** (blocks edge, `blocked_by` surfaced). Conservative; means a future v1.1 key on newer data run by this code locks rather than silently opens.
- Only **2/3** `seasonal_bridge` edges gated (the "notte" one is night, not a season).

## Rollback (03A)

Revert commit `e71b8b26`. Code is flag-gated; the data change is additive (`schema_version 2.1` is back-compat — edges without `conditions` unchanged), so revert is clean.

## Status

**DRAFT — master-dd review.** This PR includes a catalog/data change (`meta_network_alpha.yaml`) → out of auto-merge L3 scope by policy; merge is owner-gated even though the ADR authorized the write. Not merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
