### PR TITLE
feat(species): grounded lifecycle stubs for 16 authored promotes (Wave3)

### DIFF
--- a/data/core/species/aurora_gull_lifecycle.yaml
+++ b/data/core/species/aurora_gull_lifecycle.yaml
@@ -1,0 +1,63 @@
+species_id: aurora_gull
+label_it: Gabbiano d'Aurora
+doc_status: stub
+doc_owner: auto-seeded
+last_verified: '2026-05-31'
+language: it
+biome_affinity_per_stage:
+  hatchling: cryosteppe
+  juvenile: cryosteppe
+  mature: cryosteppe
+  apex: any
+  legacy: any
+phases:
+  hatchling:
+    id: hatchling
+    label_it: Cucciolo Gabbiano d'Aurora
+    level_range:
+    - 1
+    - 1
+    mutations_required: 0
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  juvenile:
+    id: juvenile
+    label_it: Giovane Gabbiano d'Aurora
+    level_range:
+    - 2
+    - 4
+    mutations_required: 1
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  mature:
+    id: mature
+    label_it: Gabbiano d'Aurora maturo
+    level_range:
+    - 5
+    - 9
+    mutations_required: 2
+    thoughts_internalized_required: 1
+    mbti_polarity_required: true
+  apex:
+    id: apex
+    label_it: Gabbiano d'Aurora apicale
+    level_range:
+    - 10
+    - 14
+    mutations_required: 4
+    thoughts_internalized_required: 2
+    mbti_polarity_required: true
+  legacy:
+    id: legacy
+    label_it: Gabbiano d'Aurora legacy
+    level_range:
+    - 15
+    - 99
+    mutations_required: 5
+    thoughts_internalized_required: 3
+    mbti_polarity_required: true
+_notes:
+- Auto-seeded grounded stub (Wave3 Strato-2, biome-native).
+- 'Customizza: aspect_token, sprite_ascii, tactical_signature, diary_milestone_event
+  per phase.'
+- Cf dune_stalker_lifecycle.yaml come template.

--- a/data/core/species/blight_micotico_lifecycle.yaml
+++ b/data/core/species/blight_micotico_lifecycle.yaml
@@ -1,0 +1,63 @@
+species_id: blight_micotico
+label_it: Piaga Micotica
+doc_status: stub
+doc_owner: auto-seeded
+last_verified: '2026-05-31'
+language: it
+biome_affinity_per_stage:
+  hatchling: foresta_temperata
+  juvenile: foresta_temperata
+  mature: foresta_temperata
+  apex: any
+  legacy: any
+phases:
+  hatchling:
+    id: hatchling
+    label_it: Cucciolo Piaga Micotica
+    level_range:
+    - 1
+    - 1
+    mutations_required: 0
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  juvenile:
+    id: juvenile
+    label_it: Giovane Piaga Micotica
+    level_range:
+    - 2
+    - 4
+    mutations_required: 1
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  mature:
+    id: mature
+    label_it: Piaga Micotica maturo
+    level_range:
+    - 5
+    - 9
+    mutations_required: 2
+    thoughts_internalized_required: 1
+    mbti_polarity_required: true
+  apex:
+    id: apex
+    label_it: Piaga Micotica apicale
+    level_range:
+    - 10
+    - 14
+    mutations_required: 4
+    thoughts_internalized_required: 2
+    mbti_polarity_required: true
+  legacy:
+    id: legacy
+    label_it: Piaga Micotica legacy
+    level_range:
+    - 15
+    - 99
+    mutations_required: 5
+    thoughts_internalized_required: 3
+    mbti_polarity_required: true
+_notes:
+- Auto-seeded grounded stub (Wave3 Strato-2, biome-native).
+- 'Customizza: aspect_token, sprite_ascii, tactical_signature, diary_milestone_event
+  per phase.'
+- Cf dune_stalker_lifecycle.yaml come template.

--- a/data/core/species/cactus_weaver_lifecycle.yaml
+++ b/data/core/species/cactus_weaver_lifecycle.yaml
@@ -1,0 +1,63 @@
+species_id: cactus_weaver
+label_it: Tessitore di Cactus
+doc_status: stub
+doc_owner: auto-seeded
+last_verified: '2026-05-31'
+language: it
+biome_affinity_per_stage:
+  hatchling: deserto_caldo
+  juvenile: deserto_caldo
+  mature: deserto_caldo
+  apex: any
+  legacy: any
+phases:
+  hatchling:
+    id: hatchling
+    label_it: Cucciolo Tessitore di Cactus
+    level_range:
+    - 1
+    - 1
+    mutations_required: 0
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  juvenile:
+    id: juvenile
+    label_it: Giovane Tessitore di Cactus
+    level_range:
+    - 2
+    - 4
+    mutations_required: 1
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  mature:
+    id: mature
+    label_it: Tessitore di Cactus maturo
+    level_range:
+    - 5
+    - 9
+    mutations_required: 2
+    thoughts_internalized_required: 1
+    mbti_polarity_required: true
+  apex:
+    id: apex
+    label_it: Tessitore di Cactus apicale
+    level_range:
+    - 10
+    - 14
+    mutations_required: 4
+    thoughts_internalized_required: 2
+    mbti_polarity_required: true
+  legacy:
+    id: legacy
+    label_it: Tessitore di Cactus legacy
+    level_range:
+    - 15
+    - 99
+    mutations_required: 5
+    thoughts_internalized_required: 3
+    mbti_polarity_required: true
+_notes:
+- Auto-seeded grounded stub (Wave3 Strato-2, biome-native).
+- 'Customizza: aspect_token, sprite_ascii, tactical_signature, diary_milestone_event
+  per phase.'
+- Cf dune_stalker_lifecycle.yaml come template.

