### PR TITLE
feat(meta): recruit persists recruited NPC into party_rosters [link-2 PR1]

### DIFF
--- a/apps/backend/routes/meta.js
+++ b/apps/backend/routes/meta.js
@@ -112,8 +112,7 @@ function createMetaRouter(opts = {}) {
   const router = Router();
   const store =
     opts.store || createMetaStore({ prisma: opts.prisma, campaignId: opts.campaignId ?? null });
-  const rosterStore =
-    opts.rosterStore || (opts.prisma ? createRosterStore(opts.prisma) : null);
+  const rosterStore = opts.rosterStore || (opts.prisma ? createRosterStore(opts.prisma) : null);
 
   // OD-001 Path A Sprint B (2026-04-26): expose MBTI compat table for
   // debrief recruit UI scoring. Read-only, cached in-process. Returns

--- a/apps/backend/routes/meta.js
+++ b/apps/backend/routes/meta.js
@@ -31,6 +31,7 @@ const {
 } = require('../services/metaProgression');
 const { addFragments } = require('../services/rewards/skipFragmentStore');
 const { loadEpigenomeConfig, computeSpeciesMean } = require('../services/genetics/epigenome');
+const { createRosterStore } = require('../services/campaign/rosterStore');
 
 // OD-001 Path A Sprint B (2026-04-26): debrief-recruit affinity-bypass threshold.
 // Defeated enemies with affinity_at_recruit >= this value can be recruited
@@ -111,6 +112,8 @@ function createMetaRouter(opts = {}) {
   const router = Router();
   const store =
     opts.store || createMetaStore({ prisma: opts.prisma, campaignId: opts.campaignId ?? null });
+  const rosterStore =
+    opts.rosterStore || (opts.prisma ? createRosterStore(opts.prisma) : null);
 
   // OD-001 Path A Sprint B (2026-04-26): expose MBTI compat table for
   // debrief recruit UI scoring. Read-only, cached in-process. Returns
@@ -189,6 +192,24 @@ function createMetaRouter(opts = {}) {
       }
 
       const result = await store.recruit(npc_id);
+
+      // link-2 — persist the recruited NPC into the run-scoped party_rosters so
+      // it shows in the Nido roster. Best-effort: a roster failure must never
+      // block/alter the recruit response. species/job/hp default in rosterStore.
+      if (result && result.success && rosterStore) {
+        const campaignId = (req.body && req.body.campaign_id) || null;
+        if (campaignId) {
+          try {
+            await rosterStore.upsert(campaignId, {
+              unit_id: npc_id,
+              traits: (result.npc && result.npc.trait_ids) || [],
+            });
+          } catch (err) {
+            console.warn('[meta/recruit] roster upsert failed (best-effort):', err.message);
+          }
+        }
+      }
+
       const payload = {
         ...result,
         ...(source_session_id ? { source_session_id } : {}),

--- a/apps/backend/services/pluginLoader.js
+++ b/apps/backend/services/pluginLoader.js
@@ -61,8 +61,8 @@ const metaPlugin = {
     // Share one store between /api/v1/meta and /api/meta. Pre-adapter, each
     // mount built its own Map → aliases saw divergent state (latent bug).
     const store = createMetaStore({ prisma, campaignId: null });
-    app.use('/api/v1/meta', createMetaRouter({ store }));
-    app.use('/api/meta', createMetaRouter({ store }));
+    app.use('/api/v1/meta', createMetaRouter({ store, prisma }));
+    app.use('/api/meta', createMetaRouter({ store, prisma }));
   },
 };
 

--- a/tests/api/metaRecruitRoster.test.js
+++ b/tests/api/metaRecruitRoster.test.js
@@ -1,0 +1,75 @@
+// link-2 — recruit success persists the recruited NPC into party_rosters via
+// rosterStore.upsert. DB-free: DI a fake store + fake rosterStore into
+// createMetaRouter, mount on a bare express app, assert upsert call gating.
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+const { createMetaRouter } = require('../../apps/backend/routes/meta');
+
+function makeApp({ recruitResult, rosterCalls }) {
+  const fakeStore = {
+    recruit: async (npc_id) => recruitResult(npc_id),
+    updateAffinity: async () => {},
+    updateTrust: async () => {},
+  };
+  const fakeRoster = {
+    upsert: async (campaignId, spec) => {
+      rosterCalls.push({ campaignId, spec });
+    },
+    get: async () => [],
+  };
+  const app = express();
+  app.use(express.json());
+  app.use('/api/meta', createMetaRouter({ store: fakeStore, rosterStore: fakeRoster }));
+  return app;
+}
+
+const SUCCESS = (npc_id) => ({ success: true, npc: { npc_id, recruited: true, trait_ids: ['t_a'] } });
+const FAIL = () => ({ success: false, reason: 'gate_not_met' });
+
+test('recruit success + campaign_id → rosterStore.upsert called with unit_id+traits', async () => {
+  const rosterCalls = [];
+  const app = makeApp({ recruitResult: SUCCESS, rosterCalls });
+  const res = await request(app)
+    .post('/api/meta/recruit')
+    .send({ npc_id: 'npc_1', campaign_id: 'run-1' })
+    .expect(200);
+  assert.equal(res.body.success, true);
+  assert.equal(rosterCalls.length, 1);
+  assert.equal(rosterCalls[0].campaignId, 'run-1');
+  assert.equal(rosterCalls[0].spec.unit_id, 'npc_1');
+  assert.deepEqual(rosterCalls[0].spec.traits, ['t_a']);
+});
+
+test('recruit success + NO campaign_id → upsert NOT called', async () => {
+  const rosterCalls = [];
+  const app = makeApp({ recruitResult: SUCCESS, rosterCalls });
+  await request(app).post('/api/meta/recruit').send({ npc_id: 'npc_2' }).expect(200);
+  assert.equal(rosterCalls.length, 0);
+});
+
+test('recruit FAIL (gate_not_met) + campaign_id → upsert NOT called', async () => {
+  const rosterCalls = [];
+  const app = makeApp({ recruitResult: FAIL, rosterCalls });
+  const res = await request(app)
+    .post('/api/meta/recruit')
+    .send({ npc_id: 'npc_3', campaign_id: 'run-1' })
+    .expect(200);
+  assert.equal(res.body.success, false);
+  assert.equal(rosterCalls.length, 0);
+});
+
+test('no rosterStore (DI absent) → recruit success, no throw', async () => {
+  const fakeStore = { recruit: async (id) => SUCCESS(id), updateAffinity: async () => {}, updateTrust: async () => {} };
+  const app = express();
+  app.use(express.json());
+  app.use('/api/meta', createMetaRouter({ store: fakeStore })); // no rosterStore, no prisma
+  const res = await request(app)
+    .post('/api/meta/recruit')
+    .send({ npc_id: 'npc_4', campaign_id: 'run-1' })
+    .expect(200);
+  assert.equal(res.body.success, true);
+});

--- a/tests/api/metaRecruitRoster.test.js
+++ b/tests/api/metaRecruitRoster.test.js
@@ -27,7 +27,10 @@ function makeApp({ recruitResult, rosterCalls }) {
   return app;
 }
 
-const SUCCESS = (npc_id) => ({ success: true, npc: { npc_id, recruited: true, trait_ids: ['t_a'] } });
+const SUCCESS = (npc_id) => ({
+  success: true,
+  npc: { npc_id, recruited: true, trait_ids: ['t_a'] },
+});
 const FAIL = () => ({ success: false, reason: 'gate_not_met' });
 
 test('recruit success + campaign_id → rosterStore.upsert called with unit_id+traits', async () => {
@@ -63,7 +66,11 @@ test('recruit FAIL (gate_not_met) + campaign_id → upsert NOT called', async ()
 });
 
 test('no rosterStore (DI absent) → recruit success, no throw', async () => {
-  const fakeStore = { recruit: async (id) => SUCCESS(id), updateAffinity: async () => {}, updateTrust: async () => {} };
+  const fakeStore = {
+    recruit: async (id) => SUCCESS(id),
+    updateAffinity: async () => {},
+    updateTrust: async () => {},
+  };
   const app = express();
   app.use(express.json());
   app.use('/api/meta', createMetaRouter({ store: fakeStore })); // no rosterStore, no prisma


### PR DESCRIPTION
## link-2 (PR1/2, Game) — recruit persists recruited NPC into `party_rosters`

Meta-loop arc link-2 (recruit N4 → **roster** → field 2b → mate §22-B). On a successful `POST /api/meta/recruit` **and** `body.campaign_id` present, persist the recruited NPC into the run-scoped `party_rosters` via the existing `rosterStore.upsert`, so it appears in the Nido roster panel. Makes N4's recruit **persistent + visible** (today it only flips an invisible `NpcRelation.recruited` flag).

Spec/plan (GGv2 arc home): `docs/superpowers/specs/2026-06-01-link2-recruit-roster-design.md` + `docs/superpowers/plans/2026-06-01-link2-recruit-roster.md`.

### Change
- `createMetaRouter(opts)`: `rosterStore = opts.rosterStore || (opts.prisma ? createRosterStore(opts.prisma) : null)` (DI).
- `metaPlugin` passes `prisma` to both `/api/v1/meta` + `/api/meta` mounts.
- `/recruit`: after `store.recruit`, on `result.success && body.campaign_id && rosterStore` → `rosterStore.upsert(campaign_id, {unit_id: npc_id, traits: result.npc?.trait_ids||[]})`. **Best-effort** (try/catch; the store is also internally no-op without a DB) — never blocks/alters the recruit response. `species`/`job`/`hp` default in `rosterStore` (NpcRelation has none).

### Invariants
- Recruit response shape **unchanged**; write is success-gated + non-blocking.
- Back-compat: no `campaign_id` or no `rosterStore` → no write (current behavior).
- Idempotent (`@@unique[campaignId,unitId]`).

### Tests
- New `tests/api/metaRecruitRoster.test.js` — DB-free DI (fake store + rosterStore): success+campaign_id → upsert(run, {unit_id,traits}); no campaign_id → no write; fail → no write; no rosterStore → no throw.
- Full `npm run test:api` **495/495** (incl. existing `metaRecruit.test.js` 8/8 unchanged).
- Fresh-eyes review: SHIP (no blockers).

GGv2 client PR (send `campaign_id` + refresh roster panel) follows. Compat-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
