### PR TITLE
feat(combat): phasec slice b4b symbiont support perks (b4 7/7)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -670,6 +670,7 @@ function createSessionRouter(options = {}) {
     let interceptResult = null;
     let bondReactionResult = null;
     let symbiontRedirectResult = null;
+    let symbiontDeathGraceResult = null;
     let terrainReactionResult = null;
     // M14-A residuo close (TKT-09 2026-04-26): surface positional info
     // (elevation_delta + multiplier) on performAttack return so callers can
@@ -927,6 +928,38 @@ function createSessionRouter(options = {}) {
               } catch {
                 /* structured log best-effort */
               }
+            }
+          }
+        } catch {
+          /* symbiont bond optional; never break the hit */
+        }
+      }
+      // TKT-JOB-PHASEC slice B4b — bonded_death_grace: if the attack still killed a
+      // bonded partner (redirect could not save it), its symbiont heals + rages.
+      if (killOccurred && target && target._bonded_by) {
+        try {
+          const symbiontBond = require('../services/combat/symbiontBond');
+          symbiontDeathGraceResult = symbiontBond.applyBondedDeathGrace(session, target);
+          if (
+            symbiontDeathGraceResult &&
+            !process.env.IDEA_ENGINE_DISABLE_BOND_LOG &&
+            process.env.NODE_ENV !== 'test'
+          ) {
+            try {
+              // eslint-disable-next-line no-console
+              console.info(
+                JSON.stringify({
+                  component: 'symbiont-bond',
+                  event: 'bonded_death_grace',
+                  session_id: session.session_id || null,
+                  turn: session.turn,
+                  symbiont_id: symbiontDeathGraceResult.symbiont_id,
+                  partner_id: symbiontDeathGraceResult.partner_id,
+                  healed: symbiontDeathGraceResult.healed,
+                }),
+              );
+            } catch {
+              /* structured log best-effort */
             }
           }
         } catch {

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -605,10 +605,12 @@ function createAbilityExecutor(deps) {
     target.hp = hpBefore + healed;
 
     // chain_heal_adjacent (SYMBIONT sy_r4, TKT-JOB-PHASEC B4b): shared_vitality
-    // also heals allies adjacent to the heal target (the bonded partner) at
-    // `factor` of the applied heal. Symbiont-only (gated on the perk + ability).
+    // also heals allies adjacent to the heal target at `factor` of the applied
+    // heal — but ONLY when the target is THIS symbiont's bonded partner (Codex
+    // #2541 P2: the effect is scoped to the bond, primary or secondary, both of
+    // which set target._bonded_by === actor.id). Symbiont-only via the perk.
     let chainHealed = null;
-    if (ability.ability_id === 'shared_vitality' && healed > 0) {
+    if (ability.ability_id === 'shared_vitality' && healed > 0 && target._bonded_by === actor.id) {
       const perk = Array.isArray(actor._perk_passives)
         ? actor._perk_passives.find((p) => p && p.tag === 'chain_heal_adjacent')
         : null;

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -604,6 +604,36 @@ function createAbilityExecutor(deps) {
     const healed = Math.max(0, Math.min(rolled, Math.max(0, maxHp - hpBefore)));
     target.hp = hpBefore + healed;
 
+    // chain_heal_adjacent (SYMBIONT sy_r4, TKT-JOB-PHASEC B4b): shared_vitality
+    // also heals allies adjacent to the heal target (the bonded partner) at
+    // `factor` of the applied heal. Symbiont-only (gated on the perk + ability).
+    let chainHealed = null;
+    if (ability.ability_id === 'shared_vitality' && healed > 0) {
+      const perk = Array.isArray(actor._perk_passives)
+        ? actor._perk_passives.find((p) => p && p.tag === 'chain_heal_adjacent')
+        : null;
+      if (perk) {
+        const factor = Number(perk.payload && perk.payload.factor) || 0.5;
+        const chainAmt = Math.floor(healed * factor);
+        if (chainAmt > 0) {
+          chainHealed = [];
+          for (const u of session.units) {
+            if (!u || u.id === target.id || u.id === actor.id) continue;
+            if (u.controlled_by !== actor.controlled_by) continue;
+            if (Number(u.hp) <= 0 || !u.position) continue;
+            if (manhattanDistance(u.position, target.position) > 1) continue;
+            const uMax = Number(u.max_hp || u.hp || 0);
+            const uBefore = Number(u.hp || 0);
+            const applied = Math.max(0, Math.min(chainAmt, Math.max(0, uMax - uBefore)));
+            if (applied > 0) {
+              u.hp = uBefore + applied;
+              chainHealed.push({ unit_id: u.id, healed: applied });
+            }
+          }
+        }
+      }
+    }
+
     let removedStatus = null;
     if (ability.remove_status && target.status) {
       const prev = Number(target.status[ability.remove_status]) || 0;
@@ -635,6 +665,7 @@ function createAbilityExecutor(deps) {
       target_hp_before: hpBefore,
       target_hp_after: target.hp,
       removed_status: removedStatus,
+      chain_healed: chainHealed,
       trait_effects: [],
     };
     await appendEvent(session, event);
@@ -652,6 +683,7 @@ function createAbilityExecutor(deps) {
         target_hp_before: hpBefore,
         target_hp_after: target.hp,
         removed_status: removedStatus,
+        chain_healed: chainHealed,
         ap_remaining: actor.ap_remaining,
       },
     };

--- a/apps/backend/services/combat/symbiontBond.js
+++ b/apps/backend/services/combat/symbiontBond.js
@@ -124,9 +124,45 @@ function applyBondRedirect(session, target, damageDealt) {
   };
 }
 
+/**
+ * SYMBIONT sy_r5_sacrifice_grace (TKT-JOB-PHASEC B4b, V3) — when a bonded partner
+ * DIES, its (living) symbiont heals heal_pct of its max_hp + gains rage. Called
+ * from performAttack when a unit with _bonded_by drops to 0. No-op (null) if the
+ * partner is not bonded, the symbiont is missing/dead, or lacks the perk.
+ *
+ * @param {object} session — { units }
+ * @param {object} deadPartner — the bonded partner that just died (hp <= 0)
+ * @returns {object|null}
+ */
+function applyBondedDeathGrace(session, deadPartner) {
+  if (!session || !deadPartner || !deadPartner._bonded_by) return null;
+  const symbiont = (session.units || []).find((u) => u && u.id === deadPartner._bonded_by);
+  if (!symbiont || Number(symbiont.hp) <= 0) return null;
+  const grace = findPassive(symbiont, 'bonded_death_grace');
+  if (!grace) return null;
+  const healPct = Number(grace.payload && grace.payload.heal_pct) || 0.5;
+  const rageTurns = Number(grace.payload && grace.payload.rage_turns) || 0;
+  const maxHp = Number(symbiont.max_hp || symbiont.hp) || 0;
+  const before = Number(symbiont.hp) || 0;
+  const heal = Math.floor(maxHp * healPct);
+  symbiont.hp = maxHp > 0 ? Math.min(maxHp, before + heal) : before + heal;
+  if (rageTurns > 0) {
+    if (!symbiont.status) symbiont.status = {};
+    symbiont.status.rage = Math.max(Number(symbiont.status.rage) || 0, rageTurns);
+  }
+  return {
+    type: 'bonded_death_grace',
+    symbiont_id: symbiont.id,
+    partner_id: deadPartner.id,
+    healed: symbiont.hp - before,
+    rage_turns: rageTurns,
+  };
+}
+
 module.exports = {
   computeBondConfig,
   applyBondRedirect,
+  applyBondedDeathGrace,
   DEFAULT_REDIRECT_PCT,
   STRONG_REDIRECT_PCT,
   SECONDARY_REDIRECT_PCT,

--- a/apps/backend/services/progression/progressionApply.js
+++ b/apps/backend/services/progression/progressionApply.js
@@ -387,6 +387,37 @@ function computePerkDefenseBonus(defender, ctx = {}) {
           });
         }
       }
+    } else if (p.tag === 'bonded_proximity_defense') {
+      // SYMBIONT sy_r2_resonance (TKT-JOB-PHASEC B4b): +per_ally defense for each
+      // ally adjacent to the bonded PARTNER (not the symbiont), capped at max.
+      // Reads defender._bond.partner_id (set by symbiotic_bond).
+      const bond = defender._bond;
+      const partner =
+        bond && bond.partner_id ? units.find((u) => u && u.id === bond.partner_id) : null;
+      if (partner && partner.position) {
+        const perAlly = Number(p.payload?.per_ally) || 1;
+        const maxBonus = Number(p.payload?.max) || 3;
+        let adjacent = 0;
+        for (const u of units) {
+          if (!u || u.id === defender.id || u.id === partner.id) continue;
+          if (u.controlled_by !== defender.controlled_by) continue;
+          if (Number(u.hp) <= 0 || !u.position) continue;
+          const d =
+            Math.abs(u.position.x - partner.position.x) +
+            Math.abs(u.position.y - partner.position.y);
+          if (d <= 1) adjacent += 1;
+        }
+        const amt = Math.min(adjacent * perAlly, maxBonus);
+        if (amt > 0) {
+          out.bonus += amt;
+          out.applied.push({
+            tag: 'bonded_proximity_defense',
+            amount: amt,
+            source_perk_id: p.source_perk_id,
+            source_unit_id: defender.id,
+          });
+        }
+      }
     }
   }
   return out;

--- a/tests/progression/symbiontBondSupport.test.js
+++ b/tests/progression/symbiontBondSupport.test.js
@@ -173,7 +173,15 @@ test('chain_heal_adjacent: shared_vitality also heals allies adjacent to the tar
       { tag: 'chain_heal_adjacent', payload: { factor: 0.5 }, source_perk_id: 'sy_r4' },
     ],
   };
