### PR TITLE
fix(combat): PHASEC perk-window correctness (defense_after_silent exact + mutation_chain rebuild)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -606,6 +606,7 @@ function createSessionRouter(options = {}) {
     // resolveAttack via target._perk_defense_bonus. 0 when no perk fired.
     target._perk_defense_bonus = computePerkDefenseBonus(target, {
       units: session.units || [],
+      round: session.turn,
     }).bonus;
     const result = resolveAttack({ actor, target, rng });
     const evaluation = evaluateAttackTraits({

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -993,6 +993,18 @@ function createAbilityExecutor(deps) {
       (actor.ap_remaining ?? actor.ap) - Number(ability.cost_ap || 0),
     );
 
+    // TKT-JOB-PHASEC mutation_chain_on_kill (correct rebuild, Codex #2524): refund
+    // the AP just spent when a mutation_burst scores the KO → free re-cast. AFTER
+    // the spend (fixes P1) and scoped to mutation_burst's own kill (fixes P2).
+    if (ability.ability_id === 'mutation_burst' && res.result.hit && target.hp <= 0) {
+      try {
+        const { applyMutationChainRefund } = require('./progression/progressionApply');
+        applyMutationChainRefund(actor, Number(ability.cost_ap || 0));
+      } catch {
+        /* progression optional — non-blocking */
+      }
+    }
+
     return {
       status: 200,
       body: {

--- a/apps/backend/services/progression/progressionApply.js
+++ b/apps/backend/services/progression/progressionApply.js
@@ -378,19 +378,31 @@ function computePerkDefenseBonus(defender, ctx = {}) {
   // Self defensive passives on the defender, conditioned on combat state.
   const selfPassives = Array.isArray(defender._perk_passives) ? defender._perk_passives : [];
   for (const p of selfPassives) {
-    if (p.tag === 'defense_after_silent' && defender._last_ability_id === 'silent_step') {
-      // Active in the window after the defender used silent_step (tracked via
-      // _last_ability_id, set in abilityExecutor). Window approximated as "until
-      // the unit's next ability"; exact payload.duration turn-decay = follow-up.
-      const amt = Number(p.payload?.defense_mod) || 0;
-      if (amt !== 0) {
-        out.bonus += amt;
-        out.applied.push({
-          tag: 'defense_after_silent',
-          amount: amt,
-          source_perk_id: p.source_perk_id,
-          source_unit_id: defender.id,
-        });
+    if (p.tag === 'defense_after_silent') {
+      // Exact "turn after silent_step" window, armed by the use-hook into
+      // _camo_silent_from/_to (= [useRound+1, useRound+duration]) and compared to
+      // ctx.round. No _last_ability_id reliance (Codex #2524: that field was stale
+      // on basic-attack turns) and no round-bridge decay (no priority_queue trap).
+      const round = ctx.round;
+      const from = Number(defender._camo_silent_from);
+      const to = Number(defender._camo_silent_to);
+      if (
+        round != null &&
+        Number.isFinite(from) &&
+        Number.isFinite(to) &&
+        round >= from &&
+        round <= to
+      ) {
+        const amt = Number(p.payload?.defense_mod) || 0;
+        if (amt !== 0) {
+          out.bonus += amt;
+          out.applied.push({
+            tag: 'defense_after_silent',
+            amount: amt,
+            source_perk_id: p.source_perk_id,
+            source_unit_id: defender.id,
+          });
+        }
       }
     }
   }
@@ -446,8 +458,51 @@ function applyPerkAbilityUseEffects(actor, abilityId, ctx = {}) {
           source_perk_id: p.source_perk_id,
         });
       }
+    } else if (p.tag === 'defense_after_silent' && abilityId === 'silent_step') {
+      // Arm the camo window: +defense_mod for `duration` rounds starting the turn
+      // AFTER silent_step. Read by computePerkDefenseBonus against ctx.round.
+      const dur = Number(p.payload?.duration) || 1;
+      if (round != null) {
+        actor._camo_silent_from = round + 1;
+        actor._camo_silent_to = round + dur;
+        out.applied.push({
+          tag: 'defense_after_silent',
+          armed_from: actor._camo_silent_from,
+          armed_to: actor._camo_silent_to,
+          source_perk_id: p.source_perk_id,
+        });
+      }
     }
   }
+  return out;
+}
+
+/**
+ * Refund the AP spent on a mutation_burst that scored a KO — the correct rebuild
+ * of mutation_chain_on_kill (TKT-JOB-PHASEC, Codex #2524). Called from
+ * executeDrainAttack AFTER the AP deduction (fixes the P1 timing where the kill
+ * hook ran before the spend) and only for mutation_burst's own kill (fixes the P2
+ * stale-_last_ability_id attribution). Once per encounter (_mutation_chain_done).
+ * The refund enables an immediate free re-cast.
+ *
+ * @param {object} actor — the unit whose mutation_burst scored the KO
+ * @param {number} costAp — the AP just spent (refunded, capped at actor.ap)
+ * @returns {{ applied: Array<object> }}
+ */
+function applyMutationChainRefund(actor, costAp) {
+  const out = { applied: [] };
+  const passives = Array.isArray(actor?._perk_passives) ? actor._perk_passives : [];
+  const mc = passives.find((p) => p.tag === 'mutation_chain_on_kill');
+  if (!mc || actor._mutation_chain_done) return out;
+  const apMax = Number(actor.ap || actor.ap_remaining || 0);
+  const before = Number(actor.ap_remaining || 0);
+  actor.ap_remaining = Math.min(apMax, before + (Number(costAp) || 0));
+  actor._mutation_chain_done = true;
+  out.applied.push({
+    tag: 'mutation_chain_on_kill',
+    ap_refunded: actor.ap_remaining - before,
+    source_perk_id: mc.source_perk_id,
+  });
   return out;
 }
 
@@ -500,6 +555,7 @@ module.exports = {
   computePerkDefenseBonus,
   applyPerkKillEffects,
   applyPerkAbilityUseEffects,
+  applyMutationChainRefund,
   grantXpToSurvivors,
   resetDefaults,
   // Test seam: the module-default store is the singleton the session /start

--- a/tests/progression/perkAbilityUseEffects.test.js
+++ b/tests/progression/perkAbilityUseEffects.test.js
@@ -4,15 +4,17 @@ const test = require('node:test');
 const assert = require('node:assert');
 const {
   applyPerkAbilityUseEffects,
+  applyMutationChainRefund,
 } = require('../../apps/backend/services/progression/progressionApply');
 const { createAbilityExecutor } = require('../../apps/backend/services/abilityExecutor');
 
 // TKT-JOB-PHASEC slice 4 (Cat F, OQ-F verdict A: event-pure subset).
 // applyPerkAbilityUseEffects(actor, abilityId, ctx) — twin of applyPerkKillEffects,
-// fired post-2xx on a successful ability use. 2 tags: sg_on_mutation_burst (use),
-// phenotype_baseline_heal (use). mutation_chain_on_kill DEFERRED (Codex #2524:
-// needs the current-kill-ability context + a free-recast that survives the AP spend
-// — not cleanly event-pure).
+// fired post-2xx on a successful ability use. tags: sg_on_mutation_burst (use),
+// phenotype_baseline_heal (use), defense_after_silent (arms the camo window on
+// silent_step use). mutation_chain_on_kill = applyMutationChainRefund, called from
+// executeDrainAttack AFTER the AP spend on a mutation_burst KO (correct rebuild,
+// Codex #2524).
 
 // --- sg_on_mutation_burst ---
 
@@ -172,4 +174,97 @@ test('executeAbility wires the use-hook: phenotype_shift heals via phenotype_bas
     `expected 200, got ${res.status}: ${JSON.stringify(res.body)}`,
   );
   assert.strictEqual(actor.hp, 7, 'use-hook applied phenotype_baseline_heal post-2xx');
+});
+
+// --- defense_after_silent: silent_step use arms the camo window ---
+
+test('silent_step use arms the camo window for defense_after_silent', () => {
+  const actor = {
+    id: 'st',
+    _perk_passives: [
+      {
+        tag: 'defense_after_silent',
+        payload: { defense_mod: 2, duration: 1 },
+        source_perk_id: 'st_r2',
+      },
+    ],
+  };
+  applyPerkAbilityUseEffects(actor, 'silent_step', { round: 3 });
+  assert.strictEqual(actor._camo_silent_from, 4, 'window starts the turn AFTER (round+1)');
+  assert.strictEqual(actor._camo_silent_to, 4, 'window ends at round+duration');
+});
+
+test('silent_step use does not arm the window without the perk', () => {
+  const actor = { id: 'st', _perk_passives: [] };
+  applyPerkAbilityUseEffects(actor, 'silent_step', { round: 3 });
+  assert.strictEqual(actor._camo_silent_from, undefined);
+});
+
+// --- mutation_chain_on_kill: applyMutationChainRefund (post-spend, once/encounter) ---
+
+test('applyMutationChainRefund: refunds the spent AP once per encounter', () => {
+  const actor = {
+    id: 'ab',
+    ap: 4,
+    ap_remaining: 2,
+    _perk_passives: [
+      { tag: 'mutation_chain_on_kill', payload: { cap_per_encounter: 1 }, source_perk_id: 'ab_r4' },
+    ],
+  };
+  applyMutationChainRefund(actor, 2);
+  assert.strictEqual(actor.ap_remaining, 4, 'spent 2 AP refunded');
+  applyMutationChainRefund(actor, 2);
+  assert.strictEqual(actor.ap_remaining, 4, 'no second refund this encounter');
+});
+
+test('applyMutationChainRefund: caps the refund at max ap', () => {
+  const actor = {
+    id: 'ab',
+    ap: 3,
+    ap_remaining: 2,
+    _perk_passives: [{ tag: 'mutation_chain_on_kill', payload: {}, source_perk_id: 'ab_r4' }],
+  };
+  applyMutationChainRefund(actor, 2);
+  assert.strictEqual(actor.ap_remaining, 3, 'refund capped at actor.ap');
+});
+
+test('applyMutationChainRefund: no refund without the perk', () => {
+  const actor = { id: 'ab', ap: 4, ap_remaining: 2, _perk_passives: [] };
+  applyMutationChainRefund(actor, 2);
+  assert.strictEqual(actor.ap_remaining, 2);
+});
+
+test('executeDrainAttack refunds AP when mutation_burst scores a KO (free re-cast)', async () => {
+  const ex = createAbilityExecutor({
+    performAttack: (s, a, t) => {
+      t.hp = 0; // mutation_burst kills the target
+      return { damageDealt: 5, result: { hit: true, die: 18, roll: 22, mos: 6 } };
+    },
+    buildAttackEvent: () => ({}),
+    appendEvent: async () => {},
+    manhattanDistance: (p, q) => Math.abs(p.x - q.x) + Math.abs(p.y - q.y),
+  });
+  const actor = {
+    id: 'ab',
+    ap: 5,
+    ap_remaining: 5,
+    position: { x: 0, y: 0 },
+    attack_range: 5,
+    _perk_passives: [
+      { tag: 'mutation_chain_on_kill', payload: { cap_per_encounter: 1 }, source_perk_id: 'ab_r4' },
+    ],
+  };
+  const target = { id: 'foe', hp: 3, max_hp: 3, position: { x: 1, y: 0 } };
+  const res = await ex.executeAbility({
+    session: { units: [actor, target], turn: 1, damage_taken: {} },
+    actor,
+    body: { ability_id: 'mutation_burst', target_id: 'foe' },
+  });
+  assert.strictEqual(
+    res.status,
+    200,
+    `expected 200, got ${res.status}: ${JSON.stringify(res.body)}`,
+  );
+  // mutation_burst cost_ap=2 spent then refunded on the KO → net 0, free re-cast enabled.
+  assert.strictEqual(actor.ap_remaining, 5, 'AP refunded after the killing mutation_burst');
 });

--- a/tests/progression/progressionDefenseBonus.test.js
+++ b/tests/progression/progressionDefenseBonus.test.js
@@ -98,75 +98,51 @@ test('defender carries its own aura but does not buff itself', () => {
   assert.strictEqual(res.bonus, 0);
 });
 
-// --- slice 2: defense_after_silent (defender self-passive gated on last ability) ---
+// --- defense_after_silent: exact round-window (set by silent_step use-hook) ---
+// Window armed as [_camo_silent_from, _camo_silent_to] = [useRound+1, useRound+duration].
+const CAMO = {
+  tag: 'defense_after_silent',
+  payload: { defense_mod: 2, duration: 1 },
+  source_perk_id: 'st_r2',
+};
 
-test('defense_after_silent: defender granted when last ability was silent_step', () => {
-  const defender = unit(
-    'hero',
-    2,
-    2,
-    [
-      {
-        tag: 'defense_after_silent',
-        payload: { defense_mod: 2, duration: 1 },
-        source_perk_id: 'st_r2',
-      },
-    ],
-    { _last_ability_id: 'silent_step' },
-  );
-  const res = computePerkDefenseBonus(defender, { units: [defender] });
+test('defense_after_silent: granted while ctx.round is inside the camo window', () => {
+  const defender = unit('hero', 2, 2, [CAMO], { _camo_silent_from: 2, _camo_silent_to: 2 });
+  const res = computePerkDefenseBonus(defender, { units: [defender], round: 2 });
   assert.strictEqual(res.bonus, 2);
   assert.strictEqual(res.applied[0].tag, 'defense_after_silent');
 });
 
-test('defense_after_silent: no bonus when last ability was something else', () => {
-  const defender = unit(
-    'hero',
-    2,
-    2,
-    [
-      {
-        tag: 'defense_after_silent',
-        payload: { defense_mod: 2, duration: 1 },
-        source_perk_id: 'st_r2',
-      },
-    ],
-    { _last_ability_id: 'alpha_strike' },
-  );
-  const res = computePerkDefenseBonus(defender, { units: [defender] });
+test('defense_after_silent: no bonus on the silent_step turn itself (round < from)', () => {
+  const defender = unit('hero', 2, 2, [CAMO], { _camo_silent_from: 2, _camo_silent_to: 2 });
+  const res = computePerkDefenseBonus(defender, { units: [defender], round: 1 });
   assert.strictEqual(res.bonus, 0);
 });
 
-test('defense_after_silent: no bonus when no ability used yet', () => {
-  const defender = unit('hero', 2, 2, [
-    {
-      tag: 'defense_after_silent',
-      payload: { defense_mod: 2, duration: 1 },
-      source_perk_id: 'st_r2',
-    },
-  ]);
+test('defense_after_silent: no bonus after the window expires (round > to)', () => {
+  const defender = unit('hero', 2, 2, [CAMO], { _camo_silent_from: 2, _camo_silent_to: 2 });
+  const res = computePerkDefenseBonus(defender, { units: [defender], round: 3 });
+  assert.strictEqual(res.bonus, 0);
+});
+
+test('defense_after_silent: no bonus when the window was never armed', () => {
+  const defender = unit('hero', 2, 2, [CAMO]);
+  const res = computePerkDefenseBonus(defender, { units: [defender], round: 2 });
+  assert.strictEqual(res.bonus, 0);
+});
+
+test('defense_after_silent: no bonus when ctx.round is absent', () => {
+  const defender = unit('hero', 2, 2, [CAMO], { _camo_silent_from: 2, _camo_silent_to: 2 });
   const res = computePerkDefenseBonus(defender, { units: [defender] });
   assert.strictEqual(res.bonus, 0);
 });
 
 test('defense_after_silent + aura stack on the same defender', () => {
-  const defender = unit(
-    'hero',
-    2,
-    2,
-    [
-      {
-        tag: 'defense_after_silent',
-        payload: { defense_mod: 2, duration: 1 },
-        source_perk_id: 'st_r2',
-      },
-    ],
-    { _last_ability_id: 'silent_step' },
-  );
+  const defender = unit('hero', 2, 2, [CAMO], { _camo_silent_from: 2, _camo_silent_to: 2 });
   const sym = unit('sym', 3, 2, [
     { tag: 'aura_defense_2tile', payload: { defense_mod: 1, range: 2 }, source_perk_id: 'sy_r3' },
   ]);
-  const res = computePerkDefenseBonus(defender, { units: [defender, sym] });
+  const res = computePerkDefenseBonus(defender, { units: [defender, sym], round: 2 });
   assert.strictEqual(res.bonus, 3);
   assert.strictEqual(res.applied.length, 2);
 });


### PR DESCRIPTION
## What

Resolves the two PHASEC perk caveats left from the slice 1-4 work (spec
[#2506](https://github.com/MasterDD-L34D/Game/pull/2506)). Both touch the combat
perk path; done with TDD + careful seam choice to avoid hot-path/round-bridge risk.

## 1. `defense_after_silent` — exact round-window

**Before:** granted while `defender._last_ability_id === 'silent_step'` → over-grant
(the +2 def persisted across basic attacks, "until the unit's next ability", since
basic attacks don't update `_last_ability_id` — the same stale-field flaw Codex
flagged on mutation_chain).

**After:** the silent_step **use-hook** arms `_camo_silent_from/_to = [round+1,
round+duration]`; `computePerkDefenseBonus(defender, {round})` grants only while
`from <= ctx.round <= to`. Exact "turn after silent_step", `payload.duration`
honored. No `_last_ability_id`, no round-bridge decay (no priority_queue trap).

## 2. `mutation_chain_on_kill` — correct rebuild (was deferred in #2524)

**Codex #2524 found 2 real bugs in the first attempt** (P1: AP refund nullified by
the killing ability's own spend; P2: keyed on stale `_last_ability_id`). Rebuilt:
new `applyMutationChainRefund(actor, costAp)` called from `executeDrainAttack`
**after** the AP deduction, **only** when `mutation_burst` itself scores the KO.

- P1 fixed: refund happens after the spend → net free re-cast (AP restored).
- P2 fixed: scoped to `mutation_burst`'s own kill in its executor → no stale field,
  basic-attack kills can't trigger it.
- Once per encounter (`_mutation_chain_done`), refund capped at `actor.ap`.

## Gate 5 — player-visible

- defense: defended stalker's DC rises only the turn after silent_step (then drops).
- mutation_chain: AP restored after a mutation_burst kill → immediate free re-cast.

## Tests (TDD, red→green)

- `progressionDefenseBonus.test.js`: defense_after_silent rewritten to the
  round-window (in/before/after window, unarmed, no-round, aura stack).
- `perkAbilityUseEffects.test.js`: silent_step arming (×2) + applyMutationChainRefund
  unit (×3) + executeDrainAttack KO integration (free re-cast).
- Regression: progression + abilityExecutor **100/100**, AI **495/495**,
  session/combat **20/20**. Prettier clean.

## Scope / safety

3 runtime files + 2 tests, all under `apps/backend/`. No forbidden paths, no deps,
no schema/data change. Additive (new `_camo_*` / refund helper default to no-op).

## Rollback (03A)

Revert `f4cc1242`. Cat F now **3/7** wired (sg + heal + mutation_chain); remaining
4 (`mutation_status_extend`, `double_phenotype_roll`, `perfect_mutation_burst`,
`phenotype_double_use`) still need the random-roll / cooldown sub-systems.
