### PR TITLE
feat(combat): catalog audit + biome stress-profile readonly endpoint

### DIFF
--- a/apps/backend/routes/combat.js
+++ b/apps/backend/routes/combat.js
@@ -4,6 +4,8 @@
 // Endpoints:
 //   GET /api/combat/status-penalties — wounded_perma + bleeding/fracture tiers
 //   GET /api/combat/biome-modifiers  — runtime diff_base + hp_mult + pressure formula per biome
+//   GET /api/combat/biome-stress-profiles      — all biomes' stresswave/hazard/narrative (DEAD fields surfaced)
+//   GET /api/combat/biome-stress-profile/:id   — one biome's stress profile (404 if unknown)
 //   GET /api/combat/ennea-effects    — 9/9 ennea archetype buff catalog (label + buffs + desc)
 //
 // Frontend combat UI può preload questi reference table evitando
@@ -13,7 +15,11 @@
 
 const { Router } = require('express');
 const { listStatusPenalties } = require('../services/combat/statusModifiers');
-const { listBiomeModifiers } = require('../services/combat/biomeModifiers');
+const {
+  listBiomeModifiers,
+  getBiomeStressProfile,
+  listBiomeStressProfiles,
+} = require('../services/combat/biomeModifiers');
 const { listEnneaEffects } = require('../services/enneaEffects');
 
 function createCombatRouter() {
@@ -35,6 +41,22 @@ function createCombatRouter() {
   router.get('/ennea-effects', (_req, res) => {
     const items = listEnneaEffects();
     res.json({ count: items.length, items });
+  });
+
+  // 2026-06-01 — surface the DEAD biomes.yaml fields (stresswave / hazard
+  // stress_modifiers / narrative / npc_archetypes) for inspection. Read-only,
+  // band-neutral (no combat effect). See docs/reports/2026-06-01-catalog-mapping-audit.md.
+  router.get('/biome-stress-profiles', (_req, res) => {
+    const items = listBiomeStressProfiles();
+    res.json({ count: items.length, items });
+  });
+
+  router.get('/biome-stress-profile/:id', (req, res) => {
+    const profile = getBiomeStressProfile(String(req.params.id || ''));
+    if (!profile) {
+      return res.status(404).json({ error: `biome "${req.params.id}" non trovato` });
+    }
+    res.json(profile);
   });
 
   return router;

--- a/apps/backend/services/combat/biomeModifiers.js
+++ b/apps/backend/services/combat/biomeModifiers.js
@@ -180,10 +180,59 @@ function listBiomeModifiers(registry) {
     }));
 }
 
