### PR TITLE
feat(combat): PHASEC C-G bundle slices 1-3 (def-eval + silent_step + PE pool)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -196,6 +196,7 @@ const {
   applyProgressionToUnits,
   computePerkDamageBonus,
   computePerkCombatModifiers,
+  computePerkDefenseBonus,
   applyPerkKillEffects,
 } = require('../services/progression/progressionApply');
 // Sprint Spore Moderate (ADR-2026-04-26 §S6) — archetype passive consumers.
@@ -600,6 +601,12 @@ function createSessionRouter(options = {}) {
       };
     }
 
+    // TKT-JOB-PHASEC slice 1 — defensive perk aura/self bonus raises the target
+    // DC. Precomputed here (needs session.units for aura scan) and read by
+    // resolveAttack via target._perk_defense_bonus. 0 when no perk fired.
+    target._perk_defense_bonus = computePerkDefenseBonus(target, {
+      units: session.units || [],
+    }).bonus;
     const result = resolveAttack({ actor, target, rng });
     const evaluation = evaluateAttackTraits({
       registry: traitRegistry,

--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -109,6 +109,10 @@ function normaliseUnit(raw, fallbackIndex) {
     // V5 SG pool — preserve from input so save-load + tests carry value through.
     // sgTracker.initUnit will keep this if already set, otherwise default to 0.
     sg: Number.isFinite(Number(input.sg)) ? Number(input.sg) : 0,
+    // TKT-JOB-PHASEC slice 3 — PE combat pool (OQ-PE verdict B: combat-scoped,
+    // separate from the meta evolution-PE). Earned via first_kill_pe_bonus,
+    // spent by aberrant cost_pe abilities. Default 0, preserved from input.
+    pe: Number.isFinite(Number(input.pe)) ? Number(input.pe) : 0,
     // Sprint Spore Moderate — preserve species_id (alias di species), applied_mutations,
     // mp pool, lineage_id. Necessari per:
     // - mutationEngine slot-conflict + bingo hydration (PR #1916)
@@ -229,10 +233,13 @@ function resolveAttack({ actor, target, rng }) {
   const baseDc = target.dc ?? target.dc_difesa ?? 10 + (target.mod || 0);
   // Ennea Cacciatore(8) evasion_bonus consumer: alza DC del target. Stesso slot
   // semantico di defense_mod_bonus ma stat distinto (decay separato + telemetria).
+  // TKT-JOB-PHASEC slice 1: perk defensive aura/self bonus, precomputed by the
+  // performAttack flow into target._perk_defense_bonus (0 when no perk fired).
   const dc =
     Number(baseDc) +
     Number(target.defense_mod_bonus || 0) +
-    Number(target.evasion_bonus_bonus || 0);
+    Number(target.evasion_bonus_bonus || 0) +
+    Number(target._perk_defense_bonus || 0);
   const mos = roll - dc;
   const hit = mos >= 0;
   let pt = 0;

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -1732,6 +1732,28 @@ function createAbilityExecutor(deps) {
         },
       };
     }
+    // TKT-JOB-PHASEC slice 3 — PE spend gate + deduction (OQ-PE verdict B:
+    // combat-scoped pool). Reject before any side effect when PE is short;
+    // deduct once the gate passes (cost_pe abilities are all valid execute paths).
+    const costPe = Number(ability.cost_pe || 0);
+    if (costPe > 0) {
+      const peAvailable = Number(actor.pe || 0);
+      if (peAvailable < costPe) {
+        return {
+          status: 400,
+          body: {
+            error: `PE insufficienti per ability (richiesti ${costPe}, disponibili ${peAvailable})`,
+            pe: peAvailable,
+            cost_pe: costPe,
+          },
+        };
+      }
+      actor.pe = Math.max(0, peAvailable - costPe);
+    }
+    // TKT-JOB-PHASEC slice 2 — track the last ability id used (ability-id
+    // granular, finer than last_action_type). Consumed by computePerkDefenseBonus
+    // (defense_after_silent). Set after the AP gate, before dispatch.
+    actor._last_ability_id = ability.ability_id;
     switch (ability.effect_type) {
       case 'move_attack':
         return executeMoveAttack({ session, actor, ability, body });

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -1732,76 +1732,82 @@ function createAbilityExecutor(deps) {
         },
       };
     }
-    // TKT-JOB-PHASEC slice 3 — PE spend gate + deduction (OQ-PE verdict B:
-    // combat-scoped pool). Reject before any side effect when PE is short;
-    // deduct once the gate passes (cost_pe abilities are all valid execute paths).
+    // TKT-JOB-PHASEC slice 3 — PE spend GATE (OQ-PE verdict B: combat-scoped
+    // pool). Reject before any side effect when PE is short. The deduction is
+    // DEFERRED until the executor resolves successfully (Codex P2 #2522), so a
+    // failed-input ability (400/501) never spends PE — mirrors the AP model.
     const costPe = Number(ability.cost_pe || 0);
-    if (costPe > 0) {
-      const peAvailable = Number(actor.pe || 0);
-      if (peAvailable < costPe) {
-        return {
-          status: 400,
-          body: {
-            error: `PE insufficienti per ability (richiesti ${costPe}, disponibili ${peAvailable})`,
-            pe: peAvailable,
-            cost_pe: costPe,
-          },
-        };
-      }
-      actor.pe = Math.max(0, peAvailable - costPe);
+    if (costPe > 0 && Number(actor.pe || 0) < costPe) {
+      return {
+        status: 400,
+        body: {
+          error: `PE insufficienti per ability (richiesti ${costPe}, disponibili ${Number(actor.pe || 0)})`,
+          pe: Number(actor.pe || 0),
+          cost_pe: costPe,
+        },
+      };
     }
     // TKT-JOB-PHASEC slice 2 — track the last ability id used (ability-id
     // granular, finer than last_action_type). Consumed by computePerkDefenseBonus
     // (defense_after_silent). Set after the AP gate, before dispatch.
     actor._last_ability_id = ability.ability_id;
-    switch (ability.effect_type) {
-      case 'move_attack':
-        return executeMoveAttack({ session, actor, ability, body });
-      case 'attack_move':
-        return executeAttackMove({ session, actor, ability, body });
-      case 'buff':
-        return executeBuff({ session, actor, ability });
-      case 'heal':
-        return executeHeal({ session, actor, ability, body });
-      case 'multi_attack':
-        return executeMultiAttack({ session, actor, ability, body });
-      case 'attack_push':
-        return executeAttackPush({ session, actor, ability, body });
-      case 'debuff':
-        return executeDebuff({ session, actor, ability, body });
-      case 'ranged_attack':
-        return executeRangedAttack({ session, actor, ability, body });
-      case 'drain_attack':
-        return executeDrainAttack({ session, actor, ability, body });
-      case 'execution_attack':
-        return executeExecutionAttack({ session, actor, ability, body });
-      case 'shield':
-        return executeShield({ session, actor, ability, body });
-      case 'team_buff':
-        return executeTeamBuff({ session, actor, ability });
-      case 'team_heal':
-        return executeTeamHeal({ session, actor, ability });
-      case 'aoe_buff':
-        return executeAoeBuff({ session, actor, ability, body });
-      case 'aoe_debuff':
-        return executeAoeDebuff({ session, actor, ability, body });
-      case 'surge_aoe':
-        return executeSurgeAoe({ session, actor, ability, body });
-      case 'reaction':
-        return executeReaction({ session, actor, ability });
-      case 'aggro_pull':
-        return executeAggroPull({ session, actor, ability, body });
-      default:
-        return {
-          status: 501,
-          body: {
-            error: `effect_type "${ability.effect_type}" non implementato in MVP`,
-            ability_id: abilityId,
-            effect_type: ability.effect_type,
-            supported: Array.from(SUPPORTED_EFFECT_TYPES),
-          },
-        };
+    const dispatch = () => {
+      switch (ability.effect_type) {
+        case 'move_attack':
+          return executeMoveAttack({ session, actor, ability, body });
+        case 'attack_move':
+          return executeAttackMove({ session, actor, ability, body });
+        case 'buff':
+          return executeBuff({ session, actor, ability });
+        case 'heal':
+          return executeHeal({ session, actor, ability, body });
+        case 'multi_attack':
+          return executeMultiAttack({ session, actor, ability, body });
+        case 'attack_push':
+          return executeAttackPush({ session, actor, ability, body });
+        case 'debuff':
+          return executeDebuff({ session, actor, ability, body });
+        case 'ranged_attack':
+          return executeRangedAttack({ session, actor, ability, body });
+        case 'drain_attack':
+          return executeDrainAttack({ session, actor, ability, body });
+        case 'execution_attack':
+          return executeExecutionAttack({ session, actor, ability, body });
+        case 'shield':
+          return executeShield({ session, actor, ability, body });
+        case 'team_buff':
+          return executeTeamBuff({ session, actor, ability });
+        case 'team_heal':
+          return executeTeamHeal({ session, actor, ability });
+        case 'aoe_buff':
+          return executeAoeBuff({ session, actor, ability, body });
+        case 'aoe_debuff':
+          return executeAoeDebuff({ session, actor, ability, body });
+        case 'surge_aoe':
+          return executeSurgeAoe({ session, actor, ability, body });
+        case 'reaction':
+          return executeReaction({ session, actor, ability });
+        case 'aggro_pull':
+          return executeAggroPull({ session, actor, ability, body });
+        default:
+          return {
+            status: 501,
+            body: {
+              error: `effect_type "${ability.effect_type}" non implementato in MVP`,
+              ability_id: abilityId,
+              effect_type: ability.effect_type,
+              supported: Array.from(SUPPORTED_EFFECT_TYPES),
+            },
+          };
+      }
+    };
+    const result = await dispatch();
+    // TKT-JOB-PHASEC slice 3 (Codex P2 #2522) — commit the PE spend only after a
+    // successful (2xx) resolution; a failed-input ability (400/501) does not pay.
+    if (costPe > 0 && result && Number(result.status) >= 200 && Number(result.status) < 300) {
+      actor.pe = Math.max(0, Number(actor.pe || 0) - costPe);
     }
+    return result;
   }
 
   return { executeAbility, findAbility, SUPPORTED_EFFECT_TYPES };

--- a/apps/backend/services/progression/progressionApply.js
+++ b/apps/backend/services/progression/progressionApply.js
@@ -234,6 +234,23 @@ function applyPerkKillEffects(actor) {
   const passives = Array.isArray(actor?._perk_passives) ? actor._perk_passives : [];
   if (passives.length === 0) return out;
 
+  // TKT-JOB-PHASEC slice 3 — first_kill_pe_bonus: earn PE on the first kill of
+  // the encounter (guarded by _first_kill_pe_done). Independent of the attack
+  // buffs below, so it runs before the eternal/temp early-return.
+  const firstKillPe = passives.find((p) => p.tag === 'first_kill_pe_bonus');
+  if (firstKillPe && !actor._first_kill_pe_done) {
+    const amt = Number(firstKillPe.payload?.pe) || 0;
+    if (amt !== 0) {
+      actor.pe = Number(actor.pe || 0) + amt;
+      actor._first_kill_pe_done = true;
+      out.applied.push({
+        tag: 'first_kill_pe_bonus',
+        pe: amt,
+        source_perk_id: firstKillPe.source_perk_id,
+      });
+    }
+  }
+
   const eternal = passives.find((p) => p.tag === 'eternal_kill_buff');
   if (eternal) {
     const amt = Number(eternal.payload?.attack_mod) || 0;
@@ -313,6 +330,72 @@ function computePerkCombatModifiers(actor, target, ctx = {}) {
 }
 
 /**
+ * Compute perk DEFENSE bonus at attack resolve time — raises the defender's
+ * effective DC. Sibling of computePerkDamageBonus (offensive). Slice 1
+ * (TKT-JOB-PHASEC C-G prereq). Handles aura-type passives emitted by ALLIES
+ * (reads OTHER units' _perk_passives) — distinct from the offensive helpers
+ * which read the actor's own passives.
+ *
+ * @param {object} defender — the unit being attacked
+ * @param {object} ctx — { units?: Array<object> }
+ * @returns {{ bonus: number, applied: Array<{ tag, amount, source_perk_id, source_unit_id }> }}
+ */
+function computePerkDefenseBonus(defender, ctx = {}) {
+  const out = { bonus: 0, applied: [] };
+  if (!defender || !defender.position) return out;
+  const units = Array.isArray(ctx.units) ? ctx.units : [];
+
+  // Aura passives: an ally carrying the tag grants the bonus to allies in range.
+  for (const ally of units) {
+    if (!ally || ally.id === defender.id) continue;
+    if (ally.controlled_by !== defender.controlled_by) continue;
+    if (Number(ally.hp) <= 0) continue;
+    if (!ally.position) continue;
+    const passives = Array.isArray(ally._perk_passives) ? ally._perk_passives : [];
+    for (const p of passives) {
+      if (p.tag !== 'aura_defense_2tile') continue;
+      const range = Number(p.payload?.range) || 2;
+      const dist =
+        Math.abs(ally.position.x - defender.position.x) +
+        Math.abs(ally.position.y - defender.position.y);
+      if (dist <= range) {
+        const amt = Number(p.payload?.defense_mod) || 0;
+        if (amt !== 0) {
+          out.bonus += amt;
+          out.applied.push({
+            tag: 'aura_defense_2tile',
+            amount: amt,
+            source_perk_id: p.source_perk_id,
+            source_unit_id: ally.id,
+          });
+        }
+      }
+    }
+  }
+
+  // Self defensive passives on the defender, conditioned on combat state.
+  const selfPassives = Array.isArray(defender._perk_passives) ? defender._perk_passives : [];
+  for (const p of selfPassives) {
+    if (p.tag === 'defense_after_silent' && defender._last_ability_id === 'silent_step') {
+      // Active in the window after the defender used silent_step (tracked via
+      // _last_ability_id, set in abilityExecutor). Window approximated as "until
+      // the unit's next ability"; exact payload.duration turn-decay = follow-up.
+      const amt = Number(p.payload?.defense_mod) || 0;
+      if (amt !== 0) {
+        out.bonus += amt;
+        out.applied.push({
+          tag: 'defense_after_silent',
+          amount: amt,
+          source_perk_id: p.source_perk_id,
+          source_unit_id: defender.id,
+        });
+      }
+    }
+  }
+  return out;
+}
+
+/**
  * Grant XP to all player survivors. Used by campaign advance hook.
  *
  * @param {Array<object>} units
@@ -358,6 +441,7 @@ module.exports = {
   applyProgressionToUnits,
   computePerkDamageBonus,
   computePerkCombatModifiers,
+  computePerkDefenseBonus,
   applyPerkKillEffects,
   grantXpToSurvivors,
   resetDefaults,

--- a/tests/progression/peCombatPool.test.js
+++ b/tests/progression/peCombatPool.test.js
@@ -81,6 +81,18 @@ test('executeAbility: insufficient PE rejects with 400', async () => {
   assert.strictEqual(actor.pe, 0, 'PE not deducted on rejection');
 });
 
+test('executeAbility: PE NOT deducted when ability fails input validation (400)', async () => {
+  const ex = makeExecutor();
+  const actor = { id: 'ab', ap_remaining: 5, pe: 10, position: { x: 0, y: 0 }, attack_range: 5 };
+  const res = await ex.executeAbility({
+    session: { units: [actor], damage_taken: {} }, // no 'foe' target present
+    actor,
+    body: { ability_id: 'aberrant_overdrive', target_id: 'foe' }, // missing target -> 400
+  });
+  assert.strictEqual(res.status, 400);
+  assert.strictEqual(actor.pe, 10, 'PE must not be spent when the ability did not resolve');
+});
+
 test('executeAbility: sufficient PE deducts cost_pe', async () => {
   const ex = makeExecutor();
   const actor = { id: 'ab', ap_remaining: 5, pe: 10, position: { x: 0, y: 0 }, attack_range: 5 };

--- a/tests/progression/peCombatPool.test.js
+++ b/tests/progression/peCombatPool.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { normaliseUnit } = require('../../apps/backend/routes/sessionHelpers');
+const {
+  applyPerkKillEffects,
+} = require('../../apps/backend/services/progression/progressionApply');
+const { createAbilityExecutor } = require('../../apps/backend/services/abilityExecutor');
+
+// TKT-JOB-PHASEC slice 3 — PE pool (combat-scoped, OQ-PE verdict B: new pool,
+// no coupling with the meta evolution-PE). Field + earn (first_kill_pe_bonus)
+// + spend gate/deduct (cost_pe).
+
+// --- 3a. normaliseUnit carries a `pe` field (mirror of `sg`/`mp`) ---
+
+test('normaliseUnit: pe defaults to 0 when absent', () => {
+  assert.strictEqual(normaliseUnit({}, 0).pe, 0);
+});
+
+test('normaliseUnit: pe preserved from input', () => {
+  assert.strictEqual(normaliseUnit({ pe: 7 }, 0).pe, 7);
+});
+
+// --- 3b. first_kill_pe_bonus earns PE on the first kill of the encounter ---
+
+test('applyPerkKillEffects: first_kill_pe_bonus grants pe once', () => {
+  const actor = {
+    id: 'st',
+    pe: 0,
+    _perk_passives: [
+      { tag: 'first_kill_pe_bonus', payload: { pe: 1 }, source_perk_id: 'st_r3_first_blood' },
+    ],
+  };
+  applyPerkKillEffects(actor);
+  assert.strictEqual(actor.pe, 1);
+});
+
+test('applyPerkKillEffects: first_kill_pe_bonus does NOT re-grant on a second kill', () => {
+  const actor = {
+    id: 'st',
+    pe: 0,
+    _perk_passives: [
+      { tag: 'first_kill_pe_bonus', payload: { pe: 1 }, source_perk_id: 'st_r3_first_blood' },
+    ],
+  };
+  applyPerkKillEffects(actor);
+  applyPerkKillEffects(actor);
+  assert.strictEqual(actor.pe, 1);
+});
+
+test('applyPerkKillEffects: no pe change without the perk', () => {
+  const actor = { id: 'plain', pe: 3, _perk_passives: [] };
+  applyPerkKillEffects(actor);
+  assert.strictEqual(actor.pe, 3);
+});
+
+// --- 3c. cost_pe gate + deduction in executeAbility ---
+
+function makeExecutor() {
+  return createAbilityExecutor({
+    performAttack: () => ({ damageDealt: 0, result: { hit: false } }),
+    buildAttackEvent: () => ({}),
+    buildMoveEvent: () => ({}),
+    appendEvent: async () => {},
+    manhattanDistance: (a, b) => Math.abs(a.x - b.x) + Math.abs(a.y - b.y),
+  });
+}
+
+test('executeAbility: insufficient PE rejects with 400', async () => {
+  const ex = makeExecutor();
+  const actor = { id: 'ab', ap_remaining: 5, pe: 0, position: { x: 0, y: 0 }, attack_range: 5 };
+  const res = await ex.executeAbility({
+    session: { units: [actor], damage_taken: {} },
+    actor,
+    body: { ability_id: 'aberrant_overdrive', target_id: 'foe' },
+  });
+  assert.strictEqual(res.status, 400);
+  assert.match(String(res.body.error), /PE/i);
+  assert.strictEqual(actor.pe, 0, 'PE not deducted on rejection');
+});
+
+test('executeAbility: sufficient PE deducts cost_pe', async () => {
+  const ex = makeExecutor();
+  const actor = { id: 'ab', ap_remaining: 5, pe: 10, position: { x: 0, y: 0 }, attack_range: 5 };
+  const target = { id: 'foe', hp: 10, max_hp: 10, position: { x: 1, y: 0 } };
+  const res = await ex.executeAbility({
+    session: { units: [actor, target], damage_taken: {} },
+    actor,
+    body: { ability_id: 'aberrant_overdrive', target_id: 'foe' },
+  });
+  assert.strictEqual(
+    res.status,
+    200,
+    `expected 200, got ${res.status}: ${JSON.stringify(res.body)}`,
+  );
+  assert.strictEqual(actor.pe, 5, 'cost_pe=5 deducted from pe=10');
+});

--- a/tests/progression/progressionDefenseBonus.test.js
+++ b/tests/progression/progressionDefenseBonus.test.js
@@ -1,0 +1,191 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  computePerkDefenseBonus,
+} = require('../../apps/backend/services/progression/progressionApply');
+const { resolveAttack } = require('../../apps/backend/routes/sessionHelpers');
+
+// TKT-JOB-PHASEC slice 1 — defensive passive aggregation.
+// computePerkDefenseBonus(defender, ctx) → { bonus, applied }
+// Mirror sibling of computePerkDamageBonus but for the defender side (raises DC).
+
+function unit(id, x, y, passives = [], extra = {}) {
+  return {
+    id,
+    controlled_by: extra.controlled_by || 'player',
+    hp: extra.hp ?? 10,
+    position: { x, y },
+    _perk_passives: passives,
+    ...extra,
+  };
+}
+
+test('aura_defense_2tile: ally symbiont within Manhattan range grants +defense_mod', () => {
+  const defender = unit('hero', 2, 2);
+  const symbiont = unit('sym', 3, 2, [
+    { tag: 'aura_defense_2tile', payload: { defense_mod: 1, range: 2 }, source_perk_id: 'sy_r3' },
+  ]);
+  const res = computePerkDefenseBonus(defender, { units: [defender, symbiont] });
+  assert.strictEqual(res.bonus, 1);
+  assert.strictEqual(res.applied.length, 1);
+  assert.strictEqual(res.applied[0].tag, 'aura_defense_2tile');
+});
+
+test('aura_defense_2tile: ally out of range (Manhattan 3 > range 2) grants nothing', () => {
+  const defender = unit('hero', 0, 0);
+  const symbiont = unit('sym', 2, 1, [
+    { tag: 'aura_defense_2tile', payload: { defense_mod: 1, range: 2 }, source_perk_id: 'sy_r3' },
+  ]);
+  const res = computePerkDefenseBonus(defender, { units: [defender, symbiont] });
+  assert.strictEqual(res.bonus, 0);
+  assert.strictEqual(res.applied.length, 0);
+});
+
+test('aura_defense_2tile: enemy carrier does NOT buff a player defender', () => {
+  const defender = unit('hero', 2, 2);
+  const enemySym = unit(
+    'foe',
+    3,
+    2,
+    [{ tag: 'aura_defense_2tile', payload: { defense_mod: 1, range: 2 }, source_perk_id: 'x' }],
+    { controlled_by: 'enemy' },
+  );
+  const res = computePerkDefenseBonus(defender, { units: [defender, enemySym] });
+  assert.strictEqual(res.bonus, 0);
+});
+
+test('aura_defense_2tile: dead carrier (hp 0) grants nothing', () => {
+  const defender = unit('hero', 2, 2);
+  const deadSym = unit(
+    'sym',
+    3,
+    2,
+    [{ tag: 'aura_defense_2tile', payload: { defense_mod: 1, range: 2 }, source_perk_id: 'x' }],
+    { hp: 0 },
+  );
+  const res = computePerkDefenseBonus(defender, { units: [defender, deadSym] });
+  assert.strictEqual(res.bonus, 0);
+});
+
+test('aura_defense_2tile: two symbionts in range stack', () => {
+  const defender = unit('hero', 2, 2);
+  const s1 = unit('s1', 3, 2, [
+    { tag: 'aura_defense_2tile', payload: { defense_mod: 1, range: 2 }, source_perk_id: 'a' },
+  ]);
+  const s2 = unit('s2', 1, 2, [
+    { tag: 'aura_defense_2tile', payload: { defense_mod: 1, range: 2 }, source_perk_id: 'b' },
+  ]);
+  const res = computePerkDefenseBonus(defender, { units: [defender, s1, s2] });
+  assert.strictEqual(res.bonus, 2);
+  assert.strictEqual(res.applied.length, 2);
+});
+
+test('no defensive passives anywhere = neutral', () => {
+  const defender = unit('hero', 2, 2);
+  const ally = unit('ally', 3, 2);
+  const res = computePerkDefenseBonus(defender, { units: [defender, ally] });
+  assert.strictEqual(res.bonus, 0);
+  assert.strictEqual(res.applied.length, 0);
+});
+
+test('defender carries its own aura but does not buff itself', () => {
+  const defender = unit('hero', 2, 2, [
+    { tag: 'aura_defense_2tile', payload: { defense_mod: 1, range: 2 }, source_perk_id: 'self' },
+  ]);
+  const res = computePerkDefenseBonus(defender, { units: [defender] });
+  assert.strictEqual(res.bonus, 0);
+});
+
+// --- slice 2: defense_after_silent (defender self-passive gated on last ability) ---
+
+test('defense_after_silent: defender granted when last ability was silent_step', () => {
+  const defender = unit(
+    'hero',
+    2,
+    2,
+    [
+      {
+        tag: 'defense_after_silent',
+        payload: { defense_mod: 2, duration: 1 },
+        source_perk_id: 'st_r2',
+      },
+    ],
+    { _last_ability_id: 'silent_step' },
+  );
+  const res = computePerkDefenseBonus(defender, { units: [defender] });
+  assert.strictEqual(res.bonus, 2);
+  assert.strictEqual(res.applied[0].tag, 'defense_after_silent');
+});
+
+test('defense_after_silent: no bonus when last ability was something else', () => {
+  const defender = unit(
+    'hero',
+    2,
+    2,
+    [
+      {
+        tag: 'defense_after_silent',
+        payload: { defense_mod: 2, duration: 1 },
+        source_perk_id: 'st_r2',
+      },
+    ],
+    { _last_ability_id: 'alpha_strike' },
+  );
+  const res = computePerkDefenseBonus(defender, { units: [defender] });
+  assert.strictEqual(res.bonus, 0);
+});
+
+test('defense_after_silent: no bonus when no ability used yet', () => {
+  const defender = unit('hero', 2, 2, [
+    {
+      tag: 'defense_after_silent',
+      payload: { defense_mod: 2, duration: 1 },
+      source_perk_id: 'st_r2',
+    },
+  ]);
+  const res = computePerkDefenseBonus(defender, { units: [defender] });
+  assert.strictEqual(res.bonus, 0);
+});
+
+test('defense_after_silent + aura stack on the same defender', () => {
+  const defender = unit(
+    'hero',
+    2,
+    2,
+    [
+      {
+        tag: 'defense_after_silent',
+        payload: { defense_mod: 2, duration: 1 },
+        source_perk_id: 'st_r2',
+      },
+    ],
+    { _last_ability_id: 'silent_step' },
+  );
+  const sym = unit('sym', 3, 2, [
+    { tag: 'aura_defense_2tile', payload: { defense_mod: 1, range: 2 }, source_perk_id: 'sy_r3' },
+  ]);
+  const res = computePerkDefenseBonus(defender, { units: [defender, sym] });
+  assert.strictEqual(res.bonus, 3);
+  assert.strictEqual(res.applied.length, 2);
+});
+
+// --- wire: resolveAttack honors the stashed perk defense bonus (raises DC) ---
+
+test('resolveAttack adds target._perk_defense_bonus to the effective DC', () => {
+  const actor = { id: 'a', mod: 0 };
+  const base = resolveAttack({ actor, target: { id: 't', dc: 10 }, rng: () => 0 });
+  const buffed = resolveAttack({
+    actor,
+    target: { id: 't', dc: 10, _perk_defense_bonus: 3 },
+    rng: () => 0,
+  });
+  assert.strictEqual(buffed.dc - base.dc, 3);
+});
+
+test('resolveAttack: missing _perk_defense_bonus = zero delta (back-compat)', () => {
+  const actor = { id: 'a', mod: 0 };
+  const r = resolveAttack({ actor, target: { id: 't', dc: 12 }, rng: () => 0.5 });
+  assert.strictEqual(r.dc, 12);
+});


### PR DESCRIPTION
## What

Implements the **zero-fork prereq bundle (slices 1-3)** from the scoping spec
[#2506](https://github.com/MasterDD-L34D/Game/pull/2506), in build-dependency
order. Real backend code, TDD. Unblocks 4 PHASEC C-G tags + enforces `cost_pe`.

## Slices

| Slice | What | Tags unblocked |
| --- | --- | --- |
| 1 — def-eval + aura | New `computePerkDefenseBonus(defender, ctx)` (aura scan over allies) + `resolveAttack` reads `target._perk_defense_bonus` (raises DC) + `session.js` stash before resolve | `aura_defense_2tile` |
| 2 — silent_step last-ability | `executeAbility` sets `actor._last_ability_id`; `computePerkDefenseBonus` adds the `defense_after_silent` self-passive case (consumes slice-1 seam) | `defense_after_silent` |
| 3 — PE pool (combat) | `normaliseUnit` carries `pe` (mirror `sg`/`mp`); `applyPerkKillEffects` earns `first_kill_pe_bonus` (once/encounter); `executeAbility` gates + deducts `cost_pe` | `first_kill_pe_bonus` + `cost_pe` enforcement |

Slice 1 precedes slice 2 by dependency (`defense_after_silent` consumes the
def-eval seam — the Codex-validated ordering from the spec).

## OQ-PE verdict (master-dd)

**Option B** — combat-scoped PE pool, separate from the meta evolution-PE
(`formEvolution`/`campaign`), no kill→evolve coupling. Reset/earn local to the
encounter. (User-decided this session.)

## Gate 5 — player-visible surface

- Slice 1/2: defended unit's effective DC rises → attacker misses more (visible
  in the attack `dc` + `applied[]`).
- Slice 3: `pe` in unit state increases on first kill; `aberrant_overdrive` is
  rejected with `400 PE insufficienti` until 5 PE earned, then deducts.

## Tests (TDD, red→green each)

- New: `tests/progression/progressionDefenseBonus.test.js` (13), `tests/progression/peCombatPool.test.js` (7).
- Regression: progression + abilityExecutor **81/81**, AI **495/495**, session/combat api **43/43**. Zero regression. Prettier clean.

## Scope / safety

- 4 runtime files, all under `apps/backend/` (+121/-1). No forbidden paths
  (`.github/workflows`, `migrations`, `packages/contracts`, `services/generation`).
  No new deps. No schema/data/yaml change.

## Rollback (03A)

Revert commit `38a2570c`. Additive + back-compat (every new field defaults to a
no-op: `_perk_defense_bonus`/`pe`/`_last_ability_id` absent → zero behavior
change), so revert is clean.

## Follow-ups (noted, out of scope)

- `defense_after_silent` window approximated as "until next ability" (exact
  `payload.duration` turn-decay = follow-up).
- Slices 4-6 (mutation use-hook, symbiont fork, minion fork) per spec #2506.
