### PR TITLE
feat(sim): exercise Nido economy + breeding seam (fase-1b-3b)

### DIFF
--- a/docs/superpowers/specs/2026-06-02-full-loop-fase1b3b-nido-economy-design.md
+++ b/docs/superpowers/specs/2026-06-02-full-loop-fase1b3b-nido-economy-design.md
@@ -1,0 +1,72 @@
+---
+title: 'Full-loop fase-1b-3b -- Nido economy + breeding seam (affinity/mating)'
+date: 2026-06-02
+workstream: ops-qa
+category: spec
+doc_status: active
+doc_owner: master-dd
+language: it
+review_cycle_days: 30
+tags: [ai-playtest, meta-loop, nido, affinity, mating, breeding, full-loop]
+---
+
+# Full-loop fase-1b-3b -- Nido economy + breeding (affinity/mating seam)
+
+> Slice di [`2026-06-02-full-loop-ai-playtest-runner-design.md`](2026-06-02-full-loop-ai-playtest-runner-design.md)
+> (spec #2559), dopo fase-1b-3a (#2565, recruit->combat). Scope approvato master-dd =
+> **economy + mating seam**: l'AI esercita l'economia Nido (affinity/trust -> recruit
+> CANONICO senza bypass) + il breeding (mating roll -> offspring). Gli offspring NON
+> combattono ancora (deferred). Zero engine change (solo `tools/sim/`) -> band-safe.
+
+## Finding chiave (store-routing) -> ha plasmato il design
+
+Probe (`createApp({databasePath:null})` + supertest, verify-first):
+
+- `/api/meta/affinity` + `/api/meta/trust` scrivono il **default** store (IGNORANO
+  `campaign_id`). Bump affinity +1, trust +2 -> `can_recruit:true` (gate canonico
+  `RECRUIT_AFFINITY_MIN=0`, `RECRUIT_TRUST_MIN=2`).
+- `/api/meta/recruit` CON `campaign_id` usa `metaStoreFactory(campaignId)` = store
+  SEPARATO -> earned-affinity sul default store NON soddisfa quel gate (`gate_not_met`).
+  SENZA `campaign_id` -> stesso default store -> recruit no-bypass SUCCEDE.
+- `/api/meta/mating/roll {parent_a:{id}, parent_b:{id}, biome_id}` funziona in no-DB
+  (Prisma hydration best-effort/swallowed) -> `{success, offspring:{lineage_id, gene_slots,
+environmental_mutation, tier...}}`, registrato in `/api/meta/nest/offspring`.
+
+**Conseguenza (forzata, band-safe):** rendere il combat-recruit (3a, campaign+bypass)
+"earned senza bypass" richiederebbe `/affinity` campaign-scoped = ENGINE change. Quindi:
+il combat-recruit (3a) resta intatto (campaign+bypass, combatte); l'economia + il breeding
+si provano su **NPC courtship separati** sul default store. Coprono i seam, NON sono le
+unita' che combattono.
+
+## Componenti (`tools/sim/`)
+
+- **`greedy-policy.js`** -- `chooseCourtship({step})` -> `{npcId:'courtship_s<step>',
+speciesId(pool), affinityDelta:1, trustDelta:2}` (deltas che raggiungono il gate
+  canonico); `chooseMating({step})` -> `null` se step<2, altrimenti
+  `{parentA:'courtship_s<step-1>', parentB:'courtship_s<step>'}`.
+- **`nido-economy.js`** (NUOVO) -- `applyNidoEconomy(http,{step,biomeId})`: affinity+trust
+  -> recruit NO-bypass NO-campaign_id (earned gate) -> mating/roll (da step 2). Ritorna
+  `{earnedRecruits, offspring, affinityProven, failures}`. Additivo: i fallimenti vanno in
+  `failures`, non lancia.
+- **`full-loop-runner.js`** -- chiama `applyNidoEconomy` nel blocco capitolo-chiuso (stesso
+  gate `adv.status===200 && victory && hasNextChapter` del combat-recruit); aggrega
+  `economyRecruited` / `offspring` / `economyAffinityProven`; `econ.failures` -> metaViolations.
+
+## Test (TDD, `node --test tests/sim/*.test.js` = 22/22)
+
+- `greedyPolicy.test.js` (+2): chooseCourtship deltas raggiungono il gate; chooseMating
+  null<step2 + parents distinti.
+- `nidoEconomy.test.js` (3, fake-http): earned-recruit no-bypass/no-campaign + affinityProven;
+  mating da step 2 (parents corretti); earned-recruit fallito -> failure (no false-green).
+- `fullLoopRunner.test.js` e2e (real app): `economyAffinityProven===true` +
+  `economyRecruited>=1` + `offspring>=1` (economia + breeding provati contro l'engine reale).
+
+## Fuori scope (fase successive)
+
+- **offspring -> combat** (risolvere l'offspring a unita' come 3a): genetica offspring ->
+  stat = piu' complesso, deferred.
+- **affinity campaign-scoped** (`/affinity` accetta `campaign_id`) = ENGINE change ->
+  permetterebbe earned-recruit campaign-scoped che combatte; gated master-dd.
+- **fase-2**: enemy scaled (encounter YAML) + band-metriche meta (completion 40-70%
+  XCOM-LW2, attrition, economia PE->PI, offspring) + mbtiPolicy +
+  `META_NETWORK_ROUTING=true` test-context + N=40 (L-069).

--- a/tests/sim/fullLoopRunner.test.js
+++ b/tests/sim/fullLoopRunner.test.js
@@ -97,6 +97,20 @@ test('runFullLoop: AI plays the cave_path campaign end-to-end with REAL combat -
       res.chapters.map((c) => ({ step: c.step, rosterIds: c.rosterIds })),
     )}`,
   );
+  // fase-1b-3b Nido economy + breeding: the AI earns affinity/trust to satisfy the
+  // CANONICAL recruit gate (no affinity_at_recruit bypass) and rolls mating offspring ->
+  // both seams are really exercised end-to-end (separate from the combat-recruit;
+  // offspring are not resolved into combat yet).
+  assert.equal(
+    res.economyAffinityProven,
+    true,
+    'earned affinity/trust flipped the canonical recruit gate',
+  );
+  assert.ok(
+    res.economyRecruited.length >= 1,
+    `at least one earned-gate (no-bypass) recruit, got ${res.economyRecruited.length}`,
+  );
+  assert.ok(res.offspring >= 1, `at least one mating offspring rolled, got ${res.offspring}`);
 });
 
 test('runFullLoop: does NOT recruit when /campaign/advance rejects a victory chapter (Codex #2563 P2)', async () => {

--- a/tests/sim/fullLoopRunner.test.js
+++ b/tests/sim/fullLoopRunner.test.js
@@ -211,3 +211,42 @@ test('runFullLoop: does NOT recruit on the campaign-completing chapter (Codex #2
   assert.deepEqual(res.recruited, [], 'no recruit on the completing chapter');
   assert.ok(!calls.includes('/api/meta/recruit'), 'meta/recruit not called on completion');
 });
+
+test('runFullLoop: repeated runs on one app do not collide on courtship ids (Codex #2566 P2)', async (t) => {
+  // The Nido economy courtship NPCs live on the default meta store (no campaign_id).
+  // With fixed ids, a second run on the same app would find them already-recruited
+  // (gate_not_met) -> economyRecruited 0 + metaViolations. Courtship ids must be scoped
+  // per run (campaign id) so a batch of full-loop sims on one process stays clean.
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const http = supertestHttp(app);
+  const run = (playerId, seed) =>
+    runFullLoop(http, {
+      playerId,
+      roster: starterRoster(),
+      branchKey: 'cave_path',
+      seed,
+      maxChapters: 15,
+    });
+
+  const r1 = await run('fl_batch1', 'b1');
+  const r2 = await run('fl_batch2', 'b2');
+
+  for (const [label, r] of [
+    ['run1', r1],
+    ['run2', r2],
+  ]) {
+    assert.deepEqual(
+      r.metaViolations,
+      [],
+      `${label} meta violations: ${JSON.stringify(r.metaViolations)}`,
+    );
+    assert.ok(
+      r.economyRecruited.length >= 1,
+      `${label} earned-recruit survives repeated runs, got ${r.economyRecruited.length}`,
+    );
+    assert.ok(r.offspring >= 1, `${label} offspring rolled, got ${r.offspring}`);
+  }
+});

--- a/tests/sim/greedyPolicy.test.js
+++ b/tests/sim/greedyPolicy.test.js
@@ -1,7 +1,12 @@
 'use strict';
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { chooseRecruits, RECRUIT_SPECIES_POOL } = require('../../tools/sim/greedy-policy');
+const {
+  chooseRecruits,
+  chooseCourtship,
+  chooseMating,
+  RECRUIT_SPECIES_POOL,
+} = require('../../tools/sim/greedy-policy');
 
 test('chooseRecruits: one recruit per cleared chapter with id + canonical species', () => {
   assert.deepEqual(chooseRecruits({ step: 1 }), [
@@ -22,4 +27,20 @@ test('chooseRecruits: species cycles deterministically through the pool (wraps)'
   const len = RECRUIT_SPECIES_POOL.length;
   assert.equal(chooseRecruits({ step: 1 })[0].speciesId, RECRUIT_SPECIES_POOL[0]);
   assert.equal(chooseRecruits({ step: len + 1 })[0].speciesId, RECRUIT_SPECIES_POOL[0]);
+});
+
+test('chooseCourtship: deltas reach the canonical recruit gate (affinity>=0, trust>=2)', () => {
+  const c = chooseCourtship({ step: 1 });
+  assert.equal(c.npcId, 'courtship_s1');
+  assert.equal(c.speciesId, RECRUIT_SPECIES_POOL[0]);
+  // RECRUIT_AFFINITY_MIN=0 (default affinity already 0) + RECRUIT_TRUST_MIN=2.
+  assert.ok(c.affinityDelta >= 0, `affinity delta keeps affinity >= 0, got ${c.affinityDelta}`);
+  assert.ok(c.trustDelta >= 2, `trust delta reaches >= 2, got ${c.trustDelta}`);
+});
+
+test('chooseMating: no pair before step 2, distinct courtship parents from step 2 on', () => {
+  assert.equal(chooseMating({ step: 1 }), null);
+  const m = chooseMating({ step: 3 });
+  assert.deepEqual(m, { parentA: 'courtship_s2', parentB: 'courtship_s3' });
+  assert.notEqual(m.parentA, m.parentB);
 });

--- a/tests/sim/greedyPolicy.test.js
+++ b/tests/sim/greedyPolicy.test.js
@@ -44,3 +44,16 @@ test('chooseMating: no pair before step 2, distinct courtship parents from step 
   assert.deepEqual(m, { parentA: 'courtship_s2', parentB: 'courtship_s3' });
   assert.notEqual(m.parentA, m.parentB);
 });
+
+test('chooseCourtship/chooseMating: runId scopes ids per run (no cross-run collision, Codex #2566 P2)', () => {
+  assert.equal(chooseCourtship({ step: 1, runId: 'r1' }).npcId, 'courtship_r1_s1');
+  // distinct runIds -> distinct courtship ids on the shared default meta store.
+  assert.notEqual(
+    chooseCourtship({ step: 1, runId: 'a' }).npcId,
+    chooseCourtship({ step: 1, runId: 'b' }).npcId,
+  );
+  assert.deepEqual(chooseMating({ step: 3, runId: 'r1' }), {
+    parentA: 'courtship_r1_s2',
+    parentB: 'courtship_r1_s3',
+  });
+});

--- a/tests/sim/nidoEconomy.test.js
+++ b/tests/sim/nidoEconomy.test.js
@@ -31,8 +31,8 @@ function fakeHttp() {
 
 test('applyNidoEconomy: earns the canonical gate + recruits no-bypass (economy proven)', async () => {
   const http = fakeHttp();
-  const out = await applyNidoEconomy(http, { step: 1, biomeId: 'badlands' });
-  assert.deepEqual(out.earnedRecruits, ['courtship_s1']);
+  const out = await applyNidoEconomy(http, { step: 1, biomeId: 'badlands', runId: 'run_x' });
+  assert.deepEqual(out.earnedRecruits, ['courtship_run_x_s1']);
   assert.equal(
     out.affinityProven,
     true,
@@ -48,11 +48,11 @@ test('applyNidoEconomy: earns the canonical gate + recruits no-bypass (economy p
 
 test('applyNidoEconomy: rolls a mating from step 2 (offspring counted, correct parents)', async () => {
   const http = fakeHttp();
-  const out = await applyNidoEconomy(http, { step: 2, biomeId: 'badlands' });
+  const out = await applyNidoEconomy(http, { step: 2, biomeId: 'badlands', runId: 'run_x' });
   assert.equal(out.offspring, 1, 'one offspring rolled');
   const mating = http.calls.find((c) => c.path === '/api/meta/mating/roll');
-  assert.deepEqual(mating.body.parent_a, { id: 'courtship_s1' });
-  assert.deepEqual(mating.body.parent_b, { id: 'courtship_s2' });
+  assert.deepEqual(mating.body.parent_a, { id: 'courtship_run_x_s1' });
+  assert.deepEqual(mating.body.parent_b, { id: 'courtship_run_x_s2' });
   assert.equal(mating.body.biome_id, 'badlands');
 });
 

--- a/tests/sim/nidoEconomy.test.js
+++ b/tests/sim/nidoEconomy.test.js
@@ -1,0 +1,72 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { applyNidoEconomy } = require('../../tools/sim/nido-economy');
+
+// Fake http modelling the real meta seam (verified by _probe_3b against createApp):
+// affinity bump -> still gated; trust bump -> can_recruit flips true; recruit
+// (no bypass) -> recruited; mating/roll -> offspring spec.
+function fakeHttp() {
+  const calls = [];
+  return {
+    calls,
+    post: async (path, body) => {
+      calls.push({ path, body });
+      if (path === '/api/meta/affinity') {
+        return { status: 200, body: { npc: { affinity: 1 }, can_recruit: false } };
+      }
+      if (path === '/api/meta/trust') {
+        return { status: 200, body: { npc: { trust: 2 }, can_recruit: true, can_mate: false } };
+      }
+      if (path === '/api/meta/recruit') {
+        return { status: 200, body: { success: true, npc: { recruited: true } } };
+      }
+      if (path === '/api/meta/mating/roll') {
+        return { status: 200, body: { success: true, offspring: { lineage_id: 'l1' } } };
+      }
+      return { status: 200, body: {} };
+    },
+  };
+}
+
+test('applyNidoEconomy: earns the canonical gate + recruits no-bypass (economy proven)', async () => {
+  const http = fakeHttp();
+  const out = await applyNidoEconomy(http, { step: 1, biomeId: 'badlands' });
+  assert.deepEqual(out.earnedRecruits, ['courtship_s1']);
+  assert.equal(
+    out.affinityProven,
+    true,
+    'trust response can_recruit flipped via earned affinity/trust',
+  );
+  assert.deepEqual(out.failures, []);
+  // recruit went through the EARNED gate: no bypass, no campaign_id (default store).
+  const rec = http.calls.find((c) => c.path === '/api/meta/recruit');
+  assert.equal(rec.body.affinity_at_recruit, undefined, 'no affinity_at_recruit bypass');
+  assert.equal(rec.body.campaign_id, undefined, 'default store (no campaign_id)');
+  assert.equal(out.offspring, 0, 'step 1 has no mating pair yet');
+});
+
+test('applyNidoEconomy: rolls a mating from step 2 (offspring counted, correct parents)', async () => {
+  const http = fakeHttp();
+  const out = await applyNidoEconomy(http, { step: 2, biomeId: 'badlands' });
+  assert.equal(out.offspring, 1, 'one offspring rolled');
+  const mating = http.calls.find((c) => c.path === '/api/meta/mating/roll');
+  assert.deepEqual(mating.body.parent_a, { id: 'courtship_s1' });
+  assert.deepEqual(mating.body.parent_b, { id: 'courtship_s2' });
+  assert.equal(mating.body.biome_id, 'badlands');
+});
+
+test('applyNidoEconomy: a failed earned-recruit surfaces as a failure (no false green)', async () => {
+  const http = {
+    post: async (path) => {
+      if (path === '/api/meta/recruit') {
+        return { status: 200, body: { success: false, reason: 'gate_not_met' } };
+      }
+      return { status: 200, body: { can_recruit: false } };
+    },
+  };
+  const out = await applyNidoEconomy(http, { step: 1, biomeId: 'badlands' });
+  assert.deepEqual(out.earnedRecruits, []);
+  assert.equal(out.affinityProven, false);
+  assert.ok(out.failures.length >= 1, 'failed earned-recruit recorded');
+});

--- a/tools/sim/full-loop-runner.js
+++ b/tools/sim/full-loop-runner.js
@@ -15,6 +15,7 @@ const { runEncounter } = require('./combat-adapter');
 const { checkInvariants } = require('./full-loop-invariants');
 const greedyPolicy = require('./greedy-policy');
 const { resolveRecruitUnit } = require('./recruit-resolver');
+const { applyNidoEconomy } = require('./nido-economy');
 
 // Nido meta-step on a cleared chapter: the greedy policy recruits NPCs via the meta
 // seam (POST /api/meta/recruit, affinity_at_recruit bypass -> getOrCreate NPC), then
@@ -113,6 +114,11 @@ async function runFullLoop(http, opts = {}) {
   const violations = [];
   const recruited = [];
   const metaViolations = [];
+  // fase-1b-3b Nido economy + breeding (separate from the combat-recruit above):
+  // earned-affinity recruits + mating offspring, proving those seams are AI-played.
+  const economyRecruited = [];
+  let offspring = 0;
+  let economyAffinityProven = false;
   let completed = false;
 
   for (let step = 1; step <= maxChapters; step += 1) {
@@ -169,6 +175,15 @@ async function runFullLoop(http, opts = {}) {
         knownIds.push(u.id);
       }
       if (meta.failures.length) metaViolations.push({ step, failures: meta.failures });
+
+      // Nido economy + breeding seams (fase-1b-3b): earn affinity/trust -> recruit via
+      // the canonical gate (no bypass) + roll a mating offspring. Default-store NPCs,
+      // separate from the combat-recruit; offspring not resolved into combat (deferred).
+      const econ = await applyNidoEconomy(http, { step, biomeId: 'badlands' });
+      economyRecruited.push(...econ.earnedRecruits);
+      offspring += econ.offspring;
+      if (econ.affinityProven) economyAffinityProven = true;
+      if (econ.failures.length) metaViolations.push({ step, econ: econ.failures });
     }
 
     if (adv.body && adv.body.choice_required) {
@@ -181,7 +196,17 @@ async function runFullLoop(http, opts = {}) {
     if (adv.status !== 200) break;
   }
 
-  return { completed, chapters, violations, finalRoster: aliveIds, recruited, metaViolations };
+  return {
+    completed,
+    chapters,
+    violations,
+    finalRoster: aliveIds,
+    recruited,
+    metaViolations,
+    economyRecruited,
+    offspring,
+    economyAffinityProven,
+  };
 }
 
 module.exports = { runFullLoop, enemiesForChapter };

--- a/tools/sim/full-loop-runner.js
+++ b/tools/sim/full-loop-runner.js
@@ -179,7 +179,7 @@ async function runFullLoop(http, opts = {}) {
       // Nido economy + breeding seams (fase-1b-3b): earn affinity/trust -> recruit via
       // the canonical gate (no bypass) + roll a mating offspring. Default-store NPCs,
       // separate from the combat-recruit; offspring not resolved into combat (deferred).
-      const econ = await applyNidoEconomy(http, { step, biomeId: 'badlands' });
+      const econ = await applyNidoEconomy(http, { step, biomeId: 'badlands', runId: id });
       economyRecruited.push(...econ.earnedRecruits);
       offspring += econ.offspring;
       if (econ.affinityProven) economyAffinityProven = true;

--- a/tools/sim/greedy-policy.js
+++ b/tools/sim/greedy-policy.js
@@ -13,8 +13,12 @@
 // the recruited unit actually fights the next mission. Species cycle deterministically
 // through the badlands canonical pool (5 real species, diverse role_class).
 //
-// Structured so chooseMatings / spendAffinity slot in next (fase-1b-3b) without
-// touching the runner's call shape.
+// fase-1b-3b: chooseCourtship + chooseMating exercise the Nido ECONOMY (earn
+// affinity/trust -> canonical recruit gate, NOT the bypass) and BREEDING (mating
+// roll -> offspring). These run on the default meta store (the affinity/trust
+// endpoints ignore campaign_id), separate from the campaign-scoped combat-recruit
+// above, so the courtship NPCs prove the economy/breeding seams without disturbing
+// the unit that actually fights.
 
 const RECRUIT_SPECIES_POOL = [
   'dune-stalker', // T3 predatore_terziario_apex -> APEX
@@ -29,4 +33,20 @@ function chooseRecruits({ step } = {}) {
   return [{ npcId: `recruit_s${step}`, speciesId }];
 }
 
-module.exports = { chooseRecruits, RECRUIT_SPECIES_POOL };
+// One courtship NPC per chapter. Deltas earn the canonical recruit gate
+// (metaProgression: RECRUIT_AFFINITY_MIN=0, RECRUIT_TRUST_MIN=2) so the AI can
+// recruit WITHOUT the affinity_at_recruit bypass -> proves the affinity economy.
+function chooseCourtship({ step } = {}) {
+  const speciesId = RECRUIT_SPECIES_POOL[(step - 1) % RECRUIT_SPECIES_POOL.length];
+  return { npcId: `courtship_s${step}`, speciesId, affinityDelta: 1, trustDelta: 2 };
+}
+
+// Mating pair (squad-mate offspring roll). Needs two courtship NPCs, so it starts
+// from step 2 and pairs the previous + current courtship NPC -> deterministic,
+// distinct parents, accumulating offspring.
+function chooseMating({ step } = {}) {
+  if (!(step >= 2)) return null;
+  return { parentA: `courtship_s${step - 1}`, parentB: `courtship_s${step}` };
+}
+
+module.exports = { chooseRecruits, chooseCourtship, chooseMating, RECRUIT_SPECIES_POOL };

--- a/tools/sim/greedy-policy.js
+++ b/tools/sim/greedy-policy.js
@@ -33,20 +33,28 @@ function chooseRecruits({ step } = {}) {
   return [{ npcId: `recruit_s${step}`, speciesId }];
 }
 
+// Courtship NPCs live on the DEFAULT meta store (the affinity/trust endpoints ignore
+// campaign_id), so their ids MUST be scoped per run -- otherwise a second full-loop sim
+// on the same process finds them already-recruited (gate_not_met), breaking repeated
+// playtest batches (Codex #2566 P2). runId = the per-run campaign id (crypto.randomUUID).
+function courtshipId(runId, step) {
+  return runId ? `courtship_${runId}_s${step}` : `courtship_s${step}`;
+}
+
 // One courtship NPC per chapter. Deltas earn the canonical recruit gate
 // (metaProgression: RECRUIT_AFFINITY_MIN=0, RECRUIT_TRUST_MIN=2) so the AI can
 // recruit WITHOUT the affinity_at_recruit bypass -> proves the affinity economy.
-function chooseCourtship({ step } = {}) {
+function chooseCourtship({ step, runId } = {}) {
   const speciesId = RECRUIT_SPECIES_POOL[(step - 1) % RECRUIT_SPECIES_POOL.length];
-  return { npcId: `courtship_s${step}`, speciesId, affinityDelta: 1, trustDelta: 2 };
+  return { npcId: courtshipId(runId, step), speciesId, affinityDelta: 1, trustDelta: 2 };
 }
 
-// Mating pair (squad-mate offspring roll). Needs two courtship NPCs, so it starts
-// from step 2 and pairs the previous + current courtship NPC -> deterministic,
-// distinct parents, accumulating offspring.
-function chooseMating({ step } = {}) {
+// Mating pair (squad-mate offspring roll). Needs two courtship NPCs, so it starts from
+// step 2 and pairs the previous + current courtship NPC (same runId scope) ->
+// deterministic, distinct parents, accumulating offspring.
+function chooseMating({ step, runId } = {}) {
   if (!(step >= 2)) return null;
-  return { parentA: `courtship_s${step - 1}`, parentB: `courtship_s${step}` };
+  return { parentA: courtshipId(runId, step - 1), parentB: courtshipId(runId, step) };
 }
 
 module.exports = { chooseRecruits, chooseCourtship, chooseMating, RECRUIT_SPECIES_POOL };

--- a/tools/sim/nido-economy.js
+++ b/tools/sim/nido-economy.js
@@ -1,0 +1,65 @@
+'use strict';
+// fase-1b-3b Nido economy + breeding meta-step. Exercises two canonical Nido seams
+// that the combat-recruit (fase-1b-3a) does not:
+//   (1) AFFINITY ECONOMY -- earn affinity/trust to satisfy the canonical recruit gate
+//       (metaProgression RECRUIT_AFFINITY_MIN=0, RECRUIT_TRUST_MIN=2) and recruit
+//       WITHOUT the affinity_at_recruit bypass.
+//   (2) BREEDING -- /api/meta/mating/roll producing an offspring spec.
+//
+// Runs on the DEFAULT meta store: the /affinity + /trust endpoints ignore campaign_id,
+// so earned affinity cannot reach the campaign-scoped recruit store without an engine
+// change (verified by probe: earn+recruit succeeds with no campaign_id; the same with a
+// campaign_id returns gate_not_met). The courtship NPCs therefore prove the
+// economy/breeding seams; they are NOT the units that fight (that is the campaign-scoped
+// combat-recruit in the runner). Offspring are not resolved into combat (deferred to a
+// later slice / fase-2). Additive: failures surface in `failures`, never throw.
+
+const greedyPolicy = require('./greedy-policy');
+
+async function applyNidoEconomy(http, { step, biomeId } = {}) {
+  const out = { earnedRecruits: [], offspring: 0, affinityProven: false, failures: [] };
+
+  // (1) Affinity economy: earn affinity + trust, then recruit through the EARNED gate.
+  const c = greedyPolicy.chooseCourtship({ step });
+  await http.post('/api/meta/affinity', { npc_id: c.npcId, delta: c.affinityDelta });
+  const tr = await http.post('/api/meta/trust', { npc_id: c.npcId, delta: c.trustDelta });
+  // can_recruit flipped true purely from the earned affinity/trust (no bypass involved).
+  out.affinityProven = !!(tr && tr.body && tr.body.can_recruit === true);
+
+  // No affinity_at_recruit bypass and no campaign_id (the default store where the
+  // affinity/trust were earned) -> proves the canonical recruit economy.
+  const rec = await http.post('/api/meta/recruit', { npc_id: c.npcId, species_id: c.speciesId });
+  const earnedOk =
+    rec.status === 200 &&
+    rec.body &&
+    rec.body.success === true &&
+    rec.body.npc &&
+    rec.body.npc.recruited === true;
+  if (earnedOk) out.earnedRecruits.push(c.npcId);
+  else {
+    out.failures.push({
+      phase: 'earned_recruit',
+      npcId: c.npcId,
+      status: rec.status,
+      reason: rec.body && rec.body.reason,
+    });
+  }
+
+  // (2) Breeding: roll a squad-mate mating once two courtship NPCs exist (step >= 2).
+  const mating = greedyPolicy.chooseMating({ step });
+  if (mating) {
+    const m = await http.post('/api/meta/mating/roll', {
+      parent_a: { id: mating.parentA },
+      parent_b: { id: mating.parentB },
+      biome_id: biomeId,
+    });
+    if (m.status === 200 && m.body && m.body.success === true && m.body.offspring)
+      out.offspring += 1;
+    else
+      out.failures.push({ phase: 'mating', status: m.status, success: m.body && m.body.success });
+  }
+
+  return out;
+}
+
+module.exports = { applyNidoEconomy };

--- a/tools/sim/nido-economy.js
+++ b/tools/sim/nido-economy.js
@@ -16,11 +16,13 @@
 
 const greedyPolicy = require('./greedy-policy');
 
-async function applyNidoEconomy(http, { step, biomeId } = {}) {
+async function applyNidoEconomy(http, { step, biomeId, runId } = {}) {
   const out = { earnedRecruits: [], offspring: 0, affinityProven: false, failures: [] };
 
   // (1) Affinity economy: earn affinity + trust, then recruit through the EARNED gate.
-  const c = greedyPolicy.chooseCourtship({ step });
+  // runId scopes the courtship ids per run (Codex #2566 P2) so repeated sims on one
+  // process don't collide on the default meta store.
+  const c = greedyPolicy.chooseCourtship({ step, runId });
   await http.post('/api/meta/affinity', { npc_id: c.npcId, delta: c.affinityDelta });
   const tr = await http.post('/api/meta/trust', { npc_id: c.npcId, delta: c.trustDelta });
   // can_recruit flipped true purely from the earned affinity/trust (no bypass involved).
@@ -46,7 +48,7 @@ async function applyNidoEconomy(http, { step, biomeId } = {}) {
   }
 
   // (2) Breeding: roll a squad-mate mating once two courtship NPCs exist (step >= 2).
-  const mating = greedyPolicy.chooseMating({ step });
+  const mating = greedyPolicy.chooseMating({ step, runId });
   if (mating) {
     const m = await http.post('/api/meta/mating/roll', {
       parent_a: { id: mating.parentA },


### PR DESCRIPTION
## fase-1b-3b -- Nido economy + breeding seam

Continuation of the full-loop AI-playtest runner (spec #2559), after fase-1b-3a (#2565, recruit->combat). The full-loop AI now exercises two canonical Nido seams the combat-recruit does not: the **affinity economy** (earn affinity/trust -> satisfy the canonical recruit gate -> recruit WITHOUT the `affinity_at_recruit` bypass) and **breeding** (`/api/meta/mating/roll` -> offspring spec). Scope (approved): seam-exercise; offspring don't fight yet (deferred).

### Probe finding that drove the design
`/api/meta/affinity` + `/api/meta/trust` write the **default** meta store and ignore `campaign_id`, while `/api/meta/recruit` with `campaign_id` uses a separate `metaStoreFactory` store. So earned-affinity recruit only works on the default store (no `campaign_id`). Making the campaign-scoped combat-recruit "earned, no bypass" would need `/affinity` to accept `campaign_id` = an engine change (out of band-safe scope). So the combat-recruit (campaign+bypass, fase-1b-3a) is left intact; the economy + breeding are proven on separate **courtship** NPCs on the default store.

### Changes (`tools/sim/` + `tests/sim/` + spec -- zero engine change)
- **`greedy-policy.js`** -- `chooseCourtship({step})` (deltas reach `RECRUIT_AFFINITY_MIN=0`/`RECRUIT_TRUST_MIN=2`) + `chooseMating({step})` (squad-mate pair from step 2).
- **`nido-economy.js`** (new) -- `applyNidoEconomy(http,{step,biomeId})`: earn affinity/trust -> recruit no-bypass/no-campaign_id -> mating roll; returns `{earnedRecruits, offspring, affinityProven, failures}`, additive (never throws).
- **`full-loop-runner.js`** -- wires `applyNidoEconomy` on cleared chapters; aggregates `economyRecruited` / `offspring` / `economyAffinityProven`; econ failures -> `metaViolations`.
- **spec** -- `docs/superpowers/specs/2026-06-02-full-loop-fase1b3b-nido-economy-design.md`.

### Verification
- `node --test tests/sim/*.test.js` -> **22/22** (greedy +2, nido-economy 3, e2e proves economy + breeding against the **real** engine: `economyAffinityProven`, earned-recruit, offspring).
- `prettier --check` clean (7 files); `python tools/check_docs_governance.py --strict` -> **errors=0**.

### Scope / band safety
- **Band-safe**: zero engine change (only `tools/sim/`). Gate-5 exception = methodology-tooling.
- Out of scope: offspring->combat + campaign-scoped affinity (engine change) + scaled enemies/band-metrics/N=40 = fase-2.

### Changelog
`feat(sim)`: full-loop AI now exercises the Nido affinity economy (canonical earned recruit) + mating breeding.

### Rollback (03A)
`git revert` this PR (squash). Pure tooling, no engine/schema/data change -- revert is risk-free.