### PR TITLE
docs(economy): h2 pt shipped + rescale verdict (keep consume-all)

### DIFF
--- a/docs/museum/cards/economy-rescale-ultimates-numeric-discard.md
+++ b/docs/museum/cards/economy-rescale-ultimates-numeric-discard.md
@@ -1,0 +1,88 @@
+---
+title: Economy rescale ultimate -> numerico — discarded (keep consume-all)
+museum_id: M-2026-06-02-002
+type: discarded_decision_path
+domain: economy-cost-gate-pp-sg
+provenance:
+  found_at: docs/superpowers/specs/2026-06-02-economy-cost-gate-pp-pt-followup.md
+  git_sha_first: TBD
+  git_sha_last: TBD
+  last_modified: 2026-06-02
+  last_author: claude-opus-4.8-design-closure
+  buried_reason: handoff H2 §2 proponeva rescale rank-2 -> numerico; verify-first SoT-completo rivela PP-numerico anti-canon + SG-ultimate identity-change -> KEEP consume-all
+relevance_score: 4
+reuse_path: docs/superpowers/specs/2026-06-02-economy-cost-gate-pp-pt-followup.md (Lever, valori numerici pronti se master-dd vuole flippare cataclysm)
+related_pillars: [P6]
+related_od: []
+status: curated
+excavated_by: claude-opus-4.8 design-closure 2026-06-02 (goal Fase-2 task rescale, repo-archaeologist non in registry sessione codemasterdd -> card autorata in formato canonico)
+excavated_on: 2026-06-02
+last_verified: 2026-06-02
+---
+
+# Economy rescale ultimate -> numerico — discarded (keep consume-all)
+
+## Summary (30s)
+
+- Il handoff H2 (`2026-06-02-h2-economy-handoff.md` §2) proponeva, come leva balance opzionale, di
+  **rescalare le ability rank-2 a costo gonfiato** (cataclysm `cost_sg 75`; PP rank-2 blade_flurry 6 /
+  resonance 4 / kill_shot 6 / deathmark 4) da **consume-all** a **numerico** (`cost <= pool`).
+- **Scartato dopo verify-first sul SoT completo** (currency-gate): per PP il numerico e' **anti-canon**
+  (il SoT fissa SOLO "Ultimate = 3 PP consume all", nessuna spesa PP numerica esiste); per gli ultimate
+  SG (cataclysm/arcane_lance/apocalypse_ray) il rescale cambia l'**identita'** (da ultimate AoE a AoE
+  ripetibile). Verdetto: **KEEP consume-all**.
+- **Reuse value**: i valori numerici sono **pronti** se master-dd vuole, in futuro, flippare cataclysm
+  (legittimo: SG ha gia un modello misto synaptic/aberrant). Il PP-numerico resta sconsigliato.
+
+## What was discarded
+
+### Il rescale proposto (band-neutral, reversibile)
+
+| Ability (rank-2)    | Pool | Oggi (consume-all) | Numerico proposto | Esito                     |
+| ------------------- | :--: | -----------------: | ----------------: | ------------------------- |
+| cataclysm           |  SG  |                 75 |          3 (≤cap) | leva legittima (rinviata) |
+| blade_flurry        |  PP  |                  6 |                 2 | anti-canon (respinto)     |
+| resonance_amplifier |  PP  |                  4 |                 2 | anti-canon (respinto)     |
+| kill_shot           |  PP  |                  6 |                 2 | anti-canon (respinto)     |
+| deathmark           |  PP  |                  4 |                 2 | anti-canon (respinto)     |
+
+### Why discarded (evidenza, non over-caution)
+
+| Criterio           |  PP  | SG ultimate | Rationale                                                                             |
+| ------------------ | :--: | :---------: | ------------------------------------------------------------------------------------- |
+| Canon (26-ECONOMY) | fail |   pass\*    | PP: solo "Ultimate = 3 consume all", zero spesa numerica -> rescale = invenzione      |
+| Catalogo           | fail |    mixed    | PP: tutti i 12 cost_pp sono 4..12 (>pool 3); SG ha gia synaptic 2/aberrant 3 numerici |
+| Identita' ability  |  ok  |    fail     | SG: cataclysm e' ultimate AoE (surge_aoe+stress_reset); numerico -> AoE spammabile    |
+| Band-verify        | n/a  |     n/a     | band-neutral (nessuna sim lancia queste ability) -> non validabile, no signal         |
+
+\* SG-numerico non e' anti-canon (precedente synaptic/aberrant) ma cambia l'identita' dell'ultimate.
+
+### Cosa NON e' stato scartato
+
+Il **cost-gate engine** resta invariato (consume-all per `cost > pool`, numerico per `cost <= pool`). I
+costi numerici GIA esistenti (SG synaptic_burst 2, aberrant_overdrive 3; tutti i cost_pt 3..10) restano
+numerici. Solo il **rescale degli ultimate** e' rinviato.
+
+## Reuse paths
+
+1. **Lever pronto**: se master-dd vuole cataclysm numerico -> set `cost_sg: 3` nel dato (`data/core/jobs.yaml`),
+   1 valore, nessun codice. Il gate flippa automaticamente. Reversibile via git.
+2. **Regola canon**: PP spende SOLO come ultimate consume-all (3 PP). Non introdurre cost_pp numerici
+   senza prima estendere il SoT `26-ECONOMY §PP` (oggi NON li prevede).
+3. **Pattern**: "valore-costo gonfiato > pool = sentinella consume-all" — leggibile, niente flag, niente
+   campo extra. Riusabile per ogni nuova ability ultimate.
+
+## Lifecycle
+
+- **Status**: `curated` (verify-first catalogo + SoT documentati; verdetto nel spec sibling).
+- **Reuse**: pendente eventuale preferenza master-dd su cataclysm-numerico.
+- **Decommission**: se master-dd flippa cataclysm -> la card diventa training-evidence del verify-first
+  currency-gate (revived), non si elimina.
+
+## Related
+
+- Spec/verdetto: `docs/superpowers/specs/2026-06-02-economy-cost-gate-pp-pt-followup.md` (§Rescale verdetto)
+- Handoff (proposta originale): `docs/planning/2026-06-02-h2-economy-handoff.md` §2
+- SoT economia: `docs/core/26-ECONOMY_CANONICAL.md` (§PP "Ultimate = consume all" / §SG)
+- Lezione: currency-gate (leggi il SoT COMPLETO prima di chiamare una cosa "balance-pending") —
+  anti-pattern #19 applicato al handoff stesso (come gia per PP/PT earn-curve)

