### PR TITLE
feat(sim): recruits fight next mission via faithful stats (fase-1b-3a)

### DIFF
--- a/docs/superpowers/specs/2026-06-02-full-loop-fase1b3a-recruit-combat-design.md
+++ b/docs/superpowers/specs/2026-06-02-full-loop-fase1b3a-recruit-combat-design.md
@@ -1,0 +1,72 @@
+---
+title: 'Full-loop fase-1b-3a -- recruit -> combat stat-resolution (faithful)'
+date: 2026-06-02
+workstream: ops-qa
+category: spec
+doc_status: active
+doc_owner: master-dd
+language: it
+review_cycle_days: 30
+tags: [ai-playtest, meta-loop, recruit, combat, stat-resolution, full-loop]
+---
+
+# Full-loop fase-1b-3a -- recruit -> combat (stat-resolution faithful)
+
+> Slice di [`2026-06-02-full-loop-ai-playtest-runner-design.md`](2026-06-02-full-loop-ai-playtest-runner-design.md)
+> (spec #2559). Continua fase-1b-2 (#2563): l'NPC reclutato finiva in `party_rosters`/Nido
+> ma NON combatteva. Qui chiudiamo il loop **recruit -> combat**: il reclutato combatte
+> la missione successiva (attrition replacement, XCOM-LW2). Zero engine change (solo
+> `tools/sim/`) -> band-safe; Gate-5 eccezione methodology-tooling.
+
+## Design-call risolto (approvato master-dd)
+
+Come trasformare un NPC reclutato (solo `id`) in unita' di combattimento? Tre opzioni:
+
+1. **`deriveCombatStats` (faithful) -- SCELTA.** Riusa la derivazione canonica
+   `ecologyCombatAdapter.deriveCombatStats()` da YAML specie REALE (la stessa che usano
+   il pilota badlands e lo scaling nemici di fase-2). Nessun numero di balance inventato.
+2. Baseline template (stat-block fisso in `tools/sim`) -- zero coupling ma stat inventate
+   = band-unfaithful per le unita' reclutate.
+3. Clone archetipo roster -- stat plausibili ma non specie-specifiche.
+
+**Perche' (1):** e' un AI-_playtest_, la fedelta' e' lo scopo. La stessa derivazione
+serve i nemici scaled di fase-2 -> recruit e nemici misurati sulla stessa canon. La
+funzione e' tollerante (soft-default di ogni campo ecologia mancante, non lancia).
+
+## Componenti (`tools/sim/`, zero engine change)
+
+- **`greedy-policy.js`** -- `chooseRecruits({step})` ora ritorna `[{npcId, speciesId}]`.
+  La specie cicla deterministicamente nel pool canonico badlands (`RECRUIT_SPECIES_POOL`,
+  5 specie reali, role_class diversi: APEX/HAZARD/PREDATOR/PREY/SUPPORT).
+- **`recruit-resolver.js`** (NUOVO) -- `resolveRecruitUnit({npcId, speciesId, position})`:
+  `deriveCombatStats(loadBadlandsSpecies(speciesId))` -> unita' PLAYER (mirror
+  dell'assembly di `badlandsPilotScenario`, `controlled_by:'player'`, `max_hp=hp`,
+  `job: stats.job || 'vanguard'`). Riusa il loader badlands gia' testato.
+- **`full-loop-runner.js`** -- il roster CRESCE (starters U recruits): su capitolo chiuso
+  (`adv.status===200 && victory`, gate Codex #2563 P2) ogni recruit risolto entra in
+  roster + `aliveIds` -> combatte la missione dopo. Il set di id "noti" passato a
+  `checkInvariants` si allarga a (starters U recruited) cosi' un reclutato sopravvissuto
+  non e' un falso "foreign survivor". Ogni capitolo registra `rosterIds` (chi ha
+  combattuto) per provare la chiusura del loop.
+
+## Invariante (identity, allargata)
+
+`survivors subset (starters U recruited-so-far)`. Nessun cambio alla funzione
+`checkInvariants`: il runner passa l'universo-id che cresce. Semantica invariata
+("nessun combattente fantasma"), universo legittimamente crescente coi recruit.
+
+## Test (TDD, `node --test tests/sim/*.test.js` = 16/16)
+
+- `recruitResolver.test.js` (2): stat canoniche fedeli (no zeri inventati) + determinismo.
+- `greedyPolicy.test.js` (3): forma `{npcId,speciesId}` + id distinti + ciclo pool (wrap).
+- `fullLoopRunner.test.js`: e2e asserisce che `recruit_s1` (reclutato dopo cap.1) ha
+  combattuto un capitolo successivo (loop recruit->combat chiuso) + invariants clean
+  nonostante il roster cresca; mantiene il guard Codex #2563 P2.
+
+## Fuori scope (fase successive)
+
+- **fase-1b-3b**: `chooseMatings`/`chooseAffinity` nel greedy-policy (mating via
+  `/api/meta/mating` + `/api/meta/mating/roll`).
+- **fase-2**: pool specie generale (oltre badlands), nemici scaled (encounter YAML),
+  band-metriche meta (completion 40-70% XCOM-LW2, attrition, economia PE->PI), `mbtiPolicy`,
+  routing GAP-C test-context (`META_NETWORK_ROUTING=true`), N=40 (L-069 ratify).