-  const target = { id: 'p', controlled_by: 'player', hp: 10, max_hp: 20, position: { x: 1, y: 0 } };
+  // target is THIS symbiont's bonded partner (chain heal is bond-scoped, Codex #2541 P2)
+  const target = {
+    id: 'p',
+    controlled_by: 'player',
+    hp: 10,
+    max_hp: 20,
+    position: { x: 1, y: 0 },
+    _bonded_by: 'sym',
+  };
   const adj = { id: 'adj', controlled_by: 'player', hp: 10, max_hp: 20, position: { x: 1, y: 1 } }; // adjacent to target
   const far = { id: 'far', controlled_by: 'player', hp: 10, max_hp: 20, position: { x: 9, y: 9 } };
   const res = await ex.executeAbility({
@@ -206,4 +214,28 @@ test('chain_heal_adjacent: absent → shared_vitality heals only the target', as
     body: { ability_id: 'shared_vitality', target_id: 'p' },
   });
   assert.strictEqual(adj.hp, 10, 'no chain heal without the perk');
+});
+
+test('chain_heal_adjacent: perk but UNbonded target → no chain (Codex #2541 P2)', async () => {
+  const ex = makeExecutor(() => 0.99);
+  const sym = {
+    id: 'sym',
+    job: 'symbiont',
+    controlled_by: 'player',
+    ap: 3,
+    ap_remaining: 3,
+    position: { x: 0, y: 0 },
+    _perk_passives: [
+      { tag: 'chain_heal_adjacent', payload: { factor: 0.5 }, source_perk_id: 'sy_r4' },
+    ],
+  };
+  // target is an ally but NOT bonded to this symbiont (no _bonded_by === 'sym')
+  const target = { id: 'p', controlled_by: 'player', hp: 10, max_hp: 20, position: { x: 1, y: 0 } };
+  const adj = { id: 'adj', controlled_by: 'player', hp: 10, max_hp: 20, position: { x: 1, y: 1 } };
+  await ex.executeAbility({
+    session: { units: [sym, target, adj], turn: 1 },
+    actor: sym,
+    body: { ability_id: 'shared_vitality', target_id: 'p' },
+  });
+  assert.strictEqual(adj.hp, 10, 'chain heal is bond-scoped — no chain on an unbonded ally');
 });

