### PR TITLE
fix(species): flag 6 mis-promoted ecological events + ETL filter (Wave3)

### DIFF
--- a/data/core/species/species_catalog.json
+++ b/data/core/species/species_catalog.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.2",
+  "version": "0.4.3",
   "merged_at": "2026-05-15",
   "source_provenance": {
     "pack_v2_full_plus": "/tmp/species_catalog_v0.2.0_backup.json",
@@ -3634,7 +3634,8 @@
         "constraints",
         "trait_refs",
         "lifecycle_yaml"
-      ]
+      ],
+      "is_event": true
     },
     {
       "species_id": "nano_rust_bloom",
@@ -3863,7 +3864,8 @@
         "constraints",
         "trait_refs",
         "lifecycle_yaml"
-      ]
+      ],
+      "is_event": true
     },
     {
       "species_id": "aurora_bridge_runner",
@@ -3912,7 +3914,8 @@
         "constraints",
         "trait_refs",
         "lifecycle_yaml"
-      ]
+      ],
+      "is_event": true
     },
     {
       "species_id": "aurora_gull",
@@ -4198,7 +4201,8 @@
         "constraints",
         "trait_refs",
         "lifecycle_yaml"
-      ]
+      ],
+      "is_event": true
     },
     {
       "species_id": "cactus_weaver",
@@ -4547,7 +4551,8 @@
         "constraints",
         "trait_refs",
         "lifecycle_yaml"
-      ]
+      ],
+      "is_event": true
     },
     {
       "species_id": "lupus_temperatus",
@@ -4653,7 +4658,8 @@
         "constraints",
         "trait_refs",
         "lifecycle_yaml"
-      ]
+      ],
+      "is_event": true
     },
     {
       "species_id": "sentinella_radice",

--- a/tests/api/envelope-b-data-integrity.test.js
+++ b/tests/api/envelope-b-data-integrity.test.js
@@ -144,6 +144,36 @@ describe('OD-027 + OD-031 — species_catalog.json Pack v2 merge', () => {
     }
   });
 