--- a/docs/superpowers/specs/2026-06-02-economy-cost-gate-pp-pt-followup.md
+++ b/docs/superpowers/specs/2026-06-02-economy-cost-gate-pp-pt-followup.md
@@ -11,21 +11,75 @@ tags: [economy, cost-gate, pp-pool, pt-pool, phasec, pending-design, balance]
 
 # Economy cost-gate follow-up — PP/PT pool model
 
-> Follow-up del verdetto master-dd 2026-06-02 su H2 (`= option C hybrid`). Lo **SG
-> cost-gate e' SHIPPED** (vedi sotto); **PP/PT restano decorativi** perche' gatearli
-> richiede prima di costruire un pool-model + earn-curve = leve di **balance** che,
-> essendo band-neutral (nessuna sim usa queste ability), **non sono validabili via
-> band-verify** -> verdetto numerico master-dd. Estende la spec `2026-06-01-phasec-economy-cost-gate.md`.
+> Follow-up del verdetto master-dd 2026-06-02 su H2 (`= option C hybrid`). Estende la spec
+> `2026-06-01-phasec-economy-cost-gate.md`.
+>
+> **STATO FINALE: SG (#2554) + PP (#2555) + PT (#2557) cost-gate TUTTI SHIPPED.** La framing originale
+> qui sotto ("PP/PT restano decorativi / earn-curve = leva balance non validabile -> verdetto master-dd")
+> e' **SUPERSEDED** dalle 2 UPDATE qui sotto: le earn-curve PP/PT erano GIA canon in `26-ECONOMY` (non
+> balance-pending) — vedi lezione currency-gate. Le sezioni storiche restano per provenance, ma leggi le
+> UPDATE + il verdetto rescale come stato corrente.
 
 > **UPDATE 2026-06-02 (master-dd ha accordato autonomia di scelta su evidenza): PP cost-gate SHIPPED.**
 > Il SoT `26-ECONOMY` GIA fissa l'earn PP (+1 crit, +1 kill) e "Ultimate = 3 PP consume all" -> NON era
 > un verdetto balance ma canon-compliance. Wired: `ppTracker` (POOL_MAX 3) + earn in `session.js`
 > performAttack (crit/kill) + gate consume-all in `executeAbility` (tutti i cost_pp 4-12 > 3 ->
 > consume-all, NO rescale) + `initial_pp` seed (mirror initial_sg). Band-neutral (AI non decide su pp;
-> ability assenti dalle sim) -> AI 500/500. **Solo PT resta deferito** (pool spendibile NON wired +
-> costi gia coerenti <=12 + ruolo canonico = manovre, non ancora costruite). NOTA: i cost_pp rank-2
-> (blade_flurry 6 / resonance 4 / kill_shot 6 / deathmark 4) sono consume-all per cost-threshold; set
-> `cost_pp <= 3` per-ability se master-dd li vuole numerici (reversibile, come cataclysm).
+> ability assenti dalle sim) -> AI 500/500.
+
+> **UPDATE 2026-06-02 (autonomia su evidenza): PT cost-gate + pool SHIPPED (#2557).** Stesso
+> currency-gate del PP: il SoT `26-ECONOMY §PT` GIA fissa pool 0..12 + reset per-round + earn
+> `nat15-19 +1 / nat20 +2 / +5 MoS +1` -> NON era balance-pending ma canon-compliance (la framing
+> "PT deferito / earn-curve = leva balance" qui sotto era SBAGLIATA: stessa lezione del PP). Il PT roll
+> si calcolava gia ma alimentava SOLO il danno (`1+pt`); ora alimenta ANCHE un pool spendibile
+> (super-meter: un colpo costruisce meter mentre infligge danno, danno INTOCCATO -> band-neutral).
+> Wired: `ptTracker` (POOL_MAX 12, resetRound) + earn in `performAttack` + gate numerico in
+> `executeAbility` (cost_pt 3..10 tutti <= 12 -> deduct esatto, NO rescale) + `initial_pt` seed +
+> surface `pt` in `publicSessionView` (Gate-5) + reset per-round ai due round-boundary. AI 500/500,
+> ptTracker 8 + ptCostGate 6 + ptEconomyWire 4. **Manovre** (perforazione/spinte/condizioni/combo)
+> deferite (non ancora azioni discrete). **Rescale rank-2 -> vedi verdetto sotto.**
+
+## Rescale rank-2 -> numerico — VERDETTO 2026-06-02 (autonomia su evidenza): KEEP consume-all
+
+Domanda residua (handoff `2026-06-02-h2-economy-handoff.md` §2): le ability rank-2 con costo gonfiato
+(cataclysm `cost_sg 75`; PP rank-2 blade_flurry 6 / resonance_amplifier 4 / kill_shot 6 / deathmark 4)
+oggi sono **consume-all per cost-threshold**. Vanno rescalate a numerico (`cost <= pool`)?
+
+**Verify-first (catalogo completo, currency-gate = leggi il SoT INTERO):**
+
+- **PP** (pool max 3): TUTTI i cost_pp del catalogo sono 4..12 (blade_flurry 6, resonance 4, kill_shot 6,
+  deathmark 4, phantom_step 5, arcane_renewal 5, hunter_mark 5, shadow_mark 5, dervish_whirlwind 10,
+  convergence_wave 10, headshot 12, shadow_assassinate 10). **ZERO cost_pp <= 3.** Il SoT `26-ECONOMY §PP`
+  dice **solo** "Ultimate = 3 PP consume all" — **non esiste un modello di spesa PP numerico in canon.**
+  Rescalare i rank-2 PP a `<=3` **INVENTEREBBE** una spesa PP sub-ultimate non canonica.
+  -> **Anti-canon. KEEP consume-all** (non e' una leva balance: e' canon-compliance).
+- **SG** (pool max 3): modello GIA MISTO — `synaptic_burst 2` + `aberrant_overdrive 3` sono **numerici**
+  (<= pool); `cataclysm 75` / `arcane_lance 40` / `apocalypse_ray 100` sono **consume-all** (ultimate-tier:
+  surge_aoe AoE + stress_reset). I valori gonfiati leggono come sentinella "ultimate -> scarica il gauge"
+  (intento autoriale, 26-ECONOMY "Ultimate = consume all"). Rescalare cataclysm a `<=3` lo trasformerebbe
+  da **ultimate AoE** a **AoE ripetibile economico** = cambio di **identita'** dell'ability.
+  -> **KEEP consume-all** (raccomandato). MA: a differenza del PP, SG **supporta** il numerico (precedente
+  synaptic/aberrant) -> il rescale di cataclysm e' una **leva reversibile master-dd** (non anti-canon).
+
+**Decisione (band-neutral, reversibile):** **NESSUN rescale.** PP resta consume-all (canon-mandato);
+gli ultimate SG (cataclysm/arcane_lance/apocalypse_ray) restano consume-all (intento + modello-misto
+gia coerente). L'opzione "rescale ultimate -> numerico" e' **preservata come leva master-dd** con i valori
+pronti, NON scartata per sempre -> museum card `M-2026-06-02-002`
+(`docs/museum/cards/economy-rescale-ultimates-numeric-discard.md`).
+
+**Se master-dd vuole il numerico** (override reversibile, 1 valore-dato per ability, nessun codice):
+
+| Ability (rank-2)    | Pool | Oggi (consume-all) | Numerico proposto |
+| ------------------- | :--: | -----------------: | ----------------: |
+| cataclysm           |  SG  |                 75 |          3 (≤cap) |
+| blade_flurry        |  PP  |                  6 |    2 (anti-canon) |
+| resonance_amplifier |  PP  |                  4 |    2 (anti-canon) |
+| kill_shot           |  PP  |                  6 |    2 (anti-canon) |
+| deathmark           |  PP  |                  4 |    2 (anti-canon) |
+
+> Nota: i valori PP-numerici sono elencati per completezza ma **sconsigliati** (anti-canon). Solo
+> cataclysm-numerico e' una leva legittima (SG mixed-model). Il gate-engine non cambia: abbassare il
+> dato sotto `pool` flippa automaticamente quell'ability da consume-all a numerico.
 
 ## Stato (questo PR) -- SG cost-gate SHIPPED
 
@@ -43,7 +97,11 @@ Implementato in `abilityExecutor.executeAbility` (option C, master-dd 2026-06-02
 - ⚠️ **NB cataclysm** e' `rank: 2` per label ma `cost_sg: 75` (ultimate-tier) -> trattato consume-all dal
   cost-threshold. Se master-dd lo vuole numerico, set `cost_sg <= 3` nel dato.
 
-## Residuo gated -- PP/PT (verdetto numerico master-dd)
+## Residuo gated -- PP/PT (verdetto numerico master-dd) — SUPERSEDED (PP #2555 + PT #2557 shipped)
+
+> ⚠️ **SUPERSEDED 2026-06-02**: questa sezione (PP/PT "non gatabili senza verdetto balance") era
+> SBAGLIATA — le earn-curve erano canon. PP e PT sono ora SHIPPED (vedi UPDATE in cima). Conservata
+> sotto per provenance / lezione currency-gate.
 
 ### Perche' NON e' stato gatato ora
 


### PR DESCRIPTION
## Cosa

Chiusura design Fase-2 economy (doc-only, **nessun cambio codice/dati**):

1. **Aggiorna** `docs/superpowers/specs/2026-06-02-economy-cost-gate-pp-pt-followup.md`: il **PT cost-gate + pool e' SHIPPED** ([#2557](https://github.com/MasterDD-L34D/Game/pull/2557)). La framing stale "PP/PT decorativi / Residuo gated / earn-curve = leva balance non validabile" e' marcata **SUPERSEDED** (SG #2554 + PP #2555 + PT #2557 tutti shipped). Stessa lezione currency-gate: le earn-curve PP/PT erano GIA canon in `26-ECONOMY`.

2. **Verdetto rescale rank-2** (autonomia su evidenza, task §2 del handoff): **KEEP consume-all**.
   - **PP numerico = anti-canon**: il SoT `26-ECONOMY §PP` fissa SOLO "Ultimate = 3 PP consume all"; ZERO cost_pp ≤ 3 nel catalogo (tutti 4..12). Rescalare i rank-2 PP a numerico inventerebbe una spesa PP sub-ultimate non canonica.
   - **SG ultimate** (cataclysm 75 / arcane_lance 40 / apocalypse_ray 100) = sentinella consume-all (intento autoriale + SG ha gia un modello misto: synaptic 2 / aberrant 3 numerici). Rescalare cataclysm cambia l'identita' (ultimate AoE -> AoE ripetibile).
   - L'opzione numerica e' **preservata come leva reversibile master-dd** (cataclysm legittimo, PP sconsigliato) con i valori pronti.

3. **Museum card** `M-2026-06-02-002` (`economy-rescale-ultimates-numeric-discard.md`): preserva l'opzione scartata (no-anticipated-judgment).

## Note

- **Task 3 GAP-C brainstorm** (handoff §3) era GIA shipped (#2554: `2026-06-02-gapc-fase3-4-build-vs-gate.md` verdetto GATE + museum card M-2026-06-02-001) -> nessuna azione (anti-pattern #19 verify-first).
- governance `--strict` errors=0; prettier verde.

## Rollback

`git revert` (doc-only, zero impatto runtime).

Coding-Agent: claude-opus-4.8