--- a/data/core/species/cryo_lynx_lifecycle.yaml
+++ b/data/core/species/cryo_lynx_lifecycle.yaml
@@ -1,0 +1,63 @@
+species_id: cryo_lynx
+label_it: Lince Criogenica
+doc_status: stub
+doc_owner: auto-seeded
+last_verified: '2026-05-31'
+language: it
+biome_affinity_per_stage:
+  hatchling: cryosteppe
+  juvenile: cryosteppe
+  mature: cryosteppe
+  apex: any
+  legacy: any
+phases:
+  hatchling:
+    id: hatchling
+    label_it: Cucciolo Lince Criogenica
+    level_range:
+    - 1
+    - 1
+    mutations_required: 0
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  juvenile:
+    id: juvenile
+    label_it: Giovane Lince Criogenica
+    level_range:
+    - 2
+    - 4
+    mutations_required: 1
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  mature:
+    id: mature
+    label_it: Lince Criogenica maturo
+    level_range:
+    - 5
+    - 9
+    mutations_required: 2
+    thoughts_internalized_required: 1
+    mbti_polarity_required: true
+  apex:
+    id: apex
+    label_it: Lince Criogenica apicale
+    level_range:
+    - 10
+    - 14
+    mutations_required: 4
+    thoughts_internalized_required: 2
+    mbti_polarity_required: true
+  legacy:
+    id: legacy
+    label_it: Lince Criogenica legacy
+    level_range:
+    - 15
+    - 99
+    mutations_required: 5
+    thoughts_internalized_required: 3
+    mbti_polarity_required: true
+_notes:
+- Auto-seeded grounded stub (Wave3 Strato-2, biome-native).
+- 'Customizza: aspect_token, sprite_ascii, tactical_signature, diary_milestone_event
+  per phase.'
+- Cf dune_stalker_lifecycle.yaml come template.

--- a/data/core/species/echo_wing_lifecycle.yaml
+++ b/data/core/species/echo_wing_lifecycle.yaml
@@ -1,0 +1,63 @@
+species_id: echo_wing
+label_it: Ala d'Eco
+doc_status: stub
+doc_owner: auto-seeded
+last_verified: '2026-05-31'
+language: it
+biome_affinity_per_stage:
+  hatchling: badlands
+  juvenile: badlands
+  mature: badlands
+  apex: any
+  legacy: any
+phases:
+  hatchling:
+    id: hatchling
+    label_it: Cucciolo Ala d'Eco
+    level_range:
+    - 1
+    - 1
+    mutations_required: 0
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  juvenile:
+    id: juvenile
+    label_it: Giovane Ala d'Eco
+    level_range:
+    - 2
+    - 4
+    mutations_required: 1
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  mature:
+    id: mature
+    label_it: Ala d'Eco maturo
+    level_range:
+    - 5
+    - 9
+    mutations_required: 2
+    thoughts_internalized_required: 1
+    mbti_polarity_required: true
+  apex:
+    id: apex
+    label_it: Ala d'Eco apicale
+    level_range:
+    - 10
+    - 14
+    mutations_required: 4
+    thoughts_internalized_required: 2
+    mbti_polarity_required: true
+  legacy:
+    id: legacy
+    label_it: Ala d'Eco legacy
+    level_range:
+    - 15
+    - 99
+    mutations_required: 5
+    thoughts_internalized_required: 3
+    mbti_polarity_required: true
+_notes:
+- Auto-seeded grounded stub (Wave3 Strato-2, biome-native).
+- 'Customizza: aspect_token, sprite_ascii, tactical_signature, diary_milestone_event
+  per phase.'
+- Cf dune_stalker_lifecycle.yaml come template.

