### PR TITLE
feat(combat): PHASEC slice 4 Cat F event-pure use-hook (OQ-F verdict A)

### DIFF
--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -1807,6 +1807,17 @@ function createAbilityExecutor(deps) {
     if (costPe > 0 && result && Number(result.status) >= 200 && Number(result.status) < 300) {
       actor.pe = Math.max(0, Number(actor.pe || 0) - costPe);
     }
+    // TKT-JOB-PHASEC slice 4 (Cat F, OQ-F verdict A) — on-ability-use perk
+    // effects, fired only on a successful (2xx) resolution. Lazy require mirrors
+    // the sgTracker pattern (non-blocking if the module is unavailable).
+    if (result && Number(result.status) >= 200 && Number(result.status) < 300) {
+      try {
+        const { applyPerkAbilityUseEffects } = require('./progression/progressionApply');
+        applyPerkAbilityUseEffects(actor, ability.ability_id, { round: session.turn });
+      } catch {
+        /* progression optional — non-blocking */
+      }
+    }
     return result;
   }
 

--- a/apps/backend/services/progression/progressionApply.js
+++ b/apps/backend/services/progression/progressionApply.js
@@ -14,6 +14,8 @@
 
 const { ProgressionEngine } = require('./progressionEngine');
 const { createProgressionStore } = require('./progressionStore');
+// SG pool cap — perk SG earns must clamp to sgTracker POOL_MAX (Codex P2 #2524).
+const { POOL_MAX: SG_POOL_MAX } = require('../combat/sgTracker');
 
 let _defaultEngine = null;
 let _defaultStore = null;
@@ -251,24 +253,6 @@ function applyPerkKillEffects(actor) {
     }
   }
 
