### PR TITLE
docs(combat): phasec gated specs (economy cost-gate + forks)

### DIFF
--- a/docs/superpowers/specs/2026-06-01-phasec-economy-cost-gate.md
+++ b/docs/superpowers/specs/2026-06-01-phasec-economy-cost-gate.md
@@ -1,0 +1,146 @@
+---
+title: 'PHASEC economy follow-ups — combat cost gate (A2) + campaign-XP perk earn (A3)'
+workstream: combat
+category: spec
+doc_status: draft
+doc_owner: claude-code
+last_verified: '2026-06-01'
+language: it
+tags: [phasec, jobs-expansion, combat, economy, cost-gate, campaign-xp, pe-canon]
+---
+
+# PHASEC economy follow-ups — combat cost gate (A2) + campaign-XP perk earn (A3)
+
+> Due follow-up sollevati dalla chiusura PE-canon (`#2528`, verdict A). **A2 è
+> GATED** (verdict master-dd sulla scala — NON deciso qui). **A3 è una decisione
+> documentata reversibile** (defer, con wire-path preservato).
+>
+> Grounding economia: vault `Spaces/Dev/Evo-Tactics/core/26-ECONOMY_CANONICAL.md`
+> (SoT). Token combat = **PT** (0-12, per-round), **PP** (0-3, per-encounter,
+> "Ultimate = 3 PP consume all"), **SG** (0-3, per-encounter, Surge Burst). **PE**
+> = XP campaign (mai combat). **PI** = build currency (5 PE = 1 PI).
+
+## A2 — combat cost-scale gate [GATED master-dd]
+
+### A2.1 — Problema
+
+`#2528` ha rinominato l'aberrant `cost_pe` → `cost_sg` per chiudere la collisione
+PE-XP, lasciando il costo **DECORATIVO** (un-gated) "coerente con gli altri
+`cost_sg/cost_pt/cost_pp`". Ground-truth: **tutti** i `cost_sg/pt/pp` sono
+decorativi — `executeAbility` (`abilityExecutor.js:1735`) gate **solo `cost_ap`**;
+non controlla né deduce SG/PT/PP. Inoltre i valori sono su **scale incoerenti**
+rispetto ai cap di pool del SoT.
+
+### A2.2 — Census costi (ground-truth `8f1e1348`, jobs.yaml + jobs_expansion.yaml)
+
+| Pool   | SoT cap           | Valori `cost_*` trovati                                                                                                                                                               | Coerente?                                         |
+| ------ | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| **PP** | **0-3** (max 3)   | blade_flurry 6, phantom_step 5, dervish 10, resonance 4, arcane_renewal 5, convergence 10, kill_shot 6, hunter_mark 5, headshot 12, deathmark 4, shadow_mark 5, shadow_assassinate 10 | ❌ **tutti > 3** → uncastabili se gated           |
+| **SG** | **0-3** (max 3)   | cataclysm 75, arcane_lance 40, apocalypse_ray 100, synaptic_burst 2, aberrant_overdrive 3, stabilized_mutation 5, perfect_mutation 80                                                 | ❌ 5/7 > 3 (solo synaptic 2 + overdrive 3 stanno) |
+| **PT** | **0-12** (max 12) | fortify 3, aegis 5, bulwark 8, sanctuary 4, chain 5, void 10, symbiotic_bloom 4, vital_drain 4, lifegrove 10, bond_amplify 4, unity_surge 8, feral_dominion 5, apex_pack 10           | ⚠️ stanno (≤12) ma vicini al cap                  |
+
+**Diagnosi**: i `cost_*` sono stati scritti in "stile PI" (numeri grandi, come
+`cost_pi` 4-22), NON calibrati ai pool combat reali. PP/SG (cap 3) sono i più rotti:
+quasi ogni ultimate dichiara un costo che eccede il pool intero. Il SoT vuole pool
+piccoli con ultimate "consume-all" (`PP: Ultimate = 3 PP consume all pool`).
+
+### A2.3 — Design del gate (qualunque sia la scala scelta)
+
+Mirror del gate `cost_ap` in `executeAbility`, prima del dispatch:
+
+```
+for (const pool of ['sg','pt','pp']) {
+  const cost = Number(ability['cost_'+pool] || 0);
+  if (cost > 0 && Number(actor[pool] || 0) < cost) return 400 { error, pool, cost, have };
+}
+// on 2xx success: deduct actor[pool] -= cost  (mirror del modello AP-inside-handler #2522)
+```
+
+Pool già su `normaliseUnit`: `sg` (sgTracker), `pt`, `pp` esistono come campi.
+Il deduct va sul success path (come `cost_pe` slice-3 #2522, Codex P2: deduce solo
+post-2xx). Il gate è meccanicamente piccolo — **il blocco è la SCALA**, non il
+codice.
+
+### A2.4 — OQ-ECON (verdict master-dd — NON deciso da Claude)
+
+Il gate è impossibile finché i costi eccedono i pool. Opzioni di riconciliazione:
+
+- **A — Rescale ai cap**: riscrivi tutti i `cost_pp` a 1-3, `cost_sg` a 1-3,
+  `cost_pt` a 1-12. Grande edit dati + pass di balance. Massima fedeltà al "gate
+  reale per-ability".
+- **B — Semantica consume-all (per ultimate)**: per le ability con `cost_pp/sg >=
+pool_max`, il gate diventa "richiede pool PIENO, consuma tutto" (fedele al SoT
+  "Ultimate = 3 PP consume all"). Le rank-1/2 con costi piccoli (synaptic 2,
+  overdrive 3) restano a gate numerico. Nessun re-scaling dei dati; cambia la
+  _semantica_ del campo per i big-cost.
+- **C — Hybrid**: rank ≤2 = gate numerico esatto (rescale solo questi a ≤pool);
+  capstone/ultimate = consume-all (B). Probabilmente il più fedele al design
+  (piccoli costi tattici + ultimate che "scarica" il pool).
+- **D — Leave decorative**: i `cost_*` restano flavor, solo `cost_ap` gate. Status
+  quo. Sconsigliata (i costi mentono al player).
+
+> **Proposta Claude**: **C (hybrid)**. Allinea al SoT senza un balance-pass enorme:
+> i tier bassi diventano gate-esatti (riscalando i pochi costi >pool), gli ultimate
+> diventano consume-all. Ma **è una decisione di balance/design → verdict master-dd**
+> (no-anticipated-judgment). Servono anche: curva earn SG/PP (oggi SG +1/5 taken +1/8
+> dealt cap 3; PP +1 crit +1 kill cap 3) per validare che gli ultimate siano
+> raggiungibili.
+
+**Scope impl post-verdict**: il gate (A2.3) + l'edit dati `cost_*` secondo il
+verdict + band-verify (questo TOCCA il balance: i player non potranno più spammare
+ultimate gratis → WR shift reale, a differenza di slice 4b). `data/core/*.yaml` →
+`validate-datasets` obbligatorio.
+
+## A3 — campaign-XP perk earn (first_kill_pe_bonus / minion_kill_pe_bonus) [DEFER]
+
+### A3.1 — Stato
+
+Post-`#2528`, `PE` = XP campaign. I perk `first_kill_pe_bonus` (stalker
+st_r3_first_blood, +1 PE su primo kill) e `minion_kill_pe_bonus` (beastmaster
+bm_r5_apex_companion, +1 PE su minion-kill) guadagnano "PE". Slice-3 `#2522` li
+aveva agganciati al combat-`unit.pe`; `#2528` ha tolto la scrittura combat di
+`unit.pe` → oggi **entrambi UNWIRED** (zero ref in `apps/backend`). Per il SoT,
+"PE su kill" = **XP campaign** (reward universale, nessun sink per-job — il residue
+"dead resource stalker" era un misread del combat-PE, vedi `#2527`).
+
+### A3.2 — Perché il wire pulito NON è banale
+
+Il XP campaign è assegnato da `grantXpToSurvivors(survivors, amount, {campaignId})`
+(`campaign.js:290`), con `amount` **uniforme** per ogni survivor (default 12 da
+`xp_curve.mission_victory`). Per dare +1 al solo unit che ha fatto il primo kill
+servono **due cose che non esistono**:
+
+1. **Canale combat → campaign**: l'evento "unit X ha fatto il primo kill
+   dell'encounter" deve viaggiare dalla session combat (endpoint separato) alla
+   `campaign advance` (chiamata dal client con `survivors` + `pe_earned`). Nessun
+   canale del genere oggi (il debrief non porta per-unit-first-kill).
+2. **Grant XP per-unit differenziato**: `grantXpToSurvivors` dà `amount` uguale a
+   tutti. Servirebbe un bonus-map per-unit (nuovo param).
+
+`minion_kill_pe_bonus` è inoltre **double-blocked**: richiede il minion runtime
+(slice 6, deferred) come sorgente-kill.
+
+### A3.3 — Decisione: DEFER (reversibile)
+
+Valore marginale (+1 XP su ~12 base, una volta per encounter) vs un mini-feature
+cross-layer (canale first-kill + bonus XP per-unit in `grantXpToSurvivors`) +
+`minion_kill_pe_bonus` comunque bloccato sul minion. **Defer** finché si tocca il
+flusso reward campaign O si costruisce il minion (slice 6).
+
+**Wire-path preservato** (per chi lo costruirà):
+
+- Combat debrief espone `first_kill_actor_id` per encounter (chi ha fatto il 1° KO).
+- `grantXpToSurvivors(units, amount, { perUnitBonus: { [unitId]: n } })` somma il
+  bonus all'`amount` per quell'unit, leggendo `first_kill_pe_bonus`/`minion_kill_pe_bonus`
+  dai `_perk_passives`.
+- `minion_kill_pe_bonus` si sblocca con la kill-attribution dei minion (slice 6).
+
+Reversibile: nessun codice scritto, solo defer documentato. Se master-dd vuole il
+wire ora (anche marginale), è una spec separata di ~S effort.
+
+## Next action
+
+1. **OQ-ECON verdict** (A2.4 A/B/C/D) → spec impl `cost-gate` (gate + edit dati +
+   band-verify). Tocca balance reale.
+2. A3 resta deferred salvo richiesta esplicita; si sblocca con la slice 6 (minion) o
+   un refactor del reward campaign.

