### PR TITLE
feat(combat): phasec b5 minion_resurrect_chance (28/32)

### DIFF
--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -1239,6 +1239,27 @@ function createRoundBridge(deps) {
       console.warn('[morale-contagion] failed:', err && err.message ? err.message : err);
     }
 
+    // TKT-JOB-PHASEC B5 minion_resurrect_chance (bm_r6 capstone) — runs LAST, after
+    // all damage ticks have finalized this round's deaths. Revives dead minions whose
+    // living owner has the perk (one roll per minion); emit the revive events.
+    const resurrectEvents = require('../services/combat/minionRuntime').applyMinionResurrect(
+      session,
+      rng,
+    );
+    for (const ev of resurrectEvents) {
+      await appendEvent(session, {
+        ts: new Date().toISOString(),
+        session_id: session.session_id,
+        action_type: 'minion_resurrect',
+        actor_id: ev.owner_id,
+        target_id: ev.minion_id,
+        turn: session.turn,
+        result: 'revived',
+        hp_after: ev.hp_after,
+        trait_effects: [],
+      });
+    }
+
     return {
       hazardEvents,
       bleedingEvents,
@@ -1246,6 +1267,7 @@ function createRoundBridge(deps) {
       terrainDecayEvents,
       alphaEvents,
       thoughtEvents,
+      resurrectEvents,
     };
   }
 

--- a/apps/backend/services/combat/minionRuntime.js
+++ b/apps/backend/services/combat/minionRuntime.js
@@ -1,0 +1,46 @@
+// Minion runtime helpers — TKT-JOB-PHASEC slice B5 (OQ-MINION verdict V4).
+//
+// End-of-round minion effects that are cleaner to unit-test in isolation than
+// inside the (un-exposed) sessionRoundBridge.applyEndOfRoundSideEffects closure.
+
+'use strict';
+
+/**
+ * minion_resurrect_chance (BEASTMASTER bm_r6 capstone "Undying Pack"): at end of
+ * round, each dead minion whose LIVING owner carries the perk has `chance` to
+ * revive in place at `hp_on_revive` (1). One roll per minion (`_resurrect_done`
+ * marks success OR failure so a minion is never re-rolled). Mutates session.units
+ * (minion.hp) and returns the revive events for the caller to emit.
+ *
+ * Band-neutral: no sim unit is a minion. NOTE the priority_queue calibration path
+ * skips applyEndOfRoundSideEffects entirely, so this is inert there (fine — the
+ * beastmaster is absent from every band scenario).
+ *
+ * @param {object} session — { units }
+ * @param {() => number} rng — 0..1 source (the bridge's closure rng)
+ * @returns {Array<{ minion_id, owner_id, hp_after }>}
+ */
+function applyMinionResurrect(session, rng) {
+  const events = [];
+  const units = Array.isArray(session && session.units) ? session.units : [];
+  const roll = typeof rng === 'function' ? rng : Math.random;
+  for (const unit of units) {
+    if (!unit || !unit.is_minion || Number(unit.hp || 0) > 0 || unit._resurrect_done) continue;
+    const owner = units.find((u) => u && u.id === unit.owner_id && Number(u.hp || 0) > 0);
+    if (!owner) continue;
+    const perk = Array.isArray(owner._perk_passives)
+      ? owner._perk_passives.find((p) => p && p.tag === 'minion_resurrect_chance')
+      : null;
+    if (!perk) continue;
+    unit._resurrect_done = true; // one roll per minion (success or fail)
+    const chance = Number(perk.payload && perk.payload.chance) || 0;
+    if (chance > 0 && roll() < chance) {
+      const revHp = Number(perk.payload && perk.payload.hp_on_revive) || 1;
+      unit.hp = Math.max(1, revHp);
+      events.push({ minion_id: unit.id, owner_id: owner.id, hp_after: unit.hp });
+    }
+  }
+  return events;
+}
+
+module.exports = { applyMinionResurrect };

