### PR TITLE
feat(worldgen): enrich 16 D4 ecosystems (clima/abiotico) + decide DEFER + fuse MERGE

### DIFF
--- a/packs/evo_tactics_pack/data/ecosystems/abisso_vulcanico.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/abisso_vulcanico.ecosystem.yaml
@@ -3,6 +3,26 @@ ecosistema:
   id: ABISSO_VULCANICO
   label: Abisso Vulcanico
   biome_id: abisso_vulcanico
+  clima:
+    temperatura_C:
+      media_annua: 48.0
+      min_mese_piu_freddo: 15.0
+      max_mese_piu_caldo: 95.0
+    precipitazioni_mm:
+      totale_annuo: 50
+      indice_stagionalita: scarso
+  composizione_aria:
+    gas_maggiori_percento:
+      N2: 70.0
+      O2: 16.0
+      Ar: 0.93
+      CO2: 6.0
+  abiotico:
+    salinita: saline-idrotermale
+    nutrienti:
+      N: medio
+      P: alto
+      K: medio
   trofico:
     produttori:
     - batteri_chemiosintetici
@@ -17,6 +37,9 @@ ecosistema:
       - magmocardium-furens
     decompositori:
     - basaltocara-scutata
+  note: 'Abisso Vulcanico (geothermal): camini di lava pressurizzata, shock termici;
+    chemiosintesi da sfiati solforosi (SO2/H2S).'
 _provenance:
   trofico: d4-ecoyaml-gen-heuristic-DRAFT
   produttori: d4-producer-selection-claude-reuse-first-DRAFT
+  clima_abiotico: d4-claude-design-proposal-grounded(biomes.yaml+vault-biomi-canonical+pf-gm)-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/atollo_obsidiana.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/atollo_obsidiana.ecosystem.yaml
@@ -3,6 +3,26 @@ ecosistema:
   id: ATOLLO_OBSIDIANA
   label: Atollo Obsidiana
   biome_id: atollo_obsidiana
+  clima:
+    temperatura_C:
+      media_annua: 26.0
+      min_mese_piu_freddo: 16.0
+      max_mese_piu_caldo: 36.0
+    precipitazioni_mm:
+      totale_annuo: 1400
+      indice_stagionalita: marino
+  composizione_aria:
+    gas_maggiori_percento:
+      N2: 78.08
+      O2: 20.95
+      Ar: 0.93
+      CO2: 0.04
+  abiotico:
+    salinita: saline-marine
+    nutrienti:
+      N: medio
+      P: medio
+      K: alto
   trofico:
     produttori:
     - alghe
@@ -15,6 +35,9 @@ ecosistema:
       - vitricyba-punctata
     decompositori:
     - magnetocola-pastoris
+  note: 'Atollo Obsidiana (littoral): arcipelago magnetico, maree EMP, piattaforme
+    di vetro vulcanico mobili.'
 _provenance:
   trofico: d4-ecoyaml-gen-heuristic-DRAFT
   produttori: d4-producer-selection-claude-reuse-first-DRAFT
+  clima_abiotico: d4-claude-design-proposal-grounded(biomes.yaml+vault-biomi-canonical+pf-gm)-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
@@ -40,11 +40,14 @@ ecosistema:
       secondari:
       - ferrocolonia-magnetotattica
       - echo-wing
+      - rubrospina-velox
       terziari:
       - dune-stalker
+      - ferrimordax-rutilus
     decompositori:
     - nano-rust-bloom
     - evento-tempesta-ferrosa
+    - ferriscroba-detrita
   note: Ecosistema desertico magnetizzato con pulse detritici stagionali.
 links:
   species_dir: packs/evo_tactics_pack/data/species/badlands

--- a/packs/evo_tactics_pack/data/ecosystems/caldera_glaciale.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/caldera_glaciale.ecosystem.yaml
@@ -3,6 +3,26 @@ ecosistema:
   id: CALDERA_GLACIALE
   label: Caldera Glaciale
   biome_id: caldera_glaciale
