### PR TITLE
feat(combat): h2 pp cost-gate (consume-all) + canon crit/kill earn

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -1023,6 +1023,15 @@ function createSessionRouter(options = {}) {
           /* symbiont bond optional; never break the hit */
         }
       }
+      // H2 PP earn (26-ECONOMY: +1 PP on crit): the attacker banks PP on any critical
+      // hit, regardless of whether the target survives. Best-effort, non-blocking.
+      if (result.is_critical) {
+        try {
+          require('../services/combat/ppTracker').earnCrit(actor);
+        } catch {
+          /* ppTracker optional */
+        }
+      }
       // TKT-ORPHAN-MORALE (SPRINT_013 successor): a critical hit (MoS >=
       // CRIT_MOS_THRESHOLD, surfaced as result.is_critical) on a SURVIVING target
       // routes through the morale module (enemy_critical_hit) instead of the old
@@ -1143,6 +1152,12 @@ function createSessionRouter(options = {}) {
     // traverses. No-op when actor carries no kill perks.
     if (killOccurred) {
       applyPerkKillEffects(actor);
+      // H2 PP earn (26-ECONOMY: +1 PP on kill): the killer banks PP on the final kill.
+      try {
+        require('../services/combat/ppTracker').earnKill(actor);
+      } catch {
+        /* ppTracker optional */
+      }
       // TKT-JOB-PHASEC V6 A3 — record the encounter's FIRST kill actor (once).
       // Surfaced by the debrief + consumed by grantXpToSurvivors' first_kill_pe_bonus.
       if (session._first_kill_actor_id == null) {
@@ -1951,6 +1966,21 @@ function createSessionRouter(options = {}) {
         }
       } catch {
         /* sgTracker optional */
+      }
+      // PP (Power Pool) seed: `req.body.initial_pp = { unit_id: pool }` for save-load
+      // + integration tests (mirror initial_sg). No tutorial default (PP is EARNED
+      // +1 crit / +1 kill via ppTracker, not gifted). Clamp 0..3 (POOL_MAX).
+      try {
+        const initialPp = req.body?.initial_pp;
+        if (initialPp && typeof initialPp === 'object') {
+          for (const [uid, pool] of Object.entries(initialPp)) {
+            const unit = (session.units || []).find((u) => u && u.id === uid);
+            if (!unit) continue;
+            unit.pp = Math.max(0, Math.min(3, Math.floor(Number(pool) || 0)));
+          }
+        }
+      } catch {
+        /* pp seed optional */
       }
       // TKT-ORPHAN-WOUNDPERMA: re-apply persistent wounds carried by this
       // campaign (cross-encounter scar). initSessionMap on first sight; the read

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -2423,6 +2423,47 @@ function createAbilityExecutor(deps) {
         };
       }
     }
+    // H2 PP cost-gate (26-ECONOMY: "Ultimate = 3 PP consume all"). PP is per-encounter
+    // (0..3), earned +1 crit / +1 kill (ppTracker, wired in session.js performAttack).
+    // Every cost_pp in the catalog (4..12) exceeds POOL_MAX -> consume-all; the <=max
+    // numeric branch is kept for future-proofing. Spend before dispatch + rollback below.
+    let ppConsumeAll = false;
+    const costPp = Number(ability.cost_pp || 0);
+    if (costPp > 0) {
+      const ppPoolMax = (() => {
+        try {
+          return Number(require('./combat/ppTracker').POOL_MAX) || 3;
+        } catch {
+          return 3;
+        }
+      })();
+      const ppHave = Number(actor.pp || 0);
+      if (costPp > ppPoolMax) {
+        ppConsumeAll = true;
+        if (ppHave < ppPoolMax) {
+          return {
+            status: 400,
+            body: {
+              error: `PP insufficienti per ultimate (richiede il pool pieno ${ppPoolMax}, disponibili ${ppHave})`,
+              pool: 'pp',
+              cost: ppPoolMax,
+              have: ppHave,
+              consume_all: true,
+            },
+          };
+        }
+      } else if (ppHave < costPp) {
+        return {
+          status: 400,
+          body: {
+            error: `PP insufficienti per ability (richiesti ${costPp}, disponibili ${ppHave})`,
+            pool: 'pp',
+            cost: costPp,
+            have: ppHave,
+          },
+        };
+      }
+    }
     // TKT-JOB-PHASEC slice 2 — track the last ability id used (ability-id
     // granular, finer than last_action_type). Consumed by computePerkDefenseBonus
     // (defense_after_silent). Set after the AP gate, before dispatch.