-  // TKT-JOB-PHASEC slice 4 (Cat F, OQ-F verdict A) — mutation_chain_on_kill:
-  // after a KO scored via mutation_burst, refund AP to enable a "free" re-cast
-  // (AP-refund approximation; +2 = mutation_burst cost_ap, capped at actor.ap).
-  // Once per encounter (_mutation_chain_done). Reuses the slice-2 _last_ability_id.
-  const mutChain = passives.find((p) => p.tag === 'mutation_chain_on_kill');
-  if (mutChain && !actor._mutation_chain_done && actor._last_ability_id === 'mutation_burst') {
-    const refund = 2; // mutation_burst cost_ap (data/core/jobs_expansion.yaml)
-    const apMax = Number(actor.ap || actor.ap_remaining || 0);
-    const before = Number(actor.ap_remaining || 0);
-    actor.ap_remaining = Math.min(apMax, before + refund);
-    actor._mutation_chain_done = true;
-    out.applied.push({
-      tag: 'mutation_chain_on_kill',
-      ap_refunded: actor.ap_remaining - before,
-      source_perk_id: mutChain.source_perk_id,
-    });
-  }
-
   const eternal = passives.find((p) => p.tag === 'eternal_kill_buff');
   if (eternal) {
     const amt = Number(eternal.payload?.attack_mod) || 0;
@@ -439,12 +423,13 @@ function applyPerkAbilityUseEffects(actor, abilityId, ctx = {}) {
     if (p.tag === 'sg_on_mutation_burst' && abilityId === 'mutation_burst') {
       if (actor._sg_on_mb_round !== round) {
         const amt = Number(p.payload?.sg) || 0;
-        if (amt !== 0) {
-          actor.sg = Number(actor.sg || 0) + amt;
+        const before = Number(actor.sg || 0);
+        if (amt !== 0 && before < SG_POOL_MAX) {
+          actor.sg = Math.min(SG_POOL_MAX, before + amt);
           actor._sg_on_mb_round = round;
           out.applied.push({
             tag: 'sg_on_mutation_burst',
-            sg: amt,
+            sg: actor.sg - before,
             source_perk_id: p.source_perk_id,
           });
         }

--- a/apps/backend/services/progression/progressionApply.js
+++ b/apps/backend/services/progression/progressionApply.js
@@ -251,6 +251,24 @@ function applyPerkKillEffects(actor) {
     }
   }
 
+  // TKT-JOB-PHASEC slice 4 (Cat F, OQ-F verdict A) — mutation_chain_on_kill:
+  // after a KO scored via mutation_burst, refund AP to enable a "free" re-cast
+  // (AP-refund approximation; +2 = mutation_burst cost_ap, capped at actor.ap).
+  // Once per encounter (_mutation_chain_done). Reuses the slice-2 _last_ability_id.
+  const mutChain = passives.find((p) => p.tag === 'mutation_chain_on_kill');
+  if (mutChain && !actor._mutation_chain_done && actor._last_ability_id === 'mutation_burst') {
+    const refund = 2; // mutation_burst cost_ap (data/core/jobs_expansion.yaml)
+    const apMax = Number(actor.ap || actor.ap_remaining || 0);
+    const before = Number(actor.ap_remaining || 0);
+    actor.ap_remaining = Math.min(apMax, before + refund);
+    actor._mutation_chain_done = true;
+    out.applied.push({
+      tag: 'mutation_chain_on_kill',
+      ap_refunded: actor.ap_remaining - before,
+      source_perk_id: mutChain.source_perk_id,
+    });
+  }
+
   const eternal = passives.find((p) => p.tag === 'eternal_kill_buff');
   if (eternal) {
     const amt = Number(eternal.payload?.attack_mod) || 0;
@@ -396,6 +414,59 @@ function computePerkDefenseBonus(defender, ctx = {}) {
 }
 
 /**
+ * Apply on-ability-use perk effects (TKT-JOB-PHASEC slice 4, Cat F event-pure
+ * subset, OQ-F verdict A). Twin of applyPerkKillEffects but keyed on a
+ * SUCCESSFUL ability use — called post-2xx from executeAbility.
+ *
+ * - sg_on_mutation_burst (ABERRANT ab_r5_sg_synergy): earn SG on mutation_burst,
+ *   capped to one earn per round (payload.cap_per_round = 1; tracked via
+ *   _sg_on_mb_round). AP economy bounds repeats anyway.
+ * - phenotype_baseline_heal (ab_r3_self_healing_chaos): flat heal on
+ *   phenotype_shift, capped at max_hp.
+ *
+ * @param {object} actor — the unit that used the ability (reads _perk_passives)
+ * @param {string} abilityId — the ability_id just resolved
+ * @param {object} ctx — { round? } current round number for per-round caps
+ * @returns {{ applied: Array<object> }}
+ */
+function applyPerkAbilityUseEffects(actor, abilityId, ctx = {}) {
+  const out = { applied: [] };
+  const passives = Array.isArray(actor?._perk_passives) ? actor._perk_passives : [];
+  if (passives.length === 0 || !abilityId) return out;
+  const round = ctx.round;
+
+  for (const p of passives) {
+    if (p.tag === 'sg_on_mutation_burst' && abilityId === 'mutation_burst') {
+      if (actor._sg_on_mb_round !== round) {
+        const amt = Number(p.payload?.sg) || 0;
+        if (amt !== 0) {
+          actor.sg = Number(actor.sg || 0) + amt;
+          actor._sg_on_mb_round = round;
+          out.applied.push({
+            tag: 'sg_on_mutation_burst',
+            sg: amt,
+            source_perk_id: p.source_perk_id,
+          });
+        }
+      }
+    } else if (p.tag === 'phenotype_baseline_heal' && abilityId === 'phenotype_shift') {
+      const heal = Number(p.payload?.heal) || 0;
+      if (heal !== 0) {
+        const maxHp = Number(actor.max_hp || actor.hp || 0);
+        const before = Number(actor.hp || 0);
+        actor.hp = maxHp > 0 ? Math.min(maxHp, before + heal) : before + heal;
+        out.applied.push({
+          tag: 'phenotype_baseline_heal',
+          heal: actor.hp - before,
+          source_perk_id: p.source_perk_id,
+        });
+      }
+    }
+  }
+  return out;
+}
+
+/**
  * Grant XP to all player survivors. Used by campaign advance hook.
  *
  * @param {Array<object>} units
@@ -443,6 +514,7 @@ module.exports = {
   computePerkCombatModifiers,
   computePerkDefenseBonus,
   applyPerkKillEffects,
+  applyPerkAbilityUseEffects,
   grantXpToSurvivors,
   resetDefaults,
   // Test seam: the module-default store is the singleton the session /start

--- a/tests/progression/perkAbilityUseEffects.test.js
+++ b/tests/progression/perkAbilityUseEffects.test.js
@@ -1,0 +1,190 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  applyPerkAbilityUseEffects,
+  applyPerkKillEffects,
+} = require('../../apps/backend/services/progression/progressionApply');
+const { createAbilityExecutor } = require('../../apps/backend/services/abilityExecutor');
+
+// TKT-JOB-PHASEC slice 4 (Cat F, OQ-F verdict A: event-pure subset).
+// applyPerkAbilityUseEffects(actor, abilityId, ctx) — twin of applyPerkKillEffects,
+// fired post-2xx on a successful ability use. 3 tags: sg_on_mutation_burst (use),
+// phenotype_baseline_heal (use), mutation_chain_on_kill (kill-hook reuse).
+
+// --- sg_on_mutation_burst ---
+
+test('sg_on_mutation_burst: earns sg on mutation_burst use', () => {
+  const actor = {
+    id: 'ab',
+    sg: 0,
+    _perk_passives: [
+      {
+        tag: 'sg_on_mutation_burst',
+        payload: { sg: 1, cap_per_round: 1 },
+        source_perk_id: 'ab_r5',
+      },
+    ],
+  };
+  applyPerkAbilityUseEffects(actor, 'mutation_burst', { round: 1 });
+  assert.strictEqual(actor.sg, 1);
+});
+
+test('sg_on_mutation_burst: capped at cap_per_round within the same round', () => {
+  const actor = {
+    id: 'ab',
+    sg: 0,
+    _perk_passives: [
+      {
+        tag: 'sg_on_mutation_burst',
+        payload: { sg: 1, cap_per_round: 1 },
+        source_perk_id: 'ab_r5',
+      },
+    ],
+  };
+  applyPerkAbilityUseEffects(actor, 'mutation_burst', { round: 1 });
+  applyPerkAbilityUseEffects(actor, 'mutation_burst', { round: 1 });
+  assert.strictEqual(actor.sg, 1, 'second use same round does not re-earn');
+});
+
+test('sg_on_mutation_burst: earns again in a new round', () => {
+  const actor = {
+    id: 'ab',
+    sg: 0,
+    _perk_passives: [
+      {
+        tag: 'sg_on_mutation_burst',
+        payload: { sg: 1, cap_per_round: 1 },
+        source_perk_id: 'ab_r5',
+      },
+    ],
+  };
+  applyPerkAbilityUseEffects(actor, 'mutation_burst', { round: 1 });
+  applyPerkAbilityUseEffects(actor, 'mutation_burst', { round: 2 });
+  assert.strictEqual(actor.sg, 2);
+});
+
+test('sg_on_mutation_burst: no earn on a different ability', () => {
+  const actor = {
+    id: 'ab',
+    sg: 0,
+    _perk_passives: [
+      {
+        tag: 'sg_on_mutation_burst',
+        payload: { sg: 1, cap_per_round: 1 },
+        source_perk_id: 'ab_r5',
+      },
+    ],
+  };
+  applyPerkAbilityUseEffects(actor, 'phenotype_shift', { round: 1 });
+  assert.strictEqual(actor.sg, 0);
+});
+
+// --- phenotype_baseline_heal ---
+
+test('phenotype_baseline_heal: heals on phenotype_shift use', () => {
+  const actor = {
+    id: 'ab',
+    hp: 5,
+    max_hp: 10,
+    _perk_passives: [
+      { tag: 'phenotype_baseline_heal', payload: { heal: 2 }, source_perk_id: 'ab_r3' },
+    ],
+  };
+  applyPerkAbilityUseEffects(actor, 'phenotype_shift', {});
+  assert.strictEqual(actor.hp, 7);
+});
+
+test('phenotype_baseline_heal: heal capped at max_hp', () => {
+  const actor = {
+    id: 'ab',
+    hp: 9,
+    max_hp: 10,
+    _perk_passives: [
+      { tag: 'phenotype_baseline_heal', payload: { heal: 2 }, source_perk_id: 'ab_r3' },
+    ],
+  };
+  applyPerkAbilityUseEffects(actor, 'phenotype_shift', {});
+  assert.strictEqual(actor.hp, 10);
+});
+
+test('phenotype_baseline_heal: no heal on a different ability', () => {
+  const actor = {
+    id: 'ab',
+    hp: 5,
+    max_hp: 10,
+    _perk_passives: [
+      { tag: 'phenotype_baseline_heal', payload: { heal: 2 }, source_perk_id: 'ab_r3' },
+    ],
+  };
+  applyPerkAbilityUseEffects(actor, 'mutation_burst', {});
+  assert.strictEqual(actor.hp, 5);
+});
+
+test('applyPerkAbilityUseEffects: no perks = no-op', () => {
+  const actor = { id: 'plain', sg: 3, hp: 5, max_hp: 10, _perk_passives: [] };
+  const res = applyPerkAbilityUseEffects(actor, 'mutation_burst', { round: 1 });
+  assert.strictEqual(actor.sg, 3);
+  assert.strictEqual(actor.hp, 5);
+  assert.deepStrictEqual(res.applied, []);
+});
+
+// --- mutation_chain_on_kill (kill-hook, reuses slice-2 _last_ability_id) ---
+
+test('mutation_chain_on_kill: refunds AP after a mutation_burst kill, once/encounter', () => {
+  const actor = {
+    id: 'ab',
+    ap: 3,
+    ap_remaining: 1,
+    _last_ability_id: 'mutation_burst',
+    _perk_passives: [
+      { tag: 'mutation_chain_on_kill', payload: { cap_per_encounter: 1 }, source_perk_id: 'ab_r4' },
+    ],
+  };
+  applyPerkKillEffects(actor);
+  assert.strictEqual(actor.ap_remaining, 3, 'AP refunded (+2 mutation_burst cost, capped at ap)');
+  applyPerkKillEffects(actor);
+  assert.strictEqual(actor.ap_remaining, 3, 'no second refund this encounter');
+});
+
+// --- wire: executeAbility fires the use-hook only post-2xx ---
+
+test('executeAbility wires the use-hook: phenotype_shift heals via phenotype_baseline_heal', async () => {
+  const ex = createAbilityExecutor({ appendEvent: async () => {} });
+  const actor = {
+    id: 'ab',
+    ap_remaining: 5,
+    hp: 5,
+    max_hp: 10,
+    position: { x: 0, y: 0 },
+    _perk_passives: [
+      { tag: 'phenotype_baseline_heal', payload: { heal: 2 }, source_perk_id: 'ab_r3' },
+    ],
+  };
+  const res = await ex.executeAbility({
+    session: { units: [actor], turn: 1 },
+    actor,
+    body: { ability_id: 'phenotype_shift' },
+  });
+  assert.strictEqual(
+    res.status,
+    200,
+    `expected 200, got ${res.status}: ${JSON.stringify(res.body)}`,
+  );
+  assert.strictEqual(actor.hp, 7, 'use-hook applied phenotype_baseline_heal post-2xx');
+});
+
+test('mutation_chain_on_kill: no refund when the kill was not via mutation_burst', () => {
+  const actor = {
+    id: 'ab',
+    ap: 3,
+    ap_remaining: 1,
+    _last_ability_id: 'alpha_strike',
+    _perk_passives: [
+      { tag: 'mutation_chain_on_kill', payload: { cap_per_encounter: 1 }, source_perk_id: 'ab_r4' },
+    ],
+  };
+  applyPerkKillEffects(actor);
+  assert.strictEqual(actor.ap_remaining, 1);
+});

--- a/tests/progression/perkAbilityUseEffects.test.js
+++ b/tests/progression/perkAbilityUseEffects.test.js
@@ -4,14 +4,15 @@ const test = require('node:test');
 const assert = require('node:assert');
 const {
   applyPerkAbilityUseEffects,
-  applyPerkKillEffects,
 } = require('../../apps/backend/services/progression/progressionApply');
 const { createAbilityExecutor } = require('../../apps/backend/services/abilityExecutor');
 
 // TKT-JOB-PHASEC slice 4 (Cat F, OQ-F verdict A: event-pure subset).
 // applyPerkAbilityUseEffects(actor, abilityId, ctx) — twin of applyPerkKillEffects,
-// fired post-2xx on a successful ability use. 3 tags: sg_on_mutation_burst (use),
-// phenotype_baseline_heal (use), mutation_chain_on_kill (kill-hook reuse).
+// fired post-2xx on a successful ability use. 2 tags: sg_on_mutation_burst (use),
+// phenotype_baseline_heal (use). mutation_chain_on_kill DEFERRED (Codex #2524:
+// needs the current-kill-ability context + a free-recast that survives the AP spend
+// — not cleanly event-pure).
 
 // --- sg_on_mutation_burst ---
 
@@ -63,6 +64,22 @@ test('sg_on_mutation_burst: earns again in a new round', () => {
   applyPerkAbilityUseEffects(actor, 'mutation_burst', { round: 1 });
   applyPerkAbilityUseEffects(actor, 'mutation_burst', { round: 2 });
   assert.strictEqual(actor.sg, 2);
+});
+
+test('sg_on_mutation_burst: clamps at the sgTracker pool max (3), never over-grants', () => {
+  const actor = {
+    id: 'ab',
+    sg: 3, // already at POOL_MAX
+    _perk_passives: [
+      {
+        tag: 'sg_on_mutation_burst',
+        payload: { sg: 1, cap_per_round: 1 },
+        source_perk_id: 'ab_r5',
+      },
+    ],
+  };
+  applyPerkAbilityUseEffects(actor, 'mutation_burst', { round: 1 });
+  assert.strictEqual(actor.sg, 3, 'SG never exceeds POOL_MAX');
 });
 
 test('sg_on_mutation_burst: no earn on a different ability', () => {
@@ -130,24 +147,6 @@ test('applyPerkAbilityUseEffects: no perks = no-op', () => {
   assert.deepStrictEqual(res.applied, []);
 });
 
-// --- mutation_chain_on_kill (kill-hook, reuses slice-2 _last_ability_id) ---
-
-test('mutation_chain_on_kill: refunds AP after a mutation_burst kill, once/encounter', () => {
-  const actor = {
-    id: 'ab',
-    ap: 3,
-    ap_remaining: 1,
-    _last_ability_id: 'mutation_burst',
-    _perk_passives: [
-      { tag: 'mutation_chain_on_kill', payload: { cap_per_encounter: 1 }, source_perk_id: 'ab_r4' },
-    ],
-  };
-  applyPerkKillEffects(actor);
-  assert.strictEqual(actor.ap_remaining, 3, 'AP refunded (+2 mutation_burst cost, capped at ap)');
-  applyPerkKillEffects(actor);
-  assert.strictEqual(actor.ap_remaining, 3, 'no second refund this encounter');
-});
-
 // --- wire: executeAbility fires the use-hook only post-2xx ---
 
 test('executeAbility wires the use-hook: phenotype_shift heals via phenotype_baseline_heal', async () => {
@@ -173,18 +172,4 @@ test('executeAbility wires the use-hook: phenotype_shift heals via phenotype_bas
     `expected 200, got ${res.status}: ${JSON.stringify(res.body)}`,
   );
   assert.strictEqual(actor.hp, 7, 'use-hook applied phenotype_baseline_heal post-2xx');
-});
-
-test('mutation_chain_on_kill: no refund when the kill was not via mutation_burst', () => {
-  const actor = {
-    id: 'ab',
-    ap: 3,
-    ap_remaining: 1,
-    _last_ability_id: 'alpha_strike',
-    _perk_passives: [
-      { tag: 'mutation_chain_on_kill', payload: { cap_per_encounter: 1 }, source_perk_id: 'ab_r4' },
-    ],
-  };
-  applyPerkKillEffects(actor);
-  assert.strictEqual(actor.ap_remaining, 1);
 });


### PR DESCRIPTION
## What

PHASEC **slice 4** (Cat F mutation/phenotype use-hook) from spec
[#2506](https://github.com/MasterDD-L34D/Game/pull/2506), after the slices 1-3
bundle (#2522). New `applyPerkAbilityUseEffects` hook — twin of
`applyPerkKillEffects`, fired **post-2xx** from `executeAbility`.

## OQ-F verdict (master-dd): A — event-pure subset

Ground-truth (this PR's base): the aberrant **random-roll mechanics don't
exist** — `executeBuff` (phenotype_shift) is a FIXED buff (no 1d6 table, no
heal), `executeDrainAttack` (mutation_burst) is a standard attack (no random
damage range, no MoS-gated status), and there is no ability cooldown system.

So this slice ships the **3 event-pure tags** that need no missing mechanic, and
**defers the 4 roll/cooldown-dependent** tags to a follow-up that would build the
random-roll + per-round-use systems.

| Tag | Hook | Effect |
| --- | --- | --- |
| `sg_on_mutation_burst` | use-hook | earn SG on `mutation_burst` (one earn/round, `_sg_on_mb_round`) |
| `phenotype_baseline_heal` | use-hook | flat heal on `phenotype_shift`, capped at max_hp |
| `mutation_chain_on_kill` | kill-hook (reuses slice-2 `_last_ability_id`) | AP refund after a `mutation_burst` KO, once/encounter — enables a "free" re-cast |

**Deferred (need a sub-system that doesn't exist):** `mutation_status_extend`,
`double_phenotype_roll`, `perfect_mutation_burst` (random-roll/status-apply);
`phenotype_double_use` (no per-round-use/cooldown system → no-op today).

## Gate 5 — player-visible surface

- `phenotype_baseline_heal`: unit HP rises when casting `phenotype_shift`.
- `sg_on_mutation_burst`: SG pool rises on `mutation_burst` (capped/round).
- `mutation_chain_on_kill`: AP restored after a `mutation_burst` kill → re-cast.

## Wire

`executeAbility` calls `applyPerkAbilityUseEffects(actor, ability_id, {round:
session.turn})` only on a **2xx** result (lazy require, mirrors the `sgTracker`
pattern — non-blocking). `mutation_chain_on_kill` rides the existing
`performAttack` kill hook.

## Tests (TDD, red→green)

- New `tests/progression/perkAbilityUseEffects.test.js` (11, incl. an
  `executeAbility` wire integration test).
- Regression: progression + abilityExecutor **93/93**, AI **495/495**,
  session/combat **20/20**. Prettier clean.

## Scope / safety

2 runtime files, all under `apps/backend/` (+83). No forbidden paths, no deps,
no schema/data change. Additive/back-compat (new fields default to no-op).

## Rollback (03A)

Revert `fa80a5a5`. Doc-faithful approximations noted as follow-ups:
`mutation_chain_on_kill` = AP-refund proxy for "free re-cast" (+2 = mutation_burst
cost_ap); `sg_on_mutation_burst` per-round cap = one earn/round (AP economy bounds
repeats). Slices 5-6 (symbiont/minion forks) remain gated on OQ-BOND/OQ-MINION.