+  clima:
+    temperatura_C:
+      media_annua: -8.0
+      min_mese_piu_freddo: -34.0
+      max_mese_piu_caldo: 10.0
+    precipitazioni_mm:
+      totale_annuo: 220
+      indice_stagionalita: invernale
+  composizione_aria:
+    gas_maggiori_percento:
+      N2: 78.08
+      O2: 20.95
+      Ar: 0.93
+      CO2: 0.04
+  abiotico:
+    salinita: brackish
+    nutrienti:
+      N: basso
+      P: basso
+      K: medio
   trofico:
     produttori:
     - alghe_cryofile
@@ -15,6 +35,9 @@ ecosistema:
       - glaciolabis-nitida
       terziari: []
     decompositori: []
+  note: 'Caldera Glaciale (upland): crateri glaciali, geyser criogenici, ghiaccio
+    vivo; risonanza glaciale.'
 _provenance:
   trofico: d4-ecoyaml-gen-heuristic-DRAFT
   produttori: d4-producer-selection-claude-reuse-first-DRAFT
+  clima_abiotico: d4-claude-design-proposal-grounded(biomes.yaml+vault-biomi-canonical+pf-gm)-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/canopia_ionica.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/canopia_ionica.ecosystem.yaml
@@ -3,6 +3,26 @@ ecosistema:
   id: CANOPIA_IONICA
   label: Canopia Ionica
   biome_id: canopia_ionica
+  clima:
+    temperatura_C:
+      media_annua: 18.0
+      min_mese_piu_freddo: 6.0
+      max_mese_piu_caldo: 30.0
+    precipitazioni_mm:
+      totale_annuo: 1600
+      indice_stagionalita: perenne
+  composizione_aria:
+    gas_maggiori_percento:
+      N2: 78.08
+      O2: 20.95
+      Ar: 0.93
+      CO2: 0.04
+  abiotico:
+    salinita: fresh
+    nutrienti:
+      N: medio
+      P: medio
+      K: medio
   trofico:
     produttori:
     - piante_superiori
@@ -14,6 +34,9 @@ ecosistema:
       - soniptera-resonans
       - sonaraptor-dissonans
     decompositori: []
+  note: 'Canopia Ionica (canopy): foresta verticale sospesa da campi elettrostatici,
+    rampicanti conduttivi; ozono di traccia.'
 _provenance:
   trofico: d4-ecoyaml-gen-heuristic-DRAFT
   produttori: d4-producer-selection-claude-reuse-first-DRAFT
+  clima_abiotico: d4-claude-design-proposal-grounded(biomes.yaml+vault-biomi-canonical+pf-gm)-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/caverna.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/caverna.ecosystem.yaml
@@ -3,6 +3,26 @@ ecosistema:
   id: CAVERNA
   label: Caverna
   biome_id: caverna
+  clima:
+    temperatura_C:
+      media_annua: 12.0
+      min_mese_piu_freddo: 10.0
+      max_mese_piu_caldo: 14.0
+    precipitazioni_mm:
+      totale_annuo: 60
+      indice_stagionalita: costante-stillicidio
+  composizione_aria:
+    gas_maggiori_percento:
+      N2: 78.08
+      O2: 19.5
+      Ar: 0.93
+      CO2: 0.3
+  abiotico:
+    salinita: fresh
+    nutrienti:
+      N: basso
+      P: medio
+      K: basso
   trofico:
     produttori:
     - lichene_emette
@@ -15,6 +35,9 @@ ecosistema:
       - cavatympa-sonans
       terziari: []
     decompositori: []
+  note: 'Caverna Risonante (subterranean): gallerie cristalline, eco e pressioni invertite;
+    termoclino stabile, niente luce solare.'
 _provenance:
   trofico: d4-ecoyaml-gen-heuristic-DRAFT
   produttori: d4-producer-selection-claude-reuse-first-DRAFT