@@ -2435,6 +2476,11 @@ function createAbilityExecutor(deps) {
     if (costSg > 0) {
       sgBefore = Number(actor.sg || 0);
       actor.sg = sgConsumeAll ? 0 : Math.max(0, sgBefore - costSg);
+    }
+    let ppBefore = null;
+    if (costPp > 0) {
+      ppBefore = Number(actor.pp || 0);
+      actor.pp = ppConsumeAll ? 0 : Math.max(0, ppBefore - costPp);
     }
     const dispatch = () => {
       switch (ability.effect_type) {
@@ -2493,6 +2539,9 @@ function createAbilityExecutor(deps) {
     // stands and the in-dispatch earn already stacked on the reduced pool.
     if (costSg > 0 && !resolved2xx) {
       actor.sg = sgBefore;
+    }
+    if (costPp > 0 && !resolved2xx) {
+      actor.pp = ppBefore;
     }
     // TKT-JOB-PHASEC slice 4 (Cat F, OQ-F verdict A) — on-ability-use perk
     // effects, fired only on a successful (2xx) resolution. Lazy require mirrors

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -1832,8 +1832,18 @@ function createAbilityExecutor(deps) {
         applySelfBuff(ally, buffStat, amount, duration);
         entry.buff = { stat: buffStat, amount, duration };
       }
-      if (ppGrant > 0) {
-        ally.pp = (Number(ally.pp) || 0) + ppGrant;
+      // H2 cost-gate (Codex #2555 P2): a cost_pp support ultimate must NOT refill its
+      // OWN caster via pp_grant (it just consume-all-spent the pool) -> grant only to
+      // OTHER allies. Clamp to POOL_MAX so a grant never overfills the 0..3 pool.
+      if (ppGrant > 0 && ally.id !== actor.id) {
+        const ppMax = (() => {
+          try {
+            return Number(require('./combat/ppTracker').POOL_MAX) || 3;
+          } catch {
+            return 3;
+          }
+        })();
+        ally.pp = Math.min(ppMax, (Number(ally.pp) || 0) + ppGrant);
         entry.pp_grant = ppGrant;
       }
       applied.push(entry);

--- a/apps/backend/services/combat/ppTracker.js
+++ b/apps/backend/services/combat/ppTracker.js
@@ -1,0 +1,36 @@
+// PP (Power Pool) tracker — combat resource, per-encounter.
+//
+// Canon: 26-ECONOMY_CANONICAL.md §PP (P0 Q54 default A):
+//   - Pool 0..3 (POOL_MAX), reset per-encounter.
+//   - Earn: +1 on crit, +1 on kill.
+//   - Spend: Ultimate = 3 PP consume all (gated in abilityExecutor.executeAbility).
+//
+// This mirrors the sgTracker pattern: a tiny pure module so the earn paths in
+// session.js performAttack stay unit-testable. Earning is band-neutral (no sim
+// party casts a cost_pp ability, and the AI does not key decisions off pp), so
+// accumulating PP in sim runs changes no outcome.
+
+'use strict';
+
+const POOL_MAX = 3;
+
+// Clamp-add `amount` PP to a unit, capped at POOL_MAX. Returns the actual gain.
+function earn(unit, amount) {
+  if (!unit || !(Number(amount) > 0)) return 0;
+  const before = Number(unit.pp) || 0;
+  const after = Math.min(POOL_MAX, before + Number(amount));
+  unit.pp = after;
+  return after - before;
+}
+
+// +1 PP on a kill (canon). Returns the actual gain (0 if already at cap).
+function earnKill(unit) {
+  return earn(unit, 1);
+}
+
+// +1 PP on a critical hit (canon). Returns the actual gain (0 if already at cap).
+function earnCrit(unit) {
+  return earn(unit, 1);
+}
+
+module.exports = { POOL_MAX, earn, earnKill, earnCrit };

--- a/docs/superpowers/specs/2026-06-02-economy-cost-gate-pp-pt-followup.md
+++ b/docs/superpowers/specs/2026-06-02-economy-cost-gate-pp-pt-followup.md
@@ -17,6 +17,16 @@ tags: [economy, cost-gate, pp-pool, pt-pool, phasec, pending-design, balance]
 > essendo band-neutral (nessuna sim usa queste ability), **non sono validabili via
 > band-verify** -> verdetto numerico master-dd. Estende la spec `2026-06-01-phasec-economy-cost-gate.md`.
 
+> **UPDATE 2026-06-02 (master-dd ha accordato autonomia di scelta su evidenza): PP cost-gate SHIPPED.**
+> Il SoT `26-ECONOMY` GIA fissa l'earn PP (+1 crit, +1 kill) e "Ultimate = 3 PP consume all" -> NON era
+> un verdetto balance ma canon-compliance. Wired: `ppTracker` (POOL_MAX 3) + earn in `session.js`
+> performAttack (crit/kill) + gate consume-all in `executeAbility` (tutti i cost_pp 4-12 > 3 ->
+> consume-all, NO rescale) + `initial_pp` seed (mirror initial_sg). Band-neutral (AI non decide su pp;
+> ability assenti dalle sim) -> AI 500/500. **Solo PT resta deferito** (pool spendibile NON wired +
+> costi gia coerenti <=12 + ruolo canonico = manovre, non ancora costruite). NOTA: i cost_pp rank-2
+> (blade_flurry 6 / resonance 4 / kill_shot 6 / deathmark 4) sono consume-all per cost-threshold; set
+> `cost_pp <= 3` per-ability se master-dd li vuole numerici (reversibile, come cataclysm).
+
 ## Stato (questo PR) -- SG cost-gate SHIPPED
 
 Implementato in `abilityExecutor.executeAbility` (option C, master-dd 2026-06-02):

--- a/tests/api/abilityExecutor.test.js
+++ b/tests/api/abilityExecutor.test.js
@@ -40,6 +40,19 @@ async function startSessionSgFull(app) {
   return { sid: startRes.body.session_id, state: startRes.body.state };
 }
 
+// H2 PP cost-gate (2026-06-02): every cost_pp (4..12) > POOL_MAX(3) -> consume-all
+// gate requires a FULL PP pool. Seed p_scout pp=3 (ally pools stay 0 so pp_grant
+// abilities still observably grant).
+async function startSessionPp(app) {
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  assert.equal(scenario.status, 200);
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units, initial_pp: { p_scout: 3 } });
+  assert.equal(startRes.status, 200);
+  return { sid: startRes.body.session_id, state: startRes.body.state };
+}
+
 test('dash_strike: move_attack end-to-end, AP decremented, event emitted', async (t) => {
   const { app, close } = createApp({ databasePath: null });
   t.after(async () => {
@@ -229,7 +242,7 @@ test('blade_flurry: multi_attack esegue fino a attack_count hit', async (t) => {
     if (typeof close === 'function') await close().catch(() => {});
   });
 
-  const { sid } = await startSession(app);
+  const { sid } = await startSessionPp(app);
   const res = await request(app).post('/api/session/action').send({
     session_id: sid,
     action_type: 'ability',
@@ -354,7 +367,7 @@ test('kill_shot: execution_attack non triggera execute se target HP piena', asyn
     if (typeof close === 'function') await close().catch(() => {});
   });
 
-  const { sid } = await startSession(app);
+  const { sid } = await startSessionPp(app);
   const res = await request(app).post('/api/session/action').send({
     session_id: sid,
     action_type: 'ability',
@@ -468,7 +481,7 @@ test('resonance_amplifier: team_buff applica pp_grant a tutti gli alleati in ran
     if (typeof close === 'function') await close().catch(() => {});
   });
 
-  const { sid } = await startSession(app);
+  const { sid } = await startSessionPp(app);
   // p_scout (1,2), p_tank (1,3) → distanza 1, range 3 da spec → entrambi affetti.
   const res = await request(app).post('/api/session/action').send({
     session_id: sid,
@@ -1294,7 +1307,7 @@ test('Sprint 8.1 dervish_whirlwind (r4 multi_attack): dispatch via skirmisher pa
     if (typeof close === 'function') await close().catch(() => {});
   });
 
-  const { sid } = await startSession(app);
+  const { sid } = await startSessionPp(app);
   const res = await request(app).post('/api/session/action').send({
     session_id: sid,
     action_type: 'ability',
@@ -1315,7 +1328,7 @@ test('Sprint 8.1 headshot (r4 execution_attack): dispatch via ranger path + exec
     if (typeof close === 'function') await close().catch(() => {});
   });
 
-  const { sid } = await startSession(app);
+  const { sid } = await startSessionPp(app);
   const res = await request(app).post('/api/session/action').send({
     session_id: sid,
     action_type: 'ability',
@@ -1383,7 +1396,7 @@ test('Sprint 8.1 shadow_assassinate (Stalker r4 expansion execution_attack): dis
     if (typeof close === 'function') await close().catch(() => {});
   });
 
-  const { sid } = await startSession(app);
+  const { sid } = await startSessionPp(app);
   const res = await request(app).post('/api/session/action').send({
     session_id: sid,
     action_type: 'ability',
@@ -1407,7 +1420,7 @@ test('Sprint 8 phantom_step (r3 move_attack): dispatch end-to-end via existing e
     if (typeof close === 'function') await close().catch(() => {});
   });
 
-  const { sid, state } = await startSession(app);
+  const { sid, state } = await startSessionPp(app);
   const scout = state.units.find((u) => u.id === 'p_scout');
   assert.ok(scout, 'scout presente nel tutorial_01');
 

--- a/tests/api/abilityExecutor.test.js
+++ b/tests/api/abilityExecutor.test.js
@@ -493,10 +493,15 @@ test('resonance_amplifier: team_buff applica pp_grant a tutti gli alleati in ran
   assert.equal(res.body.effect_type, 'team_buff');
   assert.ok(Array.isArray(res.body.allies_affected));
   assert.ok(res.body.allies_affected.length >= 2, '>=2 allies (scout+tank)');
-  // Verifica pp_grant applicato a ciascuno
-  for (const a of res.body.allies_affected) {
+  // Codex #2555 P2: the caster (p_scout) consume-all-spent its PP to cast, so it must
+  // NOT refill itself via its own pp_grant -> only OTHER allies receive pp_grant.
+  const casterEntry = res.body.allies_affected.find((a) => a.unit_id === 'p_scout');
+  const otherEntries = res.body.allies_affected.filter((a) => a.unit_id !== 'p_scout');
+  assert.ok(otherEntries.length >= 1, '>=1 non-caster ally (tank)');
+  for (const a of otherEntries) {
     assert.equal(a.pp_grant, 2);
   }
+  assert.ok(!casterEntry || casterEntry.pp_grant === undefined, 'caster does NOT self-grant pp');
 });
 
 test('symbiotic_bloom: team_heal cura tutti gli alleati in range', async (t) => {

--- a/tests/progression/ppCostGate.test.js
+++ b/tests/progression/ppCostGate.test.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const {
+  createAbilityExecutor,
+  _setAbilityForTest,
+  _resetAbilityIndex,
+} = require('../../apps/backend/services/abilityExecutor');
+
+// H2 PP cost-gate (26-ECONOMY §PP: "Ultimate = 3 PP consume all"). Every cost_pp
+// in the catalog (4..12) exceeds POOL_MAX(3) -> pure consume-all: require the FULL
+// pool, drain to 0 on a 2xx dispatch; spend before dispatch + rollback on non-2xx.
+
+function mkExecutor() {
+  return createAbilityExecutor({
+    performAttack: () => ({ damageDealt: 0, result: { hit: false } }),
+    buildAttackEvent: () => ({}),
+    appendEvent: async () => {},
+    manhattanDistance: (a, b) => Math.abs(a.x - b.x) + Math.abs(a.y - b.y),
+  });
+}
+
+function mkActor(pp) {
+  return {
+    id: 'du',
+    job: 'duelist',
+    ap_remaining: 5,
+    pp,
+    position: { x: 0, y: 0 },
+    attack_range: 5,
+  };
+}
+
+function call(ex, actor, body, extra = []) {
+  return ex.executeAbility({
+    session: { units: [actor, ...extra], turn: 1, damage_taken: {} },
+    actor,
+    body,
+  });
+}
+
+test.before(() => {
+  _setAbilityForTest('test_pp_ult', {
+    ability_id: 'test_pp_ult',
+    effect_type: 'buff',
+    cost_ap: 0,
+    cost_pp: 6,
+    buff_stat: 'defense_mod',
+    buff_amount: 1,
+    duration: 1,
+  });
+  _setAbilityForTest('test_pp_none', {
+    ability_id: 'test_pp_none',
+    effect_type: 'buff',
+    cost_ap: 0,
+    buff_stat: 'defense_mod',
+    buff_amount: 1,
+    duration: 1,
+  });
+  _setAbilityForTest('test_pp_attack', {
+    ability_id: 'test_pp_attack',
+    effect_type: 'execution_attack',
+    cost_ap: 0,
+    cost_pp: 6,
+    damage_dice: '1d6',
+  });
+});
+
+test.after(() => {
+  _resetAbilityIndex();
+});
+
+test('PP consume-all: cost_pp=6 with pp=2 -> 400 (needs full pool 3)', async () => {
+  const actor = mkActor(2);
+  const res = await call(mkExecutor(), actor, { ability_id: 'test_pp_ult' });
+  assert.strictEqual(res.status, 400, JSON.stringify(res.body));
+  assert.strictEqual(res.body.pool, 'pp');
+  assert.strictEqual(res.body.consume_all, true);
+  assert.strictEqual(actor.pp, 2, 'pp unchanged on block');
+});
+
+test('PP consume-all: cost_pp=6 with pp=3 (full) -> 200, pp drained to 0', async () => {
+  const actor = mkActor(3);
+  const res = await call(mkExecutor(), actor, { ability_id: 'test_pp_ult' });
+  assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+  assert.strictEqual(actor.pp, 0, 'consume-all drains the pool');
+});
+
+test('no cost_pp: ability unaffected (pp untouched)', async () => {
+  const actor = mkActor(2);
+  const res = await call(mkExecutor(), actor, { ability_id: 'test_pp_none' });
+  assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+  assert.strictEqual(actor.pp, 2);
+});
+
+test('PP NOT charged on a failed dispatch (non-2xx rollback)', async () => {
+  const actor = mkActor(3);
+  const res = await call(mkExecutor(), actor, {
+    ability_id: 'test_pp_attack',
+    target_id: 'does_not_exist',
+  });
+  assert.ok(res.status >= 400, `expected a failure status, got ${res.status}`);
+  assert.strictEqual(actor.pp, 3, 'pp rolled back on a failed dispatch');
+});

--- a/tests/progression/ppCostGate.test.js
+++ b/tests/progression/ppCostGate.test.js
@@ -104,3 +104,26 @@ test('PP NOT charged on a failed dispatch (non-2xx rollback)', async () => {
   assert.ok(res.status >= 400, `expected a failure status, got ${res.status}`);
   assert.strictEqual(actor.pp, 3, 'pp rolled back on a failed dispatch');
 });
+
+test('cost_pp team_buff does NOT refill the caster via its own pp_grant (Codex #2555 P2)', async () => {
+  _setAbilityForTest('test_pp_teambuff', {
+    ability_id: 'test_pp_teambuff',
+    effect_type: 'team_buff',
+    cost_ap: 0,
+    cost_pp: 6,
+    pp_grant: 2,
+    range: 3,
+  });
+  const caster = mkActor(3); // full pool
+  const ally = {
+    id: 'ally',
+    controlled_by: caster.controlled_by,
+    hp: 10,
+    pp: 0,
+    position: { x: 1, y: 0 },
+  };
+  const res = await call(mkExecutor(), caster, { ability_id: 'test_pp_teambuff' }, [ally]);
+  assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+  assert.strictEqual(caster.pp, 0, 'caster consume-all-spent the pool and did NOT self-refill');
+  assert.strictEqual(ally.pp, 2, 'the other ally received pp_grant');
+});

--- a/tests/progression/ppTracker.test.js
+++ b/tests/progression/ppTracker.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const ppTracker = require('../../apps/backend/services/combat/ppTracker');
+
+// PP tracker (26-ECONOMY §PP): pool 0..3, +1 crit, +1 kill, per-encounter.
+
+test('POOL_MAX = 3 (canon)', () => {
+  assert.strictEqual(ppTracker.POOL_MAX, 3);
+});
+
+test('earnKill: +1 pp; undefined pp -> 1', () => {
+  const u = {};
+  assert.strictEqual(ppTracker.earnKill(u), 1);
+  assert.strictEqual(u.pp, 1);
+});
+
+test('earnCrit: +1 pp', () => {
+  const u = { pp: 1 };
+  assert.strictEqual(ppTracker.earnCrit(u), 1);
+  assert.strictEqual(u.pp, 2);
+});
+
+test('earn caps at POOL_MAX (3); no gain at cap', () => {
+  const u = { pp: 3 };
+  assert.strictEqual(ppTracker.earnKill(u), 0);
+  assert.strictEqual(u.pp, 3);
+});
+
+test('crit + kill stack toward cap', () => {
+  const u = { pp: 1 };
+  ppTracker.earnCrit(u); // 2
+  ppTracker.earnKill(u); // 3
+  ppTracker.earnKill(u); // capped 3
+  assert.strictEqual(u.pp, 3);
+});
+
+test('earn ignores null unit / non-positive amount', () => {
+  assert.strictEqual(ppTracker.earn(null, 1), 0);
+  assert.strictEqual(ppTracker.earn({}, 0), 0);
+  assert.strictEqual(ppTracker.earn({}, -2), 0);
+});


### PR DESCRIPTION
## H2 PP cost-gate (master-dd autonomia su evidenza, 2026-06-02)

Estende lo SG cost-gate (#2554) a **PP** (Power Pool). Scoperta-chiave: il SoT `26-ECONOMY` **GIA fissa** l'earn PP (+1 crit, +1 kill) e "Ultimate = 3 PP consume all" -> NON era un verdetto balance ma **canon-compliance** (la mia followup-spec sbagliava a chiamarlo "pending balance").

### Cosa fa
- **`ppTracker`** (nuovo, mirror sgTracker): POOL_MAX 3, `earnKill`/`earnCrit` (+1, clamp). Puro -> unit-testabile.
- **Earn** in `session.js` performAttack: +1 PP su `is_critical` (attaccante, ungated dalla sopravvivenza) + +1 PP su `killOccurred` (killer, hook finale). Best-effort non-blocking.
- **Gate** in `executeAbility`: tutti i cost_pp (4..12) > POOL_MAX(3) -> **consume-all** (richiede pool pieno, drena a 0). Spend prima del dispatch + rollback su non-2xx (modello SG/cost_pe). Nessun rescale dati.
- **`initial_pp`** seed nel route /start (mirror initial_sg) per save-load + test.

### Decisioni autonome (evidence-based)
- **PP = build** (costi 4-12 rotti vs pool 3, come SG). Earn = canon. Risorsa visibile (apps/play render/ui) + costi in /api/jobs -> 00D §6/Gate-5 ok.
- **PT = deferito** (NON balance-defer): pool spendibile NON wired (solo roll per-round) + costi gia coerenti <=12 + ruolo canonico = manovre non ancora costruite -> slice dedicata futura, non bolt-on.
- **cataclysm + cost_pp rank-2** (blade_flurry/resonance/kill_shot/deathmark): consume-all per cost-threshold; set `cost_*<=3` per-ability se master-dd li vuole numerici (reversibile).

### Evidence
- TDD: `ppTracker.test.js` 6/6 + `ppCostGate.test.js` 4/4 (consume-all/block/rollback).
- Regressione: progression+abilityExecutor+jobPerk(kill-wire) **220/220**, AI **500/500**.
- **Band-neutral**: nessuna party sim/scenario porta una ability cost_pp (grep: solo jobs/perks yaml) + AI non decide su pp -> HC byte-identici. 7 test integration aggiornati (seed pp via `initial_pp`/`startSessionPp`; le ultimate ora richiedono il pool).
- `prettier --check` clean, `check_docs_governance --strict` errors=0.

### Cognitive protocols
- **verify-first / currency-gate**: letto il SoT `26-ECONOMY` COMPLETO -> corretto il mio framing errato ("PP balance-pending" -> canon-compliance). Band-neutrality + PT-pool-absence verificate prima di costruire.
- **no-anticipated-judgment**: PP buildato (canon decide earn + consume-all evita rescale); PT deferito su evidenza (pool assente, non un guess di balance).

### Collision
Worktree isolato off origin/main `294174b2`; mai il main checkout. Nessun file conteso con PR aperti (solo #2512 chore-drift draft, non-mio).