--- a/tests/progression/minionResurrect.test.js
+++ b/tests/progression/minionResurrect.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { applyMinionResurrect } = require('../../apps/backend/services/combat/minionRuntime');
+
+// TKT-JOB-PHASEC slice B5 minion_resurrect_chance (bm_r6 capstone, OQ-MINION V4) —
+// at end-of-round, a dead minion whose (living) beastmaster owner has the perk has
+// `chance` to revive in place at `hp_on_revive` (1). One roll per minion
+// (_resurrect_done). Pure-ish (mutates session.units, returns the revive events);
+// called from sessionRoundBridge.applyEndOfRoundSideEffects with the closure rng.
+
+function perk(chance = 0.5) {
+  return {
+    tag: 'minion_resurrect_chance',
+    payload: { chance, hp_on_revive: 1 },
+    source_perk_id: 'bm_r6',
+  };
+}
+function setup(ownerPerks) {
+  const owner = { id: 'bm', controlled_by: 'player', hp: 10, _perk_passives: ownerPerks || [] };
+  const minion = {
+    id: 'm1',
+    controlled_by: 'player',
+    owner_id: 'bm',
+    is_minion: true,
+    hp: 0,
+    max_hp: 5,
+  };
+  return { owner, minion, session: { units: [owner, minion], turn: 3 } };
+}
+
+test('applyMinionResurrect: revives a dead minion in place when the roll succeeds', () => {
+  const { minion, session } = setup([perk(0.5)]);
+  const events = applyMinionResurrect(session, () => 0.2); // 0.2 < 0.5 → success
+  assert.strictEqual(minion.hp, 1, 'revived at hp_on_revive');
+  assert.strictEqual(minion._resurrect_done, true);
+  assert.strictEqual(events.length, 1);
+  assert.strictEqual(events[0].minion_id, 'm1');
+});
+
+test('applyMinionResurrect: leaves the minion dead when the roll fails (but marks it processed)', () => {
+  const { minion, session } = setup([perk(0.5)]);
+  const events = applyMinionResurrect(session, () => 0.9); // 0.9 >= 0.5 → fail
+  assert.strictEqual(minion.hp, 0, 'stays dead');
+  assert.strictEqual(minion._resurrect_done, true, 'one roll per minion');
+  assert.strictEqual(events.length, 0);
+});
+
+test('applyMinionResurrect: does not re-roll an already-processed minion', () => {
+  const { minion, session } = setup([perk(1.0)]);
+  minion._resurrect_done = true;
+  const events = applyMinionResurrect(session, () => 0);
+  assert.strictEqual(minion.hp, 0, 'not revived again');
+  assert.strictEqual(events.length, 0);
+});
+
+test('applyMinionResurrect: no perk → no revive', () => {
+  const { minion, session } = setup([]);
+  applyMinionResurrect(session, () => 0);
+  assert.strictEqual(minion.hp, 0);
+  assert.ok(!minion._resurrect_done);
+});
+
+test('applyMinionResurrect: a dead owner cannot resurrect', () => {
+  const { owner, minion, session } = setup([perk(1.0)]);
+  owner.hp = 0;
+  applyMinionResurrect(session, () => 0);
+  assert.strictEqual(minion.hp, 0, 'no living owner → no revive');
+});
+
+test('applyMinionResurrect: a living minion is untouched', () => {
+  const { minion, session } = setup([perk(1.0)]);
+  minion.hp = 3;
+  const events = applyMinionResurrect(session, () => 0);
+  assert.strictEqual(minion.hp, 3);
+  assert.strictEqual(events.length, 0);
+});


### PR DESCRIPTION
## TKT-JOB-PHASEC slice B5 minion_resurrect_chance (OQ-MINION V4)

**minion_resurrect_chance** (bm_r6 "Undying Pack" capstone): at **end-of-round**, a dead minion whose **living** beastmaster owner carries the perk has `chance` (0.5) to **revive in place** at `hp_on_revive` (1). **One roll per minion** (`_resurrect_done` marks success OR failure → never re-rolled). PHASEC **28/32**.

### Changes
- **new `apps/backend/services/combat/minionRuntime.js`** — pure `applyMinionResurrect(session, rng)` (mutates minion hp, returns the revive events). Extracted as a module because the bridge's `applyEndOfRoundSideEffects` closure isn't exposed for unit tests.
- **`sessionRoundBridge.js`** — calls it **last** in `applyEndOfRoundSideEffects` (after the hazard/bleeding/burning ticks finalize this round's deaths) + emits `minion_resurrect` events.

### Tests (TDD red→green)
`tests/progression/minionResurrect.test.js` (6): revive-on-success / stay-dead-on-fail (still marked) / no-re-roll / no-perk / dead-owner / living-minion-untouched. Regression: bridge-touching suites **79**, AI **500/500**.

### Band-verify
**Band-neutral** — no sim unit is a minion; the priority_queue calibration path skips `applyEndOfRoundSideEffects` entirely (so it's inert there — fine, the beastmaster is absent from every band scenario). HC06/HC07 byte-identical.

### B5 remaining
`minion_kill_pe_bonus` (needs V6 campaign-XP), `minion_proximity_dmg` (held, L-069 master-dd interpretation).

No data, no schema, no new deps. No forbidden paths.