### PR TITLE
feat(combat): phasec slice b4a symbiont bond redirect (4 tags)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -898,13 +898,35 @@ function createSessionRouter(options = {}) {
           symbiontRedirectResult = symbiontBond.applyBondRedirect(session, target, damageDealt);
           if (symbiontRedirectResult) {
             if (target.hp > 0) killOccurred = false;
-            try {
-              const sgTracker = require('../services/combat/sgTracker');
-              const sym = session.units.find((u) => u.id === symbiontRedirectResult.symbiont_id);
-              if (sym)
-                sgTracker.accumulate(sym, { damage_taken: symbiontRedirectResult.redirected });
-            } catch {
-              /* sgTracker optional */
+            // SG: the targeted partner was already credited the full hit's
+            // damage_taken earlier in performAttack (the redirect is a heal-after-
+            // hit, not a re-hit) — re-crediting the symbiont here would double-count
+            // the redirected portion (Codex #2539 P2). A redirect that consumes the
+            // symbiont's last HP is a legitimate KO (V3 "capped at its HP"); it is a
+            // FRIENDLY unit, so it earns no enemy-kill rewards/pressure (parity with
+            // the companion bondReaction absorbing-ally death) and the round-level
+            // defeat sweep handles the lose-condition. Surface the down for telemetry.
+            if (
+              symbiontRedirectResult.symbiont_killed &&
+              !process.env.IDEA_ENGINE_DISABLE_BOND_LOG &&
+              process.env.NODE_ENV !== 'test'
+            ) {
+              try {
+                // eslint-disable-next-line no-console
+                console.info(
+                  JSON.stringify({
+                    component: 'symbiont-bond',
+                    event: 'symbiont_downed_by_redirect',
+                    session_id: session.session_id || null,
+                    turn: session.turn,
+                    symbiont_id: symbiontRedirectResult.symbiont_id,
+                    target_id: symbiontRedirectResult.target_id,
+                    redirected: symbiontRedirectResult.redirected,
+                  }),
+                );
+              } catch {
+                /* structured log best-effort */
+              }
             }
           }
         } catch {

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -669,6 +669,7 @@ function createSessionRouter(options = {}) {
     let parryResult = null;
     let interceptResult = null;
     let bondReactionResult = null;
+    let symbiontRedirectResult = null;
     let terrainReactionResult = null;
     // M14-A residuo close (TKT-09 2026-04-26): surface positional info
     // (elevation_delta + multiplier) on performAttack return so callers can
@@ -884,6 +885,30 @@ function createSessionRouter(options = {}) {
               killOccurred = false;
             }
           }
+        }
+      }
+      // TKT-JOB-PHASEC slice B4a (OQ-BOND verdict V3) — symbiont bond redirect.
+      // Fires on the residual damage AFTER intercept + companion bond (one absorb
+      // layer per hit: gated on !interceptResult && !bondReactionResult). Moves a
+      // share of the bonded partner's damage to the symbiont (capped at its HP),
+      // restoring the partner; resets killOccurred if the partner survives.
+      if (damageDealt > 0 && !interceptResult && !bondReactionResult) {
+        try {
+          const symbiontBond = require('../services/combat/symbiontBond');
+          symbiontRedirectResult = symbiontBond.applyBondRedirect(session, target, damageDealt);
+          if (symbiontRedirectResult) {
+            if (target.hp > 0) killOccurred = false;
+            try {
+              const sgTracker = require('../services/combat/sgTracker');
+              const sym = session.units.find((u) => u.id === symbiontRedirectResult.symbiont_id);
+              if (sym)
+                sgTracker.accumulate(sym, { damage_taken: symbiontRedirectResult.redirected });
+            } catch {
+              /* sgTracker optional */
+            }
+          }
+        } catch {
+          /* symbiont bond optional; never break the hit */
         }
       }
       // TKT-ORPHAN-MORALE (SPRINT_013 successor): a critical hit (MoS >=

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -1322,7 +1322,93 @@ function createAbilityExecutor(deps) {
   // shield (energy_barrier): assorbi prossimi N HP danno per duration turni.
   // target.shield_hp consumato in performAttack pre-damage. Decay via
   // status.shield_buff in sessionRoundBridge.
+  // TKT-JOB-PHASEC slice B4a (OQ-BOND verdict V3) — symbiotic_bond pairs the
+  // symbiont with an ally (sets actor._bond + partner._bonded_by). Re-castable
+  // (moves the bond); with dual_bond a 2nd cast sets the secondary partner. The
+  // cast-time adjacency gate is dropped by bond_no_distance_limit. The redirect
+  // itself happens in performAttack via combat/symbiontBond.applyBondRedirect.
+  async function executeSymbioticBond({ session, actor, ability, body }) {
+    const targetId = String(body.target_id || '');
+    const target = session.units.find((u) => u.id === targetId);
+    if (!target || target.hp <= 0) {
+      return { status: 400, body: { error: `target "${targetId}" non valido (morto o assente)` } };
+    }
+    if (target.id === actor.id) {
+      return { status: 400, body: { error: 'symbiotic_bond non può legare se stesso' } };
+    }
+    if (target.controlled_by !== actor.controlled_by) {
+      return { status: 400, body: { error: 'symbiotic_bond richiede target alleato' } };
+    }
+    const cfg = require('./combat/symbiontBond').computeBondConfig(actor);
+    if (!cfg.no_distance_limit && manhattanDistance(actor.position, target.position) > 1) {
+      return { status: 400, body: { error: 'symbiotic_bond richiede alleato adiacente' } };
+    }
+    if (!actor._bond) {
+      actor._bond = {
+        partner_id: null,
+        redirect_pct: cfg.redirect_pct,
+        secondary_partner_id: null,
+        secondary_pct: 0,
+      };
+    }
+    actor._bond.redirect_pct = cfg.redirect_pct;
+    let slot = 'primary';
+    if (cfg.dual && actor._bond.partner_id && actor._bond.partner_id !== target.id) {
+      actor._bond.secondary_partner_id = target.id;
+      actor._bond.secondary_pct = cfg.secondary_pct;
+      slot = 'secondary';
+    } else {
+      const prev = actor._bond.partner_id;
+      if (prev && prev !== target.id && prev !== actor._bond.secondary_partner_id) {
+        const prevUnit = session.units.find((u) => u.id === prev);
+        if (prevUnit && prevUnit._bonded_by === actor.id) delete prevUnit._bonded_by;
+      }
+      actor._bond.partner_id = target.id;
+    }
+    target._bonded_by = actor.id;
+
+    actor.ap_remaining = Math.max(
+      0,
+      (actor.ap_remaining ?? actor.ap) - Number(ability.cost_ap || 0),
+    );
+
+    const redirectPct = slot === 'secondary' ? actor._bond.secondary_pct : actor._bond.redirect_pct;
+    const event = {
+      ts: new Date().toISOString(),
+      session_id: session.session_id,
+      actor_id: actor.id,
+      actor_species: actor.species,
+      actor_job: actor.job,
+      action_type: 'ability',
+      ability_id: ability.ability_id,
+      effect_type: 'bond',
+      target_id: target.id,
+      turn: session.turn,
+      ap_spent: Number(ability.cost_ap || 0),
+      bond_slot: slot,
+      redirect_pct: redirectPct,
+      trait_effects: [],
+    };
+    await appendEvent(session, event);
+
+    return {
+      status: 200,
+      body: {
+        ok: true,
+        actor_id: actor.id,
+        ability_id: ability.ability_id,
+        effect_type: 'bond',
+        bonded: { partner_id: target.id, slot, redirect_pct: redirectPct },
+        ap_remaining: actor.ap_remaining,
+      },
+    };
+  }
+
   async function executeShield({ session, actor, ability, body }) {
+    // TKT-JOB-PHASEC slice B4a — symbiotic_bond is a pairing, not a 0-hp shield.
+    if (ability.ability_id === 'symbiotic_bond') {
+      return executeSymbioticBond({ session, actor, ability, body });
+    }
     const targetId = String(body.target_id || actor.id);
     const target = session.units.find((u) => u.id === targetId);
     if (!target || target.hp <= 0) {

--- a/apps/backend/services/combat/symbiontBond.js
+++ b/apps/backend/services/combat/symbiontBond.js
@@ -1,0 +1,135 @@
+// Symbiont bond redirect — TKT-JOB-PHASEC slice B4a (Cat C/D, OQ-BOND verdict V3).
+//
+// The SYMBIONT job links to an ally via `symbiotic_bond`; while bonded, a share of
+// the damage the partner takes is redirected to the symbiont (FFXIV "Cover" model).
+//
+// State (set at cast by executeSymbioticBond in abilityExecutor):
+//   symbiont._bond = { partner_id, redirect_pct, secondary_partner_id, secondary_pct }
+//   partner._bonded_by = symbiont.id   (inverse pointer; secondary partner too)
+//
+// Hook point: performAttack, AFTER the damage step + intercept reroute + companion
+// bondReactionTrigger (one absorb layer per hit — gated on !interceptResult &&
+// !bondReactionResult by the caller). Math mirrors bondReactionTrigger.fireShieldAlly
+// (ablative HP transfer + session.damage_taken bookkeeping), but the share is the
+// bond's redirect_pct and the absorber is the bonded symbiont (capped at its HP).
+//
+// Perks layered here / at cast:
+//   - bond_redirect_strong: 50% -> 60% (at cast).
+//   - dual_bond: a 2nd partner @ 25% redirect (at cast).
+//   - emergency_full_redirect: partner HP<=30% -> 100% redirect for the hit,
+//     cooldown 5 rounds (at damage time).
+//   - bond_no_distance_limit: drops the cast-time adjacency gate (in the executor).
+
+'use strict';
+
+const DEFAULT_REDIRECT_PCT = 0.5;
+const STRONG_REDIRECT_PCT = 0.6;
+const SECONDARY_REDIRECT_PCT = 0.25;
+const EMERGENCY_HP_THRESHOLD = 0.3;
+const EMERGENCY_COOLDOWN = 5;
+
+function findPassive(unit, tag) {
+  const passives = Array.isArray(unit && unit._perk_passives) ? unit._perk_passives : [];
+  return passives.find((p) => p && p.tag === tag) || null;
+}
+
+/**
+ * Derive the symbiont's bond configuration from its perks. Read by
+ * executeSymbioticBond at cast to populate symbiont._bond.
+ *
+ * @param {object} symbiont
+ * @returns {{ redirect_pct:number, dual:boolean, secondary_pct:number, no_distance_limit:boolean }}
+ */
+function computeBondConfig(symbiont) {
+  const strong = findPassive(symbiont, 'bond_redirect_strong');
+  const dual = findPassive(symbiont, 'dual_bond');
+  const noDist = findPassive(symbiont, 'bond_no_distance_limit');
+  return {
+    redirect_pct: strong
+      ? Number(strong.payload && strong.payload.redirect_pct) || STRONG_REDIRECT_PCT
+      : DEFAULT_REDIRECT_PCT,
+    dual: !!dual,
+    secondary_pct: dual
+      ? Number(dual.payload && dual.payload.secondary_redirect_pct) || SECONDARY_REDIRECT_PCT
+      : 0,
+    no_distance_limit: !!noDist,
+  };
+}
+
+/**
+ * Redirect a share of the damage a bonded partner just took onto its symbiont.
+ * Mutates target.hp (restored), symbiont.hp (reduced), session.damage_taken.
+ * Capped at the symbiont's HP (excess stays on the partner). No-op (null) when
+ * the partner is not bonded, the symbiont is dead/missing, or the share rounds to 0.
+ *
+ * @param {object} session — { units, turn, damage_taken }
+ * @param {object} target — the bonded partner that just took `damageDealt`
+ * @param {number} damageDealt — damage already applied to target.hp
+ * @returns {object|null} redirect result or null
+ */
+function applyBondRedirect(session, target, damageDealt) {
+  if (!session || !target || !target._bonded_by) return null;
+  const dmg = Number(damageDealt) || 0;
+  if (dmg <= 0) return null;
+  const symbiont = (session.units || []).find((u) => u && u.id === target._bonded_by);
+  if (!symbiont || Number(symbiont.hp) <= 0) return null;
+  const bond = symbiont._bond;
+  if (!bond) return null;
+
+  // primary vs secondary share
+  let pct;
+  if (bond.partner_id === target.id) pct = Number(bond.redirect_pct) || 0;
+  else if (bond.secondary_partner_id === target.id) pct = Number(bond.secondary_pct) || 0;
+  else return null;
+  if (pct <= 0) return null;
+
+  // emergency_full_redirect: partner HP <= 30% -> 100% for this hit, cooldown 5.
+  const emerg = findPassive(symbiont, 'emergency_full_redirect');
+  let emergencyFired = false;
+  if (emerg) {
+    const round = Number(session.turn) || 0;
+    const cdUntil = Number(symbiont._emergency_redirect_cd) || 0;
+    const maxHp = Number(target.max_hp || target.hp) || 1;
+    const hpPct = Number(target.hp || 0) / maxHp;
+    if (hpPct <= EMERGENCY_HP_THRESHOLD && round >= cdUntil) {
+      pct = 1.0;
+      emergencyFired = true;
+      const cd = Number(emerg.payload && emerg.payload.cooldown) || EMERGENCY_COOLDOWN;
+      symbiont._emergency_redirect_cd = round + cd;
+    }
+  }
+
+  let redirect = Math.floor(dmg * pct);
+  if (redirect <= 0) return null;
+  redirect = Math.min(redirect, Number(symbiont.hp)); // cap at symbiont HP
+  if (redirect <= 0) return null;
+
+  const maxHpT = Number(target.max_hp || Number(target.hp) + redirect);
+  target.hp = Math.min(maxHpT, Number(target.hp || 0) + redirect);
+  symbiont.hp = Math.max(0, Number(symbiont.hp) - redirect);
+  if (session.damage_taken) {
+    session.damage_taken[target.id] = (session.damage_taken[target.id] || 0) - redirect;
+    session.damage_taken[symbiont.id] = (session.damage_taken[symbiont.id] || 0) + redirect;
+  }
+
+  return {
+    type: 'symbiont_redirect',
+    symbiont_id: symbiont.id,
+    target_id: target.id,
+    redirect_pct: pct,
+    redirected: redirect,
+    emergency: emergencyFired,
+    symbiont_hp_after: symbiont.hp,
+    symbiont_killed: symbiont.hp === 0,
+  };
+}
+
+module.exports = {
+  computeBondConfig,
+  applyBondRedirect,
+  DEFAULT_REDIRECT_PCT,
+  STRONG_REDIRECT_PCT,
+  SECONDARY_REDIRECT_PCT,
+  EMERGENCY_HP_THRESHOLD,
+  EMERGENCY_COOLDOWN,
+};

--- a/tests/progression/symbiontBondRedirect.test.js
+++ b/tests/progression/symbiontBondRedirect.test.js
@@ -1,0 +1,305 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  computeBondConfig,
+  applyBondRedirect,
+} = require('../../apps/backend/services/combat/symbiontBond');
+const { createAbilityExecutor } = require('../../apps/backend/services/abilityExecutor');
+
+// TKT-JOB-PHASEC slice B4a (Cat C/D, OQ-BOND verdict V3) — symbiont bond redirect.
+// symbiotic_bond pairs the symbiont with an adjacent ally (sets symbiont._bond +
+// partner._bonded_by). When a bonded partner takes damage, applyBondRedirect (hooked
+// into performAttack AFTER intercept + companion bond) moves redirect_pct of the
+// damage from the partner to the symbiont, capped at the symbiont's HP.
+// Perks: bond_redirect_strong (50%->60%), dual_bond (2nd partner @25%),
+// emergency_full_redirect (partner HP<=30% -> 100%, cd 5), bond_no_distance_limit.
+
+// --- computeBondConfig (unit) ---
+
+test('computeBondConfig: no perks → 50%, no dual, distance gated', () => {
+  const c = computeBondConfig({ id: 's', _perk_passives: [] });
+  assert.strictEqual(c.redirect_pct, 0.5);
+  assert.strictEqual(c.dual, false);
+  assert.strictEqual(c.secondary_pct, 0);
+  assert.strictEqual(c.no_distance_limit, false);
+});
+
+test('computeBondConfig: bond_redirect_strong → 60%', () => {
+  const c = computeBondConfig({
+    id: 's',
+    _perk_passives: [
+      { tag: 'bond_redirect_strong', payload: { redirect_pct: 0.6 }, source_perk_id: 'sy_r1' },
+    ],
+  });
+  assert.strictEqual(c.redirect_pct, 0.6);
+});
+
+test('computeBondConfig: dual_bond → secondary 25%', () => {
+  const c = computeBondConfig({
+    id: 's',
+    _perk_passives: [
+      { tag: 'dual_bond', payload: { secondary_redirect_pct: 0.25 }, source_perk_id: 'sy_r2' },
+    ],
+  });
+  assert.strictEqual(c.dual, true);
+  assert.strictEqual(c.secondary_pct, 0.25);
+});
+
+test('computeBondConfig: bond_no_distance_limit → true', () => {
+  const c = computeBondConfig({
+    id: 's',
+    _perk_passives: [{ tag: 'bond_no_distance_limit', payload: {}, source_perk_id: 'sy_r6' }],
+  });
+  assert.strictEqual(c.no_distance_limit, true);
+});
+
+// --- applyBondRedirect (unit) ---
+
+function makeSession(symbiont, target) {
+  return { units: [symbiont, target], turn: 1, damage_taken: {} };
+}
+function makeSymbiont(extra = {}) {
+  return { id: 'sym', hp: 20, max_hp: 20, position: { x: 0, y: 0 }, _perk_passives: [], ...extra };
+}
+function makeTarget(extra = {}) {
+  return { id: 'ally', hp: 10, max_hp: 20, position: { x: 1, y: 0 }, ...extra };
+}
+
+test('applyBondRedirect: no _bonded_by → null', () => {
+  const sym = makeSymbiont();
+  const tgt = makeTarget();
+  assert.strictEqual(applyBondRedirect(makeSession(sym, tgt), tgt, 10), null);
+});
+
+test('applyBondRedirect: 50% basic — moves floor(dmg*0.5) to symbiont', () => {
+  const sym = makeSymbiont({
+    _bond: { partner_id: 'ally', redirect_pct: 0.5, secondary_partner_id: null, secondary_pct: 0 },
+  });
+  const tgt = makeTarget({ _bonded_by: 'sym', hp: 10, max_hp: 20 }); // took 10 (20->10)
+  const session = makeSession(sym, tgt);
+  const r = applyBondRedirect(session, tgt, 10);
+  assert.strictEqual(r.redirected, 5);
+  assert.strictEqual(tgt.hp, 15, 'target restored by 5');
+  assert.strictEqual(sym.hp, 15, 'symbiont takes 5');
+  assert.strictEqual(session.damage_taken.sym, 5);
+  assert.strictEqual(session.damage_taken.ally, -5, 'target damage_taken reduced');
+});
+
+test('applyBondRedirect: 60% strong redirect', () => {
+  const sym = makeSymbiont({
+    _bond: { partner_id: 'ally', redirect_pct: 0.6, secondary_partner_id: null, secondary_pct: 0 },
+  });
+  const tgt = makeTarget({ _bonded_by: 'sym', hp: 10, max_hp: 20 });
+  const r = applyBondRedirect(makeSession(sym, tgt), tgt, 10);
+  assert.strictEqual(r.redirected, 6);
+  assert.strictEqual(sym.hp, 14);
+});
+
+test('applyBondRedirect: capped at symbiont HP (excess stays on target)', () => {
+  const sym = makeSymbiont({
+    hp: 3,
+    _bond: { partner_id: 'ally', redirect_pct: 0.5, secondary_partner_id: null, secondary_pct: 0 },
+  });
+  const tgt = makeTarget({ _bonded_by: 'sym', hp: 10, max_hp: 20 });
+  const r = applyBondRedirect(makeSession(sym, tgt), tgt, 10); // would be 5, capped to 3
+  assert.strictEqual(r.redirected, 3);
+  assert.strictEqual(sym.hp, 0);
+  assert.strictEqual(r.symbiont_killed, true);
+  assert.strictEqual(tgt.hp, 13, 'target restored by only the capped 3');
+});
+
+test('applyBondRedirect: dead symbiont → null', () => {
+  const sym = makeSymbiont({ hp: 0, _bond: { partner_id: 'ally', redirect_pct: 0.5 } });
+  const tgt = makeTarget({ _bonded_by: 'sym' });
+  assert.strictEqual(applyBondRedirect(makeSession(sym, tgt), tgt, 10), null);
+});
+
+test('applyBondRedirect: secondary partner uses secondary_pct', () => {
+  const sym = makeSymbiont({
+    _bond: {
+      partner_id: 'main',
+      redirect_pct: 0.6,
+      secondary_partner_id: 'ally',
+      secondary_pct: 0.25,
+    },
+  });
+  const tgt = makeTarget({ _bonded_by: 'sym', hp: 12, max_hp: 20 });
+  const r = applyBondRedirect(makeSession(sym, tgt), tgt, 8); // floor(8*0.25)=2
+  assert.strictEqual(r.redirected, 2);
+});
+
+test('applyBondRedirect: emergency_full_redirect — partner HP<=30% → 100% + cooldown', () => {
+  const sym = makeSymbiont({
+    _bond: { partner_id: 'ally', redirect_pct: 0.5, secondary_partner_id: null, secondary_pct: 0 },
+    _perk_passives: [
+      { tag: 'emergency_full_redirect', payload: { cooldown: 5 }, source_perk_id: 'sy_r4' },
+    ],
+  });
+  const tgt = makeTarget({ _bonded_by: 'sym', hp: 5, max_hp: 20 }); // 25% → emergency
+  const session = makeSession(sym, tgt);
+  const r = applyBondRedirect(session, tgt, 8);
+  assert.strictEqual(r.emergency, true);
+  assert.strictEqual(r.redirected, 8, '100% redirect');
+  assert.strictEqual(sym._emergency_redirect_cd, 6, 'cooldown until round 1+5');
+  // 2nd hit same/next rounds within cooldown → no emergency (falls back to 50%)
+  const tgt2 = makeTarget({ _bonded_by: 'sym', hp: 4, max_hp: 20 });
+  const session2 = { units: [sym, tgt2], turn: 3, damage_taken: {} };
+  const r2 = applyBondRedirect(session2, tgt2, 8);
+  assert.strictEqual(r2.emergency, false, 'still on cooldown at round 3');
+  assert.strictEqual(r2.redirected, 4, 'falls back to 50%');
+});
+
+// --- symbiotic_bond cast (executeAbility integration, real catalog spec) ---
+
+function makeExecutor() {
+  return createAbilityExecutor({
+    performAttack: () => ({ damageDealt: 0, result: {} }),
+    buildAttackEvent: () => ({}),
+    appendEvent: async () => {},
+    manhattanDistance: (p, q) => Math.abs(p.x - q.x) + Math.abs(p.y - q.y),
+    rng: () => 0,
+  });
+}
+
+test('symbiotic_bond: sets bond on adjacent ally', async () => {
+  const ex = makeExecutor();
+  const sym = {
+    id: 'sym',
+    job: 'symbiont',
+    controlled_by: 'player',
+    ap: 3,
+    ap_remaining: 3,
+    position: { x: 0, y: 0 },
+    _perk_passives: [],
+  };
+  const ally = {
+    id: 'ally',
+    controlled_by: 'player',
+    hp: 20,
+    max_hp: 20,
+    position: { x: 1, y: 0 },
+  };
+  const res = await ex.executeAbility({
+    session: { units: [sym, ally], turn: 1 },
+    actor: sym,
+    body: { ability_id: 'symbiotic_bond', target_id: 'ally' },
+  });
+  assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+  assert.strictEqual(sym._bond.partner_id, 'ally');
+  assert.strictEqual(sym._bond.redirect_pct, 0.5);
+  assert.strictEqual(ally._bonded_by, 'sym');
+});
+
+test('symbiotic_bond: non-adjacent ally → 400 (distance gated)', async () => {
+  const ex = makeExecutor();
+  const sym = {
+    id: 'sym',
+    job: 'symbiont',
+    controlled_by: 'player',
+    ap: 3,
+    ap_remaining: 3,
+    position: { x: 0, y: 0 },
+    _perk_passives: [],
+  };
+  const ally = {
+    id: 'ally',
+    controlled_by: 'player',
+    hp: 20,
+    max_hp: 20,
+    position: { x: 5, y: 0 },
+  };
+  const res = await ex.executeAbility({
+    session: { units: [sym, ally], turn: 1 },
+    actor: sym,
+    body: { ability_id: 'symbiotic_bond', target_id: 'ally' },
+  });
+  assert.strictEqual(res.status, 400, 'distance gate blocks a far bond');
+});
+
+test('symbiotic_bond: bond_no_distance_limit bypasses adjacency', async () => {
+  const ex = makeExecutor();
+  const sym = {
+    id: 'sym',
+    job: 'symbiont',
+    controlled_by: 'player',
+    ap: 3,
+    ap_remaining: 3,
+    position: { x: 0, y: 0 },
+    _perk_passives: [{ tag: 'bond_no_distance_limit', payload: {}, source_perk_id: 'sy_r6' }],
+  };
+  const ally = {
+    id: 'ally',
+    controlled_by: 'player',
+    hp: 20,
+    max_hp: 20,
+    position: { x: 5, y: 0 },
+  };
+  const res = await ex.executeAbility({
+    session: { units: [sym, ally], turn: 1 },
+    actor: sym,
+    body: { ability_id: 'symbiotic_bond', target_id: 'ally' },
+  });
+  assert.strictEqual(res.status, 200, 'no_distance_limit allows a far bond');
+  assert.strictEqual(ally._bonded_by, 'sym');
+});
+
+test('symbiotic_bond: bond_redirect_strong sets 60% redirect at cast', async () => {
+  const ex = makeExecutor();
+  const sym = {
+    id: 'sym',
+    job: 'symbiont',
+    controlled_by: 'player',
+    ap: 3,
+    ap_remaining: 3,
+    position: { x: 0, y: 0 },
+    _perk_passives: [
+      { tag: 'bond_redirect_strong', payload: { redirect_pct: 0.6 }, source_perk_id: 'sy_r1' },
+    ],
+  };
+  const ally = {
+    id: 'ally',
+    controlled_by: 'player',
+    hp: 20,
+    max_hp: 20,
+    position: { x: 1, y: 0 },
+  };
+  await ex.executeAbility({
+    session: { units: [sym, ally], turn: 1 },
+    actor: sym,
+    body: { ability_id: 'symbiotic_bond', target_id: 'ally' },
+  });
+  assert.strictEqual(sym._bond.redirect_pct, 0.6);
+});
+
+test('symbiotic_bond: dual_bond second cast sets secondary partner', async () => {
+  const ex = makeExecutor();
+  const sym = {
+    id: 'sym',
+    job: 'symbiont',
+    controlled_by: 'player',
+    ap: 5,
+    ap_remaining: 5,
+    position: { x: 0, y: 0 },
+    _perk_passives: [
+      { tag: 'dual_bond', payload: { secondary_redirect_pct: 0.25 }, source_perk_id: 'sy_r2' },
+    ],
+  };
+  const a1 = { id: 'a1', controlled_by: 'player', hp: 20, max_hp: 20, position: { x: 1, y: 0 } };
+  const a2 = { id: 'a2', controlled_by: 'player', hp: 20, max_hp: 20, position: { x: 0, y: 1 } };
+  const session = { units: [sym, a1, a2], turn: 1 };
+  await ex.executeAbility({
+    session,
+    actor: sym,
+    body: { ability_id: 'symbiotic_bond', target_id: 'a1' },
+  });
+  await ex.executeAbility({
+    session,
+    actor: sym,
+    body: { ability_id: 'symbiotic_bond', target_id: 'a2' },
+  });
+  assert.strictEqual(sym._bond.partner_id, 'a1', 'primary kept');
+  assert.strictEqual(sym._bond.secondary_partner_id, 'a2', 'secondary set by dual_bond');
+  assert.strictEqual(a2._bonded_by, 'sym');
+});


### PR DESCRIPTION
## TKT-JOB-PHASEC slice B4a — symbiont bond redirect (OQ-BOND verdict V3)

First half of the symbiont fork (B4). `symbiotic_bond` was a 0-hp no-op shield; this makes it a real **pairing** + a damage-**redirect** hook (FFXIV "Cover" model). Closes 4 of the 7 B4 tags; B4b (bonded_proximity_defense / chain_heal_adjacent / bonded_death_grace) follows as the next slice.

### Changes
- **new `apps/backend/services/combat/symbiontBond.js`** — `computeBondConfig(symbiont)` (reads perks → redirect %, dual, distance-limit) + `applyBondRedirect(session, target, dmg)` (moves `redirect_pct` of a bonded partner's damage to the symbiont, **capped at the symbiont's HP**, restores the partner, updates `session.damage_taken`). Math mirrors `bondReactionTrigger.fireShieldAlly`.
- **`abilityExecutor.js`** — `executeShield` diverts `symbiotic_bond` to new `executeSymbioticBond`: sets `actor._bond` + `partner._bonded_by`, adjacency-gated at cast (unless `bond_no_distance_limit`), re-castable (moves the bond), dual_bond sets the secondary slot.
- **`session.js` performAttack** — redirect hook AFTER intercept + companion bond (one absorb layer per hit: gated `!interceptResult && !bondReactionResult`); resets `killOccurred` if the partner survives; accrues SG on the symbiont for the redirected damage.

### Tags wired (4/7 of B4)
`bond_redirect_strong` (50→60%), `dual_bond` (2nd partner @25%), `emergency_full_redirect` (partner HP≤30% → 100%, cd 5), `bond_no_distance_limit`.

### Tests (TDD red→green)
`tests/progression/symbiontBondRedirect.test.js` (16): `computeBondConfig` ×4 + `applyBondRedirect` ×8 (50%/60%/cap/dead/secondary/emergency+cooldown/no-bond) + `symbiotic_bond` cast ×4 (adjacent / distance-gate 400 / no_distance_limit / dual secondary). Regression: progression **93/93**, AI **500/500**.

### Band-verify
**Band-neutral by construction** — the symbiont job + `symbiotic_bond` are absent from every HC sim party (grep `tools/py/`), and the redirect hook is gated on `target._bonded_by` which no HC unit sets → HC06/HC07 byte-identical. Live band-verify = no signal, skipped + documented.

### Surface (Gate-5)
Player sees the bonded partner take less damage + the symbiont's HP drop (combat state / damage_taken); the cast emits a `bond` event. Wire mirrors the player-visible `bondReactionTrigger` redirect.

No data, no schema, no new deps. No forbidden paths.