--- a/data/core/species/ferrocolonia_magnetotattica_lifecycle.yaml
+++ b/data/core/species/ferrocolonia_magnetotattica_lifecycle.yaml
@@ -1,0 +1,63 @@
+species_id: ferrocolonia_magnetotattica
+label_it: Ferrocolonia Magnetotattica
+doc_status: stub
+doc_owner: auto-seeded
+last_verified: '2026-05-31'
+language: it
+biome_affinity_per_stage:
+  hatchling: badlands
+  juvenile: badlands
+  mature: badlands
+  apex: any
+  legacy: any
+phases:
+  hatchling:
+    id: hatchling
+    label_it: Cucciolo Ferrocolonia Magnetotattica
+    level_range:
+    - 1
+    - 1
+    mutations_required: 0
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  juvenile:
+    id: juvenile
+    label_it: Giovane Ferrocolonia Magnetotattica
+    level_range:
+    - 2
+    - 4
+    mutations_required: 1
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  mature:
+    id: mature
+    label_it: Ferrocolonia Magnetotattica maturo
+    level_range:
+    - 5
+    - 9
+    mutations_required: 2
+    thoughts_internalized_required: 1
+    mbti_polarity_required: true
+  apex:
+    id: apex
+    label_it: Ferrocolonia Magnetotattica apicale
+    level_range:
+    - 10
+    - 14
+    mutations_required: 4
+    thoughts_internalized_required: 2
+    mbti_polarity_required: true
+  legacy:
+    id: legacy
+    label_it: Ferrocolonia Magnetotattica legacy
+    level_range:
+    - 15
+    - 99
+    mutations_required: 5
+    thoughts_internalized_required: 3
+    mbti_polarity_required: true
+_notes:
+- Auto-seeded grounded stub (Wave3 Strato-2, biome-native).
+- 'Customizza: aspect_token, sprite_ascii, tactical_signature, diary_milestone_event
+  per phase.'
+- Cf dune_stalker_lifecycle.yaml come template.

--- a/data/core/species/lupus_temperatus_lifecycle.yaml
+++ b/data/core/species/lupus_temperatus_lifecycle.yaml
@@ -1,0 +1,63 @@
+species_id: lupus_temperatus
+label_it: Lupo della Foresta
+doc_status: stub
+doc_owner: auto-seeded
+last_verified: '2026-05-31'
+language: it
+biome_affinity_per_stage:
+  hatchling: foresta_temperata
+  juvenile: foresta_temperata
+  mature: foresta_temperata
+  apex: any
+  legacy: any
+phases:
+  hatchling:
+    id: hatchling
+    label_it: Cucciolo Lupo della Foresta
+    level_range:
+    - 1
+    - 1
+    mutations_required: 0
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  juvenile:
+    id: juvenile
+    label_it: Giovane Lupo della Foresta
+    level_range:
+    - 2
+    - 4
+    mutations_required: 1
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  mature:
+    id: mature
+    label_it: Lupo della Foresta maturo
+    level_range:
+    - 5
+    - 9
+    mutations_required: 2
+    thoughts_internalized_required: 1
+    mbti_polarity_required: true
+  apex:
+    id: apex
+    label_it: Lupo della Foresta apicale
+    level_range:
+    - 10
+    - 14
+    mutations_required: 4
+    thoughts_internalized_required: 2
+    mbti_polarity_required: true
+  legacy:
+    id: legacy
+    label_it: Lupo della Foresta legacy
+    level_range:
+    - 15
+    - 99
+    mutations_required: 5
+    thoughts_internalized_required: 3
+    mbti_polarity_required: true
+_notes:
+- Auto-seeded grounded stub (Wave3 Strato-2, biome-native).
+- 'Customizza: aspect_token, sprite_ascii, tactical_signature, diary_milestone_event
+  per phase.'
+- Cf dune_stalker_lifecycle.yaml come template.

--- a/data/core/species/nano_rust_bloom_lifecycle.yaml
+++ b/data/core/species/nano_rust_bloom_lifecycle.yaml
@@ -1,0 +1,63 @@
+species_id: nano_rust_bloom
+label_it: Fioritura di Nano-Ruggine
+doc_status: stub
+doc_owner: auto-seeded
+last_verified: '2026-05-31'
+language: it
+biome_affinity_per_stage:
+  hatchling: badlands
+  juvenile: badlands
+  mature: badlands
+  apex: any
+  legacy: any
+phases:
+  hatchling:
+    id: hatchling
+    label_it: Cucciolo Fioritura di Nano-Ruggine
+    level_range:
+    - 1
+    - 1
+    mutations_required: 0
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  juvenile:
+    id: juvenile
+    label_it: Giovane Fioritura di Nano-Ruggine
+    level_range:
+    - 2
+    - 4
+    mutations_required: 1
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  mature:
+    id: mature
+    label_it: Fioritura di Nano-Ruggine maturo
+    level_range:
+    - 5
+    - 9
+    mutations_required: 2
+    thoughts_internalized_required: 1
+    mbti_polarity_required: true
+  apex:
+    id: apex
+    label_it: Fioritura di Nano-Ruggine apicale
+    level_range:
+    - 10
+    - 14
+    mutations_required: 4
+    thoughts_internalized_required: 2
+    mbti_polarity_required: true
+  legacy:
+    id: legacy
+    label_it: Fioritura di Nano-Ruggine legacy
+    level_range:
+    - 15
+    - 99
+    mutations_required: 5
+    thoughts_internalized_required: 3
+    mbti_polarity_required: true
+_notes:
+- Auto-seeded grounded stub (Wave3 Strato-2, biome-native).
+- 'Customizza: aspect_token, sprite_ascii, tactical_signature, diary_milestone_event
+  per phase.'
+- Cf dune_stalker_lifecycle.yaml come template.

