### PR TITLE
feat(combat): h2 pt economy slice (ptTracker per-round pool + cost-gate)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -2893,6 +2893,15 @@ function createSessionRouter(options = {}) {
       } else if (usePriorityQueue) {
         // End-of-round ticks minimali: bleeding + status decay + AP reset + turn++.
         // NO AI declare (già fatto via priority queue).
+        // PT pool (26-ECONOMY §PT) resets per-round here too: this inline branch is
+        // the canonical /round/execute end-of-round (it SKIPS handleTurnEndViaRound,
+        // Codex #2557 P1). Reset ALL units (mirror the bridge reset, no hp filter).
+        try {
+          const ptTracker = require('../services/combat/ptTracker');
+          for (const u of session.units || []) ptTracker.resetRound(u);
+        } catch {
+          /* ptTracker optional */
+        }
         for (const unit of session.units) {
           if (!unit || Number(unit.hp) <= 0) continue;
           // Bleeding tick

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -683,6 +683,16 @@ function createSessionRouter(options = {}) {
       // separately for log via positionMod.damageBonus.
       const terrainDamageBonus = Number(positionMod.damageBonus) || 0;
       const baseDamage = 1 + result.pt + terrainDamageBonus;
+      // PT economy (26-ECONOMY §PT): the technique roll that feeds this hit's
+      // damage ALSO accumulates into the attacker's per-round PT pool (super-meter
+      // pattern — a hit builds meter while it deals damage). Additive + lazy-require
+      // (non-blocking, mirrors sgTracker/ppTracker); the pool is spent by cost_pt
+      // abilities (gated in executeAbility). Band-neutral: no sim party reads pt.
+      try {
+        require('../services/combat/ptTracker').earn(actor, result.pt);
+      } catch {
+        /* ptTracker optional */
+      }
       // SPRINT_007 fase 1 (issue #4): bonus damage +1 quando l'attaccante
       // e' strettamente adiacente al bersaglio (Manhattan == 1). Incentiva
       // la scelta tattica di entrare in mischia anche se skirmisher/ranger
@@ -1981,6 +1991,22 @@ function createSessionRouter(options = {}) {
         }
       } catch {
         /* pp seed optional */
+      }
+      // PT (Punti Tecnica) seed: `req.body.initial_pt = { unit_id: pool }` for
+      // save-load + integration tests (mirror initial_pp). No tutorial default (PT
+      // is EARNED from the attack technique roll via ptTracker, not gifted). Clamp
+      // 0..12 (ptTracker.POOL_MAX). PT resets per-round, so this is a round-start seed.
+      try {
+        const initialPt = req.body?.initial_pt;
+        if (initialPt && typeof initialPt === 'object') {
+          for (const [uid, pool] of Object.entries(initialPt)) {
+            const unit = (session.units || []).find((u) => u && u.id === uid);
+            if (!unit) continue;
+            unit.pt = Math.max(0, Math.min(12, Math.floor(Number(pool) || 0)));
+          }
+        }
+      } catch {
+        /* pt seed optional */
       }
       // TKT-ORPHAN-WOUNDPERMA: re-apply persistent wounds carried by this
       // campaign (cross-encounter scar). initSessionMap on first sight; the read

--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -112,6 +112,9 @@ function normaliseUnit(raw, fallbackIndex) {
     // V5 SG pool — preserve from input so save-load + tests carry value through.
     // sgTracker.initUnit will keep this if already set, otherwise default to 0.
     sg: Number.isFinite(Number(input.sg)) ? Number(input.sg) : 0,
+    // PT pool (26-ECONOMY §PT) — per-round technique points (ptTracker, cap 12).
+    // Preserve from input so save-load + initial_pt seed carry the value through.
+    pt: Number.isFinite(Number(input.pt)) ? Number(input.pt) : 0,
     // PE-canon re-label (#2527): `pe` = campaign XP (26-ECONOMY_CANONICAL), NOT a
     // combat resource. Preserved here as a read-only pass-through; combat NEVER
     // writes it (the aberrant combat cost is cost_sg). Default 0.
@@ -403,6 +406,9 @@ function publicSessionView(session) {
       ...u,
       pp: u.pp || 0,
       sg: Number.isFinite(Number(u.sg)) ? Number(u.sg) : 0,
+      // PT pool (26-ECONOMY §PT) surfaced for Gate-5 (player sees the per-round
+      // technique budget driving cost_pt abilities + maneuvers).
+      pt: Number.isFinite(Number(u.pt)) ? Number(u.pt) : 0,
       stress_gauge: stressGauge,
       surge_ready: stressGauge >= 75,
       pp_tier: (u.pp || 0) >= 10 ? 3 : (u.pp || 0) >= 6 ? 2 : (u.pp || 0) >= 3 ? 1 : 0,

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -1644,6 +1644,14 @@ function createRoundBridge(deps) {
     resetRoundAttackTracker(session);
     // Skiv ticket #2: reset synergy cooldown + archivia last_round_synergies.
     resetRoundSynergyTracker(session);
+    // PT pool (26-ECONOMY §PT) is per-round: clear every unit's technique points at
+    // the round boundary (lazy-require, non-blocking). Earned again next round.
+    try {
+      const ptTracker = require('../services/combat/ptTracker');
+      for (const u of session.units || []) ptTracker.resetRound(u);
+    } catch {
+      /* ptTracker optional */
+    }
     session.roundState = adaptSessionToRoundState(session);
 
     const { hazardEvents, bleedingEvents } = await applyEndOfRoundSideEffects(session);
@@ -2058,6 +2066,13 @@ function createRoundBridge(deps) {
 
         resetRoundAttackTracker(session);
         resetRoundSynergyTracker(session);
+        // PT pool (26-ECONOMY §PT) resets per-round at the planning boundary.
+        try {
+          const ptTracker = require('../services/combat/ptTracker');
+          for (const u of session.units || []) ptTracker.resetRound(u);
+        } catch {
+          /* ptTracker optional */
+        }
 
         const { hazardEvents, bleedingEvents } = await applyEndOfRoundSideEffects(session);
 

--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -2392,10 +2392,12 @@ function createAbilityExecutor(deps) {
     //     all"); no data rescale needed. NB cataclysm is rank-2 by label but its
     //     cost_sg 75 is ultimate-tier -> treated consume-all; set cost_sg <= POOL_MAX
     //     if master-dd wants it numeric.
-    // PP/PT are NOT modeled pools (PP un-seeded; PT a per-round dice roll) -> their
-    // cost_* stay DECORATIVE pending a pool-model + earn-curve verdict (follow-up
-    // docs/superpowers/specs/2026-06-02-economy-cost-gate-pp-pt-followup.md).
-    // Band-neutral: no sim/scenario party carries a cost_sg ability (HC byte-identical).
+    // PP (#2555) and PT (this slice) are NOW modeled pools too: PP per-encounter
+    // (ppTracker, earned +1 crit/+1 kill), PT per-round (ptTracker, earned from the
+    // attack technique roll). Both gated below mirroring SG. PT maneuvers
+    // (perforazione/spinte/condizioni/combo) stay a follow-up sink (not yet discrete
+    // combat actions). Band-neutral: no sim/scenario party carries a
+    // cost_sg/cost_pp/cost_pt ability (HC byte-identical).
     let sgConsumeAll = false;
     const costSg = Number(ability.cost_sg || 0);
     if (costSg > 0) {
@@ -2474,6 +2476,49 @@ function createAbilityExecutor(deps) {
         };
       }
     }
+    // H2 PT cost-gate (26-ECONOMY §PT: pool 0..12, per-round; earned from the attack
+    // technique roll via ptTracker, wired in session.js performAttack). Every cost_pt
+    // in the catalog (3..10) is <= POOL_MAX(12) -> NUMERIC gate (require >= cost_pt,
+    // deduct EXACTLY cost_pt — NOT consume-all, since PT is a numeric tactical economy,
+    // not an ultimate-drain like PP/SG). The consume-all branch is dormant future-proof
+    // for any cost_pt > 12. Spend before dispatch + rollback below.
+    let ptConsumeAll = false;
+    const costPt = Number(ability.cost_pt || 0);
+    if (costPt > 0) {
+      const ptPoolMax = (() => {
+        try {
+          return Number(require('./combat/ptTracker').POOL_MAX) || 12;
+        } catch {
+          return 12;
+        }
+      })();
+      const ptHave = Number(actor.pt || 0);
+      if (costPt > ptPoolMax) {
+        ptConsumeAll = true;
+        if (ptHave < ptPoolMax) {
+          return {
+            status: 400,
+            body: {
+              error: `PT insufficienti per ultimate (richiede il pool pieno ${ptPoolMax}, disponibili ${ptHave})`,
+              pool: 'pt',
+              cost: ptPoolMax,
+              have: ptHave,
+              consume_all: true,
+            },
+          };
+        }
+      } else if (ptHave < costPt) {
+        return {
+          status: 400,
+          body: {
+            error: `PT insufficienti per ability (richiesti ${costPt}, disponibili ${ptHave})`,
+            pool: 'pt',
+            cost: costPt,
+            have: ptHave,
+          },
+        };
+      }
+    }
     // TKT-JOB-PHASEC slice 2 — track the last ability id used (ability-id
     // granular, finer than last_action_type). Consumed by computePerkDefenseBonus
     // (defense_after_silent). Set after the AP gate, before dispatch.
@@ -2491,6 +2536,11 @@ function createAbilityExecutor(deps) {
     if (costPp > 0) {
       ppBefore = Number(actor.pp || 0);
       actor.pp = ppConsumeAll ? 0 : Math.max(0, ppBefore - costPp);
+    }
+    let ptBefore = null;
+    if (costPt > 0) {
+      ptBefore = Number(actor.pt || 0);
+      actor.pt = ptConsumeAll ? 0 : Math.max(0, ptBefore - costPt);
     }
     const dispatch = () => {
       switch (ability.effect_type) {
@@ -2552,6 +2602,9 @@ function createAbilityExecutor(deps) {
     }
     if (costPp > 0 && !resolved2xx) {
       actor.pp = ppBefore;
+    }
+    if (costPt > 0 && !resolved2xx) {
+      actor.pt = ptBefore;
     }
     // TKT-JOB-PHASEC slice 4 (Cat F, OQ-F verdict A) — on-ability-use perk
     // effects, fired only on a successful (2xx) resolution. Lazy require mirrors

--- a/apps/backend/services/combat/ptTracker.js
+++ b/apps/backend/services/combat/ptTracker.js
@@ -1,0 +1,56 @@
+// PT (Punti Tecnica) tracker — combat resource, per-ROUND.
+//
+// Canon: 26-ECONOMY_CANONICAL.md §PT (P0 Q51 default B):
+//   - Pool 0..12 (POOL_MAX = PT_POOL_CAP), reset per-ROUND (round-model
+//     ADR-2026-04-15), NOT per-encounter like PP/SG.
+//   - Earn: the per-attack technique roll (nat 15-19 +1 / nat 20 +2 / +5 MoS +1)
+//     computed in resolveAttack (sessionHelpers.js) and accumulated here.
+//   - Spend: cost_pt abilities (3..10, gated numerically in
+//     abilityExecutor.executeAbility) + maneuvers (perforazione/spinte/condizioni/
+//     combo — canon spend paths, not yet built as discrete combat actions).
+//
+// Mirrors the ppTracker/sgTracker pattern: a tiny pure module so the earn path in
+// session.js performAttack stays unit-testable. Earning is band-neutral — no sim
+// party casts a cost_pt ability and the AI keys no decision off pt — so
+// accumulating PT in sim runs changes no outcome. NB the same roll value also
+// feeds attack damage (1 + pt, M14-A); the pool is an ADDITIVE super-meter on top
+// (fighting-game pattern: a hit builds meter while it deals damage), so the damage
+// model is untouched (HC scenarios byte-identical).
+
+'use strict';
+
+const POOL_MAX = 12;
+
+// Ensure unit has the pt field. Idempotent (safe to call repeatedly); preserves
+// an existing value so save-load + tests carry the pool through.
+function initUnit(unit) {
+  if (!unit || typeof unit !== 'object') return unit;
+  if (typeof unit.pt !== 'number') unit.pt = 0;
+  return unit;
+}
+
+// Clamp-add `amount` PT to a unit, capped at POOL_MAX. Returns the actual gain.
+function earn(unit, amount) {
+  if (!unit || !(Number(amount) > 0)) return 0;
+  const before = Number(unit.pt) || 0;
+  const after = Math.min(POOL_MAX, before + Number(amount));
+  unit.pt = after;
+  return after - before;
+}
+
+// Reset the pool to 0 at round start (per-round, NOT per-encounter).
+function resetRound(unit) {
+  initUnit(unit);
+  unit.pt = 0;
+  return unit;
+}
+
+// Spend PT. Returns true if sufficient + decrements; false (no-op) otherwise.
+function spend(unit, amount = 1) {
+  initUnit(unit);
+  if (unit.pt < amount) return false;
+  unit.pt -= amount;
+  return true;
+}
+
+module.exports = { POOL_MAX, initUnit, earn, resetRound, spend };

--- a/tests/api/abilityExecutor.test.js
+++ b/tests/api/abilityExecutor.test.js
@@ -53,6 +53,19 @@ async function startSessionPp(app) {
   return { sid: startRes.body.session_id, state: startRes.body.state };
 }
 
+// H2 PT cost-gate (2026-06-02): cost_pt abilities (3..10) are gated numerically
+// against the per-round PT pool. Seed p_scout pt=12 (full) so the support/control
+// abilities (symbiotic_bloom 4 / sanctuary 4 / lifegrove 10) dispatch observably.
+async function startSessionPt(app) {
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  assert.equal(scenario.status, 200);
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units, initial_pt: { p_scout: 12 } });
+  assert.equal(startRes.status, 200);
+  return { sid: startRes.body.session_id, state: startRes.body.state };
+}
+
 test('dash_strike: move_attack end-to-end, AP decremented, event emitted', async (t) => {
   const { app, close } = createApp({ databasePath: null });
   t.after(async () => {
@@ -510,7 +523,7 @@ test('symbiotic_bloom: team_heal cura tutti gli alleati in range', async (t) => 
     if (typeof close === 'function') await close().catch(() => {});
   });
 
-  const { sid } = await startSession(app);
+  const { sid } = await startSessionPt(app);
   const res = await request(app).post('/api/session/action').send({
     session_id: sid,
     action_type: 'ability',
@@ -533,7 +546,7 @@ test("sanctuary: aoe_buff applica defense_mod ai allies nell'area", async (t) =>
     if (typeof close === 'function') await close().catch(() => {});
   });
 
-  const { sid } = await startSession(app);
+  const { sid } = await startSessionPt(app);
   // Centro AoE su p_tank (1,3). aoe_size=2 → ±1. p_scout (1,2) e p_tank (1,3) inclusi.
   const res = await request(app)
     .post('/api/session/action')
@@ -1379,7 +1392,7 @@ test('Sprint 8.1 lifegrove (r4 team_heal): dispatch via harvester path + remove_
     if (typeof close === 'function') await close().catch(() => {});
   });
 
-  const { sid } = await startSession(app);
+  const { sid } = await startSessionPt(app);
   const res = await request(app).post('/api/session/action').send({
     session_id: sid,
     action_type: 'ability',

--- a/tests/api/ptEconomyWire.test.js
+++ b/tests/api/ptEconomyWire.test.js
@@ -1,0 +1,121 @@
+// tests/api/ptEconomyWire.test.js
+//
+// PT economy slice (26-ECONOMY §PT, P0 Q51 B): the per-attack technique roll
+// (nat 15-19 +1 / nat 20 +2 / +5 MoS +1) accumulates into a per-ROUND actor.pt
+// pool (ptTracker, cap 12), surfaced via publicSessionView for Gate-5 visibility,
+// seeded by initial_pt at /start, reset per-round at the round boundary.
+//
+// performAttack stays a private closure; these drive it through the /action HTTP
+// seam (the sequential flow earns + persists pt until a round boundary resets it,
+// unlike /round/execute which ends the round in one shot).
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+
+function combatUnits() {
+  return [
+    {
+      id: 'atk',
+      species: 'dune_stalker',
+      job: 'stalker',
+      hp: 30,
+      max_hp: 30,
+      ap: 3,
+      mod: 20, // guarantees the hit (mos always >= 11 -> pt >= 2)
+      attack_range: 2,
+      initiative: 18,
+      position: { x: 1, y: 1 },
+      controlled_by: 'player',
+      status: {},
+    },
+    {
+      id: 'foe',
+      species: 'velox',
+      hp: 100, // survives the hit so the round state stays clean
+      max_hp: 100,
+      ap: 1,
+      mod: 0,
+      dc: 1, // trivial DC -> mos always huge -> pt earn deterministic (>=4), not RNG-flaky
+      attack_range: 1,
+      initiative: 1,
+      position: { x: 1, y: 2 }, // Manhattan 1 from atk
+      controlled_by: 'sistema',
+      status: {},
+    },
+  ];
+}
+
+async function start(app, extra = {}) {
+  const res = await request(app)
+    .post('/api/session/start')
+    .send({ units: combatUnits(), ...extra });
+  assert.equal(res.status, 200, JSON.stringify(res.body).slice(0, 200));
+  return res.body.session_id;
+}
+
+async function unit(app, sid, id) {
+  const res = await request(app).get('/api/session/state').query({ session_id: sid });
+  assert.equal(res.status, 200);
+  return (res.body.units || []).find((u) => u.id === id);
+}
+
+async function attack(app, sid) {
+  return request(app)
+    .post('/api/session/action')
+    .send({ session_id: sid, action_type: 'attack', actor_id: 'atk', target_id: 'foe' });
+}
+
+test('PT pool starts at 0 and is surfaced on /state (Gate-5 visibility)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await start(app);
+  const atk = await unit(app, sid, 'atk');
+  assert.equal(typeof atk.pt, 'number', 'pt surfaced as a number on the unit');
+  assert.equal(atk.pt, 0, 'pool starts empty');
+});
+
+test('PT is earned from the attack technique roll (performAttack wire)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await start(app);
+  const res = await attack(app, sid);
+  assert.equal(res.status, 200, JSON.stringify(res.body).slice(0, 200));
+  const atk = await unit(app, sid, 'atk');
+  assert.ok(atk.pt >= 2, `pt earned from the hit (got ${atk.pt})`);
+  assert.ok(atk.pt <= 12, 'pool never exceeds the cap');
+});
+
+test('initial_pt seeds the pool at /start (save-load / mirror initial_pp)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await start(app, { initial_pt: { atk: 7 } });
+  const atk = await unit(app, sid, 'atk');
+  assert.equal(atk.pt, 7, 'seeded pool surfaced on /state');
+});
+
+test('PT resets to 0 at the round boundary (per-round, /round/begin-planning)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await start(app, { initial_pt: { atk: 9 } });
+  let atk = await unit(app, sid, 'atk');
+  assert.equal(atk.pt, 9, 'seeded before the round boundary');
+  const bp = await request(app).post('/api/session/round/begin-planning').send({ session_id: sid });
+  assert.equal(bp.status, 200, JSON.stringify(bp.body).slice(0, 200));
+  atk = await unit(app, sid, 'atk');
+  assert.equal(atk.pt, 0, 'pool reset per-round');
+});

--- a/tests/api/ptEconomyWire.test.js
+++ b/tests/api/ptEconomyWire.test.js
@@ -119,3 +119,20 @@ test('PT resets to 0 at the round boundary (per-round, /round/begin-planning)', 
   atk = await unit(app, sid, 'atk');
   assert.equal(atk.pt, 0, 'pool reset per-round');
 });
+
+test('PT resets to 0 after a priority-queue /round/execute (Codex #2557 P1)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  // The canonical /round/execute priority_queue flow runs its OWN inline
+  // end-of-round ticks (skips handleTurnEndViaRound); the per-round PT reset must
+  // fire there too. Seed pt, run an empty round, assert it cleared.
+  const sid = await start(app, { initial_pt: { atk: 9 } });
+  const exec = await request(app)
+    .post('/api/session/round/execute')
+    .send({ session_id: sid, player_intents: [], ai_auto: false, priority_queue: true });
+  assert.equal(exec.status, 200, JSON.stringify(exec.body).slice(0, 200));
+  const atk = await unit(app, sid, 'atk');
+  assert.equal(atk.pt, 0, 'priority-queue end-of-round resets the PT pool');
+});

--- a/tests/progression/ptCostGate.test.js
+++ b/tests/progression/ptCostGate.test.js
@@ -1,0 +1,136 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const {
+  createAbilityExecutor,
+  _setAbilityForTest,
+  _resetAbilityIndex,
+} = require('../../apps/backend/services/abilityExecutor');
+
+// H2 PT cost-gate (26-ECONOMY §PT: pool 0..12, per-round). Every cost_pt in the
+// catalog (3..10) is <= POOL_MAX(12) -> NUMERIC gate: require >= cost_pt, deduct
+// EXACTLY cost_pt on a 2xx dispatch (NOT consume-all, unlike PP/SG ultimates).
+// Spend before dispatch + rollback on non-2xx. A dormant consume-all branch
+// guards cost_pt > 12 (no such ability exists; PT is canonically numeric).
+
+function mkExecutor() {
+  return createAbilityExecutor({
+    performAttack: () => ({ damageDealt: 0, result: { hit: false } }),
+    buildAttackEvent: () => ({}),
+    appendEvent: async () => {},
+    manhattanDistance: (a, b) => Math.abs(a.x - b.x) + Math.abs(a.y - b.y),
+  });
+}
+
+function mkActor(pt) {
+  return {
+    id: 'gd',
+    job: 'guardian',
+    ap_remaining: 5,
+    pt,
+    position: { x: 0, y: 0 },
+    attack_range: 5,
+  };
+}
+
+function call(ex, actor, body, extra = []) {
+  return ex.executeAbility({
+    session: { units: [actor, ...extra], turn: 1, damage_taken: {} },
+    actor,
+    body,
+  });
+}
+
+test.before(() => {
+  _setAbilityForTest('test_pt_buff', {
+    ability_id: 'test_pt_buff',
+    effect_type: 'buff',
+    cost_ap: 0,
+    cost_pt: 5,
+    buff_stat: 'defense_mod',
+    buff_amount: 1,
+    duration: 1,
+  });
+  _setAbilityForTest('test_pt_none', {
+    ability_id: 'test_pt_none',
+    effect_type: 'buff',
+    cost_ap: 0,
+    buff_stat: 'defense_mod',
+    buff_amount: 1,
+    duration: 1,
+  });
+  _setAbilityForTest('test_pt_attack', {
+    ability_id: 'test_pt_attack',
+    effect_type: 'execution_attack',
+    cost_ap: 0,
+    cost_pt: 5,
+    damage_dice: '1d6',
+  });
+  _setAbilityForTest('test_pt_ult', {
+    ability_id: 'test_pt_ult',
+    effect_type: 'buff',
+    cost_ap: 0,
+    cost_pt: 99, // > POOL_MAX -> dormant consume-all branch
+    buff_stat: 'defense_mod',
+    buff_amount: 1,
+    duration: 1,
+  });
+});
+
+test.after(() => {
+  _resetAbilityIndex();
+});
+
+test('PT numeric: cost_pt=5 with pt=3 -> 400 (insufficient), pt unchanged', async () => {
+  const actor = mkActor(3);
+  const res = await call(mkExecutor(), actor, { ability_id: 'test_pt_buff' });
+  assert.strictEqual(res.status, 400, JSON.stringify(res.body));
+  assert.strictEqual(res.body.pool, 'pt');
+  assert.strictEqual(actor.pt, 3, 'pt unchanged on block');
+});
+
+test('PT numeric: cost_pt=5 with pt=5 -> 200, pt deducted to 0', async () => {
+  const actor = mkActor(5);
+  const res = await call(mkExecutor(), actor, { ability_id: 'test_pt_buff' });
+  assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+  assert.strictEqual(actor.pt, 0, 'exact cost deducted');
+});
+
+test('PT numeric: cost_pt=5 with pt=8 -> 200, deducts EXACT cost (pt=3, not consume-all)', async () => {
+  const actor = mkActor(8);
+  const res = await call(mkExecutor(), actor, { ability_id: 'test_pt_buff' });
+  assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+  assert.strictEqual(actor.pt, 3, 'numeric deduct leaves the remainder (NOT drained)');
+});
+
+test('no cost_pt: ability unaffected (pt untouched)', async () => {
+  const actor = mkActor(4);
+  const res = await call(mkExecutor(), actor, { ability_id: 'test_pt_none' });
+  assert.strictEqual(res.status, 200, JSON.stringify(res.body));
+  assert.strictEqual(actor.pt, 4);
+});
+
+test('PT NOT charged on a failed dispatch (non-2xx rollback)', async () => {
+  const actor = mkActor(5);
+  const res = await call(mkExecutor(), actor, {
+    ability_id: 'test_pt_attack',
+    target_id: 'does_not_exist',
+  });
+  assert.ok(res.status >= 400, `expected a failure status, got ${res.status}`);
+  assert.strictEqual(actor.pt, 5, 'pt rolled back on a failed dispatch');
+});
+
+test('PT dormant consume-all: cost_pt=99 needs the FULL pool (12) -> drained; pt<12 -> 400', async () => {
+  const full = mkActor(12);
+  const okRes = await call(mkExecutor(), full, { ability_id: 'test_pt_ult' });
+  assert.strictEqual(okRes.status, 200, JSON.stringify(okRes.body));
+  assert.strictEqual(full.pt, 0, 'consume-all drains the full pool');
+
+  const partial = mkActor(11);
+  const blockRes = await call(mkExecutor(), partial, { ability_id: 'test_pt_ult' });
+  assert.strictEqual(blockRes.status, 400);
+  assert.strictEqual(blockRes.body.consume_all, true);
+  assert.strictEqual(partial.pt, 11, 'unchanged on block');
+});

--- a/tests/progression/ptTracker.test.js
+++ b/tests/progression/ptTracker.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const ptTracker = require('../../apps/backend/services/combat/ptTracker');
+
+// PT tracker (26-ECONOMY §PT, P0 Q51 B): pool 0..12, per-ROUND reset, earn the
+// per-attack technique roll (nat 15-19 +1 / nat 20 +2 / +5 MoS +1, computed in
+// resolveAttack), spend on cost_pt abilities + maneuvers. Mirrors ppTracker but
+// cap 12 + resetRound (NOT resetEncounter) + numeric earn (accumulate the roll).
+
+test('POOL_MAX = 12 (PT_POOL_CAP, canon)', () => {
+  assert.strictEqual(ptTracker.POOL_MAX, 12);
+});
+
+test('earn accumulates the roll value; undefined pt -> amount', () => {
+  const u = {};
+  assert.strictEqual(ptTracker.earn(u, 3), 3);
+  assert.strictEqual(u.pt, 3);
+  assert.strictEqual(ptTracker.earn(u, 2), 2);
+  assert.strictEqual(u.pt, 5);
+});
+
+test('earn caps at POOL_MAX (12); partial gain at the cap, none past it', () => {
+  const u = { pt: 10 };
+  assert.strictEqual(ptTracker.earn(u, 5), 2); // 10 -> 12, only +2 counted
+  assert.strictEqual(u.pt, 12);
+  assert.strictEqual(ptTracker.earn(u, 3), 0); // already capped
+  assert.strictEqual(u.pt, 12);
+});
+
+test('earn ignores null unit / non-positive amount', () => {
+  assert.strictEqual(ptTracker.earn(null, 1), 0);
+  assert.strictEqual(ptTracker.earn({}, 0), 0);
+  assert.strictEqual(ptTracker.earn({}, -2), 0);
+});
+
+test('resetRound clears the pool to 0 (per-round, NOT per-encounter)', () => {
+  const u = { pt: 7 };
+  ptTracker.resetRound(u);
+  assert.strictEqual(u.pt, 0);
+});
+
+test('spend decrements when sufficient, returns true', () => {
+  const u = { pt: 5 };
+  assert.strictEqual(ptTracker.spend(u, 3), true);
+  assert.strictEqual(u.pt, 2);
+});
+
+test('spend returns false when insufficient, pool unchanged', () => {
+  const u = { pt: 2 };
+  assert.strictEqual(ptTracker.spend(u, 3), false);
+  assert.strictEqual(u.pt, 2);
+});
+
+test('initUnit seeds pt=0 idempotently (preserves an existing value)', () => {
+  const u = {};
+  ptTracker.initUnit(u);
+  assert.strictEqual(u.pt, 0);
+  u.pt = 4;
+  ptTracker.initUnit(u);
+  assert.strictEqual(u.pt, 4);
+});


### PR DESCRIPTION
## Cosa

Costruisce il **pool PT spendibile** (Punti Tecnica) che mancava: il roll-tecnica si calcolava (`sessionHelpers.resolveAttack`) ma alimentava **solo il danno** (`1 + pt`), senza pool accumulato/spendibile. Chiude la Fase-2 economy dopo SG (#2554) + PP (#2555).

Canon: [`26-ECONOMY_CANONICAL.md §PT`](docs/core/26-ECONOMY_CANONICAL.md) (P0 Q51 B) — pool 0..12, reset **per-round**, earn `nat15-19 +1 / nat20 +2 / +5 MoS +1`, spend manovre + `cost_pt`.

## Implementazione (mirror sgTracker/ppTracker)

- **`ptTracker.js`** — `POOL_MAX 12`, `earn` (accumula clamp), `resetRound` (per-round, NON per-encounter), `spend`, `initUnit`.
- **earn** — `ptTracker.earn(actor, result.pt)` in `performAttack` dopo `baseDamage`. **Super-meter pattern** (fighting games: un colpo costruisce meter mentre infligge danno — `docs/research/2026-04-26-cross-game-extraction-MASTER.md`). Il modello danno `1+pt` resta **INTOCCATO**.
- **gate** — `cost_pt` numerico in `executeAbility` (catalog 3..10 tutti ≤ cap → deduct esatto, NON consume-all; ramo consume-all dormiente per `>12`). spend-before-dispatch + rollback su non-2xx.
- **seed** — `initial_pt` in `/start` (mirror `initial_pp`). **surface** — `pt` via `publicSessionView` (Gate-5: il player vede il budget per-round).
- **reset per-round** — ai due round-boundary (`handleTurnEndViaRound` + `/round/begin-planning`).

## Band-neutral proof

- **AI 500/500** verde. Nessuna party sim/scenario lancia un'ability `cost_pt` (grep vuoto) → gating non muove HC06/07.
- Il roll `pt` alimenta il danno **identico a prima** (additivo, il pool è nuovo + letto solo da `cost_pt`) → HC byte-identical.

## Gate-5 (engine-wired)

Player attacca (`/action`) → `pt` sale, visibile in `/state` → lancia un'ability `cost_pt` (es. `fortify` 3) → `pt` scende. Flusso sequenziale `/action` = earn-then-spend nello stesso round. Errore diegetico se pool insufficiente (`PT insufficienti per ability (richiesti X, disponibili Y)`).

## Design note (flagged master-dd, reversibile)

Il roll `pt` ha **doppio scopo**: danno (M14-A) + pool (canon). È il super-meter pattern (band-neutral additivo). Decuplarli (rimuovere `pt` dal danno) sarebbe un **rebalance band-relevant** (ricalibra HC06/07) → NON fatto qui, lasciato come scelta master-dd.

**Manovre deferite** (perforazione/spinte/condizioni/combo): non ancora azioni combat discrete. Il pool è finanziato + speso dalle `cost_pt` ability per ora; manovre = follow-up.

## Test

| Suite | Esito |
|---|---|
| `ptTracker.test.js` | 8/8 |
| `ptCostGate.test.js` | 6/6 |
| `ptEconomyWire.test.js` (integration earn+seed+surface+reset) | 4/4 |
| AI suite | 500/500 (band-neutral) |
| progression | 191/191 |
| coop + state + snapshot ripple | 47/47 |

3 test pre-esistenti `cost_pt` (symbiotic_bloom/sanctuary/lifegrove) ora seedati via `startSessionPt` (stesso pattern di `startSessionSgFull`/`startSessionPp`).

## Rollback

`git revert` del singolo commit. `ptTracker` lazy-require non-blocking ovunque (try/catch); rimuoverlo lascia il danno `1+pt` invariato. Nessun forbidden path, nessun dep, nessun schema/migration.

Coding-Agent: claude-opus-4.8