+  clima_abiotico: d4-claude-design-proposal-grounded(biomes.yaml+vault-biomi-canonical+pf-gm)-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/dorsale_termale_tropicale.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/dorsale_termale_tropicale.ecosystem.yaml
@@ -3,6 +3,26 @@ ecosistema:
   id: DORSALE_TERMALE_TROPICALE
   label: Dorsale Termale Tropicale
   biome_id: dorsale_termale_tropicale
+  clima:
+    temperatura_C:
+      media_annua: 28.0
+      min_mese_piu_freddo: 18.0
+      max_mese_piu_caldo: 60.0
+    precipitazioni_mm:
+      totale_annuo: 2200
+      indice_stagionalita: perenne-tropicale
+  composizione_aria:
+    gas_maggiori_percento:
+      N2: 78.08
+      O2: 20.95
+      Ar: 0.93
+      CO2: 0.5
+  abiotico:
+    salinita: saline
+    nutrienti:
+      N: medio
+      P: alto
+      K: alto
   trofico:
     produttori:
     - cianobatteri
@@ -14,6 +34,9 @@ ecosistema:
       - umbra-alaris
       terziari: []
     decompositori: []
+  note: 'Dorsale Termale Tropicale (geothermal sommersa): fumarole calde, fauna simbiotica;
+    gradiente idrotermale tropicale.'
 _provenance:
   trofico: d4-ecoyaml-gen-heuristic-DRAFT
   produttori: d4-producer-selection-claude-reuse-first-DRAFT
+  clima_abiotico: d4-claude-design-proposal-grounded(biomes.yaml+vault-biomi-canonical+pf-gm)-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/foresta_acida.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/foresta_acida.ecosystem.yaml
@@ -3,6 +3,26 @@ ecosistema:
   id: FORESTA_ACIDA
   label: Foresta Acida
   biome_id: foresta_acida
+  clima:
+    temperatura_C:
+      media_annua: 26.0
+      min_mese_piu_freddo: 18.0
+      max_mese_piu_caldo: 35.0
+    precipitazioni_mm:
+      totale_annuo: 2800
+      indice_stagionalita: perenne-piogge-acide
+  composizione_aria:
+    gas_maggiori_percento:
+      N2: 76.0
+      O2: 20.0
+      Ar: 0.93
+      CO2: 0.8
+  abiotico:
+    salinita: acida-fresh
+    nutrienti:
+      N: alto
+      P: medio
+      K: basso
   trofico:
     produttori:
     - ifa_psichedelica
@@ -13,6 +33,9 @@ ecosistema:
       terziari:
       - chemnotela-toxica
     decompositori: []
+  note: 'Foresta Acida (canopy): bacini tropicali saturi di piogge corrosive (pH ~4)
+    e flora predatoria (vault card 03).'
 _provenance:
   trofico: d4-ecoyaml-gen-heuristic-DRAFT
   produttori: d4-producer-selection-claude-reuse-first-DRAFT
+  clima_abiotico: d4-claude-design-proposal-grounded(biomes.yaml+vault-biomi-canonical+pf-gm)-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/foresta_temperata.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/foresta_temperata.ecosystem.yaml
@@ -37,6 +37,8 @@ ecosistema:
       primari:
       - cervidi_erborivori
       - impollinatori_misti
+      - nebulocornis-mollis
+      - arboryxis-lenis
       secondari:
       - lupus-temperatus
       terziari:

--- a/packs/evo_tactics_pack/data/ecosystems/frattura_abissale_sinaptica.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/frattura_abissale_sinaptica.ecosystem.yaml
@@ -3,6 +3,26 @@ ecosistema:
   id: FRATTURA_ABISSALE_SINAPTICA
   label: Frattura Abissale Sinaptica
   biome_id: frattura_abissale_sinaptica