--- a/data/core/species/noctule_termico_lifecycle.yaml
+++ b/data/core/species/noctule_termico_lifecycle.yaml
@@ -1,0 +1,63 @@
+species_id: noctule_termico
+label_it: Nottola Termica
+doc_status: stub
+doc_owner: auto-seeded
+last_verified: '2026-05-31'
+language: it
+biome_affinity_per_stage:
+  hatchling: deserto_caldo
+  juvenile: deserto_caldo
+  mature: deserto_caldo
+  apex: any
+  legacy: any
+phases:
+  hatchling:
+    id: hatchling
+    label_it: Cucciolo Nottola Termica
+    level_range:
+    - 1
+    - 1
+    mutations_required: 0
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  juvenile:
+    id: juvenile
+    label_it: Giovane Nottola Termica
+    level_range:
+    - 2
+    - 4
+    mutations_required: 1
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  mature:
+    id: mature
+    label_it: Nottola Termica maturo
+    level_range:
+    - 5
+    - 9
+    mutations_required: 2
+    thoughts_internalized_required: 1
+    mbti_polarity_required: true
+  apex:
+    id: apex
+    label_it: Nottola Termica apicale
+    level_range:
+    - 10
+    - 14
+    mutations_required: 4
+    thoughts_internalized_required: 2
+    mbti_polarity_required: true
+  legacy:
+    id: legacy
+    label_it: Nottola Termica legacy
+    level_range:
+    - 15
+    - 99
+    mutations_required: 5
+    thoughts_internalized_required: 3
+    mbti_polarity_required: true
+_notes:
+- Auto-seeded grounded stub (Wave3 Strato-2, biome-native).
+- 'Customizza: aspect_token, sprite_ascii, tactical_signature, diary_milestone_event
+  per phase.'
+- Cf dune_stalker_lifecycle.yaml come template.

--- a/data/core/species/rust_scavenger_lifecycle.yaml
+++ b/data/core/species/rust_scavenger_lifecycle.yaml
@@ -1,0 +1,63 @@
+species_id: rust_scavenger
+label_it: Spazzino della Ruggine
+doc_status: stub
+doc_owner: auto-seeded
+last_verified: '2026-05-31'
+language: it
+biome_affinity_per_stage:
+  hatchling: badlands
+  juvenile: badlands
+  mature: badlands
+  apex: any
+  legacy: any
+phases:
+  hatchling:
+    id: hatchling
+    label_it: Cucciolo Spazzino della Ruggine
+    level_range:
+    - 1
+    - 1
+    mutations_required: 0
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  juvenile:
+    id: juvenile
+    label_it: Giovane Spazzino della Ruggine
+    level_range:
+    - 2
+    - 4
+    mutations_required: 1
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  mature:
+    id: mature
+    label_it: Spazzino della Ruggine maturo
+    level_range:
+    - 5
+    - 9
+    mutations_required: 2
+    thoughts_internalized_required: 1
+    mbti_polarity_required: true
+  apex:
+    id: apex
+    label_it: Spazzino della Ruggine apicale
+    level_range:
+    - 10
+    - 14
+    mutations_required: 4
+    thoughts_internalized_required: 2
+    mbti_polarity_required: true
+  legacy:
+    id: legacy
+    label_it: Spazzino della Ruggine legacy
+    level_range:
+    - 15
+    - 99
+    mutations_required: 5
+    thoughts_internalized_required: 3
+    mbti_polarity_required: true
+_notes:
+- Auto-seeded grounded stub (Wave3 Strato-2, biome-native).
+- 'Customizza: aspect_token, sprite_ascii, tactical_signature, diary_milestone_event
+  per phase.'
+- Cf dune_stalker_lifecycle.yaml come template.

--- a/data/core/species/sand_burrower_lifecycle.yaml
+++ b/data/core/species/sand_burrower_lifecycle.yaml
@@ -1,0 +1,63 @@
+species_id: sand_burrower
+label_it: Scavatore delle Sabbie
+doc_status: stub
+doc_owner: auto-seeded
+last_verified: '2026-05-31'
+language: it
+biome_affinity_per_stage:
+  hatchling: badlands
+  juvenile: badlands
+  mature: badlands
+  apex: any
+  legacy: any
+phases:
+  hatchling:
+    id: hatchling
+    label_it: Cucciolo Scavatore delle Sabbie
+    level_range:
+    - 1
+    - 1
+    mutations_required: 0
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  juvenile:
+    id: juvenile
+    label_it: Giovane Scavatore delle Sabbie
+    level_range:
+    - 2
+    - 4
+    mutations_required: 1
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  mature:
+    id: mature
+    label_it: Scavatore delle Sabbie maturo
+    level_range:
+    - 5
+    - 9
+    mutations_required: 2
+    thoughts_internalized_required: 1
+    mbti_polarity_required: true
+  apex:
+    id: apex
+    label_it: Scavatore delle Sabbie apicale
+    level_range:
+    - 10
+    - 14
+    mutations_required: 4
+    thoughts_internalized_required: 2
+    mbti_polarity_required: true
+  legacy:
+    id: legacy
+    label_it: Scavatore delle Sabbie legacy
+    level_range:
+    - 15
+    - 99
+    mutations_required: 5
+    thoughts_internalized_required: 3
+    mbti_polarity_required: true
+_notes:
+- Auto-seeded grounded stub (Wave3 Strato-2, biome-native).
+- 'Customizza: aspect_token, sprite_ascii, tactical_signature, diary_milestone_event
+  per phase.'
+- Cf dune_stalker_lifecycle.yaml come template.

