### PR TITLE
feat(sim): full-loop Nido meta-step - AI recruits each chapter (fase-1b-2)

### DIFF
--- a/tests/sim/fullLoopRunner.test.js
+++ b/tests/sim/fullLoopRunner.test.js
@@ -88,3 +88,50 @@ test('runFullLoop: AI plays the cave_path campaign end-to-end with REAL combat -
     `no meta violations: ${JSON.stringify(res.metaViolations)}`,
   );
 });
+
+test('runFullLoop: does NOT recruit when /campaign/advance rejects a victory chapter (Codex #2563 P2)', async () => {
+  // Fake http: combat wins (state has no enemies) but /campaign/advance returns 409
+  // (finalized/race). The campaign did NOT clear the chapter, so the Nido meta-step
+  // must be skipped -> /api/meta/recruit is never called.
+  const calls = [];
+  const http = {
+    post: async (path) => {
+      calls.push(path);
+      if (path === '/api/campaign/start') return { status: 201, body: { campaign: { id: 'c' } } };
+      if (path === '/api/session/start') return { status: 200, body: { session_id: 's' } };
+      if (path === '/api/campaign/advance') return { status: 409, body: { error: 'finalized' } };
+      if (path === '/api/meta/recruit') return { status: 200, body: { success: true } };
+      return { status: 200, body: {} };
+    },
+    get: async (path) => {
+      if (path === '/api/session/state') {
+        // No alive sistema units -> runEncounter resolves to 'victory' immediately.
+        return {
+          status: 200,
+          body: {
+            units: [{ id: 'hero_a', controlled_by: 'player', hp: 30 }],
+            active_unit: 'hero_a',
+          },
+        };
+      }
+      if (path === '/api/campaign/summary')
+        return { status: 200, body: { current_encounter: { encounter_id: 'e1' } } };
+      return { status: 200, body: {} };
+    },
+  };
+  const res = await runFullLoop(http, {
+    playerId: 'p',
+    roster: [
+      {
+        id: 'hero_a',
+        max_hp: 30,
+        job: 'stalker',
+        position: { x: 1, y: 1 },
+        controlled_by: 'player',
+      },
+    ],
+    maxChapters: 3,
+  });
+  assert.deepEqual(res.recruited, [], 'no recruit on a rejected advance');
+  assert.ok(!calls.includes('/api/meta/recruit'), 'meta/recruit never called when advance != 200');
+});

--- a/tests/sim/fullLoopRunner.test.js
+++ b/tests/sim/fullLoopRunner.test.js
@@ -79,4 +79,12 @@ test('runFullLoop: AI plays the cave_path campaign end-to-end with REAL combat -
   assert.ok(res.chapters.length >= 5, `multiple chapters played, got ${res.chapters.length}`);
   // Every recorded outcome is real (the combat actually ran, not a faked stamp).
   assert.ok(res.chapters.every((c) => ['victory', 'defeat', 'timeout'].includes(c.outcome)));
+  // fase-1b-2 Nido meta-step: the AI loop recruits via /api/meta/recruit on each
+  // cleared chapter -> the Nido seam is really exercised end-to-end, no failures.
+  assert.ok(res.recruited.length >= 5, `recruited across chapters, got ${res.recruited.length}`);
+  assert.deepEqual(
+    res.metaViolations,
+    [],
+    `no meta violations: ${JSON.stringify(res.metaViolations)}`,
+  );
 });

--- a/tests/sim/greedyPolicy.test.js
+++ b/tests/sim/greedyPolicy.test.js
@@ -1,0 +1,15 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { chooseRecruits } = require('../../tools/sim/greedy-policy');
+
+test('chooseRecruits: one deterministic recruit id per cleared chapter', () => {
+  assert.deepEqual(chooseRecruits({ step: 1 }), ['recruit_s1']);
+  assert.deepEqual(chooseRecruits({ step: 4 }), ['recruit_s4']);
+});
+
+test('chooseRecruits: distinct ids across steps (roster grows, no collision)', () => {
+  const a = chooseRecruits({ step: 1 })[0];
+  const b = chooseRecruits({ step: 2 })[0];
+  assert.notEqual(a, b);
+});

