### PR TITLE
feat(sim): full-loop runner MVP - real combat joins the campaign (fase-1b)

### DIFF
--- a/tests/sim/fullLoopInvariants.test.js
+++ b/tests/sim/fullLoopInvariants.test.js
@@ -1,0 +1,41 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { checkInvariants } = require('../../tools/sim/full-loop-invariants');
+
+test('checkInvariants: a clean step has no violations', () => {
+  assert.deepEqual(
+    checkInvariants({
+      advanceStatus: 200,
+      outcome: 'victory',
+      peEarned: 3,
+      survivors: ['a'],
+      sourceRosterIds: ['a', 'b'],
+    }),
+    [],
+  );
+});
+
+test('checkInvariants: flags non-200 advance, bad outcome, negative pe, and foreign survivor', () => {
+  const v = checkInvariants({
+    advanceStatus: 500,
+    outcome: 'win',
+    peEarned: -1,
+    survivors: ['ghost'],
+    sourceRosterIds: ['a', 'b'],
+  });
+  assert.equal(v.length, 4, JSON.stringify(v));
+});
+
+test('checkInvariants: survivors must be a subset of the source roster (roster identity)', () => {
+  assert.deepEqual(
+    checkInvariants({
+      advanceStatus: 200,
+      outcome: 'defeat',
+      peEarned: 0,
+      survivors: [],
+      sourceRosterIds: ['a', 'b'],
+    }),
+    [],
+  );
+});

--- a/tests/sim/fullLoopRunner.test.js
+++ b/tests/sim/fullLoopRunner.test.js
@@ -1,0 +1,82 @@
+'use strict';
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+const { runFullLoop } = require('../../tools/sim/full-loop-runner');
+
+function supertestHttp(app) {
+  return {
+    post: (path, body) =>
+      request(app)
+        .post(path)
+        .send(body)
+        .then((r) => ({ status: r.status, body: r.body })),
+    get: (path, query) =>
+      request(app)
+        .get(path)
+        .query(query || {})
+        .then((r) => ({ status: r.status, body: r.body })),
+  };
+}
+
+function starterRoster() {
+  return [
+    {
+      id: 'hero_a',
+      species: 'dune_stalker',
+      job: 'stalker',
+      hp: 30,
+      max_hp: 30,
+      ap: 3,
+      mod: 20,
+      attack_range: 2,
+      initiative: 18,
+      position: { x: 1, y: 1 },
+      controlled_by: 'player',
+      status: {},
+    },
+    {
+      id: 'hero_b',
+      species: 'velox',
+      job: 'stalker',
+      hp: 30,
+      max_hp: 30,
+      ap: 3,
+      mod: 18,
+      attack_range: 2,
+      initiative: 16,
+      position: { x: 1, y: 2 },
+      controlled_by: 'player',
+      status: {},
+    },
+  ];
+}
+
+test('runFullLoop: AI plays the cave_path campaign end-to-end with REAL combat -> completed, invariants clean', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const http = supertestHttp(app);
+
+  const res = await runFullLoop(http, {
+    playerId: 'fl_e2e',
+    roster: starterRoster(),
+    branchKey: 'cave_path',
+    seed: 'fl1b',
+    maxChapters: 15,
+  });
+
+  assert.equal(res.completed, true, `campaign completed; chapters=${JSON.stringify(res.chapters)}`);
+  assert.deepEqual(
+    res.violations,
+    [],
+    `no invariant violations: ${JSON.stringify(res.violations)}`,
+  );
+  // cave_path = 5 tutorials + savana + cave + boss -> at least 5 chapters really played.
+  assert.ok(res.chapters.length >= 5, `multiple chapters played, got ${res.chapters.length}`);
+  // Every recorded outcome is real (the combat actually ran, not a faked stamp).
+  assert.ok(res.chapters.every((c) => ['victory', 'defeat', 'timeout'].includes(c.outcome)));
+});