+  clima:
+    temperatura_C:
+      media_annua: 4.0
+      min_mese_piu_freddo: 1.0
+      max_mese_piu_caldo: 12.0
+    precipitazioni_mm:
+      totale_annuo: 0
+      indice_stagionalita: abissale-acquatico
+  composizione_aria:
+    gas_maggiori_percento:
+      N2: 78.08
+      O2: 18.0
+      Ar: 0.93
+      CO2: 0.5
+  abiotico:
+    salinita: saline
+    nutrienti:
+      N: medio
+      P: alto
+      K: medio
   trofico:
     produttori:
     - batteri_chemiosintetici
@@ -20,6 +40,9 @@ ecosistema:
     decompositori:
     - simbionte-corallino-riflesso
     - radiluma-pendula
+  note: 'Frattura Abissale Sinaptica (deltaic/abyssal): stratificata 3 livelli, correnti
+    elettroluminescenti, pressione estrema (vault card 06).'
 _provenance:
   trofico: d4-ecoyaml-gen-heuristic-DRAFT
   produttori: d4-producer-selection-claude-reuse-first-DRAFT
+  clima_abiotico: d4-claude-design-proposal-grounded(biomes.yaml+vault-biomi-canonical+pf-gm)-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/mezzanotte_orbitale.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/mezzanotte_orbitale.ecosystem.yaml
@@ -1,0 +1,41 @@
+schema_version: 1.0
+ecosistema:
+  id: MEZZANOTTE_ORBITALE
+  label: Mezzanotte Orbitale
+  biome_id: mezzanotte_orbitale
+  clima:
+    temperatura_C:
+      media_annua: 5.0
+      min_mese_piu_freddo: -40.0
+      max_mese_piu_caldo: 60.0
+    precipitazioni_mm:
+      totale_annuo: 0
+      indice_stagionalita: vuoto-ciclo-orbitale
+  composizione_aria:
+    gas_maggiori_percento:
+      N2: 75.0
+      O2: 21.0
+      Ar: 0.93
+      CO2: 1.5
+  abiotico:
+    salinita: synthetic-recycled
+    nutrienti:
+      N: basso
+      P: basso
+      K: basso
+  trofico:
+    produttori:
+    - funghi_melanici_radiotrofi
+    consumatori:
+      primari: []
+      secondari: []
+      terziari:
+      - noctipedis-umbrata
+    decompositori: []
+  note: 'Mezzanotte Orbitale (upland/artificiale): stazione orbitale in decadimento,
+    gravita variabile; atmosfera riciclata da scrubber in cedimento, base trofica
+    radiotrofa (funghi melanici su radiazione residua).'
+_provenance:
+  trofico: d4-ecoyaml-gen-heuristic-DRAFT
+  produttori: d4-producer-selection-claude-reuse-first-DRAFT
+  clima_abiotico: d4-claude-design-proposal-grounded(biomes.yaml+vault-biomi-canonical+pf-gm)-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/palude.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/palude.ecosystem.yaml
@@ -3,6 +3,26 @@ ecosistema:
   id: PALUDE
   label: Palude
   biome_id: palude
+  clima:
+    temperatura_C:
+      media_annua: 23.0
+      min_mese_piu_freddo: 12.0
+      max_mese_piu_caldo: 34.0
+    precipitazioni_mm:
+      totale_annuo: 1900
+      indice_stagionalita: perenne
+  composizione_aria:
+    gas_maggiori_percento:
+      N2: 76.0
+      O2: 19.0
+      Ar: 0.93
+      CO2: 0.6
+  abiotico:
+    salinita: brackish
+    nutrienti:
+      N: alto
+      P: alto
+      K: medio
   trofico:
     produttori:
     - canneti_palustri
@@ -18,6 +38,9 @@ ecosistema:
       - limnofalcis-serrata
       - siltovena-bifida
     decompositori: []
