### PR TITLE
feat(combat): phasec b5 minion_proximity_dmg (29/32)

### DIFF
--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -673,7 +673,34 @@ function createAbilityExecutor(deps) {
         };
       }
       const res = performAttack(session, minion, target, { channel: null });
-      applySgEarn(minion, target, res.damageDealt);
+      // minion_proximity_dmg (bm_r2_pack_focus): +N when the struck target is
+      // adjacent to the BM (the commanded bodyguard punishes threats on the master).
+      // L-069: the data's additional "minion adjacent to the BM" clause is
+      // geometrically unsatisfiable for a melee minion under Manhattan adjacency
+      // (a default-commandable minion is itself adjacent to the BM, dist 2 from any
+      // other BM-neighbour), so it is dropped pending a master-dd geometry ruling.
+      let proximityBonus = 0;
+      const proxPerk = Array.isArray(actor._perk_passives)
+        ? actor._perk_passives.find((p) => p && p.tag === 'minion_proximity_dmg')
+        : null;
+      if (
+        proxPerk &&
+        res.result &&
+        res.result.hit &&
+        Number(res.damageDealt) > 0 &&
+        manhattanDistance(target.position, actor.position) <= 1
+      ) {
+        const want = Number(proxPerk.payload && proxPerk.payload.damage) || 0;
+        const extra = Math.min(want, Number(target.hp) || 0);
+        if (extra > 0) {
+          target.hp = Math.max(0, Number(target.hp) - extra);
+          if (session.damage_taken) {
+            session.damage_taken[target.id] = (session.damage_taken[target.id] || 0) + extra;
+          }
+          proximityBonus = extra;
+        }
+      }
+      applySgEarn(minion, target, res.damageDealt + proximityBonus);
       actor.ap_remaining = Math.max(0, (actor.ap_remaining ?? actor.ap) - apCost);
       await appendEvent(session, {
         ts: new Date().toISOString(),
@@ -687,7 +714,8 @@ function createAbilityExecutor(deps) {
         ap_spent: apCost,
         order: 'attack',
         minion_id: minion.id,
-        damage_dealt: res.damageDealt,
+        damage_dealt: res.damageDealt + proximityBonus,
+        proximity_bonus: proximityBonus,
         trait_effects: [],
       });
       return {
@@ -699,7 +727,8 @@ function createAbilityExecutor(deps) {
           order: 'attack',
           minion_id: minion.id,
           target_id: target.id,
-          damage_dealt: res.damageDealt,
+          damage_dealt: res.damageDealt + proximityBonus,
+          proximity_bonus: proximityBonus,
           hit: !!(res.result && res.result.hit),
           ap_remaining: actor.ap_remaining,
         },

--- a/tests/progression/minionProximityDmg.test.js
+++ b/tests/progression/minionProximityDmg.test.js
@@ -1,0 +1,143 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { createAbilityExecutor } = require('../../apps/backend/services/abilityExecutor');
+
+// TKT-JOB-PHASEC slice B5 minion_proximity_dmg (bm_r2_pack_focus, OQ-MINION V4).
+//
+// L-069 geometry: the data spec is "minion adjacent to the BM AND target adjacent
+// to the BM", which is UNSATISFIABLE for a melee minion under Manhattan adjacency
+// (the two BM-neighbour cells are dist 2 apart, and a default-range commanded
+// minion must itself be adjacent to the BM). We adopt the minimal faithful reading
+// of the INTENT ("a bodyguard minion punishes threats pressing the BM"): +N damage
+// when the struck TARGET is adjacent to the BM (the minion-adjacent-to-BM clause is
+// dropped — the minion is the BM's commanded pack member by construction).
+// ⚠️ Claude autonomous interpretation pending a master-dd geometry ruling.
+
+function makeExecutor({ dmg = 4 } = {}) {
+  return createAbilityExecutor({
+    performAttack: (s, attacker, target) => {
+      target.hp = Math.max(0, target.hp - dmg);
+      return { damageDealt: dmg, result: { hit: true, die: 18, roll: 22, mos: 6 } };
+    },
+    buildAttackEvent: () => ({}),
+    appendEvent: async () => {},
+    manhattanDistance: (p, q) => Math.abs(p.x - q.x) + Math.abs(p.y - q.y),
+    rng: () => 0,
+  });
+}
+
+function setup({ bmPerks = [], minionPos, foePos }) {
+  const bm = {
+    id: 'bm',
+    job: 'beastmaster',
+    controlled_by: 'player',
+    ap: 6,
+    ap_remaining: 6,
+    position: { x: 0, y: 0 },
+    _perk_passives: bmPerks,
+  };
+  const minion = {
+    id: 'm1',
+    controlled_by: 'player',
+    owner_id: 'bm',
+    is_minion: true,
+    hp: 5,
+    max_hp: 5,
+    mod: 1,
+    dc: 10,
+    mobility: 3,
+    position: minionPos,
+    status: {},
+  };
+  const foe = {
+    id: 'foe',
+    controlled_by: 'sistema',
+    hp: 20,
+    max_hp: 20,
+    dc: 10,
+    position: foePos,
+    status: {},
+  };
+  return {
+    bm,
+    minion,
+    foe,
+    session: {
+      units: [bm, minion, foe],
+      turn: 1,
+      grid: { width: 10, height: 10 },
+      damage_taken: {},
+    },
+  };
+}
+
+const PROX = { tag: 'minion_proximity_dmg', payload: { damage: 1 }, source_perk_id: 'bm_r2' };
+const EXT = { tag: 'pack_command_extended_range', payload: { range: 5 }, source_perk_id: 'bm_r5' };
+
+test('minion_proximity_dmg: +1 when the struck target is adjacent to the BM', async () => {
+  const ex = makeExecutor({ dmg: 4 });
+  // BM(0,0); minion(1,1) [dist 2 from BM → needs extended range to command];
+  // foe(1,0) [adjacent to BM dist 1, adjacent to minion dist 1].
+  const { bm, foe, session } = setup({
+    bmPerks: [EXT, PROX],
+    minionPos: { x: 1, y: 1 },
+    foePos: { x: 1, y: 0 },
+  });
+  const res = await ex.executeAbility({
+    session,
+    actor: bm,
+    body: {
+      ability_id: 'pack_command',
+      minion_id: 'm1',
+      order: { type: 'attack', target_id: 'foe' },
+    },
+  });
+  assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+  assert.strictEqual(res.body.proximity_bonus, 1, 'target adjacent to BM → +1');
+  assert.strictEqual(foe.hp, 15, 'base 4 + proximity 1');
+  assert.strictEqual(res.body.damage_dealt, 5);
+});
+
+test('minion_proximity_dmg: no bonus when the target is NOT adjacent to the BM', async () => {
+  const ex = makeExecutor({ dmg: 4 });
+  // minion(1,0) [adj BM, default-commandable]; foe(2,0) [adj minion dist1, adj BM dist2].
+  const { bm, foe, session } = setup({
+    bmPerks: [PROX],
+    minionPos: { x: 1, y: 0 },
+    foePos: { x: 2, y: 0 },
+  });
+  const res = await ex.executeAbility({
+    session,
+    actor: bm,
+    body: {
+      ability_id: 'pack_command',
+      minion_id: 'm1',
+      order: { type: 'attack', target_id: 'foe' },
+    },
+  });
+  assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+  assert.strictEqual(res.body.proximity_bonus, 0);
+  assert.strictEqual(foe.hp, 16, 'base 4 only');
+});
+
+test('minion_proximity_dmg: no bonus without the perk', async () => {
+  const ex = makeExecutor({ dmg: 4 });
+  const { bm, foe, session } = setup({
+    bmPerks: [EXT],
+    minionPos: { x: 1, y: 1 },
+    foePos: { x: 1, y: 0 },
+  });
+  const res = await ex.executeAbility({
+    session,
+    actor: bm,
+    body: {
+      ability_id: 'pack_command',
+      minion_id: 'm1',
+      order: { type: 'attack', target_id: 'foe' },
+    },
+  });
+  assert.strictEqual(res.body.proximity_bonus, 0);
+  assert.strictEqual(foe.hp, 16);
+});


### PR DESCRIPTION
## TKT-JOB-PHASEC slice B5 minion_proximity_dmg (bm_r2_pack_focus, OQ-MINION V4)

A commanded minion deals **+N damage when the struck target is adjacent to the BM** (the bodyguard punishes threats pressing the master), applied post-attack in `executePackCommand`. PHASEC **29/32**.

### ⚠️ L-069 interpretation (caveated, pending master-dd geometry ruling)
The data spec is *"minion adjacent to the BM **AND** target adjacent to the BM"*. Under the game's **Manhattan adjacency** this is **geometrically unsatisfiable** for a melee minion: a default-commandable minion is itself adjacent to the BM (dist 1), and any other BM-neighbour cell is dist 2 away — so the minion can never melee-reach a target that is also adjacent to the BM. I implemented the **minimal faithful reading of the intent** (`target adjacent to BM`, the minion-adjacency clause dropped — the minion is the BM's commanded pack member by construction). A master-dd ruling can tighten/adjust this (e.g. 8-dir adjacency, or a guard-zone radius).

### Tests (TDD red→green)
`tests/progression/minionProximityDmg.test.js` (3): +1 when target adj BM / no bonus when target not adj BM / no bonus without the perk. Regression: progression **140/140**, AI **500/500**.

### Band-verify
**Band-neutral** — beastmaster/pack_command/minions absent from every HC sim party.

No data, no schema, no new deps. No forbidden paths.