--- a/data/core/species/sentinella_radice_lifecycle.yaml
+++ b/data/core/species/sentinella_radice_lifecycle.yaml
@@ -1,0 +1,63 @@
+species_id: sentinella_radice
+label_it: Sentinella Radice
+doc_status: stub
+doc_owner: auto-seeded
+last_verified: '2026-05-31'
+language: it
+biome_affinity_per_stage:
+  hatchling: foresta_temperata
+  juvenile: foresta_temperata
+  mature: foresta_temperata
+  apex: any
+  legacy: any
+phases:
+  hatchling:
+    id: hatchling
+    label_it: Cucciolo Sentinella Radice
+    level_range:
+    - 1
+    - 1
+    mutations_required: 0
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  juvenile:
+    id: juvenile
+    label_it: Giovane Sentinella Radice
+    level_range:
+    - 2
+    - 4
+    mutations_required: 1
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  mature:
+    id: mature
+    label_it: Sentinella Radice maturo
+    level_range:
+    - 5
+    - 9
+    mutations_required: 2
+    thoughts_internalized_required: 1
+    mbti_polarity_required: true
+  apex:
+    id: apex
+    label_it: Sentinella Radice apicale
+    level_range:
+    - 10
+    - 14
+    mutations_required: 4
+    thoughts_internalized_required: 2
+    mbti_polarity_required: true
+  legacy:
+    id: legacy
+    label_it: Sentinella Radice legacy
+    level_range:
+    - 15
+    - 99
+    mutations_required: 5
+    thoughts_internalized_required: 3
+    mbti_polarity_required: true
+_notes:
+- Auto-seeded grounded stub (Wave3 Strato-2, biome-native).
+- 'Customizza: aspect_token, sprite_ascii, tactical_signature, diary_milestone_event
+  per phase.'
+- Cf dune_stalker_lifecycle.yaml come template.

--- a/data/core/species/silica_bloom_lifecycle.yaml
+++ b/data/core/species/silica_bloom_lifecycle.yaml
@@ -1,0 +1,63 @@
+species_id: silica_bloom
+label_it: Fioritura di Silice
+doc_status: stub
+doc_owner: auto-seeded
+last_verified: '2026-05-31'
+language: it
+biome_affinity_per_stage:
+  hatchling: deserto_caldo
+  juvenile: deserto_caldo
+  mature: deserto_caldo
+  apex: any
+  legacy: any
+phases:
+  hatchling:
+    id: hatchling
+    label_it: Cucciolo Fioritura di Silice
+    level_range:
+    - 1
+    - 1
+    mutations_required: 0
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  juvenile:
+    id: juvenile
+    label_it: Giovane Fioritura di Silice
+    level_range:
+    - 2
+    - 4
+    mutations_required: 1
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  mature:
+    id: mature
+    label_it: Fioritura di Silice maturo
+    level_range:
+    - 5
+    - 9
+    mutations_required: 2
+    thoughts_internalized_required: 1
+    mbti_polarity_required: true
+  apex:
+    id: apex
+    label_it: Fioritura di Silice apicale
+    level_range:
+    - 10
+    - 14
+    mutations_required: 4
+    thoughts_internalized_required: 2
+    mbti_polarity_required: true
+  legacy:
+    id: legacy
+    label_it: Fioritura di Silice legacy
+    level_range:
+    - 15
+    - 99
+    mutations_required: 5
+    thoughts_internalized_required: 3
+    mbti_polarity_required: true
+_notes:
+- Auto-seeded grounded stub (Wave3 Strato-2, biome-native).
+- 'Customizza: aspect_token, sprite_ascii, tactical_signature, diary_milestone_event
+  per phase.'
+- Cf dune_stalker_lifecycle.yaml come template.

--- a/data/core/species/species_catalog.json
+++ b/data/core/species/species_catalog.json
@@ -3506,7 +3506,7 @@
         "sacche_galleggianti_ascensoriali",
         "lingua_tattile_trama"
       ],
-      "lifecycle_yaml": null,
+      "lifecycle_yaml": "data/core/species/echo_wing_lifecycle.yaml",
       "source": "gameplay-promote",
       "legacy_slug": "echo_wing",
       "biome_affinity": "badlands",
@@ -3521,7 +3521,8 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "lifecycle_yaml"
+        "lifecycle_authoring",
+        "ecotypes"
       ],
       "genus": "Echopterus",
       "epithet": "pollinifer"
@@ -3565,7 +3566,7 @@
         "lingua_tattile_trama",
         "ventriglio_gastroliti"
       ],
-      "lifecycle_yaml": null,
+      "lifecycle_yaml": "data/core/species/ferrocolonia_magnetotattica_lifecycle.yaml",
       "source": "gameplay-promote",
       "legacy_slug": "ferrocolonia_magnetotattica",
       "biome_affinity": "badlands",
@@ -3580,7 +3581,8 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "lifecycle_yaml"
+        "lifecycle_authoring",
+        "ecotypes"
       ],
       "genus": "Ferrocolonia",
       "epithet": "magnetotacta"