+  note: 'Palude Tossica (wetland): acque stagnanti bio-luminescenti, fauna mutagena,
+    esalazioni metaniche.'
 _provenance:
   trofico: d4-ecoyaml-gen-heuristic-DRAFT
   produttori: d4-producer-selection-claude-reuse-first-DRAFT
+  clima_abiotico: d4-claude-design-proposal-grounded(biomes.yaml+vault-biomi-canonical+pf-gm)-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/pianura_salina_iperarida.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/pianura_salina_iperarida.ecosystem.yaml
@@ -3,6 +3,26 @@ ecosistema:
   id: PIANURA_SALINA_IPERARIDA
   label: Pianura Salina Iperarida
   biome_id: pianura_salina_iperarida
+  clima:
+    temperatura_C:
+      media_annua: 30.0
+      min_mese_piu_freddo: 4.0
+      max_mese_piu_caldo: 50.0
+    precipitazioni_mm:
+      totale_annuo: 40
+      indice_stagionalita: quasi-nullo
+  composizione_aria:
+    gas_maggiori_percento:
+      N2: 78.08
+      O2: 20.95
+      Ar: 0.93
+      CO2: 0.05
+  abiotico:
+    salinita: hypersaline
+    nutrienti:
+      N: basso
+      P: basso
+      K: molto-alto
   trofico:
     produttori:
     - crostoni_criptofite
@@ -15,6 +35,9 @@ ecosistema:
       - elastovaranus-hydrus
       terziari: []
     decompositori: []
+  note: 'Pianura Salina Iperarida (salt): distese saline ciclotroniche che drenano
+    umidita e riflettono radiazione.'
 _provenance:
   trofico: d4-ecoyaml-gen-heuristic-DRAFT
   produttori: d4-producer-selection-claude-reuse-first-DRAFT
+  clima_abiotico: d4-claude-design-proposal-grounded(biomes.yaml+vault-biomi-canonical+pf-gm)-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/reef_luminescente.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/reef_luminescente.ecosystem.yaml
@@ -3,6 +3,26 @@ ecosistema:
   id: REEF_LUMINESCENTE
   label: Reef Luminescente
   biome_id: reef_luminescente
+  clima:
+    temperatura_C:
+      media_annua: 27.0
+      min_mese_piu_freddo: 22.0
+      max_mese_piu_caldo: 31.0
+    precipitazioni_mm:
+      totale_annuo: 2000
+      indice_stagionalita: marino
+  composizione_aria:
+    gas_maggiori_percento:
+      N2: 78.08
+      O2: 20.95
+      Ar: 0.93
+      CO2: 0.04
+  abiotico:
+    salinita: saline-marine
+    nutrienti:
+      N: medio
+      P: medio
+      K: alto
   trofico:
     produttori:
     - alghe
@@ -13,6 +33,9 @@ ecosistema:
       - lucinerva-filata
       terziari: []
     decompositori: []
+  note: 'Reef Luminescente (littoral): barriere coralline sintetiche, correnti luminescenti,
+    fauna risonante (vault card 07).'
 _provenance:
   trofico: d4-ecoyaml-gen-heuristic-DRAFT
   produttori: d4-producer-selection-claude-reuse-first-DRAFT
+  clima_abiotico: d4-claude-design-proposal-grounded(biomes.yaml+vault-biomi-canonical+pf-gm)-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/savana.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/savana.ecosystem.yaml
@@ -3,6 +3,26 @@ ecosistema:
   id: SAVANA
   label: Savana
   biome_id: savana
+  clima:
+    temperatura_C:
+      media_annua: 24.0
+      min_mese_piu_freddo: 9.0
+      max_mese_piu_caldo: 42.0
+    precipitazioni_mm:
+      totale_annuo: 280
+      indice_stagionalita: estivo
+  composizione_aria:
+    gas_maggiori_percento:
+      N2: 78.08
+      O2: 20.95
+      Ar: 0.93
+      CO2: 0.05
+  abiotico:
+    salinita: arida
+    nutrienti:
+      N: basso
+      P: medio
+      K: alto
   trofico:
     produttori:
     - arbusti_xerofili
