### PR TITLE
feat(combat): phasec slice 4b mutation_burst semantics (Cat F 5/7)

### DIFF
--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -953,6 +953,50 @@ function createAbilityExecutor(deps) {
     });
     applySgEarn(actor, target, res.damageDealt);
 
+    // TKT-JOB-PHASEC slice 4b (Cat F) — mutation_burst combat semantics. Base:
+    // MoS>=5 → 1 random status from the five {rage,panic,stunned,bleeding,fracture}
+    // (faithful to jobs_expansion description). Perks layer on top via
+    // computeMutationBurstPerkMods: perfect_mutation_burst forces all five
+    // (ignoring MoS) + a flat bonus damage step; mutation_status_extend adds turns.
+    // mutation_burst-only (ability semantics, NOT job-gated). Statuses decay via the
+    // generic sessionRoundBridge status loop; bonus damage drains post-hoc (the
+    // execution_attack pattern). Placed in performAttack's flow → traversed by the
+    // /round/execute priority_queue path (not inert in band-verify).
+    let mutationStatuses = [];
+    let mutationBonusDamage = 0;
+    if (ability.ability_id === 'mutation_burst' && res.result.hit && target.hp > 0) {
+      let mods = { extraTurns: 0, forceAllStatuses: false, bonusDamage: 0 };
+      try {
+        const { computeMutationBurstPerkMods } = require('./progression/progressionApply');
+        mods = computeMutationBurstPerkMods(actor);
+      } catch {
+        /* progression optional — non-blocking */
+      }
+      const MUTATION_STATUSES = ['rage', 'panic', 'stunned', 'bleeding', 'fracture'];
+      let toApply = [];
+      if (mods.forceAllStatuses) {
+        toApply = MUTATION_STATUSES.slice();
+      } else if (Number(res.result.mos) >= 5) {
+        toApply = [MUTATION_STATUSES[Math.floor(rng() * MUTATION_STATUSES.length)]];
+      }
+      const statusTurns = 1 + Math.max(0, Number(mods.extraTurns) || 0);
+      if (toApply.length > 0) {
+        if (!target.status) target.status = {};
+        for (const sid of toApply) {
+          target.status[sid] = Math.max(Number(target.status[sid]) || 0, statusTurns);
+          mutationStatuses.push({ id: sid, duration: statusTurns });
+        }
+      }
+      const bonus = Math.max(0, Number(mods.bonusDamage) || 0);
+      if (bonus > 0 && target.hp > 0) {
+        const extra = Math.min(bonus, target.hp);
+        target.hp = Math.max(0, target.hp - extra);
+        session.damage_taken[target.id] = (session.damage_taken[target.id] || 0) + extra;
+        applySgEarn(actor, target, extra);
+        mutationBonusDamage = extra;
+      }
+    }
+
     const lifestealPct = Number(ability.lifesteal_pct || 0);
     let healed = 0;
     if (res.result.hit && res.damageDealt > 0 && lifestealPct > 0) {
@@ -985,6 +1029,8 @@ function createAbilityExecutor(deps) {
     event.ap_spent = Number(ability.cost_ap || 0);
     event.healing_applied = healed;
     event.seed_gain = seedGain;
+    if (mutationStatuses.length > 0) event.mutation_statuses = mutationStatuses;
+    if (mutationBonusDamage > 0) event.mutation_bonus_damage = mutationBonusDamage;
     if (res.parry) event.parry = res.parry;
     await appendEvent(session, event);
 
@@ -1024,6 +1070,8 @@ function createAbilityExecutor(deps) {
         healing_applied: healed,
         actor_hp: actor.hp,
         seed_gain: seedGain,
+        mutation_statuses: mutationStatuses,
+        mutation_bonus_damage: mutationBonusDamage,
         ap_remaining: actor.ap_remaining,
       },
     };

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -1012,13 +1012,18 @@ function createAbilityExecutor(deps) {
       actor.seed = Number(actor.seed || 0) + seedGain;
     }
 
+    // Total damage reported = the attack roll damage + any mutation bonus drained
+    // post-hoc (perfect_mutation_burst). mutationBonusDamage is 0 for every other
+    // case (Codex #2529 P2: don't undercount the reported damage_dealt).
+    const totalDamageDealt = res.damageDealt + mutationBonusDamage;
+
     const event = buildAttackEvent({
       session,
       actor,
       target,
       result: res.result,
       evaluation: res.evaluation,
-      damageDealt: res.damageDealt,
+      damageDealt: totalDamageDealt,
       hpBefore,
       targetPositionAtAttack,
       positional: res.positional || null,
@@ -1064,7 +1069,7 @@ function createAbilityExecutor(deps) {
           roll: res.result.roll,
           mos: res.result.mos,
           hit: res.result.hit,
-          damage_dealt: res.damageDealt,
+          damage_dealt: totalDamageDealt,
           target_hp: target.hp,
         },
         healing_applied: healed,

--- a/apps/backend/services/progression/progressionApply.js
+++ b/apps/backend/services/progression/progressionApply.js
@@ -490,6 +490,54 @@ function applyMutationChainRefund(actor, costAp) {
 }
 
 /**
+ * Compute perk modifiers for mutation_burst's combat semantics (TKT-JOB-PHASEC
+ * slice 4b, Cat F). Read by executeDrainAttack on a mutation_burst hit to layer
+ * perk effects on top of the base MoS-gated random status:
+ *
+ * - mutation_status_extend (ABERRANT ab_r2_random_status_extra): +N turns to the
+ *   applied status duration.
+ * - perfect_mutation_burst (ABERRANT capstone ab_r6_perfect_aberrant): force ALL
+ *   five statuses (ignoring the MoS gate) + a flat bonus damage step.
+ *
+ * Pure reader — applies nothing itself, returns the modifiers for the caller to
+ * layer. Unlike the sibling perk helpers it does NOT early-return on empty
+ * passives (callers always invoke it for mutation_burst; the base MoS-status is
+ * ability semantics applied by the caller regardless of perks).
+ *
+ * @param {object} actor — the unit casting mutation_burst (reads _perk_passives)
+ * @returns {{ extraTurns: number, forceAllStatuses: boolean, bonusDamage: number, applied: Array<object> }}
+ */
+function computeMutationBurstPerkMods(actor) {
+  const out = { extraTurns: 0, forceAllStatuses: false, bonusDamage: 0, applied: [] };
+  const passives = Array.isArray(actor?._perk_passives) ? actor._perk_passives : [];
+  for (const p of passives) {
+    if (p.tag === 'mutation_status_extend') {
+      const turns = Number(p.payload?.turns) || 0;
+      if (turns !== 0) {
+        out.extraTurns += turns;
+        out.applied.push({
+          tag: 'mutation_status_extend',
+          turns,
+          source_perk_id: p.source_perk_id,
+        });
+      }
+    } else if (p.tag === 'perfect_mutation_burst') {
+      const allStatuses = !!p.payload?.all_statuses;
+      const fixedDmg = Number(p.payload?.fixed_dmg) || 0;
+      if (allStatuses) out.forceAllStatuses = true;
+      out.bonusDamage += fixedDmg;
+      out.applied.push({
+        tag: 'perfect_mutation_burst',
+        all_statuses: allStatuses,
+        fixed_dmg: fixedDmg,
+        source_perk_id: p.source_perk_id,
+      });
+    }
+  }
+  return out;
+}
+
+/**
  * Grant XP to all player survivors. Used by campaign advance hook.
  *
  * @param {Array<object>} units
@@ -539,6 +587,7 @@ module.exports = {
   applyPerkKillEffects,
   applyPerkAbilityUseEffects,
   applyMutationChainRefund,
+  computeMutationBurstPerkMods,
   grantXpToSurvivors,
   resetDefaults,
   // Test seam: the module-default store is the singleton the session /start

--- a/docs/superpowers/specs/2026-06-01-phasec-slice4b-aberrant-roll-semantics.md
+++ b/docs/superpowers/specs/2026-06-01-phasec-slice4b-aberrant-roll-semantics.md
@@ -1,0 +1,217 @@
+---
+title: 'PHASEC slice 4b — aberrant ability roll semantics (Cat F residue)'
+workstream: combat
+category: spec
+doc_status: draft
+doc_owner: claude-code
+last_verified: '2026-06-01'
+language: it
+tags: [phasec, jobs-expansion, combat, aberrant, mutation, phenotype, random-roll, cooldown, cat-f]
+---
+
+# PHASEC slice 4b — aberrant ability roll semantics (Cat F residue)
+
+> **Sub-spec di OQ-F** (scoping spec
+> [#2506](https://github.com/MasterDD-L34D/Game/pull/2506) §Slice 4 → _"implementare
+> la random-roll delle ability — sub-spec separata, vedi OQ-F"_). Copre i **4 tag
+> Cat F residui** dopo `#2524`/`#2525` (Cat F oggi 3/7).
+>
+> Diviso in **Parte A (DECISA — ship)** + **Parte B (OQ-F-impl — gated master-dd)**.
+> Parte A è faithful-to-data e non tocca il signature-mechanic balance → si builda
+> subito (PR A1a). Parte B randomizza un signature-mechanic + mappa outcome
+> eterogenei + introduce un cap per-round (nerf) → verdict master-dd prima di buildare.
+
+## 0. Stato di partenza (ground-truth `origin/main` `8f1e1348`)
+
+PE-canon chiuso (`#2528`, verdict A): `unit.pe` = solo XP campaign; aberrant
+`cost_sg` DECORATIVO un-gated. Cat F wired 3/7 (`sg_on_mutation_burst`,
+`phenotype_baseline_heal`, `mutation_chain_on_kill`). Residui 4/7:
+
+| Tag                      | Perk                      | Richiede                                      | Parte |
+| ------------------------ | ------------------------- | --------------------------------------------- | ----- |
+| `mutation_status_extend` | ab_r2_random_status_extra | mutation_burst applica uno status (MoS-gated) | **A** |
+| `perfect_mutation_burst` | ab_r6_perfect_aberrant    | mutation_burst status + damage step bonus     | **A** |
+| `double_phenotype_roll`  | ab_r5_extreme_phenotype   | phenotype_shift = tabella random 1d6          | **B** |
+| `phenotype_double_use`   | ab_r6_chaos_incarnate     | sistema use-cap per-round su phenotype_shift  | **B** |
+
+Ground-truth verificato (worktree off `8f1e1348`):
+
+- `executeDrainAttack` (mutation_burst) = `performAttack` standard. **NON** applica
+  `damage_step_min/max`, **NON** applica status MoS-gated. `mutation_chain_on_kill`
+  refund già wired (`abilityExecutor.js:996`).
+- `executeBuff` (phenotype_shift) = buff FISSO singolo `buff_stat: attack_mod +3`.
+  **NON** rolla la tabella 1d6 descritta nei dati. Non gestisce `buff_stat_2`.
+- Status `rage`/`panic`/`stunned`/`bleeding`/`fracture` esistono tutti e decadono
+  nel loop generico `Object.entries(statusObj)` di
+  `sessionRoundBridge.applyEndOfRoundSideEffects`.
+- Pattern status MoS-gated GIA' presente: `executeRangedAttack` regex
+  `^mos\s*>=\s*(\d+)` + `target.status[sid] = Math.max(existing, dur)`.
+- Pattern damage post-hoc GIA' presente: `executeMultiAttack`/`Ranged`/`Execution`
+  aggiustano `res.damageDealt` via `damage_step_mod` (add/sub a target.hp +
+  `session.damage_taken`).
+- **Nessun sistema cooldown/use-per-round** esiste: le ability sono gated solo da
+  `cost_ap`.
+
+---
+
+## PARTE A — mutation_burst combat semantics (DECISA, ship A1a)
+
+**Razionale gate**: faithful-to-data (la description di `mutation_burst` dichiara
+esplicitamente _"MoS >= 5 applica un random status: rage/panic/stunned/bleeding/fracture
+(1 turno)"_). La lista status è esplicita, la soglia è esplicita, la durata è
+esplicita → **zero ambiguità di mapping**. Cambia il comportamento base di
+`mutation_burst` ma in modo canonico, e i band-scenari HC non castano
+`mutation_burst` → band-neutral (verificato by-construction + band-verify).
+
+### A.1 — Base: MoS-gated random status su mutation_burst
+
+In `executeDrainAttack`, dopo `performAttack` + `applySgEarn`, gated su
+`ability.ability_id === 'mutation_burst' && res.result.hit`:
+
+- `STATUSES = ['rage', 'panic', 'stunned', 'bleeding', 'fracture']`
+- Se `res.result.mos >= 5` → applica **1** status random (`rng`) per `turns` turni
+  (default 1), via `target.status[sid] = Math.max(existing, turns)`.
+- **NON** job-gated: è semantica dell'ability (chi casta mutation_burst la ottiene),
+  non una risorsa-exploit (≠ base-PE-earn che fu job-gated in `#2526`).
+- `rng` = la closure RNG già iniettata in `createAbilityExecutor(deps.rng)`
+  (deterministica nei test).
+
+### A.2 — Perk mods via `computeMutationBurstPerkMods(actor)` (progressionApply.js)
+
+Nuovo helper gemello di `applyMutationChainRefund`, legge `actor._perk_passives`:
+
+```
+{ extraTurns, forceAllStatuses, bonusDamage, applied[] }
+```
+
+- `mutation_status_extend` (payload `{turns:1}`) → `extraTurns += payload.turns`.
+- `perfect_mutation_burst` (payload `{fixed_dmg:6, all_statuses:true, turns:1}`) →
+  `forceAllStatuses = true`, `bonusDamage += payload.fixed_dmg`.
+
+`executeDrainAttack` consuma i mods (lazy-require non-blocking, pattern sgTracker):
+
+- `turns = 1 + extraTurns`
+- `toApply = forceAllStatuses ? [tutti i 5] : (mos>=5 ? [random] : [])`
+- applica ogni status a `turns` turni.
+- `bonusDamage` (perfect) → drena post-hoc come `damage_step_mod>0`
+  (`extra = min(bonusDamage, target.hp)`, sottrai a hp + `session.damage_taken` +
+  `applySgEarn` + somma a `adjustedDamage` per l'evento).
+- Evento `drain_attack`: aggiungi `applied_statuses[]` + `bonus_damage`.
+
+### A.3 — Interpretazione documentata (reversibile)
+
+- **`perfect_mutation_burst` "damage_step diventa 6 garantito (no random)"** → mappato
+  a `bonusDamage +6` flat post-hoc (pattern `execution_attack`). La base
+  `mutation_burst` NON ha damage random (vedi sotto), quindi "no random" è un no-op
+  e il `+6` è additivo. _Più faithful sarebbe sostituire il damage step base con 6
+  fisso, ma `resolveAttack` non espone lo "step" → l'additivo è la via clean +
+  established._
+- **Base `mutation_burst` random-1d6-DAMAGE (description `damage_step_min/max 1/6`)
+  = DEFERRED**: nessun tag Cat F lo richiede (`mutation_status_extend` vuole lo
+  status, `perfect` dà `+6` flat). Gap di faithfulness documentato; follow-up
+  separato se master-dd lo vuole (tocca il damage step base → band-impact reale).
+- **`all_statuses` (perfect) ignora la soglia MoS** (è un capstone: applica tutti
+  e 5 su hit). Interpretazione: capstone = unconditional-on-hit.
+
+### A.4 — Test (TDD) + band-verify
+
+- `computeMutationBurstPerkMods` unit (extend/perfect/none/stack).
+- `executeDrainAttack` integration via `createAbilityExecutor` con `performAttack`
+  stub (`result.mos` controllato) + `rng` deterministica: MoS<5 = nessuno status;
+  MoS>=5 = 1 status; +perfect = 5 status + bonus damage; +extend = +1 turno.
+- Regressione: AI 495/495, progression+abilityExecutor suites, combat.
+- Band-verify HC06 `[15-25%]` + HC07 `[30-50%]` seed 4242 (atteso band-neutral —
+  zero mutation_burst nei band-scenari).
+
+---
+
+## PARTE B — phenotype roll table + use-cap (OQ-F-impl, GATED master-dd)
+
+**Razionale gate**: 3 forche di design non risolvibili faithful-senza-ambiguità.
+
+### OQ-F-impl-1 — mapping della tabella 1d6 di phenotype_shift
+
+`phenotype_shift` description = tabella `1d6`: `1=attack+3, 2=defense+3,
+3=mobility+2, 4=ap+1, 5=heal 4, 6=initiative+5`. Lo schema strutturato encoda solo
+l'outcome 1 (`buff_stat: attack_mod +3`). 3 dei 6 outcome NON hanno un canale di
+applicazione pulito come attack/defense:
+
+| Roll | Outcome       | Applicazione pulita?                                                                               |
+| ---- | ------------- | -------------------------------------------------------------------------------------------------- |
+| 1    | attack +3     | ✅ `applySelfBuff('attack_mod', 3, 2)`                                                             |
+| 2    | defense +3    | ✅ `applySelfBuff('defense_mod', 3, 2)`                                                            |
+| 3    | mobility +2   | ⚠️ `mobility_bonus` consumato in 4 file (movement) — semantica buff incerta                        |
+| 4    | ap +1         | ⚠️ nessun `*_buff`; +1 `ap_remaining` immediato = action-economy swing                             |
+| 5    | heal 4        | ✅ heal `min(4, missing)`                                                                          |
+| 6    | initiative +5 | ⚠️ initiative consumata a round-order (`session.js:2387`) — effetto next-round, awkward mid-combat |
+
+**Opzioni:**
+
+- **A (faithful nearest-mechanic)** — mappa tutti i 6 con interpretazione
+  documentata: mobility→`mobility_bonus` buff, ap→`+1 ap_remaining` immediato,
+  initiative→`initiative` buff per `dur`. Massima fedeltà, ma 3 outcome hanno
+  semantica "best-effort" non testata in-combat.
+- **B (subset clean)** — la tabella rolla solo tra outcome con canale pulito
+  (attack/defense/heal), gli altri 3 → re-map al più vicino o a un default. Meno
+  fedele, zero comportamento incerto.
+- **C (defer)** — non randomizzare phenotype_shift; `double_phenotype_roll` resta
+  gated finché non si decide il mapping.
+
+> _Proposta Claude_: **A** con i 3 outcome incerti chiaramente documentati come
+> "best-effort", più band-verify. Ma è una scelta di design (vedi OQ-F-impl-2) →
+> verdict master-dd.
+
+### OQ-F-impl-2 — randomizzare il signature-mechanic (balance lever)
+
+Oggi `phenotype_shift` = `+3 attack` DETERMINISTICO. Il `signature_mechanic`
+("Mutation Cascade: rolla 1d6") + la description vogliono RANDOM. Renderlo random
+cambia EV+varianza del self-buff base aberrant (non perk-gated → ogni cast).
+
+- **Pro random**: implementa il canone (chaos = identità aberrant).
+- **Contro**: cambia il balance base del job; il `+3 attack` fisso attuale è uno
+  stopgap ma è ciò che gira in produzione. Verdict: randomizzare (faithful) o
+  tenere fisso e far operare i perk su altro?
+
+> _Proposta Claude_: randomizzare (faithful al signature). Band-verify a conferma
+> (aberrant assente dai band-scenari → band-neutral pratico). **Ma è una modifica
+> di signature-mechanic → no-anticipated-judgment, gated.**
+
+### OQ-F-impl-3 — `phenotype_double_use` richiede un base cap per-round (nerf)
+
+`phenotype_double_use` (`cap_per_round: 2`) ha senso SOLO se esiste un cap base
+`= 1/round`. Oggi le ability sono gated solo da AP (con `ap≥2` puoi già castare
+phenotype_shift `cost_ap:1` 2-3×/round). Introdurre un cap base `1/round` =
+**NERF** all'attuale gating AP-only (anche se phenotype_shift 3× è degenere). Il
+task chiede esplicitamente "un sistema per-round-use/cooldown".
+
+- **Opzione A**: cap base 1/round su phenotype_shift; capstone → 2/round (faithful
+  all'esistenza del capstone, ma nerf base + nuovo sistema use-counter).
+- **Opzione B**: nessun cap base; `phenotype_double_use` = no-op/informational
+  (unfaithful al capstone).
+
+> _Proposta Claude_: **A** — il capstone esiste perché il base è cappato; il nerf è
+> minimo. Sistema use-counter generico (`actor._use_count[abilityId][round]`),
+> riusabile per futuri cooldown. **Ma nerf base = gated.**
+
+### OQ-F-impl-4 (minore) — `double_phenotype_roll` con due roll uguali
+
+Due roll della tabella che danno lo stesso outcome (es. 1+1) → stack additivo
+(`+6 attack`) o distinct-only? _Proposta_: stack additivo (semplice, faithful a
+"applicabili entrambi"). Edge minore, deciso in impl se A1b procede.
+
+### Build A1b (post-verdict)
+
+phenotype_shift random table (per OQ-1/2) + use-cap system (per OQ-3) →
+`double_phenotype_roll` + `phenotype_double_use`. TDD + band-verify HC06/HC07.
+
+---
+
+## Sequenza
+
+1. **PR A1a** (Parte A) — ship subito: mutation_burst status + 2 tag
+   (`mutation_status_extend`, `perfect_mutation_burst`). Cat F 3/7 → **5/7**.
+2. **OQ-F-impl verdict master-dd** (Parte B, 4 forche) → **PR A1b**: phenotype table
+   - use-cap + 2 tag (`double_phenotype_roll`, `phenotype_double_use`). Cat F →
+     **7/7** (aberrante completo).
+
+A1a non dipende da A1b. A1b è gated.

--- a/tests/progression/mutationBurstEffects.test.js
+++ b/tests/progression/mutationBurstEffects.test.js
@@ -152,6 +152,8 @@ test('mutation_burst: perfect_mutation_burst applies all 5 statuses + flat bonus
   // performAttack stub deals 5 (20→15) then perfect drains a flat +6 (15→9).
   assert.strictEqual(target.hp, 9, 'flat +6 bonus damage drained post-attack');
   assert.strictEqual(res.body.mutation_bonus_damage, 6);
+  // Codex #2529 P2: reported damage_dealt must include the bonus (5 + 6 = 11).
+  assert.strictEqual(res.body.attack.damage_dealt, 11, 'damage_dealt includes the +6 bonus');
 });
 
 test('mutation_burst: a MISS applies no status', async () => {

--- a/tests/progression/mutationBurstEffects.test.js
+++ b/tests/progression/mutationBurstEffects.test.js
@@ -1,0 +1,185 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  computeMutationBurstPerkMods,
+} = require('../../apps/backend/services/progression/progressionApply');
+const {
+  createAbilityExecutor,
+  _setAbilityForTest,
+  _resetAbilityIndex,
+} = require('../../apps/backend/services/abilityExecutor');
+
+// TKT-JOB-PHASEC slice 4b (Cat F residue) — mutation_burst combat semantics.
+// Base: MoS>=5 → 1 random status from {rage,panic,stunned,bleeding,fracture}.
+// Perk mutation_status_extend (+turns), perfect_mutation_burst (all 5 statuses +
+// flat bonus damage). computeMutationBurstPerkMods(actor) reads _perk_passives.
+
+// --- computeMutationBurstPerkMods (unit) ---
+
+test('computeMutationBurstPerkMods: no perks → all zero', () => {
+  const mods = computeMutationBurstPerkMods({ id: 'ab', _perk_passives: [] });
+  assert.strictEqual(mods.extraTurns, 0);
+  assert.strictEqual(mods.forceAllStatuses, false);
+  assert.strictEqual(mods.bonusDamage, 0);
+});
+
+test('computeMutationBurstPerkMods: mutation_status_extend → extraTurns', () => {
+  const mods = computeMutationBurstPerkMods({
+    id: 'ab',
+    _perk_passives: [
+      { tag: 'mutation_status_extend', payload: { turns: 1 }, source_perk_id: 'ab_r2' },
+    ],
+  });
+  assert.strictEqual(mods.extraTurns, 1);
+  assert.strictEqual(mods.forceAllStatuses, false);
+  assert.strictEqual(mods.bonusDamage, 0);
+});
+
+test('computeMutationBurstPerkMods: perfect_mutation_burst → force all statuses + bonus damage', () => {
+  const mods = computeMutationBurstPerkMods({
+    id: 'ab',
+    _perk_passives: [
+      {
+        tag: 'perfect_mutation_burst',
+        payload: { fixed_dmg: 6, all_statuses: true, turns: 1 },
+        source_perk_id: 'ab_r6',
+      },
+    ],
+  });
+  assert.strictEqual(mods.forceAllStatuses, true);
+  assert.strictEqual(mods.bonusDamage, 6);
+});
+
+test('computeMutationBurstPerkMods: extend + perfect stack', () => {
+  const mods = computeMutationBurstPerkMods({
+    id: 'ab',
+    _perk_passives: [
+      { tag: 'mutation_status_extend', payload: { turns: 1 }, source_perk_id: 'ab_r2' },
+      {
+        tag: 'perfect_mutation_burst',
+        payload: { fixed_dmg: 6, all_statuses: true, turns: 1 },
+        source_perk_id: 'ab_r6',
+      },
+    ],
+  });
+  assert.strictEqual(mods.extraTurns, 1);
+  assert.strictEqual(mods.forceAllStatuses, true);
+  assert.strictEqual(mods.bonusDamage, 6);
+});
+
+// --- executeDrainAttack integration (via createAbilityExecutor + real catalog) ---
+
+const MUTATION_STATUSES = ['rage', 'panic', 'stunned', 'bleeding', 'fracture'];
+
+function makeExecutor({ mos, hit = true, rng = () => 0, dmg = 5 }) {
+  return createAbilityExecutor({
+    performAttack: (s, a, t) => {
+      if (hit) t.hp = Math.max(0, t.hp - dmg);
+      return { damageDealt: hit ? dmg : 0, result: { hit, die: 18, roll: 22, mos } };
+    },
+    buildAttackEvent: () => ({}),
+    appendEvent: async () => {},
+    manhattanDistance: (p, q) => Math.abs(p.x - q.x) + Math.abs(p.y - q.y),
+    rng,
+  });
+}
+
+function makeUnits() {
+  const actor = { id: 'ab', ap: 5, ap_remaining: 5, position: { x: 0, y: 0 }, _perk_passives: [] };
+  const target = { id: 'foe', hp: 20, max_hp: 20, position: { x: 1, y: 0 }, status: {} };
+  return { actor, target };
+}
+
+test('mutation_burst: MoS<5 applies no status', async () => {
+  const ex = makeExecutor({ mos: 2 });
+  const { actor, target } = makeUnits();
+  const res = await ex.executeAbility({
+    session: { units: [actor, target], turn: 1, damage_taken: {} },
+    actor,
+    body: { ability_id: 'mutation_burst', target_id: 'foe' },
+  });
+  assert.strictEqual(res.status, 200, `expected 200: ${JSON.stringify(res.body)}`);
+  const applied = MUTATION_STATUSES.filter((s) => Number(target.status[s]) > 0);
+  assert.deepStrictEqual(applied, [], 'no status below MoS 5');
+});
+
+test('mutation_burst: MoS>=5 applies exactly 1 random status for 1 turn', async () => {
+  const ex = makeExecutor({ mos: 6, rng: () => 0 }); // rng 0 → index 0 → rage
+  const { actor, target } = makeUnits();
+  await ex.executeAbility({
+    session: { units: [actor, target], turn: 1, damage_taken: {} },
+    actor,
+    body: { ability_id: 'mutation_burst', target_id: 'foe' },
+  });
+  const applied = MUTATION_STATUSES.filter((s) => Number(target.status[s]) > 0);
+  assert.strictEqual(applied.length, 1, 'exactly one status');
+  assert.strictEqual(target.status.rage, 1, 'rng=0 picks rage, 1 turn');
+});
+
+test('mutation_burst: mutation_status_extend adds +1 turn to the status', async () => {
+  const ex = makeExecutor({ mos: 6, rng: () => 0 });
+  const { actor, target } = makeUnits();
+  actor._perk_passives = [
+    { tag: 'mutation_status_extend', payload: { turns: 1 }, source_perk_id: 'ab_r2' },
+  ];
+  await ex.executeAbility({
+    session: { units: [actor, target], turn: 1, damage_taken: {} },
+    actor,
+    body: { ability_id: 'mutation_burst', target_id: 'foe' },
+  });
+  assert.strictEqual(target.status.rage, 2, 'base 1 + extend 1 = 2 turns');
+});
+
+test('mutation_burst: perfect_mutation_burst applies all 5 statuses + flat bonus damage, ignoring MoS', async () => {
+  const ex = makeExecutor({ mos: 0, dmg: 5 }); // mos 0 proves perfect ignores the MoS gate
+  const { actor, target } = makeUnits(); // target.hp 20
+  actor._perk_passives = [
+    {
+      tag: 'perfect_mutation_burst',
+      payload: { fixed_dmg: 6, all_statuses: true, turns: 1 },
+      source_perk_id: 'ab_r6',
+    },
+  ];
+  const res = await ex.executeAbility({
+    session: { units: [actor, target], turn: 1, damage_taken: {} },
+    actor,
+    body: { ability_id: 'mutation_burst', target_id: 'foe' },
+  });
+  const applied = MUTATION_STATUSES.filter((s) => Number(target.status[s]) === 1);
+  assert.strictEqual(applied.length, 5, 'all 5 statuses applied for 1 turn');
+  // performAttack stub deals 5 (20→15) then perfect drains a flat +6 (15→9).
+  assert.strictEqual(target.hp, 9, 'flat +6 bonus damage drained post-attack');
+  assert.strictEqual(res.body.mutation_bonus_damage, 6);
+});
+
+test('mutation_burst: a MISS applies no status', async () => {
+  const ex = makeExecutor({ mos: 9, hit: false });
+  const { actor, target } = makeUnits();
+  await ex.executeAbility({
+    session: { units: [actor, target], turn: 1, damage_taken: {} },
+    actor,
+    body: { ability_id: 'mutation_burst', target_id: 'foe' },
+  });
+  const applied = MUTATION_STATUSES.filter((s) => Number(target.status[s]) > 0);
+  assert.deepStrictEqual(applied, [], 'no status on miss');
+});
+
+test('drain_attack other than mutation_burst applies no mutation status', async (t) => {
+  _setAbilityForTest('essence_drain_probe', {
+    ability_id: 'essence_drain_probe',
+    effect_type: 'drain_attack',
+    cost_ap: 1,
+  });
+  t.after(() => _resetAbilityIndex());
+  const ex = makeExecutor({ mos: 9, rng: () => 0 });
+  const { actor, target } = makeUnits();
+  await ex.executeAbility({
+    session: { units: [actor, target], turn: 1, damage_taken: {} },
+    actor,
+    body: { ability_id: 'essence_drain_probe', target_id: 'foe' },
+  });
+  const applied = MUTATION_STATUSES.filter((s) => Number(target.status[s]) > 0);
+  assert.deepStrictEqual(applied, [], 'mutation status is mutation_burst-only');
+});


### PR DESCRIPTION
## What

PHASEC slice 4b (Cat F residue) — `mutation_burst` combat semantics. Wires 2 of the 4 remaining Cat F tags, taking aberrant Cat F from **3/7 → 5/7**.

Sub-spec of OQ-F (scoping spec #2506 §Slice 4 called for a dedicated random-roll sub-spec): `docs/superpowers/specs/2026-06-01-phasec-slice4b-aberrant-roll-semantics.md`.

### Shipped (Part A — faithful-to-data, no design fork)

- **Base `mutation_burst` MoS-gated random status** — on a hit with MoS ≥ 5, applies one random status from `{rage, panic, stunned, bleeding, fracture}` for 1 turn (faithful to the `jobs_expansion.yaml` description). Lives in `executeDrainAttack` (mirrors the existing `executeRangedAttack` `conditional_status` pattern). **NOT job-gated** — it is ability semantics (any unit casting `mutation_burst` gets the status; the perks below require aberrant progression).
- **`mutation_status_extend`** (ab_r2_random_status_extra) — +N turns to the applied status.
- **`perfect_mutation_burst`** (ab_r6_perfect_aberrant capstone) — forces all 5 statuses (ignoring the MoS gate) + a flat bonus damage step, drained post-hoc (the `execution_attack` pattern).

New pure reader `computeMutationBurstPerkMods(actor)` in `progressionApply.js` (sibling of `applyMutationChainRefund`), consumed by `executeDrainAttack` via a non-blocking lazy require (sgTracker pattern). Placed in `performAttack`'s flow → traversed by the `/round/execute` priority_queue path (not inert in band-verify).

### Interpretation notes (reversible, documented in the spec)

- `perfect_mutation_burst` "damage_step diventa 6 garantito" → flat `+6` post-hoc bonus damage (`resolveAttack` doesn't expose the base step; additive is the clean, established path).
- Base `mutation_burst` random-1d6-**damage** = **deferred** (no Cat F tag needs it; touches the base damage step = real band-impact → separate follow-up if wanted).
- `all_statuses` (capstone) is unconditional-on-hit.

### Gated (Part B — OQ-F-impl, master-dd verdict before build)

The 2 phenotype tags (`double_phenotype_roll`, `phenotype_double_use`) need the `phenotype_shift` 1d6 table + a per-round use-cap. Three genuine design forks: 3/6 roll outcomes (mobility/ap/initiative) lack a clean application channel; randomizing a signature mechanic is a balance lever; a base use-cap is a nerf to current AP-only gating. Presented as **OQ-F-impl 1–4** in the spec §Part B with recommended defaults. **Not built here** — awaits the verdict.

## Why band-neutral

The new code path is gated on `ability.ability_id === 'mutation_burst'`. `mutation_burst` appears only in `jobs_expansion.yaml` + code/tests/specs/planning — **never in any sim/scenario party config** — so HC06/HC07 never cast it and the block is dead in band-verify (byte-identical combat). Live N=40 band-verify skipped as no-signal (matches prior PHASEC slices' "band-neutral by construction"); master-dd can run if desired.

## Tests

- New `tests/progression/mutationBurstEffects.test.js` (10): `computeMutationBurstPerkMods` unit ×4 + `executeDrainAttack` integration ×6 (MoS<5 no status; MoS≥5 exactly 1 for 1 turn; +extend = 2 turns; +perfect = all 5 + bonus damage ignoring MoS; miss = none; non-`mutation_burst` drain = none).
- Regression: **AI 495/495**, progression 65/65, api 71/71. Prettier + docs-governance (errors=0) green.

## Rollback (03A)

Revert this squash commit. Pure additive: a new `progressionApply` export + a `mutation_burst`-gated block in `executeDrainAttack` + 1 test file + 1 spec doc. No schema, no `data/`, no migration, no new deps, no forbidden paths. Reverting restores `mutation_burst` to a plain `drain_attack` (no status); Cat F back to 3/7.

## Changelog

- Player: aberrant `mutation_burst` now inflicts a random debuff (rage/panic/stunned/bleeding/fracture) on a strong hit (MoS ≥ 5); the Perfect Aberrant capstone applies all five + extra damage. Before: `mutation_burst` was a plain melee with no status rider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
