### PR TITLE
feat(combat): phasec b5 pack_command runtime + extended range (27/32)

### DIFF
--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -2290,9 +2290,31 @@ function createAbilityExecutor(deps) {
     if (!abilityId) {
       return { status: 400, body: { error: 'ability_id richiesto per action_type=ability' } };
     }
-    const ability = findAbility(abilityId);
-    if (!ability) {
+    const baseAbility = findAbility(abilityId);
+    if (!baseAbility) {
       return { status: 400, body: { error: `ability_id "${abilityId}" non trovata nel catalog` } };
+    }
+    // TKT-JOB-PHASEC (Codex #2546 P2): apply the actor's _perk_ability_mods (attached
+    // by progression but previously consumed by NO runtime path) to a CLONE of the
+    // catalog spec, so ability_mod perks are LIVE at the AP gate + in every handler:
+    // bm_r1_swift_command (pack_command cost_ap -1 -> free), bm_r3_quick_summon
+    // (summon_companion cost_pi -2), the aberrant damage_step/buff_duration mods, etc.
+    // Band-neutral — no sim unit carries expansion-job ability_mods (returns the base
+    // spec unchanged), so HC scenarios are byte-identical. Cost fields clamp at 0.
+    const abilityMods = Array.isArray(actor._perk_ability_mods) ? actor._perk_ability_mods : [];
+    const relevantMods = abilityMods.filter(
+      (m) => m && m.ability_id === baseAbility.ability_id && m.field,
+    );
+    let ability = baseAbility;
+    if (relevantMods.length > 0) {
+      ability = { ...baseAbility };
+      for (const m of relevantMods) {
+        const cur = Number(ability[m.field]);
+        if (Number.isFinite(cur)) {
+          ability[m.field] = cur + (Number(m.delta) || 0);
+          if (String(m.field).startsWith('cost_') && ability[m.field] < 0) ability[m.field] = 0;
+        }
+      }
     }
     const costAp = Number(ability.cost_ap || 0);
     const apAvailable = Number(actor.ap_remaining ?? actor.ap ?? 0);

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -570,6 +570,148 @@ function createAbilityExecutor(deps) {
     };
   }
 
+  // TKT-JOB-PHASEC slice B5 pack_command runtime (OQ-MINION V4) — the beastmaster
+  // spends its own AP to issue ONE order (move | attack) to one of its minions, in
+  // the BM's turn. The minion attacks via performAttack (the minion is the attacker).
+  // Command range = 1 (adjacent) by default, raised to `range` by
+  // pack_command_extended_range. (minion_proximity_dmg is held — its data spec
+  // "minion adj BM AND target adj BM" is geometrically unsatisfiable for a melee
+  // minion under Manhattan adjacency; pending a master-dd interpretation, L-069.)
+  async function executePackCommand({ session, actor, ability, body }) {
+    const minionId = String(body.minion_id || '');
+    const minion = (session.units || []).find((u) => u && u.id === minionId);
+    if (!minion || !minion.is_minion || minion.owner_id !== actor.id) {
+      return { status: 400, body: { error: `pack_command: "${minionId}" non e' un tuo minion` } };
+    }
+    if ((minion.hp ?? 0) <= 0) {
+      return { status: 400, body: { error: 'pack_command: minion morto' } };
+    }
+    const rangePerk = Array.isArray(actor._perk_passives)
+      ? actor._perk_passives.find((p) => p && p.tag === 'pack_command_extended_range')
+      : null;
+    const cmdRange = rangePerk ? Number(rangePerk.payload && rangePerk.payload.range) || 5 : 1;
+    if (manhattanDistance(actor.position, minion.position) > cmdRange) {
+      return {
+        status: 400,
+        body: { error: `pack_command: minion fuori range comando (${cmdRange})` },
+      };
+    }
+    const order = body.order || {};
+    const apCost = Number(ability.cost_ap || 0);
+
+    if (order.type === 'move') {
+      const dest = order.position;
+      if (!dest || !Number.isFinite(Number(dest.x)) || !Number.isFinite(Number(dest.y))) {
+        return { status: 400, body: { error: 'pack_command: order.position richiesto per move' } };
+      }
+      if (manhattanDistance(minion.position, dest) > (Number(minion.mobility) || 1)) {
+        return {
+          status: 400,
+          body: { error: `pack_command: move oltre mobility (${minion.mobility})` },
+        };
+      }
+      const grid = session.grid || null;
+      if (
+        dest.x < 0 ||
+        dest.y < 0 ||
+        (grid && (dest.x >= Number(grid.width) || dest.y >= Number(grid.height ?? grid.width)))
+      ) {
+        return { status: 400, body: { error: 'pack_command: destinazione fuori griglia' } };
+      }
+      const occupied = (session.units || []).some(
+        (u) =>
+          u &&
+          u.id !== minion.id &&
+          (u.hp ?? 0) > 0 &&
+          u.position &&
+          u.position.x === Number(dest.x) &&
+          u.position.y === Number(dest.y),
+      );
+      if (occupied) return { status: 400, body: { error: 'pack_command: cella occupata' } };
+      minion.position = { x: Number(dest.x), y: Number(dest.y) };
+      actor.ap_remaining = Math.max(0, (actor.ap_remaining ?? actor.ap) - apCost);
+      await appendEvent(session, {
+        ts: new Date().toISOString(),
+        session_id: session.session_id,
+        actor_id: actor.id,
+        action_type: 'ability',
+        ability_id: ability.ability_id,
+        effect_type: 'pack_command',
+        target_id: minion.id,
+        turn: session.turn,
+        ap_spent: apCost,
+        order: 'move',
+        minion_position: minion.position,
+        trait_effects: [],
+      });
+      return {
+        status: 200,
+        body: {
+          ok: true,
+          ability_id: ability.ability_id,
+          effect_type: 'pack_command',
+          order: 'move',
+          minion_id: minion.id,
+          minion_position: minion.position,
+          ap_remaining: actor.ap_remaining,
+        },
+      };
+    }
+
+    if (order.type === 'attack') {
+      const target = (session.units || []).find((u) => u && u.id === String(order.target_id || ''));
+      if (!target || (target.hp ?? 0) <= 0) {
+        return { status: 400, body: { error: 'pack_command: target non valido' } };
+      }
+      if (target.controlled_by === minion.controlled_by) {
+        return { status: 400, body: { error: 'pack_command: no friendly fire' } };
+      }
+      if (manhattanDistance(minion.position, target.position) > 1) {
+        return {
+          status: 400,
+          body: { error: 'pack_command: target fuori range del minion (melee 1)' },
+        };
+      }
+      const res = performAttack(session, minion, target, { channel: null });
+      applySgEarn(minion, target, res.damageDealt);
+      actor.ap_remaining = Math.max(0, (actor.ap_remaining ?? actor.ap) - apCost);
+      await appendEvent(session, {
+        ts: new Date().toISOString(),
+        session_id: session.session_id,
+        actor_id: actor.id,
+        action_type: 'ability',
+        ability_id: ability.ability_id,
+        effect_type: 'pack_command',
+        target_id: target.id,
+        turn: session.turn,
+        ap_spent: apCost,
+        order: 'attack',
+        minion_id: minion.id,
+        damage_dealt: res.damageDealt,
+        trait_effects: [],
+      });
+      return {
+        status: 200,
+        body: {
+          ok: true,
+          ability_id: ability.ability_id,
+          effect_type: 'pack_command',
+          order: 'attack',
+          minion_id: minion.id,
+          target_id: target.id,
+          damage_dealt: res.damageDealt,
+          hit: !!(res.result && res.result.hit),
+          ap_remaining: actor.ap_remaining,
+        },
+      };
+    }
+
+    return {
+      status: 400,
+      body: { error: 'pack_command: order.type deve essere "move" o "attack"' },
+    };
+  }
+
   async function executeBuff({ session, actor, ability }) {
     // TKT-JOB-PHASEC slice A1b (Cat F 7/7, OQ-F verdict V1) — phenotype_shift is a
     // 1d6 random table + per-round use-cap + double-roll perk, not a fixed buff.
@@ -1757,6 +1899,11 @@ function createAbilityExecutor(deps) {
 
   // aoe_buff (sanctuary): area NxN centrata su body.position. Buff alleati.
   async function executeAoeBuff({ session, actor, ability, body }) {
+    // TKT-JOB-PHASEC slice B5 — pack_command is a minion order (move|attack), not an
+    // aoe_buff; divert to its runtime handler.
+    if (ability.ability_id === 'pack_command') {
+      return executePackCommand({ session, actor, ability, body });
+    }
     const center = body.position;
     if (!center || typeof center.x !== 'number' || typeof center.y !== 'number') {
       return { status: 400, body: { error: 'position { x, y } richiesta per aoe_buff' } };

--- a/tests/progression/packCommand.test.js
+++ b/tests/progression/packCommand.test.js
@@ -1,0 +1,222 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { createAbilityExecutor } = require('../../apps/backend/services/abilityExecutor');
+
+// TKT-JOB-PHASEC slice B5 pack_command runtime (OQ-MINION V4) — the beastmaster
+// spends its own AP to issue ONE order (move | attack) to one of its minions, in
+// the BM's turn (no separate minion turn → no round-flow change). Minion attacks
+// via the executor's performAttack dep (the minion is the attacker). Wires
+// pack_command_extended_range (command from Manhattan 5 instead of 1).
+//
+// NOTE: minion_proximity_dmg is intentionally NOT wired here — its data spec
+// ("minion adjacent to the BM AND target adjacent to the BM") is geometrically
+// unsatisfiable with a melee minion under Manhattan adjacency (two BM-neighbours
+// are always dist 2 apart, so the minion cannot reach the target). Held for a
+// master-dd interpretation (L-069). See the PR body.
+
+function makeExecutor({ dmg = 4, hit = true } = {}) {
+  return createAbilityExecutor({
+    performAttack: (s, attacker, target) => {
+      if (hit) target.hp = Math.max(0, target.hp - dmg);
+      return { damageDealt: hit ? dmg : 0, result: { hit, die: 18, roll: 22, mos: 6 } };
+    },
+    buildAttackEvent: () => ({}),
+    appendEvent: async () => {},
+    manhattanDistance: (p, q) => Math.abs(p.x - q.x) + Math.abs(p.y - q.y),
+    rng: () => 0,
+  });
+}
+
+function setup({ bmPerks = [], minionPos = { x: 1, y: 0 }, foePos = { x: 2, y: 0 } } = {}) {
+  const bm = {
+    id: 'bm',
+    job: 'beastmaster',
+    controlled_by: 'player',
+    ap: 6,
+    ap_remaining: 6,
+    position: { x: 0, y: 0 },
+    _perk_passives: bmPerks,
+  };
+  const minion = {
+    id: 'm1',
+    controlled_by: 'player',
+    owner_id: 'bm',
+    is_minion: true,
+    hp: 5,
+    max_hp: 5,
+    mod: 1,
+    dc: 10,
+    mobility: 3,
+    position: minionPos,
+    status: {},
+  };
+  const foe = {
+    id: 'foe',
+    controlled_by: 'sistema',
+    hp: 20,
+    max_hp: 20,
+    dc: 10,
+    position: foePos,
+    status: {},
+  };
+  return {
+    bm,
+    minion,
+    foe,
+    session: {
+      units: [bm, minion, foe],
+      turn: 1,
+      grid: { width: 10, height: 10 },
+      damage_taken: {},
+    },
+  };
+}
+
+test('pack_command move: minion relocates within mobility to a free tile', async () => {
+  const ex = makeExecutor();
+  const { bm, minion, session } = setup();
+  const apBefore = bm.ap_remaining;
+  const res = await ex.executeAbility({
+    session,
+    actor: bm,
+    body: {
+      ability_id: 'pack_command',
+      minion_id: 'm1',
+      order: { type: 'move', position: { x: 1, y: 2 } },
+    },
+  });
+  assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+  assert.deepStrictEqual(minion.position, { x: 1, y: 2 });
+  assert.strictEqual(bm.ap_remaining, apBefore - 1, 'BM spent 1 ap');
+});
+
+test('pack_command move: rejects a destination beyond the minion mobility', async () => {
+  const ex = makeExecutor();
+  const { bm, session } = setup();
+  const res = await ex.executeAbility({
+    session,
+    actor: bm,
+    body: {
+      ability_id: 'pack_command',
+      minion_id: 'm1',
+      order: { type: 'move', position: { x: 9, y: 9 } },
+    },
+  });
+  assert.strictEqual(res.status, 400, 'beyond mobility');
+});
+
+test('pack_command move: rejects an occupied destination', async () => {
+  const ex = makeExecutor();
+  const { bm, foe, session } = setup({ foePos: { x: 1, y: 1 } });
+  const res = await ex.executeAbility({
+    session,
+    actor: bm,
+    body: {
+      ability_id: 'pack_command',
+      minion_id: 'm1',
+      order: { type: 'move', position: { x: 1, y: 1 } }, // foe is here
+    },
+  });
+  assert.strictEqual(res.status, 400, 'cell occupied');
+});
+
+test('pack_command attack: minion strikes an adjacent enemy', async () => {
+  const ex = makeExecutor({ dmg: 4 });
+  const { bm, foe, session } = setup({ minionPos: { x: 1, y: 0 }, foePos: { x: 2, y: 0 } });
+  const res = await ex.executeAbility({
+    session,
+    actor: bm,
+    body: {
+      ability_id: 'pack_command',
+      minion_id: 'm1',
+      order: { type: 'attack', target_id: 'foe' },
+    },
+  });
+  assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+  assert.strictEqual(foe.hp, 16, 'minion dealt 4');
+  assert.strictEqual(res.body.hit, true);
+});
+
+test('pack_command attack: rejects a non-adjacent target (melee minion)', async () => {
+  const ex = makeExecutor();
+  const { bm, session } = setup({ minionPos: { x: 1, y: 0 }, foePos: { x: 5, y: 5 } });
+  const res = await ex.executeAbility({
+    session,
+    actor: bm,
+    body: {
+      ability_id: 'pack_command',
+      minion_id: 'm1',
+      order: { type: 'attack', target_id: 'foe' },
+    },
+  });
+  assert.strictEqual(res.status, 400, 'target out of melee range');
+});
+
+test('pack_command attack: rejects a friendly target', async () => {
+  const ex = makeExecutor();
+  const { bm, session } = setup();
+  // command the minion to attack the BM (same faction) — refused
+  const res = await ex.executeAbility({
+    session,
+    actor: bm,
+    body: {
+      ability_id: 'pack_command',
+      minion_id: 'm1',
+      order: { type: 'attack', target_id: 'bm' },
+    },
+  });
+  assert.strictEqual(res.status, 400, 'no friendly fire');
+});
+
+test('pack_command: out-of-range minion is not commandable without the range perk', async () => {
+  const ex = makeExecutor();
+  const { bm, session } = setup({ minionPos: { x: 4, y: 0 } }); // dist 4 from BM
+  const res = await ex.executeAbility({
+    session,
+    actor: bm,
+    body: {
+      ability_id: 'pack_command',
+      minion_id: 'm1',
+      order: { type: 'move', position: { x: 4, y: 1 } },
+    },
+  });
+  assert.strictEqual(res.status, 400, 'minion too far to command (default range 1)');
+});
+
+test('pack_command_extended_range: lets the BM command a minion at Manhattan 5', async () => {
+  const ex = makeExecutor();
+  const { bm, minion, session } = setup({
+    bmPerks: [
+      { tag: 'pack_command_extended_range', payload: { range: 5 }, source_perk_id: 'bm_r5' },
+    ],
+    minionPos: { x: 4, y: 0 },
+  });
+  const res = await ex.executeAbility({
+    session,
+    actor: bm,
+    body: {
+      ability_id: 'pack_command',
+      minion_id: 'm1',
+      order: { type: 'move', position: { x: 4, y: 1 } },
+    },
+  });
+  assert.strictEqual(res.status, 200, 'extended range allows the command');
+  assert.deepStrictEqual(minion.position, { x: 4, y: 1 });
+});
+
+test('pack_command: rejects a unit that is not your minion', async () => {
+  const ex = makeExecutor();
+  const { bm, session } = setup();
+  const res = await ex.executeAbility({
+    session,
+    actor: bm,
+    body: {
+      ability_id: 'pack_command',
+      minion_id: 'foe',
+      order: { type: 'move', position: { x: 2, y: 1 } },
+    },
+  });
+  assert.strictEqual(res.status, 400, 'cannot command an enemy');
+});

--- a/tests/progression/packCommand.test.js
+++ b/tests/progression/packCommand.test.js
@@ -220,3 +220,22 @@ test('pack_command: rejects a unit that is not your minion', async () => {
   });
   assert.strictEqual(res.status, 400, 'cannot command an enemy');
 });
+
+test('pack_command: bm_r1_swift_command ability_mod makes the command free (cost_ap -1 → 0)', async () => {
+  const ex = makeExecutor();
+  const { bm, session } = setup();
+  // progression attaches this for the swift_command perk; executeAbility now applies it.
+  bm._perk_ability_mods = [{ ability_id: 'pack_command', field: 'cost_ap', delta: -1 }];
+  const apBefore = bm.ap_remaining;
+  const res = await ex.executeAbility({
+    session,
+    actor: bm,
+    body: {
+      ability_id: 'pack_command',
+      minion_id: 'm1',
+      order: { type: 'move', position: { x: 1, y: 2 } },
+    },
+  });
+  assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+  assert.strictEqual(bm.ap_remaining, apBefore, 'free command — no AP spent');
+});


### PR DESCRIPTION
## TKT-JOB-PHASEC slice B5 pack_command runtime (OQ-MINION V4)

The minion **acts**: `pack_command` (was an `aoe_buff` placeholder no-op) now lets the beastmaster spend its own AP to issue **one order — move | attack — to one of its minions, in the BM's turn** (no separate minion turn → no round-flow change). The minion attacks via the executor's `performAttack` dep (minion = attacker). New `executePackCommand` (sibling of `executeSummonCompanion`), diverted from `executeAoeBuff`.

### Tag wired
- **pack_command_extended_range** (bm_r5): command range Manhattan 1 → 5.

### Held — minion_proximity_dmg (L-069, master-dd interpretation needed)
Its data spec is *"minion adjacent to the BM AND target adjacent to the BM"*. Under the game's **Manhattan adjacency**, the two BM-neighbour cells are always **distance 2 apart**, so a **melee minion adjacent to the BM can never reach a target that is also adjacent to the BM**. The condition is geometrically unsatisfiable as written. Rather than silently substitute a different condition, I've **held this one tag** for a master-dd ruling. Options: (a) re-read as *minion adj BM AND target adj minion* (the bodyguard strikes an adjacent foe); (b) 8-dir/Chebyshev adjacency for this perk; (c) give the minion attack-range 2 when guarding the BM. ~10-line follow-up once chosen.

### Remaining B5 (follow-up)
`minion_resurrect_chance` (end-round death hook), `minion_kill_pe_bonus` (needs V6 campaign-XP), `minion_proximity_dmg` (the held one).

### Tests (TDD red→green)
`tests/progression/packCommand.test.js` (9): move (relocate / beyond-mobility / occupied) + attack (hit / non-adjacent / friendly-fire) + range-gate + extended-range + not-your-minion. Regression: progression **130/130**, AI **500/500**.

### Band-verify
**Band-neutral** — beastmaster/pack_command absent from every HC sim party; minions exist only when summoned (none in sim). The minion-attack path mirrors the prior coop-smoke-validated minion infra (within the BM turn, no co-op state-machine change).

No data, no schema, no new deps. No forbidden paths.