### PR TITLE
fix(calibration): recalibrate BASELINE_WR.balanced 1.0 → 0.9 (stop nightly false-positives)

### DIFF
--- a/tools/sim/check-thresholds.js
+++ b/tools/sim/check-thresholds.js
@@ -35,7 +35,7 @@ const BASELINE_WR = {
   aggressive_with_stickiness: 0.55, // K4 sticky 0.15 (PR #2147)
   aggressive_sticky_30: 0.6, // K4 sticky 0.30 (PR #2147)
   aggressive_commit_window: 1.0, // K4 Approach B explicit profile
-  balanced: 1.0, // historical 100% WR
+  balanced: 0.9, // empirical 3-data-points 2026-06-01: N=40 #2513 85.0% (6 timeout) + N=40 95.0% + N=100 99.0% -> combined 171/180 = 95.0%. Only loss mode = timeout @ max-rounds 40 (zero defeats: balanced wins every fight it finishes, variance is round-count near cap). 0.9 = conservative lower bound covering timeout-variance (worst night 85% = -5pp in-band; real regression <80% still trips). Was 1.0 placeholder -> false-positives #2513/#2158.
   cautious: 0.95, // empirical N=40 measurements 3-data-points 2026-05-10: #25609294902 95.0%, #25616775262 97.5%, sera userland 97.5% (avg 96.67%, 0.95 = conservative -1.67pp lower bound). Was 0.85 placeholder.
 };
 


### PR DESCRIPTION
## Cosa
`BASELINE_WR.balanced` in `tools/sim/check-thresholds.js`: **1.0 → 0.9**.

Il valore `1.0` era un placeholder (`// historical 100% WR`). Il nightly drift gate (±10pp) ci sbatteva contro la normale **timeout-variance** del profilo `balanced` → falsi-positivi: regression issue **#2513** (06-01, balanced 85%, −15pp) e **#2158** (05-10) NON erano regressioni reali.

## Evidence (3 misure N≥40, 2026-06-01)

| Run | N | WR | victory/timeout |
|---|---:|---:|---|
| #2513 (nightly) | 40 | 85.0% | 34 / 6 |
| re-run | 40 | 95.0% | 38 / 2 |
| re-run | 100 | 99.0% | 99 / 1 |
| **combined** | **180** | **95.0%** | **171 / 9** |

**Insight chiave**: l'unico loss-mode è **timeout @ max-rounds 40**, **zero defeats** — `balanced` vince ogni fight che porta a termine; la variance è il numero di round vicino al cap, non win/lose. #2513's 85% = nottata con 6 timeout (low-tail), textbook N=40 swing (L-069).

## Perché 0.9

Conservative lower bound che **copre la variance osservata** (worst night 85% → −5pp, in-band) ma **cattura regressioni reali** (WR <80% trippa). Stessa filosofia del precedente `cautious` (0.85→0.95 placeholder-fix, 2026-05-10).

## Verifica

`check-thresholds.js` con baseline 0.9 sui summary reali:
- N=40 (95%) → +5.0pp → ✅ Clean
- N=100 (99%) → +9.0pp → ✅ Clean
- #2513 (85%) → −5.0pp → in-band (non avrebbe più falso-flaggato)

prettier ✅. 1-line change, nessun forbidden-path.

## Note
- Issue #2513 + #2158 possono essere chiuse come noise-false-positive (non incluse qui).
- Collegato a [#2516](https://github.com/MasterDD-L34D/Game/pull/2516) (pillar reconciliation — P6 caveat verificato qui).
- CI-gate change → lasciato per review master-dd (non auto-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
