### PR TITLE
feat(combat): OD-058 D2 woundSystem engine (location -> stat-malus)

### DIFF
--- a/apps/backend/services/combat/statusModifiers.js
+++ b/apps/backend/services/combat/statusModifiers.js
@@ -83,6 +83,13 @@ function normalizeBleedingFractureSeverity(value) {
  */
 function computeWoundedPermaAttackPenalty(unit) {
   const status = (unit && unit.status) || {};
+  // OD-058 D2 double-apply guard: the location-based woundSystem (unit.status.wounds)
+  // supersedes this legacy wounded_perma attack penalty. When the new model carries any
+  // wound, yield here so attack_mod is NOT penalized by BOTH systems. (Zero current
+  // behavior change: nothing populates unit.status.wounds until the D2 live cutover PR.)
+  if (Array.isArray(status.wounds) && status.wounds.length > 0) {
+    return { penalty: 0, severity: 'light', active: false, superseded: true };
+  }
   const wp = status.wounded_perma;
   if (!wp || typeof wp !== 'object') {
     return { penalty: 0, severity: 'light', active: false };

--- a/apps/backend/services/combat/woundSystem.js
+++ b/apps/backend/services/combat/woundSystem.js
@@ -1,0 +1,232 @@
+// OD-058 D2 (2026-06-01) — wound location system.
+//
+// Source: vault SPEC-D2-wound-location-system-2026-05-26 (ratify master-dd 2026-06-01).
+// Supersedes the two orphan models (woundedPerma HP-penalty + statusModifiers
+// severity->attack-only) with a hit-location -> stat-malus model:
+//   - 4 fixed locations cover the canonical stat set (AP / defense / attack / mobility);
+//   - 3 severity tiers (lieve / media / grave) scale malus + persistence;
+//   - only `grave` wounds persist cross-encounter (scar), like the old woundedPerma role.
+//
+// HP is left intact (SPEC §7): fragility now arrives via -defense, not raw HP cuts.
+// Data model: unit.status.wounds = Array<{ location, severity, stat, malus }>.
+//
+// NOTE (OD-058 D2 staged cutover): this PR ships the engine + read-path + data table.
+// The LIVE woundedPerma HP-penalty wire (session.js KO/wipe + statusModifiers attack
+// penalty) is deprecated-in-favor-of this module but cut over in a follow-up PR, so the
+// two systems do NOT double-apply (computeWoundMaluses reads unit.status.wounds; the
+// legacy woundedPerma reads unit.status.wounded_perma — disjoint fields). N=40 magnitude
+// probe (dedicated wound scenario, anti-pattern #14) is also a follow-up.
+
+'use strict';
+
+// SPEC §2: 4 locations cover the canonical stat set {AP, defense, attack, mobility}.
+const LOCATIONS = ['testa', 'torso', 'arti_anteriori', 'arti_posteriori'];
+
+// SPEC §3: severity tiers.
+const SEVERITIES = ['lieve', 'media', 'grave'];
+
+// SPEC §9: death-spiral guard — cap total wounds + 1 grave per location.
+const MAX_WOUNDS = 3;
+
+// SPEC §4: random-weighted location. torso heaviest (big target), testa lightest
+// (hard/critical hit). Authoritative table mirrored in
+// data/core/balance/damage_curves.yaml (wound_location_weights); kept here as the
+// in-code default / fallback.
+const DEFAULT_LOCATION_WEIGHTS = Object.freeze({
+  torso: 40,
+  arti_anteriori: 25,
+  arti_posteriori: 25,
+  testa: 10,
+});
+
+// Base location -> primary stat. `testa` is special (graduato, see woundEffect).
+const LOCATION_STAT = Object.freeze({
+  testa: 'accuracy',
+  torso: 'defense_mod',
+  arti_anteriori: 'attack_mod',
+  arti_posteriori: 'mobility',
+});
+
+// SPEC §3 + §8.1: magnitudo -1 / -1 / -2 (lieve/media/grave).
+const SEVERITY_MALUS = Object.freeze({ lieve: -1, media: -1, grave: -2 });
+
+// Stats that computeWoundMaluses aggregates (one delta per canonical stat + accuracy).
+const MALUS_STATS = ['attack_mod', 'defense_mod', 'ap', 'mobility', 'accuracy'];
+
+/**
+ * Pure mapping location + severity -> { stat, malus }.
+ *
+ * SPEC §8.4 testa graduato: lieve/media penalize `accuracy` (-mira to-hit); only a
+ * `grave` head wound costs -1 AP (NOT -2 — a -2 AP on a 2-AP budget would be unusable).
+ *
+ * @throws if location or severity is unknown (no silent wrong stat).
+ */
+function woundEffect(location, severity) {
+  if (!LOCATIONS.includes(location)) {
+    throw new Error(`woundSystem.woundEffect: invalid location "${location}"`);
+  }
+  if (!SEVERITIES.includes(severity)) {
+    throw new Error(`woundSystem.woundEffect: invalid severity "${severity}"`);
+  }
+  if (location === 'testa' && severity === 'grave') {
+    return { stat: 'ap', malus: -1 };
+  }
+  return { stat: LOCATION_STAT[location], malus: SEVERITY_MALUS[severity] };
+}
+
+function ensureWounds(unit) {
+  if (!unit.status || typeof unit.status !== 'object') unit.status = {};
+  if (!Array.isArray(unit.status.wounds)) unit.status.wounds = [];
+  return unit.status.wounds;
+}
+
+function currentWoundCount(unit) {
+  return unit && unit.status && Array.isArray(unit.status.wounds) ? unit.status.wounds.length : 0;
+}
+
+/**
+ * Apply a localized wound. Mutates unit.status.wounds (does NOT touch hp/max_hp).
+ *
+ * Caps (SPEC §9): at most MAX_WOUNDS total, at most 1 `grave` per location.
+ *
+ * @returns {{ applied: boolean, wound: object|null, total: number }}
+ */
+function applyWound(unit, location, severity, _opts = {}) {
+  if (!unit || typeof unit !== 'object' || !unit.id) {
+    return { applied: false, wound: null, total: 0 };
+  }
+  if (!LOCATIONS.includes(location) || !SEVERITIES.includes(severity)) {
+    return { applied: false, wound: null, total: currentWoundCount(unit) };
+  }
+  const wounds = ensureWounds(unit);
+  if (wounds.length >= MAX_WOUNDS) {
+    return { applied: false, wound: null, total: wounds.length };
+  }
+  if (
+    severity === 'grave' &&
+    wounds.some((w) => w && w.location === location && w.severity === 'grave')
+  ) {
+    return { applied: false, wound: null, total: wounds.length };
+  }
+  const { stat, malus } = woundEffect(location, severity);
+  const wound = { location, severity, stat, malus };
+  wounds.push(wound);
+  return { applied: true, wound, total: wounds.length };
+}
+
+/**
+ * Read-path (SPEC §6). Sums wound maluses by stat. Returns a zeroed object when no
+ * wounds. Generalizes the old computeWoundedPermaAttackPenalty (attack-only).
+ *
+ * @returns {{ attack_mod, defense_mod, ap, mobility, accuracy }}
+ */
+function computeWoundMaluses(unit) {
+  const out = { attack_mod: 0, defense_mod: 0, ap: 0, mobility: 0, accuracy: 0 };
+  const wounds = unit && unit.status && Array.isArray(unit.status.wounds) ? unit.status.wounds : [];
+  for (const w of wounds) {
+    if (w && typeof w.stat === 'string' && Object.prototype.hasOwnProperty.call(out, w.stat)) {
+      out[w.stat] += Number(w.malus) || 0;
+    }
+  }
+  return out;
+}
+
+/** Empty cross-encounter map { [unit_id]: Array<grave wound> }. */
+function initSessionMap() {
+  return {};
+}
+
+/**
+ * Serialize a unit's `grave` wounds into the session map (cross-encounter scar).
+ * lieve/media are encounter-scoped and intentionally NOT persisted (SPEC §3/§5).
+ *
+ * @returns {number} count of grave wounds persisted
+ */
+function persistGraveWounds(unit, sessionMap) {
+  if (!unit || typeof unit !== 'object' || !unit.id) return 0;
+  if (!sessionMap || typeof sessionMap !== 'object') return 0;
+  const wounds = unit.status && Array.isArray(unit.status.wounds) ? unit.status.wounds : [];
+  const grave = wounds.filter((w) => w && w.severity === 'grave').map((w) => ({ ...w }));
+  sessionMap[unit.id] = grave;
+  return grave.length;
+}
+
+/**
+ * Re-apply persisted grave wounds at encounter start. Idempotent: skips a grave wound
+ * the unit already carries at that location (no double-add).
+ *
+ * @returns {{ restored: number }}
+ */
+function restoreOnEncounterStart(unit, sessionMap) {
+  if (!unit || typeof unit !== 'object' || !unit.id) return { restored: 0 };
+  if (!sessionMap || typeof sessionMap !== 'object') return { restored: 0 };
+  const persisted = Array.isArray(sessionMap[unit.id]) ? sessionMap[unit.id] : [];
+  const wounds = ensureWounds(unit);
+  let restored = 0;
+  for (const w of persisted) {
+    if (!w || w.severity !== 'grave') continue;
+    const exists = wounds.some((x) => x.location === w.location && x.severity === 'grave');
+    if (exists) continue;
+    wounds.push({ ...w });
+    restored += 1;
+  }
+  return { restored };
+}
+
+/**
+ * Heal encounter-scoped wounds (lieve/media) at encounter end; keep grave scars.
+ *
+ * @returns {number} count removed
+ */
+function clearEncounterWounds(unit) {
+  if (!unit || !unit.status || !Array.isArray(unit.status.wounds)) return 0;
+  const before = unit.status.wounds.length;
+  unit.status.wounds = unit.status.wounds.filter((w) => w && w.severity === 'grave');
+  return before - unit.status.wounds.length;
+}
+
+/** Wipe all persisted scars (e.g., on full heal / new playthrough). */
+function clearSession(sessionMap) {
+  if (!sessionMap || typeof sessionMap !== 'object') return 0;
+  const keys = Object.keys(sessionMap);
+  for (const k of keys) delete sessionMap[k];
+  return keys.length;
+}
+
+/**
+ * Pick a location from a weight map given a uniform roll in [0, 1). Iterates the weight
+ * map's own key order (insertion order) so callers control the cumulative layout.
+ * Deterministic — caller injects the roll (no Math.random here, for testability).
+ */
+function pickWeightedLocation(weights, roll01) {
+  const map = weights && typeof weights === 'object' ? weights : DEFAULT_LOCATION_WEIGHTS;
+  const keys = Object.keys(map).filter((k) => Number(map[k]) > 0);
+  const total = keys.reduce((s, k) => s + Number(map[k]), 0);
+  if (total <= 0) return LOCATIONS[0];
+  let r = Math.max(0, Math.min(0.9999999, Number(roll01) || 0)) * total;
+  for (const k of keys) {
+    const w = Number(map[k]);
+    if (r < w) return k;
+    r -= w;
+  }
+  return keys[keys.length - 1];
+}
+
+module.exports = {
+  LOCATIONS,
+  SEVERITIES,
+  MAX_WOUNDS,
+  DEFAULT_LOCATION_WEIGHTS,
+  LOCATION_STAT,
+  SEVERITY_MALUS,
+  MALUS_STATS,
+  woundEffect,
+  applyWound,
+  computeWoundMaluses,
+  initSessionMap,
+  persistGraveWounds,
+  restoreOnEncounterStart,
+  clearEncounterWounds,
+  clearSession,
+  pickWeightedLocation,
+};

--- a/data/core/balance/damage_curves.yaml
+++ b/data/core/balance/damage_curves.yaml
@@ -269,6 +269,20 @@ scenario_overrides:
     enemy_damage_multiplier_override: 2.1
     rationale: '3A iter2 enemy_damage 1.8->2.1 (replace class). edm 2.2 N=40 WR 27.5% OOB-low (-2.5pp below floor). Slope ~8pp/0.1edm: 2.1 expect WR ~33-37% mid-band [30-50%]. iter1 enemy_count -1 rejected. PENDING N=40 ratify.'
 
+# ─── Wound location weights (OD-058 D2) ───────────────────────────────
+# SPEC-D2 §4: when a wound triggers (critico/KO), the body location is chosen
+# random-weighted. torso heaviest (large target), testa lightest (hard/critical hit).
+# Consumed by apps/backend/services/combat/woundSystem.js — DEFAULT_LOCATION_WEIGHTS
+# mirrors this table (drift-guarded by tests/scripts/damageCurvesIntegrity.test.js);
+# pickWeightedLocation iterates these in declared order.
+# Magnitudo per tier (lieve/media/grave = -1/-1/-2; testa-grave = -1 AP) + the
+# critico/KO trigger live in woundSystem.js. N=40 magnitude tuning = OD-058 D2 follow-up.
+wound_location_weights:
+  torso: 40
+  arti_anteriori: 25
+  arti_posteriori: 25
+  testa: 10
+
 # ─── Validation rules ─────────────────────────────────────────────────
 
 validation:

--- a/tests/scripts/damageCurvesIntegrity.test.js
+++ b/tests/scripts/damageCurvesIntegrity.test.js
@@ -140,3 +140,16 @@ test('player_classes resistance_archetype values ∈ known archetypes', () => {
     );
   }
 });
+
+test('wound_location_weights (OD-058 D2) present + matches woundSystem.DEFAULT_LOCATION_WEIGHTS', () => {
+  const data = loadCurves();
+  const woundSystem = require(
+    path.join(REPO_ROOT, 'apps', 'backend', 'services', 'combat', 'woundSystem'),
+  );
+  const w = data.wound_location_weights;
+  assert.ok(w && typeof w === 'object', 'missing wound_location_weights section');
+  // SPEC-D2 §4: torso heaviest (large target), testa lightest (hard/critical hit).
+  assert.ok(w.torso > w.testa, 'torso weight must exceed testa');
+  // Drift guard: YAML data-of-record must equal the in-code default/fallback.
+  assert.deepEqual(w, woundSystem.DEFAULT_LOCATION_WEIGHTS);
+});

--- a/tests/services/statusModifiers.test.js
+++ b/tests/services/statusModifiers.test.js
@@ -175,6 +175,32 @@ test('Action 5a: wounded_perma absent → no penalty + active=false', () => {
   assert.equal(r.active, false);
 });
 
+test('OD-058 D2: yields to woundSystem when unit.status.wounds present (double-apply guard)', () => {
+  // When the new location-based woundSystem carries wounds, the legacy wounded_perma
+  // attack penalty must yield (return 0) so attack_mod is NOT penalized by BOTH systems.
+  const unit = {
+    id: 'a',
+    status: {
+      wounded_perma: { hp_penalty: 3, stacks: 3, severity: 'severe' },
+      wounds: [{ location: 'arti_anteriori', severity: 'grave', stat: 'attack_mod', malus: -2 }],
+    },
+  };
+  const r = computeWoundedPermaAttackPenalty(unit);
+  assert.equal(r.penalty, 0);
+  assert.equal(r.active, false);
+  assert.equal(r.superseded, true);
+});
+
+test('OD-058 D2: legacy wounded_perma still fires when no woundSystem wounds (empty array)', () => {
+  const unit = {
+    id: 'a',
+    status: { wounded_perma: { hp_penalty: 2, stacks: 2, severity: 'medium' }, wounds: [] },
+  };
+  const r = computeWoundedPermaAttackPenalty(unit);
+  assert.equal(r.penalty, -1);
+  assert.equal(r.active, true);
+});
+
 test('Action 5a: computeStatusModifiers wires wounded_perma medium into attackDelta', () => {
   const actor = {
     id: 'a',

--- a/tests/services/woundSystem.test.js
+++ b/tests/services/woundSystem.test.js
@@ -1,0 +1,239 @@
+// OD-058 D2 (2026-06-01) — wound location system tests.
+//
+// Source: vault SPEC-D2-wound-location-system-2026-05-26 (ratify master-dd 2026-06-01).
+// Module: apps/backend/services/combat/woundSystem.js
+// Supersedes woundedPerma HP-penalty + statusModifiers severity->attack-only with a
+// hit-location -> stat-malus model. 4 fixed locations cover AP/def/atk/mobility,
+// 3 severity tiers (lieve/media/grave), grave persists cross-encounter.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  LOCATIONS,
+  SEVERITIES,
+  MAX_WOUNDS,
+  DEFAULT_LOCATION_WEIGHTS,
+  woundEffect,
+  applyWound,
+  computeWoundMaluses,
+  initSessionMap,
+  persistGraveWounds,
+  restoreOnEncounterStart,
+  clearEncounterWounds,
+  clearSession,
+  pickWeightedLocation,
+} = require('../../apps/backend/services/combat/woundSystem');
+
+// ── woundEffect: location -> stat mapping (SPEC §2 + §8.4 testa graduato) ──
+
+test('woundEffect: torso -> defense_mod (-1 lieve, -2 grave)', () => {
+  assert.deepEqual(woundEffect('torso', 'lieve'), { stat: 'defense_mod', malus: -1 });
+  assert.deepEqual(woundEffect('torso', 'media'), { stat: 'defense_mod', malus: -1 });
+  assert.deepEqual(woundEffect('torso', 'grave'), { stat: 'defense_mod', malus: -2 });
+});
+
+test('woundEffect: arti_anteriori -> attack_mod', () => {
+  assert.deepEqual(woundEffect('arti_anteriori', 'lieve'), { stat: 'attack_mod', malus: -1 });
+  assert.deepEqual(woundEffect('arti_anteriori', 'grave'), { stat: 'attack_mod', malus: -2 });
+});
+
+test('woundEffect: arti_posteriori -> mobility', () => {
+  assert.deepEqual(woundEffect('arti_posteriori', 'lieve'), { stat: 'mobility', malus: -1 });
+  assert.deepEqual(woundEffect('arti_posteriori', 'grave'), { stat: 'mobility', malus: -2 });
+});
+
+test('woundEffect: testa graduato — lieve/media = accuracy, grave = -1 AP (NON -2)', () => {
+  // SPEC §8.4: testa NON -1 AP fisso; graduato: lieve/media = -mira (accuracy),
+  // grave = -1 AP (copre AP solo al tier alto, -2 AP romperebbe il budget 2).
+  assert.deepEqual(woundEffect('testa', 'lieve'), { stat: 'accuracy', malus: -1 });
+  assert.deepEqual(woundEffect('testa', 'media'), { stat: 'accuracy', malus: -1 });
+  assert.deepEqual(woundEffect('testa', 'grave'), { stat: 'ap', malus: -1 });
+});
+
+test('woundEffect: 4 locations cover the canonical stat set {ap, defense, attack, mobility}', () => {
+  const graveStats = LOCATIONS.map((loc) => woundEffect(loc, 'grave').stat);
+  for (const s of ['ap', 'defense_mod', 'attack_mod', 'mobility']) {
+    assert.ok(graveStats.includes(s), `grave stat coverage missing: ${s}`);
+  }
+});
+
+test('woundEffect: invalid location/severity throws (no silent wrong stat)', () => {
+  assert.throws(() => woundEffect('coda', 'lieve'));
+  assert.throws(() => woundEffect('torso', 'mortale'));
+});
+
+// ── applyWound: mutate unit.status.wounds ──
+
+test('applyWound: pushes {location, severity, stat, malus} to unit.status.wounds', () => {
+  const unit = { id: 'skiv', status: {} };
+  const r = applyWound(unit, 'torso', 'lieve');
+  assert.equal(r.applied, true);
+  assert.deepEqual(r.wound, {
+    location: 'torso',
+    severity: 'lieve',
+    stat: 'defense_mod',
+    malus: -1,
+  });
+  assert.equal(unit.status.wounds.length, 1);
+  assert.deepEqual(unit.status.wounds[0], r.wound);
+});
+
+test('applyWound: does NOT touch hp/max_hp (HP intact — fragilita via -defense, SPEC §7)', () => {
+  const unit = { id: 'skiv', hp: 14, max_hp: 14, status: {} };
+  applyWound(unit, 'torso', 'grave');
+  assert.equal(unit.hp, 14);
+  assert.equal(unit.max_hp, 14);
+});
+
+test('applyWound: multiple distinct wounds accumulate', () => {
+  const unit = { id: 'skiv', status: {} };
+  applyWound(unit, 'torso', 'lieve');
+  applyWound(unit, 'arti_anteriori', 'media');
+  assert.equal(unit.status.wounds.length, 2);
+});
+
+test('applyWound: cap MAX_WOUNDS total (death-spiral guard, SPEC §9)', () => {
+  const unit = { id: 'skiv', status: {} };
+  applyWound(unit, 'torso', 'lieve');
+  applyWound(unit, 'arti_anteriori', 'lieve');
+  applyWound(unit, 'arti_posteriori', 'lieve');
+  const over = applyWound(unit, 'testa', 'lieve');
+  assert.equal(MAX_WOUNDS, 3);
+  assert.equal(over.applied, false);
+  assert.equal(unit.status.wounds.length, 3);
+});
+
+test('applyWound: max 1 grave per location (SPEC §9)', () => {
+  const unit = { id: 'skiv', status: {} };
+  const a = applyWound(unit, 'torso', 'grave');
+  const b = applyWound(unit, 'torso', 'grave');
+  assert.equal(a.applied, true);
+  assert.equal(b.applied, false);
+  assert.equal(
+    unit.status.wounds.filter((w) => w.location === 'torso' && w.severity === 'grave').length,
+    1,
+  );
+});
+
+test('applyWound: defensive — bad unit returns no-op', () => {
+  assert.equal(applyWound(null, 'torso', 'lieve').applied, false);
+  assert.equal(applyWound({}, 'torso', 'lieve').applied, false);
+  assert.equal(applyWound({ id: 'x', status: {} }, 'bad', 'lieve').applied, false);
+});
+
+// ── computeWoundMaluses: read-path (sums by stat, SPEC §6) ──
+
+test('computeWoundMaluses: zero deltas when no wounds', () => {
+  assert.deepEqual(computeWoundMaluses({ id: 'x', status: {} }), {
+    attack_mod: 0,
+    defense_mod: 0,
+    ap: 0,
+    mobility: 0,
+    accuracy: 0,
+  });
+});
+
+test('computeWoundMaluses: sums maluses across wounds by stat', () => {
+  const unit = { id: 'skiv', status: {} };
+  applyWound(unit, 'torso', 'grave'); // defense_mod -2
+  applyWound(unit, 'arti_anteriori', 'lieve'); // attack_mod -1
+  const m = computeWoundMaluses(unit);
+  assert.equal(m.defense_mod, -2);
+  assert.equal(m.attack_mod, -1);
+  assert.equal(m.ap, 0);
+  assert.equal(m.mobility, 0);
+});
+
+test('computeWoundMaluses: testa grave contributes ap -1, two arti stack attack -2', () => {
+  const unit = {
+    id: 'skiv',
+    status: {
+      wounds: [
+        { location: 'testa', severity: 'grave', stat: 'ap', malus: -1 },
+        { location: 'arti_anteriori', severity: 'lieve', stat: 'attack_mod', malus: -1 },
+        { location: 'arti_anteriori', severity: 'media', stat: 'attack_mod', malus: -1 },
+      ],
+    },
+  };
+  const m = computeWoundMaluses(unit);
+  assert.equal(m.ap, -1);
+  assert.equal(m.attack_mod, -2);
+});
+
+// ── cross-encounter persistence (grave only, SPEC §3 + §5) ──
+
+test('persistGraveWounds: serializes only grave wounds to sessionMap', () => {
+  const map = initSessionMap();
+  const unit = { id: 'skiv', status: {} };
+  applyWound(unit, 'torso', 'grave');
+  applyWound(unit, 'arti_anteriori', 'lieve'); // encounter-scoped, NOT persisted
+  const n = persistGraveWounds(unit, map);
+  assert.equal(n, 1);
+  assert.equal(map.skiv.length, 1);
+  assert.equal(map.skiv[0].severity, 'grave');
+});
+
+test('clearEncounterWounds: removes lieve/media, keeps grave', () => {
+  const unit = { id: 'skiv', status: {} };
+  applyWound(unit, 'torso', 'grave');
+  applyWound(unit, 'arti_anteriori', 'lieve');
+  applyWound(unit, 'arti_posteriori', 'media');
+  const removed = clearEncounterWounds(unit);
+  assert.equal(removed, 2);
+  assert.equal(unit.status.wounds.length, 1);
+  assert.equal(unit.status.wounds[0].severity, 'grave');
+});
+
+test('restoreOnEncounterStart: re-adds persisted grave wounds, idempotent', () => {
+  const map = initSessionMap();
+  const unit = { id: 'skiv', status: {} };
+  applyWound(unit, 'torso', 'grave');
+  persistGraveWounds(unit, map);
+  // new encounter: fresh unit, wounds cleared
+  const fresh = { id: 'skiv', status: {} };
+  const r1 = restoreOnEncounterStart(fresh, map);
+  assert.equal(r1.restored, 1);
+  assert.equal(fresh.status.wounds.length, 1);
+  assert.equal(fresh.status.wounds[0].location, 'torso');
+  // idempotent: second restore no double-add
+  const r2 = restoreOnEncounterStart(fresh, map);
+  assert.equal(r2.restored, 0);
+  assert.equal(fresh.status.wounds.length, 1);
+});
+
+test('clearSession: wipes all persisted entries', () => {
+  const map = initSessionMap();
+  const unit = { id: 'skiv', status: {} };
+  applyWound(unit, 'torso', 'grave');
+  persistGraveWounds(unit, map);
+  assert.equal(clearSession(map), 1);
+  assert.deepEqual(map, {});
+});
+
+// ── weighted location roll (SPEC §4: torso heaviest, testa lightest) ──
+
+test('DEFAULT_LOCATION_WEIGHTS: torso heaviest, testa lightest', () => {
+  assert.ok(DEFAULT_LOCATION_WEIGHTS.torso > DEFAULT_LOCATION_WEIGHTS.testa);
+  for (const loc of LOCATIONS) {
+    assert.ok(DEFAULT_LOCATION_WEIGHTS[loc] > 0, `weight missing for ${loc}`);
+  }
+});
+
+test('pickWeightedLocation: deterministic with injected roll01', () => {
+  const w = { torso: 40, arti_anteriori: 25, arti_posteriori: 25, testa: 10 };
+  // cumulative: torso [0,0.40) arti_ant [0.40,0.65) arti_post [0.65,0.90) testa [0.90,1)
+  assert.equal(pickWeightedLocation(w, 0.0), 'torso');
+  assert.equal(pickWeightedLocation(w, 0.39), 'torso');
+  assert.equal(pickWeightedLocation(w, 0.4), 'arti_anteriori');
+  assert.equal(pickWeightedLocation(w, 0.64), 'arti_anteriori');
+  assert.equal(pickWeightedLocation(w, 0.65), 'arti_posteriori');
+  assert.equal(pickWeightedLocation(w, 0.95), 'testa');
+});
+
+test('SEVERITIES + LOCATIONS canonical enums', () => {
+  assert.deepEqual(SEVERITIES, ['lieve', 'media', 'grave']);
+  assert.deepEqual(LOCATIONS, ['testa', 'torso', 'arti_anteriori', 'arti_posteriori']);
+});


### PR DESCRIPTION
## OD-058 D2 — wound location system engine (staged cutover, part 1/2)

Tracker: #2531. Spec: vault `SPEC-D2-wound-location-system-2026-05-26` (ratified master-dd 2026-06-01). Scope this PR (per build-handoff decision): **engine + read-path + data table + double-apply guard**. Live cutover + N=40 = follow-up PR.

### What ships
- **`apps/backend/services/combat/woundSystem.js`** — hit-location → stat-malus model superseding the two orphan models (woundedPerma HP-penalty + statusModifiers severity→attack-only):
  - 4 fixed locations cover the canonical stat set: `testa`→mira/accuracy (`-1 AP` only at grave), `torso`→`defense_mod`, `arti_anteriori`→`attack_mod`, `arti_posteriori`→`mobility`.
  - 3 tiers: lieve/media/grave = `-1`/`-1`/`-2` (testa-grave = `-1 AP`, SPEC §8.4 — `-2` would break the 2-AP budget).
  - `grave` persists cross-encounter (scar); lieve/media heal at encounter end.
  - Random-weighted location (`pickWeightedLocation`, injectable roll for testability).
  - **HP left intact** (SPEC §7): fragility now via `-defense`, not raw HP cuts.
  - Death-spiral guard (SPEC §9): cap 3 total wounds + 1 grave per location.
- **`data/core/balance/damage_curves.yaml`** → `wound_location_weights` table (torso 40 / arti 25+25 / testa 10), drift-guarded against the in-code default.
- **`statusModifiers.js`** double-apply guard — `computeWoundedPermaAttackPenalty` yields when `unit.status.wounds` is set, so the legacy + new systems never both penalize attack. **Zero current behavior change** (nothing populates `wounds[]` until the cutover PR).

### Deferred to follow-up (staged cutover)
- Live wire: crit/KO trigger calling `applyWound`, apply `computeWoundMaluses` to resolver stats, deprecate woundedPerma HP-penalty + route cross-encounter persistence through grave wounds (touches `session.js:1790/3146`).
- **N=40 magnitude probe** on a dedicated wound scenario (current scenarios don't field wounds — anti-pattern #14).

### Verify
- TDD red→green for every unit (watched fail first). `woundSystem` 22 + statusModifiers guard 2 + damage_curves drift guard 1.
- **Full services suite: 1369/1369 green** (no regression). `npm run schema:lint` clean.

### Rollback
`git revert` the squash — new module is inert (no live caller) + guard is dormant until `wounds[]` populated, so revert is behavior-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)