--- a/tests/progression/symbiontBondSupport.test.js
+++ b/tests/progression/symbiontBondSupport.test.js
@@ -1,0 +1,209 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  computePerkDefenseBonus,
+} = require('../../apps/backend/services/progression/progressionApply');
+const { applyBondedDeathGrace } = require('../../apps/backend/services/combat/symbiontBond');
+const { createAbilityExecutor } = require('../../apps/backend/services/abilityExecutor');
+
+// TKT-JOB-PHASEC slice B4b (Cat C/D/G, OQ-BOND verdict V3) — the 3 non-redirect
+// symbiont tags: bonded_proximity_defense (def per ally adjacent to the bonded
+// partner, via the slice-1 def-eval seam), chain_heal_adjacent (shared_vitality
+// also heals allies adjacent to the bonded partner), bonded_death_grace (the
+// symbiont heals + rages when its bonded partner dies).
+
+// --- bonded_proximity_defense (computePerkDefenseBonus self-passive) ---
+
+function ally(id, x, y, extra = {}) {
+  return { id, controlled_by: 'player', hp: 20, max_hp: 20, position: { x, y }, ...extra };
+}
+
+test('bonded_proximity_defense: +1 def per ally adjacent to the bonded partner', () => {
+  const sym = ally('sym', 0, 0, {
+    _bond: { partner_id: 'p' },
+    _perk_passives: [
+      {
+        tag: 'bonded_proximity_defense',
+        payload: { per_ally: 1, max: 3 },
+        source_perk_id: 'sy_r2',
+      },
+    ],
+  });
+  const partner = ally('p', 5, 5);
+  const units = [
+    sym,
+    partner,
+    ally('a1', 5, 6), // adjacent to partner
+    ally('a2', 6, 5), // adjacent to partner
+    ally('far', 0, 1), // adjacent to sym, NOT partner
+  ];
+  const r = computePerkDefenseBonus(sym, { units });
+  assert.strictEqual(r.bonus, 2, 'a1 + a2 adjacent to the bonded partner');
+});
+
+test('bonded_proximity_defense: capped at max', () => {
+  const sym = ally('sym', 0, 0, {
+    _bond: { partner_id: 'p' },
+    _perk_passives: [
+      {
+        tag: 'bonded_proximity_defense',
+        payload: { per_ally: 1, max: 3 },
+        source_perk_id: 'sy_r2',
+      },
+    ],
+  });
+  const partner = ally('p', 5, 5);
+  const units = [
+    sym,
+    partner,
+    ally('a1', 5, 6),
+    ally('a2', 6, 5),
+    ally('a3', 4, 5),
+    ally('a4', 5, 4), // 4 adjacent → capped at 3
+  ];
+  const r = computePerkDefenseBonus(sym, { units });
+  assert.strictEqual(r.bonus, 3, 'capped at max 3');
+});
+
+test('bonded_proximity_defense: no bond → no bonus', () => {
+  const sym = ally('sym', 0, 0, {
+    _perk_passives: [
+      {
+        tag: 'bonded_proximity_defense',
+        payload: { per_ally: 1, max: 3 },
+        source_perk_id: 'sy_r2',
+      },
+    ],
+  });
+  const r = computePerkDefenseBonus(sym, { units: [sym, ally('x', 0, 1)] });
+  assert.strictEqual(r.bonus, 0);
+});
+
+// --- bonded_death_grace (applyBondedDeathGrace) ---
+
+test('bonded_death_grace: dead partner heals the symbiont 50% max_hp + rage', () => {
+  const sym = {
+    id: 'sym',
+    hp: 4,
+    max_hp: 20,
+    status: {},
+    _perk_passives: [
+      {
+        tag: 'bonded_death_grace',
+        payload: { heal_pct: 0.5, rage_turns: 3 },
+        source_perk_id: 'sy_r5',
+      },
+    ],
+  };
+  const partner = { id: 'p', hp: 0, _bonded_by: 'sym' };
+  const r = applyBondedDeathGrace({ units: [sym, partner], turn: 1 }, partner);
+  assert.ok(r, 'grace fired');
+  assert.strictEqual(r.healed, 10, '50% of 20');
+  assert.strictEqual(sym.hp, 14, '4 + 10');
+  assert.strictEqual(sym.status.rage, 3);
+});
+
+test('bonded_death_grace: heal capped at max_hp', () => {
+  const sym = {
+    id: 'sym',
+    hp: 18,
+    max_hp: 20,
+    status: {},
+    _perk_passives: [
+      {
+        tag: 'bonded_death_grace',
+        payload: { heal_pct: 0.5, rage_turns: 3 },
+        source_perk_id: 'sy_r5',
+      },
+    ],
+  };
+  const partner = { id: 'p', hp: 0, _bonded_by: 'sym' };
+  applyBondedDeathGrace({ units: [sym, partner], turn: 1 }, partner);
+  assert.strictEqual(sym.hp, 20, 'capped at max_hp');
+});
+
+test('bonded_death_grace: no perk → null', () => {
+  const sym = { id: 'sym', hp: 4, max_hp: 20, status: {}, _perk_passives: [] };
+  const partner = { id: 'p', hp: 0, _bonded_by: 'sym' };
+  assert.strictEqual(applyBondedDeathGrace({ units: [sym, partner], turn: 1 }, partner), null);
+});
+
+test('bonded_death_grace: dead symbiont cannot grace → null', () => {
+  const sym = {
+    id: 'sym',
+    hp: 0,
+    max_hp: 20,
+    status: {},
+    _perk_passives: [
+      {
+        tag: 'bonded_death_grace',
+        payload: { heal_pct: 0.5, rage_turns: 3 },
+        source_perk_id: 'sy_r5',
+      },
+    ],
+  };
+  const partner = { id: 'p', hp: 0, _bonded_by: 'sym' };
+  assert.strictEqual(applyBondedDeathGrace({ units: [sym, partner], turn: 1 }, partner), null);
+});
+
+// --- chain_heal_adjacent (executeHeal shared_vitality integration) ---
+
+function makeExecutor(rng) {
+  return createAbilityExecutor({
+    performAttack: () => ({ damageDealt: 0, result: {} }),
+    buildAttackEvent: () => ({}),
+    appendEvent: async () => {},
+    manhattanDistance: (p, q) => Math.abs(p.x - q.x) + Math.abs(p.y - q.y),
+    rng,
+  });
+}
+
+test('chain_heal_adjacent: shared_vitality also heals allies adjacent to the target at 50%', async () => {
+  const ex = makeExecutor(() => 0.99); // 1d4 → 4
+  const sym = {
+    id: 'sym',
+    job: 'symbiont',
+    controlled_by: 'player',
+    ap: 3,
+    ap_remaining: 3,
+    position: { x: 0, y: 0 },
+    _perk_passives: [
+      { tag: 'chain_heal_adjacent', payload: { factor: 0.5 }, source_perk_id: 'sy_r4' },
+    ],
+  };
+  const target = { id: 'p', controlled_by: 'player', hp: 10, max_hp: 20, position: { x: 1, y: 0 } };
+  const adj = { id: 'adj', controlled_by: 'player', hp: 10, max_hp: 20, position: { x: 1, y: 1 } }; // adjacent to target
+  const far = { id: 'far', controlled_by: 'player', hp: 10, max_hp: 20, position: { x: 9, y: 9 } };
+  const res = await ex.executeAbility({
+    session: { units: [sym, target, adj, far], turn: 1 },
+    actor: sym,
+    body: { ability_id: 'shared_vitality', target_id: 'p' },
+  });
+  assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+  assert.strictEqual(target.hp, 14, 'primary heal 4');
+  assert.strictEqual(adj.hp, 12, 'chain heal floor(4*0.5)=2');
+  assert.strictEqual(far.hp, 10, 'non-adjacent ally not chained');
+});
+
+test('chain_heal_adjacent: absent → shared_vitality heals only the target', async () => {
+  const ex = makeExecutor(() => 0.99);
+  const sym = {
+    id: 'sym',
+    job: 'symbiont',
+    controlled_by: 'player',
+    ap: 3,
+    ap_remaining: 3,
+    position: { x: 0, y: 0 },
+    _perk_passives: [],
+  };
+  const target = { id: 'p', controlled_by: 'player', hp: 10, max_hp: 20, position: { x: 1, y: 0 } };
+  const adj = { id: 'adj', controlled_by: 'player', hp: 10, max_hp: 20, position: { x: 1, y: 1 } };
+  await ex.executeAbility({
+    session: { units: [sym, target, adj], turn: 1 },
+    actor: sym,
+    body: { ability_id: 'shared_vitality', target_id: 'p' },
+  });
+  assert.strictEqual(adj.hp, 10, 'no chain heal without the perk');
+});


