### PR TITLE
fix(meta): scope recruit gate to campaign_id [link-2 codex P2]

### DIFF
--- a/apps/backend/routes/meta.js
+++ b/apps/backend/routes/meta.js
@@ -113,6 +113,9 @@ function createMetaRouter(opts = {}) {
   const store =
     opts.store || createMetaStore({ prisma: opts.prisma, campaignId: opts.campaignId ?? null });
   const rosterStore = opts.rosterStore || (opts.prisma ? createRosterStore(opts.prisma) : null);
+  const metaStoreFactory =
+    opts.metaStoreFactory ||
+    (opts.prisma ? (cid) => createMetaStore({ prisma: opts.prisma, campaignId: cid }) : null);
 
   // OD-001 Path A Sprint B (2026-04-26): expose MBTI compat table for
   // debrief recruit UI scoring. Read-only, cached in-process. Returns
@@ -178,6 +181,9 @@ function createMetaRouter(opts = {}) {
       const { npc_id, source_session_id, affinity_at_recruit } = req.body || {};
       if (!npc_id) return res.status(400).json({ error: 'npc_id required' });
 
+      const campaignId = (req.body && req.body.campaign_id) || null;
+      const recruitStore = campaignId && metaStoreFactory ? metaStoreFactory(campaignId) : store;
+
       const affinityBypass =
         Number.isFinite(Number(affinity_at_recruit)) &&
         Number(affinity_at_recruit) >= RECRUIT_AFFINITY_BYPASS_THRESHOLD;
@@ -186,26 +192,23 @@ function createMetaRouter(opts = {}) {
         // Pre-seed affinity + trust so the store gate accepts. The store clamps
         // to [-2,+2] and [0,5]; values chosen to leave room for downstream
         // affinity/trust mutations.
-        await store.updateAffinity(npc_id, 1);
-        await store.updateTrust(npc_id, 2);
+        await recruitStore.updateAffinity(npc_id, 1);
+        await recruitStore.updateTrust(npc_id, 2);
       }
 
-      const result = await store.recruit(npc_id);
+      const result = await recruitStore.recruit(npc_id);
 
       // link-2 — persist the recruited NPC into the run-scoped party_rosters so
       // it shows in the Nido roster. Best-effort: a roster failure must never
       // block/alter the recruit response. species/job/hp default in rosterStore.
-      if (result && result.success && rosterStore) {
-        const campaignId = (req.body && req.body.campaign_id) || null;
-        if (campaignId) {
-          try {
-            await rosterStore.upsert(campaignId, {
-              unit_id: npc_id,
-              traits: (result.npc && result.npc.trait_ids) || [],
-            });
-          } catch (err) {
-            console.warn('[meta/recruit] roster upsert failed (best-effort):', err.message);
-          }
+      if (result && result.success && rosterStore && campaignId) {
+        try {
+          await rosterStore.upsert(campaignId, {
+            unit_id: npc_id,
+            traits: (result.npc && result.npc.trait_ids) || [],
+          });
+        } catch (err) {
+          console.warn('[meta/recruit] roster upsert failed (best-effort):', err.message);
         }
       }
 

--- a/tests/api/metaRecruitRoster.test.js
+++ b/tests/api/metaRecruitRoster.test.js
@@ -80,3 +80,83 @@ test('no rosterStore (DI absent) → recruit success, no throw', async () => {
     .expect(200);
   assert.equal(res.body.success, true);
 });
+
+test('recruit same npc_id in two campaigns — both succeed (campaign-scoped gate)', async () => {
+  const factoryCalls = [];
+  const perCampaign = {};
+  const metaStoreFactory = (cid) => {
+    factoryCalls.push(cid);
+    if (!perCampaign[cid]) {
+      const recruited = new Set();
+      perCampaign[cid] = {
+        updateAffinity: async () => {},
+        updateTrust: async () => {},
+        recruit: async (npc) => {
+          if (recruited.has(npc)) return { success: false, reason: 'gate_not_met' };
+          recruited.add(npc);
+          return { success: true, npc: { npc_id: npc, recruited: true, trait_ids: [] } };
+        },
+      };
+    }
+    return perCampaign[cid];
+  };
+  const rosterCalls = [];
+  const fakeRoster = {
+    upsert: async (cid, spec) => {
+      rosterCalls.push({ cid, spec });
+    },
+    get: async () => [],
+  };
+  const globalStore = {
+    recruit: async () => {
+      throw new Error('global store must NOT be used when campaign_id present');
+    },
+    updateAffinity: async () => {},
+    updateTrust: async () => {},
+  };
+  const app = express();
+  app.use(express.json());
+  app.use(
+    '/api/meta',
+    createMetaRouter({ store: globalStore, metaStoreFactory, rosterStore: fakeRoster }),
+  );
+  const a = await request(app)
+    .post('/api/meta/recruit')
+    .send({ npc_id: 'npc_X', campaign_id: 'A' })
+    .expect(200);
+  assert.equal(a.body.success, true);
+  const b = await request(app)
+    .post('/api/meta/recruit')
+    .send({ npc_id: 'npc_X', campaign_id: 'B' })
+    .expect(200);
+  assert.equal(
+    b.body.success,
+    true,
+    'campaign B not blocked by campaign A recruiting the same npc',
+  );
+  assert.equal(rosterCalls.length, 2);
+  assert.ok(factoryCalls.includes('A') && factoryCalls.includes('B'));
+});
+
+test('recruit with NO campaign_id — falls back to shared store (factory not called)', async () => {
+  let factoryCalled = false;
+  const sharedStore = {
+    recruit: async (id) => ({ success: true, npc: { npc_id: id, trait_ids: [] } }),
+    updateAffinity: async () => {},
+    updateTrust: async () => {},
+  };
+  const app = express();
+  app.use(express.json());
+  app.use(
+    '/api/meta',
+    createMetaRouter({
+      store: sharedStore,
+      metaStoreFactory: () => {
+        factoryCalled = true;
+      },
+      rosterStore: { upsert: async () => {}, get: async () => [] },
+    }),
+  );
+  await request(app).post('/api/meta/recruit').send({ npc_id: 'npc_Y' }).expect(200);
+  assert.equal(factoryCalled, false);
+});


### PR DESCRIPTION
Post-merge codex P2 on #2521. The recruit gate ran against the shared `campaignId:null` meta store while the roster write is run-scoped → two runs recruiting the same `npc_id` collided (first marks it recruited globally, second gets `gate_not_met` + no roster row). Add a `metaStoreFactory` DI; when `campaign_id` present, evaluate the gate against a campaign-scoped store (`createMetaStore({prisma, campaignId})`). No campaign_id → shared store (back-compat). metaPlugin already passes prisma.

Tests: +2 in metaRecruitRoster.test.js (two campaigns recruit same npc_id → both succeed + both get roster rows; no-campaign_id → factory not called). Full `npm run test:api` 495/495. prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)