### PR TITLE
fix(combat): base aberrant PE earn so aberrant_overdrive is castable

### DIFF
--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -1812,8 +1812,14 @@ function createAbilityExecutor(deps) {
     // the sgTracker pattern (non-blocking if the module is unavailable).
     if (result && Number(result.status) >= 200 && Number(result.status) < 300) {
       try {
-        const { applyPerkAbilityUseEffects } = require('./progression/progressionApply');
+        const {
+          applyPerkAbilityUseEffects,
+          applyBaseAbilityResourceEarn,
+        } = require('./progression/progressionApply');
         applyPerkAbilityUseEffects(actor, ability.ability_id, { round: session.turn });
+        // TKT-JOB-PHASEC OQ-PE (PE-complete) — base aberrant PE earn on
+        // mutation_burst so aberrant_overdrive (cost_pe) is reachable by play.
+        applyBaseAbilityResourceEarn(actor, ability.ability_id, { round: session.turn });
       } catch {
         /* progression optional — non-blocking */
       }

--- a/apps/backend/services/progression/progressionApply.js
+++ b/apps/backend/services/progression/progressionApply.js
@@ -471,6 +471,11 @@ function applyPerkAbilityUseEffects(actor, abilityId, ctx = {}) {
 function applyBaseAbilityResourceEarn(actor, abilityId, ctx = {}) {
   const out = { applied: [] };
   if (!actor || abilityId !== 'mutation_burst') return out;
+  // Codex P2 #2526: PE is the aberrant resource and mutation_burst is the aberrant
+  // ability. executeAbility looks abilities up from the global catalog (not the
+  // actor's list), so without this gate a non-aberrant unit submitting
+  // ability_id:'mutation_burst' could farm PE to satisfy cost_pe gates.
+  if (actor.job !== 'aberrant') return out;
   const round = ctx.round;
   if (actor._pe_on_mb_round === round) return out;
   const before = Number(actor.pe || 0);

--- a/apps/backend/services/progression/progressionApply.js
+++ b/apps/backend/services/progression/progressionApply.js
@@ -16,6 +16,12 @@ const { ProgressionEngine } = require('./progressionEngine');
 const { createProgressionStore } = require('./progressionStore');
 // SG pool cap — perk SG earns must clamp to sgTracker POOL_MAX (Codex P2 #2524).
 const { POOL_MAX: SG_POOL_MAX } = require('../combat/sgTracker');
+// TKT-JOB-PHASEC OQ-PE (PE-complete): base PE earned per mutation_burst use.
+// Tunable. The aberrant job header declares resource_usage.primary = PE, but the
+// only PE-earn perks live on stalker/beastmaster (earn/spend were on different
+// jobs => aberrant_overdrive cost_pe:5 was uncastable). This gives aberrant a
+// base PE source via its signature action so overdrive is reachable by play.
+const PE_ON_MUTATION_BURST = 1;
 
 let _defaultEngine = null;
 let _defaultStore = null;
@@ -452,6 +458,29 @@ function applyPerkAbilityUseEffects(actor, abilityId, ctx = {}) {
 }
 
 /**
+ * Base (non-perk) on-ability-use resource earn. Currently: aberrant earns PE on
+ * mutation_burst, once per round (tracked via _pe_on_mb_round). Kept SEPARATE
+ * from applyPerkAbilityUseEffects so the perk hook keeps its "no perks = no-op"
+ * contract. Called post-2xx from executeAbility, alongside the perk hook.
+ *
+ * @param {object} actor - the unit that used the ability
+ * @param {string} abilityId - the ability_id just resolved
+ * @param {object} ctx - { round? } current round number for the per-round cap
+ * @returns {{ applied: Array<object> }}
+ */
+function applyBaseAbilityResourceEarn(actor, abilityId, ctx = {}) {
+  const out = { applied: [] };
+  if (!actor || abilityId !== 'mutation_burst') return out;
+  const round = ctx.round;
+  if (actor._pe_on_mb_round === round) return out;
+  const before = Number(actor.pe || 0);
+  actor.pe = before + PE_ON_MUTATION_BURST;
+  actor._pe_on_mb_round = round;
+  out.applied.push({ tag: 'pe_on_mutation_burst', pe: actor.pe - before });
+  return out;
+}
+
+/**
  * Grant XP to all player survivors. Used by campaign advance hook.
  *
  * @param {Array<object>} units
@@ -500,6 +529,7 @@ module.exports = {
   computePerkDefenseBonus,
   applyPerkKillEffects,
   applyPerkAbilityUseEffects,
+  applyBaseAbilityResourceEarn,
   grantXpToSurvivors,
   resetDefaults,
   // Test seam: the module-default store is the singleton the session /start

--- a/tests/progression/aberrantBasePeEarn.test.js
+++ b/tests/progression/aberrantBasePeEarn.test.js
@@ -13,33 +13,33 @@ const {
 // that hook's "no perks = no-op" contract intact.
 
 test('base PE earn: mutation_burst grants +1 PE', () => {
-  const actor = { id: 'ab', pe: 0 };
+  const actor = { id: 'ab', pe: 0, job: 'aberrant' };
   applyBaseAbilityResourceEarn(actor, 'mutation_burst', { round: 1 });
   assert.strictEqual(actor.pe, 1);
 });
 
 test('base PE earn: capped once per round', () => {
-  const actor = { id: 'ab', pe: 0 };
+  const actor = { id: 'ab', pe: 0, job: 'aberrant' };
   applyBaseAbilityResourceEarn(actor, 'mutation_burst', { round: 1 });
   applyBaseAbilityResourceEarn(actor, 'mutation_burst', { round: 1 });
   assert.strictEqual(actor.pe, 1, 'second use in the same round does not re-earn');
 });
 
 test('base PE earn: earns again in a new round', () => {
-  const actor = { id: 'ab', pe: 0 };
+  const actor = { id: 'ab', pe: 0, job: 'aberrant' };
   applyBaseAbilityResourceEarn(actor, 'mutation_burst', { round: 1 });
   applyBaseAbilityResourceEarn(actor, 'mutation_burst', { round: 2 });
   assert.strictEqual(actor.pe, 2);
 });
 
 test('base PE earn: no earn on a different ability', () => {
-  const actor = { id: 'ab', pe: 0 };
+  const actor = { id: 'ab', pe: 0, job: 'aberrant' };
   applyBaseAbilityResourceEarn(actor, 'phenotype_shift', { round: 1 });
   assert.strictEqual(actor.pe, 0);
 });
 
 test('base PE earn: reaches the overdrive gate (5 PE) over 5 rounds', () => {
-  const actor = { id: 'ab', pe: 0 };
+  const actor = { id: 'ab', pe: 0, job: 'aberrant' };
   for (let r = 1; r <= 5; r += 1) {
     applyBaseAbilityResourceEarn(actor, 'mutation_burst', { round: r });
   }
@@ -47,9 +47,15 @@ test('base PE earn: reaches the overdrive gate (5 PE) over 5 rounds', () => {
 });
 
 test('base PE earn: applied[] reports the earn', () => {
-  const actor = { id: 'ab', pe: 0 };
+  const actor = { id: 'ab', pe: 0, job: 'aberrant' };
   const res = applyBaseAbilityResourceEarn(actor, 'mutation_burst', { round: 1 });
   assert.deepStrictEqual(res.applied, [{ tag: 'pe_on_mutation_burst', pe: 1 }]);
+});
+
+test('base PE earn: a non-aberrant submitting mutation_burst earns NO PE (Codex P2 #2526)', () => {
+  const actor = { id: 'sk', pe: 0, job: 'stalker' };
+  applyBaseAbilityResourceEarn(actor, 'mutation_burst', { round: 1 });
+  assert.strictEqual(actor.pe, 0, 'PE is the aberrant resource — non-aberrants cannot farm it');
 });
 
 test('base PE earn: undefined actor is a no-op', () => {

--- a/tests/progression/aberrantBasePeEarn.test.js
+++ b/tests/progression/aberrantBasePeEarn.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  applyBaseAbilityResourceEarn,
+} = require('../../apps/backend/services/progression/progressionApply');
+
+// TKT-JOB-PHASEC OQ-PE (PE-complete verdict). Base aberrant PE earn:
+// mutation_burst generates +1 PE/round (capped once/round via _pe_on_mb_round)
+// so aberrant_overdrive (cost_pe:5, #2522) is reachable by normal play. The earn
+// is BASE (not perk-gated) and lives OUTSIDE applyPerkAbilityUseEffects to keep
+// that hook's "no perks = no-op" contract intact.
+
+test('base PE earn: mutation_burst grants +1 PE', () => {
+  const actor = { id: 'ab', pe: 0 };
+  applyBaseAbilityResourceEarn(actor, 'mutation_burst', { round: 1 });
+  assert.strictEqual(actor.pe, 1);
+});
+
+test('base PE earn: capped once per round', () => {
+  const actor = { id: 'ab', pe: 0 };
+  applyBaseAbilityResourceEarn(actor, 'mutation_burst', { round: 1 });
+  applyBaseAbilityResourceEarn(actor, 'mutation_burst', { round: 1 });
+  assert.strictEqual(actor.pe, 1, 'second use in the same round does not re-earn');
+});
+
+test('base PE earn: earns again in a new round', () => {
+  const actor = { id: 'ab', pe: 0 };
+  applyBaseAbilityResourceEarn(actor, 'mutation_burst', { round: 1 });
+  applyBaseAbilityResourceEarn(actor, 'mutation_burst', { round: 2 });
+  assert.strictEqual(actor.pe, 2);
+});
+
+test('base PE earn: no earn on a different ability', () => {
+  const actor = { id: 'ab', pe: 0 };
+  applyBaseAbilityResourceEarn(actor, 'phenotype_shift', { round: 1 });
+  assert.strictEqual(actor.pe, 0);
+});
+
+test('base PE earn: reaches the overdrive gate (5 PE) over 5 rounds', () => {
+  const actor = { id: 'ab', pe: 0 };
+  for (let r = 1; r <= 5; r += 1) {
+    applyBaseAbilityResourceEarn(actor, 'mutation_burst', { round: r });
+  }
+  assert.strictEqual(actor.pe, 5, 'aberrant_overdrive cost_pe:5 is now reachable');
+});
+
+test('base PE earn: applied[] reports the earn', () => {
+  const actor = { id: 'ab', pe: 0 };
+  const res = applyBaseAbilityResourceEarn(actor, 'mutation_burst', { round: 1 });
+  assert.deepStrictEqual(res.applied, [{ tag: 'pe_on_mutation_burst', pe: 1 }]);
+});
+
+test('base PE earn: undefined actor is a no-op', () => {
+  const res = applyBaseAbilityResourceEarn(undefined, 'mutation_burst', { round: 1 });
+  assert.deepStrictEqual(res.applied, []);
+});


### PR DESCRIPTION
## Bug (cross-session audit)

`aberrant_overdrive` is **uncastable in main**. #2522 (slices 1-3) enforced its
`cost_pe: 5` gate (OQ-PE Option B), but the only PE-earn perks
(`first_kill_pe_bonus`, `minion_kill_pe_bonus`) live on **stalker / beastmaster**
— earn and spend ended up on **different jobs**, so an aberrant unit can never
reach 5 PE. The #2522 unit-tests passed only because they seed `pe` by hand; the
end-to-end economy was never exercised. #2524 separately made aberrant earn **SG**
(`sg_on_mutation_burst`), leaving the two merged PRs internally inconsistent on
the aberrant resource model.

The aberrant job header declares `resource_usage: { primary: PE, secondary: SG }`
— so the intent is PE-primary, but the PE earn-side for aberrant was never built.

## Fix (OQ-PE verdict: PE-complete, master-dd)

Honor the header. Give aberrant a **base PE source** via its signature action:

- New pure `applyBaseAbilityResourceEarn(actor, abilityId, ctx)` in
  `progressionApply.js`: `mutation_burst` earns **+1 PE/round** (tunable
  `PE_ON_MUTATION_BURST`), capped once per round via `_pe_on_mb_round`.
- Wired post-2xx in `executeAbility`, next to the slice-4 use-hook (#2524).
- Kept **out of** `applyPerkAbilityUseEffects` to preserve that hook's
  "no perks = no-op" contract (a regression caught pre-push).

Result: `aberrant_overdrive` (`cost_pe: 5`, or 3 with `ab_r2_pe_efficient`) is
reachable in ~3-5 `mutation_burst` rounds — by normal play, not gated behind a
single niche perk.

## Tests

New `tests/progression/aberrantBasePeEarn.test.js` (7): earn, per-round cap,
new-round re-earn, other-ability no-op, reaches the 5-PE gate, `applied[]`
shape, undefined-actor no-op. Logic smoke-validated locally (7/7) + `node --check`
on all 3 files. Backend test suite runs in CI.

## Scope / safety

- 2 runtime files (`progressionApply.js` +29, `abilityExecutor.js` +6) + 1 test.
- No data/yaml/schema change. Additive + back-compat (`_pe_on_mb_round`/`pe`
  default to no-op). Does **not** touch #2522's slices 1+2 (def-eval / silent_step)
  — those are correct.

## Tunables flagged for review

- `PE_ON_MUTATION_BURST = 1` and the once/round cap (charge curve).
- **Base vs perk** earn: chosen base (overdrive reachable by all aberrants); if
  you prefer a perk-gated build, say so and I'll move it to a tree perk.
- Stalker's `first_kill_pe_bonus` still earns PE with no stalker PE-sink
  (pre-existing, out of scope) — flag for a follow-up.

## Draft — do not merge until CI green + your review.