--- a/tools/sim/campaign-driver.js
+++ b/tools/sim/campaign-driver.js
@@ -1,0 +1,30 @@
+'use strict';
+// Thin wrappers over the /api/campaign/* seam (shapes verified against
+// tests/api/campaignIntegration.test.js). Injected `http` (supertest in tests,
+// fetch in production) keeps the full-loop runner unit-testable.
+
+function start(http, { playerId, campaignDefId } = {}) {
+  return http.post('/api/campaign/start', {
+    player_id: playerId,
+    ...(campaignDefId ? { campaign_def_id: campaignDefId } : {}),
+  });
+}
+
+function summary(http, id) {
+  return http.get('/api/campaign/summary', { id });
+}
+
+function advance(http, { id, outcome, peEarned = 0, survivors } = {}) {
+  return http.post('/api/campaign/advance', {
+    id,
+    outcome,
+    pe_earned: peEarned,
+    ...(survivors ? { survivors } : {}),
+  });
+}
+
+function choose(http, { id, branchKey } = {}) {
+  return http.post('/api/campaign/choose', { id, branch_key: branchKey });
+}
+
+module.exports = { start, summary, advance, choose };

--- a/tools/sim/full-loop-invariants.js
+++ b/tools/sim/full-loop-invariants.js
@@ -1,0 +1,18 @@
+'use strict';
+// Per-step integration invariants for the full-loop runner (fase-1b). Pure: given
+// one chapter's result, return a list of violation strings (empty = clean). The
+// runner aggregates these so a regression that breaks the loop surfaces as a
+// concrete failing invariant instead of a silent pass.
+
+function checkInvariants({ advanceStatus, outcome, peEarned, survivors, sourceRosterIds } = {}) {
+  const v = [];
+  if (advanceStatus !== 200) v.push(`advance status ${advanceStatus} != 200`);
+  if (!['victory', 'defeat', 'timeout'].includes(outcome)) v.push(`invalid outcome ${outcome}`);
+  if (!(Number(peEarned) >= 0)) v.push(`pe_earned ${peEarned} < 0`);
+  const src = Array.isArray(sourceRosterIds) ? sourceRosterIds : [];
+  const foreign = (survivors || []).filter((id) => !src.includes(id));
+  if (foreign.length) v.push(`foreign survivor ids: ${foreign.join(',')}`);
+  return v;
+}
+
+module.exports = { checkInvariants };

--- a/tools/sim/full-loop-runner.js
+++ b/tools/sim/full-loop-runner.js
@@ -1,0 +1,113 @@
+'use strict';
+// Full-loop AI-playtest runner — MVP fase-1b-1. Makes the AI play the WHOLE loop
+// end-to-end: a campaign chain where each chapter's combat is REALLY played (not a
+// faked `outcome:'victory'` stamp like campaignIntegration.test.js), the real
+// outcome feeds /campaign/advance, branch nodes are chosen, and survivors carry
+// across chapters (attrition). Per-step integration invariants are checked.
+//
+// Scope (fase-1b-1): the campaign+combat JOIN under AI-play + invariants. The Nido
+// meta-step (recruit/mating/affinity) + scaled-enemy balance bands = fase-1b-2/fase-2.
+// Enemies here are a weak deterministic set so the loop progresses to completion
+// (the value is the integration, not the difficulty curve).
+
+const driver = require('./campaign-driver');
+const { runEncounter } = require('./combat-adapter');
+const { checkInvariants } = require('./full-loop-invariants');
+
+// Fresh per-mission copy of the alive roster: full HP + cleared status, original
+// positions (each combat is a new session; survivors persist across missions, hp
+// is restored between missions — typical campaign convention).
+function freshRoster(roster, aliveIds) {
+  return roster
+    .filter((u) => aliveIds.includes(u.id))
+    .map((u) => ({ ...u, hp: u.max_hp ?? u.hp, status: {} }));
+}
+
+// Weak deterministic enemy for a chapter (MVP). fase-2 swaps in scaled scenario
+// enemies (encounter YAML) for real attrition/completion bands.
+function enemiesForChapter(step) {
+  return [
+    {
+      id: `foe_${step}`,
+      species: 'velox',
+      hp: 4,
+      max_hp: 4,
+      ap: 1,
+      mod: 0,
+      dc: 1,
+      attack_range: 1,
+      initiative: 1,
+      position: { x: 1, y: 4 },
+      controlled_by: 'sistema',
+      status: {},
+    },
+  ];
+}
+
+async function runFullLoop(
+  http,
+  { playerId, roster, branchKey = 'cave_path', seed, peEarned = 3, maxChapters = 15 } = {},
+) {
+  const sourceRosterIds = (roster || []).map((u) => u.id);
+  const startRes = await driver.start(http, { playerId });
+  if (startRes.status !== 201) {
+    return {
+      completed: false,
+      chapters: [],
+      violations: [{ step: 0, v: [`start status ${startRes.status} != 201`] }],
+      finalRoster: [],
+    };
+  }
+  const id = startRes.body.campaign.id;
+
+  let aliveIds = [...sourceRosterIds];
+  const chapters = [];
+  const violations = [];
+  let completed = false;
+
+  for (let step = 1; step <= maxChapters; step += 1) {
+    const sum = await driver.summary(http, id);
+    const enc = sum.body?.current_encounter?.encounter_id || `chapter_${step}`;
+    const aliveRoster = freshRoster(roster, aliveIds);
+    if (aliveRoster.length === 0) {
+      violations.push({ step, v: ['roster wiped before chapter'] });
+      break;
+    }
+
+    const combat = await runEncounter(http, {
+      roster: aliveRoster,
+      enemies: enemiesForChapter(step),
+      scenarioId: enc,
+      seed: seed ? `${seed}-${step}` : undefined,
+      maxRounds: 40,
+    });
+    aliveIds = combat.survivorIds;
+    const survivors = roster
+      .filter((u) => aliveIds.includes(u.id))
+      .map((u) => ({ id: u.id, job: u.job }));
+
+    const adv = await driver.advance(http, { id, outcome: combat.outcome, peEarned, survivors });
+    const v = checkInvariants({
+      advanceStatus: adv.status,
+      outcome: combat.outcome,
+      peEarned,
+      survivors: aliveIds,
+      sourceRosterIds,
+    });
+    if (v.length) violations.push({ step, v });
+    chapters.push({ step, encounter: enc, outcome: combat.outcome, survivors: aliveIds.length });
+
+    if (adv.body && adv.body.choice_required) {
+      await driver.choose(http, { id, branchKey });
+    }
+    if (adv.body && adv.body.campaign_completed) {
+      completed = true;
+      break;
+    }
+    if (adv.status !== 200) break;
+  }
+
+  return { completed, chapters, violations, finalRoster: aliveIds };
+}
+
+module.exports = { runFullLoop, enemiesForChapter };


