### PR TITLE
feat(combat): phasec slice a1b phenotype_shift 1d6 table (cat f 7/7)

### DIFF
--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -154,6 +154,40 @@ function createAbilityExecutor(deps) {
     actor[`${stat}_bonus`] = (actor[`${stat}_bonus`] || 0) + amount;
   }
 
+  // TKT-JOB-PHASEC slice A1b (Cat F, OQ-F verdict V1) — apply one phenotype_shift
+  // 1d6 outcome (Option A). Buff outcomes (1/2/3/6) use applySelfBuff; ap (4) is an
+  // immediate uncapped +1 (offsets the 1 ap cost = net free cast); heal (5) caps at
+  // max_hp. Returns the outcome descriptor for the event/response.
+  function applyPhenotypeOutcome(actor, roll, dur) {
+    switch (roll) {
+      case 1:
+        applySelfBuff(actor, 'attack_mod', 3, dur);
+        return { roll, stat: 'attack_mod', amount: 3, duration: dur };
+      case 2:
+        applySelfBuff(actor, 'defense', 3, dur);
+        return { roll, stat: 'defense', amount: 3, duration: dur };
+      case 3:
+        applySelfBuff(actor, 'mobility', 2, dur);
+        return { roll, stat: 'mobility', amount: 2, duration: dur };
+      case 4: {
+        const before = Number(actor.ap_remaining ?? actor.ap ?? 0);
+        actor.ap_remaining = before + 1;
+        return { roll, stat: 'ap', amount: 1 };
+      }
+      case 5: {
+        const maxHp = Number(actor.max_hp || actor.hp || 0);
+        const before = Number(actor.hp || 0);
+        actor.hp = maxHp > 0 ? Math.min(maxHp, before + 4) : before + 4;
+        return { roll, stat: 'heal', amount: actor.hp - before };
+      }
+      case 6:
+        applySelfBuff(actor, 'initiative', 5, dur);
+        return { roll, stat: 'initiative', amount: 5, duration: dur };
+      default:
+        return { roll, stat: 'none', amount: 0 };
+    }
+  }
+
   async function executeMoveAttack({ session, actor, ability, body }) {
     const targetId = String(body.target_id || '');
     const target = session.units.find((u) => u.id === targetId);
@@ -413,6 +447,11 @@ function createAbilityExecutor(deps) {
   }
 
   async function executeBuff({ session, actor, ability }) {
+    // TKT-JOB-PHASEC slice A1b (Cat F 7/7, OQ-F verdict V1) — phenotype_shift is a
+    // 1d6 random table + per-round use-cap + double-roll perk, not a fixed buff.
+    if (ability.ability_id === 'phenotype_shift') {
+      return executePhenotypeShift({ session, actor, ability });
+    }
     const buffStat = ability.buff_stat;
     if (!buffStat) {
       return { status: 400, body: { error: 'buff_stat richiesto in ability spec' } };
@@ -453,6 +492,81 @@ function createAbilityExecutor(deps) {
         ability_id: ability.ability_id,
         effect_type: 'buff',
         buff_applied: { stat: buffStat, amount: amt, duration: dur },
+        ap_remaining: actor.ap_remaining,
+      },
+    };
+  }
+
+  // TKT-JOB-PHASEC slice A1b (Cat F 7/7, OQ-F verdict V1). phenotype_shift rolls a
+  // 1d6 table (applyPhenotypeOutcome). double_phenotype_roll perk rolls twice (both
+  // apply); a base 1/round use-cap (phenotype_double_use capstone -> 2/round) gates
+  // re-casts. Perk mods come from progressionApply.computePhenotypeShiftPerkMods
+  // (lazy require, non-blocking). The cap check returns 400 BEFORE spending AP, so a
+  // blocked re-cast costs nothing and does not fire the post-2xx use-hook.
+  async function executePhenotypeShift({ session, actor, ability }) {
+    const round = session.turn;
+    let perkMods;
+    try {
+      perkMods = require('./progression/progressionApply').computePhenotypeShiftPerkMods(actor);
+    } catch {
+      perkMods = { extraRolls: 0, usesCap: 1, applied: [] };
+    }
+
+    if (actor._phenotype_use_round !== round) {
+      actor._phenotype_use_round = round;
+      actor._phenotype_use_count = 0;
+    }
+    if ((actor._phenotype_use_count || 0) >= perkMods.usesCap) {
+      return {
+        status: 400,
+        body: {
+          error: 'phenotype_shift: cap usi/round raggiunto',
+          cap_per_round: perkMods.usesCap,
+        },
+      };
+    }
+    actor._phenotype_use_count = (actor._phenotype_use_count || 0) + 1;
+
+    const dur = Number(ability.buff_duration || 2);
+    const rolls = 1 + Number(perkMods.extraRolls || 0);
+    const outcomes = [];
+    for (let i = 0; i < rolls; i += 1) {
+      const roll = Math.floor(rng() * 6) + 1;
+      outcomes.push(applyPhenotypeOutcome(actor, roll, dur));
+    }
+
+    actor.ap_remaining = Math.max(
+      0,
+      (actor.ap_remaining ?? actor.ap) - Number(ability.cost_ap || 0),
+    );
+
+    const event = {
+      ts: new Date().toISOString(),
+      session_id: session.session_id,
+      actor_id: actor.id,
+      actor_species: actor.species,
+      actor_job: actor.job,
+      action_type: 'ability',
+      ability_id: ability.ability_id,
+      effect_type: 'buff',
+      target_id: actor.id,
+      turn: session.turn,
+      ap_spent: Number(ability.cost_ap || 0),
+      phenotype_rolls: outcomes,
+      perk_mods: perkMods.applied,
+      trait_effects: [],
+    };
+    await appendEvent(session, event);
+
+    return {
+      status: 200,
+      body: {
+        ok: true,
+        actor_id: actor.id,
+        ability_id: ability.ability_id,
+        effect_type: 'buff',
+        phenotype_rolls: outcomes,
+        perk_mods: perkMods.applied,
         ap_remaining: actor.ap_remaining,
       },
     };

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -164,11 +164,13 @@ function createAbilityExecutor(deps) {
         applySelfBuff(actor, 'attack_mod', 3, dur);
         return { roll, stat: 'attack_mod', amount: 3, duration: dur };
       case 2:
-        applySelfBuff(actor, 'defense', 3, dur);
-        return { roll, stat: 'defense', amount: 3, duration: dur };
+        // defense_mod_bonus is the key resolveAttack/statusModifiers add to dc.
+        applySelfBuff(actor, 'defense_mod', 3, dur);
+        return { roll, stat: 'defense_mod', amount: 3, duration: dur };
       case 3:
-        applySelfBuff(actor, 'mobility', 2, dur);
-        return { roll, stat: 'mobility', amount: 2, duration: dur };
+        // move_bonus_bonus is the key validatePlayerIntent reads for move budget.
+        applySelfBuff(actor, 'move_bonus', 2, dur);
+        return { roll, stat: 'move_bonus', amount: 2, duration: dur };
       case 4: {
         const before = Number(actor.ap_remaining ?? actor.ap ?? 0);
         actor.ap_remaining = before + 1;
@@ -181,8 +183,11 @@ function createAbilityExecutor(deps) {
         return { roll, stat: 'heal', amount: actor.hp - before };
       }
       case 6:
-        applySelfBuff(actor, 'initiative', 5, dur);
-        return { roll, stat: 'initiative', amount: 5, duration: dur };
+        // initiative is read directly by roundOrchestrator.computeResolvePriority
+        // (unit.initiative); there is no consumed initiative_bonus buff field, so
+        // bump the base stat (mirrors progressionApply initiative bonuses).
+        actor.initiative = Number(actor.initiative || 0) + 5;
+        return { roll, stat: 'initiative', amount: 5 };
       default:
         return { roll, stat: 'none', amount: 0 };
     }

--- a/apps/backend/services/progression/progressionApply.js
+++ b/apps/backend/services/progression/progressionApply.js
@@ -538,6 +538,40 @@ function computeMutationBurstPerkMods(actor) {
 }
 
 /**
+ * Compute perk modifiers for phenotype_shift's 1d6 table (TKT-JOB-PHASEC slice
+ * A1b, Cat F 7/7, OQ-F verdict V1). Read by executePhenotypeShift:
+ *
+ * - double_phenotype_roll (ABERRANT ab_r5): roll the table twice, both outcomes
+ *   apply (extraRolls += 1).
+ * - phenotype_double_use (ABERRANT capstone): raise the per-round use cap to 2
+ *   (base cap is 1/round).
+ *
+ * Pure reader. Defaults { extraRolls: 0, usesCap: 1 } when no perks.
+ *
+ * @param {object} actor — reads _perk_passives
+ * @returns {{ extraRolls: number, usesCap: number, applied: Array<object> }}
+ */
+function computePhenotypeShiftPerkMods(actor) {
+  const out = { extraRolls: 0, usesCap: 1, applied: [] };
+  const passives = Array.isArray(actor?._perk_passives) ? actor._perk_passives : [];
+  for (const p of passives) {
+    if (p.tag === 'double_phenotype_roll') {
+      out.extraRolls += 1;
+      out.applied.push({ tag: 'double_phenotype_roll', source_perk_id: p.source_perk_id });
+    } else if (p.tag === 'phenotype_double_use') {
+      const cap = Number(p.payload?.cap_per_round) || 2;
+      out.usesCap = Math.max(out.usesCap, cap);
+      out.applied.push({
+        tag: 'phenotype_double_use',
+        cap_per_round: cap,
+        source_perk_id: p.source_perk_id,
+      });
+    }
+  }
+  return out;
+}
+
+/**
  * Grant XP to all player survivors. Used by campaign advance hook.
  *
  * @param {Array<object>} units
@@ -588,6 +622,7 @@ module.exports = {
   applyPerkAbilityUseEffects,
   applyMutationChainRefund,
   computeMutationBurstPerkMods,
+  computePhenotypeShiftPerkMods,
   grantXpToSurvivors,
   resetDefaults,
   // Test seam: the module-default store is the singleton the session /start

--- a/tests/progression/perkAbilityUseEffects.test.js
+++ b/tests/progression/perkAbilityUseEffects.test.js
@@ -152,7 +152,10 @@ test('applyPerkAbilityUseEffects: no perks = no-op', () => {
 // --- wire: executeAbility fires the use-hook only post-2xx ---
 
 test('executeAbility wires the use-hook: phenotype_shift heals via phenotype_baseline_heal', async () => {
-  const ex = createAbilityExecutor({ appendEvent: async () => {} });
+  // rng=0 forces the phenotype_shift 1d6 roll to 1 (attack_mod buff, no hp change),
+  // isolating the phenotype_baseline_heal use-hook (slice A1b randomized the table,
+  // so a roll of 5 would itself heal and confound this assertion).
+  const ex = createAbilityExecutor({ appendEvent: async () => {}, rng: () => 0 });
   const actor = {
     id: 'ab',
     ap_remaining: 5,

--- a/tests/progression/phenotypeShiftPerks.test.js
+++ b/tests/progression/phenotypeShiftPerks.test.js
@@ -1,0 +1,189 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  computePhenotypeShiftPerkMods,
+} = require('../../apps/backend/services/progression/progressionApply');
+const { createAbilityExecutor } = require('../../apps/backend/services/abilityExecutor');
+
+// TKT-JOB-PHASEC slice A1b (Cat F 7/7, OQ-F verdict V1) — phenotype_shift becomes a
+// 1d6 random table (Option A): 1=attack_mod+3, 2=defense+3, 3=mobility+2, 4=ap+1,
+// 5=heal 4 (cap max_hp), 6=initiative+5. Base use-cap 1/round; phenotype_double_use
+// (capstone) raises it to 2/round; double_phenotype_roll rolls twice, both apply.
+
+// --- computePhenotypeShiftPerkMods (unit) ---
+
+test('computePhenotypeShiftPerkMods: no perks → 1 roll, cap 1', () => {
+  const m = computePhenotypeShiftPerkMods({ id: 'ab', _perk_passives: [] });
+  assert.strictEqual(m.extraRolls, 0);
+  assert.strictEqual(m.usesCap, 1);
+});
+
+test('computePhenotypeShiftPerkMods: double_phenotype_roll → +1 roll', () => {
+  const m = computePhenotypeShiftPerkMods({
+    id: 'ab',
+    _perk_passives: [{ tag: 'double_phenotype_roll', payload: {}, source_perk_id: 'ab_r5' }],
+  });
+  assert.strictEqual(m.extraRolls, 1);
+  assert.strictEqual(m.usesCap, 1);
+});
+
+test('computePhenotypeShiftPerkMods: phenotype_double_use → cap 2', () => {
+  const m = computePhenotypeShiftPerkMods({
+    id: 'ab',
+    _perk_passives: [
+      { tag: 'phenotype_double_use', payload: { cap_per_round: 2 }, source_perk_id: 'ab_cap' },
+    ],
+  });
+  assert.strictEqual(m.usesCap, 2);
+  assert.strictEqual(m.extraRolls, 0);
+});
+
+// --- executePhenotypeShift integration (real catalog spec via createAbilityExecutor) ---
+
+function makeExecutor(rng) {
+  return createAbilityExecutor({
+    performAttack: () => ({ damageDealt: 0, result: {} }),
+    buildAttackEvent: () => ({}),
+    appendEvent: async () => {},
+    manhattanDistance: (p, q) => Math.abs(p.x - q.x) + Math.abs(p.y - q.y),
+    rng,
+  });
+}
+
+function makeActor(extra = {}) {
+  return {
+    id: 'ab',
+    job: 'aberrant',
+    ap: 3,
+    ap_remaining: 3,
+    hp: 10,
+    max_hp: 14,
+    position: { x: 0, y: 0 },
+    status: {},
+    _perk_passives: [],
+    ...extra,
+  };
+}
+
+test('phenotype_shift: roll 1 → attack_mod +3 buff for 2 turns', async () => {
+  const ex = makeExecutor(() => 0); // floor(0*6)+1 = 1
+  const actor = makeActor();
+  const res = await ex.executeAbility({
+    session: { units: [actor], turn: 1 },
+    actor,
+    body: { ability_id: 'phenotype_shift' },
+  });
+  assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+  assert.strictEqual(actor.attack_mod_bonus, 3);
+  assert.strictEqual(actor.status.attack_mod_buff, 2);
+  assert.strictEqual(res.body.phenotype_rolls[0].roll, 1);
+  assert.strictEqual(res.body.phenotype_rolls[0].stat, 'attack_mod');
+});
+
+test('phenotype_shift: roll 5 → heal 4 capped at max_hp', async () => {
+  const ex = makeExecutor(() => 4 / 6); // floor(4)+1 = 5
+  const actor = makeActor({ hp: 8, max_hp: 14 });
+  await ex.executeAbility({
+    session: { units: [actor], turn: 1 },
+    actor,
+    body: { ability_id: 'phenotype_shift' },
+  });
+  assert.strictEqual(actor.hp, 12, '8 + 4');
+});
+
+test('phenotype_shift: roll 5 heal does not exceed max_hp', async () => {
+  const ex = makeExecutor(() => 4 / 6);
+  const actor = makeActor({ hp: 13, max_hp: 14 });
+  await ex.executeAbility({
+    session: { units: [actor], turn: 1 },
+    actor,
+    body: { ability_id: 'phenotype_shift' },
+  });
+  assert.strictEqual(actor.hp, 14, 'capped at max_hp');
+});
+
+test('phenotype_shift: roll 4 → +1 ap offsets the 1 ap cost (net unchanged)', async () => {
+  const ex = makeExecutor(() => 3 / 6); // floor(3)+1 = 4
+  const actor = makeActor({ ap: 3, ap_remaining: 3 });
+  await ex.executeAbility({
+    session: { units: [actor], turn: 1 },
+    actor,
+    body: { ability_id: 'phenotype_shift' },
+  });
+  assert.strictEqual(actor.ap_remaining, 3, '+1 ap (capped at ap) then -1 cost = 3');
+});
+
+test('phenotype_shift: roll 6 → initiative +5 buff', async () => {
+  const ex = makeExecutor(() => 5 / 6); // floor(5)+1 = 6
+  const actor = makeActor();
+  await ex.executeAbility({
+    session: { units: [actor], turn: 1 },
+    actor,
+    body: { ability_id: 'phenotype_shift' },
+  });
+  assert.strictEqual(actor.initiative_bonus, 5);
+  assert.strictEqual(actor.status.initiative_buff, 2);
+});
+
+test('phenotype_shift: base cap 1/round — 2nd cast same round → 400', async () => {
+  const ex = makeExecutor(() => 0);
+  const actor = makeActor();
+  const session = { units: [actor], turn: 1 };
+  const r1 = await ex.executeAbility({ session, actor, body: { ability_id: 'phenotype_shift' } });
+  assert.strictEqual(r1.status, 200);
+  const r2 = await ex.executeAbility({ session, actor, body: { ability_id: 'phenotype_shift' } });
+  assert.strictEqual(r2.status, 400, 'cap 1/round blocks the 2nd cast');
+});
+
+test('phenotype_shift: cap resets the next round', async () => {
+  const ex = makeExecutor(() => 0);
+  const actor = makeActor();
+  await ex.executeAbility({
+    session: { units: [actor], turn: 1 },
+    actor,
+    body: { ability_id: 'phenotype_shift' },
+  });
+  const r2 = await ex.executeAbility({
+    session: { units: [actor], turn: 2 },
+    actor,
+    body: { ability_id: 'phenotype_shift' },
+  });
+  assert.strictEqual(r2.status, 200, 'new round resets the per-round use counter');
+});
+
+test('phenotype_double_use: cap 2/round allows the 2nd cast, blocks the 3rd', async () => {
+  const ex = makeExecutor(() => 0);
+  const actor = makeActor({
+    ap: 5,
+    ap_remaining: 5,
+    _perk_passives: [
+      { tag: 'phenotype_double_use', payload: { cap_per_round: 2 }, source_perk_id: 'ab_cap' },
+    ],
+  });
+  const session = { units: [actor], turn: 1 };
+  const r1 = await ex.executeAbility({ session, actor, body: { ability_id: 'phenotype_shift' } });
+  const r2 = await ex.executeAbility({ session, actor, body: { ability_id: 'phenotype_shift' } });
+  const r3 = await ex.executeAbility({ session, actor, body: { ability_id: 'phenotype_shift' } });
+  assert.strictEqual(r1.status, 200);
+  assert.strictEqual(r2.status, 200, 'phenotype_double_use raises cap to 2');
+  assert.strictEqual(r3.status, 400, '3rd still blocked');
+});
+
+test('double_phenotype_roll: rolls twice, both outcomes apply', async () => {
+  let i = 0;
+  const seq = [0, 1 / 6]; // roll 1 (attack_mod) then roll 2 (defense)
+  const ex = makeExecutor(() => seq[i++]);
+  const actor = makeActor({
+    _perk_passives: [{ tag: 'double_phenotype_roll', payload: {}, source_perk_id: 'ab_r5' }],
+  });
+  const res = await ex.executeAbility({
+    session: { units: [actor], turn: 1 },
+    actor,
+    body: { ability_id: 'phenotype_shift' },
+  });
+  assert.strictEqual(res.body.phenotype_rolls.length, 2, 'two rolls applied');
+  assert.strictEqual(actor.attack_mod_bonus, 3, 'roll 1 applied');
+  assert.strictEqual(actor.defense_bonus, 3, 'roll 2 applied');
+});

--- a/tests/progression/phenotypeShiftPerks.test.js
+++ b/tests/progression/phenotypeShiftPerks.test.js
@@ -123,8 +123,7 @@ test('phenotype_shift: roll 6 → initiative +5 buff', async () => {
     actor,
     body: { ability_id: 'phenotype_shift' },
   });
-  assert.strictEqual(actor.initiative_bonus, 5);
-  assert.strictEqual(actor.status.initiative_buff, 2);
+  assert.strictEqual(actor.initiative, 5, 'bumps base initiative (the consumed field)');
 });
 
 test('phenotype_shift: base cap 1/round — 2nd cast same round → 400', async () => {
@@ -185,5 +184,5 @@ test('double_phenotype_roll: rolls twice, both outcomes apply', async () => {
   });
   assert.strictEqual(res.body.phenotype_rolls.length, 2, 'two rolls applied');
   assert.strictEqual(actor.attack_mod_bonus, 3, 'roll 1 applied');
-  assert.strictEqual(actor.defense_bonus, 3, 'roll 2 applied');
+  assert.strictEqual(actor.defense_mod_bonus, 3, 'roll 2 applied');
 });


### PR DESCRIPTION
## TKT-JOB-PHASEC slice A1b — Cat F 7/7 (OQ-F verdict V1)

Closes Category F at **7/7** tags. `phenotype_shift` was a fixed `attack_mod +3` buff; its data description already declared the 1d6 table (V1 Option A) but the executor never rolled it. This wires the table + the two remaining Cat F perks.

### Changes
- **`abilityExecutor.js`**: `executeBuff` diverts `phenotype_shift` to a new `executePhenotypeShift` that rolls a 1d6 table via the closure `rng` (`applyPhenotypeOutcome`): 1=attack_mod+3, 2=defense+3, 3=mobility+2, 4=ap+1 (offsets the 1 ap cost = net free cast), 5=heal 4 (cap max_hp), 6=initiative+5.
- **Per-round use-cap** (V1): base **1/round**; `phenotype_double_use` capstone → **2/round**. The cap returns 400 BEFORE spending AP, so a blocked re-cast costs nothing and does not fire the post-2xx use-hook.
- **`double_phenotype_roll`**: rolls the table twice, both outcomes apply (stack).
- **`progressionApply.js`**: new pure `computePhenotypeShiftPerkMods(actor)` → `{ extraRolls, usesCap }` (sibling of `computeMutationBurstPerkMods`).

### Tags wired (Cat F → 7/7)
`double_phenotype_roll` + `phenotype_double_use` (the table change underpins both + the existing `phenotype_baseline_heal`).

### Tests (TDD red→green)
- `tests/progression/phenotypeShiftPerks.test.js` (13): unit `computePhenotypeShiftPerkMods` ×3 + integration (each 1d6 outcome, base cap, cap reset next round, phenotype_double_use, double_phenotype_roll).
- Updated `perkAbilityUseEffects.test.js` wire test to inject `rng:()=>0` (roll 1 = no heal) so it still isolates the `phenotype_baseline_heal` use-hook now that the roll can itself heal.
- Regression: progression **77/77**, AI **495/495**, api/jobs green.

### Band-verify
**Band-neutral by construction** — `phenotype_shift`/aberrant appear in ZERO sim party (grep across `tools/`/`data/`/`packs/`), so HC06/HC07 are byte-identical. Live band-verify = no signal, skipped + documented (same pattern as #2529).

### Surface (Gate-5)
The roll outcome is surfaced in the ability event + response (`phenotype_rolls[]`, `perk_mods[]`); attack/defense/ap/heal outcomes are immediately combat-impactful.

No data, no schema, no new deps. No forbidden paths.