### PR TITLE
docs(combat): OD-058 D5/D1/D4 doc propagation (phase-2 canon + overcharge supersede)

### DIFF
--- a/docs/core/00-SOURCE-OF-TRUTH.md
+++ b/docs/core/00-SOURCE-OF-TRUTH.md
@@ -20,15 +20,15 @@ _v5 (2026-04-16): merge visione prescrittiva da `evo_tactics_game_vision_reconst
 
 | Stato | Task                                             | Dettagli operativi                                                                                                                                                                                     |
 | ----- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| ☑    | Visione generale ricostruita                     | Derivata soprattutto da [`01-VISIONE.md`](01-VISIONE.md), [`03-LOOP.md`](03-LOOP.md), [`DesignDoc-Overview.md`](DesignDoc-Overview.md), [`90-FINAL-DESIGN-FREEZE.md`](90-FINAL-DESIGN-FREEZE.md)       |
-| ☑    | Prima partita ricostruita                        | Supportata da [`17-SCREEN_FLOW.md`](17-SCREEN_FLOW.md) e [`enc_tutorial_01.yaml`](../planning/encounters/enc_tutorial_01.yaml)                                                                         |
-| ☑    | Worldgen ed ecosistemi ricostruiti               | Supportati da [`biomes.yaml`](../../data/core/biomes.yaml), `data/ecosystems/*`, `packs/evo_tactics_pack/data/ecosystems/*`                                                                            |
-| ☑    | Foodweb verificata                               | Confermata da `packs/evo_tactics_pack/data/foodwebs/*`, validator e network cross-bioma                                                                                                                |
-| ☑    | Sistema evolutivo specie-trait-forme ricostruito | Supportato da [`species.yaml`](../../data/core/species.yaml), [`20-SPECIE_E_PARTI.md`](20-SPECIE_E_PARTI.md), [`22-FORME_BASE_16.md`](22-FORME_BASE_16.md), `data/core/traits/*`                       |
-| ☑    | TV + companion + salotto ricostruiti             | Supportati da [`11-REGOLE_D20_TV.md`](11-REGOLE_D20_TV.md), [`30-UI_TV_IDENTITA.md`](30-UI_TV_IDENTITA.md), [`DesignDoc-Overview.md`](DesignDoc-Overview.md), [`17-SCREEN_FLOW.md`](17-SCREEN_FLOW.md) |
-| ☑    | Premessa narrativa recuperata                    | Supportata da [`draft-narrative-lore.md`](../planning/draft-narrative-lore.md)                                                                                                                         |
-| ☑    | Documento master promosso nel repo               | Questo file è ora canonico in `docs/core/00-SOURCE-OF-TRUTH.md`                                                                                                                                        |
-| ☑    | Visione prescrittiva integrata (§20–§23)         | Merge da [`evo_tactics_game_vision_reconstructed.md`](../pitch/evo_tactics_game_vision_reconstructed.md) — contenuto nuovo (Tri-Sorgente, A.L.I.E.N.A., companion detail, loop prescrittivo)           |
+| ☑     | Visione generale ricostruita                     | Derivata soprattutto da [`01-VISIONE.md`](01-VISIONE.md), [`03-LOOP.md`](03-LOOP.md), [`DesignDoc-Overview.md`](DesignDoc-Overview.md), [`90-FINAL-DESIGN-FREEZE.md`](90-FINAL-DESIGN-FREEZE.md)       |
+| ☑     | Prima partita ricostruita                        | Supportata da [`17-SCREEN_FLOW.md`](17-SCREEN_FLOW.md) e [`enc_tutorial_01.yaml`](../planning/encounters/enc_tutorial_01.yaml)                                                                         |
+| ☑     | Worldgen ed ecosistemi ricostruiti               | Supportati da [`biomes.yaml`](../../data/core/biomes.yaml), `data/ecosystems/*`, `packs/evo_tactics_pack/data/ecosystems/*`                                                                            |
+| ☑     | Foodweb verificata                               | Confermata da `packs/evo_tactics_pack/data/foodwebs/*`, validator e network cross-bioma                                                                                                                |
+| ☑     | Sistema evolutivo specie-trait-forme ricostruito | Supportato da [`species.yaml`](../../data/core/species.yaml), [`20-SPECIE_E_PARTI.md`](20-SPECIE_E_PARTI.md), [`22-FORME_BASE_16.md`](22-FORME_BASE_16.md), `data/core/traits/*`                       |
+| ☑     | TV + companion + salotto ricostruiti             | Supportati da [`11-REGOLE_D20_TV.md`](11-REGOLE_D20_TV.md), [`30-UI_TV_IDENTITA.md`](30-UI_TV_IDENTITA.md), [`DesignDoc-Overview.md`](DesignDoc-Overview.md), [`17-SCREEN_FLOW.md`](17-SCREEN_FLOW.md) |
+| ☑     | Premessa narrativa recuperata                    | Supportata da [`draft-narrative-lore.md`](../planning/draft-narrative-lore.md)                                                                                                                         |
+| ☑     | Documento master promosso nel repo               | Questo file è ora canonico in `docs/core/00-SOURCE-OF-TRUTH.md`                                                                                                                                        |
+| ☑     | Visione prescrittiva integrata (§20–§23)         | Merge da [`evo_tactics_game_vision_reconstructed.md`](../pitch/evo_tactics_game_vision_reconstructed.md) — contenuto nuovo (Tri-Sorgente, A.L.I.E.N.A., companion detail, loop prescrittivo)           |
 
 ---
 
@@ -498,17 +498,17 @@ La memoria che avevi era giusta: il gioco era più grande del puro combat, e il 
 
 | Stato | Task                                | Dettagli operativi                                                                                    |
 | ----- | ----------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| ☑    | 1. Leggere la visione               | [`docs/core/01-VISIONE.md`](01-VISIONE.md)                                                            |
-| ☑    | 2. Leggere il loop                  | [`docs/core/03-LOOP.md`](03-LOOP.md)                                                                  |
-| ☑    | 3. Leggere il freeze                | [`docs/core/90-FINAL-DESIGN-FREEZE.md`](90-FINAL-DESIGN-FREEZE.md)                                    |
-| ☑    | 4. Recuperare il feeling originario | [`docs/core/DesignDoc-Overview.md`](DesignDoc-Overview.md)                                            |
-| ☑    | 5. Leggere il flow giocabile        | [`docs/planning/17-SCREEN_FLOW.md`](../planning/17-SCREEN_FLOW.md)                                    |
-| ☑    | 6. Leggere la prima partita         | [`docs/planning/encounters/enc_tutorial_01.yaml`](../planning/encounters/enc_tutorial_01.yaml)        |
-| ☑    | 7. Leggere specie e Forme           | [`20-SPECIE_E_PARTI.md`](20-SPECIE_E_PARTI.md), [`22-FORME_BASE_16.md`](22-FORME_BASE_16.md)          |
-| ☑    | 8. Leggere biomi e Director         | [`28-NPC_BIOMI_SPAWN.md`](28-NPC_BIOMI_SPAWN.md), [`biomes.yaml`](../../data/core/biomes.yaml)        |
-| ☑    | 9. Leggere foodweb/ecosistemi       | `packs/evo_tactics_pack/data/ecosystems/*`, `packs/evo_tactics_pack/data/foodwebs/*`, `.../network/*` |
-| ☑    | 10. Leggere meta-loop               | [`27-MATING_NIDO.md`](27-MATING_NIDO.md), [`mating.yaml`](../../data/core/mating.yaml)                |
-| ☑    | 11. Promuovere un master doc        | Questo file è ora `docs/core/00-SOURCE-OF-TRUTH.md`                                                   |
+| ☑     | 1. Leggere la visione               | [`docs/core/01-VISIONE.md`](01-VISIONE.md)                                                            |
+| ☑     | 2. Leggere il loop                  | [`docs/core/03-LOOP.md`](03-LOOP.md)                                                                  |
+| ☑     | 3. Leggere il freeze                | [`docs/core/90-FINAL-DESIGN-FREEZE.md`](90-FINAL-DESIGN-FREEZE.md)                                    |
+| ☑     | 4. Recuperare il feeling originario | [`docs/core/DesignDoc-Overview.md`](DesignDoc-Overview.md)                                            |
+| ☑     | 5. Leggere il flow giocabile        | [`docs/planning/17-SCREEN_FLOW.md`](../planning/17-SCREEN_FLOW.md)                                    |
+| ☑     | 6. Leggere la prima partita         | [`docs/planning/encounters/enc_tutorial_01.yaml`](../planning/encounters/enc_tutorial_01.yaml)        |
+| ☑     | 7. Leggere specie e Forme           | [`20-SPECIE_E_PARTI.md`](20-SPECIE_E_PARTI.md), [`22-FORME_BASE_16.md`](22-FORME_BASE_16.md)          |
+| ☑     | 8. Leggere biomi e Director         | [`28-NPC_BIOMI_SPAWN.md`](28-NPC_BIOMI_SPAWN.md), [`biomes.yaml`](../../data/core/biomes.yaml)        |
+| ☑     | 9. Leggere foodweb/ecosistemi       | `packs/evo_tactics_pack/data/ecosystems/*`, `packs/evo_tactics_pack/data/foodwebs/*`, `.../network/*` |
+| ☑     | 10. Leggere meta-loop               | [`27-MATING_NIDO.md`](27-MATING_NIDO.md), [`mating.yaml`](../../data/core/mating.yaml)                |
+| ☑     | 11. Promuovere un master doc        | Questo file è ora `docs/core/00-SOURCE-OF-TRUTH.md`                                                   |
 
 ---
 
@@ -721,6 +721,25 @@ Pattern Bevy-inspired (V1). Plugin attivi: `narrativePlugin` (monta route narrat
 | §18 Audience/Accessibilità | —                                                         | 🟡 Proposte, attesa Master DD                                                                                                                                                                                                                  |
 | §19 Decisioni GDD          | 28 domande                                                | 12✅ 9🟡 7🔴                                                                                                                                                                                                                                   |
 | M14 Mutations (Path A)     | `mutationCatalogLoader.js` + `routes/mutations.js`        | 🟡 Foundation live (30 entries, 4 endpoint REST `/registry`, `/:id`, `/eligible`, `/apply`). PE/PI charging deferred a M13.P3 wire. Decoupled da V3 mating per design semantics 2026-04-25.                                                    |
+
+### 13.9 Motori Phase-2 — stato di combattimento persistente
+
+> Canonizzazione **OD-058 D5** (verdetto 3A, master-dd Eduardo 2026-06-01). I 4 motori di "stato di combattimento persistente" entrano nel design-of-record (chiude lo scope-creep di motori shippati senza backing SoT). Confine **Phase-2 = SOLO questi 4**; **FUORI = esplicito** (anti catch-all): qualsiasi altro motore (narrative, plugin, worldgen/Flow, Atlas, AI-SIS) e la regola overcharge-AP (D1, è una _regola_ di combat, non un _motore_ Phase-2) NON sono Phase-2. Un motore futuro non è Phase-2 per default.
+
+| Motore                   | Cosa fa                                                             | Stato                      | Owner-doc                                                     |
+| ------------------------ | ------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------- |
+| `morale`                 | panic/rage on ally-death (stile Battle-Brothers)                    | SHIPPED #2390              | `00D §16.1`                                                   |
+| ferite a locazione       | hit-location → malus stat                                           | design `ready`, build D2   | SPEC-D2 / `00D §16.2`                                         |
+| `cumulativeStateTracker` | mutazioni cumulative end-of-round                                   | SHIPPED #2383              | `00D §16.3`                                                   |
+| vcSnapshot coop          | telemetria combat → scoring/debrief; server ricostruisce dal ledger | arch-gated, D3 (Opzione 2) | ADR-2026-05-30-coop-server-authoritative-combat / `00D §16.4` |
+
+Dettaglio diegetico per-motore: `00D-ENGINES_AS_GAME_FEATURES.md §16`. I 2 puntatori (ferite→D2, vcSnapshot→D3) restano gestiti dai rispettivi doc-of-record; D5 li integra, non li ridecide.
+
+#### 13.9.1 Canali di danno + matrice resistenze (OD-058 D4)
+
+Canali canonici (11): `fisico`, `taglio`, `fuoco`, `elettrico`, `psionico`, `mentale`, `gravita`, `ionico`, `earth`, `wind`, `dark`. Semantica `modifier_pct`: **100 = neutro, >100 = vulnerabile, <100 = resistente**. Dato-di-record = `packs/evo_tactics_pack/data/balance/species_resistances.yaml`.
+
+Dead-channel `elettrico` **CHIUSA** (D4 downscope-A): `corazzato elettrico: 120` (vulnerabile) shipped #2381 + N=40-ratify #2389 → il canale ha finalmente un bersaglio premiante. Enrichment residuo (1-2 nuovi trait elettrico + retune `bioelettrico`, oggi `elettrico: 70`) = ticket separato **TKT-D4-ENRICH** (NON OD-058-gating; gate = N=40 + scenario-probe elettrico dedicato corazzato-vs-attaccante, anti-pattern #14).
 
 ---
 
@@ -1335,7 +1354,7 @@ Per la mappa dettagliata di come i moduli tecnici del repo si traducono in featu
 
 | Sistema             | Descrittivo (§1–§19)              | Prescrittivo (§20–§23)                      |
 | ------------------- | --------------------------------- | ------------------------------------------- |
-| Progressione        | VC scoring + MBTI/Ennea operativi | Tri-Sorgente come ponte run↔identity (§20) |
+| Progressione        | VC scoring + MBTI/Ennea operativi | Tri-Sorgente come ponte run↔identity (§20)  |
 | Framework autoriali | Validator foodweb/trophic attivi  | A.L.I.E.N.A. come layer autoriale (§21)     |
 | Companion           | Concetto in design docs           | Funzioni specifiche per area UX (§22)       |
 | Loop                | Sequenza match documentata        | Loop completo con meta-loop integrato (§23) |

--- a/docs/core/00D-ENGINES_AS_GAME_FEATURES.md
+++ b/docs/core/00D-ENGINES_AS_GAME_FEATURES.md
@@ -520,3 +520,38 @@ Usa questo file quando devi decidere:
 Se devi invece capire **dove leggere cosa nel repo**, usa `00C-WHERE_TO_USE_WHAT.md`.
 Se devi capire **cosa è canonico e cosa no**, usa `00B-CANONICAL_PROMOTION_MATRIX.md`.
 Se devi capire **cos'è Evo Tactics come gioco**, usa `00-GDD_MASTER.md`.
+
+---
+
+## 16. Motori Phase-2 — Stato di combattimento persistente
+
+> Canonizzazione **OD-058 D5** (verdetto 3A, master-dd Eduardo 2026-06-01). I 4 motori di "stato di combattimento persistente" entrano nel design-of-record. Specchio canonico: `00-SOURCE-OF-TRUTH.md §13.9`. Confine Phase-2 = SOLO questi 4 (vedi §16.5, anti catch-all).
+
+### 16.1 Morale → "Tenuta dello scontro"
+
+- **Ruolo tecnico**: trigger panic/rage stile Battle-Brothers (Game #2390, wire on ally-death).
+- **Come appare in gioco**: quando un alleato cade, la creatura _vacilla_ (panic) o si _infuria_ (rage) — la pressione emotiva del campo diventa leggibile, non solo gli HP.
+- **Beneficio**: il morale rende visibile il costo psicologico dello scontro.
+
+### 16.2 Ferite a locazione → "Dove fa male" (vedi D2)
+
+- **Ruolo tecnico**: hit-location → malus su stat principale; 4 locazioni (testa→mira/AP, torso→difesa, arti_ant→attacco, arti_post→mobilità) + 3 tier gravità (lieve/media/grave). Build = `woundSystem.js` (SPEC-D2).
+- **Come appare in gioco**: una ferita al torso abbassa la difesa, agli arti l'attacco o la mobilità, alla testa la mira (-1 AP solo se grave). Le ferite gravi diventano cicatrici cross-encounter.
+- **Beneficio**: il danno ha una geografia — "questa creatura zoppica", non solo "ha meno HP".
+
+### 16.3 Stato cumulativo → "Memoria del corpo"
+
+- **Ruolo tecnico**: `cumulativeStateTracker` (Game #2383), trigger mutazioni cumulative a fine round.
+- **Come appare in gioco**: il corpo registra lo stress accumulato e muta nel tempo — le forme parlano.
+- **Beneficio**: continuità tra round/encounter; l'evoluzione è conseguenza visibile dell'esperienza di combattimento.
+
+### 16.4 vcSnapshot coop → "Cronaca dello scontro" (vedi D3)
+
+- **Ruolo tecnico**: telemetria combat → scoring/debrief; in coop il server **ricostruisce** `vcSnapshot` dal ledger/event-log (D3 Opzione 2 — il combat resta client-side, SoT §24.1 non violata). Decision-of-record: `ADR-2026-05-30-coop-server-authoritative-combat`.
+- **Come appare in gioco**: il debrief post-missione mostra il contributo VC anche in coop, allineato al single-player.
+- **Beneficio**: lo scoring/evoluzione coop smette di essere cittadino-di-seconda-classe.
+
+### 16.5 Confine Phase-2 (anti catch-all)
+
+- **DENTRO**: i 4 motori sopra (morale, ferite-a-locazione, stato-cumulativo, vcSnapshot-coop).
+- **FUORI (esplicito)**: ogni altro motore — narrative, plugin, worldgen/Flow, Atlas, EventScheduler, AI-SIS — e la regola **overcharge-AP** (OD-058 D1: è una regola di combat, non un motore Phase-2). Un motore futuro NON è Phase-2 per default: ci entra solo con un verdetto esplicito.

--- a/docs/core/11-REGOLE_D20_TV.md
+++ b/docs/core/11-REGOLE_D20_TV.md
@@ -48,7 +48,7 @@ Regole canoniche per turno, AP budget, syntax input. Chiude FRICTION #1-#3 dal p
 
 - **Libertà tattica**: player sceglie tempo/target senza template forzato (contro Halfway lesson "prescriptive turn = frustrating").
 - **Economy meaningful**: 2 attack vs move = trade-off esplicito damage-now vs position-now.
-- **AI symmetry**: Sistema gode stesso budget → asimmetria solo via profili AI + HP/DC, non via regole turno.
+- **AI symmetry**: Sistema gode stesso budget → asimmetria solo via profili AI + HP/DC, non via regole turno. **Eccezione canonica (OD-058 D1, ratify-as-built #2481)**: il verbo _Overcharge_ (spendi 3 SG → +1 AP questo turno, once-per-turn) è **player-only** (`actor.controlled_by === 'player'`; il SIS non può overcharge). Asimmetria deliberata che **supersede questa clausola di simmetria** limitatamente all'estensione AP via spesa risorsa esplicita (vedi §Varianti future).
 
 ### Enforcement
 
@@ -98,6 +98,7 @@ Tiebreak: priority desc, actor_id alfabetico asc, declaration order asc. Con `pr
 - Trait `ferocia_lampo` (placeholder): 2° attack guadagna bonus se MoS ≥10 al primo.
 - Job `berserker` (placeholder): 2° attack gratuito (ap_cost=0) sotto HP 25%.
 - Entrambi richiedono spec esplicita (non alterano regola base AP).
+- **Overcharge (canonico, OD-058 D1, ratify-as-built #2481)**: spendi **3 SG** (gauge piena, `POOL_MAX=3`) → **+1 AP** questo turno (ap_max 2 → 3), **once-per-turn** (`actor.status.overcharged`), **player-only**. A differenza dei placeholder qui sopra, questa variante **estende davvero** la regola base AP (2 → 3 con spesa risorsa esplicita) ed è il **supersede canonico** di "2 AP base" (freeze §7.1). Twin di _defy_ (spendi 2 SG → -1 AP turno successivo). Claim balance verso P6 gated da N=40 action-economy probe (anti-pattern #14/#15).
 
 ## Syntax mosse canonica (FRICTION #1)
 

--- a/docs/core/90-FINAL-DESIGN-FREEZE.md
+++ b/docs/core/90-FINAL-DESIGN-FREEZE.md
@@ -153,7 +153,7 @@ Regola di governance: ogni feature deve dichiarare in quale punto del loop impat
 
 - **iniziativa come reaction speed** (non piu' turn order rigido): semantica consolidata in [ADR-2026-04-15](../adr/ADR-2026-04-15-round-based-combat-model.md) e [`docs/combat/round-loop.md`](../combat/round-loop.md);
 - **round loop** shared planning → commit → ordered resolution sopra il resolver atomico;
-- 2 AP base + reazioni come intent first-class con trigger conditions;
+- 2 AP base, **esteso a 3 con spesa esplicita di 3 SG** (verbo _Overcharge_, once-per-turn, **player-only**) — superseded da OD-058 D1 / `ADR-2026-05-30-ap-extension-pt-sg` (ratify-as-built #2481, `overchargeEngine.js`); reazioni come intent first-class con trigger conditions;
 - attacco d20 vs CD target;
 - MoS con +1 step danno ogni +5;
 - PT generati da roll alti e MoS;

--- a/packs/evo_tactics_pack/data/balance/species_resistances.yaml
+++ b/packs/evo_tactics_pack/data/balance/species_resistances.yaml
@@ -31,7 +31,7 @@ species_archetypes:
       fisico: 80
       taglio: 80
       fuoco: 100
-      # balance-audit 2026-05-22: elettrico was a dead offensive channel (no archetype vulnerable). Armor conducts -> corazzato vuln 100->120. Candidate, needs N=40 ratify + lore sign-off.
+      # balance-audit 2026-05-22: elettrico was a dead offensive channel (no archetype vulnerable). Armor conducts -> corazzato vuln 100->120. RATIFIED #2381 (tune) + #2389 (N=40 EV-parity); OD-058 D4 downscope-A = dead-channel CLOSED. SoT canon: docs/core/00-SOURCE-OF-TRUTH.md §13.9.1.
       elettrico: 120
       psionico: 120
       mentale: 120


### PR DESCRIPTION
## OD-058 execution — doc-propagation bundle (D5 + D1-supersede + D4-doc-fix)

Tracker: #2531. Verdict-of-record: vault `OD-058-gate-verdicts-PROPOSAL-2026-06-01` (all 5 gates ratified master-dd Eduardo 2026-06-01). **Docs/data-comment only — zero code change.**

### D5 — canonize 4 Phase-2 motors (closes scope-creep)
- `docs/core/00D-ENGINES_AS_GAME_FEATURES.md` → new `## 16. Motori Phase-2` (morale #2390, ferite→D2, cumulative #2383, vcSnapshot→D3) + explicit `FUORI` boundary (anti catch-all).
- `docs/core/00-SOURCE-OF-TRUTH.md` → new **§13.9** (NOT §13.6 — that is "Narrative engine"; 13.1–13.8 occupied at #2530). Mirror table + co-located **§13.9.1 Canali di danno** (D4).
- Gives the 2 already-shipped motors (#2383, #2390) their design-of-record backing.

### D1 — overcharge ratify-as-built supersede (no code)
Overcharge live since #2481 (`overchargeEngine.js`: spend 3 SG → +1 AP this turn, once/turn, **player-only**). Supersede notes added:
- `90-FINAL-DESIGN-FREEZE.md §7.1` — "2 AP base" → "esteso a 3 con spesa esplicita di 3 SG".
- `11-REGOLE_D20_TV.md §AP` — AI-symmetry clause now documents the canonical player-only asymmetry + new `§Varianti future` Overcharge entry.
- ⏳ **N=40 action-economy probe still owed** before crediting toward P6 (anti-pattern #14/#15) — separate follow-up.

### D4 — dead-channel doc-fix (downscope-A)
Dead-channel already closed (`corazzato elettrico: 120`, #2381 + N=40-ratify #2389). 
- Canon-channels section co-located in SoT §13.9.1 (with D5).
- Fixed **stale comment** in `packs/evo_tactics_pack/data/balance/species_resistances.yaml` ("Candidate, needs N=40 ratify" → RATIFIED #2381/#2389).
- Enrichment (new electric traits + bioelettrico retune) → separate **TKT-D4-ENRICH** (NOT OD-058-gating).

### Verify
- `git diff` self-reviewed; mojibake check = 0; `species_resistances.yaml` parses (corazzato.elettrico=120 preserved).
- `tools/check_docs_governance.py --strict` → errors=0.
- Prettier pre-commit clean.

### Rollback
`git revert` the single squash commit — docs-only, no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)