### PR TITLE
fix(sot-drift): map combat/** to 26-ECONOMY canon (close blind spot)

### DIFF
--- a/.github/sot-drift/watch-map.yml
+++ b/.github/sot-drift/watch-map.yml
@@ -5,8 +5,8 @@
   sot_ref: ["core/00-SOURCE-OF-TRUTH.md#24", "core/90-FINAL-DESIGN-FREEZE.md#21.3"]
   concept: "modello genetico D-HEIR/D-REPRO"
 - pattern: "apps/backend/services/combat/**"
-  sot_ref: ["core/10-SISTEMA_TATTICO.md", "core/11-REGOLE_D20_TV.md"]
-  concept: "combat d20 / round loop"
+  sot_ref: ["core/10-SISTEMA_TATTICO.md", "core/11-REGOLE_D20_TV.md", "core/26-ECONOMY_CANONICAL.md"]
+  concept: "combat d20 / round loop / economy (PT)"
 - pattern: "data/core/economy*"
   sot_ref: ["core/26-ECONOMY_CANONICAL.md"]
   concept: "economia PT/PP/SG"


### PR DESCRIPTION
## What
Adds `core/26-ECONOMY_CANONICAL.md` to the `apps/backend/services/combat/**` entry in the sot-drift sentinel path-map (`.github/sot-drift/watch-map.yml`).

## Why (blind spot found via the fleet-governor)
The codemasterdd fleet-governor surfaced sot-drift issue #2477 ("runtime ahead of SoT docs"). On verdict it was **NOT-STALE / false-positive** -- the PT-economy runtime (PR #2557) was built to conform to the existing `26-ECONOMY_CANONICAL.md` §PT canon. But the verdict exposed a **path-map blind spot**:
- `combat/**` mapped only to docs `10-SISTEMA_TATTICO` + `11-REGOLE_D20_TV`.
- The authoritative doc for combat **economy** (PT/PP/SG) is `26-ECONOMY_CANONICAL.md`, which was mapped ONLY to `data/core/economy*`.
- So a combat-economy change (e.g. `ptTracker.js`) was flagged against the wrong docs, AND a **real** future economy drift originating in `combat/**` would be checked against 10/11 and **missed**.

## Fix
One-line: `combat/**` sot_ref now includes `26-ECONOMY_CANONICAL.md` (+ concept note). Conservative -- only adds the canonical economy doc that combat code provably touches.

Closes the detection gap behind #2477 (which is closed as no-drift).

[Claude Code]
