### PR TITLE
feat(species): exclude is_event from canonical species index (Wave3 consumer-wiring)

### DIFF
--- a/scripts/update_evo_pack_catalog.js
+++ b/scripts/update_evo_pack_catalog.js
@@ -289,12 +289,19 @@ function main() {
   );
   if (fs.existsSync(CANONICAL_CATALOG_PATH)) {
     const canonical = readJson(CANONICAL_CATALOG_PATH);
-    const catalogEntries = Array.isArray(canonical.catalog) ? canonical.catalog : [];
+    const allCatalogEntries = Array.isArray(canonical.catalog) ? canonical.catalog : [];
+    // Wave3 consumer-wiring: this canonical index is the species-only SoT mirror
+    // consumed by the bestiary UI + Game-Database import. Exclude entries flagged
+    // is_event (role=evento_ecologico stubs mis-promoted by #2490, flagged by #2515):
+    // they are ecological events, not species. Combat consumers that legitimately want
+    // events read species_catalog.json directly and are unaffected.
+    const catalogEntries = allCatalogEntries.filter((entry) => entry.is_event !== true);
     const canonicalIndex = {
       schema_version: canonical.version || '0.4.x',
       generated_at: nowIso,
       source: 'data/core/species/species_catalog.json',
       total_species: catalogEntries.length,
+      events_excluded: allCatalogEntries.length - catalogEntries.length,
       stats: canonical.stats || {},
       // ADR-2026-05-15 Phase 4d Scope A — exposing full 53 canonical entries
       // with rich schema (clade_tag, role_tags, ecology, default_parts,

--- a/scripts/update_evo_pack_catalog.js
+++ b/scripts/update_evo_pack_catalog.js
@@ -296,13 +296,25 @@ function main() {
     // they are ecological events, not species. Combat consumers that legitimately want
     // events read species_catalog.json directly and are unaffected.
     const catalogEntries = allCatalogEntries.filter((entry) => entry.is_event !== true);
+    // Recompute stats from the species-only set so the mirror's metadata matches the
+    // species-only contract (copying canonical.stats would keep event-inclusive counts).
+    const speciesStats = { total_species: catalogEntries.length, by_source: {}, by_sentience_tier: {} };
+    for (const e of catalogEntries) {
+      if (e.source) speciesStats.by_source[e.source] = (speciesStats.by_source[e.source] || 0) + 1;
+      if (e.sentience_index)
+        speciesStats.by_sentience_tier[e.sentience_index] =
+          (speciesStats.by_sentience_tier[e.sentience_index] || 0) + 1;
+    }
+    if (canonical.stats && canonical.stats.catalog_synergies_count != null) {
+      speciesStats.catalog_synergies_count = canonical.stats.catalog_synergies_count;
+    }
     const canonicalIndex = {
       schema_version: canonical.version || '0.4.x',
       generated_at: nowIso,
       source: 'data/core/species/species_catalog.json',
       total_species: catalogEntries.length,
       events_excluded: allCatalogEntries.length - catalogEntries.length,
-      stats: canonical.stats || {},
+      stats: speciesStats,
       // ADR-2026-05-15 Phase 4d Scope A — exposing full 53 canonical entries
       // with rich schema (clade_tag, role_tags, ecology, default_parts,
       // biome_affinity, legacy_slug, genus, epithet, sentience_index).


### PR DESCRIPTION
## Wave 3 consumer-wiring -- exclude events from the canonical species index

Follow-up to the event-flagging #2515 (the agent's flagged next step). The
`species-canonical-index.json` emitted by `update_evo_pack_catalog.js` is the
**species-only SoT mirror** consumed by the bestiary UI + Game-Database import
(Phase 4d Scope A). Filter out `is_event` entries (the 6 evento_ecologico stubs)
so a future index regen stays species-only + add an `events_excluded` counter.

**Scoped on purpose** (per the agent's note -- consumers opt-in, not blanket-filter):
- Combat consumers that legitimately want events (biomeSpawnBias) read
  `species_catalog.json` directly -> unaffected.
- By-id-lookup backend consumers are already safe (events only surface if explicitly
  referenced by id).
- Heuristics (`suggest_biome_affinity`) already exclude `gameplay-promote`.

The canonical index is the single correct architectural layer for "species mirror
for external consumers", so the filter lives there.

### Verified
Filter on current catalog -> 75 all / **69 species-only / 6 events excluded** (the
correct 6: magneto_ridge_hunter, slag_veil_ambusher, aurora_bridge_runner,
zephyr_spore_courier, glowcap_weaver, myco_spire_warden). JS syntax OK.

The committed index is currently stale (53, pre-promotion); NOT regenerated here to
avoid churning the other generated artifacts -- the filter applies on next regen.

Coding-Agent: claude-opus-4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