+  test('ecological events flagged is_event (6) -- excluded from species-only consumers', () => {
+    // CANON-RECONCILE #2490 gap: 6 role_trofico=evento_ecologico stubs (lacking the
+    // evento-* filename prefix) were swept into the catalog. They STAY (source/count
+    // unchanged, counts hold) but carry is_event:true so species-only consumers
+    // (bestiary UI, trait/biome heuristics) skip them. promote_gameplay_to_canon.py
+    // now skips this role on future runs. See species_catalog.json v0.4.3.
+    const events = catalog.catalog.filter((e) => e.is_event === true);
+    assert.equal(events.length, 6, 'expected 6 evento_ecologico stubs flagged is_event');
+    for (const e of events) {
+      assert.ok(
+        (e.role_tags || []).includes('evento_ecologico'),
+        `${e.species_id} flagged is_event must carry role_tags evento_ecologico`,
+      );
+      assert.equal(
+        e.source,
+        'gameplay-promote',
+        `${e.species_id} stays gameplay-promote (counts hold)`,
+      );
+    }
+    // Inverse: every evento_ecologico entry must be flagged (no silent leak into species consumers).
+    const unflagged = catalog.catalog.filter(
+      (e) => (e.role_tags || []).includes('evento_ecologico') && e.is_event !== true,
+    );
+    assert.equal(
+      unflagged.length,
+      0,
+      `evento_ecologico entries missing is_event flag: ${unflagged.map((e) => e.species_id)}`,
+    );
+  });
+
   test('Pack v2-full-plus metadata merged (10 species)', () => {
     const pack = catalog.catalog.filter((e) => e.source === 'pack-v2-full-plus');
     assert.equal(pack.length, 10, 'expected 10 species merged from Pack v2-full-plus');

--- a/tools/etl/promote_gameplay_to_canon.py
+++ b/tools/etl/promote_gameplay_to_canon.py
@@ -16,8 +16,12 @@ Contract enforced by tests/api/envelope-b-data-integrity.test.js:
   - source-count asserts (new source 'gameplay-promote')
   - lifecycle_yaml=null only allowed for whitelisted sources
 
-Idempotent: skips species_id already in catalog. Not a creature: *-trait-keeper /
-evento-* are excluded (they are not species).
+Idempotent: skips species_id already in catalog. Not a creature, excluded:
+  - filename *-trait-keeper (biome trait carrier, not a species)
+  - filename evento-* (ecological event stub)
+  - role_trofico == evento_ecologico (ecological event regardless of filename;
+    closes the CANON-RECONCILE #2490 gap where event-role files lacking the
+    evento-* prefix, e.g. magneto-ridge-hunter, were wrongly promoted).
 
 Usage:
   python tools/etl/promote_gameplay_to_canon.py --biome badlands [--biome cryosteppe ...]
@@ -39,6 +43,7 @@ REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 CATALOG_PATH = os.path.join(REPO_ROOT, "data", "core", "species", "species_catalog.json")
 SPECIES_DIR = os.path.join(REPO_ROOT, "packs", "evo_tactics_pack", "data", "species")
 NEW_SOURCE = "gameplay-promote"
+EVENT_ROLE = "evento_ecologico"  # role_trofico marking an ecological event (not a species)
 
 # Design-rich fields left as stubs for Strato-2 incremental authoring.
 TODO_FIELDS = [
@@ -57,6 +62,13 @@ def norm(s):
 def is_creature(fid):
     return not (fid.endswith("-trait-keeper") or fid.endswith("_trait_keeper")
                 or fid.startswith("evento-") or fid.startswith("evento_"))
+
+
+def is_event(pack):
+    """True if the pack YAML is an ecological event (role_trofico=evento_ecologico),
+    not a biological species. Catches event-role files whose filename lacks the
+    evento-* prefix (CANON-RECONCILE #2490 gap)."""
+    return str(pack.get("role_trofico", "")).strip() == EVENT_ROLE
 
 
 def load_yaml(p):
@@ -133,7 +145,7 @@ def main():
     catalog = json.load(open(CATALOG_PATH, encoding="utf-8"))
     existing = {e["species_id"] for e in catalog["catalog"]}
 
-    added, skipped = [], []
+    added, skipped, excluded_events = [], [], []
     for biome in biomes:
         for p in sorted(glob.glob(os.path.join(SPECIES_DIR, biome, "*.yaml"))):
             fid = os.path.splitext(os.path.basename(p))[0]
@@ -143,7 +155,11 @@ def main():
             if sid in existing:
                 skipped.append(sid)
                 continue
-            entry = derive_entry(load_yaml(p), biome, fid)
+            pack = load_yaml(p)
+            if is_event(pack):
+                excluded_events.append(sid)  # ecological event, not a species
+                continue
+            entry = derive_entry(pack, biome, fid)
             catalog["catalog"].append(entry)
             existing.add(sid)
             added.append(sid)
@@ -164,6 +180,7 @@ def main():
 
     print(f"added {len(added)}: {added}")
     print(f"skipped (already canon) {len(skipped)}: {skipped}")
+    print(f"excluded events (role={EVENT_ROLE}) {len(excluded_events)}: {excluded_events}")
     print(f"catalog now {len(cat)} species; by_source={by_source}")
 
     if args.dry_run:

--- a/tools/etl/promote_gameplay_to_canon.py
+++ b/tools/etl/promote_gameplay_to_canon.py
@@ -174,7 +174,7 @@ def main():
     catalog["stats"]["total_species"] = len(cat)
     catalog["stats"]["by_source"] = by_source
     catalog["stats"]["by_sentience_tier"] = by_sent
-    catalog["version"] = "0.4.2"
+    catalog["version"] = "0.4.3"  # 0.4.3 adds is_event semantics (evento_ecologico filter)
     if isinstance(catalog.get("source_provenance"), dict):
         catalog["source_provenance"]["gameplay_promote"] = "packs/evo_tactics_pack/data/species"
 


### PR DESCRIPTION
## Wave 3 -- flag 6 mis-promoted ecological events (scope correction)

The CANON-RECONCILE promotion (#2490) excluded `evento-*` *filenames* but not
`role_trofico=evento_ecologico`, so 6 events were swept into the species canon:
magneto_ridge_hunter, slag_veil_ambusher (badlands), aurora_bridge_runner,
zephyr_spore_courier (cryosteppe), glowcap_weaver, myco_spire_warden (foresta).

- `species_catalog.json`: the 6 get `"is_event": true`. **source/counts unchanged**
  (gameplay-promote 22 / total 75 / base 53 -- flag not source-change = zero count churn).
  version 0.4.2 -> 0.4.3.
- `promote_gameplay_to_canon.py`: `is_event()` filter -> future runs skip
  evento_ecologico regardless of filename.
- `envelope-b-data-integrity.test.js`: lock-in test (6 flagged + inverse no-leak);
  existing 22/75/53 asserts untouched.

**Consumers opt-in**: the flag is the exclusion signal. NOT blanket-filtered -- some
consumers (biomeSpawnBias combat) legitimately want events; species-only consumers
(bestiary UI, trait/biome heuristics) should filter `is_event !== true` -- separate follow-up.

Why flag, not source-change: changing `source` would break the base=53 / promo=22 /
lifecycle-whitelist asserts. `is_event` keeps counts stable.

### Checks
envelope-b 29/29 (incl new lock-in test) + dataset validator (rows clean) + promote --dry-run clean.

Coding-Agent: claude-opus-4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