--- a/tests/sim/fullLoopRunner.test.js
+++ b/tests/sim/fullLoopRunner.test.js
@@ -87,6 +87,16 @@ test('runFullLoop: AI plays the cave_path campaign end-to-end with REAL combat -
     [],
     `no meta violations: ${JSON.stringify(res.metaViolations)}`,
   );
+  // fase-1b-3a recruit -> combat: a unit recruited on a cleared chapter is resolved to
+  // a faithful canon-derived player unit and JOINS the next mission's combat roster
+  // (attrition replacement). Assert recruit_s1 (recruited after chapter 1) actually
+  // fought a later chapter -> the recruit -> combat feedback loop is closed.
+  assert.ok(
+    res.chapters.slice(1).some((c) => (c.rosterIds || []).includes('recruit_s1')),
+    `a recruited unit fought a later chapter; chapters=${JSON.stringify(
+      res.chapters.map((c) => ({ step: c.step, rosterIds: c.rosterIds })),
+    )}`,
+  );
 });
 
 test('runFullLoop: does NOT recruit when /campaign/advance rejects a victory chapter (Codex #2563 P2)', async () => {

--- a/tests/sim/fullLoopRunner.test.js
+++ b/tests/sim/fullLoopRunner.test.js
@@ -145,3 +145,55 @@ test('runFullLoop: does NOT recruit when /campaign/advance rejects a victory cha
   assert.deepEqual(res.recruited, [], 'no recruit on a rejected advance');
   assert.ok(!calls.includes('/api/meta/recruit'), 'meta/recruit never called when advance != 200');
 });
+
+test('runFullLoop: does NOT recruit on the campaign-completing chapter (Codex #2565 P2)', async () => {
+  // A victory whose advance completes the campaign (campaign_completed:true) has no next
+  // mission, so recruiting there would inflate finalRoster/recruited with a unit that
+  // never fights. The meta-step must be skipped on the completing chapter.
+  const calls = [];
+  const http = {
+    post: async (path) => {
+      calls.push(path);
+      if (path === '/api/campaign/start') return { status: 201, body: { campaign: { id: 'c' } } };
+      if (path === '/api/session/start') return { status: 200, body: { session_id: 's' } };
+      if (path === '/api/campaign/advance') {
+        return { status: 200, body: { campaign_completed: true } };
+      }
+      if (path === '/api/meta/recruit') {
+        return { status: 200, body: { success: true, npc: { recruited: true } } };
+      }
+      return { status: 200, body: {} };
+    },
+    get: async (path) => {
+      if (path === '/api/session/state') {
+        return {
+          status: 200,
+          body: {
+            units: [{ id: 'hero_a', controlled_by: 'player', hp: 30 }],
+            active_unit: 'hero_a',
+          },
+        };
+      }
+      if (path === '/api/campaign/summary') {
+        return { status: 200, body: { current_encounter: { encounter_id: 'e1' } } };
+      }
+      return { status: 200, body: {} };
+    },
+  };
+  const res = await runFullLoop(http, {
+    playerId: 'p',
+    roster: [
+      {
+        id: 'hero_a',
+        max_hp: 30,
+        job: 'stalker',
+        position: { x: 1, y: 1 },
+        controlled_by: 'player',
+      },
+    ],
+    maxChapters: 3,
+  });
+  assert.equal(res.completed, true, 'campaign completed');
+  assert.deepEqual(res.recruited, [], 'no recruit on the completing chapter');
+  assert.ok(!calls.includes('/api/meta/recruit'), 'meta/recruit not called on completion');
+});

--- a/tests/sim/greedyPolicy.test.js
+++ b/tests/sim/greedyPolicy.test.js
@@ -1,15 +1,25 @@
 'use strict';
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { chooseRecruits } = require('../../tools/sim/greedy-policy');
+const { chooseRecruits, RECRUIT_SPECIES_POOL } = require('../../tools/sim/greedy-policy');
 
-test('chooseRecruits: one deterministic recruit id per cleared chapter', () => {
-  assert.deepEqual(chooseRecruits({ step: 1 }), ['recruit_s1']);
-  assert.deepEqual(chooseRecruits({ step: 4 }), ['recruit_s4']);
+test('chooseRecruits: one recruit per cleared chapter with id + canonical species', () => {
+  assert.deepEqual(chooseRecruits({ step: 1 }), [
+    { npcId: 'recruit_s1', speciesId: RECRUIT_SPECIES_POOL[0] },
+  ]);
+  assert.deepEqual(chooseRecruits({ step: 4 }), [
+    { npcId: 'recruit_s4', speciesId: RECRUIT_SPECIES_POOL[3] },
+  ]);
 });
 
-test('chooseRecruits: distinct ids across steps (roster grows, no collision)', () => {
+test('chooseRecruits: distinct npc ids across steps (roster grows, no collision)', () => {
   const a = chooseRecruits({ step: 1 })[0];
   const b = chooseRecruits({ step: 2 })[0];
-  assert.notEqual(a, b);
+  assert.notEqual(a.npcId, b.npcId);
+});
+
+test('chooseRecruits: species cycles deterministically through the pool (wraps)', () => {
+  const len = RECRUIT_SPECIES_POOL.length;
+  assert.equal(chooseRecruits({ step: 1 })[0].speciesId, RECRUIT_SPECIES_POOL[0]);
+  assert.equal(chooseRecruits({ step: len + 1 })[0].speciesId, RECRUIT_SPECIES_POOL[0]);
 });

--- a/tests/sim/recruitResolver.test.js
+++ b/tests/sim/recruitResolver.test.js
@@ -1,0 +1,27 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { resolveRecruitUnit } = require('../../tools/sim/recruit-resolver');
+
+test('resolveRecruitUnit: real species -> faithful canonical stats as a player unit', () => {
+  const u = resolveRecruitUnit({
+    npcId: 'recruit_s1',
+    speciesId: 'sand-burrower',
+    position: { x: 2, y: 5 },
+  });
+  assert.equal(u.id, 'recruit_s1');
+  assert.equal(u.species, 'sand-burrower');
+  assert.equal(u.controlled_by, 'player');
+  assert.deepEqual(u.position, { x: 2, y: 5 });
+  // deriveCombatStats output is a viable combat unit (no invented zeros / no throw).
+  assert.ok(u.hp > 0, `hp > 0, got ${u.hp}`);
+  assert.equal(u.max_hp, u.hp, 'max_hp mirrors derived hp');
+  assert.ok(u.dc > 0 && u.mod >= 0 && u.attack_range >= 1);
+  assert.ok(typeof u.job === 'string' && u.job.length > 0, 'has a job for AI bias');
+});
+
+test('resolveRecruitUnit: deterministic (same species id -> identical unit)', () => {
+  const a = resolveRecruitUnit({ npcId: 'r', speciesId: 'dune-stalker', position: { x: 2, y: 1 } });
+  const b = resolveRecruitUnit({ npcId: 'r', speciesId: 'dune-stalker', position: { x: 2, y: 1 } });
+  assert.deepEqual(a, b);
+});

--- a/tools/sim/full-loop-runner.js
+++ b/tools/sim/full-loop-runner.js
@@ -1,55 +1,64 @@
 'use strict';
-// Full-loop AI-playtest runner — MVP fase-1b-1. Makes the AI play the WHOLE loop
-// end-to-end: a campaign chain where each chapter's combat is REALLY played (not a
-// faked `outcome:'victory'` stamp like campaignIntegration.test.js), the real
-// outcome feeds /campaign/advance, branch nodes are chosen, and survivors carry
-// across chapters (attrition). Per-step integration invariants are checked.
+// Full-loop AI-playtest runner. Makes the AI play the WHOLE loop end-to-end: a
+// campaign chain where each chapter's combat is REALLY played (not a faked
+// `outcome:'victory'` stamp), the real outcome feeds /campaign/advance, branch nodes
+// are chosen, survivors carry across chapters (attrition), and a cleared chapter
+// recruits an NPC into the Nido (fase-1b-2) that then FIGHTS the next mission as a
+// faithful, canon-derived unit (fase-1b-3a). Per-step integration invariants checked.
 //
-// Scope (fase-1b-1): the campaign+combat JOIN under AI-play + invariants. The Nido
-// meta-step (recruit/mating/affinity) + scaled-enemy balance bands = fase-1b-2/fase-2.
-// Enemies here are a weak deterministic set so the loop progresses to completion
-// (the value is the integration, not the difficulty curve).
+// Scope: the campaign + combat + Nido-recruit JOIN under AI-play + invariants. Enemies
+// here are a weak deterministic set so the loop progresses to completion (the value is
+// the integration; scaled-enemy balance bands + mating/affinity = fase-1b-3b/fase-2).
 
 const driver = require('./campaign-driver');
 const { runEncounter } = require('./combat-adapter');
 const { checkInvariants } = require('./full-loop-invariants');
 const greedyPolicy = require('./greedy-policy');
+const { resolveRecruitUnit } = require('./recruit-resolver');
 
-// Nido meta-step (fase-1b-2): after a cleared chapter the greedy policy recruits
-// NPCs via the meta seam (POST /api/meta/recruit, affinity_at_recruit bypass ->
-// getOrCreate NPC, gate satisfied). Recruits land in party_rosters (Nido); feeding
-// the recruit back into combat (stat-resolution) is fase-2. Returns recruited ids +
-// failures so the runner can assert the Nido seam was really exercised.
-async function applyMetaStep(http, { id, step }) {
+// Nido meta-step on a cleared chapter: the greedy policy recruits NPCs via the meta
+// seam (POST /api/meta/recruit, affinity_at_recruit bypass -> getOrCreate NPC), then
+// each recruit is resolved to a battle-ready PLAYER unit (recruit-resolver, faithful
+// canonical stats) so it can join combat next mission (attrition replacement). Returns
+// recruited ids + the resolved combat units + failures.
+async function applyMetaStep(http, { id, step, rosterSize = 0 }) {
   const recruited = [];
+  const units = [];
   const failures = [];
-  for (const npcId of greedyPolicy.chooseRecruits({ step })) {
+  const picks = greedyPolicy.chooseRecruits({ step });
+  for (let i = 0; i < picks.length; i += 1) {
+    const { npcId, speciesId } = picks[i];
     const r = await http.post('/api/meta/recruit', {
       npc_id: npcId,
+      species_id: speciesId,
       affinity_at_recruit: 1,
       campaign_id: id,
     });
     // Count a recruit only when the metaProgression store actually marked the NPC
-    // `recruited:true` (the canonical, DB-INDEPENDENT recruit state set in-memory),
-    // not merely a 200 (Codex #2563 P2): the `party_rosters` upsert in meta.js is
-    // best-effort/DB-dependent, so a 200 with a no-op roster write would otherwise
-    // false-green. This tracks the recruit MECHANIC (affinity->trust->recruited),
-    // not the party_rosters persistence layer (out of scope for the option-a seam).
+    // `recruited:true` (the canonical, DB-INDEPENDENT recruit state), not merely a 200
+    // (Codex #2563 P2): the party_rosters upsert is best-effort/DB-dependent.
     const recruitedOk =
       r.status === 200 &&
       r.body &&
       r.body.success === true &&
       r.body.npc &&
       r.body.npc.recruited === true;
-    if (recruitedOk) recruited.push(npcId);
-    else failures.push({ npcId, status: r.status, success: r.body && r.body.success });
+    if (recruitedOk) {
+      recruited.push(npcId);
+      // Recruits line up in column x:2 (starters/enemies use x:1), distinct rows, so a
+      // growing roster never overlaps a starting position.
+      const position = { x: 2, y: ((rosterSize + i) % 8) + 1 };
+      units.push(resolveRecruitUnit({ npcId, speciesId, position }));
+    } else {
+      failures.push({ npcId, status: r.status, success: r.body && r.body.success });
+    }
   }
-  return { recruited, failures };
+  return { recruited, units, failures };
 }
 
 // Fresh per-mission copy of the alive roster: full HP + cleared status, original
-// positions (each combat is a new session; survivors persist across missions, hp
-// is restored between missions — typical campaign convention).
+// positions (each combat is a new session; survivors persist across missions, hp is
+// restored between missions -- typical campaign convention).
 function freshRoster(roster, aliveIds) {
   return roster
     .filter((u) => aliveIds.includes(u.id))
@@ -77,11 +86,15 @@ function enemiesForChapter(step) {
   ];
 }
 
-async function runFullLoop(
-  http,
-  { playerId, roster, branchKey = 'cave_path', seed, peEarned = 3, maxChapters = 15 } = {},
-) {
-  const sourceRosterIds = (roster || []).map((u) => u.id);
+async function runFullLoop(http, opts = {}) {
+  const { playerId, branchKey = 'cave_path', seed, peEarned = 3, maxChapters = 15 } = opts;
+  // Roster GROWS as the Nido recruits: it starts as the authored party and gains a
+  // faithful combat unit per cleared chapter. knownIds is the matching id universe so a
+  // recruited survivor is never flagged as a "foreign" combatant by the identity
+  // invariant (starters U recruited-so-far).
+  const roster = [...(opts.roster || [])];
+  const knownIds = roster.map((u) => u.id);
+
   const startRes = await driver.start(http, { playerId });
   if (startRes.status !== 201) {
     return {
@@ -89,11 +102,13 @@ async function runFullLoop(
       chapters: [],
       violations: [{ step: 0, v: [`start status ${startRes.status} != 201`] }],
       finalRoster: [],
+      recruited: [],
+      metaViolations: [],
     };
   }
   const id = startRes.body.campaign.id;
 
-  let aliveIds = [...sourceRosterIds];
+  let aliveIds = [...knownIds];
   const chapters = [];
   const violations = [];
   const recruited = [];
@@ -127,19 +142,28 @@ async function runFullLoop(
       outcome: combat.outcome,
       peEarned,
       survivors: aliveIds,
-      sourceRosterIds,
+      sourceRosterIds: knownIds,
     });
     if (v.length) violations.push({ step, v });
-    chapters.push({ step, encounter: enc, outcome: combat.outcome, survivors: aliveIds.length });
+    chapters.push({
+      step,
+      encounter: enc,
+      outcome: combat.outcome,
+      survivors: aliveIds.length,
+      rosterIds: combat.rosterIds,
+    });
 
-    // Nido meta-step on a TRULY cleared chapter (recruit). Gated on a 200 advance
-    // (Codex #2563 P2): if combat won but /campaign/advance rejected the chapter
-    // (409 finalized / 500 missing def / race), the campaign did NOT clear it, so
-    // we must NOT mutate Nido/meta state for it. Additive otherwise; failures ->
-    // metaViolations.
+    // Nido meta-step on a TRULY cleared chapter (Codex #2563 P2: gated on a 200 advance,
+    // not just victory). Recruited units join the roster + alive pool so they fight the
+    // next mission -- the recruit -> combat feedback loop closed.
     if (adv.status === 200 && combat.outcome === 'victory') {
-      const meta = await applyMetaStep(http, { id, step });
+      const meta = await applyMetaStep(http, { id, step, rosterSize: roster.length });
       recruited.push(...meta.recruited);
+      for (const u of meta.units) {
+        roster.push(u);
+        aliveIds.push(u.id);
+        knownIds.push(u.id);
+      }
       if (meta.failures.length) metaViolations.push({ step, failures: meta.failures });
     }
 

--- a/tools/sim/full-loop-runner.js
+++ b/tools/sim/full-loop-runner.js
@@ -154,9 +154,13 @@ async function runFullLoop(http, opts = {}) {
     });
 
     // Nido meta-step on a TRULY cleared chapter (Codex #2563 P2: gated on a 200 advance,
-    // not just victory). Recruited units join the roster + alive pool so they fight the
-    // next mission -- the recruit -> combat feedback loop closed.
-    if (adv.status === 200 && combat.outcome === 'victory') {
+    // not just victory). Skipped on the campaign-completing chapter (Codex #2565 P2): a
+    // recruit there has no next mission to fight, so it would inflate finalRoster +
+    // recruit/attrition metrics with a unit that never entered combat. Recruited units
+    // join the roster + alive pool so they fight the next mission -- recruit -> combat
+    // feedback loop closed.
+    const hasNextChapter = !(adv.body && adv.body.campaign_completed);
+    if (adv.status === 200 && combat.outcome === 'victory' && hasNextChapter) {
       const meta = await applyMetaStep(http, { id, step, rosterSize: roster.length });
       recruited.push(...meta.recruited);
       for (const u of meta.units) {

--- a/tools/sim/greedy-policy.js
+++ b/tools/sim/greedy-policy.js
@@ -1,5 +1,5 @@
 'use strict';
-// Greedy Nido meta policy (fase-1b-2). MVP: recruit one NPC per cleared chapter.
+// Greedy Nido meta policy. MVP: recruit one NPC per cleared chapter.
 //
 // NPC model (routes/meta.js + metaProgression.js): getOrCreate -> ANY id is
 // recruitable; `affinity_at_recruit >= 1` bypasses the canonical gate
@@ -8,11 +8,25 @@
 // (docs/guide/games-source-index.md) + the §8 decision method (manuali GM:
 // allocare la "scorta" dove massimizza il valore-per-soglia).
 //
-// Structured so chooseMatings / spendAffinity slot in next (fase-1b-3) without
+// fase-1b-3a: each recruit now carries a SPECIES so the runner can resolve faithful
+// combat stats (recruit-resolver.js -> ecologyCombatAdapter.deriveCombatStats) and
+// the recruited unit actually fights the next mission. Species cycle deterministically
+// through the badlands canonical pool (5 real species, diverse role_class).
+//
+// Structured so chooseMatings / spendAffinity slot in next (fase-1b-3b) without
 // touching the runner's call shape.
 
+const RECRUIT_SPECIES_POOL = [
+  'dune-stalker', // T3 predatore_terziario_apex -> APEX
+  'nano-rust-bloom', // T3 minaccia_microbica -> HAZARD
+  'ferrocolonia-magnetotattica', // T2 predatore_regolatore_simbionte -> PREDATOR
+  'sand-burrower', // T1 erbivoro_primario -> PREY
+  'rust-scavenger', // T1 ingegneri_ecosistema -> SUPPORT
+];
+
 function chooseRecruits({ step } = {}) {
-  return [`recruit_s${step}`];
+  const speciesId = RECRUIT_SPECIES_POOL[(step - 1) % RECRUIT_SPECIES_POOL.length];
+  return [{ npcId: `recruit_s${step}`, speciesId }];
 }
 
-module.exports = { chooseRecruits };
+module.exports = { chooseRecruits, RECRUIT_SPECIES_POOL };

--- a/tools/sim/recruit-resolver.js
+++ b/tools/sim/recruit-resolver.js
@@ -1,0 +1,43 @@
+'use strict';
+// fase-1b-3a recruit->combat stat-resolution. Turns a recruited NPC (id + species)
+// into a battle-ready PLAYER unit using the SAME canonical derivation the worldgen
+// pilot and the fase-2 enemy scaling use: ecologyCombatAdapter.deriveCombatStats()
+// from REAL species YAML. So a recruited combatant carries FAITHFUL base stats (no
+// invented numbers) -> attrition replacements are measured on canon, not a guess.
+//
+// Recruit pool (MVP) = the badlands species, so we reuse the existing, tested
+// loadBadlandsSpecies loader (5 species, diverse role_class). fase-2 can broaden the
+// pool to a general species loader without changing this unit's shape.
+//
+// deriveCombatStats is tolerant (soft-defaults every missing ecology field, never
+// throws) -> a missing/odd species still yields a viable unit (T1 PREDATOR baseline).
+
+const { deriveCombatStats } = require('../../apps/backend/services/worldgen/ecologyCombatAdapter');
+const {
+  loadBadlandsSpecies,
+} = require('../../apps/backend/services/worldgen/badlandsPilotScenario');
+
+// Mirror of badlandsPilotScenario unit assembly, but controlled_by 'player'. Adds the
+// session-engine fields deriveCombatStats omits (max_hp, position, controlled_by,
+// status). initiative is intentionally omitted (the engine defaults it, as the
+// badlands enemies do).
+function resolveRecruitUnit({ npcId, speciesId, position } = {}) {
+  const stats = deriveCombatStats(loadBadlandsSpecies(speciesId));
+  return {
+    ...stats, // hp, ap, mod, dc, guardia, attack_range, traits, job, _adapter
+    id: npcId,
+    species: speciesId,
+    max_hp: stats.hp,
+    position: position || { x: 2, y: 1 },
+    facing: 'E',
+    controlled_by: 'player',
+    ai_profile: 'player',
+    elevation: 0,
+    // enemies need a job for AI bias; players keep one too (fallback when jobs_bias
+    // is empty, mirroring badlandsPilotScenario).
+    job: stats.job || 'vanguard',
+    status: {},
+  };
+}
+
+module.exports = { resolveRecruitUnit };


### PR DESCRIPTION
## fase-1b-3a — recruit -> combat (faithful stat-resolution)

Continuation of the full-loop AI-playtest runner (spec #2559). fase-1b-2 (#2563) recruited NPCs into the Nido/`party_rosters` but they did **not** fight. This closes the **recruit -> combat** feedback loop: a recruited NPC is resolved to a battle-ready PLAYER unit and joins the next mission's combat roster (attrition replacement, XCOM-LW2).

### Design-call (approved)
A recruit's combat stats come from the canonical `ecologyCombatAdapter.deriveCombatStats()` over **real species YAML** — the same derivation the badlands pilot and fase-2 enemy scaling use. **No invented balance numbers** (the point of an AI-*playtest* is fidelity). Alternatives (baseline template / clone archetype) rejected as band-unfaithful for recruited units.

### Changes (`tools/sim/` + `tests/sim/` + spec — zero engine change)
- **`greedy-policy.js`** — `chooseRecruits({step})` now returns `[{npcId, speciesId}]`; species cycle the badlands canonical pool (5 real species, diverse role_class).
- **`recruit-resolver.js`** (new) — `resolveRecruitUnit({npcId, speciesId, position})` -> player unit (`controlled_by:'player'`, `max_hp=hp`, `job` fallback `vanguard`); reuses the tested `loadBadlandsSpecies`.
- **`full-loop-runner.js`** — roster grows (starters ∪ recruits); recruited units join `aliveIds` after a 200-advance victory (Codex #2563 P2 guard preserved); the identity-invariant id universe widens so a recruited survivor is not a false `foreign-survivor`; per-chapter `rosterIds` recorded.
- **spec** — `docs/superpowers/specs/2026-06-02-full-loop-fase1b3a-recruit-combat-design.md`.

### Verification
- `node --test tests/sim/*.test.js` -> **16/16** (resolver 2 + greedy 3 + runner e2e+P2-guard + adapter/policy/invariants). e2e asserts `recruit_s1` fought a later chapter (loop closed) with invariants clean despite roster growth.
- `prettier --check` clean (7 files); `python tools/check_docs_governance.py --strict` -> **errors=0**.

### Scope / band safety
- **Band-safe**: zero engine change (only `tools/sim/`). Gate-5 exception = methodology-tooling.
- Out of scope: mating/affinity = fase-1b-3b; scaled enemies + meta band-metrics + N=40 = fase-2.

### Changelog
`feat(sim)`: recruited NPCs now fight subsequent missions with faithful canon-derived stats.

### Rollback (03A)
`git revert` this PR (squash). Pure tooling, no engine/schema/data change — revert is risk-free.