@@ -3672,7 +3674,7 @@
         "carapace_fase_variabile",
         "sangue_piroforico"
       ],
-      "lifecycle_yaml": null,
+      "lifecycle_yaml": "data/core/species/nano_rust_bloom_lifecycle.yaml",
       "source": "gameplay-promote",
       "legacy_slug": "nano_rust_bloom",
       "biome_affinity": "badlands",
@@ -3687,7 +3689,8 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "lifecycle_yaml"
+        "lifecycle_authoring",
+        "ecotypes"
       ],
       "genus": "Oxidospora",
       "epithet": "pestifera"
@@ -3731,7 +3734,7 @@
         "nucleo_ovomotore_rotante",
         "scheletro_idro_regolante"
       ],
-      "lifecycle_yaml": null,
+      "lifecycle_yaml": "data/core/species/rust_scavenger_lifecycle.yaml",
       "source": "gameplay-promote",
       "legacy_slug": "rust_scavenger",
       "biome_affinity": "badlands",
@@ -3746,7 +3749,8 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "lifecycle_yaml"
+        "lifecycle_authoring",
+        "ecotypes"
       ],
       "genus": "Ferrivora",
       "epithet": "saprophaga"
@@ -3791,7 +3795,7 @@
         "carapace_fase_variabile",
         "zampe_a_molla"
       ],
-      "lifecycle_yaml": null,
+      "lifecycle_yaml": "data/core/species/sand_burrower_lifecycle.yaml",
       "source": "gameplay-promote",
       "legacy_slug": "sand_burrower",
       "biome_affinity": "badlands",
@@ -3806,7 +3810,8 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "lifecycle_yaml"
+        "lifecycle_authoring",
+        "ecotypes"
       ],
       "genus": "Arenofossor",
       "epithet": "saliphilus"
@@ -3948,7 +3953,7 @@
         "sacche_galleggianti_ascensoriali",
         "occhi_infrarosso_composti"
       ],
-      "lifecycle_yaml": null,
+      "lifecycle_yaml": "data/core/species/aurora_gull_lifecycle.yaml",
       "source": "gameplay-promote",
       "legacy_slug": "aurora_gull",
       "biome_affinity": "cryosteppe",
@@ -3963,7 +3968,8 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "lifecycle_yaml"
+        "lifecycle_authoring",
+        "ecotypes"
       ],
       "genus": "Glacilarus",
       "epithet": "borealis"
@@ -4005,7 +4011,7 @@
         "criostasi_adattiva",
         "zampe_a_molla"
       ],
-      "lifecycle_yaml": null,
+      "lifecycle_yaml": "data/core/species/cryo_lynx_lifecycle.yaml",
       "source": "gameplay-promote",
       "legacy_slug": "cryo_lynx",
       "biome_affinity": "cryosteppe",
@@ -4020,7 +4026,8 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "lifecycle_yaml"
+        "lifecycle_authoring",
+        "ecotypes"
       ],
       "genus": "Cryofelis",
       "epithet": "nivalis"
@@ -4064,7 +4071,7 @@
         "carapace_fase_variabile",
         "sacche_galleggianti_ascensoriali"
       ],
-      "lifecycle_yaml": null,
+      "lifecycle_yaml": "data/core/species/steppe_bison_mini_lifecycle.yaml",
       "source": "gameplay-promote",
       "legacy_slug": "steppe_bison_mini",
       "biome_affinity": "cryosteppe",
@@ -4079,7 +4086,8 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "lifecycle_yaml"
+        "lifecycle_authoring",
+        "ecotypes"
       ],
       "genus": "Nanobison",
       "epithet": "tundrae"
@@ -4122,7 +4130,7 @@
         "secrezione_rallentante_palmi",
         "eco_interno_riflesso"
       ],
-      "lifecycle_yaml": null,
+      "lifecycle_yaml": "data/core/species/thaw_rot_lifecycle.yaml",
       "source": "gameplay-promote",
       "legacy_slug": "thaw_rot",
       "biome_affinity": "cryosteppe",
@@ -4137,7 +4145,8 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "lifecycle_yaml"
+        "lifecycle_authoring",
+        "ecotypes"
       ],
       "genus": "Geliputris",
       "epithet": "liquefaciens"
@@ -4229,7 +4238,7 @@
         "proteine_shock_termico",
         "reti_capillari_radici"
       ],
-      "lifecycle_yaml": null,
+      "lifecycle_yaml": "data/core/species/cactus_weaver_lifecycle.yaml",
       "source": "gameplay-promote",
       "legacy_slug": "cactus_weaver",
       "biome_affinity": "deserto_caldo",
@@ -4244,7 +4253,8 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "lifecycle_yaml"
+        "lifecycle_authoring",
+        "ecotypes"
       ],
       "genus": "Cactotextor",
       "epithet": "hydrophorus"
@@ -4289,7 +4299,7 @@
         "proteine_shock_termico",
         "reti_capillari_radici"
       ],
-      "lifecycle_yaml": null,
+      "lifecycle_yaml": "data/core/species/noctule_termico_lifecycle.yaml",
       "source": "gameplay-promote",
       "legacy_slug": "noctule_termico",
       "biome_affinity": "deserto_caldo",