--- a/tools/sim/full-loop-runner.js
+++ b/tools/sim/full-loop-runner.js
@@ -13,6 +13,27 @@
 const driver = require('./campaign-driver');
 const { runEncounter } = require('./combat-adapter');
 const { checkInvariants } = require('./full-loop-invariants');
+const greedyPolicy = require('./greedy-policy');
+
+// Nido meta-step (fase-1b-2): after a cleared chapter the greedy policy recruits
+// NPCs via the meta seam (POST /api/meta/recruit, affinity_at_recruit bypass ->
+// getOrCreate NPC, gate satisfied). Recruits land in party_rosters (Nido); feeding
+// the recruit back into combat (stat-resolution) is fase-2. Returns recruited ids +
+// failures so the runner can assert the Nido seam was really exercised.
+async function applyMetaStep(http, { id, step }) {
+  const recruited = [];
+  const failures = [];
+  for (const npcId of greedyPolicy.chooseRecruits({ step })) {
+    const r = await http.post('/api/meta/recruit', {
+      npc_id: npcId,
+      affinity_at_recruit: 1,
+      campaign_id: id,
+    });
+    if (r.status === 200 && r.body && r.body.success) recruited.push(npcId);
+    else failures.push({ npcId, status: r.status });
+  }
+  return { recruited, failures };
+}
 
 // Fresh per-mission copy of the alive roster: full HP + cleared status, original
 // positions (each combat is a new session; survivors persist across missions, hp