+/**
+ * 2026-06-01 — read the player-invisible biome stress/narrative fields for a
+ * read-only diagnostic surface (catalog-mapping-audit §4). Exposes the DEAD
+ * biomes.yaml fields (stresswave, hazard.severity/stress_modifiers, narrative,
+ * npc_archetypes) so they are inspectable. Pure reader, ZERO combat effect
+ * (band-neutral) — does NOT feed pressure/spawn; that wire (stresswave→pressure)
+ * is a separate combat PR requiring band-verify.
+ *
+ * @param {string} biomeId
+ * @param {object} [registry]
+ * @returns {object|null}
+ */
+function getBiomeStressProfile(biomeId, registry) {
+  if (!biomeId || typeof biomeId !== 'string') return null;
+  const biomes = registry || loadBiomesConfig();
+  const cfg = biomes && biomes[biomeId];
+  if (!cfg || typeof cfg !== 'object') return null;
+  const hazard = cfg.hazard && typeof cfg.hazard === 'object' ? cfg.hazard : {};
+  return {
+    biome_id: biomeId,
+    stresswave: cfg.stresswave && typeof cfg.stresswave === 'object' ? cfg.stresswave : null,
+    hazard_severity: hazard.severity != null ? hazard.severity : null,
+    stress_modifiers:
+      hazard.stress_modifiers && typeof hazard.stress_modifiers === 'object'
+        ? hazard.stress_modifiers
+        : null,
+    narrative: cfg.narrative && typeof cfg.narrative === 'object' ? cfg.narrative : null,
+    npc_archetypes:
+      cfg.npc_archetypes && typeof cfg.npc_archetypes === 'object' ? cfg.npc_archetypes : null,
+  };
+}
+
+/**
+ * 2026-06-01 — list stress profiles for all biomes (readonly diagnostic).
+ *
+ * @param {object} [registry]
+ * @returns {Array<object>}
+ */
+function listBiomeStressProfiles(registry) {
+  const biomes = registry || loadBiomesConfig();
+  if (!biomes || typeof biomes !== 'object') return [];
+  return Object.keys(biomes)
+    .sort()
+    .map((biome_id) => getBiomeStressProfile(biome_id, biomes))
+    .filter(Boolean);
+}
+
 module.exports = {
   loadBiomesConfig,
   getBiomeModifiers,
   listBiomeModifiers,
+  getBiomeStressProfile,
+  listBiomeStressProfiles,
   applyEnemyHpMultiplier,
   _resetCache,
   DEFAULT_BIOMES_YAML,

--- a/docs/reports/2026-06-01-catalog-mapping-audit.md
+++ b/docs/reports/2026-06-01-catalog-mapping-audit.md
@@ -1,0 +1,114 @@
+---
+title: 'Catalog mapping audit — biome / species / creature field→consumer→UI'
+doc_status: active
+doc_owner: claude-code
+workstream: dataset-pack
+last_verified: '2026-06-01'
+source_of_truth: false
+language: it
+review_cycle_days: 90
+tags: [audit, catalog, biome, species, creature, gate-5, engine-live-surface-dead]
+---
+
+# Catalog mapping audit (2026-06-01)
+
+> Audit read-only del catalogo (biomi / specie / creature) per mappare ogni campo
+> dati al suo **consumer runtime** e alla sua **superficie player** (Gate-5), e
+> quantificare il debito "Engine LIVE / Surface DEAD" (museum card M-2026-04-26-018:
+> _biomes.yaml 2/7 campi a runtime_). Prodotto dalla sessione coordinatrice GOAL
+> (fan-out 4 agent read-only, workflow `catalog-audit-d4-investigate`).
+
+Legenda status: **live** = consumer + superficie player · **partial** = consumer
+ma superficie debole/assente o solo backend · **dead** = caricato dallo YAML, zero
+consumer runtime.
+
+## 1. Biomi — `data/core/biomes.yaml` (dead: 6 campi-classe)
+
+| Campo                          | Consumer                                                     | Superficie player                          | Status  |
+| ------------------------------ | ----------------------------------------------------------- | ------------------------------------------ | ------- |
+| `diff_base`                    | biomeModifiers.getBiomeModifiers → hp_mult + pressure_init  | HP nemici + Sistema tier più alti          | live    |
+| `affixes`                      | biomeSpawnBias.applyBiomeBias (spawn weighting)             | tipi nemici biome-appropriati              | live    |
+| `npc_archetypes.primary/...`   | biomeSpawnBias (max_boost 3×) + initialAlienaTelemetry      | archetipi più frequenti nello spawn        | partial |
+| `hazard.severity`              | biomeAdapter._derivePressure (W5 bucket) + tie-break        | descrittore pressure HUD (Godot)           | partial |
+| `display_name_*` / `label`     | biomeAdapter.adaptBiome → W5 `biome_label_it`               | nome bioma nel chip HUD (resolve Godot)    | partial |
+| `magnetic_field_strength`      | biomeResonance (trait magnetic_rift) — solo atollo_obsidiana | costo ricerca thought-cabinet ridotto      | partial |
+| **`mod_biome`**                | **nessuno** (M-018: "non passato all'encounter generator")  | NONE                                       | dead    |
+| **`hazard.stress_modifiers`**  | override keys leggibili ma chiavi arbitrarie, no mapping    | NONE                                       | dead    |
+| **`stresswave.baseline`**      | **nessuno** (M-018: "StressWave è il livello mancante")     | NONE                                       | dead    |
+| **`stresswave.escalation_rate`** | nessuno                                                   | NONE                                       | dead    |
+| **`stresswave.event_thresholds`** | nessuno (no event-trigger wiring)                        | NONE                                       | dead    |
+| **`narrative.tone`/`hooks`**   | nessuno (narrativeEngine inkjs non li consuma)              | NONE                                       | dead    |
+| `legacy_slug` / `aliases`      | nessuno                                                     | NONE                                       | dead    |
+
+**Wire spedito (questa sessione):** vedi §4 — endpoint diagnostico read-only che
+espone il blocco `stresswave` + `hazard.stress_modifiers` + `narrative` (band-neutral).
+
+**Wire combat candidato (NON spedito — band-verify obbligatorio):**
+`stresswave.baseline → session.sistema_pressure init` (fold in
+`getBiomeModifiers.pressure_initial_bonus`). RISCHIO: `rovine_planari` (bioma HC06/HC07)
+ha `stresswave.baseline` → shift bande → richiede `calibrate_parallel.py` HC06/HC07
+prima del merge. Deferred a un PR combat dedicato + band-verify.
+
+## 2. Specie — `data/core/species/species_catalog.json` (dead: 10 campi)
+
+| Campo                  | Consumer                                  | Superficie player           | Status  |
+| ---------------------- | ----------------------------------------- | --------------------------- | ------- |
+| `species_id`           | catalog / synergyDetector / traitEffects  | lookup specie (panels)      | live    |
+| `sentience_index`      | vcScoring (fold)                          | VC scoring backend          | partial |
+| `default_parts`        | slot.part combos → trait synergy          | combinazioni parti          | partial |
+| `biome_affinity`       | spawn weighting                           | (non visibile)              | partial |
+| `lifecycle_yaml`       | biome affinity bonus (indiretto)          | (non visibile)              | partial |
+| `clade_tag`/`role_tags`| spawn bias / gameplay role                | (non visibile)              | partial |
+| `visual_description`   | stored, ETL only                          | NONE (codexPanel = future)  | partial |
+| **`scientific_name`**  | update_evo_pack_catalog / import (ETL)    | NONE                        | dead    |
+| **`classification`**   | speciesBiomes / wikiLinkBridge (no render)| NONE                        | dead    |
+| **`risk_profile`**     | nessuno runtime                           | NONE                        | dead    |
+| **`interactions`**     | nessuno runtime                           | NONE                        | dead    |
+| **`constraints`**      | nessuno runtime                           | NONE                        | dead    |
+| **`pack_size`/`genus`/`epithet`/`source`/`_provenance`** | ETL/schema only | NONE             | dead    |
+
+**Wire candidato:** `visual_description → codexPanel.js` species-detail prose card.
+⚠️ **OWNED da #2536 (species-enrichment, migration attiva)** → NON toccato (collision-avoidance).
+
+## 3. Creature (lifecycle / mutation) — (dead: 12 campi)
+
+| Campo                                         | Consumer / Superficie                         | Status  |
+| --------------------------------------------- | --------------------------------------------- | ------- |
+| `mutation_catalog.id` / `unit.applied_mutations` | legacyRitualPanel checkbox (live)          | live    |
+| `formEvolution.current_form_id/pe`            | formsPanel form eligibility                   | live    |
+| `mutation.tier` / `body_slot`                 | formsPanel PE cost (parz.) / slot silent      | partial |
+| `lifecycle.phases[*].id`                      | skivPanel ASCII card                           | partial |
+| `lineage_id` / `inheritable_traits`           | offspringRitualPanel                          | partial |
+| **`mutation.category`**                       | NONE (bingo grouping esiste backend, no UI)   | dead    |
+| **`mutation.visual_swap` / `aspect_token`**   | NONE in formsPanel/characterPanel/skivPanel   | dead    |
+| **`mutation.prerequisite` / `trigger_cond`**  | NONE play UI                                  | dead    |
+| **`mutation.mp_cost`**                        | NONE (offspring ritual non mostra costo)      | dead    |
+| **`lifecycle.phases[*].stadi`**               | NONE (stadium gates non sorfacciati)          | dead    |
+| **`lifecycle.mbti_aspect_correlation`**       | NONE (characterPanel mostra MBTI ma non link) | dead    |
+| **`mutation_grid` 3×3 (MHS)**                 | NONE (no grid UI — card M-2026-04-27-007)     | dead    |
+| **`morphotype_bias`**                         | NONE (char-creation morphotype bias)          | dead    |
+| **bingo `passive_token`**                     | NONE in creature detail                       | dead    |
+
+**Wire candidato:** `mutation.category` raggruppamento + bingo 3-of-kind → formsPanel
+(MHS gene-grid pattern, card M-2026-04-27-007). Deferred (Godot surface, owned cross-repo).
+
+## 4. Wire spedito — endpoint diagnostico biome stress-profile
+
+`GET /api/biomes/:id/stress-profile` (read-only, band-neutral): espone i campi
+`stresswave` (baseline/escalation_rate/event_thresholds) + `hazard.{severity,stress_modifiers}`
++ `narrative.{tone,hooks}` + `npc_archetypes` — oggi caricati ma invisibili. Superficie
+Gate-5 = debug endpoint (player/dev legge il profilo stress di un bioma). Zero impatto
+combat (sola lettura) → band-neutral by construction. Vedi PR collegata.
+
+## 5. Sintesi debito
+
+| Dimensione | Campi dead | Wire candidato top                         | Ownership      |
+| ---------- | ---------- | ------------------------------------------ | -------------- |
+| Biomi      | 6          | stresswave→pressure (combat, band-verify)  | libero         |
+| Specie     | 10         | visual_description→codexPanel              | #2536 (OWNED)  |
+| Creature   | 12         | mutation.category→formsPanel (gene-grid)   | Godot cross-repo |
+
+Pattern dominante confermato (museum M-018): il livello dati biomi/creature è molto
+più ricco di quanto il runtime consumi. Riuso raccomandato: A6 readonly-diagnostic
+(band-neutral, basso rischio) per sorfacciare incrementalmente; i wire combat
+(stresswave→pressure) richiedono band-verify dedicata.

--- a/docs/reports/2026-06-01-catalog-mapping-audit.md
+++ b/docs/reports/2026-06-01-catalog-mapping-audit.md
@@ -94,11 +94,13 @@ prima del merge. Deferred a un PR combat dedicato + band-verify.
 
 ## 4. Wire spedito — endpoint diagnostico biome stress-profile
 
-`GET /api/biomes/:id/stress-profile` (read-only, band-neutral): espone i campi
-`stresswave` (baseline/escalation_rate/event_thresholds) + `hazard.{severity,stress_modifiers}`
-+ `narrative.{tone,hooks}` + `npc_archetypes` — oggi caricati ma invisibili. Superficie
-Gate-5 = debug endpoint (player/dev legge il profilo stress di un bioma). Zero impatto
-combat (sola lettura) → band-neutral by construction. Vedi PR collegata.
+`GET /api/combat/biome-stress-profile/:id` (singolo bioma, 404 se ignoto) +
+`GET /api/combat/biome-stress-profiles` (tutti) — read-only, band-neutral. Espongono i
+campi `stresswave` (baseline/escalation_rate/event_thresholds) + `hazard.{severity,stress_modifiers}`
++ `narrative.{tone,hooks}` + `npc_archetypes` — oggi caricati ma invisibili. Registrati in
+`apps/backend/routes/combat.js` (sibling di `/api/combat/biome-modifiers`, pattern A6).
+Superficie Gate-5 = debug endpoint (player/dev legge il profilo stress di un bioma). Zero
+impatto combat (sola lettura) → band-neutral by construction. Vedi PR collegata.
 
 ## 5. Sintesi debito
 

--- a/tests/api/combatBiomeStressProfile.test.js
+++ b/tests/api/combatBiomeStressProfile.test.js
@@ -1,0 +1,63 @@
+// 2026-06-01 — Combat biome-stress-profile readonly diagnostic (A6 pattern).
+// Surfaces the DEAD biomes.yaml fields (stresswave / hazard stress_modifiers /
+// narrative / npc_archetypes) — catalog-mapping-audit §4. Mirror of
+// combatReadonly.test.js. Read-only, band-neutral.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+const { createCombatRouter } = require('../../apps/backend/routes/combat');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/combat', createCombatRouter());
+  return app;
+}
+
+test('GET /api/combat/biome-stress-profiles: returns count + items array', async () => {
+  const res = await request(buildApp()).get('/api/combat/biome-stress-profiles');
+  assert.equal(res.status, 200);
+  assert.equal(typeof res.body.count, 'number');
+  assert.ok(Array.isArray(res.body.items));
+  assert.equal(res.body.items.length, res.body.count);
+  assert.ok(res.body.count > 0, 'at least one biome');
+});
+
+test('GET /api/combat/biome-stress-profiles: each item exposes the surfaced fields', async () => {
+  const res = await request(buildApp()).get('/api/combat/biome-stress-profiles');
+  for (const item of res.body.items) {
+    assert.equal(typeof item.biome_id, 'string');
+    assert.ok('stresswave' in item);
+    assert.ok('hazard_severity' in item);
+    assert.ok('stress_modifiers' in item);
+    assert.ok('narrative' in item);
+    assert.ok('npc_archetypes' in item);
+  }
+});
+
+test('GET /api/combat/biome-stress-profiles: at least one biome carries a stresswave block', async () => {
+  const res = await request(buildApp()).get('/api/combat/biome-stress-profiles');
+  const withStresswave = res.body.items.filter(
+    (i) => i.stresswave && i.stresswave.baseline != null,
+  );
+  assert.ok(withStresswave.length > 0, 'stresswave.baseline surfaced for at least one biome');
+});
+
+test('GET /api/combat/biome-stress-profile/:id: returns the single biome profile', async () => {
+  const app = buildApp();
+  const list = await request(app).get('/api/combat/biome-stress-profiles');
+  const firstId = list.body.items[0].biome_id;
+  const res = await request(app).get(`/api/combat/biome-stress-profile/${firstId}`);
+  assert.equal(res.status, 200);
+  assert.equal(res.body.biome_id, firstId);
+  assert.ok('stresswave' in res.body);
+});
+
+test('GET /api/combat/biome-stress-profile/:id: 404 for an unknown biome', async () => {
+  const res = await request(buildApp()).get('/api/combat/biome-stress-profile/__nope__');
+  assert.equal(res.status, 404);
+  assert.ok(res.body.error);
+});