### PR DESCRIPTION
## Cosa

**Fase-1b-1 del full-loop AI-playtest runner** (spec [#2559](https://github.com/MasterDD-L34D/Game/pull/2559), dopo fase-0 [#2561](https://github.com/MasterDD-L34D/Game/pull/2561)). L'AI ora gioca il **loop intero** end-to-end.

**Il gap che chiude**: prima d'ora il combat era AI-giocato **in isolamento** (combat-sim) e la campagna testata con **esiti FINTI** (`outcome:'victory'` stampato in `campaignIntegration.test.js`). **Mai uniti sotto AI-play.** Ora: `start campagna → per capitolo[ combat REALE (combatAdapter col roster portato) → /campaign/advance(esito vero) → choose branch → survivors carry ] → completed`.

## Moduli (3 nuovi, isolati)

- `campaign-driver.js` — wrappers `/api/campaign/{start,summary,advance,choose}` (shapes verify-first vs `campaignIntegration.test.js`).
- `full-loop-invariants.js` — puro: `advance==200`, outcome valido, `pe≥0`, **identità-roster** (survivors ⊆ roster sorgente).
- `full-loop-runner.js` — orchestratore cave_path; enemy weak deterministico (MVP: il valore è l'integrazione, non la curva difficoltà).

## Test

- `fullLoopInvariants` 3/3 (puro).
- `fullLoopRunner` 1/1 — **l'AI completa cave_path con REAL combat, 0 violazioni invarianti, ≥5 capitoli giocati**. (10/10 sim totali.)

## Band-safe

Zero engine change (solo `tools/sim/`, moduli opt-in). `apps/backend` intoccato.

## Scope

Integrazione campaign+combat. **NEXT (fase-1b-2)**: Nido meta-step (`greedyPolicy` recruit/mating/affinity via `meta.js` seam) + invarianti meta. **fase-2**: enemy scaled (encounter YAML) + band-metriche + `mbtiPolicy` + routing test-context + N=40.

## Rollback

`git revert` — moduli opt-in, nessun runtime di gioco li chiama.

Coding-Agent: claude-opus-4.8