@@ -4304,7 +4314,8 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "lifecycle_yaml"
+        "lifecycle_authoring",
+        "ecotypes"
       ],
       "genus": "Thermonoctus",
       "epithet": "vagans"
@@ -4349,7 +4360,7 @@
         "proteine_shock_termico",
         "reti_capillari_radici"
       ],
-      "lifecycle_yaml": null,
+      "lifecycle_yaml": "data/core/species/silica_bloom_lifecycle.yaml",
       "source": "gameplay-promote",
       "legacy_slug": "silica_bloom",
       "biome_affinity": "deserto_caldo",
@@ -4364,7 +4375,8 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "lifecycle_yaml"
+        "lifecycle_authoring",
+        "ecotypes"
       ],
       "genus": "Siliciflora",
       "epithet": "pestifera"
@@ -4407,7 +4419,7 @@
         "proteine_shock_termico",
         "reti_capillari_radici"
       ],
-      "lifecycle_yaml": null,
+      "lifecycle_yaml": "data/core/species/thermo_raptor_lifecycle.yaml",
       "source": "gameplay-promote",
       "legacy_slug": "thermo_raptor",
       "biome_affinity": "deserto_caldo",
@@ -4422,7 +4434,8 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "lifecycle_yaml"
+        "lifecycle_authoring",
+        "ecotypes"
       ],
       "genus": "Thermoraptor",
       "epithet": "aridus"
@@ -4466,7 +4479,7 @@
         "mimetismo_cromatico_passivo",
         "filamenti_digestivi_compattanti"
       ],
-      "lifecycle_yaml": null,
+      "lifecycle_yaml": "data/core/species/blight_micotico_lifecycle.yaml",
       "source": "gameplay-promote",
       "legacy_slug": "blight_micotico",
       "biome_affinity": "foresta_temperata",
@@ -4481,7 +4494,8 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "lifecycle_yaml"
+        "lifecycle_authoring",
+        "ecotypes"
       ],
       "genus": "Mycotabes",
       "epithet": "corruptor"
@@ -4571,7 +4585,7 @@
         "focus_frazionato",
         "occhi_infrarosso_composti"
       ],
-      "lifecycle_yaml": null,
+      "lifecycle_yaml": "data/core/species/lupus_temperatus_lifecycle.yaml",
       "source": "gameplay-promote",
       "legacy_slug": "lupus_temperatus",
       "biome_affinity": "foresta_temperata",
@@ -4586,7 +4600,8 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "lifecycle_yaml"
+        "lifecycle_authoring",
+        "ecotypes"
       ],
       "genus": "Silvalupus",
       "epithet": "temperatus"
@@ -4674,7 +4689,7 @@
         "random",
         "empatia_coordinativa"
       ],
-      "lifecycle_yaml": null,
+      "lifecycle_yaml": "data/core/species/sentinella_radice_lifecycle.yaml",
       "source": "gameplay-promote",
       "legacy_slug": "sentinella_radice",
       "biome_affinity": "foresta_temperata",
@@ -4689,7 +4704,8 @@
       "merged_at": "2026-05-31",
       "_promote_stub": true,
       "_todo_fields": [
-        "lifecycle_yaml"
+        "lifecycle_authoring",
+        "ecotypes"
       ],
       "genus": "Radicustos",
       "epithet": "vigilans"

--- a/data/core/species/steppe_bison_mini_lifecycle.yaml
+++ b/data/core/species/steppe_bison_mini_lifecycle.yaml
@@ -1,0 +1,63 @@
+species_id: steppe_bison_mini
+label_it: Bisonte Nano della Steppa
+doc_status: stub
+doc_owner: auto-seeded
+last_verified: '2026-05-31'
+language: it
+biome_affinity_per_stage:
+  hatchling: cryosteppe
+  juvenile: cryosteppe
+  mature: cryosteppe
+  apex: any
+  legacy: any
+phases:
+  hatchling:
+    id: hatchling
+    label_it: Cucciolo Bisonte Nano della Steppa
+    level_range:
+    - 1
+    - 1
+    mutations_required: 0
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  juvenile:
+    id: juvenile
+    label_it: Giovane Bisonte Nano della Steppa
+    level_range:
+    - 2
+    - 4
+    mutations_required: 1
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  mature:
+    id: mature
+    label_it: Bisonte Nano della Steppa maturo
+    level_range:
+    - 5
+    - 9
+    mutations_required: 2
+    thoughts_internalized_required: 1
+    mbti_polarity_required: true
+  apex:
+    id: apex
+    label_it: Bisonte Nano della Steppa apicale
+    level_range:
+    - 10
+    - 14
+    mutations_required: 4
+    thoughts_internalized_required: 2
+    mbti_polarity_required: true
+  legacy:
+    id: legacy
+    label_it: Bisonte Nano della Steppa legacy
+    level_range:
+    - 15
+    - 99
+    mutations_required: 5
+    thoughts_internalized_required: 3
+    mbti_polarity_required: true
+_notes:
+- Auto-seeded grounded stub (Wave3 Strato-2, biome-native).
+- 'Customizza: aspect_token, sprite_ascii, tactical_signature, diary_milestone_event
+  per phase.'
+- Cf dune_stalker_lifecycle.yaml come template.

