### PR TITLE
feat(combat): phasec v5 symbiont shared_hp_pool capstone (symbiont 8/8)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -907,6 +907,30 @@ function createSessionRouter(options = {}) {
             // killOccurred reflects the struck target's post-split HP (both_ko sets
             // both to 0; otherwise the target may now survive on the shared pool).
             killOccurred = Number(target.hp) <= 0;
+            // Codex #2542 P2: the SG accrual above credited the struck unit the full
+            // hit; reconcile to the split (refund the over-count from the struck unit,
+            // credit the counterpart its actual share) so the capstone does not distort
+            // SG-economy progression. Mirrors the damage_taken reconcile in the pool.
+            try {
+              const sgT = require('../services/combat/sgTracker');
+              const overCredit = damageDealt - (symbiontPoolResult.target_actual || 0);
+              if (overCredit > 0) {
+                sgT.initUnit(target);
+                const red =
+                  1 - Math.min(0.5, Math.max(0, Number(target.stress_reduction_bonus || 0)));
+                target.sg_taken_acc = Math.max(0, target.sg_taken_acc - overCredit * red);
+              }
+              const counterpart = (session.units || []).find(
+                (u) => u && u.id === symbiontPoolResult.counterpart_id,
+              );
+              if (counterpart && (symbiontPoolResult.counter_actual || 0) > 0) {
+                sgT.accumulate(counterpart, {
+                  damage_taken: symbiontPoolResult.counter_actual,
+                });
+              }
+            } catch {
+              /* sgTracker optional */
+            }
             if (
               symbiontPoolResult.both_ko &&
               !process.env.IDEA_ENGINE_DISABLE_BOND_LOG &&
@@ -1077,6 +1101,19 @@ function createSessionRouter(options = {}) {
             session.damage_taken[target.id] = (session.damage_taken[target.id] || 0) + burst;
             if (target.hp === 0) {
               killOccurred = true;
+            }
+            // V5 shared_hp_pool (Codex #2542): the terrain burst lands AFTER the
+            // pool hook, bypassing it — re-split it too. No-op for non-pool targets.
+            try {
+              const pr = require('../services/combat/symbiontBond').applySharedHpPool(
+                session,
+                target,
+                burst,
+                Number(target.hp) + burst,
+              );
+              if (pr) killOccurred = Number(target.hp) <= 0;
+            } catch {
+              /* symbiont bond optional */
             }
           }
         }

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -839,22 +839,9 @@ function createSessionRouter(options = {}) {
       if (target.hp === 0) {
         killOccurred = true;
       }
-      // Sprint α (Hard West 2 pattern): bravado AP refill su chain-kill player.
-      // Solo player (asimmetria risk/reward); cap actor.ap. Lazy require.
-      // Opt-in via BRAVADO_ENABLED=true (default OFF per back-compat con
-      // tutorial AP budget tests). Activation deferred a calibration sprint
-      // (segue pattern LOBBY_WS_ENABLED M11).
-      if (killOccurred && process.env.BRAVADO_ENABLED === 'true') {
-        try {
-          const { onKillRefill } = require('../services/combat/bravado');
-          const bravadoRes = onKillRefill(actor, target);
-          if (bravadoRes.refilled > 0) {
-            actor.bravado_refill_last = bravadoRes.refilled;
-          }
-        } catch {
-          /* bravado optional */
-        }
-      }
+      // NB Sprint α bravado AP refill MOVED to the final-killOccurred kill-hook
+      // (Codex #2542 P2): running it here granted a kill reward even when
+      // intercept/bond/shared_hp_pool later revived the target.
       // iter4 reaction engine: intercept reroute damage da target a alleato
       // adiacente con `intercept` armed. Restore target.hp + transfer to interceptor.
       if (damageDealt > 0) {
@@ -1159,6 +1146,21 @@ function createSessionRouter(options = {}) {
       // Surfaced by the debrief + consumed by grantXpToSurvivors' first_kill_pe_bonus.
       if (session._first_kill_actor_id == null) {
         session._first_kill_actor_id = actor.id;
+      }
+      // Sprint α (Hard West 2 pattern): bravado AP refill on a chain-kill. Moved
+      // here from the damage step (Codex #2542 P2) so it gates on the FINAL
+      // killOccurred — after intercept/bond/shared_hp_pool revives — and never
+      // rewards a kill the shared pool undid. Opt-in via BRAVADO_ENABLED=true.
+      if (process.env.BRAVADO_ENABLED === 'true') {
+        try {
+          const { onKillRefill } = require('../services/combat/bravado');
+          const bravadoRes = onKillRefill(actor, target);
+          if (bravadoRes.refilled > 0) {
+            actor.bravado_refill_last = bravadoRes.refilled;
+          }
+        } catch {
+          /* bravado optional */
+        }
       }
     }
 

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -1083,6 +1083,7 @@ function createSessionRouter(options = {}) {
           // Apply burst damage to occupant (still alive) — feeds back into HP.
           if (terrainReactionResult.burst_damage > 0 && target.hp > 0) {
             const burst = terrainReactionResult.burst_damage;
+            const preBurstHp = Number(target.hp); // pre-floor; the pool split needs the real pre-burst HP
             target.hp = Math.max(0, target.hp - burst);
             damageDealt += burst;
             session.damage_taken[target.id] = (session.damage_taken[target.id] || 0) + burst;
@@ -1096,7 +1097,7 @@ function createSessionRouter(options = {}) {
                 session,
                 target,
                 burst,
-                Number(target.hp) + burst,
+                preBurstHp,
               );
               if (pr) killOccurred = Number(target.hp) <= 0;
             } catch {

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -670,6 +670,7 @@ function createSessionRouter(options = {}) {
     let interceptResult = null;
     let bondReactionResult = null;
     let symbiontRedirectResult = null;
+    let symbiontPoolResult = null;
     let symbiontDeathGraceResult = null;
     let terrainReactionResult = null;
     // M14-A residuo close (TKT-09 2026-04-26): surface positional info
@@ -833,6 +834,7 @@ function createSessionRouter(options = {}) {
           /* sgTracker optional */
         }
       }
+      const targetHpPreDamage = Number(target.hp); // pre-floor (V5 shared_hp_pool needs overkill)
       target.hp = Math.max(0, target.hp - damageDealt);
       if (target.hp === 0) {
         killOccurred = true;
@@ -888,12 +890,56 @@ function createSessionRouter(options = {}) {
           }
         }
       }
+      // TKT-JOB-PHASEC slice V5 (capstone sy_r6_one_soul) — shared_hp_pool. The
+      // symbiont + its primary bonded partner share a combined HP pool; the hit is
+      // split equally + both KO together when the pool empties. SUPERSEDES the
+      // redirect (mutual exclusion below) and bonded_death_grace (a dead symbiont
+      // can't grace). Uses the pre-floor target HP for the both-KO check.
+      if (damageDealt > 0 && !interceptResult && !bondReactionResult) {
+        try {
+          symbiontPoolResult = require('../services/combat/symbiontBond').applySharedHpPool(
+            session,
+            target,
+            damageDealt,
+            targetHpPreDamage,
+          );
+          if (symbiontPoolResult) {
+            // killOccurred reflects the struck target's post-split HP (both_ko sets
+            // both to 0; otherwise the target may now survive on the shared pool).
+            killOccurred = Number(target.hp) <= 0;
+            if (
+              symbiontPoolResult.both_ko &&
+              !process.env.IDEA_ENGINE_DISABLE_BOND_LOG &&
+              process.env.NODE_ENV !== 'test'
+            ) {
+              try {
+                // eslint-disable-next-line no-console
+                console.info(
+                  JSON.stringify({
+                    component: 'symbiont-bond',
+                    event: 'shared_hp_pool_both_ko',
+                    session_id: session.session_id || null,
+                    turn: session.turn,
+                    symbiont_id: symbiontPoolResult.symbiont_id,
+                    partner_id: symbiontPoolResult.partner_id,
+                  }),
+                );
+              } catch {
+                /* structured log best-effort */
+              }
+            }
+          }
+        } catch {
+          /* symbiont bond optional; never break the hit */
+        }
+      }
       // TKT-JOB-PHASEC slice B4a (OQ-BOND verdict V3) — symbiont bond redirect.
       // Fires on the residual damage AFTER intercept + companion bond (one absorb
       // layer per hit: gated on !interceptResult && !bondReactionResult). Moves a
       // share of the bonded partner's damage to the symbiont (capped at its HP),
-      // restoring the partner; resets killOccurred if the partner survives.
-      if (damageDealt > 0 && !interceptResult && !bondReactionResult) {
+      // restoring the partner; resets killOccurred if the partner survives. Skipped
+      // when shared_hp_pool already handled the pair (mutual exclusion).
+      if (damageDealt > 0 && !interceptResult && !bondReactionResult && !symbiontPoolResult) {
         try {
           const symbiontBond = require('../services/combat/symbiontBond');
           symbiontRedirectResult = symbiontBond.applyBondRedirect(session, target, damageDealt);

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -439,19 +439,46 @@ function createRoundBridge(deps) {
         // RIGHT AFTER it lands, BEFORE the next bonus block reads target.hp — else a
         // pooled target floored to 0 by focus_fire makes synergy read 0 and skip its
         // stackable bonus. No-op for non-pool targets (applySharedHpPool -> null).
-        const resplitBonusThroughPool = (bonus) => {
-          if (!(bonus > 0)) return;
+        // V5 shared_hp_pool (Codex #2542 P2): apply a focus_fire/synergy bonus with
+        // its FULL value through the pool, so a low-HP pooled member doesn't starve
+        // the bonus (the bonded partner absorbs the overflow) and each stacked bonus
+        // reads pool-restored HP. Pre-credit the full bonus to damage_taken; the pool
+        // reconciles it (-extra + actual) when pooled, else fall back to the solo
+        // clamp (undo the over-credit). Returns the damage that actually landed.
+        const applyBonusThroughPool = (extra) => {
+          if (!(extra > 0)) return 0;
+          const hpNow = Number(target.hp || 0);
+          if (hpNow <= 0) return 0;
+          const soloApplied = Math.min(extra, hpNow);
+          if (session.damage_taken) {
+            session.damage_taken[target.id] = (session.damage_taken[target.id] || 0) + extra;
+          }
+          target.hp = hpNow - soloApplied; // tentative solo; the pool overrides when pooled
+          let pr = null;
           try {
-            const pr = require('../services/combat/symbiontBond').applySharedHpPool(
+            pr = require('../services/combat/symbiontBond').applySharedHpPool(
               session,
               target,
-              bonus,
-              Number(target.hp) + bonus,
+              extra,
+              hpNow,
             );
-            if (pr) capturedResults.killOccurred = Number(target.hp) <= 0;
           } catch {
             /* symbiont bond optional */
           }
+          if (pr) {
+            capturedResults.killOccurred = Number(target.hp) <= 0;
+            return extra;
+          }
+          if (session.damage_taken) {
+            session.damage_taken[target.id] = Math.max(
+              0,
+              (session.damage_taken[target.id] || 0) - extra + soloApplied,
+            );
+          }
+          if (Number(target.hp) <= 0 && !capturedResults.killOccurred) {
+            capturedResults.killOccurred = true;
+          }
+          return soloApplied;
         };
         // Pilastro 5: focus_fire combo. Se altri player hanno gia' colpito lo
         // stesso target in questo round, +1 dmg al secondo/terzo attacco.
@@ -461,21 +488,9 @@ function createRoundBridge(deps) {
         if (res.result && res.result.hit && comboInfo.is_combo) {
           let applied = 0;
           if (res.damageDealt > 0) {
-            const extra = comboInfo.bonus_damage;
-            const hpNow = Number(target.hp || 0);
-            applied = Math.min(extra, hpNow);
+            applied = applyBonusThroughPool(comboInfo.bonus_damage);
             if (applied > 0) {
-              target.hp = hpNow - applied;
               capturedResults.damageDealt = res.damageDealt + applied;
-              if (session.damage_taken) {
-                session.damage_taken[target.id] = (session.damage_taken[target.id] || 0) + applied;
-              }
-              // Re-split focus_fire through the pool now, so the synergy block below
-              // reads the pool-restored HP (not a transient solo 0).
-              resplitBonusThroughPool(applied);
-              if (target.hp <= 0 && !capturedResults.killOccurred) {
-                capturedResults.killOccurred = true;
-              }
             }
           }
           capturedResults.combo = { ...comboInfo, bonus_applied: applied };
@@ -487,28 +502,15 @@ function createRoundBridge(deps) {
         if (res.result && res.result.hit && synergyInfo.triggered) {
           let appliedSyn = 0;
           if (res.damageDealt > 0) {
-            const extra = synergyInfo.bonus_damage;
-            const hpNow = Number(target.hp || 0);
-            appliedSyn = Math.min(extra, hpNow);
+            appliedSyn = applyBonusThroughPool(synergyInfo.bonus_damage);
             if (appliedSyn > 0) {
-              target.hp = hpNow - appliedSyn;
               capturedResults.damageDealt =
                 Number(capturedResults.damageDealt || res.damageDealt) + appliedSyn;
-              if (session.damage_taken) {
-                session.damage_taken[target.id] =
-                  (session.damage_taken[target.id] || 0) + appliedSyn;
-              }
-              resplitBonusThroughPool(appliedSyn);
-              if (target.hp <= 0 && !capturedResults.killOccurred) {
-                capturedResults.killOccurred = true;
-              }
             }
           }
           capturedResults.synergy = { ...synergyInfo, bonus_applied: appliedSyn };
           recordSynergyFire(session, actor, target, synergyInfo, appliedSyn);
         }
-        // (shared_hp_pool re-split now runs inline per-bonus above, so each bonus
-        // sees the pool-restored HP — Codex #2542 P2.)
         for (const uOrch of next.units) {
           const uLegacy = session.units.find((u) => u.id === uOrch.id);
           if (uLegacy) {
@@ -1350,36 +1352,47 @@ function createRoundBridge(deps) {
 
           let combo = null;
           let synergy = null;
-          // V5 shared_hp_pool (Codex #2542 P2): re-split each bonus through the pool
-          // as it lands, so the next bonus reads pool-restored HP (not a transient
-          // solo 0). Mirror of realResolveAction. No-op for non-pool targets.
-          const resplitBonusThroughPool = (bonus) => {
-            if (!(bonus > 0)) return;
+          // V5 shared_hp_pool (Codex #2542 P2): apply a bonus with its FULL value
+          // through the pool (a low-HP pooled member doesn't starve it; the partner
+          // absorbs the overflow) + each stacked bonus reads pool-restored HP.
+          // Pre-credit the full bonus to damage_taken; the pool reconciles it when
+          // pooled, else fall back to the solo clamp. Returns the damage that landed.
+          // (This path detects kills via target.hp <= 0 below, so no killOccurred.)
+          const applyBonusThroughPool = (extra) => {
+            if (!(extra > 0)) return 0;
+            const hpNow = Number(target.hp || 0);
+            if (hpNow <= 0) return 0;
+            const soloApplied = Math.min(extra, hpNow);
+            if (session.damage_taken) {
+              session.damage_taken[target.id] = (session.damage_taken[target.id] || 0) + extra;
+            }
+            target.hp = hpNow - soloApplied;
+            let pr = null;
             try {
-              require('../services/combat/symbiontBond').applySharedHpPool(
+              pr = require('../services/combat/symbiontBond').applySharedHpPool(
                 session,
                 target,
-                bonus,
-                Number(target.hp) + bonus,
+                extra,
+                hpNow,
               );
             } catch {
               /* symbiont bond optional */
             }
+            if (pr) return extra;
+            if (session.damage_taken) {
+              session.damage_taken[target.id] = Math.max(
+                0,
+                (session.damage_taken[target.id] || 0) - extra + soloApplied,
+              );
+            }
+            return soloApplied;
           };
           if (!isSis) {
             const comboInfo = detectFocusFireCombo(session, actor, target);
             if (res.result && res.result.hit && comboInfo.is_combo && res.damageDealt > 0) {
-              const extra = comboInfo.bonus_damage;
-              const hpNow = Number(target.hp || 0);
-              const applied = Math.min(extra, hpNow);
+              const applied = applyBonusThroughPool(comboInfo.bonus_damage);
               if (applied > 0) {
-                target.hp = hpNow - applied;
                 res.damageDealt = res.damageDealt + applied;
-                if (session.damage_taken) {
-                  session.damage_taken[target.id] =
-                    (session.damage_taken[target.id] || 0) + applied;
-                }
-                resplitBonusThroughPool(applied);
               }
               combo = { ...comboInfo, bonus_applied: applied };
             }
@@ -1391,17 +1404,9 @@ function createRoundBridge(deps) {
           if (res.result && res.result.hit && synergyInfo.triggered) {
             let appliedSyn = 0;
             if (res.damageDealt > 0) {
-              const extra = synergyInfo.bonus_damage;
-              const hpNow = Number(target.hp || 0);
-              appliedSyn = Math.min(extra, hpNow);
+              appliedSyn = applyBonusThroughPool(synergyInfo.bonus_damage);
               if (appliedSyn > 0) {
-                target.hp = hpNow - appliedSyn;
                 res.damageDealt = res.damageDealt + appliedSyn;
-                if (session.damage_taken) {
-                  session.damage_taken[target.id] =
-                    (session.damage_taken[target.id] || 0) + appliedSyn;
-                }
-                resplitBonusThroughPool(appliedSyn);
               }
             }
             synergy = { ...synergyInfo, bonus_applied: appliedSyn };

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -773,6 +773,7 @@ function createRoundBridge(deps) {
       }
       if (capturedResults.killOccurred) {
         await emitKillAndAssists(session, actor, target, event);
+        await emitPoolCounterpartKo(session, actor, target, event);
         // Sistema pressure (AI War pattern — sistema_pressure.yaml §deltas):
         //   player KO sistema  → +pg_kills_sis  (pressure sale)
         //   sistema KO player  → +sg_pg_down    (pressure cala, Sistema si placa)
@@ -1534,9 +1535,39 @@ function createRoundBridge(deps) {
     return { resolveFn, iaActions, playerActions, kills };
   }
 
+  // V5 shared_hp_pool (Codex #2542 P2): when a pool both-KO drops the struck
+  // target AND its bonded counterpart to 0 in one hit, the counterpart death is
+  // otherwise silent (kill plumbing only tracks `target`). Surface it: emit a
+  // kill/assist + pressure delta for the counterpart too. The living-members gate
+  // in applySharedHpPool guarantees the counterpart was alive pre-hit, so a 0-HP
+  // counterpart here means it died THIS hit. Mirrors the interceptor_killed chain.
+  async function emitPoolCounterpartKo(session, actor, target, event) {
+    if (!target) return;
+    const partnerId = (target._bond && target._bond.partner_id) || target._bonded_by || null;
+    if (!partnerId) return;
+    const cp = (session.units || []).find((u) => u && u.id === partnerId);
+    if (!cp || Number(cp.hp) > 0 || cp._pool_ko_emitted) return;
+    cp._pool_ko_emitted = true;
+    await emitKillAndAssists(session, actor, cp, event);
+    if (typeof session.sistema_pressure === 'number') {
+      if (actor.controlled_by === 'player' && cp.controlled_by === 'sistema') {
+        session.sistema_pressure = applyPressureDelta(
+          session.sistema_pressure,
+          PRESSURE_DELTAS.pg_kills_sis,
+        );
+      } else if (actor.controlled_by === 'sistema' && cp.controlled_by === 'player') {
+        session.sistema_pressure = applyPressureDelta(
+          session.sistema_pressure,
+          PRESSURE_DELTAS.sg_pg_down,
+        );
+      }
+    }
+  }
+
   async function postResolveKills(session, kills) {
     for (const { actor, target, event } of kills) {
       await emitKillAndAssists(session, actor, target, event);
+      await emitPoolCounterpartKo(session, actor, target, event);
       if (typeof session.sistema_pressure === 'number') {
         if (actor.controlled_by === 'player' && target.controlled_by === 'sistema') {
           session.sistema_pressure = applyPressureDelta(

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -1528,6 +1528,19 @@ function createRoundBridge(deps) {
         if (tgtLegacy && tgtOrch && tgtOrch.hp) {
           tgtOrch.hp.current = Number(tgtLegacy.hp || 0);
         }
+        // V5 shared_hp_pool (Codex #2542 P1): a pool hit also mutates the bonded
+        // counterpart's HP, but this path syncs only actor+target back to
+        // roundState. Sync the counterpart too (harmless no-op if it didn't change)
+        // so its roundState HP isn't stale for later intents / UI / end-of-round.
+        const partnerId =
+          tgtLegacy && ((tgtLegacy._bond && tgtLegacy._bond.partner_id) || tgtLegacy._bonded_by);
+        if (partnerId) {
+          const cpLegacy = session.units.find((u) => u.id === partnerId);
+          const cpOrch = next.units.find((u) => u.id === partnerId);
+          if (cpLegacy && cpOrch && cpOrch.hp) {
+            cpOrch.hp.current = Number(cpLegacy.hp || 0);
+          }
+        }
       }
       return { nextState: next, turnLogEntry };
     };
@@ -1546,8 +1559,13 @@ function createRoundBridge(deps) {
     const partnerId = (target._bond && target._bond.partner_id) || target._bonded_by || null;
     if (!partnerId) return null;
     const cp = (session.units || []).find((u) => u && u.id === partnerId);
-    if (!cp || Number(cp.hp) > 0 || cp._pool_ko_emitted) return null;
+    // Codex #2542 P2: emit ONLY when applySharedHpPool actually pool-KO'd this cp
+    // this hit (the `_pool_both_ko` flag) — NOT for any bonded unit at 0. A
+    // dual_bond secondary (not pooled) or an already-dead symbiont must not emit
+    // a spurious extra kill/assist + pressure.
+    if (!cp || !cp._pool_both_ko || cp._pool_ko_emitted) return null;
     cp._pool_ko_emitted = true;
+    delete cp._pool_both_ko;
     await emitKillAndAssists(session, actor, cp, event);
     if (typeof session.sistema_pressure === 'number') {
       if (actor.controlled_by === 'player' && cp.controlled_by === 'sistema') {
@@ -1823,6 +1841,19 @@ function createRoundBridge(deps) {
         const tgtOrch = next.units.find((u) => u.id === String(action.target_id));
         if (tgtLegacy && tgtOrch && tgtOrch.hp) {
           tgtOrch.hp.current = Number(tgtLegacy.hp || 0);
+        }
+        // V5 shared_hp_pool (Codex #2542 P1): a pool hit also mutates the bonded
+        // counterpart's HP, but this path syncs only actor+target back to
+        // roundState. Sync the counterpart too (harmless no-op if it didn't change)
+        // so its roundState HP isn't stale for later intents / UI / end-of-round.
+        const partnerId =
+          tgtLegacy && ((tgtLegacy._bond && tgtLegacy._bond.partner_id) || tgtLegacy._bonded_by);
+        if (partnerId) {
+          const cpLegacy = session.units.find((u) => u.id === partnerId);
+          const cpOrch = next.units.find((u) => u.id === partnerId);
+          if (cpLegacy && cpOrch && cpOrch.hp) {
+            cpOrch.hp.current = Number(cpLegacy.hp || 0);
+          }
         }
       }
       return { nextState: next, turnLogEntry };

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -1542,11 +1542,11 @@ function createRoundBridge(deps) {
   // in applySharedHpPool guarantees the counterpart was alive pre-hit, so a 0-HP
   // counterpart here means it died THIS hit. Mirrors the interceptor_killed chain.
   async function emitPoolCounterpartKo(session, actor, target, event) {
-    if (!target) return;
+    if (!target) return null;
     const partnerId = (target._bond && target._bond.partner_id) || target._bonded_by || null;
-    if (!partnerId) return;
+    if (!partnerId) return null;
     const cp = (session.units || []).find((u) => u && u.id === partnerId);
-    if (!cp || Number(cp.hp) > 0 || cp._pool_ko_emitted) return;
+    if (!cp || Number(cp.hp) > 0 || cp._pool_ko_emitted) return null;
     cp._pool_ko_emitted = true;
     await emitKillAndAssists(session, actor, cp, event);
     if (typeof session.sistema_pressure === 'number') {
@@ -1562,12 +1562,13 @@ function createRoundBridge(deps) {
         );
       }
     }
+    return cp;
   }
 
   async function postResolveKills(session, kills) {
     for (const { actor, target, event } of kills) {
       await emitKillAndAssists(session, actor, target, event);
-      await emitPoolCounterpartKo(session, actor, target, event);
+      const poolCp = await emitPoolCounterpartKo(session, actor, target, event);
       if (typeof session.sistema_pressure === 'number') {
         if (actor.controlled_by === 'player' && target.controlled_by === 'sistema') {
           session.sistema_pressure = applyPressureDelta(
@@ -1587,16 +1588,20 @@ function createRoundBridge(deps) {
       // panic (or rarely rage). Best-effort; never blocks the kill flow.
       try {
         const { moraleEventsForKill } = require('../services/combat/moraleOnKill');
-        const moraleEvents = moraleEventsForKill(target, session.units, {
-          sessionId: session.session_id,
-          turn: session.turn,
-          // Codex #2450 P1: keep the post-kill morale d20 inside the session RNG
-          // (this path runs after runWithSeed restored the global stream).
-          rng: makeHolderRng(session.combatRng),
-        });
-        for (const mEv of moraleEvents) {
-          // eslint-disable-next-line no-await-in-loop
-          await appendEvent(session, mEv);
+        // Includes the pool counterpart on a shared_hp_pool both-KO (Codex #2542)
+        // so its adjacent allies also make a morale check, not just the target's.
+        for (const victim of [target, poolCp].filter(Boolean)) {
+          const moraleEvents = moraleEventsForKill(victim, session.units, {
+            sessionId: session.session_id,
+            turn: session.turn,
+            // Codex #2450 P1: keep the post-kill morale d20 inside the session RNG
+            // (this path runs after runWithSeed restored the global stream).
+            rng: makeHolderRng(session.combatRng),
+          });
+          for (const mEv of moraleEvents) {
+            // eslint-disable-next-line no-await-in-loop
+            await appendEvent(session, mEv);
+          }
         }
       } catch (err) {
         // eslint-disable-next-line no-console

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -485,6 +485,30 @@ function createRoundBridge(deps) {
           capturedResults.synergy = { ...synergyInfo, bonus_applied: appliedSyn };
           recordSynergyFire(session, actor, target, synergyInfo, appliedSyn);
         }
+        // V5 shared_hp_pool (Codex #2542 P2): the focus_fire/synergy bonuses above
+        // hit target.hp directly (after performAttack's pool split), bypassing the
+        // pool. If the target is a shared-pool member, re-split the cumulative bonus
+        // so the pair shares it + the both-KO invariant stays consistent. No-op for
+        // non-pool targets (applySharedHpPool returns null).
+        {
+          const poolBonus =
+            ((capturedResults.combo && capturedResults.combo.bonus_applied) || 0) +
+            ((capturedResults.synergy && capturedResults.synergy.bonus_applied) || 0);
+          if (poolBonus > 0) {
+            try {
+              const sb = require('../services/combat/symbiontBond');
+              const pr = sb.applySharedHpPool(
+                session,
+                target,
+                poolBonus,
+                Number(target.hp) + poolBonus,
+              );
+              if (pr) capturedResults.killOccurred = Number(target.hp) <= 0;
+            } catch {
+              /* symbiont bond optional */
+            }
+          }
+        }
         for (const uOrch of next.units) {
           const uLegacy = session.units.find((u) => u.id === uOrch.id);
           if (uLegacy) {
@@ -1363,6 +1387,24 @@ function createRoundBridge(deps) {
             }
             synergy = { ...synergyInfo, bonus_applied: appliedSyn };
             recordSynergyFire(session, actor, target, synergyInfo, appliedSyn);
+          }
+          // V5 shared_hp_pool (Codex #2542 P2): re-split the focus_fire/synergy bonus
+          // through the pool (mirror of realResolveAction). No-op for non-pool targets.
+          {
+            const poolBonus =
+              ((combo && combo.bonus_applied) || 0) + ((synergy && synergy.bonus_applied) || 0);
+            if (poolBonus > 0) {
+              try {
+                require('../services/combat/symbiontBond').applySharedHpPool(
+                  session,
+                  target,
+                  poolBonus,
+                  Number(target.hp) + poolBonus,
+                );
+              } catch {
+                /* symbiont bond optional */
+              }
+            }
           }
 
           const event = buildAttackEvent({

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -435,6 +435,24 @@ function createRoundBridge(deps) {
         capturedResults.beastBondReactions = Array.isArray(res.beast_bond_reactions)
           ? res.beast_bond_reactions
           : [];
+        // V5 shared_hp_pool (Codex #2542 P2): re-split a bonus through the pool
+        // RIGHT AFTER it lands, BEFORE the next bonus block reads target.hp — else a
+        // pooled target floored to 0 by focus_fire makes synergy read 0 and skip its
+        // stackable bonus. No-op for non-pool targets (applySharedHpPool -> null).
+        const resplitBonusThroughPool = (bonus) => {
+          if (!(bonus > 0)) return;
+          try {
+            const pr = require('../services/combat/symbiontBond').applySharedHpPool(
+              session,
+              target,
+              bonus,
+              Number(target.hp) + bonus,
+            );
+            if (pr) capturedResults.killOccurred = Number(target.hp) <= 0;
+          } catch {
+            /* symbiont bond optional */
+          }
+        };
         // Pilastro 5: focus_fire combo. Se altri player hanno gia' colpito lo
         // stesso target in questo round, +1 dmg al secondo/terzo attacco.
         // Fix flake (iter6): combo metadata esposta anche su hit con damage=0
@@ -452,6 +470,9 @@ function createRoundBridge(deps) {
               if (session.damage_taken) {
                 session.damage_taken[target.id] = (session.damage_taken[target.id] || 0) + applied;
               }
+              // Re-split focus_fire through the pool now, so the synergy block below
+              // reads the pool-restored HP (not a transient solo 0).
+              resplitBonusThroughPool(applied);
               if (target.hp <= 0 && !capturedResults.killOccurred) {
                 capturedResults.killOccurred = true;
               }
@@ -477,6 +498,7 @@ function createRoundBridge(deps) {
                 session.damage_taken[target.id] =
                   (session.damage_taken[target.id] || 0) + appliedSyn;
               }
+              resplitBonusThroughPool(appliedSyn);
               if (target.hp <= 0 && !capturedResults.killOccurred) {
                 capturedResults.killOccurred = true;
               }
@@ -485,30 +507,8 @@ function createRoundBridge(deps) {
           capturedResults.synergy = { ...synergyInfo, bonus_applied: appliedSyn };
           recordSynergyFire(session, actor, target, synergyInfo, appliedSyn);
         }
-        // V5 shared_hp_pool (Codex #2542 P2): the focus_fire/synergy bonuses above
-        // hit target.hp directly (after performAttack's pool split), bypassing the
-        // pool. If the target is a shared-pool member, re-split the cumulative bonus
-        // so the pair shares it + the both-KO invariant stays consistent. No-op for
-        // non-pool targets (applySharedHpPool returns null).
-        {
-          const poolBonus =
-            ((capturedResults.combo && capturedResults.combo.bonus_applied) || 0) +
-            ((capturedResults.synergy && capturedResults.synergy.bonus_applied) || 0);
-          if (poolBonus > 0) {
-            try {
-              const sb = require('../services/combat/symbiontBond');
-              const pr = sb.applySharedHpPool(
-                session,
-                target,
-                poolBonus,
-                Number(target.hp) + poolBonus,
-              );
-              if (pr) capturedResults.killOccurred = Number(target.hp) <= 0;
-            } catch {
-              /* symbiont bond optional */
-            }
-          }
-        }
+        // (shared_hp_pool re-split now runs inline per-bonus above, so each bonus
+        // sees the pool-restored HP — Codex #2542 P2.)
         for (const uOrch of next.units) {
           const uLegacy = session.units.find((u) => u.id === uOrch.id);
           if (uLegacy) {
@@ -1350,6 +1350,22 @@ function createRoundBridge(deps) {
 
           let combo = null;
           let synergy = null;
+          // V5 shared_hp_pool (Codex #2542 P2): re-split each bonus through the pool
+          // as it lands, so the next bonus reads pool-restored HP (not a transient
+          // solo 0). Mirror of realResolveAction. No-op for non-pool targets.
+          const resplitBonusThroughPool = (bonus) => {
+            if (!(bonus > 0)) return;
+            try {
+              require('../services/combat/symbiontBond').applySharedHpPool(
+                session,
+                target,
+                bonus,
+                Number(target.hp) + bonus,
+              );
+            } catch {
+              /* symbiont bond optional */
+            }
+          };
           if (!isSis) {
             const comboInfo = detectFocusFireCombo(session, actor, target);
             if (res.result && res.result.hit && comboInfo.is_combo && res.damageDealt > 0) {
@@ -1363,6 +1379,7 @@ function createRoundBridge(deps) {
                   session.damage_taken[target.id] =
                     (session.damage_taken[target.id] || 0) + applied;
                 }
+                resplitBonusThroughPool(applied);
               }
               combo = { ...comboInfo, bonus_applied: applied };
             }
@@ -1384,29 +1401,13 @@ function createRoundBridge(deps) {
                   session.damage_taken[target.id] =
                     (session.damage_taken[target.id] || 0) + appliedSyn;
                 }
+                resplitBonusThroughPool(appliedSyn);
               }
             }
             synergy = { ...synergyInfo, bonus_applied: appliedSyn };
             recordSynergyFire(session, actor, target, synergyInfo, appliedSyn);
           }
-          // V5 shared_hp_pool (Codex #2542 P2): re-split the focus_fire/synergy bonus
-          // through the pool (mirror of realResolveAction). No-op for non-pool targets.
-          {
-            const poolBonus =
-              ((combo && combo.bonus_applied) || 0) + ((synergy && synergy.bonus_applied) || 0);
-            if (poolBonus > 0) {
-              try {
-                require('../services/combat/symbiontBond').applySharedHpPool(
-                  session,
-                  target,
-                  poolBonus,
-                  Number(target.hp) + poolBonus,
-                );
-              } catch {
-                /* symbiont bond optional */
-              }
-            }
-          }
+          // (shared_hp_pool re-split now runs inline per-bonus above — Codex #2542 P2.)
 
           const event = buildAttackEvent({
             session,

--- a/apps/backend/services/combat/symbiontBond.js
+++ b/apps/backend/services/combat/symbiontBond.js
@@ -205,6 +205,12 @@ function applySharedHpPool(session, target, damageDealt, targetHpPreDamage) {
   const counterpart = target.id === symbiont.id ? partner : symbiont;
   const preTarget = Number(targetHpPreDamage);
   const preCounter = Number(counterpart.hp);
+  // Codex #2542 P1: both members must be ALIVE for the pool to activate. The
+  // struck unit's pre-DAMAGE HP is used (it is floored to 0 by performAttack
+  // before this runs, so its live HP would falsely read dead); the counterpart
+  // uses its live HP. A symbiont downed outside this pool (e.g. via a secondary
+  // dual_bond redirect) must not pool or be resurrected to 1 by the split.
+  if (preTarget <= 0 || preCounter <= 0) return null;
   const poolAfter = preTarget + preCounter - d;
 
   let bothKo = false;

--- a/apps/backend/services/combat/symbiontBond.js
+++ b/apps/backend/services/combat/symbiontBond.js
@@ -218,6 +218,10 @@ function applySharedHpPool(session, target, damageDealt, targetHpPreDamage) {
     target.hp = 0;
     counterpart.hp = 0;
     bothKo = true;
+    // Codex #2542 P2: definitive signal that THIS hit pool-KO'd the counterpart,
+    // so the bridge emits its kill ONLY on an actual pool both-KO (not merely a
+    // bonded unit that happens to be at 0). Consumed + cleared by the bridge.
+    counterpart._pool_both_ko = true;
   } else {
     // Equal split: the struck unit takes the ceil half, the counterpart the floor
     // half; overflow on either side is covered by the other (pool conserved).

--- a/apps/backend/services/combat/symbiontBond.js
+++ b/apps/backend/services/combat/symbiontBond.js
@@ -251,9 +251,22 @@ function applySharedHpPool(session, target, damageDealt, targetHpPreDamage) {
       c += give;
       t -= give;
     }
-    if (c < 0) c = 0;
-    target.hp = t;
-    counterpart.hp = c;
+    if (t < 1 || c < 1) {
+      // Codex #2542 P1: the remaining pool (a single odd HP) can't keep BOTH
+      // members >= 1. Per the capstone's "both KO together" invariant, the pair
+      // falls together rather than letting one silently drop to 0 while the other
+      // lives on (which the rest of the combat code would treat as a solo KO).
+      // NB Claude design call on the integer 1-HP tail (both-KO at pool <= 1) —
+      // pending master-dd review; the alternative "pin both at 1" creates a
+      // 1-damage immortality exploit at the tail.
+      target.hp = 0;
+      counterpart.hp = 0;
+      bothKo = true;
+      counterpart._pool_both_ko = true;
+    } else {
+      target.hp = t;
+      counterpart.hp = c;
+    }
   }
 
   // The actual damage each side absorbed after the split (pool conserved:

--- a/apps/backend/services/combat/symbiontBond.js
+++ b/apps/backend/services/combat/symbiontBond.js
@@ -230,11 +230,14 @@ function applySharedHpPool(session, target, damageDealt, targetHpPreDamage) {
     counterpart.hp = c;
   }
 
+  // The actual damage each side absorbed after the split (pool conserved:
+  // targetActual + counterActual === d, minus any drained overflow).
+  const targetActual = Math.max(0, preTarget - Number(target.hp));
+  const counterActual = Math.max(0, preCounter - Number(counterpart.hp));
+
   // Reconcile damage_taken: performAttack credited the struck unit the full `d`;
   // correct it to the actual split (refund the over-count, credit the counterpart).
   if (session.damage_taken) {
-    const targetActual = Math.max(0, preTarget - Number(target.hp));
-    const counterActual = Math.max(0, preCounter - Number(counterpart.hp));
     session.damage_taken[target.id] = Math.max(
       0,
       (session.damage_taken[target.id] || 0) - d + targetActual,
@@ -247,6 +250,9 @@ function applySharedHpPool(session, target, damageDealt, targetHpPreDamage) {
     type: 'shared_hp_pool',
     symbiont_id: symbiont.id,
     partner_id: partner.id,
+    counterpart_id: counterpart.id,
+    target_actual: targetActual,
+    counter_actual: counterActual,
     both_ko: bothKo,
     pool_after: Math.max(0, poolAfter),
   };

--- a/apps/backend/services/combat/symbiontBond.js
+++ b/apps/backend/services/combat/symbiontBond.js
@@ -159,10 +159,105 @@ function applyBondedDeathGrace(session, deadPartner) {
   };
 }
 
+/**
+ * Identify a shared_hp_pool pair for `target`: returns { symbiont, partner } when
+ * `target` is a member of a pool (the symbiont carries shared_hp_pool + `target`
+ * is its PRIMARY bonded partner, or `target` IS that symbiont). Secondary
+ * (dual_bond) partners are NOT pooled. Null otherwise.
+ */
+function sharedPoolPair(session, target) {
+  if (!session || !target) return null;
+  let symbiont = null;
+  let partner = null;
+  if (target._bonded_by) {
+    symbiont = (session.units || []).find((u) => u && u.id === target._bonded_by);
+    partner = target;
+  } else if (target._bond && target._bond.partner_id) {
+    symbiont = target;
+    partner = (session.units || []).find((u) => u && u.id === target._bond.partner_id);
+  }
+  if (!symbiont || !partner) return null;
+  if (!findPassive(symbiont, 'shared_hp_pool')) return null;
+  if (!symbiont._bond || symbiont._bond.partner_id !== partner.id) return null; // primary only
+  return { symbiont, partner };
+}
+
+/**
+ * SYMBIONT capstone sy_r6_one_soul (TKT-JOB-PHASEC V5, OQ-BOND verdict V5) — the
+ * symbiont + its primary bonded partner share a combined HP pool: a hit is split
+ * equally across the pair and BOTH KO together when the pool empties. Hooked into
+ * performAttack AFTER the damage floor, in place of the redirect (mutual exclusion).
+ * `targetHpPreDamage` is the struck unit's HP BEFORE the floor (needed because the
+ * floor at 0 hides overkill, which the pool needs for the both-KO check).
+ *
+ * @param {object} session
+ * @param {object} target — the struck pool member (hp already floored by the caller)
+ * @param {number} damageDealt — the hit's damage
+ * @param {number} targetHpPreDamage — target.hp BEFORE the damage step
+ * @returns {object|null}
+ */
+function applySharedHpPool(session, target, damageDealt, targetHpPreDamage) {
+  const pair = sharedPoolPair(session, target);
+  if (!pair) return null;
+  const d = Number(damageDealt) || 0;
+  if (d <= 0) return null;
+  const { symbiont, partner } = pair;
+  const counterpart = target.id === symbiont.id ? partner : symbiont;
+  const preTarget = Number(targetHpPreDamage);
+  const preCounter = Number(counterpart.hp);
+  const poolAfter = preTarget + preCounter - d;
+
+  let bothKo = false;
+  if (poolAfter <= 0) {
+    target.hp = 0;
+    counterpart.hp = 0;
+    bothKo = true;
+  } else {
+    // Equal split: the struck unit takes the ceil half, the counterpart the floor
+    // half; overflow on either side is covered by the other (pool conserved).
+    const half = Math.floor(d / 2);
+    let t = preTarget - (d - half);
+    let c = preCounter - half;
+    if (t < 0) {
+      c += t;
+      t = 0;
+    }
+    if (c < 0) {
+      t += c;
+      c = 0;
+    }
+    target.hp = t;
+    counterpart.hp = c;
+  }
+
+  // Reconcile damage_taken: performAttack credited the struck unit the full `d`;
+  // correct it to the actual split (refund the over-count, credit the counterpart).
+  if (session.damage_taken) {
+    const targetActual = Math.max(0, preTarget - Number(target.hp));
+    const counterActual = Math.max(0, preCounter - Number(counterpart.hp));
+    session.damage_taken[target.id] = Math.max(
+      0,
+      (session.damage_taken[target.id] || 0) - d + targetActual,
+    );
+    session.damage_taken[counterpart.id] =
+      (session.damage_taken[counterpart.id] || 0) + counterActual;
+  }
+
+  return {
+    type: 'shared_hp_pool',
+    symbiont_id: symbiont.id,
+    partner_id: partner.id,
+    both_ko: bothKo,
+    pool_after: Math.max(0, poolAfter),
+  };
+}
+
 module.exports = {
   computeBondConfig,
   applyBondRedirect,
   applyBondedDeathGrace,
+  applySharedHpPool,
+  sharedPoolPair,
   DEFAULT_REDIRECT_PCT,
   STRONG_REDIRECT_PCT,
   SECONDARY_REDIRECT_PCT,

--- a/apps/backend/services/combat/symbiontBond.js
+++ b/apps/backend/services/combat/symbiontBond.js
@@ -226,6 +226,22 @@ function applySharedHpPool(session, target, damageDealt, targetHpPreDamage) {
       t += c;
       c = 0;
     }
+    // Codex #2542 P1: poolAfter > 0 means the bond keeps the pair UP — neither
+    // member may show a solo KO while the shared pool still has HP. The struck
+    // target is what performAttack tests for death, so guarantee it stays >= 1
+    // (borrow from the counterpart); then lift the counterpart off 0 when the
+    // pool can still afford it. At a 1-HP pool the struck target keeps the last HP.
+    if (t < 1) {
+      const need = 1 - t;
+      t = 1;
+      c -= need;
+    }
+    if (c < 1 && t > 1) {
+      const give = 1 - c;
+      c += give;
+      t -= give;
+    }
+    if (c < 0) c = 0;
     target.hp = t;
     counterpart.hp = c;
   }

--- a/tests/progression/symbiontSharedHpPool.test.js
+++ b/tests/progression/symbiontSharedHpPool.test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { applySharedHpPool } = require('../../apps/backend/services/combat/symbiontBond');
+
+// TKT-JOB-PHASEC slice V5 (symbiont capstone sy_r6_one_soul, OQ-BOND verdict V5) —
+// shared_hp_pool: the symbiont + its PRIMARY bonded partner share a combined HP
+// pool (sum HP). A hit is split equally across the pair; both KO together when the
+// pool empties. Supersedes the redirect (mutual exclusion) + bonded_death_grace
+// (a dead symbiont can't grace). applySharedHpPool is hooked into performAttack
+// AFTER the damage floor, receiving the struck unit's PRE-hit HP (the floor at 0
+// loses overkill, which the pool needs for the both-KO check).
+
+function pair(symExtra = {}, partnerExtra = {}) {
+  const symbiont = {
+    id: 'sym',
+    hp: 20,
+    max_hp: 20,
+    status: {},
+    _bond: { partner_id: 'p', redirect_pct: 0.5, secondary_partner_id: null, secondary_pct: 0 },
+    _perk_passives: [{ tag: 'shared_hp_pool', payload: {}, source_perk_id: 'sy_r6' }],
+    ...symExtra,
+  };
+  const partner = { id: 'p', hp: 20, max_hp: 20, status: {}, _bonded_by: 'sym', ...partnerExtra };
+  return { symbiont, partner };
+}
+
+test('shared_hp_pool: hit on the partner splits equally across the pair', () => {
+  const { symbiont, partner } = pair();
+  // performAttack already floored partner.hp = 20 - 10 = 10 and credited damage_taken 10.
+  partner.hp = 10;
+  const session = { units: [symbiont, partner], turn: 1, damage_taken: { p: 10 } };
+  const r = applySharedHpPool(session, partner, 10, 20); // preDamage partner.hp = 20
+  assert.ok(r, 'pool active');
+  assert.strictEqual(r.both_ko, false);
+  assert.strictEqual(partner.hp, 15, 'partner net took 5');
+  assert.strictEqual(symbiont.hp, 15, 'symbiont net took 5');
+  assert.strictEqual(session.damage_taken.p, 5, 'partner damage_taken corrected to 5');
+  assert.strictEqual(session.damage_taken.sym, 5, 'symbiont credited 5');
+});
+
+test('shared_hp_pool: hit on the symbiont splits equally too', () => {
+  const { symbiont, partner } = pair();
+  symbiont.hp = 12; // took 8
+  const session = { units: [symbiont, partner], turn: 1, damage_taken: { sym: 8 } };
+  applySharedHpPool(session, symbiont, 8, 20);
+  assert.strictEqual(symbiont.hp, 16, 'symbiont net took 4');
+  assert.strictEqual(partner.hp, 16, 'partner net took 4');
+});
+
+test('shared_hp_pool: both KO when the pool empties', () => {
+  const { symbiont, partner } = pair({ hp: 4 }, { hp: 4 });
+  partner.hp = 0; // floored (took 10 vs 4)
+  const session = { units: [symbiont, partner], turn: 1, damage_taken: { p: 10 } };
+  const r = applySharedHpPool(session, partner, 10, 4); // preDamage 4; pool 8 - 10 = -2
+  assert.strictEqual(r.both_ko, true);
+  assert.strictEqual(partner.hp, 0);
+  assert.strictEqual(symbiont.hp, 0, 'both KO together');
+});
+
+test('shared_hp_pool: overkill on one member overflows into the pool (no premature death)', () => {
+  const { symbiont, partner } = pair({ hp: 20 }, { hp: 3 });
+  partner.hp = 0; // floored (took 10 vs 3)
+  const session = { units: [symbiont, partner], turn: 1, damage_taken: { p: 10 } };
+  const r = applySharedHpPool(session, partner, 10, 3); // pool 23 - 10 = 13 > 0
+  assert.strictEqual(r.both_ko, false);
+  assert.strictEqual(partner.hp + symbiont.hp, 13, 'pool conserved at 13');
+  assert.ok(partner.hp >= 0 && symbiont.hp >= 0, 'no negative hp');
+});
+
+test('shared_hp_pool: no perk → null (redirect/normal path applies instead)', () => {
+  const { symbiont, partner } = pair({ _perk_passives: [] });
+  partner.hp = 10;
+  const session = { units: [symbiont, partner], turn: 1, damage_taken: { p: 10 } };
+  assert.strictEqual(applySharedHpPool(session, partner, 10, 20), null);
+});
+
+test('shared_hp_pool: only the PRIMARY bond pools (secondary partner → null)', () => {
+  const symbiont = {
+    id: 'sym',
+    hp: 20,
+    max_hp: 20,
+    _bond: { partner_id: 'p1', redirect_pct: 0.5, secondary_partner_id: 'p2', secondary_pct: 0.25 },
+    _perk_passives: [{ tag: 'shared_hp_pool', payload: {}, source_perk_id: 'sy_r6' }],
+  };
+  const secondary = { id: 'p2', hp: 10, max_hp: 20, _bonded_by: 'sym' };
+  const session = { units: [symbiont, secondary], turn: 1, damage_taken: { p2: 10 } };
+  assert.strictEqual(applySharedHpPool(session, secondary, 10, 20), null, 'secondary not pooled');
+});
+
+test('shared_hp_pool: unbonded unit → null', () => {
+  const lone = { id: 'x', hp: 10, max_hp: 20 };
+  const session = { units: [lone], turn: 1, damage_taken: {} };
+  assert.strictEqual(applySharedHpPool(session, lone, 5, 15), null);
+});

--- a/tests/progression/symbiontSharedHpPool.test.js
+++ b/tests/progression/symbiontSharedHpPool.test.js
@@ -42,6 +42,7 @@ test('shared_hp_pool: hit on the partner splits equally across the pair', () => 
   assert.strictEqual(r.counterpart_id, 'sym', 'counterpart id is the symbiont');
   assert.strictEqual(r.target_actual, 5, 'struck partner actually absorbed 5');
   assert.strictEqual(r.counter_actual, 5, 'counterpart absorbed its 5 share');
+  assert.ok(!symbiont._pool_both_ko, 'no both-KO tag on a survivable split');
 });
 
 test('shared_hp_pool: hit on the symbiont splits equally too', () => {
@@ -61,6 +62,9 @@ test('shared_hp_pool: both KO when the pool empties', () => {
   assert.strictEqual(r.both_ko, true);
   assert.strictEqual(partner.hp, 0);
   assert.strictEqual(symbiont.hp, 0, 'both KO together');
+  // Codex #2542 P2: the counterpart is tagged so the bridge emits its kill ONLY
+  // on an actual pool both-KO (not merely a bonded unit that happens to be at 0).
+  assert.strictEqual(symbiont._pool_both_ko, true, 'counterpart tagged for kill emission');
 });
 
 test('shared_hp_pool: overkill on one member overflows into the pool (no premature death)', () => {

--- a/tests/progression/symbiontSharedHpPool.test.js
+++ b/tests/progression/symbiontSharedHpPool.test.js
@@ -148,3 +148,16 @@ test('shared_hp_pool: a burst overkilling a 1-HP pool empties it (both KO) given
   assert.strictEqual(partner.hp, 0);
   assert.strictEqual(symbiont.hp, 0);
 });
+
+test('shared_hp_pool: a full bonus is absorbed by the pool when the struck member is low (Codex #2542 P2)', () => {
+  // The bridge passes the FULL bonus + the struck member's pre-bonus HP, so a
+  // +3 focus-fire on a 1-HP pooled member is covered by the 20-HP partner instead
+  // of being clamped to 1 and losing the other 2.
+  const { symbiont, partner } = pair({ hp: 20 }, { hp: 1 });
+  const session = { units: [symbiont, partner], turn: 1, damage_taken: {} };
+  const r = applySharedHpPool(session, partner, 3, 1); // full bonus 3, struck pre-HP 1
+  assert.strictEqual(r.both_ko, false);
+  assert.strictEqual(partner.hp + symbiont.hp, 18, 'pool 21 - 3 = 18 (the full 3 landed)');
+  assert.ok(partner.hp >= 1, 'struck member survives on the pool');
+  assert.strictEqual(r.counter_actual, 3, 'the bonded partner absorbed the full bonus');
+});

--- a/tests/progression/symbiontSharedHpPool.test.js
+++ b/tests/progression/symbiontSharedHpPool.test.js
@@ -112,3 +112,31 @@ test('shared_hp_pool: unbonded unit → null', () => {
   const session = { units: [lone], turn: 1, damage_taken: {} };
   assert.strictEqual(applySharedHpPool(session, lone, 5, 15), null);
 });
+
+test('shared_hp_pool: a downed counterpart does NOT pool or get resurrected (Codex #2542 P1)', () => {
+  const { symbiont, partner } = pair({ hp: 0 }); // symbiont downed OUTSIDE this pool
+  partner.hp = 0; // struck partner floored; pre-damage HP (20) passed below
+  const session = { units: [symbiont, partner], turn: 1, damage_taken: { p: 10 } };
+  const r = applySharedHpPool(session, partner, 10, 20);
+  assert.strictEqual(r, null, 'no pool while the counterpart is already KO');
+  assert.strictEqual(symbiont.hp, 0, 'dead symbiont is NOT lifted back to 1 by the split');
+});
+
+test('shared_hp_pool: a struck unit already dead pre-damage → null', () => {
+  const { symbiont, partner } = pair();
+  partner.hp = 0;
+  const session = { units: [symbiont, partner], turn: 1, damage_taken: { p: 5 } };
+  assert.strictEqual(applySharedHpPool(session, partner, 5, 0), null, 'preTarget <= 0 -> no pool');
+});
+
+test('shared_hp_pool: a burst overkilling a 1-HP pool empties it (both KO) given the real pre-burst HP', () => {
+  // Codex #2542 P1 (caller): the terrain re-split must pass the PRE-burst HP (1),
+  // not the floored hp + burst (3) — otherwise pool 1+1-3 looks like 1 and survives.
+  const { symbiont, partner } = pair({ hp: 1 }, { hp: 1 });
+  partner.hp = 0; // floored by the burst
+  const session = { units: [symbiont, partner], turn: 1, damage_taken: { p: 3 } };
+  const r = applySharedHpPool(session, partner, 3, 1); // real pre-burst HP = 1
+  assert.strictEqual(r.both_ko, true, 'pool 1+1-3 <= 0 -> both KO together');
+  assert.strictEqual(partner.hp, 0);
+  assert.strictEqual(symbiont.hp, 0);
+});

--- a/tests/progression/symbiontSharedHpPool.test.js
+++ b/tests/progression/symbiontSharedHpPool.test.js
@@ -80,15 +80,19 @@ test('shared_hp_pool: overkill on one member overflows into the pool (no prematu
   assert.strictEqual(symbiont.hp, 12, 'counterpart covered the lethal overflow');
 });
 
-test('shared_hp_pool: at a 1-HP pool the struck target keeps the last HP (no solo KO)', () => {
+test('shared_hp_pool: an odd 1-HP tail the split cannot share -> both KO together (no silent solo drop)', () => {
+  // Codex #2542 P1: poolAfter would be 1 (partner pre 1 + sym 5 - 5), but a single
+  // HP cannot keep BOTH members >= 1; rather than silently leave one at 0 while the
+  // other lives (which the rest of the combat code reads as a solo KO), the pair
+  // falls together (non-silent both-KO).
   const { symbiont, partner } = pair({ hp: 5 }, { hp: 1 });
   partner.hp = 0; // floored (took 5 vs 1)
   const session = { units: [symbiont, partner], turn: 1, damage_taken: { p: 5 } };
-  const r = applySharedHpPool(session, partner, 5, 1); // pool 6 - 5 = 1 > 0
-  assert.strictEqual(r.both_ko, false, 'pool not empty -> pair still up');
-  assert.strictEqual(partner.hp, 1, 'struck target keeps the last pool HP (performAttack wont KO)');
-  assert.strictEqual(symbiont.hp, 0, 'counterpart spent; pair alive on the shared 1 HP');
-  assert.strictEqual(partner.hp + symbiont.hp, 1, 'pool conserved at 1');
+  const r = applySharedHpPool(session, partner, 5, 1); // pool 1 + 5 - 5 = 1
+  assert.strictEqual(r.both_ko, true, 'cannot keep both >= 1 on a 1-HP pool -> both KO');
+  assert.strictEqual(partner.hp, 0);
+  assert.strictEqual(symbiont.hp, 0, 'both fall together, not a solo drop');
+  assert.strictEqual(symbiont._pool_both_ko, true, 'counterpart tagged for the kill emission');
 });
 
 test('shared_hp_pool: no perk → null (redirect/normal path applies instead)', () => {

--- a/tests/progression/symbiontSharedHpPool.test.js
+++ b/tests/progression/symbiontSharedHpPool.test.js
@@ -70,7 +70,21 @@ test('shared_hp_pool: overkill on one member overflows into the pool (no prematu
   const r = applySharedHpPool(session, partner, 10, 3); // pool 23 - 10 = 13 > 0
   assert.strictEqual(r.both_ko, false);
   assert.strictEqual(partner.hp + symbiont.hp, 13, 'pool conserved at 13');
-  assert.ok(partner.hp >= 0 && symbiont.hp >= 0, 'no negative hp');
+  // Codex #2542 P1: no SOLO KO while the pool has HP — the struck target stays
+  // >= 1 (performAttack wont treat it as killed); the counterpart covers overflow.
+  assert.strictEqual(partner.hp, 1, 'struck partner survives on the pool (>=1)');
+  assert.strictEqual(symbiont.hp, 12, 'counterpart covered the lethal overflow');
+});
+
+test('shared_hp_pool: at a 1-HP pool the struck target keeps the last HP (no solo KO)', () => {
+  const { symbiont, partner } = pair({ hp: 5 }, { hp: 1 });
+  partner.hp = 0; // floored (took 5 vs 1)
+  const session = { units: [symbiont, partner], turn: 1, damage_taken: { p: 5 } };
+  const r = applySharedHpPool(session, partner, 5, 1); // pool 6 - 5 = 1 > 0
+  assert.strictEqual(r.both_ko, false, 'pool not empty -> pair still up');
+  assert.strictEqual(partner.hp, 1, 'struck target keeps the last pool HP (performAttack wont KO)');
+  assert.strictEqual(symbiont.hp, 0, 'counterpart spent; pair alive on the shared 1 HP');
+  assert.strictEqual(partner.hp + symbiont.hp, 1, 'pool conserved at 1');
 });
 
 test('shared_hp_pool: no perk → null (redirect/normal path applies instead)', () => {

--- a/tests/progression/symbiontSharedHpPool.test.js
+++ b/tests/progression/symbiontSharedHpPool.test.js
@@ -38,6 +38,10 @@ test('shared_hp_pool: hit on the partner splits equally across the pair', () => 
   assert.strictEqual(symbiont.hp, 15, 'symbiont net took 5');
   assert.strictEqual(session.damage_taken.p, 5, 'partner damage_taken corrected to 5');
   assert.strictEqual(session.damage_taken.sym, 5, 'symbiont credited 5');
+  // Split actuals + counterpart id surfaced for the SG-accrual reconcile (Codex #2542).
+  assert.strictEqual(r.counterpart_id, 'sym', 'counterpart id is the symbiont');
+  assert.strictEqual(r.target_actual, 5, 'struck partner actually absorbed 5');
+  assert.strictEqual(r.counter_actual, 5, 'counterpart absorbed its 5 share');
 });
 
 test('shared_hp_pool: hit on the symbiont splits equally too', () => {


### PR DESCRIPTION
## TKT-JOB-PHASEC slice V5 — shared_hp_pool capstone (OQ-BOND verdict V5)

The symbiont's final tag (sy_r6_one_soul). Symbiont line now **8/8** (B4a 4 + B4b 3 + V5 1).

### Behaviour
`shared_hp_pool`: the symbiont + its **primary** bonded partner share a combined HP pool. A hit on either is **split equally** across the pair; **both KO together** when the pool empties (faithful "one soul"). Secondary (dual_bond) partners are NOT pooled.

### Changes
- **`symbiontBond.js`**: `sharedPoolPair(session, target)` (identifies an active primary pool) + `applySharedHpPool(session, target, damageDealt, targetHpPreDamage)` (equal split, pool conservation on overflow, both-KO, `damage_taken` reconciliation).
- **`session.js` performAttack**: captures the **pre-floor** target HP (the `Math.max(0, …)` floor hides overkill the both-KO check needs), runs the pool hook **before** the redirect — **mutual exclusion** (redirect gated on `!symbiontPoolResult`). `bonded_death_grace` is auto-superseded (a both-KO'd symbiont is dead → grace returns null). both-KO emits a `shared_hp_pool_both_ko` telemetry log.

### Tests (TDD red→green)
`tests/progression/symbiontSharedHpPool.test.js` (7): equal split (partner / symbiont struck) + both-KO + overkill-overflow + no-perk + secondary-not-pooled + unbonded. Regression: progression **110/110**, AI **500/500**, combat api **22/22**.

### Band-verify (party-wipe STOP gate)
**Band-neutral by construction** — symbiont job absent from every HC sim party; the pool gates on the symbiont's capstone perk + active primary bond which no HC unit carries. **AI 500/500 + combat api 22/22 (full encounters to defeat/victory) byte-identical = no party-wipe regression** (the explicit V5 STOP condition did not trigger). Opt-in capstone; does not touch the defeat/lose-condition logic.

No data, no schema, no new deps. No forbidden paths.