--- a/docs/superpowers/specs/2026-06-01-phasec-economy-cost-gate.md
+++ b/docs/superpowers/specs/2026-06-01-phasec-economy-cost-gate.md
@@ -56,10 +56,17 @@ for (const pool of ['sg','pt','pp']) {
 // on 2xx success: deduct actor[pool] -= cost  (mirror del modello AP-inside-handler #2522)
 ```
 
-Pool già su `normaliseUnit`: `sg` (sgTracker), `pt`, `pp` esistono come campi.
-Il deduct va sul success path (come `cost_pe` slice-3 #2522, Codex P2: deduce solo
-post-2xx). Il gate è meccanicamente piccolo — **il blocco è la SCALA**, non il
-codice.
+**Stato pool (ground-truth `normaliseUnit`, `sessionHelpers.js`)**: solo `sg` è un
+pool combat **seeded** (`:111`, via sgTracker); `pe` (`:115`) = XP campaign, `mp`
+(`:129`) = mutazioni. **`pt`/`pp` NON sono campi pool persistiti** su `normaliseUnit`
+(PT = roll per-round computato `:245`; PP compare solo ad-hoc in alcuni payload) —
+corretto da Codex #2530 P2. → il gate su PT/PP richiede **PRIMA di seedare i pool**
+(mirror `sg`) + definirne earn/reset (PP +1 crit / +1 kill; PT per-round cap 12, per
+SoT) = **parte dello scope OQ-ECON, non solo la scala**. Per `sg` il gate è
+meccanicamente piccolo (pool già esiste); per PT/PP va prima costruito il pool. Il
+deduct va sul success path (come `cost_pe` slice-3 #2522, Codex P2: deduce solo
+post-2xx). **Il blocco resta la SCALA + il pool-model PT/PP mancante**, non il
+dispatch.
 
 ### A2.4 — OQ-ECON (verdict master-dd — NON deciso da Claude)
 

--- a/docs/superpowers/specs/2026-06-01-phasec-forks-symbiont-minion.md
+++ b/docs/superpowers/specs/2026-06-01-phasec-forks-symbiont-minion.md
@@ -1,0 +1,153 @@
+---
+title: 'PHASEC forks — symbiont bond (B4) + minion runtime (B5) [gated]'
+workstream: combat
+category: spec
+doc_status: draft
+doc_owner: claude-code
+last_verified: '2026-06-01'
+language: it
+tags: [phasec, jobs-expansion, combat, symbiont, minion, bond, fork, gated, co-op]
+---
+
+# PHASEC forks — symbiont bond (B4) + minion runtime (B5)
+
+> I 2 fork residui dopo le slice no-fork (1-4 + 4b). **Entrambi GATED** — il task
+> richiede `spec → verdict master-dd → impl` (B4) e `spec + OQ-MINION` con build
+> deferred salvo greenlight esplicito (B5). Questo doc **affina** lo scoping di
+> [#2506](https://github.com/MasterDD-L34D/Game/pull/2506) §5/§6 con un modello di
+> stato concreto (symbiont) + risposte raccomandate alle OQ, così che il verdict
+> master-dd sia build-ready. NON costruisce nulla; NON tocca `data/`/codice.
+
+## 0. Stato (ground-truth #2506, `origin/main`)
+
+- `symbiotic_bond` esegue oggi come `shield` con `shield_amount: 0` = **no-op**.
+  Nessuno stato di pairing né redirect.
+- `summon_companion` esegue come `buff hp_max +5` su **se stesso** (`target: self`) —
+  **non spawna** alcuna entità. Nessun tipo-unità minion.
+- Template riusabile (B4): `bondReactionTrigger.js` documenta `shield_ally`
+  ("bonded ally absorbs floor(damage/2)", "identical math to intercept reroute",
+  hook "performAttack post damage step, AFTER intercept reroute check"). **DISTINTO**
+  dai job-bond: la sua sorgente dati è `data/core/companion/creature_bonds.yaml`
+  (companion/species-pair, AncientBeast Beast-Bond). Il symbiont riusa la _math/hook_,
+  non i dati.
+- Slice 1 (`#2522`) ha già il seam difensivo `computePerkDefenseBonus(defender,{units,round})`
+  — riusabile per `bonded_proximity_defense`.
+
+---
+
+## B4 — Symbiont bond-redirect (8 tag Cat C/D/G) [GATED OQ-BOND]
+
+### B4.1 — Tag in scope
+
+| Tag                        | Perk                  | Effetto                                                  |
+| -------------------------- | --------------------- | -------------------------------------------------------- |
+| `bond_redirect_strong`     | sy_r1_strong_bond     | redirect 50% → 60%                                       |
+| `dual_bond`                | sy_r2_dual_link       | 2 bonded (secondario @ 25% redirect)                     |
+| `bonded_proximity_defense` | sy_r2_resonance       | +1 def/alleato adiacente al bonded (max 3) [usa slice 1] |
+| `aura...` già fatto        | —                     | (aura_defense_2tile shippato slice 1)                    |
+| `emergency_full_redirect`  | sy_r4_emergency_swap  | bonded HP≤30% → redirect 100% 1T, cooldown 5             |
+| `chain_heal_adjacent`      | sy_r4_chain_heal      | shared_vitality cura anche adiacenti al bonded (50%)     |
+| `bonded_death_grace`       | sy_r5_sacrifice_grace | bonded muore → symbiont heal 50% + rage 3T               |
+| `shared_hp_pool`           | sy_r6_one_soul (caps) | pool HP condiviso (il più invasivo)                      |
+| `bond_no_distance_limit`   | sy_r6_eternal_link    | bond senza adiacenza dopo trigger                        |
+
+### B4.2 — Modello di stato proposto (build-ready, pending verdict)
+
+1. **Pairing**: `symbiotic_bond` (oggi shield no-op) imposta
+   `actor._bond = { partner_id, redirect_pct: 0.5, secondary_partner_id: null, secondary_pct: 0 }`
+   sul symbiont, e un puntatore inverso `partner._bonded_by = actor.id`. Persiste
+   per l'encounter. `bond_redirect_strong` → `redirect_pct = 0.6`. `dual_bond` →
+   abilita `secondary_partner_id` @ `secondary_pct: 0.25`.
+2. **Intercept danno**: hook in `performAttack` **dopo il damage step, dopo
+   l'intercept-reroute esistente** (lo stesso punto documentato da
+   `bondReactionTrigger.shield_ally`). Quando il `target` ha `_bonded_by` e il
+   symbiont è vivo: `redirect = floor(damageDealt * redirect_pct)`; sposta
+   `redirect` HP dal target al symbiont (target restored, symbiont -redirect,
+   `session.damage_taken` aggiornato per entrambi, `applySgEarn` sul symbiont).
+3. **Seam difensivo (slice 1)**: `bonded_proximity_defense` → un `case` nel
+   `computePerkDefenseBonus` esistente (conta alleati adiacenti al bonded, max 3).
+
+### B4.3 — OQ-BOND (verdict master-dd — risposte _raccomandate_ Claude)
+
+- **Pairing UX / co-op**: chi/come si bonda? _Racc._: bond all'_cast_ su 1 alleato
+  adiacente (come dice il testo), persiste l'encounter, ri-castabile (sposta il
+  bond). In co-op il link è visibile sul HUD del symbiont owner. **Verdict**:
+  adiacenza-al-cast OK? ri-bond libero o 1/encounter?
+- **Ordine vs intercept esistente**: il redirect symbiont **stacka** dopo
+  l'intercept-reroute o lo sostituisce? _Racc._: stack DOPO (intercept prima, poi
+  redirect sul danno residuo) — ma è un'interazione di sistema → **verdict**.
+- **Symbiont KO durante redirect**: se il redirect porta il symbiont a HP≤0?
+  _Racc._: il redirect è capped al HP del symbiont (non va sotto 0; il danno
+  eccedente resta sul target). **Verdict**.
+- **`dual_bond` somma redirect**: 60% primario + 25% secondario può superare 100%
+  del danno? _Racc._: cap totale redirect a 100%; secondario applica sul danno
+  residuo. **Verdict** (o i due bond sono su target diversi → no overlap).
+- **`shared_hp_pool` (capstone, il più invasivo)**: due unità un pool → morte/KO
+  come? _Racc._: trattare come **fase 2 separata** (tocca death/KO/party-wipe);
+  shippare prima gli altri 7 tag, `shared_hp_pool` in un secondo PR dopo un verdict
+  dedicato sulla semantica morte. **Verdict**: ship-in-fase-1 o defer?
+
+### B4.4 — Build (post-verdict)
+
+`spec → TDD → PR` per i 7 tag "redirect/heal/proximity" (riusa slice 1 +
+intercept-hook), `shared_hp_pool` in PR separato (death/KO). Blast radius:
+**alto** (core damage path). Band-verify obbligatorio (i symbiont non sono nei
+band-scenari → probabile band-neutral, ma il redirect tocca il damage step →
+verificare). Effort ~L (3-5 sessioni).
+
+---
+
+## B5 — Minion runtime (8 tag Cat E + capstone) [GATED OQ-MINION, DEFERRED]
+
+> **DEFER esplicito** (task: "Solo spec + OQ-MINION verdict... salvo greenlight
+> esplicito a costruire"). Peggior ROI (8 tag / ~5 sessioni = 1.6), blast radius
+> molto alto, tocca **co-op P5** (rischio regressione). NON costruire senza
+> greenlight master-dd.
+
+### B5.1 — Tag bloccati (tutti sul minion runtime)
+
+`minion_attack_buff`, `minion_proximity_dmg`, `encounter_start_buff_minions`,
+`max_minions`, `pack_command_extended_range`, `minion_resurrect_chance`,
+`alpha_pack_buff`, `minion_kill_pe_bonus` (co-req PE/XP — vedi spec economy A3).
+
+### B5.2 — Perché è un nuovo tipo-unità (non un buff)
+
+`summon_companion` oggi = `buff hp_max +5` su self. Per i tag serve: entità minion
+spawnata, lifecycle (summon/cap/death/resurrect), ordini (`pack_command`), buff.
+Tocca round-order, AI, spawn, death, grid occupancy, **co-op ownership**.
+
+### B5.3 — OQ-MINION (verdict master-dd — risposte _raccomandate_ Claude)
+
+- **`controlled_by`**: nuovo `'minion'` o `'player'` + `owner_id` = beastmaster?
+  _Racc._: `controlled_by: 'player'` + `owner_id` (il campo esiste,
+  `sessionHelpers.js:105`) → eredita la lose-condition del party senza un nuovo
+  ramo "minion team". **Verdict**.
+- **AI**: ordini scriptati o AI piena? _Racc._: scriptati minimi (move-to/attack
+  nearest) + `pack_command` per l'ordine free/round; NO `declareSistemaIntents`
+  pieno (riduce blast radius + non confonde la SIS-pressure). **Verdict**.
+- **Death/party-wipe**: il minion conta verso il wipe? _Racc._: NO — è espendibile
+  (coerente con `feral_sacrifice`); `minion_resurrect_chance` re-spawna a 1HP a fine
+  round. **Verdict**.
+- **Spawn tiles**: adiacente libero; se nessuno libero → summon fallisce con 400
+  (no auto-place lontano). **Verdict**.
+- **Initiative**: turno proprio nel round-order o agisce nel turno del BM? _Racc._:
+  agisce nel turno del BM via `pack_command` (1 ordine free/round) → niente slot di
+  initiative nuovo (meno impatto sul round orchestrator). **Verdict**.
+- **Co-op ownership (rischio P5)**: nel flow Jackbox chi comanda i minion? _Racc._:
+  il player owner del beastmaster; in assenza, il host. **Questo è il punto di
+  rischio regressione → verdict + smoke co-op obbligatorio prima di ship.**
+
+### B5.4 — Raccomandazione
+
+**Restare deferred / post-MVP.** Se greenlight: spec dedicata + spike POC (1 minion,
+no perk) prima dei 7 tag, co-op smoke gate (coop-phase-validator). `minion_kill_pe_bonus`
+si sblocca col canale XP di economy-A3.
+
+---
+
+## Sequenza consigliata
+
+1. **OQ-BOND verdict** → B4 fase 1 (7 tag) → B4 fase 2 (`shared_hp_pool`, verdict death).
+2. **B5 resta deferred** salvo greenlight; allora OQ-MINION verdict → spike → tag.
+
+Nessuno dei due è blocco per le slice no-fork già shippate.


### PR DESCRIPTION
Two **doc-only** specs presenting the master-dd-**GATED** PHASEC open questions, so a verdict can be given build-ready. No code, no `data/`, no schema. Auto-merge eligible (docs).

## economy-cost-gate (A2 + A3)

- **A2 — combat cost gate (OQ-ECON, GATED)**: combat `cost_sg/pp/pt` are **decorative** (only `cost_ap` is gated) AND on scales **incoherent** with the 26-ECONOMY SoT pool caps — PP/SG max **3**, PT max **12**, yet values run to 75/80/100. A naive gate would make most ultimates uncastable. Options **A** (rescale) / **B** (consume-all semantics) / **C** (hybrid — recommended) / **D** (leave decorative). Needs a verdict + a balance pass; touches `data/` → real band impact.
- **A3 — campaign-XP perk earn (DEFER)**: `first_kill_pe_bonus` / `minion_kill_pe_bonus` = campaign XP post-#2528, currently **unwired**. A clean wire needs a cross-layer combat→campaign first-kill channel + a per-unit XP bonus in `grantXpToSurvivors` (neither exists today); `minion_kill_pe_bonus` is double-blocked on the minion runtime. **Formally deferred** with a documented wire-path (reversible — no code written).

## forks-symbiont-minion (B4 + B5)

- **B4 — symbiont bond-redirect (OQ-BOND, GATED)**: 8 tags. Build-ready state model (`actor._bond` pairing + `performAttack` post-damage intercept hook, reusing `bondReactionTrigger` math + the slice-1 `computePerkDefenseBonus` seam) + recommended OQ answers. `shared_hp_pool` capstone flagged as a separate phase-2 (touches death/KO).
- **B5 — minion runtime (OQ-MINION, GATED + DEFERRED)**: 8 tags. New unit type (`summon_companion` today is a self-buff, spawns nothing). Worst ROI + co-op P5 regression risk → **kept deferred**; recommended OQ answers (controlled_by/AI/death/spawn/initiative/co-op) for an eventual explicit greenlight.

Sharpens the scoping in #2506 §5/§6 with concrete state models + recommended verdicts. The no-fork slices (1-4 + 4b/#2529) do not depend on either fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