--- a/data/core/species/thaw_rot_lifecycle.yaml
+++ b/data/core/species/thaw_rot_lifecycle.yaml
@@ -1,0 +1,63 @@
+species_id: thaw_rot
+label_it: Marciume del Disgelo
+doc_status: stub
+doc_owner: auto-seeded
+last_verified: '2026-05-31'
+language: it
+biome_affinity_per_stage:
+  hatchling: cryosteppe
+  juvenile: cryosteppe
+  mature: cryosteppe
+  apex: any
+  legacy: any
+phases:
+  hatchling:
+    id: hatchling
+    label_it: Cucciolo Marciume del Disgelo
+    level_range:
+    - 1
+    - 1
+    mutations_required: 0
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  juvenile:
+    id: juvenile
+    label_it: Giovane Marciume del Disgelo
+    level_range:
+    - 2
+    - 4
+    mutations_required: 1
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  mature:
+    id: mature
+    label_it: Marciume del Disgelo maturo
+    level_range:
+    - 5
+    - 9
+    mutations_required: 2
+    thoughts_internalized_required: 1
+    mbti_polarity_required: true
+  apex:
+    id: apex
+    label_it: Marciume del Disgelo apicale
+    level_range:
+    - 10
+    - 14
+    mutations_required: 4
+    thoughts_internalized_required: 2
+    mbti_polarity_required: true
+  legacy:
+    id: legacy
+    label_it: Marciume del Disgelo legacy
+    level_range:
+    - 15
+    - 99
+    mutations_required: 5
+    thoughts_internalized_required: 3
+    mbti_polarity_required: true
+_notes:
+- Auto-seeded grounded stub (Wave3 Strato-2, biome-native).
+- 'Customizza: aspect_token, sprite_ascii, tactical_signature, diary_milestone_event
+  per phase.'
+- Cf dune_stalker_lifecycle.yaml come template.

--- a/data/core/species/thermo_raptor_lifecycle.yaml
+++ b/data/core/species/thermo_raptor_lifecycle.yaml
@@ -1,0 +1,63 @@
+species_id: thermo_raptor
+label_it: Raptor Termico
+doc_status: stub
+doc_owner: auto-seeded
+last_verified: '2026-05-31'
+language: it
+biome_affinity_per_stage:
+  hatchling: deserto_caldo
+  juvenile: deserto_caldo
+  mature: deserto_caldo
+  apex: any
+  legacy: any
+phases:
+  hatchling:
+    id: hatchling
+    label_it: Cucciolo Raptor Termico
+    level_range:
+    - 1
+    - 1
+    mutations_required: 0
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  juvenile:
+    id: juvenile
+    label_it: Giovane Raptor Termico
+    level_range:
+    - 2
+    - 4
+    mutations_required: 1
+    thoughts_internalized_required: 0
+    mbti_polarity_required: false
+  mature:
+    id: mature
+    label_it: Raptor Termico maturo
+    level_range:
+    - 5
+    - 9
+    mutations_required: 2
+    thoughts_internalized_required: 1
+    mbti_polarity_required: true
+  apex:
+    id: apex
+    label_it: Raptor Termico apicale
+    level_range:
+    - 10
+    - 14
+    mutations_required: 4
+    thoughts_internalized_required: 2
+    mbti_polarity_required: true
+  legacy:
+    id: legacy
+    label_it: Raptor Termico legacy
+    level_range:
+    - 15
+    - 99
+    mutations_required: 5
+    thoughts_internalized_required: 3
+    mbti_polarity_required: true
+_notes:
+- Auto-seeded grounded stub (Wave3 Strato-2, biome-native).
+- 'Customizza: aspect_token, sprite_ascii, tactical_signature, diary_milestone_event
+  per phase.'
+- Cf dune_stalker_lifecycle.yaml come template.


### PR DESCRIPTION
## Wave 3 -- grounded lifecycle stubs for the 16 authored creatures

Seeds 5-phase lifecycle YAML stubs (hatchling/juvenile/mature/apex/legacy) for the
16 fully-authored gameplay-promote creatures, matching the canonical schema
(`seed_lifecycle_stubs.make_stub`).

- **Scoped** to my 16 (not the ~60 catalog entries missing lifecycle).
- **Grounded**: `biome_affinity_per_stage` uses each creature's real biome for
  hatchling/juvenile/mature (apex/legacy = 'any'), not the seeder's generic
  savana/deserto/caverna -> `biomeAffinity.js` applies a sensible per-stage bonus.
- `doc_status: stub` (level gates + biome only); per-phase aspect/sprite/tactical
  prose remain for later authoring (cf dune_stalker template).
- `species_catalog.json` `lifecycle_yaml` links: null -> path for the 16.

The 6 `evento_ecologico` entries get no lifecycle (events, reclassification follow-up).

### Checks
envelope-b 28/28 (lifecycle path-exists guard) + renderLifecycle + stadioMapping 43/43
+ dataset validator (rows clean) + species/swarm validators 16/16 + speciesIndex 37/37.

Coding-Agent: claude-opus-4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
