### PR TITLE
fix(combat): phasec b5 resurrect roll uses seeded session rng (codex #2547)

### DIFF
--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -1242,9 +1242,13 @@ function createRoundBridge(deps) {
     // TKT-JOB-PHASEC B5 minion_resurrect_chance (bm_r6 capstone) — runs LAST, after
     // all damage ticks have finalized this round's deaths. Revives dead minions whose
     // living owner has the perk (one roll per minion); emit the revive events.
+    // Seeded RNG (Codex #2547 P2): applyEndOfRoundSideEffects runs in async code
+    // AFTER runWithSeed restored the global stream, so — like the other async roll
+    // sites here (morale L~1208) — the revive roll must draw from the per-session
+    // holder, not the bridge-level `rng`, to stay deterministic for seeded playtests.
     const resurrectEvents = require('../services/combat/minionRuntime').applyMinionResurrect(
       session,
-      rng,
+      makeHolderRng(session.combatRng),
     );
     for (const ev of resurrectEvents) {
       await appendEvent(session, {


### PR DESCRIPTION
Post-merge follow-up to #2547 (Codex P2). `applyEndOfRoundSideEffects` runs in async end-of-round code **after** `runWithSeed` restored the global stream, so the minion resurrect roll must draw from the **per-session holder** `makeHolderRng(session.combatRng)` — like the nearby async roll sites (morale ~L1208) — not the bridge-level `rng`. Otherwise minion resurrection is nondeterministic and **desyncs reproducible seeded playtests** whenever a dead minion with `minion_resurrect_chance` is processed.

1-line change (the rng source of the resurrect call). Band-neutral (no sim unit is a minion). bridge regression 68, prettier clean.

No data, no schema, no new deps.