### PR TITLE
feat(combat): phasec b5 spike minion summon + expendable foundation

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -3199,7 +3199,9 @@ function createSessionRouter(options = {}) {
         (u) => u.controlled_by === 'sistema' && (u.hp ?? 0) > 0,
       ).length;
       const playerAlive = session.units.filter(
-        (u) => u.controlled_by === 'player' && (u.hp ?? 0) > 0,
+        // TKT-JOB-PHASEC B5: minions are expendable (V4) — exclude from the
+        // party-wipe lose-condition so a lone surviving minion is not a "party".
+        (u) => u.controlled_by === 'player' && !u.is_minion && (u.hp ?? 0) > 0,
       ).length;
       // ADR-2026-04-20: objective evaluator prende precedenza su elimination
       // fallback quando encounter.objective.type è definito.
@@ -3227,7 +3229,8 @@ function createSessionRouter(options = {}) {
         try {
           const woundedPerma = require('../services/combat/woundedPerma');
           for (const u of session.units || []) {
-            if (u && u.controlled_by === 'player' && Number(u.hp || 0) <= 0) {
+            // B5: minions are expendable, not campaign units — never scar them.
+            if (u && u.controlled_by === 'player' && !u.is_minion && Number(u.hp || 0) <= 0) {
               woundedPerma.applyWound(u, session.lastMissionWoundedPerma);
             }
           }

--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -103,6 +103,9 @@ function normaliseUnit(raw, fallbackIndex) {
     // M16 P0-1 — owner_id mapping player→unit per co-op Jackbox flow.
     // Set solo per unità player-controlled; enemy restano null.
     owner_id: input.owner_id ? String(input.owner_id) : null,
+    // TKT-JOB-PHASEC B5 — minion marker (expendable, beastmaster-summoned). Default
+    // false so every existing unit is a normal player/sistema unit (band-neutral).
+    is_minion: input.is_minion === true,
     name: input.name ? String(input.name) : null,
     form_id: input.form_id ? String(input.form_id) : null,
     resistance_archetype: resistanceArchetype,

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -460,8 +460,10 @@ function createAbilityExecutor(deps) {
   // pack_command / the 8 minion tags are follow-up slices.
   const MAX_MINIONS = 2;
   async function executeSummonCompanion({ session, actor, ability }) {
+    // Cap counts only LIVE minions (Codex #2544 P2): dead minion records linger in
+    // session.units and must not permanently block re-summoning.
     const existing = (session.units || []).filter(
-      (u) => u && u.is_minion && u.owner_id === actor.id,
+      (u) => u && u.is_minion && u.owner_id === actor.id && (u.hp ?? 0) > 0,
     );
     if (existing.length >= MAX_MINIONS) {
       return {
@@ -471,9 +473,11 @@ function createAbilityExecutor(deps) {
     }
     const pos = actor.position || { x: 0, y: 0 };
     const grid = session.grid || null;
+    // Only LIVE units block a spawn tile (Codex #2544 P2): corpses don't occupy
+    // cells, matching the codebase's live-unit movement/occupancy semantics.
     const occupied = new Set(
       (session.units || [])
-        .filter((u) => u && u.position)
+        .filter((u) => u && u.position && (u.hp ?? 0) > 0)
         .map((u) => `${u.position.x},${u.position.y}`),
     );
     const candidates = [

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -451,11 +451,109 @@ function createAbilityExecutor(deps) {
     };
   }
 
+  // TKT-JOB-PHASEC slice B5 SPIKE POC (OQ-MINION verdict V4) — summon_companion
+  // spawns a real minion unit (controlled_by 'player' + owner_id = caster +
+  // is_minion), NOT a self hp_max buff. HP from buff_amount (5), atk +1, mob 3,
+  // spawned on an adjacent free in-grid tile (else 400), capped at MAX_MINIONS (2;
+  // max_minions perk raises it in a follow-up). Minions are expendable: excluded
+  // from the party-wipe lose-condition + the round-advance intent gate. AI /
+  // pack_command / the 8 minion tags are follow-up slices.
+  const MAX_MINIONS = 2;
+  async function executeSummonCompanion({ session, actor, ability }) {
+    const existing = (session.units || []).filter(
+      (u) => u && u.is_minion && u.owner_id === actor.id,
+    );
+    if (existing.length >= MAX_MINIONS) {
+      return {
+        status: 400,
+        body: { error: `cap minion raggiunto (${MAX_MINIONS})`, max_minions: MAX_MINIONS },
+      };
+    }
+    const pos = actor.position || { x: 0, y: 0 };
+    const grid = session.grid || null;
+    const occupied = new Set(
+      (session.units || [])
+        .filter((u) => u && u.position)
+        .map((u) => `${u.position.x},${u.position.y}`),
+    );
+    const candidates = [
+      { x: pos.x + 1, y: pos.y },
+      { x: pos.x - 1, y: pos.y },
+      { x: pos.x, y: pos.y + 1 },
+      { x: pos.x, y: pos.y - 1 },
+    ];
+    const free = candidates.find((c) => {
+      if (c.x < 0 || c.y < 0) return false;
+      if (grid && (c.x >= Number(grid.width) || c.y >= Number(grid.height ?? grid.width)))
+        return false;
+      return !occupied.has(`${c.x},${c.y}`);
+    });
+    if (!free) {
+      return { status: 400, body: { error: 'nessuna tile adiacente libera per il minion' } };
+    }
+    const hp = Number(ability.buff_amount || 5);
+    const minion = {
+      id: `${actor.id}_minion_${existing.length + 1}_t${Number(session.turn) || 0}`,
+      controlled_by: 'player',
+      owner_id: actor.id,
+      is_minion: true,
+      hp,
+      max_hp: hp,
+      attack_mod: 1,
+      mobility: 3,
+      position: { x: free.x, y: free.y },
+      species: 'minion',
+      job: null,
+      status: {},
+      ap: 2,
+      ap_remaining: 2,
+    };
+    session.units.push(minion);
+    actor.ap_remaining = Math.max(
+      0,
+      (actor.ap_remaining ?? actor.ap) - Number(ability.cost_ap || 0),
+    );
+    const event = {
+      ts: new Date().toISOString(),
+      session_id: session.session_id,
+      actor_id: actor.id,
+      actor_species: actor.species,
+      actor_job: actor.job,
+      action_type: 'ability',
+      ability_id: ability.ability_id,
+      effect_type: 'summon',
+      target_id: minion.id,
+      turn: session.turn,
+      ap_spent: Number(ability.cost_ap || 0),
+      minion: { id: minion.id, position: minion.position, hp: minion.hp },
+      minions_active: existing.length + 1,
+      trait_effects: [],
+    };
+    await appendEvent(session, event);
+    return {
+      status: 200,
+      body: {
+        ok: true,
+        actor_id: actor.id,
+        ability_id: ability.ability_id,
+        effect_type: 'summon',
+        minion_id: minion.id,
+        minion_position: minion.position,
+        minions_active: existing.length + 1,
+        ap_remaining: actor.ap_remaining,
+      },
+    };
+  }
+
   async function executeBuff({ session, actor, ability }) {
     // TKT-JOB-PHASEC slice A1b (Cat F 7/7, OQ-F verdict V1) — phenotype_shift is a
     // 1d6 random table + per-round use-cap + double-roll perk, not a fixed buff.
     if (ability.ability_id === 'phenotype_shift') {
       return executePhenotypeShift({ session, actor, ability });
+    }
+    // TKT-JOB-PHASEC slice B5 — summon_companion spawns a minion, not a self-buff.
+    if (ability.ability_id === 'summon_companion') {
+      return executeSummonCompanion({ session, actor, ability });
     }
     const buffStat = ability.buff_stat;
     if (!buffStat) {

--- a/apps/backend/services/combat/objectiveEvaluator.js
+++ b/apps/backend/services/combat/objectiveEvaluator.js
@@ -47,7 +47,13 @@ function ensureObjectiveState(session, objectiveType) {
 }
 
 function countFactionAlive(session, faction) {
-  return (session.units || []).filter((u) => u.controlled_by === faction && (u.hp ?? 0) > 0).length;
+  // TKT-JOB-PHASEC B5: minions are expendable (V4) — a lone surviving minion must
+  // NOT keep the player faction "alive" for objective wipe checks (else an
+  // objective-driven encounter stalls on wipe). Band-neutral (sistema units have
+  // no is_minion; default false on every existing unit).
+  return (session.units || []).filter(
+    (u) => u.controlled_by === faction && !u.is_minion && (u.hp ?? 0) > 0,
+  ).length;
 }
 
 function pointInBox(pos, box) {
@@ -276,7 +282,8 @@ register('escape', (session, enc, obj) => {
     };
   }
   const alivePGs = (session.units || []).filter(
-    (u) => u.controlled_by === 'player' && (u.hp ?? 0) > 0,
+    // B5: minions are expendable — exclude from the escape wipe check (see countFactionAlive).
+    (u) => u.controlled_by === 'player' && !u.is_minion && (u.hp ?? 0) > 0,
   );
   if (alivePGs.length === 0) {
     state.failed = true;

--- a/apps/backend/services/roundOrchestrator.js
+++ b/apps/backend/services/roundOrchestrator.js
@@ -968,7 +968,10 @@ function shouldAutoAdvance(state, opts = {}) {
   const { requirePlayerOnly = false } = opts;
   const phase = state && state.round_phase;
   if (phase === PHASE_PLANNING) {
-    let units = (state.units || []).filter((u) => u && u.hp > 0);
+    // TKT-JOB-PHASEC B5: minions are commanded (pack_command, follow-up), not
+    // player-driven — they never declare their own intent, so they must NOT gate
+    // the round advance (else summoning one stalls planning forever).
+    let units = (state.units || []).filter((u) => u && u.hp > 0 && !u.is_minion);
     if (requirePlayerOnly) {
       units = units.filter((u) => u && u.controlled_by === 'player');
     }

--- a/tests/progression/minionSummonSpike.test.js
+++ b/tests/progression/minionSummonSpike.test.js
@@ -143,3 +143,35 @@ test('objective elimination: a surviving minion does NOT prevent player_wipe (co
   assert.strictEqual(r.outcome, 'wipe', 'minion must not keep the party alive');
   assert.strictEqual(r.reason, 'player_wipe');
 });
+
+test('summon_companion: dead minions do NOT count toward the cap (Codex #2544 P2)', async () => {
+  const ex = makeExecutor();
+  const caster = bm();
+  const session = { units: [caster], turn: 1, grid: { width: 10, height: 10 } };
+  await ex.executeAbility({ session, actor: caster, body: { ability_id: 'summon_companion' } });
+  await ex.executeAbility({ session, actor: caster, body: { ability_id: 'summon_companion' } });
+  // both minions die
+  for (const u of session.units) if (u.is_minion) u.hp = 0;
+  const r = await ex.executeAbility({
+    session,
+    actor: caster,
+    body: { ability_id: 'summon_companion' },
+  });
+  assert.strictEqual(r.status, 200, 'dead minions free up the cap');
+  assert.strictEqual(session.units.filter((u) => u.is_minion && u.hp > 0).length, 1);
+});
+
+test('summon_companion: a corpse does NOT block a spawn tile (Codex #2544 P2)', async () => {
+  const ex = makeExecutor();
+  const caster = bm({ position: { x: 0, y: 0 } }); // in-grid neighbours: (1,0) and (0,1)
+  const corpseA = { id: 'cA', controlled_by: 'sistema', hp: 0, position: { x: 1, y: 0 } };
+  const corpseB = { id: 'cB', controlled_by: 'sistema', hp: 0, position: { x: 0, y: 1 } };
+  const session = { units: [caster, corpseA, corpseB], turn: 1, grid: { width: 10, height: 10 } };
+  const r = await ex.executeAbility({
+    session,
+    actor: caster,
+    body: { ability_id: 'summon_companion' },
+  });
+  assert.strictEqual(r.status, 200, 'corpses do not occupy spawn tiles');
+  assert.strictEqual(session.units.filter((u) => u.is_minion).length, 1);
+});

--- a/tests/progression/minionSummonSpike.test.js
+++ b/tests/progression/minionSummonSpike.test.js
@@ -1,0 +1,145 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { createAbilityExecutor } = require('../../apps/backend/services/abilityExecutor');
+const {
+  shouldAutoAdvance,
+  PHASE_COMMITTED,
+} = require('../../apps/backend/services/roundOrchestrator');
+const { evaluateObjective } = require('../../apps/backend/services/combat/objectiveEvaluator');
+
+// TKT-JOB-PHASEC slice B5 SPIKE POC (OQ-MINION verdict V4) — minion runtime
+// foundation: summon_companion spawns 1 minion (HP 5, atk +1, mob 3) on an adjacent
+// free tile, controlled_by 'player' + owner_id = caster, is_minion true, capped at 2.
+// Minions are EXPENDABLE: excluded from the party-wipe lose-condition AND from the
+// round-advance intent requirement (they act via pack_command, a follow-up slice —
+// NOT declareSistemaIntents). No perks/AI in this spike. coop-phase-validator smoke
+// gates the co-op flow (V4 mandate).
+
+function makeExecutor() {
+  return createAbilityExecutor({
+    performAttack: () => ({ damageDealt: 0, result: {} }),
+    buildAttackEvent: () => ({}),
+    appendEvent: async () => {},
+    manhattanDistance: (p, q) => Math.abs(p.x - q.x) + Math.abs(p.y - q.y),
+    rng: () => 0,
+  });
+}
+
+function bm(extra = {}) {
+  return {
+    id: 'bm',
+    job: 'beastmaster',
+    controlled_by: 'player',
+    ap: 6,
+    ap_remaining: 6,
+    position: { x: 5, y: 5 },
+    ...extra,
+  };
+}
+
+test('summon_companion: spawns a minion (player + owner_id + is_minion, HP 5, adjacent)', async () => {
+  const ex = makeExecutor();
+  const caster = bm();
+  const session = { units: [caster], turn: 1, grid: { width: 10, height: 10 } };
+  const res = await ex.executeAbility({
+    session,
+    actor: caster,
+    body: { ability_id: 'summon_companion' },
+  });
+  assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+  assert.strictEqual(session.units.length, 2, 'minion added to units');
+  const minion = session.units.find((u) => u.is_minion);
+  assert.ok(minion, 'minion present');
+  assert.strictEqual(minion.controlled_by, 'player');
+  assert.strictEqual(minion.owner_id, 'bm');
+  assert.strictEqual(minion.hp, 5);
+  assert.strictEqual(minion.max_hp, 5);
+  const dist =
+    Math.abs(minion.position.x - caster.position.x) +
+    Math.abs(minion.position.y - caster.position.y);
+  assert.strictEqual(dist, 1, 'spawned on an adjacent tile');
+});
+
+test('summon_companion: capped at 2 minions per owner (3rd → 400)', async () => {
+  const ex = makeExecutor();
+  const caster = bm();
+  const session = { units: [caster], turn: 1, grid: { width: 10, height: 10 } };
+  const r1 = await ex.executeAbility({
+    session,
+    actor: caster,
+    body: { ability_id: 'summon_companion' },
+  });
+  const r2 = await ex.executeAbility({
+    session,
+    actor: caster,
+    body: { ability_id: 'summon_companion' },
+  });
+  const r3 = await ex.executeAbility({
+    session,
+    actor: caster,
+    body: { ability_id: 'summon_companion' },
+  });
+  assert.strictEqual(r1.status, 200);
+  assert.strictEqual(r2.status, 200);
+  assert.strictEqual(r3.status, 400, 'cap 2 blocks the 3rd');
+  assert.strictEqual(session.units.filter((u) => u.is_minion).length, 2);
+});
+
+test('summon_companion: no free adjacent tile → 400', async () => {
+  const ex = makeExecutor();
+  const caster = bm({ position: { x: 0, y: 0 } }); // corner: only (1,0) and (0,1) are in-grid
+  const blockerA = { id: 'bA', controlled_by: 'sistema', hp: 10, position: { x: 1, y: 0 } };
+  const blockerB = { id: 'bB', controlled_by: 'sistema', hp: 10, position: { x: 0, y: 1 } };
+  const session = { units: [caster, blockerA, blockerB], turn: 1, grid: { width: 10, height: 10 } };
+  const res = await ex.executeAbility({
+    session,
+    actor: caster,
+    body: { ability_id: 'summon_companion' },
+  });
+  assert.strictEqual(res.status, 400, 'no free adjacent tile');
+  assert.strictEqual(session.units.filter((u) => u.is_minion).length, 0);
+});
+
+test('shouldAutoAdvance: a minion without an intent does NOT block round advance', () => {
+  const state = {
+    round_phase: 'planning',
+    units: [
+      { id: 'hero', controlled_by: 'player', hp: 10 },
+      { id: 'm1', controlled_by: 'player', hp: 5, is_minion: true, owner_id: 'hero' },
+    ],
+    pending_intents: [{ unit_id: 'hero', action: { type: 'attack' } }],
+  };
+  // hero declared, minion did not — minion is expendable/commanded, must not stall.
+  assert.strictEqual(shouldAutoAdvance(state), PHASE_COMMITTED);
+});
+
+test('shouldAutoAdvance: still blocks on a non-minion player with no intent', () => {
+  const state = {
+    round_phase: 'planning',
+    units: [
+      { id: 'hero', controlled_by: 'player', hp: 10 },
+      { id: 'ally', controlled_by: 'player', hp: 10 },
+    ],
+    pending_intents: [{ unit_id: 'hero', action: { type: 'attack' } }],
+  };
+  assert.strictEqual(shouldAutoAdvance(state), null, 'ally still owes an intent');
+});
+
+test('objective elimination: a surviving minion does NOT prevent player_wipe (coop-smoke gap)', () => {
+  // coop-phase-validator GAP fix: objectiveEvaluator.countFactionAlive('player')
+  // must exclude minions, else an objective-driven encounter stalls on wipe when a
+  // summoned minion outlives the real party.
+  const session = {
+    turn: 5,
+    units: [
+      { id: 'hero', controlled_by: 'player', hp: 0 }, // real player down
+      { id: 'm1', controlled_by: 'player', hp: 5, is_minion: true, owner_id: 'hero' }, // minion alive
+      { id: 'foe', controlled_by: 'sistema', hp: 10 },
+    ],
+  };
+  const r = evaluateObjective(session, { objective: { type: 'elimination' } });
+  assert.strictEqual(r.outcome, 'wipe', 'minion must not keep the party alive');
+  assert.strictEqual(r.reason, 'player_wipe');
+});


### PR DESCRIPTION
## TKT-JOB-PHASEC slice B5 SPIKE POC — minion runtime foundation (OQ-MINION verdict V4)

V4 mandates a **spike POC first + coop-phase-validator smoke gate** before the 8 minion tags. This is that spike: the minion **unit type** + **summon** + **expendable** semantics. The 8 minion perk tags (max_minions, minion_attack_buff, minion_resurrect_chance, encounter_start_buff_minions, pack_command_extended_range, alpha_pack_buff, minion_proximity_dmg, minion_kill_pe_bonus) + scripted AI/pack_command are **follow-up slices on this foundation**.

### Changes
- **`abilityExecutor.js`**: `summon_companion` (was a self `hp_max+5` no-op) → `executeSummonCompanion` spawns a minion: `controlled_by:'player'` + `owner_id`=caster + `is_minion`, HP 5 / atk +1 / mob 3, on an adjacent **free in-grid tile** (else 400), **capped at 2/owner** (max_minions perk raises it later).
- **Expendable** (V4 "NON party-wipe"): minions excluded from the lose-condition — `session.js` `playerAlive` (~L3201), `objectiveEvaluator.countFactionAlive` + the `escape` filter, and the `woundedPerma` scar loop. Excluded from the **round-advance intent gate** (`roundOrchestrator.shouldAutoAdvance`) so a summoned minion never stalls planning.
- **`sessionHelpers.normaliseUnit`** preserves `is_minion` (default **false** → every existing unit unchanged).

### coop-phase-validator smoke (V4 gate) — GAP found + fixed
The smoke caught a real gap: `objectiveEvaluator.countFactionAlive('player')` lacked the `is_minion` exclusion → **objective-driven encounters (elimination/capture_point/sabotage/survival/escape) would stall on wipe** when a summoned minion outlives the real party (the `/end` path was guarded, the objective hot-path was not). Fixed at source. Co-op state machine / vote tally / host-auth / reconnect all verified clean (coopOrchestrator + wsSession key off `room.players`, never `session.units`).

### Tests (TDD red→green)
`tests/progression/minionSummonSpike.test.js` (6): summon spawn / cap-2 / no-free-tile-400 / shouldAutoAdvance minion-exclusion ×2 / objective elimination-wipe-with-minion. Regression: objectiveEvaluator **20/20**, progression **109/109**, AI **500/500**, combat api **10/10**.

### Band-verify
**Band-neutral by construction** — beastmaster/`summon_companion` absent from every HC sim party; `is_minion` defaults false so every existing unit + flow is byte-identical. No HC06/HC07 signal.

### Surface (Gate-5)
Player casts `summon_companion` → a minion unit appears on an adjacent tile + persists (`summon` event + `minion_id`/`minion_position` in the response).

No data, no schema, no new deps. No forbidden paths.