### PR TITLE
feat(species): Strato-2 lore prose for 11 cryosteppe/deserto/foresta creatures (Wave3)

### DIFF
--- a/data/core/species/species_catalog.json
+++ b/data/core/species/species_catalog.json
@@ -3911,25 +3911,34 @@
     },
     {
       "species_id": "aurora_gull",
-      "scientific_name": "",
+      "scientific_name": "Glacilarus borealis",
       "common_names": [
-        "Gabbiano d’Aurora"
+        "Gabbiano d'Aurora"
       ],
       "classification": {
-        "macro_class": "volatore_planatore",
-        "habitat": "cryosteppe"
+        "macro_class": "Volatore planatore / disperdente-ponte",
+        "habitat": "ponti di ghiaccio e gradienti magnetici (Cryosteppe Magnetica)"
       },
-      "functional_signature": "",
-      "visual_description": "",
+      "functional_signature": "Planatore migratore che sfrutta i gradienti termo-magnetici per coprire lunghe distanze, disperdendo spore e semi tra i lembi di permafrost.",
+      "visual_description": "Volatore slanciato dalle penne iridescenti che virano con la luce d'aurora, ali lunghe da aliante e zampe palmate per i suoli gelati.",
       "risk_profile": {
         "danger_level": 1,
         "vectors": []
       },
       "interactions": {
-        "predates_on": [],
-        "predated_by": []
+        "predates_on": [
+          "licheni_termocromici",
+          "alghe_cryofile"
+        ],
+        "predated_by": [
+          "cryo_lynx"
+        ],
+        "symbiosis": "Disperde spore di muschi_permafrost e licheni"
       },
-      "constraints": [],
+      "constraints": [
+        "Dipende dalle correnti ascensionali diurne",
+        "Vulnerabile al suolo durante le tempeste di ghiaccio"
+      ],
       "sentience_index": "T1",
       "ecotypes": [],
       "trait_refs": [
@@ -3954,36 +3963,39 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "scientific_name",
-        "classification",
-        "functional_signature",
-        "visual_description",
-        "interactions",
-        "constraints",
         "lifecycle_yaml"
-      ]
+      ],
+      "genus": "Glacilarus",
+      "epithet": "borealis"
     },
     {
       "species_id": "cryo_lynx",
-      "scientific_name": "",
+      "scientific_name": "Cryofelis nivalis",
       "common_names": [
-        "Cryo Lynx"
+        "Lince Criogenica"
       ],
       "classification": {
-        "macro_class": "cursoriale_quadrupede",
-        "habitat": "cryosteppe"
+        "macro_class": "Cursore quadrupede / predatore apex",
+        "habitat": "steppe criogeniche e creste innevate (Cryosteppe Magnetica)"
       },
-      "functional_signature": "",
-      "visual_description": "",
+      "functional_signature": "Predatore apex da agguato: insegue le prede sul ghiaccio con artigli ramponanti e pelliccia termo-isolante, colpendo nei gradienti di temperatura.",
+      "visual_description": "Felino compatto dal manto folto screziato di bianco-azzurro, zampe larghe da neve e occhi riflettenti adattati alla penombra polare.",
       "risk_profile": {
         "danger_level": 3,
         "vectors": []
       },
       "interactions": {
-        "predates_on": [],
-        "predated_by": []
+        "predates_on": [
+          "steppe_bison_mini",
+          "aurora_gull"
+        ],
+        "predated_by": [],
+        "symbiosis": "nessuna"
       },
-      "constraints": [],
+      "constraints": [
+        "Caccia inefficiente sopra lo zero termico",
+        "Territorio ampio: bassa densita di popolazione"
+      ],
       "sentience_index": "T1",
       "ecotypes": [],
       "trait_refs": [
@@ -4008,36 +4020,41 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "scientific_name",
-        "classification",
-        "functional_signature",
-        "visual_description",
-        "interactions",
-        "constraints",
         "lifecycle_yaml"
-      ]
+      ],
+      "genus": "Cryofelis",
+      "epithet": "nivalis"
     },
     {
       "species_id": "steppe_bison_mini",
-      "scientific_name": "",
+      "scientific_name": "Nanobison tundrae",
       "common_names": [
         "Bisonte Nano della Steppa"
       ],
       "classification": {
-        "macro_class": "cursoriale_quadrupede",
-        "habitat": "cryosteppe"
+        "macro_class": "Cursore quadrupede / ingegnere d'ecosistema",
+        "habitat": "praterie criogeniche a muschio (Cryosteppe Magnetica)"
       },
-      "functional_signature": "",
-      "visual_description": "",
+      "functional_signature": "Brucatore gregario ingegnere del suolo: pascola muschi e licheni in mandria, compattando la neve e fertilizzando il permafrost che apre nicchie ai produttori.",
+      "visual_description": "Erbivoro tarchiato dal vello lanoso e fitto, corna corte ricurve e zoccoli larghi che distribuiscono il peso sulla crosta gelata.",
       "risk_profile": {
         "danger_level": 1,
         "vectors": []
       },
       "interactions": {
-        "predates_on": [],
-        "predated_by": []
+        "predates_on": [
+          "muschi_permafrost",
+          "licheni_termocromici"
+        ],
+        "predated_by": [
+          "cryo_lynx"
+        ],
+        "symbiosis": "Fertilizza il suolo e dispersa propaguli (mutualismo con i produttori)"
       },
-      "constraints": [],
+      "constraints": [
+        "Dipende dalla copertura vegetale stagionale",
+        "Lento: vulnerabile in branco disperso"
+      ],
       "sentience_index": "T1",
       "ecotypes": [],
       "trait_refs": [
@@ -4062,36 +4079,40 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "scientific_name",
-        "classification",
-        "functional_signature",
-        "visual_description",
-        "interactions",
-        "constraints",
         "lifecycle_yaml"
-      ]
+      ],
+      "genus": "Nanobison",
+      "epithet": "tundrae"
     },
     {
       "species_id": "thaw_rot",
-      "scientific_name": "",
+      "scientific_name": "Geliputris liquefaciens",
       "common_names": [
-        "Thaw Rot"
+        "Marciume del Disgelo"
       ],
       "classification": {
-        "macro_class": "scavenger_corazzato",
-        "habitat": "cryosteppe"
+        "macro_class": "Colonia microbica decompositrice / minaccia patogena",
+        "habitat": "sacche di disgelo e carcasse gelate (Cryosteppe Magnetica)"
       },
-      "functional_signature": "",
-      "visual_description": "",
+      "functional_signature": "Decompositore criofilo: si attiva nei disgeli per liquefare i tessuti gelati, liberando nutrienti ma diffondendo marciume tra gli ospiti indeboliti dal freddo.",
+      "visual_description": "Patina viscida grigio-verde che fiorisce sulle superfici in disgelo, con filamenti gelatinosi e bolle di gas di fermentazione.",
       "risk_profile": {
         "danger_level": 3,
         "vectors": []
       },
       "interactions": {
-        "predates_on": [],
-        "predated_by": []
+        "predates_on": [
+          "carcasse gelate e detrito (decompositore)"
+        ],
+        "predated_by": [
+          "poche specie (deterrente patogeno)"
+        ],
+        "symbiosis": "Antagonista: marciume opportunista sugli ospiti criolesi"
       },
-      "constraints": [],
+      "constraints": [
+        "Attivo solo nei cicli di disgelo",
+        "Inerte sotto i picchi di gelo profondo"
+      ],
       "sentience_index": "T1",
       "ecotypes": [],
       "trait_refs": [
@@ -4116,14 +4137,10 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "scientific_name",
-        "classification",
-        "functional_signature",
-        "visual_description",
-        "interactions",
-        "constraints",
         "lifecycle_yaml"
-      ]
+      ],
+      "genus": "Geliputris",
+      "epithet": "liquefaciens"
     },
     {
       "species_id": "zephyr_spore_courier",
@@ -4176,25 +4193,32 @@
     },
     {
       "species_id": "cactus_weaver",
-      "scientific_name": "",
+      "scientific_name": "Cactotextor hydrophorus",
       "common_names": [
-        "Cactus Weaver"
+        "Tessitore di Cactus"
       ],
       "classification": {
-        "macro_class": "ingegnere_radicante",
-        "habitat": "deserto_caldo"
+        "macro_class": "Produttore radicante / ingegnere idrico",
+        "habitat": "dune vetrificate e lenti magnetiche sotterranee (Deserto Caldo Vetrificato)"
       },
-      "functional_signature": "",
-      "visual_description": "",
+      "functional_signature": "Produttore ingegnere idrico: tesse reti di radici e fusti succulenti che captano e ridistribuiscono l'umidita profonda, creando isole d'ombra che sostengono la fauna.",
+      "visual_description": "Groviglio di fusti spinosi intrecciati a rete, tessuti cerosi color giada e radici fittonanti che affondano verso le lenti d'acqua.",
       "risk_profile": {
         "danger_level": 1,
         "vectors": []
       },
       "interactions": {
         "predates_on": [],
-        "predated_by": []
+        "predated_by": [
+          "silica_bloom",
+          "noctule_termico"
+        ],
+        "symbiosis": "Offre ombra e umidita ai consumatori (specie ombrello)"
       },
-      "constraints": [],
+      "constraints": [
+        "Crescita lentissima legata all'acqua profonda",
+        "Sessile: indifeso contro i brucatori"
+      ],
       "sentience_index": "T1",
       "ecotypes": [],
       "trait_refs": [
@@ -4220,36 +4244,41 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "scientific_name",
-        "classification",
-        "functional_signature",
-        "visual_description",
-        "interactions",
-        "constraints",
         "lifecycle_yaml"
-      ]
+      ],
+      "genus": "Cactotextor",
+      "epithet": "hydrophorus"
     },
     {
       "species_id": "noctule_termico",
-      "scientific_name": "",
+      "scientific_name": "Thermonoctus vagans",
       "common_names": [
-        "Noctule Termico"
+        "Nottola Termica"
       ],
       "classification": {
-        "macro_class": "volatore_planatore",
-        "habitat": "deserto_caldo"
+        "macro_class": "Volatore planatore notturno / disperdente-ponte",
+        "habitat": "cieli notturni e termiche residue del deserto (Deserto Caldo Vetrificato)"
       },
-      "functional_signature": "",
-      "visual_description": "",
+      "functional_signature": "Volatore notturno che caccia insetti e sfrutta le termiche residue del crepuscolo, impollinando i fiori notturni e collegando le isole di vegetazione.",
+      "visual_description": "Piccolo volatore dalle ali membranose scure, grandi padiglioni auricolari per l'ecolocalizzazione e occhi adattati al buio.",
       "risk_profile": {
         "danger_level": 1,
         "vectors": []
       },
       "interactions": {
-        "predates_on": [],
-        "predated_by": []
+        "predates_on": [
+          "insetti notturni",
+          "nettare (cactus_weaver, arbusti_pioneer)"
+        ],
+        "predated_by": [
+          "thermo_raptor"
+        ],
+        "symbiosis": "Impollina i produttori a fioritura notturna"
       },
-      "constraints": [],
+      "constraints": [
+        "Attivo solo di notte (stress termico diurno)",
+        "Fragile nel volo radente"
+      ],
       "sentience_index": "T1",
       "ecotypes": [],
       "trait_refs": [
@@ -4275,36 +4304,41 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "scientific_name",
-        "classification",
-        "functional_signature",
-        "visual_description",
-        "interactions",
-        "constraints",
         "lifecycle_yaml"
-      ]
+      ],
+      "genus": "Thermonoctus",
+      "epithet": "vagans"
     },
     {
       "species_id": "silica_bloom",
-      "scientific_name": "",
+      "scientific_name": "Siliciflora pestifera",
       "common_names": [
-        "Silica Bloom"
+        "Fioritura di Silice"
       ],
       "classification": {
-        "macro_class": "scavenger_corazzato",
-        "habitat": "deserto_caldo"
+        "macro_class": "Colonia microbica silicea / minaccia patogena",
+        "habitat": "croste vetrificate e sabbie ioniche (Deserto Caldo Vetrificato)"
       },
-      "functional_signature": "",
-      "visual_description": "",
+      "functional_signature": "Colonia silicea aggressiva: incrosta i produttori con strutture vetrose, sottraendo substrato e diffondendo schegge patogene nel vento di polvere.",
+      "visual_description": "Efflorescenza cristallina bianco-opalescente che cresce a placche taglienti, scintillante di micro-schegge silicee.",
       "risk_profile": {
         "danger_level": 3,
         "vectors": []
       },
       "interactions": {
-        "predates_on": [],
-        "predated_by": []
+        "predates_on": [
+          "cactus_weaver",
+          "cianobatteri_dune (substrato)"
+        ],
+        "predated_by": [
+          "poche specie (substrato siliceo non commestibile)"
+        ],
+        "symbiosis": "Antagonista: competitore-patogeno dei produttori"
       },
-      "constraints": [],
+      "constraints": [
+        "Espansione legata ai venti ionizzati",
+        "Fragile: le placche si frantumano sotto urto"
+      ],
       "sentience_index": "T1",
       "ecotypes": [],
       "trait_refs": [
@@ -4330,36 +4364,39 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "scientific_name",
-        "classification",
-        "functional_signature",
-        "visual_description",
-        "interactions",
-        "constraints",
         "lifecycle_yaml"
-      ]
+      ],
+      "genus": "Siliciflora",
+      "epithet": "pestifera"
     },
     {
       "species_id": "thermo_raptor",
-      "scientific_name": "",
+      "scientific_name": "Thermoraptor aridus",
       "common_names": [
-        "Thermo Raptor"
+        "Raptor Termico"
       ],
       "classification": {
-        "macro_class": "cursoriale_quadrupede",
-        "habitat": "deserto_caldo"
+        "macro_class": "Cursore quadrupede / predatore apex",
+        "habitat": "distese vetrificate iper-aride (Deserto Caldo Vetrificato)"
       },
-      "functional_signature": "",
-      "visual_description": "",
+      "functional_signature": "Predatore apex termofilo: sfrutta il calore estremo che fiacca le prede, caricando in scatti brevi e letali nelle ore piu roventi.",
+      "visual_description": "Predatore bipede asciutto dalla pelle squamosa chiara riflettente, arti posteriori potenti e creste dorsali termo-disperdenti.",
       "risk_profile": {
         "danger_level": 3,
         "vectors": []
       },
       "interactions": {
-        "predates_on": [],
-        "predated_by": []
+        "predates_on": [
+          "noctule_termico",
+          "silica_bloom"
+        ],
+        "predated_by": [],
+        "symbiosis": "nessuna"
       },
-      "constraints": [],
+      "constraints": [
+        "Surriscalda se attivo troppo a lungo",
+        "Inattivo nelle notti fredde del deserto"
+      ],
       "sentience_index": "T1",
       "ecotypes": [],
       "trait_refs": [
@@ -4385,36 +4422,41 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "scientific_name",
-        "classification",
-        "functional_signature",
-        "visual_description",
-        "interactions",
-        "constraints",
         "lifecycle_yaml"
-      ]
+      ],
+      "genus": "Thermoraptor",
+      "epithet": "aridus"
     },
     {
       "species_id": "blight_micotico",
-      "scientific_name": "",
+      "scientific_name": "Mycotabes corruptor",
       "common_names": [
-        "Blight Micotico"
+        "Piaga Micotica"
       ],
       "classification": {
-        "macro_class": "unknown",
-        "habitat": "foresta_temperata"
+        "macro_class": "Colonia fungina patogena / decompositrice",
+        "habitat": "lettiera umida e cortecce dei corridoi fluviali (Foresta Temperata)"
       },
-      "functional_signature": "",
-      "visual_description": "",
+      "functional_signature": "Fungo patogeno dei boschi: penetra le piante superiori con ife corrosive e libera spore che marciscono la lettiera, accelerando il ciclo detritico.",
+      "visual_description": "Chiazze fungine grigio-violacee che si estendono su tronchi e suolo, con corpi fruttiferi gonfi e velo di spore polverose.",
       "risk_profile": {
         "danger_level": 3,
         "vectors": []
       },
       "interactions": {
-        "predates_on": [],
-        "predated_by": []
+        "predates_on": [
+          "piante_superiori (parassita)",
+          "lettiera (decompositore)"
+        ],
+        "predated_by": [
+          "poche specie (deterrente patogeno)"
+        ],
+        "symbiosis": "Antagonista: patogeno delle piante superiori"
       },
-      "constraints": [],
+      "constraints": [
+        "Richiede umidita elevata costante",
+        "Regredisce nelle stagioni secche"
+      ],
       "sentience_index": "T1",
       "ecotypes": [],
       "trait_refs": [
@@ -4439,14 +4481,10 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "scientific_name",
-        "classification",
-        "functional_signature",
-        "visual_description",
-        "interactions",
-        "constraints",
         "lifecycle_yaml"
-      ]
+      ],
+      "genus": "Mycotabes",
+      "epithet": "corruptor"
     },
     {
       "species_id": "glowcap_weaver",
@@ -4499,25 +4537,31 @@
     },
     {
       "species_id": "lupus_temperatus",
-      "scientific_name": "",
+      "scientific_name": "Silvalupus temperatus",
       "common_names": [
         "Lupo della Foresta"
       ],
       "classification": {
-        "macro_class": "unknown",
-        "habitat": "foresta_temperata"
+        "macro_class": "Cursore quadrupede / predatore apex",
+        "habitat": "boschi temperati e corridoi fluviali (Foresta Temperata)"
       },
-      "functional_signature": "",
-      "visual_description": "",
+      "functional_signature": "Predatore sociale di vertice: caccia in branco coordinato i grandi erbivori, regolando le popolazioni di brucatori lungo i corridoi fluviali.",
+      "visual_description": "Canide robusto dal mantello fulvo-grigio fitto, mascelle potenti e andatura instancabile da inseguitore di resistenza.",
       "risk_profile": {
         "danger_level": 2,
         "vectors": []
       },
       "interactions": {
-        "predates_on": [],
-        "predated_by": []
+        "predates_on": [
+          "cervidi_erborivori"
+        ],
+        "predated_by": [],
+        "symbiosis": "Regola gli erbivori (controllo top-down del pascolo)"
       },
-      "constraints": [],
+      "constraints": [
+        "Dipende dal branco per le prede grandi",
+        "Territorio ampio: conflitti tra branchi"
+      ],
       "sentience_index": "T1",
       "ecotypes": [],
       "trait_refs": [
@@ -4542,14 +4586,10 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "scientific_name",
-        "classification",
-        "functional_signature",
-        "visual_description",
-        "interactions",
-        "constraints",
         "lifecycle_yaml"
-      ]
+      ],
+      "genus": "Silvalupus",
+      "epithet": "temperatus"
     },
     {
       "species_id": "myco_spire_warden",
@@ -4602,25 +4642,29 @@
     },
     {
       "species_id": "sentinella_radice",
-      "scientific_name": "",
+      "scientific_name": "Radicustos vigilans",
       "common_names": [
         "Sentinella Radice"
       ],
       "classification": {
-        "macro_class": "unknown",
-        "habitat": "foresta_temperata"
+        "macro_class": "Organismo radicante sessile / ingegnere d'ecosistema",
+        "habitat": "intrichi radicali e suolo dei boschi temperati (Foresta Temperata)"
       },
-      "functional_signature": "",
-      "visual_description": "",
+      "functional_signature": "Ingegnere radicante semi-sessile: collega le piante superiori in una rete micorrizica difensiva, segnalando e contenendo le minacce che attraversano il suolo.",
+      "visual_description": "Tronco-sentinella nodoso ricoperto di radici aeree sensoriali, con escrescenze a occhio che si schiudono al passaggio di intrusi.",
       "risk_profile": {
         "danger_level": 1,
         "vectors": []
       },
       "interactions": {
         "predates_on": [],
-        "predated_by": []
+        "predated_by": [],
+        "symbiosis": "Rete micorrizica con le piante superiori (mutualismo difensivo)"
       },
-      "constraints": [],
+      "constraints": [
+        "Sessile: nessuna mobilita",
+        "Reazione lenta agli stimoli rapidi"
+      ],
       "sentience_index": "T3",
       "ecotypes": [],
       "trait_refs": [
@@ -4645,14 +4689,10 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "scientific_name",
-        "classification",
-        "functional_signature",
-        "visual_description",
-        "interactions",
-        "constraints",
         "lifecycle_yaml"
-      ]
+      ],
+      "genus": "Radicustos",
+      "epithet": "vigilans"
     }
   ]
 }