### PR DESCRIPTION
## TKT-JOB-PHASEC slice B4b — completes the symbiont fork (B4 7/7)

The 3 non-redirect symbiont tags (B4a shipped the core bond + 4 redirect tags in #2539). Symbiont B4 now **7/7**.

### Tags wired
- **bonded_proximity_defense** (sy_r2_resonance): +`per_ally` defense for each ally adjacent to the **bonded partner** (capped at `max`). New self-passive case in `computePerkDefenseBonus` (reuses the slice-1 def-eval seam).
- **chain_heal_adjacent** (sy_r4_chain_heal): `shared_vitality` also heals allies adjacent to the heal target at `factor` (0.5) of the applied heal. In `executeHeal`, symbiont-gated.
- **bonded_death_grace** (sy_r5_sacrifice_grace): when a bonded partner dies (redirect could not save it), the symbiont heals `heal_pct` of max_hp + gains `rage_turns`. New `symbiontBond.applyBondedDeathGrace`, hooked in `performAttack` after the redirect hook (gated on final `killOccurred` + `target._bonded_by`).

### Tests (TDD red→green)
`tests/progression/symbiontBondSupport.test.js` (9): proximity-defense ×3 (count / cap / no-bond) + death-grace ×4 (heal+rage / cap / no-perk / dead-symbiont) + chain-heal ×2 (adjacent at 50% / absent). Regression: progression **102/102**, AI **500/500**.

### Band-verify
**Band-neutral by construction** — symbiont job absent from every HC sim party; all three effects gate on the symbiont bond/perks which no HC unit carries. HC06/HC07 byte-identical → skipped + documented.

### Surface (Gate-5)
proximity-defense → harder-to-hit symbiont (dc); chain-heal → adjacent allies' HP rises (+ `chain_healed` in the heal event/response); death-grace → symbiont HP/rage + `bonded_death_grace` telemetry log.

No data, no schema, no new deps. No forbidden paths.