### PR TITLE
feat(combat): h2 economy sg cost-gate (option c) + pp/pt followup

### DIFF
--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -2427,6 +2427,15 @@ function createAbilityExecutor(deps) {
     // granular, finer than last_action_type). Consumed by computePerkDefenseBonus
     // (defense_after_silent). Set after the AP gate, before dispatch.
     actor._last_ability_id = ability.ability_id;
+    // H2 cost-gate (Codex #2554 P2): SPEND SG before dispatch so the ability's own
+    // damage-earn (sgTracker during the attack) stacks on the REDUCED pool instead of
+    // being dropped at the cap. Rolled back below on a non-2xx result (no charge on
+    // 400/501), mirroring the cost_ap / cost_pe (#2522) model.
+    let sgBefore = null;
+    if (costSg > 0) {
+      sgBefore = Number(actor.sg || 0);
+      actor.sg = sgConsumeAll ? 0 : Math.max(0, sgBefore - costSg);
+    }
     const dispatch = () => {
       switch (ability.effect_type) {
         case 'move_attack':
@@ -2478,14 +2487,17 @@ function createAbilityExecutor(deps) {
       }
     };
     const result = await dispatch();
+    const resolved2xx = result && Number(result.status) >= 200 && Number(result.status) < 300;
+    // H2 cost-gate (Codex #2554 P2): the SG spend ran BEFORE dispatch; roll it back
+    // if the ability did not resolve (no charge on 400/501). On success the spend
+    // stands and the in-dispatch earn already stacked on the reduced pool.
+    if (costSg > 0 && !resolved2xx) {
+      actor.sg = sgBefore;
+    }
     // TKT-JOB-PHASEC slice 4 (Cat F, OQ-F verdict A) — on-ability-use perk
     // effects, fired only on a successful (2xx) resolution. Lazy require mirrors
     // the sgTracker pattern (non-blocking if the module is unavailable).
-    if (result && Number(result.status) >= 200 && Number(result.status) < 300) {
-      // H2 cost-gate: charge SG only on a successful resolution (no charge on 400/501).
-      if (costSg > 0) {
-        actor.sg = sgConsumeAll ? 0 : Math.max(0, Number(actor.sg || 0) - costSg);
-      }
+    if (resolved2xx) {
       try {
         const { applyPerkAbilityUseEffects } = require('./progression/progressionApply');
         applyPerkAbilityUseEffects(actor, ability.ability_id, { round: session.turn });

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -2371,12 +2371,58 @@ function createAbilityExecutor(deps) {
         },
       };
     }
-    // PE-canon re-label (#2527): aberrant_overdrive's combat cost is `cost_sg`
-    // (NOT cost_pe — PE is campaign XP per 26-ECONOMY_CANONICAL). It is currently
-    // DECORATIVE (un-gated), consistent with the other cost_sg/cost_pt/cost_pp
-    // abilities. A real combat-cost gate is a separate economy-alignment follow-up:
-    // cost_sg values across abilities (3..100) are on inconsistent scales vs the
-    // SG pool (POOL_MAX=3), so a naive gate would break surge_aoe (cost_sg 75/100).
+    // H2 economy combat cost-gate (master-dd verdict 2026-06-02 = option C hybrid).
+    // SG is the only MODELED combat pool (sgTracker POOL_MAX, seeded by normaliseUnit
+    // + earned on damage). Gate it here; deduct only on a 2xx dispatch (below),
+    // mirroring the cost_ap-inside-handler / cost_pe (#2522) "no charge on 400" model.
+    //   cost_sg <= POOL_MAX -> numeric gate (require >= cost_sg, deduct cost_sg).
+    //   cost_sg >  POOL_MAX -> consume-all (require FULL pool, drain to 0): the
+    //     inflated value (cataclysm 75 / apocalypse_ray 100 / perfect_mutation 80)
+    //     reads as "ultimate -> drains the gauge" per 26-ECONOMY ("Ultimate = consume
+    //     all"); no data rescale needed. NB cataclysm is rank-2 by label but its
+    //     cost_sg 75 is ultimate-tier -> treated consume-all; set cost_sg <= POOL_MAX
+    //     if master-dd wants it numeric.
+    // PP/PT are NOT modeled pools (PP un-seeded; PT a per-round dice roll) -> their
+    // cost_* stay DECORATIVE pending a pool-model + earn-curve verdict (follow-up
+    // docs/superpowers/specs/2026-06-02-economy-cost-gate-pp-pt-followup.md).
+    // Band-neutral: no sim/scenario party carries a cost_sg ability (HC byte-identical).
+    let sgConsumeAll = false;
+    const costSg = Number(ability.cost_sg || 0);
+    if (costSg > 0) {
+      const sgPoolMax = (() => {
+        try {
+          return Number(require('./combat/sgTracker').POOL_MAX) || 3;
+        } catch {
+          return 3;
+        }
+      })();
+      const sgHave = Number(actor.sg || 0);
+      if (costSg > sgPoolMax) {
+        sgConsumeAll = true;
+        if (sgHave < sgPoolMax) {
+          return {
+            status: 400,
+            body: {
+              error: `SG insufficienti per ultimate (richiede il pool pieno ${sgPoolMax}, disponibili ${sgHave})`,
+              pool: 'sg',
+              cost: sgPoolMax,
+              have: sgHave,
+              consume_all: true,
+            },
+          };
+        }
+      } else if (sgHave < costSg) {
+        return {
+          status: 400,
+          body: {
+            error: `SG insufficienti per ability (richiesti ${costSg}, disponibili ${sgHave})`,
+            pool: 'sg',
+            cost: costSg,
+            have: sgHave,
+          },
+        };
+      }
+    }
     // TKT-JOB-PHASEC slice 2 — track the last ability id used (ability-id
     // granular, finer than last_action_type). Consumed by computePerkDefenseBonus
     // (defense_after_silent). Set after the AP gate, before dispatch.
@@ -2436,6 +2482,10 @@ function createAbilityExecutor(deps) {
     // effects, fired only on a successful (2xx) resolution. Lazy require mirrors
     // the sgTracker pattern (non-blocking if the module is unavailable).
     if (result && Number(result.status) >= 200 && Number(result.status) < 300) {
+      // H2 cost-gate: charge SG only on a successful resolution (no charge on 400/501).
+      if (costSg > 0) {
+        actor.sg = sgConsumeAll ? 0 : Math.max(0, Number(actor.sg || 0) - costSg);
+      }
       try {
         const { applyPerkAbilityUseEffects } = require('./progression/progressionApply');
         applyPerkAbilityUseEffects(actor, ability.ability_id, { round: session.turn });

--- a/docs/planning/2026-06-02-gapc-fase3-4-build-vs-gate.md
+++ b/docs/planning/2026-06-02-gapc-fase3-4-build-vs-gate.md
@@ -23,8 +23,9 @@ tags:
 # GAP-C fase-3/4 build-vs-gate — decisione H1
 
 > Deliverable gated del GOAL design-closure (§7.2, H1). La **decisione** (build-or-gate) e' Fase-1;
-> l'eventuale **build** e' Fase-2. Verdetto proposto = **GATE (POST-MVP)**, Claude-proposed pending
-> master-dd review. Le alternative sono preservate sotto + museum card M-2026-06-02-001.
+> l'eventuale **build** e' Fase-2. Verdetto = **GATE (POST-MVP)** RATIFICATO master-dd 2026-06-02
+> (build greenlit per una sessione dedicata futura, quando si attiva il flag). Alternative preservate
+> sotto + museum card M-2026-06-02-001.
 
 ## Stato verificato (verify-first 2026-06-02)
 

--- a/docs/superpowers/specs/2026-06-02-economy-cost-gate-pp-pt-followup.md
+++ b/docs/superpowers/specs/2026-06-02-economy-cost-gate-pp-pt-followup.md
@@ -1,0 +1,75 @@
+---
+title: 'Economy cost-gate follow-up — PP/PT pool model (H2 residuo)'
+date: 2026-06-02
+workstream: combat
+category: spec
+doc_status: review_needed
+doc_owner: master-dd
+language: it
+tags: [economy, cost-gate, pp-pool, pt-pool, phasec, pending-design, balance]
+---
+
+# Economy cost-gate follow-up — PP/PT pool model
+
+> Follow-up del verdetto master-dd 2026-06-02 su H2 (`= option C hybrid`). Lo **SG
+> cost-gate e' SHIPPED** (vedi sotto); **PP/PT restano decorativi** perche' gatearli
+> richiede prima di costruire un pool-model + earn-curve = leve di **balance** che,
+> essendo band-neutral (nessuna sim usa queste ability), **non sono validabili via
+> band-verify** -> verdetto numerico master-dd. Estende la spec `2026-06-01-phasec-economy-cost-gate.md`.
+
+## Stato (questo PR) -- SG cost-gate SHIPPED
+
+Implementato in `abilityExecutor.executeAbility` (option C, master-dd 2026-06-02):
+
+- `cost_sg <= POOL_MAX (3)` -> **gate numerico**: richiede `actor.sg >= cost_sg`, deduce `cost_sg` sul 2xx.
+- `cost_sg > POOL_MAX` -> **consume-all**: richiede pool PIENO (3), drena a 0 sul 2xx. Il valore gonfiato
+  (cataclysm 75 / arcane_lance 40 / apocalypse_ray 100 / stabilized_mutation 5 / perfect_mutation 80)
+  legge come "ultimate -> scarica il gauge" (26-ECONOMY "Ultimate = consume all"). **NESSUN rescale dati.**
+- Deduct SOLO sul 2xx (nessun addebito su 400/501), come il modello `cost_ap`/`cost_pe` (#2522).
+- SG e' l'unico pool MODELLATO: `normaliseUnit` lo seeda (`sessionHelpers.js:114`), `sgTracker` lo guadagna
+  (+1/5 dmg taken, +1/8 dmg dealt, cap 3) + `initial_sg` lo seeda nei test/save-load (`session.js:1936`).
+- **Band-neutral**: nessuna party sim/scenario porta una ability `cost_sg` -> HC06/HC07 byte-identici.
+  Regressione: progression+abilityExecutor+jobs 224/224, AI 500/500. Test: `tests/progression/abilityCostGate.test.js`.
+- ⚠️ **NB cataclysm** e' `rank: 2` per label ma `cost_sg: 75` (ultimate-tier) -> trattato consume-all dal
+  cost-threshold. Se master-dd lo vuole numerico, set `cost_sg <= 3` nel dato.
+
+## Residuo gated -- PP/PT (verdetto numerico master-dd)
+
+### Perche' NON e' stato gatato ora
+
+- **PP**: NON e' un pool seeded. `normaliseUnit` non scrive `pp` (compare solo come `u.pp || 0` in alcune
+  serializzazioni). Tutti i `cost_pp` (4..12) eccedono il cap 3. Gatearlo richiede: (1) seed `pp` in
+  `normaliseUnit` (mirror `sg`), (2) **earn/reset curve** (es. +1 crit / +1 kill, cap 3, reset per-encounter).
+- **PT**: NON e' un pool spendibile. PT e' un **roll per-round** (`sessionHelpers.js:248-252`: die 15-19 +1,
+  20 +2, +floor(MoS/5)) consumato come tactical-points, non un gauge accumulato. Tutti i `cost_pt` (3..10)
+  sono <= cap 12 (gia coerenti!) ma non c'e' un pool persistito da spendere. Gatearlo richiede un modello
+  PT-spendibile (per-round, cap 12) + come PT roll alimenta lo spend.
+
+Entrambe le **earn-curve** sono leve di balance che determinano la frequenza degli ultimate -- e
+**band-neutral** (le ability non sono in nessuna sim) quindi **non validabili** via HC06/HC07. Shippare
+una curva indovinata = leva di balance non verificata -> per policy no-anticipated-judgment = verdetto master-dd.
+
+### Proposta (Claude-proposed, pending master-dd review)
+
+| Pool | Modello proposto                                                                  | Earn proposto                                 | Gate (option C)                          |
+| ---- | --------------------------------------------------------------------------------- | --------------------------------------------- | ---------------------------------------- |
+| PP   | seed `pp` in normaliseUnit (default 0, cap 3), per-encounter (no reset per-round) | +1 su crit, +1 su kill (cap 3)                | tutti i cost_pp > 3 -> consume-all       |
+| PT   | pool spendibile per-round (cap 12), alimentato dal PT roll esistente              | += PT roll a inizio turno, reset a fine turno | cost_pt <= 12 -> numerico (gia coerenti) |
+
+Note: i `cost_pp` (4..12) sotto consume-all NON richiedono rescale (come SG). I `cost_pt` (3..10) sono
+gia <= cap 12 -> gate numerico esatto, nessun rescale. Resta da decidere SE PT vada gatato (oggi e' un
+roll tattico, non un gauge "speso").
+
+### Verdetto richiesto
+
+1. **PP**: approvo seed+earn (+1 crit/+1 kill cap 3)? altra curva? oppure PP resta decorativo?
+2. **PT**: PT diventa un pool spendibile (earn da roll) o resta roll-tattico decorativo?
+
+Post-verdetto: impl = mirror dello SG-gate (gate + deduct 2xx) + seed/earn nel pool model + test +
+band-neutral proof (grep). Reversibile.
+
+## Riferimenti
+
+- Verdetto: chat master-dd 2026-06-02 ("H2 = C"). Spec base: `2026-06-01-phasec-economy-cost-gate.md` (#2530-A2).
+- Report design-closure: `docs/reports/2026-06-02-design-closure.md` §H2.
+- Impl SG: `apps/backend/services/abilityExecutor.js` (executeAbility gate + 2xx deduct).

--- a/tests/api/abilityExecutor.test.js
+++ b/tests/api/abilityExecutor.test.js
@@ -28,6 +28,18 @@ async function startSession(app) {
   return { sid: startRes.body.session_id, state: startRes.body.state };
 }
 
+// H2 cost-gate (2026-06-02): surge_aoe ultimates (cataclysm/apocalypse_ray) carry
+// cost_sg > POOL_MAX -> consume-all gate requires a FULL SG pool. Seed p_scout sg=3.
+async function startSessionSgFull(app) {
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  assert.equal(scenario.status, 200);
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units, initial_sg: { p_scout: 3 } });
+  assert.equal(startRes.status, 200);
+  return { sid: startRes.body.session_id, state: startRes.body.state };
+}
+
 test('dash_strike: move_attack end-to-end, AP decremented, event emitted', async (t) => {
   const { app, close } = createApp({ databasePath: null });
   t.after(async () => {
@@ -549,7 +561,7 @@ test('cataclysm: surge_aoe danno area + stress_reset, shield-aware', async (t) =
     if (typeof close === 'function') await close().catch(() => {});
   });
 
-  const { sid } = await startSession(app);
+  const { sid } = await startSessionSgFull(app);
   const res = await request(app)
     .post('/api/session/action')
     .send({
@@ -582,7 +594,9 @@ test('cataclysm surge_aoe: actor elevation 1 vs target 0 → multiplier 1.3 ripo
   // Usa scenario tutorial_01 ma muta units con elevation raise per p_scout.
   const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
   const units = scenario.body.units.map((u) => (u.id === 'p_scout' ? { ...u, elevation: 1 } : u));
-  const startRes = await request(app).post('/api/session/start').send({ units });
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({ units, initial_sg: { p_scout: 3 } });
   const sid = startRes.body.session_id;
   const res = await request(app)
     .post('/api/session/action')
@@ -1323,7 +1337,7 @@ test('Sprint 8.1 apocalypse_ray (r4 surge_aoe): dispatch via invoker path + stre
     if (typeof close === 'function') await close().catch(() => {});
   });
 
-  const { sid } = await startSession(app);
+  const { sid } = await startSessionSgFull(app);
   const res = await request(app)
     .post('/api/session/action')
     .send({

--- a/tests/progression/abilityCostGate.test.js
+++ b/tests/progression/abilityCostGate.test.js
@@ -1,0 +1,165 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const {
+  createAbilityExecutor,
+  _setAbilityForTest,
+  _resetAbilityIndex,
+} = require('../../apps/backend/services/abilityExecutor');
+
+// H2 economy combat cost-gate (master-dd verdict 2026-06-02 = option C hybrid).
+// SG is the only MODELED combat pool (sgTracker POOL_MAX=3, seeded by normaliseUnit
+// + earned on damage). Gate semantics:
+//   cost_sg <= POOL_MAX -> numeric gate (require >= cost, deduct cost on 2xx).
+//   cost_sg >  POOL_MAX -> consume-all (require FULL pool, drain to 0 on 2xx).
+// PP/PT pools are NOT modeled -> their cost_* stay decorative (follow-up spec).
+// Deduct only on a 2xx dispatch (no charge on a 400/501 handler result).
+
+function mkExecutor() {
+  return createAbilityExecutor({
+    performAttack: () => ({ damageDealt: 0, result: { hit: false } }),
+    buildAttackEvent: () => ({}),
+    appendEvent: async () => {},
+    manhattanDistance: (a, b) => Math.abs(a.x - b.x) + Math.abs(a.y - b.y),
+  });
+}
+
+function mkActor(sg) {
+  return {
+    id: 'ab',
+    job: 'aberrant',
+    ap_remaining: 5,
+    sg,
+    position: { x: 0, y: 0 },
+    attack_range: 5,
+  };
+}
+
+function call(ex, actor, body, extraUnits = []) {
+  return ex.executeAbility({
+    session: { units: [actor, ...extraUnits], turn: 1, damage_taken: {} },
+    actor,
+    body,
+  });
+}
+
+test.before(() => {
+  // controlled buff abilities (effect_type 'buff' resolves 2xx with stub deps)
+  _setAbilityForTest('test_sg_numeric', {
+    ability_id: 'test_sg_numeric',
+    effect_type: 'buff',
+    cost_ap: 0,
+    cost_sg: 2,
+    buff_stat: 'defense_mod',
+    buff_amount: 1,
+    duration: 1,
+  });
+  _setAbilityForTest('test_sg_consume', {
+    ability_id: 'test_sg_consume',
+    effect_type: 'buff',
+    cost_ap: 0,
+    cost_sg: 80,
+    buff_stat: 'defense_mod',
+    buff_amount: 1,
+    duration: 1,
+  });
+  _setAbilityForTest('test_no_sg', {
+    ability_id: 'test_no_sg',
+    effect_type: 'buff',
+    cost_ap: 0,
+    buff_stat: 'defense_mod',
+    buff_amount: 1,
+    duration: 1,
+  });
+});
+
+test.after(() => {
+  _resetAbilityIndex();
+});
+
+test('SG numeric gate: cost_sg=2 with sg=1 -> 400 blocked, sg unchanged', async () => {
+  const actor = mkActor(1);
+  const res = await call(mkExecutor(), actor, { ability_id: 'test_sg_numeric' });
+  assert.strictEqual(res.status, 400, JSON.stringify(res.body));
+  assert.strictEqual(res.body.pool, 'sg');
+  assert.strictEqual(actor.sg, 1, 'sg unchanged on block');
+});
+
+test('SG numeric gate: cost_sg=2 with sg=2 -> 200, sg deducted to 0', async () => {
+  const actor = mkActor(2);
+  const res = await call(mkExecutor(), actor, { ability_id: 'test_sg_numeric' });
+  assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+  assert.strictEqual(actor.sg, 0, 'sg deducted by cost 2');
+});
+
+test('SG numeric gate: cost_sg=2 with sg=3 -> 200, sg deducted to 1', async () => {
+  const actor = mkActor(3);
+  const res = await call(mkExecutor(), actor, { ability_id: 'test_sg_numeric' });
+  assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+  assert.strictEqual(actor.sg, 1, 'sg 3 - cost 2 = 1');
+});
+
+test('SG consume-all: cost_sg=80 (>POOL_MAX) with sg=2 -> 400 (needs full pool)', async () => {
+  const actor = mkActor(2);
+  const res = await call(mkExecutor(), actor, { ability_id: 'test_sg_consume' });
+  assert.strictEqual(res.status, 400, JSON.stringify(res.body));
+  assert.strictEqual(res.body.consume_all, true);
+  assert.strictEqual(actor.sg, 2, 'sg unchanged on block');
+});
+
+test('SG consume-all: cost_sg=80 with sg=3 (full) -> 200, sg drained to 0', async () => {
+  const actor = mkActor(3);
+  const res = await call(mkExecutor(), actor, { ability_id: 'test_sg_consume' });
+  assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+  assert.strictEqual(actor.sg, 0, 'consume-all drains the pool');
+});
+
+test('no cost_sg: ability unaffected by the SG gate (sg untouched)', async () => {
+  const actor = mkActor(1);
+  const res = await call(mkExecutor(), actor, { ability_id: 'test_no_sg' });
+  assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+  assert.strictEqual(actor.sg, 1, 'sg untouched when ability has no cost_sg');
+});
+
+test('real aberrant_overdrive (cost_sg=3): sg=3 -> 200 + drained; sg=2 -> 400', async () => {
+  const target = { id: 'foe', hp: 10, max_hp: 10, position: { x: 1, y: 0 } };
+  const ok = mkActor(3);
+  const okRes = await call(
+    mkExecutor(),
+    ok,
+    { ability_id: 'aberrant_overdrive', target_id: 'foe' },
+    [target],
+  );
+  assert.strictEqual(okRes.status, 200, JSON.stringify(okRes.body));
+  assert.strictEqual(ok.sg, 0, 'cost_sg 3 (=POOL_MAX) numeric deducts to 0');
+
+  const low = mkActor(2);
+  const lowRes = await call(
+    mkExecutor(),
+    low,
+    { ability_id: 'aberrant_overdrive', target_id: 'foe' },
+    [target],
+  );
+  assert.strictEqual(lowRes.status, 400, JSON.stringify(lowRes.body));
+  assert.strictEqual(low.sg, 2, 'sg unchanged on block');
+});
+
+test('SG NOT charged when the dispatch fails (no charge on non-2xx)', async () => {
+  // execution_attack at a missing target -> handler returns non-2xx; SG must not charge.
+  _setAbilityForTest('test_sg_attack', {
+    ability_id: 'test_sg_attack',
+    effect_type: 'execution_attack',
+    cost_ap: 0,
+    cost_sg: 2,
+    damage_dice: '1d6',
+  });
+  const actor = mkActor(2);
+  const res = await call(mkExecutor(), actor, {
+    ability_id: 'test_sg_attack',
+    target_id: 'does_not_exist',
+  });
+  assert.ok(res.status >= 400, `expected a failure status, got ${res.status}`);
+  assert.strictEqual(actor.sg, 2, 'sg NOT charged on a failed dispatch');
+});

--- a/tests/progression/abilityCostGate.test.js
+++ b/tests/progression/abilityCostGate.test.js
@@ -163,3 +163,34 @@ test('SG NOT charged when the dispatch fails (no charge on non-2xx)', async () =
   assert.ok(res.status >= 400, `expected a failure status, got ${res.status}`);
   assert.strictEqual(actor.sg, 2, 'sg NOT charged on a failed dispatch');
 });
+
+test('SG spent BEFORE the ability damage-earn (Codex #2554 P2: cap does not eat the earn)', async () => {
+  // actor at cap (sg=3), numeric cost 2, attack deals heavy damage -> sgTracker earns.
+  // spend-first: 3 - 2 = 1, then the in-dispatch earn stacks on the reduced pool (-> >1).
+  // The buggy "capped-earn-then-deduct" order would drop the earn and leave sg=1.
+  _setAbilityForTest('test_sg_attack_earn', {
+    ability_id: 'test_sg_attack_earn',
+    effect_type: 'execution_attack',
+    cost_ap: 0,
+    cost_sg: 2,
+    damage_dice: '1d6',
+  });
+  const ex = createAbilityExecutor({
+    performAttack: () => ({ damageDealt: 40, result: { hit: true } }),
+    buildAttackEvent: () => ({}),
+    appendEvent: async () => {},
+    manhattanDistance: (a, b) => Math.abs(a.x - b.x) + Math.abs(a.y - b.y),
+  });
+  const actor = mkActor(3);
+  const target = { id: 'foe', hp: 99, max_hp: 99, position: { x: 1, y: 0 } };
+  const res = await ex.executeAbility({
+    session: { units: [actor, target], turn: 1, damage_taken: {} },
+    actor,
+    body: { ability_id: 'test_sg_attack_earn', target_id: 'foe' },
+  });
+  assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+  assert.ok(
+    actor.sg > 1,
+    `spend-before-earn keeps the earn (sg=${actor.sg} > 1); buggy order leaves 1`,
+  );
+});

--- a/tests/progression/peCanonRelabel.test.js
+++ b/tests/progression/peCanonRelabel.test.js
@@ -51,7 +51,7 @@ test('executeAbility: aberrant_overdrive resolves without mutating unit.pe (cost
     job: 'aberrant',
     ap_remaining: 5,
     pe: 10, // campaign XP
-    sg: 0,
+    sg: 3, // H2 cost-gate (2026-06-02): aberrant_overdrive cost_sg=3 needs a full SG pool
     position: { x: 0, y: 0 },
     attack_range: 5,
   };


### PR DESCRIPTION
## H2 economy combat cost-gate (master-dd verdict 2026-06-02 = option C hybrid)

Chiude H2 dal design-closure goal. Master-dd ha scelto **C (hybrid)**: rank basse numeriche, ultimate consume-all.

### Cosa fa (SG cost-gate, in `executeAbility`)
Prima i `cost_sg/pp/pt` erano **decorativi** (solo `cost_ap` gated). Ora **SG e' gatato** (unico pool modellato: `normaliseUnit` seed + `sgTracker` earn):
- `cost_sg <= POOL_MAX (3)` -> **gate numerico** (richiede >= cost, deduce cost sul 2xx).
- `cost_sg > POOL_MAX` -> **consume-all** (richiede pool pieno, drena a 0). Il valore gonfiato (cataclysm 75 / arcane_lance 40 / apocalypse_ray 100 / stabilized 5 / perfect_mutation 80) = "ultimate -> scarica il gauge" (26-ECONOMY). **Nessun rescale dati.**
- Deduct SOLO sul 2xx (nessun addebito su 400/501), come `cost_ap`/`cost_pe` (#2522).

### PP/PT deferiti (gated, followup spec)
PP (non-seeded) e PT (roll per-round, non gauge spendibile) richiedono un **pool-model + earn-curve** = leve di **balance** non validabili (band-neutral). Per no-anticipated-judgment -> verdetto numerico master-dd. Proposta + 2 domande in `docs/superpowers/specs/2026-06-02-economy-cost-gate-pp-pt-followup.md`.

### H1 ratificato
GAP-C fase-3/4 = **GATE/POST-MVP** ratificato (build greenlit per sessione futura). Doc aggiornato.

### Evidence
- TDD red->green: `tests/progression/abilityCostGate.test.js` 8/8 (numeric/consume-all/no-charge-on-400).
- Regressione: progression+abilityExecutor+jobs **224/224**, AI **500/500**.
- **Band-neutral**: nessuna party sim/scenario porta una ability `cost_sg` (grep) -> HC06/HC07 byte-identici. 4 test aggiornati (peCanonRelabel + 3 surge_aoe) ora seedano SG via `initial_sg` (le ultimate ora richiedono il pool).
- `prettier --check` clean, `check_docs_governance --strict` errors=0.

### Cognitive protocols
- **verify-first** (P1): census costi su main current + traccia pool reale (SG modellato, PP/PT no) prima di costruire; band-neutrality provata via grep + AI 500.
- **no-anticipated-judgment**: SG buildato (no balance-guess: consume-all evita il rescale); PP/PT earn-curve = leve balance -> proposta pending master-dd, non guess-shipped.
- harsh-reviewer/brainstorming: non invocati (slice singola, gate meccanico testato).

### Collision
Worktree isolato off origin/main `229ecb85`; mai il main checkout. Nessun file conteso con altri PR aperti.

NB cataclysm = rank-2 ma cost_sg:75 (ultimate-tier) -> trattato consume-all dal cost-threshold; set cost_sg<=3 se master-dd lo vuole numerico.