### PR DESCRIPTION
## Wave 3 Strato-2 -- lore prose for the remaining 11 creatures

Extends the badlands prose pass (#2508) to cryosteppe/deserto/foresta. Authored the
design-prose fields for **11 gameplay-promote creatures**:
- **cryosteppe**: aurora_gull, cryo_lynx, steppe_bison_mini, thaw_rot
- **deserto_caldo**: cactus_weaver, noctule_termico, silica_bloom, thermo_raptor
- **foresta_temperata**: blight_micotico, lupus_temperatus, sentinella_radice

Same grounding as the approved pilot: voice tassonomico/curioso/naturalista; binomials
per `00E-NAMING_STYLEGUIDE` (genus `^[A-Z][a-z]{3,17}$`, collision-avoided vs real taxa);
functional_signature/visual_description from morphotype + role_trofico + trait_refs;
interactions from each biome's `ecosystem.yaml` foodweb. **Interaction species refs use
canonical underscore ids from the start** (the Codex #2508 lesson); producers/descriptive
strings stay verbatim. Only `lifecycle_yaml` remains TODO.

**All 16 derivable gameplay-promote creatures now have full prose.** The remaining 6
gameplay-promote entries are `role=evento_ecologico` (events, not species:
aurora_bridge_runner, zephyr_spore_courier, glowcap_weaver, myco_spire_warden +
badlands magneto_ridge_hunter, slag_veil_ambusher) -> reclassification follow-up (flagged).

### Checks
envelope-b 28/28 (incl trait-ref guard) + dataset validator (rows clean) +
species/swarm validators 16/16 + JS catalog sweep 42/42.

Coding-Agent: claude-opus-4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