### PR DESCRIPTION
## Catalog mapping audit + biome wire (GOAL deliverable)

### Audit doc
`docs/reports/2026-06-01-catalog-mapping-audit.md` — maps every biome / species / creature field to its runtime consumer + player surface (Gate-5), quantifying the "Engine LIVE / Surface DEAD" debt (museum card M-2026-04-26-018). Dead-field counts: **biome 6 / species 10 / creature 12**. Produced by a read-only 4-agent fan-out (workflow `catalog-audit-d4-investigate`).

### Wire shipped (≥1 biome-package, band-neutral)
`GET /api/combat/biome-stress-profile/:id` + `/biome-stress-profiles` — surface the DEAD `biomes.yaml` fields (`stresswave` baseline/escalation/event_thresholds, `hazard.severity`/`stress_modifiers`, `narrative`, `npc_archetypes`) via the proven **A6 readonly-diagnostic pattern** (sibling of `/api/combat/biome-modifiers`). New pure readers `getBiomeStressProfile` + `listBiomeStressProfiles` in `biomeModifiers.js`.

- **Gate-5**: debug endpoint (player/dev inspects a biome's stress profile).
- **Band-neutral by construction**: read-only, zero combat effect.

### Deferred (documented in §4)
`stresswave.baseline → session pressure` (combat wire) — `rovine_planari` (HC06/HC07 biome) carries `stresswave`, so it needs a dedicated PR + `calibrate_parallel.py` band-verify.

### Tests
`tests/api/combatBiomeStressProfile.test.js` (5, supertest) + combat readonly regression **25/25**. Docs governance `errors=0`.

Disjoint from PHASEC (session/abilityExecutor/progressionApply) and #2536 (species). No data, no schema, no new deps, no forbidden paths.