### PR TITLE
feat(combat): phasec b5 minion summon-buffs (4 tags, 26/32)

### DIFF
--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -460,15 +460,24 @@ function createAbilityExecutor(deps) {
   // pack_command / the 8 minion tags are follow-up slices.
   const MAX_MINIONS = 2;
   async function executeSummonCompanion({ session, actor, ability }) {
+    // Owner perk mods (B5): cap (max_minions) + minion stat buffs (minion_attack_buff,
+    // alpha_pack_buff, encounter_start_buff_minions). Default cap MAX_MINIONS (2).
+    let perkMods = { cap: MAX_MINIONS, attackMod: 0, defenseMod: 0, startBuff: null };
+    try {
+      perkMods = require('./progression/progressionApply').computeMinionPerkMods(actor);
+    } catch {
+      /* progression optional */
+    }
+    const cap = Number(perkMods.cap) || MAX_MINIONS;
     // Cap counts only LIVE minions (Codex #2544 P2): dead minion records linger in
     // session.units and must not permanently block re-summoning.
     const existing = (session.units || []).filter(
       (u) => u && u.is_minion && u.owner_id === actor.id && (u.hp ?? 0) > 0,
     );
-    if (existing.length >= MAX_MINIONS) {
+    if (existing.length >= cap) {
       return {
         status: 400,
-        body: { error: `cap minion raggiunto (${MAX_MINIONS})`, max_minions: MAX_MINIONS },
+        body: { error: `cap minion raggiunto (${cap})`, max_minions: cap },
       };
     }
     const pos = actor.position || { x: 0, y: 0 };
@@ -503,7 +512,8 @@ function createAbilityExecutor(deps) {
       is_minion: true,
       hp,
       max_hp: hp,
-      attack_mod: 1,
+      attack_mod: 1 + Number(perkMods.attackMod || 0),
+      defense_mod: Number(perkMods.defenseMod || 0),
       mobility: 3,
       position: { x: free.x, y: free.y },
       species: 'minion',
@@ -512,6 +522,13 @@ function createAbilityExecutor(deps) {
       ap: 2,
       ap_remaining: 2,
     };
+    // encounter_start_buff_minions: a temporary +atk buff on the freshly-summoned
+    // minion (the meaningful application — minions are summoned mid-combat, not at a
+    // literal encounter start). Standard {stat}_bonus + {stat}_buff duration form.
+    if (perkMods.startBuff && Number(perkMods.startBuff.attack_mod) > 0) {
+      minion.attack_mod_bonus = Number(perkMods.startBuff.attack_mod);
+      minion.status.attack_mod_buff = Number(perkMods.startBuff.duration) || 1;
+    }
     session.units.push(minion);
     actor.ap_remaining = Math.max(
       0,

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -512,8 +512,12 @@ function createAbilityExecutor(deps) {
       is_minion: true,
       hp,
       max_hp: hp,
-      attack_mod: 1 + Number(perkMods.attackMod || 0),
-      defense_mod: Number(perkMods.defenseMod || 0),
+      // Combat-consumed fields (Codex #2545 P2): resolveAttack reads attacker `mod`
+      // (+ attack_mod_bonus) and target `dc` (+ defense_mod_bonus) — NOT attack_mod/
+      // defense_mod. Minion base = mod 1 (spec "attack_mod +1", a weak attacker) /
+      // dc 10 (weak defense, < the DEFAULT_DC 13 of a normal unit). Perks add here.
+      mod: 1 + Number(perkMods.attackMod || 0),
+      dc: 10 + Number(perkMods.defenseMod || 0),
       mobility: 3,
       position: { x: free.x, y: free.y },
       species: 'minion',

--- a/apps/backend/services/progression/progressionApply.js
+++ b/apps/backend/services/progression/progressionApply.js
@@ -603,6 +603,46 @@ function computePhenotypeShiftPerkMods(actor) {
 }
 
 /**
+ * Compute the BEASTMASTER owner's minion summon-time perk mods (TKT-JOB-PHASEC B5).
+ * Read by executeSummonCompanion to size the cap + buff the freshly-spawned minion:
+ *
+ * - max_minions (bm_r4): raise the active-minion cap (default 2).
+ * - minion_attack_buff (bm_r2): +attack_mod (base) on the minion.
+ * - alpha_pack_buff (bm_r6 capstone): +attack_mod / +defense_mod (base) on the minion.
+ * - encounter_start_buff_minions (bm_r3): a temporary +attack_mod buff (startBuff)
+ *   applied to the minion at spawn.
+ *
+ * Pure reader. Default { cap:2, attackMod:0, defenseMod:0, startBuff:null }.
+ *
+ * @param {object} owner — the beastmaster (reads _perk_passives)
+ * @returns {{ cap:number, attackMod:number, defenseMod:number, startBuff:object|null, applied:Array }}
+ */
+function computeMinionPerkMods(owner) {
+  const out = { cap: 2, attackMod: 0, defenseMod: 0, startBuff: null, applied: [] };
+  const passives = Array.isArray(owner?._perk_passives) ? owner._perk_passives : [];
+  for (const p of passives) {
+    if (p.tag === 'max_minions') {
+      out.cap = Math.max(out.cap, Number(p.payload?.cap) || out.cap);
+      out.applied.push({ tag: 'max_minions', cap: out.cap, source_perk_id: p.source_perk_id });
+    } else if (p.tag === 'minion_attack_buff') {
+      out.attackMod += Number(p.payload?.attack_mod) || 0;
+      out.applied.push({ tag: 'minion_attack_buff', source_perk_id: p.source_perk_id });
+    } else if (p.tag === 'alpha_pack_buff') {
+      out.attackMod += Number(p.payload?.attack_mod) || 0;
+      out.defenseMod += Number(p.payload?.defense_mod) || 0;
+      out.applied.push({ tag: 'alpha_pack_buff', source_perk_id: p.source_perk_id });
+    } else if (p.tag === 'encounter_start_buff_minions') {
+      out.startBuff = {
+        attack_mod: Number(p.payload?.attack_mod) || 0,
+        duration: Number(p.payload?.duration) || 1,
+      };
+      out.applied.push({ tag: 'encounter_start_buff_minions', source_perk_id: p.source_perk_id });
+    }
+  }
+  return out;
+}
+
+/**
  * Grant XP to all player survivors. Used by campaign advance hook.
  *
  * @param {Array<object>} units
@@ -654,6 +694,7 @@ module.exports = {
   applyMutationChainRefund,
   computeMutationBurstPerkMods,
   computePhenotypeShiftPerkMods,
+  computeMinionPerkMods,
   grantXpToSurvivors,
   resetDefaults,
   // Test seam: the module-default store is the singleton the session /start

--- a/tests/progression/minionSummonBuffs.test.js
+++ b/tests/progression/minionSummonBuffs.test.js
@@ -1,0 +1,171 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  computeMinionPerkMods,
+} = require('../../apps/backend/services/progression/progressionApply');
+const { createAbilityExecutor } = require('../../apps/backend/services/abilityExecutor');
+
+// TKT-JOB-PHASEC slice B5 minion summon-buffs (OQ-MINION V4) — the 4 minion tags
+// that apply AT SUMMON from the beastmaster owner's perks, no AI/pack_command
+// runtime required: max_minions (raise the cap), minion_attack_buff (+atk base),
+// alpha_pack_buff (capstone +atk/+def base), encounter_start_buff_minions
+// (temporary +atk on the freshly-summoned minion). Read by executeSummonCompanion
+// via computeMinionPerkMods(owner).
+
+// --- computeMinionPerkMods (unit) ---
+
+test('computeMinionPerkMods: no perks → cap 2, no buffs', () => {
+  const m = computeMinionPerkMods({ id: 'bm', _perk_passives: [] });
+  assert.strictEqual(m.cap, 2);
+  assert.strictEqual(m.attackMod, 0);
+  assert.strictEqual(m.defenseMod, 0);
+  assert.strictEqual(m.startBuff, null);
+});
+
+test('computeMinionPerkMods: max_minions raises the cap', () => {
+  const m = computeMinionPerkMods({
+    _perk_passives: [{ tag: 'max_minions', payload: { cap: 3 }, source_perk_id: 'bm_r4' }],
+  });
+  assert.strictEqual(m.cap, 3);
+});
+
+test('computeMinionPerkMods: minion_attack_buff → +attackMod', () => {
+  const m = computeMinionPerkMods({
+    _perk_passives: [
+      { tag: 'minion_attack_buff', payload: { attack_mod: 1 }, source_perk_id: 'bm_r2' },
+    ],
+  });
+  assert.strictEqual(m.attackMod, 1);
+});
+
+test('computeMinionPerkMods: alpha_pack_buff → +atk +def', () => {
+  const m = computeMinionPerkMods({
+    _perk_passives: [
+      {
+        tag: 'alpha_pack_buff',
+        payload: { attack_mod: 1, defense_mod: 1 },
+        source_perk_id: 'bm_r6',
+      },
+    ],
+  });
+  assert.strictEqual(m.attackMod, 1);
+  assert.strictEqual(m.defenseMod, 1);
+});
+
+test('computeMinionPerkMods: minion_attack_buff + alpha_pack_buff stack', () => {
+  const m = computeMinionPerkMods({
+    _perk_passives: [
+      { tag: 'minion_attack_buff', payload: { attack_mod: 1 }, source_perk_id: 'bm_r2' },
+      {
+        tag: 'alpha_pack_buff',
+        payload: { attack_mod: 1, defense_mod: 1 },
+        source_perk_id: 'bm_r6',
+      },
+    ],
+  });
+  assert.strictEqual(m.attackMod, 2);
+  assert.strictEqual(m.defenseMod, 1);
+});
+
+test('computeMinionPerkMods: encounter_start_buff_minions → startBuff', () => {
+  const m = computeMinionPerkMods({
+    _perk_passives: [
+      {
+        tag: 'encounter_start_buff_minions',
+        payload: { attack_mod: 1, duration: 2 },
+        source_perk_id: 'bm_r3',
+      },
+    ],
+  });
+  assert.deepStrictEqual(m.startBuff, { attack_mod: 1, duration: 2 });
+});
+
+// --- summon integration (executeSummonCompanion applies the mods) ---
+
+function makeExecutor() {
+  return createAbilityExecutor({
+    performAttack: () => ({ damageDealt: 0, result: {} }),
+    buildAttackEvent: () => ({}),
+    appendEvent: async () => {},
+    manhattanDistance: (p, q) => Math.abs(p.x - q.x) + Math.abs(p.y - q.y),
+    rng: () => 0,
+  });
+}
+
+function bm(perks) {
+  return {
+    id: 'bm',
+    job: 'beastmaster',
+    controlled_by: 'player',
+    ap: 9,
+    ap_remaining: 9,
+    position: { x: 5, y: 5 },
+    _perk_passives: perks || [],
+  };
+}
+
+test('summon: minion_attack_buff makes the minion atk 2 (base 1 + perk 1)', async () => {
+  const ex = makeExecutor();
+  const caster = bm([
+    { tag: 'minion_attack_buff', payload: { attack_mod: 1 }, source_perk_id: 'bm_r2' },
+  ]);
+  const session = { units: [caster], turn: 1, grid: { width: 10, height: 10 } };
+  await ex.executeAbility({ session, actor: caster, body: { ability_id: 'summon_companion' } });
+  const minion = session.units.find((u) => u.is_minion);
+  assert.strictEqual(minion.attack_mod, 2);
+});
+
+test('summon: alpha_pack_buff gives the minion +atk +def', async () => {
+  const ex = makeExecutor();
+  const caster = bm([
+    { tag: 'alpha_pack_buff', payload: { attack_mod: 1, defense_mod: 1 }, source_perk_id: 'bm_r6' },
+  ]);
+  const session = { units: [caster], turn: 1, grid: { width: 10, height: 10 } };
+  await ex.executeAbility({ session, actor: caster, body: { ability_id: 'summon_companion' } });
+  const minion = session.units.find((u) => u.is_minion);
+  assert.strictEqual(minion.attack_mod, 2, 'base 1 + alpha 1');
+  assert.strictEqual(minion.defense_mod, 1);
+});
+
+test('summon: encounter_start_buff_minions arms a temporary atk buff on the minion', async () => {
+  const ex = makeExecutor();
+  const caster = bm([
+    {
+      tag: 'encounter_start_buff_minions',
+      payload: { attack_mod: 1, duration: 2 },
+      source_perk_id: 'bm_r3',
+    },
+  ]);
+  const session = { units: [caster], turn: 1, grid: { width: 10, height: 10 } };
+  await ex.executeAbility({ session, actor: caster, body: { ability_id: 'summon_companion' } });
+  const minion = session.units.find((u) => u.is_minion);
+  assert.strictEqual(minion.attack_mod_bonus, 1);
+  assert.strictEqual(minion.status.attack_mod_buff, 2);
+});
+
+test('summon: max_minions raises the cap to 3 (3rd summon succeeds)', async () => {
+  const ex = makeExecutor();
+  const caster = bm([{ tag: 'max_minions', payload: { cap: 3 }, source_perk_id: 'bm_r4' }]);
+  const session = { units: [caster], turn: 1, grid: { width: 10, height: 10 } };
+  const r1 = await ex.executeAbility({
+    session,
+    actor: caster,
+    body: { ability_id: 'summon_companion' },
+  });
+  const r2 = await ex.executeAbility({
+    session,
+    actor: caster,
+    body: { ability_id: 'summon_companion' },
+  });
+  const r3 = await ex.executeAbility({
+    session,
+    actor: caster,
+    body: { ability_id: 'summon_companion' },
+  });
+  assert.strictEqual(r1.status, 200);
+  assert.strictEqual(r2.status, 200);
+  assert.strictEqual(r3.status, 200, 'cap raised to 3');
+  assert.strictEqual(session.units.filter((u) => u.is_minion).length, 3);
+});

--- a/tests/progression/minionSummonBuffs.test.js
+++ b/tests/progression/minionSummonBuffs.test.js
@@ -114,7 +114,7 @@ test('summon: minion_attack_buff makes the minion atk 2 (base 1 + perk 1)', asyn
   const session = { units: [caster], turn: 1, grid: { width: 10, height: 10 } };
   await ex.executeAbility({ session, actor: caster, body: { ability_id: 'summon_companion' } });
   const minion = session.units.find((u) => u.is_minion);
-  assert.strictEqual(minion.attack_mod, 2);
+  assert.strictEqual(minion.mod, 2, 'combat-consumed mod: base 1 + perk 1');
 });
 
 test('summon: alpha_pack_buff gives the minion +atk +def', async () => {
@@ -125,8 +125,8 @@ test('summon: alpha_pack_buff gives the minion +atk +def', async () => {
   const session = { units: [caster], turn: 1, grid: { width: 10, height: 10 } };
   await ex.executeAbility({ session, actor: caster, body: { ability_id: 'summon_companion' } });
   const minion = session.units.find((u) => u.is_minion);
-  assert.strictEqual(minion.attack_mod, 2, 'base 1 + alpha 1');
-  assert.strictEqual(minion.defense_mod, 1);
+  assert.strictEqual(minion.mod, 2, 'combat-consumed mod: base 1 + alpha 1');
+  assert.strictEqual(minion.dc, 11, 'combat-consumed dc: base 10 + alpha 1');
 });
 
 test('summon: encounter_start_buff_minions arms a temporary atk buff on the minion', async () => {


### PR DESCRIPTION
## TKT-JOB-PHASEC slice B5 minion summon-buffs (OQ-MINION V4)

Wires **4 of the 8 minion tags** — the ones that apply **at summon** from the beastmaster owner's perks, requiring **no AI/pack_command runtime** (those land on the #2544 minion-spawn foundation). PHASEC **26/32**.

### Tags wired (4)
- **max_minions** (bm_r4): raise the active-minion cap 2 → 3.
- **minion_attack_buff** (bm_r2): +1 attack_mod base on the minion (total +2).
- **alpha_pack_buff** (bm_r6 capstone): +1 attack_mod / +1 defense_mod base.
- **encounter_start_buff_minions** (bm_r3): a temporary +atk buff (`attack_mod_bonus` + `status.attack_mod_buff` duration) on the freshly-summoned minion (the meaningful application — minions are summoned mid-combat, not at a literal encounter start).

### Changes
- **`progressionApply.js`**: new pure `computeMinionPerkMods(owner)` → `{ cap, attackMod, defenseMod, startBuff }` (sibling of computeMinionPerkMods' peers).
- **`abilityExecutor.js`**: `executeSummonCompanion` reads it — cap gate uses `perkMods.cap`; the spawned minion gets `attack_mod = 1 + attackMod`, `defense_mod`, and the startBuff.

### Remaining 4 minion tags (follow-up)
`minion_proximity_dmg`, `pack_command_extended_range`, `minion_resurrect_chance`, `minion_kill_pe_bonus` — need the pack_command + scripted-AI runtime (minion acts) + end-round death hook + V6 campaign-XP.

### Tests (TDD red→green)
`tests/progression/minionSummonBuffs.test.js` (10): `computeMinionPerkMods` ×6 + summon integration ×4 (atk buff / alpha / startBuff / cap-raise). Regression: progression **121/121**, AI **500/500**.

### Band-verify
**Band-neutral** — beastmaster/summon_companion absent from every HC sim party; the mods only apply to a summoned minion (none in sim). HC06/HC07 byte-identical.

No data, no schema, no new deps. No forbidden paths.