@@ -63,6 +84,8 @@ async function runFullLoop(
   let aliveIds = [...sourceRosterIds];
   const chapters = [];
   const violations = [];
+  const recruited = [];
+  const metaViolations = [];
   let completed = false;
 
   for (let step = 1; step <= maxChapters; step += 1) {
@@ -97,6 +120,14 @@ async function runFullLoop(
     if (v.length) violations.push({ step, v });
     chapters.push({ step, encounter: enc, outcome: combat.outcome, survivors: aliveIds.length });
 
+    // Nido meta-step on a cleared chapter (recruit). Additive: never blocks the
+    // campaign flow; failures surface as metaViolations.
+    if (combat.outcome === 'victory') {
+      const meta = await applyMetaStep(http, { id, step });
+      recruited.push(...meta.recruited);
+      if (meta.failures.length) metaViolations.push({ step, failures: meta.failures });
+    }
+
     if (adv.body && adv.body.choice_required) {
       await driver.choose(http, { id, branchKey });
     }
@@ -107,7 +138,7 @@ async function runFullLoop(
     if (adv.status !== 200) break;
   }
 
-  return { completed, chapters, violations, finalRoster: aliveIds };
+  return { completed, chapters, violations, finalRoster: aliveIds, recruited, metaViolations };
 }
 
 module.exports = { runFullLoop, enemiesForChapter };

--- a/tools/sim/full-loop-runner.js
+++ b/tools/sim/full-loop-runner.js
@@ -120,9 +120,12 @@ async function runFullLoop(
     if (v.length) violations.push({ step, v });
     chapters.push({ step, encounter: enc, outcome: combat.outcome, survivors: aliveIds.length });
 
-    // Nido meta-step on a cleared chapter (recruit). Additive: never blocks the
-    // campaign flow; failures surface as metaViolations.
-    if (combat.outcome === 'victory') {
+    // Nido meta-step on a TRULY cleared chapter (recruit). Gated on a 200 advance
+    // (Codex #2563 P2): if combat won but /campaign/advance rejected the chapter
+    // (409 finalized / 500 missing def / race), the campaign did NOT clear it, so
+    // we must NOT mutate Nido/meta state for it. Additive otherwise; failures ->
+    // metaViolations.
+    if (adv.status === 200 && combat.outcome === 'victory') {
       const meta = await applyMetaStep(http, { id, step });
       recruited.push(...meta.recruited);
       if (meta.failures.length) metaViolations.push({ step, failures: meta.failures });

--- a/tools/sim/full-loop-runner.js
+++ b/tools/sim/full-loop-runner.js
@@ -29,8 +29,20 @@ async function applyMetaStep(http, { id, step }) {
       affinity_at_recruit: 1,
       campaign_id: id,
     });
-    if (r.status === 200 && r.body && r.body.success) recruited.push(npcId);
-    else failures.push({ npcId, status: r.status });
+    // Count a recruit only when the metaProgression store actually marked the NPC
+    // `recruited:true` (the canonical, DB-INDEPENDENT recruit state set in-memory),
+    // not merely a 200 (Codex #2563 P2): the `party_rosters` upsert in meta.js is
+    // best-effort/DB-dependent, so a 200 with a no-op roster write would otherwise
+    // false-green. This tracks the recruit MECHANIC (affinity->trust->recruited),
+    // not the party_rosters persistence layer (out of scope for the option-a seam).
+    const recruitedOk =
+      r.status === 200 &&
+      r.body &&
+      r.body.success === true &&
+      r.body.npc &&
+      r.body.npc.recruited === true;
+    if (recruitedOk) recruited.push(npcId);
+    else failures.push({ npcId, status: r.status, success: r.body && r.body.success });
   }
   return { recruited, failures };
 }

--- a/tools/sim/greedy-policy.js
+++ b/tools/sim/greedy-policy.js
@@ -1,0 +1,18 @@
+'use strict';
+// Greedy Nido meta policy (fase-1b-2). MVP: recruit one NPC per cleared chapter.
+//
+// NPC model (routes/meta.js + metaProgression.js): getOrCreate -> ANY id is
+// recruitable; `affinity_at_recruit >= 1` bypasses the canonical gate
+// (affinity>=0 & trust>=2), codifying the "defeat-then-recruit" emergent flow
+// (meta.js:172-197). Grounded: wesnoth recruit/retain economy
+// (docs/guide/games-source-index.md) + the §8 decision method (manuali GM:
+// allocare la "scorta" dove massimizza il valore-per-soglia).
+//
+// Structured so chooseMatings / spendAffinity slot in next (fase-1b-3) without
+// touching the runner's call shape.
+
+function chooseRecruits({ step } = {}) {
+  return [`recruit_s${step}`];
+}
+
+module.exports = { chooseRecruits };


### PR DESCRIPTION
## Cosa

**Fase-1b-2**: estende il full-loop runner ([#2562](https://github.com/MasterDD-L34D/Game/pull/2562)) col **meta-step Nido**. Ora l'AI gioca il **meta-loop COMPLETO**: `campagna → combat reale → advance → **Nido recruit** → choose → completed`.

Dopo ogni capitolo vinto la `greedyPolicy` recluta un NPC via `POST /api/meta/recruit` (`affinity_at_recruit:1` bypassa il gate `affinity>=0 & trust>=2` = flusso canonico *defeat-then-recruit*, `meta.js:172-197`; NPC `getOrCreate` = qualunque id). Verify-first: meta seam reachable via createApp (`NEST 200 / AFFINITY 200 / RECRUIT 200 success:true`).

## Moduli

- `greedy-policy.js` — `chooseRecruits` (struttura per `chooseMatings`/`spendAffinity` next). Grounded: wesnoth recruit/retain (games-source-index) + §8 decision-method (manuali GM).
- `full-loop-runner.js` — `applyMetaStep` **additivo** (solo su victory, non blocca il campaign-flow) + ritorna `recruited` + `metaViolations`.

## Test

`greedy` 2/2 + runner (recruited≥5, **metaViolations vuoto** = Nido seam esercitato end-to-end). **12/12 sim**.

## Self-review (Codex down - usage limit)

Codex non disponibile → self-review rigorosa: recruit verificato success via probe; meta-step additivo non-blocking; meta plugin carica in createApp ("8 plugins loaded: ...meta..."); recruit ids distinti per step (no dup). Band-safe (zero engine change, solo `tools/sim`).

## Stato: OPEN per review Codex

🔵 **Lasciato APERTO** (no auto-merge) per la review Codex al ritorno (usage limit), come da tua indicazione "Codex farà le review dei risultati".

## Scope

Option-a recruit-seam (recruited → `party_rosters`/Nido). Far **combattere** il recruited (stat-resolution) + mating/affinity = fase-1b-3/fase-2.

## Rollback

`git revert` — moduli opt-in.

Coding-Agent: claude-opus-4.8