@@ -16,6 +36,9 @@ ecosistema:
       - arenavolux-sagittalis
       - pulverator-gregarius
     decompositori: []
+  note: 'Savana Ionizzata (arid): dune fotoniche, tempeste ioniche e sabbia vetrificata;
+    baseline calda/temperata (vault card 01).'
 _provenance:
   trofico: d4-ecoyaml-gen-heuristic-DRAFT
   produttori: d4-producer-selection-claude-reuse-first-DRAFT
+  clima_abiotico: d4-claude-design-proposal-grounded(biomes.yaml+vault-biomi-canonical+pf-gm)-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/steppe_algoritmiche.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/steppe_algoritmiche.ecosystem.yaml
@@ -1,16 +1,16 @@
 schema_version: 1.0
 ecosistema:
-  id: CANYONS_RISONANTI
-  label: Canyons Risonanti
-  biome_id: canyons_risonanti
+  id: STEPPE_ALGORITMICHE
+  label: Steppe Algoritmiche
+  biome_id: steppe_algoritmiche
   clima:
     temperatura_C:
-      media_annua: 16.0
-      min_mese_piu_freddo: -4.0
+      media_annua: 22.0
+      min_mese_piu_freddo: 5.0
       max_mese_piu_caldo: 38.0
     precipitazioni_mm:
-      totale_annuo: 180
-      indice_stagionalita: scarso
+      totale_annuo: 400
+      indice_stagionalita: gestito-irriguo
   composizione_aria:
     gas_maggiori_percento:
       N2: 78.08
@@ -18,25 +18,23 @@ ecosistema:
       Ar: 0.93
       CO2: 0.04
   abiotico:
-    salinita: fresh-arida
+    salinita: gestita-fresh
     nutrienti:
-      N: basso
-      P: medio
+      N: alto
+      P: alto
       K: alto
   trofico:
     produttori:
+    - cianobatteri
     - licheni_termocromici
-    - arbusti_xerofili
     consumatori:
-      primari: []
-      secondari:
-      - gulogluteus-scutiger
-      - ventornis-longiala
-      terziari:
-      - lithoraptor-acutornis
+      primari:
+      - terracetus-ambulator
+      secondari: []
+      terziari: []
     decompositori: []
-  note: 'Canyons Risonanti (clastic): labirinto ventoso di gole armoniche; forte escursione
-    termica, risonanza eolica.'
+  note: 'Steppe Algoritmiche (arid/agri-artificiale): pianure modulari coltivate da
+    IA agricole; base trofica = colture cianobatteriche gestite, pattern mutevoli.'
 _provenance:
   trofico: d4-ecoyaml-gen-heuristic-DRAFT
   produttori: d4-producer-selection-claude-reuse-first-DRAFT

--- a/packs/evo_tactics_pack/data/ecosystems/stratosfera_tempestosa.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/stratosfera_tempestosa.ecosystem.yaml
@@ -1,0 +1,41 @@
+schema_version: 1.0
+ecosistema:
+  id: STRATOSFERA_TEMPESTOSA
+  label: Stratosfera Tempestosa
+  biome_id: stratosfera_tempestosa
+  clima:
+    temperatura_C:
+      media_annua: -20.0
+      min_mese_piu_freddo: -55.0
+      max_mese_piu_caldo: 5.0
+    precipitazioni_mm:
+      totale_annuo: 3000
+      indice_stagionalita: tempesta-perenne
+  composizione_aria:
+    gas_maggiori_percento:
+      N2: 78.08
+      O2: 20.95
+      Ar: 0.93
+      CO2: 0.04
+  abiotico:
+    salinita: aerea
+    nutrienti:
+      N: basso
+      P: basso
+      K: basso
+  trofico:
+    produttori:
+    - aeroplancton_fotosintetico
+    consumatori:
+      primari: []
+      secondari:
+      - zephyrovum-fidelis
+      terziari:
+      - tonitrudens-ferox
+    decompositori: []
+  note: 'Stratosfera Tempestosa (upland): piattaforme aerostatiche tra nubi di tempesta,
+    fulmini e venti supersonici; base trofica = aeroplancton fotosintetico in sospensione.'
+_provenance:
+  trofico: d4-ecoyaml-gen-heuristic-DRAFT
+  produttori: d4-producer-selection-claude-reuse-first-DRAFT
+  clima_abiotico: d4-claude-design-proposal-grounded(biomes.yaml+vault-biomi-canonical+pf-gm)-DRAFT


