### PR TITLE
feat(combat): phasec v6 campaign-xp first_kill + minion_kill pe (31/32)

### DIFF
--- a/apps/backend/routes/campaign.js
+++ b/apps/backend/routes/campaign.js
@@ -231,7 +231,8 @@ function createCampaignRouter(options = {}) {
 
   // POST /api/campaign/advance
   router.post('/campaign/advance', (req, res) => {
-    const { id, outcome, pe_earned, pi_earned, survivors, xp_per_unit } = req.body || {};
+    const { id, outcome, pe_earned, pi_earned, survivors, xp_per_unit, first_kill_actor_id } =
+      req.body || {};
     if (!id) return res.status(400).json({ error: 'id richiesto' });
     if (!['victory', 'defeat', 'timeout'].includes(outcome)) {
       return res.status(400).json({ error: 'outcome deve essere victory|defeat|timeout' });
@@ -294,7 +295,8 @@ function createCampaignRouter(options = {}) {
               : null,
           ),
           amount,
-          { campaignId: id },
+          // V6 A3 — pass the debrief's first-kill actor so first_kill_pe_bonus lands.
+          { campaignId: id, firstKillActorId: first_kill_actor_id },
         );
       } catch (err) {
         xpGrants = [];

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -1072,6 +1072,11 @@ function createSessionRouter(options = {}) {
     // traverses. No-op when actor carries no kill perks.
     if (killOccurred) {
       applyPerkKillEffects(actor);
+      // TKT-JOB-PHASEC V6 A3 — record the encounter's FIRST kill actor (once).
+      // Surfaced by the debrief + consumed by grantXpToSurvivors' first_kill_pe_bonus.
+      if (session._first_kill_actor_id == null) {
+        session._first_kill_actor_id = actor.id;
+      }
     }
 
     // SPRINT_018: valuta i trait di tipo apply_status (ferocia, intimidatore,

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -701,6 +701,20 @@ function createAbilityExecutor(deps) {
         }
       }
       applySgEarn(minion, target, res.damageDealt + proximityBonus);
+      // minion_kill_pe_bonus (bm_r5_apex_companion, V6 A3): when a minion kills, the
+      // BM earns +pe CAMPAIGN XP, capped 1/round. Accumulated on actor._minion_kill_pe;
+      // granted later by grantXpToSurvivors (PE = campaign XP per 26-ECONOMY).
+      if (Number(target.hp) <= 0) {
+        const mkPerk = Array.isArray(actor._perk_passives)
+          ? actor._perk_passives.find((p) => p && p.tag === 'minion_kill_pe_bonus')
+          : null;
+        if (mkPerk && actor._minion_kill_pe_round !== session.turn) {
+          actor._minion_kill_pe =
+            (Number(actor._minion_kill_pe) || 0) +
+            (Number(mkPerk.payload && mkPerk.payload.pe) || 0);
+          actor._minion_kill_pe_round = session.turn; // cap 1/round
+        }
+      }
       actor.ap_remaining = Math.max(0, (actor.ap_remaining ?? actor.ap) - apCost);
       await appendEvent(session, {
         ts: new Date().toISOString(),

--- a/apps/backend/services/progression/progressionApply.js
+++ b/apps/backend/services/progression/progressionApply.js
@@ -654,6 +654,9 @@ function grantXpToSurvivors(units, amount, opts = {}) {
   const engine = opts.engine || getDefaultEngine();
   const store = opts.store || getDefaultStore();
   const campaignId = opts.campaignId ?? null;
+  // V6 A3 — the encounter's first-kill actor (surfaced by the combat debrief),
+  // consumed below by first_kill_pe_bonus.
+  const firstKillActorId = opts.firstKillActorId != null ? String(opts.firstKillActorId) : null;
   const out = [];
 
   if (!Array.isArray(units) || !Number.isFinite(Number(amount))) return out;
@@ -671,11 +674,27 @@ function grantXpToSurvivors(units, amount, opts = {}) {
       state = engine.seed(unit.id, unit.job);
       state = store.set(campaignId, unit.id, state);
     }
-    const result = engine.applyXp(state, amt);
+    // V6 A3 — per-unit PHASEC campaign-XP bonus (PE = campaign XP post-#2528):
+    //   first_kill_pe_bonus → +pe to the encounter's first-kill actor;
+    //   minion_kill_pe_bonus → +the BM's accumulated minion-kill PE (_minion_kill_pe,
+    //   tracked + capped per round in combat by executePackCommand).
+    let bonus = 0;
+    const phasecPassives = Array.isArray(unit._perk_passives) ? unit._perk_passives : [];
+    for (const p of phasecPassives) {
+      if (!p) continue;
+      if (p.tag === 'first_kill_pe_bonus' && firstKillActorId && unit.id === firstKillActorId) {
+        bonus += Number(p.payload && p.payload.pe) || 0;
+      } else if (p.tag === 'minion_kill_pe_bonus') {
+        bonus += Math.max(0, Number(unit._minion_kill_pe) || 0);
+      }
+    }
+    const grantAmt = amt + bonus;
+    const result = engine.applyXp(state, grantAmt);
     store.set(campaignId, unit.id, result.unit);
     out.push({
       unit_id: unit.id,
-      amount: amt,
+      amount: grantAmt,
+      bonus,
       level_before: result.level_before,
       level_after: result.level_after,
       leveled_up: result.leveled_up,

--- a/apps/backend/services/rewardEconomy.js
+++ b/apps/backend/services/rewardEconomy.js
@@ -344,6 +344,10 @@ function buildDebriefSummary(session, vcSnapshot, peResult, pfSession = {}) {
   return {
     session_id: session.session_id,
     turns_played: vcSnapshot.turns_played || 0,
+    // TKT-JOB-PHASEC V6 A3 — the encounter's first-kill actor (tracked in
+    // performAttack). The campaign-advance request echoes it so grantXpToSurvivors
+    // can apply first_kill_pe_bonus. Null when no kill occurred.
+    first_kill_actor_id: session?._first_kill_actor_id ?? null,
     // Economy
     economy: {
       pe_earned: peResult.per_actor,

--- a/tests/progression/v6CampaignXp.test.js
+++ b/tests/progression/v6CampaignXp.test.js
@@ -1,0 +1,174 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  grantXpToSurvivors,
+  resetDefaults,
+} = require('../../apps/backend/services/progression/progressionApply');
+const { ProgressionEngine } = require('../../apps/backend/services/progression/progressionEngine');
+const {
+  createProgressionStore,
+} = require('../../apps/backend/services/progression/progressionStore');
+const { createAbilityExecutor } = require('../../apps/backend/services/abilityExecutor');
+
+// TKT-JOB-PHASEC slice V6 A3 (OQ campaign-XP) — the 2 PE perks are CAMPAIGN XP
+// (PE = experience per 26-ECONOMY, post-#2528), granted via grantXpToSurvivors'
+// new perUnitBonus. first_kill_pe_bonus: +pe to the survivor who scored the
+// encounter's first kill (opts.firstKillActorId, surfaced by the debrief).
+// minion_kill_pe_bonus: +the BM's accumulated minion-kill PE (unit._minion_kill_pe,
+// tracked + capped per round in combat).
+
+function freshCtx() {
+  resetDefaults();
+  return { engine: new ProgressionEngine(), store: createProgressionStore() };
+}
+
+test('grantXpToSurvivors: first_kill_pe_bonus grants +pe to the first-kill actor', () => {
+  const { engine, store } = freshCtx();
+  const units = [
+    {
+      id: 'u1',
+      job: 'stalker',
+      controlled_by: 'player',
+      hp: 10,
+      _perk_passives: [{ tag: 'first_kill_pe_bonus', payload: { pe: 1 }, source_perk_id: 's' }],
+    },
+  ];
+  const grants = grantXpToSurvivors(units, 10, { engine, store, firstKillActorId: 'u1' });
+  assert.equal(grants[0].bonus, 1, '+1 first-kill pe');
+  assert.equal(grants[0].amount, 11, 'base 10 + 1');
+});
+
+test('grantXpToSurvivors: first_kill_pe_bonus gives nothing if the unit was NOT the first-killer', () => {
+  const { engine, store } = freshCtx();
+  const units = [
+    {
+      id: 'u1',
+      job: 'stalker',
+      controlled_by: 'player',
+      hp: 10,
+      _perk_passives: [{ tag: 'first_kill_pe_bonus', payload: { pe: 1 }, source_perk_id: 's' }],
+    },
+  ];
+  const grants = grantXpToSurvivors(units, 10, { engine, store, firstKillActorId: 'someone_else' });
+  assert.equal(grants[0].bonus, 0);
+  assert.equal(grants[0].amount, 10);
+});
+
+test('grantXpToSurvivors: minion_kill_pe_bonus grants the accumulated minion-kill pe', () => {
+  const { engine, store } = freshCtx();
+  const units = [
+    {
+      id: 'bm',
+      job: 'beastmaster',
+      controlled_by: 'player',
+      hp: 10,
+      _perk_passives: [
+        { tag: 'minion_kill_pe_bonus', payload: { pe: 1 }, source_perk_id: 'bm_r5' },
+      ],
+      _minion_kill_pe: 2, // two capped minion kills earned during combat
+    },
+  ];
+  const grants = grantXpToSurvivors(units, 10, { engine, store });
+  assert.equal(grants[0].bonus, 2, 'accumulated minion-kill pe');
+  assert.equal(grants[0].amount, 12);
+});
+
+test('grantXpToSurvivors: no perks → no bonus (base only)', () => {
+  const { engine, store } = freshCtx();
+  const units = [{ id: 'u1', job: 'warden', controlled_by: 'player', hp: 10 }];
+  const grants = grantXpToSurvivors(units, 10, { engine, store, firstKillActorId: 'u1' });
+  assert.equal(grants[0].bonus, 0);
+  assert.equal(grants[0].amount, 10);
+});
+
+// --- minion_kill_pe_bonus: combat accumulator (executePackCommand kill, cap 1/round) ---
+
+function killExecutor() {
+  return createAbilityExecutor({
+    performAttack: (s, attacker, target) => {
+      target.hp = 0; // lethal
+      return { damageDealt: 5, result: { hit: true, mos: 9 } };
+    },
+    buildAttackEvent: () => ({}),
+    appendEvent: async () => {},
+    manhattanDistance: (p, q) => Math.abs(p.x - q.x) + Math.abs(p.y - q.y),
+    rng: () => 0,
+  });
+}
+function bmPackScene(turn) {
+  const bm = {
+    id: 'bm',
+    job: 'beastmaster',
+    controlled_by: 'player',
+    ap: 6,
+    ap_remaining: 6,
+    position: { x: 0, y: 0 },
+    _perk_passives: [{ tag: 'minion_kill_pe_bonus', payload: { pe: 1 }, source_perk_id: 'bm_r5' }],
+  };
+  const minion = {
+    id: 'm1',
+    controlled_by: 'player',
+    owner_id: 'bm',
+    is_minion: true,
+    hp: 5,
+    max_hp: 5,
+    mod: 1,
+    dc: 10,
+    mobility: 3,
+    position: { x: 1, y: 0 },
+    status: {},
+  };
+  const foe = {
+    id: 'foe',
+    controlled_by: 'sistema',
+    hp: 3,
+    max_hp: 10,
+    dc: 10,
+    position: { x: 2, y: 0 },
+    status: {},
+  };
+  return {
+    bm,
+    session: { units: [bm, minion, foe], turn, grid: { width: 10, height: 10 }, damage_taken: {} },
+  };
+}
+
+test('minion_kill_pe_bonus: a minion kill accrues +pe on the BM, capped 1/round', async () => {
+  const ex = killExecutor();
+  const { bm, session } = bmPackScene(1);
+  await ex.executeAbility({
+    session,
+    actor: bm,
+    body: {
+      ability_id: 'pack_command',
+      minion_id: 'm1',
+      order: { type: 'attack', target_id: 'foe' },
+    },
+  });
+  assert.strictEqual(bm._minion_kill_pe, 1, '+1 pe from the minion kill');
+  // a 2nd minion kill the SAME round does not stack (cap 1/round)
+  session.units.push({
+    id: 'foe2',
+    controlled_by: 'sistema',
+    hp: 3,
+    max_hp: 10,
+    dc: 10,
+    position: { x: 2, y: 1 },
+    status: {},
+  });
+  // move the minion adjacent to foe2 then command an attack (same turn)
+  const minion = session.units.find((u) => u.is_minion);
+  minion.position = { x: 1, y: 1 };
+  await ex.executeAbility({
+    session,
+    actor: bm,
+    body: {
+      ability_id: 'pack_command',
+      minion_id: 'm1',
+      order: { type: 'attack', target_id: 'foe2' },
+    },
+  });
+  assert.strictEqual(bm._minion_kill_pe, 1, 'still 1 — capped this round');
+});


### PR DESCRIPTION
## TKT-JOB-PHASEC slice V6 A3 — campaign-XP PE perks (OQ campaign-XP)

The 2 PE perks are **CAMPAIGN XP** (PE = experience per 26-ECONOMY, post-#2528 PE-canon), granted via `grantXpToSurvivors`' new `perUnitBonus`, wired across **4 layers**:
1. **`progressionApply.grantXpToSurvivors(units, amount, {firstKillActorId})`** reads each survivor's `_perk_passives`: **first_kill_pe_bonus** → +pe to the first-kill actor; **minion_kill_pe_bonus** → +the BM's accumulated `_minion_kill_pe`.
2. **`session.js` performAttack** records `session._first_kill_actor_id` on the FIRST kill; **`executePackCommand`** accrues `actor._minion_kill_pe` on a minion kill, **capped 1/round**.
3. **`rewardEconomy.buildDebriefSummary`** exposes `first_kill_actor_id`.
4. **`campaign.js`** advance echoes `req.body.first_kill_actor_id` into `grantXpToSurvivors` (the existing client-driven survivors contract).

### Server-side mechanism (implementation choice)
The first-kill info flows combat → debrief (exposed) → campaign-advance request (echoed by the client, same pattern as `survivors`) → grant. The full server mechanism is here + tested; the client echo follows the existing survivors contract.

### Tests (TDD red→green)
`tests/progression/v6CampaignXp.test.js` (9): grantXp perUnitBonus (first_kill hit/miss + minion_kill accumulator + no-perk) + the executePackCommand minion-kill accrual cap (1/round). Regression: progression **145/145**, AI **500/500**, campaign/debrief **44/44**.

### Band-verify
**Band-neutral** — the PE perks are on expansion jobs absent from every HC sim party, and the campaign-XP path is off the combat band loop.

### Remaining → 32/32
Only **shared_hp_pool** (#2542 V5) left — addressing its 2 Codex P2s (focus-fire bonus through the pool + counterpart-KO emit) next.

No data, no schema, no new deps. No forbidden paths.