### PR DESCRIPTION
## Cosa (le 3 cose chieste)

1. **Arricchiti i 13** ecosystem promossi (#2505) con `clima` + `composizione_aria` + `abiotico` + `note` → ora a parita' di schema con i canonical (cryosteppe/badlands).
2. **Decisi i 3 DEFER** — la "domanda lore" e' risolta dalla NOSTRA SoT (`data/core/biomes.yaml`), quindi li ho creati+arricchiti:
   - `mezzanotte_orbitale` = "stazione orbitale in decadimento" → base trofica **radiotrofa** (funghi melanici su radiazione residua).
   - `stratosfera_tempestosa` = "piattaforme aerostatiche tra nubi di tempesta" → **aeroplancton fotosintetico**.
   - `steppe_algoritmiche` = "pianure modulari coltivate da IA agricole" → **colture cianobatteriche gestite**.
3. **Fusi i 2 MERGE** nei canonical esistenti (ADD, non overwrite):
   - `badlands` += rubrospina-velox (sec), ferrimordax-rutilus (terz), ferriscroba-detrita (decomp).
   - `foresta_temperata` += nebulocornis-mollis, arboryxis-lenis (primari, grazer).

18 file in `packs/.../ecosystems/`, nient'altro.

## Grounding (come richiesto: ricerca + nostri doc + vault Pathfinder)

I valori clima/abiotico sono **proposta di design Claude** (`_provenance.clima_abiotico: ...DRAFT`), fondata su:
- **`data/core/biomes.yaml`** (SoT primaria): `biome_class` (arid/geothermal/upland/littoral/salt/canopy/deltaic...) + `summary` + `hazard` + `affixes`.
- **Vault `/c/dev/vault/Atlas/evo-tactics-biomi-canonical/`** (9 card canonical biomi: savana/caverna/foresta_acida/frattura/reef/abisso/steppe — lore + concept).
- **Vault Pathfinder GM** (`guida-completa-master-pathfinder` + bestiari): framework di caratterizzazione ambiente (clima/hazard/terreno/ecologia).
- Archetipo climatico reale per `biome_class` + i numeri.

## Checks (verde)

- `validate-datasets`: 14 controlli, 0 avvisi.
- `validate-ecosystem-pack`: RC=0 (nessuna collisione).
- 214 test python (biodiversity-bundle + dashboard + **trace_hashes 214**).
- `packs/` in `.prettierignore`; yaml non md (no governance).

## ⚠️ Natura + residui

- Clima/abiotico = **proposta autonoma Claude, pending master-dd review** (i numeri sono design, non fatti). Facile da editare nei YAML.
- Restano (master-dd / follow-up): `receipt`/`links`/`rules` + companion `.biome.yaml`/`.manifest.yaml`/`data/foodwebs/<b>_foodweb.yaml` per parita' piena.
- Combat-dormant finche' non c'e' il wiring foodweb (GAP-A) — vedi #2505.
- `rovine_planari` intoccato (D6).

Merge = decisione master-dd (canonical `packs/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)